### PR TITLE
fix(cua-driver): uninstall.ps1 halts when scheduled task already gone

### DIFF
--- a/libs/cua-driver/scripts/uninstall.ps1
+++ b/libs/cua-driver/scripts/uninstall.ps1
@@ -142,16 +142,34 @@ Write-Step "  package home: $HomeDir"
 Write-Host ""
 
 # 1. Scheduled Task autostart (registered by `cua-driver autostart enable`
-#    or install.ps1 -AutoStart). Idempotent — schtasks /Delete returns
-#    non-zero when the task is absent, which we swallow.
-$taskQuery = & schtasks.exe /Query /TN $AutoStartTask 2>$null
-if ($LASTEXITCODE -eq 0 -and $taskQuery) {
+#    or install.ps1 -AutoStart). Idempotent — schtasks /Query returns
+#    non-zero AND writes stderr when the task is absent. Under PS 5.1 with
+#    $ErrorActionPreference=Stop (set at the top of this script), native
+#    command stderr becomes a terminating error even when we redirect with
+#    `2>$null` — the redirect suppresses display but the error record is
+#    still emitted into the error stream. Locally lower ErrorActionPreference
+#    around the native call so the missing-task case is non-fatal.
+$prevEAP = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+try {
+    $taskQuery = & schtasks.exe /Query /TN $AutoStartTask 2>$null
+    $taskExitCode = $LASTEXITCODE
+} finally {
+    $ErrorActionPreference = $prevEAP
+}
+if ($taskExitCode -eq 0 -and $taskQuery) {
     if (Confirm-Remove "scheduled task '$AutoStartTask' (autostart at logon)") {
-        & schtasks.exe /Delete /TN $AutoStartTask /F 2>$null | Out-Null
-        if ($LASTEXITCODE -eq 0) {
+        $ErrorActionPreference = 'Continue'
+        try {
+            & schtasks.exe /Delete /TN $AutoStartTask /F 2>$null | Out-Null
+            $delExit = $LASTEXITCODE
+        } finally {
+            $ErrorActionPreference = $prevEAP
+        }
+        if ($delExit -eq 0) {
             Write-Step "removed scheduled task $AutoStartTask"
         } else {
-            Write-WarningStep "schtasks /Delete /TN $AutoStartTask returned $LASTEXITCODE"
+            Write-WarningStep "schtasks /Delete /TN $AutoStartTask returned $delExit"
         }
     } else {
         Write-Step "skipped scheduled task $AutoStartTask (user declined)"


### PR DESCRIPTION
## Summary

Under `\$ErrorActionPreference = 'Stop'` (set at uninstall.ps1:57), PowerShell 5.1 treats native-command stderr as a terminating error. `2>\$null` masks the display but the error record still trips Stop and halts the script. Net effect: when the \`cua-driver-serve\` Scheduled Task is already gone (e.g. installer's autostart step failed earlier), \`schtasks /Query\` writes "task not found" to stderr, the script terminates, and phases 2-5 (kill daemon, remove junctions, remove package home) all skip.

## Fix

Locally lower \`\$ErrorActionPreference\` to \`Continue\` around both \`schtasks\` invocations (Query and Delete), restore via \`finally\`. Missing-task detection still uses \`\$LASTEXITCODE\` — same control flow.

## Repro

```powershell
# As cuademo (a standard admin user, NOT RID-500):
irm install.ps1 | iex                     # install OK
cua-driver autostart enable               # access-denied — task NOT registered
irm uninstall.ps1 | iex                   # ❌ halts at schtasks /Query
```

After this patch the uninstall completes cleanly through all 5 phases.

## Related

- Surfaced during the cuademo fresh-install dogfood that followed #1630 / #1631 / #1632.
- Sibling install.ps1 hardening: #1628 (PS 5.1 parse), #1631 (OSArchitecture / StrictMode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in the driver uninstall process to ensure scheduled tasks are reliably removed during uninstallation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1633?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->