### PR TITLE
fix(xfce): add DHCP client for networking

### DIFF
--- a/libs/xfce/Dockerfile
+++ b/libs/xfce/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get update && apt-get install -y \
     zip \
     xdg-utils \
     gcc \
+    # DHCP client for networking
+    isc-dhcp-client \
     # Qt/XCB runtime deps for PyQt5 (libqxcb.so)
     libxcb-icccm4 \
     libxcb-image0 \

--- a/libs/xfce/Dockerfile.dev
+++ b/libs/xfce/Dockerfile.dev
@@ -23,6 +23,8 @@ RUN apt-get update && apt-get install -y \
     zip \
     xdg-utils \
     gcc \
+    # DHCP client for networking
+    isc-dhcp-client \
     # Qt/XCB runtime deps for PyQt5 (libqxcb.so)
     libxcb-icccm4 \
     libxcb-image0 \

--- a/libs/xfce/src/supervisor/supervisord.conf
+++ b/libs/xfce/src/supervisor/supervisord.conf
@@ -5,6 +5,15 @@ logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
 childlogdir=/var/log/supervisor
 
+[program:dhclient]
+command=/usr/sbin/dhclient -v eth0
+user=root
+autorestart=false
+startsecs=0
+stdout_logfile=/var/log/supervisor/dhclient.log
+stderr_logfile=/var/log/supervisor/dhclient.error.log
+priority=1
+
 [program:vncserver]
 command=/usr/local/bin/start-vnc.sh
 user=cua


### PR DESCRIPTION
## Summary
- Install `isc-dhcp-client` in both xfce Dockerfiles
- Add supervisor program to run `dhclient eth0` on container startup

This ensures the container gets an IPv4 address when running in environments that use DHCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)