### PR TITLE
perf(cua-driver): use on-screen-only SCShareableContent query for permission probe

### DIFF
--- a/libs/cua-driver/Sources/CuaDriverCore/Permissions/Permissions.swift
+++ b/libs/cua-driver/Sources/CuaDriverCore/Permissions/Permissions.swift
@@ -22,10 +22,13 @@ public enum Permissions {
     ///
     /// Accessibility uses `AXIsProcessTrusted()` — reliable.
     ///
-    /// Screen Recording does a real probe via `SCShareableContent.current`
+    /// Screen Recording does a real probe via
+    /// `SCShareableContent.excludingDesktopWindows(_:onScreenWindowsOnly:)`
     /// rather than `CGPreflightScreenCaptureAccess()` — the latter returns
     /// false negatives for subprocess-launched apps, even when the grant is
-    /// active. The probe costs ~100-300ms but returns the truth.
+    /// active. Limiting the query to on-screen windows avoids the multi-second
+    /// stall caused by `SCShareableContent.current` enumerating thousands of
+    /// off-screen windows (e.g. from a crashed system process).
     public static func currentStatus() async -> PermissionsStatus {
         async let screen = probeScreenRecording()
         return await PermissionsStatus(
@@ -54,7 +57,15 @@ public enum Permissions {
 
     private static func probeScreenRecording() async -> Bool {
         do {
-            _ = try await SCShareableContent.current
+            // Prefer the on-screen-only variant over `SCShareableContent.current`.
+            // The latter must resolve app names for every window — including
+            // thousands of off-screen windows left by crashed system processes —
+            // which can stall for several seconds on affected machines.
+            // The lighter query still throws `SCStreamError.userDeclined` when
+            // the Screen Recording TCC grant is absent, so it is equally
+            // reliable as a permission probe.
+            _ = try await SCShareableContent.excludingDesktopWindows(
+                false, onScreenWindowsOnly: true)
             return true
         } catch {
             return false


### PR DESCRIPTION
Fixes #1371

## Problem

`Permissions.currentStatus()` calls `SCShareableContent.current` to probe the Screen Recording TCC grant. This API enumerates **all** windows system-wide, including off-screen ones, and resolves the display name of each window's owner process. When a macOS system process (e.g. `CursorUIViewService`) has crashed and left thousands of zombie windows behind, the name-resolution loop can block for **6+ seconds** on M1 hardware.

## Solution

Replace `SCShareableContent.current` with `SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)`. This limits the query to on-screen windows only, skipping the heavyweight off-screen window enumeration that triggers the slowdown.

The lighter call **still throws `SCStreamError.userDeclined`** when the Screen Recording TCC grant is absent, so permission detection remains fully accurate — it just no longer stalls when a rogue system process is present.

## Testing

- Verified the API throws when Screen Recording is denied and returns successfully when granted.
- The `VideoRecorder` and `WindowCapture` code paths that need full window lists continue to use `SCShareableContent.current` as-is — this change is scoped to the permission probe only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced screen recording permission detection to reduce performance stalls when numerous windows are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->