### PR TITLE
feat(cua-driver-rs)(test-harness): WPF + WinUI3 deterministic test apps + Rust integration tests

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_winui3_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_winui3_test.rs
@@ -148,3 +148,97 @@ fn harness_winui3_smoke() {
 
     child.kill().ok();
 }
+
+fn find_idx(text: &str, aid: &str) -> Option<u64> {
+    let needle = format!("id={aid}");
+    for line in text.lines() {
+        if !line.contains(&needle) { continue; }
+        let s = line.find('[')? + 1;
+        let e = line[s..].find(']')? + s;
+        return line[s..e].trim().parse().ok();
+    }
+    None
+}
+
+#[test]
+#[ignore]
+fn harness_winui3_type_text() {
+    let driver = driver_binary();
+    if !driver.exists() { return; }
+    let harness = match Harness::launch() { Some(h) => h, None => return };
+
+    let mut child = Command::new(&driver)
+        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
+        .spawn().expect("spawn cua-driver");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut raw_stdout = child.stdout.take().unwrap();
+    let mut stdout = BufReader::new(&mut raw_stdout);
+    init(&mut stdin, &mut stdout);
+
+    let (wid, _) = find_harness_window(&mut stdin, &mut stdout, harness.pid, "CuaTestHarness WinUI3")
+        .expect("WinUI3 main window");
+
+    let snap = tools_call(&mut stdin, &mut stdout, 20, "get_window_state",
+        serde_json::json!({"pid": harness.pid as i64, "window_id": wid, "capture_mode":"som"}));
+    let snap_text = snapshot_text(&snap);
+    let idx = find_idx(snap_text, "txt-input").expect("txt-input not in WinUI3 snapshot");
+
+    // WinUI3 is a XAML host — type_text requires element_index + window_id
+    // (routes through UIA ValuePattern.SetValue, see Windows backend docs).
+    let resp = tools_call(&mut stdin, &mut stdout, 30, "type_text", serde_json::json!({
+        "pid": harness.pid as i64,
+        "window_id": wid,
+        "element_index": idx,
+        "text": "winui3-typed"
+    }));
+    println!("type_text (WinUI3): {}", resp["result"]["content"][0]["text"]);
+    std::thread::sleep(Duration::from_millis(500));
+
+    let post = tools_call(&mut stdin, &mut stdout, 31, "get_window_state",
+        serde_json::json!({"pid": harness.pid as i64, "window_id": wid, "capture_mode":"som"}));
+    let post_text = snapshot_text(&post);
+    assert!(post_text.contains("mirror=winui3-typed"),
+        "WinUI3 TextBox mirror did not advance. Snapshot excerpt: {}",
+        post_text.chars().take(600).collect::<String>());
+    println!("✅ harness_winui3_type_text: WinUI3 TextBox mirror reflects 'winui3-typed'");
+
+    child.kill().ok();
+}
+
+#[test]
+#[ignore]
+fn harness_winui3_xaml_popup_open() {
+    let driver = driver_binary();
+    if !driver.exists() { return; }
+    let harness = match Harness::launch() { Some(h) => h, None => return };
+
+    let mut child = Command::new(&driver)
+        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
+        .spawn().expect("spawn cua-driver");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut raw_stdout = child.stdout.take().unwrap();
+    let mut stdout = BufReader::new(&mut raw_stdout);
+    init(&mut stdin, &mut stdout);
+
+    let (wid, _) = find_harness_window(&mut stdin, &mut stdout, harness.pid, "CuaTestHarness WinUI3")
+        .expect("WinUI3 main window");
+
+    let snap = tools_call(&mut stdin, &mut stdout, 20, "get_window_state",
+        serde_json::json!({"pid": harness.pid as i64, "window_id": wid, "capture_mode":"som"}));
+    let idx = find_idx(snapshot_text(&snap), "btn-open-popup").expect("btn-open-popup");
+
+    let _ = tools_call(&mut stdin, &mut stdout, 30, "click", serde_json::json!({
+        "pid": harness.pid as i64, "window_id": wid, "element_index": idx
+    }));
+    std::thread::sleep(Duration::from_millis(500));
+
+    let post = tools_call(&mut stdin, &mut stdout, 31, "get_window_state",
+        serde_json::json!({"pid": harness.pid as i64, "window_id": wid, "capture_mode":"som"}));
+    let text = snapshot_text(&post);
+    assert!(text.contains("XAML_POPUP_MARKER_v1"),
+        "XAML popup body did not appear in tree after click. Excerpt: {}",
+        text.chars().take(600).collect::<String>());
+    println!("✅ harness_winui3_xaml_popup_open: popup body visible in UIA tree");
+
+    child.kill().ok();
+}

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_winui3_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_winui3_test.rs
@@ -81,9 +81,10 @@ impl Harness {
             .stdout(Stdio::null()).stderr(Stdio::null())
             .spawn().ok()?;
         let pid = app.id();
-        // WinUI3 cold-start (especially in sandbox with no cached WinAppSDK)
-        // can take several seconds.
-        std::thread::sleep(Duration::from_secs(5));
+        // Short fixed cold-start settle (window creation + foreground
+        // establishment after spawn). Polling in find_harness_window
+        // handles the variable tail.
+        std::thread::sleep(Duration::from_millis(1500));
         Some(Self { _app: app, pid })
     }
 }
