### PR TITLE
[Agent] Add support for Claude Haiku 4.5

### DIFF
--- a/docs/content/docs/agent-sdk/supported-agents/computer-use-agents.mdx
+++ b/docs/content/docs/agent-sdk/supported-agents/computer-use-agents.mdx
@@ -25,7 +25,7 @@ async for _ in agent.run("Open Firefox and navigate to github.com"):
 
 Claude models with computer-use capabilities:
 
-- Claude 4.5: `claude-sonnet-4-5-20250929`
+- Claude 4.5: `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`
 - Claude 4.1: `claude-opus-4-1-20250805`
 - Claude 4: `claude-opus-4-20250514`, `claude-sonnet-4-20250514`
 - Claude 3.7: `claude-3-7-sonnet-20250219`

--- a/libs/python/agent/agent/loops/anthropic.py
+++ b/libs/python/agent/agent/loops/anthropic.py
@@ -33,7 +33,7 @@ from ..responses import (
 MODEL_TOOL_MAPPING = [
     # Claude 4 models
     {
-        "pattern": r"claude-4|claude-opus-4|claude-sonnet-4",
+        "pattern": r"claude-4|claude-opus-4|claude-sonnet-4|claude-haiku-4",
         "tool_version": "computer_20250124",
         "beta_flag": "computer-use-2025-01-24"
     },


### PR DESCRIPTION
This PR adds support for Claude Haiku 4.5 in the Agent SDK

# Example Usage

CLI
```python
python -m agent.cli anthropic/claude-haiku-4-5-20251001
```

Python
```python
agent = ComputerAgent(
  model="anthropic/claude-haiku-4-5-20251001"
)
```