### PR TITLE
feat(CUA-482): user-defined Docker images in Computer / CloudV2 SDK

### DIFF
--- a/libs/python/computer/computer/computer.py
+++ b/libs/python/computer/computer/computer.py
@@ -117,6 +117,7 @@ class Computer:
         vnc_port: int = 5900,
         vnc_password: str = "",
         run_opts: Optional[Dict[str, Any]] = None,
+        instance_type: str = "vm",
     ):
         """Initialize a new Computer instance.
 
@@ -152,6 +153,11 @@ class Computer:
             vnc_port: VNC server port (default: 5900)
             vnc_password: VNC server password
             run_opts: Optional dictionary of provider-specific run options.
+            instance_type: For CloudV2 with a user-supplied image, controls the
+                          provisioning back-end: "vm" (default) provisions a KubeVirt
+                          VMI using the image as a containerDisk; "container" provisions
+                          a gVisor/Incus container using the image as spec.image.
+                          Ignored when no image is supplied or for non-CloudV2 providers.
         """
 
         self.logger = Logger("computer", verbosity)
@@ -189,6 +195,9 @@ class Computer:
         self.os_type = os_type
         self.provider_type = provider_type
         self.ephemeral = ephemeral
+        # instance_type controls VM vs container provisioning for CloudV2 + user image.
+        # Normalise to lowercase; default "vm".
+        self.instance_type: str = (instance_type or "vm").lower()
         self.api_key = (
             api_key
             if self.provider_type in (VMProviderType.CLOUD, VMProviderType.CLOUDV2)
@@ -529,6 +538,7 @@ class Computer:
                                 os="linux",
                                 region="us-east-1",
                                 docker_image=self.image,
+                                instance_type=self.instance_type,
                             )
                             self.logger.info(f"VM creation response: {create_resp}")
                             # The API assigns a new name via petname; update our tracking name

--- a/libs/python/computer/computer/computer.py
+++ b/libs/python/computer/computer/computer.py
@@ -168,6 +168,10 @@ class Computer:
         if api_key is None:
             api_key = os.environ.get("CUA_API_KEY")
 
+        # Track whether the user explicitly supplied an image (used by CloudV2 to
+        # decide whether to create a new VMI with a custom docker image).
+        self._user_supplied_image = bool(image)
+
         if not image:
             if os_type == "macos":
                 image = "macos-sequoia-cua:latest"
@@ -495,9 +499,67 @@ class Computer:
                     if self.config.vm_provider is None:
                         raise RuntimeError(f"VM provider not initialized for {self.config.name}")
 
-                    vm = await self.config.vm_provider.get_vm(self.config.name)
-                    self.logger.verbose(f"Found existing VM: {self.config.name}")
-                    is_running = vm.get("status") == "running"
+                    # For CloudV2: if no name was given and the user supplied a docker image,
+                    # skip the get_vm probe and go straight to creating a new VMI instance.
+                    if (
+                        self.provider_type == VMProviderType.CLOUDV2
+                        and self._user_supplied_image
+                        and not self.config.name
+                    ):
+                        vm = {"status": "not_found"}
+                    else:
+                        vm = await self.config.vm_provider.get_vm(self.config.name)
+                    vm_status = vm.get("status", "unknown")
+                    self.logger.verbose(f"Found existing VM: {self.config.name} (status={vm_status})")
+
+                    # For CloudV2: if the VM doesn't exist yet but a docker image was
+                    # explicitly provided by the user, create a new VMI instance with that image.
+                    if (
+                        vm_status == "not_found"
+                        and self.provider_type == VMProviderType.CLOUDV2
+                        and self._user_supplied_image
+                    ):
+                        from .providers.cloud.providerv2 import CloudV2Provider
+                        if isinstance(self.config.vm_provider, CloudV2Provider):
+                            self.logger.info(
+                                f"VM {self.config.name!r} not found — creating VMI with "
+                                f"docker image {self.image!r}"
+                            )
+                            create_resp = await self.config.vm_provider.create_vm(
+                                os="linux",
+                                region="us-east-1",
+                                docker_image=self.image,
+                            )
+                            self.logger.info(f"VM creation response: {create_resp}")
+                            # The API assigns a new name via petname; update our tracking name
+                            # if the response includes one.
+                            new_name = create_resp.get("name")
+                            if new_name and isinstance(new_name, str):
+                                self.logger.info(
+                                    f"Cloud assigned VM name: {new_name!r} "
+                                    f"(was: {self.config.name!r})"
+                                )
+                                self.config.name = new_name
+                            is_running = False  # Still need to wait for it to be ready
+                        else:
+                            raise RuntimeError(
+                                f"VM {self.config.name} not found and could not be created."
+                            )
+                    elif vm_status == "not_found":
+                        if self.provider_type == VMProviderType.CLOUDV2:
+                            raise RuntimeError(
+                                f"VM {self.config.name!r} not found. "
+                                "To launch a new VMI instance with a custom Docker image, "
+                                "pass image='your/image:tag' to Computer(). "
+                                "Only public images are supported."
+                            )
+                        raise RuntimeError(
+                            f"VM {self.config.name} not found."
+                        )
+                    else:
+                        is_running = vm_status == "running"
+                except RuntimeError:
+                    raise
                 except Exception as e:
                     self.logger.error(f"VM not found: {self.config.name}")
                     self.logger.error(f"Error: {e}")

