### PR TITLE
feat(cua-driver): honor GITHUB_TOKEN/GH_TOKEN in GitHub API update checks (#2106)

### DIFF
--- a/docs/content/docs/how-to-guides/driver/install.mdx
+++ b/docs/content/docs/how-to-guides/driver/install.mdx
@@ -32,6 +32,8 @@ irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/in
 
 The installer downloads the release under `%USERPROFILE%\.cua-driver\packages\releases\` and exposes `cua-driver.exe` from `%LOCALAPPDATA%\Programs\Cua\cua-driver\bin`. It runs without administrator privileges, detects whether the host is x64 or arm64, and appends the install directory to your User-scope `Path` so new PowerShell windows can resolve `cua-driver.exe`. It also attempts to register the `cua-driver-serve` autostart task; that step needs an interactive session, so on a non-interactive or SSH install it is skipped — set it up later with [`cua-driver autostart enable`](/how-to-guides/driver/keep-running).
 
+On networks that hit GitHub's unauthenticated API rate limit, set `GITHUB_TOKEN` (or `GH_TOKEN`) before installing or checking for updates. The token is used only as a GitHub API bearer token and is never printed.
+
 To skip the PATH change, pass the no-update flag:
 
 ```powershell

--- a/docs/content/docs/how-to-guides/driver/install.mdx
+++ b/docs/content/docs/how-to-guides/driver/install.mdx
@@ -37,6 +37,8 @@ cua-driver autostart kick
 
 The installer downloads the release under `%USERPROFILE%\.cua-driver\packages\releases\` and exposes `cua-driver.exe` from `%LOCALAPPDATA%\Programs\Cua\cua-driver\bin`. It runs without administrator privileges, detects whether the host is x64 or arm64, and appends the install directory to your User-scope `Path` so new PowerShell windows can resolve `cua-driver.exe`. It also attempts to register the `cua-driver-serve` autostart task; `kick` starts that task immediately, so you do not need to sign out or restart Windows. Registration needs an interactive session, so on a non-interactive or SSH install it is skipped — set it up later with [`cua-driver autostart enable`](/how-to-guides/driver/keep-running).
 
+On networks that hit GitHub's unauthenticated API rate limit, set `GH_TOKEN` or `GITHUB_TOKEN` before installing or checking for updates. If both are set, `GH_TOKEN` wins, matching the GitHub CLI. The token is used only as a GitHub API bearer token and is never printed.
+
 To skip the PATH change, pass the no-update flag:
 
 ```powershell

--- a/libs/cua-driver/rust/Skills/cua-driver/WINDOWS.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/WINDOWS.md
@@ -470,13 +470,14 @@ your prior tool calls earned.
 
 1. **`cua-driver` is on `$PATH`** — `Get-Command cua-driver` or
    `where.exe cua-driver`. Install location:
-   `%LOCALAPPDATA%\Programs\trycua\cua-driver-rs\bin\cua-driver.exe`,
+   `%LOCALAPPDATA%\Programs\Cua\cua-driver\bin\cua-driver.exe`,
    added to the user PATH by the install script.
    If missing, point the user at:
    ```powershell
-   irm https://github.com/trycua/cua/releases/latest/download/install.ps1 | iex
+   irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.ps1 | iex
    ```
-   and stop.
+   On rate-limited networks, set `GITHUB_TOKEN` or `GH_TOKEN` before installing.
+   Then stop.
 2. **The daemon must run in an interactive session (Session 1+),
    NOT Session 0.** Windows isolates services into Session 0 with no
    desktop. UIA enumeration, screenshot via PrintWindow, and

--- a/libs/cua-driver/rust/Skills/cua-driver/WINDOWS.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/WINDOWS.md
@@ -461,13 +461,14 @@ your prior tool calls earned.
 
 1. **`cua-driver` is on `$PATH`** — `Get-Command cua-driver` or
    `where.exe cua-driver`. Install location:
-   `%LOCALAPPDATA%\Programs\trycua\cua-driver-rs\bin\cua-driver.exe`,
+   `%LOCALAPPDATA%\Programs\Cua\cua-driver\bin\cua-driver.exe`,
    added to the user PATH by the install script.
    If missing, point the user at:
    ```powershell
    irm https://cua.ai/driver/install.ps1 | iex
    ```
-   and stop.
+   On rate-limited networks, set `GH_TOKEN` or `GITHUB_TOKEN` before installing.
+   Then stop.
 2. **The runtime owner must run in an interactive session (Session 1+),
    NOT Session 0.** This is the daemon for one-shot CLI/service mode and the
    MCP process for bare stdio MCP. Windows isolates services into Session 0 with no

--- a/libs/cua-driver/rust/crates/cua-driver/src/version_check.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/version_check.rs
@@ -479,6 +479,19 @@ fn cache_path() -> Option<PathBuf> {
 
 // ── HTTP fetch (shared with the `update` subcommand) ─────────────────────
 
+fn github_token() -> Option<String> {
+    std::env::var("GITHUB_TOKEN")
+        .ok()
+        .map(|token| token.trim().to_owned())
+        .filter(|token| !token.is_empty())
+        .or_else(|| {
+            std::env::var("GH_TOKEN")
+                .ok()
+                .map(|token| token.trim().to_owned())
+                .filter(|token| !token.is_empty())
+        })
+}
+
 /// Fetch the highest `cua-driver-rs-v*` release tag from GitHub.
 ///
 /// Uses `ureq` (already a dep via telemetry) so we don't shell out to
@@ -501,10 +514,16 @@ pub fn fetch_latest_version() -> Result<String, String> {
         .build()
         .new_agent();
 
-    let response = agent
+    let mut request = agent
         .get(RELEASES_URL)
         .header("Accept", "application/vnd.github+json")
-        .header("User-Agent", concat!("cua-driver-rs/", env!("CARGO_PKG_VERSION")))
+        .header("User-Agent", concat!("cua-driver-rs/", env!("CARGO_PKG_VERSION")));
+    if let Some(token) = github_token() {
+        // Unauthenticated is 60 req/hr/IP; authenticated is 5000 req/hr.
+        request = request.header("Authorization", format!("Bearer {token}"));
+    }
+
+    let response = request
         .call()
         .map_err(|e| format!("HTTP error: {e}"))?;
 
@@ -609,6 +628,37 @@ mod tests {
             None => unsafe { std::env::remove_var("USERPROFILE"); },
         }
         result
+    }
+
+    // ── GitHub token ────────────────────────────────────────────────────
+
+    #[test]
+    fn github_token_prefers_github_token_and_trims_empty_values() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let saved_github = std::env::var_os("GITHUB_TOKEN");
+        let saved_gh = std::env::var_os("GH_TOKEN");
+
+        unsafe { std::env::set_var("GITHUB_TOKEN", "  github-token  "); }
+        unsafe { std::env::set_var("GH_TOKEN", "  gh-token  "); }
+        assert_eq!(github_token().as_deref(), Some("github-token"));
+
+        unsafe { std::env::set_var("GITHUB_TOKEN", "  \t  "); }
+        assert_eq!(github_token().as_deref(), Some("gh-token"));
+
+        unsafe { std::env::remove_var("GITHUB_TOKEN"); }
+        assert_eq!(github_token().as_deref(), Some("gh-token"));
+
+        unsafe { std::env::set_var("GH_TOKEN", "  "); }
+        assert_eq!(github_token(), None);
+
+        match saved_github {
+            Some(s) => unsafe { std::env::set_var("GITHUB_TOKEN", s); },
+            None => unsafe { std::env::remove_var("GITHUB_TOKEN"); },
+        }
+        match saved_gh {
+            Some(s) => unsafe { std::env::set_var("GH_TOKEN", s); },
+            None => unsafe { std::env::remove_var("GH_TOKEN"); },
+        }
     }
 
     // ── is_newer ────────────────────────────────────────────────────────

--- a/libs/cua-driver/rust/crates/cua-driver/src/version_check.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/version_check.rs
@@ -643,6 +643,15 @@ fn migrate_legacy_cache() {
 
 // ── HTTP fetch (shared with the `update` subcommand) ─────────────────────
 
+fn github_token() -> Option<String> {
+    ["GH_TOKEN", "GITHUB_TOKEN"].into_iter().find_map(|name| {
+        std::env::var(name)
+            .ok()
+            .map(|token| token.trim().to_owned())
+            .filter(|token| !token.is_empty())
+    })
+}
+
 /// Fetch the highest `cua-driver-rs-v*` release tag from GitHub.
 ///
 /// Uses `ureq` (already a dep via telemetry) so we don't shell out to
@@ -667,20 +676,32 @@ pub fn fetch_latest_version() -> Result<String, String> {
 pub fn fetch_latest_version_for(
     channel: crate::release_channel::ReleaseChannel,
 ) -> Result<String, String> {
+    fetch_latest_version_from(RELEASES_URL, channel)
+}
+
+fn fetch_latest_version_from(
+    releases_url: &str,
+    channel: crate::release_channel::ReleaseChannel,
+) -> Result<String, String> {
     let agent = ureq::Agent::config_builder()
         .timeout_global(Some(std::time::Duration::from_secs(HTTP_TIMEOUT_SECONDS)))
         .build()
         .new_agent();
 
-    let response = agent
-        .get(RELEASES_URL)
+    let mut request = agent
+        .get(releases_url)
         .header("Accept", "application/vnd.github+json")
         .header(
             "User-Agent",
             concat!("cua-driver-rs/", env!("CARGO_PKG_VERSION")),
-        )
+        );
+    if let Some(token) = github_token() {
+        request = request.header("Authorization", format!("Bearer {token}"));
+    }
+
+    let response = request
         .call()
-        .map_err(|e| format!("HTTP error: {e}"))?;
+        .map_err(|error| format!("HTTP error: {error}"))?;
 
     let body: serde_json::Value = response
         .into_body()
@@ -829,6 +850,81 @@ mod tests {
             },
         }
         result
+    }
+
+    fn request_authorization(
+        gh_token: Option<&str>,
+        github_token: Option<&str>,
+    ) -> (Option<String>, String) {
+        for (name, value) in [("GH_TOKEN", gh_token), ("GITHUB_TOKEN", github_token)] {
+            match value {
+                Some(value) => unsafe { std::env::set_var(name, value) },
+                None => unsafe { std::env::remove_var(name) },
+            }
+        }
+
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let url = format!("http://{}/releases", listener.local_addr().unwrap());
+        let server = std::thread::spawn(move || {
+            use std::io::{Read, Write};
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = Vec::new();
+            let mut chunk = [0_u8; 1024];
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let count = stream.read(&mut chunk).unwrap();
+                if count == 0 {
+                    break;
+                }
+                request.extend_from_slice(&chunk[..count]);
+            }
+            stream
+                .write_all(
+                    b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .unwrap();
+            String::from_utf8(request).unwrap()
+        });
+
+        let error = fetch_latest_version_from(&url, crate::release_channel::ReleaseChannel::Stable)
+            .unwrap_err();
+        let request = server.join().unwrap();
+        let authorization = request.lines().find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("authorization")
+                .then(|| value.trim().to_owned())
+        });
+        (authorization, error)
+    }
+
+    #[test]
+    fn github_request_applies_token_precedence_without_leaking_secrets() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let saved_gh = std::env::var_os("GH_TOKEN");
+        let saved_github = std::env::var_os("GITHUB_TOKEN");
+
+        let (authorization, error) =
+            request_authorization(Some("  gh-secret  "), Some("github-secret"));
+        assert_eq!(authorization.as_deref(), Some("Bearer gh-secret"));
+        assert!(!error.contains("gh-secret"));
+        assert!(!error.contains("github-secret"));
+
+        let (authorization, error) = request_authorization(Some(" \t "), Some("  github-secret  "));
+        assert_eq!(authorization.as_deref(), Some("Bearer github-secret"));
+        assert!(!error.contains("github-secret"));
+
+        let (authorization, error) = request_authorization(None, None);
+        assert_eq!(authorization, None);
+        assert!(!error.contains("secret"));
+
+        match saved_gh {
+            Some(value) => unsafe { std::env::set_var("GH_TOKEN", value) },
+            None => unsafe { std::env::remove_var("GH_TOKEN") },
+        }
+        match saved_github {
+            Some(value) => unsafe { std::env::set_var("GITHUB_TOKEN", value) },
+            None => unsafe { std::env::remove_var("GITHUB_TOKEN") },
+        }
     }
 
     // ── is_newer ────────────────────────────────────────────────────────

