### PR TITLE
Add server-side TTL support for cloud sandboxes

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -517,6 +517,7 @@ class Sandbox:
         disk_gb: Optional[int] = None,
         region: str = "us-east-1",
         telemetry_enabled: bool = True,
+        ttl_seconds: Optional[int] = 3600,
     ) -> AsyncIterator["Sandbox"]:
         """Create an ephemeral sandbox that is automatically destroyed on exit.
 
@@ -530,6 +531,10 @@ class Sandbox:
             memory_mb: Memory in MB for the cloud sandbox.
             disk_gb: Disk size in GB for the cloud sandbox.
             region: Cloud region (default ``"us-east-1"``).
+            ttl_seconds: Server-side TTL in seconds (default 3600 = 1 hour).
+                The cloud operator auto-deletes the VM after this time even if
+                the client crashes without calling destroy(). Set to None to
+                disable. Only applies to cloud sandboxes.
 
         Example::
 
@@ -549,6 +554,7 @@ class Sandbox:
             disk_gb=disk_gb,
             region=region,
             telemetry_enabled=telemetry_enabled,
+            ttl_seconds=ttl_seconds,
         )
         try:
             yield sb
@@ -962,6 +968,7 @@ class Sandbox:
         disk_gb: Optional[int] = None,
         region: str = "us-east-1",
         telemetry_enabled: bool = True,
+        ttl_seconds: Optional[int] = None,
     ) -> "Sandbox":
         """Internal workhorse — all public factories delegate here."""
         _t_start = time.monotonic()
@@ -1026,6 +1033,7 @@ class Sandbox:
                     memory_mb=memory_mb,
                     disk_gb=disk_gb,
                     region=region,
+                    ttl_seconds=ttl_seconds,
                 )
                 sb = cls(
                     transport, name=name, _ephemeral=ephemeral, _telemetry_enabled=telemetry_enabled

--- a/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
@@ -41,6 +41,7 @@ class CloudTransport(Transport):
         memory_mb: Optional[int] = None,
         disk_gb: Optional[int] = None,
         region: str = "us-east-1",
+        ttl_seconds: Optional[int] = None,
     ):
         self._name = name
         self._api_key_override = api_key
@@ -50,6 +51,7 @@ class CloudTransport(Transport):
         self._memory_mb = memory_mb
         self._disk_gb = disk_gb
         self._region = region
+        self._ttl_seconds = ttl_seconds
         self._inner: Optional[HTTPTransport] = None
         self._api_client: Optional[httpx.AsyncClient] = None
 
@@ -368,6 +370,8 @@ class CloudTransport(Transport):
             body["diskGb"] = self._disk_gb or self._DEFAULT_DISK_GB
         else:
             body["configuration"] = "small"
+        if self._ttl_seconds is not None and self._ttl_seconds > 0:
+            body["ttlSeconds"] = self._ttl_seconds
         resp = await self._api_client.post("/v1/vms", json=body)
         resp.raise_for_status()
         return resp.json()

--- a/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
@@ -343,12 +343,14 @@ class CloudTransport(Transport):
         # Fork path: image came from sb.snapshot() — create VM from snapshot
         snap_source = getattr(self._image, "_snapshot_source", None)
         if snap_source:
-            body = {
+            body: Dict[str, Any] = {
                 "source": "snapshot",
                 "instance": snap_source["instance"],
                 "snapshot": snap_source["snapshot"],
                 "instanceType": snap_source.get("instanceType", "vm"),
             }
+            if self._ttl_seconds is not None and self._ttl_seconds > 0:
+                body["ttlSeconds"] = self._ttl_seconds
             resp = await self._api_client.post("/v1/vms", json=body)
             resp.raise_for_status()
             return resp.json()


### PR DESCRIPTION
## Summary
This PR adds support for server-side time-to-live (TTL) configuration for cloud sandboxes, allowing the cloud operator to automatically delete VMs after a specified duration even if the client crashes without calling `destroy()`.

## Key Changes
- Added `ttl_seconds` parameter to the `ephemeral()` method with a default value of 3600 seconds (1 hour)
- Added `ttl_seconds` parameter to the internal `_create()` method for propagating the setting
- Updated `CloudTransport.__init__()` to accept and store the `ttl_seconds` parameter
- Modified `CloudTransport._create_vm()` to include `ttlSeconds` in the VM creation request payload when the value is set and positive
- Added comprehensive docstring documentation explaining the TTL behavior and that it only applies to cloud sandboxes

## Implementation Details
- The `ttl_seconds` parameter is optional and defaults to 3600 seconds in the public `ephemeral()` API
- The internal `_create()` method accepts `None` as the default to allow flexibility for other factory methods
- The TTL is only sent to the cloud API if `ttl_seconds` is not `None` and greater than 0, allowing users to disable the feature by passing `None`
- This provides a safety mechanism for ephemeral sandboxes to prevent resource leaks in case of client failures

https://claude.ai/code/session_01Svzw1Mw6mDPDYTikgtUkcA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable time-to-live (TTL) in ephemeral cloud sandboxes, enabling automatic server-side VM deletion after a user-specified duration to improve resource management. The default TTL is 3600 seconds; users can customize this duration or disable auto-deletion by setting TTL to None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->