### PR TITLE
fix(lume): improve System Settings navigation in unattended presets

### DIFF
--- a/libs/lume/resources/unattended-sequoia.yml
+++ b/libs/lume/resources/unattended-sequoia.yml
@@ -243,27 +243,35 @@ boot_commands:
 
   # Close Terminal
   - "<cmd+q>"
+  - "<delay 2>"
+
+  # Click on desktop to ensure keyboard focus before Spotlight
+  - "<click_at 960,540>"
   - "<delay 1>"
 
   # Open Spotlight and search for System Settings
   - "<cmd+space>"
   - "<delay 2>"
   - "<type 'System Settings'>"
-  - "<delay 1>"
+  - "<delay 2>"
   - "<enter>"
+  - "<delay 5>"
+
+  # Wait for System Settings to fully load (sidebar shows General)
+  - "<wait 'General', timeout=30>"
+  - "<delay 2>"
+
+  # Use keyboard shortcut to focus search field (more reliable than clicking)
+  - "<cmd+f>"
+  - "<delay 1>"
+  - "<type 'Remote Login'>"
+  - "<delay 2>"
+  - "<click 'Remote Login'>"
   - "<delay 3>"
 
-  # Click on the search bar, then search for Remote Login
-  - "<click 'Search'>"
-  - "<delay 1>"
-  - "<type 'Remote'>"
-  - "<delay 2>"
-  - "<click 'Remote login'>"
-  - "<delay 2>"
-
-  # Tab twice to reach the "Allow full disk access" toggle, then Space to toggle
+  # Tab to reach the "Allow full disk access" toggle, then Space to toggle
   - "<tab>"
-  - "<delay 0.3>"
+  - "<delay 0.5>"
   - "<space>"
   - "<delay 2>"
 

--- a/libs/lume/resources/unattended-tahoe.yml
+++ b/libs/lume/resources/unattended-tahoe.yml
@@ -254,27 +254,35 @@ boot_commands:
 
   # Close Terminal
   - "<cmd+q>"
+  - "<delay 2>"
+
+  # Click on desktop to ensure keyboard focus before Spotlight
+  - "<click_at 960,540>"
   - "<delay 1>"
 
   # Open Spotlight and search for System Settings
   - "<cmd+space>"
   - "<delay 2>"
   - "<type 'System Settings'>"
-  - "<delay 1>"
+  - "<delay 2>"
   - "<enter>"
-  - "<delay 3>"
+  - "<delay 5>"
 
-  # Click on the search bar, then search for Remote Login
-  - "<click 'Search'>"
+  # Wait for System Settings to fully load (sidebar shows General)
+  - "<wait 'General', timeout=30>"
+  - "<delay 2>"
+
+  # Use keyboard shortcut to focus search field (more reliable than clicking)
+  - "<cmd+f>"
   - "<delay 1>"
-  - "<type 'Remote'>"
+  - "<type 'Remote Login'>"
   - "<delay 2>"
   - "<click 'Remote Login'>"
-  - "<delay 2>"
+  - "<delay 3>"
 
-  # Tab twice to reach the "Allow full disk access" toggle, then Space to toggle
+  # Tab to reach the "Allow full disk access" toggle, then Space to toggle
   - "<tab>"
-  - "<delay 0.3>"
+  - "<delay 0.5>"
   - "<space>"
   - "<delay 2>"
 


### PR DESCRIPTION
## Summary

Fix the unattended setup failure at command 170 where `<click 'Search'>` couldn't find the System Settings search field.

## Root Cause

The failure occurred because Terminal was still the active window when trying to interact with System Settings. The `<cmd+q>` to close Terminal and subsequent Spotlight search weren't reliable without proper keyboard focus.

## Changes

1. **Add desktop click** - Click at center of screen after closing Terminal to ensure keyboard focus
2. **Increase delays** - More time for app transitions (Terminal close, Spotlight, System Settings launch)
3. **Add verification wait** - `<wait 'General', timeout=30>` to confirm System Settings opened
4. **Use keyboard shortcut** - `<cmd+f>` instead of `<click 'Search'>` for reliable search field focus
5. **Increase toggle delay** - From 0.3s to 0.5s before toggling full disk access

## Affected Presets

- `sequoia.yml`
- `tahoe.yml`

## Test Plan

- [ ] Run `lume create test-vm --os macos --ipsw latest --unattended sequoia --debug`
- [ ] Verify System Settings opens and search works
- [ ] Verify Remote Login settings page loads
- [ ] Verify full disk access toggle is enabled