### PR TITLE
Bump cua-agent to v0.8.3

### DIFF
--- a/libs/python/agent/.bumpversion.cfg
+++ b/libs/python/agent/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.2
+current_version = 0.8.3
 commit = True
 tag = True
 tag_name = agent-v{new_version}

--- a/libs/python/agent/pyproject.toml
+++ b/libs/python/agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "cua-agent"
-version = "0.8.2"
+version = "0.8.3"
 description = "Cua (Computer Use) Agent for AI-driven computer interaction"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Patch bump to release the litellm security fix.

`cua-agent` `0.8.2` is the latest on PyPI and predates the litellm CVE fix (CVE-2026-35030 and others) merged in #1952. This bumps to `0.8.3` so the fix can ship.

- `libs/python/agent/pyproject.toml`: `0.8.2` → `0.8.3`
- `libs/python/agent/.bumpversion.cfg`: `current_version` → `0.8.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated agent package version to 0.8.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->