### PR TITLE
Fix PPM double-read race condition in QMP screenshot

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/transport/qmp.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/qmp.py
@@ -192,9 +192,10 @@ class QMPTransport(Transport):
         ppm_file = Path(ppm_path)
         if not ppm_file.exists():
             raise RuntimeError(f"screendump failed — {ppm_path} not created")
-        png_bytes = _ppm_to_png(ppm_file.read_bytes())
+        ppm_data = ppm_file.read_bytes()
+        png_bytes = _ppm_to_png(ppm_data)
         # Update screen dimensions from the PPM
-        w, h = _ppm_dimensions(ppm_file.read_bytes())
+        w, h = _ppm_dimensions(ppm_data)
         if w and h:
             self._screen_w = w
             self._screen_h = h


### PR DESCRIPTION
## Summary
- Fix `screenshot()` in `cua-sandbox/transport/qmp.py` reading the PPM file twice — once for PNG conversion and once for dimensions
- The second `read_bytes()` call is wasteful and introduces a race condition: QEMU could overwrite the file between the two reads, causing dimensions to come from a different frame than the image data
- Read once and reuse the bytes for both operations

## Test plan
- [ ] Run QMP transport screenshot tests to verify images are still captured correctly
- [ ] Verify screen dimensions are still parsed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved screenshot processing efficiency by optimizing file read operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->