### PR TITLE
fix(sandbox): warn on destroy with snapshots, stop in ephemeral

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -308,22 +308,25 @@ class Sandbox:
         )
 
     async def destroy(self) -> None:
-        """Disconnect and permanently delete the sandbox (VM/container).
+        """Disconnect and permanently delete the sandbox (VM/container)."""
+        if self._has_snapshots:
+            import logging
 
-        If a snapshot was taken from this sandbox, it is stopped instead of
-        deleted so that forks created from the snapshot remain valid.
-        """
+            logging.getLogger(__name__).warning(
+                "Destroying sandbox %s which has snapshots — "
+                "forks referencing those snapshots will break. "
+                "Use Sandbox.ephemeral() which auto-stops instead of deleting "
+                "when snapshots exist.",
+                self.name,
+            )
         if self.telemetry_enabled and _TELEMETRY_AVAILABLE and is_telemetry_enabled():
             record_event("sandbox_destroy", {"name": self.name, "ephemeral": self._ephemeral})
         await self._transport.disconnect()
         if isinstance(self._transport, CloudTransport):
-            if self._has_snapshots:
-                await self._transport.suspend_vm()
-            else:
-                await self._transport.delete_vm()
+            await self._transport.delete_vm()
         if self._runtime and self._runtime_info:
             vm_name = self._runtime_info.name or self.name or "cua-sandbox"
-            if self._ephemeral and hasattr(self._runtime, "delete") and not self._has_snapshots:
+            if self._ephemeral and hasattr(self._runtime, "delete"):
                 await self._runtime.delete(vm_name)
             else:
                 await self._runtime.stop(vm_name)
@@ -538,7 +541,11 @@ class Sandbox:
         try:
             yield sb
         finally:
-            await sb.destroy()
+            if sb._has_snapshots and sb.name:
+                # Stop instead of delete so forks can reference the snapshots.
+                await cls.suspend(sb.name, local=local, api_key=api_key)
+            else:
+                await sb.destroy()
 
     # ── Lifecycle management ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `destroy()` now logs a warning when called on a sandbox that has snapshots, since deletion invalidates forks
- `ephemeral()` context manager stops (suspends) instead of destroying when snapshots were taken, preserving fork references
- Follows up on #1248 — destroy always deletes as before, but callers get a clear warning

## Test plan
- [ ] `ephemeral()` with snapshot taken → verify sandbox is suspended, not deleted
- [ ] `ephemeral()` without snapshot → verify sandbox is deleted as before
- [ ] `destroy()` with snapshot → verify warning is logged and VM is deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot preservation - ephemeral sandboxes now suspend instead of delete when containing snapshots, ensuring saved configurations are retained.
  * Enhanced sandbox cleanup consistency - Cloud VM deletion now executes uniformly regardless of snapshot presence, with warnings logged for snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->