### PR TITLE
feat(cua-driver-rs)(platform-windows,platform-linux): glide agent cursor to the field on set_value/type_text

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -681,6 +681,19 @@ impl Tool for TypeTextTool {
                 }
             }
         };
+        // Pulse the agent cursor onto the field being typed into (when an
+        // element_index is supplied) so the viewer sees *where* typing happens.
+        if let Some(idx) = args.opt_u64("element_index") {
+            let idx = idx as usize;
+            if let Ok(Ok((bx, by, bw, bh))) =
+                tokio::task::spawn_blocking(move || crate::atspi::get_element_bounds(pid, idx)).await
+            {
+                crate::overlay::send_command(cursor_overlay::OverlayCommand::ClickPulse {
+                    x: bx as f64 + bw as f64 / 2.0,
+                    y: by as f64 + bh as f64 / 2.0,
+                });
+            }
+        }
         let text_len = text.chars().count();
         let result = tokio::task::spawn_blocking(move || {
             crate::input::send_type_text(xid, &text)
@@ -849,6 +862,18 @@ impl Tool for SetValueTool {
         let idx = match args.require_u64("element_index") { Ok(v) => v as usize, Err(e) => return e };
         let value = match args.require_str("value") { Ok(v) => v, Err(e) => return e };
         let value_for_task = value.clone();
+        // Pulse the agent cursor onto the target element before writing, so a
+        // value write gets the same visual feedback as a click — the viewer can
+        // see *where* the agent is acting. No-op when the element bounds can't
+        // be resolved or the overlay is disabled.
+        if let Ok(Ok((bx, by, bw, bh))) =
+            tokio::task::spawn_blocking(move || crate::atspi::get_element_bounds(pid, idx)).await
+        {
+            crate::overlay::send_command(cursor_overlay::OverlayCommand::ClickPulse {
+                x: bx as f64 + bw as f64 / 2.0,
+                y: by as f64 + bh as f64 / 2.0,
+            });
+        }
         let result = tokio::task::spawn_blocking(move || {
             crate::atspi::set_value(pid, idx, &value_for_task)
         }).await;

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -2366,6 +2366,19 @@ impl Tool for TypeTextTool {
         // duration of the keystrokes (both XAML/UIA and PostMessage paths).
         pin_overlay_above(hwnd);
 
+        // Glide the agent cursor onto the field being typed into, so the viewer
+        // can see *where* the agent is typing — same visual feedback as a click.
+        // Only when an element_index is supplied (we have its cached center);
+        // the focused-element path has no resolvable position to point at.
+        if let Some(idx) = elem_idx {
+            if let Some((cx, cy)) = self.state.element_cache.get_element_center(pid, hwnd, idx as usize) {
+                overlay_glide_to(cx as f64, cy as f64).await;
+                crate::overlay::send_command(cursor_overlay::OverlayCommand::ClickPulse {
+                    x: cx as f64, y: cy as f64,
+                });
+            }
+        }
+
         // CUA-543 routing: PostMessage WM_CHAR doesn't reach modern
         // XAML / WinUI3 hosts. When the target is one of those AND the
         // caller has supplied an element_index, route through UIA
@@ -2828,6 +2841,18 @@ impl Tool for SetValueTool {
             Some(v) => v.to_owned(),
             None    => return ToolResult::error("Missing required string field value."),
         };
+
+        // Glide the agent cursor onto the target element before writing its
+        // value, so a value write gets the same visual feedback as a click —
+        // the viewer can see *where* the agent is acting. No-op when the
+        // overlay is disabled or the element has no cached center.
+        if let Some((cx, cy)) = self.state.element_cache.get_element_center(pid, hwnd, idx) {
+            pin_overlay_above(hwnd);
+            overlay_glide_to(cx as f64, cy as f64).await;
+            crate::overlay::send_command(cursor_overlay::OverlayCommand::ClickPulse {
+                x: cx as f64, y: cy as f64,
+            });
+        }
 
         let state = self.state.clone();
         let result = tokio::task::spawn_blocking(move || -> anyhow::Result<String> {


### PR DESCRIPTION
## What

The agent-cursor overlay previously only glided to **click** targets. During `set_value` and `type_text` the cursor never moved to the field, so recordings showed fields filling with no indication of *where* the agent was acting.

This moves the agent cursor onto the target element before the write — reusing the same overlay helpers the click path already uses — whenever an `element_index` is supplied.

## Changes

- **Windows** (`platform-windows/src/tools/impl_.rs`): `SetValueTool` and `TypeTextTool` now `pin_overlay_above` + `overlay_glide_to(center)` + `ClickPulse` before writing.
- **Linux** (`platform-linux/src/tools/impl_.rs`): `SetValueTool` and `TypeTextTool` resolve `atspi::get_element_bounds` and `ClickPulse` at the element center (mirrors the existing click path).
- **macOS**: already animated the cursor (`AgentCursor.animateAndWait`) in both tools — no change.

The glide only fires when an `element_index` is provided (where a position is resolvable); the "type into the focused element" path is unchanged.

## Testing

- Windows: `cargo build -p cua-driver` ✅
- Linux / macOS not built on the authoring host (Windows). Linux change mirrors the existing click pattern; macOS was already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual cursor animation and click pulse feedback for element-focused text entry operations
  * Added visual cursor animation and click pulse feedback for element-focused value setting operations
  * Available on both Linux and Windows platforms

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->