### PR TITLE
fix(cua-driver-rs)(windows): scale zoom region by resize ratio before native crop

### DIFF
--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -4816,10 +4816,18 @@ impl Tool for ZoomTool {
             ));
         }
 
+        // Issue #1880: the caller's coordinates are in the (possibly downscaled)
+        // screenshot space of the last `get_window_state` call, but the crop below
+        // runs on a fresh native-resolution capture. Scale by the stored resize
+        // ratio so the crop lands on the intended region; the zoom context then
+        // holds native-pixel values, which is what `from_zoom` clicks expect.
+        let ratio = self.state.resize_registry.ratio(raw_pid as u32).unwrap_or(1.0);
+        let (nx1, ny1, nx2, ny2) = (x1 * ratio, y1 * ratio, x2 * ratio, y2 * ratio);
+
         let state = self.state.clone();
         let result = tokio::task::spawn_blocking(move || {
             let png = crate::capture::screenshot_window_bytes(hwnd)?;
-            cursor_overlay::capture_utils::crop_png_to_jpeg(&png, x1, y1, x2, y2, 500)
+            cursor_overlay::capture_utils::crop_png_to_jpeg(&png, nx1, ny1, nx2, ny2, 500)
         }).await;
 
         match result {


### PR DESCRIPTION
## Summary

Fixes #1880.

On Windows, `zoom` documents `x1`, `y1`, `x2`, `y2` as coordinates in the same pixel space as the screenshot returned by `get_window_state` (i.e. the resized image when `max_image_dimension` is active). `ZoomTool::invoke` however passed those values directly to `crop_png_to_jpeg` on a fresh native-resolution capture, so with downscaling active the crop landed at the wrong window region and the stored zoom context poisoned subsequent `click(..., from_zoom=true)` translations.

## Fix

- Multiply the caller-provided region by the per-pid resize ratio stored by `get_window_state` (`ResizeRegistry`) before cropping the native capture (ratio defaults to 1.0 when no downscale was recorded).
- The resulting `ZoomContext` (crop origin + scale) is therefore in native window pixels, which is exactly what the `from_zoom` click/drag paths expect, since they bypass the resize-ratio multiplication.
- The 500 px max-width validation still applies to the caller-provided scaled-image width, as documented.

## Test plan

- [x] `cargo check -p platform-windows` passes
- [ ] On Windows with `max_image_dimension` low enough to force downscaling (e.g. 400): `get_window_state(capture_mode: vision)`, then `zoom` a region from the returned image and verify the crop matches the requested region
- [ ] Verify `click(..., from_zoom=true)` lands on the intended target after such a zoom

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed zoom tool to correctly display cropped regions when window downscaling is applied, ensuring the zoomed view accurately corresponds to the selected area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->