### PR TITLE
fix(cua-driver)(windows): bail on minimized window screenshot

### DIFF
--- a/libs/cua-driver/rust/crates/platform-windows/src/capture.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/capture.rs
@@ -220,11 +220,35 @@ pub fn screenshot_window(hwnd: u64) -> Result<(String, u32, u32)> {
 }
 
 unsafe fn screenshot_window_bytes_with_occlusion_unsafe(hwnd: u64) -> Result<(Vec<u8>, bool)> {
-    use windows::Win32::UI::WindowsAndMessaging::GetWindowRect;
+    use windows::Win32::UI::WindowsAndMessaging::{GetWindowRect, IsIconic};
     use windows::Win32::Foundation::RECT;
 
     let hwnd_raw = hwnd;
     let hwnd = HWND(hwnd as *mut _);
+
+    // Bail loudly on minimized (iconic) windows BEFORE attempting any
+    // capture path. On Windows, `GetWindowRect` on an iconic HWND returns
+    // the off-screen "iconic position" (typically `(-32000, -32000,
+    // -31840, -31972)` i.e. w=160, h=28, both positive) and `PrintWindow`
+    // paints nothing into the bitmap. The result is a heavily-compressed
+    // all-black ~28x160 PNG (~300 bytes) that an upstream agent can't tell
+    // apart from a real "blank screen" capture — wasting model turns
+    // retrying against a window that's literally minimized to the taskbar.
+    //
+    // The WGC sibling path at `wgc.rs:58` already short-circuits this case;
+    // the GDI/PrintWindow fallback below + the screen-region BitBlt fallback
+    // both happily produced the degenerate PNG. Guarding here covers both
+    // and matches the WGC error shape so callers can `list_windows` or
+    // raise the window before retrying.
+    if IsIconic(hwnd).as_bool() {
+        bail!(
+            "cannot capture minimized window 0x{hwnd_raw:x}: it has no \
+             rendered content. Restore the window first via list_windows \
+             / raise_window. The PrintWindow GDI path and the screen-region \
+             BitBlt fallback both return an all-black bitmap for iconic \
+             windows."
+        );
+    }
 
     // CUA-542 routing: for known XAML / WinUI3 / UWP targets, the
     // PrintWindow GDI path returns black (DirectComposition isn't in


### PR DESCRIPTION
Closes #1973.

## Summary

`screenshot_window_bytes_with_occlusion_unsafe` (the GDI / PrintWindow + screen-region BitBlt path) only guarded `w <= 0 || h <= 0`. A minimized Win32 window has `GetWindowRect` returning the off-screen iconic position (typically `(-32000, -32000, -31840, -31972)` — width 160, height 28, **both positive**), so the check passes, `PrintWindow` paints nothing into the bitmap, and the result is a heavily-compressed all-black ~300-byte PNG that an upstream agent can't distinguish from a real "blank screen" capture.

The WGC sibling path at `wgc.rs:58` already short-circuits iconic windows, but:
- on a **non-XAML target** (most apps) WGC is never tried — the code jumps to the GDI path;
- on an **XAML target**, when WGC bails the code falls through to `screenshot_via_screen_region`, which has the same bug (`(-32000, -32000)` BitBlts a black tile of the off-screen region).

## Fix

Single `IsIconic` check at the top of `screenshot_window_bytes_with_occlusion_unsafe` so every downstream capture path (WGC / GDI PrintWindow / screen-region BitBlt) is guarded by one source of truth, with an error matching the WGC error shape so callers can call `list_windows` / `raise_window` and retry.

`+25 / -1` on a single file.

## Test plan

- [x] `cargo check -p cua-driver` clean on macOS host.
- [ ] Manual smoke on a Windows VM: minimize Notepad, call `screenshot` via MCP with its window_id, observe typed error instead of a 300-byte PNG. Restore Notepad, retry, observe a valid full-window capture.
- [ ] Downstream MCP clients (Hermes' `cua_backend.py`, cua-agent) propagate the error instead of caching the degenerate image.

## Notes

- This doesn't fix the sticky `_active_window_id` caching in MCP-client wrappers like Hermes (that's a client-side concern), but the clear error from cua-driver makes it self-correcting from the model's perspective — the next turn the model can call `list_windows` and re-resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced screenshot capture to properly handle minimized windows. The system now detects minimized windows and returns a clear error message instead of producing black or corrupted screenshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->