### PR TITLE
feat(uninstall): mirror install-convergence — single canonical uninstall.{sh,ps1} per platform

### DIFF
--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -429,9 +429,18 @@ jobs:
           # Windows build). The Rust install logic itself lives at
           # _install-rust.sh — published as a release asset alongside
           # the installers so curl|bash flows can fetch it.
-          cp libs/cua-driver/scripts/install.sh        release-upload/install.sh
-          cp libs/cua-driver/scripts/install.ps1       release-upload/install.ps1
-          cp libs/cua-driver/scripts/_install-rust.sh  release-upload/_install-rust.sh
+          cp libs/cua-driver/scripts/install.sh         release-upload/install.sh
+          cp libs/cua-driver/scripts/install.ps1        release-upload/install.ps1
+          cp libs/cua-driver/scripts/_install-rust.sh   release-upload/_install-rust.sh
+
+          # Uninstaller scripts — mirror the install side. The canonical
+          # uninstall.sh dispatches to the Swift uninstall path by default
+          # and to _uninstall-rust.sh on --experimental-rust / non-macOS
+          # auto-detect. uninstall.ps1 is the canonical Windows
+          # uninstaller (cua-driver-rs only — no Swift Windows build).
+          cp libs/cua-driver/scripts/uninstall.sh       release-upload/uninstall.sh
+          cp libs/cua-driver/scripts/uninstall.ps1      release-upload/uninstall.ps1
+          cp libs/cua-driver/scripts/_uninstall-rust.sh release-upload/_uninstall-rust.sh
 
           # Skill pack — single platform-agnostic tarball fetched by
           # `cua-driver skills install`. The .md files are identical across
@@ -564,6 +573,8 @@ jobs:
             **Installer scripts**
             - `install.sh` — Linux / macOS one-liner installer
             - `install.ps1` — Windows one-liner installer
+            - `uninstall.sh` — Linux / macOS one-liner uninstaller (mirrors the install flag set: Swift by default; `--experimental-rust` for the Rust port; non-macOS auto-detects)
+            - `uninstall.ps1` — Windows one-liner uninstaller
           generate_release_notes: false
           make_latest: false
 

--- a/docs/content/docs/cua-driver/guide/getting-started/installation.mdx
+++ b/docs/content/docs/cua-driver/guide/getting-started/installation.mdx
@@ -541,7 +541,7 @@ One canonical uninstall URL per platform mirrors the install side. Flag handling
 | Linux | Rust port (auto-detected — Swift binary is macOS-only) | `bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.sh)"` |
 | Windows | Rust port | `irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.ps1 \| iex` |
 
