### PR TITLE
Add periodic hourly GitHub Actions workflow for Linux cloud VM SDK test

### DIFF
--- a/.github/workflows/periodic-test-linux-cloud-vm.yml
+++ b/.github/workflows/periodic-test-linux-cloud-vm.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -23,6 +26,6 @@ jobs:
         run: pip install cua pytest pytest-asyncio
 
       - name: Run test
-        run: python -m pytest ./examples/sandboxes/test_linux_cloud_vm.py
+        run: python -m pytest examples/sandboxes/test_linux_cloud_vm.py
         env:
           CUA_API_KEY: ${{ secrets.PERIODIC_TEST_CUA_API_KEY }}

--- a/.github/workflows/periodic-test-linux-cloud-vm.yml
+++ b/.github/workflows/periodic-test-linux-cloud-vm.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "17 * * * *"
   workflow_dispatch:
+  pull_request:
+    paths:
+      - examples/sandboxes/test_linux_cloud_vm.py
 
 jobs:
   test:
@@ -17,30 +20,11 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install cua-sandbox pytest pytest-asyncio
+        run: pip install cua pytest pytest-asyncio
 
-      - name: Write test file
-        run: |
-          cat > test_linux_cloud_vm.py << 'PYEOF'
-          import os
-          import pytest
-          from cua_sandbox import Image, Sandbox
 
-          pytestmark = pytest.mark.asyncio
-
-          async def test_linux_cloud_vm():
-              async with Sandbox.ephemeral(
-                  Image.linux("ubuntu", "24.04", kind="vm"),
-              ) as sb:
-                  result = await sb.shell.run("uname -s")
-                  assert result.success
-                  assert "Linux" in result.stdout
-
-                  screenshot = await sb.screenshot()
-                  assert screenshot[:4] == b"\x89PNG"
-          PYEOF
 
       - name: Run test
-        run: python -m pytest test_linux_cloud_vm.py -v --tb=short
+        run: python -m pytest examples/sandboxes/test_linux_cloud_vm.py
         env:
           CUA_API_KEY: ${{ secrets.CUA_API_KEY }}

--- a/.github/workflows/periodic-test-linux-cloud-vm.yml
+++ b/.github/workflows/periodic-test-linux-cloud-vm.yml
@@ -1,0 +1,46 @@
+name: "Periodic: Test Linux Cloud VM"
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Test Linux Cloud VM
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install cua-sandbox pytest pytest-asyncio
+
+      - name: Write test file
+        run: |
+          cat > test_linux_cloud_vm.py << 'PYEOF'
+          import os
+          import pytest
+          from cua_sandbox import Image, Sandbox
+
+          pytestmark = pytest.mark.asyncio
+
+          async def test_linux_cloud_vm():
+              async with Sandbox.ephemeral(
+                  Image.linux("ubuntu", "24.04", kind="vm"),
+              ) as sb:
+                  result = await sb.shell.run("uname -s")
+                  assert result.success
+                  assert "Linux" in result.stdout
+
+                  screenshot = await sb.screenshot()
+                  assert screenshot[:4] == b"\x89PNG"
+          PYEOF
+
+      - name: Run test
+        run: python -m pytest test_linux_cloud_vm.py -v --tb=short
+        env:
+          CUA_API_KEY: ${{ secrets.CUA_API_KEY }}

--- a/.github/workflows/periodic-test-linux-cloud-vm.yml
+++ b/.github/workflows/periodic-test-linux-cloud-vm.yml
@@ -29,3 +29,23 @@ jobs:
         run: python -m pytest examples/sandboxes/test_linux_cloud_vm.py
         env:
           CUA_API_KEY: ${{ secrets.PERIODIC_TEST_CUA_API_KEY }}
+
+      - name: Alert Alertmanager on failure
+        if: failure()
+        run: |
+          curl -s -X POST https://am.cua.ai/api/v2/alerts \
+            -H 'Content-Type: application/json' \
+            -d '[{
+              "labels": {
+                "alertname": "PeriodicTestLinuxCloudVMFailed",
+                "severity": "critical",
+                "service": "cua-sdk",
+                "job": "periodic-test-linux-cloud-vm"
+              },
+              "annotations": {
+                "summary": "Periodic Linux Cloud VM test failed",
+                "description": "GitHub Actions workflow \"Periodic: Test Linux Cloud VM\" failed. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                "dashboard": "https://github.com/${{ github.repository }}/actions/workflows/periodic-test-linux-cloud-vm.yml"
+              },
+              "generatorURL": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }]'

