### PR TITLE
feat(cua-driver): verify installed binary and diagnose App Control blocks

### DIFF
--- a/libs/cua-driver/rust/Cargo.lock
+++ b/libs/cua-driver/rust/Cargo.lock
@@ -610,7 +610,6 @@ dependencies = [
  "cua-driver-core",
  "cua-driver-testkit",
  "cursor-overlay",
- "embed-resource",
  "flate2",
  "image",
  "libc",
@@ -630,6 +629,7 @@ dependencies = [
  "uuid",
  "wait-timeout",
  "windows 0.61.3",
+ "winresource",
 ]
 
 [[package]]
@@ -661,13 +661,13 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "cua-driver-core",
- "embed-manifest",
  "platform-windows",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "winresource",
 ]
 
 [[package]]
@@ -777,26 +777,6 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
-
-[[package]]
-name = "embed-manifest"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94cdc65b1cf9e871453ce2f86f5aaec24ff2eaa36a1fa3e02e441dddc3613b99"
-
-[[package]]
-name = "embed-resource"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d506610004cfc74a6f5ee7e8c632b355de5eca1f03ee5e5e0ec11b77d4eb3d61"
-dependencies = [
- "cc",
- "memchr",
- "rustc_version",
- "toml",
- "vswhom",
- "winreg",
-]
 
 [[package]]
 name = "endi"
@@ -2309,15 +2289,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2507,6 +2478,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2662,7 +2642,7 @@ dependencies = [
  "cfg-expr",
  "heck",
  "pkg-config",
- "toml",
+ "toml 0.8.23",
  "version-compare",
 ]
 
@@ -2872,9 +2852,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -2903,9 +2898,8 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
- "toml_write",
  "winnow 0.7.15",
 ]
 
@@ -2931,10 +2925,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -3233,26 +3227,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "vswhom"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b"
-dependencies = [
- "libc",
- "vswhom-sys",
-]
-
-[[package]]
-name = "vswhom-sys"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
-dependencies = [
- "cc",
- "libc",
-]
 
 [[package]]
 name = "wait-timeout"
@@ -3815,13 +3789,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.52.0"
+name = "winresource"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+checksum = "0986a8b1d586b7d3e4fe3d9ea39fb451ae22869dcea4aa109d287a374d866087"
 dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
+ "toml 1.1.2+spec-1.1.0",
+ "version_check",
 ]
 
 [[package]]

--- a/libs/cua-driver/rust/Skills/cua-driver/WINDOWS.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/WINDOWS.md
@@ -506,6 +506,16 @@ your prior tool calls earned.
      may flag the unsigned binary on first run. Click "More info →
      Run anyway" once.
 
