### PR TITLE
[codex] Reset cua-driver TCC grants on uninstall

### DIFF
--- a/libs/cua-driver/scripts/uninstall.sh
+++ b/libs/cua-driver/scripts/uninstall.sh
@@ -47,9 +47,9 @@
 # Also scrubs Claude MCP registrations in ~/.claude.json that match
 # the active backend.
 #
-# Does NOT revoke TCC grants on macOS (Accessibility + Screen Recording).
-# The closing message points at the tccutil commands for a clean
-# re-install flow.
+# Revokes TCC grants on macOS by default (Accessibility + Screen Recording)
+# so the next install prompts cleanly under the new signing identity. Pass
+# --keep-tcc to preserve grants across uninstall/reinstall.
 #
 # Usage:
 #   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.sh)"
@@ -64,7 +64,7 @@ set -euo pipefail
 # flag flows through without edits.
 # ----------------------------------------------------------------------
 USE_RUST_BACKEND=1
-RESET_TCC=0
+RESET_TCC=1
 FORWARDED_ARGS=()
 PASSTHROUGH=0
 while [[ $# -gt 0 ]]; do
@@ -75,7 +75,8 @@ while [[ $# -gt 0 ]]; do
         --experimental-rust) shift ;;  # legacy alias for default Rust path
         --backend=rust)      shift ;;
         --backend=swift)     shift ;;  # retired Swift (no-op)
-        --reset-tcc)         RESET_TCC=1; shift ;;  # also revoke TCC grants (opt-in)
+        --reset-tcc)         RESET_TCC=1; shift ;;  # legacy/explicit default: revoke TCC grants
+        --keep-tcc)          RESET_TCC=0; shift ;;  # preserve TCC grants across reinstall
         --backend=*)
             printf 'error: unknown backend %q; supported: rust\n' "${1#*=}" >&2
             exit 2
@@ -100,25 +101,25 @@ fi
 # ----------------------------------------------------------------------
 log() { printf '==> %s\n' "$*"; }
 
-# Opt-in TCC revocation (`--reset-tcc`). Off by default: the bundle id
-# com.trycua.driver is shared with the retired Swift driver, and keeping
-# grants across a reinstall avoids a re-prompt — so wiping privacy state
-# is a deliberate, explicit choice, not a side effect of uninstall.
-# When the flag is set, revoke Accessibility + Screen-Recording +
-# Automation for com.trycua.driver. macOS-only; no-op elsewhere.
+# TCC revocation is on by default so uninstall leaves the next macOS install
+# in a clean promptable state. The bundle id com.trycua.driver is shared with
+# the retired Swift driver, so `--keep-tcc` remains available for users who
+# intentionally want grants to survive uninstall/reinstall.
+# When enabled, revoke Accessibility + Screen-Recording + Automation for
+# com.trycua.driver. macOS-only; no-op elsewhere.
 maybe_reset_tcc() {
     [[ "$RESET_TCC" == "1" ]] || return 0
     if [[ "$OS" != "Darwin" ]]; then
-        log "--reset-tcc is macOS-only; nothing to revoke on $OS"
+        log "TCC reset is macOS-only; nothing to revoke on $OS"
         return 0
     fi
     if ! command -v tccutil >/dev/null 2>&1; then
-        log "--reset-tcc: tccutil not found; skipping"
+        log "TCC reset: tccutil not found; skipping"
         return 0
     fi
-    log "revoking TCC grants for com.trycua.driver (--reset-tcc)"
+    log "revoking TCC grants for com.trycua.driver"
     log "  note: com.trycua.driver is shared with the retired Swift driver;"
-    log "  this clears grants for both. The next launch will re-prompt."
+    log "  this clears grants for both. Pass --keep-tcc to preserve them."
     for SVC in Accessibility ScreenCapture AppleEvents; do
         if tccutil reset "$SVC" com.trycua.driver >/dev/null 2>&1; then
             log "  reset $SVC"
@@ -514,8 +515,8 @@ PY
             cat << 'FINALUNMSG'
 
 TCC grants (Accessibility + Screen Recording) remain in System
-Settings > Privacy & Security. Reset them explicitly — or re-run with
---reset-tcc — if you want a clean re-install flow:
+Settings > Privacy & Security because uninstall was run with --keep-tcc.
+Reset them explicitly if you want a clean re-install flow:
 
   tccutil reset Accessibility com.trycua.driver
   tccutil reset ScreenCapture com.trycua.driver
@@ -744,8 +745,8 @@ if [[ "$RESET_TCC" != "1" ]]; then
     cat << 'FINALUNMSG'
 
 TCC grants (Accessibility + Screen Recording) remain in System
-Settings > Privacy & Security. Reset them explicitly — or re-run with
---reset-tcc — if you want a clean re-install flow:
+Settings > Privacy & Security because uninstall was run with --keep-tcc.
+Reset them explicitly if you want a clean re-install flow:
 
   tccutil reset Accessibility com.trycua.driver
   tccutil reset ScreenCapture com.trycua.driver


### PR DESCRIPTION
## Summary
- Reset macOS TCC grants by default during `cua-driver` uninstall so the next install starts from a clean permission state.
- Add `--keep-tcc` to preserve the previous behavior when users intentionally want grants to survive reinstall.
- Update uninstall messaging to explain when grants are preserved.

## Why
A release install and a later local install share the `com.trycua.driver` bundle id but can use different signing identities. Leaving old TCC rows behind can make System Settings look granted while a new build still reads as ungranted.

## Validation
- `bash -n libs/cua-driver/scripts/uninstall.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Uninstall now revokes macOS Accessibility and Screen Recording permissions by default.
  * Added a clear option to keep these permissions during uninstall when needed.
  * Updated uninstall messages to better explain whether privacy grants were removed or preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->