### PR TITLE
Add Windows Arc PAYG license probe script and GitHub Actions workflow

### DIFF
--- a/.github/workflows/windows-arc-license-probe.yml
+++ b/.github/workflows/windows-arc-license-probe.yml
@@ -41,9 +41,18 @@ jobs:
   probe:
     name: Windows Arc License Probe
     runs-on: ubuntu-latest
+    env:
+      # secrets.* can't be used in step `if:` directly, so surface the presence
+      # of Azure creds here. The default pre-baked image mode has no Azure creds
+      # configured; without this gate the scheduled (cron) run would always hit
+      # `azure/login` (inputs.skip_license is empty on schedule) and fail.
+      HAS_AZURE_CREDS: ${{ secrets.AZURE_CREDENTIALS != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # The probe does no git operations; don't persist GITHUB_TOKEN.
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -52,11 +61,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install cua-train cua-computer httpx boto3 requests \
+          pip install cua-train "cua-computer>=0.5.19" httpx boto3 requests \
             --extra-index-url https://wheels.cua.ai/simple/
 
       - name: Azure login
-        if: ${{ !inputs.skip_license }}
+        # Only when licensing at runtime (Arc creds present + not skipped). The
+        # default pre-baked image mode skips this entirely.
+        if: ${{ !inputs.skip_license && env.HAS_AZURE_CREDS == 'true' }}
         uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/windows-arc-license-probe.yml
+++ b/.github/workflows/windows-arc-license-probe.yml
@@ -1,23 +1,23 @@
 name: "Windows Arc License Probe"
 
-# Provisions a Windows OSGym warm pool (if absent), claims a VM, attaches the
-# Azure Arc PAYG Windows Server license, screenshots the desktop, ships the
-# screenshot to S3, posts the presigned URL to Alertmanager (am.cua.ai), then
-# unlicenses the box and returns the claim to the pool.
+# Provisions a Windows workspace pool on run.cua.ai (if absent), claims a VM,
+# attaches the Azure Arc PAYG Windows Server license, screenshots the desktop,
+# ships the screenshot to S3, posts the presigned URL to Alertmanager
+# (am.cua.ai), then unlicenses the box and returns the claim to the pool.
 #
-# The script reaches the private K3s cluster that runs OSGym, so the runner
-# joins the tailnet first and a kubeconfig pointed at the in-tailnet API
-# server is supplied via the KUBECONFIG_B64 secret.
+# All run.cua.ai access is via an OAuth client id/secret (per-USER key) — no
+# kubectl, no cluster VPN.
 #
 # Required repo secrets (see scripts/windows_arc_license_probe.py header):
-#   TS_OAUTH_CLIENT_ID / TS_OAUTH_SECRET  - Tailscale OAuth client (cluster reach)
-#   KUBECONFIG_B64                        - base64 kubeconfig for the OSGym cluster
-#   AZURE_CREDENTIALS                     - azure/login SP JSON (Owner on the sub)
-#   AZURE_SUBSCRIPTION_ID                 - sponsorship subscription id
-#   ARC_MACHINE                           - pre-onboarded Arc machine to license
-#   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY - S3 upload creds
-# Optional repo variables (vars.*): ARC_RESOURCE_GROUP, ARC_REGION,
-#   S3_BUCKET_NAME, OSGYM_POOL, OSGYM_WINDOWS_IMAGE.
+#   CUA_CLIENT_ID / CUA_CLIENT_SECRET     - per-USER key (ukey-…) from POST /api/user-keys
+#   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY - S3 upload + presign
+#   AZURE_CREDENTIALS                     - azure/login SP JSON (Owner on the sub)  [license only]
+#   AZURE_SUBSCRIPTION_ID                 - sponsorship subscription id             [license only]
+#   ARC_MACHINE                           - pre-onboarded Arc machine to license    [license only]
+# Optional repo variables (vars.*): CUA_POOL, CUA_WINDOWS_IMAGE, ARC_RESOURCE_GROUP,
+#   ARC_REGION, S3_BUCKET_NAME, AWS_REGION.
+# If ARC_MACHINE / AZURE_SUBSCRIPTION_ID are unset (or skip_license=true) the
+# license steps are skipped and the probe just claims + screenshots.
 
 on:
   workflow_dispatch:
@@ -51,23 +51,9 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install boto3 requests
-
-      - name: Set up kubectl
-        uses: azure/setup-kubectl@v4
-
-      - name: Connect to tailnet
-        uses: tailscale/github-action@v3
-        with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: tag:ci
-
-      - name: Write kubeconfig
         run: |
-          mkdir -p "$HOME/.kube"
-          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > "$HOME/.kube/config"
-          chmod 600 "$HOME/.kube/config"
+          pip install cua-train cua-computer httpx boto3 requests \
+            --extra-index-url https://wheels.cua.ai/simple/
 
       - name: Azure login
         if: ${{ !inputs.skip_license }}
@@ -78,11 +64,12 @@ jobs:
       - name: Run probe
         run: python scripts/windows_arc_license_probe.py -v
         env:
-          # kubectl reads ~/.kube/config written above by default.
-          # OSGym
-          OSGYM_POOL: ${{ vars.OSGYM_POOL || 'arc-windows' }}
-          OSGYM_WINDOWS_IMAGE: ${{ vars.OSGYM_WINDOWS_IMAGE }}
-          # Azure Arc licensing
+          # run.cua.ai
+          CUA_CLIENT_ID: ${{ secrets.CUA_CLIENT_ID }}
+          CUA_CLIENT_SECRET: ${{ secrets.CUA_CLIENT_SECRET }}
+          CUA_POOL: ${{ vars.CUA_POOL || 'arc-windows' }}
+          CUA_WINDOWS_IMAGE: ${{ vars.CUA_WINDOWS_IMAGE }}
+          # Azure Arc licensing (skipped if ARC_MACHINE unset)
           SKIP_LICENSE: ${{ inputs.skip_license && '1' || '0' }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           ARC_MACHINE: ${{ secrets.ARC_MACHINE }}

--- a/.github/workflows/windows-arc-license-probe.yml
+++ b/.github/workflows/windows-arc-license-probe.yml
@@ -1,0 +1,115 @@
+name: "Windows Arc License Probe"
+
+# Provisions a Windows OSGym warm pool (if absent), claims a VM, attaches the
+# Azure Arc PAYG Windows Server license, screenshots the desktop, ships the
+# screenshot to S3, posts the presigned URL to Alertmanager (am.cua.ai), then
+# unlicenses the box and returns the claim to the pool.
+#
+# The script reaches the private K3s cluster that runs OSGym, so the runner
+# joins the tailnet first and a kubeconfig pointed at the in-tailnet API
+# server is supplied via the KUBECONFIG_B64 secret.
+#
+# Required repo secrets (see scripts/windows_arc_license_probe.py header):
+#   TS_OAUTH_CLIENT_ID / TS_OAUTH_SECRET  - Tailscale OAuth client (cluster reach)
+#   KUBECONFIG_B64                        - base64 kubeconfig for the OSGym cluster
+#   AZURE_CREDENTIALS                     - azure/login SP JSON (Owner on the sub)
+#   AZURE_SUBSCRIPTION_ID                 - sponsorship subscription id
+#   ARC_MACHINE                           - pre-onboarded Arc machine to license
+#   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY - S3 upload creds
+# Optional repo variables (vars.*): ARC_RESOURCE_GROUP, ARC_REGION,
+#   S3_BUCKET_NAME, OSGYM_POOL, OSGYM_WINDOWS_IMAGE.
+
+on:
+  workflow_dispatch:
+    inputs:
+      skip_license:
+        description: "Skip Arc license attach/detach (probe only)"
+        type: boolean
+        default: false
+  schedule:
+    # Daily at 06:17 UTC.
+    - cron: "17 6 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-arc-license-probe
+  cancel-in-progress: false
+
+jobs:
+  probe:
+    name: Windows Arc License Probe
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install boto3 requests
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Connect to tailnet
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - name: Write kubeconfig
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+
+      - name: Azure login
+        if: ${{ !inputs.skip_license }}
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Run probe
+        run: python scripts/windows_arc_license_probe.py -v
+        env:
+          # kubectl reads ~/.kube/config written above by default.
+          # OSGym
+          OSGYM_POOL: ${{ vars.OSGYM_POOL || 'arc-windows' }}
+          OSGYM_WINDOWS_IMAGE: ${{ vars.OSGYM_WINDOWS_IMAGE }}
+          # Azure Arc licensing
+          SKIP_LICENSE: ${{ inputs.skip_license && '1' || '0' }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARC_MACHINE: ${{ secrets.ARC_MACHINE }}
+          ARC_RESOURCE_GROUP: ${{ vars.ARC_RESOURCE_GROUP || 'arc-trial-rg' }}
+          ARC_REGION: ${{ vars.ARC_REGION || 'eastus' }}
+          # S3
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ vars.AWS_REGION || 'us-west-2' }}
+          S3_BUCKET_NAME: ${{ vars.S3_BUCKET_NAME || 'cua-agent-artifacts' }}
+
+      - name: Alert Alertmanager on failure
+        if: failure()
+        run: |
+          curl -s -X POST https://am.cua.ai/api/v2/alerts \
+            -H 'Content-Type: application/json' \
+            -d '[{
+              "labels": {
+                "alertname": "WindowsArcLicenseProbeFailed",
+                "severity": "warning",
+                "service": "cua-sdk",
+                "job": "windows-arc-license-probe"
+              },
+              "annotations": {
+                "summary": "Windows Arc license probe workflow failed",
+                "description": "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                "dashboard": "https://github.com/${{ github.repository }}/actions/workflows/windows-arc-license-probe.yml"
+              },
+              "generatorURL": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }]'