+### Troubleshooting: WinError 4551 / Device Guard policy block
+
+If install or first launch reports `WinError 4551` or "blocked by your
+organization's Device Guard policy", the unsigned `cua-driver.exe` is
+being blocked by Smart App Control / WDAC enforcement. Confirm in Event
+Viewer under **Applications and Services Logs → Microsoft → Windows →
+CodeIntegrity → Operational** (events 3033, 3077, or 3118). On managed
+machines, ask an admin for an allowlist exception. Releases are not yet
+Authenticode-signed; see [#2118](https://github.com/trycua/cua/issues/2118).
+
 ## Using cua-driver from the shell
 
 Tool names are `snake_case`, management subcommands are

--- a/libs/cua-driver/rust/crates/cua-driver-uia/Cargo.toml
+++ b/libs/cua-driver/rust/crates/cua-driver-uia/Cargo.toml
@@ -29,5 +29,5 @@ tracing-subscriber = { workspace = true }
 cua-driver-core = { path = "../cua-driver-core" }
 platform-windows = { path = "../platform-windows" }
 
-[target.'cfg(target_os = "windows")'.build-dependencies]
-embed-manifest = "1.4"
+[build-dependencies]
+winresource = "0.1"

--- a/libs/cua-driver/rust/crates/cua-driver-uia/build.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-uia/build.rs
@@ -1,8 +1,44 @@
 fn main() {
-    #[cfg(target_os = "windows")]
-    {
-        embed_manifest::embed_manifest_file("cua-driver-uia.manifest")
-            .expect("failed to embed cua-driver-uia.manifest");
-        println!("cargo:rerun-if-changed=cua-driver-uia.manifest");
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
+        return;
     }
+
+    embed_windows_version_info(
+        "cua-driver-uia",
+        "cua-driver",
+        Some("cua-driver-uia.manifest"),
+    );
+}
+
+fn embed_windows_version_info(
+    file_description: &str,
+    product_name: &str,
+    manifest_file: Option<&str>,
+) {
+    let version = std::env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "0.0.0".to_string());
+    let version_u64 = windows_version_u64(&version);
+
+    let mut resource = winresource::WindowsResource::new();
+    resource.set("FileDescription", file_description);
+    resource.set("ProductName", product_name);
+    resource.set("CompanyName", "trycua");
+    resource.set("FileVersion", &version);
+    resource.set("ProductVersion", &version);
+    if let Some(manifest_file) = manifest_file {
+        resource.set_manifest_file(manifest_file);
+        println!("cargo:rerun-if-changed={manifest_file}");
+    }
+    resource.set_version_info(winresource::VersionInfo::FILEVERSION, version_u64);
+    resource.set_version_info(winresource::VersionInfo::PRODUCTVERSION, version_u64);
+    resource
+        .compile()
+        .expect("failed to embed Windows VERSIONINFO");
+}
+
+fn windows_version_u64(version: &str) -> u64 {
+    let mut parts = [0_u64; 4];
+    for (idx, part) in version.split(['.', '-']).take(4).enumerate() {
+        parts[idx] = part.parse::<u64>().unwrap_or(0).min(0xffff);
+    }
+    (parts[0] << 48) | (parts[1] << 32) | (parts[2] << 16) | parts[3]
 }

--- a/libs/cua-driver/rust/crates/cua-driver/Cargo.toml
+++ b/libs/cua-driver/rust/crates/cua-driver/Cargo.toml
@@ -67,10 +67,8 @@ default = []
 # leaves it off. No-op on macOS/Windows builds.
 portal-libei = ["platform-linux/portal-libei"]
 
-[target.'cfg(target_os = "windows")'.build-dependencies]
-# Embed the Windows manifest for DPI awareness (fixes coordinate mismatches
-# at 125%/150%/200% scaling).
-embed-resource = "2"
+[build-dependencies]
+winresource = "0.1"
 
 [dev-dependencies]
 # Shared integration-test harness (MCP/CLI transports, child reaping, paths,

