### PR TITLE
cua-driver: fix post-install permissions guidance

### DIFF
--- a/docs/content/docs/cua-driver/guide/getting-started/installation.mdx
+++ b/docs/content/docs/cua-driver/guide/getting-started/installation.mdx
@@ -41,9 +41,19 @@ Cua Driver needs two permissions:
 - **Accessibility** — to walk AX trees and dispatch `AXUIElementPerformAction`.
 - **Screen Recording** — to capture per-window screenshots via ScreenCaptureKit.
 
-The first time you run `cua-driver serve` or `cua-driver mcp`, a permissions gate opens and walks you through granting both. Once the green checkmarks appear, close the window.
+Start the daemon first so TCC attributes the subsequent requests to `CuaDriver.app` rather than to whatever shell parent launched the CLI:
 
-To check status from the shell:
+```bash
+open -n -g -a CuaDriver --args serve
+```
+
+Then trigger the prompts:
+
+```bash
+cua-driver check_permissions
+```
+
+macOS raises the Accessibility and Screen Recording system dialogs. Grant both, then re-run the command to confirm:
 
 ```bash
 cua-driver check_permissions
@@ -54,11 +64,12 @@ cua-driver check_permissions
 <Callout type="info">
   `check_permissions` reports the TCC status of the *calling* process. Inside an IDE terminal (Claude
   Code, Cursor, VS Code, Conductor) the shell inherits the IDE's TCC responsibility chain, so results
-  can read "NOT granted" even when you've granted both to `CuaDriver.app`. Start the daemon first
-  (`cua-driver serve &`) and the CLI forwards through it for authoritative answers.
+  can read "NOT granted" even when you've granted both to `CuaDriver.app`. The daemon-first recipe
+  above sidesteps this because the CLI forwards through the daemon, which runs under
+  `CuaDriver.app`'s bundle id.
 </Callout>
 
-If a grant reads `NOT granted`, open **System Settings → Privacy & Security**, find `CuaDriver.app` under Accessibility and Screen Recording, and flip the toggle.
+If a grant still reads `NOT granted` after granting in the dialog, open **System Settings → Privacy & Security**, find `CuaDriver.app` under Accessibility and Screen Recording, and flip the toggle.
 
 ## Requirements
 

--- a/libs/cua-driver/scripts/install.sh
+++ b/libs/cua-driver/scripts/install.sh
@@ -341,14 +341,18 @@ log "cua-driver $VERSION installed"
 cat << 'FINALEOF'
 
 Next steps:
-  1. Grant Accessibility + Screen Recording permissions:
-       open /Applications/CuaDriver.app
-     (a one-time setup window will guide you)
+  1. Start the daemon so TCC attributes requests to CuaDriver.app:
+       open -n -g -a CuaDriver --args serve
 
-  2. Wire into your MCP client (Claude Code, Cursor, etc.):
+  2. Trigger the Accessibility + Screen Recording prompts:
+       cua-driver check_permissions
+     macOS will raise the system dialogs. Grant both, then re-run
+     the command to confirm it reports all green.
+
+  3. Wire into your MCP client (Claude Code, Cursor, etc.):
        cua-driver mcp-config | pbcopy
 
-  3. Or drive directly from the shell:
+  4. Or drive directly from the shell:
        cua-driver list_apps
 
 Docs: https://github.com/trycua/cua/tree/main/libs/cua-driver


### PR DESCRIPTION
## Summary

The `install.sh` post-install message told users to `open /Applications/CuaDriver.app` to trigger the permissions UI. That path is **unreliable** — Francesco just hit it live:

- `LSUIElement=true` keeps the bundle headless; a bare `open` of an already-registered bundle silently reactivates the running instance with no visible surface.
- Even on a clean launch, the `runFirstLaunchGUI` flow has been observed to exit before `PermissionsGate.presentWindow` fires (daemon race, TCC preflight short-circuit, SCShareableContent call followed immediately by CoreAnalytics exit handler).

The **reliable path** already documented in the cua-driver skill is daemon-first:

```
open -n -g -a CuaDriver --args serve   # TCC attributes requests to .app
cua-driver check_permissions            # triggers the TCC prompts
```

The second command reliably raises the Accessibility + Screen Recording system dialogs. User grants them. Re-run `check_permissions` to confirm green.

## Change

One file, the post-install FINALEOF block:

- Step 1: `open -n -g -a CuaDriver --args serve` (start daemon)
- Step 2: `cua-driver check_permissions` (triggers prompts)
- Step 3: MCP wiring (was step 2)
- Step 4: CLI example (was step 3)

## Test plan

- [ ] Fresh install on a machine without existing TCC grants, then follow the new Next Steps verbatim → both TCC prompts raise, grants land, `check_permissions` returns all green.

## Out of scope

Fixing the first-launch GUI properly (making `open /Applications/CuaDriver.app` reliably raise `PermissionsGate`) is a follow-up. This PR just stops sending users to the broken path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated installation instructions to start the app as a background service after installation
  * Added guidance to grant required Accessibility and Screen Recording permissions
  * Included permission verification command to confirm all permissions are granted

<!-- end of auto-generated comment: release notes by coderabbit.ai -->