### PR TITLE
ci(cua-driver): add SPDX header check workflow (warn-only)

### DIFF
--- a/.github/workflows/ci-spdx-headers.yml
+++ b/.github/workflows/ci-spdx-headers.yml
@@ -1,0 +1,54 @@
+name: "CI: SPDX Headers"
+
+# Verifies that every cua-driver source file carries an SPDX-License-Identifier
+# header. Currently warn-only (continue-on-error: true) while we stamp the
+# existing tree in a separate sweep PR; will be flipped to enforcing once the
+# tree is clean. See scripts/spdx-headers.py for the applier and the runbook.
+
+on:
+  pull_request:
+    paths:
+      - "libs/cua-driver/**/*.swift"
+      - "libs/cua-driver/**/*.rs"
+      - "scripts/spdx-headers.py"
+      - ".github/workflows/ci-spdx-headers.yml"
+  push:
+    branches: [main]
+    paths:
+      - "libs/cua-driver/**/*.swift"
+      - "libs/cua-driver/**/*.rs"
+      - "scripts/spdx-headers.py"
+
+jobs:
+  check:
+    name: Check SPDX headers (warn-only)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check SPDX headers
+        id: spdx
+        continue-on-error: true
+        run: python3 scripts/spdx-headers.py --check libs/cua-driver
+
+      - name: Show help if check failed
+        if: steps.spdx.outcome == 'failure'
+        run: |
+          echo ""
+          echo "╔══════════════════════════════════════════════════════════════════╗"
+          echo "║                Missing SPDX-License-Identifier headers            ║"
+          echo "╠══════════════════════════════════════════════════════════════════╣"
+          echo "║                                                                  ║"
+          echo "║  This check is WARN-ONLY today; it will become enforcing once    ║"
+          echo "║  the existing tree has been stamped in a follow-up sweep PR.     ║"
+          echo "║                                                                  ║"
+          echo "║  To stamp new files locally:                                     ║"
+          echo "║                                                                  ║"
+          echo "║    python3 scripts/spdx-headers.py --apply libs/cua-driver       ║"
+          echo "║                                                                  ║"
+          echo "║  To preview without writing:                                     ║"
+          echo "║                                                                  ║"
+          echo "║    python3 scripts/spdx-headers.py --dry-run libs/cua-driver     ║"
+          echo "║                                                                  ║"
+          echo "╚══════════════════════════════════════════════════════════════════╝"

--- a/scripts/spdx-headers.py
+++ b/scripts/spdx-headers.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Add or verify SPDX + copyright headers on cua-driver source files.
+
+Two modes:
+  --apply (default): insert the header on files that lack it
+  --check:           exit 1 if any tracked file is missing the header (use in CI)
+
+Header format (matches Linux-kernel / Rust ecosystem convention):
+
+  // SPDX-License-Identifier: MIT
+  // Copyright (c) 2026 Cua AI, Inc.
+  //
+  // <blank line>
+  // <original file content>
+
+The script is idempotent: it skips any file that already contains an
+SPDX-License-Identifier marker in its first 2 KiB.
+
+Typical use:
+  scripts/spdx-headers.py                     # apply to libs/cua-driver
+  scripts/spdx-headers.py libs/cua-driver-rs  # apply to a different tree
+  scripts/spdx-headers.py --check             # CI gate
+  scripts/spdx-headers.py --dry-run           # preview only
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+from typing import Iterable
+
+LICENSE_ID = "MIT"
+COPYRIGHT_HOLDER = "Cua AI, Inc."
+COPYRIGHT_YEAR = "2026"
+
+HEADER_LINES = [
+    f"// SPDX-License-Identifier: {LICENSE_ID}",
+    f"// Copyright (c) {COPYRIGHT_YEAR} {COPYRIGHT_HOLDER}",
+    "",
+]
+MARKER = "SPDX-License-Identifier"
+EXTENSIONS = {".swift", ".rs"}
+SKIP_DIR_NAMES = {"target", ".build", "build", "node_modules", "DerivedData", ".git"}
+DEFAULT_ROOT = "libs/cua-driver"
+
+
+def file_has_header(path: pathlib.Path) -> bool:
+    try:
+        head = path.read_bytes()[:2048].decode("utf-8", errors="replace")
+    except OSError:
+        return True  # don't try to rewrite unreadable files
+    return MARKER in head
+
+
+def insert_header(path: pathlib.Path) -> None:
+    body = path.read_text(encoding="utf-8")
+    path.write_text("\n".join(HEADER_LINES) + "\n" + body, encoding="utf-8")
+
+
+def iter_source_files(root: pathlib.Path) -> Iterable[pathlib.Path]:
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix not in EXTENSIONS:
+            continue
+        if any(part in SKIP_DIR_NAMES for part in path.parts):
+            continue
+        yield path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("root", nargs="?", default=DEFAULT_ROOT, help=f"directory to scan (default: {DEFAULT_ROOT})")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--apply", action="store_true", help="insert headers on files that lack them (default)")
+    mode.add_argument("--check", action="store_true", help="exit 1 if any file is missing a header")
+    mode.add_argument("--dry-run", action="store_true", help="report what would change without writing")
+    args = parser.parse_args()
+
+    root = pathlib.Path(args.root).resolve()
+    if not root.exists():
+        print(f"error: {root} does not exist", file=sys.stderr)
+        return 2
+
+    apply_mode = args.apply or not (args.check or args.dry_run)
+    missing: list[pathlib.Path] = []
+    touched = 0
+    skipped = 0
+
+    for path in iter_source_files(root):
+        if file_has_header(path):
+            skipped += 1
+            continue
+        missing.append(path)
+        rel = path.relative_to(root)
+        if apply_mode:
+            insert_header(path)
+            touched += 1
+            print(f"+ {rel}")
+        elif args.dry_run:
+            print(f"would add header: {rel}")
+        else:  # --check
+            print(f"missing header: {rel}")
+
+    print()
+    if args.check:
+        if missing:
+            print(f"error: {len(missing)} file(s) missing SPDX header under {root}", file=sys.stderr)
+            return 1
+        print(f"ok: all {skipped} source files under {root} carry SPDX headers")
+        return 0
+
+    if args.dry_run:
+        print(f"would add headers to {len(missing)} file(s); {skipped} already have one")
+        return 0
+
+    print(f"added headers to {touched} file(s); {skipped} already had one")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds `scripts/spdx-headers.py` — idempotent applier/checker for `// SPDX-License-Identifier: MIT` + `// Copyright (c) 2026 Cua AI, Inc.` headers on every `.swift` / `.rs` file under `libs/cua-driver/`
- Adds `.github/workflows/ci-spdx-headers.yml` — warn-only CI gate (`continue-on-error: true`) that runs the checker on PRs touching cua-driver sources
- **Does NOT stamp the existing tree.** That's a follow-up sweep PR. Today, 297 source files would be flagged; the warning lands on every relevant PR until we sweep.

