### PR TITLE
fix(keyboard): normalize command key to cmd for pynput compatibility on macOS

### DIFF
--- a/libs/python/computer-server/computer_server/handlers/macos.py
+++ b/libs/python/computer-server/computer_server/handlers/macos.py
@@ -1213,12 +1213,14 @@ class MacOSAutomationHandler(BaseAutomationHandler):
             Dictionary containing success status and error message if failed
         """
         try:
-            k = getattr(Key, key) if hasattr(Key, key) else (key if len(key) == 1 else None)
+            k = self._resolve_pynput_key(key)
             if k is None:
+                logger.warning("key_down: unknown key %r", key)
                 return {"success": False, "error": f"Unknown key: {key}"}
             self.keyboard.press(k)
             return {"success": True}
         except Exception as e:
+            logger.error("key_down failed for key %r: %s", key, e)
             return {"success": False, "error": str(e)}
 
     async def key_up(self, key: str) -> Dict[str, Any]:
@@ -1231,12 +1233,14 @@ class MacOSAutomationHandler(BaseAutomationHandler):
             Dictionary containing success status and error message if failed
         """
         try:
-            k = getattr(Key, key) if hasattr(Key, key) else (key if len(key) == 1 else None)
+            k = self._resolve_pynput_key(key)
             if k is None:
+                logger.warning("key_up: unknown key %r", key)
                 return {"success": False, "error": f"Unknown key: {key}"}
             self.keyboard.release(k)
             return {"success": True}
         except Exception as e:
+            logger.error("key_up failed for key %r: %s", key, e)
             return {"success": False, "error": str(e)}
 
     async def type_text(self, text: str) -> Dict[str, Any]:

--- a/libs/python/computer-server/computer_server/handlers/macos.py
+++ b/libs/python/computer-server/computer_server/handlers/macos.py
@@ -972,6 +972,24 @@ class MacOSAutomationHandler(BaseAutomationHandler):
     mouse = MouseController()
     keyboard = KeyboardController()
 
+    @staticmethod
+    def _resolve_pynput_key(key: str):
+        """Resolve incoming key name to a pynput Key value.
+
+        The client Key enum uses 'command' as the value for Key.COMMAND, but
+        pynput expects 'cmd'. This method resolves the alias before lookup.
+        """
+        normalized = key.lower().strip()
+        key_aliases = {
+            "command": "cmd",
+        }
+        resolved_name = key_aliases.get(normalized, normalized)
+        if hasattr(Key, resolved_name):
+            return getattr(Key, resolved_name)
+        if len(key) == 1:
+            return key
+        return None
+
     async def mouse_down(
         self, x: Optional[int] = None, y: Optional[int] = None, button: str = "left"
     ) -> Dict[str, Any]:
