### PR TITLE
fix(linux): bound Tk `send` so the tk background-GUI test can't hang

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/input/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/input/mod.rs
@@ -368,9 +368,28 @@ pub fn inject_tk_send(text: &str) -> Result<bool> {
     // We target "cua-tk-target" (the name the test app registers with) and
     // insert at the entry widget's current cursor position.
     let tcl_text = text.replace("\\", "\\\\").replace("{", "\\{").replace("}", "\\}");
+
+    // Tk's `send` is synchronous: it blocks the sender until the *target's* Tcl
+    // event loop services the request and replies. If the target is wedged, or
+    // the X server refuses `send` (SECURITY ext / xauth mismatch), it can block
+    // forever. Guard against that two ways:
+    //   1. A Tcl-level `after` timer that force-exits wish if the send hasn't
+    //      completed in time. We issue the write with `send -async` so the local
+    //      event loop stays live to fire the timer, then `vwait` on a flag.
+    //   2. A Rust-level wall-clock kill below, so even a totally wedged wish
+    //      (e.g. blocked before reaching the event loop) can't hang the driver.
     let tcl_script = format!(
-        r#"if {{[catch {{send cua-tk-target {{.entry insert insert {{{}}}}}}} err]}} {{
+        r#"set ::done 0
+set ::rc 0
+after 5000 {{ set ::rc 2; set ::done 1 }}
+if {{[catch {{send -async cua-tk-target {{.entry insert insert {{{}}}}}}} err]}} {{
     puts stderr "tk send failed: $err"
+    exit 1
+}}
+after 500 {{ set ::done 1 }}
+vwait ::done
+if {{$::rc == 2}} {{
+    puts stderr "tk send timed out"
     exit 1
 }}
 exit 0"#,
@@ -389,21 +408,44 @@ exit 0"#,
         };
 
     if let Some(mut stdin) = child.stdin.take() {
-        stdin.write_all(tcl_script.as_bytes())?;
+        // Ignore write errors: if wish already exited we observe it via wait().
+        let _ = stdin.write_all(tcl_script.as_bytes());
+        // stdin drops here → EOF, so wish runs the script to completion.
     }
 
-    let output = child.wait_with_output()?;
-
-    if output.status.success() {
-        Ok(true)
-    } else {
-        // If send fails (e.g., target not registered), treat as "not a Tk app"
-        // and let the caller fall back to XSendEvent.
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        if stderr.contains("application named") || stderr.contains("no registered") {
-            Ok(false)
-        } else {
-            anyhow::bail!("wish send failed: {}", stderr)
+    // Wall-clock backstop: poll for exit and hard-kill if wish overruns the
+    // deadline. Guarantees the driver task can never hang on a blocked Tk send,
+    // regardless of whether the Tcl-level timer fired.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    loop {
+        match child.try_wait()? {
+            Some(status) => {
+                let mut stderr = String::new();
+                if let Some(mut err) = child.stderr.take() {
+                    use std::io::Read;
+                    let _ = err.read_to_string(&mut stderr);
+                }
+                if status.success() {
+                    return Ok(true);
+                }
+                // Target not registered or send timed out → not a usable Tk
+                // target; let the caller fall back to XSendEvent.
+                if stderr.contains("application named")
+                    || stderr.contains("no registered")
+                    || stderr.contains("timed out")
+                {
+                    return Ok(false);
+                }
+                anyhow::bail!("wish send failed: {}", stderr);
+            }
+            None => {
+                if std::time::Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Ok(false);
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
         }
     }
 }

--- a/nix/cua-driver/tests/linux-background-gui.nix
+++ b/nix/cua-driver/tests/linux-background-gui.nix
@@ -432,17 +432,40 @@ let
   # Tk-specific override (using Tk's `send` command) writes into the background
   # window while the control terminal keeps focus. Tk has no AT-SPI bridge, so
   # this is the approved override path for focus-free Tk input.
+  # Readback script: read the entry value back over Tk `send`. `send` is
+  # synchronous and blocks the sender until the target's Tcl event loop replies;
+  # if the target is wedged or the X server refuses `send` (SECURITY ext / xauth
+  # mismatch) it would otherwise hang forever. Guard it with a Tcl `after` timer
+  # that prints a marker and force-exits, so wish always terminates promptly —
+  # and the invocation is additionally wrapped in `timeout` below as a backstop.
   tkGetScript = pkgs.writeText "tk-get-value.tcl" ''
-    puts [send cua-tk-target {.entry get}]
+    set ::rc 1
+    after 20000 {
+        puts "TK_SEND_READBACK_TIMEOUT"
+        flush stdout
+        exit 1
+    }
+    if {[catch {send cua-tk-target {.entry get}} val]} {
+        puts "TK_SEND_READBACK_ERROR: $val"
+        flush stdout
+        exit 1
+    }
+    puts $val
+    flush stdout
+    exit 0
   '';
   tkSubtest = lib.optionalString (selected.tksend or false) ''
     with subtest("Tk send focus-free write into the background window (Tk override)"):
         # The driver already typed via inject_tk_send in the main test. Now read
         # the entry widget's value back via Tk send to prove the write landed.
+        # `timeout` is a hard backstop on top of the Tcl `after` timer in the
+        # script: even if wish wedges before reaching its event loop, the step
+        # fails fast (within ~30s) with diagnostics instead of hanging 15 min.
         machine.copy_from_host("${tkGetScript}", "/tmp/tk-get-value.tcl")
-        tk_readback = machine.succeed("${a11yEnv} ${pkgs.tk}/bin/wish /tmp/tk-get-value.tcl 2>&1").strip()
-        machine.log("Tk send readback: " + repr(tk_readback))
-        assert "${typed}" in tk_readback, f"Expected '${typed}' in Tk entry, got: {tk_readback}"
+        status, tk_readback = machine.execute("${a11yEnv} timeout 30 ${pkgs.tk}/bin/wish /tmp/tk-get-value.tcl 2>&1")
+        tk_readback = tk_readback.strip()
+        machine.log("Tk send readback (exit=" + str(status) + "): " + repr(tk_readback))
+        assert "${typed}" in tk_readback, f"Expected '${typed}' in Tk entry, got (exit={status}): {tk_readback}"
         # The override must remain focus-free: control terminal still active.
         tk_control = machine.succeed("head -1 /tmp/control-xid.txt").strip()
         tk_active = machine.succeed("DISPLAY=:99 xdotool getactivewindow").strip()


### PR DESCRIPTION
## Problem

The **Linux background GUI test (tk)** Nix integration job (CI run 26915346957) hangs and the GitHub job times out after 15 minutes. Everything up to and including the AT-SPI read passes; the job then wedges in:

```
subtest: Tk send focus-free write into the background window (Tk override)
```

## Root cause

Tk has no AT-SPI bridge, so focus-free writes into a Tk app use Tk's `send` command (X11 IPC). `send` is **synchronous**: it blocks the sender until the target's Tcl event loop services the request and replies, and the X server must permit it. In the headless openbox/Xvfb session this can block indefinitely, and there was **no timeout on either side**:

1. The driver's `inject_tk_send` spawned `wish` and called `child.wait_with_output()` with no timeout — a blocked `send` wedged the driver's `spawn_blocking` task forever.
2. The test's readback step ran `wish /tmp/tk-get-value.tcl` with **no `timeout`** (`machine.succeed(...)`), so a blocking synchronous `send` hung the entire NixOS test until the 15‑minute job cap.

## Fix

**Driver (`libs/cua-driver/rust/crates/platform-linux/src/input/mod.rs`)**
- Issue the write with `send -async` so the sender's local event loop stays live, guarded by a Tcl `after` timer that force-exits if the send stalls.
- Add a Rust wall-clock backstop: poll `try_wait()` and hard-kill `wish` after 15s, returning `Ok(false)` to fall back to XSendEvent. The driver task can no longer hang regardless of Tk/X server behaviour.
- Treat a "timed out" / "no application named" / "no registered" stderr as not-a-usable-Tk-target (fall back), keeping unexpected failures as hard errors.

**Test (`nix/cua-driver/tests/linux-background-gui.nix`)**
- Wrap the readback `wish` in `timeout 30` (the hard backstop — a synchronous `send` blocks the Tcl event loop so an in-script `after` timer alone can't fire during a stuck send).
- Make the readback Tcl self-terminating: `catch` the `send`, emit `TK_SEND_READBACK_ERROR`/`TK_SEND_READBACK_TIMEOUT` markers, and `exit`.
- Switch the readback to `machine.execute` and surface the exit code in the assertion so a failure reports diagnostics instead of hanging.

Net effect: the subtest **passes when the Tk write lands**, and otherwise **fails fast (~30s) with clear diagnostics** instead of hanging 15 minutes.

## Validation

- `nix-instantiate --parse nix/cua-driver/tests/linux-background-gui.nix` — OK.
- `cargo check -p platform-linux --target x86_64-unknown-linux-gnu` (cross from macOS, the crate is `#[cfg(target_os = "linux")]`-gated) — **builds clean**; only pre-existing unused-import warnings, none from this change.
- Could not run the full NixOS `tk` test locally (Linux VM test, runs in CI). CI exercises the real tk nixos test on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)