### PR TITLE
cd(cua-driver): bake latest version into install.sh after each release

### DIFF
--- a/.github/workflows/cd-swift-cua-driver.yml
+++ b/.github/workflows/cd-swift-cua-driver.yml
@@ -376,3 +376,24 @@ jobs:
             > Supports Apple Silicon (arm64) and Intel (x86_64) — the release tarball contains a universal binary.
           generate_release_notes: false
           make_latest: true
+
+      - name: Bake version into install.sh
+        if: startsWith(github.ref, 'refs/tags/cua-driver-v')
+        env:
+          VERSION: ${{ steps.set_version.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Fetch main so we update the live branch, not the detached tag HEAD.
+          git fetch origin main
+          git checkout -B bake-version origin/main
+
+          # Replace the baked version line inside the sentinel block.
+          sed -i '' \
+            "s/^CUA_DRIVER_BAKED_VERSION=.*/CUA_DRIVER_BAKED_VERSION=\"${VERSION}\"/" \
+            libs/cua-driver/scripts/install.sh
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add libs/cua-driver/scripts/install.sh
+          git commit -m "chore(cua-driver): bake version ${VERSION} into install.sh [skip ci]"
+          git push origin bake-version:main

--- a/libs/cua-driver/scripts/install.sh
+++ b/libs/cua-driver/scripts/install.sh
@@ -62,10 +62,22 @@ for cmd in curl tar; do
 done
 
 # --- Resolve release tag ------------------------------------------------
+#
+# Version is resolved in priority order:
+#   1. CUA_DRIVER_VERSION env var (explicit pin)
+#   2. BAKED_VERSION below (set automatically by CD after each release — no API call needed)
+#   3. GitHub Releases API (fallback; unauthenticated = 60 req/hr per IP)
+#
+# ~~~ BAKED_VERSION: auto-updated by CD workflow after each release — do not edit ~~~
+CUA_DRIVER_BAKED_VERSION="0.1.9"
+# ~~~ END_BAKED_VERSION ~~~
 
 if [[ -n "${CUA_DRIVER_VERSION:-}" ]]; then
     TAG="${TAG_PREFIX}${CUA_DRIVER_VERSION#v}"
     log "using version from CUA_DRIVER_VERSION: $TAG"
+elif [[ -n "${CUA_DRIVER_BAKED_VERSION:-}" ]]; then
+    TAG="${TAG_PREFIX}${CUA_DRIVER_BAKED_VERSION}"
+    log "latest release: $TAG"
 else
     log "resolving latest $TAG_PREFIX* release via GitHub API"
     # `grep -v cua-driver-rs` is defense-in-depth — the Rust port (cua-driver-rs)
@@ -73,7 +85,7 @@ else
     # current grep regex `cua-driver-v[^"]+` already excludes it (differs at
     # position 11: 'r' vs 'v'), but the negation guards against any future
     # regex tweak that might accidentally widen the match.
-    TAG=$(curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=40" \
+    TAG=$(curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=100" \
         | grep -Eo '"tag_name":[[:space:]]*"'"${TAG_PREFIX}"'[^"]+"' \
         | grep -v 'cua-driver-rs' \
         | sed -E 's/.*"'"${TAG_PREFIX}"'([0-9]+[.][0-9]+[.][0-9]+)"/\1/' \


### PR DESCRIPTION
## Summary

- Adds a `BAKED_VERSION` sentinel block to `libs/cua-driver/scripts/install.sh` that the CD workflow updates automatically after every `cua-driver-v*` release
- Version resolution is now: env var override → baked version (no API call) → GitHub API fallback
- Fixes 403 errors seen by `hermes computer-use install` users on shared NAT/VPN IPs that exhaust the 60 req/hr GitHub unauthenticated rate limit
- Also bumps `per_page` from 40 → 100 on the API fallback path so future releases never fall off the page

## How it works

**`install.sh`** gains a sentinel block kept in sync by CI:
```bash
# ~~~ BAKED_VERSION: auto-updated by CD workflow after each release — do not edit ~~~
CUA_DRIVER_BAKED_VERSION="0.1.9"
# ~~~ END_BAKED_VERSION ~~~
```

The tag resolution block now tries the baked version before falling back to the API:
```bash
if   [[ -n "${CUA_DRIVER_VERSION:-}" ]];       then TAG=...  # env pin
elif [[ -n "${CUA_DRIVER_BAKED_VERSION:-}" ]]; then TAG=...  # baked (no API)
else                                                TAG=$(curl api.github.com ...)  # fallback
fi
```

**`cd-swift-cua-driver.yml`** gains a post-release step:
```yaml
- name: Bake version into install.sh
  # fetches main, sed-replaces CUA_DRIVER_BAKED_VERSION, commits, pushes main
```

## Test plan

- [ ] Trigger a `cua-driver-v*` release and confirm the CD step commits an updated `CUA_DRIVER_BAKED_VERSION` line to main
- [ ] Run `install.sh` and confirm it prints `latest release: cua-driver-vX.Y.Z` without making any GitHub API calls (check with `tcpdump` or network proxy if needed)
- [ ] Confirm `CUA_DRIVER_VERSION=0.1.8 ./install.sh` still overrides the baked version correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)