### PR TITLE
[codex] Add System Events permission handling

### DIFF
--- a/docs/content/docs/how-to-guides/driver/connect-your-agent.mdx
+++ b/docs/content/docs/how-to-guides/driver/connect-your-agent.mdx
@@ -12,7 +12,7 @@ import { Callout } from 'fumadocs-ui/components/callout';
 </Callout>
 
 <Callout type="warn">
-  Grant the required permissions before you connect an agent. On macOS, grant Accessibility and Screen Recording. Verify them with `cua-driver permissions status`.
+  Grant the required permissions before you connect an agent. On macOS, grant Accessibility, Screen Recording, and Automation access to System Events. Verify them with `cua-driver permissions status`.
 </Callout>
 
 The helper command prints the exact registration snippet for each supported client:

--- a/docs/content/docs/how-to-guides/driver/install.mdx
+++ b/docs/content/docs/how-to-guides/driver/install.mdx
@@ -17,7 +17,7 @@ Cua Driver supports macOS, Windows, and Linux. Use the same **one-line installer
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)"
 ```
 
-The installer places `CuaDriver.app` in `/Applications` and creates the `~/.local/bin/cua-driver` symlink. The app bundle uses the `com.trycua.driver` signing identity, so macOS TCC permissions for Accessibility and Screen Recording remain attached across upgrades.
+The installer places `CuaDriver.app` in `/Applications` and creates the `~/.local/bin/cua-driver` symlink. The app bundle uses the `com.trycua.driver` signing identity, so macOS TCC permissions for Accessibility, Screen Recording, and Automation access to System Events remain attached across upgrades.
 
 If `~/.local/bin` is missing from your PATH, the installer detects your shell (`zsh`, `bash`, or `fish`) and adds the matching `export PATH=…` line to your rc file. Reload the shell with `source ~/.zshrc` or open a new terminal window.
 
@@ -93,7 +93,7 @@ Then grant both permissions:
 cua-driver permissions grant
 ```
 
-That command launches CuaDriver through LaunchServices and waits while you approve Accessibility and Screen Recording in the macOS dialogs.
+That command launches CuaDriver through LaunchServices and waits while you approve Accessibility, Screen Recording, and Automation access to System Events in the macOS dialogs.
 
 You can also trigger the prompts yourself:
 
@@ -101,7 +101,7 @@ You can also trigger the prompts yourself:
 cua-driver check_permissions
 ```
 
-macOS opens the Accessibility and Screen Recording prompts. Grant both permissions, then run the check again:
+macOS opens the Accessibility, Screen Recording, and System Events Automation prompts. Grant each permission, then run the check again:
 
 ```bash
 cua-driver permissions status

--- a/docs/content/docs/how-to-guides/driver/keep-running.mdx
+++ b/docs/content/docs/how-to-guides/driver/keep-running.mdx
@@ -49,7 +49,7 @@ launchctl load ~/Library/LaunchAgents/com.trycua.cua-driver.plist
 ```
 
 <Callout type="info">
-  A LaunchAgent daemon starts under `launchd` and is attributed to `com.trycua.driver`. Grant Accessibility and Screen Recording once, and those grants persist across reboots. If you start prompts from a terminal without a LaunchAgent, macOS attributes them to the terminal instead of the driver, so the grants do not apply to Cua Driver.
+  A LaunchAgent daemon starts under `launchd` and is attributed to `com.trycua.driver`. Grant Accessibility, Screen Recording, and Automation access to System Events once, and those grants persist across reboots. If you start prompts from a terminal without a LaunchAgent, macOS attributes them to the terminal instead of the driver, so the grants do not apply to Cua Driver.
 </Callout>
 
   </Tab>

--- a/docs/content/docs/how-to-guides/recipes/build-a-report-in-a-native-app.mdx
+++ b/docs/content/docs/how-to-guides/recipes/build-a-report-in-a-native-app.mdx
@@ -45,7 +45,7 @@ Numbers is a **macOS-only** app with **no clean automation API** for building a 
   <Step>
     ### Grant macOS permissions
 
-    Grant Accessibility and Screen Recording to the driver, then verify both grants:
+    Grant Accessibility, Screen Recording, and Automation access to System Events to the driver, then verify the grants:
 
     ```bash
     cua-driver permissions status

--- a/docs/content/docs/how-to-guides/recipes/export-contacts-overnight.mdx
+++ b/docs/content/docs/how-to-guides/recipes/export-contacts-overnight.mdx
@@ -44,7 +44,7 @@ cua-driver --version
 
 ### Grant macOS permissions
 
-On macOS, grant Accessibility and Screen Recording. Then verify the driver can see its permission state:
+On macOS, grant Accessibility, Screen Recording, and Automation access to System Events. Then verify the driver can see its permission state:
 
 ```bash
 cua-driver permissions status

--- a/docs/content/docs/how-to-guides/recipes/fill-a-form-from-a-local-file.mdx
+++ b/docs/content/docs/how-to-guides/recipes/fill-a-form-from-a-local-file.mdx
@@ -43,7 +43,7 @@ Use this recipe when the data already lives on your machine, for example in a PD
   <Step>
     ### Grant desktop permissions
 
-    On macOS, grant Accessibility and Screen Recording so Cua Driver can inspect windows, click controls, and type into apps.
+    On macOS, grant Accessibility, Screen Recording, and Automation access to System Events so Cua Driver can inspect windows, click controls, and type into apps.
 
     ```bash
     cua-driver permissions grant

--- a/docs/content/docs/reference/cua-driver/limits.mdx
+++ b/docs/content/docs/reference/cua-driver/limits.mdx
@@ -109,11 +109,12 @@ Cua Driver's *no-foreground contract* holds for every app it reaches via AX or a
 
 ## Permission boundaries
 
-Cua Driver is constrained by the macOS permission model. Two relevant grants:
+Cua Driver is constrained by the macOS permission model. Three relevant grants:
 
 | Grant | Required for |
 | ----- | ------------ |
 | **Accessibility** (System Settings → Privacy & Security → Accessibility) | Every AX read, every element-indexed click, every keyboard/text primitive. Without it, `check_permissions` returns `accessibility: false` and every tool returns a structured error. |
 | **Screen Recording** | Screenshots. `get_window_state` returns both the accessibility tree and a screenshot by default; without this grant it returns the tree only (no PNG). The tree path still works. |
+| **Automation → System Events** | Apple Events-backed flows that ask System Events for process/menu state. Without it, `check_permissions` returns `system_events: false` and macOS may show “CuaDriver wants access to control System Events.” |
 
 Grants are tied to the `CuaDriver.app` bundle identity (`com.trycua.driver`). The Rust build and installer preserve this identity, so TCC grants persist across rebuilds and updates.

--- a/docs/content/docs/reference/cua-driver/macos-permissions.mdx
+++ b/docs/content/docs/reference/cua-driver/macos-permissions.mdx
@@ -1,18 +1,20 @@
 ---
 title: macOS Permissions
-description: The macOS-only `cua-driver permissions` command for inspecting and requesting Accessibility and Screen Recording TCC grants.
+description: The macOS-only `cua-driver permissions` command for inspecting and requesting Accessibility, Screen Recording, and System Events Automation TCC grants.
 ---
 
 `cua-driver permissions` is a macOS-only command. It is not part of the auto-generated [CLI reference](/reference/cua-driver/cli-reference) because it has no Windows or Linux counterpart, so it is documented here.
 
 ## `cua-driver permissions` (macOS)
 
