### PR TITLE
feat(lume): add additional virtio-blk data disks

### DIFF
--- a/docs/content/docs/reference/lume/cli-reference.mdx
+++ b/docs/content/docs/reference/lume/cli-reference.mdx
@@ -67,6 +67,7 @@ Run a virtual machine
 | `--shared-dir` | [String] | - | Directory to share with the VM (format: path or path:ro or path:rw) |
 | `--mount` | String | - | For Linux VMs only, attach a read-only disk image |
 | `--usb-storage` | [String] | - | Disk image to attach as USB mass storage device |
+| `--disk` | [String] | - | Disk image to attach as a read-write virtio-blk device |
 | `--registry` | String | ghcr.io | Container registry URL |
 | `--organization` | String | trycua | Organization to pull from |
 | `--vnc-port` | Int | 0 | Port for VNC server (0 for auto-assign) |

--- a/libs/lume/src/Commands/Run.swift
+++ b/libs/lume/src/Commands/Run.swift
@@ -34,6 +34,12 @@ struct Run: AsyncParsableCommand {
         completion: .file())
     var usbStorageDevices: [String] = []
 
+    @Option(
+        name: [.customLong("disk")],
+        help: "Disk image to attach as a read-write virtio-blk device (e.g. --disk=\"scratch.img\")",
+        completion: .file())
+    var additionalDisks: [String] = []
+
     @Option(help: "Github Container Registry to pull the images from. Defaults to ghcr.io")
     var registry: String = "ghcr.io"
 
@@ -132,6 +138,10 @@ struct Run: AsyncParsableCommand {
         usbStorageDevices.map { Path($0) }
     }
 
+    private var parsedAdditionalDisks: [Path] {
+        additionalDisks.map { Path($0) }
+    }
+
     init() {
     }
 
@@ -156,6 +166,7 @@ struct Run: AsyncParsableCommand {
             diskPath: diskPath.map { Path($0) },
             nvramPath: nvramPath.map { Path($0) },
             usbMassStoragePaths: parsedUSBStorageDevices.isEmpty ? nil : parsedUSBStorageDevices,
+            additionalDiskPaths: parsedAdditionalDisks.isEmpty ? nil : parsedAdditionalDisks,
             networkMode: parsedNetworkMode,
             clipboard: clipboard
         )

--- a/libs/lume/src/LumeController.swift
+++ b/libs/lume/src/LumeController.swift
@@ -1039,6 +1039,7 @@ final class LumeController {
         diskPath: Path? = nil,
         nvramPath: Path? = nil,
         usbMassStoragePaths: [Path]? = nil,
+        additionalDiskPaths: [Path]? = nil,
         networkMode: NetworkMode? = nil,
         clipboard: Bool = false,
         telemetryTransport: TelemetryTransport = .cli
@@ -1058,6 +1059,7 @@ final class LumeController {
                 "disk_path_override": diskPath?.path ?? "none",
                 "nvram_path_override": nvramPath?.path ?? "none",
                 "usb_storage_devices": "\(usbMassStoragePaths?.count ?? 0)",
+                "additional_disks": "\(additionalDiskPaths?.count ?? 0)",
                 "network_override": networkMode?.description ?? "vm-config",
             ])
 
@@ -1147,7 +1149,8 @@ final class LumeController {
                 vmDir: vmDir, // Pass vmDir
                 sharedDirectories: sharedDirectories,
                 mount: mount,
-                usbMassStoragePaths: usbMassStoragePaths
+                usbMassStoragePaths: usbMassStoragePaths,
+                additionalDiskPaths: additionalDiskPaths
             )
 
             // Load the VM directly using the located VMDirectory and storage context
@@ -1163,6 +1166,7 @@ final class LumeController {
                 vncPassword: vncPassword,
                 recoveryMode: recoveryMode,
                 usbMassStoragePaths: usbMassStoragePaths,
+                additionalDiskPaths: additionalDiskPaths,
                 networkMode: networkMode,
                 clipboard: clipboard)
             Logger.info("VM started successfully", metadata: ["name": normalizedName])
