### PR TITLE
fix(cli): use shutil.which for ffmpeg detection in skills record

### DIFF
--- a/libs/python/cua-cli/cua_cli/commands/skills.py
+++ b/libs/python/cua-cli/cua_cli/commands/skills.py
@@ -418,13 +418,7 @@ def cmd_record(args: argparse.Namespace) -> int:
 
 def _check_ffmpeg() -> bool:
     """Check if ffmpeg is available."""
-    import subprocess
-
-    try:
-        result = subprocess.run(["which", "ffmpeg"], capture_output=True)
-        return result.returncode == 0
-    except Exception:
-        return False
+    return shutil.which("ffmpeg") is not None
 
 
 async def _record_skill_async(args: argparse.Namespace) -> int:


### PR DESCRIPTION
## Summary

`cua skills record` was failing with "ffmpeg is required for skill recording" even when ffmpeg was installed and on `PATH`. The check in `libs/python/cua-cli/cua_cli/commands/skills.py` shelled out to the external `which` binary, which isn't available on Windows and is missing from some minimal Linux environments — producing false negatives independent of whether ffmpeg itself is installed.

Replaced `subprocess.run(["which", "ffmpeg"])` with `shutil.which("ffmpeg")`, matching the convention already used across `cua-sandbox` (e.g. `runtime/tart.py`, `runtime/lume.py`, `runtime/qemu_installer.py`). The `shutil` module was already imported at the top of the file.

## Test plan

- [ ] With ffmpeg on `PATH`: `cua skills record --sandbox <name>` proceeds past the dependency check
- [ ] Without ffmpeg installed: the command still exits with the existing "ffmpeg is required" error and install hint
- [ ] Verified on an environment lacking the `which` binary (previously broke here)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the internal ffmpeg detection mechanism for improved performance and simplified code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->