-`uninstall.sh` parses the same `--experimental-rust` / `--backend=rust` / `--backend=swift` flag set as `install.sh` and delegates to a colocated private helper, [`_uninstall-rust.sh`](https://github.com/trycua/cua/blob/main/libs/cua-driver/scripts/_uninstall-rust.sh), when the Rust backend is selected. On Linux (and any non-macOS `bash` host) it auto-detects and runs the Rust uninstall without any flag.
+`uninstall.sh` parses the same `--experimental-rust` / `--backend=rust` / `--backend=swift` flag set as `install.sh` and delegates to a colocated private helper, `_uninstall-rust.sh` (under `libs/cua-driver/scripts/`), when the Rust backend is selected. On Linux (and any non-macOS `bash` host) it auto-detects and runs the Rust uninstall without any flag.
 
 **What each uninstall removes**
 
@@ -553,7 +553,7 @@ One canonical uninstall URL per platform mirrors the install side. Flag handling
 | Rust — Windows | `%LOCALAPPDATA%\Programs\trycua\cua-driver-rs\bin` *(directory junction)* | `%USERPROFILE%\.cua-driver-rs\` (entire tree, including `packages\current` junction) | Scheduled Task `cua-driver-serve` (`schtasks /Delete`) | Junctions under `%USERPROFILE%\.claude\skills`, `.agents\skills`, `.openclaw\skills`, `%APPDATA%\opencode\skills` | Not auto-edited — closing message prints `claude mcp remove cua-driver-rs` |
 
 <Callout type="info">
-**Safety invariants** — both uninstallers refuse to clobber a real directory at a path where the matching install script could have only created a symlink/junction (Linux/macOS use `[[ -L ]]`, Windows checks `IO_REPARSE_TAG_MOUNT_POINT`). A user who hand-managed any of these dirs keeps theirs untouched. Re-running an uninstall on an already-clean system prints `nothing to remove` per item — never errors.
+**Safety invariants** — every uninstall script (`uninstall.sh`, `_uninstall-rust.sh`, `uninstall.ps1`) refuses to clobber a real directory at a path where the matching installer could have only created a symlink / junction (Linux/macOS use `[[ -L ]]`; Windows checks `IO_REPARSE_TAG_MOUNT_POINT`). A user who hand-managed any of these dirs keeps theirs untouched. Re-running an uninstall on an already-clean system prints `nothing to remove` per item — never errors.
 </Callout>
 
 <Callout type="info">
@@ -577,7 +577,7 @@ tccutil reset ScreenCapture com.trycua.cuadriverrs
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.ps1))) -Force
 ```
 
-It also doesn't auto-edit `%USERPROFILE%\.claude.json` — the closing message prints the exact `claude mcp remove cua-driver-rs` command instead. Mirrors the macOS uninstaller's conservative stance for hosts without `python3`.
+It also doesn't auto-edit `%USERPROFILE%\.claude.json` — the closing message prints the exact `claude mcp remove cua-driver-rs` command instead. The macOS / Linux uninstaller does auto-edit `~/.claude.json` when `python3` is on `PATH`; the Windows uninstaller skips the auto-edit unconditionally to keep the script dependency-free.
 </Callout>
 
 ## Troubleshooting

--- a/docs/content/docs/cua-driver/guide/getting-started/installation.mdx
+++ b/docs/content/docs/cua-driver/guide/getting-started/installation.mdx
@@ -548,7 +548,7 @@ One canonical uninstall URL per platform mirrors the install side. Flag handling
 | Backend | Symlink / bin | App bundle / package home | Autostart entry | Skill links | Claude MCP registrations |
 |---|---|---|---|---|---|
 | Swift (macOS) | `~/.local/bin/cua-driver`, `/usr/local/bin/cua-driver` (legacy) | `/Applications/CuaDriver.app`, `~/.cua-driver`, `~/Library/Application Support/Cua Driver`, `~/Library/Caches/cua-driver` | `~/Library/LaunchAgents/com.trycua.cua_driver_updater.plist` (legacy ≤ 0.0.5) | `cua-driver` symlinks under `~/.claude/skills`, `~/.agents/skills`, `~/.openclaw/skills`, `~/.config/opencode/skills` | Scrubbed from `~/.claude.json` |
-| Rust — macOS | `~/.local/bin/cua-driver` *(only when it resolves into `CuaDriverRs.app`)* | `/Applications/CuaDriverRs.app`, `~/.cua-driver-rs/` (entire tree) | `~/Library/LaunchAgents/com.trycua.cua-driver-rs.plist` | `cua-driver-rs` symlinks under the same agent dirs | Scrubbed from `~/.claude.json` |
+| Rust — macOS | `~/.local/bin/cua-driver` *(only when it resolves into `CuaDriver.app` and `~/.cua-driver-rs/` exists)* | `/Applications/CuaDriver.app` (current), `/Applications/CuaDriverRs.app` (legacy, pre-rename), `~/.cua-driver-rs/` (entire tree) | `~/Library/LaunchAgents/com.trycua.cua-driver-rs.plist` | `cua-driver-rs` symlinks under the same agent dirs | Scrubbed from `~/.claude.json` |
 | Rust — Linux | `~/.local/bin/cua-driver` *(when it resolves into `~/.cua-driver-rs/`)* | `~/.cua-driver-rs/` (entire tree) | `~/.config/systemd/user/cua-driver-rs.service` (stop + disable + remove) | Same as above | Scrubbed from `~/.claude.json` |
 | Rust — Windows | `%LOCALAPPDATA%\Programs\trycua\cua-driver-rs\bin` *(directory junction)* | `%USERPROFILE%\.cua-driver-rs\` (entire tree, including `packages\current` junction) | Scheduled Task `cua-driver-serve` (`schtasks /Delete`) | Junctions under `%USERPROFILE%\.claude\skills`, `.agents\skills`, `.openclaw\skills`, `%APPDATA%\opencode\skills` | Not auto-edited — closing message prints `claude mcp remove cua-driver-rs` |
 
@@ -560,13 +560,17 @@ One canonical uninstall URL per platform mirrors the install side. Flag handling
 **TCC grants persist on macOS** (Accessibility + Screen Recording). The uninstaller leaves them in **System Settings → Privacy & Security** so a re-install doesn't have to re-prompt. To reset them explicitly:
 
 ```bash
-# Swift driver
+# Both Swift and Rust drivers share bundle id `com.trycua.driver`
+# (the Rust port took over Swift's identity in cua-driver-rs ≥ 0.2.4).
 tccutil reset Accessibility com.trycua.driver
 tccutil reset ScreenCapture com.trycua.driver
+```
 
-# Rust port
-tccutil reset Accessibility com.trycua.cuadriverrs
-tccutil reset ScreenCapture com.trycua.cuadriverrs
+Pre-rename Rust installs (`cua-driver-rs ≤ 0.2.3`) used a separate bundle id `com.trycua.cuadriverrs` — clean those up if you had one of those installs:
+
+```bash
+tccutil reset Accessibility com.trycua.cuadriverrs 2>/dev/null
+tccutil reset ScreenCapture com.trycua.cuadriverrs 2>/dev/null
 ```
 </Callout>
 

--- a/docs/content/docs/cua-driver/guide/getting-started/installation.mdx
+++ b/docs/content/docs/cua-driver/guide/getting-started/installation.mdx
@@ -532,25 +532,53 @@ cat /Applications/CuaDriver.app/Contents/Resources/Skills/cua-driver/SKILL.md | 
 
 ## Uninstall
 
+One canonical uninstall URL per platform mirrors the install side. Flag handling and auto-detection match `install.sh` exactly:
+
+| Platform | Backend | Command |
+|---|---|---|
+| macOS | Swift (default) | `bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.sh)"` |
+| macOS | Rust port (`cua-driver-rs`) | `bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.sh)" -- --experimental-rust` |
+| Linux | Rust port (auto-detected — Swift binary is macOS-only) | `bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.sh)"` |
+| Windows | Rust port | `irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.ps1 \| iex` |
+
+`uninstall.sh` parses the same `--experimental-rust` / `--backend=rust` / `--backend=swift` flag set as `install.sh` and delegates to a colocated private helper, [`_uninstall-rust.sh`](https://github.com/trycua/cua/blob/main/libs/cua-driver/scripts/_uninstall-rust.sh), when the Rust backend is selected. On Linux (and any non-macOS `bash` host) it auto-detects and runs the Rust uninstall without any flag.
+
+**What each uninstall removes**
+
+| Backend | Symlink / bin | App bundle / package home | Autostart entry | Skill links | Claude MCP registrations |
+|---|---|---|---|---|---|
+| Swift (macOS) | `~/.local/bin/cua-driver`, `/usr/local/bin/cua-driver` (legacy) | `/Applications/CuaDriver.app`, `~/.cua-driver`, `~/Library/Application Support/Cua Driver`, `~/Library/Caches/cua-driver` | `~/Library/LaunchAgents/com.trycua.cua_driver_updater.plist` (legacy ≤ 0.0.5) | `cua-driver` symlinks under `~/.claude/skills`, `~/.agents/skills`, `~/.openclaw/skills`, `~/.config/opencode/skills` | Scrubbed from `~/.claude.json` |
+| Rust — macOS | `~/.local/bin/cua-driver` *(only when it resolves into `CuaDriverRs.app`)* | `/Applications/CuaDriverRs.app`, `~/.cua-driver-rs/` (entire tree) | `~/Library/LaunchAgents/com.trycua.cua-driver-rs.plist` | `cua-driver-rs` symlinks under the same agent dirs | Scrubbed from `~/.claude.json` |
+| Rust — Linux | `~/.local/bin/cua-driver` *(when it resolves into `~/.cua-driver-rs/`)* | `~/.cua-driver-rs/` (entire tree) | `~/.config/systemd/user/cua-driver-rs.service` (stop + disable + remove) | Same as above | Scrubbed from `~/.claude.json` |
+| Rust — Windows | `%LOCALAPPDATA%\Programs\trycua\cua-driver-rs\bin` *(directory junction)* | `%USERPROFILE%\.cua-driver-rs\` (entire tree, including `packages\current` junction) | Scheduled Task `cua-driver-serve` (`schtasks /Delete`) | Junctions under `%USERPROFILE%\.claude\skills`, `.agents\skills`, `.openclaw\skills`, `%APPDATA%\opencode\skills` | Not auto-edited — closing message prints `claude mcp remove cua-driver-rs` |
+
+<Callout type="info">
+**Safety invariants** — both uninstallers refuse to clobber a real directory at a path where the matching install script could have only created a symlink/junction (Linux/macOS use `[[ -L ]]`, Windows checks `IO_REPARSE_TAG_MOUNT_POINT`). A user who hand-managed any of these dirs keeps theirs untouched. Re-running an uninstall on an already-clean system prints `nothing to remove` per item — never errors.
+</Callout>
+
+<Callout type="info">
+**TCC grants persist on macOS** (Accessibility + Screen Recording). The uninstaller leaves them in **System Settings → Privacy & Security** so a re-install doesn't have to re-prompt. To reset them explicitly:
+
 ```bash
-# Stop the daemon if running.
-cua-driver stop 2>/dev/null
+# Swift driver
+tccutil reset Accessibility com.trycua.driver
+tccutil reset ScreenCapture com.trycua.driver
 
-# Remove the app and the CLI symlink.
-rm -rf /Applications/CuaDriver.app
-rm -f ~/.local/bin/cua-driver
-# legacy install path (only present on installs from before v0.1.0)
-sudo rm -f /usr/local/bin/cua-driver 2>/dev/null || true
-
-# Optional: remove config + telemetry state.
-rm -rf ~/.cua-driver
-rm -rf ~/Library/Application\ Support/Cua\ Driver
-rm -rf ~/Library/Caches/cua-driver
-
-# Optional: remove legacy LaunchAgent from older installs (≤ v0.0.5).
-launchctl unload ~/Library/LaunchAgents/com.trycua.cua_driver_updater.plist 2>/dev/null
-rm -f ~/Library/LaunchAgents/com.trycua.cua_driver_updater.plist
+# Rust port
+tccutil reset Accessibility com.trycua.cuadriverrs
+tccutil reset ScreenCapture com.trycua.cuadriverrs
 ```
+</Callout>
+
+<Callout type="warn">
+**Windows is interactive by default.** `uninstall.ps1` prompts before each major delete so a stray paste doesn't wipe a working install. For non-interactive / scripted teardowns, pipe through a `-Force` arg:
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.ps1))) -Force
+```
+
+It also doesn't auto-edit `%USERPROFILE%\.claude.json` — the closing message prints the exact `claude mcp remove cua-driver-rs` command instead. Mirrors the macOS uninstaller's conservative stance for hosts without `python3`.
+</Callout>
 
 ## Troubleshooting
 

--- a/libs/cua-driver/scripts/_uninstall-rust.sh
+++ b/libs/cua-driver/scripts/_uninstall-rust.sh
@@ -20,9 +20,9 @@
 #     ~/.config/opencode/skills/cua-driver-rs
 #
 # macOS:
-#   - /Applications/CuaDriverRs.app bundle
+#   - /Applications/CuaDriver.app bundle (and legacy CuaDriverRs.app if present)
 #   - ~/.local/bin/cua-driver symlink (only when it resolves into
-#     CuaDriverRs.app — Swift-driver symlinks are left in place)
+#     /Applications/CuaDriver.app — see note on the bundle-id share below)
 #   - ~/.cua-driver-rs/ (entire package home)
 #   - ~/Library/LaunchAgents/com.trycua.cua-driver-rs.plist (if
 #     --autostart was used via install-local.sh — unload + remove)
@@ -37,7 +37,13 @@
 set -euo pipefail
 
 USER_BIN_LINK="$HOME/.local/bin/cua-driver"
-APP_BUNDLE="/Applications/CuaDriverRs.app"
+# Canonical bundle path (post-rename — shares bundle id `com.trycua.driver`
+# with the Swift driver). The Rust install replaces Swift here; both
+# the Rust and Swift uninstallers target this path.
+APP_BUNDLE="/Applications/CuaDriver.app"
+# Legacy bundle path from earlier Rust releases that coexisted with
+# Swift under a separate name. Cleaned up if found.
+LEGACY_APP_BUNDLE="/Applications/CuaDriverRs.app"
 HOME_DIR="${CUA_DRIVER_RS_HOME:-$HOME/.cua-driver-rs}"
 LAUNCHAGENT_PLIST="$HOME/Library/LaunchAgents/com.trycua.cua-driver-rs.plist"
 SYSTEMD_USER_UNIT="$HOME/.config/systemd/user/cua-driver-rs.service"
@@ -73,15 +79,18 @@ resolve_link() {
 
 # --- CLI symlink ---------------------------------------------------------
 #
-# Only remove ~/.local/bin/cua-driver when it resolves to a cua-driver-rs
-# install — don't clobber a Swift-driver symlink the user might still
-# want. The Swift install would resolve to /Applications/CuaDriver.app/
-# Contents/MacOS/cua-driver; the Rust install resolves to either
-# /Applications/CuaDriverRs.app/... (macOS) or $HOME_DIR/packages/... (Linux).
+# Only remove ~/.local/bin/cua-driver when it resolves into a cua-driver-rs
+# install. Post-rename, the Rust install lives at /Applications/CuaDriver.app
+# — the SAME path the Swift driver uses, with the same bundle id
+# `com.trycua.driver`. Path-based detection alone can't distinguish
+# them. We rely on the presence of `$HOME_DIR` (~/.cua-driver-rs/) — the
+# Rust-specific state dir — as the marker that this is a Rust install.
+# Pre-rename installs at /Applications/CuaDriverRs.app are still cleaned
+# up unambiguously by path.
 if [[ -L "$USER_BIN_LINK" ]]; then
     RESOLVED="$(resolve_link "$USER_BIN_LINK")"
     case "$RESOLVED" in
-        *"CuaDriverRs.app"*|*"$HOME_DIR"*|*".cua-driver-rs"*)
+        *"CuaDriverRs.app"*|*"/Applications/CuaDriver.app"*|*"$HOME_DIR"*|*".cua-driver-rs"*)
             rm -f "$USER_BIN_LINK"
             log "removed $USER_BIN_LINK -> $RESOLVED"
             ;;
