### PR TITLE
fix(cua-driver-rs): macOS install 404 + config set not persisting to MCP sessions

### DIFF
--- a/libs/cua-driver-rs/crates/platform-macos/src/tools/mod.rs
+++ b/libs/cua-driver-rs/crates/platform-macos/src/tools/mod.rs
@@ -120,6 +120,53 @@ impl Default for DriverConfig {
     }
 }
 
+/// Path to the persistent JSON config file shared by the CLI and MCP session.
+pub fn config_file_path() -> std::path::PathBuf {
+    let home = std::env::var("HOME").unwrap_or_default();
+    std::path::PathBuf::from(format!("{home}/.cua-driver/config.json"))
+}
+
+/// Load `DriverConfig` from `~/.cua-driver/config.json`, falling back to
+/// defaults for any missing or unrecognised keys.  Called at MCP startup so
+/// that `cua-driver config set capture_mode vision` (CLI) carries over into
+/// the next MCP session without requiring a per-call `set_config`.
+pub fn load_driver_config() -> DriverConfig {
+    let mut cfg = DriverConfig::default();
+    let path = config_file_path();
+    let text = match std::fs::read_to_string(&path) {
+        Ok(t) => t,
+        Err(_) => return cfg,  // no file yet — use defaults
+    };
+    let json: serde_json::Value = match serde_json::from_str(&text) {
+        Ok(v) => v,
+        Err(_) => return cfg,  // malformed file — use defaults
+    };
+    if let Some(v) = json.get("capture_mode").and_then(|v| v.as_str()) {
+        cfg.capture_mode = v.to_owned();
+    }
+    if let Some(v) = json.get("max_image_dimension").and_then(|v| v.as_u64()) {
+        cfg.max_image_dimension = v as u32;
+    }
+    cfg
+}
+
+/// Persist a single key/value pair to `~/.cua-driver/config.json`.
+/// Merges with any existing file contents so other keys are preserved.
+pub fn write_driver_config_key(key: &str, value: &serde_json::Value) {
+    let path = config_file_path();
+    let mut json: serde_json::Value = path
+        .exists()
+        .then(|| std::fs::read_to_string(&path).ok())
+        .flatten()
+        .and_then(|t| serde_json::from_str(&t).ok())
+        .unwrap_or_else(|| serde_json::json!({}));
+    json[key] = value.clone();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(&path, serde_json::to_string_pretty(&json).unwrap_or_default());
+}
+
 /// Shared state passed to all tools.
 pub struct ToolState {
     pub element_cache: Arc<ElementCache>,
@@ -136,7 +183,9 @@ impl Default for ToolState {
             cursor_registry: Arc::new(CursorRegistry::new()),
             zoom_registry: Arc::new(ZoomRegistry::new()),
             resize_registry: Arc::new(ResizeRegistry::new()),
-            config: Arc::new(std::sync::RwLock::new(DriverConfig::default())),
+            // Load persisted config from ~/.cua-driver/config.json so that
+            // `cua-driver config set` changes carry over into MCP sessions.
+            config: Arc::new(std::sync::RwLock::new(load_driver_config())),
         }
     }
 }

--- a/libs/cua-driver-rs/crates/platform-macos/src/tools/mod.rs
+++ b/libs/cua-driver-rs/crates/platform-macos/src/tools/mod.rs
@@ -145,14 +145,17 @@ pub fn load_driver_config() -> DriverConfig {
         cfg.capture_mode = v.to_owned();
     }
     if let Some(v) = json.get("max_image_dimension").and_then(|v| v.as_u64()) {
-        cfg.max_image_dimension = v as u32;
+        if let Ok(v32) = u32::try_from(v) {
+            cfg.max_image_dimension = v32;
+        }
     }
     cfg
 }
 
 /// Persist a single key/value pair to `~/.cua-driver/config.json`.
 /// Merges with any existing file contents so other keys are preserved.
