### PR TITLE
fix(cua-driver/windows): reject stale element-cache snapshots

### DIFF
--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -208,6 +208,29 @@ pub(crate) fn resolve_cursor_key(args: &Value) -> String {
     NO_CURSOR.to_owned()
 }
 
+fn stale_element_snapshot_error(label: &str, element_index: usize, hwnd: u64) -> ToolResult {
+    ToolResult::error(format!(
+        "{label} [{element_index}] snapshot is stale for hwnd={hwnd}. The window moved or \
+         resized after get_window_state. Re-run get_window_state to refresh the cache."
+    ))
+}
+
+fn missing_cached_element_error(
+    cache: &ElementCache,
+    pid: u32,
+    hwnd: u64,
+    element_index: usize,
+    label: &str,
+) -> ToolResult {
+    if cache.is_snapshot_stale(pid, hwnd) {
+        stale_element_snapshot_error(label, element_index, hwnd)
+    } else {
+        ToolResult::error(format!(
+            "{label} [{element_index}] not in cache for hwnd={hwnd}. Call get_window_state first."
+        ))
+    }
+}
+
 /// Returns `true` when a click/scroll invocation should take the **window-less
 /// screen-absolute** branch: the caller gave numeric `x` AND `y`, gave NO `pid`
 /// and NO `window_id`, and the effective `capture_scope` is `"desktop"`.
