### PR TITLE
fix: upload swift build log as artifact on failure

### DIFF
--- a/.github/workflows/cd-swift-lume.yml
+++ b/.github/workflows/cd-swift-lume.yml
@@ -194,6 +194,14 @@ jobs:
           echo "tarball_path=.release/lume-${VERSION}-${OS_IDENTIFIER}.tar.gz" >> $GITHUB_OUTPUT
           echo "pkg_path=.release/lume-${VERSION}-${OS_IDENTIFIER}.pkg.tar.gz" >> $GITHUB_OUTPUT
 
+      - name: Upload build log on failure
+        if: failure() && steps.build_notarize.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: swift-build-log
+          path: ./libs/lume/build.log
+          retention-days: 7
+
       - name: Generate SHA256 Checksums
         id: generate_checksums
         working-directory: ./libs/lume/.release


### PR DESCRIPTION
## Summary
- `swift build` output in the lume CD workflow was silently redirected to `build.log` with no way to inspect it when the build fails
- Adds an upload-artifact step that runs only on failure of the `build_notarize` step, uploading `build.log` with 7-day retention

## Test plan
- [ ] Trigger the lume CD workflow with a build that fails — confirm `swift-build-log` artifact appears on the run page
- [ ] Confirm successful builds are unaffected (step is skipped)

Closes the issue surfaced in run [#23630508910](https://github.com/trycua/cua/actions/runs/23630508910/job/68828639003)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build failure diagnostics by automatically capturing and uploading build logs as artifacts when the build process encounters errors, improving troubleshooting capabilities for development and deployment issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->