### PR TITLE
fix(windows-click): UIA Invoke for element_index + ElementFromPoint for (x,y)

### DIFF
--- a/libs/cua-driver-rs/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/tools/impl_.rs
@@ -1066,23 +1066,62 @@ impl Tool for ClickTool {
             };
             // Step 2: animate cursor to screen coords (awaits glide_duration_ms).
             overlay_glide_to(cx as f64, cy as f64).await;
-            // Step 3: click pulse + post click.
+            // Step 3: click pulse + actual click.
             crate::overlay::send_command(cursor_overlay::OverlayCommand::ClickPulse {
                 x: cx as f64, y: cy as f64,
             });
             let btn = button.clone();
-            let action_name = match btn.as_str() {
-                "right"  => "ShowMenu",  // closest UIA analogue of Swift "show_menu"
-                "middle" => "Invoke",
-                _        => "Invoke",    // left-click = UIA Invoke pattern (matches Swift "AXPress")
-            };
+            // Try UIA Invoke first (it works for UWP / modern XAML / web
+            // content where PostMessage(WM_LBUTTONDOWN) hits the outer
+            // HWND but never reaches the inner XAML/composition element).
+            // Fall through to PostMessage when:
+            //   - element doesn't support InvokePattern (most text inputs,
+            //     non-interactive elements)
+            //   - right-click (UIA's ExpandCollapse / ShowContextMenu are
+            //     different patterns; keep PostMessage for now)
+            //   - count > 1 (double-click semantics aren't an Invoke
+            //     concept — PostMessage produces the actual WM_LBUTTONDBLCLK)
+            let state_clone = self.state.clone();
+            let use_uia_invoke = (btn == "left" || btn == "middle") && count == 1;
             let result = tokio::task::spawn_blocking(move || -> anyhow::Result<String> {
-                // cx/cy are screen coords from CurrentBoundingRectangle; use
-                // post_click_screen so deepest-child resolution happens once.
+                if use_uia_invoke {
+                    if let Some(ptr) = state_clone.element_cache.get_element_ptr(pid, hwnd, idx) {
+                        use windows::Win32::UI::Accessibility::{
+                            IUIAutomationElement, IUIAutomationInvokePattern, UIA_InvokePatternId,
+                        };
+                        use windows::core::Interface;
+                        // Reconstruct without consuming the cache's AddRef;
+                        // forget after we extract the pattern so Drop doesn't
+                        // double-Release the cached pointer.
+                        let elem: IUIAutomationElement =
+                            unsafe { IUIAutomationElement::from_raw(ptr as *mut _) };
+                        let invoke_result = unsafe { elem.GetCurrentPattern(UIA_InvokePatternId) };
+                        std::mem::forget(elem);
+                        if let Ok(pattern) = invoke_result {
+                            if let Ok(inv) = pattern.cast::<IUIAutomationInvokePattern>() {
+                                match unsafe { inv.Invoke() } {
+                                    Ok(()) => {
+                                        return Ok(format!(
+                                            "✅ Performed UIA Invoke on [{idx}] (screen ({cx},{cy}))."
+                                        ));
+                                    }
+                                    Err(e) => {
+                                        tracing::debug!(
+                                            target: "click",
+                                            "UIA Invoke failed for [{idx}]: {e}; falling back to PostMessage"
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                // PostMessage fallback (legacy Win32 + non-Invokable elements).
                 crate::input::post_click_screen(hwnd, cx, cy, count, &btn)?;
-                // Match Swift text format: "✅ Performed AXPress on [N] role \"title\"."
-                // (UIA has no readily-available role/name on the cached element here;
-                // emit element_index + screen coords for traceability instead).
+                let action_name = match btn.as_str() {
+                    "right"  => "ShowMenu",
+                    _        => "PostMessage click",
+                };
                 Ok(format!("✅ Performed {action_name} on [{idx}] (screen ({cx},{cy}))."))
             }).await;
             match result {
@@ -1114,6 +1153,27 @@ impl Tool for ClickTool {
             overlay_glide_to(sx, sy).await;
             crate::overlay::send_command(cursor_overlay::OverlayCommand::ClickPulse { x: sx, y: sy });
             let btn = button.clone();
+            // Try UIA `ElementFromPoint` + `Invoke` first — this is what
+            // makes vision-mode clicks land on modern XAML / WebView2 /
+            // packaged-UWP buttons, where the inner interactive surface
+            // is composed via DirectComposition and PostMessage to the
+            // outer HWND silently no-ops. Only run for single left/middle
+            // clicks; right-click + multi-click stay on PostMessage
+            // because UIA has no clean equivalent of `ShowContextMenu`
+            // by-coord and `Invoke()` is single-fire by definition.
+            let use_uia = (btn == "left" || btn == "middle") && count == 1;
+            if use_uia {
+                let invoked = tokio::task::spawn_blocking(move || {
+                    crate::uia::windows_enum::try_invoke_at_point(sx as i32, sy as i32)
+                })
+                .await
+                .unwrap_or(false);
+                if invoked {
+                    return ToolResult::text(format!(
+                        "✅ Performed UIA Invoke at ({sx},{sy}) for pid {pid}."
+                    ));
+                }
+            }
             let result = tokio::task::spawn_blocking(move || {
                 crate::input::post_click(hwnd, px as i32, py as i32, count, &btn)
             }).await;

--- a/libs/cua-driver-rs/crates/platform-windows/src/uia/windows_enum.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/uia/windows_enum.rs
@@ -14,17 +14,19 @@
 
 use std::cell::RefCell;
 
-use windows::Win32::Foundation::{HWND, RECT};
+use windows::Win32::Foundation::{HWND, POINT, RECT};
 use windows::Win32::Graphics::Dwm::{DwmGetWindowAttribute, DWMWA_EXTENDED_FRAME_BOUNDS};
 use windows::Win32::System::Com::{
     CoCreateInstance, CoInitializeEx, CLSCTX_INPROC_SERVER, COINIT_APARTMENTTHREADED,
 };
 use windows::Win32::UI::Accessibility::{
-    CUIAutomation, IUIAutomation, IUIAutomationElement, TreeScope_Children,
+    CUIAutomation, IUIAutomation, IUIAutomationElement, IUIAutomationInvokePattern,
+    TreeScope_Children, UIA_InvokePatternId,
 };
 use windows::Win32::UI::WindowsAndMessaging::{
     GetWindowRect, GetWindowTextLengthW, GetWindowTextW, GetWindowThreadProcessId,
 };
+use windows::core::Interface;
 
 use crate::win32::windows::WindowInfo;
 
@@ -128,6 +130,51 @@ pub fn enumerate_top_level_windows() -> Vec<WindowInfo> {
             }
         }
         out
+    }
+}
+
+/// Try to fire UIA `Invoke` on whatever element occupies screen point
+/// `(sx, sy)`. Returns `true` when both `ElementFromPoint` resolved an
+/// element AND that element supported `InvokePattern` AND `Invoke()`
+/// succeeded.
+///
+/// Used by the click tool's `(x, y)` path as the preferred mechanism for
+/// modern XAML / WebView2 / packaged-UWP targets where the inner
+/// interactive surface is composed via DirectComposition (not a child
+/// HWND) and `PostMessage(WM_LBUTTONDOWN)` to the outer HWND silently
+/// no-ops. Falls back to the caller's PostMessage path when this returns
+/// `false`.
+pub fn try_invoke_at_point(sx: i32, sy: i32) -> bool {
+    let uia = match get_uia() {
+        Some(u) => u,
+        None => return false,
+    };
+    unsafe {
+        let elem: IUIAutomationElement = match uia.ElementFromPoint(POINT { x: sx, y: sy }) {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::debug!(target: "click", "ElementFromPoint({sx},{sy}) failed: {e}");
+                return false;
+            }
+        };
+        let pattern = match elem.GetCurrentPattern(UIA_InvokePatternId) {
+            Ok(p) => p,
+            Err(_) => {
+                tracing::debug!(target: "click", "element at ({sx},{sy}) does not support InvokePattern");
+                return false;
+            }
+        };
+        let inv: IUIAutomationInvokePattern = match pattern.cast() {
+            Ok(i) => i,
+            Err(_) => return false,
+        };
+        match inv.Invoke() {
+            Ok(()) => true,
+            Err(e) => {
+                tracing::debug!(target: "click", "UIA Invoke at ({sx},{sy}) failed: {e}");
+                false
+            }
+        }
     }
 }
 


### PR DESCRIPTION
﻿## Summary

Two clicks-on-UWP fixes that should have been in #1548 but were
scp'd-to-VM-and-tested-on-binary without ever being `git add`'d to
the merged PR. Recovering them now as a small standalone PR.

- **`element_index` path**: was annotated "Performed Invoke" but
  actually shelled out to `PostMessage(WM_LBUTTONDOWN)` to the
  deepest HWND child. PostMessage works for classic Win32 apps but
  silently no-ops on UWP (Calculator, Win11 Notepad, Edge, Settings)
  because XAML lives in DirectComposition, not in child HWNDs, and
  UWP's input pipeline (`Windows.UI.Input`) doesn't process raw
  `WM_LBUTTONDOWN`. Now actually calls `IUIAutomationInvokePattern::Invoke()`
  on the cached element pointer.

- **`(x, y)` path** (vision-mode clicks): same fix via the new
  `uia::windows_enum::try_invoke_at_point` helper that runs
  `IUIAutomation::ElementFromPoint(sx, sy)` then `Invoke()` on
  whatever element resolved there. Falls through to PostMessage for
  classic Win32 + non-Invokable elements.

Skip conditions for both paths: right-click + multi-click stay on
PostMessage (UIA has no clean equivalent for `ShowContextMenu` /
`WM_LBUTTONDBLCLK`).

## Test plan

- [x] Validated live on Win11 VM: Calculator math test 17Ã—23=391 via
  6 `element_index` clicks now computes correctly. Pre-fix the
  display stayed at `0`.
- [x] Foreground preserved through all 6 clicks (PowerShell ISE
  remained frontmost â€” verified via daemon-side `GetForegroundWindow`).
- [ ] Vision-mode `(x, y)` path needs re-verification under the new
  code (the binary on the VM has these changes baked in but the
  test sequence after the rebuild only exercised `element_index`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced click functionality to use UI Automation-based invocation when available, improving reliability and compatibility for both element-based and pixel-based clicks with automatic fallback for robustness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->