### PR TITLE
fix(ci): use dynamic matrix for docker build platforms

### DIFF
--- a/.github/workflows/docker-reusable-build.yml
+++ b/.github/workflows/docker-reusable-build.yml
@@ -24,15 +24,26 @@ on:
         default: false
 
 jobs:
-  build:
+  setup:
     runs-on: ubuntu-latest
-    if: ${{ !(inputs.skip_arm64 && matrix.platform == 'linux/arm64') }}
+    outputs:
+      platforms: ${{ steps.set-platforms.outputs.platforms }}
+    steps:
+      - id: set-platforms
+        run: |
+          if [ "${{ inputs.skip_arm64 }}" == "true" ]; then
+            echo 'platforms=["linux/amd64"]' >> $GITHUB_OUTPUT
+          else
+            echo 'platforms=["linux/amd64", "linux/arm64"]' >> $GITHUB_OUTPUT
+          fi
+
+  build:
+    needs: setup
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        platform: ${{ fromJSON(needs.setup.outputs.platforms) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Fix GitHub Actions workflow configuration error where matrix context was unavailable in job-level if condition. Moved platform selection logic into a separate setup job that outputs the platform list based on the skip_arm64 input, then uses fromJSON() to dynamically populate the build matrix.