@@ -1626,11 +1630,21 @@ final class LumeController {
         vmDir: VMDirectory, // Changed signature: accept VMDirectory
         sharedDirectories: [SharedDirectory]?,
         mount: Path?,
-        usbMassStoragePaths: [Path]? = nil
+        usbMassStoragePaths: [Path]? = nil,
+        additionalDiskPaths: [Path]? = nil
     ) throws {
         // VM existence is confirmed by having vmDir, no need for validateVMExists
         if let dirs = sharedDirectories {
             try self.validateSharedDirectories(dirs)
+        }
+
+        // Validate additional disk paths
+        if let extraDisks = additionalDiskPaths {
+            for path in extraDisks {
+                if !FileManager.default.fileExists(atPath: path.path) {
+                    throw ValidationError("Additional disk image not found: \(path.path)")
+                }
+            }
         }
 
         // Validate USB mass storage paths

--- a/libs/lume/src/LumeController.swift
+++ b/libs/lume/src/LumeController.swift
@@ -1147,6 +1147,7 @@ final class LumeController {
             // Validate parameters using the located VMDirectory
             try validateRunParameters(
                 vmDir: vmDir, // Pass vmDir
+                primaryDiskPath: diskPath ?? vmDir.diskPath,
                 sharedDirectories: sharedDirectories,
                 mount: mount,
                 usbMassStoragePaths: usbMassStoragePaths,
@@ -1628,6 +1629,7 @@ final class LumeController {
 
     private func validateRunParameters(
         vmDir: VMDirectory, // Changed signature: accept VMDirectory
+        primaryDiskPath: Path,
         sharedDirectories: [SharedDirectory]?,
         mount: Path?,
         usbMassStoragePaths: [Path]? = nil,
@@ -1640,9 +1642,25 @@ final class LumeController {
 
         // Validate additional disk paths
         if let extraDisks = additionalDiskPaths {
+            let canonicalPrimaryDiskPath =
+                primaryDiskPath.url.resolvingSymlinksInPath().standardizedFileURL.path(
+                    percentEncoded: false)
+            var canonicalAdditionalDiskPaths = Swift.Set<String>()
+
             for path in extraDisks {
                 if !FileManager.default.fileExists(atPath: path.path) {
                     throw ValidationError("Additional disk image not found: \(path.path)")
+                }
+
+                let canonicalPath =
+                    path.url.resolvingSymlinksInPath().standardizedFileURL.path(
+                        percentEncoded: false)
+                if canonicalPath == canonicalPrimaryDiskPath {
+                    throw ValidationError(
+                        "Additional disk image must differ from the primary boot disk: \(path.path)")
+                }
+                guard canonicalAdditionalDiskPaths.insert(canonicalPath).inserted else {
+                    throw ValidationError("Duplicate additional disk image: \(path.path)")
                 }
             }
         }

--- a/libs/lume/src/Utils/CommandDocExtractor.swift
+++ b/libs/lume/src/Utils/CommandDocExtractor.swift
@@ -339,6 +339,7 @@ enum CommandDocExtractor {
                 OptionDoc(name: "shared-dir", shortName: nil, help: "Directory to share with the VM (format: path or path:ro or path:rw)", type: "[String]", defaultValue: nil, isOptional: true),
                 OptionDoc(name: "mount", shortName: nil, help: "For Linux VMs only, attach a read-only disk image", type: "String", defaultValue: nil, isOptional: true),
                 OptionDoc(name: "usb-storage", shortName: nil, help: "Disk image to attach as USB mass storage device", type: "[String]", defaultValue: nil, isOptional: true),
+                OptionDoc(name: "disk", shortName: nil, help: "Disk image to attach as a read-write virtio-blk device", type: "[String]", defaultValue: nil, isOptional: true),
                 OptionDoc(name: "registry", shortName: nil, help: "Container registry URL", type: "String", defaultValue: "ghcr.io", isOptional: false),
                 OptionDoc(name: "organization", shortName: nil, help: "Organization to pull from", type: "String", defaultValue: "trycua", isOptional: false),
                 OptionDoc(name: "vnc-port", shortName: nil, help: "Port for VNC server (0 for auto-assign)", type: "Int", defaultValue: "0", isOptional: false),

--- a/libs/lume/src/VM/VM.swift
+++ b/libs/lume/src/VM/VM.swift
@@ -145,6 +145,7 @@ class VM {
     func run(
         noDisplay: Bool, sharedDirectories: [SharedDirectory], mount: Path?, vncPort: Int = 0,
         vncPassword: String? = nil, recoveryMode: Bool = false, usbMassStoragePaths: [Path]? = nil,
+        additionalDiskPaths: [Path]? = nil,
         networkMode: NetworkMode? = nil, clipboard: Bool = false
     ) async throws {
         guard let resizeGuard = try vmDirContext.dir.tryAcquireResizeGuard(exclusive: false) else {
@@ -265,6 +266,7 @@ class VM {
                 mount: mount,
                 recoveryMode: recoveryMode,
                 usbMassStoragePaths: usbMassStoragePaths,
+                additionalDiskPaths: additionalDiskPaths,
                 networkMode: networkMode
             )
             Logger.info(
@@ -912,6 +914,7 @@ class VM {
         mount: Path? = nil,
         recoveryMode: Bool = false,
         usbMassStoragePaths: [Path]? = nil,
+        additionalDiskPaths: [Path]? = nil,
         networkMode: NetworkMode? = nil
     ) throws -> VMVirtualizationServiceContext {
         // This is a diagnostic log to track actual file paths on disk for debugging
@@ -933,6 +936,7 @@ class VM {
             nvramPath: vmDirContext.nvramPath,
             recoveryMode: recoveryMode,
             usbMassStoragePaths: usbMassStoragePaths,
+            additionalDiskPaths: additionalDiskPaths,
             networkMode: effectiveNetworkMode
         )
     }

--- a/libs/lume/src/Virtualization/VMVirtualizationService.swift
+++ b/libs/lume/src/Virtualization/VMVirtualizationService.swift
@@ -16,6 +16,7 @@ struct VMVirtualizationServiceContext {
     let nvramPath: Path
     let recoveryMode: Bool
     let usbMassStoragePaths: [Path]?
+    let additionalDiskPaths: [Path]?
     let networkMode: NetworkMode
 }
 
@@ -295,6 +296,13 @@ final class DarwinVirtualizationService: BaseVirtualizationService {
                     try createUSBMassStorageDeviceConfiguration(diskPath: usbPath, readOnly: true))
             }
         }
+        // Attach additional read-write disks as virtio-blk (USB mass storage is rejected for macOS guests).
+        if let extraDisks = config.additionalDiskPaths {
+            for diskPath in extraDisks {
+                storageDevices.append(
+                    try createStorageDeviceConfiguration(diskPath: diskPath, readOnly: false))
+            }
+        }
         vzConfig.storageDevices = storageDevices
         vzConfig.networkDevices = [
             try createNetworkDeviceConfiguration(
@@ -492,6 +500,14 @@ final class LinuxVirtualizationService: BaseVirtualizationService {
                 storageDevices.append(
                     try createUSBMassStorageDeviceConfiguration(
                         diskPath: usbPath, readOnly: true, cachingMode: diskCachingMode))
+            }
+        }
+        // Attach additional read-write disks as virtio-blk.
+        if let extraDisks = config.additionalDiskPaths {
+            for diskPath in extraDisks {
+                storageDevices.append(
+                    try createStorageDeviceConfiguration(
+                        diskPath: diskPath, readOnly: false, cachingMode: diskCachingMode))
             }
         }
         vzConfig.storageDevices = storageDevices

--- a/libs/lume/tests/LumeControllerTests.swift
+++ b/libs/lume/tests/LumeControllerTests.swift
@@ -1,3 +1,4 @@
+import ArgumentParser
 import Foundation
 import Testing
 
@@ -161,6 +162,81 @@ func testClonePreservesPairedBootPolicyState() throws {
     #expect(try Data(contentsOf: cloneDir.nvramPath.url) == nvramData)
     #expect(cloneConfig.machineIdentifier != sourceMachineIdentifier)
     #expect(cloneConfig.macAddress != sourceMacAddress)
+}
+
+@MainActor
+@Test("run rejects primary and duplicate additional disk aliases")
+func testRunRejectsAdditionalDiskAliases() async throws {
+    let tempConfigDir = try createTempDirectory()
+    let tempHomeDir = try createTempDirectory()
+
+    defer {
+        try? FileManager.default.removeItem(at: tempConfigDir)
+        try? FileManager.default.removeItem(at: tempHomeDir)
+    }
+
+    let previousXDGConfigHome = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"]
+    setenv("XDG_CONFIG_HOME", tempConfigDir.path, 1)
+    defer {
+        if let previousXDGConfigHome {
+            setenv("XDG_CONFIG_HOME", previousXDGConfigHome, 1)
+        } else {
+            unsetenv("XDG_CONFIG_HOME")
+        }
+    }
+
+    let settingsManager = SettingsManager(fileManager: .default)
+    try settingsManager.setHomeDirectory(path: tempHomeDir.path)
+    let home = Home(settingsManager: settingsManager, fileManager: .default)
+    let controller = LumeController(home: home, vmFactory: TestVMFactory())
+    let vmDir = try home.getVMDirectory("data-disk-validation")
+    try FileManager.default.createDirectory(
+        at: vmDir.dir.url,
+        withIntermediateDirectories: true
+    )
+    try Data(repeating: 0, count: 1024).write(to: vmDir.diskPath.url)
+    try Data(repeating: 0, count: 1024).write(to: vmDir.nvramPath.url)
+    try vmDir.saveConfig(
+        VMConfig(
+            os: "macOS",
+            cpuCount: 1,
+            memorySize: 1024,
+            diskSize: 1024,
+            display: "1024x768"
+        ))
+
+    do {
+        try await controller.runVM(
+            name: vmDir.name,
+            noDisplay: true,
+            additionalDiskPaths: [Path(vmDir.diskPath.url)]
+        )
+        Issue.record("Expected the primary boot disk alias to be rejected")
+    } catch let error as ValidationError {
+        #expect(String(describing: error).contains("must differ from the primary boot disk"))
+    }
+
+    let additionalDiskURL = tempHomeDir.appendingPathComponent("additional.img")
+    let additionalDiskAliasURL = tempHomeDir.appendingPathComponent("additional-alias.img")
+    try Data(repeating: 0, count: 1024).write(to: additionalDiskURL)
+    try FileManager.default.createSymbolicLink(
+        at: additionalDiskAliasURL,
+        withDestinationURL: additionalDiskURL
+    )
+
+    do {
+        try await controller.runVM(
+            name: vmDir.name,
+            noDisplay: true,
+            additionalDiskPaths: [
+                Path(additionalDiskURL),
+                Path(additionalDiskAliasURL),
+            ]
+        )
+        Issue.record("Expected duplicate additional disk aliases to be rejected")
+    } catch let error as ValidationError {
+        #expect(String(describing: error).contains("Duplicate additional disk image"))
+    }
 }
 
 private func createTempDirectory() throws -> URL {

--- a/libs/lume/tests/Mocks/MockVM.swift
+++ b/libs/lume/tests/Mocks/MockVM.swift
@@ -24,6 +24,7 @@ class MockVM: VM {
     override func run(
         noDisplay: Bool, sharedDirectories: [SharedDirectory], mount: Path?, vncPort: Int = 0,
         vncPassword: String? = nil, recoveryMode: Bool = false, usbMassStoragePaths: [Path]? = nil,
+        additionalDiskPaths: [Path]? = nil,
         networkMode: NetworkMode? = nil, clipboard: Bool = false
     ) async throws {
         mockIsRunning = true
@@ -31,6 +32,7 @@ class MockVM: VM {
             noDisplay: noDisplay, sharedDirectories: sharedDirectories, mount: mount,
             vncPort: vncPort, vncPassword: vncPassword, recoveryMode: recoveryMode,
             usbMassStoragePaths: usbMassStoragePaths,
+            additionalDiskPaths: additionalDiskPaths,
             networkMode: networkMode, clipboard: clipboard
         )
     }

--- a/libs/lume/tests/RunCommandTests.swift
+++ b/libs/lume/tests/RunCommandTests.swift
@@ -1,0 +1,19 @@
+import Testing
+
+@testable import lume
+
+@MainActor
+@Test("run parses repeated additional disk options")
+func runCommandParsesAdditionalDisks() throws {
+    let root = try Lume.parseAsRoot([
+        "run",
+        "test-vm",
+        "--disk",
+        "scratch.img",
+        "--disk=cache.img",
+    ])
+    let command = try #require(root as? Run)
+
+    #expect(command.name == "test-vm")
+    #expect(command.additionalDisks == ["scratch.img", "cache.img"])
+}

--- a/libs/lume/tests/VMTests.swift
+++ b/libs/lume/tests/VMTests.swift
@@ -148,6 +148,51 @@ func testVMConfigurationUpdates() async throws {
 }
 
 @MainActor
+@Test("VM virtualization context forwards additional disks")
+func testVMVirtualizationContextForwardsAdditionalDisks() throws {
+    let tempDir = try createTempDirectory()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+    let vmDir = try setupVMDirectory(tempDir)
+    let additionalDiskURLs = [
+        tempDir.appendingPathComponent("scratch.img"),
+        tempDir.appendingPathComponent("cache.img"),
+    ]
+    for url in additionalDiskURLs {
+        try Data(repeating: 0, count: 1024).write(to: url)
+    }
+
+    var config = try VMConfig(
+        os: "mock-os",
+        cpuCount: 1,
+        memorySize: 1024,
+        diskSize: 1024,
+        display: "1024x768"
+    )
+    config.setMacAddress("00:11:22:33:44:55")
+    let context = VMDirContext(
+        dir: vmDir,
+        config: config,
+        home: Home(fileManager: FileManager.default),
+        storage: nil
+    )
+    let vm = MockVM(
+        vmDirContext: context,
+        virtualizationServiceFactory: { _ in MockVMVirtualizationService() },
+        vncServiceFactory: { MockVNCService(vmDirectory: $0) }
+    )
+    let additionalDisks = additionalDiskURLs.map(Path.init)
+
+    let serviceContext = try vm.createVMVirtualizationServiceContext(
+        cpuCount: 1,
+        memorySize: 1024,
+        display: "1024x768",
+        additionalDiskPaths: additionalDisks
+    )
+
+    #expect(serviceContext.additionalDiskPaths?.map(\.path) == additionalDisks.map(\.path))
+}
+
+@MainActor
 @Test("VM setup process")
 func testVMSetup() async throws {
     let tempDir = try createTempDirectory()


### PR DESCRIPTION
lume has no way to attach an additional read-write disk to a macOS guest: `--mount` is blocked for macOS guests, and `--usb-storage` builds a VZUSBMassStorageDeviceConfiguration, which Virtualization.framework rejects for macOS guests ("Operation not supported"). The boot disk, however, is attached as virtio-blk (VZVirtioBlockDeviceConfiguration), which works for macOS guests.

This adds a repeatable `--disk <path>` option that attaches additional read-write disks as virtio-blk devices for both macOS and Linux guests. 

Validated on macOS 26 (Tahoe): a macOS guest sees the extra disk, formats it APFS, and runs at boot-disk parity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `--disk` option to attach extra read-write virtual disk images when starting a VM.
  * Multiple additional disks are supported and are included in the VM configuration automatically.

* **Bug Fixes**
  * Added validation to ensure specified disk image paths exist before launch, reducing startup errors.
  * Updated command help/documentation so the new disk option appears in usage details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->