### PR TITLE
fix(security): prevent command injection in GenericWindowHandler.launch()

### DIFF
--- a/libs/python/computer-server/computer_server/handlers/generic.py
+++ b/libs/python/computer-server/computer_server/handlers/generic.py
@@ -11,6 +11,7 @@ import base64
 import os
 import platform
 import subprocess
+import shlex
 import webbrowser
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -112,7 +113,8 @@ class GenericWindowHandler(BaseWindowHandler):
                 proc = subprocess.Popen([app, *args])
             else:
                 # allow shell command like "libreoffice --writer"
-                proc = subprocess.Popen(app, shell=True)
+                cmd_parts = shlex.split(app)
+                proc = subprocess.Popen(cmd_parts)
             return {"success": True, "pid": proc.pid}
         except Exception as e:
             return {"success": False, "error": str(e)}


### PR DESCRIPTION
## Summary

Fixes command injection vulnerability reported in issue #1097.

## Problem

The `GenericWindowHandler.launch()` method was passing the `app` parameter directly to `subprocess.Popen()` with `shell=True`, allowing arbitrary shell command execution.

## Solution

Use `shlex.split()` to safely parse the command string:

```python
cmd_parts = shlex.split(app)
proc = subprocess.Popen(cmd_parts)
```

## Impact

- Prevents RCE on sandbox host
- Mitigates CWE-78 (OS Command Injection)
- Severity: High (CVSS 7.8)

---

AI-assisted contribution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command execution handling to ensure secure and reliable processing of commands without explicit arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->