### PR TITLE
fix(platform-linux): land GTK4 focus-free write via generic AT-SPI path

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/atspi/native.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/atspi/native.rs
@@ -355,6 +355,80 @@ pub fn walk_tree(pid: u32) -> Result<Option<(String, Vec<AtspiNode>)>> {
     })
 }
 
+/// Pick the editable node to write into, by priority:
+///   1. the focused editable (if the toolkit exposes focus),
+///   2. an editable inside web/document content — for a browser this is the
+///      page's field, not the address bar (which sorts first in the tree but is
+///      chrome),
+///   3. the first editable anywhere (covers single-field apps like a GTK dialog
+///      entry, or a GTK4 GtkEntry).
+fn pick_editable<'v, 'a>(visited: &'v [Visited<'a>]) -> Option<&'v Visited<'a>> {
+    visited
+        .iter()
+        .find(|v| v.has_editable && v.focused)
+        .or_else(|| visited.iter().find(|v| v.has_editable && v.in_web_doc))
+        .or_else(|| visited.iter().find(|v| v.has_editable))
+}
+
+/// Try to write `text` into the best editable node in `visited` via AT-SPI
+/// EditableText (GrabFocus first so the toolkit exposes the field on an
+/// unfocused window's focused widget). Returns `Ok(true)` if the write landed,
+/// `Ok(false)` if no editable was found / the EditableText write was rejected.
+async fn write_into_editable(visited: &[Visited<'_>], text: &str) -> Result<bool> {
+    let target = match pick_editable(visited) {
+        Some(t) => t,
+        None => return Ok(false),
+    };
+    dlog!(
+        "insert target: role={:?} in_web_doc={} focused={} has_component={}",
+        target.role, target.in_web_doc, target.focused, target.has_component
+    );
+
+    let proxies = target
+        .acc
+        .proxies()
+        .await
+        .map_err(|e| anyhow!("interface proxies unavailable: {e}"))?;
+
+    // Try to grab focus on the widget via AT-SPI Component.GrabFocus.
+    // This should give the widget internal keyboard focus without activating
+    // the window, allowing GTK4 (and similar toolkits) to expose EditableText
+    // on an unfocused window's focused widget.
+    if target.has_component {
+        if let Ok(comp) = proxies.component().await {
+            match call(comp.grab_focus()).await {
+                Some(Ok(true)) => dlog!("GrabFocus succeeded on {:?}", target.role),
+                Some(Ok(false)) => dlog!("GrabFocus returned false on {:?}", target.role),
+                Some(Err(e)) => dlog!("GrabFocus failed on {:?}: {}", target.role, e),
+                None => dlog!("GrabFocus timed out on {:?}", target.role),
+            }
+        } else {
+            dlog!("Component interface unavailable despite has_component=true");
+        }
+    } else {
+        dlog!("Target has no Component interface, skipping GrabFocus");
+    }
+
+    let et = proxies
+        .editable_text()
+        .await
+        .map_err(|e| anyhow!("EditableText unavailable: {e}"))?;
+
+    let off = match proxies.text().await {
+        Ok(tp) => tp.caret_offset().await.unwrap_or(0),
+        Err(_) => 0,
+    };
+    let len = text.chars().count() as i32;
+
+    if et.insert_text(off, text, len).await.unwrap_or(false) {
+        return Ok(true);
+    }
+    if et.set_text_contents(text).await.unwrap_or(false) {
+        return Ok(true);
+    }
+    Ok(false)
+}
+
 pub fn insert_text(pid: u32, text: &str) -> Result<bool> {
     runtime().block_on(async {
         let conn = AccessibilityConnection::new()
@@ -372,68 +446,53 @@ pub fn insert_text(pid: u32, text: &str) -> Result<bool> {
             visited.iter().filter(|v| v.role.contains("entry") || v.role.contains("text")).count(),
         );
 
-        // Target priority:
-        //   1. the focused editable (if the toolkit exposes focus),
-        //   2. an editable inside web/document content — for a browser this is
-        //      the page's field, not the address bar (which sorts first in the
-        //      tree but is chrome),
-        //   3. the first editable anywhere (covers single-field apps like a
-        //      GTK dialog entry).
-        let target = visited
-            .iter()
-            .find(|v| v.has_editable && v.focused)
-            .or_else(|| visited.iter().find(|v| v.has_editable && v.in_web_doc))
-            .or_else(|| visited.iter().find(|v| v.has_editable));
-        let target = match target {
-            Some(t) => t,
-            None => return Ok(false),
-        };
-        dlog!(
-            "insert target: role={:?} in_web_doc={} focused={} has_component={}",
-            target.role, target.in_web_doc, target.focused, target.has_component
-        );
+        // Primary attempt: write into an editable exposed by the current tree.
+        if write_into_editable(&visited, text).await? {
+            return Ok(true);
+        }
 
-        let proxies = target
-            .acc
-            .proxies()
-            .await
-            .map_err(|e| anyhow!("interface proxies unavailable: {e}"))?;
+        // Expose-via-synthetic-focus fallback (generic across toolkits).
+        //
+        // Some toolkits only populate/expose the focused-widget subtree over
+        // AT-SPI once the *window* receives input focus. In a headless session
+        // with a background window that never happens, so the walk above sees
+        // only the top window node and `pick_editable` finds nothing (or finds
+        // an editable that still rejects EditableText). This was first needed
+        // for Qt5; GTK4 exhibits the same gate when its AT-SPI backend is active
+        // but the window is unfocused.
+        //
+        // Send a synthetic FocusIn to the window (XSendEvent — this does NOT move
+        // the X11 active window, so the no-focus-steal contract is preserved),
+        // give the toolkit a moment to (re)build its accessible subtree, re-walk,
+        // and retry the EditableText write. Always send FocusOut afterwards to
+        // restore state, regardless of whether the write landed.
+        if pick_editable(&visited).is_none() {
+            if let Some(xid) = entry_find_window_xid(pid).await {
+                dlog!("no editable exposed; trying synthetic-focus expose on xid {xid}");
+                let _ = crate::input::send_focus_in(xid);
+                // Let the toolkit react to the focus event and rebuild its tree.
+                tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
 
-        // Try to grab focus on the widget via AT-SPI Component.GrabFocus.
-        // This should give the widget internal keyboard focus without activating
-        // the window, allowing GTK4 (and similar toolkits) to expose EditableText
-        // on an unfocused window's focused widget.
-        if target.has_component {
-            if let Ok(comp) = proxies.component().await {
-                match call(comp.grab_focus()).await {
-                    Some(Ok(true)) => dlog!("GrabFocus succeeded on {:?}", target.role),
-                    Some(Ok(false)) => dlog!("GrabFocus returned false on {:?}", target.role),
-                    Some(Err(e)) => dlog!("GrabFocus failed on {:?}: {}", target.role, e),
-                    None => dlog!("GrabFocus timed out on {:?}", target.role),
+                let rewalked = collect_visited(&conn, pid).await?;
+                let landed = if let Some(ref rv) = rewalked {
+                    dlog!(
+                        "post-focus re-walk: {} node(s), {} editable",
+                        rv.len(),
+                        rv.iter().filter(|v| v.has_editable).count(),
+                    );
+                    write_into_editable(rv, text).await?
+                } else {
+                    false
+                };
+
+                let _ = crate::input::send_focus_out(xid);
+                if landed {
+                    dlog!("synthetic-focus expose: EditableText write landed");
+                    return Ok(true);
                 }
             } else {
-                dlog!("Component interface unavailable despite has_component=true");
+                dlog!("no editable exposed and no window XID found for synthetic-focus expose");
             }
-        } else {
-            dlog!("Target has no Component interface, skipping GrabFocus");
-        }
-
-        let et = proxies
-            .editable_text()
-            .await
-            .map_err(|e| anyhow!("EditableText unavailable: {e}"))?;
-
-        let off = match proxies.text().await {
-            Ok(tp) => tp.caret_offset().await.unwrap_or(0),
-            Err(_) => 0,
-        };
-        let len = text.chars().count() as i32;
-
-        if et.insert_text(off, text, len).await.unwrap_or(false) {
-            return Ok(true);
-        }
-        if et.set_text_contents(text).await.unwrap_or(false) {
-            return Ok(true);
         }
 
         // GTK3 fallback: the toolkit exposes entry/text nodes in the tree (so

--- a/nix/cua-driver/tests/linux-background-gui.nix
+++ b/nix/cua-driver/tests/linux-background-gui.nix
@@ -320,7 +320,19 @@ let
     gtk = {
       packages = [ pkgs.zenity ];
       memoryMB = 2048;
-      # zenity is a GTK app exposing AT-SPI; --entry gives a focused GtkEntry.
+      # zenity is a GTK3 app; --entry gives a focused GtkEntry. GTK3 (unlike
+      # GTK4, which speaks AT-SPI directly) only joins the AT-SPI bus by dlopening
+      # libatk-bridge-2.0.so, and atk-bridge only registers the app's accessible
+      # tree at startup when the a11y bus reports org.a11y.Status IsEnabled=true.
+      # In this hand-rolled headless session that handshake is racy: the bridge
+      # reads IsEnabled once at process start, before our `dbus-send ... Set
+      # IsEnabled true` reliably lands, so zenity frequently never registers and
+      # the driver's tree walk finds zero nodes for its pid. Because that
+      # registration is not reliably achievable here, gtk (zenity/GTK3) stays
+      # READ-ONLY in the assertions below (no typed-text assert). It is NOT
+      # fundamentally impossible — with a guaranteed IsEnabled-before-launch
+      # ordering GTK3 would expose its tree — but it was not reliably reproducible
+      # in this CI session, so we do not assert a write for it.
       launch = pkgs.writeShellScript "cua-launch-gtk.sh" ''
         exec ${pkgs.zenity}/bin/zenity --entry --title=cua-initial --text=cua --width=400
       '';
@@ -363,6 +375,14 @@ let
       launch = pkgs.writeShellScript "cua-launch-gtk4.sh" ''
         export GDK_BACKEND=x11
         export GSK_RENDERER=cairo
+        # GTK4 talks AT-SPI directly (not via atk-bridge), but it only builds and
+        # exports its accessible tree when it selects the AT-SPI accessibility
+        # backend at startup. In this hand-rolled headless session GTK4's
+        # auto-detection can pick the "none" backend, leaving the a11y tree empty
+        # (only the top window node is exposed, no GtkEntry child) — which is why
+        # focus-free writes had nothing editable to target. GTK_A11Y=atspi forces
+        # the AT-SPI backend on so the GtkEntry is exposed with EditableText.
+        export GTK_A11Y=atspi
         exec ${gtk4App}/bin/cua-gtk4
       '';
     };
@@ -668,11 +688,16 @@ pkgs.testers.nixosTest {
             "driver get_text did not return an accessibility node for the background app:\n"
             + result
         )
-        # For Qt apps, assert the typed text actually landed (now supported via
-        # synthetic-focus workaround for Qt5, and natively for Qt6).
-        if "${app}" in ["qt", "qt6"]:
+        # For Qt and GTK4 apps, assert the typed text actually landed.
+        #   - Qt5: synthetic-focus workaround exposes the widget tree.
+        #   - Qt6: exposes the editable natively over AT-SPI.
+        #   - GTK4: launched with GTK_A11Y=atspi so it exports its accessible tree
+        #     (GtkEntry with EditableText) over AT-SPI; the driver's generic
+        #     EditableText+GrabFocus path writes into it, with a synthetic-focus
+        #     re-walk fallback in atspi::insert_text for the unfocused-window gate.
+        if "${app}" in ["qt", "qt6", "gtk4"]:
             assert "${typed}" in result, (
-                "Qt app should support focus-free write, but typed text not found in readback:\n"
+                "${app} app should support focus-free write, but typed text not found in readback:\n"
                 + result
             )
 


### PR DESCRIPTION
## Summary

The "Linux background GUI test (gtk4)" job passed today only because it did **not** assert a write. In CI run 26915346957 the gtk4 `get_text` readback returned only `window "cua-initial"` (no child entry), and the focused-diagnostic logged `focused readback contains typed text: False`.

The generic AT-SPI focus-free write path **already existed and already targeted GTK4**: `atspi::native::insert_text` walks the tree, picks an editable, calls `Component.GrabFocus` (so a toolkit exposes `EditableText` on an unfocused window's focused widget), then `EditableText.insert_text` / `set_text_contents`. The real gap was **GTK4 tree exposure headless**: the GTK4 app exposed only its top window node over AT-SPI, so the walk found zero editable nodes and there was nothing to write into.

## Fix (two complementary changes, both through the generic path)

**App / launch (`nix/cua-driver/tests/linux-background-gui.nix`):** GTK4 talks AT-SPI directly (not via atk-bridge) but only builds/exports its accessible tree when it selects the AT-SPI accessibility backend at startup. In this hand-rolled headless session GTK4's auto-detection picks the `none` backend, leaving the a11y tree empty. Force it on with `GTK_A11Y=atspi` so the GtkEntry is exposed with `EditableText`.

**Driver (`platform-linux/src/atspi/native.rs`):** Generalize the Qt5 synthetic-focus workaround into a toolkit-agnostic **expose-via-synthetic-focus** fallback *inside* `insert_text`. When the tree walk finds no editable, send a synthetic `FocusIn` (XSendEvent — does **not** move the X11 active window, so the no-focus-steal contract holds), let the toolkit rebuild its subtree, re-walk, and retry the `EditableText` write, then always `FocusOut`. The editable-pick + GrabFocus + write logic is factored into `pick_editable` / `write_into_editable` so the primary and re-walk attempts share one code path. Edits are confined to `native.rs` (plus the gtk4 app/launch) to avoid conflicts with the concurrent Qt5 edit in `impl_.rs`.

**Test assertion:** Extended the "Input landed" typed-text assertion to include `gtk4` (was `qt`/`qt6` only), with a comment explaining the path. `gtk` (zenity/GTK3) stays **read-only** with a precise comment: GTK3 joins the bus via `libatk-bridge`, which reads `org.a11y.Status IsEnabled` once at startup; that handshake is racy in this session so registration is not reliably achievable here — not fundamentally impossible, just not reproducible in CI without a guaranteed IsEnabled-before-launch ordering.

## Validation

- `cargo check -p platform-linux --target x86_64-unknown-linux-gnu` passes — clean, no new warnings (the only `native.rs` warning is a pre-existing unused import unrelated to this change).
- `nix-instantiate --parse nix/cua-driver/tests/linux-background-gui.nix` passes.
- `platform-linux` is `cfg(target_os="linux")`-gated and cannot be built/run on the macOS dev host. The real gtk4 nixos test runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)