### PR TITLE
Add pixel wheel scrolling for canvas apps

### DIFF
--- a/docs/content/docs/cua-driver/reference/mcp-tools.mdx
+++ b/docs/content/docs/cua-driver/reference/mcp-tools.mdx
@@ -360,23 +360,41 @@ For free-form text entry into web inputs, prefer `type_text_chars` which synthes
 
 ### scroll
 
-Scroll the target pid's focused region by synthesized keystrokes.
+Scroll the target pid's focused region.
 
-Mapping: by='page' → PageDown/PageUp × amount; by='line' → DownArrow/UpArrow × amount. Horizontal variants use Left/Right arrow keys.
+Default mode preserves the historical keystroke path: by='page' → PageDown/PageUp × amount; by='line' → DownArrow/UpArrow × amount. Horizontal variants use Left/Right arrow keys.
+
+For canvas, video, WebGL, and infinite-canvas apps that ignore key scrolling, use by='pixel' or provide delta_x / delta_y. That path posts native pixel scroll-wheel events to the target pid, can anchor the wheel event at x/y in window-local screenshot pixels, and can hold modifier keys across the gesture.
 
 Optional element_index + window_id pre-focuses the element before scrolling.
 
 **Arguments:**
 
-- `amount` (integer, optional): Number of keystroke repetitions. Default: 3.
-- `by` (string, optional): Scroll granularity. Default: line.
-- `direction` (string, required): Scroll direction.
+- `amount` (number, optional): Keystroke repetitions for line/page; pixel distance for by=pixel. Defaults: 3 for keys, 120 for pixels.
+- `by` (string, optional): Scroll granularity. Default: line. Use pixel for native wheel events.
+- `delay_ms` (integer, optional): Native wheel path only. Delay between split wheel events. Default: 8.
+- `delta_x` (number, optional): Native wheel path only. Positive values scroll/pan the viewport right.
+- `delta_y` (number, optional): Native wheel path only. Positive values scroll/pan the viewport down.
+- `direction` (string, optional): Scroll direction. Required unless delta_x or delta_y is supplied.
 - `element_index` (integer, optional)
+- `from_zoom` (boolean, optional): When true, x/y are in the last zoom image for this pid; driver translates back to full-window coordinates.
+- `modifier` (array of string, optional): Native wheel path only. Modifier keys held across the gesture: cmd, shift, option/alt, ctrl.
 - `pid` (integer, required)
+- `steps` (integer, optional): Native wheel path only. Split the pixel delta into this many wheel events. Default: 1.
 - `window_id` (integer, optional)
+- `x` (number, optional): Native wheel path only. Window-local screenshot X coordinate to anchor the event.
+- `y` (number, optional): Native wheel path only. Window-local screenshot Y coordinate to anchor the event.
 
 ```json
 {"direction":"down","pid":844}
+```
+
+```json
+{"pid":844,"window_id":10725,"by":"pixel","direction":"down","amount":240,"x":600,"y":400}
+```
+
+```json
+{"pid":844,"window_id":10725,"delta_x":300,"delta_y":-120,"steps":4}
 ```
 
 ### move_cursor

--- a/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
@@ -324,7 +324,7 @@ against a specific window.
 | Right click / context menu | `right_click({pid, window_id, element_index})` or `click({pid, window_id, element_index, action: "show_menu"})` | Chromium web-content coerces pixel right-click to left on macOS — see `WEB_APPS.md` |
 | Type at cursor | `type_text({pid, text, window_id, element_index})` | focuses element first, then writes via the platform's text-set primitive |
 | Set whole field value | `set_value({pid, window_id, element_index, value})` | sliders, steppers, text fields; **use for keyboard-commit workarounds on minimized windows** |
