### PR TITLE
chore(cua-driver-rs)(nix): cargoLock.lockFile + sync Cargo.lock on bump (kill version drift)

### DIFF
--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -261,6 +261,31 @@ jobs:
           fi
           bump2version $CONFIG_FLAG ${{ inputs.bump_type }}
 
+      - name: Sync Cargo.lock into the cua-driver-rs bump commit
+        # bump2version edits only `[workspace.package] version` in Cargo.toml,
+        # leaving Cargo.lock's workspace-member versions stale. The next plain
+        # `cargo build` anyone runs then re-locks them and diverges from the
+        # committed lockfile — which used to break the nix build's cargoHash.
+        # Re-lock the members now and fold the change into the bump commit so the
+        # lockfile never ships out of sync with the manifest. (cargo is
+        # preinstalled on ubuntu runners; `--workspace` touches members only, not
+        # registry deps, so this never silently bumps dependencies.)
+        if: ${{ inputs.service == 'cua-driver-rs' }}
+        run: |
+          cd ${{ steps.package.outputs.directory }}
+          cargo update --workspace
+          if ! git diff --quiet Cargo.lock; then
+            TAG=$(git tag --points-at HEAD | head -1)
+            git add Cargo.lock
+            git commit --amend --no-edit
+            # bump2version tagged the pre-amend commit; move the tag onto the
+            # amended commit so the release pipeline builds the synced lockfile.
+            [ -n "$TAG" ] && git tag -f "$TAG" HEAD
+            echo "Re-locked Cargo.lock and moved tag ${TAG:-<none>} to the amended bump commit."
+          else
+            echo "Cargo.lock already in sync; nothing to fold in."
+          fi
+
       - name: Collect created tag
         id: collect_tags
         run: |

--- a/libs/cua-driver/rust/Cargo.lock
+++ b/libs/cua-driver/rust/Cargo.lock
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver"
-version = "0.5.3"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-core"
-version = "0.5.3"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-uia"
-version = "0.5.3"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "cua-driver-core",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "cursor-overlay"
-version = "0.5.3"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "image",
@@ -787,7 +787,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focus-monitor-win"
-version = "0.5.3"
+version = "0.5.6"
 dependencies = [
  "windows 0.58.0",
 ]
@@ -1591,7 +1591,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pip-preview"
-version = "0.5.3"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -1617,7 +1617,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "platform-linux"
-version = "0.5.3"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "platform-macos"
-version = "0.5.3"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "platform-windows"
-version = "0.5.3"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/nix/cua-driver/package.nix
+++ b/nix/cua-driver/package.nix
@@ -15,17 +15,24 @@
 
 pkgs.rustPlatform.buildRustPackage {
   pname = "cua-driver";
-  version = "0.5.3";
+  # Read the version from the single source of truth (the workspace manifest
+  # bumpversion edits) so it can never drift from Cargo.toml the way a
+  # hardcoded literal silently did across 0.5.3 -> 0.5.6.
+  version = (pkgs.lib.importTOML "${src}/Cargo.toml").workspace.package.version;
 
   inherit src;
 
-  # Use cargoHash (fetchCargoVendor) rather than cargoLock.lockFile because
-  # the workspace Cargo.lock includes macOS-only crates (apple-metal, apple-cf)
-  # that may be unreachable from crates.io. fetchCargoVendor handles this
-  # gracefully via `cargo vendor`.
-  # Bumped when the dependency set changes (added `atspi`/zbus for native
-  # AT-SPI). If this mismatches, the nix build prints the expected value.
-  cargoHash = "sha256-ykVW0duMeoWho0qwDdu0k//cOY6HG+HsIBQF7iT0nZ0=";
+  # Vendor straight from the committed Cargo.lock instead of a manual cargoHash.
+  # `importCargoLock` derives every dependency's fixed-output hash from the
+  # lockfile itself, so there is NO hash to hand-maintain: Cargo.lock can change
+  # (a version bump, a dependency update) and the build keeps working. The old
+  # cargoHash approach hashed the vendored lockfile, so any Cargo.lock change —
+  # even a workspace-version bump the release bump leaves behind — silently
+  # invalidated it and turned every nix job red until someone recomputed it.
+  # Every dependency here is a crates.io registry crate (the macOS-only
+  # apple-cf/apple-metal/objc2 crates included) and there are zero git deps, so
+  # importCargoLock needs no `outputHashes` overrides.
+  cargoLock.lockFile = "${src}/Cargo.lock";
 
   # Build only the main binary crate. The workspace also contains
   # platform-macos, platform-windows, cua-driver-uia, and focus-monitor-win


### PR DESCRIPTION
## The drift, and why it kept biting

The release bump (`bump2version`) edits only `Cargo.toml`'s `[workspace.package] version`. It leaves `Cargo.lock`'s 9 workspace-member versions stale, and the Nix package pinned a **manual `cargoHash`** that hashes the vendored lockfile. So the committed lock + hash stayed consistent (and green) **only by never touching the lock** — a frozen-inconsistent state that detonates the moment anyone runs `cargo build`: it re-locks the members, diverges from the committed lock, and invalidates the hash → **every Nix job goes red**. That's what hit #1933. The drift had silently accumulated across **0.5.3 → 0.5.6** (Cargo.toml said 0.5.6; Cargo.lock + `package.nix` still said 0.5.3).

## Fix — three changes so it can't recur

1. **`package.nix` uses `cargoLock.lockFile` instead of `cargoHash`.** `importCargoLock` derives each dependency's fixed-output hash from the lockfile itself, so there is **no hash to hand-maintain** — `Cargo.lock` can change freely (version bump, dep update) and the build keeps working. I verified the old "apple crates may be unreachable from crates.io" rationale is **false**: `apple-cf` / `apple-metal` / `objc2` are all `registry+crates.io` with checksums, and there are **zero git deps** (376 registry / 0 git), so no `outputHashes` overrides are needed.
2. **`package.nix` reads `version` from `Cargo.toml`** (`[workspace.package]`) instead of a hardcoded literal (which had drifted to 0.5.3).
3. **Re-locked `Cargo.lock` to 0.5.6**, and the **bump workflow now runs `cargo update --workspace`** after `bump2version` and folds the synced lockfile into the bump commit (moving the tag), so the manifest and lockfile ship in sync every release.

## Verification

- [ ] CI: the Nix jobs build via `cargoLock.lockFile` (the load-bearing change — confirms importCargoLock vendors the full dep set with no hash). I can't run Nix on the dev box, so CI is the gate.
- The `Cargo.lock` diff is **only** the 9 workspace-member version bumps (0.5.3→0.5.6); no registry deps changed.
- The bump-workflow change can't run until the next release, but it's guarded (only acts if `Cargo.lock` changed; only for `cua-driver-rs`) and `cargo` is preinstalled on the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation and build configuration to ensure dependencies are properly synchronized during releases.
  * Enhanced build system to dynamically derive package version and dependencies from source configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->