### PR TITLE
feat(oidc): add oidc_token() and aws_credentials() SDK helpers (CUA-484)

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/__init__.py
+++ b/libs/python/cua-sandbox/cua_sandbox/__init__.py
@@ -20,6 +20,7 @@ __version__ = "0.1.0"
 
 from cua_sandbox._auth import login, whoami
 from cua_sandbox._config import configure
+from cua_sandbox._oidc import AWSCredentials, OIDCToken, aws_credentials, oidc_token
 from cua_sandbox.image import Image
 from cua_sandbox.localhost import Localhost, localhost
 from cua_sandbox.runtime.compat import (
@@ -34,6 +35,12 @@ __all__ = [
     "configure",
     "login",
     "whoami",
+    # OIDC helpers
+    "oidc_token",
+    "aws_credentials",
+    "OIDCToken",
+    "AWSCredentials",
+    # Sandbox
     "Image",
     "Sandbox",
     "SandboxInfo",

--- a/libs/python/cua-sandbox/cua_sandbox/_oidc.py
+++ b/libs/python/cua-sandbox/cua_sandbox/_oidc.py
@@ -1,0 +1,274 @@
+"""OIDC token helper — exchange a CUA sandbox OIDC token for cloud credentials.
+
+CUA sandboxes can obtain short-lived JWTs from the CUA OIDC issuer
+(https://oidc.cua.ai) and exchange them with cloud providers for
+temporary credentials — no long-lived secrets stored anywhere.
+
+This mirrors exactly how GitHub Actions / Claude Code work:
+  1. Call ``oidc_token()`` → get a short-lived CUA JWT (default 5 min)
+  2. Pass it to ``aws_credentials()`` → get short-lived AWS STS credentials
+  3. Use those credentials to call Bedrock, S3, etc.
+
+The JWT can also be used directly with GCP Workload Identity Federation
+and Azure Managed Identity (federated credentials).
+
+Example — AWS Bedrock with zero stored secrets::
+
+    import cua_sandbox as cua
+    import boto3
+
+    # 1. Get a CUA OIDC token for this sandbox
+    token = await cua.oidc_token(vm_name="my-agent", audience="sts.amazonaws.com")
+
+    # 2. Exchange with AWS STS for short-lived Bedrock credentials
+    creds = await cua.aws_credentials(
+        role_arn="arn:aws:iam::123456789012:role/cua-bedrock-role",
+        token=token,
+    )
+
+    # 3. Use the credentials
+    bedrock = boto3.client("bedrock-runtime", **creds.to_boto3_kwargs())
+
+AWS IAM trust policy required (one-time setup)::
+
+    {
+      "Version": "2012-10-17",
+      "Statement": [{
+        "Effect": "Allow",
+        "Principal": {"Federated": "arn:aws:iam::123456789012:oidc-provider/oidc.cua.ai"},
+        "Action": "sts:AssumeRoleWithWebIdentity",
+        "Condition": {
+          "StringEquals": {
+            "oidc.cua.ai:aud": "sts.amazonaws.com",
+            "oidc.cua.ai:sub": "sandbox:workspace:acme:vm:my-agent"
+          }
+        }
+      }]
+    }
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import httpx
+
+from cua_sandbox._config import get_api_key, get_base_url
+
+# How many seconds before JWT expiry to refresh proactively.
+_REFRESH_BUFFER_SECS = 30
+
+
+@dataclass
+class OIDCToken:
+    """A short-lived JWT issued by the CUA OIDC provider (https://oidc.cua.ai).
+
+    Attributes:
+        token: The raw JWT string. Pass this to ``aws_credentials()`` or
+            directly to STS ``AssumeRoleWithWebIdentity``.
+        expires_in: Token lifetime in seconds from the time of issuance.
+        issued_at: Unix timestamp when the token was issued.
+    """
+
+    token: str
+    expires_in: int
+    issued_at: float
+
+    @property
+    def expires_at(self) -> float:
+        return self.issued_at + self.expires_in
+
+    @property
+    def is_expired(self) -> bool:
+        return time.time() >= self.expires_at - _REFRESH_BUFFER_SECS
+
+    def __str__(self) -> str:
+        return self.token
+
+
+@dataclass
+class AWSCredentials:
+    """Temporary AWS credentials obtained by exchanging a CUA OIDC token with STS.
+
+    Attributes:
+        access_key_id: AWS access key ID.
+        secret_access_key: AWS secret access key.
+        session_token: AWS session token (required for temporary credentials).
+        expiration: Unix timestamp when the credentials expire.
+        region: AWS region (preserved from the request for convenience).
+    """
+
+    access_key_id: str
+    secret_access_key: str
+    session_token: str
+    expiration: float
+    region: str
+
+    def to_boto3_kwargs(self) -> Dict[str, str]:
+        """Return a dict suitable for unpacking into any boto3 client constructor.
+
+        Example::
+
+            import boto3
+            bedrock = boto3.client("bedrock-runtime", **creds.to_boto3_kwargs())
+        """
+        return {
+            "aws_access_key_id": self.access_key_id,
+            "aws_secret_access_key": self.secret_access_key,
+            "aws_session_token": self.session_token,
+            "region_name": self.region,
+        }
+
+    @property
+    def is_expired(self) -> bool:
+        return time.time() >= self.expiration - _REFRESH_BUFFER_SECS
+
+
+async def oidc_token(
+    vm_name: str,
+    *,
+    audience: str = "sts.amazonaws.com",
+    ttl_seconds: int = 300,
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> OIDCToken:
+    """Request a short-lived OIDC JWT for this sandbox from the CUA OIDC issuer.
+
+    The token is signed by ``https://oidc.cua.ai`` and can be exchanged with
+    AWS STS, GCP STS, or Azure AD for short-lived cloud credentials.
+
+    Subject claim format: ``sandbox:workspace:<workspace_slug>:vm:<vm_name>``
+
+    Args:
+        vm_name: Name of the sandbox VM. Must belong to the workspace
+            associated with the API key.
+        audience: Intended audience for the token. Use ``"sts.amazonaws.com"``
+            for AWS, ``"https://iam.googleapis.com/..."`` for GCP, etc.
+            Defaults to ``"sts.amazonaws.com"``.
+        ttl_seconds: Token lifetime in seconds. Max 3600. Default 300 (5 min).
+        api_key: Override the global API key.
+        base_url: Override the global API base URL.
+
+    Returns:
+        ``OIDCToken`` with the raw JWT and expiry metadata.
+
+    Raises:
+        httpx.HTTPStatusError: If the API returns a non-2xx status.
+        RuntimeError: If no API key is configured.
+    """
+    key = get_api_key(api_key)
+    if not key:
+        raise RuntimeError(
+            "No CUA API key configured. "
+            "Set CUA_API_KEY, call cua_sandbox.configure(api_key=...), "
+            "or pass api_key= directly."
+        )
+
+    url = (base_url or get_base_url()).rstrip("/") + "/v1/oidc/token"
+    issued_at = time.time()
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.post(
+            url,
+            headers={
+                "Authorization": f"Bearer {key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "vm_name": vm_name,
+                "audience": audience,
+                "ttl_seconds": ttl_seconds,
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+    return OIDCToken(
+        token=data["token"],
+        expires_in=data.get("expires_in", ttl_seconds),
+        issued_at=issued_at,
+    )
+
+
+async def aws_credentials(
+    role_arn: str,
+    *,
+    token: Optional[OIDCToken | str] = None,
+    vm_name: Optional[str] = None,
+    region: str = "us-east-1",
+    session_name: str = "cua-sandbox",
+    duration_seconds: int = 3600,
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> AWSCredentials:
+    """Obtain temporary AWS credentials by exchanging a CUA OIDC token with STS.
+
+    Pass either a pre-fetched ``token`` *or* a ``vm_name`` (which will be used
+    to fetch a fresh token automatically with audience ``"sts.amazonaws.com"``).
+
+    Requires the ``boto3`` package: ``pip install boto3``.
+
+    Args:
+        role_arn: ARN of the IAM role to assume. The role's trust policy must
+            allow ``sts:AssumeRoleWithWebIdentity`` from the CUA OIDC provider
+            with the correct ``sub`` condition.
+        token: Pre-fetched ``OIDCToken`` or raw JWT string. If omitted,
+            ``vm_name`` must be provided.
+        vm_name: Sandbox name to fetch a fresh token for (if ``token`` not given).
+        region: AWS region for the credentials. Default ``"us-east-1"``.
+        session_name: RoleSessionName passed to STS. Default ``"cua-sandbox"``.
+        duration_seconds: Session duration in seconds (max 3600 for web identity).
+        api_key: Override the global API key (used when fetching a fresh token).
+        base_url: Override the global API base URL.
+
+    Returns:
+        ``AWSCredentials`` with access key, secret, session token, and expiry.
+
+    Raises:
+        ValueError: If neither ``token`` nor ``vm_name`` is provided.
+        ImportError: If ``boto3`` is not installed.
+        botocore.exceptions.ClientError: If STS rejects the token.
+    """
+    if token is None and vm_name is None:
+        raise ValueError("Provide either 'token' or 'vm_name'.")
+
+    # Lazy import — boto3 is optional
+    try:
+        import boto3
+        import botocore.exceptions  # noqa: F401
+    except ImportError as e:
+        raise ImportError(
+            "boto3 is required for aws_credentials(). Install it with: pip install boto3"
+        ) from e
+
+    # Fetch token if not provided
+    if token is None:
+        token = await oidc_token(
+            vm_name,  # type: ignore[arg-type]
+            audience="sts.amazonaws.com",
+            api_key=api_key,
+            base_url=base_url,
+        )
+
+    raw_token = str(token)
+
+    sts = boto3.client("sts", region_name=region)
+    resp = sts.assume_role_with_web_identity(
+        RoleArn=role_arn,
+        RoleSessionName=session_name,
+        WebIdentityToken=raw_token,
+        DurationSeconds=duration_seconds,
+    )
+
+    creds: Dict[str, Any] = resp["Credentials"]
+    expiration = creds["Expiration"].timestamp()
+
+    return AWSCredentials(
+        access_key_id=creds["AccessKeyId"],
+        secret_access_key=creds["SecretAccessKey"],
+        session_token=creds["SessionToken"],
+        expiration=expiration,
+        region=region,
+    )

--- a/libs/python/cua-sandbox/tests/test_oidc.py
+++ b/libs/python/cua-sandbox/tests/test_oidc.py
@@ -1,0 +1,216 @@
+"""Unit tests for the OIDC helper module."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cua_sandbox._oidc import AWSCredentials, OIDCToken, aws_credentials, oidc_token
+
+
+# ---------------------------------------------------------------------------
+# OIDCToken dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestOIDCToken:
+    def test_str_returns_jwt(self):
+        t = OIDCToken(token="my.jwt.here", expires_in=300, issued_at=time.time())
+        assert str(t) == "my.jwt.here"
+
+    def test_expires_at(self):
+        now = 1000.0
+        t = OIDCToken(token="x", expires_in=300, issued_at=now)
+        assert t.expires_at == 1300.0
+
+    def test_is_expired_false_when_fresh(self):
+        t = OIDCToken(token="x", expires_in=300, issued_at=time.time())
+        assert not t.is_expired
+
+    def test_is_expired_true_when_past_buffer(self):
+        # issued 300 + buffer seconds ago → expired
+        from cua_sandbox._oidc import _REFRESH_BUFFER_SECS
+
+        t = OIDCToken(token="x", expires_in=300, issued_at=time.time() - 300 - _REFRESH_BUFFER_SECS - 1)
+        assert t.is_expired
+
+
+# ---------------------------------------------------------------------------
+# AWSCredentials dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestAWSCredentials:
+    def _make(self, expiration: float | None = None) -> AWSCredentials:
+        return AWSCredentials(
+            access_key_id="AKIA...",
+            secret_access_key="secret",
+            session_token="tok",
+            expiration=expiration or time.time() + 3600,
+            region="us-east-1",
+        )
+
+    def test_to_boto3_kwargs(self):
+        creds = self._make()
+        kwargs = creds.to_boto3_kwargs()
+        assert kwargs["aws_access_key_id"] == "AKIA..."
+        assert kwargs["aws_secret_access_key"] == "secret"
+        assert kwargs["aws_session_token"] == "tok"
+        assert kwargs["region_name"] == "us-east-1"
+
+    def test_is_expired_false_when_fresh(self):
+        creds = self._make(expiration=time.time() + 3600)
+        assert not creds.is_expired
+
+    def test_is_expired_true_when_stale(self):
+        from cua_sandbox._oidc import _REFRESH_BUFFER_SECS
+
+        creds = self._make(expiration=time.time() - _REFRESH_BUFFER_SECS - 1)
+        assert creds.is_expired
+
+
+# ---------------------------------------------------------------------------
+# oidc_token()
+# ---------------------------------------------------------------------------
+
+
+class TestOidcToken:
+    @pytest.mark.asyncio
+    async def test_returns_oidc_token(self):
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "token": "header.payload.sig",
+            "expires_in": 300,
+            "token_type": "Bearer",
+        }
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch("cua_sandbox._oidc.httpx.AsyncClient", return_value=mock_client):
+            with patch("cua_sandbox._oidc.get_api_key", return_value="sk-test"):
+                token = await oidc_token("my-agent", audience="sts.amazonaws.com")
+
+        assert isinstance(token, OIDCToken)
+        assert token.token == "header.payload.sig"
+        assert token.expires_in == 300
+        assert not token.is_expired
+
+        # Verify the request body
+        call_kwargs = mock_client.post.call_args
+        assert call_kwargs.kwargs["json"]["vm_name"] == "my-agent"
+        assert call_kwargs.kwargs["json"]["audience"] == "sts.amazonaws.com"
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_api_key(self):
+        with patch("cua_sandbox._oidc.get_api_key", return_value=None):
+            with pytest.raises(RuntimeError, match="No CUA API key"):
+                await oidc_token("my-agent")
+
+    @pytest.mark.asyncio
+    async def test_uses_base_url(self):
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"token": "t", "expires_in": 300}
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch("cua_sandbox._oidc.httpx.AsyncClient", return_value=mock_client):
+            with patch("cua_sandbox._oidc.get_api_key", return_value="sk-test"):
+                await oidc_token("vm", base_url="https://staging.api.cua.ai")
+
+        url = mock_client.post.call_args.args[0]
+        assert url == "https://staging.api.cua.ai/v1/oidc/token"
+
+
+# ---------------------------------------------------------------------------
+# aws_credentials()
+# ---------------------------------------------------------------------------
+
+
+class TestAwsCredentials:
+    def _mock_sts_response(self) -> dict:
+        import datetime
+
+        expiry = datetime.datetime(2099, 1, 1, tzinfo=datetime.timezone.utc)
+        return {
+            "Credentials": {
+                "AccessKeyId": "ASIA...",
+                "SecretAccessKey": "supersecret",
+                "SessionToken": "session-tok",
+                "Expiration": expiry,
+            }
+        }
+
+    @pytest.mark.asyncio
+    async def test_uses_provided_token(self):
+        token = OIDCToken(token="raw.jwt", expires_in=300, issued_at=time.time())
+        mock_sts = MagicMock()
+        mock_sts.assume_role_with_web_identity.return_value = self._mock_sts_response()
+
+        with patch("cua_sandbox._oidc.boto3") as mock_boto3:
+            mock_boto3.client.return_value = mock_sts
+            creds = await aws_credentials(
+                "arn:aws:iam::123:role/test",
+                token=token,
+                region="eu-west-1",
+            )
+
+        mock_sts.assume_role_with_web_identity.assert_called_once()
+        call_kwargs = mock_sts.assume_role_with_web_identity.call_args.kwargs
+        assert call_kwargs["WebIdentityToken"] == "raw.jwt"
+        assert call_kwargs["RoleArn"] == "arn:aws:iam::123:role/test"
+
+        assert creds.access_key_id == "ASIA..."
+        assert creds.region == "eu-west-1"
+        assert not creds.is_expired
+
+    @pytest.mark.asyncio
+    async def test_accepts_raw_string_token(self):
+        mock_sts = MagicMock()
+        mock_sts.assume_role_with_web_identity.return_value = self._mock_sts_response()
+
+        with patch("cua_sandbox._oidc.boto3") as mock_boto3:
+            mock_boto3.client.return_value = mock_sts
+            creds = await aws_credentials(
+                "arn:aws:iam::123:role/test",
+                token="raw.string.jwt",
+            )
+
+        call_kwargs = mock_sts.assume_role_with_web_identity.call_args.kwargs
+        assert call_kwargs["WebIdentityToken"] == "raw.string.jwt"
+        assert isinstance(creds, AWSCredentials)
+
+    @pytest.mark.asyncio
+    async def test_fetches_token_when_vm_name_given(self):
+        mock_sts = MagicMock()
+        mock_sts.assume_role_with_web_identity.return_value = self._mock_sts_response()
+
+        fetched_token = OIDCToken(token="fetched.jwt", expires_in=300, issued_at=time.time())
+        with patch("cua_sandbox._oidc.oidc_token", AsyncMock(return_value=fetched_token)):
+            with patch("cua_sandbox._oidc.boto3") as mock_boto3:
+                mock_boto3.client.return_value = mock_sts
+                await aws_credentials("arn:aws:iam::123:role/test", vm_name="my-vm")
+
+        call_kwargs = mock_sts.assume_role_with_web_identity.call_args.kwargs
+        assert call_kwargs["WebIdentityToken"] == "fetched.jwt"
+
+    @pytest.mark.asyncio
+    async def test_raises_without_token_or_vm_name(self):
+        with pytest.raises(ValueError, match="Provide either"):
+            await aws_credentials("arn:aws:iam::123:role/test")
+
+    @pytest.mark.asyncio
+    async def test_raises_without_boto3(self):
+        token = OIDCToken(token="t", expires_in=300, issued_at=time.time())
+        with patch.dict("sys.modules", {"boto3": None, "botocore": None, "botocore.exceptions": None}):
+            with pytest.raises(ImportError, match="boto3"):
+                await aws_credentials("arn:aws:iam::123:role/test", token=token)


### PR DESCRIPTION
## Summary

Adds two new async helpers to `cua-sandbox` that let agent workloads (running in GHA, on Modal, or in any CI) exchange their sandbox identity for short-lived cloud credentials — no static AWS keys stored anywhere.

## Usage

```python
import cua_sandbox as cua
import boto3

# Get a short-lived OIDC JWT from the CUA issuer (oidc.cua.ai)
token = await cua.oidc_token("my-sandbox", audience="sts.amazonaws.com")

# Exchange with AWS STS for Bedrock credentials (requires cloud PR #4200 to be deployed)
creds = await cua.aws_credentials(
    "arn:aws:iam::123456789012:role/cua-bedrock-role",
    vm_name="my-sandbox",   # or pass token= directly if you already have one
    region="us-east-1",
)

# Use the credentials — no secrets in env vars
bedrock = boto3.client("bedrock-runtime", **creds.to_boto3_kwargs())
```

## New exports from `cua_sandbox`

- `oidc_token(vm_name, *, audience, ttl_seconds, api_key, base_url) -> OIDCToken`
- `aws_credentials(role_arn, *, token|vm_name, region, ...) -> AWSCredentials`
- `OIDCToken` — dataclass with `.token`, `.expires_in`, `.is_expired`, `.expires_at`
- `AWSCredentials` — dataclass with `.to_boto3_kwargs()`, `.is_expired`

## AWS trust policy required (one-time setup per workspace)

```json
{
  "Condition": {
    "StringEquals": {
      "oidc.cua.ai:aud": "sts.amazonaws.com",
      "oidc.cua.ai:sub": "sandbox:workspace:acme:vm:my-sandbox"
    }
  }
}
```

## Notes

- `boto3` is an optional dependency (only needed for `aws_credentials()`)
- Tokens auto-expire after 5 minutes (configurable up to 1 hour)
- `AWSCredentials.is_expired` can be used to refresh before expiry
- Depends on cloud PR #4200 being deployed (`POST /v1/oidc/token` endpoint)

Part of CUA-484.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OIDC token exchange functionality with configurable audience and lifetime settings.
  * Added support for obtaining short-lived AWS STS credentials using OIDC tokens.
  * Extended public API with new OIDC and credential utilities.

* **Tests**
  * Added comprehensive test coverage for OIDC and AWS credential operations including expiration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->