### PR TITLE
fix(qemu-windows): launch Windows instances to a blank desktop (CUA-650)

### DIFF
--- a/libs/qemu-docker/windows/src/vm/setup/setup-cua-server.ps1
+++ b/libs/qemu-docker/windows/src/vm/setup/setup-cua-server.ps1
@@ -26,8 +26,8 @@ Write-Log -LogFile $script:LogFile -Message "Applying blank desktop hardening...
 # modal onto the desktop on every boot.
 try {
   $reliability = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Reliability'
-  New-Item -Path $reliability -Force -ErrorAction SilentlyContinue | Out-Null
-  Set-ItemProperty -Path $reliability -Name 'ShutdownReasonOn' -Value 0 -Type DWord
+  New-Item -Path $reliability -Force -ErrorAction Stop | Out-Null
+  Set-ItemProperty -Path $reliability -Name 'ShutdownReasonOn' -Value 0 -Type DWord -ErrorAction Stop
   Write-Log -LogFile $script:LogFile -Message "Shutdown Event Tracker disabled"
 } catch {
   Write-Log -LogFile $script:LogFile -Message "Shutdown Event Tracker warning: $($_.Exception.Message)"
@@ -36,10 +36,10 @@ try {
 # Disable Edge first-run experience and startup boost (Edge opens on first login otherwise)
 try {
   $edgePolicies = 'HKLM:\SOFTWARE\Policies\Microsoft\Edge'
-  New-Item -Path $edgePolicies -Force -ErrorAction SilentlyContinue | Out-Null
-  Set-ItemProperty -Path $edgePolicies -Name 'HideFirstRunExperience' -Value 1 -Type DWord
-  Set-ItemProperty -Path $edgePolicies -Name 'StartupBoostEnabled' -Value 0 -Type DWord
-  Set-ItemProperty -Path $edgePolicies -Name 'BackgroundModeEnabled' -Value 0 -Type DWord
+  New-Item -Path $edgePolicies -Force -ErrorAction Stop | Out-Null
+  Set-ItemProperty -Path $edgePolicies -Name 'HideFirstRunExperience' -Value 1 -Type DWord -ErrorAction Stop
+  Set-ItemProperty -Path $edgePolicies -Name 'StartupBoostEnabled' -Value 0 -Type DWord -ErrorAction Stop
+  Set-ItemProperty -Path $edgePolicies -Name 'BackgroundModeEnabled' -Value 0 -Type DWord -ErrorAction Stop
   Write-Log -LogFile $script:LogFile -Message "Edge first-run and startup boost disabled"
 } catch {
   Write-Log -LogFile $script:LogFile -Message "Edge policy warning: $($_.Exception.Message)"
@@ -47,10 +47,11 @@ try {
 
 # Disable OneDrive from launching at startup
 try {
+  # OneDrive entry may not exist; suppress the not-found error specifically
   Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name 'OneDrive' -ErrorAction SilentlyContinue
   $oneDrivePolicies = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\OneDrive'
-  New-Item -Path $oneDrivePolicies -Force -ErrorAction SilentlyContinue | Out-Null
-  Set-ItemProperty -Path $oneDrivePolicies -Name 'DisableFileSyncNGSC' -Value 1 -Type DWord
+  New-Item -Path $oneDrivePolicies -Force -ErrorAction Stop | Out-Null
+  Set-ItemProperty -Path $oneDrivePolicies -Name 'DisableFileSyncNGSC' -Value 1 -Type DWord -ErrorAction Stop
   Write-Log -LogFile $script:LogFile -Message "OneDrive startup disabled"
 } catch {
   Write-Log -LogFile $script:LogFile -Message "OneDrive startup warning: $($_.Exception.Message)"
@@ -59,20 +60,15 @@ try {
 # Disable Windows Security notification icon from appearing on the desktop
 try {
   $notifications = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows Defender Security Center\Notifications'
-  New-Item -Path $notifications -Force -ErrorAction SilentlyContinue | Out-Null
-  Set-ItemProperty -Path $notifications -Name 'DisableNotifications' -Value 1 -Type DWord
+  New-Item -Path $notifications -Force -ErrorAction Stop | Out-Null
+  Set-ItemProperty -Path $notifications -Name 'DisableNotifications' -Value 1 -Type DWord -ErrorAction Stop
   Write-Log -LogFile $script:LogFile -Message "Windows Security notifications disabled"
 } catch {
   Write-Log -LogFile $script:LogFile -Message "Security notifications warning: $($_.Exception.Message)"
 }
-
-# Suppress "Windows needs your current credentials" / Network Location Wizard prompts
-try {
-  Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Lsa' -Name 'LimitBlankPasswordUse' -Value 0 -Type DWord -ErrorAction SilentlyContinue
-  Write-Log -LogFile $script:LogFile -Message "Blank password restriction disabled"
-} catch {
-  Write-Log -LogFile $script:LogFile -Message "Blank password warning: $($_.Exception.Message)"
-}
+# Note: LimitBlankPasswordUse is intentionally NOT modified here.
+# Disabling the blank-password restriction (setting it to 0) weakens system security
+# and is not required for a blank desktop. The default value (1) is preserved.
 
 Write-Log -LogFile $script:LogFile -Message "Blank desktop hardening applied"
 

--- a/libs/qemu-docker/windows/src/vm/setup/setup-cua-server.ps1
+++ b/libs/qemu-docker/windows/src/vm/setup/setup-cua-server.ps1
@@ -16,6 +16,66 @@ $script:LogFile = Join-Path $LogDir ("setup_cua_server_" + $RunId + ".log")
 
 Write-Log -LogFile $script:LogFile -Message "=== Installing Cua Computer Server ==="
 
+# --- Blank Desktop Hardening ---
+# Prevent various Windows UI elements and startup apps from appearing at login,
+# ensuring instances launch to a clean blank desktop.
+Write-Log -LogFile $script:LogFile -Message "Applying blank desktop hardening..."
+
+# Disable the Shutdown Event Tracker ("Why did the computer shut down unexpectedly?").
+# The VM is force-stopped between sessions, so Windows would otherwise pop this
+# modal onto the desktop on every boot.
+try {
+  $reliability = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Reliability'
+  New-Item -Path $reliability -Force -ErrorAction SilentlyContinue | Out-Null
+  Set-ItemProperty -Path $reliability -Name 'ShutdownReasonOn' -Value 0 -Type DWord
+  Write-Log -LogFile $script:LogFile -Message "Shutdown Event Tracker disabled"
+} catch {
+  Write-Log -LogFile $script:LogFile -Message "Shutdown Event Tracker warning: $($_.Exception.Message)"
+}
+
+# Disable Edge first-run experience and startup boost (Edge opens on first login otherwise)
+try {
+  $edgePolicies = 'HKLM:\SOFTWARE\Policies\Microsoft\Edge'
+  New-Item -Path $edgePolicies -Force -ErrorAction SilentlyContinue | Out-Null
+  Set-ItemProperty -Path $edgePolicies -Name 'HideFirstRunExperience' -Value 1 -Type DWord
+  Set-ItemProperty -Path $edgePolicies -Name 'StartupBoostEnabled' -Value 0 -Type DWord
+  Set-ItemProperty -Path $edgePolicies -Name 'BackgroundModeEnabled' -Value 0 -Type DWord
+  Write-Log -LogFile $script:LogFile -Message "Edge first-run and startup boost disabled"
+} catch {
+  Write-Log -LogFile $script:LogFile -Message "Edge policy warning: $($_.Exception.Message)"
+}
+
+# Disable OneDrive from launching at startup
+try {
+  Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name 'OneDrive' -ErrorAction SilentlyContinue
+  $oneDrivePolicies = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\OneDrive'
+  New-Item -Path $oneDrivePolicies -Force -ErrorAction SilentlyContinue | Out-Null
+  Set-ItemProperty -Path $oneDrivePolicies -Name 'DisableFileSyncNGSC' -Value 1 -Type DWord
+  Write-Log -LogFile $script:LogFile -Message "OneDrive startup disabled"
+} catch {
+  Write-Log -LogFile $script:LogFile -Message "OneDrive startup warning: $($_.Exception.Message)"
+}
+
+# Disable Windows Security notification icon from appearing on the desktop
+try {
+  $notifications = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows Defender Security Center\Notifications'
+  New-Item -Path $notifications -Force -ErrorAction SilentlyContinue | Out-Null
+  Set-ItemProperty -Path $notifications -Name 'DisableNotifications' -Value 1 -Type DWord
+  Write-Log -LogFile $script:LogFile -Message "Windows Security notifications disabled"
+} catch {
+  Write-Log -LogFile $script:LogFile -Message "Security notifications warning: $($_.Exception.Message)"
+}
+
+# Suppress "Windows needs your current credentials" / Network Location Wizard prompts
+try {
+  Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Lsa' -Name 'LimitBlankPasswordUse' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+  Write-Log -LogFile $script:LogFile -Message "Blank password restriction disabled"
+} catch {
+  Write-Log -LogFile $script:LogFile -Message "Blank password warning: $($_.Exception.Message)"
+}
+
+Write-Log -LogFile $script:LogFile -Message "Blank desktop hardening applied"
+
 # Ensure Chocolatey and Python 3.12 are present
 try {
   $ChocoExe = Resolve-ChocoPath

--- a/libs/qemu-docker/windows/src/vm/setup/setup.ps1
+++ b/libs/qemu-docker/windows/src/vm/setup/setup.ps1
@@ -42,35 +42,35 @@ Write-Host "Applying blank desktop hardening..."
 # Disable the 'restore previous folder windows on logon' option in Explorer so
 # it doesn't re-open any windows that were visible when the image was captured.
 try {
-    New-Item -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Force -ErrorAction SilentlyContinue | Out-Null
-    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'PersistBrowsers' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    New-Item -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Force -ErrorAction Stop | Out-Null
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'PersistBrowsers' -Value 0 -Type DWord -ErrorAction Stop
     Write-Host "  Explorer: PersistBrowsers disabled"
 } catch { Write-Host "  Explorer PersistBrowsers warning: $($_.Exception.Message)" }
 
 # Disable the 'show recently used files/folders' in Quick Access (cosmetic, but avoids 'File Explorer' pop notification)
 try {
-    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer' -Name 'ShowRecent' -Value 0 -Type DWord -ErrorAction SilentlyContinue
-    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer' -Name 'ShowFrequent' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer' -Name 'ShowRecent' -Value 0 -Type DWord -ErrorAction Stop
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer' -Name 'ShowFrequent' -Value 0 -Type DWord -ErrorAction Stop
     Write-Host "  Explorer: recent/frequent items disabled"
 } catch { Write-Host "  Explorer recent items warning: $($_.Exception.Message)" }
 
 # Disable Windows Widgets (News and Interests) and Chat from taskbar - they can
 # open a popup/panel if clicked accidentally or on first login.
 try {
-    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarDa' -Value 0 -Type DWord -ErrorAction SilentlyContinue
-    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarMn' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarDa' -Value 0 -Type DWord -ErrorAction Stop
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarMn' -Value 0 -Type DWord -ErrorAction Stop
     Write-Host "  Taskbar: Widgets and Chat hidden"
 } catch { Write-Host "  Taskbar widgets warning: $($_.Exception.Message)" }
 
 # Suppress "New features and suggestions" / lock screen app suggestions
 try {
     $cdm = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager'
-    New-Item -Path $cdm -Force -ErrorAction SilentlyContinue | Out-Null
-    Set-ItemProperty -Path $cdm -Name 'SubscribedContent-338393Enabled' -Value 0 -Type DWord -ErrorAction SilentlyContinue
-    Set-ItemProperty -Path $cdm -Name 'SubscribedContent-353696Enabled' -Value 0 -Type DWord -ErrorAction SilentlyContinue
-    Set-ItemProperty -Path $cdm -Name 'SubscribedContent-353694Enabled' -Value 0 -Type DWord -ErrorAction SilentlyContinue
-    Set-ItemProperty -Path $cdm -Name 'SoftLandingEnabled' -Value 0 -Type DWord -ErrorAction SilentlyContinue
-    Set-ItemProperty -Path $cdm -Name 'FeatureManagementEnabled' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    New-Item -Path $cdm -Force -ErrorAction Stop | Out-Null
+    Set-ItemProperty -Path $cdm -Name 'SubscribedContent-338393Enabled' -Value 0 -Type DWord -ErrorAction Stop
+    Set-ItemProperty -Path $cdm -Name 'SubscribedContent-353696Enabled' -Value 0 -Type DWord -ErrorAction Stop
+    Set-ItemProperty -Path $cdm -Name 'SubscribedContent-353694Enabled' -Value 0 -Type DWord -ErrorAction Stop
+    Set-ItemProperty -Path $cdm -Name 'SoftLandingEnabled' -Value 0 -Type DWord -ErrorAction Stop
+    Set-ItemProperty -Path $cdm -Name 'FeatureManagementEnabled' -Value 0 -Type DWord -ErrorAction Stop
     Write-Host "  ContentDeliveryManager: suggestions disabled"
 } catch { Write-Host "  ContentDeliveryManager warning: $($_.Exception.Message)" }
 
@@ -85,7 +85,9 @@ foreach ($key in $startupKeys) {
     foreach ($entry in $startupEntriesToRemove) {
         try {
             Remove-ItemProperty -Path $key -Name $entry -ErrorAction SilentlyContinue
-        } catch {}
+        } catch {
+            Write-Host "  Startup cleanup warning: key='$key', entry='$entry': $($_.Exception.Message)"
+        }
     }
 }
 Write-Host "  Startup: common startup entries removed"
@@ -93,8 +95,8 @@ Write-Host "  Startup: common startup entries removed"
 # Disable the 'Start' menu recommended apps and news on first login
 try {
     $startPolicies = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer'
-    New-Item -Path $startPolicies -Force -ErrorAction SilentlyContinue | Out-Null
-    Set-ItemProperty -Path $startPolicies -Name 'HideRecentlyAddedApps' -Value 1 -Type DWord -ErrorAction SilentlyContinue
+    New-Item -Path $startPolicies -Force -ErrorAction Stop | Out-Null
+    Set-ItemProperty -Path $startPolicies -Name 'HideRecentlyAddedApps' -Value 1 -Type DWord -ErrorAction Stop
     Write-Host "  Start menu: recently added apps hidden"
 } catch { Write-Host "  Start menu warning: $($_.Exception.Message)" }
 

--- a/libs/qemu-docker/windows/src/vm/setup/setup.ps1
+++ b/libs/qemu-docker/windows/src/vm/setup/setup.ps1
@@ -39,60 +39,128 @@ Write-Host ""
 # =============================================================================
 Write-Host "Applying blank desktop hardening..."
 
-# Disable the 'restore previous folder windows on logon' option in Explorer so
-# it doesn't re-open any windows that were visible when the image was captured.
-try {
-    New-Item -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Force -ErrorAction Stop | Out-Null
-    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'PersistBrowsers' -Value 0 -Type DWord -ErrorAction Stop
-    Write-Host "  Explorer: PersistBrowsers disabled"
-} catch { Write-Host "  Explorer PersistBrowsers warning: $($_.Exception.Message)" }
+# This script runs as SYSTEM during image provisioning, so HKCU writes would
+# land in the SYSTEM hive rather than the Docker user's profile.  Instead, we
+# load the Default User hive (C:\Users\Default\NTUSER.DAT) under a temporary
+# HKLM mount and write all per-user registry tweaks there.  Any new user
+# account created on this image (including "Docker") inherits the Default User
+# hive on first logon, so the values will be present from the very first login.
+$defaultUserHivePath = 'C:\Users\Default\NTUSER.DAT'
+$tempHiveMount        = 'HKLM:\TempDefaultUser'
+$tempHiveMountReg     = 'HKLM\TempDefaultUser'   # reg.exe / REG LOAD syntax (no colon)
 
-# Disable the 'show recently used files/folders' in Quick Access (cosmetic, but avoids 'File Explorer' pop notification)
+Write-Host "  Loading Default User hive from $defaultUserHivePath..."
 try {
-    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer' -Name 'ShowRecent' -Value 0 -Type DWord -ErrorAction Stop
-    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer' -Name 'ShowFrequent' -Value 0 -Type DWord -ErrorAction Stop
-    Write-Host "  Explorer: recent/frequent items disabled"
-} catch { Write-Host "  Explorer recent items warning: $($_.Exception.Message)" }
+    # Unload any stale mount from a previous failed run before loading
+    if (Test-Path $tempHiveMount) {
+        & reg.exe UNLOAD $tempHiveMountReg 2>&1 | Out-Null
+    }
+    $regLoadResult = & reg.exe LOAD $tempHiveMountReg $defaultUserHivePath 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "reg.exe LOAD failed (exit $LASTEXITCODE): $regLoadResult"
+    }
+    Write-Host "  Default User hive loaded at $tempHiveMount"
+} catch {
+    Write-Host "  WARNING: Could not load Default User hive — per-user tweaks skipped: $($_.Exception.Message)"
+    # Skip the per-user block entirely; HKLM policy tweaks below still apply.
+    $tempHiveMount = $null
+}
 
-# Disable Windows Widgets (News and Interests) and Chat from taskbar - they can
-# open a popup/panel if clicked accidentally or on first login.
-try {
-    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarDa' -Value 0 -Type DWord -ErrorAction Stop
-    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarMn' -Value 0 -Type DWord -ErrorAction Stop
-    Write-Host "  Taskbar: Widgets and Chat hidden"
-} catch { Write-Host "  Taskbar widgets warning: $($_.Exception.Message)" }
-
-# Suppress "New features and suggestions" / lock screen app suggestions
-try {
-    $cdm = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager'
-    New-Item -Path $cdm -Force -ErrorAction Stop | Out-Null
-    Set-ItemProperty -Path $cdm -Name 'SubscribedContent-338393Enabled' -Value 0 -Type DWord -ErrorAction Stop
-    Set-ItemProperty -Path $cdm -Name 'SubscribedContent-353696Enabled' -Value 0 -Type DWord -ErrorAction Stop
-    Set-ItemProperty -Path $cdm -Name 'SubscribedContent-353694Enabled' -Value 0 -Type DWord -ErrorAction Stop
-    Set-ItemProperty -Path $cdm -Name 'SoftLandingEnabled' -Value 0 -Type DWord -ErrorAction Stop
-    Set-ItemProperty -Path $cdm -Name 'FeatureManagementEnabled' -Value 0 -Type DWord -ErrorAction Stop
-    Write-Host "  ContentDeliveryManager: suggestions disabled"
-} catch { Write-Host "  ContentDeliveryManager warning: $($_.Exception.Message)" }
-
-# Remove common startup entries that can show windows on login
-# (OneDrive, Microsoft Teams, Windows Security, etc.)
-$startupKeys = @(
-    'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run',
-    'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run'
-)
-$startupEntriesToRemove = @('OneDrive', 'MicrosoftTeams', 'Teams', 'SecurityHealth')
-foreach ($key in $startupKeys) {
-    foreach ($entry in $startupEntriesToRemove) {
+if ($tempHiveMount) {
+    try {
+        # ------------------------------------------------------------------
+        # Explorer: disable 'restore previous folder windows on logon'
+        # ------------------------------------------------------------------
         try {
-            Remove-ItemProperty -Path $key -Name $entry -ErrorAction SilentlyContinue
-        } catch {
-            Write-Host "  Startup cleanup warning: key='$key', entry='$entry': $($_.Exception.Message)"
+            New-Item -Path "$tempHiveMount\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Force -ErrorAction Stop | Out-Null
+            Set-ItemProperty -Path "$tempHiveMount\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name 'PersistBrowsers' -Value 0 -Type DWord -ErrorAction Stop
+            Write-Host "  Explorer: PersistBrowsers disabled"
+        } catch { Write-Host "  Explorer PersistBrowsers warning: $($_.Exception.Message)" }
+
+        # ------------------------------------------------------------------
+        # Explorer: disable 'show recently used files/folders' in Quick Access
+        # ------------------------------------------------------------------
+        try {
+            Set-ItemProperty -Path "$tempHiveMount\Software\Microsoft\Windows\CurrentVersion\Explorer" -Name 'ShowRecent'   -Value 0 -Type DWord -ErrorAction Stop
+            Set-ItemProperty -Path "$tempHiveMount\Software\Microsoft\Windows\CurrentVersion\Explorer" -Name 'ShowFrequent' -Value 0 -Type DWord -ErrorAction Stop
+            Write-Host "  Explorer: recent/frequent items disabled"
+        } catch { Write-Host "  Explorer recent items warning: $($_.Exception.Message)" }
+
+        # ------------------------------------------------------------------
+        # Taskbar: hide Widgets (News and Interests) and Chat icons
+        # ------------------------------------------------------------------
+        try {
+            New-Item -Path "$tempHiveMount\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Force -ErrorAction Stop | Out-Null
+            Set-ItemProperty -Path "$tempHiveMount\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name 'TaskbarDa' -Value 0 -Type DWord -ErrorAction Stop
+            Set-ItemProperty -Path "$tempHiveMount\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name 'TaskbarMn' -Value 0 -Type DWord -ErrorAction Stop
+            Write-Host "  Taskbar: Widgets and Chat hidden"
+        } catch { Write-Host "  Taskbar widgets warning: $($_.Exception.Message)" }
+
+        # ------------------------------------------------------------------
+        # ContentDeliveryManager: suppress "New features and suggestions"
+        # ------------------------------------------------------------------
+        try {
+            $cdm = "$tempHiveMount\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager"
+            New-Item -Path $cdm -Force -ErrorAction Stop | Out-Null
+            Set-ItemProperty -Path $cdm -Name 'SubscribedContent-338393Enabled' -Value 0 -Type DWord -ErrorAction Stop
+            Set-ItemProperty -Path $cdm -Name 'SubscribedContent-353696Enabled' -Value 0 -Type DWord -ErrorAction Stop
+            Set-ItemProperty -Path $cdm -Name 'SubscribedContent-353694Enabled' -Value 0 -Type DWord -ErrorAction Stop
+            Set-ItemProperty -Path $cdm -Name 'SoftLandingEnabled'              -Value 0 -Type DWord -ErrorAction Stop
+            Set-ItemProperty -Path $cdm -Name 'FeatureManagementEnabled'        -Value 0 -Type DWord -ErrorAction Stop
+            Write-Host "  ContentDeliveryManager: suggestions disabled"
+        } catch { Write-Host "  ContentDeliveryManager warning: $($_.Exception.Message)" }
+
+        # ------------------------------------------------------------------
+        # Startup cleanup: remove per-user startup entries (HKCU Run key) that
+        # can open windows on login (OneDrive, Teams, SecurityHealth, etc.)
+        # The HKLM Run key is handled separately below after hive unload.
+        # Fix: use -ErrorAction Stop so real failures surface; catch handles
+        # the expected "property does not exist" case without noisy output.
+        # ------------------------------------------------------------------
+        $startupEntriesToRemove = @('OneDrive', 'MicrosoftTeams', 'Teams', 'SecurityHealth')
+        foreach ($entry in $startupEntriesToRemove) {
+            try {
+                Remove-ItemProperty -Path "$tempHiveMount\Software\Microsoft\Windows\CurrentVersion\Run" -Name $entry -ErrorAction Stop
+            } catch [System.Management.Automation.PSArgumentException] {
+                # Property does not exist — expected, not an error
+            } catch {
+                Write-Host "  Startup cleanup warning: DefaultUser Run key, entry='$entry': $($_.Exception.Message)"
+            }
+        }
+        Write-Host "  Startup: per-user startup entries removed from Default User hive"
+
+    } finally {
+        # Always unload the hive to avoid handle leaks
+        Write-Host "  Unloading Default User hive..."
+        [gc]::Collect()
+        [gc]::WaitForPendingFinalizers()
+        $regUnloadResult = & reg.exe UNLOAD $tempHiveMountReg 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "  WARNING: Failed to unload Default User hive (exit $LASTEXITCODE): $regUnloadResult"
+        } else {
+            Write-Host "  Default User hive unloaded."
         }
     }
 }
-Write-Host "  Startup: common startup entries removed"
+
+# Remove common startup entries from the machine-wide HKLM Run key
+# (OneDrive, Microsoft Teams, Windows Security, etc.)
+# Fix: use -ErrorAction Stop so real failures surface in the catch block;
+# the catch distinguishes missing-property (expected) from actual errors.
+$startupEntriesToRemove = @('OneDrive', 'MicrosoftTeams', 'Teams', 'SecurityHealth')
+foreach ($entry in $startupEntriesToRemove) {
+    try {
+        Remove-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run' -Name $entry -ErrorAction Stop
+    } catch [System.Management.Automation.PSArgumentException] {
+        # Property does not exist — expected, not an error
+    } catch {
+        Write-Host "  Startup cleanup warning: HKLM Run key, entry='$entry': $($_.Exception.Message)"
+    }
+}
+Write-Host "  Startup: HKLM startup entries removed"
 
 # Disable the 'Start' menu recommended apps and news on first login
+# (HKLM policy — machine-wide, no per-user hive needed)
 try {
     $startPolicies = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer'
     New-Item -Path $startPolicies -Force -ErrorAction Stop | Out-Null

--- a/libs/qemu-docker/windows/src/vm/setup/setup.ps1
+++ b/libs/qemu-docker/windows/src/vm/setup/setup.ps1
@@ -35,6 +35,73 @@ Write-Host "Install Windows Arena Apps: $installWinarenaApps"
 Write-Host ""
 
 # =============================================================================
+# BLANK DESKTOP: Suppress startup windows so instances launch to a clean desktop
+# =============================================================================
+Write-Host "Applying blank desktop hardening..."
+
+# Disable the 'restore previous folder windows on logon' option in Explorer so
+# it doesn't re-open any windows that were visible when the image was captured.
+try {
+    New-Item -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Force -ErrorAction SilentlyContinue | Out-Null
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'PersistBrowsers' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Write-Host "  Explorer: PersistBrowsers disabled"
+} catch { Write-Host "  Explorer PersistBrowsers warning: $($_.Exception.Message)" }
+
+# Disable the 'show recently used files/folders' in Quick Access (cosmetic, but avoids 'File Explorer' pop notification)
+try {
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer' -Name 'ShowRecent' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer' -Name 'ShowFrequent' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Write-Host "  Explorer: recent/frequent items disabled"
+} catch { Write-Host "  Explorer recent items warning: $($_.Exception.Message)" }
+
+# Disable Windows Widgets (News and Interests) and Chat from taskbar - they can
+# open a popup/panel if clicked accidentally or on first login.
+try {
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarDa' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarMn' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Write-Host "  Taskbar: Widgets and Chat hidden"
+} catch { Write-Host "  Taskbar widgets warning: $($_.Exception.Message)" }
+
+# Suppress "New features and suggestions" / lock screen app suggestions
+try {
+    $cdm = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager'
+    New-Item -Path $cdm -Force -ErrorAction SilentlyContinue | Out-Null
+    Set-ItemProperty -Path $cdm -Name 'SubscribedContent-338393Enabled' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $cdm -Name 'SubscribedContent-353696Enabled' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $cdm -Name 'SubscribedContent-353694Enabled' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $cdm -Name 'SoftLandingEnabled' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $cdm -Name 'FeatureManagementEnabled' -Value 0 -Type DWord -ErrorAction SilentlyContinue
+    Write-Host "  ContentDeliveryManager: suggestions disabled"
+} catch { Write-Host "  ContentDeliveryManager warning: $($_.Exception.Message)" }
+
+# Remove common startup entries that can show windows on login
+# (OneDrive, Microsoft Teams, Windows Security, etc.)
+$startupKeys = @(
+    'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run',
+    'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run'
+)
+$startupEntriesToRemove = @('OneDrive', 'MicrosoftTeams', 'Teams', 'SecurityHealth')
+foreach ($key in $startupKeys) {
+    foreach ($entry in $startupEntriesToRemove) {
+        try {
+            Remove-ItemProperty -Path $key -Name $entry -ErrorAction SilentlyContinue
+        } catch {}
+    }
+}
+Write-Host "  Startup: common startup entries removed"
+
+# Disable the 'Start' menu recommended apps and news on first login
+try {
+    $startPolicies = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer'
+    New-Item -Path $startPolicies -Force -ErrorAction SilentlyContinue | Out-Null
+    Set-ItemProperty -Path $startPolicies -Name 'HideRecentlyAddedApps' -Value 1 -Type DWord -ErrorAction SilentlyContinue
+    Write-Host "  Start menu: recently added apps hidden"
+} catch { Write-Host "  Start menu warning: $($_.Exception.Message)" }
+
+Write-Host "Blank desktop hardening complete."
+Write-Host ""
+
+# =============================================================================
 # CORE: Git (always installed)
 # =============================================================================
 


### PR DESCRIPTION
Re-opening closed PR #2027.

Fix: Windows instances launch to a blank desktop instead of showing taskbar/desktop icons on first boot.

Related: trycua/cloud#5214
Linear: https://linear.app/trycua/issue/CUA-650

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows desktop hardening during setup to reduce first-login clutter and unwanted prompts.
  * Disabled several startup distractions, including Edge first-run behavior, OneDrive auto-start, and Windows security notification popups.
  * Hid some taskbar and Start menu suggestions so the desktop appears cleaner on first use.

* **Bug Fixes**
  * Improved setup resilience by logging warnings and continuing if any hardening step fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->