### PR TITLE
fix: preserve shell execution status across cuabot and computer-server

### DIFF
--- a/libs/cuabot/src/bashResult.test.ts
+++ b/libs/cuabot/src/bashResult.test.ts
@@ -1,6 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { bashResultFromExecError, buildContainerScript, exitCodeForBashResult } from './bashResult.js';
+import {
+  bashResultFromBackgroundLaunch,
+  bashResultFromExecError,
+  buildContainerScript,
+  buildDockerExecScriptCommand,
+  exitCodeForBashResult,
+} from './bashResult.js';
 
 test('buildContainerScript sets GUI user environment', () => {
   const script = buildContainerScript('firefox');
@@ -59,4 +65,39 @@ test('exitCodeForBashResult propagates failures to CLI exit status', () => {
   assert.equal(exitCodeForBashResult({ success: false, exit_code: 42 }), 42);
   assert.equal(exitCodeForBashResult({ success: false, exit_code: null, timed_out: true }), 124);
   assert.equal(exitCodeForBashResult({ success: false, exit_code: null }), 1);
+});
+
+test('bashResultFromBackgroundLaunch advertises pid only when process is still running', () => {
+  const result = bashResultFromBackgroundLaunch('123\nOUTCOME:RUNNING\n', '');
+
+  assert.equal(result.success, true);
+  assert.equal(result.exit_code, 0);
+  assert.equal(result.pid, 123);
+});
+
+test('bashResultFromBackgroundLaunch reports fast background exit without stale pid', () => {
+  const result = bashResultFromBackgroundLaunch('123\nOUTCOME:EXIT:7\n', 'failure log\n');
+
+  assert.equal(result.success, false);
+  assert.equal(result.exit_code, 7);
+  assert.equal(result.pid, undefined);
+  assert.equal(result.stderr, 'failure log\n');
+});
+
+test('buildDockerExecScriptCommand omits shell timeout for non-positive timeouts', () => {
+  assert.equal(
+    buildDockerExecScriptCommand('container', '/tmp/script.sh', 0),
+    'docker exec container /tmp/script.sh'
+  );
+  assert.equal(
+    buildDockerExecScriptCommand('container', '/tmp/script.sh', -1),
+    'docker exec container /tmp/script.sh'
+  );
+});
+
+test('buildDockerExecScriptCommand wraps positive timeouts with shell timeout', () => {
+  assert.equal(
+    buildDockerExecScriptCommand('container', '/tmp/script.sh', 1500),
+    'docker exec container timeout 1.5s /tmp/script.sh'
+  );
 });

--- a/libs/cuabot/src/bashResult.test.ts
+++ b/libs/cuabot/src/bashResult.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { bashResultFromExecError, buildContainerScript, exitCodeForBashResult } from './bashResult.js';
+
+test('buildContainerScript sets GUI user environment', () => {
+  const script = buildContainerScript('firefox');
+
+  assert.match(script, /export DISPLAY=:100/);
+  assert.match(script, /export USER=user/);
+  assert.match(script, /export LOGNAME=user/);
+  assert.match(script, /export HOME=\/home\/user/);
+  assert.match(script, /export XDG_RUNTIME_DIR=\/tmp\/runtime-user/);
+  assert.match(script, /export XAUTHORITY=\/home\/user\/\.Xauthority/);
+});
+
+test('bashResultFromExecError preserves exit code and failure status', () => {
+  const result = bashResultFromExecError({ code: 42, stdout: 'out', stderr: 'err' });
+
+  assert.equal(result.success, false);
+  assert.equal(result.exit_code, 42);
+  assert.equal(result.stdout, 'out');
+  assert.equal(result.stderr, 'err');
+});
+
+test('bashResultFromExecError does not use wrapper message as stderr for plain nonzero exits', () => {
+  const result = bashResultFromExecError({ code: 42, message: 'Command failed: ...' });
+
+  assert.equal(result.success, false);
+  assert.equal(result.exit_code, 42);
+  assert.equal(result.stderr, '');
+});
+
+test('bashResultFromExecError marks timeouts', () => {
+  const result = bashResultFromExecError({ killed: true, signal: 'SIGTERM', message: 'timed out' });
+
+  assert.equal(result.success, false);
+  assert.equal(result.timed_out, true);
+  assert.equal(result.signal, 'SIGTERM');
+});
+
+test('bashResultFromExecError treats timeout exit code as timeout', () => {
+  const result = bashResultFromExecError({ code: 124, stdout: 'partial' });
+
+  assert.equal(result.success, false);
+  assert.equal(result.exit_code, 124);
+  assert.equal(result.timed_out, true);
+});
+
+test('bashResultFromExecError does not treat timeout command name as timeout', () => {
+  const result = bashResultFromExecError({ code: 127, message: 'Command failed: timeout 10s nope' });
+
+  assert.equal(result.success, false);
+  assert.equal(result.exit_code, 127);
+  assert.equal(result.timed_out, undefined);
+});
+
+test('exitCodeForBashResult propagates failures to CLI exit status', () => {
+  assert.equal(exitCodeForBashResult({ success: true, exit_code: 0 }), 0);
+  assert.equal(exitCodeForBashResult({ success: false, exit_code: 42 }), 42);
+  assert.equal(exitCodeForBashResult({ success: false, exit_code: null, timed_out: true }), 124);
+  assert.equal(exitCodeForBashResult({ success: false, exit_code: null }), 1);
+});

--- a/libs/cuabot/src/bashResult.ts
+++ b/libs/cuabot/src/bashResult.ts
@@ -25,11 +25,65 @@ ${command}
 `;
 }
 
+export function buildDockerExecScriptCommand(
+  containerName: string,
+  scriptPath: string,
+  timeout: number
+): string {
+  if (timeout <= 0) return `docker exec ${containerName} ${scriptPath}`;
+  return `docker exec ${containerName} timeout ${timeout / 1000}s ${scriptPath}`;
+}
+
+export function bashResultFromBackgroundLaunch(stdout: string, stderr: string): BashResult {
+  const [pidLine, outcomeLine] = stdout.trimEnd().split('\n');
+  const pid = parseInt(pidLine || '', 10);
+
+  if (Number.isNaN(pid)) {
+    return {
+      stdout: '',
+      stderr: stderr || `Invalid background launch response: ${stdout}`,
+      exit_code: null,
+      success: false,
+    };
+  }
+
+  if (outcomeLine === 'OUTCOME:RUNNING') {
+    return {
+      stdout: `Background process started with PID ${pid}`,
+      stderr,
+      exit_code: 0,
+      success: true,
+      pid,
+    };
+  }
+
+  const exitMatch = /^OUTCOME:EXIT:(\d+)$/.exec(outcomeLine || '');
+  if (exitMatch) {
+    const exitCode = parseInt(exitMatch[1], 10);
+    return {
+      stdout: '',
+      stderr,
+      exit_code: exitCode,
+      success: exitCode === 0,
+    };
+  }
+
+  return {
+    stdout: '',
+    stderr: stderr || `Invalid background launch outcome: ${stdout}`,
+    exit_code: null,
+    success: false,
+  };
+}
+
 export function bashResultFromExecError(err: any): BashResult {
   const exitCode = typeof err?.code === 'number' ? err.code : null;
   const signal = typeof err?.signal === 'string' ? err.signal : undefined;
   const timedOut =
-    exitCode === 124 || err?.killed === true || /timed out|timeout expired/i.test(String(err?.message || ''));
+    exitCode === 124 ||
+    err?.killed === true ||
+    ((exitCode === null || exitCode === undefined) &&
+      /timed out|timeout expired/i.test(String(err?.message || '')));
 
   return {
     stdout: err?.stdout || '',

--- a/libs/cuabot/src/bashResult.ts
+++ b/libs/cuabot/src/bashResult.ts
@@ -1,0 +1,48 @@
+export interface BashResult {
+  stdout: string;
+  stderr: string;
+  exit_code: number | null;
+  success: boolean;
+  timed_out?: boolean;
+  signal?: string;
+  pid?: number;
+}
+
+export function buildContainerScript(command: string): string {
+  return `#!/bin/bash
+export DISPLAY=:100
+export USER=user
+export LOGNAME=user
+export HOME=/home/user
+export XDG_RUNTIME_DIR=/tmp/runtime-user
+mkdir -p "$XDG_RUNTIME_DIR"
+chown user:user "$XDG_RUNTIME_DIR" 2>/dev/null || true
+chmod 700 "$XDG_RUNTIME_DIR" 2>/dev/null || true
+if [ -f /home/user/.Xauthority ]; then
+  export XAUTHORITY=/home/user/.Xauthority
+fi
+${command}
+`;
+}
+
+export function bashResultFromExecError(err: any): BashResult {
+  const exitCode = typeof err?.code === 'number' ? err.code : null;
+  const signal = typeof err?.signal === 'string' ? err.signal : undefined;
+  const timedOut =
+    exitCode === 124 || err?.killed === true || /timed out|timeout expired/i.test(String(err?.message || ''));
+
+  return {
+    stdout: err?.stdout || '',
+    stderr: err?.stderr || (timedOut ? 'Command timed out' : ''),
+    exit_code: timedOut && exitCode === null ? null : exitCode,
+    success: false,
+    timed_out: timedOut || undefined,
+    signal,
+  };
+}
+
+export function exitCodeForBashResult(result: Pick<BashResult, 'success' | 'exit_code' | 'timed_out'>): number {
+  if (result.success) return 0;
+  if (typeof result.exit_code === 'number') return result.exit_code === 0 ? 1 : result.exit_code;
+  return result.timed_out ? 124 : 1;
+}

--- a/libs/cuabot/src/client.ts
+++ b/libs/cuabot/src/client.ts
@@ -9,6 +9,7 @@ import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath } from 'url';
 import { checkDependencies } from './utils.js';
+import type { BashResult } from './bashResult.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -107,7 +108,7 @@ export class CuaBotClient {
     command: string,
     run_in_background?: boolean,
     timeout?: number
-  ): Promise<{ stdout: string; stderr: string; pid?: number }> {
+  ): Promise<BashResult> {
     return this.request('bash', { command, run_in_background, timeout });
   }
 

--- a/libs/cuabot/src/cuabot.tsx
+++ b/libs/cuabot/src/cuabot.tsx
@@ -308,8 +308,8 @@ Commands:
         }
         const client = await getClient();
         const result = await client.bash(cmd);
-        if (result.stdout) console.log(result.stdout);
-        if (result.stderr) console.error(result.stderr);
+        if (result.stdout) process.stdout.write(result.stdout);
+        if (result.stderr) process.stderr.write(result.stderr);
         process.exit(exitCodeForBashResult(result));
       }
 

--- a/libs/cuabot/src/cuabot.tsx
+++ b/libs/cuabot/src/cuabot.tsx
@@ -20,6 +20,7 @@ import {
 import { runOnboarding } from './onboarding.js';
 import { sendTelemetryToServer } from './telemetry.js';
 import { checkDependencies } from './utils.js';
+import { exitCodeForBashResult } from './bashResult.js';
 import { execSync } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 import { homedir } from 'os';
@@ -306,10 +307,10 @@ Commands:
           process.exit(1);
         }
         const client = await getClient();
-        const { stdout, stderr } = await client.bash(cmd);
-        if (stdout) console.log(stdout);
-        if (stderr) console.error(stderr);
-        process.exit(0);
+        const result = await client.bash(cmd);
+        if (result.stdout) console.log(result.stdout);
+        if (result.stderr) console.error(result.stderr);
+        process.exit(exitCodeForBashResult(result));
       }
 
       case '--click': {

--- a/libs/cuabot/src/cuabotd.ts
+++ b/libs/cuabot/src/cuabotd.ts
@@ -26,7 +26,13 @@ import {
   TelemetryEvent,
 } from './telemetry.js';
 import { getXpraAttachArgs, getXpraBinPath, nameToColor } from './utils.js';
-import { BashResult, bashResultFromExecError, buildContainerScript } from './bashResult.js';
+import {
+  BashResult,
+  bashResultFromBackgroundLaunch,
+  bashResultFromExecError,
+  buildContainerScript,
+  buildDockerExecScriptCommand,
+} from './bashResult.js';
 
 const execAsync = promisify(exec);
 
@@ -321,28 +327,20 @@ async function execInContainer(
     if (runInBackground) {
       // Run in background with nohup, capture PID
       // Wait 1 second to catch any immediate errors (syntax errors, command not found, etc.)
-      const bgCmd = `docker exec ${getContainerName()} bash -c "nohup ${scriptPath} > /tmp/cuabot-bg-${scriptId}.log 2>&1 & pid=\\$!; echo \\$pid; sleep 1; if ! kill -0 \\$pid 2>/dev/null; then wait \\$pid; code=\\$?; cat /tmp/cuabot-bg-${scriptId}.log >&2; exit \\$code; fi"`;
+      const bgCmd = `docker exec ${getContainerName()} bash -c "nohup ${scriptPath} > /tmp/cuabot-bg-${scriptId}.log 2>&1 & pid=\\$!; echo \\$pid; sleep 1; if kill -0 \\$pid 2>/dev/null; then echo OUTCOME:RUNNING; else wait \\$pid; code=\\$?; echo OUTCOME:EXIT:\\$code; cat /tmp/cuabot-bg-${scriptId}.log >&2; fi"`;
 
       const { stdout, stderr } = await execAsync(bgCmd, { timeout: 10000 });
-      const pid = parseInt(stdout.trim().split('\n')[0], 10);
 
       // Clean up script after a delay (let it start first)
       setTimeout(async () => {
         await execAsync(`docker exec ${getContainerName()} rm -f ${scriptPath}`).catch(() => {});
       }, 5000);
 
-      return {
-        stdout: `Background process started with PID ${pid}`,
-        stderr,
-        exit_code: 0,
-        success: true,
-        pid,
-      };
+      return bashResultFromBackgroundLaunch(stdout, stderr);
     } else {
       // Run synchronously
-      const timeoutSeconds = Math.max(timeout / 1000, 0.001);
       const { stdout, stderr } = await execAsync(
-        `docker exec ${getContainerName()} timeout ${timeoutSeconds}s ${scriptPath}`,
+        buildDockerExecScriptCommand(getContainerName(), scriptPath, timeout),
         { timeout: timeout + 5000 }
       );
 

--- a/libs/cuabot/src/cuabotd.ts
+++ b/libs/cuabot/src/cuabotd.ts
@@ -26,6 +26,7 @@ import {
   TelemetryEvent,
 } from './telemetry.js';
 import { getXpraAttachArgs, getXpraBinPath, nameToColor } from './utils.js';
+import { BashResult, bashResultFromExecError, buildContainerScript } from './bashResult.js';
 
 const execAsync = promisify(exec);
 
@@ -301,18 +302,14 @@ async function ensureContainer(): Promise<number> {
 async function execInContainer(
   command: string,
   options: { timeout?: number; runInBackground?: boolean } = {}
-): Promise<{ stdout: string; stderr: string; pid?: number }> {
+): Promise<BashResult> {
   const { timeout = 60000, runInBackground = false } = options;
 
   // Write command to a temp script file inside the container to avoid shell escaping issues
   const scriptId = Date.now() + Math.random().toString(36).slice(2);
   const scriptPath = `/tmp/cuabot-cmd-${scriptId}.sh`;
 
-  // Create the script content with proper shebang and DISPLAY
-  const scriptContent = `#!/bin/bash
-export DISPLAY=:100
-${command}
-`;
+  const scriptContent = buildContainerScript(command);
 
   // Write script to container using docker exec with base64 to avoid any escaping issues
   const base64Script = Buffer.from(scriptContent).toString('base64');
@@ -324,7 +321,7 @@ ${command}
     if (runInBackground) {
       // Run in background with nohup, capture PID
       // Wait 1 second to catch any immediate errors (syntax errors, command not found, etc.)
-      const bgCmd = `docker exec ${getContainerName()} bash -c "nohup ${scriptPath} > /tmp/cuabot-bg-${scriptId}.log 2>&1 & echo \\$!; sleep 1; if ! kill -0 \\$! 2>/dev/null; then cat /tmp/cuabot-bg-${scriptId}.log; exit 1; fi"`;
+      const bgCmd = `docker exec ${getContainerName()} bash -c "nohup ${scriptPath} > /tmp/cuabot-bg-${scriptId}.log 2>&1 & pid=\\$!; echo \\$pid; sleep 1; if ! kill -0 \\$pid 2>/dev/null; then wait \\$pid; code=\\$?; cat /tmp/cuabot-bg-${scriptId}.log >&2; exit \\$code; fi"`;
 
       const { stdout, stderr } = await execAsync(bgCmd, { timeout: 10000 });
       const pid = parseInt(stdout.trim().split('\n')[0], 10);
@@ -334,23 +331,30 @@ ${command}
         await execAsync(`docker exec ${getContainerName()} rm -f ${scriptPath}`).catch(() => {});
       }, 5000);
 
-      return { stdout: `Background process started with PID ${pid}`, stderr, pid };
+      return {
+        stdout: `Background process started with PID ${pid}`,
+        stderr,
+        exit_code: 0,
+        success: true,
+        pid,
+      };
     } else {
       // Run synchronously
+      const timeoutSeconds = Math.max(timeout / 1000, 0.001);
       const { stdout, stderr } = await execAsync(
-        `docker exec ${getContainerName()} ${scriptPath}`,
-        { timeout }
+        `docker exec ${getContainerName()} timeout ${timeoutSeconds}s ${scriptPath}`,
+        { timeout: timeout + 5000 }
       );
 
       // Clean up script
       await execAsync(`docker exec ${getContainerName()} rm -f ${scriptPath}`).catch(() => {});
 
-      return { stdout, stderr };
+      return { stdout, stderr, exit_code: 0, success: true };
     }
   } catch (err: any) {
     // Clean up script on error
     await execAsync(`docker exec ${getContainerName()} rm -f ${scriptPath}`).catch(() => {});
-    return { stdout: err.stdout || '', stderr: err.stderr || err.message };
+    return bashResultFromExecError(err);
   }
 }
 
@@ -762,11 +766,11 @@ const handlers: Record<string, Handler> = {
   async bash(body: { command: string; run_in_background?: boolean; timeout?: number }) {
     requireReady();
     await ensureContainer();
-    const { stdout, stderr, pid } = await execInContainer(body.command, {
+    const result = await execInContainer(body.command, {
       runInBackground: body.run_in_background,
       timeout: body.timeout,
     });
-    return { stdout, stderr, pid };
+    return result;
   },
 
   async screenshot() {

--- a/libs/python/computer-server/computer_server/handlers/base.py
+++ b/libs/python/computer-server/computer_server/handlers/base.py
@@ -203,7 +203,7 @@ def normalize_screenshot_format(format: str, quality: int) -> tuple[str, int]:
     fmt = _FORMAT_ALIASES.get(format.lower(), format.lower())
     if fmt not in _SUPPORTED_FORMATS:
         raise ValueError(
-            f"Unsupported screenshot format {format!r}. " f"Supported: {sorted(_SUPPORTED_FORMATS)}"
+            f"Unsupported screenshot format {format!r}. Supported: {sorted(_SUPPORTED_FORMATS)}"
         )
     if fmt == "jpeg":
         quality = max(1, min(95, quality))
@@ -422,7 +422,7 @@ class BaseAutomationHandler(ABC):
                     "return_code": -1,
                 }
             return {
-                "success": True,
+                "success": process.returncode == 0,
                 "stdout": stdout.decode() if stdout else "",
                 "stderr": stderr.decode() if stderr else "",
                 "return_code": process.returncode,

--- a/libs/python/computer-server/tests/test_server.py
+++ b/libs/python/computer-server/tests/test_server.py
@@ -46,67 +46,11 @@ class TestRunCommand:
         from computer_server.handlers.base import BaseAutomationHandler
 
         class Handler(BaseAutomationHandler):
-            async def mouse_down(self, x=None, y=None, button="left"):
-                pass
+            pass
 
-            async def mouse_up(self, x=None, y=None, button="left"):
-                pass
+        Handler.__abstractmethods__ = frozenset()
 
-            async def left_click(self, x=None, y=None):
-                pass
-
-            async def right_click(self, x=None, y=None):
-                pass
-
-            async def middle_click(self, x=None, y=None):
-                pass
-
-            async def double_click(self, x=None, y=None):
-                pass
-
-            async def move_cursor(self, x, y):
-                pass
-
-            async def drag_to(self, x, y, button="left", duration=0.5):
-                pass
-
-            async def drag(self, path, button="left", duration=0.5):
-                pass
-
-            async def key_down(self, key):
-                pass
-
-            async def key_up(self, key):
-                pass
-
-            async def type_text(self, text):
-                pass
-
-            async def press_key(self, key):
-                pass
-
-            async def hotkey(self, keys):
-                pass
-
-            async def scroll(self, x, y):
-                pass
-
-            async def scroll_down(self, clicks=1):
-                pass
-
-            async def scroll_up(self, clicks=1):
-                pass
-
-            async def screenshot(self, format="png", quality=95):
-                pass
-
-            async def get_screen_size(self):
-                pass
-
-            async def get_cursor_position(self):
-                pass
-
-        result = await Handler().run_command("command -v definitely-not-installed")
+        result = await Handler().run_command("false")
 
         assert result["success"] is False
         assert result["return_code"] != 0

--- a/libs/python/computer-server/tests/test_server.py
+++ b/libs/python/computer-server/tests/test_server.py
@@ -38,3 +38,75 @@ class TestServerInitialization:
         except Exception as e:
             # Some initialization errors are acceptable in unit tests
             pytest.skip(f"Server initialization requires specific setup: {e}")
+
+
+class TestRunCommand:
+    @pytest.mark.asyncio
+    async def test_run_command_marks_nonzero_returncode_as_failure(self):
+        from computer_server.handlers.base import BaseAutomationHandler
+
+        class Handler(BaseAutomationHandler):
+            async def mouse_down(self, x=None, y=None, button="left"):
+                pass
+
+            async def mouse_up(self, x=None, y=None, button="left"):
+                pass
+
+            async def left_click(self, x=None, y=None):
+                pass
+
+            async def right_click(self, x=None, y=None):
+                pass
+
+            async def middle_click(self, x=None, y=None):
+                pass
+
+            async def double_click(self, x=None, y=None):
+                pass
+
+            async def move_cursor(self, x, y):
+                pass
+
+            async def drag_to(self, x, y, button="left", duration=0.5):
+                pass
+
+            async def drag(self, path, button="left", duration=0.5):
+                pass
+
+            async def key_down(self, key):
+                pass
+
+            async def key_up(self, key):
+                pass
+
+            async def type_text(self, text):
+                pass
+
+            async def press_key(self, key):
+                pass
+
+            async def hotkey(self, keys):
+                pass
+
+            async def scroll(self, x, y):
+                pass
+
+            async def scroll_down(self, clicks=1):
+                pass
+
+            async def scroll_up(self, clicks=1):
+                pass
+
+            async def screenshot(self, format="png", quality=95):
+                pass
+
+            async def get_screen_size(self):
+                pass
+
+            async def get_cursor_position(self):
+                pass
+
+        result = await Handler().run_command("command -v definitely-not-installed")
+
+        assert result["success"] is False
+        assert result["return_code"] != 0


### PR DESCRIPTION
## Summary

This is a shell execution correctness fix, not just a cuabot UX change. Today a command can fail or time out while outer tooling still treats the invocation as success or loses the real exit status.

- Preserve structured shell execution status across `cuabotd`, the client, and the CLI with `exit_code`, `success`, `timed_out`, `signal`, and `pid`.
- Propagate non-zero exits and timeouts from `cuabot --bash` back to the local CLI exit status.
- Align `computer-server` `run_command()` semantics so `success` reflects `return_code == 0`, and set a fuller GUI shell environment for container commands.

Fixes #1403.

## Verification

- `pnpm exec node --import tsx --test src/bashResult.test.ts`
- `pnpm run build`
- `uv run pytest libs/python/computer-server/tests/test_server.py -q`
- `uv run ruff check libs/python/computer-server/computer_server/handlers/base.py libs/python/computer-server/tests/test_server.py`
- `cuabot --bash "exit 42"` exits with `42`
- missing command returns `exit_code: 127`, `success: false`
- timeout returns `exit_code: 124`, `success: false`, `timed_out: true`
- shell env includes `DISPLAY`, `USER`, `LOGNAME`, `HOME`, `XDG_RUNTIME_DIR`, `XAUTHORITY`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bash command execution with proper exit code propagation to the CLI
  * Enhanced timeout detection and signal handling for container-based commands
  * Better error reporting for failed command execution scenarios

* **Tests**
  * Added comprehensive test coverage for bash execution results and utilities
  * Added test coverage for command failure handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->