### PR TITLE
fix(playground): fix computer selection and make baseUrl optional

### DIFF
--- a/libs/typescript/playground/src/adapters/types.ts
+++ b/libs/typescript/playground/src/adapters/types.ts
@@ -97,8 +97,8 @@ export interface ComputerAdapter {
  * Returned by the inference adapter based on the selected computer.
  */
 export interface InferenceConfig {
-  /** Base URL for the agent API */
-  baseUrl: string;
+  /** Base URL for the inference API (optional, computer server has default) */
+  baseUrl?: string;
 
   /** Model to use (optional, may be selected by user) */
   model?: string;

--- a/libs/typescript/playground/src/components/Playground.tsx
+++ b/libs/typescript/playground/src/components/Playground.tsx
@@ -75,17 +75,28 @@ function PlaygroundContentInternal({
   const vncUrl = currentComputer?.vncUrl;
 
   // Create a draft chat for the empty state UI
-  const draftChat = useMemo<Chat>(
-    () => ({
+  const draftChat = useMemo<Chat>(() => {
+    const runningComputer = state.computers.find((c) => c.status === 'running');
+    const computerInfo = runningComputer ?? state.computers[0];
+
+    const computer = computerInfo
+      ? {
+          id: computerInfo.id,
+          name: computerInfo.name,
+          url: computerInfo.agentUrl,
+        }
+      : undefined;
+
+    return {
       id: 'draft',
       name: 'New Chat',
       messages: [],
       model: defaultModel,
+      computer,
       created: new Date(),
       updated: new Date(),
-    }),
-    [defaultModel]
-  );
+    };
+  }, [state.computers, defaultModel]);
 
   // Handle creating a new chat and sending the first message
   const handleCreateAndSend = async (


### PR DESCRIPTION
## Summary
- Fix "Please select a computer" error when sending messages from empty state
- Make `baseUrl` optional in `InferenceConfig` type

## Changes
- **Playground.tsx**: Add `computer` property to `draftChat`, preferring running computers
- **types.ts**: Make `baseUrl` optional since computer server has a default inference endpoint (`https://inference.cua.ai/v1`)

## Test plan
- [ ] Create a new chat from empty state and verify computer is pre-selected
- [ ] Send a message without manually selecting a computer
- [ ] Verify no "Please select a computer" error appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)