### PR TITLE
fix(uninstall): stop running cua-driver daemon before removing the binary (macOS/Linux)

### DIFF
--- a/docs/content/docs/cua-driver/guide/getting-started/installation.mdx
+++ b/docs/content/docs/cua-driver/guide/getting-started/installation.mdx
@@ -557,6 +557,10 @@ One canonical uninstall URL per platform mirrors the install side. Flag handling
 </Callout>
 
 <Callout type="info">
+**The uninstall scripts stop running `cua-driver` processes before removing the binary.** Unix (and Windows) keep `mmap`'d binary pages alive in open processes, so `rm -rf /Applications/CuaDriver.app` while the daemon is running leaves a zombie executing from a now-deleted path — its next AX request will cite the deleted path in macOS authorization dialogs. The scripts run `cua-driver stop` first (clean shutdown via the daemon's Unix socket), then `pkill -f "cua-driver mcp"` / `pkill -f "cua-driver serve"` (macOS / Linux) or `Stop-Process` (Windows) as a belt-and-suspenders cleanup.
+</Callout>
+
+<Callout type="info">
 **TCC grants persist on macOS** (Accessibility + Screen Recording). The uninstaller leaves them in **System Settings → Privacy & Security** so a re-install doesn't have to re-prompt. To reset them explicitly:
 
 ```bash

--- a/libs/cua-driver/scripts/_uninstall-rust.sh
+++ b/libs/cua-driver/scripts/_uninstall-rust.sh
@@ -8,6 +8,16 @@
 # Mirrors _install-rust.sh's on-disk knowledge — removes everything the
 # install script laid down:
 #
+# Daemon-kill step (both platforms, runs first):
+#   - `cua-driver stop` to ask the daemon to shut down cleanly via its
+#     Unix-domain socket, then `pkill -f "cua-driver mcp"` and
+#     `pkill -f "cua-driver serve"` as a belt-and-suspenders cleanup.
+#     Required because Unix keeps mmap'd binary pages alive in open
+#     processes: removing the .app / packages dir while the daemon is
+#     running leaves a zombie executing from a deleted path until next
+#     launch, which surfaces as confusing TCC dialogs ("authorize the
+#     app at <deleted-path>") on the next CLI invocation.
+#
 # Linux:
 #   - ~/.local/bin/cua-driver symlink (only when it resolves to a
 #     cua-driver-rs path — a Swift-driver symlink is left in place)
@@ -76,6 +86,36 @@ resolve_link() {
         *)  printf '%s/%s' "$(cd -- "$(dirname -- "$link")" && pwd)" "$target" ;;
     esac
 }
+
+# --- Stop running daemon ------------------------------------------------
+#
+# Unix keeps mmap'd binary pages alive in open processes, so removing
+# /Applications/CuaDriver.app (macOS) or $HOME_DIR/packages/... (Linux)
+# while the daemon is running leaves a zombie executing from a now-
+# deleted binary path. The next AX/CGS call from the still-running
+# daemon then cites the deleted path in macOS authorization dialogs
+# (observed live with cua-driver-rs 0.2.3 → 0.2.4 upgrade). Stop the
+# daemon first, then belt-and-suspenders `pkill` any survivors.
+#
+# Best-effort: missing daemon / missing CLI is a no-op. Mirrors the
+# Windows Stop-Process block in uninstall.ps1 and the Swift uninstall.sh.
+if command -v cua-driver >/dev/null 2>&1; then
+    if cua-driver stop >/dev/null 2>&1; then
+        log "stopped running cua-driver daemon via 'cua-driver stop'"
+    fi
+fi
+if command -v pkill >/dev/null 2>&1; then
+    # Match the full command line (`-f`) so a shell cd'd into a directory
+    # named "cua-driver" isn't caught. `cua-driver mcp` covers the
+    # foreground MCP server (spawned by an editor / agent); `cua-driver
+    # serve` covers the background daemon.
+    if pkill -f "cua-driver mcp" >/dev/null 2>&1; then
+        log "killed surviving 'cua-driver mcp' process(es)"
+    fi
+    if pkill -f "cua-driver serve" >/dev/null 2>&1; then
+        log "killed surviving 'cua-driver serve' process(es)"
+    fi
+fi
 
 # --- CLI symlink ---------------------------------------------------------
 #

