### PR TITLE
test(cua-driver): record E2E trajectory videos

### DIFF
--- a/.github/workflows/e2e-rust-linux.yml
+++ b/.github/workflows/e2e-rust-linux.yml
@@ -36,7 +36,7 @@ jobs:
             libgtk-3-dev clang pkg-config libdbus-1-dev libpipewire-0.3-dev \
             libspa-0.2-dev libei-dev libx11-dev libxi-dev libxtst-dev libxext-dev \
             libwebkit2gtk-4.1-dev libssl-dev libxdo-dev \
-            libayatana-appindicator3-dev librsvg2-dev
+            libayatana-appindicator3-dev librsvg2-dev ffmpeg
       - name: Run shared Rust behavior matrix
         run: |
           xvfb-run -a --server-args="-screen 0 1920x1080x24" \
@@ -49,6 +49,8 @@ jobs:
           name: rust-linux-shared
           path: artifacts/cua-driver/linux
           if-no-files-found: ignore
+          compression-level: 0
+          retention-days: 14
 
   modality:
     if: inputs.suite == 'modality' || inputs.suite == 'all'
@@ -68,7 +70,7 @@ jobs:
             libgtk-3-dev clang pkg-config libdbus-1-dev libpipewire-0.3-dev \
             libspa-0.2-dev libei-dev libx11-dev libxi-dev libxtst-dev libxext-dev \
             libwebkit2gtk-4.1-dev libssl-dev libxdo-dev \
-            libayatana-appindicator3-dev librsvg2-dev
+            libayatana-appindicator3-dev librsvg2-dev ffmpeg
       - name: Run modality Rust matrix
         run: |
           xvfb-run -a --server-args="-screen 0 1920x1080x24" \
@@ -81,6 +83,8 @@ jobs:
           name: rust-linux-modality
           path: artifacts/cua-driver/linux
           if-no-files-found: ignore
+          compression-level: 0
+          retention-days: 14
 
   summary:
     if: always()

--- a/.github/workflows/e2e-rust-windows.yml
+++ b/.github/workflows/e2e-rust-windows.yml
@@ -31,6 +31,14 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref }}
+      - name: Ensure FFmpeg for trajectory video
+        shell: pwsh
+        run: |
+          if (-not (Get-Command ffmpeg.exe -ErrorAction SilentlyContinue)) {
+            choco install ffmpeg -y --no-progress
+          }
+          ffmpeg -version
+          ffprobe -version
       - name: Run default Rust tests
         shell: pwsh
         run: .\scripts\ci\windows\run-rust-e2e.ps1 -Suite default -RequireGui
@@ -45,6 +53,8 @@ jobs:
           name: rust-windows-default
           path: artifacts/cua-driver/windows
           if-no-files-found: ignore
+          compression-level: 0
+          retention-days: 14
 
   guard:
     if: inputs.suite == 'guard' || inputs.suite == 'all'
@@ -55,6 +65,14 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref }}
+      - name: Ensure FFmpeg for trajectory video
+        shell: pwsh
+        run: |
+          if (-not (Get-Command ffmpeg.exe -ErrorAction SilentlyContinue)) {
+            choco install ffmpeg -y --no-progress
+          }
+          ffmpeg -version
+          ffprobe -version
       - name: Run UX guard tests
         shell: pwsh
         run: .\scripts\ci\windows\run-rust-e2e.ps1 -Suite guard -RequireGui
@@ -69,6 +87,8 @@ jobs:
           name: rust-windows-guard
           path: artifacts/cua-driver/windows
           if-no-files-found: ignore
+          compression-level: 0
+          retention-days: 14
 
   shared:
     if: inputs.suite == 'shared' || inputs.suite == 'all'
@@ -79,6 +99,14 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref }}
+      - name: Ensure FFmpeg for trajectory video
+        shell: pwsh
+        run: |
+          if (-not (Get-Command ffmpeg.exe -ErrorAction SilentlyContinue)) {
+            choco install ffmpeg -y --no-progress
+          }
+          ffmpeg -version
+          ffprobe -version
       - name: Run shared Rust behavior matrix
         shell: pwsh
         run: .\scripts\ci\windows\run-rust-e2e.ps1 -Suite shared -RequireGui
