### PR TITLE
Fix cua-driver PyPI license metadata

### DIFF
--- a/libs/cua-driver/python/pyproject.toml
+++ b/libs/cua-driver/python/pyproject.toml
@@ -7,7 +7,7 @@ name = "cua-driver"
 version = "0.7.0"
 description = "Python wrapper for cua-driver - cross-platform MCP server for computer-use automation"
 readme = "README.md"
-license = "MIT"
+license = { text = "MIT" }
 authors = [
     { name = "TryCua", email = "hello@trycua.com" }
 ]

--- a/libs/cua-driver/python/tests/test_build_wheel.py
+++ b/libs/cua-driver/python/tests/test_build_wheel.py
@@ -21,3 +21,11 @@ def test_wheel_tags_are_platform_specific():
     assert build_wheel.get_wheel_tag("linux", "arm64") == "py3-none-linux_aarch64"
     assert build_wheel.get_wheel_tag("windows", "x86_64") == "py3-none-win_amd64"
     assert build_wheel.get_wheel_tag("windows", "arm64") == "py3-none-win_arm64"
+
+
+def test_license_metadata_stays_legacy_upload_compatible():
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    pyproject_text = pyproject.read_text()
+
+    assert 'license = { text = "MIT" }' in pyproject_text
+    assert 'license = "MIT"' not in pyproject_text


### PR DESCRIPTION
## Summary
- use legacy-compatible license table metadata for the cua-driver Python package
- add a regression test so the package does not emit the PyPI-rejected License-Expression field again

## Validation
- PYTHONPATH=libs/cua-driver/python/src /tmp/cua-driver-pypi-venv/bin/python -m pytest libs/cua-driver/python/tests
- /tmp/cua-driver-pypi-venv/bin/python -m unittest discover .github/scripts/tests
- built temp cua_driver-0.7.1-py3-none-macosx_11_0_universal2.whl after workflow-style version stamping
- inspected METADATA: Version: 0.7.1, License: MIT, no License-Expression
- inspected WHEEL: Root-Is-Purelib: false, Tag: py3-none-macosx_11_0_universal2
- /tmp/cua-driver-pypi-venv/bin/python -m twine check /tmp/cua-driver-python-license-build/dist/*

Follow-up to the failed publish run: https://github.com/trycua/cua/actions/runs/28953234711

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated package metadata to keep Python package builds compatible with older upload tooling.

* **Tests**
  * Added coverage to ensure the package license field stays in the expected format for release packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->