### PR TITLE
cua-driver: ship the Claude Code skill pack with the app

### DIFF
--- a/libs/cua-driver/scripts/build-app.sh
+++ b/libs/cua-driver/scripts/build-app.sh
@@ -38,6 +38,15 @@ if [[ -f "App/CuaDriver/AppIcon.icns" ]]; then
     cp App/CuaDriver/AppIcon.icns "$APP_CONTENTS/Resources/AppIcon.icns"
 fi
 
+# Claude Code skill pack. install.sh symlinks ~/.claude/skills/cua-driver
+# to this path when a Claude Code install is detected on the user's
+# machine. Ships inside the bundle so it survives auto-updates and
+# relocations of CuaDriver.app.
+if [[ -d "Skills/cua-driver" ]]; then
+    mkdir -p "$APP_CONTENTS/Resources/Skills"
+    cp -R Skills/cua-driver "$APP_CONTENTS/Resources/Skills/cua-driver"
+fi
+
 # Prefer Developer ID Application cert if available; fall back to ad-hoc.
 # `security find-identity` prints identities as:
 #   1) <SHA> "Developer ID Application: Team Name (TEAMID)"

--- a/libs/cua-driver/scripts/build/build-release-notarized.sh
+++ b/libs/cua-driver/scripts/build/build-release-notarized.sh
@@ -80,6 +80,15 @@ cp -f .build/release/cua-driver "$APP_BUNDLE/Contents/MacOS/cua-driver"
 # version on the way into the bundle so dev state is left untouched.
 sed "s/<string>0.0.1<\/string>/<string>$VERSION<\/string>/" "./App/CuaDriver/Info.plist" > "$APP_BUNDLE/Contents/Info.plist"
 
+# Claude Code skill pack. install.sh symlinks ~/.claude/skills/cua-driver
+# into this bundle path when a Claude Code install is detected. Ship
+# the skill inside the .app so it survives auto-updates.
+if [ -d "Skills/cua-driver" ]; then
+    log "essential" "Copying Claude Code skill pack into bundle..."
+    mkdir -p "$APP_BUNDLE/Contents/Resources/Skills"
+    cp -R Skills/cua-driver "$APP_BUNDLE/Contents/Resources/Skills/cua-driver"
+fi
+
 # --- Sign the .app bundle ---
 log "essential" "Signing .app bundle..."
 log "essential" "Using signing identity: $CERT_APPLICATION_NAME"

--- a/libs/cua-driver/scripts/install.sh
+++ b/libs/cua-driver/scripts/install.sh
@@ -118,6 +118,28 @@ $SUDO mkdir -p "$(dirname "$BIN_LINK")"
 $SUDO ln -sf "$APP_BINARY" "$BIN_LINK"
 log "symlinked $BIN_LINK -> $APP_BINARY"
 
+# --- Install Claude Code skill pack -------------------------------------
+#
+# Detect Claude Code users (via ~/.claude/skills/ presence) and drop a
+# symlink pointing at the skill we shipped inside the bundle. Auto-updates
+# atomically replace /Applications/CuaDriver.app, so the symlink stays
+# valid across every release. Never overwrites an existing link or
+# directory — dev users with their own ~/.claude/skills/cua-driver symlink
+# pointing at a working copy of the repo keep theirs.
+
+SKILL_LINK="$HOME/.claude/skills/cua-driver"
+SKILL_TARGET="$APP_DEST/Contents/Resources/Skills/cua-driver"
+if [[ -d "$HOME/.claude/skills" ]]; then
+    if [[ -e "$SKILL_LINK" ]] || [[ -L "$SKILL_LINK" ]]; then
+        log "skill link already exists at $SKILL_LINK (skipping)"
+    elif [[ -d "$SKILL_TARGET" ]]; then
+        ln -s "$SKILL_TARGET" "$SKILL_LINK"
+        log "symlinked Claude Code skill at $SKILL_LINK"
+    else
+        log "skill pack missing at $SKILL_TARGET (skipping; older release?)"
+    fi
+fi
+
 # --- Install auto-updater -----------------------------------------------
 
 if [[ "$INSTALL_AUTO_UPDATER" == "true" ]]; then