--- a/scripts/windows_arc_license_probe.py
+++ b/scripts/windows_arc_license_probe.py
@@ -1,57 +1,89 @@
 #!/usr/bin/env python3
 """
-Windows Arc PAYG license probe against an OSGym warm pool.
+Windows Arc PAYG license probe against a run.cua.ai Windows workspace pool.
 
 End-to-end operational probe that exercises the full "license a Windows box,
-prove it's alive, then unlicense it" loop against the cua cloud OSGym fleet:
+prove it's alive, then unlicense it" loop against the cua cloud — driven
+entirely through the run.cua.ai backend with an OAuth client id/secret (no
+kubectl, no cluster VPN):
 
-  1. provision the Windows warm pool (idempotent — created only if absent)
-  2. create an OSGymSandboxClaim and wait for it to bind to a VM
+  1. provision the Windows workspace pool if it does not exist
+  2. claim a sandbox from the pool and wait for it to bind
   3. attach the Azure Arc pay-as-you-go (PAYG) Windows Server license
-  4. take a screenshot of the bound desktop
+  4. take a screenshot of the bound desktop (cua-computer SDK, through the proxy)
   5. upload the screenshot to S3 and mint a presigned URL
-  6. POST the presigned URL to Alertmanager (am.cua.ai) as an annotation
+  6. POST the presigned URL to Alertmanager (am.cua.ai)
   7. deactivate the license and return the claim to the pool (always runs)
 
-Steps 1/2/4 talk to the K3s cluster that runs OSGym (group `osgym.cua.ai`)
-through `kubectl`, so a working kubeconfig that can reach the cluster API
-server is required (see the workflow for the Tailscale + KUBECONFIG wiring).
-Steps 3/7 drive Azure Resource Manager through `az rest` against a Connected
-Machine (`Microsoft.HybridCompute/machines/<machine>/licenseProfiles/default`).
+Steps 1/2/4 talk to run.cua.ai. Authentication is the client_credentials
+exchange handled by ``cua_train.TrainClient.from_key`` — set CUA_CLIENT_ID /
+CUA_CLIENT_SECRET to a **per-user** key (``ukey-…``, from ``POST
+/api/user-keys``); per-pool keys (``key-…``) have no K8s identity and are
+rejected on the namespace/pool/claim steps.
 
+Pool + claim CRs are created through the backend's ``/api/k8s`` kubectl-proxy:
+the pool is an ``OSGymWorkspacePool`` (``cua.ai/v1``), the claim an
+``OSGymSandboxClaim`` (``osgym.cua.ai/v1alpha1``). The bound sandbox is reached
+through the authenticated ``/api/svc/{ns}/{sandbox}-{service}`` reverse proxy,
+which the cua-computer SDK speaks to directly via ``api_base_url`` +
+``api_headers`` (cua-computer>=0.5.19).
+
+Steps 3/7 drive Azure Resource Manager through ``az rest`` against a Connected
+Machine (``Microsoft.HybridCompute/machines/<machine>/licenseProfiles/default``).
 The license toggle operates on a *pre-onboarded* Arc machine named by
-`--arc-machine` / ARC_MACHINE. That machine must already be Connected to Arc
-and converted to a full (non-eval) Windows Server 2025 edition — onboarding and
-the eval->full DISM conversion are one-time manual setup, not part of this
-recurring probe. See docs/ in trycua/cloud for the onboarding runbook.
+``--arc-machine`` / ARC_MACHINE — that machine must already be Connected to Arc
+and converted to a full (non-eval) Windows Server 2025 edition (one-time manual
+setup, see the trycua/cloud onboarding runbook). If ARC_MACHINE is unset the
+license steps are skipped and the probe just claims + screenshots.
 
-Everything is configurable via flags or the matching UPPER_SNAKE env var.
-The cleanup (step 7) runs in a finally block so the license is disabled and
-the claim is returned even if an earlier step fails.
+Cleanup (step 7) runs in a finally block, so the license is disabled and the
+claim returned even if an earlier step fails.
+
+Quick start::
+
+    pip install cua-train cua-computer httpx boto3 requests \
+        --extra-index-url https://wheels.cua.ai/simple/
+    export CUA_CLIENT_ID=ukey-xxxxxxxx CUA_CLIENT_SECRET=...
+    export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...
+    export ARC_MACHINE=ws2025-trial AZURE_SUBSCRIPTION_ID=...   # optional license
+    python scripts/windows_arc_license_probe.py --pool arc-windows
 """
 
 from __future__ import annotations
 
 import argparse
-import base64
+import asyncio
 import json
 import logging
 import os
-import socket
 import subprocess
 import sys
 import time
 import uuid
-from contextlib import contextmanager
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 
 import boto3
+import httpx
 import requests
+from cua_train import TrainClient
 
 log = logging.getLogger("windows-arc-license-probe")
 
-# OSGym CRD coordinates (group osgym.cua.ai/v1alpha1; see trycua/cloud).
-API_VERSION = "osgym.cua.ai/v1alpha1"
+DEFAULT_TOKEN_URL = "https://auth.cua.ai/realms/cyclops-cs/protocol/openid-connect/token"
+DEFAULT_BASE_URL = "https://run.cua.ai"
+# Windows computer-server image: Windows Server 2022 + computer_server on :8000
+# (HTTP/WS API at /cmd, /ws, /status; MCP at /mcp). dockur-built GPT/UEFI image,
+# so the pool MUST boot it with efi firmware.
+DEFAULT_IMAGE = "296062593712.dkr.ecr.us-west-2.amazonaws.com/cua-server-windows:latest"
+
+# OSGymWorkspacePool — the single-object pool CR the run.cua.ai SPA creates
+# (cua.ai/v1); the pool-operator compat shim projects it into the native
+# OSGymSandboxTemplate + OSGymSandboxWarmPool pair.
+POOL_GROUP, POOL_VERSION, POOL_PLURAL = "cua.ai", "v1", "osgymworkspacepools"
+# OSGymSandboxTemplate / OSGymSandboxClaim live in the osgym.cua.ai group.
+EXT_GROUP, EXT_VERSION = "osgym.cua.ai", "v1alpha1"
+TEMPLATE_PLURAL, CLAIM_PLURAL = "osgymsandboxtemplates", "osgymsandboxclaims"
 
 
 # --------------------------------------------------------------------------- #
@@ -62,44 +94,43 @@ def _env(name: str, default: str | None = None) -> str | None:
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
-    p = argparse.ArgumentParser(description=__doc__)
-
-    # OSGym pool / claim
-    p.add_argument("--namespace", default=_env("OSGYM_NAMESPACE", "osgym"))
-    p.add_argument("--pool", default=_env("OSGYM_POOL", "arc-windows"))
-    p.add_argument("--template", default=_env("OSGYM_TEMPLATE", "arc-windows-template"))
-    p.add_argument(
-        "--image",
-        default=_env(
-            "OSGYM_WINDOWS_IMAGE",
-            "296062593712.dkr.ecr.us-west-2.amazonaws.com/cua-server-windows:latest",
-        ),
-        help="KubeVirt containerDisk image the pool template boots.",
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
-    p.add_argument("--image-pull-secret", default=_env("OSGYM_IMAGE_PULL_SECRET", "ecr-credentials"))
-    p.add_argument("--cpu-cores", type=int, default=int(_env("OSGYM_CPU_CORES", "4")))
-    p.add_argument("--memory", default=_env("OSGYM_MEMORY", "8Gi"))
-    p.add_argument(
-        "--api-port",
-        type=int,
-        default=int(_env("OSGYM_API_PORT", "8000")),
-        help="In-guest computer-server port that serves POST /cmd (8000 for "
-        "cua-server-windows; 5000 for desktop-workspace-windows).",
-    )
-    p.add_argument("--bind-timeout", type=int, default=int(_env("OSGYM_BIND_TIMEOUT", "900")),
-                   help="Seconds to wait for the claim to reach phase=Bound.")
-    p.add_argument("--claim-ttl", type=int, default=int(_env("OSGYM_CLAIM_TTL", "1200")),
-                   help="Seconds before the claim's shutdownTime (reaper backstop).")
 
-    # Azure Arc licensing
+    # run.cua.ai auth + pool/claim
+    p.add_argument("--client-id", default=_env("CUA_CLIENT_ID"),
+                   help="OAuth client id (per-user key 'ukey-…'); env CUA_CLIENT_ID")
+    p.add_argument("--client-secret", default=_env("CUA_CLIENT_SECRET"),
+                   help="OAuth client secret; env CUA_CLIENT_SECRET")
+    p.add_argument("--token-url", default=_env("CUA_TOKEN_URL", DEFAULT_TOKEN_URL))
+    p.add_argument("--base-url", default=_env("CUA_BASE_URL", DEFAULT_BASE_URL))
+    p.add_argument("--pool", default=_env("CUA_POOL", "arc-windows"),
+                   help="pool name (== namespace; lowercase/dashes)")
+    p.add_argument("--image", default=_env("CUA_WINDOWS_IMAGE", DEFAULT_IMAGE))
+    p.add_argument("--service-name", default=_env("CUA_SERVICE_NAME", "api"))
+    p.add_argument("--port", type=int, default=int(_env("CUA_PORT", "8000")),
+                   help="in-guest computer-server port (8000 for cua-server-windows)")
+    p.add_argument("--firmware", choices=["bios", "efi"], default=_env("CUA_FIRMWARE", "efi"))
+    p.add_argument("--cpu", type=int, default=int(_env("CUA_CPU", "4")))
+    p.add_argument("--ram", default=_env("CUA_RAM", "8Gi"))
+    p.add_argument("--replicas", type=int, default=int(_env("CUA_REPLICAS", "1")))
+    p.add_argument("--warm-timeout", type=float, default=float(_env("CUA_WARM_TIMEOUT", "1200")),
+                   help="seconds to wait for the pool's first warm VM (cold Windows boot is slow)")
+    p.add_argument("--bind-deadline", type=int, default=int(_env("CUA_BIND_DEADLINE", "600")))
+    p.add_argument("--bind-timeout", type=float, default=float(_env("CUA_BIND_TIMEOUT", "300")))
+    p.add_argument("--ready-timeout", type=float, default=float(_env("CUA_READY_TIMEOUT", "420")))
+    p.add_argument("--template-timeout", type=float, default=120)
+    p.add_argument("--poll-interval", type=float, default=5)
+
+    # Azure Arc licensing (optional — skipped unless ARC_MACHINE is set)
     p.add_argument("--subscription", default=_env("AZURE_SUBSCRIPTION_ID"))
     p.add_argument("--resource-group", default=_env("ARC_RESOURCE_GROUP", "arc-trial-rg"))
     p.add_argument("--region", default=_env("ARC_REGION", "eastus"))
     p.add_argument("--arc-machine", default=_env("ARC_MACHINE"),
-                   help="Name of the pre-onboarded Arc Connected Machine to license.")
+                   help="pre-onboarded Arc Connected Machine to license (unset => skip)")
     p.add_argument("--arc-api-version", default=_env("ARC_API_VERSION", "2023-10-03-preview"))
