### PR TITLE
ci: add cua-cloud release automation

### DIFF
--- a/.github/scripts/tests/test_cua_cloud_release_wiring.py
+++ b/.github/scripts/tests/test_cua_cloud_release_wiring.py
@@ -1,0 +1,39 @@
+"""Regression tests for cua-cloud release automation wiring."""
+
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class TestCuaCloudReleaseWiring(unittest.TestCase):
+    """Verify cua-cloud is wired into the release automation."""
+
+    def read(self, relative_path: str) -> str:
+        return (REPO_ROOT / relative_path).read_text()
+
+    def test_release_on_merge_tracks_cua_cloud(self) -> None:
+        workflow = self.read(".github/workflows/release-on-merge.yml")
+
+        self.assertIn('["libs/python/cua-cloud/"]="pypi/cloud"', workflow)
+
+    def test_release_bump_version_supports_cua_cloud(self) -> None:
+        workflow = self.read(".github/workflows/release-bump-version.yml")
+
+        self.assertIn("- pypi/cloud", workflow)
+        self.assertIn('"pypi/cloud")', workflow)
+        self.assertIn('echo "directory=libs/python/cua-cloud" >> $GITHUB_OUTPUT', workflow)
+
+    def test_unreleased_digest_tracks_cua_cloud(self) -> None:
+        workflow = self.read(".github/workflows/release-unreleased-digest.yml")
+
+        self.assertIn('SERVICE_TAG_DIR["pypi/cloud"]="cloud-v|libs/python/cua-cloud/"', workflow)
+
+    def test_package_release_files_exist(self) -> None:
+        self.assertTrue((REPO_ROOT / ".github/workflows/cd-py-cloud.yml").exists())
+        self.assertTrue((REPO_ROOT / "libs/python/cua-cloud/.bumpversion.cfg").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/cd-py-cloud.yml
+++ b/.github/workflows/cd-py-cloud.yml
@@ -1,0 +1,69 @@
+name: "CD: cua-cloud (PyPI)"
+
+on:
+  push:
+    tags:
+      - "cloud-v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (without v prefix)"
+        required: true
+        default: "0.1.0"
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to publish"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  prepare:
+    runs-on: macos-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine version
+        id: get-version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION=${{ inputs.version }}
+          elif [ "${{ github.event_name }}" == "push" ]; then
+            if [[ "${{ github.ref }}" =~ ^refs/tags/cloud-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+              VERSION=${BASH_REMATCH[1]}
+            else
+              echo "Invalid tag format for cloud"
+              exit 1
+            fi
+          elif [ -n "${{ github.event.inputs.version }}" ]; then
+            VERSION=${{ github.event.inputs.version }}
+          else
+            echo "ERROR: No version found!"
+            exit 1
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+  publish:
+    needs: prepare
+    uses: ./.github/workflows/py-reusable-publish.yml
+    with:
+      package_name: "cloud"
+      package_dir: "libs/python/cua-cloud"
+      version: ${{ needs.prepare.outputs.version }}
+      base_package_name: "cua-cloud"
+    secrets:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+
+  create-release:
+    needs: [prepare, publish]
+    uses: ./.github/workflows/release-github-reusable.yml
+    with:
+      tag_name: "cloud-v${{ needs.prepare.outputs.version }}"
+      release_name: "cua-cloud v${{ needs.prepare.outputs.version }}"
+      module_path: "libs/python/cua-cloud"
+      body: ""

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -16,6 +16,7 @@ on:
           - pypi/cli
           - pypi/computer
           - pypi/computer-server
+          - pypi/cloud
           - pypi/core
           - pypi/mcp-server
           - pypi/sandbox
@@ -88,6 +89,10 @@ jobs:
               ;;
             "pypi/computer")
               echo "directory=libs/python/computer" >> $GITHUB_OUTPUT
+              echo "type=python" >> $GITHUB_OUTPUT
+              ;;
+            "pypi/cloud")
+              echo "directory=libs/python/cua-cloud" >> $GITHUB_OUTPUT
               echo "type=python" >> $GITHUB_OUTPUT
               ;;
             "pypi/computer-server")
@@ -355,6 +360,15 @@ jobs:
           cd libs/python/computer
           VERSION=$(python -c "import tomllib; from pathlib import Path; data = tomllib.loads(Path('pyproject.toml').read_text()); print(data['project']['version'])")
           echo "Computer version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Capture bumped cloud version
+        if: ${{ inputs.service == 'pypi/cloud' }}
+        id: cloud_version
+        run: |
+          cd libs/python/cua-cloud
+          VERSION=$(python -c "import tomllib; from pathlib import Path; data = tomllib.loads(Path('pyproject.toml').read_text()); print(data['project']['version'])")
+          echo "Cloud version: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Capture bumped computer-server version

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -63,6 +63,7 @@ jobs:
             ["libs/python/agent/"]="pypi/agent"
             ["libs/python/cua-sandbox/"]="pypi/sandbox"
             ["libs/python/computer/"]="pypi/computer"
+            ["libs/python/cua-cloud/"]="pypi/cloud"
             ["libs/python/core/"]="pypi/core"
             ["libs/python/som/"]="pypi/som"
             ["libs/python/bench-ui/"]="pypi/bench-ui"

--- a/.github/workflows/release-unreleased-digest.yml
+++ b/.github/workflows/release-unreleased-digest.yml
@@ -24,6 +24,7 @@ jobs:
           SERVICE_TAG_DIR["pypi/auto"]="auto-v|libs/python/cua-auto/"
           SERVICE_TAG_DIR["pypi/agent"]="agent-v|libs/python/agent/"
           SERVICE_TAG_DIR["pypi/computer"]="computer-v|libs/python/computer/"
+          SERVICE_TAG_DIR["pypi/cloud"]="cloud-v|libs/python/cua-cloud/"
           SERVICE_TAG_DIR["pypi/core"]="core-v|libs/python/core/"
           SERVICE_TAG_DIR["pypi/som"]="som-v|libs/python/som/"
           SERVICE_TAG_DIR["pypi/bench"]="bench-v|libs/cua-bench/"

--- a/libs/python/cua-cloud/.bumpversion.cfg
+++ b/libs/python/cua-cloud/.bumpversion.cfg
@@ -1,0 +1,14 @@
+[bumpversion]
+current_version = 0.1.0
+commit = True
+tag = True
+tag_name = cloud-v{new_version}
+message = Bump cua-cloud to v{new_version}
+
+[bumpversion:file:pyproject.toml]
+search = version = "{current_version}"
+replace = version = "{new_version}"
+
+[bumpversion:file:cua_cloud/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"


### PR DESCRIPTION
## Summary
- wire `libs/python/cua-cloud` into merge-triggered release detection
- add `pypi/cloud` support to the version bump workflow and unreleased digest
- add `cd-py-cloud.yml`, package bump config, and a regression test for the release wiring

## Verification
- `python3 -m unittest discover -s .github/scripts/tests -p 'test_cua_cloud_release_wiring.py'`
- `git diff --cached --check`

## Notes
- `python3 -m pytest libs/python/cua-cloud/tests/test_placeholder.py -q` was not run here because `pytest` is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for publishing the Cloud Python package through release automation.
  * Included manual and tag-based release flows for creating package releases.

* **Bug Fixes**
  * Updated release detection so changes in the Cloud package directory are recognized correctly.
  * Added checks to ensure Cloud release wiring and required configuration files are present.

* **Chores**
  * Added version-bump configuration for automated Cloud package releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->