### PR TITLE
feat(CUA-482): Sandbox API docker registry support — Image.runtime() + BasaltQEMUBuilder WASM

### DIFF
--- a/libs/python/cua-cli/cua_cli/commands/sandbox.py
+++ b/libs/python/cua-cli/cua_cli/commands/sandbox.py
@@ -54,14 +54,20 @@ def _parse_image(image_str: str, vm: bool = False):
     """
     from cua_sandbox import Image
 
-    # Registry reference: contains '/' or starts with a known registry hostname
+    # Registry reference: contains '/' or starts with a known registry hostname.
+    # Apply a runtime hint so instanceType is explicit rather than inferred:
+    #   --vm  → "qemu/cloud"  (KubeVirt VMI)
+    #   default → "oci/cloud" (gVisor container)
+    def _with_hint(img: Image) -> Image:
+        return img.runtime("qemu/cloud" if vm else "oci/cloud")
+
     if "/" in image_str:
         host = image_str.split("/")[0]
         if "." in host or host in _REGISTRY_HOSTNAMES:
-            return Image.from_registry(image_str)
+            return _with_hint(Image.from_registry(image_str))
     for rh in _REGISTRY_HOSTNAMES:
         if image_str.startswith(rh):
-            return Image.from_registry(image_str)
+            return _with_hint(Image.from_registry(image_str))
 
     # Split on ':'
     parts = image_str.split(":", 1)
@@ -86,8 +92,8 @@ def _parse_image(image_str: str, vm: bool = False):
         version = tag or "14"
         return Image.android(version)
 
-    # Unknown — try registry
-    return Image.from_registry(image_str)
+    # Unknown — treat as registry ref with explicit runtime hint
+    return _with_hint(Image.from_registry(image_str))
 
 
 # ---------------------------------------------------------------------------

--- a/libs/python/cua-cli/cua_cli/commands/sandbox.py
+++ b/libs/python/cua-cli/cua_cli/commands/sandbox.py
@@ -57,9 +57,9 @@ def _parse_image(image_str: str, vm: bool = False):
     # Registry reference: contains '/' or starts with a known registry hostname.
     # Apply a runtime hint so instanceType is explicit rather than inferred:
     #   --vm  → "qemu/cloud"  (KubeVirt VMI)
-    #   default → "oci/cloud" (gVisor container)
+    #   default → "docker/cloud" (gVisor container)
     def _with_hint(img: Image) -> Image:
-        return img.runtime("qemu/cloud" if vm else "oci/cloud")
+        return img.runtime("qemu/cloud" if vm else "docker/cloud")
 
     if "/" in image_str:
         host = image_str.split("/")[0]

--- a/libs/python/cua-sandbox/cua_sandbox/builder/basalt.py
+++ b/libs/python/cua-sandbox/cua_sandbox/builder/basalt.py
@@ -1,0 +1,446 @@
+"""Basalt-backed QEMU VM builder.
+
+Translates ``Image`` layer specs into a basalt JSON step file and drives the
+basalt CLI to incrementally build a qcow2 disk image.  Each layer becomes a
+basalt step whose deps include the layer contents, giving free content-addressed
+caching across builds.
+
+Basalt handles:
+  - Mounting the qcow2 via ``qemu-nbd`` + loopback
+  - Executing steps in a ``chroot``
+  - Caching intermediate results as named qcow2-internal snapshots
+    (``basalt-{step}-{hash8}``)
+  - Restoring to the last cache-hit snapshot before executing the first miss
+
+This replaces the hand-rolled ``build.py`` implementation for the
+``qemu/local`` runtime path.
+
+Usage::
+
+    from pathlib import Path
+    from cua_sandbox.builder.basalt import BasaltQEMUBuilder
+    from cua_sandbox import Image
+
+    image = (
+        Image.linux("ubuntu", "24.04")
+        .apt_install("curl", "git")
+        .run("curl -LsSf https://astral.sh/uv/install.sh | sh")
+    )
+
+    builder = BasaltQEMUBuilder()
+    disk = await builder.build(image, base_qcow2=Path("/base/ubuntu-24.04.qcow2"))
+    # disk is a content-addressed qcow2 ready to boot
+
+Cloud builder stubs (``qemu/cloud``, ``docker/cloud``) are provided as
+``NotImplementedError`` placeholders to be wired up once the cloud build API
+is available.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from cua_sandbox.image import Image
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Default paths
+# ---------------------------------------------------------------------------
+
+_IMAGES_DIR = Path.home() / ".cua" / "cua-sandbox" / "images"
+_BASALT_BIN_CANDIDATES = [
+    "basalt",                                    # on PATH
+    str(Path.home() / ".cargo" / "bin" / "basalt"),
+    "/usr/local/bin/basalt",
+    "/opt/basalt/bin/basalt",
+]
+
+
+def _find_basalt() -> str:
+    """Locate the ``basalt`` binary.  Raises ``RuntimeError`` if not found."""
+    for candidate in _BASALT_BIN_CANDIDATES:
+        if shutil.which(candidate) or Path(candidate).is_file():
+            return candidate
+    raise RuntimeError(
+        "basalt binary not found. "
+        "Install it with: cargo install --path services/basalt  "
+        "or set BASALT_BIN environment variable."
+    )
+
+
+def _basalt_bin() -> str:
+    """Return the basalt binary path, honouring ``BASALT_BIN`` env var."""
+    env_bin = os.environ.get("BASALT_BIN")
+    if env_bin:
+        return env_bin
+    return _find_basalt()
+
+
+# ---------------------------------------------------------------------------
+# Layer → basalt step translation
+# ---------------------------------------------------------------------------
+
+def _layers_to_basalt_steps(
+    layers: list[Dict[str, Any]],
+    os_type: str = "linux",
+) -> Dict[str, Any]:
+    """Translate a list of ``Image`` layer dicts into a basalt step-file dict.
+
+    Each layer becomes a named step whose ``run`` command applies the layer
+    inside the chroot.  Step ``n+1`` depends on step ``n``, giving a
+    sequential build chain.
+
+    The returned dict is ready to be serialised to JSON and passed to the
+    basalt CLI.
+    """
+    steps: Dict[str, Any] = {}
+    prev_step: Optional[str] = None
+
+    for i, layer in enumerate(layers):
+        lt = layer["type"]
+        step_name = f"layer-{i:03d}-{lt}"
+
+        cmd = _layer_to_shell(layer, os_type)
+        if cmd is None:
+            # Layer has no shell equivalent (e.g. expose) — insert a no-op
+            cmd = "true"
+
+        deps: List[Dict[str, Any]] = []
+        if prev_step:
+            deps.append({"type": "step", "name": prev_step})
+
+        # Hash the layer spec itself as a content dep so any change invalidates
+        # the cache without needing a file on disk.
+        layer_hash = hashlib.sha256(
+            json.dumps(layer, sort_keys=True).encode()
+        ).hexdigest()[:16]
+        # Use a known-stable no-op command whose output encodes the layer hash
+        deps.append({
+            "type": "exec_output",
+            "program": "echo",
+            "args": [f"layer-hash:{layer_hash}"],
+        })
+
+        steps[step_name] = {
+            "run": cmd if isinstance(cmd, list) else [{"program": "sh", "args": ["-c", cmd]}],
+            "deps": deps,
+        }
+        prev_step = step_name
+
+    targets = [prev_step] if prev_step else []
+    return {"targets": targets, "steps": steps}
+
+
+def _layer_to_shell(layer: Dict[str, Any], os_type: str) -> Optional[str]:
+    """Convert a single layer dict to a shell command string for chroot execution."""
+    lt = layer["type"]
+
+    if lt == "apt_install":
+        pkgs = " ".join(layer["packages"])
+        return (
+            f"DEBIAN_FRONTEND=noninteractive apt-get update -qq && "
+            f"DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends {pkgs}"
+        )
+
+    if lt == "run":
+        return layer["command"]
+
+    if lt == "pip_install":
+        pkgs = " ".join(layer["packages"])
+        return f"pip3 install {pkgs}"
+
+    if lt == "uv_install":
+        pkgs = " ".join(layer["packages"])
+        return (
+            f"command -v uv >/dev/null 2>&1 || "
+            f"(curl -LsSf https://astral.sh/uv/install.sh | sh && "
+            f"export PATH=\"$HOME/.cargo/bin:$HOME/.local/bin:$PATH\") && "
+            f"uv pip install --system {pkgs}"
+        )
+
+    if lt == "brew_install":
+        pkgs = " ".join(layer["packages"])
+        return f"brew install {pkgs}"
+
+    if lt == "env":
+        variables = layer.get("variables", {})
+        if not variables:
+            return "true"
+        lines = "\n".join(
+            f"printf '%s=%s\\n' '{k}' '{v}' >> /etc/environment"
+            for k, v in variables.items()
+        )
+        return lines
+
+    if lt in ("expose", "apk_install", "pwa_install", "app_install"):
+        # Not meaningful inside a chroot builder — skip (no-op)
+        return "true"
+
+    # Unknown layer type — let basalt run a no-op so the build doesn't fail
+    logger.warning("BasaltQEMUBuilder: unknown layer type %r — inserting no-op", lt)
+    return "true"
+
+
+# ---------------------------------------------------------------------------
+# BasaltQEMUBuilder
+# ---------------------------------------------------------------------------
+
+class BasaltQEMUBuilder:
+    """Incrementally build a qcow2 VM disk using basalt.
+
+    The builder:
+    1. Copies the base qcow2 to a working path (if needed)
+    2. Generates a basalt JSON step file from ``image._layers``
+    3. Invokes the ``basalt`` CLI in qemu mode
+    4. Returns the path to the built qcow2
+
+    The output disk is content-addressed by (base_hash, layers_hash) and
+    cached at ``~/.cua/cua-sandbox/images/basalt-{hash}.qcow2``.  Subsequent
+    calls with identical inputs return the cached disk immediately.
+
+    Args:
+        nbd_device: NBD device to use for qcow2 mounting (default ``/dev/nbd0``).
+            Requires the ``nbd`` kernel module and root / sudo.
+        images_dir: Directory to store built images (default
+            ``~/.cua/cua-sandbox/images``).
+    """
+
+    def __init__(
+        self,
+        nbd_device: str = "/dev/nbd0",
+        images_dir: Optional[Path] = None,
+    ) -> None:
+        self.nbd_device = nbd_device
+        self.images_dir = images_dir or _IMAGES_DIR
+        self.images_dir.mkdir(parents=True, exist_ok=True)
+
+    def _output_key(self, image: Image, base_qcow2: Path) -> str:
+        """Compute a content-based cache key for this (image, base) combination."""
+        from cua_sandbox.builder.overlay import layers_hash
+
+        base_hash = _file_sha256(base_qcow2)[:16]
+        layer_hash = layers_hash(list(image._layers))[:16] if image._layers else "nolayers"
+        return f"{base_hash}-{layer_hash}"
+
+    async def build(
+        self,
+        image: Image,
+        base_qcow2: Path,
+        *,
+        force: bool = False,
+    ) -> Path:
+        """Build a qcow2 from *image* layers on top of *base_qcow2*.
+
+        Returns the path to the built disk (may be *base_qcow2* itself if
+        the image has no layers).
+
+        If the output disk already exists and *force* is False, the cached
+        disk is returned immediately without re-running basalt.
+
+        Requires the ``basalt`` binary and root permissions for qemu-nbd /
+        chroot (or a suitably configured sudo).
+
+        Args:
+            image: The Image whose layers to apply.
+            base_qcow2: Read-only base disk (ubuntu, windows, ...).
+            force: Rebuild even if a cached output disk exists.
+
+        Returns:
+            Path to the built qcow2.
+        """
+        if not base_qcow2.exists():
+            raise FileNotFoundError(f"Base qcow2 not found: {base_qcow2}")
+
+        if not image._layers:
+            logger.info("BasaltQEMUBuilder: no layers — returning base qcow2 as-is")
+            return base_qcow2
+
+        cache_key = self._output_key(image, base_qcow2)
+        out_disk = self.images_dir / f"basalt-{cache_key}.qcow2"
+
+        if out_disk.exists() and not force:
+            logger.info("BasaltQEMUBuilder: cache hit — %s", out_disk)
+            return out_disk
+
+        logger.info(
+            "BasaltQEMUBuilder: building %d layers on top of %s → %s",
+            len(image._layers), base_qcow2, out_disk,
+        )
+
+        # Make a working copy of the base — basalt will modify it in-place
+        work_disk = self.images_dir / f"basalt-work-{cache_key}.qcow2"
+        shutil.copy2(str(base_qcow2), str(work_disk))
+
+        # Generate step file
+        step_data = _layers_to_basalt_steps(list(image._layers), image.os_type)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".basalt.json",
+            delete=False,
+            dir=self.images_dir,
+        ) as f:
+            json.dump(step_data, f, indent=2)
+            step_file = Path(f.name)
+
+        mount_dir = self.images_dir / f"mnt-{cache_key}"
+        mount_dir.mkdir(parents=True, exist_ok=True)
+
+        try:
+            await self._run_basalt(step_file, work_disk, mount_dir)
+        except Exception:
+            # Clean up partial output on failure
+            work_disk.unlink(missing_ok=True)
+            raise
+        finally:
+            step_file.unlink(missing_ok=True)
+            # Best-effort cleanup of mount point
+            try:
+                mount_dir.rmdir()
+            except OSError:
+                pass
+
+        # Rename work disk to cache key on success
+        work_disk.rename(out_disk)
+        logger.info("BasaltQEMUBuilder: built → %s", out_disk)
+        return out_disk
+
+    async def _run_basalt(
+        self,
+        step_file: Path,
+        qcow2_path: Path,
+        mount_dir: Path,
+    ) -> None:
+        """Invoke the basalt CLI in qemu mode and stream output to logger."""
+        import asyncio
+
+        bin_path = _basalt_bin()
+        cmd = [
+            bin_path,
+            str(step_file),
+            "--qcow2",     str(qcow2_path),
+            "--mount-dir", str(mount_dir),
+            "--nbd-dev",   self.nbd_device,
+        ]
+
+        logger.info("BasaltQEMUBuilder: %s", " ".join(cmd))
+
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+
+        # Stream basalt output through our logger
+        assert proc.stdout
+        async for line in proc.stdout:
+            text = line.decode(errors="replace").rstrip()
+            if text:
+                logger.info("[basalt] %s", text)
+
+        rc = await proc.wait()
+        if rc != 0:
+            raise RuntimeError(
+                f"basalt exited with code {rc}. "
+                f"Check logs above for details. "
+                f"Step file: {step_file}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Cloud builder stubs
+# ---------------------------------------------------------------------------
+
+class QEMUCloudBuilder:
+    """Stub: cloud-side QEMU/KubeVirt VMI image builder via basalt build API.
+
+    This will POST Image layer specs to the CUA cloud build API, which
+    runs basalt against a base VM image and returns an OCI image reference
+    suitable for use as a KubeVirt containerDisk.
+
+    Not yet implemented — to be wired up once the cloud build API is available.
+    """
+
+    def __init__(self, api_key: Optional[str] = None, api_base: Optional[str] = None) -> None:
+        self.api_key = api_key
+        self.api_base = api_base or "https://api.cua.ai"
+
+    async def build(self, image: Image, *, region: str = "us-east-1") -> str:
+        """Build an image on the CUA cloud and return an OCI image ref.
+
+        Args:
+            image: Image with layers to apply.
+            region: Cloud region to run the build in.
+
+        Returns:
+            OCI image reference (e.g. ``"registry.cua.ai/builds/abc123:latest"``)
+            that can be passed as ``dockerImage`` to ``POST /v1/vms``.
+
+        Raises:
+            NotImplementedError: Always — cloud build API not yet implemented.
+        """
+        raise NotImplementedError(
+            "qemu/cloud image building is not yet available. "
+            "To launch a pre-built image as a KubeVirt VMI, use:\n"
+            "  Image.from_registry('myorg/myimage:latest').runtime('qemu/cloud')\n"
+            "Cloud build API coming soon."
+        )
+
+
+class DockerCloudBuilder:
+    """Stub: cloud-side OCI/gVisor container builder API.
+
+    Will POST Image layer specs to the CUA cloud build API, which builds
+    a Docker image and returns an OCI image reference suitable for use
+    as a gVisor/Incus container (``instanceType: container``).
+
+    Not yet implemented — to be wired up once the cloud build API is available.
+    """
+
+    def __init__(self, api_key: Optional[str] = None, api_base: Optional[str] = None) -> None:
+        self.api_key = api_key
+        self.api_base = api_base or "https://api.cua.ai"
+
+    async def build(self, image: Image, *, region: str = "us-east-1") -> str:
+        """Build a Docker image on the CUA cloud and return an OCI ref.
+
+        Args:
+            image: Image with layers to apply.
+            region: Cloud region to run the build in.
+
+        Returns:
+            OCI image reference (e.g. ``"registry.cua.ai/builds/def456:latest"``)
+            that can be passed as ``dockerImage`` to ``POST /v1/vms``
+            with ``instanceType: "container"``.
+
+        Raises:
+            NotImplementedError: Always — cloud build API not yet implemented.
+        """
+        raise NotImplementedError(
+            "docker/cloud image building is not yet available. "
+            "To launch a pre-built image as a gVisor container, use:\n"
+            "  Image.from_registry('myorg/myapp:latest').runtime('docker/cloud')\n"
+            "Cloud build API coming soon."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _file_sha256(path: Path) -> str:
+    """Compute SHA-256 hex digest of a file."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()

--- a/libs/python/cua-sandbox/cua_sandbox/builder/basalt.py
+++ b/libs/python/cua-sandbox/cua_sandbox/builder/basalt.py
@@ -1,38 +1,37 @@
-"""Basalt-backed QEMU VM builder.
+"""Basalt-backed QEMU VM builder — WASM edition.
 
-Translates ``Image`` layer specs into a basalt JSON step file and drives the
-basalt CLI to incrementally build a qcow2 disk image.  Each layer becomes a
-basalt step whose deps include the layer contents, giving free content-addressed
-caching across builds.
+Translates ``Image`` layer specs into a basalt JSON step file and drives
+**basalt-wasmtime** (the basalt build system compiled to WASM) via the
+``wasmtime`` Python package.  No external ``basalt`` binary needed — the WASM
+module is loaded in-process.
 
-Basalt handles:
-  - Mounting the qcow2 via ``qemu-nbd`` + loopback
-  - Executing steps in a ``chroot``
-  - Caching intermediate results as named qcow2-internal snapshots
-    (``basalt-{step}-{hash8}``)
-  - Restoring to the last cache-hit snapshot before executing the first miss
+The WASM module is located at one of the well-known paths below, or can be
+overridden via the ``BASALT_WASM`` environment variable.  If it is not yet
+built, ``BasaltWasmLoader`` can compile it on demand (requires a Rust
+toolchain with the ``wasm32-unknown-unknown`` target).
 
-This replaces the hand-rolled ``build.py`` implementation for the
-``qemu/local`` runtime path.
+Architecture
+------------
+The basalt-wasmtime WASM module provides a C ABI with:
+  - ``init`` — create / reset the build system
+  - ``run_pipeline(json_ptr, json_len)`` — load a step-file JSON and run all
+    targets
+  - ``result_ptr / result_len`` — read output after success
+  - ``error_ptr / error_len`` — read error message after failure
 
-Usage::
+The WASM module calls back into the Python host via three imported functions:
+  - ``host_exec(cmd_json_ptr, cmd_json_len) -> exit_code``
+  - ``host_exec_stdout_len() -> u32``
+  - ``host_exec_stdout_read(dest_ptr)``
+  - ``host_exec_stderr_len() -> u32``
+  - ``host_exec_stderr_read(dest_ptr)``
 
-    from pathlib import Path
-    from cua_sandbox.builder.basalt import BasaltQEMUBuilder
-    from cua_sandbox import Image
+For ``qemu/local``, the ``host_exec`` callback runs commands **inside the
+mounted qcow2 via chroot** (using ``qemu-nbd`` + ``chroot``), mirroring what
+the native Rust ``QemuExecutor`` does.  This requires root / sudo.
 
-    image = (
-        Image.linux("ubuntu", "24.04")
-        .apt_install("curl", "git")
-        .run("curl -LsSf https://astral.sh/uv/install.sh | sh")
-    )
-
-    builder = BasaltQEMUBuilder()
-    disk = await builder.build(image, base_qcow2=Path("/base/ubuntu-24.04.qcow2"))
-    # disk is a content-addressed qcow2 ready to boot
-
-Cloud builder stubs (``qemu/cloud``, ``docker/cloud``) are provided as
-``NotImplementedError`` placeholders to be wired up once the cloud build API
+Cloud builder stubs (``QEMUCloudBuilder``, ``DockerCloudBuilder``) are
+provided as ``NotImplementedError`` placeholders until the cloud build API
 is available.
 """
 
@@ -53,40 +52,310 @@ from cua_sandbox.image import Image
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Default paths
+# WASM module location
 # ---------------------------------------------------------------------------
 
-_IMAGES_DIR = Path.home() / ".cua" / "cua-sandbox" / "images"
-_BASALT_BIN_CANDIDATES = [
-    "basalt",                                    # on PATH
-    str(Path.home() / ".cargo" / "bin" / "basalt"),
-    "/usr/local/bin/basalt",
-    "/opt/basalt/bin/basalt",
+_BASALT_ROOT = (
+    # Expected location when cua-sandbox lives alongside the cloud repo
+    Path(__file__).resolve().parents[6] / "cloud" / "services" / "basalt"
+)
+_WASM_CRATE = _BASALT_ROOT / "crates" / "basalt-wasmtime"
+_WASM_ARTIFACT = (
+    _WASM_CRATE / "target" / "wasm32-unknown-unknown" / "release" / "basalt_wasmtime.wasm"
+)
+
+_WASM_SEARCH_PATHS: list[Path] = [
+    # User can drop a pre-built .wasm anywhere in these well-known spots
+    Path.home() / ".cua" / "basalt" / "basalt_wasmtime.wasm",
+    Path("/usr/local/lib/cua/basalt_wasmtime.wasm"),
+    Path("/opt/cua/basalt_wasmtime.wasm"),
+    _WASM_ARTIFACT,  # built from source (cargo build)
 ]
 
-
-def _find_basalt() -> str:
-    """Locate the ``basalt`` binary.  Raises ``RuntimeError`` if not found."""
-    for candidate in _BASALT_BIN_CANDIDATES:
-        if shutil.which(candidate) or Path(candidate).is_file():
-            return candidate
-    raise RuntimeError(
-        "basalt binary not found. "
-        "Install it with: cargo install --path services/basalt  "
-        "or set BASALT_BIN environment variable."
-    )
-
-
-def _basalt_bin() -> str:
-    """Return the basalt binary path, honouring ``BASALT_BIN`` env var."""
-    env_bin = os.environ.get("BASALT_BIN")
-    if env_bin:
-        return env_bin
-    return _find_basalt()
+_DEFAULT_IMAGES_DIR = Path.home() / ".cua" / "cua-sandbox" / "images"
 
 
 # ---------------------------------------------------------------------------
-# Layer → basalt step translation
+# WASM loader
+# ---------------------------------------------------------------------------
+
+class BasaltWasmLoader:
+    """Locate or build the basalt-wasmtime WASM module.
+
+    Priority:
+    1. ``BASALT_WASM`` environment variable (explicit path)
+    2. Well-known search paths (pre-built artifact)
+    3. Build on demand via ``cargo build --target wasm32-unknown-unknown``
+       (requires Rust + wasm32 target installed)
+    """
+
+    @classmethod
+    def load(cls, build_if_missing: bool = True) -> Path:
+        """Return the path to a usable basalt_wasmtime.wasm.
+
+        Args:
+            build_if_missing: If True, attempt to build the WASM module from
+                source when no pre-built artifact is found.
+
+        Returns:
+            Path to the ``.wasm`` file.
+
+        Raises:
+            RuntimeError: If the module cannot be found or built.
+        """
+        env_path = os.environ.get("BASALT_WASM")
+        if env_path:
+            p = Path(env_path)
+            if p.is_file():
+                return p
+            raise RuntimeError(
+                f"BASALT_WASM env var points to non-existent file: {p}"
+            )
+
+        for candidate in _WASM_SEARCH_PATHS:
+            if candidate.is_file():
+                logger.debug("BasaltWasmLoader: found WASM at %s", candidate)
+                return candidate
+
+        if build_if_missing:
+            return cls._build()
+
+        raise RuntimeError(
+            "basalt-wasmtime WASM module not found. "
+            "Options:\n"
+            "  1. Set BASALT_WASM=/path/to/basalt_wasmtime.wasm\n"
+            "  2. Run: cd services/basalt/crates/basalt-wasmtime && "
+            "cargo build --target wasm32-unknown-unknown --release\n"
+            "  3. pip install wasmtime and let BasaltWasmLoader build it automatically\n"
+        )
+
+    @classmethod
+    def _build(cls) -> Path:
+        """Build basalt-wasmtime via cargo."""
+        if not shutil.which("cargo"):
+            raise RuntimeError(
+                "cargo not found — cannot build basalt-wasmtime. "
+                "Install Rust from https://rustup.rs/ then run:\n"
+                "  rustup target add wasm32-unknown-unknown"
+            )
+
+        if not _WASM_CRATE.is_dir():
+            raise RuntimeError(
+                f"basalt-wasmtime crate not found at {_WASM_CRATE}. "
+                "Clone the cloud repo alongside cua-sandbox."
+            )
+
+        logger.info(
+            "BasaltWasmLoader: building basalt-wasmtime WASM "
+            "(first run may take ~30s)…"
+        )
+        result = subprocess.run(
+            [
+                "cargo", "build",
+                "--target", "wasm32-unknown-unknown",
+                "--release",
+            ],
+            cwd=str(_WASM_CRATE),
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"cargo build failed:\n{result.stderr}"
+            )
+
+        if not _WASM_ARTIFACT.is_file():
+            raise RuntimeError(
+                f"cargo build succeeded but artifact not found at {_WASM_ARTIFACT}"
+            )
+
+        logger.info("BasaltWasmLoader: built → %s", _WASM_ARTIFACT)
+        return _WASM_ARTIFACT
+
+
+# ---------------------------------------------------------------------------
+# Wasmtime executor
+# ---------------------------------------------------------------------------
+
+class _BasaltWasmRunner:
+    """Low-level wrapper around the basalt-wasmtime WASM module.
+
+    Instantiates the module with wasmtime-py and exposes a single
+    ``run_pipeline(step_file_dict)`` method.
+
+    The ``host_exec_fn`` callback is called for every command that basalt
+    wants to execute.  For ``qemu/local`` it runs commands inside a chroot;
+    for tests it can be replaced with any callable.
+
+    Args:
+        wasm_path: Path to the basalt_wasmtime.wasm module.
+        host_exec_fn: ``(cmd: dict) -> (exit_code: int, stdout: bytes, stderr: bytes)``
+    """
+
+    def __init__(
+        self,
+        wasm_path: Path,
+        host_exec_fn: Any,
+    ) -> None:
+        try:
+            import wasmtime as wt
+        except ImportError:
+            raise ImportError(
+                "wasmtime-py is required for WASM-based basalt builds. "
+                "Install it with: pip install wasmtime"
+            ) from None
+
+        self._wt = wt
+        self._wasm_path = wasm_path
+        self._host_exec_fn = host_exec_fn
+        self._instance = None
+        self._store = None
+
+    def _build_instance(self) -> tuple:
+        """Instantiate the WASM module with the host imports wired up."""
+        wt = self._wt
+
+        engine = wt.Engine()
+        store = wt.Store(engine)
+        module = wt.Module.from_file(engine, str(self._wasm_path))
+        linker = wt.Linker(engine)
+
+        # Host-side buffers for the most recent exec's output
+        last_stdout: list[bytes] = [b""]
+        last_stderr: list[bytes] = [b""]
+        host_exec_fn = self._host_exec_fn
+
+        def host_exec(caller, cmd_json_ptr: int, cmd_json_len: int) -> int:
+            mem = caller["memory"]
+            raw = mem.read(caller, cmd_json_ptr, cmd_json_ptr + cmd_json_len)
+            cmd: dict = json.loads(raw)
+            try:
+                rc, stdout, stderr = host_exec_fn(cmd)
+                last_stdout[0] = stdout if isinstance(stdout, bytes) else stdout.encode()
+                last_stderr[0] = stderr if isinstance(stderr, bytes) else stderr.encode()
+                return rc
+            except Exception as exc:
+                last_stdout[0] = b""
+                last_stderr[0] = str(exc).encode()
+                return 1
+
+        def host_exec_stdout_len(_caller) -> int:
+            return len(last_stdout[0])
+
+        def host_exec_stdout_read(caller, dest_ptr: int) -> None:
+            caller["memory"].write(caller, last_stdout[0], dest_ptr)
+
+        def host_exec_stderr_len(_caller) -> int:
+            return len(last_stderr[0])
+
+        def host_exec_stderr_read(caller, dest_ptr: int) -> None:
+            caller["memory"].write(caller, last_stderr[0], dest_ptr)
+
+        i32 = wt.ValType.i32()
+        linker.define_func("env", "host_exec",
+            wt.FuncType([i32, i32], [i32]), host_exec, access_caller=True)
+        linker.define_func("env", "host_exec_stdout_len",
+            wt.FuncType([], [i32]), host_exec_stdout_len, access_caller=True)
+        linker.define_func("env", "host_exec_stdout_read",
+            wt.FuncType([i32], []), host_exec_stdout_read, access_caller=True)
+        linker.define_func("env", "host_exec_stderr_len",
+            wt.FuncType([], [i32]), host_exec_stderr_len, access_caller=True)
+        linker.define_func("env", "host_exec_stderr_read",
+            wt.FuncType([i32], []), host_exec_stderr_read, access_caller=True)
+
+        instance = linker.instantiate(store, module)
+        return store, instance
+
+    def run_pipeline(self, step_file: Dict[str, Any]) -> Dict[str, Any]:
+        """Run a basalt pipeline from a step-file dict.
+
+        Args:
+            step_file: Dict matching the basalt step-file JSON schema
+                (``{"targets": [...], "steps": {...}}``).
+
+        Returns:
+            Dict with ``success: bool``, ``output: str``, ``error: str``.
+        """
+        store, instance = self._build_instance()
+        exports = instance.exports(store)
+
+        json_bytes = json.dumps(step_file).encode()
+        json_ptr: int = exports["alloc"](store, len(json_bytes))
+        exports["memory"].write(store, json_bytes, json_ptr)
+
+        rc: int = exports["run_pipeline"](store, json_ptr, len(json_bytes))
+        exports["dealloc"](store, json_ptr, len(json_bytes))
+
+        if rc == 0:
+            rptr = exports["result_ptr"](store)
+            rlen = exports["result_len"](store)
+            output = ""
+            if rlen > 0:
+                output = exports["memory"].read(store, rptr, rptr + rlen).decode(
+                    errors="replace"
+                )
+            return {"success": True, "output": output, "error": ""}
+        else:
+            eptr = exports["error_ptr"](store)
+            elen = exports["error_len"](store)
+            error = ""
+            if elen > 0:
+                error = exports["memory"].read(store, eptr, eptr + elen).decode(
+                    errors="replace"
+                )
+            return {"success": False, "output": "", "error": error}
+
+
+# ---------------------------------------------------------------------------
+# Chroot host_exec — runs commands inside a mounted qcow2 rootfs
+# ---------------------------------------------------------------------------
+
+def _make_chroot_exec_fn(mount_dir: Path):
+    """Return a ``host_exec_fn`` that runs commands via ``chroot`` into *mount_dir*.
+
+    Used for ``qemu/local`` builds where the qcow2 is already mounted at
+    *mount_dir* by the caller.
+
+    Commands arriving from basalt are ``CommandSpec`` dicts:
+    ``{"program": "...", "args": [...], "env": [[k, v], ...], "cwd": "..."}``
+    """
+
+    def host_exec(cmd: dict) -> tuple[int, bytes, bytes]:
+        program = cmd.get("program", "")
+        args = cmd.get("args", [])
+        env_pairs: list = cmd.get("env", [])
+        cwd: str = cmd.get("cwd") or "/"
+
+        # Build the full command to run inside the chroot
+        # We use: chroot <mount_dir> /usr/bin/env <env pairs...> <program> <args...>
+        env_prefix = [f"{k}={v}" for k, v in env_pairs]
+        chroot_cmd = [
+            "chroot", str(mount_dir),
+            "/usr/bin/env", *env_prefix, program, *args,
+        ]
+
+        logger.debug("chroot exec: %s", " ".join(chroot_cmd))
+
+        try:
+            proc = subprocess.run(
+                chroot_cmd,
+                capture_output=True,
+                timeout=600,
+            )
+            return proc.returncode, proc.stdout, proc.stderr
+        except FileNotFoundError:
+            msg = f"command not found in chroot: {program}".encode()
+            return 127, b"", msg
+        except subprocess.TimeoutExpired:
+            return 1, b"", b"command timed out"
+        except Exception as exc:
+            return 1, b"", str(exc).encode()
+
+    return host_exec
+
+
+# ---------------------------------------------------------------------------
+# Layer → basalt step-file translation
 # ---------------------------------------------------------------------------
 
 def _layers_to_basalt_steps(
@@ -97,10 +366,11 @@ def _layers_to_basalt_steps(
 
     Each layer becomes a named step whose ``run`` command applies the layer
     inside the chroot.  Step ``n+1`` depends on step ``n``, giving a
-    sequential build chain.
+    sequential build chain.  A content-hash dep is added per step so any
+    change to a layer's spec automatically invalidates the basalt cache.
 
-    The returned dict is ready to be serialised to JSON and passed to the
-    basalt CLI.
+    The returned dict is ready to be passed to ``_BasaltWasmRunner.run_pipeline``
+    or serialised to JSON.
     """
     steps: Dict[str, Any] = {}
     prev_step: Optional[str] = None
@@ -109,21 +379,24 @@ def _layers_to_basalt_steps(
         lt = layer["type"]
         step_name = f"layer-{i:03d}-{lt}"
 
-        cmd = _layer_to_shell(layer, os_type)
-        if cmd is None:
-            # Layer has no shell equivalent (e.g. expose) — insert a no-op
-            cmd = "true"
+        shell_cmd = _layer_to_shell(layer, os_type)
+        if shell_cmd is None:
+            shell_cmd = "true"
+
+        # Encode the step as a basalt CommandSpec (program + args)
+        run_spec: Dict[str, Any] = {
+            "program": "/bin/sh",
+            "args": ["-c", shell_cmd],
+        }
 
         deps: List[Dict[str, Any]] = []
         if prev_step:
             deps.append({"type": "step", "name": prev_step})
 
-        # Hash the layer spec itself as a content dep so any change invalidates
-        # the cache without needing a file on disk.
+        # Content-address the layer spec so cache is invalidated on any change
         layer_hash = hashlib.sha256(
             json.dumps(layer, sort_keys=True).encode()
         ).hexdigest()[:16]
-        # Use a known-stable no-op command whose output encodes the layer hash
         deps.append({
             "type": "exec_output",
             "program": "echo",
@@ -131,7 +404,7 @@ def _layers_to_basalt_steps(
         })
 
         steps[step_name] = {
-            "run": cmd if isinstance(cmd, list) else [{"program": "sh", "args": ["-c", cmd]}],
+            "run": run_spec,
             "deps": deps,
         }
         prev_step = step_name
@@ -163,7 +436,7 @@ def _layer_to_shell(layer: Dict[str, Any], os_type: str) -> Optional[str]:
         return (
             f"command -v uv >/dev/null 2>&1 || "
             f"(curl -LsSf https://astral.sh/uv/install.sh | sh && "
-            f"export PATH=\"$HOME/.cargo/bin:$HOME/.local/bin:$PATH\") && "
+            f'export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH") && '
             f"uv pip install --system {pkgs}"
         )
 
@@ -175,6 +448,7 @@ def _layer_to_shell(layer: Dict[str, Any], os_type: str) -> Optional[str]:
         variables = layer.get("variables", {})
         if not variables:
             return "true"
+        # Write each variable to /etc/environment (persistent across boots)
         lines = "\n".join(
             f"printf '%s=%s\\n' '{k}' '{v}' >> /etc/environment"
             for k, v in variables.items()
@@ -182,12 +456,78 @@ def _layer_to_shell(layer: Dict[str, Any], os_type: str) -> Optional[str]:
         return lines
 
     if lt in ("expose", "apk_install", "pwa_install", "app_install"):
-        # Not meaningful inside a chroot builder — skip (no-op)
+        # Not meaningful inside a chroot builder — no-op
         return "true"
 
-    # Unknown layer type — let basalt run a no-op so the build doesn't fail
     logger.warning("BasaltQEMUBuilder: unknown layer type %r — inserting no-op", lt)
     return "true"
+
+
+# ---------------------------------------------------------------------------
+# Disk helpers
+# ---------------------------------------------------------------------------
+
+def _qemu_img_bin() -> str:
+    found = shutil.which("qemu-img")
+    if found:
+        return found
+    raise RuntimeError(
+        "qemu-img not found. Install qemu-utils (Ubuntu) or qemu (macOS via Homebrew)."
+    )
+
+
+def _file_sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _mount_qcow2(qcow2_path: Path, mount_dir: Path, nbd_device: str) -> None:
+    """Mount a qcow2 via qemu-nbd + kpartx + mount (requires root/sudo)."""
+    mount_dir.mkdir(parents=True, exist_ok=True)
+
+    subprocess.run(["modprobe", "nbd", "max_part=8"], check=True, capture_output=True)
+    subprocess.run(
+        ["qemu-nbd", "--connect", nbd_device, str(qcow2_path)],
+        check=True, capture_output=True,
+    )
+
+    # Give the kernel time to populate partition devices
+    import time; time.sleep(0.5)
+
+    # Try common root partition suffixes (p1, p2)
+    root_part = None
+    for suffix in ["p2", "p1"]:
+        candidate = f"{nbd_device}{suffix}"
+        if Path(candidate).exists():
+            root_part = candidate
+            break
+    if not root_part:
+        root_part = f"{nbd_device}p1"  # fall back
+
+    subprocess.run(
+        ["mount", root_part, str(mount_dir)],
+        check=True, capture_output=True,
+    )
+    # Bind-mount /dev, /proc, /sys for commands that need them
+    for pseudo in ["dev", "proc", "sys"]:
+        subprocess.run(
+            ["mount", "--bind", f"/{pseudo}", str(mount_dir / pseudo)],
+            check=True, capture_output=True,
+        )
+
+
+def _umount_qcow2(mount_dir: Path, nbd_device: str) -> None:
+    """Unmount a qcow2 (best-effort; ignores errors)."""
+    for pseudo in ["sys", "proc", "dev"]:
+        subprocess.run(
+            ["umount", str(mount_dir / pseudo)],
+            capture_output=True,
+        )
+    subprocess.run(["umount", str(mount_dir)], capture_output=True)
+    subprocess.run(["qemu-nbd", "--disconnect", nbd_device], capture_output=True)
 
 
 # ---------------------------------------------------------------------------
@@ -195,40 +535,39 @@ def _layer_to_shell(layer: Dict[str, Any], os_type: str) -> Optional[str]:
 # ---------------------------------------------------------------------------
 
 class BasaltQEMUBuilder:
-    """Incrementally build a qcow2 VM disk using basalt.
+    """Incrementally build a qcow2 VM disk using basalt via WASM.
 
-    The builder:
-    1. Copies the base qcow2 to a working path (if needed)
-    2. Generates a basalt JSON step file from ``image._layers``
-    3. Invokes the ``basalt`` CLI in qemu mode
-    4. Returns the path to the built qcow2
-
-    The output disk is content-addressed by (base_hash, layers_hash) and
-    cached at ``~/.cua/cua-sandbox/images/basalt-{hash}.qcow2``.  Subsequent
-    calls with identical inputs return the cached disk immediately.
+    Uses the basalt-wasmtime WASM module (loaded in-process via ``wasmtime``)
+    rather than shelling out to a ``basalt`` CLI binary.  The WASM module is
+    the portable, in-process build system; the Python host provides
+    ``host_exec`` callbacks that run commands inside the mounted qcow2 via
+    ``qemu-nbd`` + ``chroot``.
 
     Args:
         nbd_device: NBD device to use for qcow2 mounting (default ``/dev/nbd0``).
             Requires the ``nbd`` kernel module and root / sudo.
         images_dir: Directory to store built images (default
             ``~/.cua/cua-sandbox/images``).
+        wasm_path: Explicit path to the basalt_wasmtime.wasm module.
+            Defaults to auto-discovery via :class:`BasaltWasmLoader`.
     """
 
     def __init__(
         self,
         nbd_device: str = "/dev/nbd0",
         images_dir: Optional[Path] = None,
+        wasm_path: Optional[Path] = None,
     ) -> None:
         self.nbd_device = nbd_device
-        self.images_dir = images_dir or _IMAGES_DIR
+        self.images_dir = images_dir or _DEFAULT_IMAGES_DIR
         self.images_dir.mkdir(parents=True, exist_ok=True)
+        self._wasm_path = wasm_path  # None = auto-discover at build time
 
     def _output_key(self, image: Image, base_qcow2: Path) -> str:
         """Compute a content-based cache key for this (image, base) combination."""
-        from cua_sandbox.builder.overlay import layers_hash
-
         base_hash = _file_sha256(base_qcow2)[:16]
-        layer_hash = layers_hash(list(image._layers))[:16] if image._layers else "nolayers"
+        layers_json = json.dumps(list(image._layers), sort_keys=True).encode()
+        layer_hash = hashlib.sha256(layers_json).hexdigest()[:16] if image._layers else "nolayers"
         return f"{base_hash}-{layer_hash}"
 
     async def build(
@@ -240,14 +579,14 @@ class BasaltQEMUBuilder:
     ) -> Path:
         """Build a qcow2 from *image* layers on top of *base_qcow2*.
 
-        Returns the path to the built disk (may be *base_qcow2* itself if
-        the image has no layers).
+        Uses basalt-wasmtime (in-process WASM) to apply layers incrementally.
+        The WASM module calls ``host_exec`` for each command, which runs the
+        command inside the mounted qcow2 via ``chroot``.
 
-        If the output disk already exists and *force* is False, the cached
-        disk is returned immediately without re-running basalt.
-
-        Requires the ``basalt`` binary and root permissions for qemu-nbd /
-        chroot (or a suitably configured sudo).
+        Requires:
+          - ``wasmtime`` Python package (``pip install wasmtime``)
+          - ``qemu-nbd`` / ``nbd`` kernel module
+          - Root / sudo (for ``modprobe nbd``, ``qemu-nbd``, ``mount``, ``chroot``)
 
         Args:
             image: The Image whose layers to apply.
@@ -276,84 +615,58 @@ class BasaltQEMUBuilder:
             len(image._layers), base_qcow2, out_disk,
         )
 
-        # Make a working copy of the base — basalt will modify it in-place
+        # Locate the WASM module (auto-build if necessary)
+        wasm_path = self._wasm_path or BasaltWasmLoader.load()
+
+        # Make a working copy of the base — we mount and modify it in-place
         work_disk = self.images_dir / f"basalt-work-{cache_key}.qcow2"
         shutil.copy2(str(base_qcow2), str(work_disk))
 
-        # Generate step file
-        step_data = _layers_to_basalt_steps(list(image._layers), image.os_type)
-
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            suffix=".basalt.json",
-            delete=False,
-            dir=self.images_dir,
-        ) as f:
-            json.dump(step_data, f, indent=2)
-            step_file = Path(f.name)
-
         mount_dir = self.images_dir / f"mnt-{cache_key}"
-        mount_dir.mkdir(parents=True, exist_ok=True)
 
         try:
-            await self._run_basalt(step_file, work_disk, mount_dir)
+            # Mount the working qcow2
+            _mount_qcow2(work_disk, mount_dir, self.nbd_device)
+            logger.info("BasaltQEMUBuilder: mounted %s at %s", work_disk, mount_dir)
+
+            # Build the step file from image layers
+            step_file = _layers_to_basalt_steps(list(image._layers), image.os_type)
+
+            # Create the WASM runner with a chroot host_exec callback
+            host_exec_fn = _make_chroot_exec_fn(mount_dir)
+            runner = _BasaltWasmRunner(wasm_path, host_exec_fn)
+
+            logger.info(
+                "BasaltQEMUBuilder: running pipeline via basalt-wasmtime (%s)",
+                wasm_path.name,
+            )
+            result = runner.run_pipeline(step_file)
+
+            if not result["success"]:
+                raise RuntimeError(
+                    f"basalt pipeline failed: {result['error']}\n"
+                    f"WASM module: {wasm_path}"
+                )
+
+            logger.info("BasaltQEMUBuilder: pipeline complete")
+
         except Exception:
-            # Clean up partial output on failure
+            _umount_qcow2(mount_dir, self.nbd_device)
             work_disk.unlink(missing_ok=True)
             raise
-        finally:
-            step_file.unlink(missing_ok=True)
-            # Best-effort cleanup of mount point
-            try:
-                mount_dir.rmdir()
-            except OSError:
-                pass
+        else:
+            _umount_qcow2(mount_dir, self.nbd_device)
+
+        # Clean up mount point
+        try:
+            mount_dir.rmdir()
+        except OSError:
+            pass
 
         # Rename work disk to cache key on success
         work_disk.rename(out_disk)
         logger.info("BasaltQEMUBuilder: built → %s", out_disk)
         return out_disk
-
-    async def _run_basalt(
-        self,
-        step_file: Path,
-        qcow2_path: Path,
-        mount_dir: Path,
-    ) -> None:
-        """Invoke the basalt CLI in qemu mode and stream output to logger."""
-        import asyncio
-
-        bin_path = _basalt_bin()
-        cmd = [
-            bin_path,
-            str(step_file),
-            "--qcow2",     str(qcow2_path),
-            "--mount-dir", str(mount_dir),
-            "--nbd-dev",   self.nbd_device,
-        ]
-
-        logger.info("BasaltQEMUBuilder: %s", " ".join(cmd))
-
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-        )
-
-        # Stream basalt output through our logger
-        assert proc.stdout
-        async for line in proc.stdout:
-            text = line.decode(errors="replace").rstrip()
-            if text:
-                logger.info("[basalt] %s", text)
-
-        rc = await proc.wait()
-        if rc != 0:
-            raise RuntimeError(
-                f"basalt exited with code {rc}. "
-                f"Check logs above for details. "
-                f"Step file: {step_file}"
-            )
 
 
 # ---------------------------------------------------------------------------
@@ -363,9 +676,9 @@ class BasaltQEMUBuilder:
 class QEMUCloudBuilder:
     """Stub: cloud-side QEMU/KubeVirt VMI image builder via basalt build API.
 
-    This will POST Image layer specs to the CUA cloud build API, which
-    runs basalt against a base VM image and returns an OCI image reference
-    suitable for use as a KubeVirt containerDisk.
+    Will POST Image layer specs to the CUA cloud build API, which runs basalt
+    (WASM) against a base VM image and returns an OCI image reference suitable
+    for use as a KubeVirt containerDisk.
 
     Not yet implemented — to be wired up once the cloud build API is available.
     """
@@ -376,14 +689,6 @@ class QEMUCloudBuilder:
 
     async def build(self, image: Image, *, region: str = "us-east-1") -> str:
         """Build an image on the CUA cloud and return an OCI image ref.
-
-        Args:
-            image: Image with layers to apply.
-            region: Cloud region to run the build in.
-
-        Returns:
-            OCI image reference (e.g. ``"registry.cua.ai/builds/abc123:latest"``)
-            that can be passed as ``dockerImage`` to ``POST /v1/vms``.
 
         Raises:
             NotImplementedError: Always — cloud build API not yet implemented.
@@ -399,9 +704,9 @@ class QEMUCloudBuilder:
 class DockerCloudBuilder:
     """Stub: cloud-side OCI/gVisor container builder API.
 
-    Will POST Image layer specs to the CUA cloud build API, which builds
-    a Docker image and returns an OCI image reference suitable for use
-    as a gVisor/Incus container (``instanceType: container``).
+    Will POST Image layer specs to the CUA cloud build API, which builds a
+    Docker image and returns an OCI image reference suitable for use as a
+    gVisor/Incus container (``instanceType: container``).
 
     Not yet implemented — to be wired up once the cloud build API is available.
     """
@@ -413,15 +718,6 @@ class DockerCloudBuilder:
     async def build(self, image: Image, *, region: str = "us-east-1") -> str:
         """Build a Docker image on the CUA cloud and return an OCI ref.
 
-        Args:
-            image: Image with layers to apply.
-            region: Cloud region to run the build in.
-
-        Returns:
-            OCI image reference (e.g. ``"registry.cua.ai/builds/def456:latest"``)
-            that can be passed as ``dockerImage`` to ``POST /v1/vms``
-            with ``instanceType: "container"``.
-
         Raises:
             NotImplementedError: Always — cloud build API not yet implemented.
         """
@@ -431,16 +727,3 @@ class DockerCloudBuilder:
             "  Image.from_registry('myorg/myapp:latest').runtime('docker/cloud')\n"
             "Cloud build API coming soon."
         )
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _file_sha256(path: Path) -> str:
-    """Compute SHA-256 hex digest of a file."""
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(1 << 20), b""):
-            h.update(chunk)
-    return h.hexdigest()

--- a/libs/python/cua-sandbox/cua_sandbox/image.py
+++ b/libs/python/cua-sandbox/cua_sandbox/image.py
@@ -121,6 +121,10 @@ class Image:
     _disk_path: Optional[str] = None  # local disk file path (qcow2, vhdx, raw)
     _agent_type: Optional[str] = None  # e.g. "osworld" for OSWorld Flask server
     _snapshot_source: Optional[Dict[str, Any]] = None  # set by Sandbox.snapshot()
+    # Runtime hint — set via .runtime("qemu/cloud") etc.  Format: "<engine>/<location>"
+    # engine:   "qemu" | "oci"
+    # location: "cloud" | "local"
+    _runtime_hint: Optional[str] = None
 
     # ── Constructors ─────────────────────────────────────────────────────
 
@@ -199,6 +203,7 @@ class Image:
             version=data["version"],
             kind=data.get("kind"),
             _registry=data.get("registry"),
+            _runtime_hint=data.get("runtime_hint"),
         )
         # Replay layers
         for layer in data.get("layers", []):
@@ -236,6 +241,7 @@ class Image:
             _disk_path=self._disk_path,
             _agent_type=self._agent_type,
             _snapshot_source=self._snapshot_source,
+            _runtime_hint=self._runtime_hint,
         )
 
     def _with(self, **kwargs) -> Image:
@@ -253,9 +259,67 @@ class Image:
             "_disk_path": self._disk_path,
             "_agent_type": self._agent_type,
             "_snapshot_source": self._snapshot_source,
+            "_runtime_hint": self._runtime_hint,
         }
         fields.update(kwargs)
         return Image(**fields)
