### PR TITLE
feat(cua-driver-rs)(windows)(#1620): auto-inject Chromium anti-throttling flags in launch_app

### DIFF
--- a/libs/cua-driver-rs/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/tools/impl_.rs
@@ -648,6 +648,96 @@ fn split_launchable_target(s: &str) -> (String, String) {
     (trimmed.to_owned(), String::new())
 }
 
+/// Returns `true` when the launch target names a Chromium-based browser
+/// — i.e. one whose hidden launch under `SW_SHOWNOACTIVATE` will trigger
+/// renderer-occlusion throttling unless we inject the anti-throttling flags
+/// below. See #1620.
+///
+/// Matches the executable basename (case-insensitive, with or without
+/// `.exe`). Accepts bare names (the App Paths shortcut, e.g. `"msedge"`),
+/// full paths (`"C:\...\msedge.exe"`), and round-tripped launch paths with
+/// trailing arguments (`"\"C:\...\chrome.exe\" --foo"` — the first token is
+/// matched via `split_launchable_target`).
+fn is_chromium_browser_target(target: &str) -> bool {
+    let (file, _) = split_launchable_target(target);
+    let candidate = if file.is_empty() { target } else { file.as_str() };
+    let lower = candidate.to_ascii_lowercase();
+    let basename = lower
+        .rsplit_once('\\')
+        .map(|(_, b)| b)
+        .or_else(|| lower.rsplit_once('/').map(|(_, b)| b))
+        .unwrap_or(lower.as_str());
+    let stem = basename.strip_suffix(".exe").unwrap_or(basename);
+    matches!(
+        stem,
+        "msedge"
+            | "chrome"
+            | "brave"
+            | "opera"
+            | "vivaldi"
+            | "chromium"
+            | "thorium"
+            | "iridium"
+            | "browser" // Yandex Browser's exe is browser.exe
+            | "arc"
+    )
+}
+
+/// Anti-throttling flags injected on hidden Chromium launches (#1620).
+///
+/// `launch_app` uses `SW_SHOWNOACTIVATE` so the launched window is
+/// non-foreground from birth. Chromium's `CalculateNativeWinOcclusion`
+/// feature treats that as occluded and suspends the renderer process for
+/// the tab's entire lifetime — UIA tree exposes only browser chrome, no
+/// page DOM, and `PrintWindow` returns a blank body.
+///
+/// `CalculateNativeWinOcclusion` is the root cause; the two
+/// `--disable-backgrounding-*` flags backstop the same effect through the
+/// process-priority and renderer-throttling layers (Chromium suspends
+/// renderers on multiple signals).
+const CHROMIUM_ANTI_THROTTLING_FLAGS: &[&str] = &[
+    "--disable-features=CalculateNativeWinOcclusion",
+    "--disable-backgrounding-occluded-windows",
+    "--disable-renderer-backgrounding",
+];
+
+/// Prepend the Chromium anti-throttling flags to `extra_args` unless the
+/// caller already has each one. Merges into an existing `--disable-features=`
+/// list rather than appending a second `--disable-features=` entry (Chromium
+/// has subtle merging rules across duplicate flags).
+fn inject_chromium_anti_throttling_flags(extra_args: &mut Vec<String>) {
+    const OCCLUSION_FEATURE: &str = "CalculateNativeWinOcclusion";
+
+    // Merge `CalculateNativeWinOcclusion` into any existing
+    // `--disable-features=` entry, or insert a fresh one at the front.
+    let has_occlusion = extra_args.iter().any(|a| {
+        a.strip_prefix("--disable-features=")
+            .map(|v| v.split(',').any(|f| f.trim() == OCCLUSION_FEATURE))
+            .unwrap_or(false)
+    });
+    if !has_occlusion {
+        if let Some(idx) = extra_args
+            .iter()
+            .position(|a| a.starts_with("--disable-features="))
+        {
+            extra_args[idx] = format!("{},{OCCLUSION_FEATURE}", extra_args[idx]);
+        } else {
+            extra_args.insert(
+                0,
+                format!("--disable-features={OCCLUSION_FEATURE}"),
+            );
+        }
+    }
+
+    // Boolean toggles — insert at front only when not already present.
+    for flag in &["--disable-backgrounding-occluded-windows", "--disable-renderer-backgrounding"] {
+        if !extra_args.iter().any(|a| a == flag) {
+            extra_args.insert(0, (*flag).to_string());
+        }
+    }
+    let _ = CHROMIUM_ANTI_THROTTLING_FLAGS; // referenced for docs alignment
+}
+
 // ── launch_app ───────────────────────────────────────────────────────────────
 
 pub struct LaunchAppTool;
@@ -718,7 +808,7 @@ impl Tool for LaunchAppTool {
         let urls: Vec<String> = args.get("urls").and_then(|v| v.as_array())
             .map(|a| a.iter().filter_map(|v| v.as_str().map(str::to_owned)).collect())
             .unwrap_or_default();
-        let extra_args: Vec<String> = args.get("additional_arguments").and_then(|v| v.as_array())
+        let mut extra_args: Vec<String> = args.get("additional_arguments").and_then(|v| v.as_array())
             .map(|a| a.iter().filter_map(|v| v.as_str().map(str::to_owned)).collect())
             .unwrap_or_default();
 
@@ -731,6 +821,26 @@ impl Tool for LaunchAppTool {
             .or(aumid_opt.clone())
             .or(name_opt.clone())
             .or(bundle_id_opt.clone());
+
+        // #1620: auto-inject Chromium anti-throttling flags when the resolved
+        // target names a Chromium-based browser (Edge / Chrome / Brave /
+        // Vivaldi / Opera / Chromium / Arc / Thorium / Iridium / Yandex).
+        // launch_app hides the window via SW_SHOWNOACTIVATE; Chromium's
+        // occlusion logic suspends the renderer in that case, leaving the
+        // UIA tree empty and PrintWindow capturing a blank body. The three
+        // flags below defeat that for the lifetime of the launched process
+        // without affecting normal interactive use.
+        //
+        // Skipped when `aumid` or `bundle_id` route through the UWP path
+        // (packaged Edge is the exception; the desktop Edge channel is what
+        // ships now and that goes through the ShellExecuteEx path below).
+        if launch_path_opt.is_some() || path_opt.is_some() || name_opt.is_some() {
+            if let Some(t) = target.as_deref() {
+                if is_chromium_browser_target(t) {
+                    inject_chromium_anti_throttling_flags(&mut extra_args);
+                }
+            }
+        }
 
         if target.is_none() && urls.is_empty() {
             // Match Swift's wording verbatim.
@@ -3709,4 +3819,100 @@ pub fn build_registry() -> ToolRegistry {
     let _: &TypeTextCharsTool = &TypeTextCharsTool { state: state.clone() }; // touch struct so it stays in this crate for now
     r.register_recording_tools();
     r
+}
+
+#[cfg(test)]
+mod chromium_flag_injection_tests {
+    use super::{inject_chromium_anti_throttling_flags, is_chromium_browser_target};
+
+    #[test]
+    fn detects_bare_browser_names() {
+        for name in [
+            "msedge", "chrome", "brave", "opera", "vivaldi",
+            "chromium", "thorium", "iridium", "browser", "arc",
+        ] {
+            assert!(is_chromium_browser_target(name), "{name} should match");
+            assert!(is_chromium_browser_target(&format!("{name}.exe")), "{name}.exe should match");
+            // Case-insensitive.
+            assert!(is_chromium_browser_target(&name.to_uppercase()), "uppercase {name} should match");
+        }
+    }
+
+    #[test]
+    fn detects_full_paths() {
+        assert!(is_chromium_browser_target(
+            r"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe"
+        ));
+        assert!(is_chromium_browser_target(
+            r"C:\Program Files\Google\Chrome\Application\chrome.exe"
+        ));
+        // Forward slashes too (some shells write paths that way).
+        assert!(is_chromium_browser_target(
+            r"C:/Program Files/Google/Chrome/Application/chrome.exe"
+        ));
+    }
+
+    #[test]
+    fn detects_launch_path_with_trailing_args() {
+        // Round-tripped launch_path from list_apps with shortcut arguments.
+        assert!(is_chromium_browser_target(
+            r#""C:\Program Files\Google\Chrome\Application\chrome.exe" --profile-directory="Profile 2""#
+        ));
+    }
+
+    #[test]
+    fn does_not_match_non_chromium_apps() {
+        for name in ["firefox", "notepad", "explorer", "code", "soffice"] {
+            assert!(!is_chromium_browser_target(name), "{name} should NOT match");
+            assert!(!is_chromium_browser_target(&format!("{name}.exe")), "{name}.exe should NOT match");
+        }
+        // Empty target.
+        assert!(!is_chromium_browser_target(""));
+    }
+
+    #[test]
+    fn injects_three_flags_into_empty_args() {
+        let mut args: Vec<String> = vec![];
+        inject_chromium_anti_throttling_flags(&mut args);
+        assert!(args.contains(&"--disable-features=CalculateNativeWinOcclusion".to_string()));
+        assert!(args.contains(&"--disable-backgrounding-occluded-windows".to_string()));
+        assert!(args.contains(&"--disable-renderer-backgrounding".to_string()));
+        assert_eq!(args.len(), 3);
+    }
+
+    #[test]
+    fn merges_into_existing_disable_features_list() {
+        let mut args = vec!["--disable-features=Foo,Bar".to_string()];
+        inject_chromium_anti_throttling_flags(&mut args);
+        // Should NOT have two --disable-features= entries.
+        let dfe: Vec<_> = args.iter().filter(|a| a.starts_with("--disable-features=")).collect();
+        assert_eq!(dfe.len(), 1);
+        assert!(dfe[0].contains("CalculateNativeWinOcclusion"));
+        assert!(dfe[0].contains("Foo"));
+        assert!(dfe[0].contains("Bar"));
+    }
+
+    #[test]
+    fn idempotent_when_all_flags_already_present() {
+        let mut args = vec![
+            "--disable-features=CalculateNativeWinOcclusion".to_string(),
+            "--disable-backgrounding-occluded-windows".to_string(),
+            "--disable-renderer-backgrounding".to_string(),
+        ];
+        let before = args.clone();
+        inject_chromium_anti_throttling_flags(&mut args);
+        assert_eq!(args, before, "must not duplicate flags");
+    }
+
+    #[test]
+    fn preserves_user_url_argument_after_flags() {
+        let mut args = vec!["file:///C:/test_page.html".to_string()];
+        inject_chromium_anti_throttling_flags(&mut args);
+        // URL must still be present.
+        assert!(args.iter().any(|a| a == "file:///C:/test_page.html"));
+        // All three flags now in args.
+        assert!(args.iter().any(|a| a == "--disable-features=CalculateNativeWinOcclusion"));
+        assert!(args.iter().any(|a| a == "--disable-backgrounding-occluded-windows"));
+        assert!(args.iter().any(|a| a == "--disable-renderer-backgrounding"));
+    }
 }


### PR DESCRIPTION
## Summary

`launch_app` uses `SW_SHOWNOACTIVATE` so launched windows don't steal focus. For Chromium-based browsers (Edge / Chrome / Brave / Vivaldi / Opera / Chromium / Arc / Thorium / Iridium / Yandex) that triggers occlusion-based renderer throttling — the renderer process is suspended for the entire tab lifetime, the UIA tree exposes only browser chrome, and `PrintWindow` returns a blank body. Downstream tools (`get_window_state`, `screenshot`, `click`, `type_text`) all fail silently against the page content.

This PR makes `launch_app` auto-inject three flags whenever the resolved target names a Chromium-based browser:

```
--disable-features=CalculateNativeWinOcclusion   ← root cause
--disable-backgrounding-occluded-windows         ← backstop 1 (process priority)
--disable-renderer-backgrounding                  ← backstop 2 (renderer throttle)
```

Callers don't need to know about the Chromium quirk; the driver handles it.

## Implementation

Two pure-logic helpers + a small dispatch hook in `LaunchAppTool::run`:

- **`is_chromium_browser_target(target)`** — case-insensitive basename match against the known Chromium browser names. Handles bare names (`"msedge"`), full paths (`r"C:\...\msedge.exe"`), forward-slash paths, and round-tripped launch paths with trailing arguments (`r#""C:\...\chrome.exe" --profile-directory="..."#`). Uses `split_launchable_target` to peel args off launch_path-style targets.

- **`inject_chromium_anti_throttling_flags(extra_args)`** — prepends the three flags. **Idempotent**: if `--disable-features=` already exists, merges `CalculateNativeWinOcclusion` into it (Chromium has subtle merging rules across duplicate `--disable-features=` entries — collapsing into one entry avoids ambiguity). Boolean flags only inserted when absent.

The injection runs after target resolution in `LaunchAppTool::run`, gated on the target coming from `launch_path` / `path` / `name` (the ShellExecuteExW path). UWP/AUMID routing is skipped; the modern Edge ships as a desktop install that goes through the ShellExecuteExW path here.

## Tests

8 new unit tests under `chromium_flag_injection_tests` covering:
- All 10 known Chromium browser names (case-insensitive, with/without `.exe`)
- Full Windows paths (`C:\...\msedge.exe`)
- Forward-slash paths
- Round-tripped launch paths with shortcut args
- Non-Chromium apps don't match (firefox, notepad, explorer, code, soffice)
- Injection into empty args (base case)
- Merging into existing `--disable-features=Foo,Bar`
- Idempotency (second call is a no-op)
- URL argument preserved after injection

All 8 pass on the VM (13.77s test compile, 0.00s test exec).

## E2E verification

Against `libs/cua-driver-fixtures/test_page.html` (the canonical Swift harness, now shared per #1619):

```
launch_app(path='msedge', additional_arguments=['file:///C:/.../test_page.html'])
  → pid 6708, returned without page DOM
get_window_state (after Chromium lazy-builds the tree on first AT probe)
  → 33 elements, includes:
     Document "CUA Driver Test Page v2"
     Button "Click Me" id=clicker actions=[invoke]
screenshot
  → fully painted page (Button + Text Input + Checkbox + Dropdown visible),
    not a blanked body
```

Edge launched non-foreground via `SW_SHOWNOACTIVATE`; renderer was NOT occlusion-throttled; DOM constructed, exposed via UIA, and painted — the regression-prevention case the fix targets.

## Related

- #1619 — shared HTML fixtures (whose `test_page.html` this verifies against)
- #1621 / PR #1622 — control-type whitelist for x,y → UIA Invoke (independent fix; same Windows test pass discovered both)
- #1623 — PostMessage to Chromium HWND doesn't fire DOM input (next: route Chromium coord clicks through `cua-driver-uia` worker)

Closes #1620.

## Test plan

- [x] `cargo test -p platform-windows --lib chromium_flag_injection_tests` — 8 tests pass on the VM
- [x] `cargo build --release -p cua-driver` clean (24.79s)
- [x] E2E: `launch_app(path='msedge', additional_arguments=['file:///...'])` without flags → page DOM exposed via UIA + screenshot shows rendered content
- [ ] Optional follow-up: extend the test to confirm Chrome / Brave behavior matches Edge (only Edge was on the VM tonight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test fixture documentation for cross-platform driver support.

* **New Features**
  * Added comprehensive test fixtures for form inputs, interactive gestures, and coordinate-based interactions.
  * Expanded test coverage for keyboard modifiers, drag-and-drop event sequences, and scroll position tracking.

* **Improvements**
  * Enhanced Chromium browser support on Windows with automatic performance optimizations.
  * Improved UI element interaction handling for better pixel-coordinate accuracy and control type recognition.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->