### PR TITLE
fix(windows): Session-0 hardening + UWP background-launch focus restore

### DIFF
--- a/WINDOWS_SESSION0_STATUS.md
+++ b/WINDOWS_SESSION0_STATUS.md
@@ -12,14 +12,23 @@
 1. **`doctor` crashed with `0xC0000005 ACCESS_VIOLATION`** — COM lifecycle bug in `ui_automation_available`: `IUIAutomation` dropped AFTER `CoUninitialize`, so `IUnknown::Release` ran against a torn-down apartment. Fix: flatten probe result before tearing down COM. ✅
 2. **`launch_app` hung indefinitely in Session 0** — two paths: `resolve_aumid_by_name` walked `shell:AppsFolder` via the interactive shell broker (doesn't exist in Session 0 → hang). `launch_uwp` itself called `IApplicationActivationManager::ActivateApplication` which also needs interactive AppX runtime (same hang). Both now short-circuit on Session 0 with `current_session_id() == Some(0)` — `resolve_aumid_by_name` returns None (falls through to ShellExecuteEx PATH lookup, which works), `launch_uwp` fails fast with a descriptive error. ✅
 
-**Plus**: best-effort foreground-restore after UWP activation, three parity-example fixes (Session-0 awareness + #1545 contract), and `overlay_dump` example build fix.
+**Plus**: foreground-restore after UWP activation (now with `keybd_event` workaround for Windows' foreground-lock restriction), three parity-example fixes (Session-0 awareness + #1545 contract), opaque-system-family UWP filter for list_apps, serve startup Session-0 banner, and `overlay_dump` example build fix.
 
 ## Bugs fixed (commits on `stab/windows-session0-fixes`)
 
 | Commit | Subject |
 |---|---|
-| `9ccdcc34`→ rebase → `a9d9c027` | fix(windows): doctor COM lifecycle + Session 0 hardening for launch paths |
+| `a9d9c027` | fix(windows): doctor COM lifecycle + Session 0 hardening for launch paths |
 | `9e91f683` | test(windows): parity examples Session-0 aware + #1545 contract |
+| `7251e73b` | feat(serve): Session-0 warning banner on Windows daemon startup |
+| `2eb3c4d3` | docs(parity): update list_apps + launch_app Windows status with live evidence |
+| `ac70b94d` | feat(installed_apps): filter opaque-system-family UWP packages from list_apps |
+| `6f580201` | fix(installed_apps): drop Package.IsFramework() probe — hangs in Session 0 |
+| `d5b5821c` | fix(launch_uwp): claim 'last input' before SetForegroundWindow restore |
+
+### Surprise bug found during this work (now fixed in `6f580201`)
+
+`Package.IsFramework()` WinRT call **hangs in Session 0** (0 CPU, no progress, no error). I had added it as a "filter out framework packages from list_apps" optimization in `ac70b94d`, which silently broke list_apps for ~3 hours of debug-loop. Worth documenting: avoid WinRT property getters that may touch the AppX activation runtime when running in services context. The opaque-family-name filter still catches most framework noise.
 
 ## Validated on the VM (Session 0, SSH from Mac)
 
@@ -45,12 +54,17 @@
 Pre-fix: 6 PASS / 5 FAIL — Session-0 expected-failures + stale post-#1545 assertions.
 Post-fix: see `b8jvtpz9m.output` (in flight as of this writing).
 
-## Bug still pending — visual confirmation needs RDP
+## Visual confirmation needs RDP
 
-**Background-launch focus invariant for UWP apps** is implemented as best-effort. Specifically:
+**Background-launch focus invariant for UWP apps** is now stronger than the initial best-effort:
 
 - Win32 path (ShellExecuteEx + SW_SHOWNOACTIVATE): ✅ proven by code — the API contract says SW_SHOWNOACTIVATE never activates.
-- UWP path (`IApplicationActivationManager::ActivateApplication(AO_NONE)`): the AppX runtime brings the app to foreground (= Start-Menu-click semantics). I added a snapshot-and-restore pass that captures `GetForegroundWindow` BEFORE activation and re-asserts it AFTER (3 × 50ms retry, best-effort). **This only works when SetForegroundWindow's restriction is met** — typically when the calling process was foreground at the time of the call. In Session 0 this is moot (no foreground anyway).
+- UWP path (`IApplicationActivationManager::ActivateApplication(AO_NONE)`): the AppX runtime brings the app to foreground (= Start-Menu-click semantics). Now does:
+  1. Snapshot prior foreground via `GetForegroundWindow` before the call
+  2. Inject a VK_NONAME (0xFC) `keybd_event` press+release immediately after to claim "owner of last input" — that lifts Windows' foreground-lock restriction
+  3. Call `SetForegroundWindow(prior)` in a 3 × 50ms retry loop, logging each attempt at debug
+  
+  VK_NONAME (0xFC) doesn't map to any UI action, so no application sees a keystroke. The Session-0 short-circuit higher up bypasses this entire path so it only executes on interactive logons where focus actually matters.
 
 To visually validate when you wake:
 

--- a/WINDOWS_SESSION0_STATUS.md
+++ b/WINDOWS_SESSION0_STATUS.md
@@ -1,9 +1,37 @@
 # Windows Session-0 Stabilization — Status Report
 
+## Good morning — TL;DR
+
+While you slept I stabilized Windows cua-driver-rs end-to-end on the VM
+you provisioned. **All 11 parity examples PASS** (was 6/11 before).
+**Two real bugs fixed** (`doctor` segfault, `launch_app` hang), **one
+focus-steal hardening** (UWP foreground-restore), **one quality filter**
+(opaque system packages out of `list_apps`), **one startup banner**
+(serve in Session 0 warns about GUI-tool limitations).
+
+Branch `stab/windows-session0-fixes` is 7 commits ahead of
+`origin/main`, all local — no PR opened per your ask. To turn into a
+PR when ready:
+
+```bash
+git -C /Users/francesco/cua push -u origin stab/windows-session0-fixes
+gh pr create --base main --head stab/windows-session0-fixes \
+  --title "fix(windows): Session-0 hardening + UWP focus-restore" \
+  --body-file WINDOWS_SESSION0_STATUS.md
+```
+
+**Still wants your eyes:** the UWP focus-restore needs visual
+confirmation in Session 1+ (RDP in, run the snippet under "Visual
+confirmation" below). I made it stronger than my first pass (now uses
+the `keybd_event` workaround to lift Windows' SetForegroundWindow
+restriction) but I can't visually verify from Mac side.
+
+---
+
 **Branch:** `stab/windows-session0-fixes` (local-only, no PR yet per your ask)
 **Base:** `origin/main` @ 69a9dbd5 (post-#1547)
 **VM:** `fbonacci-windows-vm` (20.115.29.195) — Rust toolchain + VS Build Tools 2022 installed
-**Dev loop:** edit on Mac → `scp` changed files to `~/cua/...` on VM → `cargo build --release -p cua-driver` (~20s incremental, ~5min cold) → run
+**Dev loop:** edit on Mac → `scp` changed files to `~/cua/...` on VM → `cargo build --release -p cua-driver` (~20s incremental, ~5min cold) → run. Full reference: `libs/cua-driver-rs/DEV_LOOP_WINDOWS_VM.md`.
 
 ## TL;DR
 

--- a/WINDOWS_SESSION0_STATUS.md
+++ b/WINDOWS_SESSION0_STATUS.md
@@ -14,7 +14,7 @@ Branch `stab/windows-session0-fixes` is 7 commits ahead of
 PR when ready:
 
 ```bash
-git -C /Users/francesco/cua push -u origin stab/windows-session0-fixes
+git -C <repo-root> push -u origin stab/windows-session0-fixes
 gh pr create --base main --head stab/windows-session0-fixes \
   --title "fix(windows): Session-0 hardening + UWP focus-restore" \
   --body-file WINDOWS_SESSION0_STATUS.md
@@ -30,7 +30,7 @@ restriction) but I can't visually verify from Mac side.
 
 **Branch:** `stab/windows-session0-fixes` (local-only, no PR yet per your ask)
 **Base:** `origin/main` @ 69a9dbd5 (post-#1547)
-**VM:** `fbonacci-windows-vm` (20.115.29.195) — Rust toolchain + VS Build Tools 2022 installed
+**VM:** `<vm-name>` (<vm-host>) — Rust toolchain + VS Build Tools 2022 installed
 **Dev loop:** edit on Mac → `scp` changed files to `~/cua/...` on VM → `cargo build --release -p cua-driver` (~20s incremental, ~5min cold) → run. Full reference: `libs/cua-driver-rs/DEV_LOOP_WINDOWS_VM.md`.
 
 ## TL;DR
@@ -97,8 +97,8 @@ Post-fix: see `b8jvtpz9m.output` (in flight as of this writing).
 To visually validate when you wake:
 
 ```powershell
-# RDP into 20.115.29.195 as fbonacci, then in a PowerShell on the desktop:
-$exe = "C:\Users\fbonacci\AppData\Local\Programs\trycua\cua-driver-rs\bin\cua-driver.exe"
+# RDP into <vm-host> as <user>, then in a PowerShell on the desktop:
+$exe = "C:\Users\<user>\AppData\Local\Programs\trycua\cua-driver-rs\bin\cua-driver.exe"
 # Or use the dev build:
 # $exe = "$env:USERPROFILE\cua\libs\cua-driver-rs\target\release\cua-driver.exe"
 
@@ -131,11 +131,11 @@ $exe = "C:\Users\fbonacci\AppData\Local\Programs\trycua\cua-driver-rs\bin\cua-dr
 
 ```bash
 # View the local-only commits
-git -C /Users/francesco/cua log --oneline origin/main..stab/windows-session0-fixes
+git -C <repo-root> log --oneline origin/main..stab/windows-session0-fixes
 
 # Bring them up onto a fresh branch for a PR
-git -C /Users/francesco/cua checkout -b fix/windows-session0
-git -C /Users/francesco/cua merge --ff-only stab/windows-session0-fixes
+git -C <repo-root> checkout -b fix/windows-session0
+git -C <repo-root> merge --ff-only stab/windows-session0-fixes
 
 # Then `gh pr create` as usual
 ```

--- a/WINDOWS_SESSION0_STATUS.md
+++ b/WINDOWS_SESSION0_STATUS.md
@@ -1,0 +1,116 @@
+# Windows Session-0 Stabilization — Status Report
+
+**Branch:** `stab/windows-session0-fixes` (local-only, no PR yet per your ask)
+**Base:** `origin/main` @ 69a9dbd5 (post-#1547)
+**VM:** `fbonacci-windows-vm` (20.115.29.195) — Rust toolchain + VS Build Tools 2022 installed
+**Dev loop:** edit on Mac → `scp` changed files to `~/cua/...` on VM → `cargo build --release -p cua-driver` (~20s incremental, ~5min cold) → run
+
+## TL;DR
+
+**Two real bugs found + fixed**, both Session-0 (services / SSH-launched) edge cases:
+
+1. **`doctor` crashed with `0xC0000005 ACCESS_VIOLATION`** — COM lifecycle bug in `ui_automation_available`: `IUIAutomation` dropped AFTER `CoUninitialize`, so `IUnknown::Release` ran against a torn-down apartment. Fix: flatten probe result before tearing down COM. ✅
+2. **`launch_app` hung indefinitely in Session 0** — two paths: `resolve_aumid_by_name` walked `shell:AppsFolder` via the interactive shell broker (doesn't exist in Session 0 → hang). `launch_uwp` itself called `IApplicationActivationManager::ActivateApplication` which also needs interactive AppX runtime (same hang). Both now short-circuit on Session 0 with `current_session_id() == Some(0)` — `resolve_aumid_by_name` returns None (falls through to ShellExecuteEx PATH lookup, which works), `launch_uwp` fails fast with a descriptive error. ✅
+
+**Plus**: best-effort foreground-restore after UWP activation, three parity-example fixes (Session-0 awareness + #1545 contract), and `overlay_dump` example build fix.
+
+## Bugs fixed (commits on `stab/windows-session0-fixes`)
+
+| Commit | Subject |
+|---|---|
+| `9ccdcc34`→ rebase → `a9d9c027` | fix(windows): doctor COM lifecycle + Session 0 hardening for launch paths |
+| `9e91f683` | test(windows): parity examples Session-0 aware + #1545 contract |
+
+## Validated on the VM (Session 0, SSH from Mac)
+
+| Tool | Status | Notes |
+|---|---|---|
+| `cua-driver --version` | ✅ 0.2.2 | |
+| `cua-driver list-tools` | ✅ 30 tools | matches Swift surface |
+| `cua-driver doctor` | ✅ exit 0 | clean run, all probes report. Session-0 warning surfaced correctly. |
+| `cua-driver call get_screen_size` | ✅ 1024x768 @ 1.0 | |
+| `cua-driver call get_cursor_position` | ✅ 0,0 | |
+| `cua-driver call check_permissions` | ✅ elevated, post_message, uia all true | |
+| `cua-driver call get_config` | ✅ returns full config | |
+| `cua-driver call list_windows` | ✅ empty `[]` (expected — no desktop) | |
+| `cua-driver call list_apps` | ✅ 3.7s cold, returns ~150 apps (running + installed) | |
+| `cua-driver call get_accessibility_tree` | ✅ returns process list | |
+| `launch_app {"name":"notepad"}` | ✅ ShellExecuteEx, pid returned | SW_SHOWNOACTIVATE (no focus steal) |
+| `launch_app {"path":"C:\\..\\calc.exe"}` | ✅ ShellExecuteEx, pid returned | |
+| `launch_app {"aumid":"...Calculator!App"}` | ✅ fails fast with Session-0 message (no hang) | needs interactive session to actually launch |
+
+### Parity tests
+*(`cargo run --example *_parity` against running daemon)*
+
+Pre-fix: 6 PASS / 5 FAIL — Session-0 expected-failures + stale post-#1545 assertions.
+Post-fix: see `b8jvtpz9m.output` (in flight as of this writing).
+
+## Bug still pending — visual confirmation needs RDP
+
+**Background-launch focus invariant for UWP apps** is implemented as best-effort. Specifically:
+
+- Win32 path (ShellExecuteEx + SW_SHOWNOACTIVATE): ✅ proven by code — the API contract says SW_SHOWNOACTIVATE never activates.
+- UWP path (`IApplicationActivationManager::ActivateApplication(AO_NONE)`): the AppX runtime brings the app to foreground (= Start-Menu-click semantics). I added a snapshot-and-restore pass that captures `GetForegroundWindow` BEFORE activation and re-asserts it AFTER (3 × 50ms retry, best-effort). **This only works when SetForegroundWindow's restriction is met** — typically when the calling process was foreground at the time of the call. In Session 0 this is moot (no foreground anyway).
+
+To visually validate when you wake:
+
+```powershell
+# RDP into 20.115.29.195 as fbonacci, then in a PowerShell on the desktop:
+$exe = "C:\Users\fbonacci\AppData\Local\Programs\trycua\cua-driver-rs\bin\cua-driver.exe"
+# Or use the dev build:
+# $exe = "$env:USERPROFILE\cua\libs\cua-driver-rs\target\release\cua-driver.exe"
+
+# Open something focusable first (e.g. Notepad++ via Start menu) and start typing into it.
+# Then from a *different* PowerShell window, fire:
+'{"name":"calculator"}' | & $exe call launch_app
+# Calculator should launch into the taskbar/background; your Notepad++ focus
+# should be preserved (no visible focus steal). If focus DOES move to
+# Calculator, the SetForegroundWindow restriction blocked our restore —
+# we have a fallback path (push to HWND_BOTTOM) on standby.
+```
+
+## Other improvements made
+
+1. **`eprintln!` traces in list_apps / installed_apps replaced with `tracing::debug!`** — silent at default log level. Enable with `RUST_LOG=cua_driver=debug,installed_apps=debug,list_apps=debug` when diagnosing.
+2. **Parity tests `list_apps_parity` / `list_windows_parity` / `launch_app_parity`** brought up to current contract (#1545's unified shape, Session-0 awareness, UWP fail-fast acceptance).
+3. **`overlay_dump.rs` example** — fixed `PrintWindow` + `PRINT_WINDOW_FLAGS` imports (moved to `Win32::Storage::Xps` in windows-rs 0.58).
+
+## Known issues NOT fixed (documented for next session)
+
+1. **UWP display names still show family-name fallback for some packages** — system Components and packages with unresolved `ms-resource:` tokens AND no `Properties/DisplayName` in their AppxManifest.xml fall back to their FamilyName (e.g. `1527c705-839a-4832-9118-54d4Bd6a0c89_cw5n1h2txyewy`). #1547 closed the common case; the long tail is system packages users mostly don't care about. Possible follow-ups: (a) filter out packages whose family_name matches GUID pattern AND display name is empty/equal-to-family — they're usually unactivatable system components; (b) try `Package.PublisherDisplayName` as a third fallback.
+
+2. **`SetForegroundWindow` restoration after UWP activation is best-effort** — Windows restricts foreground transfers and may silently ignore the call. Stronger options to consider: (a) `SetWindowPos(spawned_hwnd, HWND_BOTTOM, ..., SWP_NOACTIVATE)` to push the UWP window behind everything (more aggressive than macOS but guaranteed); (b) the `keybd_event` trick to give cua-driver "last input" status so SetForegroundWindow's restriction lifts (visible side effect of pressing Alt — usually OK).
+
+3. **`overlay_dump` builds — but won't run usefully in Session 0** since the overlay needs a desktop. Build-fix only.
+
+4. **Parity tests requiring foreground windows** — `list_windows`, `screenshot`, `get_window_state`, `click`, `type_text`, `hotkey`, `press_key`, `drag`, `scroll` etc. all need interactive desktop. They're tested by being called against the running daemon, but their assertions (e.g. "expected at least one visible window") are Session-0-aware where I touched them; the rest will naturally need Session 1+ to exercise meaningfully.
+
+## How to take the local fixes forward
+
+```bash
+# View the local-only commits
+git -C /Users/francesco/cua log --oneline origin/main..stab/windows-session0-fixes
+
+# Bring them up onto a fresh branch for a PR
+git -C /Users/francesco/cua checkout -b fix/windows-session0
+git -C /Users/francesco/cua merge --ff-only stab/windows-session0-fixes
+
+# Then `gh pr create` as usual
+```
+
+The local branch is rebased on current `origin/main` (post-#1547). No PR opened per your instruction.
+
+## Other PRs of yours seen earlier in the session
+
+- **#1546** — closed as superseded by #1547 (older diff of same domain)
+- **#1547** — merged (UWP ms-resource: display name normalization)
+- **#1523** — *parity(launch_app) macOS port of #1492* — has CR fixes pushed but **needs a port-onto-current-main**, not a simple rebase. Main moved significantly: `platform-macos/src/apps.rs` deleted and reorganized into `apps/mod.rs` + `apps/nsworkspace.rs`, `AppInfo` gained 3 new fields. Estimated ~30 min focused work to rebuild. Parked pending your call.
+
+## Timeline
+
+- Session started ~Sun May 18 00:00 (local)
+- Toolchain install on VM: 23:08 → 23:34
+- Dev loop online + first cargo build: 23:34 → 23:48 (~11min cold build)
+- doctor + launch_app bugs identified + fixed: ~00:00 → ~02:00
+- This report: ~02:35
+- Resuming at next user-online checkpoint

--- a/docs/content/docs/cua-driver/guide/getting-started/faq.mdx
+++ b/docs/content/docs/cua-driver/guide/getting-started/faq.mdx
@@ -202,6 +202,26 @@ Or set `CUA_DRIVER_TELEMETRY_ENABLED=0` in the environment for a one-off overrid
 
 Telemetry records anonymous subcommand usage (`cua_driver_api_click`, `cua_driver_serve`, etc). No command arguments, file paths, or personal information are collected.
 
+## Windows (cua-driver-rs)
+
+### Why do `click` / `type_text` / `screenshot` / `list_windows` return empty results?
+
+Your `cua-driver` daemon is probably running in **Windows Session 0** (services / SSH-launched processes). Every window-driving Win32 API — `EnumWindows`, `PostMessage`, `PrintWindow`, UI Automation tree walks — is scoped to the calling process's WindowStation + Desktop. Session 0 has no attached interactive desktop, so all these APIs silently succeed but return empty.
+
+Run `cua-driver doctor` — it surfaces this directly:
+
+```
+[warn] interactive session: running in Session 0 (services); window-driving tools
+        (list_windows, click, type_text, screenshot, get_window_state) will return
+        empty results — these APIs need an attached interactive desktop.
+```
+
+Fix: re-launch `cua-driver serve` from an interactive logon — RDP into the host, console session, or a scheduled task configured with `/RU <user> /IT` so it runs in the user's session. The non-GUI tools (`list_apps` for Win32 entries, `get_config`, `doctor`, telemetry plumbing) work normally in Session 0 either way.
+
+### `launch_app` with a UWP app fails with "requires an interactive session" in Session 0.
+
+Same root cause: `IApplicationActivationManager::ActivateApplication` needs the per-user AppX runtime which only exists in interactive logons. Until you re-run the daemon from a Session 1+ logon, fall back to the Win32 path (`launch_app {"path":"C:\\Windows\\System32\\notepad.exe"}`) — `ShellExecuteEx`-based launches work in Session 0 for anything reachable via PATH.
+
 ## Testing
 
 ### Are there tests I can run against my install?

--- a/docs/content/docs/cua-driver/guide/getting-started/installation.mdx
+++ b/docs/content/docs/cua-driver/guide/getting-started/installation.mdx
@@ -268,11 +268,44 @@ A healthy interactive logon reports the inverse:
 
 - **Run from RDP or the local console** — the simplest fix; both put your shell in your own interactive session, not Session 0.
 - **Run from a Windows Terminal / PowerShell launched by your logged-in user** — same effect.
-- **Scheduled Task in the user's session** — register a scheduled task with `Run only when user is logged on` checked and the principal set to your logged-in user. Cua Driver launched from that task inherits the user's interactive desktop.
+- **Register a logon Scheduled Task** (recommended, equivalent to macOS LaunchAgent) — see [Auto-start at logon](#auto-start-at-logon-windows) below.
 - **Use a session-launcher utility** — if you must invoke from a service / SSH context, run the binary through a launcher that spawns it inside an explicit interactive session id rather than inheriting Session 0.
 - **Configure your SSH server to spawn inside the interactive session** — possible with most modern Windows SSH server distributions but requires extra setup; the scheduled-task approach is usually simpler.
 
 Run `cua-driver doctor` after switching contexts to confirm the warning has cleared.
+
+#### Auto-start at logon (Windows)
+
+The Windows-native equivalent of macOS's LaunchAgent is a **Scheduled Task triggered at logon, running as your user, with `Run only when user is logged on`** (i.e. `LogonType: Interactive`). Once registered, `cua-driver serve` starts automatically every time you sign in via RDP or the console — no more pasting a startup one-liner.
+
+`install.ps1` prints the exact one-shot registration block on a successful install. To register it manually (substitute your install path if you built from source):
+
+```powershell
+$exe       = "$env:LOCALAPPDATA\Programs\trycua\cua-driver-rs\bin\cua-driver.exe"
+$user      = "$env:COMPUTERNAME\$env:USERNAME"
+$action    = New-ScheduledTaskAction -Execute $exe -Argument 'serve' -WorkingDirectory $env:USERPROFILE
+$trigger   = New-ScheduledTaskTrigger -AtLogOn -User $user
+$principal = New-ScheduledTaskPrincipal -UserId $user -LogonType Interactive -RunLevel Limited
+$settings  = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+                -StartWhenAvailable -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1) `
+                -ExecutionTimeLimit (New-TimeSpan -Hours 0)
+Register-ScheduledTask -TaskName 'cua-driver-serve' -Action $action -Trigger $trigger `
+    -Principal $principal -Settings $settings
+```
+
+Useful follow-ups:
+
+```powershell
+schtasks /Run    /TN cua-driver-serve         # start it now without re-logging
+schtasks /Query  /TN cua-driver-serve /V /FO LIST
+schtasks /Delete /TN cua-driver-serve /F      # remove
+```
+
+Notes:
+
+- `LogonType: Interactive` is load-bearing — it pins the task to a Session 1+ logon. The alternative (`S4U` or `Password`) would land you in Session 0 again, undoing the point.
+- `-ExecutionTimeLimit (New-TimeSpan -Hours 0)` means "no time limit"; without it Windows kills the task after 72h by default.
+- Set `CUA_DRIVER_RS_TELEMETRY_ENABLED=0` in your User environment if you want to disable telemetry persistently: `[Environment]::SetEnvironmentVariable('CUA_DRIVER_RS_TELEMETRY_ENABLED', '0', 'User')`.
 
 ## Grant TCC permissions
 

--- a/libs/cua-driver-rs/DEV_LOOP_WINDOWS_VM.md
+++ b/libs/cua-driver-rs/DEV_LOOP_WINDOWS_VM.md
@@ -1,7 +1,7 @@
 # Dev loop — cua-driver-rs on the Windows VM
 
 Quick reference for iterating on Windows-specific cua-driver-rs code
-directly on `fbonacci-windows-vm` without round-tripping through GitHub
+directly on `<vm-name>` without round-tripping through GitHub
 CD. Set up Sun 2026-05-18 by the autonomous session for the doctor
 segfault / Session-0 hang investigations.
 
@@ -9,13 +9,13 @@ segfault / Session-0 hang investigations.
 
 - **SSH** (Session 0 — services context, no desktop):
   ```bash
-  ssh -i ~/.ssh/cua_winvm fbonacci@20.115.29.195
+  ssh -i ~/.ssh/<ssh-key> <user>@<vm-host>
   ```
 - **RDP** (Session 1+ with attached desktop, needed for visual / GUI tool validation):
   ```bash
-  open /Users/francesco/Desktop/fbonacci-windows-vm.rdp
+  open <rdp-file-dir>/<vm-name>.rdp
   ```
-  Credentials: `fbonacci` + password from password manager.
+  Credentials: `<user>` + password from your password manager.
 
 ## Toolchain on the VM (already installed)
 
@@ -23,7 +23,7 @@ segfault / Session-0 hang investigations.
 - Rustup 1.29 + `stable-x86_64-pc-windows-msvc` (rustc 1.95.0)
 - Cargo 1.95.0
 - Visual Studio Build Tools 2022 (VCTools + Windows 11 SDK)
-- Clone: `C:\Users\fbonacci\cua` (HEAD pinned to origin/main at clone time;
+- Clone: `C:\Users\<user>\cua` (HEAD pinned to origin/main at clone time;
   `git pull` to refresh)
 
 ## Iteration loop
@@ -31,13 +31,13 @@ segfault / Session-0 hang investigations.
 1. **Edit locally on the Mac** (use Claude Code, your IDE, etc.).
 2. **Push changed files to the VM** via `scp`:
    ```bash
-   scp -i ~/.ssh/cua_winvm \
-     /Users/francesco/cua/libs/cua-driver-rs/crates/platform-windows/src/<file>.rs \
-     fbonacci@20.115.29.195:cua/libs/cua-driver-rs/crates/platform-windows/src/<file>.rs
+   scp -i ~/.ssh/<ssh-key> \
+     <repo-root>/libs/cua-driver-rs/crates/platform-windows/src/<file>.rs \
+     <user>@<vm-host>:cua/libs/cua-driver-rs/crates/platform-windows/src/<file>.rs
    ```
 3. **Build on the VM** (~20 s incremental, ~5 min cold):
    ```bash
-   ssh -i ~/.ssh/cua_winvm fbonacci@20.115.29.195 \
+   ssh -i ~/.ssh/<ssh-key> <user>@<vm-host> \
      "powershell -Command 'cd cua\\libs\\cua-driver-rs; cargo build --release -p cua-driver'"
    ```
 4. **Test on the VM** — use PowerShell `Start-Job` for clean timeouts;
@@ -113,20 +113,20 @@ In Session 0 the autonomous session got 11/11 PASS as of 2026-05-18.
 
 ```bash
 # Quick file push
-scp -i ~/.ssh/cua_winvm <local> fbonacci@20.115.29.195:cua/libs/cua-driver-rs/...
+scp -i ~/.ssh/<ssh-key> <local> <user>@<vm-host>:cua/libs/cua-driver-rs/...
 
 # Quick build + test with timeout (Mac side)
-ssh -o ServerAliveInterval=20 -i ~/.ssh/cua_winvm fbonacci@20.115.29.195 \
+ssh -o ServerAliveInterval=20 -i ~/.ssh/<ssh-key> <user>@<vm-host> \
   'powershell -ExecutionPolicy Bypass -File some-script.ps1'
 
 # Quick PSCMD via stdin pipe
-echo '{"name":"notepad"}' | ssh -i ~/.ssh/cua_winvm fbonacci@20.115.29.195 \
-  '"C:\\Users\\fbonacci\\cua\\libs\\cua-driver-rs\\target\\release\\cua-driver.exe" call launch_app'
+echo '{"name":"notepad"}' | ssh -i ~/.ssh/<ssh-key> <user>@<vm-host> \
+  '"C:\\Users\\<user>\\cua\\libs\\cua-driver-rs\\target\\release\\cua-driver.exe" call launch_app'
 
 # Kill all stale cua-driver procs
-ssh -i ~/.ssh/cua_winvm fbonacci@20.115.29.195 \
+ssh -i ~/.ssh/<ssh-key> <user>@<vm-host> \
   "powershell -Command 'Get-Process cua-driver -EA SilentlyContinue | Stop-Process -Force'"
 
 # Check which sessions exist
-ssh -i ~/.ssh/cua_winvm fbonacci@20.115.29.195 "powershell -Command qwinsta"
+ssh -i ~/.ssh/<ssh-key> <user>@<vm-host> "powershell -Command qwinsta"
 ```

--- a/libs/cua-driver-rs/DEV_LOOP_WINDOWS_VM.md
+++ b/libs/cua-driver-rs/DEV_LOOP_WINDOWS_VM.md
@@ -1,0 +1,132 @@
+# Dev loop — cua-driver-rs on the Windows VM
+
+Quick reference for iterating on Windows-specific cua-driver-rs code
+directly on `fbonacci-windows-vm` without round-tripping through GitHub
+CD. Set up Sun 2026-05-18 by the autonomous session for the doctor
+segfault / Session-0 hang investigations.
+
+## Connection
+
+- **SSH** (Session 0 — services context, no desktop):
+  ```bash
+  ssh -i ~/.ssh/cua_winvm fbonacci@20.115.29.195
+  ```
+- **RDP** (Session 1+ with attached desktop, needed for visual / GUI tool validation):
+  ```bash
+  open /Users/francesco/Desktop/fbonacci-windows-vm.rdp
+  ```
+  Credentials: `fbonacci` + password from password manager.
+
+## Toolchain on the VM (already installed)
+
+- Git 2.54.0
+- Rustup 1.29 + `stable-x86_64-pc-windows-msvc` (rustc 1.95.0)
+- Cargo 1.95.0
+- Visual Studio Build Tools 2022 (VCTools + Windows 11 SDK)
+- Clone: `C:\Users\fbonacci\cua` (HEAD pinned to origin/main at clone time;
+  `git pull` to refresh)
+
+## Iteration loop
+
+1. **Edit locally on the Mac** (use Claude Code, your IDE, etc.).
+2. **Push changed files to the VM** via `scp`:
+   ```bash
+   scp -i ~/.ssh/cua_winvm \
+     /Users/francesco/cua/libs/cua-driver-rs/crates/platform-windows/src/<file>.rs \
+     fbonacci@20.115.29.195:cua/libs/cua-driver-rs/crates/platform-windows/src/<file>.rs
+   ```
+3. **Build on the VM** (~20 s incremental, ~5 min cold):
+   ```bash
+   ssh -i ~/.ssh/cua_winvm fbonacci@20.115.29.195 \
+     "powershell -Command 'cd cua\\libs\\cua-driver-rs; cargo build --release -p cua-driver'"
+   ```
+4. **Test on the VM** — use PowerShell `Start-Job` for clean timeouts;
+   pipe JSON args via stdin to bypass PowerShell's nested-quoting hell:
+   ```powershell
+   '{"name":"notepad"}' | & "$env:USERPROFILE\cua\libs\cua-driver-rs\target\release\cua-driver.exe" call launch_app
+   ```
+
+## Gotchas the autonomous session hit
+
+1. **PowerShell heredoc quoting** — `Start-Process -ArgumentList` with a JSON
+   arg containing `"` will silently strip the quotes. **Workaround:**
+   pipe the JSON via stdin to `cua-driver call <tool>` instead of
+   passing it as argv.
+
+2. **`Start-Process -RedirectStandardError` buffering** — stderr from
+   the child process may not flush to the redirect file until the child
+   exits cleanly. If you `Stop-Process` mid-run you lose buffered
+   stderr. **Workaround:** use `Start-Job` with `Tee-Object` for live
+   capture, or write to a file from inside the script.
+
+3. **PowerShell strings with `(`, `,`, em-dashes** — PowerShell parses
+   parentheses and commas inside double-quoted strings as method calls
+   in some contexts. Em-dashes get corrupted by `scp`. **Workaround:**
+   stick to plain ASCII single-quoted strings in any script you `scp`
+   over.
+
+4. **`R` is a PowerShell alias for `Invoke-History`.** Don't name a
+   helper function `R`.
+
+5. **Some parity examples hard-code `target/debug/cua-driver.exe`** —
+   if you've only run `cargo build --release` you need to also run
+   `cargo build` (debug) once, otherwise `list_tools_parity` and
+   `describe_parity` fail with "cannot find the path specified".
+
+6. **`SetForegroundWindow` is restricted on Windows** — calling it
+   from a non-foreground process silently no-ops most of the time. The
+   foreground-restore in `launch_uwp` is best-effort. Plan visual
+   confirmation in Session 1+ for any focus-related work.
+
+7. **Visual Studio Build Tools install is ~5 GB and takes ~10-15 min
+   over Azure VM network.** Don't reinstall — it's there.
+
+## Running the parity suite
+
+```powershell
+$env:CUA_DRIVER_RS_TELEMETRY_ENABLED = "0"
+$exe = "$env:USERPROFILE\cua\libs\cua-driver-rs\target\release\cua-driver.exe"
+
+# 1. Start the daemon
+Get-Process | Where-Object { $_.Name -eq 'cua-driver' } | Stop-Process -Force
+Start-Process -FilePath $exe -ArgumentList 'serve' -NoNewWindow
+
+# 2. Run all parity examples (skip overlay_dump — it's interactive-overlay-only)
+cd $env:USERPROFILE\cua\libs\cua-driver-rs
+$examples = @('list_tools_parity','describe_parity','get_screen_size_parity',
+              'get_cursor_position_parity','config_parity',
+              'agent_cursor_setters_parity','get_agent_cursor_state_parity',
+              'set_agent_cursor_style_parity','list_windows_parity',
+              'list_apps_parity','launch_app_parity')
+foreach ($ex in $examples) {
+    cargo run --release --quiet --example $ex -p platform-windows
+    Write-Host "$ex exit=$LASTEXITCODE"
+}
+
+# 3. Cleanup
+Get-Process | Where-Object { $_.Name -eq 'cua-driver' } | Stop-Process -Force
+```
+
+In Session 0 the autonomous session got 11/11 PASS as of 2026-05-18.
+
+## Commands the autonomous session used most
+
+```bash
+# Quick file push
+scp -i ~/.ssh/cua_winvm <local> fbonacci@20.115.29.195:cua/libs/cua-driver-rs/...
+
+# Quick build + test with timeout (Mac side)
+ssh -o ServerAliveInterval=20 -i ~/.ssh/cua_winvm fbonacci@20.115.29.195 \
+  'powershell -ExecutionPolicy Bypass -File some-script.ps1'
+
+# Quick PSCMD via stdin pipe
+echo '{"name":"notepad"}' | ssh -i ~/.ssh/cua_winvm fbonacci@20.115.29.195 \
+  '"C:\\Users\\fbonacci\\cua\\libs\\cua-driver-rs\\target\\release\\cua-driver.exe" call launch_app'
+
+# Kill all stale cua-driver procs
+ssh -i ~/.ssh/cua_winvm fbonacci@20.115.29.195 \
+  "powershell -Command 'Get-Process cua-driver -EA SilentlyContinue | Stop-Process -Force'"
+
+# Check which sessions exist
+ssh -i ~/.ssh/cua_winvm fbonacci@20.115.29.195 "powershell -Command qwinsta"
+```

--- a/libs/cua-driver-rs/PARITY.md
+++ b/libs/cua-driver-rs/PARITY.md
@@ -313,7 +313,12 @@ terminal-only flow proves insufficient; the CLI is the MVP.
          + `crates/platform-linux/src/installed_apps.rs`
 - Status:
   - macOS: VERIFIED — unified shape + installed-app scan + running merge
-  - windows: VERIFIED for Win32 path (cross-target check), live-run pending on a Windows host
+  - windows: VERIFIED live — Win11 24H2 in Session 0 returns ~150 apps
+    (Start-Menu .lnk + WinRT PackageManager UWP), cold call ~370ms
+    (80ms Start-Menu, 320ms UWP), warm call sub-100ms. All entries
+    expose the unified shape (`pid`, `name`, `bundle_id`, `kind`,
+    `launch_path`, `last_used`, `windows`, `running`, `active`).
+    Validated against `list_apps_parity` example.
   - linux: code ready (cross-target check pending Linux host)
 - Test: `tests/integration/test_api_parity.py::RustParityTests::test_call_list_apps_*`
         + `crates/platform-windows/examples/list_apps_parity.rs`
@@ -564,11 +569,18 @@ Windows's `click` takes `{button: enum}` instead.  Rationale:
   - macOS=`crates/platform-macos/src/tools/launch_app.rs` (full focus-steal contract)
   - linux=`crates/platform-linux/src/tools/impl_.rs` (TBD audit)
 - Status:
-  - windows: VERIFIED
+  - windows: VERIFIED for Win32 path; UWP path requires interactive session
+    (returns descriptive error in Session 0 — never hangs). Win32 launches
+    use `ShellExecuteExW` + `SW_SHOWNOACTIVATE` (no focus steal, matches
+    macOS oapp). UWP launches use `IApplicationActivationManager` +
+    best-effort `GetForegroundWindow` snapshot/restore (best-effort
+    because `SetForegroundWindow` is subject to Windows' foreground-lock
+    restrictions — visual confirmation in Session 1+ recommended).
   - macOS: VERIFIED (full focus-steal contract — see [Focus-steal prevention](#focus-steal-prevention))
   - linux: OPEN
 - Tests:
-  - windows=`crates/platform-windows/examples/launch_app_parity.rs`
+  - windows=`crates/platform-windows/examples/launch_app_parity.rs` (accepts
+    Session-0 fast-fail for UWP path the same way it accepts "not installed")
   - macOS=`tests/integration/test_focus_steal_parity.py` + `crates/platform-macos/src/focus_steal.rs` (Rust unit tests)
 
 ### Fixed (Windows)

--- a/libs/cua-driver-rs/crates/cua-driver/src/serve.rs
+++ b/libs/cua-driver-rs/crates/cua-driver/src/serve.rs
@@ -580,6 +580,31 @@ pub fn run_serve_cmd(
         std::process::exit(1);
     }
 
+    // Session-0 warning banner (Windows). The daemon runs fine in services
+    // / SSH contexts for tools that don't touch the desktop, but every
+    // window-driving tool (click, type_text, screenshot, get_window_state,
+    // list_windows, launch_app for UWP) will fail or return empty when
+    // invoked from this daemon. Surfacing this at startup saves users
+    // hours of debugging tools that are working as designed.
+    #[cfg(target_os = "windows")]
+    {
+        if matches!(
+            platform_windows::diagnostics::current_session_id(),
+            Some(0),
+        ) {
+            eprintln!(
+                "WARNING: cua-driver serve is starting in Session 0 (services). \
+                 Window-driving tools — click, type_text, screenshot, \
+                 get_window_state, list_windows, and UWP launches — need an \
+                 attached interactive desktop and will fail or return empty \
+                 here. Re-run from an interactive logon (RDP, console, or a \
+                 scheduled task in the user's session) for the GUI tools to \
+                 function. Non-GUI tools (list_apps for Win32, get_config, \
+                 doctor, etc.) work normally."
+            );
+        }
+    }
+
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()

--- a/libs/cua-driver-rs/crates/platform-windows/examples/launch_app_parity.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/examples/launch_app_parity.rs
@@ -156,12 +156,22 @@ fn main() {
                 || err_text.contains("0x80070057")
                 || err_text.contains("E_INVALIDARG")
                 || err_lower.contains("the parameter is incorrect");
+            // Session-0 short-circuit: UWP activation in non-interactive
+            // sessions (services / SSH) fails fast with a descriptive
+            // error rather than hanging. This is correct behavior, not a
+            // regression — accept it the same way we accept "not installed".
+            let looks_like_session_0 = err_lower.contains("interactive session")
+                || err_lower.contains("session 0");
             assert!(
-                looks_like_not_installed,
+                looks_like_not_installed || looks_like_session_0,
                 "AUMID launch of {aumid:?} failed with an unexpected error \
-                 (not a 'not installed' signal): {err_text:?}"
+                 (not 'not installed' or 'Session 0' signal): {err_text:?}"
             );
-            println!("AUMID path: packaged Notepad not installed on this host; skipped ({err_text:?})");
+            if looks_like_session_0 {
+                println!("AUMID path: skipped — running in Session 0 (UWP needs interactive desktop) ({err_text:?})");
+            } else {
+                println!("AUMID path: packaged Notepad not installed on this host; skipped ({err_text:?})");
+            }
         }
     }
 

--- a/libs/cua-driver-rs/crates/platform-windows/examples/list_apps_parity.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/examples/list_apps_parity.rs
@@ -1,13 +1,20 @@
 //! Parity check for `list_apps`.
 //!
-//! Asserts the response has Swift's shape:
+//! Asserts the response has the unified shape introduced by #1545:
 //!   - text begins with `"✅ Found N app(s): R running, I installed-not-running."`
 //!   - one bullet line per running app: `"- <name> (pid <N>)"`
-//!   - `structuredContent.apps` is an array of `{pid, bundle_id, name, running, active}`
-//!   - at least one app is marked `active: true` (something must own the
-//!     foreground window when this test runs)
+//!   - `structuredContent.apps` is an array of
+//!     `{pid, bundle_id, name, running, active, kind, launch_path, last_used, windows}`
+//!   - the array contains BOTH running and installed-not-running entries
+//!     (running entries have pid > 0, installed have pid == 0).
 //!
-//! Hard 4-second timeout on the round-trip.
+//! Session-0 aware: when run in a non-interactive session (services / SSH)
+//! the `active` assertion is skipped because no window owns foreground.
+//! In an interactive session at least one app should be marked active.
+//!
+//! Hard 8-second timeout on the round-trip — list_apps does Start-Menu
+//! + WinRT PackageManager scans which take ~300ms on a stock Win11 image
+//! and several seconds on machines with many installed apps.
 
 use std::io::{Read, Write};
 use std::time::{Duration, Instant};
@@ -24,7 +31,7 @@ fn main() {
         p.flush().ok();
         let mut out = Vec::new();
         let mut buf = [0u8; 65536];
-        let deadline = Instant::now() + Duration::from_secs(4);
+        let deadline = Instant::now() + Duration::from_secs(8);
         loop {
             if Instant::now() > deadline { panic!("response timeout"); }
             let n = p.read(&mut buf).unwrap_or(0);
@@ -44,32 +51,60 @@ fn main() {
     println!("Header: {first_line:?}");
     assert!(
         first_line.starts_with("✅ Found ") && first_line.contains(" app(s): "),
-        "Header {first_line:?} does not match Swift `✅ Found N app(s): R running, I installed-not-running.`"
+        "Header {first_line:?} does not match `✅ Found N app(s): R running, I installed-not-running.`"
     );
 
-    // structuredContent
+    // structuredContent — #1545 contract: array of mixed running + installed.
     let apps = v.pointer("/result/structuredContent/apps").and_then(|a| a.as_array())
         .expect("structuredContent.apps is not an array");
-    assert!(!apps.is_empty(), "Expected at least one running app");
+    assert!(!apps.is_empty(), "Expected at least one app (running or installed)");
     println!("Apps: {} entries", apps.len());
 
     let mut any_active = false;
+    let mut running_count = 0;
+    let mut installed_count = 0;
     for (i, app) in apps.iter().enumerate() {
         let pid    = app.pointer("/pid").and_then(|n| n.as_u64()).expect("pid");
         let name   = app.pointer("/name").and_then(|s| s.as_str()).expect("name");
         let running = app.pointer("/running").and_then(|b| b.as_bool()).expect("running");
         let active  = app.pointer("/active").and_then(|b| b.as_bool()).expect("active");
-        // bundle_id present (null on Windows, optional string on macOS).
+        // bundle_id present (null on Windows for non-UWP, optional string on macOS).
         let _ = app.pointer("/bundle_id").expect("bundle_id key missing");
+        // #1545 fields: kind, launch_path, last_used, windows.
+        let _ = app.pointer("/kind").expect("kind key missing (added by #1545)");
+        let _ = app.pointer("/launch_path").expect("launch_path key missing (added by #1545)");
+        let _ = app.pointer("/last_used").expect("last_used key missing (added by #1545)");
+        let _ = app.pointer("/windows").expect("windows key missing (added by #1545)");
         if i < 5 {
             println!("  [{i}] pid={pid} name={name:?} running={running} active={active}");
         }
-        assert!(running, "Windows list_apps should only return running apps for now");
+        if running { running_count += 1; } else { installed_count += 1; }
+        // Running entries must have pid > 0; installed-not-running must have pid == 0.
+        if running { assert!(pid > 0, "running entry must have pid>0: {name:?}"); }
+        else       { assert_eq!(pid, 0, "installed-not-running must have pid=0: {name:?}"); }
         if active { any_active = true; }
     }
-    assert!(any_active, "Expected at least one app marked active (the foreground window owner)");
+    println!("Counts: {running_count} running, {installed_count} installed-not-running");
 
-    println!("\n✅ PASS: text header + structuredContent.apps shape match Swift");
+    // The "active" assertion only holds when run from an interactive session
+    // (Session 1+) where some foreground window exists. Skip in Session 0
+    // (services / SSH-launched processes) where GetForegroundWindow returns
+    // null and no app is reported as active — that's correct behavior, not
+    // a regression.
+    let in_session_0 = matches!(
+        platform_windows::diagnostics::current_session_id(),
+        Some(0),
+    );
+    if in_session_0 {
+        println!("(Session 0: skipping active-app assertion — no interactive desktop attached)");
+    } else if running_count > 0 {
+        assert!(
+            any_active,
+            "Expected at least one app marked active (the foreground window owner)",
+        );
+    }
+
+    println!("\n✅ PASS: text header + structuredContent.apps shape match unified contract");
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/libs/cua-driver-rs/crates/platform-windows/examples/list_windows_parity.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/examples/list_windows_parity.rs
@@ -42,7 +42,21 @@ fn main() {
 
     let wins = v.pointer("/result/structuredContent/windows").and_then(|w| w.as_array())
         .expect("structuredContent.windows is not an array");
-    assert!(!wins.is_empty(), "expected at least one visible window");
+
+    // Window enumeration requires an attached interactive desktop. In
+    // Session 0 (services / SSH-launched processes) `EnumWindows` is
+    // scoped to the caller's window station which has no on-screen
+    // windows, so an empty array here is correct behavior — not a
+    // regression. Skip the "non-empty" assertion in that case.
+    let in_session_0 = matches!(
+        platform_windows::diagnostics::current_session_id(),
+        Some(0),
+    );
+    if in_session_0 {
+        println!("(Session 0: skipping non-empty-windows assertion — no interactive desktop attached)");
+    } else {
+        assert!(!wins.is_empty(), "expected at least one visible window");
+    }
 
     for w in wins {
         for key in &["window_id","pid","app_name","title","bounds","layer","z_index","is_on_screen"] {

--- a/libs/cua-driver-rs/crates/platform-windows/examples/overlay_dump.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/examples/overlay_dump.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant};
 fn main() {
     use windows::Win32::Foundation::HWND;
     use windows::Win32::Graphics::Gdi::*;
+    use windows::Win32::Storage::Xps::{PrintWindow, PRINT_WINDOW_FLAGS};
     use windows::Win32::UI::WindowsAndMessaging::*;
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;

--- a/libs/cua-driver-rs/crates/platform-windows/src/diagnostics.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/diagnostics.rs
@@ -88,6 +88,14 @@ pub fn interactive_desktop_check() -> Result<bool, String> {
 /// Initialises COM (apartment-threaded) for the duration of the probe
 /// and uninitialises before returning so the rest of the doctor run is
 /// unaffected.
+///
+/// **COM lifecycle invariant** — the IUIAutomation interface produced by
+/// CoCreateInstance must be released BEFORE CoUninitialize tears down
+/// the apartment, or `IUnknown::Release` will dereference freed COM
+/// infrastructure and segfault (0xC0000005 ACCESS_VIOLATION). We flatten
+/// the probe result into a plain `Result<(), String>` first so the
+/// `IUIAutomation` is dropped at the end of the statement, then call
+/// CoUninitialize on the next line.
 #[cfg(target_os = "windows")]
 pub fn ui_automation_available() -> Result<(), String> {
     unsafe {
@@ -97,17 +105,24 @@ pub fn ui_automation_available() -> Result<(), String> {
         let init_result = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
         let need_uninit = init_result.is_ok();
 
-        let probe = CoCreateInstance::<_, IUIAutomation>(
+        // Bind to `_` immediately so the IUIAutomation interface is
+        // dropped (and `Release()` runs while COM is still up) before
+        // we proceed to CoUninitialize. Holding the binding past
+        // CoUninitialize and letting Drop run at function return
+        // causes a use-after-free in the COM apartment.
+        let result = CoCreateInstance::<_, IUIAutomation>(
             &CUIAutomation,
             None,
             CLSCTX_INPROC_SERVER,
-        );
+        )
+        .map(|_| ())
+        .map_err(|e| format!("{e}"));
 
         if need_uninit {
             CoUninitialize();
         }
 
-        probe.map(|_| ()).map_err(|e| format!("{e}"))
+        result
     }
 }
 

--- a/libs/cua-driver-rs/crates/platform-windows/src/launch_uwp.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/launch_uwp.rs
@@ -144,14 +144,35 @@ pub fn launch_uwp(aumid: &str, args: &str) -> windows::core::Result<u32> {
 /// foreground a few milliseconds AFTER `ActivateApplication` returns —
 /// a single immediate SetForegroundWindow call would race the AppX
 /// runtime and lose. Three attempts spaced 50ms apart covers the window.
+///
+/// **Foreground-lock workaround:** Windows restricts SetForegroundWindow
+/// to processes that meet specific conditions (foreground process,
+/// owner of last input, etc.). The daemon usually meets none of these
+/// when launch_app is called from MCP. We inject a single VK_NONAME
+/// synthetic keypress via `keybd_event` to claim "owner of last input"
+/// status long enough for SetForegroundWindow to succeed. VK_NONAME
+/// (0xFC) is the reserved no-name virtual-key code — it does not map
+/// to any UI action and is safe to inject without side effects.
 fn restore_foreground_best_effort(prior: HWND) {
-    use windows::Win32::UI::WindowsAndMessaging::{
-        IsWindow, SetForegroundWindow,
+    use windows::Win32::UI::Input::KeyboardAndMouse::{
+        keybd_event, KEYBD_EVENT_FLAGS, KEYEVENTF_KEYUP,
     };
+    use windows::Win32::UI::WindowsAndMessaging::{IsWindow, SetForegroundWindow};
+
     if prior.0.is_null() {
         tracing::debug!(target: "launch_uwp", "no prior foreground to restore");
         return;
     }
+
+    // Claim "owner of last input" so the next SetForegroundWindow call
+    // isn't silently dropped by the foreground lock. VK_NONAME (0xFC)
+    // doesn't trigger any application's key handler.
+    const VK_NONAME: u8 = 0xFC;
+    unsafe {
+        keybd_event(VK_NONAME, 0, KEYBD_EVENT_FLAGS(0), 0);
+        keybd_event(VK_NONAME, 0, KEYEVENTF_KEYUP, 0);
+    }
+
     for attempt in 0..3 {
         if attempt > 0 {
             std::thread::sleep(std::time::Duration::from_millis(50));
@@ -161,7 +182,16 @@ fn restore_foreground_best_effort(prior: HWND) {
                 tracing::debug!(target: "launch_uwp", "prior foreground HWND no longer valid");
                 return;
             }
-            let _ = SetForegroundWindow(prior);
+            let ok = SetForegroundWindow(prior).as_bool();
+            tracing::debug!(
+                target: "launch_uwp",
+                "SetForegroundWindow attempt {} -> {}",
+                attempt + 1,
+                ok,
+            );
+            if ok {
+                return;
+            }
         }
     }
 }

--- a/libs/cua-driver-rs/crates/platform-windows/src/launch_uwp.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/launch_uwp.rs
@@ -36,6 +36,7 @@
 use std::sync::{OnceLock, RwLock};
 
 use windows::core::{Interface, GUID, HSTRING, PCWSTR, PWSTR};
+use windows::Win32::Foundation::HWND;
 use windows::Win32::System::Com::{
     CoCreateInstance, CoInitializeEx, CoTaskMemFree, IBindCtx, CLSCTX_LOCAL_SERVER,
     COINIT_APARTMENTTHREADED,
@@ -45,6 +46,7 @@ use windows::Win32::UI::Shell::{
     ApplicationActivationManager, IApplicationActivationManager, IEnumShellItems, IShellItem,
     IShellItem2, SHCreateItemFromParsingName, AO_NONE, BHID_EnumItems, SIGDN_NORMALDISPLAY,
 };
+use windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow;
 
 /// `PKEY_AppUserModel_ID` (System.AppUserModel.ID) — the property key whose
 /// string value on each `shell:AppsFolder` entry is the AUMID we need to
@@ -71,6 +73,14 @@ const PKEY_APP_USER_MODEL_ID: PROPERTYKEY = PROPERTYKEY {
 /// behavior identical to a user-driven Start Menu click — splash screen
 /// shown, error UI shown on failure, default activation kind.
 ///
+/// **Background-launch invariant** — the AppX runtime's default activation
+/// brings the newly-activated app to the foreground (same as a Start Menu
+/// click). cua-driver's contract is the opposite: launched apps must not
+/// steal focus from whatever the human is doing. We snapshot the pre-call
+/// foreground window with `GetForegroundWindow` and restore it after
+/// activation returns. This matches macOS's `NSWorkspace.openApplication`
+/// + `activates=false` + `oapp` AppleEvent invariant.
+///
 /// Errors propagate the `HRESULT` from `ActivateApplication`. The most
 /// common failures:
 /// - `E_INVALIDARG` — AUMID not installed for the current user
@@ -79,6 +89,18 @@ const PKEY_APP_USER_MODEL_ID: PROPERTYKEY = PROPERTYKEY {
 /// - Any COM-init failure on a thread that has previously been
 ///   initialized with a conflicting apartment model
 pub fn launch_uwp(aumid: &str, args: &str) -> windows::core::Result<u32> {
+    // Session-0 short-circuit: `IApplicationActivationManager::ActivateApplication`
+    // relies on the per-user AppX runtime that doesn't exist in services /
+    // SSH-launched contexts. Calling it in Session 0 hangs indefinitely
+    // (no CPU, no progress, no error). Fail fast with a clear message so
+    // tools / tests don't time out silently.
+    if matches!(crate::diagnostics::current_session_id(), Some(0)) {
+        return Err(windows::core::Error::new(
+            windows::core::HRESULT(0x80004005u32 as i32), // E_FAIL
+            format!("UWP activation of {aumid:?} requires an interactive session — current process is in Session 0 (services). Re-run from an interactive logon (RDP, console, or scheduled task in the user's session)."),
+        ));
+    }
+
     // Apartment model: AAM is a local-server COM object that historically
     // requires STA on the calling thread. `CoInitializeEx` is idempotent
     // per-thread; its HRESULT is intentionally discarded — if the thread
@@ -93,6 +115,10 @@ pub fn launch_uwp(aumid: &str, args: &str) -> windows::core::Result<u32> {
     let aumid_h = HSTRING::from(aumid);
     let args_h = HSTRING::from(args);
 
+    // Snapshot prior foreground BEFORE activation — that's our restore
+    // target. Captured even if null; the restore step is a no-op then.
+    let prior_foreground = unsafe { GetForegroundWindow() };
+
     let pid = unsafe {
         manager.ActivateApplication(
             PCWSTR(aumid_h.as_ptr()),
@@ -101,7 +127,43 @@ pub fn launch_uwp(aumid: &str, args: &str) -> windows::core::Result<u32> {
         )?
     };
 
+    // Restore the prior foreground window. AppX activation has already
+    // run by this point and may have stolen focus; flip it back so the
+    // human's typing context is preserved. The restore is best-effort —
+    // failures (null prior, target window destroyed, target hung) are
+    // logged at debug level and otherwise swallowed because the launch
+    // itself succeeded and we don't want to fail the tool call on a
+    // focus-restore corner case.
+    restore_foreground_best_effort(prior_foreground);
+
     Ok(pid)
+}
+
+/// Best-effort restore of the foreground window. Run in a tight retry
+/// loop because UWP activations sometimes push their own window to
+/// foreground a few milliseconds AFTER `ActivateApplication` returns —
+/// a single immediate SetForegroundWindow call would race the AppX
+/// runtime and lose. Three attempts spaced 50ms apart covers the window.
+fn restore_foreground_best_effort(prior: HWND) {
+    use windows::Win32::UI::WindowsAndMessaging::{
+        IsWindow, SetForegroundWindow,
+    };
+    if prior.0.is_null() {
+        tracing::debug!(target: "launch_uwp", "no prior foreground to restore");
+        return;
+    }
+    for attempt in 0..3 {
+        if attempt > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        unsafe {
+            if !IsWindow(prior).as_bool() {
+                tracing::debug!(target: "launch_uwp", "prior foreground HWND no longer valid");
+                return;
+            }
+            let _ = SetForegroundWindow(prior);
+        }
+    }
 }
 
 /// Heuristic for "this string looks like an AUMID".
@@ -169,6 +231,21 @@ fn cache() -> &'static RwLock<Option<Vec<AppsFolderEntry>>> {
 /// Returns `None` if no packaged app matches. The caller should fall
 /// back to `ShellExecuteExW` for plain Win32 apps in that case.
 pub fn resolve_aumid_by_name(display_name: &str) -> Option<String> {
+    // Session 0 short-circuit: `shell:AppsFolder` enumeration goes through
+    // the interactive shell broker, which doesn't exist in services /
+    // SSH-launched contexts and causes the underlying COM call to hang
+    // indefinitely (~no CPU, no progress). Returning None here makes the
+    // caller fall through to ShellExecuteExW's PATH-based lookup, which
+    // works fine in Session 0 for any app reachable via PATH (notepad,
+    // calc, regedit, etc.). Packaged-only apps (Windows 11 Notepad) won't
+    // resolve here in Session 0 — explicit `aumid` is the workaround.
+    if matches!(crate::diagnostics::current_session_id(), Some(0)) {
+        tracing::debug!(
+            target: "launch_uwp",
+            "skipping shell:AppsFolder lookup in Session 0 (no interactive shell broker); falling back to ShellExecuteEx PATH lookup"
+        );
+        return None;
+    }
     let entries = load_or_get_cache()?;
     let query = display_name.trim().to_lowercase();
     if query.is_empty() {

--- a/libs/cua-driver-rs/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/tools/impl_.rs
@@ -161,25 +161,36 @@ impl Tool for ListAppsTool {
             use windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow;
             use windows::Win32::UI::WindowsAndMessaging::GetWindowThreadProcessId;
 
+            // Per-step timings logged via `tracing::debug!` (silent at default
+            // log level — enable with `RUST_LOG=cua_driver=debug` when debugging
+            // a slow list_apps invocation).
+            let t0 = std::time::Instant::now();
             let wins = crate::win32::list_windows(None);
+            tracing::debug!(target: "list_apps", "step 1 list_windows: {} wins ({}ms)", wins.len(), t0.elapsed().as_millis());
             let mut seen_pids = std::collections::HashSet::new();
             let mut running_pids: Vec<u32> = Vec::new();
             for w in &wins {
                 if seen_pids.insert(w.pid) { running_pids.push(w.pid); }
             }
 
+            let t1 = std::time::Instant::now();
             let foreground_pid = unsafe {
                 let fg = GetForegroundWindow();
                 let mut pid = 0u32;
                 let _ = GetWindowThreadProcessId(fg, Some(&mut pid));
                 pid
             };
+            tracing::debug!(target: "list_apps", "step 2 fg-window: pid={} ({}ms)", foreground_pid, t1.elapsed().as_millis());
 
+            let t2 = std::time::Instant::now();
             let procs = crate::win32::list_processes();
+            tracing::debug!(target: "list_apps", "step 3 list_processes: {} procs ({}ms)", procs.len(), t2.elapsed().as_millis());
             let pid_to_name: std::collections::HashMap<u32, String> =
                 procs.iter().map(|p| (p.pid, p.name.clone())).collect();
 
+            let t3 = std::time::Instant::now();
             let installed = crate::win32::list_installed_apps();
+            tracing::debug!(target: "list_apps", "step 4 list_installed_apps: {} installed ({}ms)", installed.len(), t3.elapsed().as_millis());
             // Lowercase-exe-basename → installed-app indices. We match running
             // processes by basename rather than full path because the process
             // table's executable name is `notepad.exe` while the Start-Menu

--- a/libs/cua-driver-rs/crates/platform-windows/src/win32/installed_apps.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/win32/installed_apps.rs
@@ -264,15 +264,12 @@ fn scan_uwp_packages() -> Vec<InstalledApp> {
                 continue;
             }
 
-            // Filter out frameworks (Visual C++ runtime, .NET shared
-            // assemblies, language packs, etc.) — they're libraries, not
-            // launchable apps. WinRT's `Package.IsFramework()` is the
-            // authoritative flag; a `false` from `IsFramework` errors is
-            // the conservative default (keep the entry, let the
-            // downstream display-name filter decide).
-            if let Ok(true) = pkg.IsFramework() {
-                continue;
-            }
+            // (Frameworks: Visual C++ runtime, .NET shared assemblies,
+            // language packs etc.) — we'd ideally filter via
+            // `pkg.IsFramework()`, but that WinRT call has been observed
+            // to hang in Session 0 on some Win11 SKUs. Skipping for now;
+            // the opaque-family-name filter below catches most of the
+            // noise these would have contributed.
 
             let raw_display = pkg.DisplayName().ok().map(|h| h.to_string());
             let display = normalize_uwp_display_name(raw_display, &pkg, &family_name);

--- a/libs/cua-driver-rs/crates/platform-windows/src/win32/installed_apps.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/win32/installed_apps.rs
@@ -55,8 +55,14 @@ pub struct InstalledApp {
 /// enumeration, not a guaranteed-complete catalog.
 pub fn list_installed_apps() -> Vec<InstalledApp> {
     let mut out = Vec::new();
-    out.extend(scan_start_menu());
-    out.extend(scan_uwp_packages());
+    let t0 = std::time::Instant::now();
+    let sm = scan_start_menu();
+    tracing::debug!(target: "installed_apps", "scan_start_menu: {} entries ({}ms)", sm.len(), t0.elapsed().as_millis());
+    out.extend(sm);
+    let t1 = std::time::Instant::now();
+    let uwp = scan_uwp_packages();
+    tracing::debug!(target: "installed_apps", "scan_uwp_packages: {} entries ({}ms)", uwp.len(), t1.elapsed().as_millis());
+    out.extend(uwp);
 
     // Dedupe by (kind, bundle_id) — Start Menu may list both a per-user and a
     // machine-wide shortcut for the same .exe target.

--- a/libs/cua-driver-rs/crates/platform-windows/src/win32/installed_apps.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/win32/installed_apps.rs
@@ -264,8 +264,29 @@ fn scan_uwp_packages() -> Vec<InstalledApp> {
                 continue;
             }
 
+            // Filter out frameworks (Visual C++ runtime, .NET shared
+            // assemblies, language packs, etc.) — they're libraries, not
+            // launchable apps. WinRT's `Package.IsFramework()` is the
+            // authoritative flag; a `false` from `IsFramework` errors is
+            // the conservative default (keep the entry, let the
+            // downstream display-name filter decide).
+            if let Ok(true) = pkg.IsFramework() {
+                continue;
+            }
+
             let raw_display = pkg.DisplayName().ok().map(|h| h.to_string());
             let display = normalize_uwp_display_name(raw_display, &pkg, &family_name);
+
+            // Filter out packages whose display name ended up identical
+            // to the family name (e.g. `1527c705-839a-4832-...!App` for
+            // an opaque system Component without a `<Properties><DisplayName>`
+            // entry in its manifest). These show up as line noise in
+            // list_apps and are typically unactivatable system pieces
+            // the agent should never invoke. Real user-facing apps
+            // almost always have a meaningful DisplayName.
+            if display == family_name && looks_like_opaque_system_family(&family_name) {
+                continue;
+            }
 
             // Resolve manifest Application.Id when available so launch_path
             // works for multi-entry packages too; fallback to "App" for
@@ -343,6 +364,44 @@ fn normalize_uwp_display_name(
     trimmed.to_owned()
 }
 
+/// True when a UWP family name looks like an opaque system component
+/// rather than a real user-facing app — GUID-prefixed packages
+/// (`{8-4-4-4-12}_pubid`) or names that begin with `Windows.Internal`.
+///
+/// These packages routinely ship without a meaningful `DisplayName` /
+/// `Properties/DisplayName` (e.g. `CredentialDialogHost`,
+/// `CloudExperienceHost`, internal language shims), so they fall through
+/// `normalize_uwp_display_name`'s fallbacks to the family name itself.
+/// Reporting that in `list_apps` is just noise — agents can't usefully
+/// launch them and they crowd out actual installed apps.
+fn looks_like_opaque_system_family(family_name: &str) -> bool {
+    // Strip the publisher suffix (`_pubid`) before testing the
+    // package-name half — that's where the GUID lives.
+    let pkg_name = family_name.split('_').next().unwrap_or(family_name);
+
+    // `Windows.Internal.*` is Microsoft's own conventional namespace
+    // for internal-only packages.
+    if pkg_name.starts_with("Windows.Internal") {
+        return true;
+    }
+
+    // GUID pattern: 8-4-4-4-12 hex with `-` separators.
+    let mut parts = pkg_name.splitn(5, '-');
+    let segs = [
+        parts.next().unwrap_or(""),
+        parts.next().unwrap_or(""),
+        parts.next().unwrap_or(""),
+        parts.next().unwrap_or(""),
+        parts.next().unwrap_or(""),
+    ];
+    let expected_lens = [8, 4, 4, 4, 12];
+    let all_hex = segs
+        .iter()
+        .zip(expected_lens.iter())
+        .all(|(s, &n)| s.len() == n && s.chars().all(|c| c.is_ascii_hexdigit()));
+    all_hex
+}
+
 /// Best-effort parse of AppxManifest.xml to extract `<Properties><DisplayName>`.
 fn read_uwp_manifest_display_name(pkg: &windows::ApplicationModel::Package) -> Option<String> {
     let base = pkg.InstalledPath().ok()?.to_string();
@@ -400,4 +459,62 @@ fn unix_secs_to_rfc3339(secs: i64) -> String {
         "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
         y, m, d, hour, minute, second
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opaque_system_family_matches_guid_prefix() {
+        // Both real-world examples seen on a stock Win11 image where
+        // Package.DisplayName resolved to an unresolved ms-resource:
+        // token and AppxManifest.xml didn't have a Properties/DisplayName.
+        assert!(looks_like_opaque_system_family(
+            "1527c705-839a-4832-9118-54d4Bd6a0c89_cw5n1h2txyewy"
+        ));
+        assert!(looks_like_opaque_system_family(
+            "F46D4000-FD22-4DB4-AC8E-4E1DDDE828FE_cw5n1h2txyewy"
+        ));
+    }
+
+    #[test]
+    fn opaque_system_family_matches_internal_namespace() {
+        assert!(looks_like_opaque_system_family(
+            "Windows.Internal.ShellExperience_cw5n1h2txyewy"
+        ));
+        assert!(looks_like_opaque_system_family(
+            "Windows.Internal.PrintingFramework_cw5n1h2txyewy"
+        ));
+    }
+
+    #[test]
+    fn opaque_system_family_keeps_real_apps() {
+        // Familiar packaged apps must NOT be filtered out — their family
+        // names don't look like GUIDs and don't start with the internal
+        // prefix.
+        assert!(!looks_like_opaque_system_family(
+            "Microsoft.WindowsNotepad_8wekyb3d8bbwe"
+        ));
+        assert!(!looks_like_opaque_system_family(
+            "Microsoft.WindowsCalculator_8wekyb3d8bbwe"
+        ));
+        assert!(!looks_like_opaque_system_family(
+            "Microsoft.MicrosoftEdge.Stable_8wekyb3d8bbwe"
+        ));
+        assert!(!looks_like_opaque_system_family(
+            "SpotifyAB.SpotifyMusic_zpdnekdrzrea0"
+        ));
+    }
+
+    #[test]
+    fn opaque_system_family_handles_missing_publisher_suffix() {
+        // No underscore = no publisher half. Still examine the whole
+        // string for the GUID / internal-namespace shape.
+        assert!(looks_like_opaque_system_family(
+            "1527c705-839a-4832-9118-54d4Bd6a0c89"
+        ));
+        assert!(!looks_like_opaque_system_family("Microsoft.WindowsNotepad"));
+        assert!(!looks_like_opaque_system_family(""));
+    }
 }

--- a/libs/cua-driver-rs/scripts/install-local.ps1
+++ b/libs/cua-driver-rs/scripts/install-local.ps1
@@ -67,47 +67,44 @@ if ($env:CUA_DRIVER_RS_HOME) {
 $CurrentDir  = Join-Path $PackageHome "packages\current"
 $ReleasesDir = Join-Path $PackageHome "packages\releases"
 
-# ---------- Helpers (lifted from install.ps1) -----------------------------
+# ---------- Helpers (mirror install.ps1) ----------------------------------
+#
+# install.ps1 keeps these inline in its own scope (it's a one-shot script
+# that runs end-to-end). Mirror them here so install-local.ps1 can stand
+# alone too. If install.ps1 ever extracts these into a shared file, this
+# duplication is the time to delete it.
 
-. "$ScriptDir\install.ps1.helpers.ps1" -ErrorAction SilentlyContinue 2>$null
-# install.ps1 doesn't currently extract its helpers into a separate
-# .helpers.ps1 — fall back to defining the absolute minimum here. If a
-# helpers file appears later, the dot-source above wins and these are
-# never compiled.
-if (-not (Get-Command -Name 'Test-IsJunction' -ErrorAction SilentlyContinue)) {
+function Test-IsJunction([string]$path) {
+    if (-not (Test-Path -LiteralPath $path)) { return $false }
+    $item = Get-Item -LiteralPath $path -Force
+    return [bool]($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint)
+}
 
-    function Test-IsJunction([string]$path) {
-        if (-not (Test-Path -LiteralPath $path)) { return $false }
-        $item = Get-Item -LiteralPath $path -Force
-        return [bool]($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint)
-    }
-
-    function Ensure-Junction([string]$linkPath, [string]$targetPath) {
-        New-Item -ItemType Directory -Path (Split-Path -Parent $linkPath) -Force | Out-Null
-        if (Test-Path -LiteralPath $linkPath) {
-            if (Test-IsJunction $linkPath) {
-                # Always retarget — that's the point of this helper.
-                cmd /c rmdir (Resolve-Path -LiteralPath $linkPath).Path | Out-Null
-            } else {
-                throw "Refusing to replace non-junction at $linkPath. Move or delete it first."
-            }
+function Ensure-Junction([string]$linkPath, [string]$targetPath) {
+    New-Item -ItemType Directory -Path (Split-Path -Parent $linkPath) -Force | Out-Null
+    if (Test-Path -LiteralPath $linkPath) {
+        if (Test-IsJunction $linkPath) {
+            # Always retarget — that's the point of this helper.
+            cmd /c rmdir (Resolve-Path -LiteralPath $linkPath).Path | Out-Null
+        } else {
+            throw "Refusing to replace non-junction at $linkPath. Move or delete it first."
         }
-        cmd /c mklink /J $linkPath $targetPath | Out-Null
     }
+    cmd /c mklink /J $linkPath $targetPath | Out-Null
+}
 
-    function Register-CuaDriverAutostart {
-        param([Parameter(Mandatory = $true)][string]$InstalledBinary)
-        if (-not (Test-Path -LiteralPath $InstalledBinary)) {
-            throw "binary not found at $InstalledBinary"
-        }
-        $user = "$env:COMPUTERNAME\$env:USERNAME"
-        $action = New-ScheduledTaskAction -Execute $InstalledBinary -Argument 'serve' -WorkingDirectory $env:USERPROFILE
-        $trigger = New-ScheduledTaskTrigger -AtLogOn -User $user
-        $principal = New-ScheduledTaskPrincipal -UserId $user -LogonType Interactive -RunLevel Limited
-        $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1) -ExecutionTimeLimit (New-TimeSpan -Hours 0)
-        Unregister-ScheduledTask -TaskName 'cua-driver-serve' -Confirm:$false -ErrorAction SilentlyContinue
-        Register-ScheduledTask -TaskName 'cua-driver-serve' -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Description 'cua-driver-rs: serve daemon, auto-start at interactive logon' | Out-Null
+function Register-CuaDriverAutostart {
+    param([Parameter(Mandatory = $true)][string]$InstalledBinary)
+    if (-not (Test-Path -LiteralPath $InstalledBinary)) {
+        throw "binary not found at $InstalledBinary"
     }
+    $user = "$env:COMPUTERNAME\$env:USERNAME"
+    $action = New-ScheduledTaskAction -Execute $InstalledBinary -Argument 'serve' -WorkingDirectory $env:USERPROFILE
+    $trigger = New-ScheduledTaskTrigger -AtLogOn -User $user
+    $principal = New-ScheduledTaskPrincipal -UserId $user -LogonType Interactive -RunLevel Limited
+    $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1) -ExecutionTimeLimit (New-TimeSpan -Hours 0)
+    Unregister-ScheduledTask -TaskName 'cua-driver-serve' -Confirm:$false -ErrorAction SilentlyContinue
+    Register-ScheduledTask -TaskName 'cua-driver-serve' -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Description 'cua-driver-rs: serve daemon, auto-start at interactive logon' | Out-Null
 }
 
 function Write-Step($msg) { Write-Host "==> $msg" -ForegroundColor Cyan }

--- a/libs/cua-driver-rs/scripts/install-local.ps1
+++ b/libs/cua-driver-rs/scripts/install-local.ps1
@@ -1,0 +1,201 @@
+# cua-driver-rs local/debug installer (Windows). Builds from the current
+# source tree and drops the resulting cua-driver.exe into the same
+# install layout that scripts/install.ps1 produces — so a local build
+# and a release install can coexist + the `current` junction can flip
+# between them.
+#
+# Mirrors libs/cua-driver/scripts/install-local.sh (Swift) in shape:
+#   -Release    build the release configuration (default: debug)
+#   -AutoStart  register the cua-driver-serve Scheduled Task at logon
+#               (Windows-native equivalent of macOS LaunchAgent). Default
+#               off; the post-install message prints the registration
+#               recipe so you can opt in later.
+#
+# Not for end-users — `irm https://.../install.ps1 | iex` fetches a
+# signed/built release from GitHub. This script is for the developer
+# loop (rapid edit/build/test on a Windows host).
+#
+# Layout produced (matches install.ps1 — see its header for details):
+#
+#   <visibleBinDir>            [junction → currentDir]
+#   <currentDir>               [junction → release dir, retargeted here]
+#   <release dir>              [real dir, this script's output]
+#     <version>-local-<config>-<target>\cua-driver.exe
+#
+# The version-string carries `-local-debug` / `-local-release` so it
+# never collides with a real release dir and is trivial to garbage-collect.
+
+[CmdletBinding()]
+param(
+    [switch]$Release,
+    [switch]$AutoStart
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+# Reuse the production installer's helpers (path resolution, junction
+# wiring, autostart registration) by dot-sourcing the relevant bits via
+# a small wrapper. install.ps1 expects to run end-to-end, so we don't
+# dot-source the whole thing — instead duplicate the small handful of
+# operations we need, calling out matching install.ps1 functions where
+# the logic would otherwise drift.
+
+$ScriptDir   = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot    = (Resolve-Path "$ScriptDir\..").Path
+$BinaryName  = "cua-driver.exe"
+$Config      = if ($Release) { "release" } else { "debug" }
+$Target      = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') {
+    "aarch64-pc-windows-msvc"
+} else {
+    "x86_64-pc-windows-msvc"
+}
+
+# ---------- Paths (must match install.ps1's defaults) ----------------------
+
+if ($env:CUA_DRIVER_RS_INSTALL_DIR) {
+    $VisibleBinDir = $env:CUA_DRIVER_RS_INSTALL_DIR
+} else {
+    $VisibleBinDir = Join-Path $env:LOCALAPPDATA "Programs\trycua\cua-driver-rs\bin"
+}
+if ($env:CUA_DRIVER_RS_HOME) {
+    $PackageHome = $env:CUA_DRIVER_RS_HOME
+} else {
+    $PackageHome = Join-Path $env:USERPROFILE ".cua-driver-rs"
+}
+$CurrentDir  = Join-Path $PackageHome "packages\current"
+$ReleasesDir = Join-Path $PackageHome "packages\releases"
+
+# ---------- Helpers (lifted from install.ps1) -----------------------------
+
+. "$ScriptDir\install.ps1.helpers.ps1" -ErrorAction SilentlyContinue 2>$null
+# install.ps1 doesn't currently extract its helpers into a separate
+# .helpers.ps1 — fall back to defining the absolute minimum here. If a
+# helpers file appears later, the dot-source above wins and these are
+# never compiled.
+if (-not (Get-Command -Name 'Test-IsJunction' -ErrorAction SilentlyContinue)) {
+
+    function Test-IsJunction([string]$path) {
+        if (-not (Test-Path -LiteralPath $path)) { return $false }
+        $item = Get-Item -LiteralPath $path -Force
+        return [bool]($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint)
+    }
+
+    function Ensure-Junction([string]$linkPath, [string]$targetPath) {
+        New-Item -ItemType Directory -Path (Split-Path -Parent $linkPath) -Force | Out-Null
+        if (Test-Path -LiteralPath $linkPath) {
+            if (Test-IsJunction $linkPath) {
+                # Always retarget — that's the point of this helper.
+                cmd /c rmdir (Resolve-Path -LiteralPath $linkPath).Path | Out-Null
+            } else {
+                throw "Refusing to replace non-junction at $linkPath. Move or delete it first."
+            }
+        }
+        cmd /c mklink /J $linkPath $targetPath | Out-Null
+    }
+
+    function Register-CuaDriverAutostart {
+        param([Parameter(Mandatory = $true)][string]$InstalledBinary)
+        if (-not (Test-Path -LiteralPath $InstalledBinary)) {
+            throw "binary not found at $InstalledBinary"
+        }
+        $user = "$env:COMPUTERNAME\$env:USERNAME"
+        $action = New-ScheduledTaskAction -Execute $InstalledBinary -Argument 'serve' -WorkingDirectory $env:USERPROFILE
+        $trigger = New-ScheduledTaskTrigger -AtLogOn -User $user
+        $principal = New-ScheduledTaskPrincipal -UserId $user -LogonType Interactive -RunLevel Limited
+        $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1) -ExecutionTimeLimit (New-TimeSpan -Hours 0)
+        Unregister-ScheduledTask -TaskName 'cua-driver-serve' -Confirm:$false -ErrorAction SilentlyContinue
+        Register-ScheduledTask -TaskName 'cua-driver-serve' -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Description 'cua-driver-rs: serve daemon, auto-start at interactive logon' | Out-Null
+    }
+}
+
+function Write-Step($msg) { Write-Host "==> $msg" -ForegroundColor Cyan }
+
+# ---------- Prerequisites --------------------------------------------------
+
+Write-Step "cua-driver-rs local installer (Windows)"
+Write-Host "  source:    $RepoRoot"
+Write-Host "  config:    $Config"
+Write-Host "  target:    $Target"
+Write-Host "  visible:   $VisibleBinDir"
+Write-Host "  current:   $CurrentDir"
+
+if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
+    Write-Host "Error: cargo not found on PATH." -ForegroundColor Red
+    Write-Host "Install Rust + MSVC toolchain via rustup-init: https://rustup.rs/"
+    exit 1
+}
+
+# ---------- Build ----------------------------------------------------------
+
+Write-Step "cargo build ($Config) -p cua-driver"
+Push-Location $RepoRoot
+try {
+    if ($Release) {
+        & cargo build --release -p cua-driver
+    } else {
+        & cargo build -p cua-driver
+    }
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Error: cargo build failed." -ForegroundColor Red
+        exit $LASTEXITCODE
+    }
+}
+finally {
+    Pop-Location
+}
+$BuiltBinary = Join-Path $RepoRoot "target\$Config\$BinaryName"
+if (-not (Test-Path -LiteralPath $BuiltBinary)) {
+    Write-Host "Error: build produced no binary at $BuiltBinary" -ForegroundColor Red
+    exit 1
+}
+
+# ---------- Stage into versioned release dir -------------------------------
+
+$VersionTag  = "0.0.0-local-$Config"
+$VersionedDir = Join-Path $ReleasesDir "$VersionTag-$Target"
+Write-Step "staging into $VersionedDir"
+New-Item -ItemType Directory -Path $VersionedDir -Force | Out-Null
+Copy-Item -LiteralPath $BuiltBinary -Destination (Join-Path $VersionedDir $BinaryName) -Force
+$installedBinary = Join-Path $VersionedDir $BinaryName
+
+# ---------- Repoint junctions ---------------------------------------------
+
+Write-Step "retargeting $CurrentDir -> $VersionedDir"
+Ensure-Junction -linkPath $CurrentDir -targetPath $VersionedDir
+
+Write-Step "ensuring $VisibleBinDir -> $CurrentDir"
+if (Test-Path -LiteralPath $VisibleBinDir) {
+    if (-not (Test-IsJunction $VisibleBinDir)) {
+        Write-Host "$VisibleBinDir exists and is not a junction; aborting." -ForegroundColor Red
+        Write-Host "Remove or relocate it, then re-run."
+        exit 1
+    }
+}
+Ensure-Junction -linkPath $VisibleBinDir -targetPath $CurrentDir
+
+# ---------- Done -----------------------------------------------------------
+
+Write-Host ""
+Write-Step "installed"
+Write-Host "  exe:    $(Join-Path $VisibleBinDir $BinaryName)"
+Write-Host "  source: $installedBinary"
+Write-Host ""
+
+if ($AutoStart) {
+    Write-Step "registering Scheduled Task 'cua-driver-serve'"
+    try {
+        Register-CuaDriverAutostart -InstalledBinary (Join-Path $VisibleBinDir $BinaryName)
+        Write-Host "  Registered. cua-driver serve auto-starts at every interactive logon." -ForegroundColor Green
+        Write-Host "  Start now without re-logging: schtasks /Run /TN cua-driver-serve"
+        Write-Host "  Remove:                       schtasks /Delete /TN cua-driver-serve /F"
+    }
+    catch {
+        Write-Host "  Failed to register: $($_.Exception.Message)" -ForegroundColor Red
+    }
+} else {
+    Write-Host "Auto-start (optional): re-run with -AutoStart to register a logon Scheduled Task,"
+    Write-Host "  or use 'schtasks /Run /TN cua-driver-serve' if you registered it previously."
+}
+Write-Host ""

--- a/libs/cua-driver-rs/scripts/install-local.sh
+++ b/libs/cua-driver-rs/scripts/install-local.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+#
+# cua-driver-rs local/debug installer (macOS + Linux). Builds from the
+# current source tree and drops the resulting cua-driver binary into the
+# same install layout that scripts/install.sh produces — so a local build
+# and a release install can coexist + the `current` symlink can flip
+# between them.
+#
+# Mirrors libs/cua-driver/scripts/install-local.sh (Swift) in shape:
+#   --release    build the release configuration (default: debug)
+#   --autostart  register an auto-start daemon (macOS: LaunchAgent;
+#                Linux: systemd user unit). Default off; the post-install
+#                message prints the registration command for the platform.
+#
+# Not for end-users — scripts/install.sh fetches a built release from
+# GitHub. This script is for the developer loop (rapid edit/build/test
+# on a Linux or macOS host).
+#
+# Linux layout produced (matches install.sh):
+#
+#   ${CUA_DRIVER_RS_HOME:-$HOME/.cua-driver-rs}/packages/
+#       releases/<version>-local-<config>-<target>/cua-driver
+#       current/cua-driver  -> ../releases/<active>/cua-driver
+#   ${CUA_DRIVER_RS_INSTALL_DIR:-$HOME/.local/bin}/cua-driver
+#       -> ../current/cua-driver
+#
+# macOS layout produced:
+#   /Applications/CuaDriverRs.app/Contents/MacOS/cua-driver  (bundle replaced wholesale)
+#   $HOME/.local/bin/cua-driver -> .../CuaDriverRs.app/Contents/MacOS/cua-driver
+#
+# The version string carries `-local-debug` / `-local-release` so it
+# never collides with a real release dir and is trivial to GC.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+BOLD=$(tput bold 2>/dev/null || true)
+NORMAL=$(tput sgr0 2>/dev/null || true)
+RED=$(tput setaf 1 2>/dev/null || true)
+GREEN=$(tput setaf 2 2>/dev/null || true)
+BLUE=$(tput setaf 4 2>/dev/null || true)
+
+if [ "$(id -u)" -eq 0 ] || [ -n "${SUDO_USER:-}" ]; then
+    echo "${RED}Error: do not run this script with sudo or as root.${NORMAL}"
+    echo "It prompts for sudo on the specific operations that need it."
+    exit 1
+fi
+
+# --- Parse arguments ----------------------------------------------------
+
+BUILD_CONFIG="debug"
+INSTALL_AUTOSTART=false
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --release)
+            BUILD_CONFIG="release"
+            ;;
+        --autostart)
+            INSTALL_AUTOSTART=true
+            ;;
+        --help|-h)
+            echo "${BOLD}${BLUE}cua-driver-rs local installer${NORMAL}"
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --release     Build the release configuration (default: debug)."
+            echo "  --autostart   Also register a logon-time daemon:"
+            echo "                  macOS: LaunchAgent under ~/Library/LaunchAgents"
+            echo "                  Linux: systemd --user unit"
+            echo "  --help        Show this help."
+            echo ""
+            echo "Examples:"
+            echo "  $0                       # debug build, install junction layout"
+            echo "  $0 --release             # release build"
+            echo "  $0 --release --autostart # release + daemon at logon"
+            exit 0
+            ;;
+        *)
+            echo "${RED}Unknown option: $1${NORMAL}"
+            echo "Use --help for usage."
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+case "$OS" in
+    Darwin) TARGET_TRIPLE="${ARCH}-apple-darwin" ;;
+    Linux)  TARGET_TRIPLE="${ARCH}-unknown-linux-gnu" ;;
+    *)      echo "${RED}Unsupported OS: $OS${NORMAL}"; exit 1 ;;
+esac
+
+HOME_DIR="${CUA_DRIVER_RS_HOME:-$HOME/.cua-driver-rs}"
+BIN_DIR="${CUA_DRIVER_RS_INSTALL_DIR:-${CUA_DRIVER_RS_BIN_DIR:-$HOME/.local/bin}}"
+RELEASES_DIR="$HOME_DIR/packages/releases"
+CURRENT_LINK="$HOME_DIR/packages/current"
+
+VERSION_TAG="0.0.0-local-$BUILD_CONFIG"
+VERSIONED_DIR="$RELEASES_DIR/$VERSION_TAG-$TARGET_TRIPLE"
+
+echo "${BOLD}${BLUE}cua-driver-rs local installer${NORMAL}"
+echo "  source:  ${BOLD}$REPO_ROOT${NORMAL}"
+echo "  config:  ${BOLD}$BUILD_CONFIG${NORMAL}"
+echo "  target:  ${BOLD}$TARGET_TRIPLE${NORMAL}"
+echo "  bin:     ${BOLD}$BIN_DIR/cua-driver${NORMAL}"
+echo "  current: ${BOLD}$CURRENT_LINK${NORMAL}"
+echo ""
+
+# --- Prerequisites ------------------------------------------------------
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "${RED}Error: cargo not found on PATH.${NORMAL}"
+    echo "Install Rust via rustup: https://rustup.rs/"
+    exit 1
+fi
+
+# --- Build --------------------------------------------------------------
+
+echo "${BOLD}Building cua-driver ($BUILD_CONFIG)...${NORMAL}"
+cd "$REPO_ROOT"
+if [ "$BUILD_CONFIG" = "release" ]; then
+    cargo build --release -p cua-driver
+else
+    cargo build -p cua-driver
+fi
+
+BUILT_BINARY="$REPO_ROOT/target/$BUILD_CONFIG/cua-driver"
+if [ ! -x "$BUILT_BINARY" ]; then
+    echo "${RED}Error: build produced no binary at $BUILT_BINARY${NORMAL}"
+    exit 1
+fi
+echo ""
+
+# --- Stage into versioned release dir + repoint `current` --------------
+
+echo "${BOLD}Staging into $VERSIONED_DIR${NORMAL}"
+mkdir -p "$VERSIONED_DIR"
+cp "$BUILT_BINARY" "$VERSIONED_DIR/cua-driver"
+chmod +x "$VERSIONED_DIR/cua-driver"
+
+# Atomic-ish swap of the `current` symlink.
+mkdir -p "$HOME_DIR/packages"
+TMP_LINK="$CURRENT_LINK.new"
+rm -f "$TMP_LINK"
+ln -s "$VERSIONED_DIR" "$TMP_LINK"
+mv -Tf "$TMP_LINK" "$CURRENT_LINK" 2>/dev/null || mv -f "$TMP_LINK" "$CURRENT_LINK"
+echo "${GREEN}current -> $VERSIONED_DIR${NORMAL}"
+echo ""
+
+# --- Visible-bin symlink ------------------------------------------------
+
+mkdir -p "$BIN_DIR"
+ln -sf "$CURRENT_LINK/cua-driver" "$BIN_DIR/cua-driver"
+echo "${GREEN}$BIN_DIR/cua-driver -> $CURRENT_LINK/cua-driver${NORMAL}"
+echo ""
+
+INSTALLED_BIN="$BIN_DIR/cua-driver"
+
+# --- Autostart (optional) ----------------------------------------------
+
+if [ "$INSTALL_AUTOSTART" = true ]; then
+    if [ "$OS" = "Darwin" ]; then
+        PLIST_PATH="$HOME/Library/LaunchAgents/com.trycua.cua-driver-rs.plist"
+        echo "${BOLD}Writing LaunchAgent → $PLIST_PATH${NORMAL}"
+        mkdir -p "$(dirname "$PLIST_PATH")"
+        cat >"$PLIST_PATH" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.trycua.cua-driver-rs</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$INSTALLED_BIN</string>
+    <string>serve</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>$HOME_DIR/serve.out.log</string>
+  <key>StandardErrorPath</key><string>$HOME_DIR/serve.err.log</string>
+</dict>
+</plist>
+EOF
+        launchctl unload "$PLIST_PATH" 2>/dev/null || true
+        launchctl load "$PLIST_PATH"
+        echo "${GREEN}Loaded.${NORMAL} Manage with launchctl load / unload \"$PLIST_PATH\"."
+    elif [ "$OS" = "Linux" ]; then
+        UNIT_PATH="$HOME/.config/systemd/user/cua-driver-rs.service"
+        echo "${BOLD}Writing systemd user unit → $UNIT_PATH${NORMAL}"
+        mkdir -p "$(dirname "$UNIT_PATH")"
+        cat >"$UNIT_PATH" <<EOF
+[Unit]
+Description=cua-driver-rs serve daemon
+After=graphical-session.target
+
+[Service]
+ExecStart=$INSTALLED_BIN serve
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=default.target
+EOF
+        systemctl --user daemon-reload
+        systemctl --user enable --now cua-driver-rs.service
+        echo "${GREEN}Enabled.${NORMAL} Manage with systemctl --user {start|stop|status} cua-driver-rs."
+    fi
+    echo ""
+fi
+
+# --- Done ---------------------------------------------------------------
+
+echo "${BOLD}${GREEN}Installed.${NORMAL}"
+echo "  ${BOLD}$INSTALLED_BIN${NORMAL}"
+echo ""
+echo "Verify:"
+echo "  cua-driver --version"
+echo "  cua-driver doctor"
+echo ""
+
+if [ "$INSTALL_AUTOSTART" != true ]; then
+    if [ "$OS" = "Darwin" ]; then
+        echo "Auto-start (optional): re-run with --autostart to register a LaunchAgent."
+    else
+        echo "Auto-start (optional): re-run with --autostart to register a systemd user unit."
+    fi
+    echo ""
+fi

--- a/libs/cua-driver-rs/scripts/install.ps1
+++ b/libs/cua-driver-rs/scripts/install.ps1
@@ -868,6 +868,29 @@ else {
     Write-Host ""
 }
 
+$autostartHint = @"
+
+Auto-start at logon (Windows equivalent of macOS LaunchAgent):
+  Run cua-driver serve automatically every time you sign in (RDP, console, etc.)
+  Register the Scheduled Task once (copy-paste in PowerShell):
+
+    `$exe = '$installedBinary'
+    `$user = "`$env:COMPUTERNAME\`$env:USERNAME"
+    `$action = New-ScheduledTaskAction -Execute `$exe -Argument 'serve' -WorkingDirectory `$env:USERPROFILE
+    `$trigger = New-ScheduledTaskTrigger -AtLogOn -User `$user
+    `$principal = New-ScheduledTaskPrincipal -UserId `$user -LogonType Interactive -RunLevel Limited
+    `$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1) -ExecutionTimeLimit (New-TimeSpan -Hours 0)
+    Register-ScheduledTask -TaskName 'cua-driver-serve' -Action `$action -Trigger `$trigger -Principal `$principal -Settings `$settings
+
+  Then run it now without re-logging:
+    schtasks /Run /TN cua-driver-serve
+
+  Removal:
+    schtasks /Delete /TN cua-driver-serve /F
+"@
+Write-Host $autostartHint -ForegroundColor Cyan
+
+
 Write-Host "Docs: https://github.com/trycua/cua/tree/main/libs/cua-driver-rs"
 Write-Host ""
 Write-Host "WARNING — BETA: cua-driver-rs is a cross-platform Rust port of the Swift" -ForegroundColor Yellow

--- a/libs/cua-driver-rs/scripts/install.ps1
+++ b/libs/cua-driver-rs/scripts/install.ps1
@@ -44,9 +44,17 @@
 #                                    multi-arch dirs are pruned
 #                                    independently of each other.
 #
-# Param:
-#   -Release   release tag to install ("latest" or a bare version like "0.2.0").
-#              Overridden by $env:CUA_DRIVER_RS_VERSION when set.
+# Params:
+#   -Release    release tag to install ("latest" or a bare version like "0.2.0").
+#               Overridden by $env:CUA_DRIVER_RS_VERSION when set.
+#   -AutoStart  register a Scheduled Task that runs `cua-driver serve` at
+#               every logon (Windows-native equivalent of macOS LaunchAgent).
+#               The task runs with LogonType=Interactive so it lands in
+#               Session 1+ with an attached desktop — required for the
+#               GUI tools (click, type_text, screenshot, get_window_state)
+#               to function. Default off; the post-install message prints
+#               the registration command so you can opt in later. Safe to
+#               re-run: existing task is replaced.
 #
 # WARNING — BETA: cua-driver-rs is the cross-platform Rust port of the
 # Swift cua-driver. Windows and Linux support is feature-complete;
@@ -54,7 +62,8 @@
 
 [CmdletBinding()]
 param(
-    [string]$Release = "latest"
+    [string]$Release = "latest",
+    [switch]$AutoStart
 )
 
 Set-StrictMode -Version Latest
@@ -452,6 +461,57 @@ function Ensure-Junction([string]$linkPath, [string]$targetPath) {
     }
     Set-JunctionTarget $linkPath $targetPath
     Write-Step "junction $linkPath -> $targetPath"
+}
+
+# ---------- Auto-start Scheduled Task (Windows LaunchAgent equivalent) ---
+
+# Idempotent registration of the cua-driver-serve Scheduled Task.
+#
+# - Trigger: at logon for the current local user.
+# - Principal: LogonType=Interactive so the task lands in the user's
+#   Session 1+ (NOT Session 0); window-driving tools require it.
+# - Settings: AllowStartIfOnBatteries, RestartCount=3 on failure with
+#   1-minute backoff, ExecutionTimeLimit=0 (no time cap; serve is
+#   meant to live for the session).
+# - On workgroup machines USERDOMAIN may be 'WORKGROUP' which won't
+#   resolve as a SAM account; the principal therefore uses
+#   "$COMPUTERNAME\$USERNAME" which is always valid for a local user.
+# - The task is unregistered before re-creation so the helper is
+#   safe to run repeatedly (e.g. on install upgrade).
+function Register-CuaDriverAutostart {
+    param([Parameter(Mandatory = $true)][string]$InstalledBinary)
+
+    if (-not (Test-Path -LiteralPath $InstalledBinary)) {
+        throw "binary not found at $InstalledBinary"
+    }
+
+    $user = "$env:COMPUTERNAME\$env:USERNAME"
+    $action = New-ScheduledTaskAction `
+        -Execute $InstalledBinary `
+        -Argument 'serve' `
+        -WorkingDirectory $env:USERPROFILE
+    $trigger = New-ScheduledTaskTrigger -AtLogOn -User $user
+    $principal = New-ScheduledTaskPrincipal `
+        -UserId $user `
+        -LogonType Interactive `
+        -RunLevel Limited
+    $settings = New-ScheduledTaskSettingsSet `
+        -AllowStartIfOnBatteries `
+        -DontStopIfGoingOnBatteries `
+        -StartWhenAvailable `
+        -RestartCount 3 `
+        -RestartInterval (New-TimeSpan -Minutes 1) `
+        -ExecutionTimeLimit (New-TimeSpan -Hours 0)
+
+    $taskName = 'cua-driver-serve'
+    Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
+    Register-ScheduledTask `
+        -TaskName $taskName `
+        -Action $action `
+        -Trigger $trigger `
+        -Principal $principal `
+        -Settings $settings `
+        -Description 'cua-driver-rs: serve daemon, auto-start at interactive logon' | Out-Null
 }
 
 # ---------- Concurrent-install lockfile -----------------------------------
@@ -868,11 +928,28 @@ else {
     Write-Host ""
 }
 
-$autostartHint = @"
+if ($AutoStart) {
+    Write-Host ""
+    Write-Host "Registering auto-start Scheduled Task 'cua-driver-serve'..." -ForegroundColor Cyan
+    try {
+        Register-CuaDriverAutostart -InstalledBinary $installedBinary
+        Write-Host "  Registered. cua-driver serve will auto-start at every interactive logon." -ForegroundColor Green
+        Write-Host "  Run now without re-logging: schtasks /Run /TN cua-driver-serve"
+        Write-Host "  Remove with:               schtasks /Delete /TN cua-driver-serve /F"
+        Write-Host ""
+    }
+    catch {
+        Write-Host "  Failed to register Scheduled Task: $($_.Exception.Message)" -ForegroundColor Red
+        Write-Host "  Install otherwise succeeded; re-run with -AutoStart or use the manual recipe below."
+        Write-Host ""
+    }
+}
+else {
+    $autostartHint = @"
 
 Auto-start at logon (Windows equivalent of macOS LaunchAgent):
   Run cua-driver serve automatically every time you sign in (RDP, console, etc.)
-  Register the Scheduled Task once (copy-paste in PowerShell):
+  Re-run this installer with -AutoStart to register the task, OR paste:
 
     `$exe = '$installedBinary'
     `$user = "`$env:COMPUTERNAME\`$env:USERNAME"
@@ -888,7 +965,8 @@ Auto-start at logon (Windows equivalent of macOS LaunchAgent):
   Removal:
     schtasks /Delete /TN cua-driver-serve /F
 "@
-Write-Host $autostartHint -ForegroundColor Cyan
+    Write-Host $autostartHint -ForegroundColor Cyan
+}
 
 
 Write-Host "Docs: https://github.com/trycua/cua/tree/main/libs/cua-driver-rs"


### PR DESCRIPTION
﻿## Summary

Stabilizes cua-driver-rs for Windows non-interactive (Session 0) contexts and hardens the UWP background-launch focus invariant.

- cua-driver doctor no longer crashes with 0xC0000005 ACCESS_VIOLATION (COM lifecycle fix in ui_automation_available).
- launch_app no longer hangs in Session 0 â€” name-based UWP routing falls through to ShellExecuteEx, aumid-based routing fails fast with a descriptive error.
- UWP foreground-restore upgrade: snapshots GetForegroundWindow before activation and re-asserts it after, using a keybd_event(VK_NONAME) injection to claim "owner of last input" and bypass Windows' SetForegroundWindow restriction.
- cua-driver serve prints a Session-0 warning banner at startup on Windows.
- list_apps filters opaque-system-family UWP packages (GUID-prefixed / Windows.Internal.*) whose DisplayName resolved to their FamilyName.
- 3 parity examples (list_apps_parity, list_windows_parity, launch_app_parity) updated for Session-0 awareness + the unified #1545 list_apps shape.
- FAQ + PARITY.md docs updated with Session-0 troubleshooting.

Validated live on a Win11 24H2 Azure VM in Session 0: **11/11 parity examples pass** (was 6/11 before â€” the rest were stale assertions / expected-failure Session-0 noise).

Full status + dev-loop reference live in WINDOWS_SESSION0_STATUS.md and libs/cua-driver-rs/DEV_LOOP_WINDOWS_VM.md.

## Test plan

- [x] cua-driver doctor exits 0 with all probes reporting in Session 0
- [x] cua-driver call list_apps returns ~133 apps cold in ~370ms, sub-100ms warm
- [x] cua-driver call launch_app {"name":"notepad"} returns pid (ShellExecuteEx path)
- [x] cua-driver call launch_app {"aumid":"...!App"} fails fast in Session 0 (no hang)
- [x] All 11 Session-0-compatible parity examples pass
- [x] Unit tests for looks_like_opaque_system_family pass (4/4)
- [ ] Visual: UWP background-launch on Session 1+ via RDP â€” does NOT steal focus from prior foreground app


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Session 0 startup warning banner for non-interactive environments.

* **Bug Fixes**
  * Fixed COM lifecycle crash in diagnostics.
  * Prevented Session 0 hang when launching applications.
  * Enhanced UWP focus-restoration hardening.
  * Improved system package filtering in app listings.

* **Documentation**
  * Added Windows Session 0 stabilization status report.
  * Added FAQ entries for Session 0 behavior and limitations.
  * Added Windows VM development workflow guide.
  * Updated parity verification documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->