### PR TITLE
ci(CUA-656): update nix-wayland comment — cursor-click-gif tests now GREEN

### DIFF
--- a/.github/workflows/nix-wayland.yml
+++ b/.github/workflows/nix-wayland.yml
@@ -1,12 +1,12 @@
 name: CUA Driver Native-Wayland TDD Suite
 
 # Native-Wayland reproduction of the cua-driver NixOS tests across five desktop
-# sessions (XFCE on labwc/sway, plus KDE and GNOME). These are a TDD
-# RED suite: the driver is X11-only today, so they are EXPECTED TO FAIL until
-# native Wayland support lands. The triggers mirror the X11 nix-build.yml
-# workflow (PRs/pushes touching nix/flake/driver, plus manual dispatch). These
-# jobs are BLOCKING (no continue-on-error): a red cell fails the PR, so the suite
-# can only go green once native Wayland support is implemented.
+# sessions (XFCE on labwc/sway, plus KDE and GNOME). The cursor-click-gif and
+# background-terminal-gif tests use the EIS-backed cua-compositor injection path
+# for deterministic keyboard delivery without relying on compositor focus policy.
+# The triggers mirror the X11 nix-build.yml workflow (PRs/pushes touching
+# nix/flake/driver, plus manual dispatch). These jobs are BLOCKING
+# (no continue-on-error): a red cell fails the PR.
 # Artifacts (screenshots, GIFs, logs) are uploaded so you can see exactly what
 # each compositor does.
 on:


### PR DESCRIPTION
## Summary

Update the `nix-wayland.yml` workflow comment to reflect that the Wayland CI suite is now **green** (all cursor-click-gif tests pass), removing stale "TDD RED suite" / "X11-only today" / "EXPECTED TO FAIL" language.

## Background

The 3 originally failing tests (`kde / cursor-click-gif`, `xfce-labwc / cursor-click-gif`, `gnome / cursor-click-gif`) were fixed when:

1. **Root cause**: The test relied on host compositor focus routing for keyboard delivery after a virtual pointer click. In headless CI, `labwc` (without tiling config) opens floating windows at arbitrary positions — the click at `(120, 120)` may miss the target. `xfce-sway` worked because `workspace_layout stacking` fills the output.

2. **Fix** in commit `6be1de83` (PR #2000): Changed `cursor-click-gif.nix` to `eis = true` — the EIS-backed nested `cua-compositor` path. The `click()` call is retained to exercise the virtual pointer path, but `type_text`/`press_key` use the deterministic focus-free injection path.

3. **Confirmed green**: All 4 `cursor-click-gif` combinations pass on main (run [28139436182](https://github.com/trycua/cua/actions/runs/28139436182)).

## Change

One comment block in `.github/workflows/nix-wayland.yml` — removes outdated "TDD RED suite" framing.

## References

- Linear: [CUA-656](https://linear.app/trycua/issue/CUA-656/fix-cursor-click-gif-flaky-tests-in-native-wayland-ci-suite)
- Fix commit: `6be1de83` (PR #2000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the workflow description to better explain the Native-Wayland test suite and its blocking status.
  * Clarified when the suite runs, aligning its trigger scope with related build workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->