### PR TITLE
fix(CI): filter by 4xx/5xx for link CI slack summary

### DIFF
--- a/.github/workflows/ci-check-links.yml
+++ b/.github/workflows/ci-check-links.yml
@@ -70,7 +70,7 @@ jobs:
 
           # Extract up to 5 broken links (lychee format: "* [404] <https://...> | ...")
           if [ -f "lychee-output.md" ]; then
-            BROKEN=$(grep -oP '\[\d+\] <?\Khttps?://[^\s|>]+' lychee-output.md | sed 's/>*$//' | head -5 | sed 's/^/• /' || true)
+            BROKEN=$(grep -oP '\[[45]\d\d\] <?\Khttps?://[^\s|>]+' lychee-output.md | sed 's/>*$//' | head -5 | sed 's/^/• /' || true)
             echo "Extracted broken links: '$BROKEN'"
           else
             BROKEN=""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved broken link detection in CI checks to accurately flag only HTTP 400-level and 500-level error codes as broken links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->