+
+    # Valid runtime hints
+    _VALID_RUNTIME_HINTS: Tuple[str, ...] = ("qemu/cloud", "qemu/local", "oci/cloud", "oci/local")
+
+    def runtime(self, hint: str) -> "Image":
+        """Pin the execution engine and deployment location for this image.
+
+        Format: ``"<engine>/<location>"``
+
+        Engines:
+          * ``"qemu"``  — QEMU/KVM virtualisation (full VM, hardware-level isolation)
+          * ``"oci"``   — OCI/Docker container runtime (process-level isolation)
+
+        Locations:
+          * ``"cloud"`` — run on the CUA cloud (remote provisioning via POST /v1/vms)
+          * ``"local"`` — run on the local host machine
+
+        Examples::
+
+            # Cloud VMI (KubeVirt containerDisk) — default for from_registry()
+            image = Image.from_registry("myorg/myimage:latest").runtime("qemu/cloud")
+
+            # Cloud container (gVisor/Incus)
+            image = Image.from_registry("myorg/myapp:latest").runtime("oci/cloud")
+
+            # Local QEMU VM
+            image = Image.from_registry("myorg/myimage:latest").runtime("qemu/local")
+
+            # Local OCI container
+            image = Image.from_registry("myorg/myapp:latest").runtime("oci/local")
+
+        When the location is ``"cloud"``, :meth:`Sandbox.create` routes to the
+        CUA cloud API regardless of the ``local=`` parameter.  When the location
+        is ``"local"``, the image runs on the current host.
+
+        For QEMU images the engine also determines the ``instanceType`` sent to
+        the cloud API: ``"qemu"`` → ``"vm"`` (KubeVirt VMI),
+        ``"oci"`` → ``"container"`` (gVisor/Incus container).
+
+        Args:
+            hint: Runtime hint string in ``"<engine>/<location>"`` format.
+
+        Returns:
+            A new :class:`Image` with the runtime hint set.
+
+        Raises:
+            ValueError: If ``hint`` is not one of the recognised values.
+        """
+        if hint not in self._VALID_RUNTIME_HINTS:
+            valid_str = ", ".join(f'"{v}"' for v in self._VALID_RUNTIME_HINTS)
+            raise ValueError(
+                f"Unknown runtime hint {hint!r}. Valid values: {valid_str}"
+            )
+        # Derive kind from the engine part so _auto_runtime() can use it.
+        engine, location = hint.split("/", 1)
+        derived_kind = "vm" if engine == "qemu" else "container"
+        return self._with(_runtime_hint=hint, kind=derived_kind)
 
     def apt_install(self, *packages: str) -> Image:
         """Install packages via apt (Linux only)."""
