### PR TITLE
fix(cua-agent): bump litellm to patch CVE-2026-35030 and others

### DIFF
--- a/libs/cua-bench/uv.lock
+++ b/libs/cua-bench/uv.lock
@@ -552,7 +552,7 @@ requires-dist = [
     { name = "gradio", marker = "extra == 'ui'", specifier = ">=6.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "hud-python", marker = "extra == 'hud'", specifier = "==0.4.52" },
-    { name = "litellm", specifier = "==1.80.0" },
+    { name = "litellm", specifier = "==1.86.2" },
     { name = "mlx-vlm", marker = "sys_platform == 'darwin' and extra == 'all'", specifier = ">=0.1.27" },
     { name = "mlx-vlm", marker = "sys_platform == 'darwin' and extra == 'uitars-mlx'", specifier = ">=0.1.27" },
     { name = "pillow", specifier = ">=10.0.0" },
@@ -1738,7 +1738,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.80.0"
+version = "1.86.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1754,9 +1754,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/8c/48d533affdbc6d485b7ad4221cd3b40b8c12f9f5568edfe0be0b11e7b945/litellm-1.80.0.tar.gz", hash = "sha256:eeac733eb6b226f9e5fb020f72fe13a32b3354b001dc62bcf1bc4d9b526d6231", size = 11591976, upload-time = "2025-11-16T00:03:51.812Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/1f6f3f5d01e0910629b6af3757e82c47b8b87dca497a661a9c63280b4bd8/litellm-1.86.2.tar.gz", hash = "sha256:7d559ad48b97d796ff325af88fd7eebbdc66e58773fb5312130ab1cac968f8f3", size = 15380548, upload-time = "2026-05-27T16:19:58.45Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/53/aa31e4d057b3746b3c323ca993003d6cf15ef987e7fe7ceb53681695ae87/litellm-1.80.0-py3-none-any.whl", hash = "sha256:fd0009758f4772257048d74bf79bb64318859adb4ea49a8b66fdbc718cd80b6e", size = 10492975, upload-time = "2025-11-16T00:03:49.182Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/37/4da1dd67157aaa11477d6c63e4725216bfc46b4661e581b490d17e5b2831/litellm-1.86.2-py3-none-any.whl", hash = "sha256:27096463be7add661513ada3d9039e8f1a6195859e604d30fde96c939efe0a03", size = 17013061, upload-time = "2026-05-27T16:19:53.219Z" },
 ]
 
 [[package]]
@@ -2282,7 +2282,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.13.0"
+version = "2.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2294,9 +2294,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/39/8e347e9fda125324d253084bb1b82407e5e3c7777a03dc398f79b2d95626/openai-2.13.0.tar.gz", hash = "sha256:9ff633b07a19469ec476b1e2b5b26c5ef700886524a7a72f65e6f0b5203142d5", size = 626583, upload-time = "2025-12-16T18:19:44.387Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/fa/88d0c58a0c58df7e6758e66b99c5d028d5e0bb49f8812d7203940cd9dbf1/openai-2.43.0.tar.gz", hash = "sha256:e74d238200a26868977002190fb6631613480a93dfe0c9c982e77021ed60a017", size = 785369, upload-time = "2026-06-17T17:06:56.06Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/d5/eb52edff49d3d5ea116e225538c118699ddeb7c29fa17ec28af14bc10033/openai-2.13.0-py3-none-any.whl", hash = "sha256:746521065fed68df2f9c2d85613bb50844343ea81f60009b60e6a600c9352c79", size = 1066837, upload-time = "2025-12-16T18:19:43.124Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/d2/ba767f4bbb30776c03d40906a2d3afad716a165ffa1771fc23b8992f7920/openai-2.43.0-py3-none-any.whl", hash = "sha256:65a670b54fadf2268c9e1330133373c963eb779ee969e5cbad419ec2c21dce97", size = 1355077, upload-time = "2026-06-17T17:06:53.614Z" },
 ]
 
 [[package]]

