### PR TITLE
fix(mcp-server): disable redirect for /mcp endpoint

### DIFF
--- a/libs/python/computer-server/computer_server/main.py
+++ b/libs/python/computer-server/computer_server/main.py
@@ -72,6 +72,7 @@ app = FastAPI(
     version="0.1.0",
     websocket_max_size=WEBSOCKET_MAX_SIZE,
     lifespan=_mcp_http_app.lifespan if _mcp_http_app else None,
+    redirect_slashes=False,
 )
 
 # CORS configuration


### PR DESCRIPTION
Fixes #883

Disable trailing-slash redirect so both /mcp and /mcp/ work without 307 redirects.
