### PR TITLE
fix(cua-driver): filter daemon overlay from window-change events + guard type_text against stale focus

### DIFF
--- a/libs/cua-driver/swift/Sources/CuaDriverServer/Tools/TypeTextTool.swift
+++ b/libs/cua-driver/swift/Sources/CuaDriverServer/Tools/TypeTextTool.swift
@@ -158,6 +158,34 @@ public enum TypeTextTool {
                 } else {
                     do {
                         let element = try AXInput.focusedElement(pid: pid)
+
+                        // Guard against stale focus on non-text containers.
+                        // In modal sheet contexts (e.g. macOS Open dialog with
+                        // a "Go to Folder" sheet), AX focus tracking can lag —
+                        // the previous focused element (sidebar AXOutline,
+                        // AXTable, AXList) retains focus status even after the
+                        // sheet appears. Writing to these containers silently
+                        // succeeds but inserts nothing useful.
+                        // See: https://github.com/trycua/cua/issues/1592 (Bug 3)
+                        let focusedRole = AXInput.describe(element).role ?? ""
+                        let nonTextRoles: Set<String> = [
+                            "AXOutline", "AXTable", "AXList",
+                            "AXBrowser", "AXScrollArea", "AXSplitGroup",
+                        ]
+                        if nonTextRoles.contains(focusedRole) {
+                            return CallTool.Result(
+                                content: [.text(
+                                    text: "⚠️ Focused element is \(focusedRole) — not a text input. "
+                                        + "AX focus may be stale (e.g. a modal sheet appeared after "
+                                        + "the last interaction). Use element_index targeting: call "
+                                        + "get_window_state to find the text field's index, then "
+                                        + "pass element_index to type_text.",
+                                    annotations: nil, _meta: nil
+                                )],
+                                isError: true
+                            )
+                        }
+
                         // Animate the cursor to the focused element before writing.
                         if let center = AXInput.screenCenter(of: element) {
                             await MainActor.run { AgentCursor.shared.pinAbove(pid: pid) }

--- a/libs/cua-driver/swift/Sources/CuaDriverServer/Tools/WindowChangeDetector.swift
+++ b/libs/cua-driver/swift/Sources/CuaDriverServer/Tools/WindowChangeDetector.swift
@@ -186,9 +186,14 @@ public enum WindowChangeDetector {
             var newEvents: [WindowEvent] = []
             if !newIds.isEmpty {
                 // Resolve app names / titles from the live window list.
+                // Filter out windows owned by the cua-driver daemon itself
+                // (e.g. AgentCursorOverlayWindow) so the overlay never
+                // appears as a "new window" side-effect in tool results.
+                // See: https://github.com/trycua/cua/issues/1592 (Bug 2)
+                let daemonPid = ProcessInfo.processInfo.processIdentifier
                 let allVisible = WindowEnumerator.visibleWindows().filter { $0.layer == 0 }
                 newEvents = allVisible
-                    .filter { newIds.contains($0.id) }
+                    .filter { newIds.contains($0.id) && $0.pid != daemonPid }
                     .map { WindowEvent(
                         windowId: $0.id,
                         pid: $0.pid,


### PR DESCRIPTION
Fixes Bug 2 and Bug 3 from #1592.

## Bug 2 — WindowChangeDetector reports own overlay as new window

Every click appended `🪟 Action opened new window(s): Cua Driver` because `detectChanges()` saw `AgentCursorOverlayWindow` as a newly-appeared window.

**Fix:** filter `newEvents` by `ProcessInfo.processInfo.processIdentifier` so windows owned by the daemon itself are never reported as side-effects.

## Bug 3 — type_text inserts into wrong AX element in modal sheet context

With a macOS Open dialog showing a 'Go to Folder' sheet, `type_text` inserted text into the sidebar `AXOutline` instead of the sheet's text field. AX focus tracking lags in sheet hierarchies.

**Fix:** after `focusedElement()`, check the role. If it is `AXOutline`, `AXTable`, `AXList`, `AXBrowser`, `AXScrollArea`, or `AXSplitGroup`, return an actionable error suggesting `element_index` targeting via `get_window_state`.

Fixes #1592 (Bug 2, Bug 3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text input validation to provide clearer error messages when attempting to type in non-text containers, guiding users to alternative targeting methods.
  * Fixed window detection to exclude internal application windows from change reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1700?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->