### PR TITLE
fix(docs): update navigation for Diátaxis content rewrite (CUA-615)

### DIFF
--- a/docs/src/components/custom-header.tsx
+++ b/docs/src/components/custom-header.tsx
@@ -8,53 +8,21 @@ import { cn } from 'fumadocs-ui/utils/cn';
 import { SearchToggle } from 'fumadocs-ui/components/layout/search-toggle';
 import { ChevronsUpDown, Check, Menu } from 'lucide-react';
 import { useSidebar } from 'fumadocs-ui/provider';
-import LogoBlack from '@/assets/cuala-icon-black.svg';
-import LogoWhite from '@/assets/cuala-icon-white.svg';
-import CuaBenchLogoBlack from '@/assets/cuabench-logo-black.svg';
-import CuaBenchLogoWhite from '@/assets/cuabench-logo-white.svg';
+import LogoBlack from '@/assets/logo-black.svg';
+import LogoWhite from '@/assets/logo-white.svg';
 import McpBlack from '@/assets/mcp-black.svg';
 import McpWhite from '@/assets/mcp-white.svg';
-import LumeIconBlack from '@/assets/lume-icon-black.svg';
-import LumeIconWhite from '@/assets/lume-icon-white.svg';
-import CuaBotLogoBlack from '@/assets/cuabot-logo-black.svg';
-import CuaBotLogoWhite from '@/assets/cuabot-logo-white.svg';
-import CuaDriverIconBlack from '@/assets/cua-driver-icon-black.png';
-import CuaDriverIconWhite from '@/assets/cua-driver-icon-white.png';
 
