### PR TITLE
feat(cua-driver-rs/windows): cua-driver-uia worker for UWP automation (uiAccess prototype)

### DIFF
--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -123,7 +123,11 @@ jobs:
             rust-cua-driver-rs-windows-${{ matrix.arch }}-
       - name: Build (release)
         working-directory: libs/cua-driver-rs
-        run: cargo build -p cua-driver --release --target ${{ matrix.target }}
+        # Build both the main CLI/MCP binary AND the uiAccess'd worker.
+        # `cua-driver-uia.exe` is the Windows-only sibling daemon that runs
+        # at UIAccess integrity so SendInput / UI Automation can cross UIPI
+        # into UWP apps — see crates/cua-driver-uia/ and #1602.
+        run: cargo build -p cua-driver -p cua-driver-uia --release --target ${{ matrix.target }}
       - name: Package
         working-directory: libs/cua-driver-rs
         shell: pwsh
@@ -134,6 +138,7 @@ jobs:
           $stage   = "cua-driver-rs-${version}-${label}"
           New-Item -ItemType Directory -Force -Path "release/$stage" | Out-Null
           Copy-Item "target/$target/release/cua-driver.exe" "release/$stage/"
+          Copy-Item "target/$target/release/cua-driver-uia.exe" "release/$stage/"
           if (Test-Path "../../LICENSE.md") { Copy-Item "../../LICENSE.md" "release/$stage/LICENSE" }
           # Zip the directory itself (no trailing /*) so the archive contains
           # the top-level "$stage" wrapper dir — install.ps1 walks into
@@ -142,10 +147,13 @@ jobs:
           # wrapper and dumps the files at the archive root, which breaks
           # the installer's path lookup.
           Compress-Archive -Path "release/$stage" -DestinationPath "release/$stage.zip" -Force
-          # Bare binary (cua-driver.exe by itself) — matches Swift's
-          # `*-binary.tar.gz` convention but as .zip since Windows tools
-          # don't always have tar on PATH.
-          Compress-Archive -Path "release/$stage/cua-driver.exe" -DestinationPath "release/$stage-binary.zip" -Force
+          # Bare-binaries zip: both exes side-by-side (no wrapper dir).
+          # `cua-driver-uia.exe` is currently shipped UNSIGNED in this archive
+          # — until #1602 wires an EV cert into CD, the worker won't elevate
+          # to UIAccess integrity on a default-policy machine. The main CLI/MCP
+          # binary stays fully functional regardless; uia is opt-in dead-weight
+          # until signed.
+          Compress-Archive -Path "release/$stage/cua-driver.exe","release/$stage/cua-driver-uia.exe" -DestinationPath "release/$stage-binary.zip" -Force
           Get-ChildItem "release/$stage*.zip"
       - uses: actions/upload-artifact@v4
         with:

--- a/docs/content/docs/cua-driver/guide/getting-started/autostart.mdx
+++ b/docs/content/docs/cua-driver/guide/getting-started/autostart.mdx
@@ -105,6 +105,41 @@ The session only dies on explicit logoff (`logoff` / Start menu → Sign out) or
 **Prerequisite — an active interactive session must exist.** `kick` runs the task in *some* session, but Task Scheduler only triggers it when an interactive logon is present. If you've never logged in via RDP / console on a fresh box, `kick` has nowhere to land the daemon. The fix is to RDP in once (the logon trigger fires `serve` automatically) — after that, even an RDP-disconnect keeps the session alive in `Disc` state and the daemon along with it.
 </Callout>
 