--- a/libs/cua-driver/scripts/uninstall.sh
+++ b/libs/cua-driver/scripts/uninstall.sh
@@ -84,6 +84,18 @@ else
     log "no config at $CONFIG_DIR (skipping)"
 fi
 
+# Claude Code skill symlink. Only remove when the link is ours — a dev
+# user pointing ~/.claude/skills/cua-driver at a working copy of the
+# repo keeps their link untouched.
+SKILL_LINK="$HOME/.claude/skills/cua-driver"
+SKILL_TARGET_EXPECTED="$APP_BUNDLE/Contents/Resources/Skills/cua-driver"
+if [[ -L "$SKILL_LINK" ]] && [[ "$(readlink "$SKILL_LINK")" == "$SKILL_TARGET_EXPECTED" ]]; then
+    rm -f "$SKILL_LINK"
+    log "removed $SKILL_LINK"
+else
+    log "no install-created skill symlink at $SKILL_LINK (skipping)"
+fi
+
 cat << 'FINALUNMSG'
 
 cua-driver uninstalled.


### PR DESCRIPTION
## Summary

Bundles the cua-driver Claude Code skill (`libs/cua-driver/Skills/cua-driver/`) inside `CuaDriver.app` and symlinks it into `~/.claude/skills/cua-driver` when the installer detects a Claude Code user. A public user running the remote install one-liner now gets the skill automatically; today they don't.

## Changes

- **`scripts/build-app.sh`** (dev builds): copies the skill dir into `CuaDriver.app/Contents/Resources/Skills/cua-driver/`.
- **`scripts/build/build-release-notarized.sh`** (CD pipeline): same, so the notarized release tarball ships with the skill.
- **`scripts/install.sh`**: after the CLI symlink step, checks for `~/.claude/skills/` and creates `~/.claude/skills/cua-driver → /Applications/CuaDriver.app/Contents/Resources/Skills/cua-driver`. Skips silently if the dir doesn't exist (non-Claude users unaffected) or a symlink / directory already lives at that path (dev users with their own worktree-pointing symlink keep theirs).
- **`scripts/uninstall.sh`**: removes the symlink only when it points at our expected bundle path. Dev-user symlinks pointing elsewhere are left alone.

## Why this works across auto-updates

The symlink target is `/Applications/CuaDriver.app/Contents/Resources/Skills/cua-driver`. The auto-updater (`cua-driver-update`) replaces the whole `.app` bundle atomically via `ditto`, which preserves the path. The symlink stays valid across every release without extra plumbing.

## Test plan

- [ ] Run `scripts/build-app.sh` and confirm `.build/CuaDriver.app/Contents/Resources/Skills/cua-driver/` contains all 5 skill files (`README.md`, `RECORDING.md`, `SKILL.md`, `TESTS.md`, `WEB_APPS.md`)
- [ ] Run `scripts/install.sh` on a machine with `~/.claude/skills/` present but no existing `cua-driver` symlink → confirm symlink is created pointing at the bundle
- [ ] Run `scripts/install.sh` on a machine with no `~/.claude/skills/` dir → confirm the step is skipped cleanly (no error)
- [ ] Run `scripts/install.sh` on a machine where `~/.claude/skills/cua-driver` is already a dev symlink to a worktree → confirm the existing symlink is NOT touched
- [ ] Bump (`patch`) + trigger the CD workflow → confirm the notarized tarball's `CuaDriver.app` contains the skill pack
- [ ] Run `scripts/uninstall.sh` and confirm the install-created symlink is removed, while an unrelated symlink at the same path (if any) would be preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Claude Code skill pack is now bundled with the app and automatically installed during setup, with proper cleanup on uninstall.

* **Chores**
  * Updated build and installation scripts to include and manage the Claude Code skill pack as part of the app bundle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->