### PR TITLE
chore(cua-driver-rs): bake 0.3.4 into install scripts

### DIFF
--- a/libs/cua-driver/scripts/_install-rust.sh
+++ b/libs/cua-driver/scripts/_install-rust.sh
@@ -419,7 +419,7 @@ done
 # the baked line hasn't been updated yet (dev / pre-release checkouts).
 #
 # ~~~ BAKED_VERSION: auto-updated by CD workflow after each release — do not edit ~~~
-CUA_DRIVER_RS_BAKED_VERSION="0.3.3"
+CUA_DRIVER_RS_BAKED_VERSION="0.3.4"
 # ~~~ END_BAKED_VERSION ~~~
 
 if [[ -n "${CUA_DRIVER_RS_VERSION:-}" ]]; then

--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -114,7 +114,7 @@ $BinaryName = "cua-driver.exe"
 # where the baked line hasn't been updated yet.
 #
 # ~~~ BAKED_VERSION: auto-updated by CD workflow after each release — do not edit ~~~
-$Script:CuaDriverRsBakedVersion = "0.3.3"
+$Script:CuaDriverRsBakedVersion = "0.3.4"
 # ~~~ END_BAKED_VERSION ~~~
 
 # ---------- Path resolution ------------------------------------------------


### PR DESCRIPTION
## Problem

`cua-driver-rs-v0.3.4` published with all platform assets, but the default `curl … | install.sh` still downloads **0.3.3**.

Cause: the CD "Bake version into install scripts (commit + push)" step in `cd-rust-cua-driver.yml` failed for 0.3.4 — it aborts with *"Your local changes would be overwritten by checkout"* because the working tree is already dirty from the earlier in-tree bake step. It fails deterministically (also failed on re-run). So `main`'s `CUA_DRIVER_RS_BAKED_VERSION` was never advanced past 0.3.3.

## Fix

Manually bake `0.3.4` into both installer pointers:
- `_install-rust.sh`: `CUA_DRIVER_RS_BAKED_VERSION="0.3.4"`
- `install.ps1`: `$Script:CuaDriverRsBakedVersion = "0.3.4"`

## Follow-up (separate)

The CD bake step needs fixing so the in-tree edit + commit/push double-edit no longer aborts the checkout — otherwise every future release will leave the baked pointer one version behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default CUA Driver Rust version from 0.3.3 to 0.3.4 in installation scripts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1770?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->