### PR TITLE
fix(sandbox): sync httpx client timeout with server-side timeout

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -430,9 +430,9 @@ class Sandbox:
             time_to_start: Max seconds to wait for the VM to become reachable
                 (default 600). Only applies to cloud sandboxes.
             request_timeout: Default HTTP request timeout in seconds for
-                commands sent to the computer-server (default 30). Individual
-                commands with a server-side timeout automatically extend the
-                client timeout to match.
+                commands sent to the computer-server (default 30, cloud only).
+                Individual commands with a server-side timeout automatically
+                extend the client timeout to match.
             telemetry_enabled: Set to False to disable telemetry for this instance.
 
         Example::
@@ -550,9 +550,9 @@ class Sandbox:
             time_to_start: Max seconds to wait for the VM to become reachable
                 (default 600). Only applies to cloud sandboxes.
             request_timeout: Default HTTP request timeout in seconds for
-                commands sent to the computer-server (default 30). Individual
-                commands with a server-side timeout automatically extend the
-                client timeout to match.
+                commands sent to the computer-server (default 30, cloud only).
+                Individual commands with a server-side timeout automatically
+                extend the client timeout to match.
 
         Example::
 

--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -408,6 +408,7 @@ class Sandbox:
         disk_gb: Optional[int] = None,
         region: str = "us-east-1",
         time_to_start: Optional[float] = None,
+        request_timeout: Optional[float] = None,
         telemetry_enabled: bool = True,
     ) -> "Sandbox":
         """Provision a new persistent sandbox and return it connected.
@@ -428,6 +429,10 @@ class Sandbox:
             region: Cloud region (default ``"us-east-1"``).
             time_to_start: Max seconds to wait for the VM to become reachable
                 (default 600). Only applies to cloud sandboxes.
+            request_timeout: Default HTTP request timeout in seconds for
+                commands sent to the computer-server (default 30). Individual
+                commands with a server-side timeout automatically extend the
+                client timeout to match.
             telemetry_enabled: Set to False to disable telemetry for this instance.
 
         Example::
@@ -449,6 +454,7 @@ class Sandbox:
             disk_gb=disk_gb,
             region=region,
             time_to_start=time_to_start,
+            request_timeout=request_timeout,
             telemetry_enabled=telemetry_enabled,
         )
 
@@ -526,6 +532,7 @@ class Sandbox:
         disk_gb: Optional[int] = None,
         region: str = "us-east-1",
         time_to_start: Optional[float] = None,
+        request_timeout: Optional[float] = None,
         telemetry_enabled: bool = True,
     ) -> AsyncIterator["Sandbox"]:
         """Create an ephemeral sandbox that is automatically destroyed on exit.
@@ -542,6 +549,10 @@ class Sandbox:
             region: Cloud region (default ``"us-east-1"``).
             time_to_start: Max seconds to wait for the VM to become reachable
                 (default 600). Only applies to cloud sandboxes.
+            request_timeout: Default HTTP request timeout in seconds for
+                commands sent to the computer-server (default 30). Individual
+                commands with a server-side timeout automatically extend the
+                client timeout to match.
 
         Example::
 
@@ -561,6 +572,7 @@ class Sandbox:
             disk_gb=disk_gb,
             region=region,
             time_to_start=time_to_start,
+            request_timeout=request_timeout,
             telemetry_enabled=telemetry_enabled,
         )
         try:
@@ -975,6 +987,7 @@ class Sandbox:
         disk_gb: Optional[int] = None,
         region: str = "us-east-1",
         time_to_start: Optional[float] = None,
+        request_timeout: Optional[float] = None,
         telemetry_enabled: bool = True,
     ) -> "Sandbox":
         """Internal workhorse — all public factories delegate here."""
@@ -1041,6 +1054,7 @@ class Sandbox:
                     disk_gb=disk_gb,
                     region=region,
                     time_to_start=time_to_start,
