### PR TITLE
Ensure publish-agent waits for publish-computer when bumping cua-computer

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -117,18 +117,18 @@ jobs:
         run: |
           git push origin main --follow-tags
 
-  publish-agent:
-    needs: bump-version
-    if: ${{ inputs.service == 'cua-agent' || inputs.service == 'cua-computer' }}
-    uses: ./.github/workflows/pypi-publish-agent.yml
-    with:
-      version: ${{ needs.bump-version.outputs.agent_version }}
-    secrets: inherit
-
   publish-computer:
     needs: bump-version
     if: ${{ inputs.service == 'cua-computer' }}
     uses: ./.github/workflows/pypi-publish-computer.yml
     with:
       version: ${{ needs.bump-version.outputs.computer_version }}
+    secrets: inherit
+
+  publish-agent:
+    needs: [bump-version, publish-computer]
+    if: ${{ always() && (inputs.service == 'cua-agent' || inputs.service == 'cua-computer') && needs.bump-version.result == 'success' && (inputs.service == 'cua-agent' || needs.publish-computer.result == 'success') }}
+    uses: ./.github/workflows/pypi-publish-agent.yml
+    with:
+      version: ${{ needs.bump-version.outputs.agent_version }}
     secrets: inherit


### PR DESCRIPTION
## Problem
When bumping `cua-computer`, we currently publish both `cua-computer` and `cua-agent` to PyPI. However, they run in parallel, which can cause issues:

- `cua-agent` depends on `cua-computer` (e.g., `"cua-computer>=0.4.0,<0.5.0"`)
- If `cua-agent` publishes before `cua-computer`, users installing the new agent might fail because the required computer version isn't available yet
- Even if both succeed, there's a race condition window where agent is available but computer isn't

## Solution
Modified the workflow to ensure **sequential publishing** when bumping cua-computer:

1. **Reordered jobs**: `publish-computer` now comes before `publish-agent`
2. **Added dependency**: `publish-agent` now depends on `publish-computer`
3. **Smart condition**: Uses `always()` with explicit result checks to handle both scenarios

### Workflow Behavior

**When bumping `cua-agent`:**
```
bump-version → publish-agent
```
- Publishes agent immediately (no computer dependency)

**When bumping `cua-computer`:**
```
bump-version → publish-computer → publish-agent
                     ↓
                 (must succeed first)
```
- Publishes computer first
- Only publishes agent after computer succeeds
- Ensures the new computer version is available before agent (which depends on it)

### Technical Details

The condition for `publish-agent`:
```yaml
if: ${{ always() && 
        (inputs.service == 'cua-agent' || inputs.service == 'cua-computer') && 
        needs.bump-version.result == 'success' && 
        (inputs.service == 'cua-agent' || needs.publish-computer.result == 'success') }}
```

- `always()`: Run even if `publish-computer` is skipped (for cua-agent bumps)
- Check bump-version succeeded
- For cua-agent: run immediately
- For cua-computer: require publish-computer to succeed

## Benefits
- ✅ Eliminates race conditions
- ✅ Ensures dependency availability before dependent package is published
- ✅ Better reliability for users installing packages
- ✅ Maintains backward compatibility with cua-agent-only bumps

## Test Plan
- [ ] Bump cua-agent: verify it publishes immediately without waiting
- [ ] Bump cua-computer: verify computer publishes first, then agent
- [ ] Verify publish-agent doesn't run if publish-computer fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)