### PR TITLE
docs(cua-driver-rs): mark screenshot tool as removed-on-all-platforms in PARITY.md

### DIFF
--- a/libs/cua-driver/rust/PARITY.md
+++ b/libs/cua-driver/rust/PARITY.md
@@ -24,7 +24,6 @@ cd libs/cua-driver/rust/tests/integration
 | `page` tool | ✅ (cross-platform: Apple-Events on macOS, UIA+CDP on Windows, AT-SPI+CDP on Linux) | ✅ (macOS only) |
 | `--version` flag | ✅ | ✅ |
 | `call check_permissions` JSON | ✅ JSON | human-readable text |
-| `call screenshot` (no window_id) | ✅ full-display default | error (requires window_id) |
 
 ---
 
@@ -867,53 +866,49 @@ Windows's `click` takes `{button: enum}` instead.  Rationale:
 
 ---
 
-## MCP tool: `screenshot`
+## MCP tool: `screenshot` — REMOVED on all platforms
+
 - Swift: `libs/cua-driver/Sources/CuaDriverServer/Tools/ScreenshotTool.swift:5-170`
-- Rust: windows=`crates/platform-windows/src/tools/impl_.rs` (ScreenshotTool); macOS/linux OPEN
-- Status: windows VERIFIED
-- Test: `crates/platform-windows/examples/screenshot_parity.rs`
+- Rust: **not registered on any platform** (macOS / Windows / Linux).
+- Status: **removed** — superseded by `get_window_state` (`capture_mode:"vision"`).
 
-### Fixed (Windows)
-1. **Text format** — was `"Screenshot (window): WxH png."`; now matches
-   Swift verbatim: `"✅ Window screenshot — WxH png [window_id: ID]"`
-   (em-dash, checkmark, window-id suffix). Display fallback uses
-   `"✅ Display screenshot — WxH png"` (Rust-only, see intentional below).
-2. **Description** — multi-paragraph port from Swift adapted to Windows
-   (BitBlt + PrintWindow transport; no permission gate needed).
-3. **`idempotent`** — was `true`; Swift uses `false` (a fresh pixel grab
-   every call). Now matches Swift.
-4. **`max_image_dimension` default** — was 0 (no cap), Swift uses 1568.
-   Now 1568 on all 3 Rust platforms (matches
-   `CuaDriverConfig.defaultMaxImageDimension`). The 0 default was
-   producing 10MB screenshots on the Windows VM; 1568 caps the long
-   edge before encoding.
+### History
 
-### Intentional Rust-only
+The standalone `screenshot` tool was intentionally removed from all
+three Rust platforms:
 
-- **Optional `window_id`** — Swift requires it; Windows allows omission
-  for whole-display capture (`screenshot_display_bytes`).  Useful
-  Windows-only convenience that Swift can't easily provide because
-  macOS Screen Recording requires per-window grants.  Schema accepts
-  both shapes; description explains.
-- **Default `format`** — Swift defaults `png`; all 3 Rust platforms now
-  default `jpeg`. Rationale: agents typically want compact images for
-  vision-model context windows; PNG is lossless but multi-MB on screen
-  content. Schema still accepts both; callers wanting PNG pass
-  `{"format":"png"}`. Swift may follow; tracked as a follow-up parity
-  question.
-- **Default JPEG `quality`** — Swift defaults 95; Rust defaults 85
-  (already Linux's default and the macOS Claude-Code-compat tool's
-  default). 85 is the typical sweet spot for screen content. Diverges
-  from Swift only when both sides actually emit JPEG.
+- **PR #1692** removed the `screenshot` tool registration; `get_window_state`
+  with `capture_mode:"vision"` became the single canonical full-frame
+  screenshot path, and `zoom` covers region captures.
+- **PR #1694** deleted the now-dead `ScreenshotTool` / `ScreenshotCompatTool`
+  structs on macOS and Windows.
 
-### Verified on Windows
+So `cua-driver call screenshot '{}'` returning `Unknown tool: screenshot`
+is the **intended, parity-consistent** behavior on every platform — there
+is no Linux-specific gap here.
 
-`screenshot_parity.exe`:
-- Window screenshot: text matches `"✅ Window screenshot — 1087x644 png
-  [window_id: 4464038]"` ✓
-- Image content block present ✓
-- structuredContent has `width`, `height`, `format` ✓
-- JPEG format: `mimeType: image/jpeg`, `format: "jpeg"` ✓
+The underlying capture functions still exist on each platform because the
+canonical paths use them internally:
+- Linux: `crate::capture::screenshot_window_bytes` /
+  `screenshot_display_bytes` (and `wayland::screenshot_dispatch`) feed
+  `GetWindowStateTool` and `ZoomTool`.
+- Windows: `crate::capture::screenshot_window_bytes` / `screenshot_display_bytes`
+  (and the WGC backend) feed `GetWindowStateTool`.
+
+### Canonical replacement
+
+To capture a screenshot, call `get_window_state` with
+`capture_mode:"vision"` for a full-frame image (returns the screenshot as
+an image content block, honoring `max_image_dimension`, default 1568), or
+`zoom` for a cropped native-resolution region. The image-encoding behavior
+the old `screenshot` tool documented (default `jpeg`, `max_image_dimension`
+1568, JPEG quality 85) now lives in those paths.
+
+> Historical note: this section previously documented a Windows-only
+> `ScreenshotTool` as "VERIFIED" (text format `"✅ Window screenshot —
+> WxH png [window_id: ID]"`, optional `window_id`, `jpeg` default,
+> `max_image_dimension` 1568). That tool and its `screenshot_parity.rs`
+> example predate PR #1692/#1694 and no longer exist.
 
 ---
 
