### PR TITLE
chore(cua-driver-rs)(uninstall): drop shared-Swift-TCC note from reset hint

### DIFF
--- a/libs/cua-driver/scripts/uninstall.sh
+++ b/libs/cua-driver/scripts/uninstall.sh
@@ -520,11 +520,6 @@ Settings > Privacy & Security. Reset them explicitly — or re-run with
 
   tccutil reset Accessibility com.trycua.driver
   tccutil reset ScreenCapture com.trycua.driver
-
-  (Note: `com.trycua.driver` is shared with the Swift cua-driver.
-  Resetting it clears grants for both backends. If you still use the
-  Swift driver, skip this step and let macOS keep the grants — the
-  next Swift launch will re-use them.)
 FINALUNMSG
         fi
     else


### PR DESCRIPTION
## What

Remove the parenthetical note from the uninstall closing message's `tccutil reset` hint:

> (Note: `com.trycua.driver` is shared with the Swift cua-driver. Resetting it clears grants for both backends. If you still use the Swift driver, skip this step and let macOS keep the grants — the next Swift launch will re-use them.)

The `tccutil reset Accessibility/ScreenCapture com.trycua.driver` commands stay.

## Why

With Rust now the default backend (#1768) and Swift relegated to explicit `--backend=swift` legacy use, the shared-bundle-id caveat is noise for the common uninstall path.

## Notes

- Only `uninstall.sh` carried this note; `uninstall.ps1` never had it.
- `bash -n` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed outdated information from the uninstall process on macOS.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1772?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->