### PR TITLE
fix(computer-server): tolerate any Accept header on /mcp (claude.ai connector)

### DIFF
--- a/libs/python/computer-server/computer_server/main.py
+++ b/libs/python/computer-server/computer_server/main.py
@@ -209,9 +209,54 @@ class McpBarePathRewrite:
         await self.app(scope, receive, send)
 
 
-# Mount MCP server at /mcp - FastMCP's internal path is "/" so endpoint is /mcp
+class McpAcceptHeaderShim:
+    """Make the MCP streamable-HTTP endpoint tolerant of the Accept header.
+
+    The MCP Python SDK's StreamableHTTP transport rejects requests with
+    JSON-RPC -32600 ("Not Acceptable: Client must accept ...") unless the
+    request's Accept header advertises BOTH ``application/json`` and
+    ``text/event-stream`` (POST path), or ``text/event-stream`` (GET SSE
+    path). claude.ai's MCP connector does not always send both, so its
+    handshake POST to /mcp is rejected before it ever reaches a tool.
+
+    This pure-ASGI shim normalizes the inbound Accept header for /mcp
+    requests so it always contains both media types, which lets the SDK's
+    Accept check pass for every client regardless of what it sent. It only
+    rewrites the REQUEST header — it does not touch ``json_response`` or any
+    response semantics, so the server still negotiates JSON vs. SSE exactly
+    as it would otherwise. This keeps existing MCP clients (Claude Code,
+    SDK) unaffected while admitting stricter/looser connectors.
+
+    Scoped to the /mcp prefix only; all other routes are passed through
+    untouched. Pure ASGI (not BaseHTTPMiddleware) so streaming responses
+    are not buffered.
+    """
+
+    _COMBINED = b"application/json, text/event-stream"
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        path = scope.get("path", "")
+        # Match the bare /mcp endpoint and anything under /mcp/, but NOT
+        # unrelated routes that merely share the prefix (e.g. /mcpx).
+        if scope["type"] == "http" and (path == "/mcp" or path.startswith("/mcp/")):
+            headers = [(k, v) for (k, v) in scope.get("headers", []) if k != b"accept"]
+            headers.append((b"accept", self._COMBINED))
+            scope = dict(scope, headers=headers)
+        await self.app(scope, receive, send)
+
+
+# Mount MCP server at /mcp - FastMCP's internal path is "/" so endpoint is /mcp.
+#
+# Middleware ordering note: Starlette's app.add_middleware() prepends, so the
+# LAST one added runs FIRST (outermost). We want, outermost -> innermost:
+#   McpBarePathRewrite (fix the path) -> McpAcceptHeaderShim (fix Accept) -> app
+# so add McpAcceptHeaderShim first, then McpBarePathRewrite.
 if _mcp_http_app:
     app.mount("/mcp", _mcp_http_app)
+    app.add_middleware(McpAcceptHeaderShim)
     app.add_middleware(McpBarePathRewrite)
 
 protocol_version = 1

--- a/libs/python/computer-server/tests/test_server.py
+++ b/libs/python/computer-server/tests/test_server.py
@@ -81,3 +81,82 @@ class TestMcpBarePathRewrite:
         for path in ("/mcp/", "/mcpx", "/status", "/"):
             await shim({"type": "http", "path": path}, None, None)
             assert seen["path"] == path