+## UWP automation and the uiAccess worker (Windows)
+
+Modern UWP apps (modern Notepad, Settings, Calculator, the new File Explorer) run inside an AppContainer with **User Interface Privilege Isolation (UIPI)** enabled. UIPI is an integrity-level boundary: a process at Medium integrity (like the regular `cua-driver serve` daemon) cannot inject `SendInput`, read the UI Automation tree, or `PostMessage` across the boundary into an AppContainer'd process. The OS returns `ERROR_ACCESS_DENIED` and the tool call silently fails.
+
+Windows' answer is **`uiAccess="true"`** in the application manifest — a flag that asks the OS to elevate the process to UIAccess integrity at launch, lifting UIPI for that process. The catch: a uiAccess-marked PE can only be launched via `ShellExecute` (not `CreateProcess`), must be Authenticode-signed, and must live in a "secure" location (`\Program Files\` by default, or anywhere if the `EnableSecureUIAPaths` policy is relaxed).
+
+cua-driver-rs satisfies these constraints with a **second sibling binary**, `cua-driver-uia.exe`, that ships alongside `cua-driver.exe` and is the only PE in the project carrying `uiAccess="true"` in its manifest. The main binary (CLI + MCP) stays a normal `asInvoker` process so all the existing CLI / stdio MCP entrypoints continue to work — UWP tool calls just route through the sibling worker over a separate named pipe.
+
+### How it works at runtime
+
+| Component | Integrity | Pipe |
+|---|---|---|
+| `cua-driver.exe serve` | Medium | `\\.\pipe\cua-driver` |
+| `cua-driver-uia.exe` (auto-spawned by `serve`) | UIAccess | `\\.\pipe\cua-driver-uia` |
+
+When `cua-driver serve` starts, it checks for `cua-driver-uia.exe` next to its own binary and `ShellExecute`s it as a child. The OS elevates the child to UIAccess integrity (provided the signing + secure-location requirements are met) and the child binds the second pipe. `cua-driver call ...` and `cua-driver mcp` both prefer `\\.\pipe\cua-driver-uia` over the main daemon pipe when both are listening — tool calls land in the uiAccess process, UIPI doesn't block them.
+
+No additional `autostart` configuration is needed: the single `cua-driver-serve` Scheduled Task is the only registered entry. The worker is a child of the daemon, sharing its lifecycle.
+
+### What it unlocks
+
+- Reading the **UI Automation tree** of modern Notepad, Settings, modern File Explorer, and other XAML / UWP apps
+- `type_text` via UIA `ValuePattern.SetValue` against modern Notepad's document area
+- `SendInput`-based interactions that previously failed with `ERROR_ACCESS_DENIED`
+
+### What it does NOT unlock
+
+- **Calculator-class apps** whose UI lives in a DirectComposition `CoreWindow` with no addressable `HWND` from external processes. uiAccess lifts UIPI but cannot reach a window that has no public handle. See the architectural-limit discussion in [GH #1601](https://github.com/trycua/cua/issues/1601).
+- Apps that explicitly opt out of UI Automation
+- Cross-session injection (the worker still has to live in the same interactive session as the target app)
+
+<Callout type="warn">
+**Signing prerequisite.** `uiAccess` apps must be Authenticode-signed by a cert trusted on the machine — Microsoft does not honor the manifest otherwise. Until the production CD pipeline ships a signed `cua-driver-uia.exe` ([GH #1602](https://github.com/trycua/cua/issues/1602)), the worker fails to elevate on default-policy machines, and UWP automation falls back to the Medium-integrity behavior (UIPI blocking). The main CLI / MCP daemon is unaffected — only the worker depends on the signature. Until then, the daemon logs `uia spawn failed` to stderr and proceeds without it.
+</Callout>
+
 ## Why not just `cua-driver serve &` over SSH?
 
 A naively-spawned `cua-driver serve &` over SSH inherits the SSH session — which on Windows OpenSSH is **Session 0**, the non-interactive services session. The daemon comes up, but every GUI tool it answers (`list_windows`, `click`, `screenshot`, ...) bottoms out in Win32 APIs scoped to the calling session's WindowStation + Desktop, which Session 0 doesn't have. Tools silently return empty arrays.

--- a/libs/cua-driver-rs/Cargo.lock
+++ b/libs/cua-driver-rs/Cargo.lock
@@ -269,6 +269,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cua-driver-uia"
+version = "0.2.7"
+dependencies = [
+ "anyhow",
+ "embed-manifest",
+ "mcp-server",
+ "platform-windows",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "cursor-overlay"
 version = "0.2.7"
 dependencies = [
@@ -332,6 +347,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "embed-manifest"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94cdc65b1cf9e871453ce2f86f5aaec24ff2eaa36a1fa3e02e441dddc3613b99"
 
 [[package]]
 name = "equivalent"

--- a/libs/cua-driver-rs/Cargo.toml
+++ b/libs/cua-driver-rs/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/cua-driver",
+    "crates/cua-driver-uia",
     "crates/mcp-server",
     "crates/platform-macos",
     "crates/platform-windows",

--- a/libs/cua-driver-rs/crates/cua-driver-uia/Cargo.toml
+++ b/libs/cua-driver-rs/crates/cua-driver-uia/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "cua-driver-uia"
+version.workspace = true
+edition.workspace = true
+description = "Windows uiAccess-elevated worker for cua-driver-rs (Calculator / UWP automation)"
+
+# Tiny uiAccess-marked binary that hosts the Windows tool registry over a named
+# pipe (\\.\pipe\cua-driver-uia). The main `cua-driver` CLI/MCP binary prefers
+# this pipe on Windows when present, so SendInput / UI Automation calls land in
+# this process (UIAccess integrity → UIPI bypass for UWP apps) instead of the
+# main daemon (Medium integrity → blocked by AppContainer).
+#
+# Background: #1602. Why two binaries: a uiAccess'd PE can only be launched via
+# ShellExecute (AIS auto-elevation path). The MCP/CLI binary must stay
+# CreateProcess-launchable for stdio MCP transports + ad-hoc CLI invocations,
+# so we split the elevation into this dedicated worker.
+
+[[bin]]
+name = "cua-driver-uia"
+path = "src/main.rs"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+mcp-server = { path = "../mcp-server" }
+platform-windows = { path = "../platform-windows" }
+
+[target.'cfg(target_os = "windows")'.build-dependencies]
+embed-manifest = "1.4"

--- a/libs/cua-driver-rs/crates/cua-driver-uia/build.rs
+++ b/libs/cua-driver-rs/crates/cua-driver-uia/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    #[cfg(target_os = "windows")]
+    {
+        embed_manifest::embed_manifest_file("cua-driver-uia.manifest")
+            .expect("failed to embed cua-driver-uia.manifest");
+        println!("cargo:rerun-if-changed=cua-driver-uia.manifest");
+    }
+}

--- a/libs/cua-driver-rs/crates/cua-driver-uia/cua-driver-uia.manifest
+++ b/libs/cua-driver-rs/crates/cua-driver-uia/cua-driver-uia.manifest
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity
+      type="win32"
+      name="com.trycua.driver.uia"
+      version="1.0.0.0"
+      processorArchitecture="*"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <!--
+          uiAccess="true" gives this worker UIAccess integrity at launch, which
+          lifts UIPI for SendInput / UI Automation against AppContainer'd UWP
+          apps (Calculator, modern Notepad, Settings).
+
+          Requirements honored by AIS at launch time:
+            1. Authenticode signature                  — required (production: EV cert)
+            2. Process launched via ShellExecute       — required (CreateProcess fails)
+            3. Binary under a "secure" path OR policy  — \Program Files\, OR HKLM
+               EnableSecureUIAPaths=0 set by an admin
+
+          Dev / VM testing: a self-signed cert added to LocalMachine\Root and
+          LocalMachine\TrustedPublisher is enough; EnableSecureUIAPaths=0 lets
+          this run from %LOCALAPPDATA%\Programs\trycua\cua-driver-rs\bin\.
+          Prod: signed by Anthropic/trycua EV cert + installed under \Program Files\.
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="true"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">permonitorv2</dpiAwareness>
+    </windowsSettings>
+  </application>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 / Windows 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+</assembly>

--- a/libs/cua-driver-rs/crates/cua-driver-uia/src/main.rs
+++ b/libs/cua-driver-rs/crates/cua-driver-uia/src/main.rs
@@ -1,0 +1,195 @@
+// cua-driver-uia: Windows uiAccess-elevated tool worker.
+//
+// Listens on \\.\pipe\cua-driver-uia for line-delimited JSON requests with the
+// same shape as cua-driver's daemon pipe (\\.\pipe\cua-driver), so cua-driver's
+// CLI and MCP server can prefer this worker on Windows for UIPI-blocked ops.
+//
+// Protocol (one JSON object per line, both directions):
+//   request : {"method":"call","name":"<tool>","args":{...}}
+//             {"method":"list"}
+//             {"method":"describe","name":"<tool>"}
+//             {"method":"shutdown"}
+//   response: {"ok":true,"result":...}
+//             {"ok":false,"error":"...","exit_code":N}
+//
+// The protocol is intentionally byte-identical to cua-driver/serve.rs so that
+// the existing client code in cli.rs::run_call can talk to either pipe.
+
+#[cfg(not(target_os = "windows"))]
+fn main() {
+    eprintln!("cua-driver-uia: Windows-only. (this binary is a no-op on non-Windows hosts.)");
+    std::process::exit(0);
+}
+
+#[cfg(target_os = "windows")]
+use serde::{Deserialize, Serialize};
+
+#[cfg(target_os = "windows")]
+#[derive(Debug, Deserialize)]
+struct PipeRequest {
+    method: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    args: Option<serde_json::Value>,
+}
+
+#[cfg(target_os = "windows")]
+#[derive(Debug, Serialize)]
+struct PipeResponse {
+    ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    exit_code: Option<i32>,
+}
+
+#[cfg(target_os = "windows")]
+impl PipeResponse {
+    fn ok(result: serde_json::Value) -> Self {
+        Self { ok: true, result: Some(result), error: None, exit_code: None }
+    }
+    fn err(msg: impl Into<String>, code: i32) -> Self {
+        Self { ok: false, result: None, error: Some(msg.into()), exit_code: Some(code) }
+    }
+}
+
+#[cfg(target_os = "windows")]
+const PIPE_PATH: &str = r"\\.\pipe\cua-driver-uia";
+
+#[cfg(target_os = "windows")]
+fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(async_main())
+}
+
+#[cfg(target_os = "windows")]
+async fn async_main() -> anyhow::Result<()> {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::windows::named_pipe::ServerOptions;
+
+    let registry = std::sync::Arc::new(platform_windows::register_tools());
+    let tool_count = registry.iter_defs().count();
+    eprintln!("cua-driver-uia: {tool_count} tools registered; listening on {PIPE_PATH}");
+
+    loop {
+        let server = ServerOptions::new()
+            .first_pipe_instance(false)
+            .create(PIPE_PATH)
+            .map_err(|e| anyhow::anyhow!("create named pipe {PIPE_PATH}: {e}"))?;
+
+        server.connect().await
+            .map_err(|e| anyhow::anyhow!("named pipe connect: {e}"))?;
+
+        let reg = registry.clone();
+        tokio::spawn(async move {
+            let (reader, mut writer) = tokio::io::split(server);
+            let mut lines = BufReader::new(reader).lines();
+
+            while let Ok(Some(line)) = lines.next_line().await {
+                let req: PipeRequest = match serde_json::from_str(&line) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        let _ = writer
+                            .write_all(
+                                (serde_json::to_string(&PipeResponse::err(
+                                    format!("JSON parse error: {e}"), 65,
+                                )).unwrap() + "\n")
+                                .as_bytes(),
+                            )
+                            .await;
+                        continue;
+                    }
+                };
+
+                let resp = handle_request(&reg, req).await;
+                let _ = writer
+                    .write_all((serde_json::to_string(&resp).unwrap() + "\n").as_bytes())
+                    .await;
+            }
+        });
+    }
+}
+
+#[cfg(target_os = "windows")]
+async fn handle_request(
+    reg: &mcp_server::tool::ToolRegistry,
+    req: PipeRequest,
+) -> PipeResponse {
+    match req.method.as_str() {
+        "list" => {
+            let tools: Vec<serde_json::Value> = reg.iter_defs()
+                .map(|(name, def)| serde_json::json!({
+                    "name": name,
+                    "description": def.description,
+                    "input_schema": def.input_schema,
+                    "read_only": def.read_only,
+                    "destructive": def.destructive,
+                    "idempotent": def.idempotent,
+                    "open_world": def.open_world,
+                }))
+                .collect();
+            PipeResponse::ok(serde_json::json!({ "tools": tools }))
+        }
+        "describe" => {
+            let name = req.name.as_deref().unwrap_or("");
+            match reg.get_def(name) {
+                Some(def) => PipeResponse::ok(serde_json::json!({
+                    "name": def.name,
+                    "description": def.description,
+                    "input_schema": def.input_schema,
+                })),
+                None => PipeResponse::err(format!("Unknown tool: {name}"), 64),
+            }
+        }
+        "call" => {
+            let raw = req.name.as_deref().unwrap_or("").to_owned();
+            let tool_name = if raw == "type_text_chars" { "type_text".to_owned() } else { raw };
+            let args = req.args.unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+            if reg.get_def(&tool_name).is_none() {
+                return PipeResponse::err(format!("Unknown tool: {tool_name}"), 64);
+            }
+            let result = reg.invoke(&tool_name, args).await;
+            let is_err = result.is_error.unwrap_or(false);
+            let content: Vec<serde_json::Value> = result.content.iter().map(|c| match c {
+                mcp_server::protocol::Content::Text { text, .. } =>
+                    serde_json::json!({"type":"text","text":text}),
+                mcp_server::protocol::Content::Image { data, mime_type, .. } =>
+                    serde_json::json!({"type":"image","data":data,"mimeType":mime_type}),
+            }).collect();
+            let mut result_obj = serde_json::json!({"content": content, "isError": is_err});
+            if let Some(sc) = result.structured_content {
+                result_obj["structuredContent"] = sc;
+            }
+            if is_err {
+                let msg = result.content.iter()
+                    .filter_map(|c| if let mcp_server::protocol::Content::Text { text, .. } = c {
+                        Some(text.as_str())
+                    } else { None })
+                    .collect::<Vec<_>>().join("\n");
+                PipeResponse::err(msg, 1)
+            } else {
+                PipeResponse::ok(result_obj)
+            }
+        }
+        "shutdown" => {
+            // Worker shutdown is unsupported in the prototype — restarting requires
+            // ShellExecute which the main daemon doesn't have a clean path to. Treat
+            // as a no-op for now; the supervising launcher can taskkill the process.
+            PipeResponse::ok(serde_json::json!({"shutdown": false, "reason": "uia worker ignores shutdown"}))
+        }
+        other => PipeResponse::err(format!("Unknown method: {other}"), 65),
+    }
+}

--- a/libs/cua-driver-rs/crates/cua-driver/src/autostart.rs
+++ b/libs/cua-driver-rs/crates/cua-driver/src/autostart.rs
@@ -138,6 +138,14 @@ $principal = New-ScheduledTaskPrincipal -UserId $user -LogonType Interactive -Ru
 $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1) -ExecutionTimeLimit (New-TimeSpan -Hours 0)
 Unregister-ScheduledTask -TaskName 'cua-driver-serve' -Confirm:$false -ErrorAction SilentlyContinue
 Register-ScheduledTask -TaskName 'cua-driver-serve' -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Description 'cua-driver-rs: serve daemon, auto-start at interactive logon' | Out-Null
