### PR TITLE
Allow for OpenAI Compatible Fallback Tool Output Parsing on Qwen

### DIFF
--- a/libs/python/agent/agent/loops/qwen.py
+++ b/libs/python/agent/agent/loops/qwen.py
@@ -20,6 +20,7 @@ from ..loops.base import AsyncAgentConfig
 from ..responses import (
     convert_completion_messages_to_responses_items,
     convert_responses_items_to_completion_messages,
+    make_reasoning_item,
 )
 from ..types import AgentCapability
 
@@ -373,13 +374,23 @@ class Qwen3VlConfig(AsyncAgentConfig):
         if _on_usage:
             await _on_usage(usage)
 
-        # Parse tool call from text; then convert to responses items via fake tool_calls
+        # Extract response data
         resp_dict = response.model_dump()  # type: ignore
         choice = (resp_dict.get("choices") or [{}])[0]
-        content_text = ((choice.get("message") or {}).get("content")) or ""
-        tool_call = _parse_tool_call_from_text(content_text)
+        message = choice.get("message") or {}
+        content_text = message.get("content") or ""
+        tool_calls_array = message.get("tool_calls") or []
+        reasoning_text = message.get("reasoning") or ""
 
         output_items: List[Dict[str, Any]] = []
+
+        # Add reasoning if present (Ollama Cloud format)
+        if reasoning_text:
+            output_items.append(make_reasoning_item(reasoning_text))
+
+        # Priority 1: Try to parse tool call from content text (OpenRouter format)
+        tool_call = _parse_tool_call_from_text(content_text)
+
         if tool_call and isinstance(tool_call, dict):
             fn_name = tool_call.get("name") or "computer"
             raw_args = tool_call.get("arguments") or {}
@@ -405,8 +416,50 @@ class Qwen3VlConfig(AsyncAgentConfig):
                 ],
             }
             output_items.extend(convert_completion_messages_to_responses_items([fake_cm]))
+        elif tool_calls_array:
+            # Priority 2: Use tool_calls field if present (Ollama Cloud format)
+            # Process and unnormalize coordinates in tool calls
+            processed_tool_calls = []
+            for tc in tool_calls_array:
+                function = tc.get("function", {})
+                fn_name = function.get("name", "computer")
+                args_str = function.get("arguments", "{}")
+
+                try:
+                    args = json.loads(args_str)
+
+                    # Unnormalize coordinates if present
+                    if "coordinate" in args and last_rw is not None and last_rh is not None:
+                        args = await _unnormalize_coordinate(args, (last_rw, last_rh))
+
+                    # Convert Qwen format to Computer Calls format if this is a computer tool
+                    if fn_name == "computer":
+                        converted_action = convert_qwen_tool_args_to_computer_action(args)
+                        if converted_action:
+                            args = converted_action
+
+                    processed_tool_calls.append(
+                        {
+                            "type": tc.get("type", "function"),
+                            "id": tc.get("id", "call_0"),
+                            "function": {
+                                "name": fn_name,
+                                "arguments": json.dumps(args),
+                            },
+                        }
+                    )
+                except json.JSONDecodeError:
+                    # Keep original if parsing fails
+                    processed_tool_calls.append(tc)
+
+            fake_cm = {
+                "role": "assistant",
+                "content": content_text if content_text else "",
+                "tool_calls": processed_tool_calls,
+            }
+            output_items.extend(convert_completion_messages_to_responses_items([fake_cm]))
         else:
-            # Fallback: just return assistant text
+            # No tool calls found in either format, return text response
             fake_cm = {"role": "assistant", "content": content_text}
             output_items.extend(convert_completion_messages_to_responses_items([fake_cm]))
 


### PR DESCRIPTION
tool calls dont show up on playground due to xml tool calls in the content. when routing through inference api, we need to transform to openai compatible format 

testing instructions (to pair with inference api)
- checkout my branch on cloud: feat/ollama-provider
- Get OLLAMA_API_KEY
- tunnel localhost:5001 (inference api port)

