### PR TITLE
feat(list_windows): UIA-first top-level window enumeration on Windows

### DIFF
--- a/libs/cua-driver-rs/PARITY.md
+++ b/libs/cua-driver-rs/PARITY.md
@@ -362,10 +362,31 @@ at least one entry has `active: true` (the foreground app).
   - windows=`crates/platform-windows/src/tools/impl_.rs` (ListWindowsTool)
   - linux=`crates/platform-linux/src/tools/impl_.rs` (ListWindowsTool, blocked behind Linux compile fix)
 - Status:
-  - windows: VERIFIED
+  - windows: VERIFIED (UIA-first enumeration; EnumWindows kept as union member)
   - macOS: OPEN (audit pending — macOS port already exists)
   - linux: OPEN
 - Test: `crates/platform-windows/examples/list_windows_parity.rs`
+
+### Enumeration source (Windows)
+
+`crate::win32::list_windows` runs UI Automation first
+(`AutomationElement::RootElement.FindAll(TreeScope::Children, TrueCondition)`,
+filtered to `IsOffscreen == false` + non-empty `GetWindowTextW`) and then
+takes the union with the classic `EnumWindows` walk, deduped by HWND. Each
+UIA element contributes its `NativeWindowHandle` as the canonical HWND, so
+downstream code keyed on `(pid, window_id)` keeps working unchanged.
+
+Why UIA-first: modern apps (WebView2-hosted Notepad, packaged-UWP frames,
+some Electron containers) hide their visible window inside a host HWND that
+`EnumWindows` either misses or surfaces with the wrong title/bounds. UIA's
+desktop-children walk returns the real interactable window.
+
+Why the EnumWindows union is kept: UIA can miss specific console window
+types and some installer dialogs. Merging both lists is maximally robust at
+negligible cost.
+
+`filter_pid` is applied to the merged list, so a UWP app's pid that
+previously returned empty now returns its real window.
 
 ### Fixed divergences (Windows)
 
@@ -406,10 +427,10 @@ flat `x/y/width/height`) for any pre-existing callers; remove once they migrate.
 
 Windows Rust does **not** yet enumerate **off-screen / minimized windows**.
 Swift's default (`on_screen_only: false`) returns them; Windows currently
-filters them out at the `EnumWindows` callback level (`IsWindowVisible &&
-!IsIconic`).  The `on_screen_only` schema field is accepted but has no
-effect.  Follow-up to refactor `list_windows` to return everything and
-filter at the tool layer.
+filters them out at both enumeration sources (UIA's `IsOffscreen` flag and
+`EnumWindows`'s `IsWindowVisible && !IsIconic` callback). The
+`on_screen_only` schema field is accepted but has no effect. Follow-up to
+refactor `list_windows` to return everything and filter at the tool layer.
 
 ---
 

--- a/libs/cua-driver-rs/PARITY.md
+++ b/libs/cua-driver-rs/PARITY.md
@@ -362,28 +362,32 @@ at least one entry has `active: true` (the foreground app).
   - windows=`crates/platform-windows/src/tools/impl_.rs` (ListWindowsTool)
   - linux=`crates/platform-linux/src/tools/impl_.rs` (ListWindowsTool, blocked behind Linux compile fix)
 - Status:
-  - windows: VERIFIED (UIA-first enumeration; EnumWindows kept as union member)
+  - windows: VERIFIED (EnumWindows-first enumeration; UIA contributes missing HWNDs only)
   - macOS: OPEN (audit pending — macOS port already exists)
   - linux: OPEN
 - Test: `crates/platform-windows/examples/list_windows_parity.rs`
 
 ### Enumeration source (Windows)
 
-`crate::win32::list_windows` runs UI Automation first
+`crate::win32::list_windows` walks `EnumWindows` first — that's the Win32
+window manager's canonical top-to-bottom z-order, so it's the authoritative
+source for both window membership and ordering. It then asks UI Automation
+for any top-level windows EnumWindows missed
 (`AutomationElement::RootElement.FindAll(TreeScope::Children, TrueCondition)`,
-filtered to `IsOffscreen == false` + non-empty `GetWindowTextW`) and then
-takes the union with the classic `EnumWindows` walk, deduped by HWND. Each
-UIA element contributes its `NativeWindowHandle` as the canonical HWND, so
-downstream code keyed on `(pid, window_id)` keeps working unchanged.
+filtered to `IsOffscreen == false` + non-empty `GetWindowTextW`) and appends
+those at the end of the merged list, deduped by HWND. UIA elements contribute
+their `NativeWindowHandle` as the canonical HWND so downstream code keyed on
+`(pid, window_id)` keeps working unchanged.
 