@@ -2374,6 +2397,9 @@ impl Tool for ClickTool {
                     Some(ROLE_BUTTONDROPDOWN | ROLE_BUTTONMENU | ROLE_BUTTONDROPDOWNGRID | ROLE_SPLITBUTTON)
                 );
                 let (tx, ty) = if want_expand && is_dropdown_role {
+                    if self.state.element_cache.is_snapshot_stale(pid, hwnd) {
+                        return stale_element_snapshot_error("MSAA element", idx, hwnd);
+                    }
                     match self.state.element_cache.get_element_rect(pid, hwnd, idx) {
                         Some((_l, t, r, b)) => {
                             // Right-edge of the SplitButton — the dropdown
@@ -2399,10 +2425,15 @@ impl Tool for ClickTool {
                 } else {
                     match self.state.element_cache.get_element_center(pid, hwnd, idx) {
                         Some(v) => v,
-                        None => return ToolResult::error(format!(
-                            "MSAA element [{idx}] not in cache for hwnd={hwnd}. \
-                             Call get_window_state first."
-                        )),
+                        None => {
+                            return missing_cached_element_error(
+                                &self.state.element_cache,
+                                pid,
+                                hwnd,
+                                idx,
+                                "MSAA element",
+                            )
+                        }
                     }
                 };
                 pin_overlay_above(&cursor_key, hwnd);
@@ -2432,7 +2463,15 @@ impl Tool for ClickTool {
             // UIA path: get cached center (no COM call needed — captured at walk time).
             let (cx, cy) = match self.state.element_cache.get_element_center(pid, hwnd, idx) {
                 Some(v) => v,
-                None => return ToolResult::error(format!("Element {idx} not in cache for hwnd={hwnd}. Call get_window_state first.")),
+                None => {
+                    return missing_cached_element_error(
+                        &self.state.element_cache,
+                        pid,
+                        hwnd,
+                        idx,
+                        "Element",
+                    )
+                }
             };
             // NB: the off-screen guard is applied per-delivery-path below (the
             // foreground SendInput tap and the background coordinate injection),
@@ -4543,7 +4582,15 @@ impl Tool for DoubleClickTool {
         if let Some(idx) = elem_idx {
             let (cx, cy) = match self.state.element_cache.get_element_center(pid, hwnd, idx) {
                 Some(v) => v,
-                None => return ToolResult::error(format!("Element {idx} not in cache for hwnd={hwnd}. Call get_window_state first.")),
+                None => {
+                    return missing_cached_element_error(
+                        &self.state.element_cache,
+                        pid,
+                        hwnd,
+                        idx,
+                        "Element",
+                    )
+                }
             };
             let (cx, cy) = match resolve_onscreen_point_with_scroll(
                 &self.state.element_cache, pid, hwnd, idx, cx, cy, "double-clicking",
@@ -4815,7 +4862,15 @@ impl Tool for RightClickTool {
         if let Some(idx) = elem_idx {
             let (cx, cy) = match self.state.element_cache.get_element_center(pid, hwnd, idx) {
                 Some(v) => v,
-                None => return ToolResult::error(format!("Element {idx} not in cache for hwnd={hwnd}. Call get_window_state first.")),
+                None => {
+                    return missing_cached_element_error(
+                        &self.state.element_cache,
+                        pid,
+                        hwnd,
+                        idx,
+                        "Element",
+                    )
+                }
             };
             let (cx, cy) = match resolve_onscreen_point_with_scroll(
                 &self.state.element_cache, pid, hwnd, idx, cx, cy, "right-clicking",

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -7358,7 +7358,6 @@ mod chromium_flag_injection_tests {
 mod click_button_schema_tests {
     use super::ClickTool;
     use cua_driver_core::tool::Tool;
-    use std::sync::Arc;
 
     /// Surface 5: schema must keep advertising the three canonical button
     /// values. Windows was already shipping `button` (pre-Surface-5) so this

--- a/libs/cua-driver/rust/crates/platform-windows/src/uia/cache.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/uia/cache.rs
@@ -16,7 +16,11 @@
 use super::UiaNode;
 use cua_driver_core::element_cache::ElementCacheCore;
 use windows::core::Interface;
+use windows::Win32::Foundation::{HWND, RECT};
 use windows::Win32::UI::Accessibility::{IAccessible, IUIAutomationElement};
+use windows::Win32::UI::WindowsAndMessaging::GetWindowRect;
+
+type WindowRect = (i32, i32, i32, i32);
 
 /// A cached element pointer borrowed out of the cache with an extra COM
 /// `AddRef`, so it stays alive for the duration of a UIA/MSAA action even if a
@@ -101,6 +105,10 @@ pub enum SnapshotKind {
 
 pub struct CachedSnapshot {
     pub kind: SnapshotKind,
+    /// Top-level window rect (left, top, right, bottom) captured alongside the
+    /// element snapshot so follow-up actions can detect stale screen centers if
+    /// the window moved or resized after `get_window_state`.
+    pub window_rect: Option<WindowRect>,
     /// element_index → raw COM pointer (retained).
     pub elements: Vec<usize>,
     /// element_index → screen-coordinate center (captured at walk time).
@@ -137,6 +145,23 @@ impl Drop for CachedSnapshot {
     }
 }
 
+fn live_window_rect(hwnd: u64) -> Option<WindowRect> {
+    let hwnd = HWND(hwnd as *mut _);
+    let mut rect = RECT::default();
+    unsafe {
+        GetWindowRect(hwnd, &mut rect).ok()?;
+    }
+    Some((rect.left, rect.top, rect.right, rect.bottom))
+}
+
+fn snapshot_is_stale(snapshot: &CachedSnapshot, current_window_rect: Option<WindowRect>) -> bool {
+    match (snapshot.window_rect, current_window_rect) {
+        (Some(cached), Some(current)) => cached != current,
+        (Some(_), None) => true,
+        _ => false,
+    }
+}
+
 pub struct ElementCache {
     core: ElementCacheCore<CacheKey, CachedSnapshot>,
 }
@@ -162,15 +187,44 @@ impl ElementCache {
     }
 
     fn update_with_kind(&self, pid: u32, hwnd: u64, nodes: &[UiaNode], kind: SnapshotKind) {
-        let actionable: Vec<&UiaNode> = nodes.iter().filter(|n| n.element_index.is_some()).collect();
+        let actionable: Vec<&UiaNode> =
+            nodes.iter().filter(|n| n.element_index.is_some()).collect();
+        let window_rect = live_window_rect(hwnd);
         let elements: Vec<usize> = actionable.iter().map(|n| n.element_ptr).collect();
-        let centers: Vec<(i32, i32)> = actionable.iter().map(|n| (n.center_x, n.center_y)).collect();
+        let centers: Vec<(i32, i32)> = actionable
+            .iter()
+            .map(|n| (n.center_x, n.center_y))
+            .collect();
         let rects: Vec<Option<(i32, i32, i32, i32)>> = actionable.iter().map(|n| n.rect).collect();
         let msaa_roles: Vec<Option<i32>> = actionable.iter().map(|n| n.msaa_role).collect();
         self.core.insert(
             CacheKey { pid, hwnd },
-            CachedSnapshot { kind, elements, centers, rects, msaa_roles },
+            CachedSnapshot {
+                kind,
+                window_rect,
+                elements,
+                centers,
+                rects,
+                msaa_roles,
+            },
         );
+    }
+
+    fn with_fresh_snapshot<R>(
+        &self,
+        key: &CacheKey,
+        current_window_rect: Option<WindowRect>,
+        f: impl FnOnce(&CachedSnapshot) -> R,
+    ) -> Option<R> {
+        self.core
+            .with_snapshot(key, |snapshot| {
+                if snapshot_is_stale(snapshot, current_window_rect) {
+                    None
+                } else {
+                    Some(f(snapshot))
+                }
+            })
+            .flatten()
     }
 
     /// Look up + COM-`AddRef` the element for `element_index` in (pid, hwnd),
@@ -221,19 +275,31 @@ impl ElementCache {
             .flatten()
     }
 
-    pub fn get_element_center(&self, pid: u32, hwnd: u64, element_index: usize) -> Option<(i32, i32)> {
-        self.core
-            .with_snapshot(&CacheKey { pid, hwnd }, |s| s.centers.get(element_index).copied())
-            .flatten()
+    pub fn get_element_center(
+        &self,
+        pid: u32,
+        hwnd: u64,
+        element_index: usize,
+    ) -> Option<(i32, i32)> {
+        self.with_fresh_snapshot(&CacheKey { pid, hwnd }, live_window_rect(hwnd), |s| {
+            s.centers.get(element_index).copied()
+        })
+        .flatten()
     }
 
     /// Cached screen rect for the element. Used by the click tool to
     /// compute the right-edge dispatch point for `action:"expand"` on
     /// MSAA BUTTONDROPDOWN.
-    pub fn get_element_rect(&self, pid: u32, hwnd: u64, element_index: usize) -> Option<(i32, i32, i32, i32)> {
-        self.core
-            .with_snapshot(&CacheKey { pid, hwnd }, |s| s.rects.get(element_index).copied().flatten())
-            .flatten()
+    pub fn get_element_rect(
+        &self,
+        pid: u32,
+        hwnd: u64,
+        element_index: usize,
+    ) -> Option<(i32, i32, i32, i32)> {
+        self.with_fresh_snapshot(&CacheKey { pid, hwnd }, live_window_rect(hwnd), |s| {
+            s.rects.get(element_index).copied().flatten()
+        })
+        .flatten()
     }
 
     /// Kind + MSAA role for the element. `(Msaa, Some(0x38))` identifies a
@@ -258,6 +324,42 @@ impl ElementCache {
             .with_snapshot(&CacheKey { pid, hwnd }, |s| s.elements.len())
             .unwrap_or(0)
     }
+
+    pub fn is_snapshot_stale(&self, pid: u32, hwnd: u64) -> bool {
+        self.core
+            .with_snapshot(&CacheKey { pid, hwnd }, |snapshot| {
+                snapshot_is_stale(snapshot, live_window_rect(hwnd))
+            })
+            .unwrap_or(false)
+    }
+
+    #[cfg(test)]
+    fn get_element_center_for_window_rect(
+        &self,
+        pid: u32,
+        hwnd: u64,
+        element_index: usize,
+        current_window_rect: Option<WindowRect>,
+    ) -> Option<(i32, i32)> {
+        self.with_fresh_snapshot(&CacheKey { pid, hwnd }, current_window_rect, |snapshot| {
+            snapshot.centers.get(element_index).copied()
+        })
+        .flatten()
+    }
+
+    #[cfg(test)]
+    fn get_element_rect_for_window_rect(
+        &self,
+        pid: u32,
+        hwnd: u64,
+        element_index: usize,
+        current_window_rect: Option<WindowRect>,
+    ) -> Option<WindowRect> {
+        self.with_fresh_snapshot(&CacheKey { pid, hwnd }, current_window_rect, |snapshot| {
+            snapshot.rects.get(element_index).copied().flatten()
+        })
+        .flatten()
+    }
 }
 
 impl Default for ElementCache {
@@ -270,3 +372,84 @@ impl Default for ElementCache {
 #[path = "cache_uaf_repro.rs"]
 mod cache_uaf_repro;
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn insert_test_snapshot(cache: &ElementCache, key: CacheKey, window_rect: Option<WindowRect>) {
+        cache.core.insert(
+            key,
+            CachedSnapshot {
+                kind: SnapshotKind::Uia,
+                window_rect,
+                elements: vec![0],
+                centers: vec![(250, 140)],
+                rects: vec![Some((200, 120, 300, 160))],
+                msaa_roles: vec![None],
+            },
+        );
+    }
+
+    #[test]
+    fn center_lookup_stays_valid_when_window_rect_matches() {
+        let cache = ElementCache::new();
+        let key = CacheKey { pid: 7, hwnd: 11 };
+        let window_rect = Some((100, 100, 500, 400));
+        insert_test_snapshot(&cache, key, window_rect);
+
+        assert_eq!(
+            cache.get_element_center_for_window_rect(key.pid, key.hwnd, 0, window_rect),
+            Some((250, 140))
+        );
+    }
+
+    #[test]
+    fn center_lookup_fails_when_window_rect_changes() {
+        let cache = ElementCache::new();
+        let key = CacheKey { pid: 7, hwnd: 11 };
+        insert_test_snapshot(&cache, key, Some((100, 100, 500, 400)));
+
+        assert_eq!(
+            cache.get_element_center_for_window_rect(
+                key.pid,
+                key.hwnd,
+                0,
+                Some((220, 150, 620, 450)),
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn rect_lookup_fails_when_window_rect_changes() {
+        let cache = ElementCache::new();
+        let key = CacheKey { pid: 7, hwnd: 11 };
+        insert_test_snapshot(&cache, key, Some((100, 100, 500, 400)));
+
+        assert_eq!(
+            cache.get_element_rect_for_window_rect(
+                key.pid,
+                key.hwnd,
+                0,
+                Some((220, 150, 620, 450)),
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn center_and_rect_lookup_fail_when_live_window_rect_is_unavailable() {
+        let cache = ElementCache::new();
+        let key = CacheKey { pid: 7, hwnd: 11 };
+        insert_test_snapshot(&cache, key, Some((100, 100, 500, 400)));
+
+        assert_eq!(
+            cache.get_element_center_for_window_rect(key.pid, key.hwnd, 0, None),
+            None
+        );
+        assert_eq!(
+            cache.get_element_rect_for_window_rect(key.pid, key.hwnd, 0, None),
+            None
+        );
+    }
+}

--- a/libs/cua-driver/rust/crates/platform-windows/src/uia/cache_uaf_repro.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/uia/cache_uaf_repro.rs
@@ -124,6 +124,7 @@ fn snapshot_with(ptrs: Vec<usize>) -> CachedSnapshot {
     let n = ptrs.len();
     CachedSnapshot {
         kind: SnapshotKind::Uia,
+        window_rect: None,
         elements: ptrs,
         centers: vec![(0, 0); n],
         rects: vec![None; n],


### PR DESCRIPTION
## What changed

This adds a freshness guard to the Windows UIA/MSAA element cache so cached element centers and rects are no longer reused after the target window moves or resizes.

Instead of silently dispatching a click with stale screen coordinates, click-family tools now fail fast with a stale snapshot error and ask the caller to rerun `get_window_state`.

## Related issue

Fixes #1984

## Approach

- Store the top-level window rect alongside each cached Windows element snapshot.
- Treat cached centers/rects as stale when the current `GetWindowRect` no longer matches the captured rect.
- Surface a specific stale-snapshot error from `click`, `double_click`, and `right_click` instead of the old generic cache-miss message.
- Add regression tests for both center and rect lookups when the window rect changes.

## Testing

- `cargo test -p platform-windows`

## Notes

This is the smaller fail-fast variant discussed in #1984. It does not try to auto-refresh the snapshot or hook window-move events yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of window changes during click actions, with clearer guidance when a refreshed snapshot is needed.
  * Added better detection of outdated cached UI state so interactions can be retried more reliably.

* **Bug Fixes**
  * Fixed inconsistent error messages when elements were missing from cache.
  * Reduced failures caused by stale window snapshots after a window moves or resizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->