### PR TITLE
fix(skylight): guard auth-message selector with class_respondsToSelector on macOS 14

### DIFF
--- a/libs/cua-driver-rs/crates/platform-macos/src/input/skylight.rs
+++ b/libs/cua-driver-rs/crates/platform-macos/src/input/skylight.rs
@@ -206,6 +206,30 @@ fn sel_register(name: &CStr) -> *mut c_void {
     }
 }
 
+/// Check whether `cls` responds to `sel` via `class_respondsToSelector`.
+///
+/// This is the critical guard for macOS 14 (Sonoma) compatibility.
+/// `SLSEventAuthenticationMessage` exists on macOS 14 but the selector
+/// `messageWithEventRecord:pid:version:` was added in macOS 15 (Sequoia).
+/// `sel_registerName` always succeeds (it just interns the string), so
+/// checking `!sel.is_null()` is not sufficient — we must verify the class
+/// actually implements the selector before calling `objc_msgSend`, or the
+/// runtime raises `NSInvalidArgumentException: unrecognized selector`.
+fn class_responds_to_selector(cls: *mut c_void, sel: *mut c_void) -> bool {
+    if cls.is_null() || sel.is_null() {
+        return false;
+    }
+    type RespondsToFn = unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool;
+    static SYM: OnceLock<Option<RespondsToFn>> = OnceLock::new();
+    let f = *SYM.get_or_init(|| {
+        find_sym(b"class_respondsToSelector\0").map(|p| unsafe { as_fn(p) })
+    });
+    match f {
+        Some(f) => unsafe { f(cls, sel) },
+        None => false,
+    }
+}
+
 // ── SLSEventRecord extraction ──────────────────────────────────────────────
 
 /// Extract the embedded `SLSEventRecord *` from a `CGEvent`.
@@ -244,11 +268,19 @@ pub fn post_to_pid(pid: pid_t, event_ptr: *mut c_void, attach_auth_message: bool
 
     if attach_auth_message {
         // Build and attach SLSEventAuthenticationMessage.
+        //
+        // macOS 14 (Sonoma) compatibility: the class exists on macOS 14 but
+        // `messageWithEventRecord:pid:version:` was added in macOS 15 (Sequoia).
+        // `sel_registerName` always succeeds (it interns the string), so we
+        // must use `class_respondsToSelector` to verify the class actually
+        // implements the selector before calling `objc_msgSend` — otherwise
+        // the ObjC runtime raises NSInvalidArgumentException and crashes.
+        // See: https://github.com/trycua/cua/issues/1503
         let cls = objc_class(c"SLSEventAuthenticationMessage");
         let sel = sel_register(c"messageWithEventRecord:pid:version:");
         let factory = factory_msg_send_fn();
 
-        if !cls.is_null() && !sel.is_null() {
+        if class_responds_to_selector(cls, sel) {
             if let Some(factory_fn) = factory {
                 let record = unsafe { extract_event_record(event_ptr) };
                 if !record.is_null() {
@@ -261,6 +293,10 @@ pub fn post_to_pid(pid: pid_t, event_ptr: *mut c_void, attach_auth_message: bool
                 }
             }
         }
+        // If the selector is absent (macOS < 15), we skip the auth envelope
+        // and fall through to the plain SLEventPostToPid call below.
+        // Chromium-class targets may not receive the event on macOS 14, but
+        // the daemon no longer crashes — a graceful degradation.
     }
 
     unsafe { post_fn(pid, event_ptr) };

--- a/libs/cua-driver/Sources/CuaDriverCore/Input/SkyLightEventPost.swift
+++ b/libs/cua-driver/Sources/CuaDriverCore/Input/SkyLightEventPost.swift
@@ -104,13 +104,22 @@ public enum SkyLightEventPost {
                 "SLSEventAuthenticationMessage")
         else { return nil }
 
+        // macOS 14 (Sonoma) compatibility: the class exists on macOS 14 but
+        // `messageWithEventRecord:pid:version:` was added in macOS 15 (Sequoia).
+        // `NSSelectorFromString` always succeeds (it interns the string), so we
+        // must verify the class actually responds to the selector before storing
+        // it — otherwise `objc_msgSend` raises NSInvalidArgumentException at
+        // runtime and crashes the daemon.
+        // See: https://github.com/trycua/cua/issues/1503
+        let factorySelector = NSSelectorFromString("messageWithEventRecord:pid:version:")
+        guard messageClass.responds(to: factorySelector) else { return nil }
+
         return Resolved(
             postToPid: postToPid,
             setAuthMessage: setAuth,
             msgSendFactory: msgSend,
             messageClass: messageClass,
-            factorySelector: NSSelectorFromString(
-                "messageWithEventRecord:pid:version:")
+            factorySelector: factorySelector
         )
     }()
 


### PR DESCRIPTION
## Problem

`hotkey`, `press_key`, and `scroll` crash the daemon on macOS 14 (Sonoma):

```
NSInvalidArgumentException: +[SLSEventAuthenticationMessage
messageWithEventRecord:pid:version:]: unrecognized selector
```

## Root cause

`SLSEventAuthenticationMessage` exists on macOS 14 but `messageWithEventRecord:pid:version:` was added in macOS 15 (Sequoia). Both `sel_registerName` (Rust) and `NSSelectorFromString` (Swift) always succeed — they just intern the string — so the existing `!sel.is_null()` / class-exists check was not sufficient. `objc_msgSend` was called without verifying the class actually implements the selector.

## Fix

**Rust (`skylight.rs`):**
- Add `class_responds_to_selector()` helper using the ObjC runtime's `class_respondsToSelector`.
- Replace `!cls.is_null() && !sel.is_null()` with `class_responds_to_selector(cls, sel)` in `post_to_pid()`.

**Swift (`SkyLightEventPost.swift`):**
- Add `messageClass.responds(to: factorySelector)` guard before storing the `Resolved` struct. Returns `nil` on macOS 14, disabling the auth path.

On macOS 14 the auth envelope is skipped and `SLEventPostToPid` is called without it. Chromium-class targets may not receive the event (same limitation as before macOS 15 support was added), but the daemon no longer crashes.

Fixes #1503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed potential runtime crashes on older macOS versions where certain system methods are unavailable. The application now verifies method availability before attempting to use them and gracefully falls back to alternative event posting mechanisms when required methods are not present, improving cross-version stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->