### PR TITLE
fix(cua-driver-rs): sync .bumpversion.cfg with actual Cargo.toml version

### DIFF
--- a/libs/cua-driver/rust/.bumpversion.cfg
+++ b/libs/cua-driver/rust/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.3
+current_version = 0.5.1
 commit = True
 tag = True
 tag_name = cua-driver-rs-v{new_version}


### PR DESCRIPTION
## Summary
Fixes the version desynchronization between `.bumpversion.cfg` (0.4.3) and workspace `Cargo.toml` (0.5.1) that was causing incorrect "new version available" warnings.

## Problem
Users reported that `cua-driver` always shows update notifications even after updating. Root cause: `.bumpversion.cfg` was 2 versions behind the actual codebase version.

### How this caused the issue:
1. `.bumpversion.cfg` thinks current version is 0.4.3
2. Bump workflow creates tags like `cua-driver-rs-v0.4.4`
3. But runtime code has `CARGO_PKG_VERSION = 0.5.1` from workspace Cargo.toml
4. Version check compares local 0.5.1 against latest tag 0.4.4
5. Logic says "I'm ahead, no update" but users on actual 0.5.x see old tags

## Changes
- Updated `.bumpversion.cfg` current_version from `0.4.3` → `0.5.1` to match workspace Cargo.toml

## Verification
All crates inherit version from workspace via `version.workspace = true`, so this single change restores proper version bump behavior.

Next bump workflow run will correctly tag from 0.5.1 → 0.5.2 (or 0.6.0/1.0.0 as appropriate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version to 0.5.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->