### PR TITLE
Disable watchdog on Windows Cloud instances

### DIFF
--- a/libs/python/computer-server/computer_server/cli.py
+++ b/libs/python/computer-server/computer_server/cli.py
@@ -72,7 +72,7 @@ def main() -> None:
 
     # Check if watchdog should be enabled
     container_name = os.environ.get("CONTAINER_NAME")
-    enable_watchdog = args.watchdog or bool(container_name)
+    enable_watchdog = (args.watchdog or bool(container_name)) and not sys.platform.startswith("win")
     
     if container_name:
         logger.info(f"Container environment detected (CONTAINER_NAME={container_name}), enabling watchdog")


### PR DESCRIPTION
The watchdog is a feature of computer-server that monitors the server's health and auto-restarts it if needed. This PR disables the watchdog component on Windows as it currently depends on `fcntl` which is only available on Unix.