### PR TITLE
feat(lume): add clipboard sync between host and VM via SSH

### DIFF
--- a/docs/content/docs/lume/reference/cli-reference.mdx
+++ b/docs/content/docs/lume/reference/cli-reference.mdx
@@ -174,6 +174,23 @@ Connect to a VM via SSH or execute commands remotely
 - `--storage` - Storage location name or path
 - `-t, --timeout` - Command timeout in seconds (0 for no timeout) (default: 60)
 
+### lume clipboard
+
+Sync clipboard between host and VM
+
+**Subcommands:**
+
+- `lume clipboard push` - Push host clipboard to VM
+  - `<name>` - Name of the virtual machine
+  - `-u, --user` - SSH username
+  - `-p, --password` - SSH password
+  - `--storage` - Storage location name or path
+- `lume clipboard pull` - Pull VM clipboard to host
+  - `<name>` - Name of the virtual machine
+  - `-u, --user` - SSH username
+  - `-p, --password` - SSH password
+  - `--storage` - Storage location name or path
+
 ## Image Management
 
 ### lume pull

--- a/libs/lume/src/Commands/Clipboard.swift
+++ b/libs/lume/src/Commands/Clipboard.swift
@@ -1,0 +1,136 @@
+import ArgumentParser
+import Foundation
+
+struct Clipboard: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "clipboard",
+        abstract: "Sync clipboard between host and VM",
+        discussion: """
+            Synchronize clipboard content between the macOS host and a running VM
+            using SSH. Requires SSH/Remote Login to be enabled in the VM.
+
+            Examples:
+              lume clipboard push my-vm  # Copy host clipboard to VM
+              lume clipboard pull my-vm  # Copy VM clipboard to host
+            """,
+        subcommands: [Push.self, Pull.self]
+    )
+
+    struct Push: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "push",
+            abstract: "Push host clipboard to VM"
+        )
+
+        @Argument(help: "Name of the virtual machine", completion: .custom(completeVMName))
+        var name: String
+
+        @Option(name: [.short, .long], help: "SSH username (default: lume)")
+        var user: String = "lume"
+
+        @Option(name: [.short, .long], help: "SSH password (default: lume)")
+        var password: String = "lume"
+
+        @Option(name: .customLong("storage"), help: "Storage location name or path")
+        var storage: String?
+
+        @MainActor
+        func run() async throws {
+            TelemetryClient.shared.record(event: "lume_clipboard_push")
+
+            let controller = LumeController()
+
+            // Get VM details
+            let vmDetails: VMDetails
+            do {
+                vmDetails = try controller.getDetails(name: name, storage: storage)
+            } catch {
+                throw SSHError.vmNotFound(name)
+            }
+
+            // Validate VM state
+            guard vmDetails.status == "running" else {
+                throw SSHError.vmNotRunning(name)
+            }
+
+            guard let ipAddress = vmDetails.ipAddress, !ipAddress.isEmpty else {
+                throw SSHError.noIPAddress(name)
+            }
+
+            guard vmDetails.sshAvailable == true else {
+                throw SSHError.sshNotAvailable(name)
+            }
+
+            // Create SSH client and clipboard sync
+            let sshClient = SSHClient(
+                host: ipAddress,
+                port: 22,
+                user: user,
+                password: password
+            )
+            let clipboardSync = ClipboardSync(sshClient: sshClient)
+
+            let result = try await clipboardSync.push()
+            print(result)
+        }
+    }
+
+    struct Pull: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "pull",
+            abstract: "Pull VM clipboard to host"
+        )
+
+        @Argument(help: "Name of the virtual machine", completion: .custom(completeVMName))
+        var name: String
+
+        @Option(name: [.short, .long], help: "SSH username (default: lume)")
+        var user: String = "lume"
+
+        @Option(name: [.short, .long], help: "SSH password (default: lume)")
+        var password: String = "lume"
+
+        @Option(name: .customLong("storage"), help: "Storage location name or path")
+        var storage: String?
+
+        @MainActor
+        func run() async throws {
+            TelemetryClient.shared.record(event: "lume_clipboard_pull")
+
+            let controller = LumeController()
+
+            // Get VM details
+            let vmDetails: VMDetails
+            do {
+                vmDetails = try controller.getDetails(name: name, storage: storage)
+            } catch {
+                throw SSHError.vmNotFound(name)
+            }
+
+            // Validate VM state
+            guard vmDetails.status == "running" else {
+                throw SSHError.vmNotRunning(name)
+            }
+
+            guard let ipAddress = vmDetails.ipAddress, !ipAddress.isEmpty else {
+                throw SSHError.noIPAddress(name)
+            }
+
+            guard vmDetails.sshAvailable == true else {
+                throw SSHError.sshNotAvailable(name)
+            }
+
+            // Create SSH client and clipboard sync
+            let sshClient = SSHClient(
+                host: ipAddress,
+                port: 22,
+                user: user,
+                password: password
+            )
+            let clipboardSync = ClipboardSync(sshClient: sshClient)
+
+            let result = try await clipboardSync.pull()
+            print(result)
+        }
+    }
+}

