### PR TITLE
Fix Windows Sandbox errors

### DIFF
--- a/examples/winsandbox_example.py
+++ b/examples/winsandbox_example.py
@@ -31,8 +31,8 @@ async def main():
         
         # Test running a command
         print("Testing command execution...")
-        stdout, stderr = await computer.interface.run_command("echo Hello from Windows Sandbox!")
-        print(f"Command output: {stdout}")
+        result = await computer.interface.run_command("echo Hello from Windows Sandbox!")
+        print(f"Command output: {result.stdout}")
 
         print("Press any key to continue...")
         input()

--- a/libs/python/computer/computer/computer.py
+++ b/libs/python/computer/computer/computer.py
@@ -154,8 +154,8 @@ class Computer:
         self.interface_logger = Logger("computer.interface", verbosity)
 
         if not use_host_computer_server:
-            if ":" not in image or len(image.split(":")) != 2:
-                raise ValueError("Image must be in the format <image_name>:<tag>")
+            if ":" not in image:
+                image = f"{image}:latest"
 
             if not name:
                 # Normalize the name to be used for the VM

--- a/libs/python/computer/computer/providers/winsandbox/provider.py
+++ b/libs/python/computer/computer/providers/winsandbox/provider.py
@@ -423,7 +423,7 @@ class WinSandboxProvider(BaseVMProvider):
             if total_attempts % 10 == 0:
                 self.logger.info(f"Still waiting for Windows Sandbox {name} IP after {total_attempts} attempts...")
     
-    async def _setup_computer_server(self, sandbox, name: str, visible: bool = False):
+    async def _setup_computer_server(self, sandbox, name: str, visible: bool = True):
         """Setup the computer server in the Windows Sandbox using RPyC.
         
         Args:
@@ -472,8 +472,8 @@ class WinSandboxProvider(BaseVMProvider):
                 shell=False
             )
             
-            # # Sleep for 30 seconds
-            # await asyncio.sleep(30)
+            # Sleep for 30 seconds
+            await asyncio.sleep(30)
 
             ip = await self.get_ip(name)
             self.logger.info(f"Sandbox IP: {ip}")

--- a/libs/python/computer/computer/providers/winsandbox/setup_script.ps1
+++ b/libs/python/computer/computer/providers/winsandbox/setup_script.ps1
@@ -79,15 +79,25 @@ try {
     $pythonVersion = & $pythonExe --version 2>&1
     Write-Host "Python version: $pythonVersion"
 
-    # Step 2: Create a dedicated virtual environment for the sandbox
+    # Step 2: Create a dedicated virtual environment in mapped Desktop folder (persistent)
     Write-Host "Step 2: Creating virtual environment (if needed)..."
-    $venvPath = "C:\Users\WDAGUtilityAccount\venv"
+    $cachePath = "C:\Users\WDAGUtilityAccount\Desktop\wsb_cache"
+    $venvPath = "C:\Users\WDAGUtilityAccount\Desktop\wsb_cache\venv"
     if (!(Test-Path $venvPath)) {
         Write-Host "Creating venv at: $venvPath"
         & $pythonExe -m venv $venvPath
     } else {
         Write-Host "Venv already exists at: $venvPath"
     }
+    # Hide the folder to keep Desktop clean
+    try {
+        $item = Get-Item $cachePath -ErrorAction SilentlyContinue
+        if ($item) {
+            if (-not ($item.Attributes -band [IO.FileAttributes]::Hidden)) {
+                $item.Attributes = $item.Attributes -bor [IO.FileAttributes]::Hidden
+            }
+        }
+    } catch { }
     $venvPython = Join-Path $venvPath "Scripts\python.exe"
     if (!(Test-Path $venvPython)) {
         throw "Virtual environment Python not found at $venvPython"

--- a/libs/python/computer/computer/providers/winsandbox/setup_script.ps1
+++ b/libs/python/computer/computer/providers/winsandbox/setup_script.ps1
@@ -79,23 +79,38 @@ try {
     $pythonVersion = & $pythonExe --version 2>&1
     Write-Host "Python version: $pythonVersion"
 
-    # Step 2: Install cua-computer-server directly
-    Write-Host "Step 2: Installing cua-computer-server..."
+    # Step 2: Create a dedicated virtual environment for the sandbox
+    Write-Host "Step 2: Creating virtual environment (if needed)..."
+    $venvPath = "C:\Users\WDAGUtilityAccount\venv"
+    if (!(Test-Path $venvPath)) {
+        Write-Host "Creating venv at: $venvPath"
+        & $pythonExe -m venv $venvPath
+    } else {
+        Write-Host "Venv already exists at: $venvPath"
+    }
+    $venvPython = Join-Path $venvPath "Scripts\python.exe"
+    if (!(Test-Path $venvPython)) {
+        throw "Virtual environment Python not found at $venvPython"
+    }
+    Write-Host "Using venv Python: $venvPython"
+
+    # Step 3: Install cua-computer-server into the venv
+    Write-Host "Step 3: Installing cua-computer-server..."
     
     Write-Host "Upgrading pip..."
-    & $pythonExe -m pip install --upgrade pip --quiet
+    & $venvPython -m pip install --upgrade pip --quiet
     
     Write-Host "Installing cua-computer-server..."
-    & $pythonExe -m pip install cua-computer-server --quiet
+    & $venvPython -m pip install cua-computer-server
     
     Write-Host "cua-computer-server installation completed."
 
-    # Step 3: Start computer server in background
-    Write-Host "Step 3: Starting computer server in background..."
-    Write-Host "Starting computer server with: $pythonExe"
+    # Step 4: Start computer server in background using the venv Python
+    Write-Host "Step 4: Starting computer server in background..."
+    Write-Host "Starting computer server with: $venvPython"
     
     # Start the computer server in the background
-    $serverProcess = Start-Process -FilePath $pythonExe -ArgumentList "-m", "computer_server.main" -WindowStyle Hidden -PassThru
+    $serverProcess = Start-Process -FilePath $venvPython -ArgumentList "-m", "computer_server.main" -WindowStyle Hidden -PassThru
     Write-Host "Computer server started in background with PID: $($serverProcess.Id)"
     
     # Give it a moment to start


### PR DESCRIPTION
This PR fixes the error requiring the "image" kwarg to have a ":tag" suffix when using the Windows Sandbox provider. It also fixes crashes that would occur if your Python environment is missing `cua-computer-server`. The setup now uses a cached venv to provision Windows Sandbox sessions, improving reliability and speed across different host python setups.

**Changes Included**
- Fixed errors when the `image=".."` kwarg is not in the format of `name:tag`
- Added `%HOME%/.cua/wsb_cache` for caching the venvs used within Windows Sandbox sessions
- Added 120 second wait if `%HOME%/.cua/wsb_cache/venv/Lib/site-packages/computer_server` doesn'te xist yet