### PR TITLE
Exclude file:// URLs from documentation link checker

### DIFF
--- a/.github/workflows/ci-check-docs-links.yml
+++ b/.github/workflows/ci-check-docs-links.yml
@@ -61,6 +61,7 @@ jobs:
             --verbose
             --no-progress
             --accept 100..=399
+            --exclude '^file://'
             --exclude 'localhost'
             --exclude '127\.0\.0\.1'
             --exclude 'example\.com'


### PR DESCRIPTION
## Summary
Updated the CI documentation link checker workflow to exclude `file://` URLs from validation, preventing false positives when checking local file references.

## Changes
- Added `--exclude '^file://'` flag to the `lychee` link checker configuration in the CI workflow
- This prevents the link checker from attempting to validate local file system URLs, which are not applicable in a CI environment

## Details
The `file://` protocol is commonly used in documentation for local file references but cannot be validated in automated CI pipelines. By excluding these URLs, we reduce noise in the link checker output and focus validation on actual web-accessible resources.

https://claude.ai/code/session_01TCohF6h4raHA1o4eQjhsdP