### PR TITLE
feat(lume): add configurable delay parameter to type command

### DIFF
--- a/libs/lume/src/Resources/unattended-presets/sequoia.yml
+++ b/libs/lume/src/Resources/unattended-presets/sequoia.yml
@@ -200,11 +200,11 @@ boot_commands:
   # ============================================
   - "<cmd+space>"
   - "<delay 5>"
-  - "<type 'Terminal'>"
+  - "<type 'Terminal', delay=350>"
   - "<delay 5>"
   - "<enter>"
   - "<delay 5>"
-  - "<type 'defaults write NSGlobalDomain AppleKeyboardUIMode -int 3'>"
+  - "<type 'defaults write NSGlobalDomain AppleKeyboardUIMode -int 3', delay=350>"
   - "<enter>"
   - "<delay 3>"
   - "<cmd+q>"

--- a/libs/lume/src/Resources/unattended-presets/tahoe.yml
+++ b/libs/lume/src/Resources/unattended-presets/tahoe.yml
@@ -211,11 +211,11 @@ boot_commands:
   # ============================================
   - "<cmd+space>"
   - "<delay 5>"
-  - "<type 'Terminal'>"
+  - "<type 'Terminal', delay=350>"
   - "<delay 5>"
   - "<enter>"
   - "<delay 5>"
-  - "<type 'defaults write NSGlobalDomain AppleKeyboardUIMode -int 3'>"
+  - "<type 'defaults write NSGlobalDomain AppleKeyboardUIMode -int 3', delay=350>"
   - "<enter>"
   - "<delay 3>"
   - "<cmd+q>"

--- a/libs/lume/src/Unattended/VNCAutomation.swift
+++ b/libs/lume/src/Unattended/VNCAutomation.swift
@@ -64,8 +64,8 @@ final class VNCAutomation {
                 button: .left
             )
 
-        case .typeText(let text):
-            try await vncService.sendText(text)
+        case .typeText(let text, let delay):
+            try await vncService.sendText(text, delayMs: delay)
 
         case .keyPress(let key):
             let keyCode = specialKeyToKeyCode(key)
@@ -320,8 +320,11 @@ final class VNCAutomation {
             return "click '\(text)' (index: \(index), xoffset: \(xOffset), yoffset: \(yOffset))"
         case .clickAt(let x, let y):
             return "click at (\(x), \(y))"
-        case .typeText(let text):
+        case .typeText(let text, let delay):
             let displayText = text.count > 20 ? String(text.prefix(20)) + "..." : text
+            if let delay = delay {
+                return "type '\(displayText)' (delay: \(delay)ms)"
+            }
             return "type '\(displayText)'"
         case .keyPress(let key):
             return "press <\(key.rawValue)>"

--- a/libs/lume/src/VNC/VNCService.swift
+++ b/libs/lume/src/VNC/VNCService.swift
@@ -17,7 +17,7 @@ protocol VNCService {
     func captureFramebuffer() async throws -> CGImage
     func sendMouseClick(at point: CGPoint, button: VNCMouseButton) async throws
     func sendKeyPress(_ keyCode: UInt16, modifiers: VNCKeyModifiers) async throws
-    func sendText(_ text: String) async throws
+    func sendText(_ text: String, delayMs: Int?) async throws
     func sendCharWithModifiers(_ char: Character, modifiers: VNCKeyModifiers) async throws
 
     // VNC client for input
@@ -330,10 +330,13 @@ final class DefaultVNCService: VNCService {
         Logger.debug("Key press sent via VNC client")
     }
 
-    func sendText(_ text: String) async throws {
+    func sendText(_ text: String, delayMs: Int? = nil) async throws {
         guard let client = vncClient else {
             throw UnattendedError.inputSimulationFailed("VNC input client not connected")
         }
+
+        // Use provided delay or default to 50ms
+        let delayNs = UInt64(delayMs ?? 50) * 1_000_000
 
         // Type each character using X11 keysyms
         for char in text {
@@ -344,14 +347,14 @@ final class DefaultVNCService: VNCService {
             }
 
             try await client.sendKeyEvent(key: keysym, down: true)
-            try await Task.sleep(nanoseconds: 100_000_000) // 100ms key hold
+            try await Task.sleep(nanoseconds: delayNs) // key hold
             try await client.sendKeyEvent(key: keysym, down: false)
 
             if needsShift {
                 try await client.sendKeyEvent(key: X11Keysym.shiftL.rawValue, down: false)
             }
 
-            try await Task.sleep(nanoseconds: 250_000_000) // 250ms between characters
+            try await Task.sleep(nanoseconds: delayNs) // between characters
         }
     }
 


### PR DESCRIPTION
## Summary
Adds optional `delay` parameter to `<type>` command in YAML configs, allowing per-command control over typing speed.

## Syntax
```yaml
# Default 50ms delay
- "<type 'English'>"

# Custom 100ms delay
- "<type 'Terminal', delay=100>"

# Slower 200ms for long commands
- "<type 'some command', delay=200>"
```

## Changes
- `BootCommandParser`: Parse optional `delay=N` parameter
- `BootCommand.typeText`: Now includes optional delay
- `VNCService.sendText`: Accept `delayMs` parameter (default 50ms)
- `VNCAutomation`: Pass delay to VNC service

## Test plan
- [ ] Test `<type 'text'>` uses default 50ms
- [ ] Test `<type 'text', delay=100>` uses 100ms
- [ ] Run unattended setup with custom delays