### PR TITLE
fix(cua-driver): parse uninstall.sh under macOS /bin/bash (bash 3.2)

### DIFF
--- a/libs/cua-driver/scripts/uninstall.sh
+++ b/libs/cua-driver/scripts/uninstall.sh
@@ -361,9 +361,9 @@ def invokes_cua_driver_rs(server):
     # explicit ".cua-driver-rs" segment. Plain "cua-driver" alone is
     # ambiguous (the Swift binary uses the same filename). The shared
     # /Applications/CuaDriver.app path is ALSO ambiguous (Rust took
-    # over Swift's bundle id) — only count it as Rust when a Rust
-    # install marker is on disk; otherwise it's almost certainly a
-    # Swift registration we shouldn't scrub.
+    # over the Swift bundle id) — only count it as Rust when a Rust
+    # install marker is on disk; otherwise it is almost certainly a
+    # Swift registration we should not scrub.
     if home_dir and home_dir in joined:
         return True
     if "CuaDriverRs.app" in joined or ".cua-driver-rs" in joined or "cua-driver-rs" in joined:


### PR DESCRIPTION
## What

Fixes the cua-driver uninstaller `libs/cua-driver/scripts/uninstall.sh` so it parses under **bash 3.2** — the `/bin/bash` shipped on macOS and the exact shell the documented one-liner invokes (`/bin/bash -c "$(curl -fsSL …/uninstall.sh)"`).

Closes #1722.

## Why

Under bash 3.2.57 the script aborts before doing anything:

```
uninstall.sh: line 324: unexpected EOF while looking for matching `)'
uninstall.sh: line 694: syntax error: unexpected end of file
```

bash 3.2 has a parser bug where a here-document inside a `$( … )` command substitution is **not** skipped while scanning for the closing `)`. The Rust-branch Python here-doc (`python3 <<'PY'`) carried three apostrophes in comments — `Swift's`, `it's`, `shouldn't` — an **odd** count, so bash 3.2 entered a phantom single-quoted string, never matched the `)`, and ran to EOF. The Swift branch's equivalent here-doc was already apostrophe-free, which is why only the Rust branch tripped. bash 4+/5+ (e.g. Homebrew bash) parse it correctly, so it only bites users running the documented `/bin/bash` flow.

## Change

Reword those three comment lines to drop the contractions/possessives so the here-doc no longer contains unbalanced single quotes. **No behavioral change** — comments only.

## Verification

```console
$ /bin/bash --version | head -1
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)

# before
$ /bin/bash -n libs/cua-driver/scripts/uninstall.sh
uninstall.sh: line 324: unexpected EOF while looking for matching `)'
uninstall.sh: line 694: syntax error: unexpected end of file

# after
$ /bin/bash -n libs/cua-driver/scripts/uninstall.sh && echo OK
OK
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation in the uninstall script to clarify bundle-path handling logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->