### PR TITLE
fix(cua-driver-rs)(install): kill orphan cua-driver daemons after binary swap (install.ps1 + install-local.ps1)

### DIFF
--- a/libs/cua-driver/scripts/CuaDriverInstall.psm1
+++ b/libs/cua-driver/scripts/CuaDriverInstall.psm1
@@ -1,0 +1,113 @@
+# CuaDriverInstall.psm1 - shared helpers for install.ps1 + install-local.ps1.
+#
+# Both scripts import this module to avoid drift in the daemon-kill logic.
+#
+#   * install-local.ps1 runs from a checked-out repo, so it imports the
+#     module from disk via $PSScriptRoot/CuaDriverInstall.psm1.
+#   * install.ps1 is fetched via `irm | iex` and has no file on disk
+#     during execution. It uses Import-CuaDriverInstallModule (below)
+#     which prefers the on-disk copy when available (dev / CI) and
+#     falls back to fetching the .psm1 from GitHub raw.
+#
+# Keep this module narrow on purpose - it's loaded over the network in
+# the production install path, so every additional line is paid for in
+# install latency. Things that DO belong here: kill / wait / probe
+# helpers that both scripts genuinely need. Things that DON'T: anything
+# that's only used by install-local (it can stay in install-local.ps1
+# directly) or anything that pulls in a heavy module dependency.
+
+Set-StrictMode -Version Latest
+
+# Best-effort kill of any running cua-driver / cua-driver-uia processes
+# so the next `cua-driver autostart kick` / `cua-driver mcp` starts the
+# FRESH binary, not whatever's still in memory. Without this the
+# previous daemon keeps running (and keeps drawing its overlay window)
+# until the user reboots - which surfaces as "the bug I just fixed is
+# still there" because the in-memory code is pre-fix.
+#
+# Layers of escalation:
+#   1. schtasks /End - terminates an autostart-task instance. Task
+#      Scheduler runs as SYSTEM so it can kill High-IL processes that
+#      a Medium-IL shell can't. /End on an instance the current user
+#      registered does NOT need admin.
+#   2. taskkill /F /IM - Medium-IL backstop for any process that
+#      wasn't task-attached.
+#   3. Returns the surviving process list so callers can warn the user
+#      (these are the processes a Medium-IL shell genuinely can't reach
+#      - High-IL daemons whose parent wasn't `cua-driver-serve`).
+function Stop-CuaDriverDaemons {
+    [CmdletBinding()]
+    param()
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        & schtasks.exe /End /TN "cua-driver-serve" 2>$null | Out-Null
+        Start-Sleep -Milliseconds 200
+        & taskkill.exe /F /IM "cua-driver.exe" /T 2>$null | Out-Null
+        & taskkill.exe /F /IM "cua-driver-uia.exe" /T 2>$null | Out-Null
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+    Start-Sleep -Milliseconds 200
+    return @(Get-Process -Name "cua-driver","cua-driver-uia" -ErrorAction SilentlyContinue)
+}
+
+# Prints a clear hint when Stop-CuaDriverDaemons leaves something
+# running (almost always a High-IL daemon spawned by the
+# RunLevel=Highest autostart task - Medium-IL kill returns Access
+# Denied for those).
+function Show-CuaDriverDaemonSurvivors {
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][array]$Survivors)
+    if (-not $Survivors -or $Survivors.Count -eq 0) { return }
+    $pids = ($Survivors | ForEach-Object { $_.Id }) -join ', '
+    Write-Host "Note: $($Survivors.Count) cua-driver process(es) still running after best-effort kill (pid: $pids)." -ForegroundColor Yellow
+    Write-Host "      They are likely High-IL (spawned by RunLevel=Highest autostart task)." -ForegroundColor Yellow
+    Write-Host "      From an elevated PowerShell:" -ForegroundColor Yellow
+    Write-Host "        taskkill /IM cua-driver.exe /F" -ForegroundColor Yellow
+    Write-Host "      Or just reboot. Until they exit, the OLD binary keeps running." -ForegroundColor Yellow
+}
+
+# Load this module from disk if `$LocalDir/CuaDriverInstall.psm1` exists
+# (install-local.ps1 / checked-out install.ps1), else fetch the same
+# file from GitHub raw and load it as an in-memory module
+# (`irm | iex` install.ps1 path).
+#
+# Either way the caller ends up with Stop-CuaDriverDaemons +
+# Show-CuaDriverDaemonSurvivors in scope.
+#
+# Pulled into the module itself (recursively used) so install.ps1's
+# inline bootstrap is one short call. Callers must define
+# $CuaDriverInstallPsmUrl before invoking the fallback branch.
+function Import-CuaDriverInstallModule {
+    [CmdletBinding()]
+    param(
+        [string]$LocalDir,
+        [string]$Url
+    )
+    if ($LocalDir) {
+        $localPsm = Join-Path $LocalDir "CuaDriverInstall.psm1"
+        if (Test-Path -LiteralPath $localPsm) {
+            Import-Module -Name $localPsm -Force -ErrorAction Stop
+            return
+        }
+    }
+    if (-not $Url) {
+        throw "Import-CuaDriverInstallModule: no local file and no -Url to fetch from."
+    }
+    $body = Invoke-RestMethod -Uri $Url -UseBasicParsing
+    $tmp = Join-Path $env:TEMP ("CuaDriverInstall-" + [Guid]::NewGuid().ToString('N') + ".psm1")
+    Set-Content -LiteralPath $tmp -Value $body -Encoding UTF8
+    try {
+        Import-Module -Name $tmp -Force -ErrorAction Stop
+    } finally {
+        # Module is loaded in memory; the file on disk is no longer
+        # needed. Best-effort delete - harmless if it survives.
+        Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Export-ModuleMember -Function `
+    Stop-CuaDriverDaemons, `
+    Show-CuaDriverDaemonSurvivors, `
+    Import-CuaDriverInstallModule

--- a/libs/cua-driver/scripts/_install-common.psm1
+++ b/libs/cua-driver/scripts/_install-common.psm1
@@ -1,9 +1,9 @@
-# CuaDriverInstall.psm1 - shared helpers for install.ps1 + install-local.ps1.
+# _install-common.psm1 - shared helpers for install.ps1 + install-local.ps1.
 #
 # Both scripts import this module to avoid drift in the daemon-kill logic.
 #
 #   * install-local.ps1 runs from a checked-out repo, so it imports the
-#     module from disk via $PSScriptRoot/CuaDriverInstall.psm1.
+#     module from disk via $PSScriptRoot/_install-common.psm1.
 #   * install.ps1 is fetched via `irm | iex` and has no file on disk
 #     during execution. It uses Import-CuaDriverInstallModule (below)
 #     which prefers the on-disk copy when available (dev / CI) and
@@ -68,7 +68,7 @@ function Show-CuaDriverDaemonSurvivors {
     Write-Host "      Or just reboot. Until they exit, the OLD binary keeps running." -ForegroundColor Yellow
 }
 
-# Load this module from disk if `$LocalDir/CuaDriverInstall.psm1` exists
+# Load this module from disk if `$LocalDir/_install-common.psm1` exists
 # (install-local.ps1 / checked-out install.ps1), else fetch the same
 # file from GitHub raw and load it as an in-memory module
 # (`irm | iex` install.ps1 path).
@@ -86,7 +86,7 @@ function Import-CuaDriverInstallModule {
         [string]$Url
     )
     if ($LocalDir) {
-        $localPsm = Join-Path $LocalDir "CuaDriverInstall.psm1"
+        $localPsm = Join-Path $LocalDir "_install-common.psm1"
         if (Test-Path -LiteralPath $localPsm) {
             Import-Module -Name $localPsm -Force -ErrorAction Stop
             return

--- a/libs/cua-driver/scripts/_install-common.sh
+++ b/libs/cua-driver/scripts/_install-common.sh
@@ -1,0 +1,198 @@
+# _install-common.sh — shared helpers for the .sh installers.
+#
+# Bash counterpart to CuaDriverInstall.psm1. Both files have to stay in
+# lockstep on the kill / probe behaviour so a Mac/Linux dev fix matches
+# what install.ps1 does on Windows. Function names mirror the
+# PowerShell side:
+#
+#   stop_cua_driver_daemons          ↔  Stop-CuaDriverDaemons
+#   show_cua_driver_daemon_survivors ↔  Show-CuaDriverDaemonSurvivors
+#
+# This script is sourced (not exec'd) by the per-backend install
+# helpers:
+#
+#   * _install-rust.sh           (production Rust delegate)
+#   * _install-local-rust.sh     (dev Rust installer)
+#   * _install-local-swift.sh    (dev Swift installer)
+#
+# Loaders: on-disk first when run from a checked-out tree, else fetched
+# from GitHub raw via `curl` (mirrors the irm | iex path that
+# install.ps1 uses to import the .psm1 over the network). The inline
+# loader is duplicated in each consumer because `source` doesn't have a
+# bootstrap function the way PowerShell's `Import-Module` does — kept
+# minimal so the duplication cost stays low.
+#
+# Keep this file narrow on purpose: every byte gets curl'd on every
+# `curl ... | bash` install on non-macOS hosts (where install.sh
+# auto-delegates to the Rust path) AND on dev installs. Things that DO
+# belong here: kill / wait / probe helpers that multiple consumers
+# need. Things that DON'T: anything only one script uses (leave it
+# inline there).
+#
+# Style:
+#   * No `set -e` — sourced helpers shouldn't change the caller's shell
+#     options. Caller scripts are already `set -euo pipefail`.
+#   * Best-effort everywhere: every external command is suffixed with
+#     `|| true` (or wrapped in a subshell) so a kill failure never
+#     aborts the surrounding install.
+#   * Bash 3.2 compatible (macOS default). No associative arrays, no
+#     `[[ =~ ]]` patterns that need bash 4+.
+
+# Best-effort kill of any running cua-driver daemons so the next
+# `cua-driver` invocation starts the FRESH binary, not whatever's still
+# in memory from the pre-upgrade install. Without this the previous
+# daemon keeps running (and on macOS keeps holding TCC-attributed file
+# handles) until the user logs out — which surfaces as "the bug I just
+# fixed is still there" because the in-memory code is pre-fix.
+#
+# Layered escalation, in order of decreasing politeness:
+#   1. macOS: `launchctl unload <plist>` on every LaunchAgent we know
+#      we install (com.trycua.cua-driver-rs.plist for the Rust port,
+#      com.trycua.cua_driver_daemon.plist for the Swift driver). Unload
+#      is the documented way to stop a launchd-managed daemon — it
+#      also clears the KeepAlive flag so launchd doesn't immediately
+#      respawn the process we're about to kill. No-op (with stderr
+#      suppressed) when the plist isn't installed.
+#      Linux: `systemctl --user stop cua-driver-rs.service` for the
+#      install-local --autostart path. Same shape — politely stop the
+#      supervisor first so it doesn't restart the process.
+#   2. `pkill -x cua-driver` as the backstop for processes that weren't
+#      launchd/systemd-supervised (e.g. a manual `cua-driver serve`
+#      from a dev shell, or `cua-driver mcp` spawned by an editor that
+#      isn't aware we're swapping the binary out from under it).
+#
+# Daemon-name coverage:
+#   The Rust binary and the Swift binary BOTH exec as `cua-driver` (same
+#   product name — see build-app.sh `--identifier com.trycua.driver`
+#   and _install-rust.sh `BINARY_NAME="cua-driver"`). One `pkill -x
+#   cua-driver` covers both, so callers don't need a per-backend
+#   variant — the kill is naturally symmetric across the Rust/Swift
+#   split. `cua-driver-uia` is a Windows-only helper (see
+#   libs/cua-driver/rust/crates/cua-driver-uia/) and never exists on
+#   macOS/Linux, so no pkill for it here.
+#
+# Returns: always 0. Caller threads this through unconditionally; the
+# behaviour is "kill what we can, never block the install".
+stop_cua_driver_daemons() {
+    printf '==> stopping any running cua-driver daemons before swap\n'
+
+    # Wrap the whole thing in a subshell so any unexpected non-zero exit
+    # (e.g. a `pkill` returning 1 when no process matches under a
+    # `set -e` caller — we shouldn't be `set -e` here, but defence in
+    # depth) never escapes.
+    (
+        case "$(uname -s 2>/dev/null || echo unknown)" in
+            Darwin)
+                # Both known LaunchAgent plists. `launchctl unload` is a
+                # no-op-with-warning when the plist doesn't exist; swallow
+                # stderr to keep the install log clean.
+                local plist
+                for plist in \
+                    "$HOME/Library/LaunchAgents/com.trycua.cua-driver-rs.plist" \
+                    "$HOME/Library/LaunchAgents/com.trycua.cua_driver_daemon.plist"
+                do
+                    if [ -f "$plist" ]; then
+                        launchctl unload "$plist" >/dev/null 2>&1 || true
+                    fi
+                done
+                ;;
+            Linux)
+                # systemctl --user is the only supported supervisor on
+                # Linux today (install-local-rust.sh --autostart writes
+                # ~/.config/systemd/user/cua-driver-rs.service). `command
+                # -v` so we don't error on systemd-less hosts (musl
+                # containers, NixOS without user services, etc.).
+                if command -v systemctl >/dev/null 2>&1; then
+                    systemctl --user stop cua-driver-rs.service >/dev/null 2>&1 || true
+                fi
+                ;;
+            *)
+                # Other Unixes (FreeBSD, etc.) — no supervisor we know
+                # about, fall through to the pkill backstop.
+                ;;
+        esac
+
+        # Best-effort: give the supervisor up to ~200ms to take the
+        # daemon down before we resort to pkill. Same wait as the
+        # PowerShell module after schtasks /End.
+        sleep 0.2 2>/dev/null || sleep 1
+
+        if command -v pkill >/dev/null 2>&1; then
+            # `-x` = exact match on process name so we don't kill a
+            # user's `cua-driver-rs-foo` test harness or any script
+            # named "cua-driver-something". The Rust + Swift binaries
+            # both exec as exactly `cua-driver` so a single pkill
+            # covers both.
+            pkill -x cua-driver >/dev/null 2>&1 || true
+        fi
+    ) || true
+
+    return 0
+}
+
+# Print a yellow warning if cua-driver processes are still running after
+# stop_cua_driver_daemons did its best. On macOS/Linux this almost never
+# fires for processes the current user owns — `pkill` succeeds against
+# user-owned processes without elevation — so when it DOES fire it
+# usually means:
+#
+#   * Another user on the same host has their own cua-driver running
+#     (multi-user dev box). Their daemon is fine; ours just won't see
+#     the swap until they restart theirs.
+#   * The daemon was spawned with a custom signal handler that ignores
+#     SIGTERM (we don't ship such a handler — but a debugger session
+#     could install one).
+#   * Process is in uninterruptible state (D-state on Linux from a
+#     stuck syscall — rare for a userspace daemon).
+#
+# Mirrors Show-CuaDriverDaemonSurvivors on the PowerShell side, but the
+# Unix-side mitigation is different: there's no clean User Account
+# Control / High-IL escalation analogue, so the hint is just `sudo
+# pkill` (root can reach other users' processes).
+#
+# Idempotent — safe to call even when stop_cua_driver_daemons did
+# clean up everything. Prints nothing in the common case.
+show_cua_driver_daemon_survivors() {
+    # `pgrep -x` matches the exact process name the same way `pkill -x`
+    # did above, so the survivor list is exactly what the kill couldn't
+    # reach (not random other cua-driver-* binaries).
+    if ! command -v pgrep >/dev/null 2>&1; then
+        # No pgrep, no way to check. Bail quietly — the install can
+        # still succeed; worst case the user notices a stale binary
+        # and reboots.
+        return 0
+    fi
+
+    local survivor_pids
+    survivor_pids=$(pgrep -x cua-driver 2>/dev/null || true)
+    if [ -z "$survivor_pids" ]; then
+        return 0
+    fi
+
+    # `tput` may not be available (CI, agent sandboxes without TERM);
+    # guard so we don't crash before printing the actual warning. The
+    # color is decoration — the text is the load-bearing part.
+    local yellow normal
+    yellow=$(tput setaf 3 2>/dev/null || true)
+    normal=$(tput sgr0 2>/dev/null || true)
+
+    # `wc -w` is portable across BSD and GNU; pgrep prints one pid per
+    # line so we'd get the same count from `wc -l`, but `wc -w` is
+    # robust to a missing trailing newline.
+    local count
+    count=$(printf '%s\n' "$survivor_pids" | wc -w | tr -d ' ')
+    local pid_csv
+    pid_csv=$(printf '%s\n' "$survivor_pids" | tr '\n' ',' | sed 's/,$//' | sed 's/,/, /g')
+
+    printf '%sNote: %s cua-driver process(es) still running after best-effort kill (pid: %s).%s\n' \
+        "$yellow" "$count" "$pid_csv" "$normal"
+    printf '%s      They are probably owned by another user, or are ignoring SIGTERM.%s\n' \
+        "$yellow" "$normal"
+    printf '%s      To force-kill (needs root if owned by another user):%s\n' \
+        "$yellow" "$normal"
+    printf '%s        sudo pkill -9 -x cua-driver%s\n' \
+        "$yellow" "$normal"
+    printf '%s      Or log out and back in. Until they exit, the OLD binary keeps running.%s\n' \
+        "$yellow" "$normal"
+    return 0
+}

