### PR TITLE
ci: drop BASALT matrix entry from periodic Linux Cloud VM test

### DIFF
--- a/.github/workflows/periodic-test-linux-cloud-vm.yml
+++ b/.github/workflows/periodic-test-linux-cloud-vm.yml
@@ -18,7 +18,6 @@ jobs:
       matrix:
         secret_name:
           - PERIODIC_TEST_CUA_API_KEY
-          # - PERIODIC_TEST_CUA_API_KEY_BASALT
 
     steps:
       - name: Checkout latest main


### PR DESCRIPTION
Remove the commented-out PERIODIC_TEST_CUA_API_KEY_BASALT secret from the matrix entirely so it no longer lingers in the workflow file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal testing workflow configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1747?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->