### PR TITLE
feat(lume): add post_ssh_commands for reliable post-setup configuration

### DIFF
--- a/libs/lume/src/Resources/unattended-presets/sequoia.yml
+++ b/libs/lume/src/Resources/unattended-presets/sequoia.yml
@@ -229,35 +229,7 @@ boot_commands:
   - "<delay 2>"
 
   # ============================================
-  # 3. Disable Screen Lock and Sleep
-  # ============================================
-  # Disable screen saver
-  - "<type 'defaults -currentHost write com.apple.screensaver idleTime -int 0'>"
-  - "<enter>"
-  - "<delay 1>"
-
-  # Disable require password after sleep/screen saver
-  - "<type 'defaults write com.apple.screensaver askForPassword -int 0'>"
-  - "<enter>"
-  - "<delay 1>"
-
-  # Prevent display from sleeping (never)
-  - "<type 'sudo pmset -a displaysleep 0'>"
-  - "<enter>"
-  - "<delay 1>"
-
-  # Prevent system sleep (never)
-  - "<type 'sudo pmset -a sleep 0'>"
-  - "<enter>"
-  - "<delay 1>"
-
-  # Disable auto-logout
-  - "<type 'sudo defaults write /Library/Preferences/.GlobalPreferences com.apple.autologout.AutoLogOutDelay -int 0'>"
-  - "<enter>"
-  - "<delay 1>"
-
-  # ============================================
-  # 4. Enable Full Disk Access for Remote Users
+  # 3. Enable Full Disk Access for Remote Users
   # ============================================
   # This requires navigating System Settings GUI since TCC.db is SIP-protected
 
@@ -320,3 +292,17 @@ health_check:
   timeout: 30
   retries: 5
   retry_delay: 10
+
+# Post-setup commands to run via SSH after health check passes
+# These are more reliable than typing in Terminal via VNC
+post_ssh_commands:
+  # Disable screen saver
+  - "defaults -currentHost write com.apple.screensaver idleTime -int 0"
+  # Disable require password after sleep/screen saver
+  - "defaults write com.apple.screensaver askForPassword -int 0"
+  # Prevent display from sleeping (never)
+  - "sudo pmset -a displaysleep 0"
+  # Prevent system sleep (never)
+  - "sudo pmset -a sleep 0"
+  # Disable auto-logout
+  - "sudo defaults write /Library/Preferences/.GlobalPreferences com.apple.autologout.AutoLogOutDelay -int 0"

--- a/libs/lume/src/Resources/unattended-presets/tahoe.yml
+++ b/libs/lume/src/Resources/unattended-presets/tahoe.yml
@@ -240,35 +240,7 @@ boot_commands:
   - "<delay 2>"
 
   # ============================================
-  # 3. Disable Screen Lock and Sleep
-  # ============================================
-  # Disable screen saver
-  - "<type 'defaults -currentHost write com.apple.screensaver idleTime -int 0'>"
-  - "<enter>"
-  - "<delay 1>"
-
-  # Disable require password after sleep/screen saver
-  - "<type 'defaults write com.apple.screensaver askForPassword -int 0'>"
-  - "<enter>"
-  - "<delay 1>"
-
-  # Prevent display from sleeping (never)
-  - "<type 'sudo pmset -a displaysleep 0'>"
-  - "<enter>"
-  - "<delay 1>"
-
-  # Prevent system sleep (never)
-  - "<type 'sudo pmset -a sleep 0'>"
-  - "<enter>"
-  - "<delay 1>"
-
-  # Disable auto-logout
-  - "<type 'sudo defaults write /Library/Preferences/.GlobalPreferences com.apple.autologout.AutoLogOutDelay -int 0'>"
-  - "<enter>"
-  - "<delay 1>"
-
-  # ============================================
-  # 4. Enable Full Disk Access for Remote Users
+  # 3. Enable Full Disk Access for Remote Users
   # ============================================
   # This requires navigating System Settings GUI since TCC.db is SIP-protected
 
