### PR TITLE
fix(cua-driver/windows): retry transient BuildUpdatedCache failures instead of returning elements=0 (#1881)

### DIFF
--- a/libs/cua-driver/rust/crates/platform-windows/src/uia/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/uia/mod.rs
@@ -208,12 +208,33 @@ unsafe fn walk_tree_unsafe(
             nodes: Vec::new(),
         },
     };
-    let root_elem = match uncached.BuildUpdatedCache(&cache_req) {
-        Ok(e) => e,
-        Err(e) => return UiaTreeResult {
-            tree_markdown: format!("BuildUpdatedCache failed: {e}"),
-            nodes: Vec::new(),
-        },
+    // A single transient provider error (commonly E_FAIL / 0x80004005 from a
+    // control rebuilding its automation subtree mid-walk) must not take down
+    // the whole snapshot — the same call usually succeeds a beat later. Retry
+    // the bulk cache build a few times with a short backoff before giving up,
+    // so one misbehaving provider doesn't force the agent down to pixel mode.
+    // See #1881. (A per-node partial-tree fallback — returning elements=N for
+    // the subtrees that did resolve — remains a larger follow-up.)
+    let root_elem = {
+        const MAX_ATTEMPTS: u32 = 3;
+        let mut attempt = 0u32;
+        loop {
+            match uncached.BuildUpdatedCache(&cache_req) {
+                Ok(e) => break e,
+                Err(e) => {
+                    attempt += 1;
+                    if attempt >= MAX_ATTEMPTS {
+                        return UiaTreeResult {
+                            tree_markdown: format!(
+                                "BuildUpdatedCache failed after {attempt} attempts: {e}"
+                            ),
+                            nodes: Vec::new(),
+                        };
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(40));
+                }
+            }
+        }
     };
 
     let mut nodes: Vec<UiaNode> = Vec::new();


### PR DESCRIPTION
## Problem

`get_window_state` sometimes returns an empty tree (`elements=0`) with `BuildUpdatedCache failed: Unbekannter Fehler (0x80004005)` — even though the same call returned a full tree moments earlier. One misbehaving/transient UIA provider (e.g. a rich-text control rebuilding its automation subtree, or a virtualized list re-realizing items) takes down the **entire** snapshot, forcing every `element_index` tool (click, type_text, …) down to pixel coordinates for that window. Fixes #1881.

## Root cause

`uia/mod.rs` did a single `BuildUpdatedCache(TreeScope_Subtree)` on the window root and hard-failed on any error — no retry, no fallback. A transient `E_FAIL` from one provider yields a total outage:

```rust
let root_elem = match uncached.BuildUpdatedCache(&cache_req) {
    Ok(e) => e,
    Err(e) => return UiaTreeResult { tree_markdown: format!("BuildUpdatedCache failed: {e}"), nodes: Vec::new() },
};
```

## Fix

Retry the bulk cache build up to **3 attempts with a 40 ms backoff** before giving up (the issue notes a second call right after frequently succeeds), and report the attempt count in the failure message. This is the issue's suggestion #1 (retry) plus part of #3 (diagnostics).

The per-node **partial-tree fallback** (suggestion #2 — return `elements=N` for the subtrees that did resolve, skipping the broken one) is a larger change to the walker and is left as a follow-up.

## Verification

- **Compile-verified on Windows** (MSVC, `windows` crate): `cargo build -p platform-windows` recompiled green at commit `17adb54`.
- The transient provider error is timing-dependent in real apps and not reproducible on the Session-0 build host; a deterministic harness (a custom `IRawElementProviderFragment` returning `E_FAIL` from one child) would make a good regression test — noted in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of UI automation operations on Windows by implementing resilient retry logic for cache operations that may fail transiently, improving system stability when encountering temporary failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->