### PR TITLE
fix(cua-driver-rs)(macos): don't raise a terminal-attributed TCC prompt from `call check_permissions`

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -903,6 +903,41 @@ pub fn run_call(
             crate::serve::default_socket_path()
         }
     };
+    // macOS: `check_permissions` with prompt:true raises a TCC dialog. Run
+    // in-process from a terminal, that dialog attributes to the *terminal*
+    // (LaunchServices' "responsible" process), not to com.trycua.driver —
+    // so the grant lands on the wrong app and never sticks for the driver.
+    // When we're a bundle CLI spawned from a terminal (should_use_daemon_proxy)
+    // and there's no daemon to route through, DON'T raise the mis-attributed
+    // prompt: degrade to report-only and tell the user the one launch that
+    // grants correctly (`open … CuaDriver --args serve`, which raises the
+    // dialog as CuaDriver and waits for the grant). We deliberately do NOT
+    // auto-spawn that daemon here — a `call` shouldn't leave a background
+    // daemon behind, and the first-launch gate can lag socket creation.
+    #[cfg(target_os = "macos")]
+    let json_args = {
+        let mut effective = json_args;
+        let wants_prompt = effective
+            .as_ref()
+            .and_then(|v| v.get("prompt"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true); // check_permissions defaults prompt:true
+        if tool == "check_permissions"
+            && wants_prompt
+            && !crate::serve::is_daemon_listening(&socket_path)
+            && should_use_daemon_proxy(false)
+        {
+            eprintln!(
+                "cua-driver-rs: reporting permission status only. A prompt raised from \
+                 this terminal would attribute to the terminal, not CuaDriver, so the \
+                 grant wouldn't apply to the driver. To grant correctly, launch the \
+                 driver as its own app:\n  open -n -g -a CuaDriver --args serve\n\
+                 then approve the CuaDriver dialog in System Settings."
+            );
+            effective = Some(serde_json::json!({ "prompt": false }));
+        }
+        effective
+    };
     if crate::serve::is_daemon_listening(&socket_path) {
         let args_for_daemon = json_args.clone()
             .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));


### PR DESCRIPTION
## Problem (observed live)

`cua-driver call check_permissions` (default `prompt:true`) raised the AX / Screen-Recording dialog **in-process**. Run from a terminal, macOS attributes that dialog to the **terminal** (LaunchServices' "responsible" process), not to `com.trycua.driver` — so the prompt reads *"Terminal/Gumbranch would like to control this computer"* and the grant lands on the terminal, never on the driver. The user then "keeps getting asked for permissions despite having granted" because the grant went to the wrong app. (#1491)

## Fix

When we're a bundle CLI spawned from a terminal (`should_use_daemon_proxy`) and no daemon is up to route through, degrade `check_permissions` to **report-only** (force `prompt:false`) and print the one launch that grants correctly:

```
open -n -g -a CuaDriver --args serve
```

which raises the dialog **as CuaDriver** and stays alive while the user grants.

**Deliberately no auto-spawn from `call`:** a first attempt auto-launched that daemon on every `call`, but the first-launch permissions gate lags socket creation, so `launch_daemon_and_wait` timed out, fell back to an in-process (terminal) prompt, and `open -n` piled up zombie daemons that re-prompted in a loop. Report-only + guidance avoids all of that.

The `mcp` path is unchanged — it already routes through a LaunchServices-launched daemon (`run_mcp_via_daemon_proxy`), so its prompts already attribute to CuaDriver.

## Depends on
- #1758 (install-local now produces `/Applications/CuaDriver.app`) — without the bundle there's nothing to attribute to.

## Known separate issue (not fixed here)
`serve` launched via `open -n -g -a CuaDriver --args serve` lags socket creation on first launch (the permissions gate's re-exec cycle), while terminal-foreground `serve` is instant. Filing separately — it's why the auto-spawn approach was abandoned and is the remaining rough edge in the grant flow.

## Verified
- From a terminal: `call check_permissions` reports status + the grant hint, raises **no** prompt, spawns **no** daemon (regression gone).
- `open -n -g -a CuaDriver --args serve` launches the daemon from the bundle (ppid=1) → prompts attribute to `com.trycua.driver`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved macOS permission prompt issue where checks could trigger unexpected prompts in certain conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->