### PR TITLE
docs: use branded lume installer URL

### DIFF
--- a/docs/content/docs/how-to-guides/lume/serve-api.mdx
+++ b/docs/content/docs/how-to-guides/lume/serve-api.mdx
@@ -40,7 +40,7 @@ The standard installer starts Lume's background service at login. Install with
 `--no-background-service` when you want to manage the API process yourself:
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/lume/scripts/install.sh) --no-background-service"
+/bin/bash -c "$(curl -fsSL https://cua.ai/lume/install.sh) --no-background-service"
 ```
 
 After that installation, start the server explicitly with `lume serve`.

--- a/docs/content/docs/tutorials/create-your-first-lume-vm.mdx
+++ b/docs/content/docs/tutorials/create-your-first-lume-vm.mdx
@@ -18,7 +18,7 @@ download and VM disk space.
 Run the installer:
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/lume/scripts/install.sh)"
+/bin/bash -c "$(curl -fsSL https://cua.ai/lume/install.sh)"
 ```
 
 Check the installed version:


### PR DESCRIPTION
## Summary
- update the Lume API guide to use `https://cua.ai/lume/install.sh`
- update the first Lume VM tutorial to use the branded installer

The Driver docs were updated in #2152; this closes the remaining raw GitHub installer references in the docs.
