### PR TITLE
feat(cli): add info diagnostic command

### DIFF
--- a/libs/python/cua-cli/cua_cli/commands/info.py
+++ b/libs/python/cua-cli/cua_cli/commands/info.py
@@ -1,0 +1,51 @@
+"""Diagnostic information command for Cua CLI."""
+
+import argparse
+import platform as sys_platform
+import sys
+
+from cua_cli import __version__
+
+
+def collect_diagnostics() -> dict[str, str]:
+    """Collect deterministic environment diagnostic fields."""
+
+    return {
+        "cua_cli_version": __version__,
+        "python_version": sys.version.split(" ")[0],
+        "platform": sys_platform.platform(),
+        "system": sys_platform.system(),
+        "release": sys_platform.release(),
+        "machine": sys_platform.machine(),
+    }
+
+
+def _print_diagnostics(diagnostics: dict[str, str]) -> None:
+    """Print collected diagnostics in a stable, testable format."""
+
+    print("Environment Diagnostics")
+    print("-" * 24)
+    print(f"cua-cli version: {diagnostics['cua_cli_version']}")
+    print(f"python version: {diagnostics['python_version']}")
+    print(f"platform: {diagnostics['platform']}")
+    print(f"system: {diagnostics['system']}")
+    print(f"release: {diagnostics['release']}")
+    print(f"machine/architecture: {diagnostics['machine']}")
+
+
+def execute(_args: argparse.Namespace) -> int:
+    """Execute the info command and print diagnostics."""
+
+    diagnostics = collect_diagnostics()
+    _print_diagnostics(diagnostics)
+    return 0
+
+
+def register_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Register the top-level `info` command."""
+
+    subparsers.add_parser(
+        "info",
+        help="Print environment diagnostics for bug reports",
+        description="Print environment diagnostics for bug reports and debugging.",
+    )

--- a/libs/python/cua-cli/cua_cli/main.py
+++ b/libs/python/cua-cli/cua_cli/main.py
@@ -6,7 +6,7 @@ import sys
 import time
 
 from cua_cli import __version__
-from cua_cli.commands import auth, do, image, mcp, platform, sandbox, skills, trajectory
+from cua_cli.commands import auth, do, image, info, mcp, platform, sandbox, skills, trajectory
 from cua_cli.commands import workspace as workspace_cmd
 from cua_cli.utils.output import print_error
 
@@ -47,6 +47,7 @@ def create_parser() -> argparse.ArgumentParser:
     sandbox.register_parser(subparsers)
     image.register_parser(subparsers)
     platform.register_parser(subparsers)
+    info.register_parser(subparsers)
     skills.register_parser(subparsers)
     mcp.register_parser(subparsers)
     do.register_parser(subparsers)
@@ -85,6 +86,8 @@ def main() -> int:
             exit_code = image.execute(args)
         elif args.command == "platform":
             exit_code = platform.execute(args)
+        elif args.command == "info":
+            exit_code = info.execute(args)
         elif args.command == "skills":
             exit_code = skills.execute(args)
         elif args.command == "serve-mcp":

--- a/libs/python/cua-cli/tests/test_main.py
+++ b/libs/python/cua-cli/tests/test_main.py
@@ -5,6 +5,7 @@ import sys
 from unittest.mock import patch
 
 import pytest
+from cua_cli.commands import info
 from cua_cli.main import create_parser, main
 
 
@@ -74,6 +75,13 @@ class TestCreateParser:
         args = parser.parse_args(["serve-mcp"])
         assert args.command == "serve-mcp"
 
+    def test_has_info_command(self):
+        """Test that info command is registered."""
+        parser = create_parser()
+
+        args = parser.parse_args(["info"])
+        assert args.command == "info"
+
 
 class TestMain:
     """Tests for main function."""
@@ -140,6 +148,40 @@ class TestMain:
 
         mock_execute.assert_called_once()
         assert result == 0
+
+    def test_dispatch_to_info(self):
+        """Test dispatch to info command."""
+        with patch.object(sys, "argv", ["cua", "info"]):
+            with patch("cua_cli.commands.info.execute", return_value=0) as mock_execute:
+                result = main()
+
+        mock_execute.assert_called_once()
+        assert result == 0
+
+    def test_info_output_contains_expected_fields(self, capsys):
+        """Test that info output has required diagnostic fields."""
+        diagnostics = {
+            "cua_cli_version": "test-version",
+            "python_version": "3.12.4",
+            "platform": "TestPlatform",
+            "system": "Linux",
+            "release": "6.1.0",
+            "machine": "x86_64",
+        }
+
+        with patch("cua_cli.commands.info.collect_diagnostics", return_value=diagnostics):
+            result = info.execute(argparse.Namespace())
+
+        # No host-derived fields, so output can be asserted deterministically.
+        captured = capsys.readouterr()
+        assert result == 0
+        assert "Environment Diagnostics" in captured.out
+        assert "cua-cli version: test-version" in captured.out
+        assert "python version: 3.12.4" in captured.out
+        assert "platform: TestPlatform" in captured.out
+        assert "system: Linux" in captured.out
+        assert "release: 6.1.0" in captured.out
+        assert "machine/architecture: x86_64" in captured.out
 
     def test_keyboard_interrupt_returns_130(self):
         """Test that KeyboardInterrupt returns exit code 130."""


### PR DESCRIPTION
## Summary
- add a top-level `cua info` command for local runtime diagnostics
- register the command in the CLI parser and dispatch path
- cover parser registration, dispatch, and deterministic output formatting

## Verification
- `PYTHONPATH=.:../core /tmp/cua-1751-py313-verify/bin/python -m pytest tests/test_main.py`
- `/tmp/cua-1751-py313-verify/bin/ruff check cua_cli/main.py cua_cli/commands/info.py tests/test_main.py`
- `git diff HEAD^..HEAD --check`
- `PYTHONPATH=.:../core /tmp/cua-1751-py313-verify/bin/python -m cua_cli.main info`

Refs #1751