### PR TITLE
fix: Added GPT-4o compatibility for screenshot actions with text parameter

### DIFF
--- a/libs/python/agent/agent/computers/base.py
+++ b/libs/python/agent/agent/computers/base.py
@@ -19,8 +19,12 @@ class AsyncComputerHandler(Protocol):
         """Get screen dimensions as (width, height)."""
         ...
     
-    async def screenshot(self) -> str:
-        """Take a screenshot and return as base64 string."""
+    async def screenshot(self, text: Optional[str] = None) -> str:
+        """Take a screenshot and return as base64 string.
+        
+        Args:
+            text: Optional descriptive text (for compatibility with GPT-4o models, ignored)
+        """
         ...
     
     async def click(self, x: int, y: int, button: str = "left") -> None:

--- a/libs/python/agent/agent/computers/cua.py
+++ b/libs/python/agent/agent/computers/cua.py
@@ -33,8 +33,12 @@ class cuaComputerHandler(AsyncComputerHandler):
         screen_size = await self.interface.get_screen_size()
         return screen_size["width"], screen_size["height"]
     
-    async def screenshot(self) -> str:
-        """Take a screenshot and return as base64 string."""
+    async def screenshot(self, text: Optional[str] = None) -> str:
+        """Take a screenshot and return as base64 string.
+        
+        Args:
+            text: Optional descriptive text (for compatibility with GPT-4o models, ignored)
+        """
         assert self.interface is not None
         screenshot_bytes = await self.interface.screenshot()
         return base64.b64encode(screenshot_bytes).decode('utf-8')

--- a/libs/python/agent/agent/computers/custom.py
+++ b/libs/python/agent/agent/computers/custom.py
@@ -120,8 +120,12 @@ class CustomComputerHandler(AsyncComputerHandler):
         
         return self._last_screenshot_size
     
-    async def screenshot(self) -> str:
-        """Take a screenshot and return as base64 string."""
+    async def screenshot(self, text: Optional[str] = None) -> str:
+        """Take a screenshot and return as base64 string.
+        
+        Args:
+            text: Optional descriptive text (for compatibility with GPT-4o models, ignored)
+        """
         result = await self._call_function(self.functions['screenshot'])
         b64_str = self._to_b64_str(result) # type: ignore
         


### PR DESCRIPTION
Signed-off-by: Jagjeevan Kashid <jagjeevandev97@gmail.com>

## What
Solved issue #344 

### Approach
GPT-4o models now send an additional parameter with screenshot actions for descriptive context, but CUA's computer handlers only accepted basic parameters. The agent execution logic passes all action parameters via **kwargs, causing a TypeError.

so to mitigate this I have added an `optional parameter` to all screenshot method implementations:
- cuaComputerHandler.screenshot(text: Optional[str] = None)
- AsyncComputerHandler protocol updated
- CustomComputerHandler.screenshot() updated

**Validation:** Verified against [OpenAI docs](https://platform.openai.com/docs/guides/tools-computer-use). While the docs show basic screenshot actions without text parameters, GPT-4o models are implementing enhanced behavior by including descriptive reasoning text.