### PR TITLE
Fix documentation links: remove trailing slashes and correct paths

### DIFF
--- a/docs/content/docs/cua/examples/automation/form-filling.mdx
+++ b/docs/content/docs/cua/examples/automation/form-filling.mdx
@@ -495,6 +495,6 @@ Monitor the output to see the agent's progress through each task.
 ## Next Steps
 
 - Learn more about [Cua Computer Framework](/cua/reference/computer-sdk) and [Computer Commands](/cua/reference/computer-sdk)
-- Read about [Agent Loops](/cua/guide/fundamentals/agent-loops), [Tools](/cua/guide/advanced/custom-tools), and [Supported Model Providers](/cua/guide/fundamentals/vlms/)
-- Experiment with different [Models and Providers](/cua/guide/fundamentals/vlms/)
+- Read about [Agent Loops](/cua/guide/fundamentals/agent-loops), [Tools](/cua/guide/advanced/custom-tools), and [Supported Model Providers](/cua/guide/fundamentals/vlms)
+- Experiment with different [Models and Providers](/cua/guide/fundamentals/vlms)
 - Join our [Discord community](https://discord.com/invite/mVnXXpdE85) for help

--- a/docs/content/docs/cua/examples/automation/post-event-contact-export.mdx
+++ b/docs/content/docs/cua/examples/automation/post-event-contact-export.mdx
@@ -476,7 +476,7 @@ This script demonstrates a practical workflow for extracting LinkedIn connection
 ## Next Steps
 
 - Learn more about [Cua Computer Framework](/cua/reference/computer-sdk) and [Computer Commands](/cua/reference/computer-sdk)
-- Read about [Agent Loops](/cua/guide/fundamentals/agent-loops), [Tools](/cua/guide/advanced/custom-tools), and [Supported Model Providers](/cua/guide/fundamentals/vlms/)
-- Experiment with different [Models and Providers](/cua/guide/fundamentals/vlms/)
+- Read about [Agent Loops](/cua/guide/fundamentals/agent-loops), [Tools](/cua/guide/advanced/custom-tools), and [Supported Model Providers](/cua/guide/fundamentals/vlms)
+- Experiment with different [Models and Providers](/cua/guide/fundamentals/vlms)
 - Adapt this script for other platforms (Twitter/X, email extraction, etc.)
 - Join our [Discord community](https://discord.com/invite/mVnXXpdE85) for help

--- a/docs/content/docs/cua/guide/advanced/demonstration-guided-skills.mdx
+++ b/docs/content/docs/cua/guide/advanced/demonstration-guided-skills.mdx
@@ -9,7 +9,7 @@ Human demonstrations provide powerful context for guiding agent behavior. By sho
 
 The demonstration-guided workflow consists of three stages:
 
-1. **Record** - Capture a human performing the task via [VNC recording](/docs/cua/guide/advanced/vnc-recorder)
+1. **Record** - Capture a human performing the task via [VNC recording](/cua/guide/advanced/vnc-recorder)
 2. **Process** - Convert the recording into semantic action traces with VLM captions
 3. **Prompt** - Use the processed trajectory to guide agent execution
 

--- a/docs/content/docs/cua/guide/advanced/vnc-recorder.mdx
+++ b/docs/content/docs/cua/guide/advanced/vnc-recorder.mdx
@@ -61,7 +61,7 @@ cua skills read my-skill
 
 ### 1. Start a sandbox and open the VNC UI
 
-Start a sandbox using [Docker](/docs/cua/guide/get-started/set-up-sandbox) or [Cua Cloud](/docs/cua/guide/get-started/set-up-sandbox). The VNC UI will be available at:
+Start a sandbox using [Docker](/cua/guide/get-started/set-up-sandbox) or [Cua Cloud](/cua/guide/get-started/set-up-sandbox). The VNC UI will be available at:
 
 - **Docker**: `http://localhost:8006`
 - **Cloud**: `https://{sandbox-name}.sandbox.cua.ai/vnc.html`
@@ -145,7 +145,7 @@ Recording data streams to disk in real-time via WebSocket, so the file is ready 
 | `autorecord=1`        | Start recording when connection is established |
 | `record_url=ws://...` | Stream recording to external WebSocket server  |
 
-For more details on prompting agents with demonstrations, see [Demonstration-Guided Skills](/docs/cua/guide/advanced/demonstration-guided-skills).
+For more details on prompting agents with demonstrations, see [Demonstration-Guided Skills](/cua/guide/advanced/demonstration-guided-skills).
 
 ## Reference
 

--- a/docs/content/docs/cua/reference/cloud-cli/index.mdx
+++ b/docs/content/docs/cua/reference/cloud-cli/index.mdx
@@ -65,4 +65,4 @@ cua stop my-sandbox
 
 ## Next Steps
 
-- [Command Reference](/cua/reference/cli-playbook/commands) - Full list of available commands
+- [Command Reference](/cua/reference/cloud-cli/commands) - Full list of available commands

--- a/docs/content/docs/cua/reference/computer-sdk/index.mdx
+++ b/docs/content/docs/cua/reference/computer-sdk/index.mdx
@@ -890,7 +890,7 @@ computer = Computer(
 )
 ```
 
-For macOS virtual machines on Apple Silicon. Requires [Lume](/lume) to be installed.
+For macOS virtual machines on Apple Silicon. Requires [Lume](/lume/guide/getting-started/introduction) to be installed.
 
 ### Cloud Provider
 

--- a/docs/content/docs/cua/reference/desktop-sandbox/index.mdx
+++ b/docs/content/docs/cua/reference/desktop-sandbox/index.mdx
@@ -14,7 +14,7 @@ Native macOS virtual machines on Apple Silicon using Apple's Virtualization Fram
 - **Lume** - Native CLI for VM management
 - **Lumier** - Docker wrapper for containerized deployments
 
-### [Linux Container](/cua/reference/desktop-sandbox/linux-container)
+### Linux Container
 
 Docker containers running Linux desktops. Fast startup, low resource usage.
 
@@ -23,7 +23,7 @@ Docker containers running Linux desktops. Fast startup, low resource usage.
 | [Kasm](/cua/reference/desktop-sandbox/linux-container/kasm) | KasmWeb-based Ubuntu with XFCE |
 | [XFCE](/cua/reference/desktop-sandbox/linux-container/xfce) | Vanilla XFCE, minimal dependencies |
 
-### [QEMU Container](/cua/reference/desktop-sandbox/qemu-container)
+### QEMU Container
 
 Full virtual machines running in Docker via QEMU/KVM. Complete OS isolation, supports Windows.
 

--- a/docs/content/docs/cua/reference/desktop-sandbox/macos.mdx
+++ b/docs/content/docs/cua/reference/desktop-sandbox/macos.mdx
@@ -9,7 +9,7 @@ macOS sandbox environments run native macOS virtual machines on Apple Silicon us
 
 | Option | Description | Best For |
 |--------|-------------|----------|
-| [Lume](/lume) | Native CLI for creating and managing macOS VMs | Direct VM management, development |
+| [Lume](/lume/guide/getting-started/introduction) | Native CLI for creating and managing macOS VMs | Direct VM management, development |
 | [Lumier](/lume/guide/advanced/lumier) | Docker wrapper around Lume | Containerized deployments |
 
 ## Requirements
@@ -76,6 +76,6 @@ async with computer:
 
 ## Related Documentation
 
-- [Lume Documentation](/lume) - Full Lume CLI reference
+- [Lume Documentation](/lume/guide/getting-started/introduction) - Full Lume CLI reference
 - [Lumier Documentation](/lume/guide/advanced/lumier) - Docker-based macOS VMs
-- [Unattended Setup](/lume/guide/advanced/unattended-setup) - Automate macOS VM configuration
+- [Unattended Setup](/lume/guide/fundamentals/unattended-setup) - Automate macOS VM configuration


### PR DESCRIPTION
## Summary
This PR fixes broken and inconsistent documentation links throughout the Cua documentation by removing trailing slashes from internal links and correcting several incorrect link paths.

## Key Changes
- **Removed trailing slashes** from internal documentation links (e.g., `/vlms/` → `/vlms`) across multiple files for consistency
- **Corrected link paths**:
  - `/docs/cua/guide/...` → `/cua/guide/...` (removed `/docs` prefix)
  - `/docs/cua/reference/...` → `/cua/reference/...` (removed `/docs` prefix)
  - `/cua/reference/cli-playbook/commands` → `/cua/reference/cloud-cli/commands` (fixed incorrect reference)
- **Updated Lume documentation links** to point to specific guide pages instead of root:
  - `/lume` → `/lume/guide/getting-started/introduction`
  - `/lume/guide/advanced/unattended-setup` → `/lume/guide/fundamentals/unattended-setup`
- **Removed unnecessary link markup** from section headers in desktop-sandbox documentation

## Files Modified
- `docs/content/docs/cua/examples/automation/form-filling.mdx`
- `docs/content/docs/cua/examples/automation/post-event-contact-export.mdx`
- `docs/content/docs/cua/guide/advanced/demonstration-guided-skills.mdx`
- `docs/content/docs/cua/guide/advanced/vnc-recorder.mdx`
- `docs/content/docs/cua/reference/cloud-cli/index.mdx`
- `docs/content/docs/cua/reference/computer-sdk/index.mdx`
- `docs/content/docs/cua/reference/desktop-sandbox/index.mdx`
- `docs/content/docs/cua/reference/desktop-sandbox/macos.mdx`

## Impact
These changes improve documentation navigation by ensuring all internal links are correctly formatted and point to valid documentation pages.

https://claude.ai/code/session_01AsxA3MLUo6xMgFUD5e43Dv