### PR TITLE
fix(tests): mock torch/transformers to prevent Windows OMP crash (#1381)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,3 +57,69 @@ Documentation improvements are always welcome. You can:
 For detailed instructions on setting up your development environment and submitting code contributions, please see our [Developer-Guide](Development.md).
 
 Feel free to join our [Discord community](https://discord.com/invite/mVnXXpdE85) to discuss ideas or get help with your contributions.
+## Windows (Anaconda) Setup
+
+> **Relevant to**: Windows 10 / 11 with Anaconda or Miniconda environments.
+
+### PyTorch / OMP Duplicate Library Crash
+
+When running the test suite on Windows with an Anaconda environment that has
+`numpy` installed, you may see the following fatal crash:
+
+```
+OMP: Error #15: Initializing libiomp5md.dll, but found vcomp140.dll already initialized.
+Fatal Python error: Aborted
+```
+
+**Root cause**: Anaconda ships its own OpenMP runtime (via `numpy`/`mkl`).
+PyTorch bundles a separate OpenMP runtime.  When both are loaded in the same
+process, the Intel OpenMP layer aborts to avoid undefined behaviour.
+
+**Quick fix** – set the environment variable before running pytest:
+
+```bat
+:: Windows Command Prompt
+set KMP_DUPLICATE_LIB_OK=TRUE
+pytest tests/ -v
+```
+
+```powershell
+# PowerShell
+$env:KMP_DUPLICATE_LIB_OK="TRUE"
+pytest tests/ -v
+```
+
+This variable is already set automatically inside the test suite's
+`conftest.py` (via `os.environ.setdefault`), so unit tests that mock torch
+will never hit this crash.  The manual step above is only needed when
+running **integration tests** that import real torch.
+
+**Permanent fix (optional)** – add the variable to your conda environment's
+activation script so it is always set when the environment is active:
+
+```bat
+conda env config vars set KMP_DUPLICATE_LIB_OK=TRUE -n <your-env-name>
+```
+
+### Running Tests on Windows
+
+```bat
+:: 1. Clone and enter the repo
+git clone https://github.com/trycua/cua.git
+cd cua\libs\python\agent
+
+:: 2. Install in editable mode (use pip or uv)
+pip install -e ".[uitars-hf]"   :: if you need local HuggingFace models
+pip install -e "."               :: base install
+
+:: 3. Install test dependencies
+pip install pytest pytest-asyncio
+
+:: 4. Run the test suite
+set KMP_DUPLICATE_LIB_OK=TRUE
+pytest tests/ -v
+```
+
+The unit tests for `HuggingFaceLocalAdapter` use module-level mocks for
+`torch` and `transformers`, so **you do not need a GPU or a full PyTorch
+installation** to run `tests/test_huggingfacelocal_adapter.py`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,3 +123,69 @@ pytest tests/ -v
 The unit tests for `HuggingFaceLocalAdapter` use module-level mocks for
 `torch` and `transformers`, so **you do not need a GPU or a full PyTorch
 installation** to run `tests/test_huggingfacelocal_adapter.py`.
+## Windows (Anaconda) Setup
+
+> **Relevant to**: Windows 10 / 11 with Anaconda or Miniconda environments.
+
+### PyTorch / OMP Duplicate Library Crash
+
+When running the test suite on Windows with an Anaconda environment that has
+`numpy` installed, you may see the following fatal crash:
+
+```text
+OMP: Error #15: Initializing libiomp5md.dll, but found vcomp140.dll already initialized.
+Fatal Python error: Aborted
+```
+
+**Root cause**: Anaconda ships its own OpenMP runtime (via `numpy`/`mkl`).
+PyTorch bundles a separate OpenMP runtime.  When both are loaded in the same
+process, the Intel OpenMP layer aborts to avoid undefined behaviour.
+
+**Quick fix** – set the environment variable before running pytest:
+
+```bat
+:: Windows Command Prompt
+set KMP_DUPLICATE_LIB_OK=TRUE
+pytest tests/ -v
+```
+
+```powershell
+# PowerShell
+$env:KMP_DUPLICATE_LIB_OK="TRUE"
+pytest tests/ -v
+```
+
+This variable is already set automatically inside the test suite's
+`conftest.py` (via `os.environ.setdefault`), so unit tests that mock torch
+will never hit this crash.  The manual step above is only needed when
+running **integration tests** that import real torch.
+
+**Permanent fix (optional)** – add the variable to your conda environment's
+activation script so it is always set when the environment is active:
+
+```bat
+conda env config vars set KMP_DUPLICATE_LIB_OK=TRUE -n <your-env-name>
+```
+
+### Running Tests on Windows
+
+```bat
+:: 1. Clone and enter the repo
+git clone https://github.com/trycua/cua.git
+cd cua\libs\python\agent
+
+:: 2. Install in editable mode (choose ONE):
+pip install -e "."               :: base install
+pip install -e ".[uitars-hf]"   :: base + local HuggingFace models (heavy)
+
+:: 3. Install test dependencies
+pip install pytest pytest-asyncio
+
+:: 4. Run the test suite
+set KMP_DUPLICATE_LIB_OK=TRUE
+pytest tests/ -v
+```
+
+The unit tests for `HuggingFaceLocalAdapter` use module-level mocks for
+`torch` and `transformers`, so **you do not need a GPU or a full PyTorch
+installation** to run `tests/test_huggingfacelocal_adapter.py`.

--- a/libs/python/agent/tests/conftest.py
+++ b/libs/python/agent/tests/conftest.py
@@ -25,6 +25,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
+
 # ---------------------------------------------------------------------------
 # Torch / Transformers mock fixture
 # ---------------------------------------------------------------------------
@@ -78,8 +79,16 @@ def mock_torch_and_transformers():
     originals = {k: sys.modules.get(k) for k in stubs}
 
     for name, stub in stubs.items():
-        if name not in sys.modules:
+        existing = sys.modules.get(name)
+        if existing is None:
             sys.modules[name] = stub
+        else:
+            # Fill in any attributes the earlier stub didn't define so that
+            # session-wide stubs remain authoritative even when a test module
+            # already inserted a minimal stub via sys.modules.setdefault().
+            for attr in vars(stub):
+                if not hasattr(existing, attr):
+                    setattr(existing, attr, getattr(stub, attr))
 
     yield
 

--- a/libs/python/agent/tests/conftest.py
+++ b/libs/python/agent/tests/conftest.py
@@ -2,11 +2,98 @@
 
 This file contains shared fixtures and configuration for all agent tests.
 Following SRP: This file ONLY handles test setup/teardown.
+
+Windows / Anaconda note (issue #1381)
+--------------------------------------
+On Windows with Anaconda, importing torch before numpy (or vice-versa) can
+load two copies of the OpenMP runtime (libiomp5md.dll / vcomp*.dll), which
+causes a fatal ``OMP: Error #15`` crash.  The two-line environment-variable
+patch below sets KMP_DUPLICATE_LIB_OK=TRUE *before* any test module imports
+torch, which silences the crash.  This is a well-known Intel MKL/OMP
+workaround and is safe for a test environment.
 """
+
+import os
+import sys
+
+# ── Windows / Anaconda OMP duplicate-library fix (issue #1381) ────────────
+# Must be set before torch is imported by any test or fixture.
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+# ──────────────────────────────────────────────────────────────────────────
 
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+
+# ---------------------------------------------------------------------------
+# Torch / Transformers mock fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mock_torch_and_transformers():
+    """Session-scoped fixture that injects fake torch/transformers modules.
+
+    Injecting lightweight stubs into sys.modules prevents the real PyTorch
+    from being imported during the test session.  This avoids:
+
+    * The OMP duplicate-library fatal crash on Windows + Anaconda (#1381)
+    * Long import times / CUDA initialisation in CI without a GPU
+    * Tests accidentally requiring heavyweight ML dependencies
+
+    The stubs expose just enough surface area so that
+    ``huggingfacelocal_adapter.py`` (and ``adapters/models/__init__.py``)
+    can be imported without error.
+    """
+    from types import ModuleType
+
+    def _stub(name: str, **attrs) -> ModuleType:
+        m = ModuleType(name)
+        for k, v in attrs.items():
+            setattr(m, k, v)
+        return m
+
+    # torch stub
+    torch_stub = _stub(
+        "torch",
+        cuda=MagicMock(is_available=Mock(return_value=False)),
+        device=Mock,
+        float16=None,
+        bfloat16=None,
+    )
+
+    # transformers stub
+    transformers_stub = _stub(
+        "transformers",
+        AutoModelForImageTextToText=MagicMock(),
+        AutoProcessor=MagicMock(),
+        AutoConfig=MagicMock(),
+    )
+
+    stubs = {
+        "torch": torch_stub,
+        "transformers": transformers_stub,
+    }
+
+    originals = {k: sys.modules.get(k) for k in stubs}
+
+    for name, stub in stubs.items():
+        if name not in sys.modules:
+            sys.modules[name] = stub
+
+    yield
+
+    # Restore originals (important when running alongside integration tests)
+    for name, original in originals.items():
+        if original is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = original
+
+
+# ---------------------------------------------------------------------------
+# Existing shared fixtures (unchanged)
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture

--- a/libs/python/agent/tests/test_huggingfacelocal_adapter.py
+++ b/libs/python/agent/tests/test_huggingfacelocal_adapter.py
@@ -1,0 +1,317 @@
+"""Unit tests for HuggingFaceLocalAdapter.
+
+This file tests ONLY the HuggingFaceLocalAdapter class without requiring
+torch, transformers, or any GPU hardware to be present.
+
+All heavy dependencies (torch, transformers, AutoConfig, AutoProcessor,
+AutoModelForImageTextToText) are mocked at the module level so that the
+test suite runs safely on Windows/Anaconda environments where the
+PyTorch/OMP duplicate-library crash (issue #1381) would otherwise abort
+the process.
+
+Fixes: https://github.com/trycua/cua/issues/1381
+"""
+
+import sys
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module-level mocking: inject fake `torch` and `transformers` BEFORE the
+# adapter module is imported.  This prevents the real torch from being
+# loaded (and triggering the OMP duplicate-library crash on Windows).
+# ---------------------------------------------------------------------------
+
+_fake_torch = ModuleType("torch")
+_fake_torch.cuda = MagicMock()  # type: ignore[attr-defined]
+_fake_torch.cuda.is_available = Mock(return_value=False)
+
+_fake_transformers = ModuleType("transformers")
+_fake_transformers.AutoModelForImageTextToText = MagicMock()  # type: ignore[attr-defined]
+_fake_transformers.AutoProcessor = MagicMock()  # type: ignore[attr-defined]
+_fake_transformers.AutoConfig = MagicMock()  # type: ignore[attr-defined]
+
+# Patch into sys.modules so any `import torch` / `import transformers` in
+# the adapter resolves to our fakes.
+sys.modules.setdefault("torch", _fake_torch)
+sys.modules.setdefault("transformers", _fake_transformers)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter(**kwargs):
+    """Import and instantiate HuggingFaceLocalAdapter with mocked deps."""
+    # Patch load_model so no real model weights are loaded.
+    with patch("cua_agent.adapters.huggingfacelocal_adapter.load_model_handler") as _:
+        from cua_agent.adapters.huggingfacelocal_adapter import HuggingFaceLocalAdapter
+
+        return HuggingFaceLocalAdapter(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestHuggingFaceLocalAdapterInit:
+    """Test adapter initialisation (SRP: only tests __init__)."""
+
+    def test_default_init(self):
+        """Adapter can be instantiated with default arguments."""
+        adapter = _make_adapter()
+        assert adapter.device == "auto"
+        assert adapter.trust_remote_code is False
+        assert adapter._handlers == {}
+
+    def test_custom_device(self):
+        """Adapter stores a custom device string."""
+        adapter = _make_adapter(device="cuda")
+        assert adapter.device == "cuda"
+
+    def test_trust_remote_code_flag(self):
+        """Adapter stores trust_remote_code flag correctly."""
+        adapter = _make_adapter(trust_remote_code=True)
+        assert adapter.trust_remote_code is True
+
+
+class TestConvertMessages:
+    """Test _convert_messages (SRP: only tests message conversion)."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+
+    def test_text_string_content(self):
+        """Plain string content is wrapped in a text block."""
+        messages = [{"role": "user", "content": "Hello"}]
+        result = self.adapter._convert_messages(messages)
+        assert result == [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}]
+
+    def test_multimodal_text_item(self):
+        """Text items in a list are preserved."""
+        messages = [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}]
+        result = self.adapter._convert_messages(messages)
+        assert result[0]["content"] == [{"type": "text", "text": "Hi"}]
+
+    def test_image_url_converted_to_image(self):
+        """image_url items are converted to image format."""
+        url = "data:image/png;base64,abc123"
+        messages = [
+            {
+                "role": "user",
+                "content": [{"type": "image_url", "image_url": {"url": url}}],
+            }
+        ]
+        result = self.adapter._convert_messages(messages)
+        assert result[0]["content"] == [{"type": "image", "image": url}]
+
+    def test_mixed_content(self):
+        """Mixed text + image_url content is converted correctly."""
+        url = "data:image/png;base64,xyz"
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this"},
+                    {"type": "image_url", "image_url": {"url": url}},
+                ],
+            }
+        ]
+        result = self.adapter._convert_messages(messages)
+        assert result[0]["content"] == [
+            {"type": "text", "text": "Describe this"},
+            {"type": "image", "image": url},
+        ]
+
+    def test_multiple_messages(self):
+        """Multiple messages are all converted."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
+        ]
+        result = self.adapter._convert_messages(messages)
+        assert len(result) == 2
+        assert result[0]["role"] == "user"
+        assert result[1]["role"] == "assistant"
+
+    def test_empty_messages(self):
+        """Empty list returns empty list."""
+        assert self.adapter._convert_messages([]) == []
+
+
+class TestGenerateWithoutHFDeps:
+    """Test _generate when HF dependencies are unavailable (SRP: import guard)."""
+
+    def test_raises_import_error_when_hf_unavailable(self):
+        """_generate raises ImportError with helpful message when HF deps are missing."""
+        with patch("cua_agent.adapters.huggingfacelocal_adapter.HF_AVAILABLE", False):
+            adapter = _make_adapter()
+            with pytest.raises(ImportError, match="cua-agent\\[uitars-hf\\]"):
+                adapter._generate(
+                    messages=[{"role": "user", "content": "hello"}],
+                    model="ByteDance-Seed/UI-TARS-1.5-7B",
+                )
+
+
+class TestGenerateWithMockedHF:
+    """Test _generate when HF dependencies ARE available (mocked)."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+
+    def _mock_handler(self, return_text: str = "click(100, 200)") -> Mock:
+        handler = Mock()
+        handler.generate = Mock(return_value=return_text)
+        return handler
+
+    def test_generate_delegates_to_handler(self):
+        """_generate calls handler.generate and returns its output."""
+        handler = self._mock_handler("click(50, 80)")
+        self.adapter._handlers["ByteDance-Seed/UI-TARS-1.5-7B"] = handler
+
+        with patch("cua_agent.adapters.huggingfacelocal_adapter.HF_AVAILABLE", True):
+            result = self.adapter._generate(
+                messages=[{"role": "user", "content": "click something"}],
+                model="ByteDance-Seed/UI-TARS-1.5-7B",
+                max_tokens=64,
+            )
+
+        assert result == "click(50, 80)"
+        handler.generate.assert_called_once()
+
+    def test_generate_uses_default_max_tokens(self):
+        """_generate passes max_tokens=128 when not specified."""
+        handler = self._mock_handler()
+        self.adapter._handlers["ByteDance-Seed/UI-TARS-1.5-7B"] = handler
+
+        with patch("cua_agent.adapters.huggingfacelocal_adapter.HF_AVAILABLE", True):
+            self.adapter._generate(
+                messages=[{"role": "user", "content": "hi"}],
+                model="ByteDance-Seed/UI-TARS-1.5-7B",
+            )
+
+        _, kwargs = handler.generate.call_args
+        assert kwargs.get("max_new_tokens", 128) == 128
+
+    def test_generate_warns_on_unknown_kwargs(self):
+        """_generate emits a warning for unsupported kwargs."""
+        handler = self._mock_handler()
+        self.adapter._handlers["ByteDance-Seed/UI-TARS-1.5-7B"] = handler
+
+        with patch("cua_agent.adapters.huggingfacelocal_adapter.HF_AVAILABLE", True):
+            with pytest.warns(UserWarning, match="unsupported kwargs"):
+                self.adapter._generate(
+                    messages=[{"role": "user", "content": "hi"}],
+                    model="ByteDance-Seed/UI-TARS-1.5-7B",
+                    temperature=0.7,  # unsupported
+                )
+
+    def test_handler_is_cached(self):
+        """Calling _get_handler twice for the same model reuses the same instance."""
+        mock_load = Mock(return_value=Mock())
+        with patch("cua_agent.adapters.huggingfacelocal_adapter.load_model_handler", mock_load):
+            with patch("cua_agent.adapters.huggingfacelocal_adapter.HF_AVAILABLE", True):
+                h1 = self.adapter._get_handler("some/model")
+                h2 = self.adapter._get_handler("some/model")
+
+        assert h1 is h2
+        mock_load.assert_called_once()
+
+
+class TestCompletionMethod:
+    """Test synchronous completion() method."""
+
+    def test_completion_returns_model_response(self):
+        """completion() returns a ModelResponse-like object."""
+        adapter = _make_adapter()
+        adapter._handlers["ByteDance-Seed/UI-TARS-1.5-7B"] = Mock(
+            generate=Mock(return_value="action()")
+        )
+
+        with patch("cua_agent.adapters.huggingfacelocal_adapter.HF_AVAILABLE", True):
+            with patch("cua_agent.adapters.huggingfacelocal_adapter.completion") as mock_completion:
+                mock_completion.return_value = {"choices": [{"message": {"content": "action()"}}]}
+                result = adapter.completion(
+                    messages=[{"role": "user", "content": "hi"}],
+                    model="ByteDance-Seed/UI-TARS-1.5-7B",
+                )
+
+        mock_completion.assert_called_once()
+        # model string should be prefixed
+        call_kwargs = mock_completion.call_args[1]
+        assert "huggingface-local/" in call_kwargs.get("model", "")
+
+
+class TestAsyncCompletionMethod:
+    """Test asynchronous acompletion() method."""
+
+    @pytest.mark.asyncio
+    async def test_acompletion_returns_model_response(self):
+        """acompletion() returns a ModelResponse-like object."""
+        adapter = _make_adapter()
+        adapter._handlers["ByteDance-Seed/UI-TARS-1.5-7B"] = Mock(
+            generate=Mock(return_value="action()")
+        )
+
+        with patch("cua_agent.adapters.huggingfacelocal_adapter.HF_AVAILABLE", True):
+            with patch(
+                "cua_agent.adapters.huggingfacelocal_adapter.acompletion",
+                new_callable=AsyncMock,
+            ) as mock_acompletion:
+                mock_acompletion.return_value = {"choices": [{"message": {"content": "action()"}}]}
+                result = await adapter.acompletion(
+                    messages=[{"role": "user", "content": "hi"}],
+                    model="ByteDance-Seed/UI-TARS-1.5-7B",
+                )
+
+        mock_acompletion.assert_called_once()
+        call_kwargs = mock_acompletion.call_args[1]
+        assert "huggingface-local/" in call_kwargs.get("model", "")
+
+
+class TestStreamingMethod:
+    """Test streaming() and astreaming() methods."""
+
+    def test_streaming_yields_one_chunk(self):
+        """streaming() yields exactly one GenericStreamingChunk."""
+        adapter = _make_adapter()
+        adapter._handlers["ByteDance-Seed/UI-TARS-1.5-7B"] = Mock(
+            generate=Mock(return_value="type('hello')")
+        )
+
+        with patch("cua_agent.adapters.huggingfacelocal_adapter.HF_AVAILABLE", True):
+            chunks = list(
+                adapter.streaming(
+                    messages=[{"role": "user", "content": "hi"}],
+                    model="ByteDance-Seed/UI-TARS-1.5-7B",
+                )
+            )
+
+        assert len(chunks) == 1
+        assert chunks[0]["text"] == "type('hello')"
+        assert chunks[0]["finish_reason"] == "stop"
+        assert chunks[0]["is_finished"] is True
+
+    @pytest.mark.asyncio
+    async def test_astreaming_yields_one_chunk(self):
+        """astreaming() yields exactly one GenericStreamingChunk."""
+        adapter = _make_adapter()
+        adapter._handlers["ByteDance-Seed/UI-TARS-1.5-7B"] = Mock(
+            generate=Mock(return_value="type('world')")
+        )
+
+        with patch("cua_agent.adapters.huggingfacelocal_adapter.HF_AVAILABLE", True):
+            chunks = []
+            async for chunk in adapter.astreaming(
+                messages=[{"role": "user", "content": "hi"}],
+                model="ByteDance-Seed/UI-TARS-1.5-7B",
+            ):
+                chunks.append(chunk)
+
+        assert len(chunks) == 1
+        assert chunks[0]["text"] == "type('world')"
+        assert chunks[0]["finish_reason"] == "stop"

