### PR TITLE
fix: resize MCP screenshots to max 2000px

### DIFF
--- a/libs/python/computer-server/computer_server/mcp_server.py
+++ b/libs/python/computer-server/computer_server/mcp_server.py
@@ -167,6 +167,14 @@ def create_mcp_server() -> FastMCP:
                     new_width = int(width * max_dimension / height)
                 img = img.resize((new_width, new_height), PILImage.Resampling.LANCZOS)
 
+            # Ensure max dimension <= 2000 for Claude API
+            API_MAX_DIM = 2000
+            width, height = img.size
+            if width > API_MAX_DIM or height > API_MAX_DIM:
+                scaling_factor = min(API_MAX_DIM / width, API_MAX_DIM / height)
+                new_size = (int(width * scaling_factor), int(height * scaling_factor))
+                img = img.resize(new_size, PILImage.Resampling.LANCZOS)
+
         # Convert to RGB if necessary (for JPEG compatibility)
         if img.mode in ('RGBA', 'P'):
             img = img.convert('RGB')


### PR DESCRIPTION
Problem:
The MCP server was returning screenshots exceeding Claude API max dimension (2000px), causing 400 errors.

Solution:
- Added a resize step before returning screenshots
- Images are scaled proportionally if width or height > 2000px
- Prevents API errors and preserves aspect ratio

Fixes #884 