### PR TITLE
fix(workflows): prevent ghost runs and handle existing tags

### DIFF
--- a/.github/workflows/docker-reusable-build.yml
+++ b/.github/workflows/docker-reusable-build.yml
@@ -1,6 +1,7 @@
 name: Reusable Docker Build Workflow
 
 on:
+  workflow_dispatch:  # Prevents phantom runs on push, allows manual testing
   workflow_call:
     inputs:
       image_name:

--- a/.github/workflows/docker-reusable-publish.yml
+++ b/.github/workflows/docker-reusable-publish.yml
@@ -1,6 +1,7 @@
 name: Reusable Docker Publish Workflow
 
 on:
+  workflow_dispatch:  # Prevents phantom runs on push, allows manual testing
   workflow_call:
     inputs:
       image_name:

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -158,6 +158,21 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Clean existing tag if present
+        run: |
+          cd ${{ steps.package.outputs.directory }}
+          # Get the new version that bump2version would create
+          NEW_VERSION=$(bump2version --dry-run --list ${{ inputs.bump_type }} 2>&1 | grep new_version | sed 's/new_version=//')
+          # Get tag name pattern from .bumpversion.cfg
+          TAG_NAME=$(grep 'tag_name' .bumpversion.cfg | sed 's/tag_name = //' | sed "s/{new_version}/$NEW_VERSION/")
+
+          echo "Checking for existing tag: $TAG_NAME"
+
+          # Delete local tag if exists
+          git tag -d "$TAG_NAME" 2>/dev/null || true
+          # Delete remote tag if exists
+          git push origin ":refs/tags/$TAG_NAME" 2>/dev/null || true
+
       - name: Run bump2version
         run: |
           cd ${{ steps.package.outputs.directory }}


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to reusable docker workflows to prevent phantom run entries on push events
- Add tag cleanup step to CD workflow to handle re-runs when tag already exists from a previous failed attempt

## Problem
1. **Ghost workflow runs**: `docker-reusable-build.yml` and `docker-reusable-publish.yml` were showing as failed runs on every push to main, even though they only have `workflow_call:` triggers. This is a GitHub Actions quirk where it creates phantom entries for workflow files.

2. **Tag already exists**: The CD: Bump & Publish workflow fails with `fatal: tag 'lume-v0.2.24' already exists` when re-running after a partial failure, because bump2version tries to create a tag that already exists.

## Solution
1. Added `workflow_dispatch:` trigger to both reusable workflows - this makes GitHub treat them as "real" workflows and prevents phantom entries.

2. Added a "Clean existing tag if present" step that deletes any existing local/remote tags before bump2version runs.

## Test plan
- [ ] Push a commit to main and verify no ghost workflow runs appear for the reusable docker workflows
- [ ] Run the CD: Bump & Publish workflow twice to verify the tag cleanup handles re-runs gracefully