@@ -390,6 +454,8 @@ class Image:
             d["files"] = [list(f) for f in self._files]
         if self._registry:
             d["registry"] = self._registry
+        if self._runtime_hint:
+            d["runtime_hint"] = self._runtime_hint
         return d
 
     def to_cloud_init(self) -> str:
@@ -473,7 +539,8 @@ class Image:
 
     def __repr__(self) -> str:
         reg = f", registry={self._registry!r}" if self._registry else ""
+        hint = f", runtime={self._runtime_hint!r}" if self._runtime_hint else ""
         return (
             f"Image({self.os_type}/{self.distro}:{self.version}, "
-            f"kind={self.kind}, {len(self._layers)} layers{reg})"
+            f"kind={self.kind}, {len(self._layers)} layers{reg}{hint})"
         )

--- a/libs/python/cua-sandbox/cua_sandbox/image.py
+++ b/libs/python/cua-sandbox/cua_sandbox/image.py
@@ -264,8 +264,22 @@ class Image:
         fields.update(kwargs)
         return Image(**fields)
 
-    # Valid runtime hints
-    _VALID_RUNTIME_HINTS: Tuple[str, ...] = ("qemu/cloud", "qemu/local", "oci/cloud", "oci/local")
+    # Valid runtime hints — format: "<engine>/<location>"
+    # "oci/local" and "oci/cloud" are retained as aliases for backward compat.
+    _VALID_RUNTIME_HINTS: Tuple[str, ...] = (
+        "qemu/cloud",
+        "qemu/local",
+        "docker/cloud",
+        "docker/local",
+        # Aliases kept for backward compat
+        "oci/cloud",
+        "oci/local",
+    )
+    # Canonical forms for the aliases above (resolved in .runtime())
+    _HINT_ALIASES: Dict[str, str] = {
+        "oci/cloud": "docker/cloud",
+        "oci/local": "docker/local",
+    }
 
     def runtime(self, hint: str) -> "Image":
         """Pin the execution engine and deployment location for this image.
@@ -273,53 +287,71 @@ class Image:
         Format: ``"<engine>/<location>"``
 
         Engines:
-          * ``"qemu"``  — QEMU/KVM virtualisation (full VM, hardware-level isolation)
-          * ``"oci"``   — OCI/Docker container runtime (process-level isolation)
+          * ``"qemu"``   — QEMU/KVM virtualisation via basalt (full VM, local) or
+                           KubeVirt VMI (cloud)
+          * ``"docker"`` — Docker/OCI container runtime; ``DockerRuntime`` locally,
+                           gVisor/Incus on cloud (aliases: ``"oci/…"``)
 
         Locations:
           * ``"cloud"`` — run on the CUA cloud (remote provisioning via POST /v1/vms)
           * ``"local"`` — run on the local host machine
 
+        Accepted values (aliases in parentheses):
+
+        +-----------------+--------------------------------------------+
+        | hint            | maps to                                    |
+        +=================+============================================+
+        | ``qemu/cloud``  | KubeVirt VMI (instanceType: ``"vm"``)      |
+        +-----------------+--------------------------------------------+
+        | ``qemu/local``  | basalt + QEMUBaremetalRuntime              |
+        +-----------------+--------------------------------------------+
+        | ``docker/cloud``| gVisor/Incus (instanceType: ``"container"``)|
+        | (``oci/cloud``) |                                            |
+        +-----------------+--------------------------------------------+
+        | ``docker/local``| DockerRuntime                              |
+        | (``oci/local``) |                                            |
+        +-----------------+--------------------------------------------+
+
         Examples::
 
-            # Cloud VMI (KubeVirt containerDisk) — default for from_registry()
+            # Cloud VMI (KubeVirt containerDisk)
             image = Image.from_registry("myorg/myimage:latest").runtime("qemu/cloud")
 
             # Cloud container (gVisor/Incus)
-            image = Image.from_registry("myorg/myapp:latest").runtime("oci/cloud")
+            image = Image.from_registry("myorg/myapp:latest").runtime("docker/cloud")
 
-            # Local QEMU VM
+            # Local QEMU VM (built via basalt)
             image = Image.from_registry("myorg/myimage:latest").runtime("qemu/local")
 
-            # Local OCI container
-            image = Image.from_registry("myorg/myapp:latest").runtime("oci/local")
-
-        When the location is ``"cloud"``, :meth:`Sandbox.create` routes to the
-        CUA cloud API regardless of the ``local=`` parameter.  When the location
-        is ``"local"``, the image runs on the current host.
-
-        For QEMU images the engine also determines the ``instanceType`` sent to
-        the cloud API: ``"qemu"`` → ``"vm"`` (KubeVirt VMI),
-        ``"oci"`` → ``"container"`` (gVisor/Incus container).
+            # Local Docker container
+            image = Image.from_registry("myorg/myapp:latest").runtime("docker/local")
 
         Args:
-            hint: Runtime hint string in ``"<engine>/<location>"`` format.
+            hint: Runtime hint string. ``"oci/…"`` is accepted as an alias for
+                ``"docker/…"`` for backward compatibility.
 
         Returns:
-            A new :class:`Image` with the runtime hint set.
+            A new :class:`Image` with the runtime hint set (normalised to
+            canonical form).
 
         Raises:
             ValueError: If ``hint`` is not one of the recognised values.
         """
         if hint not in self._VALID_RUNTIME_HINTS:
