### PR TITLE
fix(computer-server): lazy-load native handlers

### DIFF
--- a/libs/python/computer-server/computer_server/handlers/factory.py
+++ b/libs/python/computer-server/computer_server/handlers/factory.py
@@ -17,23 +17,6 @@ logger = logging.getLogger(__name__)
 
 OS_TYPE = get_current_os()
 
-if OS_TYPE == "android":
-    from .android import (
-        AndroidAccessibilityHandler,
-        AndroidAutomationHandler,
-        AndroidDesktopHandler,
-        AndroidFileHandler,
-        AndroidWindowHandler,
-    )
-elif OS_TYPE == "darwin":
-    from computer_server.diorama.macos import MacOSDioramaHandler
-
-    from .macos import MacOSAccessibilityHandler, MacOSAutomationHandler
-elif OS_TYPE == "linux":
-    from .linux import LinuxAccessibilityHandler, LinuxAutomationHandler
-elif OS_TYPE == "windows":
-    from .windows import WindowsAccessibilityHandler, WindowsAutomationHandler
-
 from .generic import GenericDesktopHandler, GenericFileHandler, GenericWindowHandler
 
 
@@ -81,6 +64,14 @@ class HandlerFactory:
                 GenericWindowHandler(),
             )
         elif OS_TYPE == "android":
+            from .android import (
+                AndroidAccessibilityHandler,
+                AndroidAutomationHandler,
+                AndroidDesktopHandler,
+                AndroidFileHandler,
+                AndroidWindowHandler,
+            )
+
             return (
                 AndroidAccessibilityHandler(),
                 AndroidAutomationHandler(),
@@ -90,6 +81,10 @@ class HandlerFactory:
                 AndroidWindowHandler(),
             )
         elif OS_TYPE == "darwin":
+            from computer_server.diorama.macos import MacOSDioramaHandler
+
+            from .macos import MacOSAccessibilityHandler, MacOSAutomationHandler
+
             return (
                 MacOSAccessibilityHandler(),
                 MacOSAutomationHandler(),
@@ -99,6 +94,8 @@ class HandlerFactory:
                 GenericWindowHandler(),
             )
         elif OS_TYPE == "linux":
+            from .linux import LinuxAccessibilityHandler, LinuxAutomationHandler
+
             return (
                 LinuxAccessibilityHandler(),
                 LinuxAutomationHandler(),
@@ -108,6 +105,8 @@ class HandlerFactory:
                 GenericWindowHandler(),
             )
         elif OS_TYPE == "windows":
+            from .windows import WindowsAccessibilityHandler, WindowsAutomationHandler
+
             return (
                 WindowsAccessibilityHandler(),
                 WindowsAutomationHandler(),


### PR DESCRIPTION
## Summary

- Lazy-load native OS handlers only after the backend is selected.
- Avoid importing macOS native handlers when `CUA_BACKEND=vnc` / `CUA_VNC_HOST` is set.
- Prevent VNC-backed Lume/Tart sessions from triggering native macOS Accessibility/Screen Recording permission prompts unnecessarily.

## Motivation

`computer_server.handlers.factory` imported the native macOS handler at module import time whenever the host OS was Darwin. The macOS handler intentionally probes Accessibility and Screen Recording permissions on import. For Lume VMs configured with the VNC backend, those native handlers are not used, but the import still causes the permission prompt.

This keeps the existing native behavior unchanged while making the VNC backend independent from native macOS handler side effects.

## Testing

- `python3 -m py_compile libs/python/computer-server/computer_server/handlers/factory.py`
- Manually reproduced on a Lume Tahoe VM with CUA server configured for VNC backend (`CUA_BACKEND=vnc`, `CUA_VNC_HOST`, `CUA_VNC_PORT`): `/status` and `/cmd screenshot` remain functional through the VNC backend.
