### PR TITLE
fix(sdk): surface stderr/return_code in _parse_sse error path

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/transport/http.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/http.py
@@ -68,12 +68,52 @@ class HTTPTransport(Transport):
 
     @staticmethod
     def _parse_sse(text: str) -> Dict[str, Any]:
-        """Extract the first ``data: {...}`` frame from an SSE response."""
+        """Extract the first ``data: {...}`` frame from an SSE response.
+
+        The server returns one of two failure shapes when ``success`` is
+        false:
+
+        1. Generic handler error — ``{"success": false, "error": "<msg>"}``
+        2. Shell-command shape — ``{"success": false, "stdout": "...",
+           "stderr": "...", "return_code": <n>}`` (no ``error`` key)
+
+        The old code stringified ``payload.get('error', 'unknown')`` for
+        both shapes, which turned every shell-command failure into
+        ``Remote error: unknown`` and hid the actual ``stderr`` + exit
+        code.  That masking made ``Command timed out after 10s``,
+        ``UI hierchary dump failed``, and similar concrete failures
+        indistinguishable from a genuine internal error — the common
+        pattern where ``await sb.shell.run(cmd)`` returned non-zero
+        became a debugging dead end.
+
+        This rewrite preserves the ``error``-key path verbatim and falls
+        back to a composite ``return_code=...`` / ``stderr=...`` /
+        ``stdout=...`` string when no ``error`` key is present.
+        """
         for line in text.splitlines():
             if line.startswith("data: "):
                 payload = json.loads(line[6:])
                 if isinstance(payload, dict) and not payload.get("success", True):
-                    raise RuntimeError(f"Remote error: {payload.get('error', 'unknown')}")
+                    err = payload.get("error")
+                    if err:
+                        raise RuntimeError(f"Remote error: {err}")
+                    # Shell-command shape: surface return_code/stderr/stdout.
+                    parts = []
+                    rc = payload.get("return_code")
+                    if rc is not None:
+                        parts.append(f"return_code={rc}")
+                    stderr = (payload.get("stderr") or "").strip()
+                    if stderr:
+                        parts.append(f"stderr={stderr!r}")
+                    stdout = (payload.get("stdout") or "").strip()
+                    if stdout and not stderr:
+                        # Only surface stdout when there's nothing on
+                        # stderr — saves bloating the message for noisy
+                        # successful-output commands that happened to
+                        # return non-zero.
+                        parts.append(f"stdout={stdout!r}")
+                    detail = ", ".join(parts) or "no detail"
+                    raise RuntimeError(f"Remote error: {detail}")
                 return payload
         raise RuntimeError(f"No SSE data frame in response: {text[:200]}")
 

--- a/libs/python/cua-sandbox/cua_sandbox/transport/http.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/http.py
@@ -94,9 +94,8 @@ class HTTPTransport(Transport):
             if line.startswith("data: "):
                 payload = json.loads(line[6:])
                 if isinstance(payload, dict) and not payload.get("success", True):
-                    err = payload.get("error")
-                    if err:
-                        raise RuntimeError(f"Remote error: {err}")
+                    if "error" in payload:
+                        raise RuntimeError(f"Remote error: {payload['error']}")
                     # Shell-command shape: surface return_code/stderr/stdout.
                     parts = []
                     rc = payload.get("return_code")

