### PR TITLE
docs(blog): correct Inside Linux computer-use byline to Robert Wendt

### DIFF
--- a/blog/inside-linux-computer-use.md
+++ b/blog/inside-linux-computer-use.md
@@ -1,6 +1,6 @@
 # Inside Linux computer-use: AT-SPI, XTEST, and background agents
 
-_Published on June 18 by Francesco Bonacci_
+_Published on June 18 by Robert Wendt_
 
 <img width="960" height="540" alt="screen-recording-2026-06-17" src="https://github.com/user-attachments/assets/2a8a131c-4ce4-451e-bcc6-f80b4bdfa8eb" />
 


### PR DESCRIPTION
The Inside Linux computer-use post is authored by Robert Wendt (he built the Linux backend). Fixes the in-body byline that still read "by Francesco Bonacci" so it matches the website attribution.

One-line change in `blog/inside-linux-computer-use.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected author attribution on a blog post to reflect accurate byline information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->