@@ -1246,13 +1264,15 @@ class MacOSAutomationHandler(BaseAutomationHandler):
             Dictionary containing success status and error message if failed
         """
         try:
-            k = getattr(Key, key) if hasattr(Key, key) else (key if len(key) == 1 else None)
+            k = self._resolve_pynput_key(key)
             if k is None:
+                logger.warning("press_key: unknown key %r", key)
                 return {"success": False, "error": f"Unknown key: {key}"}
             self.keyboard.press(k)
             self.keyboard.release(k)
             return {"success": True}
         except Exception as e:
+            logger.error("press_key failed for key %r: %s", key, e)
             return {"success": False, "error": str(e)}
 
     async def hotkey(self, keys: List[str]) -> Dict[str, Any]:
@@ -1267,8 +1287,9 @@ class MacOSAutomationHandler(BaseAutomationHandler):
         try:
             seq = []
             for k in keys:
-                kk = getattr(Key, k) if hasattr(Key, k) else (k if len(k) == 1 else None)
+                kk = self._resolve_pynput_key(k)
                 if kk is None:
+                    logger.warning("hotkey: unknown key %r in keys %r", k, keys)
                     return {"success": False, "error": f"Unknown key in hotkey: {k}"}
                 seq.append(kk)
             for k in seq[:-1]:
@@ -1280,6 +1301,7 @@ class MacOSAutomationHandler(BaseAutomationHandler):
                 self.keyboard.release(k)
             return {"success": True}
         except Exception as e:
+            logger.error("hotkey failed for keys %r: %s", keys, e)
             return {"success": False, "error": str(e)}
 
     # Scrolling Actions

--- a/libs/python/computer/computer/interface/generic.py
+++ b/libs/python/computer/computer/interface/generic.py
@@ -165,6 +165,19 @@ class GenericComputerInterface(BaseComputerInterface):
         await self._send_command("drag", {"path": path, "button": button, "duration": duration})
         await self._handle_delay(delay)
 
+    @staticmethod
+    def _normalize_key_for_backend(key: str) -> str:
+        """Normalize key aliases to backend-compatible names.
+
+        The Key enum uses 'command' as the value for Key.COMMAND, but pynput
+        (used by the backend) expects 'cmd'. This method normalizes outbound
+        key names to prevent silent failures.
+        """
+        key_aliases = {
+            "command": "cmd",
+        }
+        return key_aliases.get(key, key)
+
     # Keyboard Actions
     async def key_down(self, key: "KeyType", delay: Optional[float] = None) -> None:
         await self._send_command("key_down", {"key": key})
@@ -213,6 +226,7 @@ class GenericComputerInterface(BaseComputerInterface):
         else:
             raise ValueError(f"Invalid key type: {type(key)}. Must be Key enum or string.")
 
+        actual_key = self._normalize_key_for_backend(actual_key)
         await self._send_command("press_key", {"key": actual_key})
         await self._handle_delay(delay)
 
@@ -249,15 +263,15 @@ class GenericComputerInterface(BaseComputerInterface):
         actual_keys = []
         for key in keys:
             if isinstance(key, Key):
-                actual_keys.append(key.value)
+                resolved = self._normalize_key_for_backend(key.value)
             elif isinstance(key, str):
                 # Try to convert to enum if it matches a known key
                 key_or_enum = Key.from_string(key)
-                actual_keys.append(
-                    key_or_enum.value if isinstance(key_or_enum, Key) else key_or_enum
-                )
+                normalized = key_or_enum.value if isinstance(key_or_enum, Key) else key_or_enum
+                resolved = self._normalize_key_for_backend(normalized)
             else:
                 raise ValueError(f"Invalid key type: {type(key)}. Must be Key enum or string.")
+            actual_keys.append(resolved)
 
         await self._send_command("hotkey", {"keys": actual_keys})
         await self._handle_delay(delay)

--- a/libs/python/computer/computer/interface/generic.py
+++ b/libs/python/computer/computer/interface/generic.py
@@ -180,11 +180,27 @@ class GenericComputerInterface(BaseComputerInterface):
 
     # Keyboard Actions
     async def key_down(self, key: "KeyType", delay: Optional[float] = None) -> None:
-        await self._send_command("key_down", {"key": key})
+        if isinstance(key, Key):
+            actual_key = key.value
+        elif isinstance(key, str):
+            key_or_enum = Key.from_string(key)
+            actual_key = key_or_enum.value if isinstance(key_or_enum, Key) else key_or_enum
+        else:
+            raise ValueError(f"Invalid key type: {type(key)}. Must be Key enum or string.")
+        actual_key = self._normalize_key_for_backend(actual_key)
+        await self._send_command("key_down", {"key": actual_key})
         await self._handle_delay(delay)
 
     async def key_up(self, key: "KeyType", delay: Optional[float] = None) -> None:
-        await self._send_command("key_up", {"key": key})
+        if isinstance(key, Key):
+            actual_key = key.value
+        elif isinstance(key, str):
+            key_or_enum = Key.from_string(key)
+            actual_key = key_or_enum.value if isinstance(key_or_enum, Key) else key_or_enum
+        else:
+            raise ValueError(f"Invalid key type: {type(key)}. Must be Key enum or string.")
+        actual_key = self._normalize_key_for_backend(actual_key)
+        await self._send_command("key_up", {"key": actual_key})
         await self._handle_delay(delay)
 
     async def type_text(self, text: str, delay: Optional[float] = None) -> None:

--- a/libs/python/computer/computer/interface/generic.py
+++ b/libs/python/computer/computer/interface/generic.py
@@ -178,28 +178,26 @@ class GenericComputerInterface(BaseComputerInterface):
         }
         return key_aliases.get(key, key)
 
-    # Keyboard Actions
-    async def key_down(self, key: "KeyType", delay: Optional[float] = None) -> None:
+    def _coerce_key_for_backend(self, key: "KeyType") -> str:
+        """Resolve KeyType input to a backend-compatible key string."""
         if isinstance(key, Key):
-            actual_key = key.value
+            resolved_key = key.value
         elif isinstance(key, str):
             key_or_enum = Key.from_string(key)
-            actual_key = key_or_enum.value if isinstance(key_or_enum, Key) else key_or_enum
+            resolved_key = key_or_enum.value if isinstance(key_or_enum, Key) else key_or_enum
         else:
             raise ValueError(f"Invalid key type: {type(key)}. Must be Key enum or string.")
-        actual_key = self._normalize_key_for_backend(actual_key)
+
+        return self._normalize_key_for_backend(resolved_key)
+
+    # Keyboard Actions
+    async def key_down(self, key: "KeyType", delay: Optional[float] = None) -> None:
+        actual_key = self._coerce_key_for_backend(key)
         await self._send_command("key_down", {"key": actual_key})
         await self._handle_delay(delay)
 
     async def key_up(self, key: "KeyType", delay: Optional[float] = None) -> None:
-        if isinstance(key, Key):
-            actual_key = key.value
-        elif isinstance(key, str):
-            key_or_enum = Key.from_string(key)
-            actual_key = key_or_enum.value if isinstance(key_or_enum, Key) else key_or_enum
-        else:
-            raise ValueError(f"Invalid key type: {type(key)}. Must be Key enum or string.")
-        actual_key = self._normalize_key_for_backend(actual_key)
+        actual_key = self._coerce_key_for_backend(key)
         await self._send_command("key_up", {"key": actual_key})
         await self._handle_delay(delay)
 
@@ -233,16 +231,7 @@ class GenericComputerInterface(BaseComputerInterface):
         Raises:
             ValueError: If the key type is invalid or the key is not recognized
         """
