### PR TITLE
fix(cua-driver-rs): drop bogus window-enum fallback in screen-recording probe

### DIFF
--- a/libs/cua-driver-rs/Cargo.lock
+++ b/libs/cua-driver-rs/Cargo.lock
@@ -242,12 +242,13 @@ dependencies = [
 
 [[package]]
 name = "cua-driver"
-version = "0.2.1"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64",
  "cursor-overlay",
+ "flate2",
  "image",
  "libc",
  "mcp-server",
@@ -257,17 +258,19 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "tar",
  "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "ureq",
  "uuid",
+ "wait-timeout",
 ]
 
 [[package]]
 name = "cursor-overlay"
-version = "0.2.1"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "image",
@@ -371,6 +374,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,7 +407,7 @@ checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
 name = "focus-monitor-win"
-version = "0.2.1"
+version = "0.2.4"
 dependencies = [
  "windows",
 ]
@@ -831,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-server"
-version = "0.2.1"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1117,7 +1130,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "platform-linux"
-version = "0.2.1"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1136,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "platform-macos"
-version = "0.2.1"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1166,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "platform-windows"
-version = "0.2.1"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1673,6 +1686,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2114,6 +2137,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/libs/cua-driver-rs/crates/platform-macos/src/permissions/status.rs
+++ b/libs/cua-driver-rs/crates/platform-macos/src/permissions/status.rs
@@ -24,14 +24,15 @@ impl PermissionsStatus {
 }
 
 /// Read the live TCC status for both required grants.  Cheap to call
-/// repeatedly — `AXIsProcessTrusted` is a quick C function and the
-/// screen recording probe falls back to the window-enumeration heuristic
-/// when `CGPreflightScreenCaptureAccess` reports false.
+/// repeatedly — both probes are quick C-level calls into the system
+/// TCC daemon.
 ///
 /// Mirrors Swift `Permissions.currentStatus()`.  Difference: Swift uses
 /// `SCShareableContent.excludingDesktopWindows` (ScreenCaptureKit) for
 /// the screen recording probe, which is unavailable from Rust without
