### PR TITLE
Upgrade Agent SDK to require Python 3.12

### DIFF
--- a/libs/python/agent/pyproject.toml
+++ b/libs/python/agent/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "certifi>=2024.2.2",
     "litellm>=1.74.12"
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 
 [project.optional-dependencies]
 openai = []


### PR DESCRIPTION
The agent SDK uses Python 3.12 specific features, like nested quotes in fstrings, and type overrides. Trying to use it with Python 3.11 will cause an error.