--- a/libs/python/agent/pyproject.toml
+++ b/libs/python/agent/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "python-dotenv>=1.0.1",
     "cua-core>=0.3.0,<0.4.0",
     "certifi>=2024.2.2",
-    "litellm==1.80.0",
+    "litellm==1.86.2",
     "Pillow>=10.0.0"
 ]
 requires-python = ">=3.11,<3.14"

--- a/libs/python/cua-sandbox/uv.lock
+++ b/libs/python/cua-sandbox/uv.lock
@@ -407,7 +407,7 @@ wheels = [
 
 [[package]]
 name = "cua-agent"
-version = "0.7.39"
+version = "0.8.2"
 source = { editable = "../agent" }
 dependencies = [
     { name = "aiohttp" },
@@ -450,7 +450,7 @@ requires-dist = [
     { name = "gradio", marker = "extra == 'ui'", specifier = ">=6.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "hud-python", marker = "extra == 'hud'", specifier = "==0.4.52" },
-    { name = "litellm", specifier = "==1.80.0" },
+    { name = "litellm", specifier = "==1.86.2" },
     { name = "mlx-vlm", marker = "sys_platform == 'darwin' and extra == 'all'", specifier = ">=0.1.27" },
     { name = "mlx-vlm", marker = "sys_platform == 'darwin' and extra == 'uitars-mlx'", specifier = ">=0.1.27" },
     { name = "pillow", specifier = ">=10.0.0" },
@@ -508,7 +508,7 @@ wheels = [
 
 [[package]]
 name = "cua-core"
-version = "0.1.19"
+version = "0.3.1"
 source = { editable = "../core" }
 dependencies = [
     { name = "posthog" },
@@ -531,7 +531,7 @@ dev = [{ name = "pytest", specifier = ">=8.3.5" }]
 
 [[package]]
 name = "cua-sandbox"
-version = "0.1.3"
+version = "0.1.16"
 source = { editable = "." }
 dependencies = [
     { name = "cua-auto" },
@@ -566,7 +566,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cua-auto", specifier = ">=0.1.2" },
-    { name = "cua-core", specifier = ">=0.1.18,<0.2.0" },
+    { name = "cua-core", specifier = ">=0.3.0,<0.4.0" },
     { name = "grpcio", specifier = "==1.78.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "oras", specifier = ">=0.2.40" },
@@ -893,14 +893,14 @@ wheels = [
 
 [[package]]
 name = "importlib-metadata"
-version = "9.0.0"
+version = "8.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "zipp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/72/c600ae4f68c28fc19f9c31b9403053e5dbb8cace2e6842c7b7c3e4d42fe9/importlib_metadata-8.9.0.tar.gz", hash = "sha256:58850626cef4bd2df100378b0f2aea9724a7b92f10770d547725b047078f99ee", size = 56140, upload-time = "2026-03-20T16:56:26.362Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f9/97f2ca8bb3ec6e4b1d64f983ebe98b9a192faddff67fac3d6303a537e670/importlib_metadata-8.9.0-py3-none-any.whl", hash = "sha256:e0f761b6ea91ced3b0844c14c9d955224d538105921f8e6754c00f6ca79fba7f", size = 27220, upload-time = "2026-03-20T16:56:25.07Z" },
 ]
 
 [[package]]
@@ -1034,7 +1034,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.80.0"
+version = "1.86.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1050,9 +1050,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/8c/48d533affdbc6d485b7ad4221cd3b40b8c12f9f5568edfe0be0b11e7b945/litellm-1.80.0.tar.gz", hash = "sha256:eeac733eb6b226f9e5fb020f72fe13a32b3354b001dc62bcf1bc4d9b526d6231", size = 11591976, upload-time = "2025-11-16T00:03:51.812Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/1f6f3f5d01e0910629b6af3757e82c47b8b87dca497a661a9c63280b4bd8/litellm-1.86.2.tar.gz", hash = "sha256:7d559ad48b97d796ff325af88fd7eebbdc66e58773fb5312130ab1cac968f8f3", size = 15380548, upload-time = "2026-05-27T16:19:58.45Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/53/aa31e4d057b3746b3c323ca993003d6cf15ef987e7fe7ceb53681695ae87/litellm-1.80.0-py3-none-any.whl", hash = "sha256:fd0009758f4772257048d74bf79bb64318859adb4ea49a8b66fdbc718cd80b6e", size = 10492975, upload-time = "2025-11-16T00:03:49.182Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/37/4da1dd67157aaa11477d6c63e4725216bfc46b4661e581b490d17e5b2831/litellm-1.86.2-py3-none-any.whl", hash = "sha256:27096463be7add661513ada3d9039e8f1a6195859e604d30fde96c939efe0a03", size = 17013061, upload-time = "2026-05-27T16:19:53.219Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`cua-agent` pinned `litellm==1.80.0`, which is affected by **CVE-2026-35030, CVE-2026-49468, CVE-2026-35029, CVE-2026-42271, and GHSA-69x8-hrgq-fjj8** (fixed upstream in litellm >= 1.83.0 / >= 1.84.0). This bumps the pin to **`litellm==1.86.2`**.

## Version chosen & why

`1.86.2` — deliberately aligned with **cua-cli**, which already pins `litellm==1.86.2`. The umbrella `cua` package installs both `cua-agent` and `cua-cli`, so the old `1.80.0` vs `1.86.2` split was a latent **unsatisfiable resolver constraint**. Aligning on 1.86.2 fixes the CVEs and removes that conflict in one move. `1.86.2` is well above the >= 1.84.0 fix floor.

## Compatibility check (1.80.0 → 1.86.2)

Audited every litellm symbol cua-agent imports against the litellm `v1.86.2` source. **All 14 import paths are present — nothing removed or renamed:**

| Symbol | Present |
|---|---|
| `litellm.acompletion`, `litellm.completion` | yes |
| `litellm.custom_provider_map`, `litellm.suppress_debug_info` | yes |
| `litellm.exceptions` (module) | yes |
| `litellm.utils.function_to_dict` | yes |
| `litellm.ResponseInputParam`, `litellm.ResponsesAPIResponse`, `litellm.ToolParam` | yes (via `responses.main` wildcard re-export) |
| `litellm.responses.utils.Usage` | yes |
| `litellm.responses.litellm_completion_transformation.transformation.LiteLLMCompletionResponsesConfig` | yes |
| `litellm.llms.custom_llm.CustomLLM` | yes |
| `litellm.types.utils.{GenericStreamingChunk, ModelResponse, Choices, Message}` | yes |

## Files changed

- `libs/python/agent/pyproject.toml` — pin `litellm==1.80.0` → `==1.86.2` (source of truth)
- `libs/python/cua-sandbox/uv.lock` — regenerated (`uv lock --upgrade-package litellm`)
- `libs/cua-bench/uv.lock` — regenerated (`uv lock --upgrade-package litellm`)

`cua-cli` already pins 1.86.2 (no change). `cua-sandbox`, `cua-bench`, and `mcp-server` do not pin litellm directly — they inherit it transitively via `cua-agent`.

## Notes / needs a human decision

- **`libs/python/mcp-server/pdm.lock` left unchanged.** It is severely stale (still lists `cua-agent 0.4.12` resolving `litellm 1.77.7`, predating the entire `1.80.0` pin). `pdm` is not available in this environment, and regenerating it would require a network resolve and produce a large unrelated diff (cua-agent 0.4.12 → 0.8.2 + transitive churn), contradicting "keep the change minimal." It should be regenerated separately with `pdm lock`. Flagging so a maintainer can decide.
- The regenerated uv.locks also reflect pre-existing drift corrections (`cua-core`, `cua-sandbox`, `importlib-metadata`) that uv recomputes from the editable local path deps on any `uv lock` — these are unavoidable when touching the lock at all, not introduced by the litellm change.
- **Import not runtime-verified:** no matching venv exists and the 1.86.2 wheel is not in the local uv cache; a real `import litellm` check would require a heavy network install. Compatibility was verified at source level (table above) instead.

Closes #1951

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to latest compatible versions for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->