### PR TITLE
Fix agent version capture in bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -99,15 +99,7 @@ jobs:
         id: agent_version
         run: |
           cd libs/python/agent
-          VERSION=$(
-            python - <<'EOF'
-            import tomllib
-            from pathlib import Path
-
-            data = tomllib.loads(Path("pyproject.toml").read_text())
-            print(data["project"]["version"])
-            EOF
-          )
+          VERSION=$(python -c "import tomllib; from pathlib import Path; data = tomllib.loads(Path('pyproject.toml').read_text()); print(data['project']['version'])")
           echo "Agent version: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- Fixed exit code 2 error in "Capture bumped agent version" step
- Replaced heredoc-based Python script with inline command
- Simplified version extraction for better GitHub Actions compatibility

## Problem
The bump-version workflow was failing at the "Capture bumped agent version" step with exit code 2 after PR #577 was merged. The issue was caused by the heredoc syntax (`<<'EOF'`) used in the Python script, which had indentation issues when executed in GitHub Actions.

## Solution
Replaced the multi-line heredoc approach with a single-line Python command using `-c` flag:

```bash
VERSION=$(python -c "import tomllib; from pathlib import Path; data = tomllib.loads(Path('pyproject.toml').read_text()); print(data['project']['version'])")
```

This approach is more reliable in shell scripts and avoids heredoc indentation issues.

## Testing
- Tested locally and verified the command extracts the version correctly
- Command works identically to the original heredoc approach but with better shell compatibility

## Related
- Fixes: https://github.com/trycua/cua/actions/runs/19482457144
- Related to PR #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)