### PR TITLE
Change computer.interface.run_command to be asynchronous

### DIFF
--- a/libs/python/computer-server/computer_server/handlers/linux.py
+++ b/libs/python/computer-server/computer_server/handlers/linux.py
@@ -10,6 +10,7 @@ To use GUI automation in a headless environment:
 from typing import Dict, Any, List, Tuple, Optional
 import logging
 import subprocess
+import asyncio
 import base64
 import os
 import json
@@ -278,7 +279,20 @@ class LinuxAutomationHandler(BaseAutomationHandler):
     # Command Execution
     async def run_command(self, command: str) -> Dict[str, Any]:
         try:
-            process = subprocess.run(command, shell=True, capture_output=True, text=True)
-            return {"success": True, "stdout": process.stdout, "stderr": process.stderr, "return_code": process.returncode}
+            # Create subprocess
+            process = await asyncio.create_subprocess_shell(
+                command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+            # Wait for the subprocess to finish
+            stdout, stderr = await process.communicate()
+            # Return decoded output
+            return {
+                "success": True, 
+                "stdout": stdout.decode() if stdout else "", 
+                "stderr": stderr.decode() if stderr else "", 
+                "return_code": process.returncode
+            }
         except Exception as e:
             return {"success": False, "error": str(e)}


### PR DESCRIPTION
Currently, the run_command uses the synchronous subprocess.run to execute shell commands, which can cause the websocket endpoint to hang and drop new connections. This PR replaces subprocess.run with asyncio.create_subprocess_shell, allowing you to run commands that pause execution without causing websocket connection issues.

