### PR TITLE
feat(lume): add --disk-path and --nvram-path flags to run command

### DIFF
--- a/libs/lume/src/Commands/Run.swift
+++ b/libs/lume/src/Commands/Run.swift
@@ -57,6 +57,18 @@ struct Run: AsyncParsableCommand {
     var storage: String?
 
     @Option(
+        name: .customLong("disk-path"),
+        help: "Override path to disk image file. When set, uses this file instead of the default disk.img in the VM directory.",
+        completion: .file())
+    var diskPath: String?
+
+    @Option(
+        name: .customLong("nvram-path"),
+        help: "Override path to NVRAM file. When set, uses this file instead of the default nvram.bin in the VM directory.",
+        completion: .file())
+    var nvramPath: String?
+
+    @Option(
         name: .customLong("network"),
         help: "Optional network override: 'nat', 'bridged', or 'bridged:<interface>' (e.g. 'bridged:en0'). Defaults to the VM's configured mode.")
     var network: String?
@@ -141,6 +153,8 @@ struct Run: AsyncParsableCommand {
             vncPassword: vncPassword,
             recoveryMode: recoveryMode,
             storage: storage,
+            diskPath: diskPath.map { Path($0) },
+            nvramPath: nvramPath.map { Path($0) },
             usbMassStoragePaths: parsedUSBStorageDevices.isEmpty ? nil : parsedUSBStorageDevices,
             networkMode: parsedNetworkMode,
             clipboard: clipboard

--- a/libs/lume/src/LumeController.swift
+++ b/libs/lume/src/LumeController.swift
@@ -907,6 +907,8 @@ final class LumeController {
         vncPassword: String? = nil,
         recoveryMode: Bool = false,
         storage: String? = nil,
+        diskPath: Path? = nil,
+        nvramPath: Path? = nil,
         usbMassStoragePaths: [Path]? = nil,
         networkMode: NetworkMode? = nil,
         clipboard: Bool = false
@@ -923,6 +925,8 @@ final class LumeController {
                 "vnc_port": "\(vncPort)",
                 "recovery_mode": "\(recoveryMode)",
                 "storage_param": storage ?? "home", // Log the original param
+                "disk_path_override": diskPath?.path ?? "none",
+                "nvram_path_override": nvramPath?.path ?? "none",
                 "usb_storage_devices": "\(usbMassStoragePaths?.count ?? 0)",
                 "network_override": networkMode?.description ?? "vm-config",
             ])
@@ -960,28 +964,47 @@ final class LumeController {
             let effectiveStorage: String?
             let vmDir: VMDirectory
 
+            // When disk/nvram path overrides are provided, the VM directory only needs
+            // config.json (not the full disk.img + nvram.bin). This lets external tools
+            // like lumelet store disk images in their own cache and point lume at them.
+            let hasPathOverrides = diskPath != nil || nvramPath != nil
+
             if let storagePath = storage, storagePath.contains("/") || storagePath.contains("\\") {
                 // Storage is a direct path
                 vmDir = try home.getVMDirectoryFromPath(normalizedName, storagePath: storagePath)
-                guard vmDir.initialized() else {
-                    if vmDir.exists() {
-                        throw VMError.notInitialized(normalizedName)
-                    } else {
+                if hasPathOverrides {
+                    // With path overrides, only config.json is required
+                    guard vmDir.configPath.exists() else {
                         throw VMError.notFound(normalizedName)
+                    }
+                } else {
+                    guard vmDir.initialized() else {
+                        if vmDir.exists() {
+                            throw VMError.notInitialized(normalizedName)
+                        } else {
+                            throw VMError.notFound(normalizedName)
+                        }
                     }
                 }
                 effectiveStorage = storagePath // Use the path string
                 Logger.info("Using direct storage path", metadata: ["path": storagePath])
             } else {
                 // Storage is nil or a named location - validate and get the actual name
-                let actualLocationName = try validateVMExists(normalizedName, storage: storage)
-                vmDir = try home.getVMDirectory(normalizedName, storage: actualLocationName) // Get VMDir for named location
-                effectiveStorage = actualLocationName // Use the named location string
+                if hasPathOverrides {
+                    // With overrides, try to find the VM but relax initialized check
+                    let actualLocationName = try? validateVMExists(normalizedName, storage: storage)
+                    vmDir = try home.getVMDirectory(normalizedName, storage: actualLocationName)
+                    effectiveStorage = actualLocationName
+                } else {
+                    let actualLocationName = try validateVMExists(normalizedName, storage: storage)
+                    vmDir = try home.getVMDirectory(normalizedName, storage: actualLocationName) // Get VMDir for named location
+                    effectiveStorage = actualLocationName // Use the named location string
+                }
                 Logger.info(
                     "Using named storage location",
                     metadata: [
                         "requested": storage ?? "home",
-                        "actual": actualLocationName ?? "default",
+                        "actual": effectiveStorage ?? "default",
                     ])
             }
 
@@ -997,7 +1020,7 @@ final class LumeController {
             )
 
             // Load the VM directly using the located VMDirectory and storage context
-            let vm = try self.loadVM(vmDir: vmDir, storage: effectiveStorage)
+            let vm = try self.loadVM(vmDir: vmDir, storage: effectiveStorage, diskPath: diskPath, nvramPath: nvramPath)
 
             SharedVM.shared.setVM(name: normalizedName, vm: vm)
             try await vm.run(
@@ -1360,17 +1383,21 @@ final class LumeController {
     }
 
     @MainActor
-    private func loadVM(vmDir: VMDirectory, storage: String?) throws -> VM {
-        // vmDir is now passed directly
-        guard vmDir.initialized() else {
-            throw VMError.notInitialized(vmDir.name) // Use name from vmDir
+    private func loadVM(vmDir: VMDirectory, storage: String?, diskPath: Path? = nil, nvramPath: Path? = nil) throws -> VM {
+        // With path overrides, only config.json is required (not full initialized check)
+        let hasPathOverrides = diskPath != nil || nvramPath != nil
+        if !hasPathOverrides {
+            guard vmDir.initialized() else {
+                throw VMError.notInitialized(vmDir.name)
+            }
         }
 
         let config: VMConfig = try vmDir.loadConfig()
-        // Pass the provided storage (which could be a path or named location)
-        let vmDirContext = VMDirContext(
+        var vmDirContext = VMDirContext(
             dir: vmDir, config: config, home: home, storage: storage
         )
+        vmDirContext.diskPathOverride = diskPath
+        vmDirContext.nvramPathOverride = nvramPath
 
         let imageLoader =
             config.os.lowercased() == "macos" ? imageLoaderFactory.createImageLoader() : nil

--- a/libs/lume/src/Server/Handlers.swift
+++ b/libs/lume/src/Server/Handlers.swift
@@ -340,7 +340,7 @@ extension Server {
                 body.flatMap { try? JSONDecoder().decode(RunVMRequest.self, from: $0) }
                 ?? RunVMRequest(
                     noDisplay: nil, sharedDirectories: nil, recoveryMode: nil, storage: nil,
-                    network: nil, clipboard: nil)
+                    diskPath: nil, nvramPath: nil, network: nil, clipboard: nil)
 
             // Record telemetry
             TelemetryClient.shared.record(event: TelemetryEvent.apiVMRun, properties: [
@@ -372,6 +372,8 @@ extension Server {
                 sharedDirectories: dirs,
                 recoveryMode: request.recoveryMode ?? false,
                 storage: request.storage,
+                diskPath: request.diskPath.map { Path($0) },
+                nvramPath: request.nvramPath.map { Path($0) },
                 networkMode: networkMode,
                 clipboard: request.clipboard ?? false
             )
@@ -827,6 +829,8 @@ extension Server {
         sharedDirectories: [SharedDirectory] = [],
         recoveryMode: Bool = false,
         storage: String? = nil,
+        diskPath: Path? = nil,
+        nvramPath: Path? = nil,
         networkMode: NetworkMode? = nil,
         clipboard: Bool = false
     ) {
@@ -858,6 +862,8 @@ extension Server {
                     sharedDirectories: sharedDirectories,
                     recoveryMode: recoveryMode,
                     storage: storage,
+                    diskPath: diskPath,
+                    nvramPath: nvramPath,
                     networkMode: networkMode,
                     clipboard: clipboard
                 )

--- a/libs/lume/src/Server/Requests.swift
+++ b/libs/lume/src/Server/Requests.swift
@@ -16,6 +16,8 @@ struct RunVMRequest: Codable {
     let sharedDirectories: [SharedDirectoryRequest]?
     let recoveryMode: Bool?
     let storage: String?
+    let diskPath: String?
+    let nvramPath: String?
     let network: String?
     let clipboard: Bool?
 

--- a/libs/lume/src/VM/VM.swift
+++ b/libs/lume/src/VM/VM.swift
@@ -10,14 +10,21 @@ struct VMDirContext {
     let home: Home
     let storage: String?
 
+    /// Optional override paths for disk and nvram files.
+    /// When set, these take precedence over the default directory-based paths.
+    /// This allows external tools (e.g. lumelet) to point lume at files
+    /// stored outside the standard VM directory layout.
+    var diskPathOverride: Path?
+    var nvramPathOverride: Path?
+
     func saveConfig() throws {
         try dir.saveConfig(config)
     }
 
     var name: String { dir.name }
     var initialized: Bool { dir.initialized() }
-    var diskPath: Path { dir.diskPath }
-    var nvramPath: Path { dir.nvramPath }
+    var diskPath: Path { diskPathOverride ?? dir.diskPath }
+    var nvramPath: Path { nvramPathOverride ?? dir.nvramPath }
 
     func setDisk(_ size: UInt64) throws {
         try dir.setDisk(size)


### PR DESCRIPTION
## Summary
- Add `--disk-path` and `--nvram-path` CLI flags to `lume run` that override the default `disk.img` / `nvram.bin` paths from the VM directory
- When path overrides are provided, the VM directory only needs `config.json` (disk + nvram files are read from the specified paths)
- Also exposed via HTTP API (`diskPath` / `nvramPath` fields in `RunVMRequest`)

This enables external tools like lumelet to manage their own image cache and point lume at disk/nvram files without needing to create a full VM directory with renamed/cloned files.

## Files changed
- `src/VM/VM.swift` — `VMDirContext` gains optional `diskPathOverride` / `nvramPathOverride`
- `src/Commands/Run.swift` — new `--disk-path` and `--nvram-path` options
- `src/LumeController.swift` — `runVM()` and `loadVM()` accept and propagate path overrides; relaxed `initialized()` check when overrides are present
- `src/Server/Requests.swift` — `RunVMRequest` gains `diskPath` / `nvramPath`
- `src/Server/Handlers.swift` — pass new fields through to `startVM()`

## Test plan
- [x] `swift build` passes
- [x] All 15 existing tests pass (`swift test`)
- [ ] Manual: `lume run my-vm --storage /path --disk-path /other/disk.img --nvram-path /other/nvram.bin`
- [ ] Manual: verify HTTP API accepts `diskPath`/`nvramPath` in run request body

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now specify custom disk and NVRAM file paths when running virtual machines. New command-line options (`--disk-path` and `--nvram-path`) and API request parameters enable flexible storage configuration for non-standard deployment scenarios. The system automatically adjusts its validation behavior when path overrides are provided, ensuring compatibility with diverse setups while maintaining full backward compatibility with existing configurations and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->