### PR TITLE
Bump cua-agent to v0.7.7

### DIFF
--- a/libs/python/agent/pyproject.toml
+++ b/libs/python/agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "cua-agent"
-version = "0.7.6"
+version = "0.7.7"
 description = "Cua (Computer Use) Agent for AI-driven computer interaction"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary
- Bumps cua-agent version from 0.7.6 to 0.7.7

## Why
The previous version (0.7.6) already exists on PyPI, causing the publish workflow to fail with:
```
HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
File already exists ('cua_agent-0.7.6.tar.gz', ...)
```

This allows the agent package to be re-published with the new core and computer versions.

## Related
- Run that failed: https://github.com/trycua/cua/actions/runs/20919303858/