### PR TITLE
Disable telemetry for staging environments

### DIFF
--- a/libs/python/core/core/telemetry/otel.py
+++ b/libs/python/core/core/telemetry/otel.py
@@ -48,10 +48,18 @@ _tokens_total: Optional[Any] = None  # Counter
 def is_otel_enabled() -> bool:
     """Check if OpenTelemetry is enabled.
 
-    Returns True unless CUA_TELEMETRY_DISABLED is set to a truthy value.
+    Returns True unless CUA_TELEMETRY_DISABLED is set to a truthy value
+    or ENVIRONMENT indicates a staging instance.
     """
     disabled = os.environ.get("CUA_TELEMETRY_DISABLED", "").lower()
-    return disabled not in {"1", "true", "yes", "on"}
+    if disabled in {"1", "true", "yes", "on"}:
+        return False
+
+    environment = os.environ.get("ENVIRONMENT", "").lower()
+    if environment.startswith("staging"):
+        return False
+
+    return True
 
 
 def _get_otel_endpoint() -> str:


### PR DESCRIPTION
## Summary
Updated the OpenTelemetry telemetry check to automatically disable telemetry when running in staging environments, in addition to the existing explicit disable flag.

## Key Changes
- Modified `is_otel_enabled()` to check the `ENVIRONMENT` variable and return `False` if it starts with "staging"
- Refactored the function logic from a single-line return statement to explicit conditional checks for better readability
- Updated the docstring to document the new staging environment behavior

## Implementation Details
- The staging environment check is performed after the explicit `CUA_TELEMETRY_DISABLED` flag check, maintaining the priority of explicit disables
- The environment variable check is case-insensitive (converted to lowercase) and uses `startswith()` to match any staging variant (e.g., "staging", "staging-us", etc.)
- This prevents telemetry collection from staging instances while preserving the ability to explicitly enable/disable telemetry via the `CUA_TELEMETRY_DISABLED` flag

https://claude.ai/code/session_01LyQffqpod4aMSMrexVqW1C

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenTelemetry telemetry collection is now correctly disabled in staging environments, preventing unnecessary data transmission in non-production settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->