### PR TITLE
test(cua-driver/windows): robustify slider_drag coords + web CDP-port isolation

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_web_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_web_test.rs
@@ -52,6 +52,23 @@ fn electron_exe() -> PathBuf {
 
 // ── shared session helper ────────────────────────────────────────────────────
 
+/// Wait (up to ~5s) for `port` to become free. These web tests use FIXED CDP
+/// ports (9222/9223) and a process-global `CUA_DRIVER_CDP_PORT`, so they must
+/// run serially (`--test-threads=1`). A previous test's host can still be
+/// releasing its port when the next launches; reusing it before then makes the
+/// daemon discover the OLD host's page (`pages[0]`), so the click lands on a
+/// stale window and the counter check fails. This guard closes that teardown
+/// overlap — belt-and-braces on top of serial execution.
+fn wait_port_free(port: u16) {
+    for _ in 0..50 {
+        if std::net::TcpStream::connect(("127.0.0.1", port)).is_err() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    eprintln!("warning: CDP port {port} still bound after 5s — prior host may not have released it");
+}
+
 /// Launch the harness exe + a cua-driver child with `CUA_DRIVER_CDP_PORT`
 /// pointing at the harness's CDP endpoint. Polls list_windows until the
 /// host's window appears.
@@ -63,6 +80,9 @@ where
         eprintln!("{label} host exe not found at {host_exe:?} — run test-harness/build/windows.ps1");
         return;
     }
+    // A prior test's host may still hold this fixed CDP port — wait for it to
+    // free so the daemon doesn't discover the stale host's page.
+    wait_port_free(cdp_port);
     // Set the CDP port the daemon should probe; the spawned cua-driver child
     // inherits it from this process's environment.
     std::env::set_var("CUA_DRIVER_CDP_PORT", cdp_port.to_string());

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
@@ -551,16 +551,14 @@ fn harness_wpf_slider_drag() {
 
         let resp = driver.call("drag", serde_json::json!({
             "pid": pid as i64, "window_id": wid,
-            // drag screen-coords path: send_drag_synthesized takes screen
-            // coords directly. The harness window is centered at
-            // (517, 66) with the slider track at client (50-330, 275);
-            // convert to screen via ClientToScreen approximation by
-            // offsetting by window position + non-client chrome
-            // (title bar + border ~30,8). screen coords here are
-            // re-derived in window-local form by the tool's existing
-            // ClientToScreen step.
-            "from_x": 50.0, "from_y": 275.0,
-            "to_x": 330.0,  "to_y": 275.0,
+            // Window-local coords along the slider TRACK. The track row sits at
+            // window-local y≈304 (verified on the VM: y=275 landed ~29px above
+            // it, on empty GroupBox space, so the thumb never moved); the thumb
+            // rests at the left (x≈44) at value=0. Dragging left→right advances
+            // the value. (TODO: derive these from the `sld-value` element frame
+            // in get_window_state for DPI/placement independence.)
+            "from_x": 44.0, "from_y": 304.0,
+            "to_x": 330.0, "to_y": 304.0,
             "duration_ms": 700, "steps": 40,
             "dispatch": "foreground"
         }));


### PR DESCRIPTION
Two Windows harness tests flagged in the overnight harness sweep. **Both are test-side — the driver paths are correct (VM-confirmed); no driver bug.**

## `harness_wpf_slider_drag`
The hardcoded drag `y=275` landed ~29px **above** the slider track (which sits at window-local y≈304, on empty GroupBox space), so the thumb never moved — but the SendInput/foreground-drag path itself is fine: the UIA-Invoke companion (`harness_wpf_slider_increase_large`) passes, and corrected coords advance the value. Moved the drag to the track row `(44,304)→(330,304)`.
- ✅ Verified on the VM (Session 2): `✅ Sent drag via SendInput … (358,306)→(644,306)` → `thumb tracked` → **1 passed**.
- TODO (noted in-code): derive the coords from the `sld-value` element frame for DPI/placement independence.

## `harness_web_test` (CDP-port isolation)
The 5 web tests use **fixed** CDP ports (9222/9223) + a process-global `CUA_DRIVER_CDP_PORT`, so they must run serially (`--test-threads=1`). A prior host still releasing its port let the daemon discover the **stale** host's `pages[0]` (the click then lands on the wrong window, counter check fails). Added `wait_port_free()` before launch to close the teardown-overlap window.
- ✅ Verified on the VM (serial): **5 passed** (incl. `harness_electron_click_element: … counter=1`).

No driver code touched. (Latent driver hardening noted for later: `cdp_list_pages` picks `pages[0]` on a fixed env port with no correlation to the requested window — could hit the wrong Chromium app in production if two expose CDP.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of automated runs when reusing the same local port, reducing failures caused by stale processes.
  * Made drag interactions in the Windows UI more consistent by using fixed window-relative coordinates, helping avoid misaligned drags on different displays or DPI settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->