--- a/libs/python/cua-sandbox/tests/test_parse_sse.py
+++ b/libs/python/cua-sandbox/tests/test_parse_sse.py
@@ -1,0 +1,93 @@
+"""Unit tests for ``HTTPTransport._parse_sse`` — the error-surfacing path.
+
+When the server returns ``{"success": false, ...}``, ``_parse_sse`` raises
+``RuntimeError`` with a message derived from the payload.  The previous
+implementation stringified ``payload.get('error', 'unknown')``, which
+turned every shell-command failure (``{"success": false, "stdout": "",
+"stderr": "Command timed out after 10s", "return_code": 1}``) into the
+opaque ``Remote error: unknown`` — hiding the actual cause.
+
+These tests pin the new behavior:
+  * explicit ``error`` key still wins
+  * shell-command shape surfaces ``return_code`` + ``stderr``
+  * stdout only appears as a fallback when stderr is empty
+  * successful payloads pass through unchanged
+  * an SSE stream with no data frame raises a parseable error
+"""
+
+import pytest
+
+from cua_sandbox.transport.http import HTTPTransport
+
+
+def _sse(obj: str) -> str:
+    """Wrap a JSON payload in a single SSE data frame."""
+    return f"data: {obj}\n\n"
+
+
+class TestParseSSESurfacesFailures:
+    def test_success_payload_returned_unchanged(self):
+        out = HTTPTransport._parse_sse(_sse('{"success": true, "result": 42}'))
+        assert out == {"success": True, "result": 42}
+
+    def test_explicit_error_field_preserved_verbatim(self):
+        with pytest.raises(RuntimeError, match=r"Remote error: boom"):
+            HTTPTransport._parse_sse(
+                _sse('{"success": false, "error": "boom"}')
+            )
+
+    def test_shell_failure_surfaces_return_code_and_stderr(self):
+        with pytest.raises(RuntimeError) as exc:
+            HTTPTransport._parse_sse(
+                _sse(
+                    '{"success": false, "stdout": "", '
+                    '"stderr": "Command timed out after 10s", '
+                    '"return_code": 1}'
+                )
+            )
+        msg = str(exc.value)
+        assert "Remote error:" in msg
+        assert "return_code=1" in msg
+        assert "Command timed out after 10s" in msg
+
+    def test_shell_failure_uses_stdout_only_when_stderr_empty(self):
+        with pytest.raises(RuntimeError) as exc:
+            HTTPTransport._parse_sse(
+                _sse(
+                    '{"success": false, "stdout": "partial progress", '
+                    '"stderr": "", "return_code": 137}'
+                )
+            )
+        msg = str(exc.value)
+        assert "return_code=137" in msg
+        assert "partial progress" in msg
+
+    def test_shell_failure_stdout_not_added_when_stderr_present(self):
+        """stderr wins over stdout when both are non-empty — avoids bloating
+        the message with noisy successful-command output that happened to
+        return non-zero."""
+        with pytest.raises(RuntimeError) as exc:
+            HTTPTransport._parse_sse(
+                _sse(
+                    '{"success": false, '
+                    '"stdout": "UI hierchary dumped to: /sdcard/ui.xml\\n", '
+                    '"stderr": "Killed", "return_code": 137}'
+                )
+            )
+        msg = str(exc.value)
+        assert "Killed" in msg
+        assert "return_code=137" in msg
+        assert "UI hierchary dumped" not in msg  # stdout suppressed
+
+    def test_shell_failure_with_no_detail_falls_back_cleanly(self):
+        with pytest.raises(RuntimeError, match=r"Remote error: no detail"):
+            HTTPTransport._parse_sse(_sse('{"success": false}'))
+
+    def test_missing_data_frame_raises(self):
+        with pytest.raises(RuntimeError, match=r"No SSE data frame"):
+            HTTPTransport._parse_sse("event: ping\n\n")
+
+    def test_ignores_content_before_data_line(self):
+        text = ":comment\nevent: message\ndata: " + '{"success": true, "ok": 1}' + "\n\n"
+        out = HTTPTransport._parse_sse(text)
+        assert out == {"success": True, "ok": 1}


### PR DESCRIPTION
## Summary
`HTTPTransport._parse_sse` previously stringified `payload.get('error', 'unknown')` for every failure payload. Shell-command handlers return `{"success": false, "stdout": ..., "stderr": ..., "return_code": N}` — no `error` key — so **every** shell-command failure surfaced as the literal opaque string `Remote error: unknown`, hiding the actual stderr and exit code that were already in the payload.

## Observed failure mode

From the dispatch matrix N=10 run (log tail of a failing shard):
```
text = 'data: {"success": false, "stdout": "UI hierchary dumped to: /sdcard/ui.xml\\n", "stderr": "Killed ", "return_code": 137}\n\n'
...
E   RuntimeError: Remote error: unknown
```

That `137` + `stderr: "Killed"` is the entire story (android OOM killed the process mid-`uiautomator dump`). The SDK turned it into `"unknown"`, which then rippled through triage as "some opaque server-side issue" when it was actually a legible `return_code=137 + stderr=Killed`.

## Change
When `payload.get("success")` is falsy AND there's no `error` key, compose the message from what IS in the payload:
* `return_code=<n>` if present
* `stderr=<repr>` if non-empty
* `stdout=<repr>` **fallback only when stderr is empty** (avoids bloating the message with noisy successful-command output that happened to return non-zero — e.g. `uiautomator dump`'s "UI hierchary dumped to: /sdcard/ui.xml" prefix would swamp a short stderr like "Killed" otherwise)
* `no detail` when the payload is entirely empty

The `error`-key path is preserved verbatim — no behavior change for handlers that return a structured error string (`{"success": false, "error": "boom"}`).

## Tests
`libs/python/cua-sandbox/tests/test_parse_sse.py` — 8 cases, all passing:
1. Success payload returned unchanged
2. Explicit `error` key preserved verbatim
3. Shell failure surfaces `return_code` + `stderr`
4. Stdout fallback only when stderr is empty
5. Stderr wins when both are set (stdout suppressed)
6. Empty-detail payload → `Remote error: no detail`
7. Missing data frame raises the parse-level error
8. SSE comments + event lines before data are ignored

Local run:
```
============================== 8 passed in 0.03s ==============================
```

## Related work
This is one of three independent PRs addressing "Mode B" instability observed on `dispatch-test-amazon-agi-slackgym-pwa-sequence-matrix.yml`:
- trycua/cua#1343 — SDK-configurable `run_command` timeout on computer-server
- trycua/cloud#3483 — bump android VM `_ANDROID_CPU_LIMIT` 2 → 4 vCPUs
- **this PR** — stop masking the error when the cause is already in the payload

The failure modes each fix is meant to surface become actually diagnosable after this PR merges — which is also why it's valuable in isolation, even if the underlying bugs stay unresolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for HTTP responses, now providing detailed error messages with relevant diagnostics such as return codes and error output.

* **Tests**
  * Added comprehensive test suite to validate response parsing behavior and error handling accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->