### PR TITLE
feat(cua-bench): write replayable run artifacts

### DIFF
--- a/libs/cua-bench/cua_bench/__init__.py
+++ b/libs/cua-bench/cua_bench/__init__.py
@@ -7,11 +7,14 @@ from .decorators import evaluate_task, setup_task, solve_task, tasks_config
 from .desktop import Desktop
 from .environment import Environment
 from .runners import (
+    BenchmarkRunConfig,
     BenchmarkResult,
     TaskResult,
+    build_benchmark_manifest,
     run_benchmark,
     run_interactive,
     run_single_task,
+    write_benchmark_artifacts,
 )
 from .types import (
     Action,
@@ -67,6 +70,9 @@ __all__ = [
     "run_benchmark",
     "run_single_task",
     "run_interactive",
+    "build_benchmark_manifest",
+    "write_benchmark_artifacts",
+    "BenchmarkRunConfig",
     "BenchmarkResult",
     "TaskResult",
 ]

--- a/libs/cua-bench/cua_bench/runners.py
+++ b/libs/cua-bench/cua_bench/runners.py
@@ -90,7 +90,7 @@ def build_benchmark_manifest(
     manifest = {
         "schema_version": 1,
         "run_id": result.run_id,
-        "created_at": completed_at or _utc_now(),
+        "manifest_created_at": _utc_now(),
         "started_at": started_at,
         "completed_at": completed_at,
         "config": asdict(config),
@@ -104,11 +104,6 @@ def build_benchmark_manifest(
         "tasks": result.task_results,
         "failed_tasks": failed_tasks,
         "replay": {
-            "dataset_path": config.dataset_path,
-            "split": config.split,
-            "task_filter": config.task_filter,
-            "max_variants": config.max_variants,
-            "oracle": config.oracle,
             "command": _build_replay_command(config),
         },
     }
@@ -122,7 +117,7 @@ def write_benchmark_artifacts(
     *,
     started_at: Optional[str] = None,
     completed_at: Optional[str] = None,
-) -> Path:
+) -> Tuple[Path, Path]:
     """Write manifest and failure index artifacts for a benchmark run.
 
     The files are intentionally plain JSON so failed computer-use runs can be
@@ -144,7 +139,7 @@ def write_benchmark_artifacts(
         for task in manifest["failed_tasks"]:
             f.write(json.dumps(task, sort_keys=True) + "\n")
 
-    return manifest_path
+    return manifest_path, failures_path
 
 
 async def run_single_task(

--- a/libs/cua-bench/cua_bench/runners.py
+++ b/libs/cua-bench/cua_bench/runners.py
@@ -6,9 +6,11 @@ interactive environments, using the core gym interface (make, reset, step, evalu
 
 import asyncio
 import fnmatch
+import json
 import time
 import uuid
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -43,6 +45,19 @@ class BenchmarkResult:
 
 
 @dataclass
+class BenchmarkRunConfig:
+    """Configuration captured with benchmark artifacts for replay/debugging."""
+
+    dataset_path: str
+    split: str = "train"
+    max_steps: int = 100
+    max_parallel: int = 4
+    oracle: bool = False
+    max_variants: Optional[int] = None
+    task_filter: Optional[str] = None
+
+
+@dataclass
 class TaskResult:
     """Result of a single task execution.
 
@@ -61,6 +76,75 @@ class TaskResult:
     reward: float
     steps: int
     error: Optional[str] = None
+
+
+def build_benchmark_manifest(
+    result: BenchmarkResult,
+    config: BenchmarkRunConfig,
+    *,
+    started_at: Optional[str] = None,
+    completed_at: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build a replay-friendly manifest for a benchmark result."""
+    failed_tasks = [task for task in result.task_results if not task.get("success", False)]
+    manifest = {
+        "schema_version": 1,
+        "run_id": result.run_id,
+        "created_at": completed_at or _utc_now(),
+        "started_at": started_at,
+        "completed_at": completed_at,
+        "config": asdict(config),
+        "summary": {
+            "total_tasks": result.total_tasks,
+            "success_count": result.success_count,
+            "failed_count": result.failed_count,
+            "avg_reward": result.avg_reward,
+            "duration_seconds": result.duration_seconds,
+        },
+        "tasks": result.task_results,
+        "failed_tasks": failed_tasks,
+        "replay": {
+            "dataset_path": config.dataset_path,
+            "split": config.split,
+            "task_filter": config.task_filter,
+            "max_variants": config.max_variants,
+            "oracle": config.oracle,
+            "command": _build_replay_command(config),
+        },
+    }
+    return manifest
+
+
+def write_benchmark_artifacts(
+    result: BenchmarkResult,
+    output_dir: Path | str,
+    config: BenchmarkRunConfig,
+    *,
+    started_at: Optional[str] = None,
+    completed_at: Optional[str] = None,
+) -> Path:
+    """Write manifest and failure index artifacts for a benchmark run.
+
+    The files are intentionally plain JSON so failed computer-use runs can be
+    shared, diffed, and replayed without parsing terminal logs.
+    """
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    manifest = build_benchmark_manifest(
+        result,
+        config,
+        started_at=started_at,
+        completed_at=completed_at,
+    )
+    manifest_path = output_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+
+    failures_path = output_path / "failures.jsonl"
+    with failures_path.open("w", encoding="utf-8") as f:
+        for task in manifest["failed_tasks"]:
+            f.write(json.dumps(task, sort_keys=True) + "\n")
+
+    return manifest_path
 
 
 async def run_single_task(
@@ -179,6 +263,7 @@ async def run_benchmark(
     max_variants: Optional[int] = None,
     task_filter: Optional[str] = None,
     split: str = "train",
+    output_dir: Optional[Path | str] = None,
 ) -> BenchmarkResult:
     """Run a benchmark on a dataset using the gym interface.
 
@@ -195,6 +280,7 @@ async def run_benchmark(
         max_variants: Maximum variants per task (optional)
         task_filter: Glob pattern to filter tasks (optional)
         split: Dataset split (default: "train")
+        output_dir: Optional directory to write manifest.json and failures.jsonl
 
     Returns:
         BenchmarkResult with run statistics and task results
@@ -223,6 +309,7 @@ async def run_benchmark(
         )
     """
     start_time = time.time()
+    started_at = _utc_now()
 
     # Validate dataset path
     if not dataset_path.exists():
@@ -323,7 +410,7 @@ async def run_benchmark(
     avg_reward = sum(rewards) / len(rewards) if rewards else 0.0
     duration_seconds = time.time() - start_time
 
-    return BenchmarkResult(
+    benchmark_result = BenchmarkResult(
         run_id=run_id,
         task_results=task_results,
         total_tasks=len(task_results),
@@ -331,7 +418,45 @@ async def run_benchmark(
         failed_count=failed_count,
         avg_reward=avg_reward,
         duration_seconds=duration_seconds,
+        output_dir=str(output_dir) if output_dir else None,
     )
+    if output_dir:
+        write_benchmark_artifacts(
+            benchmark_result,
+            output_dir,
+            BenchmarkRunConfig(
+                dataset_path=str(dataset_path),
+                split=split,
+                max_steps=max_steps,
+                max_parallel=max_parallel,
+                oracle=oracle,
+                max_variants=max_variants,
+                task_filter=task_filter,
+            ),
+            started_at=started_at,
+            completed_at=_utc_now(),
+        )
+
+    return benchmark_result
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _build_replay_command(config: BenchmarkRunConfig) -> List[str]:
+    command = ["cb", "run", "dataset", config.dataset_path]
+    if config.oracle:
+        command.append("--oracle")
+    if config.split != "train":
+        command.extend(["--split", config.split])
+    if config.task_filter:
+        command.extend(["--task-filter", config.task_filter])
+    if config.max_variants is not None:
+        command.extend(["--max-variants", str(config.max_variants)])
+    command.extend(["--max-steps", str(config.max_steps)])
+    command.extend(["--max-parallel", str(config.max_parallel)])
+    return command
 
 
 async def run_interactive(

--- a/libs/cua-bench/cua_bench/tests/test_run_benchmark.py
+++ b/libs/cua-bench/cua_bench/tests/test_run_benchmark.py
@@ -5,16 +5,20 @@ which use the gym interface (make, reset, step, evaluate) directly.
 """
 
 from pathlib import Path
+import json
 
 import pytest
 from cua_bench import (
+    BenchmarkRunConfig,
     BenchmarkResult,
     DoneAction,
     Task,
     TaskResult,
+    build_benchmark_manifest,
     run_benchmark,
     run_interactive,
     run_single_task,
+    write_benchmark_artifacts,
 )
 
 # Simple HTML for test tasks
@@ -120,6 +124,114 @@ class TestBenchmarkResult:
         )
         assert result.success_count == 0
         assert result.failed_count == result.total_tasks
+
+
+class TestBenchmarkArtifacts:
+    """Tests for replay-friendly benchmark artifacts."""
+
+    def test_build_benchmark_manifest_includes_replay_command(self):
+        result = BenchmarkResult(
+            run_id="run-abc123",
+            task_results=[
+                {"task_path": "dataset/click", "variant_id": 0, "success": True, "reward": 1.0, "steps": 3},
+                {
+                    "task_path": "dataset/type",
+                    "variant_id": 1,
+                    "success": False,
+                    "reward": 0.0,
+                    "steps": 2,
+                    "error": "timed out",
+                },
+            ],
+            total_tasks=2,
+            success_count=1,
+            failed_count=1,
+            avg_reward=0.5,
+            duration_seconds=12.5,
+        )
+        config = BenchmarkRunConfig(
+            dataset_path="dataset",
+            split="test",
+            max_steps=25,
+            max_parallel=3,
+            oracle=True,
+            max_variants=2,
+            task_filter="type-*",
+        )
+
+        manifest = build_benchmark_manifest(
+            result,
+            config,
+            started_at="2026-06-10T12:00:00+00:00",
+            completed_at="2026-06-10T12:00:12+00:00",
+        )
+
+        assert manifest["schema_version"] == 1
+        assert manifest["summary"]["failed_count"] == 1
+        assert manifest["failed_tasks"][0]["task_path"] == "dataset/type"
+        assert manifest["replay"]["command"] == [
+            "cb",
+            "run",
+            "dataset",
+            "dataset",
+            "--oracle",
+            "--split",
+            "test",
+            "--task-filter",
+            "type-*",
+            "--max-variants",
+            "2",
+            "--max-steps",
+            "25",
+            "--max-parallel",
+            "3",
+        ]
+
+    def test_write_benchmark_artifacts_writes_manifest_and_failures(self, tmp_path):
+        result = BenchmarkResult(
+            run_id="run-failed",
+            task_results=[
+                {"task_path": "dataset/a", "variant_id": 0, "success": False, "reward": 0.0, "steps": 0, "error": "boom"},
+                {"task_path": "dataset/b", "variant_id": 0, "success": True, "reward": 1.0, "steps": 1},
+            ],
+            total_tasks=2,
+            success_count=1,
+            failed_count=1,
+            avg_reward=0.5,
+            duration_seconds=3.0,
+        )
+
+        manifest_path = write_benchmark_artifacts(
+            result,
+            tmp_path,
+            BenchmarkRunConfig(dataset_path="dataset"),
+            started_at="2026-06-10T12:00:00+00:00",
+            completed_at="2026-06-10T12:00:03+00:00",
+        )
+
+        manifest = json.loads(manifest_path.read_text())
+        failures = (tmp_path / "failures.jsonl").read_text().strip().splitlines()
+        assert manifest["run_id"] == "run-failed"
+        assert manifest["summary"]["avg_reward"] == 0.5
+        assert len(failures) == 1
+        assert json.loads(failures[0])["error"] == "boom"
+
+    @pytest.mark.asyncio
+    async def test_run_benchmark_writes_artifacts_for_failed_task(self, tmp_path):
+        dataset_path = tmp_path / "dataset"
+        task_dir = dataset_path / "broken-task"
+        task_dir.mkdir(parents=True)
+        (task_dir / "main.py").write_text("raise RuntimeError('broken import for artifact test')\n")
+
+        output_dir = tmp_path / "artifacts"
+        result = await run_benchmark(dataset_path, max_parallel=1, output_dir=output_dir)
+
+        manifest = json.loads((output_dir / "manifest.json").read_text())
+        failures = (output_dir / "failures.jsonl").read_text().strip().splitlines()
+        assert result.output_dir == str(output_dir)
+        assert manifest["summary"]["failed_count"] == 1
+        assert manifest["failed_tasks"][0]["task_path"] == str(task_dir)
+        assert json.loads(failures[0])["success"] is False
 
 
 class TestRunSingleTaskE2E:

--- a/libs/cua-bench/cua_bench/tests/test_run_benchmark.py
+++ b/libs/cua-bench/cua_bench/tests/test_run_benchmark.py
@@ -167,8 +167,10 @@ class TestBenchmarkArtifacts:
         )
 
         assert manifest["schema_version"] == 1
+        assert manifest["manifest_created_at"]
         assert manifest["summary"]["failed_count"] == 1
         assert manifest["failed_tasks"][0]["task_path"] == "dataset/type"
+        assert list(manifest["replay"].keys()) == ["command"]
         assert manifest["replay"]["command"] == [
             "cb",
             "run",
@@ -201,7 +203,7 @@ class TestBenchmarkArtifacts:
             duration_seconds=3.0,
         )
 
-        manifest_path = write_benchmark_artifacts(
+        manifest_path, failures_path = write_benchmark_artifacts(
             result,
             tmp_path,
             BenchmarkRunConfig(dataset_path="dataset"),
@@ -210,7 +212,7 @@ class TestBenchmarkArtifacts:
         )
 
         manifest = json.loads(manifest_path.read_text())
-        failures = (tmp_path / "failures.jsonl").read_text().strip().splitlines()
+        failures = failures_path.read_text().strip().splitlines()
         assert manifest["run_id"] == "run-failed"
         assert manifest["summary"]["avg_reward"] == 0.5
         assert len(failures) == 1


### PR DESCRIPTION
## Summary

Adds replay-friendly benchmark artifacts for `cua-bench` runs. Programmatic `run_benchmark(..., output_dir=...)` now writes:

- `manifest.json` with run config, summary, task results, failed tasks, timestamps, and a replay command
- `failures.jsonl` with one failed task per line for quick triage and diffing

This is meant to make failed or flaky computer-use benchmark runs easier to share and reproduce without asking maintainers to scrape terminal logs.

## API

- `BenchmarkRunConfig`
- `build_benchmark_manifest(...)`
- `write_benchmark_artifacts(...)`
- `run_benchmark(..., output_dir=...)`

## Testing

- `uv run pytest libs/cua-bench/cua_bench/tests/test_run_benchmark.py::TestBenchmarkArtifacts -q`
- `.venv/bin/python -m py_compile libs/cua-bench/cua_bench/runners.py libs/cua-bench/cua_bench/__init__.py libs/cua-bench/cua_bench/tests/test_run_benchmark.py`
- `git diff --check`

I also ran the full `test_run_benchmark.py` file. The new artifact tests passed, but four existing simulated browser E2E tests failed locally because Playwright Chromium is not installed in this environment. The failure asks to run `playwright install`, and does not appear related to this change.

Note: `uv run ruff check ...` and direct `.venv/bin/ruff check ...` both hung or were killed in this local environment, so I did not rely on them for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark runs now support generating replay and debug artifacts when an output directory is specified
  * Enhanced API with new exports for benchmark configuration and artifact management
  
* **Tests**
  * Added comprehensive tests validating artifact generation, content, and end-to-end artifact writing workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->