### PR TITLE
Add license metadata to Python distributions

### DIFF
--- a/libs/cua-driver/python/LICENSE
+++ b/libs/cua-driver/python/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Cua AI, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/python/agent/LICENSE
+++ b/libs/python/agent/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Cua AI, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/python/agent/pyproject.toml
+++ b/libs/python/agent/pyproject.toml
@@ -10,6 +10,10 @@ readme = "README.md"
 authors = [
     { name = "TryCua", email = "gh@trycua.com" }
 ]
+license = { text = "MIT" }
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+]
 dependencies = [
     "httpx>=0.27.0",
     "aiohttp>=3.9.3",
@@ -131,3 +135,4 @@ distribution = true
 
 [tool.pdm.build]
 includes = ["cua_agent/"]
+source-includes = ["README.md", "LICENSE"]

--- a/libs/python/bench-ui/LICENSE
+++ b/libs/python/bench-ui/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Cua AI, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/python/bench-ui/pyproject.toml
+++ b/libs/python/bench-ui/pyproject.toml
@@ -10,6 +10,10 @@ readme = "README.md"
 authors = [
     { name = "TryCua", email = "gh@trycua.com" }
 ]
+license = { text = "MIT" }
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+]
 dependencies = [
     "pywebview>=5.3",
     "aiohttp>=3.9.0",
@@ -22,4 +26,4 @@ distribution = true
 
 [tool.pdm.build]
 includes = ["bench_ui/"]
-source-includes = ["README.md"]
+source-includes = ["README.md", "LICENSE"]

--- a/libs/python/computer-server/LICENSE
+++ b/libs/python/computer-server/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Cua AI, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/python/computer-server/pyproject.toml
+++ b/libs/python/computer-server/pyproject.toml
@@ -12,6 +12,9 @@ authors = [
 ]
 readme = "README.md"
 license = { text = "MIT" }
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+]
 requires-python = ">=3.12,<3.14"
 dependencies = [
     "fastapi>=0.111.0",
@@ -67,6 +70,7 @@ distribution = true
 
 [tool.pdm.build]
 includes = ["computer_server"]
+source-includes = ["README.md", "LICENSE"]
 package-data = {"computer_server" = ["py.typed"]}
 
 [tool.pdm.dev-dependencies]

--- a/libs/python/computer/LICENSE
+++ b/libs/python/computer/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Cua AI, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/python/computer/pyproject.toml
+++ b/libs/python/computer/pyproject.toml
@@ -10,6 +10,10 @@ readme = "README.md"
 authors = [
     { name = "TryCua", email = "gh@trycua.com" }
 ]
+license = { text = "MIT" }
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+]
 dependencies = [
     "pillow>=10.0.0",
     "websocket-client>=1.8.0",

--- a/libs/python/core/LICENSE
+++ b/libs/python/core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Cua AI, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/python/core/pyproject.toml
+++ b/libs/python/core/pyproject.toml
@@ -10,6 +10,10 @@ readme = "README.md"
 authors = [
     { name = "TryCua", email = "gh@trycua.com" }
 ]
+license = { text = "MIT" }
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+]
 dependencies = [
     "posthog>=3.20.0",
 ]

--- a/libs/python/cua-auto/LICENSE
+++ b/libs/python/cua-auto/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Cua AI, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/python/cua-cli/LICENSE
+++ b/libs/python/cua-cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Cua AI, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/python/cua-sandbox-apps/LICENSE
+++ b/libs/python/cua-sandbox-apps/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Cua AI, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/python/cua-sandbox-apps/pyproject.toml
+++ b/libs/python/cua-sandbox-apps/pyproject.toml
@@ -5,6 +5,10 @@ description = "Universal app catalog and installer pipeline for CUA sandboxes â€
 requires-python = ">=3.11,<3.14"
 authors = [{ name = "TryCua", email = "gh@trycua.com" }]
 readme = "README.md"
