### PR TITLE
feat(computer): support Apple container runtime

### DIFF
--- a/libs/python/computer/computer/computer.py
+++ b/libs/python/computer/computer/computer.py
@@ -465,6 +465,7 @@ class Computer:
                                     ephemeral=ephemeral,
                                     noVNC_port=noVNC_port,
                                     api_port=self.api_port,
+                                    runtime=self.custom_run_opts.get("container_runtime"),
                                 )
                             else:
                                 raise ValueError(f"Unsupported provider type: {self.provider_type}")

--- a/libs/python/computer/computer/providers/docker/__init__.py
+++ b/libs/python/computer/computer/providers/docker/__init__.py
@@ -1,14 +1,20 @@
 """Docker provider for running containers with computer-server."""
 
+import subprocess
+
 from .provider import DockerProvider
 
 # Check if Docker is available
 try:
-    import subprocess
-
     subprocess.run(["docker", "--version"], capture_output=True, check=True)
     HAS_DOCKER = True
 except (subprocess.SubprocessError, FileNotFoundError):
     HAS_DOCKER = False
 
-__all__ = ["DockerProvider", "HAS_DOCKER"]
+try:
+    subprocess.run(["container", "system", "version"], capture_output=True, check=True)
+    HAS_CONTAINER = True
+except (subprocess.SubprocessError, FileNotFoundError):
+    HAS_CONTAINER = False
+
+__all__ = ["DockerProvider", "HAS_DOCKER", "HAS_CONTAINER"]

--- a/libs/python/computer/computer/providers/docker/provider.py
+++ b/libs/python/computer/computer/providers/docker/provider.py
@@ -9,6 +9,7 @@ commands and container management.
 import asyncio
 import json
 import logging
+import os
 import re
 import subprocess
 import time
@@ -26,6 +27,45 @@ try:
     HAS_DOCKER = True
 except (subprocess.SubprocessError, FileNotFoundError):
     HAS_DOCKER = False
+
+try:
+    subprocess.run(["container", "system", "version"], capture_output=True, check=True)
+    HAS_CONTAINER = True
+except (subprocess.SubprocessError, FileNotFoundError):
+    HAS_CONTAINER = False
+
+
+class ContainerRuntime:
+    DOCKER = "docker"
+    APPLE_CONTAINER = "container"
+
+
+def _normalize_runtime(runtime: Optional[str]) -> str:
+    value = (runtime or os.environ.get("CUA_CONTAINER_RUNTIME") or ContainerRuntime.DOCKER).lower()
+    aliases = {
+        "docker": ContainerRuntime.DOCKER,
+        "apple": ContainerRuntime.APPLE_CONTAINER,
+        "apple-container": ContainerRuntime.APPLE_CONTAINER,
+        "apple_container": ContainerRuntime.APPLE_CONTAINER,
+        "container": ContainerRuntime.APPLE_CONTAINER,
+    }
+    if value not in aliases:
+        raise ValueError(
+            f"Unsupported container runtime '{runtime}'. Use 'docker' or 'container'."
+        )
+    return aliases[value]
+
+
+def _normalize_image_ref(image: Any) -> str:
+    if isinstance(image, dict):
+        image = image.get("reference") or image.get("name") or ""
+    if not isinstance(image, str):
+        return ""
+    if image.startswith("docker.io/library/"):
+        return image.removeprefix("docker.io/library/")
+    if image.startswith("docker.io/"):
+        return image.removeprefix("docker.io/")
+    return image
 
 
 class DockerProvider(BaseVMProvider):
@@ -46,6 +86,7 @@ class DockerProvider(BaseVMProvider):
         ephemeral: bool = False,
         vnc_port: Optional[int] = 6901,
         api_port: Optional[int] = None,
+        runtime: Optional[str] = None,
     ):
         """Initialize the Docker VM Provider.
 
@@ -64,11 +105,22 @@ class DockerProvider(BaseVMProvider):
             ephemeral: Use ephemeral (temporary) storage
             vnc_port: Port for VNC interface (default: 6901)
             api_port: Port for API server (default: 8000)
+            runtime: Container runtime CLI to use: "docker" or Apple "container".
+                     Defaults to CUA_CONTAINER_RUNTIME or "docker".
         """
         self.host = host
         self.api_port = api_port if api_port is not None else 8000
         self.vnc_port = vnc_port
         self.ephemeral = ephemeral
