### PR TITLE
Bump cua-agent to v0.7.7

### DIFF
--- a/libs/python/agent/.bumpversion.cfg
+++ b/libs/python/agent/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.6
+current_version = 0.7.7
 commit = True
 tag = True
 tag_name = agent-v{new_version}

--- a/libs/python/agent/pyproject.toml
+++ b/libs/python/agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "cua-agent"
-version = "0.7.6"
+version = "0.7.7"
 description = "Cua (Computer Use) Agent for AI-driven computer interaction"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Previous version (0.7.6) already exists on PyPI, causing publish workflow to fail. Bumping to 0.7.7 to allow re-publishing.