### PR TITLE
fix(cua-driver/linux): get_desktop_state screen size on pure Wayland

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -2952,8 +2952,20 @@ impl Tool for GetDesktopStateTool {
             // so screen-absolute pixels land exactly.
             let png = crate::capture::screenshot_display_bytes()?;
             let (shot_w, shot_h) = crate::capture::png_dimensions_pub(&png)?;
-            // True screen size from the X11 root window.
-            let (screen_w, screen_h) = x11_screen_size()?;
+            // True screen size. On a pure-Wayland session (native backend
+            // opted in, no X11 DISPLAY) the capture above came from the
+            // wlroots `zwlr_screencopy` cascade, whose full-display buffer is
+            // the whole output at native (physical) pixels — so the PNG
+            // dimensions ARE the true screen size. Querying the X11 root
+            // window here would fail with "$DISPLAY variable not set" and
+            // abort the tool even though the screenshot already succeeded.
+            // Only fall back to the X11 root-window geometry off Wayland, so
+            // the X11 / XWayland path is unchanged. See #2017 / Sway testing.
+            let (screen_w, screen_h) = if crate::wayland::is_wayland() {
+                (shot_w, shot_h)
+            } else {
+                x11_screen_size()?
+            };
             // Optional: write PNG to disk instead of returning base64.
             let written = if let Some(path) = out_file.as_deref() {
                 std::fs::write(path, &png)?;


### PR DESCRIPTION
## Problem
On a **pure-Wayland** session (Sway, no Xwayland), `get_desktop_state` fails with `Capture error: … $DISPLAY variable not set …` — surfaced on the Sway test VM during the overnight harness sweep.

## Root cause
The full-display **capture** already routes correctly through the wlroots `zwlr_screencopy` cascade on Wayland. The bug is the line right after it:
```rust
let (screen_w, screen_h) = x11_screen_size()?;   // unconditional X11 connect
```
`x11_screen_size()` opens an X11 connection to read the root-window geometry. With no `DISPLAY`, x11rb returns "$DISPLAY variable not set" and the `?` aborts the whole tool — even though the screenshot already succeeded via screencopy.

## Fix
On Wayland the screencopy full-display buffer is the entire output at native physical pixels, so reuse the already-decoded PNG dimensions for the screen size; fall back to `x11_screen_size()` only off Wayland. X11 / XWayland path unchanged (gated by `crate::wayland::is_wayland()`, which requires `CUA_DRIVER_RS_ENABLE_WAYLAND=1` + `WAYLAND_DISPLAY` set + `DISPLAY` unset).

One-line behavioral change + a comment; no new deps, no schema change.

## Verification
- Linux compile via CI on this PR.
- Behavior on the Sway VM: `get_desktop_state` with `CUA_DRIVER_RS_ENABLE_WAYLAND=1` (DISPLAY unset) returns a PNG + non-zero `screen_width/height` instead of the `$DISPLAY` error. (Verifying now.)
- Regression: off Wayland (X11/XWayland, `DISPLAY=:0`) still reports X11 root geometry unchanged.

## Follow-up (not in this PR)
`get_screen_size` has the same unconditional `x11_screen_size()` call and will fail identically on pure Wayland — but it has no prior capture to borrow dims from, so it needs a real Wayland output-dimensions source. Tracked for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop screenshot size detection on Linux, especially in Wayland sessions.
  * Screenshots now report the correct screen dimensions even when X11 display information is unavailable.
  * Existing behavior remains unchanged on non-Wayland setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->