### PR TITLE
Add SIGTERM handler to ensure ephemeral sandboxes are cleaned up

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -185,6 +185,75 @@ def _auto_runtime(image: Image) -> "Runtime":
     return QEMURuntime(mode="docker")
 
 
+# ── Ephemeral SIGTERM cleanup ────────────────────────────────────────────
+#
+# By default, SIGTERM terminates the process without running any Python-level
+# cleanup, which leaks ephemeral sandboxes (cloud VMs in particular cost
+# money). While any ephemeral sandbox is active we install a SIGTERM handler
+# that converts the signal into SystemExit, so the ``async with`` block's
+# ``finally`` runs and calls ``destroy()``. The handler is removed once the
+# last ephemeral exits.
+
+_ACTIVE_EPHEMERAL_COUNT = 0
+_SIGTERM_INSTALLED = False
+_PREV_SIGTERM_HANDLER: Any = None
+
+
+def _sigterm_raise_systemexit(signum: int, frame: Any) -> None:
+    raise SystemExit(128 + signum)
+
+
+def _install_sigterm_handler() -> None:
+    """Install SIGTERM → SystemExit, once, from the main thread only."""
+    global _SIGTERM_INSTALLED, _PREV_SIGTERM_HANDLER
+    if _SIGTERM_INSTALLED:
+        return
+    import signal as _signal
+    import threading as _threading
+
+    if _threading.current_thread() is not _threading.main_thread():
+        return
+    try:
+        _PREV_SIGTERM_HANDLER = _signal.signal(
+            _signal.SIGTERM, _sigterm_raise_systemexit
+        )
+        _SIGTERM_INSTALLED = True
+    except (ValueError, OSError):
+        # Signal handling unavailable (e.g. embedded interpreter). Skip.
+        pass
+
+
+def _uninstall_sigterm_handler() -> None:
+    global _SIGTERM_INSTALLED, _PREV_SIGTERM_HANDLER
+    if not _SIGTERM_INSTALLED:
+        return
+    import signal as _signal
+
+    try:
+        _signal.signal(
+            _signal.SIGTERM,
+            _PREV_SIGTERM_HANDLER if _PREV_SIGTERM_HANDLER is not None else _signal.SIG_DFL,
+        )
+    except (ValueError, OSError):
+        pass
+    _SIGTERM_INSTALLED = False
+    _PREV_SIGTERM_HANDLER = None
+
+
+def _enter_ephemeral_scope() -> None:
+    global _ACTIVE_EPHEMERAL_COUNT
+    _ACTIVE_EPHEMERAL_COUNT += 1
+    if _ACTIVE_EPHEMERAL_COUNT == 1:
+        _install_sigterm_handler()
+
+
+def _exit_ephemeral_scope() -> None:
+    global _ACTIVE_EPHEMERAL_COUNT
+    _ACTIVE_EPHEMERAL_COUNT = max(0, _ACTIVE_EPHEMERAL_COUNT - 1)
+    if _ACTIVE_EPHEMERAL_COUNT == 0:
+        _uninstall_sigterm_handler()
+
+
 def _record_sandbox_create(
     sb: Any,
     *,
@@ -560,29 +629,35 @@ class Sandbox:
                 await sb.shell.run("whoami")
             # sandbox is destroyed here
         """
-        sb = await cls._create(
-            image=image,
-            name=name,
-            ephemeral=True,
-            api_key=api_key,
-            local=local,
-            runtime=runtime,
-            cpu=cpu,
-            memory_mb=memory_mb,
-            disk_gb=disk_gb,
-            region=region,
-            time_to_start=time_to_start,
-            request_timeout=request_timeout,
-            telemetry_enabled=telemetry_enabled,
-        )
+        # Install a SIGTERM handler around the ephemeral so an external kill
+        # runs the finally below instead of leaking the VM.
+        _enter_ephemeral_scope()
         try:
-            yield sb
+            sb = await cls._create(
+                image=image,
+                name=name,
+                ephemeral=True,
+                api_key=api_key,
+                local=local,
+                runtime=runtime,
+                cpu=cpu,
+                memory_mb=memory_mb,
+                disk_gb=disk_gb,
+                region=region,
+                time_to_start=time_to_start,
+                request_timeout=request_timeout,
+                telemetry_enabled=telemetry_enabled,
+            )
+            try:
+                yield sb
+            finally:
+                if sb._has_snapshots and sb.name:
+                    # Stop instead of delete so forks can reference the snapshots.
+                    await cls.suspend(sb.name, local=local, api_key=api_key)
+                else:
+                    await sb.destroy()
         finally:
-            if sb._has_snapshots and sb.name:
-                # Stop instead of delete so forks can reference the snapshots.
-                await cls.suspend(sb.name, local=local, api_key=api_key)
-            else:
-                await sb.destroy()
+            _exit_ephemeral_scope()
 
     # ── Lifecycle management ─────────────────────────────────────────────
 

--- a/libs/python/cua-sandbox/tests/test_vm_cleanup.py
+++ b/libs/python/cua-sandbox/tests/test_vm_cleanup.py
@@ -5,17 +5,27 @@ They verify that:
   1. _create() cleans up a provisioned VM when _connect() fails.
   2. destroy() runs every cleanup step independently — a failure in one
      does not prevent the others from executing.
+  3. A SIGTERM delivered while an ephemeral sandbox is active triggers
+     destroy() via the installed handler.
 """
 
 from __future__ import annotations
 
+import signal
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import sys
 
 import httpx
 import pytest
 from cua_sandbox.image import Image
 from cua_sandbox.sandbox import Sandbox
 from cua_sandbox.transport.cloud import CloudTransport
+
+# `cua_sandbox.sandbox` the module is shadowed on the package by a `sandbox`
+# factory function re-exported in __init__.py, so grab the module from
+# sys.modules directly to access its private test hooks.
+sandbox_mod = sys.modules["cua_sandbox.sandbox"]
 
 pytestmark = pytest.mark.asyncio
 
@@ -334,3 +344,130 @@ class TestEphemeralCleanup:
                     pass  # never reached
 
         transport.delete_vm.assert_awaited_once()
+
+
+# ===================================================================
+# 4. SIGTERM cleanup — ephemeral sandboxes are destroyed on kill
+# ===================================================================
+
+
+@pytest.fixture
+def _restore_sigterm():
+    """Snapshot + restore the SIGTERM handler around each test.
+
+    The ephemeral context manager installs a process-wide SIGTERM handler
+    while active; make sure we don't leak that state between tests.
+    """
+    prev = signal.getsignal(signal.SIGTERM)
+    prev_installed = sandbox_mod._SIGTERM_INSTALLED
+    prev_prev = sandbox_mod._PREV_SIGTERM_HANDLER
+    prev_count = sandbox_mod._ACTIVE_EPHEMERAL_COUNT
+    yield
+    signal.signal(signal.SIGTERM, prev)
+    sandbox_mod._SIGTERM_INSTALLED = prev_installed
+    sandbox_mod._PREV_SIGTERM_HANDLER = prev_prev
+    sandbox_mod._ACTIVE_EPHEMERAL_COUNT = prev_count
+
+
+class TestEphemeralSigtermCleanup:
+    """Ephemeral sandboxes must be destroyed when the process gets SIGTERM."""
+
+    async def test_sigterm_handler_installed_and_removed(self, _restore_sigterm):
+        """Entering ephemeral() installs a SIGTERM handler; exiting removes it."""
+        transport = _make_cloud_transport(name="eph-sig")
+        transport.connect = AsyncMock()
+        transport.disconnect = AsyncMock()
+        transport.delete_vm = AsyncMock()
+
+        before = signal.getsignal(signal.SIGTERM)
+
+        with (
+            patch.object(CloudTransport, "__init__", lambda self, **kw: None),
+            patch.object(CloudTransport, "__new__", lambda cls, **kw: transport),
+        ):
+            async with Sandbox.ephemeral(
+                Image.linux("ubuntu", "24.04"),
+                api_key="sk-fake",
+                telemetry_enabled=False,
+            ) as _sb:
+                handler = signal.getsignal(signal.SIGTERM)
+                assert handler is sandbox_mod._sigterm_raise_systemexit
+
+        # After exit, the previous handler is restored.
+        assert signal.getsignal(signal.SIGTERM) == before
+        assert sandbox_mod._ACTIVE_EPHEMERAL_COUNT == 0
+
+    async def test_sigterm_triggers_destroy(self, _restore_sigterm):
+        """Raising the installed SIGTERM handler destroys the ephemeral VM."""
+        transport = _make_cloud_transport(name="eph-killed")
+        transport.connect = AsyncMock()
+        transport.disconnect = AsyncMock()
+        transport.delete_vm = AsyncMock()
+
+        with (
+            patch.object(CloudTransport, "__init__", lambda self, **kw: None),
+            patch.object(CloudTransport, "__new__", lambda cls, **kw: transport),
+        ):
+            with pytest.raises(SystemExit):
+                async with Sandbox.ephemeral(
+                    Image.linux("ubuntu", "24.04"),
+                    api_key="sk-fake",
+                    telemetry_enabled=False,
+                ) as _sb:
+                    # Simulate the OS delivering SIGTERM: invoke the installed
+                    # handler directly. It raises SystemExit, which propagates
+                    # through the async-with's finally and calls destroy().
+                    signal.getsignal(signal.SIGTERM)(signal.SIGTERM, None)
+
+        transport.delete_vm.assert_awaited_once()
+
+    async def test_nested_ephemerals_keep_handler_until_outermost_exits(
+        self, _restore_sigterm
+    ):
+        """The handler is only uninstalled when the last ephemeral exits."""
+        t1 = _make_cloud_transport(name="outer")
+        t1.connect = AsyncMock()
+        t1.disconnect = AsyncMock()
+        t1.delete_vm = AsyncMock()
+
+        t2 = _make_cloud_transport(name="inner")
+        t2.connect = AsyncMock()
+        t2.disconnect = AsyncMock()
+        t2.delete_vm = AsyncMock()
+
+        transports = iter([t1, t2])
+
+        with (
+            patch.object(CloudTransport, "__init__", lambda self, **kw: None),
+            patch.object(
+                CloudTransport, "__new__", lambda cls, **kw: next(transports)
+            ),
+        ):
+            async with Sandbox.ephemeral(
+                Image.linux("ubuntu", "24.04"),
+                api_key="sk-fake",
+                telemetry_enabled=False,
+            ):
+                assert sandbox_mod._ACTIVE_EPHEMERAL_COUNT == 1
+                async with Sandbox.ephemeral(
+                    Image.linux("ubuntu", "24.04"),
+                    api_key="sk-fake",
+                    telemetry_enabled=False,
+                ):
+                    assert sandbox_mod._ACTIVE_EPHEMERAL_COUNT == 2
+                    assert (
+                        signal.getsignal(signal.SIGTERM)
+                        is sandbox_mod._sigterm_raise_systemexit
+                    )
+                assert sandbox_mod._ACTIVE_EPHEMERAL_COUNT == 1
+                # Handler still in place while the outer scope is active.
+                assert (
+                    signal.getsignal(signal.SIGTERM)
+                    is sandbox_mod._sigterm_raise_systemexit
+                )
+
+        assert sandbox_mod._ACTIVE_EPHEMERAL_COUNT == 0
+        assert (
+            signal.getsignal(signal.SIGTERM)
+            is not sandbox_mod._sigterm_raise_systemexit
+        )


### PR DESCRIPTION
## Summary
This PR adds a SIGTERM signal handler to the ephemeral sandbox context manager to ensure that cloud VMs are properly destroyed when the process receives a termination signal, preventing resource leaks.

## Key Changes
- **SIGTERM handler installation**: When entering an ephemeral sandbox context, a SIGTERM handler is installed that converts the signal into a `SystemExit` exception, allowing the `async with` block's `finally` clause to run and trigger cleanup via `destroy()`.
- **Reference counting for nested contexts**: Implemented a counter (`_ACTIVE_EPHEMERAL_COUNT`) to track active ephemeral scopes, ensuring the handler is only installed when the first ephemeral enters and only removed when the last one exits. This properly handles nested ephemeral contexts.
- **Thread-safe handler management**: The handler is only installed from the main thread and gracefully handles environments where signal handling is unavailable (e.g., embedded interpreters).
- **Comprehensive test coverage**: Added three new test cases covering:
  - Handler installation and removal on context entry/exit
  - SIGTERM triggering VM destruction
  - Correct handler lifecycle with nested ephemeral contexts

## Implementation Details
- Added module-level state variables (`_ACTIVE_EPHEMERAL_COUNT`, `_SIGTERM_INSTALLED`, `_PREV_SIGTERM_HANDLER`) to track handler state
- The `_sigterm_raise_systemexit()` handler raises `SystemExit(128 + signum)` following Unix signal exit code conventions
- Previous signal handlers are properly saved and restored to avoid interfering with other signal handling
- The ephemeral context manager now has nested try-finally blocks: the inner one handles sandbox cleanup, the outer one handles handler uninstallation
- Added test fixture `_restore_sigterm` to snapshot and restore signal handler state between tests

https://claude.ai/code/session_01Af133vtJ6uFeeY7fTR2SEs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ephemeral sandboxes now properly handle termination signals, ensuring cleanup executes correctly during interruptions.

* **Tests**
  * Added comprehensive test coverage for signal handling in ephemeral sandbox operations, including handler lifecycle management and nested scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->