### PR TITLE
ci(cua-driver): add OS-scoped Rust and manual e2e lanes

### DIFF
--- a/.github/workflows/ci-nix-linux.yml
+++ b/.github/workflows/ci-nix-linux.yml
@@ -1,0 +1,45 @@
+name: "CI: Nix Linux Rust source"
+
+# This is the automatic Nix lane. Desktop-heavy legacy checks live in
+# nix-build.yml and nix-wayland.yml and are maintainer-dispatched instead.
+on:
+  pull_request:
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "nix/cua-driver/package.nix"
+      - "nix/cua-driver/tests/rust-unit.nix"
+      - "libs/cua-driver/rust/**"
+      - ".github/workflows/ci-nix-linux.yml"
+  push:
+    branches: [main]
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "nix/cua-driver/package.nix"
+      - "nix/cua-driver/tests/rust-unit.nix"
+      - "libs/cua-driver/rust/**"
+      - ".github/workflows/ci-nix-linux.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-nix-linux-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rust-source:
+    name: Nix Linux Rust source check
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - name: Run source-built Rust check
+        run: nix build .#checks.x86_64-linux.cua-driver-linux-rust-unit --print-build-logs --show-trace

--- a/.github/workflows/ci-rust-linux.yml
+++ b/.github/workflows/ci-rust-linux.yml
@@ -1,0 +1,54 @@
+name: "CI: Rust Linux unit"
+
+on:
+  pull_request:
+    paths:
+      - "libs/cua-driver/rust/Cargo.toml"
+      - "libs/cua-driver/rust/Cargo.lock"
+      - "libs/cua-driver/rust/crates/cua-driver/**"
+      - "libs/cua-driver/rust/crates/cua-driver-core/**"
+      - "libs/cua-driver/rust/crates/cua-driver-testkit/**"
+      - "libs/cua-driver/rust/crates/platform-linux/**"
+      - "libs/cua-driver/tests/fixtures/**"
+      - "nix/**"
+      - "flake.nix"
+      - "flake.lock"
+      - ".github/workflows/ci-rust-linux.yml"
+  push:
+    branches: [main]
+    paths:
+      - "libs/cua-driver/rust/**"
+      - "libs/cua-driver/tests/fixtures/**"
+      - "nix/**"
+      - "flake.nix"
+      - "flake.lock"
+      - ".github/workflows/ci-rust-linux.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-rust-linux-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit:
+    name: Rust Linux unit and compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+        with:
+          workspaces: "libs/cua-driver/rust -> target"
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            clang pkg-config libdbus-1-dev libpipewire-0.3-dev libspa-0.2-dev \
+            libei-dev libx11-dev libxi-dev libxtst-dev libxext-dev
+      - name: Run Linux Rust tests
+        working-directory: libs/cua-driver/rust
+        run: cargo test -p cua-driver -p cua-driver-core -p cua-driver-testkit -p platform-linux --all-targets --locked

--- a/.github/workflows/ci-rust-windows.yml
+++ b/.github/workflows/ci-rust-windows.yml
@@ -1,0 +1,44 @@
+name: "CI: Rust Windows unit"
+
+on:
+  pull_request:
+    paths:
+      - "libs/cua-driver/rust/Cargo.toml"
+      - "libs/cua-driver/rust/Cargo.lock"
+      - "libs/cua-driver/rust/crates/cua-driver/**"
+      - "libs/cua-driver/rust/crates/cua-driver-core/**"
+      - "libs/cua-driver/rust/crates/cua-driver-testkit/**"
+      - "libs/cua-driver/rust/crates/platform-windows/**"
+      - "libs/cua-driver/rust/crates/cua-driver-uia/**"
+      - "libs/cua-driver/rust/crates/focus-monitor-win/**"
+      - "libs/cua-driver/tests/fixtures/**"
+      - ".github/workflows/ci-rust-windows.yml"
+  push:
+    branches: [main]
+    paths:
+      - "libs/cua-driver/rust/**"
+      - "libs/cua-driver/tests/fixtures/**"
+      - ".github/workflows/ci-rust-windows.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-rust-windows-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit:
+    name: Rust Windows unit and compile
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+        with:
+          workspaces: "libs/cua-driver/rust -> target"
+      - name: Run Windows Rust tests
+        working-directory: libs/cua-driver/rust
+        run: cargo test -p cua-driver -p cua-driver-core -p cua-driver-testkit -p platform-windows -p cua-driver-uia -p focus-monitor-win --all-targets --locked

--- a/.github/workflows/ci-rust-windows.yml
+++ b/.github/workflows/ci-rust-windows.yml
@@ -41,4 +41,6 @@ jobs:
           workspaces: "libs/cua-driver/rust -> target"
       - name: Run Windows Rust tests
         working-directory: libs/cua-driver/rust
-        run: cargo test -p cua-driver -p cua-driver-core -p cua-driver-testkit -p platform-windows -p cua-driver-uia -p focus-monitor-win --all-targets --locked
+        # Compile every Rust target without executing desktop-dependent integration
+        # tests; interactive behavior belongs in e2e-rust-windows.yml.
+        run: cargo test -p cua-driver -p cua-driver-core -p cua-driver-testkit -p platform-windows -p cua-driver-uia -p focus-monitor-win --all-targets --no-run --locked

--- a/.github/workflows/e2e-rust-linux.yml
+++ b/.github/workflows/e2e-rust-linux.yml
@@ -1,0 +1,50 @@
+name: "E2E: Rust Linux interactive"
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Commit, branch, or tag to test"
+        required: true
+        default: "main"
+      suite:
+        description: "Rust desktop suite"
+        required: true
+        type: choice
+        options: [shared, modality, all]
+        default: shared
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: Linux interactive Rust suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install GUI and Rust build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            xvfb dbus-x11 at-spi2-core openbox python3-gi gir1.2-gtk-3.0 \
+            libgtk-3-dev clang pkg-config libdbus-1-dev libpipewire-0.3-dev \
+            libspa-0.2-dev libei-dev libx11-dev libxi-dev libxtst-dev libxext-dev \
+            libwebkit2gtk-4.1-dev libssl-dev libxdo-dev \
+            libayatana-appindicator3-dev librsvg2-dev
+      - name: Run canonical Rust matrix
+        run: |
+          xvfb-run -a --server-args="-screen 0 1920x1080x24" \
+            dbus-run-session -- bash -lc \
+            "scripts/ci/linux/run-rust-e2e.sh --suite '${{ inputs.suite }}'"
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: rust-linux-e2e-artifacts
+          path: artifacts/cua-driver/linux
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-rust-windows.yml
+++ b/.github/workflows/e2e-rust-windows.yml
@@ -1,0 +1,46 @@
+name: "E2E: Rust Windows interactive"
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Commit, branch, or tag to test"
+        required: true
+        default: "main"
+      suite:
+        description: "Rust desktop suite"
+        required: true
+        type: choice
+        options: [shared, native, all]
+        default: shared
+      runner:
+        description: "Runner label; use the Azure RDP runner label for VM e2e"
+        required: true
+        default: "windows-latest"
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: Windows interactive Rust suite
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Run from the interactive user session
+        shell: pwsh
+        run: .\scripts\ci\windows\run-rust-e2e.ps1 -Suite ${{ inputs.suite }} -RequireGui
+      - name: Collect logs
+        if: always()
+        shell: pwsh
+        run: .\scripts\ci\windows\collect-artifacts.ps1
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: rust-windows-e2e-artifacts
+          path: artifacts/cua-driver/windows
+          if-no-files-found: ignore

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,21 +1,9 @@
 name: Nix Build & Integration Tests
 
 on:
