### PR TITLE
Refactor Docker publish workflow to correctly build and publish multi-arch images

### DIFF
--- a/.github/workflows/docker-reusable-publish.yml
+++ b/.github/workflows/docker-reusable-publish.yml
@@ -161,20 +161,33 @@ jobs:
           username: ${{ inputs.docker_hub_org }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: Extract final metadata
-        id: metadata
+      - name: Extract final metadata (PR)
+        if: github.event_name == 'pull_request'
         uses: docker/metadata-action@v5
         with:
           images: ${{ inputs.docker_hub_org }}/${{ inputs.image_name }}
           tags: |
-            type=ref,event=branch
             type=ref,event=pr
             type=sha
+
+      - name: Extract final metadata (main)
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ inputs.docker_hub_org }}/${{ inputs.image_name }}
+          tags: |
+            type=raw,value=latest
+
+      - name: Extract final metadata (semver)
+        if: startsWith(github.ref, format('refs/tags/{0}', inputs.tag_prefix))
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ inputs.docker_hub_org }}/${{ inputs.image_name }}
+          tags: |
             type=semver,pattern={{version}},prefix=${{ inputs.tag_prefix }}
             type=semver,pattern={{major}}.{{minor}},prefix=${{ inputs.tag_prefix }}
             type=semver,pattern={{major}},prefix=${{ inputs.tag_prefix }}
-          flavor: |
-            latest=true
+            type=raw,value=latest
 
       - name: Download all digest artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
This PR updates the reusable Docker publish workflow so that multi-architecture images are generated correctly. Previously, each matrix job pushed directly to the same tag, causing the last completed build to overwrite the manifest and resulting in tags containing only one architecture.

This refactor introduces the recommended Buildx pattern:
- Each platform build now pushes by digest rather than by tag.
- Each digest is uploaded as a separate artifact, one per platform.
- A final job assembles the multi-arch manifest using `docker buildx imagetools create`.

The workflow continues to support PR builds, main branch builds, and semantic version tags, but now publishes them as proper multi-arch images.

Addresses: #488