+
+
+class TestMcpAcceptHeaderShim:
+    """Test the ASGI shim that normalizes the Accept header for /mcp so the
+    MCP SDK's strict Accept check passes for any client (SRP: Only tests the
+    Accept-header rewrite). Pure ASGI with no deps; tested standalone."""
+
+    @staticmethod
+    def _accept(headers):
+        for k, v in headers:
+            if k == b"accept":
+                return v
+        return None
+
+    @pytest.mark.asyncio
+    async def test_mcp_accept_header_is_normalized(self):
+        try:
+            from computer_server.main import McpAcceptHeaderShim
+        except ImportError:
+            pytest.skip("computer_server module not installed")
+        except Exception as e:
+            pytest.skip(f"Server initialization requires specific setup: {e}")
+
+        seen = {}
+
+        async def inner(scope, receive, send):
+            seen.update(scope)
+
+        shim = McpAcceptHeaderShim(inner)
+        # claude.ai-style request that only advertises application/json:
+        for path in ("/mcp", "/mcp/", "/mcp/anything"):
+            await shim(
+                {"type": "http", "path": path, "headers": [(b"accept", b"application/json")]},
+                None,
+                None,
+            )
+            assert self._accept(seen["headers"]) == b"application/json, text/event-stream"
+
+    @pytest.mark.asyncio
+    async def test_missing_accept_header_is_added(self):
+        try:
+            from computer_server.main import McpAcceptHeaderShim
+        except ImportError:
+            pytest.skip("computer_server module not installed")
+        except Exception as e:
+            pytest.skip(f"Server initialization requires specific setup: {e}")
+
+        seen = {}
+
+        async def inner(scope, receive, send):
+            seen.update(scope)
+
+        shim = McpAcceptHeaderShim(inner)
+        await shim({"type": "http", "path": "/mcp", "headers": []}, None, None)
+        assert self._accept(seen["headers"]) == b"application/json, text/event-stream"
+
+    @pytest.mark.asyncio
+    async def test_non_mcp_paths_untouched(self):
+        try:
+            from computer_server.main import McpAcceptHeaderShim
+        except ImportError:
+            pytest.skip("computer_server module not installed")
+        except Exception as e:
+            pytest.skip(f"Server initialization requires specific setup: {e}")
+
+        seen = {}
+
+        async def inner(scope, receive, send):
+            seen.update(scope)
+
+        shim = McpAcceptHeaderShim(inner)
+        for path in ("/status", "/", "/mcpx", "/ws"):
+            await shim(
+                {"type": "http", "path": path, "headers": [(b"accept", b"application/json")]},
+                None,
+                None,
+            )
+            # Untouched: still exactly what the client sent.
+            assert self._accept(seen["headers"]) == b"application/json"


### PR DESCRIPTION
## Problem

claude.ai's MCP connector fails to connect to the computer-server's `/mcp`
endpoint with `Your account was authorized, but ... returned an error when
connecting`. Hitting `/mcp` returns:

```json
{"jsonrpc":"2.0","id":"server-error","error":{"code":-32600,"message":"Not Acceptable: Client must accept both application/json and text/event-stream"}}
```

The MCP Python SDK's StreamableHTTP transport rejects a request unless its
`Accept` header advertises **both** `application/json` and `text/event-stream`
(POST path), or `text/event-stream` (GET SSE path). Some MCP clients (incl.
claude.ai's connector) don't send both, so the handshake POST is rejected
before reaching any tool. supergateway-fronted servers (e.g. cua-driver) are
lenient here and work; the FastMCP-native computer-server does not.

This is distinct from the bare-`/mcp` 404 fixed in #1887 — that fix is intact.

## Fix

Add `McpAcceptHeaderShim`, a pure-ASGI middleware scoped to `/mcp` that
normalizes the inbound `Accept` header to `application/json, text/event-stream`.
It rewrites only the **request** header — it does not set `json_response` or
touch any response semantics, so SSE-vs-JSON negotiation and existing clients
(Claude Code, SDK) are unaffected. Mounted inside the existing
`McpBarePathRewrite` (kept intact); middleware ordering documented in-code.

`json_response=True` was deliberately *not* used: it only relaxes the POST path
(the GET SSE path still hard-requires `text/event-stream`) and would change
response framing for other clients.

## Tests

- `tests/test_server.py::TestMcpAcceptHeaderShim` — normalizes json-only Accept
  on `/mcp`, `/mcp/`, `/mcp/...`; adds a missing Accept; leaves non-mcp paths
  (`/status`, `/`, `/mcpx`, `/ws`) untouched.
- Verified by in-process integration test against the real FastMCP/MCP SDK
  (fastmcp 2.14.x): json-only `Accept` POST `initialize` returns `406 / -32600`
  **without** the shim and `200 + mcp-session-id` **with** it, on both `/mcp`
  and `/mcp/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP Accept header normalization for MCP-routed requests to improve compatibility with MCP StreamableHTTP transports and various client implementations.

* **Tests**
  * Added comprehensive test coverage for MCP HTTP Accept header normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->