-Why UIA-first: modern apps (WebView2-hosted Notepad, packaged-UWP frames,
-some Electron containers) hide their visible window inside a host HWND that
-`EnumWindows` either misses or surfaces with the wrong title/bounds. UIA's
-desktop-children walk returns the real interactable window.
+Why UIA at all: modern apps (WebView2-hosted Notepad, packaged-UWP frames,
+some Electron containers) sometimes hide their visible window inside a host
+HWND that `EnumWindows` either skips or surfaces with the wrong title/bounds.
+UIA's desktop-children walk surfaces the real interactable window — but only
+when EnumWindows didn't.
 
-Why the EnumWindows union is kept: UIA can miss specific console window
-types and some installer dialogs. Merging both lists is maximally robust at
-negligible cost.
+Why EnumWindows-first (not UIA-first): UIA's `FindAll(TreeScope::Children)`
+gives no z-order guarantee; using it as the primary source would produce
+non-deterministic ordering. EnumWindows order IS the Win32 z-order.
 
 `filter_pid` is applied to the merged list, so a UWP app's pid that
 previously returned empty now returns its real window.

--- a/libs/cua-driver-rs/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/tools/impl_.rs
@@ -265,11 +265,14 @@ impl Tool for ListWindowsTool {
             }
         }
 
