### PR TITLE
feat(cua-sandbox): add metadata kwarg to Sandbox.create/ephemeral

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -38,6 +38,7 @@ from typing import (
     AsyncIterator,
     Callable,
     Coroutine,
+    Dict,
     Optional,
     TypeVar,
 )
@@ -410,6 +411,7 @@ class Sandbox:
         time_to_start: Optional[float] = None,
         request_timeout: Optional[float] = None,
         telemetry_enabled: bool = True,
+        metadata: Optional[Dict[str, str]] = None,
     ) -> "Sandbox":
         """Provision a new persistent sandbox and return it connected.
 
@@ -456,6 +458,7 @@ class Sandbox:
             time_to_start=time_to_start,
             request_timeout=request_timeout,
             telemetry_enabled=telemetry_enabled,
+            metadata=metadata,
         )
 
     @classmethod
@@ -534,6 +537,7 @@ class Sandbox:
         time_to_start: Optional[float] = None,
         request_timeout: Optional[float] = None,
         telemetry_enabled: bool = True,
+        metadata: Optional[Dict[str, str]] = None,
     ) -> AsyncIterator["Sandbox"]:
         """Create an ephemeral sandbox that is automatically destroyed on exit.
 
@@ -560,6 +564,9 @@ class Sandbox:
                 await sb.shell.run("whoami")
             # sandbox is destroyed here
         """
+        # Auto-inject ephemeral=true into metadata so the API can
+        # stamp it on the VM image annotation for observability.
+        merged_metadata = {"ephemeral": "true", **(metadata or {})}
         sb = await cls._create(
             image=image,
             name=name,
@@ -574,6 +581,7 @@ class Sandbox:
             time_to_start=time_to_start,
             request_timeout=request_timeout,
             telemetry_enabled=telemetry_enabled,
+            metadata=merged_metadata,
         )
         try:
             yield sb
@@ -989,6 +997,7 @@ class Sandbox:
         time_to_start: Optional[float] = None,
         request_timeout: Optional[float] = None,
         telemetry_enabled: bool = True,
+        metadata: Optional[Dict[str, str]] = None,
     ) -> "Sandbox":
         """Internal workhorse — all public factories delegate here."""
         _t_start = time.monotonic()
@@ -1055,6 +1064,7 @@ class Sandbox:
                     region=region,
                     time_to_start=time_to_start,
                     request_timeout=request_timeout,
+                    metadata=metadata,
                 )
                 sb = cls(
                     transport, name=name, _ephemeral=ephemeral, _telemetry_enabled=telemetry_enabled

--- a/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
@@ -45,6 +45,7 @@ class CloudTransport(Transport):
         region: str = "us-east-1",
         time_to_start: Optional[float] = None,
         request_timeout: Optional[float] = None,
+        metadata: Optional[Dict[str, str]] = None,
     ):
         self._name = name
         self._api_key_override = api_key
@@ -54,6 +55,7 @@ class CloudTransport(Transport):
         self._memory_mb = memory_mb
         self._disk_gb = disk_gb
         self._region = region
+        self._metadata = metadata
         self._time_to_start = time_to_start if time_to_start is not None else _POLL_TIMEOUT
         self._request_timeout = request_timeout if request_timeout is not None else 30.0
         self._inner: Optional[HTTPTransport] = None
@@ -375,6 +377,8 @@ class CloudTransport(Transport):
             body["diskGb"] = self._disk_gb or self._DEFAULT_DISK_GB
         else:
             body["configuration"] = "small"
+        if self._metadata:
+            body["metadata"] = self._metadata
         resp = await self._post_with_retry("/v1/vms", body)
         resp.raise_for_status()
         return resp.json()


### PR DESCRIPTION
## Summary
- Add `metadata: Dict[str, str]` parameter to `Sandbox.create()`, `Sandbox.ephemeral()`, `Sandbox._create()`, and `CloudTransport`
- `Sandbox.ephemeral()` auto-injects `{"ephemeral": "true"}` into metadata, merged with any caller-provided entries
- `CloudTransport._create_vm()` includes `metadata` in the `POST /v1/vms` request body when present

Companion API PR: trycua/cloud#3763

## Test plan
- [ ] `Sandbox.ephemeral(Image.android())` sends `{"metadata": {"ephemeral": "true"}}` in request body
- [ ] `Sandbox.create(Image.android(), metadata={"foo": "bar"})` sends custom metadata
- [ ] `Sandbox.create(Image.android())` sends no metadata field (backward compatible)
- [ ] `Sandbox.ephemeral(Image.android(), metadata={"custom": "val"})` merges both ephemeral and custom

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to attach custom metadata tags when creating sandboxes for improved observability and resource annotation.
  * Ephemeral sandboxes now automatically include status annotations in their metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->