### PR TITLE
fix(agent): recognize cua_sandbox Localhost as a computer

### DIFF
--- a/libs/python/agent/cua_agent/computers/__init__.py
+++ b/libs/python/agent/cua_agent/computers/__init__.py
@@ -19,6 +19,11 @@ try:
 except ImportError:
     cuaSandbox = None  # type: ignore[assignment,misc]
 
+try:
+    from cua_sandbox import Localhost as cuaLocalhost
+except ImportError:
+    cuaLocalhost = None  # type: ignore[assignment,misc]
+
 from .base import AsyncComputerHandler
 from .custom import CustomComputerHandler
 from .sandbox import SandboxComputerHandler
@@ -30,6 +35,7 @@ def is_agent_computer(computer):
         isinstance(computer, AsyncComputerHandler)
         or (cuaComputer is not None and isinstance(computer, cuaComputer))
         or (cuaSandbox is not None and isinstance(computer, cuaSandbox))
+        or (cuaLocalhost is not None and isinstance(computer, cuaLocalhost))
         or (isinstance(computer, dict))
     )  # and "screenshot" in computer)
 
@@ -40,7 +46,7 @@ async def make_computer_handler(computer):
 
     Args:
         computer: Either a ComputerHandler instance, Computer instance,
-                  Sandbox instance, or dict of functions
+                  Sandbox or Localhost instance, or dict of functions
 
     Returns:
         ComputerHandler: A computer handler instance
@@ -55,6 +61,8 @@ async def make_computer_handler(computer):
         await computer_handler._initialize()
         return computer_handler
     if cuaSandbox is not None and isinstance(computer, cuaSandbox):
+        return SandboxComputerHandler(computer)
+    if cuaLocalhost is not None and isinstance(computer, cuaLocalhost):
         return SandboxComputerHandler(computer)
     if isinstance(computer, dict):
         return CustomComputerHandler(computer)

--- a/libs/python/agent/tests/test_localhost_resolution.py
+++ b/libs/python/agent/tests/test_localhost_resolution.py
@@ -1,0 +1,30 @@
+"""Tests that a cua_sandbox Localhost is resolved like a Sandbox by the agent."""
+
+from unittest.mock import patch
+
+import pytest
+from cua_agent.computers import (
+    SandboxComputerHandler,
+    is_agent_computer,
+    make_computer_handler,
+)
+
+
+class _FakeLocalhost:
+    pass
+
+
+def test_localhost_is_recognized_as_agent_computer():
+    host = _FakeLocalhost()
+    assert is_agent_computer(host) is False
+    with patch("cua_agent.computers.cuaLocalhost", _FakeLocalhost):
+        assert is_agent_computer(host) is True
+
+
+@pytest.mark.asyncio
+async def test_make_computer_handler_wraps_localhost():
+    host = _FakeLocalhost()
+    with patch("cua_agent.computers.cuaLocalhost", _FakeLocalhost):
+        handler = await make_computer_handler(host)
+    assert isinstance(handler, SandboxComputerHandler)
+    assert handler._sandbox is host


### PR DESCRIPTION
## Summary

Closes #1897

Passing a `cua_sandbox` `Localhost` to an agent as a tool fails with `Warning: Unknown tool type: Localhost()`, even though `Localhost.connect()` is documented as a no-VM alternative to `Sandbox`. The agent's tool resolution (`is_agent_computer` / `make_computer_handler` in `cua_agent/computers/__init__.py`) only recognizes `Computer`, `Sandbox`, `AsyncComputerHandler` and dicts, so a `Localhost` instance falls through to the "unknown tool" branch and is never wired up.

`Localhost` exposes the same interface as `Sandbox` (this is already relied on inside `cua_sandbox`, whose `LocalhostHandler` subclasses `SandboxHandler` and just swaps the object), so this recognizes it the same way and reuses `SandboxComputerHandler`.

## Changes

`libs/python/agent/cua_agent/computers/__init__.py`:

- import `Localhost` from `cua_sandbox` in a `try/except`, mirroring the existing optional `Sandbox` import (stays `None` when `cua_sandbox` is not installed, so nothing changes for installs without it)
- `is_agent_computer` returns `True` for a `Localhost`
- `make_computer_handler` builds a `SandboxComputerHandler` for a `Localhost`, matching how `Sandbox` is handled

## Tests

`libs/python/agent/tests/test_localhost_resolution.py`:

- `is_agent_computer` returns `False` for an object before it is a known type and `True` once `Localhost` is recognized
- `make_computer_handler` wraps a `Localhost` in a `SandboxComputerHandler` around the same instance

Both pass; the existing `tests/test_tool_resolution.py` suite still passes unchanged. Fail-before / pass-after verified (removing the new `make_computer_handler` branch fails the handler test).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for localhost-based computer sessions in the agent.
  * Localhost connections can now be recognized and handled like sandboxed computers.
* **Tests**
  * Added coverage to verify localhost recognition and handler wrapping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->