### PR TITLE
chore(cua-driver): finish sudo-free CLI path migration

### DIFF
--- a/docs/content/docs/cua-driver/guide/getting-started/installation.mdx
+++ b/docs/content/docs/cua-driver/guide/getting-started/installation.mdx
@@ -202,7 +202,7 @@ rm -f ~/Library/LaunchAgents/com.trycua.cua_driver_updater.plist
 
 ## Troubleshooting
 
-**`cua-driver: command not found`** — `/usr/local/bin` isn't on your PATH. Add it and reload (see the first-time install callout above).
+**`cua-driver: command not found`** — `~/.local/bin` isn't on your PATH. Add it and reload (see the first-time install callout above).
 
 **Permissions dialogs reappear after every launch** — macOS is attributing the process to a different bundle id than the one you granted. Run `cua-driver diagnose` and paste the output when filing an issue; it reports cdhash, team id, and which bundle TCC is checking against.
 

--- a/libs/cua-driver/Sources/CuaDriverCLI/DiagnoseCommand.swift
+++ b/libs/cua-driver/Sources/CuaDriverCLI/DiagnoseCommand.swift
@@ -19,7 +19,7 @@ import Security
 ///   - TCC probe results (Accessibility + Screen Recording, as the live
 ///     process sees them)
 ///   - install layout (/Applications/CuaDriver.app bundle + signature,
-///     /usr/local/bin/cua-driver symlink resolution)
+///     ~/.local/bin/cua-driver symlink resolution)
 ///   - TCC DB rows for `com.trycua.driver` (best-effort; system TCC DB
 ///     requires Full Disk Access)
 ///   - config + state paths (LaunchAgent plist, user-data dir, config
@@ -92,13 +92,18 @@ struct DiagnoseCommand: AsyncParsableCommand {
         }
 
         // CLI symlink that an MCP client (Claude Code etc.) invokes.
