### PR TITLE
Add overlay support to QEMU containers

### DIFF
--- a/libs/qemu-docker/windows/src/entry.sh
+++ b/libs/qemu-docker/windows/src/entry.sh
@@ -12,6 +12,21 @@ cleanup() {
 # Install trap for signals
 trap cleanup SIGTERM SIGINT SIGHUP SIGQUIT
 
+# Detect overlay mode: /golden exists (read-only base) but /storage is empty
+# This enables running multiple isolated sessions from a single golden image
+if [ -d "/golden" ] && [ ! -f "/storage/windows.boot" ]; then
+    echo "Overlay mode detected, setting up copy-on-write..."
+    # Try hard links first (instant, shares disk blocks until modified)
+    # Fall back to regular copy if hard links fail (e.g., cross-filesystem)
+    if cp -al /golden/. /storage/ 2>/dev/null; then
+        echo "Overlay setup complete (using hard links)."
+    else
+        echo "Hard links not supported, falling back to regular copy..."
+        cp -a /golden/. /storage/
+        echo "Overlay setup complete (using copy)."
+    fi
+fi
+
 # Create windows.boot file if it doesn't exist (required for proper boot)
 if [ -d "/storage" -a ! -f "/storage/windows.boot" ]; then
   echo "Creating windows.boot file in /storage..."


### PR DESCRIPTION
## Summary

- Add overlay mode detection to Windows and Linux QEMU container entrypoints
- When `/golden` is mounted read-only and `/storage` is empty, automatically set up copy-on-write using hard links
- Falls back to regular copy if hard links aren't supported (cross-filesystem mounts)

## Use Cases

- **Parallel testing** - Run multiple Windows/Linux agents simultaneously without multiplying disk usage
- **Clean state** - Each test starts from pristine golden image
- **Fast cloning** - `cb image clone` becomes instant (just creates empty overlay dir)
- **Rollback** - Delete overlay, re-run = back to clean state

## Test plan

- [ ] Rebuild Windows container: `docker build -t trycua/cua-qemu-windows:latest libs/qemu-docker/windows`
- [ ] Run `cb image shell windows-qemu` and verify "Overlay mode detected" message appears
- [ ] Confirm VM boots successfully
- [ ] Make changes in VM, exit, re-run - changes should be gone

Closes #699