--- a/libs/python/computer/computer/computer.py
+++ b/libs/python/computer/computer/computer.py
@@ -519,7 +519,9 @@ class Computer:
                     else:
                         vm = await self.config.vm_provider.get_vm(self.config.name)
                     vm_status = vm.get("status", "unknown")
-                    self.logger.verbose(f"Found existing VM: {self.config.name} (status={vm_status})")
+                    self.logger.verbose(
+                        f"Found existing VM: {self.config.name} (status={vm_status})"
+                    )
 
                     # For CloudV2: if the VM doesn't exist yet but a docker image was
                     # explicitly provided by the user, create a new VMI instance with that image.
@@ -529,6 +531,7 @@ class Computer:
                         and self._user_supplied_image
                     ):
                         from .providers.cloud.providerv2 import CloudV2Provider
+
                         if isinstance(self.config.vm_provider, CloudV2Provider):
                             self.logger.info(
                                 f"VM {self.config.name!r} not found — creating VMI with "
@@ -563,9 +566,7 @@ class Computer:
                                 "pass image='your/image:tag' to Computer(). "
                                 "Only public images are supported."
                             )
-                        raise RuntimeError(
-                            f"VM {self.config.name} not found."
-                        )
+                        raise RuntimeError(f"VM {self.config.name} not found.")
                     else:
                         is_running = vm_status == "running"
                 except RuntimeError:

--- a/libs/python/computer/computer/providers/cloud/providerv2.py
+++ b/libs/python/computer/computer/providers/cloud/providerv2.py
@@ -180,24 +180,31 @@ class CloudV2Provider(BaseVMProvider):
         os: str = "linux",
         region: str = "us-east-1",
         docker_image: Optional[str] = None,
+        instance_type: str = "vm",
         cpu: Optional[int] = None,
         memory_mb: Optional[int] = None,
         disk_gb: Optional[int] = None,
     ) -> Dict[str, Any]:
-        """Create a new VMI instance via POST /v1/vms.
+        """Create a new instance via POST /v1/vms.
 
         Args:
             os: Operating system type (default: "linux")
             region: Region to create the VM in (default: "us-east-1")
-            docker_image: Optional public Docker image to use as the containerDisk.
-                         Only public images are supported. When provided, this image
-                         will be used instead of the default CUA image.
+            docker_image: Optional public Docker image to use. Only public images
+                         are supported. When provided, instance_type determines
+                         the provisioning back-end.
+            instance_type: Controls the provisioning back-end when docker_image is set:
+                          "vm" (default) → KubeVirt VMI (containerDisk)
+                          "container"    → gVisor/Incus container (spec.image)
+                          Ignored when docker_image is None.
             cpu: Optional CPU count override
             memory_mb: Optional memory in MB override
             disk_gb: Optional disk size in GB override
 
         Returns:
             Dictionary with VM creation status and information including the VM name.