+
+# Note: the uiAccess'd worker (`cua-driver-uia.exe`) does NOT get its own
+# scheduled task. uiAccess PEs can only be launched via ShellExecute, and
+# Task Scheduler's PowerShell-wrapper Action path returns ERROR_NOT_LOGGED_ON
+# (0x800710E0). Instead, `cua-driver serve` itself spawns the sibling worker
+# via ShellExecuteEx at startup (see serve.rs `maybe_spawn_uia_worker`),
+# which works because the spawn originates from a Session-2 process with an
+# interactive desktop. See #1602.
 "#;
 
     pub fn enable(exe: &str) -> Result<()> {
@@ -160,6 +168,15 @@ Register-ScheduledTask -TaskName 'cua-driver-serve' -Action $action -Trigger $tr
     }
 
     pub fn disable() -> Result<()> {
+        // Tear down any legacy `cua-driver-uia` task from earlier autostart
+        // versions that registered a separate scheduled task for the uia
+        // worker. Current versions don't register one (serve.rs spawns the
+        // worker as a child), but `disable` should still clean up old
+        // installs. Best-effort — "task not found" is ignored.
+        let _ = Command::new("schtasks")
+            .args(["/Delete", "/TN", "cua-driver-uia", "/F"])
+            .output();
+
         // schtasks /Delete returns 0 on success, 1 on "task not found"
         // (which we treat as success: the goal is "no task registered"
         // and it already isn't). Match on stderr text rather than exit

--- a/libs/cua-driver-rs/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver-rs/crates/cua-driver/src/cli.rs
@@ -397,6 +397,17 @@ pub fn should_use_daemon_proxy(no_daemon_relaunch: bool) -> bool {
     if is_env_truthy("CUA_DRIVER_RS_MCP_FORCE_PROXY") {
         return true;
     }
+    // Either the regular daemon (`\\.\pipe\cua-driver`) OR the uiAccess'd
+    // worker (`\\.\pipe\cua-driver-uia`) is a valid proxy target on Windows:
+    // both speak the same line-delimited JSON protocol. Preferring proxy mode
+    // when only the uia worker is up means MCP tool calls land in a process
+    // that bypasses UIPI for UWP apps. See #1602 / the cua-driver-uia crate.
+    #[cfg(target_os = "windows")]
+    {
+        if crate::serve::is_daemon_listening(&crate::serve::default_uia_pipe_path()) {
+            return true;
+        }
+    }
     crate::serve::is_daemon_listening(&crate::serve::default_socket_path())
 }
 
@@ -479,7 +490,27 @@ pub fn launch_daemon_and_wait(socket_path: &str, timeout_secs: u64) -> anyhow::R
 /// socket. Builds its own tokio runtime — same shape as the other
 /// `run_*` helpers in this file that own their event loop.
 pub fn run_mcp_via_daemon_proxy(socket: Option<String>) -> anyhow::Result<()> {
-    let socket_path = socket.unwrap_or_else(crate::serve::default_socket_path);
+    // Windows: prefer the uiAccess'd worker pipe over the regular daemon pipe
+    // when both are running, so MCP tool calls land in a process that can
+    // bypass UIPI for UWP apps. The protocol on both pipes is identical so
+    // the proxy doesn't need to know which one it's talking to. See #1602.
+    let socket_path = if let Some(s) = socket {
+        s
+    } else {
+        #[cfg(target_os = "windows")]
+        {
+            let uia = crate::serve::default_uia_pipe_path();
+            if crate::serve::is_daemon_listening(&uia) {
+                uia
+            } else {
+                crate::serve::default_socket_path()
+            }
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            crate::serve::default_socket_path()
+        }
+    };
 
     if !crate::serve::is_daemon_listening(&socket_path) {
         // CUA_DRIVER_RS_MCP_FORCE_PROXY callers (test harness, custom
@@ -633,6 +664,22 @@ pub fn run_call(
 ) {
     // Daemon forwarding: if a daemon is listening, proxy the request
     // through it so AppStateEngine's element_index cache is shared.
+    //
+    // On Windows, prefer the uiAccess-elevated worker (cua-driver-uia.exe) when
+    // present — it runs at UIAccess integrity and bypasses UIPI for UWP apps
+    // like Calculator / modern Notepad / Settings. The regular daemon at
+    // `\\.\pipe\cua-driver` is Medium integrity and gets ERROR_ACCESS_DENIED on
+    // SendInput into AppContainer'd processes. See #1602.
+    #[cfg(target_os = "windows")]
+    let socket_path = {
+        let uia = crate::serve::default_uia_pipe_path();
+        if crate::serve::is_daemon_listening(&uia) {
+            uia
+        } else {
+            crate::serve::default_socket_path()
+        }
+    };
+    #[cfg(not(target_os = "windows"))]
     let socket_path = crate::serve::default_socket_path();
     if crate::serve::is_daemon_listening(&socket_path) {
         let args_for_daemon = json_args.clone()

--- a/libs/cua-driver-rs/crates/cua-driver/src/serve.rs
+++ b/libs/cua-driver-rs/crates/cua-driver/src/serve.rs
@@ -43,6 +43,16 @@ pub fn default_socket_path() -> String {
     }
 }
 
+/// On Windows, returns the named-pipe path of the uiAccess-elevated worker
+/// (`cua-driver-uia.exe`). The main CLI/MCP binary prefers this pipe over the
+/// regular daemon pipe so UIPI-blocked Windows tools (SendInput / UI Automation
+/// against UWP apps) run in a UIAccess-integrity process. See #1602 / the
+/// `cua-driver-uia` crate for the worker side.
+#[cfg(target_os = "windows")]
+pub fn default_uia_pipe_path() -> String {
+    r"\\.\pipe\cua-driver-uia".to_owned()
+}
+
 /// Returns the platform default PID file path.
 pub fn default_pid_file_path() -> String {
     #[cfg(target_os = "macos")]
@@ -388,6 +398,55 @@ pub async fn run_serve(
     Ok(())
 }
 
+/// On Windows, spawn the sibling uiAccess'd worker (`cua-driver-uia.exe`) via
+/// ShellExecute (through a PowerShell one-liner — no new deps) if it lives
+/// next to the main binary. uiAccess PEs can only be launched via
+/// ShellExecute (CreateProcess returns ERROR_ELEVATION_REQUIRED), and Task
+/// Scheduler's PowerShell-wrapper Action path can't establish a logon
+/// session for the call (ERROR_NOT_LOGGED_ON). But spawning it as a child
+/// of `cua-driver serve` works because the call originates from an already-
+/// Session-2 process with an interactive desktop attached.
+///
+/// Best-effort: if the worker isn't installed, the spawn fails, or
+/// ShellExecute returns an error, the main daemon still serves requests
+/// via the regular `\\.\pipe\cua-driver` path — just without UIPI bypass
+/// for UWP apps. See #1602 / the `cua-driver-uia` crate.
+#[cfg(target_os = "windows")]
+fn maybe_spawn_uia_worker() {
+    let current = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::debug!("uia spawn skipped: current_exe failed: {e}");
+            return;
+        }
+    };
+    let uia = match current.parent() {
+        Some(dir) => dir.join("cua-driver-uia.exe"),
+        None => return,
+    };
+    if !uia.exists() {
+        tracing::debug!("uia spawn skipped: {} not present", uia.display());
+        return;
+    }
+    let uia_str = uia.display().to_string();
+    // PowerShell ShellExecute call — same shape we proved works from Session 2.
+    // `0` = SW_HIDE so the worker doesn't flash a window.
+    let cmd = format!(
+        "(New-Object -ComObject Shell.Application).ShellExecute('{uia_str}','','','',0)"
+    );
+    match std::process::Command::new("powershell.exe")
+        .args(["-NoProfile", "-WindowStyle", "Hidden", "-Command", &cmd])
+        .spawn()
+    {
+        Ok(_child) => {
+            eprintln!("cua-driver: spawned uiAccess worker via {}", uia.display());
+        }
+        Err(e) => {
+            tracing::warn!("uia spawn failed: {e}");
+        }
+    }
+}
+
 #[cfg(target_os = "windows")]
 pub async fn run_serve(
     registry: std::sync::Arc<mcp_server::tool::ToolRegistry>,
@@ -398,6 +457,10 @@ pub async fn run_serve(
     use tokio::net::windows::named_pipe::ServerOptions;
 
     eprintln!("cua-driver daemon listening on {socket_path}");
+
+    // Spawn the sibling uiAccess'd worker if it's installed. Best-effort —
+    // the main daemon still serves requests even if the worker fails to start.
+    maybe_spawn_uia_worker();
 
     // Write PID file.
     if let Some(pid_path) = pid_file_path {

--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -826,6 +826,15 @@ if (-not $skipDownload) {
         New-Item -ItemType Directory -Force -Path $versionedDir | Out-Null
         Copy-Item -LiteralPath (Join-Path $stageDir $BinaryName) -Destination (Join-Path $versionedDir $BinaryName) -Force
         Write-Step "installed $versionedDir\$BinaryName (version $version, target $target)"
+        # Optional sibling: the uiAccess'd worker (cua-driver-uia.exe). Started
+        # shipping with cua-driver-rs-v0.2.8; absent in earlier releases. Copy
+        # it when present so `cua-driver autostart enable` can register the
+        # second ShellExecute-based scheduled task. See #1602.
+        $uiaStage = Join-Path $stageDir 'cua-driver-uia.exe'
+        if (Test-Path -LiteralPath $uiaStage) {
+            Copy-Item -LiteralPath $uiaStage -Destination (Join-Path $versionedDir 'cua-driver-uia.exe') -Force
+            Write-Step "installed $versionedDir\cua-driver-uia.exe (uiAccess worker)"
+        }
     }
     finally {
         Remove-Item -LiteralPath $tmpRoot -Recurse -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary

Adds a Windows-only sibling binary, `cua-driver-uia.exe`, that runs at **UIAccess integrity** to bypass UIPI for UWP apps. The main `cua-driver.exe` (CLI + MCP) stays a normal `asInvoker` PE so all existing CreateProcess-based entrypoints keep working — UWP-blocked tool calls transparently route through the sibling worker over its own named pipe when present.

**Status: prototype.** Production needs an EV cert to sign `cua-driver-uia.exe` ([#1602](https://github.com/trycua/cua/issues/1602)). Without trust, the worker fails to elevate on default-policy machines and UWP automation falls back to the existing Medium-integrity (UIPI-blocked) behavior. **The main binary is fully unaffected** — it never required uiAccess.

## Architecture

| Component | Integrity | Pipe | Launched via |
|---|---|---|---|
| `cua-driver.exe serve` | Medium | `\\.\pipe\cua-driver` | autostart Scheduled Task (CreateProcess) |
| `cua-driver-uia.exe` (auto-spawned by serve) | UIAccess | `\\.\pipe\cua-driver-uia` | ShellExecute child of serve |

CLI (`cua-driver call X`) and MCP stdio (`cua-driver mcp`) both prefer the uia pipe when listening, with byte-identical JSON protocol so the client doesn't need to know which one it's talking to.

## Empirical evidence (Windows 11 VM, self-signed cert + `EnableSecureUIAPaths=0`)

- **`element_count = 30`** for modern Notepad's UIA tree via uia worker (vs **`0`** in-process Medium integrity → UIPI blocking)
- **`type_text` via UIA `ValuePattern.SetValue`** across UIPI returns `0x00000000` (success)
- **MCP stdio** routing confirmed end-to-end: `cua-driver mcp` over JSON-RPC → daemon proxy → uia pipe → 30-element response
- **Auto-spawn confirmed**: `cua-driver autostart kick` fires `cua-driver-serve` → serve ShellExecutes sibling → worker process at TokenUIAccess=1 in Session 2

Calculator stays unreachable — architectural limit ([#1601](https://github.com/trycua/cua/issues/1601)).

## Files

**New**: `crates/cua-driver-uia/` — 4 files, ~200 LOC. Hosts the platform-windows tool registry over a named pipe. Embeds uiAccess manifest via [`embed-manifest`](https://crates.io/crates/embed-manifest) (no mt.exe / rc.exe needed).

**Edited**:
- `crates/cua-driver/src/cli.rs` — pipe-preference for `run_call`, `should_use_daemon_proxy`, `run_mcp_via_daemon_proxy`
- `crates/cua-driver/src/serve.rs` — `maybe_spawn_uia_worker()` ShellExecutes the sibling at startup
- `crates/cua-driver/src/autostart.rs` — `disable` cleans up legacy second-task entries for upgrade idempotency
- `libs/cua-driver/scripts/install.ps1` — copies uia binary when present in release stage
- `.github/workflows/cd-rust-cua-driver.yml` — builds both binaries, zips both
- `docs/.../autostart.mdx` — new "UWP automation and the uiAccess worker" section

## What this does NOT include (deferred to #1602)

- Authenticode EV-cert signing pipeline (Azure Key Vault + AzureSignTool in CD)
- `\Program Files\` install path option (the existing `%LOCALAPPDATA%` flow works once policy is relaxed; production policy decisions deferred)
- Calculator-class app support (architectural limit per #1601 — uiAccess cannot reach compositor-managed surfaces)

## Test plan
- [x] `cargo build -p cua-driver -p cua-driver-uia --release` clean on Windows VM
- [x] Modern Notepad UIA tree: 0 → 30 elements with uia worker
- [x] `type_text` UIA SetValue on modern Notepad returns success
- [x] MCP stdio (initialize → tools/list → tools/call) routes through uia pipe
- [x] `cua-driver autostart kick` auto-spawns the worker
- [ ] CI (Windows + macOS + Linux green — non-Windows builds skip the new crate cleanly)
- [ ] Production signing path (separate PR per #1602)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Windows support for automating modern UWP/XAML applications using an elevated worker component that enables UIAccess-level automation.
  * Enhanced the Windows driver to intelligently route tool calls through the new automation worker when available.

* **Documentation**
  * Added comprehensive guide explaining Windows UIAccess automation capabilities, supported scenarios, limitations, and requirements for proper setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->