### PR TITLE
fix: register YutoriAdapter and default n1 to n1-latest

### DIFF
--- a/libs/python/agent/agent/adapters/yutori_adapter.py
+++ b/libs/python/agent/agent/adapters/yutori_adapter.py
@@ -19,9 +19,11 @@ class YutoriAdapter(CustomLLM):
         self.api_key = api_key or os.environ.get("YUTORI_API_KEY")
 
     def _normalize_model(self, model: str) -> str:
-        """Strip the yutori/ prefix to get the bare model name."""
+        """Strip the yutori/ prefix and default bare 'n1' to 'n1-latest'."""
         if model.startswith("yutori/"):
-            return model[len("yutori/") :]
+            model = model[len("yutori/") :]
+        if model == "n1":
+            return "n1-latest"
         return model
 
     def _resolve_api_key(self, kwargs: dict | None = None) -> str:

--- a/libs/python/agent/agent/agent.py
+++ b/libs/python/agent/agent/agent.py
@@ -33,6 +33,7 @@ from .adapters import (
     HuggingFaceLocalAdapter,
     HumanAdapter,
     MLXVLMAdapter,
+    YutoriAdapter,
 )
 from .callbacks import (
     BudgetManagerCallback,
@@ -364,12 +365,14 @@ class ComputerAgent:
         mlx_adapter = MLXVLMAdapter()
         cua_adapter = CUAAdapter()
         azure_ml_adapter = AzureMLAdapter()
+        yutori_adapter = YutoriAdapter()
         litellm.custom_provider_map = [
             {"provider": "huggingface-local", "custom_handler": hf_adapter},
             {"provider": "human", "custom_handler": human_adapter},
             {"provider": "mlx", "custom_handler": mlx_adapter},
             {"provider": "cua", "custom_handler": cua_adapter},
             {"provider": "azure_ml", "custom_handler": azure_ml_adapter},
+            {"provider": "yutori", "custom_handler": yutori_adapter},
         ]
         litellm.suppress_debug_info = True
 


### PR DESCRIPTION
## Summary
- Register `YutoriAdapter` in litellm's `custom_provider_map` so `model="yutori/n1"` routes correctly instead of throwing "LLM Provider NOT provided"
- Default bare model name `n1` to `n1-latest` in the adapter, since the Yutori API rejects `n1` and requires a versioned name

## Test plan
- [x] Verified `yutori/n1` model connects to Yutori API and returns valid tool_call actions
- [x] Tested end-to-end with CUA cloudv2 sandbox running browser automation tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended model support to include the "n1" model with automatic version resolution for optimal compatibility.
  * Integrated a new provider routing capability within the agent framework, expanding available provider options and enhancing model selection flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->