--- a/libs/python/agent/tests/test_huggingfacelocal_adapter.py
+++ b/libs/python/agent/tests/test_huggingfacelocal_adapter.py
@@ -34,7 +34,9 @@ _fake_transformers.AutoProcessor = MagicMock()  # type: ignore[attr-defined]
 _fake_transformers.AutoConfig = MagicMock()  # type: ignore[attr-defined]
 
 # Patch into sys.modules so any `import torch` / `import transformers` in
-# the adapter resolves to our fakes.
+# the adapter resolves to our fakes.  `setdefault` intentionally keeps an
+# already-imported real module in place (no fresh load → no OMP crash);
+# under that scenario tests run against real deps, which is acceptable.
 sys.modules.setdefault("torch", _fake_torch)
 sys.modules.setdefault("transformers", _fake_transformers)
 
@@ -148,7 +150,9 @@ class TestGenerateWithoutHFDeps:
 
     def test_raises_import_error_when_hf_unavailable(self):
         """_generate raises ImportError with helpful message when HF deps are missing."""
-        with patch("cua_agent.adapters.huggingfacelocal_adapter.HF_AVAILABLE", False):
+        with patch(
+            "cua_agent.adapters.huggingfacelocal_adapter.HF_AVAILABLE", False
+        ):
             adapter = _make_adapter()
             with pytest.raises(ImportError, match="cua-agent\\[uitars-hf\\]"):
                 adapter._generate(
@@ -195,7 +199,8 @@ class TestGenerateWithMockedHF:
             )
 
         _, kwargs = handler.generate.call_args
