### PR TITLE
fix(computer-server): remove duplicate unconditional multitouch_gesture handler registration

### DIFF
--- a/libs/python/computer-server/computer_server/main.py
+++ b/libs/python/computer-server/computer_server/main.py
@@ -161,7 +161,6 @@ handlers = {
     "find_element": accessibility_handler.find_element,
     # Shell commands
     "run_command": automation_handler.run_command,
-    "multitouch_gesture": automation_handler.multitouch_gesture,
     # File system commands
     "file_exists": file_handler.file_exists,
     "directory_exists": file_handler.directory_exists,


### PR DESCRIPTION
## Summary

- `main.py` line 164 unconditionally registered `automation_handler.multitouch_gesture` in the handlers dict at module load time
- The correct `hasattr`-guarded registration already exists (now line 224), so this line was purely a duplicate

## Root cause

The guarded block at line 225 was the intended registration path for Android-only `multitouch_gesture`. The unconditional entry at line 164 appears to have been accidentally added alongside it.

## Test plan
- [ ] Start `cua-computer-server` on macOS — should no longer crash with `AttributeError: 'MacOSAutomationHandler' object has no attribute 'multitouch_gesture'`
- [ ] Start `cua-computer-server` on Linux — same
- [ ] On Android handler, verify `multitouch_gesture` is still registered via the `hasattr` guard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multitouch gesture command registration to only be available when supported by the system, preventing registration of unavailable commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->