-Inspect or request the macOS TCC grants the driver needs (Accessibility and Screen Recording).
+Inspect or request the macOS TCC grants the driver needs (Accessibility, Screen Recording, and Automation access to System Events).
 
 ```bash
 cua-driver permissions status   # report grant status; read-only, no prompt
 cua-driver permissions grant    # launch CuaDriver via LaunchServices so the prompt attributes to the app
 ```
+
+System Events appears under System Settings → Privacy & Security → Automation. macOS phrases that dialog as “CuaDriver wants access to control System Events”; approve it for `CuaDriver.app`.
 
 **Flags:**
 

--- a/docs/content/docs/reference/cua-driver/mcp-tools.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools.mdx
@@ -668,9 +668,9 @@ All parameters are optional; omit any you do not want to change.
 
 ### `check_permissions`
 
-Report TCC permission status for Accessibility and Screen Recording. By default also raises the system permission dialogs for any missing grants — Apple's request APIs are no-ops when the grant is already active, so this is safe to call repeatedly. Pass &#123;"prompt": false&#125; for a purely read-only status check.
+Report TCC permission status for Accessibility, Screen Recording, and Automation access to System Events. By default also raises the system permission dialogs for any missing grants — Apple's request APIs are no-ops when the grant is already active, so this is safe to call repeatedly. Pass &#123;"prompt": false&#125; for a purely read-only status check.
 
-Returns: `accessibility` + `screen_recording` (booleans from the TCC preflight APIs), `screen_recording_capturable` (a live ScreenCaptureKit probe — if it disagrees with `screen_recording`, the preflight grant belongs to a different process), and `source` (which TCC identity the booleans reflect: the CuaDriver daemon vs the launching terminal/IDE). macOS attributes grants to the responsible process, so a standalone call from a terminal reports the terminal's grants, not the driver's.
+Returns: `accessibility` + `screen_recording` + `system_events` (booleans from the TCC preflight APIs), `screen_recording_capturable` (a live ScreenCaptureKit probe — if it disagrees with `screen_recording`, the preflight grant belongs to a different process), and `source` (which TCC identity the booleans reflect: the CuaDriver daemon vs the launching terminal/IDE). macOS attributes grants to the responsible process, so a standalone call from a terminal reports the terminal's grants, not the driver's.
 
 **Arguments:**
 
@@ -690,7 +690,7 @@ If both are given, `include` wins.
 Canonical check names:
   macOS  : binary_version, platform_supported, session_active,
            bundle_identity, tcc_accessibility, tcc_screen_recording,
-           ax_capability, screen_capture_capability
+           tcc_system_events, ax_capability, screen_capture_capability
   Windows: binary_version, platform_supported, session_active,
            ax_capability (via UIA), screen_capture_capability (via DXGI)
   Linux  : binary_version, platform_supported, session_active,

--- a/docs/content/docs/tutorials/drive-your-first-app.mdx
+++ b/docs/content/docs/tutorials/drive-your-first-app.mdx
@@ -28,7 +28,7 @@ Use the same one-line installer on every platform; it picks the right path for t
     open -n -g -a CuaDriver --args serve
     ```
 
-    Then grant Accessibility and Screen Recording:
+    Then grant Accessibility, Screen Recording, and Automation access to System Events:
 
     ```bash
     cua-driver permissions grant

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/health_report.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/health_report.rs
@@ -48,6 +48,7 @@ pub const NAME_SESSION_ACTIVE: &str = "session_active";
 pub const NAME_BUNDLE_IDENTITY: &str = "bundle_identity";
 pub const NAME_TCC_ACCESSIBILITY: &str = "tcc_accessibility";
 pub const NAME_TCC_SCREEN_RECORDING: &str = "tcc_screen_recording";
+pub const NAME_TCC_SYSTEM_EVENTS: &str = "tcc_system_events";
 pub const NAME_AX_CAPABILITY: &str = "ax_capability";
 pub const NAME_SCREEN_CAPTURE_CAPABILITY: &str = "screen_capture_capability";
 
@@ -353,7 +354,7 @@ If both are given, `include` wins.
 Canonical check names:
   macOS  : binary_version, platform_supported, session_active,
            bundle_identity, tcc_accessibility, tcc_screen_recording,
-           ax_capability, screen_capture_capability
+           tcc_system_events, ax_capability, screen_capture_capability
   Windows: binary_version, platform_supported, session_active,
            ax_capability (via UIA), screen_capture_capability (via DXGI)
   Linux  : binary_version, platform_supported, session_active,
@@ -496,6 +497,7 @@ mod tests {
             NAME_BUNDLE_IDENTITY,
             NAME_TCC_ACCESSIBILITY,
             NAME_TCC_SCREEN_RECORDING,
+            NAME_TCC_SYSTEM_EVENTS,
             NAME_AX_CAPABILITY,
             NAME_SCREEN_CAPTURE_CAPABILITY,
         ]

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -242,6 +242,7 @@ pub fn default_capabilities_for(tool_name: &str) -> Vec<String> {
             "system.permissions.tcc",
             "system.permissions.tcc.accessibility",
             "system.permissions.tcc.screen_recording",
+            "system.permissions.tcc.system_events",
         ],
         "get_config" => &["system.config.read"],
         "set_config" => &["system.config.write"],
