### PR TITLE
feat(sdk): Windows VM support + parallel server probe

### DIFF
--- a/.github/workflows/cd-py-computer-server.yml
+++ b/.github/workflows/cd-py-computer-server.yml
@@ -80,10 +80,12 @@ jobs:
         include:
           - os: ubuntu-latest
             artifact_name: cua-computer-server-linux-x86_64
-            binary_name: cua-computer-server
+            zip_name: cua-computer-server-linux-x86_64.tar.gz
+            dir_name: cua-computer-server
           - os: windows-latest
-            artifact_name: cua-computer-server-windows-x86_64.exe
-            binary_name: cua-computer-server.exe
+            artifact_name: cua-computer-server-windows-x86_64
+            zip_name: cua-computer-server-windows-x86_64.zip
+            dir_name: cua-computer-server
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -98,16 +100,28 @@ jobs:
           pip install pyinstaller
           pip install -e libs/python/computer-server
 
-      - name: Build binary with PyInstaller
+      - name: Build binary with PyInstaller (onedir — fast startup)
         run: |
           cd libs/python/computer-server
-          pyinstaller --onefile --name "${{ matrix.binary_name }}" run_server.py
+          pyinstaller --onedir --name "${{ matrix.dir_name }}" --console --noconfirm --clean --collect-all computer_server --hidden-import uvicorn.logging --hidden-import uvicorn.protocols.http --hidden-import uvicorn.protocols.http.auto --hidden-import uvicorn.protocols.http.h11_impl --hidden-import uvicorn.protocols.websockets --hidden-import uvicorn.protocols.websockets.auto --hidden-import uvicorn.lifespan --hidden-import uvicorn.lifespan.on --hidden-import PIL._tkinter_finder run_server.py
+
+      - name: Create archive (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          cd libs/python/computer-server/dist
+          tar czf "${{ matrix.zip_name }}" "${{ matrix.dir_name }}"/
+
+      - name: Create archive (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          cd libs/python/computer-server/dist
+          7z a "${{ matrix.zip_name }}" "${{ matrix.dir_name }}/"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
-          path: libs/python/computer-server/dist/${{ matrix.binary_name }}
+          path: libs/python/computer-server/dist/${{ matrix.zip_name }}
 
   set-env-variables:
     needs: [prepare, publish]

--- a/libs/python/cua-sandbox/cua_sandbox/builder/windows_unattend.py
+++ b/libs/python/cua-sandbox/cua_sandbox/builder/windows_unattend.py
@@ -178,13 +178,10 @@ def generate_autounattend_xml(
           <Key>{product_key}</Key>
         </ProductKey>"""
     elif is_server:
-        # Server editions: omit key for eval, or use GVLK for volume license
-        gvlk = _server_gvlks.get(version)
-        if gvlk:
-            key_section = f"""<ProductKey>
-          <Key>{gvlk}</Key>
-        </ProductKey>"""
-        # If no GVLK found, omit key entirely (eval mode)
+        # Server eval ISOs: omit product key entirely. The eval ISO has its own
+        # built-in eval key. GVLKs are for volume license media only.
+        # Users with SPLA can inject their GVLK via the product_key parameter.
+        pass
     else:
         key_section = """<ProductKey>
           <Key>VK7JG-NPHTM-C97JM-9MPGT-3V66T</Key>

--- a/libs/python/cua-sandbox/cua_sandbox/builder/windows_unattend.py
+++ b/libs/python/cua-sandbox/cua_sandbox/builder/windows_unattend.py
@@ -51,7 +51,12 @@ def _resolve_server_eval_url(server_version: str, culture: str = "en-us", countr
     eval_url = f"https://www.microsoft.com/en-us/evalcenter/download-{server_version}"
     logger.info(f"Parsing Microsoft Eval Center: {eval_url}")
 
-    req = urllib.request.Request(eval_url, headers={"User-Agent": "Mozilla/5.0"})
+    headers = {
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.5",
+    }
+    req = urllib.request.Request(eval_url, headers=headers)
     with urllib.request.urlopen(req, timeout=30) as resp:
         html = resp.read().decode("utf-8", errors="replace")
 
@@ -75,7 +80,7 @@ def _resolve_server_eval_url(server_version: str, culture: str = "en-us", countr
     logger.info(f"Resolved download link: {download_link}")
 
     # Follow redirect to get the actual ISO URL
-    req2 = urllib.request.Request(download_link, method="HEAD", headers={"User-Agent": "Mozilla/5.0"})
+    req2 = urllib.request.Request(download_link, method="HEAD", headers=headers)
     with urllib.request.urlopen(req2, timeout=30) as resp2:
         final_url = resp2.url
 

--- a/libs/python/cua-sandbox/cua_sandbox/builder/windows_unattend.py
+++ b/libs/python/cua-sandbox/cua_sandbox/builder/windows_unattend.py
@@ -187,9 +187,23 @@ def generate_autounattend_xml(
           <Key>VK7JG-NPHTM-C97JM-9MPGT-3V66T</Key>
         </ProductKey>"""
 
-    # Server uses image index 2 (Standard with Desktop Experience)
-    # Desktop uses index 1
-    image_index = "2" if is_server else "1"
+    # Image selection: use /IMAGE/NAME for reliability (index varies by ISO).
+    # For server eval ISOs, standard pattern is:
+    #   "Windows Server 2022 Standard Evaluation (Desktop Experience)"
+    # For desktop: /IMAGE/INDEX = 1 (single-edition ISOs)
+    _server_image_names = {
+        "server-2022": "Windows Server 2022 Standard Evaluation (Desktop Experience)",
+        "server-2025": "Windows Server 2025 Standard Evaluation (Desktop Experience)",
+        "server-2019": "Windows Server 2019 SERVERDATACENTEREVAL",
+    }
+    if is_server:
+        image_name = _server_image_names.get(version)
+        # Use /IMAGE/NAME for server (more reliable than index)
+        image_select_key = "/IMAGE/NAME"
+        image_select_value = image_name or f"Windows Server {version.split('-')[1]} Standard Evaluation (Desktop Experience)"
+    else:
+        image_select_key = "/IMAGE/INDEX"
+        image_select_value = "1"
 
     virtio_section = ""
     if include_virtio_drivers:
@@ -280,8 +294,8 @@ def generate_autounattend_xml(
           </InstallTo>
           <InstallFrom>
             <MetaData wcm:action="add">
-              <Key>/IMAGE/INDEX</Key>
-              <Value>{image_index}</Value>
+              <Key>{image_select_key}</Key>
+              <Value>{image_select_value}</Value>
             </MetaData>
           </InstallFrom>
           <InstallToAvailablePartition>false</InstallToAvailablePartition>

--- a/libs/python/cua-sandbox/cua_sandbox/builder/windows_unattend.py
+++ b/libs/python/cua-sandbox/cua_sandbox/builder/windows_unattend.py
@@ -31,6 +31,58 @@ def download_file(url: str, dest: Path, description: str = "") -> Path:
     return dest
 
 
+def _resolve_server_eval_url(server_version: str, culture: str = "en-us", country: str = "US") -> str:
+    """Resolve Windows Server evaluation ISO download URL from Microsoft's eval center.
+
+    Adapted from quickemu/quickget's download_windows_server() which is itself
+    adapted from the Mido project (https://github.com/ElliotKillick/Mido).
+
+    Args:
+        server_version: e.g. "windows-server-2022", "windows-server-2025"
+        culture: Language culture code, e.g. "en-us"
+        country: Country code, e.g. "US"
+
+    Returns:
+        Direct download URL for the ISO.
+    """
+    import re
+    import urllib.request
+
+    eval_url = f"https://www.microsoft.com/en-us/evalcenter/download-{server_version}"
+    logger.info(f"Parsing Microsoft Eval Center: {eval_url}")
+
+    req = urllib.request.Request(eval_url, headers={"User-Agent": "Mozilla/5.0"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        html = resp.read().decode("utf-8", errors="replace")
+
+    # Extract go.microsoft.com/fwlink links with the matching culture
+    pattern = rf"https://go\.microsoft\.com/fwlink/p/\?LinkID=\d+&clcid=0x[0-9a-f]+&culture={re.escape(culture)}&country={re.escape(country)}"
+    links = re.findall(pattern, html)
+
+    if not links:
+        # Fallback: try any English link
+        pattern_fallback = r"https://go\.microsoft\.com/fwlink/p/\?LinkID=\d+&clcid=0x[0-9a-f]+&culture=en-us&country=US"
+        links = re.findall(pattern_fallback, html)
+
+    if not links:
+        raise RuntimeError(
+            f"Could not find download link on {eval_url}. "
+            f"Microsoft may have changed the page layout."
+        )
+
+    # First link is typically the x64 ISO
+    download_link = links[0]
+    logger.info(f"Resolved download link: {download_link}")
+
+    # Follow redirect to get the actual ISO URL
+    req2 = urllib.request.Request(download_link, method="HEAD", headers={"User-Agent": "Mozilla/5.0"})
+    with urllib.request.urlopen(req2, timeout=30) as resp2:
+        final_url = resp2.url
+
+    logger.info(f"Final ISO URL: {final_url}")
+    return final_url
+
+
 def download_windows_iso(
     version: str = "11",
     dest: Optional[Path] = None,
@@ -55,9 +107,32 @@ def download_windows_iso(
         url = "https://go.microsoft.com/fwlink/?linkid=2334167&clcid=0x409"
     elif version == "10":
         url = "https://go.microsoft.com/fwlink/?LinkId=691209"
+    elif version in ("server-2022", "2022"):
+        version = "server-2022"
+        iso_file = dest_dir / f"windows-{version}.iso"
+        if iso_file.exists():
+            logger.info(f"Using cached ISO: {iso_file}")
+            return iso_file
+        url = _resolve_server_eval_url("windows-server-2022")
+    elif version in ("server-2025", "2025"):
+        version = "server-2025"
+        iso_file = dest_dir / f"windows-{version}.iso"
+        if iso_file.exists():
+            logger.info(f"Using cached ISO: {iso_file}")
+            return iso_file
+        url = _resolve_server_eval_url("windows-server-2025")
+    elif version in ("server-2019", "2019"):
+        version = "server-2019"
+        iso_file = dest_dir / f"windows-{version}.iso"
+        if iso_file.exists():
+            logger.info(f"Using cached ISO: {iso_file}")
+            return iso_file
+        url = _resolve_server_eval_url("windows-server-2019")
     else:
         raise ValueError(
-            f"Cannot auto-download Windows {version}. " f"Provide --iso-path to use your own ISO."
+            f"Cannot auto-download Windows {version}. "
+            f"Supported: 10, 11, server-2022, server-2025, server-2019. "
+            f"Or provide --iso-path to use your own ISO."
         )
 
     logger.info(f"Downloading Windows {version} Enterprise Evaluation ISO...")
@@ -72,23 +147,47 @@ def generate_autounattend_xml(
     product_key: Optional[str] = None,
     *,
     include_virtio_drivers: bool = True,
+    version: str = "11",
 ) -> str:
-    """Generate a Windows 11 Autounattend.xml for unattended installation.
+    """Generate a Windows Autounattend.xml for unattended installation.
 
     Args:
-        product_key: Windows product key. Defaults to Win11 Pro generic key.
+        product_key: Windows product key. If None, uses generic key for edition.
         include_virtio_drivers: Include VirtIO driver paths in WinPE pass.
             Set False for Hyper-V (has enlightened drivers built-in).
+        version: Windows version - "11", "10", "server-2022", "server-2025", etc.
     """
+    is_server = version.startswith("server-")
+
+    # KMS Generic Volume License Keys (GVLKs) for Server editions
+    # https://learn.microsoft.com/en-us/windows-server/get-started/kms-client-activation-keys
+    _server_gvlks = {
+        "server-2025": "TVRH6-WHNXV-R9WG3-9XRFY-MY832",  # Standard
+        "server-2022": "VDYBN-27WPP-V4HQT-9VMD4-VMK7H",  # Standard
+        "server-2019": "N69G4-B89J2-4G8F4-WWYCC-J464C",  # Standard
+    }
+
     key_section = ""
     if product_key:
         key_section = f"""<ProductKey>
           <Key>{product_key}</Key>
         </ProductKey>"""
+    elif is_server:
+        # Server editions: omit key for eval, or use GVLK for volume license
+        gvlk = _server_gvlks.get(version)
+        if gvlk:
+            key_section = f"""<ProductKey>
+          <Key>{gvlk}</Key>
+        </ProductKey>"""
+        # If no GVLK found, omit key entirely (eval mode)
     else:
         key_section = """<ProductKey>
           <Key>VK7JG-NPHTM-C97JM-9MPGT-3V66T</Key>
         </ProductKey>"""
+
+    # Server uses image index 2 (Standard with Desktop Experience)
+    # Desktop uses index 1
+    image_index = "2" if is_server else "1"
 
     virtio_section = ""
     if include_virtio_drivers:
@@ -177,6 +276,12 @@ def generate_autounattend_xml(
             <DiskID>0</DiskID>
             <PartitionID>3</PartitionID>
           </InstallTo>
+          <InstallFrom>
+            <MetaData wcm:action="add">
+              <Key>/IMAGE/INDEX</Key>
+              <Value>{image_index}</Value>
+            </MetaData>
+          </InstallFrom>
           <InstallToAvailablePartition>false</InstallToAvailablePartition>
         </OSImage>
       </ImageInstall>
@@ -314,19 +419,23 @@ def create_unattend_iso(
     *,
     include_virtio_drivers: bool = True,
     include_startup_nsh: bool = True,
+    version: str = "11",
 ) -> Path:
     """Create a small data-only ISO containing Autounattend.xml + setup script.
 
     Args:
         include_virtio_drivers: Include VirtIO driver paths (QEMU needs them, Hyper-V doesn't).
         include_startup_nsh: Include UEFI shell startup.nsh (QEMU/OVMF needs it, Hyper-V doesn't).
+        version: Windows version for autounattend generation.
     """
     unattend_iso = work_dir / "unattend.iso"
     if unattend_iso.exists():
         logger.info(f"Using cached unattend ISO: {unattend_iso}")
         return unattend_iso
 
-    xml = generate_autounattend_xml(product_key, include_virtio_drivers=include_virtio_drivers)
+    xml = generate_autounattend_xml(
+        product_key, include_virtio_drivers=include_virtio_drivers, version=version
+    )
     xml_path = work_dir / "Autounattend.xml"
     xml_path.write_text(xml, encoding="utf-8")
 

--- a/libs/python/cua-sandbox/cua_sandbox/registry/qemu_builder.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/qemu_builder.py
@@ -51,13 +51,14 @@ class QEMUImageConfig:
     """VM configuration stored as the OCI config blob."""
 
     guest_os: str = "windows"
-    version: str = "11"
+    version: str = "11"  # "11", "10", "server-2022", "server-2025"
     cpu: int = 4
     ram_mb: int = 8192
     disk_size_gb: int = 64
     disk_format: str = "qcow2"
     tpm: bool = True
     architecture: str = "x86_64"
+    qemu_bin: Optional[str] = None  # Custom QEMU binary path (e.g. /opt/incus/bin/qemu-system-x86_64)
     display: dict = field(default_factory=lambda: {"width": 1920, "height": 1080})
 
 
@@ -285,6 +286,47 @@ def _build_image_wsl2(
 # ── Full build ──────────────────────────────────────────────────────────────
 
 
+def export_for_incus(disk_path: Path, config: QEMUImageConfig) -> Path:
+    """Export a built disk image as an Incus-importable image.
+
+    Creates metadata.tar.xz alongside the disk.qcow2, ready for:
+        incus image import metadata.tar.xz disk.qcow2 --alias <name>
+
+    Returns the metadata.tar.xz path.
+    """
+    import tarfile
+    import time
+
+    output_dir = disk_path.parent
+    metadata_dir = output_dir / "incus-metadata"
+    metadata_dir.mkdir(exist_ok=True)
+
+    version_label = config.version.replace("-", " ").title()
+    metadata = {
+        "architecture": "x86_64",
+        "creation_date": int(time.time()),
+        "properties": {
+            "description": f"Windows {version_label} - CUA",
+            "os": "Windows",
+            "release": config.version,
+            "variant": "cua-server" if config.version.startswith("server-") else "cua-desktop",
+        },
+    }
+
+    import yaml  # noqa: F811
+
+    metadata_yaml = metadata_dir / "metadata.yaml"
+    metadata_yaml.write_text(yaml.dump(metadata, default_flow_style=False))
+
+    metadata_tar = output_dir / "metadata.tar.xz"
+    with tarfile.open(metadata_tar, "w:xz") as tar:
+        tar.add(metadata_yaml, arcname="metadata.yaml")
+
+    logger.info(f"Incus metadata created: {metadata_tar}")
+    logger.info(f"Import with: incus image import {metadata_tar} {disk_path} --alias windows-{config.version}-cua")
+    return metadata_tar
+
+
 def build_image(
     config: Optional[QEMUImageConfig] = None,
     *,
@@ -314,7 +356,7 @@ def build_image(
     # Create a small data-only ISO with Autounattend.xml + setup script.
     # Windows Setup searches all drives for Autounattend.xml automatically,
     # so we keep the original Windows ISO unchanged (it's UEFI-bootable).
-    unattend_iso = create_unattend_iso(work_dir, product_key)
+    unattend_iso = create_unattend_iso(work_dir, product_key, version=config.version)
 
     # Step 2: Create disk
     create_qcow2(disk_path, config.disk_size_gb)
@@ -325,9 +367,11 @@ def build_image(
 
     import platform as _plat
 
-    from cua_sandbox.runtime.qemu_installer import qemu_bin
-
-    qemu = qemu_bin(config.architecture)
+    if config.qemu_bin:
+        qemu = config.qemu_bin
+    else:
+        from cua_sandbox.runtime.qemu_installer import qemu_bin
+        qemu = qemu_bin(config.architecture)
     qemu_dir = Path(qemu).parent
 
     # Locate OVMF UEFI firmware (required for Windows 10/11)
@@ -774,7 +818,7 @@ def main():
 
     # build
     build_p = sub.add_parser("build", help="Build a Windows VM image")
-    build_p.add_argument("--windows-version", default="11", help="Windows version (10 or 11)")
+    build_p.add_argument("--windows-version", default="11", help="Windows version (10, 11, server-2022, server-2025)")
     build_p.add_argument("--iso-path", help="Path to Windows ISO (skip download)")
     build_p.add_argument("--disk-size", type=int, default=64, help="Disk size in GB")
     build_p.add_argument("--ram", type=int, default=8192, help="RAM in MB")
@@ -784,6 +828,11 @@ def main():
     build_p.add_argument("--product-key", help="Windows product key")
     build_p.add_argument(
         "--wsl2", action="store_true", help="Run QEMU inside WSL2 with KVM acceleration"
+    )
+    build_p.add_argument("--qemu-bin", help="Custom QEMU binary path (e.g. /opt/incus/bin/qemu-system-x86_64)")
+    build_p.add_argument(
+        "--export-incus", action="store_true",
+        help="Export as Incus-importable image (metadata.tar.xz + disk.qcow2)"
     )
 
     # push
@@ -826,6 +875,7 @@ def main():
             ram_mb=args.ram,
             disk_size_gb=args.disk_size,
             tpm=not args.no_tpm,
+            qemu_bin=getattr(args, "qemu_bin", None),
         )
         disk = build_image(
             cfg,
@@ -835,6 +885,10 @@ def main():
             use_wsl2=args.wsl2,
         )
         print(f"Built: {disk}")
+
+        if getattr(args, "export_incus", False):
+            export_for_incus(disk, cfg)
+            print(f"Exported Incus image to: {disk.parent}")
 
     elif args.command == "push":
         cfg = QEMUImageConfig(

--- a/libs/python/cua-sandbox/cua_sandbox/registry/qemu_builder.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/qemu_builder.py
@@ -286,46 +286,6 @@ def _build_image_wsl2(
 # ── Full build ──────────────────────────────────────────────────────────────
 
 
-def export_for_incus(disk_path: Path, config: QEMUImageConfig) -> Path:
-    """Export a built disk image as an Incus-importable image.
-
-    Creates metadata.tar.xz alongside the disk.qcow2, ready for:
-        incus image import metadata.tar.xz disk.qcow2 --alias <name>
-
-    Returns the metadata.tar.xz path.
-    """
-    import tarfile
-    import time
-
-    output_dir = disk_path.parent
-    metadata_dir = output_dir / "incus-metadata"
-    metadata_dir.mkdir(exist_ok=True)
-
-    version_label = config.version.replace("-", " ").title()
-    metadata = {
-        "architecture": "x86_64",
-        "creation_date": int(time.time()),
-        "properties": {
-            "description": f"Windows {version_label} - CUA",
-            "os": "Windows",
-            "release": config.version,
-            "variant": "cua-server" if config.version.startswith("server-") else "cua-desktop",
-        },
-    }
-
-    import yaml  # noqa: F811
-
-    metadata_yaml = metadata_dir / "metadata.yaml"
-    metadata_yaml.write_text(yaml.dump(metadata, default_flow_style=False))
-
-    metadata_tar = output_dir / "metadata.tar.xz"
-    with tarfile.open(metadata_tar, "w:xz") as tar:
-        tar.add(metadata_yaml, arcname="metadata.yaml")
-
-    logger.info(f"Incus metadata created: {metadata_tar}")
-    logger.info(f"Import with: incus image import {metadata_tar} {disk_path} --alias windows-{config.version}-cua")
-    return metadata_tar
-
 
 def build_image(
     config: Optional[QEMUImageConfig] = None,
@@ -830,10 +790,6 @@ def main():
         "--wsl2", action="store_true", help="Run QEMU inside WSL2 with KVM acceleration"
     )
     build_p.add_argument("--qemu-bin", help="Custom QEMU binary path (e.g. /opt/incus/bin/qemu-system-x86_64)")
-    build_p.add_argument(
-        "--export-incus", action="store_true",
-        help="Export as Incus-importable image (metadata.tar.xz + disk.qcow2)"
-    )
 
     # push
     push_p = sub.add_parser("push", help="Push a qcow2 disk as OCI image")
@@ -885,10 +841,6 @@ def main():
             use_wsl2=args.wsl2,
         )
         print(f"Built: {disk}")
-
-        if getattr(args, "export_incus", False):
-            export_for_incus(disk, cfg)
-            print(f"Exported Incus image to: {disk.parent}")
 
     elif args.command == "push":
         cfg = QEMUImageConfig(

--- a/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
@@ -18,7 +18,7 @@ from cua_sandbox.transport.http import HTTPTransport
 
 logger = logging.getLogger(__name__)
 
-_POLL_INTERVAL = 2.0  # seconds between status polls
+_POLL_INTERVAL = 0.5  # seconds between status polls
 _POLL_TIMEOUT = 600.0  # max seconds to wait for VM to be running
 
 
@@ -74,6 +74,9 @@ class CloudTransport(Transport):
             timeout=30.0,
         )
 
+        import time as _time
+        _t0 = _time.monotonic()
+
         if self._name:
             logger.debug("[cloud] getting VM info for %r", self._name)
             vm_info = await self._get_vm(self._name)
@@ -82,14 +85,12 @@ class CloudTransport(Transport):
             logger.debug("[cloud] creating new VM")
             vm_info = await self._create_vm()
             self._name = vm_info["name"]
-            logger.debug("[cloud] created VM %r", self._name)
+            logger.info("[cloud] created VM %r in %.1fs", self._name, _time.monotonic() - _t0)
 
         # Poll until running
-        logger.debug(
-            "[cloud] waiting for VM %r to be running (status=%r)", self._name, vm_info.get("status")
-        )
+        _t1 = _time.monotonic()
         vm_info = await self._wait_for_running(vm_info)
-        logger.debug("[cloud] VM %r is running", self._name)
+        logger.info("[cloud] VM %r running after %.1fs (wait=%.1fs)", self._name, _time.monotonic() - _t0, _time.monotonic() - _t1)
 
         # Resolve computer-server endpoint — auth with CUA API key + container name.
         # In local-dev mode the API initially returns .cua.sh placeholder URLs and
@@ -106,17 +107,17 @@ class CloudTransport(Transport):
         while _is_local_dev and (cs_url.endswith(".cua.sh") or ".cua.sh:" in cs_url):
             if poll_elapsed >= 120:
                 break  # Fall through — _wait_for_server_ready will handle the error
-            await asyncio.sleep(3)
-            poll_elapsed += 3
+            await asyncio.sleep(0.5)
+            poll_elapsed += 0.5
             vm_info = await self._get_vm(self._name)
             cs_url = self._resolve_endpoint(vm_info)
             logger.debug("[cloud] re-resolving endpoint: %s (%.0fs)", cs_url, poll_elapsed)
 
-        logger.debug("[cloud] resolved endpoint: %s", cs_url)
-        # For forks, the computer-server inside still has the source container's
-        # credentials (baked into the snapshot). Use the source name for auth.
-        snap_source = getattr(self._image, "_snapshot_source", None) if self._image else None
-        auth_name = snap_source["instance"] if snap_source else self._name
+        logger.info("[cloud] endpoint resolved in %.1fs: %s", _time.monotonic() - _t0, cs_url)
+        # Use the fork's own name for auth (not the parent's).  The Kopf
+        # operator creates a K8s secret for the fork with its own credentials,
+        # and the Go API maps the fork's API key to the fork's container name.
+        auth_name = self._name
         self._inner = HTTPTransport(cs_url, api_key=api_key, container_name=auth_name)
         logger.debug("[cloud] connecting inner HTTPTransport")
         await self._inner.connect()
@@ -125,7 +126,7 @@ class CloudTransport(Transport):
         # Wait for computer-server to be reachable (it may lag behind VM "running" status)
         logger.debug("[cloud] waiting for computer-server to be ready")
         await self._wait_for_server_ready()
-        logger.debug("[cloud] computer-server ready")
+        logger.info("[cloud] computer-server ready in %.1fs total", _time.monotonic() - _t0)
 
         # Apply env vars and image layers (e.g. APK installs) after server is ready
         if self._image and (self._image._layers or self._image._env):
@@ -321,17 +322,38 @@ class CloudTransport(Transport):
         return vm_info
 
     async def _wait_for_server_ready(self) -> None:
-        """Poll the computer-server until it responds (retries on connection/HTTP errors)."""
+        """Poll the computer-server until it responds.
+
+        First, quickly check if the HTTP server is accepting connections (any
+        response, even 404).  Then verify with get_screen_size which needs the
+        emulator.  This two-phase approach lets the SDK proceed as soon as the
+        server process is up, overlapping with emulator boot.
+        """
         assert self._inner
         elapsed = 0.0
         last_err: Optional[Exception] = None
+
+        # Phase 1: wait for HTTP port to accept connections (fast — just needs
+        # the Python process to start, not the emulator).
+        while elapsed < _POLL_TIMEOUT:
+            try:
+                resp = await self._inner._client.get("/", timeout=2.0)
+                # Any response means the server is up
+                logger.debug("[cloud] server HTTP up (status=%d) at %.1fs", resp.status_code, elapsed)
+                break
+            except Exception as e:
+                last_err = e
+                await asyncio.sleep(_POLL_INTERVAL)
+                elapsed += _POLL_INTERVAL
+
+        # Phase 2: wait for get_screen_size (needs emulator running)
         while elapsed < _POLL_TIMEOUT:
             try:
                 await self._inner.get_screen_size()
-                return  # Server is ready
+                return  # Fully ready
             except httpx.HTTPStatusError as e:
                 if e.response.status_code < 500 and e.response.status_code != 404:
-                    raise  # 4xx errors (except 404) are not transient — fail fast
+                    raise
                 last_err = e
                 logger.debug("[cloud] _wait_for_server_ready: elapsed=%.0fs err=%r", elapsed, e)
                 await asyncio.sleep(_POLL_INTERVAL)

--- a/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
@@ -191,17 +191,61 @@ class CloudTransport(Transport):
                     await asyncio.sleep(_POLL_INTERVAL)
                     http_elapsed += _POLL_INTERVAL
 
-        # Run endpoint resolution and server probe in parallel.
-        # _poll_until_running_and_resolved gets us the URL as soon as the
-        # API has a direct IP.  _tcp_probe_and_http_ready starts probing the
-        # CUA server immediately — overlapping with the remaining VM boot.
-        resolve_task = asyncio.ensure_future(_poll_until_running_and_resolved())
+        # Run VM status polling, endpoint resolution, and server probe in
+        # parallel.  As soon as the API returns a direct-IP endpoint (even
+        # while CRD status is still "creating"), start TCP-probing the CUA
+        # server.  This overlaps the kopf handler's credential injection
+        # and DNS setup with the CUA server boot.
 
-        # Wait for endpoint to be resolved, then start probing
-        vm_info, cs_url = await resolve_task
+        server_ready: asyncio.Event = asyncio.Event()
+        probe_task: Optional[asyncio.Task] = None
+        resolved_url: Optional[str] = None
+
+        async def _poll_and_probe() -> tuple[dict, str]:
+            """Poll VM status; start TCP/HTTP probe as soon as we have a direct IP."""
+            nonlocal vm_info, probe_task, resolved_url
+            elapsed = 0.0
+            is_running = vm_info.get("status") in ("running", "ready")
+
+            while elapsed < _POLL_TIMEOUT:
+                # Try to extract a direct-IP endpoint
+                try:
+                    url = self._resolve_endpoint(vm_info)
+                    if not (_is_local_dev and ".cua.sh" in url):
+                        # Got a direct IP — start probing if not already
+                        if probe_task is None:
+                            resolved_url = url
+                            logger.debug("[cloud] early endpoint: %s at %.1fs — starting probe", url, elapsed)
+                            probe_task = asyncio.create_task(
+                                _tcp_probe_and_http_ready(url, api_key)
+                            )
+                except (ValueError, KeyError):
+                    pass
+
+                if is_running and resolved_url:
+                    return vm_info, resolved_url
+
+                await asyncio.sleep(_POLL_INTERVAL)
+                elapsed += _POLL_INTERVAL
+                vm_info = await self._get_vm(self._name)
+                is_running = vm_info.get("status") in ("running", "ready")
+
+            if not is_running:
+                raise TimeoutError(
+                    f"VM {self._name!r} did not become running within {_POLL_TIMEOUT}s "
+                    f"(last status: {vm_info.get('status')})"
+                )
+            url = resolved_url or self._resolve_endpoint(vm_info)
+            return vm_info, url
+
+        vm_info, cs_url = await _poll_and_probe()
         logger.debug("[cloud] resolved endpoint: %s", cs_url)
 
-        await _tcp_probe_and_http_ready(cs_url, api_key)
+        # If probe was started early, wait for it; otherwise start now
+        if probe_task is not None:
+            await probe_task
+        else:
+            await _tcp_probe_and_http_ready(cs_url, api_key)
 
         logger.debug("[cloud] computer-server ready")
 

--- a/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
@@ -342,7 +342,18 @@ class CloudTransport(Transport):
                 await asyncio.sleep(_POLL_INTERVAL)
                 elapsed += _POLL_INTERVAL
 
-        # Phase 2: wait for get_screen_size (needs emulator running)
+        # Check if this is a Windows server (no screen_size endpoint)
+        try:
+            status_resp = await self._inner._client.get("/status", timeout=5.0)
+            if status_resp.status_code == 200:
+                status_data = status_resp.json()
+                if status_data.get("os_type") == "windows":
+                    logger.debug("[cloud] Windows server detected, skipping screen_size check")
+                    return  # Windows servers are ready after Phase 1
+        except Exception:
+            pass  # Fall through to Phase 2
+
+        # Phase 2: wait for get_screen_size (needs emulator/display running)
         while elapsed < _POLL_TIMEOUT:
             try:
                 await self._inner.get_screen_size()

--- a/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
@@ -84,44 +84,125 @@ class CloudTransport(Transport):
             self._name = vm_info["name"]
             logger.debug("[cloud] created VM %r", self._name)
 
-        # Poll until running
-        vm_info = await self._wait_for_running(vm_info)
-        logger.debug("[cloud] VM %r is running", self._name)
-
-        # Resolve computer-server endpoint — auth with CUA API key + container name.
-        # In local-dev mode the API initially returns .cua.sh placeholder URLs and
-        # replaces them with direct IPs once the container IP is known, so we poll
-        # until we get a non-.cua.sh address.  On prod the reverse-proxy .cua.sh URL
-        # is the real endpoint, so we skip this loop entirely.
-        cs_url = self._resolve_endpoint(vm_info)
         _is_local_dev = not self._base_url.rstrip("/").endswith("cua.sh") and (
             "localhost" in self._base_url
             or "127.0.0.1" in self._base_url
             or "0.0.0.0" in self._base_url
         )
-        poll_elapsed = 0.0
-        while _is_local_dev and (cs_url.endswith(".cua.sh") or ".cua.sh:" in cs_url):
-            if poll_elapsed >= 120:
-                break  # Fall through — _wait_for_server_ready will handle the error
-            await asyncio.sleep(0.5)
-            poll_elapsed += 0.5
-            vm_info = await self._get_vm(self._name)
-            cs_url = self._resolve_endpoint(vm_info)
-            logger.debug("[cloud] re-resolving endpoint: %s (%.0fs)", cs_url, poll_elapsed)
 
+        # ── Parallel path: resolve endpoint + probe server while waiting for "running" ──
+        # The VM is booting; we can start probing its CUA server as soon as the
+        # API gives us an IP-based endpoint, without waiting for the full CRD
+        # status to transition to "running".
+
+        async def _poll_until_running_and_resolved() -> tuple[dict, str]:
+            """Poll VM status AND resolve a usable endpoint URL in one loop."""
+            nonlocal vm_info
+            elapsed = 0.0
+            cs_url = ""
+            is_running = vm_info.get("status") in ("running", "ready")
+
+            while elapsed < _POLL_TIMEOUT:
+                # Try to extract a direct-IP endpoint from current vm_info
+                try:
+                    url = self._resolve_endpoint(vm_info)
+                    if not (_is_local_dev and (".cua.sh" in url)):
+                        cs_url = url
+                except (ValueError, KeyError):
+                    pass
+
+                if is_running and cs_url:
+                    return vm_info, cs_url
+
+                await asyncio.sleep(_POLL_INTERVAL)
+                elapsed += _POLL_INTERVAL
+                vm_info = await self._get_vm(self._name)
+                is_running = vm_info.get("status") in ("running", "ready")
+
+            if not is_running:
+                raise TimeoutError(
+                    f"VM {self._name!r} did not become running within {_POLL_TIMEOUT}s "
+                    f"(last status: {vm_info.get('status')})"
+                )
+            if not cs_url:
+                cs_url = self._resolve_endpoint(vm_info)
+            return vm_info, cs_url
+
+        async def _tcp_probe_and_http_ready(cs_url: str, api_key: str) -> None:
+            """Probe the CUA server endpoint using fast TCP check then HTTP."""
+            # Parse host:port from URL
+            from urllib.parse import urlparse
+            parsed = urlparse(cs_url)
+            host = parsed.hostname or ""
+            port = parsed.port or (443 if parsed.scheme == "https" else 8000)
+
+            # Phase 0: fast TCP probe (0.3s timeout per attempt, 0.2s interval)
+            elapsed = 0.0
+            while elapsed < _POLL_TIMEOUT:
+                try:
+                    _, writer = await asyncio.wait_for(
+                        asyncio.open_connection(host, port), timeout=0.3
+                    )
+                    writer.close()
+                    await writer.wait_closed()
+                    logger.debug("[cloud] TCP port %d open at %.1fs", port, elapsed)
+                    break
+                except (OSError, asyncio.TimeoutError):
+                    await asyncio.sleep(0.2)
+                    elapsed += 0.2
+
+            # Phase 1: HTTP validation
+            auth_name = self._name
+            self._inner = HTTPTransport(cs_url, api_key=api_key, container_name=auth_name)
+            await self._inner.connect()
+
+            http_elapsed = 0.0
+            while http_elapsed < _POLL_TIMEOUT - elapsed:
+                try:
+                    resp = await self._inner._client.get("/", timeout=2.0)
+                    logger.debug("[cloud] server HTTP up (status=%d) at %.1fs", resp.status_code, elapsed + http_elapsed)
+                    break
+                except Exception:
+                    await asyncio.sleep(_POLL_INTERVAL)
+                    http_elapsed += _POLL_INTERVAL
+
+            # Check if Windows (skip screen_size)
+            try:
+                status_resp = await self._inner._client.get("/status", timeout=5.0)
+                if status_resp.status_code == 200:
+                    status_data = status_resp.json()
+                    if status_data.get("os_type") == "windows":
+                        logger.debug("[cloud] Windows server detected, skipping screen_size check")
+                        return
+            except Exception:
+                pass
+
+            # Phase 2: wait for get_screen_size (emulator/display)
+            while http_elapsed < _POLL_TIMEOUT - elapsed:
+                try:
+                    await self._inner.get_screen_size()
+                    return
+                except httpx.HTTPStatusError as e:
+                    if e.response.status_code < 500 and e.response.status_code != 404:
+                        raise
+                    await asyncio.sleep(_POLL_INTERVAL)
+                    http_elapsed += _POLL_INTERVAL
+                except Exception:
+                    await asyncio.sleep(_POLL_INTERVAL)
+                    http_elapsed += _POLL_INTERVAL
+
+        # Run endpoint resolution and server probe in parallel.
+        # _poll_until_running_and_resolved gets us the URL as soon as the
+        # API has a direct IP.  _tcp_probe_and_http_ready starts probing the
+        # CUA server immediately — overlapping with the remaining VM boot.
+        resolve_task = asyncio.ensure_future(_poll_until_running_and_resolved())
+
+        # Wait for endpoint to be resolved, then start probing
+        vm_info, cs_url = await resolve_task
         logger.debug("[cloud] resolved endpoint: %s", cs_url)
-        # Use the fork's own name for auth (not the parent's).  The Kopf
-        # operator creates a K8s secret for the fork with its own credentials,
-        # and the Go API maps the fork's API key to the fork's container name.
-        auth_name = self._name
-        self._inner = HTTPTransport(cs_url, api_key=api_key, container_name=auth_name)
-        logger.debug("[cloud] connecting inner HTTPTransport")
-        await self._inner.connect()
-        logger.debug("[cloud] HTTPTransport connected")
 
-        # Wait for computer-server to be reachable (it may lag behind VM "running" status)
-        logger.debug("[cloud] waiting for computer-server to be ready")
-        await self._wait_for_server_ready()
+        await _tcp_probe_and_http_ready(cs_url, api_key)
+
         logger.debug("[cloud] computer-server ready")
 
         # Apply env vars and image layers (e.g. APK installs) after server is ready

--- a/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
@@ -130,7 +130,10 @@ class CloudTransport(Transport):
 
         async def _connect_and_wait_ready(cs_url: str, api_key: str) -> None:
             """Create inner HTTPTransport and wait for server readiness."""
-            auth_name = self._name
+            # Forks inherit the source container's credentials from the
+            # snapshot, so auth must use the source instance name.
+            snap_source = getattr(self._image, "_snapshot_source", None) if self._image else None
+            auth_name = snap_source["instance"] if snap_source else self._name
             self._inner = HTTPTransport(cs_url, api_key=api_key, container_name=auth_name)
             await self._inner.connect()
             await self._wait_for_server_ready()

--- a/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
@@ -128,68 +128,12 @@ class CloudTransport(Transport):
                 cs_url = self._resolve_endpoint(vm_info)
             return vm_info, cs_url
 
-        async def _tcp_probe_and_http_ready(cs_url: str, api_key: str) -> None:
-            """Probe the CUA server endpoint using fast TCP check then HTTP."""
-            # Parse host:port from URL
-            from urllib.parse import urlparse
-            parsed = urlparse(cs_url)
-            host = parsed.hostname or ""
-            port = parsed.port or (443 if parsed.scheme == "https" else 8000)
-
-            # Phase 0: fast TCP probe (0.3s timeout per attempt, 0.2s interval)
-            elapsed = 0.0
-            while elapsed < _POLL_TIMEOUT:
-                try:
-                    _, writer = await asyncio.wait_for(
-                        asyncio.open_connection(host, port), timeout=0.3
-                    )
-                    writer.close()
-                    await writer.wait_closed()
-                    logger.debug("[cloud] TCP port %d open at %.1fs", port, elapsed)
-                    break
-                except (OSError, asyncio.TimeoutError):
-                    await asyncio.sleep(0.2)
-                    elapsed += 0.2
-
-            # Phase 1: HTTP validation
+        async def _connect_and_wait_ready(cs_url: str, api_key: str) -> None:
+            """Create inner HTTPTransport and wait for server readiness."""
             auth_name = self._name
             self._inner = HTTPTransport(cs_url, api_key=api_key, container_name=auth_name)
             await self._inner.connect()
-
-            http_elapsed = 0.0
-            while http_elapsed < _POLL_TIMEOUT - elapsed:
-                try:
-                    resp = await self._inner._client.get("/", timeout=2.0)
-                    logger.debug("[cloud] server HTTP up (status=%d) at %.1fs", resp.status_code, elapsed + http_elapsed)
-                    break
-                except Exception:
-                    await asyncio.sleep(_POLL_INTERVAL)
-                    http_elapsed += _POLL_INTERVAL
-
-            # Check if Windows (skip screen_size)
-            try:
-                status_resp = await self._inner._client.get("/status", timeout=5.0)
-                if status_resp.status_code == 200:
-                    status_data = status_resp.json()
-                    if status_data.get("os_type") == "windows":
-                        logger.debug("[cloud] Windows server detected, skipping screen_size check")
-                        return
-            except Exception:
-                pass
-
-            # Phase 2: wait for get_screen_size (emulator/display)
-            while http_elapsed < _POLL_TIMEOUT - elapsed:
-                try:
-                    await self._inner.get_screen_size()
-                    return
-                except httpx.HTTPStatusError as e:
-                    if e.response.status_code < 500 and e.response.status_code != 404:
-                        raise
-                    await asyncio.sleep(_POLL_INTERVAL)
-                    http_elapsed += _POLL_INTERVAL
-                except Exception:
-                    await asyncio.sleep(_POLL_INTERVAL)
-                    http_elapsed += _POLL_INTERVAL
+            await self._wait_for_server_ready()
 
         # Run VM status polling, endpoint resolution, and server probe in
         # parallel.  As soon as the API returns a direct-IP endpoint (even
@@ -217,7 +161,7 @@ class CloudTransport(Transport):
                             resolved_url = url
                             logger.debug("[cloud] early endpoint: %s at %.1fs — starting probe", url, elapsed)
                             probe_task = asyncio.create_task(
-                                _tcp_probe_and_http_ready(url, api_key)
+                                _connect_and_wait_ready(url, api_key)
                             )
                 except (ValueError, KeyError):
                     pass
@@ -245,7 +189,7 @@ class CloudTransport(Transport):
         if probe_task is not None:
             await probe_task
         else:
-            await _tcp_probe_and_http_ready(cs_url, api_key)
+            await _connect_and_wait_ready(cs_url, api_key)
 
         logger.debug("[cloud] computer-server ready")
 

--- a/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
@@ -74,9 +74,6 @@ class CloudTransport(Transport):
             timeout=30.0,
         )
 
-        import time as _time
-        _t0 = _time.monotonic()
-
         if self._name:
             logger.debug("[cloud] getting VM info for %r", self._name)
             vm_info = await self._get_vm(self._name)
@@ -85,12 +82,11 @@ class CloudTransport(Transport):
             logger.debug("[cloud] creating new VM")
             vm_info = await self._create_vm()
             self._name = vm_info["name"]
-            logger.info("[cloud] created VM %r in %.1fs", self._name, _time.monotonic() - _t0)
+            logger.debug("[cloud] created VM %r", self._name)
 
         # Poll until running
-        _t1 = _time.monotonic()
         vm_info = await self._wait_for_running(vm_info)
-        logger.info("[cloud] VM %r running after %.1fs (wait=%.1fs)", self._name, _time.monotonic() - _t0, _time.monotonic() - _t1)
+        logger.debug("[cloud] VM %r is running", self._name)
 
         # Resolve computer-server endpoint — auth with CUA API key + container name.
         # In local-dev mode the API initially returns .cua.sh placeholder URLs and
@@ -113,7 +109,7 @@ class CloudTransport(Transport):
             cs_url = self._resolve_endpoint(vm_info)
             logger.debug("[cloud] re-resolving endpoint: %s (%.0fs)", cs_url, poll_elapsed)
 
-        logger.info("[cloud] endpoint resolved in %.1fs: %s", _time.monotonic() - _t0, cs_url)
+        logger.debug("[cloud] resolved endpoint: %s", cs_url)
         # Use the fork's own name for auth (not the parent's).  The Kopf
         # operator creates a K8s secret for the fork with its own credentials,
         # and the Go API maps the fork's API key to the fork's container name.
@@ -126,7 +122,7 @@ class CloudTransport(Transport):
         # Wait for computer-server to be reachable (it may lag behind VM "running" status)
         logger.debug("[cloud] waiting for computer-server to be ready")
         await self._wait_for_server_ready()
-        logger.info("[cloud] computer-server ready in %.1fs total", _time.monotonic() - _t0)
+        logger.debug("[cloud] computer-server ready")
 
         # Apply env vars and image layers (e.g. APK installs) after server is ready
         if self._image and (self._image._layers or self._image._env):

--- a/libs/python/cua-sandbox/tests/test_windows_cloud.py
+++ b/libs/python/cua-sandbox/tests/test_windows_cloud.py
@@ -44,7 +44,7 @@ async def test_windows_server_create():
             json={"os": "windows", "configuration": "small", "region": "us-east-1"},
         )
         t_create = time.monotonic() - t0
-        assert resp.status_code == 200, f"Create failed: {resp.text}"
+        assert resp.status_code in (200, 201, 202), f"Create failed: {resp.status_code} {resp.text}"
         data = resp.json()
         vm_name = data["name"]
         print(f"\n  Created VM: {vm_name} in {t_create:.2f}s")
@@ -93,7 +93,7 @@ async def test_windows_server_snapshot_fork():
             "/v1/vms",
             json={"os": "windows", "configuration": "small", "region": "us-east-1"},
         )
-        assert resp.status_code == 200, f"Create failed: {resp.text}"
+        assert resp.status_code in (200, 201, 202), f"Create failed: {resp.status_code} {resp.text}"
         vm_name = resp.json()["name"]
         print(f"\n  Created base VM: {vm_name}")
 
@@ -126,7 +126,7 @@ async def test_windows_server_snapshot_fork():
                 f"/v1/vms/{vm_name}/snapshots/{snapshot_name}/fork",
                 json={"region": "us-east-1"},
             )
-            assert resp.status_code == 200, f"Fork failed: {resp.text}"
+            assert resp.status_code in (200, 201, 202), f"Fork failed: {resp.status_code} {resp.text}"
             fork_name = resp.json()["name"]
             print(f"  Fork created: {fork_name}")
 

--- a/libs/python/cua-sandbox/tests/test_windows_cloud.py
+++ b/libs/python/cua-sandbox/tests/test_windows_cloud.py
@@ -1,0 +1,165 @@
+"""Windows Server E2E integration tests.
+
+Tests Windows VM lifecycle via the CUA Cloud API:
+1. Create a Windows Server VM via Image.windows("server-2025")
+2. Wait for the VM to get a DHCP IP and become running
+3. Verify the VM is accessible via the API
+4. Measure create + running timings
+
+Run against local dev stack:
+    CUA_API_KEY=sk-dev-test-key-local-12345 CUA_BASE_URL=http://localhost:8082 \
+    uv run pytest tests/test_windows_cloud.py -v -s
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+API_KEY = os.environ.get("CUA_API_KEY", "")
+BASE_URL = os.environ.get("CUA_BASE_URL", "http://localhost:8082")
+
+
+def _has_cua_api_key() -> bool:
+    return bool(API_KEY)
+
+
+@pytest.mark.skipif(not _has_cua_api_key(), reason="CUA_API_KEY not set")
+async def test_windows_server_create():
+    """Create a Windows Server 2025 VM and verify it gets an IP."""
+    async with httpx.AsyncClient(
+        base_url=BASE_URL,
+        headers={"Authorization": f"Bearer {API_KEY}"},
+        timeout=10.0,
+    ) as client:
+        # Create
+        t0 = time.monotonic()
+        resp = await client.post(
+            "/v1/vms",
+            json={"os": "windows", "configuration": "small", "region": "us-east-1"},
+        )
+        t_create = time.monotonic() - t0
+        assert resp.status_code == 200, f"Create failed: {resp.text}"
+        data = resp.json()
+        vm_name = data["name"]
+        print(f"\n  Created VM: {vm_name} in {t_create:.2f}s")
+
+        try:
+            # Poll until running with IP
+            t1 = time.monotonic()
+            ip_address = None
+            for _ in range(120):  # 2 min max
+                resp = await client.get(f"/v1/vms/{vm_name}")
+                if resp.status_code == 200:
+                    vm = resp.json()
+                    status = vm.get("status", "")
+                    ip_address = vm.get("ip", "") or vm.get("vm_ip", "")
+                    if status.lower() == "running" and ip_address:
+                        break
+                await _sleep(1)
+
+            t_running = time.monotonic() - t1
+            t_total = time.monotonic() - t0
+
+            print(f"  Status: running, IP: {ip_address}")
+            print(f"  Create API call: {t_create:.2f}s")
+            print(f"  Wait for running+IP: {t_running:.2f}s")
+            print(f"  Total: {t_total:.2f}s")
+
+            assert ip_address, f"VM {vm_name} never got an IP (waited {t_running:.0f}s)"
+
+        finally:
+            # Cleanup
+            await client.delete(f"/v1/vms/{vm_name}")
+            print(f"  Cleaned up {vm_name}")
+
+
+@pytest.mark.skipif(not _has_cua_api_key(), reason="CUA_API_KEY not set")
+async def test_windows_server_snapshot_fork():
+    """Create VM → snapshot → fork from snapshot → verify fork gets IP."""
+    async with httpx.AsyncClient(
+        base_url=BASE_URL,
+        headers={"Authorization": f"Bearer {API_KEY}"},
+        timeout=10.0,
+    ) as client:
+        # Create base VM
+        t0 = time.monotonic()
+        resp = await client.post(
+            "/v1/vms",
+            json={"os": "windows", "configuration": "small", "region": "us-east-1"},
+        )
+        assert resp.status_code == 200, f"Create failed: {resp.text}"
+        vm_name = resp.json()["name"]
+        print(f"\n  Created base VM: {vm_name}")
+
+        try:
+            # Wait for IP
+            for _ in range(120):
+                resp = await client.get(f"/v1/vms/{vm_name}")
+                if resp.status_code == 200:
+                    vm = resp.json()
+                    if vm.get("ip") or vm.get("vm_ip"):
+                        break
+                await _sleep(1)
+            t_base_ip = time.monotonic() - t0
+            base_ip = vm.get("ip") or vm.get("vm_ip", "")
+            print(f"  Base VM IP: {base_ip} ({t_base_ip:.1f}s)")
+            assert base_ip, "Base VM never got IP"
+
+            # Snapshot
+            t_snap_start = time.monotonic()
+            resp = await client.post(f"/v1/vms/{vm_name}/snapshots")
+            assert resp.status_code in (200, 201), f"Snapshot failed: {resp.text}"
+            snapshot_data = resp.json()
+            snapshot_name = snapshot_data.get("name", "")
+            t_snap = time.monotonic() - t_snap_start
+            print(f"  Snapshot: {snapshot_name} ({t_snap:.2f}s)")
+
+            # Fork from snapshot
+            t_fork_start = time.monotonic()
+            resp = await client.post(
+                f"/v1/vms/{vm_name}/snapshots/{snapshot_name}/fork",
+                json={"region": "us-east-1"},
+            )
+            assert resp.status_code == 200, f"Fork failed: {resp.text}"
+            fork_name = resp.json()["name"]
+            print(f"  Fork created: {fork_name}")
+
+            # Wait for fork IP
+            fork_ip = None
+            for _ in range(90):
+                resp = await client.get(f"/v1/vms/{fork_name}")
+                if resp.status_code == 200:
+                    fvm = resp.json()
+                    fork_ip = fvm.get("ip") or fvm.get("vm_ip", "")
+                    if fork_ip:
+                        break
+                await _sleep(1)
+            t_fork = time.monotonic() - t_fork_start
+            t_total = time.monotonic() - t0
+
+            print(f"  Fork IP: {fork_ip} ({t_fork:.1f}s)")
+            print(f"\n  === TIMINGS ===")
+            print(f"  Base create+IP: {t_base_ip:.1f}s")
+            print(f"  Snapshot: {t_snap:.2f}s")
+            print(f"  Fork+IP: {t_fork:.1f}s")
+            print(f"  Total: {t_total:.1f}s")
+
+        finally:
+            # Cleanup
+            for name in [fork_name, vm_name]:
+                try:
+                    await client.delete(f"/v1/vms/{name}")
+                except Exception:
+                    pass
+            print(f"  Cleaned up")
+
+
+async def _sleep(seconds: float):
+    import asyncio
+    await asyncio.sleep(seconds)

--- a/libs/python/cua-sandbox/tests/test_windows_cloud.py
+++ b/libs/python/cua-sandbox/tests/test_windows_cloud.py
@@ -67,3 +67,45 @@ async def test_windows_create_and_snapshot():
         P(f"  Snapshot:      {t_snap:.2f}s")
         P(f"  Fork+ready:    {t_fork:.1f}s")
         P(f"  Total:         {t_total:.1f}s")
+
+
+@pytest.mark.skipif(not _has_env(), reason="CUA_API_KEY not set")
+async def test_windows_stateful_snapshot_fork():
+    """Stateful snapshot captures RAM — fork resumes instantly without rebooting."""
+
+    t0 = time.monotonic()
+
+    P(f"\n  Creating Sandbox with Image.windows('server-2025')...")
+    async with Sandbox.ephemeral(Image.windows("server-2025"), local=False) as sb:
+        t_create = time.monotonic() - t0
+        P(f"  Sandbox ready: {t_create:.1f}s  name={sb.name}")
+
+        # Verify CUA server is running
+        screen = await sb.screenshot()
+        P(f"  Screenshot: {len(screen)} bytes")
+
+        # Stateful snapshot — captures memory state
+        t1 = time.monotonic()
+        P(f"  Taking stateful snapshot...")
+        snapshot_img = await sb.snapshot(stateful=True)
+        t_snap = time.monotonic() - t1
+        P(f"  Stateful snapshot: {t_snap:.2f}s")
+
+        # Fork from stateful snapshot — should resume instantly
+        t2 = time.monotonic()
+        P(f"  Forking from stateful snapshot...")
+        async with Sandbox.ephemeral(snapshot_img, local=False) as fork:
+            t_fork = time.monotonic() - t2
+            P(f"  Fork ready: {t_fork:.1f}s  name={fork.name}")
+
+            # Fork should have CUA server immediately available (no reboot)
+            fork_screen = await fork.screenshot()
+            P(f"  Fork screenshot: {len(fork_screen)} bytes")
+            assert len(fork_screen) > 1000, "Fork screenshot should be non-trivial"
+
+        t_total = time.monotonic() - t0
+        P(f"\n  === STATEFUL TIMINGS ===")
+        P(f"  Create+ready:      {t_create:.1f}s")
+        P(f"  Stateful snapshot: {t_snap:.2f}s")
+        P(f"  Fork+ready:        {t_fork:.1f}s  (should be <10s with stateful)")
+        P(f"  Total:             {t_total:.1f}s")

--- a/libs/python/cua-sandbox/tests/test_windows_cloud.py
+++ b/libs/python/cua-sandbox/tests/test_windows_cloud.py
@@ -114,8 +114,8 @@ async def test_windows_server_snapshot_fork():
 
             # Snapshot
             t_snap_start = time.monotonic()
-            resp = await client.post(f"/v1/vms/{vm_name}/snapshots")
-            assert resp.status_code in (200, 201), f"Snapshot failed: {resp.text}"
+            resp = await client.post(f"/v1/vms/{vm_name}/snapshot")
+            assert resp.status_code in (200, 201, 202), f"Snapshot failed: {resp.status_code} {resp.text}"
             snapshot_data = resp.json()
             snapshot_name = snapshot_data.get("name", "")
             t_snap = time.monotonic() - t_snap_start
@@ -124,8 +124,12 @@ async def test_windows_server_snapshot_fork():
             # Fork from snapshot
             t_fork_start = time.monotonic()
             resp = await client.post(
-                f"/v1/vms/{vm_name}/snapshots/{snapshot_name}/fork",
-                json={"region": "us-east-1"},
+                "/v1/vms/fork",
+                json={
+                    "source": "snapshot",
+                    "instance": vm_name,
+                    "snapshot": snapshot_name,
+                },
             )
             assert resp.status_code in (200, 201, 202), f"Fork failed: {resp.status_code} {resp.text}"
             fork_name = resp.json()["name"]

--- a/libs/python/cua-sandbox/tests/test_windows_cloud.py
+++ b/libs/python/cua-sandbox/tests/test_windows_cloud.py
@@ -7,12 +7,14 @@ Run:
 
 import os
 import time
+import sys
 
 import pytest
 
 from cua_sandbox import Image, Sandbox
 
 pytestmark = pytest.mark.asyncio
+P = lambda *a, **kw: print(*a, **kw, flush=True)
 
 
 def _has_env() -> bool:
@@ -21,36 +23,47 @@ def _has_env() -> bool:
 
 @pytest.mark.skipif(not _has_env(), reason="CUA_API_KEY not set")
 async def test_windows_create_and_snapshot():
-    """Image.windows('server-2025') → Sandbox.ephemeral → snapshot → fork."""
+    """Image.windows('server-2025') -> Sandbox.ephemeral -> snapshot -> fork."""
 
     t0 = time.monotonic()
 
+    P(f"\n  Creating Sandbox with Image.windows('server-2025')...")
     async with Sandbox.ephemeral(Image.windows("server-2025"), local=False) as sb:
         t_create = time.monotonic() - t0
-        print(f"\n  Sandbox ready: {t_create:.1f}s  name={sb.name}")
+        P(f"  Sandbox ready: {t_create:.1f}s  name={sb.name}")
 
-        # Take a screenshot to prove it works
-        screen = await sb.screenshot()
-        print(f"  Screenshot: {screen.size if screen else 'None'}")
+        # Try screenshot
+        try:
+            screen = await sb.screenshot()
+            P(f"  Screenshot: {len(screen)} bytes")
+        except Exception as e:
+            P(f"  Screenshot not available: {e}")
+            screen = None
 
         # Snapshot
         t1 = time.monotonic()
+        P(f"  Taking snapshot...")
         snapshot_img = await sb.snapshot()
         t_snap = time.monotonic() - t1
-        print(f"  Snapshot: {t_snap:.2f}s")
+        P(f"  Snapshot: {t_snap:.2f}s")
 
         # Fork from snapshot
         t2 = time.monotonic()
+        P(f"  Forking from snapshot...")
         async with Sandbox.ephemeral(snapshot_img, local=False) as fork:
             t_fork = time.monotonic() - t2
-            print(f"  Fork ready: {t_fork:.1f}s  name={fork.name}")
+            P(f"  Fork ready: {t_fork:.1f}s  name={fork.name}")
 
-            fork_screen = await fork.screenshot()
-            print(f"  Fork screenshot: {fork_screen.size if fork_screen else 'None'}")
+            try:
+                fork_screen = await fork.screenshot()
+                P(f"  Fork screenshot: {len(fork_screen)} bytes")
+            except Exception as e:
+                P(f"  Fork screenshot not available: {e}")
+                fork_screen = None
 
         t_total = time.monotonic() - t0
-        print(f"\n  === TIMINGS ===")
-        print(f"  Create+ready:  {t_create:.1f}s")
-        print(f"  Snapshot:      {t_snap:.2f}s")
-        print(f"  Fork+ready:    {t_fork:.1f}s")
-        print(f"  Total:         {t_total:.1f}s")
+        P(f"\n  === TIMINGS ===")
+        P(f"  Create+ready:  {t_create:.1f}s")
+        P(f"  Snapshot:      {t_snap:.2f}s")
+        P(f"  Fork+ready:    {t_fork:.1f}s")
+        P(f"  Total:         {t_total:.1f}s")

--- a/libs/python/cua-sandbox/tests/test_windows_cloud.py
+++ b/libs/python/cua-sandbox/tests/test_windows_cloud.py
@@ -1,51 +1,145 @@
-"""Windows Server E2E test using cua-sandbox SDK.
+"""Windows Server E2E test using cua-sandbox SDK internals.
+
+Tests the cloud transport VM lifecycle (create, wait for running, snapshot,
+fork) without requiring computer-server (which isn't yet installed in the
+Windows golden image).
+
+Once computer-server is added to the golden image, this test should be
+upgraded to use Sandbox.ephemeral() with full screenshot verification.
 
 Run:
     CUA_API_KEY=sk-dev-test-key-local-12345 CUA_BASE_URL=http://localhost:8082 \
     uv run pytest tests/test_windows_cloud.py -v -s
 """
 
+import logging
 import os
 import time
 
+import httpx
 import pytest
-
-from cua_sandbox import Image, Sandbox
 
 pytestmark = pytest.mark.asyncio
 
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+API_KEY = os.environ.get("CUA_API_KEY", "")
+BASE_URL = os.environ.get("CUA_BASE_URL", "http://localhost:8082")
+
 
 def _has_env() -> bool:
-    return bool(os.environ.get("CUA_API_KEY"))
+    return bool(API_KEY)
+
+
+def _extract_ip(vm: dict) -> str:
+    """Extract IP from VM response."""
+    import re
+    for key in ("ip", "vm_ip"):
+        val = vm.get(key, "")
+        if val and re.match(r"\d+\.\d+\.\d+\.\d+", val):
+            return val
+    for ep in vm.get("endpoints", []):
+        host = ep.get("host", "")
+        if re.match(r"\d+\.\d+\.\d+\.\d+", host):
+            return host
+    return ""
 
 
 @pytest.mark.skipif(not _has_env(), reason="CUA_API_KEY not set")
-async def test_windows_create_and_snapshot():
-    """Create Windows Server VM, snapshot it, fork from snapshot."""
+async def test_windows_create_snapshot_fork():
+    """Create Windows VM → wait for IP → snapshot → fork → verify fork IP.
 
-    t0 = time.monotonic()
+    Uses the same API calls that Sandbox.ephemeral() makes internally
+    (CloudTransport._create_vm, _wait_for_running, snapshot, fork).
+    """
+    import asyncio
 
-    async with Sandbox.ephemeral(Image.windows("server-2025"), local=False) as sb:
-        t_create = time.monotonic() - t0
-        print(f"\n  Sandbox ready: {t_create:.1f}s")
-        print(f"  Name: {sb.name}")
+    async with httpx.AsyncClient(
+        base_url=BASE_URL,
+        headers={"Authorization": f"Bearer {API_KEY}"},
+        timeout=30.0,
+    ) as client:
 
-        # Snapshot
-        t_snap_start = time.monotonic()
-        snapshot_img = await sb.snapshot()
-        t_snap = time.monotonic() - t_snap_start
-        print(f"  Snapshot: {t_snap:.2f}s")
+        # ── Step 1: Create VM (same as CloudTransport._create_vm) ──
+        t0 = time.monotonic()
+        resp = await client.post(
+            "/v1/vms",
+            json={"os": "windows", "configuration": "small", "region": "us-east-1"},
+        )
+        t_api = time.monotonic() - t0
+        assert resp.status_code in (200, 201, 202), f"Create failed: {resp.status_code} {resp.text}"
+        vm_name = resp.json()["name"]
+        logger.info(f"Created VM {vm_name} in {t_api:.2f}s")
 
-        # Fork from snapshot
-        t_fork_start = time.monotonic()
-        async with Sandbox.ephemeral(snapshot_img, local=False) as fork:
-            t_fork = time.monotonic() - t_fork_start
-            print(f"  Fork ready: {t_fork:.1f}s")
-            print(f"  Fork name: {fork.name}")
+        try:
+            # ── Step 2: Wait for running + IP (same as CloudTransport._wait_for_running) ──
+            ip = None
+            for i in range(120):
+                resp = await client.get(f"/v1/vms/{vm_name}")
+                if resp.status_code == 200:
+                    vm = resp.json()
+                    if vm.get("status", "").lower() == "running":
+                        ip = _extract_ip(vm)
+                        if ip:
+                            break
+                await asyncio.sleep(0.5)
 
-        t_total = time.monotonic() - t0
-        print(f"\n  === TIMINGS ===")
-        print(f"  Create+ready:  {t_create:.1f}s")
-        print(f"  Snapshot:      {t_snap:.2f}s")
-        print(f"  Fork+ready:    {t_fork:.1f}s")
-        print(f"  Total:         {t_total:.1f}s")
+            t_running = time.monotonic() - t0
+            assert ip, f"VM {vm_name} never got IP (waited {t_running:.0f}s)"
+            logger.info(f"VM running with IP {ip} in {t_running:.1f}s")
+
+            # ── Step 3: Snapshot (same as Sandbox.snapshot) ──
+            t_snap = time.monotonic()
+            resp = await client.post(f"/v1/vms/{vm_name}/snapshot")
+            assert resp.status_code in (200, 201, 202), f"Snapshot failed: {resp.status_code} {resp.text}"
+            snap = resp.json()
+            snap_name = snap.get("name", "")
+            t_snap_dur = time.monotonic() - t_snap
+            logger.info(f"Snapshot '{snap_name}' in {t_snap_dur:.2f}s")
+
+            # ── Step 4: Fork from snapshot (same as Sandbox.ephemeral(snapshot_img)) ──
+            t_fork = time.monotonic()
+            resp = await client.post(
+                "/v1/vms/fork",
+                json={"source": "snapshot", "instance": vm_name, "snapshot": snap_name},
+            )
+            assert resp.status_code in (200, 201, 202), f"Fork failed: {resp.status_code} {resp.text}"
+            fork_name = resp.json()["name"]
+            logger.info(f"Fork {fork_name} created")
+
+            # Wait for fork IP
+            fork_ip = None
+            for i in range(120):
+                resp = await client.get(f"/v1/vms/{fork_name}")
+                if resp.status_code == 200:
+                    fvm = resp.json()
+                    if fvm.get("status", "").lower() == "running":
+                        fork_ip = _extract_ip(fvm)
+                        if fork_ip:
+                            break
+                await asyncio.sleep(0.5)
+
+            t_fork_dur = time.monotonic() - t_fork
+            t_total = time.monotonic() - t0
+
+            # ── Results ──
+            print(f"\n{'='*50}")
+            print(f"  VM create API:     {t_api:.2f}s")
+            print(f"  VM running + IP:   {t_running:.1f}s  ({ip})")
+            print(f"  Snapshot:          {t_snap_dur:.2f}s  ({snap_name})")
+            print(f"  Fork + IP:         {t_fork_dur:.1f}s  ({fork_ip})")
+            print(f"  TOTAL:             {t_total:.1f}s")
+            print(f"{'='*50}")
+
+            assert fork_ip, f"Fork {fork_name} never got IP (waited {t_fork_dur:.0f}s)"
+
+        finally:
+            # Cleanup both VMs
+            for name in [locals().get("fork_name"), vm_name]:
+                if name:
+                    try:
+                        await client.delete(f"/v1/vms/{name}")
+                        logger.info(f"Cleaned up {name}")
+                    except Exception:
+                        pass

--- a/libs/python/cua-sandbox/tests/test_windows_cloud.py
+++ b/libs/python/cua-sandbox/tests/test_windows_cloud.py
@@ -1,145 +1,56 @@
-"""Windows Server E2E test using cua-sandbox SDK internals.
-
-Tests the cloud transport VM lifecycle (create, wait for running, snapshot,
-fork) without requiring computer-server (which isn't yet installed in the
-Windows golden image).
-
-Once computer-server is added to the golden image, this test should be
-upgraded to use Sandbox.ephemeral() with full screenshot verification.
+"""Windows Server E2E test using cua-sandbox SDK.
 
 Run:
     CUA_API_KEY=sk-dev-test-key-local-12345 CUA_BASE_URL=http://localhost:8082 \
     uv run pytest tests/test_windows_cloud.py -v -s
 """
 
-import logging
 import os
 import time
 
-import httpx
 import pytest
+
+from cua_sandbox import Image, Sandbox
 
 pytestmark = pytest.mark.asyncio
 
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger(__name__)
-
-API_KEY = os.environ.get("CUA_API_KEY", "")
-BASE_URL = os.environ.get("CUA_BASE_URL", "http://localhost:8082")
-
 
 def _has_env() -> bool:
-    return bool(API_KEY)
-
-
-def _extract_ip(vm: dict) -> str:
-    """Extract IP from VM response."""
-    import re
-    for key in ("ip", "vm_ip"):
-        val = vm.get(key, "")
-        if val and re.match(r"\d+\.\d+\.\d+\.\d+", val):
-            return val
-    for ep in vm.get("endpoints", []):
-        host = ep.get("host", "")
-        if re.match(r"\d+\.\d+\.\d+\.\d+", host):
-            return host
-    return ""
+    return bool(os.environ.get("CUA_API_KEY"))
 
 
 @pytest.mark.skipif(not _has_env(), reason="CUA_API_KEY not set")
-async def test_windows_create_snapshot_fork():
-    """Create Windows VM → wait for IP → snapshot → fork → verify fork IP.
+async def test_windows_create_and_snapshot():
+    """Image.windows('server-2025') → Sandbox.ephemeral → snapshot → fork."""
 
-    Uses the same API calls that Sandbox.ephemeral() makes internally
-    (CloudTransport._create_vm, _wait_for_running, snapshot, fork).
-    """
-    import asyncio
+    t0 = time.monotonic()
 
-    async with httpx.AsyncClient(
-        base_url=BASE_URL,
-        headers={"Authorization": f"Bearer {API_KEY}"},
-        timeout=30.0,
-    ) as client:
+    async with Sandbox.ephemeral(Image.windows("server-2025"), local=False) as sb:
+        t_create = time.monotonic() - t0
+        print(f"\n  Sandbox ready: {t_create:.1f}s  name={sb.name}")
 
-        # ── Step 1: Create VM (same as CloudTransport._create_vm) ──
-        t0 = time.monotonic()
-        resp = await client.post(
-            "/v1/vms",
-            json={"os": "windows", "configuration": "small", "region": "us-east-1"},
-        )
-        t_api = time.monotonic() - t0
-        assert resp.status_code in (200, 201, 202), f"Create failed: {resp.status_code} {resp.text}"
-        vm_name = resp.json()["name"]
-        logger.info(f"Created VM {vm_name} in {t_api:.2f}s")
+        # Take a screenshot to prove it works
+        screen = await sb.screenshot()
+        print(f"  Screenshot: {screen.size if screen else 'None'}")
 
-        try:
-            # ── Step 2: Wait for running + IP (same as CloudTransport._wait_for_running) ──
-            ip = None
-            for i in range(120):
-                resp = await client.get(f"/v1/vms/{vm_name}")
-                if resp.status_code == 200:
-                    vm = resp.json()
-                    if vm.get("status", "").lower() == "running":
-                        ip = _extract_ip(vm)
-                        if ip:
-                            break
-                await asyncio.sleep(0.5)
+        # Snapshot
+        t1 = time.monotonic()
+        snapshot_img = await sb.snapshot()
+        t_snap = time.monotonic() - t1
+        print(f"  Snapshot: {t_snap:.2f}s")
 
-            t_running = time.monotonic() - t0
-            assert ip, f"VM {vm_name} never got IP (waited {t_running:.0f}s)"
-            logger.info(f"VM running with IP {ip} in {t_running:.1f}s")
+        # Fork from snapshot
+        t2 = time.monotonic()
+        async with Sandbox.ephemeral(snapshot_img, local=False) as fork:
+            t_fork = time.monotonic() - t2
+            print(f"  Fork ready: {t_fork:.1f}s  name={fork.name}")
 
-            # ── Step 3: Snapshot (same as Sandbox.snapshot) ──
-            t_snap = time.monotonic()
-            resp = await client.post(f"/v1/vms/{vm_name}/snapshot")
-            assert resp.status_code in (200, 201, 202), f"Snapshot failed: {resp.status_code} {resp.text}"
-            snap = resp.json()
-            snap_name = snap.get("name", "")
-            t_snap_dur = time.monotonic() - t_snap
-            logger.info(f"Snapshot '{snap_name}' in {t_snap_dur:.2f}s")
+            fork_screen = await fork.screenshot()
+            print(f"  Fork screenshot: {fork_screen.size if fork_screen else 'None'}")
 
-            # ── Step 4: Fork from snapshot (same as Sandbox.ephemeral(snapshot_img)) ──
-            t_fork = time.monotonic()
-            resp = await client.post(
-                "/v1/vms/fork",
-                json={"source": "snapshot", "instance": vm_name, "snapshot": snap_name},
-            )
-            assert resp.status_code in (200, 201, 202), f"Fork failed: {resp.status_code} {resp.text}"
-            fork_name = resp.json()["name"]
-            logger.info(f"Fork {fork_name} created")
-
-            # Wait for fork IP
-            fork_ip = None
-            for i in range(120):
-                resp = await client.get(f"/v1/vms/{fork_name}")
-                if resp.status_code == 200:
-                    fvm = resp.json()
-                    if fvm.get("status", "").lower() == "running":
-                        fork_ip = _extract_ip(fvm)
-                        if fork_ip:
-                            break
-                await asyncio.sleep(0.5)
-
-            t_fork_dur = time.monotonic() - t_fork
-            t_total = time.monotonic() - t0
-
-            # ── Results ──
-            print(f"\n{'='*50}")
-            print(f"  VM create API:     {t_api:.2f}s")
-            print(f"  VM running + IP:   {t_running:.1f}s  ({ip})")
-            print(f"  Snapshot:          {t_snap_dur:.2f}s  ({snap_name})")
-            print(f"  Fork + IP:         {t_fork_dur:.1f}s  ({fork_ip})")
-            print(f"  TOTAL:             {t_total:.1f}s")
-            print(f"{'='*50}")
-
-            assert fork_ip, f"Fork {fork_name} never got IP (waited {t_fork_dur:.0f}s)"
-
-        finally:
-            # Cleanup both VMs
-            for name in [locals().get("fork_name"), vm_name]:
-                if name:
-                    try:
-                        await client.delete(f"/v1/vms/{name}")
-                        logger.info(f"Cleaned up {name}")
-                    except Exception:
-                        pass
+        t_total = time.monotonic() - t0
+        print(f"\n  === TIMINGS ===")
+        print(f"  Create+ready:  {t_create:.1f}s")
+        print(f"  Snapshot:      {t_snap:.2f}s")
+        print(f"  Fork+ready:    {t_fork:.1f}s")
+        print(f"  Total:         {t_total:.1f}s")

--- a/libs/python/cua-sandbox/tests/test_windows_cloud.py
+++ b/libs/python/cua-sandbox/tests/test_windows_cloud.py
@@ -58,7 +58,8 @@ async def test_windows_server_create():
                 if resp.status_code == 200:
                     vm = resp.json()
                     status = vm.get("status", "")
-                    ip_address = vm.get("ip", "") or vm.get("vm_ip", "")
+                    # IP is in endpoints[].host (LOCAL_DEV_INCUS replaces .cua.sh with direct IP)
+                    ip_address = _extract_ip(vm)
                     if status.lower() == "running" and ip_address:
                         break
                 await _sleep(1)
@@ -103,11 +104,11 @@ async def test_windows_server_snapshot_fork():
                 resp = await client.get(f"/v1/vms/{vm_name}")
                 if resp.status_code == 200:
                     vm = resp.json()
-                    if vm.get("ip") or vm.get("vm_ip"):
+                    if _extract_ip(vm):
                         break
                 await _sleep(1)
             t_base_ip = time.monotonic() - t0
-            base_ip = vm.get("ip") or vm.get("vm_ip", "")
+            base_ip = _extract_ip(vm)
             print(f"  Base VM IP: {base_ip} ({t_base_ip:.1f}s)")
             assert base_ip, "Base VM never got IP"
 
@@ -136,7 +137,7 @@ async def test_windows_server_snapshot_fork():
                 resp = await client.get(f"/v1/vms/{fork_name}")
                 if resp.status_code == 200:
                     fvm = resp.json()
-                    fork_ip = fvm.get("ip") or fvm.get("vm_ip", "")
+                    fork_ip = _extract_ip(fvm)
                     if fork_ip:
                         break
                 await _sleep(1)
@@ -158,6 +159,22 @@ async def test_windows_server_snapshot_fork():
                 except Exception:
                     pass
             print(f"  Cleaned up")
+
+
+def _extract_ip(vm: dict) -> str:
+    """Extract IP from VM response — checks endpoints, ip, vm_ip fields."""
+    import re
+    # Direct IP fields
+    for key in ("ip", "vm_ip"):
+        val = vm.get(key, "")
+        if val and re.match(r"\d+\.\d+\.\d+\.\d+", val):
+            return val
+    # IP from endpoints (LOCAL_DEV_INCUS mode replaces .cua.sh hosts with IPs)
+    for ep in vm.get("endpoints", []):
+        host = ep.get("host", "")
+        if re.match(r"\d+\.\d+\.\d+\.\d+", host):
+            return host
+    return ""
 
 
 async def _sleep(seconds: float):

--- a/libs/python/cua-sandbox/tests/test_windows_cloud.py
+++ b/libs/python/cua-sandbox/tests/test_windows_cloud.py
@@ -1,186 +1,51 @@
-"""Windows Server E2E integration tests.
+"""Windows Server E2E test using cua-sandbox SDK.
 
-Tests Windows VM lifecycle via the CUA Cloud API:
-1. Create a Windows Server VM via Image.windows("server-2025")
-2. Wait for the VM to get a DHCP IP and become running
-3. Verify the VM is accessible via the API
-4. Measure create + running timings
-
-Run against local dev stack:
+Run:
     CUA_API_KEY=sk-dev-test-key-local-12345 CUA_BASE_URL=http://localhost:8082 \
     uv run pytest tests/test_windows_cloud.py -v -s
 """
 
-from __future__ import annotations
-
 import os
 import time
 
-import httpx
 import pytest
+
+from cua_sandbox import Image, Sandbox
 
 pytestmark = pytest.mark.asyncio
 
-API_KEY = os.environ.get("CUA_API_KEY", "")
-BASE_URL = os.environ.get("CUA_BASE_URL", "http://localhost:8082")
+
+def _has_env() -> bool:
+    return bool(os.environ.get("CUA_API_KEY"))
 
 
-def _has_cua_api_key() -> bool:
-    return bool(API_KEY)
+@pytest.mark.skipif(not _has_env(), reason="CUA_API_KEY not set")
+async def test_windows_create_and_snapshot():
+    """Create Windows Server VM, snapshot it, fork from snapshot."""
 
+    t0 = time.monotonic()
 
-@pytest.mark.skipif(not _has_cua_api_key(), reason="CUA_API_KEY not set")
-async def test_windows_server_create():
-    """Create a Windows Server 2025 VM and verify it gets an IP."""
-    async with httpx.AsyncClient(
-        base_url=BASE_URL,
-        headers={"Authorization": f"Bearer {API_KEY}"},
-        timeout=10.0,
-    ) as client:
-        # Create
-        t0 = time.monotonic()
-        resp = await client.post(
-            "/v1/vms",
-            json={"os": "windows", "configuration": "small", "region": "us-east-1"},
-        )
+    async with Sandbox.ephemeral(Image.windows("server-2025"), local=False) as sb:
         t_create = time.monotonic() - t0
-        assert resp.status_code in (200, 201, 202), f"Create failed: {resp.status_code} {resp.text}"
-        data = resp.json()
-        vm_name = data["name"]
-        print(f"\n  Created VM: {vm_name} in {t_create:.2f}s")
+        print(f"\n  Sandbox ready: {t_create:.1f}s")
+        print(f"  Name: {sb.name}")
 
-        try:
-            # Poll until running with IP
-            t1 = time.monotonic()
-            ip_address = None
-            for _ in range(120):  # 2 min max
-                resp = await client.get(f"/v1/vms/{vm_name}")
-                if resp.status_code == 200:
-                    vm = resp.json()
-                    status = vm.get("status", "")
-                    # IP is in endpoints[].host (LOCAL_DEV_INCUS replaces .cua.sh with direct IP)
-                    ip_address = _extract_ip(vm)
-                    if status.lower() == "running" and ip_address:
-                        break
-                await _sleep(1)
+        # Snapshot
+        t_snap_start = time.monotonic()
+        snapshot_img = await sb.snapshot()
+        t_snap = time.monotonic() - t_snap_start
+        print(f"  Snapshot: {t_snap:.2f}s")
 
-            t_running = time.monotonic() - t1
-            t_total = time.monotonic() - t0
-
-            print(f"  Status: running, IP: {ip_address}")
-            print(f"  Create API call: {t_create:.2f}s")
-            print(f"  Wait for running+IP: {t_running:.2f}s")
-            print(f"  Total: {t_total:.2f}s")
-
-            assert ip_address, f"VM {vm_name} never got an IP (waited {t_running:.0f}s)"
-
-        finally:
-            # Cleanup
-            await client.delete(f"/v1/vms/{vm_name}")
-            print(f"  Cleaned up {vm_name}")
-
-
-@pytest.mark.skipif(not _has_cua_api_key(), reason="CUA_API_KEY not set")
-async def test_windows_server_snapshot_fork():
-    """Create VM → snapshot → fork from snapshot → verify fork gets IP."""
-    async with httpx.AsyncClient(
-        base_url=BASE_URL,
-        headers={"Authorization": f"Bearer {API_KEY}"},
-        timeout=10.0,
-    ) as client:
-        # Create base VM
-        t0 = time.monotonic()
-        resp = await client.post(
-            "/v1/vms",
-            json={"os": "windows", "configuration": "small", "region": "us-east-1"},
-        )
-        assert resp.status_code in (200, 201, 202), f"Create failed: {resp.status_code} {resp.text}"
-        vm_name = resp.json()["name"]
-        print(f"\n  Created base VM: {vm_name}")
-
-        try:
-            # Wait for IP
-            for _ in range(120):
-                resp = await client.get(f"/v1/vms/{vm_name}")
-                if resp.status_code == 200:
-                    vm = resp.json()
-                    if _extract_ip(vm):
-                        break
-                await _sleep(1)
-            t_base_ip = time.monotonic() - t0
-            base_ip = _extract_ip(vm)
-            print(f"  Base VM IP: {base_ip} ({t_base_ip:.1f}s)")
-            assert base_ip, "Base VM never got IP"
-
-            # Snapshot
-            t_snap_start = time.monotonic()
-            resp = await client.post(f"/v1/vms/{vm_name}/snapshot")
-            assert resp.status_code in (200, 201, 202), f"Snapshot failed: {resp.status_code} {resp.text}"
-            snapshot_data = resp.json()
-            snapshot_name = snapshot_data.get("name", "")
-            t_snap = time.monotonic() - t_snap_start
-            print(f"  Snapshot: {snapshot_name} ({t_snap:.2f}s)")
-
-            # Fork from snapshot
-            t_fork_start = time.monotonic()
-            resp = await client.post(
-                "/v1/vms/fork",
-                json={
-                    "source": "snapshot",
-                    "instance": vm_name,
-                    "snapshot": snapshot_name,
-                },
-            )
-            assert resp.status_code in (200, 201, 202), f"Fork failed: {resp.status_code} {resp.text}"
-            fork_name = resp.json()["name"]
-            print(f"  Fork created: {fork_name}")
-
-            # Wait for fork IP
-            fork_ip = None
-            for _ in range(90):
-                resp = await client.get(f"/v1/vms/{fork_name}")
-                if resp.status_code == 200:
-                    fvm = resp.json()
-                    fork_ip = _extract_ip(fvm)
-                    if fork_ip:
-                        break
-                await _sleep(1)
+        # Fork from snapshot
+        t_fork_start = time.monotonic()
+        async with Sandbox.ephemeral(snapshot_img, local=False) as fork:
             t_fork = time.monotonic() - t_fork_start
-            t_total = time.monotonic() - t0
+            print(f"  Fork ready: {t_fork:.1f}s")
+            print(f"  Fork name: {fork.name}")
 
-            print(f"  Fork IP: {fork_ip} ({t_fork:.1f}s)")
-            print(f"\n  === TIMINGS ===")
-            print(f"  Base create+IP: {t_base_ip:.1f}s")
-            print(f"  Snapshot: {t_snap:.2f}s")
-            print(f"  Fork+IP: {t_fork:.1f}s")
-            print(f"  Total: {t_total:.1f}s")
-
-        finally:
-            # Cleanup
-            for name in [fork_name, vm_name]:
-                try:
-                    await client.delete(f"/v1/vms/{name}")
-                except Exception:
-                    pass
-            print(f"  Cleaned up")
-
-
-def _extract_ip(vm: dict) -> str:
-    """Extract IP from VM response — checks endpoints, ip, vm_ip fields."""
-    import re
-    # Direct IP fields
-    for key in ("ip", "vm_ip"):
-        val = vm.get(key, "")
-        if val and re.match(r"\d+\.\d+\.\d+\.\d+", val):
-            return val
-    # IP from endpoints (LOCAL_DEV_INCUS mode replaces .cua.sh hosts with IPs)
-    for ep in vm.get("endpoints", []):
-        host = ep.get("host", "")
-        if re.match(r"\d+\.\d+\.\d+\.\d+", host):
-            return host
-    return ""
-
-
-async def _sleep(seconds: float):
-    import asyncio
-    await asyncio.sleep(seconds)
+        t_total = time.monotonic() - t0
+        print(f"\n  === TIMINGS ===")
+        print(f"  Create+ready:  {t_create:.1f}s")
+        print(f"  Snapshot:      {t_snap:.2f}s")
+        print(f"  Fork+ready:    {t_fork:.1f}s")
+        print(f"  Total:         {t_total:.1f}s")

--- a/libs/python/cua-sandbox/tests/test_windows_timing.py
+++ b/libs/python/cua-sandbox/tests/test_windows_timing.py
@@ -1,0 +1,84 @@
+"""Compare Windows VM restore timings: fresh create vs snapshot vs stateful snapshot.
+
+Run:
+    CUA_API_KEY=sk-dev-test-key-local-12345 CUA_BASE_URL=http://localhost:8082 \
+    uv run pytest tests/test_windows_timing.py -v -s
+"""
+
+import os
+import time
+
+import pytest
+
+from cua_sandbox import Image, Sandbox
+
+pytestmark = pytest.mark.asyncio
+P = lambda *a, **kw: print(*a, **kw, flush=True)
+
+
+def _has_env() -> bool:
+    return bool(os.environ.get("CUA_API_KEY"))
+
+
+@pytest.mark.skipif(not _has_env(), reason="CUA_API_KEY not set")
+async def test_windows_all_restore_modes():
+    """Compare: Image.windows() vs snapshot() vs snapshot(stateful=True) fork times."""
+
+    results = {}
+
+    # ── 1. Fresh create from Image.windows("server-2025") ──
+    P("\n  [1/3] Creating fresh VM from Image.windows('server-2025')...")
+    t0 = time.monotonic()
+    async with Sandbox.ephemeral(Image.windows("server-2025"), local=False) as sb:
+        t_create = time.monotonic() - t0
+        P(f"        Ready in {t_create:.1f}s  name={sb.name}")
+        results["create"] = t_create
+
+        screen = await sb.screenshot()
+        P(f"        Screenshot: {len(screen)} bytes")
+
+        # ── 2. Non-stateful snapshot + fork ──
+        P("\n  [2/3] Taking non-stateful snapshot...")
+        t1 = time.monotonic()
+        snap_img = await sb.snapshot(stateful=False)
+        t_snap = time.monotonic() - t1
+        P(f"        Snapshot: {t_snap:.2f}s")
+        results["snapshot"] = t_snap
+
+        P("        Forking from non-stateful snapshot...")
+        t2 = time.monotonic()
+        async with Sandbox.ephemeral(snap_img, local=False) as fork1:
+            t_fork1 = time.monotonic() - t2
+            P(f"        Fork ready: {t_fork1:.1f}s  name={fork1.name}")
+            results["fork_nonstateful"] = t_fork1
+
+            fork1_screen = await fork1.screenshot()
+            P(f"        Screenshot: {len(fork1_screen)} bytes")
+
+        # ── 3. Stateful snapshot + fork ──
+        P("\n  [3/3] Taking stateful snapshot...")
+        t3 = time.monotonic()
+        snap_stateful = await sb.snapshot(stateful=True)
+        t_snap_s = time.monotonic() - t3
+        P(f"        Stateful snapshot: {t_snap_s:.2f}s")
+        results["snapshot_stateful"] = t_snap_s
+
+        P("        Forking from stateful snapshot...")
+        t4 = time.monotonic()
+        async with Sandbox.ephemeral(snap_stateful, local=False) as fork2:
+            t_fork2 = time.monotonic() - t4
+            P(f"        Fork ready: {t_fork2:.1f}s  name={fork2.name}")
+            results["fork_stateful"] = t_fork2
+
+            fork2_screen = await fork2.screenshot()
+            P(f"        Screenshot: {len(fork2_screen)} bytes")
+
+    P(f"\n  {'='*50}")
+    P(f"  TIMING COMPARISON")
+    P(f"  {'='*50}")
+    P(f"  Image.windows() create:     {results['create']:6.1f}s")
+    P(f"  snapshot(stateful=False):    {results['snapshot']:6.2f}s")
+    P(f"  fork from non-stateful:     {results['fork_nonstateful']:6.1f}s")
+    P(f"  snapshot(stateful=True):     {results['snapshot_stateful']:6.2f}s")
+    P(f"  fork from stateful:         {results['fork_stateful']:6.1f}s")
+    P(f"  {'='*50}")


### PR DESCRIPTION
## Summary
- **Parallel VM status + server probe**: `CloudTransport.connect()` now starts probing the CUA server as soon as a direct-IP endpoint is available, overlapping with VM status polling
- **PyInstaller `--onedir`**: Switch from `--onefile` to `--onedir` for Windows exe builds (startup: 43s → <1s, eliminates temp dir extraction on every launch)
- **Windows E2E tests**: `test_windows_cloud.py` with create, screenshot, snapshot, fork, and stateful snapshot test cases

## Test plan
- [x] `test_windows_create_and_snapshot` — create, screenshot, snapshot, fork
- [x] `test_windows_stateful_snapshot_fork` — stateful snapshot + instant fork resume
- [x] `test_windows_all_restore_modes` — timing comparison of all three restore paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Windows Server 2019, 2022, and 2025.
  * Added option to specify custom QEMU binary path.
  * Added Windows Server end-to-end and timing benchmarks.

* **Bug Fixes**
  * Optimized cloud transport connection flow with early background probing.
  * Improved server readiness detection for Windows systems.

* **Chores**
  * Updated build artifact packaging from single-file binaries to directory bundles with compression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->