### PR TITLE
feat(computer-sdk): route cloud traffic through api proxy

### DIFF
--- a/libs/python/computer/computer/computer.py
+++ b/libs/python/computer/computer/computer.py
@@ -629,6 +629,11 @@ class Computer:
                 and self.api_key
                 and self.config.name
             ):
+                # Determine proxy base URL from the cloud provider
+                proxy_url = None
+                if self.config.vm_provider and hasattr(self.config.vm_provider, "api_base"):
+                    proxy_url = self.config.vm_provider.api_base
+
                 interface = cast(
                     BaseComputerInterface,
                     InterfaceFactory.create_interface_for_os(
@@ -637,6 +642,7 @@ class Computer:
                         api_key=self.api_key,
                         vm_name=self.config.name,
                         api_port=self.api_port,
+                        proxy_base_url=proxy_url,
                     ),
                 )
             else:
@@ -839,6 +845,9 @@ class Computer:
                 and self.api_key
                 and self.config.name
             ):
+                proxy_url = None
+                if self.config.vm_provider and hasattr(self.config.vm_provider, "api_base"):
+                    proxy_url = self.config.vm_provider.api_base
                 self._interface = cast(
                     BaseComputerInterface,
                     InterfaceFactory.create_interface_for_os(
@@ -847,6 +856,7 @@ class Computer:
                         api_key=self.api_key,
                         vm_name=self.config.name,
                         api_port=self.api_port,
+                        proxy_base_url=proxy_url,
                     ),
                 )
             else:

--- a/libs/python/computer/computer/interface/android.py
+++ b/libs/python/computer/computer/interface/android.py
@@ -14,7 +14,8 @@ class AndroidComputerInterface(GenericComputerInterface):
         api_key: Optional[str] = None,
         vm_name: Optional[str] = None,
         api_port: Optional[int] = None,
+        proxy_base_url: Optional[str] = None,
     ):
         super().__init__(
-            ip_address, username, password, api_key, vm_name, "computer.interface.android", api_port
+            ip_address, username, password, api_key, vm_name, "computer.interface.android", api_port, proxy_base_url
         )

--- a/libs/python/computer/computer/interface/base.py
+++ b/libs/python/computer/computer/interface/base.py
@@ -17,6 +17,7 @@ class BaseComputerInterface(ABC):
         password: str = "lume",
         api_key: Optional[str] = None,
         vm_name: Optional[str] = None,
+        proxy_base_url: Optional[str] = None,
     ):
         """Initialize interface.
 
@@ -26,12 +27,16 @@ class BaseComputerInterface(ABC):
             password: Password for authentication
             api_key: Optional API key for cloud authentication
             vm_name: Optional VM name for cloud authentication
+            proxy_base_url: Optional base URL for cloud API proxy mode
+                (e.g. "https://api.cua.ai"). When set, traffic is routed
+                through the cloud API proxy instead of directly to the VM.
         """
         self.ip_address = ip_address
         self.username = username
         self.password = password
         self.api_key = api_key
         self.vm_name = vm_name
+        self.proxy_base_url = proxy_base_url.rstrip("/") if proxy_base_url else None
         self.logger = Logger("cua.interface", LogLevel.NORMAL)
 
         # Optional default delay time between commands (in seconds)

--- a/libs/python/computer/computer/interface/factory.py
+++ b/libs/python/computer/computer/interface/factory.py
@@ -17,6 +17,7 @@ class InterfaceFactory:
         api_port: Optional[int] = None,
         api_key: Optional[str] = None,
         vm_name: Optional[str] = None,
