### PR TITLE
fix: extend daemon proxy read timeout

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
@@ -354,29 +354,60 @@ pub fn read_pid_file(pid_file_path: &str) -> Option<u32> {
         .and_then(|s| s.trim().parse().ok())
 }
 
+const DAEMON_WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+const DAEMON_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+fn is_daemon_timeout_error(err: &std::io::Error) -> bool {
+    matches!(
+        err.kind(),
+        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+    )
+}
+
+fn read_daemon_response_line<R: std::io::BufRead>(
+    mut reader: R,
+    timeout: std::time::Duration,
+) -> anyhow::Result<String> {
+    let mut resp_line = String::new();
+    match reader.read_line(&mut resp_line) {
+        Ok(0) => anyhow::bail!("daemon closed connection without response"),
+        Ok(_) => {
+            while matches!(resp_line.as_bytes().last(), Some(b'\n' | b'\r')) {
+                resp_line.pop();
+            }
+            Ok(resp_line)
+        }
+        Err(err) if is_daemon_timeout_error(&err) => {
+            anyhow::bail!(
+                "daemon timed out waiting for response after {}s",
+                timeout.as_secs()
+            )
+        }
+        Err(err) => Err(err.into()),
+    }
+}
+
 /// Send a request to the daemon and return the response.
-/// Uses a 3-second connect timeout (by polling) and a 10-second read timeout.
+/// Uses a 5-second write timeout and a 60-second read timeout.
 #[cfg(unix)]
 pub fn send_request(socket_path: &str, req: &DaemonRequest) -> anyhow::Result<DaemonResponse> {
-    use std::io::{BufRead, BufReader, Write};
+    use std::io::{BufReader, Write};
     use std::os::unix::net::UnixStream;
-    use std::time::Duration;
 
     let stream = UnixStream::connect(socket_path)
         .map_err(|e| anyhow::anyhow!("connect to {socket_path}: {e}"))?;
-    stream.set_write_timeout(Some(Duration::from_secs(5)))?;
-    stream.set_read_timeout(Some(Duration::from_secs(10)))?;
+    stream.set_write_timeout(Some(DAEMON_WRITE_TIMEOUT))?;
+    // AX-heavy tools such as `get_window_state` have their own tool-level
+    // deadlines. The daemon transport must not time out first and surface
+    // macOS EAGAIN/os error 35 as an MCP transport failure.
+    stream.set_read_timeout(Some(DAEMON_READ_TIMEOUT))?;
 
     let mut w = stream.try_clone()?;
     let line = serde_json::to_string(req)? + "\n";
     w.write_all(line.as_bytes())?;
     w.flush()?;
 
-    let reader = BufReader::new(stream);
-    let mut resp_line = String::new();
-    reader.lines().next()
-        .ok_or_else(|| anyhow::anyhow!("daemon closed connection without response"))??
-        .clone_into(&mut resp_line);
+    let resp_line = read_daemon_response_line(BufReader::new(stream), DAEMON_READ_TIMEOUT)?;
     let resp: DaemonResponse = serde_json::from_str(&resp_line)?;
     Ok(resp)
 }
