### PR TITLE
docs(cua-driver): 0.4.2 changelog entry + fix 0.3.6 wording

### DIFF
--- a/docs/content/docs/cua-driver/reference/changelog.mdx
+++ b/docs/content/docs/cua-driver/reference/changelog.mdx
@@ -18,6 +18,13 @@ The canonical, always-current source is the
 release body is auto-generated per release from the commits touching
 `libs/cua-driver/rust`, including SHA256 checksums and install instructions.
 
+## 0.4.2 (2026-05-31)
+
+- macOS: guard the SkyLight auth-message selector on macOS 14 Sonoma so the
+  driver no longer crashes on launch (#1782, #1503).
+- macOS: enable Chromium/Electron accessibility trees via `AXManualAccessibility`,
+  so `get_window_state` can see their window content (#1756).
+
 ## 0.4.1 (2026-05-31)
 
 - macOS: per-session agent cursors, so concurrent sessions each get their own
@@ -35,8 +42,9 @@ release body is auto-generated per release from the commits touching
 
 ## 0.3.6 (2026-05-30)
 
-- macOS: fix permissions status so it reports the caller's actual TCC grants
-  rather than the daemon's (#1774).
+- macOS: fix permissions status so it reports the driver's real TCC grants (via
+  the daemon) instead of the calling terminal's — it no longer claims granted
+  when only the caller holds the grant (#1774).
 
 ## 0.3.5 (2026-05-30)
 


### PR DESCRIPTION
Keeps the docs changelog page in sync with the just-cut **0.4.2** release:

- **0.4.2** — macOS 14 Sonoma SkyLight auth-selector guard (#1782, closes #1503) + Chromium/Electron AX trees via `AXManualAccessibility` (#1756).
- Also corrects the **0.3.6** entry, which had the permissions-status fix backwards (it reports the *driver's* grants via the daemon, not the caller's).

Docs-only. The GitHub release body for 0.4.2 auto-generates the same content from `libs/cua-driver/rust` commits; this mirrors it into the docs site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved launch crashes on macOS 14 Sonoma
  * Improved window state observation capabilities on macOS

* **Documentation**
  * Updated changelog with version 0.4.2 release notes and clarifications regarding macOS permissions reporting behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->