### PR TITLE
fix(computer-server): navigate browser to default page on startup

### DIFF
--- a/libs/python/agent/agent/adapters/yutori_adapter.py
+++ b/libs/python/agent/agent/adapters/yutori_adapter.py
@@ -21,7 +21,7 @@ class YutoriAdapter(CustomLLM):
     def _normalize_model(self, model: str) -> str:
         """Strip the yutori/ prefix to get the bare model name."""
         if model.startswith("yutori/"):
-            return model[len("yutori/"):]
+            return model[len("yutori/") :]
         return model
 
     def _resolve_api_key(self, kwargs: dict | None = None) -> str:
@@ -61,7 +61,13 @@ class YutoriAdapter(CustomLLM):
             params["tool_choice"] = kwargs["tool_choice"]
 
         # Forward optional generation params
-        for key in ("temperature", "top_p", "max_completion_tokens", "max_tokens", "response_format"):
+        for key in (
+            "temperature",
+            "top_p",
+            "max_completion_tokens",
+            "max_tokens",
+            "response_format",
+        ):
             if key in kwargs:
                 params[key] = kwargs[key]
 

--- a/libs/python/agent/agent/agent.py
+++ b/libs/python/agent/agent/agent.py
@@ -91,6 +91,7 @@ def get_json(obj: Any, max_depth: int = 10) -> Any:
 
         # Handle enums — just use their value
         import enum
+
         if isinstance(o, enum.Enum):
             return o.value
 
@@ -856,7 +857,9 @@ class ComputerAgent:
                     # Note: function_call_output only supports text, so we include the
                     # screenshot as a separate user message with image content
                     if is_terminate:
