### PR TITLE
Update MCP server endpoint URLs to production domain

### DIFF
--- a/docs/content/docs/cua/vibe-coding-mcp.mdx
+++ b/docs/content/docs/cua/vibe-coding-mcp.mdx
@@ -14,7 +14,7 @@ The CUA MCP server equips AI coding agents with deep knowledge about CUA's APIs,
 
 | Endpoint | URL |
 |----------|-----|
-| SSE Transport | `https://docs-mcp.cua.ai/sse` |
+| SSE Transport | `https://vk-mcp.cua.ai/sse` |
 
 ## Available Tools
 
@@ -47,7 +47,7 @@ The MCP server exposes four read-only query tools:
 {
   "mcpServers": {
     "CUA MCP": {
-      "url": "https://docs-mcp.cua.ai/sse"
+      "url": "https://vk-mcp.cua.ai/sse"
     }
   }
 }
@@ -58,7 +58,7 @@ The MCP server exposes four read-only query tools:
 Add the MCP server using the CLI:
 
 ```bash
-claude mcp add --transport sse cua-mcp https://docs-mcp.cua.ai/sse
+claude mcp add --transport sse cua-mcp https://vk-mcp.cua.ai/sse
 ```
 
 Verify the connection:
@@ -71,7 +71,7 @@ Expected output:
 
 ```
 Checking MCP server health...
-cua-mcp: https://docs-mcp.cua.ai/sse (SSE) - ✓ Connected
+cua-mcp: https://vk-mcp.cua.ai/sse (SSE) - ✓ Connected
 ```
 
 Management commands:
@@ -90,7 +90,7 @@ claude mcp remove cua-mcp -s local
 2. Click **Add custom connector**
 3. Enter the following:
    - **Name**: `CUA MCP`
-   - **URL**: `https://docs-mcp.cua.ai/sse`
+   - **URL**: `https://vk-mcp.cua.ai/sse`
 4. Click **Add**
 
 ### Windsurf
@@ -98,7 +98,7 @@ claude mcp remove cua-mcp -s local
 1. Open Windsurf Settings (bottom right settings button)
 2. Navigate to **Cascade** > **Model Context Protocol**
 3. Click **Add Server** > **Add custom server**
-4. Select **SSE** transport and enter: `https://docs-mcp.cua.ai/sse`
+4. Select **SSE** transport and enter: `https://vk-mcp.cua.ai/sse`
 
 Configuration file location:
 - **macOS**: `~/.codeium/windsurf/mcp_config.json`
@@ -113,7 +113,7 @@ Configuration file location:
 4. Click **Remote Servers** tab
 5. Enter:
    - **Server Name**: `CUA MCP`
-   - **Server URL**: `https://docs-mcp.cua.ai/sse`
+   - **Server URL**: `https://vk-mcp.cua.ai/sse`
 6. Click **Add Server**
 
 ### GitHub Copilot
@@ -125,7 +125,7 @@ Configuration file location:
 {
   "servers": {
     "CUA MCP": {
-      "url": "https://docs-mcp.cua.ai/sse"
+      "url": "https://vk-mcp.cua.ai/sse"
     }
   }
 }
@@ -139,7 +139,7 @@ For any MCP-compatible application:
 
 **SSE Connection**:
 ```
-https://docs-mcp.cua.ai/sse
+https://vk-mcp.cua.ai/sse
 ```
 
 **Common JSON Configuration**:
@@ -147,7 +147,7 @@ https://docs-mcp.cua.ai/sse
 {
   "servers": {
     "CUA MCP": {
-      "url": "https://docs-mcp.cua.ai/sse"
+      "url": "https://vk-mcp.cua.ai/sse"
     }
   }
 }

--- a/docs/src/app/api/copilotkit/route.ts
+++ b/docs/src/app/api/copilotkit/route.ts
@@ -414,7 +414,7 @@ If users seem stuck, invite them to join the Discord: https://discord.com/invite
   mcpServers: [
     {
       type: 'sse',
-      url: 'https://cuaai--cua-docs-mcp-web.modal.run/sse',
+      url: 'https://vk-mcp.cua.ai/sse',
     },
   ],
 });


### PR DESCRIPTION
## Summary
Updates all references to the CUA MCP server endpoint from the development/staging URLs to the production URL `https://vk-mcp.cua.ai/sse`.

## Changes Made
- **Documentation**: Updated all MCP server endpoint references in `docs/content/docs/cua/vibe-coding-mcp.mdx`
  - Changed `https://docs-mcp.cua.ai/sse` to `https://vk-mcp.cua.ai/sse` across all integration guides (Claude, Windsurf, Cline, GitHub Copilot)
  - Updated configuration examples and CLI commands
  - Updated expected output examples in verification steps

- **API Route**: Updated the CopilotKit configuration in `docs/src/app/api/copilotkit/route.ts`
  - Changed from `https://cuaai--cua-docs-mcp-web.modal.run/sse` to `https://vk-mcp.cua.ai/sse`

## Details
This change consolidates the MCP server endpoint to use the production domain `vk-mcp.cua.ai` across all documentation and API configurations. The updates ensure consistency and point all integrations to the stable production endpoint.

https://claude.ai/code/session_019bsS6KLXJeEebktb6CvWEp