### PR TITLE
feat(lume): add screensaver and sleep disable commands to unattended presets

### DIFF
--- a/libs/lume/src/Resources/unattended-presets/sequoia.yml
+++ b/libs/lume/src/Resources/unattended-presets/sequoia.yml
@@ -229,7 +229,35 @@ boot_commands:
   - "<delay 2>"
 
   # ============================================
-  # 3. Enable Full Disk Access for Remote Users
+  # 3. Disable Screen Lock and Sleep
+  # ============================================
+  # Disable screen saver
+  - "<type 'defaults -currentHost write com.apple.screensaver idleTime -int 0'>"
+  - "<enter>"
+  - "<delay 1>"
+
+  # Disable require password after sleep/screen saver
+  - "<type 'defaults write com.apple.screensaver askForPassword -int 0'>"
+  - "<enter>"
+  - "<delay 1>"
+
+  # Prevent display from sleeping (never)
+  - "<type 'sudo pmset -a displaysleep 0'>"
+  - "<enter>"
+  - "<delay 1>"
+
+  # Prevent system sleep (never)
+  - "<type 'sudo pmset -a sleep 0'>"
+  - "<enter>"
+  - "<delay 1>"
+
+  # Disable auto-logout
+  - "<type 'sudo defaults write /Library/Preferences/.GlobalPreferences com.apple.autologout.AutoLogOutDelay -int 0'>"
+  - "<enter>"
+  - "<delay 1>"
+
+  # ============================================
+  # 4. Enable Full Disk Access for Remote Users
   # ============================================
   # This requires navigating System Settings GUI since TCC.db is SIP-protected
 

--- a/libs/lume/src/Resources/unattended-presets/tahoe.yml
+++ b/libs/lume/src/Resources/unattended-presets/tahoe.yml
@@ -240,7 +240,35 @@ boot_commands:
   - "<delay 2>"
 
   # ============================================
-  # 3. Enable Full Disk Access for Remote Users
+  # 3. Disable Screen Lock and Sleep
+  # ============================================
+  # Disable screen saver
+  - "<type 'defaults -currentHost write com.apple.screensaver idleTime -int 0'>"
+  - "<enter>"
+  - "<delay 1>"
+
+  # Disable require password after sleep/screen saver
+  - "<type 'defaults write com.apple.screensaver askForPassword -int 0'>"
+  - "<enter>"
+  - "<delay 1>"
+
+  # Prevent display from sleeping (never)
+  - "<type 'sudo pmset -a displaysleep 0'>"
+  - "<enter>"
+  - "<delay 1>"
+
+  # Prevent system sleep (never)
+  - "<type 'sudo pmset -a sleep 0'>"
+  - "<enter>"
+  - "<delay 1>"
+
+  # Disable auto-logout
+  - "<type 'sudo defaults write /Library/Preferences/.GlobalPreferences com.apple.autologout.AutoLogOutDelay -int 0'>"
+  - "<enter>"
+  - "<delay 1>"
+
+  # ============================================
+  # 4. Enable Full Disk Access for Remote Users
   # ============================================
   # This requires navigating System Settings GUI since TCC.db is SIP-protected
 


### PR DESCRIPTION
## Summary
Adds commands to disable screen lock and sleep in unattended presets to prevent re-login prompts in VMs.

## Changes
Both `tahoe.yml` and `sequoia.yml` presets now include:

```yaml
# Disable screen saver
- defaults -currentHost write com.apple.screensaver idleTime -int 0

# Disable require password after sleep/screen saver
- defaults write com.apple.screensaver askForPassword -int 0

# Prevent display from sleeping (never)
- sudo pmset -a displaysleep 0

# Prevent system sleep (never)
- sudo pmset -a sleep 0

# Disable auto-logout
- sudo defaults write /Library/Preferences/.GlobalPreferences com.apple.autologout.AutoLogOutDelay -int 0
```

## Problem
VMs created with unattended setup would prompt for re-login after the screensaver activated, breaking automated workflows.

## Test plan
- [ ] Create VM with `lume create --unattended tahoe`
- [ ] Verify screensaver doesn't activate
- [ ] Verify no re-login prompt after idle time