@@ -93,6 +121,8 @@ jobs:
           name: rust-windows-shared
           path: artifacts/cua-driver/windows
           if-no-files-found: ignore
+          compression-level: 0
+          retention-days: 14
 
   native:
     if: inputs.suite == 'native' || inputs.suite == 'all'
@@ -103,6 +133,14 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref }}
+      - name: Ensure FFmpeg for trajectory video
+        shell: pwsh
+        run: |
+          if (-not (Get-Command ffmpeg.exe -ErrorAction SilentlyContinue)) {
+            choco install ffmpeg -y --no-progress
+          }
+          ffmpeg -version
+          ffprobe -version
       - name: Run native Rust harnesses
         shell: pwsh
         run: .\scripts\ci\windows\run-rust-e2e.ps1 -Suite native -RequireGui
@@ -117,6 +155,8 @@ jobs:
           name: rust-windows-native
           path: artifacts/cua-driver/windows
           if-no-files-found: ignore
+          compression-level: 0
+          retention-days: 14
 
   modality:
     if: inputs.suite == 'modality' || inputs.suite == 'all'
@@ -127,6 +167,14 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref }}
+      - name: Ensure FFmpeg for trajectory video
+        shell: pwsh
+        run: |
+          if (-not (Get-Command ffmpeg.exe -ErrorAction SilentlyContinue)) {
+            choco install ffmpeg -y --no-progress
+          }
+          ffmpeg -version
+          ffprobe -version
       - name: Run modality input E2E
         shell: pwsh
         run: .\scripts\ci\windows\run-rust-e2e.ps1 -Suite modality -RequireGui
@@ -141,6 +189,8 @@ jobs:
           name: rust-windows-modality
           path: artifacts/cua-driver/windows
           if-no-files-found: ignore
+          compression-level: 0
+          retention-days: 14
 
   summary:
     if: always()