--- a/.github/workflows/periodic-test-linux-cloud-vm.yml
+++ b/.github/workflows/periodic-test-linux-cloud-vm.yml
@@ -2,7 +2,7 @@ name: "Periodic: Test Linux Cloud VM"
 
 on:
   schedule:
-    - cron: "17 * * * *"
+    - cron: "7/15 * * * *"
   workflow_dispatch:
   pull_request:
     paths:

--- a/.github/workflows/periodic-test-linux-cloud-vm.yml
+++ b/.github/workflows/periodic-test-linux-cloud-vm.yml
@@ -26,7 +26,7 @@ jobs:
         run: pip install cua pytest pytest-asyncio
 
       - name: Run test
-        run: python -m pytest examples/sandboxes/test_linux_cloud_vm.py
+        run: exit 1
         env:
           CUA_API_KEY: ${{ secrets.PERIODIC_TEST_CUA_API_KEY }}
 

--- a/.github/workflows/periodic-test-linux-cloud-vm.yml
+++ b/.github/workflows/periodic-test-linux-cloud-vm.yml
@@ -25,6 +25,6 @@ jobs:
 
 
       - name: Run test
-        run: python -m pytest examples/sandboxes/test_linux_cloud_vm.py
+        run: python -m pytest examples/sandboxes/test_linux_cloud_vm
         env:
           CUA_API_KEY: ${{ secrets.PERIODIC_TEST_CUA_API_KEY }}

--- a/.github/workflows/periodic-test-linux-cloud-vm.yml
+++ b/.github/workflows/periodic-test-linux-cloud-vm.yml
@@ -22,9 +22,7 @@ jobs:
       - name: Install dependencies
         run: pip install cua pytest pytest-asyncio
 
-
-
       - name: Run test
-        run: python -m pytest examples/sandboxes/test_linux_cloud_vm
+        run: python -m pytest ./examples/sandboxes/test_linux_cloud_vm.py
         env:
           CUA_API_KEY: ${{ secrets.PERIODIC_TEST_CUA_API_KEY }}

--- a/.github/workflows/periodic-test-linux-cloud-vm.yml
+++ b/.github/workflows/periodic-test-linux-cloud-vm.yml
@@ -26,7 +26,7 @@ jobs:
         run: pip install cua pytest pytest-asyncio
 
       - name: Run test
-        run: exit 1
+        run: python -m pytest examples/sandboxes/test_linux_cloud_vm.py
         env:
           CUA_API_KEY: ${{ secrets.PERIODIC_TEST_CUA_API_KEY }}
 

--- a/.github/workflows/periodic-test-linux-cloud-vm.yml
+++ b/.github/workflows/periodic-test-linux-cloud-vm.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Run test
         run: python -m pytest examples/sandboxes/test_linux_cloud_vm.py
         env:
-          CUA_API_KEY: ${{ secrets.CUA_API_KEY }}
+          CUA_API_KEY: ${{ secrets.PERIODIC_TEST_CUA_API_KEY }}

--- a/.github/workflows/periodic-test-linux-cloud-vm.yml
+++ b/.github/workflows/periodic-test-linux-cloud-vm.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 

--- a/examples/sandboxes/test_linux_cloud_vm.py
+++ b/examples/sandboxes/test_linux_cloud_vm.py
@@ -44,7 +44,6 @@ async def test_linux_cloud_vm():
 async def main():
     async with Sandbox.ephemeral(
         Image.linux("ubuntu", "24.04", kind="vm"),
-        name="example-linux-cloud-vm",
     ) as sb:
         result = await sb.shell.run("uname -s")
         print(f"uname: {result.stdout.strip()}")

--- a/examples/sandboxes/test_linux_cloud_vm.py
+++ b/examples/sandboxes/test_linux_cloud_vm.py
@@ -32,7 +32,6 @@ def _has_cua_api_key() -> bool:
 async def test_linux_cloud_vm():
     async with Sandbox.ephemeral(
         Image.linux("ubuntu", "24.04", kind="vm"),
-        name="example-linux-cloud-vm",
     ) as sb:
         result = await sb.shell.run("uname -s")
         assert result.success


### PR DESCRIPTION
Adds a scheduled CI workflow to validate the `cua-sandbox` SDK's Linux cloud VM functionality on an ongoing basis, catching regressions in the published PyPI package.

## Changes
- New workflow (`.github/workflows/`) runs hourly (`:17`) and on `workflow_dispatch`
- Installs latest `cua-sandbox` from PyPI; runs sandbox creation, command execution, and screenshot tests against a live Linux cloud VM
- Requires `CUA_API_KEY` repository secret
- Streamlined sandbox initialization in the underlying test