+        self.runtime = _normalize_runtime(runtime)
+
+        if self.runtime == ContainerRuntime.DOCKER and not HAS_DOCKER:
+            raise RuntimeError("Docker is required when runtime='docker'.")
+        if self.runtime == ContainerRuntime.APPLE_CONTAINER and not HAS_CONTAINER:
+            raise RuntimeError(
+                "Apple container CLI is required when runtime='container'. "
+                "Install https://github.com/apple/container and run 'container system start'."
+            )
 
         self.shared_path = shared_path
         self.image = image
@@ -90,6 +142,109 @@ class DockerProvider(BaseVMProvider):
             self.storage = "ephemeral"  # Handle ephemeral storage (temporary directory)
         else:
             self.storage = storage
+
+    def _runtime_provider_name(self) -> str:
+        return "container" if self.runtime == ContainerRuntime.APPLE_CONTAINER else "docker"
+
+    def _ensure_runtime_available(self) -> None:
+        if self.runtime == ContainerRuntime.DOCKER and not HAS_DOCKER:
+            raise RuntimeError("Docker is required when runtime='docker'.")
+        if self.runtime == ContainerRuntime.APPLE_CONTAINER and not HAS_CONTAINER:
+            raise RuntimeError(
+                "Apple container CLI is required when runtime='container'. "
+                "Install https://github.com/apple/container and run 'container system start'."
+            )
+
+    def _inspect_cmd(self, name: str) -> List[str]:
+        if self.runtime == ContainerRuntime.APPLE_CONTAINER:
+            return ["container", "inspect", name]
+        return ["docker", "inspect", name]
+
+    def _list_cmd(self) -> List[str]:
+        if self.runtime == ContainerRuntime.APPLE_CONTAINER:
+            return ["container", "list", "--all", "--format", "json"]
+        return ["docker", "ps", "-a", "--filter", f"ancestor={self.image}", "--format", "json"]
+
+    def _delete_cmd(self, name: str, force: bool = False) -> List[str]:
+        if self.runtime == ContainerRuntime.APPLE_CONTAINER:
+            cmd = ["container", "delete"]
+            if force:
+                cmd.append("--force")
+            return [*cmd, name]
+        return ["docker", "rm", *( ["-f"] if force else [] ), name]
+
+    def _start_cmd(self, name: str) -> List[str]:
+        return [self._runtime_provider_name(), "start", name]
+
+    def _stop_cmd(self, name: str) -> List[str]:
+        return [self._runtime_provider_name(), "stop", name]
+
+    def _run_cmd(self, name: str) -> List[str]:
+        return [self._runtime_provider_name(), "run", "-d", "--name", name]
+
+    def _parse_inspect(self, name: str, container_info: Dict[str, Any]) -> Dict[str, Any]:
+        if self.runtime == ContainerRuntime.APPLE_CONTAINER:
+            status = container_info.get("status", "unknown")
+            if isinstance(status, dict):
+                status = status.get("state", "unknown")
+            configuration = container_info.get("configuration", {})
+            image = container_info.get("image") or configuration.get("image") or self.image
+            image = _normalize_image_ref(image) or self.image
+            networks = container_info.get("networks") or []
+            ip_address = None
+            if networks:
+                address = networks[0].get("address")
+                ip_address = address.split("/", 1)[0] if address else None
+
+            return {
+                "name": configuration.get("id", name),
+                "status": "running" if status == "running" else status,
+                "ip_address": ip_address or "127.0.0.1",
+                "ports": {},
+                "image": image,
+                "provider": self._runtime_provider_name(),
+                "container_id": configuration.get("id", name),
+                "created": container_info.get("created", ""),
+                "started": container_info.get("started", ""),
+            }
+
+        state = container_info["State"]
+        network_settings = container_info["NetworkSettings"]
+
+        if state["Running"]:
+            status = "running"
+        elif state["Paused"]:
+            status = "paused"
+        else:
+            status = "stopped"
+
+        ip_address = network_settings.get("IPAddress", "")
+        if not ip_address and "Networks" in network_settings:
+            for network_info in network_settings["Networks"].values():
+                if network_info.get("IPAddress"):
+                    ip_address = network_info["IPAddress"]
+                    break
+
+        ports = {}
+        if "Ports" in network_settings and network_settings["Ports"]:
+            for container_port, port_mappings in network_settings["Ports"].items():
+                if port_mappings:
+                    for mapping in port_mappings:
+                        if mapping.get("HostPort"):
+                            ports[container_port] = mapping["HostPort"]
+                            break
+
+        return {
+            "name": name,
+            "status": status,
+            "ip_address": ip_address or "127.0.0.1",
+            "ports": ports,
+            "image": container_info["Config"]["Image"],
+            "provider": self._runtime_provider_name(),
+            "container_id": container_info["Id"][:12],
+            "created": container_info["Created"],
+            "started": state.get("StartedAt", ""),
+        }
 
     def _detect_image_config(self):
         """Detect image type and configure paths accordingly."""
