### PR TITLE
feat(cua-driver-rs)(integrations): support Google Antigravity CLI (`agy`)

### DIFF
--- a/docs/content/docs/cua-driver/guide/getting-started/integrations.mdx
+++ b/docs/content/docs/cua-driver/guide/getting-started/integrations.mdx
@@ -160,6 +160,18 @@ Paste the output into `~/.hermes/config.yaml`.
 cua-driver mcp-config --client openclaw
 ```
 
+## Antigravity CLI (and Antigravity IDE)
+
+Google's [Antigravity CLI](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/) — the `agy` binary that replaced Gemini CLI on May 19, 2026 — reads MCP server configs from `~/.gemini/config/mcp_config.json` (Unix) or `%USERPROFILE%\.gemini\config\mcp_config.json` (Windows). The same file is read by Antigravity IDE.
+
+```bash
+cua-driver mcp-config --client antigravity
+```
+
+Output is a snippet to paste under the top-level `mcpServers` object in that file. If the file doesn't exist yet, create it with `{"mcpServers": {}}` first. Antigravity CLI has no in-shell `mcp add` subcommand — edit the JSON file directly, then restart `agy` to pick up the change.
+
+`--client gemini` is accepted as a legacy alias and emits the same instructions — Antigravity inherited the `~/.gemini/` config tree from the old Gemini CLI install on purpose, so existing setups carry over without re-registration.
+
 ## Other clients
 
 For any client that accepts the standard `mcpServers` shape:

--- a/docs/content/docs/cua-driver/reference/cli-reference.mdx
+++ b/docs/content/docs/cua-driver/reference/cli-reference.mdx
@@ -183,7 +183,7 @@ Print MCP server config or a client-specific install command.
 
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
-| `--client` | String | — | Client to print the install command for: claude \| codex \| cursor \| openclaw \| opencode \| hermes \| pi. Omit for the generic JSON snippet. |
+| `--client` | String | — | Client to print the install command for: claude \| codex \| cursor \| antigravity \| openclaw \| opencode \| hermes \| pi. (`gemini` accepted as a legacy alias for `antigravity` — both read the same `~/.gemini/config/mcp_config.json` after Antigravity inherited the path in May 2026.) Omit for the generic JSON snippet. |
 
 **Flags:**
 

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -659,8 +659,8 @@ pub fn run_mcp_via_daemon_proxy(socket: Option<String>) -> anyhow::Result<()> {
 
 /// Print the MCP server config snippet or a client-specific install command.
 ///
-/// `--client <name>` selects one of: claude, codex, cursor, hermes, openclaw,
-/// opencode. Omit for the generic JSON snippet.
+/// `--client <name>` selects one of: claude, codex, cursor, hermes,
+/// antigravity, openclaw, opencode, pi. Omit for the generic JSON snippet.
 pub fn run_mcp_config(client: Option<&str>) {
     let binary = std::env::current_exe()
         .ok()
@@ -755,6 +755,58 @@ pub fn run_mcp_config(client: Option<&str>) {
             println!("    command: \"{binary}\"");
             println!("    args: [\"mcp\"]");
         }
+        Some("antigravity") | Some("gemini") => {
+            // Google Antigravity CLI (the `agy` binary, successor to Gemini
+            // CLI as of May 2026 — Gemini CLI support sunsets 2026-06-18 for
+            // consumers per the developers.googleblog.com transition post)
+            // has no `agy mcp add` subcommand: MCP servers are registered by
+            // editing JSON directly. Both Antigravity CLI and Antigravity
+            // IDE read from the SAME mcp_config.json at:
+            //
+            //   Unix:    ~/.gemini/config/mcp_config.json
+            //   Windows: %USERPROFILE%\.gemini\config\mcp_config.json
+            //
+            // (Antigravity inherited the `.gemini` directory tree from the
+            // old Gemini CLI install path on purpose — same config carries
+            // over.) An additional CLI-only path at
+            // ~/.gemini/antigravity-cli/mcp_config.json takes precedence
+            // for CLI when present; we register at the shared path so the
+            // IDE picks the same server up.
+            //
+            // Reload after edit: restart `agy` (Antigravity CLI has no
+            // mid-session config-reload hook).
+            //
+            // The `gemini` client alias points at the same instructions
+            // so anyone with old muscle memory typing `--client gemini`
+            // gets the right (forward-compatible) config.
+            let normalised = binary.replace('\\', "/");
+            // Emit the full mcp_config.json envelope so the user can paste
+            // it verbatim into a fresh file (or merge under "mcpServers" in
+            // an existing one). Single pretty-printed JSON object keeps
+            // both shapes — full file and merge fragment — useful.
+            let full = serde_json::json!({
+                "mcpServers": {
+                    "cua-driver": {
+                        "command": normalised,
+                        "args": ["mcp"],
+                    }
+                }
+            });
+            let pretty = serde_json::to_string_pretty(&full)
+                .unwrap_or_else(|_| full.to_string());
+            println!(
+                "# Antigravity CLI (the `agy` binary) reads MCP server configs from:\n\
+                 #   ~/.gemini/config/mcp_config.json   (Unix)\n\
+                 #   %USERPROFILE%\\.gemini\\config\\mcp_config.json   (Windows)\n\
+                 #\n\
+                 # No `agy` subcommand for this — drop the JSON below into that file (or\n\
+                 # merge under the existing top-level \"mcpServers\" object if it already\n\
+                 # exists), then restart `agy` to pick up the change.\n\
+                 #\n\
+                 # The same file is shared with the Antigravity IDE.\n\
+                 {pretty}",
+            );
+        }
         Some("pi") => {
             println!(
                 "Pi (badlogic/pi-mono) does not support MCP natively — the author\n\
@@ -768,7 +820,7 @@ pub fn run_mcp_config(client: Option<&str>) {
             );
         }
         Some(other) => {
-            eprintln!("Unknown client '{other}'. Valid: claude, codex, cursor, openclaw, opencode, hermes, pi.");
+            eprintln!("Unknown client '{other}'. Valid: claude, codex, cursor, antigravity, openclaw, opencode, hermes, pi.");
             process::exit(2);
         }
     }

--- a/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
@@ -39,13 +39,17 @@
 //!
 //! ## Agent detection
 //!
-//! Same four agent dirs as the Swift cua-driver installer detects:
+//! Same agent dirs as the Swift cua-driver installer detects:
 //!
 //! - Claude Code: `~/.claude/skills/`
 //! - Codex:       `~/.agents/skills/`
 //! - OpenClaw:    `~/.openclaw/skills/`
 //! - OpenCode:    `~/.config/opencode/skills/` (macOS / Linux),
 //!                `%APPDATA%\opencode\skills\` (Windows)
+//! - Antigravity: `~/.gemini/skills/` — shared between Antigravity CLI
+//!                (`agy`) and Antigravity IDE; same dir Google Gemini CLI
+//!                used before the May-2026 transition, so existing
+//!                installs migrate forward unchanged.
 //!
 //! Only acts on a given agent when its parent skills dir already
 //! exists (i.e. the agent itself is installed). Never clobbers an
@@ -182,6 +186,10 @@ const AGENTS: &[Agent] = &[
     Agent { label: "OpenCode",    parent: AgentParent::AppData("opencode/skills") },
     #[cfg(not(windows))]
     Agent { label: "OpenCode",    parent: AgentParent::Home(".config/opencode/skills") },
+    // Antigravity CLI + Antigravity IDE share the `.gemini/skills/` dir
+    // (the same path Gemini CLI used pre-May-2026). Registering the
+    // single shared path means both surfaces pick up the same symlink.
+    Agent { label: "Antigravity", parent: AgentParent::Home(".gemini/skills") },
 ];
 
 impl Agent {

--- a/libs/cua-driver/scripts/install.sh
+++ b/libs/cua-driver/scripts/install.sh
@@ -310,6 +310,9 @@ fi
 #   - OpenCode  : scans ~/.config/opencode/skills/ (also reads ~/.claude/skills/
 #                 natively, so the Claude Code symlink covers OpenCode for users
 #                 who have both)
+#   - Antigravity (CLI + IDE): scans ~/.gemini/skills/ — the dir Google
+#                              inherited from Gemini CLI in May 2026, so
+#                              existing setups carry over unchanged.
 #
 # Not auto-wired (different file format / would clobber user state):
 #   - Cursor: rules use a different frontmatter shape (description/globs/
@@ -363,6 +366,15 @@ if [[ -d "$HOME/.config/opencode" ]] && [[ ! -d "$HOME/.config/opencode/skills" 
     mkdir -p "$HOME/.config/opencode/skills"
 fi
 link_skill_into "$HOME/.config/opencode/skills" "OpenCode"
+
+# Antigravity CLI (`agy`) + Antigravity IDE — both surfaces read from
+# ~/.gemini/skills (the dir inherited from Gemini CLI on 2026-05-19).
+# Create it if either Antigravity surface is installed but the skills
+# subdir hasn't been initialized yet, then link.
+if [[ -d "$HOME/.gemini" ]] && [[ ! -d "$HOME/.gemini/skills" ]]; then
+    mkdir -p "$HOME/.gemini/skills"
+fi
+link_skill_into "$HOME/.gemini/skills" "Antigravity"
 
 # --- PATH setup ---------------------------------------------------------
 #
@@ -462,10 +474,11 @@ Next steps:
             }
             Or inside gh copilot chat: /mcp add → type=STDIO, command=$BIN_LINK, args=mcp
 
-        • Cursor / OpenCode / Hermes (no add CLI — paste config):
-            cua-driver mcp-config --client cursor     # JSON for ~/.cursor/mcp.json
-            cua-driver mcp-config --client opencode   # JSON for opencode.json
-            cua-driver mcp-config --client hermes     # YAML for ~/.hermes/config.yaml
+        • Cursor / OpenCode / Hermes / Antigravity (no add CLI — paste config):
+            cua-driver mcp-config --client cursor       # JSON for ~/.cursor/mcp.json
+            cua-driver mcp-config --client opencode     # JSON for opencode.json
+            cua-driver mcp-config --client hermes       # YAML for ~/.hermes/config.yaml
+            cua-driver mcp-config --client antigravity  # JSON for ~/.gemini/config/mcp_config.json (shared with Antigravity IDE)
 
         For other clients accepting the generic mcpServers shape:
             cua-driver mcp-config


### PR DESCRIPTION
## Summary

Wires cua-driver into Google's [Antigravity CLI](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/), the `agy` binary that replaced Gemini CLI on 2026-05-19 and shares its agent infrastructure with the Antigravity IDE.

## What lands

- **`cua-driver mcp-config --client antigravity`** prints a paste-ready `mcp_config.json` snippet plus the Unix/Windows config-file paths. Antigravity has no `agy mcp add` subcommand — config is JSON-file-only — so the output is a literal file/fragment ready to merge under the top-level `mcpServers` object. Same file is read by Antigravity IDE; one registration covers both surfaces.
- **`--client gemini`** accepted as a legacy alias (Antigravity inherited the `~/.gemini/` tree on purpose). Existing Gemini-era setups carry over without re-registration.
- **Skill pack auto-link**: new `Antigravity` entry in `AGENTS` so `cua-driver skills install` drops a symlink at `~/.gemini/skills/cua-driver` when the dir exists. Same idempotent behavior as the other agents.
- **`install.sh`** mirrors the skill-linking pattern for Antigravity.
- **Docs** updated (per `feedback_docs_updates.md`): `integrations.mdx` gets a new section, `cli-reference.mdx` updates the `--client` valid-values row.
- **Error message** updated: `Unknown client '<X>'. Valid: …` now lists `antigravity`.

## Sample output

```
$ cua-driver mcp-config --client antigravity
# Antigravity CLI (the `agy` binary) reads MCP server configs from:
#   ~/.gemini/config/mcp_config.json   (Unix)
#   %USERPROFILE%\.gemini\config\mcp_config.json   (Windows)
#
# No `agy` subcommand for this — drop the JSON below into that file (or
# merge under the existing top-level "mcpServers" object if it already
# exists), then restart `agy` to pick up the change.
#
# The same file is shared with the Antigravity IDE.
{
  "mcpServers": {
    "cua-driver": {
      "args": ["mcp"],
      "command": "/path/to/cua-driver"
    }
  }
}
```

The non-comment lines parse as valid JSON (tested via `python3 -m json.tool`).

## Files changed

| File | Change |
|---|---|
| `cua-driver/src/cli.rs` | New `Some("antigravity") \| Some("gemini")` arm in `run_mcp_config`; valid-client list updated in the doc comment and error message |
| `cua-driver/src/skills.rs` | New `Agent { label: "Antigravity", parent: AgentParent::Home(".gemini/skills") }` entry; module-level doc updated to list the new dir |
| `libs/cua-driver/scripts/install.sh` | `link_skill_into "$HOME/.gemini/skills" "Antigravity"` block + comment block updated + post-install summary mentions the new `--client antigravity` form |
| `docs/.../integrations.mdx` | New "Antigravity CLI (and Antigravity IDE)" section |
| `docs/.../cli-reference.mdx` | `--client` valid-values row updated |

No changes to `install.ps1` (script never enumerated clients individually) or `_install-rust.sh` (skills.rs handles Rust-side wiring at runtime).

## Why the JSON-file-only flow

Per Google's [Antigravity MCP config docs](https://medium.com/google-cloud/configuring-mcp-servers-and-skills-for-antigravity-cli-and-ide-a938c7eebb78), Antigravity has no shell-callable `mcp add` equivalent to `claude mcp add-json` or `codex mcp add`. The expected workflow is to edit `~/.gemini/config/mcp_config.json` directly. Our output mirrors that — a comment block explaining the path + caveat, then a paste-ready JSON object. (Matches the pattern we use for `cursor` / `opencode` / `hermes`, all of which are also paste-config flows.)

## Test plan
- [x] `cargo build --release -p cua-driver` clean
- [x] `cua-driver mcp-config --client antigravity` emits valid JSON (verified via `python3 -m json.tool` on the non-comment lines)
- [x] `cua-driver mcp-config --client gemini` emits same output (legacy alias)
- [x] `cua-driver mcp-config --client bogus` lists `antigravity` in the rejection message
- [x] `bash -n libs/cua-driver/scripts/install.sh` syntax clean
- [ ] On a Mac with Antigravity CLI installed, run `cua-driver skills install` and verify the `~/.gemini/skills/cua-driver` symlink appears (requires Antigravity actually installed somewhere — left as a manual verification step)
- [ ] Same for Linux + Windows install paths
- [ ] CodeRabbit pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Antigravity IDE and CLI integration support for cua-driver MCP server configuration
  * Added Antigravity skill-pack installation and management

* **Documentation**
  * Updated integration guides with Antigravity setup instructions
  * Updated CLI reference to document Antigravity as a supported client option
  * Added installation configuration instructions for Antigravity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1710?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->