### PR TITLE
fix(cua-driver/linux): stop reporting bare "✅ Clicked" for X11 synthetic clicks (#2022)

### DIFF
--- a/libs/cua-driver/rust/Skills/cua-driver/LINUX.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/LINUX.md
@@ -83,7 +83,7 @@ ask the user.
 | Intent | Status |
 |---|---|
 | Snapshot AT-SPI tree | ✅ GTK3/4, Qt5/6, wxWidgets, Electron (GTK4/Qt6 can be partial — re-snapshot) |
-| Pixel click | ✅ background `XSendEvent`, no focus steal, no pointer move |
+| Pixel click | ✅ background `XSendEvent`, no focus steal, no pointer move — but GTK menus/popups, SDL and Allegro filter synthetic events, so prefer **element-indexed click** for those (trycua/cua#2022) |
 | Element-indexed click | ✅ AT-SPI `do_action` |
 | Type text | ✅ AT-SPI focus-free, with XTest / pty fallback for the focused widget |
 | Hotkey / `press_key` | ✅ |

--- a/libs/cua-driver/rust/crates/platform-linux/src/input/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/input/mod.rs
@@ -10,6 +10,15 @@
 //! `crate::tty`. We deliberately do NOT fall back to the XTest extension for
 //! them, because XTest delivers to the *focused* window and would break the
 //! no-focus-steal contract.
+//!
+//! The same `send_event`-filtering bites *pointer* clicks too: GTK menus/popups
+//! under a grab, SDL, and Allegro drop the synthetic button events from
+//! [`send_click`], so a `click` is dispatched but never reaches the app — while
+//! `keyboard` input was migrated to XTEST in #1805. We can't confirm pointer
+//! delivery per click on this path, so the `click` tool no longer reports a bare
+//! "✅ Clicked" for it and points callers at the reliable AT-SPI `element_index`
+//! route (see `tools::impl_::coord_click_result_text`). Making the click itself
+//! land focus-free is tracked in trycua/cua#2022.
 
 use anyhow::{anyhow, bail, Context, Result};
 use std::collections::HashMap;

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -943,6 +943,33 @@ fn inject_terminal_input(pid: u32, xid: u64, text: &str) -> anyhow::Result<bool>
 
 // ── click ─────────────────────────────────────────────────────────────────────
 
+/// Build the result text for a coordinate-based `click`.
+///
+/// X11 clicks are injected with `XSendEvent`, whose events carry a `send_event`
+/// flag that some toolkits deliberately ignore — GTK menus/popups while they
+/// hold a pointer grab, SDL, and Allegro are the known cases. On that path the
+/// event is dispatched but may never reach the application, and we cannot
+/// confirm delivery per click. Reporting a bare "✅ Clicked" there reads as
+/// guaranteed success, so the X11 path instead exposes the uncertainty and
+/// points at the reliable AT-SPI route. The Wayland virtual-pointer path and
+/// the AT-SPI `element_index` path deliver for real, so they keep the plain
+/// success line.
+///
+/// See trycua/cua#2022 — the pointer counterpart of the keyboard
+/// XSendEvent→XTEST migration in #1805.
+fn coord_click_result_text(x: f64, y: f64, count: usize, x11_synthetic: bool) -> String {
+    let base = format!("✅ Clicked at ({x:.1}, {y:.1}) × {count}.");
+    if x11_synthetic {
+        format!(
+            "{base} (X11 synthetic event — GTK menus/popups, SDL and Allegro may \
+             ignore it; if the target didn't respond, retry it via element_index \
+             for AT-SPI delivery.)"
+        )
+    } else {
+        base
+    }
+}
+
 pub struct ClickTool {
     state: Arc<ToolState>,
 }
@@ -1122,10 +1149,44 @@ impl Tool for ClickTool {
             crate::input::send_click(xid, xi, yi, count, button)
         }).await;
         match result {
-            Ok(Ok(())) => ToolResult::text(format!("✅ Clicked at ({x:.1}, {y:.1}) × {count}.")),
+            Ok(Ok(())) => ToolResult::text(coord_click_result_text(
+                x,
+                y,
+                count,
+                !crate::wayland::is_wayland(),
+            )),
             Ok(Err(e)) => ToolResult::error(e.to_string()),
             Err(e) => ToolResult::error(format!("Task error: {e}")),
         }
+    }
+}
+
+#[cfg(test)]
+mod coord_click_result_text_tests {
+    use super::coord_click_result_text;
+
+    #[test]
+    fn x11_synthetic_path_exposes_delivery_uncertainty() {
+        let msg = coord_click_result_text(12.0, 34.5, 1, true);
+        // Keeps the actionable facts an agent already relies on…
+        assert!(msg.contains("(12.0, 34.5)"), "keeps coordinates: {msg}");
+        assert!(msg.contains("× 1"), "keeps count: {msg}");
+        // …and stops asserting delivery: names the mechanism and the reliable route.
+        assert!(
+            msg.to_ascii_lowercase().contains("synthetic"),
+            "names the delivery mechanism: {msg}"
+        );
+        assert!(
+            msg.contains("element_index"),
+            "points at the reliable AT-SPI route: {msg}"
+        );
+    }
+
+    #[test]
+    fn delivering_paths_keep_plain_success() {
+        // Wayland virtual-pointer / AT-SPI element paths deliver for real.
+        let msg = coord_click_result_text(12.0, 34.0, 2, false);
+        assert_eq!(msg, "✅ Clicked at (12.0, 34.0) × 2.");
     }
 }
 