@@ -130,17 +139,28 @@ elif [[ "$OS" == "Darwin" ]]; then
 fi
 
 # --- .app bundle (macOS only) -------------------------------------------
+#
+# Removes /Applications/CuaDriver.app (current canonical Rust path,
+# shared with the Swift driver via bundle id `com.trycua.driver`) AND
+# /Applications/CuaDriverRs.app (legacy, pre-rename releases).
+# Removing the shared `.app` path is correct here: a user who runs
+# `uninstall.sh --experimental-rust` wants the binary on disk gone;
+# if they previously had the Swift binary at the same path, they've
+# already overwritten it with Rust on install. Re-installing the
+# Swift driver afterward is a re-run of the canonical `install.sh`.
 if [[ "$OS" == "Darwin" ]]; then
-    if [[ -d "$APP_BUNDLE" ]]; then
-        SUDO=""
-        if [[ ! -w "$(dirname "$APP_BUNDLE")" ]]; then
-            SUDO="sudo"
+    for bundle_path in "$APP_BUNDLE" "$LEGACY_APP_BUNDLE"; do
+        if [[ -d "$bundle_path" ]]; then
+            SUDO=""
+            if [[ ! -w "$(dirname "$bundle_path")" ]]; then
+                SUDO="sudo"
+            fi
+            $SUDO rm -rf "$bundle_path"
+            log "removed $bundle_path"
+        else
+            log "no app bundle at $bundle_path (skipping)"
         fi
-        $SUDO rm -rf "$APP_BUNDLE"
-        log "removed $APP_BUNDLE"
-    else
-        log "no app bundle at $APP_BUNDLE (skipping)"
-    fi
+    done
 fi
 
 # --- Package home -------------------------------------------------------
@@ -228,6 +248,7 @@ def invokes_cua_driver_rs(server):
     if home_dir and home_dir in joined:
         return True
     return ("CuaDriverRs.app" in joined
+            or "/Applications/CuaDriver.app" in joined
             or ".cua-driver-rs" in joined
             or "cua-driver-rs" in joined)
 
@@ -316,8 +337,13 @@ TCC grants (Accessibility + Screen Recording) remain in System
 Settings > Privacy & Security. Reset them explicitly if you want a
 clean re-install flow:
 
-  tccutil reset Accessibility com.trycua.cuadriverrs
-  tccutil reset ScreenCapture com.trycua.cuadriverrs
+  tccutil reset Accessibility com.trycua.driver
+  tccutil reset ScreenCapture com.trycua.driver
+
+  (Note: `com.trycua.driver` is shared with the Swift cua-driver.
+  Resetting it clears grants for both backends. If you still use the
+  Swift driver, skip this step and let macOS keep the grants — the
+  next Swift launch will re-use them.)
 FINALUNMSG
 else
     cat << 'FINALUNMSG'