--- a/libs/cua-driver/scripts/_install-local-rust.sh
+++ b/libs/cua-driver/scripts/_install-local-rust.sh
@@ -43,6 +43,24 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # under libs/cua-driver/rust/.
 REPO_ROOT="$(cd "$SCRIPT_DIR/../rust" && pwd)"
 
+# --- Load shared daemon-cleanup helpers ---------------------------------
+#
+# Sibling _install-common.sh defines stop_cua_driver_daemons +
+# show_cua_driver_daemon_survivors, mirroring CuaDriverInstall.psm1.
+# This is a dev-only path always invoked from a checked-out tree (the
+# `install-local.sh` dispatcher only runs from a clone), so the on-disk
+# load is the only branch we need — no curl fallback like _install-rust.sh.
+# Define no-op stubs if the file is missing so call sites stay
+# unconditional and a stale clone doesn't fail the install.
+if [ -f "$SCRIPT_DIR/_install-common.sh" ]; then
+    # shellcheck source=_install-common.sh
+    . "$SCRIPT_DIR/_install-common.sh"
+else
+    echo "warning: $SCRIPT_DIR/_install-common.sh missing; daemon kill skipped" >&2
+    stop_cua_driver_daemons() { :; }
+    show_cua_driver_daemon_survivors() { :; }
+fi
+
 BOLD=$(tput bold 2>/dev/null || true)
 NORMAL=$(tput sgr0 2>/dev/null || true)
 RED=$(tput setaf 1 2>/dev/null || true)