-    p.add_argument("--skip-license", action="store_true", default=_env("SKIP_LICENSE") == "1",
-                   help="Skip steps 3 & 7 (useful when no Arc machine is wired up yet).")
+    p.add_argument("--skip-license", action="store_true", default=_env("SKIP_LICENSE") == "1")
 
     # S3
     p.add_argument("--s3-bucket", default=_env("S3_BUCKET_NAME", "cua-agent-artifacts"))
@@ -111,154 +142,194 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     p.add_argument("--alertmanager-url", default=_env("ALERTMANAGER_URL", "https://am.cua.ai"))
     p.add_argument("--severity", default=_env("ALERT_SEVERITY", "info"))
 
-    p.add_argument("--keep-claim", action="store_true",
-                   help="Do not delete the claim at the end (debugging).")
+    p.add_argument("--claim-name", help="claim name (default: <pool>-claim-<random>)")
+    p.add_argument("--delete-pool", action="store_true",
+                   help="also delete the pool + namespace at the end (default: keep the pool)")
+    p.add_argument("--keep-claim", action="store_true", help="do not delete the claim (debugging)")
     p.add_argument("-v", "--verbose", action="store_true")
     return p.parse_args(argv)
 
 
 # --------------------------------------------------------------------------- #
-# subprocess helpers
+# run.cua.ai /api/k8s URL builders (relative to base_url)
 # --------------------------------------------------------------------------- #
-def run(cmd: list[str], *, input_str: str | None = None, check: bool = True,
-        capture: bool = True) -> subprocess.CompletedProcess:
-    log.debug("$ %s", " ".join(cmd))
-    return subprocess.run(
-        cmd,
-        input=input_str,
-        text=True,
-        capture_output=capture,
-        check=check,
-    )
+def pool_url(pool: str, name: str | None = None) -> str:
+    base = f"/api/k8s/apis/{POOL_GROUP}/{POOL_VERSION}/namespaces/{pool}/{POOL_PLURAL}"
+    return f"{base}/{name}" if name else base
 
 
-def kubectl(args: list[str], *, namespace: str | None, input_str: str | None = None,
-            check: bool = True) -> subprocess.CompletedProcess:
-    cmd = ["kubectl"]
-    if namespace:
-        cmd += ["-n", namespace]
-    cmd += args
-    return run(cmd, input_str=input_str, check=check)
+def template_url(pool: str, name: str) -> str:
+    return f"/api/k8s/apis/{EXT_GROUP}/{EXT_VERSION}/namespaces/{pool}/{TEMPLATE_PLURAL}/{name}"
 
 
-def kubectl_apply(manifest: dict, *, namespace: str) -> None:
-    kubectl(["apply", "-f", "-"], namespace=namespace, input_str=json.dumps(manifest))
-
-
-def az_rest(method: str, url: str, body: dict | None = None) -> dict:
-    cmd = ["az", "rest", "--method", method, "--url", url]
-    if body is not None:
-        cmd += ["--body", json.dumps(body)]
-    cp = run(cmd, check=True)
-    out = (cp.stdout or "").strip()
-    return json.loads(out) if out else {}
+def claims_url(pool: str, name: str | None = None) -> str:
+    base = f"/api/k8s/apis/{EXT_GROUP}/{EXT_VERSION}/namespaces/{pool}/{CLAIM_PLURAL}"
+    return f"{base}/{name}" if name else base
 
 
 # --------------------------------------------------------------------------- #
-# step 1: provision pool
+# step 1: provision pool (idempotent)
 # --------------------------------------------------------------------------- #
-def ensure_pool(a: argparse.Namespace) -> None:
-    exists = kubectl(["get", "oswp", a.pool], namespace=a.namespace, check=False)
-    if exists.returncode == 0:
-        log.info("warm pool %s/%s already exists", a.namespace, a.pool)
+def ensure_pool(http: httpx.Client, a: argparse.Namespace) -> None:
+    # Namespace via the Capsule-backed SPA endpoint so tenant RBAC is stamped.
+    r = http.post("/api/namespaces", json={"name": a.pool})
+    if r.status_code == 403:
+        sys.exit("403 creating namespace — use a per-USER key (ukey-…, POST /api/user-keys)")
+    if r.status_code == 409:
+        log.info("namespace %s already exists", a.pool)
+    else:
+        r.raise_for_status()
+        log.info("namespace %s created", a.pool)
+
+    template: dict = {
+        "containerDiskImage": a.image,
+        "imagePullSecret": "ecr-credentials",
+        "cpuCores": a.cpu,
+        "memory": a.ram,
+    }
+    if a.firmware != "bios":
+        template["firmware"] = a.firmware
+    # Gate Ready (and claim binding) on the computer-server port being bound.
+    template["probes"] = {"readinessProbe": {"tcpSocket": {"port": a.port}}}
+
+    body = {
+        "apiVersion": f"{POOL_GROUP}/{POOL_VERSION}",
+        "kind": "OSGymWorkspacePool",
+        "metadata": {"name": a.pool, "labels": {"cua.ai/pool": a.pool}},
+        "spec": {
+            "replicas": a.replicas,
+            "template": template,
+            # Each entry becomes a per-sandbox Service "<sandbox>-<name>" mapping
+            # Service port 80 -> targetPort on the VM.
+            "services": [{"name": a.service_name, "targetPort": a.port, "protocol": "TCP"}],
+        },
+    }
+    r = http.post(pool_url(a.pool), json=body)
+    if r.status_code == 409:
+        log.info("pool %s already exists — reusing it", a.pool)
         return
+    if r.status_code == 403:
+        sys.exit("403 creating pool — use a per-USER key (ukey-…, POST /api/user-keys)")
+    r.raise_for_status()
+    log.info("pool %s created (image=%s firmware=%s replicas=%d)",
+             a.pool, a.image, a.firmware, a.replicas)
 
-    log.info("provisioning warm pool %s/%s (template=%s, image=%s)",
-             a.namespace, a.pool, a.template, a.image)
 
