### PR TITLE
stabilizes the database architecture for the MCP server and fix broken tools 

### DIFF
--- a/docs/scripts/modal_app.py
+++ b/docs/scripts/modal_app.py
@@ -1135,9 +1135,9 @@ def aggregate_code_databases() -> dict:
         total_rows += rows_copied
         print(f"    Copied {rows_copied} rows from {component_name}")
 
-        # Detach
-        cursor.execute("DETACH DATABASE comp")
+        # Commit before detaching to release locks on the attached database
         conn.commit()
+        cursor.execute("DETACH DATABASE comp")
 
     conn.close()
     print(f"SQLite aggregation complete: {total_rows} total rows")


### PR DESCRIPTION
High-level summary

This change formalizes and stabilizes the database architecture for the MCP server by:

Fixing FTS population bugs (docs + code)

Introducing a first-class aggregation step for code indexes

Replacing runtime multi-DB fan-out with unified databases

Improving correctness, performance, and operational simplicity

1. Documentation DB (docs.sqlite) – FTS correctness fix
What changed

FTS5 triggers are now created before inserting rows into the pages table.

Data insertion happens after triggers exist.

Why it matters

pages_fts uses content='pages' (external content).

Without triggers present at insert time, FTS indexes stay empty.

This fix guarantees full-text search works correctly after each crawl.

Net effect

✅ Reliable docs search
✅ No silent FTS corruption

2. New: Aggregated code databases

A new Modal function was added:

aggregate_code_databases()

Purpose

Merge per-component code indexes into single unified databases that the MCP server can query directly.

3. Code index aggregation details
SQLite aggregation

Creates a unified:

code_index.sqlite


Merges all code_index_<component>.sqlite databases into one

Sets up:

code_files table

code_files_fts (FTS5)

Triggers created before insertion (same correctness fix as docs)

LanceDB aggregation

Creates:

code_index.lancedb


Reads all component LanceDBs

Preserves existing vectors (no re-embedding)

Uses a temp directory → copies into Modal volume (safe for non-atomic FS)

Returned metrics

Total rows

Total vectors

Number of components aggregated

4. Scheduled job changes
scheduled_code_index

Timeout increased from 1 hour → 2 hours

After parallel indexing:

Automatically runs aggregate_code_databases

Stores aggregation stats in the job result

Effect

✅ End-to-end daily pipeline
✅ No manual aggregation step

5. MCP server query architecture simplification
Before

Runtime discovery of per-component DBs

Attaching multiple SQLite databases

UNION views across FTS tables

Multiple LanceDB connections merged in memory

After

Single SQLite DB for code (code_index.sqlite)

Single LanceDB table for code (code_index.lancedb)

Lazy-initialized, cached connections

Much simpler query logic

Impact

🚀 Faster startup
🧠 Simpler code
🧱 Fewer edge cases
📉 Lower runtime overhead

6. Code query behavior changes
Vector search (query_code_vectors)

Now searches one unified LanceDB

Optional component filter is applied via WHERE

Results already globally sorted (no manual merge)

SQL search

Queries a single read-only aggregated SQLite DB

No dynamic views or database attachments

7. Documentation & clarity improvements

Added a large explanatory comment block describing:

Database types

Build pipeline

Scheduling order

Modal volume limitations

Clarifies operational intent for future maintainers

Overall impact

This diff converts a fragile, runtime-assembled system into a deterministic, pre-aggregated indexing pipeline.

Key wins

✅ Correct FTS behavior

✅ Faster MCP queries

✅ Cleaner architecture

✅ Easier debugging

✅ Safer production operation

This is a foundational reliability and scalability upgrade, not just a refactor.