### PR TITLE
fix(docs): add Lume section redirects to middleware

### DIFF
--- a/docs/src/middleware.ts
+++ b/docs/src/middleware.ts
@@ -12,6 +12,10 @@ const redirects: Record<string, string> = {
   '/cuabench': '/docs/cuabench/guide/getting-started/introduction',
   '/cuabench/guide': '/docs/cuabench/guide/getting-started/introduction',
   '/cuabench/reference': '/docs/cuabench/reference/cli-reference',
+  '/lume': '/docs/lume/guide/getting-started/introduction',
+  '/lume/guide': '/docs/lume/guide/getting-started/introduction',
+  '/lume/examples': '/docs/lume/examples/claude-cowork-sandbox',
+  '/lume/reference': '/docs/lume/reference/cli-reference',
   // Legacy redirects for old URLs without /cua prefix
   '/guide': '/docs/cua/guide/get-started/what-is-cua',
   '/examples': '/docs/cua/examples/automation/form-filling',


### PR DESCRIPTION
## Summary

Add missing Lume redirects to the middleware so that `/docs/lume` and other Lume section roots redirect to their first content pages:

- `/lume` → `/docs/lume/guide/getting-started/introduction`
- `/lume/guide` → `/docs/lume/guide/getting-started/introduction`
- `/lume/examples` → `/docs/lume/examples/claude-cowork-sandbox`
- `/lume/reference` → `/docs/lume/reference/cli-reference`

This matches the existing pattern for `/cua` and `/cuabench` sections.

## Test plan

- [ ] Verify `/docs/lume` redirects to `/docs/lume/guide/getting-started/introduction`
- [ ] Verify `/docs/lume/guide` redirects correctly
- [ ] Verify `/docs/lume/examples` redirects correctly
- [ ] Verify `/docs/lume/reference` redirects correctly