### PR TITLE
feat: make docs star counter dynamic via GitHub API

### DIFF
--- a/docs/.env.example
+++ b/docs/.env.example
@@ -6,4 +6,8 @@ AWS_SECRET_ACCESS_KEY=
 SLACK_WEBHOOK_URL=
 POSTHOG_PERSONAL_API_KEY=
 POSTHOG_PROJECT_ID=
-CRON_SECRET= 
+CRON_SECRET=
+# Optional: GitHub personal access token (read-only, public_repo scope).
+# Raises the GitHub API rate limit from 60 req/hr to 5 000 req/hr.
+# Used by the landing page to fetch the live star count.
+GITHUB_TOKEN=

--- a/docs/src/app/(landing)/page.tsx
+++ b/docs/src/app/(landing)/page.tsx
@@ -13,22 +13,37 @@ export const revalidate = 3600;
 
 /** Fetch the current GitHub star count for trycua/cua.
  *  Falls back to the last known value if the request fails.
+ *
+ *  Set GITHUB_TOKEN in your environment to raise the API rate limit
+ *  from 60 req/hr (unauthenticated) to 5 000 req/hr (authenticated).
  */
 async function getGitHubStars(): Promise<string> {
   const FALLBACK = '13.1k';
   try {
+    const headers: Record<string, string> = {
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    };
+    if (process.env.GITHUB_TOKEN) {
+      headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
+    }
     const res = await fetch('https://api.github.com/repos/trycua/cua', {
-      headers: { Accept: 'application/vnd.github+json' },
+      headers,
       next: { revalidate: 3600 },
     });
     if (!res.ok) return FALLBACK;
     const data = (await res.json()) as { stargazers_count?: number };
     const count = data.stargazers_count;
     if (typeof count !== 'number') return FALLBACK;
-    // Format: <1000 → plain number, else Xk or X.Xk
-    if (count < 1000) return String(count);
-    const k = count / 1000;
-    return k % 1 === 0 ? `${k}k` : `${k.toFixed(1)}k`;
+    // Format: <1 000 → plain, <1 000 000 → Xk / X.Xk, else X.XM
+    if (count < 1_000) return String(count);
+    if (count < 1_000_000) {
+      const k = count / 1_000;
+      // Use toFixed(1) then strip a trailing ".0" so 14 000 → "14k" not "14.0k"
+      return `${parseFloat(k.toFixed(1))}k`;
+    }
+    const m = count / 1_000_000;
+    return `${parseFloat(m.toFixed(1))}M`;
   } catch {
     return FALLBACK;
   }

--- a/docs/src/app/(landing)/page.tsx
+++ b/docs/src/app/(landing)/page.tsx
@@ -8,6 +8,32 @@ export const metadata: Metadata = {
     'Give every agent a cloud desktop. Built for Claude Code, Codex, OpenClaw, and computer-use agents.',
 };
 
+// Revalidate the page every hour so the star count stays fresh
+export const revalidate = 3600;
+
+/** Fetch the current GitHub star count for trycua/cua.
+ *  Falls back to the last known value if the request fails.
+ */
+async function getGitHubStars(): Promise<string> {
+  const FALLBACK = '13.1k';
+  try {
+    const res = await fetch('https://api.github.com/repos/trycua/cua', {
+      headers: { Accept: 'application/vnd.github+json' },
+      next: { revalidate: 3600 },
+    });
+    if (!res.ok) return FALLBACK;
+    const data = (await res.json()) as { stargazers_count?: number };
+    const count = data.stargazers_count;
+    if (typeof count !== 'number') return FALLBACK;
+    // Format: <1000 → plain number, else Xk or X.Xk
+    if (count < 1000) return String(count);
+    const k = count / 1000;
+    return k % 1 === 0 ? `${k}k` : `${k.toFixed(1)}k`;
+  } catch {
+    return FALLBACK;
+  }
+}
+
 // Navigation card data
 const navCards = [
   {
@@ -60,7 +86,9 @@ const featuredExamples = [
   },
 ];
 
-export default function LandingPage() {
+export default async function LandingPage() {
+  const stars = await getGitHubStars();
+
   return (
     <div className="relative min-h-screen overflow-hidden bg-[var(--bg-base)] text-[var(--ink-body)]">
       <div className="pointer-events-none absolute inset-0 -top-14">
@@ -97,7 +125,7 @@ export default function LandingPage() {
                   >
                     <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Zm0 2.445L6.615 5.5a.75.75 0 0 1-.564.41l-3.097.45 2.24 2.184a.75.75 0 0 1 .216.664l-.528 3.084 2.769-1.456a.75.75 0 0 1 .698 0l2.77 1.456-.53-3.084a.75.75 0 0 1 .216-.664l2.24-2.183-3.096-.45a.75.75 0 0 1-.564-.41L8 2.694Z" />
                   </svg>
-                  13.1k
+                  {stars}
                 </span>
               </a>
 


### PR DESCRIPTION
## Make docs star counter dynamic

Replaces the hardcoded `13.1k` star count on the landing page with a live GitHub API fetch.

### Implementation
- `LandingPage` converted to async Next.js Server Component
- `getGitHubStars()` helper fetches GitHub API with optional `GITHUB_TOKEN` auth
- `export const revalidate = 3600` for hourly ISR refresh

### Review changes (commit d4195f2d)
- **GITHUB_TOKEN auth**: passes `Authorization: Bearer` when env var set; falls back to unauthenticated (60 req/hr limit). Adds `X-GitHub-Api-Version: 2022-11-28` header.
- **Formatting fix**: uses `parseFloat(k.toFixed(1))k` to avoid `14.0k` edge case
- **Million-star handling**: new `>= 1_000_000` branch formats as `X.XM`
- Added `GITHUB_TOKEN` to `.env.example` with comment

### Follow-up
- CUA-611: Set GITHUB_TOKEN in Vercel project env
- CUA-612: Evaluate extracting to shared `unstable_cache` helper