-  pull_request:
-    paths:
-      - 'nix/**'
-      - 'flake.nix'
-      - 'flake.lock'
-      - 'libs/cua-driver/rust/**'
-      - '.github/workflows/nix-build.yml'
-  push:
-    branches: [main]
-    paths:
-      - 'nix/**'
-      - 'flake.nix'
-      - 'flake.lock'
-      - 'libs/cua-driver/rust/**'
-      - '.github/workflows/nix-build.yml'
+  # The legacy GUI/toolkit matrix is expensive and includes GIF diagnostics.
+  # It remains available for maintainers, while ci-nix-linux.yml owns the
+  # automatic source-built Rust check.
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/nix-wayland.yml
+++ b/.github/workflows/nix-wayland.yml
@@ -4,27 +4,14 @@ name: CUA Driver Native-Wayland TDD Suite
 # sessions (XFCE on labwc/sway, plus KDE and GNOME). The cursor-click-gif and
 # background-terminal-gif tests use the EIS-backed cua-compositor injection path
 # for deterministic keyboard delivery without relying on compositor focus policy.
-# The triggers mirror the X11 nix-build.yml workflow (PRs/pushes touching
-# nix/flake/driver, plus manual dispatch). These jobs are BLOCKING
-# (no continue-on-error): a red cell fails the PR.
+# These jobs are maintainer-dispatched desktop diagnostics. They are BLOCKING
+# within a dispatched run, but do not charge every PR with the full compositor
+# matrix.
 # Artifacts (screenshots, GIFs, logs) are uploaded so you can see exactly what
 # each compositor does.
 on:
-  pull_request:
-    paths:
-      - 'nix/**'
-      - 'flake.nix'
-      - 'flake.lock'
-      - 'libs/cua-driver/rust/**'
-      - '.github/workflows/nix-wayland.yml'
-  push:
-    branches: [main]
-    paths:
-      - 'nix/**'
-      - 'flake.nix'
-      - 'flake.lock'
-      - 'libs/cua-driver/rust/**'
-      - '.github/workflows/nix-wayland.yml'
+  # Native-compositor checks are maintainer-dispatched because they are
+  # desktop e2e coverage, not cheap pull-request unit checks.
   workflow_dispatch:
 
 permissions:

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,12 @@
           checks =
             {
               cua-driver-build = cuaDriverPackage;
+              # Source-built, headless Rust checks. The desktop behavioral
+              # matrix remains an explicit maintainer-dispatched e2e lane.
+              cua-driver-linux-rust-unit = import ./nix/cua-driver/tests/rust-unit.nix {
+                inherit pkgs;
+                src = rustSrc;
+              };
             }
             // pkgs.lib.optionalAttrs (system == "x86_64-linux") {
               # NixOS container integration test (x86_64-linux only)

