### PR TITLE
fix(lume): remove stale destination file before moving downloaded layer

### DIFF
--- a/libs/lume/src/ContainerRegistry/ImageContainerRegistry.swift
+++ b/libs/lume/src/ContainerRegistry/ImageContainerRegistry.swift
@@ -2227,10 +2227,18 @@ class ImageContainerRegistry: ImageRegistry, @unchecked Sendable {
 
                 try FileManager.default.createDirectory(
                     at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-                if FileManager.default.fileExists(atPath: url.path) {
-                    try FileManager.default.removeItem(at: url)
+                do {
+                    try FileManager.default.moveItem(at: tempURL, to: url)
+                } catch let moveError as NSError
+                    where moveError.domain == NSCocoaErrorDomain
+                        && moveError.code == NSFileWriteFileExistsError
+                {
+                    // Destination already exists from a previous interrupted download.
+                    // Use replaceItemAt for an atomic swap instead of the racy
+                    // fileExists+removeItem+moveItem pattern.
+                    _ = try FileManager.default.replaceItemAt(
+                        url, withItemAt: tempURL, backupItemName: nil, options: [])
                 }
-                try FileManager.default.moveItem(at: tempURL, to: url)
                 progress.addProgress(Int64(httpResponse.expectedContentLength))
 
                 // Always save a copy to the cache directory for use by copyFromCache,


### PR DESCRIPTION
## Summary
- When a layer download is interrupted and retried, the destination file may already exist from a partial previous attempt
- `FileManager.moveItem` fails with "item with the same name already exists" in this case
- Fix: remove the destination file if it exists before attempting the move

## Test plan
- [ ] Interrupt a `lume pull` mid-download and re-run — should resume without error instead of failing with file collision

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where container image downloads would not properly replace existing files, ensuring the latest versions are correctly deployed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->