### PR TITLE
Update Mac identifier during clone process

### DIFF
--- a/libs/lume/src/LumeController.swift
+++ b/libs/lume/src/LumeController.swift
@@ -93,6 +93,9 @@ final class LumeController {
             // Update MAC address in the cloned VM to ensure uniqueness
             let clonedVM = try get(name: normalizedNewName, storage: destLocation)
             try clonedVM.setMacAddress(VZMACAddress.randomLocallyAdministered().string)
+            
+            // Update MAC Identifier in the cloned VM to ensure uniqueness
+            try clonedVM.setMachineIdentifier(DarwinVirtualizationService.generateMachineIdentifier())
 
             Logger.info(
                 "VM cloned successfully",


### PR DESCRIPTION
## Problem

- Ran lume clone image_name new_image_name to clone an existing image.

- After running the original image with lume run image_name,

- The cloned image (new_image_name) also appeared as running in the output of lume ls.

## Expected Behavior

- The original and cloned images should run independently.

- Starting the original image should not cause the cloned image to start or appear active.

- Updated the cloning logic to generate a new identifier to ensure separation between the instances.