### PR TITLE
ci(cua-driver-rs): guard release version drift

### DIFF
--- a/.github/scripts/verify-rust-cua-driver-version.sh
+++ b/.github/scripts/verify-rust-cua-driver-version.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RELEASE_VERSION="${1:?Usage: $0 <release_version> [manifest_path]}"
+MANIFEST_PATH="${2:-libs/cua-driver/rust/Cargo.toml}"
+
+MANIFEST_VERSION="$(cargo pkgid -p cua-driver --manifest-path "$MANIFEST_PATH" | awk -F'#' '{print $2}')"
+
+if [ -z "$MANIFEST_VERSION" ]; then
+  echo "::error::Unable to read crate version from $MANIFEST_PATH."
+  exit 1
+fi
+
+if [ "$RELEASE_VERSION" != "$MANIFEST_VERSION" ]; then
+  echo "::error::Release version mismatch: tag/version input '$RELEASE_VERSION' != Cargo manifest version '$MANIFEST_VERSION'."
+  echo "This prevents publishing the $MANIFEST_PATH-built binaries with stale embedded CARGO_PKG_VERSION."
+  exit 1
+fi
+
+echo "::notice::Version check passed: $RELEASE_VERSION"

--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -46,6 +46,11 @@ jobs:
             VERSION="${{ inputs.version }}"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Validate Rust crate version against release tag/input version
+        shell: bash
+        run: |
+          ./.github/scripts/verify-rust-cua-driver-version.sh "${{ steps.version.outputs.version }}"
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-unknown-linux-gnu
@@ -109,6 +114,11 @@ jobs:
             VERSION="${{ inputs.version }}"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Validate Rust crate version against release tag/input version
+        shell: bash
+        run: |
+          ./.github/scripts/verify-rust-cua-driver-version.sh "${{ steps.version.outputs.version }}"
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -195,6 +205,11 @@ jobs:
             VERSION="${{ inputs.version }}"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Validate Rust crate version against release tag/input version
+        shell: bash
+        run: |
+          ./.github/scripts/verify-rust-cua-driver-version.sh "${{ steps.version.outputs.version }}"
       - name: Import code-signing certificate
         if: env.DO_NOTARIZE == 'true'
         env:


### PR DESCRIPTION
Refs #1859

## Problem
The Rust driver release workflow can build binaries whose embedded Cargo package version does not match the release tag or manually supplied version. That lets stale `cua-driver --version` output make it into a release asset.

## Change
Add a pre-build release guard to the Linux, Windows, and macOS cua-driver-rs build jobs. The guard reads the `cua-driver` Cargo package version with `cargo pkgid` and fails closed when it differs from the release tag/input version.

## Verification
- `bash -n .github/scripts/verify-rust-cua-driver-version.sh`
- `.github/scripts/verify-rust-cua-driver-version.sh 0.5.1`
- `.github/scripts/verify-rust-cua-driver-version.sh 0.5.2` (expected mismatch failure)
- `git diff HEAD^..HEAD --check`
- committed diff sensitive-pattern scan

Local note: `actionlint` is not installed in this environment; full `cargo test -p cua-driver --no-run` previously hit a local rustc build-script hang, so validation here is focused on the release guard behavior.