### PR TITLE
fix(computer-server): route single printable keypress through type_text

### DIFF
--- a/libs/python/computer-server/computer_server/main.py
+++ b/libs/python/computer-server/computer_server/main.py
@@ -1154,7 +1154,30 @@ async def agent_response_endpoint(
             parts = [normalize_key(p) for p in parts]
 
             if len(parts) == 1:
-                await self._auto.press_key(parts[0])
+                key = parts[0]
+                # Route single printable characters through type_text so the
+                # insertion is layout-independent. press_key uses a physical-key
+                # path (pynput keyboard.press/release) that follows the active
+                # input source — under a Russian or CJK layout it inserts the
+                # layout-mapped character instead of the intended ASCII one.
+                # type_text uses pynput keyboard.type() which bypasses the
+                # layout and inserts the literal Unicode codepoint.
+                #
+                # A key is "printable" when it is exactly one character long
+                # and unicodedata.category is not a control category (Cc/Cs).
+                # Special keys (return, tab, escape, arrows, f1-f12, …) are
+                # multi-character strings or map to a Key enum — those still
+                # go through press_key unchanged.
+                #
+                # See: https://github.com/trycua/cua/issues/1605
+                import unicodedata
+                if (
+                    len(key) == 1
+                    and unicodedata.category(key) not in ("Cc", "Cs", "Cn")
+                ):
+                    await self._auto.type_text(key)
+                else:
+                    await self._auto.press_key(key)
             else:
                 await self._auto.hotkey(parts)
 

--- a/libs/python/computer-server/tests/test_keypress_layout.py
+++ b/libs/python/computer-server/tests/test_keypress_layout.py
@@ -1,0 +1,115 @@
+"""Tests for keypress layout-independence fix (issue #1605).
+
+Verifies that single printable characters are routed through type_text
+(layout-independent) rather than press_key (layout-dependent).
+"""
+
+import unicodedata
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+
+def _is_printable_char(key: str) -> bool:
+    """Mirror of the routing logic in DirectComputer.keypress()."""
+    return (
+        len(key) == 1
+        and unicodedata.category(key) not in ("Cc", "Cs", "Cn")
+    )
+
+
+class TestPrintableCharDetection:
+    """Unit tests for the printable-character detection logic."""
+
+    def test_ascii_letter_is_printable(self):
+        assert _is_printable_char("a") is True
+        assert _is_printable_char("Z") is True
+
+    def test_ascii_digit_is_printable(self):
+        assert _is_printable_char("0") is True
+        assert _is_printable_char("9") is True
+
+    def test_ascii_punctuation_is_printable(self):
+        assert _is_printable_char("/") is True
+        assert _is_printable_char(".") is True
+        assert _is_printable_char("_") is True
+
+    def test_space_is_printable(self):
+        # Space (U+0020) has category Zs — printable, should use type_text.
+        assert _is_printable_char(" ") is True
+
+    def test_special_key_names_are_not_printable(self):
+        # Multi-char strings are never single printable chars.
+        assert _is_printable_char("return") is False
+        assert _is_printable_char("tab") is False
+        assert _is_printable_char("escape") is False
+        assert _is_printable_char("f1") is False
+        assert _is_printable_char("backspace") is False
+        assert _is_printable_char("up") is False
+
+    def test_control_characters_are_not_printable(self):
+        # Cc category — should go through press_key, not type_text.
+        assert _is_printable_char("\x00") is False
+        assert _is_printable_char("\x1b") is False  # ESC
+        assert _is_printable_char("\n") is False     # newline
+
+    def test_empty_string_is_not_printable(self):
+        assert _is_printable_char("") is False
+
+
+@pytest.mark.asyncio
+async def test_keypress_single_printable_uses_type_text():
+    """Single printable char must call type_text, not press_key."""
+    auto = MagicMock()
+    auto.type_text = AsyncMock()
+    auto.press_key = AsyncMock()
+    auto.hotkey   = AsyncMock()
+
+    # Simulate the routing logic directly.
+    key = "a"
+    if _is_printable_char(key):
+        await auto.type_text(key)
+    else:
+        await auto.press_key(key)
+
+    auto.type_text.assert_awaited_once_with("a")
+    auto.press_key.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_keypress_special_key_uses_press_key():
+    """Special key names must still call press_key."""
+    auto = MagicMock()
+    auto.type_text = AsyncMock()
+    auto.press_key = AsyncMock()
+
+    key = "return"
+    if _is_printable_char(key):
+        await auto.type_text(key)
+    else:
+        await auto.press_key(key)
+
+    auto.press_key.assert_awaited_once_with("return")
+    auto.type_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_keypress_combo_uses_hotkey():
+    """Multi-key combos must still call hotkey."""
+    auto = MagicMock()
+    auto.hotkey   = AsyncMock()
+    auto.type_text = AsyncMock()
+    auto.press_key = AsyncMock()
+
+    parts = ["cmd", "shift", "g"]
+    if len(parts) == 1:
+        key = parts[0]
+        if _is_printable_char(key):
+            await auto.type_text(key)
+        else:
+            await auto.press_key(key)
+    else:
+        await auto.hotkey(parts)
+
+    auto.hotkey.assert_awaited_once_with(["cmd", "shift", "g"])
+    auto.type_text.assert_not_awaited()
+    auto.press_key.assert_not_awaited()


### PR DESCRIPTION
## Problem

`keypress()` with a single printable character (e.g. `'a'`, `'/'`) was routed through `press_key()`, which uses pynput `keyboard.press/release` — a physical-key path that follows the active input source. Under a Russian, CJK, or any non-Latin layout this inserts the layout-mapped character instead of the intended ASCII one, breaking Finder path entry and any agent workflow that types text character-by-character.

## Fix

Detect single printable characters via `unicodedata.category` and route them through `type_text()` instead. `type_text()` uses pynput `keyboard.type()` which inserts the literal Unicode codepoint regardless of the active input source.

**Detection rule:** `len(key) == 1 and category not in (Cc, Cs, Cn)`

| Input | Before | After |
|-------|--------|-------|
| `'a'`, `'/'`, `'0'`, `' '` | `press_key` (layout-dependent) | `type_text` (layout-independent) |
| `'return'`, `'tab'`, `'escape'` | `press_key` | `press_key` (unchanged) |
| `['cmd', 'shift', 'g']` | `hotkey` | `hotkey` (unchanged) |

## Tests

10 unit tests in `test_keypress_layout.py` — all passing.

Fixes #1605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard input handling to properly support different keyboard layouts by routing single printable characters through text insertion while maintaining special key support.

* **Tests**
  * Added comprehensive test coverage for keyboard input routing scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1660?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->