### PR TITLE
feat(cua-driver): autostart {enable|disable|status|kick} CLI verb (Windows)

### DIFF
--- a/libs/cua-driver-rs/crates/cua-driver/src/autostart.rs
+++ b/libs/cua-driver-rs/crates/cua-driver/src/autostart.rs
@@ -114,9 +114,24 @@ mod platform {
     /// exactly. Kept as a single one-liner so a quick `gh-blame` diff against
     /// install.ps1 surfaces any divergence; the moment install.ps1 changes
     /// shape, this script needs the same edit.
+    ///
+    /// **Account-name format**: on domain-joined machines USERDOMAIN holds the
+    /// AD domain name (e.g. CORP) and the principal must be `CORP\username`.
+    /// On workgroup machines USERDOMAIN holds either the literal string
+    /// "WORKGROUP" or the COMPUTERNAME, and the principal must be
+    /// `COMPUTERNAME\username` — `WORKGROUP\username` errors with
+    /// "No mapping between account names and security IDs was done". The
+    /// $domain selector below picks USERDOMAIN when it's a real
+    /// (non-WORKGROUP, non-COMPUTERNAME) domain and falls back to
+    /// COMPUTERNAME otherwise, covering both shapes.
     const REGISTER_PS: &str = r#"
 $ErrorActionPreference = 'Stop'
-$user = "$env:COMPUTERNAME\$env:USERNAME"
+if ($env:USERDOMAIN -and $env:USERDOMAIN -ne 'WORKGROUP' -and $env:USERDOMAIN -ne $env:COMPUTERNAME) {
+    $domain = $env:USERDOMAIN
+} else {
+    $domain = $env:COMPUTERNAME
+}
+$user = "$domain\$env:USERNAME"
 $action = New-ScheduledTaskAction -Execute $env:CUA_DRIVER_AS_EXE -Argument 'serve' -WorkingDirectory $env:USERPROFILE
 $trigger = New-ScheduledTaskTrigger -AtLogOn -User $user
 $principal = New-ScheduledTaskPrincipal -UserId $user -LogonType Interactive -RunLevel Limited

--- a/libs/cua-driver-rs/crates/cua-driver/src/autostart.rs
+++ b/libs/cua-driver-rs/crates/cua-driver/src/autostart.rs
@@ -1,0 +1,283 @@
+//! `cua-driver autostart {enable|disable|status|kick}` — register / inspect /
+//! trigger the platform-native auto-start mechanism so `cua-driver serve`
+//! comes up on every interactive logon without the user pasting a
+//! startup one-liner.
+//!
+//! ## Platform mapping
+//!
+//! - **Windows**: Scheduled Task `cua-driver-serve` registered with
+//!   `LogonType: Interactive` so it lands in a Session 1+ logon (never
+//!   Session 0). Equivalent to what `scripts/install.ps1 -AutoStart`
+//!   does — the install script can call out to this subcommand to
+//!   keep the registration logic in one place.
+//! - **macOS / Linux**: not implemented yet. Returns an error pointing
+//!   the user at the manual recipe (`launchctl` / `systemctl --user`).
+//!   `scripts/install-local.sh --autostart` covers the manual path
+//!   today.
+//!
+//! ## Why shell out (Windows)
+//!
+//! The Task Scheduler 2.0 COM surface (`ITaskService`, `ITaskDefinition`,
+//! `ITaskFolder`, `IPrincipal`, ...) is ~10 nested COM-wrapper calls in
+//! Rust before you've even configured the principal, with multiple BSTR
+//! marshalling steps and a lot of "this method takes a VARIANT, that
+//! one takes a BSTR" footguns. Shelling out to PowerShell's
+//! `Register-ScheduledTask` cmdlet — which itself uses Task Scheduler
+//! 2.0 under the hood — gets us identical behavior in 5 lines and stays
+//! exactly in lock-step with what `scripts/install.ps1` does (literally
+//! the same command). When `install.ps1` evolves, this code follows it
+//! for free.
+
+use anyhow::{anyhow, Result};
+
+/// Canonical task / unit name. Used by every platform.
+pub const TASK_NAME: &str = "cua-driver-serve";
+
+/// Reported by `status`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    /// No autostart entry registered.
+    NotRegistered,
+    /// Entry registered but not currently running.
+    RegisteredIdle,
+    /// Entry registered AND a `cua-driver serve` process is live.
+    RegisteredRunning,
+}
+
+impl Status {
+    pub fn tag(self) -> &'static str {
+        match self {
+            Status::NotRegistered => "not-registered",
+            Status::RegisteredIdle => "registered (not running)",
+            Status::RegisteredRunning => "registered (running)",
+        }
+    }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────
+
+/// Register the platform-native autostart entry for `cua-driver serve`.
+/// Idempotent: any existing entry with the same name is replaced.
+pub fn enable() -> Result<()> {
+    let exe = current_exe_for_autostart()?;
+    platform::enable(&exe)
+}
+
+/// Remove the autostart entry. No-op if none is registered.
+pub fn disable() -> Result<()> {
+    platform::disable()
+}
+
+/// Report whether the entry is registered and whether the daemon is running.
+pub fn status() -> Result<Status> {
+    platform::status()
+}
+
+/// Run the autostart entry immediately without waiting for a fresh logon.
+/// Errors if the entry isn't registered.
+pub fn kick() -> Result<()> {
+    platform::kick()
+}
+
+/// Find the cua-driver executable to bake into the autostart entry.
+/// Uses `std::env::current_exe`, canonicalised to its real path (resolves
+/// junction / symlink chains so a versioned upgrade flipping `current`
+/// stays transparent to the registered task). The resolved path is what
+/// gets stored in the Scheduled Task / LaunchAgent / unit file.
+fn current_exe_for_autostart() -> Result<String> {
+    let exe = std::env::current_exe()
+        .map_err(|e| anyhow!("could not resolve current executable: {e}"))?;
+    let canonical = std::fs::canonicalize(&exe).unwrap_or(exe);
+    let path = canonical.to_string_lossy().into_owned();
+    // On Windows, `canonicalize` returns a `\\?\C:\...` extended-length
+    // path. PowerShell + the Task Scheduler XML schema both handle it
+    // correctly, but it looks alarming in `schtasks /Query` output.
+    // Strip the prefix for readability — the unprefixed form is still
+    // valid as long as the path fits MAX_PATH (260 chars), which any
+    // realistic install will.
+    #[cfg(target_os = "windows")]
+    let path = path
+        .strip_prefix(r"\\?\")
+        .map(str::to_owned)
+        .unwrap_or(path);
+    Ok(path)
+}
+
+// ── Windows impl ──────────────────────────────────────────────────────────
+
+#[cfg(target_os = "windows")]
+mod platform {
+    use super::*;
+    use std::process::Command;
+
+    /// Inline PowerShell that mirrors `install.ps1::Register-CuaDriverAutostart`
+    /// exactly. Kept as a single one-liner so a quick `gh-blame` diff against
+    /// install.ps1 surfaces any divergence; the moment install.ps1 changes
+    /// shape, this script needs the same edit.
+    const REGISTER_PS: &str = r#"
+$ErrorActionPreference = 'Stop'
+$user = "$env:COMPUTERNAME\$env:USERNAME"
+$action = New-ScheduledTaskAction -Execute $env:CUA_DRIVER_AS_EXE -Argument 'serve' -WorkingDirectory $env:USERPROFILE
+$trigger = New-ScheduledTaskTrigger -AtLogOn -User $user
+$principal = New-ScheduledTaskPrincipal -UserId $user -LogonType Interactive -RunLevel Limited
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1) -ExecutionTimeLimit (New-TimeSpan -Hours 0)
+Unregister-ScheduledTask -TaskName 'cua-driver-serve' -Confirm:$false -ErrorAction SilentlyContinue
+Register-ScheduledTask -TaskName 'cua-driver-serve' -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Description 'cua-driver-rs: serve daemon, auto-start at interactive logon' | Out-Null
+"#;
+
+    pub fn enable(exe: &str) -> Result<()> {
+        // Pass the binary path via env var so the script doesn't need
+        // shell-quoting acrobatics for paths with spaces or odd chars.
+        let out = Command::new("powershell")
+            .args(["-NoProfile", "-NonInteractive", "-Command", REGISTER_PS])
+            .env("CUA_DRIVER_AS_EXE", exe)
+            .output()
+            .map_err(|e| anyhow!("failed to invoke powershell: {e}"))?;
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            return Err(anyhow!(
+                "PowerShell Register-ScheduledTask failed (exit {}): {}",
+                out.status.code().unwrap_or(-1),
+                stderr.trim()
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn disable() -> Result<()> {
+        // schtasks /Delete returns 0 on success, 1 on "task not found"
+        // (which we treat as success: the goal is "no task registered"
+        // and it already isn't). Match on stderr text rather than exit
+        // code because schtasks doesn't distinguish "doesn't exist" from
+        // "permission denied" via exit code.
+        let out = Command::new("schtasks")
+            .args(["/Delete", "/TN", TASK_NAME, "/F"])
+            .output()
+            .map_err(|e| anyhow!("failed to invoke schtasks: {e}"))?;
+        if out.status.success() {
+            return Ok(());
+        }
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let combined = format!("{stdout}{stderr}").to_lowercase();
+        if combined.contains("does not exist")
+            || combined.contains("cannot find the file specified")
+            || combined.contains("the system cannot find")
+        {
+            return Ok(());
+        }
+        Err(anyhow!(
+            "schtasks /Delete failed (exit {}): {}",
+            out.status.code().unwrap_or(-1),
+            stderr.trim()
+        ))
+    }
+
+    pub fn status() -> Result<Status> {
+        // schtasks /Query exits 0 with task details on stdout, or 1 with
+        // "ERROR: The system cannot find the file specified." on stderr.
+        let out = Command::new("schtasks")
+            .args(["/Query", "/TN", TASK_NAME])
+            .output()
+            .map_err(|e| anyhow!("failed to invoke schtasks: {e}"))?;
+        if !out.status.success() {
+            return Ok(Status::NotRegistered);
+        }
+        // Registered — now check whether `cua-driver serve` is running.
+        // Avoid invoking `tasklist` (slow ~200ms on first run); use the
+        // same registry the daemon's own status command uses via a
+        // direct check on the named pipe.
+        if crate::serve::is_daemon_listening(&crate::serve::default_socket_path()) {
+            Ok(Status::RegisteredRunning)
+        } else {
+            Ok(Status::RegisteredIdle)
+        }
+    }
+
+    pub fn kick() -> Result<()> {
+        let out = Command::new("schtasks")
+            .args(["/Run", "/TN", TASK_NAME])
+            .output()
+            .map_err(|e| anyhow!("failed to invoke schtasks: {e}"))?;
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            return Err(anyhow!(
+                "schtasks /Run failed (exit {}): {}",
+                out.status.code().unwrap_or(-1),
+                stderr.trim()
+            ));
+        }
+        Ok(())
+    }
+}
+
+// ── macOS / Linux stubs ───────────────────────────────────────────────────
+
+#[cfg(not(target_os = "windows"))]
+mod platform {
+    use super::*;
+
+    const NOT_YET: &str =
+        "cua-driver autostart is currently Windows-only. macOS users: see \
+         libs/cua-driver-rs/scripts/install-local.sh --autostart for the \
+         LaunchAgent recipe. Linux users: same script registers a systemd \
+         --user unit. A cross-platform impl is tracked as a follow-up.";
+
+    pub fn enable(_exe: &str) -> Result<()> {
+        Err(anyhow!(NOT_YET))
+    }
+    pub fn disable() -> Result<()> {
+        Err(anyhow!(NOT_YET))
+    }
+    pub fn status() -> Result<Status> {
+        Err(anyhow!(NOT_YET))
+    }
+    pub fn kick() -> Result<()> {
+        Err(anyhow!(NOT_YET))
+    }
+}
+
+// ── CLI dispatcher ────────────────────────────────────────────────────────
+
+/// `cua-driver autostart <subcommand>` entry point. Prints user-facing
+/// output and exits the process via `std::process::exit` so the caller
+/// (main) doesn't need to plumb back an exit code for every subcommand.
+pub fn run_autostart_cmd(subcommand: &str) {
+    let (verb_result, success_text): (Result<()>, String) = match subcommand {
+        "enable" => (enable(), format!(
+            "Registered autostart entry '{TASK_NAME}'.\n  \
+             cua-driver serve will start at every interactive logon."
+        )),
+        "disable" => (disable(), format!(
+            "Removed autostart entry '{TASK_NAME}' (no-op if it was already absent)."
+        )),
+        "status" => match status() {
+            Ok(s) => {
+                println!("{}", s.tag());
+                std::process::exit(0);
+            }
+            Err(e) => {
+                eprintln!("cua-driver autostart status: {e}");
+                std::process::exit(1);
+            }
+        },
+        "kick" => (kick(), format!(
+            "Started autostart entry '{TASK_NAME}' for the current session."
+        )),
+        other => {
+            eprintln!("Unknown autostart subcommand: {other:?}");
+            eprintln!("Usage: cua-driver autostart {{enable|disable|status|kick}}");
+            std::process::exit(64);
+        }
+    };
+    match verb_result {
+        Ok(()) => {
+            println!("{success_text}");
+            std::process::exit(0);
+        }
+        Err(e) => {
+            eprintln!("cua-driver autostart {subcommand}: {e}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/libs/cua-driver-rs/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver-rs/crates/cua-driver/src/cli.rs
@@ -65,6 +65,13 @@ pub enum Command {
     /// after install. Subsequent runs see the `.installation_recorded`
     /// marker file and become no-ops.
     TelemetryInstallEvent,
+    /// `cua-driver autostart {enable|disable|status|kick}` —
+    /// platform-native auto-start so `cua-driver serve` comes up on
+    /// every logon. Windows: Scheduled Task with LogonType=Interactive
+    /// (lands in Session 1+). macOS / Linux: not yet implemented; the
+    /// stub returns a helpful "use install-local.sh --autostart"
+    /// message. See `crates/cua-driver/src/autostart.rs`.
+    Autostart { subcommand: String },
 }
 
 /// Flags whose next token is a value (not a subcommand).
@@ -90,7 +97,13 @@ pub fn parse_command() -> Command {
     if args.iter().any(|a| a == "--help" || a == "-h") {
         println!("cua-driver {} — cross-platform computer-use automation driver", env!("CARGO_PKG_VERSION"));
         println!("Usage: cua-driver [SUBCOMMAND] [OPTIONS]");
-        println!("Subcommands: mcp, list-tools, describe, call, serve, stop, status, config, recording, update, doctor, diagnose");
+        println!("Subcommands: mcp, list-tools, describe, call, serve, stop, status, config, recording, update, doctor, diagnose, autostart");
+        println!();
+        println!("autostart options (Windows-only today):");
+        println!("  cua-driver autostart enable     Register a logon Scheduled Task so serve starts at every interactive logon.");
+        println!("  cua-driver autostart disable    Remove the autostart entry. No-op if not registered.");
+        println!("  cua-driver autostart status     Print whether the entry is registered + whether the daemon is running.");
+        println!("  cua-driver autostart kick       Start the entry now without re-logging.");
         println!();
         println!("mcp options (macOS):");
         println!("  --no-daemon-relaunch    Stay in-process; skip auto-launching the CuaDriverRs daemon.");
@@ -187,6 +200,17 @@ pub fn parse_command() -> Command {
                     process::exit(64);
                 }
             }
+        }
+        Some("autostart") => {
+            // No `cua-driver autostart` (no subcommand) shortcut today —
+            // every operation is destructive enough that we want the
+            // user to be explicit about which one.
+            let subcommand = pos.next().unwrap_or("").to_string();
+            if subcommand.is_empty() {
+                eprintln!("Usage: cua-driver autostart {{enable|disable|status|kick}}");
+                process::exit(64);
+            }
+            Command::Autostart { subcommand }
         }
         Some(first) => {
             // Implicit call: unrecognised first positional → treat as tool name.
@@ -1448,6 +1472,13 @@ pub fn telemetry_entry_event(cmd: &Command) -> Option<String> {
         Command::Update { .. } => "cua_driver_update".to_owned(),
         Command::Doctor { .. } => "cua_driver_doctor".to_owned(),
         Command::Diagnose => "cua_driver_diagnose".to_owned(),
+        // Per-subcommand event so dashboards can split enable / disable /
+        // status / kick separately — they have very different meanings
+        // for adoption. `sanitize_tool_name` already does what we want
+        // (lowercase ASCII / underscore-only / max 64 chars / fallback).
+        Command::Autostart { subcommand } => {
+            format!("cua_driver_autostart_{}", sanitize_tool_name(subcommand))
+        }
         Command::TelemetryInstallEvent => return None,
     };
     Some(name)

--- a/libs/cua-driver-rs/crates/cua-driver/src/main.rs
+++ b/libs/cua-driver-rs/crates/cua-driver/src/main.rs
@@ -24,6 +24,7 @@
 //!
 //! On all other platforms `#[tokio::main]` is used directly.
 
+mod autostart;
 mod bundle;
 mod cli;
 mod doctor;
@@ -196,6 +197,10 @@ fn main() {
         cli::Command::Diagnose => {
             let reg = Arc::new(platform_macos::register_tools());
             cli::run_diagnose_cmd(reg);
+            return;
+        }
+        cli::Command::Autostart { subcommand } => {
+            autostart::run_autostart_cmd(&subcommand);
             return;
         }
         cli::Command::Config { subcommand, key, value, socket } => {
@@ -401,6 +406,10 @@ fn main() -> anyhow::Result<()> {
         cli::Command::Diagnose => {
             let reg = Arc::new(build_registry_no_cursor());
             cli::run_diagnose_cmd(reg);
+            return Ok(());
+        }
+        cli::Command::Autostart { subcommand } => {
+            autostart::run_autostart_cmd(&subcommand);
             return Ok(());
         }
         cli::Command::Config { subcommand, key, value, socket } => {

--- a/libs/cua-driver-rs/scripts/install-local.ps1
+++ b/libs/cua-driver-rs/scripts/install-local.ps1
@@ -98,13 +98,10 @@ function Register-CuaDriverAutostart {
     if (-not (Test-Path -LiteralPath $InstalledBinary)) {
         throw "binary not found at $InstalledBinary"
     }
-    $user = "$env:COMPUTERNAME\$env:USERNAME"
-    $action = New-ScheduledTaskAction -Execute $InstalledBinary -Argument 'serve' -WorkingDirectory $env:USERPROFILE
-    $trigger = New-ScheduledTaskTrigger -AtLogOn -User $user
-    $principal = New-ScheduledTaskPrincipal -UserId $user -LogonType Interactive -RunLevel Limited
-    $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1) -ExecutionTimeLimit (New-TimeSpan -Hours 0)
-    Unregister-ScheduledTask -TaskName 'cua-driver-serve' -Confirm:$false -ErrorAction SilentlyContinue
-    Register-ScheduledTask -TaskName 'cua-driver-serve' -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Description 'cua-driver-rs: serve daemon, auto-start at interactive logon' | Out-Null
+    & $InstalledBinary autostart enable
+    if ($LASTEXITCODE -ne 0) {
+        throw "cua-driver autostart enable failed (exit $LASTEXITCODE)"
+    }
 }
 
 function Write-Step($msg) { Write-Host "==> $msg" -ForegroundColor Cyan }

--- a/libs/cua-driver-rs/scripts/install.ps1
+++ b/libs/cua-driver-rs/scripts/install.ps1
@@ -901,14 +901,14 @@ if ($AutoStart) {
     try {
         Register-CuaDriverAutostart -InstalledBinary $installedBinary
         Write-Host "  cua-driver serve will auto-start at every interactive logon." -ForegroundColor Green
-        Write-Host "  Run now without re-logging:  $installedBinary autostart kick"
-        Write-Host "  Inspect:                    $installedBinary autostart status"
-        Write-Host "  Remove:                     $installedBinary autostart disable"
+        Write-Host "  Run now without re-logging:  & `"$installedBinary`" autostart kick"
+        Write-Host "  Inspect:                     & `"$installedBinary`" autostart status"
+        Write-Host "  Remove:                      & `"$installedBinary`" autostart disable"
         Write-Host ""
     }
     catch {
         Write-Host "  Failed: $($_.Exception.Message)" -ForegroundColor Red
-        Write-Host "  Install otherwise succeeded; re-run with -AutoStart or invoke '$installedBinary autostart enable' manually."
+        Write-Host "  Install otherwise succeeded; re-run with -AutoStart or invoke '& `"$installedBinary`" autostart enable' manually."
         Write-Host ""
     }
 }
@@ -918,10 +918,10 @@ else {
 Auto-start at logon (Windows equivalent of macOS LaunchAgent):
   Run cua-driver serve automatically every time you sign in (RDP, console, etc.)
 
-  Enable:   $installedBinary autostart enable
-  Run now:  $installedBinary autostart kick
-  Status:   $installedBinary autostart status
-  Remove:   $installedBinary autostart disable
+  Enable:   & "$installedBinary" autostart enable
+  Run now:  & "$installedBinary" autostart kick
+  Status:   & "$installedBinary" autostart status
+  Remove:   & "$installedBinary" autostart disable
 
   Or re-run this installer with -AutoStart for the same result.
 "@

--- a/libs/cua-driver-rs/scripts/install.ps1
+++ b/libs/cua-driver-rs/scripts/install.ps1
@@ -465,53 +465,20 @@ function Ensure-Junction([string]$linkPath, [string]$targetPath) {
 
 # ---------- Auto-start Scheduled Task (Windows LaunchAgent equivalent) ---
 
-# Idempotent registration of the cua-driver-serve Scheduled Task.
-#
-# - Trigger: at logon for the current local user.
-# - Principal: LogonType=Interactive so the task lands in the user's
-#   Session 1+ (NOT Session 0); window-driving tools require it.
-# - Settings: AllowStartIfOnBatteries, RestartCount=3 on failure with
-#   1-minute backoff, ExecutionTimeLimit=0 (no time cap; serve is
-#   meant to live for the session).
-# - On workgroup machines USERDOMAIN may be 'WORKGROUP' which won't
-#   resolve as a SAM account; the principal therefore uses
-#   "$COMPUTERNAME\$USERNAME" which is always valid for a local user.
-# - The task is unregistered before re-creation so the helper is
-#   safe to run repeatedly (e.g. on install upgrade).
+# Thin wrapper that delegates to `cua-driver autostart enable`. The binary
+# itself owns the platform-specific registration logic so the install
+# scripts and the runtime stay in lock-step — when the verb's behavior
+# changes, this script picks it up automatically with no edit needed.
 function Register-CuaDriverAutostart {
     param([Parameter(Mandatory = $true)][string]$InstalledBinary)
 
     if (-not (Test-Path -LiteralPath $InstalledBinary)) {
         throw "binary not found at $InstalledBinary"
     }
-
-    $user = "$env:COMPUTERNAME\$env:USERNAME"
-    $action = New-ScheduledTaskAction `
-        -Execute $InstalledBinary `
-        -Argument 'serve' `
-        -WorkingDirectory $env:USERPROFILE
-    $trigger = New-ScheduledTaskTrigger -AtLogOn -User $user
-    $principal = New-ScheduledTaskPrincipal `
-        -UserId $user `
-        -LogonType Interactive `
-        -RunLevel Limited
-    $settings = New-ScheduledTaskSettingsSet `
-        -AllowStartIfOnBatteries `
-        -DontStopIfGoingOnBatteries `
-        -StartWhenAvailable `
-        -RestartCount 3 `
-        -RestartInterval (New-TimeSpan -Minutes 1) `
-        -ExecutionTimeLimit (New-TimeSpan -Hours 0)
-
-    $taskName = 'cua-driver-serve'
-    Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
-    Register-ScheduledTask `
-        -TaskName $taskName `
-        -Action $action `
-        -Trigger $trigger `
-        -Principal $principal `
-        -Settings $settings `
-        -Description 'cua-driver-rs: serve daemon, auto-start at interactive logon' | Out-Null
+    & $InstalledBinary autostart enable
+    if ($LASTEXITCODE -ne 0) {
+        throw "cua-driver autostart enable failed (exit $LASTEXITCODE)"
+    }
 }
 
 # ---------- Concurrent-install lockfile -----------------------------------
@@ -930,17 +897,18 @@ else {
 
 if ($AutoStart) {
     Write-Host ""
-    Write-Host "Registering auto-start Scheduled Task 'cua-driver-serve'..." -ForegroundColor Cyan
+    Write-Host "Registering auto-start (cua-driver autostart enable)..." -ForegroundColor Cyan
     try {
         Register-CuaDriverAutostart -InstalledBinary $installedBinary
-        Write-Host "  Registered. cua-driver serve will auto-start at every interactive logon." -ForegroundColor Green
-        Write-Host "  Run now without re-logging: schtasks /Run /TN cua-driver-serve"
-        Write-Host "  Remove with:               schtasks /Delete /TN cua-driver-serve /F"
+        Write-Host "  cua-driver serve will auto-start at every interactive logon." -ForegroundColor Green
+        Write-Host "  Run now without re-logging:  $installedBinary autostart kick"
+        Write-Host "  Inspect:                    $installedBinary autostart status"
+        Write-Host "  Remove:                     $installedBinary autostart disable"
         Write-Host ""
     }
     catch {
-        Write-Host "  Failed to register Scheduled Task: $($_.Exception.Message)" -ForegroundColor Red
-        Write-Host "  Install otherwise succeeded; re-run with -AutoStart or use the manual recipe below."
+        Write-Host "  Failed: $($_.Exception.Message)" -ForegroundColor Red
+        Write-Host "  Install otherwise succeeded; re-run with -AutoStart or invoke '$installedBinary autostart enable' manually."
         Write-Host ""
     }
 }
@@ -949,21 +917,13 @@ else {
 
 Auto-start at logon (Windows equivalent of macOS LaunchAgent):
   Run cua-driver serve automatically every time you sign in (RDP, console, etc.)
-  Re-run this installer with -AutoStart to register the task, OR paste:
 
-    `$exe = '$installedBinary'
-    `$user = "`$env:COMPUTERNAME\`$env:USERNAME"
-    `$action = New-ScheduledTaskAction -Execute `$exe -Argument 'serve' -WorkingDirectory `$env:USERPROFILE
-    `$trigger = New-ScheduledTaskTrigger -AtLogOn -User `$user
-    `$principal = New-ScheduledTaskPrincipal -UserId `$user -LogonType Interactive -RunLevel Limited
-    `$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1) -ExecutionTimeLimit (New-TimeSpan -Hours 0)
-    Register-ScheduledTask -TaskName 'cua-driver-serve' -Action `$action -Trigger `$trigger -Principal `$principal -Settings `$settings
+  Enable:   $installedBinary autostart enable
+  Run now:  $installedBinary autostart kick
+  Status:   $installedBinary autostart status
+  Remove:   $installedBinary autostart disable
 
-  Then run it now without re-logging:
-    schtasks /Run /TN cua-driver-serve
-
-  Removal:
-    schtasks /Delete /TN cua-driver-serve /F
+  Or re-run this installer with -AutoStart for the same result.
 "@
     Write-Host $autostartHint -ForegroundColor Cyan
 }


### PR DESCRIPTION
﻿## Summary

New CLI verb `cua-driver autostart {enable|disable|status|kick}` â€”
the Windows-native equivalent of the macOS LaunchAgent that
`install.sh` registers. Single source of truth for the Scheduled
Task registration logic; the install scripts now just shell out to
the verb.

- **enable**: registers `cua-driver-serve` Scheduled Task with
  `LogonType=Interactive` so it lands in Session 1+ (never Session 0).
  Idempotent â€” replaces any existing entry.
- **disable**: unregisters. No-op when not registered.
- **status**: prints one of `not-registered`, `registered (not running)`,
  `registered (running)`. The "running" probe reuses
  `is_daemon_listening` against `\\.\pipe\cua-driver`, no `tasklist`.
- **kick**: `schtasks /Run` so the daemon comes up for the current
  session without re-logging.

`install.ps1` and `install-local.ps1` now invoke `cua-driver autostart
enable` instead of duplicating ~50 LOC of PowerShell. Their helpers
are 4 lines each.

macOS / Linux: stub implementations point users at
`install-local.sh --autostart` (which already does the right thing
on those platforms). Native impl for non-Windows is a follow-up.

Telemetry: per-subcommand events (`cua_driver_autostart_enable`,
`_disable`, `_status`, `_kick`) so adoption can be split on the
PostHog dashboard.

## Test plan

- [x] Validated live on Win11 VM: enable â†’ status â†’ kick â†’ status â†’
      disable â†’ disable (no-op) â†’ enable, all green.
- [x] `schtasks /Query /TN cua-driver-serve` reports
      `Logon Mode: Interactive only` after enable.
- [x] After kick, daemon is listening on the named pipe (verified
      with `status` reporting `registered (running)`).
- [ ] `install.ps1 -AutoStart` end-to-end (not re-tested under the
      new shell-out â€” would need a clean install to validate).
- [ ] macOS / Linux stub returns the helpful error message (compile-
      time only on this PR; no live test box).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows autostart management for the daemon via new CLI commands (enable, disable, status, kick) to control automatic startup behavior.
  * Updated installer scripts to leverage the new built-in autostart functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1550?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->