### PR TITLE
ci(computer-server): add PyInstaller binary builds for Linux & Windows

### DIFF
--- a/.github/workflows/cd-py-computer-server.yml
+++ b/.github/workflows/cd-py-computer-server.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get-version.outputs.version }}
     steps:
@@ -73,19 +73,56 @@ jobs:
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
+  build-binaries:
+    needs: prepare
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: cua-computer-server-linux-x86_64
+            binary_name: cua-computer-server
+          - os: windows-latest
+            artifact_name: cua-computer-server-windows-x86_64.exe
+            binary_name: cua-computer-server.exe
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          pip install pyinstaller
+          pip install -e libs/python/computer-server
+
+      - name: Build binary with PyInstaller
+        run: |
+          cd libs/python/computer-server
+          pyinstaller --onefile --name "${{ matrix.binary_name }}" run_server.py
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: libs/python/computer-server/dist/${{ matrix.binary_name }}
+
   set-env-variables:
     needs: [prepare, publish]
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Set environment variables for use in other jobs
         run: |
           echo "COMPUTER_VERSION=${{ needs.prepare.outputs.version }}" >> $GITHUB_ENV
 
   create-release:
-    needs: [prepare, publish]
+    needs: [prepare, publish, build-binaries]
     uses: ./.github/workflows/release-github-reusable.yml
     with:
       tag_name: "computer-server-v${{ needs.prepare.outputs.version }}"
       release_name: "cua-computer-server v${{ needs.prepare.outputs.version }}"
       module_path: "libs/python/computer-server"
       body: ""
+      attach_artifacts: true


### PR DESCRIPTION
## Summary
- Add a `build-binaries` job to the computer-server CD workflow that builds standalone executables via PyInstaller for Linux (x86_64) and Windows (x86_64)
- Binaries are uploaded as artifacts and attached to the GitHub release
- macOS excluded — neither PyInstaller nor Nuitka produce working binaries for this package
- Switched `prepare` and `set-env-variables` runners from `macos-latest` to `ubuntu-latest`

## Test plan
- [ ] Trigger workflow manually and verify both Linux and Windows binaries are built
- [ ] Verify binaries are attached to the GitHub release
- [ ] Download and run each binary to confirm screenshot `/cmd` returns non-zero bytes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to build and attach pre-built executables for Windows and Linux platforms to release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->