### PR TITLE
[codex] Document Codex cua-driver onboarding

### DIFF
--- a/docs/content/docs/how-to-guides/driver/connect-your-agent.mdx
+++ b/docs/content/docs/how-to-guides/driver/connect-your-agent.mdx
@@ -12,7 +12,7 @@ import { Callout } from 'fumadocs-ui/components/callout';
 </Callout>
 
 <Callout type="warn">
-  Grant the required permissions before you connect an agent. On macOS, grant Accessibility and Screen Recording. Verify them with `cua-driver call check_permissions`.
+  Grant the required permissions before you connect an agent. On macOS, grant Accessibility and Screen Recording. Verify them with `cua-driver permissions status`.
 </Callout>
 
 The helper command prints the exact registration snippet for each supported client:
@@ -60,16 +60,38 @@ This registers the server under the key `cua-computer-use` at user scope, so it 
 
 ## Codex
 
-Register the stdio server:
+Print the Codex registration command:
 
 ```bash
-codex mcp add cua-driver -- cua-driver mcp
+cua-driver mcp-config --client codex
+```
+
+It emits a command with the absolute installed binary path, which avoids PATH issues in app-launched Codex sessions:
+
+```bash
+codex mcp add cua-driver -- /Users/you/.local/bin/cua-driver mcp
 ```
 
 Verify:
 
 ```bash
 codex mcp list
+```
+
+Restart Codex or open a fresh Codex session after adding the MCP server so the new tools appear.
+
+Optionally install the Codex skill pack:
+
+```bash
+cua-driver skills install
+cua-driver skills status
+```
+
+If the Codex agent skills directory is missing, create it and install again:
+
+```bash
+mkdir -p ~/.agents/skills
+cua-driver skills install
 ```
 
 ## Cursor

--- a/docs/content/docs/how-to-guides/driver/connect-your-agent.mdx
+++ b/docs/content/docs/how-to-guides/driver/connect-your-agent.mdx
@@ -80,7 +80,7 @@ codex mcp list
 
 Restart Codex or open a fresh Codex session after adding the MCP server so the new tools appear.
 
-Optionally install the Codex skill pack:
+For the best experience, also install the Cua Driver skill:
 
 ```bash
 cua-driver skills install

--- a/docs/content/docs/tutorials/drive-your-first-app.mdx
+++ b/docs/content/docs/tutorials/drive-your-first-app.mdx
@@ -103,11 +103,13 @@ Register Cua Driver with your agent harness once.
     cua-driver mcp-config --client codex
     ```
 
-    It prints a command you run to register the server:
+    It prints a command you run to register the server. The emitted command uses the absolute installed binary path:
 
     ```bash
-    codex mcp add cua-driver -- cua-driver mcp
+    codex mcp add cua-driver -- /Users/you/.local/bin/cua-driver mcp
     ```
+
+    Restart Codex or open a fresh Codex session after registration so the new tools appear.
   </Tab>
   <Tab value="Hermes">
     Print the Hermes snippet:


### PR DESCRIPTION
## Summary

- update Codex MCP setup docs to use `cua-driver mcp-config --client codex`
- mention that Codex needs a fresh session after MCP registration
- document the optional Codex skill-pack directory fallback
- point macOS permission verification at `cua-driver permissions status`

## Why

These notes cover friction hit during a real first-run setup: PATH-sensitive MCP registration, session reload expectations, and the missing `~/.agents/skills` directory for the optional skill pack.

## Validation

- reviewed docs diff for secrets and local machine details
- `pnpm exec prettier --check docs/content/docs/how-to-guides/driver/connect-your-agent.mdx docs/content/docs/tutorials/drive-your-first-app.mdx`
- docs-only change; no runtime tests run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the agent connection guides with the latest macOS permission check command.
  * Improved Codex setup steps to generate the correct registration command automatically, including support for an installed binary path.
  * Added clearer guidance for restarting Codex after registration so new tools appear.
  * Expanded setup instructions to verify the Cua Driver skill and handle missing Codex skill directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->