### PR TITLE
Fix incorrect str.join() usage in children_content_hash

### DIFF
--- a/libs/python/computer-server/computer_server/handlers/macos.py
+++ b/libs/python/computer-server/computer_server/handlers/macos.py
@@ -483,7 +483,7 @@ class UIElement:
             return ""
         content_hash = self.hash_from_string("".join(all_content_hashes))
         content_structure_hash = self.hash_from_string("".join(all_hashes))
-        return self.hash_from_string(content_hash.join(content_structure_hash))
+        return self.hash_from_string(content_hash + content_structure_hash)
 
     def to_dict(self):
         """Convert the UIElement to a dictionary representation.


### PR DESCRIPTION
## Summary
- Fix `children_content_hash` method in `computer-server/computer_server/handlers/macos.py` where `str.join()` was used instead of string concatenation
- `content_hash.join(content_structure_hash)` treats `content_structure_hash` as an iterable, joining its **characters** with `content_hash` as separator — producing nonsensical hashes
- Changed to use `+` operator for correct concatenation

## Test plan
- [ ] Verify that `children_content_hash` now produces deterministic, correct hashes
- [ ] Existing accessibility tree tests should pass (hash values will change since they were previously incorrect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved hash computation for UI element identification to ensure more accurate and consistent tracking of user interface components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->