### PR TITLE
Fix the links to Claude's documentation in the documentation

### DIFF
--- a/blog/bringing-computer-use-to-the-web.md
+++ b/blog/bringing-computer-use-to-the-web.md
@@ -45,7 +45,7 @@ At the time of writing, the **computer-use-preview** model has limited availabil
 - Cannot be used in the OpenAI Playground
 - Outside of ChatGPT Operator, usage is restricted to the new **Responses API**
 
-Luckily, the `@trycua/computer` library can be used in conjunction with other models, like [Anthropic’s Computer Use](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/computer-use-tool) or [UI-TARS](https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B). You’ll just have to write your own handler to parse the model output for interfacing with the container.
+Luckily, the `@trycua/computer` library can be used in conjunction with other models, like [Anthropic’s Computer Use](https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool) or [UI-TARS](https://huggingface.co/ByteDance-Seed/UI-TARS-1.5-7B). You’ll just have to write your own handler to parse the model output for interfacing with the container.
 
 ### Cua Cloud Containers
 

--- a/blog/build-your-own-operator-on-macos-2.md
+++ b/blog/build-your-own-operator-on-macos-2.md
@@ -163,7 +163,7 @@ The `cua-agent` framework provides multiple agent loop implementations to abstra
 
 - **OpenAI Loop**: Uses the Responses API with a specific `computer_call_output` format for sending screenshots after actions. Requires handling safety checks and maintains a chain of requests using `previous_response_id`.
 
-- **Anthropic Loop**: Implements a [multi-agent loop pattern](https://docs.anthropic.com/en/docs/agents-and-tools/computer-use#understanding-the-multi-agent-loop) with a sophisticated message handling system, supporting various API providers (Anthropic, Bedrock, Vertex) with token management and prompt caching capabilities.
+- **Anthropic Loop**: Implements a [multi-agent loop pattern](https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool#understanding-the-multi-agent-loop) with a sophisticated message handling system, supporting various API providers (Anthropic, Bedrock, Vertex) with token management and prompt caching capabilities.
 
 - **UI-TARS Loop**: Requires custom message formatting and specialized parsing to extract actions from text responses using a "box token" system for UI element identification.
 
@@ -191,7 +191,7 @@ The performance of different Computer-Use models varies significantly across tas
 
 - **AgentLoop.OPENAI**: Choose when you have OpenAI Tier 3 access and need the most capable computer-use agent for web-based tasks. Uses the same [OpenAI Computer-Use Loop](https://platform.openai.com/docs/guides/tools-computer-use) as Part 1, delivering strong performance on browser-based benchmarks.
 
-- **AgentLoop.ANTHROPIC**: Ideal for users with Anthropic API access who need strong reasoning capabilities with computer-use abilities. Works with `claude-sonnet-4-5-20250929` and `claude-3-7-sonnet-20250219` models following [Anthropic's Computer-Use tools](https://docs.anthropic.com/en/docs/agents-and-tools/computer-use#understanding-the-multi-agent-loop).
+- **AgentLoop.ANTHROPIC**: Ideal for users with Anthropic API access who need strong reasoning capabilities with computer-use abilities. Works with `claude-sonnet-4-5-20250929` and `claude-3-7-sonnet-20250219` models following [Anthropic's Computer-Use tools](https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool#understanding-the-multi-agent-loop).
 
 - **AgentLoop.UITARS**: Best for scenarios requiring more powerful OS/desktop, and latency-sensitive automation, as UI-TARS-1.5 leads in OS capabilities benchmarks. Requires running the model locally or accessing it through compatible endpoints (e.g. on Hugging Face).
 
@@ -677,6 +677,6 @@ With the basics covered, you might want to explore:
 - [cua-agent GitHub repository](https://github.com/trycua/cua/tree/main/libs/python/agent)
 - [Agent Notebook Examples](https://github.com/trycua/cua/blob/main/notebooks/agent_nb.ipynb)
 - [OpenAI Agent SDK Specification](https://platform.openai.com/docs/api-reference/responses)
-- [Anthropic API Documentation](https://docs.anthropic.com/en/api/getting-started)
+- [Anthropic API Documentation](https://platform.claude.com/docs/en/api/overview)
 - [UI-TARS GitHub](https://github.com/ByteDance/UI-TARS)
 - [OmniParser GitHub](https://github.com/microsoft/OmniParser)

--- a/docs/content/docs/lume/examples/claude-code/sandbox.mdx
+++ b/docs/content/docs/lume/examples/claude-code/sandbox.mdx
@@ -5,7 +5,7 @@ description: Run Claude Code CLI safely in an isolated macOS VM
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-Run [Claude Code](https://docs.anthropic.com/en/docs/claude-code) on your host while it executes commands inside a sandboxed macOS VM via SSH. No MCP required—just the `lume` CLI and SSH.
+Run [Claude Code](https://code.claude.com/docs) on your host while it executes commands inside a sandboxed macOS VM via SSH. No MCP required—just the `lume` CLI and SSH.
 
 ## Why sandbox Claude Code?
 
@@ -73,7 +73,7 @@ curl -fsSL https://claude.ai/install.sh | bash
 brew install --cask claude-code
 ```
 
-See [Claude Code docs](https://docs.anthropic.com/en/docs/claude-code) for other installation methods.
+See [Claude Code docs](https://code.claude.com/docs) for other installation methods.
 
 ## Step 5: Use Claude Code with the sandbox
 
@@ -178,4 +178,4 @@ But it can:
 - [Homebrew Testing](/lume/examples/claude-code/homebrew-testing) — Test packages in a clean environment
 - [Claude Cowork with MCP](/lume/examples/claude-cowork/sandbox) — Use MCP for native VM integration
 - [Unattended Setup](/lume/guide/fundamentals/unattended-setup) — Customize the VM configuration
-- [Claude Code docs](https://docs.anthropic.com/en/docs/claude-code) — Learn more about Claude Code's capabilities
+- [Claude Code docs](https://code.claude.com/docs) — Learn more about Claude Code's capabilities

--- a/libs/python/agent/agent/loops/anthropic.py
+++ b/libs/python/agent/agent/loops/anthropic.py
@@ -683,7 +683,7 @@ def _convert_completion_to_responses_items(response: Any) -> List[Dict[str, Any]
                         action_type = tool_input.get("action")
 
                         # Action reference:
-                        # https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/computer-use-tool#available-actions
+                        # https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool#available-actions
 
                         try:
                             # Basic actions (all versions)


### PR DESCRIPTION
Hi! 👋 

I was reading the documentation on [setting up Claude Code and Lume](https://cua.ai/docs/lume/examples/claude-code/sandbox), and I noticed that some links related to Claude are broken (e.g., https://platform.claude.com/docs/en/docs/claude-code). This PR is to update these links.

Thanks!