### PR TITLE
docs(computer-sdk): clarify TypeScript host desktop support

### DIFF
--- a/docs/content/docs/cua/guide/get-started/using-computer-sdk.mdx
+++ b/docs/content/docs/cua/guide/get-started/using-computer-sdk.mdx
@@ -321,19 +321,12 @@ The Computer SDK lets you connect to your sandbox and perform basic interactions
         ```
       </Tab>
       <Tab value="Your host desktop">
-        First, install and run `cua-computer-server`:
-        ```bash
-        pip install cua-computer-server
-        python -m computer_server
-        ```
+        <Callout type="info" title="Host desktop support (TypeScript)">
+          Connecting to a local host desktop is currently supported in **Python only** via `cua-computer-server`.
+          The TypeScript SDK does not yet support host desktop connections.
 
-        Then, use the `Computer` object to connect:
-        ```typescript
-        import { Computer } from '@trycua/computer';
-
-        const computer = new Computer({ useHostComputerServer: true });
-        await computer.run(); // Connect to the host desktop
-        ```
+          Feature parity is planned (see [#916](https://github.com/trycua/cua/issues/916)).
+        </Callout>
       </Tab>
     </Tabs>
 


### PR DESCRIPTION
References #916

- Clarify that host desktop is currently Python only via `cua-computer-server`
- Remove misleading TypeScript example for `useHostComputerServer`

This aligns the TypeScript docs with current SDK capabilities, per the discussion in #916.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Computer SDK getting started guide to clarify that host-desktop support is currently available for Python only, with TypeScript support planned for future implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->