### PR TITLE
Fix/omniparser predict refactor

### DIFF
--- a/libs/python/agent/agent/loops/omniparser.py
+++ b/libs/python/agent/agent/loops/omniparser.py
@@ -336,38 +336,20 @@ class OmniparserConfig(AsyncAgentConfig):
                 # Replace the original screenshot with the annotated image
                 annotated_image_url = f"data:image/png;base64,{result.annotated_image_base64}"
                 last_computer_call_output["output"]["image_url"] = annotated_image_url
-                print(f"🔍 DEBUG: Replaced screenshot with annotated image ({len(id2xy)} elements)")
 
         xy2id = {v: k for k, v in id2xy.items()}
-        print(
-            f"\n🔍 INPUT CONVERSION: xy2id mapping has {len(xy2id)} elements: {list(xy2id.items())[:5]}"
-        )
         messages_with_element_ids = []
         for i, message in enumerate(messages):
             if not isinstance(message, dict):
                 message = message.__dict__
 
             msg_type = message.get("type")
-            print(f"🔍 INPUT MSG {i}: type={msg_type}")
 
             if msg_type == "computer_call" and "action" in message:
                 action = message.get("action", {})
-                print(f"  → computer_call action: {action}")
-                if "x" in action and "y" in action:
-                    print(f"  → Has x,y: ({action['x']}, {action['y']})")
-                    print("  → Looking up in xy2id...")
-                    if (action["x"], action["y"]) in xy2id:
-                        print(f"  → Found element_id: {xy2id[(action['x'], action['y'])]}")
-                    else:
-                        print("  → NOT FOUND in xy2id!")
 
             converted = await replace_computer_call_with_function(message, xy2id)  # type: ignore
-            print(f"  → After conversion: {[c.get('type') for c in converted]}")
-            if converted and converted[0].get("type") == "function_call":
-                print(f"  → function_call args: {converted[0].get('arguments')}")
             messages_with_element_ids += converted
