### PR TITLE
fix(lume): update test mocks to match current API

### DIFF
--- a/libs/lume/tests/Mocks/MockVM.swift
+++ b/libs/lume/tests/Mocks/MockVM.swift
@@ -23,13 +23,15 @@ class MockVM: VM {
 
     override func run(
         noDisplay: Bool, sharedDirectories: [SharedDirectory], mount: Path?, vncPort: Int = 0,
-        recoveryMode: Bool = false, usbMassStoragePaths: [Path]? = nil
+        recoveryMode: Bool = false, usbMassStoragePaths: [Path]? = nil,
+        networkMode: NetworkMode? = nil, clipboard: Bool = false
     ) async throws {
         mockIsRunning = true
         try await super.run(
             noDisplay: noDisplay, sharedDirectories: sharedDirectories, mount: mount,
             vncPort: vncPort, recoveryMode: recoveryMode,
-            usbMassStoragePaths: usbMassStoragePaths
+            usbMassStoragePaths: usbMassStoragePaths,
+            networkMode: networkMode, clipboard: clipboard
         )
     }
 

--- a/libs/lume/tests/VM/VMDetailsPrinterTests.swift
+++ b/libs/lume/tests/VM/VMDetailsPrinterTests.swift
@@ -76,12 +76,12 @@ struct VMDetailsPrinterTests {
         let headerParts = printedLines[0].split(whereSeparator: \.isWhitespace)
         #expect(
             headerParts == [
-                "name", "os", "cpu", "memory", "disk", "display", "status", "storage", "shared_dirs", "ip", "ssh", "vnc",
+                "name", "os", "cpu", "memory", "disk", "display", "status", "network", "storage", "shared_dirs", "ip", "ssh", "vnc",
             ])
 
         #expect(
             printedLines[1].split(whereSeparator: \.isWhitespace).map(String.init) == [
-                "name", "os", "2", "0.00G", "24.0B/30.0B", "1024x768", "status", "mockLocation",
+                "name", "os", "2", "0.00G", "24.0B/30.0B", "1024x768", "status", "nat", "mockLocation",
                 "-",
                 "0.0.0.0",
                 "-",


### PR DESCRIPTION
## Summary

- Updates `MockVM.run()` signature to include `networkMode` and `clipboard` parameters that were added to the `VM` base class
- Updates `VMDetailsPrinterTests.printStatus_whenNotJSON()` to expect the `network` column in table output

These test mocks fell out of sync with the source, causing CI test failures on all PRs touching `libs/lume/`.

## Test plan
- [ ] CI passes: `swift test` in `libs/lume/`