### PR TITLE
fix(agent): accept 'computer_use' as valid function name for Fara model

### DIFF
--- a/libs/python/agent/agent/responses.py
+++ b/libs/python/agent/agent/responses.py
@@ -717,7 +717,7 @@ def convert_completion_messages_to_responses_items(
                     function = tool_call.get("function", {})
                     function_name = function.get("name")
 
-                    if function_name == "computer":
+                    if function_name in ("computer", "computer_use"):
                         # Parse computer action
                         try:
                             action = json.loads(function.get("arguments", "{}"))


### PR DESCRIPTION
## Summary

- Fix Fara model tool calls being treated as regular function calls instead of computer calls
- The Fara model sometimes outputs `computer_use` instead of `computer` as the function name
- This caused computer actions to silently fail and the agent loop to spin indefinitely

## Problem

When using the Fara model (`cua/microsoft/fara-7b`), the playground would spin indefinitely and `test_fara.py` would get stuck repeating the same message without executing any computer actions.

**Investigation findings:**
1. The Modal inference endpoint was responding correctly (200 OK, ~1-2s response time)
2. The model was generating valid tool calls with `<tool_call>` XML tags
3. Tool calls were being parsed correctly
4. However, actions were not being executed

**Root cause:**
The Fara model outputs the function name as `"computer_use"` in some cases, but `convert_completion_messages_to_responses_items()` in `responses.py` only checked for `function_name == "computer"`. This caused tool calls to fall through to the regular function call handler, which then failed silently because there was no function named `computer_use` registered.

## Fix

Updated the function name check to accept both valid names:

```python
# Before
if function_name == "computer":

# After  
if function_name in ("computer", "computer_use"):
```

## Test plan

- [x] Run `test_fara.py` - now executes computer actions (visit_url, type, click)
- [ ] Test Fara model in playground - should no longer spin indefinitely

🤖 Generated with [Claude Code](https://claude.com/claude-code)