### PR TITLE
Claude Optimize: Upgrade Gradio UI model options to Claude 4.6, +2 more

### DIFF
--- a/libs/python/agent/agent/loops/anthropic.py
+++ b/libs/python/agent/agent/loops/anthropic.py
@@ -1792,6 +1792,9 @@ class AnthropicHostedToolsConfig(AsyncAgentConfig):
             completion_messages = _combine_completion_messages(completion_messages)
             # Then add cache control, anthropic requires explicit "cache_control" dicts
             completion_messages = _add_cache_control(completion_messages)
+            # Cache tool definitions — they are identical every turn
+            if anthropic_tools:
+                anthropic_tools[-1]["cache_control"] = {"type": "ephemeral"}
 
         # Prepare API call kwargs
         api_kwargs = {

--- a/libs/python/agent/agent/ui/gradio/app.py
+++ b/libs/python/agent/agent/ui/gradio/app.py
@@ -115,16 +115,15 @@ MODEL_MAPPINGS = {
         "OpenAI: Computer-Use Preview": "openai/computer-use-preview",
     },
     "anthropic": {
-        "default": "anthropic/claude-3-7-sonnet-20250219",
-        "Anthropic: Claude 4 Opus (20250514)": "anthropic/claude-opus-4-20250514",
-        "Anthropic: Claude 4 Sonnet (20250514)": "anthropic/claude-sonnet-4-20250514",
-        "Anthropic: Claude 3.7 Sonnet (20250219)": "anthropic/claude-3-7-sonnet-20250219",
+        "default": "anthropic/claude-sonnet-4-6",
+        "Anthropic: Claude Opus 4.6": "anthropic/claude-opus-4-6",
+        "Anthropic: Claude Sonnet 4.6": "anthropic/claude-sonnet-4-6",
     },
     "omni": {
         "default": "omniparser+openai/gpt-4o",
         "OMNI: OpenAI GPT-4o": "omniparser+openai/gpt-4o",
         "OMNI: OpenAI GPT-4o mini": "omniparser+openai/gpt-4o-mini",
-        "OMNI: Claude 3.7 Sonnet (20250219)": "omniparser+anthropic/claude-3-7-sonnet-20250219",
+        "OMNI: Claude Sonnet 4.6": "omniparser+anthropic/claude-sonnet-4-6",
     },
     "uitars": {
         "default": "huggingface-local/ByteDance-Seed/UI-TARS-1.5-7B" if is_mac else "ui-tars",

--- a/libs/python/cua-cli/cua_cli/commands/do.py
+++ b/libs/python/cua-cli/cua_cli/commands/do.py
@@ -800,9 +800,7 @@ def _cmd_snapshot(args: argparse.Namespace) -> int:
                 "1. Write a 1-2 sentence summary of what is currently on screen.\n"
                 "2. List every interactive element visible (buttons, links, inputs, "
                 "menus, checkboxes, dropdowns, etc.) with its center coordinates "
-                "in image pixels (origin = top-left). Be precise.\n\n"
-                "Respond in this exact JSON format:\n"
-                '{"summary": "...", "elements": [{"name": "...", "type": "...", "x": N, "y": N}, ...]}\n'
+                "in image pixels (origin = top-left). Be precise."
             )
             if extra:
                 prompt += f"\nAdditional instructions: {extra}"
@@ -827,28 +825,44 @@ def _cmd_snapshot(args: argparse.Namespace) -> int:
                         ],
                     }
                 ],
+                output_format={
+                    "type": "json",
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "summary": {"type": "string", "description": "1-2 sentence summary of what is on screen"},
+                            "elements": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {"type": "string"},
+                                        "type": {"type": "string"},
+                                        "x": {"type": "integer"},
+                                        "y": {"type": "integer"}
+                                    },
+                                    "required": ["name", "type", "x", "y"]
+                                }
+                            }
+                        },
+                        "required": ["summary", "elements"]
+                    }
+                },
             )
 