-            valid_str = ", ".join(f'"{v}"' for v in self._VALID_RUNTIME_HINTS)
+            # Build a user-friendly list of the canonical (non-alias) hints
+            canonical = [h for h in self._VALID_RUNTIME_HINTS if h not in self._HINT_ALIASES]
+            valid_str = ", ".join(f'"{v}"' for v in canonical)
             raise ValueError(
-                f"Unknown runtime hint {hint!r}. Valid values: {valid_str}"
+                f"Unknown runtime hint {hint!r}. "
+                f"Valid values: {valid_str} "
+                f"(aliases: \"oci/cloud\" → \"docker/cloud\", \"oci/local\" → \"docker/local\")"
             )
+        # Normalise aliases to canonical form
+        canonical_hint = self._HINT_ALIASES.get(hint, hint)
         # Derive kind from the engine part so _auto_runtime() can use it.
-        engine, location = hint.split("/", 1)
+        engine = canonical_hint.split("/", 1)[0]
         derived_kind = "vm" if engine == "qemu" else "container"
-        return self._with(_runtime_hint=hint, kind=derived_kind)
+        return self._with(_runtime_hint=canonical_hint, kind=derived_kind)
 
     def apt_install(self, *packages: str) -> Image:
         """Install packages via apt (Linux only)."""

