### PR TITLE
fix(cua-bench): add KeyAction support to worker client (#1088)

### DIFF
--- a/libs/cua-bench/cua_bench/workers/worker_client.py
+++ b/libs/cua-bench/cua_bench/workers/worker_client.py
@@ -14,6 +14,7 @@ from cua_bench.types import (
     DoubleClickAction,
     DragAction,
     HotkeyAction,
+    KeyAction,
     RightClickAction,
     ScrollAction,
     TypeAction,
@@ -133,6 +134,7 @@ class CBEnvWorkerClient:
         "right_single",
         "drag",
         "hotkey",
+        "key",
         "type",
         "scroll",
         "wait",
@@ -270,6 +272,11 @@ class CBEnvWorkerClient:
         elif fn_name == "hotkey":
             args_str = ",".join(args)
             return f"hotkey({args_str})", HotkeyAction(keys=list(args))
+
+        elif fn_name == "key":
+            if not check_type(args, [str]):
+                return "wait()", default_action
+            return f"key({args[0]})", KeyAction(key=args[0])
 
         elif fn_name == "type":
             if not check_type(args, [str]):


### PR DESCRIPTION
The worker client only accepted HotkeyAction for key presses, but the Slack oracle uses KeyAction(key="Return"). Add `key` to valid_fn_names and handle it in check_and_fix_action so callers can express single-key presses matching the oracle behavior.

Closes #1088

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard key action support to the worker client, enabling users to simulate keyboard inputs through the action system with input validation for reliable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->