### PR TITLE
fix(lume): default disk/memory size to GB when no unit specified

### DIFF
--- a/libs/lume/src/Commands/Set.swift
+++ b/libs/lume/src/Commands/Set.swift
@@ -12,10 +12,10 @@ struct Set: AsyncParsableCommand {
     @Option(help: "New number of CPU cores")
     var cpu: Int?
 
-    @Option(help: "New memory size, e.g., 8192MB or 8GB.", transform: { try parseSize($0) })
+    @Option(help: "New memory size (e.g., 8, 8GB, or 8192MB). Numbers without units are treated as GB.", transform: { try parseSize($0) })
     var memory: UInt64?
 
-    @Option(help: "New disk size, e.g., 20480MB or 20GB.", transform: { try parseSize($0) })
+    @Option(help: "New disk size (e.g., 50, 50GB, or 51200MB). Numbers without units are treated as GB.", transform: { try parseSize($0) })
     var diskSize: UInt64?
 
     @Option(help: "New display resolution in format WIDTHxHEIGHT.")

--- a/libs/lume/src/Utils/Utils.swift
+++ b/libs/lume/src/Utils/Utils.swift
@@ -42,8 +42,12 @@ func parseSize(_ input: String) throws -> UInt64 {
     } else if lowercased.hasSuffix("kb") {
         multiplier = 1024
         valueString = String(lowercased.dropLast(2))
+    } else if lowercased.hasSuffix("b") {
+        multiplier = 1
+        valueString = String(lowercased.dropLast(1))
     } else {
-        multiplier = 1024 * 1024
+        // Default to GB when no unit is specified
+        multiplier = 1024 * 1024 * 1024
         valueString = lowercased
     }
 


### PR DESCRIPTION
## Summary

Fixes #923 - `--disk-size` now defaults to GB instead of MB when no unit is specified.

### Before
```bash
lume create my-vm --disk-size 50  # Created 50MB disk (unusable)
```

### After
```bash
lume create my-vm --disk-size 50   # Creates 50GB disk
lume create my-vm --disk-size 50GB # Creates 50GB disk
lume create my-vm --disk-size 51200MB # Creates 50GB disk
```

### Changes
1. **Default unit is now GB** - Numbers without units are treated as GB
2. **Sanity check added** - Throws error if disk is too small:
   - macOS VMs: minimum 30GB
   - Linux VMs: minimum 10GB
3. **Updated help text** - Clarifies that numbers without units are GB

### Files Changed
- `libs/lume/src/Utils/Utils.swift` - Changed default multiplier from MB to GB
- `libs/lume/src/Commands/Create.swift` - Added sanity check, updated help
- `libs/lume/src/Commands/Set.swift` - Updated help text

## Test Plan
```bash
# Should create 50GB disk
lume create test1 --os macos --ipsw latest --disk-size 50

# Should fail with "too small" error
lume create test2 --os macos --ipsw latest --disk-size 10

# Should work (explicit GB)
lume create test3 --os macos --ipsw latest --disk-size 50GB
```