### PR TITLE
refactor(cua-driver): migrate all integration tests onto cua-driver-testkit (Phase 2)

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-testkit/src/ax.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-testkit/src/ax.rs
@@ -1,0 +1,52 @@
+//! Accessibility-snapshot text helpers.
+//!
+//! `get_window_state` renders the AX/UIA tree as indented text lines like
+//! `  [12] AXButton id=btn-ok "OK"`. The harness tests parse that text to find
+//! an element's index or assert a control is present — logic that was
+//! copy-pasted across the per-app harness files.
+
+/// True when the snapshot text is empty or signals a permission wall (TCC on
+/// macOS) rather than a real tree — the caller should skip element assertions.
+pub fn looks_empty(text: &str) -> bool {
+    let line_count = text.lines().count();
+    text.is_empty()
+        || line_count <= 2
+        || text.contains("Accessibility permission required")
+        || text.contains("TCC permission")
+}
+
+/// True when an element with `id=<id>` appears in the snapshot.
+pub fn has_id(text: &str, id: &str) -> bool {
+    text.contains(&format!("id={id}"))
+}
+
+/// The `[index]` of the first element line carrying `id=<id>`.
+pub fn element_index_by_id(text: &str, id: &str) -> Option<u64> {
+    index_on_line_matching(text, &format!("id={id}"))
+}
+
+/// The `[index]` of the first element line containing `needle` (case-insensitive).
+pub fn element_index_containing(text: &str, needle: &str) -> Option<u64> {
+    let needle = needle.to_lowercase();
+    for line in text.lines() {
+        if line.to_lowercase().contains(&needle) {
+            if let Some(idx) = bracket_index(line) {
+                return Some(idx);
+            }
+        }
+    }
+    None
+}
+
+fn index_on_line_matching(text: &str, needle: &str) -> Option<u64> {
+    text.lines()
+        .find(|line| line.contains(needle))
+        .and_then(bracket_index)
+}
+
+/// Parse the leading `[N]` index token from an element line.
+fn bracket_index(line: &str) -> Option<u64> {
+    let start = line.find('[')? + 1;
+    let end = line[start..].find(']')? + start;
+    line[start..end].trim().parse().ok()
+}

--- a/libs/cua-driver/rust/crates/cua-driver-testkit/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-testkit/src/lib.rs
@@ -25,6 +25,7 @@
 //! them to a `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` job, so the OS reaps the whole
 //! tree even on panic / SIGKILL / Ctrl-C — no orphaned windows or held ports.
 
+pub mod ax;
 mod driver;
 mod mcp;
 mod cli;

--- a/libs/cua-driver/rust/crates/cua-driver-testkit/src/mcp.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-testkit/src/mcp.rs
@@ -3,6 +3,7 @@
 use std::io::{BufRead, BufReader, Write};
 use std::process::{ChildStdin, Command, Stdio};
 use std::sync::mpsc::{channel, Receiver};
+use std::time::{Duration, Instant};
 
 use serde_json::Value;
 
