### PR TITLE
fix(cua-driver): make GNOME/KDE Wayland input actually land via libei (#2105, #1982)

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/health_report.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/health_report.rs
@@ -304,7 +304,7 @@ async fn check_wayland_backend() -> CheckEntry {
             );
         }
     };
-    let portal_libei_backend = if crate::wayland::PORTAL_LIBEI_ENABLED {
+    let remote_desktop_portal_reachable = if crate::wayland::PORTAL_LIBEI_ENABLED {
         tokio::task::spawn_blocking(probe_portal_remote_desktop)
             .await
             .ok()
@@ -313,13 +313,17 @@ async fn check_wayland_backend() -> CheckEntry {
     } else {
         false
     };
-    classify_wayland_backend(&snap, crate::wayland::PORTAL_LIBEI_ENABLED, portal_libei_backend)
+    classify_wayland_backend(
+        &snap,
+        crate::wayland::PORTAL_LIBEI_ENABLED,
+        remote_desktop_portal_reachable,
+    )
 }
 
 fn classify_wayland_backend(
     snap: &crate::wayland::WaylandManagers,
     portal_libei_enabled: bool,
-    portal_libei_backend: bool,
+    remote_desktop_portal_reachable: bool,
 ) -> CheckEntry {
     let msg = format!(
         "foreign-toplevel={ftl}, screencopy={cap}, ext-image-copy={ext_cap}, \
@@ -338,14 +342,15 @@ fn classify_wayland_backend(
         );
     }
     if !snap.virtual_pointer {
-        if portal_libei_backend {
+        if remote_desktop_portal_reachable {
             return CheckEntry::pass(
                 NAME_WAYLAND_BACKEND,
                 format!(
-                    "No wlroots virtual-pointer advertised ({msg}), but the \
-                     portal/libei RemoteDesktop backend is compiled in and \
-                     reachable; input will use xdg-desktop-portal + EIS on \
-                     non-wlroots compositors such as GNOME/Mutter and KDE/KWin."
+                    "No wlroots virtual-pointer advertised ({msg}), but this \
+                     portal/libei build can reach the RemoteDesktop portal; \
+                     input will attempt the xdg-desktop-portal + EIS handshake \
+                     on commands for non-wlroots compositors such as \
+                     GNOME/Mutter and KDE/KWin."
                 ),
             );
         }

--- a/libs/cua-driver/rust/crates/platform-linux/src/health_report.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/health_report.rs
@@ -347,10 +347,14 @@ fn classify_wayland_backend(
                 NAME_WAYLAND_BACKEND,
                 format!(
                     "No wlroots virtual-pointer advertised ({msg}), but this \
-                     portal/libei build can reach the RemoteDesktop portal; \
-                     input will attempt the xdg-desktop-portal + EIS handshake \
-                     on commands for non-wlroots compositors such as \
-                     GNOME/Mutter and KDE/KWin."
+                     portal/libei build can reach the RemoteDesktop portal \
+                     (proxy reachability only — the full create_session → \
+                     select_devices → start → connect_to_eis handshake is NOT \
+                     exercised here, to avoid a consent prompt on every doctor \
+                     run, so this is not a guarantee that injection succeeds); \
+                     input attempts the full xdg-desktop-portal + EIS handshake \
+                     on commands for non-wlroots compositors such as GNOME/Mutter \
+                     and KDE/KWin."
                 ),
             );
         }

--- a/libs/cua-driver/rust/crates/platform-linux/src/health_report.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/health_report.rs
@@ -304,10 +304,30 @@ async fn check_wayland_backend() -> CheckEntry {
             );
         }
     };
+    let portal_libei_backend = if crate::wayland::PORTAL_LIBEI_ENABLED {
+        tokio::task::spawn_blocking(probe_portal_remote_desktop)
+            .await
+            .ok()
+            .and_then(|r| r.ok())
+            .unwrap_or(false)
+    } else {
+        false
+    };
+    classify_wayland_backend(&snap, crate::wayland::PORTAL_LIBEI_ENABLED, portal_libei_backend)
+}
+
+fn classify_wayland_backend(
+    snap: &crate::wayland::WaylandManagers,
+    portal_libei_enabled: bool,
+    portal_libei_backend: bool,
+) -> CheckEntry {
     let msg = format!(
-        "foreign-toplevel={ftl}, screencopy={cap}, virtual-pointer={vp}, wl_shm={shm}",
+        "foreign-toplevel={ftl}, screencopy={cap}, ext-image-copy={ext_cap}, \
+         ext-output-source={ext_src}, virtual-pointer={vp}, wl_shm={shm}",
         ftl = snap.foreign_toplevel,
         cap = snap.screencopy,
+        ext_cap = snap.ext_image_copy_capture,
+        ext_src = snap.ext_output_image_capture_source,
         vp = snap.virtual_pointer,
         shm = snap.wl_shm,
     );
@@ -317,15 +337,32 @@ async fn check_wayland_backend() -> CheckEntry {
             format!("All wlroots manager globals advertised ({msg})."),
         );
     }
