### PR TITLE
fix(lume): use heredoc for large clipboard content to avoid shell limits

### DIFF
--- a/libs/lume/src/Clipboard/ClipboardWatcher.swift
+++ b/libs/lume/src/Clipboard/ClipboardWatcher.swift
@@ -18,7 +18,8 @@ public actor ClipboardWatcher {
     private static let pollInterval: TimeInterval = 1.0
 
     /// Delay before starting to watch (allows VM to boot and get IP)
-    private static let startupDelay: TimeInterval = 10.0
+    /// Set to 0 since we gracefully handle SSH not being available yet
+    private static let startupDelay: TimeInterval = 0
 
     /// Max content size (1MB)
     private static let maxContentSize = 1_000_000
@@ -36,8 +37,10 @@ public actor ClipboardWatcher {
         watchTask = Task { [weak self] in
             guard let self = self else { return }
 
-            // Wait for VM to boot and potentially get an IP address
-            try? await Task.sleep(nanoseconds: UInt64(Self.startupDelay * 1_000_000_000))
+            // Optional startup delay (set to 0 since we gracefully handle SSH not ready)
+            if Self.startupDelay > 0 {
+                try? await Task.sleep(nanoseconds: UInt64(Self.startupDelay * 1_000_000_000))
+            }
 
             // Initialize with current clipboard state to avoid syncing on start
             await self.initializeState()


### PR DESCRIPTION
## Summary

Fixes clipboard sync for large content (> 64KB) by using heredoc instead of command line arguments.

### Problem
When clipboard content is large, the base64-encoded string can exceed shell `ARG_MAX` limits when passed as a command line argument.

### Solution
- **Short content** (<64KB): Use inline `printf` command (fast)
- **Long content** (64KB-1MB): Use heredoc to pass content via stdin

### Changes
- Added conditional logic to use heredoc for large content
- Increased timeout from 5s to 10s for large transfers

## Test Plan
1. Copy a large text file (>64KB) to clipboard
2. Run VM with `lume run my-vm`
3. Verify clipboard syncs to VM without errors