### PR TITLE
Ensure 'python' and 'python3' point to Python 3.12

### DIFF
--- a/libs/xfce/Dockerfile
+++ b/libs/xfce/Dockerfile
@@ -85,8 +85,9 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     python3.12 -m pip install uv && \
     rm -rf /var/lib/apt/lists/*
 
-# Ensure 'python' points to Python 3.12
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.12 2
+# Ensure 'python' and 'python3' both point to Python 3.12
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.12 2 && \
+    ln -sf /usr/bin/python3.12 /usr/local/bin/python3
 
 # Remove screensavers and power manager to avoid popups and lock screens
 RUN apt-get remove -y \


### PR DESCRIPTION
Updated Dockerfile to ensure both 'python' and 'python3' point to the correct Python 3.12 package. This fixes the missing package errors that appear when doing `computer.run_command("python3 -m bench_ui")`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python 3.12 configuration in container image by consolidating environment setup operations into a single layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->