### PR TITLE
Update Modal container configuration from keep_warm to min_containers

### DIFF
--- a/docs/scripts/modal_app.py
+++ b/docs/scripts/modal_app.py
@@ -1496,7 +1496,7 @@ async def scheduled_code_index():
     volumes={VOLUME_PATH: docs_volume, CODE_VOLUME_PATH: code_volume},
     cpu=1.0,
     memory=2048,
-    keep_warm=1,  # Keep one container warm to avoid cold start latency
+    min_containers=1,  # Keep one container warm to avoid cold start latency
 )
 @modal.concurrent(max_inputs=10)
 @modal.asgi_app(custom_domains=["docs-mcp.cua.ai"])


### PR DESCRIPTION
## Summary
Updated the Modal app configuration to use the `min_containers` parameter instead of the deprecated `keep_warm` parameter for the scheduled code index function.

## Changes
- Replaced `keep_warm=1` with `min_containers=1` in the Modal app decorator for `scheduled_code_index()`
- Maintained the same functionality and intent: ensuring at least one container remains warm to minimize cold start latency

## Details
This change aligns with Modal's current API conventions. The `min_containers` parameter is the recommended way to specify the minimum number of containers to keep running, replacing the older `keep_warm` parameter. The behavior remains identical - one container will be kept warm to avoid cold start delays when the scheduled function is triggered.

https://claude.ai/code/session_011vGY6ErZfJQ1y1tH6fpKZc