### PR TITLE
fix(cua-driver-rs): post-install + Skill hints route through mcp-config (single source of truth)

### DIFF
--- a/libs/cua-driver/rust/Skills/cua-driver/README.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/README.md
@@ -143,11 +143,14 @@ trycua.com in Edge". You can also invoke it explicitly:
 
 ## Claude Code MCP compatibility mode
 
-For normal skill-driven use, prefer the CLI or the standard MCP server. If you want Claude Code's vision/computer-use-style flow to ground on CuaDriver screenshots, register the compatibility server:
+For normal skill-driven use, prefer the CLI or the standard MCP server. If you want Claude Code's vision/computer-use-style flow to ground on CuaDriver screenshots, register the compatibility server. The cleanest path is to let `cua-driver` print the right command for your shell:
 
 ```bash
-claude mcp add --transport stdio cua-computer-use -- cua-driver mcp --claude-code-computer-use-compat
+cua-driver mcp-config --client claude
+# then paste + run the printed `claude mcp add-json …` line
 ```
+
+Under the hood this registers a `cua-computer-use` stdio server that runs `cua-driver mcp --claude-code-computer-use-compat`. The `add-json` form sidesteps a PowerShell arg-parsing quirk that mangles long flags following `--`.
 
 This mode exposes the normal CuaDriver tools and changes only `screenshot`. The compatibility screenshot requires `pid` and `window_id`, captures that window only, and establishes a window-local pixel coordinate frame. It does not call Anthropic APIs or expose Anthropic's native computer-use API tool.
 

--- a/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
@@ -75,7 +75,7 @@ server path above. If the user explicitly wants Claude Code's
 vision/computer-use-style flow, they can register:
 
 ```bash
-claude mcp add --transport stdio cua-computer-use -- cua-driver mcp --claude-code-computer-use-compat
+cua-driver mcp-config --client claude   # then paste + run the printed line
 ```
 
 Observation: Claude Code vision flows appear to treat a screenshot

--- a/libs/cua-driver/scripts/install.sh
+++ b/libs/cua-driver/scripts/install.sh
@@ -432,16 +432,16 @@ Next steps:
      B. As an MCP server — run the one matching your client. Each is also
         available via 'cua-driver mcp-config --client <name>':
 
-        • Claude Code:
-            claude mcp add --transport stdio cua-driver -- $BIN_LINK mcp
+        • Claude Code (computer-use compatibility mode — recommended):
+            cua-driver mcp-config --client claude
+          Copy-paste the printed command into your shell — it uses
+          \`claude mcp add-json\` so the long flag survives PowerShell's
+          arg parser. This grounds Claude Code's vision/computer-use-style
+          flow on CuaDriver window screenshots — keeps the normal CuaDriver
+          tools, changes only the screenshot tool.
 
-          Claude Code computer-use compatibility mode:
-            claude mcp add --transport stdio cua-computer-use -- $BIN_LINK mcp --claude-code-computer-use-compat
-          Use this when you want Claude Code's vision/computer-use-style flow
-          to ground on CuaDriver window screenshots. It keeps the normal
-          CuaDriver tools and changes only the screenshot tool.
-          Use MCP for this path; CLI screenshots do not expose the
-          mcp__cua-computer-use__screenshot tool name cue.
+          Plain Claude Code (no computer-use compat):
+            claude mcp add --transport stdio cua-driver -- $BIN_LINK mcp
 
         • Codex (OpenAI):
             codex mcp add cua-driver -- $BIN_LINK mcp

--- a/libs/cua-driver/scripts/post-install-hints.txt
+++ b/libs/cua-driver/scripts/post-install-hints.txt
@@ -14,10 +14,13 @@ Next steps:
      available via '{{BINARY}} mcp-config --client <name>':
 
      • Claude Code (computer-use compatibility mode):
-         claude mcp add --transport stdio cua-computer-use -- {{BINARY}} mcp --claude-code-computer-use-compat
-       This grounds Claude Code's vision/computer-use-style flow on
-       CuaDriver window screenshots. It keeps the normal CuaDriver tools
-       and changes only the screenshot tool.
+         {{BINARY}} mcp-config --client claude
+       Copy-paste the printed command into your shell — it uses
+       `claude mcp add-json` (not bare `--`) so the long flag travels
+       through PowerShell's arg parser intact. This mode grounds Claude
+       Code's vision/computer-use-style flow on CuaDriver window
+       screenshots — it keeps the normal CuaDriver tools and changes
+       only the screenshot tool.
 
      • Codex (OpenAI):
          codex mcp add cua-driver -- {{BINARY}} mcp


### PR DESCRIPTION
## Summary

Follow-up to #1680. The \`mcp-config --client claude\` output was already fixed to use \`add-json\` (sidesteps PowerShell's mangling of \`--<long-flag>\` after a bare \`--\`). But three other places still hard-coded the old broken form, so the user installs cua-driver, sees the post-install banner, and copies the doomed line.

Updated to point at \`cua-driver mcp-config --client claude\` as the single source of truth:

- \`libs/cua-driver/scripts/post-install-hints.txt\` — the text rendered after \`install-local.ps1\` / \`install.ps1\` finishes (this PR's prompt point — user saw the old line printed)
- \`libs/cua-driver/scripts/install.sh\` — the \`curl … | bash\` banner
- \`libs/cua-driver/rust/Skills/cua-driver/README.md\` + \`SKILL.md\`

The Swift-port Skills under \`libs/cua-driver/swift/Skills/\` are intentionally left alone: the Swift port is macOS-only and zsh/bash handle the \`--\` form correctly — the mangling is a Rust-on-Windows concern.

## Verification

- \`bash -n install.sh\`: syntax OK
- Build still clean
- \`cua-driver mcp-config --client claude\` already produces the right shell-safe \`add-json\` line from #1680

## Test plan

- [ ] Reviewer: re-run \`install-local.ps1\` in PowerShell, confirm the post-install hint says \`cua-driver mcp-config --client claude\` (not the bare-\`--\` form)
- [ ] Reviewer: run that command and the printed \`claude mcp add-json …\` end-to-end in PowerShell

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

- Updated Claude Code MCP compatibility mode setup instructions across multiple documentation files. Users can now generate the correct registration command via a dedicated utility command and copy-paste the output, significantly simplifying the configuration process. The new approach eliminates manual command entry and improves reliability when handling complex PowerShell flag parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->