+        proxy_base_url: Optional[str] = None,
     ) -> BaseComputerInterface:
         """Create an interface for the specified OS.
 
@@ -26,6 +27,7 @@ class InterfaceFactory:
             api_port: Optional API port of the computer to control
             api_key: Optional API key for cloud authentication
             vm_name: Optional VM name for cloud authentication
+            proxy_base_url: Optional cloud API proxy base URL
 
         Returns:
             BaseComputerInterface: The appropriate interface for the OS
@@ -38,25 +40,25 @@ class InterfaceFactory:
             from .macos import MacOSComputerInterface
 
             return MacOSComputerInterface(
-                ip_address, api_key=api_key, vm_name=vm_name, api_port=api_port
+                ip_address, api_key=api_key, vm_name=vm_name, api_port=api_port, proxy_base_url=proxy_base_url
             )
         elif os == "linux":
             from .linux import LinuxComputerInterface
 
             return LinuxComputerInterface(
-                ip_address, api_key=api_key, vm_name=vm_name, api_port=api_port
+                ip_address, api_key=api_key, vm_name=vm_name, api_port=api_port, proxy_base_url=proxy_base_url
             )
         elif os == "windows":
             from .windows import WindowsComputerInterface
 
             return WindowsComputerInterface(
-                ip_address, api_key=api_key, vm_name=vm_name, api_port=api_port
+                ip_address, api_key=api_key, vm_name=vm_name, api_port=api_port, proxy_base_url=proxy_base_url
             )
         elif os == "android":
             from .android import AndroidComputerInterface
 
             return AndroidComputerInterface(
-                ip_address, api_key=api_key, vm_name=vm_name, api_port=api_port
+                ip_address, api_key=api_key, vm_name=vm_name, api_port=api_port, proxy_base_url=proxy_base_url
             )
         else:
             raise ValueError(f"Unsupported OS type: {os}")

--- a/libs/python/computer/computer/interface/generic.py
+++ b/libs/python/computer/computer/interface/generic.py
@@ -32,8 +32,9 @@ class GenericComputerInterface(BaseComputerInterface):
         vm_name: Optional[str] = None,
         logger_name: str = "computer.interface.generic",
         api_port: Optional[int] = None,
+        proxy_base_url: Optional[str] = None,
     ):
-        super().__init__(ip_address, username, password, api_key, vm_name)
+        super().__init__(ip_address, username, password, api_key, vm_name, proxy_base_url)
         self._ws = None
         self._reconnect_task = None
         self._closed = False
@@ -74,6 +75,11 @@ class GenericComputerInterface(BaseComputerInterface):
         Returns:
             WebSocket URI for the Computer API Server
         """
+        if self.proxy_base_url and self.vm_name:
+            scheme = "wss" if self.proxy_base_url.startswith("https") else "ws"
+            host = self.proxy_base_url.split("://", 1)[-1]
+            return f"{scheme}://{host}/v1/vms/{self.vm_name}/ws"
+
         protocol = "wss" if self.api_key else "ws"
         # Use custom API port if provided, otherwise use defaults based on API key
         port = (
@@ -90,6 +96,9 @@ class GenericComputerInterface(BaseComputerInterface):
         Returns:
             REST URI for the Computer API Server
         """
+        if self.proxy_base_url and self.vm_name:
+            return f"{self.proxy_base_url}/v1/vms/{self.vm_name}/http/cmd"
+
         protocol = "https" if self.api_key else "http"
         # Use custom API port if provided, otherwise use defaults based on API key
         port = (
@@ -764,15 +773,20 @@ class GenericComputerInterface(BaseComputerInterface):
             # Web search
             await interface.playwright_exec("web_search", {"query": "computer use agent"})
         """
-        protocol = "https" if self.api_key else "http"
-        port = str(self._api_port) if self._api_port else ("8443" if self.api_key else "8000")
-        url = f"{protocol}://{self.ip_address}:{port}/playwright_exec"
+        if self.proxy_base_url and self.vm_name:
+            url = f"{self.proxy_base_url}/v1/vms/{self.vm_name}/http/playwright_exec"
+        else:
+            protocol = "https" if self.api_key else "http"
+            port = str(self._api_port) if self._api_port else ("8443" if self.api_key else "8000")
+            url = f"{protocol}://{self.ip_address}:{port}/playwright_exec"
 
         payload = {"command": command, "params": params or {}}
         headers = {"Content-Type": "application/json", **cua_version_headers()}
-        if self.api_key:
+        if self.proxy_base_url and self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        elif self.api_key:
             headers["X-API-Key"] = self.api_key
-        if self.vm_name:
+        if self.vm_name and not self.proxy_base_url:
             headers["X-Container-Name"] = self.vm_name
 
         try:
@@ -821,6 +835,12 @@ class GenericComputerInterface(BaseComputerInterface):
                                 f"Attempting WebSocket connection to {self.ws_uri} (attempt {retry_count})"
                             )
 
+                        # In proxy mode, the cloud API service handles auth via
+                        # the Authorization header; no WS authenticate handshake needed.
+                        ws_extra_headers = {}
+                        if self.proxy_base_url and self.api_key:
+                            ws_extra_headers["Authorization"] = f"Bearer {self.api_key}"
+
                         self._ws = await asyncio.wait_for(
                             websockets.connect(
                                 self.ws_uri,
@@ -830,13 +850,17 @@ class GenericComputerInterface(BaseComputerInterface):
                                 ping_timeout=self._ping_timeout,
                                 close_timeout=5,
                                 compression=None,  # Disable compression to reduce overhead
+                                additional_headers=ws_extra_headers or None,
                             ),
                             timeout=120,
                         )
                         self.logger.info("WebSocket connection established")
 