--- a/libs/cua-driver/docs/cross-platform-ci-test-plan.md
+++ b/libs/cua-driver/docs/cross-platform-ci-test-plan.md
@@ -1,0 +1,286 @@
+# Cross-Platform CI and E2E Test Plan
+
+Status: implementation plan, with the source-built unit and manual runner
+foundation now landed on the working branch
+
+## Goal
+
+Make the Rust harnesses the source of truth for user behavior on Linux and
+Windows. Keep unit tests cheap and OS-scoped. Run desktop end-to-end tests as a
+maintainer-controlled gate with the real session each platform requires.
+
+The same Rust scenario should run on both platforms whenever the behavior is
+supported. The runner may use different platform APIs, but the scenario ID,
+application oracle, and outcome rules should stay the same.
+
+## Test Tiers
+
+### Tier 1: Rust unit and compile checks
+
+Run automatically on pull requests when an affected platform or shared Rust
+path changes.
+
+- No desktop session, TCC, RDP, AT-SPI, or Azure credentials.
+- Run on `ubuntu-latest` and `windows-latest` in separate jobs.
+- Use `cargo test --workspace --all-targets --locked`.
+- Run Clippy in the same OS-scoped workflow where its cost remains acceptable.
+
+Shared code changes run both OS jobs. A platform-only change runs one job.
+
+### Tier 2: Fast Linux integration checks
+
+Keep the small Xvfb and AT-SPI checks that do not require a real user desktop.
+These checks can remain automatic if their runtime stays short and stable.
+
+They cover protocol setup, capture modes, accessibility reachability, and
+desktop-scope contract errors. They do not replace the behavioral harness.
+
+### Tier 3: Maintainer e2e gate
+
+Run the same Rust behavioral matrix against real harness applications.
+
+- Linux: the manual Rust runner for the canonical matrix; Nix X11 and Nix
+  Wayland remain supporting compositor checks until the source-built app pilot
+  is complete.
+- Windows: Azure Windows with an active RDP user session.
+- Trigger: `workflow_dispatch` with a commit ref, PR number, and suite.
+- Optional nightly and post-merge runs can catch drift without slowing every PR.
+- The VM or runner never pushes code.
+
+### Tier 4: Supporting compatibility checks
+
+Keep toolkit and distro checks that cover behavior outside the canonical harness
+matrix. These checks should be labeled as supporting coverage and should not
+claim that a user workflow passed when they only prove window discovery or a
+non-error response.
+
+## Canonical Behavioral Matrix
+
+The Rust test suite owns the scenario list. CI workflows should select a suite,
+not duplicate the scenario definitions in YAML or Python.
+
+### Applications
+
+- Electron
+- Tauri
+
+### Surfaces
+
+- Accessibility action path
+- Pixel-coordinate path
+
+### Delivery modes
+
+- Background
+- Foreground
+
+### Scenarios
+
+- Calculator click sequence and result oracle
+- Editor type, save, and saved-state oracle
+- Enter key and hotkey state oracles
+- Nested scroll and scroll-offset oracle
+- Child-window creation oracle
+- Drag and drop-state oracle
+- Focus sentinel and window posture checks
+
+Each result has one of these outcomes:
+
+```text
+pass
+expected_refusal
+known_gap
+not_applicable
+unexpected_failure
+```
+
+An expected refusal must include the structured driver error and capability
+reason. A driver response without an external application-state change is not a
+pass.
+
+The runner should emit a common result record:
+
+```json
+{
+  "scenario": "editor_type_and_save",
+  "os": "windows",
+  "app": "electron",
+  "surface": "ax",
+  "delivery": "background",
+  "outcome": "pass",
+  "oracle": "editor_status=saved:exact"
+}
+```
+
+Platform-specific applications such as WPF and WinUI 3 remain focused Windows
+coverage. GTK and Qt remain focused Linux coverage. They supplement the shared
+matrix and do not define cross-platform acceptance.
+
+## Linux Structure
+
+Nix remains the Linux desktop test environment. It should build the driver and
+repo-local harness applications from source and run the Rust tests against those
+outputs. The test should not download a prebuilt application and Linux e2e runs
+do not need GIF recording.
+
+Proposed layout:
+
+```text
+nix/cua-driver/
+  package.nix
+  module.nix
+  README.md
+  lib/
+    app-catalog.nix
+    artifacts.nix
+    atspi-session.nix
+    mcp-client.nix
+    wayland-session.nix
+    x11-session.nix
+  checks/
+    x11/
+      harness-electron.nix
+      harness-tauri.nix
+      input-cursor-click.nix
+      input-parallel-drag.nix
+      service-config-persistence.nix
+      service-integration.nix
+    wayland/
+      app-background-read.nix
+      input-background-terminal.nix
+      input-cursor-click.nix
+      input-parallel-drag.nix
+      service-integration.nix
+```
+
+The current generic `linux-background-gui.nix` should be split. Its read-only
+app entries should become supporting checks or be removed after equivalent
+canonical harness coverage exists. Its Chromium and Tk write paths should be
+retained until the Rust harness covers the same contract.
+
+Use explicit flake check names such as:
+
+```text
+cua-driver-linux-x11-harness-electron
+cua-driver-linux-x11-harness-tauri
+cua-driver-linux-x11-service-config-persistence
+cua-driver-linux-wayland-gnome-input-background-terminal
+```
+
+Do not put `gif` in a test name. Screenshots, AX trees, structured results, and
+driver logs are enough for routine artifacts. Capture a PNG on failure or when
+diagnosing a pixel scenario.
+
+The testkit needs test-only path overrides so Nix can use immutable build
+outputs:
+
+```text
+CUA_TEST_DRIVER_BIN
+CUA_TEST_APPS_ROOT
+CUA_TEST_WORKSPACE_ROOT
+```
+
+Local runs keep their current defaults.
+
+## Windows Structure
+
+Windows uses the same Rust scenarios and repo-local harness source. The Azure VM
+builds the applications on demand inside the active RDP session.
+
+Workflow and helper names:
+
+```text
+.github/workflows/ci-rust-windows.yml
+.github/workflows/e2e-rust-windows.yml
+scripts/ci/windows/
+  verify-user-session.ps1
+  build-harnesses.ps1
+  run-rust-e2e.ps1
+  collect-artifacts.ps1
+```
+
+The Windows e2e workflow now:
+
+1. Check out or sync the requested commit.
+2. Confirm that the target process runs in the active RDP user session, not
+   Session 0.
+3. Build Electron, Tauri, WPF, and WinUI 3 harnesses from source.
+4. Build the Rust driver and integration tests.
+5. Run the shared behavioral matrix, then Windows-native tests.
+6. Collect structured results, UIA trees, screenshots, and driver logs.
+7. Leave the VM unable to push or modify the source branch.
+
+The Windows unit workflow runs on `windows-latest` and does not attempt these
+desktop steps.
+
+## Workflow Names
+
+Use the distinction between `ci` and `e2e` in the filename and displayed job
+name:
+
+```text
+CI: Rust Linux unit
+CI: Rust Windows unit
+CI: Linux fast integration
+E2E: Linux Nix X11
+E2E: Linux Nix Wayland
+E2E: Linux Azure desktop
+E2E: Windows Azure RDP
+```
+
+The Nix X11 and Wayland workflows should stop running automatically for every
+PR update once the maintainer gate is available. Keep manual dispatch, nightly
+runs, and post-merge regression runs.
+
+## Legacy Test Migration
+
+Keep an inventory before deleting tests. For each test record its scenario,
+oracle, OS, window system, app, and current CI role.
+
+Classify each test as:
+
+- `canonical`: a trusted user-behavior acceptance test.
+- `supporting`: useful backend or toolkit coverage.
+- `diagnostic`: useful during investigation but not a product gate.
+- `retire`: redundant or weaker than a canonical replacement.
+
+Migration order:
+
+1. Add the testkit path overrides and strict fixture preflight.
+2. Land the OS-scoped unit checks and the manual desktop runners.
+3. Pilot source-built harness packaging inside Nix before moving app builds
+   into the Nix sandbox.
+4. Add missing scenario coverage before removing an old test.
+5. Move weaker tests out of required CI.
+6. Delete tests only after the replacement has passed repeatedly on the target
+   platform.
+7. Update the Nix and workflow READMEs to describe the new ownership.
+
+Do not delete specialized Wayland, MPX, WPF, or WinUI coverage merely because
+the shared Electron/Tauri matrix exists. Retain those tests until the shared
+matrix covers the behavior they uniquely exercise.
+
+## Acceptance Criteria
+
+- Shared scenario IDs and external oracles are identical on Linux and Windows.
+- Shared Rust changes run both unit-test jobs.
+- Platform-only changes run only the affected OS unit job.
+- Linux e2e builds harness applications from source in the Linux desktop runner;
+  a fully sandboxed Nix app-build pilot remains a separate follow-up.
+- Windows e2e builds harness applications from source in the Azure VM.
+- No Linux e2e test requires GIF recording.
+- No canonical test passes on driver success alone.
+- Unsupported background behavior produces a structured refusal or remains a
+  visible known gap.
+- Maintainer e2e runs publish a result table and failure artifacts linked to the
+  PR.
+- Legacy tests are either classified, upgraded, moved out of required CI, or
+  removed with an equivalent canonical replacement.
+
+## Non-Goals
+
+- Do not make Windows use Nix.
+- Do not create a second Python behavioral framework.
+- Do not download opaque prebuilt desktop fixtures.
+- Do not weaken external-state assertions to make a matrix green.
+- Do not make Azure or RDP credentials available to untrusted PR code.

