### PR TITLE
fix(cua-driver): fail closed on X11 overlay shape errors

### DIFF
--- a/.github/workflows/ci-rust-linux.yml
+++ b/.github/workflows/ci-rust-linux.yml
@@ -63,10 +63,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             clang pkg-config libdbus-1-dev libpipewire-0.3-dev libspa-0.2-dev \
-            libei-dev libxkbcommon-dev libx11-dev libxi-dev libxtst-dev libxext-dev
+            libei-dev libxkbcommon-dev libx11-dev libxi-dev libxtst-dev libxext-dev \
+            xvfb xauth
       - name: Run Linux Rust tests
         working-directory: libs/cua-driver/rust
         run: cargo test -p cua-driver -p cua-driver-contract -p cua-driver-core -p cua-driver-testkit -p cursor-overlay -p cursor-theme-cli -p platform-linux --all-targets --locked
+      - name: Run X11 overlay click-through regression
+        working-directory: libs/cua-driver/rust
+        run: >-
+          xvfb-run -a --server-args="-screen 0 1920x1080x24"
+          cargo test -p platform-linux
+          x11_overlay_input_shape_stays_empty_and_clicks_pass_through_after_resize
+          --locked -- --ignored --nocapture
       - name: Run real uinput device-name regression
         working-directory: libs/cua-driver/rust
         run: |

