### PR TITLE
feat(lume): Add bridged networking support (`--network bridged`)

### DIFF
--- a/libs/lume/resources/lume.entitlements
+++ b/libs/lume/resources/lume.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.virtualization</key>
 	<true/>
+	<key>com.apple.vm.networking</key>
+	<true/>
 </dict>
 </plist>

--- a/libs/lume/src/Commands/Config.swift
+++ b/libs/lume/src/Commands/Config.swift
@@ -1,11 +1,12 @@
 import ArgumentParser
 import Foundation
+import Virtualization
 
 struct Config: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "config",
         abstract: "Get or set lume configuration",
-        subcommands: [Get.self, Storage.self, Cache.self, Caching.self, Telemetry.self],
+        subcommands: [Get.self, Storage.self, Cache.self, Caching.self, Telemetry.self, Network.self],
         defaultSubcommand: Get.self
     )
 
@@ -286,6 +287,43 @@ struct Config: ParsableCommand {
                 let controller = LumeController()
                 try controller.setTelemetryEnabled(false)
                 print("Telemetry disabled")
+            }
+        }
+    }
+
+    // MARK: - Network Management Subcommands
+
+    struct Network: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "network",
+            abstract: "Manage network settings",
+            subcommands: [Interfaces.self]
+        )
+
+        struct Interfaces: ParsableCommand {
+            static let configuration = CommandConfiguration(
+                commandName: "interfaces",
+                abstract: "List available network interfaces for bridged networking"
+            )
+
+            func run() throws {
+                let interfaces = VZBridgedNetworkInterface.networkInterfaces
+
+                if interfaces.isEmpty {
+                    print("No bridgeable network interfaces found.")
+                    print("")
+                    print("Note: Bridged networking requires the com.apple.vm.networking entitlement.")
+                    return
+                }
+
+                print("Available network interfaces for bridged networking:")
+                print("")
+                for iface in interfaces {
+                    let name = iface.localizedDisplayName ?? "Unknown"
+                    print("  \(iface.identifier) — \(name)")
+                }
+                print("")
+                print("Usage: lume run <vm-name> --network bridged:\(interfaces.first?.identifier ?? "en0")")
             }
         }
     }

--- a/libs/lume/src/Commands/Create.swift
+++ b/libs/lume/src/Commands/Create.swift
@@ -72,6 +72,22 @@ struct Create: AsyncParsableCommand {
         help: "Port to use for the VNC server during unattended setup. Defaults to 0 (auto-assign)")
     var vncPort: Int = 0
 
+    @Option(
+        name: .customLong("network"),
+        help: "Network mode: 'nat' (default), 'bridged' (auto-select interface), or 'bridged:<interface>' (e.g. 'bridged:en0')")
+    var network: String = "nat"
+
+    private var parsedNetworkMode: NetworkMode {
+        get throws {
+            guard let mode = NetworkMode.parse(network) else {
+                throw ValidationError(
+                    "Invalid network mode '\(network)'. Expected 'nat', 'bridged', or 'bridged:<interface>'."
+                )
+            }
+            return mode
+        }
+    }
+
     init() {
     }
 
@@ -124,7 +140,8 @@ struct Create: AsyncParsableCommand {
             debug: debug,
             debugDir: debugDir,
             noDisplay: unattendedConfig != nil ? true : noDisplay,  // Default to no-display for unattended
-            vncPort: vncPort
+            vncPort: vncPort,
+            networkMode: parsedNetworkMode
         )
     }
 }

