### PR TITLE
fix(ci): check inputs.version first in all PyPI workflows

### DIFF
--- a/.github/workflows/cd-py-core.yml
+++ b/.github/workflows/cd-py-core.yml
@@ -32,7 +32,10 @@ jobs:
       - name: Determine version
         id: get-version
         run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
+          # Check inputs.version first (set by workflow_call)
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION=${{ inputs.version }}
+          elif [ "${{ github.event_name }}" == "push" ]; then
             # Extract version from tag (for package-specific tags)
             if [[ "${{ github.ref }}" =~ ^refs/tags/core-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
               VERSION=${BASH_REMATCH[1]}
@@ -44,8 +47,8 @@ jobs:
             # Use version from workflow dispatch
             VERSION=${{ github.event.inputs.version }}
           else
-            # Use version from workflow_call
-            VERSION=${{ inputs.version }}
+            echo "No version provided"
+            exit 1
           fi
           echo "VERSION=$VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/cd-py-mcp-server.yml
+++ b/.github/workflows/cd-py-mcp-server.yml
@@ -38,7 +38,10 @@ jobs:
       - name: Determine version
         id: get-version
         run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
+          # Check inputs.version first (set by workflow_call)
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION=${{ inputs.version }}
+          elif [ "${{ github.event_name }}" == "push" ]; then
             # Extract version from tag (for package-specific tags)
             if [[ "${{ github.ref }}" =~ ^refs/tags/mcp-server-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
               VERSION=${BASH_REMATCH[1]}
@@ -50,8 +53,8 @@ jobs:
             # Use version from workflow dispatch
             VERSION=${{ github.event.inputs.version }}
           else
-            # Use version from workflow_call
-            VERSION=${{ inputs.version }}
+            echo "No version provided"
+            exit 1
           fi
           echo "VERSION=$VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/cd-py-som.yml
+++ b/.github/workflows/cd-py-som.yml
@@ -36,7 +36,10 @@ jobs:
       - name: Determine version
         id: get-version
         run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
+          # Check inputs.version first (set by workflow_call)
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION=${{ inputs.version }}
+          elif [ "${{ github.event_name }}" == "push" ]; then
             # Extract version from tag (for package-specific tags)
             if [[ "${{ github.ref }}" =~ ^refs/tags/som-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
               VERSION=${BASH_REMATCH[1]}
@@ -48,8 +51,8 @@ jobs:
             # Use version from workflow dispatch
             VERSION=${{ github.event.inputs.version }}
           else
-            # Use version from workflow_call
-            VERSION=${{ inputs.version }}
+            echo "No version provided"
+            exit 1
           fi
           echo "VERSION=$VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Fixes empty version issue when PyPI workflows are called via `workflow_call` from a parent triggered by `workflow_dispatch`.

## Problem

When called via `workflow_call`, `github.event_name` is inherited from the parent (`workflow_dispatch`), so the workflow incorrectly checks `github.event.inputs.version` (empty) instead of `inputs.version` (set by workflow_call).

## Fixed workflows

- `cd-py-core.yml`
- `cd-py-mcp-server.yml`
- `cd-py-som.yml`

## Already fixed (no changes needed)

- `cd-py-agent.yml`
- `cd-py-bench.yml`
- `cd-py-bench-ui.yml`
- `cd-py-computer.yml`
- `cd-py-computer-server.yml`

## Test plan

- [ ] Re-run failed CD workflow
- [ ] Verify version is correctly passed