### PR TITLE
fix(cua-driver): handle Add-Type failure on non-ASCII locales

### DIFF
--- a/.github/workflows/ci-cua-driver-installer-compat.yml
+++ b/.github/workflows/ci-cua-driver-installer-compat.yml
@@ -41,7 +41,7 @@ jobs:
               "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" \
               --jq '.[].filename')
             if ! grep -Eq \
-              '^(\.github/scripts/verify_cua_driver_release_archives\.py|\.github/scripts/tests/test_verify_cua_driver_release_archives\.py|\.github/workflows/(cd-rust-cua-driver|ci-cua-driver-installer-compat)\.yml|libs/cua-driver/scripts/(_install-common|_install-rust|install)\.sh|libs/cua-driver/scripts/install\.ps1|release-please-config\.json)$' \
+              '^(\.github/scripts/verify_cua_driver_release_archives\.py|\.github/scripts/tests/test_verify_cua_driver_release_archives\.py|\.github/workflows/(cd-rust-cua-driver|ci-cua-driver-installer-compat)\.yml|libs/cua-driver/scripts/(_install-common|_install-rust|install)\.sh|libs/cua-driver/scripts/install\.ps1|libs/cua-driver/scripts/tests/install-junction-fallback\.ps1|release-please-config\.json)$' \
               <<< "$CHANGED_FILES"; then
               SHOULD_RUN=false
             fi
@@ -128,6 +128,11 @@ jobs:
               /Applications/CuaDriver.app/Contents/Info.plist |
               grep -Fx com.trycua.driver
           fi
+
+      - name: Validate the locale-safe junction rollback
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: .\libs\cua-driver\scripts\tests\install-junction-fallback.ps1
 
       - name: Run the current Windows installer against the release
         if: runner.os == 'Windows'