@@ -164,7 +319,7 @@ class DockerProvider(BaseVMProvider):
         """
         try:
             # Check if container exists and get its status
-            cmd = ["docker", "inspect", name]
+            cmd = self._inspect_cmd(name)
             result = subprocess.run(cmd, capture_output=True, text=True)
 
             if result.returncode != 0:
@@ -175,76 +330,49 @@ class DockerProvider(BaseVMProvider):
                     "ip_address": None,
                     "ports": {},
                     "image": self.image,
-                    "provider": "docker",
+                    "provider": self._runtime_provider_name(),
                 }
 
             # Parse container info
             container_info = json.loads(result.stdout)[0]
-            state = container_info["State"]
-            network_settings = container_info["NetworkSettings"]
-
-            # Determine status
-            if state["Running"]:
-                status = "running"
-            elif state["Paused"]:
-                status = "paused"
-            else:
-                status = "stopped"
-
-            # Get IP address
-            ip_address = network_settings.get("IPAddress", "")
-            if not ip_address and "Networks" in network_settings:
-                # Try to get IP from bridge network
-                for network_name, network_info in network_settings["Networks"].items():
-                    if network_info.get("IPAddress"):
-                        ip_address = network_info["IPAddress"]
-                        break
-
-            # Get port mappings
-            ports = {}
-            if "Ports" in network_settings and network_settings["Ports"]:
-                # network_settings["Ports"] is a dict like:
-                # {'6901/tcp': [{'HostIp': '0.0.0.0', 'HostPort': '6901'}, ...], ...}
-                for container_port, port_mappings in network_settings["Ports"].items():
-                    if port_mappings:  # Check if there are any port mappings
-                        # Take the first mapping (usually the IPv4 one)
-                        for mapping in port_mappings:
-                            if mapping.get("HostPort"):
-                                ports[container_port] = mapping["HostPort"]
-                                break  # Use the first valid mapping
-
-            return {
-                "name": name,
-                "status": status,
-                "ip_address": ip_address or "127.0.0.1",  # Use localhost if no IP
-                "ports": ports,
-                "image": container_info["Config"]["Image"],
-                "provider": "docker",
-                "container_id": container_info["Id"][:12],  # Short ID
-                "created": container_info["Created"],
-                "started": state.get("StartedAt", ""),
-            }
+            return self._parse_inspect(name, container_info)
 
         except Exception as e:
             logger.error(f"Error getting VM info for {name}: {e}")
             import traceback
 
             traceback.print_exc()
-            return {"name": name, "status": "error", "error": str(e), "provider": "docker"}
+            return {
+                "name": name,
+                "status": "error",
+                "error": str(e),
+                "provider": self._runtime_provider_name(),
+            }
 
     async def list_vms(self) -> List[Dict[str, Any]]:
         """List all Docker containers managed by this provider."""
         try:
             # List all containers (running and stopped) with the Cua image
-            cmd = ["docker", "ps", "-a", "--filter", f"ancestor={self.image}", "--format", "json"]
+            cmd = self._list_cmd()
             result = subprocess.run(cmd, capture_output=True, text=True, check=True)
 
             containers = []
             if result.stdout.strip():
-                for line in result.stdout.strip().split("\n"):
+                lines = result.stdout.strip().split("\n")
+                if self.runtime == ContainerRuntime.APPLE_CONTAINER and result.stdout.lstrip().startswith("["):
+                    lines = [json.dumps(item) for item in json.loads(result.stdout)]
+                for line in lines:
                     if line.strip():
                         container_data = json.loads(line)
-                        vm_info = await self.get_vm(container_data["Names"])
+                        container_name = container_data.get("Names") or container_data.get("id") or container_data.get("configuration", {}).get("id")
+                        image = container_data.get("Image") or container_data.get("image") or container_data.get("configuration", {}).get("image")
+                        if (
+                            self.runtime == ContainerRuntime.APPLE_CONTAINER
+                            and image
+                            and _normalize_image_ref(image) != _normalize_image_ref(self.image)
+                        ):
+                            continue
+                        vm_info = await self.get_vm(container_name)
                         containers.append(vm_info)
 
             return containers
@@ -278,6 +406,10 @@ class DockerProvider(BaseVMProvider):
         """
         try:
             # Check if container already exists
