### PR TITLE
fix(cua-driver-rs)(windows): bitmap-pixel click/drag coords + dispatch:background UIA hit-test docs

### DIFF
--- a/libs/cua-driver/rust/Skills/cua-driver/WINDOWS.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/WINDOWS.md
@@ -51,9 +51,29 @@ no-foreground:
 
 | `dispatch` | Behavior on Windows |
 |---|---|
-| `"background"` (DEFAULT) | PostMessage / UIA path only. If the target's input stack is known to silently drop PostMessage for this event kind (Chromium DOM mouse + key-combos, GTK button widgets), the call returns a structured `background_unavailable` error. **No foreground swap, ever.** |
-| `"foreground"` | SendInput with brief `SetForegroundWindow(target)` → restore. Required to drive Chromium DOM content or GTK button widgets reliably. Flashes the target visible unless `bring_to_front` was called first. |
+| `"background"` (DEFAULT) | **For pixel clicks**: cua-driver first does a UIA hit-test at the resolved screen position; if the deepest invokable element at that point exposes `InvokePattern`, it's invoked through the accessibility channel (same path as `element_index` mode — no foreground swap, no flash, works on UWP / WinUI3 / Win11 packaged apps). Only if the UIA hit-test misses does the PostMessage(WM_LBUTTONDOWN/UP) fallback run; if that's also known-to-drop for this event kind (Chromium DOM mouse + key-combos, GTK button widgets), the call returns a structured `background_unavailable` error. **No foreground swap, ever.** |
+| `"foreground"` | SendInput with brief `SetForegroundWindow(target)` → restore. Required to drive Chromium DOM content or GTK button widgets reliably, and the only path for canvas / video / custom-drawn surfaces that have no UIA peer to hit-test against. Flashes the target visible unless `bring_to_front` was called first. |
 | `"auto"` | Historical heuristic: silently falls back to SendInput on known-problematic targets. Opt-in for callers that prefer the old "things just work, sometimes at the cost of focus" behavior. |
+
+### Always try `dispatch:"background"` first
+
+The hit-test fallback above means **`dispatch:"background"` is the correct
+default even when the target is a XAML host whose input stack drops raw
+PostMessage** (UWP Calculator, Win11 Notepad, WinUI3 apps, etc.). cua-driver
+turns the pixel coord into a UIA Invoke at that point and delivers
+through the accessibility channel — no flash, no focus steal. Only
+escalate to `dispatch:"foreground"` when you actually see a
+`background_unavailable` structured error, and only with the
+`bring_to_front` flow described below so the agent pays the flash cost
+once instead of per-call.
+
+Empirical: pixel-clicks via `dispatch:"background"` against the UWP
+Calculator on Win11 (Number-pad buttons + operators) consistently
+resolve through `try_invoke_in_window_at_point` and produce
+`"✅ Performed UIA Invoke at (sx,sy) for pid X."` with zero visible
+flash. `dispatch:"foreground"` on the same coords also works but
+flashes the Calculator window foreground for ~40 ms — it's the
+costlier path; only use it for surfaces with no UIA peer.
 
 `background_unavailable` error shape:
 

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -21,6 +21,56 @@ fn pin_overlay_above(hwnd: u64) {
     crate::overlay::send_command(cursor_overlay::OverlayCommand::PinAbove(wid));
 }
 
