### PR TITLE
ci: wire cua-driver into release-bump-version workflow

### DIFF
--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -27,6 +27,7 @@ on:
           - npm/playground
           - npm/cuabot
           - lume
+          - cua-driver
           - docker/cuabot
           - docker/kasm
           - docker/xfce
@@ -129,6 +130,10 @@ jobs:
             "lume")
               echo "directory=libs/lume" >> $GITHUB_OUTPUT
               echo "type=lume" >> $GITHUB_OUTPUT
+              ;;
+            "cua-driver")
+              echo "directory=libs/cua-driver" >> $GITHUB_OUTPUT
+              echo "type=cua-driver" >> $GITHUB_OUTPUT
               ;;
             "docker/cuabot")
               echo "directory=libs/cuabot" >> $GITHUB_OUTPUT
@@ -378,6 +383,14 @@ jobs:
         run: |
           VERSION=$(grep -oP 'static let current: String = "\K[^"]+' libs/lume/src/Main.swift)
           echo "lume version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Capture bumped cua-driver version
+        if: ${{ inputs.service == 'cua-driver' }}
+        id: cua_driver_version
+        run: |
+          VERSION=$(grep -oP 'public static let version = "\K[^"]+' libs/cua-driver/Sources/CuaDriverCore/CuaDriverCore.swift)
+          echo "cua-driver version: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Capture bumped cuabot version

--- a/libs/cua-driver/.bumpversion.cfg
+++ b/libs/cua-driver/.bumpversion.cfg
@@ -1,0 +1,10 @@
+[bumpversion]
+current_version = 0.0.1
+commit = True
+tag = True
+tag_name = cua-driver-v{new_version}
+message = Bump cua-driver to v{new_version}
+
+[bumpversion:file:Sources/CuaDriverCore/CuaDriverCore.swift]
+search = public static let version = "{current_version}"
+replace = public static let version = "{new_version}"


### PR DESCRIPTION
## Summary

Adds cua-driver to the CD: Bump Version workflow dropdown, matching how lume is wired.

After this lands, running `gh workflow run "CD: Bump Version" -f service=cua-driver -f bump_type=minor` will:
1. Bump the version string in `libs/cua-driver/Sources/CuaDriverCore/CuaDriverCore.swift` from `0.0.1` to `0.1.0` via the new `libs/cua-driver/.bumpversion.cfg`.
2. Commit + push a `cua-driver-v0.1.0` tag.
3. The existing `cd-swift-cua-driver.yml` workflow (triggered by tags matching `cua-driver-v*`) then runs the codesign + notarize + GitHub-release flow.

## Changes

- `.github/workflows/release-bump-version.yml`:
  - Adds `cua-driver` to the `service` choice list (next to `lume`).
  - Adds the case branch mapping `cua-driver` → `libs/cua-driver`.
  - Adds a `Capture bumped cua-driver version` step mirroring the lume one.
- `libs/cua-driver/.bumpversion.cfg` (new): current_version `0.0.1`, tag pattern `cua-driver-v{new_version}`, bumps the `public static let version` string in `CuaDriverCore.swift`.

## Test plan

- [ ] After merge, run `gh workflow run "CD: Bump Version" -f service=cua-driver -f bump_type=minor`
- [ ] Verify the workflow succeeds (bump commit + `cua-driver-v0.1.0` tag pushed to main)
- [ ] Verify `cd-swift-cua-driver.yml` fires on the new tag and produces a signed, notarized GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation to support version management for the cua-driver service, including automatic version bumping, release tagging, and consistent version tracking during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->