### PR TITLE
lume: add --no-audio / LUME_NO_AUDIO to opt out of VZ audio attachment

### DIFF
--- a/libs/lume/src/Commands/Run.swift
+++ b/libs/lume/src/Commands/Run.swift
@@ -147,11 +147,14 @@ struct Run: AsyncParsableCommand {
             "headless": noDisplay
         ])
 
-        // LUME_NO_AUDIO=1 is an env-var fallback for the --no-audio flag so
+        // LUME_NO_AUDIO is an env-var fallback for the --no-audio flag so
         // wrappers (e.g. harbor-ios-env) can opt out host-wide without
-        // editing every caller.
+        // editing every caller. Accept the usual truthy strings.
+        let envNoAudio = (ProcessInfo.processInfo.environment["LUME_NO_AUDIO"] ?? "")
+            .trimmingCharacters(in: .whitespaces)
+            .lowercased()
         let resolvedNoAudio = noAudio
-            || ProcessInfo.processInfo.environment["LUME_NO_AUDIO"] == "1"
+            || ["1", "true", "yes", "y", "on"].contains(envNoAudio)
 
         try await LumeController().runVM(
             name: name,

--- a/libs/lume/src/Commands/Run.swift
+++ b/libs/lume/src/Commands/Run.swift
@@ -76,6 +76,11 @@ struct Run: AsyncParsableCommand {
     @Flag(name: .customLong("clipboard"), help: "Enable bidirectional clipboard sync with the VM via SSH (experimental)")
     var clipboard: Bool = false
 
+    @Flag(
+        name: .customLong("no-audio"),
+        help: "Do not attach a virtio sound device. Use on hosts where lume.app lacks Microphone TCC access and VM boot fails with 'Failed to issue audio output sandbox extension.' Can also be set via LUME_NO_AUDIO=1.")
+    var noAudio: Bool = false
+
     private var parsedNetworkMode: NetworkMode? {
         get throws {
             guard let network else {
@@ -142,6 +147,12 @@ struct Run: AsyncParsableCommand {
             "headless": noDisplay
         ])
 
+        // LUME_NO_AUDIO=1 is an env-var fallback for the --no-audio flag so
+        // wrappers (e.g. harbor-ios-env) can opt out host-wide without
+        // editing every caller.
+        let resolvedNoAudio = noAudio
+            || ProcessInfo.processInfo.environment["LUME_NO_AUDIO"] == "1"
+
         try await LumeController().runVM(
             name: name,
             noDisplay: noDisplay,
@@ -157,7 +168,8 @@ struct Run: AsyncParsableCommand {
             nvramPath: nvramPath.map { Path($0) },
             usbMassStoragePaths: parsedUSBStorageDevices.isEmpty ? nil : parsedUSBStorageDevices,
             networkMode: parsedNetworkMode,
-            clipboard: clipboard
+            clipboard: clipboard,
+            disableAudio: resolvedNoAudio
         )
     }
 }

--- a/libs/lume/src/LumeController.swift
+++ b/libs/lume/src/LumeController.swift
@@ -1000,7 +1000,8 @@ final class LumeController {
         nvramPath: Path? = nil,
         usbMassStoragePaths: [Path]? = nil,
         networkMode: NetworkMode? = nil,
-        clipboard: Bool = false
+        clipboard: Bool = false,
+        disableAudio: Bool = false
     ) async throws {
         let normalizedName = normalizeVMName(name: name)
         Logger.info(
@@ -1121,7 +1122,8 @@ final class LumeController {
                 recoveryMode: recoveryMode,
                 usbMassStoragePaths: usbMassStoragePaths,
                 networkMode: networkMode,
-                clipboard: clipboard)
+                clipboard: clipboard,
+                disableAudio: disableAudio)
             Logger.info("VM started successfully", metadata: ["name": normalizedName])
         } catch {
             SharedVM.shared.removeVM(name: normalizedName)

--- a/libs/lume/src/VM/VM.swift
+++ b/libs/lume/src/VM/VM.swift
@@ -144,7 +144,7 @@ class VM {
     func run(
         noDisplay: Bool, sharedDirectories: [SharedDirectory], mount: Path?, vncPort: Int = 0,
         vncPassword: String? = nil, recoveryMode: Bool = false, usbMassStoragePaths: [Path]? = nil,
-        networkMode: NetworkMode? = nil, clipboard: Bool = false
+        networkMode: NetworkMode? = nil, clipboard: Bool = false, disableAudio: Bool = false
     ) async throws {
         Logger.info(
             "VM.run method called",
@@ -248,7 +248,8 @@ class VM {
                 mount: mount,
                 recoveryMode: recoveryMode,
                 usbMassStoragePaths: usbMassStoragePaths,
-                networkMode: networkMode
+                networkMode: networkMode,
+                disableAudio: disableAudio
             )
             Logger.info(
                 "Successfully created virtualization service context",
@@ -870,7 +871,8 @@ class VM {
         mount: Path? = nil,
         recoveryMode: Bool = false,
         usbMassStoragePaths: [Path]? = nil,
-        networkMode: NetworkMode? = nil
+        networkMode: NetworkMode? = nil,
+        disableAudio: Bool = false
     ) throws -> VMVirtualizationServiceContext {
         // This is a diagnostic log to track actual file paths on disk for debugging
         try validateDiskState()
@@ -891,7 +893,8 @@ class VM {
             nvramPath: vmDirContext.nvramPath,
             recoveryMode: recoveryMode,
             usbMassStoragePaths: usbMassStoragePaths,
-            networkMode: effectiveNetworkMode
+            networkMode: effectiveNetworkMode,
+            disableAudio: disableAudio
         )
     }
 

--- a/libs/lume/src/Virtualization/VMVirtualizationService.swift
+++ b/libs/lume/src/Virtualization/VMVirtualizationService.swift
@@ -17,6 +17,7 @@ struct VMVirtualizationServiceContext {
     let recoveryMode: Bool
     let usbMassStoragePaths: [Path]?
     let networkMode: NetworkMode
+    let disableAudio: Bool
 }
 
 /// Protocol defining the interface for virtualization operations
@@ -304,18 +305,27 @@ final class DarwinVirtualizationService: BaseVirtualizationService {
         ]
         vzConfig.memoryBalloonDevices = [VZVirtioTraditionalMemoryBalloonDeviceConfiguration()]
         vzConfig.entropyDevices = [VZVirtioEntropyDeviceConfiguration()]
-        
-        // Audio configuration
-        let soundDeviceConfiguration = VZVirtioSoundDeviceConfiguration()
-        let inputAudioStreamConfiguration = VZVirtioSoundDeviceInputStreamConfiguration()
-        let outputAudioStreamConfiguration = VZVirtioSoundDeviceOutputStreamConfiguration()
-        
-        inputAudioStreamConfiguration.source = VZHostAudioInputStreamSource()
-        outputAudioStreamConfiguration.sink = VZHostAudioOutputStreamSink()
-        
-        soundDeviceConfiguration.streams = [inputAudioStreamConfiguration, outputAudioStreamConfiguration]
-        vzConfig.audioDevices = [soundDeviceConfiguration]
-        
+
+        // Audio configuration (opt-out via --no-audio / LUME_NO_AUDIO=1).
+        // On hosts where lume.app hasn't been granted Microphone access in TCC,
+        // requesting VZHostAudioInputStreamSource / VZHostAudioOutputStreamSink
+        // makes VZ ask the kernel for an audio sandbox extension, which is
+        // denied, and VM boot fails with:
+        //   "Failed to issue audio output sandbox extension."
+        // Default is unchanged (audio enabled); opt-out preserves behavior for
+        // everyone else.
+        if !config.disableAudio {
+            let soundDeviceConfiguration = VZVirtioSoundDeviceConfiguration()
+            let inputAudioStreamConfiguration = VZVirtioSoundDeviceInputStreamConfiguration()
+            let outputAudioStreamConfiguration = VZVirtioSoundDeviceOutputStreamConfiguration()
+
+            inputAudioStreamConfiguration.source = VZHostAudioInputStreamSource()
+            outputAudioStreamConfiguration.sink = VZHostAudioOutputStreamSink()
+
+            soundDeviceConfiguration.streams = [inputAudioStreamConfiguration, outputAudioStreamConfiguration]
+            vzConfig.audioDevices = [soundDeviceConfiguration]
+        }
+
         // Clipboard sharing via Spice agent
         let spiceAgentConsoleDevice = VZVirtioConsoleDeviceConfiguration()
         let spiceAgentPort = VZVirtioConsolePortConfiguration()
@@ -467,16 +477,20 @@ final class LinuxVirtualizationService: BaseVirtualizationService {
         vzConfig.memoryBalloonDevices = [VZVirtioTraditionalMemoryBalloonDeviceConfiguration()]
         vzConfig.entropyDevices = [VZVirtioEntropyDeviceConfiguration()]
 
-        // Audio configuration
-        let soundDeviceConfiguration = VZVirtioSoundDeviceConfiguration()
-        let inputAudioStreamConfiguration = VZVirtioSoundDeviceInputStreamConfiguration()
-        let outputAudioStreamConfiguration = VZVirtioSoundDeviceOutputStreamConfiguration()
-        
-        inputAudioStreamConfiguration.source = VZHostAudioInputStreamSource()
-        outputAudioStreamConfiguration.sink = VZHostAudioOutputStreamSink()
-        
-        soundDeviceConfiguration.streams = [inputAudioStreamConfiguration, outputAudioStreamConfiguration]
-        vzConfig.audioDevices = [soundDeviceConfiguration]
+        // Audio configuration (opt-out via --no-audio / LUME_NO_AUDIO=1).
+        // See DarwinVirtualizationService.createConfiguration for the rationale
+        // — same sandbox-extension failure mode applies to Linux guests.
+        if !config.disableAudio {
+            let soundDeviceConfiguration = VZVirtioSoundDeviceConfiguration()
+            let inputAudioStreamConfiguration = VZVirtioSoundDeviceInputStreamConfiguration()
+            let outputAudioStreamConfiguration = VZVirtioSoundDeviceOutputStreamConfiguration()
+
+            inputAudioStreamConfiguration.source = VZHostAudioInputStreamSource()
+            outputAudioStreamConfiguration.sink = VZHostAudioOutputStreamSink()
+
+            soundDeviceConfiguration.streams = [inputAudioStreamConfiguration, outputAudioStreamConfiguration]
+            vzConfig.audioDevices = [soundDeviceConfiguration]
+        }
 
         // Clipboard sharing via Spice agent
         let spiceAgentConsoleDevice = VZVirtioConsoleDeviceConfiguration()

--- a/libs/lume/src/Virtualization/VMVirtualizationService.swift
+++ b/libs/lume/src/Virtualization/VMVirtualizationService.swift
@@ -222,6 +222,22 @@ class BaseVirtualizationService: VMVirtualizationService {
             return device
         } ?? []
     }
+
+    /// Build a host-backed virtio sound device (shared between Darwin and Linux
+    /// configurations). Factored out so the two call sites can't drift.
+    static func createAudioDeviceConfiguration() -> VZVirtioSoundDeviceConfiguration {
+        let soundDeviceConfiguration = VZVirtioSoundDeviceConfiguration()
+        let inputAudioStreamConfiguration = VZVirtioSoundDeviceInputStreamConfiguration()
+        let outputAudioStreamConfiguration = VZVirtioSoundDeviceOutputStreamConfiguration()
+
+        inputAudioStreamConfiguration.source = VZHostAudioInputStreamSource()
+        outputAudioStreamConfiguration.sink = VZHostAudioOutputStreamSink()
+
+        soundDeviceConfiguration.streams = [
+            inputAudioStreamConfiguration, outputAudioStreamConfiguration,
+        ]
+        return soundDeviceConfiguration
+    }
 }
 
 /// macOS-specific virtualization service
@@ -315,15 +331,7 @@ final class DarwinVirtualizationService: BaseVirtualizationService {
         // Default is unchanged (audio enabled); opt-out preserves behavior for
         // everyone else.
         if !config.disableAudio {
-            let soundDeviceConfiguration = VZVirtioSoundDeviceConfiguration()
-            let inputAudioStreamConfiguration = VZVirtioSoundDeviceInputStreamConfiguration()
-            let outputAudioStreamConfiguration = VZVirtioSoundDeviceOutputStreamConfiguration()
-
-            inputAudioStreamConfiguration.source = VZHostAudioInputStreamSource()
-            outputAudioStreamConfiguration.sink = VZHostAudioOutputStreamSink()
-
-            soundDeviceConfiguration.streams = [inputAudioStreamConfiguration, outputAudioStreamConfiguration]
-            vzConfig.audioDevices = [soundDeviceConfiguration]
+            vzConfig.audioDevices = [createAudioDeviceConfiguration()]
         }
 
         // Clipboard sharing via Spice agent
@@ -481,15 +489,7 @@ final class LinuxVirtualizationService: BaseVirtualizationService {
         // See DarwinVirtualizationService.createConfiguration for the rationale
         // — same sandbox-extension failure mode applies to Linux guests.
         if !config.disableAudio {
-            let soundDeviceConfiguration = VZVirtioSoundDeviceConfiguration()
-            let inputAudioStreamConfiguration = VZVirtioSoundDeviceInputStreamConfiguration()
-            let outputAudioStreamConfiguration = VZVirtioSoundDeviceOutputStreamConfiguration()
-
-            inputAudioStreamConfiguration.source = VZHostAudioInputStreamSource()
-            outputAudioStreamConfiguration.sink = VZHostAudioOutputStreamSink()
-
-            soundDeviceConfiguration.streams = [inputAudioStreamConfiguration, outputAudioStreamConfiguration]
-            vzConfig.audioDevices = [soundDeviceConfiguration]
+            vzConfig.audioDevices = [createAudioDeviceConfiguration()]
         }
 
         // Clipboard sharing via Spice agent


### PR DESCRIPTION
# Pull Request — trycua/cua

**Branch (local)**: `feat/opt-out-audio` at `/tmp/cua-repo`
**Title**: `lume: add --no-audio / LUME_NO_AUDIO to opt out of VZ audio attachment`
**Closes**: #1357

---

## Summary

Adds an opt-out for the unconditional `VZVirtioSoundDevice` attachment in `VMVirtualizationService`. Users on hosts where `lume.app` lacks a Microphone TCC grant (headless CI, MDM-managed corp macs, first-run consumer macs invoked via `--no-display`) currently hit a deterministic VM-boot failure:

```
Internal Virtualization error. Failed to issue audio output sandbox extension.
```

With this change they can pass `--no-audio` (or set `LUME_NO_AUDIO=1`) and lume skips audio device construction entirely. Default behavior is unchanged — audio is attached exactly as before for every existing caller.

## Changes

| File | Change |
|---|---|
| `libs/lume/src/Virtualization/VMVirtualizationService.swift` | Added `disableAudio: Bool` to `VMVirtualizationServiceContext`. Gated both audio config blocks (Darwin + Linux `createConfiguration`) behind `if !config.disableAudio`. Added inline comment explaining the sandbox-extension failure mode. |
| `libs/lume/src/VM/VM.swift` | Added `disableAudio: Bool = false` to `createVMVirtualizationServiceContext` and propagated to the returned context. Added `disableAudio: Bool = false` to `VM.run(...)`, propagated to the `createVMVirtualizationServiceContext` call. |
| `libs/lume/src/LumeController.swift` | Added `disableAudio: Bool = false` to `runVM(...)`, propagated to `vm.run(...)`. |
| `libs/lume/src/Commands/Run.swift` | Added `--no-audio` `@Flag`. Added `LUME_NO_AUDIO` environment variable fallback resolved in `run()`. Wired resolved value into `LumeController().runVM(...)`. |

Total: 4 files, +60 / -29.

## Backwards compatibility

- All new parameters are defaulted to `false`. Every existing caller — `MCPServer.swift`, `Handlers.swift`, `runWithUSBStorage`, `DarwinVM.setup`, `LinuxVM.setup` — compiles unchanged.
- No config.json schema change. No telemetry change. No change to the MCP / HTTP server surface.
- When the flag is not passed and the env var is unset, the generated `VZVirtualMachineConfiguration` is byte-identical to the pre-change version.

## Test plan

Manual on macOS 15 / Apple Silicon:

1. **Default unchanged** — `lume run <vm>` on a host with Microphone TCC granted: VM boots normally; `vzVirtualMachine.audioDevices.count == 1` (verified in a local build via debug print).
2. **Flag opt-out** — `lume run <vm> --no-audio`: VM boots; audio device absent; no sandbox-extension error.
3. **Env opt-out** — `LUME_NO_AUDIO=1 lume run <vm>`: same as (2).
4. **MDM-suppressed host repro** — on a Meta-managed corp mac (reproduces the sandbox-extension failure without the flag), `lume run <vm> --no-audio` boots successfully.

Automated tests: lume doesn't ship unit tests over `VMVirtualizationService` today; this PR doesn't add a test framework for that, consistent with surrounding code. Happy to add one if the maintainers prefer.

## Note to maintainers

This change is the minimal surgical fix. If you'd prefer a broader audio/device configurability (e.g., separate `--no-microphone` vs `--no-speakers`, or a general `--device-blocklist`) I'm happy to rework. The current flag is scoped to the smallest change that unblocks real-world headless/MDM users without expanding the API surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-audio` CLI flag to disable audio output during VM execution
  * Added `LUME_NO_AUDIO` environment variable support for disabling audio without CLI arguments
  * Audio is enabled by default; use the flag or environment variable to disable as needed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->