### PR TITLE
Fix remaining stale agent/core namespace references

### DIFF
--- a/libs/cua-bench/cua_bench/agents/cua_agent.py
+++ b/libs/cua-bench/cua_bench/agents/cua_agent.py
@@ -202,7 +202,7 @@ class CuaAgent(BaseAgent):
             AgentResult with token counts and failure mode
         """
         try:
-            from agent import ComputerAgent
+            from cua_agent import ComputerAgent
         except ImportError as e:
             raise RuntimeError(
                 "cua-agent requires the `cua-agent` package to be installed. "

--- a/libs/cua-bench/cua_bench/agents/opencua_agent.py
+++ b/libs/cua-bench/cua_bench/agents/opencua_agent.py
@@ -143,7 +143,7 @@ class OpenCUAAgent(BaseAgent):
     ) -> AgentResult:
         """Run the task using the OpenCUA model via the CUA Computer Agent SDK."""
         try:
-            from agent import ComputerAgent
+            from cua_agent import ComputerAgent
         except ImportError as e:
             raise RuntimeError(
                 "opencua-agent requires the `cua-agent` package to be installed. "

--- a/libs/python/agent/cua_agent/__init__.py
+++ b/libs/python/agent/cua_agent/__init__.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 # Initialize telemetry when the package is imported
 try:
     # Import from core telemetry for basic functions
-    from core.telemetry import (
+    from cua_core.telemetry import (
         is_telemetry_enabled,
         record_event,
     )

--- a/libs/python/agent/cua_agent/callbacks/otel.py
+++ b/libs/python/agent/cua_agent/callbacks/otel.py
@@ -15,7 +15,7 @@ from .base import AsyncCallbackHandler
 
 # Import OTEL functions - these are available when cua-core[telemetry] is installed
 try:
-    from core.telemetry import (
+    from cua_core.telemetry import (
         create_span,
         is_otel_enabled,
         record_error,

--- a/libs/python/agent/cua_agent/callbacks/prompt_instructions.py
+++ b/libs/python/agent/cua_agent/callbacks/prompt_instructions.py
@@ -6,7 +6,7 @@ instructions message to the start of the conversation before each LLM call.
 
 Usage:
 
-    from agent.callbacks import PromptInstructionsCallback
+    from cua_agent.callbacks import PromptInstructionsCallback
     agent = ComputerAgent(
         model="openai/computer-use-preview",
         callbacks=[PromptInstructionsCallback("Follow these rules...")]

--- a/libs/python/agent/cua_agent/cli.py
+++ b/libs/python/agent/cua_agent/cli.py
@@ -358,7 +358,7 @@ Examples:
 
     # Import here to avoid import errors if dependencies are missing
     try:
-        from agent import ComputerAgent
+        from cua_agent import ComputerAgent
         from computer import Computer
     except ImportError as e:
         print_colored(f"❌ Import error: {e}", Colors.RED, bold=True)

--- a/libs/python/agent/cua_agent/loops/gemini.py
+++ b/libs/python/agent/cua_agent/loops/gemini.py
@@ -126,7 +126,7 @@ def _create_gemini_client(
         http_options: Dict[str, Any] = {"base_url": f"{cua_base_url}/gemini"}
         # Include CUA version headers if available
         try:
-            from core.http import cua_version_headers
+            from cua_core.http import cua_version_headers
 
             hdrs = cua_version_headers()
             if hdrs:

--- a/libs/python/agent/cua_agent/playground/server.py
+++ b/libs/python/agent/cua_agent/playground/server.py
@@ -84,7 +84,7 @@ class PlaygroundServer:
             """
             # Import here to avoid circular imports
             try:
-                from agent import ComputerAgent
+                from cua_agent import ComputerAgent
             except ImportError:
                 raise HTTPException(status_code=501, detail="ComputerAgent not available")
 

--- a/libs/python/agent/cua_agent/ui/gradio/ui_components.py
+++ b/libs/python/agent/cua_agent/ui/gradio/ui_components.py
@@ -149,7 +149,7 @@ try:
     from computer import Computer
 except ImportError:
     Computer = None  # type: ignore[assignment,misc]
-from agent import ComputerAgent
+from cua_agent import ComputerAgent
 
 async def main():
     async with Computer{computer_args_str} as computer:

--- a/libs/python/core/cua_core/telemetry/otel.py
+++ b/libs/python/core/cua_core/telemetry/otel.py
@@ -226,7 +226,7 @@ def _shutdown_otel() -> None:
 def _get_sdk_version() -> str:
     """Get the CUA SDK version."""
     try:
-        from core import __version__
+        from cua_core import __version__
 
         return __version__
     except ImportError:

--- a/libs/python/core/cua_core/telemetry/posthog.py
+++ b/libs/python/core/cua_core/telemetry/posthog.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import posthog
-from core import __version__
+from cua_core import __version__
 
 logger = logging.getLogger("core.telemetry")
 