### PR DESCRIPTION
## Summary

First, conservative step on #2022. On Linux/X11 the pixel `click` tool injects
`ButtonPress`/`ButtonRelease` via `XSendEvent`, whose events carry a
`send_event = True` flag that some toolkits deliberately ignore — GTK
menus/popups while they hold a pointer grab, SDL, and Allegro are the known
cases. The synthetic click is dispatched but never reaches the application's
event loop, yet the driver returned a bare `✅ Clicked at (x, y)`. Same silent
false-success the project already treats as a real bug for the keyboard
(#1805, XSendEvent→XTEST) and for Wayland (#1921→#1994, #1982→#1992) — but here
the cause is the `send_event` flag on X11.

This PR does **not** try to make the click land (that's #2022's real fix, which
needs the no-focus-steal machinery — MPX master + shield grabs — already used by
`parallel_mouse_drag`). It just stops over-claiming: on the X11 synthetic path
the `click` result now names the delivery mechanism and points at the reliable
AT-SPI `element_index` route. The Wayland virtual-pointer path and the AT-SPI
element-click path deliver for real, so they keep the plain success line.

## Why message-only, and why not gated per-app

`XSendEvent` gives no per-click delivery confirmation, so — unlike the Wayland
"no `$DISPLAY`" case in #1994 — we can't *know* a given click was dropped. A
WM_CLASS deny-list (mirroring `terminal.rs`) was considered but rejected: this
repo has no SDL/Allegro fixtures to seed accurate `WM_CLASS` substrings from, and
guessing them would be worse than honest. So the caveat is attached to the whole
X11 synthetic path. Happy to narrow it (e.g. gate on "target exposes no AT-SPI
tree", or a seeded deny-list once real `WM_CLASS` samples exist) if you'd prefer.

## Changes

- `tools/impl_::coord_click_result_text(x, y, count, x11_synthetic)` — pure,
  unit-tested message builder. Plain `✅ Clicked …` when the click was delivered
  by a path that actually lands (Wayland / AT-SPI element); on the X11 synthetic
  path it appends the uncertainty + the `element_index` remediation.
- `ClickTool` coordinate path passes `!wayland::is_wayland()` as `x11_synthetic`.
- Two unit tests (run on the Linux CI; the crate is `cfg(target_os = "linux")`).
- Doc: `input/mod.rs` module comment now records the pointer-click limitation
  (counterpart to the existing keyboard/terminal note) and cross-refs #2022;
  `LINUX.md` capability table no longer presents pixel click as unconditionally
  reliable.

## Verification

The message builder was compiled and checked at the workspace edition (2021,
clean). The crate is `cfg(target_os = "linux")` and **cannot be built on the
macOS box this was authored on** — the Linux compile of the call site + the unit
tests rely on this PR's CI. Opening as **draft** until CI is green.

Refs #2022. Related: #1805 (keyboard XTEST), #1994/#1992 (Wayland fail-loud).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Linux click behavior for background input, including cases where synthetic clicks may be ignored by some apps.
  * Added guidance to use element-based clicking when coordinate clicks are unreliable.

* **Bug Fixes**
  * Updated click status messages to better reflect when a click may not reach the target.
  * Preserved the standard success message for normal click paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->