### PR TITLE
chore(cua-driver-rs): cut the 5 remaining dead-code warnings from `cargo build`

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/src/autostart.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/autostart.rs
@@ -34,7 +34,16 @@ use anyhow::{anyhow, Result};
 pub const TASK_NAME: &str = "cua-driver-serve";
 
 /// Reported by `status`.
+///
+/// `#[allow(dead_code)]` on the variants because they're constructed
+/// only inside the `#[cfg(target_os = "windows")]` `platform::status`
+/// (schtasks-backed), while the enum itself is cross-platform — the
+/// non-Windows stub returns `Err(NOT_YET)` instead. The variants ARE
+/// reachable from `Status::tag` on every platform via the match, but
+/// rustc's dead-code analysis runs after cfg-stripping, so on
+/// macOS/Linux it sees the variants without a constructor and warns.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
 pub enum Status {
     /// No autostart entry registered.
     NotRegistered,

--- a/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
@@ -175,6 +175,14 @@ enum AgentParent {
     /// `<HOME or USERPROFILE>/<segment>`.
     Home(&'static str),
     /// `<APPDATA>/<segment>` (Windows roaming app config).
+    ///
+    /// `#[allow(dead_code)]`: constructed only inside `#[cfg(windows)]`
+    /// AGENTS entries (OpenCode on Windows reads from `%APPDATA%`) and
+    /// matched only inside `#[cfg(windows)]` arms of `parent_path`. The
+    /// enum variant itself sits in cross-platform code so rustc's
+    /// post-cfg-strip dead-code pass flags it on macOS/Linux even though
+    /// the Windows build uses it.
+    #[allow(dead_code)]
     AppData(&'static str),
 }
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/permissions/panel.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/permissions/panel.rs
@@ -227,7 +227,6 @@ const WIN_W: f64 = 460.0;
 const WIN_H: f64 = 360.0;
 const PAD: f64 = 20.0;
 const ROW_H: f64 = 76.0;
-const BUTTON_BAR_H: f64 = 56.0;
 const READY_STRIP_H: f64 = 36.0;
 
 unsafe fn show_modal_unsafe(opts: &PanelOpts) -> PanelOutcome {
@@ -379,7 +378,6 @@ unsafe fn show_modal_unsafe(opts: &PanelOpts) -> PanelOutcome {
     // ---- Stash handles for the timer callback ----
     HANDLES.with(|cell| {
         *cell.borrow_mut() = Some(PanelHandles {
-            window: ptr_to_usize(window),
             heading: ptr_to_usize(heading),
             subheading: ptr_to_usize(subheading),
             ready_strip: ptr_to_usize(ready_strip),
@@ -430,7 +428,6 @@ struct RowHandles {
 }
 
 struct PanelHandles {
-    window: usize,
     heading: usize,
     subheading: usize,
     ready_strip: usize,

--- a/libs/cua-driver/rust/crates/platform-macos/src/window_change_detector.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/window_change_detector.rs
@@ -292,6 +292,14 @@ impl Snapshot {
     /// Pure-function diff: given the snapshot's window-id set + a
     /// list of currently-visible windows, return the (opened, closed)
     /// classification.
+    ///
+    /// `#[allow(dead_code)]`: today only the `#[cfg(test)]` block below
+    /// constructs this — production callers `wait_for_window_change` /
+    /// `wait_for_window_close` keep the (opened, closed) split inline.
+    /// Kept `pub(crate)` because the doc comment near the top of this
+    /// `impl` block calls it out as the entry point for unit-testing the
+    /// diff logic without driving the live window enumerator.
+    #[allow(dead_code)]
     pub(crate) fn diff(
         snapshot_ids: &HashSet<u32>,
         current: &[WindowInfo],


### PR DESCRIPTION
## Summary

Cleans up the 5 `warning: ... never used` items that fire on every `cargo build` of `cua-driver` on macOS/Linux. After this PR: **0 warnings** on a clean build.

## Breakdown

Three deleted (truly unused, not false positives):

| Item | File | Why dead | Why safe to delete |
|---|---|---|---|
| `BUTTON_BAR_H` const | `permissions/panel.rs:230` | No references | Panel sizing math doesn't use it |
| `PanelHandles.window` field | `permissions/panel.rs:432` | Set on construction, never read | usize copy doesn't retain NSWindow; AppKit's window list holds the real ref |

Two silenced with `#[allow(dead_code)]` + a comment explaining the cfg-conditional construction (compiler can't see through cfg-strip):

| Item | File | Why it looks dead | Why kept |
|---|---|---|---|
| `Snapshot::diff` | `window_change_detector.rs:295` | Only tests construct it today | `pub(crate)` API, doc comment already calls out "internal helper exposed for unit-testing the diff logic without driving the live enumerator" — kept for future production callers |
| `Status::{NotRegistered, RegisteredIdle, RegisteredRunning}` | `autostart.rs:38` | Constructed only inside `#[cfg(target_os = "windows")]` `platform::status` | Cross-platform callers reference the type; the non-Windows stub returns `Err(NOT_YET)` instead of constructing variants |
| `AgentParent::AppData` | `skills.rs:178` | Constructed only inside `#[cfg(windows)]` AGENTS entries (OpenCode roaming dir) | Same pattern as `Status` — enum is cross-platform, construction is Windows-only |

## Verification

```
$ cargo clean -p platform-macos && cargo clean -p cua-driver
$ cargo build --release -p cua-driver 2>&1 | grep -c '^warning:'
0
```

Same `cargo build` was producing 5 warnings before this PR (3 in `platform-macos`, 2 in `cua-driver`).

## Why not just delete everything

For `Snapshot::diff`: the doc comment in the source clearly designs it as a testable extraction of the diff logic, so deleting it would force the unit tests to inline the diff (or delete the unit tests). The `#[allow(dead_code)]` preserves the test surface.

For `Status` + `AgentParent::AppData`: the variants ARE constructed, just on a different OS than where I run the build. Deleting them would break the Windows build. The `#[allow]` is the right tool for "construction is cfg-gated; enum definition is cross-platform."

## Test plan
- [x] Clean rebuild on this Mac → 0 warnings
- [x] All test binaries still link (the `Snapshot::diff` unit tests still compile)
- [ ] Spot-check on Windows that `Status` + `AgentParent::AppData` still construct (cfg paths untouched)
- [ ] CodeRabbit pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused code constants and internal fields from platform-specific implementations to improve maintainability.
  * Added compiler directives and documentation to optimize handling of platform-specific code paths and reduce unnecessary warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1714?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->