### PR TITLE
Publish both cua-agent and cua-computer when bumping cua-computer

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -119,7 +119,7 @@ jobs:
 
   publish-agent:
     needs: bump-version
-    if: ${{ inputs.service == 'cua-agent' }}
+    if: ${{ inputs.service == 'cua-agent' || inputs.service == 'cua-computer' }}
     uses: ./.github/workflows/pypi-publish-agent.yml
     with:
       version: ${{ needs.bump-version.outputs.agent_version }}

--- a/.github/workflows/pypi-publish-computer.yml
+++ b/.github/workflows/pypi-publish-computer.yml
@@ -33,21 +33,39 @@ jobs:
       - name: Determine version
         id: get-version
         run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
+          echo "=== Version Detection Debug ==="
+          echo "Event name: ${{ github.event_name }}"
+          echo "Workflow call version: ${{ inputs.version }}"
+          echo "Workflow dispatch version: ${{ github.event.inputs.version }}"
+          echo "GitHub ref: ${{ github.ref }}"
+
+          # Check inputs.version first (works for workflow_call regardless of event_name)
+          if [ -n "${{ inputs.version }}" ]; then
+            # Version provided via workflow_call or workflow_dispatch with version input
+            VERSION=${{ inputs.version }}
+            echo "Using inputs.version: $VERSION"
+          elif [ "${{ github.event_name }}" == "push" ]; then
             # Extract version from tag (for package-specific tags)
             if [[ "${{ github.ref }}" =~ ^refs/tags/computer-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
               VERSION=${BASH_REMATCH[1]}
+              echo "Extracted from tag: $VERSION"
             else
               echo "Invalid tag format for computer"
               exit 1
             fi
-          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            # Use version from workflow dispatch
+          elif [ -n "${{ github.event.inputs.version }}" ]; then
+            # Use version from workflow_dispatch event inputs
             VERSION=${{ github.event.inputs.version }}
+            echo "Using event.inputs.version: $VERSION"
           else
-            # Use version from workflow_call
-            VERSION=${{ inputs.version }}
+            echo "ERROR: No version found!"
+            echo "  - inputs.version is empty"
+            echo "  - event.inputs.version is empty"
+            echo "  - Not a tag push event"
+            exit 1
           fi
+
+          echo "=== Final Version ==="
           echo "VERSION=$VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Problem
After PR #605 was merged, we still have two issues:

1. **Version detection error in pypi-publish-computer workflow**
   - Similar to the issue fixed in PR #598 for pypi-publish-agent
   - The workflow fails with: `Usage: python get_pyproject_version.py <pyproject_path> <expected_version>`
   - This happens because version detection logic doesn't handle `workflow_call` events correctly

2. **Only cua-computer is published when bumping cua-computer**
   - When we bump cua-computer, we also bump cua-agent (since agent depends on computer)
   - However, we only publish cua-computer to PyPI, not cua-agent
   - This creates version inconsistency: agent is bumped locally but not published

## Solution

### 1. Fix version detection in pypi-publish-computer workflow
Applied the same fix from PR #598:
- Check `inputs.version` first (works for workflow_call regardless of event_name)
- Add debug output to help troubleshoot version detection
- Proper handling of all three trigger types: workflow_call, workflow_dispatch, push
- Clear error message if no version is found

### 2. Publish both packages when bumping cua-computer
Updated the `publish-agent` job condition:
```yaml
# Before
if: ${{ inputs.service == 'cua-agent' }}

# After
if: ${{ inputs.service == 'cua-agent' || inputs.service == 'cua-computer' }}
```

## Behavior After This PR

**When bumping `cua-agent`:**
- ✅ Bumps cua-agent version
- ✅ Publishes cua-agent to PyPI

**When bumping `cua-computer`:**
- ✅ Bumps cua-computer version
- ✅ Also bumps cua-agent version (maintains dependency sync)
- ✅ Publishes cua-computer to PyPI
- ✅ Publishes cua-agent to PyPI ← **New behavior**

This ensures version consistency between the two packages since cua-agent depends on cua-computer (`"cua-computer>=0.4.0,<0.5.0"`).

## Test Plan
- [ ] Trigger "Bump Version" workflow with service: `cua-computer`
- [ ] Verify both cua-computer and cua-agent are published to PyPI
- [ ] Verify version consistency between packages
- [ ] Verify no version detection errors in pypi-publish-computer workflow

## Related
- Builds on PR #605
- Similar fix to PR #598 (for pypi-publish-agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)