### PR TITLE
fix(cua-driver-rs)(install): _install-local-rust.sh uses the .cua-driver/ home (matches v0.2.16+ runtime)

### DIFF
--- a/libs/cua-driver/scripts/_install-local-rust.sh
+++ b/libs/cua-driver/scripts/_install-local-rust.sh
@@ -23,11 +23,16 @@
 #
 # Linux layout produced (matches install.sh):
 #
-#   ${CUA_DRIVER_RS_HOME:-$HOME/.cua-driver-rs}/packages/
+#   ${CUA_DRIVER_HOME:-$HOME/.cua-driver}/packages/
 #       releases/<version>-local-<config>-<target>/cua-driver
 #       current/cua-driver  -> ../releases/<active>/cua-driver
-#   ${CUA_DRIVER_RS_INSTALL_DIR:-$HOME/.local/bin}/cua-driver
+#   ${CUA_DRIVER_INSTALL_DIR:-$HOME/.local/bin}/cua-driver
 #       -> ../current/cua-driver
+#
+# Legacy env vars `CUA_DRIVER_RS_HOME` / `CUA_DRIVER_RS_INSTALL_DIR` /
+# `CUA_DRIVER_RS_BIN_DIR` are still accepted for backwards compat
+# (rename from v0.2.16 per PR #1644; this helper was missed in the
+# initial rename and ported in PR #1717).
 #
 # macOS layout produced:
 #   /Applications/CuaDriver.app/Contents/MacOS/cua-driver  (bundle replaced wholesale)
@@ -120,10 +125,23 @@ case "$OS" in
     *)      echo "${RED}Unsupported OS: $OS${NORMAL}"; exit 1 ;;
 esac
 
-HOME_DIR="${CUA_DRIVER_RS_HOME:-$HOME/.cua-driver-rs}"
-BIN_DIR="${CUA_DRIVER_RS_INSTALL_DIR:-${CUA_DRIVER_RS_BIN_DIR:-$HOME/.local/bin}}"
+# Canonical home is `~/.cua-driver/` (renamed from `~/.cua-driver-rs/`
+# in v0.2.16 — PR #1644). Accept the legacy `CUA_DRIVER_RS_HOME` env var
+# too so any dev scripts that still set it keep working.
+HOME_DIR="${CUA_DRIVER_HOME:-${CUA_DRIVER_RS_HOME:-$HOME/.cua-driver}}"
+BIN_DIR="${CUA_DRIVER_INSTALL_DIR:-${CUA_DRIVER_BIN_DIR:-${CUA_DRIVER_RS_INSTALL_DIR:-${CUA_DRIVER_RS_BIN_DIR:-$HOME/.local/bin}}}}"
 RELEASES_DIR="$HOME_DIR/packages/releases"
 CURRENT_LINK="$HOME_DIR/packages/current"
+
+# Best-effort sweep: if a previous install left a stale `~/.cua-driver-rs/`
+# (the pre-v0.2.16 home), remove it. The runtime sweeps it on first call
+# too (see telemetry.rs::migrate_legacy_telemetry_home) so this is belt-
+# and-braces — keeps the home dir layout single-rooted for the user.
+LEGACY_HOME_DIR="$HOME/.cua-driver-rs"
+if [ -d "$LEGACY_HOME_DIR" ] && [ "$HOME_DIR" != "$LEGACY_HOME_DIR" ]; then
+    echo "  Sweeping legacy install dir $LEGACY_HOME_DIR"
+    rm -rf "$LEGACY_HOME_DIR"
+fi
 
 VERSION_TAG="0.0.0-local-$BUILD_CONFIG"
 VERSIONED_DIR="$RELEASES_DIR/$VERSION_TAG-$TARGET_TRIPLE"
@@ -218,7 +236,14 @@ echo ""
 
 if [ "$INSTALL_AUTOSTART" = true ]; then
     if [ "$OS" = "Darwin" ]; then
-        PLIST_PATH="$HOME/Library/LaunchAgents/com.trycua.cua-driver-rs.plist"
+        # Unload + remove any stale LaunchAgent from the pre-rename install
+        # so the new label doesn't race the old one.
+        LEGACY_PLIST_PATH="$HOME/Library/LaunchAgents/com.trycua.cua-driver-rs.plist"
+        if [ -f "$LEGACY_PLIST_PATH" ]; then
+            launchctl unload "$LEGACY_PLIST_PATH" 2>/dev/null || true
+            rm -f "$LEGACY_PLIST_PATH"
+        fi
+        PLIST_PATH="$HOME/Library/LaunchAgents/com.trycua.cua-driver.plist"
         echo "${BOLD}Writing LaunchAgent → $PLIST_PATH${NORMAL}"
         mkdir -p "$(dirname "$PLIST_PATH")"
         cat >"$PLIST_PATH" <<EOF
@@ -226,7 +251,7 @@ if [ "$INSTALL_AUTOSTART" = true ]; then
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Label</key><string>com.trycua.cua-driver-rs</string>
+  <key>Label</key><string>com.trycua.cua-driver</string>
   <key>ProgramArguments</key>
   <array>
     <string>$INSTALLED_BIN</string>
@@ -243,12 +268,19 @@ EOF
         launchctl load "$PLIST_PATH"
         echo "${GREEN}Loaded.${NORMAL} Manage with launchctl load / unload \"$PLIST_PATH\"."
     elif [ "$OS" = "Linux" ]; then
