### PR TITLE
fix(cua-driver-rs): rename agent-cursor overlay namespace TropeCUA → Cua

### DIFF
--- a/libs/cua-driver-rs/crates/platform-linux/src/overlay.rs
+++ b/libs/cua-driver-rs/crates/platform-linux/src/overlay.rs
@@ -441,7 +441,9 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayCo
     ).ok();
 
     // Set window title (identifies our overlay, matches Windows convention).
-    let title = format!("TropeCUA.AgentCursorOverlay.{}", cfg.cursor_id);
+    // `Cua.` namespace mirrors the Windows class-name + install-path
+    // convention; was `TropeCUA.` (leaked codename from an early C# ref).
+    let title = format!("Cua.AgentCursorOverlay.{}", cfg.cursor_id);
     conn.change_property8(
         PropMode::REPLACE, win,
         AtomEnum::WM_NAME,

--- a/libs/cua-driver-rs/crates/platform-windows/examples/overlay_dump.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/examples/overlay_dump.rs
@@ -37,8 +37,8 @@ fn main() {
 
     std::thread::sleep(Duration::from_millis(1500));
 
-    // Find overlay HWND.
-    let class_name: Vec<u16> = OsStr::new("TropeCUA.AgentCursorOverlay\0")
+    // Find overlay HWND (class name matches what overlay.rs registers).
+    let class_name: Vec<u16> = OsStr::new("Cua.AgentCursorOverlay\0")
         .encode_wide().collect();
     let hwnd = unsafe { FindWindowW(
         windows::core::PCWSTR(class_name.as_ptr()),

--- a/libs/cua-driver-rs/crates/platform-windows/src/overlay.rs
+++ b/libs/cua-driver-rs/crates/platform-windows/src/overlay.rs
@@ -501,9 +501,14 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayCo
         }
     }
 
-    // Register window class.
-    let class_name_w: Vec<u16> = "TropeCUA.AgentCursorOverlay\0".encode_utf16().collect();
-    let title_w: Vec<u16> = format!("TropeCUA.AgentCursorOverlay.{}\0", cfg.cursor_id)
+    // Register window class. Class + title use the `Cua.` namespace
+    // (PascalCase Windows-class convention, matches the `Programs\Cua\`
+    // install-path namespace). Prior versions used `TropeCUA.` — a leaked
+    // codename from an early C# reference impl. The string is observable
+    // via Win32 EnumWindows; renaming gives users a recognisable namespace
+    // (and the `trycua/` org branding) instead of "what's a TropeCUA?".
+    let class_name_w: Vec<u16> = "Cua.AgentCursorOverlay\0".encode_utf16().collect();
+    let title_w: Vec<u16> = format!("Cua.AgentCursorOverlay.{}\0", cfg.cursor_id)
         .encode_utf16().collect();
 
     let hinstance = unsafe { GetModuleHandleW(PCWSTR::null()).unwrap_or_default() };


### PR DESCRIPTION
## Summary

The transparent agent-cursor overlay window registers under the namespace \`TropeCUA.AgentCursorOverlay\` — a leaked codename from an early C# reference impl. Renaming to \`Cua.AgentCursorOverlay\`:

- Matches the v0.2.14+ install-path convention (\`Programs\\Cua\\cua-driver\`).
- Matches PascalCase Windows-class-name convention.
- Gives users a recognisable \`Cua.*\` namespace in EnumWindows / Spy++ / Task Manager.
- Cross-platform: Linux X11 \`WM_NAME\` mirrored too.

## Surfaced

During cuademo dogfood — \`EnumWindows\` against the daemon's pid listed \`TropeCUA.AgentCursorOverlay.default\` as a visible top-level window. The window is intentional (transparent click-through cursor visualization) but the name confused the user.

## Files touched

- \`crates/platform-windows/src/overlay.rs\` — class + title
- \`crates/platform-linux/src/overlay.rs\` — X11 WM_NAME
- \`crates/platform-windows/examples/overlay_dump.rs\` — \`FindWindowW\` class match (kept in sync so the example still resolves the HWND)

## Compat

Class + title strings are window-metadata, not public API. No known external tools depend on the \`TropeCUA.*\` string. Agent-cursor MCP tools reference the overlay by \`cursor_id\`, not class/title — unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal window identification naming conventions across Linux and Windows platforms for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->