### PR TITLE
docs: update claude haiku model timestamp

### DIFF
--- a/docs/content/docs/cua/guide/advanced/composed-models.mdx
+++ b/docs/content/docs/cua/guide/advanced/composed-models.mdx
@@ -77,7 +77,7 @@ Any full computer-use model can serve as a planner:
 | Model                                  | Description                        |
 | -------------------------------------- | ---------------------------------- |
 | `anthropic/claude-sonnet-4-5-20250929` | Best balance of speed and accuracy |
-| `anthropic/claude-haiku-4-5-20250929`  | Faster, lower cost                 |
+| `anthropic/claude-haiku-4-5-20251001`  | Faster, lower cost                 |
 | `openai/gpt-4o`                        | Strong reasoning capabilities      |
 
 ## When to Use Composed Models

--- a/docs/content/docs/cua/guide/fundamentals/vlms.mdx
+++ b/docs/content/docs/cua/guide/fundamentals/vlms.mdx
@@ -40,7 +40,7 @@ Claude models are optimized for computer-use with native tool support.
 agent = ComputerAgent(model="anthropic/claude-sonnet-4-5-20250929", tools=[computer])
 
 # Claude Haiku 4.5 - faster, lower cost
-agent = ComputerAgent(model="anthropic/claude-haiku-4-5-20250929", tools=[computer])
+agent = ComputerAgent(model="anthropic/claude-haiku-4-5-20251001", tools=[computer])
 ```
 
 Set your API key:


### PR DESCRIPTION
The docs reference this non-existent model ID:

```
claude-haiku-4-5-20250929
```

`20250929` is the version date for **Sonnet 4.5**, not Haiku.

**Correct Haiku 4.5 ID:**

```
claude-haiku-4-5-20251001
```

**Sources with the wrong ID:**

* [https://cua.ai/docs/cua/guide/advanced/composed-models](https://cua.ai/docs/cua/guide/advanced/composed-models)
* [https://cua.ai/docs/cua/guide/fundamentals/vlms](https://cua.ai/docs/cua/guide/fundamentals/vlms)