@@ -179,6 +197,17 @@ echo "${GREEN}$BIN_DIR/cua-driver -> $CURRENT_LINK/cua-driver${NORMAL}"
 echo ""
 
 INSTALLED_BIN="$BIN_DIR/cua-driver"
+
+# --- Stop any pre-swap cua-driver daemons ------------------------------
+#
+# Mirror of install-local.ps1's daemon kill — the new binary is now
+# under packages/current/, but any LaunchAgent / systemd user unit /
+# manual `serve` shell is still running off the OLD binary. Stop them
+# so the next invocation picks up this build. Best-effort, never
+# fails the install. Survivors (rare on Unix — `pkill` reaches all
+# user-owned procs without elevation) get a yellow hint.
+stop_cua_driver_daemons
+show_cua_driver_daemon_survivors
 
 # Agent skill pack symlinks: NOT auto-created. Run
 # `cua-driver skills install --local` to symlink agent dirs to the

--- a/libs/cua-driver/scripts/_install-local-swift.sh
+++ b/libs/cua-driver/scripts/_install-local-swift.sh
@@ -32,6 +32,31 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CUA_DRIVER_DIR="$(cd "$SCRIPT_DIR/../swift" && pwd)"
 SHARED_SCRIPTS_DIR="$SCRIPT_DIR"
 
