### PR TITLE
cua-driver: unignore scripts/build/ and commit the notarization script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules/*
 .Python
 build/
 !libs/lume/scripts/build/
+!libs/cua-driver/scripts/build/
 develop-eggs/
 dist/
 downloads/

--- a/libs/cua-driver/scripts/build/build-release-notarized.sh
+++ b/libs/cua-driver/scripts/build/build-release-notarized.sh
@@ -1,0 +1,256 @@
+#!/bin/bash
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Navigate to the cua-driver root directory (two levels up from scripts/build/)
+CUA_DRIVER_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Set default log level if not provided
+LOG_LEVEL=${LOG_LEVEL:-"normal"}
+
+# Function to log based on level
+log() {
+  local level=$1
+  local message=$2
+
+  case "$LOG_LEVEL" in
+    "minimal")
+      # Only show essential or error messages
+      if [ "$level" = "essential" ] || [ "$level" = "error" ]; then
+        echo "$message"
+      fi
+      ;;
+    "none")
+      # Show nothing except errors
+      if [ "$level" = "error" ]; then
+        echo "$message" >&2
+      fi
+      ;;
+    *)
+      # Normal logging - show everything
+      echo "$message"
+      ;;
+  esac
+}
+
+# Check required environment variables
+required_vars=(
+  "CERT_APPLICATION_NAME"
+  "CERT_INSTALLER_NAME"
+  "APPLE_ID"
+  "TEAM_ID"
+  "APP_SPECIFIC_PASSWORD"
+)
+
+for var in "${required_vars[@]}"; do
+  if [ -z "${!var}" ]; then
+    log "error" "Error: $var is not set"
+    exit 1
+  fi
+done
+
+# Get VERSION from environment or use default
+VERSION=${VERSION:-"0.0.1"}
+
+# Move to the project root directory
+cd "$CUA_DRIVER_DIR"
+
+# Ensure .release directory exists and is clean
+mkdir -p .release
+log "normal" "Ensuring .release directory exists and is accessible"
+
+# Build the release version
+log "essential" "Building release version..."
+swift build -c release --product cua-driver > /dev/null
+
+# --- Assemble .app bundle ---
+log "essential" "Assembling .app bundle..."
+
+APP_BUNDLE=".release/CuaDriver.app"
+rm -rf "$APP_BUNDLE"
+mkdir -p "$APP_BUNDLE/Contents/MacOS"
+mkdir -p "$APP_BUNDLE/Contents/Resources"
+
+# Copy the binary into the bundle
+cp -f .build/release/cua-driver "$APP_BUNDLE/Contents/MacOS/cua-driver"
+
+# Stamp and copy Info.plist — the source plist ships with a static
+# `CFBundleShortVersionString` for dev builds; substitute the release
+# version on the way into the bundle so dev state is left untouched.
+sed "s/<string>0.0.1<\/string>/<string>$VERSION<\/string>/" "./App/CuaDriver/Info.plist" > "$APP_BUNDLE/Contents/Info.plist"
+
+# --- Sign the .app bundle ---
+log "essential" "Signing .app bundle..."
+log "essential" "Using signing identity: $CERT_APPLICATION_NAME"
+
+# Ensure build.keychain is in the search list for codesign
+KEYCHAIN_PATH="$HOME/Library/Keychains/build.keychain-db"
+if [ -f "$KEYCHAIN_PATH" ]; then
+  log "essential" "Adding build keychain to search list..."
+  security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+  security list-keychains
+fi
+
+# Sign the .app bundle
+log "essential" "Signing .app bundle with Developer ID..."
+codesign --force --options runtime --timestamp \
+         --entitlements ./scripts/CuaDriver.entitlements \
+         --sign "$CERT_APPLICATION_NAME" \
+         --keychain "$KEYCHAIN_PATH" \
+         "$APP_BUNDLE"
+
+# Verify the final bundle signature
+log "essential" "Verifying bundle signature..."
+codesign -dvv "$APP_BUNDLE" 2>&1
+codesign --verify --strict --deep "$APP_BUNDLE" 2>&1 || { log "error" "Bundle signature verification FAILED"; exit 1; }
+log "essential" "Signature verified successfully."
+
+# --- Package as .pkg installer ---
+log "essential" "Building installer package..."
+
+TEMP_ROOT=$(mktemp -d)
+mkdir -p "$TEMP_ROOT/usr/local/share/cua-driver"
+# Use ditto to preserve code signatures and extended attributes
+ditto "$APP_BUNDLE" "$TEMP_ROOT/usr/local/share/cua-driver/CuaDriver.app"
+
+if ! pkgbuild --root "$TEMP_ROOT" \
+         --identifier "com.trycua.driver" \
+         --version "$VERSION" \
+         --install-location "/" \
+         --sign "$CERT_INSTALLER_NAME" \
+         ./.release/cua-driver.pkg; then
+    log "error" "Failed to build installer package"
+    exit 1
+fi
+
+# Verify the package was created
+if [ ! -f "./.release/cua-driver.pkg" ]; then
+    log "error" "Package file ./.release/cua-driver.pkg was not created"
+    exit 1
+fi
+
+log "essential" "Package created successfully"
+
+# --- Notarize ---
+log "essential" "Submitting for notarization..."
+if [ "$LOG_LEVEL" = "minimal" ] || [ "$LOG_LEVEL" = "none" ]; then
+  # Minimal output - capture ID but hide details
+  NOTARY_OUTPUT=$(xcrun notarytool submit ./.release/cua-driver.pkg \
+      --apple-id "${APPLE_ID}" \
+      --team-id "${TEAM_ID}" \
+      --password "${APP_SPECIFIC_PASSWORD}" \
+      --wait 2>&1)
+
+  # Check if notarization was successful
+  if echo "$NOTARY_OUTPUT" | grep -q "status: Accepted"; then
+    log "essential" "Notarization successful!"
+  else
+    log "error" "Notarization failed. Please check logs."
+    log "error" "Notarization output:"
+    echo "$NOTARY_OUTPUT"
+    # Extract submission ID and fetch detailed log
+    SUBMISSION_ID=$(echo "$NOTARY_OUTPUT" | grep "id:" | head -1 | awk '{print $2}')
+    if [ -n "$SUBMISSION_ID" ]; then
+      log "error" "Fetching notarization log for submission $SUBMISSION_ID..."
+      xcrun notarytool log "$SUBMISSION_ID" \
+          --apple-id "${APPLE_ID}" \
+          --team-id "${TEAM_ID}" \
+          --password "${APP_SPECIFIC_PASSWORD}" \
+          developer_log.json 2>&1 || true
+      if [ -f developer_log.json ]; then
+        log "error" "Notarization log:"
+        cat developer_log.json
+      fi
+    fi
+    exit 1
+  fi
+else
+  # Normal verbose output
+  if ! xcrun notarytool submit ./.release/cua-driver.pkg \
+      --apple-id "${APPLE_ID}" \
+      --team-id "${TEAM_ID}" \
+      --password "${APP_SPECIFIC_PASSWORD}" \
+      --wait; then
+    log "error" "Notarization failed"
+    # Try to fetch the log for the last submission
+    LAST_ID=$(xcrun notarytool history \
+        --apple-id "${APPLE_ID}" \
+        --team-id "${TEAM_ID}" \
+        --password "${APP_SPECIFIC_PASSWORD}" 2>&1 | grep "id:" | head -1 | awk '{print $2}')
+    if [ -n "$LAST_ID" ]; then
+      log "error" "Fetching notarization log for submission $LAST_ID..."
+      xcrun notarytool log "$LAST_ID" \
+          --apple-id "${APPLE_ID}" \
+          --team-id "${TEAM_ID}" \
+          --password "${APP_SPECIFIC_PASSWORD}" \
+          developer_log.json 2>&1 || true
+      if [ -f developer_log.json ]; then
+        log "error" "Notarization log:"
+        cat developer_log.json
+      fi
+    fi
+    exit 1
+  fi
+fi
+
+# Staple the notarization ticket to the .pkg
+log "essential" "Stapling notarization ticket to .pkg..."
+if ! xcrun stapler staple ./.release/cua-driver.pkg > /dev/null 2>&1; then
+  log "error" "Failed to staple notarization ticket to .pkg"
+  exit 1
+fi
+
+# Staple the notarization ticket to the .app bundle
+log "essential" "Stapling notarization ticket to .app bundle..."
+if ! xcrun stapler staple "$APP_BUNDLE" > /dev/null 2>&1; then
+  log "normal" "Note: Could not staple .app bundle directly (this is expected when notarizing via .pkg)"
+fi
+
+# --- Create release archives ---
+
+# Get architecture and create OS identifier
+ARCH=$(uname -m)
+OS_IDENTIFIER="darwin-${ARCH}"
+RELEASE_DIR="$(cd .release && pwd)"
+
+log "essential" "Creating archives in $RELEASE_DIR..."
+cd "$RELEASE_DIR"
+
+# Clean up any existing artifacts first to avoid conflicts
+rm -f cua-driver-*.tar.gz cua-driver-*.pkg.tar.gz
+
+# Create a backward-compatible wrapper script at the tarball root so
+# extracting the tarball and running `./cua-driver <tool>` works
+# regardless of whether the .app is moved to /Applications yet.
+cat > cua-driver <<'WRAPPER_EOF'
+#!/bin/sh
+exec "$(dirname "$0")/CuaDriver.app/Contents/MacOS/cua-driver" "$@"
+WRAPPER_EOF
+chmod +x cua-driver
+
+# Create version-specific archives
+log "essential" "Creating version-specific archives (${VERSION})..."
+
+# Package the .app bundle and wrapper script
+tar -czf "cua-driver-${VERSION}-${OS_IDENTIFIER}.tar.gz" cua-driver CuaDriver.app > /dev/null 2>&1
+
+# Package the installer
+tar -czf "cua-driver-${VERSION}-${OS_IDENTIFIER}.pkg.tar.gz" cua-driver.pkg > /dev/null 2>&1
+
+# Create sha256 checksum file
+log "essential" "Generating checksums..."
+shasum -a 256 cua-driver-*.tar.gz > checksums.txt
+log "essential" "Package created successfully with checksums generated."
+
+# Show what's in the release directory
+log "essential" "Files in release directory:"
+ls -la "$RELEASE_DIR"
+
+# Ensure correct permissions
+chmod 644 "$RELEASE_DIR"/*.tar.gz "$RELEASE_DIR"/*.pkg.tar.gz "$RELEASE_DIR"/checksums.txt
+
+# Clean up
+rm -rf "$TEMP_ROOT"
+
+log "essential" "Build and packaging completed successfully."


### PR DESCRIPTION
## Summary

Fixes the failing `cd-swift-cua-driver.yml` release workflow for cua-driver-v0.0.2 (run [24822882816](https://github.com/trycua/cua/actions/runs/24822882816/job/72651534872)). The notarization script `libs/cua-driver/scripts/build/build-release-notarized.sh` was being silently gitignored by the root `.gitignore:13` catch-all `build/`, so the CD workflow's `chmod +x scripts/build/build-release-notarized.sh` step errored with `No such file or directory`.

## Changes

- `.gitignore`: add `!libs/cua-driver/scripts/build/` right after the existing `!libs/lume/scripts/build/` unignore entry. Same pattern lume uses for the same reason.
- `libs/cua-driver/scripts/build/build-release-notarized.sh` (newly tracked): the script was already present in Francesco's working tree but never pushed.

## Test plan

- [ ] After merge, either move the existing `cua-driver-v0.0.2` tag to the new HEAD (force-move) or run `gh workflow run "CD: Bump Version" -f service=cua-driver -f bump_type=patch` to produce a fresh `cua-driver-v0.0.3` tag.
- [ ] Verify `cd-swift-cua-driver.yml` fires on the new tag and completes (codesign + notarize + GitHub release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)