### PR TITLE
Fix stale @patch module paths in tests

### DIFF
--- a/libs/python/agent/tests/test_computer_agent.py
+++ b/libs/python/agent/tests/test_computer_agent.py
@@ -13,7 +13,7 @@ import pytest
 class TestComputerAgentInitialization:
     """Test ComputerAgent initialization (SRP: Only tests initialization)."""
 
-    @patch("agent.agent.litellm")
+    @patch("cua_agent.agent.litellm")
     def test_agent_initialization_with_model(self, mock_litellm, disable_telemetry):
         """Test that agent can be initialized with a model string."""
         from cua_agent import ComputerAgent
@@ -24,7 +24,7 @@ class TestComputerAgentInitialization:
         assert hasattr(agent, "model")
         assert agent.model == "anthropic/claude-sonnet-4-5-20250929"
 
-    @patch("agent.agent.litellm")
+    @patch("cua_agent.agent.litellm")
     def test_agent_initialization_with_tools(self, mock_litellm, disable_telemetry, mock_computer):
         """Test that agent can be initialized with tools."""
         from cua_agent import ComputerAgent
@@ -34,7 +34,7 @@ class TestComputerAgentInitialization:
         assert agent is not None
         assert hasattr(agent, "tools")
 
-    @patch("agent.agent.litellm")
+    @patch("cua_agent.agent.litellm")
     def test_agent_initialization_with_max_budget(self, mock_litellm, disable_telemetry):
         """Test that agent can be initialized with max trajectory budget."""
         from cua_agent import ComputerAgent
@@ -46,7 +46,7 @@ class TestComputerAgentInitialization:
 
         assert agent is not None
 
-    @patch("agent.agent.litellm")
+    @patch("cua_agent.agent.litellm")
     def test_agent_requires_model(self, mock_litellm, disable_telemetry):
         """Test that agent requires a model parameter."""
         from cua_agent import ComputerAgent
@@ -60,7 +60,7 @@ class TestComputerAgentRun:
     """Test ComputerAgent.run() method (SRP: Only tests run logic)."""
 
     @pytest.mark.asyncio
-    @patch("agent.agent.litellm")
+    @patch("cua_agent.agent.litellm")
     async def test_agent_run_with_messages(self, mock_litellm, disable_telemetry, sample_messages):
         """Test that agent.run() works with valid messages."""
         from cua_agent import ComputerAgent

--- a/libs/python/agent/tests/test_telemetry_events.py
+++ b/libs/python/agent/tests/test_telemetry_events.py
@@ -10,8 +10,8 @@ import pytest
 class TestAgentTelemetryEvents:
     """Test telemetry events emitted by ComputerAgent."""
 
-    @patch("agent.agent.record_event")
-    @patch("agent.agent.is_telemetry_enabled", return_value=True)
+    @patch("cua_agent.agent.record_event")
+    @patch("cua_agent.agent.is_telemetry_enabled", return_value=True)
     def test_agent_init_event(self, mock_telemetry_enabled, mock_record_event):
         """Test that agent_init event is emitted with correct args_provided."""
         from cua_agent.agent import ComputerAgent
@@ -38,8 +38,8 @@ class TestAgentTelemetryEvents:
         assert "max_retries" in event_data["args_provided"]
         assert "trajectory_dir" in event_data["args_provided"]
 
-    @patch("agent.agent.record_event")
-    @patch("agent.agent.is_telemetry_enabled", return_value=True)
+    @patch("cua_agent.agent.record_event")
+    @patch("cua_agent.agent.is_telemetry_enabled", return_value=True)
     def test_agent_init_minimal_args(self, mock_telemetry_enabled, mock_record_event):
         """Test agent_init with minimal args (defaults)."""
         from cua_agent.agent import ComputerAgent
@@ -59,8 +59,8 @@ class TestAgentTelemetryEvents:
         assert "trajectory_dir" not in event_data["args_provided"]
         assert "max_retries" not in event_data["args_provided"]  # default is 3
 
-    @patch("agent.agent.record_event")
-    @patch("agent.agent.is_telemetry_enabled", return_value=False)
+    @patch("cua_agent.agent.record_event")
+    @patch("cua_agent.agent.is_telemetry_enabled", return_value=False)
     def test_no_events_when_telemetry_disabled(self, mock_telemetry_enabled, mock_record_event):
         """Test that no events are emitted when telemetry is disabled."""
         from cua_agent.agent import ComputerAgent
@@ -82,8 +82,8 @@ class TestActionTelemetryEvents:
     """Test telemetry events for computer actions."""
 
     @pytest.mark.asyncio
-    @patch("agent.agent.record_event")
-    @patch("agent.agent.is_telemetry_enabled", return_value=True)
+    @patch("cua_agent.agent.record_event")
+    @patch("cua_agent.agent.is_telemetry_enabled", return_value=True)
     async def test_computer_action_executed_event(self, mock_telemetry_enabled, mock_record_event):
         """Test that computer_action_executed is emitted for computer calls."""
         from cua_agent.agent import ComputerAgent

--- a/libs/python/core/tests/test_telemetry.py
+++ b/libs/python/core/tests/test_telemetry.py
@@ -56,8 +56,8 @@ class TestTelemetryEnabled:
 class TestPostHogTelemetryClient:
     """Test PostHogTelemetryClient class (SRP: Only tests client logic)."""
 
-    @patch("core.telemetry.posthog.posthog")
-    @patch("core.telemetry.posthog.Path")
+    @patch("cua_core.telemetry.posthog.posthog")
+    @patch("cua_core.telemetry.posthog.Path")
     def test_client_initialization(self, mock_path, mock_posthog, disable_telemetry):
         """Test that client initializes correctly."""
         from cua_core.telemetry.posthog import PostHogTelemetryClient
