### PR TITLE
Remove all pylume and is_lume_package references from codebase

### DIFF
--- a/.github/workflows/py-reusable-publish.yml
+++ b/.github/workflows/py-reusable-publish.yml
@@ -15,20 +15,10 @@ on:
         description: "Version to publish"
         required: true
         type: string
-      is_lume_package:
-        description: "Whether this package includes the lume binary"
-        required: false
-        type: boolean
-        default: false
       base_package_name:
         description: "PyPI package name (e.g. cua-agent)"
         required: true
         type: string
-      make_latest:
-        description: "Whether to mark this release as latest (should only be true for lume)"
-        required: false
-        type: boolean
-        default: false
     secrets:
       PYPI_TOKEN:
         required: true
@@ -100,40 +90,6 @@ jobs:
             pdm lock
           fi
 
-      # Conditional step for lume binary download (only for pylume package)
-      - name: Download and setup lume binary
-        if: inputs.is_lume_package
-        run: |
-          # Create a temporary directory for extraction
-          mkdir -p temp_lume
-
-          # Download the latest lume release directly
-          echo "Downloading latest lume version..."
-          curl -sL "https://github.com/trycua/lume/releases/latest/download/lume.tar.gz" -o temp_lume/lume.tar.gz
-
-          # Extract the tar file (ignore ownership and suppress warnings)
-          cd temp_lume && tar --no-same-owner -xzf lume.tar.gz
-
-          # Make the binary executable
-          chmod +x lume
-
-          # Copy the lume binary to the correct location in the pylume package
-          mkdir -p "${GITHUB_WORKSPACE}/${{ inputs.package_dir }}/pylume"
-          cp lume "${GITHUB_WORKSPACE}/${{ inputs.package_dir }}/pylume/lume"
-
-          # Verify the binary exists and is executable
-          test -x "${GITHUB_WORKSPACE}/${{ inputs.package_dir }}/pylume/lume" || { echo "lume binary not found or not executable"; exit 1; }
-
-          # Get the version from the downloaded binary for reference
-          LUME_VERSION=$(./lume --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
-          echo "Using lume version: $LUME_VERSION"
-
-          # Cleanup
-          cd "${GITHUB_WORKSPACE}" && rm -rf temp_lume
-
-          # Save the lume version for reference
-          echo "LUME_VERSION=${LUME_VERSION}" >> $GITHUB_ENV
-
       - name: Build and publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
@@ -142,18 +98,7 @@ jobs:
           # Build with PDM
           pdm build
 
-          # For pylume package, verify the binary is in the wheel
-          if [ "${{ inputs.is_lume_package }}" = "true" ]; then
-            python -m pip install wheel
-            wheel unpack dist/*.whl --dest temp_wheel
-            echo "Listing contents of wheel directory:"
-            find temp_wheel -type f
-            test -f temp_wheel/pylume-*/pylume/lume || { echo "lume binary not found in wheel"; exit 1; }
-            rm -rf temp_wheel
-            echo "Publishing ${{ inputs.base_package_name }} ${VERSION} with lume ${LUME_VERSION}"
-          else
-            echo "Publishing ${{ inputs.base_package_name }} ${VERSION}"
-          fi
+          echo "Publishing ${{ inputs.base_package_name }} ${VERSION}"
 
           # Install and use twine directly instead of PDM publish
           echo "Installing twine for direct publishing..."

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ dry-run-major-%: ## Dry run for major version bump (e.g., make dry-run-major-cor
 show-versions: ## Show current versions of all packages
 	@echo "Current Python package versions:"
 	@echo "  cua-core:           $$(grep 'current_version' libs/python/core/.bumpversion.cfg | cut -d' ' -f3)"
-	@echo "  pylume:             $$(grep 'current_version' libs/python/pylume/.bumpversion.cfg | cut -d' ' -f3)"
 	@echo "  cua-computer:       $$(grep 'current_version' libs/python/computer/.bumpversion.cfg | cut -d' ' -f3)"
 	@echo "  cua-som:            $$(grep 'current_version' libs/python/som/.bumpversion.cfg | cut -d' ' -f3)"
 	@echo "  cua-agent:          $$(grep 'current_version' libs/python/agent/.bumpversion.cfg | cut -d' ' -f3)"

--- a/libs/python/agent/agent/ui/gradio/app.py
+++ b/libs/python/agent/agent/ui/gradio/app.py
@@ -99,9 +99,8 @@ def save_settings(settings: Dict[str, Any]):
 
 # Detect platform capabilities
 is_mac = platform.system().lower() == "darwin"
-is_lume_available = is_mac or (os.environ.get("PYLUME_HOST", "localhost") != "localhost")
+is_lume_available = is_mac
 
-print("PYLUME_HOST: ", os.environ.get("PYLUME_HOST", "localhost"))
 print("is_mac: ", is_mac)
 print("Lume available: ", is_lume_available)
 

--- a/libs/python/computer/computer/computer.py
+++ b/libs/python/computer/computer/computer.py
@@ -108,7 +108,7 @@ class Computer:
         provider_port: Optional[int] = 7777,
         noVNC_port: Optional[int] = 8006,
         api_port: Optional[int] = None,
-        host: str = os.environ.get("PYLUME_HOST", "localhost"),
+        host: str = "localhost",
         api_host: Optional[str] = None,
         storage: Optional[str] = None,
         ephemeral: bool = False,

--- a/libs/python/mcp-server/scripts/start_mcp_server.sh
+++ b/libs/python/mcp-server/scripts/start_mcp_server.sh
@@ -29,7 +29,7 @@ if [[ -z "${PYTHON_PATH}" ]]; then
 fi
 
 # --- Export PYTHONPATH so module imports work during dev ---
-export PYTHONPATH="$CUA_REPO_DIR/libs/python/mcp-server:$CUA_REPO_DIR/libs/python/agent:$CUA_REPO_DIR/libs/python/computer:$CUA_REPO_DIR/libs/python/core:$CUA_REPO_DIR/libs/python/pylume"
+export PYTHONPATH="$CUA_REPO_DIR/libs/python/mcp-server:$CUA_REPO_DIR/libs/python/agent:$CUA_REPO_DIR/libs/python/computer:$CUA_REPO_DIR/libs/python/core"
 
 # --- Helpful startup log for Claude's mcp.log ---
 >&2 echo "[cua-mcp] using python: $PYTHON_PATH"

--- a/libs/python/mcp-server/scripts/test_mcp_server.sh
+++ b/libs/python/mcp-server/scripts/test_mcp_server.sh
@@ -29,7 +29,7 @@ $PYTHON --version
 echo ""
 
 # Set up environment
-export PYTHONPATH="$CUA_REPO_DIR/libs/python/mcp-server:$CUA_REPO_DIR/libs/python/agent:$CUA_REPO_DIR/libs/python/computer:$CUA_REPO_DIR/libs/python/core:$CUA_REPO_DIR/libs/python/pylume"
+export PYTHONPATH="$CUA_REPO_DIR/libs/python/mcp-server:$CUA_REPO_DIR/libs/python/agent:$CUA_REPO_DIR/libs/python/computer:$CUA_REPO_DIR/libs/python/core"
 export CUA_MODEL_NAME="${CUA_MODEL_NAME:-anthropic/claude-sonnet-4-5-20250929}"
 
 echo "Environment:"

--- a/scripts/run-docker-dev.sh
+++ b/scripts/run-docker-dev.sh
@@ -73,7 +73,6 @@ case "$1" in
                 -v "$(pwd):/app" \
                 -e PYTHONPATH=${PYTHONPATH} \
                 -e DISPLAY=${DISPLAY:-:0} \
-                -e PYLUME_HOST="host.docker.internal" \
                 -p 7860:7860 \
                 ${IMAGE_NAME} bash
         else
@@ -91,7 +90,6 @@ case "$1" in
                 -v "$(pwd):/app" \
                 -e PYTHONPATH=${PYTHONPATH} \
                 -e DISPLAY=${DISPLAY:-:0} \
-                -e PYLUME_HOST="host.docker.internal" \
                 -p 7860:7860 \
                 ${IMAGE_NAME} python "/app/examples/$2"
         fi


### PR DESCRIPTION
## Summary
- Removes all stale references to the `pylume` package which no longer exists in `libs/python/`
- Cleans up `PYLUME_HOST` environment variable usage from Docker scripts, computer.py, and gradio app
- Removes `is_lume_package` and `make_latest` workflow inputs from the reusable publish workflow
- Removes the lume binary download step from the publish workflow
- Updates all 8 CD workflows to remove `is_lume_package: false` parameter

## Test plan
- [ ] Verify `make show-versions` works without errors
- [ ] Verify Docker dev container runs without PYLUME_HOST references
- [ ] Verify MCP server scripts run with updated PYTHONPATH
- [ ] Verify CI publish workflow still functions for existing packages