### PR TITLE
Restrict root project to Python versions below 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description = "CUA (Computer Use Agent) mono-repo"
 license = { text = "MIT" }
 name = "cua-workspace"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = "<3.14,>=3.12"
 version = "0.1.0"
 
 [project.urls]


### PR DESCRIPTION
Certain dependencies such as HUD also have this restriction, so this is necessary for those dependencies to work.