### PR TITLE
fix(cua-driver)(windows): surface get_window_state screenshot error

### DIFF
--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -695,7 +695,14 @@ impl Tool for GetWindowStateTool {
             } else {
                 None
             };
-            let screenshot = if do_shot {
+            // Capture screenshot AND any error message so the response can
+            // surface *why* there's no image (the iconic-window guard from
+            // #1973 / PR #1974 is the load-bearing case: minimized windows
+            // legitimately can't be captured, and the caller needs to know
+            // to call `raise_window` / `list_windows` instead of retrying).
+            // The previous `Err(_) => None` silently dropped the error and
+            // upstream agents saw an empty response with no signal.
+            let (screenshot, screenshot_err) = if do_shot {
                 match crate::capture::screenshot_window_bytes(hwnd) {
                     Ok(raw) => {
                         let orig_w = crate::capture::png_dimensions_pub(&raw).map(|(w, _)| w).unwrap_or(0);
@@ -703,14 +710,14 @@ impl Tool for GetWindowStateTool {
                         let (w, h) = crate::capture::png_dimensions_pub(&png)?;
                         use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
                         let original_w = if w < orig_w { Some(orig_w) } else { None };
-                        Some((B64.encode(&png), w, h, original_w))
+                        (Some((B64.encode(&png), w, h, original_w)), None)
                     }
-                    Err(_) => None,
+                    Err(e) => (None, Some(format!("{e}"))),
                 }
             } else {
-                None
+                (None, None)
             };
-            Ok((tree_result, screenshot))
+            Ok((tree_result, screenshot, screenshot_err))
         });
         // Timeout: Chrome's UIA provider can block indefinitely on property reads.
         let result: Result<anyhow::Result<_>, _> = match tokio::time::timeout(
@@ -740,7 +747,7 @@ impl Tool for GetWindowStateTool {
         let result = result.and_then(|r| r);
 
         match result {
-            Ok((tree_opt, screenshot_opt)) => {
+            Ok((tree_opt, screenshot_opt, screenshot_err)) => {
                 let mut content = Vec::new();
                 let mut structured = json!({ "window_id": hwnd, "pid": pid });
 
@@ -839,6 +846,18 @@ impl Tool for GetWindowStateTool {
                     // the structured payload so consumers don't have to sniff
                     // magic bytes off the base64 to know the format.
                     structured["screenshot_mime_type"] = json!("image/png");
+                } else if let Some(err) = screenshot_err {
+                    // Capture failed (most commonly because the target is
+                    // minimized — see #1973). Surface the reason in BOTH the
+                    // human-readable content stream (so the model sees it
+                    // alongside the UIA tree it does get) AND structuredContent
+                    // (so MCP clients with structured-only parsing can detect
+                    // and act on it). Without this the caller saw an empty
+                    // response with no clue why and burned turns retrying.
+                    content.push(cua_driver_core::protocol::Content::text(
+                        format!("screenshot unavailable: {err}")
+                    ));
+                    structured["screenshot_error"] = json!(err);
                 }
 
                 ToolResult { content, is_error: None, structured_content: Some(structured) }


### PR DESCRIPTION
Follow-up to #1974 / #1973.

## Problem

PR #1974's `IsIconic` guard in `screenshot_window_bytes_with_occlusion_unsafe` correctly bails on minimized targets, but `get_window_state` discarded the error at `impl_.rs:708`:

```rust
Err(_) => None,
```

End-to-end behaviour:

| Version | Minimized-window `get_window_state` response | Agent UX |
|---|---|---|
| v0.6.2 | degenerate 300-byte all-black PNG | "screen looks blank" → burned turns |
| v0.6.3 (with #1974) | empty `content:[]`, no error | "no screenshot" → still confused |
| this PR | typed bail surfaced in content + structuredContent | model picks `raise_window` / `list_windows` and retries |

Reproduced live on the Windows VM after PR #1974 shipped as v0.6.3: a minimized Notepad's `get_window_state` (capture_mode=`vision`) returns `{"content":[],"structuredContent":{"pid":…, "window_id":…}}` — the `IsIconic` error is firing inside `screenshot_window_bytes` but `get_window_state` was throwing it away.

## Fix

Capture the screenshot error alongside the (optional) image in the spawn_blocking closure, and on the no-image branch surface it in BOTH:

- the human-readable `content` stream (so models with content-only parsing see `"screenshot unavailable: cannot capture minimized window 0x…"` next to any UIA tree they got);
- `structuredContent.screenshot_error` (so MCP clients that consume the structured side — `cua_backend.py` and downstream wrappers — can detect and act on it).

Single-file change in `crates/platform-windows/src/tools/impl_.rs`: `+25 / -6`.

## Test plan

- [x] `cargo check -p cua-driver` clean.
- [ ] On the Windows VM with v0.6.4: spawn Notepad, minimize, call `get_window_state { pid, window_id, capture_mode: "vision" }` and confirm `structuredContent.screenshot_error` contains the iconic-bail message + `content[0].text` carries `"screenshot unavailable: cannot capture minimized window 0x…"`.
- [ ] Restore Notepad, retry, confirm a normal screenshot path with no `screenshot_error` field set.

## Out of scope

- Linux / macOS platform crates have the same pattern but their screenshot paths don't have the iconic-window failure mode; deferring symmetry until there's a real failure to surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Screenshot capture errors are now properly reported with clear error messages instead of being silently discarded. When screenshots cannot be captured, users receive transparent error feedback and diagnostic information in the response payload, enabling them to identify and troubleshoot underlying issues more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->