### PR TITLE
feat(lume): simplify provisioning markers and rename default storage to home

### DIFF
--- a/libs/lume/src/ContainerRegistry/ImageContainerRegistry.swift
+++ b/libs/lume/src/ContainerRegistry/ImageContainerRegistry.swift
@@ -746,7 +746,7 @@ class ImageContainerRegistry: ImageRegistry, @unchecked Sendable {
             metadata: [
                 "image": image,
                 "name": vmName,
-                "location": locationName ?? "default",
+                "location": locationName ?? "home",
                 "registry": registry,
                 "organization": organization,
             ])
@@ -1047,7 +1047,7 @@ class ImageContainerRegistry: ImageRegistry, @unchecked Sendable {
             "Moving files to VM directory",
             metadata: [
                 "destination": vmDir.dir.path,
-                "location": locationName ?? "default",
+                "location": locationName ?? "home",
             ])
 
         // Move files to final location

--- a/libs/lume/src/FileSystem/Settings.swift
+++ b/libs/lume/src/FileSystem/Settings.swift
@@ -20,9 +20,9 @@ struct LumeSettings: Codable, Sendable {
 
     static let defaultSettings = LumeSettings(
         vmLocations: [
-            VMLocation(name: "default", path: "~/.lume")
+            VMLocation(name: "home", path: "~/.lume")
         ],
-        defaultLocationName: "default",
+        defaultLocationName: "home",
         cacheDirectory: "~/.lume/cache",
         cachingEnabled: false,
         registry: .defaultConfig,
@@ -81,9 +81,9 @@ final class SettingsManager: @unchecked Sendable {
         // No settings file found, use defaults
         let defaultSettings = LumeSettings(
             vmLocations: [
-                VMLocation(name: "default", path: "~/.lume")
+                VMLocation(name: "home", path: "~/.lume")
             ],
-            defaultLocationName: "default",
+            defaultLocationName: "home",
             cacheDirectory: "~/.lume/cache",
             cachingEnabled: false,
             registry: .defaultConfig,
@@ -211,15 +211,15 @@ final class SettingsManager: @unchecked Sendable {
     func setHomeDirectory(path: String) throws {
         var settings = getSettings()
 
-        let defaultLocation = VMLocation(name: "default", path: path)
+        let defaultLocation = VMLocation(name: "home", path: path)
         try defaultLocation.validate()
 
         // Replace default location
-        if let index = settings.vmLocations.firstIndex(where: { $0.name == "default" }) {
+        if let index = settings.vmLocations.firstIndex(where: { $0.name == "home" }) {
             settings.vmLocations[index] = defaultLocation
         } else {
             settings.vmLocations.append(defaultLocation)
-            settings.defaultLocationName = "default"
+            settings.defaultLocationName = "home"
         }
 
         try saveSettings(settings)
@@ -313,7 +313,7 @@ final class SettingsManager: @unchecked Sendable {
         // This is a very basic YAML parser for our specific config format
         // A real implementation would use a proper YAML library
 
-        var defaultLocationName = "default"
+        var defaultLocationName = "home"
         var cacheDirectory = "~/.lume/cache"
         var cachingEnabled = false  // default to false to save disk space
         var telemetryEnabled = true  // default to true for anonymous usage tracking
@@ -482,7 +482,7 @@ final class SettingsManager: @unchecked Sendable {
 
         // Ensure at least one location exists
         if vmLocations.isEmpty {
-            vmLocations.append(VMLocation(name: "default", path: "~/.lume"))
+            vmLocations.append(VMLocation(name: "home", path: "~/.lume"))
         }
 
         // Build registry config

--- a/libs/lume/src/FileSystem/VMDirectory.swift
+++ b/libs/lume/src/FileSystem/VMDirectory.swift
@@ -198,6 +198,19 @@ extension VMDirectory {
 struct ProvisioningMarker: Codable {
     /// The type of operation being performed (e.g., "ipsw_install", "unattended_setup")
     let operation: String
+    /// When the provisioning started (Unix timestamp)
+    let startedAt: Double
+    
+    init(operation: String) {
+        self.operation = operation
+        self.startedAt = Date().timeIntervalSince1970
+    }
+    
+    /// Returns true if provisioning started more than the specified hours ago
+    func isStale(hours: Double = 8.0) -> Bool {
+        let elapsed = Date().timeIntervalSince1970 - startedAt
+        return elapsed > (hours * 3600)
+    }
 }
 
 extension VMDirectory {

--- a/libs/lume/src/LumeController.swift
+++ b/libs/lume/src/LumeController.swift
@@ -133,16 +133,37 @@ final class LumeController {
     private func getVMDetailsLightweight(vmDir: VMDirectory, locationName: String) -> VMDetails? {
         let vmName = vmDir.name
 
-        // Check provisioning marker FIRST - if present, VM is being created
+        // Check provisioning marker FIRST - if present, VM may be in creation
         if let marker = vmDir.loadProvisioningMarker() {
-            return vmDir.getDetails(
-                locationName: locationName,
-                status: "provisioning",
-                provisioningOperation: marker.operation,
-                vncUrl: nil,
-                ipAddress: nil,
-                sshAvailable: nil
-            )
+            // Check if VM is actually complete (has all required files)
+            // If complete, the marker is stale and should be auto-cleaned
+            let hasRequiredFiles = vmDir.diskPath.exists() && vmDir.nvramPath.exists()
+            
+            if hasRequiredFiles {
+                // VM is complete but marker wasn't cleaned up (e.g., after unattended setup)
+                // Auto-cleanup the stale marker
+                vmDir.clearProvisioningMarker()
+                Logger.info("Auto-cleaned stale provisioning marker for complete VM", metadata: ["name": vmName])
+                // Fall through to normal status check below
+            } else {
+                // VM is still being provisioned
+                let status = marker.isStale() ? "provisioning (stale)" : "provisioning"
+                if marker.isStale() {
+                    Logger.info("VM provisioning may be stuck", metadata: [
+                        "name": vmName,
+                        "operation": marker.operation,
+                        "hint": "If creation was interrupted, delete with: lume delete \(vmName)"
+                    ])
+                }
+                return vmDir.getDetails(
+                    locationName: locationName,
+                    status: status,
+                    provisioningOperation: marker.operation,
+                    vncUrl: nil,
+                    ipAddress: nil,
+                    sshAvailable: nil
+                )
+            }
         }
 
         // Check if VM is running via SharedVM cache (same-process fast path)
@@ -314,7 +335,7 @@ final class LumeController {
             Logger.error(
                 "Failed to get VM",
                 metadata: [
-                    "vmName": normalizedName, "storage": storage ?? "default",
+                    "vmName": normalizedName, "storage": storage ?? "home",
                     "error": error.localizedDescription,
                 ])
             // Re-throw the original error to preserve its type
@@ -343,7 +364,7 @@ final class LumeController {
             metadata: [
                 "name": name,
                 "os": os,
-                "location": storage ?? "default",
+                "location": storage ?? "home",
                 "disk_size": "\(diskSize / 1024 / 1024)MB",
                 "cpu_count": "\(cpuCount)",
                 "memory_size": "\(memorySize / 1024 / 1024)MB",
@@ -449,7 +470,7 @@ final class LumeController {
             metadata: [
                 "name": name,
                 "os": os,
-                "location": storage ?? "default",
+                "location": storage ?? "home",
                 "unattended": unattendedConfig != nil ? "yes" : "no",
             ])
 
@@ -559,7 +580,7 @@ final class LumeController {
             metadata: [
                 "name": name,
                 "os": os,
-                "location": storage ?? "default",
+                "location": storage ?? "home",
             ])
 
         let vm = try await createTempVMConfig(
@@ -607,12 +628,9 @@ final class LumeController {
 
         // Run unattended setup if config is provided
         if let config = unattendedConfig, os.lowercased() == "macos" {
-            // Update provisioning marker for unattended phase (only if async flow)
-            if vmDir != nil {
-                // Re-get the vmDir since we deleted and recreated it
-                let updatedVmDir = try home.getVMDirectory(name, storage: storage)
-                try updatedVmDir.saveProvisioningMarker(ProvisioningMarker(operation: "unattended_setup"))
-            }
+            // Note: We don't write a provisioning marker for unattended setup.
+            // The VM has disk + nvram at this point, so it's "running" during
+            // the setup automation, not "provisioning".
 
             // Wait for the installation VZVirtualMachine to fully release auxiliary storage locks.
             Logger.info("Waiting for installation resources to be released before unattended setup")
@@ -668,7 +686,7 @@ final class LumeController {
             "Running unattended setup",
             metadata: [
                 "name": normalizedName,
-                "storage": storage ?? "default",
+                "storage": storage ?? "home",
                 "bootWait": "\(config.bootWait)s",
                 "commands": "\(config.bootCommands.count)",
                 "debug": "\(debug)",
@@ -702,7 +720,7 @@ final class LumeController {
             "Deleting VM",
             metadata: [
                 "name": normalizedName,
-                "location": storage ?? "default",
+                "location": storage ?? "home",
             ])
 
         do {
@@ -757,7 +775,7 @@ final class LumeController {
             "Updating VM settings",
             metadata: [
                 "name": normalizedName,
-                "location": storage ?? "default",
+                "location": storage ?? "home",
                 "cpu": cpu.map { "\($0)" } ?? "unchanged",
                 "memory": memory.map { "\($0 / 1024 / 1024)MB" } ?? "unchanged",
                 "disk_size": diskSize.map { "\($0 / 1024 / 1024)MB" } ?? "unchanged",
@@ -850,7 +868,7 @@ final class LumeController {
                 "mount": mount?.path ?? "none",
                 "vnc_port": "\(vncPort)",
                 "recovery_mode": "\(recoveryMode)",
-                "storage_param": storage ?? "default", // Log the original param
+                "storage_param": storage ?? "home", // Log the original param
                 "usb_storage_devices": "\(usbMassStoragePaths?.count ?? 0)",
             ])
 
@@ -907,7 +925,7 @@ final class LumeController {
                 Logger.info(
                     "Using named storage location",
                     metadata: [
-                        "requested": storage ?? "default",
+                        "requested": storage ?? "home",
                         "actual": actualLocationName ?? "default",
                     ])
             }
@@ -1019,7 +1037,7 @@ final class LumeController {
                     "name": vmName,
                     "registry": registry,
                     "organization": organization,
-                    "location": storage ?? "default",
+                    "location": storage ?? "home",
                 ])
 
             try self.validatePullParameters(
@@ -1041,7 +1059,7 @@ final class LumeController {
                 "Setting new VM mac address",
                 metadata: [
                     "vm_name": vmName,
-                    "location": storage ?? "default",
+                    "location": storage ?? "home",
                 ])
 
             // Update MAC address in the cloned VM to ensure uniqueness
@@ -1055,7 +1073,7 @@ final class LumeController {
                     "name": vmName,
                     "registry": registry,
                     "organization": organization,
-                    "location": storage ?? "default",
+                    "location": storage ?? "home",
                 ])
         } catch {
             Logger.error("Failed to pull image", metadata: ["error": error.localizedDescription])
@@ -1085,7 +1103,7 @@ final class LumeController {
                     "tags": "\(tags.joined(separator: ", "))",
                     "registry": registry,
                     "organization": organization,
-                    "location": storage ?? "default",
+                    "location": storage ?? "home",
                     "chunk_size": "\(chunkSizeMb)MB",
                     "dry_run": "\(dryRun)",
                     "reassemble": "\(reassemble)",

--- a/libs/lume/src/Server/MCPServer.swift
+++ b/libs/lume/src/Server/MCPServer.swift
@@ -144,7 +144,7 @@ final class LumeMCPServer {
         ```
         lume_create_vm(name: "sandbox", unattended: "tahoe")
         ```
-        The tool returns immediately. Poll `lume_list_vms` to monitor progress—status changes from `provisioning (ipsw_install)` → `provisioning (unattended_setup)` → `stopped`.
+        The tool returns immediately. Poll `lume_list_vms` to monitor progress—status changes from `provisioning (ipsw_install)` → `running` (during unattended setup) → `stopped`.
 
         ### 3. Start the VM
         Start with optional shared directory for file access:
@@ -197,7 +197,7 @@ final class LumeMCPServer {
         | `stopped` | Ready to start |
         | `running` | VM is active |
         | `provisioning (ipsw_install)` | Installing macOS |
-        | `provisioning (unattended_setup)` | Running Setup Assistant |
+        | `running` | VM is running (including during unattended setup) |
 
         ## Limitations
         - Max 2 macOS VMs running simultaneously (Apple licensing)

--- a/libs/lume/src/VM/VM.swift
+++ b/libs/lume/src/VM/VM.swift
@@ -125,7 +125,7 @@ class VM {
             vncUrl: vncUrl,
             ipAddress: ipAddress,
             sshAvailable: sshAvailable,
-            locationName: vmDirContext.storage ?? "default"
+            locationName: vmDirContext.storage ?? "home"
         )
     }
 
@@ -753,7 +753,7 @@ class VM {
                     "\(ByteCountFormatter.string(fromByteCount: Int64(diskSize), countStyle: .file))",
                 "diskPermissions": diskPermissions,
                 "dirPermissions": dirPermsString,
-                "locationName": vmDirContext.storage ?? "default",
+                "locationName": vmDirContext.storage ?? "home",
             ])
 
         if !diskExists {


### PR DESCRIPTION
## Summary
1. **Simplify Provisioning Markers:**
   - Markers only used during IPSW install (before disk/nvram exist)
   - Removed "unattended_setup" marker - VM shows as "running" during setup
   - Auto-cleanup markers for VMs that have disk + nvram (complete VMs)
   - Stale warning (>8 hours) only for incomplete VMs

2. **VM State Logic:**
   - Has disk + nvram → VM is complete, shows normal status
   - Has marker but no disk/nvram → still provisioning
   - Running during unattended setup → shows as "running"

3. **Rename Default Storage:**
   - New installations use "home" instead of "default"
   - Reflects the ~/.lume location
   - Non-breaking for existing configs

## Test plan
- [ ] Test VM provisioning flow with unattended setup
- [ ] Verify stale marker warnings only appear for incomplete VMs
- [ ] Confirm existing "default" storage configs still work