### PR TITLE
fix(agent): handle zero coordinates in predict_click

### DIFF
--- a/libs/python/agent/cua_agent/loops/anthropic.py
+++ b/libs/python/agent/cua_agent/loops/anthropic.py
@@ -1947,7 +1947,7 @@ Task: Click {instruction}. Output ONLY a click action on the target element.""",
             ):
 
                 action = item["action"]
-                if action.get("x") and action.get("y"):
+                if action.get("x") is not None and action.get("y") is not None:
                     x = action.get("x")
                     y = action.get("y")
                     return (int(x), int(y))

--- a/libs/python/agent/tests/test_predict_click.py
+++ b/libs/python/agent/tests/test_predict_click.py
@@ -1,0 +1,132 @@
+"""Tests for predict_click handling of zero coordinates.
+
+Regression test for https://github.com/trycua/cua/issues/1400
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+MINIMAL_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"
+    "AAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+
+
+def _make_click_response(x, y):
+    """Build a liteLLM completion response containing a click tool_use."""
+    from unittest.mock import MagicMock
+
+    message = MagicMock()
+    message.content = [
+        {
+            "type": "tool_use",
+            "id": "toolu_test",
+            "name": "computer",
+            "input": {"action": "click", "coordinate": [x, y]},
+        }
+    ]
+    choice = MagicMock()
+    choice.message = message
+    response = MagicMock()
+    response.choices = [choice]
+    return response
+
+
+def _make_text_only_response():
+    from unittest.mock import MagicMock
+
+    message = MagicMock()
+    message.content = "No click here"
+    choice = MagicMock()
+    choice.message = message
+    response = MagicMock()
+    response.choices = [choice]
+    return response
+
+
+class TestAnthropicPredictClickZeroCoordinates:
+    """Regression tests for #1400: predict_click must handle x=0 and y=0."""
+
+    @pytest.mark.asyncio
+    @patch("litellm.acompletion", new_callable=AsyncMock)
+    async def test_predict_click_x_zero(self, mock_acompletion, disable_telemetry):
+        from cua_agent.loops.anthropic import AnthropicHostedToolsConfig
+
+        mock_acompletion.return_value = _make_click_response(0, 300)
+
+        config = AnthropicHostedToolsConfig()
+        result = await config.predict_click(
+            model="anthropic/claude-sonnet-4-5-20250929",
+            image_b64=MINIMAL_PNG_B64,
+            instruction="click the left edge",
+        )
+
+        assert result is not None, "predict_click returned None for x=0"
+        assert result == (0, 300)
+
+    @pytest.mark.asyncio
+    @patch("litellm.acompletion", new_callable=AsyncMock)
+    async def test_predict_click_y_zero(self, mock_acompletion, disable_telemetry):
+        from cua_agent.loops.anthropic import AnthropicHostedToolsConfig
+
+        mock_acompletion.return_value = _make_click_response(500, 0)
+
+        config = AnthropicHostedToolsConfig()
+        result = await config.predict_click(
+            model="anthropic/claude-sonnet-4-5-20250929",
+            image_b64=MINIMAL_PNG_B64,
+            instruction="click the top edge",
+        )
+
+        assert result is not None, "predict_click returned None for y=0"
+        assert result == (500, 0)
+
+    @pytest.mark.asyncio
+    @patch("litellm.acompletion", new_callable=AsyncMock)
+    async def test_predict_click_both_zero(self, mock_acompletion, disable_telemetry):
+        from cua_agent.loops.anthropic import AnthropicHostedToolsConfig
+
+        mock_acompletion.return_value = _make_click_response(0, 0)
+
+        config = AnthropicHostedToolsConfig()
+        result = await config.predict_click(
+            model="anthropic/claude-sonnet-4-5-20250929",
+            image_b64=MINIMAL_PNG_B64,
+            instruction="click the top-left pixel",
+        )
+
+        assert result is not None, "predict_click returned None for (0, 0)"
+        assert result == (0, 0)
+
+    @pytest.mark.asyncio
+    @patch("litellm.acompletion", new_callable=AsyncMock)
+    async def test_predict_click_normal_coordinates(self, mock_acompletion, disable_telemetry):
+        from cua_agent.loops.anthropic import AnthropicHostedToolsConfig
+
+        mock_acompletion.return_value = _make_click_response(512, 384)
+
+        config = AnthropicHostedToolsConfig()
+        result = await config.predict_click(
+            model="anthropic/claude-sonnet-4-5-20250929",
+            image_b64=MINIMAL_PNG_B64,
+            instruction="click the center",
+        )
+
+        assert result == (512, 384)
+
+    @pytest.mark.asyncio
+    @patch("litellm.acompletion", new_callable=AsyncMock)
+    async def test_predict_click_no_click_action(self, mock_acompletion, disable_telemetry):
+        from cua_agent.loops.anthropic import AnthropicHostedToolsConfig
+
+        mock_acompletion.return_value = _make_text_only_response()
+
+        config = AnthropicHostedToolsConfig()
+        result = await config.predict_click(
+            model="anthropic/claude-sonnet-4-5-20250929",
+            image_b64=MINIMAL_PNG_B64,
+            instruction="click something",
+        )
+
+        assert result is None


### PR DESCRIPTION
## Summary

Small fix for #1400 — `predict_click` silently returned `None` when either `x` or `y` was `0`, since the existing truthiness check treated `0` as falsy.

**Before:** `if action.get("x") and action.get("y")`
**After:** `if action.get("x") is not None and action.get("y") is not None`

## Changes

- **`libs/python/agent/cua_agent/loops/anthropic.py`** — one-line fix at the coordinate validation check
- **`libs/python/agent/tests/test_predict_click.py`** — 5 regression tests covering `(0, y)`, `(x, 0)`, `(0, 0)`, normal coordinates, and no-click response

## Testing

All 29 tests pass (24 existing + 5 new):

- `test_predict_click_x_zero` — click at (0, 300) returns `(0, 300)`, not `None`
- `test_predict_click_y_zero` — click at (500, 0) returns `(500, 0)`, not `None`
- `test_predict_click_both_zero` — click at (0, 0) returns `(0, 0)`, not `None`
- `test_predict_click_normal_coordinates` — click at (512, 384) works as before
- `test_predict_click_no_click_action` — text-only response returns `None`

Happy to adjust anything — thanks for the great project!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed click coordinate extraction to correctly handle zero values (e.g., clicks at position `(0, 0)` or with `x=0`/`y=0`).

* **Tests**
  * Added regression tests to ensure click coordinate handling works correctly for zero and non-zero coordinate values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1495)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->