### PR TITLE
feat(cd): package bare signed binary as release artifact

### DIFF
--- a/.github/workflows/cd-swift-cua-driver.yml
+++ b/.github/workflows/cd-swift-cua-driver.yml
@@ -234,6 +234,24 @@ jobs:
           echo "Files with symlinks in release directory:"
           ls -la
 
+      - name: Package bare binary
+        working-directory: ./libs/cua-driver/.release
+        run: |
+          VERSION=${{ steps.set_version.outputs.version }}
+          ARCH=$(uname -m)
+          OS_IDENTIFIER="darwin-${ARCH}"
+
+          # The bare binary is already signed (it lives inside the signed .app).
+          # Re-extract it and package it for embedders who build their own bundle.
+          BINARY="CuaDriver.app/Contents/MacOS/cua-driver"
+          if [ -f "$BINARY" ]; then
+            tar -czf "cua-driver-${VERSION}-${OS_IDENTIFIER}-binary.tar.gz" -C "CuaDriver.app/Contents/MacOS" cua-driver
+            ln -sf "cua-driver-${VERSION}-${OS_IDENTIFIER}-binary.tar.gz" "cua-driver-binary.tar.gz"
+            echo "Bare binary packaged."
+          else
+            echo "Warning: binary not found at $BINARY"
+          fi
+
       - name: Upload Notarized Package (Tarball)
         uses: actions/upload-artifact@v4
         with:
@@ -247,6 +265,13 @@ jobs:
           name: cua-driver-notarized-installer
           path: ./libs/cua-driver/${{ steps.build_notarize.outputs.pkg_path }}
           if-no-files-found: error
+
+      - name: Upload Bare Binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: cua-driver-bare-binary
+          path: ./libs/cua-driver/.release/cua-driver-*-binary.tar.gz
+          if-no-files-found: warn
 
       - name: Generate path-filtered release notes
         if: startsWith(github.ref, 'refs/tags/cua-driver-v')
@@ -289,6 +314,7 @@ jobs:
             ./libs/cua-driver/.release/cua-driver-darwin.pkg.tar.gz
             ./libs/cua-driver/.release/cua-driver.tar.gz
             ./libs/cua-driver/.release/cua-driver.pkg.tar.gz
+            ./libs/cua-driver/.release/cua-driver-binary.tar.gz
           body: |
             ${{ steps.release-notes.outputs.RELEASE_NOTES }}
 


### PR DESCRIPTION
## Summary

Adds a `cua-driver-{version}-darwin-{arch}-binary.tar.gz` artifact to the `cd-swift-cua-driver` release workflow.

The binary is the same signed Mach-O that lives inside `CuaDriver.app/Contents/MacOS/cua-driver` — extracted and packaged separately so third-party apps can embed and re-sign it under their own bundle identity without needing to clone + build from source.

## Why

When `CuaDriver.app` runs as a stdio child process of another app (e.g. Clicky), macOS grants TCC (Accessibility + Screen Recording) based on the binary's own signing identity, not the parent process. Users get a second permission prompt for CuaDriver on top of the host app's prompt.

The fix is to embed the binary inside the host app's bundle and re-sign it with the host's Developer ID, so both run under the same TCC identity. The bare binary artifact makes this straightforward: download → place in `HostApp.app/Contents/Helpers/` → re-sign → notarize as part of host app.

## Changes

- New "Package bare binary" step extracts `cua-driver` from the signed `.app` and tars it
- New "Upload Bare Binary" artifact upload step
- `cua-driver-binary.tar.gz` symlink added to release files list

## Test plan

- [ ] Trigger `cd-swift-cua-driver` workflow and verify `cua-driver-*-binary.tar.gz` appears in release artifacts
- [ ] Confirm binary inside tarball is validly signed: `codesign -dvv cua-driver`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Added macOS binary distribution packages to releases in compressed tarball format, available in both version/architecture-specific and generic variants for flexible download options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->