### PR TITLE
fix(computer-server): launch apps without shell

### DIFF
--- a/libs/python/computer-server/computer_server/handlers/generic.py
+++ b/libs/python/computer-server/computer_server/handlers/generic.py
@@ -10,6 +10,7 @@ Includes:
 import base64
 import os
 import platform
+import shlex
 import subprocess
 import webbrowser
 from pathlib import Path
@@ -22,6 +23,23 @@ try:
     import pywinctl as pwc
 except Exception:  # pragma: no cover
     pwc = None  # type: ignore
+
+
+def build_launch_argv(app: str, args: Optional[list[str]] = None) -> list[str]:
+    if args is not None:
+        return [app, *args]
+    argv = shlex.split(app, posix=(os.name != "nt"))
+    if os.name == "nt":
+        argv = [_strip_wrapping_quotes(arg) for arg in argv]
+    if not argv:
+        raise ValueError("app must not be empty")
+    return argv
+
+
+def _strip_wrapping_quotes(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        return value[1:-1]
+    return value
 
 
 def resolve_path(path: str) -> Path:
@@ -108,11 +126,7 @@ class GenericWindowHandler(BaseWindowHandler):
 
     async def launch(self, app: str, args: Optional[list[str]] = None) -> Dict[str, Any]:
         try:
-            if args:
-                proc = subprocess.Popen([app, *args])
-            else:
-                # allow shell command like "libreoffice --writer"
-                proc = subprocess.Popen(app, shell=True)
+            proc = subprocess.Popen(build_launch_argv(app, args))
             return {"success": True, "pid": proc.pid}
         except Exception as e:
             return {"success": False, "error": str(e)}

--- a/libs/python/computer-server/tests/test_window_launch.py
+++ b/libs/python/computer-server/tests/test_window_launch.py
@@ -1,0 +1,63 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+try:
+    import computer_server  # noqa: F401
+    from computer_server.handlers.generic import GenericWindowHandler, build_launch_argv
+except Exception as import_error:  # pragma: no cover - environment-dependent
+    pytest.skip(
+        f"computer_server.handlers.generic unavailable in this environment: {import_error}",
+        allow_module_level=True,
+    )
+
+
+def test_build_launch_argv_splits_compatible_command_string():
+    assert build_launch_argv("libreoffice --writer") == ["libreoffice", "--writer"]
+
+
+def test_build_launch_argv_keeps_shell_metacharacters_literal():
+    assert build_launch_argv("echo hello; touch /tmp/pwned") == [
+        "echo",
+        "hello;",
+        "touch",
+        "/tmp/pwned",
+    ]
+
+
+def test_build_launch_argv_uses_explicit_args_literally():
+    assert build_launch_argv("echo", ["hello; touch /tmp/pwned"]) == [
+        "echo",
+        "hello; touch /tmp/pwned",
+    ]
+
+
+def test_build_launch_argv_preserves_windows_paths(monkeypatch):
+    monkeypatch.setattr(build_launch_argv.__globals__["os"], "name", "nt")
+
+    assert build_launch_argv('"C:\\Program Files\\App\\app.exe" --flag') == [
+        "C:\\Program Files\\App\\app.exe",
+        "--flag",
+    ]
+    assert build_launch_argv("C:\\Tools\\app.exe --flag") == [
+        "C:\\Tools\\app.exe",
+        "--flag",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_launch_uses_argv_without_shell():
+    proc = Mock(pid=1234)
+    with patch("computer_server.handlers.generic.subprocess.Popen", return_value=proc) as popen:
+        result = await GenericWindowHandler().launch("echo hello; touch /tmp/pwned")
+
+    assert result == {"success": True, "pid": 1234}
+    popen.assert_called_once_with(["echo", "hello;", "touch", "/tmp/pwned"])
+
+
+@pytest.mark.asyncio
+async def test_launch_rejects_empty_app():
+    result = await GenericWindowHandler().launch("")
+
+    assert result["success"] is False
+    assert "app must not be empty" in result["error"]


### PR DESCRIPTION
Splits the computer-server half out of #1568.

Security:
- Avoids shell=True command interpretation for GenericWindowHandler.launch.
- Keeps shell metacharacters literal in argv.

Validation:
- pytest libs/python/computer-server/tests/test_window_launch.py: 6 passed, then local Python exited 139; the same teardown issue was observed on clean main.
- Live computer_server /cmd launch marker test: injected touch marker was not created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved app launching with safer, cross-platform command parsing for Windows and POSIX environments
  * Enhanced handling of Windows paths during application launch

* **Tests**
  * Added comprehensive test coverage for app launching functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->