### PR TITLE
Improve sandbox cleanup and connection error handling

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -313,9 +313,7 @@ class Sandbox:
     async def destroy(self) -> None:
         """Disconnect and permanently delete the sandbox (VM/container)."""
         if self._has_snapshots:
-            import logging
-
-            logging.getLogger(__name__).warning(
+            logger.warning(
                 "Destroying sandbox %s which has snapshots — "
                 "forks referencing those snapshots will break. "
                 "Use Sandbox.ephemeral() which auto-stops instead of deleting "
@@ -324,15 +322,26 @@ class Sandbox:
             )
         if self.telemetry_enabled and _TELEMETRY_AVAILABLE and is_telemetry_enabled():
             record_event("sandbox_destroy", {"name": self.name, "ephemeral": self._ephemeral})
-        await self._transport.disconnect()
+        # Run each cleanup step independently so a failure in one
+        # (e.g. disconnect timeout) doesn't prevent the VM from being deleted.
+        try:
+            await self._transport.disconnect()
+        except Exception:
+            logger.warning("Failed to disconnect transport for sandbox %r", self.name)
         if isinstance(self._transport, CloudTransport):
-            await self._transport.delete_vm()
+            try:
+                await self._transport.delete_vm()
+            except Exception:
+                logger.warning("Failed to delete cloud VM %r", self.name)
         if self._runtime and self._runtime_info:
             vm_name = self._runtime_info.name or self.name or "cua-sandbox"
-            if self._ephemeral and hasattr(self._runtime, "delete"):
-                await self._runtime.delete(vm_name)
-            else:
-                await self._runtime.stop(vm_name)
+            try:
+                if self._ephemeral and hasattr(self._runtime, "delete"):
+                    await self._runtime.delete(vm_name)
+                else:
+                    await self._runtime.stop(vm_name)
+            except Exception:
+                logger.warning("Failed to stop/delete runtime for sandbox %r", self.name)
 
     async def screenshot(
         self, text: Optional[str] = None, format: str = "png", quality: int = 95

--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -27,6 +27,7 @@ Usage::
 
 from __future__ import annotations
 
+import logging
 import random
 import time
 from contextlib import asynccontextmanager
@@ -74,6 +75,8 @@ from cua_sandbox.transport.websocket import WebSocketTransport
 
 if TYPE_CHECKING:
     from cua_sandbox.runtime.base import Runtime, RuntimeInfo
+
+logger = logging.getLogger(__name__)
 
 _T = TypeVar("_T")
 
@@ -1018,7 +1021,23 @@ class Sandbox:
                 sb = cls(
                     transport, name=name, _ephemeral=ephemeral, _telemetry_enabled=telemetry_enabled
                 )
-                await sb._connect()
+                try:
+                    await sb._connect()
+                except BaseException:
+                    # _connect() calls CloudTransport.connect() which may have
+                    # already created a VM before failing (e.g. timeout while
+                    # polling for "running" status).  Delete the orphan so it
+                    # doesn't leak.
+                    vm_name = transport._name
+                    if vm_name:
+                        try:
+                            await transport.delete_vm()
+                        except Exception:
+                            logger.warning(
+                                "Failed to clean up cloud VM %r after connect failure",
+                                vm_name,
+                            )
+                    raise
                 _record_sandbox_create(
                     sb, image=image, local=False, ephemeral=bool(ephemeral), t_start=_t_start
                 )

--- a/libs/python/cua-sandbox/tests/test_vm_cleanup.py
+++ b/libs/python/cua-sandbox/tests/test_vm_cleanup.py
@@ -1,0 +1,314 @@
+"""Unit tests for VM cleanup on connection failure and destroy() resilience.
+
+These tests mock CloudTransport so they run without a real cloud API.
+They verify that:
+  1. _create() cleans up a provisioned VM when _connect() fails.
+  2. destroy() runs every cleanup step independently — a failure in one
+     does not prevent the others from executing.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from cua_sandbox.image import Image
+from cua_sandbox.sandbox import Sandbox
+from cua_sandbox.transport.cloud import CloudTransport
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_cloud_transport(*, name: str = "test-vm") -> CloudTransport:
+    """Return a CloudTransport with internal state set as if _create_vm() succeeded."""
+    t = CloudTransport.__new__(CloudTransport)
+    t._name = name
+    t._api_key_override = "sk-fake"
+    t._base_url = "https://api.example.com"
+    t._image = None
+    t._cpu = None
+    t._memory_mb = None
+    t._disk_gb = None
+    t._region = "us-east-1"
+    t._inner = None
+    t._api_client = None
+    return t
+
+
+def _make_sandbox(transport: CloudTransport, **kwargs) -> Sandbox:
+    """Return a Sandbox wrapping *transport* without calling _connect()."""
+    return Sandbox(
+        transport,
+        name=transport._name,
+        _ephemeral=kwargs.get("ephemeral", True),
+        _telemetry_enabled=False,
+    )
+
+
+# ===================================================================
+# 1. _create() cleans up on _connect() failure
+# ===================================================================
+
+
+class TestCreateCleansUpOnConnectFailure:
+    """Sandbox._create() should delete the cloud VM when _connect() raises."""
+
+    async def test_delete_vm_called_on_timeout(self):
+        """ReadTimeout during _connect() triggers delete_vm()."""
+        transport = _make_cloud_transport(name="orphan-vm")
+        transport.connect = AsyncMock(side_effect=httpx.ReadTimeout("poll timed out"))
+        transport.delete_vm = AsyncMock()
+
+        with patch(
+            "cua_sandbox.sandbox.CloudTransport",
+            return_value=transport,
+        ):
+            with pytest.raises(httpx.ReadTimeout):
+                await Sandbox._create(
+                    image=Image.linux("ubuntu", "24.04"),
+                    api_key="sk-fake",
+                    telemetry_enabled=False,
+                )
+
+        transport.delete_vm.assert_awaited_once()
+
+    async def test_delete_vm_called_on_generic_exception(self):
+        """Any exception during _connect() triggers delete_vm()."""
+        transport = _make_cloud_transport(name="orphan-vm")
+        transport.connect = AsyncMock(side_effect=RuntimeError("unexpected"))
+        transport.delete_vm = AsyncMock()
+
+        with patch(
+            "cua_sandbox.sandbox.CloudTransport",
+            return_value=transport,
+        ):
+            with pytest.raises(RuntimeError, match="unexpected"):
+                await Sandbox._create(
+                    image=Image.linux("ubuntu", "24.04"),
+                    api_key="sk-fake",
+                    telemetry_enabled=False,
+                )
+
+        transport.delete_vm.assert_awaited_once()
+
+    async def test_original_exception_propagates_even_if_delete_fails(self):
+        """The original connect error is re-raised even when delete_vm also fails."""
+        transport = _make_cloud_transport(name="orphan-vm")
+        transport.connect = AsyncMock(side_effect=TimeoutError("poll timeout"))
+        transport.delete_vm = AsyncMock(side_effect=httpx.ConnectError("api down"))
+
+        with patch(
+            "cua_sandbox.sandbox.CloudTransport",
+            return_value=transport,
+        ):
+            with pytest.raises(TimeoutError, match="poll timeout"):
+                await Sandbox._create(
+                    image=Image.linux("ubuntu", "24.04"),
+                    api_key="sk-fake",
+                    telemetry_enabled=False,
+                )
+
+        transport.delete_vm.assert_awaited_once()
+
+    async def test_no_cleanup_when_vm_not_yet_created(self):
+        """If connect() fails before _create_vm (no _name), skip delete_vm."""
+        transport = _make_cloud_transport()
+        # Simulate: connect() fails before _create_vm sets _name
+        transport._name = None
+        transport.connect = AsyncMock(side_effect=ValueError("no api key"))
+        transport.delete_vm = AsyncMock()
+
+        with patch(
+            "cua_sandbox.sandbox.CloudTransport",
+            return_value=transport,
+        ):
+            with pytest.raises(ValueError, match="no api key"):
+                await Sandbox._create(
+                    image=Image.linux("ubuntu", "24.04"),
+                    api_key="sk-fake",
+                    telemetry_enabled=False,
+                )
+
+        transport.delete_vm.assert_not_awaited()
+
+    async def test_keyboard_interrupt_still_cleans_up(self):
+        """BaseException subclasses (KeyboardInterrupt) also trigger cleanup."""
+        transport = _make_cloud_transport(name="interrupted-vm")
+        transport.connect = AsyncMock(side_effect=KeyboardInterrupt)
+        transport.delete_vm = AsyncMock()
+
+        with patch(
+            "cua_sandbox.sandbox.CloudTransport",
+            return_value=transport,
+        ):
+            with pytest.raises(KeyboardInterrupt):
+                await Sandbox._create(
+                    image=Image.linux("ubuntu", "24.04"),
+                    api_key="sk-fake",
+                    telemetry_enabled=False,
+                )
+
+        transport.delete_vm.assert_awaited_once()
+
+
+# ===================================================================
+# 2. destroy() is resilient to individual step failures
+# ===================================================================
+
+
+class TestDestroyResilience:
+    """Each cleanup step in destroy() should run independently."""
+
+    async def test_delete_vm_runs_even_if_disconnect_fails(self):
+        """A failing disconnect() must not prevent delete_vm()."""
+        transport = _make_cloud_transport(name="leaky-vm")
+        transport.disconnect = AsyncMock(side_effect=OSError("connection reset"))
+        transport.delete_vm = AsyncMock()
+
+        sb = _make_sandbox(transport)
+        await sb.destroy()
+
+        transport.disconnect.assert_awaited_once()
+        transport.delete_vm.assert_awaited_once()
+
+    async def test_runtime_stop_runs_even_if_delete_vm_fails(self):
+        """A failing delete_vm() must not prevent runtime cleanup."""
+        transport = _make_cloud_transport(name="leaky-vm")
+        transport.disconnect = AsyncMock()
+        transport.delete_vm = AsyncMock(side_effect=httpx.ConnectError("api down"))
+
+        runtime = AsyncMock()
+        runtime_info = MagicMock()
+        runtime_info.name = "leaky-vm"
+
+        sb = _make_sandbox(transport)
+        sb._runtime = runtime
+        sb._runtime_info = runtime_info
+
+        await sb.destroy()
+
+        transport.delete_vm.assert_awaited_once()
+        runtime.delete.assert_awaited_once_with("leaky-vm")
+
+    async def test_destroy_succeeds_when_all_steps_fail(self):
+        """destroy() must not raise even if every cleanup step fails."""
+        transport = _make_cloud_transport(name="total-fail")
+        transport.disconnect = AsyncMock(side_effect=OSError("disconnect fail"))
+        transport.delete_vm = AsyncMock(side_effect=httpx.ReadTimeout("delete fail"))
+
+        runtime = AsyncMock()
+        runtime.delete = AsyncMock(side_effect=RuntimeError("runtime fail"))
+        runtime_info = MagicMock()
+        runtime_info.name = "total-fail"
+
+        sb = _make_sandbox(transport)
+        sb._runtime = runtime
+        sb._runtime_info = runtime_info
+
+        # Should not raise
+        await sb.destroy()
+
+        transport.disconnect.assert_awaited_once()
+        transport.delete_vm.assert_awaited_once()
+        runtime.delete.assert_awaited_once()
+
+    async def test_destroy_happy_path(self):
+        """All steps succeed — basic smoke test."""
+        transport = _make_cloud_transport(name="good-vm")
+        transport.disconnect = AsyncMock()
+        transport.delete_vm = AsyncMock()
+
+        sb = _make_sandbox(transport)
+        await sb.destroy()
+
+        transport.disconnect.assert_awaited_once()
+        transport.delete_vm.assert_awaited_once()
+
+    async def test_non_cloud_transport_skips_delete_vm(self):
+        """Non-CloudTransport sandboxes should not call delete_vm."""
+        transport = AsyncMock()  # generic mock, not a CloudTransport instance
+        sb = Sandbox(transport, name="local-vm", _ephemeral=True, _telemetry_enabled=False)
+
+        await sb.destroy()
+
+        transport.disconnect.assert_awaited_once()
+        # delete_vm should not be called since transport is not CloudTransport
+        assert not hasattr(transport, "delete_vm") or not transport.delete_vm.called
+
+
+# ===================================================================
+# 3. ephemeral() integration — cleanup through the context manager
+# ===================================================================
+
+
+class TestEphemeralCleanup:
+    """Sandbox.ephemeral() should destroy the VM on normal and error exits."""
+
+    async def test_ephemeral_destroys_on_normal_exit(self):
+        """VM is destroyed when the async-with block exits normally."""
+        transport = _make_cloud_transport(name="eph-ok")
+        transport.connect = AsyncMock()
+        transport.disconnect = AsyncMock()
+        transport.delete_vm = AsyncMock()
+
+        with patch.object(
+            CloudTransport, "__init__", lambda self, **kw: None,
+        ), patch.object(
+            CloudTransport, "__new__", lambda cls, **kw: transport,
+        ):
+            async with Sandbox.ephemeral(
+                Image.linux("ubuntu", "24.04"),
+                api_key="sk-fake",
+                telemetry_enabled=False,
+            ) as sb:
+                assert sb.name == "eph-ok"
+
+        transport.delete_vm.assert_awaited_once()
+
+    async def test_ephemeral_destroys_on_test_failure(self):
+        """VM is destroyed even when the body raises an assertion error."""
+        transport = _make_cloud_transport(name="eph-fail")
+        transport.connect = AsyncMock()
+        transport.disconnect = AsyncMock()
+        transport.delete_vm = AsyncMock()
+
+        with patch.object(
+            CloudTransport, "__init__", lambda self, **kw: None,
+        ), patch.object(
+            CloudTransport, "__new__", lambda cls, **kw: transport,
+        ):
+            with pytest.raises(AssertionError):
+                async with Sandbox.ephemeral(
+                    Image.linux("ubuntu", "24.04"),
+                    api_key="sk-fake",
+                    telemetry_enabled=False,
+                ) as sb:
+                    raise AssertionError("test failed")
+
+        transport.delete_vm.assert_awaited_once()
+
+    async def test_ephemeral_cleans_up_when_create_connect_fails(self):
+        """If _create raises after VM provisioning, the VM is still cleaned up."""
+        transport = _make_cloud_transport(name="eph-connect-fail")
+        transport.connect = AsyncMock(side_effect=httpx.ReadTimeout("poll timed out"))
+        transport.delete_vm = AsyncMock()
+
+        with patch.object(
+            CloudTransport, "__init__", lambda self, **kw: None,
+        ), patch.object(
+            CloudTransport, "__new__", lambda cls, **kw: transport,
+        ):
+            with pytest.raises(httpx.ReadTimeout):
+                async with Sandbox.ephemeral(
+                    Image.linux("ubuntu", "24.04"),
+                    api_key="sk-fake",
+                    telemetry_enabled=False,
+                ) as sb:
+                    pass  # never reached
+
+        transport.delete_vm.assert_awaited_once()

--- a/libs/python/cua-sandbox/tests/test_vm_cleanup.py
+++ b/libs/python/cua-sandbox/tests/test_vm_cleanup.py
@@ -24,6 +24,7 @@ pytestmark = pytest.mark.asyncio
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_cloud_transport(*, name: str = "test-vm") -> CloudTransport:
     """Return a CloudTransport with internal state set as if _create_vm() succeeded."""
     t = CloudTransport.__new__(CloudTransport)
@@ -256,10 +257,17 @@ class TestEphemeralCleanup:
         transport.disconnect = AsyncMock()
         transport.delete_vm = AsyncMock()
 
-        with patch.object(
-            CloudTransport, "__init__", lambda self, **kw: None,
-        ), patch.object(
-            CloudTransport, "__new__", lambda cls, **kw: transport,
+        with (
+            patch.object(
+                CloudTransport,
+                "__init__",
+                lambda self, **kw: None,
+            ),
+            patch.object(
+                CloudTransport,
+                "__new__",
+                lambda cls, **kw: transport,
+            ),
         ):
             async with Sandbox.ephemeral(
                 Image.linux("ubuntu", "24.04"),
@@ -277,17 +285,24 @@ class TestEphemeralCleanup:
         transport.disconnect = AsyncMock()
         transport.delete_vm = AsyncMock()
 
-        with patch.object(
-            CloudTransport, "__init__", lambda self, **kw: None,
-        ), patch.object(
-            CloudTransport, "__new__", lambda cls, **kw: transport,
+        with (
+            patch.object(
+                CloudTransport,
+                "__init__",
+                lambda self, **kw: None,
+            ),
+            patch.object(
+                CloudTransport,
+                "__new__",
+                lambda cls, **kw: transport,
+            ),
         ):
             with pytest.raises(AssertionError):
                 async with Sandbox.ephemeral(
                     Image.linux("ubuntu", "24.04"),
                     api_key="sk-fake",
                     telemetry_enabled=False,
-                ) as sb:
+                ) as _sb:
                     raise AssertionError("test failed")
 
         transport.delete_vm.assert_awaited_once()
@@ -298,17 +313,24 @@ class TestEphemeralCleanup:
         transport.connect = AsyncMock(side_effect=httpx.ReadTimeout("poll timed out"))
         transport.delete_vm = AsyncMock()
 
-        with patch.object(
-            CloudTransport, "__init__", lambda self, **kw: None,
-        ), patch.object(
-            CloudTransport, "__new__", lambda cls, **kw: transport,
+        with (
+            patch.object(
+                CloudTransport,
+                "__init__",
+                lambda self, **kw: None,
+            ),
+            patch.object(
+                CloudTransport,
+                "__new__",
+                lambda cls, **kw: transport,
+            ),
         ):
             with pytest.raises(httpx.ReadTimeout):
                 async with Sandbox.ephemeral(
                     Image.linux("ubuntu", "24.04"),
                     api_key="sk-fake",
                     telemetry_enabled=False,
-                ) as sb:
+                ) as _sb:
                     pass  # never reached
 
         transport.delete_vm.assert_awaited_once()


### PR DESCRIPTION
## Summary
This PR improves the robustness of sandbox lifecycle management by adding comprehensive error handling to cleanup operations and connection failures. It ensures that partial failures during sandbox destruction don't prevent complete cleanup, and that VMs created during failed connection attempts are properly deleted.

## Key Changes
- **Centralized logging**: Moved logger initialization to module level for consistent use throughout the file
- **Resilient destroy operation**: Wrapped each cleanup step in the `destroy()` method with independent try-except blocks so that failures in one operation (e.g., transport disconnect timeout) don't prevent subsequent cleanup steps (VM deletion, runtime stop)
- **Connection failure cleanup**: Added error handling in `_create()` to detect and delete orphaned VMs when `_connect()` fails after a VM has already been created by CloudTransport
- **Improved logging**: Added warning logs for all cleanup failures to aid in debugging and monitoring

## Implementation Details
- Each cleanup step in `destroy()` now runs independently with its own exception handler, allowing the method to attempt all cleanup operations even if some fail
- When connection fails during sandbox creation, the code attempts to delete the VM that may have been created before the failure occurred
- All exception handlers log warnings with the sandbox/VM name for traceability
- The connection failure cleanup uses `BaseException` to catch all exceptions including `KeyboardInterrupt`, ensuring cleanup is attempted even for non-standard exceptions

https://claude.ai/code/session_01Pwi6TF6n38aApHB4Pum7gM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox cleanup process to continue cleanup steps independently instead of aborting when individual steps fail, ensuring more complete resource cleanup.
  * Enhanced cloud sandbox creation with automatic cleanup of orphaned VMs when connection failures occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->