### PR TITLE
Set environment variables for supervisor managed processes

### DIFF
--- a/libs/xfce/src/supervisor/supervisord.conf
+++ b/libs/xfce/src/supervisor/supervisord.conf
@@ -17,6 +17,7 @@ priority=1
 [program:vncserver]
 command=/usr/local/bin/start-vnc.sh
 user=cua
+environment=HOME="/home/cua",USER="cua",DISPLAY=":1"
 autorestart=true
 stdout_logfile=/var/log/supervisor/vncserver.log
 stderr_logfile=/var/log/supervisor/vncserver.error.log
@@ -25,6 +26,7 @@ priority=10
 [program:novnc]
 command=/usr/local/bin/start-novnc.sh
 user=cua
+environment=HOME="/home/cua",USER="cua"
 autorestart=true
 stdout_logfile=/var/log/supervisor/novnc.log
 stderr_logfile=/var/log/supervisor/novnc.error.log
@@ -33,6 +35,7 @@ priority=20
 [program:computer-server]
 command=/usr/local/bin/start-computer-server.sh
 user=cua
+environment=HOME="/home/cua",USER="cua",DISPLAY=":1"
 autorestart=true
 stdout_logfile=/var/log/supervisor/computer-server.log
 stderr_logfile=/var/log/supervisor/computer-server.error.log


### PR DESCRIPTION
## Summary
Add environment variable configuration to supervisor programs to ensure proper execution context for VNC and computer server services.

## Changes
- **vncserver**: Added `HOME`, `USER`, and `DISPLAY` environment variables
- **novnc**: Added `HOME` and `USER` environment variables
- **computer-server**: Added `HOME`, `USER`, and `DISPLAY` environment variables

## Details
These environment variables are essential for the proper functioning of the supervised processes:
- `HOME="/home/cua"` - Sets the home directory for the cua user
- `USER="cua"` - Explicitly sets the username
- `DISPLAY=":1"` - Specifies the X11 display for graphical applications (vncserver and computer-server)

This ensures that services have the correct user context and display configuration when started by supervisor, preventing potential issues with missing environment variables that could cause runtime failures.

https://claude.ai/code/session_018YpK4fgoYBuY5SQ88nQtGp