### PR TITLE
fix(docs)(CUA-632): restore Markdown rendering in Ask AI responses

### DIFF
--- a/docs/src/providers/copilotkit-provider.tsx
+++ b/docs/src/providers/copilotkit-provider.tsx
@@ -53,27 +53,28 @@ function CustomAssistantMessage(props: React.ComponentProps<typeof DefaultAssist
       };
     }
 
+    // When content is an array of ContentParts (e.g. [{type:'text', text:'...'}]),
+    // DefaultAssistantMessage expects a plain string for Markdown rendering.
+    // Flatten to a single string so react-markdown can render it correctly.
     if (Array.isArray(message.content)) {
       const contentArray = message.content as unknown[];
-      return {
-        ...message,
-        content: contentArray.map((part: unknown) => {
-          if (typeof part === 'string') {
-            return fixTextConcatenation(part);
-          }
+      const text = contentArray
+        .map((part: unknown) => {
+          if (typeof part === 'string') return part;
           if (
             part &&
             typeof part === 'object' &&
             'text' in part &&
             typeof (part as { text?: unknown }).text === 'string'
           ) {
-            return {
-              ...part,
-              text: fixTextConcatenation((part as { text: string }).text),
-            };
+            return (part as { text: string }).text;
           }
-          return part;
-        }),
+          return '';
+        })
+        .join('');
+      return {
+        ...message,
+        content: fixTextConcatenation(text),
       };
     }
 


### PR DESCRIPTION
Fixes CUA-632. Restores Markdown rendering in Ask AI (CopilotKit) responses.

When using CopilotKit v1.50.1 with InMemoryAgentRunner, assistant message content can arrive as an array of ContentParts rather than a plain string. DefaultAssistantMessage passes content directly to react-markdown, which expects a string. When content is an array, markdown rendering breaks.

Fix: flatten array content into a joined string before delegating to DefaultAssistantMessage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how assistant messages handle and display text content, ensuring proper text concatenation and formatting in message responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->