### PR TITLE
docs(cua-driver): add integrations page and GitHub Copilot CLI MCP config

### DIFF
--- a/docs/content/docs/cua-driver/guide/getting-started/integrations.mdx
+++ b/docs/content/docs/cua-driver/guide/getting-started/integrations.mdx
@@ -1,0 +1,128 @@
+---
+title: Integrations
+description: Connect cua-driver to your AI coding agent
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+`cua-driver mcp` is a stdio MCP server. Any agent that supports MCP can use it — no extra setup beyond adding it to the agent's MCP config.
+
+<Callout type="warn">
+  Grant Accessibility and Screen Recording permissions to cua-driver before connecting any agent.
+  Run `cua-driver check_permissions` to verify.
+</Callout>
+
+## Claude Code
+
+```bash
+claude mcp add --transport stdio cua-driver -- cua-driver mcp
+```
+
+Verify:
+
+```bash
+claude mcp list
+# cua-driver: cua-driver mcp (stdio) - ✓ Connected
+```
+
+## GitHub Copilot CLI
+
+Add to `~/.copilot/mcp-config.json`:
+
+```json
+{
+  "mcpServers": {
+    "cua-driver": {
+      "type": "local",
+      "command": "cua-driver",
+      "args": ["mcp"],
+      "tools": ["*"]
+    }
+  }
+}
+```
+
+Or interactively inside `gh copilot` chat:
+
+```
+/mcp add
+```
+
+Fill in: name=`cua-driver`, type=STDIO, command=`cua-driver`, args=`mcp`. Press **Ctrl+S** to save.
+
+## Codex (OpenAI)
+
+```bash
+codex mcp add cua-driver -- cua-driver mcp
+```
+
+## Cursor
+
+Generate the config snippet and paste it into `~/.cursor/mcp.json`:
+
+```bash
+cua-driver mcp-config --client cursor
+```
+
+## Gemini CLI
+
+Add to `~/.gemini/settings.json`:
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "cua-driver": {
+        "type": "stdio",
+        "command": "cua-driver",
+        "args": ["mcp"]
+      }
+    }
+  }
+}
+```
+
+Tools appear prefixed as `mcp_cua-driver_*`.
+
+## OpenCode
+
+```bash
+cua-driver mcp-config --client opencode
+```
+
+Paste the output into your `opencode.json`.
+
+## Hermes (NousResearch)
+
+```bash
+cua-driver mcp-config --client hermes
+```
+
+Paste the output into `~/.hermes/config.yaml`.
+
+## OpenClaw
+
+```bash
+cua-driver mcp-config --client openclaw
+```
+
+## Other clients
+
+For any client that accepts the standard `mcpServers` shape:
+
+```bash
+cua-driver mcp-config
+```
+
+Output:
+
+```json
+{
+  "mcpServers": {
+    "cua-driver": {
+      "command": "cua-driver",
+      "args": ["mcp"]
+    }
+  }
+}
+```

--- a/docs/content/docs/cua-driver/guide/getting-started/meta.json
+++ b/docs/content/docs/cua-driver/guide/getting-started/meta.json
@@ -3,5 +3,5 @@
   "description": "Get up and running with Cua Driver",
   "icon": "Rocket",
   "defaultOpen": true,
-  "pages": ["introduction", "installation", "quickstart", "swift-integration", "comparison", "faq"]
+  "pages": ["introduction", "installation", "quickstart", "integrations", "swift-integration", "comparison", "faq"]
 }

--- a/libs/cua-driver/scripts/install.sh
+++ b/libs/cua-driver/scripts/install.sh
@@ -306,6 +306,19 @@ Next steps:
         • OpenClaw:
             cua-driver mcp-config --client openclaw
 
+        • GitHub Copilot CLI (paste into ~/.copilot/mcp-config.json):
+            {
+              "mcpServers": {
+                "cua-driver": {
+                  "type": "local",
+                  "command": "$BIN_LINK",
+                  "args": ["mcp"],
+                  "tools": ["*"]
+                }
+              }
+            }
+            Or inside gh copilot chat: /mcp add → type=STDIO, command=$BIN_LINK, args=mcp
+
         • Cursor / OpenCode / Hermes (no add CLI — paste config):
             cua-driver mcp-config --client cursor     # JSON for ~/.cursor/mcp.json
             cua-driver mcp-config --client opencode   # JSON for opencode.json


### PR DESCRIPTION
## What this does

Adds a new **Integrations** page to the cua-driver getting-started docs covering every supported agent client, and adds GitHub Copilot CLI to the post-install instructions in `install.sh`.

### Changes

- **`docs/content/docs/cua-driver/guide/getting-started/integrations.mdx`** — new page with exact commands or config snippets for: Claude Code, GitHub Copilot CLI, Codex, Cursor, Gemini CLI, OpenCode, Hermes, OpenClaw, and a generic fallback
- **`docs/content/docs/cua-driver/guide/getting-started/meta.json`** — adds `integrations` to the getting-started nav
- **`libs/cua-driver/scripts/install.sh`** — adds GitHub Copilot CLI `mcp-config.json` snippet to the post-install MCP client instructions

### GitHub Copilot CLI config

```json
{
  "mcpServers": {
    "cua-driver": {
      "type": "local",
      "command": "cua-driver",
      "args": ["mcp"],
      "tools": ["*"]
    }
  }
}
```

Paste into `~/.copilot/mcp-config.json`, or use `/mcp add` interactively inside `gh copilot` chat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive integrations guide documenting how to connect `cua-driver` to multiple AI coding clients (Claude Code, GitHub Copilot CLI, Codex, Cursor, Gemini CLI, OpenCode, Hermes, and OpenClaw).
  * Updated installer to include GitHub Copilot CLI MCP configuration instructions for streamlined setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->