-        // z_index: the underlying enumerator returns UIA-first (modern
-        // top-to-bottom) then any EnumWindows entries UIA missed (also
-        // roughly top-to-bottom). Higher list index = farther from front.
-        // Swift convention: higher z_index = closer to front. Invert via
-        // `(len - 1 - i)` so the front-most window gets the largest z.
+        // z_index: list_windows merges EnumWindows first (which the Win32
+        // window manager returns in canonical top-to-bottom z-order), then
+        // appends any UIA-only HWNDs UIA found that EnumWindows missed
+        // (UIA-only entries land at the bottom of the z-stack — they have
+        // no canonical Win32 ordering). Higher list index = farther from
+        // front. Swift convention: higher z_index = closer to front.
+        // Invert via `(len - 1 - i)` so the front-most window gets the
+        // largest z.
         let n = windows.len();
         let records: Vec<serde_json::Value> = windows.iter().enumerate().map(|(i, w)| {
             let app_name = pid_to_name.get(&w.pid).cloned().unwrap_or_default();

--- a/libs/cua-driver-rs/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/tools/impl_.rs
@@ -265,9 +265,11 @@ impl Tool for ListWindowsTool {
             }
         }
 
-        // z_index: EnumWindows on Win32 returns top-to-bottom; higher index =
-        // farther from front.  Swift convention: higher z_index = closer to
-        // front.  Invert via `(len - 1 - i)`.
+        // z_index: the underlying enumerator returns UIA-first (modern
+        // top-to-bottom) then any EnumWindows entries UIA missed (also
+        // roughly top-to-bottom). Higher list index = farther from front.
+        // Swift convention: higher z_index = closer to front. Invert via
+        // `(len - 1 - i)` so the front-most window gets the largest z.
         let n = windows.len();
         let records: Vec<serde_json::Value> = windows.iter().enumerate().map(|(i, w)| {
             let app_name = pid_to_name.get(&w.pid).cloned().unwrap_or_default();

--- a/libs/cua-driver-rs/crates/platform-windows/src/uia/mod.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/uia/mod.rs
@@ -23,7 +23,9 @@ use windows::Win32::UI::Accessibility::{
 };
 
 pub mod cache;
+pub mod windows_enum;
 pub use cache::ElementCache;
+pub use windows_enum::enumerate_top_level_windows;
 
 const MAX_DEPTH: usize = 25;
 const MAX_TOTAL_ELEMENTS: usize = 5000;

--- a/libs/cua-driver-rs/crates/platform-windows/src/uia/windows_enum.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/uia/windows_enum.rs
@@ -12,9 +12,8 @@
 //! UIA element's `NativeWindowHandle` — i.e. an honest Win32 HWND that downstream
 //! code can pass to `GetWindowRect`, `PostMessage`, etc.
 
-use std::sync::OnceLock;
+use std::cell::RefCell;
 
-use windows::core::Interface;
 use windows::Win32::Foundation::{HWND, RECT};
 use windows::Win32::Graphics::Dwm::{DwmGetWindowAttribute, DWMWA_EXTENDED_FRAME_BOUNDS};
 use windows::Win32::System::Com::{
@@ -35,61 +34,48 @@ use crate::win32::windows::WindowInfo;
 /// apartment. Safe to ignore — COM is up either way.
 const RPC_E_CHANGED_MODE: i32 = -2147417850; // 0x80010106
 
-/// Process-lifetime IUIAutomation singleton. Creating one is non-trivial
-/// (COM activation + cross-process marshalling setup), and the interface is
-/// thread-safe to share, so we stash it after the first successful build.
-///
-/// Stored as `usize` (raw pointer cast) because `IUIAutomation` is not `Send`
-/// in the windows-rs binding; we re-materialise the COM reference on each
-/// access via `from_raw` + `clone` + `forget` so the cached pointer never
-/// changes its refcount on lookup.
-static UIA_SINGLETON: OnceLock<usize> = OnceLock::new();
-
-/// Ensure COM is initialized on the current OS thread as STA. The UIA
-/// in-process server requires an STA; calling on an already-MTA thread is
-/// harmless (we swallow `RPC_E_CHANGED_MODE`).
-fn ensure_com_initialized() {
-    unsafe {
-        let hr = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
-        if hr.is_err() && hr.0 != RPC_E_CHANGED_MODE {
-            // Any other failure (e.g. CO_E_NOTINITIALIZED downstream) will
-            // surface from CoCreateInstance with a useful error.
-            tracing::debug!(target: "uia_windows_enum", "CoInitializeEx returned {hr:?}");
-        }
-    }
+thread_local! {
+    /// Per-thread IUIAutomation instance. UIA / COM objects are
+    /// apartment-bound, so we deliberately do NOT share one across threads —
+    /// each OS thread that calls `enumerate_top_level_windows` initializes
+    /// COM as STA exactly once (the first time the cell is `None`) and caches
+    /// its own IUIAutomation. On failure the cell stays `None`, so the next
+    /// call retries from scratch instead of being stuck with a permanent
+    /// "init failed" sentinel.
+    static UIA_THREAD_LOCAL: RefCell<Option<IUIAutomation>> = const { RefCell::new(None) };
 }
 
-/// Build or fetch the cached IUIAutomation instance.
+/// Build or fetch the per-thread IUIAutomation instance.
+///
+/// On the first successful call per OS thread this also initializes COM as
+/// STA (UIA's in-process server requires an STA; `RPC_E_CHANGED_MODE` from a
+/// pre-existing apartment is treated as "already up"). Any failure leaves
+/// the thread-local empty so subsequent calls retry.
 fn get_uia() -> Option<IUIAutomation> {
-    ensure_com_initialized();
-    let raw = UIA_SINGLETON.get_or_init(|| {
+    UIA_THREAD_LOCAL.with(|cell| {
+        if let Some(uia) = cell.borrow().as_ref() {
+            return Some(uia.clone());
+        }
+        // First (or post-failure) call on this thread: init COM + build UIA.
+        unsafe {
+            let hr = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+            if hr.is_err() && hr.0 != RPC_E_CHANGED_MODE {
+                tracing::debug!(target: "uia_windows_enum", "CoInitializeEx returned {hr:?}");
+            }
+        }
         let inst: IUIAutomation = match unsafe {
             CoCreateInstance(&CUIAutomation, None, CLSCTX_INPROC_SERVER)
         } {
             Ok(a) => a,
             Err(e) => {
                 tracing::warn!(target: "uia_windows_enum", "CoCreateInstance(CUIAutomation) failed: {e}");
-                return 0;
+                return None;
             }
         };
-        let raw_ptr = inst.as_raw() as usize;
-        std::mem::forget(inst); // leak the strong ref so OnceLock owns it
-        raw_ptr
-    });
-    if *raw == 0 {
-        return None;
-    }
-    unsafe {
-        // SAFETY: the pointer was produced by `IUIAutomation::as_raw` on a
-        // strong reference we then `mem::forget`, so it stays valid for the
-        // process lifetime. `from_raw` takes ownership of one refcount, so we
-        // clone before returning (clone bumps refcount) and `forget` the
-        // owned handle to keep the singleton's refcount untouched.
-        let owned: IUIAutomation = IUIAutomation::from_raw(*raw as *mut _);
-        let dup = owned.clone();
-        std::mem::forget(owned);
+        let dup = inst.clone();
+        *cell.borrow_mut() = Some(inst);
         Some(dup)
-    }
+    })
 }
 
 /// Enumerate top-level windows visible to UI Automation.

--- a/libs/cua-driver-rs/crates/platform-windows/src/uia/windows_enum.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/uia/windows_enum.rs
@@ -1,0 +1,224 @@
+//! UIA-based enumeration of top-level windows.
+//!
+//! Walks the UI Automation tree from the desktop root and returns one entry
+//! per top-level interactable window. UIA surfaces modern containers (WebView2
+//! hosts, packaged-UWP frames, browser windows whose chrome lives inside a
+//! container HWND) with their real title and bounds — which `EnumWindows`
+//! either misses or returns with a misleading parent HWND.
+//!
+//! The result is shape-compatible with `crate::win32::windows::WindowInfo`
+//! (returned as `WindowInfo` directly) so the existing pipeline that consumes
+//! `list_windows` output keeps working unchanged. Each record's `hwnd` is the
+//! UIA element's `NativeWindowHandle` — i.e. an honest Win32 HWND that downstream
+//! code can pass to `GetWindowRect`, `PostMessage`, etc.
+
+use std::sync::OnceLock;
+
+use windows::core::Interface;
+use windows::Win32::Foundation::{HWND, RECT};
+use windows::Win32::Graphics::Dwm::{DwmGetWindowAttribute, DWMWA_EXTENDED_FRAME_BOUNDS};
+use windows::Win32::System::Com::{
+    CoCreateInstance, CoInitializeEx, CLSCTX_INPROC_SERVER, COINIT_APARTMENTTHREADED,
+};
+use windows::Win32::UI::Accessibility::{
+    CUIAutomation, IUIAutomation, IUIAutomationElement, TreeScope_Children,
+};
+use windows::Win32::UI::WindowsAndMessaging::{
+    GetWindowRect, GetWindowTextLengthW, GetWindowTextW, GetWindowThreadProcessId,
+};
+
+use crate::win32::windows::WindowInfo;
+
+/// HRESULT for "COM already initialized in another mode on this thread."
+/// Returned by `CoInitializeEx` when something else (a previous call in the
+/// same task, or a library on the same OS thread) picked a different
+/// apartment. Safe to ignore — COM is up either way.
+const RPC_E_CHANGED_MODE: i32 = -2147417850; // 0x80010106
+
+/// Process-lifetime IUIAutomation singleton. Creating one is non-trivial
+/// (COM activation + cross-process marshalling setup), and the interface is
+/// thread-safe to share, so we stash it after the first successful build.
+///
+/// Stored as `usize` (raw pointer cast) because `IUIAutomation` is not `Send`
+/// in the windows-rs binding; we re-materialise the COM reference on each
+/// access via `from_raw` + `clone` + `forget` so the cached pointer never
+/// changes its refcount on lookup.
+static UIA_SINGLETON: OnceLock<usize> = OnceLock::new();
+
+/// Ensure COM is initialized on the current OS thread as STA. The UIA
+/// in-process server requires an STA; calling on an already-MTA thread is
+/// harmless (we swallow `RPC_E_CHANGED_MODE`).
+fn ensure_com_initialized() {
+    unsafe {
+        let hr = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+        if hr.is_err() && hr.0 != RPC_E_CHANGED_MODE {
+            // Any other failure (e.g. CO_E_NOTINITIALIZED downstream) will
+            // surface from CoCreateInstance with a useful error.
+            tracing::debug!(target: "uia_windows_enum", "CoInitializeEx returned {hr:?}");
+        }
+    }
+}
+
+/// Build or fetch the cached IUIAutomation instance.
+fn get_uia() -> Option<IUIAutomation> {
+    ensure_com_initialized();
+    let raw = UIA_SINGLETON.get_or_init(|| {
+        let inst: IUIAutomation = match unsafe {
+            CoCreateInstance(&CUIAutomation, None, CLSCTX_INPROC_SERVER)
+        } {
+            Ok(a) => a,
+            Err(e) => {
+                tracing::warn!(target: "uia_windows_enum", "CoCreateInstance(CUIAutomation) failed: {e}");
+                return 0;
+            }
+        };
+        let raw_ptr = inst.as_raw() as usize;
+        std::mem::forget(inst); // leak the strong ref so OnceLock owns it
+        raw_ptr
+    });
+    if *raw == 0 {
+        return None;
+    }
+    unsafe {
+        // SAFETY: the pointer was produced by `IUIAutomation::as_raw` on a
+        // strong reference we then `mem::forget`, so it stays valid for the
+        // process lifetime. `from_raw` takes ownership of one refcount, so we
+        // clone before returning (clone bumps refcount) and `forget` the
+        // owned handle to keep the singleton's refcount untouched.
+        let owned: IUIAutomation = IUIAutomation::from_raw(*raw as *mut _);
+        let dup = owned.clone();
+        std::mem::forget(owned);
+        Some(dup)
+    }
+}
+
+/// Enumerate top-level windows visible to UI Automation.
+///
+/// Returns one `WindowInfo` per non-offscreen child of the UIA desktop root
+/// whose `NativeWindowHandle` is non-null and resolves to a window with a
+/// non-empty title. Windows whose HWND is zero (pure UIA virtual elements,
+/// rare) are skipped because the rest of the driver pipeline keys off HWND.
+///
+/// Returns an empty vec on any UIA failure — callers should treat UIA as a
+/// best-effort source and union with `EnumWindows`.
+pub fn enumerate_top_level_windows() -> Vec<WindowInfo> {
+    let uia = match get_uia() {
+        Some(u) => u,
+        None => return Vec::new(),
+    };
+
+    unsafe {
+        let root = match uia.GetRootElement() {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::debug!(target: "uia_windows_enum", "GetRootElement failed: {e}");
+                return Vec::new();
+            }
+        };
+        let condition = match uia.CreateTrueCondition() {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::debug!(target: "uia_windows_enum", "CreateTrueCondition failed: {e}");
+                return Vec::new();
+            }
+        };
+        let children = match root.FindAll(TreeScope_Children, &condition) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::debug!(target: "uia_windows_enum", "FindAll(Children) failed: {e}");
+                return Vec::new();
+            }
+        };
+
+        let count = children.Length().unwrap_or(0);
+        let mut out: Vec<WindowInfo> = Vec::with_capacity(count as usize);
+        for i in 0..count {
+            let elem = match children.GetElement(i) {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            if let Some(info) = window_info_from_uia_element(&elem) {
+                out.push(info);
+            }
+        }
+        out
+    }
+}
+
+/// Build a `WindowInfo` from a single UIA child element of the desktop root.
+/// Returns `None` if the element doesn't correspond to a real, on-screen,
+/// non-empty-titled HWND.
+unsafe fn window_info_from_uia_element(elem: &IUIAutomationElement) -> Option<WindowInfo> {
+    // NativeWindowHandle is an i32-sized handle in UIA; cast to HWND.
+    let raw = elem.CurrentNativeWindowHandle().ok()?;
+    if raw.0.is_null() {
+        return None;
+    }
+    let hwnd = HWND(raw.0);
+
+    // Drop minimized / off-screen windows. UIA's IsOffscreen flag covers
+    // both "iconic" and "behind another window such that no part is visible"
+    // — for top-level windows it matches the EnumWindows path's intent of
+    // showing only currently-visible candidates.
+    if let Ok(flag) = elem.CurrentIsOffscreen() {
+        if flag.as_bool() {
+            return None;
+        }
+    }
+
+    // Resolve pid via the standard Win32 path. We deliberately do not trust
+    // the UIA ProcessId property here because the rest of the driver indexes
+    // windows by (hwnd, pid) tuples obtained from `GetWindowThreadProcessId`,
+    // and we want bit-identical agreement.
+    let mut pid: u32 = 0;
+    let _ = GetWindowThreadProcessId(hwnd, Some(&mut pid));
+    if pid == 0 {
+        return None;
+    }
+
+    // Title — prefer Win32 GetWindowTextW for parity with the EnumWindows path.
+    // UIA's `CurrentName` sometimes returns the AX-friendly label (e.g. the
+    // tab title) instead of the OS-level window caption, which would diverge
+    // from any caller already keyed on the GetWindowText value.
+    let title_len = GetWindowTextLengthW(hwnd);
+    if title_len == 0 {
+        return None;
+    }
+    let mut buf = vec![0u16; (title_len + 1) as usize];
+    GetWindowTextW(hwnd, &mut buf);
+    let len = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
+    let title = String::from_utf16_lossy(&buf[..len]);
+    if title.trim().is_empty() {
+        return None;
+    }
+
+    let (x, y, w, h) = window_bounds(hwnd);
+
+    Some(WindowInfo {
+        hwnd: hwnd.0 as u64,
+        pid,
+        title,
+        x,
+        y,
+        width: w,
+        height: h,
+    })
+}
+
+/// Bounds via DWM extended frame (excludes drop-shadow on W11) with
+/// `GetWindowRect` fallback — same logic as the EnumWindows path.
+fn window_bounds(hwnd: HWND) -> (i32, i32, i32, i32) {
+    unsafe {
+        let mut rect = RECT::default();
+        let ok = DwmGetWindowAttribute(
+            hwnd,
+            DWMWA_EXTENDED_FRAME_BOUNDS,
+            &mut rect as *mut RECT as *mut _,
+            std::mem::size_of::<RECT>() as u32,
+        );
+        if ok.is_err() {
+            let _ = GetWindowRect(hwnd, &mut rect);
+        }
+        (rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top)
+    }
+}

--- a/libs/cua-driver-rs/crates/platform-windows/src/win32/windows.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/win32/windows.rs
@@ -2,14 +2,17 @@
 //!
 //! Two enumeration sources, then union + dedupe by HWND:
 //!
-//! 1. **UI Automation** (preferred) — walks the desktop's UIA children. UIA
-//!    surfaces modern apps (WebView2 hosts, packaged-UWP frames, Electron
-//!    container HWNDs) with their real titles + bounds, where `EnumWindows`
-//!    alone either misses the visible surface or returns a wrapper HWND.
+//! 1. **`EnumWindows`** (canonical z-order) — the Win32 enumerator walks the
+//!    window manager's z-order list top-to-bottom, so iteration order IS the
+//!    actual z-order. We list these first so the merged array's index reflects
+//!    the true Win32 stacking for any HWND the Win32 path can see.
 //!
-//! 2. **`EnumWindows`** (fallback union member) — UIA can miss specific
-//!    console window types and some installer dialogs, so we still walk the
-//!    Win32 list and merge in any HWND UIA didn't already report.
+//! 2. **UI Automation** (extra coverage) — appended after `EnumWindows`,
+//!    contributing only HWNDs Win32 didn't surface. UIA exposes modern
+//!    containers (WebView2 hosts, packaged-UWP frames, Electron container
+//!    HWNDs) that `EnumWindows` may miss or return as wrapper HWNDs. UIA's
+//!    `FindAll(TreeScope::Children, ...)` makes no z-order guarantee, so we
+//!    deliberately do NOT let it reorder anything Win32 already reported.
 //!
 //! Both sources apply the same filters (visible, non-iconic, non-empty
 //! title). The `filter_pid` argument is applied to the merged list so the
@@ -45,24 +48,29 @@ struct EnumState {
 
 /// List top-level visible windows. If `filter_pid` is Some, only that process.
 ///
-/// Enumerates via UI Automation first, then unions with `EnumWindows`
-/// (deduped by HWND) to recover any windows UIA missed. The pid filter is
-/// applied to the merged list.
+/// `EnumWindows` first — its iteration order is the Win32 window manager's
+/// z-order (top-to-bottom), so the merged array's index doubles as a z_index
+/// for any HWND the Win32 path saw. Then UIA-only entries are appended (UIA
+/// makes no z-order guarantee, so it must not be allowed to reorder anything
+/// EnumWindows already reported). The pid filter is applied to the merged
+/// list.
 pub fn list_windows(filter_pid: Option<u32>) -> Vec<WindowInfo> {
-    let uia_windows = crate::uia::enumerate_top_level_windows();
     let win32_windows = enumerate_via_enum_windows();
+    let uia_windows = crate::uia::enumerate_top_level_windows();
 
     let mut seen: HashSet<u64> = HashSet::with_capacity(uia_windows.len() + win32_windows.len());
     let mut merged: Vec<WindowInfo> = Vec::with_capacity(uia_windows.len() + win32_windows.len());
 
-    // UIA first — preserves UIA's preferred ordering for modern apps.
-    for w in uia_windows {
+    // EnumWindows first — canonical Win32 z-order.
+    for w in win32_windows {
         if seen.insert(w.hwnd) {
             merged.push(w);
         }
     }
-    // Then any EnumWindows entry whose HWND wasn't already covered.
-    for w in win32_windows {
+    // Then any UIA-only HWND that EnumWindows didn't surface (modern
+    // containers, WebView2 hosts, etc.). These get appended (no claim on
+    // z-order priority relative to the Win32 list).
+    for w in uia_windows {
         if seen.insert(w.hwnd) {
             merged.push(w);
         }

--- a/libs/cua-driver-rs/crates/platform-windows/src/win32/windows.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/win32/windows.rs
@@ -1,8 +1,21 @@
 //! Enumerate top-level windows on Windows.
 //!
-//! Uses EnumWindows + GetWindowTextW + GetWindowThreadProcessId.
-//! Returns only visible, non-minimized windows with a non-empty title.
+//! Two enumeration sources, then union + dedupe by HWND:
+//!
+//! 1. **UI Automation** (preferred) — walks the desktop's UIA children. UIA
+//!    surfaces modern apps (WebView2 hosts, packaged-UWP frames, Electron
+//!    container HWNDs) with their real titles + bounds, where `EnumWindows`
+//!    alone either misses the visible surface or returns a wrapper HWND.
+//!
+//! 2. **`EnumWindows`** (fallback union member) — UIA can miss specific
+//!    console window types and some installer dialogs, so we still walk the
+//!    Win32 list and merge in any HWND UIA didn't already report.
+//!
+//! Both sources apply the same filters (visible, non-iconic, non-empty
+//! title). The `filter_pid` argument is applied to the merged list so the
+//! union/dedupe pipeline runs unconditionally.
 
+use std::collections::HashSet;
 use std::sync::Mutex;
 use windows::Win32::Foundation::{BOOL, HWND, LPARAM, RECT, TRUE};
 use windows::Win32::Graphics::Dwm::{
@@ -27,13 +40,45 @@ pub struct WindowInfo {
 }
 
 struct EnumState {
-    filter_pid: Option<u32>,
     windows: Vec<WindowInfo>,
 }
 
 /// List top-level visible windows. If `filter_pid` is Some, only that process.
+///
+/// Enumerates via UI Automation first, then unions with `EnumWindows`
+/// (deduped by HWND) to recover any windows UIA missed. The pid filter is
+/// applied to the merged list.
 pub fn list_windows(filter_pid: Option<u32>) -> Vec<WindowInfo> {
-    let state = Mutex::new(EnumState { filter_pid, windows: Vec::new() });
+    let uia_windows = crate::uia::enumerate_top_level_windows();
+    let win32_windows = enumerate_via_enum_windows();
+
+    let mut seen: HashSet<u64> = HashSet::with_capacity(uia_windows.len() + win32_windows.len());
+    let mut merged: Vec<WindowInfo> = Vec::with_capacity(uia_windows.len() + win32_windows.len());
+
+    // UIA first — preserves UIA's preferred ordering for modern apps.
+    for w in uia_windows {
+        if seen.insert(w.hwnd) {
+            merged.push(w);
+        }
+    }
+    // Then any EnumWindows entry whose HWND wasn't already covered.
+    for w in win32_windows {
+        if seen.insert(w.hwnd) {
+            merged.push(w);
+        }
+    }
+
+    if let Some(fp) = filter_pid {
+        merged.retain(|w| w.pid == fp);
+    }
+    merged
+}
+
+/// Walk `EnumWindows` and collect every visible, non-iconic, non-empty-titled
+/// top-level window. No pid filter is applied here — the caller does that on
+/// the merged list.
+fn enumerate_via_enum_windows() -> Vec<WindowInfo> {
+    let state = Mutex::new(EnumState { windows: Vec::new() });
     let state_ptr = &state as *const Mutex<EnumState> as isize;
     unsafe {
         let _ = EnumWindows(Some(enum_windows_cb), LPARAM(state_ptr));
@@ -52,14 +97,6 @@ unsafe extern "system" fn enum_windows_cb(hwnd: HWND, lparam: LPARAM) -> BOOL {
     // Get pid.
     let mut pid: u32 = 0;
     GetWindowThreadProcessId(hwnd, Some(&mut pid));
-
-    // Filter by pid if requested.
-    {
-        let s = state.lock().unwrap();
-        if let Some(fp) = s.filter_pid {
-            if pid != fp { return TRUE; }
-        }
-    }
 
     // Get title (skip empty).
     let title_len = GetWindowTextLengthW(hwnd);


### PR DESCRIPTION
## Summary

`crate::win32::list_windows` on Windows now walks UI Automation first and unions with the classic `EnumWindows` result (deduped by HWND), so the visible top-level windows of modern apps stop disappearing.

- **Why:** WebView2-hosted Notepad, packaged-UWP frames, and some Electron apps wrap their real surface inside a host HWND that `EnumWindows` either misses or returns with a misleading title/bounds. Asking `list_windows` for such a pid was returning an empty array. UIA's `AutomationElement::RootElement.FindAll(TreeScope::Children, TrueCondition)` returns the real interactable window — with `NativeWindowHandle` giving back an honest Win32 HWND so the (pid, window_id) tuple stays compatible with the rest of the pipeline.
- **Why keep `EnumWindows`:** UIA can miss specific console window types and some installer dialogs. Merging both lists (HWND-keyed dedupe) is maximally robust at negligible cost.
- **Filter parity:** UIA path filters on `CurrentIsOffscreen == false` + non-empty `GetWindowTextW` — same intent as the EnumWindows path's `IsWindowVisible && !IsIconic` + non-empty title.

## Implementation

Two commits:

1. `feat(platform-windows): UIA tree walker helper for top-level windows` — adds `crates/platform-windows/src/uia/windows_enum.rs` with `enumerate_top_level_windows() -> Vec<WindowInfo>`. Purely additive — no wiring yet. Stashes the `IUIAutomation` instance in a process-lifetime `OnceLock` (CoCreateInstance is non-trivial). Initializes COM via `CoInitializeEx(COINIT_APARTMENTTHREADED)` on each call, swallowing `RPC_E_CHANGED_MODE` (means COM is already up in another mode — harmless).

2. `feat(list_windows): use UIA-first enumeration on Windows` — `crate::win32::list_windows` now calls the helper, then unions with `EnumWindows` (dedupe by HWND), then applies the existing `filter_pid` argument at the end. All callers (`list_windows` tool, `get_window_state`, `launch_app`, etc.) pick the improvement up uniformly because they all go through this single helper. Adds a new "Enumeration source (Windows)" subsection to PARITY.md and updates the existing off-screen-windows limitation note.

## Notes

- No new windows-rs features required — `Win32_UI_Accessibility` and `Win32_System_Com` were already enabled in `platform-windows/Cargo.toml`.
- Pid is still resolved via `GetWindowThreadProcessId` (not UIA's `ProcessId` property) so the (hwnd, pid) tuple stays bit-identical to what the EnumWindows path computes — important for the downstream `windows_for_pid.iter().any(|w| w.hwnd == hwnd)` invariants.
- Title is read via `GetWindowTextW` rather than UIA's `CurrentName` for the same parity reason (UIA's Name property occasionally returns the AX-friendly label rather than the OS-level window caption).

## Test plan

- [ ] Manual: launch UWP Notepad from PowerShell (`start ms-launch:Microsoft.WindowsNotepad_8wekyb3d8bbwe!App`), grab its pid via `list_apps`, then `cua-driver call list_windows '{"pid":<UWP_pid>}'` — pre-change returned empty; should now return a non-empty `windows` array with the real window record.
- [ ] Regression: launch `mspaint` and `regedit` (classic Win32 apps); confirm `list_windows` still returns their windows with identical bounds + titles to pre-change.
- [ ] Regression: run `cargo run -p platform-windows --example list_windows_parity` against a running daemon — header format, structured-content field shape, and pid-warning path should all still pass.
- [ ] Build: `cargo build --release --target x86_64-pc-windows-msvc -p platform-windows` — clean (verified locally; full workspace cross-build from macOS fails on an unrelated `ring` build-script that needs the Windows native toolchain, but `platform-windows` itself compiles cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved top-level window discovery on Windows by combining multiple enumeration sources and deduplicating results to surface windows previously missed.
  * More consistent front-to-back ordering (z-order) of discovered windows.
  * Adjusted filtering so PID-based filtering and off-screen/minimized handling behave consistently after merging sources.

* **Documentation**
  * Clarified Windows enumeration behavior, ordering, and current limitations (including off-screen/minimized window handling).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1542?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->