-        if isinstance(key, Key):
-            actual_key = key.value
-        elif isinstance(key, str):
-            # Try to convert to enum if it matches a known key
-            key_or_enum = Key.from_string(key)
-            actual_key = key_or_enum.value if isinstance(key_or_enum, Key) else key_or_enum
-        else:
-            raise ValueError(f"Invalid key type: {type(key)}. Must be Key enum or string.")
-
-        actual_key = self._normalize_key_for_backend(actual_key)
+        actual_key = self._coerce_key_for_backend(key)
         await self._send_command("press_key", {"key": actual_key})
         await self._handle_delay(delay)
 
@@ -276,18 +265,7 @@ class GenericComputerInterface(BaseComputerInterface):
         Raises:
             ValueError: If any key type is invalid or not recognized
         """
-        actual_keys = []
-        for key in keys:
-            if isinstance(key, Key):
-                resolved = self._normalize_key_for_backend(key.value)
-            elif isinstance(key, str):
-                # Try to convert to enum if it matches a known key
-                key_or_enum = Key.from_string(key)
-                normalized = key_or_enum.value if isinstance(key_or_enum, Key) else key_or_enum
-                resolved = self._normalize_key_for_backend(normalized)
-            else:
-                raise ValueError(f"Invalid key type: {type(key)}. Must be Key enum or string.")
-            actual_keys.append(resolved)
+        actual_keys = [self._coerce_key_for_backend(key) for key in keys]
 
         await self._send_command("hotkey", {"keys": actual_keys})
         await self._handle_delay(delay)


### PR DESCRIPTION
## Summary

- **Bug:** The client `Key.COMMAND` enum has value `"command"`, but pynput's `Key` enum uses `cmd`. When the client sends `"command"` to the macOS backend, `hasattr(pynput.keyboard.Key, "command")` returns `False`, causing all Command key shortcuts (`cmd+a`, `cmd+c`, `cmd+v`, etc.) to silently fail with `"Unknown key: command"`.

- **Fix:** Normalize `"command"` to `"cmd"` on both sides for defense in depth:
  - **Client** (`generic.py`): `_normalize_key_for_backend()` normalizes outbound key names before sending to the backend
  - **Backend** (`macos.py`): `_resolve_pynput_key()` resolves key aliases on receipt, with warning/error logs on unknown keys and exceptions

## Root Cause

```
User code:       await interface.hotkey(Key.COMMAND, "c")

Client (generic.py):   Key.COMMAND.value  ->  "command"

Wire (WebSocket):      {"keys": ["command", "c"]}

Backend (macos.py):    hasattr(pynput.keyboard.Key, "command")  ->  False
                       len("command") == 1  ->  False
                       Result: k = None  ->  "Unknown key in hotkey: command"
```

## Testing

Verified the key alias resolution logic matches the pattern already used in `cua_auto/keyboard.py`'s `_SPECIAL` dictionary (which correctly maps `"command"` to `_Key.cmd`) and the Windows handler's `_key_from_string()` method.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard input validation and error handling.
  * Enhanced consistency in key name normalization across keyboard automation features.
  * Better error reporting when unsupported keys are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->