### PR TITLE
Update MCP server transport from SSE to Streamable HTTP

### DIFF
--- a/docs/content/docs/cua/vibe-coding-mcp.mdx
+++ b/docs/content/docs/cua/vibe-coding-mcp.mdx
@@ -14,7 +14,7 @@ The CUA MCP server equips AI coding agents with deep knowledge about CUA's APIs,
 
 | Endpoint | URL |
 |----------|-----|
-| SSE Transport | `https://vk-mcp.cua.ai/sse` |
+| Streamable HTTP Transport | `https://vk-mcp.cua.ai/mcp` |
 
 ## Available Tools
 
@@ -47,7 +47,7 @@ The MCP server exposes four read-only query tools:
 {
   "mcpServers": {
     "CUA MCP": {
-      "url": "https://vk-mcp.cua.ai/sse"
+      "url": "https://vk-mcp.cua.ai/mcp"
     }
   }
 }
@@ -58,7 +58,7 @@ The MCP server exposes four read-only query tools:
 Add the MCP server using the CLI:
 
 ```bash
-claude mcp add --transport sse cua-mcp https://vk-mcp.cua.ai/sse
+claude mcp add --transport http cua-mcp https://vk-mcp.cua.ai/mcp
 ```
 
 Verify the connection:
@@ -71,7 +71,7 @@ Expected output:
 
 ```
 Checking MCP server health...
-cua-mcp: https://vk-mcp.cua.ai/sse (SSE) - ✓ Connected
+cua-mcp: https://vk-mcp.cua.ai/mcp (HTTP) - ✓ Connected
 ```
 
 Management commands:
@@ -90,7 +90,7 @@ claude mcp remove cua-mcp -s local
 2. Click **Add custom connector**
 3. Enter the following:
    - **Name**: `CUA MCP`
-   - **URL**: `https://vk-mcp.cua.ai/sse`
+   - **URL**: `https://vk-mcp.cua.ai/mcp`
 4. Click **Add**
 
 ### Windsurf
@@ -98,7 +98,7 @@ claude mcp remove cua-mcp -s local
 1. Open Windsurf Settings (bottom right settings button)
 2. Navigate to **Cascade** > **Model Context Protocol**
 3. Click **Add Server** > **Add custom server**
-4. Select **SSE** transport and enter: `https://vk-mcp.cua.ai/sse`
+4. Select **Streamable HTTP** transport and enter: `https://vk-mcp.cua.ai/mcp`
 
 Configuration file location:
 - **macOS**: `~/.codeium/windsurf/mcp_config.json`
@@ -113,7 +113,7 @@ Configuration file location:
 4. Click **Remote Servers** tab
 5. Enter:
    - **Server Name**: `CUA MCP`
-   - **Server URL**: `https://vk-mcp.cua.ai/sse`
+   - **Server URL**: `https://vk-mcp.cua.ai/mcp`
 6. Click **Add Server**
 
 ### GitHub Copilot
@@ -125,7 +125,7 @@ Configuration file location:
 {
   "servers": {
     "CUA MCP": {
-      "url": "https://vk-mcp.cua.ai/sse"
+      "url": "https://vk-mcp.cua.ai/mcp"
     }
   }
 }
@@ -137,9 +137,9 @@ Configuration file location:
 
 For any MCP-compatible application:
 
-**SSE Connection**:
+**Streamable HTTP Connection**:
 ```
-https://vk-mcp.cua.ai/sse
+https://vk-mcp.cua.ai/mcp
 ```
 
 **Common JSON Configuration**:
@@ -147,7 +147,7 @@ https://vk-mcp.cua.ai/sse
 {
   "servers": {
     "CUA MCP": {
-      "url": "https://vk-mcp.cua.ai/sse"
+      "url": "https://vk-mcp.cua.ai/mcp"
     }
   }
 }

--- a/docs/scripts/docs-mcp-server/main.py
+++ b/docs/scripts/docs-mcp-server/main.py
@@ -499,7 +499,7 @@ def query_code_vectors(
 
 # Create the ASGI app
 app = mcp.http_app(
-    transport="sse",
+    transport="streamable-http",
     middleware=[
         Middleware(
             CORSMiddleware,

--- a/docs/src/app/api/copilotkit/route.ts
+++ b/docs/src/app/api/copilotkit/route.ts
@@ -413,8 +413,8 @@ If users seem stuck, invite them to join the Discord: https://discord.com/invite
   maxTokens: 8192 * 4,
   mcpServers: [
     {
-      type: 'sse',
-      url: 'https://vk-mcp.cua.ai/sse',
+      type: 'streamable-http',
+      url: 'https://vk-mcp.cua.ai/mcp',
     },
   ],
 });


### PR DESCRIPTION
## Summary
This PR updates the CUA MCP server configuration to use Streamable HTTP transport instead of SSE (Server-Sent Events) across all documentation and implementation files.

## Key Changes
- **Endpoint URL**: Updated from `https://vk-mcp.cua.ai/sse` to `https://vk-mcp.cua.ai/mcp`
- **Transport Type**: Changed from `sse` to `streamable-http` in:
  - MCP server configuration (Python ASGI app)
  - CopilotKit integration (TypeScript)
  - All client setup documentation
- **Documentation Updates**: Updated setup instructions for:
  - Claude Desktop
  - Windsurf
  - JetBrains IDEs
  - GitHub Copilot
  - Generic MCP-compatible applications

## Implementation Details
- The Python MCP server now uses `transport="streamable-http"` instead of `transport="sse"`
- The CopilotKit integration updated to use `type: 'streamable-http'` with the new endpoint
- All documentation examples and configuration snippets reflect the new transport protocol and endpoint URL
- This change maintains backward compatibility in terms of functionality while modernizing the transport mechanism

https://claude.ai/code/session_012FZDqv4rbviQN2dTY6wPNA