### PR TITLE
fix(cua-driver): select latest release by semver

### DIFF
--- a/libs/cua-driver/Sources/CuaDriverCLI/VersionCheck.swift
+++ b/libs/cua-driver/Sources/CuaDriverCLI/VersionCheck.swift
@@ -20,15 +20,14 @@ enum VersionCheck {
               let releases = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
         else { return nil }
 
-        for release in releases {
+        return releases.compactMap { release -> String? in
             guard let tag = release["tag_name"] as? String,
                   tag.hasPrefix(tagPrefix),
                   release["draft"] as? Bool != true,
                   release["prerelease"] as? Bool != true
-            else { continue }
+            else { return nil }
             return String(tag.dropFirst(tagPrefix.count))
-        }
-        return nil
+        }.max(by: { isNewer($1, than: $0) })
     }
 
     /// True when `candidate` is strictly newer than `current` (semver compare).

--- a/libs/cua-driver/scripts/install.sh
+++ b/libs/cua-driver/scripts/install.sh
@@ -70,8 +70,10 @@ else
     log "resolving latest $TAG_PREFIX* release via GitHub API"
     TAG=$(curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=40" \
         | grep -Eo '"tag_name":[[:space:]]*"'"${TAG_PREFIX}"'[^"]+"' \
+        | sed -E 's/.*"'"${TAG_PREFIX}"'([0-9]+[.][0-9]+[.][0-9]+)"/\1/' \
+        | sort -t. -k1,1nr -k2,2nr -k3,3nr \
         | head -n 1 \
-        | sed -E 's/.*"'"${TAG_PREFIX}"'([^"]+)"/'"${TAG_PREFIX}"'\1/')
+        | sed -E 's/^/'"${TAG_PREFIX}"'/')
     if [[ -z "$TAG" ]]; then
         err "no release matching ${TAG_PREFIX}* found on $REPO"
         exit 1


### PR DESCRIPTION
## Summary
- select the latest cua-driver GitHub release by semantic version instead of relying on API response order
- apply the same semver sort in the public install.sh resolver

## Context
GitHub returned cua-driver-v0.0.9 before cua-driver-v0.0.10 from /releases?per_page=40, so an installed 0.0.8 reported 0.0.9 as the update even though 0.0.10 was published.

## Verification
- bash -n libs/cua-driver/scripts/install.sh
- resolver pipeline returns cua-driver-v0.0.10
- swift build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved version detection and comparison to reliably identify the latest available release using proper semantic versioning across the CUA driver installation and update processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->