### PR TITLE
Add window lease validation metadata

### DIFF
--- a/libs/cua-driver/Package.resolved
+++ b/libs/cua-driver/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "5967ac3dc4b99f934ac42d2c3bd6f52f187f92607c34cce5b2be0ebdcffe11be",
+  "originHash" : "9cdd02e61c57708ebf6630e9383a13727ce9457f4b0b8c03f05daa5dbde0b58e",
   "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
+      }
+    },
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,15 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
       }
     },
     {
@@ -20,6 +38,24 @@
       }
     },
     {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
+        "version" : "1.1.3"
+      }
+    },
+    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
@@ -29,12 +65,57 @@
       }
     },
     {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "5aa1c0d1bc204908df47c2075bdbb39573d05e8d",
+        "version" : "1.19.0"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
       }
     },
     {
@@ -56,12 +137,75 @@
       }
     },
     {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "5a48717e29f62cb8326d6d42e46b562ca93847a6",
+        "version" : "1.34.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "81cc18264f92cd307ff98430f89372711d4f6fe9",
+        "version" : "1.43.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
         "revision" : "6132fd4b5b4217ce4717c4775e4607f5c3120129",
         "version" : "0.12.0"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
       }
     },
     {

--- a/libs/cua-driver/Sources/CuaDriverCore/Windows/WindowIdentityStore.swift
+++ b/libs/cua-driver/Sources/CuaDriverCore/Windows/WindowIdentityStore.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+public struct WindowIdentityMetadata: Sendable, Codable, Hashable {
+    public let windowUID: String
+    public let generation: Int
+    public let firstSeen: String
+    public let lastSeen: String
+
+    public init(
+        windowUID: String,
+        generation: Int,
+        firstSeen: String,
+        lastSeen: String
+    ) {
+        self.windowUID = windowUID
+        self.generation = generation
+        self.firstSeen = firstSeen
+        self.lastSeen = lastSeen
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case windowUID = "window_uid"
+        case generation
+        case firstSeen = "first_seen"
+        case lastSeen = "last_seen"
+    }
+}
+
+public actor WindowIdentityStore {
+    public static let shared = WindowIdentityStore()
+
+    private struct Record {
+        let fingerprint: String
+        let generation: Int
+        let firstSeen: String
+        var lastSeen: String
+
+        var uid: String {
+            "cgwindow:\(Self.windowId(from: fingerprint)):pid:\(Self.pid(from: fingerprint)):gen:\(generation)"
+        }
+
+        private static func windowId(from fingerprint: String) -> String {
+            fingerprint.split(separator: "|").first.map(String.init) ?? "unknown"
+        }
+
+        private static func pid(from fingerprint: String) -> String {
+            let parts = fingerprint.split(separator: "|")
+            guard parts.count > 1 else { return "unknown" }
+            return String(parts[1])
+        }
+    }
+
+    private var records: [Int: Record] = [:]
+
+    public init() {}
+
+    public func metadata(for windows: [WindowInfo]) -> [Int: WindowIdentityMetadata] {
+        let now = Self.timestamp()
+        var out: [Int: WindowIdentityMetadata] = [:]
+        for window in windows {
+            out[window.id] = metadata(for: window, observedAt: now)
+        }
+        return out
+    }
+
+    public func metadata(for window: WindowInfo) -> WindowIdentityMetadata {
+        metadata(for: window, observedAt: Self.timestamp())
+    }
+
+    private func metadata(
+        for window: WindowInfo,
+        observedAt now: String
+    ) -> WindowIdentityMetadata {
+        let fingerprint = Self.fingerprint(for: window)
+        let record: Record
+        if var existing = records[window.id],
+           existing.fingerprint == fingerprint
+        {
+            existing.lastSeen = now
+            record = existing
+        } else {
+            let nextGeneration = (records[window.id]?.generation ?? 0) + 1
+            record = Record(
+                fingerprint: fingerprint,
+                generation: nextGeneration,
+                firstSeen: now,
+                lastSeen: now
+            )
+        }
+        records[window.id] = record
+        return WindowIdentityMetadata(
+            windowUID: record.uid,
+            generation: record.generation,
+            firstSeen: record.firstSeen,
+            lastSeen: record.lastSeen
+        )
+    }
+
+    private static func fingerprint(for window: WindowInfo) -> String {
+        // Deliberately excludes title and bounds. Titles and bounds change
+        // during normal work; a uid should remain stable for the OS window.
+        "\(window.id)|\(window.pid)|\(window.owner)|\(window.layer)"
+    }
+
+    private static func timestamp() -> String {
+        ISO8601DateFormatter().string(from: Date())
+    }
+}

--- a/libs/cua-driver/Sources/CuaDriverServer/ToolRegistry.swift
+++ b/libs/cua-driver/Sources/CuaDriverServer/ToolRegistry.swift
@@ -215,6 +215,7 @@ public struct ToolRegistry: Sendable {
     public static let `default` = ToolRegistry(handlers: [
         ListAppsTool.handler,
         ListWindowsTool.handler,
+        ValidateWindowTool.handler,
         LaunchAppTool.handler,
         GetScreenSizeTool.handler,
         CheckPermissionsTool.handler,

--- a/libs/cua-driver/Sources/CuaDriverServer/Tools/LaunchAppTool.swift
+++ b/libs/cua-driver/Sources/CuaDriverServer/Tools/LaunchAppTool.swift
@@ -72,14 +72,15 @@ public enum LaunchAppTool {
 
                 Returns the launched app's pid, bundle_id, name, active
                 flag, AND a `windows` array — same per-window shape as
-                `list_windows` returns (window_id, title, bounds,
-                z_index, is_on_screen, on_current_space, space_ids).
-                That lets callers skip an extra `list_windows` round-trip
-                before `get_window_state(pid, window_id)` in the common
-                case. When the launch settles but no window has
-                materialized yet (transient; rare), `windows` comes back
-                empty — call `list_windows(pid)` explicitly a moment
-                later to resolve a target.
+                `list_windows` returns (window_id, window_uid, generation,
+                title, bounds, display_id, z_index, is_on_screen,
+                on_current_space, space_ids). That lets callers skip an
+                extra `list_windows` round-trip before
+                `get_window_state(pid, window_id)` in the common case.
+                When the launch settles but no window has materialized
+                yet (transient; rare), `windows` comes back empty — call
+                `list_windows(pid)` explicitly a moment later to resolve
+                a target.
                 """,
             inputSchema: [
                 "type": "object",
@@ -374,6 +375,7 @@ public enum LaunchAppTool {
                 .filter { $0.pid == pid && $0.layer == 0 }
                 .filter { $0.bounds.width > 1 && $0.bounds.height > 1 }
             if !found.isEmpty {
+                let identities = await WindowIdentityStore.shared.metadata(for: found)
                 return found.map { info -> WindowRow in
                     let spaceIDs = SpaceMigrator.spaceIDs(
                         forWindowID: UInt32(info.id))
@@ -381,10 +383,16 @@ public enum LaunchAppTool {
                         guard let spaceIDs, let currentSpaceID else { return nil }
                         return spaceIDs.contains(currentSpaceID)
                     }()
+                    let identity = identities[info.id]
                     return WindowRow(
                         windowId: info.id,
+                        windowUID: identity?.windowUID,
+                        generation: identity?.generation,
+                        firstSeen: identity?.firstSeen,
+                        lastSeen: identity?.lastSeen,
                         title: info.name,
                         bounds: info.bounds,
+                        displayId: displayID(for: info.bounds),
                         layer: info.layer,
                         zIndex: info.zIndex,
                         isOnScreen: info.isOnScreen,
@@ -398,6 +406,21 @@ public enum LaunchAppTool {
             try? await Task.sleep(nanoseconds: 100_000_000)
         }
         return []
+    }
+
+    private static func displayID(for bounds: WindowBounds) -> UInt32? {
+        let rect = CGRect(
+            x: bounds.x,
+            y: bounds.y,
+            width: max(bounds.width, 1),
+            height: max(bounds.height, 1)
+        )
+        var count: UInt32 = 0
+        CGGetDisplaysWithRect(rect, 0, nil, &count)
+        guard count > 0 else { return nil }
+        var displays = Array(repeating: CGDirectDisplayID(0), count: Int(count))
+        CGGetDisplaysWithRect(rect, count, &displays, &count)
+        return displays.first
     }
 
     /// Extends `AppInfo` with a `windows` array for `launch_app`'s
@@ -449,8 +472,13 @@ public enum LaunchAppTool {
     /// two sources interchangeably.
     private struct WindowRow: Codable, Sendable {
         let windowId: Int
+        let windowUID: String?
+        let generation: Int?
+        let firstSeen: String?
+        let lastSeen: String?
         let title: String
         let bounds: WindowBounds
+        let displayId: UInt32?
         let layer: Int
         let zIndex: Int
         let isOnScreen: Bool
@@ -459,8 +487,13 @@ public enum LaunchAppTool {
 
         private enum CodingKeys: String, CodingKey {
             case windowId = "window_id"
+            case windowUID = "window_uid"
+            case generation
+            case firstSeen = "first_seen"
+            case lastSeen = "last_seen"
             case title
             case bounds
+            case displayId = "display_id"
             case layer
             case zIndex = "z_index"
             case isOnScreen = "is_on_screen"
@@ -471,8 +504,13 @@ public enum LaunchAppTool {
         func encode(to encoder: Encoder) throws {
             var c = encoder.container(keyedBy: CodingKeys.self)
             try c.encode(windowId, forKey: .windowId)
+            try c.encodeIfPresent(windowUID, forKey: .windowUID)
+            try c.encodeIfPresent(generation, forKey: .generation)
+            try c.encodeIfPresent(firstSeen, forKey: .firstSeen)
+            try c.encodeIfPresent(lastSeen, forKey: .lastSeen)
             try c.encode(title, forKey: .title)
             try c.encode(bounds, forKey: .bounds)
+            try c.encodeIfPresent(displayId, forKey: .displayId)
             try c.encode(layer, forKey: .layer)
             try c.encode(zIndex, forKey: .zIndex)
             try c.encode(isOnScreen, forKey: .isOnScreen)

--- a/libs/cua-driver/Sources/CuaDriverServer/Tools/ListWindowsTool.swift
+++ b/libs/cua-driver/Sources/CuaDriverServer/Tools/ListWindowsTool.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CoreGraphics
 import CuaDriverCore
 import Foundation
@@ -24,11 +25,20 @@ public enum ListWindowsTool {
 
                 - window_id: CGWindowID, addressable for screenshot /
                   activation / Space-move APIs.
+                - window_uid: daemon-stable identity for this OS window
+                  observation. Stable across list order changes and title /
+                  bounds changes while the CGWindowID remains owned by the
+                  same pid.
+                - generation / first_seen / last_seen: lifecycle metadata
+                  for callers maintaining a task-level window lease.
                 - pid + app_name: owning app identity.
+                - bundle_id: owning app bundle identifier when available.
                 - title: current window title (empty string for helpers
                   and chromeless surfaces).
                 - bounds: x / y / width / height, top-left origin in
                   global screen points.
+                - display_id: CoreGraphics display containing the largest
+                  part of the window, when available.
                 - layer: CGWindow stratum. Always 0 in the default
                   filter; reserved for future higher-layer opt-in.
                 - z_index: stacking order on the current Space (higher =
@@ -105,23 +115,12 @@ public enum ListWindowsTool {
                 }
 
             let currentSpaceID = SpaceMigrator.currentSpaceID()
+            let identities = await WindowIdentityStore.shared.metadata(for: windows)
             let records = windows.map { info -> Row in
-                let spaceIDs = SpaceMigrator.spaceIDs(forWindowID: UInt32(info.id))
-                let onCurrentSpace: Bool? = {
-                    guard let spaceIDs, let currentSpaceID else { return nil }
-                    return spaceIDs.contains(currentSpaceID)
-                }()
-                return Row(
-                    windowId: info.id,
-                    pid: info.pid,
-                    appName: info.owner,
-                    title: info.name,
-                    bounds: info.bounds,
-                    layer: info.layer,
-                    zIndex: info.zIndex,
-                    isOnScreen: info.isOnScreen,
-                    onCurrentSpace: onCurrentSpace,
-                    spaceIds: spaceIDs
+                row(
+                    for: info,
+                    currentSpaceID: currentSpaceID,
+                    identity: identities[info.id]
                 )
             }
 
@@ -143,10 +142,16 @@ public enum ListWindowsTool {
 
     struct Row: Codable, Sendable {
         let windowId: Int
+        let windowUID: String?
+        let generation: Int?
+        let firstSeen: String?
+        let lastSeen: String?
         let pid: Int32
         let appName: String
+        let bundleId: String?
         let title: String
         let bounds: WindowBounds
+        let displayId: UInt32?
         let layer: Int
         let zIndex: Int
         let isOnScreen: Bool
@@ -155,10 +160,16 @@ public enum ListWindowsTool {
 
         private enum CodingKeys: String, CodingKey {
             case windowId = "window_id"
+            case windowUID = "window_uid"
+            case generation
+            case firstSeen = "first_seen"
+            case lastSeen = "last_seen"
             case pid
             case appName = "app_name"
+            case bundleId = "bundle_id"
             case title
             case bounds
+            case displayId = "display_id"
             case layer
             case zIndex = "z_index"
             case isOnScreen = "is_on_screen"
@@ -169,10 +180,16 @@ public enum ListWindowsTool {
         func encode(to encoder: Encoder) throws {
             var c = encoder.container(keyedBy: CodingKeys.self)
             try c.encode(windowId, forKey: .windowId)
+            try c.encodeIfPresent(windowUID, forKey: .windowUID)
+            try c.encodeIfPresent(generation, forKey: .generation)
+            try c.encodeIfPresent(firstSeen, forKey: .firstSeen)
+            try c.encodeIfPresent(lastSeen, forKey: .lastSeen)
             try c.encode(pid, forKey: .pid)
             try c.encode(appName, forKey: .appName)
+            try c.encodeIfPresent(bundleId, forKey: .bundleId)
             try c.encode(title, forKey: .title)
             try c.encode(bounds, forKey: .bounds)
+            try c.encodeIfPresent(displayId, forKey: .displayId)
             try c.encode(layer, forKey: .layer)
             try c.encode(zIndex, forKey: .zIndex)
             try c.encode(isOnScreen, forKey: .isOnScreen)
@@ -199,6 +216,55 @@ public enum ListWindowsTool {
             content: [.text(text: message, annotations: nil, _meta: nil)],
             isError: true
         )
+    }
+
+    static func row(
+        for info: WindowInfo,
+        currentSpaceID: UInt64?,
+        identity: WindowIdentityMetadata?
+    ) -> Row {
+        let spaceIDs = SpaceMigrator.spaceIDs(forWindowID: UInt32(info.id))
+        let onCurrentSpace: Bool? = {
+            guard let spaceIDs, let currentSpaceID else { return nil }
+            return spaceIDs.contains(currentSpaceID)
+        }()
+        return Row(
+            windowId: info.id,
+            windowUID: identity?.windowUID,
+            generation: identity?.generation,
+            firstSeen: identity?.firstSeen,
+            lastSeen: identity?.lastSeen,
+            pid: info.pid,
+            appName: info.owner,
+            bundleId: bundleIdentifier(for: info.pid),
+            title: info.name,
+            bounds: info.bounds,
+            displayId: displayID(for: info.bounds),
+            layer: info.layer,
+            zIndex: info.zIndex,
+            isOnScreen: info.isOnScreen,
+            onCurrentSpace: onCurrentSpace,
+            spaceIds: spaceIDs
+        )
+    }
+
+    private static func bundleIdentifier(for pid: Int32) -> String? {
+        NSRunningApplication(processIdentifier: pid)?.bundleIdentifier
+    }
+
+    private static func displayID(for bounds: WindowBounds) -> UInt32? {
+        let rect = CGRect(
+            x: bounds.x,
+            y: bounds.y,
+            width: max(bounds.width, 1),
+            height: max(bounds.height, 1)
+        )
+        var count: UInt32 = 0
+        CGGetDisplaysWithRect(rect, 0, nil, &count)
+        guard count > 0 else { return nil }
+        var displays = Array(repeating: CGDirectDisplayID(0), count: Int(count))
+        CGGetDisplaysWithRect(rect, count, &displays, &count)
+        return displays.first
     }
 
     private static func summary(

--- a/libs/cua-driver/Sources/CuaDriverServer/Tools/ValidateWindowTool.swift
+++ b/libs/cua-driver/Sources/CuaDriverServer/Tools/ValidateWindowTool.swift
@@ -1,0 +1,229 @@
+import CuaDriverCore
+import Foundation
+import MCP
+
+public enum ValidateWindowTool {
+    public static let handler = ToolHandler(
+        tool: Tool(
+            name: "validate_window",
+            description: """
+                Validate a task-level window lease before acting.
+
+                Use this when a caller has pinned work to a specific
+                pid/window_id or window_uid and needs to know whether that
+                target still exists, still belongs to the same process, or
+                should be treated as lost. The tool never switches windows
+                implicitly. It returns explicit status plus same-pid windows
+                and possible replacement candidates so the caller can decide
+                whether it has enough evidence to reacquire.
+
+                Status values:
+
+                - present: requested window exists and belongs to pid.
+                - missing: requested window_id/window_uid is not present.
+                - pid_mismatch: window_id exists but belongs to another pid.
+
+                Replacement candidates are conservative: exact title matches
+                when `expected_title` is supplied; otherwise the only same-pid
+                window when there is exactly one.
+                """,
+            inputSchema: [
+                "type": "object",
+                "required": ["pid"],
+                "properties": [
+                    "pid": [
+                        "type": "integer",
+                        "description": "Expected owning process id.",
+                    ],
+                    "window_id": [
+                        "type": "integer",
+                        "description": "CGWindowID from list_windows / launch_app.",
+                    ],
+                    "window_uid": [
+                        "type": "string",
+                        "description": "Stable uid from list_windows. Used when window_id is absent.",
+                    ],
+                    "expected_title": [
+                        "type": "string",
+                        "description": "Optional title used to identify possible replacements when the window is missing.",
+                    ],
+                ],
+                "additionalProperties": false,
+            ],
+            annotations: .init(
+                readOnlyHint: true,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false
+            )
+        ),
+        invoke: { arguments in
+            guard let rawPid = arguments?["pid"]?.intValue,
+                  let pid = Int32(exactly: rawPid)
+            else {
+                return errorResult("Missing or invalid required integer field pid.")
+            }
+
+            let rawWindowId = arguments?["window_id"]?.intValue
+            let uid = arguments?["window_uid"]?.stringValue
+            let expectedTitle = arguments?["expected_title"]?.stringValue
+            let windowId = rawWindowId ?? parseWindowId(fromUID: uid)
+            guard let windowId else {
+                return errorResult("validate_window requires window_id or window_uid.")
+            }
+
+            let allInfos = WindowEnumerator.allWindows().filter { $0.layer == 0 }
+            let samePidInfos = allInfos.filter { $0.pid == pid }
+            let currentSpaceID = SpaceMigrator.currentSpaceID()
+            let identities = await WindowIdentityStore.shared.metadata(for: allInfos)
+            let samePidRows = samePidInfos.map {
+                ListWindowsTool.row(
+                    for: $0,
+                    currentSpaceID: currentSpaceID,
+                    identity: identities[$0.id]
+                )
+            }
+
+            let requested = Requested(
+                pid: pid,
+                windowId: windowId,
+                windowUID: uid
+            )
+
+            if let found = allInfos.first(where: { $0.id == windowId }) {
+                let row = ListWindowsTool.row(
+                    for: found,
+                    currentSpaceID: currentSpaceID,
+                    identity: identities[found.id]
+                )
+                if found.pid == pid {
+                    return result(
+                        Output(
+                            status: .present,
+                            requested: requested,
+                            reason: "window is present and belongs to pid \(pid)",
+                            window: row,
+                            actualOwnerPid: nil,
+                            knownWindows: samePidRows,
+                            possibleReplacements: []
+                        )
+                    )
+                }
+
+                return result(
+                    Output(
+                        status: .pidMismatch,
+                        requested: requested,
+                        reason: "window_id \(windowId) belongs to pid \(found.pid), not pid \(pid)",
+                        window: row,
+                        actualOwnerPid: found.pid,
+                        knownWindows: samePidRows,
+                        possibleReplacements: replacements(
+                            from: samePidRows,
+                            expectedTitle: expectedTitle
+                        )
+                    )
+                )
+            }
+
+            return result(
+                Output(
+                    status: .missing,
+                    requested: requested,
+                    reason: "window_id \(windowId) is not present in WindowServer",
+                    window: nil,
+                    actualOwnerPid: nil,
+                    knownWindows: samePidRows,
+                    possibleReplacements: replacements(
+                        from: samePidRows,
+                        expectedTitle: expectedTitle
+                    )
+                )
+            )
+        }
+    )
+
+    enum Status: String, Codable, Sendable {
+        case present
+        case missing
+        case pidMismatch = "pid_mismatch"
+    }
+
+    struct Requested: Codable, Sendable {
+        let pid: Int32
+        let windowId: Int
+        let windowUID: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case pid
+            case windowId = "window_id"
+            case windowUID = "window_uid"
+        }
+    }
+
+    struct Output: Codable, Sendable {
+        let status: Status
+        let requested: Requested
+        let reason: String
+        let window: ListWindowsTool.Row?
+        let actualOwnerPid: Int32?
+        let knownWindows: [ListWindowsTool.Row]
+        let possibleReplacements: [ListWindowsTool.Row]
+
+        private enum CodingKeys: String, CodingKey {
+            case status
+            case requested
+            case reason
+            case window
+            case actualOwnerPid = "actual_owner_pid"
+            case knownWindows = "known_windows"
+            case possibleReplacements = "possible_replacements"
+        }
+    }
+
+    private static func result(_ output: Output) -> CallTool.Result {
+        let text = "\(output.status.rawValue): \(output.reason)"
+        let content: [Tool.Content] = [
+            .text(text: text, annotations: nil, _meta: nil)
+        ]
+        if let result = try? CallTool.Result(
+            content: content,
+            structuredContent: output
+        ) {
+            return result
+        }
+        return CallTool.Result(content: content)
+    }
+
+    private static func errorResult(_ message: String) -> CallTool.Result {
+        CallTool.Result(
+            content: [.text(text: message, annotations: nil, _meta: nil)],
+            isError: true
+        )
+    }
+
+    private static func replacements(
+        from rows: [ListWindowsTool.Row],
+        expectedTitle: String?
+    ) -> [ListWindowsTool.Row] {
+        if let expectedTitle {
+            let needle = expectedTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+            if !needle.isEmpty {
+                let matches = rows.filter {
+                    $0.title.trimmingCharacters(in: .whitespacesAndNewlines)
+                        .lowercased() == needle
+                }
+                if !matches.isEmpty { return matches }
+            }
+        }
+        return rows.count == 1 ? rows : []
+    }
+
+    private static func parseWindowId(fromUID uid: String?) -> Int? {
+        guard let uid else { return nil }
+        let parts = uid.split(separator: ":")
+        guard parts.count >= 2, parts[0] == "cgwindow" else { return nil }
+        return Int(parts[1])
+    }
+}


### PR DESCRIPTION
## Summary

- adds daemon-stable window identity metadata to list_windows and launch_app responses
- adds validate_window so callers can verify a pinned pid/window lease before acting
- returns conservative replacement candidates instead of silently switching windows

## Why

Automation clients that work across multiple windows, monitors, or document surfaces need to keep task actions pinned to the intended window. pid + window_id alone is not enough once windows are recreated or when several same-app windows exist.

## Validation

- swift build --package-path libs/cua-driver -c release
- swift test --package-path libs/cua-driver
- smoke-tested list_windows, launch_app, and validate_window with the release binary