--- a/libs/python/cua-cli/cua_cli/main.py
+++ b/libs/python/cua-cli/cua_cli/main.py
@@ -62,7 +62,7 @@ def main() -> int:
     # Suppress noisy INFO logs from dependencies (computer, core.telemetry, etc.)
     # Must set on specific loggers since they configure their own handlers at import time
     logging.basicConfig(level=logging.WARNING)
-    for name in ("computer", "core", "core.telemetry", "httpx", "httpcore", "cua_sandbox"):
+    for name in ("computer", "cua_core", "cua_core.telemetry", "httpx", "httpcore", "cua_sandbox"):
         logging.getLogger(name).setLevel(logging.WARNING)
 
     parser = create_parser()

--- a/libs/python/cua/cua/__init__.py
+++ b/libs/python/cua/cua/__init__.py
@@ -92,10 +92,10 @@ _INTERFACE_NAMES: dict[str, tuple[str, str]] = {
 }
 
 _AGENT_NAMES: dict[str, tuple[str, str]] = {
-    "ComputerAgent": ("agent", "ComputerAgent"),
-    "AgentResponse": ("agent", "AgentResponse"),
-    "Messages": ("agent", "Messages"),
-    "register_agent": ("agent", "register_agent"),
+    "ComputerAgent": ("cua_agent", "ComputerAgent"),
+    "AgentResponse": ("cua_agent", "AgentResponse"),
+    "Messages": ("cua_agent", "Messages"),
+    "register_agent": ("cua_agent", "register_agent"),
 }
 
 _LAZY: dict[str, tuple[str, str]] = {**_RUNTIME_NAMES, **_INTERFACE_NAMES, **_AGENT_NAMES}

--- a/tests/test_mcp_server_session_management.py
+++ b/tests/test_mcp_server_session_management.py
@@ -101,7 +101,7 @@ def server_module():
     _install_stub_module("computer", computer_module, stubbed_modules)
 
     # Stub agent module
-    agent_module = types.ModuleType("agent")
+    agent_module = types.ModuleType("cua_agent")
 
     class _StubComputerAgent:
         def __init__(self, *args, **kwargs):
@@ -121,7 +121,7 @@ def server_module():
 
     agent_module.ComputerAgent = _StubComputerAgent
 
-    _install_stub_module("agent", agent_module, stubbed_modules)
+    _install_stub_module("cua_agent", agent_module, stubbed_modules)
 
     # Stub session manager module
     session_manager_module = types.ModuleType("mcp_server.session_manager")

--- a/tests/test_mcp_server_streaming.py
+++ b/tests/test_mcp_server_streaming.py
@@ -98,7 +98,7 @@ def server_module():
     _install_stub_module("computer", computer_module, stubbed_modules)
 
     # Stub agent module so server can import ComputerAgent
-    agent_module = types.ModuleType("agent")
+    agent_module = types.ModuleType("cua_agent")
 
     class _StubComputerAgent:
         def __init__(self, *args, **kwargs):
@@ -111,7 +111,7 @@ def server_module():
 
     agent_module.ComputerAgent = _StubComputerAgent
 
-    _install_stub_module("agent", agent_module, stubbed_modules)
+    _install_stub_module("cua_agent", agent_module, stubbed_modules)
 
     module_name = "mcp_server_server_under_test"
     module_path = Path("libs/python/mcp-server/mcp_server/server.py").resolve()


### PR DESCRIPTION
## Summary

- `cua/__init__.py`: lazy-import map referenced `"agent"` as module name → `"cua_agent"`
- `cua-cli/main.py`: log suppression list had `"core"`/`"core.telemetry"` → `"cua_core"`
- `tests/test_mcp_server_{session_management,streaming}.py`: stub modules registered under `"agent"`, causing the mcp-server's `from cua_agent import` to miss the stub at runtime
- `cua_agent/__init__.py`, `callbacks/otel.py`, `loops/gemini.py`: still importing from `core.*`
- `cua_agent/callbacks/prompt_instructions.py`, `cli.py`, `playground/server.py`, `ui/gradio/ui_components.py`: self-importing as `agent.*`
- `cua_core/telemetry/otel.py`, `posthog.py`: self-importing as `core`
- `cua_bench/agents/cua_agent.py`, `opencua_agent.py`: still importing from `agent`

## Test plan

- [ ] Confirm MCP server tests pass (`test_mcp_server_session_management`, `test_mcp_server_streaming`)
- [ ] Confirm `cua` metapackage lazy imports resolve (`ComputerAgent`, `AgentResponse`, `Messages`, `register_agent`)
- [ ] Confirm `cua-cli` starts without errors (log suppression no longer references old namespace)
- [ ] Confirm `cua_agent` and `cua_core` packages import cleanly with no self-import failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal module structure and package naming conventions throughout the SDK for improved code consistency and maintainability.
  * Updated import paths and dependencies to align with new package organization standards.
  * All public APIs and core functionality remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->