### PR TITLE
fix(playground): route inference requests through API instead of computer server

### DIFF
--- a/libs/typescript/playground/src/adapters/cloud.ts
+++ b/libs/typescript/playground/src/adapters/cloud.ts
@@ -208,9 +208,15 @@ class CloudInferenceAdapter implements InferenceAdapter {
   ) {}
 
   async getConfig(computer: ComputerInfo): Promise<InferenceConfig> {
-    // Cloud manages API keys server-side, so we don't need to pass env vars
+    // Route through inference API instead of directly to computer server
+    // The inference API handles model routing and communicates with the computer server
     return {
-      baseUrl: computer.agentUrl,
+      baseUrl: `${this.baseUrl}/v1/inference`,
+      // Pass computer info via env vars for the inference API
+      env: {
+        CUA_COMPUTER_ID: computer.id,
+        CUA_AGENT_URL: computer.agentUrl,
+      },
     };
   }
 


### PR DESCRIPTION
## Summary

The playground has been sending inference requests **directly to the computer server** instead of routing through the inference API, causing timeouts and failed requests in production.

## The Problem

### Current (Broken) Flow
```
Playground → Computer Server (:8443/responses) ❌
  └─ Computer server receives LLM requests
  └─ Computer server can't handle model routing
  └─ Requests timeout
```

### Code Issue
```typescript
// BEFORE (libs/typescript/playground/src/adapters/cloud.ts:213)
async getConfig(computer: ComputerInfo): Promise<InferenceConfig> {
  return {
    baseUrl: computer.agentUrl,  // ❌ Points to computer server!
  };
}
```

This makes the playground send requests like:
```
POST https://s-linux-xxx.sandbox.cua.ai:8443/responses
```

The computer server **cannot handle**:
- Model routing (cua/anthropic/claude-haiku-4.5)
- LLM API calls to Anthropic/OpenAI
- Inference management

## The Fix

### Correct Flow
```
Playground → Inference API (/v1/inference) ✅
  └─ Routes to correct LLM provider (Anthropic/OpenAI)
  └─ Manages API keys and rate limits
  └─ Sends computer tool calls to computer server
  └─ Aggregates and returns response
```

### Code Fix
```typescript
// AFTER
async getConfig(computer: ComputerInfo): Promise<InferenceConfig> {
  return {
    baseUrl: `${this.baseUrl}/v1/inference`,  // ✅ Inference API
    env: {
      CUA_COMPUTER_ID: computer.id,
      CUA_AGENT_URL: computer.agentUrl,
    },
  };
}
```

Now requests go to:
```
POST https://api.cua.ai/v1/inference
```

## Impact

- ✅ Requests route through inference API properly
- ✅ Model routing works (Anthropic, OpenAI, etc.)
- ✅ Computer server only handles tool calls as designed
- ✅ Playground inference works end-to-end

## Root Cause

This bug was introduced in **PR #1013** when the playground was extracted into the `@trycua/playground` package. The cloud adapter mistakenly used `computer.agentUrl` (computer server) instead of the inference API endpoint.

## Testing

- [x] TypeScript compiles
- [x] Linting passes
- [x] Verified inference config returns correct API URL
- [x] Tested locally - requests route to inference API

Co-Authored-By: Claude Sonnet 4.5 (1M context) <noreply@anthropic.com>