### PR TITLE
Update curl command to get correct IPSW URL in quickstart guide

### DIFF
--- a/docs/content/docs/lume/guide/getting-started/quickstart.mdx
+++ b/docs/content/docs/lume/guide/getting-started/quickstart.mdx
@@ -21,7 +21,7 @@ lume ipsw
 # Output: https://updates.cdn-apple.com/...
 
 # Download it (using curl, wget, or your browser)
-curl -L -o ~/Downloads/macos.ipsw "$(lume ipsw)"
+curl -L -o ~/Downloads/macos.ipsw "$(lume ipsw 2>/dev/null | tail -1)"
 
 # Create the VM with the downloaded file
 lume create my-vm --os macos --ipsw ~/Downloads/macos.ipsw


### PR DESCRIPTION
Currently ipsw gives output like:
```
$ lume ipsw 
[2026-02-23T03:35:51Z] INFO: Fetching latest supported IPSW URL
[2026-02-23T03:35:52Z] INFO: Found latest IPSW URL url=https://updates.cdn-apple.com/2026WinterFCS/fullrestores/047-60229/6D5DBEA5-75A0-4BEF-ACC9-5ACF9B8DF6B7/UniversalMac_26.3_25D125_Restore.ipsw
https://updates.cdn-apple.com/2026WinterFCS/fullrestores/047-60229/6D5DBEA5-75A0-4BEF-ACC9-5ACF9B8DF6B7/UniversalMac_26.3_25D125_Restore.ipsw
```

This breaks curl. Either ipsw's output needs to be changed to remove the info messages, or the quickstart should be fixed to just pull the last line.