### PR TITLE
fix(lume): preserve raw ssh command output

### DIFF
--- a/libs/lume/src/Commands/SSH.swift
+++ b/libs/lume/src/Commands/SSH.swift
@@ -101,8 +101,8 @@ struct SSH: AsyncParsableCommand {
                 timeout: TimeInterval(timeout)
             )
 
-            if !result.output.isEmpty {
-                print(result.output)
+            if !result.outputData.isEmpty {
+                FileHandle.standardOutput.write(result.outputData)
             }
 
             if result.exitCode != 0 {
@@ -129,8 +129,8 @@ struct SSH: AsyncParsableCommand {
                 timeout: TimeInterval(timeout)
             )
 
-            if !result.output.isEmpty {
-                print(result.output)
+            if !result.outputData.isEmpty {
+                FileHandle.standardOutput.write(result.outputData)
             }
 
             if result.exitCode != 0 {

--- a/libs/lume/src/SSH/SSHClient.swift
+++ b/libs/lume/src/SSH/SSHClient.swift
@@ -7,11 +7,19 @@ import Foundation
 /// Result of an SSH command execution
 public struct SSHResult: Sendable {
     public let exitCode: Int32
+    public let outputData: Data
     public let output: String
 
     public init(exitCode: Int32, output: String) {
         self.exitCode = exitCode
+        self.outputData = Data(output.utf8)
         self.output = output
+    }
+
+    public init(exitCode: Int32, outputData: Data) {
+        self.exitCode = exitCode
+        self.outputData = outputData
+        self.output = String(decoding: outputData, as: UTF8.self)
     }
 }
 
@@ -310,13 +318,13 @@ private final class CommandExecHandler: ChannelDuplexHandler, @unchecked Sendabl
         // Complete when we have exit status (some servers close channel before sending exit status)
         if let status = exitStatus {
             resultPromise = nil
-            let output = outputBuffer.readString(length: outputBuffer.readableBytes) ?? ""
-            promise.succeed(SSHResult(exitCode: status, output: output))
+            let outputData = outputBuffer.readData(length: outputBuffer.readableBytes) ?? Data()
+            promise.succeed(SSHResult(exitCode: status, outputData: outputData))
         } else if channelClosed {
             // Channel closed without exit status - assume success with exit code 0
             resultPromise = nil
-            let output = outputBuffer.readString(length: outputBuffer.readableBytes) ?? ""
-            promise.succeed(SSHResult(exitCode: 0, output: output))
+            let outputData = outputBuffer.readData(length: outputBuffer.readableBytes) ?? Data()
+            promise.succeed(SSHResult(exitCode: 0, outputData: outputData))
         }
     }
 

--- a/libs/lume/src/SSH/SystemSSHClient.swift
+++ b/libs/lume/src/SSH/SystemSSHClient.swift
@@ -61,7 +61,6 @@ public final class SystemSSHClient: Sendable {
 
         let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
         let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-        let output = String(data: stdoutData, encoding: .utf8) ?? ""
         let errorOutput = String(data: stderrData, encoding: .utf8) ?? ""
 
         // Filter out SSH warnings from stderr (known_hosts, etc.)
@@ -73,11 +72,14 @@ public final class SystemSSHClient: Sendable {
             }
             .joined(separator: "\n")
 
-        let combinedOutput = filteredError.isEmpty ? output : output + filteredError
+        var outputData = stdoutData
+        if !filteredError.isEmpty, let errorData = filteredError.data(using: .utf8) {
+            outputData.append(errorData)
+        }
 
         return SSHResult(
             exitCode: process.terminationStatus,
-            output: combinedOutput
+            outputData: outputData
         )
     }
 

--- a/libs/lume/tests/SSHResultTests.swift
+++ b/libs/lume/tests/SSHResultTests.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Testing
+
+@testable import lume
+
+@Test("SSHResult preserves raw output bytes alongside text view")
+func testSSHResultPreservesRawOutputBytes() {
+    let bytes = Data([0x00, 0xff, 0x41, 0x80, 0x42])
+    let result = SSHResult(exitCode: 0, outputData: bytes)
+
+    #expect(result.outputData == bytes)
+    #expect(result.output.contains("A"))
+    #expect(result.output.contains("B"))
+}
+


### PR DESCRIPTION
## Summary

Fixes #1513 by preserving raw stdout bytes from `lume ssh <vm> <cmd>` instead of forcing SSH channel output through UTF-8 before writing it back to the host.

The previous path decoded stdout into `String` in both SSH backends, which corrupts binary streams such as `tar`, `gzip`, encrypted blobs, or random bytes. This keeps the existing text-facing `SSHResult.output` API for current callers, but adds `SSHResult.outputData` as the canonical raw byte payload and has the CLI write those bytes directly to stdout.

## Changes

- Add `SSHResult.outputData` while preserving `SSHResult.output` for text/MCP/clipboard callers.
- Have the NIO SSH command handler collect and return raw `Data` from `ByteBuffer`.
- Have the system SSH fallback keep `stdoutData` intact instead of decoding it as UTF-8.
- Write `lume ssh` command output with `FileHandle.standardOutput.write(...)` instead of `print(...)`.
- Add a small regression test that verifies `SSHResult` preserves invalid UTF-8 bytes.

## Verification

- `git diff --check`
- `swift build` from `libs/lume`

Note: `swift test --filter SSHResultTests` compiled the `lume` target but failed before running tests because this local Swift toolchain does not provide the existing repo-wide `Testing` module imported by current tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSH command results now preserve raw output data, improving support for binary and special character handling in command output.

* **Tests**
  * Added test to verify raw output bytes are correctly preserved in SSH results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->