-                        output_content = json.dumps(action_result if action_result else {"terminated": True})
+                        output_content = json.dumps(
+                            action_result if action_result else {"terminated": True}
+                        )
                         call_output = {
                             "type": "function_call_output",
                             "call_id": item.get("call_id"),
@@ -870,7 +873,9 @@ class ComputerAgent:
                         if action_result is not None:
                             output_content = json.dumps(action_result)
                         else:
-                            output_content = json.dumps({"success": True, "screenshot_captured": True})
+                            output_content = json.dumps(
+                                {"success": True, "screenshot_captured": True}
+                            )
                         call_output = {
                             "type": "function_call_output",
                             "call_id": item.get("call_id"),

--- a/libs/python/agent/agent/callbacks/trajectory_saver.py
+++ b/libs/python/agent/agent/callbacks/trajectory_saver.py
@@ -156,7 +156,10 @@ def extract_computer_call_outputs(
                     new_content = []
                     content_modified = False
                     for content_item in content:
-                        if isinstance(content_item, dict) and content_item.get("type") == "input_image":
+                        if (
+                            isinstance(content_item, dict)
+                            and content_item.get("type") == "input_image"
+                        ):
                             image_url = content_item.get("image_url", "")
                             if isinstance(image_url, str) and image_url.startswith("data:"):
                                 # Generate a unique ID for this screenshot
@@ -559,6 +562,7 @@ class TrajectorySaverCallback(AsyncCallbackHandler):
                         # Try to evaluate as Python literal (for stringified dicts)
                         try:
                             import ast
+
                             output_dict = ast.literal_eval(output)
                         except (ValueError, SyntaxError):
                             continue
@@ -589,7 +593,12 @@ class TrajectorySaverCallback(AsyncCallbackHandler):
                         image_bytes = base64.b64decode(image_data)
 
                         # If we have coordinates, draw crosshair annotation
-                        if x_coord is not None and y_coord is not None and x_coord != 0 and y_coord != 0:
+                        if (
+                            x_coord is not None
+                            and y_coord is not None
+                            and x_coord != 0
+                            and y_coord != 0
+                        ):
                             annotated_image = self._draw_crosshair_on_image(
                                 image_bytes, int(x_coord), int(y_coord)
                             )
@@ -610,7 +619,10 @@ class TrajectorySaverCallback(AsyncCallbackHandler):
                 content = result_item.get("content", [])
                 if isinstance(content, list):
                     for content_item in content:
-                        if isinstance(content_item, dict) and content_item.get("type") == "input_image":
+                        if (
+                            isinstance(content_item, dict)
+                            and content_item.get("type") == "input_image"
+                        ):
                             image_url = content_item.get("image_url", "")
                             if isinstance(image_url, str) and image_url.startswith("data:"):
                                 try:
@@ -618,7 +630,12 @@ class TrajectorySaverCallback(AsyncCallbackHandler):
                                     image_bytes = base64.b64decode(b64_payload)
 
                                     # If we have coordinates, draw crosshair annotation
-                                    if x_coord is not None and y_coord is not None and x_coord != 0 and y_coord != 0:
+                                    if (
+                                        x_coord is not None
+                                        and y_coord is not None
+                                        and x_coord != 0
+                                        and y_coord != 0
+                                    ):
                                         annotated_image = self._draw_crosshair_on_image(
                                             image_bytes, int(x_coord), int(y_coord)
                                         )

--- a/libs/python/agent/agent/loops/gemini.py
+++ b/libs/python/agent/agent/loops/gemini.py
@@ -89,11 +89,7 @@ def _sanitize_for_json(obj: Any) -> Any:
         return _sanitize_for_json(obj.model_dump())
     # Handle objects with __dict__ (like Gemini SDK response objects)
     if hasattr(obj, "__dict__"):
-        return {
-            k: _sanitize_for_json(v)
-            for k, v in obj.__dict__.items()
-            if not k.startswith("__")
-        }
+        return {k: _sanitize_for_json(v) for k, v in obj.__dict__.items() if not k.startswith("__")}
     # Fallback to string representation
     return str(obj)
 
@@ -828,9 +824,7 @@ class GeminiComputerUseConfig(AsyncAgentConfig):
         }
 
         if _on_api_start:
-            await _on_api_start(
-                _sanitize_for_json(api_kwargs)
-            )
+            await _on_api_start(_sanitize_for_json(api_kwargs))
 
         response = client.models.generate_content(**api_kwargs)
 

--- a/libs/python/agent/agent/loops/openai.py
+++ b/libs/python/agent/agent/loops/openai.py
@@ -15,7 +15,9 @@ from ..decorators import register_agent
 from ..types import AgentCapability, AgentResponse, Messages, Tools
 
 
-async def _map_computer_tool_to_openai(computer_handler: Any, use_native_tool: bool = True) -> Dict[str, Any]:
+async def _map_computer_tool_to_openai(
+    computer_handler: Any, use_native_tool: bool = True
+) -> Dict[str, Any]:
     """Map a computer tool to OpenAI's tool schema.
 
     Args:
@@ -136,6 +138,7 @@ async def _map_computer_tool_to_openai(computer_handler: Any, use_native_tool: b
 def _is_native_computer_use_model(model: str) -> bool:
     """Check if the model supports native computer_use_preview tool format."""
     import re
+
     # Only computer-use-preview models support native computer_use_preview tool
     # GPT 5.4 does NOT support computer_use_preview - it uses function calling
     return bool(re.search(r"computer-use-preview", model, re.IGNORECASE))
@@ -154,18 +157,22 @@ async def _prepare_tools_for_openai(tool_schemas: List[Dict[str, Any]], model: s
     for schema in tool_schemas:
         if schema["type"] == "computer":
             # Map computer tool to OpenAI format (native or function based on model)
-            computer_tool = await _map_computer_tool_to_openai(schema["computer"], use_native_tool=use_native)
+            computer_tool = await _map_computer_tool_to_openai(
+                schema["computer"], use_native_tool=use_native
+            )
             openai_tools.append(computer_tool)
         elif schema["type"] == "function":
             # Function tools for Responses API need: {type, name, description, parameters}
             # Note: parameters are at the root level, NOT nested under 'function'
             func = schema["function"]
-            openai_tools.append({
-                "type": "function",
-                "name": func["name"],
-                "description": func.get("description", ""),
-                "parameters": func.get("parameters", {}),
-            })
+            openai_tools.append(
+                {
+                    "type": "function",
+                    "name": func["name"],
+                    "description": func.get("description", ""),
+                    "parameters": func.get("parameters", {}),
+                }
+            )
 
     return openai_tools
 
@@ -387,10 +394,7 @@ Task: Click {instruction}. Output ONLY a click action on the target element.""",
                 continue
 
             # Native format: computer_call with action dict
-            if (
-                item.get("type") == "computer_call"
-                and isinstance(item.get("action"), dict)
-            ):
+            if item.get("type") == "computer_call" and isinstance(item.get("action"), dict):
                 action = item["action"]
                 if action.get("x") is not None and action.get("y") is not None:
                     return (int(action.get("x")), int(action.get("y")))

--- a/libs/python/agent/agent/loops/yutori.py
+++ b/libs/python/agent/agent/loops/yutori.py
@@ -370,16 +370,12 @@ class YutoriN1Config(AsyncAgentConfig):
                             }
                         ],
                     }
