### PR TITLE
Fix: Corrected f-string syntax error in agent.py

### DIFF
--- a/libs/python/agent/agent/agent.py
+++ b/libs/python/agent/agent/agent.py
@@ -533,7 +533,7 @@ class ComputerAgent:
                 # Perform function call
                 function = self._get_tool(item.get("name"))
                 if not function:
-                    raise ToolError(f"Function {item.get("name")} not found")
+                    raise ToolError(f"Function {item.get('name')} not found")
             
                 args = json.loads(item.get("arguments"))
 


### PR DESCRIPTION
A call to the `ToolError` class contained a malformed f-string; this syntax error renders the `agent` library unable to be imported. 

This pull request fixes the issue by using single line quotes.

**Steps to reproduce:**
```
$: python
>> import agent #Should fail with unmatched f-string SyntaxError
```

**Issue**
- A line in the `_handle_item` function tried to raise a `ToolError` with a dynamic name.
- To obtain the erroring function name, a dictionary lookup is used with double quotes.
- The issue is this is nested within an f-string which also uses double quotes.

**Fix**
- Use single quotes for dictionary lookup.

