### PR TITLE
Add status page link to footer

### DIFF
--- a/docs/src/components/footer.tsx
+++ b/docs/src/components/footer.tsx
@@ -127,6 +127,9 @@ export function Footer() {
               <a href="https://cua.ai/blog" className={linkClass}>
                 Blog
               </a>
+              <a href="https://status.cua.ai" className={linkClass}>
+                Status
+              </a>
             </div>
 
             {/* Company Column */}


### PR DESCRIPTION
## Summary
Added a link to the status page in the footer navigation.

## Changes
- Added a new "Status" link pointing to `https://status.cua.ai` in the footer's link section
- The link uses the existing `linkClass` styling to maintain consistency with other footer links

## Details
The status page link is placed alongside the existing "Blog" link in the footer, providing users with easy access to service status information.

https://claude.ai/code/session_011pUEffFYmbg3hLTcPsbvwB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Status" link to the footer's Resources section, enabling direct access to real-time system status information and monitoring. Users can now view current service health, uptime metrics, and performance indicators. This enhancement increases platform transparency and helps users stay informed about service availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->