### PR TITLE
chore(cua-driver-rs)(scripts): post-install hint shows only Claude Code compat MCP entry

### DIFF
--- a/libs/cua-driver/scripts/post-install-hints.txt
+++ b/libs/cua-driver/scripts/post-install-hints.txt
@@ -13,14 +13,11 @@ Next steps:
   3. As an MCP server — run the one matching your client. Each is also
      available via '{{BINARY}} mcp-config --client <name>':
 
-     • Claude Code:
-         claude mcp add --transport stdio cua-driver -- {{BINARY}} mcp
-
-       Claude Code computer-use compatibility mode:
+     • Claude Code (computer-use compatibility mode):
          claude mcp add --transport stdio cua-computer-use -- {{BINARY}} mcp --claude-code-computer-use-compat
-       Use this when you want Claude Code's vision/computer-use-style flow
-       to ground on CuaDriver window screenshots. It keeps the normal
-       CuaDriver tools and changes only the screenshot tool.
+       This grounds Claude Code's vision/computer-use-style flow on
+       CuaDriver window screenshots. It keeps the normal CuaDriver tools
+       and changes only the screenshot tool.
 
      • Codex (OpenAI):
          codex mcp add cua-driver -- {{BINARY}} mcp


### PR DESCRIPTION
## Summary
- Drop the plain `cua-driver` MCP entry from the Claude Code section of `post-install-hints.txt`.
- Keep only the `--claude-code-computer-use-compat` variant, since #1678 made compat mode the default for Claude Code.
- Reword the description so it stands on its own (no longer framed as "use this when…" relative to a default).

## Test plan
- [ ] Run the Windows installer locally and confirm the printed Next-Steps section shows only the Claude Code compat entry under (3).
- [ ] Confirm the Codex / OpenClaw / Cursor / OpenCode / Hermes / Copilot CLI sections are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated post-install instructions for Claude Code computer-use compatibility mode setup with reorganized formatting and explicit command guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->