### PR TITLE
fix(lume): show provisioning status in lume get and improve MCP docs

### DIFF
--- a/docs/content/docs/lume/guide/advanced/mcp-server.mdx
+++ b/docs/content/docs/lume/guide/advanced/mcp-server.mdx
@@ -29,13 +29,28 @@ Lume supports the [Model Context Protocol (MCP)](https://modelcontextprotocol.io
 
 ### 1. Configure Claude Desktop
 
-Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+Run this command to automatically configure Claude Desktop:
+
+```bash
+mkdir -p ~/Library/Application\ Support/Claude && cat > ~/Library/Application\ Support/Claude/claude_desktop_config.json << EOF
+{
+  "mcpServers": {
+    "lume": {
+      "command": "$(which lume)",
+      "args": ["serve", "--mcp"]
+    }
+  }
+}
+EOF
+```
+
+Or manually edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 ```json
 {
   "mcpServers": {
     "lume": {
-      "command": "lume",
+      "command": "/Users/yourname/.local/bin/lume",
       "args": ["serve", "--mcp"]
     }
   }
@@ -43,7 +58,7 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
 ```
 
 <Callout type="info">
-If `lume` isn't in your PATH, use the full path: `/Users/yourname/.local/bin/lume`
+If editing manually, replace `/Users/yourname/.local/bin/lume` with the actual path to your lume binary. You can find it by running `which lume` in your terminal.
 </Callout>
 
 ### 2. Restart Claude Desktop

--- a/libs/lume/src/Commands/Get.swift
+++ b/libs/lume/src/Commands/Get.swift
@@ -21,7 +21,7 @@ struct Get: AsyncParsableCommand {
     @MainActor
     func run() async throws {
         let vmController = LumeController()
-        let vm = try vmController.get(name: name, storage: storage)
-        try VMDetailsPrinter.printStatus([vm.details], format: self.format)
+        let vmDetails = try vmController.getDetails(name: name, storage: storage)
+        try VMDetailsPrinter.printStatus([vmDetails], format: self.format)
     }
 }


### PR DESCRIPTION
## Summary

- **Fix `lume get` provisioning status**: Added `getDetails()` method to `LumeController` that uses the lightweight path (same as `lume ls`) to show accurate VM status including provisioning state
- **Improve MCP docs**: Updated Claude Desktop config to use full path by default, added one-liner setup command that auto-detects lume path via `which lume`

## Changes

### LumeController.swift
- Added new public `getDetails(name:storage:)` method that returns `VMDetails` using `getVMDetailsLightweight()` internally
- This ensures consistent status reporting between `lume get` and `lume ls`

### Get.swift
- Changed to use `vmController.getDetails()` instead of `vmController.get().details`
- Cleaner and more direct approach

### mcp-server.mdx
- Added one-liner bash command to auto-configure Claude Desktop:
  ```bash
  mkdir -p ~/Library/Application\ Support/Claude && cat > ~/Library/Application\ Support/Claude/claude_desktop_config.json << EOF
  {
    "mcpServers": {
      "lume": {
        "command": "$(which lume)",
        "args": ["serve", "--mcp"]
      }
    }
  }
  EOF
  ```
- Updated manual config example to use full path
- Updated callout to explain how to find the actual path

## Test plan

- [ ] Verify `lume get <vm-name>` shows "provisioning" status for VMs being created
- [ ] Verify `lume ls` and `lume get` show consistent status
- [ ] Test MCP setup command on fresh Claude Desktop installation