+            if "container_runtime" in run_opts:
+                self.runtime = _normalize_runtime(run_opts["container_runtime"])
+                self._ensure_runtime_available()
+
             existing_vm = await self.get_vm(name, storage)
             if existing_vm["status"] == "running":
                 logger.info(f"Container {name} is already running")
@@ -286,12 +418,12 @@ class DockerProvider(BaseVMProvider):
                 if self.ephemeral:
                     # Delete existing container
                     logger.info(f"Deleting existing container {name}")
-                    delete_cmd = ["docker", "rm", name]
+                    delete_cmd = self._delete_cmd(name, force=True)
                     result = subprocess.run(delete_cmd, capture_output=True, text=True, check=True)
                 else:
                     # Start existing container
                     logger.info(f"Starting existing container {name}")
-                    start_cmd = ["docker", "start", name]
+                    start_cmd = self._start_cmd(name)
                     result = subprocess.run(start_cmd, capture_output=True, text=True, check=True)
 
                     # Wait for container to be ready
@@ -299,10 +431,10 @@ class DockerProvider(BaseVMProvider):
                     return await self.get_vm(name, storage)
 
             # Use provided image or default
-            docker_image = image if image != "default" else self.image
+            runtime_image = image if image != "default" else self.image
 
             # Build docker run command
-            cmd = ["docker", "run", "-d", "--name", name]
+            cmd = self._run_cmd(name)
 
             # Add memory limit if specified
             if "memory" in run_opts:
@@ -404,9 +536,11 @@ class DockerProvider(BaseVMProvider):
                 )
 
             # Add the image
-            cmd.append(docker_image)
+            cmd.append(runtime_image)
 
-            logger.info(f"Running Docker container with command: {' '.join(cmd)}")
+            logger.info(
+                f"Running {self._runtime_provider_name()} container with command: {' '.join(cmd)}"
+            )
 
             # Run the container
             result = subprocess.run(cmd, capture_output=True, text=True, check=True)
@@ -430,11 +564,21 @@ class DockerProvider(BaseVMProvider):
         except subprocess.CalledProcessError as e:
             error_msg = f"Failed to run container {name}: {e.stderr}"
             logger.error(error_msg)
-            return {"name": name, "status": "error", "error": error_msg, "provider": "docker"}
+            return {
+                "name": name,
+                "status": "error",
+                "error": error_msg,
+                "provider": self._runtime_provider_name(),
+            }
         except Exception as e:
             error_msg = f"Error running VM {name}: {e}"
             logger.error(error_msg)
