### PR TITLE
chore: serve driver and lume installers from cua.ai

### DIFF
--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -589,7 +589,7 @@ jobs:
             ### Install (macOS / Linux pre-release)
 
             ```bash
-            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)"
+            /bin/bash -c "$(curl -fsSL https://cua.ai/driver/install.sh)"
             ```
 
             The shell installer covers macOS and the Linux pre-release backend
@@ -600,7 +600,7 @@ jobs:
             ### Install (Windows)
 
             ```powershell
-            irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.ps1 | iex
+            irm https://cua.ai/driver/install.ps1 | iex
             ```
 
             The installer auto-detects host architecture (x86_64 / arm64) and uses

--- a/.github/workflows/cd-swift-lume.yml
+++ b/.github/workflows/cd-swift-lume.yml
@@ -314,7 +314,7 @@ jobs:
             ### Installation with script
 
             ```bash
-            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/lume/scripts/install.sh)"
+            /bin/bash -c "$(curl -fsSL https://cua.ai/lume/install.sh)"
             ```
           generate_release_notes: false
           make_latest: true

--- a/.github/workflows/monitor-branded-installers.yml
+++ b/.github/workflows/monitor-branded-installers.yml
@@ -1,0 +1,100 @@
+name: Monitor branded installer endpoints
+
+on:
+  schedule:
+    # Run daily; the first scheduled run will be the next day after merge.
+    - cron: '15 14 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: monitor-branded-installers
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check public installer endpoints
+        id: endpoints
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          endpoints=(
+            "https://cua.ai/driver/install.sh|cua-driver"
+            "https://cua.ai/driver/install.ps1|cua-driver"
+            "https://cua.ai/driver/uninstall.sh|cua-driver"
+            "https://cua.ai/driver/uninstall.ps1|cua-driver"
+            "https://cua.ai/driver/_install-rust.sh|cua-driver"
+            "https://cua.ai/driver/_install-common.sh|cua-driver"
+            "https://cua.ai/driver/_install-common.psm1|cua-driver"
+            "https://cua.ai/driver/post-install-hints.txt|cua-driver"
+            "https://cua.ai/lume/install.sh|Lume"
+            "https://cua.ai/lume/uninstall.sh|Lume"
+          )
+
+          failures=()
+          mkdir -p /tmp/branded-installer-check
+          for entry in "${endpoints[@]}"; do
+            url="${entry%%|*}"
+            marker="${entry##*|}"
+            key=$(echo "$url" | sed 's#https://##; s#[^A-Za-z0-9]#_#g')
+            headers="/tmp/branded-installer-check/${key}.headers"
+            body="/tmp/branded-installer-check/${key}.body"
+
+            status=$(curl --silent --show-error --location --max-redirs 0 \
+              --dump-header "$headers" --output "$body" --write-out '%{http_code}' "$url" || true)
+            content_type=$(awk -F': ' 'tolower($1)=="content-type" {print $2}' "$headers" | tail -1 | tr -d '\r')
+
+            if [[ "$status" != "200" ]]; then
+              failures+=("$url returned HTTP $status")
+            elif [[ "$content_type" != text/* ]]; then
+              failures+=("$url returned unexpected Content-Type: ${content_type:-missing}")
+            elif ! grep -qi -- "$marker" "$body"; then
+              failures+=("$url did not contain expected marker $marker")
+            fi
+          done
+
+          if ((${#failures[@]})); then
+            {
+              echo 'failures<<EOF'
+              printf '%s\n' "${failures[@]}"
+              echo EOF
+            } >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          echo 'failures=' >> "$GITHUB_OUTPUT"
+
+      - name: Open or update monitoring issue
+        if: failure() && steps.endpoints.outputs.failures != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FAILURES: ${{ steps.endpoints.outputs.failures }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          title='Branded installer endpoint check is failing'
+          body=$(cat <<EOF
+          The daily branded installer monitor found one or more failures.
+
+          ```
+          ${FAILURES}
+          ```
+
+          Workflow run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          Checked at: ${GITHUB_SHA}
+          EOF
+          )
+
+          issue_number=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --search "$title in:title" --json number --jq '.[0].number // empty')
+          if [[ -n "$issue_number" ]]; then
+            gh issue comment "$issue_number" --repo "$GITHUB_REPOSITORY" --body "$body"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body "$body"
+          fi

--- a/Development.md
+++ b/Development.md
@@ -29,7 +29,7 @@ All Python packages are part of a [uv workspace](https://docs.astral.sh/uv/conce
 1. **Install Lume CLI** (required for local VM management):
 
    ```bash
-   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/lume/scripts/install.sh)"
+   /bin/bash -c "$(curl -fsSL https://cua.ai/lume/install.sh)"
    ```
 
 2. **Clone the repository**:

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ Drive native desktop apps **in the background**. Agents click, type, and verify 
 **macOS / Linux**
 
 ```sh
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)"
+/bin/bash -c "$(curl -fsSL https://cua.ai/driver/install.sh)"
 ```
 
 **Windows (PowerShell)**
 
 ```powershell
-irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.ps1 | iex
+irm https://cua.ai/driver/install.ps1 | iex
 ```
 
 Then wire it into Claude Code as an MCP server and your agent can drive the desktop in the background:
@@ -141,7 +141,7 @@ Create and manage macOS/Linux VMs with near-native performance on Apple Silicon 
 
 ```bash
 # Install Lume
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/lume/scripts/install.sh)"
+/bin/bash -c "$(curl -fsSL https://cua.ai/lume/install.sh)"
 
 # Pull & start a macOS VM
 lume run macos-sequoia-vanilla:latest

--- a/docs/content/docs/how-to-guides/driver/install.mdx
+++ b/docs/content/docs/how-to-guides/driver/install.mdx
@@ -14,7 +14,7 @@ Cua Driver supports macOS, Windows, and Linux. Use the same **one-line installer
 **Requirements:** macOS 14 (Sonoma) or later on Apple Silicon or Intel.
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)"
+/bin/bash -c "$(curl -fsSL https://cua.ai/driver/install.sh)"
 ```
 
 The installer places `CuaDriver.app` in `/Applications` and creates the `~/.local/bin/cua-driver` symlink. The app bundle uses the `com.trycua.driver` signing identity, so macOS TCC permissions for Accessibility and Screen Recording remain attached across upgrades.
@@ -27,7 +27,7 @@ If `~/.local/bin` is missing from your PATH, the installer detects your shell (`
 **Requirements:** Windows 10/11 or Windows Server with an interactive desktop session and PowerShell.
 
 ```powershell
-irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.ps1 | iex
+irm https://cua.ai/driver/install.ps1 | iex
 ```
 
 The installer downloads the release under `%USERPROFILE%\.cua-driver\packages\releases\` and exposes `cua-driver.exe` from `%LOCALAPPDATA%\Programs\Cua\cua-driver\bin`. It runs without administrator privileges, detects whether the host is x64 or arm64, and appends the install directory to your User-scope `Path` so new PowerShell windows can resolve `cua-driver.exe`. It also attempts to register the `cua-driver-serve` autostart task; that step needs an interactive session, so on a non-interactive or SSH install it is skipped — set it up later with [`cua-driver autostart enable`](/how-to-guides/driver/keep-running).
@@ -35,7 +35,7 @@ The installer downloads the release under `%USERPROFILE%\.cua-driver\packages\re
 To skip the PATH change, pass the no-update flag:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.ps1))) -NoPathUpdate
+& ([scriptblock]::Create((irm https://cua.ai/driver/install.ps1))) -NoPathUpdate
 ```
 
   </Tab>
@@ -50,7 +50,7 @@ sudo apt install libxi6 at-spi2-core
 ```
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)"
+/bin/bash -c "$(curl -fsSL https://cua.ai/driver/install.sh)"
 ```
 
 The installer downloads the binary to `~/.cua-driver/packages/releases/`, points `~/.cua-driver/packages/current` at that release, and creates the `~/.local/bin/cua-driver` symlink. It does not use sudo.

--- a/docs/content/docs/how-to-guides/driver/update.mdx
+++ b/docs/content/docs/how-to-guides/driver/update.mdx
@@ -78,7 +78,7 @@ cua-driver check-update --json
   "source": "github_releases",
   "checked_at": "2026-07-01T14:30:00Z",
   "cache_hit": false,
-  "install_command": "curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh | bash",
+  "install_command": "curl -fsSL https://cua.ai/driver/install.sh | bash",
   "release_notes_url": "https://github.com/trycua/cua/releases/tag/cua-driver-rs-v0.7.0",
   "error": null
 }

--- a/docs/content/docs/how-to-guides/driver/windows-ssh.mdx
+++ b/docs/content/docs/how-to-guides/driver/windows-ssh.mdx
@@ -106,7 +106,7 @@ Each MCP tool call starts `cua-driver mcp` on the SSH side. That process detects
 
 Check these items before opening an issue:
 
-1. Confirm that `cua-driver --version` on the SSH side reports the same current install you expect. Upgrade if needed with `irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.ps1 | iex`.
+1. Confirm that `cua-driver --version` on the SSH side reports the same current install you expect. Upgrade if needed with `irm https://cua.ai/driver/install.ps1 | iex`.
 2. Run `cua-driver status` from SSH and confirm it reports a running daemon. If it does not, use `cua-driver autostart status` to see whether the Scheduled Task is registered.
 3. Run `query session` and confirm your user has a row in `Active` or `Disc` state.
 4. Run `cua-driver doctor` from RDP and confirm it reports `[ok] interactive session: session N has an attached interactive desktop`.

--- a/docs/content/docs/how-to-guides/lume/install-lume.mdx
+++ b/docs/content/docs/how-to-guides/lume/install-lume.mdx
@@ -19,7 +19,7 @@ Lume is Cua's local VM manager for Apple Silicon Macs. Use it when you want to c
 Install with a single command:
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/lume/scripts/install.sh)"
+/bin/bash -c "$(curl -fsSL https://cua.ai/lume/install.sh)"
 ```
 
 ## Verify the install
@@ -63,7 +63,7 @@ lume run macos-sequoia-vanilla:latest
 By default, Lume is installed as a background service that starts automatically on login. If you prefer to start the Lume API service manually when needed, you can use the `--no-background-service` option:
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/lume/scripts/install.sh) --no-background-service"
+/bin/bash -c "$(curl -fsSL https://cua.ai/lume/install.sh) --no-background-service"
 ```
 
 <Callout title="Note">

--- a/docs/content/docs/reference/cua-driver/cli-reference.mdx
+++ b/docs/content/docs/reference/cua-driver/cli-reference.mdx
@@ -13,7 +13,7 @@ description: Command-line interface specification for Cua Driver
 Cross-platform computer-use automation driver. Install via the official script:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh | bash
+curl -fsSL https://cua.ai/driver/install.sh | bash
 ```
 
 Documented against Cua Driver **0.7.1**. Run `cua-driver --version` for your installed version.

--- a/docs/content/docs/tutorials/drive-your-first-app.mdx
+++ b/docs/content/docs/tutorials/drive-your-first-app.mdx
@@ -19,7 +19,7 @@ Use the same one-line installer on every platform; it picks the right path for t
     Requires macOS 14 (Sonoma) or later.
 
     ```bash
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)"
+    /bin/bash -c "$(curl -fsSL https://cua.ai/driver/install.sh)"
     ```
 
     Start the daemon through the app bundle so macOS attributes permission prompts to CuaDriver.app. This is what makes the TCC grant stick to the driver:
@@ -38,7 +38,7 @@ Use the same one-line installer on every platform; it picks the right path for t
     Requires Windows 10/11 with an interactive desktop session and PowerShell.
 
     ```powershell
-    irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.ps1 | iex
+    irm https://cua.ai/driver/install.ps1 | iex
     ```
 
   </Tab>
@@ -46,7 +46,7 @@ Use the same one-line installer on every platform; it picks the right path for t
     Requires an x86_64 Linux desktop session with X11 or XWayland, plus AT-SPI 2.
 
     ```bash
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)"
+    /bin/bash -c "$(curl -fsSL https://cua.ai/driver/install.sh)"
     ```
 
   </Tab>

--- a/libs/cua-driver/rust/Skills/cua-driver/README.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/README.md
@@ -59,7 +59,7 @@ forbidden-list / launch / click details.
    that were stabilized in Sonoma.
 2. **`cua-driver` CLI + `CuaDriver.app`** — installable one-liner:
    ```bash
-   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)"
+   /bin/bash -c "$(curl -fsSL https://cua.ai/driver/install.sh)"
    ```
    Or from a clone of `trycua/cua`:
    ```bash
@@ -84,7 +84,7 @@ forbidden-list / launch / click details.
 1. **Windows 10/11** (any edition with PowerShell 5.1+).
 2. **`cua-driver` CLI (Rust port `cua-driver-rs`)** — one-liner:
    ```powershell
-   irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.ps1 | iex
+   irm https://cua.ai/driver/install.ps1 | iex
    ```
    No TCC equivalent; no UAC elevation required for the default
    per-user install. See `WINDOWS.md` for Session 0 vs Session 1+
@@ -99,7 +99,7 @@ The full tool surface is supported on X11 (background input via AT-SPI
 opt-in and still preview. See `LINUX.md`. Install:
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)"
+/bin/bash -c "$(curl -fsSL https://cua.ai/driver/install.sh)"
 ```
 
 (On Linux the canonical installer auto-detects the non-macOS host and

--- a/libs/cua-driver/rust/crates/cua-driver/src/updater.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/updater.rs
@@ -28,10 +28,10 @@ use std::process::{Command, ExitStatus};
 /// constant from triggering `dead_code` on the platform that doesn't use it.
 #[cfg(not(windows))]
 const CANONICAL_INSTALL_SH: &str =
-    "https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh";
+    "https://cua.ai/driver/install.sh";
 #[cfg(windows)]
 const CANONICAL_INSTALL_PS1: &str =
-    "https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.ps1";
+    "https://cua.ai/driver/install.ps1";
 
 /// The env var both scripts honour to pin the target release tag. Set to a
 /// bare version like `"0.2.18"` (no `cua-driver-rs-v` prefix). See

--- a/libs/cua-driver/rust/crates/cua-driver/src/version_check.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/version_check.rs
@@ -150,11 +150,11 @@ pub struct UpdateState {
 fn install_one_liner() -> String {
     #[cfg(windows)]
     {
-        "irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.ps1 | iex".to_owned()
+        "irm https://cua.ai/driver/install.ps1 | iex".to_owned()
     }
     #[cfg(not(windows))]
     {
-        "curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh | bash".to_owned()
+        "curl -fsSL https://cua.ai/driver/install.sh | bash".to_owned()
     }
 }
 

--- a/libs/cua-driver/scripts/_install-rust.sh
+++ b/libs/cua-driver/scripts/_install-rust.sh
@@ -15,7 +15,7 @@
 # helper is hard-pinned to `cua-driver-rs-v*` and will never pick it up.
 #
 # Canonical user-facing invocation (forwards here by default):
-#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)"
+#   /bin/bash -c "$(curl -fsSL https://cua.ai/driver/install.sh)"
 #
 # Flags:
 #   --bin-dir <path>     install the visible binary/symlink to <path>
@@ -82,7 +82,7 @@ set -euo pipefail
 # Failure here is non-fatal: the daemon-stop is a best-effort upgrade
 # nicety, not load-bearing. If we can't load the helpers, define
 # no-op stubs so the rest of the script can call them unconditionally.
-_CUA_INSTALL_COMMON_URL="https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/_install-common.sh"
+_CUA_INSTALL_COMMON_URL="https://cua.ai/driver/_install-common.sh"
 _cua_install_common_loaded=0
 if [[ -n "${BASH_SOURCE[0]:-}" && "${BASH_SOURCE[0]}" != "-" && -f "${BASH_SOURCE[0]}" ]]; then
     _CUA_SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
@@ -485,7 +485,7 @@ case "$OS-$ARCH_RAW" in
     *)
         err "unsupported platform: $OS / $ARCH_RAW"
         err "  cua-driver-rs ships prebuilts for: darwin-arm64, darwin-x86_64, linux-x86_64, linux-arm64."
-        err "  Windows users: install via install.ps1 (irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.ps1 | iex)."
+        err "  Windows users: install via install.ps1 (irm https://cua.ai/driver/install.ps1 | iex)."
         exit 1
         ;;
 esac
@@ -831,7 +831,7 @@ fi
 # (Try-it / skill pack / MCP setup / docs link) with {{BINARY}}
 # placeholders; OS-specific bits (autostart / TCC) stay inline below
 # in each installer where they're per-shell natural.
-HINTS_URL="https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/post-install-hints.txt"
+HINTS_URL="https://cua.ai/driver/post-install-hints.txt"
 HINTS_TXT="$TMP_DIR/post-install-hints.txt"
 if curl -fsSL "$HINTS_URL" -o "$HINTS_TXT" 2>/dev/null && [ -s "$HINTS_TXT" ]; then
     sed "s|{{BINARY}}|$BIN_LINK|g" "$HINTS_TXT"

--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -5,11 +5,11 @@
 # required, no admin elevation.
 #
 # Usage (one-liner — recommended):
-#   irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.ps1 | iex
+#   irm https://cua.ai/driver/install.ps1 | iex
 #
 # Pin a version:
 #   $env:CUA_DRIVER_RS_VERSION = "0.2.0"
-#   irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.ps1 | iex
+#   irm https://cua.ai/driver/install.ps1 | iex
 #
 # Layout on disk (three tiers, two directory junctions):
 #
@@ -589,7 +589,7 @@ function Import-CuaDriverInstallModuleBootstrap {
 }
 Import-CuaDriverInstallModuleBootstrap `
     -LocalDir $PSScriptRoot `
-    -Url "https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/_install-common.psm1"
+    -Url "https://cua.ai/driver/_install-common.psm1"
 
 function Register-CuaDriverAutostart {
     param([Parameter(Mandatory = $true)][string]$InstalledBinary)
@@ -1287,7 +1287,7 @@ if ($AutoStart) {
 # install-local.sh) never drift. The .txt holds the OS-agnostic bulk
 # (Try-it / skill pack / MCP setup / docs link) with {{BINARY}}
 # placeholders; OS-specific bits (autostart) stay inline below.
-$HintsUrl = "https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/post-install-hints.txt"
+$HintsUrl = "https://cua.ai/driver/post-install-hints.txt"
 try {
     $hintsRaw = (Invoke-WebRequest -Uri $HintsUrl -UseBasicParsing -TimeoutSec 10).Content
     Write-Host ($hintsRaw -replace '\{\{BINARY\}\}', $installedBinary)

--- a/libs/cua-driver/scripts/install.sh
+++ b/libs/cua-driver/scripts/install.sh
@@ -3,7 +3,7 @@
 # Downloads the latest release from GitHub Releases and wires it into the user's PATH.
 #
 # Usage (from README + release body):
-#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh)"
+#   /bin/bash -c "$(curl -fsSL https://cua.ai/driver/install.sh)"
 #
 # Flags:
 #   --bin-dir <path>     install the cua-driver wrapper to <path> instead of
@@ -22,7 +22,7 @@
 #   CUA_DRIVER_NO_MODIFY_PATH=1    same as --no-modify-path
 #
 # Uninstall:
-#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.sh)"
+#   /bin/bash -c "$(curl -fsSL https://cua.ai/driver/uninstall.sh)"
 set -euo pipefail
 
 BIN_DIR="${CUA_DRIVER_BIN_DIR:-$HOME/.local/bin}"
@@ -33,7 +33,7 @@ NO_MODIFY_PATH="${CUA_DRIVER_NO_MODIFY_PATH:-0}"
 # this directory holds the single user-facing install.sh per platform.
 # The Rust path below either execs the on-disk helper (dev /
 # checked-out-tree case) or curls this URL and pipes it to bash.
-RUST_INSTALLER_URL="https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/_install-rust.sh"
+RUST_INSTALLER_URL="https://cua.ai/driver/_install-rust.sh"
 
 # Lightweight flag parsing (avoid getopt; macOS getopt is GNU-incompatible).
 #

--- a/libs/cua-driver/scripts/uninstall.ps1
+++ b/libs/cua-driver/scripts/uninstall.ps1
@@ -6,11 +6,11 @@
 # config directories.
 #
 # Usage (one-liner — recommended):
-#   irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.ps1 | iex
+#   irm https://cua.ai/driver/uninstall.ps1 | iex
 #
 # Force (skip all prompts):
 #   $env:CUA_DRIVER_RS_UNINSTALL_FORCE = '1'
-#   irm https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.ps1 | iex
+#   irm https://cua.ai/driver/uninstall.ps1 | iex
 #
 # Why an env var and not a `-Force` parameter: `iex` (Invoke-Expression)
 # refuses to parse a script that opens with `[CmdletBinding()] param(...)`

--- a/libs/cua-driver/scripts/uninstall.sh
+++ b/libs/cua-driver/scripts/uninstall.sh
@@ -52,7 +52,7 @@
 # --keep-tcc to preserve grants across uninstall/reinstall.
 #
 # Usage:
-#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/uninstall.sh)"
+#   /bin/bash -c "$(curl -fsSL https://cua.ai/driver/uninstall.sh)"
 #
 # Env overrides (mirror install side):
 #   CUA_DRIVER_RS_HOME    Rust package home to remove (default ~/.cua-driver-rs)

--- a/libs/lume/scripts/uninstall.sh
+++ b/libs/lume/scripts/uninstall.sh
@@ -3,7 +3,7 @@ set -e
 
 # Lume Uninstaller
 # This script removes Lume from your system
-# Usage: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/lume/scripts/uninstall.sh)"
+# Usage: /bin/bash -c "$(curl -fsSL https://cua.ai/lume/uninstall.sh)"
 
 # Define colors for output
 BOLD=$(tput bold 2>/dev/null || echo "")
@@ -207,6 +207,6 @@ if [ "$PURGE_DATA" = false ]; then
   echo ""
   echo "Note: Your VMs and configuration were preserved."
   echo "To also remove all data, run with ${BOLD}--purge${NORMAL}:"
-  echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/lume/scripts/uninstall.sh)\" -- --purge"
+  echo "  /bin/bash -c \"\$(curl -fsSL https://cua.ai/lume/uninstall.sh)\" -- --purge"
 fi
 echo ""

--- a/libs/lume/src/Update/VersionCheck.swift
+++ b/libs/lume/src/Update/VersionCheck.swift
@@ -4,7 +4,7 @@ enum LumeVersionCheck {
     static let releaseTagPrefix = "lume-v"
     static let releasesURL = URL(string: "https://api.github.com/repos/trycua/cua/releases?per_page=40")!
     static let defaultInstallScriptURL =
-        "https://raw.githubusercontent.com/trycua/cua/main/libs/lume/scripts/install.sh"
+        "https://cua.ai/lume/install.sh"
 
     private static let cacheRefreshSeconds: TimeInterval = 20 * 60 * 60
     private static let updateCheckEnv = "LUME_UPDATE_CHECK"

--- a/scripts/docs-generators/cua-driver.ts
+++ b/scripts/docs-generators/cua-driver.ts
@@ -280,7 +280,7 @@ export function generateCLIReferenceMDX(docs: CLIDocumentation, releasedVersion:
   lines.push('');
   lines.push('```sh');
   lines.push(
-    'curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh | bash'
+    'curl -fsSL https://cua.ai/driver/install.sh | bash'
   );
   lines.push('```');
   lines.push('');

--- a/scripts/playground-docker.sh
+++ b/scripts/playground-docker.sh
@@ -239,7 +239,7 @@ fi
 if [[ "$USE_CLOUD" == "false" && "$COMPUTER_TYPE" == "macos" ]]; then
   if ! command -v lume &> /dev/null; then
     print_info "Installing Lume CLI..."
-    curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/lume/scripts/install.sh | bash
+    curl -fsSL https://cua.ai/lume/install.sh | bash
     
     # Add lume to PATH for this session if it's not already there
     if ! command -v lume &> /dev/null; then

--- a/scripts/playground.sh
+++ b/scripts/playground.sh
@@ -107,7 +107,7 @@ fi
 if [[ "$USE_CLOUD" == "false" ]]; then
   if ! command -v lume &> /dev/null; then
     echo "📦 Installing Lume CLI..."
-    curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/lume/scripts/install.sh | bash
+    curl -fsSL https://cua.ai/lume/install.sh | bash
     
     # Add lume to PATH for this session if it's not already there
     if ! command -v lume &> /dev/null; then


### PR DESCRIPTION
## Summary
- switch Cua Driver and Lume installer/helper URLs to `cua.ai/driver` and `cua.ai/lume`
- update docs, generated install snippets, updater messages, and release notes
- add a daily endpoint monitor that opens or updates a GitHub issue when branded installer paths fail

## Dependency
This PR expects the matching ingress rewrites in `trycua/ingress` to land first or alongside it.

## Validation
- `bash -n` passed for shell installers
- `git diff --check` passed
