### PR TITLE
fix(cua-driver): install.ps1 PowerShell 5.1 parse compatibility (#1626)

### DIFF
--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -931,7 +931,7 @@ Write-Host ""
 
 $onPath = Test-OnUserPath $VisibleBinDir
 if ($onPath) {
-    Write-Host "$VisibleBinDir is on your user PATH — cua-driver should resolve in any new shell."
+    Write-Host "$VisibleBinDir is on your user PATH -- cua-driver should resolve in any new shell."
     Write-Host ""
 }
 elseif ($NoPathUpdate) {
@@ -943,8 +943,8 @@ else {
         Add-UserPathEntry $VisibleBinDir
         Write-Host "Added $VisibleBinDir to your User PATH." -ForegroundColor Green
         Write-Host '  Open a new PowerShell window for cua-driver to resolve.'
-        Write-Host "  Use in the current session:  `$env:Path += `";$VisibleBinDir`""
-        Write-Host '  Opt out next time with:      install.ps1 -NoPathUpdate'
+        Write-Host '  Or refresh PATH in the current session by reopening the shell.'
+        Write-Host '  Opt out next time with: install.ps1 -NoPathUpdate'
         Write-Host ""
     }
     catch {
@@ -959,37 +959,37 @@ if ($AutoStart) {
     try {
         Register-CuaDriverAutostart -InstalledBinary $installedBinary
         Write-Host "  cua-driver serve will auto-start at every interactive logon." -ForegroundColor Green
-        Write-Host "  Run now without re-logging:  & `"$installedBinary`" autostart kick"
-        Write-Host "  Inspect:                     & `"$installedBinary`" autostart status"
-        Write-Host "  Remove:                      & `"$installedBinary`" autostart disable"
+        Write-Host '  Run now without re-logging: cua-driver autostart kick'
+        Write-Host '  Inspect:                    cua-driver autostart status'
+        Write-Host '  Remove:                     cua-driver autostart disable'
+        Write-Host "  Binary at: $installedBinary"
         Write-Host ""
     }
     catch {
         Write-Host "  Failed: $($_.Exception.Message)" -ForegroundColor Red
-        Write-Host "  Install otherwise succeeded; re-run with -AutoStart or invoke '& `"$installedBinary`" autostart enable' manually."
+        Write-Host '  Install otherwise succeeded; re-run with -AutoStart or invoke: cua-driver autostart enable'
+        Write-Host "  Binary at: $installedBinary"
         Write-Host ""
     }
 }
 else {
-    $autostartHint = @"
-
-Auto-start at logon (Windows equivalent of macOS LaunchAgent):
-  Run cua-driver serve automatically every time you sign in (RDP, console, etc.)
-
-  Enable:   & "$installedBinary" autostart enable
-  Run now:  & "$installedBinary" autostart kick
-  Status:   & "$installedBinary" autostart status
-  Remove:   & "$installedBinary" autostart disable
-
-  Or re-run this installer with -AutoStart for the same result.
-"@
-    Write-Host $autostartHint -ForegroundColor Cyan
+    Write-Host ""                                                                          -ForegroundColor Cyan
+    Write-Host "Auto-start at logon (Windows equivalent of macOS LaunchAgent):"            -ForegroundColor Cyan
+    Write-Host "  Run cua-driver serve automatically every time you sign in."              -ForegroundColor Cyan
+    Write-Host ""                                                                          -ForegroundColor Cyan
+    Write-Host "  Enable:   cua-driver autostart enable"                                   -ForegroundColor Cyan
+    Write-Host "  Run now:  cua-driver autostart kick"                                     -ForegroundColor Cyan
+    Write-Host "  Status:   cua-driver autostart status"                                   -ForegroundColor Cyan
+    Write-Host "  Remove:   cua-driver autostart disable"                                  -ForegroundColor Cyan
+    Write-Host "  Binary at: $installedBinary"                                             -ForegroundColor Cyan
+    Write-Host ""                                                                          -ForegroundColor Cyan
+    Write-Host "  Or re-run this installer with -AutoStart for the same result."           -ForegroundColor Cyan
 }
 
 
 Write-Host "Docs: https://github.com/trycua/cua/tree/main/libs/cua-driver-rs"
 Write-Host ""
-Write-Host "WARNING — BETA: cua-driver-rs is a cross-platform Rust port of the Swift" -ForegroundColor Yellow
+Write-Host "WARNING -- BETA: cua-driver-rs is a cross-platform Rust port of the Swift" -ForegroundColor Yellow
 Write-Host "          cua-driver. Windows and Linux support is feature-complete; macOS" -ForegroundColor Yellow
 Write-Host "          parity is in progress." -ForegroundColor Yellow
 

--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -942,8 +942,8 @@ else {
     try {
         Add-UserPathEntry $VisibleBinDir
         Write-Host "Added $VisibleBinDir to your User PATH." -ForegroundColor Green
-        Write-Host '  Open a new PowerShell window for cua-driver to resolve.'
-        Write-Host '  Or refresh PATH in the current session by reopening the shell.'
+        Write-Host '  cua-driver will resolve in any NEW PowerShell window.'
+        Write-Host '  In THIS shell, invoke via the full Binary path printed below.'
         Write-Host '  Opt out next time with: install.ps1 -NoPathUpdate'
         Write-Host ""
     }
@@ -959,16 +959,17 @@ if ($AutoStart) {
     try {
         Register-CuaDriverAutostart -InstalledBinary $installedBinary
         Write-Host "  cua-driver serve will auto-start at every interactive logon." -ForegroundColor Green
-        Write-Host '  Run now without re-logging: cua-driver autostart kick'
-        Write-Host '  Inspect:                    cua-driver autostart status'
-        Write-Host '  Remove:                     cua-driver autostart disable'
-        Write-Host "  Binary at: $installedBinary"
+        Write-Host '  In a new PowerShell window, manage with:'
+        Write-Host '    cua-driver autostart kick     (run now without re-logging)'
+        Write-Host '    cua-driver autostart status   (inspect the task)'
+        Write-Host '    cua-driver autostart disable  (remove)'
+        Write-Host "  In THIS shell, use the full path: $installedBinary"
         Write-Host ""
     }
     catch {
         Write-Host "  Failed: $($_.Exception.Message)" -ForegroundColor Red
-        Write-Host '  Install otherwise succeeded; re-run with -AutoStart or invoke: cua-driver autostart enable'
-        Write-Host "  Binary at: $installedBinary"
+        Write-Host '  Install otherwise succeeded; in a new shell run: cua-driver autostart enable'
+        Write-Host "  In THIS shell, use: $installedBinary autostart enable"
         Write-Host ""
     }
 }
@@ -977,11 +978,14 @@ else {
     Write-Host "Auto-start at logon (Windows equivalent of macOS LaunchAgent):"            -ForegroundColor Cyan
     Write-Host "  Run cua-driver serve automatically every time you sign in."              -ForegroundColor Cyan
     Write-Host ""                                                                          -ForegroundColor Cyan
-    Write-Host "  Enable:   cua-driver autostart enable"                                   -ForegroundColor Cyan
-    Write-Host "  Run now:  cua-driver autostart kick"                                     -ForegroundColor Cyan
-    Write-Host "  Status:   cua-driver autostart status"                                   -ForegroundColor Cyan
-    Write-Host "  Remove:   cua-driver autostart disable"                                  -ForegroundColor Cyan
-    Write-Host "  Binary at: $installedBinary"                                             -ForegroundColor Cyan
+    Write-Host "  In a new PowerShell window:"                                             -ForegroundColor Cyan
+    Write-Host "    cua-driver autostart enable    (register the task)"                    -ForegroundColor Cyan
+    Write-Host "    cua-driver autostart kick      (start now without re-logging)"         -ForegroundColor Cyan
+    Write-Host "    cua-driver autostart status    (inspect)"                              -ForegroundColor Cyan
+    Write-Host "    cua-driver autostart disable   (remove)"                               -ForegroundColor Cyan
+    Write-Host ""                                                                          -ForegroundColor Cyan
+    Write-Host "  In THIS shell, prefix with the full Binary path:"                        -ForegroundColor Cyan
+    Write-Host "    $installedBinary"                                                      -ForegroundColor Cyan
     Write-Host ""                                                                          -ForegroundColor Cyan
     Write-Host "  Or re-run this installer with -AutoStart for the same result."           -ForegroundColor Cyan
 }


### PR DESCRIPTION
## Summary

`iwr install.ps1 | iex` failed silently on stock Windows PowerShell 5.1 (the version that ships with Windows 10 / Server 2019 / Server 2025). PS 7+ (`pwsh`) parses fine; PS 5.1's tokenizer chokes on three patterns in the post-install hint block. Net effect: every Windows user on the default PS gets nothing installed when running the README's documented one-liner.

## Root causes

1. **Nested backtick-escaped double-quotes** (L946): `"  Use in the current session:  \`$env:Path += \`";$VisibleBinDir\`""` — PS 5.1 mis-terminates the string at the first `\`"`.
2. **Call operator `&` inside double-quoted strings with `\`"$var\`"`** (L962-964, 969): `"... & \`"$installedBinary\`" autostart kick"` — PS 5.1 treats `&` as the call operator even inside a literal string.
3. **Em-dash `—` inside a double-quoted Write-Host string** (L934): the multi-byte UTF-8 character makes PS 5.1's tokenizer mis-report "string is missing the terminator" several lines later.

## Fix

Reword the post-install hints to reference `cua-driver` by name (which the User PATH update adds anyway) instead of `& "<full-path>"`. The binary path still appears verbatim on a separate `Binary at: <path>` line. The `$autostartHint` here-string is unrolled into individual `Write-Host` calls — same visual output, no here-string body containing the problem characters. The em-dash in the User PATH success line becomes `--`.

Em-dashes inside `#` comments are left as-is; they don't affect PS 5.1's parser in comment context.

## Verification

```
PS> $PSVersionTable.PSVersion
5.1.26100
PS> $src = Get-Content -Raw install.ps1
PS> $t = $null; $e = $null
PS> [System.Management.Automation.Language.Parser]::ParseInput($src,[ref]$t,[ref]$e) | Out-Null
PS> $e.Count
0
PS> [scriptblock]::Create($src)    # what `iex` does internally — used to fail
[scriptblock]
```

End-to-end run via the README one-liner now:

- downloads windows-x86_64 binary from GitHub Releases ✅
- extracts to `%LOCALAPPDATA%\Programs\trycua\cua-driver-rs\bin` ✅
- creates the two NTFS directory junctions ✅
- adds bin dir to User PATH ✅
- prints the hint block cleanly ✅
- `cua-driver --version` resolves and reports `cua-driver 0.2.8` ✅

## Behavioral change

Post-install hints now show `cua-driver autostart kick` (relying on the just-added PATH entry resolving the command) instead of `& "C:\...\cua-driver.exe" autostart kick`. For the current PowerShell session the user still needs to open a new shell or reload the User PATH for `cua-driver` to resolve. The full binary path is still printed on a separate `Binary at: <path>` line for the explicit-invoke case.

Closes #1626.

## Test plan

- [x] Parser API (`[System.Management.Automation.Language.Parser]::ParseInput`) returns 0 errors on PS 5.1.26100
- [x] `[scriptblock]::Create($src)` succeeds (this is what `iex` does internally)
- [x] End-to-end install via `iwr | iex` on a fresh Windows Server 2025 VM with PS 5.1
- [ ] Test the `-AutoStart` path on the same VM
- [ ] Verify PS 7+ (`pwsh`) still parses + runs (not regressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved installer confirmation messages and user instructions.
  * Updated auto-start guidance with streamlined command recommendations and binary path information.
  * Enhanced beta warning formatting and failure recovery messaging.
  * Refined post-installation guidance for better clarity and accessibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->