### PR TITLE
fix(cua-driver/macos): prefer AX scroll actions

### DIFF
--- a/libs/cua-driver/rust/crates/platform-macos/src/input/ax_actions.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/ax_actions.rs
@@ -16,6 +16,36 @@ pub fn perform_ax_action(element_ptr: usize, action: &str) -> anyhow::Result<()>
     }
 }
 
+/// Perform a native AX scroll action when the target element advertises one.
+pub fn perform_ax_scroll_action_if_supported(
+    element_ptr: usize,
+    direction: &str,
+    by: &str,
+    amount: usize,
+) -> anyhow::Result<Option<&'static str>> {
+    let actions = unsafe { copy_action_names(element_ptr as AXUIElementRef) };
+    let Some(candidates) = scroll_action_candidates(direction, by) else {
+        return Ok(None);
+    };
+    let Some(action) = candidates
+        .iter()
+        .copied()
+        .find(|candidate| actions.iter().any(|advertised| advertised.as_str() == *candidate))
+    else {
+        return Ok(None);
+    };
+
+    for _ in 0..amount {
+        let err = unsafe { perform_action(element_ptr as AXUIElementRef, action) };
+        if err != kAXErrorSuccess {
+            anyhow::bail!("AXUIElementPerformAction({action}) failed with error {err}");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    Ok(Some(action))
+}
+
 fn map_action(action: &str) -> &'static str {
     match action.to_lowercase().as_str() {
         "press" | "click" => "AXPress",
@@ -26,6 +56,20 @@ fn map_action(action: &str) -> &'static str {
         "open" => "AXOpen",
         _ => "AXPress",
     }
+}
+
+fn scroll_action_candidates(direction: &str, by: &str) -> Option<[&'static str; 2]> {
+    Some(match (direction, by) {
+        ("up", "page") => ["AXScrollUpByPage", "AXScrollUp"],
+        ("down", "page") => ["AXScrollDownByPage", "AXScrollDown"],
+        ("left", "page") => ["AXScrollLeftByPage", "AXScrollLeft"],
+        ("right", "page") => ["AXScrollRightByPage", "AXScrollRight"],
+        ("up", _) => ["AXScrollUp", "AXScrollUpByPage"],
+        ("down", _) => ["AXScrollDown", "AXScrollDownByPage"],
+        ("left", _) => ["AXScrollLeft", "AXScrollLeftByPage"],
+        ("right", _) => ["AXScrollRight", "AXScrollRightByPage"],
+        _ => return None,
+    })
 }
 
 /// Set AXFocused=true on an element (for pre-focusing before key press).

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/scroll.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/scroll.rs
@@ -22,9 +22,10 @@ static DEF: std::sync::OnceLock<ToolDef> = std::sync::OnceLock::new();
 fn def() -> &'static ToolDef {
     DEF.get_or_init(|| ToolDef {
         name: "scroll".into(),
-        description: "Scroll the target pid's focused region by synthesized keystrokes.\n\n\
-            Mapping: by='page' → PageDown/PageUp × amount; by='line' → DownArrow/UpArrow × amount. \
-            Horizontal variants use Left/Right arrow keys.\n\n\
+        description: "Scroll the target pid's focused region.\n\n\
+            If the target element advertises a native AX scroll action, that action is used first. \
+            Otherwise, by='page' maps to PageDown/PageUp × amount and by='line' maps to \
+            DownArrow/UpArrow × amount. Horizontal variants use Left/Right arrow keys.\n\n\
             Optional element_index + window_id pre-focuses the element before scrolling.".into(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -46,7 +47,7 @@ fn def() -> &'static ToolDef {
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 50,
-                    "description": "Number of keystroke repetitions. Default: 3."
+                    "description": "Number of native AX scroll action or fallback keystroke repetitions. Default: 3."
                 },
                 "window_id": { "type": "integer" },
                 "element_index": { "type": "integer" },
@@ -115,9 +116,11 @@ impl Tool for ScrollTool {
             _                                                 => "down",
         };
         let key = key.to_owned();
+        let ax_direction = direction.to_owned();
+        let ax_by = by.to_owned();
 
         // ── Focus-suppression wrap (Swift WindowChangeDetector + FocusGuard) ──
-        // Scroll keystrokes (PageDown / arrow) into search-box autocomplete
+        // Scroll actions or fallback keystrokes into search-box autocomplete
         // can spawn floating helper windows; rare but real. Wrap for parity
         // with the other action tools.
         //
@@ -130,7 +133,7 @@ impl Tool for ScrollTool {
         let result = focus_guard::with_focus_suppressed(
             Some(pid),
             prior_front,
-            "scroll.CGEvent",
+            "scroll",
             || async move {
                 // Pre-focus the element under suppression so its
                 // side-effects are captured by the snapshot + lease.
@@ -139,6 +142,22 @@ impl Tool for ScrollTool {
                         crate::input::ax_actions::focus_element(element_ptr)
                     }).await;
                     tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+
+                    let direction = ax_direction.clone();
+                    let by = ax_by.clone();
+                    match tokio::task::spawn_blocking(move || {
+                        crate::input::ax_actions::perform_ax_scroll_action_if_supported(
+                            element_ptr,
+                            &direction,
+                            &by,
+                            amount,
+                        )
+                    }).await {
+                        Ok(Ok(Some(action))) => return Ok(Ok(action.to_owned())),
+                        Ok(Ok(None)) => {},
+                        Ok(Err(e)) => return Ok(Err(e)),
+                        Err(e) => return Err(e),
+                    }
                 }
 
                 tokio::task::spawn_blocking(move || {
@@ -148,7 +167,7 @@ impl Tool for ScrollTool {
                         }
                         std::thread::sleep(std::time::Duration::from_millis(50));
                     }
-                    Ok(())
+                    Ok("key synthesis".to_owned())
                 })
                 .await
             },
@@ -158,8 +177,8 @@ impl Tool for ScrollTool {
         let changes = snapshot.detect_async().await;
 
         match result {
-            Ok(Ok(())) => ToolResult::text(format!(
-                "Scrolled {direction} by {by} × {amount}.{}",
+            Ok(Ok(method)) => ToolResult::text(format!(
+                "Scrolled {direction} by {by} × {amount} via {method}.{}",
                 changes.result_suffix()
             )),
             Ok(Err(e)) => ToolResult::error(format!("Scroll failed: {e}")),


### PR DESCRIPTION
## Summary
- Prefer a native advertised AX scroll action for indexed macOS scroll targets before falling back to key synthesis.
- Support both `AXScroll*` and `AXScroll*ByPage` action families, ordered by requested `by` granularity.
- Include the selected scroll path in the success message.

## Rationale
This keeps the existing Cua scroll flow intact: resolve/retain the target element, focus under suppression, then scroll. The only change is to use the native AX action the target element advertises before using synthesized keyboard input as a fallback.

## Testing
- `git diff --check`
- Not run: `cargo check` / `rustfmt` because no Rust toolchain is installed in this environment (`rustup toolchain list` reports none).

Fixes #1895

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native scrolling support for elements that expose accessibility scroll actions.
  * Improved scrolling behavior to prefer the most appropriate available action before falling back.

* **Bug Fixes**
  * Updated scrolling to better handle focused elements and reduce reliance on synthesized input when native actions are available.
  * Success messages now indicate which scrolling method was used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->