### PR TITLE
Fix Chromium Apple Event window targeting

### DIFF
--- a/libs/cua-driver/rust/crates/platform-macos/src/browser/browser_js.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/browser/browser_js.rs
@@ -3,7 +3,16 @@
 use std::time::Duration;
 use anyhow::Context;
 
+use crate::windows::WindowBounds;
+
 pub struct BrowserJs;
+
+#[derive(Clone, Debug)]
+struct NativeWindowTarget {
+    title: String,
+    bounds: WindowBounds,
+    same_bounds_ordinal: usize,
+}
 
 fn app_name_for_bundle(bundle_id: &str) -> Option<&'static str> {
     match bundle_id {
@@ -26,22 +35,17 @@ impl BrowserJs {
         let app_name = app_name_for_bundle(bundle_id)
             .ok_or_else(|| anyhow::anyhow!("Unsupported browser bundle: {bundle_id}"))?;
 
-        // Get window title from CGWindowID.
-        let win_title = {
+        // Resolve the WindowServer CGWindowID to stable properties that can be
+        // matched against the browser's AppleScript window model.
+        let target = {
             let wid = window_id;
-            tokio::task::spawn_blocking(move || {
-                crate::windows::all_windows()
-                    .into_iter()
-                    .find(|w| w.window_id == wid)
-                    .map(|w| w.title)
-                    .unwrap_or_default()
-            }).await?
-        };
+            tokio::task::spawn_blocking(move || native_window_target(wid)).await?
+        }?;
 
-        let escaped_title = escape_for_applescript_string(&win_title);
         let escaped_js = escape_js_for_applescript(javascript);
 
         let script = if bundle_id == "com.apple.Safari" {
+            let escaped_title = escape_for_applescript_string(&target.title);
             format!(
                 r#"tell application "Safari"
   set matchedDoc to missing value
@@ -58,23 +62,7 @@ impl BrowserJs {
 end tell"#
             )
         } else {
-            format!(
-                r#"tell application "{app_name}"
-  set matchedWindow to missing value
-  repeat with w in windows
-    if name of w contains "{escaped_title}" then
-      set matchedWindow to w
-      exit repeat
-    end if
-  end repeat
-  if matchedWindow is missing value then
-    set matchedWindow to front window
-  end if
-  tell active tab of matchedWindow
-    execute javascript {escaped_js}
-  end tell
-end tell"#
-            )
+            chromium_window_script(app_name, &target, &escaped_js, window_id)
         };
 
         run_osascript(&script).await
@@ -122,6 +110,92 @@ end tell"#
 
         Ok(())
     }
+}
+
+fn native_window_target(window_id: u32) -> anyhow::Result<NativeWindowTarget> {
+    let windows = crate::windows::all_windows();
+    let target = windows
+        .iter()
+        .find(|w| w.window_id == window_id)
+        .ok_or_else(|| anyhow::anyhow!("No macOS window found for window_id {window_id}"))?;
+    let mut same_bounds = windows
+        .iter()
+        .filter(|window| window.pid == target.pid && same_bounds(&window.bounds, &target.bounds))
+        .collect::<Vec<_>>();
+    same_bounds.sort_by(|a, b| b.z_index.cmp(&a.z_index));
+    let same_bounds_ordinal = same_bounds
+        .iter()
+        .position(|window| window.window_id == target.window_id)
+        .unwrap_or(0);
+
+    Ok(NativeWindowTarget {
+        title: target.title.clone(),
+        bounds: target.bounds.clone(),
+        same_bounds_ordinal,
+    })
+}
+
+fn chromium_window_script(
+    app_name: &str,
+    target: &NativeWindowTarget,
+    escaped_js: &str,
+    window_id: u32,
+) -> String {
+    let left = rounded_i64(target.bounds.x);
+    let top = rounded_i64(target.bounds.y);
+    let right = rounded_i64(target.bounds.x + target.bounds.width);
+    let bottom = rounded_i64(target.bounds.y + target.bounds.height);
+    let ordinal = target.same_bounds_ordinal;
+    let title_fallback = if target.title.trim().is_empty() {
+        String::new()
+    } else {
+        let escaped_title = escape_for_applescript_string(&target.title);
+        format!(
+            r#"  if matchedWindow is missing value then
+    repeat with w in windows
+      if name of w contains "{escaped_title}" then
+        set matchedWindow to w
+        exit repeat
+      end if
+    end repeat
+  end if
+"#
+        )
+    };
+
+    format!(
+        r#"tell application "{app_name}"
+  set matchedWindow to missing value
+  set matchingBoundsSeen to 0
+  repeat with w in windows
+    set candidateBounds to bounds of w
+    if (item 1 of candidateBounds is {left}) and (item 2 of candidateBounds is {top}) and (item 3 of candidateBounds is {right}) and (item 4 of candidateBounds is {bottom}) then
+      if matchingBoundsSeen is {ordinal} then
+        set matchedWindow to w
+        exit repeat
+      end if
+      set matchingBoundsSeen to matchingBoundsSeen + 1
+    end if
+  end repeat
+{title_fallback}  if matchedWindow is missing value then
+    error "No {app_name} AppleScript window matched native window_id {window_id}"
+  end if
+  tell active tab of matchedWindow
+    execute javascript {escaped_js}
+  end tell
+end tell"#
+    )
+}
+
+fn same_bounds(left: &WindowBounds, right: &WindowBounds) -> bool {
+    rounded_i64(left.x) == rounded_i64(right.x)
+        && rounded_i64(left.y) == rounded_i64(right.y)
+        && rounded_i64(left.width) == rounded_i64(right.width)
+        && rounded_i64(left.height) == rounded_i64(right.height)
+}
+
+fn rounded_i64(value: f64) -> i64 {
+    value.round() as i64
 }
 
 fn find_preferences_files(profiles_dir: &str) -> Vec<String> {
@@ -235,4 +309,83 @@ fn rand_u64() -> u64 {
     // Mix in thread id for uniqueness.
     let tid = std::thread::current().id();
     t.subsec_nanos() as u64 ^ t.as_secs().wrapping_mul(6364136223846793005) ^ format!("{tid:?}").len() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target(title: &str, same_bounds_ordinal: usize) -> NativeWindowTarget {
+        NativeWindowTarget {
+            title: title.to_owned(),
+            bounds: WindowBounds {
+                x: 22.0,
+                y: 55.0,
+                width: 1200.0,
+                height: 829.0,
+            },
+            same_bounds_ordinal,
+        }
+    }
+
+    #[test]
+    fn chromium_script_matches_window_bounds_and_same_bounds_ordinal() {
+        let script = chromium_window_script(
+            "Google Chrome",
+            &target("", 2),
+            "\"window.location.href\"",
+            27655,
+        );
+
+        assert!(script.contains("item 1 of candidateBounds is 22"));
+        assert!(script.contains("item 2 of candidateBounds is 55"));
+        assert!(script.contains("item 3 of candidateBounds is 1222"));
+        assert!(script.contains("item 4 of candidateBounds is 884"));
+        assert!(script.contains("if matchingBoundsSeen is 2"));
+        assert!(
+            script.contains("No Google Chrome AppleScript window matched native window_id 27655")
+        );
+    }
+
+    #[test]
+    fn chromium_script_does_not_fall_back_to_front_window_or_empty_title_match() {
+        let script =
+            chromium_window_script("Google Chrome", &target("", 0), "\"document.title\"", 27655);
+
+        assert!(!script.contains("front window"));
+        assert!(!script.contains("contains \"\""));
+        assert!(script.contains(
+            "error \"No Google Chrome AppleScript window matched native window_id 27655\""
+        ));
+    }
+
+    #[test]
+    fn chromium_script_uses_non_empty_title_as_secondary_fallback() {
+        let script = chromium_window_script(
+            "Google Chrome",
+            &target("Example \"quoted\" Domain", 0),
+            "\"document.title\"",
+            27655,
+        );
+
+        assert!(script.contains("if name of w contains \"Example \\\"quoted\\\" Domain\""));
+    }
+
+    #[test]
+    fn same_bounds_compares_rounded_window_geometry() {
+        assert!(same_bounds(
+            &WindowBounds {
+                x: 22.2,
+                y: 55.4,
+                width: 1199.8,
+                height: 829.1,
+            },
+            &WindowBounds {
+                x: 22.0,
+                y: 55.0,
+                width: 1200.0,
+                height: 829.0,
+            }
+        ));
+    }
 }


### PR DESCRIPTION
## Summary
- resolve the native CGWindowID to bounds and same-bounds z-order before running Chromium Apple Events
- match Chrome/Brave/Edge AppleScript windows by bounds instead of blank titles
- remove the dangerous front-window fallback and error when the requested native window cannot be mapped
- add BrowserJS regression tests for empty titles, duplicate-bounds ordinals, and fallback behavior

## Verification
- `cargo check -p platform-macos`
- `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer DYLD_LIBRARY_PATH=/Applications/Xcode-26.5.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx DYLD_FALLBACK_LIBRARY_PATH=/Applications/Xcode-26.5.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx cargo test -p platform-macos browser_js -- --nocapture`
- `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer cargo build -p cua-driver`
- source-built driver live check with two Chrome app windows sharing bounds: `window_id=27655` returned the RYM URL, `window_id=27562` returned the probe URL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved script execution reliability for browser windows by targeting the intended window more accurately.
  * Fixed cases where the wrong window could be selected when multiple windows share the same size or position.
  * Added a better fallback path when a window title is available, reducing failures in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->