--- a/libs/cua-driver/scripts/uninstall.sh
+++ b/libs/cua-driver/scripts/uninstall.sh
@@ -5,6 +5,10 @@
 # the Rust port on non-macOS hosts (same as install.sh).
 #
 # Swift uninstall removes:
+#   - any running cua-driver daemon (clean shutdown via `cua-driver stop`,
+#     then `pkill` survivors — Unix keeps mmap'd binary pages alive in
+#     open processes, so removing the .app while the daemon is running
+#     leaves a zombie executing from a deleted path until next launch)
 #   - ~/.local/bin/cua-driver symlink
 #   - /Applications/CuaDriver.app bundle
 #   - ~/.cua-driver/ (telemetry id + install marker)
@@ -13,7 +17,7 @@
 #
 # Rust uninstall (--experimental-rust / --backend=rust / non-macOS) delegates
 # to a colocated private helper, _uninstall-rust.sh — see that script for
-# the full list of paths it removes.
+# the full list of paths it removes. Same daemon-kill step runs there.
 #
 # Does NOT revoke TCC grants (Accessibility + Screen Recording) on macOS.
 #
@@ -142,6 +146,36 @@ LEGACY_UPDATE_SCRIPT="/usr/local/bin/cua-driver-update"
 LEGACY_UPDATER_PLIST="$HOME/Library/LaunchAgents/com.trycua.cua_driver_updater.plist"
 
 log() { printf '==> %s\n' "$*"; }
+
+# --- Stop running daemon ------------------------------------------------
+#
+# Unix keeps mmap'd binary pages alive in open processes, so `rm -rf
+# /Applications/CuaDriver.app` while the daemon is running leaves a
+# zombie executing from a now-deleted binary path. The next `cua-driver`
+# CLI command (or any AX request the still-running daemon makes) cites
+# the deleted path, which surfaces as confusing TCC dialogs and stale
+# state. Stop the daemon first, then belt-and-suspenders `pkill` any
+# survivors before we touch the .app bundle.
+#
+# Best-effort: missing daemon / missing CLI is a no-op. Mirrors the
+# Windows Stop-Process block in uninstall.ps1.
+if command -v cua-driver >/dev/null 2>&1; then
+    if cua-driver stop >/dev/null 2>&1; then
+        log "stopped running cua-driver daemon via 'cua-driver stop'"
+    fi
+fi
+if command -v pkill >/dev/null 2>&1; then
+    # Two separate matchers — `cua-driver mcp` (foreground MCP server
+    # spawned by an editor / agent) and `cua-driver serve` (background
+    # daemon). pkill -f matches the full command line, so e.g. a shell
+    # cd'd into a "cua-driver" directory isn't caught.
+    if pkill -f "cua-driver mcp" >/dev/null 2>&1; then
+        log "killed surviving 'cua-driver mcp' process(es)"
+    fi
+    if pkill -f "cua-driver serve" >/dev/null 2>&1; then
+        log "killed surviving 'cua-driver serve' process(es)"
+    fi
+fi
 
 # CLI symlinks. Try the user-bin first (no sudo), then the legacy
 # /usr/local/bin path (needs sudo on default macOS).


### PR DESCRIPTION
## Summary

Both Unix uninstall scripts (`uninstall.sh` for Swift, `_uninstall-rust.sh` for Rust) now stop any running `cua-driver` daemon before removing the binary. The Windows `uninstall.ps1` already does this — this PR brings macOS / Linux to parity.

## Problem (observed live today, cua-driver-rs 0.2.3 → 0.2.4)

Unix keeps `mmap`'d binary pages alive in open processes. So when `uninstall.sh` (or its Rust helper) ran `rm -rf /Applications/CuaDriverRs.app` while the v0.2.3 daemon was still running:

- The daemon kept executing from the now-deleted binary path.
- Its next AX request cited the **deleted** `/Applications/CuaDriverRs.app/Contents/MacOS/cua-driver` in the macOS authorization dialog.
- The user ended up authorizing a path that no longer existed on disk, while the freshly installed v0.2.4 binary at `/Applications/CuaDriver.app/...` was left ungranted.