--- a/libs/cua-driver/docs/pr-split-plan.md
+++ b/libs/cua-driver/docs/pr-split-plan.md
@@ -1,0 +1,298 @@
+# Cua-driver PR Split Plan
+
+Status: draft for review
+
+## Decision
+
+Do not merge PR #2135 as one change. It currently contains 204 files and
+roughly 11.5k additions/deletions across fixture migration, Rust test
+ownership, Windows behavior, Linux/macOS behavior, and CI/Nix architecture.
+
+Keep the current branch as an untouched snapshot while smaller PRs are built
+from `main`. The historical commits are useful provenance, but several of them
+mix unrelated file families. Cherry-picking those commits wholesale would
+reintroduce the same review problem.
+
+## Target PRs
+
+### PR 0: Documentation lockfile housekeeping
+
+Suggested title:
+
+```text
+chore(docs): sync pnpm lockfile with pnpm 9
+```
+
+Scope:
+
+- `docs/pnpm-lock.yaml`
+- Current provenance: `8fee84dd`
+
+This is independent and can merge first. It should not be coupled to desktop
+behavior or CI changes.
+
+Acceptance:
+
+- Docs dependency install/check passes.
+- No `libs/cua-driver` files change.
+
+### PR 1: Repo-local Rust harness foundation
+
+Suggested title:
+
+```text
+test(cua-driver): make repo-local Rust harnesses canonical
+```
+
+Purpose: establish where fixtures, Rust integration tests, and runner scripts
+live. This PR should make the source tree coherent without changing the
+platform input algorithms.
+
+Scope by file family:
+
+- Move `libs/cua-driver/test-harness` content to
+  `libs/cua-driver/tests/fixtures`.
+- Add the repo-local Electron and Tauri source/build scripts for each host.
+- Move the Windows sandbox runner to `tests/runners/windows-sandbox`.
+- Add the Rust-only Windows `tests/runners/windows/run-all.ps1` entrypoint.
+- Remove the old Python e2e harness and downloaded desktop binaries.
+- Port the optional LibreOffice and macOS launch-focus tests to Rust where
+  needed, keeping them outside the default run-all path.
+- Update path references, `.gitignore` files, fixture READMEs, Rust test README,
+  and the small contributor-facing Fumadocs page.
+- Include `libs/cua-driver/scripts/sync-vm-worktree.sh` because it belongs to
+  the host-owned fixture workflow.
+
+Historical provenance:
+
+- `811ffa6d`, `d44971c`, `98e59d75`, `d9e4311f`, `9ab85981`,
+  `5e8759e1`, and `4e1636b9`.
+
+Do not take the platform implementation portions of `a759840b` or
+`d01c7a14` into this PR. If a test path needs a behavior change to compile,
+make the smallest path-only adjustment and leave the behavioral assertion
+change for the relevant behavior PR.
+
+Acceptance:
+
+- No old downloaded Electron/Tauri application is tracked.
+- No Python behavioral suite remains under the cua-driver test tree.
+- Fixture build scripts pass shell/PowerShell parsing on their native hosts.
+- `cargo test -p cua-driver --tests --no-run` passes on macOS, Linux, and
+  Windows.
+- Staged outputs remain under ignored `rust/test-apps`.
+- Optional external-app tests are visibly excluded from the default runner.
+
+### PR 2: Shared Rust behavioral matrix
+
+Suggested title:
+
+```text
+test(cua-driver): add shared external-oracle behavior matrix
+```
+
+Purpose: make the trusted user-behavior scenarios explicit before wiring them
+into expensive CI. The same scenario IDs, fixture DOM, delivery modes, and
+external-state oracles should be used on every supported host.
+
+Scope:
+
+- Add `cross_platform_behavior_test.rs`.
+- Add/update the shared web fixture and scenario catalog.
+- Add only the generic testkit response/tree helpers required by the matrix.
+- Keep the matrix ignored by default and runnable through one Rust command.
+- Keep assertions based on fresh application state, not driver success alone.
+
+Historical provenance: primarily `ca60e0ba`, but extract only the matrix,
+fixture, and generic testkit pieces. The platform algorithm changes from that
+commit belong in PRs 3 and 4.
+
+Acceptance:
+
+- Matrix compiles on all three hosts.
+- Electron and Tauri are selected from repo-local source-built fixtures.
+- Every scenario has an external oracle and a documented outcome rule.
+- Missing fixtures are visible as a runner/setup failure on dedicated e2e
+  lanes, not a green silent skip.
+
+### PR 3: Windows delivery and interactive UX fixes
+
+Suggested title:
+
+```text
+fix(cua-driver): harden Windows delivery and GUI validation
+```
+
+Scope:
+
+- Windows Session 0 and interactive-desktop diagnostics.
+- Focus sentinel and guard UX behavior.
+- Background keyboard/click refusal reporting and preserved actuator causes.
+- UIA focus, scroll, WebView2/Tauri, WPF, and WinUI3 behavior changes.
+- Windows-specific test assertions and fixture details that validate those
+  behaviors.
+
+Historical provenance: Windows portions of `a759840b`, `98e59d75`,
+`d01c7a14`, and `ca60e0ba`.
+
+Acceptance:
+
+- Windows unit and compile checks pass on `windows-latest`.
+- SSH/Session 0 runs skip GUI-only assertions with an explicit reason.
+- An active user-session run passes the guard and native harness suites.
+- W1-style background input never reports verified delivery without an
+  external state change.
+- W8-style unsupported background delivery returns a structured refusal with
+  the concrete cause.
+
+### PR 4: Linux delivery fixes
+
+Suggested title:
+
+```text
+fix(cua-driver): harden Linux AT-SPI and input delivery
+```
+
+Scope:
+
+- Linux AT-SPI reference handling, action delivery, input capability errors,
+  and related external-oracle test updates.
+- Linux focused tests and strict known-gap assertions.
+
+Historical provenance: Linux portions of `a759840b`, `ca60e0ba`, and
+`d848e365`. The VM sync helper from `d848e365` belongs in PR 1, not here.
+
+Acceptance:
+
+- Linux unit and interactive Xvfb/AT-SPI checks pass.
+- Known gaps remain strict and visible; no assertion is weakened to fit the
+  current driver behavior.
+- Linux behavior changes are covered by the shared matrix where the platform
+  supports the scenario.
+
+### PR 5: macOS input and capture delivery
+
+Suggested title:
+
+```text
+fix(cua-driver): harden macOS input and capture delivery
+```
+
+Scope:
+
+- macOS background click, drag, targeted wheel, and accessibility scrolling.
+- macOS Swift runtime/build fixes required for Rust test binaries.
+- macOS focused tests and strict nested-scroll known-gap assertions.
+
+Historical provenance: macOS portions of `a759840b`, `ca60e0ba`, and
+`9c3c719a`, plus the macOS portions of `0447bd52`.
+
+Acceptance:
+
+- macOS default tests and installed-daemon harness checks pass with TCC
+  already authorized.
+- Electron and Tauri click/drag rows use external application-state oracles.
+- The nested web scrolling gap remains strict and visible.
+
+### PR 6: OS-scoped CI and Nix e2e architecture
+
+Suggested title:
+
+```text
+ci(cua-driver): add OS-scoped Rust and manual e2e lanes
+```
+
+Scope:
+
+- Testkit path overrides and their unit test:
+  `CUA_TEST_DRIVER_BIN`, `CUA_TEST_APPS_ROOT`, and
+  `CUA_TEST_WORKSPACE_ROOT`.
+- Strict fixture preflight for canonical e2e runs.
+- Linux and Windows OS-scoped unit workflows.
+- Maintainer-dispatched Linux and Windows interactive e2e workflows.
+- Source-built Linux Rust check in Nix.
+- Nix and workflow READMEs describing canonical versus supporting coverage.
+- Move the legacy GUI/toolkit and compositor matrices to maintainer dispatch;
+  preserve them as supporting diagnostics.
+- Keep new canonical Linux tests free of GIF requirements.
+
+Historical provenance: `eef79f2a` and `0447bd52`, after extracting the Linux
+and macOS driver edits from `0447bd52` into PRs 4 and 5.
+
+Acceptance:
+
+- Shared Rust changes trigger both OS unit workflows.
+- Platform-specific changes trigger only the relevant OS unit workflow.
+- Linux Rust source check passes in Nix.
+- Manual Linux e2e builds repo-local fixtures from source.
+- Windows e2e verifies an interactive user session and supports an Azure
+  active-RDP runner label.
+- No VM or GitHub runner can push source changes.
+- The PR description says clearly that fully sandboxed Nix Electron/Tauri
+  packaging remains a follow-up requiring committed dependency lockfiles.
+
+## Dependency Graph
+
+```mermaid
+graph LR
+  P0[Docs lockfile] --> Merge
+  P1[Repo-local harness foundation] --> P2[Shared Rust behavior matrix]
+  P2 --> P3[Windows behavior fixes]
+  P2 --> P4[Linux behavior fixes]
+  P2 --> P5[macOS behavior fixes]
+  P3 --> P6[OS-scoped CI and Nix]
+  P4 --> P6
+  P5 --> P6
+```
+
+PR 0 is independent. PR 6 can technically begin earlier, but merging it last
+keeps the required CI contract aligned with the already-merged test and driver
+behavior.
+
+## Branching Procedure
+
+1. Freeze PR #2135. Do not add more mixed commits to it.
+2. Preserve the current branch as the snapshot containing all work. The
+   private `cross-platform-fix-journal.md` stays untracked and must not be
+   included in any PR.
+3. Create each split branch from `main`, then apply the final file families
+   from the snapshot. Use `git diff --find-renames main...HEAD -- <paths>` to
+   preserve moves and deletions.
+4. Do not cherry-pick `a759840b`, `ca60e0ba`, `d848e365`, or `0447bd52`
+   wholesale. Each mixes concerns that belong in different PRs.
+5. Cherry-picking `8fee84dd` is safe for PR 0. `eef79f2a` is safe only after
+   confirming the old interactive workflow remains compatible with the new CI
+   split.
+6. Run the acceptance checks for each branch before opening its PR. Keep PR
+   descriptions narrowly scoped and list known failures instead of hiding
+   them behind broad “cross-platform fixes” language.
+7. Open the PRs in dependency order. Stack PR 2 on PR 1 if needed, then
+   retarget it to `main` after PR 1 merges. Repeat for later PRs.
+8. Close PR #2135 only after the smaller PRs are open and its body links to
+   them. Keep the snapshot branch available until all split PRs merge.
+
+## Review and Rollback Rules
+
+- A PR must have one primary reason to change and one obvious owner.
+- Fixture moves must be reviewed with rename detection enabled.
+- Deleting the Python suite and downloaded binaries is only part of PR 1 when
+  the Rust replacement and build scripts are present in the same diff.
+- Platform behavior PRs must not change CI trigger policy.
+- CI/Nix PRs must not contain opportunistic platform algorithm changes.
+- If a split branch cannot compile independently, either add the missing
+  foundation to its parent PR or make the dependency explicit; do not silently
+  retain unrelated files from PR #2135.
+- Revert the smallest PR that caused a regression. The dependency order keeps
+  the harness foundation and behavior fixes independently revertible from CI.
+
+## Final State
+
+After all PRs merge, the repository should have:
+
+- Rust harnesses as the canonical behavioral source of truth.
+- One shared scenario matrix with platform-specific implementations behind it.
+- Cheap OS-scoped unit checks on normal PRs.
+- Manual, real-session e2e gates for expensive desktop behavior.
+- Nix retained as the Linux environment, with legacy visual checks clearly
+  labeled as supporting coverage.
+- No opaque downloaded desktop fixture in the canonical test path.

