### PR TITLE
fix: correct Yutori and Cua dashboard links in docs

### DIFF
--- a/docs/content/docs/cua/guide/integrations/yutori.mdx
+++ b/docs/content/docs/cua/guide/integrations/yutori.mdx
@@ -4,7 +4,7 @@ description: Use Yutori's n1 model with Cua cloud sandboxes
 icon: yutori
 ---
 
-Cua supports [Yutori](https://yutori.ai/)'s `n1` model as a computer-use agent. This guide shows how to connect Yutori n1 to a Cua cloud sandbox for an interactive agent loop.
+Cua supports [Yutori](https://yutori.com/)'s `n1` model as a computer-use agent. This guide shows how to connect Yutori n1 to a Cua cloud sandbox for an interactive agent loop.
 
 ## Setup
 
@@ -21,8 +21,8 @@ export CUA_API_KEY=your-cua-api-key
 export YUTORI_API_KEY=your-yutori-api-key
 ```
 
-- **`CUA_API_KEY`** — your Cua cloud API key. Get one from the [Cua dashboard](https://app.cua.ai/).
-- **`YUTORI_API_KEY`** — your Yutori API key. Get one from [Yutori](https://yutori.ai/).
+- **`CUA_API_KEY`** — your Cua cloud API key. Get one from the [Cua dashboard](https://cua.ai/dashboard).
+- **`YUTORI_API_KEY`** — your Yutori API key. Get one from [Yutori](https://yutori.com/).
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Fix `yutori.ai` → `yutori.com` (correct domain)
- Fix `app.cua.ai` → `cua.ai/dashboard` (correct dashboard URL)

## Test plan
- [ ] Verify links on the Yutori integration docs page resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated external links in the Yutori integration documentation to reflect current service URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->