### PR TITLE
fix(lume): clean up stale session files on VM list

### DIFF
--- a/libs/lume/src/Utils/NetworkUtils.swift
+++ b/libs/lume/src/Utils/NetworkUtils.swift
@@ -55,4 +55,27 @@ enum NetworkUtils {
     static func isSSHAvailable(ipAddress: String) -> Bool {
         return isPortOpen(ipAddress: ipAddress, port: 22, timeout: 2)
     }
-} 
+
+    /// Checks if a local port has a process listening on it
+    /// Uses lsof which is fast for local port checks
+    /// - Parameter port: The port number to check
+    /// - Returns: true if a process is listening on the port, false otherwise
+    static func isLocalPortInUse(port: UInt16) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
+        process.arguments = ["-i", ":\(port)", "-sTCP:LISTEN"]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            // lsof returns 0 if it finds a matching process
+            return process.terminationStatus == 0
+        } catch {
+            return false
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fix `lume ls` hanging when stale session files exist from crashed/killed lume processes.

## Problem

When lume crashes or is killed (`kill -9`) without proper cleanup, session files (`sessions.json`) are left behind. When `lume ls` runs, it sees these files, assumes the VM is running, and tries network operations (DHCP lookup, SSH check) that hang or timeout.

## Solution

Validate session files before assuming a VM is running:

1. Parse the VNC port from the session URL
2. Check if a process is actually listening on that port (using `lsof`)
3. If not, automatically clean up the stale session file

## Changes

- `NetworkUtils.swift`: Add `isLocalPortInUse()` function using `lsof`
- `LumeController.swift`: Add `parseVNCPort()` helper
- `LumeController.swift`: Validate sessions in `getVMDetailsLightweight()` before marking VM as running

## Test plan

1. Start a VM with `lume run`
2. Kill lume with `kill -9` (leaving stale session file)
3. Run `lume ls` - should show VM as "stopped" and log "Cleaned up stale session file"