### PR TITLE
chore(cua-driver-rs)(install): install-local.sh defaults to the Rust backend

### DIFF
--- a/libs/cua-driver/scripts/install-local.sh
+++ b/libs/cua-driver/scripts/install-local.sh
@@ -6,18 +6,28 @@
 # private helper based on host + flags.
 #
 # Helpers (private — do not invoke directly):
-#   _install-local-swift.sh   Builds CuaDriver.app from libs/cua-driver/swift
-#                             and installs to /Applications + ~/.local/bin
 #   _install-local-rust.sh    Builds cua-driver from libs/cua-driver/rust
 #                             and installs the cross-platform binary
+#   _install-local-swift.sh   Builds CuaDriver.app from libs/cua-driver/swift
+#                             and installs to /Applications + ~/.local/bin
 #
-# Defaults:
-#   macOS   → Swift backend (today's default; pass --backend=rust to override)
-#   non-mac → Rust backend (Swift is macOS-only; auto-selected)
+# Defaults (this script only — install.sh keeps the Swift default on macOS):
+#   all hosts → Rust backend
+#
+# Why the local installer defaults to Rust while the production install.sh
+# still gates it behind --experimental-rust: this script is for developers
+# working on the checked-out tree, where the Rust port is the active
+# development target across all three platforms (Windows / Linux / macOS)
+# and has the full integration-test surface attached (see
+# crates/cua-driver/tests/harness_*_test.rs). The production curl-pipe-bash
+# stays on Swift on macOS until the Rust port flips experimental → stable.
 #
 # Flags (forwarded verbatim to whichever helper runs):
-#   --experimental-rust    opt into the Rust port (same as --backend=rust)
-#   --backend=swift|rust   explicit backend selector
+#   --backend=swift|rust   explicit backend selector (defaults to rust here)
+#   --experimental-rust    legacy alias for --backend=rust; now a no-op
+#                          since rust is the default. Accepted for
+#                          backward compat with scripts/docs that still
+#                          pass it.
 #   --release              build the release configuration (default: debug)
 #   --daemon | --autostart pass through to the backend helper
 #   --bin-dir <path>       override the symlink destination (default ~/.local/bin)
@@ -31,9 +41,9 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 # --- Lightweight flag parsing (mirror install.sh) -----------------------
 # Two-pass shape: collect every unrecognised arg into FORWARDED_ARGS so the
 # selected backend helper sees the same argv shape as before the wrapper
-# existed. Recognised dispatch flags (--experimental-rust, --backend=*) are
-# consumed here and never forwarded.
-USE_RUST_BACKEND=0
+# existed. Recognised dispatch flags (--backend=*, --experimental-rust)
+# are consumed here and never forwarded.
+USE_SWIFT_BACKEND=0
 FORWARDED_ARGS=()
 PASSTHROUGH=0
 while [[ $# -gt 0 ]]; do
@@ -41,9 +51,9 @@ while [[ $# -gt 0 ]]; do
         FORWARDED_ARGS+=("$1"); shift; continue
     fi
     case "$1" in
-        --experimental-rust) USE_RUST_BACKEND=1; shift ;;
-        --backend=rust)      USE_RUST_BACKEND=1; shift ;;
-        --backend=swift)     shift ;;                 # explicit default — no-op
+        --backend=swift)     USE_SWIFT_BACKEND=1; shift ;;
+        --backend=rust)      shift ;;                 # explicit default — no-op
+        --experimental-rust) shift ;;                 # legacy alias for --backend=rust
         --backend=*)
             printf 'error: unknown backend %q; supported: swift, rust\n' "${1#*=}" >&2
             exit 2
