### PR TITLE
chore(deps-dev): bump Electron harness to 39.8.5

### DIFF
--- a/libs/cua-driver/test-harness/apps/cross-platform/electron/package.json
+++ b/libs/cua-driver/test-harness/apps/cross-platform/electron/package.json
@@ -9,7 +9,7 @@
     "build": "electron-builder --win portable --x64"
   },
   "devDependencies": {
-    "electron": "31.6.0",
+    "electron": "39.8.5",
     "electron-builder": "25.0.5"
   },
   "build": {


### PR DESCRIPTION
Replaces stale Dependabot PR #1728 from current main.

Why:
- The old PR failed CI with swift test reporting no tests found, caused by stale branch history.
- Current main has libs/cua-driver/swift/Tests, and the recreated one-line package bump passes swift test locally.

Validation:
- npm view electron@39.8.5 version
- swift test in libs/cua-driver/swift: passed, 36 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency versions for the test harness infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->