### PR TITLE
fix(cua-driver)(macos): guard SkyLight auth-message selector for macOS 14 Sonoma (#1503)

### DIFF
--- a/libs/cua-driver/rust/crates/platform-macos/src/input/skylight.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/skylight.rs
@@ -206,6 +206,28 @@ fn sel_register(name: &CStr) -> *mut c_void {
     }
 }
 
+/// Whether `cls` actually implements `sel`, via `class_respondsToSelector`.
+///
+/// macOS 14 (Sonoma) compatibility guard: `SLSEventAuthenticationMessage`
+/// exists on macOS 14, but `messageWithEventRecord:pid:version:` was only
+/// added in macOS 15 (Sequoia). `sel_registerName` always succeeds (it just
+/// interns the string), so a `!sel.is_null()` check is not enough — we must
+/// confirm the class responds before calling `objc_msgSend`, or the runtime
+/// raises `NSInvalidArgumentException: unrecognized selector`. See #1503.
+fn class_responds_to_selector(cls: *mut c_void, sel: *mut c_void) -> bool {
+    if cls.is_null() || sel.is_null() {
+        return false;
+    }
+    type RespondsToFn = unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool;
+    static SYM: OnceLock<Option<RespondsToFn>> = OnceLock::new();
+    let f = *SYM
+        .get_or_init(|| find_sym(b"class_respondsToSelector\0").map(|p| unsafe { as_fn(p) }));
+    match f {
+        Some(f) => unsafe { f(cls, sel) },
+        None => false,
+    }
+}
+
 // ── SLSEventRecord extraction ──────────────────────────────────────────────
 
 /// Extract the embedded `SLSEventRecord *` from a `CGEvent`.
@@ -244,11 +266,19 @@ pub fn post_to_pid(pid: pid_t, event_ptr: *mut c_void, attach_auth_message: bool
 
     if attach_auth_message {
         // Build and attach SLSEventAuthenticationMessage.
+        //
+        // macOS 14 (Sonoma) compatibility: the class exists on macOS 14 but
+        // `messageWithEventRecord:pid:version:` was added in macOS 15. Guard
+        // with `class_respondsToSelector` (a `!sel.is_null()` check is not
+        // enough — `sel_registerName` interns any name); when the selector is
+        // absent we skip the auth envelope and fall through to the plain
+        // `SLEventPostToPid` below. Chromium-class targets may not receive the
+        // event on macOS 14, but the daemon no longer crashes. See #1503.
         let cls = objc_class(c"SLSEventAuthenticationMessage");
         let sel = sel_register(c"messageWithEventRecord:pid:version:");
         let factory = factory_msg_send_fn();
 
-        if !cls.is_null() && !sel.is_null() {
+        if class_responds_to_selector(cls, sel) {
             if let Some(factory_fn) = factory {
                 let record = unsafe { extract_event_record(event_ptr) };
                 if !record.is_null() {

--- a/libs/cua-driver/swift/Sources/CuaDriverCore/Input/SkyLightEventPost.swift
+++ b/libs/cua-driver/swift/Sources/CuaDriverCore/Input/SkyLightEventPost.swift
@@ -104,13 +104,22 @@ public enum SkyLightEventPost {
                 "SLSEventAuthenticationMessage")
         else { return nil }
 
+        // macOS 14 (Sonoma) compatibility: the class exists on macOS 14 but
+        // `messageWithEventRecord:pid:version:` was added in macOS 15.
+        // `NSSelectorFromString` always succeeds (it interns the string), so
+        // verify the class responds before storing it — otherwise `objc_msgSend`
+        // raises NSInvalidArgumentException at runtime and crashes the daemon.
+        // When absent, return nil so callers skip the auth envelope. See #1503.
+        let factorySelector = NSSelectorFromString(
+            "messageWithEventRecord:pid:version:")
+        guard messageClass.responds(to: factorySelector) else { return nil }
+
         return Resolved(
             postToPid: postToPid,
             setAuthMessage: setAuth,
             msgSendFactory: msgSend,
             messageClass: messageClass,
-            factorySelector: NSSelectorFromString(
-                "messageWithEventRecord:pid:version:")
+            factorySelector: factorySelector
         )
     }()
 


### PR DESCRIPTION
## Problem

`hotkey`, `press_key`, and `scroll` crash the daemon on **macOS 14 (Sonoma)** with:

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException',
reason: '+[SLSEventAuthenticationMessage messageWithEventRecord:pid:version:]:
unrecognized selector sent to class'
```

Reported in #1503 (macOS 14.8.7, Apple Silicon). `type_text` (Accessibility) and `capture`/`click` are unaffected — only the SkyLight key/scroll posting path crashes.

## Root cause

`SLSEventAuthenticationMessage` exists on macOS 14, but the `messageWithEventRecord:pid:version:` factory selector was only added in **macOS 15 (Sequoia)**. The existing `!cls.is_null() && !sel.is_null()` guard is insufficient — `sel_registerName` / `NSSelectorFromString` always succeed (they just intern the string), so `objc_msgSend` dispatches an unimplemented selector and the ObjC runtime aborts the whole process.

## Fix

Guard the dispatch with **`class_respondsToSelector`** (Rust) / **`messageClass.responds(to:)`** (Swift), which actually checks whether the (meta)class implements the selector. On macOS 14 it returns false → we skip the auth envelope and fall through to plain `SLEventPostToPid`. Chromium-class targets may not receive the event on macOS 14, but the daemon no longer crashes — graceful degradation.

## Credit / relationship to #1579

This re-applies the fix originally written by @hippoley in **#1579** onto the current `libs/cua-driver/{rust,swift}/` layout. #1579 predates the #1674 directory restructure (`libs/cua-driver-rs/` → `libs/cua-driver/{rust,swift}/`) and no longer merges. @hippoley is credited as co-author on the commit. **Supersedes #1579.**

## Changes

- `rust:  platform-macos/src/input/skylight.rs` — add `class_responds_to_selector()` and use it in `post_to_pid`
- `swift: CuaDriverCore/Input/SkyLightEventPost.swift` — `messageClass.responds(to:)` guard in the resolver

## Verification

- `cargo build -p platform-macos` and `-p cua-driver` both build ✓
- The Swift `responds(to:)` form compiles on `AnyClass` and returns `true` for an existing class method, `false` for an absent one ✓ (verified with a standalone `swiftc` snippet)
- A live on-Sonoma confirmation (running `hotkey` without the crash) needs a macOS 14 box — happy to coordinate a retest with the reporter.

Closes #1503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced macOS 14 compatibility with improved runtime checks for keyboard event handling. The system now safely validates available APIs before attempting to use them, preventing potential crashes and gracefully falling back to alternative behavior when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->