+# --- Load shared daemon-cleanup helpers --------------------------------
+#
+# Sibling _install-common.sh exposes stop_cua_driver_daemons +
+# show_cua_driver_daemon_survivors, the bash counterpart to
+# CuaDriverInstall.psm1. The kill targets `cua-driver` by exact name —
+# which covers BOTH the Swift binary and the Rust binary (both exec
+# under that name; same product name, same com.trycua.driver bundle id
+# per build-app.sh), so we don't need a separate Swift-only function.
+# The shared helper also handles the Swift LaunchAgent
+# (com.trycua.cua_driver_daemon.plist) the --daemon path below
+# registers.
+#
+# This script is dev-only (always invoked from a checked-out clone via
+# the install-local.sh dispatcher), so on-disk is the only load path —
+# no curl fallback. Stub the functions if the file is missing so
+# call sites stay unconditional.
+if [ -f "$SCRIPT_DIR/_install-common.sh" ]; then
+    # shellcheck source=_install-common.sh
+    . "$SCRIPT_DIR/_install-common.sh"
+else
+    echo "warning: $SCRIPT_DIR/_install-common.sh missing; daemon kill skipped" >&2
+    stop_cua_driver_daemons() { :; }
+    show_cua_driver_daemon_survivors() { :; }
+fi
+
 # Guard `tput` against environments where TERM is unset (agent sandboxes,
 # CI containers, `launchd` jobs): tput aborts with "No value for $TERM and
 # no -T specified" otherwise, killing the script before any work starts.
@@ -173,6 +198,18 @@ if [ ! -w "$BIN_INSTALL_DIR" ]; then
 fi
 ln -sf "$APP_DEST/Contents/MacOS/cua-driver" "$BIN_LINK"
 echo "${GREEN}Linked $BIN_LINK → $APP_DEST/Contents/MacOS/cua-driver${NORMAL}"
+
+# --- Stop any pre-swap cua-driver daemons ------------------------------
+#
+# The new .app is now in /Applications, but any LaunchAgent or manual
+# `cua-driver serve` shell is still running the OLD binary (open file
+# handles survive `ditto` overwriting the bundle). Kill them so the
+# --daemon block below (or the user's next manual `serve`) picks up
+# the freshly-built binary. Without this, a TCC-permission re-prompt
+# fix that touched the binary's signature wouldn't take effect until
+# the user logged out.
+stop_cua_driver_daemons
+show_cua_driver_daemon_survivors
 
 # --- Daemon (optional) --------------------------------------------------
 

--- a/libs/cua-driver/scripts/_install-rust.sh
+++ b/libs/cua-driver/scripts/_install-rust.sh
@@ -70,6 +70,45 @@
 # production macOS automation prefer `libs/cua-driver/scripts/install.sh`.
 set -euo pipefail
 
+# --- Load shared daemon-cleanup helpers ---------------------------------
+#
+# Bash counterpart of install.ps1's `Import-CuaDriverInstallModule`. On
+# a checked-out tree (`$BASH_SOURCE` points at a real file) we source
+# the sibling _install-common.sh from disk. When this script is run via
+# `curl ... | bash` (the production path forwarded from install.sh on
+# Linux), there's no on-disk copy — fall back to curling the canonical
+# raw URL and sourcing the downloaded tempfile.
+#
+# Failure here is non-fatal: the daemon-stop is a best-effort upgrade
+# nicety, not load-bearing. If we can't load the helpers, define
+# no-op stubs so the rest of the script can call them unconditionally.
+_CUA_INSTALL_COMMON_URL="https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/_install-common.sh"
+_cua_install_common_loaded=0
+if [[ -n "${BASH_SOURCE[0]:-}" && "${BASH_SOURCE[0]}" != "-" && -f "${BASH_SOURCE[0]}" ]]; then
+    _CUA_SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+    if [[ -f "$_CUA_SCRIPT_DIR/_install-common.sh" ]]; then
+        # shellcheck source=_install-common.sh
+        . "$_CUA_SCRIPT_DIR/_install-common.sh" && _cua_install_common_loaded=1
+    fi
+fi
+if [[ "$_cua_install_common_loaded" == "0" ]] && command -v curl >/dev/null 2>&1; then
+    _cua_install_common_tmp="$(mktemp -t cua-install-common.XXXXXX 2>/dev/null || mktemp)"
+    if curl -fsSL "$_CUA_INSTALL_COMMON_URL" -o "$_cua_install_common_tmp" 2>/dev/null; then
+        # shellcheck source=/dev/null
+        . "$_cua_install_common_tmp" && _cua_install_common_loaded=1
+    fi
+    rm -f "$_cua_install_common_tmp" 2>/dev/null || true
+fi
+if [[ "$_cua_install_common_loaded" == "0" ]]; then
+    # Stubs so call sites stay unconditional. Print a one-line warning
+    # so a fetch failure shows up in the install log, but don't fail
+    # the install over it — the binary swap below is the load-bearing
+    # part, daemon cleanup is "nice to have".
+    printf 'warning: could not load _install-common.sh (on-disk + network); daemon kill skipped\n' >&2
+    stop_cua_driver_daemons() { :; }
+    show_cua_driver_daemon_survivors() { :; }
+fi
+
 REPO="trycua/cua"
 BINARY_NAME="cua-driver"
 TAG_PREFIX="cua-driver-rs-v"