```
"""
Test script to run Qwen agent with LOCAL code changes.
This uses the local modules from libs/python/agent and libs/python/computer
"""

import asyncio
import os
import sys
from pathlib import Path

# Add local libs to Python path so we use LOCAL code, not installed packages
project_root = Path(__file__).parent
sys.path.insert(0, str(project_root / "libs" / "python" / "agent"))
sys.path.insert(0, str(project_root / "libs" / "python" / "computer"))
sys.path.insert(0, str(project_root / "libs" / "python" / "core"))

print("=" * 60)
print("IMPORTANT: Using LOCAL modules from:")
print(f"  - {project_root / 'libs' / 'python' / 'agent'}")
print(f"  - {project_root / 'libs' / 'python' / 'computer'}")
print("=" * 60)

from dotenv import load_dotenv
from agent import ComputerAgent
from computer import Computer

load_dotenv()

# Override CUA Inference API URL for local testing with ngrok
# Set this to your ngrok URL or local inference API
INFERENCE_API_URL = os.getenv("CUA_BASE_URL", "https://1ef9f1d253d7.ngrok-free.app/v1")
os.environ["CUA_BASE_URL"] = INFERENCE_API_URL


async def main():
    """Test the Qwen agent with local code changes"""

    # Verify environment variables
    container_name = os.getenv("CUA_CONTAINER_NAME")
    api_key = os.getenv("CUA_API_KEY")
    cua_inference_key = os.getenv("CUA_INFERENCE_API_KEY")

    if not container_name:
        print("ERROR: CUA_CONTAINER_NAME not set in .env file")
        return
    if not api_key:
        print("ERROR: CUA_API_KEY not set in .env file")
        return
    if not cua_inference_key:
        print("ERROR: CUA_INFERENCE_API_KEY not set in .env file")
        return

    print(f"\n✓ Container: {container_name}")
    print(f"✓ API Key: {api_key[:20]}...")
    print(f"✓ CUA Inference Key: {cua_inference_key[:20]}...")
    print(f"✓ Inference API URL: {INFERENCE_API_URL}\n")

    async with Computer(
        os_type="linux",
        provider_type="cloud",
        name=container_name,
        api_key=api_key,
    ) as computer:

        # Test with Qwen through CUA inference API (Ollama Cloud)
        agent = ComputerAgent(
            model="cua/qwen/qwen3-vl-235b",
            tools=[computer],
            only_n_most_recent_images=3,
            verbosity=20,  # INFO level
        )

        print("Agent created successfully!")
        print("\nSending message: 'Type ls in the terminal'\n")

        messages = [{"role": "user", "content": "Type ls in the terminal"}]

        try:
            async for result in agent.run(messages, tools=[computer], stream=False):
                print(f"\n{'='*60}")
                print(f"Received result with {len(result['output'])} items")
                print(f"{'='*60}")

                for item in result["output"]:
                    item_type = item.get("type")
                    print(f"\n[Item Type]: {item_type}")

                    if item_type == "message":
                        content = item.get("content", [])
                        for content_item in content:
                            if content_item.get("type") == "output_text":
                                print(f"[Assistant]: {content_item['text']}")

                    elif item_type == "reasoning":
                        summary = item.get("summary", [])
                        for summary_item in summary:
                            if summary_item.get("type") == "summary_text":
                                print(f"[Reasoning]: {summary_item['text'][:200]}...")

                    elif item_type == "computer_call":
                        action = item.get("action", {})
                        action_type = action.get("type")
                        print(f"[Computer Action]: {action_type}")

                        # Print action details based on type
                        if action_type in ["click", "double_click", "move"]:
                            print(f"  - Coordinates: ({action.get('x')}, {action.get('y')})")
                        elif action_type == "type":
                            text = action.get("text", "")
                            print(f"  - Text: {repr(text)}")
                        elif action_type == "keypress":
                            keys = action.get("keys", [])
                            print(f"  - Keys: {keys}")
                        elif action_type == "screenshot":
                            print(f"  - Taking screenshot")

                    elif item_type == "computer_call_output":
                        output = item.get("output", {})
                        if isinstance(output, dict) and output.get("type") == "input_image":
                            print(f"[Computer Output]: Screenshot captured")
                        else:
                            print(f"[Computer Output]: {str(output)[:100]}")

                    elif item_type == "function_call":
                        fn_name = item.get("name")
                        fn_args = item.get("arguments")
                        print(f"[Function Call]: {fn_name}")
                        print(f"  - Arguments: {fn_args[:100]}..." if len(fn_args) > 100 else f"  - Arguments: {fn_args}")

                print(f"\n{'='*60}\n")

        except Exception as e:
            print(f"\nERROR: {e}")
            import traceback
            traceback.print_exc()


if __name__ == "__main__":
    asyncio.run(main())
```

