### PR TITLE
fix(computer-server): make fastmcp a required dependency

### DIFF
--- a/libs/python/computer-server/pyproject.toml
+++ b/libs/python/computer-server/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "websockets>=12.0",
     "pywinctl>=0.4.1",
     "playwright>=1.40.0",
+    "fastmcp>=2.0,<3",
     # OS-specific runtime deps
     "pyobjc-framework-Cocoa>=10.1; sys_platform == 'darwin'",
     "pyobjc-framework-Quartz>=10.1; sys_platform == 'darwin'",
@@ -34,9 +35,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-mcp = [
-    "fastmcp>=2.0,<3"
-]
 macos = [
     "pyobjc-framework-Cocoa>=10.1",
     "pyobjc-framework-Quartz>=10.1",


### PR DESCRIPTION
## Summary
- Move fastmcp from optional to required dependencies in cua-computer-server
- MCP support is now available out of the box without needing `pip install cua-computer-server[mcp]`

## Test plan
- [ ] Verify `pip install cua-computer-server` includes fastmcp
- [ ] Verify MCP endpoint at `/mcp` works without additional installation