### PR TITLE
fix(xfce): set HOME and environment vars in supervisor

### DIFF
--- a/libs/xfce/src/supervisor/supervisord.conf
+++ b/libs/xfce/src/supervisor/supervisord.conf
@@ -17,6 +17,7 @@ priority=1
 [program:vncserver]
 command=/usr/local/bin/start-vnc.sh
 user=cua
+environment=HOME="/home/cua",USER="cua",DISPLAY=":1"
 autorestart=true
 stdout_logfile=/var/log/supervisor/vncserver.log
 stderr_logfile=/var/log/supervisor/vncserver.error.log
@@ -25,6 +26,7 @@ priority=10
 [program:novnc]
 command=/usr/local/bin/start-novnc.sh
 user=cua
+environment=HOME="/home/cua",USER="cua"
 autorestart=true
 stdout_logfile=/var/log/supervisor/novnc.log
 stderr_logfile=/var/log/supervisor/novnc.error.log
@@ -33,6 +35,7 @@ priority=20
 [program:computer-server]
 command=/usr/local/bin/start-computer-server.sh
 user=cua
+environment=HOME="/home/cua",USER="cua",DISPLAY=":1"
 autorestart=true
 stdout_logfile=/var/log/supervisor/computer-server.log
 stderr_logfile=/var/log/supervisor/computer-server.error.log


### PR DESCRIPTION
## Summary
- When running in Incus containers, supervisor doesn't inherit environment variables
- VNC server fails with: `vncserver: The HOME environment variable must be set`
- Explicitly set HOME, USER, and DISPLAY for vncserver, novnc, and computer-server

🤖 Generated with [Claude Code](https://claude.com/claude-code)