### PR TITLE
fix(lume): simplify remote login toggle sequence

### DIFF
--- a/libs/lume/src/Resources/unattended-presets/sequoia.yml
+++ b/libs/lume/src/Resources/unattended-presets/sequoia.yml
@@ -238,16 +238,13 @@ boot_commands:
   - "<delay 10>"
 
   # Enable Remote Login toggle (first toggle on the page)
-  - "<tab>"
-  - "<delay 0.5>"
   - "<space>"
   - "<delay 3>"
-
-  # Enable "Allow full disk access for remote users" toggle (next toggle)
   - "<tab>"
-  - "<delay 0.5>"
+  - "<delay 3>"
   - "<space>"
-  - "<delay 2>"
+  - "<delay 3>"
+  - "<enter>"
 
   # Close System Settings
   - "<cmd+q>"

--- a/libs/lume/src/Resources/unattended-presets/tahoe.yml
+++ b/libs/lume/src/Resources/unattended-presets/tahoe.yml
@@ -246,23 +246,20 @@ boot_commands:
   - "<type 'login'>"
   - "<delay 2>"
   - "<click 'Remote Login'>"
-  - "<delay 10>"
+  - "<delay 20>"
 
   # Enable Remote Login toggle (first toggle on the page)
-  - "<tab>"
-  - "<delay 0.5>"
   - "<space>"
   - "<delay 3>"
-
-  # Enable "Allow full disk access for remote users" toggle (next toggle)
   - "<tab>"
-  - "<delay 0.5>"
+  - "<delay 3>"
   - "<space>"
-  - "<delay 2>"
+  - "<delay 3>"
+  - "<enter>"
 
   # Close System Settings
   - "<cmd+q>"
-  - "<delay 1>"
+  - "<delay 2>"
 
   # ============================================
   # Setup Complete!


### PR DESCRIPTION
## Summary
- Remove extra tab before the first Remote Login toggle
- Add enter confirmation after enabling full disk access toggle
- Increase delays for reliability (especially on tahoe)

## Test plan
- [ ] Run unattended setup on sequoia and verify Remote Login enables correctly
- [ ] Run unattended setup on tahoe and verify Remote Login enables correctly