### PR TITLE
Restrict Lume CI to Lume changes

### DIFF
--- a/.github/workflows/ci-lume.yml
+++ b/.github/workflows/ci-lume.yml
@@ -3,7 +3,13 @@ on:
   push:
     branches:
       - "main"
-  pull_request: {}
+    paths:
+      - "libs/lume/**"
+      - ".github/workflows/ci-lume.yml"
+  pull_request:
+    paths:
+      - "libs/lume/**"
+      - ".github/workflows/ci-lume.yml"
 
 concurrency:
   group: lume-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
  - limit lume workflow triggers to libs/lume/*
  - allow the workflow to run when it changes