### PR TITLE
fix(workflows): explicitly specify owner and repo for App token

### DIFF
--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -312,6 +312,8 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Push release to main
         env:
@@ -319,6 +321,10 @@ jobs:
         run: |
           # Configure git to use the app token for pushing
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+
+          # Verify the token works
+          echo "Verifying GitHub App token..."
+          gh auth status
 
           TAG=$(git describe --tags --abbrev=0)
           echo "Pushing version bump to main with tag: $TAG"


### PR DESCRIPTION
## Summary
Fix GitHub App token generation by explicitly specifying owner and repository.

## Changes
- Add `owner` and `repositories` parameters to `actions/create-github-app-token`
- Add token verification step to help debug issues

## Problem
The App token might not have been scoped correctly to the repository, causing the bypass to not work.

## Also Check
If this still fails, verify:
1. The GitHub App installation has **Contents: Read and write** permission (not just Read)
2. The App is installed on the `cua` repository specifically