### PR TITLE
fix(docs)(CUA-631): match Ask AI send button height to page action

### DIFF
--- a/docs/src/providers/copilotkit-provider.tsx
+++ b/docs/src/providers/copilotkit-provider.tsx
@@ -552,6 +552,12 @@ const customStyles = `
     min-height: 0 !important;
   }
 
+  /* Match send button height to page action button height (h-9 = 36px) */
+  .copilotKitInputControlButton {
+    width: 36px;
+    height: 36px;
+  }
+
   /* Match chat input radius to CDS button radius (10px) */
   .copilotKitInput {
     border-radius: 10px;


### PR DESCRIPTION
Fixes CUA-631. Makes the Ask AI send button the same height as the Ask about this page action button for visual consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted input control button sizing for improved visual consistency with other UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->