@@ -94,16 +95,27 @@ impl Drop for Harness {
 
 fn find_harness_window(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
                        pid: u32, title_substr: &str) -> Option<(u64, String)> {
-    let resp = tools_call(stdin, stdout, 10, "list_windows",
-        serde_json::json!({ "pid": pid as i64 }));
-    let wins = resp["result"]["structuredContent"]["windows"].as_array()?;
-    for w in wins {
-        let title = w["title"].as_str().unwrap_or("");
-        if title.contains(title_substr) {
-            return Some((w["window_id"].as_u64()?, title.to_string()));
+    // Polls because WinUI3 cold-start (first run, no cached WinAppSDK) can
+    // exceed a fixed 5s wait under sandbox load. Bounded so a genuinely
+    // broken harness still fails the test in ≤20s rather than hanging.
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    let mut id = 10u32;
+    loop {
+        let resp = tools_call(stdin, stdout, id, "list_windows",
+            serde_json::json!({ "pid": pid as i64 }));
+        id = id.wrapping_add(1);
+        if let Some(wins) = resp["result"]["structuredContent"]["windows"].as_array() {
+            for w in wins {
+                if w["pid"].as_u64() != Some(pid as u64) { continue; }
+                let title = w["title"].as_str().unwrap_or("");
+                if title.contains(title_substr) {
+                    return Some((w["window_id"].as_u64()?, title.to_string()));
+                }
+            }
         }
+        if std::time::Instant::now() >= deadline { return None; }
+        std::thread::sleep(Duration::from_millis(200));
     }
-    None
 }
 
 #[test]

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_winui3_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_winui3_test.rs
@@ -1,0 +1,150 @@
+//! Integration test against the CuaTestHarness.WinUI3 .NET 8 app.
+//!
+//! Pair-companion to harness_wpf_test.rs but exercises WinUI3 + DComp
+//! rendering paths. The two tests share scenario IDs (counter, text_body,
+//! exit) so any AutomationId regression that affects both UI frameworks
+//! shows up in both suites.
+//!
+//! WinUI3-specific surfaces under test:
+//!   - CommandBarFlyout : popup hosted in same HWND, rendered via XAML
+//!                        Islands / DComp. Tests UIA descent into the
+//!                        flyout subtree.
+//!   - XAML Popup       : Popup primitive (NOT a separate HWND).
+//!                        Regression guard that the agent doesn't lose
+//!                        track of in-window flyouts.
+//!
+//! Run via:
+//!   .\sandbox\run-tests-in-sandbox.ps1 harness_winui3
+//! or locally:
+//!   cargo test --test harness_winui3_test -- --ignored --nocapture
+
+#![cfg(target_os = "windows")]
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::time::Duration;
+
+fn workspace_root() -> PathBuf {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    PathBuf::from(manifest).parent().unwrap().parent().unwrap().to_owned()
+}
+
+fn driver_binary() -> PathBuf { workspace_root().join("target/debug/cua-driver.exe") }
+
+fn harness_exe() -> PathBuf {
+    if let Ok(p) = std::env::var("HARNESS_WINUI3_EXE") {
+        let pb = PathBuf::from(p);
+        if pb.exists() { return pb; }
+    }
+    workspace_root().join("test-apps/harness-winui3/CuaTestHarness.WinUI3.exe")
+}
+
+fn send(stdin: &mut ChildStdin, req: serde_json::Value) {
+    writeln!(stdin, "{}", serde_json::to_string(&req).unwrap()).unwrap();
+}
+
+fn recv(stdout: &mut BufReader<&mut ChildStdout>) -> serde_json::Value {
+    let mut line = String::new();
+    stdout.read_line(&mut line).expect("read");
+    serde_json::from_str(line.trim()).expect("json")
+}
+
+fn init(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>) {
+    send(stdin, serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}));
+    let _ = recv(stdout);
+}
+
+fn tools_call(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
+              id: u32, name: &str, args: serde_json::Value) -> serde_json::Value {
+    send(stdin, serde_json::json!({
+        "jsonrpc":"2.0","id":id,"method":"tools/call",
+        "params":{"name":name,"arguments":args}
+    }));
+    recv(stdout)
+}
+
+fn snapshot_text(snapshot: &serde_json::Value) -> &str {
+    snapshot["result"]["content"][0]["text"].as_str().unwrap_or("")
+}
+
+struct Harness { _app: Child, pid: u32 }
+
+impl Harness {
+    fn launch() -> Option<Self> {
+        let exe = harness_exe();
+        if !exe.exists() {
+            eprintln!("WinUI3 harness exe not found at {exe:?} — run test-harness/build.ps1");
+            return None;
+        }
+        let app = Command::new(&exe)
+            .stdout(Stdio::null()).stderr(Stdio::null())
+            .spawn().ok()?;
+        let pid = app.id();
+        // WinUI3 cold-start (especially in sandbox with no cached WinAppSDK)
+        // can take several seconds.
+        std::thread::sleep(Duration::from_secs(5));
+        Some(Self { _app: app, pid })
+    }
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) { let _ = self._app.kill(); }
+}
+
+fn find_harness_window(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
+                       pid: u32, title_substr: &str) -> Option<(u64, String)> {
+    let resp = tools_call(stdin, stdout, 10, "list_windows",
+        serde_json::json!({ "pid": pid as i64 }));
+    let wins = resp["result"]["structuredContent"]["windows"].as_array()?;
+    for w in wins {
+        let title = w["title"].as_str().unwrap_or("");
+        if title.contains(title_substr) {
+            return Some((w["window_id"].as_u64()?, title.to_string()));
+        }
+    }
+    None
+}
+
+#[test]
+#[ignore]
+fn harness_winui3_smoke() {
+    let driver = driver_binary();
+    if !driver.exists() { eprintln!("cua-driver.exe not built"); return; }
+    let harness = match Harness::launch() { Some(h) => h, None => return };
+    println!("WinUI3 harness pid={}", harness.pid);
+
+    let mut child = Command::new(&driver)
+        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
+        .spawn().expect("spawn cua-driver");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut raw_stdout = child.stdout.take().unwrap();
+    let mut stdout = BufReader::new(&mut raw_stdout);
+    init(&mut stdin, &mut stdout);
+
+    let (wid, _) = find_harness_window(&mut stdin, &mut stdout, harness.pid, "CuaTestHarness WinUI3")
+        .expect("WinUI3 main window not found");
+
+    let snap = tools_call(&mut stdin, &mut stdout, 20, "get_window_state",
+        serde_json::json!({"pid": harness.pid as i64, "window_id": wid, "capture_mode":"tree"}));
+    let text = snapshot_text(&snap);
+
+    // Button-class controls surface AutomationIds in the UIA tree.
+    for aid in [
+        "btn-increment", "btn-reset",
+        "btn-open-flyout",
+        "btn-open-popup",
+        "btn-exit",
+    ] {
+        assert!(text.contains(&format!("id={aid}")),
+            "missing AutomationId {aid} in WinUI3 UIA snapshot");
+    }
+
+    // TextBlock content (no AutomationId surfaces) — assert markers.
+    assert!(text.contains("HARNESS_TEXT_MARKER_v1"), "WinUI3 text_body marker not in snapshot");
+    assert!(text.contains("counter=0"),             "WinUI3 initial counter label not in snapshot");
+
+    println!("✅ harness_winui3_smoke: all expected scenarios present in UIA tree");
+
+    child.kill().ok();
+}

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
@@ -1,0 +1,263 @@
+//! Integration test against the CuaTestHarness.Wpf .NET 8 app.
+//!
+//! Pairs of test apps live under `libs/cua-driver/test-harness/`. They
+//! publish into `libs/cua-driver/rust/test-apps/harness-{wpf,winui3}/` and
+//! get mapped into the sandbox via the existing run-tests-in-sandbox.ps1
+//! mapped folder.
+//!
+//! Each scenario covers a Win32 hosting pattern the agent should handle:
+//!   - counter        : UIA Invoke on a plain WPF button
+//!   - text_body      : get_window_state extracts known marker text
+//!   - message_box    : modal MessageBox enumeration
+//!   - bottom_strip   : Save/Cancel buttons present in the UIA tree
+//!                      (regression guard for the GetClientRect-vs-
+//!                      GetWindowRect capture bug fixed in #1696)
+//!   - owned_popup    : owned secondary window discovered via list_windows
+//!   - layered_popup  : WS_EX_LAYERED window enumerated and captured
+//!   - child_hwnd     : native Win32 BUTTON child HWND visible in tree
+//!
+//! Run via the sandbox runner:
+//!   .\sandbox\run-tests-in-sandbox.ps1 harness_wpf
+//!
+//! Or locally (requires .NET 8 SDK + `test-harness/build.ps1`):
+//!   cargo test --test harness_wpf_test -- --ignored --nocapture
+//!
+//! Tests are `#[ignore]` so they don't run in plain `cargo test`. The
+//! sandbox runner unignores them explicitly via the `--ignored` arg.
+
+#![cfg(target_os = "windows")]
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::time::Duration;
+
+// ── path helpers ─────────────────────────────────────────────────────────────
+
+fn workspace_root() -> PathBuf {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    PathBuf::from(manifest).parent().unwrap().parent().unwrap().to_owned()
+}
+
+fn driver_binary() -> PathBuf {
+    workspace_root().join("target/debug/cua-driver.exe")
+}
+
+fn harness_exe() -> PathBuf {
+    if let Ok(p) = std::env::var("HARNESS_WPF_EXE") {
+        let pb = PathBuf::from(p);
+        if pb.exists() { return pb; }
+    }
+    workspace_root().join("test-apps/harness-wpf/CuaTestHarness.Wpf.exe")
+}
+
+// ── JSON-RPC helpers ─────────────────────────────────────────────────────────
+
+fn send(stdin: &mut ChildStdin, req: serde_json::Value) {
+    writeln!(stdin, "{}", serde_json::to_string(&req).unwrap()).unwrap();
+}
+
+fn recv(stdout: &mut BufReader<&mut ChildStdout>) -> serde_json::Value {
+    let mut line = String::new();
+    stdout.read_line(&mut line).expect("read response");
+    serde_json::from_str(line.trim()).expect("parse json")
+}
+
+fn init(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>) {
+    send(stdin, serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}));
+    let _ = recv(stdout);
+}
+
+fn tools_call(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
+              id: u32, name: &str, args: serde_json::Value) -> serde_json::Value {
+    send(stdin, serde_json::json!({
+        "jsonrpc": "2.0", "id": id, "method": "tools/call",
+        "params": { "name": name, "arguments": args }
+    }));
+    recv(stdout)
+}
+
+// ── harness fixture ──────────────────────────────────────────────────────────
+
+struct Harness {
+    _app: Child,
+    pid: u32,
+}
+
+impl Harness {
+    fn launch() -> Option<Self> {
+        let exe = harness_exe();
+        if !exe.exists() {
+            eprintln!("harness exe not found at {exe:?} — run test-harness/build.ps1 first");
+            return None;
+        }
+        let app = Command::new(&exe)
+            .stdout(Stdio::null()).stderr(Stdio::null())
+            .spawn().ok()?;
+        let pid = app.id();
+        // Settle. WPF cold-start in sandbox is slow.
+        std::thread::sleep(Duration::from_secs(3));
+        Some(Self { _app: app, pid })
+    }
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        let _ = self._app.kill();
+    }
+}
+
+// Look up the harness's main window via list_windows so the test doesn't
+// depend on title strings that callers might localize later. Returns
+// (window_id, title).
+fn find_harness_window(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
+                       pid: u32, title_substr: &str) -> Option<(u64, String)> {
+    let resp = tools_call(stdin, stdout, 10, "list_windows",
+        serde_json::json!({ "pid": pid as i64 }));
+    let wins = resp["result"]["structuredContent"]["windows"].as_array()?;
+    for w in wins {
+        let title = w["title"].as_str().unwrap_or("");
+        if title.contains(title_substr) {
+            return Some((w["window_id"].as_u64()?, title.to_string()));
+        }
+    }
+    None
+}
+
+// Get a UIA snapshot's flat element list — used to assert AutomationIds
+// exist in the tree without depending on tree-walk order.
+fn snapshot_elements(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
+                     pid: u32, window_id: u64) -> serde_json::Value {
+    let resp = tools_call(stdin, stdout, 20, "get_window_state",
+        serde_json::json!({
+            "pid": pid as i64,
+            "window_id": window_id,
+            "capture_mode": "tree"
+        }));
+    resp
+}
+
+fn snapshot_text(snapshot: &serde_json::Value) -> &str {
+    snapshot["result"]["content"][0]["text"].as_str().unwrap_or("")
+}
+
+fn elements_have_aid(snapshot: &serde_json::Value, aid: &str) -> bool {
+    // UIA tree is rendered as markdown lines like:
+    //   `  - [3] Button "Increment" [id=btn-increment actions=[click]]`
+    // so the substring `id=<aid>` is a reliable presence marker.
+    snapshot_text(snapshot).contains(&format!("id={aid}"))
+}
+
+/// Parse the UIA markdown snapshot for the line matching `id=<aid>` and
+/// extract the leading `[<index>]` element_index token.
+fn find_element_index_by_aid(snapshot: &serde_json::Value, aid: &str) -> Option<u64> {
+    let needle = format!("id={aid}");
+    for line in snapshot_text(snapshot).lines() {
+        if !line.contains(&needle) { continue; }
+        let start = line.find('[')? + 1;
+        let end   = line[start..].find(']')? + start;
+        return line[start..end].trim().parse().ok();
+    }
+    None
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+#[ignore]
+fn harness_wpf_smoke() {
+    let driver = driver_binary();
+    if !driver.exists() {
+        eprintln!("cua-driver.exe not built — run `cargo build` first");
+        return;
+    }
+    let harness = match Harness::launch() {
+        Some(h) => h,
+        None => { eprintln!("harness not built — skipping"); return; }
+    };
+    println!("harness pid={}", harness.pid);
+
+    let mut child = Command::new(&driver)
+        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
+        .spawn().expect("spawn cua-driver");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut raw_stdout = child.stdout.take().unwrap();
+    let mut stdout = BufReader::new(&mut raw_stdout);
+
+    init(&mut stdin, &mut stdout);
+
+    let (wid, title) = find_harness_window(&mut stdin, &mut stdout, harness.pid, "CuaTestHarness WPF")
+        .expect("main window not found via list_windows");
+    println!("main window: id={} title={:?}", wid, title);
+
+    let snap = snapshot_elements(&mut stdin, &mut stdout, harness.pid, wid);
+    let text = snapshot_text(&snap);
+
+    // Buttons appear with explicit id=<aid> tags in the UIA markdown.
+    for aid in [
+        "btn-increment", "btn-reset",
+        "btn-open-msgbox",
+        "btn-save", "btn-cancel",                       // regression guard for #1696
+        "btn-open-owned", "btn-open-layered",
+        "btn-exit",
+    ] {
+        assert!(elements_have_aid(&snap, aid), "missing AutomationId {aid} in WPF UIA snapshot");
+    }
+
+    // TextBlocks are reported as bare Text nodes (no UIA Invoke/Value pattern,
+    // no AutomationId in the rendered tree). Assert on their content instead.
+    assert!(text.contains("HARNESS_TEXT_MARKER_v1"), "text_body marker not in snapshot");
+    assert!(text.contains("counter=0"),             "initial counter label not in snapshot");
+    assert!(text.contains("accel_fired=0"),         "initial accel label not in snapshot");
+
+    // HwndHost child should surface the native Win32 BUTTON as a UIA Button.
+    assert!(text.contains("\"Native Win32 Child\""), "native HWND child button not in snapshot");
+
+    println!("✅ harness_wpf_smoke: all expected scenarios present in UIA tree");
+
+    child.kill().ok();
+}
+
+#[test]
+#[ignore]
+fn harness_wpf_counter_invoke() {
+    let driver = driver_binary();
+    if !driver.exists() { return; }
+    let harness = match Harness::launch() { Some(h) => h, None => return };
+
+    let mut child = Command::new(&driver)
+        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
+        .spawn().expect("spawn cua-driver");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut raw_stdout = child.stdout.take().unwrap();
+    let mut stdout = BufReader::new(&mut raw_stdout);
+    init(&mut stdin, &mut stdout);
+
+    let (wid, _) = find_harness_window(&mut stdin, &mut stdout, harness.pid, "CuaTestHarness WPF")
+        .expect("main window");
+    // Pre-snapshot so element_cache has indices we can address.
+    let pre = snapshot_elements(&mut stdin, &mut stdout, harness.pid, wid);
+    let idx = find_element_index_by_aid(&pre, "btn-increment")
+        .expect("btn-increment not in pre-snapshot");
+
+    let click = tools_call(&mut stdin, &mut stdout, 30, "click",
+        serde_json::json!({
+            "pid": harness.pid as i64,
+            "window_id": wid,
+            "element_index": idx
+        }));
+    println!("click [{idx}] btn-increment: {}", click["result"]["content"][0]["text"]);
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    let post = snapshot_elements(&mut stdin, &mut stdout, harness.pid, wid);
+    let text = snapshot_text(&post);
+    assert!(
+        text.contains("counter=1"),
+        "counter label did not advance after click — snapshot text: {}",
+        text.chars().take(400).collect::<String>()
+    );
+    println!("✅ harness_wpf_counter_invoke: counter advanced to 1");
+
+    child.kill().ok();
+}

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
@@ -24,6 +24,17 @@
 //!
 //! Tests are `#[ignore]` so they don't run in plain `cargo test`. The
 //! sandbox runner unignores them explicitly via the `--ignored` arg.
+//!
+//! **Foreground-lock caveat:** a handful of these tests (`double_click`,
+//! `right_click`, `type_text`) rely on `dispatch:"foreground"` to reach
+//! WPF's input chain reliably. Windows' system-wide foreground-lock
+//! kicks in after ~30s with no real user input — once that happens,
+//! `SetForegroundWindow` is denied for non-UIAccess processes and the
+//! tests fail. Run the WPF and WinUI3 suites as **separate** `cargo test`
+//! invocations (`--test harness_wpf_test`, then `--test harness_winui3_test`)
+//! rather than combined: each binary's first ~30s falls inside the
+//! foreground-lock window and stays green. The sandbox runner does this
+//! automatically.
 
 #![cfg(target_os = "windows")]
 
@@ -103,19 +114,31 @@ impl Harness {
 
 impl Drop for Harness {
     fn drop(&mut self) {
+        // Child::kill on Windows uses TerminateProcess, which signals exit
+        // but doesn't synchronously reap. Without wait() the next test's
+        // Harness::launch can briefly see TWO CuaTestHarness.Wpf windows —
+        // and find_harness_window may pick the dying one, returning stale
+        // element-cache coords (off-screen click failures).
         let _ = self._app.kill();
+        let _ = self._app.wait();
+        // Extra settle for the OS-level window destruction sweep.
+        std::thread::sleep(Duration::from_millis(300));
     }
 }
 
-// Look up the harness's main window via list_windows so the test doesn't
-// depend on title strings that callers might localize later. Returns
-// (window_id, title).
+// Look up the harness's main window via list_windows, filtered to the
+// exact spawned pid — defensive against the corner case where a previous
+// test's harness hasn't been fully reaped and there are briefly two
+// CuaTestHarness.Wpf windows on the desktop.
 fn find_harness_window(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
                        pid: u32, title_substr: &str) -> Option<(u64, String)> {
     let resp = tools_call(stdin, stdout, 10, "list_windows",
         serde_json::json!({ "pid": pid as i64 }));
     let wins = resp["result"]["structuredContent"]["windows"].as_array()?;
     for w in wins {
+        // The pid filter above already constrains to our spawned harness,
+        // but verify in-record for safety against a malformed response.
+        if w["pid"].as_u64() != Some(pid as u64) { continue; }
         let title = w["title"].as_str().unwrap_or("");
         if title.contains(title_substr) {
             return Some((w["window_id"].as_u64()?, title.to_string()));
@@ -218,6 +241,33 @@ fn harness_wpf_smoke() {
     child.kill().ok();
 }
 
+// ── shared driver session helper ─────────────────────────────────────────────
+
+/// Spin up a fresh harness + cua-driver pair, run the closure, then tear
+/// everything down. Returns whatever the closure returns. The closure
+/// receives the harness pid, the cua-driver stdin/stdout and a pre-resolved
+/// main window_id.
+fn with_session<F, R>(f: F) -> Option<R>
+where F: FnOnce(u32, u64, &mut ChildStdin, &mut BufReader<&mut ChildStdout>) -> R {
+    if !driver_binary().exists() { eprintln!("cua-driver.exe not built"); return None; }
+    let harness = Harness::launch()?;
+    let mut child = Command::new(&driver_binary())
+        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
+        .spawn().expect("spawn cua-driver");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut raw_stdout = child.stdout.take().unwrap();
+    let mut stdout = BufReader::new(&mut raw_stdout);
+    init(&mut stdin, &mut stdout);
+    let (wid, _) = find_harness_window(&mut stdin, &mut stdout, harness.pid, "CuaTestHarness WPF")
+        .expect("main window");
+    let out = f(harness.pid, wid, &mut stdin, &mut stdout);
+    drop(stdout);
+    drop(stdin);
+    child.kill().ok();
+    drop(harness);
+    Some(out)
+}
+
 #[test]
 #[ignore]
 fn harness_wpf_counter_invoke() {
@@ -260,4 +310,350 @@ fn harness_wpf_counter_invoke() {
     println!("✅ harness_wpf_counter_invoke: counter advanced to 1");
 
     child.kill().ok();
+}
+
+#[test]
+#[ignore]
+fn harness_wpf_type_text() {
+    with_session(|pid, wid, stdin, stdout| {
+        let snap = snapshot_elements(stdin, stdout, pid, wid);
+        let idx = find_element_index_by_aid(&snap, "txt-input")
+            .expect("txt-input not in snapshot");
+
+        // WPF's TextBox needs *keyboard focus* for WM_CHAR delivery — and
+        // PostMessage(WM_LBUTTONDOWN) doesn't reliably transfer keyboard
+        // focus (WPF's input system treats posted events differently from
+        // real ones). Use dispatch:"foreground" → SendInput synthesizes
+        // an OS-level click that WPF treats identically to a user mouse,
+        // landing actual keyboard focus on the TextBox.
+        let _ = tools_call(stdin, stdout, 28, "bring_to_front", serde_json::json!({
+            "pid": pid as i64, "window_id": wid
+        }));
+        std::thread::sleep(Duration::from_millis(300));
+
+        let _ = tools_call(stdin, stdout, 29, "click", serde_json::json!({
+            "pid": pid as i64, "window_id": wid, "element_index": idx,
+            "dispatch": "foreground"
+        }));
+        std::thread::sleep(Duration::from_millis(400));
+
+        // SendInput's restore_foreground_polling_best_effort may yank
+        // foreground back from the harness window between click and
+        // type_text. Re-assert foreground so PostMessage WM_CHAR finds
+        // the TextBox with keyboard focus.
+        let _ = tools_call(stdin, stdout, 30, "bring_to_front", serde_json::json!({
+            "pid": pid as i64, "window_id": wid
+        }));
+        std::thread::sleep(Duration::from_millis(300));
+
+        let resp = tools_call(stdin, stdout, 31, "type_text", serde_json::json!({
+            "pid": pid as i64, "text": "harness-typed"
+        }));
+        println!("type_text: {}", resp["result"]["content"][0]["text"]);
+        std::thread::sleep(Duration::from_millis(700));
+
+        let post = snapshot_elements(stdin, stdout, pid, wid);
+        let text = snapshot_text(&post);
+        let mirror_lines: Vec<&str> = text.lines()
+            .filter(|l| l.contains("mirror=") || l.contains("txt-input"))
+            .collect();
+        assert!(text.contains("mirror=harness-typed"),
+            "TextBox mirror did not reflect typed text. Mirror/input lines: {:?}",
+            mirror_lines);
+        println!("✅ harness_wpf_type_text: TextBox mirror advanced to 'harness-typed'");
+    });
+}
+
+#[test]
+#[ignore]
+fn harness_wpf_set_value() {
+    // Companion to harness_wpf_type_text: exercises the UIA ValuePattern
+    // write path via the `set_value` tool. No focus needed — purely UIA.
+    with_session(|pid, wid, stdin, stdout| {
+        let snap = snapshot_elements(stdin, stdout, pid, wid);
+        let idx = find_element_index_by_aid(&snap, "txt-input")
+            .expect("txt-input not in snapshot");
+        let _ = tools_call(stdin, stdout, 30, "set_value", serde_json::json!({
+            "pid": pid as i64, "window_id": wid, "element_index": idx,
+            "value": "via-uia-setvalue"
+        }));
+        std::thread::sleep(Duration::from_millis(400));
+
+        let post = snapshot_elements(stdin, stdout, pid, wid);
+        let text = snapshot_text(&post);
+        assert!(text.contains("mirror=via-uia-setvalue"),
+            "set_value did not update TextBox. Excerpt: {}",
+            text.chars().take(500).collect::<String>());
+        println!("✅ harness_wpf_set_value: ValuePattern.SetValue wrote to TextBox");
+    });
+}
+
+// In test-batch mode (many harnesses launched/killed in sequence) the WPF
+// window's input pump occasionally misses background PostMessage events —
+// reproducibly passes in isolation, intermittently fails in batch.
+// `bring_to_front` pays the foreground swap once so the click test
+// exercises the click-event-handling path itself, not the
+// background-delivery path (which the counter_invoke test already
+// covers via UIA Invoke).
+fn focus_harness(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
+                 pid: u32, wid: u64) {
+    let _ = tools_call(stdin, stdout, 28, "bring_to_front", serde_json::json!({
+        "pid": pid as i64, "window_id": wid
+    }));
+    std::thread::sleep(Duration::from_millis(300));
+}
+
+#[test]
+#[ignore]
+fn harness_wpf_right_click() {
+    with_session(|pid, wid, stdin, stdout| {
+        focus_harness(stdin, stdout, pid, wid);
+        let snap = snapshot_elements(stdin, stdout, pid, wid);
+        let idx = find_element_index_by_aid(&snap, "border-click-target")
+            .expect("border-click-target not in snapshot");
+        // Same dispatch:foreground rationale as type_text — PostMessage
+        // WM_RBUTTONDOWN doesn't always reach WPF's MouseRightButtonDown
+        // routed-event chain (intermittent in batch runs).
+        let resp = tools_call(stdin, stdout, 30, "right_click", serde_json::json!({
+            "pid": pid as i64, "window_id": wid, "element_index": idx,
+            "dispatch": "foreground"
+        }));
+        println!("right_click: {}", resp["result"]["content"][0]["text"]);
+        std::thread::sleep(Duration::from_millis(400));
+
+        let post = snapshot_elements(stdin, stdout, pid, wid);
+        let text = snapshot_text(&post);
+        let action_lines: Vec<&str> = text.lines()
+            .filter(|l| l.contains("last_action=") || l.contains("clicks="))
+            .collect();
+        assert!(text.contains("last_action=right_click"),
+            "right_click handler did not fire. Action/click lines: {:?}", action_lines);
+        println!("✅ harness_wpf_right_click: last_action=right_click");
+    });
+}
+
+#[test]
+#[ignore]
+fn harness_wpf_double_click() {
+    with_session(|pid, wid, stdin, stdout| {
+        focus_harness(stdin, stdout, pid, wid);
+        let snap = snapshot_elements(stdin, stdout, pid, wid);
+        let idx = find_element_index_by_aid(&snap, "border-click-target")
+            .expect("border-click-target not in snapshot");
+        // dispatch:foreground for the same reason as right_click —
+        // PostMessage WM_LBUTTONDOWN ×2 doesn't always reach WPF's
+        // MouseDoubleClick / ClickCount=2 path under test-batch load.
+        let resp = tools_call(stdin, stdout, 30, "double_click", serde_json::json!({
+            "pid": pid as i64, "window_id": wid, "element_index": idx,
+            "dispatch": "foreground"
+        }));
+        println!("double_click: {}", resp["result"]["content"][0]["text"]);
+        std::thread::sleep(Duration::from_millis(400));
+
+        let post = snapshot_elements(stdin, stdout, pid, wid);
+        let text = snapshot_text(&post);
+        let action_lines: Vec<&str> = text.lines()
+            .filter(|l| l.contains("last_action=") || l.contains("clicks="))
+            .collect();
+        assert!(text.contains("last_action=double_click"),
+            "double_click handler did not register a 2nd click. \
+             Action/click lines: {:?}", action_lines);
+        println!("✅ harness_wpf_double_click: last_action=double_click");
+    });
+}
+
+#[test]
+#[ignore]
+fn harness_wpf_press_key_accelerator() {
+    // F5 binding rather than the Ctrl+Shift+H one: cua-driver's hotkey
+    // PostMessage path doesn't update OS modifier-key state (GetKeyState
+    // returns "not pressed" for VK_CONTROL), so WPF's KeyBinding with
+    // Modifiers=Control+Shift never matches. The UIA-worker SendInput
+    // path would handle modifiers but requires the cua-driver-uia.exe
+    // helper that isn't in our test config. F5 has no modifier and works
+    // on the PostMessage path.
+    with_session(|pid, wid, stdin, stdout| {
+        let resp = tools_call(stdin, stdout, 30, "press_key", serde_json::json!({
+            "pid": pid as i64, "window_id": wid, "key": "f5"
+        }));
+        println!("press_key f5: {}", resp["result"]["content"][0]["text"]);
+        std::thread::sleep(Duration::from_millis(400));
+
+        let post = snapshot_elements(stdin, stdout, pid, wid);
+        let text = snapshot_text(&post);
+        assert!(text.contains("accel_fired=1"),
+            "F5 KeyBinding did not fire. Snapshot excerpt: {}",
+            text.chars().take(500).collect::<String>());
+        println!("✅ harness_wpf_press_key_accelerator: accel_fired=1 (F5 via PostMessage)");
+    });
+}
+
+#[test]
+#[ignore]
+fn harness_wpf_scroll() {
+    with_session(|pid, wid, stdin, stdout| {
+        // Pre-snapshot to populate the cache + read initial offset.
+        let pre = snapshot_elements(stdin, stdout, pid, wid);
+        let pre_text = snapshot_text(&pre);
+        assert!(pre_text.contains("scroll_offset=0"),
+            "expected initial scroll_offset=0, got: {}",
+            pre_text.lines().filter(|l| l.contains("scroll_offset")).collect::<Vec<_>>().join(" / "));
+
+        // Click into the ScrollViewer so it gets focus / its descendants
+        // become the WM_VSCROLL target.
+        let idx = find_element_index_by_aid(&pre, "scroll-tall")
+            .expect("scroll-tall not in snapshot");
+        let _ = tools_call(stdin, stdout, 30, "click", serde_json::json!({
+            "pid": pid as i64, "window_id": wid, "element_index": idx
+        }));
+        std::thread::sleep(Duration::from_millis(200));
+
+        // Scroll down 5 lines.
+        let resp = tools_call(stdin, stdout, 31, "scroll", serde_json::json!({
+            "pid": pid as i64, "window_id": wid,
+            "direction": "down", "by": "line", "amount": 5
+        }));
+        println!("scroll down: {}", resp["result"]["content"][0]["text"]);
+        std::thread::sleep(Duration::from_millis(400));
+
+        let post = snapshot_elements(stdin, stdout, pid, wid);
+        let text = snapshot_text(&post);
+        let advanced = text.lines().any(|l|
+            l.contains("scroll_offset=") && !l.contains("scroll_offset=0\""));
+        assert!(advanced, "scroll offset did not advance after WM_VSCROLL. Lines: {}",
+            text.lines().filter(|l| l.contains("scroll_offset"))
+                .collect::<Vec<_>>().join(" / "));
+        println!("✅ harness_wpf_scroll: scroll_offset advanced past 0");
+    });
+}
+
+#[test]
+#[ignore]
+fn harness_wpf_modal_messagebox() {
+    with_session(|pid, wid, stdin, stdout| {
+        let snap = snapshot_elements(stdin, stdout, pid, wid);
+        let idx = find_element_index_by_aid(&snap, "btn-open-msgbox")
+            .expect("btn-open-msgbox not in snapshot");
+        let _ = tools_call(stdin, stdout, 30, "click", serde_json::json!({
+            "pid": pid as i64, "window_id": wid, "element_index": idx
+        }));
+        std::thread::sleep(Duration::from_millis(600));
+
+        // List windows — the modal MessageBox should be a new top-level window
+        // owned by the same pid.
+        let resp = tools_call(stdin, stdout, 31, "list_windows", serde_json::json!({
+            "pid": pid as i64
+        }));
+        let windows = resp["result"]["structuredContent"]["windows"].as_array()
+            .expect("windows array");
+        let modal = windows.iter()
+            .find(|w| w["title"].as_str().map(|t| t.contains("Harness MessageBox")).unwrap_or(false))
+            .expect("Harness MessageBox modal window not found");
+        let modal_wid = modal["window_id"].as_u64().unwrap();
+        println!("modal window_id={}", modal_wid);
+
+        // Walk the modal's UIA tree — expect OK and Cancel buttons.
+        let modal_snap = tools_call(stdin, stdout, 32, "get_window_state", serde_json::json!({
+            "pid": pid as i64, "window_id": modal_wid, "capture_mode": "tree"
+        }));
+        let modal_text = snapshot_text(&modal_snap);
+        assert!(modal_text.contains("\"OK\""),
+            "MessageBox UIA tree missing OK button. Tree: {}",
+            modal_text.chars().take(800).collect::<String>());
+        assert!(modal_text.contains("\"Cancel\""),
+            "MessageBox UIA tree missing Cancel button");
+
+        // Dismiss by clicking Cancel in the modal.
+        let cancel_idx = modal_text.lines()
+            .find(|l| l.contains("\"Cancel\"") && l.contains('['))
+            .and_then(|l| {
+                let s = l.find('[')? + 1;
+                let e = l[s..].find(']')? + s;
+                l[s..e].trim().parse::<u64>().ok()
+            })
+            .expect("Cancel button element_index not parseable");
+        let _ = tools_call(stdin, stdout, 33, "click", serde_json::json!({
+            "pid": pid as i64, "window_id": modal_wid, "element_index": cancel_idx
+        }));
+        std::thread::sleep(Duration::from_millis(400));
+        println!("✅ harness_wpf_modal_messagebox: opened + parsed + dismissed");
+    });
+}
+
+#[test]
+#[ignore]
+fn harness_wpf_owned_popup() {
+    with_session(|pid, wid, stdin, stdout| {
+        let snap = snapshot_elements(stdin, stdout, pid, wid);
+        let idx = find_element_index_by_aid(&snap, "btn-open-owned")
+            .expect("btn-open-owned not in snapshot");
+        let _ = tools_call(stdin, stdout, 30, "click", serde_json::json!({
+            "pid": pid as i64, "window_id": wid, "element_index": idx
+        }));
+        std::thread::sleep(Duration::from_millis(500));
+
+        let resp = tools_call(stdin, stdout, 31, "list_windows", serde_json::json!({
+            "pid": pid as i64
+        }));
+        let windows = resp["result"]["structuredContent"]["windows"].as_array().unwrap();
+        let owned = windows.iter()
+            .find(|w| w["title"].as_str().map(|t| t.contains("Harness Owned Popup")).unwrap_or(false))
+            .expect("Harness Owned Popup window not found in list_windows");
+        let owned_wid = owned["window_id"].as_u64().unwrap();
+
+        let owned_snap = tools_call(stdin, stdout, 32, "get_window_state", serde_json::json!({
+            "pid": pid as i64, "window_id": owned_wid, "capture_mode": "tree"
+        }));
+        let owned_text = snapshot_text(&owned_snap);
+        assert!(owned_text.contains("OWNED_POPUP_MARKER_v1"),
+            "owned popup body marker missing. Tree: {}",
+            owned_text.chars().take(600).collect::<String>());
+        println!("✅ harness_wpf_owned_popup: opened + parsed");
+    });
+}
+
+#[test]
+#[ignore]
+fn harness_wpf_layered_popup_capture() {
+    with_session(|pid, wid, stdin, stdout| {
+        let snap = snapshot_elements(stdin, stdout, pid, wid);
+        let idx = find_element_index_by_aid(&snap, "btn-open-layered")
+            .expect("btn-open-layered not in snapshot");
+        let _ = tools_call(stdin, stdout, 30, "click", serde_json::json!({
+            "pid": pid as i64, "window_id": wid, "element_index": idx
+        }));
+        std::thread::sleep(Duration::from_millis(600));
+
+        let resp = tools_call(stdin, stdout, 31, "list_windows", serde_json::json!({
+            "pid": pid as i64
+        }));
+        let windows = resp["result"]["structuredContent"]["windows"].as_array().unwrap();
+        let layered = windows.iter()
+            .find(|w| w["title"].as_str().map(|t| t.contains("Harness Layered Popup")).unwrap_or(false))
+            .expect("Harness Layered Popup window not found");
+        let layered_wid = layered["window_id"].as_u64().unwrap();
+
+        // Capture-only path — assert the screenshot is not all-black, which
+        // is the failure mode for PrintWindow against layered windows
+        // without the WGC fallback.
+        let cap = tools_call(stdin, stdout, 32, "get_window_state", serde_json::json!({
+            "pid": pid as i64, "window_id": layered_wid, "capture_mode": "vision"
+        }));
+        let img_b64 = cap["result"]["content"].as_array()
+            .and_then(|arr| arr.iter().find_map(|c| {
+                if c["type"] == "image" { c["data"].as_str() } else { None }
+            }))
+            .expect("layered window capture returned no image");
+        // Decode the PNG and look for any non-black pixel.
+        let bytes = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, img_b64)
+            .expect("base64");
+        let img = image::load_from_memory(&bytes).expect("png decode");
+        let rgb = img.to_rgb8();
+        let any_color = rgb.pixels().any(|p| p.0[0] > 12 || p.0[1] > 12 || p.0[2] > 12);
+        assert!(any_color,
+            "layered window capture is all-black ({}x{}). PrintWindow likely needs WGC fallback.",
+            rgb.width(), rgb.height());
+        println!("✅ harness_wpf_layered_popup_capture: capture has non-black pixels ({}x{})",
+                 rgb.width(), rgb.height());
+    });
 }

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
@@ -106,8 +106,14 @@ impl Harness {
             .stdout(Stdio::null()).stderr(Stdio::null())
             .spawn().ok()?;
         let pid = app.id();
-        // Settle. WPF cold-start in sandbox is slow.
-        std::thread::sleep(Duration::from_secs(3));
+        // Short fixed settle for cold-start (window-creation + initial
+        // foreground hand-off after spawn) — the rest of the readiness
+        // wait happens via polling in find_harness_window. A 200ms-only
+        // wait turned out to be too short for the harness to establish
+        // foreground reliably under test-batch load, which caused
+        // SetForegroundWindow-needing tests (dispatch:foreground) to
+        // fail with a foreground-lock rejection.
+        std::thread::sleep(Duration::from_millis(800));
         Some(Self { _app: app, pid })
     }
 }
@@ -129,22 +135,30 @@ impl Drop for Harness {
 // Look up the harness's main window via list_windows, filtered to the
 // exact spawned pid — defensive against the corner case where a previous
 // test's harness hasn't been fully reaped and there are briefly two
-// CuaTestHarness.Wpf windows on the desktop.
+// CuaTestHarness.Wpf windows on the desktop. Polls with a deadline rather
+// than relying on a fixed pre-sleep, so cold-start in sandbox (where the
+// WPF runtime + harness exe both pay first-launch JIT cost) doesn't time
+// out the harness with a too-short fixed sleep.
 fn find_harness_window(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
                        pid: u32, title_substr: &str) -> Option<(u64, String)> {
-    let resp = tools_call(stdin, stdout, 10, "list_windows",
-        serde_json::json!({ "pid": pid as i64 }));
-    let wins = resp["result"]["structuredContent"]["windows"].as_array()?;
-    for w in wins {
-        // The pid filter above already constrains to our spawned harness,
-        // but verify in-record for safety against a malformed response.
-        if w["pid"].as_u64() != Some(pid as u64) { continue; }
-        let title = w["title"].as_str().unwrap_or("");
-        if title.contains(title_substr) {
-            return Some((w["window_id"].as_u64()?, title.to_string()));
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let mut id = 10u32;
+    loop {
+        let resp = tools_call(stdin, stdout, id, "list_windows",
+            serde_json::json!({ "pid": pid as i64 }));
+        id = id.wrapping_add(1);
+        if let Some(wins) = resp["result"]["structuredContent"]["windows"].as_array() {
+            for w in wins {
+                if w["pid"].as_u64() != Some(pid as u64) { continue; }
+                let title = w["title"].as_str().unwrap_or("");
+                if title.contains(title_substr) {
+                    return Some((w["window_id"].as_u64()?, title.to_string()));
+                }
+            }
         }
+        if std::time::Instant::now() >= deadline { return None; }
+        std::thread::sleep(Duration::from_millis(150));
     }
-    None
 }
 
 // Get a UIA snapshot's flat element list — used to assert AutomationIds

--- a/libs/cua-driver/rust/sandbox/run-tests-in-sandbox.ps1
+++ b/libs/cua-driver/rust/sandbox/run-tests-in-sandbox.ps1
@@ -98,9 +98,16 @@ if (Get-Command dotnet -ErrorAction SilentlyContinue) {
     $harnessBuild = Join-Path $wsRoot "..\test-harness\build.ps1"
     if (Test-Path $harnessBuild) {
         Write-Host "`n[BUILD] test-harness (dotnet publish)..." -ForegroundColor Yellow
-        & $harnessBuild
-        if ($LASTEXITCODE -ne 0) {
-            Write-Host "[WARN] test-harness build failed — harness tests will skip." -ForegroundColor Yellow
+        # build.ps1 sets $ErrorActionPreference=Stop and throws on
+        # `dotnet publish` failure — wrap so the throw doesn't abort
+        # the whole sandbox runner before we can log the skip.
+        try {
+            & $harnessBuild
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "[WARN] test-harness build failed (exit $LASTEXITCODE) — harness tests will skip." -ForegroundColor Yellow
+            }
+        } catch {
+            Write-Host "[WARN] test-harness build errored: $($_.Exception.Message) — harness tests will skip." -ForegroundColor Yellow
         }
     } else {
         Write-Host "`n[SKIP] test-harness/build.ps1 not found — harness tests will skip." -ForegroundColor Yellow

--- a/libs/cua-driver/rust/sandbox/run-tests-in-sandbox.ps1
+++ b/libs/cua-driver/rust/sandbox/run-tests-in-sandbox.ps1
@@ -79,7 +79,35 @@ try {
     Write-Host "`n[BUILD] cargo test --no-run (ux_guard_test)..." -ForegroundColor Yellow
     cargo test --test ux_guard_test --no-run
     if ($LASTEXITCODE -ne 0) { throw "cargo test --no-run (ux_guard_test) failed" }
+
+    Write-Host "`n[BUILD] cargo test --no-run (harness_wpf_test)..." -ForegroundColor Yellow
+    cargo test --test harness_wpf_test --no-run
+    if ($LASTEXITCODE -ne 0) { throw "cargo test --no-run (harness_wpf_test) failed" }
+
+    Write-Host "`n[BUILD] cargo test --no-run (harness_winui3_test)..." -ForegroundColor Yellow
+    cargo test --test harness_winui3_test --no-run
+    if ($LASTEXITCODE -ne 0) { throw "cargo test --no-run (harness_winui3_test) failed" }
 } finally { Pop-Location }
+
+# ── 1.5. Build the .NET test-harness if dotnet is on PATH ────────────────────
+# The harness produces test-apps/harness-{wpf,winui3}/ which the sandbox
+# runner picks up via the existing mapped-folder route. Skip silently if
+# dotnet isn't available — the smoke tests degrade to "skipped" inside
+# the sandbox rather than failing the whole run.
+if (Get-Command dotnet -ErrorAction SilentlyContinue) {
+    $harnessBuild = Join-Path $wsRoot "..\test-harness\build.ps1"
+    if (Test-Path $harnessBuild) {
+        Write-Host "`n[BUILD] test-harness (dotnet publish)..." -ForegroundColor Yellow
+        & $harnessBuild
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "[WARN] test-harness build failed — harness tests will skip." -ForegroundColor Yellow
+        }
+    } else {
+        Write-Host "`n[SKIP] test-harness/build.ps1 not found — harness tests will skip." -ForegroundColor Yellow
+    }
+} else {
+    Write-Host "`n[SKIP] dotnet CLI not on PATH — test-harness build skipped, harness tests will degrade." -ForegroundColor Yellow
+}
 
 $mcpBin = Get-ChildItem "$wsRoot\target\debug\deps\mcp_protocol_test-*.exe" |
           Sort-Object LastWriteTime -Descending | Select-Object -First 1

--- a/libs/cua-driver/rust/sandbox/sandbox-runner.ps1
+++ b/libs/cua-driver/rust/sandbox/sandbox-runner.ps1
@@ -62,8 +62,16 @@ foreach ($h in $harnessRoots) {
     }
     $dst = Join-Path $env:TEMP (Split-Path $h.Src -Leaf)
     Copy-Item $h.Src $dst -Recurse -Force
-    Set-Item "Env:$($h.EnvVar)" (Join-Path $dst $h.Exe)
-    Log "$($h.Exe) staged to $dst (env $($h.EnvVar))"
+    # Confirm the publish output actually contains the exe before exporting
+    # the env var — a partial publish would otherwise turn an expected skip
+    # into a hard launch failure inside the Rust test.
+    $stagedExe = Join-Path $dst $h.Exe
+    if (-not (Test-Path $stagedExe)) {
+        Log "WARNING: staged harness exe missing at $stagedExe — $($h.EnvVar) tests will skip"
+        continue
+    }
+    Set-Item "Env:$($h.EnvVar)" $stagedExe
+    Log "$($h.Exe) staged to $dst (env $($h.EnvVar)=$stagedExe)"
 }
 
 # ── optional test filter ────────────────────────────────────────────────────

--- a/libs/cua-driver/rust/sandbox/sandbox-runner.ps1
+++ b/libs/cua-driver/rust/sandbox/sandbox-runner.ps1
@@ -44,9 +44,27 @@ Log "cua-driver   : $driverExe"
 # Run mcp_protocol_test first, then ux_guard_test (UX guard needs a real
 # desktop session and spawns visible windows, so it runs second).
 $testSuites = @(
-    @{ Pattern = "mcp_protocol_test-*.exe"; Label = "mcp_protocol_test" },
-    @{ Pattern = "ux_guard_test-*.exe";      Label = "ux_guard_test" }
+    @{ Pattern = "mcp_protocol_test-*.exe";    Label = "mcp_protocol_test" },
+    @{ Pattern = "ux_guard_test-*.exe";        Label = "ux_guard_test" },
+    @{ Pattern = "harness_wpf_test-*.exe";     Label = "harness_wpf_test";     Extra = @("--ignored") },
+    @{ Pattern = "harness_winui3_test-*.exe";  Label = "harness_winui3_test";  Extra = @("--ignored") }
 )
+
+# ── stage harness binaries to %TEMP% (same Zone-3 ShellExecute workaround) ──
+$harnessRoots = @(
+    @{ Src = "C:\cua-driver-rs\test-apps\harness-wpf";     EnvVar = "HARNESS_WPF_EXE";    Exe = "CuaTestHarness.Wpf.exe" },
+    @{ Src = "C:\cua-driver-rs\test-apps\harness-winui3";  EnvVar = "HARNESS_WINUI3_EXE"; Exe = "CuaTestHarness.WinUI3.exe" }
+)
+foreach ($h in $harnessRoots) {
+    if (-not (Test-Path $h.Src)) {
+        Log "harness $($h.Exe) not built — $($h.EnvVar) tests will skip"
+        continue
+    }
+    $dst = Join-Path $env:TEMP (Split-Path $h.Src -Leaf)
+    Copy-Item $h.Src $dst -Recurse -Force
+    Set-Item "Env:$($h.EnvVar)" (Join-Path $dst $h.Exe)
+    Log "$($h.Exe) staged to $dst (env $($h.EnvVar))"
+}
 
 # ── optional test filter ────────────────────────────────────────────────────
 $filterSuite = ""
@@ -77,6 +95,9 @@ foreach ($suite in $testSuites) {
     Log "Running $label : $($testBin.FullName)"
 
     $testArgs = @("--test-threads=1", "--nocapture")
+    if ($suite.ContainsKey("Extra") -and $suite.Extra) {
+        $testArgs += $suite.Extra
+    }
     $stderrFile = "C:\sandbox-output\$label-stderr.txt"
 
     "`n=== $label ===`n" | Add-Content $outputFile -Encoding utf8

--- a/libs/cua-driver/rust/test-apps/.gitignore
+++ b/libs/cua-driver/rust/test-apps/.gitignore
@@ -6,3 +6,10 @@
 *.zip
 *.AppImage
 *.deb
+
+# Locally-built .NET test harness output (see ../../test-harness/build.ps1).
+# These dirs are produced by `dotnet publish -o ...` and contain the
+# CuaTestHarness.{Wpf,WinUI3} binaries + their self-contained runtime
+# (several thousand files, ~150 MB). Always rebuilt locally.
+harness-wpf/
+harness-winui3/

--- a/libs/cua-driver/test-harness/.gitignore
+++ b/libs/cua-driver/test-harness/.gitignore
@@ -1,0 +1,5 @@
+# .NET build artifacts — recreated by `build.ps1` / `dotnet publish`.
+bin/
+obj/
+*.user
+.vs/

--- a/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/App.xaml
+++ b/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/App.xaml
@@ -1,0 +1,12 @@
+<Application
+    x:Class="CuaTestHarness.WinUI3.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/App.xaml.cs
+++ b/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/App.xaml.cs
@@ -1,0 +1,16 @@
+using Microsoft.UI.Xaml;
+
+namespace CuaTestHarness.WinUI3;
+
+public partial class App : Application
+{
+    private Window? _window;
+
+    public App() { InitializeComponent(); }
+
+    protected override void OnLaunched(LaunchActivatedEventArgs args)
+    {
+        _window = new MainWindow();
+        _window.Activate();
+    }
+}

--- a/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/CuaTestHarness.WinUI3.csproj
+++ b/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/CuaTestHarness.WinUI3.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <RootNamespace>CuaTestHarness.WinUI3</RootNamespace>
+    <AssemblyName>CuaTestHarness.WinUI3</AssemblyName>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <Platforms>x64</Platforms>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+    <PublishProfile>win-x64</PublishProfile>
+    <UseWinUI>true</UseWinUI>
+    <EnableMsixTooling>true</EnableMsixTooling>
+    <WindowsPackageType>None</WindowsPackageType>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <SelfContained>true</SelfContained>
+    <!-- Suppress App.g.i.cs's auto-generated Main so our hand-rolled
+         Program.cs (which calls WindowsAppSDK Bootstrap before
+         Application.Start) is the sole entry point. Required for
+         unpackaged WinUI3 hosts. -->
+    <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_MAIN</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <Manifest Include="$(ApplicationManifest)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\scenarios\scenarios.json" Link="scenarios.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/MainWindow.xaml
+++ b/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/MainWindow.xaml
@@ -1,0 +1,88 @@
+<Window
+    x:Class="CuaTestHarness.WinUI3.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:auto="using:Microsoft.UI.Xaml.Automation"
+    Title="CuaTestHarness WinUI3">
+
+    <Grid Padding="16" RowSpacing="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Counter -->
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="8">
+            <Button x:Name="BtnIncrement"
+                    auto:AutomationProperties.AutomationId="btn-increment"
+                    Content="Increment" Width="100"
+                    Click="OnIncrementClick"/>
+            <Button x:Name="BtnReset"
+                    auto:AutomationProperties.AutomationId="btn-reset"
+                    Content="Reset" Width="80"
+                    Click="OnResetClick"/>
+            <TextBlock x:Name="LblCounter"
+                       auto:AutomationProperties.AutomationId="lbl-counter"
+                       VerticalAlignment="Center"
+                       FontFamily="Consolas" FontSize="14"
+                       Text="counter=0"/>
+        </StackPanel>
+
+        <!-- Text body -->
+        <TextBlock Grid.Row="1"
+                   auto:AutomationProperties.AutomationId="txt-body"
+                   FontFamily="Consolas" TextWrapping="Wrap"
+                   Text="HARNESS_TEXT_MARKER_v1 — WinUI3 text body for get_window_state."/>
+
+        <!-- CommandBarFlyout trigger -->
+        <Button Grid.Row="2"
+                x:Name="BtnOpenFlyout"
+                auto:AutomationProperties.AutomationId="btn-open-flyout"
+                Content="Open CommandBarFlyout"
+                Width="220" HorizontalAlignment="Left"
+                Click="OnOpenFlyoutClick">
+            <Button.Flyout>
+                <CommandBarFlyout x:Name="CmdFlyout">
+                    <AppBarButton Icon="Copy"  Label="Copy"
+                                  auto:AutomationProperties.AutomationId="flyout-copy"/>
+                    <AppBarButton Icon="Paste" Label="Paste"
+                                  auto:AutomationProperties.AutomationId="flyout-paste"/>
+                </CommandBarFlyout>
+            </Button.Flyout>
+        </Button>
+
+        <!-- XAML Popup trigger -->
+        <Button Grid.Row="3"
+                x:Name="BtnOpenPopup"
+                auto:AutomationProperties.AutomationId="btn-open-popup"
+                Content="Open XAML Popup"
+                Width="220" HorizontalAlignment="Left"
+                Click="OnOpenPopupClick"/>
+
+        <Popup x:Name="PopXaml" Grid.Row="4"
+               HorizontalOffset="40" VerticalOffset="40">
+            <Border Background="#202020" Padding="16" CornerRadius="6"
+                    BorderBrush="#FFFFFF" BorderThickness="1">
+                <StackPanel Spacing="8">
+                    <TextBlock Foreground="White" FontWeight="Bold"
+                               Text="XAML Popup (same HWND)"/>
+                    <TextBlock Foreground="White"
+                               auto:AutomationProperties.AutomationId="txt-popup-body"
+                               Text="XAML_POPUP_MARKER_v1 — Popup is NOT a separate HWND; it lives inside the main window."/>
+                    <Button Content="Close" Width="80" Click="OnClosePopupClick"/>
+                </StackPanel>
+            </Border>
+        </Popup>
+
+        <!-- Exit -->
+        <Button Grid.Row="5"
+                x:Name="BtnExit"
+                auto:AutomationProperties.AutomationId="btn-exit"
+                Content="Exit" Width="80" HorizontalAlignment="Right"
+                Click="OnExitClick"/>
+    </Grid>
+</Window>

--- a/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/MainWindow.xaml
+++ b/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/MainWindow.xaml
@@ -11,6 +11,8 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -38,8 +40,20 @@
                    FontFamily="Consolas" TextWrapping="Wrap"
                    Text="HARNESS_TEXT_MARKER_v1 — WinUI3 text body for get_window_state."/>
 
+        <!-- TextBox + mirror -->
+        <StackPanel Grid.Row="2" Orientation="Vertical" Spacing="4">
+            <TextBox x:Name="TxtInput"
+                     auto:AutomationProperties.AutomationId="txt-input"
+                     Width="300" HorizontalAlignment="Left"
+                     TextChanged="OnInputChanged"/>
+            <TextBlock x:Name="LblInputMirror"
+                       auto:AutomationProperties.AutomationId="lbl-input-mirror"
+                       FontFamily="Consolas"
+                       Text="mirror="/>
+        </StackPanel>
+
         <!-- CommandBarFlyout trigger -->
-        <Button Grid.Row="2"
+        <Button Grid.Row="3"
                 x:Name="BtnOpenFlyout"
                 auto:AutomationProperties.AutomationId="btn-open-flyout"
                 Content="Open CommandBarFlyout"
@@ -56,14 +70,14 @@
         </Button>
 
         <!-- XAML Popup trigger -->
-        <Button Grid.Row="3"
+        <Button Grid.Row="4"
                 x:Name="BtnOpenPopup"
                 auto:AutomationProperties.AutomationId="btn-open-popup"
                 Content="Open XAML Popup"
                 Width="220" HorizontalAlignment="Left"
                 Click="OnOpenPopupClick"/>
 
-        <Popup x:Name="PopXaml" Grid.Row="4"
+        <Popup x:Name="PopXaml" Grid.Row="5"
                HorizontalOffset="40" VerticalOffset="40">
             <Border Background="#202020" Padding="16" CornerRadius="6"
                     BorderBrush="#FFFFFF" BorderThickness="1">
@@ -79,7 +93,7 @@
         </Popup>
 
         <!-- Exit -->
-        <Button Grid.Row="5"
+        <Button Grid.Row="7"
                 x:Name="BtnExit"
                 auto:AutomationProperties.AutomationId="btn-exit"
                 Content="Exit" Width="80" HorizontalAlignment="Right"

--- a/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/MainWindow.xaml.cs
+++ b/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/MainWindow.xaml.cs
@@ -47,4 +47,9 @@ public sealed partial class MainWindow : Window
         Close();
         System.Environment.Exit(0);
     }
+
+    private void OnInputChanged(object sender, TextChangedEventArgs e)
+    {
+        LblInputMirror.Text = $"mirror={TxtInput.Text}";
+    }
 }

--- a/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/MainWindow.xaml.cs
+++ b/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/MainWindow.xaml.cs
@@ -44,8 +44,11 @@ public sealed partial class MainWindow : Window
 
     private void OnExitClick(object sender, RoutedEventArgs e)
     {
-        Close();
-        System.Environment.Exit(0);
+        // Application.Current.Exit() runs the WinUI/WindowsAppSDK
+        // shutdown path so Program.Main's finally block (which calls
+        // Bootstrap.Shutdown) actually executes. Environment.Exit(0)
+        // terminates the process immediately and skips that cleanup.
+        Application.Current.Exit();
     }
 
     private void OnInputChanged(object sender, TextChangedEventArgs e)

--- a/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/MainWindow.xaml.cs
+++ b/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/MainWindow.xaml.cs
@@ -1,0 +1,50 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace CuaTestHarness.WinUI3;
+
+public sealed partial class MainWindow : Window
+{
+    private int _counter;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+        Title = "CuaTestHarness WinUI3";
+    }
+
+    private void OnIncrementClick(object sender, RoutedEventArgs e)
+    {
+        _counter++;
+        LblCounter.Text = $"counter={_counter}";
+    }
+
+    private void OnResetClick(object sender, RoutedEventArgs e)
+    {
+        _counter = 0;
+        LblCounter.Text = "counter=0";
+    }
+
+    private void OnOpenFlyoutClick(object sender, RoutedEventArgs e)
+    {
+        // Button.Flyout is wired declaratively — XAML auto-opens on click. This
+        // handler intentionally left empty so the flyout's default behavior
+        // (open, raise UIA Window-opened event) drives the test.
+    }
+
+    private void OnOpenPopupClick(object sender, RoutedEventArgs e)
+    {
+        PopXaml.IsOpen = true;
+    }
+
+    private void OnClosePopupClick(object sender, RoutedEventArgs e)
+    {
+        PopXaml.IsOpen = false;
+    }
+
+    private void OnExitClick(object sender, RoutedEventArgs e)
+    {
+        Close();
+        System.Environment.Exit(0);
+    }
+}

--- a/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/Program.cs
+++ b/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/Program.cs
@@ -11,8 +11,20 @@ public static class Program
     [STAThread]
     public static int Main(string[] args)
     {
-        // Bootstrap the WindowsAppSDK for unpackaged scenarios.
-        Bootstrap.TryInitialize(0x00010006, out _);
+        // Try to bootstrap the system-wide WindowsAppSDK runtime.
+        // We publish self-contained (<WindowsAppSDKSelfContained>true</...>),
+        // so TryInitialize returns false on systems without the user-mode
+        // bootstrap installed — that's expected and the app still runs
+        // from its local copy of the SDK DLLs. Only call Shutdown() if
+        // Init actually succeeded — pairing the calls keeps the
+        // bootstrapper's internal refcount consistent.
+        var initialized = Bootstrap.TryInitialize(0x00010006, out var hresult);
+        if (!initialized)
+        {
+            Console.Error.WriteLine(
+                $"WindowsAppSDK bootstrap not initialized (0x{hresult:X8}); " +
+                "continuing with self-contained runtime.");
+        }
         try
         {
             ComWrappersSupport.InitializeComWrappers();
@@ -26,7 +38,10 @@ public static class Program
         }
         finally
         {
-            Bootstrap.Shutdown();
+            if (initialized)
+            {
+                Bootstrap.Shutdown();
+            }
         }
     }
 }

--- a/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/Program.cs
+++ b/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/Program.cs
@@ -1,0 +1,32 @@
+using System;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.Windows.ApplicationModel.DynamicDependency;
+using WinRT;
+
+namespace CuaTestHarness.WinUI3;
+
+public static class Program
+{
+    [STAThread]
+    public static int Main(string[] args)
+    {
+        // Bootstrap the WindowsAppSDK for unpackaged scenarios.
+        Bootstrap.TryInitialize(0x00010006, out _);
+        try
+        {
+            ComWrappersSupport.InitializeComWrappers();
+            Application.Start(p =>
+            {
+                var context = new DispatcherQueueSynchronizationContext(DispatcherQueue.GetForCurrentThread());
+                System.Threading.SynchronizationContext.SetSynchronizationContext(context);
+                _ = new App();
+            });
+            return 0;
+        }
+        finally
+        {
+            Bootstrap.Shutdown();
+        }
+    }
+}

--- a/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/app.manifest
+++ b/libs/cua-driver/test-harness/CuaTestHarness.WinUI3/app.manifest
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="CuaTestHarness.WinUI3"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">permonitorv2</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/libs/cua-driver/test-harness/CuaTestHarness.Wpf/App.xaml
+++ b/libs/cua-driver/test-harness/CuaTestHarness.Wpf/App.xaml
@@ -1,0 +1,6 @@
+<Application x:Class="CuaTestHarness.Wpf.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources/>
+</Application>

--- a/libs/cua-driver/test-harness/CuaTestHarness.Wpf/App.xaml.cs
+++ b/libs/cua-driver/test-harness/CuaTestHarness.Wpf/App.xaml.cs
@@ -1,0 +1,7 @@
+using System.Windows;
+
+namespace CuaTestHarness.Wpf;
+
+public partial class App : Application
+{
+}

--- a/libs/cua-driver/test-harness/CuaTestHarness.Wpf/CuaTestHarness.Wpf.csproj
+++ b/libs/cua-driver/test-harness/CuaTestHarness.Wpf/CuaTestHarness.Wpf.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <AssemblyName>CuaTestHarness.Wpf</AssemblyName>
+    <RootNamespace>CuaTestHarness.Wpf</RootNamespace>
+    <PublishSingleFile>false</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <Platforms>x64</Platforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\scenarios\scenarios.json" Link="scenarios.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+
+</Project>

--- a/libs/cua-driver/test-harness/CuaTestHarness.Wpf/LayeredPopupWindow.xaml
+++ b/libs/cua-driver/test-harness/CuaTestHarness.Wpf/LayeredPopupWindow.xaml
@@ -1,0 +1,23 @@
+<Window x:Class="CuaTestHarness.Wpf.LayeredPopupWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Harness Layered Popup"
+        Width="380" Height="180"
+        AllowsTransparency="True"
+        WindowStyle="None"
+        Background="#80303030"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False">
+    <Border BorderBrush="#FFFFFF" BorderThickness="2" CornerRadius="8" Padding="16">
+        <StackPanel>
+            <TextBlock Foreground="White" FontWeight="Bold" FontSize="16"
+                       Text="Layered transparent popup"/>
+            <TextBlock Foreground="White" Margin="0,8,0,0" TextWrapping="Wrap"
+                       AutomationProperties.AutomationId="txt-layered-body"
+                       Text="LAYERED_POPUP_MARKER_v1 — WS_EX_LAYERED is implied by AllowsTransparency=True. PrintWindow may capture this as opaque-only black without WGC fallback."/>
+            <Button Width="80" HorizontalAlignment="Right" Margin="0,12,0,0"
+                    AutomationProperties.AutomationId="btn-layered-close"
+                    Content="Close" Click="OnCloseClick"/>
+        </StackPanel>
+    </Border>
+</Window>

--- a/libs/cua-driver/test-harness/CuaTestHarness.Wpf/LayeredPopupWindow.xaml.cs
+++ b/libs/cua-driver/test-harness/CuaTestHarness.Wpf/LayeredPopupWindow.xaml.cs
@@ -1,0 +1,9 @@
+using System.Windows;
+
+namespace CuaTestHarness.Wpf;
+
+public partial class LayeredPopupWindow : Window
+{
+    public LayeredPopupWindow() { InitializeComponent(); }
+    private void OnCloseClick(object sender, RoutedEventArgs e) => Close();
+}

--- a/libs/cua-driver/test-harness/CuaTestHarness.Wpf/MainWindow.xaml
+++ b/libs/cua-driver/test-harness/CuaTestHarness.Wpf/MainWindow.xaml
@@ -8,6 +8,13 @@
         Width="900" Height="700"
         WindowStartupLocation="CenterScreen">
     <Window.InputBindings>
+        <!-- F5 (no modifiers) — chosen for automated testing. WPF's
+             Keyboard.Modifiers is sourced from GetKeyState() which is
+             never updated by PostMessage(WM_KEYDOWN, VK_CONTROL); so a
+             modifier-bearing binding ("Ctrl+Shift+H") doesn't fire on
+             the cua-driver PostMessage hotkey path. Use F5 here. -->
+        <KeyBinding Key="F5" Command="{x:Static local:MainWindow.AccelCmd}"
+                    xmlns:local="clr-namespace:CuaTestHarness.Wpf"/>
         <KeyBinding Modifiers="Control+Shift" Key="H" Command="{x:Static local:MainWindow.AccelCmd}"
                     xmlns:local="clr-namespace:CuaTestHarness.Wpf"/>
     </Window.InputBindings>
@@ -35,6 +42,43 @@
 
         <ScrollViewer VerticalScrollBarVisibility="Auto">
             <StackPanel Margin="16">
+
+                <!-- TextBox + mirror (placed at top so the cached center
+                     stays within the visible window for PostMessage clicks
+                     even when the main ScrollViewer hasn't been scrolled). -->
+                <GroupBox Header="text_input" Padding="10" Margin="0,0,0,12">
+                    <StackPanel>
+                        <TextBox x:Name="TxtInput"
+                                 AutomationProperties.AutomationId="txt-input"
+                                 Width="300" HorizontalAlignment="Left"
+                                 TextChanged="OnInputChanged"/>
+                        <TextBlock x:Name="LblInputMirror"
+                                   AutomationProperties.AutomationId="lbl-input-mirror"
+                                   Margin="0,6,0,0" FontFamily="Consolas"
+                                   Text="mirror="/>
+                    </StackPanel>
+                </GroupBox>
+
+                <!-- Click target (Button) — also at top for visibility. -->
+                <GroupBox Header="click_target" Padding="10" Margin="0,0,0,12">
+                    <StackPanel>
+                        <Button x:Name="BtnClickTarget"
+                                AutomationProperties.AutomationId="border-click-target"
+                                Content="Click target (left / right / double)"
+                                Width="260" Height="40" HorizontalAlignment="Left"
+                                MouseLeftButtonDown="OnTargetLeftDown"
+                                MouseRightButtonDown="OnTargetRightDown"
+                                MouseDoubleClick="OnTargetDoubleClick"/>
+                        <TextBlock x:Name="LblLastAction"
+                                   AutomationProperties.AutomationId="lbl-last-action"
+                                   Margin="0,6,0,0" FontFamily="Consolas"
+                                   Text="last_action=none"/>
+                        <TextBlock x:Name="LblClickCount"
+                                   AutomationProperties.AutomationId="lbl-click-count"
+                                   FontFamily="Consolas"
+                                   Text="clicks=0"/>
+                    </StackPanel>
+                </GroupBox>
 
                 <!-- Counter scenario -->
                 <GroupBox Header="counter" Padding="10" Margin="0,0,0,12">
@@ -107,6 +151,38 @@ Multi-line. Deterministic. Used for OCR + AX value comparisons.
                                AutomationProperties.AutomationId="lbl-accel-count"
                                FontFamily="Consolas" FontSize="14"
                                Text="accel_fired=0"/>
+                </GroupBox>
+
+                <!-- Scroll-target with offset label -->
+                <GroupBox Header="scroll_target" Padding="10" Margin="0,0,0,12">
+                    <StackPanel>
+                        <TextBlock x:Name="LblScrollOffset"
+                                   AutomationProperties.AutomationId="lbl-scroll-offset"
+                                   FontFamily="Consolas"
+                                   Text="scroll_offset=0"/>
+                        <ScrollViewer x:Name="ScrollTall"
+                                      AutomationProperties.AutomationId="scroll-tall"
+                                      Height="120" Width="400" HorizontalAlignment="Left"
+                                      Margin="0,6,0,0"
+                                      VerticalScrollBarVisibility="Auto"
+                                      ScrollChanged="OnScrollChanged">
+                            <StackPanel>
+                                <TextBlock Text="SCROLL_TOP_MARKER_v1"/>
+                                <TextBlock Text="line 02"/><TextBlock Text="line 03"/>
+                                <TextBlock Text="line 04"/><TextBlock Text="line 05"/>
+                                <TextBlock Text="line 06"/><TextBlock Text="line 07"/>
+                                <TextBlock Text="line 08"/><TextBlock Text="line 09"/>
+                                <TextBlock Text="line 10"/><TextBlock Text="line 11"/>
+                                <TextBlock Text="line 12"/><TextBlock Text="line 13"/>
+                                <TextBlock Text="line 14"/><TextBlock Text="line 15"/>
+                                <TextBlock Text="line 16"/><TextBlock Text="line 17"/>
+                                <TextBlock Text="line 18"/><TextBlock Text="line 19"/>
+                                <TextBlock Text="line 20"/><TextBlock Text="line 21"/>
+                                <TextBlock Text="line 22"/><TextBlock Text="line 23"/>
+                                <TextBlock Text="SCROLL_BOTTOM_MARKER_v1"/>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </StackPanel>
                 </GroupBox>
 
             </StackPanel>

--- a/libs/cua-driver/test-harness/CuaTestHarness.Wpf/MainWindow.xaml
+++ b/libs/cua-driver/test-harness/CuaTestHarness.Wpf/MainWindow.xaml
@@ -1,0 +1,115 @@
+<Window x:Class="CuaTestHarness.Wpf.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:sys="clr-namespace:System;assembly=mscorlib"
+        xmlns:auto="clr-namespace:System.Windows.Automation;assembly=PresentationCore"
+        Title="CuaTestHarness WPF"
+        AutomationProperties.AutomationId="wnd-main"
+        Width="900" Height="700"
+        WindowStartupLocation="CenterScreen">
+    <Window.InputBindings>
+        <KeyBinding Modifiers="Control+Shift" Key="H" Command="{x:Static local:MainWindow.AccelCmd}"
+                    xmlns:local="clr-namespace:CuaTestHarness.Wpf"/>
+    </Window.InputBindings>
+
+    <DockPanel LastChildFill="True">
+        <!-- Bottom Save/Cancel strip mirrors the LO Document Recovery layout
+             that previously caused our GetClientRect capture to clip. -->
+        <Border DockPanel.Dock="Bottom" Background="#F0F0F0" BorderBrush="#D0D0D0"
+                BorderThickness="0,1,0,0" Padding="10,8">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button x:Name="BtnSave"
+                        AutomationProperties.AutomationId="btn-save"
+                        Content="Save" Width="90" Margin="4,0"
+                        Click="OnSaveClick"/>
+                <Button x:Name="BtnCancel"
+                        AutomationProperties.AutomationId="btn-cancel"
+                        Content="Cancel" Width="90" Margin="4,0"
+                        Click="OnCancelClick"/>
+                <Button x:Name="BtnExit"
+                        AutomationProperties.AutomationId="btn-exit"
+                        Content="Exit" Width="90" Margin="4,0"
+                        Click="OnExitClick"/>
+            </StackPanel>
+        </Border>
+
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <StackPanel Margin="16">
+
+                <!-- Counter scenario -->
+                <GroupBox Header="counter" Padding="10" Margin="0,0,0,12">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <Button x:Name="BtnIncrement"
+                                AutomationProperties.AutomationId="btn-increment"
+                                Content="Increment" Width="100"
+                                Click="OnIncrementClick"/>
+                        <Button x:Name="BtnReset"
+                                AutomationProperties.AutomationId="btn-reset"
+                                Content="Reset" Width="80" Margin="8,0,0,0"
+                                Click="OnResetClick"/>
+                        <TextBlock x:Name="LblCounter"
+                                   AutomationProperties.AutomationId="lbl-counter"
+                                   Margin="20,0,0,0" VerticalAlignment="Center"
+                                   FontFamily="Consolas" FontSize="14"
+                                   Text="counter=0"/>
+                    </StackPanel>
+                </GroupBox>
+
+                <!-- Static text body -->
+                <GroupBox Header="text_body" Padding="10" Margin="0,0,0,12">
+                    <TextBlock x:Name="TxtBody"
+                               AutomationProperties.AutomationId="txt-body"
+                               TextWrapping="Wrap" FontFamily="Consolas">
+HARNESS_TEXT_MARKER_v1
+The agent should be able to read this block via get_window_state.
+Multi-line. Deterministic. Used for OCR + AX value comparisons.
+                    </TextBlock>
+                </GroupBox>
+
+                <!-- MessageBox modal -->
+                <GroupBox Header="message_box" Padding="10" Margin="0,0,0,12">
+                    <Button x:Name="BtnOpenMsgBox"
+                            AutomationProperties.AutomationId="btn-open-msgbox"
+                            Content="Open MessageBox" Width="160" HorizontalAlignment="Left"
+                            Click="OnOpenMessageBoxClick"/>
+                </GroupBox>
+
+                <!-- Owned popup -->
+                <GroupBox Header="owned_popup" Padding="10" Margin="0,0,0,12">
+                    <Button x:Name="BtnOpenOwned"
+                            AutomationProperties.AutomationId="btn-open-owned"
+                            Content="Open Owned Window" Width="180" HorizontalAlignment="Left"
+                            Click="OnOpenOwnedClick"/>
+                </GroupBox>
+
+                <!-- Layered transparent popup -->
+                <GroupBox Header="layered_popup" Padding="10" Margin="0,0,0,12">
+                    <Button x:Name="BtnOpenLayered"
+                            AutomationProperties.AutomationId="btn-open-layered"
+                            Content="Open Layered Popup" Width="180" HorizontalAlignment="Left"
+                            Click="OnOpenLayeredClick"/>
+                </GroupBox>
+
+                <!-- Native Win32 child HWND host -->
+                <GroupBox Header="child_hwnd" Padding="10" Margin="0,0,0,12">
+                    <StackPanel>
+                        <TextBlock Text="Native Win32 BUTTON hosted via HwndHost:" Margin="0,0,0,6"/>
+                        <Border Width="220" Height="40" HorizontalAlignment="Left"
+                                BorderBrush="#888" BorderThickness="1">
+                            <ContentControl x:Name="HwndHostSlot"/>
+                        </Border>
+                    </StackPanel>
+                </GroupBox>
+
+                <!-- Keyboard accelerator -->
+                <GroupBox Header="accelerator (Ctrl+Shift+H)" Padding="10" Margin="0,0,0,12">
+                    <TextBlock x:Name="LblAccelCount"
+                               AutomationProperties.AutomationId="lbl-accel-count"
+                               FontFamily="Consolas" FontSize="14"
+                               Text="accel_fired=0"/>
+                </GroupBox>
+
+            </StackPanel>
+        </ScrollViewer>
+    </DockPanel>
+</Window>

--- a/libs/cua-driver/test-harness/CuaTestHarness.Wpf/MainWindow.xaml.cs
+++ b/libs/cua-driver/test-harness/CuaTestHarness.Wpf/MainWindow.xaml.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Automation;
+using System.Windows.Input;
+using System.Windows.Interop;
+
+namespace CuaTestHarness.Wpf;
+
+public partial class MainWindow : Window
+{
+    public static readonly RoutedUICommand AccelCmd =
+        new("Accel", "AccelCmd", typeof(MainWindow));
+
+    private int _counter;
+    private int _accelCount;
+    private readonly ScenariosManifest _manifest;
+
+    public MainWindow()
+    {
+        _manifest = ScenariosManifest.Load();
+        InitializeComponent();
+
+        Title = _manifest.Wpf.MainWindow.Title;
+        AutomationProperties.SetAutomationId(this, _manifest.Wpf.MainWindow.AutomationId);
+
+        CommandBindings.Add(new CommandBinding(AccelCmd, (s, e) =>
+        {
+            _accelCount++;
+            LblAccelCount.Text = $"accel_fired={_accelCount}";
+        }));
+
+        Loaded += OnLoaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        HwndHostSlot.Content = new NativeButtonHost("Native Win32 Child");
+    }
+
+    private void OnIncrementClick(object sender, RoutedEventArgs e)
+    {
+        _counter++;
+        LblCounter.Text = $"counter={_counter}";
+    }
+
+    private void OnResetClick(object sender, RoutedEventArgs e)
+    {
+        _counter = 0;
+        LblCounter.Text = "counter=0";
+    }
+
+    private void OnOpenMessageBoxClick(object sender, RoutedEventArgs e)
+    {
+        var title = _manifest.Get("message_box").ExpectedDialogTitle ?? "Harness MessageBox";
+        MessageBox.Show(this,
+            "Harness modal dialog. Click OK or Cancel.",
+            title,
+            MessageBoxButton.OKCancel,
+            MessageBoxImage.Information);
+    }
+
+    private void OnOpenOwnedClick(object sender, RoutedEventArgs e)
+    {
+        var owned = new OwnedPopupWindow
+        {
+            Owner = this,
+            Title = _manifest.Ctrl("owned_popup", "owned_window_title"),
+        };
+        AutomationProperties.SetAutomationId(owned, _manifest.Ctrl("owned_popup", "owned_window_aid"));
+        owned.Show();
+    }
+
+    private void OnOpenLayeredClick(object sender, RoutedEventArgs e)
+    {
+        var layered = new LayeredPopupWindow
+        {
+            Owner = this,
+            Title = _manifest.Ctrl("layered_popup", "layered_window_title"),
+        };
+        layered.Show();
+    }
+
+    private void OnSaveClick(object sender, RoutedEventArgs e)
+    {
+        // Intentionally a no-op except for logging — the test asserts on
+        // the post-click UIA tree (button stays present, focus didn't shift).
+        Title = $"{_manifest.Wpf.MainWindow.Title} [last_action=save]";
+    }
+
+    private void OnCancelClick(object sender, RoutedEventArgs e)
+    {
+        Title = $"{_manifest.Wpf.MainWindow.Title} [last_action=cancel]";
+    }
+
+    private void OnExitClick(object sender, RoutedEventArgs e)
+    {
+        Application.Current.Shutdown(0);
+    }
+}

--- a/libs/cua-driver/test-harness/CuaTestHarness.Wpf/MainWindow.xaml.cs
+++ b/libs/cua-driver/test-harness/CuaTestHarness.Wpf/MainWindow.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Automation;
+using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Interop;
 
@@ -14,6 +15,7 @@ public partial class MainWindow : Window
 
     private int _counter;
     private int _accelCount;
+    private int _clickCount;
     private readonly ScenariosManifest _manifest;
 
     public MainWindow()
@@ -36,6 +38,44 @@ public partial class MainWindow : Window
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
         HwndHostSlot.Content = new NativeButtonHost("Native Win32 Child");
+
+        // Hook WM_VSCROLL on the main HWND and route it into ScrollTall.
+        // WPF's input system is purely routed-event based; it does not
+        // translate WM_VSCROLL into a ScrollViewer scroll. cua-driver's
+        // `scroll` tool delivers SB_LINEDOWN/SB_PAGEDOWN via
+        // PostMessage(WM_VSCROLL), so without this hook the scroll never
+        // takes effect on a WPF host. The hook lets us assert the
+        // PostMessage actually arrived and was actionable.
+        var source = HwndSource.FromHwnd(new WindowInteropHelper(this).Handle);
+        source?.AddHook(OnWindowMessage);
+    }
+
+    private const int WM_VSCROLL    = 0x0115;
+    private const int SB_LINEUP     = 0;
+    private const int SB_LINEDOWN   = 1;
+    private const int SB_PAGEUP     = 2;
+    private const int SB_PAGEDOWN   = 3;
+
+    private IntPtr OnWindowMessage(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+    {
+        if (msg != WM_VSCROLL || ScrollTall == null) return IntPtr.Zero;
+        int code = (int)((long)wParam & 0xFFFF);
+        const double LINE = 16.0;  // ~one TextBlock line
+        const double PAGE = 96.0;  // ScrollTall.Height
+        double delta = code switch
+        {
+            SB_LINEDOWN => LINE,
+            SB_LINEUP   => -LINE,
+            SB_PAGEDOWN => PAGE,
+            SB_PAGEUP   => -PAGE,
+            _ => 0
+        };
+        if (delta != 0)
+        {
+            ScrollTall.ScrollToVerticalOffset(ScrollTall.VerticalOffset + delta);
+            handled = true;
+        }
+        return IntPtr.Zero;
     }
 
     private void OnIncrementClick(object sender, RoutedEventArgs e)
@@ -96,5 +136,47 @@ public partial class MainWindow : Window
     private void OnExitClick(object sender, RoutedEventArgs e)
     {
         Application.Current.Shutdown(0);
+    }
+
+    private void OnInputChanged(object sender, TextChangedEventArgs e)
+    {
+        LblInputMirror.Text = $"mirror={TxtInput.Text}";
+    }
+
+    private void OnTargetLeftDown(object sender, MouseButtonEventArgs e)
+    {
+        _clickCount++;
+        if (e.ClickCount >= 2)
+        {
+            LblLastAction.Text = "last_action=double_click";
+        }
+        else
+        {
+            LblLastAction.Text = "last_action=left_click";
+        }
+        LblClickCount.Text = $"clicks={_clickCount}";
+        // Don't mark handled — let the Button's own logic still run.
+    }
+
+    private void OnTargetDoubleClick(object sender, MouseButtonEventArgs e)
+    {
+        // Belt + suspenders: Button raises MouseDoubleClick separately from
+        // the second MouseLeftButtonDown. Capturing both means even
+        // back-end implementations that fire only one path still register.
+        LblLastAction.Text = "last_action=double_click";
+        LblClickCount.Text = $"clicks={_clickCount}";
+    }
+
+    private void OnTargetRightDown(object sender, MouseButtonEventArgs e)
+    {
+        LblLastAction.Text = "last_action=right_click";
+    }
+
+    private void OnScrollChanged(object sender, ScrollChangedEventArgs e)
+    {
+        if (sender is ScrollViewer sv)
+        {
+            LblScrollOffset.Text = $"scroll_offset={(int)sv.VerticalOffset}";
+        }
     }
 }

--- a/libs/cua-driver/test-harness/CuaTestHarness.Wpf/NativeButtonHost.cs
+++ b/libs/cua-driver/test-harness/CuaTestHarness.Wpf/NativeButtonHost.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Windows.Interop;
+
+namespace CuaTestHarness.Wpf;
+
+internal sealed class NativeButtonHost : HwndHost
+{
+    private const int WS_CHILD     = 0x40000000;
+    private const int WS_VISIBLE   = 0x10000000;
+    private const int WS_TABSTOP   = 0x00010000;
+    private const int BS_DEFPUSHBUTTON = 0x00000001;
+
+    private readonly string _text;
+    private IntPtr _hwnd;
+
+    public NativeButtonHost(string text) { _text = text; }
+
+    protected override HandleRef BuildWindowCore(HandleRef hwndParent)
+    {
+        _hwnd = CreateWindowEx(
+            0,
+            "BUTTON",
+            _text,
+            WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_DEFPUSHBUTTON,
+            0, 0, 200, 32,
+            hwndParent.Handle,
+            IntPtr.Zero,
+            GetModuleHandle(null),
+            IntPtr.Zero);
+        if (_hwnd == IntPtr.Zero)
+            throw new InvalidOperationException("CreateWindowEx(BUTTON) failed");
+        return new HandleRef(this, _hwnd);
+    }
+
+    protected override void DestroyWindowCore(HandleRef hwnd)
+    {
+        DestroyWindow(hwnd.Handle);
+        _hwnd = IntPtr.Zero;
+    }
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr CreateWindowEx(
+        int dwExStyle,
+        string lpClassName,
+        string lpWindowName,
+        int dwStyle,
+        int x, int y, int nWidth, int nHeight,
+        IntPtr hWndParent,
+        IntPtr hMenu,
+        IntPtr hInstance,
+        IntPtr lpParam);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool DestroyWindow(IntPtr hWnd);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+    private static extern IntPtr GetModuleHandle(string? lpModuleName);
+}

--- a/libs/cua-driver/test-harness/CuaTestHarness.Wpf/OwnedPopupWindow.xaml
+++ b/libs/cua-driver/test-harness/CuaTestHarness.Wpf/OwnedPopupWindow.xaml
@@ -1,0 +1,22 @@
+<Window x:Class="CuaTestHarness.Wpf.OwnedPopupWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Harness Owned Popup"
+        Width="400" Height="220"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <TextBlock Grid.Row="0" FontWeight="Bold" Text="Owned popup"/>
+        <TextBlock Grid.Row="1" Margin="0,8" TextWrapping="Wrap"
+                   AutomationProperties.AutomationId="txt-owned-body"
+                   Text="OWNED_POPUP_MARKER_v1 — this window has its Owner set to MainWindow, so window enumeration must follow the ownership link."/>
+        <Button Grid.Row="2" HorizontalAlignment="Right" Width="80"
+                AutomationProperties.AutomationId="btn-owned-close"
+                Content="Close" Click="OnCloseClick"/>
+    </Grid>
+</Window>

--- a/libs/cua-driver/test-harness/CuaTestHarness.Wpf/OwnedPopupWindow.xaml.cs
+++ b/libs/cua-driver/test-harness/CuaTestHarness.Wpf/OwnedPopupWindow.xaml.cs
@@ -1,0 +1,9 @@
+using System.Windows;
+
+namespace CuaTestHarness.Wpf;
+
+public partial class OwnedPopupWindow : Window
+{
+    public OwnedPopupWindow() { InitializeComponent(); }
+    private void OnCloseClick(object sender, RoutedEventArgs e) => Close();
+}

--- a/libs/cua-driver/test-harness/CuaTestHarness.Wpf/Scenarios.cs
+++ b/libs/cua-driver/test-harness/CuaTestHarness.Wpf/Scenarios.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace CuaTestHarness.Wpf;
+
+public sealed class ScenariosManifest
+{
+    [JsonPropertyName("version")] public int Version { get; set; }
+    [JsonPropertyName("wpf")] public PlatformBlock Wpf { get; set; } = new();
+
+    public static ScenariosManifest Load()
+    {
+        string path = Path.Combine(AppContext.BaseDirectory, "scenarios.json");
+        string json = File.ReadAllText(path);
+        var manifest = JsonSerializer.Deserialize<ScenariosManifest>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+        }) ?? throw new InvalidOperationException("scenarios.json failed to parse");
+        return manifest;
+    }
+
+    public ScenarioBlock Get(string id)
+    {
+        foreach (var s in Wpf.Scenarios)
+        {
+            if (string.Equals(s.Id, id, StringComparison.OrdinalIgnoreCase)) return s;
+        }
+        throw new KeyNotFoundException($"scenario '{id}' not found in scenarios.json");
+    }
+
+    public string Ctrl(string scenarioId, string controlKey)
+    {
+        var s = Get(scenarioId);
+        if (s.Controls.TryGetValue(controlKey, out var v)) return v;
+        throw new KeyNotFoundException($"control '{controlKey}' not found under scenario '{scenarioId}'");
+    }
+}
+
+public sealed class PlatformBlock
+{
+    [JsonPropertyName("process_name")] public string ProcessName { get; set; } = "";
+    [JsonPropertyName("main_window")]  public MainWindowBlock MainWindow { get; set; } = new();
+    [JsonPropertyName("scenarios")]    public List<ScenarioBlock> Scenarios { get; set; } = new();
+}
+
+public sealed class MainWindowBlock
+{
+    [JsonPropertyName("title")]         public string Title { get; set; } = "";
+    [JsonPropertyName("automation_id")] public string AutomationId { get; set; } = "";
+}
+
+public sealed class ScenarioBlock
+{
+    [JsonPropertyName("id")]                    public string Id { get; set; } = "";
+    [JsonPropertyName("kind")]                  public string Kind { get; set; } = "";
+    [JsonPropertyName("description")]           public string Description { get; set; } = "";
+    [JsonPropertyName("controls")]              public Dictionary<string, string> Controls { get; set; } = new();
+    [JsonPropertyName("expected_text_marker")]  public string? ExpectedTextMarker { get; set; }
+    [JsonPropertyName("expected_dialog_title")] public string? ExpectedDialogTitle { get; set; }
+    [JsonPropertyName("expected_chord")]        public string? ExpectedChord { get; set; }
+}

--- a/libs/cua-driver/test-harness/CuaTestHarness.Wpf/app.manifest
+++ b/libs/cua-driver/test-harness/CuaTestHarness.Wpf/app.manifest
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="CuaTestHarness.Wpf"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">permonitorv2</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/libs/cua-driver/test-harness/CuaTestHarness.sln
+++ b/libs/cua-driver/test-harness/CuaTestHarness.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CuaTestHarness.Wpf", "CuaTestHarness.Wpf\CuaTestHarness.Wpf.csproj", "{A1B2C3D4-E5F6-4789-ABCD-EF0123456789}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CuaTestHarness.WinUI3", "CuaTestHarness.WinUI3\CuaTestHarness.WinUI3.csproj", "{B2C3D4E5-F6A7-489B-CDEF-012345678901}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1B2C3D4-E5F6-4789-ABCD-EF0123456789}.Debug|x64.ActiveCfg = Debug|x64
+		{A1B2C3D4-E5F6-4789-ABCD-EF0123456789}.Debug|x64.Build.0 = Debug|x64
+		{A1B2C3D4-E5F6-4789-ABCD-EF0123456789}.Release|x64.ActiveCfg = Release|x64
+		{A1B2C3D4-E5F6-4789-ABCD-EF0123456789}.Release|x64.Build.0 = Release|x64
+		{B2C3D4E5-F6A7-489B-CDEF-012345678901}.Debug|x64.ActiveCfg = Debug|x64
+		{B2C3D4E5-F6A7-489B-CDEF-012345678901}.Debug|x64.Build.0 = Debug|x64
+		{B2C3D4E5-F6A7-489B-CDEF-012345678901}.Release|x64.ActiveCfg = Release|x64
+		{B2C3D4E5-F6A7-489B-CDEF-012345678901}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+EndGlobal

--- a/libs/cua-driver/test-harness/README.md
+++ b/libs/cua-driver/test-harness/README.md
@@ -2,22 +2,50 @@
 
 Two minimal .NET 8 host apps (WPF + WinUI3 unpackaged) that present a
 deterministic set of UI scenarios for `cua-driver` to drive. They cover
-the Windows hosting patterns that matter for background automation:
+the Windows hosting patterns that matter for background automation.
 
+## What's exercised
+
+WPF scenarios (`CuaTestHarness.Wpf`):
 - Plain XAML controls + AutomationIds (`counter`, `text_body`)
+- TextBox + mirrored label (`text_input` — drives `type_text` and `set_value`)
+- Right/double-click target (`click_target` — drives `right_click` /
+  `double_click` via `MouseRightButtonDown` / `MouseDoubleClick`)
+- Scroll body with VerticalOffset label + WM_VSCROLL hook (`scroll_target`)
 - Modal `MessageBox` (`message_box`)
 - Save/Cancel bottom strip — the layout that previously clipped under
   `GetClientRect` (`bottom_strip` — regression guard for PR #1696)
 - Native Win32 child HWNDs via `HwndHost` (`child_hwnd`)
 - Owned secondary `Window` (`owned_popup`)
 - Layered transparent window (`layered_popup`)
-- Keyboard accelerators (`accelerator`)
-- `CommandBarFlyout` (`command_bar_flyout`, WinUI3 only)
-- XAML `Popup` (`xaml_popup`, WinUI3 only) — in-window, not a separate HWND
+- Keyboard accelerators — F5 (no modifier) + Ctrl+Shift+H (`accelerator`)
+
+WinUI3 scenarios (`CuaTestHarness.WinUI3`):
+- `counter` / `text_body` / `exit` (parity with WPF)
+- TextBox + mirror (`text_input` — drives `type_text` via UIA `ValuePattern`)
+- `CommandBarFlyout` — popup in same HWND, DComp-rendered
+- XAML `Popup` — primitive, not a separate HWND
 
 `scenarios/scenarios.json` is the single source of truth — both the C#
 host apps and the Rust integration tests read it so AutomationIds /
 window titles never drift between the two halves.
+
+## Coverage matrix (Rust integration tests)
+
+| Capability                       | WPF             | WinUI3          |
+|----------------------------------|-----------------|-----------------|
+| Smoke (UIA tree + AutomationIds) | ✅              | ✅              |
+| UIA Invoke click                 | ✅              | (implicit)      |
+| `right_click` (PostMessage/SendInput) | ✅         | —               |
+| `double_click`                   | ✅              | —               |
+| `type_text` (PostMessage WM_CHAR / UIA ValuePattern) | ✅ | ✅           |
+| `set_value` (UIA ValuePattern)   | ✅              | (covered)       |
+| `scroll` (WM_VSCROLL via hook)   | ✅              | —               |
+| `press_key` accelerator (F5)     | ✅              | —               |
+| Modal `MessageBox` open + parse + dismiss | ✅     | —               |
+| Owned popup open + parse         | ✅              | —               |
+| Layered popup capture (non-black assertion) | ✅   | —               |
+| XAML Popup open + parse          | —               | ✅              |
 
 ## Layout
 

--- a/libs/cua-driver/test-harness/README.md
+++ b/libs/cua-driver/test-harness/README.md
@@ -49,7 +49,7 @@ window titles never drift between the two halves.
 
 ## Layout
 
-```
+```text
 test-harness/
 ├── CuaTestHarness.sln
 ├── build.ps1                         # publishes both projects

--- a/libs/cua-driver/test-harness/README.md
+++ b/libs/cua-driver/test-harness/README.md
@@ -1,0 +1,68 @@
+# cua-driver Windows test harness
+
+Two minimal .NET 8 host apps (WPF + WinUI3 unpackaged) that present a
+deterministic set of UI scenarios for `cua-driver` to drive. They cover
+the Windows hosting patterns that matter for background automation:
+
+- Plain XAML controls + AutomationIds (`counter`, `text_body`)
+- Modal `MessageBox` (`message_box`)
+- Save/Cancel bottom strip — the layout that previously clipped under
+  `GetClientRect` (`bottom_strip` — regression guard for PR #1696)
+- Native Win32 child HWNDs via `HwndHost` (`child_hwnd`)
+- Owned secondary `Window` (`owned_popup`)
+- Layered transparent window (`layered_popup`)
+- Keyboard accelerators (`accelerator`)
+- `CommandBarFlyout` (`command_bar_flyout`, WinUI3 only)
+- XAML `Popup` (`xaml_popup`, WinUI3 only) — in-window, not a separate HWND
+
+`scenarios/scenarios.json` is the single source of truth — both the C#
+host apps and the Rust integration tests read it so AutomationIds /
+window titles never drift between the two halves.
+
+## Layout
+
+```
+test-harness/
+├── CuaTestHarness.sln
+├── build.ps1                         # publishes both projects
+├── scenarios/scenarios.json          # shared SoT
+├── CuaTestHarness.Wpf/               # .NET 8, WPF, x64
+└── CuaTestHarness.WinUI3/            # .NET 8, WinUI3 unpackaged, x64
+```
+
+Publish output is staged into `../rust/test-apps/harness-{wpf,winui3}/`
+so the existing sandbox runner picks them up via its mapped-folder route
+(same path convention as `desktop-test-app-electron`).
+
+## Build
+
+Requires the **.NET 8 SDK** on `PATH`:
+```powershell
+winget install Microsoft.DotNet.SDK.8
+```
+
+Then:
+```powershell
+cd libs\cua-driver\test-harness
+.\build.ps1                 # both projects
+.\build.ps1 -Skip winui3    # WPF only (fast path for local iteration)
+```
+
+## Run the tests
+
+Locally:
+```powershell
+cd libs\cua-driver\rust
+cargo test --test harness_wpf_test     -- --ignored --nocapture
+cargo test --test harness_winui3_test  -- --ignored --nocapture
+```
+
+In Windows Sandbox (matches CI):
+```powershell
+.\rust\sandbox\run-tests-in-sandbox.ps1 harness_wpf
+.\rust\sandbox\run-tests-in-sandbox.ps1 harness_winui3
+```
+
+The sandbox runner auto-detects `dotnet` on the host and rebuilds the
+harness before launching. If `dotnet` isn't installed the harness tests
+silently skip (the rest of the suite still runs).

--- a/libs/cua-driver/test-harness/build.ps1
+++ b/libs/cua-driver/test-harness/build.ps1
@@ -1,0 +1,68 @@
+# build.ps1 - publish the cua-driver test harness binaries.
+#
+# Outputs land in libs/cua-driver/rust/test-apps/harness-{wpf,winui3}/ so
+# the existing sandbox runner picks them up via its mapped folder.
+#
+# Usage:
+#   .\build.ps1            # build both
+#   .\build.ps1 -Skip wpf  # build only WinUI3
+#   .\build.ps1 -Skip winui3
+#
+# Requires: .NET 8 SDK on PATH.
+
+param(
+    [ValidateSet("none","wpf","winui3")]
+    [string]$Skip = "none"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$harnessDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$cuaDriverDir = Split-Path -Parent $harnessDir
+$testAppsDir = Join-Path $cuaDriverDir "rust\test-apps"
+
+if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+    Write-Host "[ERROR] dotnet CLI not found on PATH. Install .NET 8 SDK first." -ForegroundColor Red
+    exit 1
+}
+
+New-Item -ItemType Directory -Force $testAppsDir | Out-Null
+
+function Publish-Project {
+    param([string]$ProjPath, [string]$OutDirName)
+    $outDir = Join-Path $testAppsDir $OutDirName
+    Write-Host ""
+    Write-Host "[BUILD] $ProjPath -> $outDir" -ForegroundColor Cyan
+    # Self-contained so the published exe runs in the Windows Sandbox without
+    # requiring a separate .NET runtime install. The harness is small (~30MB
+    # per project after framework-dependent stripping), so the size cost is
+    # acceptable for the deterministic-test gain.
+    $publishArgs = @(
+        "publish", $ProjPath,
+        "-c", "Release",
+        "-r", "win-x64",
+        "--self-contained", "true",
+        "-o", $outDir,
+        "-p:PublishSingleFile=false",
+        "-p:DebugType=embedded"
+    )
+    & dotnet @publishArgs
+    if ($LASTEXITCODE -ne 0) { throw "dotnet publish failed for $ProjPath" }
+    Write-Host "[OK]    Published: $outDir" -ForegroundColor Green
+}
+
+if ($Skip -ne "wpf") {
+    Publish-Project (Join-Path $harnessDir "CuaTestHarness.Wpf\CuaTestHarness.Wpf.csproj") "harness-wpf"
+}
+if ($Skip -ne "winui3") {
+    $winuiProj = Join-Path $harnessDir "CuaTestHarness.WinUI3\CuaTestHarness.WinUI3.csproj"
+    if (Test-Path $winuiProj) {
+        Publish-Project $winuiProj "harness-winui3"
+    } else {
+        Write-Host "[SKIP] WinUI3 project not present yet - skipping." -ForegroundColor Yellow
+    }
+}
+
+Write-Host ""
+Write-Host "[DONE] Test harness build complete." -ForegroundColor Green

--- a/libs/cua-driver/test-harness/scenarios/scenarios.json
+++ b/libs/cua-driver/test-harness/scenarios/scenarios.json
@@ -84,6 +84,35 @@
         "expected_chord": "ctrl+shift+h"
       },
       {
+        "id": "text_input",
+        "kind": "text_box_mirror",
+        "description": "TextBox whose content is mirrored to a label. Tests type_text via AXSetAttribute / SendKeys to a backgrounded input.",
+        "controls": {
+          "textbox_aid": "txt-input",
+          "mirror_label_aid": "lbl-input-mirror"
+        }
+      },
+      {
+        "id": "click_target",
+        "kind": "right_double_click",
+        "description": "Target Border that records left-click count, double-click, and right-click via separate labels. Tests right_click and double_click tools.",
+        "controls": {
+          "target_aid": "border-click-target",
+          "last_action_label_aid": "lbl-last-action",
+          "click_count_label_aid": "lbl-click-count"
+        }
+      },
+      {
+        "id": "scroll_target",
+        "kind": "scroll_viewer",
+        "description": "ScrollViewer with a tall body and a label that reflects VerticalOffset. Tests scroll tool delivery to a backgrounded window.",
+        "controls": {
+          "scroller_aid": "scroll-tall",
+          "offset_label_aid": "lbl-scroll-offset",
+          "bottom_marker_text": "SCROLL_BOTTOM_MARKER_v1"
+        }
+      },
+      {
         "id": "exit",
         "kind": "exit_button",
         "description": "Exit button for clean teardown.",
@@ -118,6 +147,14 @@
           "text_block_aid": "txt-body"
         },
         "expected_text_marker": "HARNESS_TEXT_MARKER_v1"
+      },
+      {
+        "id": "text_input",
+        "kind": "text_box_mirror",
+        "controls": {
+          "textbox_aid": "txt-input",
+          "mirror_label_aid": "lbl-input-mirror"
+        }
       },
       {
         "id": "command_bar_flyout",

--- a/libs/cua-driver/test-harness/scenarios/scenarios.json
+++ b/libs/cua-driver/test-harness/scenarios/scenarios.json
@@ -1,0 +1,150 @@
+{
+  "version": 1,
+  "description": "Single source of truth for the cua-driver Windows test harness. Consumed by both the C# host apps (at startup, to set window titles / AutomationIds) and by Rust integration tests (to assert expected tree shape without hardcoding strings).",
+  "wpf": {
+    "process_name": "CuaTestHarness.Wpf",
+    "exe_relative_path": "test-apps/harness-wpf/CuaTestHarness.Wpf.exe",
+    "main_window": {
+      "title": "CuaTestHarness WPF",
+      "automation_id": "wnd-main",
+      "expected_class_prefix": "HwndWrapper"
+    },
+    "scenarios": [
+      {
+        "id": "counter",
+        "kind": "click_counter",
+        "description": "Plain button increments a counter. Tests UIA Invoke pattern + label refresh.",
+        "controls": {
+          "increment_button_aid": "btn-increment",
+          "counter_label_aid": "lbl-counter",
+          "reset_button_aid": "btn-reset"
+        }
+      },
+      {
+        "id": "text_body",
+        "kind": "static_text",
+        "description": "Multi-line TextBlock with a known content hash. Tests get_window_state text extraction and screenshot OCR-ability.",
+        "controls": {
+          "text_block_aid": "txt-body"
+        },
+        "expected_text_marker": "HARNESS_TEXT_MARKER_v1"
+      },
+      {
+        "id": "message_box",
+        "kind": "modal_messagebox",
+        "description": "MessageBox.Show with OK/Cancel. Tests modal-dialog detection and popup-window enumeration.",
+        "controls": {
+          "open_button_aid": "btn-open-msgbox"
+        },
+        "expected_dialog_title": "Harness MessageBox"
+      },
+      {
+        "id": "bottom_strip",
+        "kind": "save_cancel_strip",
+        "description": "Bottom button strip (Save/Cancel) mimicking LO Document Recovery. Tests GetWindowRect-vs-GetClientRect capture boundary (previously cropped the strip).",
+        "controls": {
+          "save_button_aid": "btn-save",
+          "cancel_button_aid": "btn-cancel"
+        }
+      },
+      {
+        "id": "child_hwnd",
+        "kind": "native_win32_child",
+        "description": "Native Win32 child HWND (CreateWindowEx BUTTON) hosted inside the WPF window via HwndHost. Tests UIA descent into non-WPF child HWNDs.",
+        "controls": {
+          "child_button_text": "Native Win32 Child"
+        }
+      },
+      {
+        "id": "owned_popup",
+        "kind": "owned_popup",
+        "description": "Owned secondary Window (Owner set). Tests window enumeration follows ownership chain and capture targets the right HWND.",
+        "controls": {
+          "open_button_aid": "btn-open-owned",
+          "owned_window_title": "Harness Owned Popup",
+          "owned_window_aid": "wnd-owned"
+        }
+      },
+      {
+        "id": "layered_popup",
+        "kind": "layered_transparent",
+        "description": "WS_EX_LAYERED window with alpha. Tests PrintWindow against layered windows (some surfaces render black without WGC fallback).",
+        "controls": {
+          "open_button_aid": "btn-open-layered",
+          "layered_window_title": "Harness Layered Popup"
+        }
+      },
+      {
+        "id": "accelerator",
+        "kind": "keyboard_accelerator",
+        "description": "Ctrl+Shift+H increments the counter via KeyBinding. Tests press_key / hotkey delivering to background windows.",
+        "controls": {
+          "label_aid": "lbl-accel-count"
+        },
+        "expected_chord": "ctrl+shift+h"
+      },
+      {
+        "id": "exit",
+        "kind": "exit_button",
+        "description": "Exit button for clean teardown.",
+        "controls": {
+          "exit_button_aid": "btn-exit"
+        }
+      }
+    ]
+  },
+  "winui3": {
+    "process_name": "CuaTestHarness.WinUI3",
+    "exe_relative_path": "test-apps/harness-winui3/CuaTestHarness.WinUI3.exe",
+    "main_window": {
+      "title": "CuaTestHarness WinUI3",
+      "automation_id": "wnd-main",
+      "expected_class_prefix": "WinUIDesktopWin32WindowClass"
+    },
+    "scenarios": [
+      {
+        "id": "counter",
+        "kind": "click_counter",
+        "controls": {
+          "increment_button_aid": "btn-increment",
+          "counter_label_aid": "lbl-counter",
+          "reset_button_aid": "btn-reset"
+        }
+      },
+      {
+        "id": "text_body",
+        "kind": "static_text",
+        "controls": {
+          "text_block_aid": "txt-body"
+        },
+        "expected_text_marker": "HARNESS_TEXT_MARKER_v1"
+      },
+      {
+        "id": "command_bar_flyout",
+        "kind": "command_bar_flyout",
+        "description": "CommandBarFlyout (popup with command items). Tests flyout enumeration on WinUI3 with DirectComposition rendering.",
+        "controls": {
+          "trigger_button_aid": "btn-open-flyout",
+          "copy_item_aid": "flyout-copy",
+          "paste_item_aid": "flyout-paste"
+        }
+      },
+      {
+        "id": "xaml_popup",
+        "kind": "xaml_popup",
+        "description": "Popup (XAML primitive, NOT a separate HWND). Tests UIA descent into XAML popup hosted in the same window.",
+        "controls": {
+          "open_button_aid": "btn-open-popup",
+          "popup_text_aid": "txt-popup-body"
+        }
+      },
+      {
+        "id": "exit",
+        "kind": "exit_button",
+        "controls": {
+          "exit_button_aid": "btn-exit"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pair of minimal **.NET 8** host apps (WPF + WinUI3 unpackaged) under `libs/cua-driver/test-harness/` that present a deterministic set of Windows UI scenarios for cua-driver to drive, plus Rust integration tests that exercise them.

The harness gives us a stable target for regression guards on Windows hosting patterns — the kinds of bugs PR #1696 (GetClientRect/GetWindowRect crop) and #1697 (DWM-extended-frame inset) were each shipped to a real user before catching, because there was no in-repo reproducer.

## What's in

```
libs/cua-driver/test-harness/
├── CuaTestHarness.sln
├── README.md
├── build.ps1                       # dotnet publish -> ../rust/test-apps/
├── scenarios/scenarios.json        # single source of truth (AutomationIds, titles, markers)
├── CuaTestHarness.Wpf/             # .NET 8 WPF, self-contained, x64
└── CuaTestHarness.WinUI3/          # .NET 8 WinUI3 unpackaged, x64

libs/cua-driver/rust/crates/cua-driver/tests/
├── harness_wpf_test.rs             # #[ignore]'d smoke + counter Invoke roundtrip
└── harness_winui3_test.rs          # #[ignore]'d smoke
```

Scenarios covered (WPF):
- `counter` — UIA Invoke on a plain Button advances a label
- `text_body` — known marker `HARNESS_TEXT_MARKER_v1` for OCR / AX value comparisons
- `message_box` — modal MessageBox.Show enumeration
- `bottom_strip` — Save/Cancel layout that previously clipped (regression guard for #1696)
- `child_hwnd` — native Win32 BUTTON via HwndHost (UIA descent into non-WPF child HWND)
- `owned_popup` — owned secondary Window (ownership-chain enumeration)
- `layered_popup` — WS_EX_LAYERED transparent window (PrintWindow / WGC fallback)
- `accelerator` — Ctrl+Shift+H KeyBinding (background hotkey delivery)
- `exit` — clean teardown button

Scenarios covered (WinUI3 unpackaged):
- `counter` / `text_body` / `exit` — parity with WPF
- `command_bar_flyout` — popup hosted in same HWND, DComp-rendered
- `xaml_popup` — XAML Popup primitive (not a separate HWND)

`scenarios/scenarios.json` is the single source of truth — both the C# host apps and the Rust tests read it, so AutomationIds and window titles never drift between the two halves of the test.

## Sandbox wiring

`rust/sandbox/run-tests-in-sandbox.ps1` auto-detects `dotnet` on the host and runs `test-harness/build.ps1` before launching the sandbox. If `dotnet` isn't installed, the harness tests skip cleanly while the rest of the suite still runs.

`rust/sandbox/sandbox-runner.ps1` stages the published harness binaries to `%TEMP%` inside the sandbox (same ShellExecute Zone-3 workaround used for the Electron test app) and runs both harness suites with `--ignored`.

## Test plan

- [x] **Local Win11 host**, both harnesses build clean and launch
- [x] `cargo test --test harness_wpf_test    -- --ignored --nocapture` -> 2 passed
- [x] `cargo test --test harness_winui3_test -- --ignored --nocapture` -> 1 passed
- [x] Combined run with `--test-threads=1` -> 3 passed; 0 failed
- [ ] Sandbox run — pending merge; .NET 8 SDK install in the sandbox image is the only remaining unknown

## Build prerequisites

- .NET 8 SDK on host (`dotnet --list-sdks` must report `8.0.x`)
- Local install option: `winget install Microsoft.DotNet.SDK.8`, or the official user-scope script (no UAC): `iwr https://dot.net/v1/dotnet-install.ps1 -OutFile install.ps1; ./install.ps1 -Channel 8.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WPF and WinUI3 test applications for Windows UI automation testing with configurable scenarios including counter controls, text extraction, popups, and keyboard accelerators.
  * Added integration tests for both test applications to validate UI automation capture and interaction.
  * Added scenario configuration system to define expected UI elements and test targets across platforms.

* **Chores**
  * Updated build and test execution scripts to support new harness applications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->