### PR TITLE
feat(linux): port type_into_editable from pyatspi subprocess to native AT-SPI

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/atspi/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/atspi/mod.rs
@@ -23,7 +23,7 @@ pub struct AtspiNode {
     pub value: Option<String>,
     pub description: Option<String>,
     pub actions: Vec<String>,
-    /// For pyatspi path: element_key = element_index as u64.
+    /// For AT-SPI path: element_key = element_index as u64.
     /// For X11 fallback: element_key = xid.
     pub element_key: u64,
 }
@@ -59,61 +59,7 @@ pub fn perform_action(pid: u32, idx: usize) -> Result<String> {
 /// For Qt5, which doesn't expose widgets when unfocused, this will return Err.
 /// Returns Ok if an editable was found and text was set, Err otherwise.
 pub fn type_into_editable(pid: u32, text: &str) -> Result<()> {
-    let safe_text = text.replace('\\', "\\\\").replace('\'', "\\'");
-    let script = format!(r#"
-import pyatspi, sys
-
-def find_editable(acc, depth=0):
-    # Try to find any EditableText interface, regardless of role
-    try:
-        et = acc.queryEditableText()
-        # If we can query it, return this node
-        return acc
-    except:
-        pass
-
-    # Recursively search children
-    try:
-        for child in acc:
-            result = find_editable(child, depth + 1)
-            if result is not None:
-                return result
-    except:
-        pass
-
-    return None
-
-desktop = pyatspi.Registry.getDesktop(0)
-editable = None
-for app in desktop:
-    try:
-        if app.get_process_id() == {pid}:
-            for win in app:
-                editable = find_editable(win)
-                if editable:
-                    break
-            break
-    except:
-        pass
-
-if editable is None:
-    print("ERROR: No editable found", file=sys.stderr)
-    sys.exit(1)
-
-try:
-    et = editable.queryEditableText()
-    et.setTextContents('{safe_text}')
-    print("ok:atspi")
-except Exception as e:
-    print(f"ERROR: {{e}}", file=sys.stderr)
-    sys.exit(1)
-"#, pid = pid, safe_text = safe_text);
-
-    let out = std::process::Command::new("python3").arg("-c").arg(&script).output()?;
-    if !out.status.success() {
-        anyhow::bail!("{}", String::from_utf8_lossy(&out.stderr).trim().to_owned());
-    }
-    Ok(())
+    native::type_into_editable(pid, text)
 }
 
 /// Set the text value of element `idx` within pid's app tree via AT-SPI.

--- a/libs/cua-driver/rust/crates/platform-linux/src/atspi/native.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/atspi/native.rs
@@ -540,6 +540,43 @@ pub fn insert_text(pid: u32, text: &str) -> Result<bool> {
     })
 }
 
+/// Replace the contents of the best editable field in pid's tree with `text`
+/// via AT-SPI EditableText (setTextContents semantics, unlike [`insert_text`]
+/// which inserts at the caret). Works on unfocused windows when the toolkit
+/// exposes EditableText (Qt6, GTK4); errs when no editable is exposed (Qt5
+/// unfocused) so the caller can run its focus workaround and retry.
+pub fn type_into_editable(pid: u32, text: &str) -> Result<()> {
+    runtime().block_on(async {
+        let conn = AccessibilityConnection::new()
+            .await
+            .map_err(|e| anyhow!("AT-SPI connect failed: {e}"))?;
+        let visited = collect_visited(&conn, pid)
+            .await?
+            .ok_or_else(|| anyhow!("no AT-SPI application for pid {pid}"))?;
+        let target = pick_editable(&visited)
+            .ok_or_else(|| anyhow!("no editable element found for pid {pid}"))?;
+        dlog!(
+            "type_into_editable target: role={:?} focused={} in_web_doc={}",
+            target.role, target.focused, target.in_web_doc
+        );
+
+        let et = target
+            .acc
+            .proxies()
+            .await
+            .map_err(|e| anyhow!("interface proxies unavailable: {e}"))?
+            .editable_text()
+            .await
+            .map_err(|e| anyhow!("EditableText unavailable: {e}"))?;
+        match call(et.set_text_contents(text)).await {
+            Some(Ok(true)) => Ok(()),
+            Some(Ok(false)) => Err(anyhow!("setTextContents rejected by toolkit")),
+            Some(Err(e)) => Err(anyhow!("setTextContents failed: {e}")),
+            None => Err(anyhow!("setTextContents timed out")),
+        }
+    })
+}
+
 /// Find the window XID for a PID by listing its X11 windows.
 async fn entry_find_window_xid(pid: u32) -> Option<u64> {
     use crate::x11::list_windows;

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -520,7 +520,7 @@ impl Tool for LaunchAppTool {
 /// Resolve an AT-SPI element's center in window-local X11 coordinates.
 ///
 /// Returns `(xid, window_local_x, window_local_y)`.
-/// Looks up element bounds via pyatspi subprocess, finds the owning window
+/// Looks up element bounds via native AT-SPI, finds the owning window
 /// (via `xid_hint` or the first window for `pid`), then converts screen-absolute
 /// → window-local coords via X11 translate_coordinates.
 fn resolve_element_local_coords(pid: u32, idx: usize, xid_hint: Option<u64>)


### PR DESCRIPTION
## Summary

Follow-up to #1789. Ports the last remaining pyatspi Python-subprocess path, `atspi::type_into_editable`, to the native Rust AT-SPI implementation in `atspi::native`:

- Walks the target pid's accessibility tree over the existing `AccessibilityConnection` (no `python3 -c` subprocess, no pyatspi runtime dependency for this path)
- Picks the best editable via the shared `pick_editable` heuristic
- Calls `EditableText.set_text_contents` directly — setTextContents semantics, unlike `insert_text` which inserts at the caret

Behaviour contract is unchanged: works on unfocused windows when the toolkit exposes EditableText (Qt6, GTK4); returns `Err` when none is exposed (e.g. Qt5 unfocused) so callers can run the focus workaround and retry.

Also drops stale pyatspi references in comments (`AtspiNode::element_key`, `resolve_element_local_coords`).

## Test plan

- [ ] CI: `cua-driver-linux-background-gui-*` matrix (exercises the AT-SPI read/write paths end-to-end in NixOS VMs, incl. the `tk` full entry which types via the native AT-SPI path)
- [ ] CI: `cua-driver-linux-background-terminal-gif` / `cua-driver-linux-cursor-click-gif`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved text input handling for editable fields through internal implementation updates

* **Documentation**
  * Updated AT-SPI path naming documentation for accessibility features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->