### PR TITLE
[codex] add launch options to launch_app

### DIFF
--- a/docs/content/docs/cua-driver/guide/getting-started/faq.mdx
+++ b/docs/content/docs/cua-driver/guide/getting-started/faq.mdx
@@ -101,6 +101,12 @@ cua-driver launch_app '{"bundle_id":"com.google.Chrome","urls":["https://trycua.
 
 The URL opens in a new window via Chrome's `application(_:open:)` delegate. The driver's focus-restore guard catches Chrome's internal activation and clobbers the frontmost back to what it was before the call.
 
+For isolated test runs, pass a fresh Chrome user data directory and force a distinct process:
+
+```bash
+cua-driver launch_app '{"bundle_id":"com.google.Chrome","urls":["https://trycua.com"],"arguments":["--user-data-dir=/tmp/cua-session-a","--no-first-run","--no-default-browser-check"],"creates_new_application_instance":true,"allows_running_application_substitution":false}'
+```
+
 <Callout type="warn">
   Don't use `hotkey ⌘L` to focus the omnibox. Even when delivered to a backgrounded pid, `⌘L` steals
   focus because the receiving app interprets "user wants to type here" as activation intent.

--- a/docs/content/docs/cua-driver/reference/mcp-tools.mdx
+++ b/docs/content/docs/cua-driver/reference/mcp-tools.mdx
@@ -111,9 +111,29 @@ Launch an app hidden (no focus steal) and return its pid plus the initial `windo
 - `bundle_id` (string, optional): App bundle identifier, e.g. `com.apple.calculator`.
 - `name` (string, optional): App display name. Used only when `bundle_id` is absent.
 - `urls` (array of string, optional): `file://` / `http(s)://` URLs (or plain paths with `~` expansion) handed to the launched app via `application(_:open:)`. For Finder, a folder URL opens a backgrounded window rooted there. Apps that don't implement `application(_:open:)` launch normally and ignore these.
+- `arguments` (array of string, optional): Process arguments passed through `NSWorkspace.OpenConfiguration`.
+- `environment` (object of string values, optional): Environment variables passed through `NSWorkspace.OpenConfiguration`.
+- `creates_new_application_instance` (boolean, optional): Maps to `NSWorkspace.OpenConfiguration.createsNewApplicationInstance`. Use this when launch arguments must apply to a distinct process instead of an already-running app instance.
+- `allows_running_application_substitution` (boolean, optional): Maps to `NSWorkspace.OpenConfiguration.allowsRunningApplicationSubstitution`. Set `false` when the launch must not be satisfied by a substitute already-running application.
 
 ```json
 {"bundle_id": "com.apple.finder", "urls": ["~/Documents"]}
+```
+
+Isolated Chrome-family sessions can pass a temporary user data directory and force a distinct process:
+
+```json
+{
+  "bundle_id": "com.google.Chrome",
+  "urls": ["http://localhost:3000"],
+  "arguments": [
+    "--user-data-dir=/tmp/cua-session-a",
+    "--no-first-run",
+    "--no-default-browser-check"
+  ],
+  "creates_new_application_instance": true,
+  "allows_running_application_substitution": false
+}
 ```
 
 ### check_permissions

--- a/libs/cua-driver/Skills/cua-driver/SKILL.md
+++ b/libs/cua-driver/Skills/cua-driver/SKILL.md
@@ -116,7 +116,7 @@ rationale in "Navigating native menu bars" below.
 
 **"Open \<app\>" in user speech means launch, not activate.**
 `cua-driver launch_app` is the one correct path for process
-startup — it's idempotent (no-op on a running app), returns the
+startup — by default it's idempotent (no-op on a running app), returns the
 pid, and has an internal `FocusRestoreGuard` that catches
 `NSApp.activate(ignoringOtherApps:)` calls the target makes during
 `application(_:open:)` and clobbers the frontmost back to what it
@@ -124,6 +124,10 @@ was before the launch. That guard is why `launch_app` with `urls`
 (e.g. `{"bundle_id": "com.colliderli.iina", "urls": ["~/video.mp4"]}`)
 is safe even for apps that normally foreground on media-load
 (Chrome, Electron, media players).
