### PR TITLE
fix: validate shared directories exist before use

### DIFF
--- a/libs/python/computer/computer/computer.py
+++ b/libs/python/computer/computer/computer.py
@@ -220,10 +220,24 @@ class Computer:
         # for VM file sharing
         self.shared_path = None
         if shared_directories and len(shared_directories) > 0:
-            self.shared_path = shared_directories[0]
-            self.logger.info(
-                f"Using first shared directory for VM file sharing: {self.shared_path}"
-            )
+            # Validate that shared directories exist before using them
+            valid_directories = []
+            for path in shared_directories:
+                abs_path = os.path.abspath(os.path.expanduser(path))
+                if os.path.exists(abs_path):
+                    valid_directories.append(path)
+                else:
+                    self.logger.warning(f"Shared directory does not exist: {path}")
+            
+            if valid_directories:
+                self.shared_path = valid_directories[0]
+                self.shared_directories = valid_directories
+                self.logger.info(
+                    f"Using first shared directory for VM file sharing: {self.shared_path}"
+                )
+            else:
+                self.shared_directories = []
+                self.logger.warning("No valid shared directories found")
 
         # Store telemetry preference
         self._telemetry_enabled = telemetry_enabled


### PR DESCRIPTION
## Summary

Add validation in `Computer.__init__` to check that shared directories actually exist on the filesystem before storing them. This prevents errors when trying to mount non-existent directories in the VM provider.

## Changes

- Validate that each shared directory path exists before adding it
- Filter out invalid paths and log warnings
- Fixes the silent failure when invalid paths are provided

## Testing

The fix has been tested by verifying the code compiles and the validation logic is correct.

Closes #124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for shared directory paths with existence checks and improved error handling.
  * Added warning messages for non-existent paths, ensuring only valid directories are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->