### PR TITLE
fix(lume): use click instead of enter for Terminal in Spotlight

### DIFF
--- a/libs/lume/src/Resources/unattended-presets/sequoia.yml
+++ b/libs/lume/src/Resources/unattended-presets/sequoia.yml
@@ -200,9 +200,9 @@ boot_commands:
   # ============================================
   - "<cmd+space>"
   - "<delay 5>"
-  - "<type 'Terminal', delay=350>"
+  - "<type 'Termina', delay=350>"
   - "<delay 5>"
-  - "<enter>"
+  - "<click 'Terminal'>"
   - "<delay 5>"
   - "<type 'defaults write NSGlobalDomain AppleKeyboardUIMode -int 3', delay=350>"
   - "<enter>"
@@ -232,7 +232,7 @@ boot_commands:
   # Search for Remote Login settings
   - "<cmd+f>"
   - "<delay 1>"
-  - "<type 'Remote Login'>"
+  - "<type 'login'>"
   - "<delay 2>"
   - "<click 'Remote Login'>"
   - "<delay 10>"

--- a/libs/lume/src/Resources/unattended-presets/tahoe.yml
+++ b/libs/lume/src/Resources/unattended-presets/tahoe.yml
@@ -211,9 +211,9 @@ boot_commands:
   # ============================================
   - "<cmd+space>"
   - "<delay 5>"
-  - "<type 'Terminal', delay=350>"
+  - "<type 'Termina', delay=350>"
   - "<delay 5>"
-  - "<enter>"
+  - "<click 'Terminal'>"
   - "<delay 5>"
   - "<type 'defaults write NSGlobalDomain AppleKeyboardUIMode -int 3', delay=350>"
   - "<enter>"
@@ -243,7 +243,7 @@ boot_commands:
   # Search for Remote Login settings
   - "<cmd+f>"
   - "<delay 1>"
-  - "<type 'Remote Login'>"
+  - "<type 'login'>"
   - "<delay 2>"
   - "<click 'Remote Login'>"
   - "<delay 10>"


### PR DESCRIPTION
## Summary
Type 'Termina' and click 'Terminal' instead of typing full word and pressing enter. This is more reliable for Spotlight search.

## Changes
- Type partial word 'Termina' with delay=350
- Click on 'Terminal' result instead of pressing enter

## Test plan
- [ ] Run unattended setup and verify Terminal opens correctly