### PR TITLE
fix(cua-driver): publish portal-enabled Linux artifacts

### DIFF
--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -539,9 +539,11 @@ jobs:
 
           echo "Baked version ${VERSION} into working-tree install scripts:"
           grep -E '^CUA_DRIVER_RS_BAKED_VERSION=' libs/cua-driver/scripts/_install-rust.sh
-          grep -E '^\$Script:CuaDriverRsBakedVersion = ' libs/cua-driver/scripts/install.ps1
+          grep -E "^\\\$Script:CuaDriverRsBakedVersion = " libs/cua-driver/scripts/install.ps1
 
       - name: Stage release files
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           mkdir -p release-upload
           find artifacts -type f \( -name "*.tar.gz" -o -name "*.zip" \) \
@@ -579,7 +581,6 @@ jobs:
           # `cua-driver skills install`. The .md files are identical across
           # OS so we publish one asset per release tag. Naming matches the
           # versioned binary tarballs.
-          VERSION="${{ steps.version.outputs.version }}"
           # Asset name keeps the `cua-driver-rs-v*` prefix for backward
           # compat with the URL skills.rs constructs.
           #
@@ -613,18 +614,22 @@ jobs:
             echo '```'
           } > checksums.txt
           checksums=$(cat checksums.txt)
-          echo "checksums<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$checksums" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          {
+            echo "checksums<<EOF"
+            echo "$checksums"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Generate path-filtered release notes
         id: notes
+        env:
+          CURRENT_REF_NAME: ${{ github.ref_name }}
         run: |
           PREV_TAG=$(git tag -l "cua-driver-rs-v*" --sort=-v:refname \
-            | grep -v "^${{ github.ref_name }}$" \
+            | grep -v "^${CURRENT_REF_NAME}$" \
             | head -n 1 || echo "")
           if [ -n "$PREV_TAG" ]; then
-            NOTES=$(git log ${PREV_TAG}..HEAD --pretty=format:"* %s (%h) by @%an" -- "libs/cua-driver/rust" | head -50)
+            NOTES=$(git log "${PREV_TAG}..HEAD" --pretty=format:"* %s (%h) by @%an" -- "libs/cua-driver/rust" | head -50)
           else
             NOTES=$(git log --pretty=format:"* %s (%h) by @%an" -- "libs/cua-driver/rust" | head -50)
           fi

--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -153,6 +153,8 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install portal build dependencies
         run: |
           sudo apt-get update
@@ -163,34 +165,31 @@ jobs:
       - name: Determine version
         id: version
         shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           if [[ "$GITHUB_REF" == refs/tags/cua-driver-rs-v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/cua-driver-rs-v}"
           else
-            VERSION="${{ inputs.version }}"
+            VERSION="$INPUT_VERSION"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            libs/cua-driver/rust/target
-          key: rust-cua-driver-rs-linux-portal-${{ matrix.arch }}-${{ hashFiles('libs/cua-driver/rust/Cargo.lock', 'libs/cua-driver/rust/**/Cargo.toml') }}
-          restore-keys: |
-            rust-cua-driver-rs-linux-portal-${{ matrix.arch }}-
       - name: Build (release, portal-libei)
         working-directory: libs/cua-driver/rust
-        run: cargo build -p cua-driver --release --features portal-libei --target ${{ matrix.target }}
+        env:
+          TARGET: ${{ matrix.target }}
+        run: cargo build -p cua-driver --release --features portal-libei --target "$TARGET"
       - name: Package
         working-directory: libs/cua-driver/rust
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          ARCH: ${{ matrix.arch }}
+          TARGET: ${{ matrix.target }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          LABEL="linux-${{ matrix.arch }}-portal"
-          TARGET="${{ matrix.target }}"
+          LABEL="linux-${ARCH}-portal"
           STAGE="cua-driver-rs-${VERSION}-${LABEL}"
           mkdir -p "release/${STAGE}"
           cp "target/${TARGET}/release/cua-driver" "release/${STAGE}/"

--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -131,6 +131,79 @@ jobs:
           path: libs/cua-driver/rust/release/cua-driver-rs-*-linux-${{ matrix.arch }}*.tar.gz
           if-no-files-found: error
 
+  # Portal-enabled Linux builds for GNOME/KDE Wayland.
+  #
+  # These intentionally do NOT replace the portable linux-* artifacts above:
+  # portal-libei pulls PipeWire/libspa through libspa-sys, which cannot be built
+  # in the Debian 11 container that preserves the GLIBC_2.31 floor. Build the
+  # portal variants on current Ubuntu runners instead and publish them under a
+  # distinct `linux-<arch>-portal` label so install.sh can opt in explicitly.
+  build-linux-portal:
+    name: linux-${{ matrix.arch }}-portal
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+          - arch: arm64
+            target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install portal build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config \
+            libx11-dev libxi-dev libxtst-dev libxext-dev libwayland-dev \
+            libpipewire-0.3-dev libspa-0.2-dev libxkbcommon-dev clang libclang-dev
+      - name: Determine version
+        id: version
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/cua-driver-rs-v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/cua-driver-rs-v}"
+          else
+            VERSION="${{ inputs.version }}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            libs/cua-driver/rust/target
+          key: rust-cua-driver-rs-linux-portal-${{ matrix.arch }}-${{ hashFiles('libs/cua-driver/rust/Cargo.lock', 'libs/cua-driver/rust/**/Cargo.toml') }}
+          restore-keys: |
+            rust-cua-driver-rs-linux-portal-${{ matrix.arch }}-
+      - name: Build (release, portal-libei)
+        working-directory: libs/cua-driver/rust
+        run: cargo build -p cua-driver --release --features portal-libei --target ${{ matrix.target }}
+      - name: Package
+        working-directory: libs/cua-driver/rust
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          LABEL="linux-${{ matrix.arch }}-portal"
+          TARGET="${{ matrix.target }}"
+          STAGE="cua-driver-rs-${VERSION}-${LABEL}"
+          mkdir -p "release/${STAGE}"
+          cp "target/${TARGET}/release/cua-driver" "release/${STAGE}/"
+          cp ../../LICENSE.md "release/${STAGE}/LICENSE" 2>/dev/null || true
+          (cd release && tar -czf "${STAGE}.tar.gz" "${STAGE}")
+          tar -czf "release/${STAGE}-binary.tar.gz" -C "release/${STAGE}" cua-driver
+          ls -lh "release/${STAGE}.tar.gz" "release/${STAGE}-binary.tar.gz"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cua-driver-rs-linux-${{ matrix.arch }}-portal
+          path: libs/cua-driver/rust/release/cua-driver-rs-*-linux-${{ matrix.arch }}-portal*.tar.gz
+          if-no-files-found: error
+
   # ── Windows (x86_64 + arm64) ─────────────────────────────────────────────────
   # One matrixed job per Windows target. The arm64 build cross-compiles from
   # the x86_64 windows-latest runner — Rust + MSVC have first-class support
@@ -417,7 +490,7 @@ jobs:
 
   # ── Release ──────────────────────────────────────────────────────────────────
   release:
-    needs: [build-linux, build-windows, build-macos-universal]
+    needs: [build-linux, build-linux-portal, build-windows, build-macos-universal]
     if: startsWith(github.ref, 'refs/tags/cua-driver-rs-v')
     runs-on: ubuntu-latest
     steps:
@@ -595,7 +668,12 @@ jobs:
             The shell installer covers macOS and the Linux pre-release backend
             and installs the Rust implementation by default. Linux artifacts are
             published for early testing and are not yet an official supported
-            release tier.
+            release tier. On GNOME/KDE Wayland, install the portal-enabled Linux
+            artifact explicitly:
+
+            ```bash
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)" -- --linux-variant=portal
+            ```
 
             ### Install (Windows)
 
@@ -616,10 +694,14 @@ jobs:
             - `cua-driver-rs-${{ steps.version.outputs.version }}-darwin-universal-binary.tar.gz` — bare universal binary (single file at archive root; **no** .app — bypasses the TCC auto-relaunch path)
 
             **Linux pre-release**
-            - `cua-driver-rs-${{ steps.version.outputs.version }}-linux-x86_64.tar.gz` — directory tarball
-            - `cua-driver-rs-${{ steps.version.outputs.version }}-linux-x86_64-binary.tar.gz` — bare binary
-            - `cua-driver-rs-${{ steps.version.outputs.version }}-linux-arm64.tar.gz` — directory tarball (Linux on ARM / aarch64)
-            - `cua-driver-rs-${{ steps.version.outputs.version }}-linux-arm64-binary.tar.gz` — bare binary (Linux on ARM / aarch64)
+            - `cua-driver-rs-${{ steps.version.outputs.version }}-linux-x86_64.tar.gz` — portable directory tarball (GLIBC_2.31 floor, no portal-libei)
+            - `cua-driver-rs-${{ steps.version.outputs.version }}-linux-x86_64-binary.tar.gz` — portable bare binary (GLIBC_2.31 floor, no portal-libei)
+            - `cua-driver-rs-${{ steps.version.outputs.version }}-linux-x86_64-portal.tar.gz` — portal-enabled directory tarball for GNOME/KDE Wayland (higher glibc floor)
+            - `cua-driver-rs-${{ steps.version.outputs.version }}-linux-x86_64-portal-binary.tar.gz` — portal-enabled bare binary for GNOME/KDE Wayland (higher glibc floor)
+            - `cua-driver-rs-${{ steps.version.outputs.version }}-linux-arm64.tar.gz` — portable directory tarball (Linux on ARM / aarch64; GLIBC_2.31 floor, no portal-libei)
+            - `cua-driver-rs-${{ steps.version.outputs.version }}-linux-arm64-binary.tar.gz` — portable bare binary (Linux on ARM / aarch64; GLIBC_2.31 floor, no portal-libei)
+            - `cua-driver-rs-${{ steps.version.outputs.version }}-linux-arm64-portal.tar.gz` — portal-enabled directory tarball for GNOME/KDE Wayland (Linux on ARM / aarch64; higher glibc floor)
+            - `cua-driver-rs-${{ steps.version.outputs.version }}-linux-arm64-portal-binary.tar.gz` — portal-enabled bare binary for GNOME/KDE Wayland (Linux on ARM / aarch64; higher glibc floor)
 
             **Windows**
             - `cua-driver-rs-${{ steps.version.outputs.version }}-windows-x86_64.zip` — directory zip

--- a/libs/cua-driver/scripts/_install-rust.sh
+++ b/libs/cua-driver/scripts/_install-rust.sh
@@ -20,10 +20,15 @@
 # Flags:
 #   --bin-dir <path>     install the visible binary/symlink to <path>
 #                        instead of ~/.local/bin
+#   --linux-variant <portable|portal>
+#                        on Linux, install the default portable binary or the
+#                        portal-enabled GNOME/KDE Wayland binary
 #   --no-modify-path     skip auto-appending an `export PATH=...` line
 #
 # Env overrides:
 #   CUA_DRIVER_RS_VERSION=0.1.2          pin a specific release tag
+#   CUA_DRIVER_RS_LINUX_VARIANT=portal  install the portal-enabled Linux binary
+#                                        instead of the portable default
 #   CUA_DRIVER_RS_INSTALL_DIR=PATH       same as --bin-dir; sets the visible
 #                                        binary location
 #   CUA_DRIVER_RS_BIN_DIR=PATH           legacy alias for INSTALL_DIR
@@ -127,6 +132,7 @@ HOME_DIR="${CUA_DRIVER_RS_HOME:-$HOME/.cua-driver}"
 # install is staged so a single rooted home (~/.cua-driver) is left behind.
 LEGACY_HOME_DIR="$HOME/.cua-driver-rs"
 NO_MODIFY_PATH="${CUA_DRIVER_RS_NO_MODIFY_PATH:-0}"
+LINUX_VARIANT="${CUA_DRIVER_RS_LINUX_VARIANT:-portable}"
 # Post-install GC: how many per-version release dirs to retain. Validated
 # below as a non-negative integer; 0 means "never GC". The dir that
 # `current` resolves to is always preserved regardless of cutoff.
@@ -148,6 +154,13 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --bin-dir) BIN_DIR="$2"; shift 2 ;;
         --bin-dir=*) BIN_DIR="${1#*=}"; shift ;;
