### PR TITLE
docs: improve Post-Event Contact Export cookbook setup instructions

### DIFF
--- a/docs/content/docs/example-usecases/post-event-contact-export.mdx
+++ b/docs/content/docs/example-usecases/post-event-contact-export.mdx
@@ -75,11 +75,12 @@ pip install -r requirements.txt
 Create a `.env` file with your API keys:
 
 ```text
-ANTHROPIC_API_KEY=your-anthropic-api-key
+ANTHROPIC_API_KEY=your-anthropic-api-key # optional, BYOK. By default, this cookbook uses the CUA VLM Router
 CUA_API_KEY=sk_cua-api01...
 CUA_CONTAINER_NAME=m-linux-...
 ```
 
+Finally, setup your VM. Refer to the [quickstart guide](https://cua.ai/docs/get-started/quickstart) on how to setup the computer environment. 
 </Step>
 
 <Step>


### PR DESCRIPTION
     Improves clarity on setup instructions:
     - Add clarification that ANTHROPIC_API_KEY is optional (BYOK)
     - Note that cookbook uses CUA VLM Router by default
     - Improve quickstart guide link text for clarity