### PR TITLE
fix(cua-driver-rs)(install): rename-out-of-way locked binary before Copy-Item in install-local.ps1

### DIFF
--- a/libs/cua-driver/scripts/install-local.ps1
+++ b/libs/cua-driver/scripts/install-local.ps1
@@ -161,10 +161,41 @@ if (-not (Test-Path -LiteralPath $BuiltBinary)) {
 
 $VersionTag  = "0.0.0-local-$Config"
 $VersionedDir = Join-Path $ReleasesDir "$VersionTag-$Target"
+$DestBinary = Join-Path $VersionedDir $BinaryName
+
+# If a previous install-local left a binary here and it's currently
+# being executed (typical: `cua-driver autostart kick` spawned a
+# High-IL daemon at logon, which we can't terminate from this
+# Medium-IL shell without UAC), the Copy-Item below fails with
+# "The process cannot access the file ... because it is being used by
+# another process." Windows DOES allow renaming a locked .exe — the
+# loader opens images with FILE_SHARE_DELETE, so a rename succeeds
+# while the content stays locked. Renaming out of the way frees up
+# the destination path so Copy-Item lands cleanly. The old file gets
+# unlinked at the next reboot or when the daemon exits.
+if (Test-Path -LiteralPath $DestBinary) {
+    $ts = (Get-Date).ToString('yyyyMMdd-HHmmss')
+    $stale = "$DestBinary.stale-$ts"
+    try {
+        Move-Item -LiteralPath $DestBinary -Destination $stale -Force -ErrorAction Stop
+        Write-Step "renamed locked previous binary to $(Split-Path -Leaf $stale)"
+    } catch {
+        Write-Host "Note: could not rename previous binary at $DestBinary." -ForegroundColor Yellow
+        Write-Host "      ($($_.Exception.Message))" -ForegroundColor Yellow
+        Write-Host "      Most likely a running cua-driver daemon is holding it." -ForegroundColor Yellow
+        Write-Host "      Stop it first (e.g. ``schtasks /End /TN cua-driver-serve`` then re-run)." -ForegroundColor Yellow
+    }
+    # Best-effort GC of stale-* siblings older than this run. Cheap;
+    # keeps the dir from growing unbounded over many re-builds.
+    Get-ChildItem -LiteralPath $VersionedDir -Filter "$BinaryName.stale-*" -ErrorAction SilentlyContinue |
+        Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-1) } |
+        ForEach-Object { try { Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue } catch {} }
+}
+
 Write-Step "staging into $VersionedDir"
 New-Item -ItemType Directory -Path $VersionedDir -Force | Out-Null
-Copy-Item -LiteralPath $BuiltBinary -Destination (Join-Path $VersionedDir $BinaryName) -Force
-$installedBinary = Join-Path $VersionedDir $BinaryName
+Copy-Item -LiteralPath $BuiltBinary -Destination $DestBinary -Force
+$installedBinary = $DestBinary
 
 # Stage the skill pack alongside the binary. install-local mirrors what
 # install.ps1 does from a release zip — copies Skills/cua-driver-rs/ from


### PR DESCRIPTION
## Summary

Repro from real user session: re-running \`install-local.ps1\` while the autostart task has a daemon running fails with:

\`\`\`
Copy-Item : The process cannot access the file '...cua-driver.exe' because it is being used by another process.
\`\`\`

## Why kill-the-daemon doesn't fix it

The autostart task is \`RunLevel=Highest\`, so the spawned \`cua-driver.exe\` runs at High IL. A Medium-IL PowerShell shell **cannot** terminate a High-IL process — \`taskkill /F\` and \`Stop-Process\` both return Access Denied. \`schtasks /End\` ends the task INSTANCE but the daemon was detached via \`Start-Process -WindowStyle Hidden\` so it survives.

The only kill paths that work need UAC elevation. Adding a UAC prompt to install-local.ps1 is ugly — interrupts the dev loop every re-build.

## Fix: rename-out-of-way

Windows loads .exe images with \`FILE_SHARE_DELETE\` set, so the directory entry can be **renamed** while the content stays mapped. \`Move-Item\` succeeds against a locked .exe; \`Copy-Item\` then lands at the (now-free) destination path. The renamed-aside file is unlinked at next reboot or when the daemon process exits.

\`\`\`powershell
if (Test-Path -LiteralPath \$DestBinary) {
    \$stale = \"\$DestBinary.stale-\$((Get-Date).ToString('yyyyMMdd-HHmmss'))\"
    Move-Item \$DestBinary \$stale -Force
}
Copy-Item \$BuiltBinary \$DestBinary -Force
\`\`\`

Plus a best-effort GC: \`.stale-*\` siblings older than 1 day get cleaned up so the dir doesn't grow unbounded across many re-builds.

## End-to-end verified on Windows

Daemon PID 14152 running (High IL, from \`cua-driver autostart kick\`):

\`\`\`
==> renamed locked previous binary to cua-driver.exe.stale-20260524-144036
==> staging into C:\Users\cuademo\.cua-driver\packages\releases\0.0.0-local-release-...
\`\`\`

Post-install:

\`\`\`
$ ls .cua-driver/packages/releases/0.0.0-local-release-.../
cua-driver.exe                          ← May 24 14:39 — fresh build
cua-driver.exe.stale-20260524-144036    ← old, still locked by PID 14152
\`\`\`

Daemon keeps running off the renamed file. New \`cua-driver autostart enable\` will re-register the task pointing at the fresh \`cua-driver.exe\`.

If \`Move-Item\` fails (rare — would require AV/EDR with \`FILE_SHARE_NONE\`), the script prints a clear hint instead of just dying:

\`\`\`
Note: could not rename previous binary at <path>.
      (<reason>)
      Most likely a running cua-driver daemon is holding it.
      Stop it first (e.g. \`schtasks /End /TN cua-driver-serve\` then re-run).
\`\`\`

## Test plan

- [x] PowerShell parser clean
- [x] End-to-end: install-local.ps1 with a High-IL daemon running succeeds (renames + copies)
- [ ] Reviewer: same on a host with no daemon — should still work (the rename branch is gated on \`Test-Path\`)
- [ ] Reviewer: rapid re-builds don't accumulate stale-* files unboundedly (GC older than 1 day)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the local Windows installer's reliability during updates. The installer now safely handles cases where the previous version's binary is still executing by renaming existing locked executable files and automatically cleaning up older installation artifacts from prior updates. This enables more robust and reliable updates even when the prior version is still running.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1687?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->