### PR TITLE
fix(lume): update tahoe unattended preset for macOS 26 Setup Assistant changes

### DIFF
--- a/libs/lume/src/Resources/unattended-presets/tahoe.yml
+++ b/libs/lume/src/Resources/unattended-presets/tahoe.yml
@@ -27,6 +27,17 @@ boot_commands:
   - "<enter>"
   - "<delay 2>"
 
+  # NEW (macOS 26): Terms and Conditions / Software License Agreement screen
+  # was added between language selection and Country/Region.
+  - "<wait 'Agree'>"
+  - "<delay 1>"
+  - "<click 'Agree'>"
+  - "<delay 2>"
+  # Possible confirmation popup ("By clicking Agree...") — second Agree click
+  # advances if the popup is present, otherwise no-op until next wait.
+  - "<click 'Agree'>"
+  - "<delay 2>"
+
   # Country/Region selection
   - "<wait 'Country or Region'>"
   - "<delay 1>"
@@ -108,10 +119,14 @@ boot_commands:
   # Wait for "Email or Phone Number" to appear (indicates page is fully loaded and buttons are clickable)
   - "<wait 'Email or Phone Number'>"
   - "<delay 1>"
-  - "<click 'Set Up Later'>"
+  # NEW (macOS 26): the direct "Set Up Later" button is gone; the skip option is
+  # now under a bottom-left "Other Sign-In Options" dropdown labeled "Sign in
+  # Later in Settings".
+  - "<click 'Other Sign-In Options'>"
+  - "<delay 2>"
+  - "<click 'Sign in Later in Settings'>"
   - "<delay 1>"
   # Confirmation popup: "Are you sure you want to skip signing in with an Apple Account?"
-  # Tab to move focus to "Skip" button, then press Enter
   - '<wait "Don''t Skip">'
   - "<delay 1>"
   - "<tab>"
@@ -130,6 +145,14 @@ boot_commands:
   - "<wait 'I have read and agree'>"
   - "<delay 1>"
   - "<click 'Agree', index=0>"
+  - "<delay 2>"
+
+  # NEW (macOS 26): Age Range screen for parental-controls / safety features.
+  # Three rows (Child / Teen / Adult); each row is a chevron-link that advances
+  # directly when clicked (no separate Continue button).
+  - "<wait 'Age Range'>"
+  - "<delay 1>"
+  - "<click 'Adult'>"
   - "<delay 2>"
 
   # Enable Location Services (skip it)


### PR DESCRIPTION
## Summary

Updates the `tahoe` unattended preset to match Apple's macOS 26.4.1 Setup Assistant flow. The current preset fails on three separate screens that have changed since the preset was authored.

Closes #1440.

## What was broken

Running `lume create test --ipsw latest --unattended tahoe` on a macOS 26.4.1 host fails at boot command index 66/167:

```
INFO: Executing boot command command=click 'Set Up Later' index=66/167
ERROR: Unattended setup failed error=Text 'Set Up Later' not found on screen after 0 seconds
```

Investigation revealed the YAML is out-of-sync with the current Setup Assistant in three places, not just one:

### 1. New Terms and Conditions screen (between Language and Country/Region)

After selecting English, a Terms / Software License Agreement screen now appears before Country/Region. The original preset has no handler for it — `<wait 'Country or Region'>` times out at 120 s with the Terms screen still on display.

OCR of the failure screen confirmed the heading **"Terms and Conditions"** with `Agree` / `Disagree` buttons. Apple is now also injecting a follow-up confirmation popup on the License Agreement after the first Agree click.

### 2. Apple Account skip moved into a dropdown

The "Sign In to Your Apple Account" screen no longer has a direct "Set Up Later" button on it. OCR of the screen at the failure point shows only:

```
"Sign In to Your Apple Account"
"Email or Phone Number"
"Create new Apple Account..."
"Forgot password?"
"Continue"
"Other Sign-In Options V"   ← bottom-left dropdown
```

Clicking `Other Sign-In Options` reveals a dropdown menu containing:
- `Use Multiple Accounts`
- `Sign in Later in Settings`   ← the new skip option

### 3. New Age Range screen (between modal Agree and Location Services)

After the modal "I have read and agree" Agree click, a new **Age Range** screen appears before Enable Location Services. Three rows: `Child` (12 or younger) / `Teen` (13 to 17) / `Adult` (18 or older). Each row is a chevron-link that advances directly on click — there is no Continue button.

## The fix

Three small additions to `libs/lume/src/Resources/unattended-presets/tahoe.yml`. Diff is +25 / -2.

```yaml
  # NEW (macOS 26): Terms and Conditions / Software License Agreement screen
  - "<wait 'Agree'>"
  - "<delay 1>"
  - "<click 'Agree'>"
  - "<delay 2>"
  - "<click 'Agree'>"   # confirmation popup; no-op if absent
  - "<delay 2>"
```

```yaml
  # NEW (macOS 26): Apple Account skip via dropdown menu
  - "<click 'Other Sign-In Options'>"
  - "<delay 2>"
  - "<click 'Sign in Later in Settings'>"
```

```yaml
  # NEW (macOS 26): Age Range screen (chevron-link rows, no Continue button)
  - "<wait 'Age Range'>"
  - "<delay 1>"
  - "<click 'Adult'>"
  - "<delay 2>"
```

## Verification

End-to-end run on macOS 26.4.1 host (Apple Silicon, lume v0.3.9):

```
lume create tahoe-base --os macos --ipsw latest --memory 8GB --disk-size 40GB
lume clone tahoe-base tahoe-iter5
lume setup tahoe-iter5 --unattended /path/to/patched/tahoe.yml --debug
```

Result:

```
INFO: Executing boot command command=click 'Done' index=176/179
INFO: Executing boot command command=hotkey <leftSuper+q> index=178/179
INFO: Executing boot command command=delay 2.0s index=179/179
INFO: Unattended setup completed successfully
```

All 179 boot commands ran to completion. 29 successful click screenshots saved by `--debug` mode; zero `*-FAILED-*` files in the debug directory.

## Notes

**SSH health check timeout (separate concern, not addressed here):** After the preset completes successfully, lume's post-setup `ssh` health check times out (5 retries against the new VM's IP). The preset itself does click `Remote Login` at step 168, so SSH should be enabling — it's possible macOS 26 takes longer than the health check window to bring sshd online, or there's a separate change in how Remote Login is enabled. Worth a separate look but doesn't affect the YAML preset's correctness.

**Iteration methodology:** Since Setup Assistant state persists across VM boots (a failed run leaves the VM partway through the wizard, breaking subsequent runs), I used `lume clone tahoe-base tahoe-iterN` between iterations to always start from a pristine post-install state. `lume setup --debug --debug-dir /tmp/tahoe-dbg-N` saves a click-screenshot + OCR JSON at every successful click and a `NNN-FAILED-X.png` at the failure point, which made each missing-screen discoverable in one iteration.

**Forward-looking note:** Issue #1215 / PR #1217 add a Claude computer-use agent mode (`lume setup --mode agent`) precisely because YAML presets are fragile against Apple's UX changes. This patch keeps the preset path working today; the agent mode is the durable answer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated unattended macOS setup automation to correctly handle system setup screens including license agreements, Apple Account sign-in flow changes, and age range selection during initial setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->