### PR TITLE
test(cua-driver/macos): assert the decoy is really frontmost in modality_focus

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/tests/modality_focus_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/modality_focus_test.rs
@@ -80,6 +80,24 @@ mod macos_focus_tests {
         let initial_focus = frontmost_bundle_id();
         println!("Initial focus: {}", initial_focus);
 
+        // Precondition: the decoy (Terminal) must REALLY be the frontmost,
+        // non-harness window before we touch the background app. Without this
+        // guard the test passes vacuously: if `focus_terminal()` silently
+        // failed (Terminal not installed / activation blocked) and Calculator
+        // were frontmost instead, every "focus unchanged" assertion below would
+        // still hold — even though the harness owns the foreground, which is
+        // exactly the regression these tests exist to catch. Mirrors the
+        // sentinel-is-up precondition the Windows background tests get for free
+        // from the focus-monitor-win pid/hwnd files.
+        assert!(
+            !initial_focus.is_empty()
+                && !initial_focus.eq_ignore_ascii_case("com.apple.calculator"),
+            "decoy precondition failed: frontmost app is {initial_focus:?}, expected a \
+             non-harness control window (Terminal) to hold the foreground before the \
+             background action. Calculator (the harness) must NOT be frontmost, otherwise \
+             the no-focus-steal assertions below are vacuous."
+        );
+
         // Start the MCP driver (skips if the binary isn't built).
         let Some(mut driver) = McpDriver::spawn() else { return };
 


### PR DESCRIPTION
## Why
`modality_focus_test` (the macOS no-focus-steal test) brings **Terminal** forward as the user's active window, then drives **Calculator** in the background and asserts the frontmost app is unchanged. But it never verified Terminal actually *became* frontmost — so if `focus_terminal()` silently failed (Terminal not installed / activation blocked) and Calculator were frontmost, every assertion would still pass **vacuously** while the harness owns the foreground. That's exactly the regression these tests exist to catch.

## Fix
A one-line precondition before any background action: the frontmost bundle must be **non-empty and not `com.apple.calculator`** — i.e. a non-harness control window really holds the foreground first. Mirrors the "sentinel is up" precondition the Windows background tests get for free from `focus-monitor-win`'s pid/hwnd files.

## Context
From a background audit of every background-modality test. The Windows ones already hold the assumption: `modality_background` (focus-monitor-win → z+0, harness z+1, `assert_no_focus_steal`), `modality_input_e2e` (sentinel + `GetForegroundWindow` poll), `guard_ux` (focus-monitor decoy + loss-delta). Only macOS `modality_focus` lacked the decoy *precondition*; this closes it.

## Verification
✅ Compiles on macOS (`cargo test --no-run --test modality_focus_test`). `#[ignore]`. To prove the guard is load-bearing: stub `focus_terminal()` to a no-op → the test now fails fast at the precondition instead of passing vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened a macOS integration test to verify the initial active app is valid before running focus checks.
  * Improved reliability of the focus-related test by avoiding false positives when the calculator is already frontmost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->