--- a/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
@@ -867,12 +867,38 @@ fn clear_x11_overlay_input_shape(
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
+fn map_x11_overlay_with_empty_input(
+    conn: &impl x11rb::connection::Connection,
+    win: u32,
+) -> anyhow::Result<()> {
+    use x11rb::protocol::shape::{ConnectionExt as ShapeConnectionExt, SK, SO};
+    use x11rb::protocol::xproto::{ClipOrdering, ConnectionExt as XprotoConnectionExt};
+
+    // Check both safety-critical shapes before mapping. If either request is
+    // rejected, the full-root overlay must remain unmapped rather than falling
+    // back to the server's default full-window input region.
+    clear_x11_overlay_input_shape(conn, win)?;
+    conn.shape_rectangles(
+        SO::SET,
+        SK::BOUNDING,
+        ClipOrdering::UNSORTED,
+        win,
+        0,
+        0,
+        &[],
+    )?
+    .check()?;
+    conn.map_window(win)?.check()?;
+    conn.flush()?;
+    Ok(())
+}
+
 // ── X11 thread ────────────────────────────────────────────────────────────
 
 #[cfg(target_os = "linux")]
 fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMsg>) {
     use x11rb::connection::Connection;
-    use x11rb::protocol::shape::{ConnectionExt as ShapeConnectionExt, SK, SO};
     use x11rb::protocol::xproto::ConnectionExt as XprotoConnectionExt;
     use x11rb::protocol::xproto::{
         AtomEnum, ColormapAlloc, CreateGCAux, CreateWindowAux, EventMask, PropMode, WindowClass,
@@ -990,20 +1016,12 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
     // bare/non-composited X servers before the first cursor command paints a
     // real visible shape. ShapeMask with a None pixmap would reset either
     // region to the full window; an empty rectangle list expresses emptiness.
-    clear_x11_overlay_input_shape(&conn, win).ok();
-    conn.shape_rectangles(
-        SO::SET,
-        SK::BOUNDING,
-        x11rb::protocol::xproto::ClipOrdering::UNSORTED,
-        win,
-        0,
-        0,
-        &[],
-    )
-    .ok();
-
-    conn.map_window(win).ok();
-    conn.flush().ok();
+    if let Err(e) = map_x11_overlay_with_empty_input(&conn, win) {
+        tracing::warn!(
+            "X11 overlay: cannot establish click-through input shape; overlay remains unmapped: {e}"
+        );
+        return;
+    }
 
     // One GC is sufficient for the lifetime of the overlay window. Recreating
     // and freeing it every 16 ms adds two avoidable X11 requests to the hot
@@ -1636,12 +1654,30 @@ mod tests {
         );
         assert_x11_button_press_target(&conn, root, overlay)?;
 
-        clear_x11_overlay_input_shape(&conn, overlay)?;
+        conn.unmap_window(overlay)?.check()?;
+        map_x11_overlay_with_empty_input(&conn, overlay)?;
         let click_through_input = conn.shape_get_rectangles(overlay, SK::INPUT)?.reply()?;
         assert!(
             click_through_input.rectangles.is_empty(),
             "click-through overlay must expose an empty X11 input shape"
         );
+        let initial_visible_bounds = [Rectangle {
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 200,
+        }];
+        conn.shape_rectangles(
+            SO::SET,
+            SK::BOUNDING,
+            ClipOrdering::UNSORTED,
+            overlay,
+            0,
+            0,
+            &initial_visible_bounds,
+        )?
+        .check()?;
+        conn.flush()?;
         assert_x11_button_press_target(&conn, root, target)?;
 
         prepare_x11_overlay_geometry(
@@ -1674,6 +1710,16 @@ mod tests {
             "resize repair must not restore a stale full-root input region"
         );
         assert_x11_button_press_target(&conn, root, target)?;
+
+        let missing_window = conn.generate_id()?;
+        assert!(
+            map_x11_overlay_with_empty_input(&conn, missing_window).is_err(),
+            "a rejected input-shape request must abort before mapping"
+        );
+        assert!(
+            conn.poll_for_event()?.is_none(),
+            "mapping must not be attempted after the checked input-shape request fails"
+        );
         Ok(())
     }
 

--- a/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
@@ -830,10 +830,17 @@ fn prepare_x11_overlay_geometry(
     // invalidated an old bounding shape during RandR reconfiguration, this
     // prevents a zero-filled full-root frame from becoming visible between the
     // ConfigureWindow request and the next cursor-local paint.
-    for shape_kind in [SK::BOUNDING, SK::INPUT] {
-        conn.shape_rectangles(SO::SET, shape_kind, ClipOrdering::UNSORTED, win, 0, 0, &[])?
-            .check()?;
-    }
+    conn.shape_rectangles(
+        SO::SET,
+        SK::BOUNDING,
+        ClipOrdering::UNSORTED,
+        win,
+        0,
+        0,
+        &[],
+    )?
+    .check()?;
+    clear_x11_overlay_input_shape(conn, win)?;
     conn.configure_window(
         win,
         &ConfigureWindowAux::new()
@@ -844,6 +851,19 @@ fn prepare_x11_overlay_geometry(
     )?
     .check()?;
     conn.flush()?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn clear_x11_overlay_input_shape(
+    conn: &impl x11rb::connection::Connection,
+    win: u32,
+) -> anyhow::Result<()> {
+    use x11rb::protocol::shape::{ConnectionExt as ShapeConnectionExt, SK, SO};
+    use x11rb::protocol::xproto::ClipOrdering;
+
+    conn.shape_rectangles(SO::SET, SK::INPUT, ClipOrdering::UNSORTED, win, 0, 0, &[])?
+        .check()?;
     Ok(())
 }
 
@@ -970,18 +990,17 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
     // bare/non-composited X servers before the first cursor command paints a
     // real visible shape. ShapeMask with a None pixmap would reset either
     // region to the full window; an empty rectangle list expresses emptiness.
-    for shape_kind in [SK::INPUT, SK::BOUNDING] {
-        conn.shape_rectangles(
-            SO::SET,
-            shape_kind,
-            x11rb::protocol::xproto::ClipOrdering::UNSORTED,
-            win,
-            0,
-            0,
-            &[],
-        )
-        .ok();
-    }
+    clear_x11_overlay_input_shape(&conn, win).ok();
+    conn.shape_rectangles(
+        SO::SET,
+        SK::BOUNDING,
+        x11rb::protocol::xproto::ClipOrdering::UNSORTED,
+        win,
+        0,
+        0,
+        &[],
+    )
+    .ok();
 
     conn.map_window(win).ok();
     conn.flush().ok();
@@ -1521,6 +1540,142 @@ fn bgra_and_visible_shape(
 #[cfg(all(test, target_os = "linux"))]
 mod tests {
     use super::*;
+
+    fn assert_x11_button_press_target(
+        conn: &impl x11rb::connection::Connection,
+        root: u32,
+        expected_window: u32,
+    ) -> anyhow::Result<()> {
+        use x11rb::protocol::xproto::{
+            BUTTON_PRESS_EVENT, BUTTON_RELEASE_EVENT, MOTION_NOTIFY_EVENT,
+        };
+        use x11rb::protocol::xtest::ConnectionExt as XtestConnectionExt;
+
+        conn.xtest_fake_input(MOTION_NOTIFY_EVENT, 0, x11rb::CURRENT_TIME, root, 50, 50, 0)?
+            .check()?;
+        conn.xtest_fake_input(BUTTON_PRESS_EVENT, 1, x11rb::CURRENT_TIME, root, 0, 0, 0)?
+            .check()?;
+        conn.xtest_fake_input(BUTTON_RELEASE_EVENT, 1, x11rb::CURRENT_TIME, root, 0, 0, 0)?
+            .check()?;
+        conn.flush()?;
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while Instant::now() < deadline {
+            if let Some(event) = conn.poll_for_event()? {
+                if let x11rb::protocol::Event::ButtonPress(button) = event {
+                    anyhow::ensure!(
+                        button.event == expected_window,
+                        "button press reached window {} instead of expected window {}",
+                        button.event,
+                        expected_window
+                    );
+                    return Ok(());
+                }
+            } else {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        }
+        anyhow::bail!("timed out waiting for an X11 button press")
+    }
+
+    #[test]
+    #[ignore = "requires a live X11 server (run under xvfb-run)"]
+    fn x11_overlay_input_shape_stays_empty_and_clicks_pass_through_after_resize(
+    ) -> anyhow::Result<()> {
+        use x11rb::connection::Connection;
+        use x11rb::protocol::shape::{ConnectionExt as ShapeConnectionExt, SK, SO};
+        use x11rb::protocol::xproto::{
+            ClipOrdering, ConnectionExt as XprotoConnectionExt, CreateWindowAux, EventMask,
+            Rectangle, WindowClass,
+        };
+
+        let (conn, screen_num) = x11rb::connect(None)?;
+        let screen = &conn.setup().roots[screen_num];
+        let root = screen.root;
+        let target = conn.generate_id()?;
+        let overlay = conn.generate_id()?;
+
+        conn.create_window(
+            screen.root_depth,
+            target,
+            root,
+            0,
+            0,
+            200,
+            200,
+            0,
+            WindowClass::INPUT_OUTPUT,
+            screen.root_visual,
+            &CreateWindowAux::new().event_mask(EventMask::BUTTON_PRESS),
+        )?
+        .check()?;
+        conn.create_window(
+            screen.root_depth,
+            overlay,
+            root,
+            0,
+            0,
+            200,
+            200,
+            0,
+            WindowClass::INPUT_OUTPUT,
+            screen.root_visual,
+            &CreateWindowAux::new()
+                .override_redirect(1)
+                .event_mask(EventMask::BUTTON_PRESS),
+        )?
+        .check()?;
+        conn.map_window(target)?.check()?;
+        conn.map_window(overlay)?.check()?;
+        conn.flush()?;
+
+        let initial_input = conn.shape_get_rectangles(overlay, SK::INPUT)?.reply()?;
+        assert!(
+            !initial_input.rectangles.is_empty(),
+            "fixture must begin with a full input region"
+        );
+        assert_x11_button_press_target(&conn, root, overlay)?;
+
+        clear_x11_overlay_input_shape(&conn, overlay)?;
+        let click_through_input = conn.shape_get_rectangles(overlay, SK::INPUT)?.reply()?;
+        assert!(
+            click_through_input.rectangles.is_empty(),
+            "click-through overlay must expose an empty X11 input shape"
+        );
+        assert_x11_button_press_target(&conn, root, target)?;
+
+        prepare_x11_overlay_geometry(
+            &conn,
+            overlay,
+            screen.width_in_pixels,
+            screen.height_in_pixels,
+        )?;
+        let full_root = [Rectangle {
+            x: 0,
+            y: 0,
+            width: screen.width_in_pixels,
+            height: screen.height_in_pixels,
+        }];
+        conn.shape_rectangles(
+            SO::SET,
+            SK::BOUNDING,
+            ClipOrdering::UNSORTED,
+            overlay,
+            0,
+            0,
+            &full_root,
+        )?
+        .check()?;
+        conn.flush()?;
+
+        let repaired_input = conn.shape_get_rectangles(overlay, SK::INPUT)?.reply()?;
+        assert!(
+            repaired_input.rectangles.is_empty(),
+            "resize repair must not restore a stale full-root input region"
+        );
+        assert_x11_button_press_target(&conn, root, target)?;
+        Ok(())
+    }
 
     #[test]
     fn keyed_render_state_carries_the_session_color_identity() {


### PR DESCRIPTION
## Status

This advances the existing contributor PR #1818 with the contributor preserved as author of the test/helper salvage commit and the original commit recorded with `-x` in history. The separate maintainer-authored production commit retains the contributor as coauthor.

Current `main` expresses the correct empty X11 input region, but startup discarded the checked-request result and mapped the full-root overlay even if the server rejected the safety-critical Shape request. This PR makes that boundary fail closed. It does not claim that every recent #1819 runtime report has been correlated to this rejection path; those reports still need current-`main` input-shape measurements.

## Production change

- synchronously check the empty `ShapeInput` request before `MapWindow`;
- synchronously check the empty startup bounding region before `MapWindow`;
- leave the overlay unmapped and stop its owner thread if either request fails;
- reuse the same checked empty-input operation during display-resize repair, whose errors already stop and tear down the mapped overlay.

## Regression coverage

Adds a focused live-X11 test that:

- begins with a full overlay input region and proves the overlay receives a synthetic button press;
- runs the production startup path, verifies `ShapeInput` contains zero rectangles, restores a visible bounding region, and proves the underlying window receives the click;
- runs the full-root resize-repair path and again proves the input region is empty and clicks reach the underlying window;
- injects a rejected input-shape request and verifies mapping is not attempted afterward.

## Validation

Validated exact source SHA `30752e64fa8b64bca10c27d2282e26c81747af9a`:

- `cargo fmt --all -- --check`
- `cargo test -p platform-linux --no-run --locked` on macOS (compile smoke only; Linux-gated code is covered by CI)
- [Exact Linux workflow run 30963663868](https://github.com/trycua/cua/actions/runs/30963663868): green; the focused Xvfb regression passed 1/1, alongside the full Linux unit suite, real-input regression, and portal compile check.
- [Exact Nix workflow run 30963664964](https://github.com/trycua/cua/actions/runs/30963664964): green; driver package, Rust unit tests, compositor, YAML policy VM, and Rego policy VM all passed.
- All standard PR checks at the final head are green (with the expected skipped installer compatibility matrix).
- The temporary exact-SHA validation ref was deleted after both workflow consumers completed and its remote absence was verified.

This PR remains draft pending final maintainer review.