### PR TITLE
feat(cua-driver-rs)(macos): enable Chromium/Electron AX trees (AXManualAccessibility) for get_window_state

### DIFF
--- a/libs/cua-driver/rust/crates/platform-macos/src/ax/bindings.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/ax/bindings.rs
@@ -287,6 +287,33 @@ pub unsafe fn set_bool_attr_true(element: AXUIElementRef, attr_name: &str) -> AX
     AXUIElementSetAttributeValue(element, attr.as_concrete_TypeRef(), cf_true.as_CFTypeRef())
 }
 
+/// Signal to a Chromium/Electron application root that a real assistive client
+/// is present so it materializes its full web-content accessibility tree.
+///
+/// Returns `true` when an attribute write was accepted — meaning the app was
+/// flipped from "tree off" to "tree building" and the caller should let the
+/// tree settle before walking. Returns `false` when the app does not support
+/// either attribute (native Cocoa apps such as Finder / Calculator / TextEdit),
+/// in which case no settle delay is warranted.
+///
+/// `AXManualAccessibility` is the modern opt-in with no screen-reader side
+/// effects; `AXEnhancedUserInterface` is the legacy fallback some Electron
+/// builds expose instead (the modern attribute returns
+/// `kAXErrorAttributeUnsupported` on those builds).
+pub unsafe fn enable_chromium_accessibility(app_element: AXUIElementRef) -> bool {
+    let manual = set_bool_attr_true(app_element, "AXManualAccessibility");
+    if manual == kAXErrorSuccess {
+        return true;
+    }
+    if manual != kAXErrorAttributeUnsupported {
+        // A transient error (e.g. timeout / app busy) rather than a hard
+        // "this app has no such attribute" — don't bother with the legacy
+        // fallback, and don't claim enablement happened.
+        return false;
+    }
+    set_bool_attr_true(app_element, "AXEnhancedUserInterface") == kAXErrorSuccess
+}
+
 /// Get the CGWindowID of an AX window element via the private `_AXUIElementGetWindow` SPI.
 /// Returns `None` if the element is not a composited window.
 pub unsafe fn ax_get_window_id(element: AXUIElementRef) -> Option<u32> {

--- a/libs/cua-driver/rust/crates/platform-macos/src/ax/tree.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/ax/tree.rs
@@ -12,6 +12,8 @@
 
 use super::bindings::*;
 use core_foundation::base::{CFRelease, CFRetain, CFTypeRef};
+use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
 
 /// Maximum depth for AX tree walks. Deep menus and complex web views can
 /// nest deeply; 25 covers realistic app chrome without exploding on
@@ -24,6 +26,22 @@ const MAX_DEPTH: usize = 25;
 /// When the cap is hit the walk stops early and the partial tree is returned
 /// with a warning line appended (mirrors Swift reference implementation).
 const MAX_ELEMENTS: usize = 2_000;
+
+/// How long to let a freshly-enabled Chromium/Electron app build its
+/// web-content AX tree before we read it. The tree is materialized
+/// asynchronously over IPC once the app detects an assistive client, so a
+/// walk that starts immediately sees only the chrome (title bar, a handful
+/// of elements). This settle is paid at most once per pid — see
+/// `enabled_pids`.
+const CHROMIUM_SETTLE_SECONDS: f64 = 0.5;
+
+/// Pids for which we have already flipped on accessibility and paid the
+/// one-time settle delay. Repeat snapshots of the same app skip the settle:
+/// the tree is already built and stays built for the life of the process.
+fn enabled_pids() -> &'static Mutex<HashSet<i32>> {
+    static ENABLED_PIDS: OnceLock<Mutex<HashSet<i32>>> = OnceLock::new();
+    ENABLED_PIDS.get_or_init(|| Mutex::new(HashSet::new()))
+}
 
 /// A single node in the AX tree.
 #[derive(Debug, Clone)]
