### PR TITLE
fix(cua-driver-rs)(skills): strip nested cua-driver/cua-driver-rs/ wrapper from skill tarball

### DIFF
--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -462,14 +462,18 @@ jobs:
           # versioned binary tarballs.
           VERSION="${{ steps.version.outputs.version }}"
           # Asset name keeps the `cua-driver-rs-v*` prefix for backward
-          # compat with the URL skills.rs constructs. Internal directory
-          # is `cua-driver/` to match the renamed SKILL_PACK_NAME — both
-          # current binaries and old ones extract correctly because the
-          # tarball-extractor strips whatever top-level dir it finds.
+          # compat with the URL skills.rs constructs.
+          #
+          # Staging layout = one wrapper directory, flat .md files under
+          # it. extract_tar_gz strips that single wrapper and lands files
+          # directly in <HomeDir>/skills/cua-driver/. v0.2.19 and earlier
+          # had a second `cua-driver/` (or `cua-driver-rs/`) dir inside
+          # the wrapper — the extractor sees that and strips it too for
+          # backward compat with already-published releases.
           SKILLS_STAGE="cua-driver-rs-v${VERSION}-skills"
-          mkdir -p "${SKILLS_STAGE}/cua-driver"
           if [ -d libs/cua-driver/rust/Skills/cua-driver ]; then
