### PR TITLE
refactor(workflows): remove push triggers from CI workflows, rename CD action

### DIFF
--- a/.github/workflows/ci-lint-python.yml
+++ b/.github/workflows/ci-lint-python.yml
@@ -6,13 +6,6 @@ on:
       - "libs/python/**"
       - "pyproject.toml"
       - ".github/workflows/ci-lint-python.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "libs/python/**"
-      - "pyproject.toml"
-      - ".github/workflows/ci-lint-python.yml"
 
 jobs:
   lint:

--- a/.github/workflows/ci-lint-typescript.yml
+++ b/.github/workflows/ci-lint-typescript.yml
@@ -5,12 +5,6 @@ on:
     paths:
       - "libs/typescript/**"
       - ".github/workflows/ci-lint-typescript.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "libs/typescript/**"
-      - ".github/workflows/ci-lint-typescript.yml"
 
 jobs:
   lint:

--- a/.github/workflows/ci-py-agent.yml
+++ b/.github/workflows/ci-py-agent.yml
@@ -6,13 +6,6 @@ on:
       - "libs/python/agent/**"
       - ".github/workflows/ci-py-agent.yml"
       - ".github/workflows/py-reusable-build.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "libs/python/agent/**"
-      - ".github/workflows/ci-py-agent.yml"
-      - ".github/workflows/py-reusable-build.yml"
 
 jobs:
   build:

--- a/.github/workflows/ci-py-bench-ui.yml
+++ b/.github/workflows/ci-py-bench-ui.yml
@@ -6,13 +6,6 @@ on:
       - "libs/python/bench-ui/**"
       - ".github/workflows/ci-py-bench-ui.yml"
       - ".github/workflows/py-reusable-build.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "libs/python/bench-ui/**"
-      - ".github/workflows/ci-py-bench-ui.yml"
-      - ".github/workflows/py-reusable-build.yml"
 
 jobs:
   build:

--- a/.github/workflows/ci-py-bench.yml
+++ b/.github/workflows/ci-py-bench.yml
@@ -6,13 +6,6 @@ on:
       - "libs/cua-bench/**"
       - ".github/workflows/ci-py-bench.yml"
       - ".github/workflows/py-reusable-build.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "libs/cua-bench/**"
-      - ".github/workflows/ci-py-bench.yml"
-      - ".github/workflows/py-reusable-build.yml"
 
 jobs:
   build:

--- a/.github/workflows/ci-py-computer-server.yml
+++ b/.github/workflows/ci-py-computer-server.yml
@@ -6,13 +6,6 @@ on:
       - "libs/python/computer-server/**"
       - ".github/workflows/ci-py-computer-server.yml"
       - ".github/workflows/py-reusable-build.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "libs/python/computer-server/**"
-      - ".github/workflows/ci-py-computer-server.yml"
-      - ".github/workflows/py-reusable-build.yml"
 
 jobs:
   build:

--- a/.github/workflows/ci-py-computer.yml
+++ b/.github/workflows/ci-py-computer.yml
@@ -6,13 +6,6 @@ on:
       - "libs/python/computer/**"
       - ".github/workflows/ci-py-computer.yml"
       - ".github/workflows/py-reusable-build.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "libs/python/computer/**"
-      - ".github/workflows/ci-py-computer.yml"
-      - ".github/workflows/py-reusable-build.yml"
 
 jobs:
   build:

--- a/.github/workflows/ci-py-core.yml
+++ b/.github/workflows/ci-py-core.yml
@@ -6,13 +6,6 @@ on:
       - "libs/python/core/**"
       - ".github/workflows/ci-py-core.yml"
       - ".github/workflows/py-reusable-build.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "libs/python/core/**"
-      - ".github/workflows/ci-py-core.yml"
-      - ".github/workflows/py-reusable-build.yml"
 
 jobs:
   build:

--- a/.github/workflows/ci-py-mcp-server.yml
+++ b/.github/workflows/ci-py-mcp-server.yml
@@ -6,13 +6,6 @@ on:
       - "libs/python/mcp-server/**"
       - ".github/workflows/ci-py-mcp-server.yml"
       - ".github/workflows/py-reusable-build.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "libs/python/mcp-server/**"
-      - ".github/workflows/ci-py-mcp-server.yml"
-      - ".github/workflows/py-reusable-build.yml"
 
 jobs:
   build:

--- a/.github/workflows/ci-py-som.yml
+++ b/.github/workflows/ci-py-som.yml
@@ -6,13 +6,6 @@ on:
       - "libs/python/som/**"
       - ".github/workflows/ci-py-som.yml"
       - ".github/workflows/py-reusable-build.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "libs/python/som/**"
-      - ".github/workflows/ci-py-som.yml"
-      - ".github/workflows/py-reusable-build.yml"
 
 jobs:
   build:

--- a/.github/workflows/ci-swift-lume.yml
+++ b/.github/workflows/ci-swift-lume.yml
@@ -1,11 +1,5 @@
 name: "CI: Lume"
 on:
-  push:
-    branches:
-      - "main"
-    paths:
-      - "libs/lume/**"
-      - ".github/workflows/ci-swift-lume.yml"
   pull_request:
     paths:
       - "libs/lume/**"

--- a/.github/workflows/ci-test-models.yml
+++ b/.github/workflows/ci-test-models.yml
@@ -15,12 +15,6 @@ on:
     paths:
       - "libs/python/**"
       - ".github/workflows/ci-test-models.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "libs/python/**"
-      - ".github/workflows/ci-test-models.yml"
 
 jobs:
   # Test all Cua models - runs on PRs, pushes to main, or when manually triggered

--- a/.github/workflows/ci-test-python.yml
+++ b/.github/workflows/ci-test-python.yml
@@ -5,12 +5,6 @@ on:
     paths:
       - "libs/python/**"
       - ".github/workflows/ci-test-python.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "libs/python/**"
-      - ".github/workflows/ci-test-python.yml"
   workflow_dispatch: # Allow manual trigger
 
 jobs:

--- a/.github/workflows/ci-test-scripts.yml
+++ b/.github/workflows/ci-test-scripts.yml
@@ -5,12 +5,6 @@ on:
     paths:
       - ".github/scripts/**"
       - ".github/workflows/ci-test-scripts.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - ".github/scripts/**"
-      - ".github/workflows/ci-test-scripts.yml"
 
 jobs:
   test:

--- a/.github/workflows/ci-ts-cli.yml
+++ b/.github/workflows/ci-ts-cli.yml
@@ -6,13 +6,6 @@ on:
       - "libs/typescript/cua-cli/**"
       - ".github/workflows/ci-ts-cli.yml"
       - ".github/workflows/ts-reusable-build.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "libs/typescript/cua-cli/**"
-      - ".github/workflows/ci-ts-cli.yml"
-      - ".github/workflows/ts-reusable-build.yml"
 
 jobs:
   build:

--- a/.github/workflows/ci-ts-computer.yml
+++ b/.github/workflows/ci-ts-computer.yml
@@ -6,13 +6,6 @@ on:
       - "libs/typescript/computer/**"
       - ".github/workflows/ci-ts-computer.yml"
       - ".github/workflows/ts-reusable-build.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "libs/typescript/computer/**"
-      - ".github/workflows/ci-ts-computer.yml"
-      - ".github/workflows/ts-reusable-build.yml"
 
 jobs:
   build:

--- a/.github/workflows/ci-ts-core.yml
+++ b/.github/workflows/ci-ts-core.yml
@@ -6,13 +6,6 @@ on:
       - "libs/typescript/core/**"
       - ".github/workflows/ci-ts-core.yml"
       - ".github/workflows/ts-reusable-build.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "libs/typescript/core/**"
-      - ".github/workflows/ci-ts-core.yml"
-      - ".github/workflows/ts-reusable-build.yml"
 
 jobs:
   build:

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -1,4 +1,4 @@
-name: Bump Version & Publish
+name: "CD: Bump & Publish"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Remove push to main triggers from all CI workflows (only run on PRs)
- Rename "Bump Version & Publish" workflow to "CD: Bump & Publish" for consistency
- Keep push trigger for ci-check-links (needed to catch external link changes)

## Rationale

CI workflows should only trigger on pull requests related to specific modules, not when code is merged to main. This prevents redundant builds and matches the pattern used by other packages.