### PR TITLE
fix(test): add logging to periodic Linux cloud VM test

### DIFF
--- a/.github/workflows/periodic-test-linux-cloud-vm.yml
+++ b/.github/workflows/periodic-test-linux-cloud-vm.yml
@@ -38,9 +38,10 @@ jobs:
         run: pip install cua pytest pytest-asyncio
 
       - name: Run test
-        run: python -m pytest examples/sandboxes/test_linux_cloud_vm.py
+        run: python -m pytest examples/sandboxes/test_linux_cloud_vm.py -v -s --log-cli-level=INFO
         env:
           CUA_API_KEY: ${{ secrets[matrix.secret_name] }}
+          CUA_LOG_LEVEL: DEBUG
 
       - name: Alert Alertmanager on failure
         if: failure()

--- a/examples/sandboxes/test_linux_cloud_vm.py
+++ b/examples/sandboxes/test_linux_cloud_vm.py
@@ -16,12 +16,20 @@ Contrast:
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
+import time
 
 import pytest
 from cua_sandbox import Image, Sandbox
 
 pytestmark = pytest.mark.asyncio
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+logger = logging.getLogger("test_linux_cloud_vm")
 
 
 def _has_cua_api_key() -> bool:
@@ -30,15 +38,47 @@ def _has_cua_api_key() -> bool:
 
 @pytest.mark.skipif(not _has_cua_api_key(), reason="CUA_API_KEY not set")
 async def test_linux_cloud_vm():
+    t0 = time.monotonic()
+    logger.info("Creating ephemeral Linux cloud VM (ubuntu 24.04, kind=vm)")
+
     async with Sandbox.ephemeral(
         Image.linux("ubuntu", "24.04", kind="vm"),
     ) as sb:
-        result = await sb.shell.run("uname -s")
-        assert result.success
-        assert "Linux" in result.stdout
+        provision_time = time.monotonic() - t0
+        logger.info(
+            "VM ready: name=%s, provisioned in %.1fs",
+            getattr(sb, "name", "unknown"),
+            provision_time,
+        )
 
+        # Log transport/endpoint info if available
+        transport = getattr(sb, "_transport", None)
+        if transport:
+            base_url = getattr(getattr(transport, "_inner", None), "_base_url", None)
+            logger.info("Transport base_url=%s", base_url)
+
+        t1 = time.monotonic()
+        result = await sb.shell.run("uname -s")
+        logger.info(
+            "shell.run('uname -s'): success=%s, stdout=%r, took=%.1fs",
+            result.success,
+            result.stdout.strip(),
+            time.monotonic() - t1,
+        )
+        assert result.success, f"uname failed: stderr={result.stderr}"
+        assert "Linux" in result.stdout, f"Expected 'Linux' in stdout, got: {result.stdout!r}"
+
+        t2 = time.monotonic()
         screenshot = await sb.screenshot()
-        assert screenshot[:4] == b"\x89PNG"
+        logger.info(
+            "screenshot: %d bytes, took=%.1fs",
+            len(screenshot),
+            time.monotonic() - t2,
+        )
+        assert screenshot[:4] == b"\x89PNG", f"Screenshot not PNG: first 4 bytes = {screenshot[:4]!r}"
+
+    total_time = time.monotonic() - t0
+    logger.info("Test passed in %.1fs (provision=%.1fs)", total_time, provision_time)
 
 
 async def main():


### PR DESCRIPTION
## Summary
- Add structured logging to `test_linux_cloud_vm` so failures are diagnosable from GHA output alone
- Log VM name, provisioning time, transport URL, and per-operation timings
- Enable `-v -s --log-cli-level=INFO` and `CUA_LOG_LEVEL=DEBUG` in workflow for SDK diagnostics

## Context
The periodic test was failing with just a timeout stack trace — no VM name, no status info, nothing to indicate whether the issue was DNS, provisioning, or the computer-server. This was the case in [run 25231174737](https://github.com/trycua/cua/actions/runs/25231174737) where root cause was Cloudflare DNS quota exhaustion blocking A record creation.

## Test plan
- [ ] Verify PR triggers the workflow (paths filter includes the test file)
- [ ] Check that passing runs show timing info in logs
- [ ] Confirm failing runs show VM name and last-known state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test instrumentation with improved logging visibility and detailed assertion messages for better debugging and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->