### PR TITLE
fix: correct inverted scroll direction mapping in Anthropic agent loop

### DIFF
--- a/libs/python/agent/agent/loops/anthropic.py
+++ b/libs/python/agent/agent/loops/anthropic.py
@@ -482,16 +482,16 @@ def _convert_responses_items_to_completion_messages(
                 scroll_y = action.get("scroll_y", 0)
                 # Determine direction and amount from scroll values
                 if scroll_x > 0:
-                    direction = "left"
+                    direction = "right"
                     amount = scroll_x
                 elif scroll_x < 0:
-                    direction = "right"
+                    direction = "left"
                     amount = -scroll_x
                 elif scroll_y > 0:
-                    direction = "up"
+                    direction = "down"
                     amount = scroll_y
                 elif scroll_y < 0:
-                    direction = "down"
+                    direction = "up"
                     amount = -scroll_y
                 else:
                     direction = "down"


### PR DESCRIPTION
## Summary

- Fix inverted scroll direction mapping in `_convert_responses_items_to_completion_messages` (`libs/python/agent/agent/loops/anthropic.py`)
- All 4 scroll directions were mapped to their opposite: `scroll_x > 0` → "left" (should be "right"), `scroll_x < 0` → "right" (should be "left"), `scroll_y > 0` → "up" (should be "down"), `scroll_y < 0` → "down" (should be "up")
- The reverse conversion in `_convert_completion_to_responses_items` was already correct, making the two functions inconsistent — a round-trip conversion would invert the scroll direction

## Details

In `_convert_completion_to_responses_items`, the mapping is:
- `"right"` → `scroll_x = +amount`
- `"left"` → `scroll_x = -amount`
- `"down"` → `scroll_y = +amount`
- `"up"` → `scroll_y = -amount`

But `_convert_responses_items_to_completion_messages` had the inverse:
- `scroll_x > 0` → `"left"` (should be `"right"`)
- `scroll_x < 0` → `"right"` (should be `"left"`)
- `scroll_y > 0` → `"up"` (should be `"down"`)
- `scroll_y < 0` → `"down"` (should be `"up"`)

This fix aligns the forward conversion with the reverse, so round-trip consistency is maintained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed scroll direction handling where directional mappings were inverted, ensuring scrolling in all directions now works correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->