### PR TITLE
docs(cua-driver)(linux): present Linux as GA in skill + docs, fix skill-install paths

### DIFF
--- a/docs/content/docs/cua-driver/guide/getting-started/comparison.mdx
+++ b/docs/content/docs/cua-driver/guide/getting-started/comparison.mdx
@@ -5,7 +5,7 @@ description: How Cua Driver compares to other computer-use tools
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-This page compares Cua Driver with other computer-use tools. The best choice depends on your workload. Several of the alternatives below are macOS-specific; Cua Driver runs on macOS and Windows, with Linux available as a pre-release backend.
+This page compares Cua Driver with other computer-use tools. The best choice depends on your workload. Several of the alternatives below are macOS-specific; Cua Driver runs on macOS, Windows, and Linux.
 
 ## Quick comparison
 

--- a/docs/content/docs/cua-driver/guide/getting-started/installation.mdx
+++ b/docs/content/docs/cua-driver/guide/getting-started/installation.mdx
@@ -1,19 +1,19 @@
 ---
 title: Installation
-description: Install Cua Driver on macOS, Windows, or the Linux pre-release backend
+description: Install Cua Driver on macOS, Windows, or the Linux backend
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-Install Cua Driver with the command for your platform. macOS and Windows are the official install targets; Linux is available as a pre-release backend while platform testing is still in progress.
+Install Cua Driver with the command for your platform. macOS, Windows, and Linux are all supported install targets. (On Linux, native Wayland input and capture are opt-in and still maturing — see the [Linux guide](/cua-driver/guide/getting-started/linux).)
 
 | Platform          | Command                                                                                                             |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------- |
 | macOS             | `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)"` |
-| Linux pre-release | `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)"` |
+| Linux | `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)"` |
 | Windows           | `irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.ps1 \| iex`                  |
 
-**macOS / Linux pre-release**
+**macOS / Linux**
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)"
@@ -27,7 +27,7 @@ irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/in
 
 On macOS, the installer drops `CuaDriver.app` into `/Applications` and symlinks the binary at `~/.local/bin/cua-driver`. The bundle is signed under `com.trycua.driver`, so TCC grants survive every release.
 
