### PR TITLE
fix(lume): make MCP server runVM non-blocking

### DIFF
--- a/libs/lume/src/Server/MCPServer.swift
+++ b/libs/lume/src/Server/MCPServer.swift
@@ -572,17 +572,33 @@ final class LumeMCPServer {
             sharedDirectories.append(SharedDirectory(hostPath: expandedPath, tag: "shared", readOnly: false))
         }
 
-        try await controller.runVM(
-            name: name,
-            noDisplay: noDisplay,
-            sharedDirectories: sharedDirectories,
-            storage: storage
-        )
+        // Run VM in detached task to avoid blocking (same pattern as HTTP API)
+        Task.detached { @MainActor @Sendable in
+            do {
+                let vmController = LumeController()
+                try await vmController.runVM(
+                    name: name,
+                    noDisplay: noDisplay,
+                    sharedDirectories: sharedDirectories,
+                    storage: storage
+                )
+            } catch {
+                Logger.error(
+                    "Failed to start VM in background task",
+                    metadata: [
+                        "name": name,
+                        "error": error.localizedDescription,
+                    ])
+            }
+        }
+
+        // Wait briefly for VM to initialize and get IP
+        try await Task.sleep(nanoseconds: 2_000_000_000)  // 2 seconds
 
         // Get VM details after starting to return IP
-        let vm = try controller.get(name: name, storage: storage)
+        let vmDetails = try controller.getDetails(name: name, storage: storage)
         var response = "VM '\(name)' started successfully."
-        if let ip = vm.details.ipAddress {
+        if let ip = vmDetails.ipAddress {
             response += "\nIP Address: \(ip)"
             response += "\nSSH: ssh lume@\(ip) (password: lume)"
         }


### PR DESCRIPTION
## Summary

The MCP server's `handleRunVM` was directly awaiting `controller.runVM()` which blocks forever (VM.run has an infinite loop to keep the VM alive). This caused MCP clients to timeout waiting for a response.

## Changes

- Use `Task.detached` pattern (same as HTTP API in `Handlers.swift`) to run VM in background
- Wait 2 seconds for VM to initialize before returning
- Use `getDetails()` to get VM status including IP address

This matches the HTTP API behavior where the run call returns immediately while the VM continues running in the background.

## Test plan

- [ ] Test `lume run` via MCP server returns immediately
- [ ] Verify VM actually starts and runs
- [ ] Verify IP address is returned in response