### PR TITLE
fix(lume): simplify Siri setup in unattended presets

### DIFF
--- a/libs/lume/src/Resources/unattended-presets/sequoia.yml
+++ b/libs/lume/src/Resources/unattended-presets/sequoia.yml
@@ -154,21 +154,9 @@ boot_commands:
 
   # Siri (longer timeout as Screen Time page can be slow)
   - "<wait 'Siri', timeout=300>"
-  - "<delay 1>"
-  - "<click 'Continue'>"
   - "<delay 2>"
-
-  # Select a Siri Voice
-  - "<wait 'Select a Siri Voice'>"
-  - "<delay 1>"
-  - "<click 'Choose For Me'>"
+  - "<click 'Enable Ask Siri'>"
   - "<delay 2>"
-
-  # Improve Siri & Dictation - select "Not Now" option
-  - "<wait 'Improve Siri'>"
-  - "<delay 1>"
-  - "<click 'Not Now'>"
-  - "<delay 1>"
   - "<click 'Continue'>"
   - "<delay 2>"
 

--- a/libs/lume/src/Resources/unattended-presets/tahoe.yml
+++ b/libs/lume/src/Resources/unattended-presets/tahoe.yml
@@ -154,21 +154,9 @@ boot_commands:
 
   # Siri (longer timeout as Screen Time page can be slow)
   - "<wait 'Siri', timeout=300>"
-  - "<delay 1>"
-  - "<click 'Continue'>"
   - "<delay 2>"
-
-  # Select a Siri Voice
-  - "<wait 'Select a Siri Voice'>"
-  - "<delay 1>"
-  - "<click 'Choose For Me'>"
+  - "<click 'Enable Ask Siri'>"
   - "<delay 2>"
-
-  # Improve Siri & Dictation - select "Not Now" option
-  - "<wait 'Improve Siri'>"
-  - "<delay 1>"
-  - "<click 'Not Now'>"
-  - "<delay 1>"
   - "<click 'Continue'>"
   - "<delay 2>"
 


### PR DESCRIPTION
## Summary
- Click "Enable Ask Siri" directly instead of going through multiple screens
- Removes unnecessary steps: "Select a Siri Voice" and "Improve Siri & Dictation"
- More reliable and faster unattended setup

## Test plan
- [ ] Run `lume create` with `--unattended sequoia` or `--unattended tahoe` and verify setup completes