### PR TITLE
fix(computer-server): add missing cua-core package

### DIFF
--- a/libs/python/computer-server/pyproject.toml
+++ b/libs/python/computer-server/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "python-xlib>=0.33; sys_platform == 'linux'",
     "pywin32>=310; sys_platform == 'win32'",
     "python-certifi-win32; sys_platform == 'win32'",
+    "cua-core",
 ]
 
 [project.optional-dependencies]
@@ -78,3 +79,6 @@ dev = [
 [tool.pdm.scripts]
 # Starts HTTP server with MCP at /mcp endpoint
 api = "python -m computer_server"
+
+[tool.uv.sources]
+cua-core = { workspace = true }


### PR DESCRIPTION
Running computer server is failing with `ModuleNotFoundError: No module named 'core'`:
```
$ uv run python -m computer_server
Traceback (most recent call last):
  File "<frozen runpy>", line 189, in _run_module_as_main
  File "<frozen runpy>", line 148, in _get_module_details
  File "<frozen runpy>", line 112, in _get_module_details
  File "D:\cua\cua-server-test\.venv\Lib\site-packages\computer_server\__init__.py", line 11, in <module>
    from .server import Server as Server  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\cua\cua-server-test\.venv\Lib\site-packages\computer_server\server.py", line 13, in <module>
    from .main import app as fastapi_app
  File "D:\cua\cua-server-test\.venv\Lib\site-packages\computer_server\main.py", line 16, in <module>
    from core.telemetry import record_event
ModuleNotFoundError: No module named 'core'
```

This is because `cua-core` was not added as a dependency when telemetry feature was introduced in https://github.com/trycua/cua/pull/915

This PR adds the `cua-core` package dependency to `cua-computer-server` to fix it.