@@ -606,6 +645,19 @@ else
     # exempted via the current-symlink check inside prune_old_releases).
     prune_old_releases "$RELEASES_DIR" "$CURRENT_LINK" "$TARGET" "$KEEP_VERSIONS"
 fi
+
+# --- Stop any pre-swap cua-driver daemons -------------------------------
+#
+# Mirror of install.ps1's `Stop-CuaDriverDaemons` call sequence. The
+# new binary is now in place under packages/current/ (Linux) or
+# /Applications/CuaDriver.app (macOS) — kill any in-memory daemon
+# that was holding the OLD binary so the next `cua-driver` invocation
+# picks up the freshly-installed code. Without this, an autostart
+# LaunchAgent / systemd user unit / manual `serve` shell keeps serving
+# pre-upgrade behaviour until logout, which is what surfaces to users
+# as "the bug I just fixed is still there".
+stop_cua_driver_daemons
+show_cua_driver_daemon_survivors
 
 # Agent skill pack: NOT auto-linked. The install script never touches
 # ~/.claude/skills/, ~/.agents/skills/, etc. Run `cua-driver skills

--- a/libs/cua-driver/scripts/install-local.ps1
+++ b/libs/cua-driver/scripts/install-local.ps1
@@ -121,10 +121,10 @@ function Register-CuaDriverAutostart {
 }
 
 # Stop-CuaDriverDaemons + Show-CuaDriverDaemonSurvivors are defined in
-# the sibling CuaDriverInstall.psm1 module - shared with install.ps1
+# the sibling _install-common.psm1 module - shared with install.ps1
 # so the daemon-cleanup logic stays in one place. Local dev runs from
 # a checked-out tree, so we always have the file on disk.
-Import-Module -Name (Join-Path $ScriptDir "CuaDriverInstall.psm1") -Force
+Import-Module -Name (Join-Path $ScriptDir "_install-common.psm1") -Force
 
 function Write-Step($msg) { Write-Host "==> $msg" -ForegroundColor Cyan }
 

--- a/libs/cua-driver/scripts/install-local.ps1
+++ b/libs/cua-driver/scripts/install-local.ps1
@@ -120,57 +120,11 @@ function Register-CuaDriverAutostart {
     }
 }
 
-# KEEP IN SYNC WITH install.ps1::Stop-CuaDriverDaemons (both scripts run
-# standalone, install.ps1 is downloaded via `irm | iex` so it can't
-# dot-source — duplicated definitions, identical bodies).
-#
-# Best-effort kill of any running cua-driver / cua-driver-uia processes
-# so the next `cua-driver autostart kick` / `cua-driver mcp` starts the
-# FRESH binary, not whatever's still in memory. Without this the
-# previous daemon keeps running (and keeps drawing its overlay window)
-# until the user reboots — which surfaces as "the bug I just fixed is
-# still there" because the in-memory code is pre-fix.
-#
-# Layers of escalation:
-#   1. schtasks /End — terminates an autostart-task instance. Task
-#      Scheduler runs as SYSTEM so it can kill High-IL processes that
-#      a Medium-IL shell can't. /End on an instance the current user
-#      registered does NOT need admin.
-#   2. taskkill /F /IM — Medium-IL backstop for any process that
-#      wasn't task-attached.
-#   3. Returns the surviving process list so callers can warn the user
-#      (these are the processes a Medium-IL shell genuinely can't reach
-#      — High-IL daemons whose parent wasn't `cua-driver-serve`).
-function Stop-CuaDriverDaemons {
-    $prevEAP = $ErrorActionPreference
-    $ErrorActionPreference = 'Continue'
-    try {
-        & schtasks.exe /End /TN "cua-driver-serve" 2>$null | Out-Null
-        Start-Sleep -Milliseconds 200
-        & taskkill.exe /F /IM "cua-driver.exe" /T 2>$null | Out-Null
-        & taskkill.exe /F /IM "cua-driver-uia.exe" /T 2>$null | Out-Null
-    } finally {
-        $ErrorActionPreference = $prevEAP
-    }
-    Start-Sleep -Milliseconds 200
-    return @(Get-Process -Name "cua-driver","cua-driver-uia" -ErrorAction SilentlyContinue)
-}
-
-# KEEP IN SYNC WITH install.ps1::Show-CuaDriverDaemonSurvivors.
-# Prints a clear hint when Stop-CuaDriverDaemons leaves something
-# running (almost always a High-IL daemon spawned by the
-# RunLevel=Highest autostart task — Medium-IL kill returns Access
-# Denied for those).
-function Show-CuaDriverDaemonSurvivors {
-    param([Parameter(Mandatory = $true)][array]$Survivors)
-    if (-not $Survivors -or $Survivors.Count -eq 0) { return }
-    $pids = ($Survivors | ForEach-Object { $_.Id }) -join ', '
-    Write-Host "Note: $($Survivors.Count) cua-driver process(es) still running after best-effort kill (pid: $pids)." -ForegroundColor Yellow
-    Write-Host "      They are likely High-IL (spawned by RunLevel=Highest autostart task)." -ForegroundColor Yellow
-    Write-Host "      From an elevated PowerShell:" -ForegroundColor Yellow
-    Write-Host "        taskkill /IM cua-driver.exe /F" -ForegroundColor Yellow
-    Write-Host "      Or just reboot. Until they exit, the OLD binary keeps running." -ForegroundColor Yellow
-}
+# Stop-CuaDriverDaemons + Show-CuaDriverDaemonSurvivors are defined in
+# the sibling CuaDriverInstall.psm1 module - shared with install.ps1
+# so the daemon-cleanup logic stays in one place. Local dev runs from
+# a checked-out tree, so we always have the file on disk.
+Import-Module -Name (Join-Path $ScriptDir "CuaDriverInstall.psm1") -Force
 
 function Write-Step($msg) { Write-Host "==> $msg" -ForegroundColor Cyan }
 

