### PR TITLE
fix: add missing PIL Image import in macos handler

### DIFF
--- a/libs/python/computer-server/computer_server/handlers/macos.py
+++ b/libs/python/computer-server/computer_server/handlers/macos.py
@@ -73,7 +73,7 @@ except Exception as e:
 
 # Trigger screen recording prompt on macOS
 try:
-    from PIL import ImageGrab
+    from PIL import ImageGrab, Image
 
     ImageGrab.grab()
 except Exception as e:


### PR DESCRIPTION
## Problem

The `screenshot` command fails on macOS with the error:
```
Screenshot error: name 'Image' is not defined
```

## Root Cause

In `handlers/macos.py` line 76, only `ImageGrab` is imported from PIL:
```python
from PIL import ImageGrab
```

But `Image.Image` and `Image.Resampling.LANCZOS` are used later in the code (lines 1329, 1337).

## Fix

Add `Image` to the import statement:
```python
from PIL import ImageGrab, Image
```