### PR TITLE
fix(cua-driver-rs)(macos): bind serve socket before the permissions gate (#1761)

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -1559,19 +1559,45 @@ fn run_permissions_grant() {
                 process::exit(1);
             }
         }
+        // Since #1761 the daemon binds its socket IMMEDIATELY — before the
+        // permissions gate completes — so the first `check_permissions`
+        // query returns "pending" while the grant is still missing. Poll
+        // the daemon until both grants flip true (success) or we time out.
+        //
+        // The gate re-execs the daemon (~every 25s) to pick up an
+        // Accessibility grant — `AXIsProcessTrusted` is cached per process
+        // and only a fresh process image sees a later grant. During each
+        // restart the socket briefly disappears, so tolerate transient
+        // connection failures rather than bailing on the first one.
         let req = crate::serve::DaemonRequest {
             method: "call".into(),
             name: Some("check_permissions".into()),
             args: Some(serde_json::json!({ "prompt": false })),
         };
-        let structured = crate::serve::send_request(&socket, &req)
-            .ok()
-            .filter(|r| r.ok)
-            .and_then(|r| r.result)
-            .and_then(|res| res.get("structuredContent").cloned())
-            .unwrap_or_else(|| serde_json::json!({}));
-        let ax = structured.get("accessibility").and_then(|v| v.as_bool()).unwrap_or(false);
-        let sr = structured.get("screen_recording").and_then(|v| v.as_bool()).unwrap_or(false);
+        let poll_deadline =
+            std::time::Instant::now() + std::time::Duration::from_secs(180);
+        let mut ax = false;
+        let mut sr = false;
+        loop {
+            if let Some(structured) = crate::serve::send_request(&socket, &req)
+                .ok()
+                .filter(|r| r.ok)
+                .and_then(|r| r.result)
+                .and_then(|res| res.get("structuredContent").cloned())
+            {
+                ax = structured.get("accessibility").and_then(|v| v.as_bool()).unwrap_or(false);
+                sr = structured.get("screen_recording").and_then(|v| v.as_bool()).unwrap_or(false);
+                if ax && sr {
+                    break;
+                }
+            }
+            // `send_request` failing (None / !ok) means the daemon is
+            // mid-restart (re-exec) or briefly down — keep polling.
+            if std::time::Instant::now() >= poll_deadline {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_secs(2));
+        }
         if ax && sr {
             println!("\n✅ CuaDriver has Accessibility + Screen Recording. You're set.");
         } else {
@@ -1581,10 +1607,10 @@ fn run_permissions_grant() {
                 (true, false) => "Screen Recording",
                 (true, true) => unreachable!(),
             };
-            println!("\n⚠️  CuaDriver is running but still missing: {missing}.");
+            println!("\n⚠️  Timed out waiting on: {missing}.");
             println!(
-                "Approve it for \u{201c}Cua Driver\u{201d} in System Settings \u{2192} Privacy & \
-                 Security, then re-run `cua-driver permissions status`."
+                "Approve CuaDriver for \u{201c}Cua Driver\u{201d} in System Settings \u{2192} \
+                 Privacy & Security, then re-run `cua-driver permissions grant`."
             );
         }
     }

