### PR TITLE
fix(cuabot): require telemetry configuration before skipping onboarding

### DIFF
--- a/libs/cuabot/src/settings.ts
+++ b/libs/cuabot/src/settings.ts
@@ -100,6 +100,12 @@ export function getTelemetryEnabled(): boolean {
   return false;
 }
 
+export function isTelemetryConfigured(): boolean {
+  const settings = loadSettings();
+  // Telemetry is configured if it's been explicitly set to true or false
+  return settings.telemetryEnabled !== undefined;
+}
+
 export function setTelemetryEnabled(enabled: boolean): void {
   const settings = loadSettings();
   settings.telemetryEnabled = enabled;

--- a/libs/cuabot/src/utils.ts
+++ b/libs/cuabot/src/utils.ts
@@ -9,6 +9,7 @@ import { tmpdir } from "os";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import { promisify } from "util";
+import { isTelemetryConfigured } from "./settings.js";
 
 const execAsync = promisify(exec);
 
@@ -277,6 +278,11 @@ export async function checkDependencies(): Promise<{ ok: boolean; errors: string
     if (!dockerImageCheck.ok) {
       errors.push("Docker image not pulled. Run: docker pull trycua/cuabot:latest");
     }
+  }
+
+  // Check telemetry configuration
+  if (!isTelemetryConfigured()) {
+    errors.push("Usage telemetry not configured");
   }
 
   return { ok: errors.length === 0, errors };


### PR DESCRIPTION
## Summary
- Onboarding was being skipped when telemetry hadn't been configured yet, going straight to starting the agent
- Added `isTelemetryConfigured()` function to settings.ts
- Added telemetry check to `checkDependencies()` in utils.ts

## Test plan
- [ ] Run `npx cuabot` with a fresh `~/.cuabot` directory
- [ ] Verify onboarding shows telemetry as "not configured" 
- [ ] Configure telemetry preference
- [ ] Verify onboarding completes and agent starts