### PR TITLE
fix(cua-driver-rs)(cli): mcp-config --client claude uses add-json to bypass PowerShell arg mangling

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -684,15 +684,29 @@ pub fn run_mcp_config(client: Option<&str>) {
             // `--claude-code-computer-use-compat` so the regular
             // `screenshot` tool is replaced by a window-scoped variant
             // (pid + window_id required, JPEG @ 85%, text note pointing
-            // at pixel tools). See `mcp-server/src/protocol.rs` for the
-            // server-name reasoning, `updater.rs`/`skills.rs` for the
-            // matching skill-pack flow, and Skills/cua-driver/SKILL.md
-            // for the user-facing rationale.
+            // at pixel tools).
             //
             // Observed Claude Code behaviour: the exact config key
             // "computer-use" is reserved, so external stdio
             // registrations use a distinct key — hence `cua-computer-use`.
-            println!("claude mcp add --transport stdio cua-computer-use -- {binary} mcp --claude-code-computer-use-compat");
+            //
+            // Why `add-json` instead of `add -- BIN --flag`? PowerShell's
+            // native-command arg parser mangles long flags (`--something`)
+            // that follow a bare `--`, so the canonical
+            //   claude mcp add NAME -- BIN mcp --extra-flag
+            // form errors out with "unknown option '--extra-flag'" on
+            // Windows. `add-json` takes the whole config as one JSON
+            // string, sidestepping both shell and claude-CLI arg parsing.
+            // Forward slashes in the binary path because Windows accepts
+            // them and the single-quoted JSON literal is portable across
+            // bash + PowerShell (cmd users with double-quoted shells can
+            // paste the raw JSON into ~/.claude.json instead).
+            let normalised = binary.replace('\\', "/");
+            let cfg = serde_json::json!({
+                "command": normalised,
+                "args": ["mcp", "--claude-code-computer-use-compat"],
+            });
+            println!("claude mcp add-json cua-computer-use '{}'", cfg);
         }
         Some("codex") => {
             println!("codex mcp add cua-driver -- {binary} mcp");


### PR DESCRIPTION
## Summary

Follow-up to #1678. The previously-emitted command:

\`\`\`
claude mcp add --transport stdio cua-computer-use -- {binary} mcp --claude-code-computer-use-compat
\`\`\`

works in bash + cmd but fails in PowerShell with:

\`\`\`
error: unknown option '--claude-code-computer-use-compat'
\`\`\`

even though the claude CLI itself (commander.js) handles \`--\` correctly. Verified by running the exact same command in Git Bash on the same Windows host — registers cleanly. Repro shows PowerShell's native-command arg parser mangling long flags that follow a bare \`--\`.

## Fix

Switch \`--client claude\` and \`--client claude-code\` to emit:

\`\`\`
claude mcp add-json cua-computer-use '{\"args\":[\"mcp\",\"--claude-code-computer-use-compat\"],\"command\":\"<binary>\"}'
\`\`\`

\`add-json\` takes the whole server config as one JSON string — no shell + no parser ambiguity on either dash. Binary path normalised to forward slashes (Windows accepts them and forward-slash-in-JSON keeps escape headaches down).

## Verification

\`\`\`
$ OUT=\$(cua-driver mcp-config --client claude)
$ eval \"\$OUT\"
Added stdio MCP server cua-computer-use to local config

$ claude mcp list | grep cua-computer-use
cua-computer-use: C:/...cua-driver.exe mcp --claude-code-computer-use-compat - ✓ Connected
\`\`\`

End-to-end add → list → remove in one session.

## Test plan

- [x] Build clean (\`cargo build --release -p cua-driver\` — 0 warnings)
- [x] End-to-end add → list → remove via the generated command (bash)
- [ ] Reviewer: run the new output in **PowerShell** on Windows — should register without the \`--claude-code-computer-use-compat\` error
- [ ] Reviewer: same on macOS / Linux to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated Claude MCP configuration command format to use JSON-based registration for better compatibility
  * Enhanced Windows path handling for improved cross-platform support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->