--- a/libs/cua-driver/rust/crates/cua-driver-testkit/src/mcp.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-testkit/src/mcp.rs
@@ -1,7 +1,9 @@
 //! MCP transport: one long-lived `cua-driver` server over stdio JSON-RPC.
 
 use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
 use std::process::{ChildStdin, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{channel, Receiver};
 use std::time::{Duration, Instant};
 
@@ -24,18 +26,30 @@ pub struct McpDriver {
     stdin: ChildStdin,
     rx: Receiver<String>,
     next_id: u32,
+    recording_dir: Option<PathBuf>,
 }
+
+static RECORDING_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 
 impl McpDriver {
     /// Spawn the driver, start the stdout reader thread, and `initialize`.
     /// Returns `None` (with a skip message) if the binary isn't built — the
     /// caller's test should early-return so an un-built binary skips, not fails.
     pub fn spawn() -> Option<Self> {
-        Self::spawn_with_env(&[])
+        Self::spawn_internal(&[], None)
+    }
+
+    /// Spawn the driver with a stable recording label for artifact naming.
+    pub fn spawn_named(recording_label: &str) -> Option<Self> {
+        Self::spawn_internal(&[], Some(recording_label))
     }
 
     /// Spawn the driver with extra environment variables set on the child.
     pub fn spawn_with_env(env: &[(&str, &str)]) -> Option<Self> {
+        Self::spawn_internal(env, None)
+    }
+
+    fn spawn_internal(env: &[(&str, &str)], recording_label: Option<&str>) -> Option<Self> {
         let bin = driver_binary();
         if !bin.exists() {
             eprintln!("[testkit] driver binary not built at {bin:?} — skipping");
@@ -79,8 +93,10 @@ impl McpDriver {
             stdin,
             rx,
             next_id: 2,
+            recording_dir: None,
         };
         d.initialize();
+        d.start_e2e_recording(recording_label);
         Some(d)
     }
 
@@ -93,6 +109,17 @@ impl McpDriver {
     /// already-running daemon and skip with a clear note when it is absent.
     #[cfg(target_os = "macos")]
     pub fn spawn_macos_daemon_proxy() -> Option<Self> {
+        Self::spawn_macos_daemon_proxy_internal(None)
+    }
+
+    /// macOS daemon-proxy variant with a stable recording artifact label.
+    #[cfg(target_os = "macos")]
+    pub fn spawn_macos_daemon_proxy_named(recording_label: &str) -> Option<Self> {
+        Self::spawn_macos_daemon_proxy_internal(Some(recording_label))
+    }
+
+    #[cfg(target_os = "macos")]
+    fn spawn_macos_daemon_proxy_internal(recording_label: Option<&str>) -> Option<Self> {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
         let socket = format!("{home}/Library/Caches/cua-driver/cua-driver.sock");
         if std::os::unix::net::UnixStream::connect(&socket).is_err() {
@@ -102,7 +129,7 @@ impl McpDriver {
             );
             return None;
         }
-        Self::spawn_with_env(&[("CUA_DRIVER_RS_MCP_FORCE_PROXY", "1")])
+        Self::spawn_internal(&[("CUA_DRIVER_RS_MCP_FORCE_PROXY", "1")], recording_label)
     }
 
     fn initialize(&mut self) {
@@ -115,6 +142,75 @@ impl McpDriver {
     fn send(&mut self, req: Value) {
         let _ = writeln!(self.stdin, "{}", serde_json::to_string(&req).unwrap());
         let _ = self.stdin.flush();
+    }
+
+    fn start_e2e_recording(&mut self, explicit_label: Option<&str>) {
+        let Some(root) = std::env::var_os("CUA_E2E_RECORDINGS_ROOT") else {
+            return;
+        };
+        let sequence = RECORDING_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let thread_name = std::thread::current()
+            .name()
+            .unwrap_or("unnamed-test")
+            .to_owned();
+        let label = recording_label(explicit_label.unwrap_or(&thread_name));
+        let output_dir =
+            PathBuf::from(root).join(format!("{label}-pid{}-{sequence:03}", std::process::id()));
+        let response = self.call(
+            "start_recording",
+            serde_json::json!({
+                "output_dir": output_dir.to_string_lossy(),
+                "record_video": true
+            }),
+        );
+        let video_active = response.structured()["video_active"]
+            .as_bool()
+            .unwrap_or(false);
+        if response.is_error() || !video_active {
+            panic!(
+                "E2E video recording did not start for {thread_name}: {}",
+                response.text()
+            );
+        }
+        let manifest = serde_json::json!({
+            "schema": "cua-e2e-trajectory/v1",
+            "label": label,
+            "rust_test_thread": thread_name,
+            "process_id": std::process::id(),
+            "sequence": sequence
+        });
+        let _ = std::fs::write(
+            output_dir.join("trajectory.json"),
+            serde_json::to_vec_pretty(&manifest).unwrap_or_default(),
+        );
+        eprintln!("[testkit] recording E2E video to {}", output_dir.display());
+        self.recording_dir = Some(output_dir);
+    }
+
+    fn stop_e2e_recording(&mut self) {
+        let Some(output_dir) = self.recording_dir.take() else {
+            return;
+        };
+        let response = self.call("stop_recording", serde_json::json!({}));
+        let video_path = output_dir.join("recording.mp4");
+        let valid_video = !response.is_error()
+            && response.structured()["last_video_path"].as_str().is_some()
+            && std::fs::metadata(&video_path)
+                .map(|metadata| metadata.len() > 0)
+                .unwrap_or(false);
+        if valid_video {
+            eprintln!("[testkit] finalized E2E video at {}", video_path.display());
+            return;
+        }
+
+        let message = format!(
+            "E2E video failed to finalize at {}: {}",
+            video_path.display(),
+            response.text()
+        );
+        eprintln!("[testkit] {message}");
+        let _ = std::fs::create_dir_all(&output_dir);
+        let _ = std::fs::write(output_dir.join("recording-error.txt"), message);
     }
 
     /// Mutable access to the child reaper, e.g. to launch a target app whose
@@ -163,6 +259,45 @@ impl McpDriver {
                 "error": format!("TIMEOUT (>{}s) on {tool}", CALL_TIMEOUT.as_secs())
             }),
         }
+    }
+}
+
+impl Drop for McpDriver {
+    fn drop(&mut self) {
+        self.stop_e2e_recording();
+    }
+}
+
+fn recording_label(name: &str) -> String {
+    let label: String = name
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.') {
+                character
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let label = label.trim_matches('-');
+    if label.is_empty() {
+        "unnamed-test".to_owned()
+    } else {
+        label.chars().take(96).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::recording_label;
+
+    #[test]
+    fn recording_label_is_artifact_safe() {
+        assert_eq!(
+            recording_label("module::test name/windows"),
+            "module--test-name-windows"
+        );
+        assert_eq!(recording_label("///"), "unnamed-test");
     }
 }
 

--- a/libs/cua-driver/rust/crates/cua-driver/tests/README.md
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/README.md
@@ -41,6 +41,14 @@ against Electron and Tauri on each supported host. CI and VM runners set
 workspace paths. They also set `CUA_TEST_REQUIRE_FIXTURES=1`, turning a missing
 fixture into a failure instead of a silent skip.
 
+The canonical Windows and Linux runners also set
+`CUA_E2E_RECORDINGS_ROOT`. Every testkit `McpDriver` then records its full
+desktop trajectory to a unique directory containing `recording.mp4`, cursor
+samples, action JSON, per-turn screenshots, and a `trajectory.json` test-label
+manifest. Windows and Linux require
+FFmpeg; macOS uses the installed driver's ScreenCaptureKit backend. The runner
+validates each MP4 with `ffprobe` before reporting success.
+
 ## Running
 
 ```bash

--- a/libs/cua-driver/rust/crates/cua-driver/tests/cross_platform_behavior_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/cross_platform_behavior_test.rs
@@ -174,7 +174,7 @@ where
 {
     let started = Instant::now();
     let outcome = panic::catch_unwind(AssertUnwindSafe(|| {
-        let Some(fixture) = launch_host(spec) else {
+        let Some(fixture) = launch_host(spec, scenario) else {
             return false;
         };
         test(fixture);
@@ -209,14 +209,14 @@ fn resume_first_failure(failure: Option<Box<dyn Any + Send>>) {
     }
 }
 
-fn spawn_driver() -> Option<McpDriver> {
+fn spawn_driver(recording_label: &str) -> Option<McpDriver> {
     #[cfg(target_os = "macos")]
     {
-        return McpDriver::spawn_macos_daemon_proxy();
+        return McpDriver::spawn_macos_daemon_proxy_named(recording_label);
     }
     #[cfg(not(target_os = "macos"))]
     {
-        McpDriver::spawn()
+        McpDriver::spawn_named(recording_label)
     }
 }
 
@@ -229,7 +229,7 @@ struct Fixture {
     name: &'static str,
 }
 
-fn launch_host(spec: &HostSpec) -> Option<Fixture> {
+fn launch_host(spec: &HostSpec, scenario: &str) -> Option<Fixture> {
     if !spec.path.exists() {
         if std::env::var_os("CUA_TEST_REQUIRE_FIXTURES").is_some() {
             panic!(
@@ -244,7 +244,8 @@ fn launch_host(spec: &HostSpec) -> Option<Fixture> {
         return None;
     }
 
-    let Some(mut driver) = spawn_driver() else {
+    let recording_label = format!("{scenario}-{}", spec.name);
+    let Some(mut driver) = spawn_driver(&recording_label) else {
         if std::env::var_os("CUA_TEST_REQUIRE_FIXTURES").is_some() {
             panic!(
                 "cua-driver could not be started for the required {} fixture",

--- a/scripts/ci/linux/run-rust-e2e.sh
+++ b/scripts/ci/linux/run-rust-e2e.sh
@@ -35,6 +35,9 @@ case "$SUITE" in
 esac
 
 mkdir -p "${REPO_ROOT}/artifacts/cua-driver/linux"
+RECORDING_ROOT="${REPO_ROOT}/artifacts/cua-driver/linux/recordings"
+rm -rf "${RECORDING_ROOT}"
+mkdir -p "${RECORDING_ROOT}"
 RESULTS_FILE="${REPO_ROOT}/artifacts/cua-driver/linux/results.jsonl"
 SUMMARY_FILE="${REPO_ROOT}/artifacts/cua-driver/linux/summary.md"
 : > "${RESULTS_FILE}"
@@ -46,11 +49,15 @@ cat > "${SUMMARY_FILE}" <<'EOF'
 EOF
 export CUA_E2E_RESULTS_FILE="${RESULTS_FILE}"
 export CUA_E2E_SUMMARY_FILE="${SUMMARY_FILE}"
+export CUA_E2E_RECORDINGS_ROOT="${RECORDING_ROOT}"
 export CUA_TEST_WORKSPACE_ROOT="${RUST_ROOT}"
 export CUA_TEST_DRIVER_BIN="${RUST_ROOT}/target/release/cua-driver"
 export CUA_TEST_APPS_ROOT="${RUST_ROOT}/test-apps"
 export CUA_TEST_REQUIRE_FIXTURES=1
 export CUA_TEST_DRIVER_STDERR=1
+
+command -v ffmpeg >/dev/null || { echo "ffmpeg is required for E2E trajectory videos" >&2; exit 1; }
+command -v ffprobe >/dev/null || { echo "ffprobe is required for E2E trajectory validation" >&2; exit 1; }
 
 if [[ "${BUILD_FIXTURES}" == 1 ]]; then
   cargo build --release -p cua-driver --manifest-path "${RUST_ROOT}/Cargo.toml"
@@ -103,6 +110,29 @@ if [[ "${SUITE}" == modality || "${SUITE}" == all ]]; then
   run_test modality-desktop-scope \
     cargo test -p cua-driver --test modality_desktop_scope_linux_test -- \
       --ignored --nocapture --test-threads=1
+fi
+
+video_count=0
+while IFS= read -r -d '' video; do
+  video_count=$((video_count + 1))
+  if ! ffprobe -v error -show_entries format=duration \
+      -of default=noprint_wrappers=1:nokey=1 "${video}" >/dev/null; then
+    echo "[VIDEO FAIL] Unplayable trajectory: ${video}" >&2
+    FAILURE_COUNT=$((FAILURE_COUNT + 1))
+  else
+    echo "[VIDEO PASS] ${video}"
+  fi
+done < <(find "${RECORDING_ROOT}" -type f -name recording.mp4 -print0)
+
+while IFS= read -r -d '' recording_error; do
+  echo "[VIDEO FAIL] ${recording_error}" >&2
+  cat "${recording_error}" >&2
+  FAILURE_COUNT=$((FAILURE_COUNT + 1))
+done < <(find "${RECORDING_ROOT}" -type f -name recording-error.txt -print0)
+
+if [[ "${video_count}" == 0 ]]; then
+  echo "[VIDEO FAIL] No E2E trajectory videos were produced" >&2
+  FAILURE_COUNT=$((FAILURE_COUNT + 1))
 fi
 
 if [[ "${FAILURE_COUNT}" != 0 ]]; then

--- a/scripts/ci/windows/run-rust-e2e.ps1
+++ b/scripts/ci/windows/run-rust-e2e.ps1
@@ -16,6 +16,9 @@ $driverRoot = Join-Path $repoRoot "libs\cua-driver"
 $rustRoot = Join-Path $driverRoot "rust"
 $artifactDir = Join-Path $repoRoot "artifacts\cua-driver\windows"
 New-Item -ItemType Directory -Force $artifactDir | Out-Null
+$recordingRoot = Join-Path $artifactDir "recordings"
+Remove-Item -Path $recordingRoot -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force $recordingRoot | Out-Null
 $resultsPath = Join-Path $artifactDir "results.jsonl"
 $summaryPath = Join-Path $artifactDir "summary.md"
 @(
@@ -27,6 +30,13 @@ $summaryPath = Join-Path $artifactDir "summary.md"
 Remove-Item -Force -ErrorAction SilentlyContinue $resultsPath
 $env:CUA_E2E_RESULTS_FILE = $resultsPath
 $env:CUA_E2E_SUMMARY_FILE = $summaryPath
+$env:CUA_E2E_RECORDINGS_ROOT = $recordingRoot
+
+$ffmpeg = Get-Command ffmpeg.exe -ErrorAction SilentlyContinue
+$ffprobe = Get-Command ffprobe.exe -ErrorAction SilentlyContinue
+if ($null -eq $ffmpeg -or $null -eq $ffprobe) {
+    throw "FFmpeg and ffprobe are required for E2E trajectory videos"
+}
 
 & (Join-Path $scriptDir "verify-user-session.ps1")
 if ($RequireGui) { $env:CUA_REQUIRE_GUI = "1" }
@@ -113,6 +123,32 @@ function Invoke-CargoTest {
     }
 }
 
+function Test-E2eRecordings {
+    $failureCount = 0
+    $errors = @(Get-ChildItem -Path $recordingRoot -Filter "recording-error.txt" -Recurse -ErrorAction SilentlyContinue)
+    foreach ($errorFile in $errors) {
+        Write-Host "[VIDEO FAIL] $($errorFile.FullName)" -ForegroundColor Red
+        Get-Content $errorFile.FullName | Write-Host
+        $failureCount++
+    }
+
+    $videos = @(Get-ChildItem -Path $recordingRoot -Filter "recording.mp4" -Recurse -ErrorAction SilentlyContinue)
+    if ($videos.Count -eq 0) {
+        Write-Host "[VIDEO FAIL] No E2E trajectory videos were produced" -ForegroundColor Red
+        return ($failureCount + 1)
+    }
+    foreach ($video in $videos) {
+        & $ffprobe.Source -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 $video.FullName | Out-Null
+        if ($LASTEXITCODE -ne 0 -or $video.Length -eq 0) {
+            Write-Host "[VIDEO FAIL] Unplayable trajectory: $($video.FullName)" -ForegroundColor Red
+            $failureCount++
+        } else {
+            Write-Host "[VIDEO PASS] $($video.FullName)" -ForegroundColor Green
+        }
+    }
+    return $failureCount
+}
+
 $script:FailureCount = 0
 
 if ($Suite -in @("shared", "all")) {
@@ -157,6 +193,8 @@ if ($Suite -in @("modality", "all")) {
         "--ignored", "--nocapture", "--test-threads=1"
     )
 }
+
+$script:FailureCount += (Test-E2eRecordings)
 
 if ($script:FailureCount -ne 0) {
     throw "Windows Rust e2e suite had $($script:FailureCount) failing lane(s)"


### PR DESCRIPTION
## Summary

- automatically record every canonical Rust E2E `McpDriver` session
- finalize and validate every MP4, including during test unwinding
- label shared Electron/Tauri trajectories and include `trajectory.json` metadata
- upload Windows and Linux recordings with their existing lane artifacts
- retain video artifacts for 14 days without redundant compression

## Validation

- `cargo test -p cua-driver-testkit`
- `cargo test -p cua-driver --test cross_platform_behavior_test --no-run`
- YAML parse and Bash syntax checks
- macOS Electron + Tauri calculator smoke: 2/2 passed; both MP4s validated and sampled visually
- [Windows full matrix](https://github.com/trycua/cua/actions/runs/29112136116): 58/58 MP4s passed ffprobe and 58/58 include trajectory metadata

## Windows trajectory counts

| Lane | Videos |
| --- | ---: |
| default | 6 |
| guard | 6 |
| shared Electron + Tauri | 10 |
| native WPF + WinUI3 + WebView2 | 30 |
| modality | 6 |

The run remains red for pre-existing driver/harness assertions (`zoom_tool_returns_jpeg`, modality key-combo/sentinel, and WebView2 marker lookup). Recording startup, finalization, validation, and artifact upload all succeeded.