+/// Convert (px, py) — "window-local screenshot pixels, top-left origin
+/// of the PNG returned by `get_window_state`" — to screen coordinates.
+///
+/// The capture path (`crate::capture::screenshot_window`) takes the
+/// PrintWindow buffer (sized to `GetWindowRect`) and crops it to
+/// `DWMWA_EXTENDED_FRAME_BOUNDS` with a 1-pixel inset on each side
+/// (`DWM_CROP_INSET_PX`). So the bitmap's top-left in screen coords is
+/// `(dwm_frame.left + 1, dwm_frame.top + 1)` — and CALLER coordinates
+/// `(px, py)` are offsets relative to that origin.
+///
+/// Pre-PR-#1697 the click / right_click / double_click / drag impls
+/// called `ClientToScreen(px, py)`, which interprets the offsets as
+/// CLIENT-area relative — so the screen click landed ~30 px BELOW the
+/// bitmap location the agent intended (the title-bar height got added).
+/// This helper aligns the screen mapping with what the screenshot
+/// actually shows.
+///
+/// Fallbacks: if the DWM call fails (very old Windows / shell-extension
+/// hook) we degrade to `GetWindowRect.top-left + (px, py)` — matches
+/// the capture fallback which also keeps the full PrintWindow bitmap
+/// without crop.
+fn bitmap_to_screen(hwnd: u64, px: i32, py: i32) -> (i32, i32) {
+    use windows::Win32::Foundation::{HWND, RECT};
+    use windows::Win32::Graphics::Dwm::{DwmGetWindowAttribute, DWMWA_EXTENDED_FRAME_BOUNDS};
+    use windows::Win32::UI::WindowsAndMessaging::GetWindowRect;
+
+    // Keep this constant in sync with `capture::DWM_CROP_INSET_PX`.
+    const DWM_CROP_INSET_PX: i32 = 1;
+    let h = HWND(hwnd as *mut _);
+    unsafe {
+        let mut dwm = RECT::default();
+        let hr = DwmGetWindowAttribute(
+            h,
+            DWMWA_EXTENDED_FRAME_BOUNDS,
+            &mut dwm as *mut _ as *mut _,
+            std::mem::size_of::<RECT>() as u32,
+        );
+        if hr.is_ok() {
+            return (dwm.left + DWM_CROP_INSET_PX + px,
+                    dwm.top  + DWM_CROP_INSET_PX + py);
+        }
+        // Fallback path — capture also keeps the full bitmap when DWM
+        // bounds aren't available, so the bitmap origin IS GetWindowRect
+        // top-left in that branch.
+        let mut wr = RECT::default();
+        let _ = GetWindowRect(h, &mut wr);
+        (wr.left + px, wr.top + py)
+    }
+}
+
 /// Animate the agent cursor to (sx, sy) in screen coordinates and wait for the
 /// glide to finish before returning.  No-op when the overlay is not enabled.
 ///
@@ -1680,11 +1730,22 @@ impl Tool for ClickTool {
                 is scoped per (pid, window_id) and is replaced by the next snapshot of the \
                 same window.\n\n\
                 - `x`, `y` (window-local screenshot pixels, top-left origin of the PNG \
-                returned by `get_window_state`) — synthesizes mouse events via \
-                PostMessage(WM_LBUTTONDOWN/UP) and delivers them to the deepest child \
-                window under that point. `count: 2` posts two down/up pairs for a \
-                double-click. Pixel clicks need a visible on-screen window to anchor the \
-                coordinate conversion (errors with `pid X has no on-screen window` otherwise).\n\n\
+                returned by `get_window_state`). On `dispatch:\"background\"` (default) and \
+                `dispatch:\"auto\"`, cua-driver FIRST does a UIA hit-test at the resolved \
+                screen position: if the deepest invokable element under that point exposes \
+                `InvokePattern`, it's invoked through the accessibility channel — same \
+                background-safe path as the `element_index` mode, no foreground swap, no \
+                visible flash. **This makes pixel clicks on UWP / WinUI3 / Win11 packaged \
+                apps work flash-free out of the box** — agents should default to \
+                `dispatch:\"background\"` even on XAML hosts whose CoreInput dispatcher \
+                drops raw PostMessage. The PostMessage(WM_LBUTTONDOWN/UP) fallback only \
+                runs when the UIA hit-test misses (canvas / video / WebGL / custom-drawn \
+                surfaces with no UIA peer), and on those targets `dispatch:\"background\"` \
+                returns a structured `background_unavailable` error if PostMessage is \
+                known to drop too — at which point you switch to `dispatch:\"foreground\"`. \
+                `count: 2` posts two down/up pairs for a double-click. Pixel clicks need \
+                a visible on-screen window to anchor the coordinate conversion (errors \
+                with `pid X has no on-screen window` otherwise).\n\n\
                 Exactly one of `element_index` or (`x` AND `y`) must be provided. \
                 `pid` is required in both modes. `window_id` is required when \
                 `element_index` is used (scopes the cache lookup). After a `zoom` call, \
@@ -1907,14 +1968,10 @@ impl Tool for ClickTool {
                 px *= ratio;
                 py *= ratio;
             }
