### PR TITLE
fix(lume): prevent ls hangs, add SSH fallback, fix bridged IP resolution

### DIFF
--- a/libs/lume/src/SSH/SystemSSHClient.swift
+++ b/libs/lume/src/SSH/SystemSSHClient.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+/// SSH client that delegates to the system's /usr/bin/ssh binary.
+/// Used as a fallback when NIO SSH cannot establish a direct TCP connection
+/// (e.g., in sandboxed environments where only system-signed binaries can
+/// access certain network interfaces like vmnet).
+///
+/// Uses SSH_ASKPASS to provide password authentication non-interactively.
+public final class SystemSSHClient: Sendable {
+    private let host: String
+    private let port: Int
+    private let user: String
+    private let password: String
+
+    public init(
+        host: String,
+        port: UInt16 = 22,
+        user: String = "lume",
+        password: String = "lume"
+    ) {
+        self.host = host
+        self.port = Int(port)
+        self.user = user
+        self.password = password
+    }
+
+    /// Execute a command on the remote host using system ssh
+    public func execute(command: String, timeout: TimeInterval = 60) throws -> SSHResult {
+        let askpassPath = try createAskpassScript()
+        defer { try? FileManager.default.removeItem(atPath: askpassPath) }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
+        process.arguments = sshArguments(extraArgs: ["\(user)@\(host)", command])
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["SSH_ASKPASS"] = askpassPath
+        environment["SSH_ASKPASS_REQUIRE"] = "force"
+        environment["DISPLAY"] = ":0"
+        process.environment = environment
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+        // Detach from controlling terminal so SSH_ASKPASS is used
+        process.standardInput = FileHandle.nullDevice
+
+        try process.run()
+
+        // Set up timeout
+        if timeout > 0 {
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
+                if process.isRunning {
+                    process.terminate()
+                }
+            }
+        }
+
+        process.waitUntilExit()
+
+        let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: stdoutData, encoding: .utf8) ?? ""
+        let errorOutput = String(data: stderrData, encoding: .utf8) ?? ""
+
+        // Filter out SSH warnings from stderr (known_hosts, etc.)
+        let filteredError = errorOutput.components(separatedBy: "\n")
+            .filter { line in
+                !line.contains("Warning: Permanently added") &&
+                !line.contains("known_hosts") &&
+                !line.trimmingCharacters(in: .whitespaces).isEmpty
+            }
+            .joined(separator: "\n")
+
+        let combinedOutput = filteredError.isEmpty ? output : output + filteredError
+
+        return SSHResult(
+            exitCode: process.terminationStatus,
+            output: combinedOutput
+        )
+    }
+
+    /// Start an interactive SSH session using system ssh
+    public func interactive() throws {
+        let askpassPath = try createAskpassScript()
+        defer { try? FileManager.default.removeItem(atPath: askpassPath) }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
+        process.arguments = sshArguments(extraArgs: ["-t", "\(user)@\(host)"])
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["SSH_ASKPASS"] = askpassPath
+        environment["SSH_ASKPASS_REQUIRE"] = "force"
+        environment["DISPLAY"] = ":0"
+        process.environment = environment
+
+        // For interactive mode, pass through stdin/stdout/stderr
+        process.standardInput = FileHandle.standardInput
+        process.standardOutput = FileHandle.standardOutput
+        process.standardError = FileHandle.standardError
+
+        try process.run()
+        process.waitUntilExit()
+
+        if process.terminationStatus != 0 {
+            throw SSHError.connectionFailed(
+                "System SSH exited with code \(process.terminationStatus)"
+            )
+        }
+    }
+
+    // MARK: - Private
+
+    private func sshArguments(extraArgs: [String]) -> [String] {
+        var args = [
+            "-o", "StrictHostKeyChecking=no",
+            "-o", "UserKnownHostsFile=/dev/null",
+            "-o", "LogLevel=ERROR",
+            "-o", "ConnectTimeout=10",
+        ]
+
+        if port != 22 {
+            args += ["-p", "\(port)"]
+        }
+
+        args += extraArgs
+        return args
+    }
+
+    /// Creates a temporary script that outputs the password for SSH_ASKPASS
+    private func createAskpassScript() throws -> String {
+        let tempDir = FileManager.default.temporaryDirectory
+        let scriptPath = tempDir.appendingPathComponent("lume-askpass-\(UUID().uuidString).sh").path
+
+        let scriptContent = """
+            #!/bin/sh
+            echo '\(password.replacingOccurrences(of: "'", with: "'\\''"))'
+            """
+
+        guard FileManager.default.createFile(
+            atPath: scriptPath,
+            contents: scriptContent.data(using: .utf8),
+            attributes: [.posixPermissions: 0o700]
+        ) else {
+            throw SSHError.connectionFailed("Failed to create askpass script")
+        }
+
+        return scriptPath
+    }
+}

