### PR TITLE
Fix local Lume provider startup and cleanup

### DIFF
--- a/libs/python/computer/computer/computer.py
+++ b/libs/python/computer/computer/computer.py
@@ -315,7 +315,7 @@ class Computer:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         """Stop the computer."""
-        await self.disconnect()
+        await self.stop()
 
     def __enter__(self):
         """Start the computer."""
@@ -401,7 +401,7 @@ class Computer:
                                     )
                                 self.config.vm_provider = VMProviderFactory.create_provider(
                                     self.provider_type,
-                                    port=port,
+                                    provider_port=port,
                                     host=host,
                                     storage=storage,
                                     shared_path=shared_path,
@@ -413,7 +413,7 @@ class Computer:
                             elif self.provider_type == VMProviderType.LUME:
                                 self.config.vm_provider = VMProviderFactory.create_provider(
                                     self.provider_type,
-                                    port=port,
+                                    provider_port=port,
                                     host=host,
                                     storage=storage,
                                     verbose=verbose,
@@ -434,7 +434,7 @@ class Computer:
                             elif self.provider_type == VMProviderType.WINSANDBOX:
                                 self.config.vm_provider = VMProviderFactory.create_provider(
                                     self.provider_type,
-                                    port=port,
+                                    provider_port=port,
                                     host=host,
                                     storage=storage,
                                     verbose=verbose,
@@ -444,7 +444,7 @@ class Computer:
                             elif self.provider_type == VMProviderType.DOCKER:
                                 self.config.vm_provider = VMProviderFactory.create_provider(
                                     self.provider_type,
-                                    port=port,
+                                    provider_port=port,
                                     host=host,
                                     storage=storage,
                                     shared_path=shared_path,

--- a/libs/python/computer/computer/providers/factory.py
+++ b/libs/python/computer/computer/providers/factory.py
@@ -55,6 +55,11 @@ class VMProviderFactory:
             except ValueError:
                 provider_type = VMProviderType.UNKNOWN
 
+        # Backward compatibility for older callers that passed `port=...`.
+        port_alias = kwargs.pop("port", None)
+        if port_alias is not None:
+            provider_port = port_alias
+
         if provider_type == VMProviderType.LUME:
             try:
                 from .lume import HAS_LUME, LumeProvider

--- a/libs/python/computer/computer/providers/lume/provider.py
+++ b/libs/python/computer/computer/providers/lume/provider.py
@@ -8,7 +8,9 @@ import json
 import logging
 import os
 import re
+import socket
 import subprocess
+import time
 import urllib.parse
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -26,6 +28,9 @@ from ..lume_api import (
 
 # Setup logging
 logger = logging.getLogger(__name__)
+
+DEFAULT_LUME_PORT = 7777
+LEGACY_LUME_PORT = 3000
 
 
 class LumeProvider(BaseVMProvider):
@@ -61,6 +66,8 @@ class LumeProvider(BaseVMProvider):
         self.storage = storage
         self.verbose = verbose
         self.ephemeral = ephemeral  # If True, VMs will be deleted after stopping
+        self._server_process: Optional[subprocess.Popen[str]] = None
+        self._manages_server = False
 
         # Base API URL for Lume API calls
         self.api_base_url = f"http://{self.host}:{self.port}"
@@ -74,13 +81,103 @@ class LumeProvider(BaseVMProvider):
 
     async def __aenter__(self):
         """Enter async context manager."""
-        # No initialization needed, just return self
+        self._ensure_server()
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         """Exit async context manager."""
-        # No cleanup needed
-        pass
+        self._stop_managed_server()
+
+    def _candidate_ports(self) -> List[int]:
+        ports = [self.port]
+        for candidate in (DEFAULT_LUME_PORT, LEGACY_LUME_PORT):
+            if candidate not in ports:
+                ports.append(candidate)
+        return ports
+
+    def _is_server_ready(self, port: Optional[int] = None, timeout: float = 0.5) -> bool:
+        target_port = self.port if port is None else port
+        try:
+            with socket.create_connection((self.host, target_port), timeout=timeout):
+                return True
+        except OSError:
+            return False
+
+    def _attach_to_existing_server(self) -> bool:
+        if self.host not in {"localhost", "127.0.0.1", "::1"}:
+            return False
+
+        for candidate in self._candidate_ports():
+            if not self._is_server_ready(candidate):
+                continue
+            if candidate != self.port:
+                self.logger.info(
+                    "Found running Lume API server on port %s, switching from %s",
+                    candidate,
+                    self.port,
+                )
+                self.port = candidate
+                self.api_base_url = f"http://{self.host}:{self.port}"
+            return True
+
+        return False
+
+    def _start_server(self) -> None:
+        if self.host not in {"localhost", "127.0.0.1", "::1"}:
+            raise RuntimeError(
+                f"Lume API server at {self.host}:{self.port} is unreachable. "
+                "Start `lume serve` on that host or use a reachable local server."
+            )
+
+        self.logger.info("Starting local Lume API server on port %s", self.port)
+        self._server_process = subprocess.Popen(  # noqa: S603
+            ["lume", "serve", "--port", str(self.port)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        self._manages_server = True
+
+    def _wait_for_server(self, timeout_seconds: float = 15.0) -> None:
+        deadline = time.time() + timeout_seconds
+        while time.time() < deadline:
+            if self._is_server_ready():
+                return
+            if self._server_process and self._server_process.poll() is not None:
+                self._manages_server = False
+                raise RuntimeError(
+                    f"`lume serve --port {self.port}` exited before becoming ready."
+                )
+            time.sleep(0.25)
+
+        raise RuntimeError(
+            f"Lume API server did not become ready on {self.host}:{self.port} within "
+            f"{timeout_seconds:.0f}s."
+        )
+
+    def _ensure_server(self) -> None:
+        if self._is_server_ready():
+            return
+        if self._attach_to_existing_server():
+            return
+        self._start_server()
+        self._wait_for_server()
+
+    def _stop_managed_server(self) -> None:
+        if not self._manages_server or self._server_process is None:
+            return
+
+        if self._server_process.poll() is None:
+            self.logger.info("Stopping managed Lume API server on port %s", self.port)
+            self._server_process.terminate()
+            try:
+                self._server_process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._server_process.kill()
+                self._server_process.wait(timeout=5)
+
+        self._server_process = None
+        self._manages_server = False
 
     def _lume_api_get(
         self, vm_name: str = "", storage: Optional[str] = None, debug: bool = False

--- a/libs/python/computer/tests/test_computer.py
+++ b/libs/python/computer/tests/test_computer.py
@@ -55,6 +55,18 @@ class TestComputerContextManager:
         assert callable(Computer.__aenter__)
         assert callable(Computer.__aexit__)
 
+    @pytest.mark.asyncio
+    async def test_async_context_exit_stops_computer(self, disable_telemetry):
+        """`async with Computer(...)` should stop the VM, not just disconnect."""
+        from computer import Computer
+
+        computer = Computer(use_host_computer_server=True)
+        computer.stop = AsyncMock()
+
+        await computer.__aexit__(None, None, None)
+
+        computer.stop.assert_awaited_once()
+
 
 class TestComputerInterface:
     """Test Computer.interface property (SRP: Only tests interface access)."""

--- a/libs/python/computer/tests/test_lume_provider.py
+++ b/libs/python/computer/tests/test_lume_provider.py
@@ -1,0 +1,55 @@
+"""Unit tests for local Lume provider startup behavior."""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from computer.providers.factory import VMProviderFactory
+from computer.providers.lume.provider import LumeProvider
+
+
+class TestVMProviderFactory:
+    """Test provider factory compatibility behavior."""
+
+    def test_factory_accepts_port_alias_for_lume(self):
+        """Older callers passing `port=` should still override provider_port."""
+        provider = VMProviderFactory.create_provider("lume", port=3000)
+        assert isinstance(provider, LumeProvider)
+        assert provider.port == 3000
+
+
+class TestLumeProviderLifecycle:
+    """Test local Lume server management behavior."""
+
+    @patch("computer.providers.lume.provider.subprocess.Popen")
+    def test_provider_starts_local_server_when_needed(self, mock_popen):
+        """Provider should launch `lume serve` if no server is reachable."""
+        process = MagicMock()
+        process.poll.return_value = None
+        mock_popen.return_value = process
+
+        provider = LumeProvider(provider_port=7777)
+
+        with patch.object(
+            provider, "_is_server_ready", side_effect=[False, False, False, True]
+        ) as mock_ready:
+            provider._ensure_server()
+
+        assert provider._manages_server is True
+        assert mock_ready.call_count >= 2
+        mock_popen.assert_called_once_with(
+            ["lume", "serve", "--port", "7777"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+
+    def test_provider_reuses_existing_server_on_legacy_port(self):
+        """Provider should attach to an already-running daemon on port 3000."""
+        provider = LumeProvider(provider_port=7777)
+
+        with patch.object(provider, "_is_server_ready", side_effect=[False, True]):
+            attached = provider._attach_to_existing_server()
+
+        assert attached is True
+        assert provider.port == 3000
+        assert provider.api_base_url == "http://localhost:3000"


### PR DESCRIPTION
## Summary
- auto-start or attach to a local Lume HTTP server for Mac VM runs
- honor `provider_port` overrides and stop VMs on `async with Computer(...)` exit
- add focused tests for cleanup and Lume startup behavior

## Validation
- `uv run --group dev pytest libs/python/computer/tests/test_computer.py libs/python/computer/tests/test_lume_provider.py -v`
- `uv run --group dev python - <<'PY' ... async with Computer(os_type="macos", provider_type="lume") ... PY`
- verified the VM returned to `stopped` and no `lume serve` listener remained on `7777` or `3000`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * LumeProvider now automatically manages local server lifecycle, starting when needed or reusing existing servers.
  * Backward compatibility maintained for existing port parameter usage.

* **Bug Fixes**
  * VM teardown now properly stops the VM instead of only disconnecting.

* **Tests**
  * Added tests for LumeProvider server management and factory compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->