Same hazard exists for the Swift `uninstall.sh` — there's nothing Rust-specific about the underlying Unix `mmap` behaviour.

## Before / after

**Before** (`uninstall.sh`, Swift backend, macOS):
```bash
# (no daemon stop)
rm -rf /Applications/CuaDriver.app
# daemon still running, pinned to a deleted path
```

**After:**
```bash
cua-driver stop                          # clean shutdown via the daemon's Unix socket
pkill -f "cua-driver mcp"                # belt + suspenders
pkill -f "cua-driver serve"              # belt + suspenders
rm -rf /Applications/CuaDriver.app
```

## Files changed

| File | Change |
|---|---|
| `libs/cua-driver/scripts/uninstall.sh` | Swift backend path — adds a daemon-stop block (`cua-driver stop` + `pkill -f "cua-driver mcp"` + `pkill -f "cua-driver serve"`) right after the var declarations, before any `rm -rf`. Best-effort: `command -v cua-driver` / `command -v pkill` guards so the missing-CLI case is a silent no-op. Header preamble updated to document the new step. |
| `libs/cua-driver/scripts/_uninstall-rust.sh` | Rust backend path — same daemon-stop block, inserted before the CLI-symlink / autostart / app-bundle / package-home removal. Mirrors the wording + log lines of `uninstall.sh` byte-for-byte. Header preamble updated. |
| `docs/content/docs/cua-driver/guide/getting-started/installation.mdx` | One-callout addition to the Uninstall section noting the new daemon-kill step. |

## Safety / idempotency

- `command -v cua-driver` / `command -v pkill` guards — missing CLI is a no-op, no error.
- `cua-driver stop` exits non-zero when no daemon is listening; we redirect both streams (`>/dev/null 2>&1`) and gate the `log` line on success only.
- `pkill -f "..."` exits non-zero (1) when no matches; same suppression pattern. No surface noise on a clean system.
- `pkill -f` matches the full command line, so a shell `cd`'d into a directory named `cua-driver` isn't caught — only actual `cua-driver mcp` / `cua-driver serve` invocations.
- Re-running uninstall on an already-clean system stays exit-0 silent.
- `set -euo pipefail` preserved; verified `bash -n` syntax-clean.

## Test plan

Validated on macOS (M-series, working dev tree):

- [x] `bash -n` clean on both `uninstall.sh` and `_uninstall-rust.sh`.
- [x] Daemon-stop block in isolation against a host with no daemon running — exit 0, no stderr noise.
- [x] Daemon-stop block in isolation with `cua-driver` not on `PATH` — exit 0 (guard works).

To validate manually before merge (need a live host with a running daemon):

- [ ] **macOS — Swift uninstall path:** install Swift driver, run `cua-driver mcp` in another shell to spawn a daemon, run `uninstall.sh`, verify (a) the daemon process is dead (`pgrep -f "cua-driver mcp"` empty), (b) `/Applications/CuaDriver.app` is gone, (c) no stale TCC dialog citing the deleted path.
- [ ] **macOS — Rust uninstall path:** same flow with `--experimental-rust` against a `cua-driver-rs` install.
- [ ] **macOS — re-run** the uninstall on the same now-clean host — should be exit-0 silent (no daemon to stop, no .app to remove).

Linux validation not run for this PR — the change is pure Unix `pkill` / socket-stop semantics and there's no Linux-specific code, but flagging this honestly.

## What this PR does NOT do

- **Doesn't touch the Windows uninstall.ps1** — it already had the right behaviour (`Get-Process cua-driver | Stop-Process -Force` before the bin-dir removal).
- **Doesn't change TCC behaviour.** Same conservative stance — uninstall still leaves the TCC grants alone for re-install convenience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated uninstall documentation explaining the daemon shutdown process during removal.

* **Bug Fixes**
  * Improved uninstallation to properly stop the daemon and related processes before removing files, preventing the daemon from continuing to run from deleted paths on macOS.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->