### PR TITLE
feat(cua-driver): require explicit user consent before enabling JS from Apple Events

### DIFF
--- a/libs/cua-driver/Sources/CuaDriverCore/Browser/ElectronJS.swift
+++ b/libs/cua-driver/Sources/CuaDriverCore/Browser/ElectronJS.swift
@@ -77,7 +77,7 @@ public enum ElectronJS {
 
         // Prefer a "page" target (renderer with DOM) if the app was launched with
         // --remote-debugging-port. Page targets expose document/window/DOM APIs.
-        if let pagePort = await pageTarget() {
+        if let pagePort = await pageTarget(pid: pid) {
             return try await cdpEvaluate(port: pagePort, javascript: javascript)
         }
 
@@ -130,8 +130,20 @@ public enum ElectronJS {
     /// DOM access). Returns the port if found. Apps launched with
     /// `--remote-debugging-port=N` expose page targets here; apps activated via
     /// SIGUSR1 only expose a "node" main-process target with no DOM.
-    private static func pageTarget() async -> Int? {
-        for port in [9222, 9223, 9224, 9225, 9230] {
+    ///
+    /// Only probes ports that `lsof` confirms are owned by `pid`, so JS is never
+    /// executed in a different Electron/Chromium app that happens to be listening
+    /// on the same well-known port. Falls back to all candidate ports when
+    /// `lsof` returns empty (race window before the inspector has started).
+    private static func pageTarget(pid: Int32) async -> Int? {
+        let candidatePorts = [9222, 9223, 9224, 9225, 9230]
+        let ownedPorts = await listeningPorts(pid: pid)
+        // Only probe ports owned by this pid; fall back to all candidates when
+        // lsof returns empty (inspector hasn't started yet).
+        let portsToProbe = ownedPorts.isEmpty
+            ? candidatePorts
+            : candidatePorts.filter { ownedPorts.contains($0) }
+        for port in portsToProbe {
             guard let url = URL(string: "http://127.0.0.1:\(port)/json") else { continue }
             var req = URLRequest(url: url); req.timeoutInterval = 0.3
             guard let (data, _) = try? await URLSession.shared.data(for: req),

--- a/libs/cua-driver/Sources/CuaDriverServer/Tools/PageTool.swift
+++ b/libs/cua-driver/Sources/CuaDriverServer/Tools/PageTool.swift
@@ -148,7 +148,7 @@ public enum PageTool {
                 }
                 let attrJS = attrs.isEmpty
                     ? "[]"
-                    : "[\(attrs.map { "\"\($0)\"" }.joined(separator: ", "))]"
+                    : "[\(attrs.map { jsonString($0) }.joined(separator: ", "))]"
                 let js = """
                 (() => {
                   const attrs = \(attrJS);


### PR DESCRIPTION
## Summary

Previously, SKILL.md documented a runbook for agents to autonomously edit Chrome's `Preferences` JSON to enable `allow_javascript_apple_events`. This is problematic: the flag allows any automation tool to execute JavaScript in the user's browser tabs, Chrome syncs it to Google's servers, and doing it silently violates user trust.

This PR adds a programmatic consent gate:

- **`BrowserJS.javascriptNotEnabled` error** now includes a structured message telling the agent to stop, present a specific consent question to the user, and only proceed with `user_has_confirmed_enabling=true`
- **`page(action=enable_javascript_apple_events)`** is a new tool action that quits the browser, patches all profile Preferences files, and relaunches — but **refuses** unless `user_has_confirmed_enabling=true` is explicitly set
- **`WEB_APPS.md`** replaces the raw shell/Python scripts with the tool invocation and a clear "do not enable autonomously" rule

## Consent flow
1. Agent calls `page(action=execute_javascript, ...)`
2. Browser rejects → `page` returns structured error with exact question to ask user
3. Agent asks user; user says yes
4. Agent calls `page(action=enable_javascript_apple_events, bundle_id="com.google.Chrome", user_has_confirmed_enabling=true, ...)`
5. cua-driver quits Chrome, patches prefs, relaunches

## Test plan
- [ ] `swift build` passes
- [ ] Call `enable_javascript_apple_events` without `user_has_confirmed_enabling=true` → error
- [ ] Call with `user_has_confirmed_enabling=true` → Chrome relaunches with flag set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * JavaScript execution now available for web browsers (Chrome, Brave, Edge, Safari, Arc, Firefox)
  * JavaScript execution support for Electron-based applications
  * New page tool for browser interactions: execute JavaScript, retrieve page text, and query DOM elements

* **Documentation**
  * Added setup guide for JavaScript execution in browsers with browser-specific configuration details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->