### PR TITLE
fix(cua-driver): percent-encode non-ASCII paths in launch_app urls

### DIFF
--- a/libs/cua-driver/Package.swift
+++ b/libs/cua-driver/Package.swift
@@ -43,5 +43,9 @@ let package = Package(
             name: "FocusStealPreventerTests",
             dependencies: ["CuaDriverCore"]
         ),
+        .testTarget(
+            name: "URLResolverTests",
+            dependencies: ["CuaDriverCore"]
+        ),
     ]
 )

--- a/libs/cua-driver/Sources/CuaDriverCore/Apps/URLResolver.swift
+++ b/libs/cua-driver/Sources/CuaDriverCore/Apps/URLResolver.swift
@@ -27,28 +27,42 @@ import Foundation
 public func resolveLaunchURL(_ raw: String) -> URL? {
     guard !raw.isEmpty else { return nil }
 
-    // Detect explicit URL schemes (http / https / file).
-    if let schemeRange = raw.range(of: "://") {
-        let scheme = raw[raw.startIndex..<schemeRange.lowerBound].lowercased()
+    // Detect any URI scheme by looking for the first ':' that appears
+    // before any '/' — this correctly handles both "://" schemes
+    // (http, https, file) and single-colon schemes (about:, mailto:, etc.).
+    if let colon = raw.firstIndex(of: ":") {
+        let beforeColon = raw[raw.startIndex..<colon]
+        // RFC 3986: scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+        let isValidScheme = !beforeColon.isEmpty &&
+            beforeColon.range(of: "^[A-Za-z][A-Za-z0-9+.\\-]*$",
+                              options: .regularExpression) != nil
 
-        if scheme == "http" || scheme == "https" {
-            // Percent-encode non-ASCII so URL(string:) doesn't return nil.
-            if let encoded = raw.addingPercentEncoding(
-                withAllowedCharacters: .urlQueryAllowed),
-               let url = URL(string: encoded)
-            {
-                return url
+        if isValidScheme {
+            let scheme = beforeColon.lowercased()
+
+            if scheme == "http" || scheme == "https" {
+                // Percent-encode non-ASCII so URL(string:) doesn't return nil.
+                if let encoded = raw.addingPercentEncoding(
+                    withAllowedCharacters: .urlQueryAllowed),
+                   let url = URL(string: encoded)
+                {
+                    return url
+                }
+                return URL(string: raw)
             }
-            // Already encoded by caller — try as-is.
-            return URL(string: raw)
-        }
 
-        if scheme == "file" {
-            // Strip "file://" prefix, decode any existing percent-encoding,
-            // then re-encode via fileURLWithPath for a clean round-trip.
-            let pathPart = String(raw[schemeRange.upperBound...])
-            let decoded = pathPart.removingPercentEncoding ?? pathPart
-            return URL(fileURLWithPath: decoded).standardizedFileURL
+            if scheme == "file", let schemeRange = raw.range(of: "://") {
+                // Strip "file://" prefix, decode any existing percent-encoding,
+                // then re-encode via fileURLWithPath for a clean round-trip.
+                let pathPart = String(raw[schemeRange.upperBound...])
+                let decoded = pathPart.removingPercentEncoding ?? pathPart
+                return URL(fileURLWithPath: decoded).standardizedFileURL
+            }
+
+            // All other schemes (about:, mailto:, data:, etc.) — pass through
+            // as-is via URL(string:). NSWorkspace handles about:blank natively
+            // for browsers; other schemes are passed verbatim to LaunchServices.
+            return URL(string: raw)
         }
     }
 

--- a/libs/cua-driver/Sources/CuaDriverCore/Apps/URLResolver.swift
+++ b/libs/cua-driver/Sources/CuaDriverCore/Apps/URLResolver.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Resolves a caller-supplied string into a `URL` suitable for
+/// `NSWorkspace.open(_:withApplicationAt:configuration:)`.
+///
+/// This is extracted from `LaunchAppTool` so it can be unit-tested
+/// without spinning up the full MCP server stack.
+///
+/// ## Handling rules
+///
+/// - `http://` / `https://` — percent-encode non-ASCII before parsing.
+/// - `file://` — strip scheme, decode percent-encoding, rebuild via
+///   `URL(fileURLWithPath:)` so LaunchServices gets a clean path.
+/// - Plain paths (absolute or `~`-prefixed) — expand tilde, then build
+///   a `file://` URL via `URL(fileURLWithPath:)`.
+///
+/// ## Why `URL(fileURLWithPath:)` instead of `URL(string:)`
+///
+/// `URL(string:)` treats its argument as an already-encoded RFC 3986
+/// string and returns `nil` for bare non-ASCII characters (e.g. CJK
+/// paths like `/Users/me/器材控/file.key`).  `URL(fileURLWithPath:)`
+/// accepts a raw filesystem path and applies the necessary
+/// percent-encoding internally, producing a well-formed `file://` URL
+/// that LaunchServices can open without crashing the daemon.
+///
+/// Fixes: https://github.com/trycua/cua/issues/1519
+public func resolveLaunchURL(_ raw: String) -> URL? {
+    guard !raw.isEmpty else { return nil }
+
+    // Detect explicit URL schemes (http / https / file).
+    if let schemeRange = raw.range(of: "://") {
+        let scheme = raw[raw.startIndex..<schemeRange.lowerBound].lowercased()
+
+        if scheme == "http" || scheme == "https" {
+            // Percent-encode non-ASCII so URL(string:) doesn't return nil.
+            if let encoded = raw.addingPercentEncoding(
+                withAllowedCharacters: .urlQueryAllowed),
+               let url = URL(string: encoded)
+            {
+                return url
+            }
+            // Already encoded by caller — try as-is.
+            return URL(string: raw)
+        }
+
+        if scheme == "file" {
+            // Strip "file://" prefix, decode any existing percent-encoding,
+            // then re-encode via fileURLWithPath for a clean round-trip.
+            let pathPart = String(raw[schemeRange.upperBound...])
+            let decoded = pathPart.removingPercentEncoding ?? pathPart
+            return URL(fileURLWithPath: decoded).standardizedFileURL
+        }
+    }
+
+    // Plain path (absolute or tilde-prefixed).
+    // URL(fileURLWithPath:) correctly percent-encodes non-ASCII characters
+    // (CJK, Cyrillic, accented Latin, emoji, etc.).
+    let expanded = (raw as NSString).expandingTildeInPath
+    return URL(fileURLWithPath: expanded).standardizedFileURL
+}

--- a/libs/cua-driver/Sources/CuaDriverServer/Tools/LaunchAppTool.swift
+++ b/libs/cua-driver/Sources/CuaDriverServer/Tools/LaunchAppTool.swift
@@ -364,26 +364,10 @@ public enum LaunchAppTool {
     /// Resolve a caller-supplied url string into a `URL` suitable for
     /// `NSWorkspace.open(_:withApplicationAt:configuration:)`.
     ///
-    /// - `http://` / `https://` / `file://` passthrough as-is.
-    /// - Tilde-prefixed paths (`~/Downloads`) expand against the current
-    ///   user's home.
-    /// - Other strings are treated as file paths — absolute paths become
-    ///   `file://` URLs; relative paths resolve against the launcher's
-    ///   cwd, which is almost never meaningful for a GUI app, so in
-    ///   practice callers should always pass absolute or ~-prefixed
-    ///   paths.
-    ///
-    /// Returns `nil` only when the string can't be parsed into any URL
-    /// at all — realistically that's the empty string (handled upstream).
+    /// Delegates to `CuaDriverCore.resolveLaunchURL(_:)` — see that
+    /// function for the full encoding contract and CJK-safety rationale.
     private static func resolveLaunchURL(_ raw: String) -> URL? {
-        if let url = URL(string: raw),
-           let scheme = url.scheme?.lowercased(),
-           scheme == "http" || scheme == "https" || scheme == "file"
-        {
-            return url
-        }
-        let expanded = (raw as NSString).expandingTildeInPath
-        return URL(fileURLWithPath: expanded)
+        CuaDriverCore.resolveLaunchURL(raw)
     }
 
     private static func errorResult(_ message: String) -> CallTool.Result {

--- a/libs/cua-driver/Tests/URLResolverTests/URLResolverTests.swift
+++ b/libs/cua-driver/Tests/URLResolverTests/URLResolverTests.swift
@@ -89,11 +89,16 @@ final class URLResolverTests: XCTestCase {
     }
 
     func testAboutBlank() throws {
-        // about:blank is used by browsers — not a file/http/https scheme,
-        // so it falls through to the plain-path branch. Verify it doesn't crash.
-        // (NSWorkspace handles about:blank natively for browsers.)
-        let result = resolveLaunchURL("about:blank")
-        // We don't assert a specific value — just that it doesn't crash/throw.
-        _ = result
+        // about:blank is used by browsers — must preserve scheme semantics,
+        // not fall through to the file-path branch.
+        let url = try XCTUnwrap(resolveLaunchURL("about:blank"))
+        XCTAssertEqual(url.scheme, "about")
+        XCTAssertEqual(url.absoluteString, "about:blank")
+    }
+
+    func testMailtoScheme() throws {
+        // Other single-colon schemes must also pass through as-is.
+        let url = try XCTUnwrap(resolveLaunchURL("mailto:user@example.com"))
+        XCTAssertEqual(url.scheme, "mailto")
     }
 }

--- a/libs/cua-driver/Tests/URLResolverTests/URLResolverTests.swift
+++ b/libs/cua-driver/Tests/URLResolverTests/URLResolverTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import CuaDriverCore
+
+/// Regression tests for `resolveLaunchURL(_:)`.
+///
+/// Covers the CJK / non-ASCII crash reported in:
+/// https://github.com/trycua/cua/issues/1519
+final class URLResolverTests: XCTestCase {
+
+    // MARK: - CJK / non-ASCII paths (the bug)
+
+    func testCJKAbsolutePath() throws {
+        let url = try XCTUnwrap(resolveLaunchURL("/Users/me/器材控/templates/file.key"))
+        XCTAssertEqual(url.scheme, "file")
+        // Path must be percent-encoded — no raw CJK bytes in the URL string.
+        XCTAssertFalse(url.absoluteString.contains("器材控"),
+            "CJK characters must be percent-encoded in the URL string")
+        // But the decoded path must round-trip back to the original.
+        XCTAssertEqual(url.path, "/Users/me/器材控/templates/file.key")
+    }
+
+    func testCyrillicPath() throws {
+        let url = try XCTUnwrap(resolveLaunchURL("/Users/me/Документы/report.pdf"))
+        XCTAssertEqual(url.scheme, "file")
+        XCTAssertEqual(url.path, "/Users/me/Документы/report.pdf")
+    }
+
+    func testAccentedLatinPath() throws {
+        let url = try XCTUnwrap(resolveLaunchURL("/Users/héloïse/Documents/résumé.pdf"))
+        XCTAssertEqual(url.scheme, "file")
+        XCTAssertEqual(url.path, "/Users/héloïse/Documents/résumé.pdf")
+    }
+
+    func testEmojiPath() throws {
+        let url = try XCTUnwrap(resolveLaunchURL("/Users/me/🎵Music/track.mp3"))
+        XCTAssertEqual(url.scheme, "file")
+        XCTAssertEqual(url.path, "/Users/me/🎵Music/track.mp3")
+    }
+
+    // MARK: - ASCII paths (regression guard)
+
+    func testASCIIAbsolutePath() throws {
+        let url = try XCTUnwrap(resolveLaunchURL("/Users/me/Documents/file.pdf"))
+        XCTAssertEqual(url.scheme, "file")
+        XCTAssertEqual(url.path, "/Users/me/Documents/file.pdf")
+    }
+
+    func testTildePath() throws {
+        let url = try XCTUnwrap(resolveLaunchURL("~/Downloads/file.zip"))
+        XCTAssertEqual(url.scheme, "file")
+        XCTAssertFalse(url.path.hasPrefix("~"), "Tilde must be expanded")
+        XCTAssertTrue(url.path.hasSuffix("/Downloads/file.zip"))
+    }
+
+    // MARK: - Explicit file:// URLs
+
+    func testFileURLPassthrough() throws {
+        let url = try XCTUnwrap(resolveLaunchURL("file:///Users/me/file.pdf"))
+        XCTAssertEqual(url.scheme, "file")
+        XCTAssertEqual(url.path, "/Users/me/file.pdf")
+    }
+
+    func testFileURLWithCJK() throws {
+        // file:// URL with percent-encoded CJK — must round-trip correctly.
+        let encoded = "file:///Users/me/%E5%99%A8%E6%9D%90%E6%8E%A7/file.key"
+        let url = try XCTUnwrap(resolveLaunchURL(encoded))
+        XCTAssertEqual(url.scheme, "file")
+        XCTAssertEqual(url.path, "/Users/me/器材控/file.key")
+    }
+
+    // MARK: - HTTP / HTTPS URLs
+
+    func testHTTPURL() throws {
+        let url = try XCTUnwrap(resolveLaunchURL("https://example.com/path"))
+        XCTAssertEqual(url.scheme, "https")
+        XCTAssertEqual(url.host, "example.com")
+    }
+
+    func testHTTPURLWithNonASCII() throws {
+        // Non-ASCII in query string — must not crash or return nil.
+        let url = try XCTUnwrap(resolveLaunchURL("https://example.com/search?q=器材控"))
+        XCTAssertEqual(url.scheme, "https")
+    }
+
+    // MARK: - Edge cases
+
+    func testEmptyStringReturnsNil() {
+        XCTAssertNil(resolveLaunchURL(""))
+    }
+
+    func testAboutBlank() throws {
+        // about:blank is used by browsers — not a file/http/https scheme,
+        // so it falls through to the plain-path branch. Verify it doesn't crash.
+        // (NSWorkspace handles about:blank natively for browsers.)
+        let result = resolveLaunchURL("about:blank")
+        // We don't assert a specific value — just that it doesn't crash/throw.
+        _ = result
+    }
+}


### PR DESCRIPTION
Fixes #1519.

launch_app crashed the daemon when urls contained CJK / Cyrillic / accented characters (e.g. /Users/me/器材控/templates/file.key).

Root cause: resolveLaunchURL() used URL(string:) to detect the scheme, which returns nil for bare non-ASCII characters. The fallback URL(fileURLWithPath:) path was reached, but without .standardizedFileURL the resulting URL could carry unencoded bytes that LaunchServices rejected mid-request, disconnecting the daemon.

Fix:
- Extract resolveLaunchURL into CuaDriverCore/Apps/URLResolver.swift as a public function so it can be unit-tested independently.
- For plain file paths: use URL(fileURLWithPath:).standardizedFileURL, which correctly percent-encodes non-ASCII before handing to LaunchServices.
- For file:// URLs: strip scheme, decode existing percent-encoding, then re-encode via fileURLWithPath for a clean round-trip.
- For http/https URLs: addingPercentEncoding before URL(string:) so non-ASCII query params don't return nil.
- LaunchAppTool.resolveLaunchURL now delegates to the core function.

Tests (URLResolverTests):
- CJK absolute path (/Users/me/器材控/...)
- Cyrillic path
- Accented Latin path
- Emoji path
- ASCII path (regression guard)
- Tilde expansion
- file:// passthrough
- file:// with percent-encoded CJK
- http/https URLs
- Non-ASCII in HTTPS query string
- Empty string returns nil

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced URL resolution for app launching with improved support for non-ASCII characters (CJK, Cyrillic, emoji, and accented characters).
  * Improved file path handling including tilde expansion for filesystem paths.

* **Refactor**
  * Reorganized URL resolution logic into a dedicated utility for better maintainability.

* **Tests**
  * Added comprehensive test coverage for URL resolution across various character sets and URL formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->