### PR TITLE
fix(docs): add missing /docs prefix in doc actions menu URLs

### DIFF
--- a/docs/src/components/doc-actions-menu.tsx
+++ b/docs/src/components/doc-actions-menu.tsx
@@ -40,7 +40,7 @@ export function DocActionsMenu({ pageUrl, pageTitle, filePath }: DocActionsMenuP
       console.error('Error copying markdown:', error);
 
       try {
-        const urlWithUtm = `https://cua.ai${pageUrl}?utm_source=cua.ai/docs`;
+        const urlWithUtm = `https://cua.ai/docs${pageUrl}?utm_source=cua.ai/docs`;
         await navigator.clipboard.writeText(urlWithUtm);
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
@@ -76,7 +76,7 @@ export function DocActionsMenu({ pageUrl, pageTitle, filePath }: DocActionsMenuP
       page_title: pageTitle,
     });
 
-    const docUrl = `https://cua.ai${pageUrl}?utm_source=cua.ai/docs`;
+    const docUrl = `https://cua.ai/docs${pageUrl}?utm_source=cua.ai/docs`;
     const prompt = `I need help understanding this cua.ai documentation page: "${pageTitle}". Please read and help me with: ${docUrl}`;
     const chatgptUrl = `https://chatgpt.com/?q=${encodeURIComponent(prompt)}`;
     window.open(chatgptUrl, '_blank', 'noopener,noreferrer');
@@ -88,7 +88,7 @@ export function DocActionsMenu({ pageUrl, pageTitle, filePath }: DocActionsMenuP
       page_title: pageTitle,
     });
 
-    const docUrl = `https://cua.ai${pageUrl}?utm_source=cua.ai/docs`;
+    const docUrl = `https://cua.ai/docs${pageUrl}?utm_source=cua.ai/docs`;
     const prompt = `I need help understanding this cua.ai documentation page: "${pageTitle}". Please read and help me with: ${docUrl}`;
     const claudeUrl = `https://claude.ai/new?q=${encodeURIComponent(prompt)}`;
     window.open(claudeUrl, '_blank', 'noopener,noreferrer');


### PR DESCRIPTION
## Summary

The doc actions menu component (`DocActionsMenu`) was constructing URLs
without the `/docs` path segment, resulting in broken links.

**Example (Quickstart page):**
- **Before:** `https://cua.ai/cua/guide/get-started/quickstart?utm_source=cua.ai/docs`
- **After:** `https://cua.ai/docs/cua/guide/get-started/quickstart?utm_source=cua.ai/docs`

The root cause is that `page.url` from fumadocs (configured with `baseUrl: '/'`)
returns paths like `/cua/guide/...` without the `/docs` prefix, but the live site
serves documentation under `cua.ai/docs/...`.

## Changes

**`docs/src/components/doc-actions-menu.tsx`**

Fixed 3 URL constructions that were missing the `/docs` prefix:

- `handleCopyMarkdown` — fallback URL copied to clipboard on error
- `handleOpenChatGPT` — URL sent to ChatGPT as context
- `handleOpenClaude` — URL sent to Claude as context

This is consistent with how `generateMetadata` in `page.tsx` already constructs
the canonical URL: `` `https://cua.ai/docs${page.url}` ``



## How I identified the issue:

<img width="1042" height="558" alt="image" src="https://github.com/user-attachments/assets/8d8cefac-b4ed-4dd5-8a00-df21a4c9ca24" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL path generation for documentation links used in copy functionality and ChatGPT/Claude integrations to ensure consistent and correct formatting across all sharing methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1509)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->