### PR TITLE
fix(cua-driver-rs)(macos): sign release with screen-capture entitlement

### DIFF
--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -264,6 +264,7 @@ jobs:
         run: |
           IDENTITY="Developer ID Application: ${DEVELOPER_NAME} (${TEAM_ID})"
           codesign --force --timestamp --options runtime \
+            --entitlements scripts/CuaDriver.entitlements \
             --sign "$IDENTITY" release/universal/cua-driver
           codesign --verify --strict --verbose=2 release/universal/cua-driver
       - name: Assemble CuaDriver.app bundle
@@ -324,6 +325,7 @@ jobs:
           # is essentially a no-op on the binary and a fresh signature
           # on the bundle wrapper.
           codesign --force --deep --timestamp --options runtime \
+            --entitlements scripts/CuaDriver.entitlements \
             --sign "$IDENTITY" release/CuaDriver.app
           codesign --verify --strict --verbose=2 release/CuaDriver.app
 

--- a/docs/content/docs/cua-driver/reference/changelog.mdx
+++ b/docs/content/docs/cua-driver/reference/changelog.mdx
@@ -18,6 +18,19 @@ The canonical, always-current source is the
 release body is auto-generated per release from the commits touching
 `libs/cua-driver/rust`, including SHA256 checksums and install instructions.
 
+## 0.5.4 (2026-06-15)
+
+- **macOS: fix 0x0 screenshots on macOS 15+ — the release bundle now ships the
+  `com.apple.security.device.screen-capture` entitlement.** The macOS release
+  codesign steps signed the universal binary and `CuaDriver.app` with the
+  hardened runtime but passed no entitlements file, so on macOS 15 Sequoia and
+  later `SCStream.startCapture` failed with "Missing entitlements" even when TCC
+  Screen Recording was granted, and vision capture (`screenshot`,
+  `get_window_state`) returned a 0x0 image. The release pipeline now signs with
+  an entitlements plist granting `com.apple.security.device.screen-capture`
+  (plus `com.apple.security.automation.apple-events`), restoring capture
+  (#1893, #1862).
+
 ## 0.5.3 (2026-06-11)
 
 - **Linux: background drag and held-button tools + MPX parallel drags** (#1871).

--- a/libs/cua-driver/rust/scripts/CuaDriver.entitlements
+++ b/libs/cua-driver/rust/scripts/CuaDriver.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.device.screen-capture</key>
+    <true/>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## What

Add a macOS entitlements plist and pass it via `--entitlements` in both
`codesign` steps of `cd-rust-cua-driver.yml`, so the released binary and
`CuaDriver.app` are signed with `com.apple.security.device.screen-capture`.

## Why (#1893, root of #1862)

The release codesign steps used `--options runtime` (hardened runtime) but
passed **no** `--entitlements`, so the published 0.5.3 bundle carries **zero**
entitlements. Verified against the actual release artifact:

```
$ codesign -dvv CuaDriver.app        # 0.5.3 universal
Authority=Developer ID Application: Cua AI, Inc. (YCK386LBJ7)
CodeDirectory ... flags=0x10000(runtime)
$ codesign -d --entitlements - CuaDriver.app
(empty — no entitlements)
```

Under the hardened runtime, `SCStream.startCapture` fails with "Missing
entitlements" on macOS 15+ even when TCC Screen Recording is granted, so
`screenshot` / `get_window_state` vision capture returns a 0x0 image.

## Fix

- New `libs/cua-driver/rust/scripts/CuaDriver.entitlements` granting
  `com.apple.security.device.screen-capture` and
  `com.apple.security.automation.apple-events`.
- Both codesign steps (bare universal binary, line ~266; `CuaDriver.app`,
  line ~326) now pass `--entitlements scripts/CuaDriver.entitlements`.

## Verification

Re-signed the real released 0.5.3 binary with this plist locally (ad-hoc +
hardened runtime, same flags as CI) and confirmed the entitlement embeds:

```
$ codesign -d --entitlements - cua-driver | grep screen-capture
        <key>com.apple.security.device.screen-capture</key>
```

The entitlements plist is intentionally comment-free — `AMFIUnserializeXML`
(codesign's entitlements parser) rejects XML comments with a syntax error.

## Scope / notes

- Release-pipeline + signing change. No Rust code change.
- Ships in the next patch (0.5.4), cut via the `release-bump-version` action
  after merge.
- The Swift driver has its own entitlements file; this one is scoped to the
  Rust release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS 15+ screenshot functionality that was producing zero-sized or empty images. Screen and window capture now works correctly on macOS Sequoia and later versions, restoring full application functionality.

* **Documentation**
  * Updated changelog with version 0.5.4 release notes documenting the macOS compatibility fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->