### PR TITLE
fix(cua-driver-rs)(windows): screenshot clips bottom row of VCL/SAL dialogs (use GetWindowRect not GetClientRect)

### DIFF
--- a/libs/cua-driver/rust/crates/platform-windows/src/capture.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/capture.rs
@@ -211,7 +211,7 @@ pub fn screenshot_window(hwnd: u64) -> Result<(String, u32, u32)> {
 }
 
 unsafe fn screenshot_window_bytes_with_occlusion_unsafe(hwnd: u64) -> Result<(Vec<u8>, bool)> {
-    use windows::Win32::UI::WindowsAndMessaging::GetClientRect;
+    use windows::Win32::UI::WindowsAndMessaging::GetWindowRect;
     use windows::Win32::Foundation::RECT;
 
     let hwnd_raw = hwnd;
@@ -262,12 +262,23 @@ unsafe fn screenshot_window_bytes_with_occlusion_unsafe(hwnd: u64) -> Result<(Ve
         }
     }
 
+    // Size the capture buffer to the WHOLE window (GetWindowRect), not
+    // just the client area (GetClientRect). PrintWindow draws the entire
+    // window at 1:1 starting at (0,0) — if the buffer is sized to the
+    // client area only, anything in the non-client region clips. The
+    // surprising case is VCL/SAL dialogs (LibreOffice's "Document
+    // Recovery", any of its Confirmation modals): VCL puts the bottom
+    // button strip OUTSIDE the standard Win32 client area, so a
+    // client-sized buffer loses the Save/Cancel/OK row at the bottom.
+    // Window-sized buffer captures title bar + body + non-client trim
+    // correctly; the small extra rows at the top (window frame) are
+    // worth it to never silently truncate buttons.
     let mut rect = RECT::default();
-    GetClientRect(hwnd, &mut rect)?;
+    GetWindowRect(hwnd, &mut rect)?;
     let w = (rect.right - rect.left) as i32;
     let h = (rect.bottom - rect.top) as i32;
     if w <= 0 || h <= 0 {
-        bail!("Window has zero/negative client size: {}x{}", w, h);
+        bail!("Window has zero/negative size: {}x{}", w, h);
     }
 
     let screen_dc = GetWindowDC(hwnd);


### PR DESCRIPTION
## Summary

The non-XAML PrintWindow path in \`capture.rs\` allocated its destination bitmap with \`GetClientRect\` dimensions, but PrintWindow draws the entire window at 1:1 starting at (0, 0). For VCL/SAL dialogs (LibreOffice) the bottom button strip lives in the non-client area — outside what GetClientRect reports — so the captured bitmap silently clips the row containing Save / Cancel / OK.

## Concrete repro

LibreOffice "Document Recovery" summary modal after discarding recovery data. \`GetWindowRect\` says 607×271. \`GetClientRect\` says 605×239. Screenshot returned the 605×239 client-sized bitmap with the bottom 32 px of buttons missing. The user couldn't see the buttons in the agent's vision input.

## Fix

Switch the buffer-allocation rect from \`GetClientRect\` to \`GetWindowRect\`. PrintWindow draws into a correctly-sized buffer; full window content (title bar + body + non-client trim + bottom command bar) is captured.

| Before | After |
|---|---|
| 605×239, Save/Cancel clipped | 621×278, Save+Cancel visible |

## Test plan

- [x] \`cargo build --release -p cua-driver\` — clean
- [x] Re-screenshot the LibreOffice recovery-interrupted dialog (HWND 2556892 in the live repro) — returns 621×278, Save and Cancel buttons visible at bottom-right.
- [x] No change to XAML/UWP path (WGC + screen-region BitBlt) which already used full-window bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced window capture to accurately include the entire window surface, including title bar and frame regions, ensuring more reliable and complete capture results across various window types.
  * Improved error handling with enhanced messages when window bounds validation fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1696?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->