### PR TITLE
Fix broken import in Agent UI example

### DIFF
--- a/examples/agent_ui_examples.py
+++ b/examples/agent_ui_examples.py
@@ -13,7 +13,7 @@ from utils import load_dotenv_files
 load_dotenv_files()
 
 # Import the create_gradio_ui function
-from agent.ui.gradio.app import create_gradio_ui
+from agent.ui.gradio.ui_components import create_gradio_ui
 
 if __name__ == "__main__":
     print("Launching Computer-Use Agent Gradio UI with advanced features...")

--- a/notebooks/agent_nb.ipynb
+++ b/notebooks/agent_nb.ipynb
@@ -379,7 +379,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from agent.ui.gradio.app import create_gradio_ui\n",
+    "from agent.ui.gradio.ui_components import create_gradio_ui\n",
     "\n",
     "app = create_gradio_ui()\n",
     "app.launch(share=False)"

--- a/scripts/playground.sh
+++ b/scripts/playground.sh
@@ -257,7 +257,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 from computer import Computer
 from agent import ComputerAgent, LLM, AgentLoop, LLMProvider
-from agent.ui.gradio.app import create_gradio_ui
+from agent.ui.gradio.ui_components import create_gradio_ui
 
 # Load environment variables from .env.local
 load_dotenv(Path(__file__).parent / ".env.local")
@@ -292,7 +292,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 from computer import Computer
 from agent import ComputerAgent, LLM, AgentLoop, LLMProvider
-from agent.ui.gradio.app import create_gradio_ui
+from agent.ui.gradio.ui_components import create_gradio_ui
 
 # Load environment variables from .env.local
 load_dotenv(Path(__file__).parent / ".env.local")


### PR DESCRIPTION
This PR fixes the issue where the Agent UI example doesn't start as reported by this Discord user: https://discord.com/channels/1328377437301641247/1328377659167604746/1401976717710459023

Copied screenshot:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/583274f1-7222-4005-9213-87aa520d9f0b" />

To test the fix, I followed the dev container setup directions. The Gradio app now launches without error.