@@ -586,6 +587,7 @@ mod capability_tests {
         "system.permissions.tcc",
         "system.permissions.tcc.accessibility",
         "system.permissions.tcc.screen_recording",
+        "system.permissions.tcc.system_events",
         // config
         "system.config.read",
         "system.config.write",

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -164,7 +164,7 @@ pub fn parse_command() -> Command {
         println!("Subcommands: mcp, list-tools, describe, call, serve, stop, status, config, recording, update, check-update, doctor, diagnose, permissions, autostart, skills, manifest");
         println!();
         println!("permissions options (macOS):");
-        println!("  cua-driver permissions status   Report Accessibility + Screen Recording status. Read-only (no prompt).");
+        println!("  cua-driver permissions status   Report Accessibility, Screen Recording, and System Events status. Read-only (no prompt).");
         println!("                                  Answers via a running daemon, so the result carries the CuaDriver");
         println!("                                  identity (com.trycua.driver). If no daemon is running it reports");
         println!("                                  `unknown` rather than your terminal's grants. Add --json for the payload.");
@@ -699,7 +699,7 @@ pub fn launch_daemon_and_wait(
 
     anyhow::bail!(
         "daemon did not appear on {socket_path} within {timeout_secs}s. If this \
-         is the first launch, grant Accessibility + Screen Recording to \
+         is the first launch, grant Accessibility, Screen Recording, and System Events to \
          CuaDriver.app in System Settings and retry. Pass --no-daemon-relaunch \
          to stay in-process."
     );
@@ -1750,7 +1750,7 @@ pub fn run_permissions_cmd(
 
 /// Report the CuaDriver daemon's TCC status — reliably, or not at all.
 ///
-/// macOS attributes Accessibility / Screen-Recording to the *responsible
+/// macOS attributes Accessibility / Screen Recording / Automation to the *responsible
 /// process*, so the ONLY process that can read `com.trycua.driver`'s real
 /// grants is the daemon running as its own responsible process. When the
 /// daemon is up we query it and report its
@@ -1795,7 +1795,7 @@ fn run_permissions_status(json: bool) {
     };
 
     let Some(structured) = daemon_status else {
-        // No reliable answer. Emit NO accessibility/screen_recording booleans —
+        // No reliable answer. Emit NO TCC grant booleans —
         // nothing downstream can misread a false `granted: true`.
         if json {
             let payload = serde_json::json!({
@@ -1813,6 +1813,7 @@ fn run_permissions_status(json: bool) {
         }
         println!("Accessibility:    ❓ unknown");
         println!("Screen Recording: ❓ unknown");
+        println!("System Events:    ❓ unknown");
         println!(
             "No CuaDriver daemon is running under the driver's own identity (com.trycua.driver), \
              so its real TCC status can't be read."
@@ -1837,6 +1838,7 @@ fn run_permissions_status(json: bool) {
     let b = |k: &str| structured.get(k).and_then(|v| v.as_bool()).unwrap_or(false);
     let ax = b("accessibility");
     let sr = b("screen_recording");
+    let se = b("system_events");
     let cap = b("screen_recording_capturable");
     let attribution = structured
         .get("source")
@@ -1846,6 +1848,7 @@ fn run_permissions_status(json: bool) {
 
     println!("Accessibility:    {}", if ax { "✅ granted" } else { "❌ not granted" });
     println!("Screen Recording: {}", if sr { "✅ granted" } else { "❌ not granted" });
+    println!("System Events:    {}", if se { "✅ granted" } else { "❌ not granted" });
     if sr && !cap {
         println!(
             "  ⚠️  preflight reports granted, but a live capture probe failed — the grant \
@@ -1853,7 +1856,7 @@ fn run_permissions_status(json: bool) {
         );
     }
     println!("Source: {attribution}");
-    if !(ax && sr) {
+    if !(ax && sr && se) {
         println!("  → To grant for the driver, run: cua-driver permissions grant");
     }
 }
@@ -1871,15 +1874,17 @@ fn run_permissions_grant() {
         } else {
             println!("Launching CuaDriver to request permissions.");
             println!(
-                "A dialog titled \u{201c}Cua Driver\u{201d} will appear — approve Accessibility \
-                 and Screen Recording in System Settings, then this command continues."
+                "Dialogs titled \u{201c}Cua Driver\u{201d} may appear — approve Accessibility, \
+                 Screen Recording, and Automation access to System Events in System Settings, \
+                 then this command continues."
             );
             // Permissions-grant launch never needs the compat screenshot surface.
             if let Err(e) = launch_daemon_and_wait(&socket, 180, false) {
                 eprintln!("\nDidn't detect the CuaDriver daemon: {e}");
                 eprintln!(
-                    "If you haven't yet, grant Accessibility + Screen Recording to CuaDriver \
-                     in System Settings, then re-run `cua-driver permissions grant`."
+                    "If you haven't yet, grant Accessibility, Screen Recording, and Automation \
+                     access to System Events to CuaDriver in System Settings, then re-run \
+                     `cua-driver permissions grant`."
                 );
                 process::exit(1);
             }
@@ -1887,7 +1892,7 @@ fn run_permissions_grant() {
         // Since #1761 the daemon binds its socket IMMEDIATELY — before the
         // permissions gate completes — so the first `check_permissions`
         // query returns "pending" while the grant is still missing. Poll
-        // the daemon until both grants flip true (success) or we time out.
+        // the daemon until all grants flip true (success) or we time out.
         //
         // The gate re-execs the daemon (~every 25s) to pick up an
         // Accessibility grant — `AXIsProcessTrusted` is cached per process
@@ -1904,6 +1909,7 @@ fn run_permissions_grant() {
             std::time::Instant::now() + std::time::Duration::from_secs(180);
         let mut ax = false;
         let mut sr = false;
+        let mut se = false;
         loop {
             if let Some(structured) = crate::serve::send_request(&socket, &req)
                 .ok()
@@ -1913,7 +1919,8 @@ fn run_permissions_grant() {
             {
                 ax = structured.get("accessibility").and_then(|v| v.as_bool()).unwrap_or(false);
                 sr = structured.get("screen_recording").and_then(|v| v.as_bool()).unwrap_or(false);
-                if ax && sr {
+                se = structured.get("system_events").and_then(|v| v.as_bool()).unwrap_or(false);
+                if ax && sr && se {
                     break;
                 }
             }
@@ -1924,15 +1931,20 @@ fn run_permissions_grant() {
             }
             std::thread::sleep(std::time::Duration::from_secs(2));
         }
-        if ax && sr {
-            println!("\n✅ CuaDriver has Accessibility + Screen Recording. You're set.");
+        if ax && sr && se {
+            println!("\n✅ CuaDriver has Accessibility + Screen Recording + System Events. You're set.");
         } else {
-            let missing = match (ax, sr) {
-                (false, false) => "Accessibility + Screen Recording",
-                (false, true) => "Accessibility",
-                (true, false) => "Screen Recording",
-                (true, true) => unreachable!(),
-            };
+            let mut missing_parts = Vec::new();
+            if !ax {
+                missing_parts.push("Accessibility");
+            }
+            if !sr {
+                missing_parts.push("Screen Recording");
+            }
+            if !se {
+                missing_parts.push("System Events");
+            }
+            let missing = missing_parts.join(" + ");
             println!("\n⚠️  Timed out waiting on: {missing}.");
             println!(
                 "Approve CuaDriver for \u{201c}Cua Driver\u{201d} in System Settings \u{2192} \
@@ -2294,7 +2306,7 @@ pub fn run_dump_docs_with_type(registry: &ToolRegistry, pretty: bool, doc_type: 
 /// Mirrors Swift `DiagnoseCommand`. Covers:
 ///   - running process identity (path, pid, version)
 ///   - codesign info (cdhash, team-id, authority) via `codesign -dvvv`
-///   - AX + screen recording TCC status (check_permissions tool)
+///   - TCC status (check_permissions tool)
 ///   - install layout (/Applications/CuaDriver.app, ~/.local/bin/cua-driver)
 ///   - TCC DB rows for com.trycua.driver (sqlite3, best-effort)
 ///   - config + state paths with existence booleans
@@ -2372,10 +2384,10 @@ fn diagnose_tcc_section(registry: std::sync::Arc<ToolRegistry>) -> String {
         .enable_all()
         .build();
 
-    let (ax, sr) = if let Ok(rt) = rt {
+    let (ax, sr, se) = if let Ok(rt) = rt {
         rt.block_on(async {
             let result = registry.invoke("check_permissions",
-                serde_json::Value::Object(Default::default())).await;
+                serde_json::json!({ "prompt": false })).await;
             if let Some(sc) = &result.structured_content {
                 let ax = sc.get("accessibility")
                     .and_then(|v| v.as_bool())
@@ -2383,19 +2395,23 @@ fn diagnose_tcc_section(registry: std::sync::Arc<ToolRegistry>) -> String {
                 let sr = sc.get("screen_recording")
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
-                (ax, sr)
+                let se = sc.get("system_events")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                (ax, sr, se)
             } else {
-                (false, false)
+                (false, false, false)
             }
         })
     } else {
-        (false, false)
+        (false, false, false)
     };
 
     format!(
         "## tcc probes (live process)\n\
          accessibility     (AXIsProcessTrusted): {ax}\n\
-         screen recording  (SCShareableContent):  {sr}\n\n\
+         screen recording  (SCShareableContent):  {sr}\n\
+         system events     (Apple Events):        {se}\n\n\
          if the UI disagrees with these booleans the live process is fine —\n\
          the issue is elsewhere (wrong bundle granted, stale cdhash, etc)."
     )
@@ -2493,7 +2509,7 @@ fn diagnose_tcc_db_section() -> String {
 
     lines.push(String::new());
     lines.push("# auth_value legend: 0=denied  2=allowed".into());
-    lines.push("# services: kTCCServiceAccessibility, kTCCServiceScreenCapture".into());
+    lines.push("# services: kTCCServiceAccessibility, kTCCServiceScreenCapture, kTCCServiceAppleEvents".into());
     lines.join("\n")
 }
 

--- a/libs/cua-driver/rust/crates/cua-driver/src/main.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/main.rs
@@ -309,8 +309,8 @@ fn main() {
             // A Unix socket + tokio accept loop has no main-thread
             // requirement, so serve runs on a background thread. The gate
             // stays on the MAIN thread: its prompt APIs
-            // (`request_accessibility` / `request_screen_recording`) and
-            // the NSPanel must run on main. On grant, the gate's
+            // (`request_accessibility` / `request_screen_recording` /
+            // `request_system_events`) and the NSPanel must run on main. On grant, the gate's
             // `reexec_self()` execvp's the whole daemon — the socket
             // re-binds fast on restart (run_serve unlinks the stale socket
             // file first) and stabilizes once the grant sticks.
@@ -325,7 +325,7 @@ fn main() {
             // Socket is binding/bound now → daemon reachable while we gate.
             //
             // First-launch permissions gate (Swift PermissionsGate parity).
-            // Runs on every `serve` start; no-op when both grants are
+            // Runs on every `serve` start; no-op when all grants are
             // already active.  Honors --no-permissions-gate and
             // CUA_DRIVER_RS_PERMISSIONS_GATE=0 for CI / headless.
             //
@@ -336,7 +336,7 @@ fn main() {
             if let Err(e) = platform_macos::permissions::run_if_needed(gate_opts) {
                 eprintln!("[cua-driver] permissions gate: {e}");
                 eprintln!("[cua-driver] continuing — tool calls touching AX or \
-                           Screen Recording fail until you grant the missing TCC \
+                           Screen Recording, or System Events fail until you grant the missing TCC \
                            permissions.");
             }
 

--- a/libs/cua-driver/rust/crates/cua-driver/tests/protocol_tools_call_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/protocol_tools_call_test.rs
@@ -80,7 +80,7 @@ fn get_config_and_check_permissions() {
         assert!(sc["post_message"].as_bool().unwrap_or(false), "post_message should be true: {sc:?}");
         assert!(sc["elevated"].is_boolean(), "elevated should be a boolean: {sc:?}");
     } else {
-        // Returns structured content with accessibility and screen_recording booleans.
+        // Returns structured content with platform permission booleans.
         assert!(resp["result"]["structuredContent"]["accessibility"].is_boolean());
     }
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/apps/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/apps/mod.rs
@@ -31,7 +31,8 @@ pub struct AppInfo {
 }
 
 /// Enumerate running apps with NSApplicationActivationPolicyRegular.
-/// Uses `osascript` to query System Events — no Accessibility permission needed.
+/// Uses `osascript` to query System Events, which requires Automation access
+/// to System Events for the responsible process.
 pub fn list_running_apps() -> Vec<AppInfo> {
     // Use `ps` + NSWorkspace via a brief Swift one-liner via swift-sh is heavy;
     // instead use the Obj-C bridge via `osascript`.

--- a/libs/cua-driver/rust/crates/platform-macos/src/permissions/gate.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/permissions/gate.rs
@@ -37,7 +37,8 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 
 use crate::permissions::status::{
-    current_status, request_accessibility, request_screen_recording, PermissionsStatus,
+    current_status, request_accessibility, request_screen_recording, request_system_events,
+    PermissionsStatus,
 };
 
 /// Which TCC grant is missing.  Each variant maps 1:1 to a System Settings
@@ -46,6 +47,7 @@ use crate::permissions::status::{
 pub enum MissingPermission {
     Accessibility,
     ScreenRecording,
+    SystemEvents,
 }
 
 impl MissingPermission {
@@ -54,6 +56,7 @@ impl MissingPermission {
         match self {
             Self::Accessibility => "Accessibility",
             Self::ScreenRecording => "Screen Recording",
+            Self::SystemEvents => "Automation (System Events)",
         }
     }
 
@@ -67,6 +70,9 @@ impl MissingPermission {
             Self::ScreenRecording =>
                 "lets cua-driver capture per-window screenshots so agents can see \
                  the current UI state alongside the tree.",
+            Self::SystemEvents =>
+                "lets cua-driver control System Events for Apple Events-backed \
+                 process inspection and menu automation.",
         }
     }
 
@@ -78,6 +84,8 @@ impl MissingPermission {
                 "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
             Self::ScreenRecording =>
                 "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture",
+            Self::SystemEvents =>
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation",
         }
     }
 }
@@ -91,6 +99,9 @@ pub fn missing_from_status(status: PermissionsStatus) -> Vec<MissingPermission> 
     }
     if !status.screen_recording {
         out.push(MissingPermission::ScreenRecording);
+    }
+    if !status.system_events {
+        out.push(MissingPermission::SystemEvents);
     }
     out
 }
@@ -266,6 +277,9 @@ pub fn run_if_needed(opts: GateOpts) -> Result<()> {
         if missing.contains(&MissingPermission::ScreenRecording) {
             let _ = request_screen_recording();
         }
+        if missing.contains(&MissingPermission::SystemEvents) {
+            let _ = request_system_events();
+        }
     }
 
     // Try to present a native NSPanel before falling back to the
@@ -280,7 +294,7 @@ pub fn run_if_needed(opts: GateOpts) -> Result<()> {
     //   * `ShownDismissed` — user clicked "Continue anyway" or the red
     //     dot; skip the auto-open since the user declined the guided
     //     flow, but still wait so a later manual grant unblocks.
-    //   * `ShownAllGranted` — the panel's poll loop saw both grants
+    //   * `ShownAllGranted` — the panel's poll loop saw all grants
     //     flip green; skip the wait loop entirely.
     let presentation = present_panel_if_available(initial);
     let should_auto_open_settings;
@@ -330,7 +344,7 @@ enum PanelPresentation {
     ShownOpenSettings,
     /// Panel shown; user clicked "Continue anyway" or closed the window.
     ShownDismissed,
-    /// Panel shown; its 1 Hz poll loop saw both grants flip green and
+    /// Panel shown; its 1 Hz poll loop saw all grants flip green and
     /// dismissed automatically. Caller can skip the trailing wait loop.
     ShownAllGranted,
 }
@@ -700,18 +714,21 @@ mod tests {
         let neither = PermissionsStatus {
             accessibility: false,
             screen_recording: false,
+            system_events: false,
         };
         assert_eq!(
             missing_from_status(neither),
             vec![
                 MissingPermission::Accessibility,
-                MissingPermission::ScreenRecording
+                MissingPermission::ScreenRecording,
+                MissingPermission::SystemEvents
             ]
         );
 
         let only_sr = PermissionsStatus {
             accessibility: false,
             screen_recording: true,
+            system_events: true,
         };
         assert_eq!(
             missing_from_status(only_sr),
@@ -721,15 +738,27 @@ mod tests {
         let only_ax = PermissionsStatus {
             accessibility: true,
             screen_recording: false,
+            system_events: true,
         };
         assert_eq!(
             missing_from_status(only_ax),
             vec![MissingPermission::ScreenRecording]
         );
 
+        let only_system_events_missing = PermissionsStatus {
+            accessibility: true,
+            screen_recording: true,
+            system_events: false,
+        };
+        assert_eq!(
+            missing_from_status(only_system_events_missing),
+            vec![MissingPermission::SystemEvents]
+        );
+
         let all = PermissionsStatus {
             accessibility: true,
             screen_recording: true,
+            system_events: true,
         };
         assert!(missing_from_status(all).is_empty());
     }
@@ -746,6 +775,10 @@ mod tests {
         assert_eq!(
             MissingPermission::ScreenRecording.settings_url(),
             "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+        );
+        assert_eq!(
+            MissingPermission::SystemEvents.settings_url(),
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation"
         );
     }
 }

--- a/libs/cua-driver/rust/crates/platform-macos/src/permissions/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/permissions/mod.rs
@@ -1,7 +1,8 @@
 //! macOS TCC permission checks + first-launch CLI gate.
 //!
 //! Two layers:
-//!   - [`status`] — low-level booleans for Accessibility / Screen Recording.
+//!   - [`status`] — low-level booleans for Accessibility / Screen Recording /
+//!                  System Events Automation.
 //!   - [`gate`]   — startup-time interactive flow that walks the user through
 //!                  granting the missing permissions before `serve` binds.
 //!

--- a/libs/cua-driver/rust/crates/platform-macos/src/permissions/panel.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/permissions/panel.rs
@@ -20,9 +20,11 @@
 //! │                                             │
 //! │  ✗ Screen Recording                         │
 //! │      lets cua-driver capture per-window …   │
+//! │  ✗ Automation (System Events)               │
+//! │      lets cua-driver control System Events… │
 //! │                                             │
 //! │  ✅ All set. CuaDriver is ready to use.      │
-//! │     (hidden until both grants flip green)   │
+//! │     (hidden until all grants flip green)    │
 //! │                                             │
 //! │  [ Continue anyway ]  [ Open Settings ]     │
 //! └─────────────────────────────────────────────┘
@@ -30,7 +32,7 @@
 //!
 //! A 1 Hz `NSTimer` reads [`current_status`] on every tick and updates
 //! the row icons / heading / subheading / "All set" strip in place.
-//! When both grants flip green and `suppress_auto_close == false` the
+//! When all grants flip green and `suppress_auto_close == false` the
 //! poll callback calls `[NSApp stopModal]` and `show_modal` returns
 //! [`PanelOutcome::AllGranted`] so the caller can skip the trailing
 //! `wait_for_grants` loop.
@@ -219,12 +221,12 @@ fn running_inside_app_bundle() -> bool {
 // ── Layout constants ────────────────────────────────────────────────────
 //
 // Window geometry mirrors Swift's `.frame(width: 460)` plus heights
-// chosen to fit: heading (24) + subheading (40) + 2 rows (76 each) +
+// chosen to fit: heading (24) + subheading (40) + 3 rows (76 each) +
 // "All set" strip (32) + button row (48) + paddings (20·5). Keeping
 // the numbers as a block here so the math is auditable.
 
 const WIN_W: f64 = 460.0;
-const WIN_H: f64 = 360.0;
+const WIN_H: f64 = 444.0;
 const PAD: f64 = 20.0;
 const ROW_H: f64 = 76.0;
 const READY_STRIP_H: f64 = 36.0;
@@ -296,8 +298,9 @@ unsafe fn show_modal_unsafe(opts: &PanelOpts) -> PanelOutcome {
 
     y -= 8.0 + 40.0; // gap + subheading height
 
+    let initial_subheading = subheading_for(opts.initial_status);
     let subheading = build_label(
-        subheading_for(opts.initial_status),
+        &initial_subheading,
         12.0,
         /*bold=*/ false,
         NSPoint { x: PAD, y },
@@ -339,11 +342,22 @@ unsafe fn show_modal_unsafe(opts: &PanelOpts) -> PanelOutcome {
     let _: () = msg_send![content_view, addSubview: sr_row.container];
     y -= ROW_H + 8.0;
 
+    let se_row = build_row(
+        MissingPermission::SystemEvents,
+        opts.initial_status.system_events,
+        NSPoint { x: PAD, y: y - ROW_H },
+        NSSize {
+            width: WIN_W - 2.0 * PAD,
+            height: ROW_H,
+        },
+    );
+    let _: () = msg_send![content_view, addSubview: se_row.container];
+    y -= ROW_H + 8.0;
+
     // ---- Ready strip (initially hidden; shown by poll on all-green) ----
     let ready_strip = build_ready_strip(NSPoint { x: PAD, y: y - READY_STRIP_H }, WIN_W - 2.0 * PAD);
     let _: () = msg_send![content_view, addSubview: ready_strip];
-    let initially_all_green =
-        opts.initial_status.accessibility && opts.initial_status.screen_recording;
+    let initially_all_green = opts.initial_status.all_granted();
     let _: () = msg_send![ready_strip, setHidden: !initially_all_green];
 
     // ---- Buttons across the bottom ----
@@ -383,6 +397,7 @@ unsafe fn show_modal_unsafe(opts: &PanelOpts) -> PanelOutcome {
             ready_strip: ptr_to_usize(ready_strip),
             ax_row,
             sr_row,
+            se_row,
             last_status: opts.initial_status,
         });
     });
@@ -433,6 +448,7 @@ struct PanelHandles {
     ready_strip: usize,
     ax_row: RowHandles,
     sr_row: RowHandles,
+    se_row: RowHandles,
     last_status: PermissionsStatus,
 }
 
@@ -511,13 +527,15 @@ unsafe fn poll_tick_inner() {
         // Update row icons + label color tints.
         update_row(handles.ax_row, status.accessibility);
         update_row(handles.sr_row, status.screen_recording);
+        update_row(handles.se_row, status.system_events);
         // Update heading + subheading copy.
         let new_heading = ns_string(heading_for(status));
         let _: () = msg_send![usize_to_ptr(handles.heading), setStringValue: new_heading];
-        let new_subheading = ns_string(subheading_for(status));
+        let new_subheading_text = subheading_for(status);
+        let new_subheading = ns_string(&new_subheading_text);
         let _: () = msg_send![usize_to_ptr(handles.subheading), setStringValue: new_subheading];
         // Toggle the ready strip.
-        let all_green = status.accessibility && status.screen_recording;
+        let all_green = status.all_granted();
         let _: () = msg_send![usize_to_ptr(handles.ready_strip), setHidden: !all_green];
         handles.last_status = status;
         if all_green {
@@ -558,24 +576,37 @@ unsafe fn update_row(row: RowHandles, granted: bool) {
 // ── Heading / subheading copy (parity with Swift) ────────────────────────
 
 fn heading_for(s: PermissionsStatus) -> &'static str {
-    match (s.accessibility, s.screen_recording) {
-        (true, true) => "CuaDriver is ready",
-        (true, false) | (false, true) => "One more permission",
-        (false, false) => "CuaDriver needs your permission",
+    let missing = missing_permission_labels(s).len();
+    match missing {
+        0 => "CuaDriver is ready",
+        1 => "One more permission",
+        _ => "CuaDriver needs your permission",
     }
 }
 
-fn subheading_for(s: PermissionsStatus) -> &'static str {
-    match (s.accessibility, s.screen_recording) {
-        (true, true) =>
-            "Both permissions are granted. You can close this window whenever you're ready.",
-        (true, false) =>
-            "Accessibility is granted. Now grant Screen Recording in the System Settings window that just opened.",
-        (false, true) =>
-            "Screen Recording is granted. Now grant Accessibility in the System Settings window that just opened.",
-        (false, false) =>
-            "Grant both so CuaDriver can inspect and drive native apps on your behalf. This window closes on its own once each item turns green.",
+fn subheading_for(s: PermissionsStatus) -> String {
+    let missing = missing_permission_labels(s);
+    match missing.as_slice() {
+        [] => "All permissions are granted. You can close this window whenever you're ready.".to_owned(),
+        [one] => format!(
+            "Almost there. Now grant {one} in the System Settings window that just opened."
+        ),
+        _ => "Grant each item so CuaDriver can inspect and drive native apps on your behalf. This window closes on its own once each item turns green.".to_owned(),
     }
+}
+
+fn missing_permission_labels(s: PermissionsStatus) -> Vec<&'static str> {
+    let mut labels = Vec::new();
+    if !s.accessibility {
+        labels.push("Accessibility");
+    }
+    if !s.screen_recording {
+        labels.push("Screen Recording");
+    }
+    if !s.system_events {
+        labels.push("Automation (System Events)");
+    }
+    labels
 }
 
 // ── Helpers: NSString, labels, buttons, icons, rows ──────────────────────
@@ -882,6 +913,7 @@ mod tests {
         let st = |a: bool, sr: bool| PermissionsStatus {
             accessibility: a,
             screen_recording: sr,
+            system_events: true,
         };
         assert_eq!(heading_for(st(true, true)), "CuaDriver is ready");
         assert_eq!(heading_for(st(true, false)), "One more permission");
@@ -897,6 +929,7 @@ mod tests {
         let st = |a: bool, sr: bool| PermissionsStatus {
             accessibility: a,
             screen_recording: sr,
+            system_events: true,
         };
         // Only Accessibility granted → mentions Screen Recording next.
         assert!(subheading_for(st(true, false)).contains("Screen Recording"));

--- a/libs/cua-driver/rust/crates/platform-macos/src/permissions/status.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/permissions/status.rs
@@ -8,22 +8,24 @@
 /// Snapshot of which TCC grants are active for the current process.
 ///
 /// Field naming matches the JSON shape used by the `check_permissions`
-/// MCP tool: `accessibility` + `screen_recording`.
+/// MCP tool: `accessibility` + `screen_recording` + `system_events`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct PermissionsStatus {
     pub accessibility: bool,
     #[serde(rename = "screen_recording")]
     pub screen_recording: bool,
+    #[serde(rename = "system_events")]
+    pub system_events: bool,
 }
 
 impl PermissionsStatus {
-    /// True when **both** required TCC grants are active.
+    /// True when all required TCC grants are active.
     pub fn all_granted(self) -> bool {
-        self.accessibility && self.screen_recording
+        self.accessibility && self.screen_recording && self.system_events
     }
 }
 
-/// Read the live TCC status for both required grants.  Cheap to call
+/// Read the live TCC status for required grants.  Cheap to call
 /// repeatedly — both probes are quick C-level calls into the system
 /// TCC daemon.
 ///
@@ -37,6 +39,7 @@ pub fn current_status() -> PermissionsStatus {
     PermissionsStatus {
         accessibility: accessibility_granted(),
         screen_recording: screen_recording_granted(),
+        system_events: system_events_granted(),
     }
 }
 
@@ -66,6 +69,17 @@ pub fn screen_recording_granted() -> bool {
     unsafe { CGPreflightScreenCaptureAccess() }
 }
 
+/// Live Automation grant state for controlling System Events.
+///
+/// This is the TCC prompt macOS phrases as:
+/// "CuaDriver wants access to control System Events". We need it for
+/// System Events-backed AppleScript / Apple Events flows such as process
+/// inspection and menu automation. `askUserIfNeeded=false` keeps status
+/// checks read-only.
+pub fn system_events_granted() -> bool {
+    determine_system_events_permission(false)
+}
+
 /// Raise the Accessibility TCC prompt if not yet granted.  No-op when
 /// already active.  Mirrors Swift `Permissions.requestAccessibility()`.
 pub fn request_accessibility() -> bool {
@@ -91,4 +105,68 @@ pub fn request_screen_recording() -> bool {
         fn CGRequestScreenCaptureAccess() -> bool;
     }
     unsafe { CGRequestScreenCaptureAccess() }
+}
+
+/// Raise the Automation → System Events TCC prompt if not yet granted.
+/// No-op when already active.
+pub fn request_system_events() -> bool {
+    determine_system_events_permission(true)
+}
+
+fn determine_system_events_permission(ask_user_if_needed: bool) -> bool {
+    use std::ffi::c_void;
+
+    #[repr(C)]
+    struct AEDesc {
+        descriptor_type: u32,
+        data_handle: *mut c_void,
+    }
+
+    #[link(name = "ApplicationServices", kind = "framework")]
+    extern "C" {
+        fn AECreateDesc(
+            type_code: u32,
+            data_ptr: *const c_void,
+            data_size: isize,
+            result: *mut AEDesc,
+        ) -> i32;
+        fn AEDisposeDesc(desc: *mut AEDesc) -> i32;
+        fn AEDeterminePermissionToAutomateTarget(
+            target: *const AEDesc,
+            event_class: u32,
+            event_id: u32,
+            ask_user_if_needed: u8,
+        ) -> i32;
+    }
+
+    // FourCharCode constants from AppleEvents.h.
+    const TYPE_APPLICATION_BUNDLE_ID: u32 = 0x6275_6e64; // 'bund'
+    const TYPE_WILD_CARD: u32 = 0x2a2a_2a2a; // '****'
+
+    let bundle_id = b"com.apple.systemevents";
+    let mut target = AEDesc {
+        descriptor_type: 0,
+        data_handle: std::ptr::null_mut(),
+    };
+
+    unsafe {
+        let create_status = AECreateDesc(
+            TYPE_APPLICATION_BUNDLE_ID,
+            bundle_id.as_ptr().cast::<c_void>(),
+            bundle_id.len() as isize,
+            &mut target,
+        );
+        if create_status != 0 {
+            return false;
+        }
+
+        let status = AEDeterminePermissionToAutomateTarget(
+            &target,
+            TYPE_WILD_CARD,
+            TYPE_WILD_CARD,
+            u8::from(ask_user_if_needed),
+        );
+        let _ = AEDisposeDesc(&mut target);
+        status == 0
+    }
 }

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/check_permissions.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/check_permissions.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 
 use crate::permissions::status::{
     accessibility_granted, request_accessibility, request_screen_recording,
-    screen_recording_granted,
+    request_system_events, screen_recording_granted, system_events_granted,
 };
 
 pub struct CheckPermissionsTool;
@@ -27,7 +27,7 @@ fn screen_recording_capturable() -> bool {
 
 /// (B) Which TCC identity the booleans in this response reflect.
 ///
-/// macOS attributes Accessibility / Screen-Recording to the *responsible
+/// macOS attributes Accessibility / Screen Recording / Automation to the *responsible
 /// process* (the LaunchServices launching app), not the executable path.
 /// So `check_permissions` answered in-process reflects:
 ///   - the **CuaDriver daemon** (`com.trycua.driver`) when this process is
@@ -91,13 +91,15 @@ fn def() -> &'static ToolDef {
     DEF.get_or_init(|| ToolDef {
         // Matches Swift `CheckPermissionsTool.swift` description verbatim.
         name: "check_permissions".into(),
-        description: "Report TCC permission status for Accessibility and Screen Recording. \
+        description: "Report TCC permission status for Accessibility, Screen Recording, \
+            and Automation access to System Events. \
             By default also raises the system permission dialogs for any missing grants — \
             Apple's request APIs are no-ops when the grant is already active, so this is \
             safe to call repeatedly. Pass {\"prompt\": false} for a purely read-only \
             status check.\n\n\
-            Returns: `accessibility` + `screen_recording` (booleans from the TCC \
-            preflight APIs), `screen_recording_capturable` (a live ScreenCaptureKit \
+            Returns: `accessibility` + `screen_recording` + `system_events` \
+            (booleans from the TCC preflight APIs), `screen_recording_capturable` \
+            (a live ScreenCaptureKit \
             probe — if it disagrees with `screen_recording`, the preflight grant \
             belongs to a different process), and `source` (which TCC identity the \
             booleans reflect: the CuaDriver daemon vs the launching terminal/IDE). \
@@ -133,9 +135,11 @@ impl Tool for CheckPermissionsTool {
         if should_prompt {
             let _ = request_accessibility();
             let _ = request_screen_recording();
+            let _ = request_system_events();
         }
         let accessibility = accessibility_granted();
         let screen_recording = screen_recording_granted();
+        let system_events = system_events_granted();
         // (A) Authoritative live probe — see `screen_recording_capturable`.
         let screen_recording_capturable = screen_recording_capturable();
         // (B) Which identity the booleans above belong to.
@@ -146,10 +150,14 @@ impl Tool for CheckPermissionsTool {
         //   "✅ Accessibility: granted.\n✅ Screen Recording: granted."
         let ax_prefix  = if accessibility   { "✅" } else { "❌" };
         let sr_prefix  = if screen_recording { "✅" } else { "❌" };
+        let se_prefix  = if system_events { "✅" } else { "❌" };
         let ax_state   = if accessibility   { "granted" } else { "NOT granted" };
         let sr_state   = if screen_recording { "granted" } else { "NOT granted" };
+        let se_state   = if system_events { "granted" } else { "NOT granted" };
         let mut summary = format!(
-            "{ax_prefix} Accessibility: {ax_state}.\n{sr_prefix} Screen Recording: {sr_state}."
+            "{ax_prefix} Accessibility: {ax_state}.\n\
+             {sr_prefix} Screen Recording: {sr_state}.\n\
+             {se_prefix} Automation (System Events): {se_state}."
         );
         // Flag a preflight/probe disagreement (the false-positive tell).
         if screen_recording && !screen_recording_capturable {
@@ -170,6 +178,7 @@ impl Tool for CheckPermissionsTool {
             .with_structured(serde_json::json!({
                 "accessibility":               accessibility,
                 "screen_recording":            screen_recording,
+                "system_events":               system_events,
                 "screen_recording_capturable": screen_recording_capturable,
                 "source":                      source,
             }))

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/health_report.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/health_report.rs
@@ -14,10 +14,11 @@ use cua_driver_core::health_report::{
     CheckData, CheckEntry, HealthCheckProvider, NAME_AX_CAPABILITY, NAME_BINARY_VERSION,
     NAME_BUNDLE_IDENTITY, NAME_PLATFORM_SUPPORTED, NAME_SCREEN_CAPTURE_CAPABILITY,
     NAME_SESSION_ACTIVE, NAME_TCC_ACCESSIBILITY, NAME_TCC_SCREEN_RECORDING,
+    NAME_TCC_SYSTEM_EVENTS,
 };
 
 use crate::permissions::status::{
-    accessibility_granted, current_status, screen_recording_granted,
+    accessibility_granted, current_status, screen_recording_granted, system_events_granted,
 };
 
 /// macOS run order, in the order consumers see them reflected back in
@@ -29,6 +30,7 @@ pub const MACOS_CHECK_NAMES: &[&str] = &[
     NAME_BUNDLE_IDENTITY,
     NAME_TCC_ACCESSIBILITY,
     NAME_TCC_SCREEN_RECORDING,
+    NAME_TCC_SYSTEM_EVENTS,
     NAME_AX_CAPABILITY,
     NAME_SCREEN_CAPTURE_CAPABILITY,
 ];
@@ -58,6 +60,7 @@ impl HealthCheckProvider for MacosHealthProvider {
             NAME_BUNDLE_IDENTITY => check_bundle_identity(),
             NAME_TCC_ACCESSIBILITY => check_tcc_accessibility(),
             NAME_TCC_SCREEN_RECORDING => check_tcc_screen_recording(),
+            NAME_TCC_SYSTEM_EVENTS => check_tcc_system_events(),
             NAME_AX_CAPABILITY => check_ax_capability(),
             NAME_SCREEN_CAPTURE_CAPABILITY => check_screen_capture_capability().await,
             // Defensive: the dispatcher only forwards names in
@@ -184,6 +187,29 @@ fn check_tcc_screen_recording() -> CheckEntry {
         "Grant Screen Recording to CuaDriver.app in System Settings → Privacy & Security → \
          Screen Recording. The grant is attributed to the responsible process — see \
          bundle_identity to confirm the right binary is being prompted.",
+    )
+    .with_data(data)
+}
+
+fn check_tcc_system_events() -> CheckEntry {
+    let granted = system_events_granted();
+    let data = CheckData {
+        bundle_identifier: current_bundle_identifier(),
+        ..Default::default()
+    };
+    if granted {
+        return CheckEntry::pass(
+            NAME_TCC_SYSTEM_EVENTS,
+            "Automation access to System Events is granted.",
+        )
+        .with_data(data);
+    }
+    CheckEntry::fail(
+        NAME_TCC_SYSTEM_EVENTS,
+        "Automation access to System Events is NOT granted for this process.",
+        "Grant CuaDriver.app permission to control System Events in System Settings → \
+         Privacy & Security → Automation. The grant is attributed to the responsible \
+         process — see bundle_identity to confirm the right binary is being prompted.",
     )
     .with_data(data)
 }

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/stubs.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/stubs.rs
@@ -121,7 +121,7 @@ stub_tool!(set_cursor_style_m, SetAgentCursorStyleTool, "set_agent_cursor_style"
     serde_json::json!({"type":"object","properties":{"cursor_id":{"type":"string"},"gradient_colors":{"type":"array","items":{"type":"string"}},"bloom_color":{"type":"string"},"image_path":{"type":"string"}},"additionalProperties":false}));
 
 stub_tool!(check_perms_m, CheckPermissionsTool, "check_permissions",
-    "Check required permissions (Accessibility, Screen Recording).",
+    "Check required platform permissions.",
     serde_json::json!({"type":"object","properties":{"prompt":{"type":"boolean"}},"additionalProperties":false}));
 
 stub_tool!(get_config_m, GetConfigTool, "get_config",

--- a/libs/cua-driver/rust/scripts/CuaDriverBundle/Contents/Info.plist
+++ b/libs/cua-driver/rust/scripts/CuaDriverBundle/Contents/Info.plist
@@ -8,7 +8,7 @@
     `com.trycua.driver` — the SAME bundle id the Swift cua-driver used.
     The bundle-id and install-path identity means installing the Rust
     port over an existing Swift install is a seamless upgrade: TCC
-    grants (Accessibility, Screen Recording) keyed on
+    grants (Accessibility, Screen Recording, System Events Automation) keyed on
     `com.trycua.driver` transfer to the new binary; LaunchServices
     discovery via `open -n -g -a CuaDriver` keeps working.
 
@@ -27,7 +27,8 @@
     Note on macOS code-signing: TCC pairs the bundle id with the
     binary's cdhash. The Rust binary has a different cdhash from the
     Swift binary, so on first run after the upgrade macOS may surface
-    a one-time re-grant prompt for Accessibility / Screen Recording
+    a one-time re-grant prompt for Accessibility / Screen Recording /
+    System Events Automation
     even though the bundle id is preserved. After that, the grants
     persist.
 

--- a/libs/cua-driver/scripts/_install-local-rust.sh
+++ b/libs/cua-driver/scripts/_install-local-rust.sh
@@ -102,7 +102,7 @@ while [ "$#" -gt 0 ]; do
             echo "                  Linux: systemd --user unit"
             echo "                On macOS this also fixes TCC: a launchd-started daemon"
             echo "                is attributed to com.trycua.driver (not your terminal),"
-            echo "                so you grant Accessibility + Screen Recording once and"
+            echo "                so you grant Accessibility + Screen Recording + System Events once and"
             echo "                every cua-driver call/mcp routes through it correctly."
             echo "  --help        Show this help."
             echo ""
@@ -263,7 +263,7 @@ echo ""
 # --- macOS: stable local code-signing identity (so TCC grants survive rebuilds) ---
 #
 # Ad-hoc signing (`codesign --sign -`) keys the TCC grant
-# (Accessibility / Screen Recording) on the binary's *cdhash*, which changes
+# (Accessibility / Screen Recording / System Events) on the binary's *cdhash*, which changes
 # on EVERY rebuild — so the grant silently invalidates on each install-local
 # and the daemon re-prompts ("I already granted!"). Signing with a certificate
 # keys the grant on the cert identity instead, which is stable across rebuilds.
@@ -309,7 +309,7 @@ ensure_local_signing_identity() {
 
 # --- macOS: wrap the binary in CuaDriver.app for a stable TCC identity ---
 #
-# TCC keys Accessibility / Screen-Recording grants on the bundle
+# TCC keys Accessibility / Screen-Recording / System-Events grants on the bundle
 # identifier (com.trycua.driver), not the bare executable path. A loose
 # binary gets grants attributed to its ad-hoc cdhash, which changes on
 # every rebuild — so permissions silently reset and never appear cleanly
@@ -364,7 +364,7 @@ if [ "$OS" = "Darwin" ]; then
 
     # --- Clear a TCC grant pinned to a PREVIOUS signing identity -----------
     #
-    # TCC pins each Accessibility / Screen-Recording grant to the app's
+    # TCC pins each Accessibility / Screen-Recording / System-Events grant to the app's
     # designated requirement AT GRANT TIME. A user who granted while the app
     # was ad-hoc signed has a grant whose csreq is a bare `cdhash H"..."`
     # (changes every rebuild); a user who granted under a different cert has
@@ -393,7 +393,8 @@ if [ "$OS" = "Darwin" ]; then
                 if [ "$NEW_IDENTITY" != "$OLD_IDENTITY" ]; then
                     tccutil reset Accessibility com.trycua.driver >/dev/null 2>&1 || true
                     tccutil reset ScreenCapture com.trycua.driver >/dev/null 2>&1 || true
-                    echo "${BOLD}cleared any stale Accessibility / Screen-Recording grant pinned to a previous build.${NORMAL}"
+                    tccutil reset AppleEvents com.trycua.driver >/dev/null 2>&1 || true
+                    echo "${BOLD}cleared any stale Accessibility / Screen-Recording / System-Events grant pinned to a previous build.${NORMAL}"
                     echo "  Grant once more (System Settings → Privacy & Security) and it will${BOLD} stick across every future rebuild${NORMAL} — the grant now pins to a stable signing certificate, not the per-build cdhash."
                 fi
                 ;;
@@ -529,7 +530,7 @@ if [ "$INSTALL_AUTOSTART" != true ]; then
         echo "Auto-start (recommended on macOS): re-run with --autostart to register a LaunchAgent."
         echo "  A launchd-started daemon is attributed to com.trycua.driver (not your terminal),"
         echo "  so permission prompts say \"Cua Driver\" and grants stick — grant Accessibility +"
-        echo "  Screen Recording once and every cua-driver call/mcp routes through it correctly."
+        echo "  Screen Recording + System Events once and every cua-driver call/mcp routes through it correctly."
         echo "  (Without it, a prompt raised from a terminal attributes to the terminal instead.)"
     else
         echo "Auto-start (optional): re-run with --autostart to register a systemd user unit."

--- a/libs/cua-driver/scripts/_install-rust.sh
+++ b/libs/cua-driver/scripts/_install-rust.sh
@@ -817,7 +817,7 @@ echo ""
 
 if [[ "${REPLACED_SWIFT:-0}" == "1" ]]; then
     echo "Upgraded the cua-driver bundle that was previously at $APP_DEST."
-    echo "TCC grants (Accessibility, Screen Recording) are keyed on the bundle id"
+    echo "TCC grants (Accessibility, Screen Recording, System Events Automation) are keyed on the bundle id"
     echo "(com.trycua.driver) — which is preserved — so they transfer to the new"
     echo "binary automatically. macOS may surface a one-time re-grant prompt on"
     echo "first action because the new binary's cdhash doesn't match the old"
@@ -846,7 +846,7 @@ fi
 case "$(uname -s)" in
     Darwin)
         echo ""
-        echo "macOS TCC: grant Accessibility + Screen Recording on first run:"
+        echo "macOS TCC: grant Accessibility + Screen Recording + System Events on first run:"
         echo "  open -n -g -a CuaDriver --args serve"
         echo "  $BIN_LINK check_permissions"
         ;;

--- a/libs/cua-driver/scripts/post-install-hints.txt
+++ b/libs/cua-driver/scripts/post-install-hints.txt
@@ -5,7 +5,7 @@ Next steps:
        {{BINARY}} --version
        {{BINARY}} list-tools
 
-  2. Grant permissions (macOS — Accessibility + Screen Recording):
+  2. Grant permissions (macOS — Accessibility + Screen Recording + System Events):
        {{BINARY}} permissions status   # report status (read-only; tells you which
                                        # identity the grants belong to)
        {{BINARY}} permissions grant    # the correct way to grant — launches CuaDriver


### PR DESCRIPTION
## Summary

- Add macOS Automation access to System Events as a first-class CuaDriver permission.
- Include `system_events` in permission status, grant prompting, the startup gate, the native permissions panel, health reports, and capability metadata.
- Update install, post-install, and reference docs so users know the System Events prompt is expected.

## Why

macOS can prompt: “CuaDriver wants access to control System Events” when the driver uses Apple Events-backed flows. Previously the driver and docs only modeled Accessibility and Screen Recording, so the prompt looked unexpected and `check_permissions` could not report or request it.

## Validation

- `cargo check -p platform-macos -p cua-driver-core -p cua-driver`
- `cargo test -p cua-driver-core health_report --lib`
- `cargo test -p cua-driver-core tool --lib`
- `git diff --cached --check` before commit
- staged diff scanned for common token/secret patterns before commit
