### PR TITLE
docs: restore the macOS open -a CuaDriver … serve step in the first-app tutorial

### DIFF
--- a/docs/content/docs/tutorials/drive-your-first-app.mdx
+++ b/docs/content/docs/tutorials/drive-your-first-app.mdx
@@ -22,7 +22,13 @@ Use the same one-line installer on every platform; it picks the right path for t
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)"
     ```
 
-    Grant Accessibility and Screen Recording (this launches CuaDriver so the prompts are attributed to it):
+    Start the daemon through the app bundle so macOS attributes permission prompts to CuaDriver.app — this is what makes the TCC grant stick to the driver:
+
+    ```bash
+    open -n -g -a CuaDriver --args serve
+    ```
+
+    Then grant Accessibility and Screen Recording:
 
     ```bash
     cua-driver permissions grant


### PR DESCRIPTION
Partially reverts #2087 for macOS only. That PR dropped the manual `open -n -g -a CuaDriver --args serve` step, but on macOS launching the daemon through the app bundle is what makes the TCC grant attribute to CuaDriver.app (`com.trycua.driver`) and register in System Settings — `permissions grant` alone isn't a reliable substitute in practice. Restored the step (with a note on *why*); Windows/Linux tabs stay as #2087 left them (no TCC). Content-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the macOS setup guide with an additional step to start the driver daemon before granting permissions.
  * Clarified the flow for enabling Accessibility and Screen Recording permissions so prompts appear correctly during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->