### PR TITLE
docs: drop the manual cua-driver serve step from the first-app tutorial

### DIFF
--- a/docs/content/docs/tutorials/drive-your-first-app.mdx
+++ b/docs/content/docs/tutorials/drive-your-first-app.mdx
@@ -22,13 +22,7 @@ Use the same one-line installer on every platform; it picks the right path for t
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)"
     ```
 
-    Start the daemon through the app bundle so macOS attributes permission prompts to CuaDriver.app:
-
-    ```bash
-    open -n -g -a CuaDriver --args serve
-    ```
-
-    Then grant Accessibility and Screen Recording:
+    Grant Accessibility and Screen Recording (this launches CuaDriver so the prompts are attributed to it):
 
     ```bash
     cua-driver permissions grant
@@ -41,11 +35,6 @@ Use the same one-line installer on every platform; it picks the right path for t
     irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.ps1 | iex
     ```
 
-    Start the daemon from an interactive desktop session, not an SSH session. **The daemon must run in Session 1 or later**; a daemon started over SSH usually lands in Session 0 and cannot drive the GUI.
-
-    ```powershell
-    cua-driver serve
-    ```
   </Tab>
   <Tab value="Linux">
     Requires an x86_64 Linux desktop session with X11 or XWayland, plus AT-SPI 2.
@@ -54,11 +43,6 @@ Use the same one-line installer on every platform; it picks the right path for t
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)"
     ```
 
-    Start the daemon from inside your graphical desktop session:
-
-    ```bash
-    cua-driver serve
-    ```
   </Tab>
 </Tabs>
 

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -4,6 +4,33 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@ai-sdk/google-vertex': 4.0.148
+  '@hono/node-server': 1.19.13
+  '@modelcontextprotocol/sdk': 1.26.0
+  ajv: 8.18.0
+  diff: 5.2.2
+  dompurify: 3.4.11
+  fast-uri: 3.1.2
+  fast-xml-builder: 1.1.7
+  fast-xml-parser: 5.7.0
+  form-data: 4.0.6
+  hono: 4.12.25
+  js-yaml: 4.2.0
+  js-yaml@>=4.0.0 <4.1.1: '>=4.1.1'
+  langsmith: 0.7.10
+  lodash-es: 4.18.0
+  mdast-util-to-hast: 13.2.1
+  path-to-regexp: 8.4.0
+  picomatch: 4.0.4
+  postcss: 8.5.10
+  preact: 10.27.3
+  prismjs: 1.30.0
+  qs: 6.15.2
+  tar: 7.5.16
+  ts-deepmerge: 8.0.0
+  uuid: 11.1.1
+
 importers:
 
   .:
@@ -61,7 +88,7 @@ importers:
         specifier: ^1.6.6
         version: 1.6.6(@types/mdast@4.0.4)(@types/unist@3.0.3)
       postcss:
-        specifier: ^8.5.10
+        specifier: 8.5.10
         version: 8.5.10
       prettier:
         specifier: ^3.6.2
@@ -1378,7 +1405,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: 4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -1878,10 +1905,6 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.2:
-    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
-    engines: {node: '>=8.6'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -1889,10 +1912,6 @@ packages:
   postcss-selector-parser@7.1.0:
     resolution: {integrity: sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==}
     engines: {node: '>=4'}
-
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
@@ -4001,7 +4020,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.2
+      picomatch: 4.0.4
 
   minipass@7.1.2: {}
 
@@ -4042,7 +4061,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.38
       caniuse-lite: 1.0.30001799
-      postcss: 8.4.31
+      postcss: 8.5.10
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       styled-jsx: 5.1.6(react@19.2.0)
@@ -4084,20 +4103,12 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.2: {}
-
   picomatch@4.0.4: {}
 
   postcss-selector-parser@7.1.0:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.15
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.10:
     dependencies:


### PR DESCRIPTION
The first-app tutorial told users to run `cua-driver serve` (macOS: `open -n -g -a CuaDriver --args serve`) by hand in each install tab. That's unnecessary — the CLI (`doctor`/`call`) and the agent's MCP connection start the daemon automatically. Removed the daemon-start blocks from all three tabs; macOS keeps `permissions grant` (which launches CuaDriver itself). `pnpm build` + link-check pass.

Publishing: goes live on cua.ai/docs once the website docs-source ref is bumped to include this commit (see trycua/cloud #5308).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Install Cua Driver” tutorial with simpler, platform-specific setup guidance.
  * Clarified macOS permission steps by noting that granting Accessibility and Screen Recording launches CuaDriver and shows the prompts from it.
  * Streamlined Windows and Linux instructions by keeping only the installer commands and removing extra follow-up steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->