-    template = {
-        "apiVersion": API_VERSION,
-        "kind": "OSGymSandboxTemplate",
-        "metadata": {"name": a.template, "namespace": a.namespace},
-        "spec": {
-            "vmTemplate": {
-                "containerDiskImage": a.image,
-                "imagePullSecret": a.image_pull_secret,
-                "cpuCores": a.cpu_cores,
-                "memory": a.memory,
-                # cua-server-windows boots BIOS; flip to "efi" for dockur EFI images.
-                "firmware": "bios",
-                # computer-server HTTP/cmd API + cua-driver MCP + noVNC, each
-                # fronted by a ClusterIP Service on :80 -> targetPort.
-                "services": [
-                    {"name": "api", "targetPort": a.api_port},
-                    {"name": "mcp", "targetPort": 3000},
-                    {"name": "novnc", "targetPort": 6080},
-                ],
-                # Gate readiness on computer-server actually serving.
-                "probes": {
-                    "readinessProbe": {
-                        "tcpSocket": {"port": a.api_port},
-                        "initialDelaySeconds": 60,
-                        "periodSeconds": 5,
-                        "failureThreshold": 120,
-                    }
-                },
-            }
-        },
-    }
-    warmpool = {
-        "apiVersion": API_VERSION,
-        "kind": "OSGymSandboxWarmPool",
-        "metadata": {"name": a.pool, "namespace": a.namespace},
-        "spec": {
-            "replicas": 0,
-            "sandboxTemplateRef": {"name": a.template},
-            # Static floor of 0; a Pending claim is the demand signal that
-            # scales the pool up on demand.
-            "autoscaling": {"minPoolSize": 0, "initialPoolSize": 0, "maxPoolSize": 4},
-        },
-    }
-    kubectl_apply(template, namespace=a.namespace)
-    kubectl_apply(warmpool, namespace=a.namespace)
-    log.info("warm pool %s provisioned", a.pool)
+def wait_template(get_http: Callable[[], httpx.Client], a: argparse.Namespace) -> None:
+    tmpl = f"{a.pool}-template"
+    deadline = time.monotonic() + a.template_timeout
+    while True:
+        r = get_http().get(template_url(a.pool, tmpl))
+        if r.status_code == 200:
+            log.info("pool-operator projected template %s + warm pool", tmpl)
+            return
+        if r.status_code not in (404, 403):
+            r.raise_for_status()
+        if time.monotonic() > deadline:
+            log.info("template %s not visible after %.0fs — claiming anyway", tmpl, a.template_timeout)
+            return
+        time.sleep(a.poll_interval)
+
+
+def pool_counts(get_http: Callable[[], httpx.Client], pool: str) -> tuple[int, int, str]:
+    try:
+        r = get_http().get(pool_url(pool, pool))
+        r.raise_for_status()
+        st = r.json().get("status") or {}
+        return int(st.get("totalCount", 0)), int(st.get("availableCount", 0)), st.get("phase", "Unknown")
+    except Exception:  # noqa: BLE001
+        return 0, 0, "Unknown"
+
+
+def wait_pool_warm(get_http: Callable[[], httpx.Client], a: argparse.Namespace) -> None:
+    """Wait for availableCount>=1 before claiming so the claim binds in seconds.
+
+    A cold Windows pool's first VM (UEFI image pull + Windows Server boot +
+    computer-server task) takes minutes and would otherwise burn the claim's
+    bind deadline.
+    """
+    start = time.monotonic()
+    deadline = start + a.warm_timeout
+    while True:
+        total, avail, phase = pool_counts(get_http, a.pool)
+        if avail >= 1:
+            log.info("pool warm: %d/%d VM(s) ready (phase %s)", avail, total, phase)
+            return
+        if time.monotonic() > deadline:
+            sys.exit(
+                f"timed out after {a.warm_timeout:.0f}s waiting for a warm VM "
+                f"(pool {phase}, {avail}/{total} ready). Most common cause: the image "
+                f"tag does not exist so the VM sits in ImagePullBackOff."
+            )
+        log.info("[%4ds] pool=%s (%d/%d ready) — warming...",
+                 int(time.monotonic() - start), phase, avail, total)
+        time.sleep(a.poll_interval)
 
 
 # --------------------------------------------------------------------------- #
-# step 2: create & bind claim
+# step 2: claim + bind
 # --------------------------------------------------------------------------- #
-def create_claim(a: argparse.Namespace) -> str:
-    claim_name = f"{a.pool}-claim-{uuid.uuid4().hex[:10]}"
-    shutdown = datetime.now(tz=timezone.utc) + timedelta(seconds=a.claim_ttl)
-    claim = {
-        "apiVersion": API_VERSION,
-        "kind": "OSGymSandboxClaim",
-        "metadata": {"name": claim_name, "namespace": a.namespace},
-        "spec": {
-            "sandboxTemplateRef": {"name": a.template},
-            "warmpool": a.pool,
-            "bindDeadline": a.bind_timeout,
-            "lifecycle": {
-                "shutdownTime": shutdown.isoformat().replace("+00:00", "Z"),
-                # Retain: returning the claim restarts the VM in place and
-                # hands it back to the warm pool.
-                "shutdownPolicy": "Retain",
-            },
+def create_claim(http: httpx.Client, a: argparse.Namespace, name: str) -> None:
+    spec: dict = {"sandboxTemplateRef": {"name": f"{a.pool}-template"}}
+    if a.bind_deadline:
+        spec["bindDeadline"] = a.bind_deadline
+    r = http.post(
+        claims_url(a.pool),
+        json={
+            "apiVersion": f"{EXT_GROUP}/{EXT_VERSION}",
+            "kind": "OSGymSandboxClaim",
+            "metadata": {"name": name},
+            "spec": spec,
         },
-    }
-    kubectl_apply(claim, namespace=a.namespace)
-    log.info("created claim %s", claim_name)
-    return claim_name
+    )
+    if r.status_code == 403:
+        sys.exit("403 creating claim — use a per-USER key (ukey-…, POST /api/user-keys)")
+    r.raise_for_status()
+    log.info("claim %s created", name)
 
 
-def wait_for_bind(a: argparse.Namespace, claim_name: str) -> tuple[str, str]:
-    deadline = time.monotonic() + a.bind_timeout
-    while time.monotonic() < deadline:
-        cp = kubectl(["get", "osbc", claim_name, "-o", "json"],
-                     namespace=a.namespace, check=False)
-        if cp.returncode == 0:
-            status = json.loads(cp.stdout).get("status", {})
-            phase = status.get("phase")
-            if phase == "Bound":
-                sb = status.get("sandbox", {})
-                log.info("claim %s bound to sandbox %s (%s)",
-                         claim_name, sb.get("name"), sb.get("service"))
-                return sb["name"], sb.get("service", "")
-            if phase == "Failed":
-                raise RuntimeError(f"claim {claim_name} reached phase=Failed: {status}")
-            log.info("claim %s phase=%s, waiting...", claim_name, phase)
-        time.sleep(5)
-    raise TimeoutError(f"claim {claim_name} did not bind within {a.bind_timeout}s")
+def wait_bound(get_http: Callable[[], httpx.Client], a: argparse.Namespace, name: str) -> str:
+    start = time.monotonic()
+    deadline = start + a.bind_timeout
+    while True:
+        r = get_http().get(claims_url(a.pool, name))
+        r.raise_for_status()
+        status = r.json().get("status") or {}
+        phase = status.get("phase", "Pending")
+        sandbox = (status.get("sandbox") or {}).get("name")
+        if phase == "Bound" and sandbox:
+            log.info("claim %s bound to sandbox %s", name, sandbox)
+            return sandbox
+        if phase == "Failed":
+            sys.exit(f"claim {name} failed: {status}")
+        if time.monotonic() > deadline:
+            sys.exit(f"timed out after {a.bind_timeout:.0f}s waiting for claim {name} (phase={phase})")
+        log.info("[%4ds] claim=%s ...", int(time.monotonic() - start), phase)
+        time.sleep(a.poll_interval)
+
+
+def wait_service_ready(get_http: Callable[[], httpx.Client], url: str, a: argparse.Namespace) -> None:
+    """GET url until the in-guest service answers (not a proxy 502/503/504).
+
+    For computer-server that endpoint is /status; the guest may still be
+    booting for a few minutes after the claim binds.
+    """
+    start = time.monotonic()
+    deadline = start + a.ready_timeout
+    while True:
+        try:
+            resp = get_http().get(url, timeout=15.0)
+            reason = f"HTTP {resp.status_code}"
+            ok = resp.status_code not in (502, 503, 504)
+        except httpx.HTTPError as e:
+            reason, ok = type(e).__name__, False
+        if ok:
+            log.info("service responding (%s)", reason)
+            return
+        if time.monotonic() > deadline:
+            sys.exit(f"timed out after {a.ready_timeout:.0f}s waiting for the in-guest service ({reason})")
+        log.info("[%4ds] %s — guest still booting...", int(time.monotonic() - start), reason)
+        time.sleep(a.poll_interval)
 
 
 # --------------------------------------------------------------------------- #
@@ -273,21 +344,28 @@ def _license_url(a: argparse.Namespace) -> str:
     )
 
 
+def _az_rest(method: str, url: str, body: dict | None = None) -> dict:
+    cmd = ["az", "rest", "--method", method, "--url", url]
+    if body is not None:
+        cmd += ["--body", json.dumps(body)]
+    log.debug("$ %s", " ".join(cmd))
+    cp = subprocess.run(cmd, text=True, capture_output=True, check=True)
+    out = (cp.stdout or "").strip()
+    return json.loads(out) if out else {}
+
+
 def set_license(a: argparse.Namespace, *, enabled: bool) -> None:
     status = "Enabled" if enabled else "Disabled"
     log.info("setting Arc PAYG license on %s -> %s", a.arc_machine, status)
-    body = {
+    _az_rest("put", _license_url(a), {
         "location": a.region,
-        "properties": {
-            "productProfile": {"productType": "WindowsServer", "subscriptionStatus": status}
-        },
-    }
-    az_rest("put", _license_url(a), body)
+        "properties": {"productProfile": {"productType": "WindowsServer", "subscriptionStatus": status}},
+    })
 
 
 def license_status(a: argparse.Namespace) -> str:
     try:
-        resp = az_rest("get", _license_url(a))
+        resp = _az_rest("get", _license_url(a))
         return resp.get("properties", {}).get("productProfile", {}).get("subscriptionStatus", "")
     except Exception as e:  # noqa: BLE001
         log.warning("could not read license status: %s", e)
@@ -295,86 +373,27 @@ def license_status(a: argparse.Namespace) -> str:
 
 
 # --------------------------------------------------------------------------- #
-# step 4: screenshot via port-forward to the bound VM's computer-server
+# step 4: screenshot via the cua-computer SDK through the run.cua.ai proxy
 # --------------------------------------------------------------------------- #
-def _free_local_port() -> int:
-    s = socket.socket()
-    s.bind(("127.0.0.1", 0))
-    port = s.getsockname()[1]
-    s.close()
-    return port
+async def take_screenshot(api_base_url: str, auth: str) -> bytes:
+    # Imported lazily so --help / arg errors don't pay the cua-computer import.
+    from computer import Computer
 
