### PR TITLE
docs(lume): add custom storage locations and Linux VM documentation

### DIFF
--- a/docs/content/docs/lume/guide/fundamentals/vm-management.mdx
+++ b/docs/content/docs/lume/guide/fundamentals/vm-management.mdx
@@ -45,6 +45,37 @@ Mount a disk image as USB storage (macOS 15+ only):
 lume run my-vm --usb-storage /path/to/disk.img
 ```
 
+## Linux VMs
+
+Lume supports Linux VMs using ARM64 ISO images. The workflow differs slightly from macOS.
+
+### Create and install
+
+```bash
+# Create empty VM configured for Linux
+lume create ubuntu-vm --os linux --cpu 4 --memory 8GB --disk-size 50GB
+
+# First boot: mount installer ISO
+lume run ubuntu-vm --mount ~/Downloads/ubuntu-24.04-live-server-arm64.iso
+
+# After installation: run normally
+lume run ubuntu-vm
+```
+
+Complete the installation in the VNC window, shut down, then run without the ISO.
+
+### Supported distributions
+
+Any ARM64 Linux distribution works. Download the ARM64 (aarch64) ISO, not x86_64:
+
+- **Ubuntu** - [ubuntu.com/download](https://ubuntu.com/download)
+- **Debian** - [debian.org](https://www.debian.org/)
+- **Fedora** - [fedoraproject.org](https://fedoraproject.org/)
+
+<Callout type="info">
+Linux VMs have no licensing restrictions—run as many concurrent instances as your hardware supports. Only macOS VMs are limited to 2 per Mac.
+</Callout>
+
 ## Stop a VM
 
 ```bash

--- a/docs/content/docs/lume/guide/getting-started/quickstart.mdx
+++ b/docs/content/docs/lume/guide/getting-started/quickstart.mdx
@@ -41,6 +41,35 @@ lume create my-vm --os macos --ipsw latest
 The IPSW file is ~15GB. If you plan to create multiple VMs, downloading manually and reusing the file saves time and bandwidth.
 </Callout>
 
+## Configure VM storage location (optional)
+
+By default, VMs are stored in `~/.lume`. You can configure custom storage locations before creating VMs—useful for external drives or organizing VMs by project.
+
+```bash
+# Add an external drive as a storage location
+lume config storage add external /Volumes/MySSD/lume
+
+# Set it as the default for new VMs
+lume config storage default external
+
+# View all configured storage locations
+lume config storage list
+```
+
+When creating a VM, specify which storage to use:
+
+```bash
+# Use a named storage location
+lume create my-vm --os macos --ipsw latest --storage external
+
+# Or use a direct path
+lume create my-vm --os macos --ipsw latest --storage /path/to/vm/directory
+```
+
+<Callout type="info">
+VM disk images can grow large (~50GB+). Using an external SSD keeps your internal storage free and can improve performance for I/O-heavy workloads.
+</Callout>
+
 ## Run your VM
 
 ```bash

--- a/docs/content/docs/lume/guide/getting-started/quickstart.mdx
+++ b/docs/content/docs/lume/guide/getting-started/quickstart.mdx
@@ -70,13 +70,32 @@ lume create my-vm --os macos --ipsw latest --storage /path/to/vm/directory
 VM disk images can grow large (~50GB+). Using an external SSD keeps your internal storage free and can improve performance for I/O-heavy workloads.
 </Callout>
 
+## Create a Linux VM
+
+Lume also supports Linux VMs using ISO images:
+
+```bash
+# Create an empty Linux VM
+lume create ubuntu-vm --os linux
+
+# First boot: mount the installer ISO
+lume run ubuntu-vm --mount ~/Downloads/ubuntu-24.04-live-server-arm64.iso
+
+# After installation completes, run normally
+lume run ubuntu-vm
+```
+
+<Callout type="info">
+Linux VMs require ARM64 ISO images (not x86). Ubuntu, Debian, and Fedora all provide ARM64 server and desktop images.
+</Callout>
+
 ## Run your VM
 
 ```bash
 lume run my-vm
 ```
 
-A VNC window opens with the macOS Setup Assistant. Complete the setup manually, or use [Unattended Setup](/lume/guide/fundamentals/unattended-setup) to automate it.
+A VNC window opens. For macOS VMs, you'll see the Setup Assistant—complete it manually or use [Unattended Setup](/lume/guide/fundamentals/unattended-setup) to automate it.
 
 ## Create a VM with custom resources
 


### PR DESCRIPTION
## Summary

Add documentation for custom storage locations and Linux VMs to the Lume quickstart and vm-management guides.

## Changes

### Custom storage locations (quickstart)
- Add "Configure VM storage location (optional)" section
- Document `lume config storage add/default/list` commands
- Show `--storage` flag usage with both named locations and direct paths
- Include tip about using external SSDs

### Linux VM documentation (quickstart + vm-management)
- Add "Create a Linux VM" section to quickstart with ISO workflow
- Add "Linux VMs" section to vm-management with detailed create/install/run steps
- Note ARM64 ISO requirement (not x86_64)
- List supported distributions (Ubuntu, Debian, Fedora)
- Mention Linux VMs have no licensing limits (unlike macOS 2-VM limit)

## Why

Users should know:
- They can configure storage locations before creating VMs
- Lume supports Linux VMs, not just macOS
- Linux uses a different workflow (ISO-based installation)