### PR TITLE
docs: expand Apple Vz abbreviation to Apple Virtualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 </div>
 
-**Cua** is an open-source platform for building, benchmarking, and deploying agents that can use any computer, with isolated, self-hostable sandboxes (Docker, QEMU, Apple Vz).
+**Cua** is an open-source platform for building, benchmarking, and deploying agents that can use any computer, with isolated, self-hostable sandboxes (Docker, QEMU, Apple Virtualization).
 
 <div align="center">
   <video src="https://github.com/user-attachments/assets/c619b4ea-bb8e-4382-860e-f3757e36af20" width="600" controls></video>


### PR DESCRIPTION
## Summary
- Expands "Apple Vz" to "Apple Virtualization" in the README for clarity

## Test plan
- [x] Verify README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)