### PR TITLE
[computer-server] Fix coordinate scaling initialization in MCP screenshot tool

### DIFF
--- a/libs/python/computer-server/computer_server/mcp_server.py
+++ b/libs/python/computer-server/computer_server/mcp_server.py
@@ -38,6 +38,7 @@ def _get_handlers():
     global _handlers
     if _handlers is None:
         from .handlers.factory import HandlerFactory
+
         _handlers = HandlerFactory.create_handlers()
     return _handlers
 
@@ -56,6 +57,7 @@ async def _detect_actual_resolution_async() -> Tuple[int, int]:
 def _detect_actual_resolution() -> Tuple[int, int]:
     """Detect the actual screen resolution (sync wrapper)."""
     import asyncio
+
     try:
         loop = asyncio.get_event_loop()
         if loop.is_running():
@@ -125,7 +127,7 @@ def create_mcp_server() -> FastMCP:
         type text, press keys, scroll, manage windows, read/write files, and run commands.
 
         Always take a screenshot first to see the current state before performing actions.
-        After performing actions, take another screenshot to verify the result."""
+        After performing actions, take another screenshot to verify the result.""",
     )
 
     # ============================================================
@@ -140,8 +142,9 @@ def create_mcp_server() -> FastMCP:
         Returns the current screen state as an image. Always call this first
         to see what's on screen before performing any actions.
         """
-        from PIL import Image as PILImage
         from io import BytesIO
+
+        from PIL import Image as PILImage
 
         _, automation_handler, _, _, _, _ = _get_handlers()
         result = await automation_handler.screenshot()
@@ -167,9 +170,14 @@ def create_mcp_server() -> FastMCP:
                     new_width = int(width * max_dimension / height)
                 img = img.resize((new_width, new_height), PILImage.Resampling.LANCZOS)
 
+                # Initialize coordinate scaling if not already configured
+                # This ensures clicks are properly scaled from resized space to actual device space
+                if not _target_width:
+                    _configure_scaling(target_width=new_width, target_height=new_height)
+
         # Convert to RGB if necessary (for JPEG compatibility)
-        if img.mode in ('RGBA', 'P'):
-            img = img.convert('RGB')
+        if img.mode in ("RGBA", "P"):
+            img = img.convert("RGB")
 
         # Use JPEG with quality setting to ensure small file size
         buffered = BytesIO()
@@ -218,11 +226,7 @@ def create_mcp_server() -> FastMCP:
         return result
 
     @mcp.tool
-    async def computer_click(
-        x: int,
-        y: int,
-        button: str = "left"
-    ) -> Dict[str, Any]:
+    async def computer_click(x: int, y: int, button: str = "left") -> Dict[str, Any]:
         """
         Click at the specified screen coordinates.
 
@@ -276,7 +280,7 @@ def create_mcp_server() -> FastMCP:
         end_x: int,
         end_y: int,
         button: str = "left",
-        duration: float = 0.5
+        duration: float = 0.5,
     ) -> Dict[str, Any]:
         """
         Drag from start coordinates to end coordinates.
@@ -295,14 +299,13 @@ def create_mcp_server() -> FastMCP:
         _, automation_handler, _, _, _, _ = _get_handlers()
         # Move to start position first
         await automation_handler.move_cursor(actual_start_x, actual_start_y)
-        return await automation_handler.drag_to(actual_end_x, actual_end_y, button=button, duration=duration)
+        return await automation_handler.drag_to(
+            actual_end_x, actual_end_y, button=button, duration=duration
+        )
 
     @mcp.tool
     async def computer_scroll(
-        x: int,
-        y: int,
-        scroll_x: int = 0,
-        scroll_y: int = 0
+        x: int, y: int, scroll_x: int = 0, scroll_y: int = 0
     ) -> Dict[str, Any]:
         """
         Scroll at the specified position.
