### PR TITLE
Add 'openclaw' to examples pages

### DIFF
--- a/docs/content/docs/lume/examples/meta.json
+++ b/docs/content/docs/lume/examples/meta.json
@@ -2,5 +2,5 @@
   "title": "Examples",
   "description": "Step-by-step tutorials and use cases",
   "icon": "Blocks",
-  "pages": ["claude-code", "claude-cowork"]
+  "pages": ["claude-code", "claude-cowork", "openclaw"]
 }


### PR DESCRIPTION
I'm not sure if this is the only change needed (I didn't try rebuilding the docs), but I just wanted to call out that https://cua.ai/docs/lume/examples/openclaw doesn't appear as an item in the left nav like the similar [example](https://cua.ai/docs/lume/examples/claude-code/sandbox) of claude code does.