### PR TITLE
Fix documentation links and add desktop sandbox index pages

### DIFF
--- a/docs/content/docs/cua/examples/automation/post-event-contact-export.mdx
+++ b/docs/content/docs/cua/examples/automation/post-event-contact-export.mdx
@@ -86,7 +86,7 @@ CUA_API_KEY=sk_cua-api01...
 CUA_CONTAINER_NAME=m-linux-...
 ```
 
-Finally, setup your sandbox. Refer to the [quickstart guide](https://cua.ai/docs/get-started/quickstart) on how to setup the computer environment.
+Finally, setup your sandbox. Refer to the [quickstart guide](/cua/guide/get-started/quickstart) on how to setup the computer environment.
 
 </Step>
 

--- a/docs/content/docs/cua/reference/agent-sdk/changelog.mdx
+++ b/docs/content/docs/cua/reference/agent-sdk/changelog.mdx
@@ -366,7 +366,7 @@ Changelog:
 - OpenAI providers - Added support for zero data retention
 - Added Agent CLI for quick testing: `python -m agent.cli <model name>`
 
-[Breaking Changes](https://docs-woad-phi.vercel.app/home/agent-sdk/migration-guide#breaking-changes)
+**Breaking Changes**
 
 - **Initialization:**
   - `ComputerAgent` (v0.4.x) uses `model` as a string (e.g. "anthropic/claude-3-5-sonnet-20241022") instead of `LLM` and `AgentLoop` objects.

--- a/docs/content/docs/cua/reference/desktop-sandbox/linux-container/index.mdx
+++ b/docs/content/docs/cua/reference/desktop-sandbox/linux-container/index.mdx
@@ -1,0 +1,37 @@
+---
+title: Linux Container
+description: Docker containers running Linux desktops for Computer-Using Agents
+---
+
+Docker containers running Linux desktops with fast startup and low resource usage. Each container includes a pre-installed computer-server for remote control via HTTP API.
+
+## Available Containers
+
+| Container | Description |
+| --- | --- |
+| [Kasm](/cua/reference/desktop-sandbox/linux-container/kasm) | KasmWeb-based Ubuntu with XFCE desktop |
+| [XFCE](/cua/reference/desktop-sandbox/linux-container/xfce) | Vanilla XFCE, minimal dependencies |
+
+## Key Features
+
+- **Fast startup** — Containers start in seconds
+- **Low resource usage** — Minimal overhead compared to full VMs
+- **Docker-based** — Works anywhere Docker runs
+- **Filesystem snapshots** — Save state via `docker commit`
+
+## Quick Start
+
+```python
+from computer import Computer
+
+async with Computer(
+    os_type="linux",
+    provider_type="docker",
+    image="trycua/cua-xfce:latest",
+) as computer:
+    screenshot = await computer.interface.screenshot()
+```
+
+## Limitations
+
+Linux containers only support filesystem snapshots via `docker commit`, which saves the disk state but not running processes or memory. The container must be restarted after restoring.

--- a/docs/content/docs/cua/reference/desktop-sandbox/linux-container/meta.json
+++ b/docs/content/docs/cua/reference/desktop-sandbox/linux-container/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Linux Container",
-  "pages": ["kasm", "xfce"]
+  "pages": ["---", "kasm", "xfce"]
 }

--- a/docs/content/docs/cua/reference/desktop-sandbox/qemu-container/index.mdx
+++ b/docs/content/docs/cua/reference/desktop-sandbox/qemu-container/index.mdx
@@ -1,0 +1,39 @@
+---
+title: QEMU Container
+description: Full virtual machines running in Docker via QEMU/KVM for Computer-Using Agents
+---
+
+Full virtual machines running in Docker via QEMU/KVM. Complete OS isolation with support for Windows, Linux, and Android.
+
+## Available Containers
+
+| Container | OS | Description |
+| --- | --- | --- |
+| [Windows](/cua/reference/desktop-sandbox/qemu-container/windows) | Windows 11 | Windows desktop with KVM |
+| [Linux](/cua/reference/desktop-sandbox/qemu-container/linux) | Ubuntu 22.04 | Full Ubuntu VM |
+| [Android](/cua/reference/desktop-sandbox/qemu-container/android) | Android 11 | Android emulator |
+
+## Key Features
+
+- **Complete OS isolation** — Full virtual machines with dedicated kernels
+- **Windows support** — Run Windows 11 in Docker
+- **Memory snapshots** — Save and restore full VM state including running processes
+- **KVM acceleration** — Near-native performance on Linux hosts with KVM support
+
+## Requirements
+
+- Linux host with KVM support
+- Docker with `--device=/dev/kvm` access
+
+## Quick Start
+
+```python
+from computer import Computer
+
+async with Computer(
+    os_type="windows",
+    provider_type="docker",
+    image="trycua/cua-qemu-windows:latest",
+) as computer:
+    screenshot = await computer.interface.screenshot()
+```

--- a/docs/content/docs/cua/reference/desktop-sandbox/qemu-container/meta.json
+++ b/docs/content/docs/cua/reference/desktop-sandbox/qemu-container/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "QEMU Container",
-  "pages": ["windows", "linux", "android"]
+  "pages": ["---", "windows", "linux", "android"]
 }

--- a/docs/content/docs/cuabot/reference/changelog.mdx
+++ b/docs/content/docs/cuabot/reference/changelog.mdx
@@ -21,8 +21,8 @@ All notable changes to the Cua-Bot are documented here.
 
 Documentation
 
-- [Getting Started](https://cua.ai/docs/cuabot/cuabot)
-- [Installation Guide](https://cua.ai/docs/cuabot/install)
+- [Getting Started](/cuabot/guide/getting-started/introduction)
+- [Installation Guide](/cuabot/guide/getting-started/installation)
 
 ### v1.0.12 (2026-02-05)
 
@@ -31,8 +31,8 @@ Documentation
 
 Documentation
 
-- [Getting Started](https://cua.ai/docs/cuabot/cuabot)
-- [Installation Guide](https://cua.ai/docs/cuabot/install)
+- [Getting Started](/cuabot/guide/getting-started/introduction)
+- [Installation Guide](/cuabot/guide/getting-started/installation)
 
 ### v1.0.11 (2026-02-04)
 
@@ -40,8 +40,8 @@ Documentation
 
 Documentation
 
-- [Getting Started](https://cua.ai/docs/cuabot/cuabot)
-- [Installation Guide](https://cua.ai/docs/cuabot/install)
+- [Getting Started](/cuabot/guide/getting-started/introduction)
+- [Installation Guide](/cuabot/guide/getting-started/installation)
 
 ### v1.0.10 (2026-02-04)
 
@@ -49,8 +49,8 @@ Documentation
 
 Documentation
 
-- [Getting Started](https://cua.ai/docs/cuabot/cuabot)
-- [Installation Guide](https://cua.ai/docs/cuabot/install)
+- [Getting Started](/cuabot/guide/getting-started/introduction)
+- [Installation Guide](/cuabot/guide/getting-started/installation)
 
 ### v1.0.9 (2026-02-04)
 
@@ -59,8 +59,8 @@ Documentation
 
 Documentation
 
-- [Getting Started](https://cua.ai/docs/cuabot/cuabot)
-- [Installation Guide](https://cua.ai/docs/cuabot/install)
+- [Getting Started](/cuabot/guide/getting-started/introduction)
+- [Installation Guide](/cuabot/guide/getting-started/installation)
 
 ### v1.0.8 (2026-02-04)
 
@@ -69,8 +69,8 @@ Documentation
 
 Documentation
 
-- [Getting Started](https://cua.ai/docs/cuabot/cuabot)
-- [Installation Guide](https://cua.ai/docs/cuabot/install)
+- [Getting Started](/cuabot/guide/getting-started/introduction)
+- [Installation Guide](/cuabot/guide/getting-started/installation)
 
 ### v1.0.7 (2026-02-04)
 
@@ -78,8 +78,8 @@ Documentation
 
 Documentation
 
-- [Getting Started](https://cua.ai/docs/cuabot/cuabot)
-- [Installation Guide](https://cua.ai/docs/cuabot/install)
+- [Getting Started](/cuabot/guide/getting-started/introduction)
+- [Installation Guide](/cuabot/guide/getting-started/installation)
 
 ### v1.0.6 (2026-02-04)
 
@@ -88,8 +88,8 @@ Documentation
 
 Documentation
 
-- [Getting Started](https://cua.ai/docs/cuabot/cuabot)
-- [Installation Guide](https://cua.ai/docs/cuabot/install)
+- [Getting Started](/cuabot/guide/getting-started/introduction)
+- [Installation Guide](/cuabot/guide/getting-started/installation)
 
 ### v1.0.5 (2026-02-04)
 
@@ -99,8 +99,8 @@ Documentation
 
 Documentation
 
-- [Getting Started](https://cua.ai/docs/cuabot/cuabot)
-- [Installation Guide](https://cua.ai/docs/cuabot/install)
+- [Getting Started](/cuabot/guide/getting-started/introduction)
+- [Installation Guide](/cuabot/guide/getting-started/installation)
 
 ### v1.0.4 (2026-02-04)
 
@@ -108,8 +108,8 @@ Documentation
 
 Documentation
 
-- [Getting Started](https://cua.ai/docs/cuabot/cuabot)
-- [Installation Guide](https://cua.ai/docs/cuabot/install)
+- [Getting Started](/cuabot/guide/getting-started/introduction)
+- [Installation Guide](/cuabot/guide/getting-started/installation)
 
 ### v1.0.3 (2026-02-04)
 
@@ -119,8 +119,8 @@ Documentation
 
 Documentation
 
-- [Getting Started](https://cua.ai/docs/cuabot/cuabot)
-- [Installation Guide](https://cua.ai/docs/cuabot/install)
+- [Getting Started](/cuabot/guide/getting-started/introduction)
+- [Installation Guide](/cuabot/guide/getting-started/installation)
 
 ### v1.0.2 (2026-02-04)
 
@@ -129,4 +129,4 @@ Documentation
 
 Documentation
 
-See [cua.ai/docs/cuabot](https://cua.ai/docs/cuabot)
+See [Cua-Bot documentation](/cuabot/guide/getting-started/introduction)

--- a/docs/content/docs/lume/examples/openclaw/index.mdx
+++ b/docs/content/docs/lume/examples/openclaw/index.mdx
@@ -213,7 +213,7 @@ Keep the VM running by:
 - Disabling sleep in **System Settings** → **Energy Saver**
 - Using `caffeinate` if needed
 
-For true always-on operation, consider a dedicated Mac mini or a small VPS. See [VPS hosting](https://openclaw.ai/docs/vps-hosting) for options.
+For true always-on operation, consider a dedicated Mac mini or a small VPS.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
This PR updates internal documentation links to use relative paths instead of absolute URLs, adds new index pages for desktop sandbox categories, and removes outdated external references.

## Key Changes

- **Link Updates**: Converted absolute URLs (e.g., `https://cua.ai/docs/...`) to relative paths (e.g., `/cua/guide/...`) across multiple documentation files for better maintainability and consistency
  - CUA quickstart guide link in post-event-contact-export example
  - Cua-Bot changelog documentation links (12 instances across multiple versions)
  - Removed broken external VPS hosting link from Lume OpenClaw example

- **New Documentation Pages**: Added index pages for desktop sandbox categories
  - `docs/content/docs/cua/reference/desktop-sandbox/linux-container/index.mdx` - Overview of Linux container options (Kasm, XFCE) with quick start examples
  - `docs/content/docs/cua/reference/desktop-sandbox/qemu-container/index.mdx` - Overview of QEMU container options (Windows, Linux, Android) with requirements and quick start examples

- **Navigation Updates**: Updated meta.json files to include separator entries (`"---"`) for better visual organization in navigation menus
  - `linux-container/meta.json`
  - `qemu-container/meta.json`

- **Changelog Formatting**: Changed breaking changes link in Agent SDK changelog from external link to bold text for better readability

## Benefits
- Improved documentation maintainability with relative links
- Better organization of desktop sandbox documentation with category index pages
- Consistent navigation structure across documentation sections

https://claude.ai/code/session_012v9UqLpLqpjoJy7XXnjwL2