### PR TITLE
fix(workflows): use GitHub API to update refs instead of git push

### DIFF
--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -319,16 +319,28 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          # Configure git to use the app token for pushing
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-
           # Verify the token works
           echo "Verifying GitHub App token..."
           gh auth status
 
+          # Get current commit SHA and tag
+          COMMIT_SHA=$(git rev-parse HEAD)
           TAG=$(git describe --tags --abbrev=0)
-          echo "Pushing version bump to main with tag: $TAG"
-          git push origin HEAD:main --follow-tags
+
+          echo "Commit SHA: $COMMIT_SHA"
+          echo "Tag: $TAG"
+
+          # Create tag using API
+          echo "Creating tag via API..."
+          gh api /repos/${{ github.repository }}/git/refs \
+            -f ref="refs/tags/${TAG}" \
+            -f sha="${COMMIT_SHA}" || echo "Tag may already exist"
+
+          # Update main branch ref using API (bypasses branch protection)
+          echo "Updating main branch via API..."
+          gh api -X PATCH /repos/${{ github.repository }}/git/refs/heads/main \
+            -f sha="${COMMIT_SHA}" \
+            -F force=false
 
   publish-computer:
     needs: [bump-version, publish-core]


### PR DESCRIPTION
## Summary
Use GitHub API to update the main branch ref instead of git push.

## Problem
Git push doesn't respect ruleset bypass for GitHub Apps, even though the App is correctly configured as a bypass actor.

## Solution
Use `gh api -X PATCH /repos/.../git/refs/heads/main` to update the branch ref via API. The API should respect bypass rules for the authenticated App.

## Changes
- Replace `git push origin HEAD:main --follow-tags` with API calls
- Create tag via API: `gh api /repos/.../git/refs`
- Update main ref via API: `gh api -X PATCH /repos/.../git/refs/heads/main`