### PR TITLE
[Computer] Removed slashes from container name

### DIFF
--- a/libs/python/computer/computer/computer.py
+++ b/libs/python/computer/computer/computer.py
@@ -160,6 +160,8 @@ class Computer:
             if not name:
                 # Normalize the name to be used for the VM
                 name = image.replace(":", "_")
+                # Remove any forward slashes
+                name = name.replace("/", "_")
 
             # Convert display parameter to Display object
             if isinstance(display, str):


### PR DESCRIPTION
This PR removes slashes when converting the image name to a container name (used when no image name is specified)

This fixes the following error:
> VM run response: {'name': 'trycua/cua-ubuntu_latest', 'status': 'error', 'error': "Failed to run container trycua/cua-ubuntu_latest: docker: Error response from daemon: Invalid container name (trycua/cua-ubuntu_latest), only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed.\nSee 'docker run --help'.\n", 'provider': 'docker'}



