### PR TITLE
fix(workflows): fix CD PR creation and add retry resilience

### DIFF
--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -315,6 +315,16 @@ jobs:
           TAG=$(git describe --tags --abbrev=0)
           BRANCH_NAME="release/${TAG}"
 
+          # Clean up any existing release branch from previous failed runs
+          git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
+
+          # Close any existing PR for this branch
+          EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$EXISTING_PR" ]; then
+            echo "Closing existing PR #$EXISTING_PR"
+            gh pr close "$EXISTING_PR" --delete-branch 2>/dev/null || true
+          fi
+
           # Create and push the release branch
           git checkout -b "$BRANCH_NAME"
           git push origin "$BRANCH_NAME" --follow-tags


### PR DESCRIPTION
## Summary
- Use `PR_TOKEN` secret instead of `GITHUB_TOKEN` for PR creation (org settings block `GITHUB_TOKEN` from creating PRs)
- Add `pull-requests: write` permission to workflow
- Clean up existing release branches/PRs before creating new ones (handles re-runs after failures)

## Problem
The CD: Bump & Publish workflow was failing with:
```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```

And on re-runs:
```
error: failed to push some refs... Updates were rejected because the tip of your current branch is behind
```

## Solution
1. Use a PAT (`PR_TOKEN`) instead of `GITHUB_TOKEN` since the org has disabled "Allow GitHub Actions to create and approve pull requests"
2. Add cleanup logic to delete any existing release branch and close existing PRs before creating new ones

## Test plan
- [ ] Add `PR_TOKEN` secret to repository (PAT with `repo` scope or fine-grained with PR + Contents permissions)
- [ ] Re-run the CD: Bump & Publish workflow