### PR TITLE
docs: clarify Cua contribution guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,20 +11,20 @@ If you've encountered a bug in the project, we encourage you to report it. Pleas
    - A clear title and detailed description
    - Steps to reproduce the issue
    - Expected vs actual behavior
-   - Your environment (macOS version, lume version)
+   - Your environment (OS version and relevant Cua package or CLI version)
    - Any relevant logs or error messages
 3. **Label Your Issue**: Label your issue as a `bug` to help maintainers identify it quickly.
 
 ## Suggesting Enhancements
 
-We're always looking for suggestions to make lume better. If you have an idea:
+We're always looking for suggestions to make Cua better. If you have an idea:
 
 1. **Check Existing Issues**: See if someone else has already suggested something similar.
 2. **Create a New Issue**: If your enhancement is new, create an issue describing:
    - The problem your enhancement solves
    - How your enhancement would work
    - Any potential implementation details
-   - Why this enhancement would benefit lume users
+   - Why this enhancement would benefit Cua users
 
 ## Code Formatting
 


### PR DESCRIPTION
## Summary
- Update the root contribution guide to ask for the relevant OS and Cua package/CLI version instead of only macOS/lume details.
- Refer to Cua users in the monorepo-wide enhancement guidance.

## Validation
- Checking formatting...
All matched files use Prettier code style!

Note: the repo-wide 
> @ prettier:check /Users/sheroyC/Desktop/Apps/Catalina_apps/trending-repo-improvements/cua
> prettier --check '**/*.{ts,tsx,js,jsx,json,md,mdx,yaml,yml}'

Checking formatting...
 ELIFECYCLE  Command failed with exit code 1. currently reports pre-existing formatting warnings outside this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with consistent naming and terminology.
  * Refined bug-reporting environment requirements to include OS version and package information.
  * Updated enhancement issue checklist wording for terminology alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->