-            return {"name": name, "status": "error", "error": error_msg, "provider": "docker"}
+            return {
+                "name": name,
+                "status": "error",
+                "error": error_msg,
+                "provider": self._runtime_provider_name(),
+            }
 
     async def _wait_for_container_ready(self, container_name: str, timeout: int = 60) -> bool:
         """Wait for the Docker container to be fully ready.
@@ -475,7 +619,7 @@ class DockerProvider(BaseVMProvider):
             logger.info(f"Stopping container {name}")
 
             # Stop the container
-            cmd = ["docker", "stop", name]
+            cmd = self._stop_cmd(name)
             result = subprocess.run(cmd, capture_output=True, text=True, check=True)
 
             # Remove from running containers tracking
@@ -486,24 +630,34 @@ class DockerProvider(BaseVMProvider):
 
             # Delete container if ephemeral=True
             if self.ephemeral:
-                cmd = ["docker", "rm", name]
+                cmd = self._delete_cmd(name)
                 result = subprocess.run(cmd, capture_output=True, text=True, check=True)
 
             return {
                 "name": name,
                 "status": "stopped",
                 "message": "Container stopped successfully",
-                "provider": "docker",
+                "provider": self._runtime_provider_name(),
             }
 
         except subprocess.CalledProcessError as e:
             error_msg = f"Failed to stop container {name}: {e.stderr}"
             logger.error(error_msg)
-            return {"name": name, "status": "error", "error": error_msg, "provider": "docker"}
+            return {
+                "name": name,
+                "status": "error",
+                "error": error_msg,
+                "provider": self._runtime_provider_name(),
+            }
         except Exception as e:
             error_msg = f"Error stopping VM {name}: {e}"
             logger.error(error_msg)
-            return {"name": name, "status": "error", "error": error_msg, "provider": "docker"}
+            return {
+                "name": name,
+                "status": "error",
+                "error": error_msg,
+                "provider": self._runtime_provider_name(),
+            }
 
     async def restart_vm(self, name: str, storage: Optional[str] = None) -> Dict[str, Any]:
         raise NotImplementedError("DockerProvider does not support restarting VMs.")

--- a/libs/python/computer/computer/providers/docker/provider.py
+++ b/libs/python/computer/computer/providers/docker/provider.py
@@ -51,7 +51,7 @@ def _normalize_runtime(runtime: Optional[str]) -> str:
     }
     if value not in aliases:
         raise ValueError(
-            f"Unsupported container runtime '{runtime}'. Use 'docker' or 'container'."
+            f"Unsupported container runtime '{value}'. Use 'docker' or 'container'."
         )
     return aliases[value]
 
@@ -406,10 +406,6 @@ class DockerProvider(BaseVMProvider):
         """
         try:
             # Check if container already exists
-            if "container_runtime" in run_opts:
-                self.runtime = _normalize_runtime(run_opts["container_runtime"])
-                self._ensure_runtime_available()
-
             existing_vm = await self.get_vm(name, storage)
             if existing_vm["status"] == "running":
                 logger.info(f"Container {name} is already running")
@@ -674,7 +670,7 @@ class DockerProvider(BaseVMProvider):
             "name": name,
             "status": "error",
             "error": "Docker containers cannot be updated while running. Please stop and recreate the container with new options.",
-            "provider": "docker",
+            "provider": self._runtime_provider_name(),
         }
 
     async def get_ip(self, name: str, storage: Optional[str] = None, retry_delay: int = 2) -> str:

--- a/libs/python/computer/computer/providers/factory.py
+++ b/libs/python/computer/computer/providers/factory.py
@@ -154,24 +154,9 @@ class VMProviderFactory:
                 ) from e
         elif provider_type == VMProviderType.DOCKER:
             try:
-                import os
-
-                from .docker import HAS_CONTAINER, HAS_DOCKER, DockerProvider
+                from .docker import DockerProvider
 
                 runtime = kwargs.get("runtime") or kwargs.get("container_runtime")
-                runtime = (runtime or os.environ.get("CUA_CONTAINER_RUNTIME") or "docker").lower()
-                uses_apple_container = runtime in {"apple", "apple-container", "apple_container", "container"}
-
-                if not HAS_DOCKER and not uses_apple_container:
-                    raise ImportError(
-                        "Docker is required for DockerProvider. "
-                        "Please install Docker and ensure it is running."
-                    )
-                if uses_apple_container and not HAS_CONTAINER:
-                    raise ImportError(
-                        "Apple container CLI is required for DockerProvider with runtime='container'. "
-                        "Install https://github.com/apple/container and run 'container system start'."
-                    )
                 return DockerProvider(
                     host=host,
                     storage=storage,

--- a/libs/python/computer/computer/providers/factory.py
+++ b/libs/python/computer/computer/providers/factory.py
@@ -154,12 +154,23 @@ class VMProviderFactory:
                 ) from e
         elif provider_type == VMProviderType.DOCKER:
             try:
