### PR TITLE
Add comprehensive debugging for version passing between workflows

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -103,6 +103,12 @@ jobs:
           echo "Agent version: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Verify agent version output
+        if: ${{ inputs.service == 'cua-agent' || inputs.service == 'cua-computer' }}
+        run: |
+          echo "=== Bump Version Job Outputs ==="
+          echo "Agent version output: ${{ steps.agent_version.outputs.version }}"
+
       - name: Push changes
         run: |
           git push origin main --follow-tags

--- a/.github/workflows/pypi-publish-agent.yml
+++ b/.github/workflows/pypi-publish-agent.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Determine version
         id: get-version
         run: |
+          echo "=== Version Determination Debug ==="
+          echo "Event name: ${{ github.event_name }}"
+          echo "Input version: ${{ inputs.version }}"
+          echo "Workflow dispatch version: ${{ github.event.inputs.version }}"
+          echo "GitHub ref: ${{ github.ref }}"
+
           if [ "${{ github.event_name }}" == "push" ]; then
             # Extract version from tag (for package-specific tags)
             if [[ "${{ github.ref }}" =~ ^refs/tags/agent-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
@@ -60,6 +66,8 @@ jobs:
             # Use version from workflow_call
             VERSION=${{ inputs.version }}
           fi
+
+          echo "=== Final Version ==="
           echo "VERSION=$VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
@@ -148,6 +156,14 @@ jobs:
           # Display the updated dependencies
           echo "Updated dependencies in pyproject.toml:"
           grep -E "cua-computer|cua-som|cua-core" pyproject.toml
+
+      - name: Verify prepare job outputs
+        run: |
+          echo "=== Prepare Job Outputs ==="
+          echo "Version output: ${{ steps.get-version.outputs.version }}"
+          echo "Computer version output: ${{ steps.update-deps.outputs.computer_version }}"
+          echo "SOM version output: ${{ steps.update-deps.outputs.som_version }}"
+          echo "Core version output: ${{ steps.update-deps.outputs.core_version }}"
 
   publish:
     needs: prepare


### PR DESCRIPTION
## Summary
- Added debug logging at every stage to trace version parameter through workflow chain
- Identifies where the version becomes empty between bump-version and publish workflows

## Problem
PR #596 revealed that the version parameter is empty when it reaches the reusable publish workflow:
```
Expected version:
```

The version should flow through this chain:
1. bump-version job outputs agent_version
2. publish-agent workflow receives via inputs.version
3. prepare job outputs version
4. publish job receives version from prepare
5. pypi-reusable-publish receives via inputs.version

But somewhere in this chain, the version is being lost.

## Debug Strategy

Added logging at three critical points to trace the version through the entire workflow chain.

## Expected Outcome

The debug output will reveal:
- Is bump-version outputting the version?
- Is pypi-publish-agent receiving the version via inputs?
- Is the prepare job outputting the version?
- Where exactly does the version get lost?

Once we identify the break in the chain, we can make a targeted fix.

## Related
- Follows: PR #596 (which revealed the empty version parameter)
- Addresses: Issue where version consistency check fails with usage error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
