### PR TITLE
fix(cua-driver/linux): glide the agent cursor to the desktop-scope click point

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -1047,6 +1047,11 @@ impl Tool for ClickTool {
             let sx = args.f64_or("x", 0.0) as i32;
             let sy = args.f64_or("y", 0.0) as i32;
             let n = args.u64_or("count", 1) as usize;
+            // Glide the agent-cursor overlay to the click point first (the macOS
+            // / Windows desktop paths already do this). Without it the overlay
+            // sits idle elsewhere while only the real pointer warps, so a viewer
+            // sees the cursor "click somewhere else."
+            overlay_glide_to_for(&cursor_id, sx as f64, sy as f64).await;
             let r = tokio::task::spawn_blocking(move || {
                 crate::input::send_click_xtest_desktop(sx, sy, button, n)
             })


### PR DESCRIPTION
## What
The Linux window-less desktop-scope click warped only the **real** pointer (XTest) and never moved the agent-cursor **overlay** — unlike the macOS/Windows desktop paths, which glide it. So the most visible cursor on screen sat idle elsewhere while the click landed on the target: a viewer (and a screen recording) sees the cursor **"click somewhere else"** even though the action is correct (the harness counter does advance).

## Fix
Reuse the existing `overlay_glide_to_for` helper to glide the overlay to `(sx, sy)` before the XTest click, matching the other platforms.

## How it was caught
Inspecting the Linux desktop-scope demo recording **frame-by-frame** — the overlay was parked in the lower-left while the counter advanced via the (warped) real pointer. Pure cosmetic/UX, but it makes the desktop-scope action legible in recordings and consistent across platforms.

Compile-checked via the Linux build in CI (couldn't build platform-linux on the dev Mac).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop clicking behavior in full-screen/window-less mode by moving the visible cursor overlay to the target position before the click is sent.
  * This makes cursor movement and click actions appear more consistent during screen interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->