### PR TITLE
fix: reduce excessive header spacing between logo and docs label

### DIFF
--- a/docs/src/components/custom-header.tsx
+++ b/docs/src/components/custom-header.tsx
@@ -194,9 +194,9 @@ export function CustomHeader() {
                   />
                 </div>
               )}
-              {/* Site name and label - min-width prevents layout shift between products */}
+              {/* Site name and label - whitespace-nowrap prevents layout shift */}
               <span
-                className="inline-block min-w-[5.5rem] font-semibold"
+                className="whitespace-nowrap font-semibold"
                 style={{ fontFamily: 'var(--font-urbanist)' }}
               >
                 {currentSite.name}


### PR DESCRIPTION
## Summary
- Replace `min-w-[5.5rem]` with `whitespace-nowrap` on the site name span in the header
- The min-width was introduced to prevent layout shift when switching between products, but it forced excessive gap for short names like "Cua"
- `whitespace-nowrap` prevents text wrapping (the actual layout shift concern) without adding unnecessary width

## Test plan
- [ ] Verify header spacing looks correct for all products (Cua, Cua Bench, Lume, Cua-Bot)
- [ ] Verify no layout shift when switching between products in the dropdown