### PR TITLE
feat(cua-driver-rs): add Linux arm64 (aarch64) prebuilt support

### DIFF
--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -30,23 +30,42 @@ permissions:
   contents: write
 
 jobs:
-  # ── Linux x86_64 ─────────────────────────────────────────────────────────────
+  # ── Linux (x86_64 + arm64) ───────────────────────────────────────────────────
+  # One matrixed job per Linux target. x86_64 builds on the standard
+  # ubuntu-latest host; arm64 builds NATIVELY on GitHub's hosted ARM runner
+  # (ubuntu-24.04-arm) rather than cross-compiling, because the native X11 /
+  # Wayland C deps (libx11-dev, libwayland-dev, …) would otherwise need their
+  # arm64 multiarch variants + a cross linker wired up by hand. A native ARM
+  # runner keeps the build identical to the x86_64 path. install.sh picks the
+  # matching tarball at install time based on the host's `uname -m`.
   build-linux:
-    name: linux-x86_64
-    runs-on: ubuntu-latest
+    name: linux-${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+          - arch: arm64
+            target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
     # Build INSIDE a Debian 11 (bullseye) container instead of directly on
-    # the ubuntu-latest host. ubuntu-latest is now Ubuntu 24.04, whose glibc
-    # is 2.39 — a binary linked there imports GLIBC_2.39 symbols (e.g.
-    # posix_spawn's pidfd_spawnp/pidfd_getpid) and refuses to even run
-    # `--version` on older distros:
+    # the host. ubuntu-latest is now Ubuntu 24.04, whose glibc is 2.39 — a
+    # binary linked there imports GLIBC_2.39 symbols (e.g. posix_spawn's
+    # pidfd_spawnp/pidfd_getpid) and refuses to even run `--version` on older
+    # distros:
     #   cua-driver: /lib/.../libc.so.6: version 'GLIBC_2.39' not found
     # That broke Debian 12 (glibc 2.36), Ubuntu 22.04 (2.35), and RHEL/Rocky
     # 9 (2.34). Debian 11's glibc is 2.31, so linking against it lowers the
     # floor to GLIBC_2.31 — covering Debian 11+, Ubuntu 20.04+, and RHEL/
     # Rocky 8+. A container (rather than the retired ubuntu-20.04 runner
     # label) keeps the floor deterministic regardless of GitHub's host image
-    # churn. The C deps below all exist in bullseye, including libwayland-dev
-    # for the native Wayland backend (#1910).
+    # churn. The debian:11 image is multi-arch, so the arm64 runner pulls the
+    # aarch64 variant automatically and the glibc floor holds on both arches.
+    # The C deps below all exist in bullseye, including libwayland-dev for the
+    # native Wayland backend (#1910).
     container:
       image: debian:11
     steps:
@@ -71,27 +90,28 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: x86_64-unknown-linux-gnu
+          targets: ${{ matrix.target }}
       - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             libs/cua-driver/rust/target
-          key: rust-cua-driver-rs-linux-x86_64-${{ hashFiles('libs/cua-driver/rust/Cargo.lock', 'libs/cua-driver/rust/**/Cargo.toml') }}
+          key: rust-cua-driver-rs-linux-${{ matrix.arch }}-${{ hashFiles('libs/cua-driver/rust/Cargo.lock', 'libs/cua-driver/rust/**/Cargo.toml') }}
           restore-keys: |
-            rust-cua-driver-rs-linux-x86_64-
+            rust-cua-driver-rs-linux-${{ matrix.arch }}-
       - name: Build (release)
         working-directory: libs/cua-driver/rust
-        run: cargo build -p cua-driver --release --target x86_64-unknown-linux-gnu
+        run: cargo build -p cua-driver --release --target ${{ matrix.target }}
       - name: Package
         working-directory: libs/cua-driver/rust
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          LABEL="linux-x86_64"
+          LABEL="linux-${{ matrix.arch }}"
+          TARGET="${{ matrix.target }}"
           STAGE="cua-driver-rs-${VERSION}-${LABEL}"
           mkdir -p "release/${STAGE}"
-          cp "target/x86_64-unknown-linux-gnu/release/cua-driver" "release/${STAGE}/"
+          cp "target/${TARGET}/release/cua-driver" "release/${STAGE}/"
           cp ../../LICENSE.md "release/${STAGE}/LICENSE" 2>/dev/null || true
           (cd release && tar -czf "${STAGE}.tar.gz" "${STAGE}")
           # Bare binary tarball — single file (cua-driver) at the archive root,
@@ -100,8 +120,8 @@ jobs:
           ls -lh "release/${STAGE}.tar.gz" "release/${STAGE}-binary.tar.gz"
       - uses: actions/upload-artifact@v4
         with:
-          name: cua-driver-rs-linux-x86_64
-          path: libs/cua-driver/rust/release/cua-driver-rs-*-linux-x86_64*.tar.gz
+          name: cua-driver-rs-linux-${{ matrix.arch }}
+          path: libs/cua-driver/rust/release/cua-driver-rs-*-linux-${{ matrix.arch }}*.tar.gz
           if-no-files-found: error
 
   # ── Windows (x86_64 + arm64) ─────────────────────────────────────────────────
@@ -599,6 +619,8 @@ jobs:
             **Linux pre-release**
             - `cua-driver-rs-${{ steps.version.outputs.version }}-linux-x86_64.tar.gz` — directory tarball
             - `cua-driver-rs-${{ steps.version.outputs.version }}-linux-x86_64-binary.tar.gz` — bare binary
+            - `cua-driver-rs-${{ steps.version.outputs.version }}-linux-arm64.tar.gz` — directory tarball (Linux on ARM / aarch64)
+            - `cua-driver-rs-${{ steps.version.outputs.version }}-linux-arm64-binary.tar.gz` — bare binary (Linux on ARM / aarch64)
 
             **Windows**
             - `cua-driver-rs-${{ steps.version.outputs.version }}-windows-x86_64.zip` — directory zip

--- a/libs/cua-driver/scripts/_install-rust.sh
+++ b/libs/cua-driver/scripts/_install-rust.sh
@@ -481,9 +481,10 @@ case "$OS-$ARCH_RAW" in
     Darwin-arm64|Darwin-aarch64)     LABEL="darwin-arm64"  ; TARGET="aarch64-apple-darwin"      ;;
     Darwin-x86_64)                   LABEL="darwin-x86_64" ; TARGET="x86_64-apple-darwin"       ;;
     Linux-x86_64|Linux-amd64)        LABEL="linux-x86_64"  ; TARGET="x86_64-unknown-linux-gnu"  ;;