-                from .docker import HAS_DOCKER, DockerProvider
+                import os
 
-                if not HAS_DOCKER:
+                from .docker import HAS_CONTAINER, HAS_DOCKER, DockerProvider
+
+                runtime = kwargs.get("runtime") or kwargs.get("container_runtime")
+                runtime = (runtime or os.environ.get("CUA_CONTAINER_RUNTIME") or "docker").lower()
+                uses_apple_container = runtime in {"apple", "apple-container", "apple_container", "container"}
+
+                if not HAS_DOCKER and not uses_apple_container:
                     raise ImportError(
                         "Docker is required for DockerProvider. "
                         "Please install Docker and ensure it is running."
+                    )
+                if uses_apple_container and not HAS_CONTAINER:
+                    raise ImportError(
+                        "Apple container CLI is required for DockerProvider with runtime='container'. "
+                        "Install https://github.com/apple/container and run 'container system start'."
                     )
                 return DockerProvider(
                     host=host,
@@ -170,6 +181,7 @@ class VMProviderFactory:
                     ephemeral=ephemeral,
                     vnc_port=noVNC_port,
                     api_port=api_port,
+                    runtime=runtime,
                 )
             except ImportError as e:
                 logger.error(f"Failed to import DockerProvider: {e}")

--- a/libs/python/computer/tests/test_docker_provider_runtime.py
+++ b/libs/python/computer/tests/test_docker_provider_runtime.py
@@ -20,6 +20,15 @@ def test_normalize_container_runtime_rejects_unknown():
         _normalize_runtime("podman")
 
 
+def test_normalize_container_runtime_reports_env_value(monkeypatch):
+    from computer.providers.docker.provider import _normalize_runtime
+
+    monkeypatch.setenv("CUA_CONTAINER_RUNTIME", "podman")
+
+    with pytest.raises(ValueError, match="podman"):
+        _normalize_runtime(None)
+
+
 @patch("computer.providers.docker.provider.HAS_DOCKER", True)
 @patch("computer.providers.docker.provider.HAS_CONTAINER", True)
 def test_docker_runtime_commands_use_docker_cli():
@@ -51,6 +60,73 @@ def test_apple_container_runtime_commands_use_container_cli():
         "--force",
         "desktop",
     ]
+
+
+@patch("computer.providers.docker.provider.HAS_DOCKER", True)
+@patch("computer.providers.docker.provider.HAS_CONTAINER", True)
+def test_run_vm_container_runtime_option_does_not_mutate_provider_runtime():
+    from computer.providers.docker.provider import ContainerRuntime, DockerProvider
+
+    provider = DockerProvider(image="trycua/cua-xfce:latest", runtime="docker")
+
+    async def fake_get_vm(name, storage=None):
+        return {"status": "running", "name": name}
+
+    provider.get_vm = fake_get_vm
+
+    vm = asyncio.run(
+        provider.run_vm(
+            "trycua/cua-xfce:latest",
+            "desktop",
+            {"container_runtime": "container"},
+        )
+    )
+
+    assert vm["status"] == "running"
+    assert provider.runtime == ContainerRuntime.DOCKER
+
+
+@patch("computer.providers.docker.provider.HAS_DOCKER", True)
+@patch("computer.providers.docker.provider.HAS_CONTAINER", True)
+def test_update_vm_reports_active_runtime_provider():
+    from computer.providers.docker.provider import DockerProvider
+
+    provider = DockerProvider(image="trycua/cua-xfce:latest", runtime="container")
+
+    result = asyncio.run(provider.update_vm("desktop", {}))
+
+    assert result["provider"] == "container"
+
+
+def test_factory_preserves_apple_container_availability_errors(monkeypatch):
+    from computer.providers.base import VMProviderType
+    from computer.providers import factory as factory_module
+
+    class FakeDockerProvider:
+        def __init__(self, **kwargs):
+            raise RuntimeError("Apple container CLI is required when runtime='container'.")
+
+    monkeypatch.setattr(factory_module, "DockerProvider", FakeDockerProvider, raising=False)
+
+    with patch.dict(
+        "sys.modules",
+        {
+            "computer.providers.docker": type(
+                "FakeDockerModule",
+                (),
+                {
+                    "HAS_CONTAINER": True,
+                    "HAS_DOCKER": True,
+                    "DockerProvider": FakeDockerProvider,
+                },
+            ),
+        },
+    ):
+        with pytest.raises(RuntimeError, match="Apple container CLI"):
+            factory_module.VMProviderFactory.create_provider(
+                VMProviderType.DOCKER,
+                runtime="container",
+            )
 
 
 @patch("computer.providers.docker.provider.HAS_DOCKER", True)

