### PR TITLE
fix(linux): return structured launch_app result

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -722,13 +722,21 @@ impl Tool for LaunchAppTool {
             return ToolResult::error("Provide at least one of: launch_path, name, or urls.");
         }
 
-        let result = tokio::task::spawn_blocking(move || -> anyhow::Result<String> {
+        let result = tokio::task::spawn_blocking(move || -> anyhow::Result<(
+            String,
+            Option<u32>,
+            String,
+        )> {
             // Open URLs via xdg-open.
             if !urls.is_empty() {
                 for url in &urls {
                     std::process::Command::new("xdg-open").arg(url).spawn()?;
                 }
-                return Ok(format!("Opened {} URL(s) via xdg-open.", urls.len()));
+                return Ok((
+                    format!("Opened {} URL(s) via xdg-open.", urls.len()),
+                    None,
+                    "xdg-open".to_owned(),
+                ));
             }
             // launch_path > name. Both go through the same direct-exec path
             // (so XDG `Exec=` commands round-trip), but launch_path is the
@@ -739,19 +747,56 @@ impl Tool for LaunchAppTool {
                 let prog = parts.next().unwrap_or(cmd);
                 let rest: Vec<&str> = parts.collect();
                 match std::process::Command::new(prog).args(&rest).spawn() {
-                    Ok(child) => return Ok(format!("Launched '{}' with pid {}.", cmd, child.id())),
+                    Ok(child) => {
+                        let pid = child.id();
+                        return Ok((
+                            format!("✅ Launched {cmd} (pid {pid}) in background."),
+                            Some(pid),
+                            cmd.to_owned(),
+                        ));
+                    }
                     Err(_) => {
-                        // Fall back to xdg-open for .desktop app names.
+                        // Fall back to xdg-open for .desktop app names. xdg-open may
+                        // spawn a helper and exit, so do not claim its pid is the app pid.
                         std::process::Command::new("xdg-open").arg(cmd).spawn()?;
-                        return Ok(format!("Opened '{}' via xdg-open.", cmd));
+                        return Ok((
+                            format!("Opened '{cmd}' via xdg-open."),
+                            None,
+                            cmd.to_owned(),
+                        ));
                     }
                 }
             }
             unreachable!()
-        }).await;
+        })
+        .await;
 
         match result {
-            Ok(Ok(msg)) => ToolResult::text(msg),
+            Ok(Ok((message, pid_opt, name))) => {
+                if let Some(pid) = pid_opt {
+                    let windows = crate::x11::list_windows(Some(pid))
+                        .iter()
+                        .map(window_record_json)
+                        .collect::<Vec<_>>();
+                    ToolResult::text(message).with_structured(json!({
+                        "pid": pid,
+                        "bundle_id": Value::Null,
+                        "name": name,
+                        "running": true,
+                        "active": false,
+                        "windows": windows,
+                    }))
+                } else {
+                    ToolResult::text(message).with_structured(json!({
+                        "pid": Value::Null,
+                        "bundle_id": Value::Null,
+                        "name": name,
+                        "running": Value::Null,
+                        "active": false,
+                        "windows": [],
+                    }))
+                }
+            }
             Ok(Err(e)) => ToolResult::error(format!("Failed to launch: {e}")),
             Err(e) => ToolResult::error(format!("Task error: {e}")),
         }

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -774,10 +774,14 @@ impl Tool for LaunchAppTool {
         match result {
             Ok(Ok((message, pid_opt, name))) => {
                 if let Some(pid) = pid_opt {
-                    let windows = crate::x11::list_windows(Some(pid))
-                        .iter()
-                        .map(window_record_json)
-                        .collect::<Vec<_>>();
+                    let windows = tokio::task::spawn_blocking(move || {
+                        crate::x11::list_windows(Some(pid))
+                            .iter()
+                            .map(window_record_json)
+                            .collect::<Vec<_>>()
+                    })
+                    .await
+                    .unwrap_or_default();
                     ToolResult::text(message).with_structured(json!({
                         "pid": pid,
                         "bundle_id": Value::Null,


### PR DESCRIPTION
## Summary

Fix Linux `launch_app` direct executable launches so they return launch identity in MCP `structuredContent`, not only in the human text response.

For direct executable launches, Linux now returns:

```json
{
  "pid": 12345,
  "bundle_id": null,
  "name": "sleep 30",
  "running": true,
  "active": false,
  "windows": []
}
```

## Why

Fixes #2090.

Before this change, Linux already had the child PID from `std::process::Command::spawn()`, but only emitted it in prose like `Launched '<cmd>' with pid <pid>.` macOS and Windows expose launch identity through structured content, so typed MCP clients can read the PID without parsing text.

## Scope

- Direct executable launches now attach structured launch identity.
- `xdg-open` fallback remains conservative and returns `pid: null`, because that helper may exit after spawning something else.
- URL-only launch behavior remains conservative and does not claim a target app PID.

## Verification

- Not run locally in this checkout. This machine is macOS, and a direct local `cargo check -p platform-linux` is not a valid Linux gate because Linux modules are cfg-gated. A Linux container check was attempted, but Docker daemon was unavailable locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On Linux, opening apps, paths, and URLs now returns richer structured results (not plain text).
  * Successful launches may include the process ID and an associated list of detected windows.
  * If a direct process launch fails, results now explicitly reflect that the system default handler (e.g., `xdg-open`) was used.

* **Bug Fixes**
  * Improved consistency of launch response shape across different open methods, including always returning the structured payload on success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->