-On Linux, the pre-release backend installer downloads the release into `~/.cua-driver/packages/releases/`, retargets `~/.cua-driver/packages/current`, and symlinks `~/.local/bin/cua-driver`.
+On Linux, the Linux backend installer downloads the release into `~/.cua-driver/packages/releases/`, retargets `~/.cua-driver/packages/current`, and symlinks `~/.local/bin/cua-driver`.
 
 <Callout type="info">
   **Install home is `~/.cua-driver` on every platform.** Earlier `cua-driver-rs` releases (before
@@ -39,11 +39,12 @@ On Linux, the pre-release backend installer downloads the release into `~/.cua-d
   override is still honored for back-compat.
 </Callout>
 
-<Callout type="warn">
-  **Linux is pre-release.** Linux artifacts and install paths are published for early testing, but
-  Linux has not completed the same official release and platform validation pass as macOS and
-  Windows. Expect gaps, report issues, and avoid treating Linux as a supported production target
-  until it is promoted out of pre-release.
+<Callout type="info">
+  **Linux:** the backend targets X11 and runs the full tool surface — input, screenshots, and
+  recording — in the background. Native **Wayland** input and capture are opt-in
+  (`CUA_DRIVER_RS_ENABLE_WAYLAND=1`) and still maturing; on Wayland sessions the default path is
+  XWayland. Run `cua-driver doctor` for distro prerequisites (AT-SPI bus, ffmpeg). See the
+  [Linux guide](/cua-driver/guide/getting-started/linux).
 </Callout>
 
 On Windows, the installer downloads the release into `%USERPROFILE%\.cua-driver\packages\releases\`, retargets the `current` junction, and exposes `cua-driver.exe` through `%LOCALAPPDATA%\Programs\Cua\cua-driver\bin`.
@@ -67,7 +68,7 @@ The install runs **without sudo/admin**. On macOS and Linux the CLI symlink live
   changed.
 </Callout>
 
-Both canonical installers live under `libs/cua-driver/scripts/`. The shell installer covers macOS and the Linux pre-release backend; `install.ps1` covers Windows.
+Both canonical installers live under `libs/cua-driver/scripts/`. The shell installer covers macOS and the Linux backend; `install.ps1` covers Windows.
 
 The Windows installer auto-detects host architecture (x64 / arm64) via `[System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture` and downloads the matching `cua-driver-rs-<v>-windows-{x86_64,arm64}.zip` from GitHub Releases.
 
@@ -462,7 +463,7 @@ release for them to recommend.
 | Platform          | Requirements                                                                                               |
 | ----------------- | ---------------------------------------------------------------------------------------------------------- |
 | macOS             | macOS 14 (Sonoma) or later; Apple Silicon or Intel; Accessibility and Screen Recording grants.             |
-| Linux pre-release | x86_64 Linux desktop session; X11 or XWayland; AT-SPI for accessibility-tree tools.                        |
+| Linux | x86_64 Linux desktop session; X11 or XWayland; AT-SPI for accessibility-tree tools.                        |
 | Windows           | Windows 10/11 or Server with an interactive desktop session; PowerShell; UI Automation enabled by default. |
 
 Plan for roughly 50 MB for the app bundle or package directory, plus any retained old versions on Linux / Windows.
@@ -477,7 +478,7 @@ Most workflows benefit from a persistent daemon. Element-indexed workflows requi
 open -n -g -a CuaDriver --args serve
 ```
 
-**Linux pre-release**
+**Linux**
 
 ```bash
 cua-driver serve &

--- a/docs/content/docs/cua-driver/guide/getting-started/linux.mdx
+++ b/docs/content/docs/cua-driver/guide/getting-started/linux.mdx
@@ -1,17 +1,19 @@
 ---
-title: Linux pre-release
-description: Display server (X11 / Wayland), AT-SPI prerequisites, autostart, and headless workflows for the Linux pre-release backend.
+title: Linux
+description: Display server (X11 / Wayland), AT-SPI prerequisites, autostart, and headless workflows for the Linux backend.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-The Linux backend is available as a **pre-release** target. It has Linux implementations under [`crates/platform-linux/`](https://github.com/trycua/cua/tree/main/libs/cua-driver/rust/crates/platform-linux/src), but it has not completed the same official release and platform validation pass as macOS and Windows. Use it for early testing, expect gaps, and report issues before relying on it in production workflows.
+The Linux backend drives **X11** apps in the background — clicks and keystrokes are injected to the target window via AT-SPI and `XSendEvent`, without raising it, activating it, or moving the real pointer (the same no-foreground contract as macOS and Windows). It runs the full tool surface: click, type, scroll, screenshot, recording, `launch_app`, and window enumeration. The implementations live under [`crates/platform-linux/`](https://github.com/trycua/cua/tree/main/libs/cua-driver/rust/crates/platform-linux/src).
 
-For the install one-liner itself, see [Installation](/cua-driver/guide/getting-started/installation) — the canonical script auto-detects Linux and routes to the pre-release Rust backend.
+Native **Wayland** input and capture are opt-in (`CUA_DRIVER_RS_ENABLE_WAYLAND=1`) and still maturing; on Wayland sessions the default path is the XWayland compatibility server (see **Display server** below).
+
+For the install one-liner itself, see [Installation](/cua-driver/guide/getting-started/installation) — the canonical script auto-detects Linux and routes to the Rust backend.
 
 ## Display server: X11 vs Wayland vs XWayland
 
-Cua Driver's window enumeration, input synthesis, and screen capture talk to your display server directly. The Linux pre-release backend targets **X11** (including the XWayland compatibility server on Wayland sessions), and probes which one you're on at startup:
+Cua Driver's window enumeration, input synthesis, and screen capture talk to your display server directly. The Linux backend targets **X11** (including the XWayland compatibility server on Wayland sessions), and probes which one you're on at startup:
 
 ```bash
 cua-driver doctor
@@ -19,7 +21,7 @@ cua-driver doctor
 
 The `display server` probe surfaces:
 
-- **`DISPLAY` set, `WAYLAND_DISPLAY` unset** — pure X11 session. This is the expected path for the current pre-release backend.
+- **`DISPLAY` set, `WAYLAND_DISPLAY` unset** — pure X11 session. This is the expected path for the Linux backend.
 - **`WAYLAND_DISPLAY` set, `DISPLAY` set** — Wayland session with XWayland. cua-driver talks to XWayland (treats the session as X11). Native-Wayland-only apps that bypass XWayland aren't visible to the tools — call this out as a known limitation.
 - **`WAYLAND_DISPLAY` set, `DISPLAY` unset** — pure Wayland session, no XWayland. Unsupported by default. There is an **experimental native-Wayland backend** (toplevel enumeration + virtual-pointer / virtual-keyboard input on wlroots compositors like sway and labwc) behind an opt-in flag — see [Experimental native Wayland](#experimental-native-wayland). Otherwise, run an X11 session or install / enable XWayland.
 - **Neither set** — headless. Window-driving tools will return errors. See [Headless workflow](#headless-workflow) for `Xvfb`.
@@ -155,7 +157,7 @@ export DISPLAY=:99
 dbus-launch --exit-with-session cua-driver serve
 ```
 
-This is a useful recipe for local CI experiments with the Linux pre-release backend.
+This is a useful recipe for local CI experiments with the Linux backend.
 
 <Callout type="info">
   **Tools that don't need a display.** Even without `DISPLAY` set, the non-graphical tools
@@ -166,7 +168,7 @@ This is a useful recipe for local CI experiments with the Linux pre-release back
 
 ## Distro-specific notes
 
-The canonical install script (`/bin/bash -c "$(curl -fsSL …/install.sh)"`) downloads a Linux x86_64 binary tarball from GitHub Releases, drops it into `~/.cua-driver/packages/releases/<v>-x86_64-unknown-linux-gnu/`, and symlinks `~/.local/bin/cua-driver`. Because Linux support is pre-release, expect distro-specific gaps and prerequisites.
+The canonical install script (`/bin/bash -c "$(curl -fsSL …/install.sh)"`) downloads a Linux x86_64 binary tarball from GitHub Releases, drops it into `~/.cua-driver/packages/releases/<v>-x86_64-unknown-linux-gnu/`, and symlinks `~/.local/bin/cua-driver`. Linux desktops vary, so run `cua-driver doctor` after install to confirm the distro-specific prerequisites (display server, AT-SPI bus, ffmpeg).
 
 The bit that varies is **what accessibility / display tooling is pre-installed**:
 
@@ -175,15 +177,15 @@ The bit that varies is **what accessibility / display tooling is pre-installed**
 - **Arch / Manjaro** — minimal install; you'll likely need to explicitly install `at-spi2-core` and ensure `dbus-launch` runs as part of your session startup.
 - **Alpine / busybox-style** — slimmest of all; needs `dbus`, `dbus-x11`, `at-spi2-core` plus likely an explicit `dbus-launch --exit-with-session` wrapper.
 
-If `cua-driver doctor` is happy after install, you have a reasonable starting point for testing the pre-release backend.
+If `cua-driver doctor` is happy after install, you have a reasonable starting point for testing the Linux backend.
 
 ## Per-tool Linux implementation matrix
 
-See [`libs/cua-driver/rust/PARITY.md`](https://github.com/trycua/cua/blob/main/libs/cua-driver/rust/PARITY.md) for the per-tool Linux implementation matrix. Treat it as implementation tracking, not an official support certification; the backend remains pre-release until Linux testing and release coverage are complete.
+See [`libs/cua-driver/rust/PARITY.md`](https://github.com/trycua/cua/blob/main/libs/cua-driver/rust/PARITY.md) for the per-tool Linux implementation matrix. Treat it as the per-tool implementation matrix; native Wayland input and capture are the main area still maturing.
 
 ## See also
 
-- [Installation](/cua-driver/guide/getting-started/installation) — canonical one-liner that handles the Linux pre-release backend
+- [Installation](/cua-driver/guide/getting-started/installation) — canonical one-liner that handles the Linux backend
 - [Autostart](/cua-driver/guide/getting-started/autostart) — concept page (Windows-only verb family; Linux uses systemd)
 - [Process model](/cua-driver/guide/getting-started/process-model) — Linux has none of the macOS-TCC or Windows-Session-0 weirdness; this page explains what those problems are and why Linux sidesteps them
 - [`PARITY.md`](https://github.com/trycua/cua/blob/main/libs/cua-driver/rust/PARITY.md) — per-tool platform implementation matrix

--- a/libs/cua-driver/rust/Skills/cua-driver/LINUX.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/LINUX.md
@@ -1,87 +1,97 @@
 ---
 name: cua-driver-rs-linux
-description: Drive a native Linux app (X11 / Wayland) via the cua-driver CLI — snapshot the AT-SPI tree, click by element_index or pixel, verify via re-snapshot. Linux backend is BETA in cua-driver-rs and the no-foreground contract has open issues (see this doc).
+description: Drive a native Linux app via the cua-driver CLI — snapshot the AT-SPI tree, click by element_index or pixel, type, screenshot, record, verify via re-snapshot. Background by default (no foreground steal, no real-pointer move) on X11. Wayland input/capture is opt-in and still preview.
 ---
 
 # cua-driver-rs — Linux
 
-**Status: BETA.** The Linux backend in cua-driver-rs covers the core
-tool surface (click, type_text, scroll, hotkey, screenshot,
-launch_app, list_apps, list_windows, get_window_state) but several
-behaviors that the macOS / Windows skills consider table-stakes are
-**not yet implemented or only partially supported**:
+The Linux backend drives X11 apps **in the background**: clicks and
+keystrokes are injected to the target window without raising it,
+activating it, or moving the real pointer — the same no-foreground
+contract the macOS and Windows backends hold. The full tool surface is
+supported: `click`, `type_text`, scroll, `press_key`, `screenshot`,
+`launch_app`, `list_apps`, `list_windows`, `get_window_state`, and
+session recording.
 
-- **No-foreground contract**: limited. X11's input model has no clean
-  per-pid event routing equivalent of macOS `CGEventPostToPSN` or
-  Windows `PostMessage(WM_LBUTTONDOWN)`. `XTestFakeKeyEvent` /
-  `XTestFakeButtonEvent` synthesize input but route to the focused
-  window — similar focus-stealing behavior to Windows `SendInput`,
-  which the Windows backend avoids by using `PostMessage` instead.
-  Linux has no equivalent per-window-message channel that bypasses
-  focus, which is why XTest's focus-stealing is the binding
-  limitation here. AT-SPI `accDoDefaultAction` works for accessible
-  elements but requires the user's accessibility bus to be running,
-  which is not the default on every distro.
-- **Wayland support**: depends on compositor. Under GNOME-Mutter and
-  KDE-KWin with `org.freedesktop.portal.RemoteDesktop` enabled, some
-  click and key paths work. Under most other compositors, input
-  synthesis is denied by the security model and the tool surface
-  degrades to "passive" (snapshot, screenshot) only.
-- **UIA / AX-tree equivalent**: AT-SPI when available, otherwise
-  empty. Many GTK4 / Qt6 apps populate AT-SPI lazily; agents should
-  expect partial trees and re-snapshot.
-- **launch_app**: backed by `xdg-open` / `gtk-launch` / `dbus-send`
-  with display-environment scrubbing to avoid stealing the user's
-  workspace. Not yet equivalent to macOS `FocusRestoreGuard`.
-- **Recording**: not supported.
+AT-SPI is talked to natively over D-Bus (the `atspi`/zbus crate) — no
+`pyatspi` or GObject-introspection typelibs are required at runtime.
 
-See `SKILL.md` (macOS) and `WINDOWS.md` (Windows) for the full
-patterns. This file will grow as the Linux backend reaches GA. For
-now, **prefer macOS / Windows hosts** for agent-driven GUI tasks; use
-the Linux daemon for read-only inspection (screenshot,
-list_windows, get_window_state) when running on a Linux host.
+## How input is delivered (the no-foreground contract)
+
+- **Pixel click** — `XSendEvent(ButtonPress/Release)` to the resolved
+  target window. No raise, no activate, no real-pointer warp. (It does
+  **not** use `XTestFakeButtonEvent`, which would route through the
+  focused window.)
+- **Element click** (`element_index`) — AT-SPI `do_action` on the
+  accessible. Toolkit-native, focus-free.
+- **type_text** — AT-SPI EditableText first (focus-free; lands in an
+  *unfocused* window's editable for Qt6 / GTK4). When a **non-editable**
+  widget holds focus — a spreadsheet cell, a terminal, a canvas — it
+  synth-types into the focused widget via XTest, and terminals take a
+  focus-free pty-injection path. So background typing into an editable
+  needs no focus; the XTest path is the foreground "type where I
+  clicked" case.
+- The **agent cursor** is a synthetic overlay showing where the run is
+  acting; it never moves the real pointer (same model as macOS/Windows).
+  It glides on clicks and `move_cursor`; issue `move_cursor` to make it
+  track a field while typing advances focus across cells.
+
+## Wayland (opt-in — still preview)
+
+Native Wayland support is behind an opt-in flag and not yet at the same
+maturity as X11:
+
+- `CUA_DRIVER_RS_ENABLE_WAYLAND=1` enables the native-Wayland backend.
+  On wlroots compositors (labwc/sway) it uses foreign-toplevel +
+  screencopy; on GNOME-Mutter / KDE-KWin, which expose no client
+  protocols for cross-window enumeration, cua-driver brings its own
+  nested compositor (`CUA_WAYLAND_NEST=1`).
+- Without the flag, on a Wayland session the driver falls back to
+  XWayland where available.
+- Screenshots work via `grim` / wlr-screencopy. **Video recording is
+  not yet available on Wayland** — the recorder is `x11grab`, which is
+  X11-only.
 
 ## Quick triage
 
-If you're agent-driving on Linux and a tool call surprises you:
+If a tool call surprises you on Linux:
 
-1. Run `cua-driver doctor` — reports display server (X11 / Wayland),
-   AT-SPI bus reachability, XTest availability.
-2. Check `XDG_SESSION_TYPE` — `wayland` means most input synthesis
-   is gated by portals; `x11` means XTest works but routes via focus.
-3. If Wayland: confirm `org.freedesktop.portal.RemoteDesktop` is
-   present (`gdbus introspect --session --dest
-   org.freedesktop.portal.Desktop --object-path
-   /org/freedesktop/portal/desktop`). Without it, input synthesis
-   is denied.
+1. `cua-driver doctor` — reports the display server (X11 / Wayland),
+   AT-SPI bus reachability, and `ffmpeg` availability (for recording).
+2. Check `XDG_SESSION_TYPE` — `x11` is fully supported; `wayland`
+   needs `CUA_DRIVER_RS_ENABLE_WAYLAND=1` for native input (preview),
+   else XWayland.
+3. Empty / partial AT-SPI tree — make sure the a11y bus is enabled
+   (`gsettings set org.gnome.desktop.interface toolkit-accessibility
+   true`). GTK4 / Qt6 also populate lazily, so re-snapshot after an
+   interaction.
 
 ## Forbidden vectors
 
 Same idea as macOS / Windows — don't shell out to anything that
 foregrounds a target:
 
-- `wmctrl -a <window>` — activates the named window.
+- `wmctrl -a <window>` / `wmctrl -R <window>` — activates / raises.
 - `xdotool windowactivate <wid>` — activates.
-- `wmctrl -R <window>` — raises and activates.
-- `xdotool key --window <wid> alt+Tab` — same problem as Windows
-  Alt+Tab.
+- `xdotool key --window <wid> alt+Tab` — focus churn.
 
-Prefer cua-driver tools with explicit `window_id`. When in doubt,
+Prefer cua-driver tools with an explicit `window_id`. When in doubt,
 ask the user.
 
-## What to expect today
+## What to expect
 
 | Intent | Status |
 |---|---|
-| Snapshot UIA tree | ✅ AT-SPI when available, often partial for GTK4/Qt6 |
-| Pixel click | ⚠️ X11 only, focus-stealing semantics |
-| Element-indexed click | ⚠️ AT-SPI `accDoDefaultAction` when supported |
-| Type text | ⚠️ XTest, focus-sensitive |
-| Hotkey | ⚠️ XTest, focus-sensitive |
-| Screenshot full-display | ✅ X11 (xshm); ⚠️ Wayland (portal-gated) |
-| Screenshot per-window | ⚠️ X11 with composite extension; Wayland TBD |
-| launch_app | ⚠️ xdg-open / gtk-launch; no FocusRestoreGuard yet |
-| Recording | ❌ not implemented |
+| Snapshot AT-SPI tree | ✅ GTK3/4, Qt5/6, wxWidgets, Electron (GTK4/Qt6 can be partial — re-snapshot) |
+| Pixel click | ✅ background `XSendEvent`, no focus steal, no pointer move |
+| Element-indexed click | ✅ AT-SPI `do_action` |
+| Type text | ✅ AT-SPI focus-free, with XTest / pty fallback for the focused widget |
+| Hotkey / `press_key` | ✅ |
+| Screenshot full-display | ✅ X11; ✅ Wayland via `grim` |
+| Screenshot per-window | ✅ X11 |
+| `launch_app` | ✅ env-scrubbed launch (no workspace steal) |
+| Recording (video) | ✅ X11 (`x11grab`); ⚠️ Wayland not yet supported (preview) |
 
-Until Linux reaches GA, treat this doc as a planning placeholder
-rather than a contract.
+See `SKILL.md` for the cross-platform loop (snapshot-before-AND-after,
+pixel-click contract, failure modes) and `RECORDING.md` for session
+recording.

--- a/libs/cua-driver/rust/Skills/cua-driver/README.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/README.md
@@ -16,8 +16,9 @@ platform: no focus steal, no cursor warp.
   ApplicationFrameHost, layered UIA+PostMessage click chain,
   Session 0 isolation, Windows web-apps section). Read this when
   driving on Windows.
-- `LINUX.md` — Linux status + carve-out (X11/Wayland, AT-SPI,
-  BETA-level). Read this when driving on Linux.
+- `LINUX.md` — Linux carve-out (X11 background input via AT-SPI +
+  XSendEvent, recording, Wayland opt-in/preview). Read this when
+  driving on Linux.
 
 ## What the skill covers
 
@@ -29,14 +30,16 @@ platform: no focus steal, no cursor warp.
   - **macOS**: yabai focus-without-raise + stamped `SLEventPostToPid`.
   - **Windows**: layered UIA `Invoke` + `PostMessage` fallback, both
     z-order-independent and focus-steal-free.
-  - **Linux** (BETA): AT-SPI `accDoDefaultAction` when available;
-    XTest as a focus-stealing last resort.
+  - **Linux**: AT-SPI `do_action` for element clicks +
+    `XSendEvent(ButtonPress)` to the window for pixel clicks — both
+    background, no raise, no real-pointer move.
 - Web-app quirks — macOS specifics in `WEB_APPS.md` (Chromium / WebKit
   / Electron / Tauri, minimized-Chrome keyboard-commit caveat,
   `set_value` workaround). Windows web-apps coverage lives in
   `WINDOWS.md`'s "Web apps on Windows" section.
 - Trajectory recording (`RECORDING.md`) — optional per-session
-  recording + replay for demos and regressions. macOS-only today.
+  recording + replay for demos and regressions. macOS and Linux
+  (X11) today; Wayland video capture not yet supported.
 - Canvas/viewport apps (Blender, Unity, GHOST, Qt, wxWidgets) —
   fallback paths when the AX/UIA/AT-SPI tree is empty.
 
@@ -86,8 +89,9 @@ forbidden-list / launch / click details.
 
 ### Linux
 
-**Status: BETA.** Limited feature parity — see `LINUX.md` for what
-works today. Install:
+The full tool surface is supported on X11 (background input via AT-SPI
++ XSendEvent, screenshots, recording); native Wayland input/capture is
+opt-in and still preview. See `LINUX.md`. Install:
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)"
@@ -104,20 +108,20 @@ The skill is a drop-in directory. Same shape on every platform.
 
 ```bash
 mkdir -p ~/.claude/skills
-cp -R libs/cua-driver/rust/Skills/cua-driver-rs ~/.claude/skills/
+cp -R libs/cua-driver/rust/Skills/cua-driver ~/.claude/skills/
 ```
 
 Or symlink if you want edits-in-place:
 
 ```bash
-ln -s "$PWD/libs/cua-driver/rust/Skills/cua-driver-rs" ~/.claude/skills/cua-driver-rs
+ln -s "$PWD/libs/cua-driver/rust/Skills/cua-driver" ~/.claude/skills/cua-driver
 ```
 
 **Project scope** (committed alongside a specific repo):
 
 ```bash
 mkdir -p .claude/skills
-cp -R /path/to/cua/libs/cua-driver/rust/Skills/cua-driver-rs .claude/skills/
+cp -R /path/to/cua/libs/cua-driver/rust/Skills/cua-driver .claude/skills/
 ```
 
 Or run the verb that does this automatically + fetches the matching
@@ -163,14 +167,14 @@ Use MCP for this Claude Code vision/computer-use-style path. CLI screenshots sti
 - `WINDOWS.md` — Windows-specific carve-out (UIA, UWP, layered
   click chain, Session 0, Windows web-apps). Loaded when driving
   on Windows.
-- `LINUX.md` — Linux-specific carve-out, BETA. Loaded when driving
-  on Linux.
+- `LINUX.md` — Linux-specific carve-out (X11 background input,
+  recording, Wayland opt-in/preview). Loaded when driving on Linux.
 - `WEB_APPS.md` — browser patterns on macOS (Chromium + WebKit,
   Electron, Tauri, minimized-Chrome keyboard-commit caveat).
   Loaded on demand from `SKILL.md`. **Note**: Windows web-apps
   coverage lives in `WINDOWS.md`'s "Web apps on Windows" section.
-- `RECORDING.md` — trajectory recording / replay (macOS-only
-  today; Windows / Linux not yet supported).
+- `RECORDING.md` — trajectory recording / replay (macOS and Linux
+  X11 today; Wayland video capture not yet supported).
 - `TESTS.md` — manual test scripts for end-to-end skill verification.
 
 ## Troubleshooting
@@ -202,7 +206,7 @@ cua-driver skills update
 # Or, from a clone of trycua/cua:
 cd /path/to/cua && git pull
 # if you copied: re-copy
-cp -R libs/cua-driver/rust/Skills/cua-driver-rs ~/.claude/skills/
+cp -R libs/cua-driver/rust/Skills/cua-driver ~/.claude/skills/
 # if you symlinked: nothing needed
 ```
 

--- a/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
@@ -25,8 +25,8 @@ directory:
 - **Windows** — read `WINDOWS.md` (UIA tree vs AX, UWP /
   ApplicationFrameHost hosting, layered UIA+PostMessage click chain,
   Session 0 isolation, Windows-specific focus-steal vectors).
-- **Linux** — read `LINUX.md` (X11/Wayland status, AT-SPI,
-  BETA-level support).
+- **Linux** — read `LINUX.md` (X11 background input via AT-SPI +
+  XSendEvent, recording, Wayland opt-in/preview).
 
 Cross-cutting topics also have their own files:
 

--- a/libs/cua-driver/rust/Skills/cua-driver/WEB_APPS.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/WEB_APPS.md
@@ -4,7 +4,8 @@
 > JavaScript bridges, and Chromium / WebKit / Electron / Tauri patterns
 > on macOS. For Windows web-app automation (Edge, Chrome with
 > PostMessage / WebView2), see `WINDOWS.md` → "Web apps on Windows". For
-> Linux: `LINUX.md` (BETA — limited browser automation today).
+> Linux: `LINUX.md` (the cross-platform `page` tool below uses AT-SPI
+> + CDP the same way).
 >
 > The `page` tool itself is **cross-platform** — Windows + Linux back
 > `get_text` / `query_dom` with UIA / AT-SPI respectively, and


### PR DESCRIPTION
## What

The Linux skill carve-out and the public Linux docs predated the Linux launch (blog #1937) and still framed the backend as **BETA / "pre-release"** — with a "prefer macOS/Windows", "Recording: not supported", "XTest focus-stealing last resort" story that's no longer true. This presents Linux as a supported platform alongside macOS/Windows, keeps **Wayland** as the one opt-in/preview caveat, and fixes the broken skill-install commands.

## Skill docs (`Skills/cua-driver/`)

- **LINUX.md** — rewritten to match reality:
  - Background input: `XSendEvent(ButtonPress)` for pixel clicks, AT-SPI `do_action` for element clicks, AT-SPI/XTest/pty for typing — no foreground steal, no real-pointer move.
  - Recording supported on X11; full tool surface (click/type/screenshot/record/launch/enumerate).
  - Wayland input + video capture kept as opt-in/preview (`CUA_DRIVER_RS_ENABLE_WAYLAND=1`).
- **README.md / SKILL.md / WEB_APPS.md** — drop the Linux BETA framing; recording is macOS + Linux (X11).
- **Skill-install fix** — the pack was renamed `cua-driver-rs` → `cua-driver` (`skills.rs` `SKILL_PACK_NAME`), but the manual `cp`/`ln -s` examples still pointed at the non-existent `Skills/cua-driver-rs` dir, so they'd fail. Repointed at `Skills/cua-driver`; verified `cp -R` and the symlink form work. (`cua-driver skills install` was already correct.)

## Public docs (`getting-started/`)

- **comparison.mdx / installation.mdx / linux.mdx** — drop "pre-release" framing; Linux is a supported install target. Wayland stays opt-in/preview. The `installation.mdx` warn-callout became an info note about the X11/Wayland split. (Left the unrelated semver "pre-release suffix" reference.)

## Not changed

- `pip-preview.mdx` — that's a genuinely experimental *feature* (macOS-only), unrelated to Linux backend maturity.
- The `cua-driver-v*` macOS Swift `install.sh` — already delegates to the Rust installer on non-Darwin (it does auto-detect Linux; the macOS-only check is only reached for the Swift path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Linux platform support status from pre-release to fully supported across installation and getting-started guides
  * Clarified Linux backend behavior with X11 as the default, Wayland support available as opt-in, and explicit feature expectations
  * Enhanced skill documentation with detailed feature matrices, setup prerequisites, and comprehensive troubleshooting guidance for all Linux users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->