### PR TITLE
fix(lume): use enter instead of click for Terminal in Spotlight

### DIFF
--- a/libs/lume/src/Resources/unattended-presets/sequoia.yml
+++ b/libs/lume/src/Resources/unattended-presets/sequoia.yml
@@ -202,7 +202,7 @@ boot_commands:
   - "<delay 5>"
   - "<type 'Termina', delay=350>"
   - "<delay 5>"
-  - "<click 'Terminal'>"
+  - "<enter>"
   - "<delay 5>"
   - "<type 'defaults write NSGlobalDomain AppleKeyboardUIMode -int 3', delay=350>"
   - "<enter>"

--- a/libs/lume/src/Resources/unattended-presets/tahoe.yml
+++ b/libs/lume/src/Resources/unattended-presets/tahoe.yml
@@ -213,7 +213,7 @@ boot_commands:
   - "<delay 5>"
   - "<type 'Termina', delay=350>"
   - "<delay 5>"
-  - "<click 'Terminal'>"
+  - "<enter>"
   - "<delay 5>"
   - "<type 'defaults write NSGlobalDomain AppleKeyboardUIMode -int 3', delay=350>"
   - "<enter>"


### PR DESCRIPTION
## Summary
Use enter after typing 'Termina' in Spotlight instead of clicking on 'Terminal' result.

## Changes
- Type 'Termina' with delay=350
- Press enter instead of clicking

## Test plan
- [ ] Run unattended setup and verify Terminal opens correctly