### PR TITLE
fix(docs): surface doc actions (Ask AI / chat) on mobile

### DIFF
--- a/docs/src/app/(docs)/[[...slug]]/page.tsx
+++ b/docs/src/app/(docs)/[[...slug]]/page.tsx
@@ -172,16 +172,15 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
     );
   };
 
-  const tocFooter = () => {
-    // Construct file path from slug
-    const filePath = slug.length === 0 ? 'index.mdx' : `${slug.join('/')}.mdx`;
+  // Construct file path from slug; shared by the TOC footer (desktop) and the
+  // mobile actions block below.
+  const filePath = slug.length === 0 ? 'index.mdx' : `${slug.join('/')}.mdx`;
 
-    return (
-      <div className="mt-4">
-        <DocActionsMenu pageUrl={page.url} pageTitle={page.data.title} filePath={filePath} />
-      </div>
-    );
-  };
+  const tocFooter = () => (
+    <div className="mt-4">
+      <DocActionsMenu pageUrl={page.url} pageTitle={page.data.title} filePath={filePath} />
+    </div>
+  );
 
   return (
     <DocsPage
@@ -253,6 +252,13 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
             </div>
           </div>
           <DocsDescription className="text-md mt-1">{page.data.description}</DocsDescription>
+          {/* The doc actions (Copy as markdown, Edit on GitHub, Open in ChatGPT /
+              Claude) normally live in the TOC footer, which fumadocs hides on
+              small screens. Surface them inline here so they stay reachable on
+              mobile; hidden at xl where the TOC and its footer are visible. */}
+          <div className="mt-4 border-t border-fd-border pt-3 xl:hidden">
+            <DocActionsMenu pageUrl={page.url} pageTitle={page.data.title} filePath={filePath} />
+          </div>
         </div>
       </div>
       <DocsBody>


### PR DESCRIPTION
## Problem
The doc actions menu — **Copy as markdown**, **Edit on GitHub**, **Open in ChatGPT**, **Open in Claude** — is rendered in the fumadocs `tableOfContent` **footer**. fumadocs hides the right-hand TOC panel on small screens, so on mobile those actions (including the "open in ChatGPT/Claude" chat buttons) are **completely unreachable**.

## Fix
Render an inline copy of `DocActionsMenu` under the page description, shown only below the `xl` breakpoint (where the TOC footer is hidden). At `xl`+ the TOC footer reappears and the inline copy hides, so there's no duplication on desktop. `filePath` is lifted to the render scope so both instances share one definition.

`docs/src/app/(docs)/[[...slug]]/page.tsx` only — no new deps.

## Verify
- Mobile / narrow viewport: the actions now appear as a bordered block under the page title+description.
- Desktop (`xl`+): unchanged — actions stay in the TOC footer, inline copy hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mobile-friendly docs actions menu near the page header, making actions easier to access on smaller screens.
  * Kept the existing docs actions footer behavior for larger screens, improving consistency across layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->