### PR TITLE
Add Python 3.11 and 3.13 testing with package exclusions

### DIFF
--- a/.github/workflows/ci-test-python.yml
+++ b/.github/workflows/ci-test-python.yml
@@ -9,12 +9,13 @@ on:
 
 jobs:
   test:
-    name: Test ${{ matrix.package }}
+    name: Test ${{ matrix.package }} (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false # Test all packages even if one fails
       matrix:
+        python-version: ["3.11", "3.12", "3.13"]
         package:
           - core
           - agent
@@ -23,15 +24,25 @@ jobs:
           - mcp-server
           - som
           - cua-auto
+        # Exclude packages that don't support Python 3.11
+        exclude:
+          - python-version: "3.11"
+            package: computer
+          - python-version: "3.11"
+            package: computer-server
+          - python-version: "3.11"
+            package: mcp-server
+          - python-version: "3.11"
+            package: som
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install uv
         run: |
@@ -72,8 +83,8 @@ jobs:
         if: always()
         with:
           file: ./libs/python/${{ matrix.package }}/coverage.xml
-          flags: ${{ matrix.package }}
-          name: codecov-${{ matrix.package }}
+          flags: ${{ matrix.package }}-py${{ matrix.python-version }}
+          name: codecov-${{ matrix.package }}-py${{ matrix.python-version }}
           fail_ci_if_error: false
         continue-on-error: true
 


### PR DESCRIPTION
## Summary
Updated the CI test workflow to test against multiple Python versions (3.11, 3.12, and 3.13) instead of only 3.12, with exclusions for packages that don't support Python 3.11.

## Key Changes
- Added `python-version` matrix with versions 3.11, 3.12, and 3.13
- Updated job name to include the Python version being tested
- Added exclusion rules for packages incompatible with Python 3.11:
  - `computer`
  - `computer-server`
  - `mcp-server`
  - `som`
- Updated Python setup step to use the matrix version instead of hardcoded 3.12
- Enhanced codecov reporting to include Python version in flags and upload names for better tracking across versions

## Implementation Details
The workflow now runs tests for each package across all compatible Python versions. Packages that don't support Python 3.11 are automatically excluded from that version's test matrix, while still being tested on 3.12 and 3.13. This ensures comprehensive version coverage while respecting package-specific compatibility constraints.

https://claude.ai/code/session_011g2T5kRBc6QFPjVFC8oW4B