-            // px/py are window-client coords. Convert to screen for the overlay.
-            let (sx, sy) = unsafe {
-                use windows::Win32::Foundation::{HWND, POINT};
-                use windows::Win32::Graphics::Gdi::ClientToScreen;
-                let mut pt = POINT { x: px as i32, y: py as i32 };
-                let _ = ClientToScreen(HWND(hwnd as *mut _), &mut pt);
-                (pt.x as f64, pt.y as f64)
-            };
+            // px/py are bitmap pixels — see `bitmap_to_screen` for the
+            // mapping (DWM-frame top-left + 1-px inset, NOT ClientToScreen).
+            let (sx_i, sy_i) = bitmap_to_screen(hwnd, px as i32, py as i32);
+            let (sx, sy) = (sx_i as f64, sy_i as f64);
             pin_overlay_above(hwnd);
             overlay_glide_to(sx, sy).await;
             crate::overlay::send_command(cursor_overlay::OverlayCommand::ClickPulse { x: sx, y: sy });
@@ -2073,8 +2130,10 @@ impl Tool for ClickTool {
                 }
             }
 
+            // bitmap pixels -> screen (DWM-frame origin + inset). Use
+            // post_click_screen so we don't double-ClientToScreen.
             let result = tokio::task::spawn_blocking(move || {
-                crate::input::post_click(hwnd, px as i32, py as i32, count, &btn)
+                crate::input::post_click_screen(hwnd, sx_i, sy_i, count, &btn)
             }).await;
             match result {
                 Ok(Ok(())) => {
@@ -3061,13 +3120,10 @@ impl Tool for DoubleClickTool {
                 px *= ratio;
                 py *= ratio;
             }
-            let (sx, sy) = unsafe {
-                use windows::Win32::Foundation::{HWND, POINT};
-                use windows::Win32::Graphics::Gdi::ClientToScreen;
-                let mut pt = POINT { x: px as i32, y: py as i32 };
-                let _ = ClientToScreen(HWND(hwnd as *mut _), &mut pt);
-                (pt.x as f64, pt.y as f64)
-            };
+            // bitmap pixels -> screen via DWM-frame origin (see
+            // `bitmap_to_screen` doc for why ClientToScreen is wrong).
+            let (sx_i, sy_i) = bitmap_to_screen(hwnd, px as i32, py as i32);
+            let (sx, sy) = (sx_i as f64, sy_i as f64);
             pin_overlay_above(hwnd);
             overlay_glide_to(sx, sy).await;
             crate::overlay::send_command(cursor_overlay::OverlayCommand::ClickPulse { x: sx, y: sy });
@@ -3083,26 +3139,24 @@ impl Tool for DoubleClickTool {
                     windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow().0 as usize
                 };
                 let send_result = tokio::task::spawn_blocking(move || {
-                    crate::input::send_click_synthesized(hwnd, sx as i32, sy as i32, 2, "left")
+                    crate::input::send_click_synthesized(hwnd, sx_i, sy_i, 2, "left")
                 }).await;
                 tokio::spawn(restore_foreground_polling_best_effort(prev_fg_addr, pid));
                 return match send_result {
                     Ok(Ok(())) => ToolResult::text(format!(
-                        "✅ Sent double-click via SendInput to pid {pid} at screen ({},{}) (dispatch:foreground).",
-                        sx as i32, sy as i32
+                        "✅ Sent double-click via SendInput to pid {pid} at screen ({sx_i},{sy_i}) (dispatch:foreground)."
                     )),
                     Ok(Err(e)) => ToolResult::error(e.to_string()),
                     Err(e) => ToolResult::error(format!("Task error: {e}")),
                 };
             }
             let (xi, yi) = (px as i32, py as i32);
-            let result = tokio::task::spawn_blocking(move || crate::input::post_click(hwnd, xi, yi, 2, "left")).await;
+            let result = tokio::task::spawn_blocking(move || crate::input::post_click_screen(hwnd, sx_i, sy_i, 2, "left")).await;
             match result {
                 Ok(Ok(())) => {
                     // Match Swift's pixel-path text 1:1.
                     ToolResult::text(format!(
-                        "✅ Posted double-click to pid {pid} at window-pixel ({xi}, {yi}) → screen-point ({}, {}).",
-                        sx as i32, sy as i32))
+                        "✅ Posted double-click to pid {pid} at window-pixel ({xi}, {yi}) → screen-point ({sx_i}, {sy_i})."))
                 }
                 Ok(Err(e)) => ToolResult::error(e.to_string()),
                 Err(e) => ToolResult::error(format!("Task error: {e}")),