+            The ``source`` key indicates the provisioning back-end used:
+            ``"kubevirt-ubuntu"`` for VMI, ``"incus-container"`` for container.
 
         Raises:
             RuntimeError: If the creation request fails.
@@ -208,6 +215,8 @@ class CloudV2Provider(BaseVMProvider):
         payload: Dict[str, Any] = {"os": os, "region": region}
         if docker_image:
             payload["dockerImage"] = docker_image
+            # Only send instanceType when an image is provided.
+            payload["instanceType"] = instance_type or "vm"
         if cpu is not None:
             payload["cpu"] = cpu
         if memory_mb is not None:

--- a/libs/python/computer/computer/providers/cloud/providerv2.py
+++ b/libs/python/computer/computer/providers/cloud/providerv2.py
@@ -175,6 +175,66 @@ class CloudV2Provider(BaseVMProvider):
                     logger.error(f"list_vms failed: HTTP {resp.status} - {text}")
                     return []
 
+    async def create_vm(
+        self,
+        os: str = "linux",
+        region: str = "us-east-1",
+        docker_image: Optional[str] = None,
+        cpu: Optional[int] = None,
+        memory_mb: Optional[int] = None,
+        disk_gb: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Create a new VMI instance via POST /v1/vms.
+
+        Args:
+            os: Operating system type (default: "linux")
+            region: Region to create the VM in (default: "us-east-1")
+            docker_image: Optional public Docker image to use as the containerDisk.
+                         Only public images are supported. When provided, this image
+                         will be used instead of the default CUA image.
+            cpu: Optional CPU count override
+            memory_mb: Optional memory in MB override
+            disk_gb: Optional disk size in GB override
+
+        Returns:
+            Dictionary with VM creation status and information including the VM name.
+
+        Raises:
+            RuntimeError: If the creation request fails.
+        """
+        url = f"{self.api_base}/v1/vms"
+        headers = {**self._base_headers(), "Content-Type": "application/json"}
+
+        payload: Dict[str, Any] = {"os": os, "region": region}
+        if docker_image:
+            payload["dockerImage"] = docker_image
+        if cpu is not None:
+            payload["cpu"] = cpu
+        if memory_mb is not None:
+            payload["memoryMb"] = memory_mb
+        if disk_gb is not None:
+            payload["diskGb"] = disk_gb
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, headers=headers, json=payload) as resp:
+                text = await resp.text()
+                if resp.status in (200, 201, 202):
+                    try:
+                        data = await resp.json(content_type=None)
+                        if isinstance(data, dict):
+                            return data
+                    except Exception:
+                        pass
+                    return {"status": "provisioning", "raw": text}
+                elif resp.status == 400:
+                    raise RuntimeError(f"Bad request creating VM: {text}")
+                elif resp.status == 401:
+                    raise RuntimeError("Unauthorized: invalid CUA API key")
+                elif resp.status == 402:
+                    raise RuntimeError(f"Payment required: {text}")
+                else:
+                    raise RuntimeError(f"Failed to create VM: HTTP {resp.status} - {text}")
+
     async def run_vm(
         self,
         name: str,

--- a/libs/python/computer/tests/test_cloudv2_docker_image.py
+++ b/libs/python/computer/tests/test_cloudv2_docker_image.py
@@ -1,12 +1,37 @@
-"""Unit tests for CloudV2Provider.create_vm and docker image support.
+"""Unit tests for CloudV2Provider.create_vm, instance_type routing, and docker image support.
 
-Tests the new user-defined docker registry feature for VMI instances.
+Tests the new user-defined docker registry feature for VMI instances and gVisor containers.
 """
 
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+
+def _make_capture_session(mock_resp, captured_payload):
+    """Helper: creates a mock aiohttp session that captures POST payloads."""
+    mock_session = MagicMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    def capturing_post(url, headers=None, json=None, **kwargs):
+        if json:
+            captured_payload.update(json)
+        return mock_resp
+
+    mock_session.post = capturing_post
+    return mock_session
+
+
+def _make_mock_resp(status, body):
+    mock_resp = MagicMock()
+    mock_resp.status = status
+    mock_resp.json = AsyncMock(return_value=body)
+    mock_resp.text = AsyncMock(return_value=str(body))
+    mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_resp.__aexit__ = AsyncMock(return_value=None)
+    return mock_resp
 
 
 class TestCloudV2ProviderCreateVM:
@@ -17,39 +42,19 @@ class TestCloudV2ProviderCreateVM:
 
         return CloudV2Provider(api_key="test-key", api_base="https://api.test.cua.ai")
 
+    # -----------------------------------------------------------------
+    # instanceType="vm" (default) — KubeVirt VMI path
+    # -----------------------------------------------------------------
+
     @pytest.mark.asyncio
-    async def test_create_vm_with_public_docker_image(self):
-        """create_vm should POST dockerImage to /v1/vms and return the name."""
+    async def test_create_vm_default_instance_type_is_vm(self):
+        """create_vm with docker_image and no instance_type should send instanceType='vm'."""
         provider = self._make_provider()
+        captured = {}
+        resp = _make_mock_resp(202, {"status": "provisioning", "name": "witty-falcon", "source": "kubevirt-ubuntu"})
+        session = _make_capture_session(resp, captured)
 
-        response_body = {
-            "status": "provisioning",
-            "name": "witty-falcon",
-            "source": "kubevirt-ubuntu",
-        }
-
-        mock_resp = MagicMock()
-        mock_resp.status = 202
-        mock_resp.json = AsyncMock(return_value=response_body)
-        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
-        mock_resp.__aexit__ = AsyncMock(return_value=None)
-
-        mock_session = MagicMock()
-        mock_session.post = MagicMock(return_value=mock_resp)
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=None)
-
-        captured_payload = {}
-
-        original_post = mock_session.post
-
-        def capturing_post(url, headers=None, json=None, **kwargs):
-            captured_payload.update(json or {})
-            return original_post(url, headers=headers, json=json, **kwargs)
-
-        mock_session.post = capturing_post
-
-        with patch("aiohttp.ClientSession", return_value=mock_session):
+        with patch("aiohttp.ClientSession", return_value=session):
             result = await provider.create_vm(
                 os="linux",
                 region="us-east-1",
@@ -57,57 +62,83 @@ class TestCloudV2ProviderCreateVM:
             )
 
         assert result["name"] == "witty-falcon"
