### PR TITLE
[Lume] Fix reassemble kill

### DIFF
--- a/libs/lume/src/Errors/Errors.swift
+++ b/libs/lume/src/Errors/Errors.swift
@@ -27,6 +27,7 @@ enum PullError: Error, LocalizedError {
     case layerDownloadFailed(String)
     case missingPart(Int)
     case decompressionFailed(String)
+    case reassemblyFailed(String)
     
     var errorDescription: String? {
         switch self {
@@ -42,6 +43,8 @@ enum PullError: Error, LocalizedError {
             return "Missing disk image part \(number)"
         case .decompressionFailed(let filename):
             return "Failed to decompress file: \(filename)"
+        case .reassemblyFailed(let reason):
+            return "Disk image reassembly failed: \(reason)."
         }
     }
 }


### PR DESCRIPTION
Fix an issue on <16GB macOS where the reassemble process is killed by the system due to memory constraints using swift.