### PR TITLE
fix(cua-driver-rs): use darwin-universal-binary in install.sh (fixes 403 on macOS)

### DIFF
--- a/libs/cua-driver-rs/scripts/install.sh
+++ b/libs/cua-driver-rs/scripts/install.sh
@@ -100,8 +100,19 @@ VERSION="${TAG#${TAG_PREFIX}}"
 
 # Prefer the bare-binary tarball (single `cua-driver` file at the root) —
 # the directory tarball would require unpacking and copying, but the bare
-# form is curl-pipe-able. Both forms are published per release.
-TARBALL="cua-driver-rs-${VERSION}-${LABEL}-binary.tar.gz"
+# form is curl-pipe-able.
+#
+# macOS: the release workflow publishes one universal binary (arm64 + x86_64
+# lipo'd together) named `darwin-universal-binary`.  There are NO per-arch
+# bare-binary tarballs for macOS — only the directory tarballs are split
+# by arch (darwin-arm64 / darwin-x86_64).  The universal binary works on
+# both Apple Silicon and Intel, so we always fetch it on macOS.
+#
+# Linux: per-arch bare-binary tarballs exist (e.g. linux-x86_64-binary).
+case "$LABEL" in
+    darwin-*) TARBALL="cua-driver-rs-${VERSION}-darwin-universal-binary.tar.gz" ;;
+    *)        TARBALL="cua-driver-rs-${VERSION}-${LABEL}-binary.tar.gz" ;;
+esac
 URL="https://github.com/$REPO/releases/download/$TAG/$TARBALL"
 
 log "downloading $URL"


### PR DESCRIPTION
## Summary

- The `cua-driver-rs/scripts/install.sh` was trying to download `cua-driver-rs-{v}-darwin-{arch}-binary.tar.gz` (e.g. `darwin-arm64-binary`, `darwin-x86_64-binary`) which **don't exist** in any release
- The CD workflow only produces one macOS bare-binary tarball: `darwin-universal-binary` (arm64 + x86_64 lipo'd together)
- GitHub's CDN returns a 4xx for the missing asset, which users reported as a 403

## Fix

Added a `case` branch in the download section: macOS always fetches `darwin-universal-binary`; Linux continues to use per-arch bare binaries as before.

```bash
case "$LABEL" in
    darwin-*) TARBALL="cua-driver-rs-${VERSION}-darwin-universal-binary.tar.gz" ;;
    *)        TARBALL="cua-driver-rs-${VERSION}-${LABEL}-binary.tar.gz" ;;
esac
```

## Verification

```bash
# These exist (302 redirect to S3):
curl -I https://github.com/trycua/cua/releases/download/cua-driver-rs-v0.1.3/cua-driver-rs-0.1.3-darwin-universal-binary.tar.gz

# This did NOT exist (404/403):
curl -I https://github.com/trycua/cua/releases/download/cua-driver-rs-v0.1.3/cua-driver-rs-0.1.3-darwin-arm64-binary.tar.gz
```

## Test plan

- [ ] Run install script on macOS arm64: `bash libs/cua-driver-rs/scripts/install.sh`
- [ ] Run install script on macOS x86_64
- [ ] Run install script on Linux x86_64 (should be unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Updated installer to use universal binary distribution for macOS systems, ensuring consistent installation across all architectures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1516)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->