### PR TITLE
fix(lume): remove key hold duration from type command

### DIFF
--- a/libs/lume/src/VNC/VNCService.swift
+++ b/libs/lume/src/VNC/VNCService.swift
@@ -347,7 +347,6 @@ final class DefaultVNCService: VNCService {
             }
 
             try await client.sendKeyEvent(key: keysym, down: true)
-            try await Task.sleep(nanoseconds: delayNs) // key hold
             try await client.sendKeyEvent(key: keysym, down: false)
 
             if needsShift {


### PR DESCRIPTION
## Summary
- Remove the sleep between key-down and key-up events in `sendText()`
- The `delay` parameter now only controls the inter-character delay, not how long each key is held
- Fixes macOS key repeat triggering in Terminal when using `<type '...', delay=350>`

## Test plan
- [ ] Run unattended setup and verify Terminal commands type correctly without repeated characters