### PR TITLE
fix: updated server endpoint from `/vms/push` to `/lume/vms/push`

### DIFF
--- a/libs/lume/src/Server/Server.swift
+++ b/libs/lume/src/Server/Server.swift
@@ -294,7 +294,7 @@ final class Server {
                     return try await self.handleSetDefaultLocation(name)
                 }),
             Route(
-                method: "POST", path: "/vms/push",
+                method: "POST", path: "/lume/vms/push",
                 handler: { [weak self] request in
                     guard let self else { throw HTTPError.internalError }
                     return try await self.handlePush(request.body)


### PR DESCRIPTION
Signed-off-by: Jagjeevan Kashid <jagjeevandev97@gmail.com>

I have updated server end point as suggested by @jamesmurdza in issue #372 