### PR TITLE
fix(ci): use GitHub App token in auto-release workflow

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -4,14 +4,26 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
 jobs:
   auto-release:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Detect packages, release labeled, notify unlabeled
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           PR_NUMBER="${{ github.event.pull_request.number }}"
           PR_TITLE="${{ github.event.pull_request.title }}"


### PR DESCRIPTION
## Summary

- The `release-on-merge.yml` workflow was failing with `HTTP 403: Resource not accessible by integration` when trying to dispatch `release-bump-version.yml` via `gh workflow run`
- Root cause: `secrets.GITHUB_TOKEN` doesn't have permission to trigger workflow dispatches
- Fix: use the same GitHub App token (`RELEASE_APP_ID`/`RELEASE_APP_PRIVATE_KEY`) already used by `release-bump-version.yml`, which has the required `actions: write` scope

Fixes: https://github.com/trycua/cua/actions/runs/22450965050/job/65018944677

## Test plan

- [ ] Merge a PR with a `release:lume` label and verify the auto-release workflow successfully dispatches `release-bump-version.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release automation workflow with enhanced security measures for authentication in the CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->