+        --linux-variant)
+            if [[ -z "${2:-}" || "${2:0:1}" == "-" ]]; then
+                printf 'error: --linux-variant requires a value: portable or portal\n' >&2
+                exit 2
+            fi
+            LINUX_VARIANT="$2"; shift 2 ;;
+        --linux-variant=*) LINUX_VARIANT="${1#*=}"; shift ;;
         --no-modify-path) NO_MODIFY_PATH=1; shift ;;
         *) shift ;;
     esac
@@ -167,6 +180,14 @@ TMP_DIR=$(mktemp -d)
 
 log() { printf '==> %s\n' "$*"; }
 err() { printf 'error: %s\n' "$*" >&2; }
+
+case "$LINUX_VARIANT" in
+    portable|portal) ;;
+    *)
+        err "unsupported CUA_DRIVER_RS_LINUX_VARIANT / --linux-variant: $LINUX_VARIANT (expected portable or portal)"
+        exit 2
+        ;;
+esac
 
 # --- Concurrent-install lockfile ---------------------------------------
 #
@@ -490,6 +511,17 @@ case "$OS-$ARCH_RAW" in
         ;;
 esac
 
+INSTALL_TARGET="$TARGET"
+if [[ "$LINUX_VARIANT" == "portal" ]]; then
+    if [[ "$OS" != "Linux" ]]; then
+        err "--linux-variant=portal is only supported on Linux"
+        exit 2
+    fi
+    LABEL="${LABEL}-portal"
+    INSTALL_TARGET="${TARGET}-portal"
+    log "using portal-enabled Linux variant (higher glibc floor; GNOME/KDE Wayland input)"
+fi
+
 for cmd in curl tar; do
     if ! command -v "$cmd" >/dev/null 2>&1; then
         err "$cmd not found on PATH"
