### PR TITLE
fix(links): broken hud links

### DIFF
--- a/blog/cua-hackathon.md
+++ b/blog/cua-hackathon.md
@@ -8,7 +8,7 @@ We’re bringing something new to [Hack the North](https://hackthenorth.com), Ca
 
 ## Track A: On-site @ Hack the North
 
-There’s one global leaderboard: **Cua - Best State-of-the-Art Computer-Use Agent**. Use any model setup you like (cloud or local). After projects are submitted, [HUD](https://www.hud.so) runs the official benchmark; the top team earns a **guaranteed YC partner interview (W26 batch)**. We’ll also feature winners on our blog and socials and kit the team out with swag.
+There’s one global leaderboard: **Cua - Best State-of-the-Art Computer-Use Agent**. Use any model setup you like (cloud or local). After projects are submitted, [HUD](https://www.hud.ai) runs the official benchmark; the top team earns a **guaranteed YC partner interview (W26 batch)**. We’ll also feature winners on our blog and socials and kit the team out with swag.
 
 ## Track B: Cua Global Online Hackathon
 

--- a/blog/hack-the-north.md
+++ b/blog/hack-the-north.md
@@ -56,7 +56,7 @@ Our slot landed at **2:30 a.m.** (_perks of the cheapest sponsor tier_). Thirty 
 **Our track rules were simple:**
 
 1. Build a Computer-Use Agent with the [Cua framework](https://github.com/trycua/cua)
-2. Benchmark the agent on [HUD](https://www.hud.so)
+2. Benchmark the agent on [HUD](https://www.hud.ai)
 3. Use [OSWorld-Tiny](https://huggingface.co/datasets/ddupont/OSWorld-Tiny-Public): a 14-task distillation of the full benchmark (~360 tasks, >1h)
 
 **Suggestions:**
@@ -108,7 +108,7 @@ We skipped a full end-to-end **Cua × HUD** dry-run. It showed.
 - ~**30** hackers gave the track a serious try; **5** crossed the finish line
 - All submissions were **solo**, mostly undergrads
 - Judging: OSWorld-Tiny on HUD, with Cua + HUD reruns to verify scores
-- Final leaderboard: [HUD Leaderboard](https://www.hud.so/leaderboards/ddupont/OSWorld-Tiny-Public)
+- Final leaderboard: [HUD Leaderboard](https://www.hud.ai/leaderboards/ddupont/OSWorld-Tiny-Public)
 
 ![hack-leaderboard](./assets/hack-leaderboard.png)
 

--- a/blog/hud-agent-evals.md
+++ b/blog/hud-agent-evals.md
@@ -2,7 +2,7 @@
 
 _Published on August 27, 2025 by Dillon DuPont_
 
-You can now benchmark any GUI-capable agent on real computer-use tasks through our new integration with [HUD](https://hud.so), the evaluation platform for computer-use agents.
+You can now benchmark any GUI-capable agent on real computer-use tasks through our new integration with [HUD](https://hud.ai), the evaluation platform for computer-use agents.
 
 If [yesterday's 0.4 release](composite-agents.md) made it easy to compose planning and grounding models, today's update makes it easy to measure them. Configure your model, run evaluations at scale, and watch traces live in HUD.
 
@@ -11,7 +11,7 @@ If [yesterday's 0.4 release](composite-agents.md) made it easy to compose planni
 ## What you get
 
 - One-line evals on OSWorld (and more) for OpenAI, Anthropic, Hugging Face, and composed GUI models.
-- Live traces at [app.hud.so](https://app.hud.so) to see every click, type, and screenshot.
+- Live traces at [app.hud.ai](https://app.hud.ai) to see every click, type, and screenshot.
 - Zero glue code needed - we wrapped the interface for you.
 - With Cua's Agent SDK, you can benchmark any configurations of models, by just changing the `model` string.
 
@@ -72,7 +72,7 @@ Starting full dataset run...
 ╔═════════════════════════════════════════════════════════════════╗
 ║ 🚀 See your agent live at: ║
 ╟─────────────────────────────────────────────────────────────────╢
-║ https://app.hud.so/jobs/fe05805d-4da9-4fc6-84b5-5c518528fd3c ║
+║ https://app.hud.ai/jobs/fe05805d-4da9-4fc6-84b5-5c518528fd3c ║
 ╚═════════════════════════════════════════════════════════════════╝
 ```
 
@@ -84,10 +84,10 @@ Customize your evaluation with these options:
 - **Model composition**: Mix planning and grounding models with `+` (e.g., `"gpt-4+gpt-5-nano"`)
 - **Parallel scaling**: Set `max_concurrent_tasks` for throughput
 - **Local trajectories**: Save with `trajectory_dir` for offline analysis
-- **Live monitoring**: Every run gets a unique trace URL at app.hud.so
+- **Live monitoring**: Every run gets a unique trace URL at app.hud.ai
 
 ## Learn more
 
 - Notebook with end‑to‑end examples: https://github.com/trycua/cua/blob/main/notebooks/eval_osworld.ipynb
 - Docs: https://cua.ai/docs/cua/guide/integrations/hud
-- Live traces: https://app.hud.so
+- Live traces: https://app.hud.ai


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all HUD service domain references across documentation pages from hud.so to hud.ai. Changes span multiple hackathon competition guides including track information and rules, leaderboard links for results tracking, and agent evaluation tool resources. Users will now access the HUD platform and all associated services through the new updated domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->