### PR TITLE
fix(playground): add direct CSS rules for TrajectoryViewer layout

### DIFF
--- a/libs/typescript/playground/src/styles.css
+++ b/libs/typescript/playground/src/styles.css
@@ -1,7 +1,28 @@
-@import 'tailwindcss';
-
 /* Standalone dark mode - works with both class and media query */
 @custom-variant dark (&:where(.dark, .dark *));
+
+/* Critical TrajectoryViewer layout styles - applied directly so they work regardless of consumer's Tailwind config */
+@media (min-width: 1024px) {
+  /* Main container padding and gap */
+  #trajectory-container {
+    padding: 0.75rem !important;
+    gap: 0.75rem !important;
+  }
+
+  /* 75/25 split between display and sidebar */
+  #trajectory-container > .order-1 {
+    width: 75% !important;
+  }
+
+  #trajectory-container > .order-2 {
+    width: 25% !important;
+  }
+
+  /* Sidebar padding */
+  #trajectory-container .overflow-y-auto {
+    padding: 0.75rem !important;
+  }
+}
 
 @theme {
   /* Custom theme colors */


### PR DESCRIPTION
## Summary
Fix TrajectoryViewer visual regression by baking critical layout styles directly into the component CSS instead of relying on the consumer's Tailwind build.

## Background

The TrajectoryViewer originally worked perfectly with proper padding, gap, and 75/25 width split. When moved to the `@trycua/playground` package, the layout regressed because:

**Original approach (worked in cloud repo, broke in package):**
- Component uses Tailwind utility classes (`lg:p-3`, `lg:gap-3`, `lg:w-3/4`, `lg:w-1/4`)
- Classes worked when component was in cloud repo (Tailwind scanned it directly)
- Broke when moved to package (Tailwind doesn't scan `node_modules` by default)
- Result: `Padding: 0px`, `Gap: normal` instead of the expected `12px`

## Problem with Import-Based Solutions

We tried multiple approaches to make the consumer's Tailwind scan the package:
- ❌ CSS `@import` - doesn't resolve package.json exports
- ❌ `@source` directive - doesn't work reliably with node_modules
- ❌ Complex import paths - brittle, breaks in different environments
- ❌ Build-time scanning configuration - requires every consumer to configure their build

**These approaches are fragile and create ongoing maintenance burden.**

## The Better Solution: Bake It In

Instead of fighting with imports and build configuration, **bake the critical styles directly into the component's CSS file**:

```css
@media (min-width: 1024px) {
  #trajectory-container {
    padding: 0.75rem !important;
    gap: 0.75rem !important;
  }
  /* 75/25 split */
  #trajectory-container > .order-1 { width: 75% !important; }
  #trajectory-container > .order-2 { width: 25% !important; }
}
```

## Why This Is Better

### Long-term Benefits
- ✅ **Works out of the box** - no consumer configuration needed
- ✅ **Truly standalone** - doesn't depend on consumer's build setup
- ✅ **Reliable** - styles always apply, no build-time scanning required
- ✅ **Maintainable** - critical layout in one place, easy to update
- ✅ **Compatible** - works with any build system (Vite, Webpack, etc.)

### No More Fighting
- No more dealing with Tailwind content scanning
- No more import path debugging
- No more "it works locally but breaks in production"
- No more consumer configuration requirements

## Changes

1. **Remove** `@import 'tailwindcss'` from styles.css
   - Avoids conflicts with consumer's Tailwind
   
2. **Add** direct CSS rules for critical layout
   - Padding, gap, and width percentages
   - Media queries for responsive behavior
   - `!important` to ensure they apply

3. **Keep** theme variables and color definitions
   - Component still looks good with the intended design

## Test Plan

- [x] Padding applied correctly (12px on large screens)
- [x] Gap applied correctly (12px on large screens)  
- [x] 75/25 width split works
- [x] Responsive behavior maintained
- [x] Works in cloud app without any consumer configuration
- [x] Tested with local link - visual regression fixed

## Impact

This fix makes `@trycua/playground` a truly standalone package. Consumers can use it without:
- Configuring Tailwind to scan the package
- Adding special imports or directives
- Wrestling with build configuration

Just `npm install @trycua/playground` and it works. That's what "standalone" should mean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)