### PR TITLE
fix(lume): add progressHandler parameter to pull function signatures

### DIFF
--- a/libs/lume/src/ContainerRegistry/GCSImageRegistry.swift
+++ b/libs/lume/src/ContainerRegistry/GCSImageRegistry.swift
@@ -31,7 +31,8 @@ class GCSImageRegistry: ImageRegistry, @unchecked Sendable {
         image: String,
         name: String?,
         locationName: String?,
-        force: Bool = false
+        force: Bool = false,
+        progressHandler: (@Sendable (Double) -> Void)? = nil
     ) async throws -> VMDirectory {
         // Parse image name and tag
         let components = image.split(separator: ":")

--- a/libs/lume/src/ContainerRegistry/ImageContainerRegistry.swift
+++ b/libs/lume/src/ContainerRegistry/ImageContainerRegistry.swift
@@ -772,7 +772,8 @@ class ImageContainerRegistry: ImageRegistry, @unchecked Sendable {
         image: String,
         name: String?,
         locationName: String? = nil,
-        force: Bool = false
+        force: Bool = false,
+        progressHandler: (@Sendable (Double) -> Void)? = nil
     ) async throws -> VMDirectory {
         guard !image.isEmpty else {
             throw ValidationError("Image name cannot be empty")

--- a/libs/lume/src/ContainerRegistry/ImageRegistry.swift
+++ b/libs/lume/src/ContainerRegistry/ImageRegistry.swift
@@ -13,7 +13,8 @@ protocol ImageRegistry: Sendable {
         image: String,
         name: String?,
         locationName: String?,
-        force: Bool
+        force: Bool,
+        progressHandler: (@Sendable (Double) -> Void)?
     ) async throws -> VMDirectory
 
     /// Push a VM to the registry
@@ -44,8 +45,8 @@ protocol ImageRegistry: Sendable {
 
 // Default implementations for optional parameters
 extension ImageRegistry {
-    func pull(image: String, name: String? = nil, locationName: String? = nil, force: Bool = false) async throws -> VMDirectory {
-        try await pull(image: image, name: name, locationName: locationName, force: force)
+    func pull(image: String, name: String? = nil, locationName: String? = nil, force: Bool = false, progressHandler: (@Sendable (Double) -> Void)? = nil) async throws -> VMDirectory {
+        try await pull(image: image, name: name, locationName: locationName, force: force, progressHandler: progressHandler)
     }
 
     func push(

--- a/libs/lume/src/LumeController.swift
+++ b/libs/lume/src/LumeController.swift
@@ -1157,7 +1157,8 @@ final class LumeController {
         storage: String? = nil,
         username: String? = nil,
         password: String? = nil,
-        force: Bool = false
+        force: Bool = false,
+        progressHandler: (@Sendable (Double) -> Void)? = nil
     ) async throws {
         do {
             // Split the image to get name and tag
@@ -1198,7 +1199,8 @@ final class LumeController {
                 image: image,
                 name: vmName,
                 locationName: storage,
-                force: force)
+                force: force,
+                progressHandler: progressHandler)
 
             Logger.debug(
                 "Setting new VM mac address",


### PR DESCRIPTION
## Summary
- `Handlers.swift` was passing a `progressHandler` closure to `pullImage` and `pull`, but neither `LumeController.pullImage`, `ImageRegistry` (protocol), `ImageContainerRegistry.pull`, nor `GCSImageRegistry.pull` had the parameter in their signatures
- This caused 3 build errors and broke the lume CD workflow (run [#23630508910](https://github.com/trycua/cua/actions/runs/23630508910))
- Added `progressHandler: (@Sendable (Double) -> Void)? = nil` to all four signatures and wired it through

## Test plan
- [ ] `swift build --configuration release` in `libs/lume` passes with no errors
- [ ] Pull progress is reported correctly via `PullProgressTracker`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added progress tracking capability to image pulling operations. Download operations can now report progress updates to external handlers, enabling real-time monitoring of image pull activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->