### PR TITLE
update python packaging to invert the source of truth to the pyproject instead of commit tag (vibe-kanban)

### DIFF
--- a/.github/workflows/auto-tag-from-pyproject.yml
+++ b/.github/workflows/auto-tag-from-pyproject.yml
@@ -1,0 +1,112 @@
+name: Auto-tag from pyproject.toml changes
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'libs/python/*/pyproject.toml'
+
+permissions:
+  contents: write
+
+jobs:
+  detect-and-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Need 2 commits to compare changes
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install toml parser
+        run: pip install toml
+
+      - name: Detect version changes and create tags
+        run: |
+          # Get list of changed pyproject.toml files
+          CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD | grep 'libs/python/.*/pyproject.toml' || true)
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No pyproject.toml files changed"
+            exit 0
+          fi
+
+          echo "Changed pyproject.toml files:"
+          echo "$CHANGED_FILES"
+
+          # Process each changed file
+          for FILE in $CHANGED_FILES; do
+            echo "Processing $FILE"
+
+            # Extract package name from path (e.g., libs/python/core/pyproject.toml -> core)
+            PACKAGE_NAME=$(echo "$FILE" | sed -n 's|libs/python/\([^/]*\)/pyproject.toml|\1|p')
+
+            if [ -z "$PACKAGE_NAME" ]; then
+              echo "Could not extract package name from $FILE"
+              continue
+            fi
+
+            echo "Package name: $PACKAGE_NAME"
+
+            # Get current version from pyproject.toml
+            CURRENT_VERSION=$(python3 << EOF
+          import toml
+          with open("$FILE") as f:
+              data = toml.load(f)
+              print(data.get("project", {}).get("version", ""))
+          EOF
+            )
+
+            if [ -z "$CURRENT_VERSION" ]; then
+              echo "Could not extract version from $FILE"
+              continue
+            fi
+
+            echo "Current version: $CURRENT_VERSION"
+
+            # Check if version was actually changed in this commit
+            git show HEAD~1:"$FILE" > /tmp/prev_pyproject.toml 2>/dev/null || {
+              echo "This appears to be a new file, tagging with current version"
+              PREV_VERSION=""
+            }
+
+            if [ -f /tmp/prev_pyproject.toml ]; then
+              PREV_VERSION=$(python3 << EOF
+          import toml
+          with open("/tmp/prev_pyproject.toml") as f:
+              data = toml.load(f)
+              print(data.get("project", {}).get("version", ""))
+          EOF
+              )
+              echo "Previous version: $PREV_VERSION"
+
+              if [ "$CURRENT_VERSION" = "$PREV_VERSION" ]; then
+                echo "Version not changed for $PACKAGE_NAME, skipping"
+                continue
+              fi
+            fi
+
+            # Create tag name (e.g., core-v0.1.9)
+            TAG_NAME="${PACKAGE_NAME}-v${CURRENT_VERSION}"
+
+            echo "Creating tag: $TAG_NAME"
+
+            # Check if tag already exists
+            if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+              echo "Tag $TAG_NAME already exists, skipping"
+              continue
+            fi
+
+            # Create and push the tag
+            git tag -a "$TAG_NAME" -m "Release $PACKAGE_NAME v${CURRENT_VERSION}"
+            git push origin "$TAG_NAME"
+
+            echo "Successfully created and pushed tag: $TAG_NAME"
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pypi-publish-agent.yml
+++ b/.github/workflows/pypi-publish-agent.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get-version.outputs.version }}
       computer_version: ${{ steps.update-deps.outputs.computer_version }}
