### PR TITLE
docs: add translated README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@
 
 </div>
 
+<!-- Keep these links, translations synced daily. -->
+<p align="center">
+<a href="https://zdoc.app/de/trycua/cua">Deutsch</a> |
+<a href="https://zdoc.app/es/trycua/cua">Español</a> |
+<a href="https://zdoc.app/fr/trycua/cua">français</a> |
+<a href="https://zdoc.app/ja/trycua/cua">日本語</a> |
+<a href="https://zdoc.app/ko/trycua/cua">한국어</a> |
+<a href="https://zdoc.app/pt/trycua/cua">Português</a> |
+<a href="https://zdoc.app/ru/trycua/cua">Русский</a> |
+<a href="https://zdoc.app/zh/trycua/cua">中文</a>
+</p>
+
 ## Choose Your Path
 
 <div align="center">


### PR DESCRIPTION
This PR adds links to translated versions of the README to help non-English-speaking users access translated documentation.

Supported languages:

- German
- Spanish
- French
- Japanese
- Korean
- Portuguese
- Russian
- Chinese

Translations are automatically synchronized and require no maintenance effort from project maintainers.

This change only affects README documentation and does not modify project code, dependencies, CI workflows, or repository settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added multi-language translation links section to the README, including support for Deutsch, Español, français, 日本語, 한국어, Português, Русский, and 中文

<!-- end of auto-generated comment: release notes by coderabbit.ai -->