### PR TITLE
fix(agent): fix drag coordinates and scroll direction for Anthropic models

### DIFF
--- a/libs/python/agent/cua_agent/loops/anthropic.py
+++ b/libs/python/agent/cua_agent/loops/anthropic.py
@@ -1355,8 +1355,23 @@ def _convert_completion_to_responses_items(
                             #         ]
                             #     }
                             # }
-                            start_coord = args.get("start_coordinate", [0, 0])
-                            end_coord = args.get("end_coordinate", [0, 0])
+                            # computer_20250124 "drag" uses "path" (list of {x,y} dicts),
+                            # while older "left_click_drag" uses "start_coordinate"/"end_coordinate".
+                            # Mirror the tool_use branch above so an Anthropic tool_call carrying
+                            # a path payload doesn't degrade to a [0,0] -> [0,0] no-op.
+                            path = args.get("path", [])
+                            if path and isinstance(path, list) and len(path) >= 2:
+                                start_coord = [
+                                    int(path[0].get("x", 0)),
+                                    int(path[0].get("y", 0)),
+                                ]
+                                end_coord = [
+                                    int(path[-1].get("x", start_coord[0])),
+                                    int(path[-1].get("y", start_coord[1])),
+                                ]
+                            else:
+                                start_coord = args.get("start_coordinate", [0, 0])
+                                end_coord = args.get("end_coordinate", [0, 0])
                             responses_items.append(
                                 make_drag_item(
                                     path=[

--- a/libs/python/agent/cua_agent/loops/anthropic.py
+++ b/libs/python/agent/cua_agent/loops/anthropic.py
@@ -888,8 +888,21 @@ def _convert_completion_to_responses_items(
                                     )
                                 )
                             elif action_type in ["left_click_drag", "drag"]:
-                                start_coord = tool_input.get("start_coordinate", [0, 0])
-                                end_coord = tool_input.get("end_coordinate", [0, 0])
+                                # computer_20250124 "drag" uses "path" (list of {x,y} dicts),
+                                # while older "left_click_drag" uses "start_coordinate"/"end_coordinate"
+                                path = tool_input.get("path", [])
+                                if path and isinstance(path, list) and len(path) >= 2:
+                                    start_coord = [
+                                        int(path[0].get("x", 0)),
+                                        int(path[0].get("y", 0)),
+                                    ]
+                                    end_coord = [
+                                        int(path[-1].get("x", start_coord[0])),
+                                        int(path[-1].get("y", start_coord[1])),
+                                    ]
+                                else:
+                                    start_coord = tool_input.get("start_coordinate", [0, 0])
+                                    end_coord = tool_input.get("end_coordinate", [0, 0])
                                 responses_items.append(
                                     make_drag_item(
                                         path=[
@@ -1286,15 +1299,17 @@ def _convert_completion_to_responses_items(
                             coordinate = args.get("coordinate", [0, 0])
                             direction = args.get("scroll_direction", "down")
                             amount = args.get("scroll_amount", 3)
+                            # scroll_x: positive=right, negative=left
+                            # scroll_y: positive=down, negative=up
                             scroll_x = (
                                 amount
-                                if direction == "left"
-                                else -amount if direction == "right" else 0
+                                if direction == "right"
+                                else -amount if direction == "left" else 0
                             )
                             scroll_y = (
                                 amount
-                                if direction == "up"
-                                else -amount if direction == "down" else 0
+                                if direction == "down"
+                                else -amount if direction == "up" else 0
                             )
                             responses_items.append(
                                 make_scroll_item(


### PR DESCRIPTION
Fixes #885

## Problem

Two bugs in `libs/python/agent/cua_agent/loops/anthropic.py` cause scroll and drag to fail silently when using Anthropic models:

### 1. Drag coordinates always (0, 0) for `computer_use_20250124`

The `drag` action in `computer_use_20250124` sends coordinates as a `path` field (list of `{x, y}` dicts), but the code only looked for `start_coordinate` / `end_coordinate` (the older `left_click_drag` format). When the model emitted a `drag` action with `path`, both start and end coordinates fell back to `[0, 0]`, making every drag a no-op.

### 2. Inverted scroll direction in OpenAI function-call handler

In the `message.tool_calls` path (used when the API returns OpenAI-style function calls), the mapping from `scroll_direction` → `scroll_x` / `scroll_y` was inverted:

| Model sends | Before fix | Expected |
|---|---|---|
| `"right"` | `scroll_x = -amount` | `scroll_x = +amount` |
| `"left"` | `scroll_x = +amount` | `scroll_x = -amount` |
| `"down"` | `scroll_y = -amount` | `scroll_y = +amount` |
| `"up"` | `scroll_y = +amount` | `scroll_y = -amount` |

This caused every scroll to go in the opposite direction.

## Solution

- **Drag**: Check for `path` first (computer_use_20250124), fall back to `start_coordinate`/`end_coordinate` (computer_use_20241022). Apply `int()` conversion to avoid issues with float coordinates from the model.
- **Scroll**: Fix the direction → value mapping in the OpenAI function-call handler to match the documented convention (`scroll_y` positive = down, `scroll_x` positive = right).

## Testing

The fixes can be verified with the evals mentioned in the issue:
```bash
cb run fill-form --dataset cua-bench-basic --agent cua-agent --model claude-opus-4.5
cb run drag-drop --dataset cua-bench-basic --agent cua-agent --model claude-opus-4.5
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scroll direction mapping: rightward and downward scrolling now correctly register as positive values, while leftward and upward scrolling register as negative values.

* **Improvements**
  * Enhanced drag action support to accept path-based input with multiple waypoints. System automatically falls back to standard start and end coordinates when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->