### PR TITLE
fix(cua-driver-rs)(macos): `mcp` runs headless instead of SIGABRT-ing without Window Server access (#1724)

### DIFF
--- a/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
@@ -145,6 +145,21 @@ pub fn run_on_main_thread() {
         loop { std::thread::park(); }
     }
 
+    // AppKit's `+[NSApplication sharedApplication]` registers the process with
+    // the Window Server and ABORTS the whole process (SIGABRT in
+    // `_RegisterApplication`) when there's no graphic-session access — e.g.
+    // `mcp` run as a stdio child from SSH, a LaunchDaemon, or headless CI.
+    // Detect that without touching AppKit and run headless: the MCP server
+    // keeps serving on its background thread while this thread just parks,
+    // exactly as it does when the overlay is disabled. See issue #1724.
+    if !crate::session::has_graphic_access() {
+        tracing::warn!(
+            "no Window Server / graphic-session access — skipping cursor \
+             overlay and running headless (issue #1724)"
+        );
+        loop { std::thread::park(); }
+    }
+
     // ------------------------------------------------------------------
     // AppKit setup (all on the main thread).
     // ------------------------------------------------------------------

--- a/libs/cua-driver/rust/crates/platform-macos/src/lib.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/lib.rs
@@ -36,6 +36,8 @@ pub mod recording_hooks;
 pub mod video_sckit;
 #[cfg(target_os = "macos")]
 pub mod pip;
+#[cfg(target_os = "macos")]
+pub mod session;
 
 use cua_driver_core::tool::ToolRegistry;
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/session.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/session.rs
@@ -1,0 +1,58 @@
+//! Security-session capability probe.
+//!
+//! AppKit's `+[NSApplication sharedApplication]` registers the process with
+//! the Window Server (`_RegisterApplication`). When the calling process has
+//! no graphic-session access — `cua-driver mcp` spawned as a stdio child from
+//! an SSH session, a `LaunchDaemon`, or a headless CI runner — that
+//! registration **aborts the whole process with SIGABRT** before any error
+//! reaches the caller (issue #1724).
+//!
+//! `SessionGetInfo` answers "can this session talk to the Window Server?"
+//! *without* touching AppKit, so we can gate overlay init on it and degrade
+//! to a headless MCP server instead of crashing. This is the macOS analogue
+//! of the Session-0 short-circuit guard used on Windows.
+
+// `SecuritySessionId` and `SessionAttributeBits` are both 32-bit ints in
+// <Security/AuthSession.h>.
+type SecuritySessionId = i32;
+type SessionAttributeBits = u32;
+
+/// `callerSecuritySession` — the session of the calling process.
+const CALLER_SECURITY_SESSION: SecuritySessionId = -1;
+/// `sessionHasGraphicAccess` — the session can use the Window Server.
+const SESSION_HAS_GRAPHIC_ACCESS: SessionAttributeBits = 0x0010;
+
+#[link(name = "Security", kind = "framework")]
+extern "C" {
+    fn SessionGetInfo(
+        session: SecuritySessionId,
+        session_id: *mut SecuritySessionId,
+        attributes: *mut SessionAttributeBits,
+    ) -> i32; // OSStatus; errSecSuccess == 0
+}
+
+/// Whether the current security session can use the Window Server (and thus
+/// safely initialize AppKit). On any failure we return `false` — skipping the
+/// overlay is always recoverable, but a wrong `true` re-introduces the
+/// `_RegisterApplication` SIGABRT (issue #1724).
+pub fn has_graphic_access() -> bool {
+    let mut session_id: SecuritySessionId = 0;
+    let mut attributes: SessionAttributeBits = 0;
+    let status =
+        unsafe { SessionGetInfo(CALLER_SECURITY_SESSION, &mut session_id, &mut attributes) };
+    status == 0 && (attributes & SESSION_HAS_GRAPHIC_ACCESS) != 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The probe must resolve the `Security` symbol and return a `bool`
+    /// without aborting. We can't assert the value: it's `true` on a dev GUI
+    /// session and `false` on a headless CI runner — which is exactly the
+    /// distinction the guard relies on (issue #1724).
+    #[test]
+    fn graphic_access_probe_does_not_abort() {
+        let _ = has_graphic_access();
+    }
+}


### PR DESCRIPTION
## Problem

`cua-driver mcp` aborts with **SIGABRT** before the MCP handshake when launched as a stdio child in a context with no Window Server / graphic-session access. CrashReporter shows the abort inside AppKit process registration:

```
abort
_RegisterApplication
…
-[NSApplication init]
+[NSApplication sharedApplication]
```

Reported in #1724 (macOS 15.7.7, arm64; parent process python/codex).

## Root cause

When `mcp` falls through to the **in-process** server (dev binary not inside `CuaDriver.app`, `--no-daemon-relaunch`, or a launchd parent), the cursor overlay brings up AppKit on the main thread. `+[NSApplication sharedApplication]` registers the process with the Window Server, and that registration **aborts the whole process** when the session has no graphic access — SSH, a `LaunchDaemon`, or a headless CI runner.

The existing headless guard (`mainScreen.is_null()` in `run_appkit`) is **too late** — the abort happens earlier, inside `sharedApplication` itself.

> Note: the *primary* repro (a bundle-resolved `mcp` spawned by an MCP client) is already handled on current releases by the daemon-proxy re-exec (#1525 / #1530), which routes that case away from AppKit entirely. This PR hardens the remaining in-process path.

## Fix

Probe `SessionGetInfo`'s `sessionHasGraphicAccess` bit — which answers "can this session talk to the Window Server?" **without touching AppKit** — and skip the overlay when it's unset, parking the main thread exactly as the overlay-disabled path already does. The MCP server keeps serving on its background thread, so `mcp` **degrades to headless instead of dying**.

This is the macOS analogue of the Windows Session-0 short-circuit guard.

## Changes

- `platform-macos/src/session.rs` — `has_graphic_access()` via `SessionGetInfo` (new)
- `platform-macos/src/cursor/overlay.rs` — gate AppKit init on it, with a `warn!` + headless fallback
- `platform-macos/src/lib.rs` — expose the module

## Verification

- `cargo build -p cua-driver` — builds and links the `Security` framework ✓
- Standalone probe in this GUI session returns `status=0 attrs=0x6030 hasGraphic=true` (the `sessionHasGraphicAccess` bit `0x10` is set) — so the overlay still runs normally for real users; only no-graphic-access contexts take the new headless path ✓
- Added a CI-safe smoke test (asserts the probe resolves the symbol and returns without aborting; can't assert the value since headless CI = `false`, which is exactly the distinction the guard relies on) ✓

A full repro of the crash itself needs a no-graphic-access spawn context (SSH / LaunchDaemon), which can't be staged on a GUI dev box — happy to coordinate a live retest with the reporter.

Closes #1724

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## macOS Headless Environment Support

* **Bug Fixes**
  * Added detection for Window Server/graphics session availability on macOS
  * Application now gracefully handles headless and CI environments without crashing when graphics access is unavailable, allowing background services to continue operating

<!-- end of auto-generated comment: release notes by coderabbit.ai -->