### PR TITLE
fix(computer-server): serve MCP at both /mcp and /mcp/

### DIFF
--- a/libs/python/computer-server/computer_server/main.py
+++ b/libs/python/computer-server/computer_server/main.py
@@ -188,6 +188,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 class McpBarePathRewrite:
     """Serve the MCP app at both /mcp and /mcp/.
 
@@ -1192,10 +1193,8 @@ async def agent_response_endpoint(
                 #
                 # See: https://github.com/trycua/cua/issues/1605
                 import unicodedata
-                if (
-                    len(key) == 1
-                    and unicodedata.category(key) not in ("Cc", "Cs", "Cn")
-                ):
+
+                if len(key) == 1 and unicodedata.category(key) not in ("Cc", "Cs", "Cn"):
                     await self._auto.type_text(key)
                 else:
                     await self._auto.press_key(key)

--- a/libs/python/computer-server/computer_server/main.py
+++ b/libs/python/computer-server/computer_server/main.py
@@ -188,9 +188,30 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+class McpBarePathRewrite:
+    """Serve the MCP app at both /mcp and /mcp/.
+
+    Starlette's Mount only matches "/mcp/..." — a bare "/mcp" resolves
+    to inner path "" and 404s, and redirect_slashes=False on the outer
+    app disables the 307 rescue. Most MCP clients (claude.ai included)
+    POST to the bare path, so rewrite it before routing. A rewrite
+    (not a redirect) keeps POST bodies and SSE streaming intact; pure
+    ASGI (not BaseHTTPMiddleware) so responses aren't buffered.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http" and scope["path"] == "/mcp":
+            scope = dict(scope, path="/mcp/")
+        await self.app(scope, receive, send)
+
+
 # Mount MCP server at /mcp - FastMCP's internal path is "/" so endpoint is /mcp
 if _mcp_http_app:
     app.mount("/mcp", _mcp_http_app)
+    app.add_middleware(McpBarePathRewrite)
 
 protocol_version = 1
 try:

--- a/libs/python/computer-server/tests/test_server.py
+++ b/libs/python/computer-server/tests/test_server.py
@@ -38,3 +38,46 @@ class TestServerInitialization:
         except Exception as e:
             # Some initialization errors are acceptable in unit tests
             pytest.skip(f"Server initialization requires specific setup: {e}")
+
+
+class TestMcpBarePathRewrite:
+    """Test the ASGI shim that serves MCP at both /mcp and /mcp/ (SRP:
+    Only tests the path rewrite). The class is pure ASGI with no
+    dependencies, so it is tested standalone against a recording stub."""
+
+    @pytest.mark.asyncio
+    async def test_bare_mcp_path_is_rewritten(self):
+        try:
+            from computer_server.main import McpBarePathRewrite
+        except ImportError:
+            pytest.skip("computer_server module not installed")
+        except Exception as e:
+            pytest.skip(f"Server initialization requires specific setup: {e}")
+
+        seen = {}
+
+        async def inner(scope, receive, send):
+            seen.update(scope)
+
+        shim = McpBarePathRewrite(inner)
+        await shim({"type": "http", "path": "/mcp"}, None, None)
+        assert seen["path"] == "/mcp/"
+
+    @pytest.mark.asyncio
+    async def test_other_paths_untouched(self):
+        try:
+            from computer_server.main import McpBarePathRewrite
+        except ImportError:
+            pytest.skip("computer_server module not installed")
+        except Exception as e:
+            pytest.skip(f"Server initialization requires specific setup: {e}")
+
+        seen = {}
+
+        async def inner(scope, receive, send):
+            seen.update(scope)
+
+        shim = McpBarePathRewrite(inner)
+        for path in ("/mcp/", "/mcpx", "/status", "/"):
+            await shim({"type": "http", "path": path}, None, None)
+            assert seen["path"] == path


### PR DESCRIPTION
## Problem

The MCP app is mounted at `/mcp` with its internal route at `/`, and the outer FastAPI app sets `redirect_slashes=False`. Starlette's `Mount` only matches `/mcp/...`, so a bare `POST /mcp` resolves to inner path `""` → 404, with no 307 rescue. Most MCP clients (claude.ai connectors included) POST to the bare path — for them the MCP server is unreachable even though `/status` advertises the `mcp` feature and the StreamableHTTP session manager is running.

Observed live on a Windows KubeVirt guest running `cua-computer-server`: `POST /mcp` → `404 {"detail":"Not Found"}` while `POST /mcp/` → `200` + `Mcp-Session-Id` from the same process.

## Fix

A small pure-ASGI middleware rewrites bare `/mcp` → `/mcp/` before routing, so both literal forms answer directly:

- **rewrite, not redirect** — POSTed initialize bodies and SSE streams survive; some MCP clients don't follow 307s on POST
- **plain ASGI, not `BaseHTTPMiddleware`** — no response buffering on the MCP event stream
- all other paths pass through untouched

Includes standalone unit tests for the shim (no server deps needed, following the existing skip-on-missing-import style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the MCP app endpoint was not directly accessible at the `/mcp` path without redirects or buffering delays. The endpoint now responds correctly at the bare path.

* **Tests**
  * Added comprehensive tests to verify the MCP path rewrite functionality and ensure other routes remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->