### PR TITLE
[Agent] Fixes for hotkeys, scrolling sensitivity

### DIFF
--- a/libs/agent/agent/providers/openai/tools/computer.py
+++ b/libs/agent/agent/providers/openai/tools/computer.py
@@ -240,11 +240,7 @@ class ComputerTool(BaseComputerTool, BaseOpenAITool):
 
             if len(mapped_keys) > 1:
                 # For key combinations (like Ctrl+C)
-                for k in mapped_keys:
-                    await self.computer.interface.press_key(k)
-                await asyncio.sleep(0.1)
-                for k in reversed(mapped_keys):
-                    await self.computer.interface.press_key(k)
+                await self.computer.interface.hotkey(*mapped_keys)
             else:
                 # Single key press
                 await self.computer.interface.press_key(mapped_keys[0])

--- a/libs/agent/agent/providers/openai/tools/computer.py
+++ b/libs/agent/agent/providers/openai/tools/computer.py
@@ -162,8 +162,8 @@ class ComputerTool(BaseComputerTool, BaseOpenAITool):
                 y = kwargs.get("y")
                 if x is None or y is None:
                     raise ToolError("x and y coordinates are required for scroll action")
-                scroll_x = kwargs.get("scroll_x", 0) // 20
-                scroll_y = kwargs.get("scroll_y", 0) // 20
+                scroll_x = kwargs.get("scroll_x", 0) // 50
+                scroll_y = kwargs.get("scroll_y", 0) // 50
                 return await self.handle_scroll(x, y, scroll_x, scroll_y)
             elif type == "screenshot":
                 return await self.screenshot()

--- a/libs/agent/agent/providers/uitars/clients/oaicompat.py
+++ b/libs/agent/agent/providers/uitars/clients/oaicompat.py
@@ -145,8 +145,13 @@ class OAICompatClient(BaseUITarsClient):
                     message = {"role": "user", "content": [{"type": "text", "text": item}]}
                 final_messages.append(message)
 
-        payload = {"model": self.model, "messages": final_messages, "temperature": self.temperature}
-        payload["max_tokens"] = max_tokens or self.max_tokens
+        payload = {
+            "model": self.model, 
+            "messages": final_messages, 
+            "max_tokens": max_tokens or self.max_tokens,
+            "temperature": self.temperature,
+            "top_p": 0.7,
+        }
 
         try:
             async with aiohttp.ClientSession() as session:

--- a/libs/agent/agent/providers/uitars/clients/oaicompat.py
+++ b/libs/agent/agent/providers/uitars/clients/oaicompat.py
@@ -94,8 +94,15 @@ class OAICompatClient(BaseUITarsClient):
         """
         headers = {"Content-Type": "application/json", "Authorization": f"Bearer {self.api_key}"}
 
-        final_messages = [{"role": "system", "content": system}]
-
+        final_messages = [
+            {
+                "role": "system", 
+                "content": [
+                    { "type": "text", "text": system }
+                ]
+            }
+        ]
+        
         # Process messages
         for item in messages:
             if isinstance(item, dict):

--- a/libs/agent/agent/providers/uitars/loop.py
+++ b/libs/agent/agent/providers/uitars/loop.py
@@ -20,7 +20,7 @@ from computer import Computer
 from .utils import add_box_token, parse_actions, parse_action_parameters
 from .tools.manager import ToolManager
 from .tools.computer import ToolResult
-from .prompts import COMPUTER_USE, SYSTEM_PROMPT
+from .prompts import COMPUTER_USE, SYSTEM_PROMPT, MAC_SPECIFIC_NOTES
 
 from .clients.oaicompat import OAICompatClient
 
@@ -184,7 +184,7 @@ class UITARSLoop(BaseLoop):
         if first_user_idx is not None and instruction:
             # Create the computer use prompt
             user_prompt = COMPUTER_USE.format(
-                instruction=instruction,
+                instruction='\n'.join([instruction, MAC_SPECIFIC_NOTES]),
                 language="English"
             )
             

--- a/libs/agent/agent/providers/uitars/prompts.py
+++ b/libs/agent/agent/providers/uitars/prompts.py
@@ -1,5 +1,9 @@
 """Prompts for UI-TARS agent."""
 
+MAC_SPECIFIC_NOTES = """
+(You are operating on macOS, use 'cmd' instead of 'ctrl' for most shortcuts e.g., hotkey(key='cmd c') for copy, hotkey(key='cmd v') for paste, hotkey(key='cmd t') for new tab).)
+"""
+
 SYSTEM_PROMPT = "You are a helpful assistant."
 
 COMPUTER_USE = """You are a GUI agent. You are given a task and your action history, with screenshots. You need to perform the next action to complete the task.
@@ -56,4 +60,4 @@ finished(content='xxx') # Use escape characters \\', \\", and \\n in content par
 
 ## User Instruction
 {instruction}
-""" 
+"""

--- a/libs/agent/agent/providers/uitars/tools/computer.py
+++ b/libs/agent/agent/providers/uitars/tools/computer.py
@@ -173,9 +173,13 @@ class ComputerTool(BaseComputerTool):
             elif action == "hotkey":
                 if "keys" in kwargs:
                     keys = kwargs["keys"]
