### PR TITLE
Fix cua-driver PyPI release wiring

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -1,0 +1,57 @@
+"""Regression tests for cua-driver-rs release and PyPI wiring."""
+
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class TestCuaDriverReleaseWiring(unittest.TestCase):
+    """Verify cua-driver-rs releases feed the Python cua-driver publisher."""
+
+    def read(self, relative_path: str) -> str:
+        return (REPO_ROOT / relative_path).read_text()
+
+    def test_python_publish_follows_rust_workflow_run(self) -> None:
+        workflow = self.read(".github/workflows/cd-py-cua-driver.yml")
+
+        self.assertIn('workflows: ["CD: Cua Driver (cross-platform)"]', workflow)
+        self.assertNotIn("branches:\n      - main", workflow)
+        self.assertIn('github.event.workflow_run.conclusion != \'cancelled\'', workflow)
+        self.assertIn('gh release view "$TAG" --repo "$GITHUB_REPOSITORY"', workflow)
+
+    def test_python_publish_defaults_to_current_rust_version(self) -> None:
+        workflow = self.read(".github/workflows/cd-py-cua-driver.yml")
+
+        self.assertIn("required: false", workflow)
+        self.assertIn('default: ""', workflow)
+        self.assertIn("libs/cua-driver/rust/Cargo.toml", workflow)
+
+    def test_python_publish_builds_linux_arm64_wheel(self) -> None:
+        workflow = self.read(".github/workflows/cd-py-cua-driver.yml")
+
+        self.assertIn("os: ubuntu-24.04-arm", workflow)
+        self.assertIn("arch: arm64", workflow)
+
+    def test_release_on_merge_tracks_rust_driver(self) -> None:
+        workflow = self.read(".github/workflows/release-on-merge.yml")
+
+        self.assertIn('["libs/cua-driver/rust/"]="cua-driver-rs"', workflow)
+
+    def test_release_reminder_tracks_rust_driver(self) -> None:
+        workflow = self.read(".github/workflows/ci-release-reminder.yml")
+
+        self.assertIn('["libs/cua-driver/rust/"]="cua-driver-rs"', workflow)
+
+    def test_unreleased_digest_tracks_rust_driver(self) -> None:
+        workflow = self.read(".github/workflows/release-unreleased-digest.yml")
+
+        self.assertIn(
+            'SERVICE_TAG_DIR["cua-driver-rs"]="cua-driver-rs-v|libs/cua-driver/rust/"',
+            workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/cd-py-cua-driver.yml
+++ b/.github/workflows/cd-py-cua-driver.yml
@@ -8,15 +8,13 @@ on:
     inputs:
       version:
         description: "cua-driver-rs version to package (without v prefix)"
-        required: true
-        default: "0.5.1"
+        required: false
+        default: ""
   # Auto-trigger when cua-driver-rs releases (after CD workflow completes)
   workflow_run:
     workflows: ["CD: Cua Driver (cross-platform)"]
     types:
       - completed
-    branches:
-      - main
 
 permissions:
   contents: read
@@ -27,8 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.head_branch == 'main')
+      github.event.workflow_run.conclusion != 'cancelled'
     outputs:
       version: ${{ steps.version.outputs.version }}
       should_publish: ${{ steps.version.outputs.should_publish }}
@@ -37,9 +34,14 @@ jobs:
 
       - name: Determine version
         id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             VERSION="${{ inputs.version }}"
+            if [ -z "$VERSION" ]; then
+              VERSION=$(sed -n -E 's/^version = "([^"]+)"/\1/p' libs/cua-driver/rust/Cargo.toml | head -1)
+            fi
             SHOULD_PUBLISH="true"
           else
             # Extract from the tag that triggered the workflow_run
@@ -54,7 +56,12 @@ jobs:
               TAG=$(git tag --points-at "$HEAD_SHA" | grep '^cua-driver-rs-v' | head -1 || echo "")
               if [ -n "$TAG" ]; then
                 VERSION="${TAG#cua-driver-rs-v}"
-                SHOULD_PUBLISH="true"
+                if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+                  SHOULD_PUBLISH="true"
+                else
+                  echo "GitHub Release $TAG is not available; skipping PyPI publish."
+                  SHOULD_PUBLISH="false"
+                fi
               else
                 # No matching tag, skip
                 VERSION="0.0.0"
@@ -81,6 +88,9 @@ jobs:
           - os: ubuntu-latest
             platform: linux
             arch: x86_64
+          - os: ubuntu-24.04-arm
+            platform: linux
+            arch: arm64
           - os: windows-latest
             platform: windows
             arch: x86_64

--- a/.github/workflows/ci-release-reminder.yml
+++ b/.github/workflows/ci-release-reminder.yml
@@ -48,6 +48,7 @@ jobs:
             ["libs/qemu-docker/linux/"]="docker/qemu-linux"
             ["libs/qemu-docker/windows/"]="docker/qemu-windows"
             ["libs/lume/"]="lume"