--- a/libs/cua-driver/scripts/install-local.ps1
+++ b/libs/cua-driver/scripts/install-local.ps1
@@ -120,6 +120,58 @@ function Register-CuaDriverAutostart {
     }
 }
 
+# KEEP IN SYNC WITH install.ps1::Stop-CuaDriverDaemons (both scripts run
+# standalone, install.ps1 is downloaded via `irm | iex` so it can't
+# dot-source — duplicated definitions, identical bodies).
+#
+# Best-effort kill of any running cua-driver / cua-driver-uia processes
+# so the next `cua-driver autostart kick` / `cua-driver mcp` starts the
+# FRESH binary, not whatever's still in memory. Without this the
+# previous daemon keeps running (and keeps drawing its overlay window)
+# until the user reboots — which surfaces as "the bug I just fixed is
+# still there" because the in-memory code is pre-fix.
+#
+# Layers of escalation:
+#   1. schtasks /End — terminates an autostart-task instance. Task
+#      Scheduler runs as SYSTEM so it can kill High-IL processes that
+#      a Medium-IL shell can't. /End on an instance the current user
+#      registered does NOT need admin.
+#   2. taskkill /F /IM — Medium-IL backstop for any process that
+#      wasn't task-attached.
+#   3. Returns the surviving process list so callers can warn the user
+#      (these are the processes a Medium-IL shell genuinely can't reach
+#      — High-IL daemons whose parent wasn't `cua-driver-serve`).
+function Stop-CuaDriverDaemons {
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        & schtasks.exe /End /TN "cua-driver-serve" 2>$null | Out-Null
+        Start-Sleep -Milliseconds 200
+        & taskkill.exe /F /IM "cua-driver.exe" /T 2>$null | Out-Null
+        & taskkill.exe /F /IM "cua-driver-uia.exe" /T 2>$null | Out-Null
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+    Start-Sleep -Milliseconds 200
+    return @(Get-Process -Name "cua-driver","cua-driver-uia" -ErrorAction SilentlyContinue)
+}
+
+# KEEP IN SYNC WITH install.ps1::Show-CuaDriverDaemonSurvivors.
+# Prints a clear hint when Stop-CuaDriverDaemons leaves something
+# running (almost always a High-IL daemon spawned by the
+# RunLevel=Highest autostart task — Medium-IL kill returns Access
+# Denied for those).
+function Show-CuaDriverDaemonSurvivors {
+    param([Parameter(Mandatory = $true)][array]$Survivors)
+    if (-not $Survivors -or $Survivors.Count -eq 0) { return }
+    $pids = ($Survivors | ForEach-Object { $_.Id }) -join ', '
+    Write-Host "Note: $($Survivors.Count) cua-driver process(es) still running after best-effort kill (pid: $pids)." -ForegroundColor Yellow
+    Write-Host "      They are likely High-IL (spawned by RunLevel=Highest autostart task)." -ForegroundColor Yellow
+    Write-Host "      From an elevated PowerShell:" -ForegroundColor Yellow
+    Write-Host "        taskkill /IM cua-driver.exe /F" -ForegroundColor Yellow
+    Write-Host "      Or just reboot. Until they exit, the OLD binary keeps running." -ForegroundColor Yellow
+}
+
 function Write-Step($msg) { Write-Host "==> $msg" -ForegroundColor Cyan }
 
 # ---------- Prerequisites --------------------------------------------------
@@ -190,6 +242,10 @@ if (Test-Path -LiteralPath $DestBinary) {
     Get-ChildItem -LiteralPath $VersionedDir -Filter "$BinaryName.stale-*" -ErrorAction SilentlyContinue |
         Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-1) } |
         ForEach-Object { try { Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue } catch {} }
+
+    Write-Step "killing previous cua-driver processes (best-effort; High-IL needs admin)"
+    $survivors = Stop-CuaDriverDaemons
+    Show-CuaDriverDaemonSurvivors -Survivors $survivors
 }
 
 Write-Step "staging into $VersionedDir"

--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -527,6 +527,54 @@ function Test-IsElevated {
     return $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
 }
 
