### PR TITLE
Add Sonnet 4.5 support to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ With the Agent SDK, you can:
 
 | [All-in-one CUAs](https://docs.trycua.com/docs/agent-sdk/supported-agents/computer-use-agents) | [UI Grounding Models](https://docs.trycua.com/docs/agent-sdk/supported-agents/composed-agents) | [UI Planning Models](https://docs.trycua.com/docs/agent-sdk/supported-agents/composed-agents) |
 |---|---|---|
-| `anthropic/claude-opus-4-1-20250805` | `huggingface-local/xlangai/OpenCUA-{7B,32B}` | any all-in-one CUA |
+| `anthropic/claude-sonnet-4-5-20250929` | `huggingface-local/xlangai/OpenCUA-{7B,32B}` | any all-in-one CUA |
 | `openai/computer-use-preview` | `huggingface-local/HelloKKMe/GTA1-{7B,32B,72B}` | any VLM (using liteLLM, requires `tools` parameter) |
 | `openrouter/z-ai/glm-4.5v` | `huggingface-local/Hcompany/Holo1.5-{3B,7B,72B}` |  |
 | `huggingface-local/OpenGVLab/InternVL3_5-{1B,2B,4B,8B,...}` | any all-in-one CUA | |

--- a/docs/content/docs/agent-sdk/supported-agents/computer-use-agents.mdx
+++ b/docs/content/docs/agent-sdk/supported-agents/computer-use-agents.mdx
@@ -13,6 +13,7 @@ See [Running Models Locally](../local-models) for how to use Hugging Face and ML
 
 Claude models with computer-use capabilities:
 
+- Claude 4.5: `claude-sonnet-4-5-20250929`
 - Claude 4.1: `claude-opus-4-1-20250805`
 - Claude 4: `claude-opus-4-20250514`, `claude-sonnet-4-20250514`
 - Claude 3.7: `claude-3-7-sonnet-20250219`

--- a/docs/content/docs/quickstart-cli.mdx
+++ b/docs/content/docs/quickstart-cli.mdx
@@ -219,6 +219,7 @@ python -m agent.cli openai/computer-use-preview
 <Tab value="uv">
 
 ```bash
+uv run --with "cua-agent[cli]" -m agent.cli anthropic/claude-sonnet-4-5-20250929
 uv run --with "cua-agent[cli]" -m agent.cli anthropic/claude-opus-4-20250514
 uv run --with "cua-agent[cli]" -m agent.cli anthropic/claude-opus-4-1-20250805
 uv run --with "cua-agent[cli]" -m agent.cli anthropic/claude-sonnet-4-20250514
@@ -229,6 +230,7 @@ uv run --with "cua-agent[cli]" -m agent.cli anthropic/claude-3-5-sonnet-20241022
 <Tab value="conda/pip">
 
 ```bash
+python -m agent.cli anthropic/claude-sonnet-4-5-20250929
 python -m agent.cli anthropic/claude-opus-4-1-20250805
 python -m agent.cli anthropic/claude-opus-4-20250514
 python -m agent.cli anthropic/claude-sonnet-4-20250514


### PR DESCRIPTION
This PR mentions support for the newly released Claude Sonnet 4.5 in the docs. No changes were needed in the Agent SDK to enable support.