--- a/libs/cua-driver/docs/pr-split-plan.md
+++ b/libs/cua-driver/docs/pr-split-plan.md
@@ -241,13 +241,12 @@ graph LR
   P2 --> P4[Linux behavior fixes]
   P2 --> P5[macOS behavior fixes]
   P3 --> P6[OS-scoped CI and Nix]
-  P4 --> P6
-  P5 --> P6
 ```
 
-PR 0 is independent. PR 6 can technically begin earlier, but merging it last
-keeps the required CI contract aligned with the already-merged test and driver
-behavior.
+PR 0 is independent. PR 6 is based on PR 3 because its Windows unit workflow
+compiles the Windows guard tests and therefore needs the Windows desktop-state
+diagnostics. It can merge after PR 3; PRs 4 and 5 remain independent platform
+slices and should merge before enabling the full cross-platform e2e gate.
 
 ## Branching Procedure
 

--- a/libs/cua-driver/rust/crates/cua-driver-testkit/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-testkit/src/lib.rs
@@ -24,6 +24,14 @@
 //! [`ChildReaper`] kills every spawned child on drop. On Windows it also assigns
 //! them to a `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` job, so the OS reaps the whole
 //! tree even on panic / SIGKILL / Ctrl-C — no orphaned windows or held ports.
+//!
+//! ## Relocated runners
+//!
+//! The testkit normally discovers the driver and staged apps under the Cargo
+//! workspace. CI runners that build those artifacts in an immutable or remote
+//! workspace can override the paths with `CUA_TEST_DRIVER_BIN`,
+//! `CUA_TEST_APPS_ROOT`, and `CUA_TEST_WORKSPACE_ROOT`. These variables affect
+//! tests only; they are never read by the shipped driver.
 
 pub mod ax;
 mod driver;

--- a/libs/cua-driver/rust/crates/cua-driver-testkit/src/paths.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-testkit/src/paths.rs
@@ -1,4 +1,5 @@
-//! Filesystem paths, resolved at test runtime from `CARGO_MANIFEST_DIR`.
+//! Filesystem paths, resolved at test runtime from environment overrides or
+//! `CARGO_MANIFEST_DIR`.
 //!
 //! When an integration test runs, Cargo sets `CARGO_MANIFEST_DIR` to the crate
 //! under test (`crates/cua-driver`), so `workspace_root()` resolves the same
@@ -8,6 +9,9 @@ use std::path::PathBuf;
 
 /// The Rust workspace root (`libs/cua-driver/rust`).
 pub fn workspace_root() -> PathBuf {
+    if let Some(root) = std::env::var_os("CUA_TEST_WORKSPACE_ROOT") {
+        return PathBuf::from(root);
+    }
     let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
     PathBuf::from(manifest)
         .parent()
@@ -22,6 +26,9 @@ pub fn workspace_root() -> PathBuf {
 /// divergent spellings (and the macOS release-or-debug variant) that were
 /// copy-pasted across the test files.
 pub fn driver_binary() -> PathBuf {
+    if let Some(path) = std::env::var_os("CUA_TEST_DRIVER_BIN") {
+        return PathBuf::from(path);
+    }
     let name = if cfg!(target_os = "windows") {
         "cua-driver.exe"
     } else {
@@ -39,5 +46,43 @@ pub fn driver_binary() -> PathBuf {
 /// `tests/fixtures/build/{windows.ps1,macos.sh}`). Example:
 /// `harness_app("harness-wpf", "CuaTestHarness.Wpf.exe")`.
 pub fn harness_app(dir: &str, exe: &str) -> PathBuf {
-    workspace_root().join("test-apps").join(dir).join(exe)
+    let root = std::env::var_os("CUA_TEST_APPS_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root().join("test-apps"));
+    root.join(dir).join(exe)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{driver_binary, harness_app, workspace_root};
+    use std::path::PathBuf;
+
+    fn with_env<F>(name: &str, value: &str, test: F)
+    where
+        F: FnOnce(),
+    {
+        let previous = std::env::var_os(name);
+        std::env::set_var(name, value);
+        test();
+        match previous {
+            Some(value) => std::env::set_var(name, value),
+            None => std::env::remove_var(name),
+        }
+    }
+
+    #[test]
+    fn relocated_runner_overrides_are_respected() {
+        with_env("CUA_TEST_WORKSPACE_ROOT", "/tmp/cua-test-workspace", || {
+            assert_eq!(workspace_root(), PathBuf::from("/tmp/cua-test-workspace"));
+        });
+        with_env("CUA_TEST_DRIVER_BIN", "/tmp/cua-driver", || {
+            assert_eq!(driver_binary(), PathBuf::from("/tmp/cua-driver"));
+        });
+        with_env("CUA_TEST_APPS_ROOT", "/tmp/cua-test-apps", || {
+            assert_eq!(
+                harness_app("harness-electron", "CuaTestHarness.Electron"),
+                PathBuf::from("/tmp/cua-test-apps/harness-electron/CuaTestHarness.Electron")
+            );
+        });
+    }
 }

--- a/libs/cua-driver/rust/crates/cua-driver/tests/README.md
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/README.md
@@ -33,6 +33,14 @@ Build harness apps before running ignored tests:
 
 Staged outputs are read from `../../test-apps/harness-<name>/`.
 
+The canonical cross-platform matrix is
+`cross_platform_behavior_test.rs`. It runs the same external-state scenarios
+against Electron and Tauri on each supported host. CI and VM runners set
+`CUA_TEST_DRIVER_BIN`, `CUA_TEST_APPS_ROOT`, and
+`CUA_TEST_WORKSPACE_ROOT` when artifacts are built outside Cargo's default
+workspace paths. They also set `CUA_TEST_REQUIRE_FIXTURES=1`, turning a missing
+fixture into a failure instead of a silent skip.
+
 ## Running
 
 ```bash
