### PR TITLE
fix(qemu): add overlay support to Windows and Linux containers

### DIFF
--- a/libs/qemu-docker/linux/src/entry.sh
+++ b/libs/qemu-docker/linux/src/entry.sh
@@ -12,6 +12,18 @@ cleanup() {
 # Install trap for signals
 trap cleanup SIGTERM SIGINT SIGHUP SIGQUIT
 
+# Overlay mode: /golden mounted read-only, /storage starts empty
+if [ -d "/golden" ] && [ -z "$(ls -A /storage 2>/dev/null)" ]; then
+  echo "Overlay mode detected, setting up copy-on-write..."
+  if cp -al /golden/. /storage/ 2>/dev/null; then
+    echo "Overlay setup complete (hard links)."
+  else
+    echo "Hard links not supported, falling back to full copy..."
+    cp -a /golden/. /storage/
+    echo "Overlay setup complete (full copy)."
+  fi
+fi
+
 # Start the VM in the background
 echo "Starting Ubuntu VM..."
 /usr/bin/tini -s /run/entry.sh &

--- a/libs/qemu-docker/linux/src/entry.sh
+++ b/libs/qemu-docker/linux/src/entry.sh
@@ -19,7 +19,10 @@ if [ -d "/golden" ] && [ -z "$(ls -A /storage 2>/dev/null)" ]; then
     echo "Overlay setup complete (hard links)."
   else
     echo "Hard links not supported, falling back to full copy..."
-    cp -a /golden/. /storage/
+    if ! cp -a /golden/. /storage/; then
+      echo "ERROR: overlay copy failed, cannot proceed."
+      exit 1
+    fi
     echo "Overlay setup complete (full copy)."
   fi
 fi

--- a/libs/qemu-docker/windows/src/entry.sh
+++ b/libs/qemu-docker/windows/src/entry.sh
@@ -12,6 +12,18 @@ cleanup() {
 # Install trap for signals
 trap cleanup SIGTERM SIGINT SIGHUP SIGQUIT
 
+# Overlay mode: /golden mounted read-only, /storage starts empty
+if [ -d "/golden" ] && [ -z "$(ls -A /storage 2>/dev/null)" ]; then
+  echo "Overlay mode detected, setting up copy-on-write..."
+  if cp -al /golden/. /storage/ 2>/dev/null; then
+    echo "Overlay setup complete (hard links)."
+  else
+    echo "Hard links not supported, falling back to full copy..."
+    cp -a /golden/. /storage/
+    echo "Overlay setup complete (full copy)."
+  fi
+fi
+
 # Create windows.boot file if it doesn't exist (required for proper boot)
 if [ -d "/storage" -a ! -f "/storage/windows.boot" ]; then
   echo "Creating windows.boot file in /storage..."

--- a/libs/qemu-docker/windows/src/entry.sh
+++ b/libs/qemu-docker/windows/src/entry.sh
@@ -19,7 +19,10 @@ if [ -d "/golden" ] && [ -z "$(ls -A /storage 2>/dev/null)" ]; then
     echo "Overlay setup complete (hard links)."
   else
     echo "Hard links not supported, falling back to full copy..."
-    cp -a /golden/. /storage/
+    if ! cp -a /golden/. /storage/; then
+      echo "ERROR: overlay copy failed, cannot proceed."
+      exit 1
+    fi
     echo "Overlay setup complete (full copy)."
   fi
 fi


### PR DESCRIPTION
## Summary

- Detect overlay mode in Windows and Linux QEMU container entrypoints
- When `/golden` is mounted read-only and `/storage` is empty, populate storage via hard links (`cp -al`) for copy-on-write semantics
- Fall back to `cp -a` when hard links are not supported (cross-filesystem mounts)

## Test plan

- [ ] Build Linux container, run with `/golden:ro` + empty `/storage` -- logs show "Overlay mode detected", VM boots from linked files
- [ ] Build Windows container, same overlay test -- overlay detected, `windows.boot` not re-created (already present from golden)
- [ ] Run without `/golden` mounted -- no overlay message, normal boot path unchanged
- [ ] Hard-link fallback: mount `/golden` and `/storage` on different filesystems -- falls back to full copy

Closes #699
Supersedes #730


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Storage initialization now includes automatic overlay mode support for both Linux and Windows environments. The system intelligently detects when template images are available and efficiently initializes storage using optimized copy-on-write techniques when supported. Automatic fallback to standard copy operations ensures compatibility across all system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->