### PR TITLE
feat(computer-server): add JPEG format option to screenshot()

### DIFF
--- a/libs/python/computer-server/computer_server/handlers/android.py
+++ b/libs/python/computer-server/computer_server/handlers/android.py
@@ -10,6 +10,7 @@ from .base import (
     BaseDesktopHandler,
     BaseFileHandler,
     BaseWindowHandler,
+    normalize_screenshot_format,
 )
 
 # Map common key names to Android keycodes
@@ -439,20 +440,24 @@ class AndroidAutomationHandler(BaseAutomationHandler):
         return {}
 
     # Screen Actions
-    async def screenshot(self, format: str = "png", quality: int = 85) -> Dict[str, Any]:
+    async def screenshot(self, format: str = "png", quality: int = 95) -> Dict[str, Any]:
         """Take a screenshot and return base64 encoded image.
 
         Args:
-            format: "png" (lossless, default) or "jpeg" (lossy, ~5-10x smaller for RL workloads).
-            quality: JPEG quality 1-95, ignored for PNG.
+            format: "png" (lossless, default) or "jpeg" / "jpg" (lossy, ~5-10x smaller).
+            quality: JPEG quality 1-95 (clamped); ignored for PNG.
         """
+        try:
+            fmt, quality = normalize_screenshot_format(format, quality)
+        except ValueError as e:
+            return {"success": False, "error": str(e)}
         try:
             success, output = await adb_exec.run("shell", "screencap", "-p")
             if not (success and output):
                 error_msg = output.decode("utf-8") if isinstance(output, bytes) else str(output)
                 return {"success": False, "error": f"Screenshot failed: {error_msg}"}
 
-            if format == "jpeg":
+            if fmt == "jpeg":
                 from io import BytesIO
 
                 from PIL import Image as PILImage
@@ -463,7 +468,7 @@ class AndroidAutomationHandler(BaseAutomationHandler):
                 output = buf.getvalue()
 
             image_b64 = base64.b64encode(output).decode("utf-8")
-            return {"success": True, "image_data": image_b64, "format": format}
+            return {"success": True, "image_data": image_b64, "format": fmt}
         except Exception as e:
             return {"success": False, "error": f"Screenshot error: {str(e)}"}
 

--- a/libs/python/computer-server/computer_server/handlers/base.py
+++ b/libs/python/computer-server/computer_server/handlers/base.py
@@ -186,6 +186,30 @@ class BaseWindowHandler(ABC):
         pass
 
 
+_SUPPORTED_FORMATS = {"png", "jpeg"}
+_FORMAT_ALIASES = {"jpg": "jpeg"}
+
+
+def normalize_screenshot_format(format: str, quality: int) -> tuple[str, int]:
+    """Normalize and validate screenshot format/quality.
+
+    Returns ``(normalized_format, clamped_quality)`` or raises ``ValueError``.
+
+    - Lowercases the format string.
+    - Maps "jpg" → "jpeg".
+    - Rejects anything not in ``{"png", "jpeg"}``.
+    - Clamps JPEG quality to 1–95 (silently caps values above 95).
+    """
+    fmt = _FORMAT_ALIASES.get(format.lower(), format.lower())
+    if fmt not in _SUPPORTED_FORMATS:
+        raise ValueError(
+            f"Unsupported screenshot format {format!r}. " f"Supported: {sorted(_SUPPORTED_FORMATS)}"
+        )
+    if fmt == "jpeg":
+        quality = max(1, min(95, quality))
+    return fmt, quality
+
+
 class BaseAutomationHandler(ABC):
     """Abstract base class for OS-specific automation handlers.
 
@@ -312,7 +336,7 @@ class BaseAutomationHandler(ABC):
 
     # Screen Actions
     @abstractmethod
-    async def screenshot(self, format: str = "png", quality: int = 85) -> Dict[str, Any]:
+    async def screenshot(self, format: str = "png", quality: int = 95) -> Dict[str, Any]:
         """Take a screenshot and return base64 encoded image data.
 
         Args:

--- a/libs/python/computer-server/computer_server/handlers/linux.py
+++ b/libs/python/computer-server/computer_server/handlers/linux.py
@@ -28,7 +28,11 @@ from pynput.keyboard import Key
 from pynput.mouse import Button
 from pynput.mouse import Controller as MouseController
 
