### PR TITLE
Fix component database aggregation error

### DIFF
--- a/docs/scripts/modal_app.py
+++ b/docs/scripts/modal_app.py
@@ -1135,9 +1135,9 @@ def aggregate_code_databases() -> dict:
         total_rows += rows_copied
         print(f"    Copied {rows_copied} rows from {component_name}")
 
-        # Detach
-        cursor.execute("DETACH DATABASE comp")
+        # Commit before detaching to release locks on the attached database
         conn.commit()
+        cursor.execute("DETACH DATABASE comp")
 
     conn.close()
     print(f"SQLite aggregation complete: {total_rows} total rows")


### PR DESCRIPTION
SQLite requires all transactions to be committed before detaching an attached database. Moving conn.commit() before the DETACH DATABASE statement releases the lock and allows the detach to succeed.