### PR TITLE
Fix bump-version workflow to publish correct package

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       agent_version: ${{ steps.agent_version.outputs.version }}
+      computer_version: ${{ steps.computer_version.outputs.version }}
     steps:
       - name: Set package directory
         id: package
@@ -103,14 +104,31 @@ jobs:
           echo "Agent version: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Capture bumped computer version
+        if: ${{ inputs.service == 'cua-computer' }}
+        id: computer_version
+        run: |
+          cd libs/python/computer
+          VERSION=$(python -c "import tomllib; from pathlib import Path; data = tomllib.loads(Path('pyproject.toml').read_text()); print(data['project']['version'])")
+          echo "Computer version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Push changes
         run: |
           git push origin main --follow-tags
 
   publish-agent:
     needs: bump-version
-    if: ${{ inputs.service == 'cua-agent' || inputs.service == 'cua-computer' }}
+    if: ${{ inputs.service == 'cua-agent' }}
     uses: ./.github/workflows/pypi-publish-agent.yml
     with:
       version: ${{ needs.bump-version.outputs.agent_version }}
+    secrets: inherit
+
+  publish-computer:
+    needs: bump-version
+    if: ${{ inputs.service == 'cua-computer' }}
+    uses: ./.github/workflows/pypi-publish-computer.yml
+    with:
+      version: ${{ needs.bump-version.outputs.computer_version }}
     secrets: inherit


### PR DESCRIPTION
## Problem
When bumping `cua-computer` version using the "Bump Version" workflow, it was incorrectly publishing `cua-agent` to PyPI instead of `cua-computer`.

**Failed workflow run:** https://github.com/trycua/cua/actions/runs/19512484987

### What was happening:
1. ✅ Bumping cua-computer version correctly
2. ✅ Also bumping cua-agent version (intentional, since agent depends on computer)
3. ❌ Publishing cua-agent to PyPI (wrong!)
4. ❌ NOT publishing cua-computer to PyPI (missing!)

## Root Cause
The `publish-agent` job condition was triggering for both services:
```yaml
if: ${{ inputs.service == 'cua-agent' || inputs.service == 'cua-computer' }}
```

This meant it would publish agent for BOTH `cua-agent` and `cua-computer` bumps, but there was no job to publish computer.

## Solution
1. **Added `computer_version` output** to capture the bumped computer version
2. **Fixed `publish-agent` condition** to only run for `cua-agent`:
   ```yaml
   if: ${{ inputs.service == 'cua-agent' }}
   ```
3. **Added new `publish-computer` job** that runs when `cua-computer` is bumped:
   ```yaml
   publish-computer:
     needs: bump-version
     if: ${{ inputs.service == 'cua-computer' }}
     uses: ./.github/workflows/pypi-publish-computer.yml
     with:
       version: ${{ needs.bump-version.outputs.computer_version }}
   ```

## Result
**Now when bumping `cua-computer`:**
- ✅ Bumps cua-computer version
- ✅ Also bumps cua-agent version (maintains dependency sync)
- ✅ Publishes cua-computer to PyPI ← **Fixed!**
- ✅ Does NOT publish cua-agent to PyPI ← **Fixed!**

**When bumping `cua-agent`:**
- ✅ Bumps cua-agent version only
- ✅ Publishes cua-agent to PyPI

## Testing
To verify this fix works correctly:
1. Trigger the "Bump Version" workflow with service: `cua-computer`
2. Verify it publishes `cua-computer` package (not `cua-agent`) to PyPI
3. Verify both versions are bumped in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)