### PR TITLE
fix(lume): use partial search term for Remote Login in System Settings

### DIFF
--- a/libs/lume/src/Resources/unattended-presets/sequoia.yml
+++ b/libs/lume/src/Resources/unattended-presets/sequoia.yml
@@ -261,7 +261,7 @@ boot_commands:
   # Use keyboard shortcut to focus search field (more reliable than clicking)
   - "<cmd+f>"
   - "<delay 1>"
-  - "<type 'Remote Login'>"
+  - "<type 'Remote Logi'>"
   - "<delay 2>"
   - "<click 'Remote Login'>"
   - "<delay 3>"

--- a/libs/lume/src/Resources/unattended-presets/tahoe.yml
+++ b/libs/lume/src/Resources/unattended-presets/tahoe.yml
@@ -272,7 +272,7 @@ boot_commands:
   # Use keyboard shortcut to focus search field (more reliable than clicking)
   - "<cmd+f>"
   - "<delay 1>"
-  - "<type 'Remote Login'>"
+  - "<type 'Remote Logi'>"
   - "<delay 2>"
   - "<click 'Remote Login'>"
   - "<delay 3>"


### PR DESCRIPTION
## Summary
Type "Remote Logi" instead of "Remote Login" to avoid ambiguous OCR matches when clicking on the search result in System Settings.

## Test plan
- [ ] Run `lume create` with `--unattended sequoia` and verify Remote Login settings are found correctly