### PR TITLE
[Lume] Update lume install location

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 If you only need the virtualization capabilities:
 
 ```bash
-sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/lume/scripts/install.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/lume/scripts/install.sh)"
 ```
 
 For Lume usage instructions, refer to the [Lume documentation](./libs/lume/README.md).
@@ -54,7 +54,7 @@ If you want to use AI agents with virtualized environments:
 
 1. Install the Lume CLI:
    ```bash
-   sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/lume/scripts/install.sh)"
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/lume/scripts/install.sh)"
    ```
 
 2. Pull the latest macOS CUA image:

--- a/notebooks/computer_nb.ipynb
+++ b/notebooks/computer_nb.ipynb
@@ -67,7 +67,7 @@
     "For installing the standalone lume binary, run the following command from a terminal:\n",
     "\n",
     "```bash\n",
-    "sudo /bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/lume/scripts/install.sh)\"\n",
+    "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/lume/scripts/install.sh)\"\n",
     "```"
    ]
   },


### PR DESCRIPTION
Fix: Make installation script sudo-free by default (#132)

Changes the default installation directory to ~/.local/bin instead of /usr/local/bin to avoid needing sudo. Adds CLI options with --install-dir parameter for custom locations and improves permission checking with helpful messages. Users can still install to system directories if they choose, but the default is now secure and user-friendly.