### PR TITLE
docs: add Cua-Bench partner interest form link

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ uv tool install -e . && cb image create linux-docker
 cb run dataset datasets/cua-bench-basic --agent cua-agent --max-parallel 4
 ```
 
-**[Get Started](https://cua.ai/docs/cuabench/guide/getting-started/first-steps)** | **[Registry](https://cuabench.ai/registry)** | **[CLI Reference](https://cua.ai/docs/cuabench/reference/cli-reference)**
+**[Get Started](https://cua.ai/docs/cuabench/guide/getting-started/first-steps)** | **[Partner With Us](https://cuabench.ai/)** | **[Registry](https://cuabench.ai/registry)** | **[CLI Reference](https://cua.ai/docs/cuabench/reference/cli-reference)**
 
 ---
 

--- a/docs/content/docs/cuabench/guide/getting-started/introduction.mdx
+++ b/docs/content/docs/cuabench/guide/getting-started/introduction.mdx
@@ -3,6 +3,10 @@ title: Introduction
 description: A benchmark to measure the capabilities of computer-use agents in desktop environments.
 ---
 
+<Callout type="info">
+  Building or researching computer-use agents? Fill out the [Interest Form](https://cuabench.ai/) to chat with us.
+</Callout>
+
 **Cua-Bench** is a framework and set of tasks for evaluating how well AI agents can accomplish complex tasks on a desktop computer using primarily the keyboard and mouse, or on a mobile device using primarily the touchscreen.
 
 <div className="not-prose relative rounded-xl overflow-hidden my-8 w-full">


### PR DESCRIPTION
## Summary
- Add "Partner With Us" link to the Cua-Bench section in README
- Add callout in the Cua-Bench docs introduction page pointing to cuabench.ai for research labs interested in partnering

## Test plan
- [ ] Verify README link renders correctly on GitHub
- [ ] Verify docs callout renders correctly on the docs site