@@ -87,6 +88,31 @@ impl McpDriver {
     /// lifetime should be tied to this driver.
     pub fn reaper(&mut self) -> &mut ChildReaper {
         &mut self.reaper
+    }
+
+    /// Poll `list_windows` until a window of `pid` whose title contains
+    /// `title_substr` appears (up to ~12s). Returns `(window_id, title)`.
+    /// Replaces the per-file `find_harness_window` helper.
+    pub fn find_window(&mut self, pid: i64, title_substr: &str) -> Option<(u64, String)> {
+        let deadline = Instant::now() + Duration::from_secs(12);
+        loop {
+            let r = self.call("list_windows", serde_json::json!({ "pid": pid }));
+            if let Some(wins) = r.structured()["windows"].as_array() {
+                for w in wins {
+                    if w["pid"].as_i64() != Some(pid) {
+                        continue;
+                    }
+                    let title = w["title"].as_str().unwrap_or("");
+                    if title.contains(title_substr) {
+                        return Some((w["window_id"].as_u64()?, title.to_string()));
+                    }
+                }
+            }
+            if Instant::now() >= deadline {
+                return None;
+            }
+            std::thread::sleep(Duration::from_millis(150));
+        }
     }
 
     /// Raw JSON-RPC response envelope, for the rare assertion needing it.

--- a/libs/cua-driver/rust/crates/cua-driver-testkit/src/paths.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-testkit/src/paths.rs
@@ -17,15 +17,22 @@ pub fn workspace_root() -> PathBuf {
         .to_owned()
 }
 
-/// The built `cua-driver` binary (`.exe` on Windows). One impl replaces the
-/// four divergent spellings that were copy-pasted across the test files.
+/// The built `cua-driver` binary (`.exe` on Windows), preferring a release
+/// build when present and falling back to debug. One impl replaces the four
+/// divergent spellings (and the macOS release-or-debug variant) that were
+/// copy-pasted across the test files.
 pub fn driver_binary() -> PathBuf {
     let name = if cfg!(target_os = "windows") {
         "cua-driver.exe"
     } else {
         "cua-driver"
     };
-    workspace_root().join("target/debug").join(name)
+    let root = workspace_root();
+    let release = root.join("target/release").join(name);
+    if release.exists() {
+        return release;
+    }
+    root.join("target/debug").join(name)
 }
 
 /// A built harness app under `test-apps/<dir>/<exe>` (produced by

--- a/libs/cua-driver/rust/crates/cua-driver/tests/e2e_windows_bg_input_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/e2e_windows_bg_input_test.rs
@@ -10,13 +10,13 @@
 //!      the action == the target window was not z-raised over the user's
 //!      window (same oracle as `harness_bg_modality_test`).
 //!
-//! ## Process hygiene (no orphaned windows / held ports)
-//! Every child (target app, sentinel, driver) is spawned into a Windows **Job
-//! Object** created with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. The test process
-//! holds the only job handle, so when it exits for ANY reason — normal end,
-//! panic, or being force-killed (Ctrl-C) — the OS terminates the entire child
-//! tree. A per-fixture `ChildBag` also kills+waits promptly between tests so
-//! windows don't pile up during a run, and every early-return path reaps.
+//! ## Process hygiene
+//! The driver, target app, and sentinel are all owned by the shared testkit
+//! `ChildReaper` (via `McpDriver`), which on Windows assigns them to a
+//! kill-on-close Job Object — the OS reaps the whole tree when the test process
+//! exits for ANY reason (normal, panic, SIGKILL), so no orphaned windows or
+//! held ports. Broker-spawned window pids (packaged apps / Electron) are
+//! tree-killed via `reaper().track_pid`.
 //!
 //! Targets (trycua test apps, auto-downloaded to %TEMP% if not provided):
 //!   - Electron (Chromium content) — `trycua/desktop-test-app-electron`.
@@ -25,112 +25,27 @@
 //! Override with `CUA_ELECTRON_EXE` / `CUA_TAURI_EXE`, or drop the exe in
 //! `test-apps/`. Auto-download uses `curl.exe`.
 //!
-//! Every JSON-RPC call is bounded by a hard timeout (a hung driver becomes a
-//! fast, localized failure — never an indefinite wall-clock hang).
-//!
 //! All tests are `#[ignore]` (GUI, real desktop session). Run explicitly,
 //! serially (apps bind a fixed HTTP port, so never in parallel):
 //!   cargo test -p cua-driver --test e2e_windows_bg_input_test -- --ignored --nocapture --test-threads=1
 
 #![cfg(target_os = "windows")]
 
-use core::ffi::c_void;
 use std::collections::HashSet;
 use std::fs;
-use std::io::{BufRead, BufReader, Write};
-use std::os::windows::io::AsRawHandle;
 use std::path::{Path, PathBuf};
-use std::process::{Child, ChildStdin, Command, Stdio};
-use std::sync::mpsc::{channel, Receiver};
-use std::sync::OnceLock;
+use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
-use windows::Win32::Foundation::{CloseHandle, HANDLE};
-use windows::Win32::System::JobObjects::{
-    AssignProcessToJobObject, CreateJobObjectW, SetInformationJobObject,
-    JobObjectExtendedLimitInformation, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
-    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
-};
-use windows::Win32::System::Threading::{OpenProcess, PROCESS_SET_QUOTA, PROCESS_TERMINATE};
-
-const CALL_TIMEOUT: Duration = Duration::from_secs(25);
+use cua_driver_testkit::{ax, workspace_root, Driver, McpDriver};
 
 const ELECTRON_URL: &str = "https://github.com/trycua/desktop-test-app-electron/releases/download/v0.1.0/desktop-test-app-electron.0.1.0.exe";
 const TAURI_URL: &str = "https://github.com/trycua/desktop-test-app/releases/download/v0.2.2/desktop-test-app-windows-x86_64.exe";
 
-// ── Job Object: kill the whole child tree when this test process dies ─────────
+// ── paths / downloads ─────────────────────────────────────────────────────────
 
-/// Process-global job handle (stored as usize so it's `Send`/`Sync` in the
-/// OnceLock). Created lazily with KILL_ON_JOB_CLOSE.
-static JOB: OnceLock<usize> = OnceLock::new();
-
-fn job() -> HANDLE {
-    let raw = *JOB.get_or_init(|| unsafe {
-        let h = CreateJobObjectW(None, windows::core::PCWSTR::null()).expect("CreateJobObjectW");
-        let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
-        info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-        let _ = SetInformationJobObject(
-            h,
-            JobObjectExtendedLimitInformation,
-            &info as *const _ as *const c_void,
-            std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
-        );
-        h.0 as usize
-    });
-    HANDLE(raw as *mut c_void)
-}
-
-/// Spawn a command and immediately assign it to the kill-on-close job, so it
-/// can never outlive this test process.
-fn spawn_in_job(cmd: &mut Command) -> std::io::Result<Child> {
-    let child = cmd.spawn()?;
-    unsafe {
-        let h = HANDLE(child.as_raw_handle() as *mut c_void);
-        let _ = AssignProcessToJobObject(job(), h);
-    }
-    Ok(child)
-}
-
-/// Assign an already-running pid (e.g. the broker-spawned window process of a
-/// packaged app, which is NOT our direct child) to the kill-on-close job, so
-/// it too dies when this test process exits. Best-effort.
-fn assign_pid_to_job(pid: u32) {
-    unsafe {
-        if let Ok(h) = OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, false, pid) {
-            if !h.is_invalid() {
-                let _ = AssignProcessToJobObject(job(), h);
-                let _ = CloseHandle(h);
-            }
-        }
-    }
-}
-
-/// Owns every spawned child AND any externally-launched pids (broker apps);
-/// kills them all on drop — prompt cleanup between tests and on early
-/// return / panic unwind. The Job Object is the backstop for hard kills.
-struct ChildBag { children: Vec<Child>, pids: Vec<u32> }
-impl ChildBag {
-    fn new() -> Self { ChildBag { children: Vec::new(), pids: Vec::new() } }
-    fn push(&mut self, c: Child) { self.children.push(c); }
-    /// Track an external pid (and its whole tree) for teardown via taskkill.
-    fn track_pid(&mut self, pid: u32) { self.pids.push(pid); }
-}
-impl Drop for ChildBag {
-    fn drop(&mut self) {
-        // Tree-kill externally-discovered window processes first (packaged /
-        // broker-launched apps whose window pid isn't our spawned child).
-        for pid in &self.pids {
-            let _ = Command::new("taskkill")
-                .args(["/F", "/T", "/PID", &pid.to_string()])
-                .stdout(Stdio::null()).stderr(Stdio::null())
-                .status();
-        }
-        for c in &mut self.children {
-            let _ = c.kill();
-            let _ = c.wait();
-        }
-        std::thread::sleep(Duration::from_millis(250));
-    }
+fn focus_monitor_binary() -> PathBuf {
+    workspace_root().join("target/debug/focus-monitor-win.exe")
 }
 
 /// Best-effort kill of any prior instance of `exe` by basename, so a leftover
@@ -139,31 +54,29 @@ fn kill_prior_by_name(exe: &Path) {
     if let Some(name) = exe.file_name().and_then(|n| n.to_str()) {
         let _ = Command::new("taskkill")
             .args(["/F", "/T", "/IM", name])
-            .stdout(Stdio::null()).stderr(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .status();
     }
 }
-
-// ── paths / downloads ─────────────────────────────────────────────────────────
-
-fn workspace_root() -> PathBuf {
-    let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
-    PathBuf::from(manifest).parent().unwrap().parent().unwrap().to_owned()
-}
-fn driver_binary() -> PathBuf { workspace_root().join("target/debug/cua-driver.exe") }
-fn focus_monitor_binary() -> PathBuf { workspace_root().join("target/debug/focus-monitor-win.exe") }
 
 fn curl_download(url: &str, dst: &Path) -> bool {
     eprintln!("[e2e] downloading {url}\n        -> {dst:?}");
     let ok = Command::new("curl.exe")
         .args(["-L", "--fail", "--silent", "--show-error", "-o"])
-        .arg(dst).arg(url).status().map(|s| s.success()).unwrap_or(false);
+        .arg(dst)
+        .arg(url)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
     ok && fs::metadata(dst).map(|m| m.len() > 4096).unwrap_or(false)
 }
 fn resolve_or_download(env_var: &str, prefix: &str, url: &str, tmp_name: &str) -> Option<PathBuf> {
     if let Ok(p) = std::env::var(env_var) {
         let pb = PathBuf::from(p);
-        if pb.exists() { return Some(pb); }
+        if pb.exists() {
+            return Some(pb);
+        }
     }
     if let Ok(entries) = fs::read_dir(workspace_root().join("test-apps")) {
         for e in entries.flatten() {
@@ -177,65 +90,49 @@ fn resolve_or_download(env_var: &str, prefix: &str, url: &str, tmp_name: &str) -
     if dst.exists() && fs::metadata(&dst).map(|m| m.len() > 4096).unwrap_or(false) {
         return Some(dst);
     }
-    if curl_download(url, &dst) { Some(dst) } else { None }
+    if curl_download(url, &dst) {
+        Some(dst)
+    } else {
+        None
+    }
 }
 fn electron_exe() -> Option<PathBuf> {
-    resolve_or_download("CUA_ELECTRON_EXE", "desktop-test-app-electron", ELECTRON_URL,
-        "desktop-test-app-electron.0.1.0.exe")
+    resolve_or_download(
+        "CUA_ELECTRON_EXE",
+        "desktop-test-app-electron",
+        ELECTRON_URL,
+        "desktop-test-app-electron.0.1.0.exe",
+    )
 }
 fn tauri_exe() -> Option<PathBuf> {
-    resolve_or_download("CUA_TAURI_EXE", "desktop-test-app-windows", TAURI_URL,
-        "desktop-test-app-windows-x86_64.exe")
+    resolve_or_download(
+        "CUA_TAURI_EXE",
+        "desktop-test-app-windows",
+        TAURI_URL,
+        "desktop-test-app-windows-x86_64.exe",
+    )
 }
 
-fn loss_file()       -> PathBuf { std::env::temp_dir().join("focus_monitor_losses.txt") }
-fn key_loss_file()   -> PathBuf { std::env::temp_dir().join("focus_monitor_key_losses.txt") }
-fn focus_pid_file()  -> PathBuf { std::env::temp_dir().join("focus_monitor_pid.txt") }
-fn focus_hwnd_file() -> PathBuf { std::env::temp_dir().join("focus_monitor_hwnd.txt") }
+fn loss_file() -> PathBuf {
+    std::env::temp_dir().join("focus_monitor_losses.txt")
+}
+fn key_loss_file() -> PathBuf {
+    std::env::temp_dir().join("focus_monitor_key_losses.txt")
+}
+fn focus_pid_file() -> PathBuf {
+    std::env::temp_dir().join("focus_monitor_pid.txt")
+}
+fn focus_hwnd_file() -> PathBuf {
+    std::env::temp_dir().join("focus_monitor_hwnd.txt")
+}
 fn read_count(p: &Path) -> u32 {
     fs::read_to_string(p).ok().and_then(|s| s.trim().parse::<u32>().ok()).unwrap_or(0)
 }
 
-// ── JSON-RPC over the driver's stdio, with per-call timeout ───────────────────
-
-fn send(stdin: &mut ChildStdin, req: serde_json::Value) {
-    let _ = writeln!(stdin, "{}", serde_json::to_string(&req).unwrap());
-    let _ = stdin.flush();
-}
-fn call(stdin: &mut ChildStdin, rx: &Receiver<String>,
-        id: u32, name: &str, args: serde_json::Value) -> serde_json::Value {
-    send(stdin, serde_json::json!({
-        "jsonrpc":"2.0","id":id,"method":"tools/call","params":{"name":name,"arguments":args}
-    }));
-    match rx.recv_timeout(CALL_TIMEOUT) {
-        Ok(line) => serde_json::from_str(&line)
-            .unwrap_or_else(|_| serde_json::json!({"error": format!("bad json: {line}")})),
-        Err(_) => serde_json::json!({"error": format!("TIMEOUT (>{}s) on {name}", CALL_TIMEOUT.as_secs())}),
-    }
-}
-fn init(stdin: &mut ChildStdin, rx: &Receiver<String>) {
-    send(stdin, serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}));
-    let _ = rx.recv_timeout(CALL_TIMEOUT);
-}
-fn result_text(s: &serde_json::Value) -> String {
-    s["result"]["content"][0]["text"].as_str().unwrap_or("").to_string()
-}
-fn is_error(s: &serde_json::Value) -> bool {
-    s["result"]["isError"].as_bool().unwrap_or(false) || s.get("error").is_some()
-}
-fn find_idx_containing(s: &serde_json::Value, needle: &str) -> Option<u64> {
-    for line in result_text(s).lines() {
-        if !line.to_lowercase().contains(&needle.to_lowercase()) { continue; }
-        let st = line.find('[')? + 1;
-        let en = line[st..].find(']')? + st;
-        if let Ok(n) = line[st..en].trim().parse() { return Some(n); }
-    }
-    None
-}
-
-fn window_ids(stdin: &mut ChildStdin, rx: &Receiver<String>) -> HashSet<u64> {
-    let r = call(stdin, rx, 99, "list_windows", serde_json::json!({}));
-    r["result"]["structuredContent"]["windows"].as_array()
+fn window_ids(driver: &mut McpDriver) -> HashSet<u64> {
+    let r = driver.call("list_windows", serde_json::json!({}));
+    r.structured()["windows"]
+        .as_array()
         .map(|a| a.iter().filter_map(|w| w["window_id"].as_u64()).collect())
         .unwrap_or_default()
 }
@@ -243,9 +140,7 @@ fn window_ids(stdin: &mut ChildStdin, rx: &Receiver<String>) -> HashSet<u64> {
 // ── fixture ───────────────────────────────────────────────────────────────────
 
 struct E2eFixture {
-    _bag: ChildBag, // kills target+sentinel+driver on drop
-    stdin: ChildStdin,
-    rx: Receiver<String>,
+    driver: McpDriver, // owns + reaps target+sentinel+driver on drop
     pid: u32,
     wid: u64,
 }
@@ -255,12 +150,14 @@ struct E2eFixture {
 /// belongs to a child pid) → sentinel (grabs foreground, pushing the app to
 /// the background) → reset counters.
 fn setup(target_exe: &Path, _title_hint: &str) -> Option<E2eFixture> {
-    let driver_bin = driver_binary();
     let fm_bin = focus_monitor_binary();
-    if !driver_bin.exists() { eprintln!("[e2e] cua-driver.exe not built — skipping"); return None; }
-    if !fm_bin.exists() { eprintln!("[e2e] focus-monitor-win.exe not built — skipping"); return None; }
+    if !fm_bin.exists() {
+        eprintln!("[e2e] focus-monitor-win.exe not built — skipping");
+        return None;
+    }
     if target_exe.is_absolute() && !target_exe.exists() {
-        eprintln!("[e2e] target {target_exe:?} missing — skipping"); return None;
+        eprintln!("[e2e] target {target_exe:?} missing — skipping");
+        return None;
     }
 
     // Defensive: clear any leftover instance holding the app's fixed port.
@@ -270,46 +167,27 @@ fn setup(target_exe: &Path, _title_hint: &str) -> Option<E2eFixture> {
     let _ = fs::remove_file(focus_pid_file());
     let _ = fs::remove_file(focus_hwnd_file());
 
-    let mut bag = ChildBag::new();
+    // 1. Driver (daemon, no visible window) — spawned + initialized by the testkit.
+    let mut driver = McpDriver::spawn()?;
 
-    // 1. Driver (daemon, no visible window).
-    let mut driver = spawn_in_job(
-        Command::new(&driver_bin).stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
-    ).inspect_err(|e| eprintln!("[e2e] driver spawn failed: {e}")).ok()?;
-    let mut stdin = driver.stdin.take().unwrap();
-    let stdout = driver.stdout.take().unwrap();
-    bag.push(driver);
-    let (tx, rx) = channel::<String>();
-    std::thread::spawn(move || {
-        let mut reader = BufReader::new(stdout);
-        let mut line = String::new();
-        loop {
-            line.clear();
-            match reader.read_line(&mut line) {
-                Ok(0) | Err(_) => break,
-                Ok(_) => { if tx.send(line.trim().to_string()).is_err() { break; } }
-            }
-        }
-    });
-    init(&mut stdin, &rx);
-
-    // 2. Snapshot existing windows, then launch the target app.
-    let before = window_ids(&mut stdin, &rx);
-    let app = match spawn_in_job(
-        Command::new(target_exe).stdout(Stdio::null()).stderr(Stdio::null())
-    ) {
-        Ok(c) => c,
-        Err(e) => { eprintln!("[e2e] target spawn failed: {e}"); return None; } // bag drops → kills driver
-    };
-    bag.push(app);
+    // 2. Snapshot existing windows, then launch the target app into the reaper.
+    let before = window_ids(&mut driver);
+    if driver
+        .reaper()
+        .spawn(Command::new(target_exe).stdout(Stdio::null()).stderr(Stdio::null()))
+        .is_err()
+    {
+        eprintln!("[e2e] target spawn failed"); // driver drops → kills itself
+        return None;
+    }
 
     // 3. Discover the app's NEW window (its pid may be a child of the launched
     //    process — Electron/WebView2 are multi-process).
     let deadline = Instant::now() + Duration::from_secs(15);
     let mut found: Option<(u32, u64)> = None;
     while Instant::now() < deadline {
-        let r = call(&mut stdin, &rx, 11, "list_windows", serde_json::json!({}));
-        if let Some(arr) = r["result"]["structuredContent"]["windows"].as_array() {
+        let r = driver.call("list_windows", serde_json::json!({}));
+        if let Some(arr) = r.structured()["windows"].as_array() {
             for w in arr {
                 let Some(wid) = w["window_id"].as_u64() else { continue };
                 let pid = w["pid"].as_u64().unwrap_or(0) as u32;
@@ -320,41 +198,54 @@ fn setup(target_exe: &Path, _title_hint: &str) -> Option<E2eFixture> {
                 }
             }
         }
-        if found.is_some() { break; }
+        if found.is_some() {
+            break;
+        }
         std::thread::sleep(Duration::from_millis(500));
     }
     let (pid, wid) = match found {
         Some(p) => p,
-        None => { eprintln!("[e2e] app window never appeared — skipping"); return None; } // bag drops
+        None => {
+            eprintln!("[e2e] app window never appeared — skipping");
+            return None;
+        }
     };
     // The window's process is often broker-spawned (packaged apps, Electron),
-    // i.e. NOT our direct child. Job-assign it (hard-kill safety) and track it
-    // for prompt tree-kill on teardown so it can't orphan.
-    assign_pid_to_job(pid);
-    bag.track_pid(pid);
+    // i.e. NOT our direct child. track_pid job-assigns it (hard-kill safety) and
+    // tree-kills it on teardown so it can't orphan.
+    driver.reaper().track_pid(pid);
 
     // 4. Sentinel grabs foreground; app drops to z+1 (the background target).
-    let fm = match spawn_in_job(
-        Command::new(&fm_bin).stdout(Stdio::null()).stderr(Stdio::null())
-    ) {
-        Ok(c) => c,
-        Err(e) => { eprintln!("[e2e] sentinel spawn failed: {e}"); return None; }
-    };
-    bag.push(fm);
+    if driver
+        .reaper()
+        .spawn(Command::new(&fm_bin).stdout(Stdio::null()).stderr(Stdio::null()))
+        .is_err()
+    {
+        eprintln!("[e2e] sentinel spawn failed — skipping");
+        return None;
+    }
     let sdeadline = Instant::now() + Duration::from_secs(10);
     loop {
         let ok = read_count(&focus_pid_file()) != 0
-            && fs::read_to_string(focus_hwnd_file()).ok()
-                .and_then(|s| s.trim().parse::<u64>().ok()).unwrap_or(0) != 0;
-        if ok { break; }
-        if Instant::now() > sdeadline { eprintln!("[e2e] sentinel never published — skipping"); return None; }
+            && fs::read_to_string(focus_hwnd_file())
+                .ok()
+                .and_then(|s| s.trim().parse::<u64>().ok())
+                .unwrap_or(0)
+                != 0;
+        if ok {
+            break;
+        }
+        if Instant::now() > sdeadline {
+            eprintln!("[e2e] sentinel never published — skipping");
+            return None;
+        }
         std::thread::sleep(Duration::from_millis(100));
     }
     std::thread::sleep(Duration::from_millis(400));
     let _ = fs::write(loss_file(), "0");
     let _ = fs::write(key_loss_file(), "0");
 
-    Some(E2eFixture { _bag: bag, stdin, rx, pid, wid })
+    Some(E2eFixture { driver, pid, wid })
 }
 
 // ── DOM registration oracle (trycua test apps serve an event log on 6769) ─────
@@ -364,20 +255,27 @@ const APP_API: &str = "http://127.0.0.1:6769";
 fn http_reset() {
     let _ = Command::new("curl.exe")
         .args(["-s", "-m", "3", "-X", "POST", &format!("{APP_API}/reset")])
-        .stdout(Stdio::null()).stderr(Stdio::null()).status();
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
 }
 /// Returns the `/events` body, or None if the app isn't serving the API.
 fn http_events() -> Option<String> {
     let out = Command::new("curl.exe")
         .args(["-s", "-m", "3", &format!("{APP_API}/events")])
-        .output().ok()?;
-    if !out.status.success() { return None; }
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
     let body = String::from_utf8_lossy(&out.stdout).into_owned();
-    // Reachable iff it looks like the JSON array the app returns.
-    if body.trim_start().starts_with('[') { Some(body) } else { None }
+    if body.trim_start().starts_with('[') {
+        Some(body)
+    } else {
+        None
+    }
 }
-/// True if the event log recorded at least one DOM event since the last reset
-/// (i.e. the action actually reached the page). None if the app has no API.
+/// True if the event log recorded at least one DOM event since the last reset.
 fn registered_since_reset() -> Option<bool> {
     http_events().map(|b| b.trim() != "[]" && !b.trim().is_empty())
 }
@@ -395,9 +293,7 @@ fn foreground_pid() -> u32 {
 /// The reliable "no z-raise / no foreground steal" oracle, independent of the
 /// machine's foreground-lock setting: after acting on a BACKGROUND target, the
 /// target's process must never become the foreground window. Polls for ~1.2s
-/// to also catch async self-reactivation (Chromium). `user_pid` is the window
-/// we expect to keep the foreground (the focus-monitor-win sentinel launched
-/// last); reported for diagnostics.
+/// to also catch async self-reactivation (Chromium).
 fn assert_target_stays_background<F: FnOnce()>(label: &str, target_pid: u32, action: F) {
     let user_pid = read_count(&focus_pid_file());
     let fg_before = foreground_pid();
@@ -410,44 +306,60 @@ fn assert_target_stays_background<F: FnOnce()>(label: &str, target_pid: u32, act
     let mut last_fg = fg_before;
     while Instant::now() < deadline {
         last_fg = foreground_pid();
-        if last_fg == target_pid { stole = true; break; }
+        if last_fg == target_pid {
+            stole = true;
+            break;
+        }
         std::thread::sleep(Duration::from_millis(80));
     }
-    assert!(!stole,
+    assert!(
+        !stole,
         "{label}: target pid {target_pid} BECAME the foreground window — z-raise / foreground steal. \
-         (expected user pid {user_pid}, fg_before={fg_before})");
+         (expected user pid {user_pid}, fg_before={fg_before})"
+    );
     println!("✅ {label}: target pid {target_pid} stayed background (foreground pid={last_fg}, user={user_pid})");
 }
 
 /// Shared body: default-mode left click into a webview target.
 fn webview_click_case(label: &str, exe: PathBuf) {
-    let mut fx = match setup(&exe, "") { Some(f) => f, None => return };
+    let mut fx = match setup(&exe, "") {
+        Some(f) => f,
+        None => return,
+    };
     let (pid, wid) = (fx.pid, fx.wid);
-    let snap = call(&mut fx.stdin, &fx.rx, 20, "get_window_state",
-        serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
-    let elem = find_idx_containing(&snap, "button").or_else(|| find_idx_containing(&snap, "click"));
+    let snap = fx.driver.call(
+        "get_window_state",
+        serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}),
+    );
+    let elem = ax::element_index_containing(snap.text(), "button")
+        .or_else(|| ax::element_index_containing(snap.text(), "click"));
 
     http_reset();
-    let mut last = serde_json::Value::Null;
+    let mut delivered = String::new();
+    let mut errored = false;
+    let mut needs_foreground = false;
     assert_target_stays_background(label, pid, || {
         let args = match elem {
             Some(idx) => serde_json::json!({"pid": pid as i64, "window_id": wid, "element_index": idx}),
             None => serde_json::json!({"pid": pid as i64, "window_id": wid, "x": 200, "y": 200}),
         };
-        last = call(&mut fx.stdin, &fx.rx, 21, "click", args);
+        let last = fx.driver.call("click", args);
+        errored = last.is_error();
+        needs_foreground = last.text().contains("background_unavailable");
+        delivered = last.text().to_string();
     });
-    assert!(!is_error(&last), "{label}: default-mode click errored: {}", result_text(&last));
-    assert!(!result_text(&last).contains("background_unavailable"),
-        "{label}: click should not need dispatch:foreground, got {:?}", result_text(&last));
+    assert!(!errored, "{label}: default-mode click errored: {delivered}");
+    assert!(
+        !needs_foreground,
+        "{label}: click should not need dispatch:foreground, got {delivered:?}"
+    );
     // Delivery is confirmed by the driver's own ✅ result (UIA Invoke fires the
-    // element's default action / DOM `click`; PostMessage/injection deliver the
-    // button events). The /events pointer-log is reported for info only — it
-    // does NOT capture accessibility-driven UIA Invoke (which raises `click`,
-    // not `pointerdown`), so a `[]` there is expected for the UIA path and is
-    // not a failure. The hard invariant of this suite is no-foreground-steal.
+    // element's default action / DOM `click`). The /events pointer-log is info
+    // only — it does NOT capture accessibility-driven UIA Invoke, so a `[]`
+    // there is expected for the UIA path. The hard invariant is no-foreground-steal.
     std::thread::sleep(Duration::from_millis(300));
     let reg = registered_since_reset().map(|b| b.to_string()).unwrap_or_else(|| "n/a".into());
-    println!("{label}: delivered={:?}  pointer-events-logged={reg}", result_text(&last));
+    println!("{label}: delivered={delivered:?}  pointer-events-logged={reg}");
 }
 
 // ── tests ─────────────────────────────────────────────────────────────────────
@@ -455,29 +367,43 @@ fn webview_click_case(label: &str, exe: PathBuf) {
 #[test]
 #[ignore]
 fn e2e_electron_background_click_no_z_raise() {
-    let Some(exe) = electron_exe() else { eprintln!("[e2e] no electron app — skipping"); return; };
+    let Some(exe) = electron_exe() else {
+        eprintln!("[e2e] no electron app — skipping");
+        return;
+    };
     webview_click_case("electron click (default dispatch)", exe);
 }
 
 #[test]
 #[ignore]
 fn e2e_tauri_background_click_no_z_raise() {
-    let Some(exe) = tauri_exe() else { eprintln!("[e2e] no tauri app — skipping"); return; };
+    let Some(exe) = tauri_exe() else {
+        eprintln!("[e2e] no tauri app — skipping");
+        return;
+    };
     webview_click_case("tauri click (default dispatch)", exe);
 }
 
 #[test]
 #[ignore]
 fn e2e_win32_notepad_background_click_no_z_raise() {
-    let mut fx = match setup(Path::new(r"C:\Windows\System32\notepad.exe"), "") { Some(f) => f, None => return };
+    let mut fx = match setup(Path::new(r"C:\Windows\System32\notepad.exe"), "") {
+        Some(f) => f,
+        None => return,
+    };
     let (pid, wid) = (fx.pid, fx.wid);
-    let mut last = serde_json::Value::Null;
+    let mut last_text = String::new();
+    let mut errored = false;
     assert_target_stays_background("notepad click (default dispatch)", pid, || {
-        last = call(&mut fx.stdin, &fx.rx, 21, "click",
-            serde_json::json!({"pid": pid as i64, "window_id": wid, "x": 120, "y": 120}));
+        let r = fx.driver.call(
+            "click",
+            serde_json::json!({"pid": pid as i64, "window_id": wid, "x": 120, "y": 120}),
+        );
+        errored = r.is_error();
+        last_text = r.text().to_string();
     });
-    assert!(!is_error(&last), "notepad click errored: {}", result_text(&last));
-    println!("notepad click result: {:?}", result_text(&last));
+    assert!(!errored, "notepad click errored: {last_text}");
+    println!("notepad click result: {last_text:?}");
 }
 
 /// Electron right-click (pen-barrel injection): no raise. Pen→right promotion
@@ -486,53 +412,74 @@ fn e2e_win32_notepad_background_click_no_z_raise() {
 #[test]
 #[ignore]
 fn e2e_electron_background_right_click_no_z_raise() {
-    let Some(exe) = electron_exe() else { eprintln!("[e2e] no electron app — skipping"); return; };
-    let mut fx = match setup(&exe, "") { Some(f) => f, None => return };
+    let Some(exe) = electron_exe() else {
+        eprintln!("[e2e] no electron app — skipping");
+        return;
+    };
+    let mut fx = match setup(&exe, "") {
+        Some(f) => f,
+        None => return,
+    };
     let (pid, wid) = (fx.pid, fx.wid);
-    let mut last = serde_json::Value::Null;
+    let mut last_text = String::new();
     assert_target_stays_background("electron right-click (default dispatch)", pid, || {
-        last = call(&mut fx.stdin, &fx.rx, 21, "click",
-            serde_json::json!({"pid": pid as i64, "window_id": wid, "x": 200, "y": 200, "button": "right"}));
+        let r = fx.driver.call(
+            "click",
+            serde_json::json!({"pid": pid as i64, "window_id": wid, "x": 200, "y": 200, "button": "right"}),
+        );
+        last_text = r.text().to_string();
     });
-    println!("electron right-click result: {:?}", result_text(&last));
+    println!("electron right-click result: {last_text:?}");
 }
 
 /// Electron TEXT typing: focus a field, then type — must register the text in
-/// the DOM AND never steal foreground / move the cursor. This is the "type into
-/// any window" half of the mission for plain text (WM_CHAR path, no foreground).
+/// the DOM AND never steal foreground / move the cursor.
 #[test]
 #[ignore]
 fn e2e_electron_background_type_text_no_z_raise() {
-    let Some(exe) = electron_exe() else { eprintln!("[e2e] no electron app — skipping"); return; };
-    let mut fx = match setup(&exe, "") { Some(f) => f, None => return };
+    let Some(exe) = electron_exe() else {
+        eprintln!("[e2e] no electron app — skipping");
+        return;
+    };
+    let mut fx = match setup(&exe, "") {
+        Some(f) => f,
+        None => return,
+    };
     let (pid, wid) = (fx.pid, fx.wid);
 
     // Focus a text field if the page exposes one (so the chars have a sink).
-    let snap = call(&mut fx.stdin, &fx.rx, 20, "get_window_state",
-        serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
-    let field = find_idx_containing(&snap, "edit")
-        .or_else(|| find_idx_containing(&snap, "text"))
-        .or_else(|| find_idx_containing(&snap, "input"));
+    let snap = fx.driver.call(
+        "get_window_state",
+        serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}),
+    );
+    let field = ax::element_index_containing(snap.text(), "edit")
+        .or_else(|| ax::element_index_containing(snap.text(), "text"))
+        .or_else(|| ax::element_index_containing(snap.text(), "input"));
     if let Some(idx) = field {
-        let _ = call(&mut fx.stdin, &fx.rx, 21, "click",
-            serde_json::json!({"pid": pid as i64, "window_id": wid, "element_index": idx}));
+        let _ = fx.driver.call(
+            "click",
+            serde_json::json!({"pid": pid as i64, "window_id": wid, "element_index": idx}),
+        );
         std::thread::sleep(Duration::from_millis(200));
     }
 
     http_reset();
-    let mut last = serde_json::Value::Null;
+    let mut last_text = String::new();
+    let mut errored = false;
     assert_target_stays_background("electron type_text (default dispatch)", pid, || {
-        last = call(&mut fx.stdin, &fx.rx, 22, "type_text",
-            serde_json::json!({"pid": pid as i64, "window_id": wid, "text": "cuatest"}));
+        let r = fx.driver.call(
+            "type_text",
+            serde_json::json!({"pid": pid as i64, "window_id": wid, "text": "cuatest"}),
+        );
+        errored = r.is_error();
+        last_text = r.text().to_string();
     });
-    assert!(!is_error(&last), "type_text errored: {}", result_text(&last));
+    assert!(!errored, "type_text errored: {last_text}");
     std::thread::sleep(Duration::from_millis(300));
     if let Some(reg) = registered_since_reset() {
-        // Soft: typing needs a focused sink; if the page had no focusable field
-        // we can't fault the input path. Report either way.
-        println!("electron type_text: registered={reg}  result={:?}", result_text(&last));
+        println!("electron type_text: registered={reg}  result={last_text:?}");
     } else {
-        println!("electron type_text result: {:?}", result_text(&last));
+        println!("electron type_text result: {last_text:?}");
     }
 }
 
@@ -541,18 +488,29 @@ fn e2e_electron_background_type_text_no_z_raise() {
 #[test]
 #[ignore]
 fn e2e_electron_background_keycombo_no_z_raise() {
-    let Some(exe) = electron_exe() else { eprintln!("[e2e] no electron app — skipping"); return; };
-    let mut fx = match setup(&exe, "") { Some(f) => f, None => return };
+    let Some(exe) = electron_exe() else {
+        eprintln!("[e2e] no electron app — skipping");
+        return;
+    };
+    let mut fx = match setup(&exe, "") {
+        Some(f) => f,
+        None => return,
+    };
     let (pid, wid) = (fx.pid, fx.wid);
-    let mut last = serde_json::Value::Null;
+    let mut last_text = String::new();
+    let mut errored = false;
     assert_target_stays_background("electron Ctrl+A (default dispatch)", pid, || {
-        last = call(&mut fx.stdin, &fx.rx, 21, "press_key",
-            serde_json::json!({"pid": pid as i64, "window_id": wid, "key": "a", "modifiers": ["control"]}));
+        let r = fx.driver.call(
+            "press_key",
+            serde_json::json!({"pid": pid as i64, "window_id": wid, "key": "a", "modifiers": ["control"]}),
+        );
+        errored = r.is_error();
+        last_text = r.text().to_string();
     });
-    // Capability-first: the combo must be DELIVERED, not refused. (UX is
-    // best-effort: the cloaked focus restores foreground, so the no-steal
-    // assertion above still holds post-action.)
-    assert!(!is_error(&last) && !result_text(&last).contains("background_unavailable"),
-        "Ctrl+A must be delivered (capability over UX), got: {:?}", result_text(&last));
-    println!("electron Ctrl+A delivered: {:?}", result_text(&last));
+    // Capability-first: the combo must be DELIVERED, not refused.
+    assert!(
+        !errored && !last_text.contains("background_unavailable"),
+        "Ctrl+A must be delivered (capability over UX), got: {last_text:?}"
+    );
+    println!("electron Ctrl+A delivered: {last_text:?}");
 }

--- a/libs/cua-driver/rust/crates/cua-driver/tests/element_token_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/element_token_test.rs
@@ -7,6 +7,11 @@
 //! `cua-driver-core::element_token` and the per-platform tool modules —
 //! this file is only for what's visible across the JSON-RPC boundary.
 
+// element_token resolution is exercised on macOS/Linux only; gate the whole
+// file (helpers included) so Windows excludes it instead of warning about the
+// then-unused tools/list helpers.
+#![cfg(any(target_os = "macos", target_os = "linux"))]
+
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Command, Stdio};
 

--- a/libs/cua-driver/rust/crates/cua-driver/tests/element_token_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/element_token_test.rs
@@ -10,16 +10,7 @@
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Command, Stdio};
 
-fn binary_path() -> std::path::PathBuf {
-    // CARGO_MANIFEST_DIR is crates/cua-driver; workspace root is two
-    // levels up.
-    let manifest = std::env::var("CARGO_MANIFEST_DIR")
-        .expect("CARGO_MANIFEST_DIR not set");
-    std::path::PathBuf::from(manifest)
-        .parent().unwrap()  // crates/
-        .parent().unwrap()  // workspace root (cua-driver-rs/)
-        .join("target/debug/cua-driver")
-}
+use cua_driver_testkit::driver_binary;
 
 fn send_request(stdin: &mut impl Write, request: &serde_json::Value) {
     let line = serde_json::to_string(request).unwrap();
@@ -36,7 +27,7 @@ fn read_response(reader: &mut impl BufRead) -> serde_json::Value {
 /// `tools/list` response. Skips the test silently if the binary hasn't
 /// been built (CI builds it separately).
 fn fetch_tools_list() -> Option<serde_json::Value> {
-    let binary = binary_path();
+    let binary = driver_binary();
     if !binary.exists() {
         eprintln!("Binary not found at {:?} — run `cargo build` first", binary);
         return None;

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
@@ -26,64 +26,25 @@
 
 #![cfg(target_os = "macos")]
 
-use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
+use cua_driver_testkit::ax::{element_index_by_id, has_id, looks_empty};
+use cua_driver_testkit::{Driver, McpDriver, ToolResponse};
+
 // ── paths ────────────────────────────────────────────────────────────────────
-
-fn workspace_root() -> PathBuf {
-    let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
-    // crates/cua-driver -> rust
-    PathBuf::from(manifest).parent().unwrap().parent().unwrap().to_owned()
-}
-
-fn driver_binary() -> PathBuf {
-    let root = workspace_root();
-    let release = root.join("target/release/cua-driver");
-    if release.exists() { return release; }
-    root.join("target/debug/cua-driver")
-}
 
 fn harness_app() -> PathBuf {
     if let Ok(p) = std::env::var("HARNESS_APPKIT_APP") {
         let pb = PathBuf::from(p);
         if pb.exists() { return pb; }
     }
-    workspace_root().join("test-apps/harness-appkit/CuaTestHarness.AppKit.app")
+    cua_driver_testkit::harness_app("harness-appkit", "CuaTestHarness.AppKit.app")
 }
 
 fn harness_exe() -> PathBuf {
     harness_app().join("Contents/MacOS/CuaTestHarness.AppKit")
-}
-
-// ── JSON-RPC ────────────────────────────────────────────────────────────────
-
-fn send(stdin: &mut ChildStdin, req: serde_json::Value) {
-    writeln!(stdin, "{}", serde_json::to_string(&req).unwrap()).unwrap();
-}
-
-fn recv(stdout: &mut BufReader<&mut ChildStdout>) -> serde_json::Value {
-    let mut line = String::new();
-    stdout.read_line(&mut line).expect("read response");
-    serde_json::from_str(line.trim()).expect("parse json")
-}
-
-fn init(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>) {
-    send(stdin, serde_json::json!({
-        "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}
-    }));
-    let _ = recv(stdout);
-}
-
-fn tools_call(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
-              id: u32, name: &str, args: serde_json::Value) -> serde_json::Value {
-    send(stdin, serde_json::json!({
-        "jsonrpc": "2.0", "id": id, "method": "tools/call",
-        "params": { "name": name, "arguments": args }
-    }));
-    recv(stdout)
 }
 
 // ── harness fixture ──────────────────────────────────────────────────────────
@@ -124,31 +85,8 @@ impl Drop for Harness {
 
 // ── window / element helpers ─────────────────────────────────────────────────
 
-fn find_harness_window(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
-                       pid: u32, title_substr: &str) -> Option<(u64, String)> {
-    let deadline = std::time::Instant::now() + Duration::from_secs(12);
-    let mut id = 10u32;
-    loop {
-        let resp = tools_call(stdin, stdout, id, "list_windows",
-            serde_json::json!({ "pid": pid as i64 }));
-        id = id.wrapping_add(1);
-        if let Some(wins) = resp["result"]["structuredContent"]["windows"].as_array() {
-            for w in wins {
-                if w["pid"].as_u64() != Some(pid as u64) { continue; }
-                let title = w["title"].as_str().unwrap_or("");
-                if title.contains(title_substr) {
-                    return Some((w["window_id"].as_u64()?, title.to_string()));
-                }
-            }
-        }
-        if std::time::Instant::now() >= deadline { return None; }
-        std::thread::sleep(Duration::from_millis(150));
-    }
-}
-
-fn snapshot_elements(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
-                     pid: u32, window_id: u64) -> serde_json::Value {
-    tools_call(stdin, stdout, 20, "get_window_state",
+fn snapshot_elements(driver: &mut McpDriver, pid: u32, window_id: u64) -> ToolResponse {
+    driver.call("get_window_state",
         serde_json::json!({
             "pid": pid as i64,
             "window_id": window_id,
@@ -156,74 +94,32 @@ fn snapshot_elements(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildSt
         }))
 }
 
-fn snapshot_text(snapshot: &serde_json::Value) -> &str {
-    snapshot["result"]["content"][0]["text"].as_str().unwrap_or("")
-}
-
-fn elements_have_aid(snapshot: &serde_json::Value, aid: &str) -> bool {
-    snapshot_text(snapshot).contains(&format!("id={aid}"))
-}
-
-fn find_element_index_by_aid(snapshot: &serde_json::Value, aid: &str) -> Option<u64> {
-    let needle = format!("id={aid}");
-    for line in snapshot_text(snapshot).lines() {
-        if !line.contains(&needle) { continue; }
-        let start = line.find('[')? + 1;
-        let end = line[start..].find(']')? + start;
-        return line[start..end].trim().parse().ok();
-    }
-    None
-}
-
-fn ax_tree_looks_empty(snapshot: &serde_json::Value) -> bool {
-    let txt = snapshot_text(snapshot);
-    let line_count = txt.lines().count();
-    txt.is_empty() || line_count <= 2 ||
-        txt.contains("Accessibility permission required") ||
-        txt.contains("TCC permission")
-}
-
 // ── tests ────────────────────────────────────────────────────────────────────
 
 #[test]
 #[ignore]
 fn harness_appkit_smoke() {
-    let driver = driver_binary();
-    if !driver.exists() {
-        eprintln!("cua-driver not built — run `cargo build` first");
-        return;
-    }
+    let Some(mut driver) = McpDriver::spawn() else { return };
     let harness = match Harness::launch() {
         Some(h) => h,
         None => { eprintln!("harness not built — skipping"); return; }
     };
     println!("harness pid={}", harness.pid);
 
-    let mut child = Command::new(&driver)
-        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
-        .spawn().expect("spawn cua-driver");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut raw_stdout = child.stdout.take().unwrap();
-    let mut stdout = BufReader::new(&mut raw_stdout);
-
-    init(&mut stdin, &mut stdout);
-
-    let (wid, title) = find_harness_window(&mut stdin, &mut stdout, harness.pid,
-                                           "CuaTestHarness AppKit")
+    let (wid, title) = driver.find_window(harness.pid as i64, "CuaTestHarness AppKit")
         .expect("main window not found via list_windows");
     println!("main window: id={wid} title={title:?}");
 
-    let snap = snapshot_elements(&mut stdin, &mut stdout, harness.pid, wid);
+    let snap = snapshot_elements(&mut driver, harness.pid, wid);
 
-    if ax_tree_looks_empty(&snap) {
+    if looks_empty(snap.text()) {
         eprintln!("AX tree empty — likely TCC Accessibility not granted to the test runner. \
                    Skipping element-assertion phase. To enable: System Settings → Privacy & \
                    Security → Accessibility → add the binary running `cargo test`.");
-        let _ = child.kill();
         return;
     }
 
-    let text = snapshot_text(&snap);
+    let text = snap.text();
     println!("snapshot:\n{text}");
 
     // AppKit AX quirk (mirrors the WPF behavior documented in
@@ -240,7 +136,7 @@ fn harness_appkit_smoke() {
         "menu-test-item",              // NSMenuItem (Mac-specific)
         "btn-exit",
     ] {
-        assert!(elements_have_aid(&snap, aid),
+        assert!(has_id(snap.text(), aid),
                 "missing AX identifier {aid} in AppKit snapshot");
     }
 
@@ -251,8 +147,6 @@ fn harness_appkit_smoke() {
     // AXStaticText nodes — assert on their starting text instead of ids.
     assert!(text.contains("L=0 R=0 D=0"), "click_count label missing");
     assert!(text.contains("(none)"),       "last_action label missing");
-
-    let _ = child.kill();
 }
 
 /// text_input: type_text into the NSTextField, verify the mirror label
@@ -261,49 +155,37 @@ fn harness_appkit_smoke() {
 #[test]
 #[ignore]
 fn harness_appkit_text_input() {
-    let driver = driver_binary();
-    if !driver.exists() { eprintln!("cua-driver not built"); return; }
+    let Some(mut driver) = McpDriver::spawn() else { return };
     let harness = match Harness::launch() {
         Some(h) => h,
         None => { eprintln!("harness not built — skipping"); return; }
     };
 
-    let mut child = Command::new(&driver)
-        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
-        .spawn().expect("spawn cua-driver");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut raw_stdout = child.stdout.take().unwrap();
-    let mut stdout = BufReader::new(&mut raw_stdout);
-    init(&mut stdin, &mut stdout);
-
-    let (wid, _) = find_harness_window(&mut stdin, &mut stdout, harness.pid,
-                                       "CuaTestHarness AppKit")
+    let (wid, _) = driver.find_window(harness.pid as i64, "CuaTestHarness AppKit")
         .expect("main window not found");
-    let snap_pre = snapshot_elements(&mut stdin, &mut stdout, harness.pid, wid);
-    if ax_tree_looks_empty(&snap_pre) {
-        eprintln!("AX empty — TCC not granted; skipping"); let _ = child.kill(); return;
+    let snap_pre = snapshot_elements(&mut driver, harness.pid, wid);
+    if looks_empty(snap_pre.text()) {
+        eprintln!("AX empty — TCC not granted; skipping"); return;
     }
-    let idx = find_element_index_by_aid(&snap_pre, "txt-input")
+    let idx = element_index_by_id(snap_pre.text(), "txt-input")
         .expect("txt-input element_index not found");
 
     // set_value via AX is the deterministic background path; type_text would
     // also work but races with cursor focus on cold-launched windows.
-    let resp = tools_call(&mut stdin, &mut stdout, 40, "set_value",
+    let resp = driver.call("set_value",
         serde_json::json!({
             "pid": harness.pid as i64,
             "window_id": wid,
             "element_index": idx,
             "value": "hello-cua"
         }));
-    println!("set_value resp: {resp}");
+    println!("set_value resp: {}", resp.text());
 
     std::thread::sleep(Duration::from_millis(250));
-    let snap_post = snapshot_elements(&mut stdin, &mut stdout, harness.pid, wid);
-    let post_text = snapshot_text(&snap_post).to_owned();
+    let snap_post = snapshot_elements(&mut driver, harness.pid, wid);
+    let post_text = snap_post.text().to_owned();
     assert!(post_text.contains("hello-cua"),
             "text_input value did not propagate to mirror; snapshot:\n{post_text}");
-
-    let _ = child.kill();
 }
 
 /// type_text: synthesize a keystroke into the NSTextField (CGEvent
@@ -312,37 +194,27 @@ fn harness_appkit_text_input() {
 #[test]
 #[ignore]
 fn harness_appkit_type_text_keystroke() {
-    let driver = driver_binary();
-    if !driver.exists() { eprintln!("cua-driver not built"); return; }
+    let Some(mut driver) = McpDriver::spawn() else { return };
     let harness = match Harness::launch() {
         Some(h) => h,
         None => { eprintln!("harness not built — skipping"); return; }
     };
 
-    let mut child = Command::new(&driver)
-        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
-        .spawn().expect("spawn cua-driver");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut raw_stdout = child.stdout.take().unwrap();
-    let mut stdout = BufReader::new(&mut raw_stdout);
-    init(&mut stdin, &mut stdout);
-
-    let (wid, _) = find_harness_window(&mut stdin, &mut stdout, harness.pid,
-                                       "CuaTestHarness AppKit")
+    let (wid, _) = driver.find_window(harness.pid as i64, "CuaTestHarness AppKit")
         .expect("main window not found");
-    let snap_pre = snapshot_elements(&mut stdin, &mut stdout, harness.pid, wid);
-    if ax_tree_looks_empty(&snap_pre) {
-        eprintln!("AX empty — TCC not granted; skipping"); let _ = child.kill(); return;
+    let snap_pre = snapshot_elements(&mut driver, harness.pid, wid);
+    if looks_empty(snap_pre.text()) {
+        eprintln!("AX empty — TCC not granted; skipping"); return;
     }
-    let idx: u64 = if let Some(i) = find_element_index_by_aid(&snap_pre, "txt-input") {
+    let idx: u64 = if let Some(i) = element_index_by_id(snap_pre.text(), "txt-input") {
         i
     } else {
-        eprintln!("txt-input not found; skipping"); let _ = child.kill(); return;
+        eprintln!("txt-input not found; skipping"); return;
     };
 
     // Focus the field first so the keystrokes land in it. AX press on
     // a text field has the side effect of giving it keyboard focus.
-    let _ = tools_call(&mut stdin, &mut stdout, 60, "click",
+    let _ = driver.call("click",
         serde_json::json!({
             "pid": harness.pid as i64, "window_id": wid,
             "element_index": idx, "action": "press"
@@ -351,20 +223,18 @@ fn harness_appkit_type_text_keystroke() {
 
     // CGEvent-based type_text against the focused field (does NOT use
     // set_value — exercises the keystroke synthesis chain).
-    let resp = tools_call(&mut stdin, &mut stdout, 61, "type_text",
+    let resp = driver.call("type_text",
         serde_json::json!({
             "pid": harness.pid as i64, "window_id": wid,
             "text": "kbd-cua"
         }));
-    println!("type_text resp: {resp}");
+    println!("type_text resp: {}", resp.text());
     std::thread::sleep(Duration::from_millis(250));
 
-    let snap_post = snapshot_elements(&mut stdin, &mut stdout, harness.pid, wid);
-    let post = snapshot_text(&snap_post).to_owned();
+    let snap_post = snapshot_elements(&mut driver, harness.pid, wid);
+    let post = snap_post.text().to_owned();
     assert!(post.contains("kbd-cua"),
             "type_text keystroke did not land in the text field; snapshot:\n{post}");
-
-    let _ = child.kill();
 }
 
 /// scroll: scroll the NSScrollView downward, verify the offset label
@@ -391,32 +261,22 @@ fn harness_appkit_type_text_keystroke() {
 #[ignore]
 #[should_panic(expected = "scroll offset label did not advance from 0")]
 fn harness_appkit_scroll_expected_fail() {
-    let driver = driver_binary();
-    if !driver.exists() { eprintln!("cua-driver not built"); return; }
+    let Some(mut driver) = McpDriver::spawn() else { return };
     let harness = match Harness::launch() {
         Some(h) => h,
         None => { eprintln!("harness not built — skipping"); return; }
     };
 
-    let mut child = Command::new(&driver)
-        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
-        .spawn().expect("spawn cua-driver");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut raw_stdout = child.stdout.take().unwrap();
-    let mut stdout = BufReader::new(&mut raw_stdout);
-    init(&mut stdin, &mut stdout);
-
-    let (wid, _) = find_harness_window(&mut stdin, &mut stdout, harness.pid,
-                                       "CuaTestHarness AppKit")
+    let (wid, _) = driver.find_window(harness.pid as i64, "CuaTestHarness AppKit")
         .expect("main window not found");
-    let snap_pre = snapshot_elements(&mut stdin, &mut stdout, harness.pid, wid);
-    if ax_tree_looks_empty(&snap_pre) {
-        eprintln!("AX empty — TCC not granted; skipping"); let _ = child.kill(); return;
+    let snap_pre = snapshot_elements(&mut driver, harness.pid, wid);
+    if looks_empty(snap_pre.text()) {
+        eprintln!("AX empty — TCC not granted; skipping"); return;
     }
     // Pre-condition: offset label should be at "0" (the controller
     // initial state). The label text appears as an AXStaticText leaf
     // immediately after the AXTextArea body in the rendered tree.
-    let pre = snapshot_text(&snap_pre).to_owned();
+    let pre = snap_pre.text().to_owned();
     let pre_has_zero_offset = pre.lines()
         .any(|l| l.trim() == "- AXStaticText = \"0\"");
     assert!(pre_has_zero_offset, "scroll offset label not at 0 pre-scroll");
@@ -424,18 +284,18 @@ fn harness_appkit_scroll_expected_fail() {
     // Scroll the scroll view down a few ticks. The scroll tool takes
     // window-local pixel coords; pick a point inside the scroller
     // (the scroll target sits roughly mid-window).
-    let resp = tools_call(&mut stdin, &mut stdout, 70, "scroll",
+    let resp = driver.call("scroll",
         serde_json::json!({
             "pid": harness.pid as i64, "window_id": wid,
             "x": 180, "y": 450,            // inside the scroll view
             "direction": "down",
             "amount": 5
         }));
-    println!("scroll resp: {resp}");
+    println!("scroll resp: {}", resp.text());
     std::thread::sleep(Duration::from_millis(250));
 
-    let snap_post = snapshot_elements(&mut stdin, &mut stdout, harness.pid, wid);
-    let post = snapshot_text(&snap_post).to_owned();
+    let snap_post = snapshot_elements(&mut driver, harness.pid, wid);
+    let post = snap_post.text().to_owned();
     // After scroll, the offset label should no longer be "0" — any
     // positive integer indicates the bounds-change notification fired
     // and the label updated. We don't pin a specific value (scroll
@@ -451,8 +311,6 @@ fn harness_appkit_scroll_expected_fail() {
         "scroll offset label did not advance from 0; pre: {} \"0\" leaves; post: {} \"0\" leaves",
         pre_count, unchanged_count
     );
-
-    let _ = child.kill();
 }
 
 /// counter: click the increment button via element_index, verify the
@@ -460,52 +318,38 @@ fn harness_appkit_scroll_expected_fail() {
 #[test]
 #[ignore]
 fn harness_appkit_counter() {
-    let driver = driver_binary();
-    if !driver.exists() {
-        eprintln!("cua-driver not built — skipping"); return;
-    }
+    let Some(mut driver) = McpDriver::spawn() else { return };
     let harness = match Harness::launch() {
         Some(h) => h,
         None => { eprintln!("harness not built — skipping"); return; }
     };
 
-    let mut child = Command::new(&driver)
-        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
-        .spawn().expect("spawn cua-driver");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut raw_stdout = child.stdout.take().unwrap();
-    let mut stdout = BufReader::new(&mut raw_stdout);
-    init(&mut stdin, &mut stdout);
-
-    let (wid, _) = find_harness_window(&mut stdin, &mut stdout, harness.pid,
-                                       "CuaTestHarness AppKit")
+    let (wid, _) = driver.find_window(harness.pid as i64, "CuaTestHarness AppKit")
         .expect("main window not found");
-    let snap_pre = snapshot_elements(&mut stdin, &mut stdout, harness.pid, wid);
-    if ax_tree_looks_empty(&snap_pre) {
-        eprintln!("AX empty — TCC not granted; skipping"); let _ = child.kill(); return;
+    let snap_pre = snapshot_elements(&mut driver, harness.pid, wid);
+    if looks_empty(snap_pre.text()) {
+        eprintln!("AX empty — TCC not granted; skipping"); return;
     }
-    let pre_text = snapshot_text(&snap_pre).to_owned();
+    let pre_text = snap_pre.text().to_owned();
     assert!(pre_text.contains("\"0\""), "counter not 0 pre-click; snapshot:\n{pre_text}");
 
-    let idx = find_element_index_by_aid(&snap_pre, "btn-increment")
+    let idx = element_index_by_id(snap_pre.text(), "btn-increment")
         .expect("btn-increment element_index not found");
 
-    let click_resp = tools_call(&mut stdin, &mut stdout, 30, "click",
+    let click_resp = driver.call("click",
         serde_json::json!({
             "pid": harness.pid as i64,
             "window_id": wid,
             "element_index": idx,
             "action": "press"
         }));
-    println!("click resp: {}", click_resp);
+    println!("click resp: {}", click_resp.text());
 
     // Let the AppKit run-loop process the press and refresh the label.
     std::thread::sleep(Duration::from_millis(200));
 
-    let snap_post = snapshot_elements(&mut stdin, &mut stdout, harness.pid, wid);
-    let post_text = snapshot_text(&snap_post).to_owned();
+    let snap_post = snapshot_elements(&mut driver, harness.pid, wid);
+    let post_text = snap_post.text().to_owned();
     assert!(post_text.contains("\"1\""),
             "counter did not advance to 1 after press; post snapshot:\n{post_text}");
-
-    let _ = child.kill();
 }

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_bg_modality_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_bg_modality_test.rs
@@ -19,25 +19,22 @@
 
 #![cfg(target_os = "windows")]
 
-use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::process::{Command, Stdio};
 use std::time::Duration;
+
+use cua_driver_testkit::ax::element_index_by_id;
+use cua_driver_testkit::{harness_app, workspace_root, Driver, McpDriver};
 
 // ── paths ────────────────────────────────────────────────────────────────────
 
-fn workspace_root() -> PathBuf {
-    let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
-    PathBuf::from(manifest).parent().unwrap().parent().unwrap().to_owned()
-}
-fn driver_binary() -> PathBuf { workspace_root().join("target/debug/cua-driver.exe") }
 fn focus_monitor_binary() -> PathBuf { workspace_root().join("target/debug/focus-monitor-win.exe") }
 fn harness_wpf_exe() -> PathBuf {
     if let Ok(p) = std::env::var("HARNESS_WPF_EXE") {
         let pb = PathBuf::from(p);
         if pb.exists() { return pb; }
     }
-    workspace_root().join("test-apps/harness-wpf/CuaTestHarness.Wpf.exe")
+    harness_app("harness-wpf", "CuaTestHarness.Wpf.exe")
 }
 
 fn loss_file()      -> PathBuf { std::env::temp_dir().join("focus_monitor_losses.txt") }
@@ -58,78 +55,17 @@ fn read_count(p: &std::path::Path) -> u32 {
         .unwrap_or_else(|e| panic!("failed parsing sentinel counter {p:?} as u32: {e}"))
 }
 
-// ── JSON-RPC ─────────────────────────────────────────────────────────────────
-
-fn send(stdin: &mut ChildStdin, req: serde_json::Value) {
-    writeln!(stdin, "{}", serde_json::to_string(&req).unwrap()).unwrap();
-}
-fn recv(stdout: &mut BufReader<&mut ChildStdout>) -> serde_json::Value {
-    let mut line = String::new();
-    stdout.read_line(&mut line).expect("read");
-    serde_json::from_str(line.trim()).expect("json")
-}
-fn init(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>) {
-    send(stdin, serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}));
-    let _ = recv(stdout);
-}
-fn call(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
-        id: u32, name: &str, args: serde_json::Value) -> serde_json::Value {
-    send(stdin, serde_json::json!({
-        "jsonrpc":"2.0","id":id,"method":"tools/call",
-        "params":{"name":name,"arguments":args}
-    }));
-    recv(stdout)
-}
-
-fn snapshot_text(s: &serde_json::Value) -> &str {
-    s["result"]["content"][0]["text"].as_str().unwrap_or("")
-}
-fn find_idx_by_aid(s: &serde_json::Value, aid: &str) -> Option<u64> {
-    let needle = format!("id={aid}");
-    for line in snapshot_text(s).lines() {
-        if !line.contains(&needle) { continue; }
-        let st = line.find('[')? + 1;
-        let en = line[st..].find(']')? + st;
-        return line[st..en].trim().parse().ok();
-    }
-    None
-}
-
 // ── shared fixture ───────────────────────────────────────────────────────────
 
-struct BgFixture {
-    harness: Child,
-    fm: Child,
-    driver: Child,
-    driver_stdin: ChildStdin,
-    driver_stdout: ChildStdout,
-    harness_pid: u32,
-    harness_wid: u64,
-}
-
-impl Drop for BgFixture {
-    fn drop(&mut self) {
-        let _ = self.driver.kill();
-        let _ = self.driver.wait();
-        let _ = self.harness.kill();
-        let _ = self.harness.wait();
-        let _ = self.fm.kill();
-        let _ = self.fm.wait();
-        std::thread::sleep(Duration::from_millis(300));
-    }
-}
-
 /// Launch sequence:
-///  1. WPF harness (becomes foreground briefly on its own activation)
+///  0. cua-driver MCP server (headless stdio; its reaper owns the harness +
+///     sentinel below, so any early-return or panic reaps the whole tree).
+///  1. WPF harness (becomes foreground briefly on its own activation).
 ///  2. focus-monitor-win sentinel — its OnLoad SetForegroundWindow displaces
 ///     the harness; sentinel is now z+0, harness z+1.
-///  3. cua-driver child
-///  4. Reset losses.txt to 0 (sentinel may have logged its own startup activate)
-fn setup() -> Option<BgFixture> {
-    let driver_bin = driver_binary();
-    if !driver_bin.exists() {
-        eprintln!("cua-driver.exe not built — skipping"); return None;
-    }
+///  3. Reset losses.txt to 0 (sentinel may have logged its own startup activate)
+///     and resolve the harness window (pid + window_id).
+fn setup() -> Option<(McpDriver, u32, u64)> {
     let fm_bin = focus_monitor_binary();
     if !fm_bin.exists() {
         eprintln!("focus-monitor-win.exe not built — skipping"); return None;
@@ -147,30 +83,30 @@ fn setup() -> Option<BgFixture> {
     let _ = std::fs::remove_file(focus_pid_file());
     let _ = std::fs::remove_file(focus_hwnd_file());
 
-    let mut harness = Command::new(&h_exe)
-        .stdout(Stdio::null()).stderr(Stdio::null())
-        .spawn().ok()?;
-    let harness_pid = harness.id();
+    // Spawn the cua-driver MCP server (skips if the binary isn't built).
+    let mut driver = McpDriver::spawn()?;
+
+    // 1. WPF harness, launched through the reaper so it can't outlive the test.
+    driver
+        .reaper()
+        .spawn(Command::new(&h_exe).stdout(Stdio::null()).stderr(Stdio::null()))
+        .ok()?;
     std::thread::sleep(Duration::from_secs(1));
 
-    // Launch sentinel. focus-monitor-win activates its own window which
-    // displaces the harness.
-    let mut fm = match Command::new(&fm_bin)
-        .stdout(Stdio::null()).stderr(Stdio::null())
-        .spawn()
+    // 2. Launch sentinel. focus-monitor-win activates its own window which
+    //    displaces the harness.
+    if driver
+        .reaper()
+        .spawn(Command::new(&fm_bin).stdout(Stdio::null()).stderr(Stdio::null()))
+        .is_err()
     {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("focus-monitor-win spawn failed: {e}");
-            // Reap the harness we already spawned so it doesn't leak.
-            let _ = harness.kill();
-            let _ = harness.wait();
-            return None;
-        }
-    };
-    // Wait for sentinel to publish its pid+hwnd files (so we know it's
-    // up and has claimed foreground). On timeout we MUST reap both child
-    // processes so they don't poison subsequent tests.
+        eprintln!("focus-monitor-win spawn failed");
+        return None;
+    }
+
+    // Wait for sentinel to publish its pid+hwnd files (so we know it's up and
+    // has claimed foreground). On timeout we return None; dropping `driver`
+    // reaps the harness + sentinel so they don't poison subsequent tests.
     let deadline = std::time::Instant::now() + Duration::from_secs(10);
     loop {
         let pid_ok = std::fs::read_to_string(focus_pid_file()).ok()
@@ -180,10 +116,6 @@ fn setup() -> Option<BgFixture> {
         if pid_ok && hwnd_ok { break; }
         if std::time::Instant::now() > deadline {
             eprintln!("focus-monitor sentinel never published pid/hwnd files");
-            let _ = harness.kill();
-            let _ = harness.wait();
-            let _ = fm.kill();
-            let _ = fm.wait();
             return None;
         }
         std::thread::sleep(Duration::from_millis(100));
@@ -198,45 +130,21 @@ fn setup() -> Option<BgFixture> {
     let _ = std::fs::write(key_loss_file(), "0");
     let _ = std::fs::write(key_gain_file(), "0");
 
-    let mut driver = match Command::new(&driver_bin)
-        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
-        .spawn()
-    {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("cua-driver spawn failed: {e}");
-            let _ = harness.kill(); let _ = harness.wait();
-            let _ = fm.kill();      let _ = fm.wait();
-            return None;
-        }
-    };
-    let mut driver_stdin = driver.stdin.take().unwrap();
-    let driver_stdout_raw = driver.stdout.take().unwrap();
-    let mut driver_stdout = driver_stdout_raw;
-    {
-        let mut stdout = BufReader::new(&mut driver_stdout);
-        init(&mut driver_stdin, &mut stdout);
-        let resp = call(&mut driver_stdin, &mut stdout, 10, "list_windows",
-            serde_json::json!({"pid": harness_pid as i64}));
-        let wid = resp["result"]["structuredContent"]["windows"].as_array()
-            .and_then(|a| a.iter().find_map(|w| {
-                if w["pid"].as_u64() == Some(harness_pid as u64)
-                    && w["title"].as_str().map(|t| t.contains("CuaTestHarness WPF")).unwrap_or(false)
-                { w["window_id"].as_u64() } else { None }
-            }))
-            .expect("harness window not found");
-        drop(stdout);
-        return Some(BgFixture {
-            harness, fm, driver, driver_stdin, driver_stdout,
-            harness_pid, harness_wid: wid,
-        });
-    }
-}
+    // Resolve the harness window (pid + window_id) by title. The WPF harness is
+    // its own window process, so list_windows surfaces it directly.
+    let resp = driver.call("list_windows", serde_json::json!({}));
+    let (harness_pid, harness_wid) = resp.structured()["windows"].as_array()
+        .and_then(|a| a.iter().find_map(|w| {
+            let title = w["title"].as_str().unwrap_or("");
+            if title.contains("CuaTestHarness WPF") {
+                Some((w["pid"].as_u64()? as u32, w["window_id"].as_u64()?))
+            } else {
+                None
+            }
+        }))
+        .expect("harness window not found");
 
-fn with_session<F, R>(fx: &mut BgFixture, f: F) -> R
-where F: FnOnce(&mut ChildStdin, &mut BufReader<&mut ChildStdout>, u32, u64) -> R {
-    let mut stdout = BufReader::new(&mut fx.driver_stdout);
-    f(&mut fx.driver_stdin, &mut stdout, fx.harness_pid, fx.harness_wid)
+    Some((driver, harness_pid, harness_wid))
 }
 
 /// Strict mode: action must not generate ANY sentinel-loss event.
@@ -296,12 +204,10 @@ where F: FnOnce() {
 #[test]
 #[ignore]
 fn bg_modality_get_window_state_no_focus_steal() {
-    let mut fx = match setup() { Some(f) => f, None => return };
-    with_session(&mut fx, |stdin, stdout, pid, wid| {
-        assert_no_focus_steal("get_window_state(som)", || {
-            let _ = call(stdin, stdout, 30, "get_window_state",
-                serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "som"}));
-        });
+    let (mut driver, pid, wid) = match setup() { Some(x) => x, None => return };
+    assert_no_focus_steal("get_window_state(som)", || {
+        let _ = driver.call("get_window_state",
+            serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "som"}));
     });
 }
 
@@ -323,29 +229,27 @@ fn bg_modality_get_window_state_no_focus_steal() {
 #[test]
 #[ignore]
 fn bg_modality_uia_invoke_click_DOCUMENTED_steals_focus() {
-    let mut fx = match setup() { Some(f) => f, None => return };
-    with_session(&mut fx, |stdin, stdout, pid, wid| {
-        let _ = call(stdin, stdout, 29, "set_agent_cursor_enabled",
-            serde_json::json!({"enabled": false}));
-        std::thread::sleep(Duration::from_millis(200));
+    let (mut driver, pid, wid) = match setup() { Some(x) => x, None => return };
+    let _ = driver.call("set_agent_cursor_enabled",
+        serde_json::json!({"enabled": false}));
+    std::thread::sleep(Duration::from_millis(200));
 
-        let snap = call(stdin, stdout, 30, "get_window_state",
-            serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
-        let idx = find_idx_by_aid(&snap, "btn-increment").expect("btn-increment");
+    let snap = driver.call("get_window_state",
+        serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
+    let idx = element_index_by_id(snap.text(), "btn-increment").expect("btn-increment");
 
-        let before = read_count(&loss_file());
-        let _ = call(stdin, stdout, 31, "click",
-            serde_json::json!({"pid": pid as i64, "window_id": wid, "element_index": idx}));
-        std::thread::sleep(Duration::from_millis(500));
-        let after = read_count(&loss_file());
-        let delta = after.saturating_sub(before);
-        assert!(delta >= 1,
-            "Expected the documented focus-steal gap (delta>=1). Got delta={delta}. \
-             If this now passes, cua-driver has fixed UIA Invoke focus-steal — \
-             flip this assertion to delta==0 and update the docstring.");
-        println!("⚠️  bg_modality_uia_invoke_click: gap confirmed (delta={delta}). \
-                  Mitigation = route UIA via cua-driver-uia.exe (UIAccess worker).");
-    });
+    let before = read_count(&loss_file());
+    let _ = driver.call("click",
+        serde_json::json!({"pid": pid as i64, "window_id": wid, "element_index": idx}));
+    std::thread::sleep(Duration::from_millis(500));
+    let after = read_count(&loss_file());
+    let delta = after.saturating_sub(before);
+    assert!(delta >= 1,
+        "Expected the documented focus-steal gap (delta>=1). Got delta={delta}. \
+         If this now passes, cua-driver has fixed UIA Invoke focus-steal — \
+         flip this assertion to delta==0 and update the docstring.");
+    println!("⚠️  bg_modality_uia_invoke_click: gap confirmed (delta={delta}). \
+              Mitigation = route UIA via cua-driver-uia.exe (UIAccess worker).");
 }
 
 /// Companion gap: UIA ValuePattern.SetValue on WPF TextBox.
@@ -354,57 +258,51 @@ fn bg_modality_uia_invoke_click_DOCUMENTED_steals_focus() {
 #[test]
 #[ignore]
 fn bg_modality_set_value_DOCUMENTED_steals_focus() {
-    let mut fx = match setup() { Some(f) => f, None => return };
-    with_session(&mut fx, |stdin, stdout, pid, wid| {
-        let _ = call(stdin, stdout, 29, "set_agent_cursor_enabled",
-            serde_json::json!({"enabled": false}));
-        std::thread::sleep(Duration::from_millis(200));
+    let (mut driver, pid, wid) = match setup() { Some(x) => x, None => return };
+    let _ = driver.call("set_agent_cursor_enabled",
+        serde_json::json!({"enabled": false}));
+    std::thread::sleep(Duration::from_millis(200));
 
-        let snap = call(stdin, stdout, 30, "get_window_state",
-            serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
-        let idx = find_idx_by_aid(&snap, "txt-input").expect("txt-input");
+    let snap = driver.call("get_window_state",
+        serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
+    let idx = element_index_by_id(snap.text(), "txt-input").expect("txt-input");
 
-        let before = read_count(&loss_file());
-        let _ = call(stdin, stdout, 31, "set_value",
-            serde_json::json!({
-                "pid": pid as i64, "window_id": wid, "element_index": idx,
-                "value": "via-uia-no-focus-steal"
-            }));
-        std::thread::sleep(Duration::from_millis(500));
-        let after = read_count(&loss_file());
-        let delta = after.saturating_sub(before);
-        assert!(delta >= 1,
-            "Expected the documented SetValue focus-steal gap. delta={delta}.");
-        println!("⚠️  bg_modality_set_value: gap confirmed (delta={delta})");
-    });
+    let before = read_count(&loss_file());
+    let _ = driver.call("set_value",
+        serde_json::json!({
+            "pid": pid as i64, "window_id": wid, "element_index": idx,
+            "value": "via-uia-no-focus-steal"
+        }));
+    std::thread::sleep(Duration::from_millis(500));
+    let after = read_count(&loss_file());
+    let delta = after.saturating_sub(before);
+    assert!(delta >= 1,
+        "Expected the documented SetValue focus-steal gap. delta={delta}.");
+    println!("⚠️  bg_modality_set_value: gap confirmed (delta={delta})");
 }
 
 #[test]
 #[ignore]
 fn bg_modality_press_key_no_focus_steal() {
-    let mut fx = match setup() { Some(f) => f, None => return };
-    with_session(&mut fx, |stdin, stdout, pid, wid| {
-        // F5 fires the harness accelerator (KeyBinding) via PostMessage
-        // WM_KEYDOWN — background path, no foreground swap.
-        assert_no_focus_steal("press_key(f5, PostMessage)", || {
-            let _ = call(stdin, stdout, 30, "press_key",
-                serde_json::json!({"pid": pid as i64, "window_id": wid, "key": "f5"}));
-        });
+    let (mut driver, pid, wid) = match setup() { Some(x) => x, None => return };
+    // F5 fires the harness accelerator (KeyBinding) via PostMessage
+    // WM_KEYDOWN — background path, no foreground swap.
+    assert_no_focus_steal("press_key(f5, PostMessage)", || {
+        let _ = driver.call("press_key",
+            serde_json::json!({"pid": pid as i64, "window_id": wid, "key": "f5"}));
     });
 }
 
 #[test]
 #[ignore]
 fn bg_modality_scroll_no_focus_steal() {
-    let mut fx = match setup() { Some(f) => f, None => return };
-    with_session(&mut fx, |stdin, stdout, pid, wid| {
-        assert_no_focus_steal("scroll(down, PostMessage WM_VSCROLL)", || {
-            let _ = call(stdin, stdout, 30, "scroll",
-                serde_json::json!({
-                    "pid": pid as i64, "window_id": wid,
-                    "direction": "down", "by": "line", "amount": 3
-                }));
-        });
+    let (mut driver, pid, wid) = match setup() { Some(x) => x, None => return };
+    assert_no_focus_steal("scroll(down, PostMessage WM_VSCROLL)", || {
+        let _ = driver.call("scroll",
+            serde_json::json!({
+                "pid": pid as i64, "window_id": wid,
+                "direction": "down", "by": "line", "amount": 3
+            }));
     });
 }
 
@@ -413,55 +311,51 @@ fn bg_modality_scroll_no_focus_steal() {
 #[test]
 #[ignore]
 fn capture_mode_ax_returns_tree_only() {
-    let mut fx = match setup() { Some(f) => f, None => return };
-    with_session(&mut fx, |stdin, stdout, pid, wid| {
-        let resp = call(stdin, stdout, 30, "get_window_state",
-            serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
-        // ax mode: tree_markdown present, no image content array entry.
-        let text = snapshot_text(&resp);
-        assert!(text.contains("id=btn-increment"),
-            "capture_mode=ax tree missing btn-increment AID");
-        let has_image = resp["result"]["content"].as_array()
-            .map(|a| a.iter().any(|c| c["type"].as_str() == Some("image")))
-            .unwrap_or(false);
-        assert!(!has_image,
-            "capture_mode=ax should NOT return image content (got one anyway)");
-        println!("✅ capture_mode_ax_returns_tree_only: tree present, no image");
+    let (mut driver, pid, wid) = match setup() { Some(x) => x, None => return };
+    let resp = driver.call("get_window_state",
+        serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
+    // ax mode: tree_markdown present, no image content array entry.
+    let text = resp.text();
+    assert!(text.contains("id=btn-increment"),
+        "capture_mode=ax tree missing btn-increment AID");
+    let has_image = resp.raw["result"]["content"].as_array()
+        .map(|a| a.iter().any(|c| c["type"].as_str() == Some("image")))
+        .unwrap_or(false);
+    assert!(!has_image,
+        "capture_mode=ax should NOT return image content (got one anyway)");
+    println!("✅ capture_mode_ax_returns_tree_only: tree present, no image");
 
-        // And ax must not steal focus.
-        assert_no_focus_steal("get_window_state(ax)", || {
-            let _ = call(stdin, stdout, 31, "get_window_state",
-                serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
-        });
+    // And ax must not steal focus.
+    assert_no_focus_steal("get_window_state(ax)", || {
+        let _ = driver.call("get_window_state",
+            serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
     });
 }
 
 #[test]
 #[ignore]
 fn capture_mode_vision_returns_image_only() {
-    let mut fx = match setup() { Some(f) => f, None => return };
-    with_session(&mut fx, |stdin, stdout, pid, wid| {
-        let resp = call(stdin, stdout, 30, "get_window_state",
+    let (mut driver, pid, wid) = match setup() { Some(x) => x, None => return };
+    let resp = driver.call("get_window_state",
+        serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "vision"}));
+    // vision mode: image content present, no tree markdown.
+    let has_image = resp.raw["result"]["content"].as_array()
+        .map(|a| a.iter().any(|c| c["type"].as_str() == Some("image")))
+        .unwrap_or(false);
+    assert!(has_image, "capture_mode=vision should return image content");
+
+    let text_first = resp.text();
+    // Tree markdown's hallmark is lines starting with `- [N] ` for elements.
+    // In vision mode, those should be absent.
+    let has_tree_markers = text_first.lines()
+        .any(|l| l.trim_start().starts_with("- [") && l.contains(']'));
+    assert!(!has_tree_markers,
+        "capture_mode=vision should not return UIA tree markdown");
+    println!("✅ capture_mode_vision_returns_image_only: image present, no tree");
+
+    assert_no_focus_steal("get_window_state(vision)", || {
+        let _ = driver.call("get_window_state",
             serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "vision"}));
-        // vision mode: image content present, no tree markdown.
-        let has_image = resp["result"]["content"].as_array()
-            .map(|a| a.iter().any(|c| c["type"].as_str() == Some("image")))
-            .unwrap_or(false);
-        assert!(has_image, "capture_mode=vision should return image content");
-
-        let text_first = snapshot_text(&resp);
-        // Tree markdown's hallmark is lines starting with `- [N] ` for elements.
-        // In vision mode, those should be absent.
-        let has_tree_markers = text_first.lines()
-            .any(|l| l.trim_start().starts_with("- [") && l.contains(']'));
-        assert!(!has_tree_markers,
-            "capture_mode=vision should not return UIA tree markdown");
-        println!("✅ capture_mode_vision_returns_image_only: image present, no tree");
-
-        assert_no_focus_steal("get_window_state(vision)", || {
-            let _ = call(stdin, stdout, 31, "get_window_state",
-                serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "vision"}));
-        });
     });
 }
 
@@ -471,28 +365,26 @@ fn capture_mode_ax_and_vision_invoke_roundtrip() {
     // Cross-modality round-trip: ax to find element, vision to confirm
     // the screenshot reflects the post-action state. Mirrors how an agent
     // alternates between symbolic and pixel views during a task.
-    let mut fx = match setup() { Some(f) => f, None => return };
-    with_session(&mut fx, |stdin, stdout, pid, wid| {
-        let snap_ax = call(stdin, stdout, 30, "get_window_state",
-            serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
-        let idx = find_idx_by_aid(&snap_ax, "btn-increment").expect("btn-increment");
+    let (mut driver, pid, wid) = match setup() { Some(x) => x, None => return };
+    let snap_ax = driver.call("get_window_state",
+        serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
+    let idx = element_index_by_id(snap_ax.text(), "btn-increment").expect("btn-increment");
 
-        let _ = call(stdin, stdout, 31, "click",
-            serde_json::json!({"pid": pid as i64, "window_id": wid, "element_index": idx}));
-        std::thread::sleep(Duration::from_millis(300));
+    let _ = driver.call("click",
+        serde_json::json!({"pid": pid as i64, "window_id": wid, "element_index": idx}));
+    std::thread::sleep(Duration::from_millis(300));
 
-        let snap_vision = call(stdin, stdout, 32, "get_window_state",
-            serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "vision"}));
-        let has_image = snap_vision["result"]["content"].as_array()
-            .map(|a| a.iter().any(|c| c["type"].as_str() == Some("image")))
-            .unwrap_or(false);
-        assert!(has_image, "vision snapshot didn't return an image");
+    let snap_vision = driver.call("get_window_state",
+        serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "vision"}));
+    let has_image = snap_vision.raw["result"]["content"].as_array()
+        .map(|a| a.iter().any(|c| c["type"].as_str() == Some("image")))
+        .unwrap_or(false);
+    assert!(has_image, "vision snapshot didn't return an image");
 
-        // And confirm counter advanced via a follow-up ax snapshot.
-        let snap_ax2 = call(stdin, stdout, 33, "get_window_state",
-            serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
-        assert!(snapshot_text(&snap_ax2).contains("counter=1"),
-            "counter didn't advance after UIA Invoke");
-        println!("✅ capture_mode_ax_and_vision_invoke_roundtrip: ax→invoke→vision+ax green");
-    });
+    // And confirm counter advanced via a follow-up ax snapshot.
+    let snap_ax2 = driver.call("get_window_state",
+        serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
+    assert!(snap_ax2.text().contains("counter=1"),
+        "counter didn't advance after UIA Invoke");
+    println!("✅ capture_mode_ax_and_vision_invoke_roundtrip: ax→invoke→vision+ax green");
 }

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_bg_modality_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_bg_modality_test.rs
@@ -172,6 +172,9 @@ where F: FnOnce() {
 /// the target's handler calls Focus() before cua-driver gets control).
 /// The cua-driver fg_bypass restores foreground after, and this check
 /// asserts that restoration actually worked.
+// Documented oracle kept for the foreground-restore scenarios; not currently
+// wired to a live test (preserved verbatim from before the testkit migration).
+#[allow(dead_code)]
 fn assert_foreground_restored<F>(label: &str, f: F)
 where F: FnOnce() {
     let sentinel_hwnd: u64 = std::fs::read_to_string(focus_hwnd_file())
@@ -228,6 +231,8 @@ fn bg_modality_get_window_state_no_focus_steal() {
 /// rename to `..._no_focus_steal`.
 #[test]
 #[ignore]
+// Name intentionally documents a KNOWN focus-steal (see doc comment above).
+#[allow(non_snake_case)]
 fn bg_modality_uia_invoke_click_DOCUMENTED_steals_focus() {
     let (mut driver, pid, wid) = match setup() { Some(x) => x, None => return };
     let _ = driver.call("set_agent_cursor_enabled",
@@ -257,6 +262,8 @@ fn bg_modality_uia_invoke_click_DOCUMENTED_steals_focus() {
 /// bg_modality_uia_invoke_click_DOCUMENTED_steals_focus.
 #[test]
 #[ignore]
+// Name intentionally documents a KNOWN focus-steal (see doc comment above).
+#[allow(non_snake_case)]
 fn bg_modality_set_value_DOCUMENTED_steals_focus() {
     let (mut driver, pid, wid) = match setup() { Some(x) => x, None => return };
     let _ = driver.call("set_agent_cursor_enabled",

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_lo_vcl_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_lo_vcl_test.rs
@@ -46,18 +46,13 @@
 
 #![cfg(target_os = "windows")]
 
-use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::process::{Command, Stdio};
 use std::time::Duration;
 
-// ── workspace / LO paths ─────────────────────────────────────────────────────
+use cua_driver_testkit::{Driver, McpDriver};
 
-fn workspace_root() -> PathBuf {
-    let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
-    PathBuf::from(manifest).parent().unwrap().parent().unwrap().to_owned()
-}
-fn driver_binary() -> PathBuf { workspace_root().join("target/debug/cua-driver.exe") }
+// ── LO paths ─────────────────────────────────────────────────────────────────
 
 /// LO Writer executable. Honour `LO_SWRITER_EXE` env override (for CI
 /// images with non-default install paths), otherwise probe the two
@@ -93,50 +88,21 @@ fn scalc_exe() -> Option<PathBuf> {
     None
 }
 
-// ── JSON-RPC plumbing ────────────────────────────────────────────────────────
-
-fn send(stdin: &mut ChildStdin, req: serde_json::Value) {
-    writeln!(stdin, "{}", serde_json::to_string(&req).unwrap()).unwrap();
-}
-fn recv(stdout: &mut BufReader<&mut ChildStdout>) -> serde_json::Value {
-    let mut line = String::new();
-    stdout.read_line(&mut line).expect("read");
-    serde_json::from_str(line.trim()).expect("json")
-}
-fn init(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>) {
-    send(stdin, serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}));
-    let _ = recv(stdout);
-}
-fn call(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
-        id: u32, name: &str, args: serde_json::Value) -> serde_json::Value {
-    send(stdin, serde_json::json!({
-        "jsonrpc":"2.0","id":id,"method":"tools/call",
-        "params":{"name":name,"arguments":args}
-    }));
-    recv(stdout)
-}
-
-fn snapshot_text(s: &serde_json::Value) -> &str {
-    s["result"]["content"][0]["text"].as_str().unwrap_or("")
-}
-
 // ── fixture ──────────────────────────────────────────────────────────────────
 
+/// Live LO Writer session: the long-lived MCP driver plus the located
+/// Writer window. The driver's reaper kills the driver and the spawned
+/// writer on drop; the extra soffice.bin sweep below clears the SAL/VCL
+/// background daemon that outlives the launcher so the next test starts
+/// clean.
 struct LoSession {
-    _writer: Child,
-    driver: Child,
-    driver_stdin: ChildStdin,
-    driver_stdout: ChildStdout,
+    driver: McpDriver,
     writer_pid: u32,
     writer_wid: u64,
 }
 
 impl Drop for LoSession {
     fn drop(&mut self) {
-        // Try clean shutdown via cua-driver kill_app first so LO doesn't
-        // leak a soffice.bin background daemon across test runs.
-        let _ = self.driver.kill(); let _ = self.driver.wait();
-        let _ = self._writer.kill(); let _ = self._writer.wait();
         // SAL/VCL soffice.bin daemon hangs around after the parent exits;
         // best-effort sweep via taskkill so the next test starts clean.
         let _ = Command::new("taskkill").args(["/F", "/IM", "soffice.bin"]).output();
@@ -145,10 +111,6 @@ impl Drop for LoSession {
 }
 
 fn setup() -> Option<LoSession> {
-    let driver = driver_binary();
-    if !driver.exists() {
-        eprintln!("cua-driver.exe not built — run `cargo build` first"); return None;
-    }
     let writer = match swriter_exe() {
         Some(p) => p,
         None => {
@@ -162,65 +124,51 @@ fn setup() -> Option<LoSession> {
     let _ = Command::new("taskkill").args(["/F", "/IM", "soffice.bin"]).output();
     std::thread::sleep(Duration::from_millis(800));
 
+    let mut driver = McpDriver::spawn()?;
+
     // `-norestore` skips the Document Recovery dialog (which would
     // block the Writer top-level window from ever appearing if the
     // previous LO session crashed). `-nologo` skips the splash screen.
-    let _writer = Command::new(&writer)
-        .args(["-norestore", "-nologo"])
-        .stdout(Stdio::null()).stderr(Stdio::null())
-        .spawn().ok()?;
+    driver
+        .reaper()
+        .spawn(
+            Command::new(&writer)
+                .args(["-norestore", "-nologo"])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null()),
+        )
+        .ok()?;
     // LO launches via soffice.bin background daemon, then forks the
     // actual writer process. The pid we just spawned is the launcher;
     // the real writer is a child. Poll list_apps via cua-driver to
     // find it.
     std::thread::sleep(Duration::from_secs(3));
 
-    let mut driver_c = Command::new(&driver)
-        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
-        .spawn().ok()?;
-    let mut driver_stdin = driver_c.stdin.take().unwrap();
-    let mut driver_stdout = driver_c.stdout.take().unwrap();
-    {
-        let mut stdout = BufReader::new(&mut driver_stdout);
-        init(&mut driver_stdin, &mut stdout);
-        // Find the LO Writer window by title — its owning pid is the
-        // soffice.bin daemon (NOT the launcher pid above). Poll up to
-        // 30 s for the recovery dialog (if any) + main window to appear.
-        let deadline = std::time::Instant::now() + Duration::from_secs(30);
-        loop {
-            let resp = call(&mut driver_stdin, &mut stdout, 10, "list_windows", serde_json::json!({}));
-            if let Some(wins) = resp["result"]["structuredContent"]["windows"].as_array() {
-                for w in wins {
-                    let title = w["title"].as_str().unwrap_or("");
-                    let app = w["app_name"].as_str().unwrap_or("");
-                    if app.contains("soffice") && title.contains("LibreOffice Writer") {
-                        let pid = w["pid"].as_u64().unwrap_or(0) as u32;
-                        let wid = w["window_id"].as_u64().unwrap_or(0);
-                        if pid > 0 && wid > 0 {
-                            drop(stdout);
-                            return Some(LoSession {
-                                _writer, driver: driver_c, driver_stdin, driver_stdout,
-                                writer_pid: pid, writer_wid: wid,
-                            });
-                        }
+    // Find the LO Writer window by title — its owning pid is the
+    // soffice.bin daemon (NOT the launcher pid above). Poll up to
+    // 30 s for the recovery dialog (if any) + main window to appear.
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        let resp = driver.call("list_windows", serde_json::json!({}));
+        if let Some(wins) = resp.structured()["windows"].as_array() {
+            for w in wins {
+                let title = w["title"].as_str().unwrap_or("");
+                let app = w["app_name"].as_str().unwrap_or("");
+                if app.contains("soffice") && title.contains("LibreOffice Writer") {
+                    let pid = w["pid"].as_u64().unwrap_or(0) as u32;
+                    let wid = w["window_id"].as_u64().unwrap_or(0);
+                    if pid > 0 && wid > 0 {
+                        return Some(LoSession { driver, writer_pid: pid, writer_wid: wid });
                     }
                 }
             }
-            if std::time::Instant::now() > deadline {
-                eprintln!("Writer window did not appear within 30 s");
-                drop(stdout);
-                let _ = driver_c.kill();
-                return None;
-            }
-            std::thread::sleep(Duration::from_millis(500));
         }
+        if std::time::Instant::now() > deadline {
+            eprintln!("Writer window did not appear within 30 s");
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(500));
     }
-}
-
-fn with_session<F, R>(fx: &mut LoSession, f: F) -> R
-where F: FnOnce(&mut ChildStdin, &mut BufReader<&mut ChildStdout>, u32, u64) -> R {
-    let mut stdout = BufReader::new(&mut fx.driver_stdout);
-    f(&mut fx.driver_stdin, &mut stdout, fx.writer_pid, fx.writer_wid)
 }
 
 // ── Test 1: Font Color SplitButton exposes `expand` via MSAA fallback ───────
@@ -245,23 +193,24 @@ where F: FnOnce(&mut ChildStdin, &mut BufReader<&mut ChildStdout>, u32, u64) -> 
 #[ignore]
 fn harness_lo_vcl_font_color_split_button_exposes_expand() {
     let mut fx = match setup() { Some(s) => s, None => return };
-    with_session(&mut fx, |stdin, stdout, pid, wid| {
-        let snap = call(stdin, stdout, 30, "get_window_state", serde_json::json!({
-            "pid": pid as i64, "window_id": wid,
-            "capture_mode": "ax", "query": "Font Color"
-        }));
-        let text = snapshot_text(&snap);
-        assert!(text.contains("SplitButton \"Font Color\""),
-            "Font Color SplitButton not found in tree: {text:?}");
-        let line = text.lines().find(|l| l.contains("\"Font Color\"")).unwrap_or("");
-        assert!(line.contains("expand"),
-            "Expected `expand` in actions on Font Color SplitButton — got {line:?}. \
-             The MSAA fallback may not be running for SALFRAME (check uia/mod.rs \
-             SAL class detection — should route ALL SAL* classes through msaa.rs).");
-        assert!(line.contains("invoke"),
-            "Expected `invoke` to remain in actions alongside `expand` — got {line:?}. \
-             MSAA walker should expose both press and dropdown halves.");
-    });
+    let (pid, wid) = (fx.writer_pid, fx.writer_wid);
+    let driver = &mut fx.driver;
+
+    let snap = driver.call("get_window_state", serde_json::json!({
+        "pid": pid as i64, "window_id": wid,
+        "capture_mode": "ax", "query": "Font Color"
+    }));
+    let text = snap.text();
+    assert!(text.contains("SplitButton \"Font Color\""),
+        "Font Color SplitButton not found in tree: {text:?}");
+    let line = text.lines().find(|l| l.contains("\"Font Color\"")).unwrap_or("");
+    assert!(line.contains("expand"),
+        "Expected `expand` in actions on Font Color SplitButton — got {line:?}. \
+         The MSAA fallback may not be running for SALFRAME (check uia/mod.rs \
+         SAL class detection — should route ALL SAL* classes through msaa.rs).");
+    assert!(line.contains("invoke"),
+        "Expected `invoke` to remain in actions alongside `expand` — got {line:?}. \
+         MSAA walker should expose both press and dropdown halves.");
 }
 
 // ── Test 2: action:"expand" actually opens the color picker ─────────────────
@@ -288,70 +237,71 @@ fn harness_lo_vcl_font_color_split_button_exposes_expand() {
 #[ignore]
 fn harness_lo_vcl_font_color_expand_opens_picker() {
     let mut fx = match setup() { Some(s) => s, None => return };
-    with_session(&mut fx, |stdin, stdout, pid, wid| {
-        // Bring Writer to foreground so SendInput click lands on it.
-        let _ = call(stdin, stdout, 30, "bring_to_front", serde_json::json!({
-            "pid": pid as i64, "window_id": wid
-        }));
-        std::thread::sleep(Duration::from_millis(400));
+    let (pid, wid) = (fx.writer_pid, fx.writer_wid);
+    let driver = &mut fx.driver;
 
-        let snap = call(stdin, stdout, 31, "get_window_state", serde_json::json!({
-            "pid": pid as i64, "window_id": wid,
-            "capture_mode": "ax", "query": "Font Color"
-        }));
-        let text = snapshot_text(&snap);
-        let line = text.lines()
-            .find(|l| l.contains("\"Font Color\"") && l.contains("expand"))
-            .unwrap_or_else(|| panic!("Font Color SplitButton with `expand` action not found: {text:?}"));
-        let s = line.find('[').expect("element_index bracket open");
-        let e = line[s..].find(']').expect("element_index bracket close") + s;
-        let idx: u64 = line[s+1..e].trim().parse()
-            .unwrap_or_else(|_| panic!("could not parse element_index from line {line:?}"));
+    // Bring Writer to foreground so SendInput click lands on it.
+    let _ = driver.call("bring_to_front", serde_json::json!({
+        "pid": pid as i64, "window_id": wid
+    }));
+    std::thread::sleep(Duration::from_millis(400));
 
-        // Snapshot windows under our pid BEFORE the click.
-        let before = call(stdin, stdout, 32, "list_windows", serde_json::json!({
-            "pid": pid as i64
-        }));
-        let before_ids: std::collections::HashSet<u64> = before
-            ["result"]["structuredContent"]["windows"].as_array()
-            .map(|a| a.iter().filter_map(|w| w["window_id"].as_u64()).collect())
-            .unwrap_or_default();
+    let snap = driver.call("get_window_state", serde_json::json!({
+        "pid": pid as i64, "window_id": wid,
+        "capture_mode": "ax", "query": "Font Color"
+    }));
+    let text = snap.text();
+    let line = text.lines()
+        .find(|l| l.contains("\"Font Color\"") && l.contains("expand"))
+        .unwrap_or_else(|| panic!("Font Color SplitButton with `expand` action not found: {text:?}"));
+    let s = line.find('[').expect("element_index bracket open");
+    let e = line[s..].find(']').expect("element_index bracket close") + s;
+    let idx: u64 = line[s+1..e].trim().parse()
+        .unwrap_or_else(|_| panic!("could not parse element_index from line {line:?}"));
 
-        let resp = call(stdin, stdout, 33, "click", serde_json::json!({
-            "pid": pid as i64, "window_id": wid,
-            "element_index": idx, "action": "expand"
-        }));
-        let resp_text = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
-        assert!(resp_text.starts_with("✅"),
-            "click(action:expand) failed: {resp_text:?}");
-        assert!(resp_text.contains("dropdown half"),
-            "Expected response to mention dropdown half — got {resp_text:?}. \
-             The MSAA dispatch path may not have triggered.");
+    // Snapshot windows under our pid BEFORE the click.
+    let before = driver.call("list_windows", serde_json::json!({
+        "pid": pid as i64
+    }));
+    let before_ids: std::collections::HashSet<u64> = before
+        .structured()["windows"].as_array()
+        .map(|a| a.iter().filter_map(|w| w["window_id"].as_u64()).collect())
+        .unwrap_or_default();
 
-        // Let the picker spawn.
-        std::thread::sleep(Duration::from_millis(900));
+    let resp = driver.call("click", serde_json::json!({
+        "pid": pid as i64, "window_id": wid,
+        "element_index": idx, "action": "expand"
+    }));
+    let resp_text = resp.text();
+    assert!(resp_text.starts_with("✅"),
+        "click(action:expand) failed: {resp_text:?}");
+    assert!(resp_text.contains("dropdown half"),
+        "Expected response to mention dropdown half — got {resp_text:?}. \
+         The MSAA dispatch path may not have triggered.");
 
-        let after = call(stdin, stdout, 34, "list_windows", serde_json::json!({
-            "pid": pid as i64
-        }));
-        let new_wins: Vec<&serde_json::Value> = after
-            ["result"]["structuredContent"]["windows"].as_array()
-            .map(|a| a.iter()
-                .filter(|w| {
-                    let id = w["window_id"].as_u64();
-                    id.map(|i| !before_ids.contains(&i)).unwrap_or(false)
-                })
-                .collect())
-            .unwrap_or_default();
-        let picker = new_wins.iter().find(|w| {
-            w["title"].as_str().map(|t| t.contains("Font Color")).unwrap_or(false)
-        });
-        assert!(picker.is_some(),
-            "No new window titled 'Font Color' appeared after click(action:expand). \
-             new_windows={new_wins:?}. The right-edge dispatch may have hit the \
-             wrong pixel (LO's toolbar scaled differently?) or the picker spawned \
-             as a child window instead of a top-level.");
+    // Let the picker spawn.
+    std::thread::sleep(Duration::from_millis(900));
+
+    let after = driver.call("list_windows", serde_json::json!({
+        "pid": pid as i64
+    }));
+    let new_wins: Vec<&serde_json::Value> = after
+        .structured()["windows"].as_array()
+        .map(|a| a.iter()
+            .filter(|w| {
+                let id = w["window_id"].as_u64();
+                id.map(|i| !before_ids.contains(&i)).unwrap_or(false)
+            })
+            .collect())
+        .unwrap_or_default();
+    let picker = new_wins.iter().find(|w| {
+        w["title"].as_str().map(|t| t.contains("Font Color")).unwrap_or(false)
     });
+    assert!(picker.is_some(),
+        "No new window titled 'Font Color' appeared after click(action:expand). \
+         new_windows={new_wins:?}. The right-edge dispatch may have hit the \
+         wrong pixel (LO's toolbar scaled differently?) or the picker spawned \
+         as a child window instead of a top-level.");
 }
 
 // ── Working path: SALSUBFRAME modal dialogs accept SendInput input ─────────
@@ -383,88 +333,89 @@ fn harness_lo_vcl_font_color_expand_opens_picker() {
 #[ignore]
 fn harness_lo_vcl_modal_input_roundtrip_works() {
     let mut fx = match setup() { Some(s) => s, None => return };
-    with_session(&mut fx, |stdin, stdout, pid, wid| {
-        std::thread::sleep(Duration::from_millis(800));
+    let (pid, wid) = (fx.writer_pid, fx.writer_wid);
+    let driver = &mut fx.driver;
 
-        let open_resp = call(stdin, stdout, 30, "hotkey", serde_json::json!({
-            "pid": pid as i64, "window_id": wid,
-            "keys": ["ctrl", "h"], "dispatch": "foreground"
-        }));
-        let open_text = open_resp["result"]["content"][0]["text"].as_str().unwrap_or("");
-        assert!(open_text.starts_with("✅"),
-            "hotkey(ctrl+h, foreground) failed: {open_text:?}");
+    std::thread::sleep(Duration::from_millis(800));
 
-        let dialog_wid = {
-            let deadline = std::time::Instant::now() + Duration::from_secs(8);
-            loop {
-                let wins = call(stdin, stdout, 31, "list_windows", serde_json::json!({
-                    "pid": pid as i64
+    let open_resp = driver.call("hotkey", serde_json::json!({
+        "pid": pid as i64, "window_id": wid,
+        "keys": ["ctrl", "h"], "dispatch": "foreground"
+    }));
+    let open_text = open_resp.text();
+    assert!(open_text.starts_with("✅"),
+        "hotkey(ctrl+h, foreground) failed: {open_text:?}");
+
+    let dialog_wid = {
+        let deadline = std::time::Instant::now() + Duration::from_secs(8);
+        loop {
+            let wins = driver.call("list_windows", serde_json::json!({
+                "pid": pid as i64
+            }));
+            let found = wins.structured()["windows"].as_array()
+                .and_then(|a| a.iter().find_map(|w| {
+                    let title = w["title"].as_str().unwrap_or("");
+                    let id = w["window_id"].as_u64();
+                    if id != Some(wid)
+                       && (title.contains("Find") || title.contains("Replace"))
+                    { id } else { None }
                 }));
-                let found = wins["result"]["structuredContent"]["windows"].as_array()
-                    .and_then(|a| a.iter().find_map(|w| {
-                        let title = w["title"].as_str().unwrap_or("");
-                        let id = w["window_id"].as_u64();
-                        if id != Some(wid)
-                           && (title.contains("Find") || title.contains("Replace"))
-                        { id } else { None }
-                    }));
-                if let Some(id) = found { break id; }
-                if std::time::Instant::now() > deadline {
-                    panic!("Find & Replace dialog did not appear after Ctrl+H — \
-                            Writer accelerator may have regressed under \
-                            foreground SendInput on SALFRAME.");
-                }
-                std::thread::sleep(Duration::from_millis(300));
+            if let Some(id) = found { break id; }
+            if std::time::Instant::now() > deadline {
+                panic!("Find & Replace dialog did not appear after Ctrl+H — \
+                        Writer accelerator may have regressed under \
+                        foreground SendInput on SALFRAME.");
             }
-        };
+            std::thread::sleep(Duration::from_millis(300));
+        }
+    };
 
-        // Snapshot the dialog — MSAA walker should produce a real tree
-        // with the dialog's buttons and edit fields, NOT the old skip
-        // stub.
-        let dialog_ax = call(stdin, stdout, 32, "get_window_state", serde_json::json!({
-            "pid": pid as i64, "window_id": dialog_wid, "capture_mode": "ax"
-        }));
-        let dialog_text = snapshot_text(&dialog_ax);
-        assert!(!dialog_text.contains("SAL/VCL target, UIA walk skipped"),
-            "Got the old skip-stub message — MSAA fallback did not engage on \
-             this SALSUBFRAME. Snapshot was: {dialog_text:?}");
-        assert!(dialog_text.contains("Button \"Close\""),
-            "Expected MSAA walker to expose a 'Close' Button in the Find & Replace \
-             dialog tree (it's a documented child via accChild). Snapshot was: {dialog_text:?}");
-        // Sanity: should have several actionable element_indices, not zero.
-        let actionable_count = dialog_text.lines()
-            .filter(|l| l.contains("actions=[invoke"))
-            .count();
-        assert!(actionable_count >= 4,
-            "Expected ≥4 actionable elements in Find & Replace via MSAA walker, \
-             got {actionable_count}. Tree: {dialog_text:?}");
+    // Snapshot the dialog — MSAA walker should produce a real tree
+    // with the dialog's buttons and edit fields, NOT the old skip
+    // stub.
+    let dialog_ax = driver.call("get_window_state", serde_json::json!({
+        "pid": pid as i64, "window_id": dialog_wid, "capture_mode": "ax"
+    }));
+    let dialog_text = dialog_ax.text();
+    assert!(!dialog_text.contains("SAL/VCL target, UIA walk skipped"),
+        "Got the old skip-stub message — MSAA fallback did not engage on \
+         this SALSUBFRAME. Snapshot was: {dialog_text:?}");
+    assert!(dialog_text.contains("Button \"Close\""),
+        "Expected MSAA walker to expose a 'Close' Button in the Find & Replace \
+         dialog tree (it's a documented child via accChild). Snapshot was: {dialog_text:?}");
+    // Sanity: should have several actionable element_indices, not zero.
+    let actionable_count = dialog_text.lines()
+        .filter(|l| l.contains("actions=[invoke"))
+        .count();
+    assert!(actionable_count >= 4,
+        "Expected ≥4 actionable elements in Find & Replace via MSAA walker, \
+         got {actionable_count}. Tree: {dialog_text:?}");
 
-        // Foreground Escape should close the dialog.
-        let esc_resp = call(stdin, stdout, 33, "press_key", serde_json::json!({
-            "pid": pid as i64, "window_id": dialog_wid,
-            "key": "escape", "dispatch": "foreground"
-        }));
-        let esc_text = esc_resp["result"]["content"][0]["text"].as_str().unwrap_or("");
-        assert!(esc_text.starts_with("✅"),
-            "press_key(escape, foreground) returned an error: {esc_text:?}");
-        std::thread::sleep(Duration::from_millis(700));
+    // Foreground Escape should close the dialog.
+    let esc_resp = driver.call("press_key", serde_json::json!({
+        "pid": pid as i64, "window_id": dialog_wid,
+        "key": "escape", "dispatch": "foreground"
+    }));
+    let esc_text = esc_resp.text();
+    assert!(esc_text.starts_with("✅"),
+        "press_key(escape, foreground) returned an error: {esc_text:?}");
+    std::thread::sleep(Duration::from_millis(700));
 
-        let wins_after = call(stdin, stdout, 34, "list_windows", serde_json::json!({
-            "pid": pid as i64
-        }));
-        let still_open = wins_after["result"]["structuredContent"]["windows"].as_array()
-            .map(|a| a.iter().any(|w| w["window_id"].as_u64() == Some(dialog_wid)))
-            .unwrap_or(false);
-        assert!(!still_open,
-            "Find & Replace dialog stayed open after foreground Escape — \
-             SAL modal input dispatch regressed. Check uia/mod.rs SAL-class \
-             handling and the press_key SendInput path.");
+    let wins_after = driver.call("list_windows", serde_json::json!({
+        "pid": pid as i64
+    }));
+    let still_open = wins_after.structured()["windows"].as_array()
+        .map(|a| a.iter().any(|w| w["window_id"].as_u64() == Some(dialog_wid)))
+        .unwrap_or(false);
+    assert!(!still_open,
+        "Find & Replace dialog stayed open after foreground Escape — \
+         SAL modal input dispatch regressed. Check uia/mod.rs SAL-class \
+         handling and the press_key SendInput path.");
 
-        // Cleanup: kill the LO process — Drop impl sweeps soffice.bin.
-        let _ = call(stdin, stdout, 35, "kill_app", serde_json::json!({
-            "pid": pid as i64
-        }));
-    });
+    // Cleanup: kill the LO process — Drop impl sweeps soffice.bin.
+    let _ = driver.call("kill_app", serde_json::json!({
+        "pid": pid as i64
+    }));
 }
 
 // ── Test 4: All toolbar SplitButtons expose `expand` ────────────────────────
@@ -488,34 +439,35 @@ fn harness_lo_vcl_modal_input_roundtrip_works() {
 #[ignore]
 fn harness_lo_vcl_all_toolbar_split_buttons_expose_expand() {
     let mut fx = match setup() { Some(s) => s, None => return };
-    with_session(&mut fx, |stdin, stdout, pid, wid| {
-        let snap = call(stdin, stdout, 30, "get_window_state", serde_json::json!({
-            "pid": pid as i64, "window_id": wid, "capture_mode": "ax"
-        }));
-        let text = snapshot_text(&snap);
-        let splitbutton_lines: Vec<&str> = text
-            .lines()
-            .filter(|l| l.contains("SplitButton") && l.contains("actions=["))
-            .collect();
-        let with_expand: Vec<&&str> = splitbutton_lines.iter()
-            .filter(|l| l.contains("expand"))
-            .collect();
-        assert!(splitbutton_lines.len() >= 15,
-            "Expected ≥15 SplitButtons in LO Writer toolbar tree, got {}. \
-             Possible MSAA walker regression. Full snapshot first 1500 chars: {}",
-            splitbutton_lines.len(),
-            &text.chars().take(1500).collect::<String>());
-        assert_eq!(with_expand.len(), splitbutton_lines.len(),
-            "{}/{} SplitButtons report `expand`. The MSAA role→actions \
-             mapping may have dropped one of BUTTONDROPDOWN / BUTTONMENU / \
-             BUTTONDROPDOWNGRID / SPLITBUTTON. Missing-expand lines:\n{}",
-            with_expand.len(), splitbutton_lines.len(),
-            splitbutton_lines.iter()
-                .filter(|l| !l.contains("expand"))
-                .map(|l| l.trim())
-                .collect::<Vec<_>>()
-                .join("\n"));
-    });
+    let (pid, wid) = (fx.writer_pid, fx.writer_wid);
+    let driver = &mut fx.driver;
+
+    let snap = driver.call("get_window_state", serde_json::json!({
+        "pid": pid as i64, "window_id": wid, "capture_mode": "ax"
+    }));
+    let text = snap.text();
+    let splitbutton_lines: Vec<&str> = text
+        .lines()
+        .filter(|l| l.contains("SplitButton") && l.contains("actions=["))
+        .collect();
+    let with_expand: Vec<&&str> = splitbutton_lines.iter()
+        .filter(|l| l.contains("expand"))
+        .collect();
+    assert!(splitbutton_lines.len() >= 15,
+        "Expected ≥15 SplitButtons in LO Writer toolbar tree, got {}. \
+         Possible MSAA walker regression. Full snapshot first 1500 chars: {}",
+        splitbutton_lines.len(),
+        &text.chars().take(1500).collect::<String>());
+    assert_eq!(with_expand.len(), splitbutton_lines.len(),
+        "{}/{} SplitButtons report `expand`. The MSAA role→actions \
+         mapping may have dropped one of BUTTONDROPDOWN / BUTTONMENU / \
+         BUTTONDROPDOWNGRID / SPLITBUTTON. Missing-expand lines:\n{}",
+        with_expand.len(), splitbutton_lines.len(),
+        splitbutton_lines.iter()
+            .filter(|l| !l.contains("expand"))
+            .map(|l| l.trim())
+            .collect::<Vec<_>>()
+            .join("\n"));
 }
 
 // ── Test 5: End-to-end color-pick ───────────────────────────────────────────
@@ -537,113 +489,114 @@ fn harness_lo_vcl_all_toolbar_split_buttons_expose_expand() {
 #[ignore]
 fn harness_lo_vcl_color_pick_green_end_to_end() {
     let mut fx = match setup() { Some(s) => s, None => return };
-    with_session(&mut fx, |stdin, stdout, pid, wid| {
-        // Foreground first so type_text + Ctrl+A land on Writer.
-        let _ = call(stdin, stdout, 30, "bring_to_front", serde_json::json!({
-            "pid": pid as i64, "window_id": wid
-        }));
-        std::thread::sleep(Duration::from_millis(400));
+    let (pid, wid) = (fx.writer_pid, fx.writer_wid);
+    let driver = &mut fx.driver;
 
-        let _ = call(stdin, stdout, 31, "type_text", serde_json::json!({
-            "pid": pid as i64, "window_id": wid,
-            "text": "color pick regression"
-        }));
-        std::thread::sleep(Duration::from_millis(400));
+    // Foreground first so type_text + Ctrl+A land on Writer.
+    let _ = driver.call("bring_to_front", serde_json::json!({
+        "pid": pid as i64, "window_id": wid
+    }));
+    std::thread::sleep(Duration::from_millis(400));
 
-        let _ = call(stdin, stdout, 32, "hotkey", serde_json::json!({
-            "pid": pid as i64, "window_id": wid,
-            "keys": ["ctrl", "a"], "dispatch": "foreground"
-        }));
-        std::thread::sleep(Duration::from_millis(400));
+    let _ = driver.call("type_text", serde_json::json!({
+        "pid": pid as i64, "window_id": wid,
+        "text": "color pick regression"
+    }));
+    std::thread::sleep(Duration::from_millis(400));
 
-        // Locate Font Color element_index in Writer's MSAA tree.
-        let snap = call(stdin, stdout, 33, "get_window_state", serde_json::json!({
-            "pid": pid as i64, "window_id": wid,
-            "capture_mode": "ax", "query": "Font Color"
-        }));
-        let snap_text = snapshot_text(&snap);
-        let fc_line = snap_text.lines()
-            .find(|l| l.contains("\"Font Color\"") && l.contains("expand"))
-            .unwrap_or_else(|| panic!("Font Color with `expand` not found in tree: {snap_text:?}"));
-        let s = fc_line.find('[').expect("[ in fc_line");
-        let e = fc_line[s..].find(']').expect("] in fc_line") + s;
-        let fc_idx: u64 = fc_line[s+1..e].trim().parse().expect("fc element_index");
+    let _ = driver.call("hotkey", serde_json::json!({
+        "pid": pid as i64, "window_id": wid,
+        "keys": ["ctrl", "a"], "dispatch": "foreground"
+    }));
+    std::thread::sleep(Duration::from_millis(400));
 
-        // Snapshot which windows existed BEFORE opening the picker so
-        // we can isolate the picker on appearance.
-        let before = call(stdin, stdout, 34, "list_windows", serde_json::json!({
-            "pid": pid as i64
-        }));
-        let before_ids: std::collections::HashSet<u64> = before
-            ["result"]["structuredContent"]["windows"].as_array()
-            .map(|a| a.iter().filter_map(|w| w["window_id"].as_u64()).collect())
-            .unwrap_or_default();
+    // Locate Font Color element_index in Writer's MSAA tree.
+    let snap = driver.call("get_window_state", serde_json::json!({
+        "pid": pid as i64, "window_id": wid,
+        "capture_mode": "ax", "query": "Font Color"
+    }));
+    let snap_text = snap.text();
+    let fc_line = snap_text.lines()
+        .find(|l| l.contains("\"Font Color\"") && l.contains("expand"))
+        .unwrap_or_else(|| panic!("Font Color with `expand` not found in tree: {snap_text:?}"));
+    let s = fc_line.find('[').expect("[ in fc_line");
+    let e = fc_line[s..].find(']').expect("] in fc_line") + s;
+    let fc_idx: u64 = fc_line[s+1..e].trim().parse().expect("fc element_index");
 
-        // Open the dropdown.
-        let open_resp = call(stdin, stdout, 35, "click", serde_json::json!({
-            "pid": pid as i64, "window_id": wid,
-            "element_index": fc_idx, "action": "expand"
-        }));
-        let open_text = open_resp["result"]["content"][0]["text"].as_str().unwrap_or("");
-        assert!(open_text.contains("dropdown half"),
-            "click(action:expand) did not dispatch via MSAA dropdown path: {open_text:?}");
-        std::thread::sleep(Duration::from_millis(900));
+    // Snapshot which windows existed BEFORE opening the picker so
+    // we can isolate the picker on appearance.
+    let before = driver.call("list_windows", serde_json::json!({
+        "pid": pid as i64
+    }));
+    let before_ids: std::collections::HashSet<u64> = before
+        .structured()["windows"].as_array()
+        .map(|a| a.iter().filter_map(|w| w["window_id"].as_u64()).collect())
+        .unwrap_or_default();
 
-        // Find the picker window.
-        let after = call(stdin, stdout, 36, "list_windows", serde_json::json!({
-            "pid": pid as i64
-        }));
-        let picker_wid = after["result"]["structuredContent"]["windows"]
-            .as_array()
-            .and_then(|a| a.iter().find_map(|w| {
-                let id = w["window_id"].as_u64();
-                let title = w["title"].as_str().unwrap_or("");
-                if id.map(|i| !before_ids.contains(&i)).unwrap_or(false)
-                   && title.contains("Font Color")
-                { id } else { None }
-            }))
-            .unwrap_or_else(|| panic!("No new 'Font Color' picker window appeared"));
+    // Open the dropdown.
+    let open_resp = driver.call("click", serde_json::json!({
+        "pid": pid as i64, "window_id": wid,
+        "element_index": fc_idx, "action": "expand"
+    }));
+    let open_text = open_resp.text();
+    assert!(open_text.contains("dropdown half"),
+        "click(action:expand) did not dispatch via MSAA dropdown path: {open_text:?}");
+    std::thread::sleep(Duration::from_millis(900));
 
-        // Walk the picker tree to find a green color cell.
-        let psnap = call(stdin, stdout, 37, "get_window_state", serde_json::json!({
-            "pid": pid as i64, "window_id": picker_wid, "capture_mode": "ax"
-        }));
-        let psnap_text = snapshot_text(&psnap);
-        let green_line = psnap_text.lines()
-            .find(|l| l.contains("\"Green\"") && l.contains("[") && l.contains("actions=[invoke"))
-            .unwrap_or_else(|| panic!(
-                "No 'Green' ListItem in picker tree. The MSAA walker may have \
-                 truncated the color grid or LO's locale renamed the color. \
-                 First 1500 chars: {}",
-                &psnap_text.chars().take(1500).collect::<String>()));
-        let s = green_line.find('[').expect("[ in green");
-        let e = green_line[s..].find(']').expect("] in green") + s;
-        let green_idx: u64 = green_line[s+1..e].trim().parse().expect("green element_index");
+    // Find the picker window.
+    let after = driver.call("list_windows", serde_json::json!({
+        "pid": pid as i64
+    }));
+    let picker_wid = after.structured()["windows"]
+        .as_array()
+        .and_then(|a| a.iter().find_map(|w| {
+            let id = w["window_id"].as_u64();
+            let title = w["title"].as_str().unwrap_or("");
+            if id.map(|i| !before_ids.contains(&i)).unwrap_or(false)
+               && title.contains("Font Color")
+            { id } else { None }
+        }))
+        .unwrap_or_else(|| panic!("No new 'Font Color' picker window appeared"));
 
-        // Pick it. Default action (invoke) clicks center via MSAA dispatch.
-        let pick_resp = call(stdin, stdout, 38, "click", serde_json::json!({
-            "pid": pid as i64, "window_id": picker_wid,
-            "element_index": green_idx
-        }));
-        let pick_text = pick_resp["result"]["content"][0]["text"].as_str().unwrap_or("");
-        assert!(pick_text.starts_with("✅"),
-            "click on Green color cell failed: {pick_text:?}");
-        std::thread::sleep(Duration::from_millis(700));
+    // Walk the picker tree to find a green color cell.
+    let psnap = driver.call("get_window_state", serde_json::json!({
+        "pid": pid as i64, "window_id": picker_wid, "capture_mode": "ax"
+    }));
+    let psnap_text = psnap.text();
+    let green_line = psnap_text.lines()
+        .find(|l| l.contains("\"Green\"") && l.contains("[") && l.contains("actions=[invoke"))
+        .unwrap_or_else(|| panic!(
+            "No 'Green' ListItem in picker tree. The MSAA walker may have \
+             truncated the color grid or LO's locale renamed the color. \
+             First 1500 chars: {}",
+            &psnap_text.chars().take(1500).collect::<String>()));
+    let s = green_line.find('[').expect("[ in green");
+    let e = green_line[s..].find(']').expect("] in green") + s;
+    let green_idx: u64 = green_line[s+1..e].trim().parse().expect("green element_index");
 
-        // Verify the picker closed (LO closes the popup after a color is
-        // selected — the canonical "color applied" signal). If it
-        // didn't, the click didn't actually land on the cell.
-        let after2 = call(stdin, stdout, 39, "list_windows", serde_json::json!({
-            "pid": pid as i64
-        }));
-        let still_open = after2["result"]["structuredContent"]["windows"]
-            .as_array()
-            .map(|a| a.iter().any(|w| w["window_id"].as_u64() == Some(picker_wid)))
-            .unwrap_or(false);
-        assert!(!still_open,
-            "Picker stayed open after click on Green — the cell click \
-             didn't land. LO didn't apply the color.");
-    });
+    // Pick it. Default action (invoke) clicks center via MSAA dispatch.
+    let pick_resp = driver.call("click", serde_json::json!({
+        "pid": pid as i64, "window_id": picker_wid,
+        "element_index": green_idx
+    }));
+    let pick_text = pick_resp.text();
+    assert!(pick_text.starts_with("✅"),
+        "click on Green color cell failed: {pick_text:?}");
+    std::thread::sleep(Duration::from_millis(700));
+
+    // Verify the picker closed (LO closes the popup after a color is
+    // selected — the canonical "color applied" signal). If it
+    // didn't, the click didn't actually land on the cell.
+    let after2 = driver.call("list_windows", serde_json::json!({
+        "pid": pid as i64
+    }));
+    let still_open = after2.structured()["windows"]
+        .as_array()
+        .map(|a| a.iter().any(|w| w["window_id"].as_u64() == Some(picker_wid)))
+        .unwrap_or(false);
+    assert!(!still_open,
+        "Picker stayed open after click on Green — the cell click \
+         didn't land. LO didn't apply the color.");
 }
 
 // ── Test 6: Recovery dialog walks via MSAA ──────────────────────────────────
@@ -688,38 +641,27 @@ fn harness_lo_vcl_recovery_dialog_walks_via_msaa() {
     std::thread::sleep(Duration::from_secs(2));
 
     // Re-launch Writer — Recovery dialog should appear.
-    let driver = driver_binary();
-    if !driver.exists() { return; }
-    let mut writer_proc = match Command::new(&writer)
-        .stdout(Stdio::null()).stderr(Stdio::null())
-        .spawn() {
-            Ok(p) => p,
-            Err(_) => return,
-        };
+    let Some(mut driver) = McpDriver::spawn() else { return };
+    if driver
+        .reaper()
+        .spawn(
+            Command::new(&writer)
+                .stdout(Stdio::null())
+                .stderr(Stdio::null()),
+        )
+        .is_err()
+    {
+        return;
+    }
     std::thread::sleep(Duration::from_secs(5));
-
-    let mut driver_c = match Command::new(&driver)
-        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
-        .spawn() {
-            Ok(p) => p,
-            Err(_) => {
-                let _ = writer_proc.kill();
-                return;
-            }
-        };
-    let mut stdin = driver_c.stdin.take().unwrap();
-    let mut stdout_raw = driver_c.stdout.take().unwrap();
-    let mut stdout = BufReader::new(&mut stdout_raw);
-
-    init(&mut stdin, &mut stdout);
 
     // Poll for the Recovery dialog.
     let recovery_wid_pid: Option<(u64, u32)> = {
         let deadline = std::time::Instant::now() + Duration::from_secs(20);
         let mut found = None;
         while std::time::Instant::now() < deadline {
-            let resp = call(&mut stdin, &mut stdout, 1, "list_windows", serde_json::json!({}));
-            if let Some(wins) = resp["result"]["structuredContent"]["windows"].as_array() {
+            let resp = driver.call("list_windows", serde_json::json!({}));
+            if let Some(wins) = resp.structured()["windows"].as_array() {
                 if let Some(w) = wins.iter().find(|w| {
                     w["title"].as_str().map(|t| t.contains("Recovery")).unwrap_or(false)
                 }) {
@@ -745,11 +687,11 @@ fn harness_lo_vcl_recovery_dialog_walks_via_msaa() {
                        returning OK.");
         }
         Some((rwid, rpid)) => {
-            let snap = call(&mut stdin, &mut stdout, 2, "get_window_state",
+            let snap = driver.call("get_window_state",
                 serde_json::json!({
                     "pid": rpid as i64, "window_id": rwid, "capture_mode": "ax"
                 }));
-            let text = snapshot_text(&snap);
+            let text = snap.text();
             assert!(!text.contains("SAL/VCL target, UIA walk skipped"),
                 "Recovery dialog returned the old SAL-skip stub — MSAA fallback \
                  isn't engaging on SALFRAME Recovery dialogs.");
@@ -762,9 +704,9 @@ fn harness_lo_vcl_recovery_dialog_walks_via_msaa() {
         }
     }
 
-    // Cleanup.
-    let _ = driver_c.kill(); let _ = driver_c.wait();
-    let _ = writer_proc.kill(); let _ = writer_proc.wait();
+    // Cleanup: reaper kills the MCP driver + the spawned writer on drop;
+    // sweep the soffice.bin daemon that outlives the launcher.
+    drop(driver);
     let _ = Command::new("taskkill").args(["/F", "/IM", "soffice.bin"]).output();
     std::thread::sleep(Duration::from_millis(800));
 }
@@ -783,42 +725,32 @@ fn harness_lo_vcl_recovery_dialog_walks_via_msaa() {
 #[ignore]
 fn harness_lo_vcl_calc_msaa_smoke() {
     let scalc = match scalc_exe() { Some(p) => p, None => return };
-    let driver = driver_binary();
-    if !driver.exists() { return; }
 
     let _ = Command::new("taskkill").args(["/F", "/IM", "soffice.bin"]).output();
     std::thread::sleep(Duration::from_millis(800));
 
-    let mut calc_proc = match Command::new(&scalc)
-        .args(["-norestore", "-nologo"])
-        .stdout(Stdio::null()).stderr(Stdio::null())
-        .spawn() {
-            Ok(p) => p,
-            Err(_) => return,
-        };
+    let Some(mut driver) = McpDriver::spawn() else { return };
+    if driver
+        .reaper()
+        .spawn(
+            Command::new(&scalc)
+                .args(["-norestore", "-nologo"])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null()),
+        )
+        .is_err()
+    {
+        return;
+    }
     std::thread::sleep(Duration::from_secs(5));
-
-    let mut driver_c = match Command::new(&driver)
-        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
-        .spawn() {
-            Ok(p) => p,
-            Err(_) => {
-                let _ = calc_proc.kill();
-                return;
-            }
-        };
-    let mut stdin_drv = driver_c.stdin.take().unwrap();
-    let mut stdout_raw = driver_c.stdout.take().unwrap();
-    let mut stdout = BufReader::new(&mut stdout_raw);
-    init(&mut stdin_drv, &mut stdout);
 
     // Poll for the Calc window.
     let calc_wid_pid: Option<(u64, u32)> = {
         let deadline = std::time::Instant::now() + Duration::from_secs(20);
         let mut found = None;
         while std::time::Instant::now() < deadline {
-            let r = call(&mut stdin_drv, &mut stdout, 1, "list_windows", serde_json::json!({}));
-            if let Some(wins) = r["result"]["structuredContent"]["windows"].as_array() {
+            let r = driver.call("list_windows", serde_json::json!({}));
+            if let Some(wins) = r.structured()["windows"].as_array() {
                 if let Some(w) = wins.iter().find(|w| {
                     w["title"].as_str().map(|t| t.contains("LibreOffice Calc")).unwrap_or(false)
                 }) {
@@ -835,18 +767,19 @@ fn harness_lo_vcl_calc_msaa_smoke() {
         found
     };
 
-    let (cwid, cpid) = calc_wid_pid.unwrap_or_else(|| {
-        let _ = driver_c.kill();
-        let _ = calc_proc.kill();
-        let _ = Command::new("taskkill").args(["/F", "/IM", "soffice.bin"]).output();
-        panic!("LO Calc window did not appear within 20 s");
-    });
+    let (cwid, cpid) = match calc_wid_pid {
+        Some(v) => v,
+        None => {
+            let _ = Command::new("taskkill").args(["/F", "/IM", "soffice.bin"]).output();
+            panic!("LO Calc window did not appear within 20 s");
+        }
+    };
 
-    let snap = call(&mut stdin_drv, &mut stdout, 2, "get_window_state",
+    let snap = driver.call("get_window_state",
         serde_json::json!({
             "pid": cpid as i64, "window_id": cwid, "capture_mode": "ax"
         }));
-    let text = snapshot_text(&snap);
+    let text = snap.text();
     assert!(!text.contains("SAL/VCL target, UIA walk skipped"),
         "Calc returned the old SAL-skip stub — MSAA didn't engage.");
     let sb_with_expand = text.lines()
@@ -857,12 +790,12 @@ fn harness_lo_vcl_calc_msaa_smoke() {
          generalizes beyond Writer). Got {sb_with_expand}. The MSAA role \
          mapping may differ in Calc, or the toolbar config is unexpectedly slim.");
 
-    // Cleanup.
-    let _ = call(&mut stdin_drv, &mut stdout, 3, "kill_app", serde_json::json!({
+    // Cleanup: reaper kills the MCP driver + the spawned calc on drop;
+    // sweep the soffice.bin daemon that outlives the launcher.
+    let _ = driver.call("kill_app", serde_json::json!({
         "pid": cpid as i64
     }));
-    let _ = driver_c.kill(); let _ = driver_c.wait();
-    let _ = calc_proc.kill(); let _ = calc_proc.wait();
+    drop(driver);
     let _ = Command::new("taskkill").args(["/F", "/IM", "soffice.bin"]).output();
     std::thread::sleep(Duration::from_millis(800));
 }

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_swiftui_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_swiftui_test.rs
@@ -16,56 +16,22 @@
 
 #![cfg(target_os = "macos")]
 
-use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
-fn workspace_root() -> PathBuf {
-    let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
-    PathBuf::from(manifest).parent().unwrap().parent().unwrap().to_owned()
-}
-
-fn driver_binary() -> PathBuf {
-    let root = workspace_root();
-    let release = root.join("target/release/cua-driver");
-    if release.exists() { return release; }
-    root.join("target/debug/cua-driver")
-}
+use cua_driver_testkit::ax::{element_index_by_id, has_id, looks_empty};
+use cua_driver_testkit::{harness_app, Driver, McpDriver, ToolResponse};
 
 fn harness_exe() -> PathBuf {
     if let Ok(p) = std::env::var("HARNESS_SWIFTUI_APP") {
         let pb = PathBuf::from(p).join("Contents/MacOS/CuaTestHarness.SwiftUI");
         if pb.exists() { return pb; }
     }
-    workspace_root().join(
-        "test-apps/harness-swiftui/CuaTestHarness.SwiftUI.app/Contents/MacOS/CuaTestHarness.SwiftUI")
-}
-
-fn send(stdin: &mut ChildStdin, req: serde_json::Value) {
-    writeln!(stdin, "{}", serde_json::to_string(&req).unwrap()).unwrap();
-}
-
-fn recv(stdout: &mut BufReader<&mut ChildStdout>) -> serde_json::Value {
-    let mut line = String::new();
-    stdout.read_line(&mut line).expect("read response");
-    serde_json::from_str(line.trim()).expect("parse json")
-}
-
-fn init(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>) {
-    send(stdin, serde_json::json!({
-        "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}
-    }));
-    let _ = recv(stdout);
-}
-
-fn tools_call(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
-              id: u32, name: &str, args: serde_json::Value) -> serde_json::Value {
-    send(stdin, serde_json::json!({
-        "jsonrpc": "2.0", "id": id, "method": "tools/call",
-        "params": { "name": name, "arguments": args }
-    }));
-    recv(stdout)
+    harness_app(
+        "harness-swiftui",
+        "CuaTestHarness.SwiftUI.app/Contents/MacOS/CuaTestHarness.SwiftUI",
+    )
 }
 
 struct Harness { _app: Child, pid: u32 }
@@ -94,95 +60,39 @@ impl Drop for Harness {
     }
 }
 
-fn find_harness_window(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
-                       pid: u32, title_substr: &str) -> Option<(u64, String)> {
-    let deadline = std::time::Instant::now() + Duration::from_secs(12);
-    let mut id = 10u32;
-    loop {
-        let resp = tools_call(stdin, stdout, id, "list_windows",
-            serde_json::json!({ "pid": pid as i64 }));
-        id = id.wrapping_add(1);
-        if let Some(wins) = resp["result"]["structuredContent"]["windows"].as_array() {
-            for w in wins {
-                if w["pid"].as_u64() != Some(pid as u64) { continue; }
-                let title = w["title"].as_str().unwrap_or("");
-                if title.contains(title_substr) {
-                    return Some((w["window_id"].as_u64()?, title.to_string()));
-                }
-            }
-        }
-        if std::time::Instant::now() >= deadline { return None; }
-        std::thread::sleep(Duration::from_millis(150));
-    }
-}
-
-fn snapshot_elements(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
-                     pid: u32, window_id: u64) -> serde_json::Value {
-    tools_call(stdin, stdout, 20, "get_window_state",
+fn snapshot_elements(driver: &mut McpDriver, pid: u32, window_id: u64) -> ToolResponse {
+    driver.call(
+        "get_window_state",
         serde_json::json!({
             "pid": pid as i64,
             "window_id": window_id,
             "capture_mode": "tree"
-        }))
-}
-
-fn snapshot_text(snap: &serde_json::Value) -> &str {
-    snap["result"]["content"][0]["text"].as_str().unwrap_or("")
-}
-
-fn elements_have_aid(snap: &serde_json::Value, aid: &str) -> bool {
-    snapshot_text(snap).contains(&format!("id={aid}"))
-}
-
-fn find_element_index_by_aid(snap: &serde_json::Value, aid: &str) -> Option<u64> {
-    let needle = format!("id={aid}");
-    for line in snapshot_text(snap).lines() {
-        if !line.contains(&needle) { continue; }
-        let start = line.find('[')? + 1;
-        let end = line[start..].find(']')? + start;
-        return line[start..end].trim().parse().ok();
-    }
-    None
-}
-
-fn ax_tree_looks_empty(snap: &serde_json::Value) -> bool {
-    let txt = snapshot_text(snap);
-    let line_count = txt.lines().count();
-    txt.is_empty() || line_count <= 2 ||
-        txt.contains("Accessibility permission required") ||
-        txt.contains("TCC permission")
+        }),
+    )
 }
 
 #[test]
 #[ignore]
 fn harness_swiftui_smoke() {
-    let driver = driver_binary();
-    if !driver.exists() { eprintln!("cua-driver not built"); return; }
     let harness = match Harness::launch() {
         Some(h) => h,
         None => { eprintln!("harness not built — skipping"); return; }
     };
     println!("harness pid={}", harness.pid);
 
-    let mut child = Command::new(&driver)
-        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
-        .spawn().expect("spawn cua-driver");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut raw_stdout = child.stdout.take().unwrap();
-    let mut stdout = BufReader::new(&mut raw_stdout);
-    init(&mut stdin, &mut stdout);
+    let Some(mut driver) = McpDriver::spawn() else { return };
 
-    let (wid, title) = find_harness_window(&mut stdin, &mut stdout, harness.pid,
-                                           "CuaTestHarness SwiftUI")
+    let (wid, title) = driver
+        .find_window(harness.pid as i64, "CuaTestHarness SwiftUI")
         .expect("main window not found");
     println!("main window: id={wid} title={title:?}");
 
-    let snap = snapshot_elements(&mut stdin, &mut stdout, harness.pid, wid);
-    if ax_tree_looks_empty(&snap) {
+    let snap = snapshot_elements(&mut driver, harness.pid, wid);
+    if looks_empty(snap.text()) {
         eprintln!("AX empty — TCC not granted; skipping element-assertions");
-        let _ = child.kill(); return;
+        return;
     }
-    let text = snapshot_text(&snap);
+    let text = snap.text();
     println!("snapshot:\n{text}");
 
     // SwiftUI Text views render as AXStaticText leaves and don't propagate
@@ -195,14 +105,12 @@ fn harness_swiftui_smoke() {
         "btn-open-popover",
         "btn-exit",
     ] {
-        assert!(elements_have_aid(&snap, aid),
+        assert!(has_id(snap.text(), aid),
                 "missing AX identifier {aid} in SwiftUI snapshot");
     }
 
     assert!(text.contains("HARNESS_TEXT_MARKER_v1"),
             "text_body marker not in SwiftUI snapshot");
-
-    let _ = child.kill();
 }
 
 /// popover: click the popover trigger, verify the popover body text appears
@@ -210,65 +118,58 @@ fn harness_swiftui_smoke() {
 #[test]
 #[ignore]
 fn harness_swiftui_popover() {
-    let driver = driver_binary();
-    if !driver.exists() { eprintln!("cua-driver not built"); return; }
     let harness = match Harness::launch() {
         Some(h) => h,
         None => { eprintln!("harness not built — skipping"); return; }
     };
 
-    let mut child = Command::new(&driver)
-        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
-        .spawn().expect("spawn cua-driver");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut raw_stdout = child.stdout.take().unwrap();
-    let mut stdout = BufReader::new(&mut raw_stdout);
-    init(&mut stdin, &mut stdout);
+    let Some(mut driver) = McpDriver::spawn() else { return };
 
-    let (wid, _) = find_harness_window(&mut stdin, &mut stdout, harness.pid,
-                                       "CuaTestHarness SwiftUI")
+    let (wid, _) = driver
+        .find_window(harness.pid as i64, "CuaTestHarness SwiftUI")
         .expect("main window not found");
-    let snap_pre = snapshot_elements(&mut stdin, &mut stdout, harness.pid, wid);
-    if ax_tree_looks_empty(&snap_pre) {
-        eprintln!("AX empty — TCC not granted; skipping"); let _ = child.kill(); return;
+    let snap_pre = snapshot_elements(&mut driver, harness.pid, wid);
+    if looks_empty(snap_pre.text()) {
+        eprintln!("AX empty — TCC not granted; skipping"); return;
     }
     // Verify popover body is NOT yet in the tree.
-    let pre_text = snapshot_text(&snap_pre).to_owned();
+    let pre_text = snap_pre.text().to_owned();
     assert!(!pre_text.contains("POPOVER_MARKER_v1"),
             "popover body unexpectedly present BEFORE open");
 
-    let trigger_idx: u64 = if let Some(i) = find_element_index_by_aid(&snap_pre, "btn-open-popover") {
+    let trigger_idx: u64 = if let Some(i) = element_index_by_id(snap_pre.text(), "btn-open-popover") {
         i
     } else {
         eprintln!("popover trigger not found, skipping");
-        let _ = child.kill();
         return;
     };
-    let click = tools_call(&mut stdin, &mut stdout, 50, "click",
+    let click = driver.call(
+        "click",
         serde_json::json!({
             "pid": harness.pid as i64,
             "window_id": wid,
             "element_index": trigger_idx,
             "action": "press"
-        }));
-    println!("popover trigger click: {click}");
+        }),
+    );
+    println!("popover trigger click: {}", click.text());
 
     std::thread::sleep(Duration::from_millis(300));
 
     // Popovers may live in a separate AXWindow on macOS — try the main
     // window first, then list_windows for additional candidates.
-    let snap_post = snapshot_elements(&mut stdin, &mut stdout, harness.pid, wid);
-    let mut found_marker = snapshot_text(&snap_post).contains("POPOVER_MARKER_v1");
+    let snap_post = snapshot_elements(&mut driver, harness.pid, wid);
+    let mut found_marker = snap_post.text().contains("POPOVER_MARKER_v1");
     if !found_marker {
         // Walk any new windows for the same pid.
-        let resp = tools_call(&mut stdin, &mut stdout, 51, "list_windows",
+        let resp = driver.call("list_windows",
             serde_json::json!({ "pid": harness.pid as i64 }));
-        if let Some(wins) = resp["result"]["structuredContent"]["windows"].as_array() {
+        if let Some(wins) = resp.structured()["windows"].as_array() {
             for w in wins {
                 if let Some(other_wid) = w["window_id"].as_u64() {
                     if other_wid == wid { continue; }
-                    let s = snapshot_elements(&mut stdin, &mut stdout, harness.pid, other_wid);
-                    if snapshot_text(&s).contains("POPOVER_MARKER_v1") {
+                    let s = snapshot_elements(&mut driver, harness.pid, other_wid);
+                    if s.text().contains("POPOVER_MARKER_v1") {
                         found_marker = true; break;
                     }
                 }
@@ -276,6 +177,4 @@ fn harness_swiftui_popover() {
         }
     }
     assert!(found_marker, "popover body marker not found after open");
-
-    let _ = child.kill();
 }

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_web_windows_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_web_windows_test.rs
@@ -27,75 +27,27 @@
 
 #![cfg(target_os = "windows")]
 
-use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::process::{Command, Stdio};
 use std::time::Duration;
 
-// ── workspace paths ──────────────────────────────────────────────────────────
+use cua_driver_testkit::{harness_app, spawn_in_job, Driver, McpDriver};
 
-fn workspace_root() -> PathBuf {
-    let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
-    PathBuf::from(manifest).parent().unwrap().parent().unwrap().to_owned()
-}
-fn driver_binary() -> PathBuf { workspace_root().join("target/debug/cua-driver.exe") }
+// ── workspace paths ──────────────────────────────────────────────────────────
 
 fn webview_exe() -> PathBuf {
     if let Ok(p) = std::env::var("HARNESS_WEBVIEW_EXE") {
         let pb = PathBuf::from(p);
         if pb.exists() { return pb; }
     }
-    workspace_root().join("test-apps/harness-webview/CuaTestHarness.WebView.exe")
+    harness_app("harness-webview", "CuaTestHarness.WebView.exe")
 }
 fn electron_exe() -> PathBuf {
     if let Ok(p) = std::env::var("HARNESS_ELECTRON_EXE") {
         let pb = PathBuf::from(p);
         if pb.exists() { return pb; }
     }
-    workspace_root().join("test-apps/harness-electron/CuaTestHarness.Electron.exe")
-}
-
-// ── JSON-RPC plumbing ────────────────────────────────────────────────────────
-
-fn send(stdin: &mut ChildStdin, req: serde_json::Value) {
-    writeln!(stdin, "{}", serde_json::to_string(&req).unwrap()).unwrap();
-}
-fn recv(stdout: &mut BufReader<&mut ChildStdout>) -> serde_json::Value {
-    let mut line = String::new();
-    stdout.read_line(&mut line).expect("read");
-    serde_json::from_str(line.trim()).expect("json")
-}
-fn init(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>) {
-    send(stdin, serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}));
-    let _ = recv(stdout);
-}
-fn tools_call(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
-              id: u32, name: &str, args: serde_json::Value) -> serde_json::Value {
-    send(stdin, serde_json::json!({
-        "jsonrpc":"2.0","id":id,"method":"tools/call",
-        "params":{"name":name,"arguments":args}
-    }));
-    recv(stdout)
-}
-
-fn find_window_by_title(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
-                        pid: u32, title_substr: &str) -> Option<u64> {
-    let deadline = std::time::Instant::now() + Duration::from_secs(20);
-    let mut id = 10u32;
-    loop {
-        let resp = tools_call(stdin, stdout, id, "list_windows", serde_json::json!({"pid": pid as i64}));
-        id = id.wrapping_add(1);
-        if let Some(wins) = resp["result"]["structuredContent"]["windows"].as_array() {
-            for w in wins {
-                if w["pid"].as_u64() != Some(pid as u64) { continue; }
-                if w["title"].as_str().unwrap_or("").contains(title_substr) {
-                    if let Some(wid) = w["window_id"].as_u64() { return Some(wid); }
-                }
-            }
-        }
-        if std::time::Instant::now() >= deadline { return None; }
-        std::thread::sleep(Duration::from_millis(200));
-    }
+    harness_app("harness-electron", "CuaTestHarness.Electron.exe")
 }
 
 // ── shared session helper ────────────────────────────────────────────────────
@@ -103,55 +55,36 @@ fn find_window_by_title(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut Chil
 /// Launch the harness exe + a cua-driver child with `CUA_DRIVER_CDP_PORT`
 /// pointing at the harness's CDP endpoint. Polls list_windows until the
 /// host's window appears.
-struct WebSession {
-    _app: Child,
-    driver: Child,
-}
-
-impl Drop for WebSession {
-    fn drop(&mut self) {
-        let _ = self.driver.kill();
-        let _ = self.driver.wait();
-        let _ = self._app.kill();
-        let _ = self._app.wait();
-        // settle so the next test's launch doesn't see leftover windows
-        std::thread::sleep(Duration::from_millis(500));
-    }
-}
-
 fn run_with_session<F>(label: &str, host_exe: PathBuf, title_substr: &str, cdp_port: u16, f: F)
-where F: FnOnce(u32, u64, &mut ChildStdin, &mut BufReader<&mut ChildStdout>) {
-    if !driver_binary().exists() {
-        eprintln!("cua-driver.exe not built — run `cargo build` first"); return;
-    }
+where
+    F: FnOnce(i64, u64, &mut McpDriver),
+{
     if !host_exe.exists() {
-        eprintln!("{label} host exe not found at {host_exe:?} — run test-harness/build/windows.ps1"); return;
+        eprintln!("{label} host exe not found at {host_exe:?} — run test-harness/build/windows.ps1");
+        return;
     }
+    // Set the CDP port the daemon should probe; the spawned cua-driver child
+    // inherits it from this process's environment.
+    std::env::set_var("CUA_DRIVER_CDP_PORT", cdp_port.to_string());
+    let Some(mut driver) = McpDriver::spawn() else { return };
+
     // Set the CDP port the host should use so the daemon can find it.
     let env_var = if label == "webview" { "CUA_WEBVIEW_CDP_PORT" } else { "CUA_ELECTRON_CDP_PORT" };
-    let app = Command::new(&host_exe)
-        .env(env_var, cdp_port.to_string())
-        .stdout(Stdio::null()).stderr(Stdio::null())
-        .spawn().expect("spawn host");
-    let pid = app.id();
+    let mut cmd = Command::new(&host_exe);
+    cmd.env(env_var, cdp_port.to_string())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let app = spawn_in_job(&mut cmd).expect("spawn host");
+    let pid = app.id() as i64;
+    driver.reaper().push(app);
     println!("{label} pid={pid} cdp_port={cdp_port}");
-    std::thread::sleep(Duration::from_secs(2));   // small cold-start for runtime spin-up
+    std::thread::sleep(Duration::from_secs(2)); // small cold-start for runtime spin-up
 
-    let mut driver = Command::new(driver_binary())
-        .env("CUA_DRIVER_CDP_PORT", cdp_port.to_string())
-        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
-        .spawn().expect("spawn cua-driver");
-    let mut stdin = driver.stdin.take().unwrap();
-    let mut raw_stdout = driver.stdout.take().unwrap();
-    let mut stdout = BufReader::new(&mut raw_stdout);
-    init(&mut stdin, &mut stdout);
-
-    let wid = find_window_by_title(&mut stdin, &mut stdout, pid, title_substr)
+    let (wid, _title) = driver
+        .find_window(pid, title_substr)
         .unwrap_or_else(|| panic!("{label} window with title containing {title_substr:?} not found"));
 
-    let session = WebSession { _app: app, driver };
-    f(pid, wid, &mut stdin, &mut stdout);
-    drop(session);
+    f(pid, wid, &mut driver);
 }
 
 // ── WebView2 structural + page tool ─────────────────────────────────────────
@@ -160,7 +93,7 @@ where F: FnOnce(u32, u64, &mut ChildStdin, &mut BufReader<&mut ChildStdout>) {
 #[ignore]
 fn harness_webview_window_discoverable() {
     run_with_session("webview", webview_exe(), "CuaTestHarness WebView", 9222,
-        |pid, wid, _stdin, _stdout| {
+        |pid, wid, _driver| {
         println!("✅ harness_webview_window_discoverable: pid={pid} wid={wid}");
     });
 }
@@ -173,40 +106,26 @@ fn harness_webview_page_tool() {
     // Combined with the `/json` Content-Length fix in mcp-server/src/cdp.rs,
     // the page tool now reaches WebView2's DOM via CDP just like Electron.
     run_with_session("webview", webview_exe(), "CuaTestHarness WebView", 9222,
-        |pid, wid, stdin, stdout| {
+        |pid, wid, driver| {
 
-        let marker_resp = tools_call(stdin, stdout, 30, "page", serde_json::json!({
-            "pid": pid as i64, "window_id": wid, "action": "execute_javascript",
+        let marker = driver.call("page", serde_json::json!({
+            "pid": pid, "window_id": wid, "action": "execute_javascript",
             "javascript": "document.querySelector('[data-cua-id=\"page-marker\"]').textContent"
-        }));
-        let marker = marker_resp.get("result")
-            .and_then(|r| r.get("content"))
-            .and_then(|c| c.as_array())
-            .and_then(|arr| arr.get(0))
-            .and_then(|item| item.get("text"))
-            .and_then(|t| t.as_str())
-            .unwrap_or("");
+        })).text().to_string();
         assert!(marker.contains("WEB_HARNESS_MARKER_v1"),
             "WebView2 CDP execute_javascript marker fetch: {marker:?}");
 
         // click_element via DOM selector + counter readback.
-        let _ = tools_call(stdin, stdout, 31, "page", serde_json::json!({
-            "pid": pid as i64, "window_id": wid, "action": "click_element",
+        let _ = driver.call("page", serde_json::json!({
+            "pid": pid, "window_id": wid, "action": "click_element",
             "selector": "#btn-increment"
         }));
         std::thread::sleep(Duration::from_millis(500));
 
-        let counter_resp = tools_call(stdin, stdout, 32, "page", serde_json::json!({
-            "pid": pid as i64, "window_id": wid, "action": "execute_javascript",
+        let post = driver.call("page", serde_json::json!({
+            "pid": pid, "window_id": wid, "action": "execute_javascript",
             "javascript": "document.getElementById('lbl-counter').textContent"
-        }));
-        let post = counter_resp.get("result")
-            .and_then(|r| r.get("content"))
-            .and_then(|c| c.as_array())
-            .and_then(|arr| arr.get(0))
-            .and_then(|item| item.get("text"))
-            .and_then(|t| t.as_str())
-            .unwrap_or("");
+        })).text().to_string();
         assert!(post.contains("counter=1"),
             "WebView2 counter didn't advance via page.click_element: {post:?}");
         println!("✅ harness_webview_page_tool: CDP+execute_javascript+click_element green");
@@ -219,7 +138,7 @@ fn harness_webview_page_tool() {
 #[ignore]
 fn harness_electron_window_discoverable() {
     run_with_session("electron", electron_exe(), "CuaTestHarness Electron", 9223,
-        |pid, wid, _stdin, _stdout| {
+        |pid, wid, _driver| {
         println!("✅ harness_electron_window_discoverable: pid={pid} wid={wid}");
     });
 }
@@ -231,31 +150,29 @@ fn harness_electron_page_tool() {
     // Content-Length / Transfer-Encoding instead of read_to_end).
     // cua-driver's page tool now reaches Electron's CDP successfully.
     run_with_session("electron", electron_exe(), "CuaTestHarness Electron", 9223,
-        |pid, wid, stdin, stdout| {
+        |pid, wid, driver| {
 
         // 1. execute_javascript via CDP.
-        let marker_resp = tools_call(stdin, stdout, 30, "page", serde_json::json!({
-            "pid": pid as i64, "window_id": wid, "action": "execute_javascript",
+        let marker = driver.call("page", serde_json::json!({
+            "pid": pid, "window_id": wid, "action": "execute_javascript",
             "javascript": "document.querySelector('[data-cua-id=\"page-marker\"]').textContent"
-        }));
-        let marker = marker_resp["result"]["content"][0]["text"].as_str().unwrap_or("");
+        })).text().to_string();
         assert!(marker.contains("WEB_HARNESS_MARKER_v1"),
             "Electron CDP execute_javascript marker fetch: {marker:?}");
 
         // 2. Increment counter via direct execute_javascript (the
         //    click_element path has a separate probe-JSON-parsing gap
         //    documented below — track separately).
-        let _ = tools_call(stdin, stdout, 31, "page", serde_json::json!({
-            "pid": pid as i64, "window_id": wid, "action": "execute_javascript",
+        let _ = driver.call("page", serde_json::json!({
+            "pid": pid, "window_id": wid, "action": "execute_javascript",
             "javascript": "document.getElementById('btn-increment').click()"
         }));
         std::thread::sleep(Duration::from_millis(300));
 
-        let counter_resp = tools_call(stdin, stdout, 32, "page", serde_json::json!({
-            "pid": pid as i64, "window_id": wid, "action": "execute_javascript",
+        let post = driver.call("page", serde_json::json!({
+            "pid": pid, "window_id": wid, "action": "execute_javascript",
             "javascript": "document.getElementById('lbl-counter').textContent"
-        }));
-        let post = counter_resp["result"]["content"][0]["text"].as_str().unwrap_or("");
+        })).text().to_string();
         assert!(post.contains("counter=1"),
             "Electron counter did not advance via execute_javascript: {post:?}");
         println!("✅ harness_electron_page_tool: CDP+execute_javascript green");
@@ -275,35 +192,26 @@ fn harness_electron_page_tool() {
 #[ignore]
 fn harness_electron_click_element() {
     run_with_session("electron", electron_exe(), "CuaTestHarness Electron", 9223,
-        |pid, wid, stdin, stdout| {
-        let resp = tools_call(stdin, stdout, 30, "page", serde_json::json!({
-            "pid": pid as i64, "window_id": wid, "action": "click_element",
+        |pid, wid, driver| {
+        let resp = driver.call("page", serde_json::json!({
+            "pid": pid, "window_id": wid, "action": "click_element",
             "selector": "#btn-increment"
         }));
-        let text = resp.get("result")
-            .and_then(|r| r.get("content"))
-            .and_then(|c| c.as_array())
-            .and_then(|arr| arr.get(0))
-            .and_then(|item| item.get("text"))
-            .and_then(|t| t.as_str())
-            .or_else(|| resp.get("error").and_then(|e| e.get("message")).and_then(|m| m.as_str()))
-            .unwrap_or("");
+        // Prefer the tool text; fall back to a JSON-RPC error message.
+        let text = if resp.text().is_empty() {
+            resp.raw["error"]["message"].as_str().unwrap_or("").to_string()
+        } else {
+            resp.text().to_string()
+        };
         assert!(!text.contains("probe JSON missing") && !text.contains("required field"),
             "click_element probe parse regressed: {text:?}");
         std::thread::sleep(Duration::from_millis(400));
 
         // Verify the click actually fired in the DOM.
-        let counter_resp = tools_call(stdin, stdout, 31, "page", serde_json::json!({
-            "pid": pid as i64, "window_id": wid, "action": "execute_javascript",
+        let post = driver.call("page", serde_json::json!({
+            "pid": pid, "window_id": wid, "action": "execute_javascript",
             "javascript": "document.getElementById('lbl-counter').textContent"
-        }));
-        let post = counter_resp.get("result")
-            .and_then(|r| r.get("content"))
-            .and_then(|c| c.as_array())
-            .and_then(|arr| arr.get(0))
-            .and_then(|item| item.get("text"))
-            .and_then(|t| t.as_str())
-            .unwrap_or("");
+        })).text().to_string();
         assert!(post.contains("counter=1"),
             "Counter didn't advance after page.click_element: {post:?}");
         println!("✅ harness_electron_click_element: probe parsed, click fired, counter=1");

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_winui3_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_winui3_test.rs
@@ -20,126 +20,59 @@
 
 #![cfg(target_os = "windows")]
 
-use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::process::{Command, Stdio};
 use std::time::Duration;
 
-fn workspace_root() -> PathBuf {
-    let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
-    PathBuf::from(manifest).parent().unwrap().parent().unwrap().to_owned()
-}
+use cua_driver_testkit::ax::element_index_by_id;
+use cua_driver_testkit::{harness_app, spawn_in_job, Driver, McpDriver};
 
-fn driver_binary() -> PathBuf { workspace_root().join("target/debug/cua-driver.exe") }
-
-fn harness_exe() -> PathBuf {
+/// Resolve the WinUI3 harness exe — the `HARNESS_WINUI3_EXE` override wins (if it
+/// points at an existing file), else the built path under `test-apps/`.
+fn harness_winui3_exe() -> PathBuf {
     if let Ok(p) = std::env::var("HARNESS_WINUI3_EXE") {
         let pb = PathBuf::from(p);
-        if pb.exists() { return pb; }
-    }
-    workspace_root().join("test-apps/harness-winui3/CuaTestHarness.WinUI3.exe")
-}
-
-fn send(stdin: &mut ChildStdin, req: serde_json::Value) {
-    writeln!(stdin, "{}", serde_json::to_string(&req).unwrap()).unwrap();
-}
-
-fn recv(stdout: &mut BufReader<&mut ChildStdout>) -> serde_json::Value {
-    let mut line = String::new();
-    stdout.read_line(&mut line).expect("read");
-    serde_json::from_str(line.trim()).expect("json")
-}
-
-fn init(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>) {
-    send(stdin, serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}));
-    let _ = recv(stdout);
-}
-
-fn tools_call(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
-              id: u32, name: &str, args: serde_json::Value) -> serde_json::Value {
-    send(stdin, serde_json::json!({
-        "jsonrpc":"2.0","id":id,"method":"tools/call",
-        "params":{"name":name,"arguments":args}
-    }));
-    recv(stdout)
-}
-
-fn snapshot_text(snapshot: &serde_json::Value) -> &str {
-    snapshot["result"]["content"][0]["text"].as_str().unwrap_or("")
-}
-
-struct Harness { _app: Child, pid: u32 }
-
-impl Harness {
-    fn launch() -> Option<Self> {
-        let exe = harness_exe();
-        if !exe.exists() {
-            eprintln!("WinUI3 harness exe not found at {exe:?} — run test-harness/build/windows.ps1");
-            return None;
+        if pb.exists() {
+            return pb;
         }
-        let app = Command::new(&exe)
-            .stdout(Stdio::null()).stderr(Stdio::null())
-            .spawn().ok()?;
-        let pid = app.id();
-        // Short fixed cold-start settle (window creation + foreground
-        // establishment after spawn). Polling in find_harness_window
-        // handles the variable tail.
-        std::thread::sleep(Duration::from_millis(1500));
-        Some(Self { _app: app, pid })
     }
+    harness_app("harness-winui3", "CuaTestHarness.WinUI3.exe")
 }
 
-impl Drop for Harness {
-    fn drop(&mut self) { let _ = self._app.kill(); }
-}
-
-fn find_harness_window(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
-                       pid: u32, title_substr: &str) -> Option<(u64, String)> {
-    // Polls because WinUI3 cold-start (first run, no cached WinAppSDK) can
-    // exceed a fixed 5s wait under sandbox load. Bounded so a genuinely
-    // broken harness still fails the test in ≤20s rather than hanging.
-    let deadline = std::time::Instant::now() + Duration::from_secs(20);
-    let mut id = 10u32;
-    loop {
-        let resp = tools_call(stdin, stdout, id, "list_windows",
-            serde_json::json!({ "pid": pid as i64 }));
-        id = id.wrapping_add(1);
-        if let Some(wins) = resp["result"]["structuredContent"]["windows"].as_array() {
-            for w in wins {
-                if w["pid"].as_u64() != Some(pid as u64) { continue; }
-                let title = w["title"].as_str().unwrap_or("");
-                if title.contains(title_substr) {
-                    return Some((w["window_id"].as_u64()?, title.to_string()));
-                }
-            }
-        }
-        if std::time::Instant::now() >= deadline { return None; }
-        std::thread::sleep(Duration::from_millis(200));
+/// Launch the WinUI3 harness through the driver's reaper (kill-on-close Job
+/// Object) and return its pid. Returns `None` (skip) if the harness isn't built.
+fn launch_winui3(driver: &mut McpDriver) -> Option<u32> {
+    let exe = harness_winui3_exe();
+    if !exe.exists() {
+        eprintln!("WinUI3 harness exe not found at {exe:?} — run test-harness/build/windows.ps1");
+        return None;
     }
+    let child = spawn_in_job(Command::new(&exe).stdout(Stdio::null()).stderr(Stdio::null())).ok()?;
+    let pid = child.id();
+    driver.reaper().push(child);
+    // Short fixed cold-start settle (window creation + foreground
+    // establishment after spawn). `find_window`'s polling handles the
+    // variable tail (WinUI3 first-run cold-start under sandbox load).
+    std::thread::sleep(Duration::from_millis(1500));
+    Some(pid)
 }
 
 #[test]
 #[ignore]
 fn harness_winui3_smoke() {
-    let driver = driver_binary();
-    if !driver.exists() { eprintln!("cua-driver.exe not built"); return; }
-    let harness = match Harness::launch() { Some(h) => h, None => return };
-    println!("WinUI3 harness pid={}", harness.pid);
+    let Some(mut driver) = McpDriver::spawn() else { return };
+    let Some(pid) = launch_winui3(&mut driver) else { return };
+    println!("WinUI3 harness pid={pid}");
 
-    let mut child = Command::new(&driver)
-        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
-        .spawn().expect("spawn cua-driver");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut raw_stdout = child.stdout.take().unwrap();
-    let mut stdout = BufReader::new(&mut raw_stdout);
-    init(&mut stdin, &mut stdout);
-
-    let (wid, _) = find_harness_window(&mut stdin, &mut stdout, harness.pid, "CuaTestHarness WinUI3")
+    let (wid, _) = driver
+        .find_window(pid as i64, "CuaTestHarness WinUI3")
         .expect("WinUI3 main window not found");
 
-    let snap = tools_call(&mut stdin, &mut stdout, 20, "get_window_state",
-        serde_json::json!({"pid": harness.pid as i64, "window_id": wid, "capture_mode":"tree"}));
-    let text = snapshot_text(&snap);
+    let snap = driver.call(
+        "get_window_state",
+        serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode":"tree"}),
+    );
+    let text = snap.text();
 
     // Button-class controls surface AutomationIds in the UIA tree.
     for aid in [
@@ -157,124 +90,89 @@ fn harness_winui3_smoke() {
     assert!(text.contains("counter=0"),             "WinUI3 initial counter label not in snapshot");
 
     println!("✅ harness_winui3_smoke: all expected scenarios present in UIA tree");
-
-    child.kill().ok();
-}
-
-fn find_idx(text: &str, aid: &str) -> Option<u64> {
-    let needle = format!("id={aid}");
-    for line in text.lines() {
-        if !line.contains(&needle) { continue; }
-        let s = line.find('[')? + 1;
-        let e = line[s..].find(']')? + s;
-        return line[s..e].trim().parse().ok();
-    }
-    None
 }
 
 #[test]
 #[ignore]
 fn harness_winui3_type_text() {
-    let driver = driver_binary();
-    if !driver.exists() { return; }
-    let harness = match Harness::launch() { Some(h) => h, None => return };
+    let Some(mut driver) = McpDriver::spawn() else { return };
+    let Some(pid) = launch_winui3(&mut driver) else { return };
 
-    let mut child = Command::new(&driver)
-        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
-        .spawn().expect("spawn cua-driver");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut raw_stdout = child.stdout.take().unwrap();
-    let mut stdout = BufReader::new(&mut raw_stdout);
-    init(&mut stdin, &mut stdout);
-
-    let (wid, _) = find_harness_window(&mut stdin, &mut stdout, harness.pid, "CuaTestHarness WinUI3")
+    let (wid, _) = driver
+        .find_window(pid as i64, "CuaTestHarness WinUI3")
         .expect("WinUI3 main window");
 
-    let snap = tools_call(&mut stdin, &mut stdout, 20, "get_window_state",
-        serde_json::json!({"pid": harness.pid as i64, "window_id": wid, "capture_mode":"som"}));
-    let snap_text = snapshot_text(&snap);
-    let idx = find_idx(snap_text, "txt-input").expect("txt-input not in WinUI3 snapshot");
+    let snap = driver.call(
+        "get_window_state",
+        serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode":"som"}),
+    );
+    let idx = element_index_by_id(snap.text(), "txt-input").expect("txt-input not in WinUI3 snapshot");
 
     // WinUI3 is a XAML host — type_text requires element_index + window_id
     // (routes through UIA ValuePattern.SetValue, see Windows backend docs).
-    let resp = tools_call(&mut stdin, &mut stdout, 30, "type_text", serde_json::json!({
-        "pid": harness.pid as i64,
+    let resp = driver.call("type_text", serde_json::json!({
+        "pid": pid as i64,
         "window_id": wid,
         "element_index": idx,
         "text": "winui3-typed"
     }));
-    println!("type_text (WinUI3): {}", resp["result"]["content"][0]["text"]);
+    println!("type_text (WinUI3): {}", resp.text());
     std::thread::sleep(Duration::from_millis(500));
 
-    let post = tools_call(&mut stdin, &mut stdout, 31, "get_window_state",
-        serde_json::json!({"pid": harness.pid as i64, "window_id": wid, "capture_mode":"som"}));
-    let post_text = snapshot_text(&post);
-    assert!(post_text.contains("mirror=winui3-typed"),
+    let post = driver.call(
+        "get_window_state",
+        serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode":"som"}),
+    );
+    assert!(post.text().contains("mirror=winui3-typed"),
         "WinUI3 TextBox mirror did not advance. Snapshot excerpt: {}",
-        post_text.chars().take(600).collect::<String>());
+        post.text().chars().take(600).collect::<String>());
     println!("✅ harness_winui3_type_text: WinUI3 TextBox mirror reflects 'winui3-typed'");
-
-    child.kill().ok();
 }
 
 #[test]
 #[ignore]
 fn harness_winui3_xaml_popup_open() {
-    let driver = driver_binary();
-    if !driver.exists() { return; }
-    let harness = match Harness::launch() { Some(h) => h, None => return };
+    let Some(mut driver) = McpDriver::spawn() else { return };
+    let Some(pid) = launch_winui3(&mut driver) else { return };
 
-    let mut child = Command::new(&driver)
-        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
-        .spawn().expect("spawn cua-driver");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut raw_stdout = child.stdout.take().unwrap();
-    let mut stdout = BufReader::new(&mut raw_stdout);
-    init(&mut stdin, &mut stdout);
-
-    let (wid, _) = find_harness_window(&mut stdin, &mut stdout, harness.pid, "CuaTestHarness WinUI3")
+    let (wid, _) = driver
+        .find_window(pid as i64, "CuaTestHarness WinUI3")
         .expect("WinUI3 main window");
 
-    let snap = tools_call(&mut stdin, &mut stdout, 20, "get_window_state",
-        serde_json::json!({"pid": harness.pid as i64, "window_id": wid, "capture_mode":"som"}));
-    let idx = find_idx(snapshot_text(&snap), "btn-open-popup").expect("btn-open-popup");
+    let snap = driver.call(
+        "get_window_state",
+        serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode":"som"}),
+    );
+    let idx = element_index_by_id(snap.text(), "btn-open-popup").expect("btn-open-popup");
 
-    let _ = tools_call(&mut stdin, &mut stdout, 30, "click", serde_json::json!({
-        "pid": harness.pid as i64, "window_id": wid, "element_index": idx
+    let _ = driver.call("click", serde_json::json!({
+        "pid": pid as i64, "window_id": wid, "element_index": idx
     }));
     std::thread::sleep(Duration::from_millis(500));
 
-    let post = tools_call(&mut stdin, &mut stdout, 31, "get_window_state",
-        serde_json::json!({"pid": harness.pid as i64, "window_id": wid, "capture_mode":"som"}));
-    let text = snapshot_text(&post);
+    let post = driver.call(
+        "get_window_state",
+        serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode":"som"}),
+    );
+    let text = post.text();
     assert!(text.contains("XAML_POPUP_MARKER_v1"),
         "XAML popup body did not appear in tree after click. Excerpt: {}",
         text.chars().take(600).collect::<String>());
     println!("✅ harness_winui3_xaml_popup_open: popup body visible in UIA tree");
-
-    child.kill().ok();
 }
 
 // ── Session helper for the additional control tests ──────────────────────────
 
 fn winui3_with_session<F>(f: F)
-where F: FnOnce(u32, u64, &mut ChildStdin, &mut BufReader<&mut ChildStdout>) {
-    let driver = driver_binary();
-    if !driver.exists() { eprintln!("cua-driver.exe not built"); return; }
-    let harness = match Harness::launch() { Some(h) => h, None => return };
-    let mut child = Command::new(&driver)
-        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
-        .spawn().expect("spawn cua-driver");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut raw_stdout = child.stdout.take().unwrap();
-    let mut stdout = BufReader::new(&mut raw_stdout);
-    init(&mut stdin, &mut stdout);
-    let (wid, _) = find_harness_window(&mut stdin, &mut stdout, harness.pid, "CuaTestHarness WinUI3")
+where
+    F: FnOnce(u32, u64, &mut McpDriver),
+{
+    let Some(mut driver) = McpDriver::spawn() else { return };
+    let Some(pid) = launch_winui3(&mut driver) else { return };
+    let (wid, _) = driver
+        .find_window(pid as i64, "CuaTestHarness WinUI3")
         .expect("WinUI3 main window");
-    f(harness.pid, wid, &mut stdin, &mut stdout);
-    drop(stdout);
-    drop(stdin);
-    child.kill().ok();
+    f(pid, wid, &mut driver);
 }
 
 /// Regression guard for the click → TogglePattern dispatch fix.
@@ -284,17 +182,17 @@ where F: FnOnce(u32, u64, &mut ChildStdin, &mut BufReader<&mut ChildStdout>) {
 #[test]
 #[ignore]
 fn harness_winui3_checkbox_toggle() {
-    winui3_with_session(|pid, wid, stdin, stdout| {
-        let snap = tools_call(stdin, stdout, 20, "get_window_state",
+    winui3_with_session(|pid, wid, driver| {
+        let snap = driver.call("get_window_state",
             serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
-        let idx = find_idx(snapshot_text(&snap), "chk-agreed").expect("chk-agreed");
-        let _ = tools_call(stdin, stdout, 30, "click", serde_json::json!({
+        let idx = element_index_by_id(snap.text(), "chk-agreed").expect("chk-agreed");
+        let _ = driver.call("click", serde_json::json!({
             "pid": pid as i64, "window_id": wid, "element_index": idx
         }));
         std::thread::sleep(Duration::from_millis(400));
-        let post = tools_call(stdin, stdout, 31, "get_window_state",
+        let post = driver.call("get_window_state",
             serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
-        assert!(snapshot_text(&post).contains("agreed=True"),
+        assert!(post.text().contains("agreed=True"),
             "WinUI3 CheckBox didn't toggle: TogglePattern dispatch may have regressed.");
         println!("✅ harness_winui3_checkbox_toggle: agreed=True via UIA Toggle");
     });
@@ -304,17 +202,17 @@ fn harness_winui3_checkbox_toggle() {
 #[test]
 #[ignore]
 fn harness_winui3_radio_select() {
-    winui3_with_session(|pid, wid, stdin, stdout| {
-        let snap = tools_call(stdin, stdout, 20, "get_window_state",
+    winui3_with_session(|pid, wid, driver| {
+        let snap = driver.call("get_window_state",
             serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
-        let idx = find_idx(snapshot_text(&snap), "rdo-high").expect("rdo-high");
-        let _ = tools_call(stdin, stdout, 30, "click", serde_json::json!({
+        let idx = element_index_by_id(snap.text(), "rdo-high").expect("rdo-high");
+        let _ = driver.call("click", serde_json::json!({
             "pid": pid as i64, "window_id": wid, "element_index": idx
         }));
         std::thread::sleep(Duration::from_millis(400));
-        let post = tools_call(stdin, stdout, 31, "get_window_state",
+        let post = driver.call("get_window_state",
             serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
-        assert!(snapshot_text(&post).contains("prio=High"),
+        assert!(post.text().contains("prio=High"),
             "WinUI3 radio didn't select High via SelectionItem.Select.");
         println!("✅ harness_winui3_radio_select: prio=High via UIA SelectionItem");
     });
@@ -335,20 +233,20 @@ fn harness_winui3_radio_select() {
 #[test]
 #[ignore]
 fn harness_winui3_slider_set_value() {
-    winui3_with_session(|pid, wid, stdin, stdout| {
-        let snap = tools_call(stdin, stdout, 20, "get_window_state",
+    winui3_with_session(|pid, wid, driver| {
+        let snap = driver.call("get_window_state",
             serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
-        let idx = find_idx(snapshot_text(&snap), "sld-value")
+        let idx = element_index_by_id(snap.text(), "sld-value")
             .expect("sld-value should now be in the UIA flat tree after RangeValuePattern detection fix");
-        let resp = tools_call(stdin, stdout, 30, "set_value", serde_json::json!({
+        let resp = driver.call("set_value", serde_json::json!({
             "pid": pid as i64, "window_id": wid, "element_index": idx,
             "value": "42"
         }));
-        println!("set_value sld-value=42: {}", resp["result"]["content"][0]["text"]);
+        println!("set_value sld-value=42: {}", resp.text());
         std::thread::sleep(Duration::from_millis(400));
-        let post = tools_call(stdin, stdout, 31, "get_window_state",
+        let post = driver.call("get_window_state",
             serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
-        let text = snapshot_text(&post);
+        let text = post.text();
         let advanced = text.lines().any(|l|
             l.contains("slider_value=") && !l.contains("slider_value=0\""));
         assert!(advanced,
@@ -364,28 +262,28 @@ fn harness_winui3_slider_set_value() {
 #[test]
 #[ignore]
 fn harness_winui3_combo_select() {
-    winui3_with_session(|pid, wid, stdin, stdout| {
-        let snap = tools_call(stdin, stdout, 20, "get_window_state",
+    winui3_with_session(|pid, wid, driver| {
+        let snap = driver.call("get_window_state",
             serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
-        let combo_idx = find_idx(snapshot_text(&snap), "cbo-color").expect("cbo-color");
+        let combo_idx = element_index_by_id(snap.text(), "cbo-color").expect("cbo-color");
         // Expand the dropdown via ExpandCollapse.
-        let _ = tools_call(stdin, stdout, 30, "click", serde_json::json!({
+        let _ = driver.call("click", serde_json::json!({
             "pid": pid as i64, "window_id": wid, "element_index": combo_idx
         }));
         std::thread::sleep(Duration::from_millis(400));
         // Re-snapshot — items materialize after expand.
-        let snap2 = tools_call(stdin, stdout, 31, "get_window_state",
+        let snap2 = driver.call("get_window_state",
             serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
-        let item_idx = find_idx(snapshot_text(&snap2), "cbo-item-orange")
+        let item_idx = element_index_by_id(snap2.text(), "cbo-item-orange")
             .expect("cbo-item-orange after expand");
         // Select the item via SelectionItem.Select.
-        let _ = tools_call(stdin, stdout, 32, "click", serde_json::json!({
+        let _ = driver.call("click", serde_json::json!({
             "pid": pid as i64, "window_id": wid, "element_index": item_idx
         }));
         std::thread::sleep(Duration::from_millis(400));
-        let post = tools_call(stdin, stdout, 33, "get_window_state",
+        let post = driver.call("get_window_state",
             serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode": "ax"}));
-        assert!(snapshot_text(&post).contains("color=orange"),
+        assert!(post.text().contains("color=orange"),
             "WinUI3 combo didn't switch to orange via ExpandCollapse + SelectionItem.Select.");
         println!("✅ harness_winui3_combo_select: color=orange via UIA Expand + Select");
     });

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
@@ -38,164 +38,61 @@
 
 #![cfg(target_os = "windows")]
 
-use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::process::{Command, Stdio};
 use std::time::Duration;
 
-// ── path helpers ─────────────────────────────────────────────────────────────
+use cua_driver_testkit::{ax, harness_app, spawn_in_job, Driver, McpDriver, ToolResponse};
 
-fn workspace_root() -> PathBuf {
-    let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
-    PathBuf::from(manifest).parent().unwrap().parent().unwrap().to_owned()
-}
-
-fn driver_binary() -> PathBuf {
-    workspace_root().join("target/debug/cua-driver.exe")
-}
+// ── harness launcher ─────────────────────────────────────────────────────────
 
 fn harness_exe() -> PathBuf {
     if let Ok(p) = std::env::var("HARNESS_WPF_EXE") {
         let pb = PathBuf::from(p);
         if pb.exists() { return pb; }
     }
-    workspace_root().join("test-apps/harness-wpf/CuaTestHarness.Wpf.exe")
+    harness_app("harness-wpf", "CuaTestHarness.Wpf.exe")
 }
 
-// ── JSON-RPC helpers ─────────────────────────────────────────────────────────
-
-fn send(stdin: &mut ChildStdin, req: serde_json::Value) {
-    writeln!(stdin, "{}", serde_json::to_string(&req).unwrap()).unwrap();
-}
-
-fn recv(stdout: &mut BufReader<&mut ChildStdout>) -> serde_json::Value {
-    let mut line = String::new();
-    stdout.read_line(&mut line).expect("read response");
-    serde_json::from_str(line.trim()).expect("parse json")
-}
-
-fn init(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>) {
-    send(stdin, serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}));
-    let _ = recv(stdout);
-}
-
-fn tools_call(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
-              id: u32, name: &str, args: serde_json::Value) -> serde_json::Value {
-    send(stdin, serde_json::json!({
-        "jsonrpc": "2.0", "id": id, "method": "tools/call",
-        "params": { "name": name, "arguments": args }
-    }));
-    recv(stdout)
-}
-
-// ── harness fixture ──────────────────────────────────────────────────────────
-
-struct Harness {
-    _app: Child,
-    pid: u32,
-}
-
-impl Harness {
-    fn launch() -> Option<Self> {
-        let exe = harness_exe();
-        if !exe.exists() {
-            eprintln!("harness exe not found at {exe:?} — run test-harness/build/windows.ps1 first");
-            return None;
-        }
-        let app = Command::new(&exe)
-            .stdout(Stdio::null()).stderr(Stdio::null())
-            .spawn().ok()?;
-        let pid = app.id();
-        // Short fixed settle for cold-start (window-creation + initial
-        // foreground hand-off after spawn) — the rest of the readiness
-        // wait happens via polling in find_harness_window. A 200ms-only
-        // wait turned out to be too short for the harness to establish
-        // foreground reliably under test-batch load, which caused
-        // SetForegroundWindow-needing tests (dispatch:foreground) to
-        // fail with a foreground-lock rejection.
-        std::thread::sleep(Duration::from_millis(800));
-        Some(Self { _app: app, pid })
+/// Launch the WPF harness app, tying its lifetime to `driver`'s reaper (the
+/// Windows kill-on-close Job Object) and returning its pid. Returns `None`
+/// (with a skip message) if the harness isn't built. We spawn via
+/// `spawn_in_job` and grab the pid before handing the child to the reaper so
+/// every subsequent `list_windows`/`find_window` filters on the exact spawned
+/// pid — defensive against the corner case where a previous test's harness
+/// hasn't been fully reaped and there are briefly two CuaTestHarness.Wpf
+/// windows on the desktop.
+fn launch_harness(driver: &mut McpDriver) -> Option<u32> {
+    let exe = harness_exe();
+    if !exe.exists() {
+        eprintln!("harness exe not found at {exe:?} — run test-harness/build/windows.ps1 first");
+        return None;
     }
-}
-
-impl Drop for Harness {
-    fn drop(&mut self) {
-        // Child::kill on Windows uses TerminateProcess, which signals exit
-        // but doesn't synchronously reap. Without wait() the next test's
-        // Harness::launch can briefly see TWO CuaTestHarness.Wpf windows —
-        // and find_harness_window may pick the dying one, returning stale
-        // element-cache coords (off-screen click failures).
-        let _ = self._app.kill();
-        let _ = self._app.wait();
-        // Extra settle for the OS-level window destruction sweep.
-        std::thread::sleep(Duration::from_millis(300));
-    }
-}
-
-// Look up the harness's main window via list_windows, filtered to the
-// exact spawned pid — defensive against the corner case where a previous
-// test's harness hasn't been fully reaped and there are briefly two
-// CuaTestHarness.Wpf windows on the desktop. Polls with a deadline rather
-// than relying on a fixed pre-sleep, so cold-start in sandbox (where the
-// WPF runtime + harness exe both pay first-launch JIT cost) doesn't time
-// out the harness with a too-short fixed sleep.
-fn find_harness_window(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
-                       pid: u32, title_substr: &str) -> Option<(u64, String)> {
-    let deadline = std::time::Instant::now() + Duration::from_secs(15);
-    let mut id = 10u32;
-    loop {
-        let resp = tools_call(stdin, stdout, id, "list_windows",
-            serde_json::json!({ "pid": pid as i64 }));
-        id = id.wrapping_add(1);
-        if let Some(wins) = resp["result"]["structuredContent"]["windows"].as_array() {
-            for w in wins {
-                if w["pid"].as_u64() != Some(pid as u64) { continue; }
-                let title = w["title"].as_str().unwrap_or("");
-                if title.contains(title_substr) {
-                    return Some((w["window_id"].as_u64()?, title.to_string()));
-                }
-            }
-        }
-        if std::time::Instant::now() >= deadline { return None; }
-        std::thread::sleep(Duration::from_millis(150));
-    }
+    let app = spawn_in_job(
+        Command::new(&exe).stdout(Stdio::null()).stderr(Stdio::null()),
+    ).ok()?;
+    let pid = app.id();
+    driver.reaper().push(app);
+    // Short fixed settle for cold-start (window-creation + initial
+    // foreground hand-off after spawn) — the rest of the readiness
+    // wait happens via polling in find_window. A 200ms-only
+    // wait turned out to be too short for the harness to establish
+    // foreground reliably under test-batch load, which caused
+    // SetForegroundWindow-needing tests (dispatch:foreground) to
+    // fail with a foreground-lock rejection.
+    std::thread::sleep(Duration::from_millis(800));
+    Some(pid)
 }
 
 // Get a UIA snapshot's flat element list — used to assert AutomationIds
-// exist in the tree without depending on tree-walk order.
-fn snapshot_elements(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
-                     pid: u32, window_id: u64) -> serde_json::Value {
-    let resp = tools_call(stdin, stdout, 20, "get_window_state",
-        serde_json::json!({
-            "pid": pid as i64,
-            "window_id": window_id,
-            "capture_mode": "tree"
-        }));
-    resp
-}
-
-fn snapshot_text(snapshot: &serde_json::Value) -> &str {
-    snapshot["result"]["content"][0]["text"].as_str().unwrap_or("")
-}
-
-fn elements_have_aid(snapshot: &serde_json::Value, aid: &str) -> bool {
-    // UIA tree is rendered as markdown lines like:
-    //   `  - [3] Button "Increment" [id=btn-increment actions=[click]]`
-    // so the substring `id=<aid>` is a reliable presence marker.
-    snapshot_text(snapshot).contains(&format!("id={aid}"))
-}
-
-/// Parse the UIA markdown snapshot for the line matching `id=<aid>` and
-/// extract the leading `[<index>]` element_index token.
-fn find_element_index_by_aid(snapshot: &serde_json::Value, aid: &str) -> Option<u64> {
-    let needle = format!("id={aid}");
-    for line in snapshot_text(snapshot).lines() {
-        if !line.contains(&needle) { continue; }
-        let start = line.find('[')? + 1;
-        let end   = line[start..].find(']')? + start;
-        return line[start..end].trim().parse().ok();
-    }
-    None
+// exist in the tree without depending on tree-walk order, and to read the
+// harness's marker/status text.
+fn snapshot(driver: &mut McpDriver, pid: u32, window_id: u64) -> ToolResponse {
+    driver.call("get_window_state", serde_json::json!({
+        "pid": pid as i64,
+        "window_id": window_id,
+        "capture_mode": "tree"
+    }))
 }
 
 // ── tests ────────────────────────────────────────────────────────────────────
@@ -203,32 +100,16 @@ fn find_element_index_by_aid(snapshot: &serde_json::Value, aid: &str) -> Option<
 #[test]
 #[ignore]
 fn harness_wpf_smoke() {
-    let driver = driver_binary();
-    if !driver.exists() {
-        eprintln!("cua-driver.exe not built — run `cargo build` first");
-        return;
-    }
-    let harness = match Harness::launch() {
-        Some(h) => h,
-        None => { eprintln!("harness not built — skipping"); return; }
-    };
-    println!("harness pid={}", harness.pid);
+    let Some(mut driver) = McpDriver::spawn() else { return };
+    let Some(pid) = launch_harness(&mut driver) else { return };
+    println!("harness pid={}", pid);
 
-    let mut child = Command::new(&driver)
-        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
-        .spawn().expect("spawn cua-driver");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut raw_stdout = child.stdout.take().unwrap();
-    let mut stdout = BufReader::new(&mut raw_stdout);
-
-    init(&mut stdin, &mut stdout);
-
-    let (wid, title) = find_harness_window(&mut stdin, &mut stdout, harness.pid, "CuaTestHarness WPF")
+    let (wid, title) = driver.find_window(pid as i64, "CuaTestHarness WPF")
         .expect("main window not found via list_windows");
     println!("main window: id={} title={:?}", wid, title);
 
-    let snap = snapshot_elements(&mut stdin, &mut stdout, harness.pid, wid);
-    let text = snapshot_text(&snap);
+    let snap = snapshot(&mut driver, pid, wid);
+    let text = snap.text();
 
     // Buttons appear with explicit id=<aid> tags in the UIA markdown.
     for aid in [
@@ -238,7 +119,7 @@ fn harness_wpf_smoke() {
         "btn-open-owned", "btn-open-layered",
         "btn-exit",
     ] {
-        assert!(elements_have_aid(&snap, aid), "missing AutomationId {aid} in WPF UIA snapshot");
+        assert!(ax::has_id(text, aid), "missing AutomationId {aid} in WPF UIA snapshot");
     }
 
     // TextBlocks are reported as bare Text nodes (no UIA Invoke/Value pattern,
@@ -251,87 +132,61 @@ fn harness_wpf_smoke() {
     assert!(text.contains("\"Native Win32 Child\""), "native HWND child button not in snapshot");
 
     println!("✅ harness_wpf_smoke: all expected scenarios present in UIA tree");
-
-    child.kill().ok();
 }
 
 // ── shared driver session helper ─────────────────────────────────────────────
 
-/// Spin up a fresh harness + cua-driver pair, run the closure, then tear
-/// everything down. Returns whatever the closure returns. The closure
-/// receives the harness pid, the cua-driver stdin/stdout and a pre-resolved
-/// main window_id.
+/// Spin up a fresh cua-driver + harness pair, run the closure, then tear
+/// everything down (the harness app is reaped with the driver via the Job
+/// Object). Returns whatever the closure returns. The closure receives the
+/// harness pid, a pre-resolved main window_id, and the driver.
 fn with_session<F, R>(f: F) -> Option<R>
-where F: FnOnce(u32, u64, &mut ChildStdin, &mut BufReader<&mut ChildStdout>) -> R {
-    if !driver_binary().exists() { eprintln!("cua-driver.exe not built"); return None; }
-    let harness = Harness::launch()?;
-    let mut child = Command::new(&driver_binary())
-        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
-        .spawn().expect("spawn cua-driver");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut raw_stdout = child.stdout.take().unwrap();
-    let mut stdout = BufReader::new(&mut raw_stdout);
-    init(&mut stdin, &mut stdout);
-    let (wid, _) = find_harness_window(&mut stdin, &mut stdout, harness.pid, "CuaTestHarness WPF")
+where F: FnOnce(u32, u64, &mut McpDriver) -> R {
+    let mut driver = McpDriver::spawn()?;
+    let pid = launch_harness(&mut driver)?;
+    let (wid, _) = driver.find_window(pid as i64, "CuaTestHarness WPF")
         .expect("main window");
-    let out = f(harness.pid, wid, &mut stdin, &mut stdout);
-    drop(stdout);
-    drop(stdin);
-    child.kill().ok();
-    drop(harness);
-    Some(out)
+    Some(f(pid, wid, &mut driver))
 }
 
 #[test]
 #[ignore]
 fn harness_wpf_counter_invoke() {
-    let driver = driver_binary();
-    if !driver.exists() { return; }
-    let harness = match Harness::launch() { Some(h) => h, None => return };
+    let Some(mut driver) = McpDriver::spawn() else { return };
+    let Some(pid) = launch_harness(&mut driver) else { return };
 
-    let mut child = Command::new(&driver)
-        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
-        .spawn().expect("spawn cua-driver");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut raw_stdout = child.stdout.take().unwrap();
-    let mut stdout = BufReader::new(&mut raw_stdout);
-    init(&mut stdin, &mut stdout);
-
-    let (wid, _) = find_harness_window(&mut stdin, &mut stdout, harness.pid, "CuaTestHarness WPF")
+    let (wid, _) = driver.find_window(pid as i64, "CuaTestHarness WPF")
         .expect("main window");
     // Pre-snapshot so element_cache has indices we can address.
-    let pre = snapshot_elements(&mut stdin, &mut stdout, harness.pid, wid);
-    let idx = find_element_index_by_aid(&pre, "btn-increment")
+    let pre = snapshot(&mut driver, pid, wid);
+    let idx = ax::element_index_by_id(pre.text(), "btn-increment")
         .expect("btn-increment not in pre-snapshot");
 
-    let click = tools_call(&mut stdin, &mut stdout, 30, "click",
-        serde_json::json!({
-            "pid": harness.pid as i64,
-            "window_id": wid,
-            "element_index": idx
-        }));
-    println!("click [{idx}] btn-increment: {}", click["result"]["content"][0]["text"]);
+    let click = driver.call("click", serde_json::json!({
+        "pid": pid as i64,
+        "window_id": wid,
+        "element_index": idx
+    }));
+    println!("click [{idx}] btn-increment: {}", click.text());
 
     std::thread::sleep(Duration::from_millis(300));
 
-    let post = snapshot_elements(&mut stdin, &mut stdout, harness.pid, wid);
-    let text = snapshot_text(&post);
+    let post = snapshot(&mut driver, pid, wid);
+    let text = post.text();
     assert!(
         text.contains("counter=1"),
         "counter label did not advance after click — snapshot text: {}",
         text.chars().take(400).collect::<String>()
     );
     println!("✅ harness_wpf_counter_invoke: counter advanced to 1");
-
-    child.kill().ok();
 }
 
 #[test]
 #[ignore]
 fn harness_wpf_type_text() {
-    with_session(|pid, wid, stdin, stdout| {
-        let snap = snapshot_elements(stdin, stdout, pid, wid);
-        let idx = find_element_index_by_aid(&snap, "txt-input")
+    with_session(|pid, wid, driver| {
+        let snap = snapshot(driver, pid, wid);
+        let idx = ax::element_index_by_id(snap.text(), "txt-input")
             .expect("txt-input not in snapshot");
 
         // WPF's TextBox needs *keyboard focus* for WM_CHAR delivery — and
@@ -340,12 +195,12 @@ fn harness_wpf_type_text() {
         // real ones). Use dispatch:"foreground" → SendInput synthesizes
         // an OS-level click that WPF treats identically to a user mouse,
         // landing actual keyboard focus on the TextBox.
-        let _ = tools_call(stdin, stdout, 28, "bring_to_front", serde_json::json!({
+        let _ = driver.call("bring_to_front", serde_json::json!({
             "pid": pid as i64, "window_id": wid
         }));
         std::thread::sleep(Duration::from_millis(300));
 
-        let _ = tools_call(stdin, stdout, 29, "click", serde_json::json!({
+        let _ = driver.call("click", serde_json::json!({
             "pid": pid as i64, "window_id": wid, "element_index": idx,
             "dispatch": "foreground"
         }));
@@ -355,19 +210,19 @@ fn harness_wpf_type_text() {
         // foreground back from the harness window between click and
         // type_text. Re-assert foreground so PostMessage WM_CHAR finds
         // the TextBox with keyboard focus.
-        let _ = tools_call(stdin, stdout, 30, "bring_to_front", serde_json::json!({
+        let _ = driver.call("bring_to_front", serde_json::json!({
             "pid": pid as i64, "window_id": wid
         }));
         std::thread::sleep(Duration::from_millis(300));
 
-        let resp = tools_call(stdin, stdout, 31, "type_text", serde_json::json!({
+        let resp = driver.call("type_text", serde_json::json!({
             "pid": pid as i64, "text": "harness-typed"
         }));
-        println!("type_text: {}", resp["result"]["content"][0]["text"]);
+        println!("type_text: {}", resp.text());
         std::thread::sleep(Duration::from_millis(700));
 
-        let post = snapshot_elements(stdin, stdout, pid, wid);
-        let text = snapshot_text(&post);
+        let post = snapshot(driver, pid, wid);
+        let text = post.text();
         let mirror_lines: Vec<&str> = text.lines()
             .filter(|l| l.contains("mirror=") || l.contains("txt-input"))
             .collect();
@@ -383,18 +238,18 @@ fn harness_wpf_type_text() {
 fn harness_wpf_set_value() {
     // Companion to harness_wpf_type_text: exercises the UIA ValuePattern
     // write path via the `set_value` tool. No focus needed — purely UIA.
-    with_session(|pid, wid, stdin, stdout| {
-        let snap = snapshot_elements(stdin, stdout, pid, wid);
-        let idx = find_element_index_by_aid(&snap, "txt-input")
+    with_session(|pid, wid, driver| {
+        let snap = snapshot(driver, pid, wid);
+        let idx = ax::element_index_by_id(snap.text(), "txt-input")
             .expect("txt-input not in snapshot");
-        let _ = tools_call(stdin, stdout, 30, "set_value", serde_json::json!({
+        let _ = driver.call("set_value", serde_json::json!({
             "pid": pid as i64, "window_id": wid, "element_index": idx,
             "value": "via-uia-setvalue"
         }));
         std::thread::sleep(Duration::from_millis(400));
 
-        let post = snapshot_elements(stdin, stdout, pid, wid);
-        let text = snapshot_text(&post);
+        let post = snapshot(driver, pid, wid);
+        let text = post.text();
         assert!(text.contains("mirror=via-uia-setvalue"),
             "set_value did not update TextBox. Excerpt: {}",
             text.chars().take(500).collect::<String>());
@@ -409,9 +264,8 @@ fn harness_wpf_set_value() {
 // exercises the click-event-handling path itself, not the
 // background-delivery path (which the counter_invoke test already
 // covers via UIA Invoke).
-fn focus_harness(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout>,
-                 pid: u32, wid: u64) {
-    let _ = tools_call(stdin, stdout, 28, "bring_to_front", serde_json::json!({
+fn focus_harness(driver: &mut McpDriver, pid: u32, wid: u64) {
+    let _ = driver.call("bring_to_front", serde_json::json!({
         "pid": pid as i64, "window_id": wid
     }));
     std::thread::sleep(Duration::from_millis(300));
@@ -420,23 +274,23 @@ fn focus_harness(stdin: &mut ChildStdin, stdout: &mut BufReader<&mut ChildStdout
 #[test]
 #[ignore]
 fn harness_wpf_right_click() {
-    with_session(|pid, wid, stdin, stdout| {
-        focus_harness(stdin, stdout, pid, wid);
-        let snap = snapshot_elements(stdin, stdout, pid, wid);
-        let idx = find_element_index_by_aid(&snap, "border-click-target")
+    with_session(|pid, wid, driver| {
+        focus_harness(driver, pid, wid);
+        let snap = snapshot(driver, pid, wid);
+        let idx = ax::element_index_by_id(snap.text(), "border-click-target")
             .expect("border-click-target not in snapshot");
         // Same dispatch:foreground rationale as type_text — PostMessage
         // WM_RBUTTONDOWN doesn't always reach WPF's MouseRightButtonDown
         // routed-event chain (intermittent in batch runs).
-        let resp = tools_call(stdin, stdout, 30, "right_click", serde_json::json!({
+        let resp = driver.call("right_click", serde_json::json!({
             "pid": pid as i64, "window_id": wid, "element_index": idx,
             "dispatch": "foreground"
         }));
-        println!("right_click: {}", resp["result"]["content"][0]["text"]);
+        println!("right_click: {}", resp.text());
         std::thread::sleep(Duration::from_millis(400));
 
-        let post = snapshot_elements(stdin, stdout, pid, wid);
-        let text = snapshot_text(&post);
+        let post = snapshot(driver, pid, wid);
+        let text = post.text();
         let action_lines: Vec<&str> = text.lines()
             .filter(|l| l.contains("last_action=") || l.contains("clicks="))
             .collect();
@@ -449,23 +303,23 @@ fn harness_wpf_right_click() {
 #[test]
 #[ignore]
 fn harness_wpf_double_click() {
-    with_session(|pid, wid, stdin, stdout| {
-        focus_harness(stdin, stdout, pid, wid);
-        let snap = snapshot_elements(stdin, stdout, pid, wid);
-        let idx = find_element_index_by_aid(&snap, "border-click-target")
+    with_session(|pid, wid, driver| {
+        focus_harness(driver, pid, wid);
+        let snap = snapshot(driver, pid, wid);
+        let idx = ax::element_index_by_id(snap.text(), "border-click-target")
             .expect("border-click-target not in snapshot");
         // dispatch:foreground for the same reason as right_click —
         // PostMessage WM_LBUTTONDOWN ×2 doesn't always reach WPF's
         // MouseDoubleClick / ClickCount=2 path under test-batch load.
-        let resp = tools_call(stdin, stdout, 30, "double_click", serde_json::json!({
+        let resp = driver.call("double_click", serde_json::json!({
             "pid": pid as i64, "window_id": wid, "element_index": idx,
             "dispatch": "foreground"
         }));
-        println!("double_click: {}", resp["result"]["content"][0]["text"]);
+        println!("double_click: {}", resp.text());
         std::thread::sleep(Duration::from_millis(400));
 
-        let post = snapshot_elements(stdin, stdout, pid, wid);
-        let text = snapshot_text(&post);
+        let post = snapshot(driver, pid, wid);
+        let text = post.text();
         let action_lines: Vec<&str> = text.lines()
             .filter(|l| l.contains("last_action=") || l.contains("clicks="))
             .collect();
@@ -486,15 +340,15 @@ fn harness_wpf_press_key_accelerator() {
     // path would handle modifiers but requires the cua-driver-uia.exe
     // helper that isn't in our test config. F5 has no modifier and works
     // on the PostMessage path.
-    with_session(|pid, wid, stdin, stdout| {
-        let resp = tools_call(stdin, stdout, 30, "press_key", serde_json::json!({
+    with_session(|pid, wid, driver| {
+        let resp = driver.call("press_key", serde_json::json!({
             "pid": pid as i64, "window_id": wid, "key": "f5"
         }));
-        println!("press_key f5: {}", resp["result"]["content"][0]["text"]);
+        println!("press_key f5: {}", resp.text());
         std::thread::sleep(Duration::from_millis(400));
 
-        let post = snapshot_elements(stdin, stdout, pid, wid);
-        let text = snapshot_text(&post);
+        let post = snapshot(driver, pid, wid);
+        let text = post.text();
         assert!(text.contains("accel_fired=1"),
             "F5 KeyBinding did not fire. Snapshot excerpt: {}",
             text.chars().take(500).collect::<String>());
@@ -505,33 +359,33 @@ fn harness_wpf_press_key_accelerator() {
 #[test]
 #[ignore]
 fn harness_wpf_scroll() {
-    with_session(|pid, wid, stdin, stdout| {
+    with_session(|pid, wid, driver| {
         // Pre-snapshot to populate the cache + read initial offset.
-        let pre = snapshot_elements(stdin, stdout, pid, wid);
-        let pre_text = snapshot_text(&pre);
+        let pre = snapshot(driver, pid, wid);
+        let pre_text = pre.text();
         assert!(pre_text.contains("scroll_offset=0"),
             "expected initial scroll_offset=0, got: {}",
             pre_text.lines().filter(|l| l.contains("scroll_offset")).collect::<Vec<_>>().join(" / "));
 
         // Click into the ScrollViewer so it gets focus / its descendants
         // become the WM_VSCROLL target.
-        let idx = find_element_index_by_aid(&pre, "scroll-tall")
+        let idx = ax::element_index_by_id(pre.text(), "scroll-tall")
             .expect("scroll-tall not in snapshot");
-        let _ = tools_call(stdin, stdout, 30, "click", serde_json::json!({
+        let _ = driver.call("click", serde_json::json!({
             "pid": pid as i64, "window_id": wid, "element_index": idx
         }));
         std::thread::sleep(Duration::from_millis(200));
 
         // Scroll down 5 lines.
-        let resp = tools_call(stdin, stdout, 31, "scroll", serde_json::json!({
+        let resp = driver.call("scroll", serde_json::json!({
             "pid": pid as i64, "window_id": wid,
             "direction": "down", "by": "line", "amount": 5
         }));
-        println!("scroll down: {}", resp["result"]["content"][0]["text"]);
+        println!("scroll down: {}", resp.text());
         std::thread::sleep(Duration::from_millis(400));
 
-        let post = snapshot_elements(stdin, stdout, pid, wid);
-        let text = snapshot_text(&post);
+        let post = snapshot(driver, pid, wid);
+        let text = post.text();
         let advanced = text.lines().any(|l|
             l.contains("scroll_offset=") && !l.contains("scroll_offset=0\""));
         assert!(advanced, "scroll offset did not advance after WM_VSCROLL. Lines: {}",
@@ -544,21 +398,21 @@ fn harness_wpf_scroll() {
 #[test]
 #[ignore]
 fn harness_wpf_modal_messagebox() {
-    with_session(|pid, wid, stdin, stdout| {
-        let snap = snapshot_elements(stdin, stdout, pid, wid);
-        let idx = find_element_index_by_aid(&snap, "btn-open-msgbox")
+    with_session(|pid, wid, driver| {
+        let snap = snapshot(driver, pid, wid);
+        let idx = ax::element_index_by_id(snap.text(), "btn-open-msgbox")
             .expect("btn-open-msgbox not in snapshot");
-        let _ = tools_call(stdin, stdout, 30, "click", serde_json::json!({
+        let _ = driver.call("click", serde_json::json!({
             "pid": pid as i64, "window_id": wid, "element_index": idx
         }));
         std::thread::sleep(Duration::from_millis(600));
 
         // List windows — the modal MessageBox should be a new top-level window
         // owned by the same pid.
-        let resp = tools_call(stdin, stdout, 31, "list_windows", serde_json::json!({
+        let resp = driver.call("list_windows", serde_json::json!({
             "pid": pid as i64
         }));
-        let windows = resp["result"]["structuredContent"]["windows"].as_array()
+        let windows = resp.structured()["windows"].as_array()
             .expect("windows array");
         let modal = windows.iter()
             .find(|w| w["title"].as_str().map(|t| t.contains("Harness MessageBox")).unwrap_or(false))
@@ -567,10 +421,10 @@ fn harness_wpf_modal_messagebox() {
         println!("modal window_id={}", modal_wid);
 
         // Walk the modal's UIA tree — expect OK and Cancel buttons.
-        let modal_snap = tools_call(stdin, stdout, 32, "get_window_state", serde_json::json!({
+        let modal_snap = driver.call("get_window_state", serde_json::json!({
             "pid": pid as i64, "window_id": modal_wid, "capture_mode": "tree"
         }));
-        let modal_text = snapshot_text(&modal_snap);
+        let modal_text = modal_snap.text();
         assert!(modal_text.contains("\"OK\""),
             "MessageBox UIA tree missing OK button. Tree: {}",
             modal_text.chars().take(800).collect::<String>());
@@ -586,7 +440,7 @@ fn harness_wpf_modal_messagebox() {
                 l[s..e].trim().parse::<u64>().ok()
             })
             .expect("Cancel button element_index not parseable");
-        let _ = tools_call(stdin, stdout, 33, "click", serde_json::json!({
+        let _ = driver.call("click", serde_json::json!({
             "pid": pid as i64, "window_id": modal_wid, "element_index": cancel_idx
         }));
         std::thread::sleep(Duration::from_millis(400));
@@ -597,28 +451,28 @@ fn harness_wpf_modal_messagebox() {
 #[test]
 #[ignore]
 fn harness_wpf_owned_popup() {
-    with_session(|pid, wid, stdin, stdout| {
-        let snap = snapshot_elements(stdin, stdout, pid, wid);
-        let idx = find_element_index_by_aid(&snap, "btn-open-owned")
+    with_session(|pid, wid, driver| {
+        let snap = snapshot(driver, pid, wid);
+        let idx = ax::element_index_by_id(snap.text(), "btn-open-owned")
             .expect("btn-open-owned not in snapshot");
-        let _ = tools_call(stdin, stdout, 30, "click", serde_json::json!({
+        let _ = driver.call("click", serde_json::json!({
             "pid": pid as i64, "window_id": wid, "element_index": idx
         }));
         std::thread::sleep(Duration::from_millis(500));
 
-        let resp = tools_call(stdin, stdout, 31, "list_windows", serde_json::json!({
+        let resp = driver.call("list_windows", serde_json::json!({
             "pid": pid as i64
         }));
-        let windows = resp["result"]["structuredContent"]["windows"].as_array().unwrap();
+        let windows = resp.structured()["windows"].as_array().unwrap();
         let owned = windows.iter()
             .find(|w| w["title"].as_str().map(|t| t.contains("Harness Owned Popup")).unwrap_or(false))
             .expect("Harness Owned Popup window not found in list_windows");
         let owned_wid = owned["window_id"].as_u64().unwrap();
 
-        let owned_snap = tools_call(stdin, stdout, 32, "get_window_state", serde_json::json!({
+        let owned_snap = driver.call("get_window_state", serde_json::json!({
             "pid": pid as i64, "window_id": owned_wid, "capture_mode": "tree"
         }));
-        let owned_text = snapshot_text(&owned_snap);
+        let owned_text = owned_snap.text();
         assert!(owned_text.contains("OWNED_POPUP_MARKER_v1"),
             "owned popup body marker missing. Tree: {}",
             owned_text.chars().take(600).collect::<String>());
@@ -629,19 +483,19 @@ fn harness_wpf_owned_popup() {
 #[test]
 #[ignore]
 fn harness_wpf_layered_popup_capture() {
-    with_session(|pid, wid, stdin, stdout| {
-        let snap = snapshot_elements(stdin, stdout, pid, wid);
-        let idx = find_element_index_by_aid(&snap, "btn-open-layered")
+    with_session(|pid, wid, driver| {
+        let snap = snapshot(driver, pid, wid);
+        let idx = ax::element_index_by_id(snap.text(), "btn-open-layered")
             .expect("btn-open-layered not in snapshot");
-        let _ = tools_call(stdin, stdout, 30, "click", serde_json::json!({
+        let _ = driver.call("click", serde_json::json!({
             "pid": pid as i64, "window_id": wid, "element_index": idx
         }));
         std::thread::sleep(Duration::from_millis(600));
 
-        let resp = tools_call(stdin, stdout, 31, "list_windows", serde_json::json!({
+        let resp = driver.call("list_windows", serde_json::json!({
             "pid": pid as i64
         }));
-        let windows = resp["result"]["structuredContent"]["windows"].as_array().unwrap();
+        let windows = resp.structured()["windows"].as_array().unwrap();
         let layered = windows.iter()
             .find(|w| w["title"].as_str().map(|t| t.contains("Harness Layered Popup")).unwrap_or(false))
             .expect("Harness Layered Popup window not found");
@@ -650,10 +504,10 @@ fn harness_wpf_layered_popup_capture() {
         // Capture-only path — assert the screenshot is not all-black, which
         // is the failure mode for PrintWindow against layered windows
         // without the WGC fallback.
-        let cap = tools_call(stdin, stdout, 32, "get_window_state", serde_json::json!({
+        let cap = driver.call("get_window_state", serde_json::json!({
             "pid": pid as i64, "window_id": layered_wid, "capture_mode": "vision"
         }));
-        let img_b64 = cap["result"]["content"].as_array()
+        let img_b64 = cap.raw["result"]["content"].as_array()
             .and_then(|arr| arr.iter().find_map(|c| {
                 if c["type"] == "image" { c["data"].as_str() } else { None }
             }))
@@ -689,13 +543,13 @@ fn harness_wpf_slider_drag() {
     // bring_to_front first to make the harness foreground (via
     // AttachThreadInput), then SendInput's own SetForegroundWindow is a
     // no-op success.
-    with_session(|pid, wid, stdin, stdout| {
-        focus_harness(stdin, stdout, pid, wid);
-        let pre = snapshot_elements(stdin, stdout, pid, wid);
-        assert!(snapshot_text(&pre).contains("slider_value=0"),
+    with_session(|pid, wid, driver| {
+        focus_harness(driver, pid, wid);
+        let pre = snapshot(driver, pid, wid);
+        assert!(pre.text().contains("slider_value=0"),
             "initial slider_value=0 missing");
 
-        let resp = tools_call(stdin, stdout, 30, "drag", serde_json::json!({
+        let resp = driver.call("drag", serde_json::json!({
             "pid": pid as i64, "window_id": wid,
             // drag screen-coords path: send_drag_synthesized takes screen
             // coords directly. The harness window is centered at
@@ -710,14 +564,14 @@ fn harness_wpf_slider_drag() {
             "duration_ms": 700, "steps": 40,
             "dispatch": "foreground"
         }));
-        let msg = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
+        let msg = resp.text();
         println!("drag slider (foreground): {msg}");
         assert!(msg.starts_with("✅"),
             "drag tool returned non-success: {msg}");
         std::thread::sleep(Duration::from_millis(500));
 
-        let post = snapshot_elements(stdin, stdout, pid, wid);
-        let text = snapshot_text(&post);
+        let post = snapshot(driver, pid, wid);
+        let text = post.text();
         let advanced = text.lines().any(|l|
             l.contains("slider_value=") && !l.contains("slider_value=0\""));
         assert!(advanced,
@@ -734,21 +588,21 @@ fn harness_wpf_slider_increase_large() {
     // Companion to slider_drag — exercises UIA Invoke on the Slider's
     // internal IncreaseLarge "page-up" button. Doesn't depend on screen
     // coords, so it's the more robust slider integration test.
-    with_session(|pid, wid, stdin, stdout| {
-        focus_harness(stdin, stdout, pid, wid);
-        let snap = snapshot_elements(stdin, stdout, pid, wid);
-        let idx = find_element_index_by_aid(&snap, "IncreaseLarge")
+    with_session(|pid, wid, driver| {
+        focus_harness(driver, pid, wid);
+        let snap = snapshot(driver, pid, wid);
+        let idx = ax::element_index_by_id(snap.text(), "IncreaseLarge")
             .expect("slider IncreaseLarge button not in snapshot");
         for i in 0..3 {
-            let resp = tools_call(stdin, stdout, 30 + i, "click", serde_json::json!({
+            let resp = driver.call("click", serde_json::json!({
                 "pid": pid as i64, "window_id": wid, "element_index": idx
             }));
-            println!("invoke IncreaseLarge #{i}: {}", resp["result"]["content"][0]["text"]);
+            println!("invoke IncreaseLarge #{i}: {}", resp.text());
             std::thread::sleep(Duration::from_millis(150));
         }
         std::thread::sleep(Duration::from_millis(300));
-        let post = snapshot_elements(stdin, stdout, pid, wid);
-        let text = snapshot_text(&post);
+        let post = snapshot(driver, pid, wid);
+        let text = post.text();
         let advanced = text.lines().any(|l|
             l.contains("slider_value=") && !l.contains("slider_value=0\""));
         assert!(advanced, "slider IncreaseLarge invokes did not advance value. Lines: {}",
@@ -760,26 +614,26 @@ fn harness_wpf_slider_increase_large() {
 #[test]
 #[ignore]
 fn harness_wpf_checkbox_toggle() {
-    with_session(|pid, wid, stdin, stdout| {
-        focus_harness(stdin, stdout, pid, wid);
-        let snap = snapshot_elements(stdin, stdout, pid, wid);
-        let idx = find_element_index_by_aid(&snap, "chk-agreed")
+    with_session(|pid, wid, driver| {
+        focus_harness(driver, pid, wid);
+        let snap = snapshot(driver, pid, wid);
+        let idx = ax::element_index_by_id(snap.text(), "chk-agreed")
             .expect("chk-agreed missing");
         // CheckBox exposes UIA TogglePattern (actions=[toggle]), not Invoke.
         // cua-driver's click tool tries UIA Invoke first; for elements that
         // don't support it the PostMessage fallback path runs. Use
         // dispatch:"foreground" to land a SendInput click that WPF
         // recognises as a real user click and processes through Toggle.
-        let resp = tools_call(stdin, stdout, 30, "click", serde_json::json!({
+        let resp = driver.call("click", serde_json::json!({
             "pid": pid as i64, "window_id": wid, "element_index": idx,
             "dispatch": "foreground"
         }));
-        println!("click chk-agreed: {}", resp["result"]["content"][0]["text"]);
+        println!("click chk-agreed: {}", resp.text());
         std::thread::sleep(Duration::from_millis(400));
-        let post = snapshot_elements(stdin, stdout, pid, wid);
-        assert!(snapshot_text(&post).contains("agreed=True"),
+        let post = snapshot(driver, pid, wid);
+        assert!(post.text().contains("agreed=True"),
             "checkbox didn't toggle: {}",
-            snapshot_text(&post).lines().filter(|l| l.contains("agreed=")).collect::<Vec<_>>().join(" / "));
+            post.text().lines().filter(|l| l.contains("agreed=")).collect::<Vec<_>>().join(" / "));
         println!("✅ harness_wpf_checkbox_toggle: agreed=True");
     });
 }
@@ -787,20 +641,20 @@ fn harness_wpf_checkbox_toggle() {
 #[test]
 #[ignore]
 fn harness_wpf_radio_select() {
-    with_session(|pid, wid, stdin, stdout| {
-        focus_harness(stdin, stdout, pid, wid);
-        let snap = snapshot_elements(stdin, stdout, pid, wid);
-        let idx = find_element_index_by_aid(&snap, "rdo-high")
+    with_session(|pid, wid, driver| {
+        focus_harness(driver, pid, wid);
+        let snap = snapshot(driver, pid, wid);
+        let idx = ax::element_index_by_id(snap.text(), "rdo-high")
             .expect("rdo-high missing");
         // RadioButton exposes SelectionItem pattern (actions=[select]).
         // Same dispatch:foreground rationale as the checkbox test.
-        let _ = tools_call(stdin, stdout, 30, "click", serde_json::json!({
+        let _ = driver.call("click", serde_json::json!({
             "pid": pid as i64, "window_id": wid, "element_index": idx,
             "dispatch": "foreground"
         }));
         std::thread::sleep(Duration::from_millis(400));
-        let post = snapshot_elements(stdin, stdout, pid, wid);
-        assert!(snapshot_text(&post).contains("prio=High"),
+        let post = snapshot(driver, pid, wid);
+        assert!(post.text().contains("prio=High"),
             "radio didn't switch to High");
         println!("✅ harness_wpf_radio_select: prio=High");
     });
@@ -809,34 +663,34 @@ fn harness_wpf_radio_select() {
 #[test]
 #[ignore]
 fn harness_wpf_combo_select() {
-    with_session(|pid, wid, stdin, stdout| {
-        focus_harness(stdin, stdout, pid, wid);
-        let snap = snapshot_elements(stdin, stdout, pid, wid);
-        let combo_idx = find_element_index_by_aid(&snap, "cbo-color")
+    with_session(|pid, wid, driver| {
+        focus_harness(driver, pid, wid);
+        let snap = snapshot(driver, pid, wid);
+        let combo_idx = ax::element_index_by_id(snap.text(), "cbo-color")
             .expect("cbo-color missing");
         // WPF ComboBox UIA peer surfaces ExpandCollapsePattern (actions=[expand])
         // but not ValuePattern — set_value at the parent is a no-op. Standard
         // recipe: invoke the combo to expand the dropdown, re-snapshot so the
         // item AIDs land in the element cache, then click the target item.
-        let _ = tools_call(stdin, stdout, 30, "click", serde_json::json!({
+        let _ = driver.call("click", serde_json::json!({
             "pid": pid as i64, "window_id": wid, "element_index": combo_idx,
             "dispatch": "foreground"
         }));
         std::thread::sleep(Duration::from_millis(500));
 
-        let snap2 = snapshot_elements(stdin, stdout, pid, wid);
-        let item_idx = find_element_index_by_aid(&snap2, "cbo-item-orange")
+        let snap2 = snapshot(driver, pid, wid);
+        let item_idx = ax::element_index_by_id(snap2.text(), "cbo-item-orange")
             .expect("cbo-item-orange missing after expand");
-        let _ = tools_call(stdin, stdout, 31, "click", serde_json::json!({
+        let _ = driver.call("click", serde_json::json!({
             "pid": pid as i64, "window_id": wid, "element_index": item_idx,
             "dispatch": "foreground"
         }));
         std::thread::sleep(Duration::from_millis(500));
 
-        let post = snapshot_elements(stdin, stdout, pid, wid);
-        assert!(snapshot_text(&post).contains("color=orange"),
+        let post = snapshot(driver, pid, wid);
+        assert!(post.text().contains("color=orange"),
             "combo didn't switch to orange: {}",
-            snapshot_text(&post).lines().filter(|l| l.contains("color=")).collect::<Vec<_>>().join(" / "));
+            post.text().lines().filter(|l| l.contains("color=")).collect::<Vec<_>>().join(" / "));
         println!("✅ harness_wpf_combo_select: color=orange");
     });
 }
@@ -844,20 +698,20 @@ fn harness_wpf_combo_select() {
 #[test]
 #[ignore]
 fn harness_wpf_listbox_select() {
-    with_session(|pid, wid, stdin, stdout| {
-        focus_harness(stdin, stdout, pid, wid);
-        let snap = snapshot_elements(stdin, stdout, pid, wid);
-        let idx = find_element_index_by_aid(&snap, "lst-cherry")
+    with_session(|pid, wid, driver| {
+        focus_harness(driver, pid, wid);
+        let snap = snapshot(driver, pid, wid);
+        let idx = ax::element_index_by_id(snap.text(), "lst-cherry")
             .expect("lst-cherry missing");
-        let _ = tools_call(stdin, stdout, 30, "click", serde_json::json!({
+        let _ = driver.call("click", serde_json::json!({
             "pid": pid as i64, "window_id": wid, "element_index": idx,
             "dispatch": "foreground"
         }));
         std::thread::sleep(Duration::from_millis(400));
-        let post = snapshot_elements(stdin, stdout, pid, wid);
-        assert!(snapshot_text(&post).contains("selected=cherry"),
+        let post = snapshot(driver, pid, wid);
+        assert!(post.text().contains("selected=cherry"),
             "list didn't select cherry: {}",
-            snapshot_text(&post).lines().filter(|l| l.contains("selected=")).collect::<Vec<_>>().join(" / "));
+            post.text().lines().filter(|l| l.contains("selected=")).collect::<Vec<_>>().join(" / "));
         println!("✅ harness_wpf_listbox_select: selected=cherry");
     });
 }
@@ -865,13 +719,13 @@ fn harness_wpf_listbox_select() {
 #[test]
 #[ignore]
 fn harness_wpf_menu_invoke() {
-    with_session(|pid, wid, stdin, stdout| {
-        focus_harness(stdin, stdout, pid, wid);
+    with_session(|pid, wid, driver| {
+        focus_harness(driver, pid, wid);
         // Expand File menu first (UIA expand pattern on MenuItem)
-        let snap = snapshot_elements(stdin, stdout, pid, wid);
-        let file_idx = find_element_index_by_aid(&snap, "menu-file")
+        let snap = snapshot(driver, pid, wid);
+        let file_idx = ax::element_index_by_id(snap.text(), "menu-file")
             .expect("menu-file missing");
-        let _ = tools_call(stdin, stdout, 30, "click", serde_json::json!({
+        let _ = driver.call("click", serde_json::json!({
             "pid": pid as i64, "window_id": wid, "element_index": file_idx,
             "dispatch": "foreground"
         }));
@@ -879,19 +733,19 @@ fn harness_wpf_menu_invoke() {
 
         // Re-snapshot so menu-file-new is in the cache (it materialized
         // when the menu expanded).
-        let snap2 = snapshot_elements(stdin, stdout, pid, wid);
-        let new_idx = find_element_index_by_aid(&snap2, "menu-file-new")
+        let snap2 = snapshot(driver, pid, wid);
+        let new_idx = ax::element_index_by_id(snap2.text(), "menu-file-new")
             .expect("menu-file-new missing after expand");
-        let _ = tools_call(stdin, stdout, 31, "click", serde_json::json!({
+        let _ = driver.call("click", serde_json::json!({
             "pid": pid as i64, "window_id": wid, "element_index": new_idx,
             "dispatch": "foreground"
         }));
         std::thread::sleep(Duration::from_millis(500));
 
-        let post = snapshot_elements(stdin, stdout, pid, wid);
-        assert!(snapshot_text(&post).contains("menu_action=file_new"),
+        let post = snapshot(driver, pid, wid);
+        assert!(post.text().contains("menu_action=file_new"),
             "File>New didn't invoke: {}",
-            snapshot_text(&post).lines().filter(|l| l.contains("menu_action=")).collect::<Vec<_>>().join(" / "));
+            post.text().lines().filter(|l| l.contains("menu_action=")).collect::<Vec<_>>().join(" / "));
         println!("✅ harness_wpf_menu_invoke: menu_action=file_new");
     });
 }

--- a/libs/cua-driver/rust/crates/cua-driver/tests/ux_guard_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/ux_guard_test.rs
@@ -24,27 +24,16 @@
 
 #![cfg(target_os = "windows")]
 
-use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
-// ── helpers shared with mcp_protocol_test ────────────────────────────────────
+use cua_driver_testkit::{driver_binary, spawn_in_job, workspace_root, Driver, McpDriver};
 
-fn binary_path() -> PathBuf {
-    let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
-    PathBuf::from(manifest)
-        .parent().unwrap()
-        .parent().unwrap()
-        .join("target/debug/cua-driver.exe")
-}
+// ── focus-monitor + test-app fixtures ────────────────────────────────────────
 
 fn focus_monitor_path() -> PathBuf {
-    let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
-    PathBuf::from(manifest)
-        .parent().unwrap()
-        .parent().unwrap()
-        .join("target/debug/focus-monitor-win.exe")
+    workspace_root().join("target/debug/focus-monitor-win.exe")
 }
 
 fn test_app_path() -> PathBuf {
@@ -54,35 +43,31 @@ fn test_app_path() -> PathBuf {
         let pb = PathBuf::from(p);
         if pb.exists() { return pb; }
     }
-    let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
-    PathBuf::from(manifest)
-        .parent().unwrap()
-        .parent().unwrap()
-        .join("test-apps/desktop-test-app-electron.0.1.0.exe")
+    workspace_root().join("test-apps/desktop-test-app-electron.0.1.0.exe")
 }
 
-/// Launch the electron test app in the background and return (process, pid).
-/// Waits up to 10s for the app's HTTP health endpoint to respond.
-/// Returns None if the binary doesn't exist or the app fails to start.
-fn launch_test_app() -> Option<(Child, u32)> {
+/// Launch the electron test app in the background (tied to the driver's reaper)
+/// and return its pid. Waits up to 10s for the app's HTTP health endpoint to
+/// respond. Returns None if the binary doesn't exist or the app fails to start.
+fn launch_test_app(driver: &mut McpDriver) -> Option<u32> {
     let exe = test_app_path();
     if !exe.exists() {
         eprintln!("desktop-test-app-electron not found at {exe:?} — skipping");
         return None;
     }
-    let child = Command::new(&exe)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .ok()?;
+    let child = spawn_in_job(
+        Command::new(&exe).stdout(Stdio::null()).stderr(Stdio::null()),
+    )
+    .ok()?;
     let pid = child.id();
+    driver.reaper().push(child);
     // Poll the HTTP health endpoint until it responds or timeout.
     // Allow extra time for cold-start in sandbox (no cached Electron DLLs).
     let deadline = std::time::Instant::now() + Duration::from_secs(20);
     loop {
         if std::time::Instant::now() > deadline {
             eprintln!("desktop-test-app-electron HTTP /health did not respond within 10s");
-            return Some((child, pid));
+            return Some(pid);
         }
         if let Ok(stream) = std::net::TcpStream::connect("127.0.0.1:6769") {
             drop(stream);
@@ -92,7 +77,7 @@ fn launch_test_app() -> Option<(Child, u32)> {
     }
     // Extra settle time for the window to appear.
     std::thread::sleep(Duration::from_millis(500));
-    Some((child, pid))
+    Some(pid)
 }
 
 fn loss_file() -> PathBuf {
@@ -107,51 +92,6 @@ fn read_losses(path: &std::path::Path) -> u32 {
         .ok()
         .and_then(|s| s.trim().parse().ok())
         .unwrap_or(0)
-}
-
-fn send_rpc(stdin: &mut impl Write, req: &serde_json::Value) {
-    let line = serde_json::to_string(req).unwrap();
-    writeln!(stdin, "{line}").unwrap();
-}
-
-fn recv_rpc(reader: &mut impl BufRead) -> serde_json::Value {
-    let mut line = String::new();
-    reader.read_line(&mut line).expect("read_line");
-    serde_json::from_str(line.trim()).expect("parse JSON")
-}
-
-/// Spawn cua-driver and do the MCP initialize handshake.
-fn spawn_driver() -> (Child, std::process::ChildStdin, BufReader<std::process::ChildStdout>) {
-    let binary = binary_path();
-    let mut child = Command::new(&binary)
-        .stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null())
-        .spawn().expect("spawn cua-driver");
-    let stdin  = child.stdin.take().unwrap();
-    let stdout = BufReader::new(child.stdout.take().unwrap());
-    (child, stdin, stdout)
-}
-
-fn init_driver(stdin: &mut impl Write, stdout: &mut impl BufRead) {
-    send_rpc(stdin, &serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}));
-    recv_rpc(stdout);
-}
-
-fn call_tool(
-    stdin: &mut impl Write,
-    stdout: &mut impl BufRead,
-    id: u64,
-    name: &str,
-    args: serde_json::Value,
-) -> serde_json::Value {
-    send_rpc(stdin, &serde_json::json!({
-        "jsonrpc":"2.0","id":id,"method":"tools/call",
-        "params":{"name":name,"arguments":args}
-    }));
-    recv_rpc(stdout)
-}
-
-fn tool_ok(resp: &serde_json::Value) -> bool {
-    resp["error"].is_null() && !resp["result"]["isError"].as_bool().unwrap_or(false)
 }
 
 fn focus_pid_file()  -> PathBuf { std::env::temp_dir().join("focus_monitor_pid.txt") }
@@ -171,11 +111,10 @@ fn launch_focus_monitor() -> (Child, u64, u32) {
     let _ = std::fs::remove_file(focus_pid_file());
     let _ = std::fs::remove_file(focus_hwnd_file());
 
-    let child = Command::new(&exe)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("spawn focus-monitor-win");
+    let child = spawn_in_job(
+        Command::new(&exe).stdout(Stdio::null()).stderr(Stdio::null()),
+    )
+    .expect("spawn focus-monitor-win");
 
     // Poll temp files until both PID and HWND are written (max 15s).
     let deadline = std::time::Instant::now() + Duration::from_secs(15);
@@ -201,15 +140,10 @@ fn launch_focus_monitor() -> (Child, u64, u32) {
 }
 
 /// Find the first on-screen window belonging to the given pid.
-fn find_window_for_pid(
-    stdin: &mut impl Write,
-    stdout: &mut impl BufRead,
-    id: u64,
-    pid: i64,
-) -> Option<u64> {
-    let resp = call_tool(stdin, stdout, id, "list_windows",
+fn find_window_for_pid(driver: &mut McpDriver, pid: i64) -> Option<u64> {
+    let resp = driver.call("list_windows",
         serde_json::json!({"pid": pid, "on_screen_only": true}));
-    resp["result"]["structuredContent"]["windows"]
+    resp.structured()["windows"]
         .as_array()?
         .iter()
         .find_map(|w| w["window_id"].as_u64())
@@ -241,39 +175,37 @@ fn test_background_click_and_type_no_focus_steal() {
     //! 3. Click inside the app and type text via cua-driver.
     //! 4. Assert act_losses on FocusMonitorWin stayed at 0.
 
-    let binary = binary_path();
-    if !binary.exists() { eprintln!("Binary not found — skipping"); return; }
+    if !driver_binary().exists() { eprintln!("Binary not found — skipping"); return; }
 
     let (mut fm_proc, _fm_hwnd, _fm_pid) = launch_focus_monitor();
     let losses_before = read_losses(&loss_file());
 
-    let (mut drv, mut stdin, mut stdout) = spawn_driver();
-    init_driver(&mut stdin, &mut stdout);
+    let Some(mut driver) = McpDriver::spawn() else { fm_proc.kill().ok(); return; };
 
-    let Some((mut app_proc, app_pid)) = launch_test_app() else {
+    let Some(app_pid) = launch_test_app(&mut driver) else {
         eprintln!("test app not available — skipping");
-        drv.kill().ok(); fm_proc.kill().ok(); return;
+        fm_proc.kill().ok(); return;
     };
-    let Some(app_wid) = find_window_for_pid(&mut stdin, &mut stdout, 3, app_pid as i64) else {
+    let Some(app_wid) = find_window_for_pid(&mut driver, app_pid as i64) else {
         eprintln!("test app window not found — skipping");
-        drv.kill().ok(); app_proc.kill().ok(); fm_proc.kill().ok(); return;
+        fm_proc.kill().ok(); return;
     };
 
     // Click inside the app (background, via PostMessage).
-    let r = call_tool(&mut stdin, &mut stdout, 4, "click",
+    let r = driver.call("click",
         serde_json::json!({"pid": app_pid, "window_id": app_wid, "x": 200.0, "y": 200.0}));
-    assert!(r["error"].is_null(), "Protocol error from click: {r:?}");
+    assert!(r.raw["error"].is_null(), "Protocol error from click: {:?}", r.raw);
 
     // Type text into the app (background, via PostMessage).
-    let r = call_tool(&mut stdin, &mut stdout, 5, "type_text",
+    let r = driver.call("type_text",
         serde_json::json!({"pid": app_pid, "window_id": app_wid, "text": "ux-guard-test"}));
-    assert!(r["error"].is_null(), "Protocol error from type_text: {r:?}");
+    assert!(r.raw["error"].is_null(), "Protocol error from type_text: {:?}", r.raw);
 
     // ux_guard: FocusMonitorWin must not have lost activation.
     assert_ux_guard(losses_before, 0,
         "background click + type_text into desktop-test-app-electron");
 
-    drv.kill().ok(); app_proc.kill().ok(); fm_proc.kill().ok();
+    fm_proc.kill().ok();
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -286,8 +218,7 @@ fn test_launch_app_no_focus_steal() {
     //!
     //! launch_app (path variant) must open a window without displacing FocusMonitorWin.
 
-    let binary = binary_path();
-    if !binary.exists() { return; }
+    if !driver_binary().exists() { return; }
 
     let exe = test_app_path();
     if !exe.exists() { eprintln!("test app not available — skipping"); return; }
@@ -295,24 +226,22 @@ fn test_launch_app_no_focus_steal() {
     let (mut fm_proc, _fm_hwnd, _fm_pid) = launch_focus_monitor();
     let losses_before = read_losses(&loss_file());
 
-    let (mut drv, mut stdin, mut stdout) = spawn_driver();
-    init_driver(&mut stdin, &mut stdout);
+    let Some(mut driver) = McpDriver::spawn() else { fm_proc.kill().ok(); return; };
 
     // Launch the test app via cua-driver launch_app (full path, SW_SHOWNOACTIVATE).
     let path_str = exe.to_string_lossy().into_owned();
-    let r = call_tool(&mut stdin, &mut stdout, 2, "launch_app",
-        serde_json::json!({"path": path_str}));
-    if !tool_ok(&r) {
-        eprintln!("launch_app failed — skipping: {:?}", r);
-        drv.kill().ok(); fm_proc.kill().ok(); return;
+    let r = driver.call("launch_app", serde_json::json!({"path": path_str}));
+    if r.is_error() {
+        eprintln!("launch_app failed — skipping: {:?}", r.raw);
+        fm_proc.kill().ok(); return;
     }
 
     // Wait for the app window to appear (Electron startup ~2-3s).
     let mut app_pid: Option<i64> = None;
     for _ in 0..20 {
         std::thread::sleep(Duration::from_millis(500));
-        let r2 = call_tool(&mut stdin, &mut stdout, 3, "list_apps", serde_json::json!({}));
-        if let Some(procs) = r2["result"]["structuredContent"]["processes"].as_array() {
+        let r2 = driver.call("list_apps", serde_json::json!({}));
+        if let Some(procs) = r2.structured()["processes"].as_array() {
             if let Some(p) = procs.iter().find(|p| {
                 p["name"].as_str().map(|n| n.to_lowercase().contains("desktop-test-app")).unwrap_or(false)
             }) {
@@ -323,7 +252,7 @@ fn test_launch_app_no_focus_steal() {
     }
     if app_pid.is_none() {
         eprintln!("desktop-test-app not found in process list after launch_app — skipping");
-        drv.kill().ok(); fm_proc.kill().ok(); return;
+        fm_proc.kill().ok(); return;
     }
 
     // ux_guard: FocusMonitorWin must not have lost activation.
@@ -332,7 +261,7 @@ fn test_launch_app_no_focus_steal() {
     // Kill the launched app by exe name.
     Command::new("taskkill").args(["/F", "/T", "/IM", "desktop-test-app-electron.0.1.0.exe"])
         .stdout(Stdio::null()).stderr(Stdio::null()).spawn().ok();
-    drv.kill().ok(); fm_proc.kill().ok();
+    fm_proc.kill().ok();
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -346,33 +275,31 @@ fn test_background_hotkey_no_focus_steal() {
     //! Send Ctrl+A to a background desktop-test-app-electron window.
     //! FocusMonitorWin must never lose activation.
 
-    let binary = binary_path();
-    if !binary.exists() { return; }
+    if !driver_binary().exists() { return; }
 
     let (mut fm_proc, _fm_hwnd, _fm_pid) = launch_focus_monitor();
     let losses_before = read_losses(&loss_file());
 
-    let (mut drv, mut stdin, mut stdout) = spawn_driver();
-    init_driver(&mut stdin, &mut stdout);
+    let Some(mut driver) = McpDriver::spawn() else { fm_proc.kill().ok(); return; };
 
-    let Some((mut app_proc, app_pid)) = launch_test_app() else {
+    let Some(app_pid) = launch_test_app(&mut driver) else {
         eprintln!("test app not available — skipping");
-        drv.kill().ok(); fm_proc.kill().ok(); return;
+        fm_proc.kill().ok(); return;
     };
-    let Some(app_wid) = find_window_for_pid(&mut stdin, &mut stdout, 3, app_pid as i64) else {
+    let Some(app_wid) = find_window_for_pid(&mut driver, app_pid as i64) else {
         eprintln!("test app window not found — skipping");
-        drv.kill().ok(); app_proc.kill().ok(); fm_proc.kill().ok(); return;
+        fm_proc.kill().ok(); return;
     };
 
     // Send Ctrl+A hotkey to background app (PostMessage, no focus steal).
-    let r = call_tool(&mut stdin, &mut stdout, 4, "hotkey",
+    let r = driver.call("hotkey",
         serde_json::json!({"pid": app_pid, "window_id": app_wid, "keys": ["ctrl", "a"]}));
-    assert!(r["error"].is_null(), "Protocol error from hotkey: {r:?}");
+    assert!(r.raw["error"].is_null(), "Protocol error from hotkey: {:?}", r.raw);
 
     // ux_guard: FocusMonitorWin must not have lost activation.
     assert_ux_guard(losses_before, 0, "background hotkey ctrl+a to desktop-test-app-electron");
 
-    drv.kill().ok(); app_proc.kill().ok(); fm_proc.kill().ok();
+    fm_proc.kill().ok();
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -390,28 +317,26 @@ fn test_background_click_opens_new_window_focus_preserved() {
     //! Verifies PostMessage doesn't inadvertently activate any new window that
     //! appears as a side-effect of the click.
 
-    let binary = binary_path();
-    if !binary.exists() { return; }
+    if !driver_binary().exists() { return; }
 
     let (mut fm_proc, _fm_hwnd, _fm_pid) = launch_focus_monitor();
     let losses_before = read_losses(&loss_file());
 
-    let (mut drv, mut stdin, mut stdout) = spawn_driver();
-    init_driver(&mut stdin, &mut stdout);
+    let Some(mut driver) = McpDriver::spawn() else { fm_proc.kill().ok(); return; };
 
-    let Some((mut app_proc, app_pid)) = launch_test_app() else {
+    let Some(app_pid) = launch_test_app(&mut driver) else {
         eprintln!("test app not available — skipping");
-        drv.kill().ok(); fm_proc.kill().ok(); return;
+        fm_proc.kill().ok(); return;
     };
-    let Some(app_wid) = find_window_for_pid(&mut stdin, &mut stdout, 3, app_pid as i64) else {
+    let Some(app_wid) = find_window_for_pid(&mut driver, app_pid as i64) else {
         eprintln!("test app window not found — skipping");
-        drv.kill().ok(); app_proc.kill().ok(); fm_proc.kill().ok(); return;
+        fm_proc.kill().ok(); return;
     };
 
     // Click somewhere in the app content area (may trigger navigation/new window).
-    let r = call_tool(&mut stdin, &mut stdout, 4, "click",
+    let r = driver.call("click",
         serde_json::json!({"pid": app_pid, "window_id": app_wid, "x": 400.0, "y": 350.0}));
-    assert!(r["error"].is_null(), "Protocol error from click: {r:?}");
+    assert!(r.raw["error"].is_null(), "Protocol error from click: {:?}", r.raw);
 
     // Brief wait for any side-effect windows to appear.
     std::thread::sleep(Duration::from_millis(500));
@@ -426,7 +351,7 @@ fn test_background_click_opens_new_window_focus_preserved() {
         "FocusMonitorWin crashed during the test"
     );
 
-    drv.kill().ok(); app_proc.kill().ok(); fm_proc.kill().ok();
+    fm_proc.kill().ok();
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -437,33 +362,30 @@ fn test_background_click_opens_new_window_focus_preserved() {
 fn test_background_screenshot_no_focus_steal() {
     //! PrintWindow captures a background window without activating it.
 
-    let binary = binary_path();
-    if !binary.exists() { return; }
+    if !driver_binary().exists() { return; }
 
     let (mut fm_proc, _fm_hwnd, _fm_pid) = launch_focus_monitor();
     let losses_before = read_losses(&loss_file());
 
-    let (mut drv, mut stdin, mut stdout) = spawn_driver();
-    init_driver(&mut stdin, &mut stdout);
+    let Some(mut driver) = McpDriver::spawn() else { fm_proc.kill().ok(); return; };
 
-    let Some((mut app_proc, app_pid)) = launch_test_app() else {
+    let Some(app_pid) = launch_test_app(&mut driver) else {
         eprintln!("test app not available — skipping");
-        drv.kill().ok(); fm_proc.kill().ok(); return;
+        fm_proc.kill().ok(); return;
     };
-    let Some(app_wid) = find_window_for_pid(&mut stdin, &mut stdout, 3, app_pid as i64) else {
+    let Some(app_wid) = find_window_for_pid(&mut driver, app_pid as i64) else {
         eprintln!("test app window not found — skipping");
-        drv.kill().ok(); app_proc.kill().ok(); fm_proc.kill().ok(); return;
+        fm_proc.kill().ok(); return;
     };
 
     // Screenshot via PrintWindow — must not activate the window.
-    let r = call_tool(&mut stdin, &mut stdout, 4, "screenshot",
-        serde_json::json!({"window_id": app_wid}));
-    assert!(r["error"].is_null(), "Protocol error from screenshot: {r:?}");
+    let r = driver.call("screenshot", serde_json::json!({"window_id": app_wid}));
+    assert!(r.raw["error"].is_null(), "Protocol error from screenshot: {:?}", r.raw);
 
     // ux_guard
     assert_ux_guard(losses_before, 0, "screenshot of background desktop-test-app-electron");
 
-    drv.kill().ok(); app_proc.kill().ok(); fm_proc.kill().ok();
+    fm_proc.kill().ok();
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -482,24 +404,20 @@ fn test_agent_cursor_visible_on_screen() {
     //!   4. Decode the PNG and sample a 40×40 px patch centred on the cursor.
     //!   5. Assert the patch contains cursor-like pixels (bright or saturated).
 
-    let binary = binary_path();
-    if !binary.exists() { eprintln!("Binary not found — skipping"); return; }
+    if !driver_binary().exists() { eprintln!("Binary not found — skipping"); return; }
 
-    let (mut drv, mut stdin, mut stdout) = spawn_driver();
-    init_driver(&mut stdin, &mut stdout);
+    let Some(mut driver) = McpDriver::spawn() else { return };
 
     // Safe centre-ish position on primary monitor.
     let cx = 640.0_f64;
     let cy = 400.0_f64;
 
     // Enable cursor overlay and glide to target.
-    let r = call_tool(&mut stdin, &mut stdout, 2, "set_agent_cursor_enabled",
-        serde_json::json!({"enabled": true}));
-    assert!(r["error"].is_null(), "set_agent_cursor_enabled failed: {r:?}");
+    let r = driver.call("set_agent_cursor_enabled", serde_json::json!({"enabled": true}));
+    assert!(r.raw["error"].is_null(), "set_agent_cursor_enabled failed: {:?}", r.raw);
 
-    let r = call_tool(&mut stdin, &mut stdout, 3, "move_cursor",
-        serde_json::json!({"x": cx, "y": cy}));
-    assert!(r["error"].is_null(), "move_cursor failed: {r:?}");
+    let r = driver.call("move_cursor", serde_json::json!({"x": cx, "y": cy}));
+    assert!(r.raw["error"].is_null(), "move_cursor failed: {:?}", r.raw);
 
     // Wait for the glide animation (750ms default) + a few render frames.
     std::thread::sleep(Duration::from_millis(900));
@@ -508,7 +426,7 @@ fn test_agent_cursor_visible_on_screen() {
     let png_bytes = platform_windows::capture::screenshot_display_bytes()
         .expect("screenshot_display_bytes failed");
 
-    drv.kill().ok();
+    drop(driver);
 
     // Decode PNG.
     let img = image::load_from_memory(&png_bytes).expect("decode PNG");


### PR DESCRIPTION
**Phase 2 of the test-suite cleanup** (Phase 1 = the testkit crate, #2039). Routes every remaining tool-call integration test through the shared `cua-driver-testkit`, deleting the machinery that was copy-pasted across the suite.

## Migrated (10 files, zero behavior change — same tests, args, assertions, `#[ignore]`)
| Platform | Files |
|---|---|
| macOS | `harness_appkit`, `harness_swiftui` |
| Windows | `harness_wpf`, `harness_winui3`, `harness_web_windows`, `harness_bg_modality`, `harness_lo_vcl`, `ux_guard`, `e2e_windows_bg_input` |
| any | `element_token` |

Each drops its local `workspace_root`/`driver_binary`/`send`/`recv`/`init`/`call`, the Windows Job Object reaper, `find_harness_window`, and the AX-snapshot text parsers — now sourced from the testkit (`McpDriver`/`Driver`/`ToolResponse`, `ChildReaper`, `find_window`, `ax::*`). **~1,000 lines of duplicated plumbing removed.**

## Testkit additions this required
- `paths::driver_binary()` now prefers `target/release` then debug (folds in the macOS release-or-debug variant).
- `McpDriver::find_window(pid, title_substr)` — replaces per-file `find_harness_window`.
- `ax` module — `looks_empty` / `has_id` / `element_index_by_id` / `element_index_containing`.

## Honest notes
- `element_token` keeps a small local `tools/list` helper — `McpDriver` does `tools/call` only (a raw-request method is a future testkit add). Its macOS/Linux gate is now file-level so Windows excludes it cleanly.
- Also silenced three **pre-existing** Windows warnings surfaced by the recompile (unused `assert_foreground_restored` oracle; two intentionally-named `*_DOCUMENTED_steals_focus` tests).
- `mcp_protocol_test` (3,412 lines, protocol-level) is **not** migrated here — it belongs to the Phase 5 split.

## Verification
- ✅ macOS: `cargo test --no-run -p cua-driver` — clean, 0 warnings.
- ✅ Windows VM: `cargo clean -p cua-driver` + full recompile — **EXIT=0, 0 warnings**, all 13 test targets build.
- Tests are `#[ignore]` (real desktop) — live `--ignored` behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more reliable window-finding and accessibility snapshot helpers, improving automation across apps and platforms.

* **Bug Fixes**
  * Improved detection of empty accessibility snapshots, including permission-related cases.
  * Updated driver path handling to prefer release builds when available, with debug fallback.
  * Strengthened integration tests and harness flows for more stable app interaction and window detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->