### PR TITLE
Remove debug logging from workflow files

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -103,12 +103,6 @@ jobs:
           echo "Agent version: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Verify agent version output
-        if: ${{ inputs.service == 'cua-agent' || inputs.service == 'cua-computer' }}
-        run: |
-          echo "=== Bump Version Job Outputs ==="
-          echo "Agent version output: ${{ steps.agent_version.outputs.version }}"
-
       - name: Push changes
         run: |
           git push origin main --follow-tags

--- a/.github/workflows/pypi-publish-agent.yml
+++ b/.github/workflows/pypi-publish-agent.yml
@@ -45,40 +45,25 @@ jobs:
       - name: Determine version
         id: get-version
         run: |
-          echo "=== Version Determination Debug ==="
-          echo "Event name: ${{ github.event_name }}"
-          echo "Input version: ${{ inputs.version }}"
-          echo "Workflow dispatch version: ${{ github.event.inputs.version }}"
-          echo "GitHub ref: ${{ github.ref }}"
-
           # Check inputs.version first (works for workflow_call regardless of event_name)
           if [ -n "${{ inputs.version }}" ]; then
-            # Version provided via workflow_call or workflow_dispatch with version input
             VERSION=${{ inputs.version }}
-            echo "Using inputs.version: $VERSION"
           elif [ "${{ github.event_name }}" == "push" ]; then
             # Extract version from tag (for package-specific tags)
             if [[ "${{ github.ref }}" =~ ^refs/tags/agent-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
               VERSION=${BASH_REMATCH[1]}
-              echo "Extracted from tag: $VERSION"
             else
-              echo "Invalid tag format for agent"
+              echo "ERROR: Invalid tag format for agent"
               exit 1
             fi
           elif [ -n "${{ github.event.inputs.version }}" ]; then
-            # Use version from workflow_dispatch event inputs
             VERSION=${{ github.event.inputs.version }}
-            echo "Using event.inputs.version: $VERSION"
           else
-            echo "ERROR: No version found!"
-            echo "  - inputs.version is empty"
-            echo "  - event.inputs.version is empty"
-            echo "  - Not a tag push event"
+            echo "ERROR: No version found (inputs.version, event.inputs.version, and tag all empty)"
             exit 1
           fi
 
-          echo "=== Final Version ==="
-          echo "VERSION=$VERSION"
+          echo "Agent version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Set up Python
@@ -166,14 +151,6 @@ jobs:
           # Display the updated dependencies
           echo "Updated dependencies in pyproject.toml:"
           grep -E "cua-computer|cua-som|cua-core" pyproject.toml
-
-      - name: Verify prepare job outputs
-        run: |
-          echo "=== Prepare Job Outputs ==="
-          echo "Version output: ${{ steps.get-version.outputs.version }}"
-          echo "Computer version output: ${{ steps.update-deps.outputs.computer_version }}"
-          echo "SOM version output: ${{ steps.update-deps.outputs.som_version }}"
-          echo "Core version output: ${{ steps.update-deps.outputs.core_version }}"
 
   publish:
     needs: prepare

--- a/.github/workflows/pypi-reusable-publish.yml
+++ b/.github/workflows/pypi-reusable-publish.yml
@@ -84,18 +84,6 @@ jobs:
           # Install toml parser
           pip install toml
 
-          # Debug: Show current directory and paths
-          echo "Current directory: $(pwd)"
-          echo "GITHUB_WORKSPACE: ${GITHUB_WORKSPACE}"
-          echo "Package dir: ${{ inputs.package_dir }}"
-          echo "Expected version: ${{ inputs.version }}"
-          echo "Script path: ${GITHUB_WORKSPACE}/.github/scripts/get_pyproject_version.py"
-          echo "Pyproject path: ${GITHUB_WORKSPACE}/${{ inputs.package_dir }}/pyproject.toml"
-
-          # Check if files exist
-          ls -la ${GITHUB_WORKSPACE}/.github/scripts/get_pyproject_version.py
-          ls -la ${GITHUB_WORKSPACE}/${{ inputs.package_dir }}/pyproject.toml
-
           # Verify version matches using script (exits with error if mismatch)
           python ${GITHUB_WORKSPACE}/.github/scripts/get_pyproject_version.py \
             ${GITHUB_WORKSPACE}/${{ inputs.package_dir }}/pyproject.toml \


### PR DESCRIPTION
## Summary
- Removed all debug logging added during investigation
- Cleaned up 3 workflow files
- Kept minimal production-ready logging
- Maintained all fixes from PR #598

## Changes

### bump-version.yml
- ❌ Removed "Verify agent version output" debug step
- ✅ Kept essential "Agent version: X.X.X" output

### pypi-publish-agent.yml  
- ❌ Removed "=== Version Determination Debug ===" section
- ❌ Removed verbose logging showing all version sources
- ❌ Removed "Verify prepare job outputs" debug step
- ✅ Kept simple "Agent version: X.X.X" output
- ✅ Kept error messages for production debugging

### pypi-reusable-publish.yml
- ❌ Removed all debug output (pwd, paths, ls commands)
- ✅ Kept core version validation logic
- ✅ Script errors still visible if validation fails

## Result

Workflows now have clean, production-ready logging:
- No verbose debug output cluttering logs
- Essential version information still logged
- Error messages preserved for troubleshooting
- All functionality from PR #598 maintained

The workflows are production-ready! 🎉

## Related
- Follows: PR #598 (the root cause fix)
- Cleanup from: PRs #593, #594, #595, #596, #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)