### PR TITLE
Improve performance with Anthropic predict_click / composed agents

### DIFF
--- a/libs/python/agent/agent/loops/anthropic.py
+++ b/libs/python/agent/agent/loops/anthropic.py
@@ -1577,11 +1577,10 @@ Task: Click {instruction}. Output ONLY a click action on the target element."""
                 isinstance(item.get("action"), dict)):
                 
                 action = item["action"]
-                if action.get("type") == "click":
+                if action.get("x") and action.get("y"):
                     x = action.get("x")
                     y = action.get("y")
-                    if x is not None and y is not None:
-                        return (int(x), int(y))
+                    return (int(x), int(y))
         
         return None
     


### PR DESCRIPTION
Previously, Claude was prompted to produce a `click` action and the `predict_click` would only return coordinates if the action type was `click`. This sometimes fails as Claude may sometimes generate `mouse_move` actions instead. This PR changes the anthropic `predict_click` implementation to always return coordinates for all mouse actions, improving the reliability of using Claude in UI Grounding Mode and improving the performance of composed agents based on Claude models