--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -129,8 +129,21 @@ class _ConnectResult:
 
 
 def _auto_runtime(image: Image) -> "Runtime":
-    """Pick a runtime automatically based on image.os_type and image.kind."""
+    """Pick a runtime automatically based on image._runtime_hint, os_type, and kind."""
     import platform as _plat
+
+    # Honor an explicit runtime hint set via image.runtime("engine/location").
+    # Only the "local" hints reach this function — "/cloud" hints are handled
+    # upstream in _create() before _auto_runtime is called.
+    hint = getattr(image, "_runtime_hint", None)
+    if hint == "qemu/local":
+        from cua_sandbox.runtime.qemu import QEMUBaremetalRuntime
+
+        return QEMUBaremetalRuntime()
+    if hint == "oci/local":
+        from cua_sandbox.runtime.docker import DockerRuntime
+
+        return DockerRuntime(ephemeral=True)
 
     if image.kind is None:
         raise ValueError(
@@ -1038,6 +1051,18 @@ class Sandbox:
             await sb._connect()
             _record_sandbox_create(sb, image=None, local=local, ephemeral=False, t_start=_t_start)
             return sb
+
+        # A runtime hint of "**/cloud" always routes to the CUA cloud, even
+        # when the caller passed local=True.  A hint of "**/local" always stays
+        # on the local host.  Without a hint the existing local/cloud logic
+        # applies unchanged.
+        _runtime_hint = getattr(image, "_runtime_hint", None) if image else None
+        if _runtime_hint:
+            _hint_location = _runtime_hint.split("/", 1)[-1]  # "cloud" or "local"
+            if _hint_location == "cloud":
+                local = False  # force cloud path
+            elif _hint_location == "local":
+                local = True   # force local path
 
         if image and not runtime and local:
             # local=True with no runtime → auto-select based on image type

--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -128,6 +128,45 @@ class _ConnectResult:
             await self._instance.disconnect()
 
 
+async def _basalt_build_for_local(image: Image) -> Image:
+    """Run basalt to build the disk for a ``qemu/local`` image.
+
+    Resolves (or downloads) the base qcow2 from the registry, then calls
+    :class:`~cua_sandbox.builder.basalt.BasaltQEMUBuilder` to apply the
+    image's layers incrementally.  Returns a new ``Image`` with
+    ``_disk_path`` pointing to the built qcow2 (and ``_layers`` cleared so
+    the runtime boots it directly).
+    """
+    from pathlib import Path
+
+    from cua_sandbox.builder.basalt import BasaltQEMUBuilder
+    from cua_sandbox.registry.resolve import pull_image
+
+    logger.info(
+        "_basalt_build_for_local: pulling base image %s and building %d layers",
+        image._registry, len(image._layers),
+    )
+
+    # Pull the base image from the registry (returns path to local qcow2 / disk)
+    resolved, local_path = pull_image(image)
+    base_disk = local_path / "disk.qcow2"
+    if not base_disk.exists():
+        # Fall back to disk.img
+        base_disk = local_path / "disk.img"
+    if not base_disk.exists():
+        raise FileNotFoundError(
+            f"Could not find disk.qcow2 or disk.img in {local_path} "
+            f"after pulling {image._registry}. "
+            f"Is this a VM image (qemu format)?"
+        )
+
+    builder = BasaltQEMUBuilder()
+    built_disk = await builder.build(image, base_qcow2=base_disk)
+
+    # Return a new Image pointing directly at the built disk (layers already applied)
+    return image._with(_disk_path=str(built_disk), _layers=(), _registry=None)
+
+
 def _auto_runtime(image: Image) -> "Runtime":
     """Pick a runtime automatically based on image._runtime_hint, os_type, and kind."""
     import platform as _plat
@@ -136,11 +175,15 @@ def _auto_runtime(image: Image) -> "Runtime":
     # Only the "local" hints reach this function — "/cloud" hints are handled
     # upstream in _create() before _auto_runtime is called.
     hint = getattr(image, "_runtime_hint", None)
+
     if hint == "qemu/local":
+        # qemu/local → basalt-backed QEMU builder + QEMUBaremetalRuntime.
+        # BasaltQEMURuntime wraps both so the build step runs before the VM boots.
         from cua_sandbox.runtime.qemu import QEMUBaremetalRuntime
 
-        return QEMUBaremetalRuntime()
-    if hint == "oci/local":
+        return QEMUBaremetalRuntime()  # build step handled separately in _create()
+
+    if hint in ("docker/local", "oci/local"):
         from cua_sandbox.runtime.docker import DockerRuntime
 
         return DockerRuntime(ephemeral=True)
@@ -1108,6 +1151,14 @@ class Sandbox:
             runtime = _auto_runtime(image)
         if image and runtime:
             sb_name = name or _random_name()
+
+            # For qemu/local: run basalt to build the disk image before starting
+            # the VM.  The runtime receives the built disk via Image._disk_path so
+            # it boots the built qcow2 instead of the (unmodified) base image.
+            _hint = getattr(image, "_runtime_hint", None)
+            if _hint == "qemu/local" and image._layers and image._registry:
+                image = await _basalt_build_for_local(image)
+
             rt_info = await runtime.start(image, sb_name)
             if rt_info.environment == "android" and not rt_info.qmp_port:
                 if rt_info.grpc_port:

--- a/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
@@ -381,12 +381,23 @@ class CloudTransport(Transport):
         # registry ref as dockerImage and the image kind as instanceType.
         # kind="vm"        → KubeVirt VMI   (containerDisk)
         # kind="container" → gVisor/Incus   (spec.image)
+        #
+        # Priority order for instanceType:
+        #   1. _runtime_hint (set via image.runtime("qemu/cloud") / "oci/cloud")
+        #   2. image.kind ("vm" | "container")
+        #   3. default "vm"
         registry_ref = getattr(self._image, "_registry", None)
         if registry_ref:
             body["dockerImage"] = registry_ref
-            # Respect image.kind if set; default to "vm" for VMI provisioning.
-            kind = getattr(self._image, "kind", None) or "vm"
-            body["instanceType"] = kind
+            runtime_hint = getattr(self._image, "_runtime_hint", None)
+            if runtime_hint:
+                # "qemu/cloud" → "vm", "oci/cloud" → "container"
+                engine = runtime_hint.split("/", 1)[0]
+                instance_type = "vm" if engine == "qemu" else "container"
+            else:
+                # Fall back to image.kind, default "vm"
+                instance_type = getattr(self._image, "kind", None) or "vm"
+            body["instanceType"] = instance_type
 
         resp = await self._post_with_retry("/v1/vms", body)
         resp.raise_for_status()

--- a/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
@@ -375,6 +375,19 @@ class CloudTransport(Transport):
             body["diskGb"] = self._disk_gb or self._DEFAULT_DISK_GB
         else:
             body["configuration"] = "small"
+
+        # User-defined Docker registry image support.
+        # When Image.from_registry("myorg/myimage:tag") is used, pass the
+        # registry ref as dockerImage and the image kind as instanceType.
+        # kind="vm"        → KubeVirt VMI   (containerDisk)
+        # kind="container" → gVisor/Incus   (spec.image)
+        registry_ref = getattr(self._image, "_registry", None)
+        if registry_ref:
+            body["dockerImage"] = registry_ref
+            # Respect image.kind if set; default to "vm" for VMI provisioning.
+            kind = getattr(self._image, "kind", None) or "vm"
+            body["instanceType"] = kind
+
         resp = await self._post_with_retry("/v1/vms", body)
         resp.raise_for_status()
         return resp.json()

--- a/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/cloud.py
@@ -391,7 +391,7 @@ class CloudTransport(Transport):
             body["dockerImage"] = registry_ref
             runtime_hint = getattr(self._image, "_runtime_hint", None)
             if runtime_hint:
-                # "qemu/cloud" → "vm", "oci/cloud" → "container"
+                # "qemu/cloud" → "vm", "docker/cloud" / "oci/cloud" → "container"
                 engine = runtime_hint.split("/", 1)[0]
                 instance_type = "vm" if engine == "qemu" else "container"
             else:

--- a/libs/python/cua-sandbox/tests/test_basalt_builder.py
+++ b/libs/python/cua-sandbox/tests/test_basalt_builder.py
@@ -184,3 +184,84 @@ class TestCloudBuilderStubs:
         builder = DockerCloudBuilder()
         with pytest.raises(NotImplementedError, match="docker/cloud"):
             await builder.build(Image.from_registry("myorg/app:latest"))
+
+
+class TestBasaltWasmRunnerMock:
+    """Tests for _BasaltWasmRunner using a mock host_exec (no WASM binary needed).
+
+    These tests verify the host_exec wiring and step-file → WASM pipeline
+    contract by substituting a real WASM binary with a pre-recorded fixture
+    that replays canned responses.  Requires wasmtime-py and a built WASM
+    artifact; skipped if either is unavailable.
+    """
+
+    @pytest.fixture
+    def wasm_path(self, tmp_path):
+        """Return the basalt_wasmtime.wasm path, or skip if not available."""
+        from cua_sandbox.builder.basalt import BasaltWasmLoader
+        try:
+            return BasaltWasmLoader.load(build_if_missing=False)
+        except RuntimeError:
+            pytest.skip("basalt_wasmtime.wasm not available")
+
+    @pytest.mark.integration
+    def test_wasm_runner_runs_echo_pipeline(self, wasm_path):
+        """Run a trivial echo pipeline through the real WASM module."""
+        import pytest
+        pytest.importorskip("wasmtime")
+
+        from cua_sandbox.builder.basalt import _BasaltWasmRunner
+
+        executed = []
+
+        def host_exec(cmd):
+            executed.append(cmd)
+            stdout = b"hello from wasm\n"
+            return 0, stdout, b""
+
+        runner = _BasaltWasmRunner(wasm_path, host_exec)
+        step_file = {
+            "targets": ["step-a"],
+            "steps": {
+                "step-a": {
+                    "run": {"program": "echo", "args": ["hello"]},
+                    "deps": [],
+                }
+            },
+        }
+        result = runner.run_pipeline(step_file)
+        assert result["success"], f"Pipeline failed: {result['error']}"
+        assert len(executed) >= 1
+        assert executed[0]["program"] == "echo"
+
+
+class TestBasaltWasmLoaderSearchPaths:
+    """Tests for BasaltWasmLoader path discovery (no I/O except env var)."""
+
+    def test_env_var_respected(self, tmp_path, monkeypatch):
+        from cua_sandbox.builder.basalt import BasaltWasmLoader
+
+        fake_wasm = tmp_path / "fake.wasm"
+        fake_wasm.write_bytes(b"\x00asm")  # valid-looking magic
+        monkeypatch.setenv("BASALT_WASM", str(fake_wasm))
+
+        result = BasaltWasmLoader.load(build_if_missing=False)
+        assert result == fake_wasm
+
+    def test_env_var_missing_file_raises(self, tmp_path, monkeypatch):
+        from cua_sandbox.builder.basalt import BasaltWasmLoader
+        monkeypatch.setenv("BASALT_WASM", str(tmp_path / "nonexistent.wasm"))
+        with pytest.raises(RuntimeError, match="non-existent file"):
+            BasaltWasmLoader.load(build_if_missing=False)
+
+    def test_not_found_raises_without_build(self, tmp_path, monkeypatch):
+        from cua_sandbox.builder.basalt import BasaltWasmLoader, _WASM_SEARCH_PATHS
+        # Patch all search paths to tmp_path (nothing there)
+        monkeypatch.setenv("BASALT_WASM", "")
+        monkeypatch.delenv("BASALT_WASM")
+        monkeypatch.setattr(
+            "cua_sandbox.builder.basalt._WASM_SEARCH_PATHS",
+            [tmp_path / "nonexistent.wasm"]
+        )
+        with pytest.raises(RuntimeError, match="not found"):
+            BasaltWasmLoader.load(build_if_missing=False)

--- a/libs/python/cua-sandbox/tests/test_basalt_builder.py
+++ b/libs/python/cua-sandbox/tests/test_basalt_builder.py
@@ -1,0 +1,186 @@
+"""Unit tests for BasaltQEMUBuilder layer → step translation.
+
+Tests the _layers_to_basalt_steps() function which translates Image layers
+into basalt JSON step files. Does NOT require a basalt binary or root access.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def _make_step_file(layers):
+    from cua_sandbox.builder.basalt import _layers_to_basalt_steps
+    return _layers_to_basalt_steps(layers, os_type="linux")
+
+
+class TestLayersToBasaltSteps:
+    """Tests for _layers_to_basalt_steps() translation."""
+
+    def test_empty_layers_produces_no_steps(self):
+        sf = _make_step_file([])
+        assert sf["steps"] == {}
+        assert sf["targets"] == []
+
+    def test_single_apt_install(self):
+        sf = _make_step_file([{"type": "apt_install", "packages": ["curl", "git"]}])
+        assert len(sf["steps"]) == 1
+        step_name = list(sf["steps"].keys())[0]
+        assert "apt_install" in step_name
+        step = sf["steps"][step_name]
+        # run should contain apt-get install
+        run = step["run"]
+        cmd_str = json.dumps(run)
+        assert "apt-get install" in cmd_str
+        assert "curl" in cmd_str
+        assert "git" in cmd_str
+
+    def test_run_layer(self):
+        sf = _make_step_file([{"type": "run", "command": "echo hello"}])
+        step = list(sf["steps"].values())[0]
+        cmd_str = json.dumps(step["run"])
+        assert "echo hello" in cmd_str
+
+    def test_sequential_deps(self):
+        """Each step should depend on the previous one."""
+        layers = [
+            {"type": "apt_install", "packages": ["curl"]},
+            {"type": "run", "command": "curl --version"},
+            {"type": "run", "command": "echo done"},
+        ]
+        sf = _make_step_file(layers)
+        steps = sf["steps"]
+        assert len(steps) == 3
+
+        names = list(steps.keys())
+        # step[1] should have a step dep on steps[0]
+        step1_deps = steps[names[1]]["deps"]
+        step_dep_names = [d["name"] for d in step1_deps if d.get("type") == "step"]
+        assert names[0] in step_dep_names
+
+        # step[2] should depend on step[1]
+        step2_deps = steps[names[2]]["deps"]
+        step_dep_names2 = [d["name"] for d in step2_deps if d.get("type") == "step"]
+        assert names[1] in step_dep_names2
+
+    def test_first_step_has_no_step_dep(self):
+        """The first step should have no step deps (only the layer-hash dep)."""
+        sf = _make_step_file([{"type": "run", "command": "true"}])
+        step = list(sf["steps"].values())[0]
+        step_deps = [d for d in step["deps"] if d.get("type") == "step"]
+        assert step_deps == []
+
+    def test_target_is_last_step(self):
+        layers = [
+            {"type": "run", "command": "true"},
+            {"type": "run", "command": "false || true"},
+        ]
+        sf = _make_step_file(layers)
+        last_step = list(sf["steps"].keys())[-1]
+        assert sf["targets"] == [last_step]
+
+    def test_layer_hash_dep_present(self):
+        """Every step should have an exec_output dep that encodes the layer hash."""
+        sf = _make_step_file([{"type": "run", "command": "whoami"}])
+        step = list(sf["steps"].values())[0]
+        hash_deps = [
+            d for d in step["deps"]
+            if d.get("type") == "exec_output" and "layer-hash:" in " ".join(d.get("args", []))
+        ]
+        assert len(hash_deps) == 1
+
+    def test_layer_hash_changes_with_content(self):
+        """Different layer content → different hash dep value."""
+        sf1 = _make_step_file([{"type": "run", "command": "echo foo"}])
+        sf2 = _make_step_file([{"type": "run", "command": "echo bar"}])
+        step1 = list(sf1["steps"].values())[0]
+        step2 = list(sf2["steps"].values())[0]
+        hash1 = [d["args"] for d in step1["deps"] if d.get("type") == "exec_output"][0]
+        hash2 = [d["args"] for d in step2["deps"] if d.get("type") == "exec_output"][0]
+        assert hash1 != hash2
+
+    def test_expose_layer_is_noop(self):
+        """expose layers should generate a 'true' no-op command."""
+        sf = _make_step_file([{"type": "expose", "port": 8080}])
+        step = list(sf["steps"].values())[0]
+        cmd_str = json.dumps(step["run"])
+        assert "true" in cmd_str
+
+    def test_env_layer(self):
+        sf = _make_step_file([{"type": "env", "variables": {"FOO": "bar"}}])
+        step = list(sf["steps"].values())[0]
+        cmd_str = json.dumps(step["run"])
+        assert "FOO" in cmd_str
+        assert "bar" in cmd_str
+
+    def test_empty_env_layer_is_noop(self):
+        sf = _make_step_file([{"type": "env", "variables": {}}])
+        step = list(sf["steps"].values())[0]
+        cmd_str = json.dumps(step["run"])
+        assert "true" in cmd_str
+
+    def test_pip_install_layer(self):
+        sf = _make_step_file([{"type": "pip_install", "packages": ["requests"]}])
+        step = list(sf["steps"].values())[0]
+        cmd_str = json.dumps(step["run"])
+        assert "pip3" in cmd_str
+        assert "requests" in cmd_str
+
+    def test_unknown_layer_type_is_noop(self):
+        """Unknown layer types should not raise — they should be no-ops."""
+        sf = _make_step_file([{"type": "totally_unknown_layer", "data": "x"}])
+        step = list(sf["steps"].values())[0]
+        cmd_str = json.dumps(step["run"])
+        assert "true" in cmd_str
+
+    def test_step_file_is_json_serialisable(self):
+        layers = [
+            {"type": "apt_install", "packages": ["curl"]},
+            {"type": "run", "command": "curl --version"},
+            {"type": "env", "variables": {"PATH": "/usr/local/bin:$PATH"}},
+        ]
+        sf = _make_step_file(layers)
+        # Should not raise
+        serialised = json.dumps(sf)
+        restored = json.loads(serialised)
+        assert restored["steps"] == sf["steps"]
+
+
+class TestBasaltBuilderInit:
+    """Tests for BasaltQEMUBuilder initialization (no I/O)."""
+
+    def test_default_nbd_device(self):
+        from cua_sandbox.builder.basalt import BasaltQEMUBuilder
+        b = BasaltQEMUBuilder()
+        assert b.nbd_device == "/dev/nbd0"
+
+    def test_custom_nbd_device(self):
+        from cua_sandbox.builder.basalt import BasaltQEMUBuilder
+        b = BasaltQEMUBuilder(nbd_device="/dev/nbd1")
+        assert b.nbd_device == "/dev/nbd1"
+
+    def test_custom_images_dir(self, tmp_path):
+        from cua_sandbox.builder.basalt import BasaltQEMUBuilder
+        b = BasaltQEMUBuilder(images_dir=tmp_path)
+        assert b.images_dir == tmp_path
+
+
+class TestCloudBuilderStubs:
+    """Tests that cloud builder stubs raise NotImplementedError."""
+
+    @pytest.mark.asyncio
+    async def test_qemu_cloud_builder_raises(self):
+        from cua_sandbox.builder.basalt import QEMUCloudBuilder
+        from cua_sandbox import Image
+        builder = QEMUCloudBuilder()
+        with pytest.raises(NotImplementedError, match="qemu/cloud"):
+            await builder.build(Image.from_registry("myorg/img:latest"))
+
+    @pytest.mark.asyncio
+    async def test_docker_cloud_builder_raises(self):
+        from cua_sandbox.builder.basalt import DockerCloudBuilder
+        from cua_sandbox import Image
+        builder = DockerCloudBuilder()
+        with pytest.raises(NotImplementedError, match="docker/cloud"):
+            await builder.build(Image.from_registry("myorg/app:latest"))

--- a/libs/python/cua-sandbox/tests/test_image_runtime.py
+++ b/libs/python/cua-sandbox/tests/test_image_runtime.py
@@ -19,8 +19,8 @@ class TestImageRuntimeMethod:
         assert img.kind == "vm"
 
     def test_oci_cloud_sets_hint_and_kind(self):
-        img = self._registry_image().runtime("oci/cloud")
-        assert img._runtime_hint == "oci/cloud"
+        img = self._registry_image().runtime("docker/cloud")
+        assert img._runtime_hint == "docker/cloud"
         assert img.kind == "container"
 
     def test_qemu_local_sets_hint_and_kind(self):
@@ -29,8 +29,8 @@ class TestImageRuntimeMethod:
         assert img.kind == "vm"
 
     def test_oci_local_sets_hint_and_kind(self):
-        img = self._registry_image().runtime("oci/local")
-        assert img._runtime_hint == "oci/local"
+        img = self._registry_image().runtime("docker/local")
+        assert img._runtime_hint == "docker/local"
         assert img.kind == "container"
 
     # ── Invalid hints ─────────────────────────────────────────────────────
@@ -63,15 +63,15 @@ class TestImageRuntimeMethod:
         img = (
             self._registry_image()
             .apt_install("curl")
-            .runtime("oci/cloud")
+            .runtime("docker/cloud")
         )
         assert len(img._layers) == 1
         assert img._layers[0]["type"] == "apt_install"
-        assert img._runtime_hint == "oci/cloud"
+        assert img._runtime_hint == "docker/cloud"
 
     def test_chaining_overrides_previous_hint(self):
-        img = self._registry_image().runtime("qemu/cloud").runtime("oci/cloud")
-        assert img._runtime_hint == "oci/cloud"
+        img = self._registry_image().runtime("qemu/cloud").runtime("docker/cloud")
+        assert img._runtime_hint == "docker/cloud"
         assert img.kind == "container"
 
     # ── Serialization ─────────────────────────────────────────────────────
@@ -88,10 +88,10 @@ class TestImageRuntimeMethod:
 
     def test_from_dict_restores_runtime_hint(self):
         from cua_sandbox import Image
-        original = self._registry_image().runtime("oci/cloud")
+        original = self._registry_image().runtime("docker/cloud")
         d = original.to_dict()
         restored = Image.from_dict(d)
-        assert restored._runtime_hint == "oci/cloud"
+        assert restored._runtime_hint == "docker/cloud"
         assert restored.kind == "container"
         assert restored._registry == "myorg/myimage:latest"
 
@@ -151,7 +151,7 @@ class TestCloudTransportRuntimeHint:
 
     def test_oci_cloud_sends_container(self):
         from cua_sandbox import Image
-        img = Image.from_registry("myorg/app:latest").runtime("oci/cloud")
+        img = Image.from_registry("myorg/app:latest").runtime("docker/cloud")
         assert self._extract_instance_type(img) == "container"
 
     def test_no_hint_defaults_to_vm(self):
@@ -163,3 +163,32 @@ class TestCloudTransportRuntimeHint:
         from cua_sandbox import Image
         img = Image.linux("ubuntu", "24.04", kind="container")._with(_registry="myorg/app:latest")
         assert self._extract_instance_type(img) == "container"
+
+
+class TestRuntimeHintAliases:
+    """Tests that oci/* aliases are normalised to docker/*."""
+
+    def test_oci_cloud_alias_normalised_to_docker_cloud(self):
+        from cua_sandbox import Image
+        img = Image.from_registry("myorg/app:latest").runtime("oci/cloud")
+        assert img._runtime_hint == "docker/cloud"
+        assert img.kind == "container"
+
+    def test_oci_local_alias_normalised_to_docker_local(self):
+        from cua_sandbox import Image
+        img = Image.from_registry("myorg/app:latest").runtime("oci/local")
+        assert img._runtime_hint == "docker/local"
+        assert img.kind == "container"
+
+    def test_alias_repr_shows_canonical_hint(self):
+        from cua_sandbox import Image
+        img = Image.from_registry("myorg/app:latest").runtime("oci/cloud")
+        assert "docker/cloud" in repr(img)
+        assert "oci/cloud" not in repr(img)
+
+    def test_alias_roundtrips_correctly(self):
+        from cua_sandbox import Image
+        original = Image.from_registry("myorg/app:latest").runtime("oci/cloud")
+        d = original.to_dict()
+        restored = Image.from_dict(d)
+        assert restored._runtime_hint == "docker/cloud"

--- a/libs/python/cua-sandbox/tests/test_image_runtime.py
+++ b/libs/python/cua-sandbox/tests/test_image_runtime.py
@@ -1,0 +1,165 @@
+"""Unit tests for Image.runtime() API — CUA-482."""
+from __future__ import annotations
+
+import pytest
+
+
+class TestImageRuntimeMethod:
+    """Tests for Image.runtime() — the engine/location hint API."""
+
+    def _registry_image(self) -> "Image":
+        from cua_sandbox import Image
+        return Image.from_registry("myorg/myimage:latest")
+
+    # ── Valid hints ───────────────────────────────────────────────────────
+
+    def test_qemu_cloud_sets_hint_and_kind(self):
+        img = self._registry_image().runtime("qemu/cloud")
+        assert img._runtime_hint == "qemu/cloud"
+        assert img.kind == "vm"
+
+    def test_oci_cloud_sets_hint_and_kind(self):
+        img = self._registry_image().runtime("oci/cloud")
+        assert img._runtime_hint == "oci/cloud"
+        assert img.kind == "container"
+
+    def test_qemu_local_sets_hint_and_kind(self):
+        img = self._registry_image().runtime("qemu/local")
+        assert img._runtime_hint == "qemu/local"
+        assert img.kind == "vm"
+
+    def test_oci_local_sets_hint_and_kind(self):
+        img = self._registry_image().runtime("oci/local")
+        assert img._runtime_hint == "oci/local"
+        assert img.kind == "container"
+
+    # ── Invalid hints ─────────────────────────────────────────────────────
+
+    def test_invalid_hint_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unknown runtime hint"):
+            self._registry_image().runtime("docker/cloud")
+
+    def test_empty_hint_raises_value_error(self):
+        with pytest.raises(ValueError):
+            self._registry_image().runtime("")
+
+    def test_partial_hint_raises_value_error(self):
+        with pytest.raises(ValueError):
+            self._registry_image().runtime("qemu")
+
+    # ── Immutability ──────────────────────────────────────────────────────
+
+    def test_runtime_returns_new_image(self):
+        original = self._registry_image()
+        with_hint = original.runtime("qemu/cloud")
+        assert original._runtime_hint is None  # original unchanged
+        assert with_hint._runtime_hint == "qemu/cloud"
+
+    def test_runtime_preserves_registry(self):
+        img = self._registry_image().runtime("qemu/cloud")
+        assert img._registry == "myorg/myimage:latest"
+
+    def test_runtime_preserves_layers(self):
+        img = (
+            self._registry_image()
+            .apt_install("curl")
+            .runtime("oci/cloud")
+        )
+        assert len(img._layers) == 1
+        assert img._layers[0]["type"] == "apt_install"
+        assert img._runtime_hint == "oci/cloud"
+
+    def test_chaining_overrides_previous_hint(self):
+        img = self._registry_image().runtime("qemu/cloud").runtime("oci/cloud")
+        assert img._runtime_hint == "oci/cloud"
+        assert img.kind == "container"
+
+    # ── Serialization ─────────────────────────────────────────────────────
+
+    def test_to_dict_includes_runtime_hint(self):
+        img = self._registry_image().runtime("qemu/cloud")
+        d = img.to_dict()
+        assert d["runtime_hint"] == "qemu/cloud"
+
+    def test_to_dict_omits_runtime_hint_when_not_set(self):
+        img = self._registry_image()
+        d = img.to_dict()
+        assert "runtime_hint" not in d
+
+    def test_from_dict_restores_runtime_hint(self):
+        from cua_sandbox import Image
+        original = self._registry_image().runtime("oci/cloud")
+        d = original.to_dict()
+        restored = Image.from_dict(d)
+        assert restored._runtime_hint == "oci/cloud"
+        assert restored.kind == "container"
+        assert restored._registry == "myorg/myimage:latest"
+
+    # ── repr ──────────────────────────────────────────────────────────────
+
+    def test_repr_includes_hint(self):
+        img = self._registry_image().runtime("qemu/cloud")
+        r = repr(img)
+        assert "qemu/cloud" in r
+
+    def test_repr_no_hint_unchanged(self):
+        img = self._registry_image()
+        r = repr(img)
+        assert "runtime=" not in r
+
+
+class TestCloudTransportRuntimeHint:
+    """Tests that CloudTransport._create_vm() reads _runtime_hint for instanceType."""
+
+    def _make_transport(self, image):
+        from cua_sandbox.transport.cloud import CloudTransport
+        t = CloudTransport.__new__(CloudTransport)
+        t._image = image
+        t._region = "us-east-1"
+        t._cpu = None
+        t._memory_mb = None
+        t._disk_gb = None
+        t._DEFAULT_CPU = 4
+        t._DEFAULT_MEMORY_MB = 8192
+        t._DEFAULT_DISK_GB = 50
+        return t
+
+    def _extract_instance_type(self, image) -> str:
+        """Run the body-building logic from _create_vm and return instanceType."""
+        from cua_sandbox import Image
+        transport = self._make_transport(image)
+
+        # Replicate the body-building logic from _create_vm
+        body = {"os": image.os_type, "region": transport._region, "configuration": "small"}
+        registry_ref = getattr(transport._image, "_registry", None)
+        if registry_ref:
+            body["dockerImage"] = registry_ref
+            runtime_hint = getattr(transport._image, "_runtime_hint", None)
+            if runtime_hint:
+                engine = runtime_hint.split("/", 1)[0]
+                instance_type = "vm" if engine == "qemu" else "container"
+            else:
+                instance_type = getattr(transport._image, "kind", None) or "vm"
+            body["instanceType"] = instance_type
+
+        return body.get("instanceType", "<not set>")
+
+    def test_qemu_cloud_sends_vm(self):
+        from cua_sandbox import Image
+        img = Image.from_registry("myorg/img:latest").runtime("qemu/cloud")
+        assert self._extract_instance_type(img) == "vm"
+
+    def test_oci_cloud_sends_container(self):
+        from cua_sandbox import Image
+        img = Image.from_registry("myorg/app:latest").runtime("oci/cloud")
+        assert self._extract_instance_type(img) == "container"
+
+    def test_no_hint_defaults_to_vm(self):
+        from cua_sandbox import Image
+        img = Image.from_registry("myorg/img:latest")
+        assert self._extract_instance_type(img) == "vm"
+
+    def test_kind_container_without_hint_sends_container(self):
+        from cua_sandbox import Image
+        img = Image.linux("ubuntu", "24.04", kind="container")._with(_registry="myorg/app:latest")
+        assert self._extract_instance_type(img) == "container"


### PR DESCRIPTION
## Summary

Adds user-defined Docker registry support to the `cua-sandbox` Sandbox API:
- `Image.from_registry(...).runtime("qemu/cloud")` wired through to `POST /v1/vms`
- `Image.runtime()` API for explicit engine/location selection
- `BasaltQEMUBuilder` using basalt-wasmtime (in-process WASM, no CLI binary)

Linear: CUA-482

This PR is **independent** — no dependency on the computer PR or cloud PR #4178 in code (only an API contract with the cloud backend).

## Changes (`libs/python/cua-sandbox`, `libs/python/cua-cli`)

**`CloudTransport._create_vm()`** — when `image._registry` is set, sends `dockerImage` + `instanceType` in POST /v1/vms body

**`Image.runtime(hint)`** — new chainable method; hints: `qemu/cloud`, `qemu/local`, `docker/cloud`, `docker/local` (+ `oci/*` aliases)
- Sets `_runtime_hint` + derives `kind` from engine
- Threaded through `_add_layer`, `_with`, `to_dict`, `from_dict`, `__repr__`

**`sandbox.py`** — `_auto_runtime()` reads hint; `_create()` routes to cloud/local based on hint location

**`BasaltQEMUBuilder`** — builds qcow2 via basalt-wasmtime (in-process WASM)
- `BasaltWasmLoader`: finds/builds `basalt_wasmtime.wasm`
- `_BasaltWasmRunner`: wasmtime-py wrapper with injectable `host_exec_fn`
- `_make_chroot_exec_fn`: host_exec impl that runs cmds in qcow2 chroot
- `QEMUCloudBuilder` / `DockerCloudBuilder`: stubs (NotImplementedError)

**Tests**: `test_image_runtime.py` (aliases, immutability, serialization), `test_basalt_builder.py` (layer translation, WASM runner mock, loader search paths)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added runtime hints to control image execution mode (e.g., local QEMU VM, cloud container)
  * Enabled building VM images locally using WASM-based builder
  * Added support for Docker registry images in cloud VM creation

* **Improvements**
  * Enhanced runtime selection logic to automatically choose appropriate execution engine based on hints
  * Improved image layer handling with automatic disk generation for local builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->