### PR TITLE
Fix force unwrap crash on optional macAddress in VM context creation

### DIFF
--- a/libs/lume/src/VM/VM.swift
+++ b/libs/lume/src/VM/VM.swift
@@ -878,6 +878,10 @@ class VM {
         // Use provided networkMode, falling back to config value
         let effectiveNetworkMode = networkMode ?? vmDirContext.config.networkMode
 
+        guard let macAddress = vmDirContext.config.macAddress else {
+            throw VMError.notInitialized(vmDirContext.name)
+        }
+
         return VMVirtualizationServiceContext(
             cpuCount: cpuCount,
             memorySize: memorySize,
@@ -886,7 +890,7 @@ class VM {
             mount: mount,
             hardwareModel: vmDirContext.config.hardwareModel,
             machineIdentifier: vmDirContext.config.machineIdentifier,
-            macAddress: vmDirContext.config.macAddress!,
+            macAddress: macAddress,
             diskPath: vmDirContext.diskPath,
             nvramPath: vmDirContext.nvramPath,
             recoveryMode: recoveryMode,


### PR DESCRIPTION
## Summary
- Fix force unwrap of `macAddress` (`String?`) in `createVMVirtualizationServiceContext()` in `libs/lume/src/VM/VM.swift`
- If a VM config was saved before `setup()` assigns a MAC address (e.g., during early creation), the force unwrap would crash the process
- Replace with `guard let` and throw `VMError.notInitialized` with a descriptive error message

## Test plan
- [ ] Verify VMs with valid MAC addresses still start correctly
- [ ] Verify that a VM config without a MAC address produces a clear error instead of a crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during virtual machine initialization to provide clearer error messages instead of potential crashes when required configuration is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->