### PR TITLE
Add UNAVAILABLE_WITHOUT_CONTAINER_NAME config for strict cloud mode

### DIFF
--- a/libs/python/computer-server/README.md
+++ b/libs/python/computer-server/README.md
@@ -38,6 +38,18 @@ Refer to this notebook for a step-by-step guide on how to use the Computer-Use S
 
 - [Computer-Use Server](../../notebooks/computer_server_nb.ipynb)
 
+## Environment variables
+
+Authentication behavior is controlled by the following environment variables:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `CONTAINER_NAME` | _unset_ | When set, the server runs in cloud auth mode: every `/ws`, `/cmd`, and `/responses` request must present a matching container name and a valid Cua API key. When unset, the server runs in local development mode and accepts all requests. |
+| `CUA_AUTH_TTL_SECONDS` | `60` | TTL for cached authentication sessions. |
+| `CUA_ENABLE_PUBLIC_PROXY` | _unset_ | When truthy (`1`/`true`/`yes`/`y`/`on`), the `/responses` agent proxy skips API-key validation even if `CONTAINER_NAME` is set. |
+| `UNAVAILABLE_WITHOUT_CONTAINER_NAME` | _unset_ | When truthy (`1`/`true`/`yes`/`y`/`on`), requests are rejected if `CONTAINER_NAME` is not set instead of falling through to local development mode. Use this to ensure a cloud deployment cannot accidentally serve unauthenticated traffic. |
+| `UNAVAILABLE_WITHOUT_CONTAINER_NAME_RESPONSE_STATUS_CODE` | `503` | HTTP status code returned by `/cmd` and `/responses` when `UNAVAILABLE_WITHOUT_CONTAINER_NAME` rejects a request. WebSocket clients receive the same code in the error JSON payload before the connection is closed. |
+
 ## Docs
 
 - [Commands](https://trycua.com/docs/libraries/computer-server/Commands)

--- a/libs/python/computer-server/computer_server/main.py
+++ b/libs/python/computer-server/computer_server/main.py
@@ -29,6 +29,15 @@ from .handlers.factory import HandlerFactory
 # Authentication session TTL (in seconds). Override via env var CUA_AUTH_TTL_SECONDS. Default: 60s
 AUTH_SESSION_TTL_SECONDS: int = int(os.environ.get("CUA_AUTH_TTL_SECONDS", "60"))
 
+# When true, requests are rejected if CONTAINER_NAME is not set on the server (instead of
+# falling through to local development mode). The rejection status code is configurable.
+UNAVAILABLE_WITHOUT_CONTAINER_NAME: bool = os.environ.get(
+    "UNAVAILABLE_WITHOUT_CONTAINER_NAME", ""
+).lower().strip() in ["1", "true", "yes", "y", "on"]
+UNAVAILABLE_WITHOUT_CONTAINER_NAME_RESPONSE_STATUS_CODE: int = int(
+    os.environ.get("UNAVAILABLE_WITHOUT_CONTAINER_NAME_RESPONSE_STATUS_CODE", "503")
+)
+
 try:
     from agent import ComputerAgent
 
@@ -264,6 +273,22 @@ async def websocket_endpoint(websocket: WebSocket):
     # Check if CONTAINER_NAME is set (indicating cloud provider)
     server_container_name = os.environ.get("CONTAINER_NAME")
 
+    # Reject connections when CONTAINER_NAME is required but unset
+    if not server_container_name and UNAVAILABLE_WITHOUT_CONTAINER_NAME:
+        logger.warning(
+            "Rejecting WebSocket: CONTAINER_NAME not set and UNAVAILABLE_WITHOUT_CONTAINER_NAME enabled"
+        )
+        await websocket.send_json(
+            {
+                "success": False,
+                "error": "Service unavailable: CONTAINER_NAME not set",
+                "status_code": UNAVAILABLE_WITHOUT_CONTAINER_NAME_RESPONSE_STATUS_CODE,
+            }
+        )
+        await websocket.close()
+        manager.disconnect(websocket)
+        return
+
     # If cloud provider, perform authentication handshake
     if server_container_name:
         try:
@@ -410,6 +435,13 @@ async def cmd_endpoint(
     # Check if CONTAINER_NAME is set (indicating cloud provider)
     server_container_name = os.environ.get("CONTAINER_NAME")
 
+    # Reject requests when CONTAINER_NAME is required but unset
+    if not server_container_name and UNAVAILABLE_WITHOUT_CONTAINER_NAME:
+        raise HTTPException(
+            status_code=UNAVAILABLE_WITHOUT_CONTAINER_NAME_RESPONSE_STATUS_CODE,
+            detail="Service unavailable: CONTAINER_NAME not set",
+        )
+
     # If cloud provider, perform authentication
     if server_container_name:
         logger.info(
@@ -493,6 +525,11 @@ async def agent_response_endpoint(
 
     # Authenticate via AuthenticationManager if running in cloud (CONTAINER_NAME set)
     container_name = os.environ.get("CONTAINER_NAME")
+    if not container_name and UNAVAILABLE_WITHOUT_CONTAINER_NAME:
+        raise HTTPException(
+            status_code=UNAVAILABLE_WITHOUT_CONTAINER_NAME_RESPONSE_STATUS_CODE,
+            detail="Service unavailable: CONTAINER_NAME not set",
+        )
     if container_name:
         is_public = os.environ.get("CUA_ENABLE_PUBLIC_PROXY", "").lower().strip() in [
             "1",

--- a/libs/python/computer-server/tests/test_unavailable_without_container_name.py
+++ b/libs/python/computer-server/tests/test_unavailable_without_container_name.py
@@ -1,0 +1,160 @@
+"""Integration tests for the UNAVAILABLE_WITHOUT_CONTAINER_NAME auth gate.
+
+Covers both scenarios:
+  1. Gate disabled (default): requests fall through to local development mode.
+  2. Gate enabled + CONTAINER_NAME unset: requests are rejected with the
+     configured HTTP status code (default 503) for /cmd and /responses, and
+     the WebSocket handshake is closed with an error payload containing the
+     same status code.
+
+The real HandlerFactory pulls in OS-specific automation libraries (pynput on
+Linux) that require an X display, so we stub it in sys.modules before
+importing computer_server.main.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _install_handler_factory_stub() -> None:
+    """Register a no-op HandlerFactory so main.py can import without a display."""
+    if "computer_server.handlers.factory" in sys.modules:
+        existing = sys.modules["computer_server.handlers.factory"]
+        if getattr(existing, "__cua_test_stub__", False):
+            return
+
+    stub_module = types.ModuleType("computer_server.handlers.factory")
+    stub_module.__cua_test_stub__ = True  # type: ignore[attr-defined]
+
+    class _StubHandlerFactory:
+        @staticmethod
+        def create_handlers():
+            return (MagicMock(), MagicMock(), MagicMock(), MagicMock())
+
+    stub_module.HandlerFactory = _StubHandlerFactory  # type: ignore[attr-defined]
+    sys.modules["computer_server.handlers.factory"] = stub_module
+
+
+def _reload_main(monkeypatch, **env: str):
+    """Reload computer_server.main with the given env vars applied.
+
+    Module-level constants (UNAVAILABLE_WITHOUT_CONTAINER_NAME and its status
+    code companion) are captured at import time, so we must reload after
+    mutating the environment.
+    """
+    _install_handler_factory_stub()
+
+    for var in (
+        "CONTAINER_NAME",
+        "UNAVAILABLE_WITHOUT_CONTAINER_NAME",
+        "UNAVAILABLE_WITHOUT_CONTAINER_NAME_RESPONSE_STATUS_CODE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    if "computer_server.main" in sys.modules:
+        return importlib.reload(sys.modules["computer_server.main"])
+    return importlib.import_module("computer_server.main")
+
+
+@pytest.fixture
+def test_client_factory(monkeypatch):
+    """Return a callable that builds a TestClient with the requested env."""
+    try:
+        from fastapi.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi.testclient (httpx) not installed")
+
+    def _build(**env: str):
+        main = _reload_main(monkeypatch, **env)
+        return main, TestClient(main.app)
+
+    return _build
+
+
+class TestGateDisabledPassthrough:
+    """Scenario 1: UNAVAILABLE_WITHOUT_CONTAINER_NAME unset -> local dev mode."""
+
+    def test_constants_default_to_disabled_and_503(self, test_client_factory):
+        main, _ = test_client_factory()
+        assert main.UNAVAILABLE_WITHOUT_CONTAINER_NAME is False
+        assert main.UNAVAILABLE_WITHOUT_CONTAINER_NAME_RESPONSE_STATUS_CODE == 503
+
+    def test_cmd_passes_gate_and_reaches_handler_lookup(self, test_client_factory):
+        # With the gate disabled and CONTAINER_NAME unset, the gate short-circuit
+        # is skipped and the request flows into the handler dispatch. An unknown
+        # command produces a 400 -- proving the 503 gate did not fire.
+        _, client = test_client_factory()
+        resp = client.post("/cmd", json={"command": "__definitely_not_a_real_command__"})
+        assert resp.status_code == 400
+        assert "Unknown command" in resp.json()["detail"]
+
+    def test_ws_accepts_connection_without_auth_handshake(self, test_client_factory):
+        _, client = test_client_factory()
+        with client.websocket_connect("/ws") as ws:
+            ws.send_json({"command": "__definitely_not_a_real_command__"})
+            msg = ws.receive_json()
+        assert msg["success"] is False
+        assert "Unknown command" in msg["error"]
+
+
+class TestGateEnabledRejection:
+    """Scenario 2: UNAVAILABLE_WITHOUT_CONTAINER_NAME=true + no CONTAINER_NAME."""
+
+    def test_constants_reflect_enabled_gate(self, test_client_factory):
+        main, _ = test_client_factory(UNAVAILABLE_WITHOUT_CONTAINER_NAME="true")
+        assert main.UNAVAILABLE_WITHOUT_CONTAINER_NAME is True
+        assert main.UNAVAILABLE_WITHOUT_CONTAINER_NAME_RESPONSE_STATUS_CODE == 503
+
+    def test_cmd_returns_default_503(self, test_client_factory):
+        _, client = test_client_factory(UNAVAILABLE_WITHOUT_CONTAINER_NAME="true")
+        resp = client.post("/cmd", json={"command": "version"})
+        assert resp.status_code == 503
+        assert "CONTAINER_NAME not set" in resp.json()["detail"]
+
+    @pytest.mark.parametrize("truthy", ["1", "true", "yes", "y", "on", "TRUE", "On"])
+    def test_cmd_gate_accepts_truthy_spellings(self, test_client_factory, truthy):
+        _, client = test_client_factory(UNAVAILABLE_WITHOUT_CONTAINER_NAME=truthy)
+        resp = client.post("/cmd", json={"command": "version"})
+        assert resp.status_code == 503
+
+    def test_cmd_honors_custom_status_code(self, test_client_factory):
+        _, client = test_client_factory(
+            UNAVAILABLE_WITHOUT_CONTAINER_NAME="1",
+            UNAVAILABLE_WITHOUT_CONTAINER_NAME_RESPONSE_STATUS_CODE="418",
+        )
+        resp = client.post("/cmd", json={"command": "version"})
+        assert resp.status_code == 418
+        assert "CONTAINER_NAME not set" in resp.json()["detail"]
+
+    def test_ws_sends_rejection_payload_and_closes(self, test_client_factory):
+        from starlette.websockets import WebSocketDisconnect
+
+        _, client = test_client_factory(
+            UNAVAILABLE_WITHOUT_CONTAINER_NAME="true",
+            UNAVAILABLE_WITHOUT_CONTAINER_NAME_RESPONSE_STATUS_CODE="521",
+        )
+        with client.websocket_connect("/ws") as ws:
+            msg = ws.receive_json()
+            assert msg["success"] is False
+            assert msg["status_code"] == 521
+            assert "CONTAINER_NAME not set" in msg["error"]
+            with pytest.raises(WebSocketDisconnect):
+                ws.receive_json()
+
+    def test_gate_ignored_when_container_name_is_set(self, test_client_factory):
+        # When CONTAINER_NAME is set, the gate is irrelevant: the cloud auth
+        # path runs instead, rejecting missing headers with 401 (not 503).
+        _, client = test_client_factory(
+            CONTAINER_NAME="my-container",
+            UNAVAILABLE_WITHOUT_CONTAINER_NAME="true",
+        )
+        resp = client.post("/cmd", json={"command": "version"})
+        assert resp.status_code == 401

--- a/uv.lock
+++ b/uv.lock
@@ -861,7 +861,7 @@ wheels = [
 
 [[package]]
 name = "cua-agent"
-version = "0.4.35"
+version = "0.4.36"
 source = { editable = "libs/python/agent" }
 dependencies = [
     { name = "aiohttp" },
@@ -1831,6 +1831,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
     { url = "https://files.pythonhosted.org/packages/3f/c7/12381b18e21aef2c6bd3a636da1088b888b97b7a0362fac2e4de92405f97/greenlet-3.2.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:20fb936b4652b6e307b8f347665e2c615540d4b42b3b4c8a321d8286da7e520f", size = 1151142, upload-time = "2025-08-07T13:18:22.981Z" },
+    { url = "https://files.pythonhosted.org/packages/27/45/80935968b53cfd3f33cf99ea5f08227f2646e044568c9b1555b58ffd61c2/greenlet-3.2.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee7a6ec486883397d70eec05059353b8e83eca9168b9f3f9a361971e77e0bcd0", size = 1564846, upload-time = "2025-11-04T12:42:15.191Z" },
+    { url = "https://files.pythonhosted.org/packages/69/02/b7c30e5e04752cb4db6202a3858b149c0710e5453b71a3b2aec5d78a1aab/greenlet-3.2.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:326d234cbf337c9c3def0676412eb7040a35a768efc92504b947b3e9cfc7543d", size = 1633814, upload-time = "2025-11-04T12:42:17.175Z" },
     { url = "https://files.pythonhosted.org/packages/e9/08/b0814846b79399e585f974bbeebf5580fbe59e258ea7be64d9dfb253c84f/greenlet-3.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:a7d4e128405eea3814a12cc2605e0e6aedb4035bf32697f72deca74de4105e02", size = 299899, upload-time = "2025-08-07T13:38:53.448Z" },
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
@@ -1840,6 +1842,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
     { url = "https://files.pythonhosted.org/packages/a2/15/0d5e4e1a66fab130d98168fe984c509249c833c1a3c16806b90f253ce7b9/greenlet-3.2.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:d25c5091190f2dc0eaa3f950252122edbbadbb682aa7b1ef2f8af0f8c0afefae", size = 1149210, upload-time = "2025-08-07T13:18:24.072Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/53/f9c440463b3057485b8594d7a638bed53ba531165ef0ca0e6c364b5cc807/greenlet-3.2.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6e343822feb58ac4d0a1211bd9399de2b3a04963ddeec21530fc426cc121f19b", size = 1564759, upload-time = "2025-11-04T12:42:19.395Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e4/3bb4240abdd0a8d23f4f88adec746a3099f0d86bfedb623f063b2e3b4df0/greenlet-3.2.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca7f6f1f2649b89ce02f6f229d7c19f680a6238af656f61e0115b24857917929", size = 1634288, upload-time = "2025-11-04T12:42:21.174Z" },
     { url = "https://files.pythonhosted.org/packages/0b/55/2321e43595e6801e105fcfdee02b34c0f996eb71e6ddffca6b10b7e1d771/greenlet-3.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:554b03b6e73aaabec3745364d6239e9e012d64c68ccd0b8430c64ccc14939a8b", size = 299685, upload-time = "2025-08-07T13:24:38.824Z" },
 ]
 


### PR DESCRIPTION
## Summary
Add a new configuration option to enforce strict cloud deployment mode by rejecting all requests when `CONTAINER_NAME` is not set, preventing accidental unauthenticated traffic in production environments.

## Key Changes
- Added two new environment variables:
  - `UNAVAILABLE_WITHOUT_CONTAINER_NAME`: When enabled, rejects requests if `CONTAINER_NAME` is unset instead of falling back to local development mode
  - `UNAVAILABLE_WITHOUT_CONTAINER_NAME_RESPONSE_STATUS_CODE`: Configurable HTTP status code (default 503) for rejection responses
  
- Implemented rejection logic across three endpoints:
  - `/ws` (WebSocket): Sends error JSON and closes connection
  - `/cmd` (HTTP): Raises HTTPException with configured status code
  - `/responses` (HTTP): Raises HTTPException with configured status code

- Updated README with environment variable documentation including descriptions and defaults

## Implementation Details
- The feature uses environment variable parsing consistent with existing patterns (lowercase string comparison against `["1", "true", "yes", "y", "on"]`)
- Default status code is 503 (Service Unavailable), appropriate for deployment configuration issues
- WebSocket rejection sends a JSON error response before closing, maintaining protocol consistency
- HTTP endpoints use standard FastAPI HTTPException for clean error handling
- All three endpoints check the condition early, before attempting authentication

https://claude.ai/code/session_01ATRJHpR6t4mwXKfsX9U3Fq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment variable controls to reject requests when container name is not set
  * New customizable HTTP status code option for service unavailability responses (default: 503)

* **Documentation**
  * Added comprehensive environment variables reference section documenting authentication and container configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->