### PR TITLE
feat(cua-driver-rs)(install-local): stable self-signed identity so TCC grants survive rebuilds

### DIFF
--- a/libs/cua-driver/scripts/_install-local-rust.sh
+++ b/libs/cua-driver/scripts/_install-local-rust.sh
@@ -260,6 +260,53 @@ ln -sfn "$VERSIONED_DIR" "$CURRENT_LINK"
 echo "${GREEN}current -> $VERSIONED_DIR${NORMAL}"
 echo ""
 
+# --- macOS: stable local code-signing identity (so TCC grants survive rebuilds) ---
+#
+# Ad-hoc signing (`codesign --sign -`) keys the TCC grant
+# (Accessibility / Screen Recording) on the binary's *cdhash*, which changes
+# on EVERY rebuild — so the grant silently invalidates on each install-local
+# and the daemon re-prompts ("I already granted!"). Signing with a certificate
+# keys the grant on the cert identity instead, which is stable across rebuilds.
+# We create a self-signed code-signing cert once (idempotent, in the login
+# keychain) and reuse it. Local dev only; releases are CI-signed.
+#
+# Echoes the `codesign --sign` argument: the cert CN when available, or "-"
+# (ad-hoc) when it can't be created — no codesign/openssl, CI, locked keychain.
+CUA_LOCAL_SIGN_CN="CuaDriver Local Signing (cua-driver-rs)"
+ensure_local_signing_identity() {
+    { [ "$OS" = "Darwin" ] && command -v codesign >/dev/null 2>&1; } || { printf -- '-'; return; }
+    # Reuse if already present (find-certificate finds it regardless of trust;
+    # `find-identity -v` would miss an untrusted self-signed cert).
+    if security find-certificate -c "$CUA_LOCAL_SIGN_CN" >/dev/null 2>&1; then
+        printf '%s' "$CUA_LOCAL_SIGN_CN"; return
+    fi
+    command -v openssl >/dev/null 2>&1 || { printf -- '-'; return; }
+    local kc="$HOME/Library/Keychains/login.keychain-db"
+    [ -f "$kc" ] || kc="$HOME/Library/Keychains/login.keychain"
+    [ -f "$kc" ] || { printf -- '-'; return; }
+    local tmp; tmp="$(mktemp -d)" || { printf -- '-'; return; }
+    printf '[req]\ndistinguished_name=dn\nx509_extensions=ext\nprompt=no\n[dn]\nCN=%s\n[ext]\nbasicConstraints=critical,CA:FALSE\nkeyUsage=critical,digitalSignature\nextendedKeyUsage=critical,codeSigning\n' \
+        "$CUA_LOCAL_SIGN_CN" > "$tmp/req.cnf"
+    # Transient password for the p12 handoff (deleted right after import).
+    # Apple's `security` rejects the empty-password p12 that openssl 3.x emits
+    # by default ("MAC verification failed"), so use a real password + `-legacy`
+    # PBE (Apple-compatible). Fall back to non-legacy for LibreSSL/older openssl
+    # which lacks `-legacy` but already writes a compatible p12.
+    local pw="cua-local-$$"
+    if openssl req -x509 -newkey rsa:2048 -keyout "$tmp/key.pem" -out "$tmp/cert.pem" \
+            -days 3650 -nodes -config "$tmp/req.cnf" >/dev/null 2>&1 \
+       && { openssl pkcs12 -export -legacy -inkey "$tmp/key.pem" -in "$tmp/cert.pem" \
+                -out "$tmp/id.p12" -passout pass:"$pw" -name "$CUA_LOCAL_SIGN_CN" >/dev/null 2>&1 \
+            || openssl pkcs12 -export -inkey "$tmp/key.pem" -in "$tmp/cert.pem" \
+                -out "$tmp/id.p12" -passout pass:"$pw" -name "$CUA_LOCAL_SIGN_CN" >/dev/null 2>&1; } \
+       && security import "$tmp/id.p12" -k "$kc" -P "$pw" -A -T /usr/bin/codesign >/dev/null 2>&1; then
+        rm -rf "$tmp"
+        printf '%s' "$CUA_LOCAL_SIGN_CN"; return
+    fi
+    rm -rf "$tmp"
+    printf -- '-'
+}
+
 # --- macOS: wrap the binary in CuaDriver.app for a stable TCC identity ---
 #
 # TCC keys Accessibility / Screen-Recording grants on the bundle
@@ -296,12 +343,22 @@ if [ "$OS" = "Darwin" ]; then
     # as install.sh). Replace any prior bundle wholesale.
     rm -rf "$APP_DEST"
     ditto "$APP_STAGE" "$APP_DEST"
-    # Ad-hoc re-sign the whole bundle (--deep covers the inner binary).
-    # Required on macOS 26+ where Taskgated rejects a copied binary's
-    # stale signature, and gives the bundle a consistent cdhash for TCC.
+    # Re-sign the whole bundle (--deep covers the inner binary). Required on
+    # macOS 26+ where Taskgated rejects a copied binary's stale signature.
+    # Prefer the STABLE self-signed identity so TCC grants survive rebuilds;
+    # fall back to ad-hoc (which works but resets grants on the next rebuild).
     if command -v codesign >/dev/null 2>&1; then
-        codesign --force --deep --sign - "$APP_DEST" 2>/dev/null \
-            || echo "${YELLOW}warning: codesign of $APP_DEST failed; first run may hit a Gatekeeper/Taskgated prompt${NORMAL}" >&2
+        SIGN_ID="$(ensure_local_signing_identity)"
+        if [ "$SIGN_ID" != "-" ] \
+           && codesign --force --deep --sign "$SIGN_ID" "$APP_DEST" 2>/dev/null; then
+            echo "${GREEN}signed $APP_DEST with a stable local identity — TCC grants survive future install-local rebuilds${NORMAL}"
+        elif codesign --force --deep --sign - "$APP_DEST" 2>/dev/null; then
+            if [ "$SIGN_ID" != "-" ]; then
+                echo "${YELLOW}note: stable-identity signing failed; signed ad-hoc instead (Accessibility/Screen Recording will reset on the next rebuild)${NORMAL}" >&2
+            fi
+        else
+            echo "${YELLOW}warning: codesign of $APP_DEST failed; first run may hit a Gatekeeper/Taskgated prompt${NORMAL}" >&2
+        fi
     fi
     echo "${GREEN}installed $APP_DEST${NORMAL}"
 fi


### PR DESCRIPTION
## Problem
`install-local` ad-hoc-signs the bundle, so the TCC grant is pinned to the binary's **cdhash** — which changes on **every rebuild**. Each `install-local` silently invalidates Accessibility/Screen Recording (Settings still shows granted; the live check fails), and the daemon re-prompts. The exact "I granted it but it keeps asking" loop.

## Fix
Create a self-signed code-signing cert **once** (idempotent, login keychain) and sign the bundle with it. TCC then keys the grant on the **certificate leaf** (stable across rebuilds):

```
designated => identifier "com.trycua.driver" and certificate leaf = H"c5a1743…"   # was: cdhash H"…"
```

Grant once; future `install-local`s keep it. Verified locally (DR is now cert-based; signs + launches fine — local bundles have no quarantine so Gatekeeper doesn't object).

Fail-soft: openssl 3.x needs `-legacy` + a p12 password for Apple's `security import`; falls back to non-legacy (LibreSSL) and ultimately to **ad-hoc + a note** if the cert can't be made (CI, locked keychain). Local-dev only; releases are CI-signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced macOS installation process with improved certificate-based code-signing and robust fallback mechanisms for more reliable application signing during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->