### PR TITLE
Add multiplatform build docs for Docker images, fix incorrect image name

### DIFF
--- a/docs/content/docs/computer-sdk/computers.mdx
+++ b/docs/content/docs/computer-sdk/computers.mdx
@@ -63,7 +63,7 @@ Cua provides two Docker images for running Linux desktops:
     2. Pull the CUA XFCE image
 
     ```bash
-    docker pull --platform=linux/amd64 trycua/cua-docker-xfce:latest
+    docker pull --platform=linux/amd64 trycua/cua-xfce:latest
     ```
 
     3. Connect with Computer
@@ -74,7 +74,7 @@ Cua provides two Docker images for running Linux desktops:
     computer = Computer(
         os_type="linux",
         provider_type="docker",
-        image="trycua/cua-docker-xfce:latest",
+        image="trycua/cua-xfce:latest",
         name="my-xfce-container"
     )
 

--- a/docs/content/docs/quickstart-cli.mdx
+++ b/docs/content/docs/quickstart-cli.mdx
@@ -47,7 +47,7 @@ Choose how you want to run your cua computer. **Cloud Sandbox is recommended** f
     2. Pull the CUA XFCE container (lightweight desktop)
 
     ```bash
-    docker pull --platform=linux/amd64 trycua/cua-docker-xfce:latest
+    docker pull --platform=linux/amd64 trycua/cua-xfce:latest
     ```
 
     Or use KASM for a full-featured desktop:

--- a/libs/python/computer/computer/providers/docker/provider.py
+++ b/libs/python/computer/computer/providers/docker/provider.py
@@ -56,7 +56,7 @@ class DockerProvider(BaseVMProvider):
             image: Docker image to use (default: "trycua/cua-ubuntu:latest")
                    Supported images:
                    - "trycua/cua-ubuntu:latest" (Kasm-based)
-                   - "trycua/cua-docker-xfce:latest" (vanilla XFCE)
+                   - "trycua/cua-xfce:latest" (vanilla XFCE)
             verbose: Enable verbose logging
             ephemeral: Use ephemeral (temporary) storage
             vnc_port: Port for VNC interface (default: 6901)

--- a/libs/xfce/README.md
+++ b/libs/xfce/README.md
@@ -52,7 +52,7 @@ docker login
 # Build and push for amd64 and arm64 in one step
 docker buildx build \
   --platform linux/amd64,linux/arm64 \
-  -t trycua/cua-docker-xfce:latest \
+  -t trycua/cua-xfce:latest \
   --push \
   .
 ```
@@ -111,7 +111,7 @@ from computer import Computer
 computer = Computer(
     os_type="linux",
     provider_type="docker",
-    image="trycua/cua-docker-xfce:latest",  # Use docker-xfce instead of Kasm
+    image="trycua/cua-xfce:latest",  # Use docker-xfce instead of Kasm
     display="1024x768",
     memory="4GB",
     cpu="2"
@@ -147,7 +147,7 @@ computer_kasm = Computer(
 computer_xfce = Computer(
     os_type="linux",
     provider_type="docker",
-    image="trycua/cua-docker-xfce:latest",  # docker-xfce image
+    image="trycua/cua-xfce:latest",  # docker-xfce image
 )
 ```
 


### PR DESCRIPTION
This PR fixes the incorrect usage of `trycua/cua-xfce:latest` in the docs, instead of `trycua/cua-docker-xfce:latest`. It also changes the readme build steps to build for both amd64 and arm64.