### PR TITLE
fix(ci): use type=match for prefixed docker tags

### DIFF
--- a/.github/workflows/docker-reusable-publish.yml
+++ b/.github/workflows/docker-reusable-publish.yml
@@ -109,9 +109,9 @@ jobs:
         with:
           images: ${{ inputs.docker_hub_org }}/${{ inputs.image_name }}
           tags: |
-            type=semver,pattern={{version}},prefix=${{ inputs.tag_prefix }}
-            type=semver,pattern={{major}}.{{minor}},prefix=${{ inputs.tag_prefix }}
-            type=semver,pattern={{major}},prefix=${{ inputs.tag_prefix }}
+            type=match,pattern=${{ inputs.tag_prefix }}(\d+\.\d+\.\d+),group=1
+            type=match,pattern=${{ inputs.tag_prefix }}(\d+\.\d+),group=1
+            type=match,pattern=${{ inputs.tag_prefix }}(\d+),group=1
             type=raw,value=latest
 
       - name: Build & push digest (semver)
@@ -185,9 +185,9 @@ jobs:
         with:
           images: ${{ inputs.docker_hub_org }}/${{ inputs.image_name }}
           tags: |
-            type=semver,pattern={{version}},prefix=${{ inputs.tag_prefix }}
-            type=semver,pattern={{major}}.{{minor}},prefix=${{ inputs.tag_prefix }}
-            type=semver,pattern={{major}},prefix=${{ inputs.tag_prefix }}
+            type=match,pattern=${{ inputs.tag_prefix }}(\d+\.\d+\.\d+),group=1
+            type=match,pattern=${{ inputs.tag_prefix }}(\d+\.\d+),group=1
+            type=match,pattern=${{ inputs.tag_prefix }}(\d+),group=1
             type=raw,value=latest
 
       - name: Download all digest artifacts


### PR DESCRIPTION
## Summary
Fix docker image tagging to properly extract version numbers from prefixed tags.

## Problem
The `docker/metadata-action`'s `type=semver` expects clean semver tags like `v0.1.3`, but our tags have prefixes like `docker-xfce-v0.1.3`. This caused:
- Warnings: `docker-xfce-v0.1.3 is not a valid semver`
- Only `latest` tag produced instead of version tags like `0.1.3`, `0.1`, `0`

## Fix
Changed from `type=semver` to `type=match` with regex patterns:
```yaml
type=match,pattern=${{ inputs.tag_prefix }}(\d+\.\d+\.\d+),group=1
type=match,pattern=${{ inputs.tag_prefix }}(\d+\.\d+),group=1
type=match,pattern=${{ inputs.tag_prefix }}(\d+),group=1
type=raw,value=latest
```

This extracts `0.1.3`, `0.1`, `0`, and `latest` from `docker-xfce-v0.1.3`.

## Test plan
- [ ] Run "CD: Bump Version" for `docker/xfce`
- [ ] Verify docker images are tagged with version numbers (e.g., `0.1.4`, `0.1`, `0`, `latest`)
- [ ] No semver warnings in logs