### PR TITLE
Added Cmake dep to playground.sh

### DIFF
--- a/scripts/playground.sh
+++ b/scripts/playground.sh
@@ -88,7 +88,7 @@ source "$VENV_DIR/bin/activate"
 
 # Install required packages
 echo "📦 Updating CUA packages..."
-pip install -U pip
+pip install -U pip setuptools wheel Cmake
 pip install -U cua-computer "cua-agent[all]"
 
 # Temporary fix for mlx-vlm, see https://github.com/Blaizzy/mlx-vlm/pull/349


### PR DESCRIPTION
This fix is meant to address issue #182 by applying the solution found in this thread: https://stackoverflow.com/questions/75322177/error-failed-building-wheel-for-sentencepiece-while-installing-flair-on-python

Changes:
- Added `pip install -U setuptools wheel Cmake`