### PR TITLE
fix(ci): check inputs.version first for workflow_call

### DIFF
--- a/.github/workflows/cd-py-computer-server.yml
+++ b/.github/workflows/cd-py-computer-server.yml
@@ -36,7 +36,10 @@ jobs:
       - name: Determine version
         id: get-version
         run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
+          # Check inputs.version first (set by workflow_call)
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION=${{ inputs.version }}
+          elif [ "${{ github.event_name }}" == "push" ]; then
             # Extract version from tag (for package-specific tags)
             if [[ "${{ github.ref }}" =~ ^refs/tags/computer-server-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
               VERSION=${BASH_REMATCH[1]}
@@ -48,8 +51,8 @@ jobs:
             # Use version from workflow dispatch
             VERSION=${{ github.event.inputs.version }}
           else
-            # Use version from workflow_call
-            VERSION=${{ inputs.version }}
+            echo "No version provided"
+            exit 1
           fi
           echo "VERSION=$VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Fixes the "Verify version consistency" step failing with empty version when `cd-py-computer-server.yml` is called via `workflow_call`.

## Problem

When called via `workflow_call` from a parent triggered by `workflow_dispatch`:
- `github.event_name` is `workflow_dispatch` (inherited from parent)
- The script checked `github.event.inputs.version` which is empty (that input doesn't exist on the child workflow)
- The correct value `inputs.version` was never used

## Fix

Check `inputs.version` first (set by `workflow_call`) before checking `github.event_name`.

## Test plan

- [ ] Re-run the CD workflow for `pypi/computer-server`
- [ ] Verify the version is correctly passed through