--- a/libs/python/computer/tests/test_docker_provider_runtime.py
+++ b/libs/python/computer/tests/test_docker_provider_runtime.py
@@ -1,0 +1,147 @@
+import asyncio
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+def test_normalize_container_runtime_aliases():
+    from computer.providers.docker.provider import ContainerRuntime, _normalize_runtime
+
+    assert _normalize_runtime("docker") == ContainerRuntime.DOCKER
+    assert _normalize_runtime("container") == ContainerRuntime.APPLE_CONTAINER
+    assert _normalize_runtime("apple-container") == ContainerRuntime.APPLE_CONTAINER
+
+
+def test_normalize_container_runtime_rejects_unknown():
+    from computer.providers.docker.provider import _normalize_runtime
+
+    with pytest.raises(ValueError):
+        _normalize_runtime("podman")
+
+
+@patch("computer.providers.docker.provider.HAS_DOCKER", True)
+@patch("computer.providers.docker.provider.HAS_CONTAINER", True)
+def test_docker_runtime_commands_use_docker_cli():
+    from computer.providers.docker.provider import DockerProvider
+
+    provider = DockerProvider(image="trycua/cua-xfce:latest", runtime="docker")
+
+    assert provider._run_cmd("desktop") == ["docker", "run", "-d", "--name", "desktop"]
+    assert provider._inspect_cmd("desktop") == ["docker", "inspect", "desktop"]
+    assert provider._start_cmd("desktop") == ["docker", "start", "desktop"]
+    assert provider._stop_cmd("desktop") == ["docker", "stop", "desktop"]
+    assert provider._delete_cmd("desktop", force=True) == ["docker", "rm", "-f", "desktop"]
+
+
+@patch("computer.providers.docker.provider.HAS_DOCKER", True)
+@patch("computer.providers.docker.provider.HAS_CONTAINER", True)
+def test_apple_container_runtime_commands_use_container_cli():
+    from computer.providers.docker.provider import DockerProvider
+
+    provider = DockerProvider(image="trycua/cua-xfce:latest", runtime="container")
+
+    assert provider._run_cmd("desktop") == ["container", "run", "-d", "--name", "desktop"]
+    assert provider._inspect_cmd("desktop") == ["container", "inspect", "desktop"]
+    assert provider._start_cmd("desktop") == ["container", "start", "desktop"]
+    assert provider._stop_cmd("desktop") == ["container", "stop", "desktop"]
+    assert provider._delete_cmd("desktop", force=True) == [
+        "container",
+        "delete",
+        "--force",
+        "desktop",
+    ]
+
+
+@patch("computer.providers.docker.provider.HAS_DOCKER", True)
+@patch("computer.providers.docker.provider.HAS_CONTAINER", True)
+def test_parse_apple_container_inspect_json():
+    from computer.providers.docker.provider import DockerProvider
+
+    provider = DockerProvider(image="trycua/cua-xfce:latest", runtime="container")
+    info = provider._parse_inspect(
+        "desktop",
+        {
+            "status": "running",
+            "image": "trycua/cua-xfce:latest",
+            "configuration": {"id": "desktop"},
+            "networks": [{"address": "192.168.64.3/24"}],
+        },
+    )
+
+    assert info["name"] == "desktop"
+    assert info["status"] == "running"
+    assert info["ip_address"] == "192.168.64.3"
+    assert info["image"] == "trycua/cua-xfce:latest"
+    assert info["provider"] == "container"
+
+
+@patch("computer.providers.docker.provider.HAS_DOCKER", True)
+@patch("computer.providers.docker.provider.HAS_CONTAINER", True)
+def test_parse_apple_container_inspect_json_objects():
+    from computer.providers.docker.provider import DockerProvider
+
+    provider = DockerProvider(image="trycua/cua-xfce:latest", runtime="container")
+    info = provider._parse_inspect(
+        "desktop",
+        {
+            "status": {"state": "running", "networks": []},
+            "image": {"reference": "docker.io/trycua/cua-xfce:latest"},
+            "configuration": {"id": "desktop"},
+            "networks": [{"address": "192.168.64.3/24"}],
+        },
+    )
+
+    assert info["status"] == "running"
+    assert info["image"] == "trycua/cua-xfce:latest"
+
+
+@patch("computer.providers.docker.provider.HAS_DOCKER", True)
+@patch("computer.providers.docker.provider.HAS_CONTAINER", True)
+def test_apple_container_list_vms_matches_normalized_image():
+    from computer.providers.docker.provider import DockerProvider
+
+    provider = DockerProvider(image="trycua/cua-xfce:latest", runtime="container")
+    list_output = json.dumps(
+        [
+            {
+                "id": "desktop",
+                "image": {"reference": "docker.io/trycua/cua-xfce:latest"},
+            },
+            {
+                "id": "other",
+                "image": {"reference": "docker.io/library/alpine:latest"},
+            },
+        ]
+    )
+    inspect_output = json.dumps(
+        [
+            {
+                "status": {"state": "running"},
+                "image": {"reference": "docker.io/trycua/cua-xfce:latest"},
+                "configuration": {"id": "desktop"},
+                "networks": [{"address": "192.168.64.3/24"}],
+            }
+        ]
+    )
+
+    def fake_run(cmd, capture_output=True, text=True, check=False):
+        class Result:
+            returncode = 0
+            stderr = ""
+
+        result = Result()
+        if cmd[:2] == ["container", "list"]:
+            result.stdout = list_output
+        elif cmd[:2] == ["container", "inspect"]:
+            result.stdout = inspect_output
+        else:
+            raise AssertionError(f"unexpected command: {cmd}")
+        return result
+
+    with patch("computer.providers.docker.provider.subprocess.run", side_effect=fake_run):
+        vms = asyncio.run(provider.list_vms())
+
+    assert len(vms) == 1
+    assert vms[0]["name"] == "desktop"
+    assert vms[0]["image"] == "trycua/cua-xfce:latest"


