### PR TITLE
fix(cua-driver): install.ps1 fails when $env:TEMP is a missing 8.3 short path (#1911)

### DIFF
--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -544,6 +544,27 @@ function Test-IsElevated {
 #     Fetch the .psm1 from GitHub raw and Import-Module from a temp
 #     file. See Import-CuaDriverInstallModule below (defined inline so
 #     it's available before the module load itself).
+# Resolve a temp directory that actually exists. $env:TEMP / $env:TMP can point
+# at a missing or unresolvable short 8.3 profile path (e.g. C:\Users\SHORTN~1.DOM),
+# which makes Set-Content / Remove-Item fail. Pick the first candidate that
+# exists, expand 8.3 short components to the long form, and fall back to
+# %SystemRoot%\Temp (always present). See issue #1911.
+function Get-CuaDriverTempDir {
+    foreach ($cand in @($env:TEMP, $env:TMP, (Join-Path $env:LOCALAPPDATA 'Temp'), (Join-Path $env:SystemRoot 'Temp'))) {
+        if ([string]::IsNullOrWhiteSpace($cand)) { continue }
+        try {
+            if (Test-Path -LiteralPath $cand) {
+                return (Get-Item -LiteralPath $cand -ErrorAction Stop).FullName
+            }
+        } catch { }
+    }
+    $fallback = Join-Path $env:SystemRoot 'Temp'
+    if (-not (Test-Path -LiteralPath $fallback)) {
+        New-Item -ItemType Directory -Path $fallback -Force | Out-Null
+    }
+    return $fallback
+}
+
 function Import-CuaDriverInstallModuleBootstrap {
     [CmdletBinding()]
     param(
@@ -558,7 +579,7 @@ function Import-CuaDriverInstallModuleBootstrap {
         }
     }
     $body = Invoke-RestMethod -Uri $Url -UseBasicParsing
-    $tmp = Join-Path $env:TEMP ("CuaDriverInstall-" + [Guid]::NewGuid().ToString('N') + ".psm1")
+    $tmp = Join-Path (Get-CuaDriverTempDir) ("CuaDriverInstall-" + [Guid]::NewGuid().ToString('N') + ".psm1")
     Set-Content -LiteralPath $tmp -Value $body -Encoding UTF8
     try {
         Import-Module -Name $tmp -Force -ErrorAction Stop
@@ -1063,7 +1084,7 @@ if (Test-Path -LiteralPath (Join-Path $versionedDir $BinaryName)) {
 }
 
 if (-not $skipDownload) {
-    $tmpRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("cua-driver-rs-install-" + [Guid]::NewGuid().ToString("N"))
+    $tmpRoot = Join-Path (Get-CuaDriverTempDir) ("cua-driver-rs-install-" + [Guid]::NewGuid().ToString("N"))
     New-Item -ItemType Directory -Force -Path $tmpRoot | Out-Null
     try {
         $stageDir = Get-ReleaseAsset $version $archLabel $tmpRoot


### PR DESCRIPTION
## Problem

`install.ps1` writes its bootstrap module and download staging dir under `$env:TEMP` / `[System.IO.Path]::GetTempPath()`. On some Windows profiles those resolve to a **non-existent or unresolvable short 8.3 path** (e.g. `C:\Users\SHORTN~1.DOM`), so `Set-Content` / `Remove-Item` fail with:

```
Could not find a part of the path 'C:\Users\SHORTN~1.DOM\CuaDriverInstall-<guid>.psm1'.
```

The installer aborts before it can do anything. Fixes #1911.

## Fix

Add `Get-CuaDriverTempDir`: walk a candidate list (`$env:TEMP`, `$env:TMP`, `%LOCALAPPDATA%\Temp`, `%SystemRoot%\Temp`), return the first that **actually exists**, expanding any 8.3 short path to its long form via `(Get-Item -LiteralPath $cand).FullName`, and fall back to `%SystemRoot%\Temp` (creating it if needed). Both temp-using sites — the bootstrap module file and the install `tmpRoot` — now go through it.

## Verification (real Windows VM, PowerShell 5.1)

Ran against this branch's `install.ps1` on a Windows VM:

```
SYNTAX: OK (no parse errors)
HAS_HELPER: True
BOOTSTRAP_USES_HELPER: True
OLD(env:TEMP): FAILS as reported -> Could not find a part of the path 'C:\Users\SHORTN~1.DOM\CuaDriverInstall-x.psm1'.
NEW dir=C:\Windows\Temp exists=True
NEW(helper): write+remove OK
```

- Reproduces the reported failure with the old `$env:TEMP`-direct path.
- Confirms the helper resolves to an existing dir and the write+remove round-trips.
- Full-installer end-to-end (download + extract) not run on the VM; the change is isolated to temp-dir resolution and the two call sites are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temporary directory handling during installation to ensure reliable access to writable storage locations across different system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->