@@ -78,8 +78,8 @@ class TestPostHogTelemetryClient:
         assert hasattr(client, "initialized")
         assert hasattr(client, "queued_events")
 
-    @patch("core.telemetry.posthog.posthog")
-    @patch("core.telemetry.posthog.Path")
+    @patch("cua_core.telemetry.posthog.posthog")
+    @patch("cua_core.telemetry.posthog.Path")
     def test_installation_id_generation(self, mock_path, mock_posthog, disable_telemetry):
         """Test that installation ID is generated if not exists."""
         from cua_core.telemetry.posthog import PostHogTelemetryClient
@@ -102,8 +102,8 @@ class TestPostHogTelemetryClient:
         assert client.installation_id is not None
         assert len(client.installation_id) == 36  # UUID format
 
-    @patch("core.telemetry.posthog.posthog")
-    @patch("core.telemetry.posthog.Path")
+    @patch("cua_core.telemetry.posthog.posthog")
+    @patch("cua_core.telemetry.posthog.Path")
     def test_installation_id_persistence(self, mock_path, mock_posthog, disable_telemetry):
         """Test that installation ID is read from file if exists."""
         from cua_core.telemetry.posthog import PostHogTelemetryClient
@@ -127,8 +127,8 @@ class TestPostHogTelemetryClient:
 
         assert client.installation_id == existing_id
 
-    @patch("core.telemetry.posthog.posthog")
-    @patch("core.telemetry.posthog.Path")
+    @patch("cua_core.telemetry.posthog.posthog")
+    @patch("cua_core.telemetry.posthog.Path")
     def test_record_event_when_disabled(self, mock_path, mock_posthog, monkeypatch):
         """Test that events are not recorded when telemetry is disabled."""
         from cua_core.telemetry.posthog import PostHogTelemetryClient
@@ -151,8 +151,8 @@ class TestPostHogTelemetryClient:
         # PostHog capture should not be called at all when telemetry is disabled
         mock_posthog.capture.assert_not_called()
 
-    @patch("core.telemetry.posthog.posthog")
-    @patch("core.telemetry.posthog.Path")
+    @patch("cua_core.telemetry.posthog.posthog")
+    @patch("cua_core.telemetry.posthog.Path")
     def test_record_event_when_enabled(self, mock_path, mock_posthog, monkeypatch):
         """Test that events are recorded when telemetry is enabled."""
         from cua_core.telemetry.posthog import PostHogTelemetryClient
@@ -180,8 +180,8 @@ class TestPostHogTelemetryClient:
         # PostHog capture should be called
         assert mock_posthog.capture.call_count >= 1
 
-    @patch("core.telemetry.posthog.posthog")
-    @patch("core.telemetry.posthog.Path")
+    @patch("cua_core.telemetry.posthog.posthog")
+    @patch("cua_core.telemetry.posthog.Path")
     def test_singleton_pattern(self, mock_path, mock_posthog, disable_telemetry):
         """Test that get_client returns the same instance."""
         from cua_core.telemetry.posthog import PostHogTelemetryClient
@@ -204,7 +204,7 @@ class TestPostHogTelemetryClient:
 class TestRecordEvent:
     """Test the public record_event function (SRP: Only tests public API)."""
 
-    @patch("core.telemetry.posthog.PostHogTelemetryClient")
+    @patch("cua_core.telemetry.posthog.PostHogTelemetryClient")
     def test_record_event_calls_client(self, mock_client_class, disable_telemetry):
         """Test that record_event delegates to the client."""
         from cua_core.telemetry import record_event
@@ -219,7 +219,7 @@ class TestRecordEvent:
 
         mock_client_instance.record_event.assert_called_once_with(event_name, event_props)
 
-    @patch("core.telemetry.posthog.PostHogTelemetryClient")
+    @patch("cua_core.telemetry.posthog.PostHogTelemetryClient")
     def test_record_event_without_properties(self, mock_client_class, disable_telemetry):
         """Test that record_event works without properties."""
         from cua_core.telemetry import record_event
@@ -237,7 +237,7 @@ class TestRecordEvent:
 class TestDestroyTelemetryClient:
     """Test client destruction (SRP: Only tests cleanup)."""
 
-    @patch("core.telemetry.posthog.PostHogTelemetryClient")
+    @patch("cua_core.telemetry.posthog.PostHogTelemetryClient")
     def test_destroy_client_calls_class_method(self, mock_client_class):
         """Test that destroy_telemetry_client delegates correctly."""
         from cua_core.telemetry import destroy_telemetry_client


### PR DESCRIPTION
## Summary

- `core/tests/test_telemetry.py`: `@patch("core.telemetry.posthog.*")` → `"cua_core.telemetry.posthog.*"` (14 occurrences)
- `agent/tests/test_telemetry_events.py`: `@patch("agent.agent.*")` → `"cua_agent.agent.*"` (8 occurrences)
- `agent/tests/test_computer_agent.py`: `@patch("agent.agent.litellm")` → `"cua_agent.agent.litellm"` (5 occurrences)

`unittest.mock.patch` targets must match the module path where the object is actually imported, not the old package name — these were causing `ModuleNotFoundError: No module named 'core'` / `No module named 'agent'` at test collection time.

## Test plan

- [ ] `libs/python/core` tests pass (`TestPostHogTelemetryClient::*`)
- [ ] `libs/python/agent` tests pass (`TestTelemetryEvents::*`, `TestComputerAgent::*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure for improved mocking accuracy across agent and telemetry test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->