### PR TITLE
fix(cua-driver): register resize ratio in ScreenshotTool, filter self-windows, guard stale AX focus

### DIFF
--- a/libs/cua-driver/Sources/CuaDriverServer/Tools/ScreenshotTool.swift
+++ b/libs/cua-driver/Sources/CuaDriverServer/Tools/ScreenshotTool.swift
@@ -87,11 +87,31 @@ public enum ScreenshotTool {
             }
 
             do {
+                let config = await ConfigStore.shared.load()
+                let maxDim = config.maxImageDimension
+
                 let shot = try await capture.captureWindow(
                     windowID: windowID,
                     format: format,
-                    quality: quality
+                    quality: quality,
+                    maxImageDimension: maxDim
                 )
+
+                // Register the resize ratio so ClickTool can map
+                // screenshot-pixel coordinates back to native pixels,
+                // matching what GetWindowStateTool already does.
+                if let ownerPid = WindowEnumerator.allWindows()
+                    .first(where: { UInt32($0.id) == windowID })?.pid
+                {
+                    if let origW = shot.originalWidth, shot.width > 0 {
+                        await ImageResizeRegistry.shared.setRatio(
+                            Double(origW) / Double(shot.width),
+                            forPid: ownerPid)
+                    } else {
+                        await ImageResizeRegistry.shared.clearRatio(forPid: ownerPid)
+                    }
+                }
+
                 let base64 = shot.imageData.base64EncodedString()
                 let mime = format == .png ? "image/png" : "image/jpeg"
                 var summaryLines: [String] = [

--- a/libs/cua-driver/Sources/CuaDriverServer/Tools/TypeTextTool.swift
+++ b/libs/cua-driver/Sources/CuaDriverServer/Tools/TypeTextTool.swift
@@ -158,6 +158,25 @@ public enum TypeTextTool {
                 } else {
                     do {
                         let element = try AXInput.focusedElement(pid: pid)
+                        let target = AXInput.describe(element)
+                        let role = target.role ?? ""
+
+                        // Guard against writing into non-text containers.
+                        // macOS AX focus tracking can lag behind modal sheets,
+                        // leaving a container (e.g. sidebar AXOutline) as the
+                        // focused element even when a text field is visually
+                        // active. Fall through to CGEvent which targets the
+                        // actual key-focus owner.
+                        let nonTextRoles: Set<String> = [
+                            "AXOutline", "AXTable", "AXList",
+                            "AXBrowser", "AXScrollArea", "AXGroup",
+                        ]
+                        guard !nonTextRoles.contains(role) else {
+                            // Fall through to CGEvent synthesis.
+                            throw AXInputError.setAttributeFailed(
+                                attribute: "AXSelectedText", code: -1)
+                        }
+
                         // Animate the cursor to the focused element before writing.
                         if let center = AXInput.screenCenter(of: element) {
                             await MainActor.run { AgentCursor.shared.pinAbove(pid: pid) }
@@ -175,9 +194,9 @@ public enum TypeTextTool {
                         {
                             // Silent-accept detected — fall through.
                         } else {
-                            let target = AXInput.describe(element)
+                            let roleLabel = role.isEmpty ? "?" : role
                             let summary =
-                                "✅ Inserted \(text.count) char(s) into focused \(target.role ?? "?") \"\(target.title ?? "")\" on pid \(rawPid) via AX."
+                                "✅ Inserted \(text.count) char(s) into focused \(roleLabel) \"\(target.title ?? "")\" on pid \(rawPid) via AX."
                             await MainActor.run { AgentCursor.shared.pinAbove(pid: pid) }
                             await AgentCursor.shared.playClickPress()
                             await AgentCursor.shared.finishClick(pid: pid)

--- a/libs/cua-driver/Sources/CuaDriverServer/Tools/WindowChangeDetector.swift
+++ b/libs/cua-driver/Sources/CuaDriverServer/Tools/WindowChangeDetector.swift
@@ -185,10 +185,13 @@ public enum WindowChangeDetector {
             let newIds = current.subtracting(snapshot.windowIds)
             var newEvents: [WindowEvent] = []
             if !newIds.isEmpty {
-                // Resolve app names / titles from the live window list.
+                let ownPid = ProcessInfo.processInfo.processIdentifier
+                // Resolve app names / titles from the live window list,
+                // excluding windows owned by the cua-driver daemon itself
+                // (e.g. the AgentCursorOverlayWindow).
                 let allVisible = WindowEnumerator.visibleWindows().filter { $0.layer == 0 }
                 newEvents = allVisible
-                    .filter { newIds.contains($0.id) }
+                    .filter { newIds.contains($0.id) && $0.pid != ownPid }
                     .map { WindowEvent(
                         windowId: $0.id,
                         pid: $0.pid,


### PR DESCRIPTION
## Summary

Fixes three independent bugs in the macOS CUA driver that caused
click-miss failures in native dialogs (observed in Open File sheets):

- **ScreenshotTool** did not pass `maxImageDimension` to `captureWindow`
  and never registered the resize ratio in `ImageResizeRegistry`. ClickTool
  found no ratio and treated Retina-native pixel coordinates as pre-scaled,
  landing clicks at half the intended position.

- **WindowChangeDetector** counted cua-driver's own `AgentCursorOverlayWindow`
  as a new window, producing false "action opened new window(s)" reports.

- **TypeTextTool** attempted `AXSetAttribute(kAXSelectedText)` on stale-focused
  non-text containers (e.g. `AXOutline`) when macOS AX focus tracking lagged
  behind a modal sheet. Now checks the element role and falls through to
  CGEvent synthesis for known container roles.

## Test plan

- [ ] `swift build --target CuaDriverServer` passes
- [ ] Screenshot a Retina window, then click a coordinate from that screenshot
      -- click should land on the correct target (not offset by 2x)
- [ ] Trigger an action that shows the AgentCursor overlay -- no false
      "new window" report in the tool result
- [ ] `type_text` into a text field behind a modal sheet -- CGEvent fallback
      should deliver the text

Closes #1592

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Screenshot capture now respects configured maximum image dimension settings for accurate coordinate mapping
* Text input tool improved to intelligently handle non-text UI elements with fallback input method
* Window detection refined to exclude internal process windows for improved accuracy

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->