### PR TITLE
fix(cua-driver): check_permissions prompts by default

### DIFF
--- a/docs/content/docs/cua-driver/reference/mcp-tools.mdx
+++ b/docs/content/docs/cua-driver/reference/mcp-tools.mdx
@@ -120,14 +120,14 @@ Launch an app hidden (no focus steal) and return its pid plus the initial `windo
 
 ### check_permissions
 
-Report TCC permission status for Accessibility and Screen Recording.
+Report TCC permission status for Accessibility and Screen Recording. By default also raises the system permission dialogs for any missing grants — Apple's request APIs no-op when the grant is already active, so the call is safe to repeat.
 
 **Arguments:**
 
-- `prompt` (boolean, optional): If true, raise the system permission prompts for any missing grants. Otherwise the call is purely read-only.
+- `prompt` (boolean, optional): Raise the system permission prompts for missing grants. Default `true`. Pass `false` for a purely read-only status check.
 
 ```json
-{"prompt": true}
+{"prompt": false}
 ```
 
 ## Mouse

--- a/libs/cua-driver/Skills/cua-driver/SKILL.md
+++ b/libs/cua-driver/Skills/cua-driver/SKILL.md
@@ -214,11 +214,14 @@ editor state.
 
 1. `cua-driver` is on `$PATH` (`which cua-driver`). If not, point the
    user at `scripts/install-local.sh` and stop.
-2. Run `cua-driver check_permissions`. If either grant is `false`, tell
-   the user to open System Settings → Privacy & Security and grant
+2. Run `cua-driver check_permissions` (with the daemon up — see step 3).
+   The default behavior also raises the system permission dialogs for
+   any missing grants, so the user can grant on the spot. If either
+   grant still reads `false` after that (user dismissed the dialog),
+   tell them to open System Settings → Privacy & Security and grant
    Accessibility and Screen Recording to `CuaDriver.app`, then stop.
-   (`cua-driver check_permissions '{"prompt":true}'` raises the system
-   dialogs, but only do that if the user asks — it steals focus.)
+   Pass `'{"prompt":false}'` for a purely read-only status check that
+   won't steal focus.
 3. Start the daemon with `open -n -g -a CuaDriver --args serve` (the
    recommended form — goes through LaunchServices so TCC attributes
    the process to CuaDriver.app). `cua-driver serve &` also works;

--- a/libs/cua-driver/Sources/CuaDriverCLI/CallCommand.swift
+++ b/libs/cua-driver/Sources/CuaDriverCLI/CallCommand.swift
@@ -124,6 +124,7 @@ struct CallCommand: AsyncParsableCommand {
 
     private func runInProcess(arguments: [String: Value]?) async throws {
         let registry = ToolRegistry.default
+        var arguments = arguments
 
         guard let handler = registry.handlers[toolName] else {
             printUnknownTool(toolName, registry: registry)
@@ -152,7 +153,10 @@ struct CallCommand: AsyncParsableCommand {
         // "NOT granted" even when the user has granted both permissions
         // to CuaDriver.app. If the daemon were up we'd already have
         // forwarded in run(); reaching this branch means no daemon is
-        // listening. Warn the user that the fallback answer is unreliable.
+        // listening. Warn the user that the fallback answer is unreliable,
+        // and force `prompt: false` — the tool's default would otherwise
+        // raise a TCC dialog attributed to the calling shell/IDE bundle,
+        // not CuaDriver.app, so the user would grant the wrong identity.
         if toolName == "check_permissions" {
             printToStderr(
                 """
@@ -160,6 +164,9 @@ struct CallCommand: AsyncParsableCommand {
                 For authoritative results, start the daemon first: `open -n -g -a CuaDriver --args serve`, then re-run this check.
                 """
             )
+            var coerced = arguments ?? [:]
+            coerced["prompt"] = .bool(false)
+            arguments = coerced
         }
 
         let result: CallTool.Result

--- a/libs/cua-driver/Sources/CuaDriverServer/Tools/CheckPermissionsTool.swift
+++ b/libs/cua-driver/Sources/CuaDriverServer/Tools/CheckPermissionsTool.swift
@@ -8,8 +8,10 @@ public enum CheckPermissionsTool {
             name: "check_permissions",
             description: """
                 Report TCC permission status for Accessibility and Screen Recording.
-                Pass {"prompt": true} to raise the system permission dialogs for any
-                missing grants — otherwise the call is purely read-only.
+                By default also raises the system permission dialogs for any missing
+                grants — Apple's request APIs are no-ops when the grant is already
+                active, so this is safe to call repeatedly. Pass {"prompt": false}
+                for a purely read-only status check.
                 """,
             inputSchema: [
                 "type": "object",
@@ -17,13 +19,13 @@ public enum CheckPermissionsTool {
                     "prompt": [
                         "type": "boolean",
                         "description":
-                            "If true, raise the system permission prompts for missing grants.",
+                            "Raise the system permission prompts for missing grants. Default true.",
                     ]
                 ],
                 "additionalProperties": false,
             ],
             annotations: .init(
-                // Not readOnly when prompt=true (it may raise a modal dialog).
+                // Not readOnly because the default path may raise a modal dialog.
                 readOnlyHint: false,
                 destructiveHint: false,
                 idempotentHint: true,
@@ -31,7 +33,13 @@ public enum CheckPermissionsTool {
             )
         ),
         invoke: { arguments in
-            if arguments?["prompt"]?.boolValue == true {
+            // Default to prompting. The point of `check_permissions` is to
+            // surface and resolve missing grants — a read-only status check
+            // that leaves the user hunting for `CuaDriver.app` in System
+            // Settings is the wrong default. Apple's request APIs no-op
+            // when the grant is already active, so prompting is safe.
+            let shouldPrompt = arguments?["prompt"]?.boolValue ?? true
+            if shouldPrompt {
                 _ = Permissions.requestAccessibility()
                 _ = Permissions.requestScreenRecording()
             }


### PR DESCRIPTION
## Summary

- `cua-driver check_permissions` now raises the Accessibility + Screen Recording dialogs by default. Previously only `{"prompt": true}` did — the bare form (which `installation.mdx`, `SKILL.md`, and `install.sh` all tell users to run) was read-only, so new users saw `❌ NOT granted` and had to go hunt for `CuaDriver.app` in System Settings.
- Apple's request APIs (`AXIsProcessTrustedWithOptions(prompt:)`, `CGRequestScreenCaptureAccess`) no-op when the grant is already active, so this is safe to call repeatedly. Callers who explicitly want a quiet status check can pass `{"prompt": false}`.
- The CLI's in-process fallback (no daemon running) force-coerces `prompt: false`. Prompting from a one-shot CLI inside an IDE terminal would attribute the TCC dialog to the IDE's bundle, not `CuaDriver.app` — the user would grant the wrong identity. The existing stderr warning still steers them to start the daemon.

## Why

Caught while walking through a fresh install: install.sh ends with "macOS raises the Accessibility + Screen Recording dialogs" — but only if the user knew to add `{"prompt": true}` themselves. Without that, the install flow surfaces a red ❌ and goes silent. The defaults should match what install.sh / installation.mdx promise.

## Files

- `Sources/CuaDriverServer/Tools/CheckPermissionsTool.swift` — flip default + update tool description.
- `Sources/CuaDriverCLI/CallCommand.swift` — coerce `prompt: false` in the in-process fallback.
- `docs/content/docs/cua-driver/reference/mcp-tools.mdx` — update tool reference.
- `Skills/cua-driver/SKILL.md` — update prereqs guidance.

## Test plan

- [x] `swift build` clean.
- [x] Existing `test_no_daemon_emits_tcc_warning_on_stderr` integration test passes (exercises the in-process path; verifies warning + summary). The other test in that file fails on a pre-existing `.app`-bundle path assumption unrelated to this change.
- [x] Smoke-tested locally with the daemon running: dialog fires when a grant is missing; no dialog (and no behavior change) when both grants are already active.
- [ ] Smoke-test from a fresh-install machine where neither grant has been given to confirm the dialogs actually appear in the install flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated `check_permissions` tool documentation to clarify that the default behavior now triggers macOS permission dialogs for missing Accessibility/Screen Recording grants.
  * Revised permission-checking prerequisites and added guidance on using read-only status checks with `{"prompt": false}`.

* **Changes**
  * `check_permissions` now prompts for missing permissions by default; repeated calls are safe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->