### PR TITLE
fix(qemu-windows): launch Windows instances to a blank desktop

### DIFF
--- a/libs/qemu-docker/windows/src/vm/setup/setup-cua-server.ps1
+++ b/libs/qemu-docker/windows/src/vm/setup/setup-cua-server.ps1
@@ -26,8 +26,8 @@ Write-Log -LogFile $script:LogFile -Message "Applying blank desktop hardening...
 # modal onto the desktop on every boot.
 try {
   $reliability = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Reliability'
-  New-Item -Path $reliability -Force -ErrorAction SilentlyContinue | Out-Null
-  Set-ItemProperty -Path $reliability -Name 'ShutdownReasonOn' -Value 0 -Type DWord
+  New-Item -Path $reliability -Force -ErrorAction Stop | Out-Null
+  Set-ItemProperty -Path $reliability -Name 'ShutdownReasonOn' -Value 0 -Type DWord -ErrorAction Stop
   Write-Log -LogFile $script:LogFile -Message "Shutdown Event Tracker disabled"
 } catch {
   Write-Log -LogFile $script:LogFile -Message "Shutdown Event Tracker warning: $($_.Exception.Message)"
@@ -36,10 +36,10 @@ try {
 # Disable Edge first-run experience and startup boost (Edge opens on first login otherwise)
 try {
   $edgePolicies = 'HKLM:\SOFTWARE\Policies\Microsoft\Edge'
-  New-Item -Path $edgePolicies -Force -ErrorAction SilentlyContinue | Out-Null
-  Set-ItemProperty -Path $edgePolicies -Name 'HideFirstRunExperience' -Value 1 -Type DWord
-  Set-ItemProperty -Path $edgePolicies -Name 'StartupBoostEnabled' -Value 0 -Type DWord
-  Set-ItemProperty -Path $edgePolicies -Name 'BackgroundModeEnabled' -Value 0 -Type DWord
+  New-Item -Path $edgePolicies -Force -ErrorAction Stop | Out-Null
+  Set-ItemProperty -Path $edgePolicies -Name 'HideFirstRunExperience' -Value 1 -Type DWord -ErrorAction Stop
+  Set-ItemProperty -Path $edgePolicies -Name 'StartupBoostEnabled' -Value 0 -Type DWord -ErrorAction Stop
+  Set-ItemProperty -Path $edgePolicies -Name 'BackgroundModeEnabled' -Value 0 -Type DWord -ErrorAction Stop
   Write-Log -LogFile $script:LogFile -Message "Edge first-run and startup boost disabled"
 } catch {
   Write-Log -LogFile $script:LogFile -Message "Edge policy warning: $($_.Exception.Message)"
@@ -47,10 +47,11 @@ try {
 
 # Disable OneDrive from launching at startup
 try {
+  # OneDrive entry may not exist; suppress the not-found error specifically
   Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name 'OneDrive' -ErrorAction SilentlyContinue
   $oneDrivePolicies = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\OneDrive'
-  New-Item -Path $oneDrivePolicies -Force -ErrorAction SilentlyContinue | Out-Null
-  Set-ItemProperty -Path $oneDrivePolicies -Name 'DisableFileSyncNGSC' -Value 1 -Type DWord
+  New-Item -Path $oneDrivePolicies -Force -ErrorAction Stop | Out-Null
+  Set-ItemProperty -Path $oneDrivePolicies -Name 'DisableFileSyncNGSC' -Value 1 -Type DWord -ErrorAction Stop
   Write-Log -LogFile $script:LogFile -Message "OneDrive startup disabled"
 } catch {
   Write-Log -LogFile $script:LogFile -Message "OneDrive startup warning: $($_.Exception.Message)"
@@ -59,20 +60,15 @@ try {
 # Disable Windows Security notification icon from appearing on the desktop
 try {
   $notifications = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows Defender Security Center\Notifications'
-  New-Item -Path $notifications -Force -ErrorAction SilentlyContinue | Out-Null
-  Set-ItemProperty -Path $notifications -Name 'DisableNotifications' -Value 1 -Type DWord
+  New-Item -Path $notifications -Force -ErrorAction Stop | Out-Null
+  Set-ItemProperty -Path $notifications -Name 'DisableNotifications' -Value 1 -Type DWord -ErrorAction Stop
   Write-Log -LogFile $script:LogFile -Message "Windows Security notifications disabled"
 } catch {
   Write-Log -LogFile $script:LogFile -Message "Security notifications warning: $($_.Exception.Message)"
 }
-
-# Suppress "Windows needs your current credentials" / Network Location Wizard prompts
-try {
-  Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Lsa' -Name 'LimitBlankPasswordUse' -Value 0 -Type DWord -ErrorAction SilentlyContinue
-  Write-Log -LogFile $script:LogFile -Message "Blank password restriction disabled"
-} catch {
-  Write-Log -LogFile $script:LogFile -Message "Blank password warning: $($_.Exception.Message)"
-}
+# Note: LimitBlankPasswordUse is intentionally NOT modified here.
+# Disabling the blank-password restriction (setting it to 0) weakens system security
+# and is not required for a blank desktop. The default value (1) is preserved.
 
 Write-Log -LogFile $script:LogFile -Message "Blank desktop hardening applied"
 

--- a/libs/qemu-docker/windows/src/vm/setup/setup-cua-server.ps1
+++ b/libs/qemu-docker/windows/src/vm/setup/setup-cua-server.ps1
@@ -16,6 +16,66 @@ $script:LogFile = Join-Path $LogDir ("setup_cua_server_" + $RunId + ".log")
 
 Write-Log -LogFile $script:LogFile -Message "=== Installing Cua Computer Server ==="
 
+# --- Blank Desktop Hardening ---
+# Prevent various Windows UI elements and startup apps from appearing at login,
+# ensuring instances launch to a clean blank desktop.
+Write-Log -LogFile $script:LogFile -Message "Applying blank desktop hardening..."
+
+# Disable the Shutdown Event Tracker ("Why did the computer shut down unexpectedly?").
+# The VM is force-stopped between sessions, so Windows would otherwise pop this
+# modal onto the desktop on every boot.
+try {
+  $reliability = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Reliability'
+  New-Item -Path $reliability -Force -ErrorAction SilentlyContinue | Out-Null
+  Set-ItemProperty -Path $reliability -Name 'ShutdownReasonOn' -Value 0 -Type DWord
+  Write-Log -LogFile $script:LogFile -Message "Shutdown Event Tracker disabled"
+} catch {
+  Write-Log -LogFile $script:LogFile -Message "Shutdown Event Tracker warning: $($_.Exception.Message)"
+}
+
+# Disable Edge first-run experience and startup boost (Edge opens on first login otherwise)
+try {
+  $edgePolicies = 'HKLM:\SOFTWARE\Policies\Microsoft\Edge'
+  New-Item -Path $edgePolicies -Force -ErrorAction SilentlyContinue | Out-Null
+  Set-ItemProperty -Path $edgePolicies -Name 'HideFirstRunExperience' -Value 1 -Type DWord
+  Set-ItemProperty -Path $edgePolicies -Name 'StartupBoostEnabled' -Value 0 -Type DWord
+  Set-ItemProperty -Path $edgePolicies -Name 'BackgroundModeEnabled' -Value 0 -Type DWord
+  Write-Log -LogFile $script:LogFile -Message "Edge first-run and startup boost disabled"
+} catch {
+  Write-Log -LogFile $script:LogFile -Message "Edge policy warning: $($_.Exception.Message)"
+}
+
+# Disable OneDrive from launching at startup
+try {
+  Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name 'OneDrive' -ErrorAction SilentlyContinue
+  $oneDrivePolicies = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\OneDrive'
+  New-Item -Path $oneDrivePolicies -Force -ErrorAction SilentlyContinue | Out-Null
+  Set-ItemProperty -Path $oneDrivePolicies -Name 'DisableFileSyncNGSC' -Value 1 -Type DWord
+  Write-Log -LogFile $script:LogFile -Message "OneDrive startup disabled"
+} catch {
+  Write-Log -LogFile $script:LogFile -Message "OneDrive startup warning: $($_.Exception.Message)"
+}
+
+# Disable Windows Security notification icon from appearing on the desktop
+try {
+  $notifications = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows Defender Security Center\Notifications'
+  New-Item -Path $notifications -Force -ErrorAction SilentlyContinue | Out-Null
+  Set-ItemProperty -Path $notifications -Name 'DisableNotifications' -Value 1 -Type DWord
+  Write-Log -LogFile $script:LogFile -Message "Windows Security notifications disabled"
+} catch {
+  Write-Log -LogFile $script:LogFile -Message "Security notifications warning: $($_.Exception.Message)"
+}
+
+# Suppress "Windows needs your current credentials" / Network Location Wizard prompts
+try {
+  Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Lsa' -Name 'LimitBlankPasswordUse' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+  Write-Log -LogFile $script:LogFile -Message "Blank password restriction disabled"
+} catch {
+  Write-Log -LogFile $script:LogFile -Message "Blank password warning: $($_.Exception.Message)"
+}
+
+Write-Log -LogFile $script:LogFile -Message "Blank desktop hardening applied"
+
 # Ensure Chocolatey and Python 3.12 are present
 try {
   $ChocoExe = Resolve-ChocoPath

--- a/libs/qemu-docker/windows/src/vm/setup/setup.ps1
+++ b/libs/qemu-docker/windows/src/vm/setup/setup.ps1
@@ -42,35 +42,35 @@ Write-Host "Applying blank desktop hardening..."
 # Disable the 'restore previous folder windows on logon' option in Explorer so
 # it doesn't re-open any windows that were visible when the image was captured.
 try {
-    New-Item -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Force -ErrorAction SilentlyContinue | Out-Null
-    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'PersistBrowsers' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    New-Item -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Force -ErrorAction Stop | Out-Null
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'PersistBrowsers' -Value 0 -Type DWord -ErrorAction Stop
     Write-Host "  Explorer: PersistBrowsers disabled"
 } catch { Write-Host "  Explorer PersistBrowsers warning: $($_.Exception.Message)" }
 
 # Disable the 'show recently used files/folders' in Quick Access (cosmetic, but avoids 'File Explorer' pop notification)
 try {
-    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer' -Name 'ShowRecent' -Value 0 -Type DWord -ErrorAction SilentlyContinue
-    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer' -Name 'ShowFrequent' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer' -Name 'ShowRecent' -Value 0 -Type DWord -ErrorAction Stop
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer' -Name 'ShowFrequent' -Value 0 -Type DWord -ErrorAction Stop
     Write-Host "  Explorer: recent/frequent items disabled"
 } catch { Write-Host "  Explorer recent items warning: $($_.Exception.Message)" }
 
 # Disable Windows Widgets (News and Interests) and Chat from taskbar - they can
 # open a popup/panel if clicked accidentally or on first login.
 try {
-    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarDa' -Value 0 -Type DWord -ErrorAction SilentlyContinue
-    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarMn' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarDa' -Value 0 -Type DWord -ErrorAction Stop
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarMn' -Value 0 -Type DWord -ErrorAction Stop
     Write-Host "  Taskbar: Widgets and Chat hidden"
 } catch { Write-Host "  Taskbar widgets warning: $($_.Exception.Message)" }
 
 # Suppress "New features and suggestions" / lock screen app suggestions
 try {
     $cdm = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager'
-    New-Item -Path $cdm -Force -ErrorAction SilentlyContinue | Out-Null
-    Set-ItemProperty -Path $cdm -Name 'SubscribedContent-338393Enabled' -Value 0 -Type DWord -ErrorAction SilentlyContinue
-    Set-ItemProperty -Path $cdm -Name 'SubscribedContent-353696Enabled' -Value 0 -Type DWord -ErrorAction SilentlyContinue
-    Set-ItemProperty -Path $cdm -Name 'SubscribedContent-353694Enabled' -Value 0 -Type DWord -ErrorAction SilentlyContinue
-    Set-ItemProperty -Path $cdm -Name 'SoftLandingEnabled' -Value 0 -Type DWord -ErrorAction SilentlyContinue
-    Set-ItemProperty -Path $cdm -Name 'FeatureManagementEnabled' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    New-Item -Path $cdm -Force -ErrorAction Stop | Out-Null
+    Set-ItemProperty -Path $cdm -Name 'SubscribedContent-338393Enabled' -Value 0 -Type DWord -ErrorAction Stop
+    Set-ItemProperty -Path $cdm -Name 'SubscribedContent-353696Enabled' -Value 0 -Type DWord -ErrorAction Stop
+    Set-ItemProperty -Path $cdm -Name 'SubscribedContent-353694Enabled' -Value 0 -Type DWord -ErrorAction Stop
+    Set-ItemProperty -Path $cdm -Name 'SoftLandingEnabled' -Value 0 -Type DWord -ErrorAction Stop
+    Set-ItemProperty -Path $cdm -Name 'FeatureManagementEnabled' -Value 0 -Type DWord -ErrorAction Stop
     Write-Host "  ContentDeliveryManager: suggestions disabled"
 } catch { Write-Host "  ContentDeliveryManager warning: $($_.Exception.Message)" }
 
@@ -85,7 +85,9 @@ foreach ($key in $startupKeys) {
     foreach ($entry in $startupEntriesToRemove) {
         try {
             Remove-ItemProperty -Path $key -Name $entry -ErrorAction SilentlyContinue
-        } catch {}
+        } catch {
+            Write-Host "  Startup cleanup warning: key='$key', entry='$entry': $($_.Exception.Message)"
+        }
     }
 }
 Write-Host "  Startup: common startup entries removed"
@@ -93,8 +95,8 @@ Write-Host "  Startup: common startup entries removed"
 # Disable the 'Start' menu recommended apps and news on first login
 try {
     $startPolicies = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer'
-    New-Item -Path $startPolicies -Force -ErrorAction SilentlyContinue | Out-Null
-    Set-ItemProperty -Path $startPolicies -Name 'HideRecentlyAddedApps' -Value 1 -Type DWord -ErrorAction SilentlyContinue
+    New-Item -Path $startPolicies -Force -ErrorAction Stop | Out-Null
+    Set-ItemProperty -Path $startPolicies -Name 'HideRecentlyAddedApps' -Value 1 -Type DWord -ErrorAction Stop
     Write-Host "  Start menu: recently added apps hidden"
 } catch { Write-Host "  Start menu warning: $($_.Exception.Message)" }
 

--- a/libs/qemu-docker/windows/src/vm/setup/setup.ps1
+++ b/libs/qemu-docker/windows/src/vm/setup/setup.ps1
@@ -35,6 +35,73 @@ Write-Host "Install Windows Arena Apps: $installWinarenaApps"
 Write-Host ""
 
 # =============================================================================
+# BLANK DESKTOP: Suppress startup windows so instances launch to a clean desktop
+# =============================================================================
+Write-Host "Applying blank desktop hardening..."
+
+# Disable the 'restore previous folder windows on logon' option in Explorer so
+# it doesn't re-open any windows that were visible when the image was captured.
+try {
+    New-Item -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Force -ErrorAction SilentlyContinue | Out-Null
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'PersistBrowsers' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Write-Host "  Explorer: PersistBrowsers disabled"
+} catch { Write-Host "  Explorer PersistBrowsers warning: $($_.Exception.Message)" }
+
+# Disable the 'show recently used files/folders' in Quick Access (cosmetic, but avoids 'File Explorer' pop notification)
+try {
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer' -Name 'ShowRecent' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer' -Name 'ShowFrequent' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Write-Host "  Explorer: recent/frequent items disabled"
+} catch { Write-Host "  Explorer recent items warning: $($_.Exception.Message)" }
+
+# Disable Windows Widgets (News and Interests) and Chat from taskbar - they can
+# open a popup/panel if clicked accidentally or on first login.
+try {
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarDa' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarMn' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Write-Host "  Taskbar: Widgets and Chat hidden"
+} catch { Write-Host "  Taskbar widgets warning: $($_.Exception.Message)" }
+
+# Suppress "New features and suggestions" / lock screen app suggestions
+try {
+    $cdm = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager'
+    New-Item -Path $cdm -Force -ErrorAction SilentlyContinue | Out-Null
+    Set-ItemProperty -Path $cdm -Name 'SubscribedContent-338393Enabled' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $cdm -Name 'SubscribedContent-353696Enabled' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $cdm -Name 'SubscribedContent-353694Enabled' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $cdm -Name 'SoftLandingEnabled' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $cdm -Name 'FeatureManagementEnabled' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Write-Host "  ContentDeliveryManager: suggestions disabled"
+} catch { Write-Host "  ContentDeliveryManager warning: $($_.Exception.Message)" }
+
+# Remove common startup entries that can show windows on login
+# (OneDrive, Microsoft Teams, Windows Security, etc.)
+$startupKeys = @(
+    'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run',
+    'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run'
+)
+$startupEntriesToRemove = @('OneDrive', 'MicrosoftTeams', 'Teams', 'SecurityHealth')
+foreach ($key in $startupKeys) {
+    foreach ($entry in $startupEntriesToRemove) {
+        try {
+            Remove-ItemProperty -Path $key -Name $entry -ErrorAction SilentlyContinue
+        } catch {}
+    }
+}
+Write-Host "  Startup: common startup entries removed"
+
+# Disable the 'Start' menu recommended apps and news on first login
+try {
+    $startPolicies = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer'
+    New-Item -Path $startPolicies -Force -ErrorAction SilentlyContinue | Out-Null
+    Set-ItemProperty -Path $startPolicies -Name 'HideRecentlyAddedApps' -Value 1 -Type DWord -ErrorAction SilentlyContinue
+    Write-Host "  Start menu: recently added apps hidden"
+} catch { Write-Host "  Start menu warning: $($_.Exception.Message)" }
+
+Write-Host "Blank desktop hardening complete."
+Write-Host ""
+
+# =============================================================================
 # CORE: Git (always installed)
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Fixes CUA-650 — Windows instances should launch to a blank desktop.

When creating a Windows instance, the desktop currently opens with multiple windows already visible at launch. This PR adds blank desktop hardening to ensure instances start clean.

## Root Cause

Several Windows UI elements and startup applications were opening on login:
1. **Shutdown Event Tracker modal**: Since the VM is force-stopped between sessions, Windows pops a "Why did the computer shut down unexpectedly?" modal on every boot
2. **Microsoft Edge**: Launches its first-run experience and runs in background/startup mode by default on Windows 11 Enterprise
3. **OneDrive**: Registers in the startup Run key and opens on login
4. **Windows Security notifications**: Can display notification icons/toasts on the desktop
5. **Explorer restoring previous windows**: Can re-open file explorer windows from the previous session
6. **ContentDeliveryManager**: Shows app suggestions, feature announcements, and lock screen suggestions
7. **Taskbar Widgets and Chat**: Can open panels on first login

## Changes

### setup-cua-server.ps1
Added a **blank desktop hardening** block that runs before server installation:
- Disable Shutdown Event Tracker via registry policy
- Disable Edge first-run experience, startup boost, and background mode via group policy
- Disable OneDrive startup via OneDrive group policy
- Disable Windows Security notification icon via Defender group policy

### setup.ps1
Added a **BLANK DESKTOP** section running at initial setup time:
- Disable Explorer's PersistBrowsers to prevent re-opening previous folder windows
- Hide recently used files/folders in Quick Access
- Disable Taskbar Widgets and Chat (TaskbarDa, TaskbarMn)
- Suppress ContentDeliveryManager suggestions
- Remove common startup entries: OneDrive, Teams, SecurityHealth from Run keys
- Hide recently added apps from Start menu

## Relation to Cloud PR

The same issue was addressed in trycua/cloud PR #5214 (for kubevirt Windows workspace VMs), which fixes cmd.exe visibility in scheduled tasks. This PR addresses the same user-facing problem for the open-source QEMU Docker Windows image (trycua/cua-qemu-windows), using registry-based suppression of Windows startup behaviors.

Fixes: https://linear.app/trycua/issue/CUA-650

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added blank-desktop hardening during Windows setup to reduce first-run prompts and startup distractions.
  * Improved the initial desktop experience by suppressing common UI elements and notifications such as startup boosts, widget/chat entries, promotional suggestions, and select security prompts.
  * Added status and warning logging for each hardening step so setup progress is easier to follow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->