### PR TITLE
spike(cua-driver): native-Wayland backgrounded per-window input injection

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/spikes/wayland-bg-input/README.md
+++ b/libs/cua-driver/rust/crates/platform-linux/spikes/wayland-bg-input/README.md
@@ -1,0 +1,108 @@
+# Spike 0 — native-Wayland backgrounded per-window input injection
+
+**Question:** On native Wayland (no XWayland), can we deliver pointer input to a
+**specific, unfocused window** — without raising it, without moving the user's
+real cursor, and without a real input device — such that **real UI toolkits act
+on it**? This is the load-bearing unknown for adding background, multi-cursor
+computer-use to cua-driver on Wayland (the "16-window cursive" demo), via the
+libei/EIS "remote-control" route where the EIS server lives inside a
+cua-controlled compositor.
+
+**Answer: YES.** Validated for raw libwayland (`wev`), **GTK4**, **Qt6**, and
+**Chromium** (Google Chrome 149 — the accessibility-less / Electron-class case).
+
+## Mechanism
+
+A Wayland client cannot inject into another client; only the compositor can.
+The compositor delivers pointer events straight to the **target client's
+existing `wl_pointer` resources**, bypassing the `wlr_seat` focus machinery
+entirely (the Wayland analogue of X11 `XSendEvent`-to-XID):
+
+```c
+struct wl_client *c = wl_resource_get_client(surface->resource);
+struct wlr_seat_client *sc = wlr_seat_client_for_wl_client(seat, c);
+uint32_t serial = wlr_seat_client_next_serial(sc);
+struct wl_resource *res;
+wl_resource_for_each(res, &sc->pointers) {
+    wl_pointer_send_enter(res, serial, surface->resource, sx, sy);
+    wl_pointer_send_motion(res, time, sx, sy);
+    wl_pointer_send_button(res, serial2, time, BTN_LEFT, WL_POINTER_BUTTON_STATE_PRESSED);
+    /* ... released, frame ... */
+}
+```
+
+`wlr_seat`'s focus/cursor state is never touched: no `wlr_seat_pointer_notify_*`,
+no `server.seat.cursor` movement, no window raise.
+
+## What's here
+
+| File | Purpose |
+|---|---|
+| `tinywl.spike.patch` | Unified diff against wlroots **0.19** `tinywl/tinywl.c`. Adds focus-bypassing injection on a timer (no keyboard needed) into every non-focused toplevel. |
+| `spike_patch.py` | The generator that produces the above (idempotent, asserts anchors). |
+| `gtk4_test.c` | Minimal GTK4 client logging pointer enter/press + button **activation**. |
+| `qt6_test.cpp` | Minimal Qt6 widget client logging enter/press + button **activation**. |
+| `spike.html` | Chromium test page; button `onclick` sets `document.title` (observed via `xdg_toplevel.set_title`, so no rendering/visuals needed). |
+
+The compositor vehicle is **tinywl** (wlroots' ~1000-line reference compositor),
+not labwc, because the question is about wlroots seat mechanics + toolkit
+behavior, which are compositor-agnostic. tinywl is trivial to patch and build.
+
+## Results
+
+Each toolkit ran as an **unfocused** target (a second client held focus) under
+headless tinywl; injection fired at the window's content center:
+
+| Client | Outcome on the unfocused window |
+|---|---|
+| `wev` (raw libwayland) | received `enter`/`motion`/`button`; the focused client received nothing |
+| **GTK4** | `ENTER → MOTION → PRESSED → button CLICKED` |
+| **Qt6** | `ENTER → PRESSED → button CLICKED` |
+| **Chromium** | DOM `onclick` fired → title → `CLICKED-OK` (renderer hit-test + JS ran) |
+
+## Implementation learnings (must carry into the real EIS server)
+
+1. **Inject at the xdg window-geometry content center**, not the surface
+   origin. Toolkits with client-side decorations (GTK4/Qt) exclude the
+   shadow/resize margin from their input region, so naïve `(30,30)` is silently
+   dropped. Use `xdg_toplevel->base->geometry` (x/y/w/h). Raw clients (`wev`)
+   have no such margin, which is why they reacted to `(30,30)` and GTK didn't.
+2. **Send `wl_pointer.leave` before re-`enter`** on the same surface. Qt warns
+   that back-to-back enters violate the protocol (it works around it); the real
+   server must track enter/leave state per (device, surface).
+3. **Headless has no input devices**, so the compositor must explicitly
+   `wlr_seat_set_capabilities(seat, WL_SEAT_CAPABILITY_POINTER)` or clients
+   never bind a `wl_pointer`.
+
+## Reproduce
+
+On an Ubuntu 26.04 + wlroots-0.19 host (e.g. the `desktop-workspace-wayland`
+VM), headless:
+
+```bash
+# deps
+apt-get install -y meson ninja-build pkg-config libwayland-bin wayland-protocols \
+    libwayland-dev libwlroots-0.19-dev libxkbcommon-dev libpixman-1-dev \
+    wev libgtk-4-dev qt6-base-dev qt6-wayland
+# patch + build tinywl (fetch wlroots 0.19 tinywl/tinywl.c first)
+python3 spike_patch.py                       # edits ./tinywl.c in place
+wayland-scanner server-header /usr/share/wayland-protocols/stable/xdg-shell/xdg-shell.xml xdg-shell-protocol.h
+wayland-scanner private-code  /usr/share/wayland-protocols/stable/xdg-shell/xdg-shell.xml xdg-shell-protocol.c
+gcc -DWLR_USE_UNSTABLE -I. tinywl.c xdg-shell-protocol.c -o tinywl \
+    $(pkg-config --cflags --libs wlroots-0.19 wayland-server xkbcommon pixman-1)
+# build test clients
+gcc gtk4_test.c -o gtk4_test $(pkg-config --cflags --libs gtk4)
+g++ -std=c++17 qt6_test.cpp -o qt6_test $(pkg-config --cflags --libs Qt6Widgets) -fPIC
+# run (target maps first, wev steals focus second); inspect each client's log
+export XDG_RUNTIME_DIR=/tmp/spike-xdg; mkdir -p $XDG_RUNTIME_DIR; chmod 700 $XDG_RUNTIME_DIR
+export WLR_BACKENDS=headless WLR_RENDERER=pixman WLR_HEADLESS_OUTPUTS=1
+./tinywl -s "stdbuf -oL ./gtk4_test >/tmp/gtk.log 2>&1 & sleep 6; wev >/dev/null 2>&1 &"
+```
+
+`tinywl` logs each injection (`[SPIKE] ...`); the client logs prove receipt.
+
+## Next
+
+This greenlights **Phase A** of the plan: stand up an EIS (libei) server inside
+a cua-controlled compositor that performs this routing, driven by a libei client
+over a direct socket. See the architecture note in the project plan.

--- a/libs/cua-driver/rust/crates/platform-linux/spikes/wayland-bg-input/gtk4_test.c
+++ b/libs/cua-driver/rust/crates/platform-linux/spikes/wayland-bg-input/gtk4_test.c
@@ -1,0 +1,42 @@
+#include <gtk/gtk.h>
+
+static void on_clicked(GtkButton *b, gpointer u) {
+	g_print("GTK4: button CLICKED (activated)\n");
+}
+static void on_pressed(GtkGestureClick *g, int n, double x, double y, gpointer u) {
+	g_print("GTK4: gesture PRESSED at %.0f,%.0f\n", x, y);
+}
+static void on_enter(GtkEventControllerMotion *m, double x, double y, gpointer u) {
+	g_print("GTK4: pointer ENTER at %.0f,%.0f\n", x, y);
+}
+static void on_motion(GtkEventControllerMotion *m, double x, double y, gpointer u) {
+	g_print("GTK4: pointer MOTION at %.0f,%.0f\n", x, y);
+}
+
+int main(int argc, char **argv) {
+	gtk_init();
+	GtkWidget *win = gtk_window_new();
+	gtk_window_set_default_size(GTK_WINDOW(win), 200, 150);
+	gtk_window_set_title(GTK_WINDOW(win), "cua-spike-gtk4");
+
+	GtkWidget *btn = gtk_button_new_with_label("hit me");
+	g_signal_connect(btn, "clicked", G_CALLBACK(on_clicked), NULL);
+
+	GtkGesture *click = gtk_gesture_click_new();
+	g_signal_connect(click, "pressed", G_CALLBACK(on_pressed), NULL);
+	gtk_widget_add_controller(btn, GTK_EVENT_CONTROLLER(click));
+
+	GtkEventController *mot = gtk_event_controller_motion_new();
+	g_signal_connect(mot, "enter", G_CALLBACK(on_enter), NULL);
+	g_signal_connect(mot, "motion", G_CALLBACK(on_motion), NULL);
+	gtk_widget_add_controller(btn, mot);
+
+	gtk_window_set_child(GTK_WINDOW(win), btn);
+	gtk_window_present(GTK_WINDOW(win));
+	g_print("GTK4: window presented\n");
+
+	while (TRUE) {
+		g_main_context_iteration(NULL, TRUE);
+	}
+	return 0;
+}

--- a/libs/cua-driver/rust/crates/platform-linux/spikes/wayland-bg-input/qt6_test.cpp
+++ b/libs/cua-driver/rust/crates/platform-linux/spikes/wayland-bg-input/qt6_test.cpp
@@ -1,0 +1,35 @@
+#include <QApplication>
+#include <QPushButton>
+#include <QMouseEvent>
+#include <cstdio>
+
+class Btn : public QPushButton {
+public:
+	Btn(const QString &t) : QPushButton(t) { setMouseTracking(true); }
+protected:
+	void enterEvent(QEnterEvent *e) override {
+		printf("QT6: ENTER at %d,%d\n", (int)e->position().x(), (int)e->position().y());
+		fflush(stdout);
+		QPushButton::enterEvent(e);
+	}
+	void mousePressEvent(QMouseEvent *e) override {
+		printf("QT6: PRESSED at %d,%d\n", (int)e->position().x(), (int)e->position().y());
+		fflush(stdout);
+		QPushButton::mousePressEvent(e);
+	}
+};
+
+int main(int argc, char **argv) {
+	QApplication a(argc, argv);
+	Btn b("hit me");
+	QObject::connect(&b, &QPushButton::clicked, [] {
+		printf("QT6: button CLICKED (activated)\n");
+		fflush(stdout);
+	});
+	b.resize(200, 150);
+	b.setWindowTitle("cua-spike-qt6");
+	b.show();
+	printf("QT6: window shown\n");
+	fflush(stdout);
+	return a.exec();
+}

--- a/libs/cua-driver/rust/crates/platform-linux/spikes/wayland-bg-input/spike.html
+++ b/libs/cua-driver/rust/crates/platform-linux/spikes/wayland-bg-input/spike.html
@@ -1,0 +1,7 @@
+<!doctype html><html><head><title>BEFORE</title></head>
+<body style="margin:0">
+<button id="b" style="width:100vw;height:100vh;font-size:28px"
+  onpointermove="if(document.title.indexOf('CLICK')<0)document.title='PMOVE-OK'"
+  onpointerdown="document.title='PDOWN-OK'"
+  onclick="document.title='CLICKED-OK'">hit me</button>
+</body></html>

--- a/libs/cua-driver/rust/crates/platform-linux/spikes/wayland-bg-input/spike_patch.py
+++ b/libs/cua-driver/rust/crates/platform-linux/spikes/wayland-bg-input/spike_patch.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# Patch tinywl.c (wlroots 0.19) for Spike 0: focus-bypassing background pointer injection.
+import sys, io
+
+P = "/opt/spike/tinywl.c"
+src = io.open(P, encoding="utf-8").read()
+
+INCLUDES = """#include <linux/input-event-codes.h>
+#include <wayland-server-protocol.h>
+
+"""
+
+FUNCS = r"""
+/* SPIKE 0: focus-bypassing background pointer injection. Deliver wl_pointer
+ * enter+motion+button DIRECTLY to a chosen UNFOCUSED toplevel's client pointer
+ * resources, with NO wlr_seat focus change and NO real pointer device. Tests
+ * whether toolkits act on input to a surface that does not hold seat focus. */
+static uint32_t spike_now_ms(void) {
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (uint32_t)(ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
+}
+
+static void spike_frame(struct wl_resource *res) {
+	if (wl_resource_get_version(res) >= WL_POINTER_FRAME_SINCE_VERSION) {
+		wl_pointer_send_frame(res);
+	}
+}
+
+static void spike_inject_one(struct tinywl_server *server,
+		struct tinywl_toplevel *t) {
+	struct wlr_surface *surface = t->xdg_toplevel->base->surface;
+	const char *title = t->xdg_toplevel->title ? t->xdg_toplevel->title : "(none)";
+	struct wl_client *client = wl_resource_get_client(surface->resource);
+	struct wlr_seat_client *sc =
+		wlr_seat_client_for_wl_client(server->seat, client);
+	if (sc == NULL) {
+		wlr_log(WLR_ERROR, "[SPIKE] '%s': client never bound the seat", title);
+		return;
+	}
+	int n = wl_list_length(&sc->pointers);
+	if (n == 0) {
+		wlr_log(WLR_ERROR, "[SPIKE] '%s': bound no wl_pointer", title);
+		return;
+	}
+	/* Aim at the CONTENT center using xdg window geometry, so we clear any
+	 * client-side-decoration shadow/margin that the client excludes from its
+	 * input region (raw clients like wev have no such margin; GTK/Qt do). */
+	struct wlr_box geo = t->xdg_toplevel->base->geometry;
+	int cx = geo.width > 0 ? geo.x + geo.width / 2 : 100;
+	int cy = geo.height > 0 ? geo.y + geo.height / 2 : 75;
+	wlr_log(WLR_INFO, "[SPIKE] '%s' geometry %dx%d@%d,%d -> inject at %d,%d",
+		title, geo.width, geo.height, geo.x, geo.y, cx, cy);
+	wl_fixed_t sx = wl_fixed_from_int(cx), sy = wl_fixed_from_int(cy);
+	uint32_t tm = spike_now_ms();
+	struct wl_resource *res;
+	uint32_t es = wlr_seat_client_next_serial(sc);
+	wl_resource_for_each(res, &sc->pointers) {
+		wl_pointer_send_enter(res, es, surface->resource, sx, sy);
+		wl_pointer_send_motion(res, tm, sx, sy);
+		spike_frame(res);
+	}
+	uint32_t bs = wlr_seat_client_next_serial(sc);
+	wl_resource_for_each(res, &sc->pointers) {
+		wl_pointer_send_button(res, bs, tm + 5, BTN_LEFT,
+			WL_POINTER_BUTTON_STATE_PRESSED);
+		spike_frame(res);
+	}
+	uint32_t rs = wlr_seat_client_next_serial(sc);
+	wl_resource_for_each(res, &sc->pointers) {
+		wl_pointer_send_button(res, rs, tm + 15, BTN_LEFT,
+			WL_POINTER_BUTTON_STATE_RELEASED);
+		spike_frame(res);
+	}
+	wlr_log(WLR_INFO, "[SPIKE] injected click to UNFOCUSED '%s' (%d ptr, e=%u b=%u r=%u)",
+		title, n, es, bs, rs);
+}
+
+static void spike_inject(struct tinywl_server *server) {
+	if (wl_list_length(&server->toplevels) < 2) {
+		wlr_log(WLR_INFO, "[SPIKE] waiting: need >=2 toplevels, have %d",
+			wl_list_length(&server->toplevels));
+		return;
+	}
+	struct wlr_surface *kfocus = server->seat->keyboard_state.focused_surface;
+	/* Inject into EVERY toplevel that does NOT hold keyboard focus. */
+	struct tinywl_toplevel *t;
+	wl_list_for_each(t, &server->toplevels, link) {
+		struct wlr_surface *surface = t->xdg_toplevel->base->surface;
+		const char *title = t->xdg_toplevel->title ? t->xdg_toplevel->title : "(none)";
+		if (surface == kfocus) {
+			wlr_log(WLR_INFO, "[SPIKE] skipping FOCUSED toplevel '%s'", title);
+			continue;
+		}
+		spike_inject_one(server, t);
+	}
+	wl_display_flush_clients(server->wl_display);
+}
+
+static int spike_timer_cb(void *data) {
+	struct tinywl_server *server = data;
+	static int n = 0;
+	n++;
+	wlr_log(WLR_INFO, "[SPIKE] timer fire #%d", n);
+	spike_inject(server);
+	if (n < 10) {
+		struct wl_event_loop *loop =
+			wl_display_get_event_loop(server->wl_display);
+		struct wl_event_source *src =
+			wl_event_loop_add_timer(loop, spike_timer_cb, server);
+		wl_event_source_timer_update(src, 2000);
+	}
+	return 0;
+}
+
+"""
+
+TIMER = """	struct wl_event_loop *spike_loop = wl_display_get_event_loop(server.wl_display);
+	struct wl_event_source *spike_src = wl_event_loop_add_timer(spike_loop, spike_timer_cb, &server);
+	wl_event_source_timer_update(spike_src, 3000);
+	wlr_log(WLR_INFO, "[SPIKE] armed injection timer (first fire +3s)");
+	"""
+
+def repl(s, old, new, label):
+    c = s.count(old)
+    if c != 1:
+        print("ANCHOR FAIL [%s]: count=%d" % (label, c)); sys.exit(1)
+    print("ok [%s]" % label)
+    return s.replace(old, new)
+
+src = repl(src, "struct tinywl_server {", INCLUDES + "struct tinywl_server {", "includes")
+src = repl(src,
+    'server.seat = wlr_seat_create(server.wl_display, "seat0");',
+    'server.seat = wlr_seat_create(server.wl_display, "seat0");\n\twlr_seat_set_capabilities(server.seat, WL_SEAT_CAPABILITY_POINTER);',
+    "force-pointer-cap")
+src = repl(src, "int main(int argc, char *argv[]) {", FUNCS + "int main(int argc, char *argv[]) {", "inject-funcs")
+src = repl(src, "wl_display_run(server.wl_display);", TIMER + "wl_display_run(server.wl_display);", "arm-timer")
+
+io.open(P, "w", encoding="utf-8").write(src)
+print("PATCHED OK")

--- a/libs/cua-driver/rust/crates/platform-linux/spikes/wayland-bg-input/tinywl.spike.patch
+++ b/libs/cua-driver/rust/crates/platform-linux/spikes/wayland-bg-input/tinywl.spike.patch
@@ -1,0 +1,141 @@
+--- tinywl.c.orig	2026-06-16 19:01:54.638862995 +0000
++++ tinywl.c	2026-06-16 19:01:54.690699333 +0000
+@@ -32,6 +32,9 @@
+ 	TINYWL_CURSOR_RESIZE,
+ };
+ 
++#include <linux/input-event-codes.h>
++#include <wayland-server-protocol.h>
++
+ struct tinywl_server {
+ 	struct wl_display *wl_display;
+ 	struct wlr_backend *backend;
+@@ -871,6 +874,109 @@
+ 	wl_signal_add(&xdg_popup->events.destroy, &popup->destroy);
+ }
+ 
++
++/* SPIKE 0: focus-bypassing background pointer injection. Deliver wl_pointer
++ * enter+motion+button DIRECTLY to a chosen UNFOCUSED toplevel's client pointer
++ * resources, with NO wlr_seat focus change and NO real pointer device. Tests
++ * whether toolkits act on input to a surface that does not hold seat focus. */
++static uint32_t spike_now_ms(void) {
++	struct timespec ts;
++	clock_gettime(CLOCK_MONOTONIC, &ts);
++	return (uint32_t)(ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
++}
++
++static void spike_frame(struct wl_resource *res) {
++	if (wl_resource_get_version(res) >= WL_POINTER_FRAME_SINCE_VERSION) {
++		wl_pointer_send_frame(res);
++	}
++}
++
++static void spike_inject_one(struct tinywl_server *server,
++		struct tinywl_toplevel *t) {
++	struct wlr_surface *surface = t->xdg_toplevel->base->surface;
++	const char *title = t->xdg_toplevel->title ? t->xdg_toplevel->title : "(none)";
++	struct wl_client *client = wl_resource_get_client(surface->resource);
++	struct wlr_seat_client *sc =
++		wlr_seat_client_for_wl_client(server->seat, client);
++	if (sc == NULL) {
++		wlr_log(WLR_ERROR, "[SPIKE] '%s': client never bound the seat", title);
++		return;
++	}
++	int n = wl_list_length(&sc->pointers);
++	if (n == 0) {
++		wlr_log(WLR_ERROR, "[SPIKE] '%s': bound no wl_pointer", title);
++		return;
++	}
++	/* Aim at the CONTENT center using xdg window geometry, so we clear any
++	 * client-side-decoration shadow/margin that the client excludes from its
++	 * input region (raw clients like wev have no such margin; GTK/Qt do). */
++	struct wlr_box geo = t->xdg_toplevel->base->geometry;
++	int cx = geo.width > 0 ? geo.x + geo.width / 2 : 100;
++	int cy = geo.height > 0 ? geo.y + geo.height / 2 : 75;
++	wlr_log(WLR_INFO, "[SPIKE] '%s' geometry %dx%d@%d,%d -> inject at %d,%d",
++		title, geo.width, geo.height, geo.x, geo.y, cx, cy);
++	wl_fixed_t sx = wl_fixed_from_int(cx), sy = wl_fixed_from_int(cy);
++	uint32_t tm = spike_now_ms();
++	struct wl_resource *res;
++	uint32_t es = wlr_seat_client_next_serial(sc);
++	wl_resource_for_each(res, &sc->pointers) {
++		wl_pointer_send_enter(res, es, surface->resource, sx, sy);
++		wl_pointer_send_motion(res, tm, sx, sy);
++		spike_frame(res);
++	}
++	uint32_t bs = wlr_seat_client_next_serial(sc);
++	wl_resource_for_each(res, &sc->pointers) {
++		wl_pointer_send_button(res, bs, tm + 5, BTN_LEFT,
++			WL_POINTER_BUTTON_STATE_PRESSED);
++		spike_frame(res);
++	}
++	uint32_t rs = wlr_seat_client_next_serial(sc);
++	wl_resource_for_each(res, &sc->pointers) {
++		wl_pointer_send_button(res, rs, tm + 15, BTN_LEFT,
++			WL_POINTER_BUTTON_STATE_RELEASED);
++		spike_frame(res);
++	}
++	wlr_log(WLR_INFO, "[SPIKE] injected click to UNFOCUSED '%s' (%d ptr, e=%u b=%u r=%u)",
++		title, n, es, bs, rs);
++}
++
++static void spike_inject(struct tinywl_server *server) {
++	if (wl_list_length(&server->toplevels) < 2) {
++		wlr_log(WLR_INFO, "[SPIKE] waiting: need >=2 toplevels, have %d",
++			wl_list_length(&server->toplevels));
++		return;
++	}
++	struct wlr_surface *kfocus = server->seat->keyboard_state.focused_surface;
++	/* Inject into EVERY toplevel that does NOT hold keyboard focus. */
++	struct tinywl_toplevel *t;
++	wl_list_for_each(t, &server->toplevels, link) {
++		struct wlr_surface *surface = t->xdg_toplevel->base->surface;
++		const char *title = t->xdg_toplevel->title ? t->xdg_toplevel->title : "(none)";
++		if (surface == kfocus) {
++			wlr_log(WLR_INFO, "[SPIKE] skipping FOCUSED toplevel '%s'", title);
++			continue;
++		}
++		spike_inject_one(server, t);
++	}
++	wl_display_flush_clients(server->wl_display);
++}
++
++static int spike_timer_cb(void *data) {
++	struct tinywl_server *server = data;
++	static int n = 0;
++	n++;
++	wlr_log(WLR_INFO, "[SPIKE] timer fire #%d", n);
++	spike_inject(server);
++	if (n < 10) {
++		struct wl_event_loop *loop =
++			wl_display_get_event_loop(server->wl_display);
++		struct wl_event_source *src =
++			wl_event_loop_add_timer(loop, spike_timer_cb, server);
++		wl_event_source_timer_update(src, 2000);
++	}
++	return 0;
++}
++
+ int main(int argc, char *argv[]) {
+ 	wlr_log_init(WLR_DEBUG, NULL);
+ 	char *startup_cmd = NULL;
+@@ -1015,6 +1121,7 @@
+ 	server.new_input.notify = server_new_input;
+ 	wl_signal_add(&server.backend->events.new_input, &server.new_input);
+ 	server.seat = wlr_seat_create(server.wl_display, "seat0");
++	wlr_seat_set_capabilities(server.seat, WL_SEAT_CAPABILITY_POINTER);
+ 	server.request_cursor.notify = seat_request_cursor;
+ 	wl_signal_add(&server.seat->events.request_set_cursor,
+ 			&server.request_cursor);
+@@ -1051,6 +1158,10 @@
+ 	 * frame events at the refresh rate, and so on. */
+ 	wlr_log(WLR_INFO, "Running Wayland compositor on WAYLAND_DISPLAY=%s",
+ 			socket);
++		struct wl_event_loop *spike_loop = wl_display_get_event_loop(server.wl_display);
++	struct wl_event_source *spike_src = wl_event_loop_add_timer(spike_loop, spike_timer_cb, &server);
++	wl_event_source_timer_update(spike_src, 3000);
++	wlr_log(WLR_INFO, "[SPIKE] armed injection timer (first fire +3s)");
+ 	wl_display_run(server.wl_display);
+ 
+ 


### PR DESCRIPTION
## What

Spike 0 for native-Wayland (no XWayland) **backgrounded, per-window input injection** — the load-bearing capability for adding background multi-cursor computer-use to cua-driver on Wayland (the 16-window cursive demo).

Adds `libs/cua-driver/rust/crates/platform-linux/spikes/wayland-bg-input/`: a patched **tinywl** (wlroots 0.19, headless) that delivers `wl_pointer` events **directly to a chosen unfocused window's pointer resource** — bypassing `wlr_seat` focus, with no real input device, no global cursor movement, and no window raise — plus minimal logging clients for GTK4 / Qt6 / Chromium.

## Result — all toolkits accept it ✅

| Client | Outcome on the **unfocused** window |
|---|---|
| `wev` (raw libwayland) | enter/motion/button delivered; focused client got nothing |
| **GTK4** | ENTER → MOTION → PRESSED → button **CLICKED** |
| **Qt6** | ENTER → PRESSED → button **CLICKED** |
| **Chromium** (Chrome 149) | DOM `onclick` fired → `document.title` → `CLICKED-OK` |

## Why it matters

This retires the deepest risk in the Wayland plan: that toolkits might internally gate input on seat focus. They don't. The validated mechanism (`wlr_seat_client_for_wl_client` → iterate `sc->pointers` → `wl_pointer_send_*`) is exactly what the **Phase A** EIS (libei) server's per-window routing will call.

## Implementation learnings (baked into the README)

1. Inject at the **xdg window-geometry content center**, not surface origin — CSD margins are excluded from toolkit input regions.
2. Send `wl_pointer.leave` before re-`enter` (Qt flagged the protocol violation).
3. Headless must explicitly advertise `WL_SEAT_CAPABILITY_POINTER`.

## Scope

Spike only — no changes to shipped cua-driver code. Vehicle is tinywl (not labwc) because the question is compositor-agnostic wlroots/toolkit behavior. See the directory README for full reproduce steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive spike documentation detailing experimental native Wayland pointer input injection approach and implementation learnings.

* **New Features**
  * Added test applications (GTK4, Qt6, HTML) for validating pointer event handling across toolkits.
  * Introduced experimental spike implementation and patch generator for testing background pointer input injection on Wayland.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->