-
-        print(f"🔍 INPUT CONVERSION COMPLETE: {len(messages_with_element_ids)} messages\n")
 
         completion_messages = convert_responses_items_to_completion_messages(
             messages_with_element_ids, allow_images_in_tool_results=False
@@ -410,14 +392,6 @@ class OmniparserConfig(AsyncAgentConfig):
         for choice_message in choice_messages:
             responses_items.extend(convert_completion_messages_to_responses_items([choice_message]))
 
-        print("🔍 DEBUG: responses_items after completion conversion:")
-        for item in responses_items:
-            print(
-                f"  - {item.get('type')}: {item.get('action') if item.get('type') == 'computer_call' else item}"
-            )
-
-        print(f"🔍 DEBUG: id2xy mapping has {len(id2xy)} elements: {list(id2xy.items())[:5]}")
-
         # Convert element_id → x,y (similar to moondream's convert_computer_calls_desc2xy)
         final_output = []
         for item in responses_items:
@@ -432,7 +406,6 @@ class OmniparserConfig(AsyncAgentConfig):
                         action["x"] = x
                         action["y"] = y
                         del action["element_id"]
-                        print(f"🔍 DEBUG: Converted element_id {element_id} → x={x}, y={y}")
 
                 # Handle start_element_id and end_element_id for drag operations
                 elif "start_element_id" in action and "end_element_id" in action:


### PR DESCRIPTION
I generated this summary from my session during coding. but all the relevant documentation is linked below. I wanted to stress that the main issue was the input/ output mismatch. 

And to test this:

```python
"""
Test script to run agent with LOCAL code changes.
This uses the local modules from libs/python/agent and libs/python/computer
"""

import asyncio
import os
import sys
from pathlib import Path
import logging

# Add local libs to Python path so we use LOCAL code, not installed packages
project_root = Path(__file__).parent
sys.path.insert(0, str(project_root / "libs" / "python" / "agent"))
sys.path.insert(0, str(project_root / "libs" / "python" / "computer"))
sys.path.insert(0, str(project_root / "libs" / "python" / "core"))

print("=" * 60)
print("IMPORTANT: Using LOCAL modules from:")
print(f"  - {project_root / 'libs' / 'python' / 'agent'}")
print(f"  - {project_root / 'libs' / 'python' / 'computer'}")
print("=" * 60)

from dotenv import load_dotenv
from agent import ComputerAgent
from computer import Computer

load_dotenv()


async def main():
    """Test the agent with local code changes"""

    # Verify environment variables
    container_name = os.getenv("CUA_CONTAINER_NAME")
    api_key = os.getenv("CUA_API_KEY")
    openai_key = os.getenv("OPENAI_API_KEY")

    if not container_name:
        print("ERROR: CUA_CONTAINER_NAME not set in .env file")
        return
    if not api_key:
        print("ERROR: CUA_API_KEY not set in .env file")
        return
    if not openai_key:
        print("ERROR: OPENAI_API_KEY not set in .env file")
        return

    print(f"\n✓ Container: {container_name}")
    print(f"✓ API Key: {api_key[:20]}...")
    print(f"✓ OpenAI Key: {openai_key[:20]}...\n")

    async with Computer(
        os_type="linux",
        provider_type="cloud",
        name=container_name,
        api_key=api_key,
    ) as computer:

        agent = ComputerAgent(
            model="omniparser+openai/gpt-4o",
            tools=[computer],
            only_n_most_recent_images=3,
            verbosity=logging.DEBUG,
            trajectory_dir="trajectories",
            use_prompt_caching=True,
            max_trajectory_budget=1.0,
        )

        # Example tasks to demonstrate the agent
        tasks = [
              "Click on the web browser icon",
            #   "Visit https://form.jotform.com/252881246782264 and fill the form from the information in the pdf."
          ]

        # Use message-based conversation history
        history = []
        
        for i, task in enumerate(tasks):
            print(f"\nExecuting task {i+1}/{len(tasks)}: {task}")
            
            # Add user message to history
            history.append({"role": "user", "content": task})
            
            # Run agent with conversation history
            async for result in agent.run(history, stream=False):
                # Add agent outputs to history
                history += result.get("output", [])
                
                # Print output for debugging
                for item in result.get("output", []):
                    if item.get("type") == "message":
                        content = item.get("content", [])
                        for content_part in content:
                            if content_part.get("text"):
                                print(f"Agent: {content_part.get('text')}")
                    elif item.get("type") == "computer_call":
                        action = item.get("action", {})
                        action_type = action.get("type", "")
                        print(f"Computer Action: {action_type}({action})")
                    elif item.get("type") == "computer_call_output":
                        print("Computer Output: [Screenshot/Result]")
                        
            print(f"✅ Task {i+1}/{len(tasks)} completed: {task}")


if __name__ == "__main__":
    asyncio.run(main())

```

and for anthropic: 

```python
"""
Test script to run agent with LOCAL code changes.
This uses the local modules from libs/python/agent and libs/python/computer
"""
import logging
import asyncio
import os
import sys
from pathlib import Path

# Add local libs to Python path so we use LOCAL code, not installed packages
project_root = Path(__file__).parent
sys.path.insert(0, str(project_root / "libs" / "python" / "agent"))
sys.path.insert(0, str(project_root / "libs" / "python" / "computer"))
sys.path.insert(0, str(project_root / "libs" / "python" / "core"))

print("=" * 60)
print("IMPORTANT: Using LOCAL modules from:")
print(f"  - {project_root / 'libs' / 'python' / 'agent'}")
print(f"  - {project_root / 'libs' / 'python' / 'computer'}")
print("=" * 60)

from dotenv import load_dotenv
from agent import ComputerAgent
from computer import Computer

load_dotenv()


async def main():
    """Test the agent with local code changes"""

    # Verify environment variables
    container_name = os.getenv("CUA_CONTAINER_NAME")
    api_key = os.getenv("CUA_API_KEY")
    openai_key = os.getenv("OPENAI_API_KEY")
    anthropic_key = os.getenv("ANTHROPIC_API_KEY")

    if not container_name:
        print("ERROR: CUA_CONTAINER_NAME not set in .env file")
        return
    if not api_key:
        print("ERROR: CUA_API_KEY not set in .env file")
        return
    if not openai_key:
        print("ERROR: OPENAI_API_KEY not set in .env file")
        return
    if not anthropic_key:
        print("ERROR: ANTHROPIC_API_KEY not set in .env file")
        return

    print(f"\n✓ Container: {container_name}")
    print(f"✓ API Key: {api_key[:20]}...")
    print(f"✓ OpenAI Key: {openai_key[:20]}...\n")
    print(f"✓ Anthropic Key: {anthropic_key[:20]}...\n")
    async with Computer(
        os_type="linux",
        provider_type="cloud",
        name=container_name,
        api_key=api_key,
    ) as computer:

        agent = ComputerAgent(
            model="omniparser+anthropic/claude-sonnet-4-20250514",
            tools=[computer],
            only_n_most_recent_images=3,
            verbosity=logging.DEBUG,
            trajectory_dir="trajectories",
            use_prompt_caching=True,
            max_trajectory_budget=1.0,
        )

        # Example tasks to demonstrate the agent
        tasks = [
              "Click on the web browser icon"
          ]

        # Use message-based conversation history
        history = []
        
        for i, task in enumerate(tasks):
            print(f"\nExecuting task {i+1}/{len(tasks)}: {task}")
            
            # Add user message to history
            history.append({"role": "user", "content": task})
            
            # Run agent with conversation history
            async for result in agent.run(history, stream=False):
                # Add agent outputs to history
                history += result.get("output", [])
                
                # Print output for debugging
                for item in result.get("output", []):
                    if item.get("type") == "message":
                        content = item.get("content", [])
                        for content_part in content:
                            if content_part.get("text"):
                                print(f"Agent: {content_part.get('text')}")
                    elif item.get("type") == "computer_call":
                        action = item.get("action", {})
                        action_type = action.get("type", "")
                        print(f"Computer Action: {action_type}({action})")
                    elif item.get("type") == "computer_call_output":
                        print("Computer Output: [Screenshot/Result]")
                        
            print(f"✅ Task {i+1}/{len(tasks)} completed: {task}")


if __name__ == "__main__":
    asyncio.run(main())

```

# OmniParser: Migration from `aresponses` to `acompletion`

## Problem

OmniParser loop was using `litellm.aresponses()` which is **buggy and poorly supported** across providers, causing errors like:

```
BadRequestError: Unknown parameter: 'input[3].content'
```

## Root Cause

Per [LiteLLM documentation](https://github.com/berriai/litellm):

- **`aresponses()`**: Uses non-standard `input` parameter, provider-specific format, minimal documentation
- **`acompletion()`**: Uses standard `messages` parameter, universal provider support, extensive documentation

The moondream3 loop already uses `acompletion()` successfully.

## Changes Applied

### 1. **API Call Migration** (lines 344, 330, 377)
```python
# Before
response = await litellm.aresponses(input=messages, ...)

# After
response = await litellm.acompletion(messages=completion_messages, ...)
```

**Why**: Standard completion API is stable across all providers (OpenAI, Anthropic, Gemini, etc.)

### 2. **Tool Schema Format** (lines 23-85)
```python
# Before (Responses API format)
{
    "type": "function",
    "name": "computer",
    "parameters": {...}
}

# After (Completion API format)
{
    "type": "function",
    "function": {
        "name": "computer",
        "parameters": {...}
    }
}
```

**Why**: Completion API requires schema wrapped in `function` key per [Anthropic tool calling docs](https://docs.litellm.ai/docs/providers/anthropic#function-calling).

### 3. **Message Format Conversion** (lines 370-372, 407-411)
```python
# Convert responses format → completion format
completion_messages = convert_responses_items_to_completion_messages(
    messages_with_element_ids,
    allow_images_in_tool_results=False
)

# Convert completion format → responses format
responses_items.extend(
    convert_completion_messages_to_responses_items([choice_message])
)
```

**Why**: Following moondream3 pattern (lines 398-441). Uses proven helpers from `responses.py`.

### 4. **Coordinate Normalization** (lines 305-333)
```python
# Get screen dimensions from computer handler
width, height = await computer_handler.get_dimensions()

# Convert OmniParser normalized coords (0-1) to absolute pixels
pixel_x = int(norm_x * width)
pixel_y = int(norm_y * height)
```

**Why**: OmniParser returns normalized coordinates but computer handler expects pixels. Pattern from anthropic.py:72-77 and openai.py:20-25.

### 5. **Annotated Image Injection** (lines 335-337)
```python
# Replace original screenshot with annotated image
annotated_image_url = f"data:image/png;base64,{result.annotated_image_base64}"
last_computer_call_output["output"]["image_url"] = annotated_image_url
```

**Why**: LLM must see numbered overlays to choose valid element IDs (1-58) instead of hallucinating IDs like 535.

### 6. **Element ID Conversion** (lines 422-445)
```python
# Convert element_id → x,y after LLM response
if "element_id" in action:
    element_id = action["element_id"]
    if element_id in id2xy:
        x, y = id2xy[element_id]
        action["x"] = x
        action["y"] = y
        del action["element_id"]
```

**Why**: Mirrors moondream3's `convert_computer_calls_desc2xy()` pattern (responses.py:305-351).

### 7. **Schema Required Fields** (line 82)
```python
"required": ["action", "element_id"]  # Added element_id
```

**Why**: Anthropic strictly follows JSON schema. Without `element_id` in `required`, Claude treats it as optional per [Anthropic tool schema spec](https://docs.litellm.ai/docs/providers/anthropic#tool-choice).

## Results

- ✅ Works with OpenAI (gpt-4o, gpt-4o-mini)
- ✅ Works with Anthropic (claude-sonnet-4, claude-3.5-sonnet)
- ✅ Works with any provider supporting `acompletion`
- ✅ Coordinates properly converted (pixels, not normalized)
- ✅ LLM sees annotated images with element IDs
- ✅ Cross-provider compatibility maintained

## References

- [LiteLLM Completion API](https://docs.litellm.ai/docs/completion/input)
- [LiteLLM Anthropic Provider](https://docs.litellm.ai/docs/providers/anthropic)
- [Moondream3 Implementation](libs/python/agent/agent/loops/moondream3.py)
- [Responses Format Helpers](libs/python/agent/agent/responses.py)
