### PR TITLE
fix(cua-driver-rs)(macos): permissions status never reports the caller's grants

### DIFF
--- a/docs/content/docs/cua-driver/guide/getting-started/autostart.mdx
+++ b/docs/content/docs/cua-driver/guide/getting-started/autostart.mdx
@@ -29,7 +29,8 @@ cua-driver autostart disable   # remove the entry
   and the grants persist across reboots — every `cua-driver call` / `mcp` then routes through the
   always-on, correctly-attributed daemon. Without autostart, a prompt raised from a terminal
   attributes to the terminal and the grant never applies to the driver — run
-  `cua-driver permissions status` to see which identity your grants belong to, or
+  `cua-driver permissions status` to read the driver's real grant state (it answers via the daemon,
+  or reports `unknown` when none is running rather than your terminal's grants), or
   `cua-driver permissions grant` to grant correctly without autostart. Autostart stays opt-in
   because a standing computer-control daemon with these grants is a deliberate choice, not a default.
 </Callout>

--- a/docs/content/docs/cua-driver/guide/getting-started/faq.mdx
+++ b/docs/content/docs/cua-driver/guide/getting-started/faq.mdx
@@ -167,6 +167,11 @@ open -n -g -a CuaDriver --args serve
 cua-driver call check_permissions   # forwards to the daemon — authoritative answer
 ```
 
+Or use the dedicated verbs, which handle attribution for you: `cua-driver permissions grant` launches
+CuaDriver via LaunchServices and waits for the grant, and `cua-driver permissions status` reports the
+driver's real state through the daemon — when no daemon is running it answers `❓ unknown` rather than
+the calling terminal's grants, so it never reports a false `granted`.
+
 ### `cua-driver mcp` from an IDE terminal can't see Accessibility.
 
 This is the same TCC-attribution issue as the previous question, applied to the stdio MCP server. `cua-driver mcp` detects it and auto-launches the daemon via `open -n -g -a CuaDriver --args serve`, then proxies every MCP tool call through the daemon's Unix socket. From the MCP client's perspective nothing changes — the same stdio server, the same tool names, the same response shapes — but every AX probe now hits a process that LaunchServices attributed to `CuaDriver.app`. No Python bridge needed. Force the in-process path with `--no-daemon-relaunch` (or `CUA_DRIVER_MCP_NO_RELAUNCH=1`) if you really want it, e.g. when `mcp` is launched from `CuaDriver.app` directly.

--- a/docs/content/docs/cua-driver/guide/getting-started/installation.mdx
+++ b/docs/content/docs/cua-driver/guide/getting-started/installation.mdx
@@ -349,6 +349,13 @@ cua-driver check_permissions
   so results can read "NOT granted" even when you've granted both to `CuaDriver.app`. The
   daemon-first recipe above sidesteps this because the CLI forwards through the daemon, which runs
   under `CuaDriver.app`'s bundle id.
+
+  **Prefer the `permissions` verbs.** `cua-driver permissions grant` launches CuaDriver via
+  LaunchServices so the dialog attributes to `com.trycua.driver` (not your terminal), then waits for
+  and confirms the grant — the one-step authoritative path. `cua-driver permissions status` reads
+  the driver's real grant state *through the daemon*; when no daemon is running it reports
+  `❓ unknown` rather than your terminal's grants, so it can never claim `granted` when the driver
+  has none.
 </Callout>
 
 If a grant still reads `NOT granted` after granting in the dialog, open **System Settings → Privacy & Security**, find `CuaDriver.app` under Accessibility and Screen Recording, and flip the toggle.

--- a/libs/cua-driver/rust/Cargo.lock
+++ b/libs/cua-driver/rust/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver"
-version = "0.3.2"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-core"
-version = "0.3.2"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-uia"
-version = "0.3.2"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "cua-driver-core",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "cursor-overlay"
-version = "0.3.2"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "image",
@@ -488,7 +488,7 @@ checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
 name = "focus-monitor-win"
-version = "0.3.2"
+version = "0.3.5"
 dependencies = [
  "windows 0.58.0",
 ]
@@ -1192,7 +1192,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pip-preview"
-version = "0.3.2"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -1207,7 +1207,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "platform-linux"
-version = "0.3.2"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "platform-macos"
-version = "0.3.2"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "platform-windows"
-version = "0.3.2"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -145,9 +145,9 @@ pub fn parse_command() -> Command {
         println!();
         println!("permissions options (macOS):");
         println!("  cua-driver permissions status   Report Accessibility + Screen Recording status. Read-only (no prompt).");
-        println!("                                  Routes through a running daemon when one is up, so the answer carries");
-        println!("                                  the CuaDriver identity; otherwise reads the calling process's grants");
-        println!("                                  and labels them as such (`source`). Add --json for the raw payload.");
+        println!("                                  Answers via a running daemon, so the result carries the CuaDriver");
+        println!("                                  identity (com.trycua.driver). If no daemon is running it reports");
+        println!("                                  `unknown` rather than your terminal's grants. Add --json for the payload.");
         println!("  cua-driver permissions grant    Launch CuaDriver via LaunchServices so the permission dialog attributes");
         println!("                                  to com.trycua.driver (not your terminal), wait for the grant, then");
         println!("                                  confirm the driver's own status. This is the correct way to grant.");
@@ -1454,12 +1454,12 @@ pub fn run_update_cmd(apply: bool, json: bool) {
 
 /// `cua-driver permissions status|grant`.
 pub fn run_permissions_cmd(
-    registry: std::sync::Arc<ToolRegistry>,
+    _registry: std::sync::Arc<ToolRegistry>,
     subcommand: &str,
     json: bool,
 ) {
     match subcommand {
-        "status" => run_permissions_status(registry, json),
+        "status" => run_permissions_status(json),
         "grant" => run_permissions_grant(),
         other => {
             eprintln!("unknown permissions subcommand '{other}'. Valid: status, grant.");
@@ -1468,13 +1468,25 @@ pub fn run_permissions_cmd(
     }
 }
 
-/// Report TCC status with source attribution + the live capture probe.
-/// Routes through a running daemon when one is up (so the answer carries the
-/// com.trycua.driver identity); otherwise reads in-process (the caller's
-/// identity, clearly labelled). Never raises a prompt — `grant` does that.
-fn run_permissions_status(registry: std::sync::Arc<ToolRegistry>, json: bool) {
+/// Report the CuaDriver daemon's TCC status — reliably, or not at all.
+///
+/// macOS attributes Accessibility / Screen-Recording to the *responsible
+/// process*, so the ONLY process that can read `com.trycua.driver`'s real
+/// grants is the bundle daemon (launched via LaunchServices, reparented to
+/// launchd). When the daemon is up we query it and report its
+/// `driver-daemon`-attributed answer. When it is NOT up we deliberately
+/// report `unknown` rather than fall back to an in-process check — that
+/// fallback would report the *calling terminal's* grants and could print
+/// `✅ granted` while the driver itself has none. An honest "unknown" beats a
+/// confident lie. To grant + verify, use `cua-driver permissions grant`.
+/// Never raises a prompt.
+fn run_permissions_status(json: bool) {
     let socket = crate::serve::default_socket_path();
-    let structured: serde_json::Value = if crate::serve::is_daemon_listening(&socket) {
+
+    // Only a listening daemon can answer for com.trycua.driver. A failed/!ok
+    // response (e.g. daemon mid-re-exec during the gate's recheck window) is
+    // treated the same as "no daemon" → unknown.
+    let daemon_status: Option<serde_json::Value> = if crate::serve::is_daemon_listening(&socket) {
         let req = crate::serve::DaemonRequest {
             method: "call".into(),
             name: Some("check_permissions".into()),
@@ -1485,18 +1497,53 @@ fn run_permissions_status(registry: std::sync::Arc<ToolRegistry>, json: bool) {
             .filter(|r| r.ok)
             .and_then(|r| r.result)
             .and_then(|res| res.get("structuredContent").cloned())
-            .unwrap_or_else(|| serde_json::json!({}))
+            // Trust the booleans ONLY when the answering process is the launchd
+            // bundle daemon (`driver-daemon`). A daemon spawned from a terminal
+            // (`cua-driver serve` by hand) answers with `caller` attribution —
+            // those are the terminal's grants, not the driver's, so we discard
+            // them and fall through to `unknown` rather than report a false
+            // `granted`. A missing `source` (non-macOS, no TCC) is trusted as-is.
+            .filter(|s| {
+                s.get("source")
+                    .and_then(|src| src.get("attribution"))
+                    .and_then(|v| v.as_str())
+                    .map(|a| a == "driver-daemon")
+                    .unwrap_or(true)
+            })
     } else {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("tokio runtime");
-        rt.block_on(registry.invoke(
-            "check_permissions",
-            serde_json::json!({ "prompt": false }),
-        ))
-        .structured_content
-        .unwrap_or_else(|| serde_json::json!({}))
+        None
+    };
+
+    let Some(structured) = daemon_status else {
+        // No reliable answer. Emit NO accessibility/screen_recording booleans —
+        // nothing downstream can misread a false `granted: true`.
+        if json {
+            let payload = serde_json::json!({
+                "daemon_running": false,
+                "status": "unknown",
+                "reason": "no CuaDriver daemon is running under the driver's own identity \
+                           (com.trycua.driver), so its real TCC status can't be read from this \
+                           process. Run `cua-driver permissions grant` to grant + verify.",
+            });
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&payload).unwrap_or_else(|_| payload.to_string())
+            );
+            return;
+        }
+        println!("Accessibility:    ❓ unknown");
+        println!("Screen Recording: ❓ unknown");
+        println!(
+            "No CuaDriver daemon is running under the driver's own identity (com.trycua.driver), \
+             so its real TCC status can't be read."
+        );
+        println!(
+            "(A status check from this terminal would report the terminal's grants, not the \
+             driver's.)"
+        );
+        println!("  → Run `cua-driver permissions grant` to grant + verify, or start the daemon");
+        println!("    (`open -n -g -a CuaDriver --args serve`) and re-run this command.");
+        return;
     };
 
     if json {
@@ -1511,11 +1558,11 @@ fn run_permissions_status(registry: std::sync::Arc<ToolRegistry>, json: bool) {
     let ax = b("accessibility");
     let sr = b("screen_recording");
     let cap = b("screen_recording_capturable");
-    let source = structured.get("source");
-    let attribution = source
+    let attribution = structured
+        .get("source")
         .and_then(|s| s.get("attribution"))
         .and_then(|v| v.as_str())
-        .unwrap_or("unknown");
+        .unwrap_or("driver-daemon");
 
     println!("Accessibility:    {}", if ax { "✅ granted" } else { "❌ not granted" });
     println!("Screen Recording: {}", if sr { "✅ granted" } else { "❌ not granted" });
@@ -1526,10 +1573,7 @@ fn run_permissions_status(registry: std::sync::Arc<ToolRegistry>, json: bool) {
         );
     }
     println!("Source: {attribution}");
-    if attribution == "caller" {
-        if let Some(note) = source.and_then(|s| s.get("note")).and_then(|v| v.as_str()) {
-            println!("  {note}");
-        }
+    if !(ax && sr) {
         println!("  → To grant for the driver, run: cua-driver permissions grant");
     }
 }


### PR DESCRIPTION
## Problem

`cua-driver permissions status`, run standalone from a terminal, prints `✅ granted` **even when `com.trycua.driver` has zero TCC grants**:

```
% cua-driver permissions status
Accessibility:    ✅ granted
Screen Recording: ✅ granted
Source: caller
```

macOS attributes Accessibility / Screen-Recording to the **responsible process** (the LaunchServices launching app), not the executable path. With no daemon listening, `run_permissions_status` fell back to an in-process `check_permissions` that reads the **calling terminal's** grants. The `Source: caller` label was the only signal it was lying — buried under two green checkmarks. A status command that confidently reports "granted" when the driver has nothing is worse than no command.

## Fix

The only process that can read `com.trycua.driver`'s real grants is the **launchd bundle daemon** (`driver-daemon` attribution, `ppid==1`). So:

| State | Output |
|---|---|
| daemon up + `driver-daemon` | `✅/❌ granted` · `Source: driver-daemon` (reliable, unchanged) |
| **no daemon** | `❓ unknown` + guidance — **no booleans in `--json`** |
| **terminal-spawned daemon** (`caller` attribution) | `❓ unknown` — its grants are the terminal's, not the driver's |

The in-process caller fallback in `run_permissions_status` is **deleted**. `--json` in the unknown case emits `{"daemon_running": false, "status": "unknown", "reason": …}` with **no `accessibility`/`screen_recording` keys**, so no scripted consumer can ever misread a false `granted: true`. A missing `source` (non-macOS, no TCC) is still trusted as-is.

The `grant` flow is unchanged — it already spawns via LaunchServices and verifies.

## Verified locally
- **No daemon** → `❓ unknown`, JSON has no booleans ✅
- **Terminal-spawned `serve`** (caller attribution) → now `❓ unknown`, not the old `caller`/`granted` ✅
- **launchd `driver-daemon`** path → reports real grants (validated in #1773) ✅
- `cargo build` + `cargo clippy` clean; `Cargo.lock` synced to 0.3.5 (was drifted at 0.3.2).

## Docs
Updated `autostart.mdx`, `installation.mdx`, `faq.mdx` to describe daemon-or-unknown behavior and point at `permissions grant` as the authoritative grant+verify path.

Closes the false-positive thread from the macOS TCC attribution series (follow-up to #1765/#1773).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated permissions guidance clarifying that `cua-driver permissions` verbs handle attribution via the daemon
  * Clarified behavior: `permissions status` returns "unknown" when no daemon is running

* **Bug Fixes**
  * Improved permissions status reporting to prevent false positives by returning "unknown" when daemon is unavailable

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trycua/cua/pull/1774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->