### PR TITLE
chore(cua-driver-rs)(install): make Rust the default backend

### DIFF
--- a/libs/cua-driver/scripts/install.sh
+++ b/libs/cua-driver/scripts/install.sh
@@ -62,10 +62,9 @@ RUST_INSTALLER_URL="https://raw.githubusercontent.com/trycua/cua/main/libs/cua-d
 # parsing without breaking forwarding, and keeps both installers' argv shapes
 # (--bin-dir, --no-modify-path) bit-compatible.
 #
-# Default backend is the Swift macOS implementation. The Rust implementation
-# is opt-in via --backend=rust / --experimental-rust, and is used
-# automatically on non-macOS hosts where the Swift build can't run.
-USE_RUST_BACKEND=0
+# Default backend is the cross-platform Rust implementation. The Swift macOS
+# implementation is opt-in via --backend=swift, and only runs on macOS.
+USE_RUST_BACKEND=1
 FORWARDED_ARGS=()
 PASSTHROUGH=0
 while [[ $# -gt 0 ]]; do
@@ -75,7 +74,7 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --experimental-rust) USE_RUST_BACKEND=1; shift ;;  # legacy alias for --backend=rust
         --backend=rust)      USE_RUST_BACKEND=1; shift ;;  # opt into the Rust implementation
-        --backend=swift)     USE_RUST_BACKEND=0; shift ;;  # explicit default — no-op
+        --backend=swift)     USE_RUST_BACKEND=0; shift ;;  # opt into the macOS-only Swift implementation
         --backend=*)
             printf 'error: unknown backend %q; supported: swift, rust\n' "${1#*=}" >&2
             exit 2
@@ -95,8 +94,8 @@ done
 
 # --- Opt-in delegation to the Rust implementation -----------------------
 #
-# The default backend is the Swift macOS implementation, but Swift only
-# runs on macOS — so on any non-macOS host we transparently promote to the
+# The Swift backend only runs on macOS — so if it was explicitly requested
+# via --backend=swift on any non-macOS host, transparently fall back to the
 # Rust implementation, which is the only one that builds there.
 OS="$(uname -s 2>/dev/null || echo unknown)"
 if [[ "$USE_RUST_BACKEND" == "0" && "$OS" != "Darwin" ]]; then
@@ -104,8 +103,8 @@ if [[ "$USE_RUST_BACKEND" == "0" && "$OS" != "Darwin" ]]; then
     USE_RUST_BACKEND=1
 fi
 
-# Hand the rest of argv to _install-rust.sh and exit. The default Swift
-# install path below is only reached when the Rust backend was not selected.
+# Hand the rest of argv to _install-rust.sh and exit. The Swift install path
+# below is only reached when --backend=swift was selected on macOS.
 if [[ "$USE_RUST_BACKEND" == "1" ]]; then
     if [[ "$OS" != "Darwin" ]]; then
         printf 'note: detected non-macOS host (%s); installing cua-driver via the Rust implementation.\n' "$OS" >&2


### PR DESCRIPTION
## What

Flip the `install.sh` backend dispatcher default from the **Swift** macOS implementation to the cross-platform **Rust** implementation.

- `USE_RUST_BACKEND` now defaults to `1`, so a plain `curl … | bash` installs the Rust backend on every platform.
- Swift becomes opt-in via `--backend=swift` (macOS only).
- The existing non-macOS guard is retained: an explicit `--backend=swift` on a non-macOS host still transparently falls back to Rust.
- Header / usage / inline comments updated to match; `--backend=rust` is now the explicit-default no-op.

## Why

Switches the default install back to the Rust driver, which is the actively-developed, cross-platform implementation.

## Notes

- `bash -n` syntax check passes.
- PowerShell installer (`install.ps1`) is unaffected — Windows is Rust-only and has no Swift default.
- No docs change: no cua-driver docs page references the backend default or the `--backend` flags.

## Separate PR

Filed on its own, separate from the agent-cursor registry fix (#1769), per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Installation script now defaults to the Rust backend instead of Swift. Users can explicitly select Swift on macOS, with automatic fallback to Rust on non-macOS systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1768?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->