### PR TITLE
fix(readme): stop product cards overflowing the README column

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,24 +27,24 @@
     <tr>
       <td colspan="3" align="center">
         <a href="#cua-drivers---background-computer-use-on-macos-and-windows-with-linux-pre-release">
-          <img src="img/card-cua-driver.gif" alt="Cua Drivers — background computer-use for any agent" width="888">
+          <img src="img/card-cua-driver.gif" alt="Cua Drivers — background computer-use for any agent" width="790">
         </a>
       </td>
     </tr>
     <tr>
       <td align="center">
         <a href="#cua---agent-ready-sandboxes-for-any-os">
-          <img src="img/card-cua-sandbox.gif" alt="Cua &amp; Cua Sandbox" width="280">
+          <img src="img/card-cua-sandbox.gif" alt="Cua &amp; Cua Sandbox" width="246">
         </a>
       </td>
       <td align="center">
         <a href="#cua-bench---benchmarks--rl-environments">
-          <img src="img/card-cua-bench.gif" alt="Cua Bench" width="280">
+          <img src="img/card-cua-bench.gif" alt="Cua Bench" width="246">
         </a>
       </td>
       <td align="center">
         <a href="#lume---macos-virtualization">
-          <img src="img/card-cua-lume.gif" alt="Lume" width="280">
+          <img src="img/card-cua-lume.gif" alt="Lume" width="246">
         </a>
       </td>
     </tr>


### PR DESCRIPTION
## Problem

The product-card table rendered at **922px** wide against GitHub's **~838px** README content column (measured on the live repo page), so the cards pushed a horizontal scrollbar onto the page.

## Fix

Reduce the fixed widths so the table fits with margin (simulated against an 838px column → ~820px, no overflow):
- Driver card: `888` → `790`
- Small cards: `280` → `246` each

The GIFs keep their larger intrinsic dimensions, so they downscale crisply — no re-encoding needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Adjusted image dimensions in the "Choose Your Path" section for improved layout and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->