### PR TITLE
docs(cua-driver): 0.4.3 changelog entry

### DIFF
--- a/docs/content/docs/cua-driver/reference/changelog.mdx
+++ b/docs/content/docs/cua-driver/reference/changelog.mdx
@@ -18,6 +18,20 @@ The canonical, always-current source is the
 release body is auto-generated per release from the commits touching
 `libs/cua-driver/rust`, including SHA256 checksums and install instructions.
 
+## 0.4.3 (2026-05-31)
+
+- macOS: the agent-cursor overlay now actually renders in the `serve` daemon.
+  It was only wired into the in-process `mcp` path, so in the daemon-proxy
+  setup (the default) every cursor command was a silent no-op and the agent
+  cursor never appeared (#1790).
+- macOS: `cua-driver permissions grant` no longer spams the TCC prompt — it
+  raises a single dialog and then polls silently, and the gate honours its
+  deadline instead of re-prompting (and restarting the daemon) on every
+  ~25s re-exec (#1791).
+- Dev: `install-local` now signs the bundle with a stable self-signed
+  identity, so TCC grants (Accessibility / Screen Recording) survive rebuilds
+  instead of resetting on every install (#1792).
+
 ## 0.4.2 (2026-05-31)
 
 - macOS: guard the SkyLight auth-message selector on macOS 14 Sonoma so the


### PR DESCRIPTION
Keeps the docs changelog in sync with the 0.4.3 release: cursor overlay in the daemon (#1790), permissions-grant no-spam (#1791), install-local stable signing (#1792).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS agent-cursor overlay rendering in serve daemon mode.
  * Improved macOS permission request process to show a single dialog and poll silently, preventing repeated prompts.
  * macOS TCC permission grants now persist across rebuilds with stable bundle signing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->