### PR TITLE
Fix version determination logic for workflow_call

### DIFF
--- a/.github/workflows/pypi-publish-agent.yml
+++ b/.github/workflows/pypi-publish-agent.yml
@@ -51,20 +51,30 @@ jobs:
           echo "Workflow dispatch version: ${{ github.event.inputs.version }}"
           echo "GitHub ref: ${{ github.ref }}"
 
-          if [ "${{ github.event_name }}" == "push" ]; then
+          # Check inputs.version first (works for workflow_call regardless of event_name)
+          if [ -n "${{ inputs.version }}" ]; then
+            # Version provided via workflow_call or workflow_dispatch with version input
+            VERSION=${{ inputs.version }}
+            echo "Using inputs.version: $VERSION"
+          elif [ "${{ github.event_name }}" == "push" ]; then
             # Extract version from tag (for package-specific tags)
             if [[ "${{ github.ref }}" =~ ^refs/tags/agent-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
               VERSION=${BASH_REMATCH[1]}
+              echo "Extracted from tag: $VERSION"
             else
               echo "Invalid tag format for agent"
               exit 1
             fi
-          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            # Use version from workflow dispatch
+          elif [ -n "${{ github.event.inputs.version }}" ]; then
+            # Use version from workflow_dispatch event inputs
             VERSION=${{ github.event.inputs.version }}
+            echo "Using event.inputs.version: $VERSION"
           else
-            # Use version from workflow_call
-            VERSION=${{ inputs.version }}
+            echo "ERROR: No version found!"
+            echo "  - inputs.version is empty"
+            echo "  - event.inputs.version is empty"
+            echo "  - Not a tag push event"
+            exit 1
           fi
 
           echo "=== Final Version ==="


### PR DESCRIPTION
## Summary
- Fixed version determination logic to prioritize inputs.version
- Resolves empty version parameter issue in publish workflows
- This is THE ROOT CAUSE FIX for the version consistency failures

## The Bug

When `pypi-publish-agent` is called via `workflow_call` from `bump-version`:
- `github.event_name` is `"workflow_dispatch"` (inherited from parent workflow)
- NOT `"workflow_call"` as one might expect
- The code was checking: `if event_name == "workflow_dispatch"` then use `github.event.inputs.version`
- But `github.event.inputs.version` is EMPTY (it's not a UI-triggered workflow_dispatch)
- The actual version `0.4.44` was in `inputs.version` all along!

## Debug Output Revealed

From PR #597 debugging:
```
Event name: workflow_dispatch
Input version: 0.4.44          <- The correct value!
Workflow dispatch version:     <- Empty
=== Final Version ===
VERSION=                       <- Bug: used wrong source
```

## The Fix

Changed version determination order to check `inputs.version` FIRST:

1. **Check `inputs.version`** (works for all workflow_call scenarios)
2. Check if tag push event
3. Check `event.inputs.version` as fallback

This works correctly for ALL trigger methods:
- ✅ workflow_call from bump-version → uses `inputs.version`  
- ✅ Tag push → extracts from tag
- ✅ Manual workflow_dispatch with version param → uses `inputs.version`
- ✅ Manual workflow_dispatch from UI → uses `event.inputs.version`

## Result

Now the version flows correctly:
1. bump-version captures: `0.4.44`
2. Calls publish-agent with: `version: 0.4.44`
3. prepare job checks `inputs.version` first: `VERSION=0.4.44`
4. Passes to reusable-publish: `version: 0.4.44`
5. Version consistency check: PASSES! ✅

## Related
- Fixes: https://github.com/trycua/cua/actions/runs/19483269380
- Debug from: PR #597
- Supersedes: PRs #593, #594, #595, #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)
