### PR TITLE
fix(lume): sync bumpversion config to current version 0.2.83

### DIFF
--- a/libs/lume/.bumpversion.cfg
+++ b/libs/lume/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.81
+current_version = 0.2.83
 commit = True
 tag = True
 tag_name = lume-v{new_version}

--- a/libs/lume/src/Main.swift
+++ b/libs/lume/src/Main.swift
@@ -17,7 +17,7 @@ struct Lume: AsyncParsableCommand {
 // MARK: - Version Management
 extension Lume {
     enum Version {
-        static let current: String = "0.2.81"
+        static let current: String = "0.2.83"
     }
 }
 


### PR DESCRIPTION
## Summary

- `bump2version` was failing with: `Did not find '0.2.81' in file: 'VERSION'`
- Root cause: `.bumpversion.cfg` and `Main.swift` were stuck at `0.2.81` while `VERSION` was at `0.2.83`. The CD workflow that bumped 0.2.82 and 0.2.83 only updated the `VERSION` file without going through `bump2version`
- Fix: sync `.bumpversion.cfg` (`current_version`) and `Main.swift` (`Version.current`) to `0.2.83`

Fixes: https://github.com/trycua/cua/actions/runs/22451012514/job/65019123065

## Test plan

- [ ] Run `bump2version patch` in `libs/lume/` and verify it bumps to 0.2.84 across all three files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.2.83

<!-- end of auto-generated comment: release notes by coderabbit.ai -->