### PR TITLE
feat: add pypi/cli to version bump workflow

### DIFF
--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -11,6 +11,7 @@ on:
           - pypi/agent
           - pypi/bench
           - pypi/bench-ui
+          - pypi/cli
           - pypi/computer
           - pypi/computer-server
           - pypi/core
@@ -59,6 +60,10 @@ jobs:
               ;;
             "pypi/bench-ui")
               echo "directory=libs/python/bench-ui" >> $GITHUB_OUTPUT
+              echo "type=python" >> $GITHUB_OUTPUT
+              ;;
+            "pypi/cli")
+              echo "directory=libs/python/cua-cli" >> $GITHUB_OUTPUT
               echo "type=python" >> $GITHUB_OUTPUT
               ;;
             "pypi/computer")
@@ -288,6 +293,15 @@ jobs:
           cd libs/python/bench-ui
           VERSION=$(python -c "import tomllib; from pathlib import Path; data = tomllib.loads(Path('pyproject.toml').read_text()); print(data['project']['version'])")
           echo "Bench-ui version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Capture bumped cli version
+        if: ${{ inputs.service == 'pypi/cli' }}
+        id: cli_version
+        run: |
+          cd libs/python/cua-cli
+          VERSION=$(python -c "import tomllib; from pathlib import Path; data = tomllib.loads(Path('pyproject.toml').read_text()); print(data['project']['version'])")
+          echo "CLI version: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Capture bumped computer version


### PR DESCRIPTION
## Summary
- Add `pypi/cli` option to the `CD: Bump Version` workflow dropdown
- Add case mapping pointing to `libs/python/cua-cli`
- Add version capture step for the CLI package

The `cua-cli` Python package already has a CD workflow (`cd-py-cli.yml`) triggered by `cli-v*` tags and a `.bumpversion.cfg`, but was missing from `release-bump-version.yml` — so there was no way to trigger a release from the Actions UI.

## Test plan
- [ ] Verify `pypi/cli` appears in the workflow dispatch dropdown
- [ ] Run the bump workflow with `pypi/cli` + `patch` and confirm it creates a `cli-v*` tag
- [ ] Confirm the tag triggers `cd-py-cli.yml` and publishes to PyPI