### PR TITLE
Add debugging and fix absolute paths in version consistency check

### DIFF
--- a/.github/workflows/pypi-reusable-publish.yml
+++ b/.github/workflows/pypi-reusable-publish.yml
@@ -84,9 +84,21 @@ jobs:
           # Install toml parser
           pip install toml
 
+          # Debug: Show current directory and paths
+          echo "Current directory: $(pwd)"
+          echo "GITHUB_WORKSPACE: ${GITHUB_WORKSPACE}"
+          echo "Package dir: ${{ inputs.package_dir }}"
+          echo "Expected version: ${{ inputs.version }}"
+          echo "Script path: ${GITHUB_WORKSPACE}/.github/scripts/get_pyproject_version.py"
+          echo "Pyproject path: ${GITHUB_WORKSPACE}/${{ inputs.package_dir }}/pyproject.toml"
+
+          # Check if files exist
+          ls -la ${GITHUB_WORKSPACE}/.github/scripts/get_pyproject_version.py
+          ls -la ${GITHUB_WORKSPACE}/${{ inputs.package_dir }}/pyproject.toml
+
           # Verify version matches using script (exits with error if mismatch)
           python ${GITHUB_WORKSPACE}/.github/scripts/get_pyproject_version.py \
-            ${{ inputs.package_dir }}/pyproject.toml \
+            ${GITHUB_WORKSPACE}/${{ inputs.package_dir }}/pyproject.toml \
             ${{ inputs.version }}
 
       - name: Initialize PDM in package directory


### PR DESCRIPTION
## Summary
- Added comprehensive debugging to diagnose argument passing issue
- Fixed pyproject.toml path to use absolute path with GITHUB_WORKSPACE
- Added file existence checks before running validation script

## Problem
The version consistency check is failing with a usage error:
```
Usage: python get_pyproject_version.py <pyproject_path> <expected_version>
Error: Process completed with exit code 1.
```

This indicates the script is running but not receiving the required 2 arguments correctly. This started happening after PR #595 added the `git reset --hard origin/main` step.

## Investigation Approach
This PR adds extensive debugging to understand what's happening:

1. **Path Information:**
   - Current working directory
   - GITHUB_WORKSPACE value
   - Package directory input
   - Expected version input
   - Full script path
   - Full pyproject.toml path

2. **File Existence Checks:**
   - Verify the script file exists
   - Verify the pyproject.toml file exists

3. **Path Fix:**
   - Changed from relative path `${{ inputs.package_dir }}/pyproject.toml`
   - To absolute path `${GITHUB_WORKSPACE}/${{ inputs.package_dir }}/pyproject.toml`
   - Ensures consistency with script path format

## Expected Outcome
The debug output will reveal:
- Whether GITHUB_WORKSPACE is set correctly after git reset
- Whether the files exist at the expected locations
- Whether the arguments are being passed correctly
- If paths need further adjustment

Once we see the debug output, we can make a targeted fix.

## Related
- Follows: PR #595 (which added git fetch/reset)
- Addresses: https://github.com/trycua/cua/actions/runs/19482970320

🤖 Generated with [Claude Code](https://claude.com/claude-code)