### PR TITLE
Default computer-server binding to localhost

### DIFF
--- a/changelog/2026-05-18.md
+++ b/changelog/2026-05-18.md
@@ -1,0 +1,5 @@
+### Highlights
+
+- **Computer server bind default** — `computer_server` now binds to `127.0.0.1`
+  by default. Use `--host 0.0.0.0` when the server needs to accept external
+  connections.

--- a/libs/python/computer-server/README.md
+++ b/libs/python/computer-server/README.md
@@ -32,9 +32,15 @@ python -m computer_server
 # Or with custom port
 python -m computer_server --port 8080
 
+# Allow external access explicitly
+python -m computer_server --host 0.0.0.0
+
 # With resolution scaling (useful for Retina displays or VMs)
 python -m computer_server --width 1512 --height 982
 ```
+
+By default the server binds to `127.0.0.1`. Deployments that need access from
+other hosts should pass `--host 0.0.0.0` or another explicit interface.
 
 This provides:
 

--- a/libs/python/computer-server/computer_server/cli.py
+++ b/libs/python/computer-server/computer_server/cli.py
@@ -30,7 +30,9 @@ def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
         help="Auto-detect and log the actual screen resolution at startup",
     )
     parser.add_argument(
-        "--host", default="0.0.0.0", help="Host to bind the server to (default: 0.0.0.0)"
+        "--host",
+        default="127.0.0.1",
+        help="Host to bind the server to (default: 127.0.0.1; use 0.0.0.0 for external access)",
     )
     parser.add_argument(
         "--port", type=int, default=8000, help="Port to bind the server to (default: 8000)"

--- a/libs/python/computer-server/computer_server/main.py
+++ b/libs/python/computer-server/computer_server/main.py
@@ -1342,4 +1342,4 @@ async def playwright_exec_endpoint(
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="127.0.0.1", port=8000)
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/libs/python/computer-server/computer_server/main.py
+++ b/libs/python/computer-server/computer_server/main.py
@@ -1342,4 +1342,4 @@ async def playwright_exec_endpoint(
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host="127.0.0.1", port=8000)

--- a/libs/python/computer-server/computer_server/server.py
+++ b/libs/python/computer-server/computer_server/server.py
@@ -35,7 +35,7 @@ class Server:
 
     def __init__(
         self,
-        host: str = "0.0.0.0",
+        host: str = "127.0.0.1",
         port: int = 8000,
         log_level: str = "info",
         ssl_keyfile: Optional[str] = None,
@@ -45,7 +45,8 @@ class Server:
         Initialize the server.
 
         Args:
-            host: Host to bind the server to
+            host: Host to bind the server to. Defaults to localhost; pass
+                "0.0.0.0" explicitly for external access.
             port: Port to bind the server to
             log_level: Logging level (debug, info, warning, error, critical)
             ssl_keyfile: Path to SSL private key file (for HTTPS)


### PR DESCRIPTION
## Summary
- change computer-server CLI and server wrapper defaults from `0.0.0.0` to `127.0.0.1`
- document explicit `--host 0.0.0.0` for deployments that need external access
- add a current changelog note for the default-bind change

## Testing
- static check confirmed defaults in `cli.py`, `server.py`, README, and changelog
- left `computer_server.main` direct script fallback unchanged to avoid expanding this PR; `python -m computer_server` uses the CLI entrypoint