### PR TITLE
ci(cua-driver): restore full Windows Rust matrix

### DIFF
--- a/.github/workflows/e2e-rust-windows.yml
+++ b/.github/workflows/e2e-rust-windows.yml
@@ -11,7 +11,7 @@ on:
         description: "Rust desktop suite"
         required: true
         type: choice
-        options: [shared, native, all]
+        options: [default, guard, shared, native, modality, all]
         default: shared
       runner:
         description: "Runner label; use the Azure RDP runner label for VM e2e"
@@ -22,6 +22,54 @@ permissions:
   contents: read
 
 jobs:
+  default:
+    if: inputs.suite == 'default' || inputs.suite == 'all'
+    name: "Windows / default Rust tests"
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Run default Rust tests
+        shell: pwsh
+        run: .\scripts\ci\windows\run-rust-e2e.ps1 -Suite default -RequireGui
+      - name: Collect logs
+        if: always()
+        shell: pwsh
+        run: .\scripts\ci\windows\collect-artifacts.ps1
+      - name: Upload default results
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: rust-windows-default
+          path: artifacts/cua-driver/windows
+          if-no-files-found: ignore
+
+  guard:
+    if: inputs.suite == 'guard' || inputs.suite == 'all'
+    name: "Windows / UX guards"
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Run UX guard tests
+        shell: pwsh
+        run: .\scripts\ci\windows\run-rust-e2e.ps1 -Suite guard -RequireGui
+      - name: Collect logs
+        if: always()
+        shell: pwsh
+        run: .\scripts\ci\windows\collect-artifacts.ps1
+      - name: Upload guard results
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: rust-windows-guard
+          path: artifacts/cua-driver/windows
+          if-no-files-found: ignore
+
   shared:
     if: inputs.suite == 'shared' || inputs.suite == 'all'
     name: "Windows / shared Electron + Tauri"
@@ -70,9 +118,33 @@ jobs:
           path: artifacts/cua-driver/windows
           if-no-files-found: ignore
 
+  modality:
+    if: inputs.suite == 'modality' || inputs.suite == 'all'
+    name: "Windows / modality input E2E"
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Run modality input E2E
+        shell: pwsh
+        run: .\scripts\ci\windows\run-rust-e2e.ps1 -Suite modality -RequireGui
+      - name: Collect logs
+        if: always()
+        shell: pwsh
+        run: .\scripts\ci\windows\collect-artifacts.ps1
+      - name: Upload modality results
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: rust-windows-modality
+          path: artifacts/cua-driver/windows
+          if-no-files-found: ignore
+
   summary:
     if: always()
-    needs: [shared, native]
+    needs: [default, guard, shared, native, modality]
     name: "Windows / matrix summary"
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/libs/cua-driver/docs/e2e-ci-reporting.md
+++ b/libs/cua-driver/docs/e2e-ci-reporting.md
@@ -6,8 +6,10 @@ selects the lane and publishes its results.
 ## Workflow UI
 
 The Linux and Windows manual workflows split the expensive suites into
-independent jobs. The workflow summary job collects their artifacts and writes
-one Markdown table to the GitHub Actions run summary.
+independent jobs. On Windows, `suite=all` covers the default Rust tests, UX
+guards, shared Electron/Tauri behavior, WPF/WinUI3/WebView2 harnesses, and
+modality-input E2E. The workflow summary job collects their artifacts and
+writes one Markdown table to the GitHub Actions run summary.
 
 This means a failure in the shared Electron/Tauri lane does not prevent the
 native or modality lane from running. The workflow still fails when a required
