### PR TITLE
Organize imports alphabetically across codebase

### DIFF
--- a/docs/scripts/modal_app.py
+++ b/docs/scripts/modal_app.py
@@ -76,10 +76,12 @@ def init_otel(service_name: str = OTEL_SERVICE_NAME):
         service_name: Name of the service for OTEL resource
     """
     from opentelemetry import metrics
+    from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+        OTLPMetricExporter,
+    )
     from opentelemetry.sdk.metrics import MeterProvider
     from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
-    from opentelemetry.sdk.resources import Resource, SERVICE_NAME, SERVICE_VERSION
-    from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+    from opentelemetry.sdk.resources import SERVICE_NAME, SERVICE_VERSION, Resource
 
     resource = Resource.create({
         SERVICE_NAME: service_name,

--- a/libs/python/agent/agent/callbacks/__init__.py
+++ b/libs/python/agent/agent/callbacks/__init__.py
@@ -6,8 +6,8 @@ from .base import AsyncCallbackHandler
 from .budget_manager import BudgetManagerCallback
 from .image_retention import ImageRetentionCallback
 from .logging import LoggingCallback
-from .otel import OtelCallback, OtelErrorCallback
 from .operator_validator import OperatorNormalizerCallback
+from .otel import OtelCallback, OtelErrorCallback
 from .prompt_instructions import PromptInstructionsCallback
 from .telemetry import TelemetryCallback
 from .trajectory_saver import TrajectorySaverCallback

--- a/libs/python/computer-server/computer_server/handlers/macos.py
+++ b/libs/python/computer-server/computer_server/handlers/macos.py
@@ -73,7 +73,7 @@ except Exception as e:
 
 # Trigger screen recording prompt on macOS
 try:
-    from PIL import ImageGrab, Image
+    from PIL import Image, ImageGrab
 
     ImageGrab.grab()
 except Exception as e:

--- a/libs/python/computer-server/computer_server/mcp_server.py
+++ b/libs/python/computer-server/computer_server/mcp_server.py
@@ -140,8 +140,9 @@ def create_mcp_server() -> FastMCP:
         Returns the current screen state as an image. Always call this first
         to see what's on screen before performing any actions.
         """
-        from PIL import Image as PILImage
         from io import BytesIO
+
+        from PIL import Image as PILImage
 
         _, automation_handler, _, _, _, _ = _get_handlers()
         result = await automation_handler.screenshot()

--- a/libs/python/core/core/telemetry/__init__.py
+++ b/libs/python/core/core/telemetry/__init__.py
@@ -4,12 +4,6 @@ It provides a low-overhead way to collect anonymous usage data via PostHog,
 operational metrics via OpenTelemetry, and error tracking via Sentry.
 """
 
-from core.telemetry.posthog import (
-    destroy_telemetry_client,
-    is_telemetry_enabled,
-    record_event,
-)
-
 # OpenTelemetry instrumentation for Four Golden Signals
 from core.telemetry.otel import (
     create_span,
@@ -20,6 +14,11 @@ from core.telemetry.otel import (
     record_operation,
     record_tokens,
     track_concurrent,
+)
+from core.telemetry.posthog import (
+    destroy_telemetry_client,
+    is_telemetry_enabled,
+    record_event,
 )
 
 # Sentry error tracking

--- a/libs/python/mcp-server/mcp_server/otel.py
+++ b/libs/python/mcp-server/mcp_server/otel.py
@@ -5,24 +5,24 @@ Exports the Four Golden Signals: Latency, Traffic, Errors, Saturation
 Exporter endpoint: otel.cua.ai
 """
 
+import logging
 import os
 import time
-import logging
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional, Callable
 from functools import wraps
+from typing import Any, Callable, Dict, Optional
 
 # OpenTelemetry imports
 from opentelemetry import metrics, trace
-from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.sdk.resources import Resource, SERVICE_NAME, SERVICE_VERSION
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.metrics import Counter, Histogram, UpDownCounter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import SERVICE_NAME, SERVICE_VERSION, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 logger = logging.getLogger("mcp-server.otel")
 

--- a/libs/python/mcp-server/mcp_server/server.py
+++ b/libs/python/mcp-server/mcp_server/server.py
@@ -15,15 +15,15 @@ import anyio
 # Import OTEL instrumentation
 try:
     from .otel import (
-        initialize_otel,
-        shutdown_otel,
-        timed_tool_execution,
-        timed_task,
-        record_session_created,
-        record_session_closed,
-        record_session_error,
-        update_saturation,
         get_metrics,
+        initialize_otel,
+        record_session_closed,
+        record_session_created,
+        record_session_error,
+        shutdown_otel,
+        timed_task,
+        timed_tool_execution,
+        update_saturation,
     )
     OTEL_AVAILABLE = True
 except ImportError:


### PR DESCRIPTION
## Summary
This PR standardizes import organization across the codebase by sorting imports alphabetically within their respective groups, following PEP 8 conventions and improving code consistency.

## Key Changes
- **docs/scripts/modal_app.py**: Alphabetized OpenTelemetry imports and reordered resource imports
- **libs/python/agent/agent/callbacks/__init__.py**: Reordered callback imports alphabetically
- **libs/python/computer-server/computer_server/handlers/macos.py**: Sorted PIL imports alphabetically
- **libs/python/computer-server/computer_server/mcp_server.py**: Reorganized imports with proper grouping and blank line separation
- **libs/python/core/core/telemetry/__init__.py**: Moved posthog imports after otel imports for logical grouping
- **libs/python/mcp-server/mcp_server/otel.py**: Comprehensively reorganized all imports alphabetically within standard library, third-party, and local import groups
- **libs/python/mcp-server/mcp_server/server.py**: Alphabetized OTEL instrumentation imports

## Implementation Details
- Imports are organized following PEP 8 style guide: standard library → third-party → local imports
- Within each group, imports are sorted alphabetically
- Blank lines are maintained between import groups for readability
- Multi-line imports maintain alphabetical ordering of imported items

https://claude.ai/code/session_01F7MB1v4FhrWWzNpkkLarUV