### PR TITLE
docs(cua-driver-rs): surface `permissions status|grant` in post-install hints

### DIFF
--- a/libs/cua-driver/scripts/post-install-hints.txt
+++ b/libs/cua-driver/scripts/post-install-hints.txt
@@ -5,12 +5,21 @@ Next steps:
        {{BINARY}} --version
        {{BINARY}} list-tools
 
-  2. Agent skill pack (optional):
+  2. Grant permissions (macOS — Accessibility + Screen Recording):
+       {{BINARY}} permissions status   # report status (read-only; tells you which
+                                       # identity the grants belong to)
+       {{BINARY}} permissions grant    # the correct way to grant — launches CuaDriver
+                                       # so the dialog says "Cua Driver" and the grant
+                                       # sticks to the driver, not your terminal.
+                                   # Tip: `--autostart` (above) keeps a launchd daemon
+                                   # running so you grant once and it persists.
+
+  3. Agent skill pack (optional):
        {{BINARY}} skills install   # fetch + link the cua-driver skill pack
                                    # into Claude Code / Codex / OpenClaw / OpenCode.
                                    # The install never touches your agent dirs.
 
-  3. As an MCP server — run the one matching your client. Each is also
+  4. As an MCP server — run the one matching your client. Each is also
      available via '{{BINARY}} mcp-config --client <name>':
 
      • Claude Code (computer-use compatibility mode):


### PR DESCRIPTION
Post-install "Next steps" went straight from *try it* to skills + MCP, never mentioning permissions — yet on macOS nothing works until Accessibility + Screen Recording are granted, and granting from a terminal silently attributes to the terminal, not the driver.

Adds a **Grant permissions (macOS)** step (new #2, ahead of skills/MCP since it's foundational) pointing at `cua-driver permissions status|grant` (from #1765), with a tip toward `--autostart` for grant-once persistence.

Shared template so it shows on both the curl-pipe-bash install and install-local. macOS-scoped wording; harmless on Linux/Windows (no TCC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced macOS setup instructions with new guidance for granting Accessibility and Screen Recording permissions, including steps to check current status and enable access as needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->