### PR TITLE
Fix PyPI pipeline triggers for cascade version bumps

### DIFF
--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -143,20 +143,48 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Clean existing tag if present
+      - name: Clean existing tags if present
         run: |
-          cd ${{ steps.package.outputs.directory }}
-          # Get the new version that bump2version would create (capture only first match, ignore stderr)
-          NEW_VERSION=$(bump2version --dry-run --list ${{ inputs.bump_type }} 2>/dev/null | grep -m1 '^new_version=' | sed 's/new_version=//')
-          # Get tag name pattern from .bumpversion.cfg
-          TAG_NAME=$(grep -m1 '^tag_name' .bumpversion.cfg | sed 's/tag_name *= *//' | sed "s|{new_version}|$NEW_VERSION|")
+          # Function to clean a tag for a given package directory
+          clean_tag() {
+            local dir=$1
+            cd "$dir"
+            NEW_VERSION=$(bump2version --dry-run --list ${{ inputs.bump_type }} 2>/dev/null | grep -m1 '^new_version=' | sed 's/new_version=//')
+            TAG_NAME=$(grep -m1 '^tag_name' .bumpversion.cfg | sed 's/tag_name *= *//' | sed "s|{new_version}|$NEW_VERSION|")
+            echo "Checking for existing tag: $TAG_NAME"
+            git tag -d "$TAG_NAME" 2>/dev/null || true
+            git push origin ":refs/tags/$TAG_NAME" 2>/dev/null || true
+            cd - > /dev/null
+          }
 
-          echo "Checking for existing tag: $TAG_NAME"
+          # Clean tag for the primary package
+          clean_tag "${{ steps.package.outputs.directory }}"
 
-          # Delete local tag if exists
-          git tag -d "$TAG_NAME" 2>/dev/null || true
-          # Delete remote tag if exists
-          git push origin ":refs/tags/$TAG_NAME" 2>/dev/null || true
+          # Clean cascade tags when bumping pypi/core (also bumps computer and agent)
+          if [ "${{ inputs.service }}" == "pypi/core" ]; then
+            clean_tag "libs/python/computer"
+            clean_tag "libs/python/agent"
+          fi
+
+          # Clean cascade tags when bumping pypi/computer (also bumps agent)
+          if [ "${{ inputs.service }}" == "pypi/computer" ]; then
+            clean_tag "libs/python/agent"
+          fi
+
+          # Clean cascade tags when bumping pypi/som (also bumps agent)
+          if [ "${{ inputs.service }}" == "pypi/som" ]; then
+            clean_tag "libs/python/agent"
+          fi
+
+          # Clean cascade tags when bumping npm/core (also bumps npm/computer)
+          if [ "${{ inputs.service }}" == "npm/core" ]; then
+            clean_tag "libs/typescript/computer"
+          fi
+
+      - name: Save starting commit
+        id: start_commit
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Run bump2version
         run: |
@@ -186,6 +214,32 @@ jobs:
         run: |
           cd libs/typescript/computer
           bump2version ${{ inputs.bump_type }}
+
+      - name: Collect all created tags
+        id: collect_tags
+        run: |
+          # Find all tags pointing to commits after the starting commit
+          START_SHA="${{ steps.start_commit.outputs.sha }}"
+          echo "Starting commit: $START_SHA"
+
+          # Get all local tags and filter to those pointing to commits after START_SHA
+          ALL_TAGS=""
+          for tag in $(git tag --points-at HEAD) $(git tag --points-at HEAD~1 2>/dev/null) $(git tag --points-at HEAD~2 2>/dev/null); do
+            if [ -n "$tag" ]; then
+              TAG_SHA=$(git rev-parse "$tag^{commit}" 2>/dev/null || true)
+              if [ -n "$TAG_SHA" ]; then
+                # Check if this tag's commit is a descendant of (or equal to) START_SHA
+                if git merge-base --is-ancestor "$START_SHA" "$TAG_SHA" 2>/dev/null; then
+                  ALL_TAGS="$ALL_TAGS $tag"
+                fi
+              fi
+            fi
+          done
+
+          # Remove duplicates and trim
+          ALL_TAGS=$(echo "$ALL_TAGS" | tr ' ' '\n' | sort -u | tr '\n' ' ' | xargs)
+          echo "Tags to push: $ALL_TAGS"
+          echo "tags=$ALL_TAGS" >> $GITHUB_OUTPUT
 
       - name: Capture bumped agent version
         if: ${{ inputs.service == 'pypi/agent' || inputs.service == 'pypi/computer' || inputs.service == 'pypi/core' || inputs.service == 'pypi/som' }}
