### PR TITLE
Remove broken starchart

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,6 @@ Apple, macOS, Ubuntu, Canonical, and Microsoft are trademarks of their respectiv
 
 <div align="center">
 
-[![Stargazers over time](https://starchart.cc/trycua/cua.svg?variant=adaptive)](https://starchart.cc/trycua/cua)
-
 Thank you to all our [GitHub Sponsors](https://github.com/sponsors/trycua)!
 
 <img width="300" alt="coderabbit-cli" src="https://github.com/user-attachments/assets/23a98e38-7897-4043-8ef7-eb990520dccc" />

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -207,10 +207,6 @@ const config = {
       },
       {
         protocol: 'https',
-        hostname: 'starchart.cc',
-      },
-      {
-        protocol: 'https',
         hostname: 'github.com',
       },
     ],


### PR DESCRIPTION
## Summary

- remove the broken starchart embed from the README footer
- remove the unused `starchart.cc` image allowlist entry

## Why

The starchart is not visible, leaving a broken or empty visual area in the repository README. Removing it keeps the footer clean and eliminates the now-unused external image host configuration.

## Impact

The README footer now goes directly to the GitHub Sponsors acknowledgement. No application behavior changes.

## Validation

- `git diff --check`
- `node --check docs/next.config.mjs`
- repository-wide search confirms no starchart references remain