### PR TITLE
fix(cua-driver-python): bump wrapper to 0.7.0

### DIFF
--- a/libs/cua-driver/python/build_wheel.py
+++ b/libs/cua-driver/python/build_wheel.py
@@ -246,8 +246,8 @@ def main():
     parser = argparse.ArgumentParser(description="Build cua-driver Python wheel with bundled binary")
     parser.add_argument(
         "--version",
-        default="0.5.1",
-        help="cua-driver-rs version to download (default: 0.5.1)",
+        default="0.7.0",
+        help="cua-driver-rs version to download (default: 0.7.0)",
     )
     parser.add_argument(
         "--arch",

--- a/libs/cua-driver/python/pyproject.toml
+++ b/libs/cua-driver/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cua-driver"
-version = "0.5.1"
+version = "0.7.0"
 description = "Python wrapper for cua-driver - cross-platform MCP server for computer-use automation"
 readme = "README.md"
 license = "MIT"
@@ -35,6 +35,9 @@ classifiers = [
 requires-python = ">=3.10"
 
 dependencies = []
+
+[project.optional-dependencies]
+test = ["pytest"]
 
 [project.urls]
 Homepage = "https://github.com/trycua/cua"

--- a/libs/cua-driver/python/src/cua_driver/__init__.py
+++ b/libs/cua-driver/python/src/cua_driver/__init__.py
@@ -4,7 +4,7 @@ This package provides a thin Python wrapper around the cua-driver Rust binary,
 enabling pip-installable access to the MCP server for computer-use automation.
 """
 
-__version__ = "0.5.1"
+__version__ = "0.7.0"
 
 from .wrapper import run_cua_driver, get_binary_path
 


### PR DESCRIPTION
Updates the Python cua-driver wrapper package metadata and wheel build default to match the cua-driver-rs 0.7.0 release. Also adds a `test` optional dependency extra so wrapper tests can be installed with `pip install -e '.[test]'`.\n\nValidation:\n- `cd libs/cua-driver/python && python3 -m venv .venv`\n- `. .venv/bin/activate && python -m pip install -e '.[test]'`\n- `python -m pytest tests -v` → 2 passed, 3 skipped (binary not bundled), 1 warning (root pyproject unknown asyncio_mode).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the Python package version to **0.7.0** across the build metadata and package info.
  * Updated the wheel build command’s default **version** output to match the new release.
  * Added an optional **test** extra dependency (includes **pytest**).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->