@@ -81,6 +99,23 @@ pub fn walk_tree(pid: i32, window_id: Option<u32>, query: Option<&str>) -> TreeW
         let app_elem = AXUIElementCreateApplication(pid);
         if app_elem.is_null() {
             return TreeWalkResult { tree_markdown: String::new(), nodes, truncated: false };
+        }
+
+        // Chromium/Electron apps (Arc, VS Code, Electron shells) ship their
+        // web-content AX tree OFF and only build it once an assistive client
+        // asks for it. Without this, the first walk of such an app returns an
+        // empty/title-bar-only tree (#1616). Flip the enablement attribute,
+        // then — only when the flip actually took and only the first time we
+        // see this pid — let the asynchronously-built tree settle before we
+        // read it. Native Cocoa apps reject the attribute, so they pay no
+        // settle cost. This relies on the MAX_ELEMENTS node cap to keep the
+        // now-materialized (potentially large) tree bounded.
+        let already_enabled = enabled_pids().lock().map(|s| s.contains(&pid)).unwrap_or(false);
+        if !already_enabled && enable_chromium_accessibility(app_elem) {
+            crate::permissions::panel::pump_run_loop_briefly(CHROMIUM_SETTLE_SECONDS);
+            if let Ok(mut set) = enabled_pids().lock() {
+                set.insert(pid);
+            }
         }
 
         // Union AXChildren + AXWindows — the only way to see background windows.


### PR DESCRIPTION
## Problem

Chromium-based apps (Arc, VS Code, Electron shells) ship their web-content accessibility tree **off** and only build it once an assistive client requests it. Without enablement, the first `get_window_state` AX walk of such an app returns an empty / title-bar-only tree — the macOS/AX analog of the empty-tree symptom tracked in #1616 (VS Code exposing only its title-bar elements). With enablement the full tree materializes.

## Change

In `walk_tree`'s app-setup path (right after `AXUIElementCreateApplication(pid)`):

1. **Enable** — set `AXManualAccessibility = true` on the app root (the modern, side-effect-free opt-in). If the app reports the attribute unsupported (`kAXErrorAttributeUnsupported` / -25205), fall back to `AXEnhancedUserInterface = true` (the legacy flag some Electron builds expose instead). Native Cocoa apps (Finder, Calculator, TextEdit) reject both — they take no further action.
2. **Settle** — the tree is built asynchronously over IPC once the app detects the client, so a walk that starts immediately still sees only the chrome. When the flip actually took, pump the run loop ~500ms (reusing the existing `pump_run_loop_briefly` helper) so the tree has time to materialize before the walk reads it.
3. **Per-pid cache** — a process-global `HashSet<pid>` (guarded by a `Mutex` in a `OnceLock`) records pids we've already enabled + settled. Repeat snapshots of the same app skip the settle; the tree is already built and stays built for the life of the process.

The settle delay fires **only** when enablement actually flips an app from unsupported→supported, so apps that never needed it (every native Cocoa app) pay zero added latency.

## Hard dependency

This is intentionally higher-risk and **must land after the Phase 1 messaging-timeout PR**. Enablement makes the tree *bigger* (fully materialized instead of empty/partial) — which is exactly why it depends on the per-element AX messaging timeout (so a wedged element fails fast rather than stalling the now-larger walk) plus the node cap to keep the materialized tree bounded. Shipping this without those bounds would trade "empty/partial" for "complete but potentially huge."

## Test

- `cargo build --release -p cua-driver` passes.
- `cargo test --no-run -p platform-macos` compiles cleanly (the crate's test binary has a pre-existing, unrelated `libswift_Concurrency.dylib` rpath issue at the *run* step only).
- macOS-only change; platform-windows / platform-linux are untouched.

Refs #1616

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility support for Chromium and Electron-based applications on macOS. The system now properly enables accessibility features and allows adequate initialization time, preventing incomplete or missing accessibility information when first accessing these applications and improving overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->