### PR TITLE
fix(cursor): seed default cursor with enabled=false to prevent overlay process leak

### DIFF
--- a/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
@@ -467,6 +467,7 @@ impl RenderStateCore {
             }
             OverlayCommand::SetEnabled(v) => {
                 self.visible = v;
+                self.cfg.enabled = v; // keep cfg.enabled in sync with visible (#1900)
                 true
             }
             OverlayCommand::SetMotion(m) => {

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
@@ -96,6 +96,7 @@ impl RenderStateCore {
         let palette = cfg.palette();
         let motion = cfg.motion.clone();
         let shape = cfg.shape.clone();
+        let visible = cfg.enabled;
         Self {
             cfg,
             palette,
@@ -111,7 +112,7 @@ impl RenderStateCore {
             spring_tgt: None,
             click_t: None,
             pressed: false,
-            visible: true,
+            visible, // was hardcoded true — respect config.enabled (#1777)
             idle_secs: 0.0,
             idle_alpha: 1.0,
             pinned_wid: None,

--- a/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
@@ -156,7 +156,10 @@ pub fn init(cfg: CursorConfig) {
     *CMD_RX_CELL.lock().unwrap() = Some(rx);
     *ARRIVAL_TX.lock().unwrap() = Some(HashMap::new());
     let mut cursors = IndexMap::new();
-    cursors.insert("default".to_owned(), RenderState::new(cfg.clone()));
+    // Default cursor starts disabled — see state.rs:new() and #1777.
+    let mut default_cfg = cfg.clone();
+    default_cfg.enabled = false;
+    cursors.insert("default".to_owned(), RenderState::new(default_cfg));
     *RENDER.lock().unwrap() = Some(RenderMap {
         cursors,
         win_w: 0.0,

--- a/libs/cua-driver/rust/crates/platform-macos/src/cursor/state.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/cursor/state.rs
@@ -59,8 +59,17 @@ pub struct CursorRegistry {
 impl CursorRegistry {
     pub fn new() -> Self {
         let mut map = HashMap::new();
+        let default_cfg = CursorConfig {
+            // Default cursor starts DISABLED. The anonymous / non-session
+            // path must never render a cursor — the documented contract is
+            // "without a session, actions run cursor-less." A session's
+            // first enable/start_session call activates its own cursor.
+            // See #1777.
+            enabled: false,
+            ..CursorConfig::default()
+        };
         let default = CursorState {
-            config: CursorConfig::default(),
+            config: default_cfg,
             position: None,
         };
         map.insert("default".into(), default);
@@ -203,15 +212,17 @@ mod tests {
     }
 
     #[test]
-    fn default_cursor_unaffected_by_guard() {
-        // "default" is seeded and is never tombstoned — its mutators still work.
+    fn default_cursor_starts_disabled() {
+        // Default cursor is seeded disabled — anonymous calls must be
+        // cursor-less per the documented contract. See #1777.
         let reg = CursorRegistry::new();
         assert!(!cua_driver_core::session::is_session_ended("default"));
-        reg.set_enabled("default", false);
-        reg.update_position("default", 1.0, 2.0);
         let s = reg.get("default").expect("default cursor always present");
-        assert!(!s.config.enabled);
-        assert_eq!(s.position.as_ref().map(|p| (p.x, p.y)), Some((1.0, 2.0)));
+        assert!(!s.config.enabled, "default cursor must start disabled");
+        // But mutators still work — a session that enables it should succeed.
+        reg.set_enabled("default", true);
+        let s2 = reg.get("default").unwrap();
+        assert!(s2.config.enabled);
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/cursor_tools.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/cursor_tools.rs
@@ -603,8 +603,9 @@ mod tests {
         };
         assert!(read_for(&json!({ "session": "sessA" })));
         assert!(!read_for(&json!({ "session": "sessB" })));
-        // Anonymous caller (no session) falls back to the seeded default (on).
-        assert!(read_for(&json!({})));
+        // Anonymous caller (no session) falls back to the seeded default,
+        // which starts disabled per #1777.
+        assert!(!read_for(&json!({})));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Every anonymous (non-session) CUA tool call spawns a cursor overlay process
that is never cleaned up, causing 30+ zombie processes after moderate use.

Root cause: the default cursor is seeded in three places with a hardcoded
assumption that it should always render:

1. `CursorRegistry::new()` seeds `"default"` with `enabled: true`
2. `overlay::init()` seeds default render state from the launch config
3. `RenderStateCore::new()` hardcodes `visible: true`, ignoring
   `cfg.enabled` entirely — the documented contract says "without a
   session, actions run cursor-less" but the code always renders

The `"default"` key is explicitly guarded against removal (both in
`CursorRegistry::remove()` and `overlay::apply_msg()`), so these
overlays accumulate until daemon restart.

## Fix (3 files, 24 lines)

1. **`platform-macos/src/cursor/state.rs`** — seed default cursor
   registry entry with `enabled: false`
2. **`platform-macos/src/cursor/overlay.rs`** — seed default render
   state with `enabled: false` 
3. **`cursor-overlay/src/render_state.rs`** — derive `visible` from
   `cfg.enabled` instead of hardcoding `true`

The overlay NSWindow still exists (AppKit lifecycle unchanged) but the
default cursor draws nothing — `paint_cursor` early-returns on
`!visible`, and `animate_cursor_to` skips on `!cfg.enabled`.
Session cursors still work normally via `set_agent_cursor_enabled` /
`start_session`.

## Verification

- Updated test: `default_cursor_starts_disabled` verifies the seed
- Existing cursor tests pass unchanged for session-based paths
- Manual: HermesBar + Hermes agent, 20+ anonymous CUA calls → 1 daemon
  process (vs 30+ before)

Closes #1777

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Cursor overlay visibility now properly respects launch-time configuration settings instead of defaulting to always enabled.
* Default cursor overlay initializes to disabled state for predictable, configuration-based control.
* Updated tests to verify correct initialization and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->