### PR TITLE
fix: propagate INSTALL_WINARENA_APPS to Windows guest

### DIFF
--- a/libs/qemu-docker/windows/src/entry.sh
+++ b/libs/qemu-docker/windows/src/entry.sh
@@ -18,6 +18,16 @@ if [ -d "/storage" -a ! -f "/storage/windows.boot" ]; then
   touch /storage/windows.boot
 fi
 
+# Generate install_config.json from Docker environment variable
+# This allows the INSTALL_WINARENA_APPS env var to be passed to the Windows guest
+if [ "$INSTALL_WINARENA_APPS" = "true" ]; then
+  echo "Creating install_config.json with INSTALL_WINARENA_APPS=true..."
+  echo '{"INSTALL_WINARENA_APPS": true}' > /oem/install_config.json
+else
+  echo "Creating install_config.json with INSTALL_WINARENA_APPS=false..."
+  echo '{"INSTALL_WINARENA_APPS": false}' > /oem/install_config.json
+fi
+
 # Start the VM in the background
 echo "Starting Windows VM..."
 /usr/bin/tini -s /run/entry.sh &


### PR DESCRIPTION
## Summary
Generate `install_config.json` in the Docker entrypoint before booting the Windows VM. This allows the `INSTALL_WINARENA_APPS` environment variable to be passed through to the Windows setup script, fixing #700 where benchmark apps would not install even when the flag was set.

## Changes
- Modified `libs/qemu-docker/windows/src/entry.sh` to create `install_config.json` from the Docker environment variable before the VM boots
- The Windows setup script already had fallback logic to read this config file

## How to test
Build with `INSTALL_WINARENA_APPS=true` and verify that benchmark apps install correctly.