## Why now

[EYHN/kwwk-computer-use-core#6](https://github.com/EYHN/kwwk-computer-use-core/issues/6) — a downstream Swift repo ported substantial code from `cua-driver`'s `AppState.swift` and `SkyLightEventPost.swift` without preserving the MIT copyright notice. Three days later, zero engagement on the issue.

Per-file SPDX headers:
- Make attribution stripping mechanically obvious (it stops being "we missed the LICENSE file" and becomes "they deleted the header")
- Give us stronger, file-by-file evidence in any future GitHub DMCA filing
- Are the standard convention across Rust ecosystem, Linux kernel, and modern OSS — low friction for contributors

## Sequencing

1. **This PR** — script + warn-only CI. Zero conflicts with in-flight PRs (only adds new files). ← *you are here*
2. **Follow-up sweep PR** — runs `scripts/spdx-headers.py --apply libs/cua-driver` once. Single mechanical commit touching ~297 files. Timed for a quiet merge window to minimize rebase pain on the ~9 currently-open PRs that touch cua-driver sources.
3. **Enforcement flip PR** — removes `continue-on-error: true` from the workflow. One-line diff.

## Script usage

```bash
# Preview what would change without writing
python3 scripts/spdx-headers.py --dry-run libs/cua-driver

# Stamp files that lack headers
python3 scripts/spdx-headers.py --apply libs/cua-driver

# CI-mode: exit 1 if anything is missing
python3 scripts/spdx-headers.py --check libs/cua-driver
```

The script is idempotent — it skips any file that already contains an `SPDX-License-Identifier` marker in its first 2 KiB. Safe to re-run on partially stamped trees, safe to run in `--apply` mode locally before opening a PR.

## Test plan

- [x] `--dry-run` reports 297 files would receive headers, 0 already have them
- [x] `--check` exits 1 with file list when headers are missing
- [x] YAML workflow validates cleanly (parsed via `ruby -ryaml`)
- [ ] CI workflow runs on this PR and emits the warn-only output (will verify after push)
- [ ] Workflow message renders correctly in the GitHub Actions UI

## Out of scope

- Stamping existing files (separate sweep PR)
- Flipping CI to enforcing (separate one-line PR after sweep lands)
- Trademark policy + DMCA runbook (separate work tracks)
- Extending headers to TypeScript / Python source — happy to follow up if the team agrees, but cua-driver is the highest-priority surface given the kwwk incident specifically involved Swift code derived from it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Actions workflow for automated SPDX header validation during pull requests and pushes to main
  * Added script with check, apply, and dry-run modes for managing SPDX license headers in source files

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1732?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->