-            cp -R libs/cua-driver/rust/Skills/cua-driver/* "${SKILLS_STAGE}/cua-driver/"
+            mkdir -p "${SKILLS_STAGE}"
+            cp -R libs/cua-driver/rust/Skills/cua-driver/. "${SKILLS_STAGE}/"
             tar -czf "release-upload/${SKILLS_STAGE}.tar.gz" "${SKILLS_STAGE}"
             echo "Packaged skill pack: release-upload/${SKILLS_STAGE}.tar.gz"
           else

--- a/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
@@ -439,17 +439,30 @@ fn http_get_bytes(url: &str) -> Result<Vec<u8>> {
 fn extract_tar_gz(bytes: &[u8], dest: &Path) -> Result<()> {
     let gz = flate2::read::GzDecoder::new(bytes);
     let mut archive = tar::Archive::new(gz);
-    // The tarball contains a `cua-driver/` top-level dir matching the
-    // pack name. Strip it during extraction so the .md files land
-    // directly in `dest` (which is itself `<HomeDir>/skills/cua-driver`).
-    // Pre-rename tarballs had `cua-driver-rs/` — the stripping logic
-    // below is name-agnostic so both shapes extract identically.
+    // Tarball shape across versions:
+    //   v0.2.18 and earlier: cua-driver-rs-v<v>-skills/cua-driver-rs/<file>
+    //   v0.2.19 (briefly):   cua-driver-rs-v<v>-skills/cua-driver/<file>
+    //   v0.2.20+:            cua-driver-rs-v<v>-skills/<file>     (CD workflow now flattens)
+    //
+    // Strip the outer staging dir always; additionally strip a SECOND
+    // wrapping dir IF it's named `cua-driver` or `cua-driver-rs` — that
+    // covers the legacy double-wrap without losing files in the
+    // (now-canonical) single-wrap shape.
     for entry in archive.entries()? {
         let mut entry = entry?;
         let path = entry.path()?.into_owned();
         let mut components = path.components();
         if components.next().is_none() {
             continue; // empty entry
+        }
+        // Peek the next component; if it's an unambiguous skill-pack
+        // wrapper, drop it too.
+        let mut peek = components.clone();
+        if let Some(next) = peek.next() {
+            let name = next.as_os_str();
+            if name == "cua-driver" || name == "cua-driver-rs" {
+                components.next();
+            }
         }
         let stripped: PathBuf = components.collect();
         if stripped.as_os_str().is_empty() {
@@ -599,4 +612,98 @@ fn print_path() -> Result<()> {
     let local = local_skill_dir()?;
     println!("{}", local.display());
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_tar_gz;
+    use tempfile::tempdir;
+
+    /// Build a gzipped tarball with the entries given as
+    /// `(path, contents)` pairs. Returns the raw `.tar.gz` bytes.
+    fn build_tarball(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut gz_buf = Vec::new();
+        {
+            let gz = flate2::write::GzEncoder::new(&mut gz_buf, flate2::Compression::default());
+            let mut tar = tar::Builder::new(gz);
+            for (path, contents) in entries {
+                let mut header = tar::Header::new_gnu();
+                header.set_size(contents.len() as u64);
+                header.set_mode(0o644);
+                header.set_cksum();
+                tar.append_data(&mut header, path, &contents[..]).unwrap();
+            }
+            tar.finish().unwrap();
+        }
+        gz_buf
+    }
+
+    #[test]
+    fn extract_flat_tarball_v_0_2_20_plus() {
+        // Post-fix shape: one wrapper dir, files directly under it.
+        //   cua-driver-rs-v0.2.20-skills/SKILL.md
+        //   cua-driver-rs-v0.2.20-skills/WINDOWS.md
+        let bytes = build_tarball(&[
+            ("cua-driver-rs-v0.2.20-skills/SKILL.md",   b"flat-skill"),
+            ("cua-driver-rs-v0.2.20-skills/WINDOWS.md", b"flat-win"),
+        ]);
+        let dest = tempdir().unwrap();
+        extract_tar_gz(&bytes, dest.path()).unwrap();
+
+        let s = std::fs::read_to_string(dest.path().join("SKILL.md")).unwrap();
+        assert_eq!(s, "flat-skill");
+        let w = std::fs::read_to_string(dest.path().join("WINDOWS.md")).unwrap();
+        assert_eq!(w, "flat-win");
+        // No nested wrapper dir created.
+        assert!(!dest.path().join("cua-driver").exists());
+        assert!(!dest.path().join("cua-driver-rs").exists());
+    }
+
+    #[test]
+    fn extract_legacy_tarball_v_0_2_18_double_wrap_old_name() {
+        // v0.2.18 and earlier shape:
+        //   cua-driver-rs-v0.2.18-skills/cua-driver-rs/SKILL.md
+        // Both wrappers must be stripped or the user ends up with a
+        // nested cua-driver-rs/ dir (the bug this fixes).
+        let bytes = build_tarball(&[
+            ("cua-driver-rs-v0.2.18-skills/cua-driver-rs/SKILL.md",   b"legacy-skill"),
+            ("cua-driver-rs-v0.2.18-skills/cua-driver-rs/WINDOWS.md", b"legacy-win"),
+        ]);
+        let dest = tempdir().unwrap();
+        extract_tar_gz(&bytes, dest.path()).unwrap();
+
+        let s = std::fs::read_to_string(dest.path().join("SKILL.md")).unwrap();
+        assert_eq!(s, "legacy-skill");
+        let w = std::fs::read_to_string(dest.path().join("WINDOWS.md")).unwrap();
+        assert_eq!(w, "legacy-win");
+        assert!(!dest.path().join("cua-driver-rs").exists(),
+            "nested cua-driver-rs/ dir should have been stripped");
+    }
+
+    #[test]
+    fn extract_double_wrap_new_name_also_strips() {
+        // Interim shape (v0.2.19, briefly): inner dir is `cua-driver/`.
+        let bytes = build_tarball(&[
+            ("cua-driver-rs-v0.2.19-skills/cua-driver/SKILL.md", b"interim-skill"),
+        ]);
+        let dest = tempdir().unwrap();
+        extract_tar_gz(&bytes, dest.path()).unwrap();
+        let s = std::fs::read_to_string(dest.path().join("SKILL.md")).unwrap();
+        assert_eq!(s, "interim-skill");
+        assert!(!dest.path().join("cua-driver").exists());
+    }
+
+    #[test]
+    fn extract_preserves_subdirs_inside_pack() {
+        // If a future skill pack adds a real subdir (e.g. `examples/`),
+        // it must NOT be stripped — only the unambiguous pack-name
+        // wrappers are.
+        let bytes = build_tarball(&[
+            ("cua-driver-rs-v0.2.20-skills/examples/click.md", b"sample"),
+        ]);
+        let dest = tempdir().unwrap();
+        extract_tar_gz(&bytes, dest.path()).unwrap();
+        let s = std::fs::read_to_string(dest.path().join("examples/click.md")).unwrap();
+        assert_eq!(s, "sample");
+    }
 }


### PR DESCRIPTION
## Summary

User reported \`~/.claude/skills/cua-driver/cua-driver-rs/SKILL.md\` after running \`cua-driver skills install\` — a redundant \`cua-driver-rs/\` dir nested inside the pack root.

Root cause: tarball-shape mismatch. The CD workflow historically staged files under \`<outer>/cua-driver-rs/\` (and briefly \`<outer>/cua-driver/\` after #1677) — **two** wrapping dirs. The extractor only stripped **one**. So files landed at \`dest/cua-driver{-rs}/<file>\` instead of \`dest/<file>\`.

## Fix

**1. \`extract_tar_gz\` strips a second wrapper iff named \`cua-driver\` or \`cua-driver-rs\`**:

\`\`\`rust
let mut peek = components.clone();
if let Some(next) = peek.next() {
    if next.as_os_str() == \"cua-driver\" || next.as_os_str() == \"cua-driver-rs\" {
        components.next();
    }
}
\`\`\`

Covers three tarball shapes:

| Released | Shape | Stripped |
|---|---|---|
| v0.2.18 and earlier | \`<outer>/cua-driver-rs/<file>\` | both wrappers |
| v0.2.19 (briefly) | \`<outer>/cua-driver/<file>\` | both wrappers |
| v0.2.20+ (this PR) | \`<outer>/<file>\` (flat) | just outer |

Stripping is name-gated so a future skill pack with a real subdir (e.g. \`examples/\`) doesn't accidentally get flattened.

**2. CD workflow flattens the staging dir** — no more inner \`cua-driver/\` between the version-stamped outer dir and the .md files.

## Tests

4 new unit tests in \`skills::tests\` cover the three legacy shapes + a \"preserve real subdir\" guard. All pass.

## End-to-end on the user's machine

After this lands + the user runs \`cua-driver skills install --force\`:

- \`fetch_into\` wipes the current \`~/.cua-driver/skills/cua-driver/\` (which contains the nested \`cua-driver-rs/\` dir)
- Re-fetches the v0.2.18 tarball from GitHub Releases (still has the legacy double-wrap shape on disk; this won't change until the next release ships)
- New extractor strips both wrappers → \`SKILL.md\`, \`WINDOWS.md\`, etc. land directly in \`~/.cua-driver/skills/cua-driver/\` with no nesting

## Test plan

- [x] Build clean (\`cargo build --release\` — 0 warnings)
- [x] 4 unit tests for extractor — all pass
- [x] 49/49 existing tests still green
- [ ] Reviewer: \`cua-driver skills install --force\` against the live v0.2.18 release tarball — verify no nested \`cua-driver-rs/\` after extraction
- [ ] Reviewer: trigger the CD workflow + re-publish, verify the new tarball has the flat shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed skill pack tarball extraction to correctly handle multiple directory structure formats and prevent unintended nested wrapper directories.

* **Tests**
  * Added comprehensive unit tests for tarball extraction, verifying proper path handling across various skill pack layouts.

* **Chores**
  * Updated release workflow staging configuration for skill pack file organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1684?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->