### PR TITLE
fix: predict_click returns None for zero coordinates (x=0 or y=0)

### DIFF
--- a/libs/python/agent/cua_agent/loops/anthropic.py
+++ b/libs/python/agent/cua_agent/loops/anthropic.py
@@ -1947,7 +1947,7 @@ Task: Click {instruction}. Output ONLY a click action on the target element.""",
             ):
 
                 action = item["action"]
-                if action.get("x") and action.get("y"):
+                if action.get("x") is not None and action.get("y") is not None:
                     x = action.get("x")
                     y = action.get("y")
                     return (int(x), int(y))


### PR DESCRIPTION
## Summary

Fixes a bug in `AnthropicHostedToolsConfig.predict_click` where coordinates with a value of `0` were silently discarded due to a Python truthiness check.

## Problem

```python
# BEFORE (buggy): 0 is falsy, so clicks at left/top edge return None
if action.get("x") and action.get("y"):
```

When a model predicts a click at the leftmost column (`x=0`) or topmost row (`y=0`) of the screen, `0` evaluates as falsy in Python, causing the condition to fail and the method to return `None` instead of the valid `(0, y)` or `(x, 0)` coordinates.

## Fix

```python
# AFTER (correct): explicitly check for None
if action.get("x") is not None and action.get("y") is not None:
```

This correctly treats `0` as a valid coordinate value while still guarding against missing keys.

## Files Changed

- `libs/python/agent/cua_agent/loops/anthropic.py` — line 1950: replace truthiness check with `is not None`

Closes #1400

Signed-off-by: cocoon <54054995+kuishou68@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed coordinate validation to correctly accept click positions at the top-left corner (0,0), resolving issues where such interactions were being incorrectly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->