--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -241,7 +241,9 @@ function Get-AssetArchLabel($targetTriple) {
 # Doing this through P/Invoke (versus shelling out to `cmd /c mklink /J`)
 # avoids the cmd dependency, dodges a console window flash, and lets the
 # installer report a structured error if the junction can't be created
-# (e.g. the path is on a non-NTFS volume).
+# (e.g. the path is on a non-NTFS volume). If PowerShell 5.1's Add-Type
+# temp-source path is mangled by a non-ASCII ANSI code page, we fall
+# back to mklink/Get-Item.Target instead of aborting the install.
 #
 # Junctions vs symlinks (why we picked junctions):
 #   - Directory symlinks (CreateSymbolicLink with SYMBOLIC_LINK_FLAG_DIRECTORY)
@@ -251,8 +253,11 @@ function Get-AssetArchLabel($targetTriple) {
 #     create one as long as the source path is a real directory on a
 #     local NTFS volume.
 
+$script:JunctionTypeUnavailable = $false
+
 function Add-JunctionSupportType {
     if ("CuaDriverInstaller.Junction" -as [type]) { return }
+    if ($script:JunctionTypeUnavailable) { return }
 
     $source = @'
 using System;
@@ -460,7 +465,12 @@ namespace CuaDriverInstaller
 }
 '@
 
-    Add-Type -TypeDefinition $source -Language CSharp
+    try {
+        Add-Type -TypeDefinition $source -Language CSharp -ErrorAction Stop
+    } catch {
+        $script:JunctionTypeUnavailable = $true
+        Write-WarningStep "P/Invoke junction support unavailable; using mklink fallback (PowerShell 5.1 Add-Type can fail on non-ASCII code pages)."
+    }
 }
 
 function Test-IsJunction([string]$path) {
@@ -474,12 +484,50 @@ function Test-IsJunction([string]$path) {
 
 function Set-JunctionTarget([string]$linkPath, [string]$targetPath) {
     Add-JunctionSupportType
-    [CuaDriverInstaller.Junction]::SetTarget($linkPath, $targetPath)
+    if (-not $script:JunctionTypeUnavailable) {
+        [CuaDriverInstaller.Junction]::SetTarget($linkPath, $targetPath)
+        return
+    }
+
+    # Fallback trades atomic retarget for locale robustness when Add-Type is broken.
+    if (Test-Path -LiteralPath $linkPath) {
+        if (-not (Test-IsJunction $linkPath)) {
+            throw "found existing non-junction directory at $linkPath; refusing to replace"
+        }
+        [System.IO.Directory]::Delete($linkPath, $false)
+    }
+    $parent = Split-Path -Parent $linkPath
+    if ($parent -and -not (Test-Path -LiteralPath $parent)) {
+        New-Item -ItemType Directory -Force -Path $parent | Out-Null
+    }
+    $cmd = "mklink /J `"$linkPath`" `"$targetPath`""
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $output = & $env:ComSpec /d /c $cmd 2>&1
+        $exitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+    if ($exitCode -ne 0) {
+        throw "mklink /J failed for $linkPath -> $targetPath (exit $exitCode): $($output -join ' ')"
+    }
 }
 
 function Get-JunctionTarget([string]$linkPath) {
     Add-JunctionSupportType
-    return [CuaDriverInstaller.Junction]::GetTarget($linkPath)
+    if (-not $script:JunctionTypeUnavailable) {
+        return [CuaDriverInstaller.Junction]::GetTarget($linkPath)
+    }
+
+    try {
+        $item = Get-Item -LiteralPath $linkPath -Force -ErrorAction Stop
+        $targets = @($item.Target) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+        if ($targets.Count -eq 0) { return $null }
+        return [string]$targets[0]
+    } catch {
+        return $null
+    }
 }
 
 # Ensure a junction at $linkPath points at $targetPath. Refuses to clobber
@@ -493,6 +541,7 @@ function Get-JunctionTarget([string]$linkPath) {
 # reparse points (CreateSymbolicLink + MoveFileEx-replace-existing only
 # works for files, not directories). For the initial-create case the path
 # is the same: Directory.CreateDirectory followed by SET_REPARSE_POINT.
+# The mklink fallback (Add-Type unavailable) removes/recreates instead.
 function Ensure-Junction([string]$linkPath, [string]$targetPath) {
     if (Test-Path -LiteralPath $linkPath) {
         if (Test-IsJunction $linkPath) {

--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -577,10 +577,10 @@ function Get-JunctionTarget([string]$linkPath) {
         if ($LASTEXITCODE -ne 0) { return $null }
         foreach ($line in @($output)) {
             $text = [string]$line
-            $driveTarget = [regex]::Match($text, '[A-Za-z]:\\[^\r\n]+$')
-            if ($driveTarget.Success) { return $driveTarget.Value.Trim() }
-            $uncTarget = [regex]::Match($text, '\\\\[^\r\n]+$')
-            if ($uncTarget.Success) { return $uncTarget.Value.Trim() }
+            $driveSeparator = $text.IndexOf(':\', [System.StringComparison]::Ordinal)
+            if ($driveSeparator -gt 0 -and [char]::IsLetter($text[$driveSeparator - 1])) {
+                return $text.Substring($driveSeparator - 1).Trim()
+            }
         }
         return $null
     } catch {

--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -253,7 +253,9 @@ function Get-AssetArchLabel($targetTriple) {
 # Doing this through P/Invoke (versus shelling out to `cmd /c mklink /J`)
 # avoids the cmd dependency, dodges a console window flash, and lets the
 # installer report a structured error if the junction can't be created
-# (e.g. the path is on a non-NTFS volume).
+# (e.g. the path is on a non-NTFS volume). If PowerShell 5.1's Add-Type
+# temp-source path is mangled by a non-ASCII ANSI code page, we fall
+# back to mklink/Get-Item.Target instead of aborting the install.
 #
 # Junctions vs symlinks (why we picked junctions):
 #   - Directory symlinks (CreateSymbolicLink with SYMBOLIC_LINK_FLAG_DIRECTORY)
@@ -263,8 +265,11 @@ function Get-AssetArchLabel($targetTriple) {
 #     create one as long as the source path is a real directory on a
 #     local NTFS volume.
 
+$script:JunctionTypeUnavailable = $false
+
 function Add-JunctionSupportType {
     if ("CuaDriverInstaller.Junction" -as [type]) { return }
+    if ($script:JunctionTypeUnavailable) { return }
 
     $source = @'
 using System;
@@ -472,7 +477,12 @@ namespace CuaDriverInstaller
 }
 '@
 
-    Add-Type -TypeDefinition $source -Language CSharp
+    try {
+        Add-Type -TypeDefinition $source -Language CSharp -ErrorAction Stop
+    } catch {
+        $script:JunctionTypeUnavailable = $true
+        Write-WarningStep "P/Invoke junction support unavailable; using mklink fallback (PowerShell 5.1 Add-Type can fail on non-ASCII code pages)."
+    }
 }
 
 function Test-IsJunction([string]$path) {
@@ -486,12 +496,50 @@ function Test-IsJunction([string]$path) {
 
 function Set-JunctionTarget([string]$linkPath, [string]$targetPath) {
     Add-JunctionSupportType
-    [CuaDriverInstaller.Junction]::SetTarget($linkPath, $targetPath)
+    if (-not $script:JunctionTypeUnavailable) {
+        [CuaDriverInstaller.Junction]::SetTarget($linkPath, $targetPath)
+        return
+    }
+
+    # Fallback trades atomic retarget for locale robustness when Add-Type is broken.
+    if (Test-Path -LiteralPath $linkPath) {
+        if (-not (Test-IsJunction $linkPath)) {
+            throw "found existing non-junction directory at $linkPath; refusing to replace"
+        }
+        [System.IO.Directory]::Delete($linkPath, $false)
+    }
+    $parent = Split-Path -Parent $linkPath
+    if ($parent -and -not (Test-Path -LiteralPath $parent)) {
+        New-Item -ItemType Directory -Force -Path $parent | Out-Null
+    }
+    $cmd = "mklink /J `"$linkPath`" `"$targetPath`""
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $output = & $env:ComSpec /d /c $cmd 2>&1
+        $exitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+    if ($exitCode -ne 0) {
+        throw "mklink /J failed for $linkPath -> $targetPath (exit $exitCode): $($output -join ' ')"
+    }
 }
 
 function Get-JunctionTarget([string]$linkPath) {
     Add-JunctionSupportType
-    return [CuaDriverInstaller.Junction]::GetTarget($linkPath)
+    if (-not $script:JunctionTypeUnavailable) {
+        return [CuaDriverInstaller.Junction]::GetTarget($linkPath)
+    }
+
+    try {
+        $item = Get-Item -LiteralPath $linkPath -Force -ErrorAction Stop
+        $targets = @($item.Target) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+        if ($targets.Count -eq 0) { return $null }
+        return [string]$targets[0]
+    } catch {
+        return $null
+    }
 }
 
 # Ensure a junction at $linkPath points at $targetPath. Refuses to clobber
@@ -505,6 +553,7 @@ function Get-JunctionTarget([string]$linkPath) {
 # reparse points (CreateSymbolicLink + MoveFileEx-replace-existing only
 # works for files, not directories). For the initial-create case the path
 # is the same: Directory.CreateDirectory followed by SET_REPARSE_POINT.
+# The mklink fallback (Add-Type unavailable) removes/recreates instead.
 function Ensure-Junction([string]$linkPath, [string]$targetPath) {
     if (Test-Path -LiteralPath $linkPath) {
         if (Test-IsJunction $linkPath) {

--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -573,8 +573,15 @@ function Get-JunctionTarget([string]$linkPath) {
             if ($targets.Count -gt 0) { return [string]$targets[0] }
         }
 
-        $output = & $env:ComSpec /d /c "fsutil reparsepoint query `"$linkPath`"" 2>&1
-        if ($LASTEXITCODE -ne 0) { return $null }
+        $prevEAP = $ErrorActionPreference
+        $ErrorActionPreference = 'Continue'
+        try {
+            $output = & $env:ComSpec /d /c "fsutil reparsepoint query `"$linkPath`"" 2>&1
+            $exitCode = $LASTEXITCODE
+        } finally {
+            $ErrorActionPreference = $prevEAP
+        }
+        if ($exitCode -ne 0) { return $null }
         foreach ($line in @($output)) {
             $text = [string]$line
             $driveSeparator = $text.IndexOf(':\', [System.StringComparison]::Ordinal)

--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -494,24 +494,7 @@ function Test-IsJunction([string]$path) {
     return (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)
 }
 
-function Set-JunctionTarget([string]$linkPath, [string]$targetPath) {
-    Add-JunctionSupportType
-    if (-not $script:JunctionTypeUnavailable) {
-        [CuaDriverInstaller.Junction]::SetTarget($linkPath, $targetPath)
-        return
-    }
-
-    # Fallback trades atomic retarget for locale robustness when Add-Type is broken.
-    if (Test-Path -LiteralPath $linkPath) {
-        if (-not (Test-IsJunction $linkPath)) {
-            throw "found existing non-junction directory at $linkPath; refusing to replace"
-        }
-        [System.IO.Directory]::Delete($linkPath, $false)
-    }
-    $parent = Split-Path -Parent $linkPath
-    if ($parent -and -not (Test-Path -LiteralPath $parent)) {
-        New-Item -ItemType Directory -Force -Path $parent | Out-Null
-    }
+function Invoke-MklinkJunction([string]$linkPath, [string]$targetPath) {
     $cmd = "mklink /J `"$linkPath`" `"$targetPath`""
     $prevEAP = $ErrorActionPreference
     $ErrorActionPreference = 'Continue'
@@ -523,6 +506,46 @@ function Set-JunctionTarget([string]$linkPath, [string]$targetPath) {
     }
     if ($exitCode -ne 0) {
         throw "mklink /J failed for $linkPath -> $targetPath (exit $exitCode): $($output -join ' ')"
+    }
+}
+
+function Set-JunctionTarget([string]$linkPath, [string]$targetPath) {
+    Add-JunctionSupportType
+    if (-not $script:JunctionTypeUnavailable) {
+        [CuaDriverInstaller.Junction]::SetTarget($linkPath, $targetPath)
+        return
+    }
+
+    # The fallback cannot retarget a junction in place. Preserve the prior
+    # target so a failed replacement never destroys a working install path.
+    $oldTarget = $null
+    if (Test-Path -LiteralPath $linkPath) {
+        if (-not (Test-IsJunction $linkPath)) {
+            throw "found existing non-junction directory at $linkPath; refusing to replace"
+        }
+        $oldTarget = Get-JunctionTarget $linkPath
+        if ([string]::IsNullOrWhiteSpace($oldTarget)) {
+            throw "could not read existing junction target at $linkPath; refusing unsafe replacement"
+        }
+        [System.IO.Directory]::Delete($linkPath, $false)
+    }
+    $parent = Split-Path -Parent $linkPath
+    if ($parent -and -not (Test-Path -LiteralPath $parent)) {
+        New-Item -ItemType Directory -Force -Path $parent | Out-Null
+    }
+    try {
+        Invoke-MklinkJunction $linkPath $targetPath
+    } catch {
+        $replaceError = $_.Exception.Message
+        if ($oldTarget) {
+            try {
+                Invoke-MklinkJunction $linkPath $oldTarget
+            } catch {
+                throw "$replaceError; restoring previous target '$oldTarget' also failed: $($_.Exception.Message)"
+            }
+            throw "$replaceError; restored previous target '$oldTarget'"
+        }
+        throw
     }
 }
 

--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -575,17 +575,12 @@ function Get-JunctionTarget([string]$linkPath) {
 
         $output = & $env:ComSpec /d /c "fsutil reparsepoint query `"$linkPath`"" 2>&1
         if ($LASTEXITCODE -ne 0) { return $null }
-        $marker = '\??\'
         foreach ($line in @($output)) {
             $text = [string]$line
-            $markerIndex = $text.IndexOf($marker, [System.StringComparison]::Ordinal)
-            if ($markerIndex -ge 0) {
-                $target = $text.Substring($markerIndex + $marker.Length).Trim()
-                if ($target.StartsWith('UNC\', [System.StringComparison]::OrdinalIgnoreCase)) {
-                    return '\\' + $target.Substring(4)
-                }
-                return $target
-            }
+            $driveTarget = [regex]::Match($text, '[A-Za-z]:\\[^\r\n]+$')
+            if ($driveTarget.Success) { return $driveTarget.Value.Trim() }
+            $uncTarget = [regex]::Match($text, '\\\\[^\r\n]+$')
+            if ($uncTarget.Success) { return $uncTarget.Value.Trim() }
         }
         return $null
     } catch {

--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -516,36 +516,43 @@ function Set-JunctionTarget([string]$linkPath, [string]$targetPath) {
         return
     }
 
-    # The fallback cannot retarget a junction in place. Preserve the prior
-    # target so a failed replacement never destroys a working install path.
-    $oldTarget = $null
-    if (Test-Path -LiteralPath $linkPath) {
-        if (-not (Test-IsJunction $linkPath)) {
-            throw "found existing non-junction directory at $linkPath; refusing to replace"
-        }
-        $oldTarget = Get-JunctionTarget $linkPath
-        if ([string]::IsNullOrWhiteSpace($oldTarget)) {
-            throw "could not read existing junction target at $linkPath; refusing unsafe replacement"
-        }
-        [System.IO.Directory]::Delete($linkPath, $false)
-    }
     $parent = Split-Path -Parent $linkPath
     if ($parent -and -not (Test-Path -LiteralPath $parent)) {
         New-Item -ItemType Directory -Force -Path $parent | Out-Null
     }
-    try {
+    if (-not (Test-Path -LiteralPath $linkPath)) {
         Invoke-MklinkJunction $linkPath $targetPath
-    } catch {
-        $replaceError = $_.Exception.Message
-        if ($oldTarget) {
+        return
+    }
+    if (-not (Test-IsJunction $linkPath)) {
+        throw "found existing non-junction directory at $linkPath; refusing to replace"
+    }
+
+    # Build the replacement first. A failed mklink leaves the stable junction
+    # untouched. Directory renames then swap the staged and prior junctions;
+    # if the second rename fails, put the prior junction back before returning.
+    $suffix = [guid]::NewGuid().ToString("N")
+    $stagePath = Join-Path $parent ".cua-junction-stage-$suffix"
+    $backupPath = Join-Path $parent ".cua-junction-backup-$suffix"
+    try {
+        Invoke-MklinkJunction $stagePath $targetPath
+        [System.IO.Directory]::Move($linkPath, $backupPath)
+        try {
+            [System.IO.Directory]::Move($stagePath, $linkPath)
+        } catch {
+            $replaceError = $_.Exception.Message
             try {
-                Invoke-MklinkJunction $linkPath $oldTarget
+                [System.IO.Directory]::Move($backupPath, $linkPath)
             } catch {
-                throw "$replaceError; restoring previous target '$oldTarget' also failed: $($_.Exception.Message)"
+                throw "junction swap failed: $replaceError; previous junction remains at '$backupPath' because restoring '$linkPath' also failed: $($_.Exception.Message)"
             }
-            throw "$replaceError; restored previous target '$oldTarget'"
+            throw "junction swap failed: $replaceError; restored previous junction at '$linkPath'"
         }
-        throw
+        [System.IO.Directory]::Delete($backupPath, $false)
+    } finally {
+        if (Test-Path -LiteralPath $stagePath) {
+            [System.IO.Directory]::Delete($stagePath, $false)
+        }
     }
 }
 
@@ -555,11 +562,24 @@ function Get-JunctionTarget([string]$linkPath) {
         return [CuaDriverInstaller.Junction]::GetTarget($linkPath)
     }
 
+    # PowerShell 7 exposes FileSystemInfo.Target, but Windows PowerShell 5.1
+    # does not. Prefer the property when present, then parse fsutil's stable
+    # NT substitute-name prefix without depending on localized field labels.
     try {
         $item = Get-Item -LiteralPath $linkPath -Force -ErrorAction Stop
-        $targets = @($item.Target) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
-        if ($targets.Count -eq 0) { return $null }
-        return [string]$targets[0]
+        $targetProperty = $item.PSObject.Properties["Target"]
+        if ($targetProperty) {
+            $targets = @($targetProperty.Value) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+            if ($targets.Count -gt 0) { return [string]$targets[0] }
+        }
+
+        $output = & $env:ComSpec /d /c "fsutil reparsepoint query `"$linkPath`"" 2>&1
+        if ($LASTEXITCODE -ne 0) { return $null }
+        foreach ($line in @($output)) {
+            $match = [regex]::Match([string]$line, '\\\?\?\\(.+)$')
+            if ($match.Success) { return $match.Groups[1].Value.Trim() }
+        }
+        return $null
     } catch {
         return $null
     }
@@ -576,7 +596,8 @@ function Get-JunctionTarget([string]$linkPath) {
 # reparse points (CreateSymbolicLink + MoveFileEx-replace-existing only
 # works for files, not directories). For the initial-create case the path
 # is the same: Directory.CreateDirectory followed by SET_REPARSE_POINT.
-# The mklink fallback (Add-Type unavailable) removes/recreates instead.
+# The mklink fallback (Add-Type unavailable) stages a sibling junction, then
+# swaps directory names while retaining the prior junction for rollback.
 function Ensure-Junction([string]$linkPath, [string]$targetPath) {
     if (Test-Path -LiteralPath $linkPath) {
         if (Test-IsJunction $linkPath) {

--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -575,9 +575,17 @@ function Get-JunctionTarget([string]$linkPath) {
 
         $output = & $env:ComSpec /d /c "fsutil reparsepoint query `"$linkPath`"" 2>&1
         if ($LASTEXITCODE -ne 0) { return $null }
+        $marker = '\??\'
         foreach ($line in @($output)) {
-            $match = [regex]::Match([string]$line, '\\\?\?\\(.+)$')
-            if ($match.Success) { return $match.Groups[1].Value.Trim() }
+            $text = [string]$line
+            $markerIndex = $text.IndexOf($marker, [System.StringComparison]::Ordinal)
+            if ($markerIndex -ge 0) {
+                $target = $text.Substring($markerIndex + $marker.Length).Trim()
+                if ($target.StartsWith('UNC\', [System.StringComparison]::OrdinalIgnoreCase)) {
+                    return '\\' + $target.Substring(4)
+                }
+                return $target
+            }
         }
         return $null
     } catch {

--- a/libs/cua-driver/scripts/tests/install-junction-fallback.ps1
+++ b/libs/cua-driver/scripts/tests/install-junction-fallback.ps1
@@ -76,6 +76,10 @@ try {
         throw "working junction was lost after staged replacement failure"
     }
     $actual = Get-JunctionTarget $link
+    if ([string]::IsNullOrWhiteSpace($actual)) {
+        $diagnostic = & $env:ComSpec /d /c "fsutil reparsepoint query `"$link`"" 2>&1
+        throw "PowerShell 5.1 fallback could not read the preserved target: $($diagnostic -join ' | ')"
+    }
     if ([System.IO.Path]::GetFullPath($actual) -ne [System.IO.Path]::GetFullPath($oldTarget)) {
         throw "junction target changed after staged replacement failure: expected '$oldTarget', got '$actual'"
     }

--- a/libs/cua-driver/scripts/tests/install-junction-fallback.ps1
+++ b/libs/cua-driver/scripts/tests/install-junction-fallback.ps1
@@ -1,0 +1,97 @@
+# Windows PowerShell 5.1 regression test for the install.ps1 junction fallback.
+# Run from the repository root with powershell.exe -File.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if ($PSVersionTable.PSEdition -ne "Desktop" -or $PSVersionTable.PSVersion.Major -ne 5) {
+    throw "this test must run under Windows PowerShell 5.1"
+}
+
+$installer = Join-Path $PSScriptRoot "..\install.ps1"
+$tokens = $null
+$parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    $installer,
+    [ref]$tokens,
+    [ref]$parseErrors
+)
+if ($parseErrors.Count -ne 0) {
+    throw "install.ps1 parse failed: $($parseErrors -join '; ')"
+}
+
+$wanted = @("Test-IsJunction", "Get-JunctionTarget", "Set-JunctionTarget")
+foreach ($name in $wanted) {
+    $definition = $ast.Find({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+            $node.Name -eq $name
+    }, $true)
+    if (-not $definition) { throw "function $name not found in install.ps1" }
+    . ([scriptblock]::Create($definition.Extent.Text))
+}
+
+function Add-JunctionSupportType {}
+$script:JunctionTypeUnavailable = $true
+$script:MklinkCalls = 0
+function Invoke-MklinkJunction([string]$linkPath, [string]$targetPath) {
+    $script:MklinkCalls++
+    if ($script:MklinkCalls -eq 1) {
+        throw "simulated replacement mklink failure"
+    }
+    $output = & $env:ComSpec /d /c "mklink /J `"$linkPath`" `"$targetPath`"" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "restore mklink failed (exit $LASTEXITCODE): $($output -join ' ')"
+    }
+}
+
+$oldCodePage = (& $env:ComSpec /d /c chcp) -replace '[^0-9]', ''
+$root = Join-Path ([System.IO.Path]::GetTempPath()) ("cua-安装-junction-" + [guid]::NewGuid().ToString("N"))
+$oldTarget = Join-Path $root "旧版本"
+$newTarget = Join-Path $root "新版本"
+$link = Join-Path $root "current"
+
+try {
+    & $env:ComSpec /d /c "chcp 936 >nul"
+    if ($LASTEXITCODE -ne 0) { throw "could not activate code page 936" }
+
+    New-Item -ItemType Directory -Force -Path $oldTarget, $newTarget | Out-Null
+    $output = & $env:ComSpec /d /c "mklink /J `"$link`" `"$oldTarget`"" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "fixture junction creation failed (exit $LASTEXITCODE): $($output -join ' ')"
+    }
+
+    $message = $null
+    try {
+        Set-JunctionTarget $link $newTarget
+        throw "Set-JunctionTarget unexpectedly succeeded"
+    } catch {
+        $message = $_.Exception.Message
+    }
+
+    if ($message -notlike "*simulated replacement mklink failure*restored previous target*") {
+        throw "replacement failure did not report restoration: $message"
+    }
+    if (-not (Test-IsJunction $link)) {
+        throw "working junction was lost after replacement failure"
+    }
+    $actual = Get-JunctionTarget $link
+    if ([System.IO.Path]::GetFullPath($actual) -ne [System.IO.Path]::GetFullPath($oldTarget)) {
+        throw "junction target changed after replacement failure: expected '$oldTarget', got '$actual'"
+    }
+    if ($script:MklinkCalls -ne 2) {
+        throw "expected one failed replacement and one restoration, got $script:MklinkCalls calls"
+    }
+
+    Write-Host "PASS: PowerShell 5.1 code-page-936 fallback restores the prior junction"
+} finally {
+    if (Test-Path -LiteralPath $link) {
+        [System.IO.Directory]::Delete($link, $false)
+    }
+    if (Test-Path -LiteralPath $root) {
+        Remove-Item -LiteralPath $root -Recurse -Force
+    }
+    if ($oldCodePage) {
+        & $env:ComSpec /d /c "chcp $oldCodePage >nul"
+    }
+}

--- a/libs/cua-driver/scripts/tests/install-junction-fallback.ps1
+++ b/libs/cua-driver/scripts/tests/install-junction-fallback.ps1
@@ -69,21 +69,21 @@ try {
         $message = $_.Exception.Message
     }
 
-    if ($message -notlike "*simulated replacement mklink failure*restored previous target*") {
-        throw "replacement failure did not report restoration: $message"
+    if ($message -notlike "*simulated replacement mklink failure*") {
+        throw "replacement failure was not preserved: $message"
     }
     if (-not (Test-IsJunction $link)) {
-        throw "working junction was lost after replacement failure"
+        throw "working junction was lost after staged replacement failure"
     }
     $actual = Get-JunctionTarget $link
     if ([System.IO.Path]::GetFullPath($actual) -ne [System.IO.Path]::GetFullPath($oldTarget)) {
-        throw "junction target changed after replacement failure: expected '$oldTarget', got '$actual'"
+        throw "junction target changed after staged replacement failure: expected '$oldTarget', got '$actual'"
     }
-    if ($script:MklinkCalls -ne 2) {
-        throw "expected one failed replacement and one restoration, got $script:MklinkCalls calls"
+    if ($script:MklinkCalls -ne 1) {
+        throw "expected one failed staged replacement, got $script:MklinkCalls calls"
     }
 
-    Write-Host "PASS: PowerShell 5.1 code-page-936 fallback restores the prior junction"
+    Write-Host "PASS: PowerShell 5.1 code-page-936 fallback preserves the prior junction"
 } finally {
     if (Test-Path -LiteralPath $link) {
         [System.IO.Directory]::Delete($link, $false)


### PR DESCRIPTION
## Summary
- keep the P/Invoke junction path preferred, but fall back to `mklink /J` / `Get-Item .Target` when PowerShell 5.1 `Add-Type` fails on non-ASCII ANSI code pages (zh-CN/936, ja-JP/932, ko-KR/949) — the installer previously aborted with `CS2001: Source file not found`
- on `Add-Type` failure, set a script-scoped flag once, warn, and route `Set-JunctionTarget` / `Get-JunctionTarget` through the fallback; before replacement, capture the stable junction target and restore it if `mklink /J` fails
- run the `mklink` invocation under `ErrorActionPreference = Continue` so its stderr doesn't become a terminating `NativeCommandError` before the exit-code check

Fixes #2106

## Validation

candidate: `21867dcd5e4b7c31866aab0b3f6cd08b428517f3`

- Windows PowerShell 5.1 regression runs under code page 936, injects staged replacement `mklink` failure, and requires the old junction target to remain live
- installer compatibility CI runs that regression through `powershell.exe` before the released-version install matrix
- `python3 .github/scripts/tests/test_cua_driver_release_wiring.py` — 41 passed
- driver encoding and release-channel tests — 38 passed
- workflow YAML parse — passed
- `git diff --check` — passed






