### PR TITLE
fix(cua-driver-rs)(windows)(#1646): check_permissions reverts impersonation + uses explicit OpenProcess handle

### DIFF
--- a/libs/cua-driver-rs/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/tools/impl_.rs
@@ -3129,18 +3129,60 @@ impl Tool for CheckPermissionsTool {
         //
         // TokenIntegrityLevel asks the kernel directly: what IL is this token
         // at? RID 0x3000 (High) or higher == elevated; anything below is not.
-        use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+        //
+        // #1646: PR #1641's initial implementation called
+        // `OpenProcessToken(GetCurrentProcess(), ...)` and STILL misreported
+        // High-IL daemons as Medium IL. Root cause: the named-pipe server's
+        // handler thread can be left impersonating the connecting client
+        // (cuademo's Medium-IL shell, in the failing case), and on Windows
+        // the impersonation token leaks through `GetCurrentProcess()`'s
+        // pseudo-handle in a way that returns the impersonation token's IL
+        // rather than the primary token's. Two-part fix:
+        //   1. `RevertToSelf()` at the top — drops any active impersonation
+        //      on this thread so subsequent token queries see the primary.
+        //   2. `OpenProcess(GetCurrentProcessId())` — uses an explicit
+        //      handle to the daemon's own process, mirroring the working
+        //      C# diagnostic (Win32 OpenProcess + OpenProcessToken from a
+        //      Medium-IL shell against the daemon's pid). Avoids any
+        //      pseudo-handle quirks.
+        use windows::Win32::System::Threading::{
+            GetCurrentProcessId, OpenProcess, OpenProcessToken, PROCESS_QUERY_LIMITED_INFORMATION,
+        };
         use windows::Win32::Security::{
-            GetTokenInformation, TokenIntegrityLevel, TOKEN_MANDATORY_LABEL, TOKEN_QUERY,
-            GetSidSubAuthority, GetSidSubAuthorityCount,
+            GetTokenInformation, RevertToSelf, TokenIntegrityLevel, TOKEN_MANDATORY_LABEL,
+            TOKEN_QUERY, GetSidSubAuthority, GetSidSubAuthorityCount,
         };
 
         const HIGH_IL_RID: u32 = 0x3000;
 
         let il_rid: Option<u32> = unsafe {
-            let proc = GetCurrentProcess();
+            // Drop any impersonation on this thread before we query. The
+            // call returns BOOL — if there's nothing to revert it returns
+            // FALSE with ERROR_NO_TOKEN, which is fine and not an error.
+            let _ = RevertToSelf();
+
+            let proc_handle = match OpenProcess(
+                PROCESS_QUERY_LIMITED_INFORMATION,
+                false,
+                GetCurrentProcessId(),
+            ) {
+                Ok(h) => h,
+                Err(_) => {
+                    // Should never happen — we always have rights to query
+                    // our own process. Bail and report Unavailable.
+                    return ToolResult::text("Process integrity level: Unavailable (OpenProcess on self failed)")
+                        .with_structured(json!({
+                            "elevated": false,
+                            "integrity_level": "Unavailable",
+                            "integrity_level_rid": serde_json::Value::Null,
+                            "uia": true,
+                            "post_message": true,
+                        }));
+                }
+            };
             let mut token = windows::Win32::Foundation::HANDLE::default();
-            if OpenProcessToken(proc, TOKEN_QUERY, &mut token).is_err() {
+            if OpenProcessToken(proc_handle, TOKEN_QUERY, &mut token).is_err() {
+                let _ = windows::Win32::Foundation::CloseHandle(proc_handle);
                 None
             } else {
                 let mut needed: u32 = 0;
@@ -3188,6 +3230,7 @@ impl Tool for CheckPermissionsTool {
                     }
                 };
                 let _ = windows::Win32::Foundation::CloseHandle(token);
+                let _ = windows::Win32::Foundation::CloseHandle(proc_handle);
                 rid
             }
         };


### PR DESCRIPTION
## Summary

PR #1641 fixed \`check_permissions\` to read \`TokenIntegrityLevel\` instead of the legacy \`TokenIsElevated\` flag. The new code STILL misreported — on a cuademo daemon at kernel-verified IL=0x3000 (High), \`check_permissions\` returned IL=0x2000 (Medium). The same C# Win32 code reading the same token externally (\`OpenProcess(pid) → OpenProcessToken\`) returned the correct High IL.

## Root cause

The named-pipe server's handler thread can be left impersonating the connecting client token. \`GetCurrentProcess()\`'s pseudo-handle interacts with the impersonation context such that \`OpenProcessToken(pseudo_handle, ...)\` returns the impersonation token's IL rather than the primary token's. Net effect: a daemon at High IL serving a request from a Medium-IL client reports Medium IL.

## Fix

\`crates/platform-windows/src/tools/impl_.rs::CheckPermissionsTool::invoke\` now does two things at the top:

1. \`RevertToSelf()\` — drops any active impersonation on this thread before the query.
2. \`OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, GetCurrentProcessId())\` for an explicit handle, instead of the pseudo-handle from \`GetCurrentProcess()\`. Closed alongside the token handle in cleanup.

## Verification

cuademo non-RID-500 admin on Windows 11 24H2:

Before:
\`\`\`
direct Win32 (PowerShell C#):  IL=High (RID=12288) ✓
cua-driver call check_permissions: IL=Medium (RID=8192) ✗
\`\`\`

After:
\`\`\`
direct Win32 (PowerShell C#):  IL=High (RID=12288)
cua-driver call check_permissions: integrity_level: "High", integrity_level_rid: 12288 ✓
\`\`\`

## Closes / related

- Closes #1646
- Followup audit item: ALL tool handlers should be robust against impersonation leaks from the pipe layer. A wider sweep of \`crates/platform-windows/src/tools/impl_.rs\` for any code that reads thread/process security state without \`RevertToSelf()\` first is worth doing — filed as a triage TODO in #1646.
- Reconfirms PR #1641's premise (TokenIntegrityLevel is the right field to query); just fixes the QUERY CONTEXT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved Windows permissions checking to prevent potential security issues with token handling during integrity verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->