### PR TITLE
ci(cd-rust-cua-driver): pin macOS build to macos-26 runner

### DIFF
--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -163,13 +163,20 @@ jobs:
 
   # ── macOS universal (arm64 + x86_64 → lipo) ─────────────────────────────────
   # Mirrors cd-swift-cua-driver.yml's approach: build both arches in one job
-  # on macos-15, then combine into a universal binary via `lipo -create`.
+  # on macos-26, then combine into a universal binary via `lipo -create`.
   # The same universal binary is used in BOTH the arm64 and x86_64 named
   # tarballs (so callers that download by arch still get the universal
   # binary), plus a third `darwin-universal` tarball and a bare binary.
+  #
+  # Runner pinned to macos-26 because `screencapturekit` (added in PR #1720
+  # for the native ScreenCaptureKit recording backend) pulls in
+  # `apple-metal v0.8.7`, whose Swift bridge references macOS 26 Metal
+  # symbols (`MTLSamplerReductionMode`, `MTLSamplerDescriptor.reductionMode`,
+  # `.lodBias`). The macos-15 runner ships a macOS 15 SDK that doesn't
+  # expose those symbols, so the transitive Swift bridge fails to compile.
   build-macos-universal:
     name: darwin-universal
-    runs-on: macos-15
+    runs-on: macos-26
     # Notarize on tag push (real release); on workflow_dispatch honor the
     # `notarize` input so we can iterate on the build pipeline without
     # touching the Apple notary service.


### PR DESCRIPTION
## Why

v0.3.0 CD failed on `darwin-universal`:

\`\`\`
.../apple-metal-0.8.7/swift-bridge/Sources/AppleMetalBridge/State.swift:128:
  error: cannot find 'MTLSamplerReductionMode' in scope
  error: value of type 'MTLSamplerDescriptor' has no member 'reductionMode'
  error: value of type 'MTLSamplerDescriptor' has no member 'lodBias'
\`\`\`

Dep chain:

\`\`\`
cua-driver → platform-macos → screencapturekit v6.0.1 → apple-metal v0.8.7
\`\`\`

`apple-metal v0.8.7` uses `#available(macOS 26.0, *)`-guarded Swift code that references symbols only present in the **macOS 26 SDK**. The `macos-15` runner ships a macOS 15 SDK, so the Swift bridge fails to compile even though the code is gated by `if #available`.

`screencapturekit = "6"` was added in #1720 to ship the native ScreenCaptureKit recording backend.

## Change

Single line: `runs-on: macos-15` → `runs-on: macos-26` in the `build-macos-universal` job, plus an inline comment recording the why for future me.

macOS 26 runners are available now per [actions/runner-images#13739](https://github.com/actions/runner-images/issues/13739).

## Out of scope

The Swift CI/CD workflows (`cd-swift-cua-driver.yml`, `cd-swift-lume.yml`, `ci-swift-*.yml`) also pin `macos-15`. Leaving them on macos-15 for now — they don't share the apple-metal transitive and have their own release cadence.

## Test plan

- [x] Workflow YAML still parses (no syntax changes beyond the runner label + comment)
- [ ] After merge: re-trigger bump for cua-driver-rs (patch → v0.3.1) and confirm `darwin-universal` job now passes, release publishes all 6 platform asset sets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build environment from macOS 15 to macOS 26 for the universal binary build.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1733?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->