### PR TITLE
docs: restructure documentation with Fumadocs

### DIFF
--- a/docs/content/docs/cua/examples/meta.json
+++ b/docs/content/docs/cua/examples/meta.json
@@ -2,5 +2,5 @@
   "title": "Examples",
   "description": "Real-world examples of building with Cua",
   "icon": "Blocks",
-  "pages": ["index", "automation", "platform-specific", "ai-models"]
+  "pages": ["..."]
 }


### PR DESCRIPTION
## Summary

- Fix duplicate "Examples" entry in sidebar navigation

## Test plan

- [ ] Verify Examples section in sidebar shows only subcategories (Automation, Platform-Specific, AI Models)