### PR TITLE
refactor(windows): use decorator to reduce lock check duplication

### DIFF
--- a/libs/python/computer-server/computer_server/handlers/windows.py
+++ b/libs/python/computer-server/computer_server/handlers/windows.py
@@ -7,11 +7,33 @@ for accessibility and system operations.
 
 import asyncio
 import base64
+import functools
 import logging
 import os
 import subprocess
 from io import BytesIO
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def require_unlocked_desktop(func: F) -> F:
+    """Decorator that checks if the Windows desktop is locked before executing.
+
+    Returns an error response if the desktop is locked, preventing automation
+    actions that would silently fail on the Windows Secure Desktop.
+    """
+
+    @functools.wraps(func)
+    async def wrapper(self: "WindowsAutomationHandler", *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        if self.is_desktop_locked():
+            return {
+                "success": False,
+                "error": "Windows desktop is locked. Automation input is blocked by OS security.",
+            }
+        return await func(self, *args, **kwargs)
+
+    return wrapper  # type: ignore[return-value]
 
 from PIL import Image, ImageGrab
 from pynput.keyboard import Controller as KeyboardController
@@ -249,6 +271,7 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         return None
 
     # Mouse Actions
+    @require_unlocked_desktop
     async def mouse_down(
         self, x: Optional[int] = None, y: Optional[int] = None, button: str = "left"
     ) -> Dict[str, Any]:
@@ -262,12 +285,6 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         Returns:
             Dict[str, Any]: A dictionary with success status and optional error message.
         """
-
-        if self.is_desktop_locked():
-            return {
-                "success": False,
-                "error": "Windows desktop is locked. Automation input is blocked by OS security."
-            }
         try:
             if x is not None and y is not None:
                 self.mouse.position = (x, y)
@@ -276,6 +293,7 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         except Exception as e:
             return {"success": False, "error": str(e)}
 
+    @require_unlocked_desktop
     async def mouse_up(
         self, x: Optional[int] = None, y: Optional[int] = None, button: str = "left"
     ) -> Dict[str, Any]:
@@ -289,12 +307,6 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         Returns:
             Dict[str, Any]: A dictionary with success status and optional error message.
         """
-        if self.is_desktop_locked():
-            return {
-                "success": False,
-                "error": "Windows desktop is locked. Automation input is blocked by OS security."
-            }
-
         try:
             if x is not None and y is not None:
                 self.mouse.position = (x, y)
@@ -303,6 +315,7 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         except Exception as e:
             return {"success": False, "error": str(e)}
 
+    @require_unlocked_desktop
     async def move_cursor(self, x: int, y: int) -> Dict[str, Any]:
         """Move the mouse cursor to the specified coordinates.
 
@@ -313,17 +326,13 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         Returns:
             Dict[str, Any]: A dictionary with success status and optional error message.
         """
-        if self.is_desktop_locked():
-            return {
-                "success": False,
-                "error": "Windows desktop is locked. Automation input is blocked by OS security."
-            }
         try:
             self.mouse.position = (x, y)
             return {"success": True}
         except Exception as e:
             return {"success": False, "error": str(e)}
 
+    @require_unlocked_desktop
     async def left_click(self, x: Optional[int] = None, y: Optional[int] = None) -> Dict[str, Any]:
         """Perform a left mouse click at the specified coordinates.
 
@@ -334,11 +343,6 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         Returns:
             Dict[str, Any]: A dictionary with success status and optional error message.
         """
-        if self.is_desktop_locked():
-            return {
-                "success": False,
-                "error": "Windows desktop is locked. Automation input is blocked by OS security."
-            }
         try:
             if x is not None and y is not None:
                 self.mouse.position = (x, y)
@@ -347,6 +351,7 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         except Exception as e:
             return {"success": False, "error": str(e)}
 
+    @require_unlocked_desktop
     async def right_click(self, x: Optional[int] = None, y: Optional[int] = None) -> Dict[str, Any]:
         """Perform a right mouse click at the specified coordinates.
 
@@ -357,11 +362,6 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         Returns:
             Dict[str, Any]: A dictionary with success status and optional error message.
         """
-        if self.is_desktop_locked():
-            return {
-                "success": False,
-                "error": "Windows desktop is locked. Automation input is blocked by OS security."
-            }
         try:
             if x is not None and y is not None:
                 self.mouse.position = (x, y)
@@ -370,6 +370,7 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         except Exception as e:
             return {"success": False, "error": str(e)}
 
+    @require_unlocked_desktop
     async def double_click(
         self, x: Optional[int] = None, y: Optional[int] = None
     ) -> Dict[str, Any]:
@@ -382,11 +383,6 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         Returns:
             Dict[str, Any]: A dictionary with success status and optional error message.
         """
-        if self.is_desktop_locked():
-            return {
-                "success": False,
-                "error": "Windows desktop is locked. Automation input is blocked by OS security."
-            }
         try:
             if x is not None and y is not None:
                 self.mouse.position = (x, y)
@@ -395,6 +391,7 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         except Exception as e:
             return {"success": False, "error": str(e)}
 
+    @require_unlocked_desktop
     async def drag_to(
         self, x: int, y: int, button: str = "left", duration: float = 0.5
     ) -> Dict[str, Any]:
@@ -409,11 +406,6 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         Returns:
             Dict[str, Any]: A dictionary with success status and optional error message.
         """
-        if self.is_desktop_locked():
-            return {
-                "success": False,
-                "error": "Windows desktop is locked. Automation input is blocked by OS security."
-            }
         try:
             # simple drag implementation
             self.mouse.press(self._map_button(button))
@@ -423,6 +415,7 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         except Exception as e:
             return {"success": False, "error": str(e)}
 
+    @require_unlocked_desktop
     async def drag(
         self, path: List[Tuple[int, int]], button: str = "left", duration: float = 0.5
     ) -> Dict[str, Any]:
@@ -436,11 +429,6 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         Returns:
             Dict[str, Any]: A dictionary with success status and optional error message.
         """
-        if self.is_desktop_locked():
-            return {
-                "success": False,
-                "error": "Windows desktop is locked. Automation input is blocked by OS security."
-            }
         try:
             if not path:
                 return {"success": False, "error": "Path is empty"}
@@ -459,6 +447,7 @@ class WindowsAutomationHandler(BaseAutomationHandler):
             return {"success": False, "error": str(e)}
 
     # Keyboard Actions
+    @require_unlocked_desktop
     async def key_down(self, key: str) -> Dict[str, Any]:
         """Press and hold a keyboard key.
 
@@ -468,11 +457,6 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         Returns:
             Dict[str, Any]: A dictionary with success status and optional error message.
         """
-        if self.is_desktop_locked():
-            return {
-                "success": False,
-                "error": "Windows desktop is locked. Automation input is blocked by OS security."
-            }
         try:
             k = self._key_from_string(key)
             if k is None:
@@ -482,6 +466,7 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         except Exception as e:
             return {"success": False, "error": str(e)}
 
+    @require_unlocked_desktop
     async def key_up(self, key: str) -> Dict[str, Any]:
         """Release a keyboard key.
 
@@ -491,11 +476,6 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         Returns:
             Dict[str, Any]: A dictionary with success status and optional error message.
         """
-        if self.is_desktop_locked():
-            return {
-                "success": False,
-                "error": "Windows desktop is locked. Automation input is blocked by OS security."
-            }
         try:
             k = self._key_from_string(key)
             if k is None:
@@ -505,6 +485,7 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         except Exception as e:
             return {"success": False, "error": str(e)}
 
+    @require_unlocked_desktop
     async def type_text(self, text: str) -> Dict[str, Any]:
         """Type the specified text.
 
@@ -514,11 +495,6 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         Returns:
             Dict[str, Any]: A dictionary with success status and optional error message.
         """
-        if self.is_desktop_locked():
-            return {
-                "success": False,
-                "error": "Windows desktop is locked. Automation input is blocked by OS security."
-            }
         try:
             # use pynput for Unicode support
             self.keyboard.type(text)
@@ -526,6 +502,7 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         except Exception as e:
             return {"success": False, "error": str(e)}
 
+    @require_unlocked_desktop
     async def press_key(self, key: str) -> Dict[str, Any]:
         """Press and release a keyboard key.
 
@@ -535,11 +512,6 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         Returns:
             Dict[str, Any]: A dictionary with success status and optional error message.
         """
-        if self.is_desktop_locked():
-            return {
-                "success": False,
-                "error": "Windows desktop is locked. Automation input is blocked by OS security."
-            }
         try:
             k = self._key_from_string(key)
             if k is None:
@@ -550,6 +522,7 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         except Exception as e:
             return {"success": False, "error": str(e)}
 
+    @require_unlocked_desktop
     async def hotkey(self, keys: List[str]) -> Dict[str, Any]:
         """Press a combination of keys simultaneously.
 
@@ -559,11 +532,6 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         Returns:
             Dict[str, Any]: A dictionary with success status and optional error message.
         """
-        if self.is_desktop_locked():
-            return {
-                "success": False,
-                "error": "Windows desktop is locked. Automation input is blocked by OS security."
-            }
         try:
             # press keys sequentially while holding modifiers
             resolved = [self._key_from_string(k) for k in keys]
@@ -587,6 +555,7 @@ class WindowsAutomationHandler(BaseAutomationHandler):
             return {"success": False, "error": str(e)}
 
     # Scrolling Actions
+    @require_unlocked_desktop
     async def scroll(self, x: int, y: int) -> Dict[str, Any]:
         """Scroll vertically at the current cursor position.
 
@@ -597,17 +566,13 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         Returns:
             Dict[str, Any]: A dictionary with success status and optional error message.
         """
-        if self.is_desktop_locked():
-            return {
-                "success": False,
-                "error": "Windows desktop is locked. Automation input is blocked by OS security."
-            }
         try:
             self.mouse.scroll(x, y)
             return {"success": True}
         except Exception as e:
             return {"success": False, "error": str(e)}
 
+    @require_unlocked_desktop
     async def scroll_down(self, clicks: int = 1) -> Dict[str, Any]:
         """Scroll down by the specified number of clicks.
 
@@ -617,11 +582,6 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         Returns:
             Dict[str, Any]: A dictionary with success status and optional error message.
         """
-        if self.is_desktop_locked():
-            return {
-                "success": False,
-                "error": "Windows desktop is locked. Automation input is blocked by OS security."
-            }
         try:
             # negative y to scroll down
             self.mouse.scroll(0, -abs(clicks))
@@ -629,6 +589,7 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         except Exception as e:
             return {"success": False, "error": str(e)}
 
+    @require_unlocked_desktop
     async def scroll_up(self, clicks: int = 1) -> Dict[str, Any]:
         """Scroll up by the specified number of clicks.
 
@@ -638,11 +599,6 @@ class WindowsAutomationHandler(BaseAutomationHandler):
         Returns:
             Dict[str, Any]: A dictionary with success status and optional error message.
         """
-        if self.is_desktop_locked():
-            return {
-                "success": False,
-                "error": "Windows desktop is locked. Automation input is blocked by OS security."
-            }
         try:
             self.mouse.scroll(0, abs(clicks))
             return {"success": True}
@@ -650,6 +606,7 @@ class WindowsAutomationHandler(BaseAutomationHandler):
             return {"success": False, "error": str(e)}
 
     # Screen Actions
+    @require_unlocked_desktop
     async def screenshot(self) -> Dict[str, Any]:
         """Capture a screenshot of the entire screen.
 


### PR DESCRIPTION
## Summary

- Replaces 15+ duplicated 5-line lock check blocks with a single `@require_unlocked_desktop` decorator
- Adds the missing lock check to `screenshot()` method (which was mentioned in the original issue #794 but not covered in #808)
- Net reduction of 43 lines of code while adding functionality

This is a follow-up cleanup to PR #808 which introduced locked desktop detection but had significant code duplication.

## Test plan

- [ ] Verify existing tests pass
- [ ] Manual testing on Windows with locked desktop should still return the explicit error message
- [ ] Verify screenshot() now also returns an error when desktop is locked