### PR TITLE
fix(lume): use click instead of enter for language selection

### DIFF
--- a/libs/lume/src/Resources/unattended-presets/sequoia.yml
+++ b/libs/lume/src/Resources/unattended-presets/sequoia.yml
@@ -19,10 +19,10 @@ boot_commands:
   - "<wait 'English', timeout=120>"
   - "<delay 1>"
 
-  # Type "English" to filter the list and select it, then press Enter
+  # Type "English" to filter the list, then click on "English" to select it
   - "<type 'English'>"
   - "<delay 1>"
-  - "<enter>"
+  - "<click 'English'>"
   - "<delay 2>"
 
   # Country/Region selection

--- a/libs/lume/src/Resources/unattended-presets/tahoe.yml
+++ b/libs/lume/src/Resources/unattended-presets/tahoe.yml
@@ -19,10 +19,10 @@ boot_commands:
   - "<wait 'English', timeout=120>"
   - "<delay 1>"
 
-  # Type "English" to filter the list and select it, then press Enter
+  # Type "English" to filter the list, then click on "English" to select it
   - "<type 'English'>"
   - "<delay 1>"
-  - "<enter>"
+  - "<click 'English'>"
   - "<delay 2>"
 
   # Country/Region selection


### PR DESCRIPTION
## Summary
On European hosts, "English (UK)" appears first in the filtered language list, so pressing enter selects it instead of plain "English".

Using `<click 'English'>` instead of `<enter>` targets the exact "English" text more reliably.

## Test plan
- [ ] Run `lume create` with `--unattended sequoia` on a European host and verify "English" (not "English (UK)") is selected