### PR TITLE
fix(lume): pull 21GB OCI tar-part images without skipping disk layers

### DIFF
--- a/libs/lume/src/ContainerRegistry/ImageContainerRegistry.swift
+++ b/libs/lume/src/ContainerRegistry/ImageContainerRegistry.swift
@@ -1924,7 +1924,7 @@ class ImageContainerRegistry: ImageRegistry, @unchecked Sendable {
             Logger.info("Found \(rawDiskPartCount) raw OCI disk parts in cache to reassemble.")
         }
         if let expectedRawDiskParts {
-            let rawPartNumbers = Set(
+            let rawPartNumbers = Swift.Set(
                 diskPartSources.filter { $0.compression == .raw }.map(\.partNumber))
             for partNumber in 1...expectedRawDiskParts where !rawPartNumbers.contains(partNumber) {
                 Logger.error("Missing raw OCI disk part \(partNumber) of \(expectedRawDiskParts).")

--- a/libs/lume/src/ContainerRegistry/ImageContainerRegistry.swift
+++ b/libs/lume/src/ContainerRegistry/ImageContainerRegistry.swift
@@ -107,12 +107,64 @@ enum OCIMediaType {
     static let config = "application/vnd.trycua.lume.config.v1+json"
     static let disk   = "application/vnd.trycua.lume.disk.v1"
     static let nvram  = "application/vnd.trycua.lume.nvram.v1"
+    static let standardTarLayer = "application/vnd.oci.image.layer.v1.tar"
 
     static func detect(_ manifest: Manifest) -> ImageFormat {
         let hasOCIDisk = manifest.layers.contains { $0.mediaType == disk }
         let hasOCIConfig = manifest.config?.mediaType == config
         return (hasOCIDisk || hasOCIConfig) ? .oci : .legacy
     }
+
+    static func rawDiskPartInfo(for layer: Layer) -> OCIDiskPartInfo? {
+        let mediaType = parse(layer.mediaType)
+        guard mediaType.base == standardTarLayer,
+            let partNumberText = mediaType.parameters["part.number"],
+            let partNumber = Int(partNumberText),
+            partNumber > 0
+        else {
+            return nil
+        }
+
+        guard
+            layer.annotations?["org.opencontainers.image.title"]?.hasPrefix("disk.img.part.")
+                == true
+        else {
+            return nil
+        }
+
+        let totalParts = mediaType.parameters["part.total"].flatMap(Int.init)
+        return OCIDiskPartInfo(partNumber: partNumber, totalParts: totalParts)
+    }
+
+    private static func parse(_ mediaType: String) -> OCIMediaTypeComponents {
+        let parts = mediaType
+            .split(separator: ";", omittingEmptySubsequences: true)
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+
+        guard let base = parts.first else {
+            return OCIMediaTypeComponents(base: mediaType, parameters: [:])
+        }
+
+        var parameters: [String: String] = [:]
+        for parameter in parts.dropFirst() {
+            let pair = parameter.split(
+                separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard pair.count == 2 else { continue }
+            parameters[String(pair[0])] = String(pair[1])
+        }
+
+        return OCIMediaTypeComponents(base: base, parameters: parameters)
+    }
+}
+
+struct OCIMediaTypeComponents: Equatable {
+    let base: String
+    let parameters: [String: String]
+}
+
+struct OCIDiskPartInfo: Equatable {
+    let partNumber: Int
+    let totalParts: Int?
 }
 
 /// Annotation keys for multi-layer chunked disk images.
@@ -131,6 +183,17 @@ struct DiskChunkDescriptor {
     let uncompressedDigest: String
     let uncompressedSize: UInt64
     let diskOffset: UInt64
+}
+
+enum DiskPartCompression: Equatable {
+    case lz4
+    case raw
+}
+
+struct DiskPartSource {
+    let partNumber: Int
+    let url: URL
+    let compression: DiskPartCompression
 }
 
 /// OCI config JSON structure for lume VM images.
@@ -175,27 +238,69 @@ struct ImageMetadata: Codable {
 
 // Actor to safely collect disk part information from concurrent tasks
 actor DiskPartsCollector {
-    // Store tuples of (sequentialPartNum, url)
-    private var diskParts: [(Int, URL)] = []
+    private var diskParts: [DiskPartSource] = []
     // Restore internal counter
     private var partCounter = 0
 
     // Adds a part and returns its assigned sequential number
-    func addPart(url: URL) -> Int {
+    func addPart(url: URL, compression: DiskPartCompression = .lz4) -> Int {
         partCounter += 1  // Use counter logic
         let partNum = partCounter
-        diskParts.append((partNum, url))  // Store sequential number
+        diskParts.append(DiskPartSource(partNumber: partNum, url: url, compression: compression))
         return partNum  // Return assigned sequential number
     }
 
-    // Sort by the sequential part number (index 0 of tuple)
-    func getSortedParts() -> [(Int, URL)] {
-        return diskParts.sorted { $0.0 < $1.0 }
+    @discardableResult
+    func addPart(partNumber: Int, url: URL, compression: DiskPartCompression) -> Int {
+        partCounter = max(partCounter, partNumber)
+        diskParts.append(DiskPartSource(partNumber: partNumber, url: url, compression: compression))
+        return partNumber
+    }
+
+    func getSortedParts() -> [DiskPartSource] {
+        return diskParts.sorted { $0.partNumber < $1.partNumber }
     }
 
     // Restore getTotalParts
     func getTotalParts() -> Int {
-        return partCounter
+        return diskParts.count
+    }
+}
+
+enum DiskPartWriter {
+    private static let holeGranularityBytes = 4 * 1024 * 1024
+    private static let zeroChunk = Data(count: holeGranularityBytes)
+
+    static func writeRawChunk(
+        inputPath: String, outputHandle: FileHandle, startOffset: UInt64
+    ) throws -> UInt64 {
+        guard FileManager.default.fileExists(atPath: inputPath) else {
+            Logger.error("Raw disk part not found at: \(inputPath)")
+            return 0
+        }
+
+        let readHandle = try FileHandle(forReadingFrom: URL(fileURLWithPath: inputPath))
+        defer { try? readHandle.close() }
+
+        var currentWriteOffset = startOffset
+        var totalBytesWritten: UInt64 = 0
+
+        while true {
+            let data = readHandle.readData(ofLength: holeGranularityBytes)
+            if data.isEmpty { break }
+
+            if data.count == holeGranularityBytes && data == zeroChunk {
+                currentWriteOffset += UInt64(data.count)
+            } else {
+                try outputHandle.seek(toOffset: currentWriteOffset)
+                try outputHandle.write(contentsOf: data)
+                currentWriteOffset += UInt64(data.count)
+            }
+
+            totalBytesWritten += UInt64(data.count)
+        }
+
+        return totalBytesWritten
     }
 }
 
@@ -975,7 +1080,51 @@ class ImageContainerRegistry: ImageRegistry, @unchecked Sendable {
                     }
 
                     // Identify disk parts by media type
-                    if layer.mediaType == "application/octet-stream+lz4" {
+                    if let rawDiskPart = OCIMediaType.rawDiskPartInfo(for: layer) {
+                        // --- Handle raw OCI tar disk part layer ---
+                        let currentPartNum = rawDiskPart.partNumber
+                        let cachedLayer = getCachedLayerPath(
+                            manifestId: manifestId, digest: layer.digest)
+                        let digest = layer.digest
+                        let size = layer.size
+
+                        if FileManager.default.fileExists(atPath: cachedLayer.path) {
+                            Logger.info(
+                                "Using cached raw OCI disk part \(currentPartNum): \(cachedLayer.lastPathComponent)"
+                            )
+                            await downloadProgress.addProgress(Int64(size))
+                            continue
+                        }
+
+                        group.addTask { [self] in
+                            await counter.increment()
+                            let tempPartURL = tempDownloadDir.appendingPathComponent(
+                                "disk.img.raw.part.\(currentPartNum)")
+                            if isDownloading(digest) {
+                                try await waitForExistingDownload(
+                                    digest, cachedLayer: cachedLayer)
+                                if FileManager.default.fileExists(atPath: cachedLayer.path) {
+                                    await downloadProgress.addProgress(Int64(size))
+                                    await counter.decrement()
+                                    return Int64(size)
+                                }
+                            }
+
+                            markDownloadStarted(digest)
+                            try await self.downloadLayer(
+                                repository: "\(self.organization)/\(imageName)",
+                                digest: digest, mediaType: layer.mediaType,
+                                token: token,
+                                to: tempPartURL, maxRetries: 5,
+                                progress: downloadProgress, manifestId: manifestId
+                            )
+                            Logger.info(
+                                "Downloaded raw OCI disk part \(currentPartNum): \(tempPartURL.lastPathComponent)"
+                            )
+                            await counter.decrement()
+                            return Int64(size)
+                        }
+                    } else if layer.mediaType == "application/octet-stream+lz4" {
                         // --- Handle LZ4 Disk Part Layer ---
                         lz4LayerCount += 1  // Increment count
                         let currentPartNum = lz4LayerCount  // Use the current count as the logical number for logging
@@ -1673,6 +1822,8 @@ class ImageContainerRegistry: ImageRegistry, @unchecked Sendable {
         // Instantiate collector
         let diskPartsCollector = DiskPartsCollector()
         var lz4LayerCount = 0  // Count lz4 layers found
+        var rawDiskPartCount = 0
+        var expectedRawDiskParts: Int?
         var hasNvram = false
         var configPath: URL? = nil
 
@@ -1681,7 +1832,32 @@ class ImageContainerRegistry: ImageRegistry, @unchecked Sendable {
             let cachedLayer = getCachedLayerPath(manifestId: manifestId, digest: layer.digest)
 
             // Identify disk parts simply by media type
-            if layer.mediaType == "application/octet-stream+lz4" {
+            if let rawDiskPart = OCIMediaType.rawDiskPartInfo(for: layer) {
+                rawDiskPartCount += 1
+                if let totalParts = rawDiskPart.totalParts {
+                    expectedRawDiskParts = max(expectedRawDiskParts ?? 0, totalParts)
+                }
+
+                if !FileManager.default.fileExists(atPath: cachedLayer.path) {
+                    Logger.info("Raw disk part not found in cache: \(cachedLayer.path) - skipping")
+                    continue
+                }
+
+                let collectorPartNum = await diskPartsCollector.addPart(
+                    partNumber: rawDiskPart.partNumber,
+                    url: cachedLayer,
+                    compression: .raw
+                )
+                if let totalParts = rawDiskPart.totalParts {
+                    Logger.info(
+                        "Adding cached raw OCI disk part \(collectorPartNum)/\(totalParts): \(cachedLayer.lastPathComponent)"
+                    )
+                } else {
+                    Logger.info(
+                        "Adding cached raw OCI disk part \(collectorPartNum): \(cachedLayer.lastPathComponent)"
+                    )
+                }
+            } else if layer.mediaType == "application/octet-stream+lz4" {
                 lz4LayerCount += 1  // Increment count
 
                 // When caching is disabled, the file might not exist with the cache path name
@@ -1737,7 +1913,18 @@ class ImageContainerRegistry: ImageRegistry, @unchecked Sendable {
         let diskPartSources = await diskPartsCollector.getSortedParts()  // Sorted by assigned sequential number
         let totalParts = await diskPartsCollector.getTotalParts()  // Get total count from collector
 
-        Logger.info("Found \(totalParts) lz4 disk parts in cache to reassemble.")
+        Logger.info("Found \(totalParts) disk parts in cache to reassemble.")
+        if rawDiskPartCount > 0 {
+            Logger.info("Found \(rawDiskPartCount) raw OCI disk parts in cache to reassemble.")
+        }
+        if let expectedRawDiskParts {
+            let rawPartNumbers = Set(
+                diskPartSources.filter { $0.compression == .raw }.map(\.partNumber))
+            for partNumber in 1...expectedRawDiskParts where !rawPartNumbers.contains(partNumber) {
+                Logger.error("Missing raw OCI disk part \(partNumber) of \(expectedRawDiskParts).")
+                throw PullError.missingPart(partNumber)
+            }
+        }
         // --- End retrieving parts ---
 
         // Reassemble disk parts if needed
@@ -1798,12 +1985,37 @@ class ImageContainerRegistry: ImageRegistry, @unchecked Sendable {
             // If we have just one disk part, use the shared function
             if totalParts == 1 {
                 // Single part - use shared function
-                let sourceURL = diskPartSources[0].1  // Get the first source URL (index 1 of the tuple)
-                try createDiskImageFromSource(
-                    sourceURL: sourceURL,
-                    destinationURL: outputURL,
-                    diskSize: sizeForTruncate
-                )
+                let source = diskPartSources[0]
+                switch source.compression {
+                case .lz4:
+                    try createDiskImageFromSource(
+                        sourceURL: source.url,
+                        destinationURL: outputURL,
+                        diskSize: sizeForTruncate
+                    )
+                case .raw:
+                    if FileManager.default.fileExists(atPath: outputURL.path) {
+                        try FileManager.default.removeItem(at: outputURL)
+                    }
+                    guard FileManager.default.createFile(atPath: outputURL.path, contents: nil)
+                    else {
+                        throw PullError.fileCreationFailed(outputURL.path)
+                    }
+                    let outputHandle = try FileHandle(forWritingTo: outputURL)
+                    do {
+                        try outputHandle.truncate(atOffset: sizeForTruncate)
+                        _ = try DiskPartWriter.writeRawChunk(
+                            inputPath: source.url.path,
+                            outputHandle: outputHandle,
+                            startOffset: 0
+                        )
+                        try outputHandle.synchronize()
+                        try outputHandle.close()
+                    } catch {
+                        try? outputHandle.close()
+                        throw error
+                    }
+                }
             } else {
                 // Multiple parts - we need to reassemble
                 // Wrap file handle setup and sparse file creation within this block
@@ -1846,27 +2058,39 @@ class ImageContainerRegistry: ImageRegistry, @unchecked Sendable {
                 for collectorPartNum in 1...totalParts {
                     // Find the source URL from our collected parts using the sequential collectorPartNum
                     guard
-                        let sourceInfo = diskPartSources.first(where: { $0.0 == collectorPartNum })
+                        let sourceInfo = diskPartSources.first(where: {
+                            $0.partNumber == collectorPartNum
+                        })
                     else {
                         Logger.error(
                             "Missing required cached part number \(collectorPartNum) in collected parts during reassembly."
                         )
                         throw PullError.missingPart(collectorPartNum)
                     }
-                    let sourceURL = sourceInfo.1  // Get URL from tuple
+                    let sourceURL = sourceInfo.url
 
                     // Log using the sequential collector part number
+                    let action = sourceInfo.compression == .raw ? "Copying" : "Decompressing"
                     Logger.info(
-                        "Decompressing part \(collectorPartNum) of \(totalParts) from cache: \(sourceURL.lastPathComponent) at offset \(currentOffset)..."
+                        "\(action) part \(collectorPartNum) of \(totalParts) from cache: \(sourceURL.lastPathComponent) at offset \(currentOffset)..."
                     )
 
-                    // Always use the correct sparse decompression function
-                    let decompressedBytesWritten = try decompressChunkAndWriteSparse(
-                        inputPath: sourceURL.path,
-                        outputHandle: outputHandle,
-                        startOffset: currentOffset
-                    )
-                    currentOffset += decompressedBytesWritten
+                    let bytesWritten: UInt64
+                    switch sourceInfo.compression {
+                    case .lz4:
+                        bytesWritten = try decompressChunkAndWriteSparse(
+                            inputPath: sourceURL.path,
+                            outputHandle: outputHandle,
+                            startOffset: currentOffset
+                        )
+                    case .raw:
+                        bytesWritten = try DiskPartWriter.writeRawChunk(
+                            inputPath: sourceURL.path,
+                            outputHandle: outputHandle,
+                            startOffset: currentOffset
+                        )
+                    }
+                    currentOffset += bytesWritten
                     // Update progress (using sizeForTruncate which should be available)
                     reassemblyProgressLogger.logProgress(
                         current: Double(currentOffset) / Double(sizeForTruncate),
@@ -1877,15 +2101,6 @@ class ImageContainerRegistry: ImageRegistry, @unchecked Sendable {
 
                 // Finalize progress, close handle (done by defer)
                 reassemblyProgressLogger.logProgress(current: 1.0, context: "Reassembly Complete")
-
-                // Add test patterns at the beginning and end of the file
-                Logger.info("Writing test patterns to sparse file to verify integrity...")
-                let testPattern = "LUME_TEST_PATTERN".data(using: .utf8)!
-                try outputHandle.seek(toOffset: 0)
-                try outputHandle.write(contentsOf: testPattern)
-                try outputHandle.seek(toOffset: sizeForTruncate - UInt64(testPattern.count))
-                try outputHandle.write(contentsOf: testPattern)
-                try outputHandle.synchronize()
 
                 // Ensure handle is properly synchronized before closing
                 try outputHandle.synchronize()
@@ -1973,7 +2188,8 @@ class ImageContainerRegistry: ImageRegistry, @unchecked Sendable {
                 // Use an array to track unique file paths to avoid trying to delete the same file multiple times
                 var processedPaths: [String] = []
 
-                for (_, partURL) in diskPartSources {
+                for part in diskPartSources {
+                    let partURL = part.url
                     let path = partURL.path
 
                     // Skip if we've already processed this exact path

--- a/libs/lume/src/ContainerRegistry/ImageContainerRegistry.swift
+++ b/libs/lume/src/ContainerRegistry/ImageContainerRegistry.swift
@@ -117,7 +117,7 @@ enum OCIMediaType {
 
     static func rawDiskPartInfo(for layer: Layer) -> OCIDiskPartInfo? {
         let mediaType = parse(layer.mediaType)
-        guard mediaType.base == standardTarLayer,
+        guard mediaType.base.lowercased() == standardTarLayer,
             let partNumberText = mediaType.parameters["part.number"],
             let partNumber = Int(partNumberText),
             partNumber > 0
@@ -150,7 +150,13 @@ enum OCIMediaType {
             let pair = parameter.split(
                 separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
             guard pair.count == 2 else { continue }
-            parameters[String(pair[0])] = String(pair[1])
+            let key = String(pair[0])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+            let value = String(pair[1])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+            parameters[key] = value
         }
 
         return OCIMediaTypeComponents(base: base, parameters: parameters)
@@ -276,7 +282,7 @@ enum DiskPartWriter {
     ) throws -> UInt64 {
         guard FileManager.default.fileExists(atPath: inputPath) else {
             Logger.error("Raw disk part not found at: \(inputPath)")
-            return 0
+            throw PullError.layerDownloadFailed(inputPath)
         }
 
         let readHandle = try FileHandle(forReadingFrom: URL(fileURLWithPath: inputPath))
@@ -2054,25 +2060,15 @@ class ImageContainerRegistry: ImageRegistry, @unchecked Sendable {
                 var reassemblyProgressLogger = ProgressLogger(threshold: 0.05)
                 var currentOffset: UInt64 = 0
 
-                // Iterate from 1 up to the total number of parts found by the collector
-                for collectorPartNum in 1...totalParts {
-                    // Find the source URL from our collected parts using the sequential collectorPartNum
-                    guard
-                        let sourceInfo = diskPartSources.first(where: {
-                            $0.partNumber == collectorPartNum
-                        })
-                    else {
-                        Logger.error(
-                            "Missing required cached part number \(collectorPartNum) in collected parts during reassembly."
-                        )
-                        throw PullError.missingPart(collectorPartNum)
-                    }
+                // Use the collector's sorted sources directly. Raw OCI disk parts are validated
+                // against part.total above when that metadata is present.
+                for sourceInfo in diskPartSources {
                     let sourceURL = sourceInfo.url
 
                     // Log using the sequential collector part number
                     let action = sourceInfo.compression == .raw ? "Copying" : "Decompressing"
                     Logger.info(
-                        "\(action) part \(collectorPartNum) of \(totalParts) from cache: \(sourceURL.lastPathComponent) at offset \(currentOffset)..."
+                        "\(action) part \(sourceInfo.partNumber) of \(totalParts) from cache: \(sourceURL.lastPathComponent) at offset \(currentOffset)..."
                     )
 
                     let bytesWritten: UInt64

--- a/libs/lume/tests/ImageContainerRegistryTests.swift
+++ b/libs/lume/tests/ImageContainerRegistryTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Testing
+
+@testable import lume
+
+@Test("parameterized OCI tar disk layers are recognized as raw disk parts")
+func testParameterizedTarDiskLayerIsRecognizedAsRawDiskPart() throws {
+    let layer = Layer(
+        mediaType: "application/vnd.oci.image.layer.v1.tar;part.number=2;part.total=41",
+        digest: "sha256:part2",
+        size: 512,
+        annotations: ["org.opencontainers.image.title": "disk.img.part.ab"]
+    )
+
+    let diskPart = OCIMediaType.rawDiskPartInfo(for: layer)
+
+    #expect(diskPart?.partNumber == 2)
+    #expect(diskPart?.totalParts == 41)
+}
+
+@Test("non-disk OCI tar layers are not treated as disk parts")
+func testNonDiskTarLayerIsNotRecognizedAsRawDiskPart() throws {
+    let layer = Layer(
+        mediaType: "application/vnd.oci.image.layer.v1.tar;part.number=1;part.total=1",
+        digest: "sha256:config",
+        size: 128,
+        annotations: ["org.opencontainers.image.title": "metadata.tar"]
+    )
+
+    #expect(OCIMediaType.rawDiskPartInfo(for: layer) == nil)
+}
+
+@Test("disk part collector preserves explicit part ordering")
+func testDiskPartsCollectorPreservesExplicitPartOrdering() async {
+    let collector = DiskPartsCollector()
+    let tempDir = FileManager.default.temporaryDirectory
+
+    await collector.addPart(
+        partNumber: 10,
+        url: tempDir.appendingPathComponent("disk.img.part.10"),
+        compression: .raw
+    )
+    await collector.addPart(
+        partNumber: 2,
+        url: tempDir.appendingPathComponent("disk.img.part.2"),
+        compression: .raw
+    )
+    await collector.addPart(
+        partNumber: 1,
+        url: tempDir.appendingPathComponent("disk.img.part.1"),
+        compression: .raw
+    )
+
+    let parts = await collector.getSortedParts()
+
+    #expect(parts.map(\.partNumber) == [1, 2, 10])
+    #expect(parts.map(\.compression) == [.raw, .raw, .raw])
+}
+
+@Test("raw disk part writer copies bytes without decompression")
+func testRawDiskPartWriterCopiesBytesWithoutDecompression() throws {
+    let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let source = tempDir.appendingPathComponent("disk.img.part.1")
+    let destination = tempDir.appendingPathComponent("disk.img")
+    try Data([0xde, 0xad, 0xbe, 0xef]).write(to: source)
+    _ = FileManager.default.createFile(atPath: destination.path, contents: nil)
+
+    let handle = try FileHandle(forWritingTo: destination)
+
+    let writtenBytes = try DiskPartWriter.writeRawChunk(
+        inputPath: source.path,
+        outputHandle: handle,
+        startOffset: 2
+    )
+
+    try handle.close()
+    let output = try Data(contentsOf: destination)
+
+    #expect(writtenBytes == 4)
+    #expect(output == Data([0x00, 0x00, 0xde, 0xad, 0xbe, 0xef]))
+}

--- a/libs/lume/tests/ImageContainerRegistryTests.swift
+++ b/libs/lume/tests/ImageContainerRegistryTests.swift
@@ -18,6 +18,21 @@ func testParameterizedTarDiskLayerIsRecognizedAsRawDiskPart() throws {
     #expect(diskPart?.totalParts == 41)
 }
 
+@Test("OCI tar disk layer parameters tolerate case, whitespace, and quoted values")
+func testParameterizedTarDiskLayerNormalizesParameters() throws {
+    let layer = Layer(
+        mediaType: "Application/Vnd.Oci.Image.Layer.V1.Tar; Part.Number = \"2\" ; PART.TOTAL = \"41\"",
+        digest: "sha256:part2",
+        size: 512,
+        annotations: ["org.opencontainers.image.title": "disk.img.part.ab"]
+    )
+
+    let diskPart = OCIMediaType.rawDiskPartInfo(for: layer)
+
+    #expect(diskPart?.partNumber == 2)
+    #expect(diskPart?.totalParts == 41)
+}
+
 @Test("non-disk OCI tar layers are not treated as disk parts")
 func testNonDiskTarLayerIsNotRecognizedAsRawDiskPart() throws {
     let layer = Layer(
@@ -81,4 +96,29 @@ func testRawDiskPartWriterCopiesBytesWithoutDecompression() throws {
 
     #expect(writtenBytes == 4)
     #expect(output == Data([0x00, 0x00, 0xde, 0xad, 0xbe, 0xef]))
+}
+
+@Test("raw disk part writer fails when the source file is missing")
+func testRawDiskPartWriterThrowsForMissingSource() throws {
+    let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let destination = tempDir.appendingPathComponent("disk.img")
+    _ = FileManager.default.createFile(atPath: destination.path, contents: nil)
+    let handle = try FileHandle(forWritingTo: destination)
+    defer { try? handle.close() }
+
+    var didThrow = false
+    do {
+        _ = try DiskPartWriter.writeRawChunk(
+            inputPath: tempDir.appendingPathComponent("missing.part").path,
+            outputHandle: handle,
+            startOffset: 0
+        )
+    } catch {
+        didThrow = true
+    }
+
+    #expect(didThrow)
 }


### PR DESCRIPTION
## Summary

Fixes `lume pull` for OCI images whose disk is split across parameterized tar layers such as:

`application/vnd.oci.image.layer.v1.tar;part.number=N;part.total=41`

These layers were previously skipped as unsupported, which could leave the pulled VM directory with `config.json` and `nvram.bin` but no `disk.img`.

## Motivation

`ubuntu-noble-vanilla:latest` publishes its disk as 41 `disk.img.part.*` layers totaling about 21.5 GB. The manifest exposes explicit `part.number` and `part.total` media type parameters, but the existing legacy pull path only recognized exact media type matches and lz4 disk parts.

The result is that all disk layers are skipped and the VM cannot be assembled.

## Changes

- Parse parameterized OCI media types.
- Recognize raw OCI tar disk parts only when the layer title starts with `disk.img.part.`.
- Download those raw disk parts instead of skipping them.
- Preserve explicit `part.number` ordering during cache reassembly.
- Validate expected `part.total` coverage before assembling the disk.
- Write raw disk parts directly with sparse-file support instead of trying lz4/gzip decompression.
- Avoid writing test marker bytes into the final reassembled `disk.img`.
- Add focused tests for media type recognition, non-disk tar exclusion, part ordering, and raw disk part writing.

## Test Plan

- `swiftc -parse libs/lume/src/ContainerRegistry/ImageContainerRegistry.swift libs/lume/tests/ImageContainerRegistryTests.swift`
- `git diff --check`
- Manual registry assembly check for `ghcr.io/trycua/ubuntu-noble-vanilla:latest`:
  - Downloaded all 41 parameterized tar disk parts.
  - Reassembled them in explicit `part.number` order into `disk.img`.
  - Verified final size matches both summed manifest layer size and `config.diskSize`: `21474836480` bytes.
  - Verified the assembled image is recognized as a disk image with a protective MBR/GPT layout:
    `DOS/MBR boot sector; partition 1 : ID=0xee`.

I also attempted:

- `swift test --filter ImageContainerRegistryTests`

but local SwiftPM failed before compiling tests because this machine only has Command Line Tools available and the package manifest fails to link `PackageDescription`. This repository's Lume CI uses `macos-15` with `Xcode_16.3`, so the PR should get the authoritative `swift test` and release build checks there.

## Risk

The new handling is intentionally narrow: it only treats parameterized OCI tar layers as raw disk parts when the layer is explicitly titled `disk.img.part.*`. Existing lz4 and single-layer paths are left in place.

## Related Issue

Fixes #1102


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OCI tar disk images with enhanced caching and retrieval mechanisms.

* **Bug Fixes**
  * Improved error detection and reporting when disk components are missing.

* **Tests**
  * Added unit tests for disk part collection, ordering, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->