### PR TITLE
fix(screenshot): apply maxImageDimension cap to match get_window_state

### DIFF
--- a/libs/cua-driver/swift/Sources/CuaDriverServer/Tools/ScreenshotTool.swift
+++ b/libs/cua-driver/swift/Sources/CuaDriverServer/Tools/ScreenshotTool.swift
@@ -87,10 +87,17 @@ public enum ScreenshotTool {
             }
 
             do {
+                // Load config so we can apply the same maxImageDimension cap
+                // that get_window_state uses. Without this, screenshot returns
+                // native Retina resolution (2× logical) while click coordinates
+                // are calibrated against the downscaled image — causing every
+                // click to miss its target on Retina displays (issue #1592).
+                let config = await ConfigStore.shared.load()
                 let shot = try await capture.captureWindow(
                     windowID: windowID,
                     format: format,
-                    quality: quality
+                    quality: quality,
+                    maxImageDimension: config.maxImageDimension
                 )
                 let base64 = shot.imageData.base64EncodedString()
                 let mime = format == .png ? "image/png" : "image/jpeg"


### PR DESCRIPTION
## Problem (Bug 1 from #1592)

`screenshot` returns native Retina resolution (2× logical) while `click` coordinates are calibrated against the downscaled image from `get_window_state`. An agent using `screenshot` to see the screen and then calling `click` with those pixel coordinates misses every target on a Retina display.

**Root cause:** `ScreenshotTool` called `captureWindow(windowID:format:quality:)` without `maxImageDimension` (defaults to `0` = no resize). `GetWindowStateTool` passes `config.maxImageDimension` and registers the resize ratio in `ImageResizeRegistry` so `ClickTool` can reverse it.

## Fix

Load `ConfigStore.shared` in `ScreenshotTool` and pass `config.maxImageDimension` to `captureWindow`, matching the `GetWindowStateTool` code path exactly.

**Before:** `captureWindow(windowID:, format:, quality:)` → native 2× resolution

**After:** `captureWindow(windowID:, format:, quality:, maxImageDimension: config.maxImageDimension)` → same downscaled resolution as `get_window_state`

Fixes #1592 (Bug 1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Screenshots now respect maximum image dimension constraints from configuration, preventing the generation of excessively large images that could impact performance and resource usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->