### PR TITLE
fix(workflows): add pull-requests write permission for PR creation

### DIFF
--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -39,6 +39,7 @@ permissions:
   contents: write
   id-token: write
   packages: write
+  pull-requests: write
 
 jobs:
   bump-version:


### PR DESCRIPTION
## Summary
- Adds `pull-requests: write` permission to the CD: Bump & Publish workflow

## Problem
The workflow was failing with:
```
pull request create failed: GraphQL: Resource not accessible by integration (createPullRequest)
```

Ref: https://github.com/trycua/cua/actions/runs/20899191103/job/60042445280

## Root Cause
The `GITHUB_TOKEN` didn't have `pull-requests: write` permission, which is required by:
- `gh pr create`
- `gh pr merge --auto`

## Test plan
- [ ] Re-run the "CD: Bump & Publish" workflow to verify PR creation works