@@ -3256,13 +3310,10 @@ impl Tool for RightClickTool {
                 px *= ratio;
                 py *= ratio;
             }
-            let (sx, sy) = unsafe {
-                use windows::Win32::Foundation::{HWND, POINT};
-                use windows::Win32::Graphics::Gdi::ClientToScreen;
-                let mut pt = POINT { x: px as i32, y: py as i32 };
-                let _ = ClientToScreen(HWND(hwnd as *mut _), &mut pt);
-                (pt.x as f64, pt.y as f64)
-            };
+            // bitmap pixels -> screen via DWM-frame origin (see
+            // `bitmap_to_screen` doc).
+            let (sx_i, sy_i) = bitmap_to_screen(hwnd, px as i32, py as i32);
+            let (sx, sy) = (sx_i as f64, sy_i as f64);
             pin_overlay_above(hwnd);
             overlay_glide_to(sx, sy).await;
             crate::overlay::send_command(cursor_overlay::OverlayCommand::ClickPulse { x: sx, y: sy });
@@ -3276,26 +3327,24 @@ impl Tool for RightClickTool {
                     windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow().0 as usize
                 };
                 let send_result = tokio::task::spawn_blocking(move || {
-                    crate::input::send_click_synthesized(hwnd, sx as i32, sy as i32, 1, "right")
+                    crate::input::send_click_synthesized(hwnd, sx_i, sy_i, 1, "right")
                 }).await;
                 tokio::spawn(restore_foreground_polling_best_effort(prev_fg_addr, pid));
                 return match send_result {
                     Ok(Ok(())) => ToolResult::text(format!(
-                        "✅ Sent right-click via SendInput to pid {pid} at screen ({},{}) (dispatch:foreground).",
-                        sx as i32, sy as i32
+                        "✅ Sent right-click via SendInput to pid {pid} at screen ({sx_i},{sy_i}) (dispatch:foreground)."
                     )),
                     Ok(Err(e)) => ToolResult::error(e.to_string()),
                     Err(e) => ToolResult::error(format!("Task error: {e}")),
                 };
             }
             let (xi, yi) = (px as i32, py as i32);
-            let result = tokio::task::spawn_blocking(move || crate::input::post_click(hwnd, xi, yi, 1, "right")).await;
+            let result = tokio::task::spawn_blocking(move || crate::input::post_click_screen(hwnd, sx_i, sy_i, 1, "right")).await;
             match result {
                 Ok(Ok(())) => {
                     // Swift pixel-path text 1:1.
                     ToolResult::text(format!(
-                        "✅ Posted right-click to pid {pid} at window-pixel ({xi}, {yi}) → screen-point ({}, {}).",
-                        sx as i32, sy as i32))
+                        "✅ Posted right-click to pid {pid} at window-pixel ({xi}, {yi}) → screen-point ({sx_i}, {sy_i})."))
                 }
                 Ok(Err(e)) => ToolResult::error(e.to_string()),
                 Err(e)     => ToolResult::error(format!("Task error: {e}")),
@@ -3397,16 +3446,11 @@ impl Tool for DragTool {
             }
         };
 
-        // Compute screen-coord endpoints for Swift's text format.
-        let (sx_from, sy_from, sx_to, sy_to) = unsafe {
-            use windows::Win32::Foundation::{HWND, POINT};
-            use windows::Win32::Graphics::Gdi::ClientToScreen;
-            let mut p1 = POINT { x: from_x as i32, y: from_y as i32 };
-            let mut p2 = POINT { x: to_x   as i32, y: to_y   as i32 };
-            let _ = ClientToScreen(HWND(hwnd as *mut _), &mut p1);
-            let _ = ClientToScreen(HWND(hwnd as *mut _), &mut p2);
-            (p1.x, p1.y, p2.x, p2.y)
-        };
+        // Compute screen-coord endpoints. Same correction as the click
+        // tools — bitmap pixels are anchored to the DWM-frame top-left,
+        // not the client area top-left (see `bitmap_to_screen` doc).
+        let (sx_from, sy_from) = bitmap_to_screen(hwnd, from_x as i32, from_y as i32);
+        let (sx_to,   sy_to)   = bitmap_to_screen(hwnd, to_x   as i32, to_y   as i32);
 
         // dispatch:"background" — refuse if PostMessage drag would silently drop.
         if dispatch == DispatchMode::Background


