### PR TITLE
feat(computer-server): configurable auth URL via CUA_BASE_URL_AUTH

### DIFF
--- a/libs/python/computer-server/computer_server/main.py
+++ b/libs/python/computer-server/computer_server/main.py
@@ -229,6 +229,9 @@ class AuthenticationManager:
     def __init__(self):
         self.sessions: Dict[str, Dict[str, Any]] = {}
         self.container_name = os.environ.get("CONTAINER_NAME")
+        self.api_base_url = os.environ.get(
+            "CUA_BASE_URL_AUTH", "https://www.cua.ai"
+        ).rstrip("/")
 
     def _hash_credentials(self, container_name: str, api_key: str) -> str:
         """Create a hash of container name and API key for session identification"""
@@ -282,7 +285,7 @@ class AuthenticationManager:
                 headers = {"Authorization": f"Bearer {api_key}", **cua_version_headers()}
 
                 async with session.get(
-                    f"https://www.cua.ai/api/vm/auth?container_name={container_name}",
+                    f"{self.api_base_url}/api/vm/auth?container_name={container_name}",
                     headers=headers,
                 ) as resp:
                     is_valid = resp.status == 200 and bool((await resp.text()).strip())


### PR DESCRIPTION
## Summary
Add `CUA_BASE_URL_AUTH` env var to the computer-server's `AuthenticationManager` so the auth endpoint can point to local/staging API servers instead of the hardcoded `https://www.cua.ai`.

Default: `https://www.cua.ai` (unchanged production behavior)

## Test plan
- [ ] Set `CUA_BASE_URL_AUTH=http://localhost:8082` + `CONTAINER_NAME=test` and verify auth calls hit local API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Authentication service now supports configurable server endpoints through environment settings. The system reads an optional configuration to specify the authentication server URL, enabling seamless deployments across multiple environments and infrastructure setups while maintaining full backward compatibility with existing installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->