+
+When an agent needs a separate browser state, pass launch
+`arguments` and `creates_new_application_instance: true`; for
+Chrome-family browsers, use a fresh `--user-data-dir` per session.
 
 ## Defaults — always prefer cua-driver over shell shims
 

--- a/libs/cua-driver/Skills/cua-driver/WEB_APPS.md
+++ b/libs/cua-driver/Skills/cua-driver/WEB_APPS.md
@@ -78,6 +78,28 @@ AX reads + element-indexed actions against the hidden window
 work normally, so for agents that just need to extract / click
 things on the loaded page, no unhide is required.
 
+**Isolated test sessions:** when the agent must avoid the user's
+default browser profile, pass Chrome-family launch flags through
+`arguments` and force a distinct app instance:
+
+```
+launch_app({
+  bundle_id: "com.google.Chrome",
+  urls: ["http://localhost:3000"],
+  arguments: [
+    "--user-data-dir=/tmp/cua-session-a",
+    "--no-first-run",
+    "--no-default-browser-check"
+  ],
+  creates_new_application_instance: true,
+  allows_running_application_substitution: false
+})
+```
+
+Use a fresh `--user-data-dir` per agent. This keeps cookies,
+localStorage, extensions, and profile state isolated from both the
+human user's Chrome profile and other agent sessions.
+
 **Last-resort path — omnibox via `⌘L`:** forbidden under the
 no-foreground contract (see SKILL.md) because `⌘L` activates
 Chrome even when delivered to a backgrounded pid. Keep this