--- a/libs/cua-driver/rust/crates/cua-driver/build.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/build.rs
@@ -12,9 +12,8 @@
 // 125%/150%/200% scaling and clicks land where screenshots say they do.
 
 fn main() {
-    #[cfg(target_os = "windows")]
-    {
-        embed_resource::compile("cua-driver.rc", embed_resource::NONE);
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
+        embed_windows_version_info("cua-driver", "cua-driver", Some("cua-driver.manifest"));
     }
 
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("macos") {
@@ -22,7 +21,10 @@ fn main() {
     }
     println!("cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift");
 
-    if let Ok(out) = std::process::Command::new("xcode-select").arg("-p").output() {
+    if let Ok(out) = std::process::Command::new("xcode-select")
+        .arg("-p")
+        .output()
+    {
         if out.status.success() {
             let xcode_path = String::from_utf8_lossy(&out.stdout).trim().to_string();
             for sub in [
@@ -33,4 +35,37 @@ fn main() {
             }
         }
     }
+}
+
+fn embed_windows_version_info(
+    file_description: &str,
+    product_name: &str,
+    manifest_file: Option<&str>,
+) {
+    let version = std::env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "0.0.0".to_string());
+    let version_u64 = windows_version_u64(&version);
+
+    let mut resource = winresource::WindowsResource::new();
+    resource.set("FileDescription", file_description);
+    resource.set("ProductName", product_name);
+    resource.set("CompanyName", "trycua");
+    resource.set("FileVersion", &version);
+    resource.set("ProductVersion", &version);
+    if let Some(manifest_file) = manifest_file {
+        resource.set_manifest_file(manifest_file);
+        println!("cargo:rerun-if-changed={manifest_file}");
+    }
+    resource.set_version_info(winresource::VersionInfo::FILEVERSION, version_u64);
+    resource.set_version_info(winresource::VersionInfo::PRODUCTVERSION, version_u64);
+    resource
+        .compile()
+        .expect("failed to embed Windows VERSIONINFO");
+}
+
+fn windows_version_u64(version: &str) -> u64 {
+    let mut parts = [0_u64; 4];
+    for (idx, part) in version.split(['.', '-']).take(4).enumerate() {
+        parts[idx] = part.parse::<u64>().unwrap_or(0).min(0xffff);
+    }
+    (parts[0] << 48) | (parts[1] << 32) | (parts[2] << 16) | parts[3]
 }

--- a/libs/cua-driver/rust/crates/cua-driver/cua-driver.rc
+++ b/libs/cua-driver/rust/crates/cua-driver/cua-driver.rc
@@ -1,6 +1,0 @@
-// 24 = RT_MANIFEST. The numeric type is required: `RT_MANIFEST` is not an
-// .rc keyword, so the resource compiler would emit a custom *string-typed*
-// resource named "RT_MANIFEST" that the Windows loader never applies as a
-// manifest (the process then starts DPI-unaware). ID 1 =
-// CREATEPROCESS_MANIFEST_RESOURCE_ID.
-1 24 "cua-driver.manifest"

--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -70,6 +70,8 @@
 #               this when you manage PATH out-of-band (chezmoi, a dotfiles
 #               repo, group policy). Idempotent either way: if the dir is
 #               already on PATH, nothing changes.
+#   -SkipVerify skip the post-install `cua-driver --version` smoke test.
+#               Default off.
 #
 # Windows installer for the cross-platform cua-driver Rust implementation.
 
@@ -84,7 +86,8 @@ param(
     # that specifically don't want a scheduled task registered.
     [switch]$AutoStart = $true,
     [switch]$NoAutoStart,
-    [switch]$NoPathUpdate
+    [switch]$NoPathUpdate,
+    [switch]$SkipVerify
 )
 # `-NoAutoStart` is the explicit opt-out and takes precedence over
 # the default-true `-AutoStart`.
@@ -178,6 +181,87 @@ function Write-WarningStep($message) {
 
 function Write-ErrorStep($message) {
     Write-Host "error: $message" -ForegroundColor Red
+}
+
+function Test-CuaDriverAppControlBlock {
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)]$ErrorObject)
+
+    $message = ""
+    $nativeErrorCode = $null
+    $current = $null
+
+    if ($ErrorObject -is [System.Management.Automation.ErrorRecord]) {
+        $current = $ErrorObject.Exception
+        $message = [string]$ErrorObject
+    } elseif ($ErrorObject -is [System.Exception]) {
+        $current = $ErrorObject
+        $message = $ErrorObject.Message
+    } else {
+        $message = [string]$ErrorObject
+    }
+
+    while ($null -ne $current) {
+        if ($current.Message) { $message = "$message`n$($current.Message)" }
+        if ($current -is [System.ComponentModel.Win32Exception]) {
+            $nativeErrorCode = $current.NativeErrorCode
+        }
+        $current = $current.InnerException
+    }
+
+    $hasAppControlText = ($message -match 'Application Control' -or $message -match 'Device Guard')
+    return ($nativeErrorCode -eq 4551 -or $message -match '\b4551\b' -or $hasAppControlText)
+}
+
+function Write-CuaDriverAppControlDiagnostic {
+    Write-ErrorStep "Windows Application Control blocked cua-driver.exe."
+    Write-ErrorStep "  Smart App Control / WDAC policy blocks unsigned binaries on this machine."
+    Write-ErrorStep "  This is not a Mark-of-the-Web issue."
+    Write-ErrorStep "  Confirm in Event Viewer: Applications and Services Logs > Microsoft > Windows > CodeIntegrity > Operational."
+    Write-ErrorStep "  Look for Code Integrity events 3033, 3077, or 3118."
+    Write-ErrorStep "  On managed machines, ask an admin for an allowlist exception."
+    Write-ErrorStep "  Releases are not yet Authenticode-signed; see https://github.com/trycua/cua/issues/2118."
+}
+
+function Test-CuaDriverInstalledBinary {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$InstalledBinary,
+        [Parameter(Mandatory = $true)][string]$ExpectedVersion
+    )
+
+    if (-not (Test-Path -LiteralPath $InstalledBinary)) {
+        throw "binary not found at $InstalledBinary"
+    }
+
+    try {
+        $versionOutput = @(& $InstalledBinary --version 2>&1)
+        $exitCode = $LASTEXITCODE
+    }
+    catch {
+        if (Test-CuaDriverAppControlBlock -ErrorObject $_) {
+            Write-CuaDriverAppControlDiagnostic
+            exit 1
+        }
+        throw
+    }
+
+    if ($exitCode -ne 0) {
+        $combined = ($versionOutput | ForEach-Object { [string]$_ }) -join "`n"
+        if (Test-CuaDriverAppControlBlock -ErrorObject "$exitCode`n$combined") {
+            Write-CuaDriverAppControlDiagnostic
+            exit 1
+        }
+        if ($combined) { throw $combined }
+        throw "cua-driver --version failed (exit $exitCode)"
+    }
+
+    $combinedOutput = ($versionOutput | ForEach-Object { [string]$_ }) -join "`n"
+    if ($combinedOutput -notmatch [regex]::Escape($ExpectedVersion)) {
+        throw "cua-driver --version did not report expected version $ExpectedVersion; output: $combinedOutput"
+    }
+
+    Write-Step "verified $InstalledBinary --version ($ExpectedVersion)"
 }
 
 # ---------- Architecture detection -----------------------------------------
