### PR TITLE
fix(cua-driver-rs)(windows): per-session overlay windows, visible distinct cursors, parallel-transport discoverability

### DIFF
--- a/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
@@ -271,11 +271,78 @@ distinct *connections*. Subagents that share one `cua-driver mcp` (stdio)
 connection have their tool calls **serialized** by the transport — they take
 turns, not run in parallel. That's not a correctness problem (session + window
 isolation means they can't collide), just a throughput one. For genuinely
-parallel agents, give each its **own connection**: separate `cua-driver mcp`
-processes, or point each agent's MCP client at the daemon's HTTP endpoint
-(`CUA_DRIVER_RS_MCP_HTTP_PORT` → `POST http://127.0.0.1:<port>/mcp`). The daemon
-serves connections concurrently; per-connection ordering keeps each agent's own
-sequence (e.g. `3 → + → 1 → =`) correct.
+parallel agents, give each its **own connection** — see "Parallel agents over
+the HTTP/JSON-RPC transport" below.
+
+## Parallel agents over the HTTP/JSON-RPC transport
+
+When you need several agents (or one agent's fan-out) to act on the host *at the
+same time* rather than taking turns, run them over the daemon's HTTP transport
+instead of stdio. Each TCP connection is its own task in the daemon, so N
+connections run **truly concurrently**; requests on a single connection stay
+FIFO-ordered, so one agent's own sequence (`3 → + → 1 → =`) is still correct.
+Concurrency is safe because the element cache is keyed on `(pid, window_id)` and
+the cursor on `session`, so cross-connection actions don't collide.
+
+**The unit of parallelism is the session, and a session is sequential.** Map it
+one-to-one: **one agent = one `session` = one connection = one in-flight call at
+a time.** Parallelism comes from running *multiple sessions* concurrently, each
+on its own connection — **never** from fanning out concurrent calls *within* one
+session. Within a session you issue a call, await it, then issue the next. This
+isn't just etiquette — two per-session resources assume an ordered, one-at-a-time
+stream and break under intra-session concurrency:
+
+- **The agent cursor is per-session.** Two concurrent calls on the same session
+  fire two glide commands at the *same* cursor, which then races (last-writer-
+  wins, jumps around) instead of gliding target-to-target in order.
+- **Recording is per-session.** Concurrent calls record in nondeterministic
+  order, so `replay_trajectory` replays a garbled sequence.
+
+So: to fill four fields of one window, one session writes them sequentially. To
+fill four *windows* at once, use four sessions — each filling its window
+sequentially — running in parallel. (The data may still land if you cheat and
+fan out within a session, because the `(pid, window_id)` cache makes independent
+writes non-colliding — but the cursor and any recording are then wrong. Don't.)
+
+**Enable it — `serve`-daemon only.** The HTTP listener is spawned *only* by the
+`serve` daemon, and *only* when a port is configured. The plain stdio
+`cua-driver mcp` path never opens it, so pointing `curl` at a port while only an
+`mcp` server is running connects to nothing. Start a daemon with the port:
+
+```bash
+cua-driver serve --http-port 8799                            # flag (preferred)
+CUA_DRIVER_RS_MCP_HTTP_PORT=8799 cua-driver serve            # env var (flag wins if both)
+```
+
+Confirm it's live with `cua-driver status` — it prints `mcp-http: listening on
+http://127.0.0.1:8799/mcp` when up, or `disabled` otherwise (it re-probes the
+port, so a crashed daemon reads as disabled). When the listener is bound, the
+daemon also advertises the concrete URL in its MCP `instructions`, so a
+connecting client is told the live endpoint automatically. It binds loopback
+only. Each call is a `POST http://127.0.0.1:8799/mcp` with
+`Content-Type: application/json` and a JSON-RPC 2.0 `tools/call` body. The
+`arguments` object is exactly what the tool takes over MCP/CLI, plus the same
+`session` key for the per-session cursor + identity:
+
+```bash
+curl -s http://127.0.0.1:8799/mcp -H 'Content-Type: application/json' -d '{
+  "jsonrpc":"2.0","id":1,"method":"tools/call",
+  "params":{"name":"set_value","arguments":{
+    "pid":15472,"window_id":10814686,"element_index":22,
+    "value":"Anna Esposito","session":"agent-A"}}}'
+```
+
+The reply is a standard JSON-RPC result: `result.content[0].text` is the tool's
+text output, `result.structuredContent` the typed payload (e.g. `launch_app`'s
+pid + `windows` array). **The `(pid, window_id)` element cache lives in the
+daemon process**, so the whole loop — `launch_app` → `get_window_state` → act →
+verify — must run over the *same* daemon; never resolve an `element_index` on
+one server and dispatch it on another. To fan out, give each **agent** its own
+connection + its own `session` and let it run its steps **sequentially**;
+parallelism is across agents (one per window / task), not within one — e.g. one
+background `curl`-driving process or HTTP client per session, each looping its
+own ordered calls. (Windows quoting tip: write the JSON body to a file and
+`curl --data-binary "@body.json"` to avoid PowerShell mangling inline JSON.)
 
 `list_apps` is for app-level discovery (answering "what's installed /
 running / frontmost?") — not part of the core action loop. Skip it

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/protocol.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/protocol.rs
@@ -156,6 +156,27 @@ pub fn initialize_result() -> Value {
     })
 }
 
+/// Live MCP HTTP endpoint URL, published by the daemon's `mcp_http` listener
+/// once it has SUCCESSFULLY bound (and cleared on shutdown / if it never binds).
+/// `agent_instructions()` appends it so a connecting client is told the concrete
+/// parallel endpoint only when it is genuinely reachable — not merely when the
+/// port was requested but the bind lost a race. `None` keeps the instructions in
+/// their "how to enable" form.
+static MCP_HTTP_ENDPOINT: std::sync::RwLock<Option<String>> = std::sync::RwLock::new(None);
+
+/// Record (or clear with `None`) the live MCP HTTP endpoint URL. Called by the
+/// cua-driver binary's HTTP listener on a successful bind, and on shutdown.
+pub fn set_mcp_http_endpoint(url: Option<String>) {
+    if let Ok(mut g) = MCP_HTTP_ENDPOINT.write() {
+        *g = url;
+    }
+}
+
+/// The live MCP HTTP endpoint URL, if the listener is currently bound.
+pub fn mcp_http_endpoint() -> Option<String> {
+    MCP_HTTP_ENDPOINT.read().ok().and_then(|g| g.clone())
+}
+
 /// MCP `instructions` (`InitializeResult.instructions`) sent to every
 /// connecting client. The spec frames this as a "hint... MAY be added
 /// to the system prompt" — eager, every-turn cost. We keep it under
@@ -185,6 +206,16 @@ fn agent_instructions() -> String {
         )
     };
 
+    // Parallel-agents line: when the HTTP listener is genuinely bound, name the
+    // concrete live endpoint; otherwise tell the reader how to turn it on. Kept
+    // to one line either way so the eager every-turn instructions stay lean.
+    let parallel_line = match mcp_http_endpoint() {
+        Some(url) => format!(
+            "Parallel agents: ONE session = one connection = sequential — issue a call, await it, then the next (FIFO). Parallelism is ACROSS sessions, NEVER within one (the per-session cursor + recording assume an ordered, one-at-a-time stream). This daemon's HTTP transport is LIVE at {url}: give each agent its OWN connection there, POSTing JSON-RPC `tools/call` bodies with its own `session`. Details + example in SKILL.md."
+        ),
+        None => "Parallel agents: a single stdio `cua-driver mcp` connection serializes all its calls. ONE session = one connection = sequential; parallelism is ACROSS sessions, NEVER within one (the per-session cursor + recording assume an ordered, one-at-a-time stream). For concurrent agents, start `cua-driver serve --http-port <port>` (or set CUA_DRIVER_RS_MCP_HTTP_PORT) and give each agent its OWN connection POSTing JSON-RPC `tools/call` to http://127.0.0.1:<port>/mcp. Details + example in SKILL.md.".to_owned(),
+    };
+
     format!(
         r#"cua-driver: cross-platform background computer-use automation.
 
@@ -198,8 +229,36 @@ Workflow per turn:
 4. click/type_text/press_key using element_index from step 3 (+ your `session`)
 5. get_window_state(pid, window_id) again → verify the action landed
 
-Agent cursor: a per-SESSION overlay cursor visualises where a run is acting without moving the real pointer. It is shown only for a DECLARED session (pass `session`), is color-coded by the session id, and is removed by end_session or the idle-TTL. The same id over MCP, the CLI, or the raw socket drives the same cursor. set_agent_cursor_* tools hide/show/customise it. Note: a pure accessibility-action (element_index) click snaps the cursor with a brief pulse on its first action rather than a long glide, so it can be easy to miss — issue a pixel click or move_cursor first for a visibly gliding demo/recording.
+Agent cursor: a per-SESSION overlay cursor visualises where a run is acting without moving the real pointer. It is shown only for a DECLARED session (pass `session`), is color-coded by the session id, and is removed by end_session or the idle-TTL. The same id over MCP, the CLI, or the raw socket drives the same cursor. set_agent_cursor_* tools hide/show/customise it. Note: on its FIRST action a pure accessibility-action (element_index) run seeds the cursor near the target and plays a short glide+pulse (not the long sweep it traces once already on-screen), so it can be easy to miss — issue a pixel click or move_cursor first for a fully gliding demo/recording.
+
+{parallel_line}
 
 If a `cua-driver` skill is loaded in your harness (Claude Code / Codex / OpenClaw / OpenCode dirs), prefer its detailed workflow — SKILL.md plus {platform_skill_pointer}. Install with `cua-driver skills install` if not yet present."#
     )
