### PR TITLE
Remove --exclude-mail flag from docs link checker workflow

### DIFF
--- a/.github/workflows/ci-check-docs-links.yml
+++ b/.github/workflows/ci-check-docs-links.yml
@@ -61,7 +61,6 @@ jobs:
             --verbose
             --no-progress
             --accept 100..=399
-            --exclude-mail
             --exclude 'localhost'
             --exclude '127\.0\.0\.1'
             --exclude 'example\.com'


### PR DESCRIPTION
## Summary
Removed the `--exclude-mail` flag from the CI documentation link checker workflow to allow validation of email links.

## Changes
- Removed `--exclude-mail` flag from the `lychee` link checker configuration in `.github/workflows/ci-check-docs-links.yml`

## Details
This change enables the link checker to validate email addresses in documentation, which were previously being skipped. This ensures more comprehensive documentation link validation and helps catch broken email references.

https://claude.ai/code/session_01SGxvjUaBKjgwQuLyDQz1HS