### PR TITLE
[CI] fix npm publish workflow permissions error

### DIFF
--- a/.github/workflows/npm-publish-cli.yml
+++ b/.github/workflows/npm-publish-cli.yml
@@ -15,13 +15,13 @@ on:
         type: string
         default: ""
 
+permissions:
+  id-token: write
+  contents: write
+  packages: write
+
 jobs:
   build-binaries:
-    permissions:
-      id-token: write
-      contents: write
-      packages: write
-
     strategy:
       matrix:
         include:
@@ -83,8 +83,6 @@ jobs:
   create-release:
     needs: [build-binaries, publish-npm]
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/npm-publish-computer.yml
+++ b/.github/workflows/npm-publish-computer.yml
@@ -17,6 +17,10 @@ on:
         type: string
         default: ""
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   publish:
     uses: ./.github/workflows/npm-reusable-publish.yml

--- a/.github/workflows/npm-publish-core.yml
+++ b/.github/workflows/npm-publish-core.yml
@@ -17,6 +17,10 @@ on:
         type: string
         default: ""
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   publish:
     uses: ./.github/workflows/npm-reusable-publish.yml


### PR DESCRIPTION
Fixes `id-token: write` permissions error in NPM publish workflows that occurred when triggered by push to main.

## Problem
```
Error calling workflow 'npm-reusable-publish.yml'. The nested job 'publish' is requesting 'id-token: write', but is only allowed 'id-token: none'.
```

## Solution
Moved permissions to workflow-level (matching PyPI pattern):
- npm-publish-cli.yml
- npm-publish-computer.yml
- npm-publish-core.yml

This allows the reusable workflow to inherit the required permissions.