### PR DESCRIPTION
This branch bundles two related Windows changes.

## 1. Fix: `click(x, y)` / `drag` coord-space mismatch (the actual ship-blocker)

`tools/impl_.rs` previously called `ClientToScreen(px, py)` on the bitmap pixels returned by `get_window_state`. But `ClientToScreen` interprets its argument as CLIENT-area-relative — top-left of the client area, EXCLUDING the title bar — while the bitmap covers the full window (top-left = DWM-cropped frame top-left, INCLUDING the title bar). The title-bar height (~30 px on Win11 dialogs) got double-counted, so every pixel click landed ~30 px below the agent's intended spot.

Concretely caught when trying to click **Save** on the LibreOffice Document Recovery dialog: the crosshair marker on the screenshot landed cleanly on the button, but the actual click went to the empty space just below it. PR #1697's DWM crop made the mismatch visible (was previously masked by the 7 px shadow margin partially absorbing the title-bar offset).

**Fix**: new `bitmap_to_screen(hwnd, px, py)` helper in `tools/impl_.rs` that uses `DwmGetWindowAttribute(DWMWA_EXTENDED_FRAME_BOUNDS) + DWM_CROP_INSET_PX` to compute the bitmap's actual screen origin, then adds the caller's (px, py). Falls back to `GetWindowRect.top-left + (px, py)` when the DWM call fails (matching the capture path's fallback).

Replaces 4 `ClientToScreen` sites:
- `click` `(x, y)` mode
- `double_click` `(x, y)` mode
- `right_click` `(x, y)` mode
- `drag` `(from_x, from_y) / (to_x, to_y)`

Also switches the PostMessage path in those tools from `post_click` (which re-applies `ClientToScreen` internally) to `post_click_screen` so the bitmap → screen mapping happens exactly once.

Verified end-to-end against the LO Document Recovery dialog: pixel click at bitmap `(470, 244)` now correctly maps to screen `(988, 575)` (the Save button's center) and the dialog dismisses.

## 2. Docs: `dispatch:\"background\"` already does a UIA hit-test for pixel clicks

The click tool's `(x, y)` background path runs `try_invoke_in_window_at_point` BEFORE PostMessage delivery: if the deepest invokable element at the resolved screen position exposes `InvokePattern`, the click is delivered through the UIA accessibility channel (same path as `element_index` mode — no foreground swap, no flash). PostMessage is only the fallback.

That means pixel clicks on UWP / WinUI3 / Win11 packaged apps (Calculator, modern Notepad, etc.) work flash-free out of the box with the default `dispatch:\"background\"` — no need to escalate to `\"foreground\"`.

The schema description and `WINDOWS.md` previously didn't mention this hit-test fallback at all — agents reading the docs would conclude they have to use `dispatch:\"foreground\"` for any XAML host and accept the visible flash. Both updated:

- `tools/impl_.rs` click schema docstring — `(x, y)` paragraph now explains the UIA hit-test fallback and recommends `background` as the default even on XAML hosts.
- `Skills/cua-driver/WINDOWS.md` — `dispatch` table's `\"background\"` row mentions the hit-test; new \"Always try `dispatch:'background'` first\" section with the recommendation and the empirical UWP-Calculator result.

Empirical evidence (verified in this session): 4 pixel clicks against the UWP Calculator numpad with `dispatch:\"background\"` produced `\"✅ Performed UIA Invoke at (sx,sy) for pid X.\"` with zero visible flash, vs. the same coords with `dispatch:\"foreground\"` flashing the Calculator window for ~40 ms each.

## Test plan

- [x] LO Document Recovery dialog: pixel click at bitmap `(470, 244)` dismisses (was off by ~30 px before)
- [x] UWP Calculator: `2 + 1 =` via pixel clicks with `dispatch:\"background\"` — all four resolved as `UIA Invoke at (sx,sy)`, display = `3`, no flash
- [x] `cargo build --bin cua-driver` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed coordinate conversion for click, double-click, right-click, and drag operations to accurately translate screenshot pixel coordinates to screen coordinates, improving compatibility across Windows application types.

* **Documentation**
  * Updated dispatch contract documentation with improved descriptions of background and foreground behavior, including error handling and guidance for coordinate-based operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1708?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->