### PR TITLE
fix(computer-server): fix touch device detection on VMs with multiple input devices

### DIFF
--- a/libs/python/computer-server/computer_server/handlers/android.py
+++ b/libs/python/computer-server/computer_server/handlers/android.py
@@ -3,11 +3,7 @@ import base64
 import logging
 from typing import Any, Dict, List, Optional, Tuple
 
-logger = logging.getLogger(__name__)
-
 from ..utils.helpers import CommandExecutor
-
-logger = logging.getLogger(__name__)
 from .base import (
     BaseAccessibilityHandler,
     BaseAutomationHandler,
@@ -34,6 +30,7 @@ ANDROID_KEY_MAP = {
     "right": "22",
 }
 
+logger = logging.getLogger(__name__)
 adb_exec = CommandExecutor("adb", "-s", "emulator-5554")
 
 


### PR DESCRIPTION
## Summary

- `/dev/input/event*` glob sorts lexicographically (`event0, event1, event10, event11, ...`), so `event1` ("AT Translated Set 2 keyboard") is checked before `event10`-`event12` (virtio touch devices)
- The AT keyboard's getevent output contains `0035` as a key scancode in its KEY event list, causing `grep -q '0035'` to match falsely
- Result: `sendevent` writes MT Protocol B events to the **keyboard device** instead of the touchscreen — events injected silently but never reach Android apps

## Fix

Replace per-device loop with `getevent -p` (no file arg — lists all devices and exits cleanly) and awk matching `"0035  :"` — the ABS axis definition syntax — which only appears for MT touchscreen devices, never for keyboard scan codes.

Same fix applied to axis-max detection (was using `getevent -p {dev}` with a file arg, which may hang in event-monitoring mode).

## Test plan

- [ ] Run `test_android_multitouch.py` — all multitouch tests should pass (previously pinch/gesture tests failed with "No events received")
- [ ] Verify detected device is a `virtio_input_multi_touch_*` device (not `AT Translated Set 2 keyboard`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-finger gesture support for Android devices, enabling complex touch interactions with customizable duration and step interpolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->