### PR TITLE
fix(cua-driver/linux): report dead input backend on KDE/GNOME Wayland instead of silent no-op (#1982)

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/health_report.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/health_report.rs
@@ -281,6 +281,29 @@ async fn check_wayland_backend() -> CheckEntry {
             format!("All wlroots manager globals advertised ({msg})."),
         );
     }
+    // Input-injection backend check (#1982). A non-wlroots compositor
+    // (KWin/Plasma, Mutter/GNOME) advertises no zwlr_virtual_pointer; on those
+    // the ONLY working input path is libei via xdg-desktop-portal. If this
+    // binary was built without `portal-libei` (the published tarball is — see
+    // #1967), input injection has no backend and silently no-ops: the agent
+    // cursor renders but clicks/keys are never delivered, while list_windows
+    // and capture still work. Report that explicitly instead of the misleading
+    // "input may fall back" partial-pass below.
+    if !snap.virtual_pointer && !crate::wayland::PORTAL_LIBEI_ENABLED {
+        return CheckEntry::fail(
+            NAME_WAYLAND_BACKEND,
+            format!(
+                "Input injection has no backend on this compositor ({msg}): it \
+                 advertises no zwlr_virtual_pointer and this build was compiled \
+                 without libei/portal support, so clicks and key presses will not \
+                 be delivered (the agent cursor still renders). list_windows and \
+                 screen capture are unaffected."
+            ),
+            "Use the portal-enabled Linux build (compiled with --features \
+             portal-libei) for input on KDE Plasma / GNOME, or a wlroots \
+             compositor (sway, labwc, hyprland) where zwlr_virtual_pointer exists.",
+        );
+    }
     // Partial-pass: list_windows + capture both work, but virtual-pointer
     // input is missing. Require `wl_shm` here too — `check_screen_capture_capability`
     // gates on both `screencopy && wl_shm`, so excluding `wl_shm` from the

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
@@ -26,6 +26,16 @@ pub mod portal_screencast;
 #[cfg(feature = "portal-libei")]
 pub mod libei;
 
+/// Whether this binary was compiled with the `portal-libei` feature — the
+/// xdg-desktop-portal RemoteDesktop + libei input path. It is the ONLY input
+/// backend that works on non-wlroots compositors (KWin/Plasma, Mutter/GNOME),
+/// which do not implement `zwlr_virtual_pointer_v1`. The published
+/// curl-pipe-bash tarball is built WITHOUT it (#1967 — debian:11 CD container
+/// lacks a new-enough PipeWire/libei), so on those compositors input injection
+/// has no backend and silently no-ops. Consulted by the doctor and the input
+/// dispatch so that failure is reported instead of hidden. See #1982.
+pub const PORTAL_LIBEI_ENABLED: bool = cfg!(feature = "portal-libei");
+
 use std::collections::HashMap;
 
 use wayland_client::{
@@ -786,10 +796,22 @@ pub fn open_vptr_session(activate_window_id: Option<u32>) -> anyhow::Result<Vptr
         .seat
         .clone()
         .ok_or_else(|| anyhow::anyhow!("compositor exposed no wl_seat for virtual-pointer input"))?;
-    let mgr = state
-        .vptr_manager
-        .clone()
-        .ok_or_else(|| anyhow::anyhow!("compositor does not expose zwlr_virtual_pointer_manager_v1"))?;
+    let mgr = state.vptr_manager.clone().ok_or_else(|| {
+        if PORTAL_LIBEI_ENABLED {
+            anyhow::anyhow!("compositor does not expose zwlr_virtual_pointer_manager_v1")
+        } else {
+            // KWin/Plasma and Mutter/GNOME don't implement zwlr_virtual_pointer,
+            // and this build has no libei/portal fallback — so input has no
+            // backend at all rather than silently no-op'ing. See #1982.
+            anyhow::anyhow!(
+                "no input backend for this compositor: it exposes no \
+                 zwlr_virtual_pointer_manager_v1 and this build was compiled \
+                 without libei/portal support (#1982). Use the portal-enabled \
+                 Linux build for input on KDE Plasma / GNOME, or a wlroots \
+                 compositor (sway, labwc, hyprland)."
+            )
+        }
+    })?;
 
     if let Some(id) = activate_window_id {
         let handle = state


### PR DESCRIPTION
## Problem

On KDE Plasma 6.x (and GNOME) Wayland, the agent cursor renders but **clicks and key presses are never delivered** — and `cua-driver doctor` reports all-green, so the failure is invisible. Fixes #1982 (the near-term half).

## Root cause

Non-wlroots compositors (KWin/Plasma, Mutter/GNOME) don't implement `zwlr_virtual_pointer_v1`. The only input path that works there is libei via `xdg-desktop-portal RemoteDesktop`, which is feature-gated behind `portal-libei` and compiled **out** of the published curl-pipe-bash tarball (#1967 — the debian:11 CD container can't satisfy the PipeWire/libei build deps without raising the GLIBC floor).

So on those compositors `open_vptr_session` finds no virtual-pointer manager and there's no fallback in the binary — input has no backend. Worse, the doctor's `wayland_backend` check returned a misleading **partial-pass** (*"input may fall back where virtual-pointer is absent"*) whenever capture + foreign-toplevel + `wl_shm` were present, which is exactly the KWin case.

## Fix (issue author's recommended option #2 — end the silent failure mode)

- Add `wayland::PORTAL_LIBEI_ENABLED` = `cfg!(feature = "portal-libei")`.
- `doctor` `wayland_backend`: when `virtual_pointer` is absent **and** this build has no libei/portal support, return a **FAIL** with an actionable hint (use the portal-enabled build, or a wlroots compositor) instead of a false partial-pass. `list_windows` / capture are explicitly noted as unaffected.
- `open_vptr_session`: emit the same actionable error at input time, so a `click`/`type` call on KDE/GNOME returns a clear *"no input backend… use the portal build"* error rather than looking like a silent success.

This does not add the libei path to the published binary — the two-variant publish (option #1, `…-portal.tar.gz` selected by an install.sh glibc sniff) remains separate, larger release-infra work. This PR's job is to make the current limitation honest and diagnosable.

## Verification

- **Build-verified on Linux** (Ubuntu, system libxcb/Wayland deps): `cargo build -p platform-linux` recompiled green at commit `d8885e5` (default features — i.e. `portal-libei` off, exactly the published-binary config that exercises the new FAIL path).
- Runtime behaviour on a live KDE Plasma session not exercised here (no KDE Wayland host in the test fleet); the change is a verdict/error-message correction along the existing no-backend code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health diagnostics for input injection on Wayland compositors, providing clearer error messages when input features are unavailable or incompatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->