@@ -321,9 +324,7 @@ def create_mcp_server() -> FastMCP:
 
     @mcp.tool
     async def computer_mouse_down(
-        x: Optional[int] = None,
-        y: Optional[int] = None,
-        button: str = "left"
+        x: Optional[int] = None, y: Optional[int] = None, button: str = "left"
     ) -> Dict[str, Any]:
         """
         Press and hold a mouse button.
@@ -342,9 +343,7 @@ def create_mcp_server() -> FastMCP:
 
     @mcp.tool
     async def computer_mouse_up(
-        x: Optional[int] = None,
-        y: Optional[int] = None,
-        button: str = "left"
+        x: Optional[int] = None, y: Optional[int] = None, button: str = "left"
     ) -> Dict[str, Any]:
         """
         Release a mouse button.
@@ -794,9 +793,7 @@ def create_mcp_server() -> FastMCP:
 
     @mcp.tool
     async def computer_find_element(
-        role: Optional[str] = None,
-        title: Optional[str] = None,
-        value: Optional[str] = None
+        role: Optional[str] = None, title: Optional[str] = None, value: Optional[str] = None
     ) -> Dict[str, Any]:
         """
         Find a UI element in the accessibility tree.


### PR DESCRIPTION
Related https://github.com/trycua/cua/issues/898 (Issue 2)

Fixes a critical bug where coordinates from grounding models were never scaled back to actual device resolution, causing clicks to land at completely wrong locations.

**The Problem:**
- MCP server auto-resizes screenshots (e.g., 1440x3040 → 606x1280) before sending to grounding models
- Grounding models predict coordinates in the resized space (e.g., `(414, 1069)`)
- These coordinates were sent directly to the device **without scaling**
- Clicks landed ~1575 pixels away from intended targets

**The Fix:**
- Call `_configure_scaling()` after auto-resize to initialize scale factors
- Coordinates are now properly scaled: `(414, 1069)` → `(983, 2538)`
- Clicks land at correct locations

**Changes:**
- `computer_server/mcp_server.py`: Added 4 lines after auto-resize logic to initialize coordinate scaling

---

## Visual Demonstration

### Original Screenshot (1440x3040)

<img src="https://github.com/user-attachments/assets/e56ebd64-8ae8-44ab-b3d5-b00675b6d8a8" width="300" alt="Original Android Screenshot">

*Android home screen with Chrome and Messages icons at the bottom*

---

## Reproduction & Testing

Run this script to visualize the bug and fix:

<details>
<summary>demo_coordinate_fix.py (click to expand)</summary>

```python
#!/usr/bin/env python3
# /// script
# dependencies = ["pillow"]
# ///
"""Demonstrates the coordinate scaling fix."""

from PIL import Image, ImageDraw, ImageFont

# MCP auto-resize logic
def resize_image(img, max_dim=1280):
    w, h = img.size
    if max(w, h) > max_dim:
        scale = max_dim / max(w, h)
        return img.resize((int(w * scale), int(h * scale)), Image.LANCZOS)
    return img

# Draw marker on image
def mark_point(img, x, y, label, color):
    draw = ImageDraw.Draw(img)
    # Crosshair
    s = 50
    draw.line([(x-s, y), (x+s, y)], fill=color, width=6)
    draw.line([(x, y-s), (x, y+s)], fill=color, width=6)
    draw.ellipse([(x-10, y-10), (x+10, y+10)], fill=color)
    # Label
    try:
        font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 36)
    except:
        font = ImageFont.load_default()
    bbox = draw.textbbox((0, 0), label, font=font)
    tw = bbox[2] - bbox[0]
    lx, ly = x + 70, y - 70
    draw.rectangle([lx-12, ly-12, lx+tw+12, ly+bbox[3]-bbox[1]+12],
                   fill=(255,255,0), outline=(0,0,0), width=4)
    draw.text((lx, ly), label, fill=(0,0,0), font=font)
    return img

# Load and process
original = Image.open("android_screenshot.png")
orig_w, orig_h = original.size
resized = resize_image(original.copy())
res_w, res_h = resized.size

# Chrome icon coordinates (from grounding model on resized image)
chrome_x, chrome_y = 414, 1069

# Calculate scale factors (what _configure_scaling() would do)
scale_x = orig_w / res_w
scale_y = orig_h / res_h

# WITHOUT FIX: coordinates sent directly (bug)
bug_x, bug_y = chrome_x, chrome_y

# WITH FIX: coordinates scaled to device space
fixed_x, fixed_y = int(chrome_x * scale_x), int(chrome_y * scale_y)

# Generate 3 images
mark_point(resized.copy(), chrome_x, chrome_y,
           "Model Predicts\n(414, 1069)", (0,150,255)).save("1_model_prediction.png")

mark_point(original.copy(), bug_x, bug_y,
           "Without Fix\n(414, 1069)\nWRONG", (255,50,50)).save("2_without_fix.png")

mark_point(original.copy(), fixed_x, fixed_y,
           f"With Fix\n({fixed_x}, {fixed_y})\nCORRECT", (50,255,50)).save("3_with_fix.png")

print(f"Original: {orig_w}x{orig_h} → Resized: {res_w}x{res_h}")
print(f"Scale: {scale_x:.2f}x, {scale_y:.2f}x")
print(f"Without fix: ({bug_x}, {bug_y}) - {((fixed_x-bug_x)**2+(fixed_y-bug_y)**2)**0.5:.0f}px off")
print(f"With fix: ({fixed_x}, {fixed_y}) - correct!")
print("Generated: 1_model_prediction.png, 2_without_fix.png, 3_with_fix.png")
```

</details>

**Run with:**
```bash
uv run demo_coordinate_fix.py
```

**Output:**
```
Original: 1440x3040 → Resized: 606x1280
Scale: 2.38x, 2.38x
Without fix: (414, 1069) - 1575px off
With fix: (983, 2538) - correct!
Generated: 1_model_prediction.png, 2_without_fix.png, 3_with_fix.png
```

---

## Results

### Coordinate Scaling Comparison

<table>
<tr>
<td width="33%">

**1. Model Prediction**
*(Resized 606x1280)*

<img src="https://github.com/user-attachments/assets/77eb3bdd-37a0-409a-ae6d-057a6b509f8c" width="300" alt="Model Prediction">

Grounding model sees resized screenshot and predicts Chrome icon at `(414, 1069)`

</td>
<td width="33%">

**2. Without Fix (Bug)**
*(Original 1440x3040)*

<img src="https://github.com/user-attachments/assets/382edb3f-48d9-4572-b9b1-0c7976203fb9" width="300" alt="Without Fix">

Coordinates sent directly to device: `(414, 1069)`
❌ Click lands **1575px away** from target

</td>
<td width="33%">

**3. With Fix**
*(Original 1440x3040)*

<img src="https://github.com/user-attachments/assets/5b5293ca-60cd-4e33-9aa3-6e9210f1f475" width="300" alt="With Fix">

Coordinates scaled to device: `(983, 2538)`
✅ Click lands **on Chrome icon**

</td>
</tr>
</table>

---

## Technical Details

**Before (Bug):**
```python
# Screenshot auto-resized but scaling never initialized
img = img.resize((new_width, new_height), PILImage.Resampling.LANCZOS)
# _scale_x and _scale_y remain at default 1.0
# Coordinates are NOT scaled when clicking
```

**After (Fixed):**
```python
# Screenshot auto-resized AND scaling initialized
img = img.resize((new_width, new_height), PILImage.Resampling.LANCZOS)

# Initialize coordinate scaling if not already configured
if not _target_width:
    _configure_scaling(target_width=new_width, target_height=new_height)
# Now _scale_x = 2.38, _scale_y = 2.38
# Coordinates are properly scaled: (414, 1069) * 2.38 = (983, 2538)
```

**Impact:**
- Fixes grounding model clicks on all platforms (Android, desktop, tablets)
- Most severe on high-resolution mobile devices (1440x3040, 1080x2340, etc.)
- Existing coordinate scaling infrastructure now actually works

