### PR TITLE
fix(cua-driver)(#1651): install.ps1 updates current shell's PATH for immediate cua-driver resolution

### DIFF
--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -1109,6 +1109,17 @@ function Add-UserPathEntry([string]$dir) {
         $newValue = $dir
     }
     [Environment]::SetEnvironmentVariable("Path", $newValue, "User")
+
+    # Also update the CURRENT process's $env:Path so `cua-driver` resolves
+    # immediately in the same shell — the SetEnvironmentVariable('User') call
+    # above only writes to the registry; existing processes have their
+    # $env:Path cached at launch time and don't see the update otherwise.
+    # The install.ps1 body runs in the caller's shell via iex (per the
+    # `irm install.ps1 | iex` one-liner), so writing $env:Path here mutates
+    # exactly the shell the user is typing into. See #1651.
+    if (-not (($env:Path -split ';') -contains $dir)) {
+        $env:Path = "$dir;$env:Path"
+    }
 }
 
 function Write-ManualPathInstructions([string]$dir) {
@@ -1117,7 +1128,7 @@ function Write-ManualPathInstructions([string]$dir) {
     Write-Host ""
     Write-Host "  [Environment]::SetEnvironmentVariable('Path', `"`$([Environment]::GetEnvironmentVariable('Path','User'));$dir`", 'User')"
     Write-Host ""
-    Write-Host "Then open a new PowerShell window. To use it in the current session:"
+    Write-Host "To use it in the current session immediately:"
     Write-Host ""
     Write-Host "  `$env:Path += `";$dir`""
     Write-Host ""
@@ -1143,8 +1154,7 @@ else {
     try {
         Add-UserPathEntry $VisibleBinDir
         Write-Host "Added $VisibleBinDir to your User PATH." -ForegroundColor Green
-        Write-Host '  cua-driver will resolve in any NEW PowerShell window.'
-        Write-Host '  In THIS shell, invoke via the full Binary path printed below.'
+        Write-Host '  cua-driver resolves immediately in THIS shell and in any new shell.'
         Write-Host '  Opt out next time with: install.ps1 -NoPathUpdate'
         Write-Host ""
     }


### PR DESCRIPTION
## Summary

After \`irm install.ps1 | iex\`, the user's next \`cua-driver --version\` fails with "not recognized" because PowerShell's \`\$env:Path\` was cached at process start and doesn't see the User PATH registry update. install.ps1 runs in the caller's shell via \`iex\`, so it CAN mutate \`\$env:Path\` directly. This PR makes \`Add-UserPathEntry\` do that too.

## Fix

Two-line change in \`Add-UserPathEntry\`:
\`\`\`powershell
if (-not (($env:Path -split ';') -contains $dir)) {
    $env:Path = "$dir;$env:Path"
}
\`\`\`

Plus hint-message update: "resolves immediately in THIS shell and in any new shell."

## Verification

Before:
\`\`\`
PS> irm install.ps1 | iex
... cua-driver-rs 0.2.16 installed.
PS> cua-driver --version
cua-driver : The term 'cua-driver' is not recognized ...
\`\`\`

After (v0.2.17):
\`\`\`
PS> irm install.ps1 | iex
... cua-driver-rs 0.2.17 installed.
PS> cua-driver --version
cua-driver 0.2.17
\`\`\`

Closes #1651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The installer now updates your current shell session's PATH immediately after installation, allowing you to use `cua-driver` without restarting your terminal.
  * Updated installer messaging to clarify that `cua-driver` is available immediately in the current session.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1652?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->