### PR TITLE
fix(cua-driver-rs)(dev)(#1631): install-local.ps1 arch detection under StrictMode

### DIFF
--- a/libs/cua-driver-rs/scripts/install-local.ps1
+++ b/libs/cua-driver-rs/scripts/install-local.ps1
@@ -54,10 +54,13 @@ $RepoRoot    = (Resolve-Path "$ScriptDir\..").Path
 $BinaryName  = "cua-driver.exe"
 # Always release-config — matches the binary install.ps1 hands end users.
 $Config      = "release"
-$Target      = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') {
-    "aarch64-pc-windows-msvc"
-} else {
-    "x86_64-pc-windows-msvc"
+# Arch detection — use $env:PROCESSOR_ARCHITECTURE rather than
+# RuntimeInformation::OSArchitecture so this works under
+# Set-StrictMode -Version Latest (same fix as install.ps1 PR #1631).
+$archEnv = $env:PROCESSOR_ARCHITECTURE
+$Target = switch -Regex ($archEnv) {
+    '^ARM64$' { "aarch64-pc-windows-msvc"; break }
+    default   { "x86_64-pc-windows-msvc" }
 }
 
 # ---------- Paths (must match install.ps1's defaults) ----------------------


### PR DESCRIPTION
## Summary

`install-local.ps1` was using `[System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture` which trips `Set-StrictMode -Version Latest`:
```
The property 'OSArchitecture' cannot be found on this object.
```

Same fix PR #1631 applied to install.ps1 — use `$env:PROCESSOR_ARCHITECTURE` instead.

Surfaced live in fbonacci's RDP shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows installer's system architecture detection to accurately identify your hardware type
  * Enhanced support for ARM64-based Windows systems to ensure proper installation targeting and configuration
  * Updated installer mechanism for more reliable platform identification across all Windows variants
  * Optimized automatic build selection to deploy the correct platform-specific version for your system

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1658?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->