### PR TITLE
fix(cua-driver-rs)(cli): per-OS escape on mcp-config --client claude JSON literal

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -691,22 +691,31 @@ pub fn run_mcp_config(client: Option<&str>) {
             // registrations use a distinct key — hence `cua-computer-use`.
             //
             // Why `add-json` instead of `add -- BIN --flag`? PowerShell's
-            // native-command arg parser mangles long flags (`--something`)
-            // that follow a bare `--`, so the canonical
-            //   claude mcp add NAME -- BIN mcp --extra-flag
-            // form errors out with "unknown option '--extra-flag'" on
+            // native-command arg parser mangles long flags after a bare
+            // `--`, so the canonical `claude mcp add NAME -- BIN mcp
+            // --extra-flag` form errors with "unknown option …" on
             // Windows. `add-json` takes the whole config as one JSON
-            // string, sidestepping both shell and claude-CLI arg parsing.
+            // string, sidestepping the bare-dash issue.
+            //
+            // Why a per-OS escape on the JSON literal? PowerShell 5.1's
+            // native-command arg passing strips the inner `"` characters
+            // when crossing the PS → exe boundary unless they're
+            // backslash-escaped inside the single-quoted literal. The
+            // bash form keeps the raw quotes. The two escapings are
+            // mutually exclusive — verified by piping each into the
+            // other shell — so we emit per-host.
+            //
             // Forward slashes in the binary path because Windows accepts
-            // them and the single-quoted JSON literal is portable across
-            // bash + PowerShell (cmd users with double-quoted shells can
-            // paste the raw JSON into ~/.claude.json instead).
+            // them and avoid backslash-soup inside the JSON literal.
             let normalised = binary.replace('\\', "/");
             let cfg = serde_json::json!({
                 "command": normalised,
                 "args": ["mcp", "--claude-code-computer-use-compat"],
             });
-            println!("claude mcp add-json cua-computer-use '{}'", cfg);
+            let json = cfg.to_string();
+            #[cfg(windows)]
+            let json = json.replace('"', "\\\"");
+            println!("claude mcp add-json cua-computer-use '{}'", json);
         }
         Some("codex") => {
             println!("codex mcp add cua-driver -- {binary} mcp");


### PR DESCRIPTION
## Summary

Second follow-up to #1680. The single-quoted JSON literal in the \`claude mcp add-json\` output works in bash but PowerShell 5.1 still strips the inner \`\"\` characters when passing the arg through to the native exe — commander.js then sees malformed JSON and prints:

\`\`\`
Invalid configuration: : Invalid input
\`\`\`

This is the well-known PowerShell-native-exe-arg-passing bug. Confirmed by piping the same bash-form into a fresh \`powershell.exe -Command\` subprocess and reproducing the exact error.

## Empirical findings

Tried these PowerShell forms; only one worked:

| Form | PS result |
|---|---|
| \`add-json NAME '{\"args\":[\"mcp\",...]}\'\` (bash form) | ❌ Invalid input |
| \`add-json NAME --% '{\"args\":[\"mcp\",...]}\'\` (--% stop-parsing) | ❌ \"unknown option '--%'\" |
| \`claude --% mcp add-json NAME …\` (--% before subcommand) | ❌ same |
| \`add-json NAME \$cfg\` (variable) | ❌ Invalid input |
| \`add-json NAME (... | ConvertTo-Json -Compress)\` | ❌ Invalid input |
| **\`add-json NAME '{\\\"args\\\":[\\\"mcp\\\",...]}\'\`** (backslash-escape inner quotes) | **✅ Added** |

The bash form and the PS form are mutually exclusive — I verified the PS-escaped form fails in bash with the same \"Invalid input\" error. So no single string works for both.

## Fix

Pick the right escape at the emit site via \`#[cfg(windows)]\`:

\`\`\`rust
let json = cfg.to_string();
#[cfg(windows)]
let json = json.replace('\"', \"\\\\\\\"\");
println!(\"claude mcp add-json cua-computer-use '{}'\", json);
\`\`\`

Now Windows users get:
\`\`\`
claude mcp add-json cua-computer-use '{\\\"args\\\":[\\\"mcp\\\",\\\"--claude-code-computer-use-compat\\\"],\\\"command\\\":\\\"C:/.../cua-driver.exe\\\"}'
\`\`\`

Unix users get the unchanged bash form.

## Verification

\`\`\`
$ OUT=\$(cua-driver mcp-config --client claude)   # in Git Bash on Windows
$ powershell.exe -Command \"\$OUT\"
Added stdio MCP server cua-computer-use to local config
OK exit=0
\`\`\`

End-to-end add → list → remove from a PowerShell subprocess.

## Test plan

- [x] Build clean (\`cargo build --release\` — 0 warnings)
- [x] PS end-to-end smoke test (this Git Bash → \`powershell.exe -Command\")
- [ ] Reviewer: run \`cua-driver mcp-config --client claude\` from a real PowerShell window, paste the output, confirm registration succeeds
- [ ] Reviewer: run the same from macOS/Linux bash to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON argument handling in MCP configuration generation for enhanced stability.
  * Enhanced Windows platform compatibility by properly handling special characters in JSON arguments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->