### PR TITLE
fix(lume): add delays in account creation for reliable password entry

### DIFF
--- a/libs/lume/src/Resources/unattended-presets/sequoia.yml
+++ b/libs/lume/src/Resources/unattended-presets/sequoia.yml
@@ -71,25 +71,32 @@ boot_commands:
   - "<delay 2>"
 
   # Create a Mac Account
-  # Initial focus is on avatar picker (6 icons: +, panda, cow, fox, owl, etc.)
-  # Need to tab 6 times to reach Full Name field
-  # Field order after avatar: Full Name -> Account Name (auto-filled) -> Password -> Verify Password -> Hint -> Checkbox -> Continue
+  # Field order: Full Name -> Account Name (auto-filled) -> Password -> Verify Password -> Hint -> Checkbox -> Continue
   - "<wait 'Create a Mac Account'>"
   - "<delay 10>"
   - "<click 'Full Name'>"
+  - "<delay 1>"
   # Type Full Name
   - "<type 'lume'>"
-  - "<tab>" 
+  - "<delay 1>"
+  - "<tab>"
+  - "<delay 1>"
   # Skip Account Name (auto-filled from Full Name)
   - "<tab>"
+  - "<delay 1>"
   # Type Password
   - "<type 'lume'>"
+  - "<delay 1>"
   - "<tab>"
+  - "<delay 1>"
   # Type Verify Password
   - "<type 'lume'>"
+  - "<delay 1>"
   - "<tab>"
+  - "<delay 1>"
   # Skip Hint field
   - "<tab>"
+  - "<delay 1>"
   # Untoggle "Allow computer account password to be reset with Apple Account" checkbox
   - "<space>"
   - "<delay 1>"

--- a/libs/lume/src/Resources/unattended-presets/tahoe.yml
+++ b/libs/lume/src/Resources/unattended-presets/tahoe.yml
@@ -71,25 +71,32 @@ boot_commands:
   - "<delay 2>"
 
   # Create a Mac Account
-  # Initial focus is on avatar picker (6 icons: +, panda, cow, fox, owl, etc.)
-  # Need to tab 6 times to reach Full Name field
-  # Field order after avatar: Full Name -> Account Name (auto-filled) -> Password -> Verify Password -> Hint -> Checkbox -> Continue
+  # Field order: Full Name -> Account Name (auto-filled) -> Password -> Verify Password -> Hint -> Checkbox -> Continue
   - "<wait 'Create a Mac Account'>"
   - "<delay 10>"
   - "<click 'Full Name'>"
+  - "<delay 1>"
   # Type Full Name
   - "<type 'lume'>"
+  - "<delay 1>"
   - "<tab>"
+  - "<delay 1>"
   # Skip Account Name (auto-filled from Full Name)
   - "<tab>"
+  - "<delay 1>"
   # Type Password
   - "<type 'lume'>"
+  - "<delay 1>"
   - "<tab>"
+  - "<delay 1>"
   # Type Verify Password
   - "<type 'lume'>"
+  - "<delay 1>"
   - "<tab>"
+  - "<delay 1>"
   # Skip Hint field
   - "<tab>"
+  - "<delay 1>"
   # Untoggle "Allow computer account password to be reset with Apple Account" checkbox
   - "<space>"
   - "<delay 1>"


### PR DESCRIPTION
## Summary
Add 1-second delays between each tab and type command during account creation. Without delays, the UI may not keep up with the rapid keyboard input, causing password fields to receive incomplete input.

The debug output showed the password field only had partial content ("..•." instead of 4 bullets for "lume").

## Changes
- Add `<delay 1>` after clicking Full Name field
- Add `<delay 1>` after each `<type>` command
- Add `<delay 1>` after each `<tab>` command

## Test plan
- [ ] Run `lume create` with `--unattended sequoia` and verify account creation completes with correct password