### PR TITLE
[codex] Fix TypeScript computer test contract and reconnect

### DIFF
--- a/libs/typescript/computer/src/interface/base.ts
+++ b/libs/typescript/computer/src/interface/base.ts
@@ -65,15 +65,28 @@ export abstract class BaseComputerInterface {
     this.telemetry = new Telemetry();
     this.sessionId = uuidv4();
 
-    // Initialize WebSocket with headers if needed
+    // Create the WebSocket instance
+    this.ws = this.createWebSocket();
+  }
+
+  private createWebSocket(): WebSocket {
     const headers: { [key: string]: string } = {};
     if (this.apiKey && this.vmName) {
       headers['X-API-Key'] = this.apiKey;
       headers['X-VM-Name'] = this.vmName;
     }
 
-    // Create the WebSocket instance
-    this.ws = new WebSocket(this.wsUri, { headers });
+    const ws = new WebSocket(this.wsUri, { headers });
+    ws.on('close', () => {
+      if (!this.closed && this.ws === ws) {
+        setTimeout(() => {
+          void this.connect().catch((error) => {
+            this.logger.error(`Error reconnecting websocket: ${JSON.stringify(error)}`);
+          });
+        }, 1000);
+      }
+    });
+    return ws;
   }
 
   /**
@@ -164,6 +177,8 @@ export abstract class BaseComputerInterface {
    * Connect to the WebSocket server.
    */
   public async connect(): Promise<void> {
+    this.closed = false;
+
     // If the WebSocket is already open, check if we need to authenticate
     if (this.ws.readyState === WebSocket.OPEN) {
       this.logger.info('Websocket is open, ensuring authentication is complete.');
@@ -173,49 +188,62 @@ export abstract class BaseComputerInterface {
     // If the WebSocket is closed or closing, reinitialize it
     if (this.ws.readyState === WebSocket.CLOSED || this.ws.readyState === WebSocket.CLOSING) {
       this.logger.info('Websocket is closed. Reinitializing connection.');
-      const headers: { [key: string]: string } = {};
-      if (this.apiKey && this.vmName) {
-        headers['X-API-Key'] = this.apiKey;
-        headers['X-VM-Name'] = this.vmName;
-      }
-      this.ws = new WebSocket(this.wsUri, { headers });
-      return this.authenticate();
+      this.ws = this.createWebSocket();
     }
 
     // Connect and authenticate
     return new Promise((resolve, reject) => {
+      const ws = this.ws;
+      let settled = false;
+
+      const cleanup = () => {
+        ws.off('open', onOpen);
+        ws.off('error', onError);
+        ws.off('close', onClose);
+      };
+
       const onOpen = async () => {
         try {
           // Always authenticate immediately after connection
           await this.authenticate();
+          settled = true;
+          cleanup();
           resolve();
         } catch (error) {
+          settled = true;
+          cleanup();
           reject(error);
         }
       };
 
+      const onError = (error: Error) => {
+        if (!settled) {
+          settled = true;
+          cleanup();
+          reject(error);
+        }
+      };
+
+      const onClose = () => {
+        if (!settled) {
+          settled = true;
+          cleanup();
+          reject(new Error('WebSocket closed before connection established'));
+        }
+      };
+
       // If already connecting, wait for it to complete then authenticate
-      if (this.ws.readyState === WebSocket.CONNECTING) {
-        this.ws.addEventListener('open', onOpen, { once: true });
-        this.ws.addEventListener('error', (error) => reject(error), {
-          once: true,
-        });
+      if (ws.readyState === WebSocket.CONNECTING) {
+        ws.once('open', onOpen);
+        ws.once('error', onError);
+        ws.once('close', onClose);
         return;
       }
 
       // Set up event handlers
-      this.ws.on('open', onOpen);
-
-      this.ws.on('error', (error: Error) => {
-        reject(error);
-      });
-
-      this.ws.on('close', () => {
-        if (!this.closed) {
-          // Attempt to reconnect
-          setTimeout(() => this.connect(), 1000);
-        }
-      });
+      ws.once('open', onOpen);
+      ws.once('error', onError);
+      ws.once('close', onClose);
     });
   }
 

--- a/libs/typescript/computer/tests/interface/macos.test.ts
+++ b/libs/typescript/computer/tests/interface/macos.test.ts
@@ -115,7 +115,9 @@ describe('MacOSComputerInterface', () => {
             case 'read_bytes':
               ws.send(
                 JSON.stringify({
-                  content_b64: Buffer.from('binary content').toString('base64'),
+                  content_b64: Buffer.from(
+                    message.params?.path === '/path/to/file.txt' ? 'file content' : 'binary content'
+                  ).toString('base64'),
                   success: true,
                 })
               );
@@ -674,9 +676,10 @@ describe('MacOSComputerInterface', () => {
 
       const lastMessage = receivedMessages[receivedMessages.length - 1];
       expect(lastMessage).toEqual({
-        command: 'read_text',
+        command: 'read_bytes',
         params: {
           path: '/path/to/file.txt',
+          offset: 0,
         },
       });
     });
@@ -686,10 +689,11 @@ describe('MacOSComputerInterface', () => {
 
       const lastMessage = receivedMessages[receivedMessages.length - 1];
       expect(lastMessage).toEqual({
-        command: 'write_text',
+        command: 'write_bytes',
         params: {
           path: '/path/to/file.txt',
-          content: 'new content',
+          content_b64: Buffer.from('new content').toString('base64'),
+          append: false,
         },
       });
     });
@@ -705,6 +709,7 @@ describe('MacOSComputerInterface', () => {
         command: 'read_bytes',
         params: {
           path: '/path/to/file.bin',
+          offset: 0,
         },
       });
     });
@@ -719,6 +724,7 @@ describe('MacOSComputerInterface', () => {
         params: {
           path: '/path/to/file.bin',
           content_b64: buffer.toString('base64'),
+          append: false,
         },
       });
     });


### PR DESCRIPTION
Closed in favor of a replacement PR created via local `gh` from the intended contributor account (`iqdoctor`).

Original body:

## Summary

- fixes `BaseComputerInterface.connect()` so reconnect after a closed socket waits for the recreated WebSocket to open before sending commands
- updates `MacOSComputerInterface` tests to assert the current byte-transport file contract used by TS and Python generic interfaces
- covers default `offset: 0` and `append: false` transport parameters

Closes #1499.

## Validation

```bash
cd libs/typescript
pnpm --filter @trycua/computer test --run
pnpm --filter @trycua/computer typecheck
pnpm --filter @trycua/core test --run
pnpm --filter @trycua/agent test --run
pnpm build
pnpm exec prettier --check computer/src/interface/base.ts computer/tests/interface/macos.test.ts
pnpm -r typecheck
```

Not run: `pnpm -r test`, because `@trycua/playground` has no test files and exits nonzero.