+license = "MIT"
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+]
 
 dependencies = [
     "claude-agent-sdk>=0.1.0",

--- a/libs/python/cua-sandbox-apps/pyproject.toml
+++ b/libs/python/cua-sandbox-apps/pyproject.toml
@@ -5,7 +5,7 @@ description = "Universal app catalog and installer pipeline for CUA sandboxes â€
 requires-python = ">=3.11,<3.14"
 authors = [{ name = "TryCua", email = "gh@trycua.com" }]
 readme = "README.md"
-license = "MIT"
+license = { text = "MIT" }
 classifiers = [
     "License :: OSI Approved :: MIT License",
 ]

--- a/libs/python/cua-sandbox/LICENSE
+++ b/libs/python/cua-sandbox/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Cua AI, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/python/mcp-server/LICENSE
+++ b/libs/python/mcp-server/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Cua AI, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/python/mcp-server/pyproject.toml
+++ b/libs/python/mcp-server/pyproject.toml
@@ -11,6 +11,10 @@ version = "0.1.16"
 authors = [
     {name = "TryCua", email = "gh@trycua.com"}
 ]
+license = { text = "MIT" }
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+]
 dependencies = [
     "mcp>=1.6.0,<2.0.0",
     "cua-agent[all]>=0.8.0",
@@ -22,6 +26,9 @@ cua-mcp-server = "mcp_server.server:main"
 
 [tool.pdm]
 distribution = true
+
+[tool.pdm.build]
+source-includes = ["README.md", "LICENSE"]
 
 [tool.pdm.dev-dependencies]
 dev = [


### PR DESCRIPTION
Fixes #1868

## Missing metadata evidence

Before this change, I built and inspected the wheel/sdist metadata for the Python packages under `libs/`.

- `cua-agent`, `cua-core`, `cua-computer`, `cua-mcp-server`, `cua-bench-ui`, and `cua-sandbox-apps` had no `License` metadata, no license classifier, and no LICENSE entry in the built archives.
- `cua-computer-server` had `License: MIT`, but no license classifier and no LICENSE entry in the built archives.
- `cua-auto`, `cua-cli`, `cua-sandbox`, and `cua-driver` had an MIT classifier but no LICENSE entry in wheel/sdist archives.
- `cua`, `cua-bench`, and `cua-som` already produced license file entries, so this PR leaves their existing license behavior intact.

I also checked for duplicates with:

```bash
gh pr list -R trycua/cua --state open --search "1868" --json number,title,state,headRefName,author,url,updatedAt
gh search prs --repo trycua/cua --state open "license metadata" --json number,title,state,url,author,updatedAt --limit 20
```

Both returned no open PRs.

## Changes

- Add MIT license metadata and MIT license classifiers to the affected Python package `pyproject.toml` files.
- Add package-local `LICENSE` files for the MIT-licensed Python distributions that did not include one.
- Add PDM `source-includes` entries where needed so sdists include the license file.
- Keep the change scoped to packaging metadata and license inclusion; no runtime code changes.

## Verification

I ran a metadata build inspection over these packages:

- `libs/python/agent`
- `libs/python/core`
- `libs/python/computer`
- `libs/python/computer-server`
- `libs/python/som`
- `libs/python/mcp-server`
- `libs/python/bench-ui`
- `libs/python/cua`
- `libs/python/cua-auto`
- `libs/python/cua-cli`
- `libs/python/cua-sandbox`
- `libs/python/cua-sandbox-apps`
- `libs/cua-driver/python`
- `libs/cua-bench`

Command pattern:

```bash
uv build --no-progress --color never --out-dir build/license-green <package-dir>
```

Then I inspected each wheel `METADATA` and each sdist `PKG-INFO` plus archive contents. Result:

```text
All checked distributions include license metadata and a LICENSE file entry.
```

Additional checks:

```bash
python - <<'PY'
import pathlib, tomllib
for path in sorted(pathlib.Path('.').glob('libs/**/pyproject.toml')) + [pathlib.Path('pyproject.toml')]:
    tomllib.loads(path.read_text(encoding='utf-8'))
print('parsed pyproject.toml files successfully')
PY

git diff --check
git diff --cached --check
```

Both diff checks exited 0, and all `pyproject.toml` files parsed successfully.

## Not run

I did not run runtime pytest/mypy suites because this PR only changes package metadata and LICENSE files, with no Python runtime source changes. The direct risk is package build metadata, covered by the wheel/sdist inspection above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added MIT License documentation to multiple Python packages
  * Updated package metadata to explicitly declare MIT licensing and include license files in package distributions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->