+}
+
+#[cfg(test)]
+mod instruction_tests {
+    use super::{agent_instructions, set_mcp_http_endpoint};
+
+    /// One test, mutating the shared endpoint serially, so the two branches are
+    /// asserted without racing the process-global on parallel test threads.
+    #[test]
+    fn parallel_line_reflects_live_http_endpoint() {
+        // Bound → advertise the concrete live URL.
+        set_mcp_http_endpoint(Some("http://127.0.0.1:8799/mcp".to_owned()));
+        let live = agent_instructions();
+        assert!(
+            live.contains("LIVE at http://127.0.0.1:8799/mcp"),
+            "bound endpoint must advertise the concrete URL, got:\n{live}"
+        );
+
+        // Not bound → fall back to the "how to enable" form (no false advert).
+        set_mcp_http_endpoint(None);
+        let disabled = agent_instructions();
+        assert!(
+            disabled.contains("--http-port") && !disabled.contains("is LIVE at"),
+            "unbound endpoint must show enablement help, not a live URL, got:\n{disabled}"
+        );
+    }
 }

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -66,6 +66,13 @@ pub enum Command {
         /// flag was a no-op for `cua-driver mcp --claude-code-computer-use-compat`,
         /// which always routes through the proxy on an installed bundle.
         claude_code_compat: bool,
+        /// `--http-port <port>` — enable the MCP HTTP/JSON-RPC transport (the
+        /// parallel-agents surface) on `127.0.0.1:<port>`. `None` falls back to
+        /// the `CUA_DRIVER_RS_MCP_HTTP_PORT` env var; the flag wins when both
+        /// are present. Flowed into the listener by exporting the env var before
+        /// serve runs (see `main`), so `mcp_http::configured_port()` picks it up
+        /// at both run-loop spawn sites without threading a param through.
+        http_port: Option<u16>,
     },
     Stop { socket: Option<String> },
     Status { socket: Option<String> },
