### PR TITLE
Sync cua-driver Python wrapper version

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -52,6 +52,12 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
             workflow,
         )
 
+    def test_rust_driver_bump_keeps_python_wrapper_version_synced(self) -> None:
+        config = self.read("libs/cua-driver/rust/.bumpversion.cfg")
+
+        self.assertIn("[bumpversion:file:../python/pyproject.toml]", config)
+        self.assertIn("[bumpversion:file:../python/src/cua_driver/__init__.py]", config)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/libs/cua-driver/python/pyproject.toml
+++ b/libs/cua-driver/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cua-driver"
-version = "0.7.0"
+version = "0.7.1"
 description = "Python wrapper for cua-driver - cross-platform MCP server for computer-use automation"
 readme = "README.md"
 license = { text = "MIT" }

--- a/libs/cua-driver/python/src/cua_driver/__init__.py
+++ b/libs/cua-driver/python/src/cua_driver/__init__.py
@@ -4,7 +4,7 @@ This package provides a thin Python wrapper around the cua-driver Rust binary,
 enabling pip-installable access to the MCP server for computer-use automation.
 """
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 from .wrapper import run_cua_driver, get_binary_path
 

--- a/libs/cua-driver/rust/.bumpversion.cfg
+++ b/libs/cua-driver/rust/.bumpversion.cfg
@@ -8,3 +8,11 @@ message = Bump cua-driver-rs to v{new_version}
 [bumpversion:file:Cargo.toml]
 search = version = "{current_version}"
 replace = version = "{new_version}"
+
+[bumpversion:file:../python/pyproject.toml]
+search = version = "{current_version}"
+replace = version = "{new_version}"
+
+[bumpversion:file:../python/src/cua_driver/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"


### PR DESCRIPTION
## Summary
- update the checked-in Python cua-driver wrapper version defaults to 0.7.1
- wire the Python wrapper version files into the cua-driver-rs bump2version config
- add a release wiring regression test so future cua-driver-rs bumps keep the Python wrapper source version synced

## Validation
- PYTHONPATH=libs/cua-driver/python/src /tmp/cua-driver-pypi-venv/bin/python -m pytest libs/cua-driver/python/tests
- /tmp/cua-driver-pypi-venv/bin/python -m unittest discover .github/scripts/tests
- cd libs/cua-driver/rust && /tmp/cua-driver-pypi-venv/bin/python -m bumpversion --allow-dirty --dry-run --list patch
- cd libs/cua-driver/rust && /tmp/cua-driver-pypi-venv/bin/python -m bumpversion --allow-dirty --dry-run --verbose patch

The published wheel version was already 0.7.1; this keeps the source defaults and future bump automation aligned with that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Kept the Python wrapper version in sync with the Rust driver release process.
  * Bumped the Python package version to **0.7.1**.
  * Added a regression test to verify version bumping updates both Python release files automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->