### PR TITLE
Make VS Code Python interpreter path cross-platform

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "python-envs.pythonProjects": [],
-  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.organizeImports": "explicit",


### PR DESCRIPTION
Replaces

`python.defaultInterpreterPath: ${workspaceFolder}/.venv/bin/python
`

with

`python.defaultInterpreterPath: ${workspaceFolder}/.venv`


so VS Code can automatically detect the correct interpreter on all platforms.
