### PR TITLE
Pin OpenAI version to work around BerriAI/litellm#13711

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ requires = ["pdm-backend"]
 
 [project]
 authors = [{ name = "TryCua", email = "gh@trycua.com" }]
-dependencies = []
+dependencies = [
+    "openai<1.100.0",
+]
 description = "CUA (Computer Use Agent) mono-repo"
 license = { text = "MIT" }
 name = "cua-workspace"


### PR DESCRIPTION
The latest versions of `openai` and `litellm` are incompatible (BerriAI/litellm#13711) and we are waiting for LiteLLM to release 1.75.9:

https://pypi.org/project/litellm/

If we want to fix this without waiting, we use this workaround.

Fixes #354 