### PR TITLE
fix(autostart): hide console window at logon via PowerShell wrapper

### DIFF
--- a/libs/cua-driver-rs/crates/cua-driver/src/autostart.rs
+++ b/libs/cua-driver-rs/crates/cua-driver/src/autostart.rs
@@ -115,6 +115,15 @@ mod platform {
     /// install.ps1 surfaces any divergence; the moment install.ps1 changes
     /// shape, this script needs the same edit.
     ///
+    /// **Hidden-console launch (issue #1645):** the task action wraps
+    /// `cua-driver.exe serve` in `powershell -WindowStyle Hidden` +
+    /// `Start-Process -WindowStyle Hidden`. Without this, Task Scheduler
+    /// allocates a new CUI console window (because `cua-driver.exe` is a
+    /// console-subsystem binary) that stays visible on the user's desktop
+    /// for the lifetime of the daemon. The PowerShell wrapper exits
+    /// immediately after spawning the child, leaving only `cua-driver.exe`
+    /// in the process tree.
+    ///
     /// **RunLevel = Highest** (since 2026-05-21): the daemon is registered to
     /// run at the user's elevated/admin token rather than the filtered
     /// standard-user token. This is what lets the daemon drive UWP /
@@ -145,7 +154,18 @@ if ($env:USERDOMAIN -and $env:USERDOMAIN -ne 'WORKGROUP' -and $env:USERDOMAIN -n
     $domain = $env:COMPUTERNAME
 }
 $user = "$domain\$env:USERNAME"
-$action = New-ScheduledTaskAction -Execute $env:CUA_DRIVER_AS_EXE -Argument 'serve' -WorkingDirectory $env:USERPROFILE
+# Use a hidden PowerShell wrapper as the task action so Windows never
+# allocates a visible console window when the daemon is launched at
+# logon. cua-driver.exe is a CUI (console-subsystem) binary: without
+# this wrapper, Task Scheduler allocates a new console and the window
+# stays on the user's desktop for the lifetime of the daemon (issue #1645).
+# Start-Process -WindowStyle Hidden spawns the child fully detached;
+# the powershell.exe wrapper exits immediately after, leaving only the
+# cua-driver.exe daemon in the process tree.
+$action = New-ScheduledTaskAction `
+    -Execute 'powershell.exe' `
+    -Argument "-NoProfile -WindowStyle Hidden -NonInteractive -Command `"Start-Process -FilePath '$env:CUA_DRIVER_AS_EXE' -ArgumentList 'serve' -WindowStyle Hidden -WorkingDirectory '$env:USERPROFILE'`"" `
+    -WorkingDirectory $env:USERPROFILE
 $trigger = New-ScheduledTaskTrigger -AtLogOn -User $user
 $principal = New-ScheduledTaskPrincipal -UserId $user -LogonType Interactive -RunLevel Highest
 $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1) -ExecutionTimeLimit (New-TimeSpan -Hours 0)


### PR DESCRIPTION
## Problem

The `cua-driver-serve` Scheduled Task launches a visible console window at every interactive logon (issue #1645). `cua-driver.exe` is a CUI binary — without a parent console, Task Scheduler allocates one and it stays on the desktop for the daemon lifetime.

## Fix

Implement **Option 2** from the issue: wrap the task action in a hidden PowerShell launcher.

**Before:**
```
Action: cua-driver.exe serve
```

**After:**
```
Action: powershell.exe -NoProfile -WindowStyle Hidden -NonInteractive
        -Command "Start-Process -FilePath <exe>
                  -ArgumentList 'serve' -WindowStyle Hidden
                  -WorkingDirectory <home>"
```

`Start-Process -WindowStyle Hidden` spawns the daemon fully detached. The `powershell.exe` wrapper exits immediately, leaving only `cua-driver.exe` in the process tree. No visible window, no flash.

Fixes #1645

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Windows autostart feature to launch the daemon silently without displaying a console window at user logon, improving startup experience.

* **Documentation**
  * Updated documentation to explain the hidden-console startup behavior and resulting process tree management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1654?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->