@@ -1133,6 +1217,12 @@ if (Test-Path -LiteralPath $installedBinary) {
     catch {
         # Ignore — telemetry must never block install.
     }
+}
+
+if ($SkipVerify) {
+    Write-Step "skipping binary verification (-SkipVerify set)"
+} else {
+    Test-CuaDriverInstalledBinary -InstalledBinary $installedBinary -ExpectedVersion $version
 }
 
 # ---------- PATH update (User scope, idempotent, fallback to manual) ------


### PR DESCRIPTION
## Summary
- Run a post-install `cua-driver.exe --version` smoke test by default, with `-SkipVerify` as an explicit opt-out, so any non-runnable install (App Control block, AV quarantine, corrupted download) fails at install time instead of in a downstream tool.
- Classify Windows App Control / Smart App Control / WDAC blocks (Win32 error 4551 or Device Guard / Application Control message text) and print a focused diagnostic; all other execution failures surface unchanged.
- Embed Windows VERSIONINFO metadata in `cua-driver.exe` and `cua-driver-uia.exe` (migrating both crates' existing manifest embedding to `winresource`), and add a WinError 4551 troubleshooting section to the Windows skill docs.

## What this does NOT do
This makes App Control blocks diagnosable during install; it does **not** resolve them — that requires Authenticode-signed releases. Note that #1602 was closed as not-planned on the grounds that signing wasn't needed for *functionality* (UWP automation works unsigned); #2118 is a new, distinct motivation: on SAC/WDAC-enforced machines the unsigned binary cannot execute at all. Signing options (e.g. Azure Trusted Signing, SignPath OSS) are being discussed in #2118.

Related to #2118 (diagnosability only — intentionally not `Fixes`, since the underlying block remains).

## Verification
- [x] `cargo check -p cua-driver -p cua-driver-uia` from `libs/cua-driver/rust`
- [x] `rg -l "cua-driver\.rc"` returns empty after deleting the orphaned `.rc`
- [ ] PowerShell parse-check for `install.ps1` (not run: no `pwsh`/`powershell` on this host)
- [ ] Injected classifier checks: Device-Guard-text-only → block, NativeErrorCode 4551 only → block, generic error → no-block (not run: no PowerShell host)
- [ ] Windows-native build confirming VERSIONINFO in both exes (winresource needs `rc.exe`; exercised only on Windows CI runners)
- [ ] Live Windows install run confirming the verified line and `-SkipVerify` behavior

Note: the MSVC cross-check from macOS fails earlier in `ring`'s C build (missing MSVC headers) — pre-existing, unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer Windows troubleshooting guidance for installation or first-launch failures blocked by Smart App Control / Device Guard.
  * Added an optional install switch to skip post-install version verification when needed.

* **Bug Fixes**
  * Improved Windows install checks to detect application-control blocks more reliably and show actionable diagnostics.
  * Updated Windows packaging details so installed binaries include proper version information and resource metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->