### PR TITLE
chore(test-harness): per-OS runners for the interactive #[ignore] matrix

### DIFF
--- a/libs/cua-driver/test-harness/TEST_SUITE.md
+++ b/libs/cua-driver/test-harness/TEST_SUITE.md
@@ -124,3 +124,21 @@ Windows" gap.
 
 Run an `#[ignore]` suite explicitly:
 `cargo test -p cua-driver --test <name> -- --ignored --nocapture --test-threads=1`
+
+### Run the whole matrix for the host OS
+
+`test-harness/run-suite.sh` (macOS + Linux) and `test-harness/run-suite.ps1`
+(Windows) build the host harness and run every `#[ignore]` modality/harness test
+for that OS in one shot, printing a `PASS / FAIL / SKIP` summary. Each test file
+is `#![cfg(target_os = "…")]`-gated, so the runner lists the full matrix and cfg
+selects the host's subset (non-host files compile to empty binaries).
+
+```sh
+libs/cua-driver/test-harness/run-suite.sh               # macOS / Linux
+pwsh -File libs/cua-driver/test-harness/run-suite.ps1   # Windows (Session 2)
+```
+
+Flags: `--no-build` reuse the staged harness, `--release` use the release driver.
+Headless Linux CI runs the capture_mode + gate subset
+(`.github/workflows/ci-cua-driver-interactive-linux.yml`); the desktop-scope
+landing needs a real display.

--- a/libs/cua-driver/test-harness/run-suite.ps1
+++ b/libs/cua-driver/test-harness/run-suite.ps1
@@ -1,0 +1,61 @@
+# Run the full cua-driver interactive #[ignore] modality/harness matrix on
+# Windows in one shot, with a PASS/FAIL/SKIP summary. Windows peer of run-suite.sh.
+#
+# Each test file is `#![cfg(target_os = "windows")]`-gated; the matrix below is
+# the Windows subset. Non-Windows files compile to empty binaries if listed, so
+# only the Windows-relevant ones are run here.
+#
+# GUI/UIA tests need an INTERACTIVE desktop session (not SSH/Session 0). On a VM,
+# drive this from Session 2 via a scheduled task with an interactive token.
+#
+# Usage:
+#   pwsh -File run-suite.ps1                 # build harness, run the matrix
+#   pwsh -File run-suite.ps1 -NoBuild        # reuse the staged harness
+#   pwsh -File run-suite.ps1 -Release        # use the release driver binary
+param(
+  [switch]$NoBuild,
+  [switch]$Release
+)
+$ErrorActionPreference = "Continue"
+
+$HarnessDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RustDir = Resolve-Path (Join-Path $HarnessDir "..\rust")
+
+$Tests = @(
+  "harness_wpf_test", "harness_winui3_test", "harness_web_test", "harness_libreoffice_test",
+  "modality_capture_mode_test", "modality_background_test", "modality_input_e2e_test",
+  "modality_desktop_scope_test", "guard_ux_test"
+)
+
+Write-Host "==> cua-driver interactive matrix — host: windows$(if($Release){' (release)'})"
+
+if (-not $NoBuild) {
+  Write-Host "==> building Windows harness…"
+  & powershell -File (Join-Path $HarnessDir "build\windows.ps1")
+}
+
+Push-Location $RustDir
+$profileArg = if ($Release) { "--release" } else { "" }
+$summary = @()
+$overall = 0
+foreach ($t in $Tests) {
+  $out = & cargo test $profileArg -p cua-driver --test $t -- --ignored --nocapture --test-threads=1 2>&1 | Out-String
+  Write-Host $out
+  $line = ($out -split "`n" | Select-String '^test result:' | Select-Object -Last 1)
+  if (-not $line) {
+    $summary += "SKIP  $t (no host tests / did not build)"
+  } else {
+    $passed = if ($line -match '(\d+) passed') { [int]$Matches[1] } else { 0 }
+    $failed = if ($line -match '(\d+) failed') { [int]$Matches[1] } else { 0 }
+    if ($failed -gt 0) { $summary += "FAIL  $t ($passed passed, $failed failed)"; $overall = 1 }
+    elseif ($passed -eq 0) { $summary += "SKIP  $t (0 tests)" }
+    else { $summary += "PASS  $t ($passed passed)" }
+  }
+}
+Pop-Location
+
+Write-Host ""
+Write-Host "================ cua-driver matrix summary (windows) ================"
+$summary | ForEach-Object { Write-Host $_ }
+Write-Host "===================================================================="
+exit $overall

