### PR TITLE
fix(cua-driver-rs/windows): more honest hotkey no-match error message

### DIFF
--- a/libs/cua-driver-rs/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/tools/impl_.rs
@@ -1588,12 +1588,15 @@ impl Tool for HotkeyTool {
                 )),
                 Ok(Ok((false, scanned))) => ToolResult::error(format!(
                     "hotkey on a modern XAML / UWP target (pid {raw_pid}, hwnd {hwnd}) \
-                     could not find a descendant UIA AcceleratorKey matching \
-                     `{key_display_for_result}` (scanned {scanned} element(s)). \
+                     could not find a UIA AcceleratorKey or `(Ctrl+X)`-style name hint \
+                     matching `{key_display_for_result}` (scanned {scanned} element(s)). \
                      PostMessage WM_KEYDOWN/UP is ignored by this target's input pipeline. \
-                     Call `get_window_state(pid={raw_pid}, window_id={hwnd})` to inspect \
-                     available UIA actions, then use an exposed accelerator or invoke/click \
-                     the matching element."
+                     Common cause: the action is nested behind a closed menu (e.g. modern \
+                     Notepad's Save under the File menu) — its element isn't in the visible \
+                     subtree until the menu is opened. Call \
+                     `get_window_state(pid={raw_pid}, window_id={hwnd})` to inspect available \
+                     UIA actions, then use an exposed accelerator or `click` the matching \
+                     element directly."
                 )),
                 Ok(Err(e)) => ToolResult::error(format!("hotkey (UIA path): {e}")),
                 Err(e) => ToolResult::error(format!("Task error: {e}")),


### PR DESCRIPTION
## Summary

Tiny wording fix on the `hotkey` UIA no-match error. The scan in #1611 tries TWO ways to match a shortcut: the `UIA_AcceleratorKeyPropertyId` property AND the `(Ctrl+X)`-style hint in element Names (added because modern Notepad doesn't set AcceleratorKey). The error message only mentioned the first, which was misleading.

Found in end-to-end testing of #1611 — Claude Code received the error after `cua-driver call hotkey ctrl+s` on modern Notepad and flagged the wording as not quite honest about what was tried.

## Diff

```diff
-                     could not find a descendant UIA AcceleratorKey matching \
-                     `{key_display_for_result}` (scanned {scanned} element(s)). \
+                     could not find a UIA AcceleratorKey or `(Ctrl+X)`-style name hint \
+                     matching `{key_display_for_result}` (scanned {scanned} element(s)). \
                      PostMessage WM_KEYDOWN/UP is ignored by this target's input pipeline. \
+                     Common cause: the action is nested behind a closed menu (e.g. modern \
+                     Notepad's Save under the File menu) — its element isn't in the visible \
+                     subtree until the menu is opened. Call ...
```

Also added a one-line hint about the most common root cause (menu-nested actions) so the caller knows what to look for in `get_window_state` output.

## Test plan
- [x] `cargo build -p cua-driver -p cua-driver-uia --release` clean on VM
- [ ] No behavioral change — pure error-string update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced diagnostic messages for HotkeyTool errors, providing clearer guidance when matching hotkeys cannot be located and suggesting troubleshooting steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->