### PR TITLE
fix(cua-driver)(test-harness): point Windows csprojs at shared/scenarios.json

### DIFF
--- a/libs/cua-driver/test-harness/apps/windows/winui3/CuaTestHarness.WinUI3.csproj
+++ b/libs/cua-driver/test-harness/apps/windows/winui3/CuaTestHarness.WinUI3.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\scenarios\scenarios.json" Link="scenarios.json">
+    <None Include="..\..\..\shared\scenarios.json" Link="scenarios.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/libs/cua-driver/test-harness/apps/windows/wpf/CuaTestHarness.Wpf.csproj
+++ b/libs/cua-driver/test-harness/apps/windows/wpf/CuaTestHarness.Wpf.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\scenarios\scenarios.json" Link="scenarios.json">
+    <None Include="..\..\..\shared\scenarios.json" Link="scenarios.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
## What
The per-OS harness reorg (#1727) moved `scenarios.json` to `test-harness/shared/`, but the **WPF** and **WinUI3** csprojs still reference `..\scenarios\scenarios.json` — i.e. `apps/windows/scenarios/`, a directory that no longer exists. A fresh `test-harness/build/windows.ps1` aborts with:

```
MSB3030: Could not copy "...apps/windows/scenarios/scenarios.json" because it was not found.
```

`windows.ps1` doesn't stage the file, so nothing papered over it on a clean checkout. Both `<None Include>` paths now point at the real, tracked location `..\..\..\shared\scenarios.json`. The `Link="scenarios.json"` + `CopyToOutputDirectory` still drop it next to the exe where `Scenarios.cs` reads it from `AppContext.BaseDirectory`.

## How it surfaced
Build-verifying the harness suite on the Windows VM for #2053 — a fresh `windows.ps1` failed here; copying `shared/scenarios.json` into the stale path unblocked the build, confirming the diagnosis.

## Verification
Path arithmetic verified from each csproj dir (`..\..\..\shared\scenarios.json` resolves to the existing `test-harness/shared/scenarios.json`). Runtime `windows.ps1` build-confirm on the VM is pending its interactive-session/ACL constraints; the change is a mechanical path correction to the independently-confirmed location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Windows test harness apps to use a shared `scenarios.json` file from a common location.
  * Kept the existing file copy and output behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->