### PR TITLE
feat: require customer impact section in PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## What changed?
+
+<!-- Describe the technical changes -->
+
+## Why?
+
+<!-- What problem does this solve or what feature does it add? -->
+
+## Customer Impact
+
+<!-- REQUIRED: Explain how this change affects end users. Do NOT delete this section or leave it empty — the PR check will fail. -->
+<!-- Examples: "Users can now resize windows via drag", "Fixes crash when uploading files >10MB" -->
+
+### Visibility
+
+<!-- Check one: -->
+
+- [ ] External — visible to customers (include in changelog/release notes)
+- [ ] Internal — not customer-facing (infra, CI, refactor, tooling, docs, tests)
+
+<!-- If external: describe the user-facing change clearly enough for a non-technical person to understand -->
+<!-- If internal: briefly explain what area this touches and why it doesn't affect users -->
+
+## Test Plan
+
+<!-- How was this tested? -->

--- a/.github/workflows/ci-check-customer-impact.yml
+++ b/.github/workflows/ci-check-customer-impact.yml
@@ -1,0 +1,53 @@
+name: Check Customer Impact
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  check-customer-impact:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for Customer Impact section
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+
+            // Find the Customer Impact section
+            const impactMatch = body.match(/## Customer Impact\s*\n([\s\S]*?)(?=\n## |\n*$)/);
+            const impactContent = impactMatch ? impactMatch[1].trim() : '';
+
+            // Strip HTML comments
+            const stripped = impactContent.replace(/<!--[\s\S]*?-->/g, '').trim();
+
+            // Check that at least one visibility checkbox is checked
+            const externalChecked = /- \[x\] External/i.test(impactContent);
+            const internalChecked = /- \[x\] Internal/i.test(impactContent);
+            const hasVisibility = externalChecked || internalChecked;
+
+            const errors = [];
+
+            if (!stripped) {
+              errors.push(
+                '❌ Missing customer impact.\n' +
+                'Please fill out the "Customer Impact" section in your PR description.\n' +
+                'Explain how this change affects end users. If there is no direct impact, say why.'
+              );
+            }
+
+            if (!hasVisibility) {
+              errors.push(
+                '❌ Missing visibility label.\n' +
+                'Check one of the boxes in the Visibility section:\n' +
+                '- [x] External — visible to customers\n' +
+                '- [x] Internal — not customer-facing'
+              );
+            }
+
+            if (errors.length > 0) {
+              core.setFailed(errors.join('\n\n'));
+            } else {
+              const visibility = externalChecked ? 'External' : 'Internal';
+              core.info(`✅ Customer impact found (${visibility}): "${stripped.substring(0, 100)}..."`);
+            }


### PR DESCRIPTION
## Summary
- Adds a PR template with **Customer Impact** and **Visibility** (External/Internal) sections
- Adds a CI check (`ci-check-customer-impact`) that fails if the impact section is empty or no visibility checkbox is checked
- Ensures every PR documents user-facing impact, whether it's a new feature, bug fix, or internal-only change

## Customer Impact
- [x] Internal — not customer-facing (infra, CI, refactor, tooling, docs, tests)

This adds process tooling to improve how we document changes. No direct user-facing behavior change.

## Test plan
- [ ] Open a test PR with empty Customer Impact section → CI should fail
- [ ] Open a test PR with filled section but no checkbox → CI should fail
- [ ] Open a test PR with filled section and checkbox → CI should pass
- [ ] Verify PR template auto-populates when creating a new PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a standardized pull request template to improve documentation consistency.
  * Added automated validation to ensure customer impact information is properly documented in pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->