### PR TITLE
feat(cua-driver): remove LaunchAgent auto-updater; add version hint and launch_app improvements

### DIFF
--- a/libs/cua-driver/Sources/CuaDriverCLI/CuaDriverCommand.swift
+++ b/libs/cua-driver/Sources/CuaDriverCLI/CuaDriverCommand.swift
@@ -327,65 +327,53 @@ enum AppKitBootstrap {
     }
 }
 
-/// `cua-driver update` — trigger a manual update check and optionally apply updates.
-/// Respects the auto-update config flag: if disabled, this command will refuse to run.
+/// `cua-driver update` — check for a newer release and optionally apply it.
 struct UpdateCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "update",
-        abstract: "Check for and apply updates to cua-driver."
+        abstract: "Check for a newer cua-driver release and apply it."
     )
 
-    @Flag(name: .long, help: "Apply updates silently without prompting.")
-    var silent = false
+    @Flag(name: .long, help: "Download and apply the update without prompting.")
+    var apply = false
 
     func run() async throws {
-        let config = await ConfigStore.shared.load()
-        let envOverride = ProcessInfo.processInfo.environment["CUA_DRIVER_AUTO_UPDATE_ENABLED"]
-        
-        var autoUpdateEnabled = config.autoUpdateEnabled
-        if let envValue = envOverride {
-            let lower = envValue.lowercased()
-            if ["0", "false", "no", "off"].contains(lower) {
-                autoUpdateEnabled = false
-            } else if ["1", "true", "yes", "on"].contains(lower) {
-                autoUpdateEnabled = true
-            }
-        }
-        
-        if !autoUpdateEnabled {
-            print("Auto-update is disabled. Enable it with:")
-            print("  cua-driver config updates enable")
+        let current = CuaDriverCore.version
+        print("Current version: \(current)")
+        print("Checking for updates…")
+
+        guard let latest = await VersionCheck.fetchLatest() else {
+            print("Could not reach GitHub — check your connection and try again.")
             throw ExitCode(1)
         }
-        
-        // Find and execute the update script
-        let updateScriptPath = "/usr/local/bin/cua-driver-update"
-        let fileManager = FileManager.default
-        
-        if !fileManager.fileExists(atPath: updateScriptPath) {
-            print("Error: update script not found at \(updateScriptPath)")
-            throw ExitCode(1)
+
+        guard VersionCheck.isNewer(latest, than: current) else {
+            print("Already up to date.")
+            return
         }
-        
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/bash")
-        var args = [updateScriptPath]
-        if silent {
-            args.append("--silent")
+
+        print("New version available: \(latest)")
+
+        if !apply {
+            print("")
+            print("Run with --apply to download and install it:")
+            print("  cua-driver update --apply")
+            print("")
+            print("Or reinstall directly:")
+            print("  curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh | bash")
+            return
         }
-        process.arguments = args
-        
-        do {
-            try process.run()
-            process.waitUntilExit()
-            
-            if process.terminationStatus != 0 {
-                print("Update check failed. See /tmp/cua_driver_updater.log for details.")
-                throw ExitCode(Int32(process.terminationStatus))
-            }
-        } catch {
-            print("Error running update script: \(error)")
-            throw ExitCode(1)
+
+        print("Downloading and installing cua-driver \(latest)…")
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/bash")
+        proc.arguments = ["-c",
+            "curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh | bash"]
+        try proc.run()
+        proc.waitUntilExit()
+        if proc.terminationStatus != 0 {
+            print("Installation failed — run the command above manually for details.")
+            throw ExitCode(Int32(proc.terminationStatus))
         }
     }
 }

--- a/libs/cua-driver/Sources/CuaDriverCLI/ServeCommand.swift
+++ b/libs/cua-driver/Sources/CuaDriverCLI/ServeCommand.swift
@@ -143,6 +143,10 @@ struct ServeCommand: ParsableCommand {
             // defaults inside `ConfigStore.load()` — no failure here.
             let config = await ConfigStore.shared.load()
 
+            // Non-blocking version hint — prints to stderr if a newer release
+            // exists on GitHub. Fails silently when offline.
+            VersionCheck.warnIfOutdated()
+
             // Propagate persisted agent-cursor preferences into the live
             // singleton so the daemon boots in the same state the user
             // last wrote. `setAgentCursorEnabled` / `setAgentCursorMotion`

--- a/libs/cua-driver/Sources/CuaDriverCLI/VersionCheck.swift
+++ b/libs/cua-driver/Sources/CuaDriverCLI/VersionCheck.swift
@@ -1,0 +1,62 @@
+import CuaDriverCore
+import Foundation
+
+enum VersionCheck {
+
+    private static let repo = "trycua/cua"
+    private static let tagPrefix = "cua-driver-v"
+
+    /// Fetch the latest cua-driver release tag from GitHub.
+    /// Returns nil silently on network failure or timeout.
+    static func fetchLatest(timeout: TimeInterval = 4) async -> String? {
+        guard let url = URL(string: "https://api.github.com/repos/\(repo)/releases?per_page=40") else {
+            return nil
+        }
+        var req = URLRequest(url: url, timeoutInterval: timeout)
+        req.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        req.setValue("cua-driver/\(CuaDriverCore.version)", forHTTPHeaderField: "User-Agent")
+
+        guard let (data, _) = try? await URLSession.shared.data(for: req),
+              let releases = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        else { return nil }
+
+        for release in releases {
+            guard let tag = release["tag_name"] as? String,
+                  tag.hasPrefix(tagPrefix),
+                  release["draft"] as? Bool != true,
+                  release["prerelease"] as? Bool != true
+            else { continue }
+            return String(tag.dropFirst(tagPrefix.count))
+        }
+        return nil
+    }
+
+    /// True when `candidate` is strictly newer than `current` (semver compare).
+    static func isNewer(_ candidate: String, than current: String) -> Bool {
+        let lhs = parts(candidate)
+        let rhs = parts(current)
+        for (a, b) in zip(lhs, rhs) {
+            if a != b { return a > b }
+        }
+        return lhs.count > rhs.count
+    }
+
+    /// Fire-and-forget: print a one-liner to stderr if a newer version exists.
+    /// Safe to call at server startup — exits silently if offline or up to date.
+    static func warnIfOutdated() {
+        Task.detached(priority: .background) {
+            guard let latest = await fetchLatest(),
+                  isNewer(latest, than: CuaDriverCore.version)
+            else { return }
+            fputs(
+                "⚠  cua-driver \(latest) is available (you have \(CuaDriverCore.version))."
+                + " Run: cua-driver update\n",
+                stderr
+            )
+        }
+    }
+
+    private static func parts(_ version: String) -> [Int] {
+        version.split(separator: ".").compactMap { Int($0) }
+    }
+}

--- a/libs/cua-driver/Sources/CuaDriverCore/Apps/AppLauncher.swift
+++ b/libs/cua-driver/Sources/CuaDriverCore/Apps/AppLauncher.swift
@@ -53,11 +53,21 @@ public enum AppLauncher {
     public static func launch(
         bundleId: String? = nil,
         name: String? = nil,
-        urls: [URL] = []
+        urls: [URL] = [],
+        additionalArguments: [String] = [],
+        additionalEnvironment: [String: String] = [:],
+        createsNewApplicationInstance: Bool = false
     ) async throws -> AppInfo {
         let appURL = try locate(bundleId: bundleId, name: name)
 
         let config = NSWorkspace.OpenConfiguration()
+        if !additionalArguments.isEmpty {
+            config.arguments = additionalArguments
+        }
+        if !additionalEnvironment.isEmpty {
+            config.environment = additionalEnvironment
+        }
+        config.createsNewApplicationInstance = createsNewApplicationInstance
         config.activates = false
         config.addsToRecentItems = false
         // NOTE: we used to set `config.hides = true` on the theory that

--- a/libs/cua-driver/Sources/CuaDriverCore/Apps/AppLauncher.swift
+++ b/libs/cua-driver/Sources/CuaDriverCore/Apps/AppLauncher.swift
@@ -65,7 +65,9 @@ public enum AppLauncher {
             config.arguments = additionalArguments
         }
         if !additionalEnvironment.isEmpty {
-            config.environment = additionalEnvironment
+            var env = ProcessInfo.processInfo.environment
+            env.merge(additionalEnvironment) { _, new in new }
+            config.environment = env
         }
         config.createsNewApplicationInstance = createsNewApplicationInstance
         config.activates = false

--- a/libs/cua-driver/Sources/CuaDriverServer/Tools/LaunchAppTool.swift
+++ b/libs/cua-driver/Sources/CuaDriverServer/Tools/LaunchAppTool.swift
@@ -47,6 +47,24 @@ public enum LaunchAppTool {
                 with any app that implements `application(_:open:)`; apps
                 that ignore the delegate simply launch without side effects.
 
+                Optional `electron_debugging_port` launches an Electron app
+                with `--remote-debugging-port=<N>`, activating its Chrome
+                DevTools Protocol (CDP) on that port. This gives the `page`
+                tool full renderer/DOM access (`document`, `window`,
+                `fetch`, etc.) via page targets rather than the restricted
+                Node main-process context exposed by SIGUSR1. Use port 9222
+                unless you're running multiple Electron apps simultaneously.
+                Has no effect on non-Electron apps.
+
+                Optional `webkit_inspector_port` launches a Tauri/WKWebView
+                app with `WEBKIT_INSPECTOR_SERVER=127.0.0.1:<N>`, activating
+                WebKit's remote inspector. The `page` tool will use this to
+                execute JavaScript in the WKWebView renderer. Use port 9226
+                (reserved WebKit range: 9226–9228). Requires
+                `developerExtrasEnabled = true` in the app's WKWebView config
+                (default in Tauri debug builds; production builds may disable
+                it). Has no effect on non-WKWebView apps.
+
                 Use this instead of shelling out to `open -a` — the shell form
                 always activates the target, requires an extra permission
                 prompt for Bash, and doesn't even try to respect
@@ -82,6 +100,37 @@ public enum LaunchAppTool {
                         "description":
                             "Optional file:// or http(s):// URLs (or plain paths with ~ expansion) to hand to the launched app via application(_:open:). For Finder, pass a folder URL or path to open a backgrounded Finder window rooted at that folder — no activation. Apps that don't implement application(_:open:) launch normally and ignore these.",
                     ],
+                    "electron_debugging_port": [
+                        "type": "integer",
+                        "description": "Launch an Electron app with --remote-debugging-port=<N> so the `page` tool gets full renderer/DOM access. Use 9222 unless running multiple Electron apps. Ignored for non-Electron apps.",
+                    ],
+                    "webkit_inspector_port": [
+                        "type": "integer",
+                        "description": "Launch a Tauri/WKWebView app with WEBKIT_INSPECTOR_SERVER=127.0.0.1:<N> so the `page` tool can reach its WebKit inspector. Use 9226 (reserved WebKit range: 9226–9228, distinct from Electron's 9222–9225). Requires developerExtrasEnabled=true in the WKWebView config (default in Tauri debug builds).",
+                    ],
+                    "creates_new_application_instance": [
+                        "type": "boolean",
+                        "description": """
+                            Force a brand-new process even if the app is already running. \
+                            Useful for isolated browser sessions: pass \
+                            creates_new_application_instance=true together with \
+                            additional_arguments=[\"--user-data-dir=/tmp/session-a\", \
+                            \"--no-first-run\", \"--no-default-browser-check\"] to launch \
+                            a sandboxed Chrome that cannot see the user's real profile, \
+                            cookies, or extensions. Each session gets its own pid and \
+                            window identity and can be controlled independently.
+                            """,
+                    ],
+                    "additional_arguments": [
+                        "type": "array",
+                        "items": ["type": "string"],
+                        "description": """
+                            Extra command-line arguments passed to the launched process. \
+                            Passed directly as argv entries — no shell expansion. \
+                            Example: [\"--user-data-dir=/tmp/cua-session\", \
+                            \"--no-first-run\"] for an isolated Chrome session.
+                            """,
+                    ],
                 ],
                 "additionalProperties": false,
             ],
@@ -96,6 +145,10 @@ public enum LaunchAppTool {
             let bundleId = arguments?["bundle_id"]?.stringValue
             let name = arguments?["name"]?.stringValue
             let rawUrls = arguments?["urls"]?.arrayValue ?? []
+            let electronDebuggingPort = arguments?["electron_debugging_port"]?.intValue
+            let webkitInspectorPort = arguments?["webkit_inspector_port"]?.intValue
+            let createsNewInstance = arguments?["creates_new_application_instance"]?.boolValue ?? false
+            let rawExtraArgs = arguments?["additional_arguments"]?.arrayValue ?? []
 
             if bundleId == nil && name == nil {
                 return errorResult(
@@ -150,10 +203,28 @@ public enum LaunchAppTool {
                         )
                 }
 
+                var additionalArguments: [String] = rawExtraArgs.compactMap { $0.stringValue }
+                if let port = electronDebuggingPort {
+                    additionalArguments.append("--remote-debugging-port=\(port)")
+                }
+
+                var additionalEnvironment: [String: String] = [:]
+                if let port = webkitInspectorPort {
+                    additionalEnvironment["WEBKIT_INSPECTOR_SERVER"] = "127.0.0.1:\(port)"
+                    // wry (the WebView runtime used by Tauri) checks this env var at
+                    // WKWebView init time and sets allowsRemoteInspection = true, which
+                    // is required for WEBKIT_INSPECTOR_SERVER to actually open the socket.
+                    // Harmless for non-Tauri WKWebView apps (they don't read it).
+                    additionalEnvironment["TAURI_WEBVIEW_AUTOMATION"] = "1"
+                }
+
                 let info = try await AppLauncher.launch(
                     bundleId: bundleId,
                     name: name,
-                    urls: urls
+                    urls: urls,
+                    additionalArguments: additionalArguments,
+                    additionalEnvironment: additionalEnvironment,
+                    createsNewApplicationInstance: createsNewInstance
                 )
 
                 // Replace the placeholder pid with the real one so any
@@ -203,6 +274,12 @@ public enum LaunchAppTool {
                 }
 
                 var summary = "✅ Launched \(info.name) (pid \(info.pid)) in background."
+                if let port = electronDebuggingPort {
+                    summary += " CDP renderer available on port \(port) — use `page` tool for full DOM access."
+                }
+                if let port = webkitInspectorPort {
+                    summary += " WebKit inspector available on port \(port) — use `page` tool for DOM access."
+                }
                 if shouldSuppress {
                     let frontmostAfter = await MainActor.run {
                         NSWorkspace.shared.frontmostApplication

--- a/libs/cua-driver/scripts/install.sh
+++ b/libs/cua-driver/scripts/install.sh
@@ -10,11 +10,8 @@
 # Override the release tag with $CUA_DRIVER_VERSION:
 #   CUA_DRIVER_VERSION=0.1.0 /bin/bash -c "$(curl -fsSL .../install.sh)"
 #
-# Skip the auto-updater setup:
-#   CUA_DRIVER_NO_UPDATER=1 /bin/bash -c "$(curl -fsSL .../install.sh)"
-#
 # Uninstall:
-#   sudo rm -rf /Applications/CuaDriver.app /usr/local/bin/cua-driver
+#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.sh)"
 set -euo pipefail
 
 REPO="trycua/cua"
@@ -25,14 +22,6 @@ APP_DEST="/Applications/$APP_NAME"
 BIN_LINK="/usr/local/bin/$BINARY_NAME"
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT
-
-# Whether to install the auto-updater (default: true)
-INSTALL_AUTO_UPDATER="${CUA_DRIVER_NO_UPDATER:-0}"
-if [[ "$INSTALL_AUTO_UPDATER" == "1" ]]; then
-    INSTALL_AUTO_UPDATER=false
-else
-    INSTALL_AUTO_UPDATER=true
-fi
 
 log() { printf '==> %s\n' "$*"; }
 err() { printf 'error: %s\n' "$*" >&2; }
@@ -138,201 +127,6 @@ if [[ -d "$HOME/.claude/skills" ]]; then
     else
         log "skill pack missing at $SKILL_TARGET (skipping; older release?)"
     fi
-fi
-
-# --- Install auto-updater -----------------------------------------------
-
-if [[ "$INSTALL_AUTO_UPDATER" == "true" ]]; then
-    log "setting up auto-updater"
-
-    # Matches lume's pattern — emit the update script as a heredoc
-    # from inside install.sh rather than shipping a sibling
-    # update.sh file. Keeps the installer self-contained and means a
-    # user who runs just `curl | bash` has everything they need with
-    # no second fetch. Contents are identical to what an external
-    # update.sh would be.
-    UPDATER_SCRIPT="/usr/local/bin/cua-driver-update"
-    $SUDO tee "$UPDATER_SCRIPT" > /dev/null << 'UPDATER_EOF'
-#!/bin/bash
-# cua-driver auto-updater. Installed by scripts/install.sh; invoked
-# weekly by the com.trycua.cua_driver_updater LaunchAgent or on demand
-# via `cua-driver update`. Reads the opt-out flag from the persisted
-# config + the CUA_DRIVER_AUTO_UPDATE_ENABLED env var, fetches the
-# latest cua-driver-v* release from GitHub, and atomically replaces
-# /Applications/CuaDriver.app when a newer version is available.
-set -e
-
-LOG_FILE="/tmp/cua_driver_updater.log"
-GITHUB_REPO="trycua/cua"
-TAG_PREFIX="cua-driver-v"
-APP_NAME="CuaDriver.app"
-APP_INSTALL_DIR="/Applications/$APP_NAME"
-BIN_LINK="/usr/local/bin/cua-driver"
-
-log() {
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
-}
-
-log "Starting cua-driver update check..."
-
-# Env override wins over config.
-if [ -n "${CUA_DRIVER_AUTO_UPDATE_ENABLED:-}" ]; then
-    case "${CUA_DRIVER_AUTO_UPDATE_ENABLED,,}" in
-        0|false|no|off)
-            log "Auto-update disabled via CUA_DRIVER_AUTO_UPDATE_ENABLED; exiting."
-            exit 0
-            ;;
-    esac
-fi
-
-# Otherwise consult the persisted config.
-CONFIG_FILE="$HOME/Library/Application Support/Cua Driver/config.json"
-if [ -f "$CONFIG_FILE" ] && grep -q '"auto_update_enabled":[[:space:]]*false' "$CONFIG_FILE"; then
-    log "Auto-update disabled in config; exiting."
-    exit 0
-fi
-
-if [ ! -x "$BIN_LINK" ]; then
-    log "ERROR: cua-driver binary not found at $BIN_LINK"
-    exit 1
-fi
-
-CURRENT_VERSION=$("$BIN_LINK" --version 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "0.0.0")
-log "Current version: $CURRENT_VERSION"
-
-get_latest_tag() {
-    local response=$(curl -s "https://api.github.com/repos/$GITHUB_REPO/releases?per_page=40")
-    [ -z "$response" ] && return 1
-    echo "$response" | grep -oE '"tag_name":[[:space:]]*"'"${TAG_PREFIX}"'[^"]+"' | head -n 1 | sed -E 's/.*"('"${TAG_PREFIX}"'[^"]+)".*/\1/'
-}
-
-LATEST_TAG=$(get_latest_tag)
-if [ -z "$LATEST_TAG" ]; then
-    log "ERROR: Could not fetch latest release tag"
-    exit 1
-fi
-
-LATEST_VERSION="${LATEST_TAG#${TAG_PREFIX}}"
-log "Latest version: $LATEST_VERSION"
-
-version_gt() {
-    [ "$(printf '%s\n' "$1" "$2" | sort -V | tail -n1)" = "$1" ] && [ "$1" != "$2" ]
-}
-
-apply_update() {
-    log "Downloading and applying update..."
-    local temp_dir=$(mktemp -d)
-    trap 'rm -rf "$temp_dir"' EXIT
-
-    local arch=$(uname -m)
-    local version="${LATEST_TAG#${TAG_PREFIX}}"
-    local tarball="cua-driver-${version}-darwin-${arch}.tar.gz"
-    local download_url="https://github.com/$GITHUB_REPO/releases/download/$LATEST_TAG/$tarball"
-
-    if ! curl -fsSL -o "$temp_dir/$tarball" "$download_url"; then
-        log "ERROR: Failed to download $tarball"
-        exit 1
-    fi
-    if ! tar -tzf "$temp_dir/$tarball" > /dev/null 2>&1; then
-        log "ERROR: Downloaded file is not a valid tar.gz archive"
-        exit 1
-    fi
-    if ! tar -xzf "$temp_dir/$tarball" -C "$temp_dir"; then
-        log "ERROR: Failed to extract tarball"
-        exit 1
-    fi
-    if [ ! -d "$temp_dir/$APP_NAME" ]; then
-        log "ERROR: $APP_NAME not found inside tarball"
-        exit 1
-    fi
-
-    # ditto preserves code signatures and xattrs; cp -R strips
-    # Gatekeeper metadata on some macOS versions.
-    [ -e "$APP_INSTALL_DIR" ] && rm -rf "$APP_INSTALL_DIR"
-    ditto "$temp_dir/$APP_NAME" "$APP_INSTALL_DIR"
-
-    local app_binary="$APP_INSTALL_DIR/Contents/MacOS/cua-driver"
-    if [ ! -x "$app_binary" ]; then
-        log "ERROR: Binary missing at $app_binary after extraction"
-        exit 1
-    fi
-
-    local sudo=""
-    [ ! -w "$(dirname "$BIN_LINK")" ] && sudo="sudo"
-    $sudo mkdir -p "$(dirname "$BIN_LINK")"
-    $sudo ln -sf "$app_binary" "$BIN_LINK"
-
-    log "Successfully updated cua-driver to version $version"
-    osascript -e "display notification \"Updated to version $version\" with title \"cua-driver Updated\"" 2>/dev/null || true
-}
-
-if version_gt "$LATEST_VERSION" "$CURRENT_VERSION"; then
-    log "New version available: $LATEST_VERSION (current: $CURRENT_VERSION)"
-    case "${1:-}" in
-        --silent|--apply)
-            # LaunchAgent path: no dialog.
-            apply_update
-            ;;
-        *)
-            # Interactive path (user ran `cua-driver update` in a terminal):
-            # prompt via osascript before downloading.
-            response=$(osascript -e "display dialog \"cua-driver $LATEST_VERSION is available (current: $CURRENT_VERSION).\" buttons {\"Later\", \"Update Now\"} default button \"Update Now\" with title \"cua-driver Update\"" 2>/dev/null || echo "")
-            if echo "$response" | grep -q "Update Now"; then
-                log "User chose to update"
-                apply_update
-            else
-                log "User chose to skip update"
-            fi
-            ;;
-    esac
-else
-    log "Already up to date (version $CURRENT_VERSION)"
-fi
-
-log "Update check complete"
-UPDATER_EOF
-
-    $SUDO chmod +x "$UPDATER_SCRIPT"
-    log "installed updater at $UPDATER_SCRIPT"
-
-    AGENT_LABEL="com.trycua.cua_driver_updater"
-    AGENT_PLIST="$HOME/Library/LaunchAgents/$AGENT_LABEL.plist"
-
-    mkdir -p "$HOME/Library/LaunchAgents"
-
-    cat > "$AGENT_PLIST" << 'PLIST_EOF'
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>Label</key>
-    <string>com.trycua.cua_driver_updater</string>
-    <key>ProgramArguments</key>
-    <array>
-        <string>/usr/local/bin/cua-driver-update</string>
-        <string>--silent</string>
-    </array>
-    <key>RunAtLoad</key>
-    <true/>
-    <key>StartInterval</key>
-    <integer>604800</integer>
-    <key>StandardOutPath</key>
-    <string>/tmp/cua_driver_updater.log</string>
-    <key>StandardErrorPath</key>
-    <string>/tmp/cua_driver_updater.error.log</string>
-</dict>
-</plist>
-PLIST_EOF
-    
-    chmod 644 "$AGENT_PLIST"
-    launchctl load "$AGENT_PLIST" 2>/dev/null || true
-    
-    log "auto-updater installed (checks weekly)"
-    echo ""
-    echo "To disable auto-updates later, run:"
-    echo "  cua-driver config updates disable"
-else
-    log "skipping auto-updater setup (CUA_DRIVER_NO_UPDATER=1)"
 fi
 
 # --- Done ---------------------------------------------------------------

--- a/libs/cua-driver/scripts/uninstall.sh
+++ b/libs/cua-driver/scripts/uninstall.sh
@@ -2,11 +2,9 @@
 # cua-driver uninstaller. Removes everything install.sh laid down:
 #
 #   - /usr/local/bin/cua-driver symlink
-#   - /usr/local/bin/cua-driver-update script
 #   - /Applications/CuaDriver.app bundle
 #   - ~/.cua-driver/ (telemetry id + install marker)
 #   - ~/Library/Application Support/Cua Driver/ (config.json)
-#   - ~/Library/LaunchAgents/com.trycua.cua_driver_updater.plist
 #
 # Does NOT revoke TCC grants (Accessibility + Screen Recording).
 #
@@ -15,11 +13,12 @@
 set -euo pipefail
 
 BIN_LINK="/usr/local/bin/cua-driver"
-UPDATE_SCRIPT="/usr/local/bin/cua-driver-update"
 APP_BUNDLE="/Applications/CuaDriver.app"
 USER_DATA="$HOME/.cua-driver"
 CONFIG_DIR="$HOME/Library/Application Support/Cua Driver"
-UPDATER_PLIST="$HOME/Library/LaunchAgents/com.trycua.cua_driver_updater.plist"
+# Legacy — remove if present from older installs.
+LEGACY_UPDATE_SCRIPT="/usr/local/bin/cua-driver-update"
+LEGACY_UPDATER_PLIST="$HOME/Library/LaunchAgents/com.trycua.cua_driver_updater.plist"
 
 log() { printf '==> %s\n' "$*"; }
 
@@ -35,25 +34,16 @@ else
     log "no symlink at $BIN_LINK (skipping)"
 fi
 
-# Update script (may need sudo on some systems).
-if [[ -f "$UPDATE_SCRIPT" ]]; then
-    SUDO=""
-    if [[ ! -w "$(dirname "$UPDATE_SCRIPT")" ]]; then
-        SUDO="sudo"
-    fi
-    $SUDO rm -f "$UPDATE_SCRIPT"
-    log "removed $UPDATE_SCRIPT"
-else
-    log "no update script at $UPDATE_SCRIPT (skipping)"
+# Legacy update script + LaunchAgent (present in installs before 0.0.6).
+if [[ -f "$LEGACY_UPDATE_SCRIPT" ]]; then
+    SUDO=""; [[ ! -w "$(dirname "$LEGACY_UPDATE_SCRIPT")" ]] && SUDO="sudo"
+    $SUDO rm -f "$LEGACY_UPDATE_SCRIPT"
+    log "removed legacy $LEGACY_UPDATE_SCRIPT"
 fi
-
-# LaunchAgent updater plist.
-if [[ -f "$UPDATER_PLIST" ]]; then
-    launchctl unload "$UPDATER_PLIST" 2>/dev/null || true
-    rm -f "$UPDATER_PLIST"
-    log "removed $UPDATER_PLIST"
-else
-    log "no updater LaunchAgent at $UPDATER_PLIST (skipping)"
+if [[ -f "$LEGACY_UPDATER_PLIST" ]]; then
+    launchctl unload "$LEGACY_UPDATER_PLIST" 2>/dev/null || true
+    rm -f "$LEGACY_UPDATER_PLIST"
+    log "removed legacy $LEGACY_UPDATER_PLIST"
 fi
 
 # .app bundle (in /Applications, usually writable by the user).


### PR DESCRIPTION
## Summary

### Auto-updater removal
The weekly LaunchAgent (`com.trycua.cua_driver_updater`) silently replaced a security-sensitive binary (accessibility + Apple Events entitlements) on a schedule. This is disruptive and raises concerns for users on managed machines.

**New model:** passive version hint on startup + explicit `cua-driver update [--apply]` command.
- Server startup prints to stderr if a newer release exists (background task, 4s timeout, silent if offline)
- `cua-driver update` shows what's available; `cua-driver update --apply` runs `install.sh`
- `uninstall.sh` cleans up the legacy LaunchAgent from existing installs

### `launch_app` improvements (closes #1377)
Two new params enable isolated browser sessions for multi-agent testing:

```json
{
  "bundle_id": "com.google.Chrome",
  "urls": ["http://localhost:3000"],
  "creates_new_application_instance": true,
  "additional_arguments": [
    "--user-data-dir=/tmp/cua-session-a",
    "--no-first-run",
    "--no-default-browser-check"
  ]
}
```

Each session gets a distinct pid, isolated profile (no shared cookies/localStorage/extensions), and can be controlled independently. The user's real Chrome profile is untouched.

## Test plan
- [ ] `swift build` passes
- [ ] `cua-driver update` shows version info without applying
- [ ] `cua-driver update --apply` triggers install.sh
- [ ] `launch_app` with `creates_new_application_instance=true` + `additional_arguments` launches isolated Chrome

Closes #1377

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Version checking now alerts users when updates are available.
  * App launching extended to support debugging ports and WebKit inspection configuration.

* **Changes**
  * Update command now fetches releases from GitHub with new `--apply` flag for automatic installation; without it, users receive manual update guidance.
  * Automatic updater removed from installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->