### PR TITLE
Fix unicode typing on windows and linux

### DIFF
--- a/libs/python/computer-server/computer_server/handlers/windows.py
+++ b/libs/python/computer-server/computer_server/handlers/windows.py
@@ -169,6 +169,7 @@ class WindowsAutomationHandler(BaseAutomationHandler):
     """Windows implementation of automation handler using pyautogui and Windows APIs."""
     
     mouse = MouseController()
+    keyboard = KeyboardController()
 
     # Mouse Actions
     async def mouse_down(self, x: Optional[int] = None, y: Optional[int] = None, button: str = "left") -> Dict[str, Any]:
@@ -393,11 +394,9 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         Returns:
             Dict[str, Any]: A dictionary with success status and optional error message.
         """
-        if not pyautogui:
-            return {"success": False, "error": "pyautogui not available"}
-        
         try:
-            pyautogui.write(text)
+            # use pynput for Unicode support
+            self.keyboard.type(text)
             return {"success": True}
         except Exception as e:
             return {"success": False, "error": str(e)}

--- a/libs/python/computer/computer/interface/generic.py
+++ b/libs/python/computer/computer/interface/generic.py
@@ -117,15 +117,7 @@ class GenericComputerInterface(BaseComputerInterface):
         await self._handle_delay(delay)
     
     async def type_text(self, text: str, delay: Optional[float] = None) -> None:
-        # Temporary fix for https://github.com/trycua/cua/issues/165
-        # Check if text contains Unicode characters
-        if any(ord(char) > 127 for char in text):
-            # For Unicode text, use clipboard and paste
-            await self.set_clipboard(text)
-            await self.hotkey(Key.COMMAND, 'v')
-        else:
-            # For ASCII text, use the regular typing method
-            await self._send_command("type_text", {"text": text})
+        await self._send_command("type_text", {"text": text})
         await self._handle_delay(delay)
 
     async def press(self, key: "KeyType", delay: Optional[float] = None) -> None:


### PR DESCRIPTION
This PR allows you to pass multi-line Unicode strings into type_text on Windows and Mac.

**Changes Included**
- Replaced pyautogui.type_text with pynput.keyboard.type (Unicode compatible)
- Removed temporary patch that would send a "CMD+V" hotkey to type unicode text