### PR TITLE
fix(lume): fix sudo handling in post-SSH and prevent idle lock screen

### DIFF
--- a/libs/lume/src/Resources/unattended-presets/sequoia.yml
+++ b/libs/lume/src/Resources/unattended-presets/sequoia.yml
@@ -273,11 +273,16 @@ post_ssh_commands:
   # Enable auto-login for the lume user
   - "sudo sysadminctl -autologin set -userName lume -password lume"
   # Generate kcpassword for auto-login (sysadminctl alone doesn't always create it)
-  - "perl -e 'my @k=(125,137,82,35,210,188,221,234,163,185,31);my @p=unpack(q{C*},q{lume});my @e;for my $i(0..$#p){$e[$i]=$p[$i]^$k[$i%scalar@k]}my $r=scalar@e%12;push@e,(0)x(12-$r) if $r;open my $f,q{>},q{/tmp/kcp};binmode $f;print $f pack(q{C*},@e);close $f' && sudo cp /tmp/kcp /etc/kcpassword && sudo chmod 600 /etc/kcpassword && rm /tmp/kcp"
+  - "perl -e 'my @k=(125,137,82,35,210,188,221,234,163,185,31);my @p=unpack(q{C*},q{lume});my @e;for my $i(0..$#p){$e[$i]=$p[$i]^$k[$i%scalar@k]}my $r=scalar@e%12;push@e,(0)x(12-$r) if $r;open my $f,q{>},q{/tmp/kcp};binmode $f;print $f pack(q{C*},@e);close $f'"
+  - "sudo cp /tmp/kcp /etc/kcpassword"
+  - "sudo chmod 600 /etc/kcpassword"
+  - "rm /tmp/kcp"
   # Disable screen saver
   - "defaults -currentHost write com.apple.screensaver idleTime -int 0"
   # Disable require password after sleep/screen saver
   - "defaults write com.apple.screensaver askForPassword -int 0"
+  # Set password delay to 0 (no delay before requiring password)
+  - "defaults write com.apple.screensaver askForPasswordDelay -int 0"
   # Prevent display from sleeping (never)
   - "sudo pmset -a displaysleep 0"
   # Prevent system sleep (never)

--- a/libs/lume/src/Resources/unattended-presets/tahoe.yml
+++ b/libs/lume/src/Resources/unattended-presets/tahoe.yml
@@ -284,11 +284,16 @@ post_ssh_commands:
   # Enable auto-login for the lume user
   - "sudo sysadminctl -autologin set -userName lume -password lume"
   # Generate kcpassword for auto-login (sysadminctl alone doesn't always create it)
-  - "perl -e 'my @k=(125,137,82,35,210,188,221,234,163,185,31);my @p=unpack(q{C*},q{lume});my @e;for my $i(0..$#p){$e[$i]=$p[$i]^$k[$i%scalar@k]}my $r=scalar@e%12;push@e,(0)x(12-$r) if $r;open my $f,q{>},q{/tmp/kcp};binmode $f;print $f pack(q{C*},@e);close $f' && sudo cp /tmp/kcp /etc/kcpassword && sudo chmod 600 /etc/kcpassword && rm /tmp/kcp"
+  - "perl -e 'my @k=(125,137,82,35,210,188,221,234,163,185,31);my @p=unpack(q{C*},q{lume});my @e;for my $i(0..$#p){$e[$i]=$p[$i]^$k[$i%scalar@k]}my $r=scalar@e%12;push@e,(0)x(12-$r) if $r;open my $f,q{>},q{/tmp/kcp};binmode $f;print $f pack(q{C*},@e);close $f'"
+  - "sudo cp /tmp/kcp /etc/kcpassword"
+  - "sudo chmod 600 /etc/kcpassword"
+  - "rm /tmp/kcp"
   # Disable screen saver
   - "defaults -currentHost write com.apple.screensaver idleTime -int 0"
   # Disable require password after sleep/screen saver
   - "defaults write com.apple.screensaver askForPassword -int 0"
+  # Set password delay to 0 (no delay before requiring password)
+  - "defaults write com.apple.screensaver askForPasswordDelay -int 0"
   # Prevent display from sleeping (never)
   - "sudo pmset -a displaysleep 0"
   # Prevent system sleep (never)

--- a/libs/lume/src/Unattended/HealthCheckRunner.swift
+++ b/libs/lume/src/Unattended/HealthCheckRunner.swift
@@ -105,12 +105,14 @@ struct HealthCheckRunner {
                 "command": command.prefix(50).description
             ])
 
-            // Handle sudo commands by using sudo -S which reads password from stdin
+            // Handle sudo commands by replacing sudo with password-piped sudo -S
+            let escapedPassword = password.replacingOccurrences(of: "'", with: "'\\''")
             let actualCommand: String
-            if command.hasPrefix("sudo ") {
-                let sudoCommand = String(command.dropFirst(5))
-                let escapedPassword = password.replacingOccurrences(of: "'", with: "'\\''")
-                actualCommand = "echo '\(escapedPassword)' | sudo -S \(sudoCommand)"
+            if command.contains("sudo ") {
+                actualCommand = command.replacingOccurrences(
+                    of: "sudo ",
+                    with: "echo '\(escapedPassword)' | sudo -S "
+                )
             } else {
                 actualCommand = command
             }


### PR DESCRIPTION
## Summary
- Split kcpassword perl command so `sudo cp` and `sudo chmod` are separate commands, ensuring HealthCheckRunner pipes the password correctly
- Change HealthCheckRunner `hasPrefix("sudo ")` → `contains("sudo ")` to handle sudo anywhere in a command
- Add `askForPasswordDelay` setting to prevent lock screen after idle

## Test plan
- [ ] Run unattended setup and verify all post-SSH commands succeed
- [ ] Verify VM doesn't show lock screen after being idle
- [ ] Verify `/etc/kcpassword` is created correctly