### PR TITLE
Register gemini model

### DIFF
--- a/libs/python/agent/agent/loops/__init__.py
+++ b/libs/python/agent/agent/loops/__init__.py
@@ -14,6 +14,7 @@ from . import opencua
 from . import internvl
 from . import holo
 from . import moondream3
+from . import gemini
 
 __all__ = [
     "anthropic", 
@@ -27,4 +28,5 @@ __all__ = [
     "internvl",
     "holo",
     "moondream3",
+    "gemini"
 ]

--- a/libs/python/agent/agent/loops/openai.py
+++ b/libs/python/agent/agent/loops/openai.py
@@ -53,8 +53,7 @@ async def _prepare_tools_for_openai(tool_schemas: List[Dict[str, Any]]) -> Tools
     
     return openai_tools
 
-
-@register_agent(models=r".*computer-use-preview.*")
+@register_agent(models=r".*(^|/)computer-use-preview")
 class OpenAIComputerUseConfig:
     """
     OpenAI computer-use-preview agent configuration using liteLLM responses.


### PR DESCRIPTION
This PR adds the gemini model to the `__init__.py`, ensuring that `@register_model` gets called