### PR TITLE
ci: run model tests on weekly schedule instead of per-PR

### DIFF
--- a/.github/workflows/ci-test-models.yml
+++ b/.github/workflows/ci-test-models.yml
@@ -1,7 +1,7 @@
 name: "CI: Test Models"
 
 # This workflow tests all supported Cua models with API keys
-# Runs on changes to libs/python or manually via workflow_dispatch
+# Runs weekly on Monday or manually via workflow_dispatch
 
 on:
   workflow_dispatch:
@@ -11,10 +11,8 @@ on:
         required: false
         default: true
         type: boolean
-  pull_request:
-    paths:
-      - "libs/python/**"
-      - ".github/workflows/ci-test-models.yml"
+  schedule:
+    - cron: '0 9 * * 1'  # Every Monday at 9:00 UTC
 
 jobs:
   # Test all Cua models - runs on PRs, pushes to main, or when manually triggered


### PR DESCRIPTION
Change the CI model test workflow from running on every PR touching `libs/python/` to a weekly schedule (Mondays at 9:00 UTC). These tests hit external APIs, are expensive, slow, and flaky — not suitable as PR gates. Manual triggering via `workflow_dispatch` is still available for on-demand runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test workflow scheduling to run weekly on Mondays instead of on every pull request, while maintaining manual trigger capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->