to test that we can still run with qwen on other providers: (openrouter)
- get an openrouter api key, add to env OPENROUTER_API_KEY=...
```
"""
Test script to verify Qwen agent works with OpenRouter (XML format).
This uses the local modules from libs/python/agent and libs/python/computer
"""

import asyncio
import os
import sys
from pathlib import Path

# Add local libs to Python path so we use LOCAL code, not installed packages
project_root = Path(__file__).parent
sys.path.insert(0, str(project_root / "libs" / "python" / "agent"))
sys.path.insert(0, str(project_root / "libs" / "python" / "computer"))
sys.path.insert(0, str(project_root / "libs" / "python" / "core"))

print("=" * 60)
print("IMPORTANT: Using LOCAL modules from:")
print(f"  - {project_root / 'libs' / 'python' / 'agent'}")
print(f"  - {project_root / 'libs' / 'python' / 'computer'}")
print("=" * 60)

from dotenv import load_dotenv
from agent import ComputerAgent
from computer import Computer

load_dotenv()


async def main():
    """Test the Qwen agent with OpenRouter (XML format)"""

    # Verify environment variables
    container_name = os.getenv("CUA_CONTAINER_NAME")
    api_key = os.getenv("CUA_API_KEY")
    openrouter_key = os.getenv("OPENROUTER_API_KEY")

    if not container_name:
        print("ERROR: CUA_CONTAINER_NAME not set in .env file")
        return
    if not api_key:
        print("ERROR: CUA_API_KEY not set in .env file")
        return
    if not openrouter_key:
        print("ERROR: OPENROUTER_API_KEY not set in .env file")
        print("       Get one from: https://openrouter.ai/keys")
        return

    print(f"\n✓ Container: {container_name}")
    print(f"✓ API Key: {api_key[:20]}...")
    print(f"✓ OpenRouter Key: {openrouter_key[:20]}...\n")

    async with Computer(
        os_type="linux",
        provider_type="cloud",
        name=container_name,
        api_key=api_key,
    ) as computer:

        # Test with Qwen through OpenRouter (returns XML format)
        agent = ComputerAgent(
            model="openrouter/qwen/qwen-2.5-vl-72b-instruct",
            tools=[computer],
            only_n_most_recent_images=3,
            verbosity=20,  # INFO level
        )

        print("Agent created successfully!")
        print("Testing OpenRouter path (XML <tool_call> format)")
        print("\nSending message: 'Type ls in the terminal'\n")

        messages = [{"role": "user", "content": "Type ls in the terminal"}]

        try:
            async for result in agent.run(messages, tools=[computer], stream=False):
                print(f"\n{'='*60}")
                print(f"Received result with {len(result['output'])} items")
                print(f"{'='*60}")

                for item in result["output"]:
                    item_type = item.get("type")
                    print(f"\n[Item Type]: {item_type}")

                    if item_type == "message":
                        content = item.get("content", [])
                        for content_item in content:
                            if content_item.get("type") == "output_text":
                                print(f"[Assistant]: {content_item['text']}")

                    elif item_type == "reasoning":
                        summary = item.get("summary", [])
                        for summary_item in summary:
                            if summary_item.get("type") == "summary_text":
                                print(f"[Reasoning]: {summary_item['text'][:200]}...")

                    elif item_type == "computer_call":
                        action = item.get("action", {})
                        action_type = action.get("type")
                        print(f"[Computer Action]: {action_type} ✅")

                        # Print action details based on type
                        if action_type in ["click", "double_click", "move"]:
                            print(f"  - Coordinates: ({action.get('x')}, {action.get('y')})")
                        elif action_type == "type":
                            text = action.get("text", "")
                            print(f"  - Text: {repr(text)}")
                        elif action_type == "keypress":
                            keys = action.get("keys", [])
                            print(f"  - Keys: {keys}")
                        elif action_type == "screenshot":
                            print(f"  - Taking screenshot")

                    elif item_type == "computer_call_output":
                        output = item.get("output", {})
                        if isinstance(output, dict) and output.get("type") == "input_image":
                            print(f"[Computer Output]: Screenshot captured")
                        else:
                            print(f"[Computer Output]: {str(output)[:100]}")

                print(f"\n{'='*60}\n")
                print("✅ OpenRouter path (XML format) is working correctly!")

        except Exception as e:
            print(f"\n❌ ERROR: {e}")
            import traceback
            traceback.print_exc()


if __name__ == "__main__":
    asyncio.run(main())
```