@@ -331,3 +303,17 @@ health_check:
   timeout: 30
   retries: 5
   retry_delay: 10
+
+# Post-setup commands to run via SSH after health check passes
+# These are more reliable than typing in Terminal via VNC
+post_ssh_commands:
+  # Disable screen saver
+  - "defaults -currentHost write com.apple.screensaver idleTime -int 0"
+  # Disable require password after sleep/screen saver
+  - "defaults write com.apple.screensaver askForPassword -int 0"
+  # Prevent display from sleeping (never)
+  - "sudo pmset -a displaysleep 0"
+  # Prevent system sleep (never)
+  - "sudo pmset -a sleep 0"
+  # Disable auto-logout
+  - "sudo defaults write /Library/Preferences/.GlobalPreferences com.apple.autologout.AutoLogOutDelay -int 0"

--- a/libs/lume/src/Unattended/UnattendedConfig.swift
+++ b/libs/lume/src/Unattended/UnattendedConfig.swift
@@ -51,16 +51,22 @@ struct UnattendedConfig: Codable, Sendable {
     /// Optional health check to verify setup success
     let healthCheck: HealthCheck?
 
+    /// Optional commands to run via SSH after health check passes
+    /// These are more reliable than typing in Terminal via VNC
+    let postSshCommands: [String]?
+
     enum CodingKeys: String, CodingKey {
         case bootWait = "boot_wait"
         case bootCommands = "boot_commands"
         case healthCheck = "health_check"
+        case postSshCommands = "post_ssh_commands"
     }
 
-    init(bootWait: Int = 60, bootCommands: [String], healthCheck: HealthCheck? = nil) {
+    init(bootWait: Int = 60, bootCommands: [String], healthCheck: HealthCheck? = nil, postSshCommands: [String]? = nil) {
         self.bootWait = bootWait
         self.bootCommands = bootCommands
         self.healthCheck = healthCheck
+        self.postSshCommands = postSshCommands
     }
 
     /// Load configuration from a YAML file path or preset name

--- a/libs/lume/src/Unattended/UnattendedInstaller.swift
+++ b/libs/lume/src/Unattended/UnattendedInstaller.swift
@@ -140,6 +140,18 @@ final class UnattendedInstaller {
 
                 if passed {
                     Logger.info("Health check passed ✓", metadata: ["type": healthCheck.type])
+
+                    // Run post-SSH commands if configured (more reliable than VNC typing)
+                    if let postCommands = config.postSshCommands, !postCommands.isEmpty {
+                        Logger.info("Running post-SSH commands", metadata: ["count": "\(postCommands.count)"])
+                        try await runner.runPostSshCommands(
+                            commands: postCommands,
+                            vmIP: vmIP,
+                            user: healthCheck.user ?? "lume",
+                            password: healthCheck.password ?? "lume"
+                        )
+                        Logger.info("Post-SSH commands completed ✓")
+                    }
                 } else {
                     Logger.error("Health check failed ✗", metadata: ["type": healthCheck.type])
                     throw UnattendedError.healthCheckFailed("Health check '\(healthCheck.type)' failed")


### PR DESCRIPTION
## Summary
- Adds `post_ssh_commands` field to unattended config that runs commands via SSH after health check passes
- More reliable than VNC keyboard typing which can have issues with fast typing in Terminal
- Moves screensaver/sleep disable commands from VNC typing to SSH-based execution

## Changes
- Add `postSshCommands` field to `UnattendedConfig`
- Add `runPostSshCommands` method to `HealthCheckRunner`  
- Update `UnattendedInstaller` to execute post-SSH commands after health check
- Update `tahoe.yml` and `sequoia.yml` presets to use `post_ssh_commands` instead of Terminal typing

## Test plan
- [ ] Run `lume setup --unattended tahoe` on a fresh VM
- [ ] Verify health check passes
- [ ] Verify post-SSH commands execute (check screensaver/sleep settings)