### PR TITLE
Moved platform-specific deps from computer-server out of optional dependencies

### DIFF
--- a/libs/python/computer-server/pyproject.toml
+++ b/libs/python/computer-server/pyproject.toml
@@ -22,7 +22,13 @@ dependencies = [
     "pillow>=10.2.0",
     "aiohttp>=3.9.1",
     "pyperclip>=1.9.0",
-    "websockets>=12.0"
+    "websockets>=12.0",
+    # OS-specific runtime deps
+    "pyobjc-framework-Cocoa>=10.1; sys_platform == 'darwin'",
+    "pyobjc-framework-Quartz>=10.1; sys_platform == 'darwin'",
+    "pyobjc-framework-ApplicationServices>=10.1; sys_platform == 'darwin'",
+    "python-xlib>=0.33; sys_platform == 'linux'",
+    "pywin32>=310; sys_platform == 'win32'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR changes the computer-server dependencies to have the platform specific dependencies listed as primary dependencies. Previously, they were listed as optional dependencies.

**Before:**
```
pip install cua-computer-server
pip install cua-computer-server[windows]
pip install cua-computer-server[mac]
pip install cua-computer-server[linux]
```

**After:**
```
pip install cua-computer-server # Now installs correct dependencies depending on your sys_platform
```