### PR TITLE
feat: add cua-cli to release cascade (depends on cua-computer)

### DIFF
--- a/.github/workflows/cd-py-cli.yml
+++ b/.github/workflows/cd-py-cli.yml
@@ -26,8 +26,19 @@ jobs:
     runs-on: macos-latest
     outputs:
       version: ${{ steps.get-version.outputs.version }}
+      computer_version: ${{ steps.update-deps.outputs.computer_version }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Ensure latest main branch
+        run: |
+          git fetch origin main
+          git reset --hard origin/main
+          echo "Current HEAD commit:"
+          git log -1 --oneline
 
       - name: Determine version
         id: get-version
@@ -43,8 +54,7 @@ jobs:
               echo "Invalid tag format for cli"
               exit 1
             fi
-          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            # Use version from workflow dispatch
+          elif [ -n "${{ github.event.inputs.version }}" ]; then
             VERSION=${{ github.event.inputs.version }}
           else
             echo "No version provided"
@@ -52,6 +62,54 @@ jobs:
           fi
           echo "VERSION=$VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Update dependencies to latest versions
+        id: update-deps
+        run: |
+          cd libs/python/cua-cli
+          pip install requests
+
+          cat > get_latest_version.py << 'EOF'
+          import requests
+          import json
+          import sys
+
+          def get_package_version(package_name, fallback="0.1.0"):
+              try:
+                  response = requests.get(f'https://pypi.org/pypi/{package_name}/json')
+                  if response.status_code != 200:
+                      print(f"API request failed for {package_name}, using fallback", file=sys.stderr)
+                      return fallback
+                  data = json.loads(response.text)
+                  return data['info']['version']
+              except Exception as e:
+                  print(f"Error fetching version for {package_name}: {e}", file=sys.stderr)
+                  return fallback
+
+          print(get_package_version('cua-computer'))
+          EOF
+
+          LATEST_COMPUTER=$(python get_latest_version.py)
+          echo "Latest cua-computer version: $LATEST_COMPUTER"
+          echo "computer_version=$LATEST_COMPUTER" >> $GITHUB_OUTPUT
+
+          # Update dependency in pyproject.toml
+          COMPUTER_MAJOR=$(echo $LATEST_COMPUTER | cut -d. -f1)
+          NEXT_COMPUTER_MAJOR=$((COMPUTER_MAJOR + 1))
+
+          if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' "s/\"cua-computer>=.*\"/\"cua-computer>=$LATEST_COMPUTER,<$NEXT_COMPUTER_MAJOR.0.0\"/" pyproject.toml
+          else
+            sed -i "s/\"cua-computer>=.*\"/\"cua-computer>=$LATEST_COMPUTER,<$NEXT_COMPUTER_MAJOR.0.0\"/" pyproject.toml
+          fi
+
+          echo "Updated dependencies in pyproject.toml:"
+          grep "cua-computer" pyproject.toml
 
   publish:
     needs: prepare
@@ -71,4 +129,5 @@ jobs:
       tag_name: "cli-v${{ needs.prepare.outputs.version }}"
       release_name: "cua-cli v${{ needs.prepare.outputs.version }}"
       module_path: "libs/python/cua-cli"
-      body: ""
+      body: |
+        **Dependencies:** cua-computer ${{ needs.prepare.outputs.computer_version }}

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -183,15 +183,17 @@ jobs:
           BUMPVERSION_CONFIG="${{ steps.package.outputs.bumpversion_config }}"
           clean_tag "${{ steps.package.outputs.directory }}" "${BUMPVERSION_CONFIG:-.bumpversion.cfg}"
 
-          # Clean cascade tags when bumping pypi/core (also bumps computer and agent)
+          # Clean cascade tags when bumping pypi/core (also bumps computer, agent, cli)
           if [ "${{ inputs.service }}" == "pypi/core" ]; then
             clean_tag "libs/python/computer"
             clean_tag "libs/python/agent"
+            clean_tag "libs/python/cua-cli"
           fi
 
-          # Clean cascade tags when bumping pypi/computer (also bumps agent)
+          # Clean cascade tags when bumping pypi/computer (also bumps agent, cli)
           if [ "${{ inputs.service }}" == "pypi/computer" ]; then
             clean_tag "libs/python/agent"
+            clean_tag "libs/python/cua-cli"
           fi
 
           # Clean cascade tags when bumping pypi/som (also bumps agent)
@@ -230,6 +232,12 @@ jobs:
           cd libs/python/agent
           bump2version ${{ inputs.bump_type }}
 
+      - name: Also bump cua-cli (when bumping cua-computer or cua-core)
+        if: ${{ inputs.service == 'pypi/computer' || inputs.service == 'pypi/core' }}
+        run: |
+          cd libs/python/cua-cli
+          bump2version ${{ inputs.bump_type }}
+
       - name: Also bump cua-agent (when bumping cua-som)
         if: ${{ inputs.service == 'pypi/som' }}
         run: |
@@ -251,7 +259,7 @@ jobs:
 
           # Get all local tags and filter to those pointing to commits after START_SHA
           ALL_TAGS=""
-          for tag in $(git tag --points-at HEAD) $(git tag --points-at HEAD~1 2>/dev/null) $(git tag --points-at HEAD~2 2>/dev/null); do
+          for tag in $(git tag --points-at HEAD) $(git tag --points-at HEAD~1 2>/dev/null) $(git tag --points-at HEAD~2 2>/dev/null) $(git tag --points-at HEAD~3 2>/dev/null); do
             if [ -n "$tag" ]; then
               TAG_SHA=$(git rev-parse "$tag^{commit}" 2>/dev/null || true)
               if [ -n "$TAG_SHA" ]; then
@@ -296,7 +304,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Capture bumped cli version
-        if: ${{ inputs.service == 'pypi/cli' }}
+        if: ${{ inputs.service == 'pypi/cli' || inputs.service == 'pypi/computer' || inputs.service == 'pypi/core' }}
         id: cli_version
         run: |
           cd libs/python/cua-cli

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -107,14 +107,16 @@ jobs:
           declare -A RELEASE_MAP
           for svc in "${LABELED[@]}"; do RELEASE_MAP["$svc"]=1; done
 
-            # pypi/core cascades to pypi/computer and pypi/agent
+            # pypi/core cascades to pypi/computer, pypi/agent, and pypi/cli
             if [[ -n "${RELEASE_MAP["pypi/core"]}" ]]; then
               unset RELEASE_MAP["pypi/computer"]
               unset RELEASE_MAP["pypi/agent"]
+              unset RELEASE_MAP["pypi/cli"]
             fi
-            # pypi/computer cascades to pypi/agent
+            # pypi/computer cascades to pypi/agent and pypi/cli
             if [[ -n "${RELEASE_MAP["pypi/computer"]}" ]]; then
               unset RELEASE_MAP["pypi/agent"]
+              unset RELEASE_MAP["pypi/cli"]
             fi
             # pypi/som cascades to pypi/agent
             if [[ -n "${RELEASE_MAP["pypi/som"]}" ]]; then


### PR DESCRIPTION
## Summary

`cua-cli` depends on `cua-computer` but wasn't included in the release cascade. This means bumping `pypi/core` or `pypi/computer` would publish new versions of computer and agent but leave cli pinned to an old computer version.

### Changes

- **`release-bump-version.yml`**: Bump `cua-cli` alongside `cua-agent` when bumping `computer` or `core`. Clean cascade tags for cli. Capture cli version. Expand tag collection to `HEAD~3` for 4-package cascades.
- **`cd-py-cli.yml`**: Fetch latest `cua-computer` version from PyPI before publishing (same pattern as `cd-py-agent.yml`). Include dependency info in release notes.
- **`release-on-merge.yml`**: Update cascade dedup to remove `pypi/cli` when `pypi/core` or `pypi/computer` is being released.

### Cascade graph
```
core → computer → agent
                → cli
       som → agent
```

## Test plan
- [ ] Bump `pypi/core` → verify `cli` tag is created alongside computer and agent tags
- [ ] Verify `cd-py-cli.yml` fetches latest computer version and updates pyproject.toml