--- a/libs/cua-driver/rust/crates/cua-driver/src/main.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/main.rs
@@ -229,24 +229,9 @@ fn main() {
             // before any blocking work so the banner can land on stderr
             // early in the serve lifecycle.
             version_check::maybe_announce_update();
-            // First-launch permissions gate (Swift PermissionsGate parity).
-            // Runs on every `serve` start; no-op when both grants are
-            // already active.  Honors --no-permissions-gate and
-            // CUA_DRIVER_RS_PERMISSIONS_GATE=0 for CI / headless.
-            //
-            // Failures (e.g. deadline elapsed without grants) are logged
-            // and the daemon continues to start — individual tool calls
-            // will then fail with the underlying TCC error, mirroring
-            // Swift's "user closed the panel" fallback.
             let gate_opts = platform_macos::permissions::GateOpts::from_env_and_flag(
                 no_permissions_gate,
             );
-            if let Err(e) = platform_macos::permissions::run_if_needed(gate_opts) {
-                eprintln!("[cua-driver] permissions gate: {e}");
-                eprintln!("[cua-driver] continuing serve startup anyway — \
-                           expect tool calls touching AX or Screen Recording \
-                           to fail until you grant the missing TCC permissions.");
-            }
             cua_driver_core::recording::set_screenshot_fn(|window_id, pid| {
                 if let Some(wid) = window_id {
                     platform_macos::capture::screenshot_window_bytes(wid as u32).ok()
@@ -278,27 +263,66 @@ fn main() {
             reg.init_self_weak();
             let sp = socket.unwrap_or_else(serve::default_socket_path);
             let pid_path = serve::default_pid_file_path();
-            // PiP needs the AppKit main run loop to process the
-            // dispatch_async_f calls that push frames into NSImageView.
-            // When --experimental-pip is on, move the serve loop onto
-            // a background thread and park the main thread in
-            // NSApplication.run() so the dispatched blocks actually
-            // execute. Without this, frames queue forever and the
-            // window stays blank. The non-PiP path keeps the original
-            // run-on-main semantics so we don't change behaviour for
-            // existing users.
-            if pip_cfg.enabled {
-                std::thread::Builder::new()
-                    .name("cua-serve".into())
-                    .spawn(move || {
-                        serve::run_serve_cmd(reg, &sp, Some(&pid_path));
-                        std::process::exit(0);
-                    })
-                    .expect("spawn serve thread");
-                platform_macos::pip::run_appkit_main_loop();
-                return;
+
+            // Bind the Unix socket FIRST, on a background thread, BEFORE
+            // running the (blocking) permissions gate (#1761).
+            //
+            // The gate's `wait_for_grants` blocks while `com.trycua.driver`
+            // is ungranted — it prompts and re-exec-loops until the user
+            // grants or the deadline elapses. If serve ran after the gate,
+            // the daemon's socket wouldn't appear for minutes on first
+            // launch, so `permissions grant` / MCP clients launched via
+            // `open -n -g -a CuaDriver --args serve` (the correct-TCC-
+            // attribution path) couldn't reach the daemon to even report
+            // "pending". Binding the socket first makes the daemon
+            // reachable within ~1s while the gate works toward the grant.
+            //
+            // A Unix socket + tokio accept loop has no main-thread
+            // requirement, so serve runs on a background thread. The gate
+            // stays on the MAIN thread: its prompt APIs
+            // (`request_accessibility` / `request_screen_recording`) and
+            // the NSPanel must run on main. On grant, the gate's
+            // `reexec_self()` execvp's the whole daemon — the socket
+            // re-binds fast on restart (run_serve unlinks the stale socket
+            // file first) and stabilizes once the grant sticks.
+            let serve_handle = std::thread::Builder::new()
+                .name("cua-serve".into())
+                .spawn(move || {
+                    serve::run_serve_cmd(reg, &sp, Some(&pid_path));
+                    std::process::exit(0);
+                })
+                .expect("spawn serve thread");
+
+            // Socket is binding/bound now → daemon reachable while we gate.
+            //
+            // First-launch permissions gate (Swift PermissionsGate parity).
+            // Runs on every `serve` start; no-op when both grants are
+            // already active.  Honors --no-permissions-gate and
+            // CUA_DRIVER_RS_PERMISSIONS_GATE=0 for CI / headless.
+            //
+            // Failures (e.g. deadline elapsed without grants) are logged
+            // and the daemon continues to serve — individual tool calls
+            // will then fail with the underlying TCC error, mirroring
+            // Swift's "user closed the panel" fallback.
+            if let Err(e) = platform_macos::permissions::run_if_needed(gate_opts) {
+                eprintln!("[cua-driver] permissions gate: {e}");
+                eprintln!("[cua-driver] continuing — tool calls touching AX or \
+                           Screen Recording fail until you grant the missing TCC \
+                           permissions.");
             }
-            serve::run_serve_cmd(reg, &sp, Some(&pid_path));
+
+            // Keep the main thread alive for the daemon.
+            //
+            // PiP needs the AppKit main run loop to process the
+            // dispatch_async_f calls that push frames into NSImageView;
+            // park main in NSApplication.run() when --experimental-pip is
+            // on. Otherwise just join the serve thread so the process
+            // stays up as long as the daemon does.
+            if pip_cfg.enabled {
+                platform_macos::pip::run_appkit_main_loop();
+            } else {
+                let _ = serve_handle.join();
+            }
             return;
         }
         cli::Command::Stop { socket } => {

--- a/libs/cua-driver/rust/crates/platform-macos/src/permissions/gate.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/permissions/gate.rs
@@ -384,14 +384,22 @@ pub fn wait_for_grants(opts: &GateOpts) -> Result<()> {
         // On macOS, when polling has gone several iterations without
         // any change, re-exec the binary to invalidate the per-process
         // TCC cache. See the function-level doc for the rationale.
-        // Threshold of 5 polls (~5s) is tuned to feel snappy without
-        // exec-spinning when the user is mid-grant.
+        //
+        // Since #1761 the serve loop runs concurrently with this gate on
+        // a background thread, so every `reexec_self()` restarts the whole
+        // daemon — including re-binding the Unix socket. A tight re-exec
+        // cadence would therefore make the socket flap (clients see brief
+        // connection failures on each restart). We trade grant-detection
+        // latency (fine for the grant flow — the user is clicking through
+        // System Settings on a human timescale) for socket stability:
+        // ~25 polls (~25s) between re-execs instead of ~5s.
         #[cfg(target_os = "macos")]
         {
-            const EXEC_AFTER_POLLS: u32 = 5;
+            const EXEC_AFTER_POLLS: u32 = 25;
             if polls_without_change >= EXEC_AFTER_POLLS {
                 println!(
-                    "[cua-driver] rechecking permissions (still missing: {})",
+                    "[cua-driver] rechecking permissions — restarting daemon \
+                     (still missing: {})",
                     fmt_missing(&last_missing)
                 );
                 let _ = std::io::stdout().flush();


### PR DESCRIPTION
## Problem

On macOS first launch with `com.trycua.driver` ungranted, the `Serve` arm ran the **blocking** permissions gate (`run_if_needed`) *before* `run_serve_cmd` bound the Unix socket. The gate sits in `wait_for_grants` (prompting + re-exec-looping) until the user grants or the 10-min deadline elapses, so the socket never appears. A daemon launched via `open -n -g -a CuaDriver --args serve` (the only launch that gives correct TCC attribution + System Settings registration) is therefore unreachable for minutes — `permissions grant` and MCP clients can't even get a "pending" answer.

## Fix

**Reorder the macOS serve arm** (`main.rs`): serve now runs on a **background thread first** (it binds the socket — a Unix socket + tokio accept loop has no main-thread requirement), and the **gate runs on the main thread** (kept there because its prompt APIs `request_accessibility` / `request_screen_recording` and the NSPanel must stay on main). The socket is binding/bound within ~1s while the gate works toward the grant. Main stays alive via `run_appkit_main_loop()` (PiP) or `serve_handle.join()` (non-PiP).

**Why the re-exec stays + cadence tradeoff** (`gate.rs`): `AXIsProcessTrusted()` is cached per process, so a process that cached `false` cannot see a later Accessibility grant without re-executing (execvp, fresh process). The re-exec is load-bearing and is NOT removed. But now that serve runs concurrently, each `reexec_self()` restarts the whole daemon and flaps the socket. Raised `EXEC_AFTER_POLLS` **5 → 25** (~25s between re-execs at the 1s poll interval) to trade grant-detection latency (fine on a human-clicking-through-Settings timescale) for socket stability. Added a "restarting daemon" log before each re-exec so the restart isn't silent.

**Stale-socket unlink**: already present — the macOS `#[cfg(unix)]` `run_serve` does `std::fs::remove_file(socket_path)` before `UnixListener::bind`, and `is_daemon_listening` is a connect probe that returns false after the old process is gone. No change needed; verified the restart rebinds cleanly without EADDRINUSE.

**`permissions grant` polling** (`cli.rs`): the socket now appears *before* the grant, so a single `check_permissions` query returns "pending". Changed to poll `check_permissions` via the daemon every 2s up to 180s, tolerating transient connection failures during a re-exec restart, until both grants flip `true` (success) or timeout (tells the user to approve the CuaDriver dialog + re-run). The "daemon already running" fast branch is preserved.

**Happy path unchanged**: when `current_status().all_granted()` is true, `run_if_needed` fast-returns at `gate.rs:213` — no banner, no polling, no flapping. Serve still starts normally.

## Scope

macOS-only. The non-macOS `Serve` arm already spawns serve on a thread and has no gate — untouched.

## Test plan (live, maintainer — needs GUI + grant clicks)

- [ ] **(a) grants present → instant**: launch `serve` with Accessibility + Screen Recording already granted to `com.trycua.driver`. Socket binds immediately, gate fast-returns, no flap, no regression vs current behavior.
- [ ] **(b) ungranted first launch**: `tccutil reset Accessibility com.trycua.driver && tccutil reset ScreenCapture com.trycua.driver`, then `cua-driver permissions grant`. Verify: socket appears fast (within ~1s, `permissions status` answers "pending" immediately); the system prompt reads "Cua Driver"; after granting both, the daemon stabilizes and `grant` reports granted (no infinite flap; the ~25s re-exec cadence means at most a brief socket blip per recheck).
- [ ] **(c) MCP still works**: `cua-driver mcp` via Claude Code connects and drives tools normally.
- [ ] **(d) never-granted → bounded**: launch ungranted and never grant. Confirm no infinite flap — the gate stops at its deadline (default 10 min), logs the timeout, and the daemon keeps serving (tool calls touching AX/Screen Recording fail with the underlying TCC error).

## Build

- `cargo build --release -p cua-driver` ✅
- `cargo test --no-run -p platform-macos` ✅ (compile clean; the pre-existing `libswift_Concurrency` rpath *run* failure is unrelated — compile is what matters here)

DRAFT — this is load-bearing daemon-startup code that needs live TCC-state verification before merge. Please do not merge until the test plan above passes on a real machine.

Refs #1761

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced macOS permissions verification with polling to better handle transient permission state changes
  * Improved timeout error messages with clearer System Settings navigation guidance
  * Optimized daemon initialization sequence for more reliable startup flow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1773?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->