### PR TITLE
docs(lume): add OpenClaw setup example

### DIFF
--- a/docs/content/docs/lume/examples/index.mdx
+++ b/docs/content/docs/lume/examples/index.mdx
@@ -4,7 +4,7 @@ description: Step-by-step tutorials and use cases for Lume
 ---
 
 import { Card, Cards } from 'fumadocs-ui/components/card';
-import { Bot, Terminal } from 'lucide-react';
+import { Bot, Terminal, MessageCircle } from 'lucide-react';
 
 # Examples
 
@@ -23,6 +23,12 @@ Explore real-world examples and tutorials for using Lume to create and manage ma
     title="Claude Cowork"
     description="Use Claude Cowork with Lume MCP connector"
   />
+  <Card
+    icon={<MessageCircle className="w-6 h-6" />}
+    href="/lume/examples/openclaw"
+    title="OpenClaw"
+    description="Run OpenClaw messaging gateway with iMessage support"
+  />
 </Cards>
 
 ## Available Examples
@@ -40,6 +46,12 @@ Use Claude Cowork with the Lume MCP connector for native VM management:
 
 - **[Sandbox with MCP](/lume/examples/claude-cowork/sandbox)** — Configure the MCP connector for VM lifecycle control
 - **[Stock Analysis with Numbers](/lume/examples/claude-cowork/numbers-stock-analysis)** — Use macOS-only apps like Numbers.app
+
+### OpenClaw
+
+Run a unified messaging gateway that bridges WhatsApp, Telegram, iMessage, and more with AI agents:
+
+- **[OpenClaw Setup](/lume/examples/openclaw)** — Install and configure OpenClaw in a headless macOS VM with iMessage support
 
 ## Coming Soon
 

--- a/docs/content/docs/lume/examples/meta.json
+++ b/docs/content/docs/lume/examples/meta.json
@@ -2,5 +2,5 @@
   "title": "Examples",
   "description": "Step-by-step tutorials and use cases",
   "icon": "Blocks",
-  "pages": ["claude-code", "claude-cowork"]
+  "pages": ["claude-code", "claude-cowork", "openclaw"]
 }

