### PR TITLE
fix(cua-driver-rs): CLI 'call' surfaces JSON parse errors with PS5.1 stdin-pipe hint (#1637, closes #1635)

### DIFF
--- a/libs/cua-driver-rs/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver-rs/crates/cua-driver/src/cli.rs
@@ -206,9 +206,34 @@ pub fn parse_command() -> Command {
         }
         Some("call") => {
             let tool = pos.next().unwrap_or("").to_string();
-            let json_args = pos.next()
-                .and_then(|s| serde_json::from_str(s).ok())
-                .or_else(|| read_stdin_json());
+            // Differentiate "no positional arg" (fall back to stdin) from
+            // "positional arg given but didn't parse as JSON" (surface the
+            // error instead of silently falling back to stdin and letting
+            // the tool's required-field validator emit a misleading
+            // "missing field X" later). See #1637.
+            //
+            // The common cause of an unparseable positional arg is
+            // PowerShell 5.1's native-command-arg quote-stripping on
+            // multi-field JSON — `'{"a":1,"b":2}'` arrives as `{a:1,b:2}`
+            // which serde_json rejects. The error message points users at
+            // the stdin-pipe workaround.
+            let json_args = match pos.next() {
+                Some(s) => match serde_json::from_str(s) {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        eprintln!("error: positional JSON arg to 'cua-driver call' did not parse: {e}");
+                        eprintln!("       received: {s}");
+                        eprintln!();
+                        eprintln!("hint: PowerShell 5.1 strips quotes around JSON field names in");
+                        eprintln!("      multi-field args. Pipe the JSON via stdin instead:");
+                        eprintln!("        '{{\"pid\":1234,\"window_id\":5678}}' | cua-driver call {}", tool);
+                        eprintln!();
+                        eprintln!("      Or use PowerShell 7+ (pwsh) which preserves the quotes.");
+                        process::exit(2);
+                    }
+                },
+                None => read_stdin_json(),
+            };
             Command::Call { tool, json_args, screenshot_out_file }
         }
         Some("telemetry") => {
@@ -251,10 +276,25 @@ pub fn parse_command() -> Command {
         }
         Some(first) => {
             // Implicit call: unrecognised first positional → treat as tool name.
+            // Same parse-error handling as the explicit `call` branch above. See #1637.
             let tool = first.to_string();
-            let json_args = pos.next()
-                .and_then(|s| serde_json::from_str(s).ok())
-                .or_else(|| read_stdin_json());
+            let json_args = match pos.next() {
+                Some(s) => match serde_json::from_str(s) {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        eprintln!("error: positional JSON arg to 'cua-driver {tool}' did not parse: {e}");
+                        eprintln!("       received: {s}");
+                        eprintln!();
+                        eprintln!("hint: PowerShell 5.1 strips quotes around JSON field names in");
+                        eprintln!("      multi-field args. Pipe the JSON via stdin instead:");
+                        eprintln!("        '{{\"pid\":1234,\"window_id\":5678}}' | cua-driver {}", tool);
+                        eprintln!();
+                        eprintln!("      Or use PowerShell 7+ (pwsh) which preserves the quotes.");
+                        process::exit(2);
+                    }
+                },
+                None => read_stdin_json(),
+            };
             Command::Call { tool, json_args, screenshot_out_file }
         }
     }

--- a/libs/cua-driver-rs/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/tools/impl_.rs
@@ -843,8 +843,15 @@ impl Tool for LaunchAppTool {
         }
 
         if target.is_none() && urls.is_empty() {
-            // Match Swift's wording verbatim.
-            return ToolResult::error("Provide either bundle_id or name to identify the app to launch.");
+            // Error message lists every field the resolver actually accepts.
+            // The Swift-original "bundle_id or name" message predated the Windows
+            // additions (aumid, path, launch_path, urls) and made #1635 look like
+            // an aumid-specific bug. The actual cause of #1635 was the upstream
+            // PS argv quote-stripping bug fixed in #1637; this message just stops
+            // misleading anyone who hits the error for unrelated reasons.
+            return ToolResult::error(
+                "Provide one of: bundle_id, name, aumid, path, launch_path, or urls to identify the app to launch.",
+            );
         }
 
         // ── Packaged-app (UWP / MSIX) routing decision ──────────────────────


### PR DESCRIPTION
## Summary

`cua-driver call <tool> <json>` used `.and_then(|s| serde_json::from_str(s).ok()).or_else(stdin)` which silently swallowed parse errors and fell back to stdin. On PowerShell 5.1, native-command argv parsing mangles multi-field JSON (strips quotes around field names) — the CLI never told the user. The tool's own required-field validator then emitted a misleading "missing field X" error.

## Fix

Differentiate "no positional arg" (legit stdin fallback) from "positional arg given but didn't parse" (emit clear error + stdin-pipe hint + exit 2). Applied to both `cua-driver call <tool>` and the implicit `cua-driver <tool>` paths.

Sample output after fix:

```
error: positional JSON arg to 'cua-driver call' did not parse: ...
       received: {pid:9912,window_id:197488}

hint: PowerShell 5.1 strips quotes around JSON field names in
      multi-field args. Pipe the JSON via stdin instead:
        '{"pid":1234,"window_id":5678}' | cua-driver call get_window_state

      Or use PowerShell 7+ (pwsh) which preserves the quotes.
```

## Also closes #1635

The launch_app error "Provide either bundle_id or name" was misleading — Windows resolver accepts `aumid`, `path`, `launch_path`, `urls` too. The Swift-original message predated those additions. Now reads: "Provide one of: bundle_id, name, aumid, path, launch_path, or urls".

Note: the actual root cause of #1635 (cuademo's `cua-driver call launch_app '{"aumid":"..."}'` failing) is the PS argv quote-stripping fixed above. The error-message tweak just prevents future confusion when someone hits the error for unrelated reasons.

Closes #1637, closes #1635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and diagnostic output when JSON argument parsing fails, now displaying detailed error information and platform-specific hints.
  * Enhanced validation error messages to enumerate all supported application identifier resolver options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1642?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->