### PR TITLE
Replace bare except: with except Exception: in macOS handlers

### DIFF
--- a/libs/python/computer-server/computer_server/handlers/macos.py
+++ b/libs/python/computer-server/computer_server/handlers/macos.py
@@ -822,7 +822,7 @@ class MacOSAccessibilityHandler(BaseAccessibilityHandler):
                 if isinstance(windows, Foundation.NSArray):  # type: ignore
                     return windows
             return []
-        except:
+        except Exception:
             return []
 
     def get_all_windows(self):
@@ -856,11 +856,11 @@ class MacOSAccessibilityHandler(BaseAccessibilityHandler):
                             "windows": app_windows,
                         }
                     )
-                except:
+                except Exception:
                     continue
 
             return windows
-        except:
+        except Exception:
             return []
 
     def get_running_apps(self):
@@ -1192,7 +1192,7 @@ class MacOSAutomationHandler(BaseAutomationHandler):
         except Exception as e:
             try:
                 self.mouse.release(btn)
-            except:
+            except Exception:
                 pass
             return {"success": False, "error": str(e)}
 
@@ -1229,7 +1229,7 @@ class MacOSAutomationHandler(BaseAutomationHandler):
         except Exception as e:
             try:
                 self.mouse.release(btn)
-            except:
+            except Exception:
                 pass
             return {"success": False, "error": str(e)}
 


### PR DESCRIPTION
## Summary
- Replace 5 bare `except:` clauses in `computer-server/computer_server/handlers/macos.py` with `except Exception:`
- Bare `except:` catches `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, preventing clean process shutdown during accessibility tree traversal
- `except Exception:` still catches all runtime errors while allowing interrupt signals to propagate correctly

Affected methods:
- `get_application_windows()` (line 825)
- `get_all_windows()` inner loop (line 859) and outer (line 863)
- `click_and_drag()` cleanup (line 1195)
- `drag()` cleanup (line 1232)

## Test plan
- [ ] Verify macOS accessibility handlers still gracefully handle AX API errors
- [ ] Verify `Ctrl+C` can now cleanly interrupt the process during accessibility tree traversal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced error handling in macOS system operations by refining exception-catching behavior across application window and drag interaction methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->