--- a/docs/content/docs/lume/examples/openclaw/index.mdx
+++ b/docs/content/docs/lume/examples/openclaw/index.mdx
@@ -1,0 +1,231 @@
+---
+title: OpenClaw Setup
+description: Run OpenClaw messaging gateway in an isolated macOS VM with Lume
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Run [OpenClaw](https://openclaw.dev) in a headless macOS VM to create a unified messaging gateway that bridges WhatsApp, Telegram, iMessage, and more with AI agents.
+
+## Why run OpenClaw in a VM?
+
+Running OpenClaw in a macOS VM provides several advantages:
+
+- **iMessage integration** — Only macOS can run iMessage natively; a VM gives you this capability on any Apple Silicon Mac
+- **Isolation** — Keep your messaging gateway separate from your main system
+- **Always-on operation** — Run the VM headlessly 24/7 without affecting your desktop
+- **Easy reset** — Clone and restore VMs to quickly recover from issues
+
+## Quick path (experienced users)
+
+```bash
+# Install Lume
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/lume/scripts/install.sh)"
+
+# Create and setup VM
+lume create openclaw --os macos --ipsw latest
+
+# Complete Setup Assistant in VNC window, enable Remote Login (SSH)
+# Then run headlessly
+lume run openclaw --no-display
+
+# SSH in, install OpenClaw, configure channels
+ssh youruser@<VM_IP>
+npm install -g openclaw@latest
+openclaw onboard --install-daemon
+```
+
+## Requirements
+
+- Apple Silicon Mac (M1/M2/M3/M4)
+- macOS Sequoia or later on the host
+- ~60 GB free disk space per VM
+
+## Step 1: Install Lume
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/lume/scripts/install.sh)"
+```
+
+If `~/.local/bin` isn't in your PATH:
+
+```bash
+echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.zshrc && source ~/.zshrc
+```
+
+Verify the installation:
+
+```bash
+lume --version
+```
+
+See [Lume Installation](/lume/guide/getting-started/installation) for more details.
+
+## Step 2: Create the macOS VM
+
+```bash
+lume create openclaw --os macos --ipsw latest
+```
+
+This downloads macOS and creates the VM. A VNC window opens automatically.
+
+<Callout type="info">
+The macOS download can take a while depending on your connection speed.
+</Callout>
+
+## Step 3: Complete Setup Assistant
+
+In the VNC window:
+
+1. Select language and region
+2. Skip Apple ID (or sign in if you want iMessage later)
+3. Create a user account (remember the username and password)
+4. Skip all optional features
+
+After setup completes, enable SSH:
+
+1. Open **System Settings** → **General** → **Sharing**
+2. Enable **Remote Login**
+
+## Step 4: Get the VM's IP address
+
+```bash
+lume get openclaw
+```
+
+Look for the IP address in the output (usually `192.168.64.x`).
+
+## Step 5: SSH into the VM
+
+```bash
+ssh youruser@192.168.64.X
+```
+
+Replace `youruser` with the account you created, and the IP with your VM's IP.
+
+## Step 6: Install OpenClaw
+
+Inside the VM via SSH:
+
+```bash
+npm install -g openclaw@latest
+openclaw onboard --install-daemon
+```
+
+Follow the onboarding prompts to set up your model provider (Anthropic, OpenAI, etc.).
+
+## Step 7: Configure channels
+
+Edit the config file:
+
+```bash
+nano ~/.openclaw/openclaw.json
+```
+
+Add your channels:
+
+```json
+{
+  "channels": {
+    "whatsapp": {
+      "dmPolicy": "allowlist",
+      "allowFrom": ["+15551234567"]
+    },
+    "telegram": {
+      "botToken": "YOUR_BOT_TOKEN"
+    }
+  }
+}
+```
+
+Then login to WhatsApp (scan QR):
+
+```bash
+openclaw channels login
+```
+
+## Step 8: Run the VM headlessly
+
+Stop the VM and restart without display:
+
+```bash
+lume stop openclaw
+lume run openclaw --no-display
+```
+
+The VM runs in the background. OpenClaw's daemon keeps the gateway running.
+
+To check status:
+
+```bash
+ssh youruser@192.168.64.X "openclaw status"
+```
+
+## iMessage integration with BlueBubbles
+
+This is the killer feature of running on macOS. Use [BlueBubbles](https://bluebubbles.app) to add iMessage to OpenClaw.
+
+Inside the VM:
+
+1. Download BlueBubbles from [bluebubbles.app](https://bluebubbles.app)
+2. Sign in with your Apple ID
+3. Enable the Web API and set a password
+4. Point BlueBubbles webhooks at your gateway (example: `https://your-gateway-host:3000/bluebubbles-webhook?password=<password>`)
+
+Add to your OpenClaw config:
+
+```json
+{
+  "channels": {
+    "bluebubbles": {
+      "serverUrl": "http://localhost:1234",
+      "password": "your-api-password",
+      "webhookPath": "/bluebubbles-webhook"
+    }
+  }
+}
+```
+
+Restart the gateway. Now your agent can send and receive iMessages.
+
+## Save a golden image
+
+Before customizing further, snapshot your clean state:
+
+```bash
+lume stop openclaw
+lume clone openclaw openclaw-golden
+```
+
+Reset anytime:
+
+```bash
+lume stop openclaw && lume delete openclaw
+lume clone openclaw-golden openclaw
+lume run openclaw --no-display
+```
+
+## Running 24/7
+
+Keep the VM running by:
+
+- Keeping your Mac plugged in
+- Disabling sleep in **System Settings** → **Energy Saver**
+- Using `caffeinate` if needed
+
+For true always-on operation, consider a dedicated Mac mini or a small VPS. See [VPS hosting](https://openclaw.dev/docs/vps-hosting) for options.
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Can't SSH into VM | Check "Remote Login" is enabled in VM's System Settings |
+| VM IP not showing | Wait for VM to fully boot, run `lume get openclaw` again |
+| Lume command not found | Add `~/.local/bin` to your PATH |
+| WhatsApp QR not scanning | Ensure you're logged into the VM (not host) when running `openclaw channels login` |
+
+## Next steps
+
+- [VM Management](/lume/guide/fundamentals/vm-management) — Learn more about managing VMs
+- [Unattended Setup](/lume/guide/fundamentals/unattended-setup) — Automate VM creation without manual steps
+- [HTTP Server](/lume/guide/advanced/http-server) — Control VMs programmatically via API

--- a/docs/content/docs/lume/examples/openclaw/meta.json
+++ b/docs/content/docs/lume/examples/openclaw/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "OpenClaw",
+  "description": "Run OpenClaw messaging gateway in a macOS VM",
+  "pages": ["index"]
+}


### PR DESCRIPTION
Add documentation for setting up OpenClaw messaging gateway in a macOS VM using Lume. The guide covers:
- Quick start path for experienced users
- Step-by-step VM creation and setup
- OpenClaw installation and channel configuration
- iMessage integration via BlueBubbles
- Creating golden images for easy reset
- Running VMs headlessly 24/7
- Troubleshooting common issues

https://claude.ai/code/session_01GVP7fuhGZ11EqSK9DX7CPq