### PR TITLE
fix(ci): use env vars to avoid backtick interpretation in release notes

### DIFF
--- a/.github/workflows/release-github-reusable.yml
+++ b/.github/workflows/release-github-reusable.yml
@@ -103,23 +103,27 @@ jobs:
 
       - name: Prepare release body
         id: prepare-body
+        env:
+          # Use env vars to avoid shell interpretation of backticks in commit messages
+          RELEASE_NOTES: ${{ steps.release-notes.outputs.RELEASE_NOTES }}
+          CUSTOM_BODY: ${{ inputs.body }}
         run: |
           # Combine path-filtered notes with custom body
           BODY=""
 
           # Add path-filtered notes if available
-          if [ -n "${{ steps.release-notes.outputs.RELEASE_NOTES }}" ]; then
-            BODY="${{ steps.release-notes.outputs.RELEASE_NOTES }}"
+          if [ -n "$RELEASE_NOTES" ]; then
+            BODY="$RELEASE_NOTES"
           fi
 
           # Add custom body if provided
-          if [ -n "${{ inputs.body }}" ]; then
+          if [ -n "$CUSTOM_BODY" ]; then
             if [ -n "$BODY" ]; then
-              BODY="${BODY}
+              BODY="$BODY
 
-          ${{ inputs.body }}"
+          $CUSTOM_BODY"
             else
-              BODY="${{ inputs.body }}"
+              BODY="$CUSTOM_BODY"
             fi
           fi
 


### PR DESCRIPTION
## Summary

Fixes `uv: command not found` error in release workflow caused by backticks in commit messages being interpreted as shell command substitution.

## Problem

Commit messages like:
```
Format tests with `uv run pre-commit run --all-files`
```

When interpolated directly into shell script via `${{ }}`, the backticks cause bash to try executing the content as commands.

## Fix

Use environment variables (`env:`) instead of direct `${{ }}` interpolation. Environment variables are not subject to shell command substitution.

## Test plan

- [ ] Re-run the CD workflow for `pypi/core`
- [ ] Verify release is created with proper release notes