--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -50,6 +50,9 @@
 #                                    disable GC entirely). Per-target —
 #                                    multi-arch dirs are pruned
 #                                    independently of each other.
+#   $env:GITHUB_TOKEN / GH_TOKEN     optional GitHub API bearer token for
+#                                    rate-limited networks; GITHUB_TOKEN
+#                                    wins over GH_TOKEN.
 #
 # Params:
 #   -Release    release tag to install ("latest" or a bare version like "0.2.0").
@@ -100,6 +103,17 @@ $ProgressPreference = "SilentlyContinue"
 $Repo       = "trycua/cua"
 $TagPrefix  = "cua-driver-rs-v"
 $BinaryName = "cua-driver.exe"
+
+function Get-GitHubApiHeaders {
+    $token = $null
+    if ($env:GITHUB_TOKEN -and $env:GITHUB_TOKEN.Trim()) {
+        $token = $env:GITHUB_TOKEN.Trim()
+    } elseif ($env:GH_TOKEN -and $env:GH_TOKEN.Trim()) {
+        $token = $env:GH_TOKEN.Trim()
+    }
+    if ($token) { return @{ Authorization = "Bearer $token" } }
+    return @{}
+}
 
 # Baked-version constant — kept in lock-step with the latest published
 # cua-driver-rs-v* release tag by the CD workflow's bake-version step
