### PR TITLE
fix(xfce): remove pip upgrade on every container boot

### DIFF
--- a/libs/xfce/src/scripts/start-computer-server.sh
+++ b/libs/xfce/src/scripts/start-computer-server.sh
@@ -8,10 +8,6 @@ while ! xdpyinfo -display :1 >/dev/null 2>&1; do
 done
 echo "X server is ready"
 
-# Update cua-computer-server and cua-agent
-echo "Updating cua-computer-server and cua-agent..."
-sudo uv pip install --upgrade --system cua-computer-server "cua-agent[all]"
-
 # Start computer-server
 export DISPLAY=:1
 python3.12 -m computer_server --port ${API_PORT:-8000}


### PR DESCRIPTION
## Summary

- Removes `sudo uv pip install --upgrade --system cua-computer-server cua-agent[all]` from `start-computer-server.sh`
- This was running on every container boot, causing ~90s delay before port 8000 became available
- Packages are already baked into the Docker image at build time

## Test plan
- [ ] Build new `trycua/cua-xfce` image and verify computer server starts immediately after X server is ready

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed automatic package update step from the computer server startup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->