### PR TITLE
Fix Windows command output decoding for UTF-8 and system encodings (#788)

### DIFF
--- a/libs/python/computer-server/computer_server/handlers/windows.py
+++ b/libs/python/computer-server/computer_server/handlers/windows.py
@@ -670,6 +670,17 @@ class WindowsAutomationHandler(BaseAutomationHandler):
                            Structure: {"success": bool, "stdout": str, "stderr": str, "return_code": int} or
                                     {"success": bool, "error": str}
         """
+        def decode_output(data: bytes) -> str:
+            if not data:
+                return ""
+            encodings = ['utf-8', 'gbk', 'gb2312', 'cp936', 'latin1']
+            for enc in encodings:
+                try:
+                    return data.decode(enc)
+                except (UnicodeDecodeError, LookupError):
+                    continue
+            return data.decode('utf-8', errors='replace')
+
         try:
             # Create subprocess
             process = await asyncio.create_subprocess_shell(
@@ -680,8 +691,9 @@ class WindowsAutomationHandler(BaseAutomationHandler):
             # Return decoded output
             return {
                 "success": True,
-                "stdout": stdout.decode() if stdout else "",
-                "stderr": stderr.decode() if stderr else "",
+                "stdout": decode_output(stdout),
+                "stderr": decode_output(stderr),
+
                 "return_code": process.returncode,
             }
         except Exception as e:


### PR DESCRIPTION
Windows commands with non-ASCII output (e.g., Chinese Windows) were failing due to
UTF-8 decoding errors in run_command. This PR:

- Tries multiple encodings (UTF-8, GBK, GB2312, CP936, Latin1)
- Falls back to UTF-8 with errors='replace' if all fail
- Prevents UnicodeDecodeError for non-ASCII command outputs

Fixes #788
