### PR TITLE
feat(cua-bench): robust agent runs with retry/backoff and fixed cb run stop

### DIFF
--- a/libs/cua-bench/Dockerfile
+++ b/libs/cua-bench/Dockerfile
@@ -45,9 +45,6 @@ RUN python -m pip install --upgrade pip && \
 # Install cua-agent and non torch optional deps
 RUN python -m pip install --no-cache-dir cua-agent[qwen,omni,gemini]
 
-# Install OpenTelemetry packages
-RUN python -m pip install --no-cache-dir opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
-
 # Create a non-root user and set ownership
 RUN useradd -m -u 1000 cuauser && \
     chown -R cuauser:cuauser /app && \

--- a/libs/cua-bench/cua_bench/agents/cua_agent.py
+++ b/libs/cua-bench/cua_bench/agents/cua_agent.py
@@ -232,6 +232,12 @@ class CuaAgent(BaseAgent):
         print("CUA Agent initialized with model:", self.model)
 
         # Run the agent and track usage (with task-level retry on transient API errors)
+        total_usage = {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+            "response_cost": 0.0,
+        }
         last_exc: BaseException | None = None
         for attempt in range(self.task_retries + 1):
             if attempt > 0:
@@ -243,13 +249,6 @@ class CuaAgent(BaseAgent):
                 await asyncio.sleep(delay)
 
             try:
-                total_usage = {
-                    "prompt_tokens": 0,
-                    "completion_tokens": 0,
-                    "total_tokens": 0,
-                    "response_cost": 0.0,
-                }
-
                 step = 0
                 task_completed = False
 

--- a/libs/cua-bench/cua_bench/cli/commands/run.py
+++ b/libs/cua-bench/cua_bench/cli/commands/run.py
@@ -606,7 +606,9 @@ async def _cmd_stop_async(args) -> int:
             # Give it a moment to clean up, then SIGKILL if still alive
             await asyncio.sleep(2)
             try:
-                os.kill(pid, signal.SIGKILL)
+                sigkill = getattr(signal, "SIGKILL", None)
+                if sigkill is not None:
+                    os.kill(pid, sigkill)
             except ProcessLookupError:
                 pass  # Already exited cleanly
         except (ValueError, ProcessLookupError):
@@ -1789,6 +1791,8 @@ async def _cmd_run_dataset_async(args) -> int:
             stderr=subprocess.STDOUT,
             env=env_vars,
         )
+        # Close the parent's copy of the fd; the subprocess has its own inherited copy.
+        log_handle.close()
 
         # Save PID so `cb run stop` can kill the process
         pid_file = output_dir / "run.pid"

--- a/libs/cua-bench/pyproject.toml
+++ b/libs/cua-bench/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cua-bench"
-version = "0.2.6"
+version = "0.2.5"
 description = "Toolkit for computer-use RL environments and benchmarks"
 readme = "README.md"
 license = "MIT"
@@ -59,7 +59,7 @@ dependencies = [
 [project.optional-dependencies]
 # Full installation with all features
 all = [
-    "cua-bench[browser,agents,cloud]",
+    "cua-bench[browser,agents,cloud,otel]",
 ]
 
 # Browser automation (for simulated environments)
@@ -73,6 +73,13 @@ agents = [
     "anthropic>=0.26.0",
 ]
 
+# OpenTelemetry tracing and metrics export
+otel = [
+    "opentelemetry-api>=1.20.0",
+    "opentelemetry-sdk>=1.20.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.20.0",
+]
+
 # Cloud batch execution (Google Cloud)
 cloud = [
     "google-cloud-batch>=0.17.0",
@@ -80,6 +87,7 @@ cloud = [
     "google-cloud-storage>=2.10.0",
     "gcloud-aio-storage>=9.0.0",
     "grpcio>=1.60.0",
+    "cua-bench[otel]",
 ]
 
 # API server (for custom environments)

--- a/libs/python/agent/agent/agent.py
+++ b/libs/python/agent/agent/agent.py
@@ -234,6 +234,8 @@ async def _predict_step_with_retry(
         max_retries: Maximum number of retry attempts (total attempts = max_retries + 1).
         base_delay: Base delay in seconds for the first retry; doubles each attempt.
     """
+    if max_retries is None:
+        max_retries = 0
     last_exc: Optional[BaseException] = None
     for attempt in range(max_retries + 1):
         try:
@@ -969,7 +971,9 @@ class ComputerAgent:
                 "tools": self.tool_schemas,
                 "stream": False,
                 "computer_handler": self.computer_handler,
-                "max_retries": self.max_retries,
+                # Inner liteLLM retries are disabled here; _predict_step_with_retry
+                # is the sole retry layer so the two don't stack.
+                "max_retries": 0,
                 "use_prompt_caching": self.use_prompt_caching,
                 **merged_kwargs,
             }

--- a/libs/python/agent/agent/loops/anthropic.py
+++ b/libs/python/agent/agent/loops/anthropic.py
@@ -1922,6 +1922,7 @@ Task: Click {instruction}. Output ONLY a click action on the target element.""",
             "stream": False,
             "max_tokens": 100,  # Keep response short for click prediction
             "headers": {"anthropic-beta": tool_config["beta_flag"]},
+            "request_timeout": kwargs.pop("request_timeout", 120),
         }
         # Thread optional API params
         if "api_key" in kwargs and kwargs.get("api_key") is not None:

--- a/libs/python/agent/agent/loops/openai.py
+++ b/libs/python/agent/agent/loops/openai.py
@@ -379,6 +379,7 @@ Task: Click {instruction}. Output ONLY a click action on the target element.""",
             "reasoning": {"summary": "concise"},
             "truncation": "auto",
             "max_tokens": 200,  # Keep response short for click prediction
+            "request_timeout": kwargs.pop("request_timeout", 120),
             **kwargs,
         }
 


### PR DESCRIPTION
## Summary

- **Request timeouts**: Added 120s `request_timeout` to all liteLLM API calls (anthropic + openai loops) so stalled connections don't hang forever
- **Step-level retry**: `_predict_step_with_retry()` in `agent.py` wraps each `predict_step` call with exponential backoff (2s → 4s → 8s + jitter) for transient errors (timeouts, rate limits, 5xx, connection drops)
- **Task-level retry**: `cua_agent.py` retries the entire task run on transient API failures (configurable via `--agent-kwarg task_retries=N`, default 0)
- **Better error classification**: Added `FailureMode.API_ERROR` to distinguish transient API failures from logic errors
- **Fix tracer crash**: `Usage` pydantic object was not JSON serializable when passed to the tracer — now normalized to dict
- **OpenTelemetry in Dockerfile**: Added `opentelemetry-api/sdk/exporter-otlp-proto-http` to stop the repeated missing-module warnings
- **Fix `cb run stop`**: Now saves the orchestrator PID to `run.pid` on start, and on stop sends SIGTERM → SIGKILL to actually kill the background process before stopping Docker containers

## Test plan
- [ ] Run `cb run dataset datasets/cua-bench-basic --agent cua-agent --model openai/computer-use-preview` and confirm it completes without dying on first timeout
- [ ] Run `cb run stop <id>` and confirm the background process actually exits
- [ ] Confirm no more OpenTelemetry import warnings in agent container logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic retry capability for agent tasks when encountering transient API errors
  * Enhanced failure tracking with new API error classification
  * Improved background process management for runs

* **Infrastructure**
  * Added OpenTelemetry integration for enhanced observability
  * Configured default request timeout (120 seconds) for API operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->