--- a/libs/cua-driver/scripts/_uninstall-rust.sh
+++ b/libs/cua-driver/scripts/_uninstall-rust.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# _uninstall-rust.sh — private helper invoked by libs/cua-driver/scripts/uninstall.sh
+# (the canonical user-facing uninstaller) when --backend=rust is selected or
+# the script auto-detects a non-macOS host. Not intended for direct
+# invocation; user-facing one-liners always go through the parent
+# uninstall.sh, which forwards args + handles backend selection.
+#
+# Mirrors _install-rust.sh's on-disk knowledge — removes everything the
+# install script laid down:
+#
+# Linux:
+#   - ~/.local/bin/cua-driver symlink (only when it resolves to a
+#     cua-driver-rs path — a Swift-driver symlink is left in place)
+#   - ~/.cua-driver-rs/ (entire package home: telemetry id, install
+#     marker, versioned releases, current symlink, lockfile)
+#   - ~/.config/systemd/user/cua-driver-rs.service (if --autostart was
+#     used via install-local.sh — stop + disable + remove)
+#   - Skill symlinks under ~/.claude/skills/cua-driver-rs, ~/.agents/
+#     skills/cua-driver-rs, ~/.openclaw/skills/cua-driver-rs,
+#     ~/.config/opencode/skills/cua-driver-rs
+#
+# macOS:
+#   - /Applications/CuaDriverRs.app bundle
+#   - ~/.local/bin/cua-driver symlink (only when it resolves into
+#     CuaDriverRs.app — Swift-driver symlinks are left in place)
+#   - ~/.cua-driver-rs/ (entire package home)
+#   - ~/Library/LaunchAgents/com.trycua.cua-driver-rs.plist (if
+#     --autostart was used via install-local.sh — unload + remove)
+#   - Skill symlinks under ~/.claude/skills/cua-driver-rs, etc.
+#
+# Also scrubs Claude MCP registrations in ~/.claude.json that point at
+# the cua-driver-rs binary.
+#
+# Does NOT revoke TCC grants on macOS — same conservative stance as the
+# Swift uninstall.sh. The closing message points at the tccutil commands
+# for a clean re-install flow.
+set -euo pipefail
+
+USER_BIN_LINK="$HOME/.local/bin/cua-driver"
+APP_BUNDLE="/Applications/CuaDriverRs.app"
+HOME_DIR="${CUA_DRIVER_RS_HOME:-$HOME/.cua-driver-rs}"
+LAUNCHAGENT_PLIST="$HOME/Library/LaunchAgents/com.trycua.cua-driver-rs.plist"
+SYSTEMD_USER_UNIT="$HOME/.config/systemd/user/cua-driver-rs.service"
+SKILL_PACK_NAME="cua-driver-rs"
+
+OS="$(uname -s 2>/dev/null || echo unknown)"
+
+log() { printf '==> %s\n' "$*"; }
+
+# Resolve a symlink target to an absolute path. realpath -e fails when the
+# target is missing — we want to inspect dangling symlinks too (a leftover
+# from a half-removed install should still be cleaned up here), so fall
+# back to readlink + manual normalize when realpath errors out.
+resolve_link() {
+    local link="$1"
+    if [[ ! -L "$link" ]]; then
+        printf ''; return 0
+    fi
+    local target
+    if target="$(realpath "$link" 2>/dev/null)"; then
+        printf '%s' "$target"
+        return 0
+    fi
+    # Dangling symlink — readlink still returns the stored target. Make
+    # it absolute by joining with the link's dirname for non-absolute
+    # stored values.
+    target="$(readlink "$link" 2>/dev/null || true)"
+    case "$target" in
+        /*) printf '%s' "$target" ;;
+        *)  printf '%s/%s' "$(cd -- "$(dirname -- "$link")" && pwd)" "$target" ;;
+    esac
+}
+
+# --- CLI symlink ---------------------------------------------------------
+#
+# Only remove ~/.local/bin/cua-driver when it resolves to a cua-driver-rs
+# install — don't clobber a Swift-driver symlink the user might still
+# want. The Swift install would resolve to /Applications/CuaDriver.app/
+# Contents/MacOS/cua-driver; the Rust install resolves to either
+# /Applications/CuaDriverRs.app/... (macOS) or $HOME_DIR/packages/... (Linux).
+if [[ -L "$USER_BIN_LINK" ]]; then
+    RESOLVED="$(resolve_link "$USER_BIN_LINK")"
+    case "$RESOLVED" in
+        *"CuaDriverRs.app"*|*"$HOME_DIR"*|*".cua-driver-rs"*)
+            rm -f "$USER_BIN_LINK"
+            log "removed $USER_BIN_LINK -> $RESOLVED"
+            ;;
+        *)
+            log "$USER_BIN_LINK resolves to $RESOLVED (not a cua-driver-rs path; skipping)"
+            ;;
+    esac
+elif [[ -e "$USER_BIN_LINK" ]]; then
+    log "$USER_BIN_LINK exists but is not a symlink (skipping; refusing to clobber a real file)"
+else
+    log "no CLI symlink at $USER_BIN_LINK (skipping)"
+fi
+
+# --- Autostart (Linux systemd --user) -----------------------------------
+#
+# install-local.sh --autostart registers ~/.config/systemd/user/
+# cua-driver-rs.service. Stop + disable + remove if present so the
+# daemon doesn't come back at the next logon. systemctl --user no-ops
+# gracefully on a non-systemd host (returns non-zero, which we swallow).
+if [[ "$OS" == "Linux" && -f "$SYSTEMD_USER_UNIT" ]]; then
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl --user stop    cua-driver-rs.service 2>/dev/null || true
+        systemctl --user disable cua-driver-rs.service 2>/dev/null || true
+        log "stopped + disabled systemd --user unit cua-driver-rs.service"
+    fi
+    rm -f "$SYSTEMD_USER_UNIT"
+    log "removed $SYSTEMD_USER_UNIT"
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl --user daemon-reload 2>/dev/null || true
+    fi
+elif [[ "$OS" == "Linux" ]]; then
+    log "no systemd --user unit at $SYSTEMD_USER_UNIT (skipping)"
+fi
+
+# --- Autostart (macOS LaunchAgent) --------------------------------------
+#
+# install-local.sh --autostart on macOS registers
+# ~/Library/LaunchAgents/com.trycua.cua-driver-rs.plist. Unload (so the
+# running daemon stops) + remove the plist.
+if [[ "$OS" == "Darwin" && -f "$LAUNCHAGENT_PLIST" ]]; then
+    launchctl unload "$LAUNCHAGENT_PLIST" 2>/dev/null || true
+    rm -f "$LAUNCHAGENT_PLIST"
+    log "removed LaunchAgent $LAUNCHAGENT_PLIST"
+elif [[ "$OS" == "Darwin" ]]; then
+    log "no LaunchAgent at $LAUNCHAGENT_PLIST (skipping)"
+fi
+
+# --- .app bundle (macOS only) -------------------------------------------
+if [[ "$OS" == "Darwin" ]]; then
+    if [[ -d "$APP_BUNDLE" ]]; then
+        SUDO=""
+        if [[ ! -w "$(dirname "$APP_BUNDLE")" ]]; then
+            SUDO="sudo"
+        fi
+        $SUDO rm -rf "$APP_BUNDLE"
+        log "removed $APP_BUNDLE"
+    else
+        log "no app bundle at $APP_BUNDLE (skipping)"
+    fi
+fi
+
+# --- Package home -------------------------------------------------------
+#
+# Everything under $CUA_DRIVER_RS_HOME (default ~/.cua-driver-rs):
+# telemetry id, install marker, versioned releases, current symlink,
+# lockfile, local skill copy, version_check.json cache.
+if [[ -d "$HOME_DIR" ]]; then
+    rm -rf "$HOME_DIR"
+    log "removed $HOME_DIR"
+else
+    log "no package home at $HOME_DIR (skipping)"
+fi
+
+# --- Agent skill symlinks -----------------------------------------------
+#
+# Only remove when the link is a symlink — never clobber a real
+# directory (a dev user with a hand-managed skills dir is safe). Note
+# we don't check the target here because `cua-driver skills install`
+# writes platform-dependent targets (the local copy under $HOME_DIR/
+# skills/cua-driver-rs/), and on Windows the `<HomeDir>/skills` shape
+# is different. The [[ -L ]] check is the load-bearing safety bar.
+for SKILL_LINK in \
+    "$HOME/.claude/skills/$SKILL_PACK_NAME" \
+    "$HOME/.agents/skills/$SKILL_PACK_NAME" \
+    "$HOME/.openclaw/skills/$SKILL_PACK_NAME" \
+    "$HOME/.config/opencode/skills/$SKILL_PACK_NAME"; do
+    if [[ -L "$SKILL_LINK" ]]; then
+        rm -f "$SKILL_LINK"
+        log "removed skill symlink $SKILL_LINK"
+    elif [[ -d "$SKILL_LINK" ]]; then
+        log "$SKILL_LINK is a real directory, not a symlink (skipping)"
+    else
+        log "no skill symlink at $SKILL_LINK (skipping)"
+    fi
+done
+
+# --- Claude Code MCP registrations --------------------------------------
+#
+# Same scrub shape as the Swift uninstall.sh, keyed on the cua-driver-rs
+# binary name + the per-platform install paths. Unrelated MCP servers
+# are left alone.
+CLAUDE_JSON="$HOME/.claude.json"
+if [[ -f "$CLAUDE_JSON" ]] && command -v python3 >/dev/null 2>&1; then
+    PY_OUTPUT="$(
+        CLAUDE_JSON="$CLAUDE_JSON" HOME_DIR="$HOME_DIR" python3 <<'PY'
+import json
+import os
+import shutil
+import sys
+import tempfile
+import time
+
+path = os.environ["CLAUDE_JSON"]
+home_dir = os.environ.get("HOME_DIR", "")
+
+try:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+except Exception as exc:
+    print(f"could not read Claude config {path}: {exc}", file=sys.stderr)
+    raise SystemExit(0)
+
+removed = []
+
+def text_parts(value):
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, str)]
+    return []
+
+def invokes_cua_driver_rs(server):
+    if not isinstance(server, dict):
+        return False
+    parts = []
+    parts.extend(text_parts(server.get("command")))
+    parts.extend(text_parts(server.get("args")))
+    joined = " ".join(parts)
+    # Match the Rust-port-specific anchors: bundle name, package home,
+    # explicit ".cua-driver-rs" segment. Plain "cua-driver" alone is
+    # ambiguous (the Swift binary uses the same filename), so we key on
+    # the Rust-specific paths here. The user can run the Swift
+    # uninstall.sh separately if they have both.
+    if home_dir and home_dir in joined:
+        return True
+    return ("CuaDriverRs.app" in joined
+            or ".cua-driver-rs" in joined
+            or "cua-driver-rs" in joined)
+
+def should_remove(name, server):
+    return name in {"cua-driver-rs"} or invokes_cua_driver_rs(server)
+
+def scrub_servers(servers, scope):
+    if not isinstance(servers, dict):
+        return
+    for name in list(servers.keys()):
+        if should_remove(name, servers[name]):
+            del servers[name]
+            removed.append(f"{scope}:{name}")
+
+scrub_servers(data.get("mcpServers"), "user")
+
+projects = data.get("projects")
+if isinstance(projects, dict):
+    for project in projects.values():
+        if isinstance(project, dict):
+            scrub_servers(project.get("mcpServers"), "project")
+
+if not removed:
+    raise SystemExit(0)
+
+backup = f"{path}.bak-cua-driver-rs-uninstall-{int(time.time())}"
+shutil.copy2(path, backup)
+
+directory = os.path.dirname(path) or "."
+fd, tmp_path = tempfile.mkstemp(
+    prefix=".claude.json.",
+    suffix=".tmp",
+    dir=directory,
+    text=True,
+)
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    os.replace(tmp_path, path)
+except Exception:
+    try:
+        os.unlink(tmp_path)
+    except OSError:
+        pass
+    raise
+
+print(f"removed Claude MCP registration(s): {', '.join(removed)}")
+print(f"backed up Claude config to {backup}")
+PY
+    )"
+    if [[ -n "$PY_OUTPUT" ]]; then
+        while IFS= read -r line; do
+            log "$line"
+        done <<< "$PY_OUTPUT"
+    else
+        log "no Claude MCP registrations for cua-driver-rs found in $CLAUDE_JSON"
+    fi
+else
+    log "no Claude config cleanup via python3 (missing $CLAUDE_JSON or python3)"
+fi
+
+# Best-effort CLI cleanup. `claude mcp remove` only touches the active
+# project / user scopes — fine to run; it's a no-op when the entries
+# were already scrubbed above.
+if command -v claude >/dev/null 2>&1; then
+    for SERVER in cua-driver-rs; do
+        for SCOPE in local project user; do
+            if claude mcp remove "$SERVER" -s "$SCOPE" >/dev/null 2>&1; then
+                log "removed Claude MCP server $SERVER from $SCOPE scope"
+            fi
+        done
+    done
+else
+    log "claude CLI not found (skipping Claude MCP CLI cleanup)"
+fi
+
+# --- Closing message ----------------------------------------------------
+
+if [[ "$OS" == "Darwin" ]]; then
+    cat << 'FINALUNMSG'
+
+cua-driver-rs uninstalled.
+
+TCC grants (Accessibility + Screen Recording) remain in System
+Settings > Privacy & Security. Reset them explicitly if you want a
+clean re-install flow:
+
+  tccutil reset Accessibility com.trycua.cuadriverrs
+  tccutil reset ScreenCapture com.trycua.cuadriverrs
+FINALUNMSG
+else
+    cat << 'FINALUNMSG'
+
+cua-driver-rs uninstalled.
+FINALUNMSG
+fi

--- a/libs/cua-driver/scripts/uninstall.ps1
+++ b/libs/cua-driver/scripts/uninstall.ps1
@@ -1,0 +1,281 @@
+# cua-driver-rs uninstaller (Windows) — removes everything install.ps1
+# laid down: the Scheduled Task autostart entry, running daemon
+# processes, the directory junctions wiring the visible bin dir back to
+# a per-version release dir, the entire package home tree, and any skill
+# junctions the binary's `skills install` verb dropped under the agent
+# config directories.
+#
+# Usage (one-liner — recommended):
+#   irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.ps1 | iex
+#
+# Force (no prompts):
+#   $forceArgs = @('-Force')
+#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.ps1))) @forceArgs
+#
+# What gets removed:
+#   - Scheduled Task 'cua-driver-serve' (autostart entry registered by
+#     `cua-driver autostart enable` or install.ps1 -AutoStart)
+#   - Any running cua-driver.exe processes (so file handles don't pin
+#     the binary directory open during the delete pass)
+#   - <visibleBinDir>     = %LOCALAPPDATA%\Programs\trycua\cua-driver-rs\bin  (directory junction)
+#   - <currentDir>        = %USERPROFILE%\.cua-driver-rs\packages\current     (directory junction)
+#   - <packageHome>       = %USERPROFILE%\.cua-driver-rs\                     (entire tree:
+#                                                                              releases, lockfile,
+#                                                                              telemetry id,
+#                                                                              install marker,
+#                                                                              version_check.json)
+#   - Skill junctions under:
+#       %USERPROFILE%\.claude\skills\cua-driver-rs
+#       %USERPROFILE%\.agents\skills\cua-driver-rs
+#       %USERPROFILE%\.openclaw\skills\cua-driver-rs
+#       %APPDATA%\opencode\skills\cua-driver-rs
+#     (each only when it's a reparse point — never clobber a real dir).
+#
+# Conservative on Claude MCP cleanup: we DON'T auto-edit %USERPROFILE%\
+# .claude.json on Windows (mirrors the macOS uninstall.sh's stance for
+# environments without python3). The closing message prints the
+# `claude mcp remove cua-driver-rs` command for the user to run.
+#
+# Env overrides (mirror install.ps1's variable names):
+#   $env:CUA_DRIVER_RS_INSTALL_DIR   visible bin dir to remove
+#                                    (default %LOCALAPPDATA%\Programs\trycua\cua-driver-rs\bin)
+#   $env:CUA_DRIVER_RS_HOME          package home to remove
+#                                    (default %USERPROFILE%\.cua-driver-rs)
+#
+# Params:
+#   -Force      non-interactive: skip the "remove? [y/N]" prompt before
+#               each major delete. The one-liner is interactive by
+#               default so a stray paste doesn't accidentally wipe a
+#               working install.
+
+[CmdletBinding()]
+param(
+    [switch]$Force
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+# ---------- Path resolution (mirrors install.ps1) -------------------------
+
+if ($env:CUA_DRIVER_RS_INSTALL_DIR) {
+    $VisibleBinDir = $env:CUA_DRIVER_RS_INSTALL_DIR
+} else {
+    $VisibleBinDir = Join-Path $env:LOCALAPPDATA "Programs\trycua\cua-driver-rs\bin"
+}
+
+if ($env:CUA_DRIVER_RS_HOME) {
+    $HomeDir = $env:CUA_DRIVER_RS_HOME
+} else {
+    $HomeDir = Join-Path $env:USERPROFILE ".cua-driver-rs"
+}
+
+$PackagesDir  = Join-Path $HomeDir   "packages"
+$CurrentDir   = Join-Path $PackagesDir "current"
+$AutoStartTask = "cua-driver-serve"
+
+# Skill junctions — mirrors the AGENTS list in
+# libs/cua-driver-rs/crates/cua-driver/src/skills.rs (the verb that
+# creates them) so we remove from the same paths.
+$SkillJunctions = @(
+    (Join-Path $env:USERPROFILE ".claude\skills\cua-driver-rs"),
+    (Join-Path $env:USERPROFILE ".agents\skills\cua-driver-rs"),
+    (Join-Path $env:USERPROFILE ".openclaw\skills\cua-driver-rs"),
+    (Join-Path $env:APPDATA      "opencode\skills\cua-driver-rs")
+)
+
+# ---------- Log helpers ----------------------------------------------------
+
+function Write-Step($message) {
+    Write-Host "==> $message"
+}
+
+function Write-WarningStep($message) {
+    Write-Host "WARNING: $message" -ForegroundColor Yellow
+}
+
+function Write-ErrorStep($message) {
+    Write-Host "error: $message" -ForegroundColor Red
+}
+
+# ---------- Reparse-point helpers -----------------------------------------
+#
+# install.ps1 wires the bin\ and current\ directories with NTFS directory
+# junctions (IO_REPARSE_TAG_MOUNT_POINT). Test-IsReparsePoint differentiates
+# them from real directories so we only ever Remove-Item a path the
+# installer could have created — never clobber a user's hand-managed dir.
+
+function Test-IsReparsePoint([string]$path) {
+    if (-not (Test-Path -LiteralPath $path)) { return $false }
+    try {
+        $item = Get-Item -LiteralPath $path -Force -ErrorAction Stop
+    } catch {
+        return $false
+    }
+    return (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)
+}
+
+# ---------- Confirmation prompt -------------------------------------------
+#
+# The one-liner runs interactive by default so a stray paste doesn't wipe
+# a working install — Confirm-Remove gates each major delete. -Force
+# (passed at param parse time) skips every prompt, which is what CI / a
+# scripted teardown wants.
+
+function Confirm-Remove([string]$what) {
+    if ($Force) { return $true }
+    # PowerShell's Host.UI prompt handles non-interactive shells (e.g.
+    # piped from `irm | iex` in some hosts) by reading from stdin —
+    # which is the same channel the script body was just piped through.
+    # Fall back to treating an empty / non-y response as "no" so the
+    # default is safe.
+    $resp = Read-Host "Remove $what ? [y/N]"
+    return ($resp -match '^(y|yes)$')
+}
+
+# ---------- Main -----------------------------------------------------------
+
+Write-Step "cua-driver-rs uninstaller (Windows)"
+Write-Step "  bin dir     : $VisibleBinDir"
+Write-Step "  package home: $HomeDir"
+Write-Host ""
+
+# 1. Scheduled Task autostart (registered by `cua-driver autostart enable`
+#    or install.ps1 -AutoStart). Idempotent — schtasks /Delete returns
+#    non-zero when the task is absent, which we swallow.
+$taskQuery = & schtasks.exe /Query /TN $AutoStartTask 2>$null
+if ($LASTEXITCODE -eq 0 -and $taskQuery) {
+    if (Confirm-Remove "scheduled task '$AutoStartTask' (autostart at logon)") {
+        & schtasks.exe /Delete /TN $AutoStartTask /F 2>$null | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Step "removed scheduled task $AutoStartTask"
+        } else {
+            Write-WarningStep "schtasks /Delete /TN $AutoStartTask returned $LASTEXITCODE"
+        }
+    } else {
+        Write-Step "skipped scheduled task $AutoStartTask (user declined)"
+    }
+} else {
+    Write-Step "no scheduled task '$AutoStartTask' registered (skipping)"
+}
+
+# 2. Running cua-driver.exe processes. The serve daemon and any active
+#    `cua-driver` invocation hold file handles to the binary, which
+#    pin the directory junction's target open and make Remove-Item
+#    fail with "in use". Stop them up front so subsequent deletes
+#    aren't racy.
+$running = @(Get-Process -Name "cua-driver" -ErrorAction SilentlyContinue)
+if ($running.Count -gt 0) {
+    Write-Step "stopping $($running.Count) running cua-driver.exe process(es)"
+    foreach ($p in $running) {
+        try {
+            Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue
+        } catch {
+            Write-WarningStep "could not stop pid $($p.Id): $($_.Exception.Message)"
+        }
+    }
+    # Brief pause so the kernel finishes tearing down the process and
+    # releases its file handles before we try to delete the binary dir.
+    Start-Sleep -Milliseconds 250
+} else {
+    Write-Step "no running cua-driver.exe processes"
+}
+
+# 3. Visible bin directory junction. Only remove when it's actually a
+#    reparse point — refuse to clobber a real directory the user might
+#    have at that path.
+if (Test-Path -LiteralPath $VisibleBinDir) {
+    if (Test-IsReparsePoint $VisibleBinDir) {
+        if (Confirm-Remove "directory junction $VisibleBinDir") {
+            # Remove-Item on a reparse point removes the reparse point
+            # itself, NOT the contents of the target. -Force is needed
+            # to delete a non-empty junction; -Recurse is harmless
+            # against a junction (we're removing the link, not the
+            # tree it points to).
+            Remove-Item -LiteralPath $VisibleBinDir -Force -Recurse -ErrorAction SilentlyContinue
+            Write-Step "removed junction $VisibleBinDir"
+        } else {
+            Write-Step "skipped $VisibleBinDir (user declined)"
+        }
+    } else {
+        Write-WarningStep "$VisibleBinDir exists but is not a reparse point — refusing to remove."
+        Write-WarningStep "  install.ps1 only creates junctions at this path, so this is likely a hand-managed directory."
+    }
+} else {
+    Write-Step "no junction at $VisibleBinDir (skipping)"
+}
+
+# 4. current\ directory junction inside the package home. Same
+#    reparse-point check as above — never clobber a real dir.
+if (Test-Path -LiteralPath $CurrentDir) {
+    if (Test-IsReparsePoint $CurrentDir) {
+        Remove-Item -LiteralPath $CurrentDir -Force -Recurse -ErrorAction SilentlyContinue
+        Write-Step "removed junction $CurrentDir"
+    } else {
+        Write-WarningStep "$CurrentDir exists but is not a reparse point — leaving it for the package-home pass below."
+    }
+}
+
+# 5. Entire package home ($HomeDir). Contains releases\, lockfile,
+#    telemetry id, install marker, version_check.json, and the now-
+#    removed current\ junction.
+if (Test-Path -LiteralPath $HomeDir) {
+    if (Confirm-Remove "package home tree $HomeDir (releases, lockfile, telemetry id, install marker)") {
+        # -Recurse -Force walks into every subdir and clears read-only
+        # bits. ErrorAction SilentlyContinue tolerates leftover handles
+        # (rare after step 2's process kill); we log a follow-up if
+        # anything survived.
+        Remove-Item -LiteralPath $HomeDir -Force -Recurse -ErrorAction SilentlyContinue
+        if (Test-Path -LiteralPath $HomeDir) {
+            Write-WarningStep "$HomeDir was not fully removed — some files may still be locked."
+            Write-WarningStep "  Close any open cua-driver processes / shells with cwd inside the tree and re-run."
+        } else {
+            Write-Step "removed $HomeDir"
+        }
+    } else {
+        Write-Step "skipped $HomeDir (user declined)"
+    }
+} else {
+    Write-Step "no package home at $HomeDir (skipping)"
+}
+
+# 6. Skill junctions. Only remove reparse points — leave a real dir
+#    in place (a user with a hand-managed cua-driver-rs skill dir
+#    gets to keep it). Same defensive shape as Linux/macOS.
+foreach ($skillLink in $SkillJunctions) {
+    if (Test-Path -LiteralPath $skillLink) {
+        if (Test-IsReparsePoint $skillLink) {
+            Remove-Item -LiteralPath $skillLink -Force -Recurse -ErrorAction SilentlyContinue
+            Write-Step "removed skill junction $skillLink"
+        } else {
+            Write-Step "$skillLink is a real directory (not a reparse point) — skipping"
+        }
+    } else {
+        Write-Step "no skill junction at $skillLink (skipping)"
+    }
+}
+
+# ---------- Closing message -----------------------------------------------
+
+Write-Host ""
+Write-Host "cua-driver-rs uninstalled." -ForegroundColor Green
+Write-Host ""
+Write-Host "Claude Code MCP registrations:" -ForegroundColor Yellow
+Write-Host "  We don't auto-edit ~/.claude.json on Windows. If you registered cua-driver-rs"
+Write-Host "  with Claude Code, remove it manually:"
+Write-Host ""
+Write-Host "    claude mcp remove cua-driver-rs"
+Write-Host ""
+Write-Host "  Or edit ~/.claude.json directly and delete entries whose 'command' points at"
+Write-Host "  cua-driver.exe under %LOCALAPPDATA%\Programs\trycua\cua-driver-rs\bin\."
+Write-Host ""
+Write-Host "PATH:"
+Write-Host "  If you added $VisibleBinDir to your User PATH after the install, remove it:"
+Write-Host ""
+Write-Host "    `$old = [Environment]::GetEnvironmentVariable('Path', 'User')"
+Write-Host "    `$new = ((`$old.Split(';')) | Where-Object { `$_ -and (`$_.TrimEnd('\') -ne '$($VisibleBinDir.TrimEnd('\'))') }) -join ';'"
+Write-Host "    [Environment]::SetEnvironmentVariable('Path', `$new, 'User')"
+Write-Host ""
+Write-Host "  Then open a new PowerShell window for the change to take effect."
+Write-Host ""

--- a/libs/cua-driver/scripts/uninstall.sh
+++ b/libs/cua-driver/scripts/uninstall.sh
@@ -1,17 +1,135 @@
 #!/usr/bin/env bash
-# cua-driver uninstaller. Removes everything install.sh laid down:
+# cua-driver uninstaller. Removes everything install.sh laid down — Swift
+# driver by default, cua-driver-rs (Rust port) when --experimental-rust /
+# --backend=rust is passed (mirrors install.sh's flag set), or auto-detects
+# the Rust port on non-macOS hosts (same as install.sh).
 #
+# Swift uninstall removes:
 #   - ~/.local/bin/cua-driver symlink
 #   - /Applications/CuaDriver.app bundle
 #   - ~/.cua-driver/ (telemetry id + install marker)
 #   - ~/Library/Application Support/Cua Driver/ (config.json)
 #   - ~/Library/Caches/cua-driver/ (daemon/cache state)
 #
-# Does NOT revoke TCC grants (Accessibility + Screen Recording).
+# Rust uninstall (--experimental-rust / --backend=rust / non-macOS) delegates
+# to a colocated private helper, _uninstall-rust.sh — see that script for
+# the full list of paths it removes.
+#
+# Does NOT revoke TCC grants (Accessibility + Screen Recording) on macOS.
+#
+# Flags:
+#   --experimental-rust  uninstall the cua-driver-rs (Rust port) backend
+#                        instead of the Swift binary. Delegates to
+#                        libs/cua-driver/scripts/_uninstall-rust.sh. The
+#                        Swift binary (if present) is left untouched.
+#                        Also accepted as --backend=rust.
+#   --backend=swift      explicit no-op default (Swift uninstall).
 #
 # Usage:
 #   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.sh)"
+#
+#   # cua-driver-rs (Rust port) — explicit opt-in on macOS:
+#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.sh)" -- --experimental-rust
+#
+#   # Linux auto-detects and removes the Rust port without any flag.
 set -euo pipefail
+
+# Rust-backend delegation target. The Rust uninstall logic is a private
+# helper script colocated with this one — _uninstall-rust.sh — so that
+# this directory holds the single user-facing uninstall.sh per platform.
+# `--experimental-rust` below either execs the on-disk helper (dev /
+# checked-out-tree case) or curls this URL and pipes it to bash
+# (`curl ... | bash` uninstall case). Mirrors install.sh's pattern.
+RUST_UNINSTALLER_URL="https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/_uninstall-rust.sh"
+
+# Lightweight flag parsing — same two-pass shape as install.sh so the
+# argv shapes stay bit-compatible across install/uninstall and a future
+# Rust-only flag added to _uninstall-rust.sh flows through here without
+# edits to this file.
+USE_RUST_BACKEND=0
+FORWARDED_ARGS=()
+PASSTHROUGH=0
+while [[ $# -gt 0 ]]; do
+    if [[ "$PASSTHROUGH" == "1" ]]; then
+        FORWARDED_ARGS+=("$1"); shift; continue
+    fi
+    case "$1" in
+        --experimental-rust) USE_RUST_BACKEND=1; shift ;;
+        --backend=rust)      USE_RUST_BACKEND=1; shift ;;
+        --backend=swift)     shift ;;                 # explicit default — no-op
+        --backend=*)
+            printf 'error: unknown backend %q; supported: swift, rust\n' "${1#*=}" >&2
+            exit 2
+            ;;
+        --)                  PASSTHROUGH=1; shift ;;  # forward the rest verbatim
+        *)                   FORWARDED_ARGS+=("$1"); shift ;;
+    esac
+done
+
+# --- Auto-delegate to Rust on non-macOS ---------------------------------
+#
+# The Swift binary is macOS-only — there's nothing for the Swift uninstall
+# path to remove on Linux. Auto-set USE_RUST_BACKEND=1 so a single
+# canonical URL works on every platform: `curl … cua-driver/scripts/
+# uninstall.sh | bash` removes the Swift driver on macOS (today's default)
+# and the Rust port on Linux. macOS users who want to remove the Rust
+# port still pass `--experimental-rust` / `--backend=rust` explicitly.
+AUTO_RUST=0
+if [[ "$USE_RUST_BACKEND" == "0" && "$(uname -s 2>/dev/null)" != "Darwin" ]]; then
+    USE_RUST_BACKEND=1
+    AUTO_RUST=1
+    printf 'note: detected non-macOS host (%s); auto-selecting the cua-driver-rs Rust uninstall.\n' \
+        "$(uname -s 2>/dev/null || echo unknown)" >&2
+    printf '      Pass --backend=swift to force the Swift uninstall path (will be a no-op on non-Darwin).\n' >&2
+fi
+
+# --- Optional delegation to the experimental Rust backend ---------------
+#
+# If the user opted in with --experimental-rust / --backend=rust, hand the
+# rest of argv to _uninstall-rust.sh and exit. The Swift uninstall path
+# below is never touched in this case, so the Swift binary (if present)
+# is left exactly as-is.
+if [[ "$USE_RUST_BACKEND" == "1" ]]; then
+    if [[ "$AUTO_RUST" == "0" ]]; then
+        # Explicit opt-in on macOS.
+        printf 'note: uninstalling cua-driver-rs (Rust port). The Swift binary won'"'"'t be touched.\n' >&2
+    else
+        # Auto-selected on Linux/other — drop the "experimental" qualifier
+        # (Rust is the canonical install path on every non-macOS platform).
+        printf 'note: uninstalling cua-driver-rs (the Rust port — canonical on non-macOS).\n' >&2
+    fi
+
+    # Prefer the on-disk copy when this script is running from a checked-out
+    # tree (dev / CI). Falls back to curling the canonical URL for the
+    # `curl ... | bash` uninstall path, where $BASH_SOURCE is unset / -.
+    LOCAL_RUST_UNINSTALLER=""
+    if [[ -n "${BASH_SOURCE[0]:-}" && "${BASH_SOURCE[0]}" != "-" && -f "${BASH_SOURCE[0]}" ]]; then
+        SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+        CANDIDATE="$SCRIPT_DIR/_uninstall-rust.sh"
+        if [[ -f "$CANDIDATE" ]]; then
+            LOCAL_RUST_UNINSTALLER="$CANDIDATE"
+        fi
+    fi
+
+    # macOS ships bash 3.2, which trips `set -u` when expanding an empty
+    # array via "${arr[@]}" — guard with the +alt-value pattern so the
+    # zero-arg case becomes a literal no-expansion.
+    if [[ -n "$LOCAL_RUST_UNINSTALLER" ]]; then
+        exec /bin/bash "$LOCAL_RUST_UNINSTALLER" ${FORWARDED_ARGS[@]+"${FORWARDED_ARGS[@]}"}
+    else
+        if ! command -v curl >/dev/null 2>&1; then
+            printf 'error: curl not found on PATH; cannot fetch %s\n' "$RUST_UNINSTALLER_URL" >&2
+            exit 1
+        fi
+        # `exec` so the Rust uninstaller replaces this process — we don't
+        # want to fall through to the Swift uninstall path on any error here.
+        RUST_UNINSTALLER_SCRIPT="$(curl -fsSL "$RUST_UNINSTALLER_URL")" || {
+            printf 'error: failed to download Rust uninstaller from %s\n' "$RUST_UNINSTALLER_URL" >&2
+            exit 1
+        }
+        exec /bin/bash -c "$RUST_UNINSTALLER_SCRIPT" cua-driver-rs-uninstall ${FORWARDED_ARGS[@]+"${FORWARDED_ARGS[@]}"}
+    fi
+fi
 
 USER_BIN_LINK="$HOME/.local/bin/cua-driver"
 SYSTEM_BIN_LINK="/usr/local/bin/cua-driver"


### PR DESCRIPTION
## Summary

Mirrors the install-convergence work (#1556, #1557) for the uninstall side. After this PR, **one canonical uninstall URL works on every platform**, with the same flag set as `install.sh`:

| Platform | Backend | Command |
|---|---|---|
| macOS | Swift (default) | `bash -c "$(curl -fsSL .../libs/cua-driver/scripts/uninstall.sh)"` |
| macOS | Rust port (`cua-driver-rs`) | `bash -c "$(curl -fsSL .../libs/cua-driver/scripts/uninstall.sh)" -- --experimental-rust` |
| Linux | Rust port (auto-detected — Swift binary is macOS-only) | `bash -c "$(curl -fsSL .../libs/cua-driver/scripts/uninstall.sh)"` |
| Windows | Rust port | `irm .../libs/cua-driver/scripts/uninstall.ps1 \| iex` |

Before this PR the Rust port had **no uninstall script** and Windows had **no uninstall script at all** — we just confirmed on a real macOS box that removing the Rust port required manual `rm -rf /Applications/CuaDriverRs.app` + `rm -rf ~/.cua-driver-rs/`. This was the obvious gap left after #1556 / #1557 converged the install side.

## What this PR does

| Layer | Before | After |
|---|---|---|
| `libs/cua-driver/scripts/uninstall.sh` | Swift-only, errored out on Linux | Adds `--experimental-rust` / `--backend=rust` / `--backend=swift` flag handling (mirrors `install.sh` byte-for-byte). Auto-flips `USE_RUST_BACKEND=1` on `uname -s != Darwin`. Same `FORWARDED_ARGS` bucket so future Rust-only uninstall flags pass through cleanly. Swift uninstall path is bit-identical when no flag is passed. |
| `libs/cua-driver/scripts/_uninstall-rust.sh` | Did not exist | **New** private helper, colocated with `_install-rust.sh`. Removes everything the Rust install laid down (per-platform; see "What gets removed" below). |
| `libs/cua-driver/scripts/uninstall.ps1` | Did not exist | **New** Windows uninstaller. Mirrors `install.ps1`'s variable naming + path resolution. Stops the `cua-driver-serve` scheduled task, kills running `cua-driver.exe` processes, removes the bin/current junctions and the entire `~/.cua-driver-rs/` tree, and removes skill junctions (only when they're actually reparse points). |
| `.github/workflows/cd-rust-cua-driver.yml` | Staged only the install scripts | Now also stages `uninstall.sh`, `uninstall.ps1`, and `_uninstall-rust.sh` as per-tag release assets, alongside the install scripts. |
| `docs/.../installation.mdx` | Manual `rm -rf` recipe | Replaced with the canonical one-liners + per-platform / per-backend table of what gets removed + safety-invariant + Windows interactive-by-default callouts. |

## What gets removed

| Backend | Symlink / bin | App bundle / package home | Autostart entry | Skill links | Claude MCP |
|---|---|---|---|---|---|
| **Swift (macOS)** — unchanged | `~/.local/bin/cua-driver`, `/usr/local/bin/cua-driver` (legacy) | `/Applications/CuaDriver.app`, `~/.cua-driver`, `~/Library/Application Support/Cua Driver`, `~/Library/Caches/cua-driver` | `~/Library/LaunchAgents/com.trycua.cua_driver_updater.plist` (legacy ≤ 0.0.5) | `cua-driver` symlinks under `~/.claude/skills`, `~/.agents/skills`, `~/.openclaw/skills`, `~/.config/opencode/skills` | Scrubbed from `~/.claude.json` |
| **Rust — macOS** | `~/.local/bin/cua-driver` *(only when it resolves into `CuaDriverRs.app`)* | `/Applications/CuaDriverRs.app`, `~/.cua-driver-rs/` (entire tree) | `~/Library/LaunchAgents/com.trycua.cua-driver-rs.plist` | `cua-driver-rs` symlinks under the same agent dirs | Scrubbed from `~/.claude.json` |
| **Rust — Linux** | `~/.local/bin/cua-driver` *(when it resolves into `~/.cua-driver-rs/`)* | `~/.cua-driver-rs/` (entire tree) | `~/.config/systemd/user/cua-driver-rs.service` (stop + disable + remove) | Same as above | Scrubbed from `~/.claude.json` |
| **Rust — Windows** | `%LOCALAPPDATA%\Programs\trycua\cua-driver-rs\bin` *(directory junction)* | `%USERPROFILE%\.cua-driver-rs\` (entire tree — releases, current junction, lockfile, telemetry id, install marker) | Scheduled Task `cua-driver-serve` (`schtasks /Delete`) + kill running `cua-driver.exe` processes | Junctions under `%USERPROFILE%\.claude\skills`, `.agents\skills`, `.openclaw\skills`, `%APPDATA%\opencode\skills` | Not auto-edited — closing message prints `claude mcp remove cua-driver-rs` |

## Safety invariants

- **`[[ -L ]]` / reparse-point gating before every delete.** Linux/macOS check `[[ -L ]]`; Windows checks `IO_REPARSE_TAG_MOUNT_POINT` via `Get-Item .Attributes`. A user with a hand-managed `cua-driver-rs` dir at any of these paths keeps theirs untouched.
- **`realpath`-based symlink target check on the bin symlink** before removing — refuses to clobber a Swift-driver `~/.local/bin/cua-driver` when the Rust uninstall runs.
- **Idempotent.** Re-running an uninstall on an already-clean system prints `nothing to remove` per item, never errors. Verified by running each path twice locally on macOS.
- **`set -euo pipefail`** on both `.sh` scripts (mirrors `_install-rust.sh`).

## What this PR does NOT do

- **Auto-revoke TCC grants on macOS.** Same conservative stance as the existing Swift uninstall — the closing message prints the `tccutil reset Accessibility/ScreenCapture` commands for both `com.trycua.driver` (Swift) and `com.trycua.cuadriverrs` (Rust). One paste away from a clean re-install flow.
- **Auto-edit `%USERPROFILE%\.claude.json` on Windows.** Mirrors the macOS uninstall's stance for hosts without `python3` — closing message prints `claude mcp remove cua-driver-rs` for the user to run.
- **Auto-remove the user's PATH entry on Windows.** The install script never auto-edits PATH (it prints the command instead); uninstall does the same — the closing message prints an exact `[Environment]::SetEnvironmentVariable` snippet.

## Test plan

Validated on a real macOS box (M-series, working dev tree):

- [x] `uninstall.sh` (no flag) → Swift uninstall, idempotent across re-runs.
- [x] `uninstall.sh --experimental-rust` → removes `/Applications/CuaDriverRs.app` + `~/.cua-driver-rs/` cleanly; Swift binary at `/Applications/CuaDriver.app` untouched.
- [x] `uninstall.sh --backend=rust` (long form) → behaves identically to `--experimental-rust`.
- [x] `uninstall.sh --backend=foo` → exits 2 with `error: unknown backend foo; supported: swift, rust`.
- [x] Linux auto-detection — verified via a fake `uname -s = Linux` shim: prints the auto-select note, skips macOS-only paths (LaunchAgent, `/Applications/CuaDriverRs.app`), runs the Linux systemd cleanup branch.
- [x] Re-run each path on an already-clean host — every item prints `(skipping)`, exit 0.
- [x] `bash -n` syntax-check passes on both new scripts.

To validate before merge (need a live host for each):

- [ ] **Linux end-to-end:** `curl …/libs/cua-driver/scripts/uninstall.sh | bash` on a Linux box with cua-driver-rs installed (incl. via `install-local.sh --autostart` so the systemd unit branch fires).
- [ ] **Windows end-to-end:** `irm …/libs/cua-driver/scripts/uninstall.ps1 | iex` on a Windows VM with `install.ps1 -AutoStart` already run. Verify the scheduled task is removed, the bin/current junctions are gone, and `~/.cua-driver-rs/` is empty.
- [ ] **Windows `-Force` flag:** non-interactive run with `& ([scriptblock]::Create((irm …))) -Force` — confirm no prompts.
- [ ] **Windows: real directory at the bin path** (not a junction) — verify the script refuses to clobber it with the documented warning.
- [ ] **macOS: `~/.local/bin/cua-driver` pointing at the Swift binary while running the Rust uninstall** — verify the symlink is left in place (Swift-binary safety invariant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-platform uninstall support with platform-specific uninstallers (macOS, Linux, Windows) and optional forced/scripted cleanup.
  * Introduced a Rust-backend uninstaller and automatic backend selection/delegation on non-macOS hosts.

* **Documentation**
  * Installation guide updated with detailed, platform/backend-specific uninstall steps, a cleanup matrix, and macOS/Windows notes for permission and MCP cleanup.

* **Chores**
  * Release assets and release notes now include uninstall script artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->