-                        # If api_key and vm_name are provided, perform authentication handshake
-                        if self.api_key and self.vm_name:
+                        # In proxy mode, skip the authenticate handshake — the proxy
+                        # already validated the workspace key via the Bearer header.
+                        if self.proxy_base_url:
+                            self.logger.info("Proxy mode: skipping authenticate handshake")
+                        elif self.api_key and self.vm_name:
                             self.logger.info("Performing authentication handshake...")
                             auth_message = {
                                 "command": "authenticate",
@@ -1009,9 +1033,11 @@ class GenericComputerInterface(BaseComputerInterface):
 
             # Prepare headers
             headers = {"Content-Type": "application/json", **cua_version_headers()}
-            if self.api_key:
+            if self.proxy_base_url and self.api_key:
+                headers["Authorization"] = f"Bearer {self.api_key}"
+            elif self.api_key:
                 headers["X-API-Key"] = self.api_key
-            if self.vm_name:
+            if self.vm_name and not self.proxy_base_url:
                 headers["X-Container-Name"] = self.vm_name
 
             # Send the request

--- a/libs/python/computer/computer/interface/linux.py
+++ b/libs/python/computer/computer/interface/linux.py
@@ -14,7 +14,8 @@ class LinuxComputerInterface(GenericComputerInterface):
         api_key: Optional[str] = None,
         vm_name: Optional[str] = None,
         api_port: Optional[int] = None,
+        proxy_base_url: Optional[str] = None,
     ):
         super().__init__(
-            ip_address, username, password, api_key, vm_name, "computer.interface.linux", api_port
+            ip_address, username, password, api_key, vm_name, "computer.interface.linux", api_port, proxy_base_url
         )

--- a/libs/python/computer/computer/interface/macos.py
+++ b/libs/python/computer/computer/interface/macos.py
@@ -14,9 +14,10 @@ class MacOSComputerInterface(GenericComputerInterface):
         api_key: Optional[str] = None,
         vm_name: Optional[str] = None,
         api_port: Optional[int] = None,
+        proxy_base_url: Optional[str] = None,
     ):
         super().__init__(
-            ip_address, username, password, api_key, vm_name, "computer.interface.macos", api_port
+            ip_address, username, password, api_key, vm_name, "computer.interface.macos", api_port, proxy_base_url
         )
 
     async def diorama_cmd(self, action: str, arguments: Optional[dict] = None) -> dict:

--- a/libs/python/computer/computer/interface/windows.py
+++ b/libs/python/computer/computer/interface/windows.py
@@ -14,7 +14,8 @@ class WindowsComputerInterface(GenericComputerInterface):
         api_key: Optional[str] = None,
         vm_name: Optional[str] = None,
         api_port: Optional[int] = None,
+        proxy_base_url: Optional[str] = None,
     ):
         super().__init__(
-            ip_address, username, password, api_key, vm_name, "computer.interface.windows", api_port
+            ip_address, username, password, api_key, vm_name, "computer.interface.windows", api_port, proxy_base_url
         )


### PR DESCRIPTION
## Summary
- Adds `proxy_base_url` parameter through the entire interface chain (`BaseComputerInterface` → `GenericComputerInterface` → OS interfaces → `InterfaceFactory` → `Computer`).
- When set (automatically for `CloudProvider`), traffic is routed through the cloud API proxy:
  - **WebSocket**: `wss://api.cua.ai/v1/vms/{name}/ws` with `Authorization: Bearer` header
  - **HTTP**: `https://api.cua.ai/v1/vms/{name}/http/{path}` with `Authorization: Bearer` header
- Skips the WebSocket `authenticate` handshake in proxy mode (the proxy validates the key).
- Drops `X-API-Key` / `X-Container-Name` headers in proxy mode (not needed).
- `proxy_base_url` is derived from `CloudProvider.api_base` automatically — no user-facing API change.

## Why
Part of a multi-PR refactor. The cloud API service now validates workspace keys and proxies to computer-server. The SDK needs to talk to the proxy instead of directly to the VM.

## Stacked PR

> This PR is stacked on trycua/cua#1339 (`feature/cua-auth-disabled-flag`).
> Retarget to `main` after PR 1 merges.

## Test plan
- [ ] `python examples/sandboxes/test_linux_cloud_vm.py` works against staging with `CUA_API_BASE=https://api-staging.cua.ai`
- [ ] WebSocket connects via proxy without sending `authenticate` message
- [ ] HTTP `/cmd`, `/screen`, `/pty` work through proxy
- [ ] Existing non-cloud usage (local provider, Lume) unaffected (proxy_base_url is None)

## Rollout
This is **PR 4 of 4** (deploy order):
1. trycua/cua#1339 — computer-server no-auth gate ✅
2. trycua/cloud#3446 — API service proxy handler ✅
3. trycua/cloud#3448 — kopf-operator stops injecting CUA_API_KEY ✅
4. **This PR** — SDK repoint to proxy URL

## Not in scope
- TypeScript SDK changes (separate follow-up PR)
- `CUA_USE_DIRECT_VM` escape hatch (can add if needed during rollout)