### PR TITLE
feat(skills): autodetect Hermes (~/.hermes/skills) on skills install

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
@@ -50,6 +50,13 @@
 //!                (`agy`) and Antigravity IDE; same dir Google Gemini CLI
 //!                used before the May-2026 transition, so existing
 //!                installs migrate forward unchanged.
+//! - Hermes:      `~/.hermes/skills/` — NousResearch/hermes-agent.
+//!                The user-level skill space Hermes resolves at agent
+//!                load time (separate from the repo-bundled
+//!                `hermes-agent/skills/` tree, which is read-only and
+//!                version-controlled). Hermes' own `computer-use`
+//!                skill teaches its wrapper vocabulary; the
+//!                cua-driver pack provides the platform deep dives.
 //!
 //! Only acts on a given agent when its parent skills dir already
 //! exists (i.e. the agent itself is installed). Never clobbers an
@@ -198,6 +205,15 @@ const AGENTS: &[Agent] = &[
     // (the same path Gemini CLI used pre-May-2026). Registering the
     // single shared path means both surfaces pick up the same symlink.
     Agent { label: "Antigravity", parent: AgentParent::Home(".gemini/skills") },
+    // Hermes (NousResearch/hermes-agent) resolves user skills from
+    // `~/.hermes/skills/` at agent load time — the same directory its
+    // `/skills install …` slash command and `hermes skills install`
+    // CLI write to. Hermes' bundled `skills/computer-use/SKILL.md`
+    // teaches the Hermes `computer_use` action vocabulary; the
+    // cua-driver pack symlinked here adds the platform-specific deep
+    // dives (MACOS.md / WINDOWS.md / LINUX.md / RECORDING.md /
+    // WEB_APPS.md / TESTS.md) that Hermes deliberately doesn't clone.
+    Agent { label: "Hermes",      parent: AgentParent::Home(".hermes/skills") },
 ];
 
 impl Agent {
@@ -290,7 +306,7 @@ fn install(flags: &[String], force: bool) -> Result<()> {
         }
     }
     if !linked_any {
-        println!("(No agent skills dirs present yet — install Claude Code / Codex / OpenClaw / OpenCode then re-run.)");
+        println!("(No agent skills dirs present yet — install Claude Code / Codex / OpenClaw / OpenCode / Antigravity / Hermes then re-run.)");
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Adds NousResearch/hermes-agent to \`cua-driver skills install\`'s
autodetection. With this change, the cua-driver skill pack symlinks
into \`~/.hermes/skills/cua-driver\` alongside the existing Claude
Code, Codex, OpenClaw, OpenCode, and Antigravity entries.

Pairs with a Hermes-side refresh (separate PR on \`NousResearch/hermes-agent\`)
that:

- Replaces \`skills/apple/macos-computer-use/SKILL.md\` (macOS-only clone) with
  \`skills/computer-use/SKILL.md\` — a single cross-platform Hermes-vocabulary
  skill that deliberately delegates platform deep dives to the cua-driver pack
  symlinked here.
- Refreshes the user-facing docs to point at \`cua.ai/docs/how-to-guides/driver/*\`
  for the deep dives instead of cloning their content into Hermes.

So this PR is the trycua/cua half: makes \`cua-driver skills install\` the
single command that wires the pack into Hermes without the user touching
symlinks. Single source of truth for the cua-driver-side platform internals;
Hermes owns its own wrapper vocabulary; no duplication.

## What changed

\`libs/cua-driver/rust/crates/cua-driver/src/skills.rs\`:

- \`AGENTS\` const: new \`Agent { label: "Hermes", parent: AgentParent::Home(".hermes/skills") }\` entry, with an inline comment explaining the split between Hermes' bundled skill and this pack.
- Module docstring: added Hermes to the agent-detection list.
- "No agent skills dirs present yet" prompt: added Hermes to the suggested-harness list so a fresh user knows it's one of the supported targets.

No other behavior changes — Hermes is detected and linked the exact same way as the existing harnesses (parent dir must already exist; never clobbers an existing \`cua-driver\` link; idempotent on re-run).

## Test plan

Manual on macOS (existing live setup, Hermes installed):

\`\`\`
$ cua-driver skills status
...
  Hermes — not linked (/Users/me/.hermes/skills/cua-driver)

$ cua-driver skills install
...
  ✅ linked Hermes skill at /Users/me/.hermes/skills/cua-driver

$ cua-driver skills status
...
  Hermes — ✅ linked: /Users/me/.hermes/skills/cua-driver
                     → /Users/me/.cua-driver/skills/cua-driver

$ ls -la ~/.hermes/skills/cua-driver
lrwxr-xr-x ... cua-driver -> /Users/me/.cua-driver/skills/cua-driver
\`\`\`

Re-running \`install\` is a no-op (link already exists; skip).

When Hermes is not installed (no \`~/.hermes/skills/\`), the status row reports \`agent dir not present (/Users/me/.hermes/skills)\` — matches the OpenClaw / Antigravity behavior on this host.

- [x] Manual verification on macOS
- [x] Build: \`cargo build -p cua-driver --bin cua-driver\` clean
- [x] Existing test suite still passes for the bits this PR touches (the pre-existing \`mcp_protocol_test\` failures on \`main\` are unrelated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent detection documentation to include Hermes support information.

* **New Features**
  * Added Hermes agent support for skill installation and updates, automatically linking skill packs into the Hermes user skills directory.

* **Improvements**
  * Enhanced user-facing messages to include Hermes when prompting for agent setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->