### PR TITLE
fix(lume): remove com.apple.vm.networking from release entitlements

### DIFF
--- a/libs/lume/resources/lume.entitlements
+++ b/libs/lume/resources/lume.entitlements
@@ -4,7 +4,5 @@
 <dict>
 	<key>com.apple.security.virtualization</key>
 	<true/>
-	<key>com.apple.vm.networking</key>
-	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Remove `com.apple.vm.networking` from `lume.entitlements` (used by release/notarized builds)

## Problem
The `com.apple.vm.networking` entitlement is a restricted entitlement that requires a matching provisioning profile. Without one, macOS's AMFI (Apple Mobile File Integrity) kills the binary immediately on launch with error `-413: No matching profile found` — even for commands like `lume ls` that don't use bridged networking.

This was introduced in the bridged networking PR and makes the v0.2.78 release completely unusable.

## Fix
Remove the entitlement from the release entitlements file. The entitlement remains in `lume.local.entitlements` for local development builds where users can provide their own provisioning profile.

## Test plan
- [ ] Build and sign with `lume.entitlements` — binary should launch without being killed
- [ ] `lume ls`, `lume run`, `lume serve` all work normally
- [ ] Bridged networking correctly errors when attempted (entitlement not present)