### PR TITLE
Add native-Wayland TDD test suite for cua-driver

### DIFF
--- a/.github/workflows/nix-wayland.yml
+++ b/.github/workflows/nix-wayland.yml
@@ -1,0 +1,205 @@
+name: CUA Driver Native-Wayland TDD Suite
+
+# Native-Wayland reproduction of the cua-driver NixOS tests across five desktop
+# sessions (XFCE on labwc/wayfire/sway, plus KDE and GNOME). These are a TDD
+# RED suite: the driver is X11-only today, so they are EXPECTED TO FAIL until
+# native Wayland support lands. They therefore never gate a PR — this workflow
+# is opt-in (manual dispatch, or the `cua-driver-wayland` PR label) and every
+# job is continue-on-error. Artifacts (screenshots, GIFs, logs) are uploaded so
+# you can see exactly what each compositor does.
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+env:
+  AWS_REGION: us-west-2
+  NIX_CACHE_BUCKET: trycua-nix-cache
+  NIX_CACHE_SECRET: nix-cache/trycua-nix-cache/signing-key
+
+jobs:
+  wayland-scenarios:
+    name: ${{ matrix.desktop }} / ${{ matrix.scenario }}
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'cua-driver-wayland'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        desktop: [xfce-labwc, xfce-wayfire, xfce-sway, kde, gnome]
+        scenario:
+          - integration
+          - screenshot
+          - cursor-click-gif
+          - background-terminal-gif
+          - parallel-drag
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Configure AWS Credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
+        with:
+          role-to-assume: arn:aws:iam::296062593712:role/github-actions-nix-cache
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Get Nix signing key
+        id: nix-key
+        run: |
+          SECRET=$(aws secretsmanager get-secret-value \
+            --secret-id "${{ env.NIX_CACHE_SECRET }}" \
+            --query 'SecretString' --output text)
+          SECRET_KEY=$(echo "$SECRET" | jq -r '.secret_key')
+          echo "::add-mask::$SECRET_KEY"
+          echo "$SECRET_KEY" > "${{ runner.temp }}/signing-key.sec"
+          chmod 600 "${{ runner.temp }}/signing-key.sec"
+          PUBLIC_KEY=$(echo "$SECRET" | jq -r '.public_key')
+          echo "public_key=$PUBLIC_KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Setup AWS credentials file for Nix
+        run: |
+          mkdir -p ~/.aws
+          printf '[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\nregion = %s\n' \
+            "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY" "$AWS_SESSION_TOKEN" "$AWS_REGION" > ~/.aws/credentials
+          chmod 600 ~/.aws/credentials
+          sudo mkdir -p /root/.aws
+          sudo bash -c "printf '[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\nregion = %s\n' \
+            '$AWS_ACCESS_KEY_ID' '$AWS_SECRET_ACCESS_KEY' '$AWS_SESSION_TOKEN' '$AWS_REGION' > /root/.aws/credentials"
+          sudo chmod 600 /root/.aws/credentials
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            substituters = s3://${{ env.NIX_CACHE_BUCKET }}?region=${{ env.AWS_REGION }} https://cache.nixos.org
+            trusted-substituters = s3://${{ env.NIX_CACHE_BUCKET }}?region=${{ env.AWS_REGION }}
+            trusted-public-keys = ${{ steps.nix-key.outputs.public_key }} cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+
+      - name: Run cua-driver-wayland-${{ matrix.desktop }}-${{ matrix.scenario }}
+        continue-on-error: true
+        run: |
+          nix build ".#checks.x86_64-linux.cua-driver-wayland-${{ matrix.desktop }}-${{ matrix.scenario }}" \
+            --print-build-logs --show-trace \
+            -o "result-${{ matrix.desktop }}-${{ matrix.scenario }}" || true
+
+      - name: Collect artifacts
+        if: always()
+        run: |
+          mkdir -p artifacts
+          find -L "result-${{ matrix.desktop }}-${{ matrix.scenario }}/" \
+            \( -name '*.gif' -o -name '*.png' -o -name '*.json' \) -type f \
+            -exec cp {} artifacts/ \; 2>/dev/null || true
+          ls -la artifacts/ 2>/dev/null || echo "No artifacts found"
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: cua-driver-wayland-${{ matrix.desktop }}-${{ matrix.scenario }}
+          path: artifacts/*
+          if-no-files-found: warn
+
+      - name: Sign and upload to Nix cache
+        if: always()
+        run: |
+          nix store sign --key-file "${{ runner.temp }}/signing-key.sec" --all || true
+          nix copy --to "s3://${{ env.NIX_CACHE_BUCKET }}?region=${{ env.AWS_REGION }}&want-mass-query=true" --all -L || true
+
+      - name: Cleanup signing key
+        if: always()
+        run: rm -f "${{ runner.temp }}/signing-key.sec"
+
+  wayland-background-gui:
+    name: ${{ matrix.desktop }} / background-gui ${{ matrix.app }}
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'cua-driver-wayland'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        desktop: [xfce-labwc, xfce-wayfire, xfce-sway, kde, gnome]
+        app: [foot, gtk3-gedit, qt6-kcalc]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Configure AWS Credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
+        with:
+          role-to-assume: arn:aws:iam::296062593712:role/github-actions-nix-cache
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Get Nix signing key
+        id: nix-key
+        run: |
+          SECRET=$(aws secretsmanager get-secret-value \
+            --secret-id "${{ env.NIX_CACHE_SECRET }}" \
+            --query 'SecretString' --output text)
+          SECRET_KEY=$(echo "$SECRET" | jq -r '.secret_key')
+          echo "::add-mask::$SECRET_KEY"
+          echo "$SECRET_KEY" > "${{ runner.temp }}/signing-key.sec"
+          chmod 600 "${{ runner.temp }}/signing-key.sec"
+          PUBLIC_KEY=$(echo "$SECRET" | jq -r '.public_key')
+          echo "public_key=$PUBLIC_KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Setup AWS credentials file for Nix
+        run: |
+          mkdir -p ~/.aws
+          printf '[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\nregion = %s\n' \
+            "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY" "$AWS_SESSION_TOKEN" "$AWS_REGION" > ~/.aws/credentials
+          chmod 600 ~/.aws/credentials
+          sudo mkdir -p /root/.aws
+          sudo bash -c "printf '[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\nregion = %s\n' \
+            '$AWS_ACCESS_KEY_ID' '$AWS_SECRET_ACCESS_KEY' '$AWS_SESSION_TOKEN' '$AWS_REGION' > /root/.aws/credentials"
+          sudo chmod 600 /root/.aws/credentials
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            substituters = s3://${{ env.NIX_CACHE_BUCKET }}?region=${{ env.AWS_REGION }} https://cache.nixos.org
+            trusted-substituters = s3://${{ env.NIX_CACHE_BUCKET }}?region=${{ env.AWS_REGION }}
+            trusted-public-keys = ${{ steps.nix-key.outputs.public_key }} cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+
+      - name: Run cua-driver-wayland-${{ matrix.desktop }}-background-gui-${{ matrix.app }}
+        continue-on-error: true
+        run: |
+          nix build ".#checks.x86_64-linux.cua-driver-wayland-${{ matrix.desktop }}-background-gui-${{ matrix.app }}" \
+            --print-build-logs --show-trace \
+            -o "result-${{ matrix.desktop }}-bg-gui-${{ matrix.app }}" || true
+
+      - name: Collect artifacts
+        if: always()
+        run: |
+          mkdir -p artifacts
+          find -L "result-${{ matrix.desktop }}-bg-gui-${{ matrix.app }}/" \
+            \( -name '*.gif' -o -name '*.png' -o -name '*.json' \) -type f \
+            -exec cp {} artifacts/ \; 2>/dev/null || true
+          ls -la artifacts/ 2>/dev/null || echo "No artifacts found"
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: cua-driver-wayland-${{ matrix.desktop }}-background-gui-${{ matrix.app }}
+          path: artifacts/*
+          if-no-files-found: warn
+
+      - name: Sign and upload to Nix cache
+        if: always()
+        run: |
+          nix store sign --key-file "${{ runner.temp }}/signing-key.sec" --all || true
+          nix copy --to "s3://${{ env.NIX_CACHE_BUCKET }}?region=${{ env.AWS_REGION }}&want-mass-query=true" --all -L || true
+
+      - name: Cleanup signing key
+        if: always()
+        run: rm -f "${{ runner.temp }}/signing-key.sec"

--- a/.github/workflows/nix-wayland.yml
+++ b/.github/workflows/nix-wayland.yml
@@ -4,8 +4,9 @@ name: CUA Driver Native-Wayland TDD Suite
 # sessions (XFCE on labwc/wayfire/sway, plus KDE and GNOME). These are a TDD
 # RED suite: the driver is X11-only today, so they are EXPECTED TO FAIL until
 # native Wayland support lands. The triggers mirror the X11 nix-build.yml
-# workflow (PRs/pushes touching nix/flake/driver, plus manual dispatch); every
-# job stays continue-on-error so the expected-red suite never blocks a PR.
+# workflow (PRs/pushes touching nix/flake/driver, plus manual dispatch). These
+# jobs are BLOCKING (no continue-on-error): a red cell fails the PR, so the suite
+# can only go green once native Wayland support is implemented.
 # Artifacts (screenshots, GIFs, logs) are uploaded so you can see exactly what
 # each compositor does.
 on:
@@ -41,7 +42,6 @@ jobs:
     name: ${{ matrix.desktop }} / ${{ matrix.scenario }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -132,7 +132,6 @@ jobs:
     name: ${{ matrix.desktop }} / background-gui ${{ matrix.app }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nix-wayland.yml
+++ b/.github/workflows/nix-wayland.yml
@@ -8,9 +8,22 @@ name: CUA Driver Native-Wayland TDD Suite
 # job is continue-on-error. Artifacts (screenshots, GIFs, logs) are uploaded so
 # you can see exactly what each compositor does.
 on:
-  workflow_dispatch:
   pull_request:
-    types: [labeled]
+    paths:
+      - 'nix/**'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'libs/cua-driver/rust/**'
+      - '.github/workflows/nix-build.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'nix/**'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'libs/cua-driver/rust/**'
+      - '.github/workflows/nix-build.yml'
+  workflow_dispatch:
 
 permissions:
   id-token: write

--- a/.github/workflows/nix-wayland.yml
+++ b/.github/workflows/nix-wayland.yml
@@ -3,10 +3,11 @@ name: CUA Driver Native-Wayland TDD Suite
 # Native-Wayland reproduction of the cua-driver NixOS tests across five desktop
 # sessions (XFCE on labwc/wayfire/sway, plus KDE and GNOME). These are a TDD
 # RED suite: the driver is X11-only today, so they are EXPECTED TO FAIL until
-# native Wayland support lands. They therefore never gate a PR — this workflow
-# is opt-in (manual dispatch, or the `cua-driver-wayland` PR label) and every
-# job is continue-on-error. Artifacts (screenshots, GIFs, logs) are uploaded so
-# you can see exactly what each compositor does.
+# native Wayland support lands. The triggers mirror the X11 nix-build.yml
+# workflow (PRs/pushes touching nix/flake/driver, plus manual dispatch); every
+# job stays continue-on-error so the expected-red suite never blocks a PR.
+# Artifacts (screenshots, GIFs, logs) are uploaded so you can see exactly what
+# each compositor does.
 on:
   pull_request:
     paths:
@@ -14,7 +15,7 @@ on:
       - 'flake.nix'
       - 'flake.lock'
       - 'libs/cua-driver/rust/**'
-      - '.github/workflows/nix-build.yml'
+      - '.github/workflows/nix-wayland.yml'
   push:
     branches: [main]
     paths:
@@ -22,7 +23,7 @@ on:
       - 'flake.nix'
       - 'flake.lock'
       - 'libs/cua-driver/rust/**'
-      - '.github/workflows/nix-build.yml'
+      - '.github/workflows/nix-wayland.yml'
   workflow_dispatch:
 
 permissions:
@@ -38,7 +39,6 @@ env:
 jobs:
   wayland-scenarios:
     name: ${{ matrix.desktop }} / ${{ matrix.scenario }}
-    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'cua-driver-wayland'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     continue-on-error: true
@@ -131,7 +131,6 @@ jobs:
 
   wayland-background-gui:
     name: ${{ matrix.desktop }} / background-gui ${{ matrix.app }}
-    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'cua-driver-wayland'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     continue-on-error: true

--- a/.github/workflows/nix-wayland.yml
+++ b/.github/workflows/nix-wayland.yml
@@ -1,7 +1,7 @@
 name: CUA Driver Native-Wayland TDD Suite
 
 # Native-Wayland reproduction of the cua-driver NixOS tests across five desktop
-# sessions (XFCE on labwc/wayfire/sway, plus KDE and GNOME). These are a TDD
+# sessions (XFCE on labwc/sway, plus KDE and GNOME). These are a TDD
 # RED suite: the driver is X11-only today, so they are EXPECTED TO FAIL until
 # native Wayland support lands. The triggers mirror the X11 nix-build.yml
 # workflow (PRs/pushes touching nix/flake/driver, plus manual dispatch). These
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        desktop: [xfce-labwc, xfce-wayfire, xfce-sway, kde, gnome]
+        desktop: [xfce-labwc, xfce-sway, kde, gnome]
         scenario:
           - integration
           - screenshot
@@ -135,7 +135,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        desktop: [xfce-labwc, xfce-wayfire, xfce-sway, kde, gnome]
+        desktop: [xfce-labwc, xfce-sway, kde, gnome]
         app: [foot, gtk3-gedit, qt6-kcalc]
     steps:
       - name: Checkout

--- a/.github/workflows/nix-wayland.yml
+++ b/.github/workflows/nix-wayland.yml
@@ -99,7 +99,7 @@ jobs:
         run: |
           nix build ".#checks.x86_64-linux.cua-driver-wayland-${{ matrix.desktop }}-${{ matrix.scenario }}" \
             --print-build-logs --show-trace \
-            -o "result-${{ matrix.desktop }}-${{ matrix.scenario }}" || true
+            -o "result-${{ matrix.desktop }}-${{ matrix.scenario }}"
 
       - name: Collect artifacts
         if: always()
@@ -182,11 +182,10 @@ jobs:
             trusted-public-keys = ${{ steps.nix-key.outputs.public_key }} cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 
       - name: Run cua-driver-wayland-${{ matrix.desktop }}-background-gui-${{ matrix.app }}
-        continue-on-error: true
         run: |
           nix build ".#checks.x86_64-linux.cua-driver-wayland-${{ matrix.desktop }}-background-gui-${{ matrix.app }}" \
             --print-build-logs --show-trace \
-            -o "result-${{ matrix.desktop }}-bg-gui-${{ matrix.app }}" || true
+            -o "result-${{ matrix.desktop }}-bg-gui-${{ matrix.app }}"
 
       - name: Collect artifacts
         if: always()

--- a/.github/workflows/nix-wayland.yml
+++ b/.github/workflows/nix-wayland.yml
@@ -96,7 +96,6 @@ jobs:
             trusted-public-keys = ${{ steps.nix-key.outputs.public_key }} cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 
       - name: Run cua-driver-wayland-${{ matrix.desktop }}-${{ matrix.scenario }}
-        continue-on-error: true
         run: |
           nix build ".#checks.x86_64-linux.cua-driver-wayland-${{ matrix.desktop }}-${{ matrix.scenario }}" \
             --print-build-logs --show-trace \

--- a/flake.nix
+++ b/flake.nix
@@ -156,6 +156,71 @@
                   "electron-logseq"
                 ]
               )
+            )
+            # Native-Wayland TDD matrix — reproduce the cua-driver scenarios on
+            # real, NATIVE Wayland sessions (XFCE on labwc/wayfire/sway, plus KDE
+            # and GNOME). Apps run as Wayland clients and the tests never set
+            # DISPLAY, so the X11-only driver cannot see them: this is a RED suite
+            # specifying native Wayland support. One check per (desktop × scenario)
+            # and per (desktop × background-GUI app). See
+            # nix/cua-driver/tests/wayland/README.md.
+            // pkgs.lib.optionalAttrs (system == "x86_64-linux") (
+              let
+                waylandDesktops = [
+                  "xfce-labwc"
+                  "xfce-wayfire"
+                  "xfce-sway"
+                  "kde"
+                  "gnome"
+                ];
+                waylandScenarios = {
+                  integration = ./nix/cua-driver/tests/wayland/integration.nix;
+                  screenshot = ./nix/cua-driver/tests/wayland/screenshot.nix;
+                  cursor-click-gif = ./nix/cua-driver/tests/wayland/cursor-click-gif.nix;
+                  background-terminal-gif = ./nix/cua-driver/tests/wayland/background-terminal-gif.nix;
+                  parallel-drag = ./nix/cua-driver/tests/wayland/parallel-drag.nix;
+                };
+                waylandBgApps = [
+                  "foot"
+                  "gtk3-gedit"
+                  "qt6-kcalc"
+                ];
+                waylandModule = {
+                  imports = [ ./nix/cua-driver/module.nix ];
+                  services.cua-driver.package = cuaDriverPackage;
+                };
+                scenarioChecks = pkgs.lib.listToAttrs (
+                  pkgs.lib.concatMap (
+                    desktop:
+                    map (
+                      scenario:
+                      pkgs.lib.nameValuePair "cua-driver-wayland-${desktop}-${scenario}" (
+                        import waylandScenarios.${scenario} {
+                          inherit pkgs desktop;
+                          inherit (pkgs) lib;
+                          cuaDriverModule = waylandModule;
+                        }
+                      )
+                    ) (builtins.attrNames waylandScenarios)
+                  ) waylandDesktops
+                );
+                bgGuiChecks = pkgs.lib.listToAttrs (
+                  pkgs.lib.concatMap (
+                    desktop:
+                    map (
+                      app:
+                      pkgs.lib.nameValuePair "cua-driver-wayland-${desktop}-background-gui-${app}" (
+                        import ./nix/cua-driver/tests/wayland/background-gui.nix {
+                          inherit pkgs desktop app;
+                          inherit (pkgs) lib;
+                          cuaDriverModule = waylandModule;
+                        }
+                      )
+                    ) waylandBgApps
+                  ) waylandDesktops
+                );
+              in
+              scenarioChecks // bgGuiChecks
             );
         }
       )

--- a/flake.nix
+++ b/flake.nix
@@ -166,9 +166,12 @@
             # nix/cua-driver/tests/wayland/README.md.
             // pkgs.lib.optionalAttrs (system == "x86_64-linux") (
               let
+                # NOTE: xfce-wayfire dropped — the wayfire package fails to
+                # build in the current nixpkgs pin (wf-config can't link
+                # -ldoctest), an upstream packaging bug unrelated to cua-driver.
+                # labwc + sway still cover XFCE-on-wlroots.
                 waylandDesktops = [
                   "xfce-labwc"
-                  "xfce-wayfire"
                   "xfce-sway"
                   "kde"
                   "gnome"

--- a/nix/cua-driver/package.nix
+++ b/nix/cua-driver/package.nix
@@ -25,7 +25,7 @@ pkgs.rustPlatform.buildRustPackage {
   # gracefully via `cargo vendor`.
   # Bumped when the dependency set changes (added `atspi`/zbus for native
   # AT-SPI). If this mismatches, the nix build prints the expected value.
-  cargoHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  cargoHash = "sha256-PshgCgZCKQ1Kn0jK5juPluhCYP2c9NOuYu2erm0a69E=";
 
   # Build only the main binary crate. The workspace also contains
   # platform-macos, platform-windows, cua-driver-uia, and focus-monitor-win

--- a/nix/cua-driver/package.nix
+++ b/nix/cua-driver/package.nix
@@ -15,7 +15,7 @@
 
 pkgs.rustPlatform.buildRustPackage {
   pname = "cua-driver";
-  version = "0.5.1";
+  version = "0.5.3";
 
   inherit src;
 
@@ -25,7 +25,7 @@ pkgs.rustPlatform.buildRustPackage {
   # gracefully via `cargo vendor`.
   # Bumped when the dependency set changes (added `atspi`/zbus for native
   # AT-SPI). If this mismatches, the nix build prints the expected value.
-  cargoHash = "sha256-8e/8inqyEUJA3s9lp/YGU5ckDXV1PnUVTyArwAM1e5g=";
+  cargoHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
 
   # Build only the main binary crate. The workspace also contains
   # platform-macos, platform-windows, cua-driver-uia, and focus-monitor-win

--- a/nix/cua-driver/tests/wayland/README.md
+++ b/nix/cua-driver/tests/wayland/README.md
@@ -59,6 +59,7 @@ virtual-pointer protocols.
 The `.github/workflows/nix-wayland.yml` workflow runs the whole matrix on the
 same triggers as the X11 `nix-build.yml` workflow — PRs and `main` pushes that
 touch `nix/**`, `flake.{nix,lock}`, `libs/cua-driver/rust/**`, or the workflow
-itself, plus manual `workflow_dispatch`. Every job is `continue-on-error` so the
-expected-red suite never blocks a PR, and each uploads its screenshots / GIFs /
-logs as artifacts so you can see what each compositor did.
+itself, plus manual `workflow_dispatch`. The jobs are BLOCKING: a red cell fails
+the PR, so the suite only goes green once native Wayland support lands. Each job
+uploads its screenshots / GIFs / logs as artifacts so you can see what each
+compositor did.

--- a/nix/cua-driver/tests/wayland/README.md
+++ b/nix/cua-driver/tests/wayland/README.md
@@ -36,8 +36,10 @@ a `grim`/screencopy capture path, and a `wlr-virtual-pointer` /
 
 ## Matrix
 
-Desktops: `xfce-labwc`, `xfce-wayfire`, `xfce-sway` (XFCE 4.20's Wayland-session
-compositors), `kde` (kwin_wayland), `gnome` (mutter headless).
+Desktops: `xfce-labwc`, `xfce-sway` (XFCE 4.20's Wayland-session compositors),
+`kde` (kwin_wayland), `gnome` (mutter headless). (`xfce-wayfire` was dropped —
+wayfire fails to build in the current nixpkgs pin, an upstream `wf-config`/
+`doctest` issue unrelated to cua-driver.)
 
 Checks (built on demand):
 

--- a/nix/cua-driver/tests/wayland/README.md
+++ b/nix/cua-driver/tests/wayland/README.md
@@ -1,0 +1,62 @@
+# cua-driver native-Wayland TDD suite
+
+A reproduction of the cua-driver NixOS tests on **native Wayland**, across five
+desktop sessions. These tests are a **TDD red suite**: the Linux backend is
+X11-only today, so they are **expected to fail** until native Wayland support is
+added. They exist to *specify* that work and to show, per compositor, exactly
+what survives.
+
+## Why they fail today
+
+cua-driver enumerates windows with X11 `_NET_CLIENT_LIST`, captures with
+`import`/`xwd`/XGetImage, and injects input with X11 `XSendEvent` (plus uinput +
+XI2 for the agent cursor / parallel drags). On native Wayland:
+
+- apps are **Wayland clients with no X11 window id**, so `list_windows` returns
+  nothing and `find_window` times out;
+- there is no X display to capture or `XSendEvent` into (the tests never set
+  `DISPLAY`, so there is no XWayland fallback either).
+
+To make a scenario green you implement the corresponding native-Wayland path in
+`libs/cua-driver/rust/crates/platform-linux` (e.g. a Wayland window enumerator,
+a `grim`/screencopy capture path, and a `wlr-virtual-pointer` /
+`virtual-keyboard` / `libei` input path), then re-run the matching check.
+
+## Layout
+
+- `session.nix` — brings up a chosen desktop headless and exposes the Wayland
+  socket. The compositor is the only per-desktop difference.
+- `driver-client.nix` — shared MCP client; window discovery goes **only** through
+  cua-driver's own `list_windows` (no xdotool/X11 cheat).
+- `record-wayland-gif.nix` — `grim`-based GIF recorder (wlroots only; no-op
+  elsewhere).
+- `integration.nix`, `screenshot.nix`, `cursor-click-gif.nix`,
+  `background-terminal-gif.nix`, `parallel-drag.nix`, `background-gui.nix` — the
+  scenarios, each parameterised by `desktop` (and `background-gui` also by `app`).
+
+## Matrix
+
+Desktops: `xfce-labwc`, `xfce-wayfire`, `xfce-sway` (XFCE 4.20's Wayland-session
+compositors), `kde` (kwin_wayland), `gnome` (mutter headless).
+
+Checks (built on demand):
+
+```
+nix build .#checks.x86_64-linux.cua-driver-wayland-<desktop>-<scenario>
+nix build .#checks.x86_64-linux.cua-driver-wayland-<desktop>-background-gui-<app>
+```
+
+Scenarios: `integration`, `screenshot`, `cursor-click-gif`,
+`background-terminal-gif`, `parallel-drag`.
+Background-GUI apps: `foot`, `gtk3-gedit`, `qt6-kcalc`.
+
+`parallel-drag` is the hardest: it needs X11 MPX master pointers, for which there
+is no native Wayland equivalent — keep it red, or redesign around multi-seat /
+virtual-pointer protocols.
+
+## Running in CI
+
+The `.github/workflows/nix-wayland.yml` workflow runs the whole matrix opt-in
+(manual `workflow_dispatch`, or the `cua-driver-wayland` PR label). Every job is
+`continue-on-error` so the red suite never blocks a PR, and each uploads its
+screenshots / GIFs / logs as artifacts so you can see what each compositor did.

--- a/nix/cua-driver/tests/wayland/README.md
+++ b/nix/cua-driver/tests/wayland/README.md
@@ -56,7 +56,9 @@ virtual-pointer protocols.
 
 ## Running in CI
 
-The `.github/workflows/nix-wayland.yml` workflow runs the whole matrix opt-in
-(manual `workflow_dispatch`, or the `cua-driver-wayland` PR label). Every job is
-`continue-on-error` so the red suite never blocks a PR, and each uploads its
-screenshots / GIFs / logs as artifacts so you can see what each compositor did.
+The `.github/workflows/nix-wayland.yml` workflow runs the whole matrix on the
+same triggers as the X11 `nix-build.yml` workflow — PRs and `main` pushes that
+touch `nix/**`, `flake.{nix,lock}`, `libs/cua-driver/rust/**`, or the workflow
+itself, plus manual `workflow_dispatch`. Every job is `continue-on-error` so the
+expected-red suite never blocks a PR, and each uploads its screenshots / GIFs /
+logs as artifacts so you can see what each compositor did.

--- a/nix/cua-driver/tests/wayland/background-gui.nix
+++ b/nix/cua-driver/tests/wayland/background-gui.nix
@@ -1,0 +1,148 @@
+# CUA Driver native-Wayland background-GUI skeleton (per desktop, per app) — TDD red.
+#
+# Native-Wayland analogue of the READ-ONLY skeleton class in
+# ../../tests/linux-background-gui.nix. Launches a real toolkit app as a NATIVE
+# Wayland client (no GDK_BACKEND/QT_QPA forcing), finds it via cua-driver
+# list_windows, and screenshots it via get_window_state (vision). Records a GIF
+# via grim. Fails today: the driver can neither enumerate nor capture native
+# Wayland surfaces — the spec for native Wayland read support across toolkits.
+#
+# To run: nix build .#checks.x86_64-linux.cua-driver-wayland-<desktop>-background-gui-<app>
+{
+  pkgs,
+  lib ? pkgs.lib,
+  cuaDriverModule,
+  desktop,
+  app,
+  ...
+}:
+
+let
+  session = import ./session.nix { inherit pkgs desktop; };
+  driverClient = import ./driver-client.nix { inherit pkgs; };
+  recordGifScript = import ./record-wayland-gif.nix { inherit pkgs; };
+
+  # Representative native-Wayland apps, one per major toolkit. `match` is the
+  # identity substring find_window looks for (title/app_id/app/class).
+  apps = {
+    foot = {
+      packages = [ pkgs.foot ];
+      # foot is Wayland-only; no backend hint needed.
+      env = "";
+      launch = "foot --title=cua-wayland-foot-app";
+      match = "cua-wayland-foot-app";
+    };
+    "gtk3-gedit" = {
+      packages = [ pkgs.gedit ];
+      # GTK auto-selects the Wayland backend from WAYLAND_DISPLAY.
+      env = "GDK_BACKEND=wayland";
+      launch = "gedit";
+      match = "gedit";
+    };
+    "qt6-kcalc" = {
+      packages = [ pkgs.kdePackages.kcalc ];
+      # Qt defaults to xcb; force the NATIVE Wayland platform plugin (not xcb).
+      env = "QT_QPA_PLATFORM=wayland";
+      launch = "kcalc";
+      match = "kcalc";
+    };
+  };
+
+  cfg = apps.${app} or (throw "wayland/background-gui.nix: unknown app '${app}'");
+  outputGif = "/tmp/cua-driver-wayland-${desktop}-background-gui-${app}.gif";
+  outputPng = "/tmp/cua-driver-wayland-${desktop}-background-gui-${app}.png";
+
+  testScriptPy = pkgs.writeText "wayland-bg-gui.py" ''
+    import base64, sys
+    sys.path.insert(0, "/tmp")
+    from driver_client import Driver
+
+    MATCH = "${cfg.match}"
+    OUTPNG = "${outputPng}"
+
+    d = Driver()
+    try:
+        d.initialize("nixos-wayland-bg-gui")
+        pid, wid = d.find_window(MATCH, timeout=40)
+        print(f"app window pid={pid} window_id={wid}", flush=True)
+        resp = d.call("get_window_state", {
+            "pid": pid, "window_id": wid, "capture_mode": "vision"}, timeout=45)
+        saved = False
+        for item in resp.get("result", {}).get("content", []):
+            if item.get("type") == "image" and item.get("data"):
+                with open(OUTPNG, "wb") as f:
+                    f.write(base64.b64decode(item["data"]))
+                saved = True
+                break
+        assert saved, f"no capture for native Wayland window: {resp}"
+        print("background gui read test complete", flush=True)
+    finally:
+        d.close()
+  '';
+in
+
+pkgs.testers.nixosTest {
+  name = "cua-driver-wayland-${desktop}-background-gui-${app}-test";
+  meta.maintainers = [ ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ cuaDriverModule ];
+      virtualisation = {
+        cores = 2;
+        memorySize = 4096;
+      };
+      services.cua-driver.enable = true;
+      boot.kernelModules = [ "uinput" ];
+      hardware.graphics.enable = true;
+      services.udev.extraRules = ''
+        KERNEL=="uinput", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput"
+      '';
+      environment.systemPackages =
+        session.packages ++ cfg.packages ++ (with pkgs; [ python3 jq at-spi2-core ]);
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("Bring up ${session.label}"):
+        machine.execute("${session.start} >/tmp/session.log 2>&1 &")
+        try:
+            machine.wait_for_file("/tmp/wl-ready", timeout=120)
+        except Exception:
+            machine.log(machine.execute("cat /tmp/session.log || true")[1])
+            machine.log(machine.execute("cat /tmp/compositor.log || true")[1])
+            raise
+        wl = machine.succeed("cat /tmp/wl-display").strip()
+
+    with subtest("Launch native Wayland app (${app})"):
+        wl = machine.succeed("cat /tmp/wl-display").strip()
+        env = f"env -u DISPLAY WAYLAND_DISPLAY={wl} XDG_RUNTIME_DIR=/run/user/0"
+        machine.execute(f"sh -lc '{env} ${cfg.env} ${cfg.launch} >/tmp/bg-app.log 2>&1 & echo $! >/tmp/bg-app-pid.txt'")
+        machine.succeed("sleep 5")
+        machine.log(machine.execute("cat /tmp/bg-app.log || true")[1])
+
+    with subtest("Record GIF and read inactive app window via cua-driver"):
+        wl = machine.succeed("cat /tmp/wl-display").strip()
+        env = f"env -u DISPLAY WAYLAND_DISPLAY={wl} XDG_RUNTIME_DIR=/run/user/0"
+        machine.copy_from_host("${driverClient}", "/tmp/driver_client.py")
+        machine.copy_from_host("${testScriptPy}", "/tmp/wayland-bg-gui.py")
+        machine.execute(
+            f"sh -lc '{env} ${recordGifScript} /tmp/bg-gui-frames "
+            "${outputGif} /tmp/stop-bg-gui-recorder /tmp/rec-bg-gui.log 12 0.2 "
+            ">/dev/null 2>&1 & echo $! >/tmp/rec-bg-gui.pid'"
+        )
+        result = machine.execute(f"timeout 120 {env} python3 /tmp/wayland-bg-gui.py 2>&1")[1]
+        machine.log(result)
+        # Stop + copy the GIF BEFORE asserting so even failing jobs upload one.
+        machine.execute("touch /tmp/stop-bg-gui-recorder")
+        machine.execute("sh -lc 'for i in $(seq 1 60); do kill -0 $(cat /tmp/rec-bg-gui.pid) 2>/dev/null || break; sleep 1; done'")
+        machine.execute("test -e ${outputGif} || : > ${outputGif}")
+        machine.copy_from_machine("${outputGif}", "")
+
+    with subtest("cua-driver read/captured the native Wayland app window (RED until Wayland support lands)"):
+        assert "background gui read test complete" in result, result
+  '';
+}

--- a/nix/cua-driver/tests/wayland/background-terminal-gif.nix
+++ b/nix/cua-driver/tests/wayland/background-terminal-gif.nix
@@ -1,0 +1,113 @@
+# CUA Driver native-Wayland background-terminal GIF test (per desktop) — TDD red.
+#
+# Native-Wayland analogue of ../../tests/linux-background-terminal-gif.nix. A
+# control terminal is launched after the target so the target is NOT focused;
+# cua-driver then types a command into the inactive native Wayland target and we
+# verify it ran via a file side-effect. Records a GIF via grim. Fails today: the
+# driver's focus-free injection (X11 XSendEvent) does not reach native Wayland
+# surfaces — the spec for focus-free Wayland input.
+#
+# To run: nix build .#checks.x86_64-linux.cua-driver-wayland-<desktop>-background-terminal-gif
+{
+  pkgs,
+  lib ? pkgs.lib,
+  cuaDriverModule,
+  desktop,
+  ...
+}:
+
+let
+  session = import ./session.nix { inherit pkgs desktop; };
+  driverClient = import ./driver-client.nix { inherit pkgs; };
+  recordGifScript = import ./record-wayland-gif.nix { inherit pkgs; };
+
+  testScriptPy = pkgs.writeText "wayland-background-terminal.py" ''
+    import sys, time
+    sys.path.insert(0, "/tmp")
+    from driver_client import Driver
+
+    d = Driver()
+    try:
+        d.initialize("nixos-wayland-bg-terminal")
+        tpid, twid = d.find_window("cua-wayland-target", timeout=30)
+        cpid, cwid = d.find_window("cua-wayland-control", timeout=30)
+        print(f"target pid={tpid} window_id={twid} control pid={cpid} window_id={cwid}", flush=True)
+        d.call("set_agent_cursor_enabled", {"enabled": True})
+        # Focus-free type into the INACTIVE target while control stays focused.
+        d.call("type_text", {"pid": tpid, "window_id": twid,
+            "text": "echo hello | tee /tmp/background-hello.txt"})
+        d.call("press_key", {"pid": tpid, "window_id": twid, "key": "enter"})
+        time.sleep(1.8)
+        print("background terminal GIF test complete", flush=True)
+    finally:
+        d.close()
+  '';
+in
+
+pkgs.testers.nixosTest {
+  name = "cua-driver-wayland-${desktop}-background-terminal-gif-test";
+  meta.maintainers = [ ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ cuaDriverModule ];
+      virtualisation = {
+        cores = 2;
+        memorySize = 3072;
+      };
+      services.cua-driver.enable = true;
+      boot.kernelModules = [ "uinput" ];
+      hardware.graphics.enable = true;
+      services.udev.extraRules = ''
+        KERNEL=="uinput", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput"
+      '';
+      environment.systemPackages = session.packages ++ (with pkgs; [ python3 jq ]);
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+    machine.succeed("modprobe uinput && test -e /dev/uinput")
+
+    with subtest("Bring up ${session.label} + native Wayland target/control terminals"):
+        machine.execute("${session.start} >/tmp/session.log 2>&1 &")
+        try:
+            machine.wait_for_file("/tmp/wl-ready", timeout=120)
+        except Exception:
+            machine.log(machine.execute("cat /tmp/session.log || true")[1])
+            machine.log(machine.execute("cat /tmp/compositor.log || true")[1])
+            raise
+        wl = machine.succeed("cat /tmp/wl-display").strip()
+        env = f"env -u DISPLAY WAYLAND_DISPLAY={wl} XDG_RUNTIME_DIR=/run/user/0"
+        # Target first, control second so the target is left UNFOCUSED.
+        machine.execute(f"sh -lc '{env} foot --title=cua-wayland-target >/tmp/target.log 2>&1 &'")
+        machine.succeed("sleep 1")
+        machine.execute(f"sh -lc '{env} foot --title=cua-wayland-control >/tmp/control.log 2>&1 &'")
+        machine.succeed("sleep 3")
+
+    with subtest("Record GIF and type into the inactive native Wayland terminal"):
+        wl = machine.succeed("cat /tmp/wl-display").strip()
+        env = f"env -u DISPLAY WAYLAND_DISPLAY={wl} XDG_RUNTIME_DIR=/run/user/0"
+        machine.copy_from_host("${driverClient}", "/tmp/driver_client.py")
+        machine.copy_from_host("${testScriptPy}", "/tmp/wayland-background-terminal.py")
+        machine.execute(
+            f"sh -lc '{env} ${recordGifScript} /tmp/background-frames "
+            "/tmp/cua-driver-wayland-${desktop}-background-terminal.gif /tmp/stop-background-recorder "
+            "/tmp/rec-background.log 10 0.15 >/dev/null 2>&1 & echo $! >/tmp/rec-background.pid'"
+        )
+        # Non-raising so the grim session GIF is captured even on a red run.
+        result = machine.execute(f"timeout 90 {env} python3 /tmp/wayland-background-terminal.py 2>&1")[1]
+        machine.log(result)
+        machine.execute("touch /tmp/stop-background-recorder")
+        machine.execute("sh -lc 'for i in $(seq 1 60); do kill -0 $(cat /tmp/rec-background.pid) 2>/dev/null || break; sleep 1; done'")
+
+    with subtest("Copy GIF out of the VM (best-effort)"):
+        machine.execute("test -e /tmp/cua-driver-wayland-${desktop}-background-terminal.gif || : > /tmp/cua-driver-wayland-${desktop}-background-terminal.gif")
+        machine.copy_from_machine("/tmp/cua-driver-wayland-${desktop}-background-terminal.gif", "")
+
+    with subtest("Driver typed into inactive terminal AND the command ran (RED until Wayland input lands)"):
+        assert "background terminal GIF test complete" in result, result
+        machine.wait_until_succeeds("grep -Fx 'hello' /tmp/background-hello.txt", timeout=20)
+  '';
+}

--- a/nix/cua-driver/tests/wayland/cursor-click-gif.nix
+++ b/nix/cua-driver/tests/wayland/cursor-click-gif.nix
@@ -1,0 +1,115 @@
+# CUA Driver native-Wayland cursor-click GIF test (per desktop) — TDD red.
+#
+# Native-Wayland analogue of ../../tests/linux-cursor-click-gif.nix. Launches a
+# native Wayland terminal (foot running a shell), finds it via cua-driver
+# list_windows, clicks into it and types a command, then verifies the command
+# RAN by checking a file it writes (display-server-agnostic proof). Records a
+# GIF of the composited output via grim. Fails today: the driver can neither
+# enumerate nor inject into native Wayland surfaces.
+#
+# To run: nix build .#checks.x86_64-linux.cua-driver-wayland-<desktop>-cursor-click-gif
+{
+  pkgs,
+  lib ? pkgs.lib,
+  cuaDriverModule,
+  desktop,
+  ...
+}:
+
+let
+  session = import ./session.nix { inherit pkgs desktop; };
+  driverClient = import ./driver-client.nix { inherit pkgs; };
+  recordGifScript = import ./record-wayland-gif.nix { inherit pkgs; };
+
+  testScriptPy = pkgs.writeText "wayland-cursor-click.py" ''
+    import sys, time
+    sys.path.insert(0, "/tmp")
+    from driver_client import Driver
+
+    d = Driver()
+    try:
+        d.initialize("nixos-wayland-click")
+        pid, wid = d.find_window("cua-wayland-target", timeout=30)
+        print(f"target pid={pid} window_id={wid}", flush=True)
+        d.call("set_agent_cursor_enabled", {"enabled": True})
+        d.call("move_cursor", {"x": 1100.0, "y": 900.0})
+        time.sleep(0.6)
+        d.call("click", {"pid": pid, "window_id": wid, "x": 120.0, "y": 120.0})
+        time.sleep(0.4)
+        d.call("type_text", {"pid": pid, "window_id": wid,
+            "text": "echo click-focus > /tmp/click-focus.txt"})
+        d.call("press_key", {"pid": pid, "window_id": wid, "key": "enter"})
+        time.sleep(1.5)
+        print("click GIF test complete", flush=True)
+    finally:
+        d.close()
+  '';
+in
+
+pkgs.testers.nixosTest {
+  name = "cua-driver-wayland-${desktop}-cursor-click-gif-test";
+  meta.maintainers = [ ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ cuaDriverModule ];
+      virtualisation = {
+        cores = 2;
+        memorySize = 3072;
+      };
+      services.cua-driver.enable = true;
+      boot.kernelModules = [ "uinput" ];
+      hardware.graphics.enable = true;
+      services.udev.extraRules = ''
+        KERNEL=="uinput", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput"
+      '';
+      environment.systemPackages = session.packages ++ (with pkgs; [ python3 jq ]);
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+    machine.succeed("modprobe uinput && test -e /dev/uinput")
+
+    with subtest("Bring up ${session.label} + native Wayland target/control terminals"):
+        machine.execute("${session.start} >/tmp/session.log 2>&1 &")
+        try:
+            machine.wait_for_file("/tmp/wl-ready", timeout=120)
+        except Exception:
+            machine.log(machine.execute("cat /tmp/session.log || true")[1])
+            machine.log(machine.execute("cat /tmp/compositor.log || true")[1])
+            raise
+        wl = machine.succeed("cat /tmp/wl-display").strip()
+        env = f"env -u DISPLAY WAYLAND_DISPLAY={wl} XDG_RUNTIME_DIR=/run/user/0"
+        machine.execute(f"sh -lc '{env} foot --title=cua-wayland-control >/tmp/control.log 2>&1 &'")
+        machine.execute(f"sh -lc '{env} foot --title=cua-wayland-target >/tmp/target.log 2>&1 &'")
+        machine.succeed("sleep 3")
+
+    with subtest("Record GIF and run driver click+type into native Wayland terminal"):
+        wl = machine.succeed("cat /tmp/wl-display").strip()
+        env = f"env -u DISPLAY WAYLAND_DISPLAY={wl} XDG_RUNTIME_DIR=/run/user/0"
+        machine.copy_from_host("${driverClient}", "/tmp/driver_client.py")
+        machine.copy_from_host("${testScriptPy}", "/tmp/wayland-cursor-click.py")
+        machine.execute(
+            f"sh -lc '{env} ${recordGifScript} /tmp/click-frames "
+            "/tmp/cua-driver-wayland-${desktop}-cursor-click.gif /tmp/stop-click-recorder "
+            "/tmp/rec-click.log 10 0.15 >/dev/null 2>&1 & echo $! >/tmp/rec-click.pid'"
+        )
+        # Non-raising so the grim session GIF is captured even on a red run.
+        result = machine.execute(f"timeout 90 {env} python3 /tmp/wayland-cursor-click.py 2>&1")[1]
+        machine.log(result)
+        machine.execute("touch /tmp/stop-click-recorder")
+        machine.execute("sh -lc 'for i in $(seq 1 60); do kill -0 $(cat /tmp/rec-click.pid) 2>/dev/null || break; sleep 1; done'")
+
+    with subtest("Copy GIF out of the VM (best-effort)"):
+        # Ensure the path exists so copy never errors before the real assertion;
+        # it may be empty on compositors where grim could not capture.
+        machine.execute("test -e /tmp/cua-driver-wayland-${desktop}-cursor-click.gif || : > /tmp/cua-driver-wayland-${desktop}-cursor-click.gif")
+        machine.copy_from_machine("/tmp/cua-driver-wayland-${desktop}-cursor-click.gif", "")
+
+    with subtest("Driver completed click+type AND the command ran (RED until Wayland input lands)"):
+        assert "click GIF test complete" in result, result
+        machine.wait_until_succeeds("test -f /tmp/click-focus.txt", timeout=20)
+  '';
+}

--- a/nix/cua-driver/tests/wayland/driver-client.nix
+++ b/nix/cua-driver/tests/wayland/driver-client.nix
@@ -1,0 +1,132 @@
+# Shared MCP client used by the native-Wayland TDD tests.
+#
+# It is copied into the VM as /tmp/driver_client.py and imported by the small
+# per-test scripts. Crucially, window discovery goes ONLY through cua-driver's
+# own `list_windows` tool — there is no xdotool/X11 fallback — so on native
+# Wayland (where the driver currently enumerates nothing) `find_window` times
+# out and the test fails. That is the intended red state for TDD.
+{ pkgs }:
+
+pkgs.writeText "driver_client.py" ''
+  import json, os, subprocess, sys, threading, time
+
+  DRIVER_BIN = os.environ.get("CUA_DRIVER_BIN", "cua-driver")
+
+
+  class Driver:
+      def __init__(self):
+          self.proc = subprocess.Popen(
+              [DRIVER_BIN, "mcp", "--no-daemon-relaunch"],
+              stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+              env={**os.environ},
+          )
+          threading.Thread(target=self._drain, daemon=True).start()
+          self._id = 1
+
+      def _drain(self):
+          for line in self.proc.stderr:
+              sys.stderr.buffer.write(line)
+              sys.stderr.buffer.flush()
+
+      def _send(self, method, params=None, req_id=None):
+          msg = {"jsonrpc": "2.0", "method": method}
+          if params is not None:
+              msg["params"] = params
+          if req_id is not None:
+              msg["id"] = req_id
+          self.proc.stdin.write((json.dumps(msg) + "\n").encode())
+          self.proc.stdin.flush()
+
+      def _recv(self, timeout=45):
+          result = [None]
+
+          def reader():
+              result[0] = self.proc.stdout.readline()
+
+          th = threading.Thread(target=reader)
+          th.start()
+          th.join(timeout)
+          if th.is_alive():
+              raise TimeoutError("no response from driver within timeout")
+          line = result[0].decode().strip()
+          if not line:
+              raise RuntimeError("driver returned an empty response")
+          return json.loads(line)
+
+      def initialize(self, client="nixos-wayland"):
+          self._send("initialize", {
+              "protocolVersion": "2024-11-05", "capabilities": {},
+              "clientInfo": {"name": client, "version": "1.0.0"},
+          }, req_id=self._id)
+          resp = self._recv()
+          self._id += 1
+          assert "result" in resp, f"initialize failed: {resp}"
+          self._send("notifications/initialized", {})
+          time.sleep(0.3)
+          return resp
+
+      def call(self, name, args, timeout=60):
+          self._send("tools/call", {"name": name, "arguments": args}, req_id=self._id)
+          self._id += 1
+          resp = self._recv(timeout=timeout)
+          if resp.get("error"):
+              raise RuntimeError(f"{name} failed: {resp}")
+          if resp.get("result", {}).get("isError"):
+              raise RuntimeError(f"{name} returned isError: {resp}")
+          return resp
+
+      def list_windows(self):
+          resp = self.call("list_windows", {})
+          result = resp.get("result", {})
+          # Preferred: MCP structuredContent = { "windows": [ {window_id, pid,
+          # title, ...}, ... ] }.
+          structured = result.get("structuredContent")
+          if isinstance(structured, dict) and isinstance(structured.get("windows"), list):
+              return structured["windows"]
+          if isinstance(structured, list):
+              return structured
+          # Fallback: a text item that happens to be JSON.
+          for item in result.get("content", []):
+              if item.get("type") == "text":
+                  try:
+                      data = json.loads(item.get("text", ""))
+                  except Exception:
+                      continue
+                  if isinstance(data, list):
+                      return data
+                  if isinstance(data, dict) and "windows" in data:
+                      return data["windows"]
+          return []
+
+      def find_window(self, title_substr, timeout=30, interval=1.0):
+          """Poll list_windows until a native Wayland toplevel whose title
+          contains `title_substr` appears. Raises on timeout — the red point on
+          a driver that cannot yet enumerate Wayland windows."""
+          deadline = time.time() + timeout
+          needle = title_substr.lower()
+          last = []
+          while time.time() < deadline:
+              last = self.list_windows()
+              for w in last:
+                  # Match across whatever identity fields a Wayland-capable
+                  # list_windows might surface (title today; app_id/app/class
+                  # once native Wayland metadata is wired up).
+                  hay = " ".join(
+                      str(w.get(k, "")) for k in ("title", "app_id", "app", "class")
+                  ).lower()
+                  if needle in hay:
+                      return int(w.get("pid") or 0), int(w["window_id"])
+              time.sleep(interval)
+          raise AssertionError(
+              f"cua-driver never enumerated a Wayland window titled ~{title_substr!r}; "
+              f"last list_windows() = {last}"
+          )
+
+      def close(self):
+          try:
+              self.proc.stdin.close()
+              self.proc.terminate()
+              self.proc.wait(timeout=5)
+          except Exception:
+              pass
+''

--- a/nix/cua-driver/tests/wayland/integration.nix
+++ b/nix/cua-driver/tests/wayland/integration.nix
@@ -1,0 +1,119 @@
+# CUA Driver native-Wayland integration test (per desktop) — TDD red.
+#
+# Brings up a native Wayland session, verifies the MCP handshake + doctor
+# recognise the Wayland environment, then launches a native Wayland terminal
+# (foot) and asserts cua-driver can ENUMERATE it via list_windows. The driver
+# is X11-only today, so list_windows finds nothing and this fails — the spec for
+# native Wayland window enumeration.
+#
+# To run: nix build .#checks.x86_64-linux.cua-driver-wayland-<desktop>-integration
+{
+  pkgs,
+  lib ? pkgs.lib,
+  cuaDriverModule,
+  desktop,
+  ...
+}:
+
+let
+  session = import ./session.nix { inherit pkgs desktop; };
+  driverClient = import ./driver-client.nix { inherit pkgs; };
+
+  testScriptPy = pkgs.writeText "wayland-integration.py" ''
+    import sys, time
+    sys.path.insert(0, "/tmp")
+    from driver_client import Driver
+
+    d = Driver()
+    try:
+        d.initialize("nixos-wayland-integration")
+
+        # Handshake sanity: required tools are advertised.
+        d._send("tools/list", {}, req_id=999)
+        resp = d._recv()
+        names = [t["name"] for t in resp.get("result", {}).get("tools", [])]
+        for t in ("list_windows", "get_window_state", "click", "type_text"):
+            assert t in names, f"{t} not advertised: {names}"
+        print(f"tools advertised: {len(names)}", flush=True)
+
+        # The native-Wayland spec: list_windows must surface the foot terminal.
+        pid, wid = d.find_window("cua-wayland-foot", timeout=30)
+        print(f"RESOLVED native wayland window pid={pid} window_id={wid}", flush=True)
+        print("integration test complete", flush=True)
+    finally:
+        d.close()
+  '';
+in
+
+pkgs.testers.nixosTest {
+  name = "cua-driver-wayland-${desktop}-integration-test";
+  meta.maintainers = [ ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ cuaDriverModule ];
+      virtualisation = {
+        cores = 2;
+        memorySize = 3072;
+      };
+      services.cua-driver.enable = true;
+      boot.kernelModules = [ "uinput" ];
+      hardware.graphics.enable = true;
+      services.udev.extraRules = ''
+        KERNEL=="uinput", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput"
+      '';
+      environment.systemPackages = session.packages ++ (with pkgs; [ python3 jq ]);
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("Binary exists and lists tools"):
+        machine.succeed("cua-driver --help")
+        tools = machine.succeed("cua-driver list-tools")
+        for t in ("list_windows", "get_window_state", "click", "type_text"):
+            assert t in tools, f"{t} missing from list-tools"
+
+    with subtest("Bring up ${session.label}"):
+        machine.execute("${session.start} >/tmp/session.log 2>&1 &")
+        try:
+            machine.wait_for_file("/tmp/wl-ready", timeout=120)
+        except Exception:
+            machine.log(machine.execute("cat /tmp/session.log || true")[1])
+            machine.log(machine.execute("cat /tmp/compositor.log || true")[1])
+            raise
+        wl = machine.succeed("cat /tmp/wl-display").strip()
+        machine.log(f"WAYLAND_DISPLAY={wl}")
+
+    with subtest("doctor recognises native Wayland (no DISPLAY)"):
+        wl = machine.succeed("cat /tmp/wl-display").strip()
+        result = machine.succeed(
+            f"timeout 20 env -u DISPLAY WAYLAND_DISPLAY={wl} "
+            "XDG_RUNTIME_DIR=/run/user/0 cua-driver doctor 2>&1 || true"
+        )
+        machine.log(result)
+        assert "Wayland" in result, f"doctor did not report Wayland: {result}"
+
+    with subtest("Launch native Wayland terminal (foot)"):
+        wl = machine.succeed("cat /tmp/wl-display").strip()
+        machine.execute(
+            f"sh -lc 'env -u DISPLAY WAYLAND_DISPLAY={wl} XDG_RUNTIME_DIR=/run/user/0 "
+            "foot --title=cua-wayland-foot >/tmp/foot.log 2>&1 & echo $! >/tmp/foot-pid.txt'"
+        )
+        # Give the client a moment to map its surface.
+        machine.succeed("sleep 3")
+
+    with subtest("cua-driver enumerates the native Wayland window (RED until Wayland support lands)"):
+        wl = machine.succeed("cat /tmp/wl-display").strip()
+        machine.copy_from_host("${driverClient}", "/tmp/driver_client.py")
+        machine.copy_from_host("${testScriptPy}", "/tmp/wayland-integration.py")
+        result = machine.succeed(
+            f"timeout 90 env -u DISPLAY WAYLAND_DISPLAY={wl} "
+            "XDG_RUNTIME_DIR=/run/user/0 python3 /tmp/wayland-integration.py 2>&1"
+        )
+        machine.log(result)
+        assert "integration test complete" in result, result
+  '';
+}

--- a/nix/cua-driver/tests/wayland/parallel-drag.nix
+++ b/nix/cua-driver/tests/wayland/parallel-drag.nix
@@ -1,0 +1,109 @@
+# CUA Driver native-Wayland parallel multi-cursor drag test (per desktop) — TDD red.
+#
+# Native-Wayland analogue of ../../tests/linux-parallel-drag-xserver.nix, and
+# the hardest of the suite. parallel_mouse_drag relies on X11 XInput2 MPX master
+# pointers and kernel uinput slaves; Wayland has no MPX and the headless
+# compositor has no libinput seat. There is no native-Wayland multi-pointer
+# protocol in wide use, so this is expected to fail hard. It is kept as a check
+# to record exactly how the driver reports the limitation per compositor and to
+# anchor any future multi-seat / virtual-pointer Wayland design.
+#
+# To run: nix build .#checks.x86_64-linux.cua-driver-wayland-<desktop>-parallel-drag
+{
+  pkgs,
+  lib ? pkgs.lib,
+  cuaDriverModule,
+  desktop,
+  ...
+}:
+
+let
+  session = import ./session.nix { inherit pkgs desktop; };
+  driverClient = import ./driver-client.nix { inherit pkgs; };
+  recordGifScript = import ./record-wayland-gif.nix { inherit pkgs; };
+
+  testScriptPy = pkgs.writeText "wayland-parallel-drag.py" ''
+    import sys, time
+    sys.path.insert(0, "/tmp")
+    from driver_client import Driver
+
+    d = Driver()
+    try:
+        d.initialize("nixos-wayland-parallel-drag")
+        pid, wid = d.find_window("cua-wayland-paint", timeout=30)
+        print(f"target pid={pid} window_id={wid}", flush=True)
+        d.call("parallel_mouse_drag", {"drags": [
+            {"session": "agent-1", "window_id": wid, "from_x": 100.0, "from_y": 100.0, "to_x": 380.0, "to_y": 420.0, "duration_ms": 2000, "steps": 60},
+            {"session": "agent-2", "window_id": wid, "from_x": 700.0, "from_y": 100.0, "to_x": 420.0, "to_y": 420.0, "duration_ms": 2000, "steps": 60},
+        ]})
+        time.sleep(0.6)
+        print("parallel drag test complete", flush=True)
+    finally:
+        d.close()
+  '';
+in
+
+pkgs.testers.nixosTest {
+  name = "cua-driver-wayland-${desktop}-parallel-drag-test";
+  meta.maintainers = [ ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ cuaDriverModule ];
+      virtualisation = {
+        cores = 2;
+        memorySize = 3072;
+      };
+      services.cua-driver.enable = true;
+      boot.kernelModules = [ "uinput" ];
+      hardware.graphics.enable = true;
+      services.udev.extraRules = ''
+        KERNEL=="uinput", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput"
+      '';
+      services.libinput.enable = true;
+      environment.systemPackages = session.packages ++ (with pkgs; [ python3 jq ]);
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+    machine.succeed("modprobe uinput && test -e /dev/uinput")
+
+    with subtest("Bring up ${session.label} + native Wayland target terminal"):
+        machine.execute("${session.start} >/tmp/session.log 2>&1 &")
+        try:
+            machine.wait_for_file("/tmp/wl-ready", timeout=120)
+        except Exception:
+            machine.log(machine.execute("cat /tmp/session.log || true")[1])
+            machine.log(machine.execute("cat /tmp/compositor.log || true")[1])
+            raise
+        wl = machine.succeed("cat /tmp/wl-display").strip()
+        env = f"env -u DISPLAY WAYLAND_DISPLAY={wl} XDG_RUNTIME_DIR=/run/user/0"
+        machine.execute(f"sh -lc '{env} foot --title=cua-wayland-paint >/tmp/paint.log 2>&1 &'")
+        machine.succeed("sleep 3")
+
+    with subtest("Record GIF and pilot cua-driver through parallel_mouse_drag (expected RED)"):
+        wl = machine.succeed("cat /tmp/wl-display").strip()
+        env = f"env -u DISPLAY WAYLAND_DISPLAY={wl} XDG_RUNTIME_DIR=/run/user/0"
+        machine.copy_from_host("${driverClient}", "/tmp/driver_client.py")
+        machine.copy_from_host("${testScriptPy}", "/tmp/wayland-parallel-drag.py")
+        machine.execute(
+            f"sh -lc '{env} ${recordGifScript} /tmp/drag-frames "
+            "/tmp/cua-driver-wayland-${desktop}-parallel-drag.gif /tmp/stop-drag-recorder "
+            "/tmp/rec-drag.log 8 0.12 >/dev/null 2>&1 & echo $! >/tmp/rec-drag.pid'"
+        )
+        # Non-raising so the grim session GIF is captured even on a red run.
+        result = machine.execute(f"timeout 90 {env} python3 /tmp/wayland-parallel-drag.py 2>&1")[1]
+        machine.log(result)
+        machine.execute("touch /tmp/stop-drag-recorder")
+        machine.execute("sh -lc 'for i in $(seq 1 60); do kill -0 $(cat /tmp/rec-drag.pid) 2>/dev/null || break; sleep 1; done'")
+
+    with subtest("Copy GIF out of the VM (best-effort)"):
+        machine.execute("test -e /tmp/cua-driver-wayland-${desktop}-parallel-drag.gif || : > /tmp/cua-driver-wayland-${desktop}-parallel-drag.gif")
+        machine.copy_from_machine("/tmp/cua-driver-wayland-${desktop}-parallel-drag.gif", "")
+
+    with subtest("parallel_mouse_drag succeeded on native Wayland (expected RED)"):
+        assert "parallel drag test complete" in result, result
+  '';
+}

--- a/nix/cua-driver/tests/wayland/record-wayland-gif.nix
+++ b/nix/cua-driver/tests/wayland/record-wayland-gif.nix
@@ -1,0 +1,44 @@
+# Native-Wayland screen-recording helper for the cua-driver Wayland TDD tests.
+#
+# Captures the composited Wayland output with `grim` (wlr-screencopy) in a loop
+# and stitches the frames into an animated GIF. grim only works on wlroots
+# compositors (labwc/wayfire/sway); on kwin/mutter it simply produces no frames
+# and no GIF — which is fine, the GIF is a best-effort artifact and these tests
+# are expected to fail before/around it anyway.
+#
+# Usage (in a test's `let`):
+#   recordGifScript = import ./record-wayland-gif.nix { inherit pkgs; };
+# then inside the testScript, start it in the background before driving and
+# `touch` the stop-file afterwards:
+#   ${recordGifScript} <frames_dir> <output_gif> <stop_file> <log_file> \
+#                      <delay_cs> <interval>
+# The caller must export WAYLAND_DISPLAY and XDG_RUNTIME_DIR for grim.
+{ pkgs }:
+
+pkgs.writeShellScript "record-wayland-gif.sh" ''
+  set -u
+  frames_dir="$1"
+  output_gif="$2"
+  stop_file="$3"
+  log_file="$4"
+  delay_cs="$5"
+  interval="$6"
+
+  rm -f "$stop_file" "$output_gif" "$log_file"
+  rm -rf "$frames_dir"
+  mkdir -p "$frames_dir"
+
+  max_frames=450
+  i=0
+  while [ ! -f "$stop_file" ] && [ "$i" -lt "$max_frames" ]; do
+    frame=$(printf "%s/frame-%04d.png" "$frames_dir" "$i")
+    timeout 10 ${pkgs.grim}/bin/grim "$frame" >>"$log_file" 2>&1 || true
+    i=$((i + 1))
+    sleep "$interval"
+  done
+
+  if ls "$frames_dir"/frame-*.png >/dev/null 2>&1; then
+    timeout 120 ${pkgs.imagemagick}/bin/convert -delay "$delay_cs" -loop 0 \
+      "$frames_dir"/frame-*.png "$output_gif" >>"$log_file" 2>&1 || true
+  fi
+''

--- a/nix/cua-driver/tests/wayland/screenshot.nix
+++ b/nix/cua-driver/tests/wayland/screenshot.nix
@@ -1,0 +1,104 @@
+# CUA Driver native-Wayland screenshot test (per desktop) — TDD red.
+#
+# Launches a native Wayland terminal (foot), finds it via cua-driver
+# list_windows, and asserts get_window_state (capture_mode=vision) returns a
+# real PNG of that native Wayland surface. The driver captures via X11 today, so
+# both discovery and capture fail on native Wayland — the spec for native
+# Wayland window capture.
+#
+# To run: nix build .#checks.x86_64-linux.cua-driver-wayland-<desktop>-screenshot
+{
+  pkgs,
+  lib ? pkgs.lib,
+  cuaDriverModule,
+  desktop,
+  ...
+}:
+
+let
+  session = import ./session.nix { inherit pkgs desktop; };
+  driverClient = import ./driver-client.nix { inherit pkgs; };
+
+  testScriptPy = pkgs.writeText "wayland-screenshot.py" ''
+    import base64, sys
+    sys.path.insert(0, "/tmp")
+    from driver_client import Driver
+
+    d = Driver()
+    try:
+        d.initialize("nixos-wayland-screenshot")
+        pid, wid = d.find_window("cua-wayland-foot", timeout=30)
+        print(f"window pid={pid} window_id={wid}", flush=True)
+        resp = d.call("get_window_state", {
+            "pid": pid, "window_id": wid, "capture_mode": "vision"}, timeout=30)
+        saved = False
+        for item in resp.get("result", {}).get("content", []):
+            if item.get("type") == "image" and item.get("data"):
+                data = base64.b64decode(item["data"])
+                assert len(data) > 0, "empty image payload"
+                with open("/tmp/cua-driver-wayland-${desktop}-screenshot.png", "wb") as f:
+                    f.write(data)
+                saved = True
+                break
+        assert saved, f"no image returned for native Wayland window: {resp}"
+        print("screenshot test complete", flush=True)
+    finally:
+        d.close()
+  '';
+in
+
+pkgs.testers.nixosTest {
+  name = "cua-driver-wayland-${desktop}-screenshot-test";
+  meta.maintainers = [ ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ cuaDriverModule ];
+      virtualisation = {
+        cores = 2;
+        memorySize = 3072;
+      };
+      services.cua-driver.enable = true;
+      boot.kernelModules = [ "uinput" ];
+      hardware.graphics.enable = true;
+      services.udev.extraRules = ''
+        KERNEL=="uinput", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput"
+      '';
+      environment.systemPackages = session.packages ++ (with pkgs; [ python3 jq ]);
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("Bring up ${session.label} + native Wayland foot terminal"):
+        machine.execute("${session.start} >/tmp/session.log 2>&1 &")
+        try:
+            machine.wait_for_file("/tmp/wl-ready", timeout=120)
+        except Exception:
+            machine.log(machine.execute("cat /tmp/session.log || true")[1])
+            machine.log(machine.execute("cat /tmp/compositor.log || true")[1])
+            raise
+        wl = machine.succeed("cat /tmp/wl-display").strip()
+        machine.execute(
+            f"sh -lc 'env -u DISPLAY WAYLAND_DISPLAY={wl} XDG_RUNTIME_DIR=/run/user/0 "
+            "foot --title=cua-wayland-foot >/tmp/foot.log 2>&1 & echo $! >/tmp/foot-pid.txt'"
+        )
+        machine.succeed("sleep 3")
+
+    with subtest("Screenshot the native Wayland window via cua-driver (RED until Wayland capture lands)"):
+        wl = machine.succeed("cat /tmp/wl-display").strip()
+        machine.copy_from_host("${driverClient}", "/tmp/driver_client.py")
+        machine.copy_from_host("${testScriptPy}", "/tmp/wayland-screenshot.py")
+        result = machine.succeed(
+            f"timeout 90 env -u DISPLAY WAYLAND_DISPLAY={wl} "
+            "XDG_RUNTIME_DIR=/run/user/0 python3 /tmp/wayland-screenshot.py 2>&1"
+        )
+        machine.log(result)
+        assert "screenshot test complete" in result, result
+
+    with subtest("Extract screenshot"):
+        machine.copy_from_machine("/tmp/cua-driver-wayland-${desktop}-screenshot.png", "")
+  '';
+}

--- a/nix/cua-driver/tests/wayland/session.nix
+++ b/nix/cua-driver/tests/wayland/session.nix
@@ -1,0 +1,161 @@
+# Shared NATIVE-Wayland desktop-session bring-up for the cua-driver Wayland TDD
+# suite.
+#
+# These tests deliberately target *native* Wayland — apps run as real Wayland
+# clients (NOT XWayland), and the tests never set DISPLAY, so the X11-only
+# cua-driver has nothing to fall back to. Today the driver therefore cannot see
+# or drive these windows and the whole suite is RED; it is a TDD specification
+# for adding native Wayland support to the Linux backend.
+#
+# Given a `desktop` this returns:
+#
+#   { packages; start; label; }
+#
+#   * packages — extra `environment.systemPackages` the session needs.
+#   * start    — a `writeShellScript` that launches the compositor headless,
+#                waits for its Wayland socket, writes the socket name to
+#                /tmp/wl-display, then `touch`es /tmp/wl-ready and blocks. Tests
+#                run it in the background, wait for /tmp/wl-ready, read
+#                WAYLAND_DISPLAY, and drive cua-driver against native clients.
+#   * label    — human label for logs.
+#
+# Supported desktops (the compositor IS the per-desktop difference):
+#   xfce-labwc   — labwc, the compositor XFCE 4.20's Wayland session uses
+#   xfce-wayfire — the other compositor XFCE 4.20's Wayland session supports
+#   xfce-sway    — sway (wlroots, headless-friendly)
+#   kde          — KDE Plasma's kwin_wayland (virtual backend)
+#   gnome        — GNOME Shell / mutter headless (virtual monitor)
+#
+# Everything runs HEADLESS (no GPU/seat): wlroots compositors use the headless
+# backend + pixman software renderer; kwin uses --virtual; mutter uses
+# --headless --virtual-monitor.
+{
+  pkgs,
+  desktop,
+}:
+
+let
+  inherit (pkgs) lib;
+
+  # Native-Wayland tooling only. No xorg.* / xdotool / xterm here — those are
+  # X11 and would let the driver cheat via XWayland. `foot` is a Wayland-native
+  # terminal; `grim` captures the wlroots output for the GIF artifacts.
+  commonPkgs = with pkgs; [
+    foot
+    grim
+    dbus
+    procps
+  ];
+
+  # Minimal sway config: native Wayland only (XWayland off), stable output.
+  swayConfig = pkgs.writeText "sway-config" ''
+    xwayland disable
+    output HEADLESS-1 resolution 1280x1024
+    exec_always foot --server
+  '';
+
+  # Minimal wayfire config: XWayland disabled so apps are forced native.
+  wayfireConfig = pkgs.writeText "wayfire.ini" ''
+    [core]
+    plugins = autostart
+    xwayland = false
+
+    [autostart]
+    autostart_wf_shell = false
+  '';
+
+  desktops = {
+    "xfce-labwc" = {
+      label = "XFCE on labwc (native Wayland)";
+      packages = with pkgs; [ labwc ];
+      wlroots = true;
+      launch = "labwc >/tmp/compositor.log 2>&1 &";
+    };
+    "xfce-wayfire" = {
+      label = "XFCE on wayfire (native Wayland)";
+      packages = with pkgs; [ wayfire ];
+      wlroots = true;
+      launch = "wayfire -c ${wayfireConfig} >/tmp/compositor.log 2>&1 &";
+    };
+    "xfce-sway" = {
+      label = "XFCE on sway (native Wayland)";
+      packages = with pkgs; [ sway ];
+      wlroots = true;
+      launch = "sway -c ${swayConfig} >/tmp/compositor.log 2>&1 &";
+    };
+    "kde" = {
+      label = "KDE Plasma kwin_wayland (native Wayland)";
+      packages = with pkgs; [ kdePackages.kwin ];
+      wlroots = false;
+      # No --xwayland: keep the session native-Wayland only.
+      launch = "kwin_wayland --virtual --width 1280 --height 1024 --no-lockscreen >/tmp/compositor.log 2>&1 &";
+    };
+    "gnome" = {
+      label = "GNOME Shell / mutter (native Wayland, headless)";
+      packages = with pkgs; [ gnome-shell mutter ];
+      wlroots = false;
+      launch = "gnome-shell --wayland --headless --virtual-monitor 1280x1024 --unsafe-mode >/tmp/compositor.log 2>&1 &";
+    };
+  };
+
+  cfg = desktops.${desktop} or (throw "wayland/session.nix: unknown desktop '${desktop}'");
+
+  wlrootsEnv = lib.optionalString cfg.wlroots ''
+    export WLR_BACKENDS=headless
+    export WLR_RENDERER=pixman
+    export WLR_RENDERER_ALLOW_SOFTWARE=1
+    export WLR_LIBINPUT_NO_DEVICES=1
+  '';
+
+  start = pkgs.writeShellScript "wayland-session-start-${desktop}.sh" ''
+    set -u
+    export PATH=${lib.makeBinPath (commonPkgs ++ cfg.packages)}:$PATH
+
+    export XDG_RUNTIME_DIR=/run/user/0
+    mkdir -p "$XDG_RUNTIME_DIR"
+    chmod 700 "$XDG_RUNTIME_DIR"
+
+    ${wlrootsEnv}
+    export QT_QPA_PLATFORM=wayland
+    export GDK_BACKEND=wayland
+    export LIBGL_ALWAYS_SOFTWARE=1
+
+    rm -f /tmp/wl-ready /tmp/wl-display
+
+    # Run the compositor + readiness wait inside the session bus. `wlsock` is
+    # defined INSIDE this subshell (sh -c spawns a fresh shell) and prints the
+    # name of the first Wayland display socket under XDG_RUNTIME_DIR.
+    dbus-run-session -- sh -c '
+      wlsock() { ls "$XDG_RUNTIME_DIR" 2>/dev/null | grep -E "^wayland-[0-9]+$" | head -1; }
+
+      ${cfg.launch}
+      compositor_pid=$!
+
+      n=0
+      while [ -z "$(wlsock)" ] && [ "$n" -lt 120 ]; do
+        if ! kill -0 "$compositor_pid" 2>/dev/null; then
+          echo "compositor exited early" >&2
+          break
+        fi
+        sleep 0.5
+        n=$((n + 1))
+      done
+
+      sock="$(wlsock)"
+      if [ -z "$sock" ]; then
+        echo "no Wayland display socket appeared" >&2
+        cat /tmp/compositor.log >&2 2>/dev/null || true
+        exit 1
+      fi
+      echo "$sock" > /tmp/wl-display
+
+      touch /tmp/wl-ready
+      exec sleep infinity
+    '
+  '';
+in
+{
+  inherit (cfg) label;
+  packages = commonPkgs ++ cfg.packages;
+  inherit start;
+}

--- a/nix/cua-driver/tests/wayland/session.nix
+++ b/nix/cua-driver/tests/wayland/session.nix
@@ -54,16 +54,6 @@ let
     exec_always foot --server
   '';
 
-  # Minimal wayfire config: XWayland disabled so apps are forced native.
-  wayfireConfig = pkgs.writeText "wayfire.ini" ''
-    [core]
-    plugins = autostart
-    xwayland = false
-
-    [autostart]
-    autostart_wf_shell = false
-  '';
-
   desktops = {
     "xfce-labwc" = {
       label = "XFCE on labwc (native Wayland)";
@@ -71,12 +61,9 @@ let
       wlroots = true;
       launch = "labwc >/tmp/compositor.log 2>&1 &";
     };
-    "xfce-wayfire" = {
-      label = "XFCE on wayfire (native Wayland)";
-      packages = with pkgs; [ wayfire ];
-      wlroots = true;
-      launch = "wayfire -c ${wayfireConfig} >/tmp/compositor.log 2>&1 &";
-    };
+    # NOTE: xfce-wayfire intentionally omitted — wayfire fails to build in the
+    # current nixpkgs pin (wf-config can't link -ldoctest). labwc + sway cover
+    # XFCE-on-wlroots.
     "xfce-sway" = {
       label = "XFCE on sway (native Wayland)";
       packages = with pkgs; [ sway ];


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive Test-Driven Development (TDD) red suite for native Wayland support in cua-driver. The suite specifies the work needed to make the Linux backend functional on native Wayland by testing against real Wayland sessions across five different desktop environments.

## Key Changes

- **New Wayland test infrastructure** (`nix/cua-driver/tests/wayland/`):
  - `session.nix`: Headless Wayland session launcher supporting labwc, wayfire, sway, KDE Plasma (kwin_wayland), and GNOME Shell (mutter)
  - `driver-client.nix`: Shared MCP client for tests that discovers windows exclusively through cua-driver's `list_windows` (no X11 fallback)
  - `record-wayland-gif.nix`: Screen recording helper using `grim` for wlroots compositors

- **Five test scenarios** (per desktop, expected to fail):
  - `integration.nix`: Verifies MCP handshake and window enumeration via `list_windows`
  - `screenshot.nix`: Tests window capture via `get_window_state` with vision mode
  - `cursor-click-gif.nix`: Tests focused input injection (click + type) with GIF recording
  - `background-terminal-gif.nix`: Tests focus-free input injection into inactive windows
  - `parallel-drag.nix`: Tests multi-pointer drag operations (expected to fail hard on Wayland)

- **Background GUI test** (`background-gui.nix`):
  - Per-desktop, per-app variant testing read-only window state capture
  - Supports foot (Wayland terminal), gedit (GTK3), and kcalc (Qt6)

- **GitHub Actions workflow** (`.github/workflows/nix-wayland.yml`):
  - Opt-in workflow (manual dispatch or `cua-driver-wayland` PR label)
  - 25 job matrix (5 desktops × 5 scenarios) + 15 background-GUI jobs
  - All jobs marked `continue-on-error: true` (expected failures)
  - AWS S3 Nix cache integration with OIDC authentication
  - Artifact collection (screenshots, GIFs, logs) for inspection

- **Flake integration** (`flake.nix`):
  - Registers all Wayland checks under `checks.x86_64-linux.cua-driver-wayland-*`
  - Parameterized check generation for desktop/scenario/app combinations

- **Documentation** (`nix/cua-driver/tests/wayland/README.md`):
  - Explains why tests fail (X11-only implementation)
  - Describes required native Wayland paths (window enumeration, screencopy, virtual input)
  - Documents test matrix and how to run individual checks

## Implementation Details

- **Native-Wayland enforcement**: Tests never set `DISPLAY` and disable XWayland where possible, forcing the driver to work with real Wayland clients or fail
- **Headless compositors**: All desktops run headless (wlroots with pixman renderer, kwin with `--virtual`, mutter with `--headless`)
- **Per-compositor differences**: Only the compositor launch command varies; session setup is shared
- **Artifact preservation**: Screenshots, GIFs, and logs are uploaded to GitHub Actions artifacts for post-mortem analysis
- **Nix cache optimization**: Signed builds are cached to S3 to avoid repeated compilation

This is a specification-by-test approach: each failing check documents exactly what native Wayland capability is needed (window enumeration, capture, input injection, multi-pointer support) and on which compositors.

https://claude.ai/code/session_01BaHABvpkD9CvnKGMa5CEqc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added native Wayland test suite supporting multiple desktop environments and test scenarios including integration, screenshots, cursor operations, and multi-touch interactions
  
* **Documentation**
  * Added comprehensive guide for the native Wayland test suite
  
* **Chores**
  * Set up automated CI workflow for running native Wayland tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->