### PR TITLE
fix(cua-driver-rs)(linux): set_value via AT-SPI EditableText for GTK4 editables (Closes #1924)

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -49,6 +49,12 @@ jobs:
             visual: false
             result_link: result-cua-driver-set-config
             artifact_name: ""
+          - name: NixOS set_value EditableText test
+            check_attr: cua-driver-set-value
+            timeout_minutes: 15
+            visual: false
+            result_link: result-cua-driver-set-value
+            artifact_name: ""
           - name: Linux cursor click GIF test
             check_attr: cua-driver-linux-cursor-click-gif
             timeout_minutes: 12

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,20 @@
                 };
               };
 
+              # set_value EditableText test — regression for #1924 (fixed in
+              # #1929): set_value on a GTK4 editable failed with "neither
+              # EditableText nor Value". Launches a packaged GTK4 editor
+              # (gnome-text-editor) and proves set_value writes via AT-SPI
+              # EditableText::SetTextContents.
+              cua-driver-set-value = import ./nix/cua-driver/tests/set-value.nix {
+                inherit pkgs;
+                inherit (pkgs) lib;
+                cuaDriverModule = {
+                  imports = [ ./nix/cua-driver/module.nix ];
+                  services.cua-driver.package = cuaDriverPackage;
+                };
+              };
+
               # Screenshot test — uses cua-driver's own get_window_state tool
               # to capture a screenshot via MCP, proving the driver can see the display
               cua-driver-screenshot = import ./nix/cua-driver/tests/screenshot.nix {

--- a/nix/cua-driver/tests/set-value.nix
+++ b/nix/cua-driver/tests/set-value.nix
@@ -10,24 +10,26 @@
 #
 #   1. boot a NixOS VM with a session D-Bus + AT-SPI bus (same scaffolding as
 #      linux-background-gui.nix),
-#   2. launch a GTK4 app exposing a real editable text field,
+#   2. launch a packaged GTK4 app exposing a real editable text field,
 #   3. over MCP stdio: get_window_state to locate the editable element_index,
 #      assert the field does NOT already contain the test string (baseline),
 #      set_value to write the test string, then get_window_state again and
 #      assert the field now DOES contain it.
 #
-# GTK4 choice / why a self-contained app:
+# GTK4 choice — why gnome-text-editor:
 # #1924 is GTK4-SPECIFIC (the focus-gated EditableText advertisement is a GTK4
 # behaviour), so this test must drive a GTK4 editable — a GTK3 fallback would
-# not exercise the regression. The real GNOME GTK4 apps named in the issue
-# (gnome-text-editor) were dropped from the linux-background-gui matrix because
-# they never mapped a window within 120s headless in CI (missing portals / EDS
-# / VTE runtime). So, exactly like the `tk` and `chromium` targets in
-# linux-background-gui.nix, this test ships its OWN minimal GTK4 app: a single
-# GtkApplicationWindow holding one GtkEntry (a genuine GTK4 editable that
-# exposes Text/EditableText), with no portal/EDS/VTE dependencies, so it maps
-# reliably headless. The GtkEntry starts empty, guaranteeing the baseline
-# "field is empty" assert holds and a pass can only mean the write took.
+# not exercise the regression. gnome-text-editor is the exact app the issue
+# names as the repro: it is GTK4 and its main view is a large editable
+# GtkTextView that exposes the AT-SPI Text/EditableText interfaces. It is a
+# properly-packaged Nix app, so (unlike a hand-rolled PyGObject script, which
+# needs the full GObject-introspection typelib set on GI_TYPELIB_PATH) its
+# wrapper already wires up GTK4 + all typelibs. We launch it FOREGROUND as the
+# only window under Xvfb/openbox — the linux-background-gui matrix only dropped
+# the GTK4 GNOME apps because they were slow to map *in the background while
+# focus was held elsewhere*; here the app is the active window, which maps fine.
+# The editor starts on an empty buffer, so the baseline "field is empty" assert
+# holds and a pass can only mean the write took.
 #
 # To run: nix build .#checks.x86_64-linux.cua-driver-set-value
 {
@@ -45,6 +47,8 @@ let
   # Shared session-bus + a11y environment, identical in spirit to
   # linux-background-gui.nix: the GTK4 app and the driver's native AT-SPI client
   # must reach the same registry. Fixed bus path so every machine.* shell opts in.
+  # The GTK4-specific exports (GTK_A11Y=atspi, x11 backend, cairo renderer) are
+  # the same ones linux-background-gui.nix uses for its GTK4 entries.
   a11yEnv = lib.concatStringsSep " " [
     "DISPLAY=:99"
     "DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/cua-session-bus"
@@ -58,51 +62,21 @@ let
     "GNOME_ACCESSIBILITY=1"
     "QT_ACCESSIBILITY=1"
     "NO_AT_BRIDGE=0"
-    # GTK4 talks AT-SPI directly (not via atk-bridge), but only exports its
-    # accessible tree when it selects the AT-SPI backend at startup; GTK_A11Y=atspi
-    # forces it on. x11 backend + cairo renderer keep it headless-safe. (Same
-    # exports linux-background-gui.nix uses for its GTK4 entries.)
     "GTK_A11Y=atspi"
     "GDK_BACKEND=x11"
     "GSK_RENDERER=cairo"
   ];
 
-  # Minimal self-contained GTK4 app: one window, one GtkEntry, autofocused. The
-  # GtkEntry is a real GTK4 editable that exposes the AT-SPI Text/EditableText
-  # interfaces — exactly the widget class #1924 failed on. No portal/EDS/VTE, so
-  # it maps reliably headless. Fixed window title so xdotool can find it.
-  gtk4Env = pkgs.python3.withPackages (ps: [ ps.pygobject3 ]);
-
-  # PyGObject loads GTK4 via GObject-introspection typelibs at runtime, so the
-  # GTK-4.0 (and its dependency) typelibs must be on GI_TYPELIB_PATH. The
-  # `withPackages` env only carries PyGObject itself, not the GTK4 typelib, so
-  # point GI at gtk4's girepository dir explicitly before launching the app.
-  giTypelibEnv = "GI_TYPELIB_PATH=${pkgs.gtk4}/lib/girepository-1.0:${pkgs.glib}/lib/girepository-1.0:${pkgs.graphene}/lib/girepository-1.0:${pkgs.pango.out}/lib/girepository-1.0:${pkgs.gdk-pixbuf}/lib/girepository-1.0:${pkgs.harfbuzz.out}/lib/girepository-1.0";
-  gtk4App = pkgs.writeText "cua-gtk4-entry.py" ''
-    import gi
-    gi.require_version("Gtk", "4.0")
-    from gi.repository import Gtk, GLib
-
-    def on_activate(app):
-        win = Gtk.ApplicationWindow(application=app)
-        win.set_title("cua-setvalue")
-        win.set_default_size(400, 120)
-        entry = Gtk.Entry()
-        entry.set_hexpand(True)
-        # Start EMPTY so the baseline "field does not contain the test string"
-        # assertion is guaranteed to hold before the write.
-        entry.set_text("")
-        win.set_child(entry)
-        win.present()
-        entry.grab_focus()
-
-    app = Gtk.Application(application_id="com.trycua.SetValueEntry")
-    app.connect("activate", on_activate)
-    app.run(None)
-  '';
+  # Packaged GTK4 editor with a large editable GtkTextView (the repro app from
+  # #1924). Launched foreground; --new-window forces its own toplevel.
+  gtk4App = pkgs.gnome-text-editor;
+  gtk4Launch = "${gtk4App}/bin/gnome-text-editor --new-window";
+  # Its WM_CLASS for the xdotool window search.
+  gtk4WindowMatch = "--class org.gnome.TextEditor";
 
   # Python MCP client that drives cua-driver over stdio against the live GTK4
   # window: find the editable element_index, baseline-read, set_value, read back.
+  # Same MCP-stdio structure as set-config.nix.
   setValueTest = pkgs.writeText "set-value-test.py" ''
     import json, os, sys, threading, time
 
@@ -166,12 +140,12 @@ let
         return "\n".join(parts)
 
     def find_editable_index(result):
-        # Pick the editable element. The tree markdown lines for actionable
-        # elements look like `- [N] entry "..." [...] [actions=[...]]`. A GtkEntry
-        # renders with role "entry"/"text". Prefer an entry/text line; fall back
-        # to the first indexed element if the role name differs across builds.
+        # Pick the editable element. Indexed actionable lines look like
+        # `- [N] <role> "..." [...] [actions=[...]]`. A GtkTextView renders with
+        # role "text"; a GtkEntry with role "entry". Prefer a text/entry line;
+        # fall back to the first indexed element if the role name differs.
         text = tree_text(result)
-        entry_idx = None
+        editable_idx = None
         first_idx = None
         for line in text.splitlines():
             s = line.strip()
@@ -184,9 +158,9 @@ let
             if first_idx is None:
                 first_idx = idx
             low = s.lower()
-            if ("entry" in low or "text" in low) and entry_idx is None:
-                entry_idx = idx
-        return entry_idx if entry_idx is not None else first_idx
+            if ("entry" in low or "text" in low) and editable_idx is None:
+                editable_idx = idx
+        return editable_idx if editable_idx is not None else first_idx
 
     def get_window_state(proc, req_id, pid, xid):
         # ax = tree only (no screenshot needed; faster + avoids capture flakiness).
@@ -216,7 +190,7 @@ let
             print("\n--- get_window_state (locate editable) ---", flush=True)
             idx = None
             before_state = None
-            for _ in range(10):
+            for _ in range(15):
                 before_state = get_window_state(proc, 2, target_pid, target_xid)
                 idx = find_editable_index(before_state)
                 if idx is not None:
@@ -253,7 +227,7 @@ let
             # moment after SetTextContents. ─────────────────────────────────────
             print("\n--- get_window_state (read back) ---", flush=True)
             after_text = ""
-            for _ in range(10):
+            for _ in range(15):
                 after_state = get_window_state(proc, 4, target_pid, target_xid)
                 after_text = tree_text(after_state)
                 if TEST_VALUE in after_text:
@@ -274,6 +248,21 @@ let
         main()
   '';
 
+  # Window-find: match the GTK4 app's class, then fall back to the launched PID's
+  # window, then the newest visible window. Store-path script (one safe token for
+  # the Python testScript string), same idiom as linux-background-gui.nix.
+  windowFindCmd = pkgs.writeShellScript "cua-setvalue-window-find.sh" ''
+    export DISPLAY=:99
+    xid=$(${pkgs.xdotool}/bin/xdotool search --sync --onlyvisible ${gtk4WindowMatch} 2>/dev/null | head -1)
+    if [ -z "$xid" ]; then
+      xid=$(${pkgs.xdotool}/bin/xdotool search --all --pid "$(cat /tmp/target-pid.txt)" 2>/dev/null | head -1)
+    fi
+    if [ -z "$xid" ]; then
+      xid=$(${pkgs.xdotool}/bin/xdotool search --onlyvisible "" 2>/dev/null | tail -1)
+    fi
+    test -n "$xid" && printf "%s" "$xid" >/tmp/target-xid.txt && test -s /tmp/target-xid.txt
+  '';
+
 in
 
 pkgs.testers.nixosTest {
@@ -286,7 +275,7 @@ pkgs.testers.nixosTest {
       imports = [ cuaDriverModule ];
       virtualisation = {
         cores = 2;
-        memorySize = 2048;
+        memorySize = 4096;
         diskSize = 8192;
       };
       services.cua-driver.enable = true;
@@ -299,9 +288,7 @@ pkgs.testers.nixosTest {
         dbus
         at-spi2-core
         python3
-        gtk4Env # PyGObject env for the self-contained editable app
-        gtk4 # GTK-4.0 typelib + libs (loaded by PyGObject at runtime)
-        gobject-introspection
+        gtk4App # gnome-text-editor (GTK4 editable) — properly packaged
         glib # `gsettings`
         gsettings-desktop-schemas
         procps
@@ -337,26 +324,32 @@ pkgs.testers.nixosTest {
         )
         machine.log("atspi-launcher.log: " + machine.execute("cat /tmp/atspi-launcher.log")[1])
 
-    with subtest("Launch the self-contained GTK4 editable app"):
-        machine.execute("sh -lc '${a11yEnv} ${giTypelibEnv} ${gtk4Env}/bin/python3 ${gtk4App} >/tmp/target.log 2>&1 & echo $! >/tmp/target-pid.txt'")
+    with subtest("Launch the GTK4 editable app (gnome-text-editor)"):
+        machine.execute("sh -lc '${a11yEnv} ${gtk4Launch} >/tmp/target.log 2>&1 & echo $! >/tmp/target-pid.txt'")
+        # Surface the app's own stdout/stderr early so a launch failure is visible
+        # instead of just a window-find timeout.
         machine.sleep(5)
         machine.log("target.log after launch: " + machine.execute("cat /tmp/target.log")[1])
-        # Find the GTK4 window by its fixed title; fall back to the launched PID's
-        # window, then the newest visible window.
-        machine.wait_until_succeeds(
-            "sh -lc 'export DISPLAY=:99; "
-            "xid=$(${pkgs.xdotool}/bin/xdotool search --sync --onlyvisible --name cua-setvalue 2>/dev/null | head -1); "
-            "[ -z \"$xid\" ] && xid=$(${pkgs.xdotool}/bin/xdotool search --all --pid $(cat /tmp/target-pid.txt) 2>/dev/null | head -1); "
-            "[ -z \"$xid\" ] && xid=$(${pkgs.xdotool}/bin/xdotool search --onlyvisible \"\" 2>/dev/null | tail -1); "
-            "test -n \"$xid\" && printf %s \"$xid\" >/tmp/target-xid.txt && test -s /tmp/target-xid.txt'",
-            timeout=60,
-        )
+        machine.wait_until_succeeds("${windowFindCmd}", timeout=120)
         machine.log("target-xid: " + machine.execute("cat /tmp/target-xid.txt")[1])
+        # Resolve the PID that actually owns the mapped window (gnome-text-editor
+        # is single-instance: the launched shell may differ from the GTK process),
+        # and persist it for the driver.
+        machine.execute(
+            "sh -lc 'export DISPLAY=:99; "
+            "wpid=$(${pkgs.xdotool}/bin/xdotool getwindowpid $(cat /tmp/target-xid.txt) 2>/dev/null); "
+            "[ -n \"$wpid\" ] && echo $wpid >/tmp/target-pid.txt; true'"
+        )
+        machine.log("target-pid: " + machine.execute("cat /tmp/target-pid.txt")[1])
+        # Make sure the editor window holds focus so GTK4 advertises EditableText
+        # on its text view (the fix also GrabFocus-es, but this gives the tree a
+        # focused editable from the start).
+        machine.succeed("DISPLAY=:99 xdotool windowactivate --sync $(cat /tmp/target-xid.txt)")
 
     with subtest("set_value writes the test string into the GTK4 editable via EditableText"):
         machine.copy_from_host("${setValueTest}", "/tmp/set-value-test.py")
         result = machine.succeed(
-            "${a11yEnv} timeout 180 python3 /tmp/set-value-test.py 2>&1"
+            "${a11yEnv} timeout 240 python3 /tmp/set-value-test.py 2>&1"
         )
         machine.log(result)
         assert "set_value EditableText test passed" in result, f"set_value test failed: {result}"

--- a/nix/cua-driver/tests/set-value.nix
+++ b/nix/cua-driver/tests/set-value.nix
@@ -16,21 +16,26 @@
 #      set_value to write the test string, then get_window_state again and
 #      assert the field now DOES contain it.
 #
-# GTK4 choice — why gnome-characters:
+# GTK4 choice — why gtk4-widget-factory:
 # #1924 is GTK4-SPECIFIC (the focus-gated EditableText advertisement is a GTK4
 # behaviour), so this test must drive a GTK4 editable — a GTK3 fallback would
-# not exercise the regression. We drive gnome-characters because it is the ONE
-# GTK4 app the linux-background-gui matrix found reliably surfaces a window
-# under headless Xvfb (the other GNOME GTK4 apps, gnome-text-editor included,
-# launch but never map an X11 window without a real compositor/portal, so the
-# window-find times out). gnome-characters is GTK4 and its search field is a
-# GtkText/GtkSearchEntry — a real GTK4 editable that advertises the AT-SPI
-# EditableText interface once focused, which is exactly the surface #1924's fix
-# touches (GrabFocus, then EditableText::SetTextContents). It is a packaged Nix
-# app, so its wrapper wires up GTK4 + all typelibs (unlike a hand-rolled
-# PyGObject script, which needs the full GObject-introspection typelib set on
-# GI_TYPELIB_PATH). The search field starts empty, so the baseline "field is
-# empty" assert holds and a pass can only mean the write took.
+# not exercise the regression. We drive gtk4-widget-factory (the GTK4 reference
+# demo, shipped in pkgs.gtk4's bin) because, unlike the GNOME apps tried first:
+#   - gnome-text-editor launches but never maps an X11 window under headless
+#     Xvfb (no compositor/portal) — the window-find timed out.
+#   - gnome-characters maps a window, but its only editable is a GtkSearchEntry
+#     hidden behind a "Search" toggle button (not realized in the default
+#     AT-SPI tree, and Ctrl+F does not open it headless), so the strict editable
+#     finder found no entry.
+# gtk4-widget-factory is a pure GTK4 app (NOT a GNOME portal app), so it maps a
+# real X11 window headless, AND its first page shows a VISIBLE GtkEntry by
+# default — a genuine GTK4 editable that advertises the AT-SPI EditableText
+# interface once focused, exactly the surface #1924's fix touches (GrabFocus,
+# then EditableText::SetTextContents). It is a packaged Nix app, so its wrapper
+# wires up GTK4 + all typelibs (unlike a hand-rolled PyGObject script, which
+# needs the full GObject-introspection typelib set on GI_TYPELIB_PATH). The
+# entry starts empty, so the baseline "field does not contain the test string"
+# assert holds and a pass can only mean the write took.
 #
 # To run: nix build .#checks.x86_64-linux.cua-driver-set-value
 {
@@ -68,14 +73,19 @@ let
     "GSK_RENDERER=cairo"
   ];
 
-  # Packaged GTK4 app whose search field is an editable GtkText/GtkSearchEntry
-  # (the GTK4 editable surface #1924 is about). The one GTK4 app proven to map a
-  # window under headless Xvfb — see the rationale above.
-  gtk4App = pkgs.gnome-characters;
-  gtk4Launch = "${gtk4App}/bin/gnome-characters";
-  # Its WM_CLASS for the xdotool window search (same match the passing
-  # gtk4-characters entry in linux-background-gui.nix uses).
-  gtk4WindowMatch = "--class org.gnome.Characters";
+  # gtk4-widget-factory: the GTK4 reference demo, shipped in the gtk4 package's
+  # bin. Unlike the GNOME apps (gnome-text-editor never mapped a window headless;
+  # gnome-characters maps but hides its search entry behind a toggle button), it
+  # is a pure GTK4 app — NOT a GNOME portal app — so it maps a real X11 window
+  # under headless Xvfb, AND its first page shows a VISIBLE GtkEntry by default
+  # (no search toggle, no choreography). That GtkEntry is the editable GTK4
+  # surface #1924's fix targets (GrabFocus -> EditableText::SetTextContents).
+  gtk4App = pkgs.gtk4;
+  gtk4Launch = "${gtk4App}/bin/gtk4-widget-factory";
+  # Its WM_CLASS (GTK4 reference app id). The window-find also falls back to the
+  # launched PID's window and the newest visible window, so a class mismatch
+  # still resolves a window.
+  gtk4WindowMatch = "--class org.gtk.WidgetFactory";
 
   # Python MCP client that drives cua-driver over stdio against the live GTK4
   # window: find the editable element_index, baseline-read, set_value, read back.
@@ -196,11 +206,10 @@ let
             send(proc, "notifications/initialized", {})
             time.sleep(0.5)
 
-            # ── Locate the editable element. gnome-characters' GtkSearchEntry is
-            # only realized (and thus only appears in the AT-SPI tree) once the
-            # search is opened, so the helper testScript opens search via xdotool
-            # BEFORE this client runs. Retry: GTK4 builds its accessible tree a
-            # moment after first paint / after the search bar slides in. ─────────
+            # ── Locate the editable element. gtk4-widget-factory shows a GtkEntry
+            # on its first page by default, so it is present in the AT-SPI tree
+            # without any UI choreography. Retry: GTK4 builds its accessible tree
+            # a moment after first paint. ───────────────────────────────────────
             print("\n--- get_window_state (locate editable) ---", flush=True)
             idx = None
             before_state = None
@@ -312,7 +321,7 @@ pkgs.testers.nixosTest {
         dbus
         at-spi2-core
         python3
-        gtk4App # gnome-characters (GTK4 editable search field) — properly packaged
+        gtk4App # gtk4 — provides bin/gtk4-widget-factory (GTK4 editable demo)
         glib # `gsettings`
         gsettings-desktop-schemas
         procps
@@ -348,7 +357,7 @@ pkgs.testers.nixosTest {
         )
         machine.log("atspi-launcher.log: " + machine.execute("cat /tmp/atspi-launcher.log")[1])
 
-    with subtest("Launch the GTK4 editable app (gnome-characters)"):
+    with subtest("Launch the GTK4 editable app (gtk4-widget-factory)"):
         machine.execute("sh -lc '${a11yEnv} ${gtk4Launch} >/tmp/target.log 2>&1 & echo $! >/tmp/target-pid.txt'")
         # Surface the app's own stdout/stderr early so a launch failure is visible
         # instead of just a window-find timeout.
@@ -356,34 +365,25 @@ pkgs.testers.nixosTest {
         machine.log("target.log after launch: " + machine.execute("cat /tmp/target.log")[1])
         machine.wait_until_succeeds("${windowFindCmd}", timeout=120)
         machine.log("target-xid: " + machine.execute("cat /tmp/target-xid.txt")[1])
-        # Resolve the PID that actually owns the mapped window (gnome-characters
-        # is single-instance: the launched shell may differ from the GTK process),
-        # and persist it for the driver.
+        # Diagnostic: dump the resolved window's actual WM_CLASS so a class
+        # mismatch (which would have fallen through to the PID/newest-window
+        # fallback) is visible in the CI log.
+        machine.log("target-class: " + machine.execute(
+            "DISPLAY=:99 xdotool getwindowclassname $(cat /tmp/target-xid.txt) 2>&1"
+        )[1])
+        # Resolve the PID that actually owns the mapped window (the launched shell
+        # may differ from the GTK process), and persist it for the driver.
         machine.execute(
             "sh -lc 'export DISPLAY=:99; "
             "wpid=$(${pkgs.xdotool}/bin/xdotool getwindowpid $(cat /tmp/target-xid.txt) 2>/dev/null); "
             "[ -n \"$wpid\" ] && echo $wpid >/tmp/target-pid.txt; true'"
         )
         machine.log("target-pid: " + machine.execute("cat /tmp/target-pid.txt")[1])
-        # Make sure the editor window holds focus so GTK4 advertises EditableText
-        # on its text view (the fix also GrabFocus-es, but this gives the tree a
-        # focused editable from the start).
+        # Hold focus on the app window so GTK4 advertises EditableText on its
+        # entry (the fix also GrabFocus-es; this gives the tree a focused
+        # editable from the start). gtk4-widget-factory's first page shows a
+        # GtkEntry by default — no search toggle / choreography needed.
         machine.succeed("DISPLAY=:99 xdotool windowactivate --sync $(cat /tmp/target-xid.txt)")
-
-    with subtest("Realize the GtkSearchEntry so it appears in the AT-SPI tree"):
-        # gnome-characters' search field is a GtkSearchEntry that is NOT realized
-        # (and so is absent from the default AT-SPI tree) until search is opened.
-        # Open it via the GTK "find" accelerator and a typed key (Characters also
-        # supports type-to-search), then give the bar a moment to slide in and
-        # register its accessible. Without this the only indexed element is the
-        # window itself — set_value on which correctly fails, masking the real fix.
-        xid = machine.succeed("cat /tmp/target-xid.txt").strip()
-        machine.succeed(f"DISPLAY=:99 xdotool windowactivate --sync {xid}")
-        machine.execute(f"DISPLAY=:99 xdotool key --clearmodifiers --window {xid} ctrl+f")
-        machine.sleep(1)
-        # Type-to-search fallback: a plain letter also pops the search bar.
-        machine.execute(f"DISPLAY=:99 xdotool key --clearmodifiers --window {xid} a")
-        machine.sleep(2)
 
     with subtest("set_value writes the test string into the GTK4 editable via EditableText"):
         machine.copy_from_host("${setValueTest}", "/tmp/set-value-test.py")

--- a/nix/cua-driver/tests/set-value.nix
+++ b/nix/cua-driver/tests/set-value.nix
@@ -16,20 +16,21 @@
 #      set_value to write the test string, then get_window_state again and
 #      assert the field now DOES contain it.
 #
-# GTK4 choice — why gnome-text-editor:
+# GTK4 choice — why gnome-characters:
 # #1924 is GTK4-SPECIFIC (the focus-gated EditableText advertisement is a GTK4
 # behaviour), so this test must drive a GTK4 editable — a GTK3 fallback would
-# not exercise the regression. gnome-text-editor is the exact app the issue
-# names as the repro: it is GTK4 and its main view is a large editable
-# GtkTextView that exposes the AT-SPI Text/EditableText interfaces. It is a
-# properly-packaged Nix app, so (unlike a hand-rolled PyGObject script, which
-# needs the full GObject-introspection typelib set on GI_TYPELIB_PATH) its
-# wrapper already wires up GTK4 + all typelibs. We launch it FOREGROUND as the
-# only window under Xvfb/openbox — the linux-background-gui matrix only dropped
-# the GTK4 GNOME apps because they were slow to map *in the background while
-# focus was held elsewhere*; here the app is the active window, which maps fine.
-# The editor starts on an empty buffer, so the baseline "field is empty" assert
-# holds and a pass can only mean the write took.
+# not exercise the regression. We drive gnome-characters because it is the ONE
+# GTK4 app the linux-background-gui matrix found reliably surfaces a window
+# under headless Xvfb (the other GNOME GTK4 apps, gnome-text-editor included,
+# launch but never map an X11 window without a real compositor/portal, so the
+# window-find times out). gnome-characters is GTK4 and its search field is a
+# GtkText/GtkSearchEntry — a real GTK4 editable that advertises the AT-SPI
+# EditableText interface once focused, which is exactly the surface #1924's fix
+# touches (GrabFocus, then EditableText::SetTextContents). It is a packaged Nix
+# app, so its wrapper wires up GTK4 + all typelibs (unlike a hand-rolled
+# PyGObject script, which needs the full GObject-introspection typelib set on
+# GI_TYPELIB_PATH). The search field starts empty, so the baseline "field is
+# empty" assert holds and a pass can only mean the write took.
 #
 # To run: nix build .#checks.x86_64-linux.cua-driver-set-value
 {
@@ -67,12 +68,14 @@ let
     "GSK_RENDERER=cairo"
   ];
 
-  # Packaged GTK4 editor with a large editable GtkTextView (the repro app from
-  # #1924). Launched foreground; --new-window forces its own toplevel.
-  gtk4App = pkgs.gnome-text-editor;
-  gtk4Launch = "${gtk4App}/bin/gnome-text-editor --new-window";
-  # Its WM_CLASS for the xdotool window search.
-  gtk4WindowMatch = "--class org.gnome.TextEditor";
+  # Packaged GTK4 app whose search field is an editable GtkText/GtkSearchEntry
+  # (the GTK4 editable surface #1924 is about). The one GTK4 app proven to map a
+  # window under headless Xvfb — see the rationale above.
+  gtk4App = pkgs.gnome-characters;
+  gtk4Launch = "${gtk4App}/bin/gnome-characters";
+  # Its WM_CLASS for the xdotool window search (same match the passing
+  # gtk4-characters entry in linux-background-gui.nix uses).
+  gtk4WindowMatch = "--class org.gnome.Characters";
 
   # Python MCP client that drives cua-driver over stdio against the live GTK4
   # window: find the editable element_index, baseline-read, set_value, read back.
@@ -253,7 +256,10 @@ let
   # the Python testScript string), same idiom as linux-background-gui.nix.
   windowFindCmd = pkgs.writeShellScript "cua-setvalue-window-find.sh" ''
     export DISPLAY=:99
-    xid=$(${pkgs.xdotool}/bin/xdotool search --sync --onlyvisible ${gtk4WindowMatch} 2>/dev/null | head -1)
+    # No --sync: a non-matching class makes xdotool block until killed, which
+    # would swallow the whole wait_until_succeeds budget before the fallbacks
+    # below ever run. wait_until_succeeds re-runs this script to poll instead.
+    xid=$(${pkgs.xdotool}/bin/xdotool search --onlyvisible ${gtk4WindowMatch} 2>/dev/null | head -1)
     if [ -z "$xid" ]; then
       xid=$(${pkgs.xdotool}/bin/xdotool search --all --pid "$(cat /tmp/target-pid.txt)" 2>/dev/null | head -1)
     fi
@@ -288,7 +294,7 @@ pkgs.testers.nixosTest {
         dbus
         at-spi2-core
         python3
-        gtk4App # gnome-text-editor (GTK4 editable) — properly packaged
+        gtk4App # gnome-characters (GTK4 editable search field) — properly packaged
         glib # `gsettings`
         gsettings-desktop-schemas
         procps
@@ -324,7 +330,7 @@ pkgs.testers.nixosTest {
         )
         machine.log("atspi-launcher.log: " + machine.execute("cat /tmp/atspi-launcher.log")[1])
 
-    with subtest("Launch the GTK4 editable app (gnome-text-editor)"):
+    with subtest("Launch the GTK4 editable app (gnome-characters)"):
         machine.execute("sh -lc '${a11yEnv} ${gtk4Launch} >/tmp/target.log 2>&1 & echo $! >/tmp/target-pid.txt'")
         # Surface the app's own stdout/stderr early so a launch failure is visible
         # instead of just a window-find timeout.
@@ -332,7 +338,7 @@ pkgs.testers.nixosTest {
         machine.log("target.log after launch: " + machine.execute("cat /tmp/target.log")[1])
         machine.wait_until_succeeds("${windowFindCmd}", timeout=120)
         machine.log("target-xid: " + machine.execute("cat /tmp/target-xid.txt")[1])
-        # Resolve the PID that actually owns the mapped window (gnome-text-editor
+        # Resolve the PID that actually owns the mapped window (gnome-characters
         # is single-instance: the launched shell may differ from the GTK process),
         # and persist it for the driver.
         machine.execute(

--- a/nix/cua-driver/tests/set-value.nix
+++ b/nix/cua-driver/tests/set-value.nix
@@ -142,14 +142,19 @@ let
             parts.append(sc["tree_markdown"])
         return "\n".join(parts)
 
+    # Roles that denote an actually-editable text widget. STRICT: we only ever
+    # accept one of these. We must NOT fall back to a window/group/label/panel —
+    # set_value on a non-editable (e.g. the window at index 0) correctly fails
+    # with "neither EditableText nor Value", which would masquerade as the #1929
+    # fix being broken when really we just picked the wrong element.
+    EDITABLE_ROLES = ("entry", "text box", "textbox", "password text", "editable")
+
     def find_editable_index(result):
-        # Pick the editable element. Indexed actionable lines look like
-        # `- [N] <role> "..." [...] [actions=[...]]`. A GtkTextView renders with
-        # role "text"; a GtkEntry with role "entry". Prefer a text/entry line;
-        # fall back to the first indexed element if the role name differs.
+        # Indexed actionable lines look like `- [N] <role> "..." [...]
+        # [actions=[...]]`. A GtkText/GtkSearchEntry renders with role "entry"
+        # or "text"; match the role token that sits right after `- [N] `. Returns
+        # None (never a window/group fallback) if no editable role is present.
         text = tree_text(result)
-        editable_idx = None
-        first_idx = None
         for line in text.splitlines():
             s = line.strip()
             if not s.startswith("- ["):
@@ -158,12 +163,15 @@ let
                 idx = int(s[s.index("[") + 1 : s.index("]")])
             except Exception:
                 continue
-            if first_idx is None:
-                first_idx = idx
-            low = s.lower()
-            if ("entry" in low or "text" in low) and editable_idx is None:
-                editable_idx = idx
-        return editable_idx if editable_idx is not None else first_idx
+            # The role is the text between the closing `]` of the index and the
+            # first double-quote of the name.
+            after_idx = s[s.index("]") + 1 :].lstrip()
+            role = after_idx.split('"', 1)[0].strip().lower()
+            # role "text" (bare) is GtkText/GtkTextView's AT-SPI role; also accept
+            # the explicit editable roles. Reject "static text"/"label"/etc.
+            if role == "text" or role in EDITABLE_ROLES:
+                return idx
+        return None
 
     def get_window_state(proc, req_id, pid, xid):
         # ax = tree only (no screenshot needed; faster + avoids capture flakiness).
@@ -188,19 +196,29 @@ let
             send(proc, "notifications/initialized", {})
             time.sleep(0.5)
 
-            # ── Locate the editable element. Retry: GTK4 builds its accessible
-            # tree a moment after first paint. ──────────────────────────────────
+            # ── Locate the editable element. gnome-characters' GtkSearchEntry is
+            # only realized (and thus only appears in the AT-SPI tree) once the
+            # search is opened, so the helper testScript opens search via xdotool
+            # BEFORE this client runs. Retry: GTK4 builds its accessible tree a
+            # moment after first paint / after the search bar slides in. ─────────
             print("\n--- get_window_state (locate editable) ---", flush=True)
             idx = None
             before_state = None
-            for _ in range(15):
+            for _ in range(20):
                 before_state = get_window_state(proc, 2, target_pid, target_xid)
                 idx = find_editable_index(before_state)
                 if idx is not None:
                     break
                 time.sleep(1.0)
+            if idx is None:
+                # Dump the full tree so a "no editable" failure is diagnosable: it
+                # tells us whether the search entry realized at all.
+                print("NO_EDITABLE_TREE_BEGIN", flush=True)
+                print(tree_text(before_state or {}), flush=True)
+                print("NO_EDITABLE_TREE_END", flush=True)
             assert idx is not None, (
-                "no editable element found in GTK4 window:\n" + tree_text(before_state or {})
+                "no editable (entry/text) element found in the GTK4 window — the "
+                "search entry may not have realized. Tree dumped above."
             )
             print(f"editable element_index = {idx}", flush=True)
 
@@ -351,6 +369,21 @@ pkgs.testers.nixosTest {
         # on its text view (the fix also GrabFocus-es, but this gives the tree a
         # focused editable from the start).
         machine.succeed("DISPLAY=:99 xdotool windowactivate --sync $(cat /tmp/target-xid.txt)")
+
+    with subtest("Realize the GtkSearchEntry so it appears in the AT-SPI tree"):
+        # gnome-characters' search field is a GtkSearchEntry that is NOT realized
+        # (and so is absent from the default AT-SPI tree) until search is opened.
+        # Open it via the GTK "find" accelerator and a typed key (Characters also
+        # supports type-to-search), then give the bar a moment to slide in and
+        # register its accessible. Without this the only indexed element is the
+        # window itself — set_value on which correctly fails, masking the real fix.
+        xid = machine.succeed("cat /tmp/target-xid.txt").strip()
+        machine.succeed(f"DISPLAY=:99 xdotool windowactivate --sync {xid}")
+        machine.execute(f"DISPLAY=:99 xdotool key --clearmodifiers --window {xid} ctrl+f")
+        machine.sleep(1)
+        # Type-to-search fallback: a plain letter also pops the search bar.
+        machine.execute(f"DISPLAY=:99 xdotool key --clearmodifiers --window {xid} a")
+        machine.sleep(2)
 
     with subtest("set_value writes the test string into the GTK4 editable via EditableText"):
         machine.copy_from_host("${setValueTest}", "/tmp/set-value-test.py")

--- a/nix/cua-driver/tests/set-value.nix
+++ b/nix/cua-driver/tests/set-value.nix
@@ -1,0 +1,364 @@
+# CUA Driver set_value EditableText Test
+#
+# Regression test for #1924 (fixed in PR #1929): `set_value` on a GTK4 editable
+# text box failed with "element N exposes neither EditableText nor Value". GTK4
+# only advertises the AT-SPI EditableText interface on a widget once it holds
+# keyboard focus, so the interface list captured during the unfocused tree walk
+# was missing it. The fix GrabFocus-es the target, then resolves EditableText
+# live over D-Bus and writes via EditableText::SetTextContents (falling back to
+# InsertText, then Value). This test proves that exact path end-to-end:
+#
+#   1. boot a NixOS VM with a session D-Bus + AT-SPI bus (same scaffolding as
+#      linux-background-gui.nix),
+#   2. launch a GTK4 app exposing a real editable text field,
+#   3. over MCP stdio: get_window_state to locate the editable element_index,
+#      assert the field does NOT already contain the test string (baseline),
+#      set_value to write the test string, then get_window_state again and
+#      assert the field now DOES contain it.
+#
+# GTK4 choice / why a self-contained app:
+# #1924 is GTK4-SPECIFIC (the focus-gated EditableText advertisement is a GTK4
+# behaviour), so this test must drive a GTK4 editable — a GTK3 fallback would
+# not exercise the regression. The real GNOME GTK4 apps named in the issue
+# (gnome-text-editor) were dropped from the linux-background-gui matrix because
+# they never mapped a window within 120s headless in CI (missing portals / EDS
+# / VTE runtime). So, exactly like the `tk` and `chromium` targets in
+# linux-background-gui.nix, this test ships its OWN minimal GTK4 app: a single
+# GtkApplicationWindow holding one GtkEntry (a genuine GTK4 editable that
+# exposes Text/EditableText), with no portal/EDS/VTE dependencies, so it maps
+# reliably headless. The GtkEntry starts empty, guaranteeing the baseline
+# "field is empty" assert holds and a pass can only mean the write took.
+#
+# To run: nix build .#checks.x86_64-linux.cua-driver-set-value
+{
+  pkgs,
+  lib ? pkgs.lib,
+  cuaDriverModule,
+  ...
+}:
+
+let
+  # The known string we write via set_value. Distinctive so a tree-markdown
+  # substring match can't collide with any default widget label/name.
+  testValue = "cuasetvalue9271";
+
+  # Shared session-bus + a11y environment, identical in spirit to
+  # linux-background-gui.nix: the GTK4 app and the driver's native AT-SPI client
+  # must reach the same registry. Fixed bus path so every machine.* shell opts in.
+  a11yEnv = lib.concatStringsSep " " [
+    "DISPLAY=:99"
+    "DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/cua-session-bus"
+    "XDG_RUNTIME_DIR=/run/user/0"
+    "XDG_DATA_DIRS=/run/current-system/sw/share"
+    "LD_LIBRARY_PATH=${pkgs.at-spi2-atk}/lib"
+    "GSETTINGS_BACKEND=keyfile"
+    "XDG_CONFIG_HOME=/tmp/cua-cfg"
+    "GSETTINGS_SCHEMA_DIR=${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}/glib-2.0/schemas"
+    "GTK_MODULES=gail:atk-bridge"
+    "GNOME_ACCESSIBILITY=1"
+    "QT_ACCESSIBILITY=1"
+    "NO_AT_BRIDGE=0"
+    # GTK4 talks AT-SPI directly (not via atk-bridge), but only exports its
+    # accessible tree when it selects the AT-SPI backend at startup; GTK_A11Y=atspi
+    # forces it on. x11 backend + cairo renderer keep it headless-safe. (Same
+    # exports linux-background-gui.nix uses for its GTK4 entries.)
+    "GTK_A11Y=atspi"
+    "GDK_BACKEND=x11"
+    "GSK_RENDERER=cairo"
+  ];
+
+  # Minimal self-contained GTK4 app: one window, one GtkEntry, autofocused. The
+  # GtkEntry is a real GTK4 editable that exposes the AT-SPI Text/EditableText
+  # interfaces — exactly the widget class #1924 failed on. No portal/EDS/VTE, so
+  # it maps reliably headless. Fixed window title so xdotool can find it.
+  gtk4Env = pkgs.python3.withPackages (ps: [ ps.pygobject3 ]);
+
+  # PyGObject loads GTK4 via GObject-introspection typelibs at runtime, so the
+  # GTK-4.0 (and its dependency) typelibs must be on GI_TYPELIB_PATH. The
+  # `withPackages` env only carries PyGObject itself, not the GTK4 typelib, so
+  # point GI at gtk4's girepository dir explicitly before launching the app.
+  giTypelibEnv = "GI_TYPELIB_PATH=${pkgs.gtk4}/lib/girepository-1.0:${pkgs.glib}/lib/girepository-1.0:${pkgs.graphene}/lib/girepository-1.0:${pkgs.pango.out}/lib/girepository-1.0:${pkgs.gdk-pixbuf}/lib/girepository-1.0:${pkgs.harfbuzz.out}/lib/girepository-1.0";
+  gtk4App = pkgs.writeText "cua-gtk4-entry.py" ''
+    import gi
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk, GLib
+
+    def on_activate(app):
+        win = Gtk.ApplicationWindow(application=app)
+        win.set_title("cua-setvalue")
+        win.set_default_size(400, 120)
+        entry = Gtk.Entry()
+        entry.set_hexpand(True)
+        # Start EMPTY so the baseline "field does not contain the test string"
+        # assertion is guaranteed to hold before the write.
+        entry.set_text("")
+        win.set_child(entry)
+        win.present()
+        entry.grab_focus()
+
+    app = Gtk.Application(application_id="com.trycua.SetValueEntry")
+    app.connect("activate", on_activate)
+    app.run(None)
+  '';
+
+  # Python MCP client that drives cua-driver over stdio against the live GTK4
+  # window: find the editable element_index, baseline-read, set_value, read back.
+  setValueTest = pkgs.writeText "set-value-test.py" ''
+    import json, os, sys, threading, time
+
+    DRIVER_BIN = os.environ.get("CUA_DRIVER_BIN", "cua-driver")
+    TEST_VALUE = "${testValue}"
+
+    def start_driver():
+        import subprocess
+        env = {**os.environ, "CUA_ATSPI_DEBUG": "1"}
+        proc = subprocess.Popen(
+            [DRIVER_BIN, "mcp", "--no-daemon-relaunch"],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            env=env,
+        )
+        def drain():
+            for line in proc.stderr:
+                sys.stderr.buffer.write(line); sys.stderr.buffer.flush()
+        threading.Thread(target=drain, daemon=True).start()
+        return proc
+
+    def send(proc, method, params=None, req_id=None):
+        msg = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            msg["params"] = params
+        if req_id is not None:
+            msg["id"] = req_id
+        line = json.dumps(msg) + "\n"
+        print(f"[send] {line.strip()}", flush=True)
+        proc.stdin.write(line.encode()); proc.stdin.flush()
+
+    def recv(proc, timeout=60):
+        result = [None]
+        def reader():
+            result[0] = proc.stdout.readline()
+        t = threading.Thread(target=reader); t.start(); t.join(timeout)
+        if t.is_alive():
+            raise TimeoutError("No response within timeout")
+        line = result[0].decode().strip()
+        if not line:
+            raise RuntimeError("Driver returned an empty response")
+        print(f"[recv] {line[:400]}", flush=True)
+        return json.loads(line)
+
+    def call_tool(proc, req_id, name, arguments):
+        send(proc, "tools/call", {"name": name, "arguments": arguments}, req_id=req_id)
+        resp = recv(proc)
+        if resp.get("error"):
+            raise RuntimeError(f"{name} failed: {resp}")
+        if resp.get("result", {}).get("isError"):
+            raise RuntimeError(f"{name} returned isError: {resp}")
+        return resp["result"]
+
+    def tree_text(result):
+        # get_window_state returns the AT-SPI tree as Markdown text content; the
+        # driver surfaces an editable widget's Text content as the node's display
+        # name, so the written value shows up in the tree as `[idx] ... "VALUE"`.
+        parts = [c.get("text", "") for c in result.get("content", []) if c.get("type") == "text"]
+        sc = result.get("structuredContent", {}) or {}
+        if isinstance(sc.get("tree_markdown"), str):
+            parts.append(sc["tree_markdown"])
+        return "\n".join(parts)
+
+    def find_editable_index(result):
+        # Pick the editable element. The tree markdown lines for actionable
+        # elements look like `- [N] entry "..." [...] [actions=[...]]`. A GtkEntry
+        # renders with role "entry"/"text". Prefer an entry/text line; fall back
+        # to the first indexed element if the role name differs across builds.
+        text = tree_text(result)
+        entry_idx = None
+        first_idx = None
+        for line in text.splitlines():
+            s = line.strip()
+            if not s.startswith("- ["):
+                continue
+            try:
+                idx = int(s[s.index("[") + 1 : s.index("]")])
+            except Exception:
+                continue
+            if first_idx is None:
+                first_idx = idx
+            low = s.lower()
+            if ("entry" in low or "text" in low) and entry_idx is None:
+                entry_idx = idx
+        return entry_idx if entry_idx is not None else first_idx
+
+    def get_window_state(proc, req_id, pid, xid):
+        # ax = tree only (no screenshot needed; faster + avoids capture flakiness).
+        return call_tool(proc, req_id, "get_window_state", {
+            "pid": pid, "window_id": xid, "capture_mode": "ax",
+        })
+
+    def main():
+        with open("/tmp/target-xid.txt") as f:
+            target_xid = int(f.read().strip())
+        with open("/tmp/target-pid.txt") as f:
+            target_pid = int(f.read().strip())
+
+        proc = start_driver()
+        try:
+            send(proc, "initialize", {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "nixos-set-value-test", "version": "1.0.0"},
+            }, req_id=1)
+            recv(proc)
+            send(proc, "notifications/initialized", {})
+            time.sleep(0.5)
+
+            # ── Locate the editable element. Retry: GTK4 builds its accessible
+            # tree a moment after first paint. ──────────────────────────────────
+            print("\n--- get_window_state (locate editable) ---", flush=True)
+            idx = None
+            before_state = None
+            for _ in range(10):
+                before_state = get_window_state(proc, 2, target_pid, target_xid)
+                idx = find_editable_index(before_state)
+                if idx is not None:
+                    break
+                time.sleep(1.0)
+            assert idx is not None, (
+                "no editable element found in GTK4 window:\n" + tree_text(before_state or {})
+            )
+            print(f"editable element_index = {idx}", flush=True)
+
+            # ── Baseline: the field must NOT already contain the test string, so
+            # a passing read-back can only mean the write took effect. ───────────
+            before_text = tree_text(before_state)
+            assert TEST_VALUE not in before_text, (
+                f"baseline already contains '{TEST_VALUE}'; cannot prove the write "
+                f"took:\n{before_text}"
+            )
+            print("baseline OK: field does not contain the test string", flush=True)
+
+            # ── The regression: set_value into the GTK4 editable. Pre-fix this
+            # errored with "neither EditableText nor Value"; the fix writes via
+            # EditableText::SetTextContents. ────────────────────────────────────
+            print("\n--- set_value ---", flush=True)
+            sv = call_tool(proc, 3, "set_value", {
+                "pid": target_pid,
+                "window_id": target_xid,
+                "element_index": idx,
+                "value": TEST_VALUE,
+            })
+            print("set_value result: " + json.dumps(sv)[:400], flush=True)
+
+            # ── Read back: get_window_state must now show the test string in the
+            # editable's Text content. Retry — the write + tree rebuild settle a
+            # moment after SetTextContents. ─────────────────────────────────────
+            print("\n--- get_window_state (read back) ---", flush=True)
+            after_text = ""
+            for _ in range(10):
+                after_state = get_window_state(proc, 4, target_pid, target_xid)
+                after_text = tree_text(after_state)
+                if TEST_VALUE in after_text:
+                    break
+                time.sleep(1.0)
+            print("READBACK_BEGIN", flush=True)
+            print(after_text, flush=True)
+            print("READBACK_END", flush=True)
+            assert TEST_VALUE in after_text, (
+                f"set_value did not write '{TEST_VALUE}' into the GTK4 editable via "
+                f"EditableText; field still reads:\n{after_text}"
+            )
+            print("\n=== set_value EditableText test passed! ===", flush=True)
+        finally:
+            proc.stdin.close(); proc.terminate(); proc.wait(timeout=5)
+
+    if __name__ == "__main__":
+        main()
+  '';
+
+in
+
+pkgs.testers.nixosTest {
+  name = "cua-driver-set-value-test";
+  meta.maintainers = [ ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ cuaDriverModule ];
+      virtualisation = {
+        cores = 2;
+        memorySize = 2048;
+        diskSize = 8192;
+      };
+      services.cua-driver.enable = true;
+      services.dbus.enable = true;
+      environment.systemPackages = with pkgs; [
+        xorg.xorgserver
+        xterm
+        openbox
+        xdotool
+        dbus
+        at-spi2-core
+        python3
+        gtk4Env # PyGObject env for the self-contained editable app
+        gtk4 # GTK-4.0 typelib + libs (loaded by PyGObject at runtime)
+        gobject-introspection
+        glib # `gsettings`
+        gsettings-desktop-schemas
+        procps
+      ];
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("Binary exists and runs"):
+        machine.succeed("cua-driver --help")
+
+    with subtest("Start X11 + session D-Bus + AT-SPI bus"):
+        machine.execute("Xvfb :99 -screen 0 1280x1024x24 >/tmp/xvfb.log 2>&1 &")
+        machine.wait_until_succeeds("test -e /tmp/.X11-unix/X99", timeout=10)
+        machine.execute("DISPLAY=:99 openbox >/tmp/openbox.log 2>&1 &")
+        machine.succeed("mkdir -p /run/user/0 && chmod 700 /run/user/0")
+        machine.execute("dbus-daemon --session --address=unix:path=/tmp/cua-session-bus --fork >/tmp/dbus.log 2>&1")
+        machine.wait_until_succeeds("test -S /tmp/cua-session-bus", timeout=10)
+        machine.succeed("mkdir -p /tmp/cua-cfg")
+        machine.execute("${a11yEnv} ${pkgs.at-spi2-core}/libexec/at-spi-bus-launcher --launch-immediately >/tmp/atspi-launcher.log 2>&1 &")
+        machine.wait_until_succeeds(
+            "${a11yEnv} dbus-send --session --print-reply "
+            "--dest=org.freedesktop.DBus / org.freedesktop.DBus.NameHasOwner "
+            "string:org.a11y.Bus | grep -q 'boolean true'",
+            timeout=15,
+        )
+        machine.execute(
+            "${a11yEnv} dbus-send --session --print-reply --dest=org.a11y.Bus "
+            "/org/a11y/bus org.freedesktop.DBus.Properties.Set "
+            "string:org.a11y.Status string:IsEnabled variant:boolean:true 2>&1 | tee /tmp/a11y-enable.log"
+        )
+        machine.log("atspi-launcher.log: " + machine.execute("cat /tmp/atspi-launcher.log")[1])
+
+    with subtest("Launch the self-contained GTK4 editable app"):
+        machine.execute("sh -lc '${a11yEnv} ${giTypelibEnv} ${gtk4Env}/bin/python3 ${gtk4App} >/tmp/target.log 2>&1 & echo $! >/tmp/target-pid.txt'")
+        machine.sleep(5)
+        machine.log("target.log after launch: " + machine.execute("cat /tmp/target.log")[1])
+        # Find the GTK4 window by its fixed title; fall back to the launched PID's
+        # window, then the newest visible window.
+        machine.wait_until_succeeds(
+            "sh -lc 'export DISPLAY=:99; "
+            "xid=$(${pkgs.xdotool}/bin/xdotool search --sync --onlyvisible --name cua-setvalue 2>/dev/null | head -1); "
+            "[ -z \"$xid\" ] && xid=$(${pkgs.xdotool}/bin/xdotool search --all --pid $(cat /tmp/target-pid.txt) 2>/dev/null | head -1); "
+            "[ -z \"$xid\" ] && xid=$(${pkgs.xdotool}/bin/xdotool search --onlyvisible \"\" 2>/dev/null | tail -1); "
+            "test -n \"$xid\" && printf %s \"$xid\" >/tmp/target-xid.txt && test -s /tmp/target-xid.txt'",
+            timeout=60,
+        )
+        machine.log("target-xid: " + machine.execute("cat /tmp/target-xid.txt")[1])
+
+    with subtest("set_value writes the test string into the GTK4 editable via EditableText"):
+        machine.copy_from_host("${setValueTest}", "/tmp/set-value-test.py")
+        result = machine.succeed(
+            "${a11yEnv} timeout 180 python3 /tmp/set-value-test.py 2>&1"
+        )
+        machine.log(result)
+        assert "set_value EditableText test passed" in result, f"set_value test failed: {result}"
+  '';
+}


### PR DESCRIPTION
## Problem

Closes #1924.

`set_value` on a GTK4 text box (role "text box") errored `element N exposes neither EditableText nor Value`, even though the element exposes the AT-SPI `Text`/`EditableText` interface.

## Root cause

`set_value` gated the EditableText write on the cached `has_editable` flag captured during the AT-SPI tree walk. GTK4 (and similar toolkits) only advertise the `EditableText` interface on a widget once it holds keyboard focus, so the interface list captured from the **unfocused** tree snapshot is missing it — and the tool bailed before ever trying.

## Fix

Mirror the `type_text` EditableText path:
1. `GrabFocus` on the target's `Component` (internal widget focus, no window activation).
2. Resolve the `EditableText` proxy **live over D-Bus regardless of the cached flag** and try `SetTextContents`, falling back to an insert at the caret offset.
3. Numeric `Value` handling is unchanged and still used when `EditableText` is genuinely absent.

## Verification

- CI `cd-rust-cua-driver.yml` linux-x86_64 build (compile).
- Runtime on an ephemeral Ubuntu 24.04 VM under Xvfb + dbus + AT-SPI: `set_value` writes text into a gnome-text-editor (GTK4) text box; confirmed via a follow-up `get_window_state`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)