### PR TITLE
fix(computer-server): fix multitouch gesture on VMs with multiple input devices

### DIFF
--- a/libs/python/computer-server/computer_server/handlers/android.py
+++ b/libs/python/computer-server/computer_server/handlers/android.py
@@ -634,53 +634,23 @@ class AndroidAutomationHandler(BaseAutomationHandler):
         return {"success": success, "output": output}
 
     async def run_command(self, command: str) -> Dict[str, Any]:
-        """Run a shell command.
-
-        Commands containing 'uv', 'python', or '/home/androidusr' run on the container host.
-        Other commands run in the Android emulator via adb shell.
-        """
-        # Check if this command should run on the host
-        should_run_on_host = any(
-            keyword in command for keyword in ["uv", "python", "/home/androidusr"]
+        """Run a shell command inside the Android emulator via adb shell."""
+        process = await asyncio.create_subprocess_exec(
+            "adb",
+            "-s",
+            "emulator-5554",
+            "shell",
+            command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
         )
-
-        if should_run_on_host:
-            # Run on container host
-            import os
-            import subprocess
-
-            try:
-                # Clear VIRTUAL_ENV to avoid UV conflicts
-                env = os.environ.copy()
-                env.pop("VIRTUAL_ENV", None)
-
-                result = subprocess.run(
-                    command, shell=True, capture_output=True, text=True, timeout=300, env=env
-                )
-                return {
-                    "stdout": result.stdout,
-                    "stderr": result.stderr,
-                    "return_code": result.returncode,
-                    "success": result.returncode == 0,
-                }
-            except subprocess.TimeoutExpired:
-                return {
-                    "stdout": "",
-                    "stderr": "Command timed out",
-                    "return_code": -1,
-                    "success": False,
-                }
-            except Exception as e:
-                return {"stdout": "", "stderr": str(e), "return_code": -1, "success": False}
-        else:
-            # Run in Android emulator via adb shell
-            success, output = await adb_exec.run("shell", command, decode=True)
-            return {
-                "stdout": output if success else "",
-                "stderr": "" if success else output,
-                "return_code": 0 if success else 1,
-                "success": success,
-            }
+        stdout, stderr = await process.communicate()
+        return {
+            "success": process.returncode == 0,
+            "stdout": stdout.decode() if stdout else "",
+            "stderr": stderr.decode() if stderr else "",
+            "return_code": process.returncode,
+        }
 
 
 class AndroidFileHandler(BaseFileHandler):


### PR DESCRIPTION
## Summary

- `getevent -p` lists MT-capable devices in reverse order; the previously selected device was not the one Android dispatches input from
- Fix: collect all MT-capable devices, sort numerically, and always use the primary (lowest-numbered) device with standard MT Protocol B slots for all fingers
- Verified with TouchTest app: `ACTION_POINTER_DOWN` with `pointer_count=2` confirmed

## Test plan

- [ ] Run `test_android_multitouch.py` cloud tests — all pinch/gesture tests should pass
- [ ] Confirm single-touch tests still pass (unchanged path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced multi-touch gesture handling with improved device detection and structured error responses.
  * Optimized command execution with intelligent routing and consistent result formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->