### PR TITLE
Swap pip-system-certs for python-certifi-win32

### DIFF
--- a/libs/python/computer-server/pyproject.toml
+++ b/libs/python/computer-server/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pyobjc-framework-ApplicationServices>=10.1; sys_platform == 'darwin'",
     "python-xlib>=0.33; sys_platform == 'linux'",
     "pywin32>=310; sys_platform == 'win32'",
-    "pip-system-certs; sys_platform == 'win32'",
+    "python-certifi-win32; sys_platform == 'win32'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR fixes instability issues on windows VMs where the computer-server would produce error codes 522 / empty responses