### PR TITLE
Claude Optimize: Add tool_choice: any to force tool call in predict_click, +4 more

### DIFF
--- a/libs/python/agent/agent/agent.py
+++ b/libs/python/agent/agent/agent.py
@@ -272,7 +272,7 @@ class ComputerAgent:
         trajectory_dir: Optional[str | Path | dict] = None,
         max_retries: Optional[int] = 3,
         screenshot_delay: Optional[float | int] = 0.5,
-        use_prompt_caching: Optional[bool] = False,
+        use_prompt_caching: Optional[bool] = True,
         max_trajectory_budget: Optional[float | dict] = None,
         telemetry_enabled: Optional[bool] = True,
         trust_remote_code: Optional[bool] = False,

--- a/libs/python/agent/agent/loops/anthropic.py
+++ b/libs/python/agent/agent/loops/anthropic.py
@@ -1673,11 +1673,18 @@ def _add_cache_control(completion_messages: List[Dict[str, Any]]) -> List[Dict[s
     for message in completion_messages:
         message["cache_control"] = {"type": "ephemeral"}
         num_writes += 1
-        # Cache control has a maximum of 4 blocks
-        if num_writes >= 4:
+        # Reserve 1 breakpoint for tools, so use at most 3 for messages
+        if num_writes >= 3:
             break
 
     return completion_messages
+
+
+def _add_cache_control_to_tools(tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Add cache_control to the last tool so the entire tools prefix is cached."""
+    if tools:
+        tools[-1]["cache_control"] = {"type": "ephemeral"}
+    return tools
 
 
 def _combine_completion_messages(completion_messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -1792,6 +1799,8 @@ class AnthropicHostedToolsConfig(AsyncAgentConfig):
             completion_messages = _combine_completion_messages(completion_messages)
             # Then add cache control, anthropic requires explicit "cache_control" dicts
             completion_messages = _add_cache_control(completion_messages)
+            if anthropic_tools:
+                anthropic_tools = _add_cache_control_to_tools(anthropic_tools)
 
         # Prepare API call kwargs
         api_kwargs = {
@@ -1891,22 +1900,20 @@ class AnthropicHostedToolsConfig(AsyncAgentConfig):
         # Construct messages in OpenAI chat completion format for liteLLM
         messages = [
             {
+                "role": "system",
+                "content": """<role>You are a UI grounding expert that identifies and clicks on UI elements in screenshots.</role>
+
+<rules>
+- Act autonomously. Never ask for confirmation.
+- Output ONLY a single click action on the target element. No text responses.
+</rules>""",
+            },
+            {
                 "role": "user",
                 "content": [
                     {
                         "type": "text",
-                        "text": f"""You are a UI grounding expert. Follow these guidelines:
-
-1. NEVER ask for confirmation. Complete all tasks autonomously.
-2. Do NOT send messages like "I need to confirm before..." or "Do you want me to continue?" - just proceed.
-3. When the user asks you to interact with something (like clicking a chat or typing a message), DO IT without asking.
-4. Only use the formal safety check mechanism for truly dangerous operations (like deleting important files).
-5. For normal tasks like clicking buttons, typing in chat boxes, filling forms - JUST DO IT.
-6. The user has already given you permission by running this agent. No further confirmation is needed.
-7. Be decisive and action-oriented. Complete the requested task fully.
-
-Remember: You are expected to complete tasks autonomously. The user trusts you to do what they asked.
-Task: Click {instruction}. Output ONLY a click action on the target element.""",
+                        "text": f"<task>Click on: {instruction}</task>",
                     },
                     {
                         "type": "image_url",
@@ -1921,6 +1928,7 @@ Task: Click {instruction}. Output ONLY a click action on the target element.""",
             "model": model,
             "messages": messages,
             "tools": [computer_tool],
+            "tool_choice": {"type": "any"},
             "stream": False,
             "max_tokens": 100,  # Keep response short for click prediction
             "headers": {"anthropic-beta": tool_config["beta_flag"]},

--- a/libs/python/agent/agent/ui/gradio/app.py
+++ b/libs/python/agent/agent/ui/gradio/app.py
@@ -115,16 +115,16 @@ MODEL_MAPPINGS = {
         "OpenAI: Computer-Use Preview": "openai/computer-use-preview",
     },
     "anthropic": {
-        "default": "anthropic/claude-3-7-sonnet-20250219",
-        "Anthropic: Claude 4 Opus (20250514)": "anthropic/claude-opus-4-20250514",
-        "Anthropic: Claude 4 Sonnet (20250514)": "anthropic/claude-sonnet-4-20250514",
-        "Anthropic: Claude 3.7 Sonnet (20250219)": "anthropic/claude-3-7-sonnet-20250219",
+        "default": "anthropic/claude-sonnet-4-6",
+        "Anthropic: Claude Sonnet 4.6": "anthropic/claude-sonnet-4-6",
+        "Anthropic: Claude Opus 4.6": "anthropic/claude-opus-4-6",
+        "Anthropic: Claude Sonnet 4.5 (20250929)": "anthropic/claude-sonnet-4-5-20250929",
     },
     "omni": {
         "default": "omniparser+openai/gpt-4o",
         "OMNI: OpenAI GPT-4o": "omniparser+openai/gpt-4o",
         "OMNI: OpenAI GPT-4o mini": "omniparser+openai/gpt-4o-mini",
-        "OMNI: Claude 3.7 Sonnet (20250219)": "omniparser+anthropic/claude-3-7-sonnet-20250219",
+        "OMNI: Claude Sonnet 4.6": "omniparser+anthropic/claude-sonnet-4-6",
     },
     "uitars": {
         "default": "huggingface-local/ByteDance-Seed/UI-TARS-1.5-7B" if is_mac else "ui-tars",


### PR DESCRIPTION
## Summary

This PR applies **5** optimization(s) identified by [Claude Optimize](https://github.com/saharmor/claude-optimize), an automated tool that scans your codebase for Claude API and agentic SDK usage patterns and suggests improvements to reduce cost, latency, and improve reliability.

## Optimizations applied

### Add tool_choice: any to force tool call in predict_click
`libs/python/agent/agent/loops/anthropic.py`

When you know the model MUST respond with a tool call (as in predict_click, which only cares about click coordinates from the computer tool), set tool_choice to {"type": "any"}. This forces Claude to always return a tool_use response block rather than potentially responding with text. Benefits: (1) Eliminates wasted output tokens from explanatory text before the tool call, (2) Prevents silent failures where Claude responds with text and the method returns None, (3) Reduces latency since the model doesn't deliberate about whether to use a tool. Note: tool_choice "any" or "tool" cannot be used when thinking is enabled, but predict_click is a focused single-shot call where thinking is not configured.

Expected impact: **Medium** latency reduction, **High** reliability improvement

[Read more in the docs](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/implement-tool-use)

### Restructure predict_click prompt with XML tags, system role, and concise instructions
`libs/python/agent/agent/loops/anthropic.py`

Claude performs significantly better when prompts use XML tags to delineate sections, when behavioral instructions are in a system message (role assignment), and when instructions are concise rather than repetitive. The current prompt has 7 numbered guidelines that all say the same thing ('act autonomously'), wasting ~150 input tokens per call. Restructuring this with: (1) a system message for the role and behavioral constraints, (2) XML-tagged sections for clarity, and (3) a concise task instruction in the user message will improve both reliability and token efficiency. Since this is a click-only prediction (max_tokens=100), the response contract should also be explicit.

Expected impact: **Medium** reliability improvement

[Read more in the docs](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/use-xml-tags)

### Upgrade Gradio UI model defaults to Claude 4.6
`libs/python/agent/agent/ui/gradio/app.py`

The Gradio UI presents users with outdated Claude models as their options and default. Claude Sonnet 4.6 and Opus 4.6 are the latest models with significantly improved capabilities: 1M token context window (vs 200K), adaptive thinking, and better instruction following. Sonnet 4.6 is the same price as all prior Sonnet 4.x models, and Opus 4.6 is 3x cheaper than Opus 4.0 ($5/$25 vs $15/$75 per MTok). The default should be updated to Sonnet 4.6, and the model list should include the latest versions. Note: the computer-use beta flag will be correctly auto-detected by the existing MODEL_TOOL_MAPPING since it already has a pattern for 'claude-sonnet-4-6'.

Expected impact: **Medium** latency reduction, **Medium** reliability improvement

[Read more in the docs](https://docs.anthropic.com/en/docs/about-claude/models)

### Add cache_control to the last tool definition so tools + messages are all cached
`libs/python/agent/agent/loops/anthropic.py`

Anthropic's prompt caching uses prefix matching in the order: tools → system → messages. By only adding cache_control to messages and never to tool definitions, the computer-use tool schemas (which can be 1,000+ tokens and are identical every turn) are never cached. Adding a cache_control marker to the last tool in the tools array caches the entire tools prefix, and combined with message-level markers, enables full prefix caching across the conversation. Use 1 of the 4 available breakpoints on the last tool, leaving 3 for messages.

Expected impact: **High** cost reduction, **Medium** latency reduction

[Read more in the docs](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching)

### Default use_prompt_caching to True for Anthropic models
`libs/python/agent/agent/agent.py`

Prompt caching is a pure win for multi-turn conversations with Claude models: after a one-time 25% write premium on the first request, every subsequent turn reads the cached prefix at 90% lower cost. Computer-use sessions are the ideal use case — long conversations with large, unchanging tool definitions and growing message history. Defaulting to True ensures all users get this benefit automatically. The feature is safe to enable by default since it has no behavioral side effects — it only affects pricing and latency.

Expected impact: **High** cost reduction, **Medium** latency reduction

[Read more in the docs](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching)

---
*Generated by [Claude Optimize](https://github.com/saharmor/claude-optimize). Claude Optimize is an open-source tool that analyzes how your project uses the Claude API and Anthropic's agentic SDKs, identifies optimization opportunities (prompt caching, batching, model selection, and more), and can automatically apply the recommended changes.*