-        assert kwargs.get("max_new_tokens", 128) == 128
+        assert "max_new_tokens" in kwargs, "default max_new_tokens not forwarded to handler"
+        assert kwargs["max_new_tokens"] == 128
 
     def test_generate_warns_on_unknown_kwargs(self):
         """_generate emits a warning for unsupported kwargs."""
@@ -213,7 +218,9 @@ class TestGenerateWithMockedHF:
     def test_handler_is_cached(self):
         """Calling _get_handler twice for the same model reuses the same instance."""
         mock_load = Mock(return_value=Mock())
-        with patch("cua_agent.adapters.huggingfacelocal_adapter.load_model_handler", mock_load):
+        with patch(
+            "cua_agent.adapters.huggingfacelocal_adapter.load_model_handler", mock_load
+        ):
             with patch("cua_agent.adapters.huggingfacelocal_adapter.HF_AVAILABLE", True):
                 h1 = self.adapter._get_handler("some/model")
                 h2 = self.adapter._get_handler("some/model")
@@ -233,7 +240,9 @@ class TestCompletionMethod:
         )
 
         with patch("cua_agent.adapters.huggingfacelocal_adapter.HF_AVAILABLE", True):
-            with patch("cua_agent.adapters.huggingfacelocal_adapter.completion") as mock_completion:
+            with patch(
+                "cua_agent.adapters.huggingfacelocal_adapter.completion"
+            ) as mock_completion:
                 mock_completion.return_value = {"choices": [{"message": {"content": "action()"}}]}
                 result = adapter.completion(
                     messages=[{"role": "user", "content": "hi"}],
@@ -262,7 +271,9 @@ class TestAsyncCompletionMethod:
                 "cua_agent.adapters.huggingfacelocal_adapter.acompletion",
                 new_callable=AsyncMock,
             ) as mock_acompletion:
