### PR TITLE
fix(workflows): handle multi-line output in bump2version tag cleanup

### DIFF
--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -161,10 +161,10 @@ jobs:
       - name: Clean existing tag if present
         run: |
           cd ${{ steps.package.outputs.directory }}
-          # Get the new version that bump2version would create
-          NEW_VERSION=$(bump2version --dry-run --list ${{ inputs.bump_type }} 2>&1 | grep new_version | sed 's/new_version=//')
+          # Get the new version that bump2version would create (capture only first match, ignore stderr)
+          NEW_VERSION=$(bump2version --dry-run --list ${{ inputs.bump_type }} 2>/dev/null | grep -m1 '^new_version=' | sed 's/new_version=//')
           # Get tag name pattern from .bumpversion.cfg
-          TAG_NAME=$(grep 'tag_name' .bumpversion.cfg | sed 's/tag_name = //' | sed "s/{new_version}/$NEW_VERSION/")
+          TAG_NAME=$(grep -m1 '^tag_name' .bumpversion.cfg | sed 's/tag_name *= *//' | sed "s|{new_version}|$NEW_VERSION|")
 
           echo "Checking for existing tag: $TAG_NAME"
 


### PR DESCRIPTION
## Summary
- Fixes failing CD: Bump & Publish workflow where the "Clean existing tag if present" step was failing with `sed: unterminated 's' command`
- Root cause: `bump2version --dry-run --list 2>&1` captured stderr along with stdout, causing multi-line matches that broke the sed replacement

## Changes
- Use `2>/dev/null` instead of `2>&1` to discard stderr warnings
- Use `grep -m1` with anchored patterns (`^new_version=`, `^tag_name`) for single-match extraction
- Use `|` delimiter in sed for safer special character handling
- Handle variable whitespace in tag_name parsing with `tag_name *= */`

## Test plan
- [x] Verify the fix by reviewing the workflow syntax
- [ ] Re-run the failing CD: Bump & Publish workflow for lume

Fixes: https://github.com/trycua/cua/actions/runs/20899143714/job/60042332042