-pub fn write_driver_config_key(key: &str, value: &serde_json::Value) {
+/// Returns `Err` if the directory cannot be created or the file cannot be written.
+pub fn write_driver_config_key(key: &str, value: &serde_json::Value) -> Result<(), String> {
     let path = config_file_path();
     let mut json: serde_json::Value = path
         .exists()
@@ -162,9 +165,11 @@ pub fn write_driver_config_key(key: &str, value: &serde_json::Value) {
         .unwrap_or_else(|| serde_json::json!({}));
     json[key] = value.clone();
     if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
-    let _ = std::fs::write(&path, serde_json::to_string_pretty(&json).unwrap_or_default());
+    let body = serde_json::to_string_pretty(&json).map_err(|e| e.to_string())?;
+    std::fs::write(&path, body).map_err(|e| e.to_string())?;
+    Ok(())
 }
 
 /// Shared state passed to all tools.

--- a/libs/cua-driver-rs/crates/platform-macos/src/tools/set_config.rs
+++ b/libs/cua-driver-rs/crates/platform-macos/src/tools/set_config.rs
@@ -3,7 +3,7 @@ use mcp_server::{protocol::ToolResult, tool::{Tool, ToolDef}};
 use serde_json::Value;
 use std::sync::Arc;
 
-use super::ToolState;
+use super::{write_driver_config_key, ToolState};
 
 pub struct SetConfigTool {
     state: Arc<ToolState>,
@@ -49,9 +49,11 @@ impl Tool for SetConfigTool {
         let mut cfg = self.state.config.write().unwrap();
         if let Some(mode) = args.get("capture_mode").and_then(|v| v.as_str()) {
             cfg.capture_mode = mode.to_owned();
+            write_driver_config_key("capture_mode", &Value::String(mode.to_owned()));
         }
         if let Some(dim) = args.get("max_image_dimension").and_then(|v| v.as_u64()) {
             cfg.max_image_dimension = dim as u32;
+            write_driver_config_key("max_image_dimension", &Value::Number(dim.into()));
         }
         ToolResult::text(format!(
             "Config updated: capture_mode={}, max_image_dimension={}",

--- a/libs/cua-driver-rs/crates/platform-macos/src/tools/set_config.rs
+++ b/libs/cua-driver-rs/crates/platform-macos/src/tools/set_config.rs
@@ -49,11 +49,19 @@ impl Tool for SetConfigTool {
         let mut cfg = self.state.config.write().unwrap();
         if let Some(mode) = args.get("capture_mode").and_then(|v| v.as_str()) {
             cfg.capture_mode = mode.to_owned();
-            write_driver_config_key("capture_mode", &Value::String(mode.to_owned()));
+            if let Err(e) = write_driver_config_key("capture_mode", &Value::String(mode.to_owned())) {
+                tracing::warn!("set_config: failed to persist capture_mode: {e}");
+            }
         }
         if let Some(dim) = args.get("max_image_dimension").and_then(|v| v.as_u64()) {
-            cfg.max_image_dimension = dim as u32;
-            write_driver_config_key("max_image_dimension", &Value::Number(dim.into()));
+            if let Ok(dim32) = u32::try_from(dim) {
+                cfg.max_image_dimension = dim32;
+                if let Err(e) = write_driver_config_key("max_image_dimension", &Value::Number(dim.into())) {
+                    tracing::warn!("set_config: failed to persist max_image_dimension: {e}");
+                }
+            } else {
+                return ToolResult::error(format!("max_image_dimension {dim} exceeds u32::MAX"));
+            }
         }
         ToolResult::text(format!(
             "Config updated: capture_mode={}, max_image_dimension={}",

--- a/libs/cua-driver-rs/scripts/install.sh
+++ b/libs/cua-driver-rs/scripts/install.sh
@@ -100,8 +100,19 @@ VERSION="${TAG#${TAG_PREFIX}}"
 
 # Prefer the bare-binary tarball (single `cua-driver` file at the root) —
 # the directory tarball would require unpacking and copying, but the bare
-# form is curl-pipe-able. Both forms are published per release.
-TARBALL="cua-driver-rs-${VERSION}-${LABEL}-binary.tar.gz"
+# form is curl-pipe-able.
+#
+# macOS: the release workflow publishes one universal binary (arm64 + x86_64
+# lipo'd together) named `darwin-universal-binary`.  There are NO per-arch
+# bare-binary tarballs for macOS — only the directory tarballs are split
+# by arch (darwin-arm64 / darwin-x86_64).  The universal binary works on
+# both Apple Silicon and Intel, so we always fetch it on macOS.
+#
+# Linux: per-arch bare-binary tarballs exist (e.g. linux-x86_64-binary).
+case "$LABEL" in
+    darwin-*) TARBALL="cua-driver-rs-${VERSION}-darwin-universal-binary.tar.gz" ;;
+    *)        TARBALL="cua-driver-rs-${VERSION}-${LABEL}-binary.tar.gz" ;;
+esac
 URL="https://github.com/$REPO/releases/download/$TAG/$TARBALL"
 
 log "downloading $URL"


### PR DESCRIPTION
## Summary

Two bugs reported after the cua-driver-rs beta drop:

### 1. Install script 404 on Apple Silicon (and Intel)

The script built the download URL as `cua-driver-rs-{ver}-darwin-arm64-binary.tar.gz` but the release only publishes `darwin-universal-binary.tar.gz` (a single lipo'd arm64+x86_64 binary). Per-arch bare-binary tarballs don't exist for macOS.

**Fix:** Collapse all `darwin-*` labels to the universal tarball name in a `case` block; Linux per-arch tarballs (`linux-x86_64-binary`) are unchanged.

```
Before: cua-driver-rs-0.1.3-darwin-arm64-binary.tar.gz  ← 404
After:  cua-driver-rs-0.1.3-darwin-universal-binary.tar.gz  ← ✓
```

### 2. `config set capture_mode vision` not visible in MCP sessions

`cua-driver config set capture_mode vision` persisted to `~/.cua-driver/config.json`, but every `cua-driver mcp` invocation initialised `DriverConfig` from hardcoded defaults (`som`), silently ignoring the file. MCP clients that opted into `vision` via the CLI were still paying the full AX-tree walk cost every turn.

**Fix (two parts):**
- `ToolState::default()` now calls `load_driver_config()` which reads `~/.cua-driver/config.json` at startup — CLI `config set` changes carry over into every subsequent MCP session automatically.
- The `set_config` MCP tool now also writes through to disk (`write_driver_config_key`), so config changes made inside an MCP session persist for future sessions too.

## Test plan

- [ ] `curl` the install script on Apple Silicon — should download `darwin-universal-binary.tar.gz`, not 404
- [ ] `cua-driver config set capture_mode vision` → start `cua-driver mcp` → `tools/call get_config` → `capture_mode` should be `vision`
- [ ] Inside an MCP session: `tools/call set_config {"capture_mode":"vision"}` → restart mcp → `get_config` → still `vision`
- [ ] `CUA_DRIVER_RS_VERSION=0.1.3 ./install.sh` still works on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration settings now persist across sessions on macOS, allowing user preferences to be retained between restarts.

* **Chores**
  * Updated macOS installer to use universal-binary releases for improved platform compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1518)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->