### PR TITLE
docs(cua-driver): Windows SSH workflow + autostart concept page

### DIFF
--- a/docs/content/docs/cua-driver/guide/getting-started/autostart.mdx
+++ b/docs/content/docs/cua-driver/guide/getting-started/autostart.mdx
@@ -1,0 +1,118 @@
+---
+title: Autostart
+description: Keep cua-driver's daemon running in the user's interactive session across logons, RDP disconnects, and reboots.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+`cua-driver autostart` registers the platform-native "run at logon" mechanism that keeps a `cua-driver serve` daemon alive in the user's interactive session. On Windows this is the difference between GUI tools that work over SSH and GUI tools that return empty arrays — see [Running cua-driver under SSH on Windows](/cua-driver/guide/getting-started/windows-ssh) for the full reasoning.
+
+```bash
+cua-driver autostart enable    # register the platform entry
+cua-driver autostart kick      # start it now without waiting for next logon
+cua-driver autostart status    # registered? running?
+cua-driver autostart disable   # remove the entry
+```
+
+## What it does per platform
+
+| Platform | Mechanism | Where it lives |
+|---|---|---|
+| Windows | Scheduled Task `cua-driver-serve` with `LogonType: Interactive` | Task Scheduler (`schtasks /Query /TN cua-driver-serve`) |
+| macOS | Not yet implemented in the Rust port — use the manual `LaunchAgent` recipe ([`scripts/install-local.sh --autostart`](https://github.com/trycua/cua/blob/main/libs/cua-driver-rs/scripts/install-local.sh)) | `~/Library/LaunchAgents/com.trycua.cua-driver-rs.plist` |
+| Linux | Not yet implemented in the Rust port — use the manual `systemd --user` unit ([`scripts/install-local.sh --autostart`](https://github.com/trycua/cua/blob/main/libs/cua-driver-rs/scripts/install-local.sh)) | `~/.config/systemd/user/cua-driver-rs.service` |
+
+<Callout type="info">
+**Platform parity status.** `cua-driver autostart` is currently a Windows-only verb in the Rust port — the macOS / Linux cases return an error pointing at the manual recipe. A cross-platform native impl is tracked as a follow-up. The verb is documented as the cross-platform interface so existing scripts and skill-pack instructions land in the right place once parity ships.
+</Callout>
+
+## The four verbs
+
+### `enable`
+
+Registers the Scheduled Task on Windows. Idempotent — any existing task with the same name is replaced, so re-running after a `cua-driver` upgrade picks up the new binary path automatically.
+
+```powershell
+cua-driver autostart enable
+# Registered autostart entry 'cua-driver-serve'.
+#   cua-driver serve will start at every interactive logon.
+```
+
+The registered task pins to `LogonType: Interactive` — load-bearing, because the alternative (`S4U` / `Password`) would land the daemon back in Session 0. The exact PowerShell that gets run is in [`autostart.rs`](https://github.com/trycua/cua/blob/main/libs/cua-driver-rs/crates/cua-driver/src/autostart.rs) and stays in lock-step with `scripts/install.ps1`.
+
+### `kick`
+
+Runs the registered task immediately, without waiting for the next logon. Use this right after `enable` so the daemon is up in the current session — otherwise `enable` is a "next-logon" change and your current shell still has no daemon to talk to.
+
+```powershell
+cua-driver autostart enable
+cua-driver autostart kick
+cua-driver status    # confirms the daemon's listening
+```
+
+### `status`
+
+Reports the registration + liveness state in three flavours:
+
+```text
+not-registered                  # no Scheduled Task exists
+registered (not running)        # task is there but no daemon process
+registered (running)            # task is there AND a daemon is listening on the socket
+```
+
+The "running" check probes the daemon's named pipe directly (no `tasklist` spawn — that's slow on first run), so it reflects real liveness, not just "Task Scheduler thinks the task is registered".
+
+### `disable`
+
+Removes the Scheduled Task. No-op if nothing's registered, so it's safe to script unconditionally.
+
+```powershell
+cua-driver autostart disable
+# Removed autostart entry 'cua-driver-serve' (no-op if it was already absent).
+```
+
+## Worked example: `enable && kick` from an interactive shell
+
+The canonical first-time recipe — run this once from an interactive shell (RDP, local console, Windows Terminal under your logged-in user) and the daemon is up immediately *and* will come back after every logon:
+
+```powershell
+cua-driver autostart enable
+cua-driver autostart kick
+cua-driver status
+# cua-driver daemon is running
+#   socket: \\.\pipe\cua-driver
+#   pid: 12345
+```
+
+After this, you can SSH into the box and `cua-driver mcp` / `cua-driver call <tool>` will proxy through the running daemon — see [Running cua-driver under SSH on Windows](/cua-driver/guide/getting-started/windows-ssh).
+
+## The "daemon survives RDP disconnect" property
+
+Scheduled Tasks registered with `LogonType: Interactive` are *session-attached* — the task and any processes it spawned live and die with the interactive session, not with the RDP client window. Disconnecting the RDP client leaves the session in `Disc` (disconnected) state, which is still a live interactive session as far as Windows is concerned:
+
+```powershell
+query session
+# SESSIONNAME    USERNAME    ID  STATE   TYPE     DEVICE
+# console                     0  Disc
+# rdp-tcp#23     you         2  Disc                                  ← still alive
+```
+
+The daemon keeps running in session `2`. A subsequent SSH connection (which lands in Session 0) can proxy through the still-listening daemon. Reconnecting RDP reattaches to the same session — the daemon was never killed.
+
+The session only dies on explicit logoff (`logoff` / Start menu → Sign out) or reboot. On reboot, the next interactive logon re-triggers the Scheduled Task and a fresh daemon comes back up.
+
+<Callout type="info">
+**Prerequisite — an active interactive session must exist.** `kick` runs the task in *some* session, but Task Scheduler only triggers it when an interactive logon is present. If you've never logged in via RDP / console on a fresh box, `kick` has nowhere to land the daemon. The fix is to RDP in once (the logon trigger fires `serve` automatically) — after that, even an RDP-disconnect keeps the session alive in `Disc` state and the daemon along with it.
+</Callout>
+
+## Why not just `cua-driver serve &` over SSH?
+
+A naively-spawned `cua-driver serve &` over SSH inherits the SSH session — which on Windows OpenSSH is **Session 0**, the non-interactive services session. The daemon comes up, but every GUI tool it answers (`list_windows`, `click`, `screenshot`, ...) bottoms out in Win32 APIs scoped to the calling session's WindowStation + Desktop, which Session 0 doesn't have. Tools silently return empty arrays.
+
+`autostart enable && kick` sidesteps this by running the daemon under the user's interactive logon (Session 1+) instead of inheriting whatever session called `serve`. The daemon then has a real desktop attached and GUI tools work.
+
+See [Running cua-driver under SSH on Windows](/cua-driver/guide/getting-started/windows-ssh) for the end-to-end SSH workflow.
+
+## Uninstall behaviour
+
+The platform uninstaller (`uninstall.ps1` on Windows, `uninstall.sh` elsewhere) removes the autostart entry automatically as part of its teardown — you don't need to call `autostart disable` explicitly before uninstalling. See the [uninstall removal matrix](/cua-driver/guide/getting-started/installation#uninstall) for the per-platform specifics.

--- a/docs/content/docs/cua-driver/guide/getting-started/installation.mdx
+++ b/docs/content/docs/cua-driver/guide/getting-started/installation.mdx
@@ -274,15 +274,19 @@ A healthy interactive logon reports the inverse:
 
 - **Run from RDP or the local console** — the simplest fix; both put your shell in your own interactive session, not Session 0.
 - **Run from a Windows Terminal / PowerShell launched by your logged-in user** — same effect.
-- **Register a logon Scheduled Task** (recommended, equivalent to macOS LaunchAgent) — see [Auto-start at logon](#auto-start-at-logon-windows) below.
-- **Use a session-launcher utility** — if you must invoke from a service / SSH context, run the binary through a launcher that spawns it inside an explicit interactive session id rather than inheriting Session 0.
-- **Configure your SSH server to spawn inside the interactive session** — possible with most modern Windows SSH server distributions but requires extra setup; the scheduled-task approach is usually simpler.
+- **Register a logon Scheduled Task** (recommended, equivalent to macOS LaunchAgent) — see [Auto-start at logon](#auto-start-at-logon-windows) below, or the [Autostart concept page](/cua-driver/guide/getting-started/autostart) for the `cua-driver autostart enable` one-liner.
+- **Driving over SSH?** Register the autostart task once from an interactive session, then `cua-driver mcp` and `cua-driver call` over SSH proxy through the running daemon automatically. See [Running cua-driver under SSH on Windows](/cua-driver/guide/getting-started/windows-ssh) for the full workflow.
+- **Use a session-launcher utility** — if you must invoke from a service / SSH context *without* the daemon-proxy path, run the binary through a launcher that spawns it inside an explicit interactive session id rather than inheriting Session 0.
 
 Run `cua-driver doctor` after switching contexts to confirm the warning has cleared.
 
 #### Auto-start at logon (Windows)
 
 The Windows-native equivalent of macOS's LaunchAgent is a **Scheduled Task triggered at logon, running as your user, with `Run only when user is logged on`** (i.e. `LogonType: Interactive`). Once registered, `cua-driver serve` starts automatically every time you sign in via RDP or the console — no more pasting a startup one-liner.
+
+<Callout type="info">
+**One-liner:** `cua-driver autostart enable && cua-driver autostart kick` does everything the manual block below does. See the [Autostart concept page](/cua-driver/guide/getting-started/autostart) for the full `enable / disable / kick / status` verb family, and [Running cua-driver under SSH on Windows](/cua-driver/guide/getting-started/windows-ssh) for the recommended headless workflow on top of it.
+</Callout>
 
 `install.ps1` prints the exact one-shot registration block on a successful install. To register it manually (substitute your install path if you built from source):
 
@@ -524,6 +528,18 @@ The client spawns `cua-driver mcp` on demand once registered.
   under LaunchServices with the right TCC context. No Python bridge, no manual `serve` step required.
   Pass `--no-daemon-relaunch` (or set `CUA_DRIVER_MCP_NO_RELAUNCH=1`) to opt out, e.g. when MCP is
   launched from CuaDriver.app directly and already has the right TCC grants.
+</Callout>
+
+<Callout type="info">
+  **Daemon-proxy on Windows / Linux (`cua-driver-rs` v0.2.7+).** The same proxy mechanism applies on
+  Windows and Linux, addressing the Session 0 / interactive-session problem rather than TCC: when
+  `cua-driver mcp` starts up and detects a daemon already listening on the default socket, it
+  proxies every tool call through to it instead of running in-process. Crucial for SSH on Windows,
+  where the SSH session lands in Session 0 (no desktop) but the daemon — registered via
+  `cua-driver autostart enable` — lives in the user's Session 1+ interactive logon. Same
+  `--no-daemon-relaunch` / `CUA_DRIVER_RS_MCP_NO_RELAUNCH=1` opt-out as macOS. See
+  [Running cua-driver under SSH on Windows](/cua-driver/guide/getting-started/windows-ssh) for the
+  full workflow.
 </Callout>
 
 ## Agent skills (auto-wired)

--- a/docs/content/docs/cua-driver/guide/getting-started/meta.json
+++ b/docs/content/docs/cua-driver/guide/getting-started/meta.json
@@ -3,5 +3,5 @@
   "description": "Get up and running with Cua Driver",
   "icon": "Rocket",
   "defaultOpen": true,
-  "pages": ["introduction", "installation", "quickstart", "integrations", "swift-integration", "process-model", "comparison", "faq"]
+  "pages": ["introduction", "installation", "quickstart", "windows-ssh", "autostart", "integrations", "swift-integration", "process-model", "comparison", "faq"]
 }

--- a/docs/content/docs/cua-driver/guide/getting-started/windows-ssh.mdx
+++ b/docs/content/docs/cua-driver/guide/getting-started/windows-ssh.mdx
@@ -1,0 +1,174 @@
+---
+title: Running cua-driver under SSH on Windows
+description: The "daemon in interactive session + SSH-side proxy" workflow that makes cua-driver work headlessly over SSH on Windows.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+The canonical headless / remote-driving setup for cua-driver on Windows is:
+
+1. A `cua-driver serve` daemon runs in the user's **interactive session** (Session 1+), kept alive by [`cua-driver autostart`](/cua-driver/guide/getting-started/autostart).
+2. You SSH into the same box (which lands in Session 0).
+3. `cua-driver mcp` and `cua-driver call <tool>` on the SSH side **proxy through the interactive-session daemon** over the daemon's named pipe.
+4. Claude Code (or any MCP client) over SSH drives real GUI apps — `list_apps`, `click`, `type_text`, `screenshot` all respond against the user's real desktop.
+
+This page explains why the proxy is necessary, how to wire it up, and the opt-outs.
+
+## The Session 0 problem
+
+Windows OpenSSH server runs in **Session 0** — the non-interactive services session. Sessions `1`, `2`, ... are interactive logons (one per console / RDP user). Every process inherits the session of its parent, so a shell spawned from `sshd` lands in Session 0 too.
+
+The Win32 APIs that cua-driver's window tools bottom out in — `EnumWindows`, `GetForegroundWindow`, `PrintWindow`, UIA, `BitBlt` over the screen DC — are all scoped to the **calling process's WindowStation + Desktop**. Session 0 has no interactive desktop attached. So:
+
+```powershell
+# Over SSH (Session 0), with no daemon helper:
+cua-driver call list_windows
+# []                       ← empty. The user's RDP session has 12 windows open.
+```
+
+That's not a cua-driver bug — those APIs are working as designed against a session with no desktop. The same thing would happen to any native Win32 tool spawned the same way.
+
+<Callout type="info">
+**Confirm with `cua-driver doctor`.** The Windows session probe surfaces this directly:
+
+```text
+[warn] interactive session: running in Session 0 (services); window-driving
+       tools (list_windows, click, type_text, screenshot, get_window_state)
+       will return empty results — these APIs need an attached interactive
+       desktop.
+```
+</Callout>
+
+## The fix: daemon in Session 1+, proxy from Session 0
+
+The Rust port (`cua-driver-rs`) ships with a daemon-proxy path on every platform. When `cua-driver mcp` or `cua-driver call <tool>` starts up and detects a daemon already listening on the default socket, it forwards every request through to the daemon instead of running tool calls in-process.
+
+The daemon runs in the user's interactive session (registered via `cua-driver autostart enable`, which uses a Scheduled Task with `LogonType: Interactive`). The SSH-side CLI runs in Session 0 but only does protocol-shuttling — the actual tool invocations execute inside the daemon, which has a real desktop attached.
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│  Session 1+ (RDP / console — has interactive desktop)         │
+│                                                               │
+│    cua-driver-serve  (autostart Scheduled Task)               │
+│      ↑                                                        │
+│      │ named pipe: \\.\pipe\cua-driver                        │
+│      │                                                        │
+└──────┼────────────────────────────────────────────────────────┘
+       │
+┌──────┼────────────────────────────────────────────────────────┐
+│  Session 0 (services / SSH — no desktop)                      │
+│      │                                                        │
+│    cua-driver mcp                                             │
+│    cua-driver call list_windows                               │
+│    Claude Code → MCP stdio → cua-driver mcp                   │
+└───────────────────────────────────────────────────────────────┘
+```
+
+## The canonical recipe
+
+```powershell
+# ── ONE-TIME from your interactive session (RDP or console) ──────────
+cua-driver autostart enable        # register the Scheduled Task
+cua-driver autostart kick          # start it now, don't wait for next logon
+
+# ── from SSH (or any session — Just Works) ───────────────────────────
+cua-driver status
+# cua-driver daemon is running
+#   socket: \\.\pipe\cua-driver
+#   pid: 12345
+#   session: 2                     ← daemon's in your interactive session
+
+cua-driver call list_apps          # sees real GUI apps
+claude                             # Claude Code's MCP tool calls proxy through
+```
+
+`autostart enable` registers a Scheduled Task that re-runs `cua-driver serve` at every interactive logon — see the [Autostart concept page](/cua-driver/guide/getting-started/autostart) for the verb-by-verb breakdown and the RDP-disconnect-survives property.
+
+<Callout type="warn">
+**Prerequisite — the user must have an active interactive session.** Either:
+
+- An RDP client is connected, OR
+- An RDP client *was* connected and has disconnected without logging off (the session stays in `Disc` state and is still considered active), OR
+- The user is logged in at the local console.
+
+Confirm with `query session` from any shell — the user row should show `Active` or `Disc`:
+
+```powershell
+query session
+# SESSIONNAME    USERNAME    ID  STATE   TYPE
+# rdp-tcp#23     you         2  Active                     ← good
+# # — or —
+# rdp-tcp#23     you         2  Disc                       ← also good
+```
+
+No interactive session means `autostart kick` has no Session 1+ to land the daemon in — `kick` will report success but the daemon won't have a desktop attached. Open an RDP session once and the autostart trigger will fire `serve` automatically next logon.
+</Callout>
+
+## How the proxy decides whether to forward
+
+`cua-driver mcp` and `cua-driver call <tool>` share the same gating function ([`should_use_daemon_proxy` in `cli.rs`](https://github.com/trycua/cua/blob/main/libs/cua-driver-rs/crates/cua-driver/src/cli.rs)):
+
+- If `--no-daemon-relaunch` is passed, **stay in-process**.
+- If `CUA_DRIVER_RS_MCP_NO_RELAUNCH=1` is set, **stay in-process**.
+- Otherwise, **proxy if a daemon is listening** on the default socket; **run in-process if none is up**.
+
+There's no auto-spawn on Windows / Linux — unlike macOS, there's no `open -a CuaDriver` equivalent that could land a fresh daemon in the right session. If no daemon is listening when you run `cua-driver mcp`, the CLI bails with an actionable error:
+
+```text
+no cua-driver daemon listening on \\.\pipe\cua-driver. Start one in your
+interactive session — on Windows run `cua-driver autostart enable &&
+cua-driver autostart kick`; on Linux run `cua-driver serve &` in the user's
+session. Then re-run `cua-driver mcp`. To skip the proxy and run in-process
+anyway (Session 0 attribution, GUI tools will return empty), pass
+--no-daemon-relaunch.
+```
+
+<Callout type="info">
+**Why `call` worked over SSH before v0.2.7 but `mcp` didn't.** The `call` CLI had its own daemon-proxy shortcut baked in from the start (the daemon is the only place the per-pid element cache lives, so `call` had to proxy to share state across invocations anyway). The `mcp` entrypoint was hardcoded to run in-process on Windows / Linux on the assumption that MCP clients spawn fresh subprocesses — true, but irrelevant: a fresh subprocess over SSH is still in Session 0. `cua-driver-rs` v0.2.7 ([PR #1580](https://github.com/trycua/cua/pull/1580)) lined the two entrypoints up so `mcp` proxies on the same conditions `call` does.
+
+If you're on v0.2.6 or earlier and saw empty MCP results over SSH while `cua-driver call list_apps` worked, upgrade — `irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.ps1 | iex`.
+</Callout>
+
+## Wiring Claude Code over SSH
+
+Once the daemon is up in your interactive session, the Claude Code registration is unchanged from the local case:
+
+```powershell
+# From inside your SSH session:
+claude mcp add --transport stdio cua-driver -- cua-driver.exe mcp
+claude
+```
+
+Every MCP tool call Claude makes over the stdio link triggers `cua-driver mcp` on the SSH side, which detects the daemon and proxies to it. The MCP client sees an ordinary stdio server; the daemon sees a steady stream of tool calls from its Session 1+ desktop context.
+
+## Opt-out: in-process even when a daemon is up
+
+There are legitimate reasons to skip the proxy — running inside CI in an already-interactive runner that owns its own session, debugging the in-process MCP server, or running an integration test that boots its own daemon and wants the CLI to talk to a different socket.
+
+Two equivalent opt-outs:
+
+```powershell
+cua-driver mcp --no-daemon-relaunch                    # CLI flag, per-invocation
+$env:CUA_DRIVER_RS_MCP_NO_RELAUNCH = "1"               # env var, per-shell
+cua-driver mcp                                         # now stays in-process
+```
+
+Either form keeps `cua-driver mcp` in-process and the tool calls execute against whatever session spawned the CLI — Session 0 over SSH (empty GUI results), or the interactive session if you're running locally.
+
+## Diagnostics — "my MCP calls return empty over SSH"
+
+Walk this list before opening an issue:
+
+1. **`cua-driver --version` on the SSH side reports `0.2.7` or later.** Earlier versions don't proxy `mcp` on Windows / Linux. Upgrade with the [install one-liner](/cua-driver/guide/getting-started/installation#install-cua-driver-rs-directly-linux--windows--macos).
+2. **`cua-driver status` from SSH reports a running daemon.** If not, `cua-driver autostart status` will tell you whether the Scheduled Task is registered. Re-run `enable && kick` from an RDP session if not.
+3. **`query session` shows an `Active` or `Disc` row for your user.** No interactive session means no Session 1+ for the daemon to land in.
+4. **`cua-driver doctor` from RDP reports `[ok] interactive session: session N has an attached interactive desktop`** — confirms the daemon's session has a desktop attached. Run from the same session you registered autostart in.
+5. **You did not pass `--no-daemon-relaunch`** and `CUA_DRIVER_RS_MCP_NO_RELAUNCH` is unset — both opt the proxy out.
+
+If all five pass and tool calls still come back empty, run `cua-driver call list_windows` over SSH and compare with the same call from RDP. Same empty result on both means the daemon's in the wrong session; differing results mean the proxy isn't activating (file an issue with `cua-driver doctor --json` from both sessions).
+
+## See also
+
+- [Autostart](/cua-driver/guide/getting-started/autostart) — verb-by-verb breakdown of `cua-driver autostart`, the daemon-survives-RDP-disconnect property.
+- [Installation → Windows interactive-session requirements](/cua-driver/guide/getting-started/installation#windows-interactive-session-requirements) — the underlying session model.
+- [Installation → Auto-start at logon (Windows)](/cua-driver/guide/getting-started/installation#auto-start-at-logon-windows) — manual Scheduled Task registration (equivalent to `autostart enable`, kept for users who want to hand-craft the task).


### PR DESCRIPTION
## Summary

Adds two sibling pages under `docs/content/docs/cua-driver/guide/getting-started/` to close two gaps in the cua-driver fumadocs, which today is heavily macOS-focused:

- **`windows-ssh.mdx`** — the "daemon in user's interactive Session 1+ → SSH (Session 0) → `cua-driver mcp`/`call` proxies through the daemon → real GUI apps respond" workflow. This is the actual ergonomic story for headless / remote Windows automation and nothing in the docs covered it before. Covers the Session 0 problem, the canonical `autostart enable && kick` recipe, the active-interactive-session prerequisite, opt-outs, and why `mcp` now proxies the same way `call` always did (PR #1580, shipped in v0.2.7).
- **`autostart.mdx`** — concept page for the `cua-driver autostart {enable, disable, kick, status}` verb family. Documents per-platform mechanics (Windows = Scheduled Task with `LogonType: Interactive`; macOS/Linux Rust port still TBD — manual recipe via `install-local.sh --autostart`), the daemon-survives-RDP-disconnect property, and the `enable && kick` worked example.

Both pages are linked from the existing Windows section of `installation.mdx` (in the "common fixes for empty arrays" list and as a callout on the manual Scheduled Task block). A small sibling callout was also added under "TCC auto-delegation" to surface that the daemon-proxy mechanism now works on Windows / Linux too, addressing Session 0 rather than TCC.

**Decision on placement:** new sibling pages under `getting-started/`, not inline in `installation.mdx`. The installation page is already 619 lines, the SSH workflow needs its own discoverability (people searching "cua-driver ssh windows" need a page title that matches), and the autostart verb family deserves its own conceptual home as a sibling to the SSH workflow.

**Total new content:** 292 lines across the two new MDX files + ~25 lines of cross-link edits in `installation.mdx`. Inside the 300-500 line target.

## Scope

Docs-only PR. No code changes. The behaviours described shipped in `cua-driver-rs` v0.2.7 (PR #1580 — `should_use_daemon_proxy` on Windows/Linux) and the `autostart` verb family already in the Rust port.

## Files changed

- `docs/content/docs/cua-driver/guide/getting-started/windows-ssh.mdx` *(new)*
- `docs/content/docs/cua-driver/guide/getting-started/autostart.mdx` *(new)*
- `docs/content/docs/cua-driver/guide/getting-started/meta.json` *(added the two new page slugs to the ordered list)*
- `docs/content/docs/cua-driver/guide/getting-started/installation.mdx` *(cross-link callouts in 3 places; no content moved out)*

## Test plan

- [ ] `pnpm dev` in `docs/` renders both new pages with working internal links to each other and to existing installation.mdx anchors
- [ ] meta.json ordering puts `windows-ssh` and `autostart` between `quickstart` and `integrations` (sidebar reads top-to-bottom in workflow order)
- [ ] All anchor links (`#auto-start-at-logon-windows`, `#windows-interactive-session-requirements`, `#install-cua-driver-rs-directly-linux--windows--macos`, `#uninstall`) resolve against the current `installation.mdx`
- [ ] Code blocks render with correct syntax highlighting (PowerShell + bash + text)
- [ ] `<Callout>` components render in both new pages (already imported from `fumadocs-ui/components/callout`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for the autostart command to keep the daemon running across sessions and reboots
  * Added Windows SSH workflow documentation for proxying commands through an interactive daemon session
  * Updated installation guidance with autostart command reference and daemon proxy capabilities
  * Expanded documentation navigation to include new autostart and SSH setup guides

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->