### PR TITLE
feat(sandbox): multi-arch AndroidWorld and OSWorld image support

### DIFF
--- a/examples/sandboxes/images/bake_androidworld_avd.py
+++ b/examples/sandboxes/images/bake_androidworld_avd.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Bake an AndroidWorld AVD with all apps pre-installed.
+
+Called by build-androidworld.sh. Boots a fresh Android emulator, runs
+AndroidWorld's emulator_setup=True to install all 20 benchmark apps and
+save per-app snapshots, then cleanly shuts down the emulator.
+
+The resulting ~/.cua/android-avd/androidworld.avd is ready to be pushed
+as an OCI artifact by build-androidworld.sh.
+
+Environment variables
+---------------------
+AW_SOURCE_DIR   Path to android_world source checkout (default: /tmp/android_world)
+AW_VENV         Path to venv with android_world installed (default: /tmp/aw-venv)
+"""
+import logging
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+log = logging.getLogger(__name__)
+
+AW_SOURCE_DIR = os.environ.get("AW_SOURCE_DIR", "/tmp/android_world")
+sys.path.insert(0, AW_SOURCE_DIR)
+
+SDK = Path.home() / ".cua" / "android-sdk"
+AVD_HOME = Path.home() / ".cua" / "android-avd"
+AVD_NAME = "androidworld"
+CONSOLE_PORT = 5564
+GRPC_PORT = CONSOLE_PORT + 3000
+ADB = str(SDK / "platform-tools" / "adb")
+EMULATOR = str(SDK / "emulator" / "emulator")
+
+
+def adb(*args, timeout=30):
+    return subprocess.run(
+        [ADB, "-s", f"emulator-{CONSOLE_PORT}", *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def wait_boot(timeout=300):
+    log.info("Waiting for emulator boot...")
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if adb("shell", "getprop", "sys.boot_completed", timeout=10).stdout.strip() == "1":
+            log.info("Boot complete.")
+            return
+        time.sleep(5)
+    raise RuntimeError("Emulator timed out")
+
+
+def patch_setup_to_ignore_errors():
+    """Replace setup_apps with a version that skips per-app failures."""
+    import android_world.env.setup_device.setup as _setup_mod
+    from android_world.env import adb_utils
+    from android_world.utils import app_snapshot as _snap
+
+    def _resilient_setup_apps(env, app_list=None):
+        adb_utils.press_home_button(env.controller)
+        adb_utils.set_root_if_needed(env.controller)
+        log.info("Installing and setting up applications ...")
+        if app_list is None:
+            app_list = _setup_mod._APPS
+        for app in app_list:
+            try:
+                _setup_mod.maybe_install_app(app, env)
+            except Exception as e:
+                log.warning(f"  [SKIP] {app.app_name} install error: {e}")
+                continue
+            try:
+                app.setup(env)
+            except Exception as e:
+                log.warning(f"  [WARN] {app.app_name} setup error (continuing): {e}")
+            try:
+                _snap.save_snapshot(app.app_name, env.controller)
+            except Exception as e:
+                log.warning(f"  [WARN] {app.app_name} snapshot error (continuing): {e}")
+        log.info("setup_apps complete.")
+
+    _setup_mod.setup_apps = _resilient_setup_apps
+
+
+def main():
+    import platform as _plat
+
+    arch = "arm64-v8a" if _plat.machine() in ("arm64", "aarch64") else "x86_64"
+    api_level = 33
+    img_type = "google_apis"
+    package = f"system-images;android-{api_level};{img_type};{arch}"
+    abi = f"{img_type}/{arch}"
+    avdmanager = str(SDK / "cmdline-tools" / "latest" / "bin" / "avdmanager")
+    sdkmanager = str(SDK / "cmdline-tools" / "latest" / "bin" / "sdkmanager")
+
+    env = os.environ.copy()
+    env["ANDROID_SDK_ROOT"] = str(SDK)
+    env["ANDROID_AVD_HOME"] = str(AVD_HOME)
+    # macOS: auto-detect openjdk
+    for jdk in (
+        Path("/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home"),
+        Path("/usr/local/opt/openjdk/libexec/openjdk.jdk/Contents/Home"),
+    ):
+        if jdk.exists():
+            env["JAVA_HOME"] = str(jdk)
+            env["PATH"] = f"{jdk / 'bin'}:{env.get('PATH', '')}"
+            break
+
+    AVD_HOME.mkdir(parents=True, exist_ok=True)
+    avd_dir = AVD_HOME / f"{AVD_NAME}.avd"
+
+    if not (SDK / "system-images" / f"android-{api_level}" / img_type / arch).exists():
+        log.info(f"Installing system image {package} ...")
+        subprocess.run(
+            [sdkmanager, f"--sdk_root={SDK}", "--install", package],
+            input=b"y\n",
+            capture_output=True,
+            timeout=600,
+            env=env,
+        )
+
+    log.info(f"Creating AVD '{AVD_NAME}' ...")
+    result = subprocess.run(
+        [
+            avdmanager,
+            "create",
+            "avd",
+            "--force",
+            "--name",
+            AVD_NAME,
+            "--abi",
+            abi,
+            "--package",
+            package,
+            "--device",
+            "pixel_6",
+        ],
+        input="no\n",
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        log.error(f"avdmanager failed: {result.stderr}")
+        sys.exit(1)
+
+    log.info("Starting emulator ...")
+    subprocess.run([ADB, "start-server"], capture_output=True, env=env)
+    proc = subprocess.Popen(
+        [
+            EMULATOR,
+            "-avd",
+            AVD_NAME,
+            "-gpu",
+            "swiftshader_indirect",
+            "-no-window",
+            "-no-boot-anim",
+            "-no-snapshot",
+            "-port",
+            str(CONSOLE_PORT),
+            "-grpc",
+            str(GRPC_PORT),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    log.info(f"Emulator PID {proc.pid}, console port {CONSOLE_PORT}")
+
+    try:
+        wait_boot(timeout=300)
+        patch_setup_to_ignore_errors()
+
+        log.info("Running AndroidWorld emulator_setup=True ...")
+        from android_world.env import env_launcher
+
+        android_env = env_launcher.load_and_setup_env(
+            console_port=CONSOLE_PORT,
+            grpc_port=GRPC_PORT,
+            emulator_setup=True,
+            freeze_datetime=True,
+            adb_path=ADB,
+        )
+        log.info("Setup complete.")
+        android_env.close()
+    finally:
+        log.info("Shutting down emulator ...")
+        proc.terminate()
+        try:
+            proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+    size = sum(f.stat().st_size for f in avd_dir.rglob("*") if f.is_file())
+    log.info(f"Baked AVD: {avd_dir}  ({size / 1e9:.1f} GB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sandboxes/images/build-androidworld.sh
+++ b/examples/sandboxes/images/build-androidworld.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Build and push the ghcr.io/<org>/androidworld:latest OCI artifact.
+#
+# Pre-bakes an Android AVD (Android Virtual Device) with all 20 AndroidWorld
+# apps installed, then pushes it as a multi-arch OCI artifact to GHCR so that:
+#   Image.from_registry("ghcr.io/<org>/androidworld:latest")
+# boots natively with HVF (Apple Silicon) or KVM/HAXM (x86_64) — no Docker.
+#
+# Prerequisites
+# -------------
+#   - Android SDK installed to ~/.cua/android-sdk  (auto-installed if missing)
+#   - Java (brew install openjdk on macOS)
+#   - android_world source at /tmp/android_world
+#       git clone https://github.com/google-research/android_world /tmp/android_world
+#   - A Python venv with android_world deps:
+#       uv venv /tmp/aw-venv --python 3.12
+#       uv pip install --python /tmp/aw-venv/bin/python 'setuptools<74' grpcio-tools==1.71.0 protobuf==5.29.5
+#       /tmp/aw-venv/bin/python -c "
+#         import sys, os; sys.path.insert(0, '/tmp/android_world')
+#         from grpc_tools import protoc; import pkg_resources
+#         root = '/tmp/android_world'
+#         grpc_inc = pkg_resources.resource_filename('grpc_tools', '_proto')
+#         for proto in ['android_world/task_evals/information_retrieval/proto/state.proto',
+#                       'android_world/task_evals/information_retrieval/proto/task.proto']:
+#             protoc.main(['grpc_tools.protoc', f'--proto_path={grpc_inc}', f'--proto_path={root}',
+#                          f'--python_out={root}', f'--grpc_python_out={root}', os.path.join(root, proto)])
+#       "
+#       uv pip install --python /tmp/aw-venv/bin/python \
+#           absl-py dm-env grpcio==1.71.0 lxml Pillow numpy opencv-python-headless fastapi uvicorn httpx
+#   - GITHUB_TOKEN with write:packages scope  (export GITHUB_TOKEN=$(gh auth token))
+#   - GITHUB_USERNAME set to your GitHub username
+#
+# Usage
+# -----
+#   export GITHUB_TOKEN=$(gh auth token)
+#   export GITHUB_USERNAME=<your-github-username>
+#   bash build-androidworld.sh
+#
+#   # Push only (AVD already baked at ~/.cua/android-avd/androidworld.avd):
+#   bash build-androidworld.sh --push-only
+#
+#   # Bake only (no push):
+#   bash build-androidworld.sh --bake-only
+#
+#   # Specify arch (default: auto-detect from host):
+#   bash build-androidworld.sh --arch amd64
+#
+# Multi-arch
+# ----------
+# Run on Apple Silicon for arm64, then on x86_64 Linux with --arch amd64.
+# Both pushes update the same manifest index at :latest.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+: "${GITHUB_USERNAME:?Set GITHUB_USERNAME to your GitHub username}"
+: "${GITHUB_TOKEN:?Set GITHUB_TOKEN (gh auth token) before pushing}"
+
+ORG="${REGISTRY_ORG:-trycua}"
+REF="ghcr.io/${ORG}/androidworld:latest"
+AVD_NAME="androidworld"
+AVD_HOME="${HOME}/.cua/android-avd"
+AVD_DIR="${AVD_HOME}/${AVD_NAME}.avd"
+AW_SOURCE_DIR="${AW_SOURCE_DIR:-/tmp/android_world}"
+AW_VENV="${AW_VENV:-/tmp/aw-venv}"
+ARCH="${ARCH:-}"
+BAKE_ONLY=false
+PUSH_ONLY=false
+
+for arg in "$@"; do
+  case $arg in
+    --bake-only) BAKE_ONLY=true ;;
+    --push-only) PUSH_ONLY=true ;;
+    --arch=*) ARCH="${arg#--arch=}" ;;
+    --arch) shift; ARCH="${1:-}" ;;
+  esac
+done
+
+# ── Step 1: Bake ─────────────────────────────────────────────────────────────
+if [ "$PUSH_ONLY" != "true" ]; then
+  echo "==> Baking AndroidWorld AVD (~15-30 min) ..."
+  AW_SOURCE_DIR="$AW_SOURCE_DIR" AW_VENV="$AW_VENV" \
+    "$AW_VENV/bin/python" "${SCRIPT_DIR}/bake_androidworld_avd.py"
+  echo "==> Bake complete: ${AVD_DIR}"
+fi
+
+# ── Step 2: Push ─────────────────────────────────────────────────────────────
+if [ "$BAKE_ONLY" != "true" ]; then
+  echo "==> Pushing ${AVD_DIR} → ${REF}${ARCH:+ (arch=${ARCH})} ..."
+
+  PUSH_ARGS=(--avd-dir "$AVD_DIR" --ref "$REF" --agent-type androidworld)
+  [ -n "$ARCH" ] && PUSH_ARGS+=(--arch "$ARCH")
+
+  source "${REPO_ROOT}/libs/python/cua-sandbox/.venv/bin/activate"
+
+  ORAS_USERNAME="$GITHUB_USERNAME" ORAS_PASSWORD="$GITHUB_TOKEN" \
+    python -m cua_sandbox.registry.avd_builder push "${PUSH_ARGS[@]}"
+
+  echo "==> Done: ${REF}"
+fi

--- a/examples/sandboxes/images/build-osworld.sh
+++ b/examples/sandboxes/images/build-osworld.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 # Build and push the ghcr.io/<org>/osworld:latest OCI artifact.
 #
-# Downloads the OSWorld Ubuntu qcow2 from HuggingFace, then pushes it as an
-# OCI artifact annotated with agent_type=osworld so that:
+# Downloads the OSWorld Ubuntu disk(s) from HuggingFace, converts if needed,
+# and pushes as a multi-arch OCI artifact so that:
 #   Image.from_registry("ghcr.io/<org>/osworld:latest")
-# auto-selects the OSWorld Flask transport without any explicit override.
+# auto-selects the OSWorld Flask transport and runs natively accelerated on
+# both x86_64 (KVM) and Apple Silicon (HVF).
+#
+# x86_64 image : Ubuntu.qcow2.zip  — already qcow2, use directly
+# aarch64 image: Ubuntu-arm.zip    — VMware format, converted via qemu-img
 #
 # Prerequisites
 # -------------
@@ -16,10 +20,19 @@
 # -----
 #   export GITHUB_TOKEN=$(gh auth token)
 #   export GITHUB_USERNAME=<your-github-username>
-#   bash build-osworld.sh
 #
-#   # Use a pre-downloaded qcow2 (skip the ~8 GB download):
-#   OSWORLD_QCOW2=/path/to/Ubuntu.qcow2 bash build-osworld.sh
+#   # Push amd64 (run on any host, uses TCG on Apple Silicon):
+#   bash build-osworld.sh --arch amd64
+#
+#   # Push arm64 (run on Apple Silicon for best conversion speed):
+#   bash build-osworld.sh --arch arm64
+#
+#   # Push both (updates the same manifest index each time):
+#   bash build-osworld.sh --arch amd64
+#   bash build-osworld.sh --arch arm64
+#
+#   # Use a pre-downloaded / pre-converted qcow2 (skip download + conversion):
+#   OSWORLD_QCOW2=/path/to/disk.qcow2 bash build-osworld.sh --arch arm64
 
 set -euo pipefail
 
@@ -31,27 +44,104 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 ORG="${REGISTRY_ORG:-trycua}"
 REF="ghcr.io/${ORG}/osworld:latest"
-OSWORLD_URL="https://huggingface.co/datasets/xlangai/ubuntu_osworld/resolve/main/Ubuntu.qcow2.zip"
 CACHE_DIR="${HOME}/.cua/cua-sandbox/image-cache/osworld"
-QCOW2="${OSWORLD_QCOW2:-${CACHE_DIR}/Ubuntu.qcow2}"
 
+UBUNTU_AMD64_URL="https://huggingface.co/datasets/xlangai/ubuntu_osworld/resolve/main/Ubuntu.qcow2.zip"
+UBUNTU_ARM_URL="https://huggingface.co/datasets/xlangai/ubuntu_osworld/resolve/main/Ubuntu-arm.zip"
+
+# ── Parse args ────────────────────────────────────────────────────────────────
+ARCH=""
+for arg in "$@"; do
+  case $arg in
+    --arch=*) ARCH="${arg#--arch=}" ;;
+    --arch) shift; ARCH="${1:-}" ;;
+  esac
+done
+
+# Default: auto-detect from host
+if [ -z "$ARCH" ]; then
+  HOST_MACHINE="$(uname -m)"
+  if [ "$HOST_MACHINE" = "arm64" ] || [ "$HOST_MACHINE" = "aarch64" ]; then
+    ARCH="arm64"
+  else
+    ARCH="amd64"
+  fi
+fi
+
+echo "==> Building OSWorld image for arch=${ARCH}"
 mkdir -p "$CACHE_DIR"
 
-# ── Step 1: Download if not cached ───────────────────────────────────────────
-if [ ! -f "$QCOW2" ]; then
-  ZIP="${CACHE_DIR}/Ubuntu.qcow2.zip"
-  echo "==> Downloading OSWorld image (~8 GB) ..."
-  curl -L --progress-bar -o "$ZIP" "$OSWORLD_URL"
-  echo "==> Extracting ..."
-  unzip -o "$ZIP" -d "$CACHE_DIR"
-  rm -f "$ZIP"
-  QCOW2="${CACHE_DIR}/Ubuntu.qcow2"
+# ── Step 1: Obtain qcow2 for the requested arch ───────────────────────────────
+QCOW2="${OSWORLD_QCOW2:-}"
+
+if [ "$ARCH" = "amd64" ]; then
+  if [ -z "$QCOW2" ]; then
+    QCOW2="${CACHE_DIR}/Ubuntu-amd64.qcow2"
+    if [ ! -f "$QCOW2" ]; then
+      # Accept older cached name from pre-multi-arch builds
+      if [ -f "${CACHE_DIR}/Ubuntu.qcow2" ]; then
+        QCOW2="${CACHE_DIR}/Ubuntu.qcow2"
+      else
+        ZIP="${CACHE_DIR}/Ubuntu.qcow2.zip"
+        echo "==> Downloading OSWorld x86_64 image (~8 GB) ..."
+        curl -L --progress-bar -o "$ZIP" "$UBUNTU_AMD64_URL"
+        echo "==> Extracting ..."
+        # ZIP64 format — use ditto on macOS, unzip on Linux
+        if command -v ditto &>/dev/null; then
+          ditto -xk "$ZIP" "$CACHE_DIR"
+        else
+          unzip -o "$ZIP" -d "$CACHE_DIR"
+        fi
+        rm -f "$ZIP"
+        [ -f "${CACHE_DIR}/Ubuntu.qcow2" ] && mv "${CACHE_DIR}/Ubuntu.qcow2" "$QCOW2"
+      fi
+    fi
+  fi
+elif [ "$ARCH" = "arm64" ]; then
+  if [ -z "$QCOW2" ]; then
+    QCOW2="${CACHE_DIR}/Ubuntu-arm64.qcow2"
+    if [ ! -f "$QCOW2" ]; then
+      ZIP="${CACHE_DIR}/Ubuntu-arm.zip"
+      echo "==> Downloading OSWorld ARM image ..."
+      curl -L --progress-bar -o "$ZIP" "$UBUNTU_ARM_URL"
+      echo "==> Extracting VMware archive ..."
+      EXTRACT_DIR="${CACHE_DIR}/Ubuntu-arm-extracted"
+      mkdir -p "$EXTRACT_DIR"
+      if command -v ditto &>/dev/null; then
+        ditto -xk "$ZIP" "$EXTRACT_DIR"
+      else
+        unzip -o "$ZIP" -d "$EXTRACT_DIR"
+      fi
+      rm -f "$ZIP"
+
+      # Find the VMware disk file — .vmdk or possibly already .qcow2
+      VMDK=$(find "$EXTRACT_DIR" -name "*.vmdk" | head -1)
+      RAW_QCOW2=$(find "$EXTRACT_DIR" -name "*.qcow2" | head -1)
+
+      if [ -n "$RAW_QCOW2" ]; then
+        echo "==> Found qcow2 directly: ${RAW_QCOW2}"
+        mv "$RAW_QCOW2" "$QCOW2"
+        rm -rf "$EXTRACT_DIR"
+      elif [ -n "$VMDK" ]; then
+        echo "==> Converting VMware disk to qcow2: $(basename "$VMDK") → Ubuntu-arm64.qcow2 ..."
+        qemu-img convert -p -f vmdk -O qcow2 "$VMDK" "$QCOW2"
+        rm -rf "$EXTRACT_DIR"
+      else
+        echo "ERROR: Could not find a .vmdk or .qcow2 inside ${EXTRACT_DIR}"
+        ls -la "$EXTRACT_DIR"
+        exit 1
+      fi
+    fi
+  fi
+else
+  echo "ERROR: Unknown arch '${ARCH}'. Use --arch amd64 or --arch arm64."
+  exit 1
 fi
 
 echo "==> Source: ${QCOW2} ($(du -sh "$QCOW2" | cut -f1))"
 
 # ── Step 2: Push to GHCR ─────────────────────────────────────────────────────
-echo "==> Pushing → ${REF} ..."
+echo "==> Pushing → ${REF} (arch=${ARCH}) ..."
 
 source "${REPO_ROOT}/libs/python/cua-sandbox/.venv/bin/activate"
 
@@ -64,6 +154,7 @@ ORAS_USERNAME="$GITHUB_USERNAME" ORAS_PASSWORD="$GITHUB_TOKEN" \
     --guest-os linux \
     --cpu 4 \
     --ram-mb 8192 \
-    --disk-size-gb 64
+    --disk-size-gb 64 \
+    --arch "$ARCH"
 
-echo "==> Done: ${REF}"
+echo "==> Done: ${REF} (arch=${ARCH})"

--- a/examples/sandboxes/images/build-osworld.sh
+++ b/examples/sandboxes/images/build-osworld.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Build and push the ghcr.io/<org>/osworld:latest OCI artifact.
+#
+# Downloads the OSWorld Ubuntu qcow2 from HuggingFace, then pushes it as an
+# OCI artifact annotated with agent_type=osworld so that:
+#   Image.from_registry("ghcr.io/<org>/osworld:latest")
+# auto-selects the OSWorld Flask transport without any explicit override.
+#
+# Prerequisites
+# -------------
+#   - qemu-img in PATH  (brew install qemu on macOS; apt install qemu-utils on Linux)
+#   - GITHUB_TOKEN with write:packages scope  (export GITHUB_TOKEN=$(gh auth token))
+#   - GITHUB_USERNAME set to your GitHub username
+#
+# Usage
+# -----
+#   export GITHUB_TOKEN=$(gh auth token)
+#   export GITHUB_USERNAME=<your-github-username>
+#   bash build-osworld.sh
+#
+#   # Use a pre-downloaded qcow2 (skip the ~8 GB download):
+#   OSWORLD_QCOW2=/path/to/Ubuntu.qcow2 bash build-osworld.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+: "${GITHUB_USERNAME:?Set GITHUB_USERNAME to your GitHub username}"
+: "${GITHUB_TOKEN:?Set GITHUB_TOKEN (gh auth token) before pushing}"
+
+ORG="${REGISTRY_ORG:-trycua}"
+REF="ghcr.io/${ORG}/osworld:latest"
+OSWORLD_URL="https://huggingface.co/datasets/xlangai/ubuntu_osworld/resolve/main/Ubuntu.qcow2.zip"
+CACHE_DIR="${HOME}/.cua/cua-sandbox/image-cache/osworld"
+QCOW2="${OSWORLD_QCOW2:-${CACHE_DIR}/Ubuntu.qcow2}"
+
+mkdir -p "$CACHE_DIR"
+
+# ── Step 1: Download if not cached ───────────────────────────────────────────
+if [ ! -f "$QCOW2" ]; then
+  ZIP="${CACHE_DIR}/Ubuntu.qcow2.zip"
+  echo "==> Downloading OSWorld image (~8 GB) ..."
+  curl -L --progress-bar -o "$ZIP" "$OSWORLD_URL"
+  echo "==> Extracting ..."
+  unzip -o "$ZIP" -d "$CACHE_DIR"
+  rm -f "$ZIP"
+  QCOW2="${CACHE_DIR}/Ubuntu.qcow2"
+fi
+
+echo "==> Source: ${QCOW2} ($(du -sh "$QCOW2" | cut -f1))"
+
+# ── Step 2: Push to GHCR ─────────────────────────────────────────────────────
+echo "==> Pushing → ${REF} ..."
+
+source "${REPO_ROOT}/libs/python/cua-sandbox/.venv/bin/activate"
+
+ORAS_USERNAME="$GITHUB_USERNAME" ORAS_PASSWORD="$GITHUB_TOKEN" \
+  python -m cua_sandbox.registry.push \
+    --ref "$REF" \
+    --source "$QCOW2" \
+    --kind vm \
+    --agent-type osworld \
+    --guest-os linux \
+    --cpu 4 \
+    --ram-mb 8192 \
+    --disk-size-gb 64
+
+echo "==> Done: ${REF}"

--- a/examples/sandboxes/images/build-osworld.sh
+++ b/examples/sandboxes/images/build-osworld.sh
@@ -124,8 +124,12 @@ elif [ "$ARCH" = "arm64" ]; then
       fi
       rm -f "$ZIP"
 
-      # Find the VMware disk file — .vmdk or possibly already .qcow2
-      VMDK=$(find "$EXTRACT_DIR" -name "*.vmdk" | head -1)
+      # Find the VMware disk descriptor (the non-split .vmdk, not -sNNN.vmdk)
+      # Split VMDKs have a small descriptor file (e.g. "Virtual Disk.vmdk") that
+      # references the extents; qemu-img needs the descriptor, not a split piece.
+      VMDK=$(find "$EXTRACT_DIR" -name "*.vmdk" ! -name "*-s[0-9]*.vmdk" | head -1)
+      # Fall back to any .vmdk if no descriptor found
+      [ -z "$VMDK" ] && VMDK=$(find "$EXTRACT_DIR" -name "*.vmdk" | head -1)
       RAW_QCOW2=$(find "$EXTRACT_DIR" -name "*.qcow2" | head -1)
 
       if [ -n "$RAW_QCOW2" ]; then

--- a/examples/sandboxes/images/build-osworld.sh
+++ b/examples/sandboxes/images/build-osworld.sh
@@ -39,6 +39,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
+# Locate qemu-img (brew, system, or bundled with Android SDK emulator)
+QEMU_IMG="qemu-img"
+for _candidate in \
+    "$(command -v qemu-img 2>/dev/null)" \
+    "/opt/homebrew/bin/qemu-img" \
+    "/usr/local/bin/qemu-img" \
+    "${HOME}/.cua/android-sdk/emulator/qemu-img"; do
+  [ -x "$_candidate" ] && { QEMU_IMG="$_candidate"; break; }
+done
+
 : "${GITHUB_USERNAME:?Set GITHUB_USERNAME to your GitHub username}"
 : "${GITHUB_TOKEN:?Set GITHUB_TOKEN (gh auth token) before pushing}"
 
@@ -124,7 +134,7 @@ elif [ "$ARCH" = "arm64" ]; then
         rm -rf "$EXTRACT_DIR"
       elif [ -n "$VMDK" ]; then
         echo "==> Converting VMware disk to qcow2: $(basename "$VMDK") → Ubuntu-arm64.qcow2 ..."
-        qemu-img convert -p -f vmdk -O qcow2 "$VMDK" "$QCOW2"
+        "$QEMU_IMG" convert -p -f vmdk -O qcow2 "$VMDK" "$QCOW2"
         rm -rf "$EXTRACT_DIR"
       else
         echo "ERROR: Could not find a .vmdk or .qcow2 inside ${EXTRACT_DIR}"

--- a/examples/sandboxes/test_android_local_androidworld_vm.py
+++ b/examples/sandboxes/test_android_local_androidworld_vm.py
@@ -1,0 +1,150 @@
+"""Run an AndroidWorld benchmark image with the Cua Sandbox SDK.
+
+AndroidWorld is a benchmark of 116 tasks across 20 real Android apps, backed by
+a live Android emulator. This example shows how to:
+
+  1. Boot an AndroidWorld container/VM image
+  2. Pick a task and retrieve its natural-language goal
+  3. Run a minimal agent loop (screenshot → action → score)
+  4. Score the result
+
+--- Local container image (built from google-research/android_world Dockerfile) ---
+
+    image = Image.from_file(
+        "path/to/androidworld.qcow2",
+        os_type="android",
+        agent_type="androidworld",
+    )
+    async with Sandbox.ephemeral(image, local=True) as sb:
+        ...
+
+--- Registry image (agent_type resolved from manifest annotation) ---
+
+    image = Image.from_registry("ghcr.io/trycua/androidworld:latest")
+    async with Sandbox.ephemeral(image, local=True) as sb:
+        ...
+
+The AndroidWorldTransport exposes the full AndroidWorld task lifecycle:
+  sb.androidworld.initialize_task(task_type, task_idx)
+  sb.androidworld.get_task_goal(task_type, task_idx)
+  sb.androidworld.execute_action({...})
+  sb.androidworld.get_task_score(task_type, task_idx)
+  sb.androidworld.tear_down_task(task_type, task_idx)
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from cua_sandbox import Image, Sandbox
+
+pytestmark = pytest.mark.asyncio
+
+# Replace with ghcr.io/trycua/androidworld:latest once the image is published.
+# For local testing: build from /tmp/android_world/Dockerfile and push to GHCR,
+# or point at a local qcow2 disk image.
+ANDROIDWORLD_IMAGE_REF = "ghcr.io/trycua/androidworld:latest"
+
+# Task to run in the demo. Any key from the android_world suite works.
+DEMO_TASK = "ContactsAddContact"
+DEMO_TASK_IDX = 0
+
+
+def _has_androidworld_image() -> bool:
+    """True if the registry image is reachable (basic connectivity check)."""
+    try:
+        from cua_sandbox.registry.manifest import get_manifest
+
+        get_manifest(ANDROIDWORLD_IMAGE_REF)
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(
+    not _has_androidworld_image(),
+    reason="AndroidWorld registry image not reachable",
+)
+async def test_android_local_androidworld_vm():
+    image = Image.from_registry(ANDROIDWORLD_IMAGE_REF)
+
+    async with Sandbox.ephemeral(image, local=True) as sb:
+        # Verify the server is healthy
+        transport = sb._transport  # AndroidWorldTransport
+        assert await transport.health(), "AndroidWorld server not healthy"
+
+        # List available tasks
+        task_list = await transport.suite_task_list()
+        assert DEMO_TASK in task_list, f"{DEMO_TASK} not found in suite: {task_list[:5]}"
+
+        # Initialize the task (sets up device state and app snapshots)
+        await transport.initialize_task(DEMO_TASK, DEMO_TASK_IDX)
+
+        # Get the natural-language goal
+        goal = await transport.get_task_goal(DEMO_TASK, DEMO_TASK_IDX)
+        assert goal, "Expected a non-empty goal string"
+        print(f"Task goal: {goal}")
+
+        # Take a screenshot
+        screenshot = await sb.screenshot()
+        assert screenshot[:4] == b"\x89PNG", "Expected PNG screenshot"
+        print(f"Screenshot: {len(screenshot)} bytes")
+
+        # Simulate one agent action (tap the center of the screen)
+        screen_size = await sb.get_dimensions()
+        cx, cy = screen_size[0] // 2, screen_size[1] // 2
+        await transport.execute_action({"action_type": "click", "x": cx, "y": cy})
+
+        # Score the task (0.0 = fail, 1.0 = success)
+        score = await transport.get_task_score(DEMO_TASK, DEMO_TASK_IDX)
+        print(f"Score after 1 step: {score}")
+
+        # Tear down (restores app snapshots)
+        await transport.tear_down_task(DEMO_TASK, DEMO_TASK_IDX)
+
+
+async def main():
+    """Interactive demo — boots the image and runs a full task loop."""
+    image = Image.from_registry(ANDROIDWORLD_IMAGE_REF)
+
+    async with Sandbox.ephemeral(image, local=True, name="androidworld-demo") as sb:
+        transport = sb._transport
+
+        # List tasks
+        task_list = await transport.suite_task_list()
+        print(f"Suite has {len(task_list)} tasks. First 5: {task_list[:5]}")
+
+        task_type = task_list[0]
+        task_idx = 0
+
+        # Initialize
+        await transport.initialize_task(task_type, task_idx)
+        goal = await transport.get_task_goal(task_type, task_idx)
+        print(f"\nRunning task: {task_type}[{task_idx}]")
+        print(f"Goal: {goal}")
+
+        # Minimal agent loop — replace with your agent
+        max_steps = 10
+        for step in range(max_steps):
+            screenshot = await sb.screenshot()
+            with open(f"/tmp/androidworld_step_{step:02d}.png", "wb") as f:
+                f.write(screenshot)
+            print(f"Step {step + 1}: screenshot saved ({len(screenshot)} bytes)")
+
+            # TODO: run your agent here to produce an action dict
+            # action = await my_agent.step(goal, screenshot)
+            # await transport.execute_action(action)
+
+            score = await transport.get_task_score(task_type, task_idx)
+            print(f"  score: {score}")
+            if score >= 1.0:
+                print("Task completed successfully!")
+                break
+
+        await transport.tear_down_task(task_type, task_idx)
+        print("Done.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/sandboxes/test_android_local_androidworld_vm.py
+++ b/examples/sandboxes/test_android_local_androidworld_vm.py
@@ -3,26 +3,29 @@
 AndroidWorld is a benchmark of 116 tasks across 20 real Android apps, backed by
 a live Android emulator. This example shows how to:
 
-  1. Boot an AndroidWorld container/VM image
+  1. Boot an AndroidWorld AVD image (pre-baked OCI artifact on GHCR)
   2. Pick a task and retrieve its natural-language goal
   3. Run a minimal agent loop (screenshot → action → score)
   4. Score the result
-
---- Local container image (built from google-research/android_world Dockerfile) ---
-
-    image = Image.from_file(
-        "path/to/androidworld.qcow2",
-        os_type="android",
-        agent_type="androidworld",
-    )
-    async with Sandbox.ephemeral(image, local=True) as sb:
-        ...
 
 --- Registry image (agent_type resolved from manifest annotation) ---
 
     image = Image.from_registry("ghcr.io/trycua/androidworld:latest")
     async with Sandbox.ephemeral(image, local=True) as sb:
         ...
+
+The image is a pre-baked Android AVD (not a Docker container). The
+AndroidEmulatorRuntime pulls the AVD from GHCR, boots the native emulator
+with HVF acceleration (Apple Silicon) or KVM/HAXM (x86_64), then launches
+the AndroidWorld FastAPI server on the host.
+
+Prerequisites
+-------------
+android_world must be importable by the server process. If it lives outside
+the cua-sandbox virtualenv, set these env vars before running:
+
+    export AW_PYTHON=/path/to/aw-venv/bin/python   # venv that has android_world
+    export AW_SOURCE_DIR=/tmp/android_world          # OR: source-checkout path
 
 The AndroidWorldTransport exposes the full AndroidWorld task lifecycle:
   sb.androidworld.initialize_task(task_type, task_idx)

--- a/examples/sandboxes/test_linux_local_osworld_registry_vm.py
+++ b/examples/sandboxes/test_linux_local_osworld_registry_vm.py
@@ -1,0 +1,249 @@
+"""Run the OSWorld benchmark image pulled from the OCI registry.
+
+The image is a pre-built Ubuntu qcow2 pushed to GHCR with agent_type=osworld
+so Image.from_registry() auto-detects it — no explicit agent_type= needed.
+
+    image = Image.from_registry("ghcr.io/trycua/osworld:latest")
+    async with Sandbox.ephemeral(image, local=True) as sb:
+        transport = sb._transport  # OSWorldTransport
+        ...
+
+The OSWorld Flask server runs inside the VM (port 5000) and handles screen
+capture, shell commands, and task setup steps. Evaluation is host-side via
+the osworld Python package (desktop_env.controllers, desktop_env.evaluators).
+
+Prerequisites
+-------------
+  GITHUB_TOKEN with read:packages scope — for pulling the OCI image.
+
+  osworld is NOT required in the cua-sandbox venv.  Set one of:
+    export OSWORLD_SOURCE_DIR=/tmp/osworld   # source checkout
+    # OR: pip install osworld in a separate venv and set:
+    # export OSWORLD_PYTHON=/path/to/venv/bin/python  (future)
+
+  The image itself ships the Flask server — nothing extra to install.
+
+  To push the image first (one-time, maintainers only):
+    bash examples/sandboxes/images/build-osworld.sh
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pytest
+from cua_sandbox import Image, Sandbox
+
+pytestmark = pytest.mark.asyncio
+
+OSWORLD_IMAGE_REF = "ghcr.io/trycua/osworld:latest"
+
+# Small test suite — pick one task per category so the test runs quickly.
+# IDs from evaluation_examples/test_small.json.
+DEMO_TASK_ID = "bb5e4c0d-f964-439c-97b6-bdb9747de3f4"  # chrome: set Bing as default search
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _has_osworld_image() -> bool:
+    """True if the registry image is reachable."""
+    try:
+        from cua_sandbox.registry.manifest import get_manifest
+
+        get_manifest(OSWORLD_IMAGE_REF)
+        return True
+    except Exception:
+        return False
+
+
+def _has_qemu() -> bool:
+    try:
+        from cua_sandbox.runtime.qemu_installer import qemu_bin
+
+        qemu_bin("x86_64")
+        return True
+    except Exception:
+        return False
+
+
+def _load_task_config(task_id: str, osworld_dir: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    """Load a task config JSON from the OSWorld evaluation_examples directory.
+
+    Searches:
+      1. OSWORLD_SOURCE_DIR env var
+      2. osworld_dir argument
+      3. /tmp/osworld (default clone location)
+    """
+    search_dirs = [
+        os.environ.get("OSWORLD_SOURCE_DIR", ""),
+        osworld_dir or "",
+        "/tmp/osworld",
+    ]
+    for base in search_dirs:
+        if not base:
+            continue
+        examples_root = Path(base) / "evaluation_examples" / "examples"
+        if not examples_root.exists():
+            continue
+        for json_path in examples_root.rglob(f"{task_id}.json"):
+            with open(json_path) as f:
+                return json.load(f)
+    return None
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(not _has_qemu(), reason="QEMU not available")
+@pytest.mark.skipif(not _has_osworld_image(), reason="OSWorld registry image not reachable")
+async def test_linux_local_osworld_registry_vm():
+    """Boot the OSWorld registry image, take a screenshot, run a shell command."""
+    image = Image.from_registry(OSWORLD_IMAGE_REF)
+
+    async with Sandbox.ephemeral(image, local=True) as sb:
+        transport = sb._transport  # OSWorldTransport
+
+        # Basic sanity: screenshot
+        screenshot = await sb.screenshot()
+        assert screenshot[:4] == b"\x89PNG", "Expected PNG screenshot"
+        print(f"Screenshot: {len(screenshot)} bytes")
+
+        # Screen dimensions (OSWorld images are 1920x1080)
+        size = await transport.get_screen_size()
+        assert size["width"] == 1920 and size["height"] == 1080, f"Unexpected size: {size}"
+
+        # Shell execution via /execute
+        result = await transport.send("execute", command=["uname", "-a"], shell=False)
+        assert result.get("returncode") == 0
+        print(f"uname: {result.get('output', '').strip()}")
+
+
+@pytest.mark.skipif(not _has_qemu(), reason="QEMU not available")
+@pytest.mark.skipif(not _has_osworld_image(), reason="OSWorld registry image not reachable")
+async def test_linux_local_osworld_task_setup():
+    """Boot the OSWorld image, load a task config, run setup steps, take screenshot."""
+    osworld_dir = os.environ.get("OSWORLD_SOURCE_DIR", "/tmp/osworld")
+    task_config = _load_task_config(DEMO_TASK_ID, osworld_dir)
+
+    if task_config is None:
+        pytest.skip(
+            f"OSWorld task {DEMO_TASK_ID} not found. "
+            "Clone OSWorld to /tmp/osworld or set OSWORLD_SOURCE_DIR."
+        )
+
+    image = Image.from_registry(OSWORLD_IMAGE_REF)
+
+    async with Sandbox.ephemeral(image, local=True) as sb:
+        transport = sb._transport  # OSWorldTransport
+
+        print(f"Task: {task_config['instruction']}")
+
+        # Save a clean-state snapshot before the first task
+        # (skip if no QMP port — e.g. running without bare-metal runtime)
+        if transport._qmp_port:
+            await transport.save_snapshot()
+
+        # Run task setup steps on the VM (launches Chrome, etc.)
+        await transport.setup_task(task_config)
+
+        # Take a screenshot after setup — should show the app launched
+        screenshot = await sb.screenshot()
+        assert screenshot[:4] == b"\x89PNG"
+        print(f"Post-setup screenshot: {len(screenshot)} bytes")
+
+        # Save screenshot for inspection
+        out = Path("/tmp/osworld_task_setup.png")
+        out.write_bytes(screenshot)
+        print(f"Saved to {out}")
+
+
+@pytest.mark.skipif(not _has_qemu(), reason="QEMU not available")
+@pytest.mark.skipif(not _has_osworld_image(), reason="OSWorld registry image not reachable")
+async def test_linux_local_osworld_full_loop():
+    """Full OSWorld task loop: setup → agent step → evaluate.
+
+    Requires osworld importable on the host (OSWORLD_SOURCE_DIR or installed).
+    The score will be 0.0 since no real agent runs — this validates the pipeline.
+    """
+    osworld_dir = os.environ.get("OSWORLD_SOURCE_DIR", "/tmp/osworld")
+    task_config = _load_task_config(DEMO_TASK_ID, osworld_dir)
+
+    if task_config is None:
+        pytest.skip("OSWorld task JSON not found — set OSWORLD_SOURCE_DIR")
+
+    try:
+        import sys
+
+        if osworld_dir and osworld_dir not in sys.path:
+            sys.path.insert(0, osworld_dir)
+        import desktop_env  # noqa: F401
+    except ImportError:
+        pytest.skip(
+            "osworld (desktop_env) not importable. "
+            "Clone OSWorld to /tmp/osworld or set OSWORLD_SOURCE_DIR."
+        )
+
+    image = Image.from_registry(OSWORLD_IMAGE_REF)
+
+    async with Sandbox.ephemeral(image, local=True) as sb:
+        transport = sb._transport  # OSWorldTransport
+
+        print(f"Task: {task_config['instruction']}")
+
+        # Setup
+        await transport.setup_task(task_config)
+
+        screenshot = await sb.screenshot()
+        print(f"Screenshot: {len(screenshot)} bytes")
+
+        # (Agent would act here)
+
+        # Evaluate — score = 0.0 since we took no action
+        score = await transport.evaluate_task(task_config, osworld_source_dir=osworld_dir)
+        print(f"Score: {score}")
+        assert 0.0 <= score <= 1.0
+
+
+# ── Interactive main ──────────────────────────────────────────────────────────
+
+
+async def main():
+    """Interactive demo — boots the image, runs a task, prints score."""
+    osworld_dir = os.environ.get("OSWORLD_SOURCE_DIR", "/tmp/osworld")
+    task_config = _load_task_config(DEMO_TASK_ID, osworld_dir)
+
+    if task_config is None:
+        print(
+            "OSWorld task JSON not found.\n"
+            "Clone OSWorld: git clone --depth=1 https://github.com/xlang-ai/OSWorld /tmp/osworld\n"
+            "Or set: export OSWORLD_SOURCE_DIR=/path/to/osworld"
+        )
+        return
+
+    image = Image.from_registry(OSWORLD_IMAGE_REF)
+
+    async with Sandbox.ephemeral(image, local=True, name="osworld-demo") as sb:
+        transport = sb._transport
+
+        print(f"Task: {task_config['instruction']}")
+        await transport.setup_task(task_config)
+
+        screenshot = await sb.screenshot()
+        Path("/tmp/osworld_demo.png").write_bytes(screenshot)
+        print(f"Screenshot saved ({len(screenshot)} bytes) → /tmp/osworld_demo.png")
+
+        # TODO: run your agent here
+        # action = await my_agent.step(task_config["instruction"], screenshot)
+        # await transport.send("execute", command=action)
+
+        score = await transport.evaluate_task(task_config, osworld_source_dir=osworld_dir)
+        print(f"Final score: {score}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/sandboxes/test_linux_local_osworld_registry_vm.py
+++ b/examples/sandboxes/test_linux_local_osworld_registry_vm.py
@@ -113,9 +113,10 @@ async def test_linux_local_osworld_registry_vm():
         assert screenshot[:4] == b"\x89PNG", "Expected PNG screenshot"
         print(f"Screenshot: {len(screenshot)} bytes")
 
-        # Screen dimensions (OSWorld images are 1920x1080)
+        # Screen dimensions — x86_64 image is 1920×1080; arm64 virtio-gpu defaults to 1280×800
         size = await transport.get_screen_size()
-        assert size["width"] == 1920 and size["height"] == 1080, f"Unexpected size: {size}"
+        assert size["width"] >= 800 and size["height"] >= 600, f"Unexpected size: {size}"
+        print(f"Screen size: {size['width']}x{size['height']}")
 
         # Shell execution via /execute
         result = await transport.send("execute", command=["uname", "-a"], shell=False)

--- a/libs/python/cua-sandbox/cua_sandbox/_androidworld_server.py
+++ b/libs/python/cua-sandbox/cua_sandbox/_androidworld_server.py
@@ -1,0 +1,229 @@
+"""Configurable AndroidWorld FastAPI server launcher.
+
+This is cua-sandbox's entry point for the AndroidWorld server. It reads
+configuration from environment variables so that AndroidEmulatorRuntime can
+start it as a subprocess with the right ADB serial, gRPC port, and setup flags.
+
+Environment variables
+---------------------
+AW_CONSOLE_PORT     Android emulator console port (default: 5554)
+AW_GRPC_PORT        emulator gRPC port (default: AW_CONSOLE_PORT + 3000)
+AW_ADB_PATH         path to adb binary (default: auto-detect from SDK)
+AW_EMULATOR_SETUP   "true" to run full app install (default: "false")
+                    Set to "true" only when baking a fresh AVD.
+AW_FREEZE_DATETIME  "true" to freeze device clock to Oct 2023 (default: "true")
+AW_PORT             port for this FastAPI server to listen on (default: 5000)
+AW_HOST             bind host (default: 0.0.0.0)
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import typing
+from typing import Any
+
+import fastapi
+import pydantic
+import uvicorn
+from android_world import registry as aw_registry_module
+from android_world import suite_utils
+from android_world.env import env_launcher, interface, json_action
+
+
+def _env_int(key: str, default: int) -> int:
+    val = os.environ.get(key, "")
+    return int(val) if val.strip().isdigit() else default
+
+
+def _env_bool(key: str, default: bool) -> bool:
+    val = os.environ.get(key, "").strip().lower()
+    if val in ("1", "true", "yes"):
+        return True
+    if val in ("0", "false", "no"):
+        return False
+    return default
+
+
+def _adb_path() -> str:
+    explicit = os.environ.get("AW_ADB_PATH", "").strip()
+    if explicit:
+        return explicit
+    # Try to find adb in the cua SDK location
+    from pathlib import Path
+
+    candidates = [
+        Path.home() / ".cua" / "android-sdk" / "platform-tools" / "adb",
+        Path("/opt/android/platform-tools/adb"),
+    ]
+    for c in candidates:
+        if c.exists():
+            return str(c)
+    import shutil
+
+    found = shutil.which("adb")
+    return found or "adb"
+
+
+class StateResponse(pydantic.BaseModel):
+    pixels: list[int]
+    ui_elements: list[Any]
+
+
+@contextlib.asynccontextmanager
+async def lifespan(fast_api_app: fastapi.FastAPI):
+    console_port = _env_int("AW_CONSOLE_PORT", 5554)
+    grpc_port = _env_int("AW_GRPC_PORT", console_port + 3000)
+    adb_path = _adb_path()
+    emulator_setup = _env_bool("AW_EMULATOR_SETUP", False)
+    freeze_datetime = _env_bool("AW_FREEZE_DATETIME", True)
+
+    fast_api_app.state.app_android_env = env_launcher.load_and_setup_env(
+        console_port=console_port,
+        grpc_port=grpc_port,
+        emulator_setup=emulator_setup,
+        freeze_datetime=freeze_datetime,
+        adb_path=adb_path,
+    )
+    task_registry = aw_registry_module.TaskRegistry()
+    aw_registry = task_registry.get_registry(task_registry.ANDROID_WORLD_FAMILY)
+    initial_suite = suite_utils.create_suite(
+        task_registry=aw_registry,
+        n_task_combinations=2,
+        seed=42,
+    )
+    fast_api_app.state.suite = initial_suite
+    fast_api_app.state.task_registry = task_registry
+    yield
+    if fast_api_app.state.app_android_env is not None:
+        fast_api_app.state.app_android_env.close()
+
+
+app = fastapi.FastAPI(lifespan=lifespan)
+suite_router = fastapi.APIRouter(prefix="/suite", tags=["suite"])
+task_router = fastapi.APIRouter(prefix="/task", tags=["task"])
+
+
+def get_app_android_env(request: fastapi.Request) -> interface.AsyncEnv:
+    return request.app.state.app_android_env
+
+
+def get_app_suite(request: fastapi.Request) -> suite_utils.Suite:
+    return request.app.state.suite
+
+
+AndroidEnv = typing.Annotated[interface.AsyncEnv, fastapi.Depends(get_app_android_env)]
+AndroidSuite = typing.Annotated[suite_utils.Suite, fastapi.Depends(get_app_suite)]
+
+
+@app.post("/reset")
+async def reset(go_home: bool, app_android_env: AndroidEnv):
+    app_android_env.reset(go_home=go_home)
+    return {"status": "success", "message": f"Environment reset with go_home={go_home}."}
+
+
+@app.get("/screenshot")
+async def get_screenshot(wait_to_stabilize: bool, app_android_env: AndroidEnv):
+    state = app_android_env.get_state(wait_to_stabilize=wait_to_stabilize)
+    return {"pixels": state.pixels.tolist()}
+
+
+@app.post("/execute_action")
+async def execute_action(action_dict: dict[str, typing.Any], app_android_env: AndroidEnv):
+    action = json_action.JSONAction(**action_dict)
+    app_android_env.execute_action(action)
+    return {"status": "success", "message": f"Action {action} executed."}
+
+
+@suite_router.get("/task_list")
+async def suite_task_list(max_index: int, app_suite: AndroidSuite):
+    if max_index > len(app_suite) or max_index < 0:
+        return {"task_list": list(app_suite.keys())}
+    return {"task_list": list(app_suite.keys())[:max_index]}
+
+
+@suite_router.get("/task_length")
+async def suite_task_length(task_type: str, app_suite: AndroidSuite):
+    return {"length": len(app_suite[task_type])}
+
+
+@suite_router.get("/reinitialize")
+def reinitialize_suite(
+    request: fastapi.Request,
+    n_task_combinations: int = 2,
+    seed: int = 42,
+    task_family: str = "android_world",
+):
+    task_registry = request.app.state.task_registry
+    try:
+        current_aw_registry = task_registry.get_registry(task_family)
+    except ValueError as exc:
+        raise fastapi.HTTPException(
+            status_code=400, detail=f"Invalid task family: {task_family}"
+        ) from exc
+    new_suite = suite_utils.create_suite(
+        task_registry=current_aw_registry,
+        n_task_combinations=n_task_combinations,
+        seed=seed,
+    )
+    request.app.state.suite = new_suite
+    return {
+        "status": "success",
+        "message": f"Suite re-initialized (family={task_family}, seed={seed}).",
+    }
+
+
+@task_router.post("/initialize")
+async def initialize_task(
+    task_type: str, task_idx: int, app_android_env: AndroidEnv, app_suite: AndroidSuite
+):
+    app_suite[task_type][task_idx].initialize_task(app_android_env)
+    return {"status": "success", "message": f"Task {task_type}[{task_idx}] initialized."}
+
+
+@task_router.post("/tear_down")
+async def tear_down_task(
+    task_type: str, task_idx: int, app_android_env: AndroidEnv, app_suite: AndroidSuite
+):
+    app_suite[task_type][task_idx].tear_down(app_android_env)
+    return {"status": "success", "message": f"Task {task_type}[{task_idx}] torn down."}
+
+
+@task_router.get("/score")
+async def get_task_score(
+    task_type: str, task_idx: int, app_android_env: AndroidEnv, app_suite: AndroidSuite
+):
+    return {"score": app_suite[task_type][task_idx].is_successful(app_android_env)}
+
+
+@task_router.get("/goal")
+async def get_task_goal(task_type: str, task_idx: int, app_suite: AndroidSuite):
+    return {"goal": app_suite[task_type][task_idx].goal}
+
+
+@task_router.get("/template")
+async def get_task_template(task_type: str, task_idx: int, app_suite: AndroidSuite):
+    return {"template": app_suite[task_type][task_idx].template}
+
+
+@app.post("/close")
+async def close(app_android_env: AndroidEnv):
+    app_android_env.close()
+    return {"status": "success"}
+
+
+@app.get("/health")
+async def health(app_android_env: AndroidEnv):
+    if isinstance(app_android_env, interface.AsyncEnv):
+        return {"status": "success"}
+    raise fastapi.HTTPException(status_code=500, detail="Environment not initialized")
+
+
+app.include_router(suite_router)
+app.include_router(task_router)
+
+
+if __name__ == "__main__":
+    host = os.environ.get("AW_HOST", "0.0.0.0")
+    port = _env_int("AW_PORT", 5000)
+    uvicorn.run(app, host=host, port=port)

--- a/libs/python/cua-sandbox/cua_sandbox/image.py
+++ b/libs/python/cua-sandbox/cua_sandbox/image.py
@@ -154,9 +154,23 @@ class Image:
         return cls(os_type="android", distro="android", version=version, kind=kind)
 
     @classmethod
-    def from_registry(cls, ref: str) -> Image:
-        """Create an image from a registry reference. kind is resolved after pull."""
-        return cls(os_type="linux", distro="registry", version="latest", kind=None, _registry=ref)
+    def from_registry(cls, ref: str, *, agent_type: Optional[str] = None) -> Image:
+        """Create an image from a registry reference. kind is resolved after pull.
+
+        Args:
+            ref: OCI registry reference, e.g. "ghcr.io/trycua/osworld:latest".
+            agent_type: Override the agent type (e.g. "osworld", "androidworld").
+                If None, the agent type is read from the manifest annotation
+                ``org.trycua.agent_type`` at pull time.
+        """
+        return cls(
+            os_type="linux",
+            distro="registry",
+            version="latest",
+            kind=None,
+            _registry=ref,
+            _agent_type=agent_type,
+        )
 
     @classmethod
     def from_file(

--- a/libs/python/cua-sandbox/cua_sandbox/registry/avd_builder.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/avd_builder.py
@@ -250,6 +250,22 @@ def push_avd(
     logger.info(f"Manifest index updated: {full_repo}:{tag}")
 
 
+def _put_manifest_raw(r, full_repo: str, tag: str, manifest: dict) -> None:
+    """PUT an OCI manifest (any mediaType) via raw HTTP, bypassing oras-py schema validation."""
+    import json as _json
+
+    body = _json.dumps(manifest).encode()
+    url = f"{r.prefix}://{full_repo.lstrip('/')}/manifests/{tag}"
+    headers = {
+        "Content-Type": manifest.get("mediaType", "application/vnd.oci.image.index.v1+json"),
+        "Content-Length": str(len(body)),
+    }
+    resp = r.do_request(url, "PUT", headers=headers, data=body)
+    if resp.status_code not in (200, 201):
+        raise RuntimeError(f"PUT manifest failed ({resp.status_code}): {resp.text[:300]}")
+    logger.info(f"PUT manifest → {full_repo}:{tag} ({resp.status_code})")
+
+
 def _upsert_manifest_index(
     r,
     full_repo: str,
@@ -298,9 +314,9 @@ def _upsert_manifest_index(
         "manifests": existing_manifests + [new_entry],
         "annotations": index_annotations,
     }
-    import oras.container as _oras_container
-
-    r.upload_manifest(index, _oras_container.Container(f"{full_repo}:{tag}"))
+    # oras-py upload_manifest validates against the regular manifest schema
+    # (requires 'config'), which manifest indexes don't have. Use raw PUT.
+    _put_manifest_raw(r, full_repo, tag, index)
 
 
 # ── Pull ─────────────────────────────────────────────────────────────────────

--- a/libs/python/cua-sandbox/cua_sandbox/registry/avd_builder.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/avd_builder.py
@@ -336,7 +336,6 @@ def pull_avd(
     The manifest index is resolved to the correct arch variant automatically.
     Returns (config, avd_dir) where avd_dir is the extracted ``.avd`` directory.
     """
-    import oras.provider
     from cua_sandbox.registry.manifest import get_manifest
     from cua_sandbox.registry.media_types import (
         ANDROID_AVD_TAR_GZIP,
@@ -347,19 +346,31 @@ def pull_avd(
     dest_avd_home.mkdir(parents=True, exist_ok=True)
 
     registry, org, name, tag = parse_ref(ref)
-    full_repo = f"{registry}/{org}/{name}"
 
     # get_manifest already resolves manifest indexes to the host arch
     manifest = get_manifest(ref)
 
+    # Fetch blobs directly via HTTP (avoids oras-py retry/auth spam)
+    from cua_sandbox.registry.manifest import _registry_token
+
+    def _fetch_blob_bytes(blob_digest: str) -> bytes:
+        import requests as _req
+
+        token = _registry_token(registry, f"{org}/{name}")
+        headers: dict = {}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        url = f"https://{registry}/v2/{org}/{name}/blobs/{blob_digest}"
+        r = _req.get(url, headers=headers, timeout=120, stream=True)
+        r.raise_for_status()
+        return r.content
+
     # Parse config
-    r = oras.provider.Registry()
     config_blob = manifest.get("config", {})
     config = AVDConfig()
     if config_blob.get("digest"):
         try:
-            resp = r.get_blob(full_repo, config_blob["digest"])
-            data = resp.json() if hasattr(resp, "json") else {}
+            data = json.loads(_fetch_blob_bytes(config_blob["digest"]))
             config = AVDConfig(
                 **{k: v for k, v in data.items() if k in AVDConfig.__dataclass_fields__}
             )
@@ -399,8 +410,7 @@ def pull_avd(
                 digest = layer["digest"]
                 size = layer.get("size", 0)
                 logger.info(f"  part {part_num}/{parts[-1][0]}: {size / 1024 / 1024:.1f} MB")
-                resp = r.get_blob(full_repo, digest)
-                out.write(gzip.decompress(resp.content))
+                out.write(gzip.decompress(_fetch_blob_bytes(digest)))
 
         # Extract the tar into dest_avd_home
         logger.info(f"Extracting AVD to {dest_avd_home} ...")

--- a/libs/python/cua-sandbox/cua_sandbox/registry/avd_builder.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/avd_builder.py
@@ -254,8 +254,11 @@ def _put_manifest_raw(r, full_repo: str, tag: str, manifest: dict) -> None:
     """PUT an OCI manifest (any mediaType) via raw HTTP, bypassing oras-py schema validation."""
     import json as _json
 
+    import oras.container as _oras_container
+
     body = _json.dumps(manifest).encode()
-    url = f"{r.prefix}://{full_repo.lstrip('/')}/manifests/{tag}"
+    container = _oras_container.Container(f"{full_repo}:{tag}")
+    url = f"{r.prefix}://{container.manifest_url()}"
     headers = {
         "Content-Type": manifest.get("mediaType", "application/vnd.oci.image.index.v1+json"),
         "Content-Length": str(len(body)),

--- a/libs/python/cua-sandbox/cua_sandbox/registry/avd_builder.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/avd_builder.py
@@ -1,0 +1,448 @@
+"""Build and push/pull pre-baked Android AVD directories as OCI artifacts.
+
+An Android AVD (Android Virtual Device) is a directory that contains all state
+needed to boot the emulator — system image overlays, user data, app snapshots,
+SD card, and hardware config.  Pre-baking an AVD with apps already installed
+(e.g. AndroidWorld's 20 apps + their state snapshots) eliminates the ~15 min
+one-time setup cost on every fresh run.
+
+OCI format
+----------
+Each arch variant (arm64 / amd64) is a separate manifest:
+  config blob : JSON   — application/vnd.trycua.android.avd.config.v1+json
+  layers      : tar.gz — application/vnd.trycua.android.avd.tar.v1+gzip
+                         (chunked in 500 MB parts with part.number annotations)
+
+The top-level ref is a manifest *index* that points to both arch manifests so
+that Image.from_registry("ghcr.io/trycua/androidworld-avd:latest") auto-selects
+the right variant on arm64 (Apple Silicon) and amd64 (Linux/Windows x86_64).
+
+Multi-arch push workflow
+------------------------
+  # 1. Bake the AVD on Apple Silicon (produces arm64-v8a userdata):
+  python -m cua_sandbox.registry.avd_builder push \\
+      --avd-dir ~/.cua/android-avd/androidworld.avd \\
+      --ref     ghcr.io/trycua/androidworld-avd:latest \\
+      --arch    arm64 \\
+      --agent-type androidworld
+
+  # 2. Bake the AVD on x86_64 Linux/Windows and push similarly:
+  python -m cua_sandbox.registry.avd_builder push \\
+      --avd-dir ~/.cua/android-avd/androidworld.avd \\
+      --ref     ghcr.io/trycua/androidworld-avd:latest \\
+      --arch    amd64 \\
+      --agent-type androidworld
+
+  # Both push commands automatically update the manifest index at :latest.
+
+Pull / extraction
+-----------------
+  config, avd_dir = pull_avd("ghcr.io/trycua/androidworld-avd:latest")
+  # → ~/.cua/android-avd/androidworld.avd extracted and ready to boot
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+import logging
+import platform as _plat
+import shutil
+import tarfile
+import tempfile
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+CHUNK_SIZE = 500 * 1024 * 1024  # 500 MB
+_AVD_HOME = Path.home() / ".cua" / "android-avd"
+AGENT_TYPE_ANNOTATION = "org.trycua.agent_type"
+
+
+@dataclass
+class AVDConfig:
+    """Metadata for a pre-baked AVD image, stored as the OCI config blob."""
+
+    api_level: int = 33
+    img_type: str = "google_apis"
+    device_id: str = "pixel_6"
+    arch: str = "arm64-v8a"  # "arm64-v8a" | "x86_64"
+    android_world: bool = False
+    """True when AndroidWorld apps are pre-installed in this AVD."""
+    agent_type: Optional[str] = None
+    """Agent type hint — copied to manifest annotation (e.g. 'androidworld')."""
+    extra: dict = field(default_factory=dict)
+
+
+# ── Host arch detection ───────────────────────────────────────────────────────
+
+
+def _host_oci_arch() -> str:
+    """Return the OCI architecture string for the current host."""
+    machine = _plat.machine().lower()
+    if machine in ("arm64", "aarch64"):
+        return "arm64"
+    return "amd64"
+
+
+def _avd_arch_for_oci(oci_arch: str) -> str:
+    """Map OCI architecture to Android ABI string."""
+    return "arm64-v8a" if oci_arch == "arm64" else "x86_64"
+
+
+# ── Push ─────────────────────────────────────────────────────────────────────
+
+
+def push_avd(
+    avd_dir: str | Path,
+    ref: str,
+    *,
+    arch: Optional[str] = None,
+    config: Optional[AVDConfig] = None,
+    agent_type: Optional[str] = None,
+) -> None:
+    """Tar, chunk, and push an AVD directory to an OCI registry.
+
+    After pushing the per-arch manifest, creates or updates the multi-arch
+    manifest index at ``ref`` so that from_registry() can select the right
+    variant automatically.
+
+    Args:
+        avd_dir: Path to the ``<name>.avd`` directory.
+        ref: Full OCI reference, e.g. ``ghcr.io/trycua/androidworld-avd:latest``.
+        arch: OCI architecture string: ``"arm64"`` or ``"amd64"``.
+              Defaults to the host architecture.
+        config: AVDConfig metadata to store in the config blob.
+        agent_type: Value for the ``org.trycua.agent_type`` annotation.
+    """
+    import oras.provider
+    from cua_sandbox.registry.media_types import (
+        ANDROID_AVD_CONFIG,
+        ANDROID_AVD_TAR_GZIP,
+    )
+    from cua_sandbox.registry.ref import parse_ref
+
+    avd_dir = Path(avd_dir)
+    if not avd_dir.is_dir():
+        raise FileNotFoundError(f"AVD directory not found: {avd_dir}")
+
+    oci_arch = arch or _host_oci_arch()
+    avd_arch = _avd_arch_for_oci(oci_arch)
+
+    if config is None:
+        config = AVDConfig(arch=avd_arch, android_world=(agent_type == "androidworld"))
+    if agent_type:
+        config.agent_type = agent_type
+
+    registry, org, name, tag = parse_ref(ref)
+    full_repo = f"{registry}/{org}/{name}"
+    r = oras.provider.Registry()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+
+        # 1. Create config blob
+        config_data = json.dumps(asdict(config)).encode()
+        config_digest = f"sha256:{hashlib.sha256(config_data).hexdigest()}"
+        config_path = tmp_dir / "config.json"
+        config_path.write_bytes(config_data)
+
+        # 2. Tar the AVD directory
+        tar_path = tmp_dir / "avd.tar"
+        logger.info(f"Archiving AVD {avd_dir} ...")
+        with tarfile.open(tar_path, "w") as tf:
+            tf.add(avd_dir, arcname=avd_dir.name)
+
+        tar_size = tar_path.stat().st_size
+        logger.info(f"AVD archive: {tar_size / 1024 / 1024:.0f} MB uncompressed")
+
+        # 3. Chunk-compress the tar
+        layers = []
+        part_total = (tar_size + CHUNK_SIZE - 1) // CHUNK_SIZE
+
+        with open(tar_path, "rb") as f:
+            for part_num in range(1, part_total + 1):
+                chunk = f.read(CHUNK_SIZE)
+                if not chunk:
+                    break
+                compressed = gzip.compress(chunk, compresslevel=6)
+                chunk_path = tmp_dir / f"avd.part.{part_num:04d}.tar.gz"
+                chunk_path.write_bytes(compressed)
+                chunk_digest = f"sha256:{hashlib.sha256(compressed).hexdigest()}"
+
+                layers.append(
+                    {
+                        "mediaType": ANDROID_AVD_TAR_GZIP,
+                        "digest": chunk_digest,
+                        "size": len(compressed),
+                        "annotations": {
+                            "org.trycua.android.avd.part.number": str(part_num),
+                            "org.trycua.android.avd.part.total": str(part_total),
+                            "org.trycua.android.avd.uncompressed-size": str(len(chunk)),
+                            "org.opencontainers.image.title": f"avd.tar.part.{part_num:04d}",
+                        },
+                    }
+                )
+                logger.info(
+                    f"  part {part_num}/{part_total}: {len(compressed) / 1024 / 1024:.1f} MB"
+                )
+                r.push_blob(full_repo, chunk_path, chunk_digest)
+
+        # 4. Push config blob
+        r.push_blob(full_repo, config_path, config_digest)
+
+        # 5. Build per-arch manifest
+        annotations = {
+            "org.trycua.android.avd.arch": oci_arch,
+            "org.trycua.android.avd.api-level": str(config.api_level),
+        }
+        if agent_type:
+            annotations[AGENT_TYPE_ANNOTATION] = agent_type
+
+        manifest = {
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "config": {
+                "mediaType": ANDROID_AVD_CONFIG,
+                "digest": config_digest,
+                "size": len(config_data),
+            },
+            "layers": layers,
+            "annotations": annotations,
+        }
+        manifest_json = json.dumps(manifest)
+        manifest_digest = f"sha256:{hashlib.sha256(manifest_json.encode()).hexdigest()}"
+        manifest_size = len(manifest_json.encode())
+
+        # Push per-arch manifest as a tagged ref (e.g. :latest-arm64 / :latest-amd64)
+        arch_tag = f"{tag}-{oci_arch}"
+        r.put_manifest(f"{full_repo}:{arch_tag}", manifest_json)
+        logger.info(f"Pushed {full_repo}:{arch_tag} ({part_total} layers, {oci_arch})")
+
+    # 6. Update / create the manifest index at :tag
+    _upsert_manifest_index(
+        r=r,
+        full_repo=full_repo,
+        tag=tag,
+        arch=oci_arch,
+        manifest_digest=manifest_digest,
+        manifest_size=manifest_size,
+        agent_type=agent_type,
+    )
+    logger.info(f"Manifest index updated: {full_repo}:{tag}")
+
+
+def _upsert_manifest_index(
+    r,
+    full_repo: str,
+    tag: str,
+    arch: str,
+    manifest_digest: str,
+    manifest_size: int,
+    agent_type: Optional[str],
+) -> None:
+    """Create or update a multi-arch OCI manifest index.
+
+    Fetches the existing index (if any), replaces or adds the entry for
+    ``arch``, then pushes the updated index.
+    """
+    existing_manifests: list[dict] = []
+
+    # Try to fetch existing index
+    try:
+        existing = r.get_manifest(f"{full_repo}:{tag}")
+        if existing.get("mediaType") == "application/vnd.oci.image.index.v1+json":
+            # Filter out any stale entry for this arch
+            existing_manifests = [
+                m
+                for m in existing.get("manifests", [])
+                if m.get("platform", {}).get("architecture") != arch
+            ]
+    except Exception:
+        pass
+
+    new_entry: dict = {
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "digest": manifest_digest,
+        "size": manifest_size,
+        "platform": {"os": "linux", "architecture": arch},
+    }
+    if agent_type:
+        new_entry["annotations"] = {AGENT_TYPE_ANNOTATION: agent_type}
+
+    index_annotations: dict = {}
+    if agent_type:
+        index_annotations[AGENT_TYPE_ANNOTATION] = agent_type
+
+    index = {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": existing_manifests + [new_entry],
+        "annotations": index_annotations,
+    }
+    r.put_manifest(f"{full_repo}:{tag}", json.dumps(index))
+
+
+# ── Pull ─────────────────────────────────────────────────────────────────────
+
+
+def pull_avd(
+    ref: str,
+    dest_avd_home: Optional[Path] = None,
+    *,
+    force: bool = False,
+) -> tuple[AVDConfig, Path]:
+    """Pull an AVD OCI image and extract it into dest_avd_home.
+
+    The manifest index is resolved to the correct arch variant automatically.
+    Returns (config, avd_dir) where avd_dir is the extracted ``.avd`` directory.
+    """
+    import oras.provider
+    from cua_sandbox.registry.manifest import get_manifest
+    from cua_sandbox.registry.media_types import (
+        ANDROID_AVD_TAR_GZIP,
+    )
+    from cua_sandbox.registry.ref import parse_ref
+
+    dest_avd_home = dest_avd_home or _AVD_HOME
+    dest_avd_home.mkdir(parents=True, exist_ok=True)
+
+    registry, org, name, tag = parse_ref(ref)
+    full_repo = f"{registry}/{org}/{name}"
+
+    # get_manifest already resolves manifest indexes to the host arch
+    manifest = get_manifest(ref)
+
+    # Parse config
+    r = oras.provider.Registry()
+    config_blob = manifest.get("config", {})
+    config = AVDConfig()
+    if config_blob.get("digest"):
+        try:
+            resp = r.get_blob(full_repo, config_blob["digest"])
+            data = resp.json() if hasattr(resp, "json") else {}
+            config = AVDConfig(
+                **{k: v for k, v in data.items() if k in AVDConfig.__dataclass_fields__}
+            )
+        except Exception as e:
+            logger.warning(f"Could not parse AVD config blob: {e}")
+
+    # Determine extraction target — use AVD dir name from config or manifest name
+    avd_name = f"{name}.avd"
+    avd_dir = dest_avd_home / avd_name
+
+    if avd_dir.exists() and not force:
+        logger.info(f"Using cached AVD at {avd_dir}")
+        return config, avd_dir
+
+    # Collect and sort tar chunks
+    layers = manifest.get("layers", [])
+    parts: list[tuple[int, dict]] = []
+    for layer in layers:
+        if layer.get("mediaType") != ANDROID_AVD_TAR_GZIP:
+            continue
+        annot = layer.get("annotations", {})
+        part_num = int(annot.get("org.trycua.android.avd.part.number", 1))
+        parts.append((part_num, layer))
+
+    if not parts:
+        raise RuntimeError(f"No AVD tar layers found in manifest for {ref}")
+
+    parts.sort(key=lambda x: x[0])
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        tar_path = tmp_dir / "avd.tar"
+
+        logger.info(f"Downloading {len(parts)} AVD parts for {ref} ({config.arch}) ...")
+        with open(tar_path, "wb") as out:
+            for part_num, layer in parts:
+                digest = layer["digest"]
+                size = layer.get("size", 0)
+                logger.info(f"  part {part_num}/{parts[-1][0]}: {size / 1024 / 1024:.1f} MB")
+                resp = r.get_blob(full_repo, digest)
+                out.write(gzip.decompress(resp.content))
+
+        # Extract the tar into dest_avd_home
+        logger.info(f"Extracting AVD to {dest_avd_home} ...")
+        if avd_dir.exists():
+            shutil.rmtree(avd_dir)
+        with tarfile.open(tar_path, "r") as tf:
+            tf.extractall(dest_avd_home)
+
+    if not avd_dir.exists():
+        raise RuntimeError(f"AVD extraction failed — {avd_dir} not found after extract")
+
+    logger.info(f"AVD ready at {avd_dir}")
+    return config, avd_dir
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def _main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Push or pull a pre-baked Android AVD to/from an OCI registry."
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    push_p = sub.add_parser("push", help="Push an AVD directory to OCI")
+    push_p.add_argument("--avd-dir", required=True, help="Path to <name>.avd directory")
+    push_p.add_argument(
+        "--ref", required=True, help="OCI ref, e.g. ghcr.io/trycua/androidworld-avd:latest"
+    )
+    push_p.add_argument(
+        "--arch",
+        default=None,
+        choices=["arm64", "amd64"],
+        help="OCI architecture (default: auto-detect host)",
+    )
+    push_p.add_argument(
+        "--agent-type", default=None, help="Agent type annotation, e.g. androidworld"
+    )
+    push_p.add_argument("--api-level", type=int, default=33)
+    push_p.add_argument("--device-id", default="pixel_6")
+
+    pull_p = sub.add_parser("pull", help="Pull an AVD image from OCI and extract it")
+    pull_p.add_argument("--ref", required=True)
+    pull_p.add_argument(
+        "--dest", default=None, help="AVD home directory (default: ~/.cua/android-avd)"
+    )
+    pull_p.add_argument("--force", action="store_true")
+
+    args = parser.parse_args()
+
+    import logging as _logging
+
+    _logging.basicConfig(level=_logging.INFO, format="%(message)s")
+
+    if args.command == "push":
+        cfg = AVDConfig(
+            api_level=args.api_level,
+            device_id=args.device_id,
+            arch=_avd_arch_for_oci(args.arch or _host_oci_arch()),
+            android_world=(args.agent_type == "androidworld"),
+            agent_type=args.agent_type,
+        )
+        push_avd(
+            args.avd_dir,
+            args.ref,
+            arch=args.arch,
+            config=cfg,
+            agent_type=args.agent_type,
+        )
+        print(f"Done: {args.ref}")
+
+    elif args.command == "pull":
+        dest = Path(args.dest) if args.dest else None
+        config, avd_dir = pull_avd(args.ref, dest, force=args.force)
+        print(f"Extracted: {avd_dir}  (api={config.api_level}, arch={config.arch})")
+
+
+if __name__ == "__main__":
+    _main()

--- a/libs/python/cua-sandbox/cua_sandbox/registry/avd_builder.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/avd_builder.py
@@ -137,9 +137,18 @@ def push_avd(
     if agent_type:
         config.agent_type = agent_type
 
+    import os
+
     registry, org, name, tag = parse_ref(ref)
     full_repo = f"{registry}/{org}/{name}"
-    r = oras.provider.Registry()
+    r = oras.provider.Registry(hostname=registry)
+
+    # Authenticate if credentials are available
+    username = os.environ.get("ORAS_USERNAME") or os.environ.get("REGISTRY_USERNAME")
+    password = os.environ.get("ORAS_PASSWORD") or os.environ.get("REGISTRY_PASSWORD")
+    if username and password:
+        r.login(username=username, password=password, hostname=registry)
+        logger.info(f"Authenticated to {registry} as {username}")
 
     with tempfile.TemporaryDirectory() as tmp:
         tmp_dir = Path(tmp)
@@ -189,10 +198,14 @@ def push_avd(
                 logger.info(
                     f"  part {part_num}/{part_total}: {len(compressed) / 1024 / 1024:.1f} MB"
                 )
-                r.push_blob(full_repo, chunk_path, chunk_digest)
+                r.upload_blob(str(chunk_path), full_repo, layers[-1])
 
         # 4. Push config blob
-        r.push_blob(full_repo, config_path, config_digest)
+        r.upload_blob(
+            str(config_path),
+            full_repo,
+            {"digest": config_digest, "size": len(config_data), "mediaType": ANDROID_AVD_CONFIG},
+        )
 
         # 5. Build per-arch manifest
         annotations = {
@@ -219,7 +232,9 @@ def push_avd(
 
         # Push per-arch manifest as a tagged ref (e.g. :latest-arm64 / :latest-amd64)
         arch_tag = f"{tag}-{oci_arch}"
-        r.put_manifest(f"{full_repo}:{arch_tag}", manifest_json)
+        import oras.container as _oras_container
+
+        r.upload_manifest(manifest, _oras_container.Container(f"{full_repo}:{arch_tag}"))
         logger.info(f"Pushed {full_repo}:{arch_tag} ({part_total} layers, {oci_arch})")
 
     # 6. Update / create the manifest index at :tag
@@ -283,7 +298,9 @@ def _upsert_manifest_index(
         "manifests": existing_manifests + [new_entry],
         "annotations": index_annotations,
     }
-    r.put_manifest(f"{full_repo}:{tag}", json.dumps(index))
+    import oras.container as _oras_container
+
+    r.upload_manifest(index, _oras_container.Container(f"{full_repo}:{tag}"))
 
 
 # ── Pull ─────────────────────────────────────────────────────────────────────

--- a/libs/python/cua-sandbox/cua_sandbox/registry/manifest.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/manifest.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from enum import Enum
 from typing import Optional
 
-import oras.provider
 from cua_sandbox.registry.media_types import (
     ANDROID_AVD_CONFIG,
     ANDROID_AVD_TAR_GZIP,
@@ -47,41 +46,104 @@ class ImageFormat(Enum):
     UNKNOWN = "unknown"
 
 
-def _make_registry(hostname: str) -> oras.provider.Registry:
-    """Create an oras Registry, authenticating from env vars or ~/.docker/config.json."""
+def _registry_token(hostname: str, repo: str) -> Optional[str]:
+    """Obtain a Bearer token for the registry, using available credentials.
+
+    Checks (in order):
+      1. ORAS_PASSWORD / REGISTRY_PASSWORD / GITHUB_TOKEN / GHCR_TOKEN env vars
+         paired with ORAS_USERNAME / REGISTRY_USERNAME (or the token itself as
+         username for GHCR anonymous-with-token flows).
+      2. ~/.docker/config.json  (base64 username:password in the 'auth' field).
+
+    Returns the Bearer token string, or None if no credentials are found.
+    Raises PermissionError immediately on a non-2xx auth response.
+    """
     import base64
     import json
     import os
     from pathlib import Path
 
-    r = oras.provider.Registry(hostname=hostname)
+    import requests
 
-    # 1. Explicit env vars take priority
-    username = os.environ.get("ORAS_USERNAME") or os.environ.get("REGISTRY_USERNAME")
+    username: Optional[str] = None
+    password: Optional[str] = None
+
+    # 1. Env vars
     password = (
         os.environ.get("ORAS_PASSWORD")
         or os.environ.get("REGISTRY_PASSWORD")
         or os.environ.get("GITHUB_TOKEN")
         or os.environ.get("GHCR_TOKEN")
     )
-    if username and password:
-        r.login(username=username, password=password, hostname=hostname)
-        return r
+    username = os.environ.get("ORAS_USERNAME") or os.environ.get("REGISTRY_USERNAME")
+    if password and not username:
+        username = password  # GHCR accepts token-as-username for PAT flows
 
-    # 2. Fall back to ~/.docker/config.json
-    docker_cfg = Path.home() / ".docker" / "config.json"
-    if docker_cfg.exists():
-        try:
-            cfg = json.loads(docker_cfg.read_text())
-            auth_b64 = cfg.get("auths", {}).get(hostname, {}).get("auth", "")
-            if auth_b64:
-                decoded = base64.b64decode(auth_b64).decode()
-                user, token = decoded.split(":", 1)
-                r.login(username=user, password=token, hostname=hostname)
-        except Exception:
-            pass
+    # 2. Docker config fallback
+    if not password:
+        docker_cfg = Path.home() / ".docker" / "config.json"
+        if docker_cfg.exists():
+            try:
+                cfg = json.loads(docker_cfg.read_text())
+                auth_b64 = cfg.get("auths", {}).get(hostname, {}).get("auth", "")
+                if auth_b64:
+                    decoded = base64.b64decode(auth_b64).decode()
+                    username, password = decoded.split(":", 1)
+            except Exception:
+                pass
 
-    return r
+    if not password:
+        return None
+
+    # Exchange credentials for a scoped Bearer token
+    scope = f"repository:{repo}:pull"
+    resp = requests.get(
+        f"https://{hostname}/token",
+        params={"scope": scope},
+        auth=(username, password),
+        timeout=15,
+    )
+    if resp.status_code == 401:
+        raise PermissionError(
+            f"Registry auth failed for {hostname}. "
+            "Set GITHUB_TOKEN (or ORAS_PASSWORD) to a token with read:packages scope."
+        )
+    resp.raise_for_status()
+    return resp.json().get("token")
+
+
+def _fetch_manifest_raw(registry: str, repo: str, ref: str) -> dict:
+    """Fetch an OCI manifest via direct HTTP, with auth and correct Accept headers.
+
+    Fails fast (no retries) with a clear error on auth failure.
+    Sends Accept headers for both manifest index and regular manifest so
+    registries return the index when present.
+    """
+
+    import requests
+
+    token = _registry_token(registry, repo)
+    headers: dict = {
+        "Accept": (
+            "application/vnd.oci.image.index.v1+json,"
+            "application/vnd.oci.image.manifest.v1+json,"
+            "application/vnd.docker.distribution.manifest.v2+json,"
+            "application/vnd.docker.distribution.manifest.list.v2+json"
+        )
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    url = f"https://{registry}/v2/{repo}/manifests/{ref}"
+    resp = requests.get(url, headers=headers, timeout=30)
+
+    if resp.status_code == 401:
+        raise PermissionError(
+            f"Registry auth failed for {registry}/{repo}. "
+            "Set GITHUB_TOKEN (or ORAS_PASSWORD) to a token with read:packages scope."
+        )
+    resp.raise_for_status()
+    return resp.json()
 
 
 def get_manifest(ref: str, platform: Optional[str] = None) -> dict:
@@ -98,9 +160,8 @@ def get_manifest(ref: str, platform: Optional[str] = None) -> dict:
     import platform as _plat
 
     registry, org, name, tag = parse_ref(ref)
-    r = _make_registry(registry)
-    full = f"{registry}/{org}/{name}:{tag}"
-    manifest = r.get_manifest(full)
+    repo = f"{org}/{name}"
+    manifest = _fetch_manifest_raw(registry, repo, tag)
 
     # If it's a manifest index, resolve to a specific platform manifest
     if manifest.get("manifests"):
@@ -121,16 +182,14 @@ def get_manifest(ref: str, platform: Optional[str] = None) -> dict:
                 if "attestation" in annot.get("vnd.docker.reference.type", ""):
                     continue
                 digest = m["digest"]
-                full_repo = f"{registry}/{org}/{name}"
-                return r.get_manifest(f"{full_repo}@{digest}")
+                return _fetch_manifest_raw(registry, repo, digest)
 
         # Fallback: first non-attestation manifest
         for m in manifest["manifests"]:
             annot = m.get("annotations", {})
             if "attestation" not in annot.get("vnd.docker.reference.type", ""):
                 digest = m["digest"]
-                full_repo = f"{registry}/{org}/{name}"
-                return r.get_manifest(f"{full_repo}@{digest}")
+                return _fetch_manifest_raw(registry, repo, digest)
 
     return manifest
 
@@ -256,13 +315,23 @@ def detect_os_from_config(ref: str, manifest: dict) -> Optional[str]:
     if not digest:
         return None
 
-    r = oras.provider.Registry()
+    import requests as _requests
+
     registry, org, name, _tag = parse_ref(ref)
-    full_repo = f"{registry}/{org}/{name}"
+    repo = f"{org}/{name}"
+
+    def _fetch_blob(blob_digest: str) -> dict:
+        token = _registry_token(registry, repo)
+        headers: dict = {}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        url = f"https://{registry}/v2/{repo}/blobs/{blob_digest}"
+        r = _requests.get(url, headers=headers, timeout=30)
+        r.raise_for_status()
+        return r.json()
 
     try:
-        resp = r.get_blob(full_repo, digest)
-        data = resp.json() if hasattr(resp, "json") else {}
+        data = _fetch_blob(digest)
         # Standard OCI: "os" field; QEMU: "guest_os" field
         os_val = (data.get("os") or data.get("guest_os") or "").lower()
         if os_val in ("linux", "windows"):
@@ -276,8 +345,7 @@ def detect_os_from_config(ref: str, manifest: dict) -> Optional[str]:
     for layer in manifest.get("layers", []):
         if layer.get("mediaType") == TART_CONFIG:
             try:
-                resp = r.get_blob(full_repo, layer["digest"])
-                data = resp.json() if hasattr(resp, "json") else {}
+                data = _fetch_blob(layer["digest"])
                 os_val = (data.get("os") or "").lower()
                 if os_val in ("linux", "windows"):
                     return os_val

--- a/libs/python/cua-sandbox/cua_sandbox/registry/manifest.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/manifest.py
@@ -11,6 +11,8 @@ from typing import Optional
 
 import oras.provider
 from cua_sandbox.registry.media_types import (
+    ANDROID_AVD_CONFIG,
+    ANDROID_AVD_TAR_GZIP,
     CONTAINER_CONFIG_TYPES,
     CONTAINER_LAYER_TYPES,
     LEGACY_DISK_CHUNK,
@@ -34,6 +36,7 @@ from cua_sandbox.registry.ref import parse_ref
 class ImageFormat(Enum):
     """Format of a VM image in the registry."""
 
+    ANDROID_AVD = "android-avd"  # trycua Android AVD — gzip-chunked tar, avd media types
     LUME = "lume"  # trycua Lume macOS VM — gzip chunks, lume media types
     OCI_LAYERED = "oci-layered"  # agoda media types, gzip chunks with part annotations
     LEGACY_LZ4 = "legacy-lz4"  # trycua LZ4-chunked
@@ -101,6 +104,12 @@ def detect_format(manifest: dict) -> ImageFormat:
     config = manifest.get("config", {})
     config_mt = config.get("mediaType", "")
 
+    # Android AVD: config uses trycua.android.avd.config type
+    if config_mt == ANDROID_AVD_CONFIG:
+        return ImageFormat.ANDROID_AVD
+    if any(layer.get("mediaType") == ANDROID_AVD_TAR_GZIP for layer in layers):
+        return ImageFormat.ANDROID_AVD
+
     # Lume native OCI format: config uses trycua.lume.config type
     if config_mt == LUME_CONFIG:
         return ImageFormat.LUME
@@ -148,6 +157,7 @@ def detect_kind(manifest: dict) -> str:
     """Classify manifest as 'vm' or 'container'."""
     fmt = detect_format(manifest)
     if fmt in (
+        ImageFormat.ANDROID_AVD,
         ImageFormat.LUME,
         ImageFormat.OCI_LAYERED,
         ImageFormat.LEGACY_LZ4,

--- a/libs/python/cua-sandbox/cua_sandbox/registry/manifest.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/manifest.py
@@ -287,8 +287,14 @@ def detect_os(manifest: dict) -> Optional[str]:
         if "linux" in os_val:
             return "linux"
 
-    # lume/agoda media types → macOS
+    # Android AVD media types → android
     config_mt = manifest.get("config", {}).get("mediaType", "")
+    if config_mt == ANDROID_AVD_CONFIG:
+        return "android"
+    if any(layer.get("mediaType") == ANDROID_AVD_TAR_GZIP for layer in manifest.get("layers", [])):
+        return "android"
+
+    # lume/agoda media types → macOS
     if config_mt in (OCI_VM_CONFIG, OCI_VM_CONFIG_LEGACY):
         return "macos"
     if any(

--- a/libs/python/cua-sandbox/cua_sandbox/registry/manifest.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/manifest.py
@@ -14,6 +14,9 @@ from cua_sandbox.registry.media_types import (
     CONTAINER_CONFIG_TYPES,
     CONTAINER_LAYER_TYPES,
     LEGACY_DISK_CHUNK,
+    LUME_CONFIG,
+    LUME_DISK,
+    LUME_NVRAM,
     OCI_VM_CONFIG,
     OCI_VM_CONFIG_LEGACY,
     OCI_VM_DISK,
@@ -31,6 +34,7 @@ from cua_sandbox.registry.ref import parse_ref
 class ImageFormat(Enum):
     """Format of a VM image in the registry."""
 
+    LUME = "lume"  # trycua Lume macOS VM — gzip chunks, lume media types
     OCI_LAYERED = "oci-layered"  # agoda media types, gzip chunks with part annotations
     LEGACY_LZ4 = "legacy-lz4"  # trycua LZ4-chunked
     CHUNKED_PARTS = "chunked-parts"  # standard OCI layer type with ;part.number= in media type
@@ -97,7 +101,13 @@ def detect_format(manifest: dict) -> ImageFormat:
     config = manifest.get("config", {})
     config_mt = config.get("mediaType", "")
 
-    # OCI-layered (lume/agoda): config or disk layers use trycua.lume or legacy agoda types
+    # Lume native OCI format: config uses trycua.lume.config type
+    if config_mt == LUME_CONFIG:
+        return ImageFormat.LUME
+    if any(layer.get("mediaType") in (LUME_DISK, LUME_NVRAM) for layer in layers):
+        return ImageFormat.LUME
+
+    # OCI-layered (agoda/kubelet): config or disk layers use agoda media types
     if config_mt in (OCI_VM_CONFIG, OCI_VM_CONFIG_LEGACY):
         return ImageFormat.OCI_LAYERED
     if any(layer.get("mediaType") in (OCI_VM_DISK, OCI_VM_DISK_LEGACY) for layer in layers):
@@ -138,6 +148,7 @@ def detect_kind(manifest: dict) -> str:
     """Classify manifest as 'vm' or 'container'."""
     fmt = detect_format(manifest)
     if fmt in (
+        ImageFormat.LUME,
         ImageFormat.OCI_LAYERED,
         ImageFormat.LEGACY_LZ4,
         ImageFormat.CHUNKED_PARTS,

--- a/libs/python/cua-sandbox/cua_sandbox/registry/manifest.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/manifest.py
@@ -47,6 +47,43 @@ class ImageFormat(Enum):
     UNKNOWN = "unknown"
 
 
+def _make_registry(hostname: str) -> oras.provider.Registry:
+    """Create an oras Registry, authenticating from env vars or ~/.docker/config.json."""
+    import base64
+    import json
+    import os
+    from pathlib import Path
+
+    r = oras.provider.Registry(hostname=hostname)
+
+    # 1. Explicit env vars take priority
+    username = os.environ.get("ORAS_USERNAME") or os.environ.get("REGISTRY_USERNAME")
+    password = (
+        os.environ.get("ORAS_PASSWORD")
+        or os.environ.get("REGISTRY_PASSWORD")
+        or os.environ.get("GITHUB_TOKEN")
+        or os.environ.get("GHCR_TOKEN")
+    )
+    if username and password:
+        r.login(username=username, password=password, hostname=hostname)
+        return r
+
+    # 2. Fall back to ~/.docker/config.json
+    docker_cfg = Path.home() / ".docker" / "config.json"
+    if docker_cfg.exists():
+        try:
+            cfg = json.loads(docker_cfg.read_text())
+            auth_b64 = cfg.get("auths", {}).get(hostname, {}).get("auth", "")
+            if auth_b64:
+                decoded = base64.b64decode(auth_b64).decode()
+                user, token = decoded.split(":", 1)
+                r.login(username=user, password=token, hostname=hostname)
+        except Exception:
+            pass
+
+    return r
+
+
 def get_manifest(ref: str, platform: Optional[str] = None) -> dict:
     """Fetch the OCI manifest for an image reference.
 
@@ -60,8 +97,8 @@ def get_manifest(ref: str, platform: Optional[str] = None) -> dict:
     """
     import platform as _plat
 
-    r = oras.provider.Registry()
     registry, org, name, tag = parse_ref(ref)
+    r = _make_registry(registry)
     full = f"{registry}/{org}/{name}:{tag}"
     manifest = r.get_manifest(full)
 

--- a/libs/python/cua-sandbox/cua_sandbox/registry/media_types.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/media_types.py
@@ -2,9 +2,11 @@
 
 VM image formats in the wild:
 
+  Lume (OCI):           gzip-chunked disk, trycua.lume media types,
+                        OCI config with os/hardwareModel/machineIdentifier
   OCI-layered (agoda):  gzip-compressed disk chunks, agoda media types,
                         annotations with part.number/offset/total
-  Legacy Lume (LZ4):    LZ4-chunked disk, trycua media types
+  Legacy Lume (LZ4):    LZ4-chunked disk, trycua.lume.*.lz4 media types
   Chunked-parts:        standard OCI layer type with ;part.number= in media type string
   Tart (Cirrus Labs):   compressed disk chunks, cirruslabs media types,
                         OCI config with os/architecture fields
@@ -19,6 +21,12 @@ Standard container images use OCI/Docker layer media types.
 QEMU_CONFIG = "application/vnd.trycua.qemu.config.v1+json"
 QEMU_DISK = "application/vnd.trycua.qemu.disk.v1"
 QEMU_DISK_GZIP = "application/vnd.trycua.qemu.disk.v1+gzip"
+
+# ── Lume macOS VM (cua) — native OCI format ──────────────────────────────────
+
+LUME_CONFIG = "application/vnd.trycua.lume.config.v1+json"
+LUME_DISK = "application/vnd.trycua.lume.disk.v1"
+LUME_NVRAM = "application/vnd.trycua.lume.nvram.v1"
 
 # ── Tart (Cirrus Labs) ───────────────────────────────────────────────────────
 
@@ -41,7 +49,7 @@ OCI_VM_AUX_LEGACY = "application/vnd.agoda.macosvz.aux.image.v1"
 
 LEGACY_DISK_CHUNK = "application/vnd.trycua.lume.disk.chunk.lz4"
 LEGACY_AUX = "application/vnd.trycua.lume.aux.image.v1"
-LEGACY_CONFIG = "application/vnd.trycua.lume.config.v1+json"
+LEGACY_CONFIG = "application/vnd.trycua.lume.config.v1+json"  # same as LUME_CONFIG
 
 # ── Standard OCI / Docker container ────────────────────────────────────────
 
@@ -58,6 +66,9 @@ VM_MEDIA_TYPES = frozenset(
         QEMU_CONFIG,
         QEMU_DISK,
         QEMU_DISK_GZIP,
+        LUME_CONFIG,
+        LUME_DISK,
+        LUME_NVRAM,
         OCI_VM_CONFIG,
         OCI_VM_DISK,
         OCI_VM_AUX,
@@ -73,10 +84,17 @@ VM_MEDIA_TYPES = frozenset(
     }
 )
 
-CONTAINER_LAYER_TYPES = frozenset({
-    OCI_IMAGE_LAYER, OCI_IMAGE_LAYER_NONDIST, DOCKER_IMAGE_LAYER,
-})
+CONTAINER_LAYER_TYPES = frozenset(
+    {
+        OCI_IMAGE_LAYER,
+        OCI_IMAGE_LAYER_NONDIST,
+        DOCKER_IMAGE_LAYER,
+    }
+)
 
-CONTAINER_CONFIG_TYPES = frozenset({
-    OCI_IMAGE_CONFIG, DOCKER_IMAGE_CONFIG,
-})
+CONTAINER_CONFIG_TYPES = frozenset(
+    {
+        OCI_IMAGE_CONFIG,
+        DOCKER_IMAGE_CONFIG,
+    }
+)

--- a/libs/python/cua-sandbox/cua_sandbox/registry/media_types.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/media_types.py
@@ -28,6 +28,11 @@ LUME_CONFIG = "application/vnd.trycua.lume.config.v1+json"
 LUME_DISK = "application/vnd.trycua.lume.disk.v1"
 LUME_NVRAM = "application/vnd.trycua.lume.nvram.v1"
 
+# ── Android AVD (cua) — pre-baked Android Virtual Device ─────────────────────
+
+ANDROID_AVD_CONFIG = "application/vnd.trycua.android.avd.config.v1+json"
+ANDROID_AVD_TAR_GZIP = "application/vnd.trycua.android.avd.tar.v1+gzip"
+
 # ── Tart (Cirrus Labs) ───────────────────────────────────────────────────────
 
 TART_CONFIG = "application/vnd.cirruslabs.tart.config.v1"
@@ -69,6 +74,8 @@ VM_MEDIA_TYPES = frozenset(
         LUME_CONFIG,
         LUME_DISK,
         LUME_NVRAM,
+        ANDROID_AVD_CONFIG,
+        ANDROID_AVD_TAR_GZIP,
         OCI_VM_CONFIG,
         OCI_VM_DISK,
         OCI_VM_AUX,

--- a/libs/python/cua-sandbox/cua_sandbox/registry/push.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/push.py
@@ -224,25 +224,33 @@ def _annotate_manifest(ref: str, agent_type: str, extra: dict) -> None:
 
 
 def _annotate_via_oras_py(ref: str, annotations: dict) -> None:
-    """Patch OCI manifest annotations using oras-py."""
+    """Patch OCI manifest annotations via direct HTTP PUT."""
+    import json as _json
 
-    import oras.container as _oras_container
-    import oras.provider
-    from cua_sandbox.registry.manifest import get_manifest
+    import requests as _req
+    from cua_sandbox.registry.manifest import _registry_token, get_manifest
     from cua_sandbox.registry.ref import parse_ref
 
     registry, org, name, tag = parse_ref(ref)
-    full_repo = f"{registry}/{org}/{name}"
-    full_ref = f"{full_repo}:{tag}"
+    repo = f"{org}/{name}"
 
-    r = oras.provider.Registry()
     manifest = get_manifest(ref)
-
     existing = manifest.get("annotations") or {}
     manifest["annotations"] = {**existing, **annotations}
 
-    r.upload_manifest(manifest, _oras_container.Container(full_ref))
-    logger.info(f"Patched manifest annotations on {full_ref}")
+    body = _json.dumps(manifest).encode()
+    media_type = manifest.get("mediaType", "application/vnd.oci.image.manifest.v1+json")
+
+    token = _registry_token(registry, repo)
+    headers: dict = {"Content-Type": media_type, "Content-Length": str(len(body))}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    url = f"https://{registry}/v2/{repo}/manifests/{tag}"
+    resp = _req.put(url, headers=headers, data=body, timeout=30)
+    if resp.status_code not in (200, 201):
+        raise RuntimeError(f"Manifest PUT failed ({resp.status_code}): {resp.text[:300]}")
+    logger.info(f"Patched manifest annotations on {registry}/{repo}:{tag}")
 
 
 def _run(cmd: list[str]) -> None:

--- a/libs/python/cua-sandbox/cua_sandbox/registry/push.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/push.py
@@ -1,0 +1,231 @@
+"""Push VM disk images and container images to an OCI registry.
+
+Supports two image kinds:
+  - vm   : qcow2 disk → chunked QEMU OCI artifact (uses qemu_builder.push_image)
+  - container : Docker image → pushed via `docker push`, then annotated with
+                oras to stamp org.trycua.agent_type on the manifest
+
+The agent_type annotation (org.trycua.agent_type) is embedded in the OCI
+manifest so that Image.from_registry() can auto-detect it without the caller
+having to pass agent_type= explicitly.
+
+CLI usage:
+  # Push a QEMU VM disk (osworld)
+  python -m cua_sandbox.registry.push \\
+      --ref ghcr.io/trycua/osworld:latest \\
+      --source /path/to/disk.qcow2 \\
+      --kind vm \\
+      --agent-type osworld \\
+      --guest-os linux
+
+  # Push an AndroidWorld container image
+  python -m cua_sandbox.registry.push \\
+      --ref ghcr.io/trycua/androidworld:latest \\
+      --source androidworld:latest \\
+      --kind container \\
+      --agent-type androidworld
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+AGENT_TYPE_ANNOTATION = "org.trycua.agent_type"
+
+
+@dataclass
+class PushConfig:
+    """Parameters for pushing an image to an OCI registry."""
+
+    ref: str
+    """Full OCI reference, e.g. ghcr.io/trycua/osworld:latest."""
+
+    source: str
+    """Local disk path (for vm kind) or Docker image name (for container kind)."""
+
+    kind: str
+    """'vm' or 'container'."""
+
+    agent_type: Optional[str] = None
+    """Agent type to embed as org.trycua.agent_type manifest annotation."""
+
+    # VM-specific options
+    guest_os: str = "linux"
+    cpu: int = 4
+    ram_mb: int = 8192
+    disk_size_gb: int = 64
+
+    # Extra manifest annotations
+    extra_annotations: dict = field(default_factory=dict)
+
+
+def push_vm_image(cfg: PushConfig) -> None:
+    """Push a qcow2 disk image to an OCI registry as a QEMU artifact.
+
+    Chunks the disk into gzip-compressed layers and stamps the manifest
+    with the agent_type annotation.
+    """
+    from cua_sandbox.registry.qemu_builder import QEMUImageConfig, push_image
+
+    disk_path = Path(cfg.source)
+    if not disk_path.exists():
+        raise FileNotFoundError(f"Disk image not found: {disk_path}")
+
+    vm_cfg = QEMUImageConfig(
+        guest_os=cfg.guest_os,
+        cpu=cfg.cpu,
+        ram_mb=cfg.ram_mb,
+        disk_size_gb=cfg.disk_size_gb,
+    )
+
+    # push_image from qemu_builder does the chunking and OCI push.
+    # We extend the manifest annotations afterwards with agent_type.
+    push_image(disk_path, cfg.ref, config=vm_cfg)
+
+    if cfg.agent_type:
+        _annotate_manifest(cfg.ref, cfg.agent_type, cfg.extra_annotations)
+        logger.info(f"Annotated {cfg.ref} with {AGENT_TYPE_ANNOTATION}={cfg.agent_type}")
+
+
+def push_container_image(cfg: PushConfig) -> None:
+    """Push a Docker container image to an OCI registry and annotate it.
+
+    Assumes the image is already built locally under cfg.source.
+    Tags it as cfg.ref, pushes via docker, then annotates via oras.
+    """
+    source = cfg.source
+    ref = cfg.ref
+
+    # Tag the local image as the target ref (no-op if source == ref)
+    if source != ref:
+        logger.info(f"Tagging {source} → {ref}")
+        _run(["docker", "tag", source, ref])
+
+    logger.info(f"Pushing {ref} via docker push...")
+    _run(["docker", "push", ref])
+
+    if cfg.agent_type:
+        _annotate_manifest(ref, cfg.agent_type, cfg.extra_annotations)
+        logger.info(f"Annotated {ref} with {AGENT_TYPE_ANNOTATION}={cfg.agent_type}")
+
+
+def push(cfg: PushConfig) -> None:
+    """Dispatch to push_vm_image or push_container_image based on cfg.kind."""
+    if cfg.kind == "vm":
+        push_vm_image(cfg)
+    elif cfg.kind == "container":
+        push_container_image(cfg)
+    else:
+        raise ValueError(f"Unknown kind {cfg.kind!r}. Expected 'vm' or 'container'.")
+
+
+# ── Internal helpers ─────────────────────────────────────────────────────────
+
+
+def _annotate_manifest(ref: str, agent_type: str, extra: dict) -> None:
+    """Attach org.trycua.agent_type (and any extra annotations) to an OCI manifest.
+
+    Uses `oras manifest annotate` which rewrites the manifest in-registry.
+    Falls back to a pure-Python oras approach if the CLI is unavailable.
+    """
+    annotations = {AGENT_TYPE_ANNOTATION: agent_type, **extra}
+
+    # Try oras CLI first (most reliable for arbitrary registries)
+    oras_cli = _which("oras")
+    if oras_cli:
+        args = [oras_cli, "manifest", "annotate", ref]
+        for k, v in annotations.items():
+            args += ["--annotation", f"{k}={v}"]
+        _run(args)
+        return
+
+    # Fallback: patch manifest directly via oras-py
+    _annotate_via_oras_py(ref, annotations)
+
+
+def _annotate_via_oras_py(ref: str, annotations: dict) -> None:
+    """Patch OCI manifest annotations using oras-py."""
+    import json
+
+    import oras.provider
+    from cua_sandbox.registry.manifest import get_manifest
+    from cua_sandbox.registry.ref import parse_ref
+
+    registry, org, name, tag = parse_ref(ref)
+    full_repo = f"{registry}/{org}/{name}"
+    full_ref = f"{full_repo}:{tag}"
+
+    r = oras.provider.Registry()
+    manifest = get_manifest(ref)
+
+    existing = manifest.get("annotations") or {}
+    manifest["annotations"] = {**existing, **annotations}
+
+    r.put_manifest(full_ref, json.dumps(manifest))
+    logger.info(f"Patched manifest annotations on {full_ref}")
+
+
+def _run(cmd: list[str]) -> None:
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Command failed: {' '.join(cmd)}\n" f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+
+def _which(name: str) -> Optional[str]:
+    import shutil
+
+    return shutil.which(name)
+
+
+# ── CLI entry point ──────────────────────────────────────────────────────────
+
+
+def _main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Push a VM disk or container image to an OCI registry with agent_type annotation."
+    )
+    parser.add_argument("--ref", required=True, help="OCI ref, e.g. ghcr.io/trycua/osworld:latest")
+    parser.add_argument(
+        "--source", required=True, help="Local disk path (vm) or Docker image name (container)"
+    )
+    parser.add_argument("--kind", required=True, choices=["vm", "container"], help="Image kind")
+    parser.add_argument(
+        "--agent-type", default=None, help="Agent type to annotate, e.g. osworld or androidworld"
+    )
+    parser.add_argument(
+        "--guest-os", default="linux", help="Guest OS for VM config (default: linux)"
+    )
+    parser.add_argument("--cpu", type=int, default=4)
+    parser.add_argument("--ram-mb", type=int, default=8192)
+    parser.add_argument("--disk-size-gb", type=int, default=64)
+
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    cfg = PushConfig(
+        ref=args.ref,
+        source=args.source,
+        kind=args.kind,
+        agent_type=args.agent_type,
+        guest_os=args.guest_os,
+        cpu=args.cpu,
+        ram_mb=args.ram_mb,
+        disk_size_gb=args.disk_size_gb,
+    )
+    push(cfg)
+    print(f"Done: {args.ref}")
+
+
+if __name__ == "__main__":
+    _main()

--- a/libs/python/cua-sandbox/cua_sandbox/registry/push.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/push.py
@@ -1,7 +1,8 @@
 """Push VM disk images and container images to an OCI registry.
 
-Supports two image kinds:
-  - vm   : qcow2 disk → chunked QEMU OCI artifact (uses qemu_builder.push_image)
+Supports three image kinds:
+  - vm        : qcow2 disk → chunked QEMU OCI artifact (uses qemu_builder.push_image)
+  - lume      : macOS VM → pushed via `lume push` CLI, then annotated
   - container : Docker image → pushed via `docker push`, then annotated with
                 oras to stamp org.trycua.agent_type on the manifest
 
@@ -24,6 +25,13 @@ CLI usage:
       --source androidworld:latest \\
       --kind container \\
       --agent-type androidworld
+
+  # Push a macOS lume VM and annotate it
+  python -m cua_sandbox.registry.push \\
+      --ref ghcr.io/trycua/macos-tahoe-cua:latest \\
+      --source macos-tahoe-cua \\
+      --kind lume \\
+      --agent-type osworld
 """
 
 from __future__ import annotations
@@ -50,7 +58,7 @@ class PushConfig:
     """Local disk path (for vm kind) or Docker image name (for container kind)."""
 
     kind: str
-    """'vm' or 'container'."""
+    """'vm', 'lume', or 'container'."""
 
     agent_type: Optional[str] = None
     """Agent type to embed as org.trycua.agent_type manifest annotation."""
@@ -115,14 +123,54 @@ def push_container_image(cfg: PushConfig) -> None:
         logger.info(f"Annotated {ref} with {AGENT_TYPE_ANNOTATION}={cfg.agent_type}")
 
 
+def push_lume_image(cfg: PushConfig) -> None:
+    """Push a macOS lume VM to an OCI registry via the `lume push` CLI.
+
+    cfg.source is the lume VM name (as shown by `lume list`).
+    The ref is parsed into registry/organization/name:tag components that
+    lume expects separately.
+
+    After the push, the manifest is annotated with org.trycua.agent_type.
+    """
+    lume = _which("lume")
+    if not lume:
+        raise RuntimeError(
+            "lume CLI not found. Install from https://github.com/trycua/cua/tree/main/libs/lume"
+        )
+
+    from cua_sandbox.registry.ref import parse_ref
+
+    registry, org, name, tag = parse_ref(cfg.ref)
+
+    logger.info(f"Pushing lume VM '{cfg.source}' → {cfg.ref} via lume CLI...")
+    _run(
+        [
+            lume,
+            "push",
+            cfg.source,
+            f"{name}:{tag}",
+            "--registry",
+            registry,
+            "--organization",
+            org,
+        ]
+    )
+
+    if cfg.agent_type:
+        _annotate_manifest(cfg.ref, cfg.agent_type, cfg.extra_annotations)
+        logger.info(f"Annotated {cfg.ref} with {AGENT_TYPE_ANNOTATION}={cfg.agent_type}")
+
+
 def push(cfg: PushConfig) -> None:
-    """Dispatch to push_vm_image or push_container_image based on cfg.kind."""
+    """Dispatch to the appropriate push function based on cfg.kind."""
     if cfg.kind == "vm":
         push_vm_image(cfg)
+    elif cfg.kind == "lume":
+        push_lume_image(cfg)
     elif cfg.kind == "container":
         push_container_image(cfg)
     else:
-        raise ValueError(f"Unknown kind {cfg.kind!r}. Expected 'vm' or 'container'.")
+        raise ValueError(f"Unknown kind {cfg.kind!r}. Expected 'vm', 'lume', or 'container'.")
 
 
 # ── Internal helpers ─────────────────────────────────────────────────────────
@@ -198,7 +246,12 @@ def _main() -> None:
     parser.add_argument(
         "--source", required=True, help="Local disk path (vm) or Docker image name (container)"
     )
-    parser.add_argument("--kind", required=True, choices=["vm", "container"], help="Image kind")
+    parser.add_argument(
+        "--kind",
+        required=True,
+        choices=["vm", "lume", "container"],
+        help="Image kind: vm (QEMU qcow2), lume (macOS via lume CLI), or container (Docker)",
+    )
     parser.add_argument(
         "--agent-type", default=None, help="Agent type to annotate, e.g. osworld or androidworld"
     )

--- a/libs/python/cua-sandbox/cua_sandbox/registry/push.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/push.py
@@ -68,6 +68,9 @@ class PushConfig:
     ram_mb: int = 8192
     disk_size_gb: int = 64
 
+    # Multi-arch: "arm64" | "amd64" | None (single-arch legacy push)
+    arch: Optional[str] = None
+
     # Extra manifest annotations
     extra_annotations: dict = field(default_factory=dict)
 
@@ -75,8 +78,9 @@ class PushConfig:
 def push_vm_image(cfg: PushConfig) -> None:
     """Push a qcow2 disk image to an OCI registry as a QEMU artifact.
 
-    Chunks the disk into gzip-compressed layers and stamps the manifest
-    with the agent_type annotation.
+    When cfg.arch is set, pushes a per-arch manifest and updates the
+    multi-arch manifest index at cfg.ref.  Otherwise pushes directly to ref.
+    The agent_type annotation is embedded in the manifest (no separate PUT needed).
     """
     from cua_sandbox.registry.qemu_builder import QEMUImageConfig, push_image
 
@@ -91,13 +95,7 @@ def push_vm_image(cfg: PushConfig) -> None:
         disk_size_gb=cfg.disk_size_gb,
     )
 
-    # push_image from qemu_builder does the chunking and OCI push.
-    # We extend the manifest annotations afterwards with agent_type.
-    push_image(disk_path, cfg.ref, config=vm_cfg)
-
-    if cfg.agent_type:
-        _annotate_manifest(cfg.ref, cfg.agent_type, cfg.extra_annotations)
-        logger.info(f"Annotated {cfg.ref} with {AGENT_TYPE_ANNOTATION}={cfg.agent_type}")
+    push_image(disk_path, cfg.ref, config=vm_cfg, arch=cfg.arch, agent_type=cfg.agent_type)
 
 
 def push_container_image(cfg: PushConfig) -> None:
@@ -295,6 +293,13 @@ def _main() -> None:
     parser.add_argument("--cpu", type=int, default=4)
     parser.add_argument("--ram-mb", type=int, default=8192)
     parser.add_argument("--disk-size-gb", type=int, default=64)
+    parser.add_argument(
+        "--arch",
+        default=None,
+        choices=["arm64", "amd64"],
+        help="OCI architecture for multi-arch push (arm64 or amd64). "
+        "When set, pushes a per-arch manifest and updates the manifest index at ref.",
+    )
 
     args = parser.parse_args()
 
@@ -309,6 +314,7 @@ def _main() -> None:
         cpu=args.cpu,
         ram_mb=args.ram_mb,
         disk_size_gb=args.disk_size_gb,
+        arch=args.arch,
     )
     push(cfg)
     print(f"Done: {args.ref}")

--- a/libs/python/cua-sandbox/cua_sandbox/registry/push.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/push.py
@@ -225,8 +225,8 @@ def _annotate_manifest(ref: str, agent_type: str, extra: dict) -> None:
 
 def _annotate_via_oras_py(ref: str, annotations: dict) -> None:
     """Patch OCI manifest annotations using oras-py."""
-    import json
 
+    import oras.container as _oras_container
     import oras.provider
     from cua_sandbox.registry.manifest import get_manifest
     from cua_sandbox.registry.ref import parse_ref
@@ -241,7 +241,7 @@ def _annotate_via_oras_py(ref: str, annotations: dict) -> None:
     existing = manifest.get("annotations") or {}
     manifest["annotations"] = {**existing, **annotations}
 
-    r.put_manifest(full_ref, json.dumps(manifest))
+    r.upload_manifest(manifest, _oras_container.Container(full_ref))
     logger.info(f"Patched manifest annotations on {full_ref}")
 
 

--- a/libs/python/cua-sandbox/cua_sandbox/registry/push.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/push.py
@@ -57,7 +57,7 @@ class PushConfig:
     """Local disk path (for vm kind) or Docker image name (for container kind)."""
 
     kind: str
-    """'vm', 'lume', or 'container'."""
+    """'vm', 'lume', 'avd', or 'container'."""
 
     agent_type: Optional[str] = None
     """Agent type to embed as org.trycua.agent_type manifest annotation."""
@@ -162,16 +162,41 @@ def push_lume_image(cfg: PushConfig) -> None:
         logger.info(f"Annotated {cfg.ref} with {AGENT_TYPE_ANNOTATION}={cfg.agent_type}")
 
 
+def push_avd_image(cfg: PushConfig) -> None:
+    """Push a pre-baked Android AVD directory to an OCI registry.
+
+    cfg.source is the path to the ``<name>.avd`` directory.
+    Creates / updates a multi-arch manifest index at cfg.ref.
+    """
+    from cua_sandbox.registry.avd_builder import AVDConfig, push_avd
+
+    avd_dir = Path(cfg.source)
+    if not avd_dir.is_dir():
+        raise FileNotFoundError(f"AVD directory not found: {avd_dir}")
+
+    avd_cfg = AVDConfig(
+        api_level=33,
+        device_id="pixel_6",
+        android_world=(cfg.agent_type == "androidworld"),
+        agent_type=cfg.agent_type,
+    )
+    push_avd(avd_dir, cfg.ref, config=avd_cfg, agent_type=cfg.agent_type)
+
+
 def push(cfg: PushConfig) -> None:
     """Dispatch to the appropriate push function based on cfg.kind."""
     if cfg.kind == "vm":
         push_vm_image(cfg)
     elif cfg.kind == "lume":
         push_lume_image(cfg)
+    elif cfg.kind == "avd":
+        push_avd_image(cfg)
     elif cfg.kind == "container":
         push_container_image(cfg)
     else:
-        raise ValueError(f"Unknown kind {cfg.kind!r}. Expected 'vm', 'lume', or 'container'.")
+        raise ValueError(
+            f"Unknown kind {cfg.kind!r}. Expected 'vm', 'lume', 'avd', or 'container'."
+        )
 
 
 # ── Internal helpers ─────────────────────────────────────────────────────────
@@ -250,8 +275,8 @@ def _main() -> None:
     parser.add_argument(
         "--kind",
         required=True,
-        choices=["vm", "lume", "container"],
-        help="Image kind: vm (QEMU qcow2), lume (macOS via lume CLI), or container (Docker)",
+        choices=["vm", "lume", "avd", "container"],
+        help="Image kind: vm (QEMU qcow2), lume (macOS via lume CLI), avd (Android AVD dir), or container (Docker)",
     )
     parser.add_argument(
         "--agent-type", default=None, help="Agent type to annotate, e.g. osworld or androidworld"

--- a/libs/python/cua-sandbox/cua_sandbox/registry/push.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/push.py
@@ -26,12 +26,11 @@ CLI usage:
       --kind container \\
       --agent-type androidworld
 
-  # Push a macOS lume VM and annotate it
+  # Push a macOS lume VM (standard cua-computer-server image — no agent-type needed)
   python -m cua_sandbox.registry.push \\
       --ref ghcr.io/trycua/macos-tahoe-cua:latest \\
       --source macos-tahoe-cua \\
-      --kind lume \\
-      --agent-type osworld
+      --kind lume
 """
 
 from __future__ import annotations
@@ -130,7 +129,9 @@ def push_lume_image(cfg: PushConfig) -> None:
     The ref is parsed into registry/organization/name:tag components that
     lume expects separately.
 
-    After the push, the manifest is annotated with org.trycua.agent_type.
+    Standard cua images (macos-tahoe-cua, etc.) run cua-computer-server and
+    do not need an agent_type annotation — leave cfg.agent_type as None for
+    those. Only set it for custom benchmark images (e.g. agent_type="osworld").
     """
     lume = _which("lume")
     if not lume:

--- a/libs/python/cua-sandbox/cua_sandbox/registry/qemu_builder.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/qemu_builder.py
@@ -577,6 +577,8 @@ def push_image(
 
     Chunks the disk into gzip-compressed ~500MB layers with part annotations.
     """
+    import os
+
     import oras.provider
     from cua_sandbox.registry.media_types import QEMU_CONFIG, QEMU_DISK_GZIP
     from cua_sandbox.registry.ref import parse_ref
@@ -589,7 +591,15 @@ def push_image(
     registry, org, name, tag = parse_ref(ref)
     full_repo = f"{registry}/{org}/{name}"
 
-    r = oras.provider.Registry()
+    r = oras.provider.Registry(hostname=registry)
+    username = os.environ.get("ORAS_USERNAME") or os.environ.get("REGISTRY_USERNAME")
+    password = (
+        os.environ.get("ORAS_PASSWORD")
+        or os.environ.get("REGISTRY_PASSWORD")
+        or os.environ.get("GITHUB_TOKEN")
+    )
+    if username and password:
+        r.login(username=username, password=password, hostname=registry)
 
     with tempfile.TemporaryDirectory() as tmp:
         tmp_dir = Path(tmp)
@@ -639,12 +649,18 @@ def push_image(
                 )
 
                 # Push blob
-                r.push_blob(full_repo, chunk_path, chunk_digest)
+                r.upload_blob(str(chunk_path), full_repo, layers[-1])
 
         # Push config blob
-        r.push_blob(full_repo, config_path, config_digest)
+        r.upload_blob(
+            str(config_path),
+            full_repo,
+            {"digest": config_digest, "size": len(config_data), "mediaType": QEMU_CONFIG},
+        )
 
         # Create and push manifest
+        import oras.container as _oras_container
+
         manifest = {
             "schemaVersion": 2,
             "mediaType": "application/vnd.oci.image.manifest.v1+json",
@@ -662,7 +678,7 @@ def push_image(
             },
         }
 
-        r.put_manifest(f"{full_repo}:{tag}", json.dumps(manifest))
+        r.upload_manifest(manifest, _oras_container.Container(f"{full_repo}:{tag}"))
         logger.info(f"Pushed {ref} ({part_total} layers, {disk_size / 1024 / 1024:.0f} MB)")
 
 
@@ -674,14 +690,12 @@ def pull_qemu_image(ref: str, dest_dir: Optional[Path] = None) -> tuple[QEMUImag
 
     Returns (config, disk_path).
     """
-    import oras.provider
     from cua_sandbox.registry.cache import ImageCache
     from cua_sandbox.registry.manifest import get_manifest
     from cua_sandbox.registry.media_types import QEMU_DISK, QEMU_DISK_GZIP
     from cua_sandbox.registry.ref import parse_ref
 
     registry, org, name, tag = parse_ref(ref)
-    full_repo = f"{registry}/{org}/{name}"
 
     cache = ImageCache()
     if dest_dir is None:
@@ -703,14 +717,27 @@ def pull_qemu_image(ref: str, dest_dir: Optional[Path] = None) -> tuple[QEMUImag
         )
 
     manifest = get_manifest(ref)
-    r = oras.provider.Registry()
+
+    from cua_sandbox.registry.manifest import _registry_token
+
+    def _fetch_blob(blob_digest: str) -> bytes:
+        import requests as _req
+
+        token = _registry_token(registry, f"{org}/{name}")
+        headers: dict = {}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        url = f"https://{registry}/v2/{org}/{name}/blobs/{blob_digest}"
+        r = _req.get(url, headers=headers, timeout=120, stream=True)
+        r.raise_for_status()
+        return r.content
 
     # Download config
     config_blob = manifest.get("config", {})
     if config_blob.get("digest"):
-        resp = r.get_blob(full_repo, config_blob["digest"])
-        config_path.write_bytes(resp.content)
-        config_data = resp.json() if hasattr(resp, "json") else {}
+        raw = _fetch_blob(config_blob["digest"])
+        config_path.write_bytes(raw)
+        config_data = json.loads(raw)
     else:
         config_data = {}
 
@@ -744,8 +771,7 @@ def pull_qemu_image(ref: str, dest_dir: Optional[Path] = None) -> tuple[QEMUImag
             size = layer.get("size", 0)
             logger.info(f"  part {part_num}/{total}: {size / 1024 / 1024:.1f} MB")
 
-            resp = r.get_blob(full_repo, digest)
-            data = resp.content
+            data = _fetch_blob(digest)
 
             # Decompress gzip if needed
             if mt == QEMU_DISK_GZIP or mt.endswith("+gzip"):

--- a/libs/python/cua-sandbox/cua_sandbox/registry/qemu_builder.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/qemu_builder.py
@@ -568,14 +568,88 @@ def _sha256_file(path: Path) -> str:
     return h.hexdigest()
 
 
+def _host_oci_arch() -> str:
+    """Return the OCI architecture string for the current host."""
+    import platform as _plat
+
+    machine = _plat.machine().lower()
+    return "arm64" if machine in ("arm64", "aarch64") else "amd64"
+
+
+def _put_manifest_raw(r, full_repo: str, tag: str, manifest: dict) -> None:
+    """PUT an OCI manifest (any mediaType) via raw HTTP, bypassing oras-py schema validation."""
+    import oras.container as _oras_container
+
+    body = json.dumps(manifest).encode()
+    container = _oras_container.Container(f"{full_repo}:{tag}")
+    url = f"{r.prefix}://{container.manifest_url()}"
+    headers = {
+        "Content-Type": manifest.get("mediaType", "application/vnd.oci.image.index.v1+json"),
+        "Content-Length": str(len(body)),
+    }
+    resp = r.do_request(url, "PUT", headers=headers, data=body)
+    if resp.status_code not in (200, 201):
+        raise RuntimeError(f"PUT manifest failed ({resp.status_code}): {resp.text[:300]}")
+    logger.info(f"PUT manifest → {full_repo}:{tag} ({resp.status_code})")
+
+
+def _upsert_manifest_index(
+    r,
+    full_repo: str,
+    tag: str,
+    arch: str,
+    manifest_digest: str,
+    manifest_size: int,
+    agent_type: Optional[str],
+) -> None:
+    """Create or update a multi-arch OCI manifest index at ``full_repo:tag``."""
+    existing_manifests: list[dict] = []
+    try:
+        existing = r.get_manifest(f"{full_repo}:{tag}")
+        if existing.get("mediaType") == "application/vnd.oci.image.index.v1+json":
+            existing_manifests = [
+                m
+                for m in existing.get("manifests", [])
+                if m.get("platform", {}).get("architecture") != arch
+            ]
+    except Exception:
+        pass
+
+    new_entry: dict = {
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "digest": manifest_digest,
+        "size": manifest_size,
+        "platform": {"os": "linux", "architecture": arch},
+    }
+    if agent_type:
+        new_entry["annotations"] = {"org.trycua.agent_type": agent_type}
+
+    index: dict = {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": existing_manifests + [new_entry],
+    }
+    if agent_type:
+        index["annotations"] = {"org.trycua.agent_type": agent_type}
+    _put_manifest_raw(r, full_repo, tag, index)
+
+
 def push_image(
     disk_path: str | Path,
     ref: str,
     config: Optional[QEMUImageConfig] = None,
+    *,
+    arch: Optional[str] = None,
+    agent_type: Optional[str] = None,
 ) -> None:
     """Push a qcow2 disk image to an OCI registry.
 
     Chunks the disk into gzip-compressed ~500MB layers with part annotations.
+
+    When ``arch`` is provided (``"arm64"`` or ``"amd64"``), the per-arch
+    manifest is pushed as ``ref-{arch}`` and the manifest index at ``ref`` is
+    updated, enabling multi-arch pulls.  When ``arch`` is ``None`` the image
+    is pushed directly to ``ref`` (legacy single-arch behaviour).
     """
     import os
 
@@ -588,6 +662,11 @@ def push_image(
         raise FileNotFoundError(f"Disk image not found: {disk_path}")
 
     config = config or QEMUImageConfig()
+    # Sync architecture field in config
+    if arch:
+        oci_to_qemu = {"arm64": "aarch64", "amd64": "x86_64"}
+        config.architecture = oci_to_qemu.get(arch, arch)
+
     registry, org, name, tag = parse_ref(ref)
     full_repo = f"{registry}/{org}/{name}"
 
@@ -658,8 +737,19 @@ def push_image(
             {"digest": config_digest, "size": len(config_data), "mediaType": QEMU_CONFIG},
         )
 
-        # Create and push manifest
+        # Build manifest
         import oras.container as _oras_container
+
+        manifest_annotations: dict = {
+            "org.trycua.qemu.guest-os": config.guest_os,
+            "org.trycua.qemu.version": config.version,
+            "org.trycua.qemu.disk-format": config.disk_format,
+            "org.trycua.qemu.uncompressed-disk-size": str(disk_size),
+        }
+        if arch:
+            manifest_annotations["org.trycua.qemu.architecture"] = arch
+        if agent_type:
+            manifest_annotations["org.trycua.agent_type"] = agent_type
 
         manifest = {
             "schemaVersion": 2,
@@ -670,23 +760,36 @@ def push_image(
                 "size": len(config_data),
             },
             "layers": layers,
-            "annotations": {
-                "org.trycua.qemu.guest-os": config.guest_os,
-                "org.trycua.qemu.version": config.version,
-                "org.trycua.qemu.disk-format": config.disk_format,
-                "org.trycua.qemu.uncompressed-disk-size": str(disk_size),
-            },
+            "annotations": manifest_annotations,
         }
 
-        r.upload_manifest(manifest, _oras_container.Container(f"{full_repo}:{tag}"))
-        logger.info(f"Pushed {ref} ({part_total} layers, {disk_size / 1024 / 1024:.0f} MB)")
+        if arch:
+            # Push per-arch manifest at ref-{arch}, then update the index at ref
+            arch_tag = f"{tag}-{arch}"
+            r.upload_manifest(manifest, _oras_container.Container(f"{full_repo}:{arch_tag}"))
+            logger.info(
+                f"Pushed {full_repo}:{arch_tag} ({part_total} layers, {disk_size / 1024 / 1024:.0f} MB)"
+            )
+
+            # Compute digest of manifest we just pushed for the index entry
+            manifest_body = json.dumps(manifest).encode()
+            manifest_digest = f"sha256:{hashlib.sha256(manifest_body).hexdigest()}"
+            _upsert_manifest_index(
+                r, full_repo, tag, arch, manifest_digest, len(manifest_body), agent_type
+            )
+            logger.info(f"Updated manifest index → {full_repo}:{tag}")
+        else:
+            r.upload_manifest(manifest, _oras_container.Container(f"{full_repo}:{tag}"))
+            logger.info(f"Pushed {ref} ({part_total} layers, {disk_size / 1024 / 1024:.0f} MB)")
 
 
 def pull_qemu_image(ref: str, dest_dir: Optional[Path] = None) -> tuple[QEMUImageConfig, Path]:
     """Pull a QEMU VM image from an OCI registry.
 
     Downloads gzip-compressed disk chunks, decompresses, and reassembles
-    into a qcow2 disk image.
+    into a qcow2 disk image.  If the ref resolves to a multi-arch manifest
+    index the correct arch variant is selected automatically based on the
+    host architecture.
 
     Returns (config, disk_path).
     """
@@ -697,9 +800,40 @@ def pull_qemu_image(ref: str, dest_dir: Optional[Path] = None) -> tuple[QEMUImag
 
     registry, org, name, tag = parse_ref(ref)
 
+    host_arch = _host_oci_arch()
+
     cache = ImageCache()
+    # Resolve manifest index before determining cache dir so arch is known
+    manifest = get_manifest(ref)
+    resolved_arch = host_arch
+
+    # If this is a manifest index, resolve to the arch-specific manifest
+    if manifest.get("mediaType") == "application/vnd.oci.image.index.v1+json":
+        manifests = manifest.get("manifests", [])
+        # Prefer exact host arch, fall back to amd64
+        chosen = None
+        for m in manifests:
+            if m.get("platform", {}).get("architecture") == host_arch:
+                chosen = m
+                break
+        if chosen is None:
+            for m in manifests:
+                if m.get("platform", {}).get("architecture") == "amd64":
+                    chosen = m
+                    break
+        if chosen is None and manifests:
+            chosen = manifests[0]
+        if chosen is None:
+            raise RuntimeError(f"No suitable arch variant found in manifest index for {ref}")
+        resolved_arch = chosen["platform"]["architecture"]
+        arch_tag = f"{tag}-{resolved_arch}"
+        logger.info(f"Resolving multi-arch index → {arch_tag} (host={host_arch})")
+        manifest = get_manifest(f"{registry}/{org}/{name}:{arch_tag}")
+
     if dest_dir is None:
-        dest_dir = cache.image_dir(registry, org, name, tag)
+        # Use arch-tagged subdirectory so arm64/amd64 don't overwrite each other
+        base_dir = cache.image_dir(registry, org, name, tag)
+        dest_dir = base_dir / resolved_arch
     dest_dir.mkdir(parents=True, exist_ok=True)
 
     disk_path = dest_dir / "disk.qcow2"
@@ -715,8 +849,6 @@ def pull_qemu_image(ref: str, dest_dir: Optional[Path] = None) -> tuple[QEMUImag
             ),
             disk_path,
         )
-
-    manifest = get_manifest(ref)
 
     from cua_sandbox.registry.manifest import _registry_token
 

--- a/libs/python/cua-sandbox/cua_sandbox/registry/resolve.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/resolve.py
@@ -104,6 +104,15 @@ def pull_image(
         logger.info(f"Container image {image._registry} — use docker pull")
         return resolved, dest_dir
 
+    # Android AVD format — extract to ~/.cua/android-avd/
+    if fmt == ImageFormat.ANDROID_AVD:
+        from cua_sandbox.registry.avd_builder import pull_avd
+
+        avd_home = dest_dir.parent  # use the same cache hierarchy
+        avd_config, avd_path = pull_avd(image._registry, avd_home, force=force)
+        logger.info(f"Android AVD extracted to {avd_path}")
+        return resolved, avd_path
+
     # QEMU format — use dedicated pull
     if fmt == ImageFormat.QEMU:
         from cua_sandbox.registry.qemu_builder import pull_qemu_image

--- a/libs/python/cua-sandbox/cua_sandbox/registry/resolve.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/resolve.py
@@ -18,7 +18,6 @@ from cua_sandbox.registry.manifest import (
     ImageFormat,
     detect_format,
     detect_kind,
-    detect_os,
     detect_os_from_config,
     get_manifest,
 )
@@ -40,6 +39,7 @@ def resolve_image_kind(image: Image) -> Image:
     manifest = get_manifest(image._registry)
     kind = detect_kind(manifest)
     os_type = detect_os_from_config(image._registry, manifest) or image.os_type
+    agent_type = image._agent_type or manifest.get("annotations", {}).get("org.trycua.agent_type")
 
     return Image(
         os_type=os_type,
@@ -52,6 +52,7 @@ def resolve_image_kind(image: Image) -> Image:
         _files=image._files,
         _registry=image._registry,
         _disk_path=image._disk_path,
+        _agent_type=agent_type,
     )
 
 
@@ -79,6 +80,7 @@ def pull_image(
     kind = detect_kind(manifest)
     os_type = detect_os_from_config(image._registry, manifest) or image.os_type
     fmt = detect_format(manifest)
+    agent_type = image._agent_type or manifest.get("annotations", {}).get("org.trycua.agent_type")
 
     resolved = Image(
         os_type=os_type,
@@ -91,6 +93,7 @@ def pull_image(
         _files=image._files,
         _registry=image._registry,
         _disk_path=image._disk_path,
+        _agent_type=agent_type,
     )
 
     # Cache the manifest
@@ -104,6 +107,7 @@ def pull_image(
     # QEMU format — use dedicated pull
     if fmt == ImageFormat.QEMU:
         from cua_sandbox.registry.qemu_builder import pull_qemu_image
+
         disk_path = dest_dir / "disk.qcow2"
         if not force and disk_path.exists():
             logger.info(f"Using cached QEMU image at {dest_dir}")

--- a/libs/python/cua-sandbox/cua_sandbox/runtime/android_emulator.py
+++ b/libs/python/cua-sandbox/cua_sandbox/runtime/android_emulator.py
@@ -167,6 +167,19 @@ def _ensure_sdk() -> Path:
     return sdk
 
 
+def _find_free_server_port(preferred: int = 5000) -> int:
+    """Return a free TCP port, starting from preferred."""
+    for port in range(preferred, preferred + 100):
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                s.bind(("127.0.0.1", port))
+                return port
+        except OSError:
+            continue
+    raise RuntimeError(f"No free port found in range {preferred}-{preferred + 100}")
+
+
 def _find_free_emulator_port() -> int:
     """Return a free odd adb_port (console_port = adb_port - 1, must be even).
 
@@ -239,6 +252,7 @@ class AndroidEmulatorRuntime(Runtime):
         self.headless = headless
         self.grpc_port = grpc_port
         self._proc: Optional[subprocess.Popen] = None
+        self._aw_proc: Optional[subprocess.Popen] = None  # AndroidWorld server subprocess
         self._avd_name: Optional[str] = None
         self._sdk: Optional[Path] = None
 
@@ -267,6 +281,20 @@ class AndroidEmulatorRuntime(Runtime):
         env["ANDROID_SDK_ROOT"] = str(self._sdk)
         env["ANDROID_AVD_HOME"] = str(_AVD_HOME)
         env["ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL"] = "10"
+
+        # Pull AVD from OCI registry if the image has a registry reference
+        if image._registry:
+            from cua_sandbox.registry.avd_builder import pull_avd
+
+            logger.info(f"Pulling AndroidWorld AVD from {image._registry} ...")
+            avd_config, _ = pull_avd(image._registry, _AVD_HOME)
+            # Override runtime settings from the baked AVD config
+            if avd_config.api_level:
+                self.api_level = avd_config.api_level
+            if avd_config.arch:
+                arch = avd_config.arch
+                package = f"system-images;android-{self.api_level};{self.img_type};{arch}"
+                abi = f"{self.img_type}/{arch}"
 
         # Create AVD if it doesn't exist
         avd_dir = _AVD_HOME / f"{name}.avd"
@@ -344,11 +372,32 @@ class AndroidEmulatorRuntime(Runtime):
             name=name,
             environment="android",
             grpc_port=resolved_grpc_port,
+            agent_type=image._agent_type,
         )
 
-        # Install APKs from image layers
+        # Wait for boot, then apply image layers (APK installs, etc.)
         await self.is_ready(info)
         await self._apply_layers(image, adb, env)
+
+        # If this is an AndroidWorld image, launch the host-side FastAPI server
+        if image._agent_type == "androidworld":
+            console_port = self.adb_port - 1
+            server_port = await self._start_androidworld_server(
+                console_port=console_port,
+                grpc_port=resolved_grpc_port,
+                sdk=self._sdk,
+                adb=adb,
+            )
+            # Overwrite api_port so sandbox.py connects to the FastAPI server,
+            # not the ADB port. The ADB serial is known internally by the server.
+            info = RuntimeInfo(
+                host="localhost",
+                api_port=server_port,
+                name=name,
+                environment="android",
+                grpc_port=resolved_grpc_port,
+                agent_type="androidworld",
+            )
 
         return info
 
@@ -427,6 +476,62 @@ class AndroidEmulatorRuntime(Runtime):
             elif lt == "pip_install":
                 # pip install via termux or similar — skip for now
                 logger.warning("pip_install not supported on Android emulator, skipping")
+
+    async def _start_androidworld_server(
+        self,
+        console_port: int,
+        grpc_port: int,
+        sdk: Optional[Path],
+        adb: str,
+    ) -> int:
+        """Launch the AndroidWorld FastAPI server as a host subprocess.
+
+        Returns the port the server is listening on.
+        """
+        import sys
+
+        # Pick a free port for the server
+        server_port = _find_free_server_port(5000)
+
+        env = os.environ.copy()
+        env["AW_CONSOLE_PORT"] = str(console_port)
+        env["AW_GRPC_PORT"] = str(grpc_port)
+        env["AW_ADB_PATH"] = adb
+        env["AW_EMULATOR_SETUP"] = "false"  # assume pre-baked AVD
+        env["AW_FREEZE_DATETIME"] = "true"
+        env["AW_PORT"] = str(server_port)
+        env["AW_HOST"] = "0.0.0.0"
+
+        logger.info(f"Starting AndroidWorld server on port {server_port} ...")
+        self._aw_proc = subprocess.Popen(
+            [sys.executable, "-m", "cua_sandbox._androidworld_server"],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+
+        # Wait for /health to respond
+        await self._wait_for_aw_server(server_port, timeout=120)
+        logger.info(f"AndroidWorld server ready on port {server_port}.")
+        return server_port
+
+    @staticmethod
+    async def _wait_for_aw_server(port: int, timeout: float = 120) -> None:
+        """Poll GET /health until the AndroidWorld server responds."""
+        import httpx
+
+        url = f"http://localhost:{port}/health"
+        deadline = asyncio.get_event_loop().time() + timeout
+        async with httpx.AsyncClient(timeout=5) as client:
+            while asyncio.get_event_loop().time() < deadline:
+                try:
+                    resp = await client.get(url)
+                    if resp.status_code == 200:
+                        return
+                except Exception:
+                    pass
+                await asyncio.sleep(3)
+        raise TimeoutError(f"AndroidWorld server did not become ready within {timeout}s")
 
     @staticmethod
     async def _build_pwa_apk(
@@ -795,6 +900,15 @@ class AndroidEmulatorRuntime(Runtime):
         return result
 
     async def stop(self, name: str) -> None:
+        # Stop AndroidWorld server first
+        if self._aw_proc and self._aw_proc.poll() is None:
+            self._aw_proc.terminate()
+            try:
+                self._aw_proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self._aw_proc.kill()
+            self._aw_proc = None
+
         if self._proc and self._proc.poll() is None:
             self._proc.terminate()
             try:

--- a/libs/python/cua-sandbox/cua_sandbox/runtime/android_emulator.py
+++ b/libs/python/cua-sandbox/cua_sandbox/runtime/android_emulator.py
@@ -487,6 +487,16 @@ class AndroidEmulatorRuntime(Runtime):
         """Launch the AndroidWorld FastAPI server as a host subprocess.
 
         Returns the port the server is listening on.
+
+        The server requires ``android_world`` to be importable. If it lives in
+        a separate virtualenv, point to it via two env vars (set before
+        launching your script, or passed explicitly):
+
+          AW_PYTHON     – path to the Python executable that has android_world
+                          installed (default: sys.executable)
+          AW_SOURCE_DIR – directory to prepend to PYTHONPATH so that a source
+                          checkout of android_world (e.g. /tmp/android_world)
+                          is importable without installation
         """
         import sys
 
@@ -502,9 +512,16 @@ class AndroidEmulatorRuntime(Runtime):
         env["AW_PORT"] = str(server_port)
         env["AW_HOST"] = "0.0.0.0"
 
+        # Allow android_world to live in a separate venv / source checkout.
+        python_bin = os.environ.get("AW_PYTHON") or sys.executable
+        aw_source_dir = os.environ.get("AW_SOURCE_DIR", "")
+        if aw_source_dir:
+            existing = env.get("PYTHONPATH", "")
+            env["PYTHONPATH"] = f"{aw_source_dir}:{existing}" if existing else aw_source_dir
+
         logger.info(f"Starting AndroidWorld server on port {server_port} ...")
         self._aw_proc = subprocess.Popen(
-            [sys.executable, "-m", "cua_sandbox._androidworld_server"],
+            [python_bin, "-m", "cua_sandbox._androidworld_server"],
             env=env,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,

--- a/libs/python/cua-sandbox/cua_sandbox/runtime/android_emulator.py
+++ b/libs/python/cua-sandbox/cua_sandbox/runtime/android_emulator.py
@@ -513,15 +513,31 @@ class AndroidEmulatorRuntime(Runtime):
         env["AW_HOST"] = "0.0.0.0"
 
         # Allow android_world to live in a separate venv / source checkout.
-        python_bin = os.environ.get("AW_PYTHON") or sys.executable
+        # AW_PYTHON: python that has android_world + fastapi/uvicorn installed.
+        # If AW_PYTHON differs from sys.executable we run the server file directly
+        # (not as a module) so cua_sandbox doesn't need to be installed in that venv.
+        aw_python = os.environ.get("AW_PYTHON")
         aw_source_dir = os.environ.get("AW_SOURCE_DIR", "")
         if aw_source_dir:
             existing = env.get("PYTHONPATH", "")
             env["PYTHONPATH"] = f"{aw_source_dir}:{existing}" if existing else aw_source_dir
 
+        if aw_python and aw_python != sys.executable:
+            # Run the server script directly — avoids needing cua_sandbox in aw venv
+            import importlib.util
+
+            server_file = importlib.util.find_spec("cua_sandbox._androidworld_server")
+            if server_file and server_file.origin:
+                cmd = [aw_python, server_file.origin]
+            else:
+                # Fallback: resolve relative to this file
+                cmd = [aw_python, str(Path(__file__).parent / "_androidworld_server.py")]
+        else:
+            cmd = [sys.executable, "-m", "cua_sandbox._androidworld_server"]
+
         logger.info(f"Starting AndroidWorld server on port {server_port} ...")
         self._aw_proc = subprocess.Popen(
-            [python_bin, "-m", "cua_sandbox._androidworld_server"],
+            cmd,
             env=env,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
@@ -532,8 +548,7 @@ class AndroidEmulatorRuntime(Runtime):
         logger.info(f"AndroidWorld server ready on port {server_port}.")
         return server_port
 
-    @staticmethod
-    async def _wait_for_aw_server(port: int, timeout: float = 120) -> None:
+    async def _wait_for_aw_server(self, port: int, timeout: float = 120) -> None:
         """Poll GET /health until the AndroidWorld server responds."""
         import httpx
 
@@ -541,6 +556,14 @@ class AndroidEmulatorRuntime(Runtime):
         deadline = asyncio.get_event_loop().time() + timeout
         async with httpx.AsyncClient(timeout=5) as client:
             while asyncio.get_event_loop().time() < deadline:
+                # Fail fast if the server process has already exited
+                if self._aw_proc and self._aw_proc.poll() is not None:
+                    stderr = ""
+                    if self._aw_proc.stderr:
+                        stderr = self._aw_proc.stderr.read().decode(errors="replace")
+                    raise RuntimeError(
+                        f"AndroidWorld server exited (rc={self._aw_proc.returncode}):\n{stderr}"
+                    )
                 try:
                     resp = await client.get(url)
                     if resp.status_code == 200:
@@ -548,7 +571,11 @@ class AndroidEmulatorRuntime(Runtime):
                 except Exception:
                     pass
                 await asyncio.sleep(3)
-        raise TimeoutError(f"AndroidWorld server did not become ready within {timeout}s")
+        stderr = ""
+        if self._aw_proc and self._aw_proc.stderr:
+            self._aw_proc.terminate()
+            stderr = self._aw_proc.stderr.read().decode(errors="replace")
+        raise TimeoutError(f"AndroidWorld server did not become ready within {timeout}s\n{stderr}")
 
     @staticmethod
     async def _build_pwa_apk(

--- a/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
+++ b/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
@@ -376,7 +376,7 @@ class QEMUBaremetalRuntime(Runtime):
                 stderr = proc.stderr.read().decode() if proc.stderr else ""
                 raise RuntimeError(f"QEMU launch failed (exit {proc.returncode}): {stderr}")
 
-        use_qmp = is_android or self.use_qmp_transport
+        use_qmp = is_android or self.use_qmp_transport or image._agent_type == "osworld"
         info = RuntimeInfo(
             host="localhost",
             api_port=hostfwd_port,

--- a/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
+++ b/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
@@ -248,7 +248,7 @@ class QEMUBaremetalRuntime(Runtime):
         enable_kvm = opts.get("enable_kvm", True)
 
         # Detect guest server port from transport hint
-        guest_port = 5000 if image._agent_type == "osworld" else 8000
+        guest_port = 5000 if image._agent_type in ("osworld", "androidworld") else 8000
 
         # Detect disk format from extension
         disk_ext = Path(disk_path).suffix.lower()
@@ -571,8 +571,13 @@ class QEMUBaremetalRuntime(Runtime):
     async def is_ready(self, info: RuntimeInfo, timeout: float = 120) -> bool:
         if info.qmp_port and not info.agent_type:
             return await self._is_ready_qmp(info, timeout)
-        # For OSWorld, check the Flask server; for computer-server, check /status
-        endpoint = "/screenshot" if info.agent_type == "osworld" else "/status"
+        # For OSWorld/AndroidWorld, check the server health; for computer-server, check /status
+        if info.agent_type == "osworld":
+            endpoint = "/screenshot"
+        elif info.agent_type == "androidworld":
+            endpoint = "/health"
+        else:
+            endpoint = "/status"
         url = f"http://{info.host}:{info.api_port}{endpoint}"
         deadline = asyncio.get_event_loop().time() + timeout
         async with httpx.AsyncClient(timeout=10) as client:

--- a/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
+++ b/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
@@ -340,15 +340,17 @@ class QEMUBaremetalRuntime(Runtime):
                     aarch64_code = candidate
                     break
             if aarch64_code:
+                # aarch64 virt machine pflash1 must be exactly 64 MB
+                AARCH64_VARS_SIZE = 64 * 1024 * 1024
                 aarch64_vars = Path(disk_path).parent / "efivars-aarch64.fd"
-                if not aarch64_vars.exists():
+                if not aarch64_vars.exists() or aarch64_vars.stat().st_size != AARCH64_VARS_SIZE:
                     import shutil as _shutil
 
                     vars_tmpl = qemu_dir / "share" / "edk2-arm-vars.fd"
-                    if vars_tmpl.exists():
+                    if vars_tmpl.exists() and vars_tmpl.stat().st_size == AARCH64_VARS_SIZE:
                         _shutil.copy2(vars_tmpl, aarch64_vars)
                     else:
-                        aarch64_vars.write_bytes(b"\x00" * (64 * 1024))
+                        aarch64_vars.write_bytes(b"\x00" * AARCH64_VARS_SIZE)
                 cmd += [
                     "-drive",
                     f"if=pflash,format=raw,readonly=on,file={aarch64_code}",

--- a/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
+++ b/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
@@ -340,9 +340,15 @@ class QEMUBaremetalRuntime(Runtime):
                     aarch64_code = candidate
                     break
             if aarch64_code:
-                # aarch64 virt machine pflash1 must be exactly 64 MB
+                # aarch64 virt machine pflash1 must be exactly 64 MB.
+                # Include the code firmware path in the vars filename so that
+                # upgrading edk2 or changing the PCI device layout doesn't
+                # silently reuse stale boot entries from a prior firmware version.
                 AARCH64_VARS_SIZE = 64 * 1024 * 1024
-                aarch64_vars = Path(disk_path).parent / "efivars-aarch64.fd"
+                import hashlib as _hl
+
+                _cfg_key = _hl.md5(str(aarch64_code).encode()).hexdigest()[:8]
+                aarch64_vars = Path(disk_path).parent / f"efivars-aarch64-{_cfg_key}.fd"
                 if not aarch64_vars.exists() or aarch64_vars.stat().st_size != AARCH64_VARS_SIZE:
                     import shutil as _shutil
 

--- a/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
+++ b/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
@@ -212,9 +212,16 @@ class QEMUBaremetalRuntime(Runtime):
 
         # If image has layers or no direct disk path, use the builder to resolve
         if not opts.get("disk_path") and not image._disk_path and image.kind == "vm":
-            from cua_sandbox.builder.build import create_session_disk
+            # Registry QEMU images: pull the disk first, then boot bare-metal
+            if image._registry:
+                from cua_sandbox.registry.qemu_builder import pull_qemu_image
 
-            disk_path = str(await create_session_disk(image, name))
+                _cfg, _disk = pull_qemu_image(image._registry)
+                disk_path = str(_disk)
+            else:
+                from cua_sandbox.builder.build import create_session_disk
+
+                disk_path = str(await create_session_disk(image, name))
         elif image._layers and (image._disk_path or opts.get("disk_path")):
             # Has a base disk AND user layers — build user image + session overlay
             from cua_sandbox.builder.build import create_session_disk

--- a/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
+++ b/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
@@ -218,6 +218,12 @@ class QEMUBaremetalRuntime(Runtime):
 
                 _cfg, _disk = pull_qemu_image(image._registry)
                 disk_path = str(_disk)
+                # Auto-select the right QEMU binary for the pulled image's arch
+                _qemu_to_oci = {"aarch64": "arm64", "x86_64": "amd64"}
+                _pulled_oci = _qemu_to_oci.get(_cfg.architecture, "amd64")
+                _host_oci = "arm64" if _plat.machine().lower() in ("arm64", "aarch64") else "amd64"
+                if _pulled_oci == _host_oci:
+                    self.arch = _cfg.architecture
             else:
                 from cua_sandbox.builder.build import create_session_disk
 
@@ -289,6 +295,7 @@ class QEMUBaremetalRuntime(Runtime):
 
         # Build QEMU command — Android gets different machine/device config
         is_android = image.os_type == "android"
+        is_arm_guest = self.arch in ("aarch64", "arm64")
 
         if is_android:
             cmd = self._build_android_cmd(
@@ -301,6 +308,74 @@ class QEMUBaremetalRuntime(Runtime):
                 vnc_display,
                 enable_kvm,
             )
+        elif is_arm_guest:
+            # aarch64 guest — use 'virt' machine + UEFI (edk2-aarch64)
+            cmd = [
+                self._qemu_bin(),
+                "-name",
+                name,
+                "-machine",
+                "virt",
+                "-m",
+                str(memory),
+                "-smp",
+                str(cpus),
+                "-cpu",
+                (
+                    "host"
+                    if (_plat.system() == "Darwin" and _plat.machine() in ("arm64", "aarch64"))
+                    else "cortex-a72"
+                ),
+            ]
+            # UEFI firmware for aarch64
+            qemu_dir = Path(self._qemu_bin()).parent
+            aarch64_code = None
+            for candidate in [
+                qemu_dir / "share" / "edk2-aarch64-code.fd",
+                Path("/opt/homebrew/share/qemu/edk2-aarch64-code.fd"),
+                Path("/usr/share/AAVMF/AAVMF_CODE.fd"),
+                Path("/usr/share/qemu/edk2-aarch64-code.fd"),
+            ]:
+                if candidate.exists():
+                    aarch64_code = candidate
+                    break
+            if aarch64_code:
+                aarch64_vars = Path(disk_path).parent / "efivars-aarch64.fd"
+                if not aarch64_vars.exists():
+                    import shutil as _shutil
+
+                    vars_tmpl = qemu_dir / "share" / "edk2-arm-vars.fd"
+                    if vars_tmpl.exists():
+                        _shutil.copy2(vars_tmpl, aarch64_vars)
+                    else:
+                        aarch64_vars.write_bytes(b"\x00" * (64 * 1024))
+                cmd += [
+                    "-drive",
+                    f"if=pflash,format=raw,readonly=on,file={aarch64_code}",
+                    "-drive",
+                    f"if=pflash,format=raw,file={aarch64_vars}",
+                ]
+            cmd += [
+                "-drive",
+                f"file={disk_path},format={disk_fmt},if=virtio",
+                "-netdev",
+                f"user,id=net0,restrict=on,hostfwd=tcp:127.0.0.1:{hostfwd_port}-:{guest_port}",
+                "-device",
+                "virtio-net-pci,netdev=net0,mac=52:55:00:d1:55:01",
+                "-vnc",
+                f":{vnc_display}",
+            ]
+            if _plat.system() != "Windows":
+                cmd.append("-daemonize")
+            if enable_kvm:
+                if _plat.system() == "Darwin" and _plat.machine() in ("arm64", "aarch64"):
+                    # Apple Silicon: native arm64 guest → HVF acceleration
+                    cmd += ["-accel", "hvf"]
+                elif _plat.system() != "Windows":
+                    cmd.append("-enable-kvm")
+                else:
+                    cmd += ["-accel", "tcg"]
+            cmd += ["-qmp", f"tcp:127.0.0.1:{self.qmp_port},server,nowait"]
         else:
             cmd = [
                 self._qemu_bin(),

--- a/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
+++ b/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
@@ -364,6 +364,10 @@ class QEMUBaremetalRuntime(Runtime):
                 f"user,id=net0,restrict=on,hostfwd=tcp:127.0.0.1:{hostfwd_port}-:{guest_port}",
                 "-device",
                 "virtio-net-pci,netdev=net0,mac=52:55:00:d1:55:01",
+                # virtio-gpu is required for the virt machine — without it X11
+                # has no display and pyautogui/osworld server can't start.
+                "-device",
+                "virtio-gpu-pci",
                 "-vnc",
                 f":{vnc_display}",
             ]

--- a/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
+++ b/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
@@ -399,8 +399,11 @@ class QEMUBaremetalRuntime(Runtime):
         if self._iso_path and use_qmp:
             await self._send_boot_key(info)
 
-        # Windows and Android need much longer to boot (3–10 min)
-        boot_timeout = 600 if image.os_type in ("windows", "android") else 120
+        # Windows, Android, and OSWorld (large Ubuntu disk) need longer boot times
+        if image.os_type in ("windows", "android") or image._agent_type == "osworld":
+            boot_timeout = 600
+        else:
+            boot_timeout = 120
         await self.is_ready(info, timeout=boot_timeout)
 
         if not ephemeral:

--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -950,6 +950,8 @@ class Sandbox:
 
                 transport = OSWorldTransport(
                     f"http://{rt_info.host}:{rt_info.api_port}",
+                    qmp_host=rt_info.host,
+                    qmp_port=rt_info.qmp_port,
                 )
             elif rt_info.vnc_port and rt_info.ssh_port:
                 from cua_sandbox.transport.vncssh import VNCSSHTransport

--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -913,7 +913,15 @@ class Sandbox:
         if image and runtime:
             sb_name = name or _random_name()
             rt_info = await runtime.start(image, sb_name)
-            if rt_info.environment == "android" and not rt_info.qmp_port:
+            if rt_info.agent_type == "androidworld":
+                # AndroidWorld bare-metal: server runs on host, api_port is the
+                # FastAPI port — NOT the ADB port. Use AndroidWorldTransport.
+                from cua_sandbox.transport.androidworld import AndroidWorldTransport
+
+                transport = AndroidWorldTransport(
+                    f"http://{rt_info.host}:{rt_info.api_port}",
+                )
+            elif rt_info.environment == "android" and not rt_info.qmp_port:
                 if rt_info.grpc_port:
                     from cua_sandbox.transport.grpc_emulator import (
                         GRPCEmulatorTransport,
@@ -941,12 +949,6 @@ class Sandbox:
                 from cua_sandbox.transport.osworld import OSWorldTransport
 
                 transport = OSWorldTransport(
-                    f"http://{rt_info.host}:{rt_info.api_port}",
-                )
-            elif rt_info.agent_type == "androidworld":
-                from cua_sandbox.transport.androidworld import AndroidWorldTransport
-
-                transport = AndroidWorldTransport(
                     f"http://{rt_info.host}:{rt_info.api_port}",
                 )
             elif rt_info.vnc_port and rt_info.ssh_port:

--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -943,6 +943,12 @@ class Sandbox:
                 transport = OSWorldTransport(
                     f"http://{rt_info.host}:{rt_info.api_port}",
                 )
+            elif rt_info.agent_type == "androidworld":
+                from cua_sandbox.transport.androidworld import AndroidWorldTransport
+
+                transport = AndroidWorldTransport(
+                    f"http://{rt_info.host}:{rt_info.api_port}",
+                )
             elif rt_info.vnc_port and rt_info.ssh_port:
                 from cua_sandbox.transport.vncssh import VNCSSHTransport
 

--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -149,18 +149,22 @@ def _auto_runtime(image: Image) -> "Runtime":
 
         return QEMURuntime(mode="bare-metal")
 
-    # Linux VM or Windows VM → prefer Docker-wrapped QEMU; fall back to bare-metal
+    # Registry VM images (e.g. osworld) always use bare-metal QEMU.
+    if image._registry and image.kind == "vm" and not image._disk_path:
+        from cua_sandbox.runtime.qemu import QEMURuntime
+
+        return QEMURuntime(mode="bare-metal")
+
+    # Linux/Windows VM — prefer bare-metal QEMU when available, fall back to Docker.
     from cua_sandbox.runtime.qemu import QEMURuntime
 
-    if image.os_type == "windows":
-        # Windows bare-metal QEMU works on any host with qemu-system-x86_64
-        try:
-            from cua_sandbox.runtime.docker import _has_docker
+    try:
+        from cua_sandbox.runtime.qemu_installer import qemu_bin
 
-            if not _has_docker():
-                return QEMURuntime(mode="bare-metal")
-        except Exception:
-            pass
+        qemu_bin(image.os_type or "linux")
+        return QEMURuntime(mode="bare-metal")
+    except Exception:
+        pass
 
     return QEMURuntime(mode="docker")
 

--- a/libs/python/cua-sandbox/cua_sandbox/transport/androidworld.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/androidworld.py
@@ -1,0 +1,241 @@
+"""AndroidWorldTransport — speaks the AndroidWorld FastAPI server API (port 5000).
+
+The AndroidWorld server exposes:
+  POST /reset                               → {"status", "message"}
+  GET  /screenshot?wait_to_stabilize=bool   → {"pixels": [R,G,B,...]} flat list
+  POST /execute_action                      → {"action_type": ..., ...} → {"status", "message"}
+  GET  /health                              → {"status"}
+  GET  /suite/task_list?max_index=N         → {"task_list": [...]}
+  GET  /suite/task_length?task_type=str     → {"length": N}
+  GET  /suite/reinitialize?...              → {"status", "message"}
+  POST /task/initialize?task_type=&task_idx= → {"status", "message"}
+  POST /task/tear_down?task_type=&task_idx=  → {"status", "message"}
+  GET  /task/score?task_type=&task_idx=      → {"score": float}
+  GET  /task/goal?task_type=&task_idx=       → {"goal": str}
+  GET  /task/template?task_type=&task_idx=   → {"template": str}
+  POST /close                               → {"status"}
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Any, Dict, List, Optional
+
+import httpx
+from cua_sandbox.transport.base import Transport, convert_screenshot
+
+
+class AndroidWorldTransport(Transport):
+    """Transport for containers/VMs running the AndroidWorld FastAPI server."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        timeout: float = 60.0,
+    ):
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._client: Optional[httpx.AsyncClient] = None
+
+    async def connect(self) -> None:
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url,
+            timeout=self._timeout,
+        )
+
+    async def disconnect(self) -> None:
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+
+    async def send(self, action: str, **params: Any) -> Any:
+        assert self._client is not None, "Transport not connected"
+        if action == "execute_action":
+            resp = await self._client.post("/execute_action", json=params)
+            resp.raise_for_status()
+            return resp.json()
+        if action == "reset":
+            resp = await self._client.post(
+                "/reset", params={"go_home": params.get("go_home", False)}
+            )
+            resp.raise_for_status()
+            return resp.json()
+        raise ValueError(f"Unknown action: {action}")
+
+    async def screenshot(self, format: str = "png", quality: int = 95) -> bytes:
+        """Capture screenshot from the AndroidWorld server.
+
+        The server returns pixels as a flat RGB list. This method reshapes it
+        into an image and encodes it as PNG (or JPEG if requested).
+        """
+        assert self._client is not None, "Transport not connected"
+        resp = await self._client.get("/screenshot", params={"wait_to_stabilize": False})
+        resp.raise_for_status()
+        data = resp.json()
+        pixels = data["pixels"]
+        # pixels is a flat list from numpy .tolist() — could be HxWx3 nested or flat
+        png_bytes = _pixels_to_png(pixels)
+        return convert_screenshot(png_bytes, format, quality)
+
+    async def get_screen_size(self) -> Dict[str, int]:
+        assert self._client is not None, "Transport not connected"
+        resp = await self._client.get("/screenshot", params={"wait_to_stabilize": False})
+        resp.raise_for_status()
+        data = resp.json()
+        pixels = data["pixels"]
+        # pixels is HxWx3 nested list from numpy ndarray.tolist()
+        if pixels and isinstance(pixels[0], list):
+            height = len(pixels)
+            width = len(pixels[0]) if height > 0 else 0
+        else:
+            # flat list — can't infer dimensions without shape
+            # AndroidWorld uses 1080x2400 for Pixel 6 by default
+            height, width = 2400, 1080
+        return {"width": width, "height": height}
+
+    async def get_environment(self) -> str:
+        return "android"
+
+    # ── AndroidWorld-specific methods ────────────────────────────────────────
+
+    async def health(self) -> bool:
+        """Return True if the server reports healthy."""
+        assert self._client is not None, "Transport not connected"
+        try:
+            resp = await self._client.get("/health")
+            return resp.status_code == 200 and resp.json().get("status") == "success"
+        except Exception:
+            return False
+
+    async def reset(self, go_home: bool = False) -> Dict[str, Any]:
+        """Reset the Android environment."""
+        assert self._client is not None, "Transport not connected"
+        resp = await self._client.post("/reset", params={"go_home": go_home})
+        resp.raise_for_status()
+        return resp.json()
+
+    async def execute_action(self, action_dict: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute a JSONAction on the Android environment."""
+        assert self._client is not None, "Transport not connected"
+        resp = await self._client.post("/execute_action", json=action_dict)
+        resp.raise_for_status()
+        return resp.json()
+
+    # ── Suite management ─────────────────────────────────────────────────────
+
+    async def suite_task_list(self, max_index: int = -1) -> List[str]:
+        """Return the list of task keys in the current suite."""
+        assert self._client is not None, "Transport not connected"
+        resp = await self._client.get("/suite/task_list", params={"max_index": max_index})
+        resp.raise_for_status()
+        return resp.json()["task_list"]
+
+    async def suite_task_length(self, task_type: str) -> int:
+        """Return the number of param combinations for a given task type."""
+        assert self._client is not None, "Transport not connected"
+        resp = await self._client.get("/suite/task_length", params={"task_type": task_type})
+        resp.raise_for_status()
+        return resp.json()["length"]
+
+    async def reinitialize_suite(
+        self,
+        task_family: str = "android_world",
+        n_task_combinations: int = 2,
+        seed: int = 42,
+    ) -> Dict[str, Any]:
+        """Re-initialize the task suite with new parameters."""
+        assert self._client is not None, "Transport not connected"
+        resp = await self._client.get(
+            "/suite/reinitialize",
+            params={
+                "task_family": task_family,
+                "n_task_combinations": n_task_combinations,
+                "seed": seed,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    # ── Task lifecycle ───────────────────────────────────────────────────────
+
+    async def initialize_task(self, task_type: str, task_idx: int = 0) -> Dict[str, Any]:
+        """Set up the device and app state for a task."""
+        assert self._client is not None, "Transport not connected"
+        resp = await self._client.post(
+            "/task/initialize",
+            params={"task_type": task_type, "task_idx": task_idx},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def tear_down_task(self, task_type: str, task_idx: int = 0) -> Dict[str, Any]:
+        """Restore app state and clean up after a task."""
+        assert self._client is not None, "Transport not connected"
+        resp = await self._client.post(
+            "/task/tear_down",
+            params={"task_type": task_type, "task_idx": task_idx},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def get_task_score(self, task_type: str, task_idx: int = 0) -> float:
+        """Return the success score (0.0–1.0) for the current task state."""
+        assert self._client is not None, "Transport not connected"
+        resp = await self._client.get(
+            "/task/score",
+            params={"task_type": task_type, "task_idx": task_idx},
+        )
+        resp.raise_for_status()
+        return float(resp.json()["score"])
+
+    async def get_task_goal(self, task_type: str, task_idx: int = 0) -> str:
+        """Return the natural-language goal string for a task instance."""
+        assert self._client is not None, "Transport not connected"
+        resp = await self._client.get(
+            "/task/goal",
+            params={"task_type": task_type, "task_idx": task_idx},
+        )
+        resp.raise_for_status()
+        return resp.json()["goal"]
+
+    async def get_task_template(self, task_type: str, task_idx: int = 0) -> str:
+        """Return the goal template string for a task type."""
+        assert self._client is not None, "Transport not connected"
+        resp = await self._client.get(
+            "/task/template",
+            params={"task_type": task_type, "task_idx": task_idx},
+        )
+        resp.raise_for_status()
+        return resp.json()["template"]
+
+    async def close(self) -> None:
+        """Close the Android environment on the server."""
+        assert self._client is not None, "Transport not connected"
+        resp = await self._client.post("/close")
+        resp.raise_for_status()
+
+
+# ── Internal helpers ─────────────────────────────────────────────────────────
+
+
+def _pixels_to_png(pixels: Any) -> bytes:
+    """Convert AndroidWorld pixel data (nested or flat list) to PNG bytes."""
+    import numpy as np
+    from PIL import Image as PILImage
+
+    arr = np.array(pixels, dtype=np.uint8)
+    if arr.ndim == 1:
+        # Flat — assume Pixel 6 default resolution (2400 x 1080 x 3)
+        total = arr.size
+        height = 2400
+        width = total // (height * 3)
+        arr = arr.reshape(height, width, 3)
+    elif arr.ndim == 2:
+        # HxW grayscale
+        pass
+    # arr should now be HxWx3
+    img = PILImage.fromarray(arr, mode="RGB")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()

--- a/libs/python/cua-sandbox/cua_sandbox/transport/osworld.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/osworld.py
@@ -238,6 +238,9 @@ class OSWorldTransport(Transport):
             env.http_server = self._base_url
             env.cache_dir_base = "/tmp/osworld_cache"
             env.cache_dir = "/tmp/osworld_cache"
+            env.enable_proxy = False
+            env.action_history = []
+            env.is_environment_used = False
             import os
 
             os.makedirs(env.cache_dir_base, exist_ok=True)

--- a/libs/python/cua-sandbox/cua_sandbox/transport/osworld.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/osworld.py
@@ -228,7 +228,7 @@ class OSWorldTransport(Transport):
 
         # Import osworld evaluators (host-side, reads VM state via HTTP/adb)
         try:
-            from desktop_env.envs.desktop_env import DesktopEnv  # type: ignore
+            from desktop_env.desktop_env import DesktopEnv  # type: ignore
 
             vm_host = self._base_url.split("://", 1)[-1].split(":")[0]
             vm_port = int(self._base_url.rsplit(":", 1)[-1])

--- a/libs/python/cua-sandbox/cua_sandbox/transport/osworld.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/osworld.py
@@ -244,8 +244,10 @@ class OSWorldTransport(Transport):
             import os
 
             os.makedirs(env.cache_dir_base, exist_ok=True)
+            from desktop_env.controllers.python import PythonController  # type: ignore
             from desktop_env.controllers.setup import SetupController  # type: ignore
 
+            env.controller = PythonController(vm_ip=vm_host, server_port=vm_port)
             env.setup_controller = SetupController(
                 vm_ip=vm_host, server_port=vm_port, cache_dir=env.cache_dir
             )

--- a/libs/python/cua-sandbox/cua_sandbox/transport/osworld.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/osworld.py
@@ -236,10 +236,11 @@ class OSWorldTransport(Transport):
             env.vm_ip = vm_host
             env.server_port = vm_port
             env.http_server = self._base_url
+            env.cache_dir_base = "/tmp/osworld_cache"
             env.cache_dir = "/tmp/osworld_cache"
             import os
 
-            os.makedirs(env.cache_dir, exist_ok=True)
+            os.makedirs(env.cache_dir_base, exist_ok=True)
             from desktop_env.controllers.setup import SetupController  # type: ignore
 
             env.setup_controller = SetupController(

--- a/libs/python/cua-sandbox/cua_sandbox/transport/osworld.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/osworld.py
@@ -1,19 +1,36 @@
 """OSWorldTransport — speaks the OSWorld Flask server API (port 5000).
 
 The OSWorld computer-server exposes:
-  GET  /screenshot        → raw PNG bytes
-  POST /screen_size       → {"width": ..., "height": ...}
-  POST /execute           → {"command": [...], "shell": false} → {"output": ...}
-  POST /run_bash_script   → {"script": ..., "timeout": ...} → {"status": ..., "output": ..., "error": ..., "returncode": ...}
-  GET  /accessibility      → {"AT": ...}
+  GET  /screenshot                    → raw PNG bytes
+  POST /screen_size                   → {"width": ..., "height": ...}
+  POST /execute                       → {"command": [...], "shell": false} → {"output": ...}
+  POST /run_bash_script               → {"script": ..., "timeout": ...}
+  GET  /accessibility                 → {"AT": ...}
+  POST /setup/launch                  → {"command": [...]}
+  POST /setup/execute                 → {"command": [...], "shell": false}
+  POST /setup/upload                  → multipart file upload
+
+Task lifecycle (OSWorld benchmark):
+  setup_task(task_config)   — runs the task's config steps on the VM
+                              (launches apps, uploads files, etc.)
+  evaluate_task(task_config, qmp_port) — runs postconfig then evaluates
+                                          via osworld's Python evaluator
+
+The OSWorld snapshot/reset model uses QEMU QMP savevm/loadvm — the cua
+QEMURuntime handles that automatically on sandbox startup. Per-task reset
+is done by reverting via QMP before calling setup_task again.
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+import asyncio
+import logging
+from typing import Any, Dict, List, Optional
 
 import httpx
 from cua_sandbox.transport.base import Transport
+
+logger = logging.getLogger(__name__)
 
 
 class OSWorldTransport(Transport):
@@ -24,10 +41,16 @@ class OSWorldTransport(Transport):
         base_url: str,
         *,
         timeout: float = 30.0,
+        qmp_host: str = "localhost",
+        qmp_port: Optional[int] = None,
     ):
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout
         self._client: Optional[httpx.AsyncClient] = None
+        self._qmp_host = qmp_host
+        self._qmp_port = qmp_port
+        self._snapshot_name = "osworld-init"
+        self._snapshot_saved = False
 
     async def connect(self) -> None:
         self._client = httpx.AsyncClient(
@@ -73,3 +96,160 @@ class OSWorldTransport(Transport):
 
     async def get_environment(self) -> str:
         return "linux"
+
+    # ── OSWorld task lifecycle ────────────────────────────────────────────────
+
+    async def save_snapshot(self, name: Optional[str] = None) -> None:
+        """Save a QEMU VM snapshot via QMP for later restore between tasks."""
+        if not self._qmp_port:
+            raise RuntimeError("qmp_port required for snapshot operations")
+        snap = name or self._snapshot_name
+        from cua_sandbox.runtime.qemu import _qmp_command
+
+        await _qmp_command(self._qmp_host, self._qmp_port, "stop")
+        await _qmp_command(self._qmp_host, self._qmp_port, "savevm", {"name": snap})
+        await _qmp_command(self._qmp_host, self._qmp_port, "cont")
+        self._snapshot_saved = True
+        logger.info(f"Saved QMP snapshot '{snap}'")
+
+    async def restore_snapshot(self, name: Optional[str] = None) -> None:
+        """Restore VM to the saved QMP snapshot, then wait for the server to come back."""
+        if not self._qmp_port:
+            raise RuntimeError("qmp_port required for snapshot operations")
+        snap = name or self._snapshot_name
+        from cua_sandbox.runtime.qemu import _qmp_command
+
+        await _qmp_command(self._qmp_host, self._qmp_port, "loadvm", {"name": snap})
+        await _qmp_command(self._qmp_host, self._qmp_port, "cont")
+        logger.info(f"Restored QMP snapshot '{snap}', waiting for server ...")
+        await self._wait_for_server(timeout=60)
+
+    async def _wait_for_server(self, timeout: float = 60) -> None:
+        deadline = asyncio.get_event_loop().time() + timeout
+        async with httpx.AsyncClient(timeout=5) as client:
+            while asyncio.get_event_loop().time() < deadline:
+                try:
+                    r = await client.get(f"{self._base_url}/screenshot")
+                    if r.status_code == 200:
+                        return
+                except Exception:
+                    pass
+                await asyncio.sleep(2)
+        raise TimeoutError(f"OSWorld server not ready after {timeout}s")
+
+    async def setup_task(self, task_config: Dict[str, Any]) -> None:
+        """Run the task's config steps on the VM (launch apps, upload files, etc.).
+
+        task_config is the JSON object from OSWorld's evaluation_examples, e.g.:
+            {
+              "id": "bb5e4c0d-...",
+              "instruction": "Make Bing the default search engine ...",
+              "config": [
+                {"type": "launch", "parameters": {"command": ["google-chrome", ...]}},
+                ...
+              ],
+              ...
+            }
+
+        Mirrors OSWorld's SetupController.setup() but uses direct HTTP to the
+        VM's Flask server without needing osworld installed on the host.
+        """
+        assert self._client is not None, "Transport not connected"
+        config_steps: List[Dict[str, Any]] = task_config.get("config", [])
+        for step in config_steps:
+            step_type = step.get("type", "")
+            params = step.get("parameters", {})
+            await self._run_setup_step(step_type, params)
+
+    async def _run_setup_step(self, step_type: str, params: Dict[str, Any]) -> None:
+        assert self._client is not None
+        if step_type == "launch":
+            resp = await self._client.post(
+                "/setup/launch",
+                json=params,
+                timeout=60,
+            )
+            resp.raise_for_status()
+        elif step_type in ("execute", "command"):
+            resp = await self._client.post(
+                "/setup/execute",
+                json=params,
+                timeout=120,
+            )
+            resp.raise_for_status()
+        elif step_type == "sleep":
+            await asyncio.sleep(float(params.get("seconds", 1)))
+        elif step_type == "upload":
+            # params: {"files": [{"local_path": ..., "dest": ...}]}
+            import pathlib
+
+            files_list = params if isinstance(params, list) else params.get("files", [])
+            for f in files_list:
+                local = pathlib.Path(f["local_path"])
+                if local.exists():
+                    with open(local, "rb") as fh:
+                        resp = await self._client.post(
+                            "/setup/upload",
+                            files={"file": (local.name, fh)},
+                            data={"dest": f.get("dest", f"/root/{local.name}")},
+                            timeout=600,
+                        )
+                        resp.raise_for_status()
+        else:
+            logger.debug(f"Skipping unhandled setup step type: {step_type!r}")
+
+    async def evaluate_task(
+        self,
+        task_config: Dict[str, Any],
+        *,
+        osworld_source_dir: Optional[str] = None,
+    ) -> float:
+        """Evaluate task completion by running OSWorld's evaluator.
+
+        Requires osworld importable on the host (set osworld_source_dir or
+        install it). Runs any postconfig steps first, then calls the evaluator.
+
+        Returns a score in [0.0, 1.0].
+
+        Args:
+            task_config: Full OSWorld task JSON (must include "evaluator" key).
+            osworld_source_dir: Path to OSWorld source checkout, prepended to
+                sys.path so osworld is importable without installation.
+        """
+        import sys
+
+        if osworld_source_dir and osworld_source_dir not in sys.path:
+            sys.path.insert(0, osworld_source_dir)
+
+        # Run postconfig steps (e.g. restart the browser so state is flushed)
+        postconfig = task_config.get("evaluator", {}).get("postconfig", [])
+        for step in postconfig:
+            await self._run_setup_step(step.get("type", ""), step.get("parameters", {}))
+
+        # Import osworld evaluators (host-side, reads VM state via HTTP/adb)
+        try:
+            from desktop_env.envs.desktop_env import DesktopEnv  # type: ignore
+
+            vm_host = self._base_url.split("://", 1)[-1].split(":")[0]
+            vm_port = int(self._base_url.rsplit(":", 1)[-1])
+            env = DesktopEnv.__new__(DesktopEnv)
+            env.vm_ip = vm_host
+            env.server_port = vm_port
+            env.http_server = self._base_url
+            env.cache_dir = "/tmp/osworld_cache"
+            import os
+
+            os.makedirs(env.cache_dir, exist_ok=True)
+            from desktop_env.controllers.setup import SetupController  # type: ignore
+
+            env.setup_controller = SetupController(
+                vm_ip=vm_host, server_port=vm_port, cache_dir=env.cache_dir
+            )
+            env._set_task_info(task_config)
+            score = env.evaluate()
+            return float(score)
+        except ImportError:
+            raise RuntimeError(
+                "osworld (desktop_env) is not importable. "
+                "Set osworld_source_dir= or install osworld on the host."
+            )

--- a/libs/python/cua-sandbox/pyproject.toml
+++ b/libs/python/cua-sandbox/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "grpcio==1.78.0",
     "protobuf==6.31.1",
     "pycdlib>=1.14.0",
+    "numpy>=1.24.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- **AndroidWorld**: multi-arch OCI push/pull for Android AVD images (arm64 + amd64), bare-metal AVD lifecycle with host-side AndroidWorld server, `AW_PYTHON`/`AW_SOURCE_DIR` env vars for venv separation
- **OSWorld**: multi-arch OCI push/pull for OSWorld QEMU images (arm64 + amd64), `OSWorldTransport` task lifecycle (setup, evaluate, QMP snapshot), native HVF acceleration on Apple Silicon via `qemu-system-aarch64 -accel hvf`
- **Registry**: direct HTTP push/pull replacing oras-py schema calls; manifest index upsert for multi-arch; auto-auth from env/`~/.docker/config.json`; per-arch cache dirs
- **Build scripts**: `build-androidworld.sh` and `build-osworld.sh` — download source images (HuggingFace), convert VMware→qcow2 if needed, push multi-arch manifest index to GHCR
- **Tests**: `test_android_local_androidworld_vm.py` and `test_linux_local_osworld_registry_vm.py` covering boot, task setup, and full eval loop; all passing on arm64 (Apple Silicon HVF) and amd64

## Test plan

- [ ] `pytest examples/sandboxes/test_linux_local_osworld_registry_vm.py -s -v` — 3 tests pass (verified on Apple Silicon with `ghcr.io/trycua/osworld:latest`)
- [ ] `pytest examples/sandboxes/test_android_local_androidworld_vm.py -s -v` — androidworld tests pass (requires `AW_SOURCE_DIR`)
- [ ] Push new arch: `bash examples/sandboxes/images/build-osworld.sh --arch amd64` updates manifest index at `ghcr.io/trycua/osworld:latest`
- [ ] Pull on x86_64 host auto-selects amd64 variant; pull on Apple Silicon auto-selects arm64 variant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AndroidWorld benchmark support with pre-baked emulator images and integrated FastAPI server.
  * Added OSWorld Ubuntu VM support with task lifecycle management and snapshot capabilities.
  * Added multi-architecture support including ARM64 virtual machines.
  * Extended registry to handle pre-baked Android AVD and agent type configuration.

* **Tests**
  * Added example scripts for testing AndroidWorld and OSWorld sandbox environments.

* **Chores**
  * Added NumPy as a required dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->