### PR TITLE
docs(cua-driver-rs)(windows): hotkey tool description reflects actual SendInput dispatch

### DIFF
--- a/libs/cua-driver-rs/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/tools/impl_.rs
@@ -1723,15 +1723,31 @@ impl Tool for HotkeyTool {
     fn def(&self) -> &ToolDef {
         HOTKEY_DEF.get_or_init(|| ToolDef {
             name: "hotkey".into(),
-            // Description ported from Swift `HotkeyTool.swift` (omitting macOS-
-            // specific FocusWithoutRaise/SLEventPostToPid mechanics — Windows
-            // uses PostMessage which doesn't need a NSMenu-activation dance).
+            // Description ported from Swift `HotkeyTool.swift` with the
+            // Windows-specific dispatch (UIA accelerator for XAML; SendInput
+            // for legacy Win32 with modifiers per #1614 / #1618; PostMessage
+            // for modifier-less keys).
             description: "Press a combination of keys simultaneously — e.g. `[\"ctrl\", \"c\"]` \
-                for Copy, `[\"ctrl\", \"shift\", \"t\"]` for reopen-closed-tab. Legacy Win32 \
-                targets receive the combo directly via PostMessage(WM_KEYDOWN/UP); modern \
-                XAML / WinUI / UWP targets route through UI Automation by finding a descendant \
-                whose AcceleratorKey matches the combo and invoking it. The target does NOT \
-                need to be frontmost.\n\n\
+                for Copy, `[\"ctrl\", \"shift\", \"t\"]` for reopen-closed-tab. Dispatch is \
+                target-aware:\n\n\
+                - **Modern XAML / WinUI / UWP targets** route through UI Automation: the driver \
+                walks the target's accessibility subtree, finds a descendant whose AcceleratorKey \
+                matches the combo, and invokes it. No focus steal, no system-queue input.\n\n\
+                - **Legacy Win32 targets with modifiers** (Ctrl+S, Alt+Tab, etc.) route through \
+                `SendInput` against the system input queue, with a brief `SetForegroundWindow` \
+                swap so the events land on the target. This path is necessary because \
+                PostMessage(WM_KEYDOWN, VK_CONTROL) does NOT update the OS-wide modifier state \
+                visible to `GetKeyState` / `TranslateAccelerator`, so Win32 apps that bind \
+                accelerators via `TranslateAccelerator` (LibreOffice, FAR, classic Notepad, etc.) \
+                never see the combo as a real accelerator on the PostMessage-only path. \
+                Trade-off: brief foreground swap (mitigated by restoring the previous foreground \
+                after the keystrokes flush). Requires the daemon to have UIAccess integrity so \
+                `SetForegroundWindow` is permitted — the MCP proxy auto-prefers the \
+                `cua-driver-uia.exe` worker pipe when both daemons are running.\n\n\
+                - **Legacy Win32 targets without modifiers** (plain `enter`, `tab`, `f5`, etc.) \
+                route through `PostMessage(WM_KEYDOWN/UP)` — no focus steal, no need to update \
+                modifier state.\n\n\
+                The target does NOT need to be frontmost in any branch.\n\n\
                 **`window_id`** (optional): explicit HWND when the pid owns more than one \
                 window; otherwise the pid's first visible window is used.\n\n\
                 Recognized modifiers: ctrl/control, shift, alt, win/windows. Non-modifier \


### PR DESCRIPTION
## Summary

The hotkey tool description still claimed `Legacy Win32 targets receive the combo directly via PostMessage(WM_KEYDOWN/UP)` — but #1614 / #1618 changed the dispatch to use SendInput (via the `cua-driver-uia` worker) for combos containing modifiers. PostMessage doesn't update the OS-wide modifier state, so accelerators bound via `TranslateAccelerator` (LibreOffice, FAR, classic Notepad, etc.) never see Ctrl+S as a real accelerator on the PostMessage-only path.

The actual current dispatch in `HotkeyTool::invoke` (lines ~1859-1879):

```
1. XAML / WinUI / UWP target          → UIA accelerator-key invocation
2. Legacy Win32 WITH modifiers        → SendInput (brief foreground swap; UIAccess required)
3. Legacy Win32 WITHOUT modifiers     → PostMessage WM_KEYDOWN/UP (unchanged)
```

This PR updates the description to match — three explicit branches, the UIAccess requirement, and the `cua-driver-uia.exe` worker proxy auto-preference.

## Why this matters

Agents (and humans) reading the tool docs would expect PostMessage-only behavior. Two surprises that came up during Inkscape stress testing:

- Visible cursor / foreground change on modifier+key hotkeys (the SendInput path momentarily swaps the foreground HWND)
- `"SendInput inserted only 0 of 4 events..."` diagnostic when the daemon lacks UIAccess — and the description gave no hint that the uia worker matters

## Docs flow

The `mcp-tools.mdx` entry for `hotkey` is auto-generated from this Rust source (per the `AUTO-GENERATED FILE` comment at the top of `mcp-tools.mdx`), so this fix regenerates the public docs on the next docs build. PR #1627 adds an inline cross-reference from the `hotkey` section to a new `Windows behavior notes` block — the two land complementary improvements (one fixes the source-of-truth, one adds the high-level Windows behavior section).

## Test plan

- [x] `cargo check -p platform-windows` clean on the VM
- [ ] Trigger the docs-generator (`npx tsx scripts/docs-generators/cua-driver.ts`) and confirm the regenerated `mcp-tools.mdx` hotkey section reflects the new description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved hotkey tool documentation with clearer details on Windows-specific behavior for modern (XAML/WinUI/UWP) and legacy Win32 targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1629?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->