### PR TITLE
Update domain URLs from .dev to .ai

### DIFF
--- a/docs/content/docs/cua/examples/ai-models/gemini-complex-ui-navigation.mdx
+++ b/docs/content/docs/cua/examples/ai-models/gemini-complex-ui-navigation.mdx
@@ -131,7 +131,7 @@ Replace the values:
 
 - `your-project-id`: Your Google Cloud Project ID from Step 1
 - `/path/to/your-service-account-key.json`: Path to the JSON key file you downloaded
-- `sk_cua-api01...`: Your Cua API key from the [Cua dashboard](https://cua.dev)
+- `sk_cua-api01...`: Your Cua API key from the [Cua dashboard](https://cua.ai)
 - `your-sandbox-name`: Your sandbox name (if using cloud sandboxes)
 
 </Step>

--- a/docs/content/docs/lume/examples/openclaw/index.mdx
+++ b/docs/content/docs/lume/examples/openclaw/index.mdx
@@ -5,7 +5,7 @@ description: Run OpenClaw messaging gateway in an isolated macOS VM with Lume
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-Run [OpenClaw](https://openclaw.dev) in a headless macOS VM to create a unified messaging gateway that bridges WhatsApp, Telegram, iMessage, and more with AI agents.
+Run [OpenClaw](https://openclaw.ai) in a headless macOS VM to create a unified messaging gateway that bridges WhatsApp, Telegram, iMessage, and more with AI agents.
 
 ## Why run OpenClaw in a VM?
 
@@ -213,7 +213,7 @@ Keep the VM running by:
 - Disabling sleep in **System Settings** → **Energy Saver**
 - Using `caffeinate` if needed
 
-For true always-on operation, consider a dedicated Mac mini or a small VPS. See [VPS hosting](https://openclaw.dev/docs/vps-hosting) for options.
+For true always-on operation, consider a dedicated Mac mini or a small VPS. See [VPS hosting](https://openclaw.ai/docs/vps-hosting) for options.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
Updated all documentation links to use the new `.ai` domain extensions for Cua and OpenClaw services, replacing the previous `.dev` domains.

## Changes
- Updated Cua dashboard link from `https://cua.dev` to `https://cua.ai` in the Gemini complex UI navigation example
- Updated OpenClaw documentation links from `https://openclaw.dev` to `https://openclaw.ai` in the OpenClaw Lume example (2 occurrences)

## Details
These changes reflect the domain migration for both services to their new `.ai` domain extensions. All documentation examples and references now point to the correct, current URLs.

https://claude.ai/code/session_01UUas213X98Fr6xKRarmvRu