+    Linux-aarch64|Linux-arm64)       LABEL="linux-arm64"   ; TARGET="aarch64-unknown-linux-gnu" ;;
     *)
         err "unsupported platform: $OS / $ARCH_RAW"
-        err "  cua-driver-rs ships prebuilts for: darwin-arm64, darwin-x86_64, linux-x86_64."
+        err "  cua-driver-rs ships prebuilts for: darwin-arm64, darwin-x86_64, linux-x86_64, linux-arm64."
         err "  Windows users: install via install.ps1 (irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.ps1 | iex)."
         exit 1
         ;;


### PR DESCRIPTION
## Summary

Adds Linux ARM (aarch64) prebuilt support to `cua-driver-rs`. Linux was previously x86_64-only — the CD matrix had no aarch64 job, and the installer rejected `Linux-aarch64`/`Linux-arm64` hosts outright at the platform switch. ARM was already covered on Windows (`aarch64-pc-windows-msvc`) and macOS (universal binary), so this brings Linux in line.

## Changes

- **`.github/workflows/cd-rust-cua-driver.yml`** — convert the single `build-linux` job into a matrix over `x86_64` and `arm64` (mirroring the existing `build-windows` matrix pattern). The arm64 build runs **natively** on GitHub's hosted `ubuntu-24.04-arm` runner inside the **same `debian:11` container** — the image is multi-arch, so the ARM runner pulls the aarch64 variant and the `GLIBC_2.31` floor holds on both arches. Native build avoids hand-wiring a cross linker plus arm64 multiarch X11/Wayland C deps. Publishes `linux-arm64` directory + bare-binary tarballs and documents them in the release notes body.
- **`libs/cua-driver/scripts/_install-rust.sh`** — add a `Linux-aarch64|Linux-arm64` case mapping to label `linux-arm64` / target `aarch64-unknown-linux-gnu`, and list it in the unsupported-platform error message.

## Notes

- The Linux backend remains **BETA** regardless of arch (input synthesis is portal-gated, recording isn't implemented) — this change only adds the missing arm64 artifact + install path, it doesn't change backend maturity.
- `flake.nix` Nix checks still target `x86_64-linux` only; building from source on Linux ARM via Nix remains untested and is left out of scope here.

## Test plan

- [x] Workflow YAML validated (`yaml.safe_load`)
- [ ] CD dry-run via `workflow_dispatch` to confirm the `ubuntu-24.04-arm` runner builds and uploads the `linux-arm64` artifacts
- [ ] `_install-rust.sh` exercised on a Linux aarch64 host once the tarballs are published

Slack thread: https://trycua.slack.com/archives/C0B6UULU24X/p1781802580972109?thread_ts=1781801432.218699&cid=C0B6UULU24X

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016KPzszrGkqwt7UTAYFnP4z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ARM64 (Linux arm64) architecture builds. Pre-release artifacts for ARM64 are now available for download.

* **Chores**
  * Refactored CI/CD build pipeline to support multi-architecture matrix builds with dedicated runners and architecture-specific build parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->