### PR TITLE
fix(get_window_state): 30s timeout + 2000-node cap for heavy webview apps

### DIFF
--- a/libs/cua-driver-rs/crates/platform-macos/src/ax/tree.rs
+++ b/libs/cua-driver-rs/crates/platform-macos/src/ax/tree.rs
@@ -18,6 +18,13 @@ use core_foundation::base::{CFRelease, CFRetain, CFTypeRef};
 /// pathological trees (mirrors Swift reference implementation).
 const MAX_DEPTH: usize = 25;
 
+/// Maximum total nodes visited during a single AX walk. Chromium-family apps
+/// (Arc, VS Code, Chrome) can expose thousands of nodes; capping at 2 000
+/// keeps the walk bounded while still covering realistic app chrome.
+/// When the cap is hit the walk stops early and the partial tree is returned
+/// with a warning line appended (mirrors Swift reference implementation).
+const MAX_ELEMENTS: usize = 2_000;
+
 /// A single node in the AX tree.
 #[derive(Debug, Clone)]
 pub struct AXNode {
@@ -42,6 +49,8 @@ pub struct AXNode {
 pub struct TreeWalkResult {
     pub tree_markdown: String,
     pub nodes: Vec<AXNode>,
+    /// True when the walk was cut short by the MAX_ELEMENTS cap.
+    pub truncated: bool,
 }
 
 /// Walk the AX tree of `pid`, optionally filtered to a specific window.
@@ -62,11 +71,13 @@ pub fn walk_tree(pid: i32, window_id: Option<u32>, query: Option<&str>) -> TreeW
     let mut nodes: Vec<AXNode> = Vec::new();
     let mut lines: Vec<(usize, String)> = Vec::new(); // (depth, line)
     let mut index_counter = 0usize;
+    // Shared visited-node counter passed into walk_element to enforce MAX_ELEMENTS.
+    let mut visited_count = 0usize;
 
     unsafe {
         let app_elem = AXUIElementCreateApplication(pid);
         if app_elem.is_null() {
-            return TreeWalkResult { tree_markdown: String::new(), nodes };
+            return TreeWalkResult { tree_markdown: String::new(), nodes, truncated: false };
         }
 
         // Union AXChildren + AXWindows — the only way to see background windows.
@@ -102,7 +113,7 @@ pub fn walk_tree(pid: i32, window_id: Option<u32>, query: Option<&str>) -> TreeW
 
         // Walk each top-level child at depth 0.
         for child in walk_these {
-            walk_element(child, 0, &mut nodes, &mut lines, &mut index_counter);
+            walk_element(child, 0, &mut nodes, &mut lines, &mut index_counter, &mut visited_count);
         }
 
         // Release all top-level elements (copy_children / copy_ax_windows both retain).
@@ -113,14 +124,24 @@ pub fn walk_tree(pid: i32, window_id: Option<u32>, query: Option<&str>) -> TreeW
         CFRelease(app_elem as CFTypeRef);
     }
 
+    let truncated = visited_count >= MAX_ELEMENTS;
     let raw_markdown = render_lines(&lines);
-    let tree_markdown = if let Some(q) = query {
+    let mut tree_markdown = if let Some(q) = query {
         filter_tree(&raw_markdown, q)
     } else {
         raw_markdown
     };
 
-    TreeWalkResult { tree_markdown, nodes }
+    if truncated {
+        tree_markdown.push_str(&format!(
+            "\n⚠️  AX tree truncated at {MAX_ELEMENTS} nodes \
+             (app has a very large accessibility tree — Arc, Electron, or similar). \
+             Element indices above are still valid. Use pixel clicks for elements \
+             not visible in this partial tree."
+        ));
+    }
+
+    TreeWalkResult { tree_markdown, nodes, truncated }
 }
 
 unsafe fn walk_element(
@@ -129,8 +150,12 @@ unsafe fn walk_element(
     nodes: &mut Vec<AXNode>,
     lines: &mut Vec<(usize, String)>,
     counter: &mut usize,
+    visited_count: &mut usize,
 ) {
     if depth > MAX_DEPTH { return; }
+    // Enforce total-node cap — mirrors Swift's maxElements guard.
+    if *visited_count >= MAX_ELEMENTS { return; }
+    *visited_count += 1;
 
     let role = copy_string_attr(element, "AXRole")
         .unwrap_or_else(|| "AXUnknown".into());
@@ -140,7 +165,7 @@ unsafe fn walk_element(
         // Still recurse — children may be interesting.
         let children = copy_children(element);
         for child in children {
-            walk_element(child, depth, nodes, lines, counter);
+            walk_element(child, depth, nodes, lines, counter, visited_count);
             CFRelease(child as CFTypeRef);
         }
         return;
@@ -173,7 +198,7 @@ unsafe fn walk_element(
     if !is_actionable && !has_content && role != "AXWindow" && role != "AXSheet" {
         let children = copy_children(element);
         for child in children {
-            walk_element(child, depth + 1, nodes, lines, counter);
+            walk_element(child, depth + 1, nodes, lines, counter, visited_count);
             CFRelease(child as CFTypeRef);
         }
         return;
@@ -217,7 +242,7 @@ unsafe fn walk_element(
 
     let children = copy_children(element);
     for child in children {
-        walk_element(child, depth + 1, nodes, lines, counter);
+        walk_element(child, depth + 1, nodes, lines, counter, visited_count);
         CFRelease(child as CFTypeRef);
     }
 }

--- a/libs/cua-driver-rs/crates/platform-macos/src/ax/tree.rs
+++ b/libs/cua-driver-rs/crates/platform-macos/src/ax/tree.rs
@@ -73,6 +73,9 @@ pub fn walk_tree(pid: i32, window_id: Option<u32>, query: Option<&str>) -> TreeW
     let mut index_counter = 0usize;
     // Shared visited-node counter passed into walk_element to enforce MAX_ELEMENTS.
     let mut visited_count = 0usize;
+    // Set to true only when walk_element actually stops early due to the cap —
+    // avoids a false-positive when the tree naturally ends on exactly MAX_ELEMENTS.
+    let mut truncated = false;
 
     unsafe {
         let app_elem = AXUIElementCreateApplication(pid);
@@ -113,7 +116,7 @@ pub fn walk_tree(pid: i32, window_id: Option<u32>, query: Option<&str>) -> TreeW
 
         // Walk each top-level child at depth 0.
         for child in walk_these {
-            walk_element(child, 0, &mut nodes, &mut lines, &mut index_counter, &mut visited_count);
+            walk_element(child, 0, &mut nodes, &mut lines, &mut index_counter, &mut visited_count, &mut truncated);
         }
 
         // Release all top-level elements (copy_children / copy_ax_windows both retain).
@@ -124,7 +127,7 @@ pub fn walk_tree(pid: i32, window_id: Option<u32>, query: Option<&str>) -> TreeW
         CFRelease(app_elem as CFTypeRef);
     }
 
-    let truncated = visited_count >= MAX_ELEMENTS;
+    let truncated_flag = truncated;
     let raw_markdown = render_lines(&lines);
     let mut tree_markdown = if let Some(q) = query {
         filter_tree(&raw_markdown, q)
@@ -132,7 +135,7 @@ pub fn walk_tree(pid: i32, window_id: Option<u32>, query: Option<&str>) -> TreeW
         raw_markdown
     };
 
-    if truncated {
+    if truncated_flag {
         tree_markdown.push_str(&format!(
             "\n⚠️  AX tree truncated at {MAX_ELEMENTS} nodes \
              (app has a very large accessibility tree — Arc, Electron, or similar). \
@@ -141,7 +144,7 @@ pub fn walk_tree(pid: i32, window_id: Option<u32>, query: Option<&str>) -> TreeW
         ));
     }
 
-    TreeWalkResult { tree_markdown, nodes, truncated }
+    TreeWalkResult { tree_markdown, nodes, truncated: truncated_flag }
 }
 
 unsafe fn walk_element(
@@ -151,10 +154,15 @@ unsafe fn walk_element(
     lines: &mut Vec<(usize, String)>,
     counter: &mut usize,
     visited_count: &mut usize,
+    truncated: &mut bool,
 ) {
     if depth > MAX_DEPTH { return; }
     // Enforce total-node cap — mirrors Swift's maxElements guard.
-    if *visited_count >= MAX_ELEMENTS { return; }
+    // Set the truncated flag only when we actually stop early.
+    if *visited_count >= MAX_ELEMENTS {
+        *truncated = true;
+        return;
+    }
     *visited_count += 1;
 
     let role = copy_string_attr(element, "AXRole")
@@ -165,7 +173,7 @@ unsafe fn walk_element(
         // Still recurse — children may be interesting.
         let children = copy_children(element);
         for child in children {
-            walk_element(child, depth, nodes, lines, counter, visited_count);
+            walk_element(child, depth, nodes, lines, counter, visited_count, truncated);
             CFRelease(child as CFTypeRef);
         }
         return;
@@ -198,7 +206,7 @@ unsafe fn walk_element(
     if !is_actionable && !has_content && role != "AXWindow" && role != "AXSheet" {
         let children = copy_children(element);
         for child in children {
-            walk_element(child, depth + 1, nodes, lines, counter, visited_count);
+            walk_element(child, depth + 1, nodes, lines, counter, visited_count, truncated);
             CFRelease(child as CFTypeRef);
         }
         return;
@@ -242,7 +250,7 @@ unsafe fn walk_element(
 
     let children = copy_children(element);
     for child in children {
-        walk_element(child, depth + 1, nodes, lines, counter, visited_count);
+        walk_element(child, depth + 1, nodes, lines, counter, visited_count, truncated);
         CFRelease(child as CFTypeRef);
     }
 }

--- a/libs/cua-driver-rs/crates/platform-macos/src/tools/get_window_state.rs
+++ b/libs/cua-driver-rs/crates/platform-macos/src/tools/get_window_state.rs
@@ -99,8 +99,7 @@ impl Tool for GetWindowStateTool {
                          The app (likely Arc, Electron, or Safari with many tabs) has a \
                          pathologically large accessibility tree. \
                          Workarounds: switch to capture_mode=vision for pixel-click \
-                         workflows, or use capture_mode=ax with a query filter to \
-                         limit the walk scope."
+                         workflows, or use capture_mode=ax with a depth-limited scan."
                     ));
                 }
             }

--- a/libs/cua-driver-rs/crates/platform-macos/src/tools/get_window_state.rs
+++ b/libs/cua-driver-rs/crates/platform-macos/src/tools/get_window_state.rs
@@ -83,12 +83,26 @@ impl Tool for GetWindowStateTool {
         let capture_mode = if capture_mode == "tree" { "ax" } else { capture_mode };
         let tree_result = if capture_mode != "vision" {
             let q = query.clone();
-            let result = tokio::task::spawn_blocking(move || {
+            // Wrap the blocking AX walk in a 30-second timeout. Heavy webview apps
+            // (Arc, Safari with many tabs, Electron) can block
+            // AXUIElementCopyAttributeValue indefinitely via XPC — without a
+            // deadline the MCP server hangs forever (issue #1537).
+            let walk_future = tokio::task::spawn_blocking(move || {
                 crate::ax::tree::walk_tree(pid, Some(window_id), q.as_deref())
-            }).await;
-            match result {
-                Ok(r) => Some(r),
-                Err(e) => return ToolResult::error(format!("AX tree walk failed: {e}")),
+            });
+            match tokio::time::timeout(std::time::Duration::from_secs(30), walk_future).await {
+                Ok(Ok(r)) => Some(r),
+                Ok(Err(e)) => return ToolResult::error(format!("AX tree walk failed: {e}")),
+                Err(_elapsed) => {
+                    return ToolResult::error(format!(
+                        "AX tree walk for pid={pid} timed out after 30 s. \
+                         The app (likely Arc, Electron, or Safari with many tabs) has a \
+                         pathologically large accessibility tree. \
+                         Workarounds: switch to capture_mode=vision for pixel-click \
+                         workflows, or use capture_mode=ax with a query filter to \
+                         limit the walk scope."
+                    ));
+                }
             }
         } else {
             None

--- a/libs/cua-driver/Sources/CuaDriverCore/AppState/AppState.swift
+++ b/libs/cua-driver/Sources/CuaDriverCore/AppState/AppState.swift
@@ -148,6 +148,7 @@ public enum AppStateError: Error, CustomStringConvertible, Sendable {
     case appNotFound(Int32)
     case noCachedState(pid: Int32, windowId: UInt32)
     case invalidElementIndex(pid: Int32, windowId: UInt32, index: Int)
+    case axWalkTimedOut(pid: Int32)
 
     public var description: String {
         switch self {
@@ -167,6 +168,13 @@ public enum AppStateError: Error, CustomStringConvertible, Sendable {
                 + "out of range in the cached snapshot. Re-run "
                 + "`get_window_state({pid: \(pid), window_id: \(windowId)})` and use "
                 + "an index from the fresh tree."
+        case .axWalkTimedOut(let pid):
+            return "AX tree walk for pid \(pid) timed out after 30 s. "
+                + "The app (likely Arc, Electron, or Safari with many tabs) has a "
+                + "pathologically large accessibility tree. "
+                + "Workarounds: switch to `capture_mode: vision` for pixel-click "
+                + "workflows, or use `capture_mode: ax` with a `query` filter to "
+                + "limit the walk scope."
         }
     }
 }
@@ -192,6 +200,13 @@ public actor AppStateEngine {
     /// Depth cap for AX walks. Menus and complex web views can nest deep;
     /// 25 covers realistic app chrome without exploding on pathological trees.
     public static let maxDepth = 25
+
+    /// Maximum total elements visited during a single AX walk. Chromium-family
+    /// apps (Arc, VS Code, Chrome) can expose thousands of nodes; capping at
+    /// 2 000 keeps the walk bounded while still covering realistic app chrome.
+    /// When the cap is hit the walk stops and the partial tree is returned with
+    /// a warning appended to the markdown.
+    public static let maxElements = 2_000
 
     /// Shared assertion that tracks which pids accept AXManualAccessibility /
     /// AXEnhancedUserInterface. Extracted into its own actor so a call-site-
@@ -252,34 +267,63 @@ public actor AppStateEngine {
             throw AppStateError.appNotFound(pid)
         }
 
-        let root = AXUIElementCreateApplication(pid)
-
         // Cue Chromium/Electron apps to turn on their web accessibility tree.
         // Non-Chromium apps ignore these attribute writes — safe no-op.
-        try await activateAccessibilityIfNeeded(pid: pid, root: root)
+        // Must be called before the task group so it runs on the actor.
+        try await activateAccessibilityIfNeeded(pid: pid, root: AXUIElementCreateApplication(pid))
 
         nextTurnId += 1
         let turnId = nextTurnId
 
-        var elements: [Int: AXUIElement] = [:]
-        var nextIndex = 0
-        var markdown = ""
+        // Wrap the AX walk in a 30-second timeout. Heavy webview apps (Arc,
+        // Safari with many tabs, Electron) can block AXUIElementCopyAttributeValue
+        // indefinitely via XPC. The walk runs on a detached task so the timeout
+        // can cancel it; the main snapshot task throws axWalkTimedOut if the
+        // deadline is exceeded.
+        let (snapshotMarkdown, snapshotElements, snapshotVisited) = try await withThrowingTaskGroup(
+            of: (String, [Int: AXUIElement], Int).self
+        ) { group in
+            group.addTask {
+                let root = AXUIElementCreateApplication(pid)
+                var els: [Int: AXUIElement] = [:]
+                var idx = 0
+                var md = ""
+                var visited = 0
+                let layer0WindowIds: Set<CGWindowID> = Set(
+                    WindowEnumerator.allWindows()
+                        .filter { $0.layer == 0 }
+                        .map { CGWindowID($0.id) }
+                )
+                self.renderTree(
+                    root,
+                    depth: 0,
+                    targetWindowId: windowId,
+                    layer0WindowIds: layer0WindowIds,
+                    elements: &els,
+                    nextIndex: &idx,
+                    output: &md,
+                    visitedCount: &visited
+                )
+                return (md, els, visited)
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: 30_000_000_000)
+                throw AppStateError.axWalkTimedOut(pid: pid)
+            }
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
 
-        let layer0WindowIds: Set<CGWindowID> = Set(
-            WindowEnumerator.allWindows()
-                .filter { $0.layer == 0 }
-                .map { CGWindowID($0.id) }
-        )
+        var markdown = snapshotMarkdown
+        let elements = snapshotElements
 
-        renderTree(
-            root,
-            depth: 0,
-            targetWindowId: windowId,
-            layer0WindowIds: layer0WindowIds,
-            elements: &elements,
-            nextIndex: &nextIndex,
-            output: &markdown
-        )
+        if snapshotVisited >= AppStateEngine.maxElements {
+            markdown += "\n⚠️  AX tree truncated at \(AppStateEngine.maxElements) nodes"
+                + " (app has a very large accessibility tree — Arc, Electron, or similar)."
+                + " Element indices above are still valid. Use pixel clicks for elements"
+                + " not visible in this partial tree."
+        }
 
         sessions[SessionKey(pid: pid, windowId: windowId)] =
             SessionState(turnId: turnId, elements: elements)
@@ -513,16 +557,19 @@ public actor AppStateEngine {
 
     // MARK: - Walking
 
-    private func renderTree(
+    private nonisolated func renderTree(
         _ element: AXUIElement,
         depth: Int,
         targetWindowId: UInt32?,
         layer0WindowIds: Set<CGWindowID> = [],
         elements: inout [Int: AXUIElement],
         nextIndex: inout Int,
-        output: inout String
+        output: inout String,
+        visitedCount: inout Int
     ) {
         guard depth <= AppStateEngine.maxDepth else { return }
+        guard visitedCount < AppStateEngine.maxElements else { return }
+        visitedCount += 1
 
         let role = attributeString(element, "AXRole") ?? "?"
         let title = attributeString(element, "AXTitle")
@@ -616,7 +663,8 @@ public actor AppStateEngine {
                 layer0WindowIds: layer0WindowIds,
                 elements: &elements,
                 nextIndex: &nextIndex,
-                output: &output
+                output: &output,
+                visitedCount: &visitedCount
             )
         }
     }

--- a/libs/cua-driver/Sources/CuaDriverCore/AppState/AppState.swift
+++ b/libs/cua-driver/Sources/CuaDriverCore/AppState/AppState.swift
@@ -280,8 +280,8 @@ public actor AppStateEngine {
         // indefinitely via XPC. The walk runs on a detached task so the timeout
         // can cancel it; the main snapshot task throws axWalkTimedOut if the
         // deadline is exceeded.
-        let (snapshotMarkdown, snapshotElements, snapshotVisited) = try await withThrowingTaskGroup(
-            of: (String, [Int: AXUIElement], Int).self
+        let (snapshotMarkdown, snapshotElements, snapshotDidTruncate) = try await withThrowingTaskGroup(
+            of: (String, [Int: AXUIElement], Bool).self
         ) { group in
             group.addTask {
                 let root = AXUIElementCreateApplication(pid)
@@ -289,6 +289,7 @@ public actor AppStateEngine {
                 var idx = 0
                 var md = ""
                 var visited = 0
+                var didTruncate = false
                 let layer0WindowIds: Set<CGWindowID> = Set(
                     WindowEnumerator.allWindows()
                         .filter { $0.layer == 0 }
@@ -302,9 +303,10 @@ public actor AppStateEngine {
                     elements: &els,
                     nextIndex: &idx,
                     output: &md,
-                    visitedCount: &visited
+                    visitedCount: &visited,
+                    didTruncate: &didTruncate
                 )
-                return (md, els, visited)
+                return (md, els, didTruncate)
             }
             group.addTask {
                 try await Task.sleep(nanoseconds: 30_000_000_000)
@@ -318,7 +320,7 @@ public actor AppStateEngine {
         var markdown = snapshotMarkdown
         let elements = snapshotElements
 
-        if snapshotVisited >= AppStateEngine.maxElements {
+        if snapshotDidTruncate {
             markdown += "\n⚠️  AX tree truncated at \(AppStateEngine.maxElements) nodes"
                 + " (app has a very large accessibility tree — Arc, Electron, or similar)."
                 + " Element indices above are still valid. Use pixel clicks for elements"
@@ -565,10 +567,16 @@ public actor AppStateEngine {
         elements: inout [Int: AXUIElement],
         nextIndex: inout Int,
         output: inout String,
-        visitedCount: inout Int
+        visitedCount: inout Int,
+        didTruncate: inout Bool
     ) {
         guard depth <= AppStateEngine.maxDepth else { return }
-        guard visitedCount < AppStateEngine.maxElements else { return }
+        guard visitedCount < AppStateEngine.maxElements else {
+            // Set the flag only when we actually stop early due to the cap —
+            // avoids a false-positive when the tree naturally ends on exactly maxElements.
+            didTruncate = true
+            return
+        }
         visitedCount += 1
 
         let role = attributeString(element, "AXRole") ?? "?"
@@ -664,7 +672,8 @@ public actor AppStateEngine {
                 elements: &elements,
                 nextIndex: &nextIndex,
                 output: &output,
-                visitedCount: &visitedCount
+                visitedCount: &visitedCount,
+                didTruncate: &didTruncate
             )
         }
     }


### PR DESCRIPTION
## Problem

`get_window_state` hangs forever on Arc, Safari with many tabs, and Electron apps because `AXUIElementCopyAttributeValue` blocks indefinitely via XPC when the app's accessibility tree is pathologically large.

## Fix

**Rust (`get_window_state.rs` + `ax/tree.rs`):**
- Wrap `spawn_blocking` AX walk in `tokio::time::timeout(30s)`. Returns a descriptive error suggesting `capture_mode=vision` or a query filter.
- Add `MAX_ELEMENTS=2000` cap to `walk_element`. When hit, the walk stops early and `TreeWalkResult.truncated=true` is set. The partial tree is returned with a warning line appended to `tree_markdown`.

**Swift (`AppState.swift`):**
- Wrap `renderTree` in `withThrowingTaskGroup` with a 30s deadline task. Throws `AppStateError.axWalkTimedOut(pid:)` on expiry.
- Add `maxElements=2000` cap via `visitedCount` parameter. When hit, appends a warning line to the markdown output.
- `renderTree` is now `nonisolated` so it can run on the detached task.

Both implementations mirror each other: 30s timeout + 2000-node cap with a user-visible warning rather than a silent hang.

Fixes #1537. Addresses #1564.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed potential hangs when processing very large accessibility trees by implementing an element traversal limit.
  * Added 30-second timeout protection for accessibility tree operations with informative error messages and suggested workaround configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->