### PR TITLE
feat(ci): add GitHub Actions workflow for Modal docs MCP server deplo…

### DIFF
--- a/.github/workflows/modal-deploy-docs.yml
+++ b/.github/workflows/modal-deploy-docs.yml
@@ -15,6 +15,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: modal-deploy-docs-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to automatically deploy the CUA documentation MCP server to Modal
- Workflow triggers on push to `main` when `docs/scripts/modal_app.py` or the workflow file changes
- Supports manual deployment via `workflow_dispatch` with optional initial crawl

## Setting Up Modal Authentication

To enable automated deployments, configure Modal authentication in your GitHub repository secrets:

### Step 1: Create Modal API Tokens

1. Log in to [Modal](https://modal.com/)
2. Go to **Settings** → **API Tokens** (or visit https://modal.com/settings/tokens)
3. Click **Create new token**
4. Give it a descriptive name (e.g., `github-actions-deploy`)
5. Copy the **Token ID** and **Token Secret** - you will only see these once!

### Step 2: Add GitHub Repository Secrets

1. Go to your repository on GitHub
2. Navigate to **Settings** → **Secrets and variables** → **Actions**
3. Click **New repository secret** and add:
   - Name: `MODAL_TOKEN_ID`
   - Value: Your Modal Token ID

4. Click **New repository secret** again and add:
   - Name: `MODAL_TOKEN_SECRET`
   - Value: Your Modal Token Secret

### Step 3: Test the Deployment

1. Go to the **Actions** tab in your repository
2. Select the **Deploy Modal Docs MCP Server** workflow
3. Click **Run workflow**
4. Optionally check "Run initial crawl and database generation before deploy" for first-time setup
5. Click the green **Run workflow** button

### Workflow Features

| Feature | Description |
|---------|-------------|
| **Auto-deploy** | Deploys on push to `main` when modal_app.py changes |
| **Manual trigger** | Run anytime via workflow_dispatch |
| **Initial crawl** | Optional flag to run full crawl + DB generation |
| **Daily crawl** | Modal schedules automatic crawl at 6 AM UTC |

### After Deployment

The MCP server will be available at:
