### PR TITLE
ci(docs): skip Vercel preview builds when docs/ unchanged

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -4,5 +4,6 @@
       "path": "/docs/api/cron/prompt-digest",
       "schedule": "17 4 * * 2-6"
     }
-  ]
+  ],
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD ./"
 }


### PR DESCRIPTION
## Summary

Vercel currently builds a docs preview on every PR, even ones that don't touch `docs/` (e.g. #1378, which is a cua-driver-only fix). Add an `ignoreCommand` to `docs/vercel.json` so Vercel skips the build when nothing under the project root has changed.

## How it works

Vercel runs `ignoreCommand` from the configured project root (already `docs/`). The command exits 0 → skip build, exit 1 → continue.

```
git diff --quiet HEAD^ HEAD ./
```

`./` is relative to the Vercel project root, so the diff is naturally scoped to `docs/`. PRs that touch any file under `docs/` still get a preview; PRs that don't are skipped immediately.

## Test plan

- [ ] After merge, open a non-docs PR and confirm Vercel reports "Build skipped"
- [ ] Open a docs-only PR and confirm a preview deploys as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration to skip deployments when documentation remains unchanged, improving deployment efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->