### PR TITLE
fix(pyproject): remove asyncio from pip dependencies (stdlib module)

### DIFF
--- a/libs/python/agent/pyproject.toml
+++ b/libs/python/agent/pyproject.toml
@@ -13,7 +13,6 @@ authors = [
 dependencies = [
     "httpx>=0.27.0",
     "aiohttp>=3.9.3",
-    "asyncio",
     "anyio>=4.4.1",
     "typing-extensions>=4.12.2",
     "pydantic>=2.6.4",


### PR DESCRIPTION
## Summary

`asyncio` is a Python standard library module (available since Python 3.4), but it was incorrectly listed as a pip dependency in `libs/python/agent/pyproject.toml`.

The project's `requires-python = ">=3.11,<3.14"`, so `asyncio` is guaranteed to be available without `pip install`. All 25 usages of `asyncio` in this package are stdlib `import asyncio` statements.

## Changes

- Removed `"asyncio"` from the `dependencies` list in `libs/python/agent/pyproject.toml`

Closes #1913