### PR TITLE
feat(ci): matrix periodic test over multiple API key secrets

### DIFF
--- a/.github/workflows/periodic-test-linux-cloud-vm.yml
+++ b/.github/workflows/periodic-test-linux-cloud-vm.yml
@@ -10,12 +10,24 @@ on:
 
 jobs:
   test:
-    name: Test Linux Cloud VM
+    name: Test Linux Cloud VM (${{ matrix.secret_name }})
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        secret_name:
+          - PERIODIC_TEST_CUA_API_KEY
+          - PERIODIC_TEST_CUA_API_KEY_BASALT
+
     steps:
-      - name: Checkout code
+      - name: Checkout latest main
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: main
+
+      - name: Create test branch
+        run: git checkout -b periodic-test/${{ matrix.secret_name }}/${{ github.run_id }}
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -28,7 +40,7 @@ jobs:
       - name: Run test
         run: python -m pytest examples/sandboxes/test_linux_cloud_vm.py
         env:
-          CUA_API_KEY: ${{ secrets.PERIODIC_TEST_CUA_API_KEY }}
+          CUA_API_KEY: ${{ secrets[matrix.secret_name] }}
 
       - name: Alert Alertmanager on failure
         if: failure()
@@ -40,11 +52,12 @@ jobs:
                 "alertname": "PeriodicTestLinuxCloudVMFailed",
                 "severity": "critical",
                 "service": "cua-sdk",
-                "job": "periodic-test-linux-cloud-vm"
+                "job": "periodic-test-linux-cloud-vm",
+                "secret": "${{ matrix.secret_name }}"
               },
               "annotations": {
-                "summary": "Periodic Linux Cloud VM test failed",
-                "description": "GitHub Actions workflow \"Periodic: Test Linux Cloud VM\" failed. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                "summary": "Periodic Linux Cloud VM test failed (${{ matrix.secret_name }})",
+                "description": "GitHub Actions workflow \"Periodic: Test Linux Cloud VM\" failed for ${{ matrix.secret_name }}. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
                 "dashboard": "https://github.com/${{ github.repository }}/actions/workflows/periodic-test-linux-cloud-vm.yml"
               },
               "generatorURL": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## Summary
- Convert periodic Linux Cloud VM test to use a matrix strategy over multiple GitHub secrets
- Each secret runs as a parallel job, with `fail-fast: false` so one failure doesn't cancel others
- Adds `PERIODIC_TEST_CUA_API_KEY_BASALT` as a second test key
- Always checks out latest `main` for test runs

## Test plan
- [ ] Add `PERIODIC_TEST_CUA_API_KEY_BASALT` secret in repo settings
- [ ] Verify both matrix jobs run in parallel on next scheduled trigger or manual dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced periodic testing infrastructure to validate against multiple configurations, improving test coverage with expanded failure reporting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->