### PR TITLE
docs(sandbox): avoid container wording in tutorials

### DIFF
--- a/docs/content/docs/tutorials/run-an-agent-in-a-sandbox.mdx
+++ b/docs/content/docs/tutorials/run-an-agent-in-a-sandbox.mdx
@@ -85,7 +85,7 @@ You should also see a new file named `screenshot.png` in the current directory.
 
 ## What just happened
 
-`Sandbox.ephemeral(Image.linux())` created a cloud Linux sandbox. `sb.shell.run("python3 -c 'print(1 + 1)'")` executed code inside the cloud container and returned a `CommandResult` with `stdout`, `stderr`, `returncode`, and the `success` boolean property. The script printed `result.stdout`.
+`Sandbox.ephemeral(Image.linux())` created a cloud Linux sandbox. `sb.shell.run("python3 -c 'print(1 + 1)'")` executed code inside the sandbox and returned a `CommandResult` with `stdout`, `stderr`, `returncode`, and the `success` boolean property. The script printed `result.stdout`.
 
 `sb.clipboard.set(...)` changed the sandbox desktop clipboard state. `sb.clipboard.get()` read that GUI state back as a string. `sb.screenshot()` captured the sandbox display as PNG bytes and wrote them to `screenshot.png`.
 

--- a/docs/content/docs/tutorials/your-first-cloud-sandbox.mdx
+++ b/docs/content/docs/tutorials/your-first-cloud-sandbox.mdx
@@ -74,7 +74,7 @@ You should also see a new file named `screenshot.png` in the current directory.
 
 ## What just happened
 
-`Sandbox.ephemeral(Image.linux())` created a cloud Linux container. The script ran `uname -a` inside that container, printed the command output, took a screenshot, and wrote it to `screenshot.png`.
+`Sandbox.ephemeral(Image.linux())` created a cloud Linux sandbox. The script ran `uname -a` inside that sandbox, printed the command output, took a screenshot, and wrote it to `screenshot.png`.
 
 When the `async with` block exited, **the sandbox destroyed itself**. No cleanup is needed.
 


### PR DESCRIPTION
## Summary
- Replace default cloud Linux `container` wording with `sandbox` in beginner tutorials.
- Avoid implying that `Image.linux()` always creates a container; the implementation defaults Linux images to VM kind.

## Testing
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified tutorial explanations to consistently refer to the runtime environment as a sandbox rather than a container.
  * Updated the step-by-step descriptions so the examples match the actual execution flow and output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->