### PR TITLE
fix(workflows): use PR workflow for version bumps

### DIFF
--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -291,9 +291,29 @@ jobs:
           echo "lume version: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Push changes
+      - name: Create release branch and PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git push origin main --follow-tags
+          # Get the tag that was created by bump2version
+          TAG=$(git describe --tags --abbrev=0)
+          BRANCH_NAME="release/${TAG}"
+
+          # Create and push the release branch
+          git checkout -b "$BRANCH_NAME"
+          git push origin "$BRANCH_NAME" --follow-tags
+
+          # Create PR and enable auto-merge
+          PR_URL=$(gh pr create \
+            --title "chore: bump version to ${TAG}" \
+            --body "Automated version bump to ${TAG}" \
+            --base main \
+            --head "$BRANCH_NAME")
+
+          echo "Created PR: $PR_URL"
+
+          # Enable auto-merge (will merge once requirements are met)
+          gh pr merge "$PR_URL" --auto --squash
 
   publish-computer:
     needs: [bump-version, publish-core]


### PR DESCRIPTION
## Summary
- Fixes the CD workflow failure caused by branch protection rules requiring all changes to go through pull requests
- Changes the version bump workflow to create a release branch and PR instead of pushing directly to main
- Enables auto-merge so PRs will merge once approved by a maintainer

## Test plan
- [ ] Trigger a version bump via workflow_dispatch and verify it creates a PR instead of failing