@@ -1184,8 +1179,8 @@ description content.
 ### Verified on Windows
 `list_tools_parity.exe`:
 - Names sorted ascending ✓
-- All 23 core tools present (click, double_click, right_click, type_text,
-  press_key, hotkey, scroll, screenshot, list_apps, list_windows,
+- All core tools present (click, double_click, right_click, type_text,
+  press_key, hotkey, scroll, list_apps, list_windows,
   get_cursor_position, get_screen_size, launch_app, move_cursor,
   set_agent_cursor_enabled, set_agent_cursor_motion,
   get_agent_cursor_state, set_value, get_config, set_config,
@@ -1411,7 +1406,6 @@ older clients that only read name/description still work.
          { "name": "press_key",               "…": "…" },
          { "name": "replay_trajectory",       "…": "…" },
          { "name": "right_click",             "…": "…" },
-         { "name": "screenshot",              "…": "…" },
          { "name": "scroll",                  "…": "…" },
          { "name": "set_config",              "…": "…" },
          { "name": "set_recording",           "…": "…" },

--- a/libs/cua-driver/rust/Skills/cua-driver/LINUX.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/LINUX.md
@@ -6,8 +6,8 @@ description: Drive a native Linux app (X11 / Wayland) via the cua-driver CLI —
 # cua-driver-rs — Linux
 
 **Status: BETA.** The Linux backend in cua-driver-rs covers the core
-tool surface (click, type_text, scroll, hotkey, screenshot,
-launch_app, list_apps, list_windows, get_window_state) but several
+tool surface (click, type_text, scroll, hotkey, launch_app,
+list_apps, list_windows, get_window_state, zoom) but several
 behaviors that the macOS / Windows skills consider table-stakes are
 **not yet implemented or only partially supported**:
 
@@ -26,7 +26,7 @@ behaviors that the macOS / Windows skills consider table-stakes are
   KDE-KWin with `org.freedesktop.portal.RemoteDesktop` enabled, some
   click and key paths work. Under most other compositors, input
   synthesis is denied by the security model and the tool surface
-  degrades to "passive" (snapshot, screenshot) only.
+  degrades to "passive" (snapshot via get_window_state) only.
 - **UIA / AX-tree equivalent**: AT-SPI when available, otherwise
   empty. Many GTK4 / Qt6 apps populate AT-SPI lazily; agents should
   expect partial trees and re-snapshot.
@@ -38,8 +38,9 @@ behaviors that the macOS / Windows skills consider table-stakes are
 See `SKILL.md` (macOS) and `WINDOWS.md` (Windows) for the full
 patterns. This file will grow as the Linux backend reaches GA. For
 now, **prefer macOS / Windows hosts** for agent-driven GUI tasks; use
-the Linux daemon for read-only inspection (screenshot,
-list_windows, get_window_state) when running on a Linux host.
+the Linux daemon for read-only inspection (list_windows,
+get_window_state — which embeds a screenshot — and zoom) when running
+on a Linux host.
 
 ## Quick triage
 


### PR DESCRIPTION
## Summary

Docs-only fix. The standalone `screenshot` MCP tool was **intentionally removed from all three Rust platforms** (macOS, Windows, Linux), but `PARITY.md` was never updated — so it still read as though `screenshot` was a registered, "VERIFIED" tool. That stale doc made Linux look like it had a `screenshot`-tool parity gap (`cua-driver call screenshot '{}'` → `Unknown tool: screenshot`), when in fact that response is the **intended, parity-consistent** behavior on every platform.

### The actual history
- **PR #1692** (`892edd47`) removed the `screenshot` tool registration; `get_window_state` with `capture_mode:"vision"` became the single canonical full-frame screenshot path, and `zoom` covers region captures.
- **PR #1694** (`c4c84710`) deleted the now-dead `ScreenshotTool` / `ScreenshotCompatTool` structs on macOS and Windows.

The Linux registry already documents this in-code (`crates/platform-linux/src/tools/impl_.rs` `build_registry`: "`screenshot` removed - see the matching comment in platform-windows... Canonical screenshot path is `get_window_state` with `capture_mode:\"vision\"`"), and Windows has the matching comment. The underlying capture fns (`screenshot_window_bytes`, `screenshot_display_bytes`, wayland `screenshot_dispatch`) still exist because `get_window_state` / `zoom` use them internally.

## Changes (PARITY.md)
- Rewrote the `## MCP tool: screenshot` section to document the removal, the canonical replacement (`get_window_state` `capture_mode:"vision"` + `zoom`), and kept the old "VERIFIED" Windows behavior as a historical note.
- Dropped `screenshot` from the list-tools roster and the example `list-tools` output.
- Removed the misleading `call screenshot (no window_id) → ✅ full-display default` row from the known-gaps table.

## Changes (Skills/cua-driver/LINUX.md)
The Linux skill doc carried the same stale claim (it's what misled a Linux test-campaign agent into filing a phantom "screenshot tool missing" gap). Fixed the three references: `screenshot` is not a standalone tool on Linux; capture is via `get_window_state` (which embeds a screenshot) and `zoom`.

## Non-goals
No code or tool-registration changes. Specifically **not** adding a `screenshot` tool to Linux — doing so would make Linux the only platform exposing it, the opposite of parity, and would contradict the deliberate #1692/#1694 decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)