### PR TITLE
[codex] Remove Vercel docs config

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,3 +1,0 @@
-{
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD ./"
-}


### PR DESCRIPTION
## Summary

- remove the remaining repo-side Vercel config file from `docs/`

## Why

The Vercel project Git connection for `trycua/cua` was disconnected in the Vercel UI, so the repository should no longer carry Vercel-specific docs config.

## Validation

- verified the Vercel project Git settings page no longer shows `trycua/cua` as connected
- inspected the diff; only `docs/vercel.json` is removed
- config-only removal; no runtime tests run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused deployment configuration file.
  * Simplified project setup by dropping a no-longer-needed setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->