### PR TITLE
Use manylinux tags for cua-driver PyPI wheels

### DIFF
--- a/libs/cua-driver/python/build_wheel.py
+++ b/libs/cua-driver/python/build_wheel.py
@@ -80,10 +80,11 @@ def get_wheel_tag(platform_name: str, arch: str) -> str:
     if platform_name == "darwin":
         return "py3-none-macosx_11_0_universal2"
     if platform_name == "linux":
+        # Rust Linux release binaries are built in debian:11, whose glibc floor is 2.31.
         if arch == "x86_64":
-            return "py3-none-linux_x86_64"
+            return "py3-none-manylinux_2_31_x86_64"
         if arch == "arm64":
-            return "py3-none-linux_aarch64"
+            return "py3-none-manylinux_2_31_aarch64"
     if platform_name == "windows":
         if arch == "x86_64":
             return "py3-none-win_amd64"

--- a/libs/cua-driver/python/tests/test_build_wheel.py
+++ b/libs/cua-driver/python/tests/test_build_wheel.py
@@ -17,8 +17,8 @@ def test_wheel_tags_are_platform_specific():
     build_wheel = load_build_wheel_module()
 
     assert build_wheel.get_wheel_tag("darwin", "universal") == "py3-none-macosx_11_0_universal2"
-    assert build_wheel.get_wheel_tag("linux", "x86_64") == "py3-none-linux_x86_64"
-    assert build_wheel.get_wheel_tag("linux", "arm64") == "py3-none-linux_aarch64"
+    assert build_wheel.get_wheel_tag("linux", "x86_64") == "py3-none-manylinux_2_31_x86_64"
+    assert build_wheel.get_wheel_tag("linux", "arm64") == "py3-none-manylinux_2_31_aarch64"
     assert build_wheel.get_wheel_tag("windows", "x86_64") == "py3-none-win_amd64"
     assert build_wheel.get_wheel_tag("windows", "arm64") == "py3-none-win_arm64"
 


### PR DESCRIPTION
## Summary
- tag Linux cua-driver wheels as manylinux_2_31 instead of generic linux tags
- keep x86_64 and arm64/aarch64 expectations covered in the wheel tag helper tests

## Why
The publish run reached PyPI but was rejected with:

```
400 Binary wheel 'cua_driver-0.7.1-py3-none-linux_aarch64.whl' has an unsupported platform tag 'linux_aarch64'.
```

The Rust release workflow builds Linux binaries inside debian:11, giving a GLIBC_2.31 floor, so manylinux_2_31 is the accurate PyPI-uploadable tag.

## Validation
- PYTHONPATH=libs/cua-driver/python/src /tmp/cua-driver-pypi-venv/bin/python -m pytest libs/cua-driver/python/tests
- /tmp/cua-driver-pypi-venv/bin/python -m unittest discover .github/scripts/tests
- parsed candidate wheel names with packaging.utils.parse_wheel_filename for manylinux_2_31_x86_64 and manylinux_2_31_aarch64

Follow-up to failed publish run: https://github.com/trycua/cua/actions/runs/28953598513

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Linux wheel packaging to use the correct manylinux-compatible tags for x86_64 and ARM64 builds.
  * Adjusted validation to match the new Linux wheel tag format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->