### PR TITLE
fix(cd): pass universal binary to notarization script (fixes #1493)

### DIFF
--- a/.github/workflows/cd-swift-cua-driver.yml
+++ b/.github/workflows/cd-swift-cua-driver.yml
@@ -177,28 +177,22 @@ jobs:
           lipo -create "$ARM64_BIN" "$X86_BIN" -output .build/cua-driver-universal
           lipo -info .build/cua-driver-universal
 
-          # The notarization script builds from source; we'll inject the
-          # universal binary into the .app after the script runs.
-          # First, run the script to get the signed .app structure.
+          # Pass the universal binary to the notarization script so it is
+          # embedded in the .app (and therefore the tarballs) from the start.
+          # Without this the script rebuilds arm64-only from source, packages
+          # it into the tarball, and the post-hoc binary swap comes too late.
+          export CUA_DRIVER_PREBUILT_BINARY="$(pwd)/.build/cua-driver-universal"
+
           chmod +x scripts/build/build-release-notarized.sh
           cd scripts/build
           LOG_LEVEL=minimal ./build-release-notarized.sh
           # Return from libs/cua-driver/scripts/build back to libs/cua-driver
           cd ../..
 
-          # Replace the single-arch binary inside the .app with the universal one.
+          echo "Verifying universal binary in packaged .app..."
           APP_BINARY=".release/CuaDriver.app/Contents/MacOS/cua-driver"
           if [ -f "$APP_BINARY" ]; then
-            cp .build/cua-driver-universal "$APP_BINARY"
-            # Re-sign the binary (the .app is already signed; we need to
-            # re-sign just the binary slice we replaced).
-            codesign --force --sign "$CERT_APPLICATION_NAME" \
-              --options runtime \
-              --entitlements scripts/build/entitlements.plist \
-              "$APP_BINARY" || true
-            echo "Universal binary injected and re-signed."
-          else
-            echo "Warning: app binary not found at $APP_BINARY — using architecture-specific release."
+            lipo -info "$APP_BINARY"
           fi
 
           echo "Files in .release directory:"

--- a/libs/cua-driver/scripts/build/build-release-notarized.sh
+++ b/libs/cua-driver/scripts/build/build-release-notarized.sh
@@ -60,9 +60,16 @@ cd "$CUA_DRIVER_DIR"
 mkdir -p .release
 log "normal" "Ensuring .release directory exists and is accessible"
 
-# Build the release version
-log "essential" "Building release version..."
-swift build -c release --product cua-driver > /dev/null
+# Build or use a prebuilt binary (e.g. a pre-lipo'd universal binary from CI).
+# Set CUA_DRIVER_PREBUILT_BINARY to an absolute path to skip swift build entirely.
+if [ -n "${CUA_DRIVER_PREBUILT_BINARY:-}" ]; then
+    log "essential" "Using prebuilt binary: $CUA_DRIVER_PREBUILT_BINARY"
+    BUILT_BINARY="$CUA_DRIVER_PREBUILT_BINARY"
+else
+    log "essential" "Building release version..."
+    swift build -c release --product cua-driver > /dev/null
+    BUILT_BINARY=".build/release/cua-driver"
+fi
 
 # --- Assemble .app bundle ---
 log "essential" "Assembling .app bundle..."
@@ -73,7 +80,7 @@ mkdir -p "$APP_BUNDLE/Contents/MacOS"
 mkdir -p "$APP_BUNDLE/Contents/Resources"
 
 # Copy the binary into the bundle
-cp -f .build/release/cua-driver "$APP_BUNDLE/Contents/MacOS/cua-driver"
+cp -f "$BUILT_BINARY" "$APP_BUNDLE/Contents/MacOS/cua-driver"
 
 # Stamp and copy Info.plist — the source plist ships with a static
 # `CFBundleShortVersionString` for dev builds; substitute the release


### PR DESCRIPTION
## Problem

The CD workflow correctly built arm64 + x86\_64 and combined them with `lipo` into a universal binary, but then called `build-release-notarized.sh` **without** `CUA_DRIVER_PREBUILT_BINARY`. The script would:

1. Rebuild from source (arm64 only via `swift build -c release`)
2. Package the arm64 binary into `.app` and then into the tarball
3. The workflow's post-hoc `cp .build/cua-driver-universal` only updated the `.app` on disk — the tarball was already sealed

Result: **every released tarball** (`-arm64`, `-x86_64`, `-universal`) contained an arm64-only binary. Intel users got `zsh: bad CPU type in executable` (#1493 / reported by @jakechism).

## Fix

- Export `CUA_DRIVER_PREBUILT_BINARY="$(pwd)/.build/cua-driver-universal"` **before** calling the notarization script so it uses the fat binary when assembling the `.app` and creating tarballs
- Add `CUA_DRIVER_PREBUILT_BINARY` support to `build-release-notarized.sh` (skips `swift build`, uses the provided binary path)
- Replace the post-hoc binary injection block with a `lipo -info` verification so it's clear from CI logs whether the packaged binary is actually universal
- Backward-compatible: running the script locally without the env var still builds from source as before

## Test plan

- [ ] Trigger CD workflow for a new `cua-driver-v*` tag
- [ ] In the "Build arm64 + x86_64" step logs, confirm `lipo -info` reports `Architectures in the fat file: arm64 x86_64`
- [ ] Download the released `-x86_64.tar.gz` and run `file cua-driver` — expect `Mach-O universal binary with 2 architectures`
- [ ] Install on an Intel Mac and confirm `cua-driver --version` works

Fixes #1493

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * **Streamlined macOS release workflow** - Optimized the application packaging and notarization process to support prebuilt binaries. Previously, the system would build applications, then package them, and finally re-sign them. Now, prebuilt binaries are embedded directly during assembly, reducing redundant steps and improving the efficiency of generating notarized macOS applications.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1494)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->