### PR TITLE
[Computer-Server] Disable pyautogui FAILSAFE

### DIFF
--- a/libs/python/computer-server/computer_server/handlers/linux.py
+++ b/libs/python/computer-server/computer_server/handlers/linux.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 # This allows the server to run in headless environments
 try:
     import pyautogui
+    pyautogui.FAILSAFE = False
 
     logger.info("pyautogui successfully imported, GUI automation available")
 except Exception as e:

--- a/libs/python/computer-server/computer_server/handlers/macos.py
+++ b/libs/python/computer-server/computer_server/handlers/macos.py
@@ -1,4 +1,5 @@
 import pyautogui
+pyautogui.FAILSAFE = False
 from pynput.mouse import Button, Controller as MouseController
 from pynput.keyboard import Key, Controller as KeyboardController
 import time

--- a/libs/python/computer-server/computer_server/handlers/windows.py
+++ b/libs/python/computer-server/computer_server/handlers/windows.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 # Try to import pyautogui
 try:
     import pyautogui
+    pyautogui.FAILSAFE = False
     logger.info("pyautogui successfully imported, GUI automation available")
 except Exception as e:
     logger.error(f"pyautogui import failed: {str(e)}. GUI operations will not work.")


### PR DESCRIPTION
The pyautogui FAILSAFE feature disables pyautogui commands when the cursor is located at (0,0). This can cause containerized workflows to fail, as the agent may move the cursor to that position, or the cursor may find itself there due to the VNC server. This PR fixes that issue.

**Changes Included**
- Disabled pyautogui.FAILSAFE which activated when the cursor was at (0,0)