--- a/libs/lume/src/Commands/Run.swift
+++ b/libs/lume/src/Commands/Run.swift
@@ -51,6 +51,22 @@ struct Run: AsyncParsableCommand {
     @Option(name: .customLong("storage"), help: "VM storage location to use or direct path to VM location")
     var storage: String?
 
+    @Option(
+        name: .customLong("network"),
+        help: "Network mode: 'nat' (default), 'bridged' (auto-select interface), or 'bridged:<interface>' (e.g. 'bridged:en0')")
+    var network: String = "nat"
+
+    private var parsedNetworkMode: NetworkMode {
+        get throws {
+            guard let mode = NetworkMode.parse(network) else {
+                throw ValidationError(
+                    "Invalid network mode '\(network)'. Expected 'nat', 'bridged', or 'bridged:<interface>'."
+                )
+            }
+            return mode
+        }
+    }
+
     private var parsedSharedDirectories: [SharedDirectory] {
         get throws {
             try sharedDirectories.map { dirString -> SharedDirectory in
@@ -113,7 +129,8 @@ struct Run: AsyncParsableCommand {
             vncPort: vncPort,
             recoveryMode: recoveryMode,
             storage: storage,
-            usbMassStoragePaths: parsedUSBStorageDevices.isEmpty ? nil : parsedUSBStorageDevices
+            usbMassStoragePaths: parsedUSBStorageDevices.isEmpty ? nil : parsedUSBStorageDevices,
+            networkMode: parsedNetworkMode
         )
     }
 }

--- a/libs/lume/src/Errors/Errors.swift
+++ b/libs/lume/src/Errors/Errors.swift
@@ -96,6 +96,7 @@ enum VMConfigError: CustomNSError, LocalizedError {
     case invalidHardwareModel
     case invalidDiskSize
     case malformedSizeInput(String)
+    case noBridgeInterfaceFound(requested: String?, available: String)
     
     var errorDescription: String? {
         switch self {
@@ -113,6 +114,11 @@ enum VMConfigError: CustomNSError, LocalizedError {
             return "Invalid disk size"
         case .malformedSizeInput(let input):
             return "Malformed size input: \(input)"
+        case .noBridgeInterfaceFound(let requested, let available):
+            if let requested = requested {
+                return "Bridge network interface '\(requested)' not found. Available interfaces: \(available)"
+            }
+            return "No bridge network interfaces available on this host. Available: \(available)"
         }
     }
     
@@ -127,6 +133,7 @@ enum VMConfigError: CustomNSError, LocalizedError {
         case .invalidHardwareModel: return 5
         case .invalidDiskSize: return 6
         case .malformedSizeInput: return 7
+        case .noBridgeInterfaceFound: return 8
         }
     }
 }

--- a/libs/lume/src/FileSystem/VMConfig.swift
+++ b/libs/lume/src/FileSystem/VMConfig.swift
@@ -25,6 +25,7 @@ struct VMConfig: Codable {
     private var _display: VMDisplayResolution
     private var _hardwareModel: Data?
     private var _machineIdentifier: Data?
+    private var _networkMode: NetworkMode
     
     // MARK: - Initialization
     init(
@@ -35,7 +36,8 @@ struct VMConfig: Codable {
         macAddress: String? = nil,
         display: String,
         hardwareModel: Data? = nil,
-        machineIdentifier: Data? = nil
+        machineIdentifier: Data? = nil,
+        networkMode: NetworkMode = .nat
     ) throws {
         self.os = os
         self._cpuCount = cpuCount
@@ -45,6 +47,7 @@ struct VMConfig: Codable {
         self._display = VMDisplayResolution(string: display) ?? VMDisplayResolution(string: "1024x768")!
         self._hardwareModel = hardwareModel
         self._machineIdentifier = machineIdentifier
+        self._networkMode = networkMode
     }
     
     var display: VMDisplayResolution {
@@ -81,6 +84,11 @@ struct VMConfig: Codable {
         get { _macAddress }
         set { _macAddress = newValue }
     }
+
+    var networkMode: NetworkMode {
+        get { _networkMode }
+        set { _networkMode = newValue }
+    }
     
     mutating func setCpuCount(_ count: Int) {
         _cpuCount = count
@@ -110,6 +118,10 @@ struct VMConfig: Codable {
         self._display = newDisplay
     }
 
+    mutating func setNetworkMode(_ newNetworkMode: NetworkMode) {
+        self._networkMode = newNetworkMode
+    }
+
     // MARK: - Codable
     enum CodingKeys: String, CodingKey {
         case _cpuCount = "cpuCount"
@@ -120,6 +132,7 @@ struct VMConfig: Codable {
         case _hardwareModel = "hardwareModel"
         case _machineIdentifier = "machineIdentifier"
         case os
+        case networkMode
     }
     
     init(from decoder: Decoder) throws {
@@ -133,6 +146,8 @@ struct VMConfig: Codable {
         _display = VMDisplayResolution(string: try container.decode(String.self, forKey: .display))!
         _hardwareModel = try container.decodeIfPresent(Data.self, forKey: ._hardwareModel)
         _machineIdentifier = try container.decodeIfPresent(Data.self, forKey: ._machineIdentifier)
+        // Default to .nat for backward compatibility with existing configs
+        _networkMode = try container.decodeIfPresent(NetworkMode.self, forKey: .networkMode) ?? .nat
     }
     
     func encode(to encoder: Encoder) throws {
@@ -146,5 +161,6 @@ struct VMConfig: Codable {
         try container.encode(display.string, forKey: .display)
         try container.encodeIfPresent(_hardwareModel, forKey: ._hardwareModel)
         try container.encodeIfPresent(_machineIdentifier, forKey: ._machineIdentifier)
+        try container.encode(_networkMode, forKey: .networkMode)
     }
 }

--- a/libs/lume/src/FileSystem/VMDirectory.swift
+++ b/libs/lume/src/FileSystem/VMDirectory.swift
@@ -330,7 +330,8 @@ extension VMDirectory {
             ipAddress: ipAddress,
             sshAvailable: sshAvailable,
             locationName: locationName,
-            sharedDirectories: nil
+            sharedDirectories: nil,
+            networkMode: config.networkMode.description
         )
     }
 }

--- a/libs/lume/src/LumeController.swift
+++ b/libs/lume/src/LumeController.swift
@@ -400,7 +400,8 @@ final class LumeController {
         debug: Bool = false,
         debugDir: String? = nil,
         noDisplay: Bool = true,
-        vncPort: Int = 0
+        vncPort: Int = 0,
+        networkMode: NetworkMode = .nat
     ) async throws {
         Logger.info(
             "Creating VM",
@@ -437,7 +438,8 @@ final class LumeController {
                 cpuCount: cpuCount,
                 memorySize: memorySize,
                 diskSize: diskSize,
-                display: display
+                display: display,
+                networkMode: networkMode
             )
             try vmDir.saveConfig(config)
 
@@ -467,7 +469,8 @@ final class LumeController {
                 debugDir: debugDir,
                 noDisplay: noDisplay,
                 vncPort: vncPort,
-                vmDir: vmDir
+                vmDir: vmDir,
+                networkMode: networkMode
             )
 
             // Clear provisioning marker on success
@@ -506,7 +509,8 @@ final class LumeController {
         display: String,
         ipsw: String?,
         storage: String? = nil,
-        unattendedConfig: UnattendedConfig? = nil
+        unattendedConfig: UnattendedConfig? = nil,
+        networkMode: NetworkMode = .nat
     ) throws {
         Logger.info(
             "Starting async VM creation",
@@ -536,7 +540,8 @@ final class LumeController {
                 cpuCount: cpuCount,
                 memorySize: memorySize,
                 diskSize: diskSize,
-                display: display
+                display: display,
+                networkMode: networkMode
             )
             try vmDir.saveConfig(config)
 
@@ -571,7 +576,8 @@ final class LumeController {
                     ipsw: ipsw,
                     storage: storage,
                     unattendedConfig: unattendedConfig,
-                    vmDir: vmDir
+                    vmDir: vmDir,
+                    networkMode: networkMode
                 )
 
                 // Clear marker on success
@@ -609,7 +615,8 @@ final class LumeController {
         debugDir: String? = nil,
         noDisplay: Bool = true,
         vncPort: Int = 0,
-        vmDir: VMDirectory? = nil
+        vmDir: VMDirectory? = nil,
+        networkMode: NetworkMode = .nat
     ) async throws {
         Logger.info(
             "Creating VM (internal)",
@@ -891,7 +898,8 @@ final class LumeController {
         vncPort: Int = 0,
         recoveryMode: Bool = false,
         storage: String? = nil,
-        usbMassStoragePaths: [Path]? = nil
+        usbMassStoragePaths: [Path]? = nil,
+        networkMode: NetworkMode = .nat
     ) async throws {
         let normalizedName = normalizeVMName(name: name)
         Logger.info(
@@ -987,7 +995,8 @@ final class LumeController {
                 mount: mount,
                 vncPort: vncPort,
                 recoveryMode: recoveryMode,
-                usbMassStoragePaths: usbMassStoragePaths)
+                usbMassStoragePaths: usbMassStoragePaths,
+                networkMode: networkMode)
             Logger.info("VM started successfully", metadata: ["name": normalizedName])
         } catch {
             SharedVM.shared.removeVM(name: normalizedName)

--- a/libs/lume/src/Server/Requests.swift
+++ b/libs/lume/src/Server/Requests.swift
@@ -7,6 +7,7 @@ struct RunVMRequest: Codable {
     let sharedDirectories: [SharedDirectoryRequest]?
     let recoveryMode: Bool?
     let storage: String?
+    let network: String?
 
     struct SharedDirectoryRequest: Codable {
         let hostPath: String
@@ -67,6 +68,8 @@ struct CreateVMRequest: Codable {
     let storage: String?
     /// Preset name or path to YAML config file for unattended macOS Setup Assistant automation
     let unattended: String?
+    /// Network mode: "nat" (default), "bridged", or "bridged:<interface>"
+    let network: String?
 
     func parse() throws -> (memory: UInt64, diskSize: UInt64) {
         return (

--- a/libs/lume/src/VM/NetworkMode.swift
+++ b/libs/lume/src/VM/NetworkMode.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Represents the networking mode for a virtual machine.
+///
+/// Supports NAT (default) and bridged networking modes.
+/// Bridged networking allows the VM to get its own IP on the LAN via DHCP,
+/// bypassing the host's routing table entirely.
+///
+/// Usage:
+///   - `"nat"` → `.nat`
+///   - `"bridged"` → `.bridged(interface: nil)` (auto-select first available)
+///   - `"bridged:en0"` → `.bridged(interface: "en0")` (specific interface)
+enum NetworkMode: Equatable, CustomStringConvertible {
+    case nat
+    case bridged(interface: String?)
+
+    /// Parse a network mode string.
+    ///
+    /// Accepted formats:
+    ///   - `"nat"` → NAT mode (default)
+    ///   - `"bridged"` → Bridged mode with auto-detected interface
+    ///   - `"bridged:<interface>"` → Bridged mode on a specific interface (e.g. `"bridged:en0"`)
+    ///
+    /// - Parameter string: The string to parse.
+    /// - Returns: A `NetworkMode` value, or `nil` if the string is invalid.
+    static func parse(_ string: String) -> NetworkMode? {
+        let lowercased = string.lowercased()
+
+        if lowercased == "nat" {
+            return .nat
+        }
+
+        if lowercased == "bridged" {
+            return .bridged(interface: nil)
+        }
+
+        if lowercased.hasPrefix("bridged:") {
+            let interface = String(string.dropFirst("bridged:".count))
+            guard !interface.isEmpty else {
+                return .bridged(interface: nil)
+            }
+            return .bridged(interface: interface)
+        }
+
+        return nil
+    }
+
+    var description: String {
+        switch self {
+        case .nat:
+            return "nat"
+        case .bridged(let interface):
+            if let interface = interface {
+                return "bridged:\(interface)"
+            }
+            return "bridged"
+        }
+    }
+
+    /// The string representation used for config persistence.
+    var configString: String {
+        return description
+    }
+}
+
+// MARK: - Codable
+
+extension NetworkMode: Codable {
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let string = try container.decode(String.self)
+        guard let mode = NetworkMode.parse(string) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid network mode: \(string). Expected 'nat', 'bridged', or 'bridged:<interface>'."
+            )
+        }
+        self = mode
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(configString)
+    }
+}

--- a/libs/lume/src/VM/VM.swift
+++ b/libs/lume/src/VM/VM.swift
@@ -126,7 +126,8 @@ class VM {
             vncUrl: vncUrl,
             ipAddress: ipAddress,
             sshAvailable: sshAvailable,
-            locationName: vmDirContext.storage ?? "home"
+            locationName: vmDirContext.storage ?? "home",
+            networkMode: vmDirContext.config.networkMode.description
         )
     }
 
@@ -134,7 +135,8 @@ class VM {
 
     func run(
         noDisplay: Bool, sharedDirectories: [SharedDirectory], mount: Path?, vncPort: Int = 0,
-        recoveryMode: Bool = false, usbMassStoragePaths: [Path]? = nil
+        recoveryMode: Bool = false, usbMassStoragePaths: [Path]? = nil,
+        networkMode: NetworkMode? = nil
     ) async throws {
         Logger.info(
             "VM.run method called",
@@ -221,7 +223,8 @@ class VM {
                 sharedDirectories: sharedDirectories,
                 mount: mount,
                 recoveryMode: recoveryMode,
-                usbMassStoragePaths: usbMassStoragePaths
+                usbMassStoragePaths: usbMassStoragePaths,
+                networkMode: networkMode
             )
             Logger.info(
                 "Successfully created virtualization service context",
@@ -709,10 +712,14 @@ class VM {
         sharedDirectories: [SharedDirectory] = [],
         mount: Path? = nil,
         recoveryMode: Bool = false,
-        usbMassStoragePaths: [Path]? = nil
+        usbMassStoragePaths: [Path]? = nil,
+        networkMode: NetworkMode? = nil
     ) throws -> VMVirtualizationServiceContext {
         // This is a diagnostic log to track actual file paths on disk for debugging
         try validateDiskState()
+
+        // Use provided networkMode, falling back to config value
+        let effectiveNetworkMode = networkMode ?? vmDirContext.config.networkMode
 
         return VMVirtualizationServiceContext(
             cpuCount: cpuCount,
@@ -726,7 +733,8 @@ class VM {
             diskPath: vmDirContext.diskPath,
             nvramPath: vmDirContext.nvramPath,
             recoveryMode: recoveryMode,
-            usbMassStoragePaths: usbMassStoragePaths
+            usbMassStoragePaths: usbMassStoragePaths,
+            networkMode: effectiveNetworkMode
         )
     }
 

--- a/libs/lume/src/VM/VMDetails.swift
+++ b/libs/lume/src/VM/VMDetails.swift
@@ -44,10 +44,12 @@ struct VMDetails: Codable {
     let sshAvailable: Bool?
     let locationName: String
     let sharedDirectories: [SharedDirectory]?
+    let networkMode: String?
 
     enum CodingKeys: String, CodingKey {
         case name, os, cpuCount, memorySize, diskSize, display, status
         case provisioningOperation, vncUrl, ipAddress, sshAvailable, locationName, sharedDirectories
+        case networkMode
     }
 
     init(
@@ -63,7 +65,8 @@ struct VMDetails: Codable {
         ipAddress: String?,
         sshAvailable: Bool? = nil,
         locationName: String,
-        sharedDirectories: [SharedDirectory]? = nil
+        sharedDirectories: [SharedDirectory]? = nil,
+        networkMode: String? = nil
     ) {
         self.name = name
         self.os = os
@@ -78,6 +81,7 @@ struct VMDetails: Codable {
         self.sshAvailable = sshAvailable
         self.locationName = locationName
         self.sharedDirectories = sharedDirectories
+        self.networkMode = networkMode
     }
 
     // Custom encoder to always include optional fields (even when nil)
@@ -96,5 +100,6 @@ struct VMDetails: Codable {
         try container.encode(sshAvailable, forKey: .sshAvailable)
         try container.encode(locationName, forKey: .locationName)
         try container.encode(sharedDirectories, forKey: .sharedDirectories)
+        try container.encode(networkMode, forKey: .networkMode)
     }
 }

--- a/libs/lume/src/VM/VMDetailsPrinter.swift
+++ b/libs/lume/src/VM/VMDetailsPrinter.swift
@@ -34,6 +34,7 @@ enum VMDetailsPrinter {
                 }
                 return vm.status
             }),
+        Column(header: "network", width: 12, getValue: { $0.networkMode ?? "nat" }),
         Column(header: "storage", width: 16, getValue: { $0.locationName }),
         Column(
             header: "shared_dirs", width: 54,


### PR DESCRIPTION
## Summary

Add support for bridged networking as an alternative to the current NAT-only networking mode. This allows VMs to get their own IP address directly on the LAN via DHCP, bypassing the host's routing table entirely.

Closes #1007

## Problem

Lume currently hardcodes `VZNATNetworkDeviceAttachment()` as the only networking mode. NAT networking relies on the host's `vmnet` NAT daemon and routing table, which breaks when VPN clients modify the routing table — often irreversibly until reboot.

## Solution

Add a `--network` option supporting:
- `nat` (default, current behavior)
- `bridged` (auto-select first available interface)
- `bridged:<interface>` (specific interface, e.g. `bridged:en0`)

## Usage

```bash
# Current behavior (default)
lume run my-vm --network nat

# Bridged networking (auto-select interface)
lume run my-vm --network bridged

# Bridged to a specific interface
lume run my-vm --network bridged:en0

# Create a VM with bridged networking
lume create my-vm --ipsw latest --network bridged

# List available bridge interfaces
lume config network interfaces
```

## Changes

### New files
- **`libs/lume/src/VM/NetworkMode.swift`** — `NetworkMode` enum with `nat` and `bridged(interface:)` cases, including `Codable` conformance and string parsing

### Modified files
- **`VMVirtualizationService.swift`** — `createNetworkDeviceConfiguration()` now supports `VZBridgedNetworkDeviceAttachment` alongside `VZNATNetworkDeviceAttachment`; `VMVirtualizationServiceContext` gains `networkMode` field
- **`Run.swift`** — Added `--network` option (default: `"nat"`)
- **`Create.swift`** — Added `--network` option (default: `"nat"`)
- **`VMConfig.swift`** — Added `networkMode` field with backward-compatible default (`.nat`); existing configs without this field will decode as NAT
- **`VM.swift`** — Network mode flows from config → virtualization context; `run()` accepts optional `networkMode` override
- **`LumeController.swift`** — `runVM()`, `create()`, `createAsync()`, and `createInternal()` all accept and propagate `networkMode`
- **`Errors.swift`** — Added `VMConfigError.noBridgeInterfaceFound` error case
- **`Config.swift`** — Added `lume config network interfaces` subcommand to list available bridge interfaces
- **`VMDetails.swift`** — Added `networkMode` to VM details output
- **`VMDetailsPrinter.swift`** — Added network column to table output
- **`VMDirectory.swift`** — Pass `networkMode` through lightweight details path
- **`Requests.swift`** — Added `network` field to `RunVMRequest` and `CreateVMRequest`
- **`Handlers.swift`** — Parse and forward `networkMode` in run/create API handlers
- **`lume.entitlements`** — Added `com.apple.vm.networking` entitlement (required for bridged mode)

## Important notes

- **Backward compatible**: Default is `nat`, existing configs without `networkMode` decode as NAT
- **Entitlement**: Bridged networking requires the `com.apple.vm.networking` restricted entitlement from Apple. This entitlement needs to be requested from Apple via a Developer representative or DTS TSI. NAT mode continues to work without it.
- **No breaking changes**: All existing behavior is preserved