### PR TITLE
fix(computer-server): default to localhost binding

### DIFF
--- a/changelog/2026-05-18.md
+++ b/changelog/2026-05-18.md
@@ -1,0 +1,5 @@
+### Highlights
+
+- **Computer server bind default** — `computer_server` now binds to `127.0.0.1`
+  by default. Use `--host 0.0.0.0` when the server needs to accept external
+  connections.

--- a/libs/python/computer-server/README.md
+++ b/libs/python/computer-server/README.md
@@ -32,9 +32,15 @@ python -m computer_server
 # Or with custom port
 python -m computer_server --port 8080
 
+# Allow external access explicitly
+python -m computer_server --host 0.0.0.0
+
 # With resolution scaling (useful for Retina displays or VMs)
 python -m computer_server --width 1512 --height 982
 ```
+
+By default the server binds to `127.0.0.1`. Deployments that need access from
+other hosts should pass `--host 0.0.0.0` or another explicit interface.
 
 This provides:
 

--- a/libs/python/computer-server/computer_server/cli.py
+++ b/libs/python/computer-server/computer_server/cli.py
@@ -30,7 +30,9 @@ def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
         help="Auto-detect and log the actual screen resolution at startup",
     )
     parser.add_argument(
-        "--host", default="0.0.0.0", help="Host to bind the server to (default: 0.0.0.0)"
+        "--host",
+        default="127.0.0.1",
+        help="Host to bind the server to (default: 127.0.0.1; use 0.0.0.0 for external access)",
     )
     parser.add_argument(
         "--port", type=int, default=8000, help="Port to bind the server to (default: 8000)"

--- a/libs/python/computer-server/computer_server/server.py
+++ b/libs/python/computer-server/computer_server/server.py
@@ -35,7 +35,7 @@ class Server:
 
     def __init__(
         self,
-        host: str = "0.0.0.0",
+        host: str = "127.0.0.1",
         port: int = 8000,
         log_level: str = "info",
         ssl_keyfile: Optional[str] = None,
@@ -45,7 +45,8 @@ class Server:
         Initialize the server.
 
         Args:
-            host: Host to bind the server to
+            host: Host to bind the server to. Defaults to localhost; pass
+                "0.0.0.0" explicitly for external access.
             port: Port to bind the server to
             log_level: Logging level (debug, info, warning, error, critical)
             ssl_keyfile: Path to SSL private key file (for HTTPS)


### PR DESCRIPTION
Recreates #1571 from current main.

Security:
- Defaults computer-server host binding to 127.0.0.1.
- Preserves explicit --host 0.0.0.0 opt-in.

Validation:
- parse_args([]).host == 127.0.0.1
- Server().host == 127.0.0.1
- parse_args([--host, 0.0.0.0]).host == 0.0.0.0
- Live server without --host listened on TCP 127.0.0.1 only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Server now binds to localhost by default instead of all network interfaces, improving default security posture.
  * External connections now require explicitly passing the `--host` configuration flag.

* **Documentation**
  * Updated documentation with instructions for configuring external access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->