### PR TITLE
Upgrade Claude 3.5 snapshot in web app, examples and docs

### DIFF
--- a/docs/content/docs/agent-sdk/custom-computer-handlers.mdx
+++ b/docs/content/docs/agent-sdk/custom-computer-handlers.mdx
@@ -34,7 +34,7 @@ You can then use this as a tool for your agent:
 from agent import ComputerAgent
 
 agent = ComputerAgent(
-    model="anthropic/claude-3-5-sonnet-20240620",
+    model="anthropic/claude-3-5-sonnet-20241022",
     tools=[custom_computer],
 )
 
@@ -122,7 +122,7 @@ class MyCustomComputer(AsyncComputerHandler):
 custom_computer = MyCustomComputer()
 
 agent = ComputerAgent(
-    model="anthropic/claude-3-5-sonnet-20240620",
+    model="anthropic/claude-3-5-sonnet-20241022",
     tools=[custom_computer],
 )
 

--- a/docs/content/docs/agent-sdk/prompt-caching.mdx
+++ b/docs/content/docs/agent-sdk/prompt-caching.mdx
@@ -36,7 +36,7 @@ With the OpenAI provider, prompt caching is handled automatically for prompts of
 ```python
 from agent import ComputerAgent
 agent = ComputerAgent(
-    model="anthropic/claude-3-5-sonnet-20240620",
+    model="anthropic/claude-3-5-sonnet-20241022",
     use_prompt_caching=True,
 )
 ```

--- a/docs/content/docs/agent-sdk/sandboxed-tools.mdx
+++ b/docs/content/docs/agent-sdk/sandboxed-tools.mdx
@@ -25,7 +25,7 @@ from computer import Computer
 
 computer = Computer(...)
 agent = ComputerAgent(
-    model="anthropic/claude-3-5-sonnet-20240620",
+    model="anthropic/claude-3-5-sonnet-20241022",
     tools=[computer, read_file],
 )
 ```

--- a/docs/content/docs/agent-sdk/supported-agents/computer-use-agents.mdx
+++ b/docs/content/docs/agent-sdk/supported-agents/computer-use-agents.mdx
@@ -16,7 +16,7 @@ Claude models with computer-use capabilities:
 - Claude 4.1: `claude-opus-4-1-20250805`
 - Claude 4: `claude-opus-4-20250514`, `claude-sonnet-4-20250514`
 - Claude 3.7: `claude-3-7-sonnet-20250219`
-- Claude 3.5: `claude-3-5-sonnet-20240620`
+- Claude 3.5: `claude-3-5-sonnet-20241022`
 
 ```python
 agent = ComputerAgent("claude-3-5-sonnet-20241022", tools=[computer])

--- a/docs/content/docs/agent-sdk/supported-agents/grounding-models.mdx
+++ b/docs/content/docs/agent-sdk/supported-agents/grounding-models.mdx
@@ -16,7 +16,7 @@ All models that support `ComputerAgent.run()` also support `ComputerAgent.predic
 - Claude 4.1: `claude-opus-4-1-20250805`
 - Claude 4: `claude-opus-4-20250514`, `claude-sonnet-4-20250514`
 - Claude 3.7: `claude-3-7-sonnet-20250219`
-- Claude 3.5: `claude-3-5-sonnet-20240620`
+- Claude 3.5: `claude-3-5-sonnet-20241022`
 
 ### OpenAI CUA Preview
 - Computer-use-preview: `computer-use-preview`

--- a/examples/agent_examples.py
+++ b/examples/agent_examples.py
@@ -48,7 +48,7 @@ async def run_agent_example():
             # model="anthropic/claude-opus-4-20250514", 
             # model="anthropic/claude-sonnet-4-20250514",
             # model="anthropic/claude-3-7-sonnet-20250219",
-            # model="anthropic/claude-3-5-sonnet-20240620",
+            # model="anthropic/claude-3-5-sonnet-20241022",
 
             # == UI-TARS ==
             # model="huggingface-local/ByteDance-Seed/UI-TARS-1.5-7B",

--- a/libs/python/agent/README.md
+++ b/libs/python/agent/README.md
@@ -84,7 +84,7 @@ if __name__ == "__main__":
 ### Anthropic Claude (Computer Use API)
 ```python
 model="anthropic/claude-3-5-sonnet-20241022"