@@ -311,11 +365,13 @@ jobs:
           echo "Verifying GitHub App token..."
           gh auth status
 
-          # Get the tag name from bump2version (it creates a local tag)
-          TAG=$(git describe --tags --abbrev=0)
-          TEMP_BRANCH="temp-release-${TAG}"
+          # Get all tags created by bump2version
+          ALL_TAGS="${{ steps.collect_tags.outputs.tags }}"
+          echo "Tags to push: $ALL_TAGS"
 
-          echo "Tag: $TAG"
+          # Use the first tag for naming the temp branch
+          FIRST_TAG=$(echo "$ALL_TAGS" | awk '{print $1}')
+          TEMP_BRANCH="temp-release-${FIRST_TAG}"
           echo "Temp branch: $TEMP_BRANCH"
 
           # Retry loop for handling concurrent bumps
@@ -337,8 +393,23 @@ jobs:
               # Rebase our commit(s) onto the latest main
               git rebase origin/main
 
-              # Update the local tag to point to the new rebased commit
-              git tag -f "$TAG" HEAD
+              # Update ALL local tags to point to their rebased commits
+              # Each tag should point to the commit with its corresponding message
+              for tag in $ALL_TAGS; do
+                # Find the commit message pattern for this tag
+                TAG_MSG=$(echo "$tag" | sed 's/-v/ to v/')
+                TAG_MSG="Bump $TAG_MSG"
+                # Find the commit with this message and update the tag
+                COMMIT_FOR_TAG=$(git log --oneline --grep="$TAG_MSG" -1 --format="%H" 2>/dev/null || true)
+                if [ -n "$COMMIT_FOR_TAG" ]; then
+                  git tag -f "$tag" "$COMMIT_FOR_TAG"
+                  echo "Updated tag $tag to commit $COMMIT_FOR_TAG"
+                else
+                  # Fallback: point to HEAD
+                  git tag -f "$tag" HEAD
+                  echo "Updated tag $tag to HEAD (fallback)"
+                fi
+              done
             fi
 
             # Get the current commit SHA (may have changed after rebase)
@@ -357,15 +428,19 @@ jobs:
 
               echo "Successfully updated main branch!"
 
-              # Now create the tag via API (only after main is successfully updated)
-              echo "Creating tag via API..."
-              # Delete existing remote tag if present (in case of retry with different SHA)
-              gh api -X DELETE /repos/${{ github.repository }}/git/refs/tags/${TAG} 2>/dev/null || true
-              gh api /repos/${{ github.repository }}/git/refs \
-                -f ref="refs/tags/${TAG}" \
-                -f sha="${COMMIT_SHA}"
-
-              echo "Tag created successfully!"
+              # Now create ALL tags via API (only after main is successfully updated)
+              echo "Creating tags via API..."
+              for tag in $ALL_TAGS; do
+                echo "Creating tag: $tag"
+                # Get the SHA for this specific tag
+                TAG_SHA=$(git rev-parse "$tag^{commit}" 2>/dev/null || echo "$COMMIT_SHA")
+                # Delete existing remote tag if present (in case of retry with different SHA)
+                gh api -X DELETE /repos/${{ github.repository }}/git/refs/tags/${tag} 2>/dev/null || true
+                gh api /repos/${{ github.repository }}/git/refs \
+                  -f ref="refs/tags/${tag}" \
+                  -f sha="${TAG_SHA}"
+                echo "Tag $tag created successfully!"
+              done
 
               # Clean up temp branch
               echo "Cleaning up temp branch..."


### PR DESCRIPTION
## Summary
When bumping packages with dependencies (e.g., cua-core triggers bumps of cua-computer and cua-agent), only the final tag was being pushed to GitHub. This prevented dependent packages from triggering their CD workflows and being published to PyPI.

## Changes
- Collect all tags created during cascade bumps instead of just the last one
- Push all collected tags to GitHub to trigger corresponding CD workflows
- Update tag references after rebase to maintain correct commit mappings
- Handle cascade scenarios for pypi/core, pypi/computer, pypi/som, and npm/core

## Test Plan
- Next release using pypi/core bumping should publish core, computer, and agent to PyPI
- Verify all three tags (core-v*, computer-v*, agent-v*) are created on GitHub