### PR TITLE
Initialize step_start_time in OTEL callback on_run_start

### DIFF
--- a/libs/python/agent/agent/callbacks/otel.py
+++ b/libs/python/agent/agent/callbacks/otel.py
@@ -79,6 +79,7 @@ class OtelCallback(AsyncCallbackHandler):
             return
 
         self.run_start_time = time.perf_counter()
+        self.step_start_time = self.run_start_time
         self.step_count = 0
 
     async def on_run_end(


### PR DESCRIPTION
## Summary
Initialize the `step_start_time` attribute when a run starts in the OpenTelemetry callback handler.

## Key Changes
- Added initialization of `self.step_start_time` to `self.run_start_time` in the `on_run_start` method
- This ensures `step_start_time` is set before any step tracking occurs, preventing potential undefined attribute errors

## Implementation Details
The `step_start_time` is now initialized alongside other run-level timing attributes (`run_start_time` and `step_count`) at the beginning of a run. This maintains consistency in the timing tracking lifecycle and ensures the attribute is always defined when needed for step duration calculations.

https://claude.ai/code/session_0199dLRaxJHe4tcF9f5mETqc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced step timing measurement accuracy by ensuring step durations are calculated from the actual run start time, resulting in more reliable performance metrics for agent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->