### PR TITLE
fix(cua-driver/linux): retry root-only AT-SPI tree on cold Qt6 launch (#1927)

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/atspi/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/atspi/mod.rs
@@ -56,11 +56,27 @@ pub fn walk_tree_bounded(
     max_elements: Option<usize>,
     max_depth: Option<usize>,
 ) -> AtspiTreeResult {
-    // Native AT-SPI (most complete).
-    if let Ok(Some((raw_md, nodes))) = native::walk_tree_bounded(pid, max_elements, max_depth) {
-        if !raw_md.is_empty() {
-            let md = if let Some(q) = query { filter_tree(&raw_md, q) } else { raw_md };
-            return AtspiTreeResult { tree_markdown: md, nodes };
+    // Native AT-SPI (most complete). On a COLD launch the Qt6 (and some GTK)
+    // AT-SPI bridge registers lazily — the first walk against a freshly
+    // launched app can come back with just the root window (element_count=1,
+    // no children) because `org.a11y.atspi.Registry` hasn't finished
+    // enumerating the app's tree yet. Retry a few times with a short backoff
+    // while the tree is suspiciously root-only, so the first get_window_state
+    // after launch returns the real tree instead of an empty one. See #1927.
+    const MAX_ATTEMPTS: usize = 4;
+    for attempt in 0..MAX_ATTEMPTS {
+        if let Ok(Some((raw_md, nodes))) = native::walk_tree_bounded(pid, max_elements, max_depth) {
+            // `nodes.len() <= 1` == only the root window resolved: the
+            // cold-registry symptom. Accept any real tree immediately; only
+            // keep waiting on the degenerate case, and accept it anyway on the
+            // final attempt rather than discarding a (minimal) valid result.
+            if !raw_md.is_empty() && (nodes.len() > 1 || attempt == MAX_ATTEMPTS - 1) {
+                let md = if let Some(q) = query { filter_tree(&raw_md, q) } else { raw_md };
+                return AtspiTreeResult { tree_markdown: md, nodes };
+            }
+        }
+        if attempt < MAX_ATTEMPTS - 1 {
+            std::thread::sleep(std::time::Duration::from_millis(150));
         }
     }
 


### PR DESCRIPTION
## Problem

On Linux, `get_window_state` against a Qt6 app launched as the **first / only** accessibility client sometimes returns just the root window (`element_count=1`, empty tree). The full tree (e.g. 155 elements) appears only once `org.a11y.atspi.Registry` is already active. Qt6 has the AT-SPI bridge built in, but registration is timing-sensitive on a cold launch. Fixes #1927.

## Root cause

`atspi::walk_tree_bounded` returned as soon as `native::walk_tree` produced **non-empty** markdown — and a root-only tree (the window node with no children) *is* non-empty, so the degenerate cold-start result was accepted and returned.

## Fix

Retry the native walk up to **4 times with a 150 ms backoff** while the tree is root-only (`nodes.len() <= 1`), giving the registry time to finish enumerating the app. Any tree with real content is accepted on the first attempt; the root-only result is still accepted on the final attempt rather than discarded (and the existing X11-properties fallback remains for the truly-empty case). Latency is added **only** on the cold-start path — a populated window returns immediately.

This implements the issue's "retry/wait briefly for the tree to populate when it comes back with only the root" direction. (A more proactive option — having the daemon pre-activate the registry / `toolkit-accessibility` at startup — is left as a possible follow-up.)

## Verification

- **Build-verified on Linux**: `cargo build -p platform-linux` recompiled green at commit `b37d7cc`.
- The cold-launch race is timing-dependent (needs a freshly-launched Qt6 app as the first AT-SPI client); the change is a bounded retry around the existing walk and is safe for the populated case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of accessibility tree detection on Linux by implementing retry logic for initial service queries, ensuring more complete initialization during application startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->