@@ -702,11 +734,11 @@ else
     PACKAGES_DIR="$HOME_DIR/packages"
     RELEASES_DIR="$PACKAGES_DIR/releases"
     CURRENT_LINK="$PACKAGES_DIR/current"
-    VERSIONED_DIR="$RELEASES_DIR/${VERSION}-${TARGET}"
+    VERSIONED_DIR="$RELEASES_DIR/${VERSION}-${INSTALL_TARGET}"
 
     mkdir -p "$VERSIONED_DIR"
     install -m 0755 "$SRC" "$VERSIONED_DIR/$BINARY_NAME"
-    log "installed $VERSIONED_DIR/$BINARY_NAME (version $VERSION, target $TARGET)"
+    log "installed $VERSIONED_DIR/$BINARY_NAME (version $VERSION, target $INSTALL_TARGET)"
 
     # `ln -sfn` would replace an existing dir-symlink in place but is
     # not atomic on Linux (it unlinks then symlinks). Use a tmp symlink
@@ -715,7 +747,7 @@ else
     TMP_LINK="$PACKAGES_DIR/.current.$$"
     rm -rf "$TMP_LINK"
     # Relative target so the link is portable if $HOME_DIR is moved.
-    ln -s "releases/${VERSION}-${TARGET}" "$TMP_LINK"
+    ln -s "releases/${VERSION}-${INSTALL_TARGET}" "$TMP_LINK"
     # `mv -Tf` is the atomic-rename form on GNU coreutils (Linux). On
     # BSD mv (macOS — which doesn't take this branch in production, but
     # we still want this script to be runnable from a macOS dev shell
