### PR TITLE
feat(ci): test Python packages on all supported versions (3.11, 3.12, 3.13)

### DIFF
--- a/.github/workflows/ci-test-python.yml
+++ b/.github/workflows/ci-test-python.yml
@@ -9,12 +9,13 @@ on:
 
 jobs:
   test:
-    name: Test ${{ matrix.package }}
+    name: Test ${{ matrix.package }} (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false # Test all packages even if one fails
       matrix:
+        python-version: ["3.11", "3.12", "3.13"]
         package:
           - core
           - agent
@@ -23,15 +24,26 @@ jobs:
           - mcp-server
           - som
           - cua-auto
+          - cua-sandbox
+        # Exclude packages that don't support Python 3.11
+        exclude:
+          - python-version: "3.11"
+            package: computer
+          - python-version: "3.11"
+            package: computer-server
+          - python-version: "3.11"
+            package: mcp-server
+          - python-version: "3.11"
+            package: som
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install uv
         run: |
@@ -72,8 +84,8 @@ jobs:
         if: always()
         with:
           file: ./libs/python/${{ matrix.package }}/coverage.xml
-          flags: ${{ matrix.package }}
-          name: codecov-${{ matrix.package }}
+          flags: ${{ matrix.package }}-py${{ matrix.python-version }}
+          name: codecov-${{ matrix.package }}-py${{ matrix.python-version }}
           fail_ci_if_error: false
         continue-on-error: true
 


### PR DESCRIPTION
## Summary

- Add Python version matrix to CI workflow to test packages on Python 3.11, 3.12, and 3.13
- Exclude packages that require Python 3.12+ from Python 3.11 tests (computer, computer-server, mcp-server, som)
- Add `cua-sandbox` package to the CI test workflow
- Update job names and Codecov flags to include Python version for better tracking

## Test Matrix

| Package | Python 3.11 | Python 3.12 | Python 3.13 |
|---------|-------------|-------------|-------------|
| core | ✓ | ✓ | ✓ |
| agent | ✓ | ✓ | ✓ |
| cua-auto | ✓ | ✓ | ✓ |
| cua-sandbox | ✓ | ✓ | ✓ |
| computer | - | ✓ | ✓ |
| computer-server | - | ✓ | ✓ |
| mcp-server | - | ✓ | ✓ |
| som | - | ✓ | ✓ |

## Test Plan

- [ ] Verify CI workflow runs successfully on all Python versions
- [ ] Confirm packages excluded from Python 3.11 are correctly skipped
- [ ] Verify cua-sandbox tests pass

---

Slack thread: https://trycua.slack.com/archives/C097D4VDEGK/p1774565379468359?thread_ts=1774564842.436969&cid=C097D4VDEGK

https://claude.ai/code/session_01JLHGAD3kT6KqEUXc5KGZr4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded continuous integration testing to validate compatibility across Python 3.11, 3.12, and 3.13.
  * Enhanced test reporting metadata to include Python version details.
  * Added testing constraints for specific packages on Python 3.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->