### PR TITLE
fix(cua-driver-rs/windows): move AttachThreadInput import to correct module (build hotfix)

### DIFF
--- a/libs/cua-driver-rs/crates/platform-windows/src/input/keyboard.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/input/keyboard.rs
@@ -26,8 +26,8 @@ use windows::Win32::UI::WindowsAndMessaging::{
     GetClassNameW, GetWindowThreadProcessId, IsChild,
     PostMessageW, WM_CHAR, WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN, WM_SYSKEYUP,
 };
-use windows::Win32::UI::Input::KeyboardAndMouse::{AttachThreadInput, GetFocus};
-use windows::Win32::System::Threading::GetCurrentThreadId;
+use windows::Win32::UI::Input::KeyboardAndMouse::GetFocus;
+use windows::Win32::System::Threading::{AttachThreadInput, GetCurrentThreadId};
 
 // ── XAML / UWP host detection ────────────────────────────────────────────────
 //


### PR DESCRIPTION
Hotfix — #1613's import for AttachThreadInput pointed at KeyboardAndMouse, but windows-rs exposes it from System::Threading. Main build is broken without this. Verified on the VM via scp during #1613 verification (the binary works), but the committed source needs this patch to compile. 1-line move.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal module references for Windows keyboard input handling to ensure proper code organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->