### PR TITLE
Add server-side TTL for ephemeral VMs to prevent orphaned instances

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -1018,6 +1018,10 @@ class Sandbox:
         if image and not runtime and not local:
             # image without runtime and not local → cloud creation
             if not any([ws_url, http_url]):
+                # Ephemeral VMs get a 30-minute server-side TTL as a safety net.
+                # If the SDK process dies without calling destroy(), the kopf
+                # operator will auto-delete the VM after this period.
+                _DEFAULT_EPHEMERAL_TTL = 30 * 60  # 30 minutes
                 transport = CloudTransport(
                     name=name,
                     api_key=api_key,
@@ -1026,6 +1030,7 @@ class Sandbox:
                     memory_mb=memory_mb,
                     disk_gb=disk_gb,
                     region=region,
+                    max_lifetime_seconds=_DEFAULT_EPHEMERAL_TTL if ephemeral else None,
                 )
                 sb = cls(
                     transport, name=name, _ephemeral=ephemeral, _telemetry_enabled=telemetry_enabled

--- a/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
@@ -41,6 +41,7 @@ class CloudTransport(Transport):
         memory_mb: Optional[int] = None,
         disk_gb: Optional[int] = None,
         region: str = "us-east-1",
+        max_lifetime_seconds: Optional[int] = None,
     ):
         self._name = name
         self._api_key_override = api_key
@@ -50,6 +51,7 @@ class CloudTransport(Transport):
         self._memory_mb = memory_mb
         self._disk_gb = disk_gb
         self._region = region
+        self._max_lifetime_seconds = max_lifetime_seconds
         self._inner: Optional[HTTPTransport] = None
         self._api_client: Optional[httpx.AsyncClient] = None
 
@@ -368,6 +370,9 @@ class CloudTransport(Transport):
             body["diskGb"] = self._disk_gb or self._DEFAULT_DISK_GB
         else:
             body["configuration"] = "small"
+        # Set server-side TTL so orphaned VMs are auto-deleted
+        if self._max_lifetime_seconds is not None:
+            body["maxLifetimeSeconds"] = self._max_lifetime_seconds
         resp = await self._api_client.post("/v1/vms", json=body)
         resp.raise_for_status()
         return resp.json()


### PR DESCRIPTION
## Summary
This change adds automatic cleanup for ephemeral VMs by setting a server-side time-to-live (TTL) of 30 minutes. If the SDK process terminates unexpectedly without calling `destroy()`, the kopf operator will automatically delete the VM after this period, preventing resource leaks.

## Key Changes
- Added `_DEFAULT_EPHEMERAL_TTL` constant (30 minutes) in `sandbox.py` with explanatory comments about the safety net mechanism
- Extended `CloudTransport.__init__()` to accept an optional `max_lifetime_seconds` parameter
- Updated the VM creation logic in `sandbox.py` to pass the TTL when creating ephemeral cloud VMs
- Modified `_create_vm()` in `cloud.py` to include `maxLifetimeSeconds` in the API request body when the parameter is set

## Implementation Details
- The TTL is only applied to ephemeral VMs created in the cloud (when `ephemeral=True`)
- Non-ephemeral VMs and local/runtime-based sandboxes are unaffected
- The TTL is passed as `max_lifetime_seconds` through the transport layer and sent to the API as `maxLifetimeSeconds`
- This provides a safety mechanism for orphaned VMs without requiring explicit cleanup in normal operation

https://claude.ai/code/session_01BantzgKCb554fUD1sZLeRA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ephemeral cloud virtual machines now automatically terminate after 30 minutes if not explicitly destroyed, providing a safety mechanism to prevent resource leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->