### PR TITLE
fix: free disk space before docker image builds

### DIFF
--- a/.github/workflows/docker-reusable-publish.yml
+++ b/.github/workflows/docker-reusable-publish.yml
@@ -47,6 +47,12 @@ jobs:
         exclude:
           - platform: ${{ inputs.skip_arm64 && 'linux/arm64' || 'none' }}
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
+          sudo docker system prune -af
+          df -h /
+
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
Large docker images (QEMU Android, XFCE) consistently fail with `No space left on device` on standard GitHub runners.

Adds a disk cleanup step to `docker-reusable-publish.yml` that removes ~25GB of pre-installed software (.NET, Android SDK, GHC, toolcache) before building.

## Test plan
- [ ] Re-run `cd-container-qemu-android` after merge — should succeed