### PR TITLE
docs: Rename cloud sandbox tabs to Cloud Linux and remove macOS/Windows

### DIFF
--- a/docs/content/docs/cua/guide/get-started/using-sandbox-sdk.mdx
+++ b/docs/content/docs/cua/guide/get-started/using-sandbox-sdk.mdx
@@ -26,8 +26,8 @@ uv pip install cua-sandbox
 
 ## Create a Sandbox
 
-<Tabs items={['Cloud Container', 'Cloud VM', 'Cloud macOS', 'Cloud Windows', 'Local Linux', 'Local macOS (Lume)', 'Local Windows', 'Local Android']}>
-  <Tab value="Cloud Container">
+<Tabs items={['Cloud Linux Container', 'Cloud Linux VM', 'Local Linux', 'Local macOS (Lume)', 'Local Windows', 'Local Android']}>
+  <Tab value="Cloud Linux Container">
     ```python
     import asyncio
     from cua_sandbox import Sandbox, Image
@@ -45,7 +45,7 @@ uv pip install cua-sandbox
     ```
     Requires `CUA_API_KEY` environment variable.
   </Tab>
-  <Tab value="Cloud VM">
+  <Tab value="Cloud Linux VM">
     ```python
     import asyncio
     from cua_sandbox import Sandbox, Image
@@ -54,42 +54,6 @@ uv pip install cua-sandbox
         async with Sandbox.ephemeral(Image.linux(kind="vm")) as sb:
             result = await sb.shell.run("uname -s")
             print(result.stdout)  # "Linux"
-
-            screenshot = await sb.screenshot()
-            with open("screenshot.png", "wb") as f:
-                f.write(screenshot)
-
-    asyncio.run(main())
-    ```
-    Requires `CUA_API_KEY` environment variable.
-  </Tab>
-  <Tab value="Cloud macOS">
-    ```python
-    import asyncio
-    from cua_sandbox import Sandbox, Image
-
-    async def main():
-        async with Sandbox.ephemeral(Image.macos()) as sb:
-            result = await sb.shell.run("sw_vers")
-            print(result.stdout)
-
-            screenshot = await sb.screenshot()
-            with open("screenshot.png", "wb") as f:
-                f.write(screenshot)
-
-    asyncio.run(main())
-    ```
-    Requires `CUA_API_KEY` environment variable. Works on any host OS — no Mac needed.
-  </Tab>
-  <Tab value="Cloud Windows">
-    ```python
-    import asyncio
-    from cua_sandbox import Sandbox, Image
-
-    async def main():
-        async with Sandbox.ephemeral(Image.windows()) as sb:
-            result = await sb.shell.run("ver")
-            print(result.stdout)
 
             screenshot = await sb.screenshot()
             with open("screenshot.png", "wb") as f:


### PR DESCRIPTION
## Summary

- Rename "Cloud Container" to "Cloud Linux Container" for clarity
- Rename "Cloud VM" to "Cloud Linux VM" for clarity
- Remove "Cloud macOS" and "Cloud Windows" tabs from the Create a Sandbox section

## Changes

Updates the `using-sandbox-sdk.mdx` documentation to reflect the current cloud sandbox offerings.

---

Slack thread: https://trycua.slack.com/archives/D0AF3A3V2DS/p1774565543850299?thread_ts=1774565230.667209&cid=D0AF3A3V2DS

https://claude.ai/code/session_01EE3M6x8qq8ycir7x61fPne

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "Create a Sandbox" guide to feature Linux cloud sandbox options, including Cloud Linux Container and Cloud Linux VM configurations. Removed example code and guidance for macOS and Windows cloud sandbox setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->