### PR TITLE
Reduce logging verbosity from httpx/httpcore libraries

### DIFF
--- a/libs/python/cua-cli/cua_cli/commands/mcp.py
+++ b/libs/python/cua-cli/cua_cli/commands/mcp.py
@@ -23,6 +23,10 @@ logging.basicConfig(
 )
 logger = logging.getLogger("cua-mcp")
 
+# Suppress verbose HTTP client debug output from httpx/httpcore
+for _name in ("httpx", "httpcore"):
+    logging.getLogger(_name).setLevel(logging.WARNING)
+
 
 class Permission(Enum):
     """MCP permission types."""

--- a/libs/python/mcp-server/mcp_server/server.py
+++ b/libs/python/mcp-server/mcp_server/server.py
@@ -13,11 +13,15 @@ import anyio
 
 # Configure logging to output to stderr for debug visibility
 logging.basicConfig(
-    level=logging.DEBUG,  # Changed to DEBUG
+    level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     stream=sys.stderr,
 )
 logger = logging.getLogger("mcp-server")
+
+# Suppress verbose HTTP client debug output from httpx/httpcore
+for _name in ("httpx", "httpcore"):
+    logging.getLogger(_name).setLevel(logging.WARNING)
 
 # More visible startup message
 logger.debug("MCP Server module loading...")


### PR DESCRIPTION
## Summary
This PR reduces excessive debug logging output from the httpx and httpcore HTTP client libraries by setting their log levels to WARNING, while keeping the application's own logging at INFO level.

## Key Changes
- Changed MCP server logging level from DEBUG to INFO to reduce noise
- Added suppression of verbose HTTP client debug output from httpx and httpcore libraries in both the MCP server and CUA CLI modules
- HTTP client libraries now only log warnings and errors, not debug/info messages

## Implementation Details
- Added a loop in both `mcp_server/server.py` and `cua_cli/commands/mcp.py` that explicitly sets the log level to WARNING for "httpx" and "httpcore" loggers
- This prevents the HTTP client libraries from flooding logs with verbose connection and request details while maintaining visibility into application-level events
- The change improves log readability without losing important diagnostic information

https://claude.ai/code/session_01HnAcHnKED6KTYVdN2i9F34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging configuration to reduce output verbosity. HTTP client debugging output is now less detailed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->