### PR TITLE
Replaced pkg_resources with importlib

### DIFF
--- a/libs/python/computer-server/computer_server/main.py
+++ b/libs/python/computer-server/computer_server/main.py
@@ -32,10 +32,15 @@ app = FastAPI(
 
 protocol_version = 1
 try:
-    import pkg_resources
-    package_version = pkg_resources.get_distribution("cua-computer-server").version
-except pkg_resources.DistributionNotFound:
-    package_version = "unknown"
+    from importlib.metadata import version
+    package_version = version("cua-computer-server")
+except Exception:
+    # Fallback for cases where package is not installed or importlib.metadata is not available
+    try:
+        import pkg_resources
+        package_version = pkg_resources.get_distribution("cua-computer-server").version
+    except Exception:
+        package_version = "unknown"
 
 accessibility_handler, automation_handler, diorama_handler, file_handler = HandlerFactory.create_handlers()
 handlers = {


### PR DESCRIPTION
This PR replaces the outdated `pkg_resources` with `importlib.metadata`, used by the `version` command on the `cua-computer-server`

> I found that recently the computer server script has an issue importing the (very old and deprecated) `pkg_resources` module. You can work around this by adding `setuptools` to the `pip install` line in `on_startup.sh`. 
 _Originally discovered by @ngaloppo in [#307](https://github.com/trycua/cua/issues/307#issuecomment-3063110260)_
