### PR TITLE
feat(python): add cua-cloud placeholder package

### DIFF
--- a/libs/python/cua-cloud/README.md
+++ b/libs/python/cua-cloud/README.md
@@ -1,0 +1,14 @@
+# cua-cloud
+
+Placeholder package for the future Cua Cloud Python SDK.
+
+## Installation
+
+```bash
+pip install cua-cloud
+```
+
+## Status
+
+This package is intentionally empty today. It exists to reserve the package
+name and provide a stable place for future Cua Cloud Python APIs.

--- a/libs/python/cua-cloud/cua_cloud/__init__.py
+++ b/libs/python/cua-cloud/cua_cloud/__init__.py
@@ -1,0 +1,5 @@
+"""Placeholder package for future Cua Cloud Python SDK."""
+
+__version__ = "0.1.0"
+
+__all__ = ["__version__"]

--- a/libs/python/cua-cloud/pyproject.toml
+++ b/libs/python/cua-cloud/pyproject.toml
@@ -1,0 +1,49 @@
+[project]
+name = "cua-cloud"
+version = "0.1.0"
+description = "Placeholder package for future Cua Cloud Python SDK."
+readme = "README.md"
+license = "MIT"
+authors = [
+    { name = "TryCua", email = "hello@trycua.com" }
+]
+keywords = [
+    "cua",
+    "cloud",
+    "computer-use",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries",
+]
+requires-python = ">=3.11,<3.14"
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/trycua/cua"
+Documentation = "https://docs.trycua.com"
+Repository = "https://github.com/trycua/cua"
+Issues = "https://github.com/trycua/cua/issues"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = [
+    "cua_cloud/**",
+    "README.md",
+]
+exclude = [
+    "cua_cloud/**/__pycache__",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["cua_cloud"]

--- a/libs/python/cua-cloud/tests/test_placeholder.py
+++ b/libs/python/cua-cloud/tests/test_placeholder.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import importlib
+import pathlib
+import tomllib
+
+
+def test_placeholder_package_metadata() -> None:
+    repo_root = pathlib.Path(__file__).resolve().parents[4]
+    pyproject_path = repo_root / "libs/python/cua-cloud/pyproject.toml"
+
+    package = importlib.import_module("cua_cloud")
+
+    assert package.__version__ == "0.1.0"
+
+    project = tomllib.loads(pyproject_path.read_text())["project"]
+    assert project["name"] == "cua-cloud"
+    assert project["description"] == "Placeholder package for future Cua Cloud Python SDK."


### PR DESCRIPTION
## Summary
- add a new `libs/python/cua-cloud` Python package stub
- expose only a placeholder module version and package metadata
- add a targeted test covering import and placeholder metadata

## Verification
- `PYTHONPATH=/home/node/cua/.worktrees/cua-cloud-placeholder/libs/python/cua-cloud pytest /home/node/cua/.worktrees/cua-cloud-placeholder/libs/python/cua-cloud/tests/test_placeholder.py -q`
- `cd /home/node/cua/.worktrees/cua-cloud-placeholder/libs/python/cua-cloud && uv build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a placeholder Python package with a published version, ready for future SDK use.

* **Documentation**
  * Added package documentation with installation guidance and a clear note that no SDK functionality is available yet.

* **Tests**
  * Added coverage to verify package metadata and the exposed version value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->