### PR TITLE
fix(cua-driver-rs): TTY hint instead of silent stdin hang on bare invocation

### DIFF
--- a/libs/cua-driver-rs/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver-rs/crates/cua-driver/src/cli.rs
@@ -172,7 +172,34 @@ pub fn parse_command() -> Command {
 
     let mut pos = positionals.into_iter();
     match pos.next() {
-        None | Some("mcp") => Command::Mcp {
+        None => {
+            // Bare `cua-driver` defaults to MCP, which reads JSON-RPC from
+            // stdin forever. From a terminal that looks like a hang. If
+            // stdin is a TTY (i.e. interactive shell, no client piping
+            // stdio), surface a hint and exit. Piped / redirected stdin —
+            // the normal MCP client case — falls through to MCP mode.
+            // Explicit `cua-driver mcp` bypasses the check entirely.
+            use std::io::IsTerminal as _;
+            if std::io::stdin().is_terminal() {
+                eprintln!("cua-driver: bare invocation defaults to the MCP server, which reads");
+                eprintln!("JSON-RPC from stdin. From a terminal that looks like a hang.");
+                eprintln!();
+                eprintln!("You probably meant one of:");
+                eprintln!("  cua-driver list-tools                           # available tools");
+                eprintln!("  cua-driver status                               # check the daemon");
+                eprintln!("  cua-driver mcp-config --client claude-code      # wire into a client");
+                eprintln!("  cua-driver --help                               # everything else");
+                eprintln!();
+                eprintln!("To run the MCP server explicitly (and pipe JSON-RPC by hand):");
+                eprintln!("  cua-driver mcp");
+                std::process::exit(0);
+            }
+            Command::Mcp {
+                no_daemon_relaunch,
+                socket: socket.clone(),
+            }
+        }
+        Some("mcp") => Command::Mcp {
             no_daemon_relaunch,
             socket: socket.clone(),
         },


### PR DESCRIPTION
## Summary

Bare \`cua-driver\` (no subcommand) defaults to MCP mode and reads JSON-RPC from stdin forever. From an interactive terminal that looks like a hang — users see no output and assume the binary is broken.

This PR adds a stdin-is-a-TTY check. When true, print a one-paragraph hint and exit 0. When stdin is piped/redirected (the normal MCP client case — Claude Code, Claude Desktop, etc.), behaviour is unchanged.

## Before

\`\`\`
PS> cua-driver
<hangs forever>
\`\`\`

## After

\`\`\`
PS> cua-driver
cua-driver: bare invocation defaults to the MCP server, which reads
JSON-RPC from stdin. From a terminal that looks like a hang.

You probably meant one of:
  cua-driver list-tools                           # available tools
  cua-driver status                               # check the daemon
  cua-driver mcp-config --client claude-code      # wire into a client
  cua-driver --help                               # everything else

To run the MCP server explicitly (and pipe JSON-RPC by hand):
  cua-driver mcp
PS> $LASTEXITCODE
0
\`\`\`

Explicit \`cua-driver mcp\` bypasses the check for power users who want to pipe JSON-RPC by hand.

## Implementation

\`std::io::IsTerminal\` (stable since Rust 1.70) on \`stdin()\`. Hint to stderr so it never collides with an MCP wire on stdout. Exit 0 since this is a successful diagnosis, not a failure.

## Test plan

- [x] Build clean on Windows (\`cargo build --release -p cua-driver\` — 0 warnings)
- [x] \`cargo test -p cua-driver\` — 49/49 pass
- [x] \`cua-driver --version\` still works
- [x] \`cua-driver list-tools\` still works
- [ ] Reviewer: confirm hint appears when run bare from a real terminal on macOS / Linux
- [ ] Reviewer: confirm piped invocation (e.g. \`echo '{...}' | cua-driver\`) still enters MCP loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added helpful guidance message when running the CLI with no arguments in an interactive terminal, explaining the default MCP server behavior and listing available subcommands.

* **Bug Fixes**
  * Improved CLI experience to reduce confusion from apparent hangs when running in interactive mode by providing clear instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->