### PR DESCRIPTION
## Summary
- Add Apple container CLI runtime support to the existing DockerProvider
- Allow selecting the runtime with run_opts={"container_runtime": "container"} or CUA_CONTAINER_RUNTIME=container
- Normalize Apple container image/inspect/list output and keep Docker as the default runtime
- Add unit coverage for runtime command generation, inspect parsing, and list_vms image matching

## Related PR check
- Searched open PRs for exact Apple container runtime terms: no matching PRs found
- Reviewed related open PRs #1442 and #471; they cover CloudV2 user Docker images and Docker API port handling, not Apple container runtime support

## Verification
- uv run --directory libs/python/computer --with ruff ruff check computer tests
- uv run --directory libs/python/computer --with pytest pytest -q
- uv run --directory libs/python/computer python -m py_compile computer/providers/docker/provider.py computer/providers/docker/__init__.py computer/providers/factory.py computer/computer.py tests/test_docker_provider_runtime.py
- container run --rm alpine:latest uname -m
- Real provider smoke test: started trycua/cua-xfce:latest with runtime=container, observed status=running, then stopped/deleted it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for alternate container runtimes alongside Docker, enabling users to configure their preferred container execution environment.

* **Tests**
  * Added comprehensive test coverage for runtime selection, command generation, and container inspection across different runtime types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->