-/// large bindings — same caveat documented in `check_permissions.rs`.
+/// large bindings.  `CGPreflightScreenCaptureAccess` is Apple's
+/// documented preflight API for the same grant and is accurate on
+/// macOS 11+.
 pub fn current_status() -> PermissionsStatus {
     PermissionsStatus {
         accessibility: accessibility_granted(),
@@ -44,18 +45,25 @@ pub fn accessibility_granted() -> bool {
     unsafe { crate::ax::bindings::AXIsProcessTrusted() }
 }
 
-/// Best-effort screen recording probe.  Uses `CGPreflightScreenCaptureAccess`
-/// then falls back to the window-enumeration heuristic for parity with
-/// the existing `check_permissions` tool — see that file for rationale.
+/// Live Screen Recording grant state — `CGPreflightScreenCaptureAccess()`.
+///
+/// This is the only probe.  Earlier versions fell back to
+/// `!all_windows().is_empty()` when preflight returned false, on the
+/// theory that `CGWindowListCopyWindowInfo` returning real windows
+/// implied the grant was active.  That theory is wrong:
+/// `CGWindowListCopyWindowInfo` returns window IDs and bounds for **any**
+/// process without requiring the Screen Recording grant — only window
+/// titles are gated.  The fallback therefore returned `true` on any
+/// populated desktop regardless of grant state, which (a) made
+/// `check_permissions` report a false positive after `tccutil reset
+/// ScreenCapture com.trycua.driver`, and (b) short-circuited the
+/// startup permissions gate's prompt for users who had never granted SR.
 pub fn screen_recording_granted() -> bool {
     #[link(name = "CoreGraphics", kind = "framework")]
     extern "C" {
         fn CGPreflightScreenCaptureAccess() -> bool;
     }
-    if unsafe { CGPreflightScreenCaptureAccess() } {
-        return true;
-    }
-    !crate::windows::all_windows().is_empty()
+    unsafe { CGPreflightScreenCaptureAccess() }
 }
 
 /// Raise the Accessibility TCC prompt if not yet granted.  No-op when


### PR DESCRIPTION
## Summary

`permissions::status::screen_recording_granted()` had a heuristic fallback when `CGPreflightScreenCaptureAccess` returned false: `!crate::windows::all_windows().is_empty()`. The theory was that getting non-empty results from `CGWindowListCopyWindowInfo` implied the Screen Recording grant was active. That theory is wrong — `CGWindowListCopyWindowInfo` returns window IDs and bounds for any process **without** requiring the Screen Recording grant; only window **titles** are gated. So the fallback returned \`true\` on any populated desktop regardless of grant state.

Two user-visible bugs follow from this:

1. **\`check_permissions\` false positive after \`tccutil reset\`** — observed live: after \`tccutil reset ScreenCapture com.trycua.driver\` clears the SR row, the freshly-spawned daemon still reports \`screen_recording: true\`. This is half of #1561 — the SR half, anyway; the AX half is a separate concern (see below).
2. **Startup permissions gate skipped** — \`permissions::gate::run_if_needed\` short-circuits when \`status.all_granted()\` (\`gate.rs:213\`). With the bogus fallback, users who had never granted SR would have the gate silently no-op on first \`cua-driver serve\` start, and only hit the failure inside \`screenshot\` / \`record\` tool calls later.

The fix is to remove the fallback entirely and trust \`CGPreflightScreenCaptureAccess\` — Apple's documented preflight API for this grant, accurate on macOS 11+.

## Files changed

- \`libs/cua-driver-rs/crates/platform-macos/src/permissions/status.rs\` — strip the \`all_windows()\` fallback in \`screen_recording_granted()\`; expand the doc-comment to record the rationale so the heuristic doesn't get re-introduced.
- \`libs/cua-driver-rs/Cargo.lock\` — refreshed to match the v0.2.4 workspace version (the \`release-bump-version.yml\` workflow didn't update the lock when it bumped \`Cargo.toml\`; \`cargo check\` on this branch catches that up). No new direct deps; only the workspace package version + transitive dep additions that were already present in \`crates/cua-driver/Cargo.toml\` (\`tar\`, \`flate2\` from the skills tarball reader).

## On the AX side of #1561

The umbrella issue (#1561) reported that **both** \`accessibility\` and \`screen_recording\` come back \`true\` after \`tccutil reset\`. The SR side is a probe bug, fixed here. The AX side is a TCC attribution question: \`AXIsProcessTrusted()\` is the right API, but TCC attributes shell-invoked CLI processes to the parent terminal — so any shell that already has AX granted (Terminal, Claude Code, iTerm) will make \`cua-driver check_permissions\` see \`accessibility: true\` no matter what \`com.trycua.driver\` has in TCC. That's a fundamentally separate problem from this fix; tracking it on #1561.

## Test plan

- [x] \`cargo check -p platform-macos\` — clean, no new warnings on the changed file
- [x] Reproduced original bug on installed v0.2.4: \`tccutil reset ScreenCapture com.trycua.driver\` then \`cua-driver check_permissions '{\"prompt\":false}'\` → \`screen_recording: true\` (BUG)
- [x] Debug binary built from this branch ran against shell-attributed process (shell has SR) → \`true\` (correct: shell-attributed probe sees real shell grant)
- [ ] End-to-end \`com.trycua.driver\`-attributed validation (run inside \`/Applications/CuaDriver.app\` after \`tccutil reset\`, expect \`false\`) — pending the released artifact, easiest to verify post-merge via the next CD-published \`cua-driver-rs\` build

## Related

- Issue: #1561
- Sibling: #1560 (\`fix(uninstall): stop running cua-driver daemon before removing the binary\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of Screen Recording permission detection on macOS 11+
  * Fixed an issue where the system could incorrectly report Screen Recording access as granted

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->