### PR TITLE
Add support for direct path when cloning VM

### DIFF
--- a/libs/lume/src/FileSystem/Home.swift
+++ b/libs/lume/src/FileSystem/Home.swift
@@ -87,7 +87,14 @@ final class Home {
             let baseDir = Path(cleanPath)
             return VMDirectory(baseDir.directory(name))
         }
-        
+
+        // Check if storage is a direct path
+        if let storage = storage, (storage.contains("/") || storage.contains("\\")) {
+            let cleanPath = storage.hasSuffix("/") ? String(storage.dropLast()) : storage
+            let baseDir = Path(cleanPath)
+            return VMDirectory(baseDir.directory(name))
+        }
+
         let location: VMLocation
 
         if let storage = storage {


### PR DESCRIPTION
This PR fixes a bug when trying to clone a VM from a direct path (e.g trying to clone from a lumier location into a typical lume configured storage location).

Before
![CleanShot 2025-05-14 at 17 23 26@2x](https://github.com/user-attachments/assets/7df358a3-5e25-49c4-b2ba-c91b5497adc8)

After
![CleanShot 2025-05-14 at 17 22 58@2x](https://github.com/user-attachments/assets/6bc9f898-ddbc-4992-9f70-96cc2b97ef55)
