### PR TITLE
fix(lume): handle guest-initiated VM shutdown via VZVirtualMachineDelegate

### DIFF
--- a/libs/lume/src/LumeController.swift
+++ b/libs/lume/src/LumeController.swift
@@ -1122,7 +1122,8 @@ final class LumeController {
                 usbMassStoragePaths: usbMassStoragePaths,
                 networkMode: networkMode,
                 clipboard: clipboard)
-            Logger.info("VM started successfully", metadata: ["name": normalizedName])
+            SharedVM.shared.removeVM(name: normalizedName)
+            Logger.info("VM exited", metadata: ["name": normalizedName])
         } catch {
             SharedVM.shared.removeVM(name: normalizedName)
             Logger.error("Failed to run VM", metadata: ["error": error.localizedDescription])

--- a/libs/lume/src/VM/VM.swift
+++ b/libs/lume/src/VM/VM.swift
@@ -326,14 +326,7 @@ class VM {
             }
 
             // Block until the guest OS shuts down or crashes
-            if let guestError = await service.waitForGuestStop() {
-                Logger.error("VM stopped unexpectedly", metadata: [
-                    "name": vmDirContext.name,
-                    "error": guestError.localizedDescription,
-                ])
-            } else {
-                Logger.info("Guest initiated shutdown", metadata: ["name": vmDirContext.name])
-            }
+            let guestError = await service.waitForGuestStop()
 
             // Clean up after guest stop
             await clipboardWatcher?.stop()
@@ -345,6 +338,11 @@ class VM {
             flock(fileHandle.fileDescriptor, LOCK_UN)
             try? fileHandle.close()
             unlockConfigFile()
+
+            if let guestError {
+                throw guestError
+            }
+            Logger.info("Guest initiated shutdown", metadata: ["name": vmDirContext.name])
         } catch {
             Logger.error(
                 "Failed in VM.run",
@@ -1068,19 +1066,17 @@ class VM {
                 }
             }
 
-            if let guestError = await service.waitForGuestStop() {
-                Logger.error("VM stopped unexpectedly", metadata: [
-                    "name": vmDirContext.name,
-                    "error": guestError.localizedDescription,
-                ])
-            } else {
-                Logger.info("Guest initiated shutdown", metadata: ["name": vmDirContext.name])
-            }
+            let guestError = await service.waitForGuestStop()
 
             virtualizationService = nil
             vncService.stop()
             flock(fileHandle.fileDescriptor, LOCK_UN)
             try? fileHandle.close()
+
+            if let guestError {
+                throw guestError
+            }
+            Logger.info("Guest initiated shutdown", metadata: ["name": vmDirContext.name])
         } catch {
             Logger.error(
                 "Failed to create/start VM with USB storage",

--- a/libs/lume/src/VM/VM.swift
+++ b/libs/lume/src/VM/VM.swift
@@ -325,9 +325,26 @@ class VM {
                 await clipboardWatcher?.start()
             }
 
-            while true {
-                try await Task.sleep(nanoseconds: UInt64(1e9))
+            // Block until the guest OS shuts down or crashes
+            if let guestError = await service.waitForGuestStop() {
+                Logger.error("VM stopped unexpectedly", metadata: [
+                    "name": vmDirContext.name,
+                    "error": guestError.localizedDescription,
+                ])
+            } else {
+                Logger.info("Guest initiated shutdown", metadata: ["name": vmDirContext.name])
             }
+
+            // Clean up after guest stop
+            await clipboardWatcher?.stop()
+            clipboardWatcher = nil
+            virtualizationService = nil
+            vncService.stop()
+
+            Logger.info("Releasing file lock after guest stop", metadata: ["name": vmDirContext.name])
+            flock(fileHandle.fileDescriptor, LOCK_UN)
+            try? fileHandle.close()
+            unlockConfigFile()
         } catch {
             Logger.error(
                 "Failed in VM.run",
@@ -1051,9 +1068,19 @@ class VM {
                 }
             }
 
-            while true {
-                try await Task.sleep(nanoseconds: UInt64(1e9))
+            if let guestError = await service.waitForGuestStop() {
+                Logger.error("VM stopped unexpectedly", metadata: [
+                    "name": vmDirContext.name,
+                    "error": guestError.localizedDescription,
+                ])
+            } else {
+                Logger.info("Guest initiated shutdown", metadata: ["name": vmDirContext.name])
             }
+
+            virtualizationService = nil
+            vncService.stop()
+            flock(fileHandle.fileDescriptor, LOCK_UN)
+            try? fileHandle.close()
         } catch {
             Logger.error(
                 "Failed to create/start VM with USB storage",

--- a/libs/lume/src/Virtualization/VMVirtualizationService.swift
+++ b/libs/lume/src/Virtualization/VMVirtualizationService.swift
@@ -28,13 +28,17 @@ protocol VMVirtualizationService {
     func pause() async throws
     func resume() async throws
     func getVirtualMachine() -> Any
+    func waitForGuestStop() async -> Error?
 }
 
 /// Base implementation of VMVirtualizationService using VZVirtualMachine
 @MainActor
-class BaseVirtualizationService: VMVirtualizationService {
+class BaseVirtualizationService: NSObject, VMVirtualizationService, VZVirtualMachineDelegate {
     let virtualMachine: VZVirtualMachine
     let recoveryMode: Bool  // Store whether we should start in recovery mode
+
+    private var guestStopContinuation: CheckedContinuation<Error?, Never>?
+    private var pendingGuestStop: (fired: Bool, error: Error?) = (false, nil)
 
     var state: VZVirtualMachine.State {
         virtualMachine.state
@@ -43,6 +47,43 @@ class BaseVirtualizationService: VMVirtualizationService {
     init(virtualMachine: VZVirtualMachine, recoveryMode: Bool = false) {
         self.virtualMachine = virtualMachine
         self.recoveryMode = recoveryMode
+        super.init()
+        self.virtualMachine.delegate = self
+    }
+
+    func waitForGuestStop() async -> Error? {
+        if pendingGuestStop.fired {
+            return pendingGuestStop.error
+        }
+        return await withCheckedContinuation { continuation in
+            guestStopContinuation = continuation
+        }
+    }
+
+    // MARK: - VZVirtualMachineDelegate
+
+    nonisolated func guestDidStop(_ virtualMachine: VZVirtualMachine) {
+        Task { @MainActor in
+            Logger.info("Guest initiated shutdown")
+            if let continuation = guestStopContinuation {
+                guestStopContinuation = nil
+                continuation.resume(returning: nil)
+            } else {
+                pendingGuestStop = (true, nil)
+            }
+        }
+    }
+
+    nonisolated func virtualMachine(_ virtualMachine: VZVirtualMachine, didStopWithError error: Error) {
+        Task { @MainActor in
+            Logger.error("Guest stopped with error", metadata: ["error": error.localizedDescription])
+            if let continuation = guestStopContinuation {
+                guestStopContinuation = nil
+                continuation.resume(returning: error)
+            } else {
+                pendingGuestStop = (true, error)
+            }
+        }
     }
 
     func start() async throws {

--- a/libs/lume/tests/Mocks/MockVMVirtualizationService.swift
+++ b/libs/lume/tests/Mocks/MockVMVirtualizationService.swift
@@ -62,4 +62,8 @@ final class MockVMVirtualizationService: VMVirtualizationService {
     func getVirtualMachine() -> Any {
         return "mock_vm"
     }
+
+    func waitForGuestStop() async -> Error? {
+        return nil
+    }
 } 

--- a/libs/lume/tests/Mocks/MockVMVirtualizationService.swift
+++ b/libs/lume/tests/Mocks/MockVMVirtualizationService.swift
@@ -63,7 +63,39 @@ final class MockVMVirtualizationService: VMVirtualizationService {
         return "mock_vm"
     }
 
+    private var guestStopContinuation: CheckedContinuation<Error?, Never>?
+    private var pendingGuestStopResult: Error??
+
     func waitForGuestStop() async -> Error? {
-        return nil
+        if let result = pendingGuestStopResult {
+            pendingGuestStopResult = nil
+            currentState = .stopped
+            return result
+        }
+        return await withCheckedContinuation { continuation in
+            guestStopContinuation = continuation
+        }
     }
-} 
+
+    /// Simulate a normal guest shutdown.
+    func simulateGuestStop() {
+        currentState = .stopped
+        if let continuation = guestStopContinuation {
+            guestStopContinuation = nil
+            continuation.resume(returning: nil)
+        } else {
+            pendingGuestStopResult = .some(nil)
+        }
+    }
+
+    /// Simulate a guest crash with the given error.
+    func simulateGuestError(_ error: Error) {
+        currentState = .stopped
+        if let continuation = guestStopContinuation {
+            guestStopContinuation = nil
+            continuation.resume(returning: error)
+        } else {
+            pendingGuestStopResult = .some(error)
+        }
+    }
+}


### PR DESCRIPTION
## Problem

When shutting down macOS from inside the guest (Apple menu > Shut Down), the Lume host process does not exit. `lume ls` continues to show the VM as running, and `lume stop` hangs because the `while true { Task.sleep }` loop in `VM.run()` never breaks. The only recovery is `kill`.

The root cause is that Lume never sets a `VZVirtualMachineDelegate` on its `VZVirtualMachine` instance, so the `guestDidStop` callback -- which Virtualization.framework fires when the guest OS powers off -- is never received.

## Fix

Conform `BaseVirtualizationService` to `VZVirtualMachineDelegate` and replace the infinite sleep loops with `waitForGuestStop()`, a continuation-based suspend that returns when `guestDidStop` or `didStopWithError` fires. On return, the existing cleanup path runs (release file lock, stop VNC, nil out service).

A `pendingGuestStop` buffer handles the edge case where the delegate fires between `service.start()` and `waitForGuestStop()`.

## Changes

- `VMVirtualizationService.swift` -- add `NSObject` + `VZVirtualMachineDelegate` conformance to `BaseVirtualizationService`, set delegate in init, implement `guestDidStop` / `didStopWithError`, add `waitForGuestStop()` to protocol and implementation
- `VM.swift` -- replace `while true` loops in `run()` and `runWithUSBStorage()` with `waitForGuestStop()` + cleanup on return
- `MockVMVirtualizationService.swift` -- add `waitForGuestStop()` stub

## Test plan

- [ ] `lume run <vm>` -- inside guest, Apple menu > Shut Down -- host process exits cleanly, `lume ls` shows stopped
- [ ] `lume run <vm>` -- `lume stop <vm>` from another terminal -- still works as before
- [ ] `lume serve` -- run VM via API, guest shutdown -- VM cleaned up, server stays alive
- [ ] `swift build` passes (verified on macOS 15.7.5 -- zero new errors, all failures are pre-existing ARM-only symbols)

Closes #1184


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * VM shutdown detection now uses event-driven approach instead of time-based polling for faster response times.
  * Enhanced error tracking and logging when VMs stop unexpectedly or shut down normally.
  * Improved explicit cleanup procedures during VM termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->