--- a/libs/lume/src/SSH/ClipboardErrors.swift
+++ b/libs/lume/src/SSH/ClipboardErrors.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Errors that can occur during clipboard operations
+public enum ClipboardError: Error, LocalizedError {
+    case contentTooLarge(Int, Int)
+    case unsupportedContentType
+    case vmCommandFailed(String)
+    case decodingFailed
+    case hostClipboardEmpty
+    case vmClipboardEmpty
+    case hostClipboardReadFailed
+
+    public var errorDescription: String? {
+        switch self {
+        case .contentTooLarge(let actual, let max):
+            return "Clipboard content too large: \(actual) bytes (max: \(max) bytes)"
+        case .unsupportedContentType:
+            return "Unsupported clipboard content type. Only text is currently supported."
+        case .vmCommandFailed(let output):
+            return "VM clipboard command failed: \(output)"
+        case .decodingFailed:
+            return "Failed to decode clipboard content from VM"
+        case .hostClipboardEmpty:
+            return "Host clipboard is empty"
+        case .vmClipboardEmpty:
+            return "VM clipboard is empty"
+        case .hostClipboardReadFailed:
+            return "Failed to read host clipboard"
+        }
+    }
+}

--- a/libs/lume/src/SSH/ClipboardSync.swift
+++ b/libs/lume/src/SSH/ClipboardSync.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Clipboard synchronization service using SSH
+public actor ClipboardSync {
+    private let sshClient: SSHClient
+
+    /// Maximum clipboard size (10MB)
+    private static let maxClipboardSize = 10 * 1024 * 1024
+
+    public init(sshClient: SSHClient) {
+        self.sshClient = sshClient
+    }
+
+    /// Push host clipboard to VM
+    /// - Returns: A message indicating success and bytes transferred
+    public func push() async throws -> String {
+        // 1. Read host clipboard using pbpaste
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/pbpaste")
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            throw ClipboardError.hostClipboardReadFailed
+        }
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+
+        guard !data.isEmpty else {
+            throw ClipboardError.hostClipboardEmpty
+        }
+
+        guard data.count <= Self.maxClipboardSize else {
+            throw ClipboardError.contentTooLarge(data.count, Self.maxClipboardSize)
+        }
+
+        // Verify it's valid UTF-8 text
+        guard String(data: data, encoding: .utf8) != nil else {
+            throw ClipboardError.unsupportedContentType
+        }
+
+        // 2. Base64 encode for safe transport
+        let base64Content = data.base64EncodedString()
+
+        // 3. Execute on VM: decode and pipe to pbcopy
+        // Use printf to avoid echo interpretation issues with special characters
+        let command = "printf '%s' '\(base64Content)' | base64 -D | pbcopy"
+        let result = try await sshClient.execute(command: command, timeout: 30)
+
+        if result.exitCode != 0 {
+            throw ClipboardError.vmCommandFailed(result.output)
+        }
+
+        return "Pushed \(data.count) bytes to VM clipboard"
+    }
+
+    /// Pull VM clipboard to host
+    /// - Returns: A message indicating success and bytes transferred
+    public func pull() async throws -> String {
+        // 1. Read VM clipboard via SSH
+        let command = "pbpaste | base64"
+        let result = try await sshClient.execute(command: command, timeout: 30)
+
+        guard result.exitCode == 0 else {
+            throw ClipboardError.vmCommandFailed(result.output)
+        }
+
+        let trimmedOutput = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedOutput.isEmpty else {
+            throw ClipboardError.vmClipboardEmpty
+        }
+
+        // 2. Decode base64 content
+        guard let data = Data(base64Encoded: trimmedOutput) else {
+            throw ClipboardError.decodingFailed
+        }
+
+        guard data.count <= Self.maxClipboardSize else {
+            throw ClipboardError.contentTooLarge(data.count, Self.maxClipboardSize)
+        }
+
+        // 3. Write to host clipboard using pbcopy
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/pbcopy")
+        let inputPipe = Pipe()
+        process.standardInput = inputPipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            inputPipe.fileHandleForWriting.write(data)
+            try inputPipe.fileHandleForWriting.close()
+            process.waitUntilExit()
+        } catch {
+            throw ClipboardError.hostClipboardReadFailed
+        }
+
+        return "Pulled \(data.count) bytes from VM clipboard"
+    }
+}