-model="anthropic/claude-3-5-sonnet-20240620"
+model="anthropic/claude-3-7-sonnet-20250219"
 model="anthropic/claude-opus-4-20250514"
 model="anthropic/claude-sonnet-4-20250514"
 ```

--- a/libs/python/agent/agent/ui/gradio/app.py
+++ b/libs/python/agent/agent/ui/gradio/app.py
@@ -114,14 +114,14 @@ MODEL_MAPPINGS = {
         "Anthropic: Claude 4 Opus (20250514)": "anthropic/claude-opus-4-20250514",
         "Anthropic: Claude 4 Sonnet (20250514)": "anthropic/claude-sonnet-4-20250514",
         "Anthropic: Claude 3.7 Sonnet (20250219)": "anthropic/claude-3-7-sonnet-20250219",
-        "Anthropic: Claude 3.5 Sonnet (20240620)": "anthropic/claude-3-5-sonnet-20240620",
+        "Anthropic: Claude 3.5 Sonnet (20241022)": "anthropic/claude-3-5-sonnet-20241022",
     },
     "omni": {
         "default": "omniparser+openai/gpt-4o",
         "OMNI: OpenAI GPT-4o": "omniparser+openai/gpt-4o",
         "OMNI: OpenAI GPT-4o mini": "omniparser+openai/gpt-4o-mini",
         "OMNI: Claude 3.7 Sonnet (20250219)": "omniparser+anthropic/claude-3-7-sonnet-20250219",
-        "OMNI: Claude 3.5 Sonnet (20240620)": "omniparser+anthropic/claude-3-5-sonnet-20240620",
+        "OMNI: Claude 3.5 Sonnet (20241022)": "omniparser+anthropic/claude-3-5-sonnet-20241022",
     },
     "uitars": {
         "default": "huggingface-local/ByteDance-Seed/UI-TARS-1.5-7B" if is_mac else "ui-tars",

--- a/libs/python/agent/agent/ui/gradio/ui_components.py
+++ b/libs/python/agent/agent/ui/gradio/ui_components.py
@@ -38,13 +38,13 @@ def create_gradio_ui() -> gr.Blocks:
         "Anthropic: Claude 4 Opus (20250514)",
         "Anthropic: Claude 4 Sonnet (20250514)",
         "Anthropic: Claude 3.7 Sonnet (20250219)",
-        "Anthropic: Claude 3.5 Sonnet (20240620)",
+        "Anthropic: Claude 3.5 Sonnet (20241022)",
     ]
     omni_models = [
         "OMNI: OpenAI GPT-4o",
         "OMNI: OpenAI GPT-4o mini",
         "OMNI: Claude 3.7 Sonnet (20250219)", 
-        "OMNI: Claude 3.5 Sonnet (20240620)"
+        "OMNI: Claude 3.5 Sonnet (20241022)"
     ]
     
     # Check if API keys are available

--- a/libs/python/agent/example.py
+++ b/libs/python/agent/example.py
@@ -98,7 +98,7 @@ async def main():
             # model="anthropic/claude-opus-4-20250514", 
             # model="anthropic/claude-sonnet-4-20250514",
             # model="anthropic/claude-3-7-sonnet-20250219",
-            # model="anthropic/claude-3-5-sonnet-20240620",
+            # model="anthropic/claude-3-5-sonnet-20241022",
 
             # == UI-TARS ==
             # model="huggingface-local/ByteDance-Seed/UI-TARS-1.5-7B",

--- a/notebooks/agent_nb.ipynb
+++ b/notebooks/agent_nb.ipynb
@@ -442,7 +442,7 @@
    "source": [
     "anthropic_agent = ComputerAgent(\n",
     "    tools=[computer],\n",
-    "    model=\"anthropic/claude-3-5-sonnet-20240620\",\n",
+    "    model=\"anthropic/claude-3-5-sonnet-20241022\",\n",
     "    trajectory_dir=str(Path(\"trajectories\")),\n",
     "    verbosity=logging.INFO\n",
     ")\n"


### PR DESCRIPTION
Across the codebase, we had been using both `claude-3-5-sonnet-20240620` and `claude-3-5-sonnet-20241022`.

I replaced instances of `claude-3-5-sonnet-20240620`, since it doesn't support computer use.

Fixes #343