### PR TITLE
Fix TypeScript Computer SDK host desktop docs

### DIFF
--- a/docs/content/docs/cua/guide/get-started/using-computer-sdk.mdx
+++ b/docs/content/docs/cua/guide/get-started/using-computer-sdk.mdx
@@ -344,6 +344,10 @@ The Computer SDK lets you connect to your sandbox and perform basic interactions
 
 ## Common Operations
 
+TypeScript examples below use the cloud `Computer` shape. If you connected with a host desktop
+interface, call the same TypeScript methods directly on `computer`, such as
+`await computer.screenshot()` or `await computer.leftClick(x, y)`.
+
 | Operation    | Python                                          | TypeScript                                      |
 | ------------ | ----------------------------------------------- | ----------------------------------------------- |
 | Screenshot   | `await computer.interface.screenshot()`         | `await computer.interface.screenshot()`         |
@@ -351,8 +355,8 @@ The Computer SDK lets you connect to your sandbox and perform basic interactions
 | Right click  | `await computer.interface.right_click(x, y)`    | `await computer.interface.rightClick(x, y)`     |
 | Double click | `await computer.interface.double_click(x, y)`   | `await computer.interface.doubleClick(x, y)`    |
 | Type text    | `await computer.interface.type_text("text")`    | `await computer.interface.typeText("text")`     |
-| Press key    | `await computer.interface.key("Enter")`         | `await computer.interface.key("Enter")`         |
-| Scroll       | `await computer.interface.scroll(x, y, clicks)` | `await computer.interface.scroll(x, y, clicks)` |
+| Press key    | `await computer.interface.key("Enter")`         | `await computer.interface.pressKey("Enter")`    |
+| Scroll       | `await computer.interface.scroll(x, y, clicks)` | `await computer.interface.scroll(x, y)`         |
 
 ## Lifecycle Methods
 

--- a/docs/content/docs/cua/guide/get-started/using-computer-sdk.mdx
+++ b/docs/content/docs/cua/guide/get-started/using-computer-sdk.mdx
@@ -271,7 +271,7 @@ The Computer SDK lets you connect to your sandbox and perform basic interactions
   </Tab>
   <Tab value="TypeScript">
 
-    <Tabs items={['Cloud Sandbox', 'Linux on Docker', 'macOS Sandbox', 'Windows Sandbox', 'Your host desktop']}>
+    <Tabs items={['Cloud Sandbox', 'Your host desktop']}>
       <Tab value="Cloud Sandbox">
         Set your Cua API key (same key used for model inference):
         ```bash
@@ -282,46 +282,17 @@ The Computer SDK lets you connect to your sandbox and perform basic interactions
         ```typescript
         import { Computer, OSType } from '@trycua/computer';
 
+        const apiKey = process.env.CUA_API_KEY;
+        if (!apiKey) {
+          throw new Error("CUA_API_KEY is required");
+        }
+
         const computer = new Computer({
+          apiKey,
           osType: OSType.LINUX,  // or OSType.WINDOWS or OSType.MACOS
           name: "your-sandbox-name"  // from CLI or website
         });
         await computer.run(); // Connect to the sandbox
-        ```
-      </Tab>
-      <Tab value="Linux on Docker">
-        ```typescript
-        import { Computer, OSType, ProviderType } from '@trycua/computer';
-
-        const computer = new Computer({
-          osType: OSType.LINUX,
-          providerType: ProviderType.DOCKER,
-          image: "trycua/cua-xfce:latest"  // or "trycua/cua-ubuntu:latest"
-        });
-        await computer.run(); // Launch & connect to the sandbox
-        ```
-      </Tab>
-      <Tab value="macOS Sandbox">
-        ```typescript
-        import { Computer, OSType, ProviderType } from '@trycua/computer';
-
-        const computer = new Computer({
-          osType: OSType.MACOS,
-          providerType: ProviderType.LUME,
-          name: "macos-sequoia-cua:latest"
-        });
-        await computer.run(); // Launch & connect to the sandbox
-        ```
-      </Tab>
-      <Tab value="Windows Sandbox">
-        ```typescript
-        import { Computer, OSType, ProviderType } from '@trycua/computer';
-
-        const computer = new Computer({
-          osType: OSType.WINDOWS,
-          providerType: ProviderType.WINDOWS_SANDBOX
-        });
-        await computer.run(); // Launch & connect to the sandbox
         ```
       </Tab>
       <Tab value="Your host desktop">
@@ -331,17 +302,19 @@ The Computer SDK lets you connect to your sandbox and perform basic interactions
         python -m computer_server
         ```
 