-            raw = response.content[0].text.strip()
-            # Try to parse JSON; fall back to raw text
-            try:
-                parsed = json.loads(raw)
-                summary = parsed.get("summary", "")
-                elements = parsed.get("elements", [])
-                print(f"✅ snapshot — {save_path}")
+            parsed = json.loads(response.content[0].text)
+            summary = parsed["summary"]
+            elements = parsed["elements"]
+            print(f"✅ snapshot — {save_path}")
+            print()
+            print(summary)
+            if elements:
                 print()
-                print(summary)
-                if elements:
-                    print()
-                    print("Interactive elements:")
-                    for el in elements:
-                        print(
-                            f"  • {el.get('name', '?')} [{el.get('type', '?')}]  ({el.get('x', '?')}, {el.get('y', '?')})"
-                        )
-            except json.JSONDecodeError:
-                print(f"✅ snapshot — {save_path}")
-                print()
-                print(raw)
+                print("Interactive elements:")
+                for el in elements:
+                    print(
+                        f"  • {el['name']} [{el['type']}]  ({el['x']}, {el['y']})"
+                    )
 
         except ImportError:
             await _print_context(state["provider"], state.get("name", ""), state)


### PR DESCRIPTION
## Summary

This PR applies **3** optimization(s) identified by [Claude Optimize](https://github.com/saharmor/claude-optimize), an automated tool that scans your codebase for Claude API and agentic SDK usage patterns and suggests improvements to reduce cost, latency, and improve reliability.

## Optimizations applied

### Upgrade Gradio UI model options to Claude 4.6
`libs/python/agent/agent/ui/gradio/app.py`

The Gradio UI defaults to claude-3-7-sonnet and offers claude-opus-4-20250514 and claude-sonnet-4-20250514, all of which have newer replacements. Claude Sonnet 4.6 and Opus 4.6 offer improved instruction following, 1M context windows, and better computer-use performance at the same price (Sonnet) or 3x cheaper (Opus 4.0 → 4.6: $15/$75 → $5/$25). Since this is the user-facing model selector, updating it ensures users get the best available models by default.

Expected impact: **Medium** cost reduction, **Medium** latency reduction, **Medium** reliability improvement

[Read more in the docs](https://docs.anthropic.com/en/docs/about-claude/models)

### Use structured outputs to guarantee valid JSON from Claude
`libs/python/cua-cli/cua_cli/commands/do.py`

Claude's structured outputs feature (via the `output_format` parameter on Haiku 4.5) guarantees the response conforms to a JSON schema. This eliminates the need for prompt-based JSON formatting instructions, the try/except fallback around json.loads(), and any risk of malformed output. The API will always return valid JSON matching your schema, so the fallback path that prints raw unstructured text will never be needed. This also slightly reduces input tokens by removing the format instructions from the prompt.

Expected impact: **High** reliability improvement

[Read more in the docs](https://docs.anthropic.com/en/docs/build-with-claude/structured-outputs)

### Add cache_control to the last tool in the tools array
`libs/python/agent/agent/loops/anthropic.py`

Anthropic's prompt caching uses prefix matching in the order: tools → system → messages. By placing a cache_control breakpoint on the last tool in the tools array, the entire tool definitions prefix is cached. In a computer-use agent loop, the tool definitions (computer tool + any function tools) are identical on every turn, so after the first request they would be read from cache at 90% lower cost. This is especially impactful because computer-use sessions are multi-turn by nature — every subsequent step in the agent loop would benefit from cached tool definitions.

Expected impact: **Medium** cost reduction

[Read more in the docs](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching)

---
*Generated by [Claude Optimize](https://github.com/saharmor/claude-optimize). Claude Optimize is an open-source tool that analyzes how your project uses the Claude API and Anthropic's agentic SDKs, identifies optimization opportunities (prompt caching, batching, model selection, and more), and can automatically apply the recommended changes.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cache control attributes for tool definitions when using prompt caching

* **Bug Fixes**
  * Enhanced response parsing for AI snapshot operations with improved structured JSON handling

* **Chores**
  * Updated available Claude model options; replaced version-pinned models with Claude Sonnet 4.6 across provider configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->