### PR TITLE
docs(platform-windows): provenance note

### DIFF
--- a/libs/cua-driver/rust/crates/platform-windows/src/lib.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/lib.rs
@@ -7,7 +7,14 @@
 //! - Win32 EnumWindows / CreateToolhelp32Snapshot for enumeration
 //! - PrintWindow / GDI BitBlt for screenshots
 //!
-//! Reference: /tmp/trope-cua/src/CuaDriver.Win/
+//! ## Provenance
+//!
+//! The Windows accessibility-tree walk, app/window enumeration, UIA
+//! InvokePattern click, and ValuePattern set-value all derive from prior art in
+//! Interface-Agent (github.com/francedot/Interface-Agent, packages/windows, 2024).
+//! trope-cua (MIT, github.com/voctory/trope-cua) was a useful cross-reference for
+//! some of the details during this Rust implementation — thanks to Victor Vannara
+//! for that work.
 
 use cua_driver_core::tool::ToolRegistry;
 


### PR DESCRIPTION
## What

Replace the `Reference: /tmp/trope-cua/src/CuaDriver.Win/` line in
platform-windows/src/lib.rs with a `## Provenance` block.

## Why

Code change credited the wrong ancestor. The Windows accessibility-tree walk,
app/window enumeration, UIA InvokePattern click, and ValuePattern set-value
trace to prior art in Interface-Agent (francedot/Interface-Agent,
packages/windows, 2024). The new note records that lineage and keeps a courtesy
nod to trope-cua (MIT) as a cross-reference for some of the details during the
Rust implementation.

## Scope

Comment-only, one file. No code or behavior change. The inline
`// mirroring trope-cua` breadcrumbs in mouse.rs, impl_.rs, and overlay.rs are
left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced internal documentation for the Windows platform module with updated provenance and attribution information.

*Note: This is an internal documentation update with no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->