### PR TITLE
docs(contributing): fix lume copy-paste residue in bug report template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,20 +11,20 @@ If you've encountered a bug in the project, we encourage you to report it. Pleas
    - A clear title and detailed description
    - Steps to reproduce the issue
    - Expected vs actual behavior
-   - Your environment (macOS version, lume version)
+   - Your environment (macOS version, cua version)
    - Any relevant logs or error messages
 3. **Label Your Issue**: Label your issue as a `bug` to help maintainers identify it quickly.
 
 ## Suggesting Enhancements
 
-We're always looking for suggestions to make lume better. If you have an idea:
+We're always looking for suggestions to make Cua better. If you have an idea:
 
 1. **Check Existing Issues**: See if someone else has already suggested something similar.
 2. **Create a New Issue**: If your enhancement is new, create an issue describing:
    - The problem your enhancement solves
    - How your enhancement would work
    - Any potential implementation details
-   - Why this enhancement would benefit lume users
+   - Why this enhancement would benefit Cua users
 
 ## Code Formatting
 


### PR DESCRIPTION
## Summary

The root `CONTRIBUTING.md` had three copy-paste references to "lume" (from `libs/lume/CONTRIBUTING.md`). Changed to "Cua" to match the project.

## Changes
- Line 14: `lume version` → `cua version` (bug report environment info)
- Line 20: `make lume better` → `make Cua better` (enhancement suggestions)
- Line 27: `benefit lume users` → `benefit Cua users` (enhancement rationale)

Closes #ISSUE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines to reflect current project naming conventions in bug report and enhancement suggestion sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->