### PR TITLE
Use uvicorn directly to run MCP server instead of main.py

### DIFF
--- a/docs/scripts/docs-mcp-server/Dockerfile
+++ b/docs/scripts/docs-mcp-server/Dockerfile
@@ -61,5 +61,5 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
 
-# Run the server
-CMD ["python", "main.py"]
+# Run the server with uvicorn directly
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
Updated the MCP server startup command to use uvicorn directly instead of relying on a `main.py` entry point script. This provides more explicit control over the server configuration and improves clarity of how the application is launched.

## Changes
- Replaced `python main.py` with `uvicorn main:app --host 0.0.0.0 --port 8000`
- Updated the CMD instruction to explicitly specify the ASGI application entry point
- Added explicit host and port configuration to the uvicorn command

## Implementation Details
- The new command directly invokes uvicorn with the ASGI app instance (`main:app`)
- Host is bound to `0.0.0.0` to ensure the server is accessible from outside the container
- Port `8000` is explicitly specified to match the EXPOSE directive and health check endpoint
- This approach eliminates the need for a wrapper script and makes the startup process more transparent

https://claude.ai/code/session_012qhGzNmFLooUiGESc4s483