### PR TITLE
fix(cua-driver/linux): auto-discover XAUTHORITY for SSH-driven Wayland+Xwayland (#1926)

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/src/main.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/main.rs
@@ -799,6 +799,11 @@ fn build_registry(cursor_cfg: cursor_overlay::CursorConfig) -> cua_driver_core::
         cua_driver_core::video::set_video_backend_factory(
             Box::new(cua_driver_core::video_ffmpeg::FfmpegVideoBackendFactory),
         );
+        // SSH-driven Wayland+Xwayland sessions inherit DISPLAY but not
+        // XAUTHORITY; adopt the running X server's auth cookie so X11 tools
+        // don't all fail "Authorization required" (#1926). No-op when
+        // XAUTHORITY is already set or there's no DISPLAY.
+        platform_linux::xauth::ensure_xauthority_discovered();
         // Turn on Chromium/Electron (and GTK/Qt) accessibility for the session
         // so their AT-SPI trees are visible to get_window_state. Best-effort and
         // idempotent; only on the serve path, not for short-lived CLI calls.

--- a/libs/cua-driver/rust/crates/platform-linux/src/health_report.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/health_report.rs
@@ -133,7 +133,16 @@ async fn check_ax_capability() -> CheckEntry {
             "X11 reachable; AT-SPI + XSendEvent input will work.",
         );
     }
