### PR TITLE
chore(docs): sync pnpm lockfile with pnpm 9

### DIFF
--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -4,33 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@ai-sdk/google-vertex': 4.0.148
-  '@hono/node-server': 1.19.13
-  '@modelcontextprotocol/sdk': 1.26.0
-  ajv: 8.18.0
-  diff: 5.2.2
-  dompurify: 3.4.11
-  fast-uri: 3.1.2
-  fast-xml-builder: 1.1.7
-  fast-xml-parser: 5.7.0
-  form-data: 4.0.6
-  hono: 4.12.25
-  js-yaml: 4.2.0
-  js-yaml@>=4.0.0 <4.1.1: '>=4.1.1'
-  langsmith: 0.7.10
-  lodash-es: 4.18.0
-  mdast-util-to-hast: 13.2.1
-  path-to-regexp: 8.4.0
-  picomatch: 4.0.4
-  postcss: 8.5.10
-  preact: 10.27.3
-  prismjs: 1.30.0
-  qs: 6.15.2
-  tar: 7.5.16
-  ts-deepmerge: 8.0.0
-  uuid: 11.1.1
-
 importers:
 
   .:
@@ -88,7 +61,7 @@ importers:
         specifier: ^1.6.6
         version: 1.6.6(@types/mdast@4.0.4)(@types/unist@3.0.3)
       postcss:
-        specifier: 8.5.10
+        specifier: ^8.5.10
         version: 8.5.10
       prettier:
         specifier: ^3.6.2
@@ -1405,7 +1378,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: 4.0.4
+      picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -1905,6 +1878,10 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -1912,6 +1889,10 @@ packages:
   postcss-selector-parser@7.1.0:
     resolution: {integrity: sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==}
     engines: {node: '>=4'}
+
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
@@ -4020,7 +4001,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 4.0.4
+      picomatch: 2.3.2
 
   minipass@7.1.2: {}
 
@@ -4061,7 +4042,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.38
       caniuse-lite: 1.0.30001799
-      postcss: 8.5.10
+      postcss: 8.4.31
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       styled-jsx: 5.1.6(react@19.2.0)
@@ -4103,12 +4084,20 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch@2.3.2: {}
+
   picomatch@4.0.4: {}
 
   postcss-selector-parser@7.1.0:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.10:
     dependencies:


### PR DESCRIPTION
## Summary\n\nSynchronizes the documentation pnpm lockfile with pnpm 9. This is an independent housekeeping change extracted from the larger cross-platform driver work.\n\n## Validation\n\nDocumentation dependency and link checks should run in CI. No cua-driver source, fixtures, or workflow behavior changes are included.