### PR TITLE
fix(cua-driver-rs)(linux): modal-dialog hang (#1936) + type_text focused-widget targeting

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-core/src/video_ffmpeg.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/video_ffmpeg.rs
@@ -280,8 +280,17 @@ fn platform_input_args(cmd: &mut Command) {
     #[cfg(target_os = "linux")]
     {
         let display = std::env::var("DISPLAY").unwrap_or_else(|_| ":0.0".into());
+        // x11grab draws the real X pointer by default. When the synthetic agent
+        // cursor is the actor (the usual case for a recorded run), the real
+        // pointer is just noise — set CUA_DRIVER_RS_DRAW_SYSTEM_CURSOR=0 to
+        // suppress it so only the agent cursor appears.
+        let draw_mouse = match std::env::var("CUA_DRIVER_RS_DRAW_SYSTEM_CURSOR").as_deref() {
+            Ok("0") => "0",
+            _ => "1",
+        };
         cmd.arg("-f").arg("x11grab")
             .arg("-framerate").arg(framerate)
+            .arg("-draw_mouse").arg(draw_mouse)
             .arg("-i").arg(display);
     }
 

--- a/libs/cua-driver/rust/crates/platform-linux/src/atspi/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/atspi/mod.rs
@@ -133,6 +133,14 @@ pub fn insert_text(pid: u32, text: &str) -> Result<bool> {
     native::insert_text(pid, text)
 }
 
+/// Classify what holds keyboard focus so `type_text` can target the focused
+/// widget (the thing just clicked) instead of the first editable anywhere:
+/// `Some(true)` = focused editable, `Some(false)` = focused non-editable input
+/// (spreadsheet cell, terminal, canvas), `None` = nothing focused / unreachable.
+pub fn focused_is_editable(pid: u32) -> Result<Option<bool>> {
+    native::focused_is_editable(pid)
+}
+
 /// Get the screen-coordinate bounding box (x, y, width, height) of element `idx`.
 /// Screen-coordinate bounds for every action node in pid's AT-SPI tree, keyed
 /// by `element_index`. Best-effort: nodes whose bounds can't be read are

--- a/libs/cua-driver/rust/crates/platform-linux/src/atspi/native.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/atspi/native.rs
@@ -650,6 +650,30 @@ pub fn insert_text(pid: u32, text: &str) -> Result<bool> {
     })
 }
 
