### PR TITLE
fix(cua-driver): surface system overlay windows in list_windows and get_window_state

### DIFF
--- a/libs/cua-driver/Sources/CuaDriverCore/AppState/AppState.swift
+++ b/libs/cua-driver/Sources/CuaDriverCore/AppState/AppState.swift
@@ -265,10 +265,17 @@ public actor AppStateEngine {
         var nextIndex = 0
         var markdown = ""
 
+        let layer0WindowIds: Set<CGWindowID> = Set(
+            WindowEnumerator.allWindows()
+                .filter { $0.layer == 0 }
+                .map { CGWindowID($0.id) }
+        )
+
         renderTree(
             root,
             depth: 0,
             targetWindowId: windowId,
+            layer0WindowIds: layer0WindowIds,
             elements: &elements,
             nextIndex: &nextIndex,
             output: &markdown
@@ -510,6 +517,7 @@ public actor AppStateEngine {
         _ element: AXUIElement,
         depth: Int,
         targetWindowId: UInt32?,
+        layer0WindowIds: Set<CGWindowID> = [],
         elements: inout [Int: AXUIElement],
         nextIndex: inout Int,
         output: inout String
@@ -595,7 +603,8 @@ public actor AppStateEngine {
                     // windows whose CGWindowID we can't read.
                     return true
                 }
-                return cgWindowId == targetWid
+                if cgWindowId == targetWid { return true }
+                return !layer0WindowIds.contains(cgWindowId)
             }
         }
 
@@ -604,6 +613,7 @@ public actor AppStateEngine {
                 child,
                 depth: depth + 1,
                 targetWindowId: targetWindowId,
+                layer0WindowIds: layer0WindowIds,
                 elements: &elements,
                 nextIndex: &nextIndex,
                 output: &output

--- a/libs/cua-driver/Sources/CuaDriverServer/Tools/ListWindowsTool.swift
+++ b/libs/cua-driver/Sources/CuaDriverServer/Tools/ListWindowsTool.swift
@@ -98,9 +98,10 @@ public enum ListWindowsTool {
                 : WindowEnumerator.allWindows()
 
             let windows = raw
-                .filter { $0.layer == 0 }
                 .filter { info in
-                    guard let pid = pidFilter else { return true }
+                    guard let pid = pidFilter else {
+                        return info.layer == 0
+                    }
                     return info.pid == pid
                 }
 


### PR DESCRIPTION
Fixes #1451.

## Problem

`list_windows` applied a `layer == 0` filter unconditionally, so system overlay windows — such as the macOS LocalAuthentication dialog (`coreautha`, layer 1000) — were invisible to callers. Without a valid `window_id`, `get_window_state` cannot be called and the dialog is completely unreachable via cua-driver tools.

A second issue: `get_window_state`'s internal `renderTree` filtered AX child windows at depth 0 by requiring their CGWindowID to match the requested `window_id`. System overlay windows have valid CGWindowIDs that are absent from the layer-0 window-server list, so they were silently excluded and their buttons never appeared in the element index.

## Fix

**`ListWindowsTool`** — move the `layer == 0` guard inside the no-pid branch. Generic callers (no pid) keep the existing behaviour; pid-scoped callers get all layers for that process.

**`AppState / renderTree`** — pre-compute the set of layer-0 CGWindowIDs and pass it into `renderTree`. At depth 0, also admit AX windows whose CGWindowID is absent from that set. Generic callers are unaffected.

## Testing

Verified against a live `coreautha` LocalAuthentication dialog:

- `list_windows({pid})` now returns the dialog window at layer 1000
- `get_window_state` exposes its full AX tree including `AXButton "Use Password…"`, `AXTextField`, and `AXButton "OK"`
- `click` / `set_value` / `click` completes the flow via `element_index` — no AppleScript fallback required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window filtering accuracy in the accessibility tree to ensure proper targeting of specific windows while preserving non-window elements like the menu bar.

* **Refactor**
  * Streamlined window filtering logic by consolidating multiple filter operations into a single, more efficient pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->