### PR TITLE
fix(cua-driver-rs)(windows): install.ps1 migration uses schtasks /End to kill High-IL legacy daemon

### DIFF
--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -891,20 +891,48 @@ function Remove-LegacyInstall {
 
     Write-Step "detected legacy install layout (v0.2.13 or earlier); migrating to Cua\cua-driver"
 
-    # 1. Stop any cua-driver / cua-driver-uia daemon that's pinning the
-    #    legacy binary directory open. Use the regular Get-Process route —
-    #    these are user-owned processes, kill is allowed.
+    # 1. End the running daemon. Order matters:
+    #
+    #    a. `schtasks /End` first — Task Scheduler runs as SYSTEM and can
+    #       terminate elevated (RunLevel=Highest, High IL) processes that a
+    #       Medium-IL Stop-Process from the user's shell cannot. This is
+    #       the case any time the legacy daemon was spawned via the
+    #       AtLogon trigger of the v0.2.13 autostart task on a non-RID-500
+    #       admin account (e.g. cuademo). Without this, Step 4 below fails
+    #       with "Access to the path 'cua-driver.exe' is denied" because
+    #       the legacy binary is held open by an unkillable elevated
+    #       process. Discovered during the cuademo v0.2.13 → v0.2.14
+    #       migration dogfood.
+    #    b. taskkill /F /IM as a backstop for any cua-driver process that
+    #       wasn't task-attached (manual `cua-driver serve`, legacy uia
+    #       worker, etc.). taskkill is more permissive than Stop-Process
+    #       for cross-IL termination.
+    #    c. Stop-Process last — catches anything taskkill missed.
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        # Ends the running task instance. Returns non-zero when the task
+        # isn't running or doesn't exist, both of which we swallow.
+        & schtasks.exe /End /TN "cua-driver-serve" 2>$null | Out-Null
+        Start-Sleep -Milliseconds 250
+        # Force-kill via taskkill — handles High-IL processes that
+        # Stop-Process can't touch from a Medium-IL caller.
+        & taskkill.exe /F /IM "cua-driver.exe" /T 2>$null | Out-Null
+        & taskkill.exe /F /IM "cua-driver-uia.exe" /T 2>$null | Out-Null
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
     $procs = Get-Process -Name "cua-driver","cua-driver-uia" -ErrorAction SilentlyContinue
     if ($procs) {
         foreach ($p in $procs) {
             try { Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue } catch {}
         }
-        Start-Sleep -Milliseconds 250
     }
+    Start-Sleep -Milliseconds 500
 
     # 2. Unregister the autostart Scheduled Task if present. Idempotent —
-    #    schtasks /Query returns non-zero when the task is absent, which we
-    #    swallow (matches uninstall.ps1's pattern for the same call).
+    #    schtasks /Delete returns non-zero when the task is absent, which
+    #    we swallow.
     $prevEAP = $ErrorActionPreference
     $ErrorActionPreference = 'Continue'
     try {


### PR DESCRIPTION
## Summary

PR #1644's v0.2.14 migration step relied on \`Stop-Process\` to terminate the legacy running daemon before removing legacy directories. On non-RID-500 admin accounts (cuademo) where the daemon was spawned via v0.2.13's \`RunLevel=Highest\` AtLogon trigger, the daemon is at High IL — and a Medium-IL Stop-Process call from the user's install.ps1 shell gets access-denied. The legacy \`.cua-driver-rs\\\` directory then can't be removed because the binary is held open by an unkillable elevated process.

## Fix

Three-tier kill in migration step 1:
1. \`schtasks /End /TN cua-driver-serve\` — Task Scheduler (running as SYSTEM) terminates elevated processes that Stop-Process can't.
2. \`taskkill /F /IM cua-driver.exe /T\` + same for cua-driver-uia.exe — Win32 service-layer fallback.
3. \`Stop-Process\` — catches the rest.

Plus a 500ms final sleep so the kernel can finalize process tear-down before the directory removal.

## Repro (from cuademo v0.2.14 dogfood)

```powershell
PS> irm install.ps1 | iex
==> detected legacy install layout (v0.2.13 or earlier); migrating to Cua\cua-driver
  (could not remove C:\Users\cuademo\.cua-driver-rs : Access to the path 'cua-driver.exe' is denied.)
==>   pruned legacy ... from User PATH
==> legacy install removed   ← misleading; .cua-driver-rs\ still has orphan files
```

After this PR, the schtasks /End call kills the High-IL daemon, the binary file handle is released, and the .cua-driver-rs\ tree removes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the installation cleanup process during uninstallation or upgrade to more reliably terminate driver processes using an improved multi-stage approach.
  * Improved the robustness of scheduled task cleanup operations, with better handling of edge cases where tasks may already be absent or require forced termination.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->