-        assert result["status"] == "provisioning"
-        assert captured_payload.get("dockerImage") == "trycua/cua-ubuntu:custom"
-        assert captured_payload.get("os") == "linux"
-        assert captured_payload.get("region") == "us-east-1"
+        assert result["source"] == "kubevirt-ubuntu"
+        assert captured["dockerImage"] == "trycua/cua-ubuntu:custom"
+        assert captured["instanceType"] == "vm"
 
     @pytest.mark.asyncio
-    async def test_create_vm_without_docker_image(self):
-        """create_vm should NOT include dockerImage when image is None."""
+    async def test_create_vm_explicit_instance_type_vm(self):
+        """create_vm with instance_type='vm' should send instanceType='vm'."""
         provider = self._make_provider()
+        captured = {}
+        resp = _make_mock_resp(202, {"status": "provisioning", "name": "brave-eagle", "source": "kubevirt-ubuntu"})
+        session = _make_capture_session(resp, captured)
 
-        response_body = {"status": "provisioning", "name": "calm-panda"}
-        mock_resp = MagicMock()
-        mock_resp.status = 202
-        mock_resp.json = AsyncMock(return_value=response_body)
-        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
-        mock_resp.__aexit__ = AsyncMock(return_value=None)
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = await provider.create_vm(
+                os="linux",
+                region="us-east-1",
+                docker_image="myorg/myimage:v1",
+                instance_type="vm",
+            )
 
-        mock_session = MagicMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=None)
+        assert captured["instanceType"] == "vm"
+        assert result["source"] == "kubevirt-ubuntu"
 
-        captured_payload = {}
+    # -----------------------------------------------------------------
+    # instanceType="container" — gVisor/Incus container path
+    # -----------------------------------------------------------------
 