@@ -127,6 +134,9 @@ const VALUE_FLAGS: &[&str] = &[
     "--cursor-icon", "--cursor-id", "--cursor-palette",
     "--glide-ms", "--dwell-ms", "--idle-hide-ms",
     "--screenshot-out-file", "--client", "--socket", "--pid-file", "--type",
+    // `serve --http-port <port>` — first-class flag for the MCP HTTP transport
+    // (the parallel-agents surface). Overrides CUA_DRIVER_RS_MCP_HTTP_PORT.
+    "--http-port",
     // Experimental PiP preview — value flag for the optional geometry
     // override (--experimental-pip itself is a bare flag and doesn't
     // need to be listed here).
@@ -198,13 +208,25 @@ pub fn parse_command() -> Command {
         println!("                          has no tool-surface effect today; the wiring is in place");
         println!("                          for any future compat-gated tool.");
         println!();
+        println!("serve options:");
+        println!("  --socket <path>         Override the daemon socket / named-pipe path.");
+        println!("  --http-port <port>      Enable the MCP HTTP/JSON-RPC transport on 127.0.0.1:<port>");
+        println!("                          (loopback only) so multiple agents can each open their OWN");
+        println!("                          connection and run truly in parallel — `POST /mcp` with a");
+        println!("                          JSON-RPC tools/call body. Without it (stdio `mcp`), one");
+        println!("                          connection's calls serialize. Overrides, and is overridden");
+        println!("                          by, CUA_DRIVER_RS_MCP_HTTP_PORT (flag wins). `cua-driver");
+        println!("                          status` reports the live endpoint. See SKILL.md for the");
+        println!("                          request shape + a worked example.");
+        println!();
         println!("agent cursor overlay (serve / mcp only — needs the daemon UI runloop):");
         println!("  The overlay is ON by default: every MCP session automatically gets its own");
         println!("  cursor (keyed by session id) that shows where the agent acts without moving the");
-        println!("  real pointer. It is removed when the session ends. A pure accessibility (AX)");
-        println!("  action snaps the cursor with a brief pulse on its first action instead of a long");
-        println!("  glide, so it can be easy to miss — do a pixel click or move_agent_cursor first");
-        println!("  for a visibly gliding demo. These flags tune the overlay on `serve`/`mcp`:");
+        println!("  real pointer. It is removed when the session ends. On its FIRST action a pure");
+        println!("  accessibility (AX) run seeds the cursor near the target and plays a short");
+        println!("  glide+pulse (not the long sweep it traces once already on-screen), so it can be");
+        println!("  easy to miss — do a pixel click or move_agent_cursor first for a fully gliding");
+        println!("  demo. These flags tune the overlay on `serve`/`mcp`:");
         println!("  --no-overlay            Disable the cursor overlay entirely for this daemon.");
         println!("  --cursor-id <id>        Name the default cursor instance (default: 'default').");
         println!("  --cursor-icon <path>    Use a custom PNG cursor icon.");
@@ -229,6 +251,7 @@ pub fn parse_command() -> Command {
     let screenshot_out_file = flag_value(&args, "--screenshot-out-file");
     let mcp_client = flag_value(&args, "--client");
     let socket = flag_value(&args, "--socket");
+    let http_port = flag_value(&args, "--http-port").and_then(|v| v.parse::<u16>().ok());
 
     // Strip cursor-overlay flags (and their values) to expose the subcommand.
     let mut positionals: Vec<&str> = Vec::new();
@@ -290,6 +313,7 @@ pub fn parse_command() -> Command {
             // Bare flag — present anywhere on argv counts as "skip the gate".
             no_permissions_gate: args.iter().any(|a| a == "--no-permissions-gate"),
             claude_code_compat,
+            http_port,
         },
         Some("stop") => Command::Stop { socket },
         Some("status") => Command::Status { socket },

--- a/libs/cua-driver/rust/crates/cua-driver/src/main.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/main.rs
@@ -225,11 +225,17 @@ fn main() {
             cli::run_call(reg, &tool, json_args, screenshot_out_file, socket);
             return;
         }
-        cli::Command::Serve { socket, no_permissions_gate, claude_code_compat } => {
+        cli::Command::Serve { socket, no_permissions_gate, claude_code_compat, http_port } => {
             // Long-running daemon — kick off the background update check
             // before any blocking work so the banner can land on stderr
             // early in the serve lifecycle.
             version_check::maybe_announce_update();
+            // `--http-port` is a first-class alias for CUA_DRIVER_RS_MCP_HTTP_PORT
+            // (flag wins); export it before serve so `mcp_http::configured_port()`
+            // sees it. Edition 2021 → set_var is safe.
+            if let Some(port) = http_port {
+                std::env::set_var("CUA_DRIVER_RS_MCP_HTTP_PORT", port.to_string());
+            }
             let gate_opts = platform_macos::permissions::GateOpts::from_env_and_flag(
                 no_permissions_gate,
             );
@@ -570,10 +576,17 @@ fn main() -> anyhow::Result<()> {
             }).join().ok();
             return Ok(());
         }
-        cli::Command::Serve { socket, no_permissions_gate, claude_code_compat } => {
+        cli::Command::Serve { socket, no_permissions_gate, claude_code_compat, http_port } => {
             // Long-running daemon — kick off the background update check
             // before any blocking work so the banner can land on stderr.
             version_check::maybe_announce_update();
+            // `--http-port` is a first-class alias for CUA_DRIVER_RS_MCP_HTTP_PORT
+            // (flag wins). Export it before serve runs so `mcp_http::configured_port()`
+            // picks it up at both run-loop spawn sites without threading a param
+            // through run_serve_cmd / run_serve. Edition 2021 → set_var is safe.
+            if let Some(port) = http_port {
+                std::env::set_var("CUA_DRIVER_RS_MCP_HTTP_PORT", port.to_string());
+            }
             // The Rust permissions gate is macOS-only (TCC concept).
             // On Windows / Linux the flag is silently accepted for
             // CLI uniformity and ignored. The Claude-Code compat screenshot

--- a/libs/cua-driver/rust/crates/cua-driver/src/mcp_http.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/mcp_http.rs
@@ -44,6 +44,19 @@ pub fn spawn(registry: Arc<ToolRegistry>, port: u16) {
         match TcpListener::bind(addr).await {
             Ok(listener) => {
                 info!("MCP HTTP transport listening on http://{addr}/mcp (one connection per agent → parallel)");
+                // Publish the live endpoint exactly once it is bound: into the
+                // in-process registry (so `agent_instructions()` advertises the
+                // concrete URL) AND into a sibling state file (so the separate
+                // `cua-driver status` process can report it). Both are torn down
+                // on graceful shutdown; `status` also re-probes the port, so a
+                // stale file left by a crash reads as "not listening".
+                let url = format!("http://127.0.0.1:{port}/mcp");
+                cua_driver_core::protocol::set_mcp_http_endpoint(Some(url.clone()));
+                let url_file = crate::serve::mcp_http_url_file_path();
+                if let Some(dir) = std::path::Path::new(&url_file).parent() {
+                    let _ = std::fs::create_dir_all(dir);
+                }
+                let _ = std::fs::write(&url_file, &url);
                 loop {
                     match listener.accept().await {
                         Ok((stream, peer)) => {
@@ -61,7 +74,12 @@ pub fn spawn(registry: Arc<ToolRegistry>, port: u16) {
                     }
                 }
             }
-            Err(e) => warn!("MCP HTTP transport disabled — bind {addr} failed: {e}"),
+            Err(e) => {
+                // Lost the port (already in use, etc.) — make sure nothing
+                // advertises an endpoint that never came up.
+                cua_driver_core::protocol::set_mcp_http_endpoint(None);
+                warn!("MCP HTTP transport disabled — bind {addr} failed: {e}");
+            }
         }
     });
 }

--- a/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
@@ -256,6 +256,22 @@ pub fn default_pid_file_path() -> String {
     }
 }
 
+/// Path of the tiny state file the MCP HTTP listener writes (its live
+/// `http://127.0.0.1:<port>/mcp` URL) on a successful bind. Lives beside the pid
+/// file so `cua-driver status` — a *separate* process that can't read the
+/// daemon's in-process state or env — can report the endpoint. Removed on
+/// graceful shutdown; `status` also re-probes the port, so a file left stale by
+/// a crash reads as "not listening".
+pub fn mcp_http_url_file_path() -> String {
+    let pid = default_pid_file_path();
+    std::path::Path::new(&pid)
+        .parent()
+        .map(|d| d.join("cua-driver-mcp-http.url"))
+        .unwrap_or_else(|| std::path::PathBuf::from("cua-driver-mcp-http.url"))
+        .to_string_lossy()
+        .into_owned()
+}
+
 // ── Protocol types ────────────────────────────────────────────────────────────
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -767,6 +783,9 @@ pub async fn run_serve(
     if let Some(pid_path) = pid_file_path {
         let _ = std::fs::remove_file(pid_path);
     }
+    // Tear down the MCP HTTP endpoint advert (if the listener was up).
+    cua_driver_core::protocol::set_mcp_http_endpoint(None);
+    let _ = std::fs::remove_file(mcp_http_url_file_path());
 
     Ok(())
 }
@@ -1245,6 +1264,9 @@ pub async fn run_serve(
     if let Some(pid_path) = pid_file_path {
         let _ = std::fs::remove_file(pid_path);
     }
+    // Tear down the MCP HTTP endpoint advert (if the listener was up).
+    cua_driver_core::protocol::set_mcp_http_endpoint(None);
+    let _ = std::fs::remove_file(mcp_http_url_file_path());
     Ok(())
 }
 
@@ -1369,9 +1391,34 @@ pub fn run_status_cmd(socket_path: &str, pid_file_path: &str) {
         } else {
             println!("  pid: unknown (no pid file)");
         }
+        // MCP HTTP transport (the parallel-agents surface). Report it from the
+        // daemon-written URL file, re-probed so a stale file reads as off.
+        match live_mcp_http_url() {
+            Some(url) => println!("  mcp-http: listening on {url} (parallel agents — one connection each)"),
+            None => println!("  mcp-http: disabled (stdio only — enable with `serve --http-port <port>` or CUA_DRIVER_RS_MCP_HTTP_PORT)"),
+        }
     } else {
         eprintln!("Cua Driver daemon is not running");
         std::process::exit(1);
+    }
+}
+
+/// Read the MCP HTTP URL the daemon wrote on bind, then **probe the port** so a
+/// stale file (left by a crash) doesn't read as live. Returns the URL only when
+/// the listener actually accepts a connection.
+fn live_mcp_http_url() -> Option<String> {
+    let url = std::fs::read_to_string(mcp_http_url_file_path()).ok()?;
+    let url = url.trim().to_owned();
+    if url.is_empty() {
+        return None;
+    }
+    // "http://127.0.0.1:8799/mcp" → authority "127.0.0.1:8799" to probe.
+    let authority = url.strip_prefix("http://").unwrap_or(&url);
+    let authority = authority.split('/').next().unwrap_or(authority);
+    let addr: std::net::SocketAddr = authority.parse().ok()?;
+    match std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(400)) {
+        Ok(_) => Some(url),
+        Err(_) => None,
     }
 }
 

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/palette.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/palette.rs
@@ -35,6 +35,15 @@ const PALETTE_DATA: &[PaletteData] = &[
     ("crimson",       rgba(255,226,226), rgba(232, 82, 98), rgba(150, 94,255), rgba(255,168,178), rgba(255,240,241)),
     ("chartreuse",    rgba(247,255,218), rgba(184,220, 54), rgba( 72,190,119), rgba(224,247,128), rgba(249,255,232)),
     ("cobalt",        rgba(226,235,255), rgba( 80,126,236), rgba( 91,219,222), rgba(170,195,255), rgba(239,246,255)),
+    // Added to widen the hue spread (the originals clustered around blue/teal/
+    // green); these fill green / yellow / indigo / orange / pink / teal gaps so a
+    // larger fleet of concurrent cursors stays visually distinguishable.
+    ("emerald",       rgba(225,255,236), rgba( 46,204,113), rgba( 16,185,129), rgba(190,245,215), rgba(240,255,247)),
+    ("gold",          rgba(255,250,220), rgba(255,205, 30), rgba(255,170, 40), rgba(255,235,160), rgba(255,252,232)),
+    ("indigo",        rgba(231,229,255), rgba( 99, 82,235), rgba(139, 92,246), rgba(199,194,255), rgba(242,240,255)),
+    ("tangerine",     rgba(255,238,224), rgba(255,130, 40), rgba(255, 94, 58), rgba(255,205,170), rgba(255,244,234)),
+    ("hot_pink",      rgba(255,228,242), rgba(255, 55,150), rgba(236, 72,153), rgba(255,190,222), rgba(255,240,248)),
+    ("teal",          rgba(220,252,250), rgba( 20,184,166), rgba( 13,148,136), rgba(175,240,234), rgba(236,255,253)),
 ];
 
 fn from_data(d: &PaletteData) -> Palette {
@@ -71,6 +80,35 @@ impl Palette {
         PALETTE_DATA.iter().map(|d| d.0).collect()
     }
 
+    /// Like [`Self::for_instance`], but **avoids colliding** with palettes already
+    /// in use by other live cursors. The hash still chooses the *preferred*
+    /// palette (so a given id is stable when nothing conflicts), then we linear-
+    /// probe forward to the first palette not in `in_use`. This guarantees every
+    /// concurrent cursor gets a distinct colour for up to `PALETTE_DATA[1..].len()`
+    /// of them — fixing the case where ids sharing a numeric/letter suffix (e.g.
+    /// `mil-005253`, `rom-005253`) all hashed to the same index and rendered the
+    /// same colour. Beyond capacity we fall back to the hash pick (reuse begins).
+    pub fn for_instance_distinct(instance_id: &str, in_use: &[String]) -> Self {
+        if instance_id.is_empty() || instance_id == "default" {
+            return Self::default_blue();
+        }
+        // An exact palette-name id is an explicit request — honour it even if
+        // it collides (the caller asked for that specific colour).
+        if let Some(d) = PALETTE_DATA.iter().find(|d| d.0 == instance_id) {
+            return from_data(d);
+        }
+        let alternates = &PALETTE_DATA[1..];
+        let start = stable_index(instance_id, alternates.len());
+        for off in 0..alternates.len() {
+            let idx = (start + off) % alternates.len();
+            if !in_use.iter().any(|n| n == alternates[idx].0) {
+                return from_data(&alternates[idx]);
+            }
+        }
+        // More live cursors than palettes — unavoidable reuse; keep it stable.
+        from_data(&alternates[start])
+    }
+
     /// Lerp along cursor_start → cursor_mid → cursor_end at `t ∈ [0,1]`.
     pub fn gradient_at(&self, t: f64) -> [u8; 4] {
         let t = t.clamp(0.0, 1.0);
@@ -101,4 +139,51 @@ fn stable_index(id: &str, count: usize) -> usize {
     let mut hash: u32 = 2_166_136_261;
     for c in id.chars() { hash ^= c as u32; hash = hash.wrapping_mul(16_777_619); }
     (hash as usize) % count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    /// The regression that motivated `for_instance_distinct`: ids sharing a
+    /// numeric suffix (`mil-005253`, `rom-005253`, …) all hash to the SAME index
+    /// via `stable_index` (it keys off the suffix), so plain `for_instance` gave
+    /// them one identical colour. The collision-free picker must hand out
+    /// distinct palettes as each cursor is created.
+    #[test]
+    fn shared_suffix_ids_get_distinct_palettes() {
+        let ids = ["mil-005253", "rom-005253", "nap-005253", "fir-005253"];
+        // Plain hash collides — documents the bug.
+        let hashed: HashSet<_> = ids.iter().map(|id| Palette::for_instance(id).name).collect();
+        assert_eq!(hashed.len(), 1, "precondition: shared suffix collides under plain hash");
+
+        // Collision-free picker: feed each new cursor the palettes already taken.
+        let mut used: Vec<String> = vec![];
+        for id in ids {
+            let p = Palette::for_instance_distinct(id, &used);
+            assert!(!used.contains(&p.name), "{id} reused an in-use palette {}", p.name);
+            used.push(p.name);
+        }
+        assert_eq!(used.iter().collect::<HashSet<_>>().len(), ids.len());
+    }
+
+    /// An exact palette-name id is an explicit colour request and is honoured
+    /// verbatim even against in-use (the caller asked for that specific colour).
+    #[test]
+    fn exact_name_id_is_honoured_even_if_in_use() {
+        let p = Palette::for_instance_distinct("crimson", &["crimson".to_owned()]);
+        assert_eq!(p.name, "crimson");
+    }
+
+    /// More live cursors than palettes degrades gracefully (no panic; reuse
+    /// begins) rather than looping forever.
+    #[test]
+    fn more_cursors_than_palettes_does_not_panic() {
+        let n = Palette::all_names().len();
+        let used: Vec<String> = Palette::all_names().iter().map(|s| s.to_string()).collect();
+        let p = Palette::for_instance_distinct("overflow-session", &used);
+        assert!(Palette::all_names().contains(&p.name.as_str()));
+        assert!(n >= 10, "palette should have grown beyond the original 10");
+    }
 }

--- a/libs/cua-driver/rust/crates/platform-windows/src/capture.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/capture.rs
@@ -461,7 +461,13 @@ pub fn screenshot_display_bytes() -> Result<Vec<u8>> {
         let mem_dc = CreateCompatibleDC(screen_dc);
         let bitmap = CreateCompatibleBitmap(screen_dc, w, h);
         let old_bitmap = SelectObject(mem_dc, bitmap);
-        BitBlt(mem_dc, 0, 0, w, h, screen_dc, 0, 0, SRCCOPY)?;
+        // SRCCOPY | CAPTUREBLT (0x40000000): CAPTUREBLT includes LAYERED windows
+        // (WS_EX_LAYERED / UpdateLayeredWindow) in the blit. The agent-cursor
+        // overlay is exactly such a window, so plain SRCCOPY silently omits it —
+        // a full-display screenshot would show everything EXCEPT the cursor. With
+        // CAPTUREBLT the overlay (and any other layered UI) is captured.
+        BitBlt(mem_dc, 0, 0, w, h, screen_dc, 0, 0,
+               windows::Win32::Graphics::Gdi::ROP_CODE(SRCCOPY.0 | 0x4000_0000))?;
         let mut bmi = BITMAPINFO {
             bmiHeader: BITMAPINFOHEADER {
                 biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,

--- a/libs/cua-driver/rust/crates/platform-windows/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/overlay.rs
@@ -105,19 +105,27 @@ struct RenderMap {
     /// `Remove` can never resurrect the just-removed cursor. "default" is never
     /// tombstoned (it backs the anonymous / one-shot path).
     ended: HashSet<CursorKey>,
-    /// Cursor key whose target the overlay should currently sit above. A single
-    /// layered window can occupy only one z-band, so the most-recently-touched
-    /// cursor wins (mirrors macOS). `None` until the first PinAbove/Cmd.
-    last_active: Option<CursorKey>,
 }
 
 /// Build the `RenderState` for a lazily-created cursor key: derive from the
 /// launch template but give each non-default key its own palette so distinct
-/// sessions get distinct colours automatically.
-fn render_state_for_key(template: &CursorConfig, key: &str) -> RenderState {
+/// sessions get distinct colours automatically. `in_use` is the set of palette
+/// names already held by other live cursors, so the picker can avoid colliding
+/// with them (see [`Palette::for_instance_distinct`]).
+fn render_state_for_key(template: &CursorConfig, key: &str, in_use: &[String]) -> RenderState {
     let mut rs = RenderState::new(template.clone());
-    rs.core.palette = Palette::for_instance(key);
+    rs.core.palette = Palette::for_instance_distinct(key, in_use);
     rs
+}
+
+/// Palette names currently held by every live cursor except `except` — passed to
+/// [`render_state_for_key`] so a newly-created cursor avoids colliding with them.
+fn palettes_in_use(map: &RenderMap, except: &str) -> Vec<String> {
+    map.cursors
+        .iter()
+        .filter(|(k, _)| k.as_str() != except)
+        .map(|(_, rs)| rs.core.palette.name.clone())
+        .collect()
 }
 
 /// Apply one inbound [`OverlayMsg`] to the render map (drain step). Factored
@@ -132,14 +140,21 @@ fn apply_msg(map: &mut RenderMap, msg: OverlayMsg) -> Option<CursorKey> {
             // The "default" cursor backs the anonymous / one-shot path and must
             // survive every session_end + the daemon lifetime.
             if key != "default" {
+                // Destroy the key's own layered window BEFORE dropping the
+                // RenderState. This runs inside the WM_TIMER tick on the STA
+                // thread (the same thread that created the window), so the
+                // DestroyWindow call has correct HWND affinity. In unit tests
+                // (and on non-Windows) hwnd_isize stays 0 → the helper no-ops.
+                if let Some(rs) = map.cursors.get(&key) {
+                    if rs.hwnd_isize != 0 {
+                        destroy_session_window(rs.hwnd_isize);
+                    }
+                }
                 map.cursors.shift_remove(&key);
                 if let Ok(mut guard) = ARRIVAL_TX.lock() {
                     if let Some(m) = guard.as_mut() {
                         m.remove(&key);
                     }
-                }
-                if map.last_active.as_deref() == Some(key.as_str()) {
-                    map.last_active = None;
                 }
                 // Tombstone the key so a late in-flight Cmd from another task
                 // cannot re-create the just-removed cursor.
@@ -156,10 +171,11 @@ fn apply_msg(map: &mut RenderMap, msg: OverlayMsg) -> Option<CursorKey> {
             }
             let template = map.template.clone();
             let k = key.clone();
+            let in_use = palettes_in_use(map, &k);
             let rs = map
                 .cursors
                 .entry(key)
-                .or_insert_with(|| render_state_for_key(&template, &k));
+                .or_insert_with(|| render_state_for_key(&template, &k, &in_use));
             rs.apply_command(cmd);
             Some(k)
         }
@@ -182,7 +198,6 @@ pub fn init(cfg: CursorConfig) {
         last_tick: Instant::now(),
         template: cfg,
         ended: HashSet::new(),
-        last_active: None,
     });
 }
 
@@ -289,10 +304,11 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
     }
     let template = map.template.clone();
     let k = key.clone();
+    let in_use = palettes_in_use(map, &k);
     let rs = map
         .cursors
         .entry(key.clone())
-        .or_insert_with(|| render_state_for_key(&template, &k));
+        .or_insert_with(|| render_state_for_key(&template, &k, &in_use));
     if !(rs.core.cfg.enabled && rs.core.pos.0 < -50.0) {
         return false;
     }
@@ -400,12 +416,37 @@ pub fn run_on_thread() {
 
 struct RenderState {
     core: RenderStateCore,
+    /// Per-key layered window handle stored as `isize` (HWND is `*mut c_void`,
+    /// not `Send`/`Sync`). `0` = not yet created. Created lazily on the first
+    /// tick that observes this key, destroyed on `Remove`. The map lives behind
+    /// the `RENDER` mutex and window ops only happen on the STA thread, so the
+    /// raw handle never actually crosses threads.
+    hwnd_isize: isize,
+    /// Per-key z-order enforcer, bound to this key's own window + pinned target,
+    /// so each cursor sits at z+1 of ITS OWN `pinned_wid` (no shared band).
+    z: Option<WinZOrderEnforcer>,
+    /// Reusable per-key pixmap, (re)allocated to the virtual-screen size on
+    /// first use and after a `WM_DISPLAYCHANGE`. Painted into by this key's
+    /// cursor only, then blitted via `UpdateLayeredWindow`.
+    pm: Option<tiny_skia::Pixmap>,
+    /// Whether this key's window currently shows a non-empty frame. Used to
+    /// erase the window exactly once when a cursor goes visible→hidden: the
+    /// per-key tick `continue`s for hidden cursors (so a quiescent session
+    /// costs nothing), but the OLD single-window design re-blitted the whole
+    /// composite every tick, which erased a just-disabled cursor. Without a
+    /// one-shot clearing blit here a `set_agent_cursor_enabled(false)` would
+    /// leave the last painted frame frozen on screen (a ghost cursor).
+    painted: bool,
 }
 
 impl RenderState {
     fn new(cfg: CursorConfig) -> Self {
         RenderState {
             core: RenderStateCore::new(cfg),
+            hwnd_isize: 0,
+            z: None,
+            pm: None,
+            painted: false,
         }
     }
 
@@ -424,6 +465,114 @@ impl RenderState {
         let _ = self.core.apply_command_base(cmd, false, false);
     }
 }
+
+// ── Per-key window lifecycle (Windows) ────────────────────────────────────
+
+/// Shared window-class name for every per-key overlay window. Registered
+/// idempotently (a duplicate `RegisterClassExW` returns
+/// `ERROR_CLASS_ALREADY_EXISTS`, which we ignore) so we never leak class atoms.
+#[cfg(target_os = "windows")]
+const OVERLAY_CLASS: &str = "Cua.AgentCursorOverlay";
+
+/// Half-extent (px) of the per-cursor layered window. The whole cursor — arrow
+/// (≤14px from `pos`), bloom (±22px), click-pulse ring (≤~26px) — fits well
+/// inside this radius, so each cursor paints into a tiny `2*CURSOR_HALF` square
+/// pixmap that *follows* it (positioned via `UpdateLayeredWindow`'s `pt_dst`)
+/// instead of a full virtual-screen RGBA buffer (~14MB at 2560×1440) per cursor.
+/// 64 leaves ~32px of margin around the drawn extent.
+#[cfg(target_os = "windows")]
+const CURSOR_HALF: i32 = 64;
+
+/// Lazily create the layered window that backs the cursor for `key` if it does
+/// not have one yet. MUST be called only on the STA thread (window handles have
+/// thread affinity). Stores the new `hwnd_isize` + a per-key
+/// [`WinZOrderEnforcer`] into the key's [`RenderState`].
+///
+/// `CreateWindowExW` dispatches `WM_NCCREATE`/`WM_CREATE` synchronously to the
+/// shared `wnd_proc`; those fall through to `DefWindowProcW` and never touch
+/// `RENDER`, so this is safe to call while the caller holds the `RENDER` lock.
+#[cfg(target_os = "windows")]
+fn ensure_session_window(map: &mut RenderMap, key: &CursorKey) {
+    use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+    use windows::Win32::UI::WindowsAndMessaging::*;
+    use windows::core::PCWSTR;
+
+    let (virt_x, virt_y, virt_w, virt_h) = (map.virt_x, map.virt_y, map.virt_w, map.virt_h);
+    let Some(rs) = map.cursors.get_mut(key) else {
+        return;
+    };
+    if rs.hwnd_isize != 0 {
+        return;
+    }
+
+    let class_name_w: Vec<u16> = format!("{OVERLAY_CLASS}\0").encode_utf16().collect();
+    let title_w: Vec<u16> = format!("{OVERLAY_CLASS}.{key}\0").encode_utf16().collect();
+
+    let hinstance = unsafe { GetModuleHandleW(PCWSTR::null()).unwrap_or_default() };
+
+    // Idempotent: registering an already-registered class fails with
+    // ERROR_CLASS_ALREADY_EXISTS, which we deliberately ignore.
+    let wc = WNDCLASSEXW {
+        cbSize: std::mem::size_of::<WNDCLASSEXW>() as u32,
+        style: CS_HREDRAW | CS_VREDRAW,
+        lpfnWndProc: Some(wnd_proc),
+        hInstance: hinstance.into(),
+        lpszClassName: PCWSTR(class_name_w.as_ptr()),
+        ..Default::default()
+    };
+    unsafe {
+        RegisterClassExW(&wc);
+    }
+
+    let ex_style = WS_EX_TRANSPARENT | WS_EX_LAYERED | WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW;
+    let style = WS_POPUP;
+    let hwnd = unsafe {
+        CreateWindowExW(
+            ex_style,
+            PCWSTR(class_name_w.as_ptr()),
+            PCWSTR(title_w.as_ptr()),
+            style,
+            virt_x,
+            virt_y,
+            virt_w,
+            virt_h,
+            None,
+            None,
+            hinstance,
+            None,
+        )
+    };
+    let Ok(hwnd) = hwnd else {
+        tracing::error!("Win32 overlay: CreateWindowExW failed for key {key}");
+        return;
+    };
+    unsafe {
+        let _ = ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+    }
+    rs.hwnd_isize = hwnd.0 as isize;
+    rs.z = Some(WinZOrderEnforcer {
+        hwnd_isize: hwnd.0 as isize,
+    });
+}
+
+/// Destroy a per-key overlay window. Called from the `Remove` branch on the STA
+/// thread (the creating thread), so `DestroyWindow` has correct affinity.
+#[cfg(target_os = "windows")]
+fn destroy_session_window(hwnd_isize: isize) {
+    use windows::Win32::Foundation::HWND;
+    use windows::Win32::UI::WindowsAndMessaging::DestroyWindow;
+    if hwnd_isize == 0 {
+        return;
+    }
+    unsafe {
+        let _ = DestroyWindow(HWND(hwnd_isize as *mut _));
+    }
+}
+
+/// Non-Windows / test stub: hwnd_isize is always 0, so this is never reached
+/// with a live handle.
+#[cfg(not(target_os = "windows"))]
+fn destroy_session_window(_hwnd_isize: isize) {}
 
 // ── Win32 message-loop thread ─────────────────────────────────────────────
 
@@ -515,13 +664,24 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
         SetTimer(hwnd, 1, 8, None);
     }
 
-    // Store hwnd and rx globally for the wnd_proc callback.
+    // Store hwnd and rx globally for the wnd_proc callback. This supervisor
+    // window owns the SINGLE WM_TIMER + the message loop, and is also
+    // REPURPOSED as the "default" key's own layered window so default paints
+    // into it like every other per-key window (no extra HWND, no shared band).
     OVERLAY_HWND.store(hwnd.0 as isize, std::sync::atomic::Ordering::Relaxed);
     *CMD_RX_WIN.lock().unwrap() = Some(rx);
     LAST_ZTICK.store(0, std::sync::atomic::Ordering::Relaxed);
-    let _ = Z_ORDER.set(WinZOrderEnforcer {
-        hwnd_isize: hwnd.0 as isize,
-    });
+    {
+        let mut guard = RENDER.lock().unwrap();
+        if let Some(map) = guard.as_mut() {
+            if let Some(rs) = map.cursors.get_mut("default") {
+                rs.hwnd_isize = hwnd.0 as isize;
+                rs.z = Some(WinZOrderEnforcer {
+                    hwnd_isize: hwnd.0 as isize,
+                });
+            }
+        }
+    }
 
     // Standard Win32 message loop.
     let mut msg = MSG::default();
@@ -543,7 +703,6 @@ fn run_overlay_thread(_cfg: CursorConfig, _rx: std::sync::mpsc::Receiver<Overlay
 static OVERLAY_HWND: std::sync::atomic::AtomicIsize = std::sync::atomic::AtomicIsize::new(0);
 static CMD_RX_WIN: Mutex<Option<std::sync::mpsc::Receiver<OverlayMsg>>> = Mutex::new(None);
 static LAST_ZTICK: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-static Z_ORDER: OnceLock<WinZOrderEnforcer> = OnceLock::new();
 
 // ── Window procedure ──────────────────────────────────────────────────────
 
@@ -564,20 +723,36 @@ unsafe extern "system" fn wnd_proc(
                 .unwrap_or_default()
                 .as_millis() as u64;
 
-            // ── Drain commands, tick all cursors, composite one pixmap ───────
+            // ── Drain commands, tick + paint EACH cursor into ITS OWN window ──
             // Measure real dt from last tick — Windows timer resolution defaults
             // to 15ms so the hardcoded 8ms ran the animation at half speed.
-            let (pixmap, arrived, pinned_wid) = {
+            //
+            // Each key owns its own layered window (created lazily here on the
+            // STA thread) + its own reusable pixmap + its own z-enforcer, so a
+            // cursor sits at z+1 of ITS OWN pinned target — no single-window /
+            // last-active bottleneck. Per-key paint + UpdateLayeredWindow +
+            // z-reassert all happen under one RENDER lock (microseconds for a
+            // handful of sessions); idle/hidden cursors skip the blit entirely.
+            let do_ztick = {
+                let last = LAST_ZTICK.load(std::sync::atomic::Ordering::Relaxed);
+                if now_ms.wrapping_sub(last) >= 80 {
+                    LAST_ZTICK.store(now_ms, std::sync::atomic::Ordering::Relaxed);
+                    true
+                } else {
+                    false
+                }
+            };
+
+            let mut arrived: Vec<CursorKey> = Vec::new();
+            {
                 let mut guard = RENDER.lock().unwrap();
                 if let Some(map) = guard.as_mut() {
-                    // Drain the channel via get-or-create; track the last-touched
-                    // key so the z-order pin follows the most-recent cursor.
+                    // Drain the channel via get-or-create (no last-active: each
+                    // key pins against its own target independently).
                     if let Ok(rx_guard) = CMD_RX_WIN.try_lock() {
                         if let Some(ref rx) = *rx_guard {
                             while let Ok(m) = rx.try_recv() {
-                                if let Some(k) = apply_msg(map, m) {
-                                    map.last_active = Some(k);
-                                }
+                                let _ = apply_msg(map, m);
                             }
                         }
                     }
@@ -589,47 +764,85 @@ unsafe extern "system" fn wnd_proc(
                         .clamp(0.0, 0.05);
                     map.last_tick = now;
 
-                    // Tick every cursor; record the ones that just arrived.
-                    let mut arrived: Vec<CursorKey> = Vec::new();
+                    // Each cursor paints into a small FIXED box that follows it
+                    // (see CURSOR_HALF) rather than a full-screen pixmap.
+                    let box_w = (CURSOR_HALF * 2) as u32;
+
+                    // Lazily create any key's window (covers Cmd- and
+                    // seed-created cursors uniformly) BEFORE borrowing the entry
+                    // mutably below. Collect keys first to avoid borrow overlap.
+                    let keys: Vec<CursorKey> = map.cursors.keys().cloned().collect();
+                    for key in &keys {
+                        let needs = map
+                            .cursors
+                            .get(key)
+                            .map(|rs| rs.hwnd_isize == 0)
+                            .unwrap_or(false);
+                        if needs {
+                            ensure_session_window(map, key);
+                        }
+                    }
+
+                    // Tick + paint + blit + reassert per cursor.
                     for (k, rs) in map.cursors.iter_mut() {
                         if rs.tick(dt) {
                             arrived.push(k.clone());
                         }
-                    }
+                        if rs.hwnd_isize == 0 {
+                            continue; // window creation failed; skip this frame
+                        }
+                        let key_hwnd = HWND(rs.hwnd_isize as *mut _);
 
-                    // Composite every cursor into ONE virtual-screen pixmap.
-                    // tiny-skia fills are alpha-over, so insertion order =
-                    // paint/z-order; idle/hidden cursors early-return inside
-                    // paint_cursor so an idle session costs ~nothing.
-                    let w = map.virt_w.max(1) as u32;
-                    let h = map.virt_h.max(1) as u32;
-                    let mut pm = tiny_skia::Pixmap::new(w.max(1), h.max(1))
-                        .unwrap_or_else(|| tiny_skia::Pixmap::new(1, 1).unwrap());
-                    for (_k, rs) in &map.cursors {
+                        // Hidden cursor: hide its window ONCE (so a disabled cursor
+                        // disappears instead of freezing its last frame), then skip
+                        // every later tick so a quiescent session costs ~nothing.
+                        if !rs.core.visible {
+                            if rs.painted {
+                                let _ = ShowWindow(key_hwnd, SW_HIDE);
+                                rs.painted = false;
+                            }
+                            continue;
+                        }
+
+                        // Box that FOLLOWS the cursor: top-left = pos - CURSOR_HALF.
+                        let bx = rs.core.pos.0.round() as i32 - CURSOR_HALF;
+                        let by = rs.core.pos.1.round() as i32 - CURSOR_HALF;
+                        if rs
+                            .pm
+                            .as_ref()
+                            .map(|p| p.width() != box_w || p.height() != box_w)
+                            .unwrap_or(true)
+                        {
+                            rs.pm = tiny_skia::Pixmap::new(box_w, box_w);
+                        }
+                        let Some(pm) = rs.pm.as_mut() else { continue };
+                        // Clear, then paint ONLY this cursor. Passing the box's
+                        // screen top-left as the paint origin lands the cursor at
+                        // (CURSOR_HALF, CURSOR_HALF) inside the box.
+                        pm.data_mut().fill(0);
                         cursor_overlay::paint_cursor(
-                            &mut pm,
+                            pm,
                             &rs.core,
-                            map.virt_x as f64,
-                            map.virt_y as f64,
+                            bx as f64,
+                            by as f64,
                             None, // focus-rect is macOS-only
                         );
+                        // Re-show if it had been hidden, then blit + reposition the
+                        // window to the box (UpdateLayeredWindow sets both size and
+                        // pt_dst, so the small window tracks the cursor).
+                        if !rs.painted {
+                            let _ = ShowWindow(key_hwnd, SW_SHOWNOACTIVATE);
+                        }
+                        update_layered_window(key_hwnd, pm, bx, by);
+                        rs.painted = true;
+
+                        if do_ztick {
+                            if let Some(z) = rs.z.as_ref() {
+                                z.reassert(rs.core.pinned_wid);
+                            }
+                        }
                     }
-
-                    // Pin above the most-recently-touched cursor's target.
-                    let pinned = map
-                        .last_active
-                        .as_ref()
-                        .and_then(|k| map.cursors.get(k))
-                        .and_then(|rs| rs.core.pinned_wid);
-
-                    (Some(pm), arrived, pinned)
-                } else {
-                    (None, Vec::new(), None)
                 }
-            };
-
-            if let Some(pm) = pixmap {
-                update_layered_window(hwnd, &pm);
             }
 
             // Fire arrival oneshots for cursors whose path just ended — unblocks
@@ -639,22 +852,84 @@ unsafe extern "system" fn wnd_proc(
                 arrival_fire(k);
             }
 
-            // Z-order maintenance every 80ms — delegate to the cross-platform
-            // ZOrderEnforcer so the contract for "z+1 of the application under
-            // test" is documented once in `cursor_overlay::z_order`.
-            let last = LAST_ZTICK.load(std::sync::atomic::Ordering::Relaxed);
-            if now_ms.wrapping_sub(last) >= 80 {
-                LAST_ZTICK.store(now_ms, std::sync::atomic::Ordering::Relaxed);
-                if let Some(enforcer) = Z_ORDER.get() {
-                    enforcer.reassert(pinned_wid);
+            LRESULT(0)
+        }
+        WM_DISPLAYCHANGE => {
+            // The desktop resolution / monitor layout changed (common on VMs,
+            // RDP, dock/undock, and — as hit in testing — a Mac-hosted Windows
+            // VM whose backing resolution flips, e.g. 1512×949 ↔ 2560×1440).
+            //
+            // The virtual-screen geometry was captured ONCE at thread start into
+            // `RenderMap.virt_*` and the overlay window was sized to it. If we
+            // don't refresh on resize, the overlay keeps covering only the old
+            // (smaller) region, the per-tick pixmap stays that size, and any
+            // cursor positioned in the newly-exposed area falls OUTSIDE the
+            // pixmap → it silently never paints. Re-query the metrics, update
+            // the shared map (the WM_TIMER tick rebuilds the pixmap from these),
+            // and resize/reposition the window to span the new virtual screen.
+            // (GetSystemMetrics / SM_* / SetWindowPos come from the
+            // WindowsAndMessaging glob imported at the top of this fn.)
+            let vx = GetSystemMetrics(SM_XVIRTUALSCREEN);
+            let vy = GetSystemMetrics(SM_YVIRTUALSCREEN);
+            let vw = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+            let vh = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+            if vw > 0 && vh > 0 {
+                if let Ok(mut guard) = RENDER.lock() {
+                    if let Some(map) = guard.as_mut() {
+                        map.virt_x = vx;
+                        map.virt_y = vy;
+                        map.virt_w = vw;
+                        map.virt_h = vh;
+                        // Resize/reposition EVERY per-key window to span the new
+                        // virtual screen and drop each pixmap so the next tick
+                        // reallocates it to the new size. SWP_NOZORDER makes the
+                        // insert-after handle irrelevant.
+                        for (_k, rs) in map.cursors.iter_mut() {
+                            if rs.hwnd_isize != 0 {
+                                let _ = SetWindowPos(
+                                    HWND(rs.hwnd_isize as *mut _),
+                                    HWND::default(),
+                                    vx,
+                                    vy,
+                                    vw,
+                                    vh,
+                                    SWP_NOACTIVATE | SWP_NOZORDER | SWP_NOOWNERZORDER,
+                                );
+                            }
+                            rs.pm = None;
+                        }
+                    }
                 }
             }
-
             LRESULT(0)
         }
         WM_DESTROY => {
-            PostQuitMessage(0);
-            LRESULT(0)
+            // The shared wnd_proc backs every per-key window, so a per-session
+            // DestroyWindow also lands here. ONLY the supervisor/"default"
+            // window (the one owning the SetTimer + message loop) may quit the
+            // loop; a per-key teardown must NOT kill the whole overlay.
+            let supervisor = OVERLAY_HWND.load(std::sync::atomic::Ordering::Relaxed);
+            if hwnd.0 as isize == supervisor {
+                // Overlay is shutting down — destroy every per-key window so none
+                // leak (e.g. a session that never sent session_end). Skip the
+                // supervisor (it's being destroyed now). RENDER isn't held here
+                // (WM_DESTROY is a distinct message, not a WM_TIMER tick), so the
+                // lock is safe; each DestroyWindow re-enters this wnd_proc with a
+                // non-supervisor HWND → falls through, never re-quitting.
+                if let Ok(guard) = RENDER.lock() {
+                    if let Some(map) = guard.as_ref() {
+                        for rs in map.cursors.values() {
+                            if rs.hwnd_isize != 0 && rs.hwnd_isize != supervisor {
+                                destroy_session_window(rs.hwnd_isize);
+                            }
+                        }
+                    }
+                }
+                PostQuitMessage(0);
+                LRESULT(0)
+            } else {
+                DefWindowProcW(hwnd, msg, wparam, lparam)
+            }
         }
         _ => DefWindowProcW(hwnd, msg, wparam, lparam),
     }
@@ -662,10 +937,16 @@ unsafe extern "system" fn wnd_proc(
 
 // ── UpdateLayeredWindow helper ────────────────────────────────────────────
 
+/// Blit `pixmap` into `hwnd` via `UpdateLayeredWindow`. `origin_x`/`origin_y`
+/// are the virtual-screen top-left (passed in rather than read from `RENDER`
+/// so this can be called WHILE the caller holds the `RENDER` lock — std Mutex
+/// is not reentrant and would deadlock on a self re-lock).
 #[cfg(target_os = "windows")]
 unsafe fn update_layered_window(
     hwnd: windows::Win32::Foundation::HWND,
     pixmap: &tiny_skia::Pixmap,
+    origin_x: i32,
+    origin_y: i32,
 ) {
     use windows::Win32::Foundation::*;
     use windows::Win32::Graphics::Gdi::*;
@@ -719,22 +1000,9 @@ unsafe fn update_layered_window(
         dst[i * 4 + 3] = a;
     }
 
-    // UpdateLayeredWindow.
-    let virt_x;
-    let virt_y;
-    {
-        let guard = RENDER.lock().unwrap();
-        if let Some(map) = &*guard {
-            virt_x = map.virt_x;
-            virt_y = map.virt_y;
-        } else {
-            virt_x = 0;
-            virt_y = 0;
-        }
-    }
-
+    // UpdateLayeredWindow — origin passed in (no RENDER re-lock; see doc above).
     let pt_src = POINT { x: 0, y: 0 };
-    let pt_dst = POINT { x: virt_x, y: virt_y };
+    let pt_dst = POINT { x: origin_x, y: origin_y };
     let sz = SIZE { cx: w, cy: h };
     let blend = BLENDFUNCTION {
         BlendOp: 0, // AC_SRC_OVER
@@ -867,7 +1135,6 @@ mod tests {
             last_tick: Instant::now(),
             template: CursorConfig::default(),
             ended: HashSet::new(),
-            last_active: None,
         }
     }
 
@@ -1003,12 +1270,15 @@ mod tests {
     }
 
     #[test]
-    fn remove_clears_last_active_for_that_key() {
+    fn remove_is_window_noop_when_no_hwnd() {
+        // In tests hwnd_isize is always 0 (no Win32 window), so Remove must be a
+        // pure data-model no-op for the window side: destroy_session_window is
+        // skipped and the entry is shift_removed + tombstoned as usual.
         let mut map = empty_map();
-        let k = apply_msg(&mut map, move_msg("sessA", 10.0, 10.0));
-        map.last_active = k;
-        assert_eq!(map.last_active.as_deref(), Some("sessA"));
+        apply_msg(&mut map, move_msg("sessA", 10.0, 10.0));
+        assert_eq!(map.cursors["sessA"].hwnd_isize, 0);
         apply_msg(&mut map, OverlayMsg::Remove("sessA".to_owned()));
-        assert_eq!(map.last_active, None, "removing the active cursor must clear last_active");
+        assert!(!map.cursors.contains_key("sessA"));
+        assert!(map.ended.contains("sessA"));
     }
 }

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -74,15 +74,23 @@ fn bitmap_to_screen(hwnd: u64, px: i32, py: i32) -> (i32, i32) {
 /// Animate the agent cursor to (sx, sy) in screen coordinates and wait for the
 /// glide to finish before returning.  No-op when the overlay is not enabled.
 ///
-/// On the very first call the cursor is at the off-screen initial position
-/// (-200, -200).  Animating from there would cause a jarring off-screen fly-in,
-/// so we snap to the target with a ClickPulse first and skip the glide wait.
+/// Always glides — including the session's FIRST action. A brand-new cursor
+/// still parked at the off-screen sentinel `(-200, -200)` is seeded on-screen
+/// (offset up-left of the target) inside [`crate::overlay::animate_cursor_to`]
+/// via `seed_start_if_sentinel`, so the `MoveTo` below glides INTO the target
+/// instead of snapping. We previously short-circuited the first action with a
+/// static `ClickPulse` to skip the arrival wait, but on a pure accessibility
+/// action (no real pointer movement) that snap was a single-frame pulse that
+/// was easy to miss — the cursor appeared to never move. Mirrors
+/// `platform_macos::cursor::overlay::animate_cursor_to`, which dropped the same
+/// snap-first shortcut for this reason.
 ///
-/// For all subsequent calls this defers to
-/// [`crate::overlay::animate_cursor_to`], which sends `MoveTo` and awaits the
-/// render thread's arrival oneshot — that's how we keep the click action
-/// from firing before the cursor has visually landed (the old heuristic
-/// `tokio::sleep(80..600 ms)` was racing the spring-physics glide).
+/// [`crate::overlay::animate_cursor_to`] sends `MoveTo` and awaits the render
+/// thread's arrival oneshot — that's how we keep the action from firing before
+/// the cursor has visually landed (the old heuristic `tokio::sleep(80..600 ms)`
+/// was racing the spring-physics glide). It is itself a no-op (returns without
+/// waiting) when the cursor is disabled, so the redundant guard here just saves
+/// the allocation in the common cursor-less case.
 ///
 /// `key` is the session's cursor key (see [`resolve_cursor_key`]). An empty key
 /// (anonymous, no declared session) is cursor-less: every overlay op
@@ -90,12 +98,6 @@ fn bitmap_to_screen(hwnd: u64, px: i32, py: i32) -> (i32, i32) {
 async fn overlay_glide_to(key: &str, sx: f64, sy: f64) {
     if key.is_empty() { return; }
     if !crate::overlay::is_enabled(key) { return; }
-    let pos = crate::overlay::current_position(key);
-    if pos.0 < 0.0 && pos.1 < 0.0 {
-        // Snap to target on first use; no animation to wait for.
-        crate::overlay::send_command(key.to_owned(), cursor_overlay::OverlayCommand::ClickPulse { x: sx, y: sy });
-        return;
-    }
     crate::overlay::animate_cursor_to(key.to_owned(), sx, sy).await;
 }
 use cua_driver_core::{protocol::ToolResult, tool::{Tool, ToolDef, ToolRegistry}};
@@ -3944,6 +3946,34 @@ impl Tool for SetAgentCursorMotionTool {
             if let Some(v) = num(args.get("cursor_size"))    { cfg.cursor_size    = Some(v); }
             if let Some(v) = num(args.get("cursor_opacity")) { cfg.cursor_opacity = Some(v.clamp(0.0, 1.0)); }
         });
+        // 1b. Make `cursor_color` actually RENDER. The painter only reads the
+        // per-cursor `gradient_override` (set via SetGradient) or the palette —
+        // it never consulted the config's `cursor_color`, so before this the
+        // field was stored + echoed by get_agent_cursor_state but invisible on
+        // screen (every cursor stayed the palette/default colour, which is why
+        // per-session cursors all looked identical). Translate a single colour
+        // into a solid one-stop gradient (the painter repeats a 1-element
+        // gradient across tip→tail) plus a lightened bloom so the halo matches,
+        // so `set_agent_cursor_motion {cursor_color}` is the natural way to give
+        // each session a distinct, visible colour. Sending SetGradient also
+        // keeps this on the same render path as `set_agent_cursor_style`.
+        if let Some(hex) = args.get("cursor_color").and_then(|v| v.as_str()) {
+            if let Some(rgba) = parse_hex_color(hex) {
+                let bloom = [
+                    ((rgba[0] as u16 + 255) / 2) as u8,
+                    ((rgba[1] as u16 + 255) / 2) as u8,
+                    ((rgba[2] as u16 + 255) / 2) as u8,
+                    rgba[3],
+                ];
+                crate::overlay::send_command(
+                    cursor_id.clone(),
+                    cursor_overlay::OverlayCommand::SetGradient {
+                        gradient_colors: vec![rgba],
+                        bloom_color: Some(bloom),
+                    },
+                );
+            }
+        }
         // 2. Apply motion knobs to the live render state — was silently
         // dropped before; this is the Swift parity behavior.
         let current = crate::overlay::current_motion(&cursor_id);

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -3790,6 +3790,32 @@ impl Tool for MoveCursorTool {
         let cursor_key = resolve_cursor_key(&args);
         if !cursor_key.is_empty() {
             self.state.cursor_registry.update_position(&cursor_key, x, y);
+            // Pin the overlay above the window under the destination point so a
+            // brand-new session cursor is z-visible. Sibling tools (click,
+            // type_text, drag…) pin against their explicit target HWND; move_cursor
+            // only carries (x, y), so we derive the target via WindowFromPoint at
+            // the destination. Without this, the first move_cursor on a fresh
+            // session lands the overlay at an unpinned z-position — usually
+            // behind the target HWND — so the cursor stays invisible until a
+            // sibling tool happens to run and pin it. (macOS's move_cursor
+            // sidesteps this by routing through `animate_cursor_to`, which seeds
+            // the off-screen sentinel and lets the macOS render loop's
+            // ZOrderEnforcer handle pinning; the Windows port has explicit
+            // per-tool pins instead — see project_agent_cursor_zorder.md.)
+            //
+            // The overlay HWND itself is WS_EX_TRANSPARENT (click-through), so
+            // WindowFromPoint walks past it and returns the app behind. Empty
+            // desktop returns the desktop HWND, which pin_overlay_above resolves
+            // to GA_ROOT and PinAbove no-ops harmlessly.
+            unsafe {
+                use windows::Win32::Foundation::POINT;
+                use windows::Win32::UI::WindowsAndMessaging::WindowFromPoint;
+                let pt = POINT { x: x.round() as i32, y: y.round() as i32 };
+                let hwnd = WindowFromPoint(pt);
+                if !hwnd.0.is_null() {
+                    pin_overlay_above(&cursor_key, hwnd.0 as u64);
+                }
+            }
         }
         // End pointing upper-left (45°) — matches Swift's
         // `AgentCursor.animateAndWait(endAngleDegrees: 45)` convention so


### PR DESCRIPTION
## Summary

Four related improvements to the Rust driver's agent-cursor + parallel-agent story, developed and runtime-verified live on Windows:

### 1. Per-session overlay windows — stable multi-cursor z-order
The overlay was a single layered window compositing every session cursor, pinned z+1 of only the **last-active** cursor's target — any action by one cursor dragged all others out of their own window's z-band. Each cursor key now owns its **own** small layered window (lazy-created, destroyed on `session_end`, supervisor cleans up all on shutdown), each pinned z+1 of **its own** target, painted into a **128×128 box that follows the cursor** instead of a ~14MB full-screen buffer per cursor. Also: `WM_DISPLAYCHANGE` re-captures the virtual screen (the VM resolution flip 1512×949↔2560×1440 previously left cursors rendering outside a stale overlay), and a disabled cursor hides its window instead of freezing a ghost frame. macOS parity: #1807. Long-lived-daemon degradation: #1806.

### 2. Visible, distinctly-colored cursors
- First accessibility action **glides in** (seed + glide) instead of an easy-to-miss snap, matching macOS.
- `set_agent_cursor_motion {cursor_color}` now actually **renders** (it was stored but never reached the painter) via `SetGradient`.
- **Collision-free palette assignment**: ids sharing a numeric suffix all hashed to one palette (`stable_index` suffix rule) → identical colors; `for_instance_distinct` probes past in-use palettes, and the palette grows by six hue-gap colors.
- Display capture uses `SRCCOPY|CAPTUREBLT` so the layered overlay appears in full-screen screenshots.

### 3. Parallel HTTP transport discoverability
- `serve --http-port <port>` first-class flag (env var still honored).
- `cua-driver status` reports the live `mcp-http` endpoint (self-correcting via port probe).
- The daemon **self-advertises the live URL** in its MCP `initialize` instructions only when the listener genuinely bound.

### 4. Docs: the concurrency contract
SKILL.md + MCP instructions now state it explicitly: **one session = one connection = sequential (FIFO); parallelism is across sessions, never within one** (per-session cursor + recording assume an ordered stream) — with a worked `curl` example and the same-daemon element-cache caveat.

## Test plan
- `cargo test`: cursor-overlay 7/7, cua-driver-core 51/51, platform-windows 49/49, cua-driver bin 62/62; release build clean.
- Runtime-verified on Windows 11 (2560×1440 VM): per-session 128×128 overlay windows tracking their cursors independently; `end_session` destroys exactly its window; four concurrent sessions filled four windows **simultaneously** (staggered, sequential-within-session) with distinct colors and stable z; native recording captures it end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
