### PR TITLE
docs(install.ps1): remove false claim that UWP needs the elevated autostart task

### DIFF
--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -1200,9 +1200,9 @@ else {
     Write-Host ""                                                                          -ForegroundColor Cyan
     Write-Host "  Or re-run this installer with -AutoStart for the same result."           -ForegroundColor Cyan
     Write-Host ""                                                                          -ForegroundColor Cyan
-    Write-Host "  Without auto-start, the daemon runs at the user's default token IL."     -ForegroundColor Cyan
-    Write-Host "  That's fine for Win32 + Chromium apps. UWP / AppContainer apps"          -ForegroundColor Cyan
-    Write-Host "  (Calculator, modern Settings, Photos) need the elevated autostart task." -ForegroundColor Cyan
+    Write-Host "  Without auto-start, you'll need to run 'cua-driver serve' manually."     -ForegroundColor Cyan
+    Write-Host "  Auto-start spawns the daemon at logon at RunLevel=Highest, which is"     -ForegroundColor Cyan
+    Write-Host "  needed for some elevated operations (registry, services, ACLs)."         -ForegroundColor Cyan
 }
 
 


### PR DESCRIPTION
## Summary

install.ps1's post-install hint was telling users:

> Without auto-start, the daemon runs at the user's default token IL.
> That's fine for Win32 + Chromium apps. UWP / AppContainer apps
> (Calculator, modern Settings, Photos) need the elevated autostart task.

The "**UWP needs the elevated autostart task**" claim is wrong. Empirical verification during 2026-05-22 Windows dogfood arc:

| Account | IL | Calculator UIA \`element_count\` |
|---|---|---|
| fbonacci (RID 500) at High IL via RunLevel=Highest task | High | **41** |
| cuademo (regular admin, UAC-split) running cua-driver directly from her PowerShell | **Medium** | **41** |

So UWP / AppContainer UIA works at Medium IL too. The IL gating turned out to be a methodological artifact — earlier 0-element results came from running tests in non-interactive SSH / psexec contexts, which can't drive UIA cross-AppContainer correctly **regardless of IL**. Live RDP sessions just work at any IL level.

Replacing the hint with the honest reason RunLevel=Highest is useful: elevated operations like registry / services / ACL writes the daemon may need. UWP is not the differentiator.

## Follow-ups
- #1602 (EV cert + UIAccess for UWP) will be closed — premise was wrong
- #1638 (RunLevel=Highest doesn't elevate) will be closed — both premises wrong
- #1657 (overlay default disabled) will be closed — overlay is intentional UX

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installer messaging to clarify that users must manually run `cua-driver serve` when auto-start is not enabled, and explained how auto-start allows the daemon to run with elevated privileges at system logon for privileged operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->