--- a/libs/cua-driver/Sources/CuaDriverCore/Apps/AppLauncher.swift
+++ b/libs/cua-driver/Sources/CuaDriverCore/Apps/AppLauncher.swift
@@ -3,6 +3,26 @@ import CoreGraphics
 import Foundation
 
 public enum AppLauncher {
+    public struct LaunchOptions: Sendable {
+        public var arguments: [String]
+        public var environment: [String: String]
+        public var createsNewApplicationInstance: Bool?
+        public var allowsRunningApplicationSubstitution: Bool?
+
+        public init(
+            arguments: [String] = [],
+            environment: [String: String] = [:],
+            createsNewApplicationInstance: Bool? = nil,
+            allowsRunningApplicationSubstitution: Bool? = nil
+        ) {
+            self.arguments = arguments
+            self.environment = environment
+            self.createsNewApplicationInstance = createsNewApplicationInstance
+            self.allowsRunningApplicationSubstitution =
+                allowsRunningApplicationSubstitution
+        }
+    }
+
     public enum LaunchError: Error, CustomStringConvertible, Sendable {
         case notFound(String)
         case launchFailed(String)
@@ -53,13 +73,31 @@ public enum AppLauncher {
     public static func launch(
         bundleId: String? = nil,
         name: String? = nil,
-        urls: [URL] = []
+        urls: [URL] = [],
+        options: LaunchOptions = LaunchOptions()
     ) async throws -> AppInfo {
         let appURL = try locate(bundleId: bundleId, name: name)
 
         let config = NSWorkspace.OpenConfiguration()
         config.activates = false
         config.addsToRecentItems = false
+        if !options.arguments.isEmpty {
+            config.arguments = options.arguments
+        }
+        if !options.environment.isEmpty {
+            config.environment = options.environment
+        }
+        if let createsNewApplicationInstance =
+            options.createsNewApplicationInstance
+        {
+            config.createsNewApplicationInstance = createsNewApplicationInstance
+        }
+        if let allowsRunningApplicationSubstitution =
+            options.allowsRunningApplicationSubstitution
+        {
+            config.allowsRunningApplicationSubstitution =
+                allowsRunningApplicationSubstitution
+        }
         // NOTE: we used to set `config.hides = true` on the theory that
         // it forced the launch lifecycle to complete. Empirically, when
         // LaunchServices cold-launches Calculator without `hides`,

--- a/libs/cua-driver/Sources/CuaDriverServer/Tools/LaunchAppTool.swift
+++ b/libs/cua-driver/Sources/CuaDriverServer/Tools/LaunchAppTool.swift
@@ -4,6 +4,11 @@ import Foundation
 import MCP
 
 public enum LaunchAppTool {
+    private enum Validation<T> {
+        case success(T)
+        case failure(String)
+    }
+
     public static let handler = ToolHandler(
         tool: Tool(
             name: "launch_app",
@@ -47,6 +52,17 @@ public enum LaunchAppTool {
                 with any app that implements `application(_:open:)`; apps
                 that ignore the delegate simply launch without side effects.
 
+                Optional `arguments`, `environment`,
+                `creates_new_application_instance`, and
+                `allows_running_application_substitution` map directly to
+                `NSWorkspace.OpenConfiguration`. Use these when the target
+                app needs launch-time configuration, for example starting a
+                Chrome-family browser with an isolated `--user-data-dir`.
+                Note that apps may ignore launch arguments when the request
+                is routed to an already-running instance; pass
+                `creates_new_application_instance: true` when you need a
+                distinct process.
+
                 Use this instead of shelling out to `open -a` — the shell form
                 always activates the target, requires an extra permission
                 prompt for Bash, and doesn't even try to respect
@@ -82,13 +98,35 @@ public enum LaunchAppTool {
                         "description":
                             "Optional file:// or http(s):// URLs (or plain paths with ~ expansion) to hand to the launched app via application(_:open:). For Finder, pass a folder URL or path to open a backgrounded Finder window rooted at that folder — no activation. Apps that don't implement application(_:open:) launch normally and ignore these.",
                     ],
+                    "arguments": [
+                        "type": "array",
+                        "items": ["type": "string"],
+                        "description":
+                            "Optional process arguments passed through NSWorkspace.OpenConfiguration. For isolated Chrome-family sessions, include flags such as --user-data-dir=/tmp/cua-session-a, --no-first-run, and --no-default-browser-check.",
+                    ],
+                    "environment": [
+                        "type": "object",
+                        "additionalProperties": ["type": "string"],
+                        "description":
+                            "Optional environment variables passed through NSWorkspace.OpenConfiguration.",
+                    ],
+                    "creates_new_application_instance": [
+                        "type": "boolean",
+                        "description":
+                            "Optional NSWorkspace.OpenConfiguration.createsNewApplicationInstance. Set true when launch arguments must apply to a distinct process instead of an already-running app instance.",
+                    ],
+                    "allows_running_application_substitution": [
+                        "type": "boolean",
+                        "description":
+                            "Optional NSWorkspace.OpenConfiguration.allowsRunningApplicationSubstitution. Set false when the launch must not be satisfied by a substitute already-running application.",
+                    ],
                 ],
                 "additionalProperties": false,
             ],
             annotations: .init(
                 readOnlyHint: false,
                 destructiveHint: false,
-                idempotentHint: true,  // relaunching a running app is a no-op
+                idempotentHint: false,
                 openWorldHint: true
             )
         ),
@@ -96,10 +134,48 @@ public enum LaunchAppTool {
             let bundleId = arguments?["bundle_id"]?.stringValue
             let name = arguments?["name"]?.stringValue
             let rawUrls = arguments?["urls"]?.arrayValue ?? []
+            let launchArguments: [String]
+            let launchEnvironment: [String: String]
+            let createsNewApplicationInstance: Bool?
+            let allowsRunningApplicationSubstitution: Bool?
 
             if bundleId == nil && name == nil {
                 return errorResult(
                     "Provide either bundle_id or name to identify the app to launch.")
+            }
+
+            switch parseStringArray(arguments?["arguments"], field: "arguments") {
+            case .success(let values):
+                launchArguments = values
+            case .failure(let message):
+                return errorResult(message)
+            }
+
+            switch parseStringMap(arguments?["environment"], field: "environment") {
+            case .success(let values):
+                launchEnvironment = values
+            case .failure(let message):
+                return errorResult(message)
+            }
+
+            switch parseOptionalBool(
+                arguments?["creates_new_application_instance"],
+                field: "creates_new_application_instance"
+            ) {
+            case .success(let value):
+                createsNewApplicationInstance = value
+            case .failure(let message):
+                return errorResult(message)
+            }
+
+            switch parseOptionalBool(
+                arguments?["allows_running_application_substitution"],
+                field: "allows_running_application_substitution"
+            ) {
+            case .success(let value):
+                allowsRunningApplicationSubstitution = value
+            case .failure(let message):
+                return errorResult(message)
             }
 
             // Resolve url strings → URL values. Accept file:// and http(s)://
@@ -153,7 +229,14 @@ public enum LaunchAppTool {
                 let info = try await AppLauncher.launch(
                     bundleId: bundleId,
                     name: name,
-                    urls: urls
+                    urls: urls,
+                    options: AppLauncher.LaunchOptions(
+                        arguments: launchArguments,
+                        environment: launchEnvironment,
+                        createsNewApplicationInstance: createsNewApplicationInstance,
+                        allowsRunningApplicationSubstitution:
+                            allowsRunningApplicationSubstitution
+                    )
                 )
 
                 // Replace the placeholder pid with the real one so any
@@ -276,6 +359,53 @@ public enum LaunchAppTool {
         }
         let expanded = (raw as NSString).expandingTildeInPath
         return URL(fileURLWithPath: expanded)
+    }
+
+    private static func parseStringArray(
+        _ value: Value?,
+        field: String
+    ) -> Validation<[String]> {
+        guard let value else { return .success([]) }
+        guard let rawValues = value.arrayValue else {
+            return .failure("\(field) must be an array of strings.")
+        }
+        var values: [String] = []
+        for raw in rawValues {
+            guard let str = raw.stringValue, !str.isEmpty else {
+                return .failure("\(field) entries must be non-empty strings.")
+            }
+            values.append(str)
+        }
+        return .success(values)
+    }
+
+    private static func parseStringMap(
+        _ value: Value?,
+        field: String
+    ) -> Validation<[String: String]> {
+        guard let value else { return .success([:]) }
+        guard let rawValues = value.objectValue else {
+            return .failure("\(field) must be an object with string values.")
+        }
+        var values: [String: String] = [:]
+        for (key, raw) in rawValues {
+            guard let str = raw.stringValue else {
+                return .failure("\(field).\(key) must be a string.")
+            }
+            values[key] = str
+        }
+        return .success(values)
+    }
+
+    private static func parseOptionalBool(
+        _ value: Value?,
+        field: String
+    ) -> Validation<Bool?> {
+        guard let value else { return .success(nil) }
+        guard let flag = value.boolValue else {
+            return .failure("\(field) must be a boolean.")
+        }
+        return .success(flag)
     }
 
     private static func errorResult(_ message: String) -> CallTool.Result {


### PR DESCRIPTION
## Summary

Adds launch-time options to `launch_app` so callers can start isolated browser sessions without falling back to shelling out to `open`.

This exposes selected `NSWorkspace.OpenConfiguration` fields through the MCP tool:

- `arguments`
- `environment`
- `creates_new_application_instance`
- `allows_running_application_substitution`

The intended use case is launching Chrome-family browsers with a fresh `--user-data-dir` per agent/session while preserving Cua's background launch/focus-restore behavior.

Fixes #1377.

## Validation

- `swift build` in `libs/cua-driver`
- `swift test` in `libs/cua-driver`
- Local Cua smoke with two background Chrome instances:
  - session A launched with a fresh profile and set `cookie=agent=A`, `localStorage=A`
  - session B launched with a different fresh profile and reported `cookie=none`, `localStorage=none`
  - sessions used distinct root Chrome pids and offscreen/background windows
- Local usertester-agent spike using only `cua-driver` CLI, no Playwright/CDP: `npx tsx src/spikes/cua_isolation_smoke.ts`

## Notes

This does not add a browser-specific abstraction. It keeps `launch_app` generic and lets callers pass app-specific launch flags when they need deterministic process/profile isolation.