@@ -32,31 +32,47 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Determine version
-        id: get-version
-        run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
-            # Extract version from tag (for package-specific tags)
-            if [[ "${{ github.ref }}" =~ ^refs/tags/agent-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
-              VERSION=${BASH_REMATCH[1]}
-            else
-              echo "Invalid tag format for agent"
-              exit 1
-            fi
-          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            # Use version from workflow dispatch
-            VERSION=${{ github.event.inputs.version }}
-          else
-            # Use version from workflow_call
-            VERSION=${{ inputs.version }}
-          fi
-          echo "VERSION=$VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+
+      - name: Install toml parser
+        run: pip install toml
+
+      - name: Determine version
+        id: get-version
+        run: |
+          # First, try to extract version from git tag if triggered by tag push
+          if [ "${{ github.event_name }}" == "push" ] && [[ "${{ github.ref }}" =~ ^refs/tags/agent-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+            VERSION=${BASH_REMATCH[1]}
+            echo "Extracted version from tag: $VERSION"
+          # Next, try workflow dispatch input
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "${{ github.event.inputs.version }}" ]; then
+            VERSION=${{ github.event.inputs.version }}
+            echo "Using version from workflow dispatch: $VERSION"
+          # Next, try workflow_call input
+          elif [ "${{ github.event_name }}" == "workflow_call" ] && [ -n "${{ inputs.version }}" ]; then
+            VERSION=${{ inputs.version }}
+            echo "Using version from workflow_call: $VERSION"
+          else
+            # Default: read from pyproject.toml
+            echo "Reading version from pyproject.toml..."
+            VERSION=$(python3 << EOF
+          import toml
+          with open("libs/python/agent/pyproject.toml") as f:
+              data = toml.load(f)
+              print(data.get("project", {}).get("version", ""))
+          EOF
+            )
+            if [ -z "$VERSION" ]; then
+              echo "Error: Could not extract version from pyproject.toml"
+              exit 1
+            fi
+            echo "Extracted version from pyproject.toml: $VERSION"
+          fi
+          echo "VERSION=$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Update dependencies to latest versions
         id: update-deps

--- a/.github/workflows/pypi-publish-computer-server.yml
+++ b/.github/workflows/pypi-publish-computer-server.yml
@@ -27,37 +27,53 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get-version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Determine version
-        id: get-version
-        run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
-            # Extract version from tag (for package-specific tags)
-            if [[ "${{ github.ref }}" =~ ^refs/tags/computer-server-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
-              VERSION=${BASH_REMATCH[1]}
-            else
-              echo "Invalid tag format for computer-server"
-              exit 1
-            fi
-          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            # Use version from workflow dispatch
-            VERSION=${{ github.event.inputs.version }}
-          else
-            # Use version from workflow_call
-            VERSION=${{ inputs.version }}
-          fi
-          echo "VERSION=$VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
+
+      - name: Install toml parser
+        run: pip install toml
+
+      - name: Determine version
+        id: get-version
+        run: |
+          # First, try to extract version from git tag if triggered by tag push
+          if [ "${{ github.event_name }}" == "push" ] && [[ "${{ github.ref }}" =~ ^refs/tags/computer-server-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+            VERSION=${BASH_REMATCH[1]}
+            echo "Extracted version from tag: $VERSION"
+          # Next, try workflow dispatch input
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "${{ github.event.inputs.version }}" ]; then
+            VERSION=${{ github.event.inputs.version }}
+            echo "Using version from workflow dispatch: $VERSION"
+          # Next, try workflow_call input
+          elif [ "${{ github.event_name }}" == "workflow_call" ] && [ -n "${{ inputs.version }}" ]; then
+            VERSION=${{ inputs.version }}
+            echo "Using version from workflow_call: $VERSION"
+          else
+            # Default: read from pyproject.toml
+            echo "Reading version from pyproject.toml..."
+            VERSION=$(python3 << EOF
+          import toml
+          with open("libs/python/computer-server/pyproject.toml") as f:
+              data = toml.load(f)
+              print(data.get("project", {}).get("version", ""))
+          EOF
+            )
+            if [ -z "$VERSION" ]; then
+              echo "Error: Could not extract version from pyproject.toml"
+              exit 1
+            fi
+            echo "Extracted version from pyproject.toml: $VERSION"
+          fi
+          echo "VERSION=$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
   publish:
     needs: prepare

--- a/.github/workflows/pypi-publish-computer.yml
+++ b/.github/workflows/pypi-publish-computer.yml
@@ -23,38 +23,54 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get-version.outputs.version }}
       core_version: ${{ steps.update-deps.outputs.core_version }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Determine version
-        id: get-version
-        run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
-            # Extract version from tag (for package-specific tags)
-            if [[ "${{ github.ref }}" =~ ^refs/tags/computer-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
-              VERSION=${BASH_REMATCH[1]}
-            else
-              echo "Invalid tag format for computer"
-              exit 1
-            fi
-          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            # Use version from workflow dispatch
-            VERSION=${{ github.event.inputs.version }}
-          else
-            # Use version from workflow_call
-            VERSION=${{ inputs.version }}
-          fi
-          echo "VERSION=$VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+
+      - name: Install toml parser
+        run: pip install toml
+
+      - name: Determine version
+        id: get-version
+        run: |
+          # First, try to extract version from git tag if triggered by tag push
+          if [ "${{ github.event_name }}" == "push" ] && [[ "${{ github.ref }}" =~ ^refs/tags/computer-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+            VERSION=${BASH_REMATCH[1]}
+            echo "Extracted version from tag: $VERSION"
+          # Next, try workflow dispatch input
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "${{ github.event.inputs.version }}" ]; then
+            VERSION=${{ github.event.inputs.version }}
+            echo "Using version from workflow dispatch: $VERSION"
+          # Next, try workflow_call input
+          elif [ "${{ github.event_name }}" == "workflow_call" ] && [ -n "${{ inputs.version }}" ]; then
+            VERSION=${{ inputs.version }}
+            echo "Using version from workflow_call: $VERSION"
+          else
+            # Default: read from pyproject.toml
+            echo "Reading version from pyproject.toml..."
+            VERSION=$(python3 << EOF
+          import toml
+          with open("libs/python/computer/pyproject.toml") as f:
+              data = toml.load(f)
+              print(data.get("project", {}).get("version", ""))
+          EOF
+            )
+            if [ -z "$VERSION" ]; then
+              echo "Error: Could not extract version from pyproject.toml"
+              exit 1
+            fi
+            echo "Extracted version from pyproject.toml: $VERSION"
+          fi
+          echo "VERSION=$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Update dependencies to latest versions
         id: update-deps

--- a/.github/workflows/pypi-publish-core.yml
+++ b/.github/workflows/pypi-publish-core.yml
@@ -23,29 +23,50 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get-version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install toml parser
+        run: pip install toml
+
       - name: Determine version
         id: get-version
         run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
-            # Extract version from tag (for package-specific tags)
-            if [[ "${{ github.ref }}" =~ ^refs/tags/core-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
-              VERSION=${BASH_REMATCH[1]}
-            else
-              echo "Invalid tag format for core"
+          # First, try to extract version from git tag if triggered by tag push
+          if [ "${{ github.event_name }}" == "push" ] && [[ "${{ github.ref }}" =~ ^refs/tags/core-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+            VERSION=${BASH_REMATCH[1]}
+            echo "Extracted version from tag: $VERSION"
+          # Next, try workflow dispatch input
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "${{ github.event.inputs.version }}" ]; then
+            VERSION=${{ github.event.inputs.version }}
+            echo "Using version from workflow dispatch: $VERSION"
+          # Next, try workflow_call input
+          elif [ "${{ github.event_name }}" == "workflow_call" ] && [ -n "${{ inputs.version }}" ]; then
+            VERSION=${{ inputs.version }}
+            echo "Using version from workflow_call: $VERSION"
+          else
+            # Default: read from pyproject.toml
+            echo "Reading version from pyproject.toml..."
+            VERSION=$(python3 << EOF
+          import toml
+          with open("libs/python/core/pyproject.toml") as f:
+              data = toml.load(f)
+              print(data.get("project", {}).get("version", ""))
+          EOF
+            )
+            if [ -z "$VERSION" ]; then
+              echo "Error: Could not extract version from pyproject.toml"
               exit 1
             fi
-          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            # Use version from workflow dispatch
-            VERSION=${{ github.event.inputs.version }}
-          else
-            # Use version from workflow_call
-            VERSION=${{ inputs.version }}
+            echo "Extracted version from pyproject.toml: $VERSION"
           fi
           echo "VERSION=$VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/pypi-publish-mcp-server.yml
+++ b/.github/workflows/pypi-publish-mcp-server.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get-version.outputs.version }}
       agent_version: ${{ steps.update-deps.outputs.agent_version }}
@@ -35,31 +35,47 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Determine version
-        id: get-version
-        run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
-            # Extract version from tag (for package-specific tags)
-            if [[ "${{ github.ref }}" =~ ^refs/tags/mcp-server-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
-              VERSION=${BASH_REMATCH[1]}
-            else
-              echo "Invalid tag format for mcp-server"
-              exit 1
-            fi
-          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            # Use version from workflow dispatch
-            VERSION=${{ github.event.inputs.version }}
-          else
-            # Use version from workflow_call
-            VERSION=${{ inputs.version }}
-          fi
-          echo "VERSION=$VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+
+      - name: Install toml parser
+        run: pip install toml
+
+      - name: Determine version
+        id: get-version
+        run: |
+          # First, try to extract version from git tag if triggered by tag push
+          if [ "${{ github.event_name }}" == "push" ] && [[ "${{ github.ref }}" =~ ^refs/tags/mcp-server-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+            VERSION=${BASH_REMATCH[1]}
+            echo "Extracted version from tag: $VERSION"
+          # Next, try workflow dispatch input
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "${{ github.event.inputs.version }}" ]; then
+            VERSION=${{ github.event.inputs.version }}
+            echo "Using version from workflow dispatch: $VERSION"
+          # Next, try workflow_call input
+          elif [ "${{ github.event_name }}" == "workflow_call" ] && [ -n "${{ inputs.version }}" ]; then
+            VERSION=${{ inputs.version }}
+            echo "Using version from workflow_call: $VERSION"
+          else
+            # Default: read from pyproject.toml
+            echo "Reading version from pyproject.toml..."
+            VERSION=$(python3 << EOF
+          import toml
+          with open("libs/python/mcp-server/pyproject.toml") as f:
+              data = toml.load(f)
+              print(data.get("project", {}).get("version", ""))
+          EOF
+            )
+            if [ -z "$VERSION" ]; then
+              echo "Error: Could not extract version from pyproject.toml"
+              exit 1
+            fi
+            echo "Extracted version from pyproject.toml: $VERSION"
+          fi
+          echo "VERSION=$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Update dependencies to latest versions
         id: update-deps

--- a/.github/workflows/pypi-publish-pylume.yml
+++ b/.github/workflows/pypi-publish-pylume.yml
@@ -33,32 +33,47 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install toml parser
+        run: pip install toml
+
       - name: Determine version
         id: get-version
         run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
-            # Extract version from tag (for package-specific tags)
-            if [[ "${{ github.ref }}" =~ ^refs/tags/pylume-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
-              VERSION=${BASH_REMATCH[1]}
-            else
-              echo "Invalid tag format for pylume"
+          # First, try to extract version from git tag if triggered by tag push
+          if [ "${{ github.event_name }}" == "push" ] && [[ "${{ github.ref }}" =~ ^refs/tags/pylume-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+            VERSION=${BASH_REMATCH[1]}
+            echo "Extracted version from tag: $VERSION"
+          # Next, try workflow dispatch input
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "${{ github.event.inputs.version }}" ]; then
+            VERSION=${{ github.event.inputs.version }}
+            echo "Using version from workflow dispatch: $VERSION"
+          # Next, try workflow_call input
+          elif [ "${{ github.event_name }}" == "workflow_call" ] && [ -n "${{ inputs.version }}" ]; then
+            VERSION=${{ inputs.version }}
+            echo "Using version from workflow_call: $VERSION"
+          else
+            # Default: read from pyproject.toml
+            echo "Reading version from pyproject.toml..."
+            VERSION=$(python3 << EOF
+          import toml
+          with open("libs/python/pylume/pyproject.toml") as f:
+              data = toml.load(f)
+              print(data.get("project", {}).get("version", ""))
+          EOF
+            )
+            if [ -z "$VERSION" ]; then
+              echo "Error: Could not extract version from pyproject.toml"
               exit 1
             fi
-          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            # Use version from workflow dispatch
-            VERSION=${{ github.event.inputs.version }}
-          else
-            # Use version from workflow_call
-            VERSION=${{ inputs.version }}
+            echo "Extracted version from pyproject.toml: $VERSION"
           fi
           echo "VERSION=$VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-  validate-version:
-    runs-on: macos-latest
-    needs: determine-version
-    steps:
-      - uses: actions/checkout@v4
       - name: Validate version
         id: validate-version
         run: |

--- a/.github/workflows/pypi-publish-som.yml
+++ b/.github/workflows/pypi-publish-som.yml
@@ -33,27 +33,47 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install toml parser
+        run: pip install toml
+
       - name: Determine version
         id: get-version
         run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
-            # Extract version from tag (for package-specific tags)
-            if [[ "${{ github.ref }}" =~ ^refs/tags/som-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
-              VERSION=${BASH_REMATCH[1]}
-            else
-              echo "Invalid tag format for som"
+          # First, try to extract version from git tag if triggered by tag push
+          if [ "${{ github.event_name }}" == "push" ] && [[ "${{ github.ref }}" =~ ^refs/tags/som-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+            VERSION=${BASH_REMATCH[1]}
+            echo "Extracted version from tag: $VERSION"
+          # Next, try workflow dispatch input
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "${{ github.event.inputs.version }}" ]; then
+            VERSION=${{ github.event.inputs.version }}
+            echo "Using version from workflow dispatch: $VERSION"
+          # Next, try workflow_call input
+          elif [ "${{ github.event_name }}" == "workflow_call" ] && [ -n "${{ inputs.version }}" ]; then
+            VERSION=${{ inputs.version }}
+            echo "Using version from workflow_call: $VERSION"
+          else
+            # Default: read from pyproject.toml
+            echo "Reading version from pyproject.toml..."
+            VERSION=$(python3 << EOF
+          import toml
+          with open("libs/python/som/pyproject.toml") as f:
+              data = toml.load(f)
+              print(data.get("project", {}).get("version", ""))
+          EOF
+            )
+            if [ -z "$VERSION" ]; then
+              echo "Error: Could not extract version from pyproject.toml"
               exit 1
             fi
-          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            # Use version from workflow dispatch
-            VERSION=${{ github.event.inputs.version }}
-          else
-            # Use version from workflow_call
-            VERSION=${{ inputs.version }}
+            echo "Extracted version from pyproject.toml: $VERSION"
           fi
           echo "VERSION=$VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-
   publish:
     needs: determine-version
     uses: ./.github/workflows/pypi-reusable-publish.yml

--- a/.github/workflows/pypi-reusable-publish.yml
+++ b/.github/workflows/pypi-reusable-publish.yml
@@ -12,8 +12,8 @@ on:
         required: true
         type: string
       version:
-        description: "Version to publish"
-        required: true
+        description: "Version to publish (if not provided, will be read from pyproject.toml)"
+        required: false
         type: string
       is_lume_package:
         description: "Whether this package includes the lume binary"
@@ -65,11 +65,34 @@ jobs:
           python-version: "3.11"
           cache: true
 
+      - name: Install toml parser
+        run: pip install toml
+
       - name: Set version
         id: set-version
         run: |
-          echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
-          echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          if [ -n "${{ inputs.version }}" ]; then
+            # Use provided version
+            VERSION="${{ inputs.version }}"
+            echo "Using provided version: $VERSION"
+          else
+            # Extract version from pyproject.toml
+            echo "No version provided, reading from pyproject.toml..."
+            VERSION=$(python3 << EOF
+          import toml
+          with open("${{ inputs.package_dir }}/pyproject.toml") as f:
+              data = toml.load(f)
+              print(data.get("project", {}).get("version", ""))
+          EOF
+            )
+            if [ -z "$VERSION" ]; then
+              echo "Error: Could not extract version from pyproject.toml"
+              exit 1
+            fi
+            echo "Extracted version from pyproject.toml: $VERSION"
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Initialize PDM in package directory
         run: |
@@ -82,20 +105,13 @@ jobs:
             pdm lock
           fi
 
-      - name: Set version in package
+      - name: Verify version in package
         run: |
           cd ${{ inputs.package_dir }}
-          # Replace pdm bump with direct edit of pyproject.toml
-          if [[ "$OSTYPE" == "darwin"* ]]; then
-            # macOS version of sed needs an empty string for -i
-            sed -i '' "s/version = \".*\"/version = \"$VERSION\"/" pyproject.toml
-          else
-            # Linux version
-            sed -i "s/version = \".*\"/version = \"$VERSION\"/" pyproject.toml
-          fi
-          # Verify version was updated
-          echo "Updated version in pyproject.toml:"
+          # Verify the version in pyproject.toml matches what we're publishing
+          echo "Version in pyproject.toml:"
           grep "version =" pyproject.toml
+          echo "Publishing version: $VERSION"
 
       # Conditional step for lume binary download (only for pylume package)
       - name: Download and setup lume binary

--- a/PYTHON_PACKAGING_CHANGES.md
+++ b/PYTHON_PACKAGING_CHANGES.md
@@ -1,0 +1,197 @@
+# Python Packaging Refactor: pyproject.toml as Source of Truth
+
+## Summary
+
+This PR refactors the Python package release process to use **`pyproject.toml` as the single source of truth** for package versions, instead of git tags.
+
+### What Changed
+
+**Before:**
+```bash
+# Create tag manually
+git tag core-v0.1.9
+git push origin core-v0.1.9
+# Workflow extracts version from tag and updates pyproject.toml
+```
+
+**After:**
+```bash
+# Update version in pyproject.toml
+vim libs/python/core/pyproject.toml  # version = "0.1.9"
+git commit -am "Bump core to 0.1.9"
+git push origin main
+# Workflow automatically creates tag and publishes
+```
+
+## Files Changed
+
+### New Files
+
+1. **`.github/workflows/auto-tag-from-pyproject.yml`**
+   - Monitors changes to `pyproject.toml` files on main branch
+   - Automatically creates git tags when versions change
+   - Format: `{package}-v{version}` (e.g., `core-v0.1.9`)
+
+2. **`docs/PYTHON_VERSIONING.md`**
+   - Complete documentation of the new versioning process
+   - Examples, troubleshooting, best practices
+   - Migration guide from old system
+
+3. **`scripts/batch_update_workflows.py`**
+   - Script used to update all package workflows
+   - Can be used for future workflow updates
+
+4. **`scripts/test_version_extraction.sh`**
+   - Test script to verify version extraction works
+   - Validates all `pyproject.toml` files
+
+### Modified Files
+
+1. **`.github/workflows/pypi-reusable-publish.yml`**
+   - Made `version` input optional
+   - Added logic to read version from `pyproject.toml` if not provided
+   - Changed "Set version in package" step to "Verify version in package"
+   - No longer overwrites `pyproject.toml` version during build
+
+2. **Package Publish Workflows** (All updated):
+   - `.github/workflows/pypi-publish-core.yml`
+   - `.github/workflows/pypi-publish-computer.yml`
+   - `.github/workflows/pypi-publish-som.yml`
+   - `.github/workflows/pypi-publish-agent.yml`
+   - `.github/workflows/pypi-publish-pylume.yml`
+   - `.github/workflows/pypi-publish-computer-server.yml`
+   - `.github/workflows/pypi-publish-mcp-server.yml`
+
+   Changes:
+   - Added version extraction from `pyproject.toml`
+   - Fallback order: git tag → workflow_dispatch → workflow_call → pyproject.toml
+   - Changed prepare job runner from `macos-latest` to `ubuntu-latest` (faster)
+   - Added `toml` package installation
+   - Fixed duplicate "Set up Python" steps
+
+## How It Works
+
+```mermaid
+graph TD
+    A[Developer updates pyproject.toml version] --> B[Commit and push to main]
+    B --> C[auto-tag-from-pyproject.yml workflow]
+    C --> D{Version changed?}
+    D -->|Yes| E[Create git tag]
+    D -->|No| F[No action]
+    E --> G[Tag push triggers publish workflow]
+    G --> H[Read version from pyproject.toml]
+    H --> I[Build with PDM]
+    I --> J[Publish to PyPI]
+    J --> K[Create GitHub release]
+```
+
+## Benefits
+
+1. **Single Source of Truth**: Version is defined once in `pyproject.toml`
+2. **Reduced Errors**: No risk of tag/pyproject.toml version mismatch
+3. **Better Developer Experience**: Update version in one place
+4. **Automation**: Tags created automatically
+5. **Backward Compatible**: Manual tags and workflow dispatch still work
+
+## Migration Notes
+
+### No Breaking Changes
+
+- Existing workflows continue to work
+- Manual tag creation still supported
+- Workflow dispatch still supported
+- All existing git tags remain valid
+
+### For Developers
+
+**Old process still works:**
+```bash
+git tag core-v0.1.9
+git push origin core-v0.1.9
+```
+
+**New recommended process:**
+```bash
+# Edit pyproject.toml
+vim libs/python/core/pyproject.toml
+# version = "0.1.9"
+
+git commit -am "Bump core to 0.1.9"
+git push origin main
+# Tag created automatically
+```
+
+## Testing Recommendations
+
+Before merging, test the following scenarios:
+
+### Test 1: Auto-tag on version change
+```bash
+# On a test branch
+vim libs/python/core/pyproject.toml  # Change version
+git commit -am "Test: Bump version"
+git push origin test-branch
+# Merge to main and verify tag is created
+```
+
+### Test 2: Manual tag creation
+```bash
+git tag core-v0.1.10
+git push origin core-v0.1.10
+# Verify workflow runs and reads version from pyproject.toml
+```
+
+### Test 3: Workflow dispatch
+```bash
+# Go to Actions → Publish Core Package → Run workflow
+# Enter version manually
+# Verify it still works
+```
+
+### Test 4: Multiple packages
+```bash
+# Update versions in multiple packages
+vim libs/python/core/pyproject.toml
+vim libs/python/computer/pyproject.toml
+git commit -am "Bump core and computer"
+git push origin main
+# Verify both tags are created
+```
+
+## Rollback Plan
+
+If issues arise, rollback is simple:
+
+1. **Revert the auto-tag workflow:**
+   ```bash
+   git rm .github/workflows/auto-tag-from-pyproject.yml
+   ```
+
+2. **Revert workflow changes:**
+   ```bash
+   git checkout main~1 -- .github/workflows/pypi-*.yml
+   ```
+
+3. **Continue using manual tags:**
+   - Old process continues to work
+   - No data loss or corruption
+
+## Related Issues
+
+- Addresses: #4d28 (update-python-pa)
+- Improves: Developer experience, automation, error prevention
+- Maintains: Backward compatibility, existing workflows
+
+## Documentation
+
+Full documentation available in:
+- `docs/PYTHON_VERSIONING.md` - Complete guide with examples
+- `.github/workflows/auto-tag-from-pyproject.yml` - Auto-tag workflow
+- `.github/workflows/pypi-reusable-publish.yml` - Reusable publish workflow
+
+## Questions?
+
+For questions or issues:
+1. Check `docs/PYTHON_VERSIONING.md` for troubleshooting
+2. Review workflow run logs in GitHub Actions
+3. Contact the infrastructure team

--- a/docs/PYTHON_VERSIONING.md
+++ b/docs/PYTHON_VERSIONING.md
@@ -1,0 +1,301 @@
+# Python Package Versioning and Release Process
+
+## Overview
+
+The Python SDK packages in this repository now use **`pyproject.toml` as the source of truth** for versioning. When you update the version in a package's `pyproject.toml` file and push to the main branch, the system automatically creates git tags and triggers the release process.
+
+## Quick Start
+
+To release a new version of a package:
+
+1. **Update the version** in the package's `pyproject.toml`:
+   ```toml
+   [project]
+   name = "cua-core"
+   version = "0.1.9"  # Changed from 0.1.8
+   ```
+
+2. **Commit and push** to the main branch:
+   ```bash
+   git add libs/python/core/pyproject.toml
+   git commit -m "Bump cua-core version to 0.1.9"
+   git push origin main
+   ```
+
+3. **Automated process** kicks in:
+   - Auto-tag workflow detects the version change
+   - Creates git tag `core-v0.1.9`
+   - Triggers the publish workflow
+   - Builds and publishes to PyPI
+   - Creates GitHub release
+
+## How It Works
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Developer updates pyproject.toml version                    │
+│  and pushes to main branch                                   │
+└─────────────────────┬───────────────────────────────────────┘
+                      │
+                      ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Auto-tag Workflow (.github/workflows/                       │
+│  auto-tag-from-pyproject.yml)                                │
+│  - Detects changed pyproject.toml files                      │
+│  - Extracts package name and version                         │
+│  - Creates git tag (e.g., core-v0.1.9)                       │
+└─────────────────────┬───────────────────────────────────────┘
+                      │
+                      ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Package Publish Workflow (e.g.,                             │
+│  .github/workflows/pypi-publish-core.yml)                    │
+│  - Triggered by tag push                                     │
+│  - Reads version from pyproject.toml                         │
+│  - Builds package with PDM                                   │
+│  - Publishes to PyPI                                         │
+│  - Creates GitHub release                                    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Workflow Files
+
+1. **Auto-tag Workflow** (`.github/workflows/auto-tag-from-pyproject.yml`)
+   - Monitors: Changes to `libs/python/*/pyproject.toml` on main branch
+   - Action: Creates git tags automatically when version changes
+
+2. **Package Publish Workflows** (`.github/workflows/pypi-publish-*.yml`)
+   - Triggered by: Git tags (e.g., `core-v*`, `agent-v*`)
+   - Action: Build and publish to PyPI
+   - Version source: Reads from `pyproject.toml` (tag version is for validation)
+
+3. **Reusable Publish Workflow** (`.github/workflows/pypi-reusable-publish.yml`)
+   - Shared workflow used by all package publish workflows
+   - Handles building, publishing, and release creation
+
+## Packages
+
+The following packages are managed by this system:
+
+| Package | PyPI Name | Directory | Workflow |
+|---------|-----------|-----------|----------|
+| Core | `cua-core` | `libs/python/core` | `pypi-publish-core.yml` |
+| Computer | `cua-computer` | `libs/python/computer` | `pypi-publish-computer.yml` |
+| SOM | `cua-som` | `libs/python/som` | `pypi-publish-som.yml` |
+| Agent | `cua-agent` | `libs/python/agent` | `pypi-publish-agent.yml` |
+| Pylume | `pylume` | `libs/python/pylume` | `pypi-publish-pylume.yml` |
+| Computer Server | `cua-computer-server` | `libs/python/computer-server` | `pypi-publish-computer-server.yml` |
+| MCP Server | `cua-mcp-server` | `libs/python/mcp-server` | `pypi-publish-mcp-server.yml` |
+
+## Version Numbering
+
+We follow [Semantic Versioning](https://semver.org/) (SemVer):
+
+- **MAJOR.MINOR.PATCH** (e.g., `1.2.3`)
+- **MAJOR**: Breaking changes
+- **MINOR**: New features (backward compatible)
+- **PATCH**: Bug fixes (backward compatible)
+
+### Dependency Version Constraints
+
+Related packages use caret version constraints:
+
+```toml
+dependencies = [
+    "cua-core>=0.1.8,<0.2.0",     # Allow patch updates, not minor
+    "cua-computer>=0.4.0,<0.5.0",  # Allow patch updates, not minor
+]
+```
+
+## Manual Triggers
+
+### Option 1: Manual Workflow Dispatch
+
+You can manually trigger a release without creating a tag:
+
+1. Go to **Actions** → Select package workflow (e.g., "Publish Core Package")
+2. Click **"Run workflow"**
+3. Enter version (e.g., `0.1.9`)
+4. Click **"Run workflow"**
+
+### Option 2: Manual Tag Creation
+
+You can still create tags manually:
+
+```bash
+git tag core-v0.1.9
+git push origin core-v0.1.9
+```
+
+The publish workflow will still read the version from `pyproject.toml` for validation.
+
+## Special Cases
+
+### Agent Package
+
+The agent package has special dependency management:
+- Automatically updates to latest versions of `cua-core`, `cua-computer`, and `cua-som` during release
+- See `.github/workflows/pypi-publish-agent.yml` for details
+
+### Pylume Package
+
+The pylume package includes the lume binary:
+- Downloads latest lume binary during build
+- Verifies binary is included in wheel
+- See `.github/workflows/pypi-publish-pylume.yml` for details
+
+## Troubleshooting
+
+### Tag Already Exists
+
+If you need to republish a version:
+```bash
+# Delete local tag
+git tag -d core-v0.1.9
+
+# Delete remote tag
+git push origin :refs/tags/core-v0.1.9
+
+# Update pyproject.toml and push again
+```
+
+### Version Not Detected
+
+Check that:
+1. The version field in `pyproject.toml` is formatted correctly:
+   ```toml
+   version = "0.1.9"  # Correct
+   version = '0.1.9'  # Also works
+   version = 0.1.9    # Wrong - needs quotes
+   ```
+
+2. The `pyproject.toml` file is in the correct location:
+   ```
+   libs/python/<package-name>/pyproject.toml
+   ```
+
+### Workflow Failed
+
+1. Check the **Actions** tab for error details
+2. Common issues:
+   - TOML parsing error: Check `pyproject.toml` syntax
+   - PyPI upload failed: Check version doesn't already exist on PyPI
+   - Build failed: Check dependencies and build configuration
+
+## Migration Notes
+
+### What Changed
+
+**Before:**
+- Git tags were the source of truth
+- Workflow extracted version from tag
+- Updated `pyproject.toml` during build
+
+**After:**
+- `pyproject.toml` is the source of truth
+- Workflow reads version from `pyproject.toml`
+- Git tags are created automatically
+
+### Backward Compatibility
+
+The system maintains backward compatibility:
+- Manual tag creation still works
+- Manual workflow dispatch still works
+- `pyproject.toml` version is always used for the actual build
+
+## Best Practices
+
+1. **Update version in one place**: Only update the version in `pyproject.toml`
+2. **Commit message**: Use clear commit messages like "Bump cua-core to 0.1.9"
+3. **Test locally**: Test your changes with `pdm build` before pushing
+4. **Dependencies**: Update dependent package versions when releasing breaking changes
+5. **Changelog**: Consider maintaining a CHANGELOG.md for each package
+
+## Examples
+
+### Example 1: Patch Release
+
+Fixing a bug in cua-core:
+
+```bash
+# Edit the code
+vim libs/python/core/core/telemetry.py
+
+# Update version
+vim libs/python/core/pyproject.toml
+# Change: version = "0.1.8" → "0.1.9"
+
+# Commit and push
+git add .
+git commit -m "Fix telemetry bug - bump to 0.1.9"
+git push origin main
+
+# Automated:
+# - Tag created: core-v0.1.9
+# - Package published to PyPI
+```
+
+### Example 2: Minor Release
+
+Adding a new feature to cua-agent:
+
+```bash
+# Edit the code
+vim libs/python/agent/agent/agent.py
+
+# Update version
+vim libs/python/agent/pyproject.toml
+# Change: version = "0.4.0" → "0.5.0"
+
+# Commit and push
+git add .
+git commit -m "Add new agent feature - bump to 0.5.0"
+git push origin main
+
+# Automated:
+# - Tag created: agent-v0.5.0
+# - Dependencies updated automatically
+# - Package published to PyPI
+```
+
+### Example 3: Multiple Packages
+
+Releasing core and computer together:
+
+```bash
+# Update both packages
+vim libs/python/core/pyproject.toml    # 0.1.8 → 0.1.9
+vim libs/python/computer/pyproject.toml # 0.4.0 → 0.4.1
+
+# Commit both
+git add .
+git commit -m "Bump core to 0.1.9 and computer to 0.4.1"
+git push origin main
+
+# Automated:
+# - Tag created: core-v0.1.9
+# - Tag created: computer-v0.4.1
+# - Both packages published
+```
+
+## Reference
+
+### File Locations
+
+- Auto-tag workflow: `.github/workflows/auto-tag-from-pyproject.yml`
+- Reusable publish: `.github/workflows/pypi-reusable-publish.yml`
+- Package workflows: `.github/workflows/pypi-publish-*.yml`
+- Package files: `libs/python/*/pyproject.toml`
+
+### Required Secrets
+
+- `PYPI_TOKEN`: PyPI API token for publishing packages
+- `GITHUB_TOKEN`: Automatically provided by GitHub Actions
+
+### Permissions
+
+Workflows require:
+- `contents: write` - For creating tags and releases
+- `actions: read` - For reading workflow status

--- a/scripts/batch_update_workflows.py
+++ b/scripts/batch_update_workflows.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Script to update package publish workflows to read version from pyproject.toml
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# Package configurations: (workflow_filename, package_name, package_dir)
+PACKAGES = [
+    ("pypi-publish-computer.yml", "computer", "libs/python/computer"),
+    ("pypi-publish-som.yml", "som", "libs/python/som"),
+    ("pypi-publish-pylume.yml", "pylume", "libs/python/pylume"),
+    ("pypi-publish-computer-server.yml", "computer-server", "libs/python/computer-server"),
+    ("pypi-publish-mcp-server.yml", "mcp-server", "libs/python/mcp-server"),
+]
+
+VERSION_DETERMINATION_TEMPLATE = '''      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install toml parser
+        run: pip install toml
+
+      - name: Determine version
+        id: get-version
+        run: |
+          # First, try to extract version from git tag if triggered by tag push
+          if [ "${{{{ github.event_name }}}}" == "push" ] && [[ "${{{{ github.ref }}}}" =~ ^refs/tags/{package}-v([0-9]+\\.[0-9]+\\.[0-9]+) ]]; then
+            VERSION=${{BASH_REMATCH[1]}}
+            echo "Extracted version from tag: $VERSION"
+          # Next, try workflow dispatch input
+          elif [ "${{{{ github.event_name }}}}" == "workflow_dispatch" ] && [ -n "${{{{ github.event.inputs.version }}}}" ]; then
+            VERSION=${{{{ github.event.inputs.version }}}}
+            echo "Using version from workflow dispatch: $VERSION"
+          # Next, try workflow_call input
+          elif [ "${{{{ github.event_name }}}}" == "workflow_call" ] && [ -n "${{{{ inputs.version }}}}" ]; then
+            VERSION=${{{{ inputs.version }}}}
+            echo "Using version from workflow_call: $VERSION"
+          else
+            # Default: read from pyproject.toml
+            echo "Reading version from pyproject.toml..."
+            VERSION=$(python3 << EOF
+          import toml
+          with open("{package_dir}/pyproject.toml") as f:
+              data = toml.load(f)
+              print(data.get("project", {{}}).get("version", ""))
+          EOF
+            )
+            if [ -z "$VERSION" ]; then
+              echo "Error: Could not extract version from pyproject.toml"
+              exit 1
+            fi
+            echo "Extracted version from pyproject.toml: $VERSION"
+          fi
+          echo "VERSION=$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+'''
+
+
+def update_workflow(workflow_path: Path, package_name: str, package_dir: str):
+    """Update a single workflow file"""
+    print(f"Processing {workflow_path.name}...")
+
+    if not workflow_path.exists():
+        print(f"  Warning: File not found, skipping")
+        return False
+
+    content = workflow_path.read_text()
+
+    # Check if already updated
+    if "Reading version from pyproject.toml" in content:
+        print(f"  Already updated, skipping")
+        return False
+
+    # Create backup
+    backup_path = workflow_path.with_suffix('.yml.bak')
+    backup_path.write_text(content)
+
+    # Change macos-latest to ubuntu-latest in prepare job
+    content = re.sub(
+        r'(prepare:\s+runs-on:)\s+macos-latest',
+        r'\1 ubuntu-latest',
+        content
+    )
+
+    # Find the "Determine version" step and everything until the next step
+    determine_version_pattern = r'      - name: Determine version.*?(?=\n      - name:|\n  \w+:|\Z)'
+
+    # Replace with new version determination logic
+    new_version_step = VERSION_DETERMINATION_TEMPLATE.format(
+        package=package_name,
+        package_dir=package_dir
+    )
+
+    # If there's already a "Determine version" step, replace it
+    if re.search(determine_version_pattern, content, re.DOTALL):
+        content = re.sub(
+            determine_version_pattern,
+            new_version_step.rstrip(),
+            content,
+            flags=re.DOTALL
+        )
+    else:
+        # If there's no "Determine version" step, add it after checkout
+        # Find the checkout step and add after it
+        checkout_pattern = r'(- uses: actions/checkout@v4.*?\n)'
+        match = re.search(checkout_pattern, content, re.DOTALL)
+        if match:
+            insert_pos = match.end()
+            content = content[:insert_pos] + '\n' + new_version_step + content[insert_pos:]
+
+    # Write updated content
+    workflow_path.write_text(content)
+    print(f"  Updated successfully")
+    return True
+
+
+def main():
+    repo_root = Path(__file__).parent.parent
+    workflows_dir = repo_root / ".github" / "workflows"
+
+    if not workflows_dir.exists():
+        print(f"Error: Workflows directory not found: {workflows_dir}")
+        sys.exit(1)
+
+    print("Updating package workflows...\n")
+
+    updated_count = 0
+    for workflow_file, package_name, package_dir in PACKAGES:
+        workflow_path = workflows_dir / workflow_file
+        if update_workflow(workflow_path, package_name, package_dir):
+            updated_count += 1
+
+    print(f"\nCompleted! Updated {updated_count} workflows.")
+    print("Backup files created with .bak extension")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_version_extraction.sh
+++ b/scripts/test_version_extraction.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Test script to verify version extraction from pyproject.toml files
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "Testing version extraction from pyproject.toml files..."
+echo ""
+
+# Test each package
+PACKAGES=(
+    "core:libs/python/core"
+    "computer:libs/python/computer"
+    "som:libs/python/som"
+    "agent:libs/python/agent"
+    "pylume:libs/python/pylume"
+    "computer-server:libs/python/computer-server"
+    "mcp-server:libs/python/mcp-server"
+)
+
+all_passed=true
+
+for package_info in "${PACKAGES[@]}"; do
+    IFS=':' read -r package_name package_dir <<< "$package_info"
+    pyproject_file="$REPO_ROOT/$package_dir/pyproject.toml"
+
+    echo "Testing $package_name..."
+    echo "  Path: $pyproject_file"
+
+    if [ ! -f "$pyproject_file" ]; then
+        echo "  ❌ FAIL: pyproject.toml not found"
+        all_passed=false
+        continue
+    fi
+
+    # Extract version using the same method as the workflow
+    VERSION=$(python3 << EOF
+import toml
+with open("$pyproject_file") as f:
+    data = toml.load(f)
+    print(data.get("project", {}).get("version", ""))
+EOF
+    )
+
+    if [ -z "$VERSION" ]; then
+        echo "  ❌ FAIL: Could not extract version"
+        all_passed=false
+    else
+        echo "  ✅ PASS: Version = $VERSION"
+
+        # Verify version format (semver)
+        if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "  ⚠️  WARNING: Version doesn't match semver format (X.Y.Z)"
+        fi
+    fi
+    echo ""
+done
+
+if [ "$all_passed" = true ]; then
+    echo "✅ All tests passed!"
+    exit 0
+else
+    echo "❌ Some tests failed"
+    exit 1
+fi


### PR DESCRIPTION
Based on my analysis of the repository, here's how the Python SDK is built and released:

## Build System

The Python SDK is organized as a **monorepo** with multiple packages managed by **PDM** (Python Development Master):

### Python Packages
- `cua-core` - Base package with telemetry and shared utilities
- `pylume` - Python bindings for the lume virtualization tool (includes macOS binary)
- `cua-computer` - Computer-use interface (CUI) library
- `cua-som` - Set-of-Mark parser for computer vision/OCR
- `cua-agent` - AI agent library with multi-provider support
- `cua-computer-server` - FastAPI server for computer control
- `cua-mcp-server` - MCP (Model Context Protocol) integration

### Build Configuration
- Uses **PDM** as the build backend (`pdm.backend`)
- Configuration in `pyproject.toml` files for each package
- Requires Python 3.12+ (3.11 for some packages)
- Code formatting: Black, Ruff, MyPy
- Line length: 100 characters

## Local Development

**Setup:**
```bash
# Option 1: Using build script (recommended)
./scripts/build.sh

# Option 2: Using PDM directly
pdm install -G:all
```

The build script (scripts/build.sh:1):
1. Creates a shared virtual environment
2. Installs packages in dependency order (core → pylume → computer → som → agent → server → mcp)
3. Installs in development mode with `-e` flag
4. Sets up PYTHONPATH for imports

## Release Process

### Trigger Methods
Each package has its own GitHub Actions workflow:

1. **Tag-based releases**: Push tags like `core-v0.1.8`, `agent-v0.4.0`, etc.
2. **Manual dispatch**: Through GitHub Actions UI with version input
3. **Workflow calls**: Programmatic triggering with version parameter

### Workflow Steps (.github/workflows/pypi-reusable-publish.yml:1)

1. **Version Determination** - Extract version from tag or input
2. **Dependency Updates** (for agent/server packages) - Fetch latest versions of dependencies from PyPI
3. **Version Update** - Update `pyproject.toml` with new version using `sed`
4. **Binary Download** (pylume only) - Downloads latest lume binary from GitHub releases
5. **Build** - `pdm build` creates wheel and source distributions
6. **Verification** (pylume only) - Unpacks wheel to verify binary inclusion
7. **Publish** - Uses `twine` to upload to PyPI with API token
8. **Release Creation** - Creates GitHub release with auto-generated notes and wheel attachment

### Key Features
- **Runs on macOS** (macOS-latest runner)
- **Python 3.11** for build environment
- **Dependency pinning**: Agent package automatically updates to use latest versions of core, computer, and som packages
- **Reusable workflow**: Single workflow template (.github/workflows/pypi-reusable-publish.yml:1) used by all packages
- **GitHub releases**: Automatically created with package-specific documentation and installation instructions

### Example: Publishing cua-core v0.1.8
```bash
git tag core-v0.1.8
git push origin core-v0.1.8
```

This triggers the workflow at .github/workflows/pypi-publish-core.yml:1 which calls the reusable workflow to build and publish to PyPI.


i want to refactor this so that the pyproject.toml is the source of truth for these packages. so instead of tracking changes via git tags, i want to update the version of a dependency via pyproject.toml and for that to create a git tag

