### PR TITLE
test(cua-driver): use canonical capture_mode "ax", drop deprecated "tree" alias

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_appkit_test.rs
@@ -90,7 +90,7 @@ fn snapshot_elements(driver: &mut McpDriver, pid: u32, window_id: u64) -> ToolRe
         serde_json::json!({
             "pid": pid as i64,
             "window_id": window_id,
-            "capture_mode": "tree"
+            "capture_mode": "ax"
         }))
 }
 

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_swiftui_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_swiftui_test.rs
@@ -66,7 +66,7 @@ fn snapshot_elements(driver: &mut McpDriver, pid: u32, window_id: u64) -> ToolRe
         serde_json::json!({
             "pid": pid as i64,
             "window_id": window_id,
-            "capture_mode": "tree"
+            "capture_mode": "ax"
         }),
     )
 }

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_winui3_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_winui3_test.rs
@@ -70,7 +70,7 @@ fn harness_winui3_smoke() {
 
     let snap = driver.call(
         "get_window_state",
-        serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode":"tree"}),
+        serde_json::json!({"pid": pid as i64, "window_id": wid, "capture_mode":"ax"}),
     );
     let text = snap.text();
 

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
@@ -91,7 +91,7 @@ fn snapshot(driver: &mut McpDriver, pid: u32, window_id: u64) -> ToolResponse {
     driver.call("get_window_state", serde_json::json!({
         "pid": pid as i64,
         "window_id": window_id,
-        "capture_mode": "tree"
+        "capture_mode": "ax"
     }))
 }
 
@@ -422,7 +422,7 @@ fn harness_wpf_modal_messagebox() {
 
         // Walk the modal's UIA tree — expect OK and Cancel buttons.
         let modal_snap = driver.call("get_window_state", serde_json::json!({
-            "pid": pid as i64, "window_id": modal_wid, "capture_mode": "tree"
+            "pid": pid as i64, "window_id": modal_wid, "capture_mode": "ax"
         }));
         let modal_text = modal_snap.text();
         assert!(modal_text.contains("\"OK\""),
@@ -470,7 +470,7 @@ fn harness_wpf_owned_popup() {
         let owned_wid = owned["window_id"].as_u64().unwrap();
 
         let owned_snap = driver.call("get_window_state", serde_json::json!({
-            "pid": pid as i64, "window_id": owned_wid, "capture_mode": "tree"
+            "pid": pid as i64, "window_id": owned_wid, "capture_mode": "ax"
         }));
         let owned_text = owned_snap.text();
         assert!(owned_text.contains("OWNED_POPUP_MARKER_v1"),

--- a/libs/cua-driver/rust/crates/cua-driver/tests/modality_focus_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/modality_focus_test.rs
@@ -124,7 +124,7 @@ mod macos_focus_tests {
         // Walk AX tree.
         let resp = driver.call(
             "get_window_state",
-            serde_json::json!({ "pid": calc_pid, "window_id": window_id, "capture_mode": "tree" }),
+            serde_json::json!({ "pid": calc_pid, "window_id": window_id, "capture_mode": "ax" }),
         );
         println!(
             "get_window_state: {}",


### PR DESCRIPTION
## What
Seven `get_window_state` call sites across the harness/focus tests passed `capture_mode: "tree"`, which is **not** in the documented enum (`som`/`vision`/`ax`). Its behavior was **inconsistent across platforms**:

| Platform | `"tree"` resolves to |
|---|---|
| macOS | explicitly aliased to `"ax"` (tree only) |
| Windows / Linux | `do_tree = mode != "vision"`, `do_shot = mode != "ax"` → **both** tree + screenshot (i.e. `som`), wasting a capture the tests never read |

The tests passed everywhere only because they assert on the tree. Switching to the canonical `"ax"` makes intent explicit and behavior consistent (tree-only, no wasted screenshot) on all three platforms. On macOS this is a no-op (the alias already resolved to `"ax"`).

## Files (7 sites, 5 files)
`modality_focus_test`, `harness_wpf_test` (×3), `harness_appkit_test`, `harness_winui3_test`, `harness_swiftui_test`.

## Verification (macOS)
- `harness_appkit` (5) + `harness_swiftui` (2) ✅ green; the `get_window_state(ax)` snapshot renders the full tree unchanged.
- `modality_focus`'s focus-steal assertion flaked because an unrelated background app grabbed focus on the dev host (`com.apple.Terminal` → `com.superhuman.electron`) — not driver behavior, not this change. The `ax` snapshot itself returned the expected 267-element tree.

Companion to #2053 (modality matrix docs + capture_mode coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated multiple UI harness checks to capture accessibility-based window state snapshots instead of tree-based snapshots.
  * Aligned AppKit, SwiftUI, WinUI3, and WPF test flows with the new snapshot source.
  * Kept focus-related assertions intact while changing the snapshot data used immediately before validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->