### PR TITLE
feat(sandbox): add timeout parameter to Sandbox.create/ephemeral

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -407,7 +407,7 @@ class Sandbox:
         memory_mb: Optional[int] = None,
         disk_gb: Optional[int] = None,
         region: str = "us-east-1",
-        timeout: Optional[float] = None,
+        time_to_start: Optional[float] = None,
         telemetry_enabled: bool = True,
     ) -> "Sandbox":
         """Provision a new persistent sandbox and return it connected.
@@ -426,7 +426,7 @@ class Sandbox:
             memory_mb: Memory in MB for the cloud sandbox.
             disk_gb: Disk size in GB for the cloud sandbox.
             region: Cloud region (default ``"us-east-1"``).
-            timeout: Max seconds to wait for the VM to become reachable
+            time_to_start: Max seconds to wait for the VM to become reachable
                 (default 600). Only applies to cloud sandboxes.
             telemetry_enabled: Set to False to disable telemetry for this instance.
 
@@ -448,7 +448,7 @@ class Sandbox:
             memory_mb=memory_mb,
             disk_gb=disk_gb,
             region=region,
-            timeout=timeout,
+            time_to_start=time_to_start,
             telemetry_enabled=telemetry_enabled,
         )
 
@@ -525,7 +525,7 @@ class Sandbox:
         memory_mb: Optional[int] = None,
         disk_gb: Optional[int] = None,
         region: str = "us-east-1",
-        timeout: Optional[float] = None,
+        time_to_start: Optional[float] = None,
         telemetry_enabled: bool = True,
     ) -> AsyncIterator["Sandbox"]:
         """Create an ephemeral sandbox that is automatically destroyed on exit.
@@ -540,7 +540,7 @@ class Sandbox:
             memory_mb: Memory in MB for the cloud sandbox.
             disk_gb: Disk size in GB for the cloud sandbox.
             region: Cloud region (default ``"us-east-1"``).
-            timeout: Max seconds to wait for the VM to become reachable
+            time_to_start: Max seconds to wait for the VM to become reachable
                 (default 600). Only applies to cloud sandboxes.
 
         Example::
@@ -560,7 +560,7 @@ class Sandbox:
             memory_mb=memory_mb,
             disk_gb=disk_gb,
             region=region,
-            timeout=timeout,
+            time_to_start=time_to_start,
             telemetry_enabled=telemetry_enabled,
         )
         try:
@@ -974,7 +974,7 @@ class Sandbox:
         memory_mb: Optional[int] = None,
         disk_gb: Optional[int] = None,
         region: str = "us-east-1",
-        timeout: Optional[float] = None,
+        time_to_start: Optional[float] = None,
         telemetry_enabled: bool = True,
     ) -> "Sandbox":
         """Internal workhorse — all public factories delegate here."""
@@ -1040,7 +1040,7 @@ class Sandbox:
                     memory_mb=memory_mb,
                     disk_gb=disk_gb,
                     region=region,
-                    timeout=timeout,
+                    time_to_start=time_to_start,
                 )
                 sb = cls(
                     transport, name=name, _ephemeral=ephemeral, _telemetry_enabled=telemetry_enabled

--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -407,6 +407,7 @@ class Sandbox:
         memory_mb: Optional[int] = None,
         disk_gb: Optional[int] = None,
         region: str = "us-east-1",
+        timeout: Optional[float] = None,
         telemetry_enabled: bool = True,
     ) -> "Sandbox":
         """Provision a new persistent sandbox and return it connected.
@@ -425,6 +426,8 @@ class Sandbox:
             memory_mb: Memory in MB for the cloud sandbox.
             disk_gb: Disk size in GB for the cloud sandbox.
             region: Cloud region (default ``"us-east-1"``).
+            timeout: Max seconds to wait for the VM to become reachable
+                (default 600). Only applies to cloud sandboxes.
             telemetry_enabled: Set to False to disable telemetry for this instance.
 
         Example::
@@ -445,6 +448,7 @@ class Sandbox:
             memory_mb=memory_mb,
             disk_gb=disk_gb,
             region=region,
+            timeout=timeout,
             telemetry_enabled=telemetry_enabled,
         )
 
@@ -521,6 +525,7 @@ class Sandbox:
         memory_mb: Optional[int] = None,
         disk_gb: Optional[int] = None,
         region: str = "us-east-1",
+        timeout: Optional[float] = None,
         telemetry_enabled: bool = True,
     ) -> AsyncIterator["Sandbox"]:
         """Create an ephemeral sandbox that is automatically destroyed on exit.
@@ -535,6 +540,8 @@ class Sandbox:
             memory_mb: Memory in MB for the cloud sandbox.
             disk_gb: Disk size in GB for the cloud sandbox.
             region: Cloud region (default ``"us-east-1"``).
+            timeout: Max seconds to wait for the VM to become reachable
+                (default 600). Only applies to cloud sandboxes.
 
         Example::
 
@@ -553,6 +560,7 @@ class Sandbox:
             memory_mb=memory_mb,
             disk_gb=disk_gb,
             region=region,
