### PR TITLE
fix(cua-driver/linux): surface native Wayland windows in list_windows on GNOME/KDE (#1978)

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
@@ -1383,14 +1383,28 @@ pub fn list_windows_dispatch(filter_pid: Option<u32>) -> Vec<WindowInfo> {
     // invisible (#1978). Merge in the AT-SPI registry (keyed by pid), which does
     // surface native Wayland apps that expose accessibility. Gated on the same
     // opt-in as the rest of the native-Wayland backend.
+    //
+    // Caveats for the merged AT-SPI entries: they carry a synthetic (non-X11)
+    // xid and zero geometry (x/y/w/h = 0), like the existing wlroots AT-SPI
+    // fallback — so `bring_to_front` / `screenshot_window` / pixel translation
+    // against them error cleanly rather than acting (input on GNOME/KDE routes
+    // by pid + screen coords, not xid, so it's unaffected). Dedup is per-pid, so
+    // the rare app owning BOTH an XWayland window and a separate native-Wayland
+    // toplevel would list only the XWayland one.
     let mut ws = crate::x11::list_windows(filter_pid);
     if wayland_enabled() && std::env::var_os("WAYLAND_DISPLAY").is_some() {
         let seen: std::collections::HashSet<u32> = ws.iter().filter_map(|w| w.pid).collect();
-        for w in crate::atspi::list_windows(filter_pid) {
-            // XWayland apps appear in both lists; keep the X11 entry (real XID +
-            // geometry) and add only AT-SPI windows for pids X11 didn't report.
-            if w.pid.map_or(true, |p| !seen.contains(&p)) {
-                ws.push(w);
+        // A specific pid already resolved via X11 needs no AT-SPI walk (a full
+        // D-Bus enumeration of every registered app): it can only add duplicates.
+        let already_covered = filter_pid.map_or(false, |p| seen.contains(&p));
+        if !already_covered {
+            for w in crate::atspi::list_windows(filter_pid) {
+                // XWayland apps appear in both lists; keep the X11 entry (real
+                // XID + geometry) and add only AT-SPI windows for pids X11 didn't
+                // report.
+                if w.pid.map_or(true, |p| !seen.contains(&p)) {
+                    ws.push(w);
+                }
             }
         }
     }

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
@@ -1377,7 +1377,24 @@ pub fn list_windows_dispatch(filter_pid: Option<u32>) -> Vec<WindowInfo> {
         }
         // Last resort under Wayland: an Xwayland app may still have an X11 XID.
     }
-    crate::x11::list_windows(filter_pid)
+    // On an XWayland-co-present Wayland session (GNOME/Mutter, KDE/KWin: DISPLAY
+    // is set, so `is_wayland()` above is false), X11 enumeration only sees
+    // XWayland apps — native Wayland apps have no X11 XID and are otherwise
+    // invisible (#1978). Merge in the AT-SPI registry (keyed by pid), which does
+    // surface native Wayland apps that expose accessibility. Gated on the same
+    // opt-in as the rest of the native-Wayland backend.
+    let mut ws = crate::x11::list_windows(filter_pid);
+    if wayland_enabled() && std::env::var_os("WAYLAND_DISPLAY").is_some() {
+        let seen: std::collections::HashSet<u32> = ws.iter().filter_map(|w| w.pid).collect();
+        for w in crate::atspi::list_windows(filter_pid) {
+            // XWayland apps appear in both lists; keep the X11 entry (real XID +
+            // geometry) and add only AT-SPI windows for pids X11 didn't report.
+            if w.pid.map_or(true, |p| !seen.contains(&p)) {
+                ws.push(w);
+            }
+        }
+    }
+    ws
 }
 
 /// Snapshot of which wlroots manager globals the running compositor advertises.


### PR DESCRIPTION
## Summary
`list_windows` returned no real application windows on GNOME/Mutter (and KDE/KWin) — only XWayland infrastructure. Native Wayland apps were invisible (#1978). This surfaces them via the AT-SPI registry.

## Root cause
`list_windows_dispatch` gates the native-Wayland enumeration on `is_wayland()`, which requires `DISPLAY` unset. GNOME/KDE always run XWayland → `DISPLAY` set → `is_wayland()` false → it goes straight to X11 enumeration, which only sees XWayland apps. Native Wayland apps have no X11 XID, so they never appear.

## Change
On an opted-in Wayland session (`CUA_DRIVER_RS_ENABLE_WAYLAND=1` + `WAYLAND_DISPLAY`), merge the AT-SPI registry (keyed by pid — the same tree `get_window_state` walks) into the X11 results:
- X11 entries keep priority (real XID + geometry).
- AT-SPI adds windows for pids X11 didn't report (native Wayland apps that expose accessibility).

No change on pure-wlroots sessions (the existing `is_wayland()` path) or non-opted-in sessions.

## Validation (Ubuntu 26.04, Mutter, Wayland)
- **Before:** `list_windows` returns only `mutter guard window`, `GNOME Shell`, `mutter-x11-frames`, `ibus-*` — no real apps.
- **After:** a native `gnome-text-editor` (no X11 XID) appears with its pid + title (`New Document (Draft) - Text Editor`), alongside the XWayland windows.

## Limitations
Only apps that expose an AT-SPI accessibility tree are enumerable this way (the same constraint as `get_window_state`). AT-SPI windows carry a stable synthetic xid + pid but no geometry (x/y/size are 0), consistent with the existing AT-SPI fallback used on wlroots. Full native-Wayland geometry needs a compositor-side helper (out of scope).

## Refs
Part of the #1922 native-Wayland follow-ups. Complements #2112 (input) — you can now both enumerate and drive native Wayland apps on GNOME/KDE.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window listing on Wayland by combining information from multiple sources when available.
  * Reduced missing or duplicate windows in mixed Wayland/X11 sessions by merging results more intelligently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->