-        def capturing_post(url, headers=None, json=None, **kwargs):
-            captured_payload.update(json or {})
-            return mock_resp
+    @pytest.mark.asyncio
+    async def test_create_vm_instance_type_container(self):
+        """create_vm with instance_type='container' should send instanceType='container'."""
+        provider = self._make_provider()
+        captured = {}
+        resp = _make_mock_resp(202, {"status": "provisioning", "name": "calm-fox", "source": "incus-container"})
+        session = _make_capture_session(resp, captured)
 
-        mock_session.post = capturing_post
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = await provider.create_vm(
+                os="linux",
+                region="us-east-1",
+                docker_image="myorg/myapp:latest",
+                instance_type="container",
+            )
 
-        with patch("aiohttp.ClientSession", return_value=mock_session):
-            result = await provider.create_vm(os="linux", region="us-east-1")
+        assert captured["dockerImage"] == "myorg/myapp:latest"
+        assert captured["instanceType"] == "container"
+        assert result["source"] == "incus-container"
 
-        assert "dockerImage" not in captured_payload
+    # -----------------------------------------------------------------
+    # No docker image → instanceType not sent
+    # -----------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_create_vm_without_docker_image_no_instance_type_in_payload(self):
+        """create_vm should NOT include dockerImage or instanceType when image is None."""
+        provider = self._make_provider()
+        captured = {}
+        resp = _make_mock_resp(202, {"status": "provisioning", "name": "calm-panda"})
+        session = _make_capture_session(resp, captured)
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            await provider.create_vm(os="linux", region="us-east-1")
+
+        assert "dockerImage" not in captured
+        assert "instanceType" not in captured
+
+    # -----------------------------------------------------------------
+    # Error cases
+    # -----------------------------------------------------------------
 
     @pytest.mark.asyncio
     async def test_create_vm_raises_on_400(self):
         """create_vm should raise RuntimeError on 400 Bad Request."""
         provider = self._make_provider()
+        resp = _make_mock_resp(400, '{"error":"invalid dockerImage"}')
+        session = _make_capture_session(resp, {})
 
-        mock_resp = MagicMock()
-        mock_resp.status = 400
-        mock_resp.text = AsyncMock(return_value='{"error":"invalid dockerImage"}')
-        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
-        mock_resp.__aexit__ = AsyncMock(return_value=None)
-
-        mock_session = MagicMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=None)
-        mock_session.post = MagicMock(return_value=mock_resp)
-
-        with patch("aiohttp.ClientSession", return_value=mock_session):
+        with patch("aiohttp.ClientSession", return_value=session):
             with pytest.raises(RuntimeError, match="Bad request"):
                 await provider.create_vm(
                     os="linux",
@@ -119,19 +150,10 @@ class TestCloudV2ProviderCreateVM:
     async def test_create_vm_raises_on_401(self):
         """create_vm should raise RuntimeError on 401 Unauthorized."""
         provider = self._make_provider()
+        resp = _make_mock_resp(401, "Unauthorized")
+        session = _make_capture_session(resp, {})
 
-        mock_resp = MagicMock()
-        mock_resp.status = 401
-        mock_resp.text = AsyncMock(return_value="Unauthorized")
-        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
-        mock_resp.__aexit__ = AsyncMock(return_value=None)
-
-        mock_session = MagicMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=None)
-        mock_session.post = MagicMock(return_value=mock_resp)
-
-        with patch("aiohttp.ClientSession", return_value=mock_session):
+        with patch("aiohttp.ClientSession", return_value=session):
             with pytest.raises(RuntimeError, match="Unauthorized"):
                 await provider.create_vm(os="linux", region="us-east-1")
 
@@ -139,18 +161,9 @@ class TestCloudV2ProviderCreateVM:
     async def test_create_vm_raises_on_402(self):
         """create_vm should raise RuntimeError on 402 Payment Required."""
         provider = self._make_provider()
+        resp = _make_mock_resp(402, '{"error":"Free credits exhausted"}')
+        session = _make_capture_session(resp, {})
 
