### PR TITLE
Patch SSL cert store on Windows VMs with cua-computer-server

### DIFF
--- a/libs/python/computer-server/pyproject.toml
+++ b/libs/python/computer-server/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pyobjc-framework-ApplicationServices>=10.1; sys_platform == 'darwin'",
     "python-xlib>=0.33; sys_platform == 'linux'",
     "pywin32>=310; sys_platform == 'win32'",
-    "python-certifi-win32; sys_platform == 'win32'",
+    "pip-system-certs; sys_platform == 'win32'",
 ]
 
 [project.optional-dependencies]

--- a/libs/python/computer-server/pyproject.toml
+++ b/libs/python/computer-server/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "pyobjc-framework-ApplicationServices>=10.1; sys_platform == 'darwin'",
     "python-xlib>=0.33; sys_platform == 'linux'",
     "pywin32>=310; sys_platform == 'win32'",
+    "python-certifi-win32; sys_platform == 'win32'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
The SSL implementation in Python does not work on a fresh Windows installation (https://bugs.python.org/issue36011). This PR updates the cua-computer-server to install the `pip-system-certs` pypi package, which patches python `requests` to use the system certificate store as well as the `certifi` store. 