### PR TITLE
fix(docs): remove footer from docs content pages

### DIFF
--- a/docs/src/app/(landing)/layout.tsx
+++ b/docs/src/app/(landing)/layout.tsx
@@ -1,12 +1,14 @@
 import type { ReactNode } from 'react';
 import { HomeLayout } from 'fumadocs-ui/layouts/home';
 import { CustomHeader } from '@/components/custom-header';
+import { Footer } from '@/components/footer';
 
 export default function LandingLayout({ children }: { children: ReactNode }) {
   return (
     <>
       <CustomHeader />
       <HomeLayout nav={{ enabled: false }}>{children}</HomeLayout>
+      <Footer />
     </>
   );
 }

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -6,7 +6,7 @@ import { PHProvider, PostHogPageView } from '@/providers/posthog-provider';
 import { CopilotKitProvider } from '@/providers/copilotkit-provider';
 import { AnalyticsTracker } from '@/components/analytics-tracker';
 import { CookieConsent } from '@/components/cookie-consent';
-import { Footer } from '@/components/footer';
+
 import { Suspense } from 'react';
 
 const geist = Geist({
@@ -67,7 +67,7 @@ export default function Layout({ children }: { children: ReactNode }) {
             >
               {children}
             </RootProvider>
-            <Footer />
+
           </CopilotKitProvider>
           <CookieConsent />
         </PHProvider>


### PR DESCRIPTION
## Summary
- Move Footer component from root layout to landing layout only
- Fixes the footer incorrectly appearing at the bottom of documentation content pages

## Test plan
- [ ] Verify footer no longer appears on docs content pages (e.g. `/docs/...`)
- [ ] Verify footer still appears on the landing page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Footer positioning has been adjusted. The footer now appears exclusively on the landing page rather than across the entire site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->