### PR TITLE
fix(cua-driver): make uninstall.ps1 one-liner iex-safe (drop param() block)

### DIFF
--- a/libs/cua-driver/scripts/uninstall.ps1
+++ b/libs/cua-driver/scripts/uninstall.ps1
@@ -8,9 +8,16 @@
 # Usage (one-liner — recommended):
 #   irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.ps1 | iex
 #
-# Force (no prompts):
-#   $forceArgs = @('-Force')
-#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.ps1))) @forceArgs
+# Force (skip all prompts):
+#   $env:CUA_DRIVER_RS_UNINSTALL_FORCE = '1'
+#   irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.ps1 | iex
+#
+# Why an env var and not a `-Force` parameter: `iex` (Invoke-Expression)
+# refuses to parse a script that opens with `[CmdletBinding()] param(...)`
+# — the natural one-liner above otherwise fails with
+# "Unexpected attribute 'CmdletBinding'" at parse time. Reading the flag
+# from $env: keeps the body iex-safe, and the env var inherits across
+# the self-elevation re-exec for free (no -ArgumentList forwarding).
 #
 # What gets removed:
 #   - Scheduled Task 'cua-driver-serve' (autostart entry registered by
@@ -46,11 +53,13 @@
 #                                     v0.2.13 and earlier used .cua-driver-rs —
 #                                     that legacy path is always cleaned up too)
 #
-# Params:
-#   -Force      non-interactive: skip the "remove? [y/N]" prompt before
+# Env (force mode):
+#   $env:CUA_DRIVER_RS_UNINSTALL_FORCE
+#               non-interactive: skip the "remove? [y/N]" prompt before
 #               each major delete. The one-liner is interactive by
 #               default so a stray paste doesn't accidentally wipe a
-#               working install.
+#               working install. Inherited automatically by the elevated
+#               re-exec child (see Elevation below).
 #
 # Elevation:
 #   `install.ps1 -AutoStart` (and `cua-driver autostart enable`) register
@@ -64,14 +73,18 @@
 #   we self-elevate via UAC; otherwise we run in-place. Mirrors the
 #   install side's elevation pattern in autostart.rs:215-223.
 
-[CmdletBinding()]
-param(
-    [switch]$Force
-)
-
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
+
+# $Force is read from the environment so the script body stays iex-safe.
+# `[CmdletBinding()]` / `param()` declarations are only legal at the start
+# of a script-file, function, or scriptblock — NOT inside an
+# Invoke-Expression'd string — so `irm <url> | iex` parses with
+# "Unexpected attribute 'CmdletBinding'" if we keep a formal param block.
+# Env var also inherits across the self-elevation re-exec automatically,
+# so we don't need to plumb -Force through -ArgumentList.
+$Force = [bool]$env:CUA_DRIVER_RS_UNINSTALL_FORCE
 
 # ---------- Elevation pre-check -------------------------------------------
 
@@ -109,8 +122,10 @@ if (-not (Test-IsElevated) -and (Test-NeedsElevation)) {
     # from a file on disk; empty when piped through `irm ... | iex` (the
     # canonical one-liner). For the iex case we materialize the script body
     # to a tempfile and re-exec from there — RunAs needs a file path.
-    $forwarded = @()
-    if ($Force) { $forwarded += '-Force' }
+    #
+    # No -Force forwarding needed: $env:CUA_DRIVER_RS_UNINSTALL_FORCE
+    # already lives in this process's env if the user opted in, and
+    # Start-Process inherits the current env into the elevated child.
 
     $scriptPath = $MyInvocation.MyCommand.Path
     if (-not $scriptPath) {
@@ -120,7 +135,7 @@ if (-not (Test-IsElevated) -and (Test-NeedsElevation)) {
         $scriptPath = $tmp
     }
 
-    $argList = @('-ExecutionPolicy', 'Bypass', '-NoProfile', '-File', $scriptPath) + $forwarded
+    $argList = @('-ExecutionPolicy', 'Bypass', '-NoProfile', '-File', $scriptPath)
     try {
         $proc = Start-Process -FilePath powershell.exe -ArgumentList $argList -Verb RunAs -PassThru -Wait -ErrorAction Stop
         exit $proc.ExitCode


### PR DESCRIPTION
## Summary

- The documented one-liner `irm <url>/scripts/uninstall.ps1 | iex` crashes at parse time with `Unexpected attribute 'CmdletBinding'` because `[CmdletBinding()] param([switch]$Force)` is only legal at the start of a script-file, function, or scriptblock — **not** inside an `Invoke-Expression`'d string.
- Replace the formal param block with an env var (`$env:CUA_DRIVER_RS_UNINSTALL_FORCE`). Env vars inherit across `Start-Process … -Verb RunAs`, so the `-Force` argument-forwarding plumbing in the self-elevation re-exec collapses too.
- Doc block updated to show the new force-mode usage and explain *why* it's an env var (so a future contributor doesn't reintroduce the param block).

## Repro (before this PR)

```
PS> irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.ps1 | iex
iex : At line:67 char:1
+ [CmdletBinding()]
+ ~~~~~~~~~~~~~~~~~
Unexpected attribute 'CmdletBinding'.
At line:68 char:1
+ param(
+ ~~~~~
Unexpected token 'param' in expression or statement.
```

## After

```
# Interactive (asks before each major delete):
irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.ps1 | iex

# Force (skip all prompts):
$env:CUA_DRIVER_RS_UNINSTALL_FORCE = '1'
irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.ps1 | iex
```

Force flag survives the self-elevation re-exec (env inherits into the elevated child via `Start-Process`), so no `-ArgumentList` forwarding needed.

## Test plan

- [x] Parser-level: `[System.Management.Automation.Language.Parser]::ParseFile` on the patched file → 0 errors.
- [x] iex-level: piped the patched script through `Invoke-Expression` up to the elevation pre-check.
  - env unset → `$Force = False` ✓
  - `$env:CUA_DRIVER_RS_UNINSTALL_FORCE = '1'` → `$Force = True` ✓
- [ ] End-to-end on a fresh box: install via `install.ps1` then run the new one-liner.
- [ ] End-to-end force path: same as above with the env var set, confirm no prompts.

## Follow-up — `install.ps1` has the same bug

`scripts/install.ps1` opens with the same `[CmdletBinding()] param(...)` block (L76-88) and reproduces the same parser error under `iex`:

```
PS> irm <url>/scripts/install.ps1 | iex
At line:78 char:33
+     [string]$Release = "latest",
+                                 ~
Missing expression after ','.
Missing ')' in function parameter list.
```

Three params there (`-Release`, `-AutoStart`/`-NoAutoStart`, `-NoPathUpdate`) → more API surface to translate, so deliberately left for a separate PR. Tracking issue worth opening if not already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored the uninstall script to use environment-based configuration instead of command-line parameters, improving compatibility with remote execution methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1750?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->