### PR TITLE
fix(cua-driver-rs)(install): source ~/.cargo/env when cargo isn't on PATH

### DIFF
--- a/libs/cua-driver/scripts/_install-local-rust.sh
+++ b/libs/cua-driver/scripts/_install-local-rust.sh
@@ -157,8 +157,27 @@ echo ""
 # --- Prerequisites ------------------------------------------------------
 
 if ! command -v cargo >/dev/null 2>&1; then
+    # Common rustup default install at $HOME/.cargo/bin/cargo — source the
+    # rustup-shipped env script if present so cargo + rustc + the active
+    # toolchain shims all land on PATH for the rest of this script. This
+    # matters because rustup-init writes the PATH-prepending line into the
+    # user's shell rc, which only takes effect in NEW interactive shells —
+    # a fresh post-rustup invocation of `./install-local.sh` in the same
+    # shell as the rustup install would otherwise fail here even though
+    # cargo is on disk.
+    if [ -f "$HOME/.cargo/env" ]; then
+        # shellcheck disable=SC1091
+        . "$HOME/.cargo/env"
+    elif [ -x "$HOME/.cargo/bin/cargo" ]; then
+        # Older rustup installs (or non-rustup Cargo installs) may lack
+        # the env script — directly prepend the canonical bin dir.
+        export PATH="$HOME/.cargo/bin:$PATH"
+    fi
+fi
+if ! command -v cargo >/dev/null 2>&1; then
     echo "${RED}Error: cargo not found on PATH.${NORMAL}"
     echo "Install Rust via rustup: https://rustup.rs/"
+    echo "After install, either open a new shell or run: . \$HOME/.cargo/env"
     exit 1
 fi
 


### PR DESCRIPTION
## Bug

First `./install-local.sh` invocation in the same shell that just ran rustup-init fails:

```
$ ./install-local.sh
…
Error: cargo not found on PATH.
Install Rust via rustup: https://rustup.rs/
```

…even though `~/.cargo/bin/cargo` is right there. rustup-init writes a PATH-prepending line into the user's shell rc, but rc files only get sourced in **new** interactive shells. The existing shell doesn't see the new PATH until you open a new terminal or manually source `~/.cargo/env`.

## Fix

If `cargo` isn't on `$PATH`:

1. Source `~/.cargo/env` if present (the canonical rustup-shipped env script — adds `~/.cargo/bin` to PATH for the rest of this script).
2. Else, if `~/.cargo/bin/cargo` exists, prepend `~/.cargo/bin` to PATH directly (older rustups or non-rustup Cargo installs).
3. Only if neither works, print the original error — now with a hint to source `~/.cargo/env` so re-running succeeds in the same shell.

## Repro / verification

```bash
# Reproduce the original failure by clearing PATH:
$ env -i HOME=$HOME PATH=/usr/bin:/bin bash install-local.sh
# Before this PR: Error: cargo not found on PATH.
# After  this PR: Building cua-driver (debug)... [proceeds to build]
```

## Why not just fix the user's shell

Because the dev-loop expectation is "I just installed rust, my next command should work." Forcing the user to re-shell or memorize `. ~/.cargo/env` is an unnecessary papercut on a script that's already running in their shell and can fix it for itself.

## Scope

19-line addition to `_install-local-rust.sh` (the dev/local installer helper). No changes elsewhere. The production curl-pipe-bash `install.sh` doesn't build with cargo so it's not affected. Windows `.ps1` already handles this differently (rustup-init updates the user environment block on Windows, picked up by new Powershell sessions).

## Test plan
- [x] `bash -n` clean
- [x] Reproduced original failure + verified fix locally
- [ ] CodeRabbit pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Rust toolchain installation prerequisite checking with improved error messages and clearer guidance when Rust configuration is needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->