+// Single unified docs site — Diátaxis structure
+// (Old per-product switcher replaced after the Diátaxis content rewrite)
 const docsSites = [
-  {
-    name: 'Cua Driver',
-    label: 'Docs',
-    href: '/cua-driver/guide/getting-started/introduction',
-    prefix: '/cua-driver',
-    isDefault: true,
-    description: 'Background computer-use',
-    logoBlack: CuaDriverIconBlack,
-    logoWhite: CuaDriverIconWhite,
-    iconWidth: 24,
-    iconHeight: 24,
-    dropdownIconWidth: 28,
-    dropdownIconHeight: 28,
-    navTabs: [
-      {
-        name: 'Guide',
-        href: '/cua-driver/guide/getting-started/introduction',
-        prefix: '/cua-driver/guide',
-      },
-      {
-        name: 'Reference',
-        href: '/cua-driver/reference/cli-reference',
-        prefix: '/cua-driver/reference',
-      },
-    ],
-  },
   {
     name: 'Cua',
     label: 'Docs',
-    href: '/cua/guide/get-started/what-is-cua',
-    prefix: '/cua',
-    isDefault: false,
-    description: 'Computer Use Agent SDK',
+    href: '/tutorials/drive-your-first-app',
+    prefix: '/',
+    isDefault: true,
+    description: 'Computer-use automation platform',
     logoBlack: LogoBlack,
     logoWhite: LogoWhite,
     iconWidth: 24,
@@ -62,97 +30,10 @@ const docsSites = [
     dropdownIconWidth: 28,
     dropdownIconHeight: 28,
     navTabs: [
-      { name: 'Guide', href: '/cua/guide/get-started/what-is-cua', prefix: '/cua/guide' },
-      { name: 'Examples', href: '/cua/examples/automation/form-filling', prefix: '/cua/examples' },
-      { name: 'Reference', href: '/cua/reference/computer-sdk', prefix: '/cua/reference' },
-    ],
-  },
-  {
-    name: 'Cua Bench',
-    label: 'Docs',
-    href: '/cuabench/guide/getting-started/introduction',
-    prefix: '/cuabench',
-    isDefault: false,
-    description: 'Benchmarking toolkit',
-    logoBlack: CuaBenchLogoBlack,
-    logoWhite: CuaBenchLogoWhite,
-    iconWidth: 36,
-    iconHeight: 22,
-    dropdownIconWidth: 42,
-    dropdownIconHeight: 25,
-    navTabs: [
-      {
-        name: 'Guide',
-        href: '/cuabench/guide/getting-started/introduction',
-        prefix: '/cuabench/guide',
-      },
-      {
-        name: 'Examples',
-        href: '/cuabench/examples/custom-agent',
-        prefix: '/cuabench/examples',
-      },
-      {
-        name: 'Reference',
-        href: '/cuabench/reference/cli-reference',
-        prefix: '/cuabench/reference',
-      },
-    ],
-  },
-  {
-    name: 'Lume',
-    label: 'Docs',
-    href: '/lume/guide/getting-started/introduction',
-    prefix: '/lume',
-    isDefault: false,
-    description: 'macOS VM CLI and Framework',
-    logoBlack: LumeIconBlack,
-    logoWhite: LumeIconWhite,
-    iconWidth: 24,
-    iconHeight: 24,
-    dropdownIconWidth: 28,
-    dropdownIconHeight: 28,
-    navTabs: [
-      {
-        name: 'Guide',
-        href: '/lume/guide/getting-started/introduction',
-        prefix: '/lume/guide',
-      },
-      {
-        name: 'Examples',
-        href: '/lume/examples',
-        prefix: '/lume/examples',
-      },
-      {
-        name: 'Reference',
-        href: '/lume/reference/cli-reference',
-        prefix: '/lume/reference',
-      },
-    ],
-  },
-  {
-    name: 'Cua-Bot',
-    label: 'Docs',
-    href: '/cuabot/guide/getting-started/introduction',
-    prefix: '/cuabot',
-    isDefault: false,
-    description: 'Co-op computer-use for any agent',
-    logoBlack: CuaBotLogoBlack,
-    logoWhite: CuaBotLogoWhite,
-    iconWidth: 24,
-    iconHeight: 24,
-    dropdownIconWidth: 28,
-    dropdownIconHeight: 28,
-    navTabs: [
-      {
-        name: 'Guide',
-        href: '/cuabot/guide/getting-started/introduction',
-        prefix: '/cuabot/guide',
-      },
-      {
-        name: 'Reference',
-        href: '/cuabot/reference',
-        prefix: '/cuabot/reference',
-      },
+      { name: 'Tutorials', href: '/tutorials/drive-your-first-app', prefix: '/tutorials' },
+      { name: 'Explanation', href: '/explanation/what-is-computer-use', prefix: '/explanation' },
+      { name: 'How-to guides', href: '/how-to-guides/driver/install', prefix: '/how-to-guides' },
+      { name: 'Reference', href: '/reference/cua-driver/cli-reference', prefix: '/reference' },
     ],
   },
 ];
@@ -333,9 +214,9 @@ export function CustomHeader() {
 
           {/* MCP - hidden on mobile */}
           <Link
-            href="/cua/vibe-coding-mcp"
+            href="/reference/cua-driver/mcp-tools"
             className="cds-icon-button hidden h-9 w-9 items-center justify-center rounded-xl sm:inline-flex"
-            title="Vibe Coding MCP"
+            title="MCP Tools Reference"
           >
             <Image src={McpBlack} alt="MCP" width={20} height={20} className="block dark:hidden" />
             <Image src={McpWhite} alt="MCP" width={20} height={20} className="hidden dark:block" />

--- a/docs/src/components/scoped-docs-layout.tsx
+++ b/docs/src/components/scoped-docs-layout.tsx
@@ -5,19 +5,12 @@ import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import type { Root, Node, Folder } from 'fumadocs-core/page-tree';
 import type { ReactNode } from 'react';
 
-// Must match the navTabs prefixes defined in custom-header.tsx
+// Diátaxis section prefixes — must match the content paths in docs/content/docs/
 const SECTION_PREFIXES = [
-  '/cua/guide',
-  '/cua/examples',
-  '/cua/reference',
-  '/cuabench/guide',
-  '/cuabench/examples',
-  '/cuabench/reference',
-  '/lume/guide',
-  '/lume/examples',
-  '/lume/reference',
-  '/cuabot/guide',
-  '/cuabot/reference',
+  '/tutorials',
+  '/explanation',
+  '/how-to-guides',
+  '/reference',
 ];
 
 function hasDescendantWithPrefix(nodes: Node[], prefix: string): boolean {

--- a/docs/src/middleware.ts
+++ b/docs/src/middleware.ts
@@ -4,25 +4,31 @@ import type { NextRequest } from 'next/server';
 // Redirect section roots to their first content page
 // These paths don't include basePath because middleware receives paths without it
 const redirects: Record<string, string> = {
-  '/': '/docs/cua/guide/get-started/what-is-cua',
-  '/cua': '/docs/cua/guide/get-started/what-is-cua',
-  '/cua/guide': '/docs/cua/guide/get-started/what-is-cua',
-  '/cua/examples': '/docs/cua/examples/automation/form-filling',
-  '/cua/reference': '/docs/cua/reference/computer-sdk',
-  '/cua-driver': '/docs/cua-driver/guide/getting-started/introduction',
-  '/cua-driver/guide': '/docs/cua-driver/guide/getting-started/introduction',
-  '/cua-driver/reference': '/docs/cua-driver/reference/cli-reference',
-  '/cuabench': '/docs/cuabench/guide/getting-started/introduction',
-  '/cuabench/guide': '/docs/cuabench/guide/getting-started/introduction',
-  '/cuabench/reference': '/docs/cuabench/reference/cli-reference',
-  '/lume': '/docs/lume/guide/getting-started/introduction',
-  '/lume/guide': '/docs/lume/guide/getting-started/introduction',
-  '/lume/examples': '/docs/lume/examples/claude-code/sandbox',
-  '/lume/reference': '/docs/lume/reference/cli-reference',
-  // Legacy redirects for old URLs without /cua prefix
-  '/guide': '/docs/cua/guide/get-started/what-is-cua',
-  '/examples': '/docs/cua/examples/automation/form-filling',
-  '/reference': '/docs/cua/reference/computer-sdk',
+  // Redirect root to the new Diátaxis docs entry point
+  '/': '/docs/tutorials/drive-your-first-app',
+  // Diátaxis section roots
+  '/tutorials': '/docs/tutorials/drive-your-first-app',
+  '/explanation': '/docs/explanation/what-is-computer-use',
+  '/how-to-guides': '/docs/how-to-guides/driver/install',
+  '/reference': '/docs/reference/cua-driver/cli-reference',
+  // Legacy section redirects (pre-Diátaxis)
+  '/cua': '/docs/tutorials/drive-your-first-app',
+  '/cua/guide': '/docs/tutorials/drive-your-first-app',
+  '/cua/examples': '/docs/how-to-guides/recipes/fill-a-form-from-a-local-file',
+  '/cua/reference': '/docs/reference/sandbox-sdk/index',
+  '/cua-driver': '/docs/tutorials/drive-your-first-app',
+  '/cua-driver/guide': '/docs/tutorials/drive-your-first-app',
+  '/cua-driver/reference': '/docs/reference/cua-driver/cli-reference',
+  '/cuabench': '/docs/tutorials/drive-your-first-app',
+  '/cuabench/guide': '/docs/tutorials/drive-your-first-app',
+  '/cuabench/reference': '/docs/reference/cua-driver/cli-reference',
+  '/lume': '/docs/tutorials/drive-your-first-app',
+  '/lume/guide': '/docs/tutorials/drive-your-first-app',
+  '/lume/examples': '/docs/how-to-guides/sandbox/lifecycle',
+  '/lume/reference': '/docs/reference/cua-driver/cli-reference',
+  // Legacy redirects for old URLs without product prefix
+  '/guide': '/docs/tutorials/drive-your-first-app',
+  '/examples': '/docs/how-to-guides/recipes/fill-a-form-from-a-local-file',
 };
 
 export function middleware(request: NextRequest) {


### PR DESCRIPTION
## Problem

After the Diátaxis content rewrite (PR #1957), the docs at `cua.ai/docs` had broken navigation:
- The root `/` redirect pointed to old paths that no longer exist (e.g. `/cua/guide/get-started/what-is-cua` → 404)
- The `custom-header.tsx` showed a five-product docs switcher with old per-product paths
- The `scoped-docs-layout.tsx` used old section prefixes that never matched any URL

Separately, the Ask AI (CopilotKit) button was not working because `POST cua.ai/docs/api/copilotkit` returned HTTP 405 — the React Router Lambda was intercepting the request before the Vercel rewrite could proxy it to the docs Next.js app. This is fixed in the cloud repo: **trycua/cloud#5128**.

## Changes

### `docs/src/middleware.ts`
- Replace all old per-product section redirects with Diátaxis section roots
- `/` → `/docs/tutorials/drive-your-first-app` (was `/docs/cua/guide/get-started/what-is-cua`)
- Legacy `/cua`, `/cua-driver`, `/lume`, `/cuabench` paths redirect to nearest equivalent

### `docs/src/components/scoped-docs-layout.tsx`
- Update `SECTION_PREFIXES` to Diátaxis sections: `/tutorials`, `/explanation`, `/how-to-guides`, `/reference`

### `docs/src/components/custom-header.tsx`
- Replace the five-product docs switcher with a single unified entry showing Diátaxis navigation tabs: Tutorials | Explanation | How-to guides | Reference
- Remove unused per-product logo imports
- Fix MCP icon link (old `/cua/vibe-coding-mcp` → new `/reference/cua-driver/mcp-tools`)

## Notes

- The Ask AI backend fix (routing) is in **trycua/cloud#5128** and must be merged alongside this PR for Ask AI to fully work.
- The docs Next.js app itself (CopilotKit, fumadocs, API routes) is unchanged; only navigation/routing is fixed here.

Fixes CUA-615.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Unified documentation site structure into a single cohesive experience
  * Reorganized navigation tabs into Diátaxis-style categories: Tutorials, Explanation, How-to guides, and Reference
  * Configured redirects for legacy documentation paths to new locations
  * Updated MCP Tools reference link in the documentation header

<!-- end of auto-generated comment: release notes by coderabbit.ai -->