### PR TITLE
fix(docker): replace deprecated libgl1-mesa-glx with libgl1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,12 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONPATH="/app/libs/python/core:/app/libs/python/computer:/app/libs/python/agent:/app/libs/python/som:/app/libs/python/computer-server:/app/libs/python/mcp-server"
 
 # Install system dependencies for ARM architecture
+# Note: libgl1-mesa-glx was removed in Debian Bookworm (python:3.12-slim base);
+# use libgl1 instead, which pulls in the appropriate Mesa/DRI backend.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     build-essential \
-    libgl1-mesa-glx \
+    libgl1 \
     libglib2.0-0 \
     libxcb-xinerama0 \
     libxkbcommon-x11-0 \

--- a/libs/cuabot/Dockerfile
+++ b/libs/cuabot/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openjdk-17-jdk-headless \
     unzip \
     libpulse0 \
-    libgl1-mesa-glx \
+    libgl1 \
     libnss3 \
     libxcomposite1 \
     libxcursor1 \

--- a/libs/python/cua-sandbox-apps/cua_sandbox_apps/apps/godot-engine/linux/launch.sh
+++ b/libs/python/cua-sandbox-apps/cua_sandbox_apps/apps/godot-engine/linux/launch.sh
@@ -4,7 +4,11 @@
 # The --editor flag starts the editor interface
 
 export DISPLAY=:1
-export LIBGL_ALWAYS_INDIRECT=1
+# Use software rendering (llvmpipe/swrast) in containers without GPU access.
+# LIBGL_ALWAYS_SOFTWARE forces Mesa's software rasteriser even when a GPU DRI
+# device is present but inaccessible — avoids "libGL: screen 0 does not appear
+# to be DRI2/DRI3 capable" and similar errors in headless/containerised envs.
+export LIBGL_ALWAYS_SOFTWARE=1
 
 /opt/godot/godot --editor > /tmp/godot.log 2>&1 &
 GODOT_PID=$!


### PR DESCRIPTION
libgl1-mesa-glx was removed in Debian Bookworm (the base for python:3.12-slim) and is only a transitional stub on Ubuntu 22.04. The canonical replacement is libgl1, which pulls in the appropriate Mesa DRI/software-rast backend on both Debian and Ubuntu.

Also replace LIBGL_ALWAYS_INDIRECT (removed in Mesa 23+) with LIBGL_ALWAYS_SOFTWARE in the Godot Engine launch script, which correctly forces software rendering in headless/containerised environments where no GPU DRI device is accessible.

Fixes: CUA-500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated graphics library dependencies across Docker environments for better compatibility.
  * Modified GL rendering configuration to use software rendering in headless and container environments.
  * Optimized Docker build process to skip unnecessary steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->