-        UNIT_PATH="$HOME/.config/systemd/user/cua-driver-rs.service"
+        # Stop + remove any pre-rename systemd unit so the new one doesn't
+        # race the old one.
+        LEGACY_UNIT_PATH="$HOME/.config/systemd/user/cua-driver-rs.service"
+        if [ -f "$LEGACY_UNIT_PATH" ]; then
+            systemctl --user disable --now cua-driver-rs.service 2>/dev/null || true
+            rm -f "$LEGACY_UNIT_PATH"
+        fi
+        UNIT_PATH="$HOME/.config/systemd/user/cua-driver.service"
         echo "${BOLD}Writing systemd user unit → $UNIT_PATH${NORMAL}"
         mkdir -p "$(dirname "$UNIT_PATH")"
         cat >"$UNIT_PATH" <<EOF
 [Unit]
-Description=cua-driver-rs serve daemon
+Description=cua-driver serve daemon
 After=graphical-session.target
 
 [Service]
@@ -260,8 +292,8 @@ RestartSec=2
 WantedBy=default.target
 EOF
         systemctl --user daemon-reload
-        systemctl --user enable --now cua-driver-rs.service
-        echo "${GREEN}Enabled.${NORMAL} Manage with systemctl --user {start|stop|status} cua-driver-rs."
+        systemctl --user enable --now cua-driver.service
+        echo "${GREEN}Enabled.${NORMAL} Manage with systemctl --user {start|stop|status} cua-driver."
     fi
     echo ""
 fi


### PR DESCRIPTION
## Summary

Picks up the home-dir rename that landed in v0.2.16 (PR #1644) but missed this Bash dev-installer helper. Before this fix, every `./install-local.sh` on macOS/Linux re-created a stale `~/.cua-driver-rs/` directory parallel to the canonical `~/.cua-driver/`. The Windows `.ps1` and the production `install.sh` already had the rename.

## Bug repro (before this fix)

```bash
$ ./install-local.sh
cua-driver-rs local installer
source:  /Users/francesco/cua/libs/cua-driver/rust
config:  debug
target:  arm64-apple-darwin
bin:     /Users/francesco/.local/bin/cua-driver
current: /Users/francesco/.cua-driver-rs/packages/current   ← old path!
```

## What this fixes

- `HOME_DIR` now defaults to `${CUA_DRIVER_HOME:-${CUA_DRIVER_RS_HOME:-$HOME/.cua-driver}}`. The legacy `CUA_DRIVER_RS_HOME` env var is still accepted so any dev scripts that set it keep working.
- Same backcompat layering for `CUA_DRIVER_INSTALL_DIR` / `CUA_DRIVER_BIN_DIR` (the `_RS_` variants remain accepted as fallbacks).
- macOS LaunchAgent label: `com.trycua.cua-driver-rs` → `com.trycua.cua-driver`. Same .plist filename change.
- Linux systemd user unit: `cua-driver-rs.service` → `cua-driver.service`.

## Sweep blocks (legacy cleanup)

Three blocks remove the pre-rename artefacts so existing developers get a clean migration on first re-run:

1. **`~/.cua-driver-rs/` directory** — unconditional sweep (only if `HOME_DIR` differs, so users with the env var set keep their override).
2. **Legacy LaunchAgent plist** — unloaded + removed *before* the new plist is written, so the new label doesn't race the old one.
3. **Legacy systemd unit** — disabled + removed *before* the new unit is written, same race-avoidance.

The runtime already sweeps the legacy home on first invocation (see `telemetry.rs::migrate_legacy_telemetry_home` + the `LEGACY_HOME_SUBDIRECTORY` constant introduced in PR #1644 / #1683) — this fix is belt-and-braces on the installer side.

## Verification (after this fix, same machine)

```bash
$ ./install-local.sh
…
current: /Users/francesco/.cua-driver/packages/current     ← canonical path
…
Installed.
  /Users/francesco/.local/bin/cua-driver

$ ls -d ~/.cua-driver-rs                # → does not exist (swept)
$ ls -la ~/.cua-driver/packages/current # → symlink to ../releases/0.0.0-local-debug-arm64-apple-darwin
$ ~/.local/bin/cua-driver --version     # → cua-driver 0.2.18
```

## What's intentionally NOT renamed

Strings that contain the verbatim "cua-driver-rs" as a *project identifier* (not a user-visible install path) were left alone:
- The banner `${BOLD}${BLUE}cua-driver-rs local installer${NORMAL}` — still the project / cargo workspace name
- Skill-pack staging path `Skills/cua-driver-rs` — that's a directory inside the staged install, not a user home path; renaming that needs a separate coordinated change with `_install-rust.sh` and the `cua-driver skills install` runtime resolver

If you want those renamed too, that's a separate follow-up — this PR only fixes the user-visible install dirs and autostart unit names.

## Test plan
- [x] `bash -n libs/cua-driver/scripts/_install-local-rust.sh` clean
- [x] Verified install on this Mac (arm64-apple-darwin) — install succeeds end-to-end, binary works, no `~/.cua-driver-rs/` left behind
- [ ] Verify on Linux (Ubuntu 22.04 + Debian 12 VMs in the lab) — pending VM reachability
- [ ] CodeRabbit pass

## Why dev-only

This is `_install-local-rust.sh`, called from `install-local.sh`, which is the developer / checked-out-tree installer. The production `install.sh` (curl-pipe-bash) was already migrated to `.cua-driver/` in PR #1644 — only this helper was overlooked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Installation directory updated to use new canonical layout with automatic cleanup of legacy directories.
  * Autostart registration updated for macOS and Linux with automatic migration from legacy configurations.
  * Full backwards compatibility maintained for existing environment variables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->