### PR TITLE
fix(agent): create screenshot_dir when trajectory_dir option is specified

### DIFF
--- a/libs/python/agent/agent/callbacks/trajectory_saver.py
+++ b/libs/python/agent/agent/callbacks/trajectory_saver.py
@@ -140,6 +140,10 @@ class TrajectorySaverCallback(AsyncCallbackHandler):
         # Ensure trajectory directory exists
         self.trajectory_dir.mkdir(parents=True, exist_ok=True)
 
+        # Ensure screenshot directory exists if specified
+        if self.screenshot_dir:
+            self.screenshot_dir.mkdir(parents=True, exist_ok=True)
+
     def _get_turn_dir(self) -> Path:
         """Get the directory for the current turn."""
         if not self.trajectory_id:


### PR DESCRIPTION
Fixes https://github.com/trycua/cua/issues/811

```py
agent = ComputerAgent(
    model="cua/anthropic/claude-sonnet-4.5",
    tools=[computer],
    trajectory_dir={
        "trajectory_dir": "trajectories",
        "screenshot_dir": "trajectories/screenshots"
    }
)
```

<img width="363" height="423" alt="image" src="https://github.com/user-attachments/assets/a6da606e-45ce-4635-842c-645318b96843" />