--- a/libs/lume/src/Utils/CommandDocExtractor.swift
+++ b/libs/lume/src/Utils/CommandDocExtractor.swift
@@ -81,6 +81,7 @@ enum CommandDocExtractor {
             runDoc,
             stopDoc,
             sshDoc,
+            clipboardDoc,
             ipswDoc,
             serveDoc,
             deleteDoc,
@@ -327,6 +328,51 @@ enum CommandDocExtractor {
             ],
             flags: [],
             subcommands: []
+        )
+    }
+
+    // MARK: - Clipboard
+
+    private static var clipboardDoc: CommandDoc {
+        CommandDoc(
+            name: "clipboard",
+            abstract: "Sync clipboard between host and VM",
+            discussion: "Synchronize clipboard content between the macOS host and a running VM using SSH. Requires Remote Login to be enabled on the VM.",
+            arguments: [],
+            options: [],
+            flags: [],
+            subcommands: [
+                CommandDoc(
+                    name: "push",
+                    abstract: "Push host clipboard to VM",
+                    discussion: nil,
+                    arguments: [
+                        ArgumentDoc(name: "name", help: "Name of the virtual machine", type: "String", isOptional: false),
+                    ],
+                    options: [
+                        OptionDoc(name: "user", shortName: "u", help: "SSH username", type: "String", defaultValue: "lume", isOptional: false),
+                        OptionDoc(name: "password", shortName: "p", help: "SSH password", type: "String", defaultValue: "lume", isOptional: false),
+                        OptionDoc(name: "storage", shortName: nil, help: "Storage location name or path", type: "String", defaultValue: nil, isOptional: true),
+                    ],
+                    flags: [],
+                    subcommands: []
+                ),
+                CommandDoc(
+                    name: "pull",
+                    abstract: "Pull VM clipboard to host",
+                    discussion: nil,
+                    arguments: [
+                        ArgumentDoc(name: "name", help: "Name of the virtual machine", type: "String", isOptional: false),
+                    ],
+                    options: [
+                        OptionDoc(name: "user", shortName: "u", help: "SSH username", type: "String", defaultValue: "lume", isOptional: false),
+                        OptionDoc(name: "password", shortName: "p", help: "SSH password", type: "String", defaultValue: "lume", isOptional: false),
+                        OptionDoc(name: "storage", shortName: nil, help: "Storage location name or path", type: "String", defaultValue: nil, isOptional: true),
+                    ],
+                    flags: [],
+                    subcommands: []
+                ),
+            ]
         )
     }
 

--- a/libs/lume/src/Utils/CommandRegistry.swift
+++ b/libs/lume/src/Utils/CommandRegistry.swift
@@ -14,6 +14,7 @@ enum CommandRegistry {
             Run.self,
             Stop.self,
             SSH.self,
+            Clipboard.self,
             IPSW.self,
             Serve.self,
             Delete.self,

--- a/scripts/docs-generators/lume.ts
+++ b/scripts/docs-generators/lume.ts
@@ -257,7 +257,7 @@ function generateCLIReferenceMDX(docs: CLIDocumentation): string {
   // Group commands by category
   const vmManagement = ['create', 'run', 'stop', 'delete', 'clone'];
   const vmInfo = ['ls', 'get', 'set'];
-  const remoteAccess = ['ssh'];
+  const remoteAccess = ['ssh', 'clipboard'];
   const imageManagement = ['images', 'pull', 'push', 'ipsw', 'prune'];
   const configuration = ['config', 'serve', 'logs', 'setup'];
 


### PR DESCRIPTION
## Summary

Adds clipboard synchronization between the macOS host and running Lume VMs using SSH. This addresses issue #924 where the VNC clipboard doesn't work (because macOS Screen Sharing doesn't integrate with the VZSpiceAgentPortAttachment).

### New CLI Commands
- `lume clipboard push <vm>` - Copy host clipboard to VM
- `lume clipboard pull <vm>` - Copy VM clipboard to host

### New MCP Tools
- `lume_clipboard_push` - Push host clipboard to VM
- `lume_clipboard_pull` - Pull VM clipboard to host

### Implementation Details
- Uses SSH to execute `pbpaste`/`pbcopy` on both host and VM
- Base64 encoding for safe transport of clipboard content
- 10MB size limit for safety
- Text-only support initially (images could be added later)

## Test Plan
- [ ] Build and run: `cd libs/lume && swift build`
- [ ] Test push: `echo "test" | pbcopy && lume clipboard push my-vm` then SSH to VM and run `pbpaste`
- [ ] Test pull: In VM run `echo "from vm" | pbcopy`, then on host `lume clipboard pull my-vm && pbpaste`
- [ ] Test MCP tools via Claude Desktop or MCP inspector

Closes #924