-                    output_items.extend(
-                        convert_completion_messages_to_responses_items([fake_cm])
-                    )
+                    output_items.extend(convert_completion_messages_to_responses_items([fake_cm]))
                     # Only use content_text once
                     content_text = ""
                 else:
                     # Custom tool — emit as function_call
-                    output_items.append(
-                        make_function_call_item(fn_name, args, call_id=tc_id)
-                    )
+                    output_items.append(make_function_call_item(fn_name, args, call_id=tc_id))
         else:
             # No tool calls — task is complete
             if content_text:

--- a/libs/python/agent/agent/tools/browser_tool.py
+++ b/libs/python/agent/agent/tools/browser_tool.py
@@ -188,7 +188,11 @@ class BrowserTool(BaseComputerTool):
                     ],
                     "type": "string",
                 },
-                "keys": {"description": "Required only by action=key.", "type": "array", "items": {"type": "string"}},
+                "keys": {
+                    "description": "Required only by action=key.",
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
                 "text": {"description": "Required only by action=type.", "type": "string"},
                 "coordinate": {
                     "description": "(x, y) coordinates for mouse actions. Required only by action=left_click, action=mouse_move, and action=type.",

--- a/libs/python/computer-server/computer_server/browser.py
+++ b/libs/python/computer-server/computer_server/browser.py
@@ -25,12 +25,18 @@ class BrowserManager:
     Uses persistent context to maintain cookies and sessions.
     """
 
-    def __init__(self):
-        """Initialize the BrowserManager."""
+    def __init__(self, default_url: Optional[str] = None):
+        """Initialize the BrowserManager.
+
+        Args:
+            default_url: URL to navigate to on startup instead of about:blank.
+                         Falls back to BROWSER_DEFAULT_URL env var, then https://www.google.com.
+        """
         self.playwright = None
         self.browser: Optional[Browser] = None
         self.context: Optional[BrowserContext] = None
         self.page: Optional[Page] = None
+        self.default_url = default_url or os.environ.get("BROWSER_DEFAULT_URL", "https://www.google.com")
         self._initialized = False
         self._initialization_error: Optional[str] = None
         self._lock = asyncio.Lock()
@@ -144,12 +150,11 @@ class BrowserManager:
                     self.page = await self.context.new_page()
 
                 # Navigate to a default page so the browser isn't blank
-                default_url = os.environ.get("BROWSER_DEFAULT_URL", "https://www.google.com")
                 try:
-                    await self.page.goto(default_url, wait_until="domcontentloaded", timeout=15000)
-                    logger.info(f"Navigated to default page: {default_url}")
+                    await self.page.goto(self.default_url, wait_until="domcontentloaded", timeout=15000)
+                    logger.info(f"Navigated to default page: {self.default_url}")
                 except Exception as e:
-                    logger.warning(f"Failed to load default page ({default_url}): {e}")
+                    logger.warning(f"Failed to load default page ({self.default_url}): {e}")
 
                 self._initialized = True
                 logger.info("Browser initialized successfully")
@@ -374,9 +379,14 @@ class BrowserManager:
 _browser_manager: Optional[BrowserManager] = None
 
 
-def get_browser_manager() -> BrowserManager:
-    """Get or create the global BrowserManager instance."""
+def get_browser_manager(default_url: Optional[str] = None) -> BrowserManager:
+    """Get or create the global BrowserManager instance.
+
+    Args:
+        default_url: URL to navigate to on startup instead of about:blank.
+                     Only used when creating a new instance (first call).
+    """
     global _browser_manager
     if _browser_manager is None:
-        _browser_manager = BrowserManager()
+        _browser_manager = BrowserManager(default_url=default_url)
     return _browser_manager

--- a/libs/python/computer-server/computer_server/browser.py
+++ b/libs/python/computer-server/computer_server/browser.py
@@ -143,6 +143,14 @@ class BrowserManager:
                 else:
                     self.page = await self.context.new_page()
 
+                # Navigate to a default page so the browser isn't blank
+                default_url = os.environ.get("BROWSER_DEFAULT_URL", "https://www.google.com")
+                try:
+                    await self.page.goto(default_url, wait_until="domcontentloaded", timeout=15000)
+                    logger.info(f"Navigated to default page: {default_url}")
+                except Exception as e:
+                    logger.warning(f"Failed to load default page ({default_url}): {e}")
+
                 self._initialized = True
                 logger.info("Browser initialized successfully")
 

--- a/libs/python/cua-auto/cua_auto/terminal.py
+++ b/libs/python/cua-auto/cua_auto/terminal.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import os
 import sys
 import threading
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional
 
 

--- a/libs/python/cua-cli/cua_cli/commands/auth.py
+++ b/libs/python/cua-cli/cua_cli/commands/auth.py
@@ -3,7 +3,6 @@
 import argparse
 import os
 from pathlib import Path
-from typing import Any, Optional
 
 import aiohttp
 from core.http import cua_version_headers

--- a/libs/python/cua-cli/cua_cli/commands/sandbox.py
+++ b/libs/python/cua-cli/cua_cli/commands/sandbox.py
@@ -13,7 +13,7 @@ from urllib.parse import quote
 
 import aiohttp
 from core.http import cua_version_headers
-from cua_cli.auth.store import get_api_key, require_api_key
+from cua_cli.auth.store import require_api_key
 from cua_cli.utils.async_utils import run_async
 from cua_cli.utils.output import (
     print_error,

--- a/libs/python/cua-cli/tests/commands/test_sandbox.py
+++ b/libs/python/cua-cli/tests/commands/test_sandbox.py
@@ -476,7 +476,9 @@ class TestCmdShell:
         subparsers = parser.add_subparsers()
         sandbox.register_parser(subparsers)
 
-        args = parser.parse_args(["sb", "shell", "--cols", "120", "--rows", "40", "my-sandbox", "ls"])
+        args = parser.parse_args(
+            ["sb", "shell", "--cols", "120", "--rows", "40", "my-sandbox", "ls"]
+        )
         assert args.cols == 120
         assert args.rows == 40
         assert args.name == "my-sandbox"


### PR DESCRIPTION
## Problem

When the browser initializes via Playwright, it starts on `about:blank`. This produces a completely blank screenshot, which causes VLM/computer-use models to hallucinate — they often assume the page is "still loading" and either wait indefinitely or take incorrect actions. This is especially problematic for browser-only models (e.g. Yutori n1) that rely on visual context from the first screenshot.

## Solution

After initializing the browser page, navigate to a default URL (`https://www.google.com`) so the first screenshot shows a real page. The default URL is configurable via the `BROWSER_DEFAULT_URL` environment variable. If the navigation fails (no internet, timeout), it logs a warning and continues without blocking initialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Browser now automatically navigates to a default startup page on initialization (configurable via environment variable, defaults to Google).
  * Navigation includes a 15-second timeout with logging for success or failure status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->