+# KEEP IN SYNC WITH install-local.ps1::Stop-CuaDriverDaemons (both
+# scripts run standalone, install.ps1 is fetched via `irm | iex` so it
+# can't dot-source — duplicated definitions, identical bodies).
+#
+# Best-effort kill of any running cua-driver / cua-driver-uia processes
+# so the next `cua-driver autostart kick` / `cua-driver mcp` starts the
+# FRESH binary, not whatever's still in memory. Without this the
+# previous daemon keeps running (and keeps drawing its overlay window)
+# until the user reboots — which surfaces as "the bug I just fixed is
+# still there" because the in-memory code is pre-fix.
+#
+# Layers of escalation:
+#   1. schtasks /End — terminates an autostart-task instance. Task
+#      Scheduler runs as SYSTEM so it can kill High-IL processes that
+#      a Medium-IL shell can't. /End on an instance the current user
+#      registered does NOT need admin.
+#   2. taskkill /F /IM — Medium-IL backstop for any process that
+#      wasn't task-attached.
+#   3. Returns the surviving process list so callers can warn the user
+#      (these are the processes a Medium-IL shell genuinely can't reach
+#      — High-IL daemons whose parent wasn't `cua-driver-serve`).
+function Stop-CuaDriverDaemons {
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        & schtasks.exe /End /TN "cua-driver-serve" 2>$null | Out-Null
+        Start-Sleep -Milliseconds 200
+        & taskkill.exe /F /IM "cua-driver.exe" /T 2>$null | Out-Null
+        & taskkill.exe /F /IM "cua-driver-uia.exe" /T 2>$null | Out-Null
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+    Start-Sleep -Milliseconds 200
+    return @(Get-Process -Name "cua-driver","cua-driver-uia" -ErrorAction SilentlyContinue)
+}
+
+# KEEP IN SYNC WITH install-local.ps1::Show-CuaDriverDaemonSurvivors.
+function Show-CuaDriverDaemonSurvivors {
+    param([Parameter(Mandatory = $true)][array]$Survivors)
+    if (-not $Survivors -or $Survivors.Count -eq 0) { return }
+    $pids = ($Survivors | ForEach-Object { $_.Id }) -join ', '
+    Write-Host "Note: $($Survivors.Count) cua-driver process(es) still running after best-effort kill (pid: $pids)." -ForegroundColor Yellow
+    Write-Host "      They are likely High-IL (spawned by RunLevel=Highest autostart task)." -ForegroundColor Yellow
+    Write-Host "      From an elevated PowerShell:" -ForegroundColor Yellow
+    Write-Host "        taskkill /IM cua-driver.exe /F" -ForegroundColor Yellow
+    Write-Host "      Or just reboot. Until they exit, the OLD binary keeps running." -ForegroundColor Yellow
+}
+
 function Register-CuaDriverAutostart {
     param([Parameter(Mandatory = $true)][string]$InstalledBinary)
 
@@ -1159,6 +1207,19 @@ else {
         Write-ManualPathInstructions $VisibleBinDir
     }
 }
