### PR TITLE
docs(driver): update version examples

### DIFF
--- a/docs/content/docs/how-to-guides/driver/install.mdx
+++ b/docs/content/docs/how-to-guides/driver/install.mdx
@@ -58,14 +58,14 @@ X11 is fully supported. Native Wayland input and capture remain opt-in with `CUA
 
 ```bash
 cua-driver --version
-# cua-driver 0.5.x
+# cua-driver 0.6.x
 ```
 
 For a full environment and install report:
 
 ```bash
 cua-driver doctor
-# [ok  ] binary: cua-driver 0.5.x (aarch64-macos)
+# [ok  ] binary: cua-driver 0.6.x (aarch64-macos)
 # [ok  ] install dir: /Users/you/.local/bin/cua-driver
 # [ok  ] home dir: /Users/you/.cua-driver (3 release dirs cached)
 # ...

--- a/docs/content/docs/how-to-guides/recipes/build-a-report-in-a-native-app.mdx
+++ b/docs/content/docs/how-to-guides/recipes/build-a-report-in-a-native-app.mdx
@@ -38,7 +38,7 @@ Numbers is a **macOS-only** app with **no clean automation API** for building a 
 
     ```bash
     cua-driver --version
-    # cua-driver 0.5.x
+    # cua-driver 0.6.x
     ```
   </Step>
 

--- a/docs/content/docs/how-to-guides/recipes/fill-a-form-from-a-local-file.mdx
+++ b/docs/content/docs/how-to-guides/recipes/fill-a-form-from-a-local-file.mdx
@@ -36,7 +36,7 @@ Use this recipe when the data already lives on your machine, for example in a PD
 
     ```bash
     cua-driver --version
-    # cua-driver 0.5.x
+    # cua-driver 0.6.x
     ```
   </Step>
 


### PR DESCRIPTION
## Summary
- Update cua-driver example version output from `0.5.x` to `0.6.x` in install and recipe docs.

## Testing
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation and quick-start examples to show the latest `cua-driver` version output (`0.6.x`).
  * Refreshed sample CLI/doctor output in guides so the version checks match current behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->