@@ -31,8 +33,9 @@ object per host and scenario:
 ```
 
 When `CUA_E2E_SUMMARY_FILE` is set, the same test writes a Markdown row for the
-GitHub summary. Native and modality scripts add lane-level rows to the same
-files and retain their full logs alongside them.
+GitHub summary. The CI scripts also parse each Cargo `test ... ok/FAILED` line,
+so native, guard, default, and modality suites appear as individual test rows
+as well as lane-level rows. Full logs are retained alongside them.
 
 Statuses are deliberately explicit:
 

--- a/scripts/ci/windows/run-rust-e2e.ps1
+++ b/scripts/ci/windows/run-rust-e2e.ps1
@@ -2,7 +2,7 @@
 # Scenario definitions and assertions stay in the Rust integration test.
 param(
     [switch]$NoBuild,
-    [ValidateSet("shared", "native", "all")]
+    [ValidateSet("default", "guard", "shared", "native", "modality", "all")]
     [string]$Suite = "shared",
     [switch]$RequireGui
 )
@@ -43,6 +43,11 @@ if (-not $NoBuild) {
     & (Join-Path $scriptDir "build-harnesses.ps1")
 }
 
+if ($Suite -in @("default", "guard", "modality", "all")) {
+    & cargo build -p focus-monitor-win --manifest-path (Join-Path $rustRoot "Cargo.toml")
+    if ($LASTEXITCODE -ne 0) { throw "Focus monitor build failed" }
+}
+
 if (-not (Test-Path $env:CUA_TEST_DRIVER_BIN)) {
     throw "Driver binary not found: $($env:CUA_TEST_DRIVER_BIN)"
 }
@@ -62,6 +67,32 @@ function Invoke-CargoTest {
         $output = & cargo @Arguments 2>&1
         $exitCode = $LASTEXITCODE
         $output | Tee-Object -FilePath $logPath
+        foreach ($line in $output) {
+            $match = [regex]::Match(
+                [string]$line,
+                '^\s*test\s+(?<name>\S+)\s+\.\.\.\s+(?<status>ok|FAILED|ignored)\s*$'
+            )
+            if (-not $match.Success) { continue }
+
+            $testStatus = switch ($match.Groups["status"].Value) {
+                "ok" { "PASS" }
+                "FAILED" { "FAIL" }
+                default { "SKIP" }
+            }
+            $testName = $match.Groups["name"].Value
+            $testMessage = if ($testStatus -eq "FAIL") { "test case failed; see lane log" } else { "" }
+            $testRecord = [ordered]@{
+                schema = "cua-e2e-result/v1"
+                platform = "windows"
+                host = "cargo"
+                scenario = $testName
+                status = $testStatus
+                message = $testMessage
+            } | ConvertTo-Json -Compress
+            Add-Content -Path $resultsPath -Value $testRecord
+            $testDetails = if ($testMessage) { $testMessage } else { "-" }
+            Add-Content -Path $summaryPath -Value "| Windows | cargo | $testName | $testStatus | n/a | $testDetails |"
+        }
         $status = if ($exitCode -eq 0) { "PASS" } else { "FAIL" }
         $record = [ordered]@{
             schema = "cua-e2e-result/v1"
@@ -91,13 +122,38 @@ if ($Suite -in @("shared", "all")) {
     )
 }
 
+if ($Suite -in @("default", "all")) {
+    Invoke-CargoTest "default Rust tests" @(
+        "test", "-p", "cua-driver", "-p", "platform-windows", "--",
+        "--nocapture", "--test-threads=1"
+    )
+}
+
+if ($Suite -in @("guard", "all")) {
+    Invoke-CargoTest "guard UX" @(
+        "test", "-p", "cua-driver", "--test", "guard_ux_test", "--",
+        "--nocapture", "--test-threads=1"
+    )
+}
+
 if ($Suite -in @("native", "all")) {
     Invoke-CargoTest "Windows native harnesses" @(
         "test", "-p", "cua-driver", "--test", "harness_wpf_test", "--",
         "--ignored", "--nocapture", "--test-threads=1"
     )
+    Invoke-CargoTest "WinUI3 harnesses" @(
+        "test", "-p", "cua-driver", "--test", "harness_winui3_test", "--",
+        "--ignored", "--nocapture", "--test-threads=1"
+    )
     Invoke-CargoTest "Windows web harnesses" @(
         "test", "-p", "cua-driver", "--test", "harness_web_test", "--",
+        "--ignored", "--nocapture", "--test-threads=1"
+    )
+}
+
+if ($Suite -in @("modality", "all")) {
+    Invoke-CargoTest "Windows modality input e2e" @(
+        "test", "-p", "cua-driver", "--test", "modality_input_e2e_test", "--",
         "--ignored", "--nocapture", "--test-threads=1"
     )
 }


### PR DESCRIPTION
## What changed

- Restore the canonical Windows lanes previously run by `tests/runners/windows/run-all.ps1`: default Rust tests, UX guards, shared Electron/Tauri behavior, WPF/WinUI3/WebView2 harnesses, and modality-input E2E.
- Expand the workflow suite selector with independent lanes and keep `suite=all` failure-isolated.
- Parse Cargo test output into individual GitHub summary rows, while retaining lane rows and raw logs.

## Why

The prior reporting workflow only invoked the shared and native lanes. It hid default, guard, WinUI3, and modality coverage, and collapsed 18 WPF and 5 web tests into two rows.

## Validation

- YAML parse and Git diff checks
- Cargo test target compilation
- Cargo result parser samples for `ok` and `FAILED` output

The full Windows workflow will be dispatched after merge.