### PR TITLE
fix(workflows): make auto-merge step non-fatal

### DIFF
--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -339,7 +339,8 @@ jobs:
           echo "Created PR: $PR_URL"
 
           # Enable auto-merge (will merge once requirements are met)
-          gh pr merge "$PR_URL" --auto --squash
+          # This may fail if auto-merge is not enabled for the repository
+          gh pr merge "$PR_URL" --auto --squash || echo "Auto-merge not available, PR will need manual merge"
 
   publish-computer:
     needs: [bump-version, publish-core]


### PR DESCRIPTION
## Summary
- Make the auto-merge step gracefully fail instead of breaking the workflow

## Problem
The CD: Bump & Publish workflow fails with:
```
GraphQL: Pull request Auto merge is not allowed for this repository (enablePullRequestAutoMerge)
```

This happens because auto-merge is not enabled in the repository settings.

## Solution
Add `|| echo "..."` to make the auto-merge step non-fatal. The PR is still created successfully; it just needs manual merge if auto-merge isn't available.

## Test plan
- [ ] Re-run the CD: Bump & Publish workflow - should succeed even without auto-merge enabled