-                    for key in keys:
-                        await self.computer.interface.press_key(key)
                     
+                    if len(keys) > 1:
+                        await self.computer.interface.hotkey(*keys)
+                    else:
+                        # Single key press
+                        await self.computer.interface.press_key(keys[0])
+                        
                     # Wait for UI to update
                     await asyncio.sleep(0.3)
                     

--- a/libs/computer/computer/interface/models.py
+++ b/libs/computer/computer/interface/models.py
@@ -8,7 +8,7 @@ NavigationKey = Literal['pagedown', 'pageup', 'home', 'end', 'left', 'right', 'u
 SpecialKey = Literal['enter', 'esc', 'tab', 'space', 'backspace', 'del']
 
 # Modifier key literals
-ModifierKey = Literal['ctrl', 'shift', 'win', 'command', 'option']
+ModifierKey = Literal['ctrl', 'alt', 'shift', 'win', 'command', 'option']
 
 # Function key literals
 FunctionKey = Literal['f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7', 'f8', 'f9', 'f10', 'f11', 'f12']
@@ -39,6 +39,7 @@ class Key(Enum):
     DELETE = 'del'
     
     # Modifier keys
+    ALT = 'alt'
     CTRL = 'ctrl'
     SHIFT = 'shift'
     WIN = 'win'
@@ -85,6 +86,7 @@ class Key(Enum):
             'delete': cls.DELETE,
             'del': cls.DELETE,
             # Modifier key mappings
+            'alt': cls.ALT,
             'ctrl': cls.CTRL,
             'control': cls.CTRL,
             'shift': cls.SHIFT,
@@ -95,7 +97,6 @@ class Key(Enum):
             'cmd': cls.COMMAND,
             '⌘': cls.COMMAND,
             'option': cls.OPTION,
-            'alt': cls.OPTION,
             '⌥': cls.OPTION,
         }
         

--- a/libs/computer/computer/interface/models.py
+++ b/libs/computer/computer/interface/models.py
@@ -7,6 +7,9 @@ NavigationKey = Literal['pagedown', 'pageup', 'home', 'end', 'left', 'right', 'u
 # Special key literals
 SpecialKey = Literal['enter', 'esc', 'tab', 'space', 'backspace', 'del']
 
+# Modifier key literals
+ModifierKey = Literal['ctrl', 'shift', 'win', 'command', 'option']
+
 # Function key literals
 FunctionKey = Literal['f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7', 'f8', 'f9', 'f10', 'f11', 'f12']
 
@@ -34,6 +37,13 @@ class Key(Enum):
     SPACE = 'space'
     BACKSPACE = 'backspace'
     DELETE = 'del'
+    
+    # Modifier keys
+    CTRL = 'ctrl'
+    SHIFT = 'shift'
+    WIN = 'win'
+    COMMAND = 'command'
+    OPTION = 'option'
     
     # Function keys
     F1 = 'f1'
@@ -73,14 +83,26 @@ class Key(Enum):
             'escape': cls.ESCAPE,
             'esc': cls.ESC,
             'delete': cls.DELETE,
-            'del': cls.DELETE
+            'del': cls.DELETE,
+            # Modifier key mappings
+            'ctrl': cls.CTRL,
+            'control': cls.CTRL,
+            'shift': cls.SHIFT,
+            'win': cls.WIN,
+            'windows': cls.WIN,
+            'command': cls.COMMAND,
+            'cmd': cls.COMMAND,
+            '⌘': cls.COMMAND,
+            'option': cls.OPTION,
+            'alt': cls.OPTION,
+            '⌥': cls.OPTION,
         }
         
         normalized = key.lower().strip()
         return key_mapping.get(normalized, key)
 
 # Combined key type
-KeyType = Union[Key, NavigationKey, SpecialKey, FunctionKey, str]
+KeyType = Union[Key, NavigationKey, SpecialKey, ModifierKey, FunctionKey, str]
 
 class AccessibilityWindow(TypedDict):
     """Information about a window in the accessibility tree."""

--- a/libs/computer/computer/interface/models.py
+++ b/libs/computer/computer/interface/models.py
@@ -90,6 +90,7 @@ class Key(Enum):
             'shift': cls.SHIFT,
             'win': cls.WIN,
             'windows': cls.WIN,
+            'super': cls.WIN,
             'command': cls.COMMAND,
             'cmd': cls.COMMAND,
             '⌘': cls.COMMAND,


### PR DESCRIPTION
- Fixed OpenAI loop and UITARS loop not using `computer.interface.hotkey`
- Reduced scrolling sensitivity for OpenAI's loop by a factor of 2.5x
- Added `top_p` parameter to UITARS inference (using the value from the UITARS repo)
- Added additional prompt for UITARS to use mac hotkeys: `(You are operating on macOS, use 'cmd' instead of 'ctrl' for most shortcuts e.g., hotkey(key='cmd c') for copy, hotkey(key='cmd v') for paste, hotkey(key='cmd t') for new tab).)`
- Added key mappings for modifier keys (e.g., 'command', '⌘', 'super', '⌥', etc)