+            ["libs/cua-driver/rust/"]="cua-driver-rs"
           )
 
           # Find affected services

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -82,6 +82,7 @@ jobs:
             ["libs/qemu-docker/linux/"]="docker/qemu-linux"
             ["libs/qemu-docker/windows/"]="docker/qemu-windows"
             ["libs/lume/"]="lume"
+            ["libs/cua-driver/rust/"]="cua-driver-rs"
           )
 
           # Find all affected services from changed files

--- a/.github/workflows/release-unreleased-digest.yml
+++ b/.github/workflows/release-unreleased-digest.yml
@@ -43,6 +43,7 @@ jobs:
           SERVICE_TAG_DIR["docker/qemu-linux"]="docker-cua-qemu-linux-v|libs/qemu-docker/linux/"
           SERVICE_TAG_DIR["docker/qemu-windows"]="docker-cua-qemu-windows-v|libs/qemu-docker/windows/"
           SERVICE_TAG_DIR["lume"]="lume-v|libs/lume/"
+          SERVICE_TAG_DIR["cua-driver-rs"]="cua-driver-rs-v|libs/cua-driver/rust/"
 
           UNRELEASED=""
           UNRELEASED_COUNT=0

--- a/libs/cua-driver/python/build_wheel.py
+++ b/libs/cua-driver/python/build_wheel.py
@@ -24,6 +24,16 @@ import zipfile
 from pathlib import Path
 
 
+def get_default_version() -> str:
+    """Read the wrapper package version from pyproject.toml."""
+    pyproject = Path(__file__).parent / "pyproject.toml"
+    for line in pyproject.read_text().splitlines():
+        line = line.strip()
+        if line.startswith("version = "):
+            return line.split('"', 2)[1]
+    raise RuntimeError(f"Could not read project version from {pyproject}")
+
+
 def get_platform_info(arch_override: str = None):
     """Determine platform and architecture for binary selection.
 
@@ -63,6 +73,24 @@ def get_platform_info(arch_override: str = None):
         return "windows", arch
     else:
         raise ValueError(f"Unsupported platform: {system}")
+
+
+def get_wheel_tag(platform_name: str, arch: str) -> str:
+    """Return the Python wheel tag for the bundled binary target."""
+    if platform_name == "darwin":
+        return "py3-none-macosx_11_0_universal2"
+    if platform_name == "linux":
+        if arch == "x86_64":
+            return "py3-none-linux_x86_64"
+        if arch == "arm64":
+            return "py3-none-linux_aarch64"
+    if platform_name == "windows":
+        if arch == "x86_64":
+            return "py3-none-win_amd64"
+        if arch == "arm64":
+            return "py3-none-win_arm64"
+
+    raise ValueError(f"Unsupported wheel target: {platform_name}-{arch}")
 
 
 def get_release_url(version: str, platform_name: str, arch: str) -> tuple[str, list[str]]:
@@ -210,16 +238,18 @@ def extract_binaries(archive_path: Path, binary_names: list[str], dest_dir: Path
     return extracted_paths
 
 
-def build_wheel(package_dir: Path, target_arch: str = None) -> None:
+def build_wheel(package_dir: Path, wheel_tag: str, target_arch: str = None) -> None:
     """Build the wheel using hatchling.
 
     Args:
         package_dir: Directory containing pyproject.toml
