### PR TITLE
Add "Book a call" CTA button to landing page

### DIFF
--- a/docs/src/app/(landing)/page.tsx
+++ b/docs/src/app/(landing)/page.tsx
@@ -121,6 +121,14 @@ export default function LandingPage() {
                   Get started
                 </Link>
                 <a
+                  href="https://cua.cal.com/f/cua-demo"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="cds-button-secondary inline-flex items-center gap-2 rounded-[10px] px-6 py-3 text-[0.95rem] font-semibold"
+                >
+                  Book a call
+                </a>
+                <a
                   href="https://cua.ai"
                   target="_blank"
                   rel="noreferrer"


### PR DESCRIPTION
## Summary
Added a new "Book a call" call-to-action button to the landing page hero section, linking to a Calendly scheduling page.

## Changes
- Added a new anchor link button with the text "Book a call" that directs users to `https://cua.cal.com/f/cua-demo`
- Button uses the same styling pattern as existing CTAs with `cds-button-secondary` class and consistent spacing/typography
- Configured with `target="_blank"` and `rel="noreferrer"` for secure external link handling
- Positioned between the "Get started" and existing external link buttons in the hero section

## Implementation Details
- Uses standard HTML anchor tag for simplicity and SEO benefits
- Maintains consistent button styling with existing CTAs on the page
- Opens in a new tab to preserve user's position on the landing page

https://claude.ai/code/session_01Pa2Vfi6GvdFgffK2vi8HbB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a call-to-action button to the landing page's hero section that links to an external calendaring service, opening in a new browser tab with security measures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->