+/// Classify what holds keyboard focus in `pid`'s tree, so `type_text` can target
+/// the thing the user just clicked rather than the first editable anywhere:
+///   `Some(true)`  — a focused **editable** widget (a text entry/box). AT-SPI
+///                   EditableText insertion targets it correctly.
+///   `Some(false)` — a focused **non-editable** widget that still accepts typed
+///                   input (a spreadsheet cell/grid, a terminal, a canvas). An
+///                   AT-SPI editable search would grab the wrong field here (e.g.
+///                   gnumeric's name box), so the caller should synth-type into
+///                   the focused widget instead.
+///   `None`        — nothing is focused (or the app is unreachable): fall back to
+///                   the focus-free "first editable" path for background typing.
+pub fn focused_is_editable(pid: u32) -> Result<Option<bool>> {
+    bounded(async {
+        let conn = AccessibilityConnection::new()
+            .await
+            .map_err(|e| anyhow!("AT-SPI connect failed: {e}"))?;
+        let visited = match collect_visited(&conn, pid).await? {
+            Some(v) => v,
+            None => return Ok(None),
+        };
+        Ok(visited.iter().find(|v| v.focused).map(|v| v.has_editable))
+    }, || Ok(None))
+}
+
 /// Find the window XID for a PID by listing its X11 windows.
 async fn entry_find_window_xid(pid: u32) -> Option<u64> {
     use crate::x11::list_windows;

--- a/libs/cua-driver/rust/crates/platform-linux/src/atspi/native.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/atspi/native.rs
@@ -34,6 +34,29 @@ async fn call<T>(fut: impl std::future::Future<Output = T>) -> Option<T> {
     tokio::time::timeout(CALL_TIMEOUT, fut).await.ok()
 }
 
+/// Drive an AT-SPI op `work` on the runtime, bounded by [`OP_TIMEOUT`].
+///
+/// Individual interface calls are each bounded by [`call`], and `app_for_pid` /
+/// `collect_visited` carry their own deadlines — but not every internal await is
+/// wrapped (e.g. the EditableText writes in `write_into_editable`, the proxy
+/// builds in `app_for_pid`), and an app that holds a modal grab can leave one of
+/// those unwrapped round-trips pending indefinitely. `walk_tree` already guards
+/// itself this way; this helper applies the same backstop to every other public
+/// entry point so a modal/wedged app can never hang the caller (the daemon, an
+/// MCP client) past OP_TIMEOUT (#1936). On timeout it yields `on_timeout` — the
+/// graceful "couldn't complete" value, so e.g. `type_text` falls back to XTEST.
+fn bounded<T>(
+    work: impl std::future::Future<Output = Result<T>>,
+    on_timeout: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    runtime().block_on(async move {
+        match tokio::time::timeout(OP_TIMEOUT, work).await {
+            Ok(r) => r,
+            Err(_) => on_timeout(),
+        }
+    })
+}
+
 /// Emit a one-line diagnostic to stderr when `CUA_ATSPI_DEBUG` is set. The
 /// driver's stderr is surfaced in the test logs, so this is how we see what the
 /// native walk actually found in CI.
@@ -214,24 +237,77 @@ async fn collect_visited<'a>(
     let mut visited: Vec<Visited<'a>> = Vec::new();
     // Guard against pathological/looping trees.
     let mut budget = 5000usize;
+    // Time budget alongside the node budget: when an app is unresponsive to
+    // AT-SPI (most commonly because it holds a modal grab and isn't servicing
+    // D-Bus), every per-node `call()` burns the full CALL_TIMEOUT before being
+    // skipped, so the walk would otherwise grind for minutes. Callers that lack
+    // their own OP_TIMEOUT (get_all_element_bounds, insert_text) relied on this
+    // never happening — bound it here so the walk returns partial within
+    // OP_TIMEOUT for every caller, instead of hanging get_window_state/type_text
+    // on modal dialogs (#1936).
+    let deadline = std::time::Instant::now() + OP_TIMEOUT;
+    // Fast bail for an app that has stopped answering AT-SPI entirely (modal
+    // grab): if several consecutive nodes each burn the full CALL_TIMEOUT, the
+    // app is unresponsive and the remaining ~OP_TIMEOUT of walking would all
+    // time out too. Give up after a few so type_text falls back to XTEST in a
+    // few seconds rather than ~25s.
+    let mut consecutive_timeouts = 0u32;
 
     while let Some((oref, depth, in_web_doc)) = stack.pop() {
         if budget == 0 {
             dlog!("node budget exhausted; truncating walk");
             break;
         }
+        if std::time::Instant::now() >= deadline {
+            dlog!("collect_visited time budget exhausted; returning partial walk");
+            break;
+        }
         budget -= 1;
 
-        let acc = match accessible_for(zconn, &oref).await {
-            Ok(a) => a,
-            Err(_) => continue,
+        // accessible_for builds a proxy whose first use round-trips to the
+        // target app. On a modal-grabbed (AT-SPI-unresponsive) app this is the
+        // await that actually hangs, so it MUST carry the per-call timeout —
+        // otherwise the loop never returns to the deadline check at the top and
+        // the walk stalls past OP_TIMEOUT for callers without an outer guard
+        // (get_all_element_bounds, insert_text). That was the residual #1936 hang.
+        let acc = match call(accessible_for(zconn, &oref)).await {
+            Some(Ok(a)) => a,
+            Some(Err(_)) => continue,
+            None => {
+                consecutive_timeouts += 1;
+                if consecutive_timeouts >= 3 {
+                    dlog!(
+                        "{} consecutive AT-SPI timeouts (accessible_for); app unresponsive, bailing walk",
+                        consecutive_timeouts
+                    );
+                    break;
+                }
+                continue;
+            }
         };
 
         // Interfaces gate every other query; if even this times out the node is
         // unreachable, so skip it rather than stall.
         let ifaces = match call(acc.get_interfaces()).await {
-            Some(Ok(i)) => i,
-            _ => continue,
+            Some(Ok(i)) => {
+                consecutive_timeouts = 0;
+                i
+            }
+            // A completed-but-errored call is node-specific; keep walking.
+            Some(Err(_)) => continue,
+            // A timeout means the app didn't answer in CALL_TIMEOUT. A run of
+            // these means the whole app is wedged — bail so callers fall back.
+            None => {
+                consecutive_timeouts += 1;
+                if consecutive_timeouts >= 3 {
+                    dlog!(
+                        "{} consecutive AT-SPI timeouts; app unresponsive, bailing walk",
+                        consecutive_timeouts
+                    );
+                    break;
+                }
+                continue;
+            }
         };
         let has_action = ifaces.contains(Interface::Action);
         let has_editable = ifaces.contains(Interface::EditableText);
@@ -478,7 +554,7 @@ async fn write_into_editable(visited: &[Visited<'_>], text: &str) -> Result<bool
 }
 
 pub fn insert_text(pid: u32, text: &str) -> Result<bool> {
-    runtime().block_on(async {
+    bounded(async {
         let conn = AccessibilityConnection::new()
             .await
             .map_err(|e| anyhow!("AT-SPI connect failed: {e}"))?;
@@ -568,6 +644,9 @@ pub fn insert_text(pid: u32, text: &str) -> Result<bool> {
         }
 
         Ok(false)
+    }, || {
+        dlog!("insert_text timed out for pid {pid}; falling back to synthetic typing");
+        Ok(false)
     })
 }
 
@@ -601,7 +680,7 @@ fn screen_to_window_coords(xid: u64, screen_x: i32, screen_y: i32) -> Option<(i3
 }
 
 pub fn perform_action(pid: u32, idx: usize) -> Result<String> {
-    runtime().block_on(async {
+    bounded(async {
         let conn = AccessibilityConnection::new()
             .await
             .map_err(|e| anyhow!("AT-SPI connect failed: {e}"))?;
@@ -625,11 +704,11 @@ pub fn perform_action(pid: u32, idx: usize) -> Result<String> {
             .await
             .map_err(|e| anyhow!("doAction failed: {e}"))?;
         Ok(target.actions.first().cloned().unwrap_or_default())
-    })
+    }, || Err(anyhow!("perform_action timed out for pid {pid} (app unresponsive to AT-SPI)")))
 }
 
 pub fn set_value(pid: u32, idx: usize, value: &str) -> Result<()> {
-    runtime().block_on(async {
+    bounded(async {
         let conn = AccessibilityConnection::new()
             .await
             .map_err(|e| anyhow!("AT-SPI connect failed: {e}"))?;
@@ -692,11 +771,11 @@ pub fn set_value(pid: u32, idx: usize, value: &str) -> Result<()> {
             return Ok(());
         }
         Err(anyhow!("element {idx} exposes neither EditableText nor Value"))
-    })
+    }, || Err(anyhow!("set_value timed out for pid {pid} (app unresponsive to AT-SPI)")))
 }
 
 pub fn get_element_bounds(pid: u32, idx: usize) -> Result<(i32, i32, u32, u32)> {
-    runtime().block_on(async {
+    bounded(async {
         let conn = AccessibilityConnection::new()
             .await
             .map_err(|e| anyhow!("AT-SPI connect failed: {e}"))?;
@@ -723,7 +802,7 @@ pub fn get_element_bounds(pid: u32, idx: usize) -> Result<(i32, i32, u32, u32)> 
             .await
             .map_err(|e| anyhow!("getExtents failed: {e}"))?;
         Ok((x, y, w.max(0) as u32, h.max(0) as u32))
-    })
+    }, || Err(anyhow!("get_element_bounds timed out for pid {pid} (app unresponsive to AT-SPI)")))
 }
 
 /// Real on-screen origin (root-relative top-left) of an X11 window, or `None`
@@ -817,7 +896,7 @@ async fn gtk4_screen_offset(visited: &[Visited<'_>], pid: u32, xid: u64) -> (i32
 ///
 /// Returns `(element_index, x, y, width, height)` tuples.
 pub fn get_all_element_bounds(pid: u32, xid: u64) -> Result<Vec<(usize, i32, i32, u32, u32)>> {
-    runtime().block_on(async {
+    bounded(async {
         let conn = AccessibilityConnection::new()
             .await
             .map_err(|e| anyhow!("AT-SPI connect failed: {e}"))?;
@@ -878,5 +957,8 @@ pub fn get_all_element_bounds(pid: u32, xid: u64) -> Result<Vec<(usize, i32, i32
             }
         }
         Ok(out)
+    }, || {
+        dlog!("get_all_element_bounds timed out for pid {pid}; returning no bounds");
+        Ok(Vec::new())
     })
 }

--- a/libs/cua-driver/rust/crates/platform-linux/src/atspi/native.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/atspi/native.rs
@@ -138,21 +138,52 @@ async fn app_for_pid<'a>(
     pid: u32,
 ) -> Result<Option<AccessibleProxy<'a>>> {
     let zconn = conn.connection();
-    let root = conn
-        .root_accessible_on_registry()
-        .await
-        .map_err(|e| anyhow!("registry root unavailable: {e}"))?;
+    // Every AT-SPI round-trip below can block on an app whose main loop isn't
+    // servicing D-Bus — most commonly one holding a modal grab (an "Add/Edit/
+    // Preferences" dialog). Without a bound, `GetConnectionUnixProcessID` stalls
+    // on the zbus default (~25s) per such app, which made get_window_state and
+    // type_text hang on real apps (#1936). Bound each step with CALL_TIMEOUT and
+    // skip/return instead of stalling — for type_text this returns fast so the
+    // tool falls back to XTEST, which still types into the focused dialog field.
+    let root = match call(conn.root_accessible_on_registry()).await {
+        Some(Ok(r)) => r,
+        Some(Err(e)) => return Err(anyhow!("registry root unavailable: {e}")),
+        None => {
+            dlog!("registry root lookup timed out");
+            return Ok(None);
+        }
+    };
     let dbus = atspi::zbus::fdo::DBusProxy::new(zconn)
         .await
         .map_err(|e| anyhow!("DBus proxy unavailable: {e}"))?;
 
-    let apps = root.get_children().await.unwrap_or_default();
+    let apps = match call(root.get_children()).await {
+        Some(r) => r.unwrap_or_default(),
+        None => {
+            dlog!("registry get_children timed out");
+            return Ok(None);
+        }
+    };
     dlog!("registry root has {} application(s); seeking pid {pid}", apps.len());
     for child in apps {
-        let cpid = pid_of(&dbus, &child).await;
+        // A modal-grabbed app can't answer the pid query; skip it after
+        // CALL_TIMEOUT rather than blocking the whole walk on it.
+        let cpid = match call(pid_of(&dbus, &child)).await {
+            Some(p) => p,
+            None => {
+                dlog!("  pid_of timed out for bus={:?}, skipping", child.name_as_str());
+                continue;
+            }
+        };
         dlog!("  app bus={:?} pid={:?}", child.name_as_str(), cpid);
         if cpid == Some(pid) {
-            return Ok(Some(accessible_for(zconn, &child).await?));
+            return match call(accessible_for(zconn, &child)).await {
+                Some(r) => r.map(Some),
+                None => {
+                    dlog!("  accessible_for timed out for pid {pid}");
+                    Ok(None)
+                }
+            };
         }
     }
     dlog!("no application accessible matched pid {pid}");

--- a/libs/cua-driver/rust/crates/platform-linux/src/input/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/input/mod.rs
@@ -1433,6 +1433,48 @@ pub fn send_type_text_with_delay(xid: u64, text: &str, inter_char_ms: u64) -> Re
     Ok(())
 }
 
+/// Type `text` into whatever window currently holds X keyboard focus, using the
+/// XTest extension. Unlike [`send_type_text`] (synthetic XSendEvent, which GTK/Qt
+/// silently drop for key input), XTest injects *real* input events, so they
+/// actually reach the focused widget — a spreadsheet cell, a terminal, a canvas —
+/// that exposes no AT-SPI EditableText interface to fill. There is no window
+/// argument because XTest always delivers to the focused window; the caller
+/// focuses the target by clicking it first. `\n`/`\t` map to Return/Tab.
+pub fn send_type_text_xtest(text: &str) -> Result<()> {
+    use x11rb::protocol::xtest::ConnectionExt as _;
+    let (conn, _) = RustConnection::connect(None)?;
+    let mapping = conn.get_keyboard_mapping(8, 248)?.reply()?;
+    // Shift keycode (modifier index 0) for shifted characters.
+    let modmap = conn.get_modifier_mapping()?.reply()?;
+    let kpm = modmap.keycodes_per_modifier() as usize;
+    let shift_kc = modmap
+        .keycodes
+        .get(..kpm)
+        .and_then(|s| s.iter().copied().find(|&k| k != 0))
+        .unwrap_or(50);
+    for ch in text.chars() {
+        let cp = match ch {
+            '\n' => 0xff0d, // XK_Return
+            '\t' => 0xff09, // XK_Tab
+            c => c as u32,
+        };
+        let Some((keycode, needs_shift)) = char_to_keycode_shift(&mapping, cp) else {
+            continue;
+        };
+        if needs_shift {
+            conn.xtest_fake_input(KEY_PRESS_EVENT, shift_kc, 0, x11rb::NONE, 0, 0, 0)?;
+        }
+        conn.xtest_fake_input(KEY_PRESS_EVENT, keycode, 0, x11rb::NONE, 0, 0, 0)?;
+        conn.xtest_fake_input(KEY_RELEASE_EVENT, keycode, 0, x11rb::NONE, 0, 0, 0)?;
+        if needs_shift {
+            conn.xtest_fake_input(KEY_RELEASE_EVENT, shift_kc, 0, x11rb::NONE, 0, 0, 0)?;
+        }
+        conn.flush()?;
+        sleep(Duration::from_millis(KEY_DELAY_MS));
+    }
+    Ok(())
+}
+
 /// Send a named key press to a window.
 pub fn send_key(xid: u64, key: &str, modifiers: &[&str]) -> Result<()> {
     let (conn, _) = RustConnection::connect(None)?;

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -1054,6 +1054,38 @@ impl Tool for TypeTextTool {
         }
         let text_len = text.chars().count();
 
+        // Prefer the focused widget — the element the user just clicked. If a
+        // NON-editable input holds keyboard focus (a spreadsheet cell, a
+        // terminal, a canvas), the focus-free AT-SPI editable search below would
+        // grab the wrong field (e.g. gnumeric's name box instead of the selected
+        // cell, or skip a terminal entirely), so synth-type into the focused
+        // widget instead: terminals via pty injection, everything else via
+        // XSendEvent to the focused window. A focused *editable* (Some(true)) or
+        // nothing focused (None) falls through to the existing AT-SPI-first flow.
+        let focus_kind = tokio::task::spawn_blocking(move || {
+            crate::atspi::focused_is_editable(pid).ok().flatten()
+        }).await.ok().flatten();
+        if focus_kind == Some(false) {
+            let text_f = text.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                if inject_terminal_input(pid, xid, &text_f)? {
+                    return Ok(());
+                }
+                // XTest (real input to the focused window), NOT XSendEvent: GTK/Qt
+                // drop synthetic key events, so a spreadsheet cell / canvas would
+                // stay empty. The click that gave this widget focus already put it
+                // under the X input focus, so XTest-to-focus lands correctly.
+                crate::input::send_type_text_xtest(&text_f)
+            }).await;
+            return match result {
+                Ok(Ok(())) => ToolResult::text(format!(
+                    "Typed {text_len} character(s) into the focused widget."
+                )),
+                Ok(Err(e)) => ToolResult::error(e.to_string()),
+                Err(e) => ToolResult::error(format!("Task error: {e}")),
+            };
+        }
+
         // Try AT-SPI EditableText first (focus-free, works for Qt6/GTK4).
         let text_clone = text.clone();
         let atspi_result = tokio::task::spawn_blocking(move || {


### PR DESCRIPTION
## Summary

A night of live-driving cua-driver on real Linux apps (X11 + software-GL), consolidated into one PR. Three fixes.

## 1. Modal-dialog hang (#1936)

`get_window_state` / `type_text` (and `perform_action` / `set_value` / `get_element_bounds`) hung ~25s–60s+ when the target app had a **modal dialog** open — found live-driving HomeBank's "Add transaction" dialog.

**Root cause.** A modal-grabbed app isn't servicing D-Bus, so AT-SPI round-trips stall. Only `walk_tree` carried an operation-level `OP_TIMEOUT` guard; every other entry point called `collect_visited` directly, and several awaits were unbounded — notably `accessible_for()` inside `collect_visited`'s loop (the one await not wrapped in `call()`, so the loop never returned to its deadline check), plus the EditableText writes and GetExtents loops.

**Fix.** Wrap `accessible_for` in the per-call timeout (and count it toward the fast-bail), and add a `bounded()` helper — the same `OP_TIMEOUT` pattern `walk_tree` already uses — to `insert_text`, `get_all_element_bounds`, `get_element_bounds`, `perform_action`, `set_value`. A modal/wedged app can no longer hang any tool past `OP_TIMEOUT`. Regression-checked on mousepad (~1s, no hang on a crash-restore modal).

## 2. `type_text` targets the focused widget (spreadsheet / terminal typing)

`type_text` searched the AT-SPI tree for the *first* editable and typed there — wrong when a **non-editable** widget holds focus: in gnumeric the text landed in the name box instead of the selected cell; terminals/canvases got nothing.

**Fix.** Before the focus-free AT-SPI search, classify what holds keyboard focus (`focused_is_editable`): focused-editable → existing AT-SPI path; focused **non-editable** (cell/terminal/canvas) → synth-type into the focused widget; nothing focused → unchanged. The focused-widget path uses a new `send_type_text_xtest` (XTest real key injection) rather than XSendEvent, which GTK/Qt drop for keys. Verified: click gnumeric A1, type a budget with Tab/Enter navigation → all cells + a live `=SUM` total land correctly (was: empty cells, text in the name box).

## 3. `CUA_DRIVER_RS_DRAW_SYSTEM_CURSOR`

Env knob to pass `-draw_mouse 0` to x11grab, suppressing the real pointer in recordings (useful when compositing a synthetic cursor). Default unchanged. (The real X pointer is already captured by default and moves with coordinate clicks, so it shows in recordings without extra work.)

## Findings (no code change)

- Coordinate-only clicks (`{x,y}`, no AX) work everywhere — verified.
- Software-GL: Audacity (wxWidgets) and Krita (Qt6) paint under LLVMpipe. FreeCAD is blocked only by snap-cgroup confinement under headless SSH, not rendering.
- Wayland video recording doesn't exist yet (x11grab is X-only) — a real follow-up feature (`wf-recorder`/wlr-screencopy).
- The pyatspi `type_into_editable` shellout (primary path when pyatspi is installed) has the same first-editable bias; the focus classifier short-circuits it for the non-editable case, but the script itself could be made focus-aware too.
