### PR TITLE
feat(computer-server): add multitouch_gesture action for Android

### DIFF
--- a/libs/python/computer-server/computer_server/handlers/android.py
+++ b/libs/python/computer-server/computer_server/handlers/android.py
@@ -1,8 +1,11 @@
 import asyncio
 import base64
+import logging
 from typing import Any, Dict, List, Optional, Tuple
 
 from ..utils.helpers import CommandExecutor
+
+logger = logging.getLogger(__name__)
 from .base import (
     BaseAccessibilityHandler,
     BaseAutomationHandler,
@@ -521,9 +524,27 @@ class AndroidAutomationHandler(BaseAutomationHandler):
             screen_h:    Screen height in pixels.
             duration_ms: Total gesture duration in milliseconds.
             steps:       Interpolation steps (0 = auto).
+
+        Raises:
+            ValueError:   If fewer than 2 fingers are provided or a finger dict
+                          is missing ``start``/``end`` keys.
+            RuntimeError: If sendevent injection fails.
         """
+        # Validate fingers
+        if len(fingers) < 2:
+            raise ValueError(f"multitouch_gesture requires at least 2 fingers, got {len(fingers)}")
+        for i, finger in enumerate(fingers):
+            if "start" not in finger or "end" not in finger:
+                raise ValueError(
+                    f"fingers[{i}] must have 'start' and 'end' keys, got: {list(finger.keys())}"
+                )
+            if len(finger["start"]) != 2 or len(finger["end"]) != 2:
+                raise ValueError(f"fingers[{i}] 'start' and 'end' must be [x, y] pairs")
+
         # Restart adbd as root so sendevent works without su
-        await adb_exec.run("root", decode=True)
+        ok_root, root_out = await adb_exec.run("root", decode=True)
+        if not ok_root:
+            logger.warning("adb root failed (output: %r); sendevent may lack permissions", root_out)
         await asyncio.sleep(1.0)  # wait for adbd to restart
 
         # Find the touchscreen event device
@@ -535,7 +556,11 @@ class AndroidAutomationHandler(BaseAutomationHandler):
             "done",
             decode=True,
         )
-        dev = dev_out.strip() if ok and dev_out.strip() else "/dev/input/event1"
+        if ok and dev_out.strip():
+            dev = dev_out.strip()
+        else:
+            dev = "/dev/input/event1"
+            logger.warning("touch device detection failed; falling back to %s", dev)
 
         # Detect axis max from getevent -p (e.g. "max 32767")
         axis_max = 32767
@@ -597,7 +622,9 @@ class AndroidAutomationHandler(BaseAutomationHandler):
 
         script = " && ".join(cmds)
         success, output = await adb_exec.run("shell", script, decode=True)
-        return {"success": success, "output": output}
+        if not success:
+            raise RuntimeError(f"multitouch_gesture sendevent failed: {output}")
+        return {}
 
     async def run_command(self, command: str) -> Dict[str, Any]:
         """Run a shell command.

--- a/libs/python/computer-server/computer_server/main.py
+++ b/libs/python/computer-server/computer_server/main.py
@@ -161,7 +161,6 @@ handlers = {
     "find_element": accessibility_handler.find_element,
     # Shell commands
     "run_command": automation_handler.run_command,
-    "multitouch_gesture": automation_handler.multitouch_gesture,
     # File system commands
     "file_exists": file_handler.file_exists,
     "directory_exists": file_handler.directory_exists,
@@ -219,6 +218,11 @@ handlers = {
     "copy_to_clipboard": automation_handler.copy_to_clipboard,
     "set_clipboard": automation_handler.set_clipboard,
 }
+
+# Android-only commands — registered only when the Android handler is active
+# so non-Android server instances don't fail at startup with AttributeError.
+if hasattr(automation_handler, "multitouch_gesture"):
+    handlers["multitouch_gesture"] = automation_handler.multitouch_gesture
 
 
 class AuthenticationManager:


### PR DESCRIPTION
## Summary

- Adds `multitouch_gesture` action to `AndroidAutomationHandler` in the computer-server
- Calls `adb root` to restart adbd as root before injecting events — fixes silent SELinux blocking of `su root sendevent` on cloud-hosted Android emulators
- Auto-detects touch device path and axis range via `getevent -p`
- Builds full MT Protocol B sendevent script (down → interpolated movement → up) as a single `adb shell` invocation
- Registers `multitouch_gesture` in the handlers map in `main.py`

**Why `adb root` instead of `su root`?**  
On cloud VMs, `su root sendevent` runs without error but events are silently dropped (likely SELinux blocking kernel input injection from the su context). `adb root` restarts adbd at the daemon level as root, so subsequent `adb shell` commands run as root and `sendevent` works reliably.

## Test plan

- [ ] Deploy updated computer-server to a cloud Android VM
- [ ] Run `CUA_TEST_API_KEY=... pytest tests/test_android_multitouch.py -v -k cloud` — all 17 tests (including 8 multi-touch) should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-touch gesture support for Android automation, enabling simultaneous multi-finger touch interactions with configurable duration and finger positioning on the device screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->