### PR TITLE
fix(lume): improve unattended preset reliability for account creation

### DIFF
--- a/libs/lume/resources/unattended-sequoia.yml
+++ b/libs/lume/resources/unattended-sequoia.yml
@@ -73,7 +73,8 @@ boot_commands:
   # Need to tab 6 times to reach Full Name field
   # Field order after avatar: Full Name -> Account Name (auto-filled) -> Password -> Verify Password -> Hint -> Checkbox -> Continue
   - "<wait 'Create a Mac Account'>"
-  - "<delay 1>"
+  - "<delay 10>"
+  - "<click 'Full Name'>"
   # Type Full Name
   - "<type 'lume'>"
   - "<tab>" 

--- a/libs/lume/resources/unattended-tahoe.yml
+++ b/libs/lume/resources/unattended-tahoe.yml
@@ -73,19 +73,8 @@ boot_commands:
   # Need to tab 6 times to reach Full Name field
   # Field order after avatar: Full Name -> Account Name (auto-filled) -> Password -> Verify Password -> Hint -> Checkbox -> Continue
   - "<wait 'Create a Mac Account'>"
-  - "<delay 1>"
-  # Tab past avatar picker icons (6 tabs)
-  - "<tab>"
-  - "<delay 1>"
-  - "<tab>"
-  - "<delay 1>"
-  - "<tab>"
-  - "<delay 1>"
-  - "<tab>"
-  - "<delay 1>"
-  - "<tab>"
-  - "<delay 1>"
-  - "<tab>"
+  - "<delay 10>"
+  - "<click 'Full Name'>"
   # Type Full Name
   - "<type 'lume'>"
   - "<tab>"


### PR DESCRIPTION
## Summary

Improve reliability of the unattended Setup Assistant automation for macOS VM creation.

## Changes

- Replace 6-tab navigation with direct `<click 'Full Name'>` action
- Increase delay from 1 to 10 seconds before field interaction

## Why

The tab-based navigation was fragile and could fail depending on UI timing. Using a direct click on the "Full Name" field label is more reliable and works consistently across different system loads.

## Affected presets

- `sequoia.yml`
- `tahoe.yml`