### PR TITLE
Fix copy_to_clipboard returning wrong format in LocalTransport

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/transport/local.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/local.py
@@ -68,7 +68,7 @@ class LocalTransport(Transport):
             "key_down": lambda p: keyboard.key_down(p["key"]),
             "key_up": lambda p: keyboard.key_up(p["key"]),
             # Clipboard
-            "copy_to_clipboard": lambda p: clipboard.get(),
+            "copy_to_clipboard": lambda p: {"success": True, "content": clipboard.get()},
             "set_clipboard": lambda p: clipboard.set(p["text"]),
             # Shell
             "run_command": lambda p: shell.run(p["command"], p.get("timeout", 30)),


### PR DESCRIPTION
## Summary
- Fix `copy_to_clipboard` handler in `cua-sandbox/transport/local.py` returning a raw string from `clipboard.get()` instead of the expected `{"success": True, "content": ...}` dict format
- Without the dict wrapper, the `Clipboard` interface's `_unwrap()` method checks `isinstance(result, dict)` which returns `False` for the raw string, causing clipboard reads via localhost to silently return `None`
- Aligns the local transport format with the base handler's `copy_to_clipboard` return format

## Test plan
- [ ] Test clipboard read via LocalTransport and verify it returns the actual clipboard content instead of `None`
- [ ] Test clipboard write still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved clipboard operation response format to return a structured confirmation with operation status and content instead of raw content, ensuring more reliable operation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->