### PR TITLE
fix(cua-driver-rs)(macos): sync agent-cursor registry on click

### DIFF
--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/click.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/click.rs
@@ -137,6 +137,10 @@ impl Tool for ClickTool {
                     cursor_overlay::OverlayCommand::PinAbove(wid as u64)
                 );
                 crate::cursor::overlay::animate_cursor_to(cx, cy).await;
+                // Keep the registry in sync with the overlay so
+                // get_agent_cursor_state reports a truthful position even when
+                // the click was dispatched via the AX path (no pixel coords).
+                self.state.cursor_registry.update_position("default", cx, cy);
             }
 
             // ── Focus-suppression wrap (Swift WindowChangeDetector + FocusGuard) ──
@@ -286,6 +290,8 @@ impl Tool for ClickTool {
             // Animate the visual cursor to the click point and wait for it to
             // arrive — mirrors Swift's `AgentCursor.shared.animateAndWait(to:)`.
             crate::cursor::overlay::animate_cursor_to(screen_x, screen_y).await;
+            // Keep the registry in sync with the overlay (see AX path above).
+            self.state.cursor_registry.update_position("default", screen_x, screen_y);
             // Show click-pulse on the agent cursor overlay.
             crate::cursor::overlay::send_command(
                 cursor_overlay::OverlayCommand::ClickPulse { x: screen_x, y: screen_y }


### PR DESCRIPTION
## Problem

The `click` tool has two addressing modes — **element_index (AXPress)** and **pixel (x, y)**. Both animate the agent-cursor overlay to the target, but neither wrote the resulting position back to the `CursorRegistry`. Only `move_cursor` did.

As a result, `get_agent_cursor_state` always reported `position: null` after a click, even though the overlay had moved to the element. The state query and the rendered overlay were tracked in two separate places that were never synced — so a backgrounded automation clicking via `element_index` (the recommended path) could never report where its cursor was.

## Fix

Mirror each `animate_cursor_to(...)` with a `cursor_registry.update_position("default", x, y)` call on **both** paths in `click.rs` (AX path + pixel path), so the reported state matches what is actually rendered regardless of which mode drove the click.

Pure state-reporting fix — clicking behaviour itself is unchanged.

## Verification

- `cargo check -p platform-macos` → exit 0.

## Follow-up

A docs note for `get_agent_cursor_state` (that `position` now tracks click-driven movement) will land in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cursor position tracking accuracy to ensure cursor state reporting remains synchronized with actual cursor movements during click operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1769?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->