-    let hint = if std::env::var_os("WAYLAND_DISPLAY").is_some() {
+    let display_set = std::env::var_os("DISPLAY").is_some();
+    let xauth_unset = std::env::var_os("XAUTHORITY").is_none();
+    let hint = if display_set && xauth_unset {
+        // SSH-driven Wayland+Xwayland: DISPLAY inherited but no auth cookie (#1926).
+        "DISPLAY is set but XAUTHORITY is not (typical when driving a \
+         Wayland+Xwayland session over SSH): the X server's per-session auth \
+         cookie isn't discoverable, so X11 connects fail 'Authorization required'. \
+         Point XAUTHORITY at the Xwayland '-auth' cookie file, or restart the \
+         cua-driver daemon — it auto-discovers the cookie from /proc at startup."
+    } else if std::env::var_os("WAYLAND_DISPLAY").is_some() {
         "Pure Wayland session: opt into the experimental Wayland backend by \
          setting CUA_DRIVER_RS_ENABLE_WAYLAND=1, or run the target under XWayland."
     } else {

--- a/libs/cua-driver/rust/crates/platform-linux/src/lib.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/lib.rs
@@ -48,6 +48,9 @@ pub mod wayland;
 // Keeping it un-gated lets the unit tests run on any host.
 pub mod terminal;
 
+#[cfg(target_os = "linux")]
+pub mod xauth;
+
 pub fn register_tools() -> ToolRegistry {
     #[cfg(target_os = "linux")]
     wayland::ensure_nested_session();

--- a/libs/cua-driver/rust/crates/platform-linux/src/xauth.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/xauth.rs
@@ -1,0 +1,81 @@
+//! Xwayland `XAUTHORITY` auto-discovery for SSH-driven Wayland sessions.
+//!
+//! When cua-driver is driven over SSH against a Wayland+Xwayland desktop,
+//! `DISPLAY` is typically inherited (e.g. `:0`) but `XAUTHORITY` is not.
+//! Xwayland authenticates X11 clients with a per-session MIT cookie passed to
+//! it via its own `-auth <file>` argument, which an X11 client cannot guess —
+//! so every X11 connect fails with "Authorization required, but no
+//! authorization protocol specified" (empty `list_windows`, failing
+//! `get_screen_size` / `get_cursor_position`, overlay connect errors). See
+//! issue #1926.
+//!
+//! [`ensure_xauthority_discovered`] recovers the cookie by reading the running
+//! Xwayland (or Xorg) process's `-auth` argument out of `/proc` and exporting
+//! it as `XAUTHORITY` before the first X11 connect. It is a no-op when
+//! `XAUTHORITY` is already set or there is no `DISPLAY`, and runs at most once.
+
+use std::sync::OnceLock;
+
+static DONE: OnceLock<()> = OnceLock::new();
+
+/// Discover and export `XAUTHORITY` from the running X server's `-auth`
+/// argument when it is unset on a session that has a `DISPLAY`. Idempotent
+/// (runs once per process) and safe to call eagerly at daemon startup.
+pub fn ensure_xauthority_discovered() {
+    DONE.get_or_init(|| {
+        // Already have an explicit cookie, or no X11 DISPLAY to authenticate
+        // against — nothing to do.
+        if std::env::var_os("XAUTHORITY").is_some() {
+            return;
+        }
+        if std::env::var_os("DISPLAY").is_none() {
+            return;
+        }
+        if let Some(auth) = discover_xauth_from_proc() {
+            // SAFETY: set early at startup, before any X11 connect / worker
+            // thread reads the environment.
+            std::env::set_var("XAUTHORITY", &auth);
+            tracing::info!(
+                target: "cua-driver",
+                "XAUTHORITY was unset; adopted the running X server's auth cookie at {auth} (#1926)"
+            );
+        } else {
+            tracing::debug!(
+                target: "cua-driver",
+                "XAUTHORITY unset and no X server -auth cookie found in /proc; \
+                 X11 connects may fail with 'Authorization required' (#1926)"
+            );
+        }
+    });
+}
+
+/// Scan `/proc` for an X server process (`Xwayland`, `Xorg`, or `X`) and return
+/// the existing file named by its `-auth <file>` argument, if any.
+fn discover_xauth_from_proc() -> Option<String> {
+    let proc_dir = std::fs::read_dir("/proc").ok()?;
+    for entry in proc_dir.flatten() {
+        let pid_dir = entry.path();
+        // `comm` is the (possibly truncated) executable name + trailing newline.
+        let comm = std::fs::read_to_string(pid_dir.join("comm")).unwrap_or_default();
+        match comm.trim() {
+            "Xwayland" | "Xorg" | "X" => {}
+            _ => continue,
+        }
+        // `cmdline` is NUL-separated argv. Find `-auth` and take the next arg.
+        let cmdline = match std::fs::read(pid_dir.join("cmdline")) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let args: Vec<&[u8]> = cmdline.split(|&b| b == 0).collect();
+        for pair in args.windows(2) {
+            if pair[0] == b"-auth" {
+                if let Ok(path) = std::str::from_utf8(pair[1]) {
+                    if !path.is_empty() && std::path::Path::new(path).exists() {
+                        return Some(path.to_owned());
+                    }
+                }
+            }
+        }
+    }
+    None
+}


### PR DESCRIPTION
## Problem

Driving a Wayland+Xwayland desktop over SSH fails: `DISPLAY` is inherited (e.g. `:0`) but `XAUTHORITY` is not, so every X11 tool errors `X11 setup failed: 'Authorization required, but no authorization protocol specified'` — `list_windows` empty, `get_screen_size` / `get_cursor_position` fail, `serve` logs an overlay connect error. Xwayland uses a per-session auth cookie passed via its own `-auth` argument that X11 clients can't auto-discover. Worse, `doctor` reported the display server "ok" and only the first tool call revealed the failure. Fixes #1926.

## Fix

**Auto-discover the cookie (the functional fix).** New `platform_linux::xauth::ensure_xauthority_discovered()`: when `XAUTHORITY` is unset and a `DISPLAY` is present, scan `/proc` for the running X server (`Xwayland` / `Xorg` / `X`), parse its `-auth <file>` argument from `cmdline`, and export it as `XAUTHORITY`. Idempotent (runs once), and a no-op when `XAUTHORITY` is already set or there's no `DISPLAY`. Called once at daemon startup, before any X11 connect.

**Make doctor actionable.** When X11 is unreachable with `DISPLAY` set but `XAUTHORITY` unset, the `ax_capability` check now hints at the Xwayland `-auth` cookie / daemon restart instead of the generic Wayland message.

## Verification

- **Build-verified on Linux**: `cargo build -p cua-driver` recompiled green at commit `a070468` (covers the new module + the `main.rs` startup wiring).
- The `/proc` `-auth` parse is deterministic and gated to only act when `XAUTHORITY` is unset (safe/additive). Full end-to-end confirmation needs a Wayland+Xwayland session driven over SSH, which the headless build host can't provide — calling that out rather than claiming a runtime pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed X11 authentication discovery in SSH sessions, preventing accessibility tool registration failures.
  * Improved error diagnostics with clearer messaging when X server authentication is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->