### PR TITLE
docs: unifiy capitalization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Missing a model? [Raise a feature request](https://github.com/trycua/cua/issues/
 
 - [Get started with a Computer-Use Agent UI](https://docs.trycua.com/docs/quickstart-ui)
 - [Get started with the Computer-Use Agent CLI](https://docs.trycua.com/docs/quickstart-cli)
-- [Get Started with the Python SDKs](https://docs.trycua.com/docs/quickstart-devs)
+- [Get started with the Python SDKs](https://docs.trycua.com/docs/quickstart-devs)
 
 <br/>
 


### PR DESCRIPTION
Unified capitalization of 'Get started' in the Quick Start section of the README. 