### PR TITLE
fix(cua-driver-rs)(scripts): point Rust dev installers at libs/cua-driver/rust/

### DIFF
--- a/libs/cua-driver/scripts/_install-local-rust.sh
+++ b/libs/cua-driver/scripts/_install-local-rust.sh
@@ -38,7 +38,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Rust workspace root: scripts/ is the cross-cutting installer dir at
+# libs/cua-driver/scripts/; the Cargo workspace lives one level deeper
+# under libs/cua-driver/rust/.
+REPO_ROOT="$(cd "$SCRIPT_DIR/../rust" && pwd)"
 
 BOLD=$(tput bold 2>/dev/null || true)
 NORMAL=$(tput sgr0 2>/dev/null || true)
@@ -150,7 +153,7 @@ chmod +x "$VERSIONED_DIR/cua-driver"
 # Skill pack — stage from the repo so the `current` symlink below
 # transparently exposes it to agents. Mirrors what install.sh does
 # from a release tarball.
-SOURCE_SKILLS="$SCRIPT_DIR/../Skills/cua-driver-rs"
+SOURCE_SKILLS="$REPO_ROOT/Skills/cua-driver-rs"
 if [ -d "$SOURCE_SKILLS" ]; then
     STAGED_SKILLS="$VERSIONED_DIR/Skills/cua-driver-rs"
     rm -rf "$STAGED_SKILLS"
@@ -245,7 +248,7 @@ echo ""
 # install.ps1) never drift. The .txt holds the OS-agnostic bulk
 # (Try-it / skill pack / MCP setup / docs link) with {{BINARY}}
 # placeholders; OS-specific bits stay inline below.
-HINTS_TXT="$REPO_ROOT/../cua-driver/scripts/post-install-hints.txt"
+HINTS_TXT="$SCRIPT_DIR/post-install-hints.txt"
 if [ -f "$HINTS_TXT" ]; then
     sed "s|{{BINARY}}|$INSTALLED_BIN|g" "$HINTS_TXT"
 else

--- a/libs/cua-driver/scripts/install-local.ps1
+++ b/libs/cua-driver/scripts/install-local.ps1
@@ -50,7 +50,10 @@ $ProgressPreference = "SilentlyContinue"
 # the logic would otherwise drift.
 
 $ScriptDir   = Split-Path -Parent $MyInvocation.MyCommand.Path
-$RepoRoot    = (Resolve-Path "$ScriptDir\..").Path
+# Rust workspace root: scripts/ is the cross-cutting installer dir at
+# libs/cua-driver/scripts/; the Cargo workspace lives one level deeper
+# under libs/cua-driver/rust/.
+$RepoRoot    = (Resolve-Path "$ScriptDir\..\rust").Path
 $BinaryName  = "cua-driver.exe"
 # Always release-config — matches the binary install.ps1 hands end users.
 $Config      = "release"
@@ -244,7 +247,7 @@ if ($AutoStart) {
 # (Try-it / skill pack / MCP setup / docs link) with {{BINARY}}
 # placeholders; OS-specific bits stay inline below.
 $installedBinary = Join-Path $VisibleBinDir $BinaryName
-$HintsTxt = Join-Path $RepoRoot "..\cua-driver\scripts\post-install-hints.txt"
+$HintsTxt = Join-Path $ScriptDir "post-install-hints.txt"
 if (Test-Path -LiteralPath $HintsTxt) {
     # Read explicitly as UTF-8. PowerShell 5.1's Get-Content -Raw falls
     # back to Windows-1252 when the source file has no BOM, which turns


### PR DESCRIPTION
## Summary

Follow-up to #1674. The Rust dev installers moved up from \`libs/cua-driver/rust/scripts/\` to \`libs/cua-driver/scripts/\` in that PR, but their internal source-dir resolution wasn't adjusted. Running \`.\install-local.ps1\` against a fresh checkout failed with:

\`\`\`
error: could not find \`Cargo.toml\` in \`C:\Users\cuademo\cua\libs\cua-driver\` or any parent directory
\`\`\`

\$ScriptDir/.. used to resolve to the Cargo workspace at \`libs/cua-driver/rust/\`. After the move it lands at \`libs/cua-driver/\` (no Cargo.toml).

## Fix

| File | What |
|---|---|
| \`install-local.ps1\` | \`\$RepoRoot = \$ScriptDir\..\rust\` (was just \`\..\`) |
| \`install-local.ps1\` | \`\$HintsTxt = \$ScriptDir\post-install-hints.txt\` (was via the now-broken \`\$RepoRoot\..\cua-driver\scripts\\` indirection) |
| \`_install-local-rust.sh\` | \`REPO_ROOT = \$SCRIPT_DIR/../rust\` |
| \`_install-local-rust.sh\` | \`SOURCE_SKILLS = \$REPO_ROOT/Skills/cua-driver-rs\` |
| \`_install-local-rust.sh\` | \`HINTS_TXT = \$SCRIPT_DIR/post-install-hints.txt\` |

The Swift dev installer (\`_install-local-swift.sh\`) was already pointed at \`swift/\` in #1674 — only the Rust side needed this follow-up.

## Test plan

- [x] \`bash -n _install-local-rust.sh\` clean
- [x] Verified \`libs/cua-driver/rust/Cargo.toml\` and \`libs/cua-driver/rust/Skills/cua-driver-rs/\` exist at the new \$REPO_ROOT
- [ ] Reviewer: run \`./scripts/install-local.ps1\` from a fresh checkout on Windows — should build + install (the failing path that prompted this PR)
- [ ] Reviewer: run \`./scripts/install-local.sh\` on Linux — should auto-select Rust backend, build, install
- [ ] Reviewer: run \`./scripts/install-local.sh\` on macOS — should default to Swift backend (Swift side unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installation script path configurations for improved workspace root resolution and build artifact handling during local installations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->