### PR TITLE
Remove hud-python from cua-agent[all] extra

### DIFF
--- a/libs/python/agent/pyproject.toml
+++ b/libs/python/agent/pyproject.toml
@@ -100,8 +100,6 @@ all = [
     "python-dotenv>=1.0.1",
     # cli requirements
     "yaspin>=3.1.0",
-    # hud requirements
-    "hud-python==0.4.52",
     # gemini requirements
     "google-genai>=1.41.0",
     # qwen requirements


### PR DESCRIPTION
## Summary

Removes `hud-python==0.4.52` from the `[all]` extra dependencies in `cua-agent` to fix installation issues.

## Problem

`hud-python==0.4.52` is not published to PyPI (latest is 0.4.28), which was blocking installation of `cua-agent[all]`:

```bash
ERROR: Could not find a version that satisfies the requirement hud-python==0.4.52
ERROR: No matching distribution found for hud-python==0.4.52
```

## Solution

- Removed `hud-python==0.4.52` from the `[all]` extra dependencies
- Kept the separate `[hud]` extra for users who have access to `hud-python`
- Now `pip install cua-agent[all]` works without dependency errors

## Testing

Users can now successfully install:
```bash
pip install cua-agent[all]
```

Users who need hud functionality can still install it separately:
```bash
pip install cua-agent[hud]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)