### PR TITLE
fix(lume): include resource bundle in installation

### DIFF
--- a/libs/lume/scripts/build/build-release-notarized.sh
+++ b/libs/lume/scripts/build/build-release-notarized.sh
@@ -168,6 +168,12 @@ log "normal" "Using release directory: $RELEASE_DIR"
 # Copy extracted lume to the release directory
 cp -f usr/local/bin/lume "$RELEASE_DIR/lume"
 
+# Copy the resource bundle (contains unattended presets) from the build directory
+BUILD_BUNDLE="$LUME_DIR/.build/release/lume_lume.bundle"
+if [ -d "$BUILD_BUNDLE" ]; then
+  cp -rf "$BUILD_BUNDLE" "$RELEASE_DIR/"
+fi
+
 # Install to user-local bin directory (standard location)
 USER_BIN="$HOME/.local/bin"
 mkdir -p "$USER_BIN"
@@ -191,8 +197,12 @@ rm -f lume-*.tar.gz lume-*.pkg.tar.gz
 
 # Create version-specific archives
 log "essential" "Creating version-specific archives (${VERSION})..."
-# Package the binary
-tar -czf "lume-${VERSION}-${OS_IDENTIFIER}.tar.gz" lume > /dev/null 2>&1
+# Package the binary and resource bundle
+if [ -d "lume_lume.bundle" ]; then
+  tar -czf "lume-${VERSION}-${OS_IDENTIFIER}.tar.gz" lume lume_lume.bundle > /dev/null 2>&1
+else
+  tar -czf "lume-${VERSION}-${OS_IDENTIFIER}.tar.gz" lume > /dev/null 2>&1
+fi
 # Package the installer
 tar -czf "lume-${VERSION}-${OS_IDENTIFIER}.pkg.tar.gz" lume.pkg > /dev/null 2>&1
 

--- a/libs/lume/scripts/build/build-release.sh
+++ b/libs/lume/scripts/build/build-release.sh
@@ -14,10 +14,20 @@ codesign --force --entitlement ./resources/lume.entitlements --sign - .build/rel
 mkdir -p ./.release
 cp -f .build/release/lume ./.release/lume
 
+# Copy the resource bundle (contains unattended presets)
+if [ -d ".build/release/lume_lume.bundle" ]; then
+  cp -rf .build/release/lume_lume.bundle ./.release/
+fi
+
 # Install to user-local bin directory (standard location)
 USER_BIN="$HOME/.local/bin"
 mkdir -p "$USER_BIN"
 cp -f ./.release/lume "$USER_BIN/lume"
+
+# Install the resource bundle alongside the binary
+if [ -d "./.release/lume_lume.bundle" ]; then
+  cp -rf ./.release/lume_lume.bundle "$USER_BIN/"
+fi
 
 # Advise user to add to PATH if not present
 if ! echo "$PATH" | grep -q "$USER_BIN"; then

--- a/libs/lume/scripts/install.sh
+++ b/libs/lume/scripts/install.sh
@@ -262,10 +262,17 @@ install_binary() {
   
   # Move the binary to the installation directory
   mv "$TEMP_DIR/lume" "$INSTALL_DIR/"
-  
+
   # Make the binary executable
   chmod +x "$INSTALL_DIR/lume"
-  
+
+  # Move the resource bundle if it exists (contains unattended presets)
+  if [ -d "$TEMP_DIR/lume_lume.bundle" ]; then
+    rm -rf "$INSTALL_DIR/lume_lume.bundle"
+    mv "$TEMP_DIR/lume_lume.bundle" "$INSTALL_DIR/"
+    echo "Resource bundle installed to ${BOLD}$INSTALL_DIR/lume_lume.bundle${NORMAL}"
+  fi
+
   echo "${GREEN}Installation complete!${NORMAL}"
   echo "Lume has been installed to ${BOLD}$INSTALL_DIR/lume${NORMAL}"
   
@@ -387,6 +394,13 @@ apply_update() {
       # Install new binary
       mv "$TEMP_DIR/lume" "$INSTALL_DIR/"
       chmod +x "$INSTALL_DIR/lume"
+
+      # Install resource bundle if it exists (contains unattended presets)
+      if [ -d "$TEMP_DIR/lume_lume.bundle" ]; then
+        rm -rf "$INSTALL_DIR/lume_lume.bundle"
+        mv "$TEMP_DIR/lume_lume.bundle" "$INSTALL_DIR/"
+        log "Resource bundle installed"
+      fi
 
       # Restart the daemon
       launchctl load "$HOME/Library/LaunchAgents/com.trycua.lume_daemon.plist" 2>/dev/null || true

--- a/libs/lume/src/Main.swift
+++ b/libs/lume/src/Main.swift
@@ -54,39 +54,6 @@ extension Lume {
     }
 }
 
-// MARK: - ASCII Art Banner
-extension Lume {
-    static let banner = """
-    \u{001B}[34m  ⠀⣀⣀⡀⠀⠀⠀⠀⢀⣀⣀⣀⡀⠘⠋⢉⠙⣷⠀⠀ ⠀
-     ⠀⠀⢀⣴⣿⡿⠋⣉⠁⣠⣾⣿⣿⣿⣿⡿⠿⣦⡈⠀⣿⡇⠃⠀
-     ⠀⠀⠀⣽⣿⣧⠀⠃⢰⣿⣿⡏⠙⣿⠿⢧⣀⣼⣷⠀⡿⠃⠀⠀
-     ⠀⠀⠀⠉⣿⣿⣦⠀⢿⣿⣿⣷⣾⡏⠀⠀⢹⣿⣿⠀⠀⠀⠀⠀⠀
-     ⠀⠀⠀⠀⠀⠉⠛⠁⠈⠿⣿⣿⣿⣷⣄⣠⡼⠟⠁\u{001B}[0m\u{001B}[1m  lume v\(Version.current)\u{001B}[0m
-    \u{001B}[34m           macOS VM CLI and server\u{001B}[0m
-    """
-
-    static func printBanner() {
-        print(banner)
-        print()
-    }
-
-    static func shouldShowBanner() -> Bool {
-        let args = CommandLine.arguments.dropFirst()
-        // Show banner when: no args, --help, -h, help, or just the root command
-        if args.isEmpty {
-            return true
-        }
-        if args.contains("--help") || args.contains("-h") {
-            return true
-        }
-        // Check if first arg is "help" (e.g., "lume help")
-        if args.first == "help" && args.count == 1 {
-            return true
-        }
-        return false
-    }
-}
-
 // MARK: - Command Execution
 extension Lume {
     public static func main() async {


### PR DESCRIPTION
## Summary

Fix fatal error when using `--unattended` flag by including the resource bundle in installation.

The lume CLI requires `lume_lume.bundle` for unattended presets (sequoia, tahoe). Previously, only the binary was installed, causing this fatal error:

```
lume/resource_bundle_accessor.swift:12: Fatal error: could not load resource bundle: from /Users/.../.local/bin/lume_lume.bundle
```

## Changes

- **build-release.sh**: Copy bundle to `.release/` and install alongside binary
- **build-release-notarized.sh**: Include bundle in release tarball
- **install.sh**: Extract and install bundle from tarball (both fresh install and auto-updater)
- **Main.swift**: Remove duplicate ASCII Art Banner extension (compilation fix)

## Test plan

- [x] Build lume: `./scripts/build/build-release.sh`
- [x] Verify bundle installed: `ls ~/.local/bin/lume_lume.bundle/unattended-presets/`
- [x] Test `lume create --unattended sequoia` works without fatal error