-        let cliPath = "/usr/local/bin/cua-driver"
-        let cliExists = FileManager.default.fileExists(atPath: cliPath)
-        lines.append("symlink: \(cliPath)   exists=\(cliExists)")
-        if cliExists {
-            let resolved = (try? FileManager.default.destinationOfSymbolicLink(
-                atPath: cliPath)) ?? "<not a symlink>"
-            lines.append("  resolves to: \(resolved)")
+        let cliPaths = [
+            ("symlink", "\(NSHomeDirectory())/.local/bin/cua-driver"),
+            ("legacy symlink", "/usr/local/bin/cua-driver"),
+        ]
+        for (label, cliPath) in cliPaths {
+            let cliExists = FileManager.default.fileExists(atPath: cliPath)
+            lines.append("\(label): \(cliPath)   exists=\(cliExists)")
+            if cliExists {
+                let resolved = (try? FileManager.default.destinationOfSymbolicLink(
+                    atPath: cliPath)) ?? "<not a symlink>"
+                lines.append("  resolves to: \(resolved)")
+            }
         }
 
         // Stale dev-install paths — flag these specifically so users who
@@ -106,7 +111,6 @@ struct DiagnoseCommand: AsyncParsableCommand {
         // they have leftovers to clean up.
         let stalePaths = [
             "\(NSHomeDirectory())/Applications/CuaDriver.app",
-            "\(NSHomeDirectory())/.local/bin/cua-driver",
         ]
         for stale in stalePaths where FileManager.default.fileExists(atPath: stale) {
             lines.append("stale:   \(stale)   ← old install-local.sh path, consider removing")

--- a/libs/cua-driver/Sources/CuaDriverCLI/ServeCommand.swift
+++ b/libs/cua-driver/Sources/CuaDriverCLI/ServeCommand.swift
@@ -27,7 +27,7 @@ struct ServeCommand: ParsableCommand {
             Responses: {"ok":true,"result":...} or
                        {"ok":false,"error":"...","exitCode":64|65|70|1}.
 
-            TCC responsibility chain: when invoked via the `/usr/local/bin/cua-driver`
+            TCC responsibility chain: when invoked via the `~/.local/bin/cua-driver`
             symlink from a shell that itself lacks Accessibility + Screen Recording
             grants (any IDE terminal — Claude Code, Cursor, VS Code, Conductor),
             macOS attributes the serve process to the parent shell/IDE, not to
@@ -172,7 +172,7 @@ extension ServeCommand {
     ///     truthy in the environment.
     ///   - `Bundle.main.bundlePath` does NOT end in `.app`. That's the
     ///     signal we were invoked as a bare binary — almost always the
-    ///     `/usr/local/bin/cua-driver` symlink from a shell — rather
+    ///     `~/.local/bin/cua-driver` symlink from a shell — rather
     ///     than as the main executable of a loaded `.app` bundle. The
     ///     `open -n -g -a` path always lands in the second form
     ///     (bundlePath ends in `/CuaDriver.app`), so checking for its
@@ -311,7 +311,7 @@ extension ServeCommand {
     /// True when the argv[0] / executablePath resolves (through any
     /// symlinks) to a binary physically living inside some
     /// `CuaDriver.app/Contents/MacOS/` directory. That's the "installed
-    /// via install-local.sh / install.sh" shape — `/usr/local/bin/cua-driver`
+    /// via install-local.sh / install.sh" shape — `~/.local/bin/cua-driver`
     /// is a symlink into `/Applications/CuaDriver.app`, and `realpath`
     /// walks into the bundle.
     ///

--- a/libs/cua-driver/scripts/install-local.sh
+++ b/libs/cua-driver/scripts/install-local.sh
@@ -7,10 +7,10 @@
 # Installs to the same paths as scripts/install.sh (the production
 # installer), so TCC grants made against one install survive the other:
 #   app bundle  → /Applications/CuaDriver.app
-#   CLI symlink → /usr/local/bin/cua-driver
+#   CLI symlink → ~/.local/bin/cua-driver
 #
 # The script prompts for sudo only on the specific steps that need it
-# (moving the .app into /Applications, symlinking into /usr/local/bin)
+# (moving the .app into /Applications)
 # — do NOT run the whole script with `sudo`.
 #
 # --release builds the release configuration (default is debug — faster).
@@ -36,7 +36,7 @@ YELLOW=$(tput setaf 3 2>/dev/null || true)
 if [ "$(id -u)" -eq 0 ] || [ -n "${SUDO_USER:-}" ]; then
     echo "${RED}Error: do not run this script with sudo or as root.${NORMAL}"
     echo "The script will prompt for sudo on the specific operations that"
-    echo "need it (writing to /Applications + /usr/local/bin); running the"
+    echo "need it (writing to /Applications); running the"
     echo "whole thing as root puts the LaunchAgent plist under /var/root"
     echo "and breaks telemetry / config paths."
     exit 1
@@ -81,20 +81,15 @@ while [ "$#" -gt 0 ]; do
 done
 
 APP_INSTALL_DIR="/Applications"
-BIN_INSTALL_DIR="/usr/local/bin"
+BIN_INSTALL_DIR="$HOME/.local/bin"
 APP_DEST="$APP_INSTALL_DIR/CuaDriver.app"
 BIN_LINK="$BIN_INSTALL_DIR/cua-driver"
 
 # Conditional sudo — matches install.sh. /Applications is usually
-# group-writable by the admin group, so most users won't be prompted;
-# /usr/local/bin typically requires sudo on a fresh machine.
+# group-writable by the admin group, so most users won't be prompted.
 SUDO_APP=""
 if [ ! -w "$APP_INSTALL_DIR" ]; then
     SUDO_APP="sudo"
-fi
-SUDO_BIN=""
-if [ ! -w "$BIN_INSTALL_DIR" ]; then
-    SUDO_BIN="sudo"
 fi
 
 echo "${BOLD}${BLUE}cua-driver local installer${NORMAL}"
@@ -131,17 +126,14 @@ fi
 # --- Remove stale dev-install paths -------------------------------------
 #
 # Older revisions of this script (and ad-hoc `install-cli.sh`, since
-# removed) installed to `~/Applications/CuaDriver.app` and
-# `~/.local/bin/cua-driver`. Both paths leak a second bundle that
-# LaunchServices keys off `CFBundleIdentifier=com.trycua.driver` —
-# which can silently re-route `cua-driver serve` (invoked through the
-# canonical `/usr/local/bin/cua-driver` symlink) to the *stale*
-# `~/Applications` copy, so rebuilds look like they do nothing.
+# removed) installed to `~/Applications/CuaDriver.app`. That leaks a
+# second bundle that LaunchServices keys off
+# `CFBundleIdentifier=com.trycua.driver`, which can silently re-route
+# `cua-driver serve` to the stale `~/Applications` copy.
 # Proactively remove them here so there is exactly one registered
 # CuaDriver.app on the machine after every install.
 STALE_APP="$HOME/Applications/CuaDriver.app"
-STALE_CLI="$HOME/.local/bin/cua-driver"
-for stale in "$STALE_APP" "$STALE_CLI"; do
+for stale in "$STALE_APP"; do
     if [ -e "$stale" ] || [ -L "$stale" ]; then
         echo "Removing stale dev-install leftover: $stale"
         rm -rf "$stale"
@@ -164,24 +156,14 @@ echo "${GREEN}Installed $APP_DEST${NORMAL}"
 
 echo ""
 echo "${BOLD}Linking cua-driver CLI into $BIN_INSTALL_DIR...${NORMAL}"
-# Non-fatal symlink step: the `.app` bundle is already installed and usable
-# via its absolute path; the /usr/local/bin symlink is a convenience.
-# In non-TTY shells (agent sandboxes, CI) sudo can't prompt for a password
-# and fails — without this guard `set -e` would abort the whole script with
-# exit 1, making the caller think the build itself failed. Warn and exit 0.
-set +e
-$SUDO_BIN mkdir -p "$BIN_INSTALL_DIR" \
-    && $SUDO_BIN ln -sf "$APP_DEST/Contents/MacOS/cua-driver" "$BIN_LINK"
-SYMLINK_STATUS=$?
-set -e
-if [ "$SYMLINK_STATUS" -eq 0 ]; then
-    echo "${GREEN}Linked $BIN_LINK → $APP_DEST/Contents/MacOS/cua-driver${NORMAL}"
-else
-    echo "${YELLOW}Warning: could not create $BIN_LINK (sudo may have failed in a non-TTY shell).${NORMAL}"
-    echo "${YELLOW}The .app bundle is installed and functional at $APP_DEST.${NORMAL}"
-    echo "${YELLOW}To add the CLI symlink manually, run:${NORMAL}"
-    echo "    sudo ln -sf $APP_DEST/Contents/MacOS/cua-driver $BIN_LINK"
+mkdir -p "$BIN_INSTALL_DIR"
+if [ ! -w "$BIN_INSTALL_DIR" ]; then
+    echo "${RED}Error: $BIN_INSTALL_DIR is not writable.${NORMAL}"
+    echo "Pick a user-writable bin directory or fix ownership before rerunning."
+    exit 1
 fi
+ln -sf "$APP_DEST/Contents/MacOS/cua-driver" "$BIN_LINK"
+echo "${GREEN}Linked $BIN_LINK → $APP_DEST/Contents/MacOS/cua-driver${NORMAL}"
 
 # --- Daemon (optional) --------------------------------------------------
 

--- a/libs/cua-driver/scripts/uninstall.sh
+++ b/libs/cua-driver/scripts/uninstall.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # cua-driver uninstaller. Removes everything install.sh laid down:
 #
-#   - /usr/local/bin/cua-driver symlink
+#   - ~/.local/bin/cua-driver symlink
 #   - /Applications/CuaDriver.app bundle
 #   - ~/.cua-driver/ (telemetry id + install marker)
 #   - ~/Library/Application Support/Cua Driver/ (config.json)


### PR DESCRIPTION
## Summary

Follow-up to 4352f3d6 (the sudo-free install PR). That commit moved the production installer's CLI symlink from `/usr/local/bin/cua-driver` to `~/.local/bin/cua-driver`, but five spots still referenced the old path. This PR catches them all.

## Files

- **`docs/.../installation.mdx`** — Troubleshooting "command not found" line now points at `~/.local/bin`.
- **`Sources/CuaDriverCLI/DiagnoseCommand.swift`** — `cua-driver diagnose` now probes both `~/.local/bin/cua-driver` (primary) and `/usr/local/bin/cua-driver` (legacy) and reports each, so the output is useful regardless of which install path the user is on. Drops `~/.local/bin/cua-driver` from the "stale dev-install" warning list — it is now the canonical CLI path, not a dev leftover.
- **`Sources/CuaDriverCLI/ServeCommand.swift`** — comment-only doc updates.
- **`scripts/install-local.sh`** — dev installer's bin dir flips to `~/.local/bin`. Drops the conditional sudo path and the non-fatal symlink fallback (no longer needed without sudo). Stops aggressively removing `~/.local/bin/cua-driver` as a stale leftover.
- **`scripts/uninstall.sh`** — header comment update.

## Test plan

- [x] `swift build` clean.
- [x] `cua-driver diagnose` output shows both symlinks correctly:
  ```
  symlink: /Users/<me>/.local/bin/cua-driver   exists=true
    resolves to: /Applications/CuaDriver.app/Contents/MacOS/cua-driver
  legacy symlink: /usr/local/bin/cua-driver   exists=false
  ```
- [ ] `install-local.sh` smoke-test on a clean machine — verify no sudo prompts on the symlink step, dev install lands in `~/.local/bin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated CLI installation to use user-writable `~/.local/bin` directory instead of system-wide `/usr/local/bin`, eliminating installation privilege requirements

* **Documentation**
  * Installation guide updated to reflect new default CLI symlink location at `~/.local/bin`
  * Diagnostic output enhanced to report symlink status for both user-local and legacy system paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->