### PR TITLE
fix(cua-driver-rs)(macos): run the agent-cursor overlay in the serve daemon

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/src/main.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/main.rs
@@ -259,6 +259,21 @@ fn main() {
                 None => pip_preview::PipConfig::from_args(),
             };
             maybe_init_pip();
+
+            // Agent-cursor overlay. The DAEMON is the process that actually
+            // performs clicks / AX presses, so the overlay NSWindow + render
+            // loop must run HERE — not only in the in-process `mcp` arm. In the
+            // daemon-proxy setup (`mcp` relaunches `open -n -g … serve` and
+            // proxies to it), the proxy never renders and, before this, neither
+            // did the daemon — so every cursor command was a silent no-op and
+            // the agent cursor never appeared. Init the channel before spawning
+            // the serve thread so `run_on_main_thread()` always finds it ready
+            // (mirrors the Mcp arm).
+            let cursor_cfg = cursor_overlay::CursorConfig::from_args();
+            if cursor_cfg.enabled {
+                platform_macos::cursor::overlay::init(cursor_cfg.clone());
+            }
+
             let reg = Arc::new(build_macos_registry());
             reg.init_self_weak();
             let sp = socket.unwrap_or_else(serve::default_socket_path);
@@ -320,6 +335,15 @@ fn main() {
             // stays up as long as the daemon does.
             if pip_cfg.enabled {
                 platform_macos::pip::run_appkit_main_loop();
+            } else if cursor_cfg.enabled {
+                // Render the agent-cursor overlay: park the main thread in the
+                // AppKit run loop so the overlay NSWindow draws. `run_on_main_thread`
+                // self-guards on `has_graphic_access()` and returns immediately
+                // when the daemon has no Window Server session — fall through to
+                // join so the daemon still serves headless. The serve thread runs
+                // on its background thread regardless.
+                platform_macos::cursor::overlay::run_on_main_thread();
+                let _ = serve_handle.join();
             } else {
                 let _ = serve_handle.join();
             }


### PR DESCRIPTION
## The bug (why the agent cursor was never visible)
The overlay NSWindow + AppKit render loop were wired into the **in-process `mcp` arm** but **never the `serve` daemon arm**. In the daemon-proxy setup everyone actually runs — `cua-driver mcp` relaunches `open -n -g … serve` and proxies to it for correct TCC attribution — the **daemon** does the clicking but parked its main thread in `serve_handle.join()` and never inited/ran the overlay. So `CMD_TX` was unset and every `OverlayCommand` was a **silent no-op**; the cursor could not render.

Confirmed empirically on the running daemon: main thread in `pthread_join`, **zero** `tiny_skia`/`SkyLight`/`NSWindow` activity.

## Fix
The Serve arm now builds `cursor_cfg`, inits the overlay channel before spawning the serve thread, and (when the cursor is enabled) parks main in `overlay::run_on_main_thread()` — mirroring the Mcp arm — instead of `join`. It self-guards on `has_graphic_access()` and falls back to `join` when there's no Window Server session, so headless serving is unaffected. PiP path unchanged.

## Verified
After the fix the serve daemon's main thread runs `__CFRunLoopRun` / `-[NSApplication run]` with `tiny_skia` + `SkyLight` overlay activity, and still serves (`list_windows` over the socket works). On-screen pixel confirmation is a manual VM eyeball (redo the Calculator AX run → the agent cursor now renders + glides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized macOS startup: cursor overlay channel now initializes earlier in the process to ensure consistent availability across all configurations. Enhanced main-thread handling to improve execution flow management based on active features, whether using Picture-in-Picture mode, cursor overlay functionality, or running in standalone mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->