### PR TITLE
Adjust periodic Linux Cloud VM test schedule

### DIFF
--- a/.github/workflows/periodic-test-linux-cloud-vm.yml
+++ b/.github/workflows/periodic-test-linux-cloud-vm.yml
@@ -2,7 +2,7 @@ name: "Periodic: Test Linux Cloud VM"
 
 on:
   schedule:
-    - cron: "17 * * * *"
+    - cron: "*/15 * * * *"
   workflow_dispatch:
   pull_request:
     paths:

--- a/.github/workflows/periodic-test-linux-cloud-vm.yml
+++ b/.github/workflows/periodic-test-linux-cloud-vm.yml
@@ -2,7 +2,7 @@ name: "Periodic: Test Linux Cloud VM"
 
 on:
   schedule:
-    - cron: "*/15 * * * *"
+    - cron: "7/15 * * * *"
   workflow_dispatch:
   pull_request:
     paths:


### PR DESCRIPTION
## Summary
Updated the cron schedule for the periodic Linux Cloud VM test workflow to run more frequently and at a different interval.

## Changes
- Modified the cron expression from `"17 * * * *"` to `"7/15 * * * *"`
  - Previous schedule: ran once per hour at the 17-minute mark
  - New schedule: runs every 15 minutes starting at minute 7 (7, 22, 37, 52 of each hour)

This change increases the frequency of the periodic test from once per hour to four times per hour, allowing for more frequent validation of the Linux Cloud VM test suite.

https://claude.ai/code/session_01YZVUXKqXAN2EFmS2E96MXy