### PR TITLE
Raise clear error when using Ollama models with ComputerAgent image inputs

### DIFF
--- a/libs/python/agent/agent/agent.py
+++ b/libs/python/agent/agent/agent.py
@@ -728,7 +728,7 @@ class ComputerAgent:
 
                     return False
 
-                if contains_image_content(messages):
+                if contains_image_content(preprocessed_messages):
                     raise ValueError(
                         "Ollama models do not support image inputs required by ComputerAgent. "
                         "Please use a vision-capable model (e.g., OpenAI or Anthropic) "


### PR DESCRIPTION
## Problem
Ollama models currently do not support image inputs required by ComputerAgent (e.g., screenshot or computer/screenshot actions). 
If a user attempts to run an Ollama model with image content, it could lead to confusing runtime errors or silent failures.

## Solution
This PR adds an explicit guard that:

- Detects if the agent model starts with "ollama".
- Checks all messages for image inputs (type "image_url").
- Raises a clear ValueError with guidance to use a vision-capable model like OpenAI or Anthropic.

## Benefits
- Provides immediate, readable feedback to users attempting unsupported image inputs.
- Prevents subtle bugs during agent execution.
- Explicit, safe, and easy to review.

No other functional changes are made outside this guard.

fixes #602 