@@ -724,7 +756,7 @@ else
         rm -rf "$CURRENT_LINK"
         mv "$TMP_LINK" "$CURRENT_LINK"
     fi
-    log "current -> releases/${VERSION}-${TARGET}"
+    log "current -> releases/${VERSION}-${INSTALL_TARGET}"
 
     # Visible PATH entry: replace whatever was at $BIN_LINK (could be
     # an old plain binary from a pre-versioned-dirs install) with a
@@ -737,7 +769,7 @@ else
     # atomic `current` swap above so the about-to-be-active version is
     # never a deletion candidate (it's both the newest by mtime and
     # exempted via the current-symlink check inside prune_old_releases).
-    prune_old_releases "$RELEASES_DIR" "$CURRENT_LINK" "$TARGET" "$KEEP_VERSIONS"
+    prune_old_releases "$RELEASES_DIR" "$CURRENT_LINK" "$INSTALL_TARGET" "$KEEP_VERSIONS"
 fi
 
 # --- Sweep the legacy ~/.cua-driver-rs home -----------------------------

--- a/libs/cua-driver/scripts/install.sh
+++ b/libs/cua-driver/scripts/install.sh
@@ -10,6 +10,9 @@
 #                        ~/.local/bin (e.g. /usr/local/bin — that target needs sudo)
 #   --no-modify-path     skip auto-appending an `export PATH=...` line to your
 #                        shell rc when ~/.local/bin is missing from PATH
