### PR TITLE
fix(cua-driver): gate Wayland health check on Linux

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/health_report.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/health_report.rs
@@ -325,6 +325,7 @@ async fn check_wayland_backend() -> CheckEntry {
     // cursor renders but clicks/keys are never delivered, while list_windows
     // and capture still work. Report that explicitly instead of the misleading
     // "input may fall back" partial-pass below.
+    #[cfg(target_os = "linux")]
     if !snap.virtual_pointer && !crate::wayland::PORTAL_LIBEI_ENABLED {
         return CheckEntry::fail(
             NAME_WAYLAND_BACKEND,


### PR DESCRIPTION
## Summary

Gate the Wayland/libei backend diagnostic on Linux, matching the existing platform boundary of the `wayland` module.

## Why

`platform-linux::health_report` has non-Linux stubs so the cua-driver workspace can be built from macOS. One diagnostic referenced `crate::wayland::PORTAL_LIBEI_ENABLED` unconditionally even though `crate::wayland` only exists under `#[cfg(target_os = "linux")]`. This caused macOS workspace builds to fail with `E0433`.

Linux behavior is unchanged; non-Linux builds simply omit a branch that cannot be reached because the health check already identifies that it is not in a Wayland session.

No related cua issue was found.

## Testing

- `cargo check --manifest-path libs/cua-driver/rust/Cargo.toml -p platform-linux`
- `cargo check --manifest-path libs/cua-driver/rust/Cargo.toml --workspace`
- `cargo build --manifest-path libs/cua-driver/rust/Cargo.toml --release --workspace`
- `git diff --check`
