### PR TITLE
feat(agent): add MiniMax as first-class LLM provider with M3 default

### DIFF
--- a/libs/python/agent/README.md
+++ b/libs/python/agent/README.md
@@ -3,3 +3,27 @@
 Computer-Use framework with liteLLM integration for running agentic workflows on macOS, Windows, and Linux sandboxes.
 
 **[Documentation](https://cua.ai/docs/cua/reference/agent-sdk)** - Installation, guides, and configuration.
+
+## Supported Models
+
+| Provider | Models | Prefix |
+|----------|--------|--------|
+| Anthropic | Claude 3.5+, Claude 4 | `anthropic/` |
+| OpenAI | GPT-4, computer-use-preview | `openai/` |
+| Google | Gemini 2.5+, Gemini 3 | `gemini-*` |
+| MiniMax | MiniMax-M2.5, MiniMax-M2.5-highspeed | `minimax/` |
+| Yutori | n1 | `yutori/` |
+| CUA | Any model via CUA inference | `cua/` |
+
+### MiniMax Setup
+
+Set the `MINIMAX_API_KEY` environment variable and use the `minimax/` prefix:
+
+```python
+agent = ComputerAgent(
+    model="minimax/MiniMax-M2.5",
+    tools=[computer],
+)
+```
+
+MiniMax M2.5 offers a 204K context window. The `MiniMax-M2.5-highspeed` variant provides faster inference.

--- a/libs/python/agent/README.md
+++ b/libs/python/agent/README.md
@@ -11,7 +11,7 @@ Computer-Use framework with liteLLM integration for running agentic workflows on
 | Anthropic | Claude 3.5+, Claude 4 | `anthropic/` |
 | OpenAI | GPT-4, computer-use-preview | `openai/` |
 | Google | Gemini 2.5+, Gemini 3 | `gemini-*` |
-| MiniMax | MiniMax-M2.5, MiniMax-M2.5-highspeed | `minimax/` |
+| MiniMax | MiniMax-M2.7 (default), MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed | `minimax/` |
 | Yutori | n1 | `yutori/` |
 | CUA | Any model via CUA inference | `cua/` |
 
@@ -21,9 +21,9 @@ Set the `MINIMAX_API_KEY` environment variable and use the `minimax/` prefix:
 
 ```python
 agent = ComputerAgent(
-    model="minimax/MiniMax-M2.5",
+    model="minimax/MiniMax-M2.7",
     tools=[computer],
 )
 ```
 
-MiniMax M2.5 offers a 204K context window. The `MiniMax-M2.5-highspeed` variant provides faster inference.
+MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities. The `MiniMax-M2.7-highspeed` variant provides faster inference. Previous models (M2.5, M2.5-highspeed) remain available.

--- a/libs/python/agent/README.md
+++ b/libs/python/agent/README.md
@@ -11,7 +11,7 @@ Computer-Use framework with liteLLM integration for running agentic workflows on
 | Anthropic | Claude 3.5+, Claude 4 | `anthropic/` |
 | OpenAI | GPT-4, computer-use-preview | `openai/` |
 | Google | Gemini 2.5+, Gemini 3 | `gemini-*` |
-| MiniMax | MiniMax-M2.7 (default), MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed | `minimax/` |
+| MiniMax | MiniMax-M3 (default), MiniMax-M2.7, MiniMax-M2.7-highspeed | `minimax/` |
 | Yutori | n1 | `yutori/` |
 | CUA | Any model via CUA inference | `cua/` |
 
@@ -21,9 +21,9 @@ Set the `MINIMAX_API_KEY` environment variable and use the `minimax/` prefix:
 
 ```python
 agent = ComputerAgent(
-    model="minimax/MiniMax-M2.7",
+    model="minimax/MiniMax-M3",
     tools=[computer],
 )
 ```
 
-MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities. The `MiniMax-M2.7-highspeed` variant provides faster inference. Previous models (M2.5, M2.5-highspeed) remain available.
+MiniMax-M3 is the latest flagship model with a 512K context window, up to 128K max output, and image input support. The `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` variants from the previous generation remain available.

--- a/libs/python/agent/agent/adapters/__init__.py
+++ b/libs/python/agent/agent/adapters/__init__.py
@@ -6,6 +6,7 @@ from .azure_ml_adapter import AzureMLAdapter
 from .cua_adapter import CUAAdapter
 from .huggingfacelocal_adapter import HuggingFaceLocalAdapter
 from .human_adapter import HumanAdapter
+from .minimax_adapter import MiniMaxAdapter
 from .mlxvlm_adapter import MLXVLMAdapter
 from .yutori_adapter import YutoriAdapter
 
@@ -13,6 +14,7 @@ __all__ = [
     "AzureMLAdapter",
     "HuggingFaceLocalAdapter",
     "HumanAdapter",
+    "MiniMaxAdapter",
     "MLXVLMAdapter",
     "CUAAdapter",
     "YutoriAdapter",

--- a/libs/python/agent/agent/adapters/minimax_adapter.py
+++ b/libs/python/agent/agent/adapters/minimax_adapter.py
@@ -1,0 +1,112 @@
+"""
+MiniMax adapter for litellm - routes minimax/ prefixed models to the MiniMax API.
+
+MiniMax provides OpenAI-compatible API endpoints at https://api.minimax.io/v1.
+Supported models: MiniMax-M2.5, MiniMax-M2.5-highspeed (204K context window).
+
+Environment variable: MINIMAX_API_KEY
+"""
+
+import os
+from typing import Any, AsyncIterator, Iterator
+
+from litellm import acompletion, completion
+from litellm.llms.custom_llm import CustomLLM
+from litellm.types.utils import GenericStreamingChunk, ModelResponse
+
+MINIMAX_API_BASE = "https://api.minimax.io/v1"
+
+
+class MiniMaxAdapter(CustomLLM):
+    def __init__(self, base_url: str | None = None, api_key: str | None = None, **_: Any):
+        super().__init__()
+        self.base_url = base_url or os.environ.get("MINIMAX_API_BASE") or MINIMAX_API_BASE
+        self.api_key = api_key or os.environ.get("MINIMAX_API_KEY")
+
+    def _normalize_model(self, model: str) -> str:
+        """Strip the minimax/ prefix to get the bare model name."""
+        if model.startswith("minimax/"):
+            return model[len("minimax/"):]
+        return model
+
+    def _resolve_api_key(self, kwargs: dict | None = None) -> str:
+        """Resolve the MiniMax API key, raising a clear error if missing."""
+        resolved = (kwargs.get("api_key") if kwargs else None) or self.api_key
+        if not resolved:
+            raise ValueError(
+                "No MiniMax API key provided. "
+                "Please either set the MINIMAX_API_KEY environment variable "
+                "or pass api_key to ComputerAgent()."
+            )
+        return resolved
+
+    def _clamp_temperature(self, kwargs: dict) -> None:
+        """Clamp temperature to MiniMax's accepted range [0, 1.0]."""
+        if "temperature" in kwargs:
+            temp = kwargs["temperature"]
+            if temp is not None:
+                kwargs["temperature"] = max(0.0, min(float(temp), 1.0))
+
+    def _build_params(self, kwargs: dict, stream: bool = False) -> dict:
+        """Build parameters for the inner litellm call."""
+        model = self._normalize_model(kwargs.get("model", ""))
+        api_key = self._resolve_api_key(kwargs)
+
+        self._clamp_temperature(kwargs)
+
+        extra_headers = {}
+        if "extra_headers" in kwargs:
+            extra_headers.update(kwargs.pop("extra_headers"))
+        extra_headers["Authorization"] = f"Bearer {api_key}"
+
+        params = {
+            "model": f"openai/{model}",
+            "messages": kwargs.get("messages", []),
+            "api_base": self.base_url,
+            "api_key": api_key,
+            "extra_headers": extra_headers,
+            "stream": stream,
+        }
+
+        # Forward tools if provided
+        if "tools" in kwargs:
+            params["tools"] = kwargs["tools"]
+        if "tool_choice" in kwargs:
+            params["tool_choice"] = kwargs["tool_choice"]
+
+        # Forward optional generation params
+        for key in ("temperature", "top_p", "max_completion_tokens", "max_tokens", "response_format"):
+            if key in kwargs:
+                params[key] = kwargs[key]
+
+        if "optional_params" in kwargs:
+            protected_keys = {"api_key", "extra_headers", "model", "api_base", "stream"}
+            filtered = {
+                k: v for k, v in kwargs["optional_params"].items() if k not in protected_keys
+            }
+            params.update(filtered)
+
+        if "headers" in kwargs:
+            params["headers"] = kwargs["headers"]
+
+        return params
+
+    def completion(self, *args, **kwargs) -> ModelResponse:
+        params = self._build_params(kwargs)
+        return completion(**params)  # type: ignore
+
+    async def acompletion(self, *args, **kwargs) -> ModelResponse:
+        params = self._build_params(kwargs)
+        response = await acompletion(**params)  # type: ignore
+        return response
+
+    def streaming(self, *args, **kwargs) -> Iterator[GenericStreamingChunk]:
+        params = self._build_params(kwargs, stream=True)
+        for chunk in completion(**params):  # type: ignore
+            yield chunk  # type: ignore
+
+    async def astreaming(self, *args, **kwargs) -> AsyncIterator[GenericStreamingChunk]:
+        params = self._build_params(kwargs, stream=True)
+        stream = await acompletion(**params)  # type: ignore
+        async for chunk in stream:  # type: ignore
+            yield chunk  # type: ignore

--- a/libs/python/agent/agent/adapters/minimax_adapter.py
+++ b/libs/python/agent/agent/adapters/minimax_adapter.py
@@ -2,7 +2,8 @@
 MiniMax adapter for litellm - routes minimax/ prefixed models to the MiniMax API.
 
 MiniMax provides OpenAI-compatible API endpoints at https://api.minimax.io/v1.
-Supported models: MiniMax-M2.5, MiniMax-M2.5-highspeed (204K context window).
+Supported models: MiniMax-M2.7 (default), MiniMax-M2.7-highspeed,
+MiniMax-M2.5, MiniMax-M2.5-highspeed (204K context window).
 
 Environment variable: MINIMAX_API_KEY
 """

--- a/libs/python/agent/agent/adapters/minimax_adapter.py
+++ b/libs/python/agent/agent/adapters/minimax_adapter.py
@@ -2,8 +2,8 @@
 MiniMax adapter for litellm - routes minimax/ prefixed models to the MiniMax API.
 
 MiniMax provides OpenAI-compatible API endpoints at https://api.minimax.io/v1.
-Supported models: MiniMax-M2.7 (default), MiniMax-M2.7-highspeed,
-MiniMax-M2.5, MiniMax-M2.5-highspeed (204K context window).
+Supported models: MiniMax-M3 (default, 512K context, 128K max output, image input),
+MiniMax-M2.7, MiniMax-M2.7-highspeed.
 
 Environment variable: MINIMAX_API_KEY
 """

--- a/libs/python/agent/agent/agent.py
+++ b/libs/python/agent/agent/agent.py
@@ -30,6 +30,7 @@ from .adapters import (
     CUAAdapter,
     HuggingFaceLocalAdapter,
     HumanAdapter,
+    MiniMaxAdapter,
     MLXVLMAdapter,
     YutoriAdapter,
 )
@@ -299,6 +300,7 @@ class ComputerAgent:
         cua_adapter = CUAAdapter()
         azure_ml_adapter = AzureMLAdapter()
         yutori_adapter = YutoriAdapter()
+        minimax_adapter = MiniMaxAdapter()
         litellm.custom_provider_map = [
             {"provider": "huggingface-local", "custom_handler": hf_adapter},
             {"provider": "human", "custom_handler": human_adapter},
@@ -306,6 +308,7 @@ class ComputerAgent:
             {"provider": "cua", "custom_handler": cua_adapter},
             {"provider": "azure_ml", "custom_handler": azure_ml_adapter},
             {"provider": "yutori", "custom_handler": yutori_adapter},
+            {"provider": "minimax", "custom_handler": minimax_adapter},
         ]
         litellm.suppress_debug_info = True
 

--- a/libs/python/agent/example.py
+++ b/libs/python/agent/example.py
@@ -108,7 +108,9 @@ async def main():
             # TODO: add local mlx provider
             # model="mlx-community/UI-TARS-1.5-7B-6bit",
             # model="ollama_chat/0000/ui-tars-1.5-7b",
-            # == MiniMax (M2.5 with 204K context) ==
+            # == MiniMax (M2.7 flagship, M2.5 also available) ==
+            # model="minimax/MiniMax-M2.7",
+            # model="minimax/MiniMax-M2.7-highspeed",
             # model="minimax/MiniMax-M2.5",
             # model="minimax/MiniMax-M2.5-highspeed",
             # == Omniparser + Any LLM ==

--- a/libs/python/agent/example.py
+++ b/libs/python/agent/example.py
@@ -108,6 +108,9 @@ async def main():
             # TODO: add local mlx provider
             # model="mlx-community/UI-TARS-1.5-7B-6bit",
             # model="ollama_chat/0000/ui-tars-1.5-7b",
+            # == MiniMax (M2.5 with 204K context) ==
+            # model="minimax/MiniMax-M2.5",
+            # model="minimax/MiniMax-M2.5-highspeed",
             # == Omniparser + Any LLM ==
             # model="omniparser+..."
             # model="omniparser+anthropic/claude-opus-4-20250514",

--- a/libs/python/agent/example.py
+++ b/libs/python/agent/example.py
@@ -108,11 +108,10 @@ async def main():
             # TODO: add local mlx provider
             # model="mlx-community/UI-TARS-1.5-7B-6bit",
             # model="ollama_chat/0000/ui-tars-1.5-7b",
-            # == MiniMax (M2.7 flagship, M2.5 also available) ==
+            # == MiniMax (M3 flagship, M2.7 also available) ==
+            # model="minimax/MiniMax-M3",
             # model="minimax/MiniMax-M2.7",
             # model="minimax/MiniMax-M2.7-highspeed",
-            # model="minimax/MiniMax-M2.5",
-            # model="minimax/MiniMax-M2.5-highspeed",
             # == Omniparser + Any LLM ==
             # model="omniparser+..."
             # model="omniparser+anthropic/claude-opus-4-20250514",

--- a/libs/python/agent/pyproject.toml
+++ b/libs/python/agent/pyproject.toml
@@ -29,6 +29,7 @@ requires-python = ">=3.12,<3.14"
 [project.optional-dependencies]
 openai = []
 anthropic = []
+minimax = []
 qwen = [
     "qwen-vl-utils",
     "qwen-agent",

--- a/libs/python/agent/tests/test_minimax_adapter.py
+++ b/libs/python/agent/tests/test_minimax_adapter.py
@@ -58,6 +58,14 @@ class TestModelNormalization:
         adapter = MiniMaxAdapter()
         assert adapter._normalize_model("minimax/MiniMax-M2.5-highspeed") == "MiniMax-M2.5-highspeed"
 
+    def test_strip_m27_prefix(self):
+        adapter = MiniMaxAdapter()
+        assert adapter._normalize_model("minimax/MiniMax-M2.7") == "MiniMax-M2.7"
+
+    def test_m27_highspeed_model(self):
+        adapter = MiniMaxAdapter()
+        assert adapter._normalize_model("minimax/MiniMax-M2.7-highspeed") == "MiniMax-M2.7-highspeed"
+
 
 class TestAPIKeyResolution:
     """Tests for API key resolution logic."""
@@ -227,6 +235,18 @@ class TestBuildParams:
         params = adapter._build_params(kwargs)
         assert params["model"] == "openai/MiniMax-M2.5-highspeed"
 
+    def test_m27_model_routing(self):
+        adapter = MiniMaxAdapter(api_key="test-key")
+        kwargs = {"model": "minimax/MiniMax-M2.7", "messages": []}
+        params = adapter._build_params(kwargs)
+        assert params["model"] == "openai/MiniMax-M2.7"
+
+    def test_m27_highspeed_model_routing(self):
+        adapter = MiniMaxAdapter(api_key="test-key")
+        kwargs = {"model": "minimax/MiniMax-M2.7-highspeed", "messages": []}
+        params = adapter._build_params(kwargs)
+        assert params["model"] == "openai/MiniMax-M2.7-highspeed"
+
 
 class TestCompletion:
     """Tests for completion and acompletion methods."""
@@ -311,6 +331,22 @@ class TestComputerAgentMiniMaxIntegration:
 
         agent = ComputerAgent(model="minimax/MiniMax-M2.5-highspeed")
         assert agent.model == "minimax/MiniMax-M2.5-highspeed"
+
+    @patch("agent.agent.litellm")
+    def test_agent_initialization_with_minimax_m27(self, mock_litellm, disable_telemetry):
+        """Test that ComputerAgent can be initialized with MiniMax M2.7 model."""
+        from agent import ComputerAgent
+
+        agent = ComputerAgent(model="minimax/MiniMax-M2.7")
+        assert agent.model == "minimax/MiniMax-M2.7"
+
+    @patch("agent.agent.litellm")
+    def test_agent_initialization_with_minimax_m27_highspeed(self, mock_litellm, disable_telemetry):
+        """Test that ComputerAgent can be initialized with MiniMax M2.7 highspeed model."""
+        from agent import ComputerAgent
+
+        agent = ComputerAgent(model="minimax/MiniMax-M2.7-highspeed")
+        assert agent.model == "minimax/MiniMax-M2.7-highspeed"
 
     @patch("agent.agent.litellm")
     def test_minimax_registered_in_provider_map(self, mock_litellm, disable_telemetry):

--- a/libs/python/agent/tests/test_minimax_adapter.py
+++ b/libs/python/agent/tests/test_minimax_adapter.py
@@ -1,0 +1,370 @@
+"""Unit tests for MiniMaxAdapter.
+
+Tests the MiniMax litellm adapter: model normalization, API key resolution,
+temperature clamping, parameter building, and completion routing.
+"""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.adapters.minimax_adapter import MINIMAX_API_BASE, MiniMaxAdapter
+
+
+class TestMiniMaxAdapterInit:
+    """Tests for MiniMaxAdapter initialization."""
+
+    def test_default_base_url(self):
+        adapter = MiniMaxAdapter()
+        assert adapter.base_url == MINIMAX_API_BASE
+
+    def test_custom_base_url(self):
+        adapter = MiniMaxAdapter(base_url="https://custom.minimax.io/v1")
+        assert adapter.base_url == "https://custom.minimax.io/v1"
+
+    def test_api_key_from_constructor(self):
+        adapter = MiniMaxAdapter(api_key="test-key-123")
+        assert adapter.api_key == "test-key-123"
+
+    def test_api_key_from_env(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "env-key-456")
+        adapter = MiniMaxAdapter()
+        assert adapter.api_key == "env-key-456"
+
+    def test_base_url_from_env(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_BASE", "https://env.minimax.io/v1")
+        adapter = MiniMaxAdapter()
+        assert adapter.base_url == "https://env.minimax.io/v1"
+
+    def test_constructor_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "env-key")
+        adapter = MiniMaxAdapter(api_key="constructor-key")
+        assert adapter.api_key == "constructor-key"
+
+
+class TestModelNormalization:
+    """Tests for model name normalization."""
+
+    def test_strip_minimax_prefix(self):
+        adapter = MiniMaxAdapter()
+        assert adapter._normalize_model("minimax/MiniMax-M2.5") == "MiniMax-M2.5"
+
+    def test_no_prefix(self):
+        adapter = MiniMaxAdapter()
+        assert adapter._normalize_model("MiniMax-M2.5") == "MiniMax-M2.5"
+
+    def test_highspeed_model(self):
+        adapter = MiniMaxAdapter()
+        assert adapter._normalize_model("minimax/MiniMax-M2.5-highspeed") == "MiniMax-M2.5-highspeed"
+
+
+class TestAPIKeyResolution:
+    """Tests for API key resolution logic."""
+
+    def test_key_from_kwargs(self):
+        adapter = MiniMaxAdapter(api_key="default-key")
+        resolved = adapter._resolve_api_key({"api_key": "override-key"})
+        assert resolved == "override-key"
+
+    def test_key_from_adapter(self):
+        adapter = MiniMaxAdapter(api_key="adapter-key")
+        resolved = adapter._resolve_api_key({})
+        assert resolved == "adapter-key"
+
+    def test_missing_key_raises(self):
+        adapter = MiniMaxAdapter()
+        adapter.api_key = None
+        with pytest.raises(ValueError, match="No MiniMax API key provided"):
+            adapter._resolve_api_key({})
+
+    def test_none_kwargs(self):
+        adapter = MiniMaxAdapter(api_key="adapter-key")
+        resolved = adapter._resolve_api_key(None)
+        assert resolved == "adapter-key"
+
+
+class TestTemperatureClamping:
+    """Tests for temperature clamping to MiniMax range [0, 1.0]."""
+
+    def test_clamp_high_temperature(self):
+        adapter = MiniMaxAdapter()
+        kwargs = {"temperature": 2.0}
+        adapter._clamp_temperature(kwargs)
+        assert kwargs["temperature"] == 1.0
+
+    def test_clamp_negative_temperature(self):
+        adapter = MiniMaxAdapter()
+        kwargs = {"temperature": -0.5}
+        adapter._clamp_temperature(kwargs)
+        assert kwargs["temperature"] == 0.0
+
+    def test_valid_temperature_unchanged(self):
+        adapter = MiniMaxAdapter()
+        kwargs = {"temperature": 0.7}
+        adapter._clamp_temperature(kwargs)
+        assert kwargs["temperature"] == 0.7
+
+    def test_zero_temperature(self):
+        adapter = MiniMaxAdapter()
+        kwargs = {"temperature": 0}
+        adapter._clamp_temperature(kwargs)
+        assert kwargs["temperature"] == 0.0
+
+    def test_max_temperature(self):
+        adapter = MiniMaxAdapter()
+        kwargs = {"temperature": 1.0}
+        adapter._clamp_temperature(kwargs)
+        assert kwargs["temperature"] == 1.0
+
+    def test_no_temperature_key(self):
+        adapter = MiniMaxAdapter()
+        kwargs = {"model": "test"}
+        adapter._clamp_temperature(kwargs)
+        assert "temperature" not in kwargs
+
+    def test_none_temperature(self):
+        adapter = MiniMaxAdapter()
+        kwargs = {"temperature": None}
+        adapter._clamp_temperature(kwargs)
+        assert kwargs["temperature"] is None
+
+
+class TestBuildParams:
+    """Tests for _build_params parameter construction."""
+
+    def test_basic_params(self):
+        adapter = MiniMaxAdapter(api_key="test-key")
+        kwargs = {
+            "model": "minimax/MiniMax-M2.5",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        params = adapter._build_params(kwargs)
+
+        assert params["model"] == "openai/MiniMax-M2.5"
+        assert params["api_base"] == MINIMAX_API_BASE
+        assert params["api_key"] == "test-key"
+        assert params["messages"] == [{"role": "user", "content": "Hello"}]
+        assert params["stream"] is False
+
+    def test_stream_param(self):
+        adapter = MiniMaxAdapter(api_key="test-key")
+        kwargs = {"model": "minimax/MiniMax-M2.5", "messages": []}
+        params = adapter._build_params(kwargs, stream=True)
+        assert params["stream"] is True
+
+    def test_forwards_tools(self):
+        adapter = MiniMaxAdapter(api_key="test-key")
+        tools = [{"type": "function", "function": {"name": "test"}}]
+        kwargs = {"model": "minimax/MiniMax-M2.5", "messages": [], "tools": tools}
+        params = adapter._build_params(kwargs)
+        assert params["tools"] == tools
+
+    def test_forwards_tool_choice(self):
+        adapter = MiniMaxAdapter(api_key="test-key")
+        kwargs = {
+            "model": "minimax/MiniMax-M2.5",
+            "messages": [],
+            "tool_choice": "auto",
+        }
+        params = adapter._build_params(kwargs)
+        assert params["tool_choice"] == "auto"
+
+    def test_forwards_generation_params(self):
+        adapter = MiniMaxAdapter(api_key="test-key")
+        kwargs = {
+            "model": "minimax/MiniMax-M2.5",
+            "messages": [],
+            "temperature": 0.5,
+            "top_p": 0.9,
+            "max_tokens": 1024,
+        }
+        params = adapter._build_params(kwargs)
+        assert params["temperature"] == 0.5
+        assert params["top_p"] == 0.9
+        assert params["max_tokens"] == 1024
+
+    def test_temperature_clamped_in_params(self):
+        adapter = MiniMaxAdapter(api_key="test-key")
+        kwargs = {
+            "model": "minimax/MiniMax-M2.5",
+            "messages": [],
+            "temperature": 2.0,
+        }
+        params = adapter._build_params(kwargs)
+        assert params["temperature"] == 1.0
+
+    def test_optional_params_forwarded(self):
+        adapter = MiniMaxAdapter(api_key="test-key")
+        kwargs = {
+            "model": "minimax/MiniMax-M2.5",
+            "messages": [],
+            "optional_params": {"presence_penalty": 0.5},
+        }
+        params = adapter._build_params(kwargs)
+        assert params["presence_penalty"] == 0.5
+
+    def test_optional_params_protected_keys_excluded(self):
+        adapter = MiniMaxAdapter(api_key="test-key")
+        kwargs = {
+            "model": "minimax/MiniMax-M2.5",
+            "messages": [],
+            "optional_params": {"api_key": "bad-key", "model": "bad-model"},
+        }
+        params = adapter._build_params(kwargs)
+        assert params["api_key"] == "test-key"
+        assert params["model"] == "openai/MiniMax-M2.5"
+
+    def test_auth_header_set(self):
+        adapter = MiniMaxAdapter(api_key="test-key")
+        kwargs = {"model": "minimax/MiniMax-M2.5", "messages": []}
+        params = adapter._build_params(kwargs)
+        assert params["extra_headers"]["Authorization"] == "Bearer test-key"
+
+    def test_highspeed_model_routing(self):
+        adapter = MiniMaxAdapter(api_key="test-key")
+        kwargs = {"model": "minimax/MiniMax-M2.5-highspeed", "messages": []}
+        params = adapter._build_params(kwargs)
+        assert params["model"] == "openai/MiniMax-M2.5-highspeed"
+
+
+class TestCompletion:
+    """Tests for completion and acompletion methods."""
+
+    @patch("agent.adapters.minimax_adapter.completion")
+    def test_completion_calls_litellm(self, mock_completion):
+        mock_completion.return_value = MagicMock()
+        adapter = MiniMaxAdapter(api_key="test-key")
+        adapter.completion(
+            model="minimax/MiniMax-M2.5",
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+        mock_completion.assert_called_once()
+        call_kwargs = mock_completion.call_args
+        assert call_kwargs[1]["model"] == "openai/MiniMax-M2.5" or call_kwargs[0][0] if call_kwargs[0] else True
+
+    @pytest.mark.asyncio
+    @patch("agent.adapters.minimax_adapter.acompletion")
+    async def test_acompletion_calls_litellm(self, mock_acompletion):
+        mock_acompletion.return_value = MagicMock()
+        adapter = MiniMaxAdapter(api_key="test-key")
+        await adapter.acompletion(
+            model="minimax/MiniMax-M2.5",
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+        mock_acompletion.assert_called_once()
+
+
+class TestStreaming:
+    """Tests for streaming methods."""
+
+    @patch("agent.adapters.minimax_adapter.completion")
+    def test_streaming_yields_chunks(self, mock_completion):
+        mock_chunks = [MagicMock(), MagicMock()]
+        mock_completion.return_value = iter(mock_chunks)
+        adapter = MiniMaxAdapter(api_key="test-key")
+
+        chunks = list(adapter.streaming(
+            model="minimax/MiniMax-M2.5",
+            messages=[{"role": "user", "content": "Hi"}],
+        ))
+        assert len(chunks) == 2
+        call_kwargs = mock_completion.call_args[1]
+        assert call_kwargs["stream"] is True
+
+    @pytest.mark.asyncio
+    @patch("agent.adapters.minimax_adapter.acompletion")
+    async def test_astreaming_yields_chunks(self, mock_acompletion):
+        mock_chunks = [MagicMock(), MagicMock()]
+
+        async def async_gen():
+            for chunk in mock_chunks:
+                yield chunk
+
+        mock_acompletion.return_value = async_gen()
+        adapter = MiniMaxAdapter(api_key="test-key")
+
+        chunks = []
+        async for chunk in adapter.astreaming(
+            model="minimax/MiniMax-M2.5",
+            messages=[{"role": "user", "content": "Hi"}],
+        ):
+            chunks.append(chunk)
+        assert len(chunks) == 2
+
+
+class TestComputerAgentMiniMaxIntegration:
+    """Tests for MiniMax integration with ComputerAgent."""
+
+    @patch("agent.agent.litellm")
+    def test_agent_initialization_with_minimax(self, mock_litellm, disable_telemetry):
+        """Test that ComputerAgent can be initialized with a minimax model."""
+        from agent import ComputerAgent
+
+        agent = ComputerAgent(model="minimax/MiniMax-M2.5")
+        assert agent.model == "minimax/MiniMax-M2.5"
+
+    @patch("agent.agent.litellm")
+    def test_agent_initialization_with_minimax_highspeed(self, mock_litellm, disable_telemetry):
+        """Test that ComputerAgent can be initialized with minimax highspeed model."""
+        from agent import ComputerAgent
+
+        agent = ComputerAgent(model="minimax/MiniMax-M2.5-highspeed")
+        assert agent.model == "minimax/MiniMax-M2.5-highspeed"
+
+    @patch("agent.agent.litellm")
+    def test_minimax_registered_in_provider_map(self, mock_litellm, disable_telemetry):
+        """Test that minimax is registered in litellm custom_provider_map."""
+        from agent import ComputerAgent
+
+        ComputerAgent(model="minimax/MiniMax-M2.5")
+
+        provider_map = mock_litellm.custom_provider_map
+        providers = [p["provider"] for p in provider_map]
+        assert "minimax" in providers
+
+    @patch("agent.agent.litellm")
+    def test_minimax_handler_is_adapter_instance(self, mock_litellm, disable_telemetry):
+        """Test that the minimax handler is a MiniMaxAdapter instance."""
+        from agent import ComputerAgent
+
+        ComputerAgent(model="minimax/MiniMax-M2.5")
+
+        provider_map = mock_litellm.custom_provider_map
+        minimax_entry = next(p for p in provider_map if p["provider"] == "minimax")
+        assert isinstance(minimax_entry["custom_handler"], MiniMaxAdapter)
+
+    @patch("agent.agent.litellm")
+    def test_minimax_uses_generic_vlm_loop(self, mock_litellm, disable_telemetry):
+        """Test that minimax models fall through to the generic VLM agent loop."""
+        from agent import ComputerAgent
+        from agent.loops.generic_vlm import GenericVlmConfig
+
+        agent = ComputerAgent(model="minimax/MiniMax-M2.5")
+        assert isinstance(agent.agent_loop, GenericVlmConfig)
+
+    @patch("agent.agent.litellm")
+    def test_agent_with_minimax_has_run_method(self, mock_litellm, disable_telemetry):
+        """Test that a MiniMax-initialized agent has a callable run method."""
+        from agent import ComputerAgent
+
+        agent = ComputerAgent(model="minimax/MiniMax-M2.5")
+        assert hasattr(agent, "run")
+        assert callable(agent.run)
+
+    @patch("agent.agent.litellm")
+    def test_agent_with_minimax_api_key(self, mock_litellm, disable_telemetry):
+        """Test that api_key is forwarded when using minimax model."""
+        from agent import ComputerAgent
+
+        agent = ComputerAgent(model="minimax/MiniMax-M2.5", api_key="my-minimax-key")
+        assert agent.api_key == "my-minimax-key"
+
+    @patch("agent.agent.litellm")
+    def test_agent_with_minimax_and_computer(self, mock_litellm, disable_telemetry, mock_computer):
+        """Test that ComputerAgent accepts tools with minimax model."""
+        from agent import ComputerAgent
+
+        agent = ComputerAgent(model="minimax/MiniMax-M2.5", tools=[mock_computer])
+        assert agent is not None
+        assert hasattr(agent, "tools")

--- a/libs/python/agent/tests/test_minimax_adapter.py
+++ b/libs/python/agent/tests/test_minimax_adapter.py
@@ -48,15 +48,11 @@ class TestModelNormalization:
 
     def test_strip_minimax_prefix(self):
         adapter = MiniMaxAdapter()
-        assert adapter._normalize_model("minimax/MiniMax-M2.5") == "MiniMax-M2.5"
+        assert adapter._normalize_model("minimax/MiniMax-M3") == "MiniMax-M3"
 
     def test_no_prefix(self):
         adapter = MiniMaxAdapter()
-        assert adapter._normalize_model("MiniMax-M2.5") == "MiniMax-M2.5"
-
-    def test_highspeed_model(self):
-        adapter = MiniMaxAdapter()
-        assert adapter._normalize_model("minimax/MiniMax-M2.5-highspeed") == "MiniMax-M2.5-highspeed"
+        assert adapter._normalize_model("MiniMax-M3") == "MiniMax-M3"
 
     def test_strip_m27_prefix(self):
         adapter = MiniMaxAdapter()
@@ -144,12 +140,12 @@ class TestBuildParams:
     def test_basic_params(self):
         adapter = MiniMaxAdapter(api_key="test-key")
         kwargs = {
-            "model": "minimax/MiniMax-M2.5",
+            "model": "minimax/MiniMax-M3",
             "messages": [{"role": "user", "content": "Hello"}],
         }
         params = adapter._build_params(kwargs)
 
-        assert params["model"] == "openai/MiniMax-M2.5"
+        assert params["model"] == "openai/MiniMax-M3"
         assert params["api_base"] == MINIMAX_API_BASE
         assert params["api_key"] == "test-key"
         assert params["messages"] == [{"role": "user", "content": "Hello"}]
@@ -157,21 +153,21 @@ class TestBuildParams:
 
     def test_stream_param(self):
         adapter = MiniMaxAdapter(api_key="test-key")
-        kwargs = {"model": "minimax/MiniMax-M2.5", "messages": []}
+        kwargs = {"model": "minimax/MiniMax-M3", "messages": []}
         params = adapter._build_params(kwargs, stream=True)
         assert params["stream"] is True
 
     def test_forwards_tools(self):
         adapter = MiniMaxAdapter(api_key="test-key")
         tools = [{"type": "function", "function": {"name": "test"}}]
-        kwargs = {"model": "minimax/MiniMax-M2.5", "messages": [], "tools": tools}
+        kwargs = {"model": "minimax/MiniMax-M3", "messages": [], "tools": tools}
         params = adapter._build_params(kwargs)
         assert params["tools"] == tools
 
     def test_forwards_tool_choice(self):
         adapter = MiniMaxAdapter(api_key="test-key")
         kwargs = {
-            "model": "minimax/MiniMax-M2.5",
+            "model": "minimax/MiniMax-M3",
             "messages": [],
             "tool_choice": "auto",
         }
@@ -181,7 +177,7 @@ class TestBuildParams:
     def test_forwards_generation_params(self):
         adapter = MiniMaxAdapter(api_key="test-key")
         kwargs = {
-            "model": "minimax/MiniMax-M2.5",
+            "model": "minimax/MiniMax-M3",
             "messages": [],
             "temperature": 0.5,
             "top_p": 0.9,
@@ -195,7 +191,7 @@ class TestBuildParams:
     def test_temperature_clamped_in_params(self):
         adapter = MiniMaxAdapter(api_key="test-key")
         kwargs = {
-            "model": "minimax/MiniMax-M2.5",
+            "model": "minimax/MiniMax-M3",
             "messages": [],
             "temperature": 2.0,
         }
@@ -205,7 +201,7 @@ class TestBuildParams:
     def test_optional_params_forwarded(self):
         adapter = MiniMaxAdapter(api_key="test-key")
         kwargs = {
-            "model": "minimax/MiniMax-M2.5",
+            "model": "minimax/MiniMax-M3",
             "messages": [],
             "optional_params": {"presence_penalty": 0.5},
         }
@@ -215,25 +211,25 @@ class TestBuildParams:
     def test_optional_params_protected_keys_excluded(self):
         adapter = MiniMaxAdapter(api_key="test-key")
         kwargs = {
-            "model": "minimax/MiniMax-M2.5",
+            "model": "minimax/MiniMax-M3",
             "messages": [],
             "optional_params": {"api_key": "bad-key", "model": "bad-model"},
         }
         params = adapter._build_params(kwargs)
         assert params["api_key"] == "test-key"
-        assert params["model"] == "openai/MiniMax-M2.5"
+        assert params["model"] == "openai/MiniMax-M3"
 
     def test_auth_header_set(self):
         adapter = MiniMaxAdapter(api_key="test-key")
-        kwargs = {"model": "minimax/MiniMax-M2.5", "messages": []}
+        kwargs = {"model": "minimax/MiniMax-M3", "messages": []}
         params = adapter._build_params(kwargs)
         assert params["extra_headers"]["Authorization"] == "Bearer test-key"
 
-    def test_highspeed_model_routing(self):
+    def test_m3_model_routing(self):
         adapter = MiniMaxAdapter(api_key="test-key")
-        kwargs = {"model": "minimax/MiniMax-M2.5-highspeed", "messages": []}
+        kwargs = {"model": "minimax/MiniMax-M3", "messages": []}
         params = adapter._build_params(kwargs)
-        assert params["model"] == "openai/MiniMax-M2.5-highspeed"
+        assert params["model"] == "openai/MiniMax-M3"
 
     def test_m27_model_routing(self):
         adapter = MiniMaxAdapter(api_key="test-key")
@@ -256,12 +252,12 @@ class TestCompletion:
         mock_completion.return_value = MagicMock()
         adapter = MiniMaxAdapter(api_key="test-key")
         adapter.completion(
-            model="minimax/MiniMax-M2.5",
+            model="minimax/MiniMax-M3",
             messages=[{"role": "user", "content": "Hi"}],
         )
         mock_completion.assert_called_once()
         call_kwargs = mock_completion.call_args
-        assert call_kwargs[1]["model"] == "openai/MiniMax-M2.5" or call_kwargs[0][0] if call_kwargs[0] else True
+        assert call_kwargs[1]["model"] == "openai/MiniMax-M3" or call_kwargs[0][0] if call_kwargs[0] else True
 
     @pytest.mark.asyncio
     @patch("agent.adapters.minimax_adapter.acompletion")
@@ -269,7 +265,7 @@ class TestCompletion:
         mock_acompletion.return_value = MagicMock()
         adapter = MiniMaxAdapter(api_key="test-key")
         await adapter.acompletion(
-            model="minimax/MiniMax-M2.5",
+            model="minimax/MiniMax-M3",
             messages=[{"role": "user", "content": "Hi"}],
         )
         mock_acompletion.assert_called_once()
@@ -285,7 +281,7 @@ class TestStreaming:
         adapter = MiniMaxAdapter(api_key="test-key")
 
         chunks = list(adapter.streaming(
-            model="minimax/MiniMax-M2.5",
+            model="minimax/MiniMax-M3",
             messages=[{"role": "user", "content": "Hi"}],
         ))
         assert len(chunks) == 2
@@ -306,7 +302,7 @@ class TestStreaming:
 
         chunks = []
         async for chunk in adapter.astreaming(
-            model="minimax/MiniMax-M2.5",
+            model="minimax/MiniMax-M3",
             messages=[{"role": "user", "content": "Hi"}],
         ):
             chunks.append(chunk)
@@ -317,20 +313,12 @@ class TestComputerAgentMiniMaxIntegration:
     """Tests for MiniMax integration with ComputerAgent."""
 
     @patch("agent.agent.litellm")
-    def test_agent_initialization_with_minimax(self, mock_litellm, disable_telemetry):
-        """Test that ComputerAgent can be initialized with a minimax model."""
+    def test_agent_initialization_with_minimax_m3(self, mock_litellm, disable_telemetry):
+        """Test that ComputerAgent can be initialized with the default M3 model."""
         from agent import ComputerAgent
 
-        agent = ComputerAgent(model="minimax/MiniMax-M2.5")
-        assert agent.model == "minimax/MiniMax-M2.5"
-
-    @patch("agent.agent.litellm")
-    def test_agent_initialization_with_minimax_highspeed(self, mock_litellm, disable_telemetry):
-        """Test that ComputerAgent can be initialized with minimax highspeed model."""
-        from agent import ComputerAgent
-
-        agent = ComputerAgent(model="minimax/MiniMax-M2.5-highspeed")
-        assert agent.model == "minimax/MiniMax-M2.5-highspeed"
+        agent = ComputerAgent(model="minimax/MiniMax-M3")
+        assert agent.model == "minimax/MiniMax-M3"
 
     @patch("agent.agent.litellm")
     def test_agent_initialization_with_minimax_m27(self, mock_litellm, disable_telemetry):
@@ -353,7 +341,7 @@ class TestComputerAgentMiniMaxIntegration:
         """Test that minimax is registered in litellm custom_provider_map."""
         from agent import ComputerAgent
 
-        ComputerAgent(model="minimax/MiniMax-M2.5")
+        ComputerAgent(model="minimax/MiniMax-M3")
 
         provider_map = mock_litellm.custom_provider_map
         providers = [p["provider"] for p in provider_map]
@@ -364,7 +352,7 @@ class TestComputerAgentMiniMaxIntegration:
         """Test that the minimax handler is a MiniMaxAdapter instance."""
         from agent import ComputerAgent
 
-        ComputerAgent(model="minimax/MiniMax-M2.5")
+        ComputerAgent(model="minimax/MiniMax-M3")
 
         provider_map = mock_litellm.custom_provider_map
         minimax_entry = next(p for p in provider_map if p["provider"] == "minimax")
@@ -376,7 +364,7 @@ class TestComputerAgentMiniMaxIntegration:
         from agent import ComputerAgent
         from agent.loops.generic_vlm import GenericVlmConfig
 
-        agent = ComputerAgent(model="minimax/MiniMax-M2.5")
+        agent = ComputerAgent(model="minimax/MiniMax-M3")
         assert isinstance(agent.agent_loop, GenericVlmConfig)
 
     @patch("agent.agent.litellm")
@@ -384,7 +372,7 @@ class TestComputerAgentMiniMaxIntegration:
         """Test that a MiniMax-initialized agent has a callable run method."""
         from agent import ComputerAgent
 
-        agent = ComputerAgent(model="minimax/MiniMax-M2.5")
+        agent = ComputerAgent(model="minimax/MiniMax-M3")
         assert hasattr(agent, "run")
         assert callable(agent.run)
 
@@ -393,7 +381,7 @@ class TestComputerAgentMiniMaxIntegration:
         """Test that api_key is forwarded when using minimax model."""
         from agent import ComputerAgent
 
-        agent = ComputerAgent(model="minimax/MiniMax-M2.5", api_key="my-minimax-key")
+        agent = ComputerAgent(model="minimax/MiniMax-M3", api_key="my-minimax-key")
         assert agent.api_key == "my-minimax-key"
 
     @patch("agent.agent.litellm")
@@ -401,6 +389,6 @@ class TestComputerAgentMiniMaxIntegration:
         """Test that ComputerAgent accepts tools with minimax model."""
         from agent import ComputerAgent
 
-        agent = ComputerAgent(model="minimax/MiniMax-M2.5", tools=[mock_computer])
+        agent = ComputerAgent(model="minimax/MiniMax-M3", tools=[mock_computer])
         assert agent is not None
         assert hasattr(agent, "tools")

--- a/libs/python/agent/tests/test_minimax_integration.py
+++ b/libs/python/agent/tests/test_minimax_integration.py
@@ -54,3 +54,25 @@ class TestMiniMaxLiveCompletion:
             max_tokens=10,
         )
         assert response is not None
+
+    def test_m27_sync_completion(self):
+        """Test synchronous completion with MiniMax M2.7."""
+        adapter = MiniMaxAdapter()
+        response = adapter.completion(
+            model="minimax/MiniMax-M2.7",
+            messages=[{"role": "user", "content": "Say hello in one word."}],
+            temperature=0.7,
+            max_tokens=10,
+        )
+        assert response is not None
+        assert hasattr(response, "choices") or isinstance(response, dict)
+
+    def test_m27_highspeed_model(self):
+        """Test completion with MiniMax M2.7 highspeed variant."""
+        adapter = MiniMaxAdapter()
+        response = adapter.completion(
+            model="minimax/MiniMax-M2.7-highspeed",
+            messages=[{"role": "user", "content": "Say hi."}],
+            max_tokens=10,
+        )
+        assert response is not None

--- a/libs/python/agent/tests/test_minimax_integration.py
+++ b/libs/python/agent/tests/test_minimax_integration.py
@@ -1,0 +1,56 @@
+"""Integration tests for MiniMax adapter with real API calls.
+
+These tests require MINIMAX_API_KEY to be set.
+Run with: pytest tests/test_minimax_integration.py -v
+
+Skipped automatically if MINIMAX_API_KEY is not available.
+"""
+
+import os
+
+import pytest
+
+from agent.adapters.minimax_adapter import MiniMaxAdapter
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("MINIMAX_API_KEY"),
+    reason="MINIMAX_API_KEY not set",
+)
+
+
+class TestMiniMaxLiveCompletion:
+    """Integration tests with the MiniMax API."""
+
+    def test_sync_completion(self):
+        """Test synchronous completion with MiniMax M2.5."""
+        adapter = MiniMaxAdapter()
+        response = adapter.completion(
+            model="minimax/MiniMax-M2.5",
+            messages=[{"role": "user", "content": "Say hello in one word."}],
+            temperature=0.7,
+            max_tokens=10,
+        )
+        assert response is not None
+        assert hasattr(response, "choices") or isinstance(response, dict)
+
+    @pytest.mark.asyncio
+    async def test_async_completion(self):
+        """Test async completion with MiniMax M2.5."""
+        adapter = MiniMaxAdapter()
+        response = await adapter.acompletion(
+            model="minimax/MiniMax-M2.5",
+            messages=[{"role": "user", "content": "Say hello in one word."}],
+            temperature=0.7,
+            max_tokens=10,
+        )
+        assert response is not None
+
+    def test_highspeed_model(self):
+        """Test completion with MiniMax M2.5 highspeed variant."""
+        adapter = MiniMaxAdapter()
+        response = adapter.completion(
+            model="minimax/MiniMax-M2.5-highspeed",
+            messages=[{"role": "user", "content": "Say hi."}],
+            max_tokens=10,
+        )
+        assert response is not None

--- a/libs/python/agent/tests/test_minimax_integration.py
+++ b/libs/python/agent/tests/test_minimax_integration.py
@@ -22,10 +22,10 @@ class TestMiniMaxLiveCompletion:
     """Integration tests with the MiniMax API."""
 
     def test_sync_completion(self):
-        """Test synchronous completion with MiniMax M2.5."""
+        """Test synchronous completion with MiniMax M3 (default)."""
         adapter = MiniMaxAdapter()
         response = adapter.completion(
-            model="minimax/MiniMax-M2.5",
+            model="minimax/MiniMax-M3",
             messages=[{"role": "user", "content": "Say hello in one word."}],
             temperature=0.7,
             max_tokens=10,
@@ -35,22 +35,12 @@ class TestMiniMaxLiveCompletion:
 
     @pytest.mark.asyncio
     async def test_async_completion(self):
-        """Test async completion with MiniMax M2.5."""
+        """Test async completion with MiniMax M3."""
         adapter = MiniMaxAdapter()
         response = await adapter.acompletion(
-            model="minimax/MiniMax-M2.5",
+            model="minimax/MiniMax-M3",
             messages=[{"role": "user", "content": "Say hello in one word."}],
             temperature=0.7,
-            max_tokens=10,
-        )
-        assert response is not None
-
-    def test_highspeed_model(self):
-        """Test completion with MiniMax M2.5 highspeed variant."""
-        adapter = MiniMaxAdapter()
-        response = adapter.completion(
-            model="minimax/MiniMax-M2.5-highspeed",
-            messages=[{"role": "user", "content": "Say hi."}],
             max_tokens=10,
         )
         assert response is not None


### PR DESCRIPTION
## Summary
Add MiniMax as a first-class LLM provider in the CUA agent framework via a custom litellm adapter, with MiniMax-M3 set as the default model.

## Changes
- Add `MiniMaxAdapter` custom litellm handler with OpenAI-compatible routing
- Register `minimax/` prefix in the provider map
- Support MiniMax-M3 (default), MiniMax-M2.7, MiniMax-M2.7-highspeed
- Temperature clamping to MiniMax range [0, 1.0]
- API key resolution via constructor, kwargs, or MINIMAX_API_KEY env var
- Full streaming support (sync and async)
- Unit and integration tests
- Update README and example.py with model options

## Why
MiniMax-M3 is the latest flagship model with a 512K context window, up to 128K max output, and image input support (OpenAI-compatible and Anthropic-compatible). Adding it as the default first-class provider enables CUA users to leverage the most capable MiniMax model for computer-use agent workflows, while keeping the previous-generation MiniMax-M2.7 / MiniMax-M2.7-highspeed available as alternatives.

## Testing
- Unit tests cover adapter init, model normalization, API key resolution, temperature clamping, parameter building, completion routing, streaming, and ComputerAgent integration
- Integration tests verify real API calls with M3 and M2.7 models