### PR TITLE
fix(lume): improve Remote Login search in System Settings

### DIFF
--- a/libs/lume/src/Resources/unattended-presets/sequoia.yml
+++ b/libs/lume/src/Resources/unattended-presets/sequoia.yml
@@ -261,10 +261,10 @@ boot_commands:
   # Use keyboard shortcut to focus search field (more reliable than clicking)
   - "<cmd+f>"
   - "<delay 1>"
-  - "<type 'Remote Logi'>"
+  - "<type 'login'>"
   - "<delay 2>"
   - "<click 'Remote Login'>"
-  - "<delay 3>"
+  - "<delay 10>"
 
   # Tab to reach the "Allow full disk access" toggle, then Space to toggle
   - "<tab>"

--- a/libs/lume/src/Resources/unattended-presets/tahoe.yml
+++ b/libs/lume/src/Resources/unattended-presets/tahoe.yml
@@ -272,10 +272,10 @@ boot_commands:
   # Use keyboard shortcut to focus search field (more reliable than clicking)
   - "<cmd+f>"
   - "<delay 1>"
-  - "<type 'Remote Logi'>"
+  - "<type 'login'>"
   - "<delay 2>"
   - "<click 'Remote Login'>"
-  - "<delay 3>"
+  - "<delay 10>"
 
   # Tab to reach the "Allow full disk access" toggle, then Space to toggle
   - "<tab>"


### PR DESCRIPTION
## Summary
- Type "login" instead of "Remote Logi" for cleaner search
- Increase delay after clicking to 10s to allow settings pane to fully load

## Test plan
- [ ] Run `lume create` with `--unattended sequoia` and verify Remote Login settings are found and toggled correctly