### PR TITLE
docs(lume): fix cache config commands

### DIFF
--- a/docs/content/docs/lume/guide/fundamentals/vm-management.mdx
+++ b/docs/content/docs/lume/guide/fundamentals/vm-management.mdx
@@ -195,10 +195,13 @@ When pulling images from a registry, Lume can cache layers locally for faster fu
 
 ```bash
 # Enable caching
-lume config caching set true
+lume config cache enable
+
+# Disable caching
+lume config cache disable
 
 # Set cache directory
-lume config cache set /path/to/cache
+lume config cache dir /path/to/cache
 
 # View current config
 lume config get


### PR DESCRIPTION
## Why
The Lume VM management docs listed cache commands that no longer match the current CLI implementation, which can mislead users trying to enable/disable caching or set the cache directory.

## What Changed
Updated the **Image caching** snippet to reflect the current commands:
- Enable caching: `lume config cache enable`
- Disable caching: `lume config cache disable`
- Set cache directory: `lume config cache dir /path/to/cache`
- View current config: `lume config get`
- Clear cache: `lume prune`

## References
- Docs page: `docs/content/docs/lume/guide/fundamentals/vm-management.mdx`
- CLI source: `libs/lume/src/Commands/Config.swift` (Cache subcommands)

## Verification
- Confirmed `lume config cache enable/disable/dir` exist in `libs/lume/src/Commands/Config.swift`.
- Checked docs page content and updated the snippet accordingly.