@@ -878,7 +892,7 @@ function Resolve-Version {
     $matches = @()
     for ($page = 1; $page -le 10; $page++) {
         $uri = "https://api.github.com/repos/$Repo/releases?per_page=100&page=$page"
-        $batch = Invoke-RestMethod -Uri $uri -UseBasicParsing
+        $batch = Invoke-RestMethod -Uri $uri -UseBasicParsing -Headers (Get-GitHubApiHeaders)
         if (-not $batch -or $batch.Count -eq 0) { break }
         $matches += @($batch | Where-Object { $_.tag_name -like "$TagPrefix*" })
         if ($batch.Count -lt 100) { break }

--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -50,6 +50,8 @@
 #                                    disable GC entirely). Per-target —
 #                                    multi-arch dirs are pruned
 #                                    independently of each other.
+#   $env:GH_TOKEN / GITHUB_TOKEN     optional GitHub API bearer token for
+#                                    rate-limited networks; GH_TOKEN wins.
 #
 # Params:
 #   -Release    release to install ("latest", a bare stable version, or a
@@ -875,16 +877,21 @@ function Invoke-OldReleasesGc {
 $Script:CuaDriverRsVersionSource = $null
 $Script:CuaDriverRsReleaseTag = $null
 
-function Get-GitHubApiHeaders {
-    # GH_TOKEN matches the GitHub CLI's precedence. Keep the token in a header
-    # object only; never include it in installer diagnostics.
-    $token = $env:GH_TOKEN
-    if (-not $token) { $token = $env:GITHUB_TOKEN }
+function Get-GitHubApiToken {
+    # GH_TOKEN matches the GitHub CLI and Unix installer precedence.
+    foreach ($value in @($env:GH_TOKEN, $env:GITHUB_TOKEN)) {
+        if ($value -and $value.Trim()) { return $value.Trim() }
+    }
+    return $null
+}
 
+function Get-GitHubApiHeaders {
+    # Keep the token in a header object only; never include it in diagnostics.
     $headers = @{
         Accept = "application/vnd.github+json"
         "User-Agent" = "cua-driver-installer"
     }
+    $token = Get-GitHubApiToken
     if ($token) {
         $headers["Authorization"] = "Bearer $token"
     }
@@ -952,7 +959,13 @@ function Get-LatestVersionFromApi {
         }
     }
     catch {
-        Write-WarningStep "GitHub Releases API query failed: $($_.Exception.Message)"
+        $message = $_.Exception.Message
+        foreach ($value in @($env:GH_TOKEN, $env:GITHUB_TOKEN)) {
+            if ($value -and $value.Trim()) {
+                $message = $message.Replace($value.Trim(), '<redacted>')
+            }
+        }
+        Write-WarningStep "GitHub Releases API query failed: $message"
         return $null
     }
     if (-not $releaseMatches -or $releaseMatches.Count -eq 0) {

--- a/libs/cua-driver/scripts/tests/test_install_version_fallback.py
+++ b/libs/cua-driver/scripts/tests/test_install_version_fallback.py
@@ -323,6 +323,72 @@ Get-LatestVersionFromApi
     assert result.stdout.strip() == "1.20.3"
 
 
+@requires_powershell
+@pytest.mark.parametrize(
+    ("gh_token", "github_token", "expected"),
+    [
+        ("  gh-secret  ", "github-secret", "Bearer gh-secret"),
+        ("   ", "  github-secret  ", "Bearer github-secret"),
+        (None, None, None),
+    ],
+)
+def test_windows_api_request_applies_token_precedence_without_leaking_errors(
+    tmp_path: Path,
+    gh_token: str | None,
+    github_token: str | None,
+    expected: str | None,
+) -> None:
+    source = _windows_source()
+    functions = "\n\n".join(
+        _extract_powershell_function(source, name)
+        for name in (
+            "Get-GitHubApiToken",
+            "Get-GitHubApiHeaders",
+            "Get-LatestVersionFromApi",
+        )
+    )
+
+    def ps_env(value: str | None) -> str:
+        if value is None:
+            return "$null"
+        return "'" + value.replace("'", "''") + "'"
+
+    result = _run_powershell(
+        tmp_path,
+        f"""
+$env:GH_TOKEN = {ps_env(gh_token)}
+$env:GITHUB_TOKEN = {ps_env(github_token)}
+$Repo = 'trycua/cua'
+$TagPrefix = 'cua-driver-rs-v'
+$NightlyTagPrefix = 'nightly-cua-driver-rs-v'
+$Script:CuaDriverRsSelectedChannel = 'stable'
+$script:ObservedAuthorization = $null
+$script:WarningMessage = $null
+function Write-Step {{ param([string]$Message) }}
+function Write-WarningStep {{ param([string]$Message) $script:WarningMessage = $Message }}
+function Invoke-RestMethod {{
+    param([string]$Uri, [hashtable]$Headers, [switch]$UseBasicParsing)
+    $script:ObservedAuthorization = $Headers['Authorization']
+    throw "request failed with $($Headers['Authorization']); env=$env:GH_TOKEN/$env:GITHUB_TOKEN"
+}}
+
+{functions}
+
+$resolved = Get-LatestVersionFromApi
+[pscustomobject]@{{
+    Authorization = $script:ObservedAuthorization
+    Warning = $script:WarningMessage
+    IsNull = $null -eq $resolved
+}} | ConvertTo-Json -Compress
+""",
+    )
+    observed = json.loads(result.stdout)
+    assert observed["Authorization"] == expected
+    assert observed["IsNull"] is True
+    assert "gh-secret" not in observed["Warning"]
+    assert "github-secret" not in observed["Warning"]
+
+
 # ---------- Unix ----------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- honor `GITHUB_TOKEN`, then `GH_TOKEN`, for cua-driver GitHub Releases API update checks
- pass GitHub API auth headers from `install.ps1` release resolution without logging tokens
- document the env vars and correct stale Windows install path/one-liner

## Docs
- Regenerated cua-driver reference docs with `npx tsx scripts/docs-generators/cua-driver.ts`; no generated file drift.
- Verified with `npx tsx scripts/docs-generators/cua-driver.ts --check`.

## Verification
- `cd libs/cua-driver/rust && cargo check -p cua-driver`
- `npx tsx scripts/docs-generators/cua-driver.ts --check`
- `cargo test -p cua-driver github_token_prefers_github_token_and_trims_empty_values` was attempted, but macOS linking failed due missing Swift compatibility libraries/frameworks (`swiftCompatibility56`, `swiftCompatibilityConcurrency`, `CoreAudioTypes`).
- PowerShell parse check skipped: `pwsh`/`powershell` is not installed in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using `GITHUB_TOKEN` or `GH_TOKEN` during install and update checks to help avoid GitHub API rate limits.
  * Updated Windows install guidance with the latest default driver location and fallback install path.

* **Bug Fixes**
  * Improved release lookup on rate-limited networks by sending authenticated GitHub API requests when a token is available.
  * Added a note that empty or whitespace-only tokens are ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->