### PR TITLE
fix(computer-server): accept SDK-supplied timeout in run_command

### DIFF
--- a/libs/python/computer-server/computer_server/handlers/android.py
+++ b/libs/python/computer-server/computer_server/handlers/android.py
@@ -687,8 +687,21 @@ class AndroidAutomationHandler(BaseAutomationHandler):
         success, output = await adb_exec.run("shell", script, decode=True)
         return {"success": success, "output": output}
 
-    async def run_command(self, command: str) -> Dict[str, Any]:
-        """Run a shell command inside the Android emulator via adb shell."""
+    async def run_command(
+        self, command: str, timeout: Optional[float] = None
+    ) -> Dict[str, Any]:
+        """Run a shell command inside the Android emulator via adb shell.
+
+        Args:
+            command: The shell command to run (inside the emulator, via adb).
+            timeout: Optional timeout in seconds.  When ``None`` (default),
+                waits indefinitely.  SDK callers propagate their
+                ``sb.shell.run(cmd, timeout=...)`` value here so long-running
+                Android commands (e.g. ``uiautomator dump`` on a heavy PWA
+                under concurrent emulator CPU contention) can be given a
+                realistic budget instead of being cut off by a server-side
+                hardcoded default.
+        """
         process = await asyncio.create_subprocess_exec(
             "adb",
             "-s",
@@ -698,7 +711,21 @@ class AndroidAutomationHandler(BaseAutomationHandler):
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        stdout, stderr = await process.communicate()
+        try:
+            if timeout is None:
+                stdout, stderr = await process.communicate()
+            else:
+                stdout, stderr = await asyncio.wait_for(
+                    process.communicate(), timeout=timeout
+                )
+        except asyncio.TimeoutError:
+            process.kill()
+            return {
+                "success": False,
+                "stdout": "",
+                "stderr": f"Command timed out after {timeout}s",
+                "return_code": -1,
+            }
         return {
             "success": process.returncode == 0,
             "stdout": stdout.decode() if stdout else "",

--- a/libs/python/computer-server/computer_server/handlers/base.py
+++ b/libs/python/computer-server/computer_server/handlers/base.py
@@ -377,11 +377,23 @@ class BaseAutomationHandler(ABC):
             return {"success": False, "error": str(e)}
 
     # Command Execution
-    async def run_command(self, command: str) -> Dict[str, Any]:
+    async def run_command(
+        self, command: str, timeout: Optional[float] = None
+    ) -> Dict[str, Any]:
         """Run a shell command locally and return its output.
 
         When IS_CUA_ANDROID env var is set, routes the command through
         ``adb shell`` so execution runs inside the Android emulator.
+
+        Args:
+            command: The shell command to run.
+            timeout: Optional timeout in seconds.  When ``None`` (default),
+                the command runs until completion with no upper bound.  SDK
+                callers set this via ``sb.shell.run(cmd, timeout=...)``
+                (see ``cua_sandbox.interfaces.shell.Shell.run``).  On
+                expiry the subprocess is killed and the result is
+                ``{"success": False, "stderr": "Command timed out after <t>s",
+                "return_code": -1}``.
         """
         import os
 
@@ -398,7 +410,21 @@ class BaseAutomationHandler(ABC):
                 process = await asyncio.create_subprocess_shell(
                     command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
                 )
-            stdout, stderr = await process.communicate()
+            try:
+                if timeout is None:
+                    stdout, stderr = await process.communicate()
+                else:
+                    stdout, stderr = await asyncio.wait_for(
+                        process.communicate(), timeout=timeout
+                    )
+            except asyncio.TimeoutError:
+                process.kill()
+                return {
+                    "success": False,
+                    "stdout": "",
+                    "stderr": f"Command timed out after {timeout}s",
+                    "return_code": -1,
+                }
             return {
                 "success": True,
                 "stdout": stdout.decode() if stdout else "",

--- a/libs/python/computer-server/computer_server/handlers/windows.py
+++ b/libs/python/computer-server/computer_server/handlers/windows.py
@@ -709,11 +709,16 @@ class WindowsAutomationHandler(BaseAutomationHandler):
     # Clipboard inherited from BaseAutomationHandler
 
     # Command Execution (Windows override for multi-encoding support)
-    async def run_command(self, command: str) -> Dict[str, Any]:
+    async def run_command(
+        self, command: str, timeout: Optional[float] = None
+    ) -> Dict[str, Any]:
         """Execute a shell command asynchronously.
 
         Args:
             command (str): The shell command to execute.
+            timeout (Optional[float]): Optional timeout in seconds.  When
+                ``None`` (default), waits indefinitely.  SDK callers set
+                this via ``sb.shell.run(cmd, timeout=...)``.
 
         Returns:
             Dict[str, Any]: A dictionary containing the success status and either
@@ -746,7 +751,21 @@ class WindowsAutomationHandler(BaseAutomationHandler):
                 process = await asyncio.create_subprocess_shell(
                     command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
                 )
-            stdout, stderr = await process.communicate()
+            try:
+                if timeout is None:
+                    stdout, stderr = await process.communicate()
+                else:
+                    stdout, stderr = await asyncio.wait_for(
+                        process.communicate(), timeout=timeout
+                    )
+            except asyncio.TimeoutError:
+                process.kill()
+                return {
+                    "success": False,
+                    "stdout": "",
+                    "stderr": f"Command timed out after {timeout}s",
+                    "return_code": -1,
+                }
             return {
                 "success": True,
                 "stdout": decode_output(stdout),

--- a/libs/python/computer-server/tests/test_run_command_timeout.py
+++ b/libs/python/computer-server/tests/test_run_command_timeout.py
@@ -1,0 +1,128 @@
+"""Tests for SDK-configurable ``run_command`` timeout propagation.
+
+The SDK's ``cua_sandbox.interfaces.shell.Shell.run(cmd, timeout=...)`` sends
+the timeout as a ``/cmd`` param; ``computer_server.main``'s dispatcher
+filters kwargs by the handler signature before forwarding.  These tests
+cover the handler-side contract:
+
+* handler accepts ``timeout`` as a float keyword
+* ``timeout=None`` → waits indefinitely
+* ``timeout=<float>`` → times out at expiry with a ``success=False`` result
+  containing the standardised ``Command timed out after <t>s`` stderr and
+  ``return_code=-1``
+
+The Android / Windows variants share the same shape; the base handler is
+exercised here because it exposes a POSIX subprocess without adb/emulator
+state being required for a focused unit test.
+"""
+
+import asyncio
+
+import pytest
+
+from computer_server.handlers.base import BaseAutomationHandler
+
+
+class _MinimalHandler(BaseAutomationHandler):
+    """Concrete BaseAutomationHandler with the abstract methods stubbed out."""
+
+    async def mouse_down(self, x=None, y=None, button="left"):  # pragma: no cover
+        return {}
+
+    async def mouse_up(self, x=None, y=None, button="left"):  # pragma: no cover
+        return {}
+
+    async def left_click(self, x=None, y=None):  # pragma: no cover
+        return {}
+
+    async def right_click(self, x=None, y=None):  # pragma: no cover
+        return {}
+
+    async def double_click(self, x=None, y=None):  # pragma: no cover
+        return {}
+
+    async def move_cursor(self, x, y):  # pragma: no cover
+        return {}
+
+    async def drag_to(self, x, y, button="left", duration=0.5):  # pragma: no cover
+        return {}
+
+    async def drag(self, path, button="left", duration=0.5):  # pragma: no cover
+        return {}
+
+    async def key_down(self, key):  # pragma: no cover
+        return {}
+
+    async def key_up(self, key):  # pragma: no cover
+        return {}
+
+    async def type_text(self, text):  # pragma: no cover
+        return {}
+
+    async def press_key(self, key):  # pragma: no cover
+        return {}
+
+    async def hotkey(self, *keys):  # pragma: no cover
+        return {}
+
+    async def scroll(self, x, y):  # pragma: no cover
+        return {}
+
+    async def scroll_down(self, clicks=1):  # pragma: no cover
+        return {}
+
+    async def scroll_up(self, clicks=1):  # pragma: no cover
+        return {}
+
+    async def get_cursor_position(self):  # pragma: no cover
+        return {}
+
+    async def get_screen_size(self):  # pragma: no cover
+        return {}
+
+    async def screenshot(self):  # pragma: no cover
+        return {}
+
+    async def copy_to_clipboard(self):  # pragma: no cover
+        return {}
+
+    async def set_clipboard(self, text):  # pragma: no cover
+        return {}
+
+
+class TestRunCommandTimeout:
+    @pytest.mark.asyncio
+    async def test_no_timeout_defaults_to_indefinite_wait(self, monkeypatch):
+        # Ensure we hit the subprocess_shell branch (not the android adb branch).
+        monkeypatch.delenv("IS_CUA_ANDROID", raising=False)
+        h = _MinimalHandler()
+
+        result = await h.run_command("echo hello")
+        assert result["success"] is True
+        assert result["stdout"].strip() == "hello"
+        assert result["return_code"] == 0
+
+    @pytest.mark.asyncio
+    async def test_timeout_honoured_when_passed(self, monkeypatch):
+        monkeypatch.delenv("IS_CUA_ANDROID", raising=False)
+        h = _MinimalHandler()
+
+        # sleep 5, cap at 0.2 — should time out
+        start = asyncio.get_event_loop().time()
+        result = await h.run_command("sleep 5", timeout=0.2)
+        elapsed = asyncio.get_event_loop().time() - start
+
+        assert result["success"] is False
+        assert "timed out" in result["stderr"].lower()
+        assert result["return_code"] == -1
+        # Must have returned within a small factor of the requested timeout.
+        assert elapsed < 2.0, f"expected quick timeout, took {elapsed:.2f}s"
+
+    @pytest.mark.asyncio
+    async def test_fast_command_under_timeout_succeeds(self, monkeypatch):
+        monkeypatch.delenv("IS_CUA_ANDROID", raising=False)
+        h = _MinimalHandler()
+
+        result = await h.run_command("echo done", timeout=10.0)
+        assert result["success"] is True
+        assert result["stdout"].strip() == "done"

--- a/libs/python/computer-server/tests/test_run_command_timeout.py
+++ b/libs/python/computer-server/tests/test_run_command_timeout.py
@@ -19,75 +19,20 @@ state being required for a focused unit test.
 import asyncio
 
 import pytest
-
 from computer_server.handlers.base import BaseAutomationHandler
 
 
 class _MinimalHandler(BaseAutomationHandler):
-    """Concrete BaseAutomationHandler with the abstract methods stubbed out."""
+    """Concrete BaseAutomationHandler for exercising ``run_command`` only.
 
-    async def mouse_down(self, x=None, y=None, button="left"):  # pragma: no cover
-        return {}
+    We clear ``__abstractmethods__`` instead of stubbing every abstract
+    method — the set changes as the interface grows (``middle_click`` was
+    added after these tests were first written) and keeping a mirror of
+    the full abstract surface here is pure maintenance overhead for a
+    test that only touches ``run_command``.
+    """
 
-    async def mouse_up(self, x=None, y=None, button="left"):  # pragma: no cover
-        return {}
-
-    async def left_click(self, x=None, y=None):  # pragma: no cover
-        return {}
-
-    async def right_click(self, x=None, y=None):  # pragma: no cover
-        return {}
-
-    async def double_click(self, x=None, y=None):  # pragma: no cover
-        return {}
-
-    async def move_cursor(self, x, y):  # pragma: no cover
-        return {}
-
-    async def drag_to(self, x, y, button="left", duration=0.5):  # pragma: no cover
-        return {}
-
-    async def drag(self, path, button="left", duration=0.5):  # pragma: no cover
-        return {}
-
-    async def key_down(self, key):  # pragma: no cover
-        return {}
-
-    async def key_up(self, key):  # pragma: no cover
-        return {}
-
-    async def type_text(self, text):  # pragma: no cover
-        return {}
-
-    async def press_key(self, key):  # pragma: no cover
-        return {}
-
-    async def hotkey(self, *keys):  # pragma: no cover
-        return {}
-
-    async def scroll(self, x, y):  # pragma: no cover
-        return {}
-
-    async def scroll_down(self, clicks=1):  # pragma: no cover
-        return {}
-
-    async def scroll_up(self, clicks=1):  # pragma: no cover
-        return {}
-
-    async def get_cursor_position(self):  # pragma: no cover
-        return {}
-
-    async def get_screen_size(self):  # pragma: no cover
-        return {}
-
-    async def screenshot(self):  # pragma: no cover
-        return {}
-
-    async def copy_to_clipboard(self):  # pragma: no cover
-        return {}
-
-    async def set_clipboard(self, text):  # pragma: no cover
-        return {}
+    __abstractmethods__ = frozenset()
 
 
 class TestRunCommandTimeout:

--- a/libs/python/computer-server/tests/test_run_command_timeout.py
+++ b/libs/python/computer-server/tests/test_run_command_timeout.py
@@ -25,14 +25,21 @@ from computer_server.handlers.base import BaseAutomationHandler
 class _MinimalHandler(BaseAutomationHandler):
     """Concrete BaseAutomationHandler for exercising ``run_command`` only.
 
-    We clear ``__abstractmethods__`` instead of stubbing every abstract
-    method — the set changes as the interface grows (``middle_click`` was
-    added after these tests were first written) and keeping a mirror of
-    the full abstract surface here is pure maintenance overhead for a
-    test that only touches ``run_command``.
+    We clear ``__abstractmethods__`` AFTER class creation (below) instead
+    of stubbing every abstract method — the set changes as the interface
+    grows and keeping a mirror of the full abstract surface here is pure
+    maintenance overhead for a test that only touches ``run_command``.
+
+    Note: setting ``__abstractmethods__ = frozenset()`` inside the class
+    body does NOT work — Python's ``ABCMeta`` overwrites it during class
+    creation.  The override must happen after the class statement.
     """
 
-    __abstractmethods__ = frozenset()
+    pass
+
+
+# Bypass ABC enforcement — ABCMeta.__call__ checks this at instantiation time.
+_MinimalHandler.__abstractmethods__ = frozenset()
 
 
 class TestRunCommandTimeout:


### PR DESCRIPTION
## Summary
Make the subprocess timeout for `run_command` driven by the SDK instead of being silently dropped.

## Motivation
The SDK already passes a timeout over the wire:
```python
# cua_sandbox/interfaces/shell.py:44
result = await self._t.send("run_command", command=command, timeout=timeout)
```
But `main.py`'s `/cmd` dispatcher filters kwargs by the handler signature (`inspect.signature`, main.py:573-574) before forwarding. Since `AutomationHandler.run_command(self, command)` didn't accept a `timeout` parameter, the value was filtered out — the SDK's 30 s default (and any caller override) had no effect. The subprocess would then wait indefinitely for `adb` / shell completion.

This surfaced during a N=25 Android matrix test where `uiautomator dump` + `cat /sdcard/ui.xml` routinely exceeded any reasonable budget under concurrent emulator CPU contention on incus-2 (SwiftShader is software-GPU-bound; 25 emulators competing for shared host cycles → slow adb round-trips) — failures presented as "command hangs forever" on the test side, with no server-side cutoff to produce a clean error.

## Changes
- `BaseAutomationHandler.run_command(self, command, timeout=None)` — `asyncio.wait_for(process.communicate(), timeout=timeout)` when `timeout` is set; kills the subprocess on expiry and returns `{"success": False, "stderr": "Command timed out after <t>s", "return_code": -1}`.
- `AndroidAutomationHandler.run_command` — same, over `adb -s emulator-5554 shell`.
- `WindowsAutomationHandler.run_command` — same, preserving the existing `decode_output()` multi-encoding fallback.

`timeout=None` keeps the pre-fix "wait forever" semantics for callers that don't set one. The SDK always sets one (transport default 30 s) — so this PR is what makes that SDK-side timeout actually honored.

## Out of scope
Two other internal adb paths still use `CommandExecutor`'s hardcoded 10 s default and don't accept an SDK-supplied timeout yet:
- `AndroidFileHandler.write_bytes` → `adb_exec.run("push", ...)` (this is what produces `RuntimeError: Remote error: Failed to write bytes: b'Command timed out after 10s'` during PWA install under concurrency)
- `AccessibilityHandler.get_accessibility_tree` → `adb_exec.run("shell", "uiautomator dump … && cat …")`

Both need a coordinated SDK change (new `timeout=` arg on the Files / Accessibility interfaces) — tracking as a follow-up.

## Tests
`tests/test_run_command_timeout.py` exercises the base handler via a minimal concrete subclass:
- `test_no_timeout_defaults_to_indefinite_wait` — `timeout=None` (default) still waits for the subprocess; fast command succeeds cleanly.
- `test_timeout_honoured_when_passed` — `sleep 5, timeout=0.2` returns `success=False`, `return_code=-1`, `stderr` contains "timed out", and elapsed wall time stays under ~2s.
- `test_fast_command_under_timeout_succeeds` — command that finishes well before the timeout still returns `success=True` with expected stdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Command execution now supports an optional timeout parameter. Operations exceeding the specified duration are automatically terminated, returning a failure result with timeout-specific error details.

* **Tests**
  * Added comprehensive test coverage for timeout functionality across supported command execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->