-        mock_resp = MagicMock()
-        mock_resp.status = 402
-        mock_resp.text = AsyncMock(return_value='{"error":"Free credits exhausted"}')
-        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
-        mock_resp.__aexit__ = AsyncMock(return_value=None)
-
-        mock_session = MagicMock()
-        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session.__aexit__ = AsyncMock(return_value=None)
-        mock_session.post = MagicMock(return_value=mock_resp)
-
-        with patch("aiohttp.ClientSession", return_value=mock_session):
+        with patch("aiohttp.ClientSession", return_value=session):
             with pytest.raises(RuntimeError, match="Payment required"):
                 await provider.create_vm(os="linux", region="us-east-1")

--- a/libs/python/computer/tests/test_cloudv2_docker_image.py
+++ b/libs/python/computer/tests/test_cloudv2_docker_image.py
@@ -1,0 +1,156 @@
+"""Unit tests for CloudV2Provider.create_vm and docker image support.
+
+Tests the new user-defined docker registry feature for VMI instances.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestCloudV2ProviderCreateVM:
+    """Tests for CloudV2Provider.create_vm (SRP: Only tests create_vm)."""
+
+    def _make_provider(self):
+        from computer.providers.cloud.providerv2 import CloudV2Provider
+
+        return CloudV2Provider(api_key="test-key", api_base="https://api.test.cua.ai")
+
+    @pytest.mark.asyncio
+    async def test_create_vm_with_public_docker_image(self):
+        """create_vm should POST dockerImage to /v1/vms and return the name."""
+        provider = self._make_provider()
+
+        response_body = {
+            "status": "provisioning",
+            "name": "witty-falcon",
+            "source": "kubevirt-ubuntu",
+        }
+
+        mock_resp = MagicMock()
+        mock_resp.status = 202
+        mock_resp.json = AsyncMock(return_value=response_body)
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        captured_payload = {}
+
+        original_post = mock_session.post
+
+        def capturing_post(url, headers=None, json=None, **kwargs):
+            captured_payload.update(json or {})
+            return original_post(url, headers=headers, json=json, **kwargs)
+
+        mock_session.post = capturing_post
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = await provider.create_vm(
+                os="linux",
+                region="us-east-1",
+                docker_image="trycua/cua-ubuntu:custom",
+            )
+
+        assert result["name"] == "witty-falcon"
+        assert result["status"] == "provisioning"
+        assert captured_payload.get("dockerImage") == "trycua/cua-ubuntu:custom"
+        assert captured_payload.get("os") == "linux"
+        assert captured_payload.get("region") == "us-east-1"
+
+    @pytest.mark.asyncio
+    async def test_create_vm_without_docker_image(self):
+        """create_vm should NOT include dockerImage when image is None."""
+        provider = self._make_provider()
+
+        response_body = {"status": "provisioning", "name": "calm-panda"}
+        mock_resp = MagicMock()
+        mock_resp.status = 202
+        mock_resp.json = AsyncMock(return_value=response_body)
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        captured_payload = {}
+
+        def capturing_post(url, headers=None, json=None, **kwargs):
+            captured_payload.update(json or {})
+            return mock_resp
+
+        mock_session.post = capturing_post
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = await provider.create_vm(os="linux", region="us-east-1")
+
+        assert "dockerImage" not in captured_payload
+
+    @pytest.mark.asyncio
+    async def test_create_vm_raises_on_400(self):
+        """create_vm should raise RuntimeError on 400 Bad Request."""
+        provider = self._make_provider()
+
+        mock_resp = MagicMock()
+        mock_resp.status = 400
+        mock_resp.text = AsyncMock(return_value='{"error":"invalid dockerImage"}')
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session.post = MagicMock(return_value=mock_resp)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            with pytest.raises(RuntimeError, match="Bad request"):
+                await provider.create_vm(
+                    os="linux",
+                    region="us-east-1",
+                    docker_image="invalid image",
+                )
+
+    @pytest.mark.asyncio
+    async def test_create_vm_raises_on_401(self):
+        """create_vm should raise RuntimeError on 401 Unauthorized."""
+        provider = self._make_provider()
+
+        mock_resp = MagicMock()
+        mock_resp.status = 401
+        mock_resp.text = AsyncMock(return_value="Unauthorized")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session.post = MagicMock(return_value=mock_resp)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            with pytest.raises(RuntimeError, match="Unauthorized"):
+                await provider.create_vm(os="linux", region="us-east-1")
+
+    @pytest.mark.asyncio
+    async def test_create_vm_raises_on_402(self):
+        """create_vm should raise RuntimeError on 402 Payment Required."""
+        provider = self._make_provider()
+
+        mock_resp = MagicMock()
+        mock_resp.status = 402
+        mock_resp.text = AsyncMock(return_value='{"error":"Free credits exhausted"}')
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session.post = MagicMock(return_value=mock_resp)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            with pytest.raises(RuntimeError, match="Payment required"):
+                await provider.create_vm(os="linux", region="us-east-1")

--- a/libs/python/computer/tests/test_cloudv2_docker_image.py
+++ b/libs/python/computer/tests/test_cloudv2_docker_image.py
@@ -51,7 +51,9 @@ class TestCloudV2ProviderCreateVM:
         """create_vm with docker_image and no instance_type should send instanceType='vm'."""
         provider = self._make_provider()
         captured = {}
-        resp = _make_mock_resp(202, {"status": "provisioning", "name": "witty-falcon", "source": "kubevirt-ubuntu"})
+        resp = _make_mock_resp(
+            202, {"status": "provisioning", "name": "witty-falcon", "source": "kubevirt-ubuntu"}
+        )
         session = _make_capture_session(resp, captured)
 
         with patch("aiohttp.ClientSession", return_value=session):
@@ -71,7 +73,9 @@ class TestCloudV2ProviderCreateVM:
         """create_vm with instance_type='vm' should send instanceType='vm'."""
         provider = self._make_provider()
         captured = {}
-        resp = _make_mock_resp(202, {"status": "provisioning", "name": "brave-eagle", "source": "kubevirt-ubuntu"})
+        resp = _make_mock_resp(
+            202, {"status": "provisioning", "name": "brave-eagle", "source": "kubevirt-ubuntu"}
+        )
         session = _make_capture_session(resp, captured)
 
         with patch("aiohttp.ClientSession", return_value=session):
@@ -94,7 +98,9 @@ class TestCloudV2ProviderCreateVM:
         """create_vm with instance_type='container' should send instanceType='container'."""
         provider = self._make_provider()
         captured = {}
-        resp = _make_mock_resp(202, {"status": "provisioning", "name": "calm-fox", "source": "incus-container"})
+        resp = _make_mock_resp(
+            202, {"status": "provisioning", "name": "calm-fox", "source": "incus-container"}
+        )
         session = _make_capture_session(resp, captured)
 
         with patch("aiohttp.ClientSession", return_value=session):


### PR DESCRIPTION
## Summary

Adds support for user-supplied public Docker images and `instance_type` routing in the `computer` library (`CloudV2Provider` + `Computer`).

Linear: CUA-482

This PR is **independent** — no dependency on cua-sandbox PR or cloud PR #4178.

## Changes (`libs/python/computer`)

**`CloudV2Provider.create_vm()`** (new)
- POSTs to `POST /v1/vms` with `dockerImage`, `instanceType`, `os`, `region`
- Raises `RuntimeError` on 400 / 401 / 402

**`Computer.__init__`**
- New `instance_type: str = "vm"` parameter (`"vm"` → KubeVirt VMI, `"container"` → gVisor)
- `_user_supplied_image` flag distinguishes explicit vs defaulted image

**`Computer.run()` CloudV2 flow**
- If VM not found and user supplied an image → `create_vm(docker_image=..., instance_type=...)`
- Updates `config.name` with the cloud-assigned petname

**Tests**: `tests/test_cloudv2_docker_image.py` — happy path, instance_type vm/container, no-image payload, 400/401/402 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Computer class now accepts a configurable `instance_type` parameter for VM provisioning
  * CloudV2 provider now supports provisioning new VMs with custom Docker images and configurable resource specifications (CPU, memory, disk, region)

* **Tests**
  * Added comprehensive test coverage for CloudV2 custom Docker image provisioning workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->