+            timeout=timeout,
             telemetry_enabled=telemetry_enabled,
         )
         try:
@@ -966,6 +974,7 @@ class Sandbox:
         memory_mb: Optional[int] = None,
         disk_gb: Optional[int] = None,
         region: str = "us-east-1",
+        timeout: Optional[float] = None,
         telemetry_enabled: bool = True,
     ) -> "Sandbox":
         """Internal workhorse — all public factories delegate here."""
@@ -1031,6 +1040,7 @@ class Sandbox:
                     memory_mb=memory_mb,
                     disk_gb=disk_gb,
                     region=region,
+                    timeout=timeout,
                 )
                 sb = cls(
                     transport, name=name, _ephemeral=ephemeral, _telemetry_enabled=telemetry_enabled

--- a/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
@@ -41,7 +41,7 @@ class CloudTransport(Transport):
         memory_mb: Optional[int] = None,
         disk_gb: Optional[int] = None,
         region: str = "us-east-1",
-        timeout: Optional[float] = None,
+        time_to_start: Optional[float] = None,
     ):
         self._name = name
         self._api_key_override = api_key
@@ -51,7 +51,7 @@ class CloudTransport(Transport):
         self._memory_mb = memory_mb
         self._disk_gb = disk_gb
         self._region = region
-        self._timeout = timeout if timeout is not None else _POLL_TIMEOUT
+        self._time_to_start = time_to_start if time_to_start is not None else _POLL_TIMEOUT
         self._inner: Optional[HTTPTransport] = None
         self._api_client: Optional[httpx.AsyncClient] = None
 
@@ -104,7 +104,7 @@ class CloudTransport(Transport):
             cs_url = ""
             is_running = vm_info.get("status") in ("running", "ready")
 
-            while elapsed < self._timeout:
+            while elapsed < self._time_to_start:
                 # Try to extract a direct-IP endpoint from current vm_info
                 try:
                     url = self._resolve_endpoint(vm_info)
@@ -123,7 +123,7 @@ class CloudTransport(Transport):
 
             if not is_running:
                 raise TimeoutError(
-                    f"VM {self._name!r} did not become running within {self._timeout}s "
+                    f"VM {self._name!r} did not become running within {self._time_to_start}s "
                     f"(last status: {vm_info.get('status')})"
                 )
             if not cs_url:
@@ -155,7 +155,7 @@ class CloudTransport(Transport):
             elapsed = 0.0
             is_running = vm_info.get("status") in ("running", "ready")
 
-            while elapsed < self._timeout:
+            while elapsed < self._time_to_start:
                 # Try to extract a direct-IP endpoint
                 try:
                     url = self._resolve_endpoint(vm_info)
@@ -180,7 +180,7 @@ class CloudTransport(Transport):
 
             if not is_running:
                 raise TimeoutError(
-                    f"VM {self._name!r} did not become running within {self._timeout}s "
+                    f"VM {self._name!r} did not become running within {self._time_to_start}s "
                     f"(last status: {vm_info.get('status')})"
                 )
             url = resolved_url or self._resolve_endpoint(vm_info)
@@ -377,9 +377,9 @@ class CloudTransport(Transport):
         """Poll until the VM status is 'running' (or 'ready')."""
         elapsed = 0.0
         while vm_info.get("status") not in ("running", "ready"):
-            if elapsed >= self._timeout:
+            if elapsed >= self._time_to_start:
                 raise TimeoutError(
-                    f"VM {self._name!r} did not become running within {self._timeout}s "
+                    f"VM {self._name!r} did not become running within {self._time_to_start}s "
                     f"(last status: {vm_info.get('status')})"
                 )
             await asyncio.sleep(_POLL_INTERVAL)
@@ -404,7 +404,7 @@ class CloudTransport(Transport):
 
         # Phase 1: wait for HTTP port to accept connections (fast — just needs
         # the Python process to start, not the emulator).
-        while elapsed < self._timeout:
+        while elapsed < self._time_to_start:
             try:
                 resp = await self._inner._client.get("/", timeout=2.0)
                 # Any response means the server is up
@@ -429,7 +429,7 @@ class CloudTransport(Transport):
             pass  # Fall through to Phase 2
 
         # Phase 2: wait for get_screen_size (needs emulator/display running)
-        while elapsed < self._timeout:
+        while elapsed < self._time_to_start:
             try:
                 await self._inner.get_screen_size()
                 return  # Fully ready
@@ -446,7 +446,7 @@ class CloudTransport(Transport):
                 await asyncio.sleep(_POLL_INTERVAL)
                 elapsed += _POLL_INTERVAL
         raise TimeoutError(
-            f"Computer-server for VM {self._name!r} not reachable within {self._timeout}s: {last_err}"
+            f"Computer-server for VM {self._name!r} not reachable within {self._time_to_start}s: {last_err}"
         )
 
     async def _apply_image_layers(self) -> None:

--- a/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
@@ -41,6 +41,7 @@ class CloudTransport(Transport):
         memory_mb: Optional[int] = None,
         disk_gb: Optional[int] = None,
         region: str = "us-east-1",
