### PR TITLE
fix(cua-driver): target page JavaScript exactly

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-core/src/cdp.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/cdp.rs
@@ -25,7 +25,19 @@ pub async fn evaluate(
     expression: &str,
     await_promise: bool,
 ) -> anyhow::Result<String> {
-    let response = cdp_evaluate(port, expression, await_promise).await?;
+    evaluate_targeted(port, expression, await_promise, None).await
+}
+
+/// Evaluate `expression` in the unique page whose URL contains
+/// `target_url_contains`. When no hint is supplied, preserves the legacy
+/// first-page behavior.
+pub async fn evaluate_targeted(
+    port: u16,
+    expression: &str,
+    await_promise: bool,
+    target_url_contains: Option<&str>,
+) -> anyhow::Result<String> {
+    let response = cdp_evaluate(port, expression, await_promise, target_url_contains).await?;
     Ok(format_cdp_result(&response))
 }
 
@@ -35,6 +47,7 @@ async fn cdp_evaluate(
     port: u16,
     expression: &str,
     await_promise: bool,
+    target_url_contains: Option<&str>,
 ) -> anyhow::Result<Value> {
     // Wrap the /json discovery in its own timeout — `cdp_list_pages` does an
     // unbounded `read_to_end`, and a half-open localhost socket (browser
@@ -50,7 +63,14 @@ async fn cdp_evaluate(
         anyhow::bail!("No CDP page tabs found on port {port}");
     }
 
-    let ws_url = pages[0]
+    let page = pick_page(&pages, target_url_contains)
+        .ok_or_else(|| match target_url_contains {
+            Some(hint) => anyhow::anyhow!(
+                "No unique CDP page URL contains {hint:?} on port {port}"
+            ),
+            None => anyhow::anyhow!("No CDP page tabs found on port {port}"),
+        })?;
+    let ws_url = page
         .get("webSocketDebuggerUrl")
         .and_then(|u| u.as_str())
         .ok_or_else(|| anyhow::anyhow!("Page has no webSocketDebuggerUrl"))?
@@ -72,6 +92,25 @@ async fn cdp_evaluate(
     )
     .await
     .map_err(|_| anyhow::anyhow!("CDP evaluate timed out after 30 s"))?
+}
+
+fn pick_page<'a>(pages: &'a [Value], hint: Option<&str>) -> Option<&'a Value> {
+    match hint {
+        None => pages.first(),
+        Some(hint) => {
+            let hint_lower = hint.to_ascii_lowercase();
+            let mut matches = pages.iter().filter(|page| {
+                page.get("url")
+                    .and_then(Value::as_str)
+                    .is_some_and(|url| url.to_ascii_lowercase().contains(&hint_lower))
+            });
+            let page = matches.next()?;
+            if matches.next().is_some() {
+                return None;
+            }
+            Some(page)
+        }
+    }
 }
 
 fn format_cdp_result(response: &Value) -> String {
@@ -370,5 +409,40 @@ fn encode_len_masked(buf: &mut Vec<u8>, len: usize) {
         for i in (0..8).rev() {
             buf.push((len >> (i * 8)) as u8);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pick_page;
+    use serde_json::json;
+
+    fn pages() -> Vec<serde_json::Value> {
+        vec![
+            json!({ "url": "app://fixture/#window-a", "webSocketDebuggerUrl": "ws://a" }),
+            json!({ "url": "app://fixture/#window-b", "webSocketDebuggerUrl": "ws://b" }),
+        ]
+    }
+
+    #[test]
+    fn targeted_page_selection_is_unique_and_case_insensitive() {
+        let pages = pages();
+        assert_eq!(
+            pick_page(&pages, Some("#WINDOW-B"))
+                .and_then(|page| page["webSocketDebuggerUrl"].as_str()),
+            Some("ws://b")
+        );
+        assert!(pick_page(&pages, Some("#missing")).is_none());
+        assert!(pick_page(&pages, Some("app://fixture/")).is_none());
+    }
+
+    #[test]
+    fn omitted_page_hint_preserves_first_page_behavior() {
+        let pages = pages();
+        assert_eq!(
+            pick_page(&pages, None)
+                .and_then(|page| page["webSocketDebuggerUrl"].as_str()),
+            Some("ws://a")
+        );
     }
 }

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/page.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/page.rs
@@ -72,6 +72,27 @@ pub trait PageBackend: Send + Sync {
         javascript: &str,
     ) -> anyhow::Result<String>;
 
+    /// Evaluate `javascript` against an explicitly selected CDP page.
+    ///
+    /// Backends that do not expose per-page CDP routing keep their legacy
+    /// behavior only when no explicit target was requested. A supplied port
+    /// or URL hint must never be silently ignored.
+    async fn execute_javascript_targeted(
+        &self,
+        pid: i32,
+        window_id: u32,
+        javascript: &str,
+        cdp_port: Option<u16>,
+        target_url_contains: Option<&str>,
+    ) -> anyhow::Result<String> {
+        if cdp_port.is_some() || target_url_contains.is_some() {
+            anyhow::bail!(
+                "targeted execute_javascript is not implemented on this platform's page backend"
+            );
+        }
+        self.execute_javascript(pid, window_id, javascript).await
+    }
+
     /// Whether this backend can execute JS at all.  False → the tool short-
     /// circuits with a "not supported here" error; true → the backend may
     /// still return an error at call time (e.g. CDP port not reachable).
@@ -251,11 +272,13 @@ fn def() -> &'static ToolDef {
                 },
                 "cdp_port": {
                     "type": "integer",
-                    "description": "Optional, for insert_text/type_keystrokes only: use this exact CDP port instead of auto-discovering one from pid. Needed when the port was opened via the browser's own remote-debugging toggle rather than a launch-time flag, since that path may not answer the auto-discovery probe."
+                    "minimum": 1,
+                    "maximum": 65535,
+                    "description": "Optional, for execute_javascript/insert_text/type_keystrokes: use this exact CDP port instead of auto-discovering one from pid. Needed when the port was opened via the browser's own remote-debugging toggle rather than a launch-time flag, since that path may not answer the auto-discovery probe."
                 },
                 "target_url_contains": {
                     "type": "string",
-                    "description": "Optional, for insert_text/type_keystrokes only: pick the browser tab whose URL contains this substring instead of whichever tab is found first. Use this on a multi-tab browser — there's no built-in link between window_id and which tab a CDP call reaches."
+                    "description": "Optional, for execute_javascript/insert_text/type_keystrokes: require exactly one browser tab whose URL contains this substring. Use this on a multi-tab browser — there's no built-in link between window_id and which tab a CDP call reaches."
                 },
                 "javascript": {
                     "type": "string",
@@ -374,7 +397,23 @@ impl Tool for PageTool {
                     Some(v) => v.to_owned(),
                     None => return ToolResult::error("Missing required parameter: javascript"),
                 };
-                match self.backend.execute_javascript(pid, window_id, &js).await {
+                let cdp_port = match optional_cdp_port(&args) {
+                    Ok(value) => value,
+                    Err(error) => return ToolResult::error(error),
+                };
+                let target_url_contains =
+                    args.get("target_url_contains").and_then(|v| v.as_str());
+                match self
+                    .backend
+                    .execute_javascript_targeted(
+                        pid,
+                        window_id,
+                        &js,
+                        cdp_port,
+                        target_url_contains,
+                    )
+                    .await
+                {
                     Ok(result) => ToolResult::text(result),
                     Err(e) => ToolResult::error(format!("{e}")),
                 }
@@ -420,7 +459,10 @@ impl Tool for PageTool {
                     Some(v) => v.to_owned(),
                     None => return ToolResult::error("Missing required parameter: text"),
                 };
-                let cdp_port = args.get("cdp_port").and_then(|v| v.as_u64()).map(|v| v as u16);
+                let cdp_port = match optional_cdp_port(&args) {
+                    Ok(value) => value,
+                    Err(error) => return ToolResult::error(error),
+                };
                 let target_url_contains = args.get("target_url_contains").and_then(|v| v.as_str());
                 match self.backend.insert_text(pid, window_id, &text, cdp_port, target_url_contains).await {
                     Ok(msg) => ToolResult::text(msg),
@@ -433,7 +475,10 @@ impl Tool for PageTool {
                     Some(v) => v.to_owned(),
                     None => return ToolResult::error("Missing required parameter: text"),
                 };
-                let cdp_port = args.get("cdp_port").and_then(|v| v.as_u64()).map(|v| v as u16);
+                let cdp_port = match optional_cdp_port(&args) {
+                    Ok(value) => value,
+                    Err(error) => return ToolResult::error(error),
+                };
                 let target_url_contains = args.get("target_url_contains").and_then(|v| v.as_str());
                 match self.backend.type_keystrokes(pid, window_id, &text, cdp_port, target_url_contains).await {
                     Ok(msg) => ToolResult::text(msg),
@@ -468,5 +513,139 @@ impl Tool for PageTool {
 
             other => ToolResult::error(format!("Unknown action: {other}")),
         }
+    }
+}
+
+fn optional_cdp_port(args: &Value) -> Result<Option<u16>, String> {
+    let Some(value) = args.get("cdp_port") else {
+        return Ok(None);
+    };
+    let raw = value
+        .as_u64()
+        .ok_or_else(|| "Invalid parameter: cdp_port must be an integer from 1 to 65535".to_owned())?;
+    let port = u16::try_from(raw)
+        .ok()
+        .filter(|port| *port > 0)
+        .ok_or_else(|| format!("Invalid parameter: cdp_port {raw} outside 1..=65535"))?;
+    Ok(Some(port))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    type TargetedCall = (i32, u32, String, Option<u16>, Option<String>);
+
+    #[derive(Default)]
+    struct RecordingBackend {
+        targeted: Mutex<Option<TargetedCall>>,
+    }
+
+    #[async_trait]
+    impl PageBackend for RecordingBackend {
+        async fn get_text(&self, _pid: i32, _window_id: u32) -> anyhow::Result<String> {
+            Ok(String::new())
+        }
+
+        async fn query_dom(
+            &self,
+            _pid: i32,
+            _window_id: u32,
+            _css_selector: &str,
+            _attributes: &[String],
+        ) -> anyhow::Result<String> {
+            Ok(String::new())
+        }
+
+        async fn execute_javascript(
+            &self,
+            _pid: i32,
+            _window_id: u32,
+            _javascript: &str,
+        ) -> anyhow::Result<String> {
+            anyhow::bail!("untargeted execute must not be used")
+        }
+
+        async fn execute_javascript_targeted(
+            &self,
+            pid: i32,
+            window_id: u32,
+            javascript: &str,
+            cdp_port: Option<u16>,
+            target_url_contains: Option<&str>,
+        ) -> anyhow::Result<String> {
+            *self.targeted.lock().unwrap() = Some((
+                pid,
+                window_id,
+                javascript.to_owned(),
+                cdp_port,
+                target_url_contains.map(str::to_owned),
+            ));
+            Ok("targeted".to_owned())
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_javascript_forwards_explicit_page_target() {
+        let backend = Arc::new(RecordingBackend::default());
+        let tool = PageTool::new(backend.clone());
+
+        let result = tool
+            .invoke(serde_json::json!({
+                "pid": 42,
+                "window_id": 7,
+                "action": "execute_javascript",
+                "javascript": "document.title",
+                "cdp_port": 9333,
+                "target_url_contains": "#window-b"
+            }))
+            .await;
+
+        assert!(result.is_error.is_none());
+        assert_eq!(
+            *backend.targeted.lock().unwrap(),
+            Some((
+                42,
+                7,
+                "document.title".to_owned(),
+                Some(9333),
+                Some("#window-b".to_owned()),
+            ))
+        );
+    }
+
+    #[test]
+    fn schema_advertises_targeted_execute_javascript() {
+        let schema = &def().input_schema["properties"];
+        assert_eq!(schema["cdp_port"]["minimum"], 1);
+        assert_eq!(schema["cdp_port"]["maximum"], 65535);
+        assert!(schema["cdp_port"]["description"]
+            .as_str()
+            .unwrap()
+            .contains("execute_javascript"));
+        assert!(schema["target_url_contains"]["description"]
+            .as_str()
+            .unwrap()
+            .contains("exactly one"));
+    }
+
+    #[tokio::test]
+    async fn rejects_out_of_range_cdp_port_before_dispatch() {
+        let backend = Arc::new(RecordingBackend::default());
+        let tool = PageTool::new(backend.clone());
+
+        let result = tool
+            .invoke(serde_json::json!({
+                "pid": 42,
+                "window_id": 7,
+                "action": "execute_javascript",
+                "javascript": "document.title",
+                "cdp_port": 65536
+            }))
+            .await;
+
+        assert_eq!(result.is_error, Some(true));
+        assert!(backend.targeted.lock().unwrap().is_none());
     }
 }

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/page.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/page.rs
@@ -127,6 +127,33 @@ impl PageBackend for LinuxPageBackend {
         let result = cua_driver_core::cdp::evaluate(port, javascript, true).await?;
         Ok(format!("cdp.runtime.evaluate.user_gesture: {result}"))
     }
+
+    async fn execute_javascript_targeted(
+        &self,
+        pid: i32,
+        window_id: u32,
+        javascript: &str,
+        cdp_port: Option<u16>,
+        target_url_contains: Option<&str>,
+    ) -> anyhow::Result<String> {
+        if cdp_port.is_none() && target_url_contains.is_none() {
+            return self.execute_javascript(pid, window_id, javascript).await;
+        }
+        let port = cdp_port.or_else(|| {
+            std::env::var("CUA_DRIVER_CDP_PORT")
+                .ok()
+                .and_then(|value| value.parse::<u16>().ok())
+        }).ok_or_else(|| anyhow::anyhow!(
+            "targeted execute_javascript on Linux requires cdp_port or CUA_DRIVER_CDP_PORT"
+        ))?;
+        let result = cua_driver_core::cdp::evaluate_targeted(
+            port,
+            javascript,
+            true,
+            target_url_contains,
+        ).await?;
+        Ok(format!("cdp.runtime.evaluate.user_gesture: {result}"))
+    }
 }
 
 /// Map common CSS selectors to AT-SPI role names. Returns `None` for `*` or

--- a/libs/cua-driver/rust/crates/platform-macos/src/browser/cdp_client.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/browser/cdp_client.rs
@@ -67,7 +67,18 @@ impl CdpClient {
     /// "Allow remote debugging?" confirmation the Chrome-toggle path does,
     /// so there's no reason to route it through `CdpSessionCache`.
     pub async fn evaluate(javascript: &str, port: u16) -> anyhow::Result<String> {
-        let mut session = CdpSession::connect(port, None).await?;
+        Self::evaluate_targeted(javascript, port, None).await
+    }
+
+    /// Evaluate JavaScript against the unique page target selected by
+    /// `target_url_contains`. An explicit hint never falls back to another
+    /// page when it is absent or ambiguous.
+    pub async fn evaluate_targeted(
+        javascript: &str,
+        port: u16,
+        target_url_contains: Option<&str>,
+    ) -> anyhow::Result<String> {
+        let mut session = CdpSession::connect(port, target_url_contains).await?;
         let obj = tokio::time::timeout(
             Duration::from_secs(10),
             session.call("Runtime.evaluate", serde_json::json!({
@@ -419,24 +430,77 @@ async fn ws_url_for_page_target(port: u16, target_url_contains: Option<&str>) ->
     Ok((ws_url, target_url))
 }
 
-/// Pick the page target whose `url` contains `hint` (case-insensitive), or
-/// fall back to the first page in `pages` if no hint is given or nothing
-/// matches. Shared by both discovery paths (classic `/json` and
+/// Pick the unique page target whose `url` contains `hint`
+/// (case-insensitive), or the first page when no hint is given. Explicit
+/// hints fail closed when zero or multiple pages match. Shared by both
+/// discovery paths (classic `/json` and
 /// `Target.getTargets`) since a browser with more than one tab open is
 /// otherwise picked non-deterministically — CDP target ids carry no
 /// relationship to the caller's `window_id`.
 fn pick_target<'a>(pages: &[&'a serde_json::Value], hint: Option<&str>) -> Option<&'a serde_json::Value> {
-    if let Some(hint) = hint {
-        let hint_lower = hint.to_ascii_lowercase();
-        if let Some(t) = pages.iter().find(|t| {
-            t.get("url")
-                .and_then(|v| v.as_str())
-                .is_some_and(|url| url.to_ascii_lowercase().contains(&hint_lower))
-        }) {
-            return Some(t);
+    match hint {
+        None => pages.first().copied(),
+        Some(hint) => {
+            let hint_lower = hint.to_ascii_lowercase();
+            let mut matches = pages.iter().copied().filter(|target| {
+                target
+                    .get("url")
+                    .and_then(|value| value.as_str())
+                    .is_some_and(|url| url.to_ascii_lowercase().contains(&hint_lower))
+            });
+            let target = matches.next()?;
+            if matches.next().is_some() {
+                return None;
+            }
+            Some(target)
         }
     }
-    pages.first().copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pick_target;
+
+    fn pages() -> Vec<serde_json::Value> {
+        vec![
+            serde_json::json!({ "type": "page", "url": "app://fixture/#window-a" }),
+            serde_json::json!({ "type": "page", "url": "app://fixture/#window-b" }),
+        ]
+    }
+
+    #[test]
+    fn explicit_target_hint_selects_one_page() {
+        let pages = pages();
+        let refs = pages.iter().collect::<Vec<_>>();
+        assert_eq!(
+            pick_target(&refs, Some("#WINDOW-B")).and_then(|target| target["url"].as_str()),
+            Some("app://fixture/#window-b")
+        );
+    }
+
+    #[test]
+    fn explicit_target_hint_never_falls_back() {
+        let pages = pages();
+        let refs = pages.iter().collect::<Vec<_>>();
+        assert!(pick_target(&refs, Some("#missing")).is_none());
+    }
+
+    #[test]
+    fn ambiguous_target_hint_fails_closed() {
+        let pages = pages();
+        let refs = pages.iter().collect::<Vec<_>>();
+        assert!(pick_target(&refs, Some("app://fixture/")).is_none());
+    }
+
+    #[test]
+    fn omitted_target_hint_keeps_legacy_first_page_behavior() {
+        let pages = pages();
+        let refs = pages.iter().collect::<Vec<_>>();
+        assert_eq!(
+            pick_target(&refs, None).and_then(|target| target["url"].as_str()),
+            Some("app://fixture/#window-a")
+        );
+    }
 }
 
 fn parse_cdp_result(obj: &serde_json::Value) -> anyhow::Result<String> {

--- a/libs/cua-driver/rust/crates/platform-macos/src/browser/cdp_client.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/browser/cdp_client.rs
@@ -122,15 +122,11 @@ impl CdpSessionCache {
         target_url_contains: Option<&str>,
     ) -> anyhow::Result<String> {
         let arc = self.get_or_connect(port, target_url_contains).await?;
-        let first_attempt = {
+        {
             let mut session = arc.lock().await;
-            match session.ensure_target(port, target_url_contains).await {
-                Ok(()) => do_evaluate(&mut session, javascript).await,
-                Err(e) => Err(e),
+            if session.ensure_target(port, target_url_contains).await.is_ok() {
+                return do_evaluate(&mut session, javascript).await;
             }
-        };
-        if first_attempt.is_ok() {
-            return first_attempt;
         }
 
         self.evict(port).await;
@@ -487,6 +483,7 @@ mod tests {
         atomic::{AtomicUsize, Ordering},
         Arc,
     };
+    use std::time::Duration;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
     use tokio_tungstenite::{accept_async, tungstenite::Message};
@@ -602,6 +599,69 @@ mod tests {
             cache.evaluate("2", port, Some("#window-a")).await.unwrap(),
             "value-2"
         );
+        server.await.unwrap();
+        assert_eq!(accepted.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn targeted_evaluate_does_not_replay_after_disconnect() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let accepted = Arc::new(AtomicUsize::new(0));
+        let accepted_by_server = accepted.clone();
+
+        let server = tokio::spawn(async move {
+            let (mut probe, _) = listener.accept().await.unwrap();
+            accepted_by_server.fetch_add(1, Ordering::SeqCst);
+            let mut request = [0u8; 1024];
+            let _ = probe.read(&mut request).await.unwrap();
+            probe
+                .write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n")
+                .await
+                .unwrap();
+
+            let (socket, _) = listener.accept().await.unwrap();
+            accepted_by_server.fetch_add(1, Ordering::SeqCst);
+            let mut websocket = accept_async(socket).await.unwrap();
+
+            loop {
+                let message = websocket.next().await.unwrap().unwrap();
+                let Message::Text(text) = message else { continue };
+                let request: serde_json::Value = serde_json::from_str(&text).unwrap();
+                let id = request["id"].as_u64().unwrap();
+                let method = request["method"].as_str().unwrap();
+                let response = match method {
+                    "Target.getTargets" => serde_json::json!({
+                        "id": id,
+                        "result": {
+                            "targetInfos": [{
+                                "targetId": "page-a",
+                                "type": "page",
+                                "url": "app://fixture/#window-a"
+                            }]
+                        }
+                    }),
+                    "Target.attachToTarget" => serde_json::json!({
+                        "id": id,
+                        "result": { "sessionId": "session-a" }
+                    }),
+                    "Runtime.evaluate" => break,
+                    other => panic!("unexpected method {other}"),
+                };
+                websocket.send(Message::Text(response.to_string().into())).await.unwrap();
+            }
+            websocket.close(None).await.unwrap();
+
+            if let Ok(Ok((mut retry, _))) =
+                tokio::time::timeout(Duration::from_millis(250), listener.accept()).await
+            {
+                accepted_by_server.fetch_add(1, Ordering::SeqCst);
+                let _ = retry.read(&mut request).await.unwrap();
+            }
+        });
+
+        let cache = CdpSessionCache::new();
+        assert!(cache.evaluate("sideEffect()", port, Some("#window-a")).await.is_err());
         server.await.unwrap();
         assert_eq!(accepted.load(Ordering::SeqCst), 2);
     }

--- a/libs/cua-driver/rust/crates/platform-macos/src/browser/cdp_client.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/browser/cdp_client.rs
@@ -67,29 +67,8 @@ impl CdpClient {
     /// "Allow remote debugging?" confirmation the Chrome-toggle path does,
     /// so there's no reason to route it through `CdpSessionCache`.
     pub async fn evaluate(javascript: &str, port: u16) -> anyhow::Result<String> {
-        Self::evaluate_targeted(javascript, port, None).await
-    }
-
-    /// Evaluate JavaScript against the unique page target selected by
-    /// `target_url_contains`. An explicit hint never falls back to another
-    /// page when it is absent or ambiguous.
-    pub async fn evaluate_targeted(
-        javascript: &str,
-        port: u16,
-        target_url_contains: Option<&str>,
-    ) -> anyhow::Result<String> {
-        let mut session = CdpSession::connect(port, target_url_contains).await?;
-        let obj = tokio::time::timeout(
-            Duration::from_secs(10),
-            session.call("Runtime.evaluate", serde_json::json!({
-                "expression": javascript,
-                "returnByValue": true,
-                "awaitPromise": true
-            })),
-        ).await
-        .map_err(|_| anyhow::anyhow!("CDP evaluate timed out after 10s"))??;
-
-        parse_cdp_result(&obj)
+        let mut session = CdpSession::connect(port, None).await?;
+        do_evaluate(&mut session, javascript).await
     }
 }
 
@@ -130,6 +109,35 @@ impl CdpSessionCache {
 
     async fn evict(&self, port: u16) {
         self.sessions.lock().await.remove(&port);
+    }
+
+    /// Evaluate JavaScript against the unique page target selected by
+    /// `target_url_contains`, reusing the cached browser connection. This
+    /// avoids re-triggering Chrome's "Allow remote debugging?" confirmation
+    /// for every targeted page action.
+    pub async fn evaluate(
+        &self,
+        javascript: &str,
+        port: u16,
+        target_url_contains: Option<&str>,
+    ) -> anyhow::Result<String> {
+        let arc = self.get_or_connect(port, target_url_contains).await?;
+        let first_attempt = {
+            let mut session = arc.lock().await;
+            match session.ensure_target(port, target_url_contains).await {
+                Ok(()) => do_evaluate(&mut session, javascript).await,
+                Err(e) => Err(e),
+            }
+        };
+        if first_attempt.is_ok() {
+            return first_attempt;
+        }
+
+        self.evict(port).await;
+        let arc = self.get_or_connect(port, target_url_contains).await?;
+        let mut session = arc.lock().await;
+        session.ensure_target(port, target_url_contains).await?;
+        do_evaluate(&mut session, javascript).await
     }
 
     /// Insert `text` at whatever currently holds DOM focus, via CDP's native
@@ -211,6 +219,20 @@ impl CdpSessionCache {
 
 impl Default for CdpSessionCache {
     fn default() -> Self { Self::new() }
+}
+
+async fn do_evaluate(session: &mut CdpSession, javascript: &str) -> anyhow::Result<String> {
+    let obj = tokio::time::timeout(
+        Duration::from_secs(10),
+        session.call("Runtime.evaluate", serde_json::json!({
+            "expression": javascript,
+            "returnByValue": true,
+            "awaitPromise": true
+        })),
+    ).await
+    .map_err(|_| anyhow::anyhow!("CDP evaluate timed out after 10s"))??;
+
+    parse_cdp_result(&obj)
 }
 
 async fn do_insert_text(session: &mut CdpSession, text: &str) -> anyhow::Result<()> {
@@ -459,7 +481,15 @@ fn pick_target<'a>(pages: &[&'a serde_json::Value], hint: Option<&str>) -> Optio
 
 #[cfg(test)]
 mod tests {
-    use super::pick_target;
+    use super::{pick_target, CdpSessionCache};
+    use futures_util::{SinkExt, StreamExt};
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::{accept_async, tungstenite::Message};
 
     fn pages() -> Vec<serde_json::Value> {
         vec![
@@ -500,6 +530,80 @@ mod tests {
             pick_target(&refs, None).and_then(|target| target["url"].as_str()),
             Some("app://fixture/#window-a")
         );
+    }
+
+    #[tokio::test]
+    async fn targeted_evaluate_reuses_browser_websocket() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let accepted = Arc::new(AtomicUsize::new(0));
+        let accepted_by_server = accepted.clone();
+
+        let server = tokio::spawn(async move {
+            let (mut probe, _) = listener.accept().await.unwrap();
+            accepted_by_server.fetch_add(1, Ordering::SeqCst);
+            let mut request = [0u8; 1024];
+            let _ = probe.read(&mut request).await.unwrap();
+            probe
+                .write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n")
+                .await
+                .unwrap();
+
+            let (socket, _) = listener.accept().await.unwrap();
+            accepted_by_server.fetch_add(1, Ordering::SeqCst);
+            let mut websocket = accept_async(socket).await.unwrap();
+            let mut attached = 0;
+            let mut evaluated = 0;
+
+            while evaluated < 2 {
+                let message = websocket.next().await.unwrap().unwrap();
+                let Message::Text(text) = message else { continue };
+                let request: serde_json::Value = serde_json::from_str(&text).unwrap();
+                let id = request["id"].as_u64().unwrap();
+                let method = request["method"].as_str().unwrap();
+                let response = match method {
+                    "Target.getTargets" => serde_json::json!({
+                        "id": id,
+                        "result": {
+                            "targetInfos": [{
+                                "targetId": "page-a",
+                                "type": "page",
+                                "url": "app://fixture/#window-a"
+                            }]
+                        }
+                    }),
+                    "Target.attachToTarget" => {
+                        attached += 1;
+                        serde_json::json!({
+                            "id": id,
+                            "result": { "sessionId": format!("session-{attached}") }
+                        })
+                    }
+                    "Runtime.evaluate" => {
+                        evaluated += 1;
+                        serde_json::json!({
+                            "id": id,
+                            "sessionId": request["sessionId"],
+                            "result": { "result": { "value": format!("value-{evaluated}") } }
+                        })
+                    }
+                    other => panic!("unexpected method {other}"),
+                };
+                websocket.send(Message::Text(response.to_string().into())).await.unwrap();
+            }
+        });
+
+        let cache = CdpSessionCache::new();
+        assert_eq!(
+            cache.evaluate("1", port, Some("#window-a")).await.unwrap(),
+            "value-1"
+        );
+        assert_eq!(
+            cache.evaluate("2", port, Some("#window-a")).await.unwrap(),
+            "value-2"
+        );
+        server.await.unwrap();
+        assert_eq!(accepted.load(Ordering::SeqCst), 2);
     }
 }
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/page.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/page.rs
@@ -99,6 +99,21 @@ impl PageBackend for MacOsPageBackend {
         execute_js(javascript, &bundle_id, pid, window_id).await
     }
 
+    async fn execute_javascript_targeted(
+        &self,
+        pid: i32,
+        window_id: u32,
+        javascript: &str,
+        cdp_port: Option<u16>,
+        target_url_contains: Option<&str>,
+    ) -> anyhow::Result<String> {
+        if cdp_port.is_none() && target_url_contains.is_none() {
+            return self.execute_javascript(pid, window_id, javascript).await;
+        }
+        let port = resolve_cdp_port(pid, cdp_port, "execute_javascript").await?;
+        CdpClient::evaluate_targeted(javascript, port, target_url_contains).await
+    }
+
     async fn click_element(
         &self,
         pid: i32,

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/page.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/page.rs
@@ -111,7 +111,7 @@ impl PageBackend for MacOsPageBackend {
             return self.execute_javascript(pid, window_id, javascript).await;
         }
         let port = resolve_cdp_port(pid, cdp_port, "execute_javascript").await?;
-        CdpClient::evaluate_targeted(javascript, port, target_url_contains).await
+        self.state.cdp_sessions.evaluate(javascript, port, target_url_contains).await
     }
 
     async fn click_element(

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/page.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/page.rs
@@ -129,6 +129,33 @@ impl PageBackend for WindowsPageBackend {
         Ok(format!("cdp.runtime.evaluate.user_gesture: {result}"))
     }
 
+    async fn execute_javascript_targeted(
+        &self,
+        pid: i32,
+        window_id: u32,
+        javascript: &str,
+        cdp_port: Option<u16>,
+        target_url_contains: Option<&str>,
+    ) -> anyhow::Result<String> {
+        if cdp_port.is_none() && target_url_contains.is_none() {
+            return self.execute_javascript(pid, window_id, javascript).await;
+        }
+        let port = cdp_port.or_else(|| {
+            std::env::var("CUA_DRIVER_CDP_PORT")
+                .ok()
+                .and_then(|value| value.parse::<u16>().ok())
+        }).ok_or_else(|| anyhow::anyhow!(
+            "targeted execute_javascript on Windows requires cdp_port or CUA_DRIVER_CDP_PORT"
+        ))?;
+        let result = cua_driver_core::cdp::evaluate_targeted(
+            port,
+            javascript,
+            true,
+            target_url_contains,
+        ).await?;
+        Ok(format!("cdp.runtime.evaluate.user_gesture: {result}"))
+    }
+
     async fn click_element(
         &self,
         pid: i32,


### PR DESCRIPTION
## Summary

- allow `page.execute_javascript` to accept explicit `cdp_port` and `target_url_contains`
- require an explicit target hint to match exactly one CDP page
- reject invalid CDP ports instead of truncating them

## Why

Multi-window Electron processes expose multiple page targets on one CDP port. `execute_javascript` previously discarded the caller's resolved page identity and selected the first page target. An explicit URL hint also fell back to the first page when no target matched, so a successful RPC could execute against the wrong renderer.

The lower-level CDP session code already supported selecting a target by URL. This change threads that identity through the `page` tool and makes explicit hints fail closed when absent or ambiguous.

## Validation on latest upstream main

Rebased without conflict onto `trycua/cua@8c921b2b3bf13494724ead4f0a814d80c56a7e8b`.

```text
cargo test -p cua-driver-core page::tests
  3 passed

cargo test -p platform-macos browser::cdp_client::tests
  6 passed

cargo test -p cua-driver-core cdp::tests
  2 passed

cargo check -p cua-driver --release
  passed

cargo check -p platform-windows --target x86_64-pc-windows-gnu
  passed

cargo check -p platform-linux  # Debian bookworm / Rust 1.92
  passed
```

The targeted-page commit is `68a42c06bf3fdfa429d65e9c011efa13c2414548`; review feedback is addressed by `5c2b402d`, which reuses the existing CDP session cache, and `0e9a8294`, which prevents replay after a script has been sent. `35fa5658` completes explicit targeted routing on Windows and Linux. `git range-diff` reports it equivalent to the originally tested patch commit `adef3e87405986cc82df52ae59aef4c32e08a082`.

## Real multi-window downstream validation

Maka uses cua-driver as the sole page executor. Its real-machine harness runs two independent Electron `BrowserWindow` pages on one CDP port and passes the exact port + unique URL hint through cua-driver for pointer actions, element inspection, `Input.insertText`, and post-action readback.

Final batch `semantic-targeting-v5`:

- 10/10 complete runs passed
- 39/39 checks passed in every run
- two-window click/type routing and text isolation passed in every run
- zero fallback, wrong-target, no-op, or duplicate-effect cases
- frontmost application and real pointer remained unchanged

Per-action results:

| Action | Pass | Route | p50 / p90 / max |
| --- | ---: | --- | ---: |
| left click | 10/10 | targeted `page.execute_javascript` | 84 / 87 / 102 ms |
| checkbox click | 10/10 | targeted `page.execute_javascript` | 70 / 77 / 77 ms |
| range drag | 10/10 | targeted `page.execute_javascript` | 96 / 102 / 127 ms |
| right click | 10/10 | targeted `page.execute_javascript` | 74 / 80 / 85 ms |
| double click | 10/10 | targeted `page.execute_javascript` | 74 / 78 / 98 ms |

The downstream repo also passed its full typecheck, build, tests, bundle provenance gate, and final 39/39 real-machine E2E after integrating the patched driver.

## Compatibility

- Repeated targeted evaluations reuse the existing per-port CDP session cache, avoiding repeated Chrome remote-debugging confirmation prompts.
- Retry is limited to retarget failures before `Runtime.evaluate`; a sent script is never replayed after timeout or disconnect.
- Windows and Linux consume explicit `cdp_port` and unique URL hints through the shared CDP helper; calls without explicit targeting retain the existing backend behavior.
- Backends that do not implement targeted execution fail closed only when the caller supplies an explicit target.
- `insert_text` and `type_keystrokes` now share the checked CDP port parser, eliminating the previous `u16` truncation behavior.