+#   --linux-variant <portable|portal>
+#                        forward to the Rust installer; use portal for
+#                        GNOME/KDE Wayland input via xdg-desktop-portal/libei
 #   --backend=rust       explicit Rust backend (no-op; Rust is the only option)
 #   --experimental-rust  legacy alias for --backend=rust (no-op)
 #   --backend=swift      retired Swift backend (no-op; accepted for compat)
@@ -20,6 +23,8 @@
 #   CUA_DRIVER_RS_INSTALL_DIR=PATH same as --bin-dir
 #   CUA_DRIVER_BIN_DIR=PATH        legacy alias for --bin-dir
 #   CUA_DRIVER_NO_MODIFY_PATH=1    same as --no-modify-path
+#   CUA_DRIVER_RS_LINUX_VARIANT=portal
+#                                  install the portal-enabled Linux binary
 #
 # Uninstall:
 #   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.sh)"


### PR DESCRIPTION
## Summary
- Add separate portal-enabled Linux release jobs that build `cua-driver` with `--features portal-libei` on current Ubuntu runners.
- Publish the portal builds under distinct `linux-<arch>-portal` artifact names so the existing portable GLIBC_2.31 Linux artifacts remain unchanged.
- Add `--linux-variant=portal` / `CUA_DRIVER_RS_LINUX_VARIANT=portal` installer selection and document the GNOME/KDE Wayland install path in the release notes.

## Root cause
The published Linux artifacts are built inside `debian:11` to preserve a GLIBC_2.31 floor. That container intentionally cannot build the `portal-libei` feature because PipeWire/libspa are too old and libei-related portal support is not available there. As a result, the code-level libei fallback from #2008 can exist without users having a release artifact that actually carries it.

This PR keeps the portable artifact path intact and adds an explicit portal variant for users who need GNOME/KDE Wayland input injection.

## Related reconnaissance
- Complements #2008, which implements the `portal-libei` runtime fallback in `platform-linux/src/wayland/mod.rs`.
- Addresses the packaging/install gap described by #1982 and the later user-facing issue #2105.
- Not intended to solve the separate X11/XSendEvent no-op issue #2022.

## Test plan
- `bash -n libs/cua-driver/scripts/_install-rust.sh libs/cua-driver/scripts/install.sh`
- `shellcheck -e SC2034,SC1091,SC2295,SC2015,SC2016 libs/cua-driver/scripts/install.sh libs/cua-driver/scripts/_install-rust.sh`
- `python - <<'PY' ... yaml.safe_load('.github/workflows/cd-rust-cua-driver.yml') ... PY`
- `$HOME/go/bin/actionlint -ignore 'SC2016' -ignore 'SC2129' -ignore 'SC2086' .github/workflows/cd-rust-cua-driver.yml`
- `git diff --check`
- Installer error-path smoke tests:
  - `bash libs/cua-driver/scripts/_install-rust.sh --linux-variant nope` exits 2 with a clear unsupported-variant error.
  - `bash libs/cua-driver/scripts/_install-rust.sh --linux-variant` exits 2 with a clear missing-value error.

Note: local `cargo check -p cua-driver --features portal-libei --target x86_64-unknown-linux-gnu` was attempted, but this VM lacks `libpipewire-0.3.pc` / `libspa-0.2.pc`. The new CI job installs `libpipewire-0.3-dev` and `libspa-0.2-dev` explicitly before the portal build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Linux installer option to choose between standard and portal-enabled builds.
  * Published portal-enabled Linux downloads for both x86_64 and arm64, including archive and direct-binary formats.
  * Updated release notes to show the portal-specific install command.

* **Documentation**
  * Expanded installer usage details with the new Linux variant option and environment override.

* **Bug Fixes**
  * Improved Linux install paths and update handling so versioned installs and cleanup stay consistent for each variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->