### PR TITLE
fix(cua-driver-rs)(linux): lower glibc floor so the release binary runs on Debian 12 / RHEL 9 / Ubuntu 22.04

### DIFF
--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -34,7 +34,30 @@ jobs:
   build-linux:
     name: linux-x86_64
     runs-on: ubuntu-latest
+    # Build INSIDE a Debian 11 (bullseye) container instead of directly on
+    # the ubuntu-latest host. ubuntu-latest is now Ubuntu 24.04, whose glibc
+    # is 2.39 — a binary linked there imports GLIBC_2.39 symbols (e.g.
+    # posix_spawn's pidfd_spawnp/pidfd_getpid) and refuses to even run
+    # `--version` on older distros:
+    #   cua-driver: /lib/.../libc.so.6: version 'GLIBC_2.39' not found
+    # That broke Debian 12 (glibc 2.36), Ubuntu 22.04 (2.35), and RHEL/Rocky
+    # 9 (2.34). Debian 11's glibc is 2.31, so linking against it lowers the
+    # floor to GLIBC_2.31 — covering Debian 11+, Ubuntu 20.04+, and RHEL/
+    # Rocky 8+. A container (rather than the retired ubuntu-20.04 runner
+    # label) keeps the floor deterministic regardless of GitHub's host image
+    # churn. The C deps below all exist in bullseye, including libwayland-dev
+    # for the native Wayland backend (#1910).
+    container:
+      image: debian:11
     steps:
+      # actions/checkout needs git inside the container; the bullseye image
+      # is bare. Install git + the build toolchain before anything else.
+      - name: Install base tooling (container is bare)
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            git ca-certificates curl build-essential pkg-config \
+            libx11-dev libxi-dev libxtst-dev libxext-dev libwayland-dev
       - uses: actions/checkout@v4
       - name: Determine version
         id: version
@@ -58,12 +81,6 @@ jobs:
           key: rust-cua-driver-rs-linux-x86_64-${{ hashFiles('libs/cua-driver/rust/Cargo.lock', 'libs/cua-driver/rust/**/Cargo.toml') }}
           restore-keys: |
             rust-cua-driver-rs-linux-x86_64-
-      # The `x11` crate (raw Xlib FFI for MPX multi-cursor drags) locates
-      # libX11/libXi/libXtst via pkg-config in its build.rs.
-      - name: Install X11 build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y pkg-config libx11-dev libxi-dev libxtst-dev libxext-dev
       - name: Build (release)
         working-directory: libs/cua-driver/rust
         run: cargo build -p cua-driver --release --target x86_64-unknown-linux-gnu


### PR DESCRIPTION
## Problem

The released Linux binary is built on `ubuntu-latest` (now Ubuntu 24.04, **glibc 2.39**), so it imports `GLIBC_2.39` symbols and refuses to even run `--version` on any older distro:

```
cua-driver: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

The only 2.39 imports were `pidfd_spawnp` / `pidfd_getpid` (newer-glibc `posix_spawn` internals), but that's enough to break the binary on:

- Debian 12 (glibc 2.36)
- Ubuntu 22.04 (2.35)
- RHEL / Rocky / Alma 9 (2.34)

## Fix

Build the Linux release **inside a `debian:11` (bullseye, glibc 2.31) container** on the `ubuntu-latest` runner, instead of directly on the host. Linking against glibc 2.31 lowers the floor accordingly.

A container is used rather than the `ubuntu-20.04` runner label because GitHub retired that hosted label — a pinned container keeps the glibc floor deterministic regardless of runner-image churn. Bullseye ships every C build dep we need: `libx11-dev libxi-dev libxtst-dev libxext-dev` plus `libwayland-dev` for the native Wayland backend (#1910). The bare image needs `git` + `build-essential` installed before `actions/checkout` and the Rust toolchain.

Only `build-linux` changed; Windows/macOS jobs are untouched.

## Verification

Built via `workflow_dispatch` on this branch ([run 27717164308](https://github.com/trycua/cua/actions/runs/27717164308), `build-linux` ✅) and ran the resulting binary:

| Target | glibc | `cua-driver --version` | `cua-driver doctor` |
|---|---|---|---|
| **OLD** binary on Rocky 9 | 2.34 | ❌ `GLIBC_2.39 not found` (exit 1) | — |
| **NEW** binary on Debian 12 VM | 2.36 | ✅ `cua-driver 0.5.5` (exit 0) | ✅ runs |
| **NEW** binary in `rockylinux:9` | 2.34 | ✅ `cua-driver 0.5.5` (exit 0) | ✅ runs |

The new binary's highest glibc import drops from **2.39 → 2.30** (`objdump -T`). The only runtime deps on Rocky 9 are the standard X11 libs (`libX11`/`libXi`/`libXtst`/`libXext`), present on any real desktop session.

## Coverage

Now runs on **glibc ≥ 2.31**: Debian 11+, Ubuntu 20.04+, RHEL / Rocky / Alma 8+. Verified live on Debian 12 (2.36) and Rocky 9 (2.34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Linux build environment consistency and reliability by standardizing dependency setup within a containerized build system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->