### PR TITLE
fix(cua-driver-rs)(windows): overlay stops escaping into topmost band, foreground app renders above pin

### DIFF
--- a/libs/cua-driver/rust/crates/platform-windows/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/overlay.rs
@@ -445,19 +445,39 @@ unsafe fn reapply_z_order(hwnd: windows::Win32::Foundation::HWND) {
         guard.as_ref().and_then(|rs| rs.core.pinned_wid)
     };
 
-    // If a target window is pinned, place the overlay just above it.
-    // Falls back to HWND_TOP when not set or when the target is gone.
-    let insert_after = if let Some(wid) = pinned_wid {
-        let target = HWND(wid as *mut _);
-        if IsWindow(target).as_bool() {
-            target
-        } else {
-            HWND_TOPMOST
-        }
-    } else {
-        HWND_TOPMOST
-    };
+    let pinned_target = pinned_wid.and_then(|wid| {
+        let h = HWND(wid as *mut _);
+        if IsWindow(h).as_bool() { Some(h) } else { None }
+    });
 
+    // The overlay must sit JUST above the pinned target window so the
+    // user's foreground app (a different non-topmost window — say their
+    // terminal) renders on top of the overlay. Two pitfalls:
+    //
+    //   1. HWND_TOPMOST was the previous fallback. Once Windows promotes
+    //      a window into the topmost band (sets WS_EX_TOPMOST), a later
+    //      SetWindowPos with a normal target_hwnd does NOT drop it back
+    //      out — the overlay stays above EVERYTHING non-topmost (incl.
+    //      the user's foreground). That was the symptom in #1688-style
+    //      reports: overlay sticks visible over a terminal even when
+    //      the pinned window (Calculator) is behind it.
+    //   2. To drop out of the topmost band, we need an explicit
+    //      SetWindowPos(hwnd, HWND_NOTOPMOST, …) call. Then we can
+    //      issue a second SetWindowPos with the real target_hwnd so
+    //      the overlay lands ABOVE the pin but BELOW any window
+    //      currently above the pin (the user's foreground).
+    //
+    // Fallback when there's no live pin: HWND_TOP — top of non-topmost
+    // band, NOT the topmost band. So a "no pin" overlay still respects
+    // the user's foreground stack.
+    let _ = SetWindowPos(
+        hwnd,
+        HWND_NOTOPMOST,
+        0, 0, 0, 0,
+        SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOOWNERZORDER,
+    );
+
+    let insert_after = pinned_target.unwrap_or(HWND_TOP);
     let _ = SetWindowPos(
         hwnd,
         insert_after,


### PR DESCRIPTION
## Summary

User report: agent cursor overlay pinned over Calculator. User brings their terminal in front of the Calculator. **Overlay renders on top of the terminal too** — should be above the Calculator (pinned target) but below the terminal (user's foreground).

## Root cause

\`reapply_z_order\` used \`HWND_TOPMOST\` as a fallback when no pin was live:

\`\`\`rust
let insert_after = if let Some(wid) = pinned_wid {
    let target = HWND(wid as *mut _);
    if IsWindow(target).as_bool() { target } else { HWND_TOPMOST }
} else {
    HWND_TOPMOST  // ← bug
};
SetWindowPos(overlay, insert_after, ...);
\`\`\`

Once Windows promotes a window into the topmost band via \`SetWindowPos(HWND_TOPMOST)\`, \`WS_EX_TOPMOST\` gets set on the window. A later \`SetWindowPos(overlay, target_hwnd, …)\` with a normal target does **not** drop the overlay back out of the topmost band — it stays above every non-topmost window, including the user's foreground app.

This happens whenever no pin is live: at startup, between \`PinAbove\` commands, briefly when the pinned window is destroyed and recreated. Once it happens, the overlay is topmost-forever.

## Fix — two-call shape

\`\`\`rust
// 1. Drop out of topmost band (idempotent if already non-topmost).
SetWindowPos(overlay, HWND_NOTOPMOST, …);
// 2. Position relative to the live target (or HWND_TOP if no pin).
SetWindowPos(overlay, pinned_or_HWND_TOP, …);
\`\`\`

Why two calls: \`HWND_NOTOPMOST\` is a band-transition pseudo-value (-2) that doesn't represent a positioning target. The second call positions relative to the actual pin (or the top of the non-topmost band when no pin).

Fallback when no pin is now \`HWND_TOP\` (top of non-topmost band) instead of \`HWND_TOPMOST\` — overlay still renders above other normal windows, but no longer hardcoded above the user's foreground.

## Expected Z-order after fix

For the user's repro (terminal foreground, Calculator pinned):

\`\`\`
top    terminal       ← user's foreground (non-topmost)
       overlay        ← just above Calculator, below terminal
       calculator     ← pinned target
       ...
bottom
\`\`\`

## Verification

- [x] Build clean (0 warnings)
- [x] 32/32 platform-windows tests pass
- [ ] Reviewer: pin overlay above Calculator, bring a normal foreground app over the Calculator, verify overlay is hidden behind the foreground app
- [ ] Reviewer: same but with the foreground app a topmost window (e.g. Task Manager). Overlay correctly stays behind (since it's now non-topmost) — and that's also the right behaviour, the topmost app should win

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated overlay window positioning on Windows to properly respect foreground window selection and prevent the overlay from remaining above user-focused windows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1688?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->