### PR TITLE
fix(cua-driver-rs)(macos): tear down recording on client disconnect + default record_video=false (#1764)

### DIFF
--- a/docs/content/docs/cua-driver/reference/mcp-tools.mdx
+++ b/docs/content/docs/cua-driver/reference/mcp-tools.mdx
@@ -460,6 +460,8 @@ Turn folders are named `turn-00001/`, `turn-00002/`, etc.  Turn numbering restar
 
 State persists for the life of the daemon / MCP session; a restart resets to disabled with no on-disk state. Call `stop_recording` to disable + finalize the mp4.
 
+The result's `structuredContent` includes a `generation` token (an integer that increments on every successful `start_recording`) identifying this session. The daemon-proxy disconnect auto-stop captures it and passes it back to `stop_recording` so a client exiting can't stop a recording a later client started — see `stop_recording`'s `generation` argument.
+
 **Arguments:**
 
 - `output_dir` (string, required): Absolute or ~-rooted directory where turn folders and (when enabled) the video file are written.
@@ -473,7 +475,9 @@ State persists for the life of the daemon / MCP session; a restart resets to dis
 
 Stop trajectory recording. Disables further per-turn capture and, when video was enabled, gracefully terminates the ffmpeg subprocess so the mp4's moov atom is finalized (the file is playable). Calling stop on an already-stopped session is a no-op. The response carries `last_video_path` pointing at the finalized mp4 (when video was on).
 
-**Arguments:** none.
+**Arguments:**
+
+- `generation` (integer, optional): Ownership token from a prior `start_recording`'s `structuredContent.generation`. When present, the stop only acts if it matches the current recording's generation — a stale token (a session already clobbered by a newer `start_recording`) is a silent no-op. This is used by the MCP proxy's disconnect auto-stop so a client exiting doesn't stop a recording a later client started. Omit it for a normal manual stop, which unconditionally stops the active recording.
 
 ### replay_trajectory
 

--- a/docs/content/docs/cua-driver/reference/mcp-tools.mdx
+++ b/docs/content/docs/cua-driver/reference/mcp-tools.mdx
@@ -452,7 +452,7 @@ Start trajectory recording. Every subsequent action-tool invocation (click, righ
 
 Turn folders are named `turn-00001/`, `turn-00002/`, etc.  Turn numbering restarts at 1 each time recording is (re-)started.
 
-**Video is on by default** — the main display is captured to `<output_dir>/recording.mp4` (H.264 / 30 fps) for the lifetime of the session. Pass `record_video: false` to opt out.
+**Video is off by default.** Pass `record_video: true` to also capture the main display to `<output_dir>/recording.mp4` (H.264 / 30 fps) for the lifetime of the session. On the daemon-proxy path (the default macOS `cua-driver mcp` flow), recording is stopped automatically when the MCP client disconnects, so a forgotten session no longer keeps writing to disk; a daemon-side idle timeout (~5 min of no tool activity) is a backstop in case the client is killed before it can clean up.
 
 **macOS uses native ScreenCaptureKit** (in-process SCStream + SCRecordingOutput) so video inherits Cua Driver's own Screen Recording grant — no extra TCC prompt, no ffmpeg subprocess. Requires macOS 15.0+.
 
@@ -463,7 +463,7 @@ State persists for the life of the daemon / MCP session; a restart resets to dis
 **Arguments:**
 
 - `output_dir` (string, required): Absolute or ~-rooted directory where turn folders and (when enabled) the video file are written.
-- `record_video` (boolean, optional): Capture the main display to &lt;output_dir&gt;/recording.mp4. Default: true. Set to false to record only the per-turn screenshots + JSON. On macOS this uses native ScreenCaptureKit (no extra TCC prompt, macOS 15.0+); on Windows + Linux it requires ffmpeg on PATH.
+- `record_video` (boolean, optional): Capture the main display to &lt;output_dir&gt;/recording.mp4. Default: false. Set to true to also capture the main display to recording.mp4 (otherwise only the per-turn screenshots + JSON are recorded). On macOS this uses native ScreenCaptureKit (no extra TCC prompt, macOS 15.0+); on Windows + Linux it requires ffmpeg on PATH.
 
 ```json
 {"output_dir":"~/cua-trajectories/demo1"}

--- a/libs/cua-driver/rust/Cargo.lock
+++ b/libs/cua-driver/rust/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-uia"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "cua-driver-core",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "cursor-overlay"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "image",
@@ -488,7 +488,7 @@ checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
 name = "focus-monitor-win"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "windows 0.58.0",
 ]
@@ -1192,7 +1192,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pip-preview"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -1207,7 +1207,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "platform-linux"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "platform-macos"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "platform-windows"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/recording.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/recording.rs
@@ -288,8 +288,9 @@ impl RecordingSession {
 
     /// Legacy toggle API kept as a thin shim over `start()`/`stop()` so
     /// existing callers (CLI subcommand, tests) keep compiling during the
-    /// rename window. Defaults `record_video` to true to match the new
-    /// surface.
+    /// rename window. Forces `record_video` on for this legacy CLI path — the
+    /// MCP `start_recording` tool now defaults video OFF (see
+    /// `recording_tools.rs`), but the CLI `recording start` keeps video on.
     pub fn configure(&self, enabled: bool, output_dir: Option<&str>) -> anyhow::Result<()> {
         if !enabled {
             return self.stop();

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/recording.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/recording.rs
@@ -153,9 +153,12 @@ impl RecordingSession {
     /// Enable recording at `output_dir`, optionally with video capture.
     /// Counterpart to `stop()`. Returns the resulting state.
     ///
-    /// `record_video=true` (the default for callers that don't opt out)
-    /// spawns ffmpeg writing `<output_dir>/recording.mp4` for the lifetime
-    /// of the session. If ffmpeg isn't on PATH the start still succeeds —
+    /// `record_video=true` spawns ffmpeg writing `<output_dir>/recording.mp4`
+    /// for the lifetime of the session. NOTE: the MCP `start_recording` tool
+    /// now defaults `record_video` to *false* (opt-in) — see
+    /// `recording_tools.rs` — so video only records when explicitly requested.
+    /// The legacy CLI `recording start` path via `configure()` still forces
+    /// video on. If ffmpeg isn't on PATH the start still succeeds —
     /// the per-turn capture (action.json + screenshot.png) is independent
     /// of video — but the structured state carries the ffmpeg error so
     /// the caller can surface it.

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/recording.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/recording.rs
@@ -93,6 +93,16 @@ pub struct RecordingSession {
 
 struct RecordingInner {
     enabled: bool,
+    /// Monotonically-increasing ownership token, bumped on every successful
+    /// `start()` (gen 1 for the first session, 2 for the next, …). The
+    /// daemon-global recorder is a singleton, so when client A starts a
+    /// recording and client B later starts another (clobbering A's session),
+    /// A's disconnect must NOT stop B's recording. The proxy-exit hook
+    /// captures the generation it started with and passes it to `stop()`,
+    /// which no-ops when the live generation has moved on. Never reset in
+    /// `stop()` — it must keep climbing so a stale token never collides with
+    /// a future live one (#1764).
+    generation: u64,
     output_dir: Option<PathBuf>,
     next_turn: u32,
     session_start_ms: u64,
@@ -130,6 +140,11 @@ pub struct RecordingState {
     /// Path to the most recently finalized video file, if any. Populated
     /// after a stop; cleared on next start.
     pub last_video_path: Option<String>,
+    /// Ownership token of the current (or most recent) session. Bumped on
+    /// every successful `start()`. Surfaced so the proxy-exit hook can
+    /// capture the generation it started a recording with and pass it back
+    /// to `stop()` to avoid stopping a recording a later client now owns.
+    pub generation: u64,
 }
 
 impl RecordingSession {
@@ -137,6 +152,7 @@ impl RecordingSession {
         Self {
             inner: Mutex::new(RecordingInner {
                 enabled: false,
+                generation: 0,
                 output_dir: None,
                 next_turn: 1,
                 session_start_ms: 0,
@@ -228,6 +244,15 @@ impl RecordingSession {
             &session_payload,
         );
 
+        // Bump the ownership token on every successful start so each session
+        // gets a fresh, monotonically-increasing generation (gen 1 for the
+        // first start(), 2 for the next, …). Reached only on the success path
+        // — start() returns early via `?` on `create_dir_all` failure above,
+        // so a failed start does not consume a generation. Deliberately NOT
+        // reset in stop() so a stale token can never collide with a future
+        // live one. `wrapping_add` avoids a debug-overflow panic at the
+        // (astronomically improbable) 2^64th start (#1764).
+        inner.generation = inner.generation.wrapping_add(1);
         inner.enabled = true;
         inner.output_dir = Some(dir);
         inner.next_turn = 1;
@@ -243,10 +268,27 @@ impl RecordingSession {
     /// session is a no-op. If a video subprocess is running, it's
     /// gracefully terminated and the finalized metadata is folded into
     /// `session.json`.
-    pub fn stop(&self) -> anyhow::Result<()> {
+    ///
+    /// `expected_generation` is the ownership guard for the proxy-exit hook
+    /// (#1764). When `Some(gen)`, the stop only acts if `gen` matches the
+    /// live generation — a stale token (a disconnecting client whose session
+    /// was already clobbered by a newer `start()`) is a silent no-op, leaving
+    /// the recording owned by the newer generation running. When `None`
+    /// (manual `stop_recording`, the legacy `configure()` shim, and the
+    /// idle-TTL backstop), the stop is unconditional — current behavior.
+    /// The guard lives inside the lock so it is race-free against a
+    /// concurrent `start()`.
+    pub fn stop(&self, expected_generation: Option<u64>) -> anyhow::Result<()> {
         let mut inner = self.inner.lock().unwrap();
         if !inner.enabled {
             return Ok(());
+        }
+        if let Some(expected) = expected_generation {
+            if expected != inner.generation {
+                // Stale token: the active recording is owned by a newer
+                // generation. Leave it running.
+                return Ok(());
+            }
         }
         let dir = inner.output_dir.clone();
         let video_meta = inner.video.take().and_then(|rec| rec.stop().ok());
@@ -293,7 +335,7 @@ impl RecordingSession {
     /// `recording_tools.rs`), but the CLI `recording start` keeps video on.
     pub fn configure(&self, enabled: bool, output_dir: Option<&str>) -> anyhow::Result<()> {
         if !enabled {
-            return self.stop();
+            return self.stop(None);
         }
         let dir = output_dir
             .ok_or_else(|| anyhow::anyhow!("output_dir is required when enabling recording"))?;
@@ -311,6 +353,7 @@ impl RecordingSession {
             video_active: inner.video.is_some(),
             last_video_path: inner.last_video.as_ref()
                 .map(|m| m.path.to_string_lossy().into_owned()),
+            generation: inner.generation,
         }
     }
 

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/recording_tools.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/recording_tools.rs
@@ -166,10 +166,25 @@ impl Tool for StopRecordingTool {
                 and, when video was enabled, gracefully terminates the ffmpeg subprocess \
                 so the mp4's moov atom is finalized (the file is playable). Calling \
                 stop on an already-stopped session is a no-op. The response carries \
-                `last_video_path` pointing at the finalized mp4 (when video was on).".into(),
+                `last_video_path` pointing at the finalized mp4 (when video was on).\n\n\
+                **Optional `generation` (ownership guard, #1764).** When present, the \
+                stop only acts if it matches the current recording's generation token \
+                (surfaced in `start_recording`'s `structuredContent.generation`); a \
+                stale token is a silent no-op. This is used by the MCP proxy's \
+                disconnect auto-stop so a client exiting doesn't stop a recording a \
+                later client started. Omit it for a normal manual stop — that \
+                unconditionally stops the active recording.".into(),
             input_schema: json!({
                 "type": "object",
-                "properties": {},
+                "properties": {
+                    "generation": {
+                        "type": "integer",
+                        "description": "Ownership token from a prior start_recording's \
+                            structuredContent.generation. When set, stop only acts if \
+                            it matches the live recording's generation (stale = no-op). \
+                            Omit for an unconditional manual stop."
+                    }
+                },
                 "additionalProperties": false
             }),
             read_only: false,
@@ -179,8 +194,11 @@ impl Tool for StopRecordingTool {
         })
     }
 
-    async fn invoke(&self, _args: Value) -> ToolResult {
-        match self.session.stop() {
+    async fn invoke(&self, args: Value) -> ToolResult {
+        use crate::tool_args::ArgsExt;
+        // Optional ownership token (#1764). `None` (omitted) → unconditional
+        // manual stop; `Some(gen)` → guarded stop that no-ops on a stale token.
+        match self.session.stop(args.opt_u64("generation")) {
             Ok(()) => {
                 let state = self.session.current_state();
                 let video_note = state.last_video_path.as_deref()
@@ -442,6 +460,10 @@ fn recording_state_json(state: &RecordingState) -> Value {
         "last_error": state.last_error,
         "video_active": state.video_active,
         "last_video_path": state.last_video_path,
+        // Ownership token for the proxy-exit teardown guard (#1764). The
+        // disconnect auto-stop captures this off a successful start_recording
+        // and passes it back so it can't stop a recording a later client owns.
+        "generation": state.generation,
     })
 }
 

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/recording_tools.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/recording_tools.rs
@@ -68,9 +68,10 @@ impl Tool for StartRecordingTool {
                   red dot drawn at the click point.\n\n\
                 Turn folders are named `turn-00001/`, `turn-00002/`, etc.  Turn \
                 numbering restarts at 1 each time recording is (re-)started.\n\n\
-                **Video is on by default** — the main display is captured to \
-                `<output_dir>/recording.mp4` (H.264 / 30 fps) for the lifetime of \
-                the session. Pass `record_video: false` to opt out.\n\n\
+                **Video is off by default.** Pass `record_video: true` to also \
+                capture the main display to `<output_dir>/recording.mp4` (H.264 / \
+                30 fps) for the lifetime of the session. The recording is torn \
+                down automatically when the MCP client disconnects.\n\n\
                 **macOS uses native ScreenCaptureKit** (in-process SCStream + \
                 SCRecordingOutput) so video inherits Cua Driver's own Screen \
                 Recording grant — no extra TCC prompt, no ffmpeg subprocess. \
@@ -96,8 +97,9 @@ impl Tool for StartRecordingTool {
                     "record_video": {
                         "type": "boolean",
                         "description": "Capture the main display to <output_dir>/recording.mp4. \
-                            Default: true. Set to false to record only the per-turn \
-                            screenshots + JSON. On macOS this uses native \
+                            Default: false. Set to true to also capture the main \
+                            display to recording.mp4 (otherwise only the per-turn \
+                            screenshots + JSON are recorded). On macOS this uses native \
                             ScreenCaptureKit (no extra TCC prompt, macOS 15.0+); on \
                             Windows + Linux it requires ffmpeg on PATH."
                     }
@@ -117,7 +119,7 @@ impl Tool for StartRecordingTool {
         if output_dir.as_deref().map(str::is_empty).unwrap_or(true) {
             return ToolResult::error("`output_dir` is required.");
         }
-        let record_video = args.bool_or("record_video", true);
+        let record_video = args.bool_or("record_video", false);
 
         match self.session.start(output_dir.as_deref().unwrap(), record_video) {
             Ok(()) => {

--- a/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
@@ -65,18 +65,22 @@ pub async fn run_proxy(socket_path: String) -> anyhow::Result<()> {
     let mut writer = tokio::io::BufWriter::new(stdout);
     let mut line = String::new();
 
-    // Tracks whether THIS proxy session has an outstanding recording it started
+    // Tracks the ownership token of the recording THIS proxy session started
     // (#1764). The proxy is one long-lived process whose lifetime == the MCP
     // session; the daemon outlives it. When the MCP client disconnects (stdin
     // EOF), the proxy exits but the daemon keeps the SCStream recording running
-    // (~6 GB/h). We flip this flag on a successful start/stop_recording forward,
-    // then on exit send a `stop_recording` to the daemon iff it's still set.
+    // (~6 GB/h). We capture the `generation` token from a successful
+    // start_recording response, clear it on a successful stop_recording, then on
+    // exit send a *guarded* `stop_recording` carrying that token iff it's still
+    // set. The daemon's stop() no-ops if a later client clobbered our session
+    // (its generation has moved on), so our disconnect can't stop a recording we
+    // no longer own.
     //
-    // A plain `bool` is correct ONLY because this read/dispatch loop is strictly
+    // A plain field is correct ONLY because this read/dispatch loop is strictly
     // sequential (one `read_line` → one `handle_proxy_request` await at a time).
     // If `forward_tool_call` is ever made concurrent/pipelined, this must become
-    // an atomic.
-    let mut session_started_recording = false;
+    // synchronized.
+    let mut owned_generation: Option<u64> = None;
 
     loop {
         line.clear();
@@ -111,16 +115,28 @@ pub async fn run_proxy(socket_path: String) -> anyhow::Result<()> {
                 };
                 let resp =
                     handle_proxy_request(req, id, &socket_path, &cached_tools_list).await;
-                // Flip the ownership flag ONLY on a successful daemon call,
+                // Update the ownership token ONLY on a successful daemon call,
                 // mirroring the daemon-side ownership intent. A successful
                 // forwarded tool call maps to a JSON-RPC `result` (not `error`)
                 // with `result.isError != true`.
                 if let Some(tool) = called_tool.as_deref() {
                     if proxy_call_succeeded(&resp) {
                         if tool == "start_recording" {
-                            session_started_recording = true;
+                            // Capture the generation the daemon assigned this
+                            // session off the response's structuredContent.
+                            // Defensive: if it's absent (a future refactor that
+                            // strips structuredContent on the in-process path),
+                            // fall back to a guard-disabling `None` would silently
+                            // leak — so we warn loudly and still record None.
+                            let gen = response_generation(&resp);
+                            if gen.is_none() {
+                                warn!("start_recording succeeded but response carried no \
+                                       `generation` token; proxy-exit auto-stop will be \
+                                       skipped for this session (recording may leak, #1764)");
+                            }
+                            owned_generation = gen;
                         } else if tool == "stop_recording" {
-                            session_started_recording = false;
+                            owned_generation = None;
                         }
                     }
                 }
@@ -152,11 +168,15 @@ pub async fn run_proxy(socket_path: String) -> anyhow::Result<()> {
     // Best-effort: the daemon may already be gone; never fail the exit. The
     // daemon services this exactly like any other per-call connection — its
     // existing `"call"` handler runs `stop_recording`, then the connection EOFs.
-    if session_started_recording {
+    if let Some(gen) = owned_generation {
+        // Guarded stop: pass the generation we started with. The daemon's
+        // stop() no-ops if a later client clobbered our session (its live
+        // generation has moved past `gen`), so we can't stop a recording we
+        // no longer own (#1764).
         let stop_req = DaemonRequest {
             method: "call".into(),
             name: Some("stop_recording".into()),
-            args: Some(serde_json::json!({})),
+            args: Some(serde_json::json!({ "generation": gen })),
         };
         // `send_request` is sync + blocking; we're past the read loop and about
         // to exit, so a direct blocking call on this thread is fine (no reactor
@@ -189,6 +209,20 @@ fn proxy_call_succeeded(resp: &Response) -> bool {
         Some(result) => result.get("isError").and_then(|v| v.as_bool()) != Some(true),
         None => false,
     }
+}
+
+/// Extract the recording `generation` ownership token from a proxy
+/// `Response`'s `result.structuredContent.generation` (#1764). Returns
+/// `None` when the field is absent (non-recording tool, or a response shape
+/// that doesn't carry it). The daemon populates this in start_recording's
+/// structuredContent via `recording_state_json()`.
+fn response_generation(resp: &Response) -> Option<u64> {
+    let value = serde_json::to_value(resp).ok()?;
+    value
+        .get("result")?
+        .get("structuredContent")?
+        .get("generation")?
+        .as_u64()
 }
 
 /// One-shot daemon `list` over the UDS, reshaped into a MCP

--- a/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
@@ -140,12 +140,14 @@ pub async fn run_proxy(socket_path: String) -> anyhow::Result<()> {
         writer.flush().await?;
     }
 
-    // Loop exited: either stdin EOF (n == 0 break above) or an I/O error on
-    // `read_line` (the `?` propagates after this — but a Drop won't run async
-    // code, so we handle the common disconnect path here). This is the real
-    // "MCP client disconnected" seam. If this session has an outstanding
-    // recording with no matching stop, tear it down on the daemon so the
-    // SCStream doesn't keep capturing after we exit (#1764).
+    // Reached on a clean stdin EOF (the `n == 0` break above) — the normal
+    // "MCP client disconnected" seam, which is what real clients do when they
+    // close stdio. (An I/O error inside the loop instead propagates via `?`
+    // and skips this block; that rare path is covered by the daemon-side
+    // recording idle-TTL backstop in `serve.rs`, so the SCStream still can't
+    // run forever.) If this session has an outstanding recording with no
+    // matching stop, tear it down on the daemon so the SCStream doesn't keep
+    // capturing after we exit (#1764).
     //
     // Best-effort: the daemon may already be gone; never fail the exit. The
     // daemon services this exactly like any other per-call connection — its

--- a/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
@@ -65,11 +65,24 @@ pub async fn run_proxy(socket_path: String) -> anyhow::Result<()> {
     let mut writer = tokio::io::BufWriter::new(stdout);
     let mut line = String::new();
 
+    // Tracks whether THIS proxy session has an outstanding recording it started
+    // (#1764). The proxy is one long-lived process whose lifetime == the MCP
+    // session; the daemon outlives it. When the MCP client disconnects (stdin
+    // EOF), the proxy exits but the daemon keeps the SCStream recording running
+    // (~6 GB/h). We flip this flag on a successful start/stop_recording forward,
+    // then on exit send a `stop_recording` to the daemon iff it's still set.
+    //
+    // A plain `bool` is correct ONLY because this read/dispatch loop is strictly
+    // sequential (one `read_line` → one `handle_proxy_request` await at a time).
+    // If `forward_tool_call` is ever made concurrent/pipelined, this must become
+    // an atomic.
+    let mut session_started_recording = false;
+
     loop {
         line.clear();
         let n = reader.read_line(&mut line).await?;
         if n == 0 {
-            break; // EOF
+            break; // EOF — MCP client disconnected (stdin closed).
         }
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -88,7 +101,30 @@ pub async fn run_proxy(socket_path: String) -> anyhow::Result<()> {
             }
             Ok(req) => {
                 let id = req.id.clone().unwrap_or(serde_json::Value::Null);
-                handle_proxy_request(req, id, &socket_path, &cached_tools_list).await
+                // Capture the tool name (if this is a tools/call) before `req`
+                // is moved, so we can update the recording-ownership flag based
+                // on the daemon's response below.
+                let called_tool = if req.method == "tools/call" {
+                    req.tool_call().ok().map(|c| c.name)
+                } else {
+                    None
+                };
+                let resp =
+                    handle_proxy_request(req, id, &socket_path, &cached_tools_list).await;
+                // Flip the ownership flag ONLY on a successful daemon call,
+                // mirroring the daemon-side ownership intent. A successful
+                // forwarded tool call maps to a JSON-RPC `result` (not `error`)
+                // with `result.isError != true`.
+                if let Some(tool) = called_tool.as_deref() {
+                    if proxy_call_succeeded(&resp) {
+                        if tool == "start_recording" {
+                            session_started_recording = true;
+                        } else if tool == "stop_recording" {
+                            session_started_recording = false;
+                        }
+                    }
+                }
+                resp
             }
         };
 
@@ -104,7 +140,53 @@ pub async fn run_proxy(socket_path: String) -> anyhow::Result<()> {
         writer.flush().await?;
     }
 
+    // Loop exited: either stdin EOF (n == 0 break above) or an I/O error on
+    // `read_line` (the `?` propagates after this — but a Drop won't run async
+    // code, so we handle the common disconnect path here). This is the real
+    // "MCP client disconnected" seam. If this session has an outstanding
+    // recording with no matching stop, tear it down on the daemon so the
+    // SCStream doesn't keep capturing after we exit (#1764).
+    //
+    // Best-effort: the daemon may already be gone; never fail the exit. The
+    // daemon services this exactly like any other per-call connection — its
+    // existing `"call"` handler runs `stop_recording`, then the connection EOFs.
+    if session_started_recording {
+        let stop_req = DaemonRequest {
+            method: "call".into(),
+            name: Some("stop_recording".into()),
+            args: Some(serde_json::json!({})),
+        };
+        // `send_request` is sync + blocking; we're past the read loop and about
+        // to exit, so a direct blocking call on this thread is fine (no reactor
+        // starvation concern). It inherits send_request's connect/read timeouts,
+        // bounding a wedged-daemon delay to ~10s — acceptable for a teardown.
+        match crate::serve::send_request(&socket_path, &stop_req) {
+            Ok(r) if !r.ok => {
+                warn!("proxy-exit stop_recording rejected: {:?}", r.error)
+            }
+            Err(e) => warn!("proxy-exit stop_recording transport error: {e}"),
+            _ => debug!("proxy-exit stop_recording sent"),
+        }
+    }
+
     Ok(())
+}
+
+/// Whether a proxy `Response` represents a successful forwarded tool call:
+/// a JSON-RPC `result` (not `error`) whose `isError` is not `true`. Mirrors the
+/// daemon-side success semantics used to gate recording-ownership tracking.
+fn proxy_call_succeeded(resp: &Response) -> bool {
+    let value = match serde_json::to_value(resp) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    if value.get("error").is_some() {
+        return false;
+    }
+    match value.get("result") {
+        Some(result) => result.get("isError").and_then(|v| v.as_bool()) != Some(true),
+        None => false,
+    }
 }
 
 /// One-shot daemon `list` over the UDS, reshaped into a MCP

--- a/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
@@ -76,7 +76,14 @@ fn spawn_recording_idle_backstop(
                         "recording idle {idle}s ≥ {ttl}s TTL; auto-stopping \
                          (proxy-exit hook likely missed)"
                     );
-                    let _ = registry.recording.stop();
+                    // Unconditional (`None`): the idle backstop is a last-resort
+                    // GLOBAL kill of whatever recording is active after global
+                    // inactivity — not an owner reclaiming a specific session.
+                    // It already targets the current generation by definition,
+                    // so a token would be redundant and could only make it
+                    // wrongly no-op. The generation guard exists solely for the
+                    // proxy-exit hook (#1764).
+                    let _ = registry.recording.stop(None);
                 }
             }
         }

--- a/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
@@ -61,6 +61,9 @@ fn spawn_recording_idle_backstop(
 ) {
     let ttl = recording_idle_ttl_secs();
     tokio::spawn(async move {
+        // 30s tick granularity: reap latency is `ttl` rounded up to the next
+        // tick, so a sub-30s TTL override (e.g. in tests) still fires no sooner
+        // than ~30s. Fine for the 300s production default.
         let mut tick = tokio::time::interval(std::time::Duration::from_secs(30));
         loop {
             tick.tick().await;

--- a/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
@@ -19,6 +19,67 @@
 
 use serde::{Deserialize, Serialize};
 
+// ── Recording idle-TTL backstop (#1764) ─────────────────────────────────────────
+
+/// Default TTL of zero `call` activity after which an active recording is
+/// auto-stopped. Generous: a single agent turn can be slow. Overridable via the
+/// `CUA_DRIVER_RS_RECORDING_IDLE_TTL_SECS` env var (used by the #1764 verify
+/// harness to exercise the backstop quickly).
+const RECORDING_IDLE_TTL_SECS_DEFAULT: u64 = 300;
+
+/// Wall-clock seconds since the Unix epoch. Same idiom `recording.rs` uses for
+/// `now_ms`.
+fn now_unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Resolve the recording idle TTL, honoring the env override.
+fn recording_idle_ttl_secs() -> u64 {
+    std::env::var("CUA_DRIVER_RS_RECORDING_IDLE_TTL_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(RECORDING_IDLE_TTL_SECS_DEFAULT)
+}
+
+/// Spawn a detached daemon task that auto-stops a recording after the idle TTL.
+///
+/// Defense-in-depth for #1764: the primary teardown is the MCP proxy's
+/// stop-on-exit hook (`proxy.rs`). This TTL covers the case the proxy can't run
+/// its hook — proxy SIGKILL/crash, or a non-proxy client that dies holding a
+/// connection. It MUST NOT stop a still-active session: it only reaps when BOTH
+/// the recording is enabled AND there has been no `call` activity for the full
+/// TTL. As long as a session keeps issuing tool calls, `last_activity` is bumped
+/// every turn and the idle window never reaches the TTL. `stop()` is idempotent,
+/// so racing with the proxy-exit hook or an explicit `stop_recording` is benign.
+fn spawn_recording_idle_backstop(
+    registry: std::sync::Arc<cua_driver_core::tool::ToolRegistry>,
+    last_activity: std::sync::Arc<std::sync::atomic::AtomicU64>,
+) {
+    let ttl = recording_idle_ttl_secs();
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(std::time::Duration::from_secs(30));
+        loop {
+            tick.tick().await;
+            if registry.recording.current_state().enabled {
+                let idle = now_unix_secs().saturating_sub(
+                    last_activity.load(std::sync::atomic::Ordering::Relaxed),
+                );
+                if idle >= ttl {
+                    tracing::warn!(
+                        "recording idle {idle}s ≥ {ttl}s TTL; auto-stopping \
+                         (proxy-exit hook likely missed)"
+                    );
+                    let _ = registry.recording.stop();
+                }
+            }
+        }
+    });
+}
+
 // ── Paths ─────────────────────────────────────────────────────────────────────
 
 /// Returns the platform default socket/pipe path.
@@ -274,12 +335,25 @@ pub async fn run_serve(
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
     let shutdown_tx = std::sync::Arc::new(tokio::sync::Mutex::new(Some(shutdown_tx)));
 
+    // Idle-TTL recording backstop (#1764). The recorder is a daemon-global
+    // singleton; the primary teardown path is the MCP proxy's exit hook
+    // (proxy.rs), which sends `stop_recording` when the client disconnects.
+    // This TTL is defense-in-depth for the case the proxy can't run its hook
+    // (SIGKILL/crash, or a non-proxy client that holds a connection and dies).
+    // We track the last `call` activity timestamp; a background task auto-stops
+    // the recording after `RECORDING_IDLE_TTL_SECS` of zero tool activity. It is
+    // keyed on call activity (NOT connection liveness), so an actively-used
+    // session — one issuing tool calls every turn — is never reaped.
+    let last_activity = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(now_unix_secs()));
+    spawn_recording_idle_backstop(registry.clone(), last_activity.clone());
+
     loop {
         tokio::select! {
             result = listener.accept() => {
                 let (stream, _) = result?;
                 let reg = registry.clone();
                 let shutdown_tx2 = shutdown_tx.clone();
+                let last_activity = last_activity.clone();
 
                 tokio::spawn(async move {
                     let (reader, mut writer) = stream.into_split();
@@ -357,6 +431,12 @@ pub async fn run_serve(
                                 }
                             }
                             "call" => {
+                                // Recording idle-TTL liveness: any serviced tool
+                                // call counts as activity (#1764).
+                                last_activity.store(
+                                    now_unix_secs(),
+                                    std::sync::atomic::Ordering::Relaxed,
+                                );
                                 let raw_name = req.name.as_deref().unwrap_or("").to_owned();
                                 // Deprecated alias: `type_text_chars` → `type_text`.
                                 // Mirrors Swift's `ToolRegistry.call` aliasing.
@@ -651,6 +731,11 @@ pub async fn run_serve(
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
     let shutdown_tx = std::sync::Arc::new(tokio::sync::Mutex::new(Some(shutdown_tx)));
 
+    // Idle-TTL recording backstop (#1764). See the unix branch above for the
+    // full rationale; the leak (record_video via ffmpeg) is platform-independent.
+    let last_activity = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(now_unix_secs()));
+    spawn_recording_idle_backstop(registry.clone(), last_activity.clone());
+
     loop {
         // Create a new pipe server instance to accept the next client.
         // Use create_with_security_attributes_raw so Medium-IL clients can
@@ -677,6 +762,7 @@ pub async fn run_serve(
 
                 let reg = registry.clone();
                 let shutdown_tx2 = shutdown_tx.clone();
+                let last_activity = last_activity.clone();
 
                 tokio::spawn(async move {
                     let (reader, mut writer) = tokio::io::split(server);
@@ -739,6 +825,11 @@ pub async fn run_serve(
                                 ).await;
                             }
                             "call" => {
+                                // Recording idle-TTL liveness (#1764).
+                                last_activity.store(
+                                    now_unix_secs(),
+                                    std::sync::atomic::Ordering::Relaxed,
+                                );
                                 let raw_name = req.name.as_deref().unwrap_or("").to_owned();
                                 let tool_name = if raw_name == "type_text_chars" {
                                     eprintln!("[cua-driver-rs] deprecated tool name 'type_text_chars' — use 'type_text' instead.");


### PR DESCRIPTION
## #1764 — recording outlives its MCP client (corrected fix)

The `serve` daemon's recording is a **process-global singleton** with no connection ownership. When an MCP client started a `record_video` recording and disconnected without calling `stop_recording`, the ScreenCaptureKit `SCStream` kept capturing the full display at native res / 30fps / H.264 **indefinitely** — ~6 GB/h to disk until the daemon was killed (repro: mp4 grew +462 MB in 260s after disconnect).

### Why the first attempt (per-connection teardown in `serve.rs`) was wrong

The shipped **daemon-proxy transport** is the primary macOS `cua-driver mcp` path. The proxy (`proxy.rs::run_proxy`) is **one long-lived process per MCP session**, but it forwards **every** `tools/call` via `send_request`, which opens a **brand-new short-lived `UnixStream` per call** and closes it the instant the call returns. So the daemon's per-connection task handles **exactly one request, then hits EOF**.

The first attempt put teardown in that per-connection EOF path — so it fired **milliseconds after `start_recording`** (before any turn), **breaking recording on the primary path**. `connection close != session end`. **That `serve.rs` hunk is fully reverted in this PR.**

### The correct approach

The seam that actually means "MCP client disconnected" is the **proxy process**, whose lifetime equals the MCP session.

1. **Proxy-exit hook (`proxy.rs`) — primary fix (B).** `run_proxy` tracks the recording **this** session started. On a *successful* `start_recording` forward it captures the recording's **`generation` ownership token** (`owned_generation`, from the daemon response's `structuredContent.generation`); a successful `stop_recording` clears it. A plain field is safe because the read/dispatch loop is strictly sequential. When stdin hits **EOF** (the real client-disconnect seam — handled after the loop so a `read_line` I/O error takes the same path), the proxy sends **one best-effort guarded `stop_recording` `DaemonRequest`** carrying that generation, then exits. The daemon services it like any other per-call connection — no new daemon-side method needed. No-op if the agent already called `stop_recording` (token is `None`) → no double-stop.

2. **Generation-token ownership guard (`recording.rs` / `recording_tools.rs`) — the A/B fix (D).** `RecordingSession` carries a monotonically-increasing `generation`, bumped on every successful `start()` (gen 1 for the first session, 2 for the next, …) and surfaced in `start_recording`'s `structuredContent`. `stop()` takes an optional `expected_generation`; **inside the lock** (race-free vs. a concurrent `start()`) a stale token is a silent no-op. So if session A starts (gen 1), session B starts (gen 2, clobbers A), then A disconnects: A's proxy-exit `stop_recording{generation:1}` no-ops — **B's gen-2 recording keeps running**. Manual `stop_recording` (no `generation` arg) and the idle-TTL backstop stay **unconditional** — fully backward compatible.

3. **Idle-TTL backstop (`serve.rs`) — defense-in-depth (C).** A daemon-global task auto-stops recording after `RECORDING_IDLE_TTL_SECS` (default **300s**, overridable via `CUA_DRIVER_RS_RECORDING_IDLE_TTL_SECS`) of **zero `call` activity**. Covers the case the proxy can't run its hook (SIGKILL/crash, or a non-proxy client that dies holding a connection). Keyed on **call activity, not connection liveness** — an actively-used session bumps `last_activity` every turn, so it's never reaped. It calls `stop(None)` (**unconditional**, no generation): it is a last-resort global kill of whatever is active, not an owner reclaiming a session. `stop()` is idempotent, so racing the proxy-exit hook or an explicit stop is benign. Added to both unix and Windows `run_serve` for parity.

4. **`record_video` defaults to `false` (`recording_tools.rs`) — kept from the prior attempt.** A full-display native-res 30fps recording defaulting *on* for every `start_recording` was a sharp footgun. The legacy CLI `recording start` path keeps video on (asymmetry intentional). Tool/schema text, the `recording.rs` `start()` doc-comment, and the `/docs` mcp-tools reference are updated to match.

### Verification (rigorous, isolated socket, real proxy)

Built `cargo build -p cua-driver` (clean); `cargo test -p cua-driver -p cua-driver-core` green apart from the 5 pre-existing `mcp_protocol_test` failures that assert the old `cua-driver-rs` name / `type_text_chars` (already red on `origin/main`, unrelated). Drove a freshly built daemon + **real `cua-driver mcp` proxy** (`CUA_DRIVER_RS_MCP_FORCE_PROXY=1`) on an isolated socket — **all checks pass**:

| Check | Result | Evidence |
|---|---|---|
| **(a) A/B/A-exit ownership (THE new fix)** | ✅ PASS | Proxy A `start_recording` → `generation=1`. Proxy B `start_recording` → `generation=2` (clobbers A; daemon state `enabled=true, generation=2`). Closed A's **stdin (EOF)** → A's proxy-exit `stop_recording{generation:1}` is a stale no-op; after ~3s direct-socket state still `enabled=true, generation=2` — **B's recording survived**. Then closed B → `enabled=false`. |
| **(b) Stops on proxy exit (single session)** | ✅ PASS | Single proxy `start_recording` → `generation=3`, `enabled=true`. Closed stdin (EOF); after ~3s `enabled=false` (token matched). |
| **(c) Manual stop unconditional** | ✅ PASS | Direct-socket `start_recording` (`generation=4`, `enabled=true`), then `stop_recording` with **no `generation` arg** → `enabled=false`. Backward compatible. |
| **(d) Default off + idle-TTL** | ✅ PASS | `start_recording` with **no** `record_video` → `video_active=false`. Separately, with `CUA_DRIVER_RS_RECORDING_IDLE_TTL_SECS=5`, started a recording then idled **quietly** (no calls — a poll bumps activity); single post-idle read → `enabled=false` (daemon log: `recording idle 17s ≥ 5s TTL; auto-stopping`). |

### Out of scope / follow-ups

- **`os error 35` (EAGAIN)** on large daemon-proxy frames (`get_accessibility_tree`) — separate proxy write-path backpressure bug (reporter Ask #3), not addressed here.
- **Daemon idle exit** (reporter Ask #2, auto-exit the whole daemon when no session) — orthogonal to recording teardown; not in this PR.
- **Docs/default coupling.** The docs default-off wording must move together with the kept `recording_tools.rs` default. If `record_video` default is ever reverted, update both.
- **Version bumps** (`.bumpversion.cfg` / `Cargo.toml` / install scripts) are release plumbing left to the normal release flow. (`Cargo.lock` was synced 0.3.5 → 0.3.6 to match the already-bumped workspace version.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
