### PR TITLE
fix(cua-driver-rs): make Cargo.toml the source of truth for release bumps

### DIFF
--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -200,6 +200,31 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Reconcile cua-driver-rs bump base with Cargo.toml (drift guard)
+        if: ${{ inputs.service == 'cua-driver-rs' }}
+        run: |
+          # Cargo.toml is the single source of truth for the cua-driver-rs
+          # version. bump2version keeps a duplicate current_version in
+          # .bumpversion.cfg, and that copy has silently drifted before and cut
+          # a release at the wrong version (binary reported a stale version,
+          # tag could downgrade). Reconcile the cfg to Cargo.toml here, before
+          # the dry-run tag-clean and the real bump both read it, so a bump can
+          # never start from a stale base again no matter what the committed
+          # cfg says.
+          cd "${{ steps.package.outputs.directory }}"
+          CARGO_VERSION=$(grep -m1 '^version[[:space:]]*=' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          CFG_VERSION=$(grep -m1 '^current_version[[:space:]]*=' .bumpversion.cfg | sed -E 's/.*=[[:space:]]*//')
+          if [ -z "$CARGO_VERSION" ]; then
+            echo "::error::could not read version from libs/cua-driver/rust/Cargo.toml"
+            exit 1
+          fi
+          if [ "$CARGO_VERSION" != "$CFG_VERSION" ]; then
+            echo "::warning::.bumpversion.cfg current_version ($CFG_VERSION) drifted from Cargo.toml ($CARGO_VERSION); reconciling to Cargo.toml before bump."
+            sed -i.bak -E "s/^current_version[[:space:]]*=.*/current_version = ${CARGO_VERSION}/" .bumpversion.cfg
+            rm -f .bumpversion.cfg.bak
+          fi
+          echo "cua-driver-rs bump base: $(grep -m1 '^current_version' .bumpversion.cfg)"
+
       - name: Clean existing tags if present
         run: |
           # Function to clean a tag for a given package directory

--- a/libs/cua-driver/rust/.bumpversion.cfg
+++ b/libs/cua-driver/rust/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.3
+current_version = 0.5.3
 commit = True
 tag = True
 tag_name = cua-driver-rs-v{new_version}


### PR DESCRIPTION
## What

Stop the cua-driver-rs release version from drifting, so a bump can never cut a
release at the wrong version again.

## Why (root cause behind #1870, and the reason the 0.5.x re-release needed care)

`release-bump-version` runs `bump2version` off
`libs/cua-driver/rust/.bumpversion.cfg`, which keeps a **duplicate**
`current_version`. That copy had drifted badly:

```
.bumpversion.cfg current_version = 0.4.3
Cargo.toml       version          = 0.5.3
```

`bump2version` bumps from `current_version` and search-replaces
`version = "{current_version}"` in `Cargo.toml`. With the cfg at 0.4.3, a patch
bump would compute `0.4.4` (a downgrade tag) and the `version = "0.4.3"` search
would miss `0.5.3` entirely — so `Cargo.toml` stays put and the built binary
reports a stale version. That is the 0.5.2 stale-binary failure mode (#1870).
PR #1854 tried to fix this by setting the cfg to `0.5.1`, but that value was
already stale too — it just moves the drift.

## Fix (make it impossible to recur)

1. Sync `.bumpversion.cfg` `current_version` to `0.5.3` (matches `Cargo.toml`).
2. Add a **reconcile step** to `release-bump-version.yml` (gated on
   `service == cua-driver-rs`) that rewrites `current_version` from `Cargo.toml`
   **before** bump2version reads it — for both the dry-run tag-clean and the
   real bump. `Cargo.toml` is now the single source of truth, so the cfg can
   never start a bump from a stale base again no matter how it drifts. It emits
   a `::warning::` when it has to correct, so silent drift stays visible.

## Verification

- `bump2version --dry-run` from base `0.5.3` -> `new_version=0.5.4`, tag
  `cua-driver-rs-v0.5.4`.
- Reconcile logic self-heals a simulated `0.4.3` drift back to `0.5.3` against
  the real `Cargo.toml`.

## Notes

- Release-infra only; no driver code or user-facing behavior change, so no
  changelog entry.
- **Supersedes #1854** — recommend closing it.
- Pairs with #1906 (macOS screen-capture entitlement); both need to be on
  `main` before the next `release-bump-version` cuts 0.5.4 cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped cua-driver-rs version to 0.5.3
  * Enhanced release automation to ensure version consistency across configuration files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->