### PR TITLE
ci: update Xcode to 16.3 for Swift 6.1 compatibility

### DIFF
--- a/.github/workflows/cd-swift-lume.yml
+++ b/.github/workflows/cd-swift-lume.yml
@@ -56,9 +56,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Select Xcode 16
+      - name: Select Xcode 16.3
         run: |
-          sudo xcode-select -s /Applications/Xcode_16.app
+          sudo xcode-select -s /Applications/Xcode_16.3.app
           xcodebuild -version
 
       - name: Install dependencies

--- a/.github/workflows/ci-swift-lume.yml
+++ b/.github/workflows/ci-swift-lume.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: uname -a
-      - run: sudo xcode-select -s /Applications/Xcode_16.app # Swift 6.0
+      - run: sudo xcode-select -s /Applications/Xcode_16.3.app # Swift 6.1
       - run: swift test
         working-directory: ./libs/lume
   build:
@@ -27,6 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: uname -a
-      - run: sudo xcode-select -s /Applications/Xcode_16.app # Swift 6.0
+      - run: sudo xcode-select -s /Applications/Xcode_16.3.app # Swift 6.1
       - run: swift build --configuration release
         working-directory: ./libs/lume


### PR DESCRIPTION
## Summary
- Updates both `cd-swift-lume.yml` and `ci-swift-lume.yml` to use `Xcode_16.3.app` instead of `Xcode_16.app`
- `swift-sdk` 0.12+ uses `withThrowingTaskGroup { group in }` without the `of:` label, which requires Swift 6.1 (Xcode 16.3+)
- Xcode 16.0 (Swift 6.0) on `macos-15` runners cannot compile this syntax

## Test plan
- [ ] Merge this PR first to unblock CI on trycua/cua#1236
- [ ] Re-run CI on #1236 after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build toolchain to Xcode 16.3 with Swift 6.1 across CI/CD workflows for improved build consistency and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->