@@ -52,11 +60,11 @@ builds selected Windows harness apps and maps them into the sandbox. The current
 Windows GUI validation path should use a real user desktop session through RDP
 or an interactive scheduled task.
 
-Windows GUI modality tests require a foreground interactive desktop where
-`GetForegroundWindow` returns a real user window. SSH-launched commands,
-scheduled tasks, and PsExec-launched commands can enter the right user session
-while still exposing no foreground desktop; those tests self-skip in that state
-because the focus oracle would otherwise report meaningless pid-0 results.
+Windows GUI modality tests require a user desktop where the focus sentinel can
+become the foreground window. SSH-launched commands start in Session 0 and
+cannot drive the user's desktop directly; launch GUI tests through an
+interactive scheduled task (`/IT`) or equivalent so they run in the logged-on
+user session.
 
 The Windows probe distinguishes two no-foreground states:
 
@@ -70,6 +78,17 @@ The Windows probe distinguishes two no-foreground states:
 
 Set `CUA_REQUIRE_GUI=1` on dedicated GUI runners to turn these desktop
 self-skips into hard failures with the full desktop-state diagnostic.
+
+The repository-level runners are the preferred entrypoints for the canonical
+matrix:
+
+```bash
+scripts/ci/linux/run-rust-e2e.sh --suite shared
+```
+
+```powershell
+.\scripts\ci\windows\run-rust-e2e.ps1 -Suite shared -RequireGui
+```
 
 ## Optional External Apps
 