+        timeout: Optional[float] = None,
     ):
         self._name = name
         self._api_key_override = api_key
@@ -50,6 +51,7 @@ class CloudTransport(Transport):
         self._memory_mb = memory_mb
         self._disk_gb = disk_gb
         self._region = region
+        self._timeout = timeout if timeout is not None else _POLL_TIMEOUT
         self._inner: Optional[HTTPTransport] = None
         self._api_client: Optional[httpx.AsyncClient] = None
 
@@ -102,7 +104,7 @@ class CloudTransport(Transport):
             cs_url = ""
             is_running = vm_info.get("status") in ("running", "ready")
 
-            while elapsed < _POLL_TIMEOUT:
+            while elapsed < self._timeout:
                 # Try to extract a direct-IP endpoint from current vm_info
                 try:
                     url = self._resolve_endpoint(vm_info)
@@ -121,7 +123,7 @@ class CloudTransport(Transport):
 
             if not is_running:
                 raise TimeoutError(
-                    f"VM {self._name!r} did not become running within {_POLL_TIMEOUT}s "
+                    f"VM {self._name!r} did not become running within {self._timeout}s "
                     f"(last status: {vm_info.get('status')})"
                 )
             if not cs_url:
@@ -153,7 +155,7 @@ class CloudTransport(Transport):
             elapsed = 0.0
             is_running = vm_info.get("status") in ("running", "ready")
 
-            while elapsed < _POLL_TIMEOUT:
+            while elapsed < self._timeout:
                 # Try to extract a direct-IP endpoint
                 try:
                     url = self._resolve_endpoint(vm_info)
@@ -178,7 +180,7 @@ class CloudTransport(Transport):
 
             if not is_running:
                 raise TimeoutError(
-                    f"VM {self._name!r} did not become running within {_POLL_TIMEOUT}s "
+                    f"VM {self._name!r} did not become running within {self._timeout}s "
                     f"(last status: {vm_info.get('status')})"
                 )
             url = resolved_url or self._resolve_endpoint(vm_info)
@@ -375,9 +377,9 @@ class CloudTransport(Transport):
         """Poll until the VM status is 'running' (or 'ready')."""
         elapsed = 0.0
         while vm_info.get("status") not in ("running", "ready"):
-            if elapsed >= _POLL_TIMEOUT:
+            if elapsed >= self._timeout:
                 raise TimeoutError(
-                    f"VM {self._name!r} did not become running within {_POLL_TIMEOUT}s "
+                    f"VM {self._name!r} did not become running within {self._timeout}s "
                     f"(last status: {vm_info.get('status')})"
                 )
             await asyncio.sleep(_POLL_INTERVAL)
@@ -402,7 +404,7 @@ class CloudTransport(Transport):
 
         # Phase 1: wait for HTTP port to accept connections (fast — just needs
         # the Python process to start, not the emulator).
-        while elapsed < _POLL_TIMEOUT:
+        while elapsed < self._timeout:
             try:
                 resp = await self._inner._client.get("/", timeout=2.0)
                 # Any response means the server is up
@@ -427,7 +429,7 @@ class CloudTransport(Transport):
             pass  # Fall through to Phase 2
 
         # Phase 2: wait for get_screen_size (needs emulator/display running)
-        while elapsed < _POLL_TIMEOUT:
+        while elapsed < self._timeout:
             try:
                 await self._inner.get_screen_size()
                 return  # Fully ready
@@ -444,7 +446,7 @@ class CloudTransport(Transport):
                 await asyncio.sleep(_POLL_INTERVAL)
                 elapsed += _POLL_INTERVAL
         raise TimeoutError(
-            f"Computer-server for VM {self._name!r} not reachable within {_POLL_TIMEOUT}s: {last_err}"
+            f"Computer-server for VM {self._name!r} not reachable within {self._timeout}s: {last_err}"
         )
 
     async def _apply_image_layers(self) -> None:


### PR DESCRIPTION
## Summary
- Adds a `timeout` parameter to `Sandbox.create()`, `Sandbox.ephemeral()`, and `CloudTransport`
- Default remains 600s (no behavior change for existing callers)
- Replaces hardcoded `_POLL_TIMEOUT` module constant with per-instance `self._timeout` in all poll loops

## Motivation
When a server-side concurrency gate queues VM creates (e.g. kopf operator limiting concurrent boots), later VMs can spend several minutes in the queue before provisioning starts. The fixed 600s timeout doesn't account for this queuing delay, causing `TimeoutError: Computer-server for VM not reachable within 600.0s` even though the VM would eventually come up.

## Usage
\`\`\`python
# Raise timeout for workloads with known queuing delay
async with Sandbox.ephemeral(image, timeout=900) as sb:
    ...
\`\`\`

## Test plan
- [ ] Verify default behavior unchanged (no timeout arg = 600s)
- [ ] Verify custom timeout is respected by CloudTransport poll loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable timeout parameter to sandbox creation methods, allowing customization of the maximum wait duration for cloud VM provisioning (default 600 seconds).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->