### PR TITLE
fix(cua-driver-rs)(windows)(#1621): x,y click skips UIA Invoke on canvas-like surfaces

### DIFF
--- a/libs/cua-driver-rs/crates/platform-windows/src/uia/windows_enum.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/uia/windows_enum.rs
@@ -23,8 +23,11 @@ use windows::Win32::System::Com::{
 use windows::Win32::UI::Accessibility::{
     CUIAutomation, IUIAutomation, IUIAutomationElement, IUIAutomationInvokePattern,
     IUIAutomationTogglePattern, TreeScope_Children, TreeScope_Subtree,
-    UIA_AcceleratorKeyPropertyId, UIA_InvokePatternId, UIA_PROPERTY_ID,
-    UIA_TogglePatternId,
+    UIA_AcceleratorKeyPropertyId, UIA_ButtonControlTypeId, UIA_CheckBoxControlTypeId,
+    UIA_CONTROLTYPE_ID, UIA_HyperlinkControlTypeId, UIA_InvokePatternId,
+    UIA_ListItemControlTypeId, UIA_MenuItemControlTypeId, UIA_PROPERTY_ID,
+    UIA_RadioButtonControlTypeId, UIA_SplitButtonControlTypeId, UIA_TabItemControlTypeId,
+    UIA_TogglePatternId, UIA_TreeItemControlTypeId,
 };
 use windows::core::{BSTR, Interface};
 use windows::Win32::UI::WindowsAndMessaging::{
@@ -176,6 +179,35 @@ pub fn enumerate_top_level_windows() -> Vec<WindowInfo> {
 /// `CurrentBoundingRectangle` contains the point AND which exposes
 /// `InvokePattern`. Smallest-area approximates "deepest" without
 /// having to track tree depth explicitly.
+/// Returns `true` when the element's control type has a *coord-independent*
+/// primary action — i.e. a UIA `Invoke()` on it does something semantically
+/// equivalent to "click the element" regardless of where inside its bounding
+/// rectangle the click was requested.
+///
+/// Used by the `x, y` click path to decide whether to take the UIA Invoke
+/// route or fall through to PostMessage with the literal coords. The split
+/// matters for canvases, panes, and custom-drawn surfaces where Invoke would
+/// fire `mousedown` at the element centre — losing the caller's pixel
+/// precision (see #1621).
+fn is_coord_independent_action(elem: &IUIAutomationElement) -> bool {
+    let ct: UIA_CONTROLTYPE_ID = match unsafe { elem.CurrentControlType() } {
+        Ok(t) => t,
+        Err(_) => return false,
+    };
+    matches!(
+        ct,
+        UIA_ButtonControlTypeId
+            | UIA_MenuItemControlTypeId
+            | UIA_HyperlinkControlTypeId
+            | UIA_TabItemControlTypeId
+            | UIA_ListItemControlTypeId
+            | UIA_CheckBoxControlTypeId
+            | UIA_RadioButtonControlTypeId
+            | UIA_SplitButtonControlTypeId
+            | UIA_TreeItemControlTypeId
+    )
+}
+
 pub fn try_invoke_in_window_at_point(hwnd: isize, sx: i32, sy: i32) -> bool {
     if hwnd == 0 {
         return false;
@@ -232,6 +264,22 @@ pub fn try_invoke_in_window_at_point(hwnd: isize, sx: i32, sy: i32) -> bool {
                 )
                 .is_ok();
             if !has_invoke && !has_expand {
+                continue;
+            }
+            // For coordinate-addressed clicks, only accept elements whose
+            // control type has a *coord-independent* primary action. UIA
+            // `Invoke()` fires the element's default action at its centre,
+            // ignoring the requested (sx, sy). For container surfaces
+            // (Pane, Image, Custom, Document, Group, etc.) that means the
+            // caller's pixel precision is silently lost — see #1621, where
+            // `click(canvas, x=110, y=677)` reported success but actually
+            // fired the canvas's `mousedown` at its centre (152, 77).
+            // Buttons / MenuItems / Hyperlinks / TabItems / ListItems /
+            // CheckBoxes / RadioButtons / SplitButtons / TreeItems all
+            // have a single primary action whose location is the element
+            // itself — Invoke is the right path for those. Everything
+            // else falls through to PostMessage with the literal coords.
+            if !is_coord_independent_action(&elem) {
                 continue;
             }
             let w = (rect.right - rect.left).max(0) as i64;


### PR DESCRIPTION
## Summary

`click(x, y)` was routing through `try_invoke_in_window_at_point` for *any* UIA element advertising InvokePattern at the click coordinates. For container surfaces (Pane / Image / Custom / Document / Group) `Invoke()` fires the element's default action at its **centre** and ignores the requested `(x, y)` — silently breaking pixel precision on canvases, paint surfaces, image maps, and 3D viewports.

The fix adds `is_coord_independent_action()` — a control-type whitelist for elements whose primary action is coord-independent (Button, MenuItem, Hyperlink, TabItem, ListItem, CheckBox, RadioButton, SplitButton, TreeItem). For these, UIA Invoke is semantically correct. For everything else, even if the element advertises InvokePattern, fall through to PostMessage with the literal coords.

## Why this asymmetry

The UIA-first path was added so `click(x, y)` could reach UWP / WebView2 / DirectComposition surfaces where `PostMessage(WM_LBUTTONDOWN)` no-ops (input routes via `Windows.UI.Input` instead of the message queue). That's still valuable for **buttons + menu items** in those targets — which is exactly what the whitelist preserves. But invoking the *container* of a canvas, paint surface, or 3D viewport gives the caller the canvas's geometric centre instead of the requested coords — that's the user-visible bug from #1621.

## Repro (from issue #1621)

```
cua-driver call click '{"pid":<edge-pid>,"x":110,"y":677}'
# Before: "✅ Performed UIA Invoke at (110,677)"
#         #canvas-status shows: "canvas: clicked at (152,77)" — canvas centre
# After:  "✅ Posted click to pid <pid>"
#         #canvas-status shows: "canvas: clicked at (<computed x>, <computed y>)" — requested coords
```

## What this does NOT change

- **Element-indexed click** (`click(element_index=N)`) is unchanged — different code site (`impl_.rs:1168`). Callers asking for "invoke this specific element" by index keep the previous behaviour, regardless of control type.
- **Right-click + multi-click** already skipped the UIA path (`use_uia = (btn == "left" || btn == "middle") && count == 1`); they remain on PostMessage.
- **ExpandCollapsePattern preference for Qt menu items** (added in #1566) is unchanged — runs after the new control-type filter; only fires when a whitelisted-type element also has ExpandCollapse.

## Test plan

- [x] `cargo check -p platform-windows` clean (41.82s, 0 new warnings)
- [x] `cargo build --release -p cua-driver` clean (24.43s release)
- [ ] **Runtime verification on RDP-connected interactive session**:
  1. Open Edge to `libs/cua-driver-fixtures/test_page.html` with the four flags from #1620.
  2. `get_window_state` to find the canvas bounding rectangle.
  3. `click(pid, x, y)` at a non-centre point inside the canvas (e.g. canvas-relative `(30, 30)`).
  4. Tool response should say `"✅ Posted click to pid X"` (not `"Performed UIA Invoke"`).
  5. `#canvas-status` should report the requested coords ±2px.

  The SSH-only session in tonight's autonomous run couldn't reach an interactive desktop (daemon ends up in Session 0; `list_windows` returns empty), so the live click test couldn't run end-to-end. Verification needs an RDP'd interactive session.

## Related

- #1619 — shared HTML fixtures (which exposed this when driving the canonical `test_page.html` on Windows)
- #1620 — Chromium anti-throttling flags (must land before runtime verification of this fix is observable)

Closes #1621.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced interaction reliability for UI controls by improving coordinate-precision handling during element invocation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->