### PR TITLE
chore: add workflow_dispatch to cd-container-xfce.yml

### DIFF
--- a/.github/workflows/cd-container-xfce.yml
+++ b/.github/workflows/cd-container-xfce.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "docker-xfce-v*.*.*"
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to `cd-container-xfce.yml`

## Why
The `CD: Container XFCE` workflow was not registered in GitHub Actions even though the file existed. Adding `workflow_dispatch` forces GitHub to register the workflow when merged to main, and also allows manual triggering.

This fixes the issue where bumping `docker/xfce` didn't trigger the container publish.