### PR TITLE
fix(cua-driver-rs): warn + force prompt:false for check_permissions in CLI mode

### DIFF
--- a/libs/cua-driver-rs/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver-rs/crates/cua-driver/src/cli.rs
@@ -671,12 +671,12 @@ so permissions granted to CuaDriver.app may read as \"NOT granted\" here.\n\
 For authoritative results, start the daemon first: `cua-driver serve`, \
 then re-run this check."
         );
-        let mut coerced = json_args
-            .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
-        if let serde_json::Value::Object(ref mut map) = coerced {
-            map.insert("prompt".into(), serde_json::Value::Bool(false));
-        }
-        Some(coerced)
+        let mut map = match json_args {
+            Some(serde_json::Value::Object(m)) => m,
+            _ => serde_json::Map::new(),
+        };
+        map.insert("prompt".into(), serde_json::Value::Bool(false));
+        Some(serde_json::Value::Object(map))
     } else {
         json_args
     };

--- a/libs/cua-driver-rs/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver-rs/crates/cua-driver/src/cli.rs
@@ -649,6 +649,38 @@ pub fn run_call(
         process::exit(64);
     }
 
+    // `check_permissions` in-process is ONLY correct when the process is
+    // running from CuaDriver.app (the daemon). Any one-shot CLI spawned by
+    // an IDE terminal (VS Code, Cursor, Claude Code, etc.) inherits the
+    // IDE's TCC responsibility chain, so AXIsProcessTrusted() reads against
+    // the IDE's bundle — not com.trycua.driver — and may report stale or
+    // wrong results after `tccutil reset Accessibility com.trycua.driver`.
+    //
+    // If the daemon were up we would already have forwarded above; reaching
+    // this branch means no daemon is listening. Warn the user and force
+    // `prompt: false` — the tool's default would otherwise raise a TCC
+    // dialog attributed to the calling shell/IDE bundle, not CuaDriver.app,
+    // so the user would grant the wrong identity.
+    //
+    // Mirrors Swift CallCommand.swift lines 148-171.
+    let json_args = if tool == "check_permissions" {
+        eprintln!(
+            "⚠️  Not running inside the cua-driver daemon process. \
+Results may be inaccurate — TCC checks the calling process, not CuaDriver.app, \
+so permissions granted to CuaDriver.app may read as \"NOT granted\" here.\n\
+For authoritative results, start the daemon first: `cua-driver serve`, \
+then re-run this check."
+        );
+        let mut coerced = json_args
+            .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
+        if let serde_json::Value::Object(ref mut map) = coerced {
+            map.insert("prompt".into(), serde_json::Value::Bool(false));
+        }
+        Some(coerced)
+    } else {
+        json_args
+    };
+
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()

--- a/libs/cua-driver-rs/crates/platform-macos/src/permissions/status.rs
+++ b/libs/cua-driver-rs/crates/platform-macos/src/permissions/status.rs
@@ -41,6 +41,21 @@ pub fn current_status() -> PermissionsStatus {
 }
 
 /// Live AX trust state — `AXIsProcessTrusted()`.
+///
+/// ⚠️ Attribution caveat: when called from a CLI process spawned by a
+/// terminal application (Terminal.app, VS Code, Cursor, etc.), macOS
+/// attributes the calling process to the *responsible* parent application
+/// rather than to the codesigned CuaDriver.app bundle. This means
+/// `AXIsProcessTrusted()` reflects the parent's Accessibility grant, not
+/// CuaDriver.app's — so results can be stale or misleading after
+/// `tccutil reset Accessibility com.trycua.driver`.
+///
+/// This is only a concern for in-process CLI calls without a running daemon.
+/// When the daemon is up, `run_call` forwards through the Unix socket and
+/// the check runs inside the daemon process (CuaDriver.app), where the
+/// attribution is correct.
+///
+/// See: https://github.com/trycua/cua/issues/1561
 pub fn accessibility_granted() -> bool {
     unsafe { crate::ax::bindings::AXIsProcessTrusted() }
 }

--- a/libs/cua-driver-rs/crates/platform-macos/src/tools/check_permissions.rs
+++ b/libs/cua-driver-rs/crates/platform-macos/src/tools/check_permissions.rs
@@ -19,7 +19,15 @@ fn def() -> &'static ToolDef {
             By default also raises the system permission dialogs for any missing grants — \
             Apple's request APIs are no-ops when the grant is already active, so this is \
             safe to call repeatedly. Pass {\"prompt\": false} for a purely read-only \
-            status check.".into(),
+            status check.\n\n\
+            ⚠️ CLI caveat: when called from a shell or IDE terminal without a running \
+            cua-driver daemon, macOS attributes the calling process to the parent \
+            application (Terminal.app, VS Code, Cursor, etc.) rather than to \
+            CuaDriver.app. AXIsProcessTrusted() therefore reflects the parent's \
+            Accessibility grant, not CuaDriver.app's — so the result can be stale or \
+            misleading after `tccutil reset Accessibility com.trycua.driver`. \
+            For authoritative results, start the daemon first \
+            (`cua-driver serve` or open CuaDriver.app), then re-run this check.".into(),
         input_schema: serde_json::json!({
             "type": "object",
             "properties": {


### PR DESCRIPTION
## Problem

`cua-driver check_permissions` reports stale/wrong results after `tccutil reset Accessibility com.trycua.driver` when called from a shell or IDE terminal without a running daemon.

**Root cause:** macOS attributes the calling CLI process to the *responsible* parent application (Terminal.app, VS Code, Cursor, etc.) rather than to CuaDriver.app. `AXIsProcessTrusted()` therefore reflects the parent's Accessibility grant, not CuaDriver.app's.

The Swift binary already handles this in `CallCommand.swift` lines 148-171. The Rust CLI had no equivalent guard.

## Fix

Ports the Swift fix to the Rust CLI:

- **`cli.rs`**: when no daemon is listening and `tool == check_permissions`, emit a stderr warning and force `prompt:false`. Prevents a TCC dialog being attributed to the wrong bundle identity.
- **`check_permissions.rs`**: add the caveat to the tool description so MCP clients and `cua-driver describe` surface the limitation.
- **`status.rs`**: document the `AXIsProcessTrusted()` attribution caveat in the `accessibility_granted()` doc comment.

No behaviour change when the daemon is running (requests are forwarded through the Unix socket and run inside CuaDriver.app where attribution is correct).

Fixes #1561

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added warning messages when running permission checks without the daemon, clarifying that results may be inaccurate
  * Updated tool descriptions to explain daemon requirements for correct macOS TCC permission attribution

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1575?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->