-from .base import BaseAccessibilityHandler, BaseAutomationHandler
+from .base import (
+    BaseAccessibilityHandler,
+    BaseAutomationHandler,
+    normalize_screenshot_format,
+)
 
 
 class LinuxAccessibilityHandler(BaseAccessibilityHandler):
@@ -489,19 +493,23 @@ class LinuxAutomationHandler(BaseAutomationHandler):
             return {"success": False, "error": str(e)}
 
     # Screen Actions
-    async def screenshot(self, format: str = "png", quality: int = 85) -> Dict[str, Any]:
+    async def screenshot(self, format: str = "png", quality: int = 95) -> Dict[str, Any]:
         """Take a screenshot of the current screen.
 
         Args:
-            format: "png" (lossless, default) or "jpeg" (lossy, smaller).
-            quality: JPEG quality 1-95, ignored for PNG.
+            format: "png" (lossless, default), "jpeg" or "jpg" (lossy, smaller).
+            quality: JPEG quality 1-95 (clamped); ignored for PNG.
         """
+        try:
+            fmt, quality = normalize_screenshot_format(format, quality)
+        except ValueError as e:
+            return {"success": False, "error": str(e)}
         try:
             screenshot = ImageGrab.grab()
             if not isinstance(screenshot, Image.Image):
                 return {"success": False, "error": "Failed to capture screenshot"}
             buffered = BytesIO()
-            if format == "jpeg":
+            if fmt == "jpeg":
                 screenshot.convert("RGB").save(
                     buffered, format="JPEG", quality=quality, optimize=True
                 )
@@ -509,7 +517,7 @@ class LinuxAutomationHandler(BaseAutomationHandler):
                 screenshot.save(buffered, format="PNG", optimize=True)
             buffered.seek(0)
             image_data = base64.b64encode(buffered.getvalue()).decode()
-            return {"success": True, "image_data": image_data, "format": format}
+            return {"success": True, "image_data": image_data, "format": fmt}
         except Exception as e:
             return {"success": False, "error": f"Screenshot error: {str(e)}"}
 

--- a/libs/python/computer-server/computer_server/handlers/macos.py
+++ b/libs/python/computer-server/computer_server/handlers/macos.py
@@ -49,7 +49,11 @@ from pynput.mouse import Controller as MouseController
 from Quartz.CoreGraphics import *  # type: ignore
 from Quartz.CoreGraphics import CGPoint, CGSize  # type: ignore
 
-from .base import BaseAccessibilityHandler, BaseAutomationHandler
+from .base import (
+    BaseAccessibilityHandler,
+    BaseAutomationHandler,
+    normalize_screenshot_format,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1357,13 +1361,17 @@ class MacOSAutomationHandler(BaseAutomationHandler):
             return {"success": False, "error": str(e)}
 
     # Screen Actions
-    async def screenshot(self, format: str = "png", quality: int = 85) -> Dict[str, Any]:
+    async def screenshot(self, format: str = "png", quality: int = 95) -> Dict[str, Any]:
         """Capture a screenshot of the current screen.
 
         Args:
-            format: "png" (lossless, default) or "jpeg" (lossy, smaller).
-            quality: JPEG quality 1-95, ignored for PNG.
+            format: "png" (lossless, default), "jpeg" or "jpg" (lossy, smaller).
+            quality: JPEG quality 1-95 (clamped); ignored for PNG.
         """
+        try:
+            fmt, quality = normalize_screenshot_format(format, quality)
+        except ValueError as e:
+            return {"success": False, "error": str(e)}
         try:
             screenshot = ImageGrab.grab()
             if not isinstance(screenshot, Image.Image):
@@ -1377,7 +1385,7 @@ class MacOSAutomationHandler(BaseAutomationHandler):
                 screenshot = screenshot.resize((max_width, new_height), Image.Resampling.LANCZOS)
 
             buffered = BytesIO()
-            if format == "jpeg":
+            if fmt == "jpeg":
                 screenshot.convert("RGB").save(
                     buffered, format="JPEG", quality=quality, optimize=True
                 )
@@ -1385,7 +1393,7 @@ class MacOSAutomationHandler(BaseAutomationHandler):
                 screenshot.save(buffered, format="PNG", optimize=True)
             buffered.seek(0)
             image_data = base64.b64encode(buffered.getvalue()).decode()
-            return {"success": True, "image_data": image_data, "format": format}
+            return {"success": True, "image_data": image_data, "format": fmt}
         except Exception as e:
             return {"success": False, "error": f"Screenshot error: {str(e)}"}
 

--- a/libs/python/computer-server/computer_server/handlers/windows.py
+++ b/libs/python/computer-server/computer_server/handlers/windows.py
@@ -63,7 +63,11 @@ except Exception as e:
     )
     WINDOWS_API_AVAILABLE = False
 