--- a/libs/lume/src/Virtualization/DHCPLeaseParser.swift
+++ b/libs/lume/src/Virtualization/DHCPLeaseParser.swift
@@ -53,24 +53,77 @@ private struct DHCPLease {
 enum DHCPLeaseParser {
     private static let leasePath = "/var/db/dhcpd_leases"
     
-    /// Retrieves the IP address for a given MAC address from the DHCP lease file
+    /// Retrieves the IP address for a given MAC address.
+    /// First checks vmnet's DHCP leases (for NAT mode), then falls back to the
+    /// system ARP table (for bridged mode where the VM gets its IP from the
+    /// physical network's DHCP server).
     /// - Parameter macAddress: The MAC address to look up
     /// - Returns: The IP address if found, nil otherwise
     static func getIPAddress(forMAC macAddress: String) -> String? {
-        guard let leaseContents = try? String(contentsOfFile: leasePath, encoding: .utf8) else {
-            return nil
-        }
-
         // Normalize the input MAC address to ensure consistent format
         let normalizedMacAddress = macAddress.split(separator: ":").map { component in
             let hex = String(component)
             return hex.count == 1 ? "0\(hex)" : hex
         }.joined(separator: ":")
-        
-        let leases = try? parseDHCPLeases(leaseContents)
-        return leases?.first { lease in 
-            lease.macAddress == normalizedMacAddress
-        }?.ipAddress
+
+        // Check both sources: vmnet DHCP leases (NAT mode) and ARP table (bridged mode)
+        let dhcpIP: String? = {
+            guard let leaseContents = try? String(contentsOfFile: leasePath, encoding: .utf8),
+                  let leases = try? parseDHCPLeases(leaseContents) else {
+                return nil
+            }
+            return leases.first(where: { $0.macAddress == normalizedMacAddress })?.ipAddress
+        }()
+        let arpIP = getIPFromARP(forMAC: normalizedMacAddress)
+
+        // If ARP has an entry, the VM is actively communicating on the physical
+        // network (bridged mode). Prefer ARP since DHCP may contain a stale NAT
+        // lease from a previous session.
+        if let arpIP = arpIP {
+            return arpIP
+        }
+
+        // No ARP entry means NAT mode (vmnet traffic doesn't appear in host ARP table)
+        return dhcpIP
+    }
+
+    /// Looks up an IP address in the system ARP table by MAC address.
+    /// Used for bridged networking where the VM gets its IP from the physical
+    /// network's DHCP server instead of vmnet.
+    private static func getIPFromARP(forMAC macAddress: String) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/sbin/arp")
+        process.arguments = ["-an"]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return nil
+        }
+
+        guard let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) else {
+            return nil
+        }
+
+        // ARP output format: ? (192.168.14.18) at be:bd:fd:9d:8b:38 on en0 ifscope [ethernet]
+        let lowercaseMAC = macAddress.lowercased()
+        for line in output.components(separatedBy: "\n") {
+            if line.lowercased().contains(lowercaseMAC) {
+                // Extract IP from parentheses: ? (192.168.14.18) at ...
+                if let openParen = line.firstIndex(of: "("),
+                   let closeParen = line.firstIndex(of: ")") {
+                    let ip = String(line[line.index(after: openParen)..<closeParen])
+                    return ip
+                }
+            }
+        }
+
+        return nil
     }
     
     /// Parses the contents of a DHCP lease file into lease entries


### PR DESCRIPTION
## Summary

- **Prevent `lume ls` hangs**: Added `runWithTimeout` helper in `NetworkUtils` that kills stuck subprocesses (`lsof`, `nc`, `ping`) after a deadline. Previously, `Process.waitUntilExit()` had no timeout, so `lume ls` could hang indefinitely when subprocesses got stuck during concurrent VM state transitions (e.g., running `lume ls` while `lume stop` is tearing down networking).

- **SSH system fallback**: Added `SystemSSHClient` that delegates to `/usr/bin/ssh` with `SSH_ASKPASS` for password authentication. `lume ssh` now tries NIO SSH first and silently falls back to system SSH on connection failure. This fixes SSH in sandboxed/restricted environments where macOS blocks non-system-signed binaries from making direct TCP connections to vmnet interfaces (errno 65: EHOSTUNREACH).

- **Bridged mode IP resolution**: Added ARP table lookup as fallback in `DHCPLeaseParser`. In bridged mode, VMs get their IP from the physical network's DHCP server (not vmnet), so `lume ls`/`lume get` showed a stale NAT IP. Now checks the ARP table first (recent, accurate for bridged) and falls back to vmnet DHCP leases (for NAT mode). NAT traffic doesn't appear in the host ARP table, so there's no ambiguity.

## Files changed

| File | Change |
|------|--------|
| `libs/lume/src/Utils/NetworkUtils.swift` | `runWithTimeout` helper, kill timeouts on all subprocess calls |
| `libs/lume/src/SSH/SystemSSHClient.swift` | **New** — system SSH client using `/usr/bin/ssh` + `SSH_ASKPASS` |
| `libs/lume/src/Commands/SSH.swift` | NIO → system SSH fallback on connection failure |
| `libs/lume/src/Virtualization/DHCPLeaseParser.swift` | ARP table lookup for bridged mode IP resolution |

## Test plan

- [x] `lume ls` no longer hangs during concurrent `lume stop` operations
- [x] `lume ssh` works in restricted environments (falls back to system SSH)
- [x] `lume ls` shows correct bridged IP (192.168.14.x) instead of stale NAT IP (192.168.64.x)
- [x] `lume ssh` still works in NAT mode
- [x] Bridged networking verified end-to-end: VM gets IP on host subnet, SSH works, internet works
- [ ] CI build passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured SSH execution with improved fallback handling
  * Enhanced network operation timeout management for stability
  * Strengthened IP address discovery mechanism

* **Bug Fixes**
  * Improved resilience during VM network state transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->