--- a/libs/cua-driver/rust/crates/cua-driver/tests/cross_platform_behavior_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/cross_platform_behavior_test.rs
@@ -127,6 +127,12 @@ struct Fixture {
 
 fn launch_host(spec: &HostSpec) -> Option<Fixture> {
     if !spec.path.exists() {
+        if std::env::var_os("CUA_TEST_REQUIRE_FIXTURES").is_some() {
+            panic!(
+                "{} fixture is required but was not staged at {:?}",
+                spec.name, spec.path
+            );
+        }
         eprintln!(
             "[{}] fixture not staged at {:?}; skipping",
             spec.name, spec.path
@@ -134,7 +140,12 @@ fn launch_host(spec: &HostSpec) -> Option<Fixture> {
         return None;
     }
 
-    let mut driver = spawn_driver()?;
+    let Some(mut driver) = spawn_driver() else {
+        if std::env::var_os("CUA_TEST_REQUIRE_FIXTURES").is_some() {
+            panic!("cua-driver could not be started for the required {} fixture", spec.name);
+        }
+        return None;
+    };
     let mut command = Command::new(&spec.path);
     command
         .args(&spec.args)

--- a/nix/cua-driver/README.md
+++ b/nix/cua-driver/README.md
@@ -1,0 +1,37 @@
+# Linux driver checks
+
+Nix is the Linux test environment. It is used for reproducible builds and for
+containerized or compositor-backed Linux checks; Windows and macOS checks do
+not belong here.
+
+## Check tiers
+
+| Tier | Check family | Trigger | Evidence |
+| --- | --- | --- | --- |
+| Source | `cua-driver-linux-rust-unit` | Linux Rust/Nix changes | Cargo unit tests and compilation |
+| Contract | `cua-driver-integration`, `cua-driver-set-config`, `cua-driver-screenshot` | Maintainer or Linux CI | service, config, and capture assertions |
+| Behavioral | `e2e-rust-linux` and the shared Rust matrix | Manual maintainer dispatch | external app state, AX trees, logs, failure screenshots |
+| Supporting | legacy background GUI and compatibility checks | Explicitly selected | toolkit-specific diagnostics |
+
+The behavioral matrix is owned by
+`libs/cua-driver/rust/crates/cua-driver/tests/cross_platform_behavior_test.rs`.
+Nix checks must not create a second scenario list in Nix expressions.
+
+The current automatic Nix lane builds the driver and Rust workspace from source.
+The manual Linux desktop runner builds Electron/Tauri from the repo-local
+fixture sources in the desktop session. Moving those app builds fully inside
+Nix requires committing and hashing their dependency lockfiles, especially the
+Electron npm graph, and is intentionally a follow-up rather than an opaque
+prebuilt download.
+
+## Naming and artifacts
+
+Use `cua-driver-linux-<surface>-<scenario>` for new checks. Do not add `gif`
+to new check names. A failing behavioral check should retain structured output,
+the driver log, an AX/UIA tree where available, and a PNG when the scenario is
+pixel-based. GIF recorders remain legacy supporting diagnostics until their
+behavior is covered by the Rust matrix.
+
+The old `linux-background-gui.nix` and compositor matrix are not deleted in one
+step. They contain useful toolkit and regression evidence, but read-only
+skeleton entries must not be reported as equivalent to a passing user workflow.

--- a/nix/cua-driver/tests/README.md
+++ b/nix/cua-driver/tests/README.md
@@ -1,0 +1,17 @@
+# Linux Nix test layout
+
+Nix expressions are grouped by what they prove:
+
+| Path | Role |
+| --- | --- |
+| `rust-unit.nix` | Source-built Rust workspace checks without a desktop session |
+| `integration.nix` | Driver service starts and answers protocol requests |
+| `set-config.nix` | Configuration persistence contract |
+| `screenshot.nix` | Capture contract in a managed display |
+| `wayland/` | Compositor-specific supporting and red/green checks |
+| `linux-background-gui.nix` | Legacy toolkit matrix, supporting coverage only |
+| `linux-*-gif.nix` | Legacy visual diagnostics, never the canonical Rust matrix |
+
+New user-behavior coverage belongs in the Rust test harness first. A Nix check
+may provide the session and package environment, but it should invoke the
+shared Rust scenario or clearly identify itself as supporting coverage.

--- a/nix/cua-driver/tests/rust-unit.nix
+++ b/nix/cua-driver/tests/rust-unit.nix
@@ -1,0 +1,51 @@
+# Source-built Linux Rust unit/compile checks.
+#
+# This is intentionally separate from package.nix: the shipped daemon package
+# must remain display-independent, while this check validates the Rust source
+# and testkit in Nix's reproducible build environment.
+{
+  pkgs,
+  src,
+  ...
+}:
+
+pkgs.rustPlatform.buildRustPackage {
+  pname = "cua-driver-rust-unit-tests";
+  version = (pkgs.lib.importTOML "${src}/Cargo.toml").workspace.package.version;
+  inherit src;
+
+  cargoLock.lockFile = "${src}/Cargo.lock";
+  cargoTestFlags = [
+    "-p"
+    "cua-driver"
+    "-p"
+    "cua-driver-core"
+    "-p"
+    "cua-driver-testkit"
+    "-p"
+    "platform-linux"
+    "--all-targets"
+  ];
+
+  nativeBuildInputs = with pkgs; [
+    pkg-config
+    rustPlatform.bindgenHook
+    clang
+  ];
+  buildInputs = with pkgs; [
+    libx11
+    libxi
+    libxtst
+    libxext
+    pipewire
+    libei
+  ];
+
+  # The default Cargo test set is deliberately headless. The ignored desktop
+  # matrix is run by the manual Linux e2e workflow and is not hidden in Nix.
+  doCheck = true;
+
+  installPhase = ''
+    touch $out
+  '';
+}

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -1,0 +1,15 @@
+# Cua-driver CI runners
+
+These scripts are thin entrypoints around the Rust integration tests. They
+build the repo-local fixture applications on demand, set the testkit path
+overrides, and collect logs. They do not push code or alter branches.
+
+| Runner | Session | Canonical command |
+| --- | --- | --- |
+| `linux/run-rust-e2e.sh` | Linux X11/Wayland desktop | `--suite shared` |
+| `windows/run-rust-e2e.ps1` | Windows console/RDP user session | `-Suite shared -RequireGui` |
+
+The Windows workflow accepts a runner label so the same command can execute on
+the Azure VM's active-RDP runner when that self-hosted label is configured. A
+GitHub-hosted Windows runner is useful for smoke validation, but it is not a
+substitute for the Azure user-session run.

--- a/scripts/ci/linux/run-rust-e2e.sh
+++ b/scripts/ci/linux/run-rust-e2e.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Run the canonical Rust desktop matrix on a Linux user session.
+# Scenario definitions and assertions live in the Rust integration test.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+DRIVER_ROOT="${REPO_ROOT}/libs/cua-driver"
+RUST_ROOT="${DRIVER_ROOT}/rust"
+BUILD_FIXTURES=1
+SUITE="shared"
+
+usage() {
+  cat <<'EOF'
+Usage: run-rust-e2e.sh [--no-build] [--suite shared|modality|all]
+
+The caller must provide a real or virtual Linux desktop session. For a
+headless session, wrap this command in xvfb-run and dbus-run-session.
+EOF
+}
+
+while (($#)); do
+  case "$1" in
+    --no-build) BUILD_FIXTURES=0 ;;
+    --suite) SUITE="${2:?missing suite}"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+case "$SUITE" in
+  shared|modality|all) ;;
+  *) echo "unsupported suite: $SUITE" >&2; exit 2 ;;
+esac
+
+mkdir -p "${REPO_ROOT}/artifacts/cua-driver/linux"
+export CUA_TEST_WORKSPACE_ROOT="${RUST_ROOT}"
+export CUA_TEST_DRIVER_BIN="${RUST_ROOT}/target/release/cua-driver"
+export CUA_TEST_APPS_ROOT="${RUST_ROOT}/test-apps"
+export CUA_TEST_REQUIRE_FIXTURES=1
+export CUA_TEST_DRIVER_STDERR=1
+
+if [[ "${BUILD_FIXTURES}" == 1 ]]; then
+  cargo build --release -p cua-driver --manifest-path "${RUST_ROOT}/Cargo.toml"
+  bash "${DRIVER_ROOT}/tests/fixtures/build/linux.sh"
+fi
+
+if [[ ! -x "${CUA_TEST_DRIVER_BIN}" ]]; then
+  echo "driver binary not found: ${CUA_TEST_DRIVER_BIN}" >&2
+  exit 1
+fi
+if [[ ! -x "${CUA_TEST_APPS_ROOT}/harness-electron/CuaTestHarness.Electron" ]]; then
+  echo "Electron fixture was not built: ${CUA_TEST_APPS_ROOT}/harness-electron" >&2
+  exit 1
+fi
+
+run_test() {
+  local name="$1"
+  shift
+  echo "[RUN] ${name}"
+  (cd "${RUST_ROOT}" && "$@") 2>&1 | tee "${REPO_ROOT}/artifacts/cua-driver/linux/${name}.log"
+}
+
+if [[ "${SUITE}" == shared || "${SUITE}" == all ]]; then
+  run_test shared-behavior-matrix \
+    cargo test -p cua-driver --test cross_platform_behavior_test -- \
+      --ignored --nocapture --test-threads=1
+fi
+
+if [[ "${SUITE}" == modality || "${SUITE}" == all ]]; then
+  run_test modality-capture \
+    cargo test -p cua-driver --test modality_capture_mode_test -- \
+      --ignored --nocapture --test-threads=1
+  run_test modality-desktop-scope \
+    cargo test -p cua-driver --test modality_desktop_scope_linux_test -- \
+      --ignored --nocapture --test-threads=1
+fi
+
+echo "Linux Rust e2e suite completed: ${SUITE}"

--- a/scripts/ci/windows/build-harnesses.ps1
+++ b/scripts/ci/windows/build-harnesses.ps1
@@ -1,0 +1,16 @@
+# Build all repo-local Windows harness apps from source.
+param(
+    [ValidateSet("none", "wpf", "winui3", "webview", "electron", "tauri")]
+    [string]$Skip = "none"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$repoRoot = (Resolve-Path (Join-Path $scriptDir "..\..\..")).Path
+$fixtureBuild = Join-Path $repoRoot "libs\cua-driver\tests\fixtures\build\windows.ps1"
+
+& $fixtureBuild -Skip $Skip
+if ($LASTEXITCODE -ne 0) {
+    throw "Windows harness build failed with exit code $LASTEXITCODE"
+}

--- a/scripts/ci/windows/collect-artifacts.ps1
+++ b/scripts/ci/windows/collect-artifacts.ps1
@@ -1,0 +1,19 @@
+param(
+    [string]$OutputDirectory = "artifacts\cua-driver\windows"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$repoRoot = (Resolve-Path (Join-Path $scriptDir "..\..\..")).Path
+$destination = Join-Path $repoRoot $OutputDirectory
+New-Item -ItemType Directory -Force $destination | Out-Null
+
+$rustRoot = Join-Path $repoRoot "libs\cua-driver\rust"
+$target = Join-Path $rustRoot "target"
+if (Test-Path $target) {
+    Get-ChildItem -Path $target -Filter "*.log" -Recurse -ErrorAction SilentlyContinue |
+        Copy-Item -Destination $destination -Force
+}
+
+Write-Host "Collected Windows driver artifacts in $destination" -ForegroundColor Green

--- a/scripts/ci/windows/run-rust-e2e.ps1
+++ b/scripts/ci/windows/run-rust-e2e.ps1
@@ -1,0 +1,78 @@
+# Run the canonical Rust desktop matrix in an active Windows user session.
+# Scenario definitions and assertions stay in the Rust integration test.
+param(
+    [switch]$NoBuild,
+    [ValidateSet("shared", "native", "all")]
+    [string]$Suite = "shared",
+    [switch]$RequireGui
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$repoRoot = (Resolve-Path (Join-Path $scriptDir "..\..\..")).Path
+$driverRoot = Join-Path $repoRoot "libs\cua-driver"
+$rustRoot = Join-Path $driverRoot "rust"
+$artifactDir = Join-Path $repoRoot "artifacts\cua-driver\windows"
+New-Item -ItemType Directory -Force $artifactDir | Out-Null
+
+& (Join-Path $scriptDir "verify-user-session.ps1")
+if ($RequireGui) { $env:CUA_REQUIRE_GUI = "1" }
+
+$env:CUA_TEST_WORKSPACE_ROOT = $rustRoot
+$env:CUA_TEST_DRIVER_BIN = Join-Path $rustRoot "target\release\cua-driver.exe"
+$env:CUA_TEST_APPS_ROOT = Join-Path $rustRoot "test-apps"
+$env:CUA_TEST_REQUIRE_FIXTURES = "1"
+$env:CUA_TEST_DRIVER_STDERR = "1"
+
+if (-not $NoBuild) {
+    & cargo build --release -p cua-driver --manifest-path (Join-Path $rustRoot "Cargo.toml")
+    if ($LASTEXITCODE -ne 0) { throw "Rust driver build failed" }
+    & (Join-Path $scriptDir "build-harnesses.ps1")
+}
+
+if (-not (Test-Path $env:CUA_TEST_DRIVER_BIN)) {
+    throw "Driver binary not found: $($env:CUA_TEST_DRIVER_BIN)"
+}
+foreach ($fixture in @(
+    (Join-Path $env:CUA_TEST_APPS_ROOT "harness-electron\CuaTestHarness.Electron.exe"),
+    (Join-Path $env:CUA_TEST_APPS_ROOT "harness-tauri\CuaTestHarness.Tauri.exe")
+)) {
+    if (-not (Test-Path $fixture)) { throw "Required fixture was not built: $fixture" }
+}
+
+function Invoke-CargoTest {
+    param([string]$Name, [string[]]$Arguments)
+    Write-Host "[RUN] $Name" -ForegroundColor Yellow
+    Push-Location $rustRoot
+    try {
+        $logPath = Join-Path $artifactDir ("$($Name -replace '[^A-Za-z0-9_.-]', '-')}.log")
+        $output = & cargo @Arguments 2>&1
+        $exitCode = $LASTEXITCODE
+        $output | Tee-Object -FilePath $logPath
+        if ($exitCode -ne 0) { throw "$Name failed with exit code $exitCode" }
+    } finally {
+        Pop-Location
+    }
+}
+
+if ($Suite -in @("shared", "all")) {
+    Invoke-CargoTest "shared behavior matrix" @(
+        "test", "-p", "cua-driver", "--test", "cross_platform_behavior_test", "--",
+        "--ignored", "--nocapture", "--test-threads=1"
+    )
+}
+
+if ($Suite -in @("native", "all")) {
+    Invoke-CargoTest "Windows native harnesses" @(
+        "test", "-p", "cua-driver", "--test", "harness_wpf_test", "--",
+        "--ignored", "--nocapture", "--test-threads=1"
+    )
+    Invoke-CargoTest "Windows web harnesses" @(
+        "test", "-p", "cua-driver", "--test", "harness_web_test", "--",
+        "--ignored", "--nocapture", "--test-threads=1"
+    )
+}
+
+Write-Host "Windows Rust e2e suite completed: $Suite" -ForegroundColor Green

--- a/scripts/ci/windows/verify-user-session.ps1
+++ b/scripts/ci/windows/verify-user-session.ps1
@@ -1,0 +1,11 @@
+# Verify that the runner is inside an interactive user session, not Session 0.
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$sessionId = (Get-Process -Id $PID).SessionId
+if ($sessionId -eq 0) {
+    throw "The test runner is in Session 0. Start it from the active console/RDP user session."
+}
+
+$sessionName = if ($env:SESSIONNAME) { $env:SESSIONNAME } else { "unknown" }
+Write-Host "Interactive Windows session verified: id=$sessionId name=$sessionName" -ForegroundColor Green


### PR DESCRIPTION
## Summary

Adds the OS-scoped Rust CI and maintainer-controlled desktop e2e architecture extracted from the large cross-platform PR. Linux remains the Nix-owned platform for source checks; Windows e2e accepts a runner label for an active user-session VM.

## Included

- Linux and Windows Rust unit workflows with platform-aware path filters.
- Manual Linux and Windows interactive Rust e2e workflows.
- Testkit artifact path overrides and strict fixture preflight.
- Automatic source-built Nix Rust check.
- Legacy GUI/toolkit and compositor matrices moved to maintainer dispatch.
- Contributor-facing Nix and CI documentation.

## Validation

- `cargo test -p cua-driver-testkit -p cua-driver --test cross_platform_behavior_test --no-run --locked` passed on macOS.
- Workflow YAML parsed successfully, Bash syntax check passed, and `git diff --check` passed.
- Native Windows and Linux checks are running on GitHub-hosted runners.
- Nix and interactive desktop e2e remain native-runner checks rather than local validation.

## Scope

Stacked on the Windows behavior PR #2141 because the Windows unit workflow compiles the Windows guard tests and needs the desktop-state diagnostics introduced there. Linux #2142 and macOS #2143 remain independent platform slices; merge them before enabling the complete cross-platform e2e gate.