@@ -53,17 +63,18 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Auto-select Rust on non-macOS — Swift has no install path off Darwin.
-if [[ "$USE_RUST_BACKEND" == "0" && "$(uname -s 2>/dev/null)" != "Darwin" ]]; then
-    USE_RUST_BACKEND=1
-    printf 'note: detected non-macOS host (%s); auto-selecting the cua-driver-rs Rust backend.\n' \
+# Hard-error on --backend=swift off-Darwin — there's no Swift install path
+# anywhere else and the helper would just bail with a confusing error.
+if [[ "$USE_SWIFT_BACKEND" == "1" && "$(uname -s 2>/dev/null)" != "Darwin" ]]; then
+    printf 'error: --backend=swift requested on non-macOS host (%s); Swift binary is macOS-only.\n' \
         "$(uname -s 2>/dev/null || echo unknown)" >&2
+    exit 2
 fi
 
-if [[ "$USE_RUST_BACKEND" == "1" ]]; then
-    HELPER="$SCRIPT_DIR/_install-local-rust.sh"
-else
+if [[ "$USE_SWIFT_BACKEND" == "1" ]]; then
     HELPER="$SCRIPT_DIR/_install-local-swift.sh"
+else
+    HELPER="$SCRIPT_DIR/_install-local-rust.sh"
 fi
 
 if [[ ! -f "$HELPER" ]]; then


### PR DESCRIPTION
## Summary

Flip the default backend in `libs/cua-driver/scripts/install-local.sh` from Swift to Rust on every host. The production curl-pipe-bash `install.sh` is **unchanged** — it still keeps the Swift default on macOS until cua-driver-rs flips from experimental to stable.

## Why

- `install-local.sh` is the **developer / checked-out-tree** installer. Its audience is people working on the Rust port (across Windows / Linux / macOS) who've been typing `--experimental-rust` or `--backend=rust` reflexively for weeks.
- The Rust port is the active dev target across all three platforms and now has the full integration-test surface attached (`crates/cua-driver/tests/harness_{appkit,swiftui,wpf,winui3,…}_test.rs`).
- Flipping this default cuts a flag from every checked-out-tree install and reduces the chance of "wait, why is this building Swift?" surprise.

## Flag semantics after this change

| Flag | Before | After |
|---|---|---|
| (none) | macOS → Swift, Linux → Rust auto | **Rust everywhere** |
| `--backend=swift` | no-op (was the default) | **explicit Swift opt-in** (hard-errors on non-Darwin) |
| `--backend=rust` | opt-in to Rust | no-op (matches default) |
| `--experimental-rust` | opt-in to Rust | **legacy alias**, no-op now. Accepted so any script/doc still passing it keeps working. |

## Behavior verification

```text
$ bash -x install-local.sh                          → _install-local-rust.sh
$ bash -x install-local.sh --backend=swift          → _install-local-swift.sh (macOS only)
$ bash -x install-local.sh --backend=swift (Linux)  → hard-error before helper exec
$ bash -x install-local.sh --experimental-rust      → _install-local-rust.sh (no-op alias)
```

`bash -n` clean.

## What this does NOT touch

- `install.sh` (production curl-pipe-bash) — Swift default on macOS stays
- `install.ps1` / `install-local.ps1` (Windows) — already Rust-only on Windows
- Either helper script (`_install-local-{rust,swift}.sh`) — unchanged
- Any caller that explicitly passes `--backend=swift` or `--backend=rust` — they keep doing what they asked

## Test plan
- [x] `bash -n libs/cua-driver/scripts/install-local.sh` clean
- [x] Verified dispatch via `bash -x` for the four argv shapes above
- [ ] Try a full `bash install-local.sh --release` on this Mac (builds the Rust release; ~1 min)
- [ ] Try the same on Linux to confirm nothing broke (auto-rust was already the existing Linux behavior, just no longer needs the special-case branch)
- [ ] CodeRabbit pass

## Rollback

Revert this commit. Single-file, 51-line diff. Anyone caught off-guard can pass `--backend=swift` to get the old behavior on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Installer now properly rejects unsupported backend configurations when requested on incompatible platforms.
  * Improved error handling with clear failure messages.

* **Documentation**
  * Clarified backend availability: Swift is macOS-only; Rust is the default backend.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->