-                mock_acompletion.return_value = {"choices": [{"message": {"content": "action()"}}]}
+                mock_acompletion.return_value = {
+                    "choices": [{"message": {"content": "action()"}}]
+                }
                 result = await adapter.acompletion(
                     messages=[{"role": "user", "content": "hi"}],
                     model="ByteDance-Seed/UI-TARS-1.5-7B",


### PR DESCRIPTION
## Problem

On Windows 11 with Anaconda, running `pytest tests/ -v` in `libs/python/agent` causes a fatal process abort:


This happens because `cua_agent/adapters/huggingfacelocal_adapter.py` imports `torch` at module level during test collection. Anaconda's `numpy` has already loaded one OpenMP runtime; PyTorch loads a second one, and Intel's OMP layer calls `abort()` — a crash that cannot be caught.

## Root Cause

`huggingfacelocal_adapter.py` does a bare `import torch` at the top level inside a `try/except ImportError` block. While the guard is correct for runtime use, it still triggers the OMP crash during pytest collection on Windows + Anaconda because the import executes before any test runs.

## Changes

### `tests/test_huggingfacelocal_adapter.py` (new file)
- 18 unit tests covering all public methods: `__init__`, `_convert_messages`, `_generate`, `completion`, `acompletion`, `streaming`, `astreaming`
- Injects lightweight `torch` and `transformers` stubs into `sys.modules` at module level, before any adapter import — so the real PyTorch is never loaded
- No GPU, no CUDA, no heavy ML dependencies required to run

### `tests/conftest.py` (modified)
- Added `os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")` at the top — must be set before torch is imported anywhere in the process
- Added `mock_torch_and_transformers` session-scoped `autouse=True` fixture that stubs out torch/transformers for the entire test session as a belt-and-suspenders safeguard

### `CONTRIBUTING.md` (modified)
- Added a **Windows (Anaconda) Setup** section explaining the OMP crash, the quick fix, the permanent conda fix, and exact steps to run tests on Windows

## Testing

```bash
# Windows — no GPU required
set KMP_DUPLICATE_LIB_OK=TRUE
pytest tests/test_huggingfacelocal_adapter.py -v
# 18 passed
```

## Related

Closes #1381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Windows/Anaconda testing guidance, including troubleshooting steps and configuration instructions for OpenMP compatibility issues.

* **Tests**
  * Enhanced test suite with improved isolation and streamlined dependency mocking to support faster, more reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->