-| Scroll | `scroll({pid, direction, amount, by, window_id, element_index})` | synthesizes per-pid PageUp/PageDown/arrows |
+| Scroll | `scroll({pid, direction, amount, by, window_id, element_index})` | default path synthesizes per-pid PageUp/PageDown/arrows; use `by: "pixel"` or `delta_x`/`delta_y` for native wheel events in canvas/WebGL surfaces |
 | Focus + send key | `press_key({pid, key, window_id, element_index, modifiers})` | element_index sets focus, then posts key |
 | Send key to pid | `press_key({pid, key, modifiers})` | no focus change; key goes to pid's current focus |
 | Modifier combo | `hotkey({pid, keys})` | e.g. `["cmd","c"]` / `["ctrl","c"]`; posted per-pid, not HID tap |

--- a/libs/cua-driver/rust/Skills/cua-driver/WEB_APPS.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/WEB_APPS.md
@@ -199,19 +199,31 @@ snap = get_window_state({pid, window_id})
 scroll({pid, window_id, direction: "down", amount: 3, by: "page", element_index: <web_area>})
 ```
 
-Under the hood: `scroll` synthesizes PageUp / PageDown / arrow-key
-keystrokes and posts them via the same auth-signed `SLEventPostToPid`
-path `press_key` uses. That's why it reaches Chromium even when the
-window is backgrounded. Wheel events posted via the same per-pid
-SkyLight path are silently dropped by Chromium's renderer (no
-Scroll-specific auth subclass exists — probe tests confirmed this),
-so the working primitive is keyboard.
+Under the hood: `scroll` uses PageUp / PageDown / arrow-key
+keystrokes for `by: "page"` and `by: "line"`, posted via the same
+auth-signed `SLEventPostToPid` path `press_key` uses. That's the
+most reliable primitive for ordinary document scrolling.
 
 Granularity: `by: "page"` → PageDown/PageUp (one viewport height
 per unit). `by: "line"` → arrow keys (fine-grained; a few pixels
 per unit in web views, one line in text views). Horizontal `page`
 falls back to Left/Right arrows since there's no standard
 horizontal-page shortcut.
+
+For canvas / WebGL / infinite-canvas surfaces that don't expose a
+scrollable AXWebArea and don't respond to arrow/PageDown, switch to
+native pixel-wheel mode:
+
+```text
+scroll({pid, window_id, by: "pixel", direction: "down", amount: 240, x: 600, y: 400})
+scroll({pid, window_id, delta_x: 300, delta_y: -120, steps: 4})
+```
+
+`x` / `y` are window-local screenshot pixels and anchor the wheel
+event under the virtual cursor. Positive `delta_x` pans right;
+positive `delta_y` pans down. Use `modifier: ["cmd"]` /
+`["option"]` / `["ctrl"]` for apps that bind wheel+modifier to zoom
+or alternate pan modes.
 
 `element_index` is focused (`AXFocused=true`) before the
 keystrokes fire — useful for directing the scroll into a specific

--- a/libs/cua-driver/rust/crates/platform-macos/src/input/mouse.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/mouse.rs
@@ -11,7 +11,7 @@
 //! cgAnnotatedSessionEventTap, which Chromium's window handler subscribes to.
 
 use core_graphics::{
-    event::{CGEvent, CGEventFlags, CGEventType, CGMouseButton},
+    event::{CGEvent, CGEventFlags, CGEventType, CGMouseButton, ScrollEventUnit},
     event_source::{CGEventSource, CGEventSourceStateID},
     geometry::CGPoint,
 };
@@ -316,6 +316,50 @@ pub fn drag_at_xy(
     Ok(())
 }
 
+/// Post a native scroll-wheel event to `pid`.
+///
+/// `delta_x` / `delta_y` use tool-facing viewport semantics: positive X scrolls
+/// right, positive Y scrolls down. CoreGraphics wheel deltas are inverted from
+/// that convention, so this helper translates before creating the event.
+pub fn scroll_wheel_at_xy(
+    pid: i32,
+    screen_point: Option<(f64, f64)>,
+    window_local: Option<(f64, f64)>,
+    wid: Option<u32>,
+    delta_x: f64,
+    delta_y: f64,
+    modifiers: &[&str],
+) -> anyhow::Result<()> {
+    let source = CGEventSource::new(CGEventSourceStateID::HIDSystemState)
+        .map_err(|_| anyhow::anyhow!("CGEventSource::new failed"))?;
+    let flags = parse_modifier_flags(modifiers);
+
+    let wheel_y = (-delta_y).round().clamp(i32::MIN as f64, i32::MAX as f64) as i32;
+    let wheel_x = (-delta_x).round().clamp(i32::MIN as f64, i32::MAX as f64) as i32;
+    if wheel_x == 0 && wheel_y == 0 {
+        return Ok(());
+    }
+
+    let event = CGEvent::new_scroll_event(
+        source,
+        ScrollEventUnit::PIXEL,
+        2,
+        wheel_y,
+        wheel_x,
+        0,
+    ).map_err(|_| anyhow::anyhow!("CGEvent::new_scroll_event failed"))?;
+
+    if let Some((x, y)) = screen_point {
+        event.set_location(CGPoint::new(x, y));
+    }
+    if flags != CGEventFlags::CGEventFlagNull {
+        event.set_flags(flags);
+    }
+
+    post_scroll_event(pid, &event, window_local, wid);
+    Ok(())
+}
+
 /// Mouse button for drag gestures.
 #[derive(Clone, Copy, Debug)]
 pub enum DragButton {
@@ -434,6 +478,33 @@ fn post_mouse_event(
 
     // Public path: delivers to AppKit targets where SkyLight mouse drops.
     // Belt+suspenders — both fire unconditionally (matches Swift `postBoth`).
+    event.post_to_pid(pid as libc::pid_t);
+}
+
+fn post_scroll_event(
+    pid: i32,
+    event: &CGEvent,
+    window_local: Option<(f64, f64)>,
+    wid: Option<u32>,
+) {
+    let event_ptr = event.as_ptr() as *mut std::ffi::c_void;
+
+    if let Some((wx, wy)) = window_local {
+        crate::input::skylight::set_window_location(event_ptr, wx, wy);
+    }
+
+    if let Some(wid) = wid {
+        let window_id = wid as i64;
+        let set = |f: u32, v: i64| { crate::input::skylight::set_integer_field(event_ptr, f, v); };
+        set(51, window_id); // windowNumber
+        set(91, window_id); // kCGMouseEventWindowUnderMousePointer
+        set(92, window_id); // kCGMouseEventWindowUnderMousePointerThatCanHandleThisEvent
+    }
+
+    crate::input::skylight::set_integer_field(event_ptr, 40, pid as i64);
+    // kCGScrollWheelEventIsContinuous = 88; mark pixel wheels as trackpad-style.
+    crate::input::skylight::set_integer_field(event_ptr, 88, 1);
+    crate::input::skylight::post_to_pid(pid as libc::pid_t, event_ptr, false);
     event.post_to_pid(pid as libc::pid_t);
 }
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/scroll.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/scroll.rs
@@ -18,34 +18,78 @@ impl ScrollTool {
 }
 
 static DEF: std::sync::OnceLock<ToolDef> = std::sync::OnceLock::new();
+const DEFAULT_KEY_AMOUNT: u64 = 3;
+const MAX_KEY_AMOUNT: f64 = 20_000.0;
+const DEFAULT_PIXEL_AMOUNT: f64 = 120.0;
 
 fn def() -> &'static ToolDef {
     DEF.get_or_init(|| ToolDef {
         name: "scroll".into(),
-        description: "Scroll the target pid's focused region by synthesized keystrokes.\n\n\
-            Mapping: by='page' → PageDown/PageUp × amount; by='line' → DownArrow/UpArrow × amount. \
-            Horizontal variants use Left/Right arrow keys.\n\n\
-            Optional element_index + window_id pre-focuses the element before scrolling.".into(),
+        description: "Scroll the target pid's focused region.\n\n\
+            Default mode preserves the historical keystroke path: by='page' → PageDown/PageUp × amount; \
+            by='line' → DownArrow/UpArrow × amount. Horizontal variants use Left/Right arrow keys.\n\n\
+            For canvas, video, WebGL, and infinite-canvas apps that ignore key scrolling, use by='pixel' \
+            or provide delta_x / delta_y. That path posts native pixel scroll-wheel events to the target \
+            pid, can anchor the wheel event at x/y in window-local screenshot pixels, and can hold modifier \
+            keys across the gesture.\n\n\
+            Optional element_index + window_id pre-focuses the element before keystroke scrolling.".into(),
         input_schema: serde_json::json!({
             "type": "object",
-            "required": ["pid", "direction"],
+            "required": ["pid"],
             "properties": {
                 "pid": { "type": "integer" },
                 "direction": {
                     "type": "string",
                     "enum": ["up", "down", "left", "right"],
-                    "description": "Scroll direction."
+                    "description": "Scroll direction. Required unless delta_x or delta_y is supplied."
                 },
                 "by": {
                     "type": "string",
-                    "enum": ["line", "page"],
-                    "description": "Scroll granularity. Default: line."
+                    "enum": ["line", "page", "pixel"],
+                    "description": "Scroll granularity. Default: line. Use pixel for native wheel events."
                 },
                 "amount": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 20000,
+                    "description": "Keystroke repetitions for line/page; pixel distance for by=pixel. Defaults: 3 for keys, 120 for pixels."
+                },
+                "delta_x": {
+                    "type": "number",
+                    "description": "Native wheel path only. Positive values scroll/pan the viewport right."
+                },
+                "delta_y": {
+                    "type": "number",
+                    "description": "Native wheel path only. Positive values scroll/pan the viewport down."
+                },
+                "x": {
+                    "type": "number",
+                    "description": "Native wheel path only. Window-local screenshot X coordinate to anchor the event."
+                },
+                "y": {
+                    "type": "number",
+                    "description": "Native wheel path only. Window-local screenshot Y coordinate to anchor the event."
+                },
+                "from_zoom": {
+                    "type": "boolean",
+                    "description": "When true, x/y are in the last zoom image for this pid; driver translates back to full-window coordinates."
+                },
+                "modifier": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Native wheel path only. Modifier keys held across the gesture: cmd, shift, option/alt, ctrl."
+                },
+                "steps": {
                     "type": "integer",
                     "minimum": 1,
-                    "maximum": 50,
-                    "description": "Number of keystroke repetitions. Default: 3."
+                    "maximum": 100,
+                    "description": "Native wheel path only. Split the pixel delta into this many wheel events. Default: 1."
+                },
+                "delay_ms": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 1000,
+                    "description": "Native wheel path only. Delay between split wheel events. Default: 8."
                 },
                 "window_id": { "type": "integer" },
                 "element_index": { "type": "integer" }
@@ -66,9 +110,31 @@ impl Tool for ScrollTool {
     async fn invoke(&self, args: Value) -> ToolResult {
         use cua_driver_core::tool_args::ArgsExt;
         let pid = match args.require_i32("pid") { Ok(v) => v, Err(e) => return e };
-        let direction = match args.require_str("direction") { Ok(v) => v, Err(e) => return e };
         let by = args.str_or("by", "line");
-        let amount = args.u64_or("amount", 3) as usize;
+        if by != "line" && by != "page" && by != "pixel" {
+            return ToolResult::error("by must be one of: line, page, pixel");
+        }
+
+        if by == "pixel" || has_number(&args, "delta_x") || has_number(&args, "delta_y") {
+            return self.invoke_pixel_scroll(&args, pid).await;
+        }
+
+        self.invoke_key_scroll(&args, pid, &by).await
+    }
+}
+
+impl ScrollTool {
+    async fn invoke_key_scroll(&self, args: &Value, pid: i32, by: &str) -> ToolResult {
+        use cua_driver_core::tool_args::ArgsExt;
+        let direction = match args.require_str("direction") { Ok(v) => v, Err(e) => return e };
+        let amount = coerce_number(args, "amount").unwrap_or(DEFAULT_KEY_AMOUNT as f64);
+        if !amount.is_finite() || amount <= 0.0 {
+            return ToolResult::error("amount must be a positive finite number");
+        }
+        if amount > MAX_KEY_AMOUNT {
+            return ToolResult::error("amount must be <= 20000");
+        }
+        let amount = amount.round().clamp(1.0, MAX_KEY_AMOUNT) as usize;
         let element_index = args.opt_u64("element_index").map(|v| v as usize);
         let window_id = args.opt_u64("window_id").map(|v| v as u32);
 
@@ -81,7 +147,7 @@ impl Tool for ScrollTool {
             None
         };
 
-        let key = match (by.as_str(), direction.as_str()) {
+        let key = match (by, direction.as_str()) {
             ("page", "down")  | (_, "down") if by == "page"  => "pagedown",
             ("page", "up")    | (_, "up")   if by == "page"  => "pageup",
             ("line", "down")  | (_, "down")                  => "down",
@@ -141,5 +207,244 @@ impl Tool for ScrollTool {
             Ok(Err(e)) => ToolResult::error(format!("Scroll failed: {e}")),
             Err(e) => ToolResult::error(format!("Task error: {e}")),
         }
+    }
+
+    async fn invoke_pixel_scroll(&self, args: &Value, pid: i32) -> ToolResult {
+        use cua_driver_core::tool_args::ArgsExt;
+
+        let amount = coerce_number(args, "amount").unwrap_or(DEFAULT_PIXEL_AMOUNT);
+        if !amount.is_finite() || amount <= 0.0 {
+            return ToolResult::error("amount must be a positive finite number");
+        }
+
+        let explicit_dx = coerce_number(args, "delta_x");
+        let explicit_dy = coerce_number(args, "delta_y");
+        let (delta_x, delta_y) = match (explicit_dx, explicit_dy) {
+            (Some(dx), Some(dy)) => (dx, dy),
+            (Some(dx), None) => (dx, 0.0),
+            (None, Some(dy)) => (0.0, dy),
+            (None, None) => {
+                let direction = match args.require_str("direction") { Ok(v) => v, Err(e) => return e };
+                match direction_to_delta(&direction, amount) {
+                    Some(delta) => delta,
+                    None => return ToolResult::error("direction must be one of: up, down, left, right"),
+                }
+            }
+        };
+
+        if !delta_x.is_finite() || !delta_y.is_finite() {
+            return ToolResult::error("delta_x and delta_y must be finite numbers");
+        }
+        if delta_x == 0.0 && delta_y == 0.0 {
+            return ToolResult::error("delta_x and delta_y cannot both be zero");
+        }
+
+        let mut x = coerce_number(args, "x");
+        let mut y = coerce_number(args, "y");
+        if x.is_some() ^ y.is_some() {
+            return ToolResult::error("x and y must be provided together");
+        }
+
+        let window_id = args.opt_u64("window_id").map(|v| v as u32);
+        let from_zoom = args.bool_or("from_zoom", false);
+        let modifiers: Vec<String> = args.str_array("modifier");
+        let steps = args.u64_or("steps", 1).clamp(1, 100) as usize;
+        let delay_ms = args.u64_or("delay_ms", 8).clamp(0, 1000);
+        let cursor_key = super::cursor_tools::resolve_cursor_key(args);
+
+        if from_zoom {
+            let (Some(cx), Some(cy)) = (x, y) else {
+                return ToolResult::error("from_zoom=true requires x and y");
+            };
+            match self.state.zoom_registry.get(pid) {
+                Some(ctx) => {
+                    let (wx, wy) = ctx.zoom_to_window(cx, cy);
+                    x = Some(wx);
+                    y = Some(wy);
+                }
+                None => return ToolResult::error(format!(
+                    "from_zoom=true but no zoom context for pid {pid}. Call zoom first."
+                )),
+            }
+        } else if let Some(ratio) = self.state.resize_registry.ratio(pid) {
+            if let (Some(cx), Some(cy)) = (x, y) {
+                x = Some(cx * ratio);
+                y = Some(cy * ratio);
+            }
+        }
+        if (x.is_some() || y.is_some()) && window_id.is_none() {
+            return ToolResult::error(
+                "window_id is required when x/y are provided; x/y are window-local screenshot coordinates."
+            );
+        }
+
+        let anchor = resolve_scroll_anchor(window_id, x, y).await;
+        let (screen_point, window_local) = match anchor {
+            Ok(anchor) => anchor,
+            Err(e) => return ToolResult::error(e),
+        };
+
+        if let (Some(wid), Some((screen_x, screen_y))) = (window_id, screen_point) {
+            crate::cursor::overlay::send_command(
+                cursor_key.clone(),
+                cursor_overlay::OverlayCommand::PinAbove(wid as u64),
+            );
+            crate::cursor::overlay::animate_cursor_to(cursor_key.clone(), screen_x, screen_y).await;
+            self.state.cursor_registry.update_position(&cursor_key, screen_x, screen_y);
+        }
+
+        let prior_front = apps::frontmost_pid();
+        let snapshot = WindowChangeDetector::snapshot(prior_front);
+        let mods_owned = modifiers.clone();
+
+        let result = focus_guard::with_focus_suppressed(
+            Some(pid),
+            prior_front,
+            "scroll.CGWheel",
+            || async move {
+                tokio::task::spawn_blocking(move || {
+                    let m: Vec<&str> = mods_owned.iter().map(String::as_str).collect();
+                    for i in 0..steps {
+                        let step_dx = split_delta(delta_x, steps, i);
+                        let step_dy = split_delta(delta_y, steps, i);
+                        crate::input::mouse::scroll_wheel_at_xy(
+                            pid,
+                            screen_point,
+                            window_local,
+                            window_id,
+                            step_dx,
+                            step_dy,
+                            &m,
+                        )?;
+                        if delay_ms > 0 && i + 1 < steps {
+                            std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+                        }
+                    }
+                    Ok(())
+                })
+                .await
+            },
+        )
+        .await;
+
+        let changes = snapshot.detect_async().await;
+        let mod_suffix = if modifiers.is_empty() {
+            String::new()
+        } else {
+            format!(" with {}", modifiers.join("+"))
+        };
+        let anchor_suffix = match screen_point {
+            Some((sx, sy)) => format!(" at screen ({}, {})", sx as i64, sy as i64),
+            None => String::new(),
+        };
+
+        match result {
+            Ok(Ok(())) => ToolResult::text(format!(
+                "✅ Posted pixel scroll{mod_suffix} to pid {pid} \
+                 delta ({}, {}){anchor_suffix} in {steps} step(s).{}",
+                delta_x.round() as i64,
+                delta_y.round() as i64,
+                changes.result_suffix(),
+            )),
+            Ok(Err(e)) => ToolResult::error(format!("Pixel scroll failed: {e}")),
+            Err(e) => ToolResult::error(format!("Task error: {e}")),
+        }
+    }
+}
+
+fn has_number(args: &Value, key: &str) -> bool {
+    args.get(key).and_then(|v| v.as_f64()).is_some()
+}
+
+fn coerce_number(args: &Value, key: &str) -> Option<f64> {
+    args.get(key).and_then(|v| v.as_f64())
+}
+
+fn direction_to_delta(direction: &str, amount: f64) -> Option<(f64, f64)> {
+    match direction {
+        "up" => Some((0.0, -amount)),
+        "down" => Some((0.0, amount)),
+        "left" => Some((-amount, 0.0)),
+        "right" => Some((amount, 0.0)),
+        _ => None,
+    }
+}
+
+fn split_delta(total: f64, steps: usize, index: usize) -> f64 {
+    let steps = steps.max(1) as f64;
+    let prev = (total * index as f64 / steps).round();
+    let next = (total * (index + 1) as f64 / steps).round();
+    next - prev
+}
+
+async fn resolve_scroll_anchor(
+    window_id: Option<u32>,
+    x: Option<f64>,
+    y: Option<f64>,
+) -> Result<(Option<(f64, f64)>, Option<(f64, f64)>), String> {
+    let (Some(cx), Some(cy)) = (x, y) else {
+        if let Some(wid) = window_id {
+            let bounds = tokio::task::spawn_blocking(move || crate::windows::window_bounds_by_id(wid))
+                .await
+                .unwrap_or(None);
+            return match bounds {
+                Some(b) => {
+                    let local = (b.width / 2.0, b.height / 2.0);
+                    Ok((Some((b.x + local.0, b.y + local.1)), Some(local)))
+                }
+                None => Err(format!("No window bounds found for window_id={wid}. Provide x and y.")),
+            };
+        }
+        return Ok((None, None));
+    };
+
+    if let Some(wid) = window_id {
+        let result = tokio::task::spawn_blocking(move || {
+            let bounds = crate::windows::window_bounds_by_id(wid);
+            let scale: f64 = if let Some(ref b) = bounds {
+                if let Ok(png) = crate::capture::screenshot_window_bytes(wid) {
+                    if png.len() >= 24 {
+                        let pw = u32::from_be_bytes([png[16], png[17], png[18], png[19]]) as f64;
+                        let lw = b.width;
+                        if lw > 0.0 && pw > lw { pw / lw } else { 1.0 }
+                    } else { 1.0 }
+                } else { 1.0 }
+            } else { 1.0 };
+            (bounds, scale)
+        }).await.unwrap_or((None, 1.0));
+
+        if let (Some(b), scale) = result {
+            let local = (cx / scale, cy / scale);
+            Ok((Some((b.x + local.0, b.y + local.1)), Some(local)))
+        } else {
+            Err(format!("No window bounds found for window_id={wid}."))
+        }
+    } else {
+        Ok((Some((cx, cy)), None))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{direction_to_delta, split_delta};
+
+    #[test]
+    fn direction_to_delta_uses_viewport_semantics() {
+        assert_eq!(direction_to_delta("up", 120.0), Some((0.0, -120.0)));
+        assert_eq!(direction_to_delta("down", 120.0), Some((0.0, 120.0)));
+        assert_eq!(direction_to_delta("left", 80.0), Some((-80.0, 0.0)));
+        assert_eq!(direction_to_delta("right", 80.0), Some((80.0, 0.0)));
+        assert_eq!(direction_to_delta("sideways", 80.0), None);
+    }
+
+    #[test]
+    fn split_delta_preserves_rounded_total() {
+        let parts: Vec<f64> = (0..4).map(|i| split_delta(121.0, 4, i)).collect();
+        assert_eq!(parts, vec![30.0, 30.0, 31.0, 30.0]);
+        assert_eq!(parts.iter().sum::<f64>(), 121.0);
+
+        let parts: Vec<f64> = (0..4).map(|i| split_delta(-121.0, 4, i)).collect();
+        assert_eq!(parts, vec![-30.0, -30.0, -31.0, -30.0]);
+        assert_eq!(parts.iter().sum::<f64>(), -121.0);
     }
 }


### PR DESCRIPTION
## Summary
- add a native pixel scroll-wheel path to the macOS scroll tool for canvas, WebGL, and infinite-canvas surfaces
- support x/y anchoring, delta_x/delta_y panning, modifier keys, split-step wheel gestures, and from_zoom coordinate translation
- document the new MCP scroll options and update the Rust cua-driver skill guidance

## Testing
- git diff --check
- Not run: cargo test / rustfmt, because cargo and rustfmt are not installed in this local environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native pixel-scroll mode to the scroll tool, enabling scrolling on canvas/WebGL surfaces and applications that don't respond to keyboard scrolling.
  * Introduced new scroll parameters for advanced control including position anchoring, delta values, modifiers, and animated steps.

* **Documentation**
  * Updated scroll tool documentation with guidance for using pixel-based scrolling on specialized application surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->