### PR TITLE
ci(cua-driver-rs): gate Linux release bumps on the harness suite (Phase 0)

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -17,6 +17,10 @@ on:
       - 'libs/cua-driver/rust/**'
       - '.github/workflows/nix-build.yml'
   workflow_dispatch:
+  # Callable as the Linux release-gate preamble from release-bump-version.yml:
+  # the bump action runs THIS exact suite against the release commit before any
+  # bump/tag/publish. See RELEASE_TEST_GATE_PLAN.md (Phase 0).
+  workflow_call:
 
 permissions:
   id-token: write
@@ -33,6 +37,10 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # Quarantine known-flaky jobs (matrix `allow_failure: true`): they still run
+    # and upload artifacts, but a failure does NOT fail the workflow — so a flake
+    # can't block a PR merge OR the release gate. De-flake then remove the flag.
+    continue-on-error: ${{ matrix.allow_failure || false }}
     strategy:
       fail-fast: false
       matrix:
@@ -51,6 +59,7 @@ jobs:
             artifact_name: ""
           - name: Linux cursor click GIF test
             check_attr: cua-driver-linux-cursor-click-gif
+            allow_failure: true  # known-flaky (GIF timing) — quarantined; de-flake + remove
             timeout_minutes: 12
             visual: true
             result_link: result-linux-cursor-click-gif

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -50,12 +50,41 @@ on:
         required: false
         type: string
         default: "main"
+      force_release:
+        description: "EMERGENCY: bypass the cua-driver-rs Linux harness gate (audited). Use only when the gate is blocked by infra, not failing tests."
+        required: false
+        type: boolean
+        default: false
 
+# `id-token`/`pull-requests` are needed by the reusable nix-build harness gate
+# (AWS OIDC for the Nix cache); `contents: write` is for the bump commit + tag.
 permissions:
   contents: write
+  id-token: write
+  pull-requests: write
 
 jobs:
+  # ── Linux release gate (Phase 0) ─────────────────────────────────────────────
+  # For cua-driver-rs ONLY: actually RUN the Linux harness suite against the
+  # exact commit being released, BEFORE any bump/tag/publish. We re-run the suite
+  # (rather than query prior PR CI) so the gate tests the precise bits being
+  # shipped and can't be fooled by stale evidence or the auto-on-merge path.
+  # Calls the same nix-build.yml the PR gate uses, so the two never diverge.
+  # Skipped for every non-cua-driver-rs service and when force_release is set.
+  # Windows/macOS gates land later on self-hosted runners. See
+  # RELEASE_TEST_GATE_PLAN.md.
+  harness-preamble:
+    name: "Release gate: Linux harness suite"
+    if: ${{ inputs.service == 'cua-driver-rs' && !inputs.force_release }}
+    uses: ./.github/workflows/nix-build.yml
+    secrets: inherit
+
   bump-version:
+    needs: [harness-preamble]
+    # Proceed when the gate passed, was skipped (non-cua-driver-rs service), or
+    # was explicitly bypassed. A FAILED gate (cua-driver-rs with real test
+    # failures) blocks the bump → no tag, no publish.
+    if: ${{ always() && (needs.harness-preamble.result == 'success' || needs.harness-preamble.result == 'skipped' || inputs.force_release) }}
     runs-on: ubuntu-latest
     steps:
       - name: Set package directory and type


### PR DESCRIPTION
Phase 0 of the cua-driver-rs release test-gate (see `RELEASE_TEST_GATE_PLAN.md`). **Linux only.** Draft until validated by a CI dry-run (reusable-workflow + OIDC perms + conditional `needs` can only be confirmed live).

## What

Two gates, distinct jobs:
1. **PR required checks** (branch protection, configured separately) — the merge gate.
2. **A harness preamble inside the bump action** (this PR) — the release gate: `release-bump-version.yml` now **runs the Linux harness suite against the exact release commit** before `bump-version`. Red suite ⇒ no bump ⇒ no tag ⇒ no publish.

## How

- **`nix-build.yml`**: add `workflow_call` so the bump action can invoke the *same* suite the PR gate runs (no divergence between merge-gate and release-gate). Quarantine the known-flaky `cursor-click-gif` (`allow_failure: true` + job-level `continue-on-error`) so a flake can't block a PR merge or a release. *De-flake and remove the flag as a follow-up.*
- **`release-bump-version.yml`**:
  - `harness-preamble` job → `uses: ./.github/workflows/nix-build.yml`, gated `if: service == 'cua-driver-rs' && !force_release` (skipped for all other services).
  - `bump-version` `needs: [harness-preamble]`, proceeds on `success || skipped || force_release`.
  - `force_release` boolean input — audited emergency bypass for when the gate is blocked by *infra*, not failing tests.
  - `+id-token: write` / `+pull-requests: write` perms (the reusable gate's AWS-OIDC Nix cache needs them).

## Why re-run, not query

The PR's checks ran against the PR head, not the post-squash `main` commit that gets tagged. Querying the Checks API can pass on stale evidence (main moved, or the merge commit's CI hasn't finished). Re-running against the release commit tests the precise artifact. Cost: extra latency + duplicate compute at release time — acceptable for an infrequent patch release.

## Validate before un-drafting

1. Dispatch `release-bump-version` with a **non-cua-driver-rs** service → `harness-preamble` is **skipped**, `bump-version` proceeds (no regression for other packages).
2. Dispatch with `service=cua-driver-rs` on a branch with a **deliberately broken** harness → `bump-version` is **blocked** (no tag).
3. Same, healthy branch → suite passes, bump proceeds.
4. `force_release=true` → preamble skipped, bump proceeds (confirm it's audited in the run log).

## Limitations / follow-ups

- The preamble tests the **ref the bump runs on** (normally `main`); if `target_branch` differs from the dispatch ref, it'd test the wrong commit — fine for the common case, worth hardening later.
- **Windows/macOS** gates need self-hosted interactive runners → later phases.
- **#1969** (post-publish distro-compat smoke) is still separate — the preamble gates the *source*, not the *published binary*.
- De-flake `cursor-click-gif` and drop the quarantine flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)