### PR TITLE
docs: add deprecation notice to VLM Router page

### DIFF
--- a/docs/content/docs/cua/guide/fundamentals/cua-vlm-router.mdx
+++ b/docs/content/docs/cua/guide/fundamentals/cua-vlm-router.mdx
@@ -3,6 +3,12 @@ title: Cua VLM Router
 description: Unified API access to multiple VLM providers without managing infrastructure
 ---
 
+import { Callout } from 'fumadocs-ui/components/callout';
+
+<Callout title="Deprecated" type="warn">
+The Cua VLM Router has been sunset. Please use direct provider APIs with your own API keys (BYOK) instead. See [Vision Language Models](/cua/guide/fundamentals/vlms) for setup instructions with Claude, Gemini, and other providers.
+</Callout>
+
 Instead of deploying and managing computer-use vision language models yourself on various cloud providers, Cua VLM Router gives you instant access to all supported models through a single API key. No infrastructure setup, no multiple provider accounts—just one integration for Claude, Gemini, Qwen, and more.
 
 ## Setup


### PR DESCRIPTION
The Cua VLM Router has been sunset. Users should now use direct
provider APIs with their own API keys (BYOK) instead.

https://claude.ai/code/session_01Wic811z4vNNaNPMnB4JHHt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deprecation notice to the Cua VLM Router documentation, informing users that the router has been sunset and recommending migration to direct provider APIs with BYOK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->