### PR TITLE
[Typescript] Publish packages based on package.json.

### DIFF
--- a/.github/workflows/npm-publish-computer.yml
+++ b/.github/workflows/npm-publish-computer.yml
@@ -22,14 +22,15 @@ jobs:
 
       - name: Install dependencies
         working-directory: ./libs/typescript/computer
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Build package
         working-directory: ./libs/typescript/computer
-        run: npm run build --if-present
+        run: pnpm run build --if-present
 
       - name: Publish to npm
         working-directory: ./libs/typescript/computer
-        run: npm publish --provenance --access public
+        run: pnpm publish --access public --no-git-checks
         env:
+          NPM_CONFIG_PROVENANCE: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish-computer.yml
+++ b/.github/workflows/npm-publish-computer.yml
@@ -2,8 +2,7 @@ name: Publish @trycua/computer to npm
 
 on:
   push:
-    tags:
-      - "computer-v*"
+    branches: main
 
 jobs:
   publish:
@@ -20,15 +19,26 @@ jobs:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Check if version changed
+        id: check-version
+        uses: EndBug/version-check@v2
+        with:
+          file-name: libs/typescript/computer/package.json
+          static-checking: localIsNew
+          diff-search: true
+
       - name: Install dependencies
+        if: steps.check-version.outputs.changed == 'true'
         working-directory: ./libs/typescript/computer
         run: pnpm install --frozen-lockfile
 
       - name: Build package
+        if: steps.check-version.outputs.changed == 'true'
         working-directory: ./libs/typescript/computer
         run: pnpm run build --if-present
 
       - name: Publish to npm
+        if: steps.check-version.outputs.changed == 'true'
         working-directory: ./libs/typescript/computer
         run: pnpm publish --access public --no-git-checks
         env:

--- a/.github/workflows/npm-publish-core.yml
+++ b/.github/workflows/npm-publish-core.yml
@@ -22,14 +22,15 @@ jobs:
 
       - name: Install dependencies
         working-directory: ./libs/typescript/core
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Build package
         working-directory: ./libs/typescript/core
-        run: npm run build --if-present
+        run: pnpm run build --if-present
 
       - name: Publish to npm
         working-directory: ./libs/typescript/core
-        run: npm publish --provenance --access public
+        run: pnpm publish --access public --no-git-checks
         env:
+          NPM_CONFIG_PROVENANCE: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish-core.yml
+++ b/.github/workflows/npm-publish-core.yml
@@ -2,8 +2,7 @@ name: Publish @trycua/core to npm
 
 on:
   push:
-    tags:
-      - "core-v*"
+    branches: main
 
 jobs:
   publish:
@@ -20,15 +19,26 @@ jobs:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Check if version changed
+        id: check-version
+        uses: EndBug/version-check@v2
+        with:
+          file-name: libs/typescript/core/package.json
+          static-checking: localIsNew
+          diff-search: true
+
       - name: Install dependencies
+        if: steps.check-version.outputs.changed == 'true'
         working-directory: ./libs/typescript/core
         run: pnpm install --frozen-lockfile
 
       - name: Build package
+        if: steps.check-version.outputs.changed == 'true'
         working-directory: ./libs/typescript/core
         run: pnpm run build --if-present
 
       - name: Publish to npm
+        if: steps.check-version.outputs.changed == 'true'
         working-directory: ./libs/typescript/core
         run: pnpm publish --access public --no-git-checks
         env:

--- a/libs/typescript/core/tsdown.config.ts
+++ b/libs/typescript/core/tsdown.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsdown';
 export default defineConfig([
   {
     entry: ['./src/index.ts'],
-    platform: 'neutral',
+    platform: 'node',
     dts: true,
   },
 ]);


### PR DESCRIPTION
This PR updates the workflows for publishing the typescript packages. It compares the current published npm version with the repository and publishes if it's been bumped.

It also fixes a warning on the core lib build step and an issue with using npm instead of pnpm.