@@ -385,7 +416,7 @@ pub fn send_request(socket_path: &str, req: &DaemonRequest) -> anyhow::Result<Da
 pub fn send_request(socket_path: &str, req: &DaemonRequest) -> anyhow::Result<DaemonResponse> {
     #[cfg(target_os = "windows")]
     {
-        use std::io::{BufRead, BufReader, Write};
+        use std::io::{BufReader, Write};
         use std::time::Duration;
 
         // Retry opening the pipe — server may still be starting.
@@ -410,11 +441,7 @@ pub fn send_request(socket_path: &str, req: &DaemonRequest) -> anyhow::Result<Da
         writer.flush()?;
 
         // Server writes one JSON line then flushes; pipe stays open until we drop it.
-        let reader = BufReader::new(pipe);
-        let resp_line = reader
-            .lines()
-            .next()
-            .ok_or_else(|| anyhow::anyhow!("daemon closed connection without response"))??;
+        let resp_line = read_daemon_response_line(BufReader::new(pipe), DAEMON_READ_TIMEOUT)?;
         let resp: DaemonResponse = serde_json::from_str(&resp_line)?;
         Ok(resp)
     }
@@ -1376,6 +1403,68 @@ pub fn run_status_cmd(socket_path: &str, pid_file_path: &str) {
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod daemon_response_read_tests {
+    use super::read_daemon_response_line;
+    use std::io::{self, BufRead, Cursor, Read};
+
+    struct FailingReader {
+        kind: io::ErrorKind,
+    }
+
+    impl Read for FailingReader {
+        fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::new(self.kind, "synthetic failure"))
+        }
+    }
+
+    impl BufRead for FailingReader {
+        fn fill_buf(&mut self) -> io::Result<&[u8]> {
+            Err(io::Error::new(self.kind, "synthetic failure"))
+        }
+
+        fn consume(&mut self, _amt: usize) {}
+    }
+
+    #[test]
+    fn read_daemon_response_line_trims_newline() {
+        let line = read_daemon_response_line(
+            Cursor::new(b"{\"ok\":true}\r\n"),
+            std::time::Duration::from_secs(60),
+        )
+        .expect("response line");
+        assert_eq!(line, "{\"ok\":true}");
+    }
+
+    #[test]
+    fn read_daemon_response_line_maps_wouldblock_to_clear_timeout() {
+        let err = read_daemon_response_line(
+            FailingReader {
+                kind: io::ErrorKind::WouldBlock,
+            },
+            std::time::Duration::from_secs(60),
+        )
+        .expect_err("timeout should become a friendly daemon timeout error");
+        assert!(err
+            .to_string()
+            .contains("daemon timed out waiting for response after 60s"));
+    }
+
+    #[test]
+    fn read_daemon_response_line_maps_timedout_to_clear_timeout() {
+        let err = read_daemon_response_line(
+            FailingReader {
+                kind: io::ErrorKind::TimedOut,
+            },
+            std::time::Duration::from_secs(60),
+        )
+        .expect_err("timeout should become a friendly daemon timeout error");
+        assert!(err
+            .to_string()
+            .contains("daemon timed out waiting for response after 60s"));
+    }
+}
 
 #[cfg(all(test, unix))]
 mod gate_tests {


### PR DESCRIPTION
## Summary

Fixes #1864.

This PR fixes the MCP -> daemon proxy timeout described in the issue. It does not make `get_window_state` smaller or bypass AX traversal; it makes the daemon transport wait long enough for legitimate tool execution and return a clearer transport timeout if the daemon still does not respond.

## Issue Behavior Addressed

The issue reports that this path can fail:

```text
MCP client -> cua-driver mcp stdio server -> cua-driver serve daemon over Unix socket -> get_window_state
```

The same `get_window_state` operation can look healthy through `cua-driver call`, while the MCP proxy path fails with:

```text
Resource temporarily unavailable (os error 35)
```

The root cause fixed here is the proxy client read timeout: `send_request` used a hardcoded 10-second socket read timeout. Slow but valid daemon calls, especially `get_window_state`, could exceed that transport timeout before the tool returned its own result or timeout. On macOS, that timed-out socket read appears as `WouldBlock` / `EAGAIN` / os error 35.

## What Changed

- Replaced the inline daemon socket timeout with named daemon write/read timeout constants.
- Raised the daemon read timeout from 10 seconds to 60 seconds.
- Kept the write timeout short at 5 seconds.
- Mapped `WouldBlock` / `TimedOut` while reading the daemon response into a clear error:

```text
daemon timed out waiting for response after 60s
```

The 60-second transport budget is intentionally above the macOS `get_window_state` AX walk timeout of 30 seconds, leaving room for screenshot capture, resizing/encoding or `screenshot_out_file`, and JSON response serialization.

This PR intentionally does not blindly retry on `EAGAIN`. In this code path, `EAGAIN` is the socket read timeout firing, not a transient readiness event from a nonblocking socket loop. Retrying would hide the timeout policy instead of fixing the proxy deadline.

## Relation To The Issue's Upstream Questions

Resolved by this PR:

- `os error 35` / `EAGAIN` in the MCP -> daemon proxy no longer leaks as the primary failure for slow-but-valid daemon responses below the transport budget.
- The proxy now waits longer than the old 10-second transport timeout and longer than the macOS `get_window_state` AX timeout.
- If the daemon still does not respond inside the transport budget, the user gets a daemon timeout message instead of raw macOS `EAGAIN`.

Not changed by this PR and still follow-up scope:

- Whether `screenshot_out_file` should be the recommended long-term payload-size strategy.
- Whether large screenshot payloads should default to files or be chunked.
- Whether Apple Notes empty/unusable AX trees are a known platform limitation or need an alternate traversal path.
- Coordinate click semantics on HiDPI displays, including whether coordinate click should accept `window_id` for multi-window disambiguation.
- Idle CPU around 52-54% in the driver process.
- Whether the removed `screenshot` tool is intentionally replaced by `get_window_state(capture_mode=vision)`.

`screenshot_out_file` remains useful as an optional payload-size mitigation, but it is not the primary fix for this bug. The transport timeout/backpressure behavior is the bug addressed here.

## Validation

- `cargo test -p cua-driver daemon_response_read_tests`
- `git diff --check`
- local `install-local.sh` rebuild and CuaDriver daemon restart
- forced MCP proxy reproduction with a fake daemon delaying `get_window_state` for 12 seconds; the call succeeds instead of failing at the old ~10-second transport timeout
