### PR TITLE
fix(cua-driver): Linux list_windows emits `bounds` for cross-platform parity (#2017)

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -320,14 +320,74 @@ impl Tool for ListWindowsTool {
             lines.push(format!("  [xid={}] pid={:?} \"{}\" {}x{}+{}+{}",
                 w.xid, w.pid, w.title, w.width, w.height, w.x, w.y));
         }
-        let structured = json!({ "windows": windows.iter().map(|w| json!({
-            "window_id": w.xid,
-            "pid": w.pid,
-            "title": w.title,
-            "x": w.x, "y": w.y,
-            "width": w.width, "height": w.height,
-        })).collect::<Vec<_>>() });
+        let structured = json!({ "windows": windows.iter().map(window_record_json).collect::<Vec<_>>() });
         ToolResult::text(lines.join("\n")).with_structured(structured)
+    }
+}
+
+/// Build the structured `list_windows` record for one Linux window.
+///
+/// Emits the canonical cross-platform shape — geometry nested under a
+/// `bounds: {x,y,width,height}` object plus `app_name` / `is_on_screen`,
+/// matching the macOS and Windows backends (#2017) — while KEEPING the
+/// historical flat `x/y/width/height` fields inline as a legacy alias so
+/// existing Linux callers don't break. Fully additive; no field removed,
+/// no schema_version bump.
+///
+/// The Linux `WindowInfo` struct (see `crate::x11::WindowInfo`) exposes
+/// neither an app name nor a visibility flag, so `app_name` is an empty
+/// string and `is_on_screen` defaults to `true` — the same best-effort
+/// default the Windows backend uses.
+fn window_record_json(w: &crate::x11::WindowInfo) -> Value {
+    json!({
+        "window_id": w.xid,
+        "pid": w.pid,
+        "app_name": "",
+        "title": w.title,
+        // Canonical cross-platform geometry (macOS/Windows parity).
+        "bounds": { "x": w.x, "y": w.y, "width": w.width, "height": w.height },
+        "is_on_screen": true,
+        // Legacy alias: flat fields kept inline for pre-existing callers.
+        "x": w.x, "y": w.y,
+        "width": w.width, "height": w.height,
+    })
+}
+
+#[cfg(test)]
+mod list_windows_tests {
+    use super::*;
+
+    #[test]
+    fn record_has_bounds_and_flat_legacy_fields() {
+        let w = crate::x11::WindowInfo {
+            xid: 42,
+            pid: Some(1234),
+            title: "Example".to_owned(),
+            x: 10,
+            y: 20,
+            width: 300,
+            height: 400,
+        };
+        let rec = window_record_json(&w);
+
+        // Canonical cross-platform shape: nested `bounds` object.
+        let bounds = rec.get("bounds").expect("record must carry a `bounds` object");
+        assert_eq!(bounds["x"], json!(10));
+        assert_eq!(bounds["y"], json!(20));
+        assert_eq!(bounds["width"], json!(300));
+        assert_eq!(bounds["height"], json!(400));
+
+        // Legacy alias: flat fields must still be present.
+        assert_eq!(rec["x"], json!(10));
+        assert_eq!(rec["y"], json!(20));
+        assert_eq!(rec["width"], json!(300));
+        assert_eq!(rec["height"], json!(400));
+
+        // Cross-platform companions.
+        assert_eq!(rec["app_name"], json!(""));
+        assert_eq!(rec["is_on_screen"], json!(true));
+        assert_eq!(rec["window_id"], json!(42));
+        assert_eq!(rec["title"], json!("Example"));
     }
 }
 


### PR DESCRIPTION
cat <<'EOF'
Fixes #2017.

## What

`list_windows` returned window geometry under a nested `bounds: {x,y,width,height}` object on macOS and Windows, but as flat top-level `x/y/width/height` on Linux (and omitted `app_name` / `is_on_screen`). Any cross-platform consumer reading `window.bounds.width` worked on macOS/Windows and silently broke on Linux. This surfaced while wiring a Gemini `computers/desktop` backend, which had to add a `_window_dims()` shim purely to tolerate the two shapes.

## How

In `crates/platform-linux/src/tools/impl_.rs`, each `list_windows` record now emits:

- `bounds: { x, y, width, height }` — the canonical cross-platform field, matching macOS/Windows
- `app_name` and `is_on_screen` — companion fields the other backends already emit
- the historical flat `x/y/width/height` fields, **kept inline as a legacy alias** so existing Linux callers don't break (mirrors the additive pattern Windows uses)

The per-record JSON is extracted into a `window_record_json` helper, with a no-display unit test asserting both the nested `bounds` and the flat legacy fields are present.

### Defaults

`app_name` is `""` and `is_on_screen` is `true`. The Linux `WindowInfo` struct (`crate::x11::WindowInfo`) exposes only `xid, pid, title, x, y, width, height` — no app-name or visibility field — so these are best-effort defaults matching the Windows backend. No new lookup was invented.

### Schema

Purely additive — no field removed — so `schema_version` is **not** bumped.

## Testing

- Added `list_windows_tests::record_has_bounds_and_flat_legacy_fields` (synthetic `WindowInfo`, no display required).
- ⚠️ Could not run `cargo check -p platform-linux` on the macOS dev host: the `x11` crate's build script fails cross-compiling to `x86_64-unknown-linux-gnu` ("pkg-config has not been configured to support cross-compilation"). Manual review confirms the Rust is sound (imports, field accesses, `json!` macro, balanced braces). **Needs CI / a Linux box to confirm the build + run the test.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMXCW4M5uK1HRGjjH4wueZ
EOF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Window listings on Linux now include a standardized `bounds` object for each window, making window geometry consistent across platforms.
  * Each window record now also includes `app_name` and `is_on_screen` fields.

* **Bug Fixes**
  * Kept the older flat `x`, `y`, `width`, and `height` fields in place for compatibility with existing Linux integrations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->