### PR TITLE
[Computer] Add disconnect() method for Computer

### DIFF
--- a/libs/computer/computer/providers/cloud/provider.py
+++ b/libs/computer/computer/providers/cloud/provider.py
@@ -52,11 +52,11 @@ class CloudProvider(BaseVMProvider):
         return []
 
     async def run_vm(self, image: str, name: str, run_opts: Dict[str, Any], storage: Optional[str] = None) -> Dict[str, Any]:
-        logger.warning("CloudProvider.run_vm is not implemented")
-        return {"name": name, "status": "unavailable", "message": "CloudProvider is not implemented"}
+        # logger.warning("CloudProvider.run_vm is not implemented")
+        return {"name": name, "status": "unavailable", "message": "CloudProvider.run_vm is not implemented"}
 
     async def stop_vm(self, name: str, storage: Optional[str] = None) -> Dict[str, Any]:
-        logger.warning("CloudProvider.stop_vm is not implemented")
+        logger.warning("CloudProvider.stop_vm is not implemented. To clean up resources, please use Computer.disconnect()")
         return {"name": name, "status": "stopped", "message": "CloudProvider is not implemented"}
 
     async def update_vm(self, name: str, update_opts: Dict[str, Any], storage: Optional[str] = None) -> Dict[str, Any]:


### PR DESCRIPTION
This PR introduces a new `disconnect()` method to the `Computer` class in the `libs/computer/computer/computer.py` file.

It also updates the `__aenter__` and `__aexit__` methods, in order to call `.run()` at the start and `.disconnect()` at the end, respectively. The existing `.stop()` method has been modified to call `.disconnect()` as well. 

This fixes an issue with old Computer instances maintaining a WebSocket connection even after they have been closed. This also makes it possible to seperately initiate resource cleanup without stopping the computer. 

Changes:
- Removed warning when calling `start_vm` in the CloudProvider
- Split the `.stop()` function into `.stop()` and `.disconnect()` in the Computer class