-
-@contextmanager
-def port_forward(a: argparse.Namespace, sandbox: str):
-    """kubectl port-forward to the sandbox's `-api` Service (listens on :80)."""
-    local = _free_local_port()
-    svc = f"svc/{sandbox}-api"
-    proc = subprocess.Popen(
-        ["kubectl", "-n", a.namespace, "port-forward", svc, f"{local}:80"],
-        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+    log.info("connecting cua-computer SDK to %s", api_base_url)
+    computer = Computer(
+        use_host_computer_server=True,  # connect to an existing server, don't spawn a VM
+        os_type="windows",
+        api_base_url=api_base_url,
+        api_headers={"Authorization": auth},
     )
-    try:
-        # Wait for the local listener to come up.
-        for _ in range(60):
-            try:
-                with socket.create_connection(("127.0.0.1", local), timeout=1):
-                    break
-            except OSError:
-                if proc.poll() is not None:
-                    out = proc.stdout.read() if proc.stdout else ""
-                    raise RuntimeError(f"port-forward to {svc} exited early:\n{out}")
-                time.sleep(1)
-        else:
-            raise TimeoutError(f"port-forward to {svc} never became reachable")
-        log.info("port-forward %s -> 127.0.0.1:%d ready", svc, local)
-        yield local
-    finally:
-        proc.terminate()
-        try:
-            proc.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-
-
-def take_screenshot(a: argparse.Namespace, sandbox: str) -> bytes:
-    with port_forward(a, sandbox) as local:
-        url = f"http://127.0.0.1:{local}/cmd"
-        # computer-server may take a moment after readiness; retry briefly.
-        last_err: Exception | None = None
-        for attempt in range(12):
-            try:
-                resp = requests.post(
-                    url,
-                    json={"command": "screenshot", "params": {}},
-                    timeout=30,
-                )
-                resp.raise_for_status()
-                # Response is an SSE-style chunk: `data: {json}` (one line).
-                payload = _parse_cmd_response(resp.text)
-                if not payload.get("success"):
-                    raise RuntimeError(f"screenshot command failed: {payload}")
-                b64 = payload["image_data"]
-                png = base64.b64decode(b64)
-                if png[:4] != b"\x89PNG":
-                    log.warning("screenshot is not a PNG (got %r)", png[:8])
-                log.info("captured screenshot (%d bytes)", len(png))
-                return png
-            except Exception as e:  # noqa: BLE001
-                last_err = e
-                log.info("screenshot attempt %d failed: %s", attempt + 1, e)
-                time.sleep(5)
-        raise RuntimeError(f"screenshot failed after retries: {last_err}")
-
-
-def _parse_cmd_response(text: str) -> dict:
-    text = text.strip()
-    for line in text.splitlines():
-        line = line.strip()
-        if line.startswith("data:"):
-            return json.loads(line[len("data:"):].strip())
-    # Some builds return bare JSON.
-    return json.loads(text)
+    async with computer:
+        size = await computer.interface.get_screen_size()
+        log.info("screen size: %sx%s", size["width"], size["height"])
+        png = await computer.interface.screenshot()
+    if png[:4] != b"\x89PNG":
+        log.warning("screenshot is not a PNG (got %r)", png[:8])
+    log.info("captured screenshot (%d bytes)", len(png))
+    return png
 
 
 # --------------------------------------------------------------------------- #
@@ -386,16 +405,14 @@ def upload_and_presign(a: argparse.Namespace, png: bytes, sandbox: str) -> str:
     s3 = boto3.client("s3", region_name=a.s3_region)
     s3.put_object(Bucket=a.s3_bucket, Key=key, Body=png, ContentType="image/png")
     url = s3.generate_presigned_url(
-        "get_object",
-        Params={"Bucket": a.s3_bucket, "Key": key},
-        ExpiresIn=a.presign_ttl,
+        "get_object", Params={"Bucket": a.s3_bucket, "Key": key}, ExpiresIn=a.presign_ttl
     )
     log.info("uploaded s3://%s/%s and signed URL (ttl=%ds)", a.s3_bucket, key, a.presign_ttl)
     return url
 
 
 # --------------------------------------------------------------------------- #
-# step 6: post to Alertmanager
+# step 6: post to Alertmanager (am.cua.ai)
 # --------------------------------------------------------------------------- #
 def post_alert(a: argparse.Namespace, *, signed_url: str, sandbox: str, lic: str) -> None:
     now = datetime.now(tz=timezone.utc)
@@ -435,38 +452,51 @@ def post_alert(a: argparse.Namespace, *, signed_url: str, sandbox: str, lic: str
 # --------------------------------------------------------------------------- #
 # orchestration
 # --------------------------------------------------------------------------- #
-def main(argv: list[str]) -> int:
-    a = parse_args(argv)
-    logging.basicConfig(
-        level=logging.DEBUG if a.verbose else logging.INFO,
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    )
+async def amain(a: argparse.Namespace) -> int:
+    if not a.client_id or not a.client_secret:
+        sys.exit("set CUA_CLIENT_ID / CUA_CLIENT_SECRET (per-user key, POST /api/user-keys)")
+    if a.client_id.startswith("key-"):
+        sys.exit("that is a per-POOL key ('key-…') with no K8s identity — use a per-USER key ('ukey-…')")
 
     do_license = not a.skip_license and bool(a.arc_machine) and bool(a.subscription)
-    if not a.skip_license and not do_license:
-        log.warning(
-            "license steps disabled: ARC_MACHINE/AZURE_SUBSCRIPTION_ID not set "
-            "(pass --skip-license to silence)"
-        )
+    if not a.skip_license and a.arc_machine and not a.subscription:
+        log.warning("ARC_MACHINE set but AZURE_SUBSCRIPTION_ID missing — skipping license steps")
 
-    # Step 1 & 2
-    ensure_pool(a)
-    claim_name = create_claim(a)
+    client = TrainClient.from_key(
+        token_url=a.token_url, client_id=a.client_id,
+        client_secret=a.client_secret, base_url=a.base_url,
+    )
+    # get_httpx_client() re-mints the bearer near expiry — fetch it per request.
+    http = client.get_httpx_client
+    log.info("authenticated to %s as %s", a.base_url, a.client_id)
+
+    # Step 1
+    ensure_pool(http(), a)
+    wait_template(http, a)
+    wait_pool_warm(http, a)
+
+    # Step 2
+    claim_name = a.claim_name or f"{a.pool}-claim-{uuid.uuid4().hex[:10]}"
+    create_claim(http(), a, claim_name)
 
     licensed = False
     try:
-        sandbox, _service = wait_for_bind(a, claim_name)
+        sandbox = wait_bound(http, a, claim_name)
+        svc_path = f"/api/svc/{a.pool}/{sandbox}-{a.service_name}"
+        wait_service_ready(http, f"{svc_path}/status", a)
 
         # Step 3
         if do_license:
             set_license(a, enabled=True)
             licensed = True
 
-        # Step 4 & 5
-        png = take_screenshot(a, sandbox)
-        signed_url = upload_and_presign(a, png, sandbox)
+        # Step 4 — fresh bearer for the SDK (proxy re-checks it per request).
+        client.get_httpx_client()  # forces a token refresh
+        auth = f"Bearer {client.token}"
+        png = await take_screenshot(f"{a.base_url}{svc_path}", auth)
 
-        # Step 6
+        # Step 5 & 6
+        signed_url = upload_and_presign(a, png, sandbox)
         post_alert(a, signed_url=signed_url, sandbox=sandbox,
                    lic=license_status(a) if do_license else "")
         log.info("probe succeeded: %s", signed_url)
@@ -479,12 +509,28 @@ def main(argv: list[str]) -> int:
             except Exception:  # noqa: BLE001
                 log.exception("failed to disable license on %s", a.arc_machine)
         if not a.keep_claim:
-            cp = kubectl(["delete", "osbc", claim_name, "--ignore-not-found"],
-                         namespace=a.namespace, check=False)
-            if cp.returncode == 0:
-                log.info("deleted claim %s (returned to pool)", claim_name)
-            else:
-                log.warning("failed to delete claim %s: %s", claim_name, cp.stderr)
+            try:
+                r = http().delete(claims_url(a.pool, claim_name))
+                log.info("deleted claim %s (returned to pool, HTTP %s)", claim_name, r.status_code)
+            except httpx.HTTPError as e:
+                log.warning("failed to delete claim %s: %s", claim_name, e)
+        if a.delete_pool:
+            for what, url in ((f"pool {a.pool}", pool_url(a.pool, a.pool)),
+                              (f"namespace {a.pool}", f"/api/namespaces/{a.pool}")):
+                try:
+                    r = http().delete(url)
+                    log.info("deleted %s (HTTP %s)", what, r.status_code)
+                except httpx.HTTPError as e:
+                    log.warning("could not delete %s: %s", what, e)
+
+
+def main(argv: list[str]) -> int:
+    a = parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if a.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    return asyncio.run(amain(a))
 
 
 if __name__ == "__main__":

--- a/scripts/windows_arc_license_probe.py
+++ b/scripts/windows_arc_license_probe.py
@@ -1,0 +1,491 @@
+#!/usr/bin/env python3
+"""
+Windows Arc PAYG license probe against an OSGym warm pool.
+
+End-to-end operational probe that exercises the full "license a Windows box,
+prove it's alive, then unlicense it" loop against the cua cloud OSGym fleet:
+
+  1. provision the Windows warm pool (idempotent — created only if absent)
+  2. create an OSGymSandboxClaim and wait for it to bind to a VM
+  3. attach the Azure Arc pay-as-you-go (PAYG) Windows Server license
+  4. take a screenshot of the bound desktop
+  5. upload the screenshot to S3 and mint a presigned URL
+  6. POST the presigned URL to Alertmanager (am.cua.ai) as an annotation
+  7. deactivate the license and return the claim to the pool (always runs)
+
+Steps 1/2/4 talk to the K3s cluster that runs OSGym (group `osgym.cua.ai`)
+through `kubectl`, so a working kubeconfig that can reach the cluster API
+server is required (see the workflow for the Tailscale + KUBECONFIG wiring).
+Steps 3/7 drive Azure Resource Manager through `az rest` against a Connected
+Machine (`Microsoft.HybridCompute/machines/<machine>/licenseProfiles/default`).
+
+The license toggle operates on a *pre-onboarded* Arc machine named by
+`--arc-machine` / ARC_MACHINE. That machine must already be Connected to Arc
+and converted to a full (non-eval) Windows Server 2025 edition — onboarding and
+the eval->full DISM conversion are one-time manual setup, not part of this
+recurring probe. See docs/ in trycua/cloud for the onboarding runbook.
+
+Everything is configurable via flags or the matching UPPER_SNAKE env var.
+The cleanup (step 7) runs in a finally block so the license is disabled and
+the claim is returned even if an earlier step fails.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import logging
+import os
+import socket
+import subprocess
+import sys
+import time
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+
+import boto3
+import requests
+
+log = logging.getLogger("windows-arc-license-probe")
+
+# OSGym CRD coordinates (group osgym.cua.ai/v1alpha1; see trycua/cloud).
+API_VERSION = "osgym.cua.ai/v1alpha1"
+
+
+# --------------------------------------------------------------------------- #
+# config
+# --------------------------------------------------------------------------- #
+def _env(name: str, default: str | None = None) -> str | None:
+    return os.environ.get(name, default)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+
+    # OSGym pool / claim
+    p.add_argument("--namespace", default=_env("OSGYM_NAMESPACE", "osgym"))
+    p.add_argument("--pool", default=_env("OSGYM_POOL", "arc-windows"))
+    p.add_argument("--template", default=_env("OSGYM_TEMPLATE", "arc-windows-template"))
+    p.add_argument(
+        "--image",
+        default=_env(
+            "OSGYM_WINDOWS_IMAGE",
+            "296062593712.dkr.ecr.us-west-2.amazonaws.com/cua-server-windows:latest",
+        ),
+        help="KubeVirt containerDisk image the pool template boots.",
+    )
+    p.add_argument("--image-pull-secret", default=_env("OSGYM_IMAGE_PULL_SECRET", "ecr-credentials"))
+    p.add_argument("--cpu-cores", type=int, default=int(_env("OSGYM_CPU_CORES", "4")))
+    p.add_argument("--memory", default=_env("OSGYM_MEMORY", "8Gi"))
+    p.add_argument(
+        "--api-port",
+        type=int,
+        default=int(_env("OSGYM_API_PORT", "8000")),
+        help="In-guest computer-server port that serves POST /cmd (8000 for "
+        "cua-server-windows; 5000 for desktop-workspace-windows).",
+    )
+    p.add_argument("--bind-timeout", type=int, default=int(_env("OSGYM_BIND_TIMEOUT", "900")),
+                   help="Seconds to wait for the claim to reach phase=Bound.")
+    p.add_argument("--claim-ttl", type=int, default=int(_env("OSGYM_CLAIM_TTL", "1200")),
+                   help="Seconds before the claim's shutdownTime (reaper backstop).")
+
+    # Azure Arc licensing
+    p.add_argument("--subscription", default=_env("AZURE_SUBSCRIPTION_ID"))
+    p.add_argument("--resource-group", default=_env("ARC_RESOURCE_GROUP", "arc-trial-rg"))
+    p.add_argument("--region", default=_env("ARC_REGION", "eastus"))
+    p.add_argument("--arc-machine", default=_env("ARC_MACHINE"),
+                   help="Name of the pre-onboarded Arc Connected Machine to license.")
+    p.add_argument("--arc-api-version", default=_env("ARC_API_VERSION", "2023-10-03-preview"))
+    p.add_argument("--skip-license", action="store_true", default=_env("SKIP_LICENSE") == "1",
+                   help="Skip steps 3 & 7 (useful when no Arc machine is wired up yet).")
+
+    # S3
+    p.add_argument("--s3-bucket", default=_env("S3_BUCKET_NAME", "cua-agent-artifacts"))
+    p.add_argument("--s3-region", default=_env("AWS_REGION", "us-west-2"))
+    p.add_argument("--s3-prefix", default=_env("S3_PREFIX", "windows-arc-license-probe"))
+    p.add_argument("--presign-ttl", type=int, default=int(_env("PRESIGN_TTL", "3600")))
+
+    # Alertmanager
+    p.add_argument("--alertmanager-url", default=_env("ALERTMANAGER_URL", "https://am.cua.ai"))
+    p.add_argument("--severity", default=_env("ALERT_SEVERITY", "info"))
+
+    p.add_argument("--keep-claim", action="store_true",
+                   help="Do not delete the claim at the end (debugging).")
+    p.add_argument("-v", "--verbose", action="store_true")
+    return p.parse_args(argv)
+
+
+# --------------------------------------------------------------------------- #
+# subprocess helpers
+# --------------------------------------------------------------------------- #
+def run(cmd: list[str], *, input_str: str | None = None, check: bool = True,
+        capture: bool = True) -> subprocess.CompletedProcess:
+    log.debug("$ %s", " ".join(cmd))
+    return subprocess.run(
+        cmd,
+        input=input_str,
+        text=True,
+        capture_output=capture,
+        check=check,
+    )
+
+
+def kubectl(args: list[str], *, namespace: str | None, input_str: str | None = None,
+            check: bool = True) -> subprocess.CompletedProcess:
+    cmd = ["kubectl"]
+    if namespace:
+        cmd += ["-n", namespace]
+    cmd += args
+    return run(cmd, input_str=input_str, check=check)
+
+
+def kubectl_apply(manifest: dict, *, namespace: str) -> None:
+    kubectl(["apply", "-f", "-"], namespace=namespace, input_str=json.dumps(manifest))
+
+
+def az_rest(method: str, url: str, body: dict | None = None) -> dict:
+    cmd = ["az", "rest", "--method", method, "--url", url]
+    if body is not None:
+        cmd += ["--body", json.dumps(body)]
+    cp = run(cmd, check=True)
+    out = (cp.stdout or "").strip()
+    return json.loads(out) if out else {}
+
+
+# --------------------------------------------------------------------------- #
+# step 1: provision pool
+# --------------------------------------------------------------------------- #
+def ensure_pool(a: argparse.Namespace) -> None:
+    exists = kubectl(["get", "oswp", a.pool], namespace=a.namespace, check=False)
+    if exists.returncode == 0:
+        log.info("warm pool %s/%s already exists", a.namespace, a.pool)
+        return
+
+    log.info("provisioning warm pool %s/%s (template=%s, image=%s)",
+             a.namespace, a.pool, a.template, a.image)
+
+    template = {
+        "apiVersion": API_VERSION,
+        "kind": "OSGymSandboxTemplate",
+        "metadata": {"name": a.template, "namespace": a.namespace},
+        "spec": {
+            "vmTemplate": {
+                "containerDiskImage": a.image,
+                "imagePullSecret": a.image_pull_secret,
+                "cpuCores": a.cpu_cores,
+                "memory": a.memory,
+                # cua-server-windows boots BIOS; flip to "efi" for dockur EFI images.
+                "firmware": "bios",
+                # computer-server HTTP/cmd API + cua-driver MCP + noVNC, each
+                # fronted by a ClusterIP Service on :80 -> targetPort.
+                "services": [
+                    {"name": "api", "targetPort": a.api_port},
+                    {"name": "mcp", "targetPort": 3000},
+                    {"name": "novnc", "targetPort": 6080},
+                ],
+                # Gate readiness on computer-server actually serving.
+                "probes": {
+                    "readinessProbe": {
+                        "tcpSocket": {"port": a.api_port},
+                        "initialDelaySeconds": 60,
+                        "periodSeconds": 5,
+                        "failureThreshold": 120,
+                    }
+                },
+            }
+        },
+    }
+    warmpool = {
+        "apiVersion": API_VERSION,
+        "kind": "OSGymSandboxWarmPool",
+        "metadata": {"name": a.pool, "namespace": a.namespace},
+        "spec": {
+            "replicas": 0,
+            "sandboxTemplateRef": {"name": a.template},
+            # Static floor of 0; a Pending claim is the demand signal that
+            # scales the pool up on demand.
+            "autoscaling": {"minPoolSize": 0, "initialPoolSize": 0, "maxPoolSize": 4},
+        },
+    }
+    kubectl_apply(template, namespace=a.namespace)
+    kubectl_apply(warmpool, namespace=a.namespace)
+    log.info("warm pool %s provisioned", a.pool)
+
+
+# --------------------------------------------------------------------------- #
+# step 2: create & bind claim
+# --------------------------------------------------------------------------- #
+def create_claim(a: argparse.Namespace) -> str:
+    claim_name = f"{a.pool}-claim-{uuid.uuid4().hex[:10]}"
+    shutdown = datetime.now(tz=timezone.utc) + timedelta(seconds=a.claim_ttl)
+    claim = {
+        "apiVersion": API_VERSION,
+        "kind": "OSGymSandboxClaim",
+        "metadata": {"name": claim_name, "namespace": a.namespace},
+        "spec": {
+            "sandboxTemplateRef": {"name": a.template},
+            "warmpool": a.pool,
+            "bindDeadline": a.bind_timeout,
+            "lifecycle": {
+                "shutdownTime": shutdown.isoformat().replace("+00:00", "Z"),
+                # Retain: returning the claim restarts the VM in place and
+                # hands it back to the warm pool.
+                "shutdownPolicy": "Retain",
+            },
+        },
+    }
+    kubectl_apply(claim, namespace=a.namespace)
+    log.info("created claim %s", claim_name)
+    return claim_name
+
+
+def wait_for_bind(a: argparse.Namespace, claim_name: str) -> tuple[str, str]:
+    deadline = time.monotonic() + a.bind_timeout
+    while time.monotonic() < deadline:
+        cp = kubectl(["get", "osbc", claim_name, "-o", "json"],
+                     namespace=a.namespace, check=False)
+        if cp.returncode == 0:
+            status = json.loads(cp.stdout).get("status", {})
+            phase = status.get("phase")
+            if phase == "Bound":
+                sb = status.get("sandbox", {})
+                log.info("claim %s bound to sandbox %s (%s)",
+                         claim_name, sb.get("name"), sb.get("service"))
+                return sb["name"], sb.get("service", "")
+            if phase == "Failed":
+                raise RuntimeError(f"claim {claim_name} reached phase=Failed: {status}")
+            log.info("claim %s phase=%s, waiting...", claim_name, phase)
+        time.sleep(5)
+    raise TimeoutError(f"claim {claim_name} did not bind within {a.bind_timeout}s")
+
+
+# --------------------------------------------------------------------------- #
+# step 3 / 7: Azure Arc PAYG license
+# --------------------------------------------------------------------------- #
+def _license_url(a: argparse.Namespace) -> str:
+    return (
+        f"https://management.azure.com/subscriptions/{a.subscription}"
+        f"/resourceGroups/{a.resource_group}"
+        f"/providers/Microsoft.HybridCompute/machines/{a.arc_machine}"
+        f"/licenseProfiles/default?api-version={a.arc_api_version}"
+    )
+
+
+def set_license(a: argparse.Namespace, *, enabled: bool) -> None:
+    status = "Enabled" if enabled else "Disabled"
+    log.info("setting Arc PAYG license on %s -> %s", a.arc_machine, status)
+    body = {
+        "location": a.region,
+        "properties": {
+            "productProfile": {"productType": "WindowsServer", "subscriptionStatus": status}
+        },
+    }
+    az_rest("put", _license_url(a), body)
+
+
+def license_status(a: argparse.Namespace) -> str:
+    try:
+        resp = az_rest("get", _license_url(a))
+        return resp.get("properties", {}).get("productProfile", {}).get("subscriptionStatus", "")
+    except Exception as e:  # noqa: BLE001
+        log.warning("could not read license status: %s", e)
+        return ""
+
+
+# --------------------------------------------------------------------------- #
+# step 4: screenshot via port-forward to the bound VM's computer-server
+# --------------------------------------------------------------------------- #
+def _free_local_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+@contextmanager
+def port_forward(a: argparse.Namespace, sandbox: str):
+    """kubectl port-forward to the sandbox's `-api` Service (listens on :80)."""
+    local = _free_local_port()
+    svc = f"svc/{sandbox}-api"
+    proc = subprocess.Popen(
+        ["kubectl", "-n", a.namespace, "port-forward", svc, f"{local}:80"],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+    )
+    try:
+        # Wait for the local listener to come up.
+        for _ in range(60):
+            try:
+                with socket.create_connection(("127.0.0.1", local), timeout=1):
+                    break
+            except OSError:
+                if proc.poll() is not None:
+                    out = proc.stdout.read() if proc.stdout else ""
+                    raise RuntimeError(f"port-forward to {svc} exited early:\n{out}")
+                time.sleep(1)
+        else:
+            raise TimeoutError(f"port-forward to {svc} never became reachable")
+        log.info("port-forward %s -> 127.0.0.1:%d ready", svc, local)
+        yield local
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def take_screenshot(a: argparse.Namespace, sandbox: str) -> bytes:
+    with port_forward(a, sandbox) as local:
+        url = f"http://127.0.0.1:{local}/cmd"
+        # computer-server may take a moment after readiness; retry briefly.
+        last_err: Exception | None = None
+        for attempt in range(12):
+            try:
+                resp = requests.post(
+                    url,
+                    json={"command": "screenshot", "params": {}},
+                    timeout=30,
+                )
+                resp.raise_for_status()
+                # Response is an SSE-style chunk: `data: {json}` (one line).
+                payload = _parse_cmd_response(resp.text)
+                if not payload.get("success"):
+                    raise RuntimeError(f"screenshot command failed: {payload}")
+                b64 = payload["image_data"]
+                png = base64.b64decode(b64)
+                if png[:4] != b"\x89PNG":
+                    log.warning("screenshot is not a PNG (got %r)", png[:8])
+                log.info("captured screenshot (%d bytes)", len(png))
+                return png
+            except Exception as e:  # noqa: BLE001
+                last_err = e
+                log.info("screenshot attempt %d failed: %s", attempt + 1, e)
+                time.sleep(5)
+        raise RuntimeError(f"screenshot failed after retries: {last_err}")
+
+
+def _parse_cmd_response(text: str) -> dict:
+    text = text.strip()
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("data:"):
+            return json.loads(line[len("data:"):].strip())
+    # Some builds return bare JSON.
+    return json.loads(text)
+
+
+# --------------------------------------------------------------------------- #
+# step 5: S3 upload + presigned URL
+# --------------------------------------------------------------------------- #
+def upload_and_presign(a: argparse.Namespace, png: bytes, sandbox: str) -> str:
+    ts = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d/%H%M%SZ")
+    key = f"{a.s3_prefix}/{ts}/{sandbox}.png"
+    s3 = boto3.client("s3", region_name=a.s3_region)
+    s3.put_object(Bucket=a.s3_bucket, Key=key, Body=png, ContentType="image/png")
+    url = s3.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": a.s3_bucket, "Key": key},
+        ExpiresIn=a.presign_ttl,
+    )
+    log.info("uploaded s3://%s/%s and signed URL (ttl=%ds)", a.s3_bucket, key, a.presign_ttl)
+    return url
+
+
+# --------------------------------------------------------------------------- #
+# step 6: post to Alertmanager
+# --------------------------------------------------------------------------- #
+def post_alert(a: argparse.Namespace, *, signed_url: str, sandbox: str, lic: str) -> None:
+    now = datetime.now(tz=timezone.utc)
+    alert = {
+        "labels": {
+            "alertname": "WindowsArcLicenseProbe",
+            "severity": a.severity,
+            "service": "cua-sdk",
+            "job": "windows-arc-license-probe",
+            "pool": a.pool,
+            "sandbox": sandbox,
+        },
+        "annotations": {
+            "summary": f"Windows Arc license probe captured {sandbox}",
+            "description": (
+                f"Bound sandbox {sandbox} from pool {a.pool}.\n"
+                f"Arc machine: {a.arc_machine or '(none)'} license={lic or 'n/a'}.\n"
+                f"Screenshot (presigned, expires in {a.presign_ttl}s): {signed_url}"
+            ),
+            "screenshot_url": signed_url,
+            "dashboard": "https://grafana.cua.ai",
+        },
+        "startsAt": now.isoformat(),
+        "endsAt": (now + timedelta(minutes=30)).isoformat(),
+    }
+    resp = requests.post(
+        f"{a.alertmanager_url}/api/v2/alerts",
+        data=json.dumps([alert]),
+        headers={"Content-Type": "application/json"},
+        timeout=15,
+    )
+    if resp.status_code != 200:
+        raise RuntimeError(f"alertmanager returned {resp.status_code}: {resp.text}")
+    log.info("posted alert to %s/api/v2/alerts", a.alertmanager_url)
+
+
+# --------------------------------------------------------------------------- #
+# orchestration
+# --------------------------------------------------------------------------- #
+def main(argv: list[str]) -> int:
+    a = parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if a.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    do_license = not a.skip_license and bool(a.arc_machine) and bool(a.subscription)
+    if not a.skip_license and not do_license:
+        log.warning(
+            "license steps disabled: ARC_MACHINE/AZURE_SUBSCRIPTION_ID not set "
+            "(pass --skip-license to silence)"
+        )
+
+    # Step 1 & 2
+    ensure_pool(a)
+    claim_name = create_claim(a)
+
+    licensed = False
+    try:
+        sandbox, _service = wait_for_bind(a, claim_name)
+
+        # Step 3
+        if do_license:
+            set_license(a, enabled=True)
+            licensed = True
+
+        # Step 4 & 5
+        png = take_screenshot(a, sandbox)
+        signed_url = upload_and_presign(a, png, sandbox)
+
+        # Step 6
+        post_alert(a, signed_url=signed_url, sandbox=sandbox,
+                   lic=license_status(a) if do_license else "")
+        log.info("probe succeeded: %s", signed_url)
+        return 0
+    finally:
+        # Step 7 — always runs.
+        if licensed:
+            try:
+                set_license(a, enabled=False)
+            except Exception:  # noqa: BLE001
+                log.exception("failed to disable license on %s", a.arc_machine)
+        if not a.keep_claim:
+            cp = kubectl(["delete", "osbc", claim_name, "--ignore-not-found"],
+                         namespace=a.namespace, check=False)
+            if cp.returncode == 0:
+                log.info("deleted claim %s (returned to pool)", claim_name)
+            else:
+                log.warning("failed to delete claim %s: %s", claim_name, cp.stderr)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/windows_arc_license_probe.py
+++ b/scripts/windows_arc_license_probe.py
@@ -216,7 +216,18 @@ def ensure_pool(http: httpx.Client, a: argparse.Namespace) -> None:
     }
     r = http.post(pool_url(a.pool), json=body)
     if r.status_code == 409:
-        log.info("pool %s already exists — reusing it", a.pool)
+        # Reuse an existing pool, but don't silently validate the wrong VM:
+        # if the existing pool boots a different image, fail loudly. (We compare
+        # only the containerDisk image — the server normalizes/defaults other
+        # spec fields, so a full-spec equality check would misfire.)
+        existing = http.get(pool_url(a.pool, a.pool))
+        existing.raise_for_status()
+        cur_image = (((existing.json().get("spec") or {}).get("template") or {})
+                     .get("containerDiskImage"))
+        if cur_image and cur_image != a.image:
+            sys.exit(f"pool {a.pool} already exists with a different image "
+                     f"({cur_image} != {a.image}) — refusing to reuse it")
+        log.info("pool %s already exists with the expected image — reusing it", a.pool)
         return
     if r.status_code == 403:
         sys.exit("403 creating pool — use a per-USER key (ukey-…, POST /api/user-keys)")
@@ -247,7 +258,11 @@ def pool_counts(get_http: Callable[[], httpx.Client], pool: str) -> tuple[int, i
         r.raise_for_status()
         st = r.json().get("status") or {}
         return int(st.get("totalCount", 0)), int(st.get("availableCount", 0)), st.get("phase", "Unknown")
-    except Exception:  # noqa: BLE001
+    except (httpx.TimeoutException, httpx.TransportError) as e:
+        # Only swallow transient transport errors (retried by the caller's poll
+        # loop). Auth/RBAC/server/JSON errors propagate so the probe fails fast
+        # instead of looping to a misleading warm-pool timeout.
+        log.warning("transient error reading pool status: %s", e)
         return 0, 0, "Unknown"
 
 
@@ -330,7 +345,14 @@ def wait_service_ready(get_http: Callable[[], httpx.Client], url: str, a: argpar
         try:
             resp = get_http().get(url, timeout=15.0)
             reason = f"HTTP {resp.status_code}"
-            ok = resp.status_code not in (502, 503, 504)
+            # Require a real 2xx from /status — a persistent 401/404/500 means
+            # broken auth, a wrong service path, or a failed computer-server, and
+            # should fail at readiness rather than feed a broken VM to the
+            # screenshot step. 502/503/504 are the normal "guest still booting"
+            # proxy codes and keep polling.
+            ok = 200 <= resp.status_code < 300
+            if not ok and resp.status_code not in (502, 503, 504):
+                reason = f"HTTP {resp.status_code}: {resp.text[:200]}"
         except httpx.HTTPError as e:
             reason, ok = type(e).__name__, False
         if ok:
@@ -359,7 +381,12 @@ def _az_rest(method: str, url: str, body: dict | None = None) -> dict:
     if body is not None:
         cmd += ["--body", json.dumps(body)]
     log.debug("$ %s", " ".join(cmd))
-    cp = subprocess.run(cmd, text=True, capture_output=True, check=True)
+    try:
+        cp = subprocess.run(cmd, text=True, capture_output=True, check=True, timeout=120)
+    except subprocess.TimeoutExpired as e:
+        # An az CLI auth/network hang would otherwise stall the probe until the
+        # workflow timeout and delay cleanup/alerting — fail fast instead.
+        raise RuntimeError(f"az rest timed out after {e.timeout}s") from e
     out = (cp.stdout or "").strip()
     return json.loads(out) if out else {}
 

--- a/scripts/windows_arc_license_probe.py
+++ b/scripts/windows_arc_license_probe.py
@@ -2,18 +2,25 @@
 """
 Windows Arc PAYG license probe against a run.cua.ai Windows workspace pool.
 
-End-to-end operational probe that exercises the full "license a Windows box,
-prove it's alive, then unlicense it" loop against the cua cloud — driven
-entirely through the run.cua.ai backend with an OAuth client id/secret (no
-kubectl, no cluster VPN):
+End-to-end operational probe against the cua cloud, driven entirely through the
+run.cua.ai backend with an OAuth client id/secret (no kubectl, no cluster VPN).
 
-  1. provision the Windows workspace pool if it does not exist
+DEFAULT MODE — pre-baked licensed image (cua-server-windows-2025, a warm pool of
+size 1). The image is already Windows Server 2025 full-edition + Arc-connected +
+PAYG activated at build time, so the probe does no Azure work:
+
+  1. provision the Windows workspace pool (replicas=1) if it does not exist
   2. claim a sandbox from the pool and wait for it to bind
-  3. attach the Azure Arc pay-as-you-go (PAYG) Windows Server license
   4. take a screenshot of the bound desktop (cua-computer SDK, through the proxy)
   5. upload the screenshot to S3 and mint a presigned URL
   6. POST the presigned URL to Alertmanager (am.cua.ai)
-  7. deactivate the license and return the claim to the pool (always runs)
+  7. return the claim to the pool (always runs)
+
+RUNTIME-ONBOARDING MODE (the non-baked alternative) — set ARC_MACHINE +
+AZURE_SUBSCRIPTION_ID and the probe also:
+
+  3. attaches the Azure Arc PAYG Windows Server license (before the screenshot)
+  7. deactivates the license (after), then returns the claim
 
 Steps 1/2/4 talk to run.cua.ai. Authentication is the client_credentials
 exchange handled by ``cua_train.TrainClient.from_key`` — set CUA_CLIENT_ID /
@@ -72,10 +79,13 @@ log = logging.getLogger("windows-arc-license-probe")
 
 DEFAULT_TOKEN_URL = "https://auth.cua.ai/realms/cyclops-cs/protocol/openid-connect/token"
 DEFAULT_BASE_URL = "https://run.cua.ai"
-# Windows computer-server image: Windows Server 2022 + computer_server on :8000
-# (HTTP/WS API at /cmd, /ws, /status; MCP at /mcp). dockur-built GPT/UEFI image,
-# so the pool MUST boot it with efi firmware.
-DEFAULT_IMAGE = "296062593712.dkr.ecr.us-west-2.amazonaws.com/cua-server-windows:latest"
+# Windows computer-server image: Windows Server 2025 + computer_server on :8000
+# (HTTP/WS API at /cmd, /ws, /status; MCP at /mcp), PRE-LICENSED via Azure Arc
+# PAYG at build time (cua-server-windows-2025-workspace). dockur-built GPT/UEFI
+# image, so the pool MUST boot it with efi firmware. Because the image is
+# pre-licensed, the probe does NOT toggle licensing per run unless ARC_MACHINE
+# is set (the runtime-onboarding alternative).
+DEFAULT_IMAGE = "296062593712.dkr.ecr.us-west-2.amazonaws.com/cua-server-windows-2025:latest"
 
 # OSGymWorkspacePool — the single-object pool CR the run.cua.ai SPA creates
 # (cua.ai/v1); the pool-operator compat shim projects it into the native


### PR DESCRIPTION
## Summary

This PR adds an end-to-end operational probe for Windows Arc PAYG licensing against the run.cua.ai backend, along with a GitHub Actions workflow to run it on a schedule.

## Key Changes

- **`scripts/windows_arc_license_probe.py`**: A comprehensive Python probe script that:
  - Provisions a Windows workspace pool on run.cua.ai (idempotent)
  - Claims a sandbox VM from the pool and waits for it to bind
  - Optionally attaches/detaches Azure Arc PAYG Windows Server licenses via `az rest` commands
  - Takes a screenshot of the bound desktop using the cua-computer SDK
  - Uploads the screenshot to S3 and generates a presigned URL
  - Posts the result to Alertmanager (am.cua.ai) with the screenshot URL
  - Returns the claim to the pool (cleanup runs in a finally block)
  - Supports both "pre-baked licensed image" mode (default) and "runtime-onboarding" mode (when `ARC_MACHINE` and `AZURE_SUBSCRIPTION_ID` are set)
  - Fully configurable via command-line arguments and environment variables
  - Authenticates to run.cua.ai using OAuth client credentials (per-user keys only)

- **`.github/workflows/windows-arc-license-probe.yml`**: A GitHub Actions workflow that:
  - Runs daily at 06:17 UTC and supports manual triggering via `workflow_dispatch`
  - Installs Python dependencies and sets up Azure CLI authentication
  - Executes the probe script with secrets and variables from the repository
  - Posts a failure alert to Alertmanager if the probe fails
  - Supports skipping license operations via workflow input

## Notable Implementation Details

- The probe uses `cua_train.TrainClient` for OAuth token management and `httpx` for HTTP requests to run.cua.ai
- Pool provisioning is idempotent—reuses existing pools/namespaces
- Waits for the pool to have at least one warm VM before claiming to avoid burning the claim's bind deadline
- Uses the cua-computer SDK to connect to the in-guest computer-server through the run.cua.ai reverse proxy
- License operations use `az rest` commands against Azure Resource Manager's Connected Machine API
- Comprehensive logging and error handling with graceful cleanup (license disable + claim return always execute)
- Supports both BIOS and EFI firmware, configurable CPU/RAM, and custom service names

https://claude.ai/code/session_01XFdKD6MUDzEP2tkthfJnf3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a scheduled and manually runnable Windows licensing probe to monitor the end-to-end Arc PAYG flow.
  * The probe now captures a screenshot, uploads it securely, and generates a shareable link for review.
  * Added automatic failure alerts with direct links to the run details.

* **Bug Fixes**
  * Improved cleanup after probe runs to reduce leftover resources and keep environments tidy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->