--- a/libs/cua-driver/test-harness/run-suite.sh
+++ b/libs/cua-driver/test-harness/run-suite.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Run the full cua-driver interactive #[ignore] modality/harness matrix for the
+# HOST OS (macOS or Linux) in one shot, with a PASS/FAIL/SKIP summary.
+#
+# Each test file is `#![cfg(target_os = "…")]`-gated, so the non-host files
+# compile to empty binaries (0 tests) and are skipped for free — this script
+# lists the whole matrix and lets cfg pick the host's subset.
+#
+# Usage:
+#   ./run-suite.sh                 # build the host harness, run the matrix
+#   ./run-suite.sh --no-build      # skip the harness build (reuse what's staged)
+#   ./run-suite.sh --release       # use the release driver binary (default: debug)
+#   CARGO_TEST_FILTER=foo ./run-suite.sh   # only tests whose name contains foo
+#
+# Windows has its own runner: run-suite.ps1.
+set -uo pipefail
+
+HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUST_DIR="$(cd "$HARNESS_DIR/../rust" && pwd)"
+BUILD=1
+PROFILE=""
+for arg in "$@"; do
+  case "$arg" in
+    --no-build) BUILD=0 ;;
+    --release)  PROFILE="--release" ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+case "$(uname -s)" in
+  Darwin) HOST=macos ;;
+  Linux)  HOST=linux ;;
+  *) echo "run-suite.sh supports macOS + Linux; use run-suite.ps1 on Windows." >&2; exit 2 ;;
+esac
+
+# The full matrix (cfg-gated; only the host's run). Grouped by family for a
+# readable run order.
+TESTS=(
+  # harness_ (per-toolkit AX/UIA/AT-SPI/CDP)
+  harness_appkit_test harness_swiftui_test           # macOS
+  harness_gtk3_test                                  # Linux
+  harness_wpf_test harness_winui3_test harness_web_test harness_libreoffice_test  # Windows
+  # modality_ (the matrix axes)
+  modality_capture_mode_test                         # all OSes
+  modality_background_test modality_input_e2e_test   # Windows
+  modality_desktop_scope_test                        # Windows desktop scope
+  modality_desktop_scope_macos_test                  # macOS desktop scope
+  modality_desktop_scope_linux_test                  # Linux desktop scope
+  modality_focus_test                                # macOS no-focus-steal
+  # guard_
+  guard_ux_test                                      # Windows UX guards
+)
+
+echo "==> cua-driver interactive matrix — host: $HOST${PROFILE:+ (release)}"
+
+if [ "$BUILD" -eq 1 ]; then
+  echo "==> building host harness ($HOST)…"
+  bash "$HARNESS_DIR/build/$HOST.sh"
+fi
+
+cd "$RUST_DIR"
+declare -a SUMMARY
+overall=0
+for t in "${TESTS[@]}"; do
+  out=$(cargo test $PROFILE -p cua-driver --test "$t" \
+        ${CARGO_TEST_FILTER:-} -- --ignored --nocapture --test-threads=1 2>&1)
+  code=$?
+  echo "$out"
+  # Parse the last `test result:` line for this file.
+  line=$(printf '%s\n' "$out" | grep -E '^test result:' | tail -1)
+  passed=$(printf '%s' "$line" | grep -oE '[0-9]+ passed' | grep -oE '[0-9]+' || echo 0)
+  failed=$(printf '%s' "$line" | grep -oE '[0-9]+ failed' | grep -oE '[0-9]+' || echo 0)
+  if [ -z "$line" ]; then
+    SUMMARY+=("SKIP  $t (no host tests / did not build)")
+  elif [ "${failed:-0}" -gt 0 ] || [ "$code" -ne 0 ]; then
+    SUMMARY+=("FAIL  $t (${passed:-0} passed, ${failed:-0} failed)")
+    overall=1
+  elif [ "${passed:-0}" -eq 0 ]; then
+    SUMMARY+=("SKIP  $t (0 tests — not this OS)")
+  else
+    SUMMARY+=("PASS  $t (${passed} passed)")
+  fi
+done
+
+echo
+echo "================ cua-driver matrix summary ($HOST) ================"
+printf '%s\n' "${SUMMARY[@]}"
+echo "==================================================================="
+exit $overall


### PR DESCRIPTION
Adds the missing per-OS suite runners (`run-suite.sh` for macOS/Linux, `run-suite.ps1` for Windows) that build the host harness and run the full `#[ignore]` modality/harness matrix in one shot with a PASS/FAIL/SKIP summary. cfg-gating selects the host's subset automatically. Documented in TEST_SUITE.md. Foundation for running + cleanly recording the matrix per OS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added one-command test harness runners for macOS/Linux and Windows to run the full host-specific interactive test matrix.
  * Added support for skipping builds, running release builds, and filtering tests.

* **Documentation**
  * Expanded test harness docs with step-by-step guidance, expected pass/fail/skip summaries, and notes on host-platform and display requirements for CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->