### PR TITLE
lume: avoid black Screen Sharing windows during VM startup

### DIFF
--- a/libs/lume/src/VNC/VNCService.swift
+++ b/libs/lume/src/VNC/VNCService.swift
@@ -184,7 +184,18 @@ final class DefaultVNCService: VNCService {
 
     func openClient(url: String) async throws {
         let processRunner = DefaultProcessRunner()
-        try processRunner.run(executable: "/usr/bin/open", arguments: [url])
+        do {
+            // Force a fresh Screen Sharing instance to avoid stale/paused sessions.
+            try processRunner.run(
+                executable: "/usr/bin/open",
+                arguments: ["-n", "-a", "Screen Sharing", url]
+            )
+        } catch {
+            Logger.info("Failed to open Screen Sharing explicitly, falling back to default URL open", metadata: [
+                "error": "\(error)"
+            ])
+            try processRunner.run(executable: "/usr/bin/open", arguments: [url])
+        }
     }
 
     /// Connect a VNC client to the server for sending input events


### PR DESCRIPTION
## Summary
- open the VNC client only after VM start completes
- wait for visible framebuffer content (non-black pixels) before launching Screen Sharing, with timeout fallback
- open Screen Sharing as a fresh app instance to avoid stale/paused sessions

## Why
`lume run <vm>` could open Screen Sharing while the framebuffer was still black, and some sessions remained stuck black. This change gates viewer launch on visible framebuffer content to avoid that startup race.

## Testing
- swift test --filter VMTests
- swift test --filter VNCServiceTests
- manual local validation with `lume run tahoe-pass` confirmed log sequence:
  - `Detected visible VM framebuffer content before opening VNC client`
  - `Starting VNC session`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Optimized VNC client launch by waiting for the display to be ready before opening the connection, ensuring more reliable connection establishment.
  * Enhanced VNC client opening with improved error handling and fallback mechanism for more robust connection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->