-    // Input-injection backend check (#1982). A non-wlroots compositor
-    // (KWin/Plasma, Mutter/GNOME) advertises no zwlr_virtual_pointer; on those
-    // the ONLY working input path is libei via xdg-desktop-portal. If this
-    // binary was built without `portal-libei` (the published tarball is — see
-    // #1967), input injection has no backend and silently no-ops: the agent
-    // cursor renders but clicks/keys are never delivered, while list_windows
-    // and capture still work. Report that explicitly instead of the misleading
-    // "input may fall back" partial-pass below.
-    if !snap.virtual_pointer && !crate::wayland::PORTAL_LIBEI_ENABLED {
+    if !snap.virtual_pointer {
+        if portal_libei_backend {
+            return CheckEntry::pass(
+                NAME_WAYLAND_BACKEND,
+                format!(
+                    "No wlroots virtual-pointer advertised ({msg}), but the \
+                     portal/libei RemoteDesktop backend is compiled in and \
+                     reachable; input will use xdg-desktop-portal + EIS on \
+                     non-wlroots compositors such as GNOME/Mutter and KDE/KWin."
+                ),
+            );
+        }
+        if portal_libei_enabled {
+            return CheckEntry::fail(
+                NAME_WAYLAND_BACKEND,
+                format!(
+                    "No wlroots virtual-pointer advertised ({msg}) and the \
+                     portal/libei RemoteDesktop backend is compiled in but not \
+                     reachable on this session; clicks and key presses have no \
+                     native Wayland input backend."
+                ),
+                "Ensure xdg-desktop-portal and a desktop backend such as \
+                 xdg-desktop-portal-gnome or xdg-desktop-portal-kde are running \
+                 on the session bus, or run under XWayland.",
+            );
+        }
         return CheckEntry::fail(
             NAME_WAYLAND_BACKEND,
             format!(
@@ -340,27 +377,27 @@ async fn check_wayland_backend() -> CheckEntry {
              compositor (sway, labwc, hyprland) where zwlr_virtual_pointer exists.",
         );
     }
-    // Partial-pass: list_windows + capture both work, but virtual-pointer
-    // input is missing. Require `wl_shm` here too — `check_screen_capture_capability`
-    // gates on both `screencopy && wl_shm`, so excluding `wl_shm` from the
-    // partial-pass verdict would let the matrices disagree on degenerate
-    // compositors that omit it.
+    // Partial-pass: list_windows + capture both work, but some optional
+    // wlroots globals are absent. Require `wl_shm` here too —
+    // `check_screen_capture_capability` gates on both `screencopy && wl_shm`,
+    // so excluding `wl_shm` from the partial-pass verdict would let the
+    // matrices disagree on degenerate compositors that omit it.
     if snap.foreign_toplevel && snap.screencopy && snap.wl_shm {
         return CheckEntry::pass(
             NAME_WAYLAND_BACKEND,
             format!(
-                "Core wlroots manager globals available; some optional globals missing ({msg}). \
-                 Input may fall back where virtual-pointer is absent."
+                "Core wlroots manager globals available; some optional globals missing ({msg})."
             ),
         );
     }
     CheckEntry::fail(
         NAME_WAYLAND_BACKEND,
         format!(
-            "Compositor does not advertise the wlroots manager globals cua-driver \
-             needs ({msg})."
+            "Compositor does not advertise a complete native Wayland backend \
+             set ({msg})."
         ),
-        "Use a wlroots-based compositor (sway, labwc, hyprland) or run under XWayland.",
+        "Use a wlroots-based compositor (sway, labwc, hyprland), a portal/libei \
+         build on GNOME/KDE, or run under XWayland.",
     )
 }
 
@@ -471,6 +508,45 @@ fn probe_portal_screenshot() -> anyhow::Result<bool> {
     Ok(false)
 }
 
+#[cfg(target_os = "linux")]
+fn probe_portal_remote_desktop() -> anyhow::Result<bool> {
+    #[cfg(feature = "portal-libei")]
+    {
+        use ashpd::desktop::remote_desktop::RemoteDesktop;
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| anyhow::anyhow!("failed to build tokio runtime for RemoteDesktop probe: {e}"))?;
+
+        rt.block_on(async {
+            match RemoteDesktop::new().await {
+                Ok(_) => Ok(true),
+                Err(e) => {
+                    let msg = format!("{e}");
+                    if msg.contains("ServiceUnknown")
+                        || msg.contains("NameHasNoOwner")
+                        || msg.contains("NotFound")
+                    {
+                        Ok(false)
+                    } else {
+                        Err(anyhow::anyhow!("portal RemoteDesktop probe failed: {e}"))
+                    }
+                }
+            }
+        })
+    }
+    #[cfg(not(feature = "portal-libei"))]
+    {
+        Ok(false)
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn probe_portal_remote_desktop() -> anyhow::Result<bool> {
+    Ok(false)
+}
+
 /// Stub of `wayland::WaylandManagers` so off-Linux builds compile. Always
 /// reports nothing advertised — non-Linux code paths never call this.
 #[cfg(not(target_os = "linux"))]
@@ -539,6 +615,42 @@ mod tests {
             assert_eq!(entry.status, CheckStatus::Skip, "{name} must be skipped");
             assert_eq!(entry.message, "not applicable on Linux");
         }
+    }
+
+    #[test]
+    fn wayland_backend_passes_on_non_wlroots_when_portal_libei_backend_is_reachable() {
+        let snap = crate::wayland::WaylandManagers {
+            foreign_toplevel: false,
+            screencopy: false,
+            ext_image_copy_capture: false,
+            ext_output_image_capture_source: false,
+            virtual_pointer: false,
+            wl_shm: true,
+        };
+
+        let entry = classify_wayland_backend(&snap, true, true);
+
+        assert_eq!(entry.status, CheckStatus::Pass);
+        assert!(entry.message.contains("portal/libei"), "{}", entry.message);
+        assert!(entry.message.contains("RemoteDesktop"), "{}", entry.message);
+    }
+
+    #[test]
+    fn wayland_backend_fails_on_non_wlroots_when_portal_libei_backend_is_unreachable() {
+        let snap = crate::wayland::WaylandManagers {
+            foreign_toplevel: false,
+            screencopy: false,
+            ext_image_copy_capture: false,
+            ext_output_image_capture_source: false,
+            virtual_pointer: false,
+            wl_shm: true,
+        };
+
+        let entry = classify_wayland_backend(&snap, true, false);
+
+        assert_eq!(entry.status, CheckStatus::Fail);
+        assert!(entry.message.contains("portal/libei"), "{}", entry.message);
+        assert!(entry.hint.as_deref().unwrap_or("").contains("xdg-desktop-portal"));
     }
 
     #[tokio::test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -2969,9 +2969,9 @@ impl Tool for DragTool {
         );
 
         // Native Wayland: emit press + interpolated motion + release as one
-        // virtual-pointer sequence (output-relative coords). Returns early so
-        // we don't fall into the X11 XSendEvent loop below.
-        if crate::wayland::is_wayland() {
+        // virtual-pointer (wlroots) or libei (GNOME/KDE) sequence, output-relative
+        // coords. Returns early so we don't fall into the X11 XSendEvent loop below.
+        if crate::wayland::wayland_input_enabled() {
             let (fxi, fyi) = (from_x.round() as i32, from_y.round() as i32);
             let (txi, tyi) = (to_x.round() as i32, to_y.round() as i32);
             let steps_u32 = steps as u32;

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -1596,7 +1596,7 @@ impl Tool for ClickTool {
         // then restore prior active. Mirrors macOS/Windows.
         let delivery = crate::input::delivery::DeliveryMode::from_args(&args);
         let result = tokio::task::spawn_blocking(move || -> anyhow::Result<&'static str> {
-            if crate::wayland::is_wayland() {
+            if crate::wayland::wayland_input_enabled() {
                 // Vision/pixel click on native Wayland. Mutter drops synthetic
                 // virtual-pointer events (the `wayland::click` warp doesn't land),
                 // so for a plain left single click resolve the screen pixel to the
@@ -1831,7 +1831,7 @@ impl Tool for TypeTextTool {
         // Native Wayland: keys go to the *focused* surface (no pid/window
         // targeting in the protocol). Type via the virtual-keyboard tool; pair
         // with a prior `click`/`activate` to focus the intended window.
-        if crate::wayland::is_wayland() {
+        if crate::wayland::wayland_input_enabled() {
             let text_len = text.chars().count();
             let text_w = text.clone();
             let result =
@@ -2144,7 +2144,7 @@ impl Tool for PressKeyTool {
         }
 
         // Native Wayland: send the key to the focused surface via virtual-keyboard.
-        if crate::wayland::is_wayland() {
+        if crate::wayland::wayland_input_enabled() {
             let key_w = key.clone();
             let result = tokio::task::spawn_blocking(move || crate::wayland::press_key(&key_w)).await;
             return match result {
@@ -2471,7 +2471,7 @@ impl Tool for ScrollTool {
         let cursor_id_for_task = cursor_id.clone();
         let delivery = crate::input::delivery::DeliveryMode::from_args(&args);
         let result = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-            if crate::wayland::is_wayland() {
+            if crate::wayland::wayland_input_enabled() {
                 return crate::wayland::scroll(xid, &direction_for_wayland, amount_u32);
             }
             // foreground: activate the window, then scroll, then restore — for
@@ -2611,7 +2611,7 @@ impl Tool for DoubleClickTool {
                     let lyi = ly as i32;
                     let cursor_id_for_task = cursor_id.clone();
                     let click_result = tokio::task::spawn_blocking(move || {
-                        if crate::wayland::is_wayland() {
+                        if crate::wayland::wayland_input_enabled() {
                             return crate::wayland::click(xid, lxi, lyi, 2, 1);
                         }
                         x11_pixel_click_no_focus_steal(&cursor_id_for_task, xid, lxi, lyi, 1, 2)
@@ -2671,7 +2671,7 @@ impl Tool for DoubleClickTool {
         let cursor_id_for_task = cursor_id.clone();
         let delivery = crate::input::delivery::DeliveryMode::from_args(&args);
         let result = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-            if crate::wayland::is_wayland() {
+            if crate::wayland::wayland_input_enabled() {
                 return crate::wayland::click(xid, xi, yi, 2, 1);
             }
             if delivery.is_foreground() {
@@ -2786,7 +2786,7 @@ impl Tool for RightClickTool {
                     let lyi = ly as i32;
                     let cursor_id_for_task = cursor_id.clone();
                     let click_result = tokio::task::spawn_blocking(move || {
-                        if crate::wayland::is_wayland() {
+                        if crate::wayland::wayland_input_enabled() {
                             return crate::wayland::click(xid, lxi, lyi, 1, 3);
                         }
                         x11_pixel_click_no_focus_steal(&cursor_id_for_task, xid, lxi, lyi, 3, 1)
@@ -2846,7 +2846,7 @@ impl Tool for RightClickTool {
         let cursor_id_for_task = cursor_id.clone();
         let delivery = crate::input::delivery::DeliveryMode::from_args(&args);
         let result = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-            if crate::wayland::is_wayland() {
+            if crate::wayland::wayland_input_enabled() {
                 return crate::wayland::click(xid, xi, yi, 1, 3);
             }
             if delivery.is_foreground() {
@@ -4732,7 +4732,7 @@ impl Tool for TypeTextCharsTool {
         };
         let text_len = text.chars().count();
         let result = tokio::task::spawn_blocking(move || {
-            if crate::wayland::is_wayland() {
+            if crate::wayland::wayland_input_enabled() {
                 // Per-char `wtype` loop with the requested delay — mirrors the
                 // X11 XSendEvent per-char path. Sleeping here is fine because
                 // we're inside spawn_blocking.

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -1573,7 +1573,7 @@ impl Tool for ClickTool {
         // `get_window_state` frames are screen-space, and `window_local_to_screen`
         // — an X11 `translate_coordinates` call — can't run with DISPLAY unset),
         // so use them directly. On X11 the coords are window-local; translate.
-        let glide_target = if crate::wayland::is_wayland() {
+        let glide_target = if crate::wayland::wayland_input_enabled() {
             Some((x, y))
         } else {
             tokio::task::spawn_blocking(move || window_local_to_screen(xid, x, y))
@@ -2283,7 +2283,7 @@ impl Tool for HotkeyTool {
         let deliver_fg = delivery.is_foreground() && !px_focused;
 
         let result = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-            if crate::wayland::is_wayland() {
+            if crate::wayland::wayland_input_enabled() {
                 // Native Wayland: route the modifier combo through wtype's
                 // -M/-k/-m sequence — the closest equivalent to the X11
                 // state-mask path. window_id is irrelevant once focused.
@@ -2652,7 +2652,7 @@ impl Tool for DoubleClickTool {
         // `get_window_state` frames are screen-space, and `window_local_to_screen`
         // — an X11 `translate_coordinates` call — can't run with DISPLAY unset),
         // so use them directly. On X11 the coords are window-local; translate.
-        let glide_target = if crate::wayland::is_wayland() {
+        let glide_target = if crate::wayland::wayland_input_enabled() {
             Some((x, y))
         } else {
             tokio::task::spawn_blocking(move || window_local_to_screen(xid, x, y))
@@ -2827,7 +2827,7 @@ impl Tool for RightClickTool {
         // `get_window_state` frames are screen-space, and `window_local_to_screen`
         // — an X11 `translate_coordinates` call — can't run with DISPLAY unset),
         // so use them directly. On X11 the coords are window-local; translate.
-        let glide_target = if crate::wayland::is_wayland() {
+        let glide_target = if crate::wayland::wayland_input_enabled() {
             Some((x, y))
         } else {
             tokio::task::spawn_blocking(move || window_local_to_screen(xid, x, y))
@@ -3965,7 +3965,7 @@ impl Tool for MoveCursorTool {
         // Off-thread because the wayland-client roundtrip is blocking. Best-effort
         // — overlay update + registry write already succeeded; surface a warning
         // only if the warp itself failed.
-        let real_warp_note = if crate::wayland::is_wayland() {
+        let real_warp_note = if crate::wayland::wayland_input_enabled() {
             let xi = x.round() as i32;
             let yi = y.round() as i32;
             match tokio::task::spawn_blocking(move || crate::wayland::move_cursor_absolute(window_id, xi, yi)).await {

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/libei.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/libei.rs
@@ -36,6 +36,7 @@ use std::sync::OnceLock;
 use std::thread;
 
 use crossbeam_channel::{bounded, Receiver, Sender};
+use xkbcommon::xkb;
 
 /// Buttons the public API exposes. Mapped to evdev codes in the worker
 /// thread so the libei surface only sees evdev integers.
@@ -407,6 +408,13 @@ struct EisState {
     /// would fail with "no EIS device negotiated yet"; the worker queues them
     /// until [`EisState::input_ready`] returns true.
     resumed: bool,
+    /// `char -> (evdev keycode, needs_shift)` built from the compositor's active
+    /// xkb keymap (delivered by the `ei_keyboard` device). Lets keycode typing
+    /// follow the user's real layout instead of assuming US. Empty until the
+    /// `Keymap` event arrives; typing then falls back to [`char_to_evdev`].
+    keymap_chars: HashMap<char, (u32, bool)>,
+    /// evdev keycode that produces `Shift_L` in the active keymap (else 42).
+    keymap_shift: Option<u32>,
 }
 
 #[derive(Default)]
@@ -577,8 +585,74 @@ impl EisState {
                     _ => {}
                 }
             }
+            Event::Keyboard(
+                _kb,
+                reis::ei::keyboard::Event::Keymap {
+                    keymap_type,
+                    size,
+                    keymap,
+                },
+            ) => {
+                if keymap_type == reis::ei::keyboard::KeymapType::Xkb {
+                    self.load_xkb_keymap(keymap, size);
+                }
+            }
             _ => {}
         }
+    }
+
+    /// Compile the compositor's xkb keymap (from the `ei_keyboard` `Keymap` fd)
+    /// into a `char -> (evdev keycode, shift)` table + the Shift keycode, so
+    /// keycode typing follows the user's real layout instead of assuming US.
+    /// Best-effort: on any failure the table stays empty and typing falls back
+    /// to [`char_to_evdev`].
+    fn load_xkb_keymap(&mut self, fd: std::os::unix::io::OwnedFd, size: u32) {
+        use std::io::{Read, Seek, SeekFrom};
+        const XKB_EVDEV_OFFSET: u32 = 8;
+        const SHIFT_L: u32 = 0xffe1;
+
+        let mut file = std::fs::File::from(fd);
+        let mut buf = vec![0u8; size as usize];
+        let _ = file.seek(SeekFrom::Start(0));
+        if file.read_exact(&mut buf).is_err() {
+            return;
+        }
+        // The keymap buffer is NUL-terminated text.
+        let text = match buf.iter().position(|&b| b == 0) {
+            Some(n) => String::from_utf8_lossy(&buf[..n]).into_owned(),
+            None => String::from_utf8_lossy(&buf).into_owned(),
+        };
+        let ctx = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+        let keymap = match xkb::Keymap::new_from_string(
+            &ctx,
+            text,
+            xkb::KEYMAP_FORMAT_TEXT_V1,
+            xkb::KEYMAP_COMPILE_NO_FLAGS,
+        ) {
+            Some(k) => k,
+            None => return,
+        };
+
+        let mut chars: HashMap<char, (u32, bool)> = HashMap::new();
+        let mut shift = None;
+        for kc in keymap.min_keycode().raw()..=keymap.max_keycode().raw() {
+            let keycode = xkb::Keycode::new(kc);
+            let evdev = kc.wrapping_sub(XKB_EVDEV_OFFSET);
+            // Level 0 = unshifted, 1 = shifted; scan 0 first so the unshifted
+            // mapping wins when a char is reachable both ways.
+            for level in 0..=1u32 {
+                for sym in keymap.key_get_syms_by_level(keycode, 0, level) {
+                    if shift.is_none() && sym.raw() == SHIFT_L {
+                        shift = Some(evdev);
+                    }
+                    if let Some(ch) = sym.key_char() {
+                        chars.entry(ch).or_insert((evdev, level == 1));
+                    }
+                }
+            }
+        }
+        self.keymap_chars = chars;
+        self.keymap_shift = shift;
     }
 
     /// True once the EIS handshake has negotiated a usable input device: a
@@ -659,20 +733,27 @@ impl EisState {
                     device.stop_emulating(self.last_serial);
                 } else {
                     use reis::ei::keyboard::KeyState;
-                    const KEY_LEFTSHIFT: u32 = 42;
                     let device = self.device_with_interface("ei_keyboard").ok_or_else(|| {
                         anyhow::anyhow!("no EIS keyboard device negotiated yet — wait for handshake")
                     })?;
                     let kb = require_device_interface::<reis::ei::Keyboard>(&self.devices, &device)?;
+                    let shift_code = self.keymap_shift.unwrap_or(42);
                     device.start_emulating(self.sequence, self.last_serial);
                     self.sequence = self.sequence.wrapping_add(1);
                     let mut fseq = 0u64;
                     for ch in text.chars() {
-                        let Some((code, shift)) = char_to_evdev(ch) else {
+                        // Prefer the compositor's actual keymap (layout-correct);
+                        // fall back to the US-layout table if no keymap arrived.
+                        let mapped = self
+                            .keymap_chars
+                            .get(&ch)
+                            .copied()
+                            .or_else(|| char_to_evdev(ch));
+                        let Some((code, shift)) = mapped else {
                             continue;
                         };
                         if shift {
-                            kb.key(KEY_LEFTSHIFT, KeyState::Press);
+                            kb.key(shift_code, KeyState::Press);
                             device.frame(self.last_serial, fseq);
                             fseq += 1;
                         }
@@ -683,7 +764,7 @@ impl EisState {
                         device.frame(self.last_serial, fseq);
                         fseq += 1;
                         if shift {
-                            kb.key(KEY_LEFTSHIFT, KeyState::Released);
+                            kb.key(shift_code, KeyState::Released);
                             device.frame(self.last_serial, fseq);
                             fseq += 1;
                         }

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/libei.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/libei.rs
@@ -525,63 +525,62 @@ impl EisState {
         match cmd {
             Cmd::Click { x, y, button, .. } => {
                 let (device, rel_x, rel_y) = self.pointer_device_for(*x, *y)?;
-                if let Some(ptr_abs) = device_interface::<reis::ei::PointerAbsolute>(&self.devices, &device) {
-                    device.start_emulating(self.sequence, self.last_serial);
-                    self.sequence = self.sequence.wrapping_add(1);
-                    ptr_abs.motion_absolute(rel_x, rel_y);
-                }
-                if let Some(btn) = device_interface::<reis::ei::Button>(&self.devices, &device) {
-                    btn.button(button.to_evdev(), reis::ei::button::ButtonState::Press);
-                    device.frame(self.last_serial, 0);
-                    btn.button(button.to_evdev(), reis::ei::button::ButtonState::Released);
-                    device.frame(self.last_serial, 1);
-                }
+                let ptr_abs = require_device_interface::<reis::ei::PointerAbsolute>(&self.devices, &device)?;
+                let btn = require_device_interface::<reis::ei::Button>(&self.devices, &device)?;
+
+                device.start_emulating(self.sequence, self.last_serial);
+                self.sequence = self.sequence.wrapping_add(1);
+                ptr_abs.motion_absolute(rel_x, rel_y);
+                btn.button(button.to_evdev(), reis::ei::button::ButtonState::Press);
+                device.frame(self.last_serial, 0);
+                btn.button(button.to_evdev(), reis::ei::button::ButtonState::Released);
+                device.frame(self.last_serial, 1);
                 device.stop_emulating(self.last_serial);
             }
             Cmd::MoveAbsolute { x, y, .. } => {
                 let (device, rel_x, rel_y) = self.pointer_device_for(*x, *y)?;
-                if let Some(ptr_abs) = device_interface::<reis::ei::PointerAbsolute>(&self.devices, &device) {
-                    device.start_emulating(self.sequence, self.last_serial);
-                    self.sequence = self.sequence.wrapping_add(1);
-                    ptr_abs.motion_absolute(rel_x, rel_y);
-                    device.frame(self.last_serial, 0);
-                    device.stop_emulating(self.last_serial);
-                }
+                let ptr_abs = require_device_interface::<reis::ei::PointerAbsolute>(&self.devices, &device)?;
+
+                device.start_emulating(self.sequence, self.last_serial);
+                self.sequence = self.sequence.wrapping_add(1);
+                ptr_abs.motion_absolute(rel_x, rel_y);
+                device.frame(self.last_serial, 0);
+                device.stop_emulating(self.last_serial);
             }
             Cmd::Scroll { dx, dy, .. } => {
                 let device = self.any_pointer_device()
                     .ok_or_else(|| anyhow::anyhow!("no EIS pointer device negotiated yet — wait for handshake"))?;
-                if let Some(scroll) = device_interface::<reis::ei::Scroll>(&self.devices, &device) {
-                    device.start_emulating(self.sequence, self.last_serial);
-                    self.sequence = self.sequence.wrapping_add(1);
-                    scroll.scroll(*dx as f32, *dy as f32);
-                    device.frame(self.last_serial, 0);
-                    device.stop_emulating(self.last_serial);
-                }
+                let scroll = require_device_interface::<reis::ei::Scroll>(&self.devices, &device)?;
+
+                device.start_emulating(self.sequence, self.last_serial);
+                self.sequence = self.sequence.wrapping_add(1);
+                scroll.scroll(*dx as f32, *dy as f32);
+                device.frame(self.last_serial, 0);
+                device.stop_emulating(self.last_serial);
             }
             Cmd::TypeText { text, .. } => {
                 let device = self.any_pointer_device()
                     .ok_or_else(|| anyhow::anyhow!("no EIS device negotiated yet — wait for handshake"))?;
-                if let Some(text_iface) = device_interface::<reis::ei::Text>(&self.devices, &device) {
-                    device.start_emulating(self.sequence, self.last_serial);
-                    self.sequence = self.sequence.wrapping_add(1);
-                    text_iface.utf8(text);
-                    device.frame(self.last_serial, 0);
-                    device.stop_emulating(self.last_serial);
-                }
+                let text_iface = require_device_interface::<reis::ei::Text>(&self.devices, &device)?;
+
+                device.start_emulating(self.sequence, self.last_serial);
+                self.sequence = self.sequence.wrapping_add(1);
+                text_iface.utf8(text);
+                device.frame(self.last_serial, 0);
+                device.stop_emulating(self.last_serial);
             }
             Cmd::PressKey { keycode, .. } => {
                 let device = self.any_pointer_device()
                     .ok_or_else(|| anyhow::anyhow!("no EIS device negotiated yet — wait for handshake"))?;
-                if let Some(kb) = device_interface::<reis::ei::Keyboard>(&self.devices, &device) {
-                    device.start_emulating(self.sequence, self.last_serial);
-                    self.sequence = self.sequence.wrapping_add(1);
-                    kb.key(*keycode, reis::ei::keyboard::KeyState::Press);
-                    device.frame(self.last_serial, 0);
-                    kb.key(*keycode, reis::ei::keyboard::KeyState::Released);
-                    device.frame(self.last_serial, 1);
-                    device.stop_emulating(self.last_serial);
-                }
+                let kb = require_device_interface::<reis::ei::Keyboard>(&self.devices, &device)?;
+
+                device.start_emulating(self.sequence, self.last_serial);
+                self.sequence = self.sequence.wrapping_add(1);
+                kb.key(*keycode, reis::ei::keyboard::KeyState::Press);
+                device.frame(self.last_serial, 0);
+                kb.key(*keycode, reis::ei::keyboard::KeyState::Released);
+                device.frame(self.last_serial, 1);
+                device.stop_emulating(self.last_serial);
             }
             Cmd::Shutdown => {}
         }
@@ -633,6 +632,14 @@ impl EisState {
             ))
             .map(|(d, _)| d.clone())
     }
+}
+
+fn require_device_interface<T: reis::Interface>(
+    devices: &HashMap<reis::ei::Device, DeviceData>,
+    device: &reis::ei::Device,
+) -> anyhow::Result<T> {
+    device_interface::<T>(devices, device)
+        .ok_or_else(|| anyhow::anyhow!("EIS device lacks required {} interface", T::NAME))
 }
 
 fn device_interface<T: reis::Interface>(

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/libei.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/libei.rs
@@ -409,12 +409,13 @@ fn run_calloop(context: reis::ei::Context, rx: Receiver<Cmd>) -> anyhow::Result<
             .dispatch(Some(std::time::Duration::from_millis(20)), &mut state)
             .map_err(|e| anyhow::anyhow!("calloop dispatch failed: {e}"))?;
 
-        // Run queued commands once a device is negotiated; time stale ones out.
+        // Run each queued command once the device IT needs is negotiated; time
+        // stale ones out. Per-command (not one global gate) so a keyboard-only
+        // session doesn't make keyboard commands wait 20s for a pointer device.
         if !pending.is_empty() {
-            let ready = state.input_ready();
             let mut still = Vec::with_capacity(pending.len());
             for (cmd, queued) in pending.drain(..) {
-                if ready || queued.elapsed() >= READY_TIMEOUT {
+                if state.cmd_ready(&cmd) || queued.elapsed() >= READY_TIMEOUT {
                     state.handle_command(cmd);
                 } else {
                     still.push((cmd, queued));
@@ -648,6 +649,12 @@ impl EisState {
         const XKB_EVDEV_OFFSET: u32 = 8;
         const SHIFT_L: u32 = 0xffe1;
 
+        // Sanity-cap the size from the (trusted, but possibly buggy) compositor
+        // event: real xkb keymaps are a few KiB; refuse absurd values rather
+        // than attempt a multi-GB allocation.
+        if size == 0 || size as usize > 16 * 1024 * 1024 {
+            return;
+        }
         let mut file = std::fs::File::from(fd);
         let mut buf = vec![0u8; size as usize];
         let _ = file.seek(SeekFrom::Start(0));
@@ -692,16 +699,28 @@ impl EisState {
         self.keymap_shift = shift;
     }
 
-    /// True once the EIS handshake has negotiated a usable input device: a
-    /// pointer/keyboard device that has announced its interfaces and been
-    /// `Resumed` by the server. Commands run before this fail with "no EIS
-    /// device negotiated yet", so `run_calloop` queues them until this holds.
-    fn input_ready(&self) -> bool {
-        // Gate on the absolute-pointer device: we always request Keyboard|Pointer,
-        // and Mutter/KWin announce the absolute pointer alongside (typically
-        // after) the keyboard, so once it exists every device a command needs
-        // has arrived. Avoids running a command against a half-negotiated seat.
-        self.resumed && self.device_with_interface("ei_pointer_absolute").is_some()
+    /// True once the device THIS command needs has been negotiated and
+    /// `Resumed`. Gating per-command (rather than on one global pointer check)
+    /// means a keyboard-only session doesn't stall keyboard commands waiting for
+    /// an absolute-pointer device that never arrives — and vice versa. Commands
+    /// run before their device exists fail with "no EIS device negotiated yet",
+    /// so `run_calloop` queues them until this holds (or READY_TIMEOUT elapses).
+    fn cmd_ready(&self, cmd: &Cmd) -> bool {
+        if !self.resumed {
+            return false;
+        }
+        match cmd {
+            Cmd::Click { .. } | Cmd::MoveAbsolute { .. } | Cmd::Drag { .. } => {
+                self.device_with_interface("ei_pointer_absolute").is_some()
+            }
+            Cmd::Scroll { .. } => self.device_with_interface("ei_scroll").is_some(),
+            Cmd::PressKey { .. } => self.device_with_interface("ei_keyboard").is_some(),
+            Cmd::TypeText { .. } => {
+                self.device_with_interface("ei_text").is_some()
+                    || self.device_with_interface("ei_keyboard").is_some()
+            }
+            Cmd::Shutdown => true,
+        }
     }
 
     fn handle_command(&mut self, cmd: Cmd) {
@@ -747,11 +766,18 @@ impl EisState {
                 let ptr_abs =
                     require_device_interface::<reis::ei::PointerAbsolute>(&self.devices, &device)?;
                 let btn = require_device_interface::<reis::ei::Button>(&self.devices, &device)?;
-                // Map the drag end into the same region the start resolved to.
-                let off_x = *from_x as f32 - from_rx;
-                let off_y = *from_y as f32 - from_ry;
-                let to_rx = *to_x as f32 - off_x;
-                let to_ry = *to_y as f32 - off_y;
+                // Map the drag end into the SAME device's region (a single EIS
+                // emulation session can't span devices). Fall back to the start
+                // region's offset when no region of this device contains the end
+                // (single-region device, or a point just off-screen) — this is
+                // correct only within one region, but avoids the cross-monitor
+                // mis-mapping of blindly reusing the start offset.
+                let (to_rx, to_ry) =
+                    self.region_local_on(&device, *to_x, *to_y).unwrap_or_else(|| {
+                        let off_x = *from_x as f32 - from_rx;
+                        let off_y = *from_y as f32 - from_ry;
+                        (*to_x as f32 - off_x, *to_y as f32 - off_y)
+                    });
 
                 device.start_emulating(self.sequence, self.last_serial);
                 self.sequence = self.sequence.wrapping_add(1);
@@ -759,7 +785,10 @@ impl EisState {
                 device.frame(self.last_serial, 0);
                 btn.button(button.to_evdev(), reis::ei::button::ButtonState::Press);
                 device.frame(self.last_serial, 1);
-                let n = (*steps).max(1);
+                // Bound the interpolation: run_command executes synchronously in
+                // the worker loop, so a huge step count would block EIS event
+                // processing (incl. Ping) and balloon the unflushed request queue.
+                let n = (*steps).max(1).min(500);
                 let mut fseq = 2u64;
                 for s in 1..=n {
                     let t = s as f32 / n as f32;
@@ -818,6 +847,7 @@ impl EisState {
                     device.start_emulating(self.sequence, self.last_serial);
                     self.sequence = self.sequence.wrapping_add(1);
                     let mut fseq = 0u64;
+                    let mut skipped = 0usize;
                     for ch in text.chars() {
                         // Prefer the compositor's actual keymap (layout-correct);
                         // fall back to the US-layout table if no keymap arrived.
@@ -827,6 +857,10 @@ impl EisState {
                             .copied()
                             .or_else(|| char_to_evdev(ch));
                         let Some((code, shift)) = mapped else {
+                            // No keycode for this char in the keymap/US table
+                            // (e.g. CJK/emoji via the keycode path). Skip it, but
+                            // don't pretend the whole string was typed.
+                            skipped += 1;
                             continue;
                         };
                         if shift {
@@ -845,6 +879,13 @@ impl EisState {
                             device.frame(self.last_serial, fseq);
                             fseq += 1;
                         }
+                    }
+                    if skipped > 0 {
+                        tracing::warn!(
+                            "libei keycode typing skipped {skipped} char(s) with no \
+                             keycode in the active keymap (e.g. non-Latin/emoji) — \
+                             the ei_text path (libei 1.6+) would type these verbatim"
+                        );
                     }
                     device.stop_emulating(self.last_serial);
                 }
@@ -902,6 +943,17 @@ impl EisState {
         let device = self.device_with_interface("ei_pointer_absolute")
             .ok_or_else(|| anyhow::anyhow!("no EIS absolute-pointer device negotiated yet — wait for handshake"))?;
         Ok((device, x as f32, y as f32))
+    }
+
+    /// Region-local coordinates for absolute `(x, y)` within one of `device`'s
+    /// announced regions, or `None` when no region of that device contains the
+    /// point. Used to map a drag endpoint into the same device the drag start
+    /// resolved to (a single EIS emulation session can't span devices).
+    fn region_local_on(&self, device: &reis::ei::Device, x: f64, y: f64) -> Option<(f32, f32)> {
+        let data = self.devices.get(device)?;
+        data.regions.iter().find(|r| r.contains(x, y)).map(|r| {
+            (x as f32 - r.offset_x, y as f32 - r.offset_y)
+        })
     }
 
     /// The negotiated device that exposes `iface` (e.g. `ei_pointer_absolute`,

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/libei.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/libei.rs
@@ -84,6 +84,15 @@ enum Cmd {
         keycode: u32,
         reply: Sender<anyhow::Result<()>>,
     },
+    Drag {
+        from_x: f64,
+        from_y: f64,
+        to_x: f64,
+        to_y: f64,
+        steps: u32,
+        button: Button,
+        reply: Sender<anyhow::Result<()>>,
+    },
     Shutdown,
 }
 
@@ -181,6 +190,34 @@ pub fn press_key(keycode: u32) -> anyhow::Result<()> {
     ensure_started()?;
     let (tx_r, rx_r) = bounded(1);
     tx()?.send(Cmd::PressKey { keycode, reply: tx_r })
+        .map_err(|e| anyhow::anyhow!("libei worker channel closed: {e}"))?;
+    rx_r.recv().map_err(|e| anyhow::anyhow!("libei reply closed: {e}"))?
+}
+
+/// Press `button` at (from_x, from_y), move through `steps` interpolated points
+/// to (to_x, to_y), then release — a genuine button-held drag (text selection /
+/// drag-and-drop / slider). Coordinates are absolute within the announced
+/// device region, like [`click`].
+pub fn drag(
+    from_x: f64,
+    from_y: f64,
+    to_x: f64,
+    to_y: f64,
+    steps: u32,
+    button: Button,
+) -> anyhow::Result<()> {
+    ensure_started()?;
+    let (tx_r, rx_r) = bounded(1);
+    tx()?
+        .send(Cmd::Drag {
+            from_x,
+            from_y,
+            to_x,
+            to_y,
+            steps,
+            button,
+            reply: tx_r,
+        })
         .map_err(|e| anyhow::anyhow!("libei worker channel closed: {e}"))?;
     rx_r.recv().map_err(|e| anyhow::anyhow!("libei reply closed: {e}"))?
 }
@@ -676,6 +713,7 @@ impl EisState {
             Cmd::Scroll { reply, .. } => { let _ = reply.send(result); }
             Cmd::TypeText { reply, .. } => { let _ = reply.send(result); }
             Cmd::PressKey { reply, .. } => { let _ = reply.send(result); }
+            Cmd::Drag { reply, .. } => { let _ = reply.send(result); }
             Cmd::Shutdown => {}
         }
     }
@@ -694,6 +732,45 @@ impl EisState {
                 device.frame(self.last_serial, 0);
                 btn.button(button.to_evdev(), reis::ei::button::ButtonState::Released);
                 device.frame(self.last_serial, 1);
+                device.stop_emulating(self.last_serial);
+            }
+            Cmd::Drag {
+                from_x,
+                from_y,
+                to_x,
+                to_y,
+                steps,
+                button,
+                ..
+            } => {
+                let (device, from_rx, from_ry) = self.pointer_device_for(*from_x, *from_y)?;
+                let ptr_abs =
+                    require_device_interface::<reis::ei::PointerAbsolute>(&self.devices, &device)?;
+                let btn = require_device_interface::<reis::ei::Button>(&self.devices, &device)?;
+                // Map the drag end into the same region the start resolved to.
+                let off_x = *from_x as f32 - from_rx;
+                let off_y = *from_y as f32 - from_ry;
+                let to_rx = *to_x as f32 - off_x;
+                let to_ry = *to_y as f32 - off_y;
+
+                device.start_emulating(self.sequence, self.last_serial);
+                self.sequence = self.sequence.wrapping_add(1);
+                ptr_abs.motion_absolute(from_rx, from_ry);
+                device.frame(self.last_serial, 0);
+                btn.button(button.to_evdev(), reis::ei::button::ButtonState::Press);
+                device.frame(self.last_serial, 1);
+                let n = (*steps).max(1);
+                let mut fseq = 2u64;
+                for s in 1..=n {
+                    let t = s as f32 / n as f32;
+                    let ix = from_rx + (to_rx - from_rx) * t;
+                    let iy = from_ry + (to_ry - from_ry) * t;
+                    ptr_abs.motion_absolute(ix, iy);
+                    device.frame(self.last_serial, fseq);
+                    fseq += 1;
+                }
+                btn.button(button.to_evdev(), reis::ei::button::ButtonState::Released);
+                device.frame(self.last_serial, fseq);
                 device.stop_emulating(self.last_serial);
             }
             Cmd::MoveAbsolute { x, y, .. } => {

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/libei.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/libei.rs
@@ -197,9 +197,31 @@ pub fn shutdown() {
 // the negotiated input region. It runs a calloop event loop that handles
 // both the EIS protocol and the inbound command channel.
 
+/// Owns the resources that must outlive a single libei call so the portal
+/// RemoteDesktop + EIS session stays alive for the whole worker-thread lifetime.
+///
+/// GNOME/Mutter (and KDE) tie the RemoteDesktop session — and therefore the
+/// handed-off EIS fd — to the D-Bus connection that created it. The previous
+/// code dropped the ashpd proxy/session (and the tokio runtime backing their
+/// zbus connection) at the end of `open_eis_context`, before the calloop loop
+/// even started, so the session died immediately on those compositors (#2105).
+/// Holding these for the worker's lifetime keeps the connection — and the
+/// session — open. The `$LIBEI_SOCKET` / cua-compositor fast path has no portal
+/// session, so it carries `None`.
+#[allow(dead_code)] // fields are keep-alive only; never read
+enum PortalKeepAlive {
+    None,
+    Portal {
+        _rt: tokio::runtime::Runtime,
+        _proxy: ashpd::desktop::remote_desktop::RemoteDesktop,
+        _session: ashpd::desktop::Session<ashpd::desktop::remote_desktop::RemoteDesktop>,
+    },
+}
+
 fn worker(rx: Receiver<Cmd>) -> anyhow::Result<()> {
-    // Phase 1 — acquire an EIS context.
-    let context = open_eis_context()
+    // Phase 1 — acquire an EIS context (plus, on the portal path, a keep-alive
+    // that owns the ashpd RemoteDesktop session + its tokio runtime).
+    let (context, _portal_keepalive) = open_eis_context()
         .map_err(|e| anyhow::anyhow!("failed to obtain EIS connection: {e}"))?;
 
     // Phase 2 — handshake. The reis API requires we call context.handshake()
@@ -210,17 +232,19 @@ fn worker(rx: Receiver<Cmd>) -> anyhow::Result<()> {
     // Phase 3 — run the calloop event loop. We use a calloop Generic source
     // wrapping the ei::Context's underlying socket so the loop wakes up on
     // EIS messages. The command channel is polled at the top of each loop
-    // iteration.
+    // iteration. `_portal_keepalive` stays bound until this fn returns — i.e.
+    // across the entire loop — so the portal session is never dropped early (#2105).
     run_calloop(context, rx)
 }
 
 /// Open the EIS context. Fast path: $LIBEI_SOCKET (cua-compositor /
 /// inject mode). Fallback: ashpd portal RemoteDesktop handshake.
-fn open_eis_context() -> anyhow::Result<reis::ei::Context> {
+fn open_eis_context() -> anyhow::Result<(reis::ei::Context, PortalKeepAlive)> {
     if let Some(ctx) = reis::ei::Context::connect_to_env()
         .map_err(|e| anyhow::anyhow!("env ei socket open failed: {e}"))?
     {
-        return Ok(ctx);
+        // $LIBEI_SOCKET / cua-compositor fast path: no portal session to keep alive.
+        return Ok((ctx, PortalKeepAlive::None));
     }
 
     // Portal RemoteDesktop fallback.
@@ -233,12 +257,18 @@ fn open_eis_context() -> anyhow::Result<reis::ei::Context> {
     use ashpd::enumflags2::BitFlags;
     use std::os::unix::net::UnixStream;
 
-    let rt = tokio::runtime::Builder::new_current_thread()
+    // A multi-threaded runtime (1 worker) so the zbus connection backing the
+    // RemoteDesktop session keeps being driven after this fn returns. The
+    // session must stay live for the whole worker lifetime (#2105); a
+    // current-thread runtime would freeze the connection the moment we stop
+    // calling `block_on`, and GNOME/KDE would tear the session down.
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
         .enable_all()
         .build()
         .map_err(|e| anyhow::anyhow!("failed to build tokio runtime for ashpd: {e}"))?;
 
-    let fd = rt.block_on(async {
+    let (fd, proxy, session) = rt.block_on(async {
         let proxy = RemoteDesktop::new()
             .await
             .map_err(|e| anyhow::anyhow!("portal RemoteDesktop proxy unreachable: {e}. Install xdg-desktop-portal-gnome / xdg-desktop-portal-kde."))?;
@@ -281,13 +311,13 @@ fn open_eis_context() -> anyhow::Result<reis::ei::Context> {
             .connect_to_eis(&session, ConnectToEISOptions::default())
             .await
             .map_err(|e| anyhow::anyhow!("portal connect_to_eis failed: {e}"))?;
-        anyhow::Ok(fd)
+        anyhow::Ok((fd, proxy, session))
     })?;
 
     let stream = UnixStream::from(fd);
     let ctx = reis::ei::Context::new(stream)
         .map_err(|e| anyhow::anyhow!("reis ei::Context::new failed: {e}"))?;
-    Ok(ctx)
+    Ok((ctx, PortalKeepAlive::Portal { _rt: rt, _proxy: proxy, _session: session }))
 }
 
 // ── calloop dispatch ────────────────────────────────────────────────────
@@ -318,13 +348,21 @@ fn run_calloop(context: reis::ei::Context, rx: Receiver<Cmd>) -> anyhow::Result<
 
     let mut state = EisState::default();
 
-    // Command channel: drain at the top of each loop iteration with a
-    // bounded timeout so the EIS source stays responsive.
+    // Inbound commands can arrive before the EIS handshake has negotiated a
+    // usable input device — seat → device → interface → Resumed is async and
+    // only advances while `dispatch` runs, and the portal consent-and-connect
+    // path (#2105) returns before the device is live. Running a command against
+    // a not-yet-negotiated device fails with "no EIS device negotiated yet". So
+    // queue commands and run each only once `input_ready()`; fail any that wait
+    // longer than READY_TIMEOUT (handle_command then replies with the natural
+    // "no device" error) so a caller blocked on the reply never hangs forever.
+    let mut pending: Vec<(Cmd, std::time::Instant)> = Vec::new();
+    const READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+
     loop {
-        // Process pending commands.
         match rx.try_recv() {
             Ok(Cmd::Shutdown) => break,
-            Ok(cmd) => state.handle_command(cmd),
+            Ok(cmd) => pending.push((cmd, std::time::Instant::now())),
             Err(crossbeam_channel::TryRecvError::Empty) => {}
             Err(crossbeam_channel::TryRecvError::Disconnected) => break,
         }
@@ -332,6 +370,20 @@ fn run_calloop(context: reis::ei::Context, rx: Receiver<Cmd>) -> anyhow::Result<
         event_loop
             .dispatch(Some(std::time::Duration::from_millis(20)), &mut state)
             .map_err(|e| anyhow::anyhow!("calloop dispatch failed: {e}"))?;
+
+        // Run queued commands once a device is negotiated; time stale ones out.
+        if !pending.is_empty() {
+            let ready = state.input_ready();
+            let mut still = Vec::with_capacity(pending.len());
+            for (cmd, queued) in pending.drain(..) {
+                if ready || queued.elapsed() >= READY_TIMEOUT {
+                    state.handle_command(cmd);
+                } else {
+                    still.push((cmd, queued));
+                }
+            }
+            pending = still;
+        }
 
         // The handle_command path may have queued frame() requests; flush
         // them once per loop iteration so the EIS server sees them.
@@ -350,6 +402,11 @@ struct EisState {
     devices: HashMap<reis::ei::Device, DeviceData>,
     sequence: u32,
     last_serial: u32,
+    /// Set once the server has sent at least one device `Resumed` — the point
+    /// at which emulation is actually accepted. Commands issued before this
+    /// would fail with "no EIS device negotiated yet"; the worker queues them
+    /// until [`EisState::input_ready`] returns true.
+    resumed: bool,
 }
 
 #[derive(Default)]
@@ -421,11 +478,20 @@ impl EisState {
                     handshake.handshake_version(1);
                     handshake.name("cua-driver");
                     handshake.context_type(reis::ei::handshake::ContextType::Sender);
+                    // Advertise the interface set + versions that reis 0.7's own
+                    // EIS client examples use against real compositors. The
+                    // previous list advertised ei_device v2 and omitted
+                    // ei_pingpong, which Mutter rejects — it closes the EIS
+                    // connection immediately after our handshake `finish()`
+                    // (observed: one Handshake event, then read() errors). reis's
+                    // handshaker also requires ei_pingpong / ei_callback /
+                    // ei_connection. See reis 0.7 examples/type-text.rs.
                     for (iface, ver) in [
                         ("ei_callback", 1u32),
                         ("ei_connection", 1),
+                        ("ei_pingpong", 1),
                         ("ei_seat", 1),
-                        ("ei_device", 2),
+                        ("ei_device", 1),
                         ("ei_pointer", 1),
                         ("ei_pointer_absolute", 1),
                         ("ei_button", 1),
@@ -438,11 +504,17 @@ impl EisState {
                     handshake.finish();
                 }
             }
-            Event::Connection(_conn, ev) => {
-                if let reis::ei::connection::Event::Seat { seat } = ev {
+            Event::Connection(_conn, ev) => match ev {
+                reis::ei::connection::Event::Seat { seat } => {
                     self.seats.insert(seat, SeatData::default());
                 }
-            }
+                // The EIS server pings to check liveness; failing to answer
+                // makes it drop the connection. Mirror reis's examples.
+                reis::ei::connection::Event::Ping { ping } => {
+                    ping.done(0);
+                }
+                _ => {}
+            },
             Event::Seat(seat, ev) => {
                 let data = self.seats.entry(seat.clone()).or_default();
                 match ev {
@@ -500,12 +572,25 @@ impl EisState {
                     }
                     reis::ei::device::Event::Resumed { serial } => {
                         self.last_serial = serial;
+                        self.resumed = true;
                     }
                     _ => {}
                 }
             }
             _ => {}
         }
+    }
+
+    /// True once the EIS handshake has negotiated a usable input device: a
+    /// pointer/keyboard device that has announced its interfaces and been
+    /// `Resumed` by the server. Commands run before this fail with "no EIS
+    /// device negotiated yet", so `run_calloop` queues them until this holds.
+    fn input_ready(&self) -> bool {
+        // Gate on the absolute-pointer device: we always request Keyboard|Pointer,
+        // and Mutter/KWin announce the absolute pointer alongside (typically
+        // after) the keyboard, so once it exists every device a command needs
+        // has arrived. Avoids running a command against a half-negotiated seat.
+        self.resumed && self.device_with_interface("ei_pointer_absolute").is_some()
     }
 
     fn handle_command(&mut self, cmd: Cmd) {
@@ -548,8 +633,8 @@ impl EisState {
                 device.stop_emulating(self.last_serial);
             }
             Cmd::Scroll { dx, dy, .. } => {
-                let device = self.any_pointer_device()
-                    .ok_or_else(|| anyhow::anyhow!("no EIS pointer device negotiated yet — wait for handshake"))?;
+                let device = self.device_with_interface("ei_scroll")
+                    .ok_or_else(|| anyhow::anyhow!("no EIS scroll device negotiated yet — wait for handshake"))?;
                 let scroll = require_device_interface::<reis::ei::Scroll>(&self.devices, &device)?;
 
                 device.start_emulating(self.sequence, self.last_serial);
@@ -559,19 +644,56 @@ impl EisState {
                 device.stop_emulating(self.last_serial);
             }
             Cmd::TypeText { text, .. } => {
-                let device = self.any_pointer_device()
-                    .ok_or_else(|| anyhow::anyhow!("no EIS device negotiated yet — wait for handshake"))?;
-                let text_iface = require_device_interface::<reis::ei::Text>(&self.devices, &device)?;
-
-                device.start_emulating(self.sequence, self.last_serial);
-                self.sequence = self.sequence.wrapping_add(1);
-                text_iface.utf8(text);
-                device.frame(self.last_serial, 0);
-                device.stop_emulating(self.last_serial);
+                // Prefer ei_text (libei 1.6+ — a UTF-8 string, layout-correct).
+                // Mutter does NOT advertise ei_text, so fall back to keycode
+                // typing via ei_keyboard: map each char to a US-layout evdev
+                // keycode + shift and emit press/release. Chars with no US-layout
+                // keycode are skipped (a documented limitation — full layout
+                // support needs an xkb keymap, like reis's type-text example).
+                if let Some(device) = self.device_with_interface("ei_text") {
+                    let text_iface = require_device_interface::<reis::ei::Text>(&self.devices, &device)?;
+                    device.start_emulating(self.sequence, self.last_serial);
+                    self.sequence = self.sequence.wrapping_add(1);
+                    text_iface.utf8(text);
+                    device.frame(self.last_serial, 0);
+                    device.stop_emulating(self.last_serial);
+                } else {
+                    use reis::ei::keyboard::KeyState;
+                    const KEY_LEFTSHIFT: u32 = 42;
+                    let device = self.device_with_interface("ei_keyboard").ok_or_else(|| {
+                        anyhow::anyhow!("no EIS keyboard device negotiated yet — wait for handshake")
+                    })?;
+                    let kb = require_device_interface::<reis::ei::Keyboard>(&self.devices, &device)?;
+                    device.start_emulating(self.sequence, self.last_serial);
+                    self.sequence = self.sequence.wrapping_add(1);
+                    let mut fseq = 0u64;
+                    for ch in text.chars() {
+                        let Some((code, shift)) = char_to_evdev(ch) else {
+                            continue;
+                        };
+                        if shift {
+                            kb.key(KEY_LEFTSHIFT, KeyState::Press);
+                            device.frame(self.last_serial, fseq);
+                            fseq += 1;
+                        }
+                        kb.key(code, KeyState::Press);
+                        device.frame(self.last_serial, fseq);
+                        fseq += 1;
+                        kb.key(code, KeyState::Released);
+                        device.frame(self.last_serial, fseq);
+                        fseq += 1;
+                        if shift {
+                            kb.key(KEY_LEFTSHIFT, KeyState::Released);
+                            device.frame(self.last_serial, fseq);
+                            fseq += 1;
+                        }
+                    }
+                    device.stop_emulating(self.last_serial);
+                }
             }
             Cmd::PressKey { keycode, .. } => {
-                let device = self.any_pointer_device()
-                    .ok_or_else(|| anyhow::anyhow!("no EIS device negotiated yet — wait for handshake"))?;
+                let device = self.device_with_interface("ei_keyboard")
+                    .ok_or_else(|| anyhow::anyhow!("no EIS keyboard device negotiated yet — wait for handshake"))?;
                 let kb = require_device_interface::<reis::ei::Keyboard>(&self.devices, &device)?;
 
                 device.start_emulating(self.sequence, self.last_serial);
@@ -602,12 +724,12 @@ impl EisState {
     /// back to the first pointer device with the raw coordinates, which
     /// matches the pre-multi-monitor behaviour.
     fn pointer_device_for(&self, x: f64, y: f64) -> anyhow::Result<(reis::ei::Device, f32, f32)> {
-        let is_pointer = |data: &DeviceData| matches!(
-            data.device_type,
-            Some(reis::ei::device::DeviceType::Virtual) | Some(reis::ei::device::DeviceType::Physical)
-        );
+        // Absolute motion needs the device that actually carries
+        // ei_pointer_absolute — Mutter/KWin split the relative and absolute
+        // pointers onto separate devices, and only one of them accepts an
+        // absolute warp.
         for (device, data) in self.devices.iter() {
-            if !is_pointer(data) {
+            if !data.interfaces.contains_key("ei_pointer_absolute") {
                 continue;
             }
             for region in &data.regions {
@@ -618,20 +740,117 @@ impl EisState {
                 }
             }
         }
-        // Fallback: first pointer device, raw coords (single-region behaviour).
-        let device = self.any_pointer_device()
-            .ok_or_else(|| anyhow::anyhow!("no EIS pointer device negotiated yet — wait for handshake"))?;
+        // Fallback: first absolute-pointer device, raw coords (single-region).
+        let device = self.device_with_interface("ei_pointer_absolute")
+            .ok_or_else(|| anyhow::anyhow!("no EIS absolute-pointer device negotiated yet — wait for handshake"))?;
         Ok((device, x as f32, y as f32))
     }
 
-    fn any_pointer_device(&self) -> Option<reis::ei::Device> {
-        self.devices.iter()
-            .find(|(_, data)| matches!(
-                data.device_type,
-                Some(reis::ei::device::DeviceType::Virtual) | Some(reis::ei::device::DeviceType::Physical)
-            ))
+    /// The negotiated device that exposes `iface` (e.g. `ei_pointer_absolute`,
+    /// `ei_scroll`, `ei_keyboard`, `ei_text`). Mutter/KWin announce one device
+    /// per capability group — a relative pointer, an absolute pointer, a
+    /// keyboard — so a command must pick the device carrying the interface it
+    /// needs, not just "the first virtual device" (which may be the relative
+    /// pointer that has no `ei_pointer_absolute`).
+    fn device_with_interface(&self, iface: &str) -> Option<reis::ei::Device> {
+        self.devices
+            .iter()
+            .find(|(_, data)| data.interfaces.contains_key(iface))
             .map(|(d, _)| d.clone())
     }
+}
+
+/// Map a character to a US-layout evdev keycode + whether Shift is needed.
+/// Used by the keyboard-typing fallback when the compositor's EIS exposes no
+/// `ei_text` interface (e.g. Mutter). Returns `None` for characters outside the
+/// US-ASCII printable set — those are skipped rather than mistyped. Full
+/// layout-correct typing would need an xkb keymap (see reis `type-text` example).
+fn char_to_evdev(c: char) -> Option<(u32, bool)> {
+    // Letter codes follow the QWERTY scancode layout (input-event-codes.h).
+    fn letter(c: char) -> u32 {
+        // KEY_A..KEY_Z follow the QWERTY scancode layout, not the alphabet.
+        match c {
+            'a' => 30,
+            'b' => 48,
+            'c' => 46,
+            'd' => 32,
+            'e' => 18,
+            'f' => 33,
+            'g' => 34,
+            'h' => 35,
+            'i' => 23,
+            'j' => 36,
+            'k' => 37,
+            'l' => 38,
+            'm' => 50,
+            'n' => 49,
+            'o' => 24,
+            'p' => 25,
+            'q' => 16,
+            'r' => 19,
+            's' => 31,
+            't' => 20,
+            'u' => 22,
+            'v' => 47,
+            'w' => 17,
+            'x' => 45,
+            'y' => 21,
+            'z' => 44,
+            _ => 0,
+        }
+    }
+    // (keycode, needs_shift). Digit/symbol codes and their shifted variants
+    // follow the US QWERTY row (input-event-codes.h).
+    Some(match c {
+        'a'..='z' => (letter(c), false),
+        'A'..='Z' => (letter(c.to_ascii_lowercase()), true),
+        '1' => (2, false),
+        '2' => (3, false),
+        '3' => (4, false),
+        '4' => (5, false),
+        '5' => (6, false),
+        '6' => (7, false),
+        '7' => (8, false),
+        '8' => (9, false),
+        '9' => (10, false),
+        '0' => (11, false),
+        '!' => (2, true),
+        '@' => (3, true),
+        '#' => (4, true),
+        '$' => (5, true),
+        '%' => (6, true),
+        '^' => (7, true),
+        '&' => (8, true),
+        '*' => (9, true),
+        '(' => (10, true),
+        ')' => (11, true),
+        ' ' => (57, false),
+        '\n' => (28, false),
+        '\t' => (15, false),
+        '-' => (12, false),
+        '_' => (12, true),
+        '=' => (13, false),
+        '+' => (13, true),
+        '[' => (26, false),
+        '{' => (26, true),
+        ']' => (27, false),
+        '}' => (27, true),
+        '\\' => (43, false),
+        '|' => (43, true),
+        ';' => (39, false),
+        ':' => (39, true),
+        '\'' => (40, false),
+        '"' => (40, true),
+        '`' => (41, false),
+        '~' => (41, true),
+        ',' => (51, false),
+        '<' => (51, true),
+        '.' => (52, false),
+        '>' => (52, true),
+        '/' => (53, false),
+        '?' => (53, true),
+        _ => return None,
+    })
 }
 
 fn require_device_interface<T: reis::Interface>(

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
@@ -784,6 +784,50 @@ pub fn screenshot_window_dispatch(xid: u64) -> anyhow::Result<Vec<u8>> {
 
 // ── Input session helper ─────────────────────────────────────────────────────
 
+/// Sentinel substring carried by the `open_vptr_session` error when the
+/// compositor exposes no `zwlr_virtual_pointer_manager_v1` (KWin/Plasma,
+/// Mutter/GNOME). The input dispatch matches on this to decide whether the
+/// libei/portal fallback ([`libei`]) can recover the call. Kept as a string
+/// marker (rather than a typed error) so the existing `anyhow::Result`
+/// signatures of every input fn are unchanged. See #1982.
+pub const NO_VPTR_MARKER: &str = "no-zwlr-virtual-pointer";
+
+/// True when `err` is the "compositor has no wlroots virtual-pointer" failure
+/// from [`open_vptr_session`] — i.e. the point where a non-wlroots compositor
+/// needs the libei fallback rather than a hard error.
+fn is_no_vptr(err: &anyhow::Error) -> bool {
+    err.to_string().contains(NO_VPTR_MARKER)
+}
+
+/// Run the wlroots virtual-pointer closure `f`; if it fails specifically
+/// because the compositor exposes no `zwlr_virtual_pointer_manager_v1` and this
+/// binary carries the `portal-libei` feature, run the libei `fallback` instead.
+/// Any other wlroots error (and the no-vptr error in a build without the
+/// feature) propagates unchanged. This is the single seam through which #1982's
+/// KDE/GNOME input recovery flows.
+fn with_libei_fallback<T>(
+    f: impl FnOnce() -> anyhow::Result<T>,
+    #[allow(unused_variables)] fallback: impl FnOnce() -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    match f() {
+        Ok(v) => Ok(v),
+        Err(e) if is_no_vptr(&e) => {
+            #[cfg(feature = "portal-libei")]
+            {
+                tracing::info!(
+                    "wlroots virtual-pointer unavailable ({e}); falling back to libei/portal"
+                );
+                return fallback();
+            }
+            #[cfg(not(feature = "portal-libei"))]
+            {
+                Err(e)
+            }
+        }
+        Err(e) => Err(e),
+    }
+}
+
 /// Live virtual-pointer session: connection + queue + the bound objects every
 /// pointer op (click, scroll, drag) needs. Returned by [`open_vptr_session`].
 pub struct VptrSession {
@@ -810,33 +854,50 @@ pub fn open_vptr_session(activate_window_id: Option<u32>) -> anyhow::Result<Vptr
 
     let mut state = State::default();
     queue.roundtrip(&mut state)?;
-    if state.manager.is_none() {
-        anyhow::bail!("compositor does not expose zwlr_foreign_toplevel_manager_v1");
-    }
     for _ in 0..4 {
         queue.roundtrip(&mut state)?;
+    }
+
+    // Evaluate the virtual-pointer / NO_VPTR_MARKER path FIRST: on compositors
+    // that expose neither zwlr_virtual_pointer nor zwlr_foreign_toplevel
+    // (KWin/Plasma, Mutter/GNOME) we must surface the marker so
+    // `with_libei_fallback` re-routes through libei/portal. Requiring
+    // foreign-toplevel up front would mask the marker and leave the libei
+    // fallback dead. See #1982.
+    let mgr = state.vptr_manager.clone().ok_or_else(|| {
+        if PORTAL_LIBEI_ENABLED {
+            // The caller (via `with_libei_fallback`) recognises NO_VPTR_MARKER
+            // and re-routes the op through the libei/portal backend, which DOES
+            // reach KWin/Plasma and Mutter/GNOME. Keep the marker in the text.
+            anyhow::anyhow!(
+                "compositor does not expose zwlr_virtual_pointer_manager_v1 \
+                 ({NO_VPTR_MARKER})"
+            )
+        } else {
+            // KWin/Plasma and Mutter/GNOME don't implement zwlr_virtual_pointer,
+            // and this build has no libei/portal fallback — so input has no
+            // backend at all rather than silently no-op'ing. The marker still
+            // lets the dispatch layer classify the failure uniformly. See #1982.
+            anyhow::anyhow!(
+                "no input backend for this compositor ({NO_VPTR_MARKER}): it \
+                 exposes no zwlr_virtual_pointer_manager_v1 and this build was \
+                 compiled without libei/portal support (#1982). Use the \
+                 portal-enabled Linux build for input on KDE Plasma / GNOME, or \
+                 a wlroots compositor (sway, labwc, hyprland)."
+            )
+        }
+    })?;
+
+    // foreign-toplevel is only needed to activate a specific window before
+    // synthesising input; require it only when a caller actually asks for that.
+    if activate_window_id.is_some() && state.manager.is_none() {
+        anyhow::bail!("compositor does not expose zwlr_foreign_toplevel_manager_v1");
     }
 
     let seat = state
         .seat
         .clone()
         .ok_or_else(|| anyhow::anyhow!("compositor exposed no wl_seat for virtual-pointer input"))?;
-    let mgr = state.vptr_manager.clone().ok_or_else(|| {
-        if PORTAL_LIBEI_ENABLED {
-            anyhow::anyhow!("compositor does not expose zwlr_virtual_pointer_manager_v1")
-        } else {
-            // KWin/Plasma and Mutter/GNOME don't implement zwlr_virtual_pointer,
-            // and this build has no libei/portal fallback — so input has no
-            // backend at all rather than silently no-op'ing. See #1982.
-            anyhow::anyhow!(
-                "no input backend for this compositor: it exposes no \
-                 zwlr_virtual_pointer_manager_v1 and this build was compiled \
-                 without libei/portal support (#1982). Use the portal-enabled \
-                 Linux build for input on KDE Plasma / GNOME, or a wlroots \
-                 compositor (sway, labwc, hyprland)."
-            )
-        }
-    })?;
 
     if let Some(id) = activate_window_id {
         let handle = state
@@ -851,6 +912,42 @@ pub fn open_vptr_session(activate_window_id: Option<u32>) -> anyhow::Result<Vptr
     let vptr = mgr.create_virtual_pointer(Some(&seat), &qh, ());
     let (output_w, output_h) = (state.output_w.max(1), state.output_h.max(1));
     Ok(VptrSession { conn, queue, state, seat, vptr, output_w, output_h })
+}
+
+/// Query the first `wl_output`'s pixel dimensions via a short Wayland
+/// roundtrip, independent of the virtual-pointer protocol. Used by the libei
+/// fallback (which never opens a `VptrSession`) to reproduce the vptr path's
+/// default-to-centre and clamp behaviour so both backends treat coordinates
+/// identically. Falls back to `(1, 1)` when no output reports a mode.
+#[cfg(feature = "portal-libei")]
+fn output_dimensions() -> anyhow::Result<(u32, u32)> {
+    let conn = Connection::connect_to_env()?;
+    let mut queue = conn.new_event_queue::<State>();
+    let qh = queue.handle();
+    conn.display().get_registry(&qh, ());
+    let mut state = State::default();
+    queue.roundtrip(&mut state)?;
+    for _ in 0..4 {
+        queue.roundtrip(&mut state)?;
+    }
+    Ok((state.output_w.max(1), state.output_h.max(1)))
+}
+
+/// Reproduce the wlroots vptr path's coordinate handling for the libei
+/// fallback: `(0, 0)` defaults to the output centre, and any value is clamped
+/// to `[0, dim-1]`. Keeps `click(.., 0, 0, ..)` landing on centre rather than
+/// the top-left corner across both backends.
+#[cfg(feature = "portal-libei")]
+fn normalize_click_xy(x: i32, y: i32, w: u32, h: u32) -> (i32, i32) {
+    let (px, py) = if x == 0 && y == 0 {
+        ((w / 2) as i32, (h / 2) as i32)
+    } else {
+        (x, y)
+    };
+    (
+        px.clamp(0, (w as i32).saturating_sub(1)),
+        py.clamp(0, (h as i32).saturating_sub(1)),
+    )
 }
 
 /// Map a cua/X11 pointer button (1=left / 2=middle / 3=right) to its evdev
@@ -871,6 +968,15 @@ pub fn evdev_pointer_button(button: u8) -> u32 {
 /// real coords. A short delay between iterations gives the compositor time
 /// to discriminate single vs. double clicks.
 pub fn click(window_id: u64, x: i32, y: i32, count: u32, button: u8) -> anyhow::Result<()> {
+    with_libei_fallback(
+        || click_vptr(window_id, x, y, count, button),
+        || libei_click(x, y, count, button),
+    )
+}
+
+/// wlroots virtual-pointer implementation of [`click`]. Falls back to libei via
+/// [`with_libei_fallback`] when the compositor exposes no virtual-pointer.
+fn click_vptr(window_id: u64, x: i32, y: i32, count: u32, button: u8) -> anyhow::Result<()> {
     let mut sess = open_vptr_session(Some(window_id as u32))?;
     let (w, h) = (sess.output_w, sess.output_h);
     let (px, py) = if x == 0 && y == 0 {
@@ -906,6 +1012,15 @@ pub fn click(window_id: u64, x: i32, y: i32, count: u32, button: u8) -> anyhow::
 /// virtual-pointer protocol, mirroring how a real wheel notch decomposes. The
 /// magnitude follows wl_pointer convention: ±10 (in wl_fixed = ×256) per tick.
 pub fn scroll(window_id: u64, direction: &str, amount: u32) -> anyhow::Result<()> {
+    let direction = direction.to_string();
+    with_libei_fallback(
+        || scroll_vptr(window_id, &direction, amount),
+        || libei_scroll(&direction, amount),
+    )
+}
+
+/// wlroots virtual-pointer implementation of [`scroll`].
+fn scroll_vptr(window_id: u64, direction: &str, amount: u32) -> anyhow::Result<()> {
     let mut sess = open_vptr_session(Some(window_id as u32))?;
     let (axis, sign): (Axis, i32) = match direction.to_ascii_lowercase().as_str() {
         "up" => (Axis::VerticalScroll, -1),
@@ -965,6 +1080,14 @@ pub fn last_synth_cursor_pos() -> Option<(i32, i32)> {
 /// the compositor commits the warp before returning. Records the position in
 /// the synthetic-cursor registry so `last_synth_cursor_pos` can report it.
 pub fn move_cursor_absolute(window_id: Option<u64>, x: i32, y: i32) -> anyhow::Result<()> {
+    with_libei_fallback(
+        || move_cursor_absolute_vptr(window_id, x, y),
+        || libei_move_absolute(x, y),
+    )
+}
+
+/// wlroots virtual-pointer implementation of [`move_cursor_absolute`].
+fn move_cursor_absolute_vptr(window_id: Option<u64>, x: i32, y: i32) -> anyhow::Result<()> {
     let mut sess = open_vptr_session(window_id.map(|w| w as u32))?;
     let (w, h) = (sess.output_w, sess.output_h);
     let px = x.clamp(0, (w as i32).saturating_sub(1)) as u32;
@@ -984,6 +1107,23 @@ pub fn move_cursor_absolute(window_id: Option<u64>, x: i32, y: i32) -> anyhow::R
 /// output-relative; window-local coords need the EIS inject socket
 /// (`CUA_INJECT_SOCKET`).
 pub fn drag(
+    window_id: u64,
+    from_x: i32,
+    from_y: i32,
+    to_x: i32,
+    to_y: i32,
+    steps: u32,
+    button: u8,
+) -> anyhow::Result<()> {
+    with_libei_fallback(
+        || drag_vptr(window_id, from_x, from_y, to_x, to_y, steps, button),
+        || libei_drag(from_x, from_y, to_x, to_y, steps, button),
+    )
+}
+
+/// wlroots virtual-pointer implementation of [`drag`].
+#[allow(clippy::too_many_arguments)]
+fn drag_vptr(
     window_id: u64,
     from_x: i32,
     from_y: i32,
@@ -1048,24 +1188,34 @@ pub fn type_text(text: &str) -> anyhow::Result<()> {
     // to wire up keyboard routing, and that first key is dropped. Sacrificing a
     // modifier tap (no character) absorbs the drop so the real text lands intact;
     // it's harmless where routing is already live (labwc).
-    let out = std::process::Command::new("wtype")
+    let result = std::process::Command::new("wtype")
         .args(["-k", "Shift_L", "--"])
         .arg(text)
-        .output()?;
-    if !out.status.success() {
-        anyhow::bail!("wtype failed: {}", String::from_utf8_lossy(&out.stderr));
+        .output();
+    match result {
+        Ok(out) if out.status.success() => Ok(()),
+        // `wtype` relies on `zwp_virtual_keyboard_v1`, which KWin/Plasma and
+        // Mutter/GNOME don't implement (and the binary may be missing wtype
+        // entirely). On a portal-libei build, route typing through libei's
+        // `ei_text` interface instead. See #1982.
+        other => with_wtype_libei_fallback(
+            || libei_type_text(text),
+            other.map(|o| String::from_utf8_lossy(&o.stderr).into_owned()),
+        ),
     }
-    Ok(())
 }
 
 /// Press a single named key into the focused Wayland surface via `wtype -k`.
 pub fn press_key(key: &str) -> anyhow::Result<()> {
     let keysym = key_to_keysym(key);
-    let out = std::process::Command::new("wtype").args(["-k", &keysym]).output()?;
-    if !out.status.success() {
-        anyhow::bail!("wtype -k {keysym} failed: {}", String::from_utf8_lossy(&out.stderr));
+    let result = std::process::Command::new("wtype").args(["-k", &keysym]).output();
+    match result {
+        Ok(out) if out.status.success() => Ok(()),
+        other => with_wtype_libei_fallback(
+            || libei_press_key(key),
+            other.map(|o| String::from_utf8_lossy(&o.stderr).into_owned()),
+        ),
     }
-    Ok(())
 }
 
 /// Press a key combination (modifiers + final key) via `wtype`. Each modifier
@@ -1088,15 +1238,43 @@ pub fn hotkey(keys: &[String]) -> anyhow::Result<()> {
         args.push("-m".into());
         args.push(m.clone());
     }
-    let out = std::process::Command::new("wtype").args(&args).output()?;
-    if !out.status.success() {
-        anyhow::bail!(
-            "wtype {} failed: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&out.stderr)
-        );
+    let result = std::process::Command::new("wtype").args(&args).output();
+    match result {
+        Ok(out) if out.status.success() => Ok(()),
+        other => {
+            let stderr = other.map(|o| String::from_utf8_lossy(&o.stderr).into_owned());
+            #[cfg(feature = "portal-libei")]
+            {
+                // A bare key (no modifiers) is just a single key press, which
+                // the libei adapter handles. Route it through the same wtype→
+                // libei fallback as `press_key`. Only true modifier chords stay
+                // unsupported: the worker doesn't yet wire ei_keyboard modifier
+                // state, so dropping the modifiers would mis-fire the bare key.
+                // See #1982.
+                if mods.is_empty() {
+                    return with_wtype_libei_fallback(
+                        || libei_press_key(&final_key),
+                        stderr,
+                    );
+                }
+                let _ = &stderr;
+                anyhow::bail!(
+                    "hotkey {keys:?} cannot be delivered: this compositor has no \
+                     virtual-keyboard ({}) and the libei fallback does not yet \
+                     support modifier chords",
+                    stderr.unwrap_or_else(|_| "wtype unavailable".into())
+                );
+            }
+            #[cfg(not(feature = "portal-libei"))]
+            {
+                anyhow::bail!(
+                    "wtype {} failed: {}",
+                    args.join(" "),
+                    stderr.unwrap_or_else(|_| "wtype unavailable".into())
+                );
+            }
+        }
     }
-    Ok(())
 }
 
 /// Split a `keys` array into wtype-compatible modifier names and a single
@@ -1142,6 +1320,257 @@ fn key_to_keysym(key: &str) -> String {
         _ => return key.to_string(),
     }
     .to_string()
+}
+
+// ── libei / portal fallback adapters ───────────────────────────────────────
+//
+// These bridge the wlroots-shaped public input API (output-relative integer
+// coordinates, cua button codes, X-keysym key names) onto the libei worker
+// (`libei` module), which speaks logical device-region floats and evdev
+// codes. They are the recovery path for compositors with no
+// `zwlr_virtual_pointer_v1` (KWin/Plasma, Mutter/GNOME) — see #1982.
+//
+// In a build WITHOUT the `portal-libei` feature the `libei` module does not
+// exist, so each adapter compiles to an error stub. The dispatch seams above
+// only ever CALL these inside `#[cfg(feature = "portal-libei")]` branches, so
+// the stubs are dead in that build; they exist purely so the closures passed
+// to `with_libei_fallback` / `with_wtype_libei_fallback` type-check.
+
+/// libei recovery wrapper for the `wtype`-based typing/key functions: when the
+/// virtual-keyboard shell-out failed (`wtype_err`), try the libei `run` on a
+/// portal-libei build, otherwise surface the original wtype failure.
+fn with_wtype_libei_fallback(
+    #[allow(unused_variables)] run: impl FnOnce() -> anyhow::Result<()>,
+    wtype_err: Result<String, std::io::Error>,
+) -> anyhow::Result<()> {
+    #[cfg(feature = "portal-libei")]
+    {
+        match wtype_err {
+            Ok(stderr) => tracing::info!(
+                "wtype failed ({stderr}); falling back to libei/portal typing"
+            ),
+            Err(e) => tracing::info!(
+                "wtype unavailable ({e}); falling back to libei/portal typing"
+            ),
+        }
+        run()
+    }
+    #[cfg(not(feature = "portal-libei"))]
+    {
+        let _ = run;
+        match wtype_err {
+            Ok(stderr) => anyhow::bail!("wtype failed: {stderr}"),
+            Err(e) => anyhow::bail!("wtype unavailable: {e}"),
+        }
+    }
+}
+
+// Stubs for the no-feature build: the dispatch seams never call these (the
+// libei branch in `with_libei_fallback` / `with_wtype_libei_fallback` is
+// `#[cfg]`-d out), but the closures still need them to exist to type-check.
+#[cfg(not(feature = "portal-libei"))]
+fn libei_click(_x: i32, _y: i32, _count: u32, _button: u8) -> anyhow::Result<()> {
+    unreachable!("libei fallback compiled out (no portal-libei feature)")
+}
+#[cfg(not(feature = "portal-libei"))]
+fn libei_scroll(_direction: &str, _amount: u32) -> anyhow::Result<()> {
+    unreachable!("libei fallback compiled out (no portal-libei feature)")
+}
+#[cfg(not(feature = "portal-libei"))]
+fn libei_move_absolute(_x: i32, _y: i32) -> anyhow::Result<()> {
+    unreachable!("libei fallback compiled out (no portal-libei feature)")
+}
+#[cfg(not(feature = "portal-libei"))]
+#[allow(clippy::too_many_arguments)]
+fn libei_drag(
+    _from_x: i32,
+    _from_y: i32,
+    _to_x: i32,
+    _to_y: i32,
+    _steps: u32,
+    _button: u8,
+) -> anyhow::Result<()> {
+    unreachable!("libei fallback compiled out (no portal-libei feature)")
+}
+#[cfg(not(feature = "portal-libei"))]
+fn libei_type_text(_text: &str) -> anyhow::Result<()> {
+    unreachable!("libei fallback compiled out (no portal-libei feature)")
+}
+#[cfg(not(feature = "portal-libei"))]
+fn libei_press_key(_key: &str) -> anyhow::Result<()> {
+    unreachable!("libei fallback compiled out (no portal-libei feature)")
+}
+
+#[cfg(feature = "portal-libei")]
+fn cua_button_to_libei(button: u8) -> libei::Button {
+    match button {
+        2 => libei::Button::Middle,
+        3 => libei::Button::Right,
+        _ => libei::Button::Left,
+    }
+}
+
+#[cfg(feature = "portal-libei")]
+fn libei_click(x: i32, y: i32, count: u32, button: u8) -> anyhow::Result<()> {
+    let btn = cua_button_to_libei(button);
+    let (w, h) = output_dimensions()?;
+    let (px, py) = normalize_click_xy(x, y, w, h);
+    libei::move_absolute(px as f64, py as f64)?;
+    for i in 0..count.max(1) {
+        if i > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(80));
+        }
+        libei::click(px as f64, py as f64, btn)?;
+    }
+    record_synth_cursor(px, py);
+    Ok(())
+}
+
+#[cfg(feature = "portal-libei")]
+fn libei_scroll(direction: &str, amount: u32) -> anyhow::Result<()> {
+    // libei scroll is logical-unit deltas; mirror the wlroots ±10/tick step.
+    let (dx, dy): (f64, f64) = match direction.to_ascii_lowercase().as_str() {
+        "up" => (0.0, -10.0),
+        "down" => (0.0, 10.0),
+        "left" => (-10.0, 0.0),
+        "right" => (10.0, 0.0),
+        other => anyhow::bail!("unknown scroll direction: {other}"),
+    };
+    for i in 0..amount.max(1) {
+        if i > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        libei::scroll(dx, dy)?;
+    }
+    Ok(())
+}
+
+#[cfg(feature = "portal-libei")]
+fn libei_move_absolute(x: i32, y: i32) -> anyhow::Result<()> {
+    // Match `move_cursor_absolute_vptr`: clamp to output bounds (no
+    // default-to-centre — an explicit (0,0) move means the top-left corner).
+    let (w, h) = output_dimensions()?;
+    let px = x.clamp(0, (w as i32).saturating_sub(1));
+    let py = y.clamp(0, (h as i32).saturating_sub(1));
+    libei::move_absolute(px as f64, py as f64)?;
+    record_synth_cursor(px, py);
+    Ok(())
+}
+
+#[cfg(feature = "portal-libei")]
+fn libei_drag(
+    _from_x: i32,
+    _from_y: i32,
+    _to_x: i32,
+    _to_y: i32,
+    _steps: u32,
+    _button: u8,
+) -> anyhow::Result<()> {
+    // A real drag needs the button HELD across the interpolated motion. The
+    // libei worker only exposes a combined press+release `click`, with no
+    // standalone button-hold (press/release) primitive, so we cannot perform a
+    // genuine press→move→release sequence. Emulating it as move→click-at-end
+    // would hold nothing and silently no-op drag-and-drop / selection / resize
+    // while reporting success — so fail loudly instead. See #1982.
+    anyhow::bail!(
+        "libei fallback cannot perform button-hold drags yet: the libei worker \
+         exposes no standalone button press/release primitive (only a combined \
+         click). Drag is unsupported on this compositor via the libei/portal \
+         backend (#1982)."
+    )
+}
+
+#[cfg(feature = "portal-libei")]
+fn libei_type_text(text: &str) -> anyhow::Result<()> {
+    if text.is_empty() {
+        return Ok(());
+    }
+    libei::type_text(text)
+}
+
+#[cfg(feature = "portal-libei")]
+fn libei_press_key(key: &str) -> anyhow::Result<()> {
+    let keycode = key_to_evdev(key)
+        .ok_or_else(|| anyhow::anyhow!("no evdev keycode mapping for key '{key}' (libei path)"))?;
+    libei::press_key(keycode)
+}
+
+/// Map cua key names to Linux evdev keycodes for the libei `press_key` path
+/// (libei emulates raw evdev, not X keysyms). Mirrors [`key_to_keysym`] but
+/// emits `linux/input-event-codes.h` values. Returns `None` for keys with no
+/// known mapping so the caller can fail loudly.
+#[cfg(feature = "portal-libei")]
+fn key_to_evdev(key: &str) -> Option<u32> {
+    let code = match key.to_lowercase().as_str() {
+        "enter" | "return" => 28, // KEY_ENTER
+        "tab" => 15,              // KEY_TAB
+        "esc" | "escape" => 1,    // KEY_ESC
+        "space" => 57,            // KEY_SPACE
+        "backspace" => 14,        // KEY_BACKSPACE
+        "delete" | "del" => 111,  // KEY_DELETE
+        "up" => 103,              // KEY_UP
+        "down" => 108,            // KEY_DOWN
+        "left" => 105,            // KEY_LEFT
+        "right" => 106,           // KEY_RIGHT
+        "home" => 102,            // KEY_HOME
+        "end" => 107,             // KEY_END
+        "pageup" | "page_up" => 104,    // KEY_PAGEUP
+        "pagedown" | "page_down" => 109, // KEY_PAGEDOWN
+        // Letters a-z. evdev codes follow the QWERTY scancode layout, not the
+        // alphabet, so each is listed explicitly (linux/input-event-codes.h).
+        "a" => 30,  // KEY_A
+        "b" => 48,  // KEY_B
+        "c" => 46,  // KEY_C
+        "d" => 32,  // KEY_D
+        "e" => 18,  // KEY_E
+        "f" => 33,  // KEY_F
+        "g" => 34,  // KEY_G
+        "h" => 35,  // KEY_H
+        "i" => 23,  // KEY_I
+        "j" => 36,  // KEY_J
+        "k" => 37,  // KEY_K
+        "l" => 38,  // KEY_L
+        "m" => 50,  // KEY_M
+        "n" => 49,  // KEY_N
+        "o" => 24,  // KEY_O
+        "p" => 25,  // KEY_P
+        "q" => 16,  // KEY_Q
+        "r" => 19,  // KEY_R
+        "s" => 31,  // KEY_S
+        "t" => 20,  // KEY_T
+        "u" => 22,  // KEY_U
+        "v" => 47,  // KEY_V
+        "w" => 17,  // KEY_W
+        "x" => 45,  // KEY_X
+        "y" => 21,  // KEY_Y
+        "z" => 44,  // KEY_Z
+        // Digits. KEY_1=2 .. KEY_9=10, KEY_0=11 (input-event-codes.h).
+        "1" => 2,   // KEY_1
+        "2" => 3,   // KEY_2
+        "3" => 4,   // KEY_3
+        "4" => 5,   // KEY_4
+        "5" => 6,   // KEY_5
+        "6" => 7,   // KEY_6
+        "7" => 8,   // KEY_7
+        "8" => 9,   // KEY_8
+        "9" => 10,  // KEY_9
+        "0" => 11,  // KEY_0
+        // Function keys. KEY_F1=59 .. KEY_F10=68, then KEY_F11=87, KEY_F12=88.
+        "f1" => 59,
+        "f2" => 60,
+        "f3" => 61,
+        "f4" => 62,
+        "f5" => 63,
+        "f6" => 64,
+        "f7" => 65,
+        "f8" => 66,
+        "f9" => 67,
+        "f10" => 68,
+        "f11" => 87,
+        "f12" => 88,
+        _ => return None,
+    };
+    Some(code)
 }
 
 // ── EIS nested-compositor injection ────────────────────────────────────────

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
@@ -1481,25 +1481,24 @@ fn libei_move_absolute(x: i32, y: i32) -> anyhow::Result<()> {
 
 #[cfg(feature = "portal-libei")]
 fn libei_drag(
-    _from_x: i32,
-    _from_y: i32,
-    _to_x: i32,
-    _to_y: i32,
-    _steps: u32,
-    _button: u8,
+    from_x: i32,
+    from_y: i32,
+    to_x: i32,
+    to_y: i32,
+    steps: u32,
+    button: u8,
 ) -> anyhow::Result<()> {
-    // A real drag needs the button HELD across the interpolated motion. The
-    // libei worker only exposes a combined press+release `click`, with no
-    // standalone button-hold (press/release) primitive, so we cannot perform a
-    // genuine press→move→release sequence. Emulating it as move→click-at-end
-    // would hold nothing and silently no-op drag-and-drop / selection / resize
-    // while reporting success — so fail loudly instead. See #1982.
-    anyhow::bail!(
-        "libei fallback cannot perform button-hold drags yet: the libei worker \
-         exposes no standalone button press/release primitive (only a combined \
-         click). Drag is unsupported on this compositor via the libei/portal \
-         backend (#1982)."
-    )
+    // ei_button exposes separate Press/Released states, so the libei worker can
+    // hold the button across the interpolated motion — a genuine
+    // press→move→release drag. Clamp both endpoints to the output like
+    // `libei_click`.
+    let btn = cua_button_to_libei(button);
+    let (w, h) = output_dimensions()?;
+    let (fx, fy) = normalize_click_xy(from_x, from_y, w, h);
+    let (tx, ty) = normalize_click_xy(to_x, to_y, w, h);
+    libei::drag(fx as f64, fy as f64, tx as f64, ty as f64, steps, btn)?;
+    record_synth_cursor(tx, ty);
+    Ok(())
 }
 
 #[cfg(feature = "portal-libei")]

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
@@ -1490,14 +1490,23 @@ fn libei_drag(
 ) -> anyhow::Result<()> {
     // ei_button exposes separate Press/Released states, so the libei worker can
     // hold the button across the interpolated motion — a genuine
-    // press→move→release drag. Clamp both endpoints to the output like
-    // `libei_click`.
+    // press→move→release drag. Clamp both endpoints to the output — but NOT via
+    // `normalize_click_xy`, whose (0,0)→centre convention (for coordinate-free
+    // clicks) is wrong here: a drag endpoint is always explicit and (0,0) is a
+    // valid top-left corner target.
     let btn = cua_button_to_libei(button);
     let (w, h) = output_dimensions()?;
-    let (fx, fy) = normalize_click_xy(from_x, from_y, w, h);
-    let (tx, ty) = normalize_click_xy(to_x, to_y, w, h);
-    libei::drag(fx as f64, fy as f64, tx as f64, ty as f64, steps, btn)?;
-    record_synth_cursor(tx, ty);
+    let cx = |x: i32| x.clamp(0, (w as i32).saturating_sub(1));
+    let cy = |y: i32| y.clamp(0, (h as i32).saturating_sub(1));
+    libei::drag(
+        cx(from_x) as f64,
+        cy(from_y) as f64,
+        cx(to_x) as f64,
+        cy(to_y) as f64,
+        steps,
+        btn,
+    )?;
+    record_synth_cursor(cx(to_x), cy(to_y));
     Ok(())
 }
 

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
@@ -107,6 +107,28 @@ pub fn is_wayland() -> bool {
         && std::env::var_os("DISPLAY").is_none()
 }
 
+/// True when input tools should attempt the Wayland input path (wlroots
+/// virtual-pointer, falling back to libei/portal via [`with_libei_fallback`]).
+///
+/// Unlike [`is_wayland`] this deliberately does NOT require `DISPLAY` to be
+/// unset. GNOME/Mutter and KDE/KWin always run XWayland, so `DISPLAY` is
+/// essentially always present alongside `WAYLAND_DISPLAY` on those sessions —
+/// which made `is_wayland()` false and left every input tool on the X11 path,
+/// where Mutter/KWin silently drop synthetic XTEST/XSendEvent input (#2105,
+/// #1982, #2022). The right routing signal for *input* is "opted in + a Wayland
+/// compositor is present"; the wlroots-vs-portal decision is then made at
+/// runtime by the compositor-capability probe inside the `wayland::*` input
+/// functions (`open_vptr_session`'s `NO_VPTR_MARKER` → `with_libei_fallback`),
+/// not from environment variables.
+///
+/// Screen capture and `list_windows` intentionally keep using [`is_wayland`]:
+/// on an XWayland-co-present GNOME session the X11 dispatch for those is still
+/// serviceable, whereas the native-Wayland enumeration path depends on
+/// `zwlr_foreign_toplevel_manager_v1`, which Mutter does not expose.
+pub fn wayland_input_enabled() -> bool {
+    wayland_enabled() && std::env::var_os("WAYLAND_DISPLAY").is_some()
+}
+
 /// Reason string when X11 input injection cannot possibly work, so callers
 /// **fail loudly** instead of falling through to an X11 path that no-ops yet
 /// reports success. Triggers only on a *pure* Wayland session — `WAYLAND_DISPLAY`


### PR DESCRIPTION
## Summary
Makes synthetic input actually land on GNOME/Mutter (and KDE/KWin) Wayland.
The first revision of this PR fixed doctor reporting + libei readiness but not
dispatch — input still silently no-oped on the compositors it claimed to
support. This revision fixes the whole chain, verified end-to-end on a real
Ubuntu 26.04 GNOME/Wayland session (`click` lands in ~3 ms; `type_text` lands
in a focused entry).

## What was broken (root causes, in order)
1. **Routing gate** — input tools gated the Wayland branch on `is_wayland()`,
   which requires `DISPLAY` unset. GNOME/KDE always run XWayland → `DISPLAY`
   set → `is_wayland()` false → input fell to X11 XTEST (dropped by Mutter),
   while `doctor` reported `wayland_backend: pass`. Silent false-success.
2. **EIS handshake rejected** — the client advertised `ei_device` v2, omitted
   `ei_pingpong`, and never answered `Ping`. Mutter closed the EIS connection
   immediately after our `finish()` (confirmed: one `Handshake` event, then
   `read()` errors).
3. **Portal session died early (#2105)** — `open_eis_context` dropped the
   ashpd proxy/session + runtime before the EIS loop ran.
4. **Command/handshake race** — commands ran before `Resumed`.
5. **Wrong device** — Mutter announces multiple devices; the code took the first.
6. **No ei_text on Mutter** — `type_text` via `ei_text` fails.

## Changes
- `wayland_input_enabled()` predicate + 9 input call sites (capture / `list_windows`
  keep `is_wayland()` — native enum needs `wlr-foreign-toplevel`, absent on Mutter).
- Handshake: `ei_device` v1, advertise `ei_pingpong`, answer `Ping` — matches
  reis 0.7 `examples/type-text.rs`.
- Hold the portal `RemoteDesktop` session + runtime for the worker lifetime
  (multi-thread(1) runtime so the zbus connection stays driven).
- Queue input commands until a device is negotiated (`input_ready` + timeout).
- `device_with_interface(...)` selects the device carrying the needed interface.
- Keycode typing fallback via `ei_keyboard` when `ei_text` is absent, mapped
  through the compositor's **actual xkb keymap** (read from the `ei_keyboard`
  `Keymap` event via `xkbcommon`) so typing is layout-correct; a US-layout table
  is the fallback when no keymap arrives.
- Single-shot `drag` (press → interpolated motion → release) via `ei_button`
  Press/Released — text selection / drag-and-drop / sliders.

## Validation (Ubuntu 26.04, Mutter, Wayland; `--features portal-libei`)
| Action | Result |
|---|---|
| EIS handshake | Handshake → Seat → Device → **Resumed** (was: disconnect after `finish()`) |
| `click` / `scroll` / `move` | ✅ lands (`click` OK ~3 ms) |
| `press_key` | ✅ |
| `type_text` (incl. layout-specific chars) | ✅ lands layout-correctly — verified on a German QWERTZ keymap (`test_YZ_yz_123` typed verbatim) |
| `drag` (select / drag-and-drop) | ✅ drag-select verified — dragging over a filled entry then typing replaced the whole selection (`XXXXXXXXXX` → `Z`) |
| doctor `wayland_backend` | pass **and** input lands (mismatch gone) |
| first call | one-time xdg-desktop-portal consent dialog |

## Honest deferrals (documented, not silently broken)
- **`ei_text`**: used when the compositor advertises it (libei 1.6+); Mutter
  doesn't, hence the keycode + xkb-keymap fallback.
- **Button held across separate tool calls** (`mouse_button_down` / `mouse_button_up`,
  the persistent-cursor `mouse_drag`) and **`parallel_mouse_drag`** (multi-pointer /
  MPX) stay on the X11 path — they need cross-call emulation state / multiple
  pointers the single-shot libei command model doesn't provide, so on native
  Wayland windows they no-op (they still work on XWayland windows). Single-shot
  `drag` (above) does work via libei.
- **Modifier hotkeys**: a bare-key `hotkey` now routes via libei; true modifier
  chords (Ctrl+C, …) aren't wired into the libei keyboard yet and error loudly
  rather than silently mis-firing.
- Per-window *background* input is impossible on Wayland by design; the
  substitute is `delivery_mode:"foreground"`.

## Refs
Closes the runtime half of #1982 / #2105. Pairs with #2111 (publishes the
`portal-libei` artifact users need). Builds on #1966 / #2008 (libei machinery).