-from .base import BaseAccessibilityHandler, BaseAutomationHandler
+from .base import (
+    BaseAccessibilityHandler,
+    BaseAutomationHandler,
+    normalize_screenshot_format,
+)
 
 
 class WindowsAccessibilityHandler(BaseAccessibilityHandler):
@@ -632,20 +636,24 @@ class WindowsAutomationHandler(BaseAutomationHandler):
 
     # Screen Actions
     @require_unlocked_desktop
-    async def screenshot(self, format: str = "png", quality: int = 85) -> Dict[str, Any]:
+    async def screenshot(self, format: str = "png", quality: int = 95) -> Dict[str, Any]:
         """Capture a screenshot of the entire screen.
 
         Args:
-            format: "png" (lossless, default) or "jpeg" (lossy, smaller).
-            quality: JPEG quality 1-95, ignored for PNG.
+            format: "png" (lossless, default), "jpeg" or "jpg" (lossy, smaller).
+            quality: JPEG quality 1-95 (clamped); ignored for PNG.
         """
+        try:
+            fmt, quality = normalize_screenshot_format(format, quality)
+        except ValueError as e:
+            return {"success": False, "error": str(e)}
         try:
             screenshot = ImageGrab.grab()
             if not isinstance(screenshot, Image.Image):
                 return {"success": False, "error": "Failed to capture screenshot"}
 
             buffered = BytesIO()
-            if format == "jpeg":
+            if fmt == "jpeg":
                 screenshot.convert("RGB").save(
                     buffered, format="JPEG", quality=quality, optimize=True
                 )
@@ -653,7 +661,7 @@ class WindowsAutomationHandler(BaseAutomationHandler):
                 screenshot.save(buffered, format="PNG", optimize=True)
             buffered.seek(0)
             image_data = base64.b64encode(buffered.getvalue()).decode()
-            return {"success": True, "image_data": image_data, "format": format}
+            return {"success": True, "image_data": image_data, "format": fmt}
         except Exception as e:
             return {"success": False, "error": f"Screenshot error: {str(e)}"}
 


### PR DESCRIPTION
## Summary

- Adds `format` and `quality` params to `screenshot()` on all OS handlers (android, linux, macos, windows) and the base abstract class
- Default is `format="png"` — fully backwards compatible, no behaviour change for existing callers
- Pass `{"format": "jpeg", "quality": 85}` in command params to get JPEG output; the existing `inspect.signature` dispatch in `main.py` wires it up with no other changes needed
- On Android: ADB `screencap -p` returns PNG bytes → PIL decodes and re-encodes to JPEG
- On desktop (Linux/macOS/Windows): PIL saves directly to JPEG via `ImageGrab`
- Response includes a `"format"` key so clients know what they received

## Motivation

Android sandboxes at 1080×2400 produce ~1.4 MB PNG screenshots with ~1.9s round-trip latency through ADB + base64 + network. For large-scale Android RL training (many parallel sandboxes each doing action→observation loops), this is the dominant bottleneck. JPEG at q=85 is expected to be ~100–200 KB — a ~7–14× reduction — with a meaningful latency improvement.

## Test plan

- [ ] `sb.screenshot()` still returns PNG bytes (no params = backwards compat)
- [ ] `sb.screenshot(format="jpeg", quality=85)` returns valid JPEG bytes
- [ ] `sb.screenshot(format="jpeg", quality=40)` returns smaller JPEG
- [ ] Android handler: PIL correctly opens ADB screencap PNG and re-encodes to JPEG
- [ ] Desktop handlers: PIL JPEG save path works on Linux/macOS/Windows
- [ ] Response includes `"format": "jpeg"` or `"format": "png"` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Screenshots can now be captured in JPEG or PNG format with adjustable quality levels (PNG by default, quality 85 for JPEG).
  * Android automation now supports multi-finger touch gestures with configurable duration and interpolated movement paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->