+
+# Kill any cua-driver / cua-driver-uia process still running off the
+# OLD binary, so the next time the daemon is invoked (autostart kick,
+# manual `cua-driver mcp`, MCP client startup) it picks up the freshly-
+# installed code. Without this, in-memory daemons keep serving old
+# behaviour - which surfaces as "the bug I just patched is still
+# there" because the user's in-memory code is pre-fix. Best-effort:
+# High-IL daemons from the RunLevel=Highest autostart task survive a
+# Medium-IL kill and get reported via Show-CuaDriverDaemonSurvivors.
+Write-Host ""
+Write-Host "Stopping any previous cua-driver processes (best-effort; High-IL needs admin)..." -ForegroundColor Cyan
+$survivors = Stop-CuaDriverDaemons
+Show-CuaDriverDaemonSurvivors -Survivors $survivors
 
 if ($AutoStart) {
     Write-Host ""

--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -528,7 +528,7 @@ function Test-IsElevated {
 }
 
 # Stop-CuaDriverDaemons + Show-CuaDriverDaemonSurvivors live in the
-# sibling CuaDriverInstall.psm1 module so install-local.ps1 and this
+# sibling _install-common.psm1 module so install-local.ps1 and this
 # script share the daemon-cleanup logic. Two load paths:
 #   * checked-out tree: the .psm1 sits next to install.ps1 on disk;
 #     Import-Module from $PSScriptRoot works directly.
@@ -543,7 +543,7 @@ function Import-CuaDriverInstallModuleBootstrap {
         [Parameter(Mandatory = $true)][string]$Url
     )
     if ($LocalDir) {
-        $localPsm = Join-Path $LocalDir "CuaDriverInstall.psm1"
+        $localPsm = Join-Path $LocalDir "_install-common.psm1"
         if (Test-Path -LiteralPath $localPsm) {
             Import-Module -Name $localPsm -Force -ErrorAction Stop
             return
@@ -560,7 +560,7 @@ function Import-CuaDriverInstallModuleBootstrap {
 }
 Import-CuaDriverInstallModuleBootstrap `
     -LocalDir $PSScriptRoot `
-    -Url "https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/CuaDriverInstall.psm1"
+    -Url "https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/_install-common.psm1"
 
 function Register-CuaDriverAutostart {
     param([Parameter(Mandatory = $true)][string]$InstalledBinary)

--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -527,53 +527,40 @@ function Test-IsElevated {
     return $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
 }
 
-# KEEP IN SYNC WITH install-local.ps1::Stop-CuaDriverDaemons (both
-# scripts run standalone, install.ps1 is fetched via `irm | iex` so it
-# can't dot-source — duplicated definitions, identical bodies).
-#
-# Best-effort kill of any running cua-driver / cua-driver-uia processes
-# so the next `cua-driver autostart kick` / `cua-driver mcp` starts the
-# FRESH binary, not whatever's still in memory. Without this the
-# previous daemon keeps running (and keeps drawing its overlay window)
-# until the user reboots — which surfaces as "the bug I just fixed is
-# still there" because the in-memory code is pre-fix.
-#
-# Layers of escalation:
-#   1. schtasks /End — terminates an autostart-task instance. Task
-#      Scheduler runs as SYSTEM so it can kill High-IL processes that
-#      a Medium-IL shell can't. /End on an instance the current user
-#      registered does NOT need admin.
-#   2. taskkill /F /IM — Medium-IL backstop for any process that
-#      wasn't task-attached.
-#   3. Returns the surviving process list so callers can warn the user
-#      (these are the processes a Medium-IL shell genuinely can't reach
-#      — High-IL daemons whose parent wasn't `cua-driver-serve`).
-function Stop-CuaDriverDaemons {
-    $prevEAP = $ErrorActionPreference
-    $ErrorActionPreference = 'Continue'
-    try {
-        & schtasks.exe /End /TN "cua-driver-serve" 2>$null | Out-Null
-        Start-Sleep -Milliseconds 200
-        & taskkill.exe /F /IM "cua-driver.exe" /T 2>$null | Out-Null
-        & taskkill.exe /F /IM "cua-driver-uia.exe" /T 2>$null | Out-Null
-    } finally {
-        $ErrorActionPreference = $prevEAP
+# Stop-CuaDriverDaemons + Show-CuaDriverDaemonSurvivors live in the
+# sibling CuaDriverInstall.psm1 module so install-local.ps1 and this
+# script share the daemon-cleanup logic. Two load paths:
+#   * checked-out tree: the .psm1 sits next to install.ps1 on disk;
+#     Import-Module from $PSScriptRoot works directly.
+#   * `irm | iex` install: no file on disk, $PSScriptRoot is empty.
+#     Fetch the .psm1 from GitHub raw and Import-Module from a temp
+#     file. See Import-CuaDriverInstallModule below (defined inline so
+#     it's available before the module load itself).
+function Import-CuaDriverInstallModuleBootstrap {
+    [CmdletBinding()]
+    param(
+        [string]$LocalDir,
+        [Parameter(Mandatory = $true)][string]$Url
+    )
+    if ($LocalDir) {
+        $localPsm = Join-Path $LocalDir "CuaDriverInstall.psm1"
+        if (Test-Path -LiteralPath $localPsm) {
+            Import-Module -Name $localPsm -Force -ErrorAction Stop
+            return
+        }
     }
-    Start-Sleep -Milliseconds 200
-    return @(Get-Process -Name "cua-driver","cua-driver-uia" -ErrorAction SilentlyContinue)
+    $body = Invoke-RestMethod -Uri $Url -UseBasicParsing
+    $tmp = Join-Path $env:TEMP ("CuaDriverInstall-" + [Guid]::NewGuid().ToString('N') + ".psm1")
+    Set-Content -LiteralPath $tmp -Value $body -Encoding UTF8
+    try {
+        Import-Module -Name $tmp -Force -ErrorAction Stop
+    } finally {
+        Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+    }
 }
-
-# KEEP IN SYNC WITH install-local.ps1::Show-CuaDriverDaemonSurvivors.
-function Show-CuaDriverDaemonSurvivors {
-    param([Parameter(Mandatory = $true)][array]$Survivors)
-    if (-not $Survivors -or $Survivors.Count -eq 0) { return }
-    $pids = ($Survivors | ForEach-Object { $_.Id }) -join ', '
-    Write-Host "Note: $($Survivors.Count) cua-driver process(es) still running after best-effort kill (pid: $pids)." -ForegroundColor Yellow
-    Write-Host "      They are likely High-IL (spawned by RunLevel=Highest autostart task)." -ForegroundColor Yellow
-    Write-Host "      From an elevated PowerShell:" -ForegroundColor Yellow
-    Write-Host "        taskkill /IM cua-driver.exe /F" -ForegroundColor Yellow
-    Write-Host "      Or just reboot. Until they exit, the OLD binary keeps running." -ForegroundColor Yellow
-}
+Import-CuaDriverInstallModuleBootstrap `
+    -LocalDir $PSScriptRoot `
+    -Url "https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/CuaDriverInstall.psm1"
 
 function Register-CuaDriverAutostart {
     param([Parameter(Mandatory = $true)][string]$InstalledBinary)


### PR DESCRIPTION
## Summary

After PR #1687 (\`install-local.ps1\` rename-out-of-way), re-installs leave the previous in-memory daemon **running**. It keeps serving requests + drawing its overlay window from the OLD code until reboot — which surfaces as \"the bug I just fixed is still there\" even though the binary on disk is the new build.

Reporter's machine on dogfood: **3 orphan \`cua-driver.exe\` processes** accumulated from successive \`install-local.ps1\` + \`autostart kick\` rounds. Top one stuck in the topmost band (from before PR #1688's Z-order fix), drawing the cursor overlay above the user's terminal.

## Fix

Both \`install.ps1\` (production curl-installer) and \`install-local.ps1\` (dev) now call a shared kill helper after the binary swap. Same function pair in both files, marked with \`KEEP IN SYNC\` because \`install.ps1\` is fetched via \`irm | iex\` and can't dot-source.

\`\`\`powershell
function Stop-CuaDriverDaemons {
    # 1. schtasks /End — SYSTEM-level kill, reaches High-IL processes
    & schtasks.exe /End /TN \"cua-driver-serve\" 2>$null | Out-Null
    # 2. taskkill /F /IM — Medium-IL backstop
    & taskkill.exe /F /IM \"cua-driver.exe\" /T 2>$null | Out-Null
    & taskkill.exe /F /IM \"cua-driver-uia.exe\" /T 2>$null | Out-Null
    # 3. Return survivors so caller can warn
    return @(Get-Process -Name \"cua-driver\",\"cua-driver-uia\" -ErrorAction SilentlyContinue)
}
\`\`\`

Plus \`Show-CuaDriverDaemonSurvivors\` prints a clear hint when a High-IL daemon (e.g. spawned by the RunLevel=Highest autostart task) survives the Medium-IL kill — pointing the user at \`taskkill /IM cua-driver.exe /F\` from an elevated shell.

## Knock-on benefit: `cua-driver update --apply`

Already shells out to install.ps1, so the update path inherits this for free.

## Verified end-to-end on Windows

Before: 3 cua-driver.exe orphans (pid 14152 + 2676 + 12380).

After \`install-local.ps1\`:

\`\`\`
==> killing previous cua-driver processes (best-effort; High-IL needs admin)
Note: 1 cua-driver process(es) still running after best-effort kill (pid: 14152).
      They are likely High-IL (spawned by RunLevel=Highest autostart task).
      From an elevated PowerShell:
        taskkill /IM cua-driver.exe /F
      Or just reboot. Until they exit, the OLD binary keeps running.
\`\`\`

2 of 3 orphans cleaned; the 1 High-IL survivor is correctly flagged.

## Test plan

- [x] Both scripts pass PS parser
- [x] End-to-end on Windows: 3 orphans → 1 (only the High-IL autostart-spawned one survives)
- [ ] Reviewer: run \`install.ps1\` on a host with multiple cua-driver instances, confirm cleanup + Note message
- [ ] Reviewer: run \`cua-driver update --apply\` on Windows, confirm it inherits the cleanup via install.ps1 delegate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installation process now automatically stops running daemons before upgrading to ensure clean deployment of new versions.
  * Added clear user guidance when daemon processes persist after shutdown attempts.
  * Installation scripts now support both local and remote execution scenarios while maintaining daemon management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1689?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->