### PR TITLE
fix: remove message filtering that was causing variable reference error

### DIFF
--- a/docs/src/app/api/copilotkit/route.ts
+++ b/docs/src/app/api/copilotkit/route.ts
@@ -213,17 +213,18 @@ class AnthropicSafeBuiltInAgent extends BuiltInAgent {
   }
 
   run(input: any): ReturnType<BuiltInAgent['run']> {
-    const filteredMessages = this.filterEmptyMessages(input.messages || []);
+    // Don't filter messages - let CopilotKit/Anthropic handle empty messages
+    const messages = input.messages || [];
     const modifiedInput = {
       ...input,
-      messages: filteredMessages,
+      messages: messages,
     };
 
     // Fix message ordering - without unique IDs, responses get merged
     const uniqueMessageId = randomUUID();
     const conversationId = input.threadId || uniqueMessageId;
 
-    const userMessages = filteredMessages.filter((m: any) => m.role === 'user');
+    const userMessages = messages.filter((m: any) => m.role === 'user');
     const latestUserMessage = userMessages[userMessages.length - 1];
     const userPrompt = this.extractMessageContent(latestUserMessage);
 
@@ -237,7 +238,7 @@ class AnthropicSafeBuiltInAgent extends BuiltInAgent {
           question_type: detectQuestionType(userPrompt),
           topics: extractTopics(userPrompt),
           prompt_length: userPrompt.length,
-          message_count: filteredMessages.length,
+          message_count: messages.length,
           conversation_id: conversationId,
           timestamp: new Date().toISOString(),
         },


### PR DESCRIPTION
## Summary
- Removed `filterEmptyMessages` call that left `filteredMessages` undefined after previous partial changes
- Uses `messages` directly instead, letting CopilotKit/Anthropic handle empty messages
- Fixes build error in `docs/src/app/api/copilotkit/route.ts`

## Test plan
- [ ] Verify docs site builds successfully
- [ ] Verify CopilotKit API route handles messages correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)