### PR TITLE
fix(platform-linux): stop Qt5 AT-SPI segfault in background GUI test

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/atspi/native.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/atspi/native.rs
@@ -90,6 +90,22 @@ fn is_document_role(role: &str) -> bool {
 /// Build an `AccessibleProxy` for an arbitrary (bus name, path) in the tree.
 /// Uses owned `String`s for destination/path so the resulting `BusName`/
 /// `ObjectPath` are `'static` and the proxy borrows only the connection.
+///
+/// `cache_properties(No)` is load-bearing, not just an optimization: with the
+/// zbus default (`Lazily`) the first property read on the proxy — our
+/// `acc.name()` during the walk — makes zbus issue
+/// `org.freedesktop.DBus.Properties.GetAll` (one argument: the interface name)
+/// to warm the cache. Qt5's AT-SPI bridge (`AtSpiAdaptor::handleMessage`)
+/// assumes every Properties call is `Get`/`Set` and unconditionally reads
+/// `message.arguments().at(1)`; for a one-argument `GetAll` that index is out
+/// of range, so the following `QVariant::toString()` dereferences garbage and
+/// the Qt5 app *segfaults* (observed crash: `libQt5Core` via
+/// `AtSpiAdaptor::handleMessage`). Qt6's bridge handles `GetAll`, which is why
+/// only Qt5 crashed. Forcing `No` makes zbus issue per-property `Get` calls
+/// (two arguments) instead, which Qt5 handles correctly — so the Qt5 window can
+/// be walked and written without killing the app. Other toolkits are
+/// unaffected (they already tolerate `GetAll`), and the sub-interface proxies
+/// from `proxies()` already use `CacheProperties::No`.
 async fn accessible_for<'a>(
     conn: &'a atspi::zbus::Connection,
     oref: &atspi::ObjectRefOwned,
@@ -100,6 +116,7 @@ async fn accessible_for<'a>(
         .to_owned();
     let path = oref.path_as_str().to_owned();
     AccessibleProxy::builder(conn)
+        .cache_properties(atspi::zbus::proxy::CacheProperties::No)
         .destination(dest)
         .map_err(|e| anyhow!("bad a11y destination: {e}"))?
         .path(path)


### PR DESCRIPTION
## Problem

The **Linux background GUI test (qt)** Nix integration job (CI run 26915346957) failed at the *"Input landed: driver's native AT-SPI reads the window back"* subtest. When `cua-driver` performed its focus-free AT-SPI walk/write into the background PyQt5 (Qt5) `QLineEdit` window, the **Qt5 app segfaulted**:

```
python3.13[1491]: segfault ... in libQt5Core.so.5.15.18
Stack trace:
  #0 QVariant::toString()
  #1 AtSpiAdaptor::handleMessage(QDBusMessage, QDBusConnection)   (libQt5XcbQpa)
  #2 QDBusConnectionPrivate::activateObject(...)
```

so the typed text never landed and the assertion failed. `qt6` passed; only Qt5 crashed.

## Root cause

Our top-level `AccessibleProxy` in `accessible_for` (the proxy built for every node during the AT-SPI tree walk) was created with the zbus **default** `CacheProperties::Lazily`. With `Lazily`, the first property read on the proxy — our `acc.name()` during the walk — makes zbus issue `org.freedesktop.DBus.Properties.GetAll`, which has a **single** argument (the interface name).

Qt5's AT-SPI bridge, `AtSpiAdaptor::handleMessage`, assumes every `org.freedesktop.DBus.Properties` message is a `Get`/`Set` and unconditionally reads `message.arguments().at(1)` to derive the member name. For a one-argument `GetAll` that index is **out of range**, so the following `QVariant::toString()` dereferences garbage → `SIGSEGV` inside the Qt5 process. Qt6's bridge handles `GetAll`, which is exactly why only Qt5 crashed.

The CI debug log corroborates this: the crash happens *during the walk* (the driver logs `walked pid 1491: 1 node(s)` / `0 editable`, then sees the Qt app disconnect with `Failed to populate properties cache via GetAll ... NoReply`), i.e. before any `insert_text` write — the "synthetic-focus write crashes the app" framing was a symptom; the trigger was the property-cache `GetAll`.

## Fix

Build the `AccessibleProxy` with `CacheProperties::No`. zbus then issues per-property `Get` calls (two arguments: interface + property name), which Qt5's `handleMessage` reads correctly. The Qt5 window can be walked and written without killing the app.

This aligns the top-level Accessible proxy with the sub-interface proxies from `proxies()` (Action/Value/Text/EditableText/Component/Application), which already use `CacheProperties::No`. Other toolkits (Qt6, GTK3/4, Chromium, Electron, Tk) already tolerate `GetAll`, so there is no behavior change for them; this is a one-line, additive change behind a clear comment.

```rust
AccessibleProxy::builder(conn)
    .cache_properties(atspi::zbus::proxy::CacheProperties::No)   // <-- added
    .destination(dest)?
    .path(path)?
    .build().await
```

## Validation

- `cargo check -p platform-linux --target x86_64-unknown-linux-gnu` — **passes** (only pre-existing unrelated warnings). This is the crate containing the fix, and it is `cfg(target_os = "linux")`-gated, so it cannot build on the macOS host without the cross target.
- `cargo check -p cua-driver --target x86_64-unknown-linux-gnu` could **not** complete locally: it pulls in a C dependency whose build needs an `x86_64-linux-gnu-gcc` cross-linker that isn't installed on this macOS dev box (`cc-rs: failed to find tool "x86_64-linux-gnu-gcc"`). Unrelated to this change.
- The authoritative check is the real `qt` (and `qt6`/`chromium`/`electron`/`gtk`/`tk`) NixOS integration tests in CI, which exercise the actual Qt5 AT-SPI bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)