+                    request_timeout=request_timeout,
                 )
                 sb = cls(
                     transport, name=name, _ephemeral=ephemeral, _telemetry_enabled=telemetry_enabled

--- a/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
@@ -138,7 +138,9 @@ class CloudTransport(Transport):
             # snapshot, so auth must use the source instance name.
             snap_source = getattr(self._image, "_snapshot_source", None) if self._image else None
             auth_name = snap_source["instance"] if snap_source else self._name
-            self._inner = HTTPTransport(cs_url, api_key=api_key, container_name=auth_name, timeout=self._request_timeout)
+            self._inner = HTTPTransport(
+                cs_url, api_key=api_key, container_name=auth_name, timeout=self._request_timeout
+            )
             await self._inner.connect()
             await self._wait_for_server_ready()
 

--- a/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
@@ -42,6 +42,7 @@ class CloudTransport(Transport):
         disk_gb: Optional[int] = None,
         region: str = "us-east-1",
         time_to_start: Optional[float] = None,
+        request_timeout: Optional[float] = None,
     ):
         self._name = name
         self._api_key_override = api_key
@@ -52,6 +53,7 @@ class CloudTransport(Transport):
         self._disk_gb = disk_gb
         self._region = region
         self._time_to_start = time_to_start if time_to_start is not None else _POLL_TIMEOUT
+        self._request_timeout = request_timeout if request_timeout is not None else 30.0
         self._inner: Optional[HTTPTransport] = None
         self._api_client: Optional[httpx.AsyncClient] = None
 
@@ -136,7 +138,7 @@ class CloudTransport(Transport):
             # snapshot, so auth must use the source instance name.
             snap_source = getattr(self._image, "_snapshot_source", None) if self._image else None
             auth_name = snap_source["instance"] if snap_source else self._name
-            self._inner = HTTPTransport(cs_url, api_key=api_key, container_name=auth_name)
+            self._inner = HTTPTransport(cs_url, api_key=api_key, container_name=auth_name, timeout=self._request_timeout)
             await self._inner.connect()
             await self._wait_for_server_ready()
 

--- a/libs/python/cua-sandbox/cua_sandbox/transport/http.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/http.py
@@ -62,7 +62,17 @@ class HTTPTransport(Transport):
         body = {"command": command}
         if params:
             body["params"] = params
-        resp = await self._client.post("/cmd", json=body)
+        # When the caller passes a server-side timeout (e.g. push_timeout for
+        # write_bytes, or timeout for run_command), the server may legitimately
+        # take that long to respond.  Set the httpx read timeout to match so the
+        # client doesn't drop the connection before the server finishes.
+        server_timeout = (params or {}).get("timeout")
+        if server_timeout is not None:
+            # Add 10s headroom so the server timeout fires before the client one
+            req_timeout = httpx.Timeout(self._timeout, read=float(server_timeout) + 10)
+        else:
+            req_timeout = None  # use client default
+        resp = await self._client.post("/cmd", json=body, timeout=req_timeout)
         resp.raise_for_status()
         return self._parse_sse(resp.text)
 


### PR DESCRIPTION
## Summary
- **Bug fix**: `_cmd()` in `HTTPTransport` now extends the httpx read timeout to match the server-side `timeout` param (+ 10s headroom). Previously the 30s httpx default would kill the connection before the server finished long operations like APK pushes.
- **New parameter**: `request_timeout` on `Sandbox.create()` / `Sandbox.ephemeral()` to configure the default httpx timeout for all commands (default 30s, unchanged).

## Root cause
`write_bytes` with `push_timeout=120` sets `{"timeout": 120}` in the JSON body — the server uses this to allow 120s for the write. But `httpx.AsyncClient` has a 30s default timeout, so the client drops the TCP connection after 30s, producing `httpx.ReadTimeout`. This surfaces as 4/25 failures at N=25 concurrent emulators where CPU contention slows the server's I/O.

## Changes
- `http.py`: `_cmd()` reads `params.timeout` and sets `httpx.Timeout(read=timeout+10)` per-request
- `cloud.py`: `CloudTransport.__init__` accepts `request_timeout`, passes to `HTTPTransport`
- `sandbox.py`: `create()`, `ephemeral()`, `_create()` accept and thread `request_timeout`

## Usage
```python
# Default: 30s httpx timeout, auto-extended for commands with server-side timeout
async with Sandbox.ephemeral(image) as sb:
    ...

# Custom default for slow environments
async with Sandbox.ephemeral(image, request_timeout=90) as sb:
    ...
```

## Test plan
- [ ] Verify default behavior unchanged (no args = 30s client timeout)
- [ ] Verify APK push with push_timeout=120 no longer hits httpx.ReadTimeout
- [ ] Dispatch N=25 matrix test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable request timeout parameter for sandbox creation, enabling users to customize HTTP request timeout behavior for commands sent to the server with improved client-server timeout synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->