### PR TITLE
Support `display` and `ephemeral` in Docker provider

### DIFF
--- a/libs/python/computer/computer/providers/docker/provider.py
+++ b/libs/python/computer/computer/providers/docker/provider.py
@@ -258,14 +258,20 @@ class DockerProvider(BaseVMProvider):
                 logger.info(f"Container {name} is already running")
                 return existing_vm
             elif existing_vm["status"] in ["stopped", "paused"]:
-                # Start existing container
-                logger.info(f"Starting existing container {name}")
-                start_cmd = ["docker", "start", name]
-                result = subprocess.run(start_cmd, capture_output=True, text=True, check=True)
+                if self.ephemeral:
+                    # Delete existing container
+                    logger.info(f"Deleting existing container {name}")
+                    delete_cmd = ["docker", "rm", name]
+                    result = subprocess.run(delete_cmd, capture_output=True, text=True, check=True)
+                else:
+                    # Start existing container
+                    logger.info(f"Starting existing container {name}")
+                    start_cmd = ["docker", "start", name]
+                    result = subprocess.run(start_cmd, capture_output=True, text=True, check=True)
 
-                # Wait for container to be ready
-                await self._wait_for_container_ready(name)
-                return await self.get_vm(name, storage)
+                    # Wait for container to be ready
+                    await self._wait_for_container_ready(name)
+                    return await self.get_vm(name, storage)
 
             # Use provided image or default
             docker_image = image if image != "default" else self.image
@@ -401,6 +407,11 @@ class DockerProvider(BaseVMProvider):
                 del self._running_containers[name]
 
             logger.info(f"Container {name} stopped successfully")
+
+            # Delete container if ephemeral=True
+            if self.ephemeral:
+                cmd = ["docker", "rm", name]
+                result = subprocess.run(cmd, capture_output=True, text=True, check=True)
 
             return {
                 "name": name,


### PR DESCRIPTION
This PR allows you to change the computer screen resolution using Docker in the `trycua/cua-xfce` image. It also changes the behavior of when `ephemeral=True` for Docker containers, now deleting and recreating stopped containers instead of restarting them.