-        Then, use the `Computer` object to connect:
+        The TypeScript SDK does not expose `useHostComputerServer`. Connect to the local
+        `computer_server` with the interface class for your host OS:
         ```typescript
-        import { Computer } from '@trycua/computer';
+        import { MacOSComputerInterface } from '@trycua/computer';
+        // Use LinuxComputerInterface or WindowsComputerInterface on those hosts.
 
-        const computer = new Computer({ useHostComputerServer: true });
-        await computer.run(); // Connect to the host desktop
+        const computer = new MacOSComputerInterface("localhost");
+        await computer.waitForReady(); // Connect to the host desktop
         ```
       </Tab>
     </Tabs>
 
-    Once connected, you can perform interactions:
+    For cloud sandbox `Computer` instances, perform interactions through `computer.interface`:
     ```typescript
     try {
       // Take a screenshot of the computer's current display
@@ -352,6 +325,17 @@ The Computer SDK lets you connect to your sandbox and perform basic interactions
       await computer.interface.typeText("Hello!");
     } finally {
       await computer.disconnect();
+    }
+    ```
+
+    For host desktop interfaces, call the same methods directly:
+    ```typescript
+    try {
+      const screenshot = await computer.screenshot();
+      await computer.leftClick(100, 100);
+      await computer.typeText("Hello!");
+    } finally {
+      computer.disconnect();
     }
     ```
 

--- a/libs/typescript/computer/src/index.ts
+++ b/libs/typescript/computer/src/index.ts
@@ -1,5 +1,13 @@
 // Export classes
 export { CloudComputer as Computer } from './computer';
+export {
+  BaseComputerInterface,
+  InterfaceFactory,
+  LinuxComputerInterface,
+  MacOSComputerInterface,
+  WindowsComputerInterface,
+} from './interface';
+export type { AccessibilityNode, CursorPosition, MouseButton } from './interface';
 
 export { OSType } from './types';
 export { VMProviderType as ProviderType } from './computer/types';

--- a/libs/typescript/computer/tests/index.test.ts
+++ b/libs/typescript/computer/tests/index.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import * as ComputerExports from '../src/index.ts';
+
+describe('package exports', () => {
+  it('exports host computer interfaces from the package root', () => {
+    expect(ComputerExports.MacOSComputerInterface).toBeDefined();
+    expect(ComputerExports.LinuxComputerInterface).toBeDefined();
+    expect(ComputerExports.WindowsComputerInterface).toBeDefined();
+  });
+});

--- a/libs/typescript/computer/tests/index.test.ts
+++ b/libs/typescript/computer/tests/index.test.ts
@@ -3,6 +3,8 @@ import * as ComputerExports from '../src/index.ts';
 
 describe('package exports', () => {
   it('exports host computer interfaces from the package root', () => {
+    expect(ComputerExports.BaseComputerInterface).toBeDefined();
+    expect(ComputerExports.InterfaceFactory).toBeDefined();
     expect(ComputerExports.MacOSComputerInterface).toBeDefined();
     expect(ComputerExports.LinuxComputerInterface).toBeDefined();
     expect(ComputerExports.WindowsComputerInterface).toBeDefined();


### PR DESCRIPTION
Fixes #916.

The TypeScript docs currently show:

```ts
new Computer({ useHostComputerServer: true })
```

but that option is not part of the published `@trycua/computer` API. In the TypeScript package, `Computer` is currently the cloud computer class, while host desktop access goes through the OS-specific interface classes.

This PR updates the docs to show the supported path instead:

```ts
import { MacOSComputerInterface } from '@trycua/computer';

const computer = new MacOSComputerInterface("localhost");
await computer.waitForReady();
```

It also exports the existing interface classes from the package root so the docs can import them directly from `@trycua/computer`.

Changes:
- export `MacOSComputerInterface`, `LinuxComputerInterface`, and `WindowsComputerInterface` from the package root
- update the TypeScript Computer SDK docs to avoid `useHostComputerServer`
- remove TypeScript sandbox examples that reference unsupported local provider config
- add a small package export regression test

Tested:
- `pnpm test tests\index.test.ts`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm exec prettier --check docs/content/docs/cua/guide/get-started/using-computer-sdk.mdx libs/typescript/computer/src/index.ts libs/typescript/computer/tests/index.test.ts`

One note: the full `pnpm test` suite still has unrelated existing failures in `tests/interface/macos.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TypeScript "Connect to Your Sandbox" guide with simplified setup instructions for Cloud Sandbox and host desktop options
  * Clarified API key configuration and interaction methods for each connection type

* **New Features**
  * Exposed additional interface classes and utility types in the TypeScript SDK for direct access and customization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->