+        wheel_tag: Platform-specific wheel tag to write.
         target_arch: Target architecture for cross-compilation (x86_64, arm64)
     """
     print("\nBuilding wheel...")
 
     env = os.environ.copy()
+    env["CUA_DRIVER_WHEEL_TAG"] = wheel_tag
 
     # Set platform tag override for cross-compilation
     if target_arch:
@@ -246,8 +276,7 @@ def main():
     parser = argparse.ArgumentParser(description="Build cua-driver Python wheel with bundled binary")
     parser.add_argument(
         "--version",
-        default="0.7.0",
-        help="cua-driver-rs version to download (default: 0.7.0)",
+        help="cua-driver-rs version to download (default: pyproject.toml version)",
     )
     parser.add_argument(
         "--arch",
@@ -259,23 +288,26 @@ def main():
         help="Skip download and use existing binary in bin/ (for local testing)",
     )
     args = parser.parse_args()
+    version = args.version or get_default_version()
 
     # Determine paths
     script_dir = Path(__file__).parent
     bin_dir = script_dir / "src" / "cua_driver" / "bin"
     download_dir = script_dir / "downloads"
+    platform_name, arch = get_platform_info(args.arch)
+    wheel_tag = get_wheel_tag(platform_name, arch)
+    print(f"Wheel tag: {wheel_tag}")
 
     if not args.skip_download:
         # Get platform info and download URL
-        platform_name, arch = get_platform_info(args.arch)
         print(f"Building for {platform_name}-{arch}")
 
-        url, binary_names = get_release_url(args.version, platform_name, arch)
+        url, binary_names = get_release_url(version, platform_name, arch)
         archive_name = url.split("/")[-1]
         archive_path = download_dir / archive_name
 
         # Get expected SHA256 from checksums.txt
-        expected_sha256 = get_expected_sha256(args.version, archive_name)
+        expected_sha256 = get_expected_sha256(version, archive_name)
 
         # Download the release archive (or verify cached)
         if not archive_path.exists():
@@ -311,7 +343,7 @@ def main():
             print(f"  - {binary.name} ({binary.stat().st_size / 1024 / 1024:.2f} MB)")
 
     # Build the wheel (pass target arch for cross-compilation)
-    build_wheel(script_dir, target_arch=arch if not args.skip_download else None)
+    build_wheel(script_dir, wheel_tag, target_arch=arch)
 
 
 if __name__ == "__main__":

--- a/libs/cua-driver/python/hatch_build.py
+++ b/libs/cua-driver/python/hatch_build.py
@@ -1,0 +1,17 @@
+"""Hatch build hook for platform-tagged cua-driver wheels."""
+
+import os
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class CustomBuildHook(BuildHookInterface):
+    """Apply the wheel tag selected by build_wheel.py."""
+
+    def initialize(self, version: str, build_data: dict) -> None:
+        wheel_tag = os.environ.get("CUA_DRIVER_WHEEL_TAG")
+        if not wheel_tag:
+            return
+
+        build_data["tag"] = wheel_tag
+        build_data["pure_python"] = False

--- a/libs/cua-driver/python/pyproject.toml
+++ b/libs/cua-driver/python/pyproject.toml
@@ -54,3 +54,6 @@ artifacts = [
     "src/cua_driver/bin/*",
 ]
 pure-python = false
+
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "hatch_build.py"

--- a/libs/cua-driver/python/tests/test_build_wheel.py
+++ b/libs/cua-driver/python/tests/test_build_wheel.py
@@ -1,0 +1,23 @@
+"""Tests for cua-driver wheel build helpers."""
+
+import importlib.util
+from pathlib import Path
+
+
+def load_build_wheel_module():
+    module_path = Path(__file__).resolve().parents[1] / "build_wheel.py"
+    spec = importlib.util.spec_from_file_location("build_wheel", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_wheel_tags_are_platform_specific():
+    build_wheel = load_build_wheel_module()
+
+    assert build_wheel.get_wheel_tag("darwin", "universal") == "py3-none-macosx_11_0_universal2"
+    assert build_wheel.get_wheel_tag("linux", "x86_64") == "py3-none-linux_x86_64"
+    assert build_wheel.get_wheel_tag("linux", "arm64") == "py3-none-linux_aarch64"
+    assert build_wheel.get_wheel_tag("windows", "x86_64") == "py3-none-win_amd64"
+    assert build_wheel.get_wheel_tag("windows", "arm64") == "py3-none-win_arm64"


### PR DESCRIPTION
## Summary

- let the Python cua-driver PyPI workflow follow cua-driver-rs tag workflow completions instead of filtering to main-only workflow runs
- add Linux arm64 wheel builds and release/reminder/digest wiring for cua-driver-rs changes
- make cua-driver wheels non-pure and platform-tagged so matrix artifacts do not collapse into one py3-none-any wheel

## Validation

- /tmp/cua-driver-pypi-venv/bin/python -m unittest discover .github/scripts/tests
- PYTHONPATH=libs/cua-driver/python/src /tmp/cua-driver-pypi-venv/bin/python -m pytest libs/cua-driver/python/tests
- /tmp/cua-driver-pypi-venv/bin/python -c "from pathlib import Path; import yaml; [yaml.safe_load(path.read_text()) for path in [Path('.github/workflows/cd-py-cua-driver.yml'), Path('.github/workflows/release-on-merge.yml'), Path('.github/workflows/ci-release-reminder.yml'), Path('.github/workflows/release-unreleased-digest.yml')]]; print('YAML parsed')"
- /tmp/cua-driver-pypi-venv/bin/python build_wheel.py --version 0.7.1 --arch universal (from a temp copy with Python metadata stamped to 0.7.1)
- /tmp/cua-driver-pypi-venv/bin/python -m twine check /tmp/cua-driver-python-build/dist/cua_driver-0.7.1-py3-none-macosx_11_0_universal2.whl

## Publish note

Do not dispatch the current main workflow for 0.7.1 before this lands: current main still builds a bundled-binary wheel as py3-none-any. After merge, dispatch cd-py-cua-driver.yml for version 0.7.1 to publish the current cua-driver-rs release assets to PyPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for publishing and packaging the Python driver from the Rust driver release flow.
  * Added ARM64 Linux wheel builds, plus platform-specific wheel tagging for better install compatibility.
  * Expanded release tracking so Rust driver changes are included in release reminders and unreleased-change digests.

* **Tests**
  * Added regression checks to keep release wiring and wheel tag behavior consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->