### PR TITLE
fix(sandbox): treat 404 as transient during server readiness poll

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
@@ -326,8 +326,8 @@ class CloudTransport(Transport):
                 await self._inner.get_screen_size()
                 return  # Server is ready
             except httpx.HTTPStatusError as e:
-                if e.response.status_code < 500:
-                    raise  # 4xx errors are not transient — fail fast
+                if e.response.status_code < 500 and e.response.status_code != 404:
+                    raise  # 4xx errors (except 404) are not transient — fail fast
                 last_err = e
                 logger.debug("[cloud] _wait_for_server_ready: elapsed=%.0fs err=%r", elapsed, e)
                 await asyncio.sleep(_POLL_INTERVAL)


### PR DESCRIPTION
## Summary
- Cloud transport's `_wait_for_server_ready` now treats HTTP 404 as transient, like 5xx errors
- The server can return 404 before routes are fully registered; previously this was treated as a fatal 4xx, causing premature connection failures

## Test plan
- [ ] Start a cloud sandbox — verify it connects successfully even if server briefly returns 404
- [ ] Verify non-transient 4xx errors (401, 403, etc.) still fail fast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved cloud server polling resilience by treating transient connection errors as retryable during initialization, reducing unnecessary connection failures and increasing overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->