### PR TITLE
fix(lume): add enter after click for language selection

### DIFF
--- a/libs/lume/src/Resources/unattended-presets/sequoia.yml
+++ b/libs/lume/src/Resources/unattended-presets/sequoia.yml
@@ -19,10 +19,12 @@ boot_commands:
   - "<wait 'English', timeout=120>"
   - "<delay 1>"
 
-  # Type "English" to filter the list, then click on "English" to select it
+  # Type "English" to filter the list, click on "English" to select it, then press Enter
   - "<type 'English'>"
   - "<delay 1>"
   - "<click 'English'>"
+  - "<delay 1>"
+  - "<enter>"
   - "<delay 2>"
 
   # Country/Region selection

--- a/libs/lume/src/Resources/unattended-presets/tahoe.yml
+++ b/libs/lume/src/Resources/unattended-presets/tahoe.yml
@@ -19,10 +19,12 @@ boot_commands:
   - "<wait 'English', timeout=120>"
   - "<delay 1>"
 
-  # Type "English" to filter the list, then click on "English" to select it
+  # Type "English" to filter the list, click on "English" to select it, then press Enter
   - "<type 'English'>"
   - "<delay 1>"
   - "<click 'English'>"
+  - "<delay 1>"
+  - "<enter>"
   - "<delay 2>"
 
   # Country/Region selection


### PR DESCRIPTION
## Summary
The click selects "English" in the list, but enter is still needed to confirm and proceed to the next screen.

Sequence is now:
1. Type "English" to filter the list
2. Click "English" to select it (avoids "English (UK)" on European hosts)
3. Press Enter to confirm and proceed

## Test plan
- [ ] Run `lume create` with `--unattended sequoia` and verify language selection works