### PR TITLE
feat(lume): default macOS disks to 100GB

### DIFF
--- a/libs/lume/src/Commands/Create.swift
+++ b/libs/lume/src/Commands/Create.swift
@@ -27,9 +27,9 @@ struct Create: AsyncParsableCommand {
     var memory: UInt64 = 8 * 1024 * 1024 * 1024
 
     @Option(
-        help: "Disk size (e.g., 50, 50GB, or 51200MB). Numbers without units are treated as GB. Defaults to 50GB.",
+        help: "Disk size (e.g., 100, 100GB, or 102400MB). Numbers without units are treated as GB. Defaults to 100GB for macOS and 50GB for Linux.",
         transform: { try parseSize($0) })
-    var diskSize: UInt64 = 50 * 1024 * 1024 * 1024
+    var diskSize: UInt64?
 
     @Option(help: "Display resolution in format WIDTHxHEIGHT. Defaults to 1024x768.")
     var display: VMDisplayResolution = VMDisplayResolution(string: "1024x768")!
@@ -93,6 +93,8 @@ struct Create: AsyncParsableCommand {
 
     @MainActor
     func run() async throws {
+        let diskSize = diskSize ?? Self.defaultDiskSize(for: os)
+
         // Validate unattended is only used with macOS
         if unattended != nil && os.lowercased() != "macos" {
             throw ValidationError("--unattended is only supported for macOS VMs")
@@ -142,5 +144,10 @@ struct Create: AsyncParsableCommand {
             vncPort: vncPort,
             networkMode: parsedNetworkMode
         )
+    }
+
+    static func defaultDiskSize(for os: String) -> UInt64 {
+        let sizeInGB: UInt64 = os.lowercased() == "macos" ? 100 : 50
+        return sizeInGB * 1024 * 1024 * 1024
     }
 }

--- a/libs/lume/src/Server/MCPServer.swift
+++ b/libs/lume/src/Server/MCPServer.swift
@@ -171,7 +171,7 @@ final class LumeMCPServer {
         - Avoid spaces and special characters
 
         ### Resource Allocation
-        - Default: 4 CPU cores, 8GB RAM, 64GB disk
+        - Default: 4 CPU cores, 8GB RAM, 100GB disk
         - For builds: Consider 8 CPU cores, 16GB RAM
         - Disk grows dynamically (sparse files)
 
@@ -493,7 +493,7 @@ final class LumeMCPServer {
                         ]),
                         "disk_size": .object([
                             "type": .string("string"),
-                            "description": .string("Disk size, e.g., '64GB' (default: 64GB)")
+                            "description": .string("Disk size, e.g., '100GB' (default: 100GB)")
                         ]),
                         "storage": .object([
                             "type": .string("string"),
@@ -803,12 +803,12 @@ final class LumeMCPServer {
             memorySize = 8 * 1024 * 1024 * 1024  // 8GB default
         }
 
-        // Parse disk size (default 64GB)
+        // Parse disk size (default 100GB)
         let diskSize: UInt64
         if let diskStr = args?["disk_size"]?.stringValue {
             diskSize = try parseSize(diskStr)
         } else {
-            diskSize = 64 * 1024 * 1024 * 1024  // 64GB default
+            diskSize = 100 * 1024 * 1024 * 1024  // 100GB default
         }
 
         // Load unattended config if specified

--- a/libs/lume/src/Utils/CommandDocExtractor.swift
+++ b/libs/lume/src/Utils/CommandDocExtractor.swift
@@ -128,7 +128,7 @@ enum CommandDocExtractor {
                 OptionDoc(name: "os", shortName: nil, help: "Operating system to install (macOS or linux)", type: "String", defaultValue: "macOS", isOptional: false),
                 OptionDoc(name: "cpu", shortName: nil, help: "Number of CPU cores", type: "Int", defaultValue: "4", isOptional: false),
                 OptionDoc(name: "memory", shortName: nil, help: "Memory size (e.g., 8GB)", type: "String", defaultValue: "8GB", isOptional: false),
-                OptionDoc(name: "disk-size", shortName: nil, help: "Disk size (e.g., 50GB)", type: "String", defaultValue: "50GB", isOptional: false),
+                OptionDoc(name: "disk-size", shortName: nil, help: "Disk size (e.g., 100GB)", type: "String", defaultValue: "100GB for macOS; 50GB for Linux", isOptional: false),
                 OptionDoc(name: "display", shortName: nil, help: "Display resolution (e.g., 1024x768)", type: "String", defaultValue: "1024x768", isOptional: false),
                 OptionDoc(name: "ipsw", shortName: nil, help: "Path to IPSW file or 'latest' for macOS VMs", type: "String", defaultValue: nil, isOptional: true),
                 OptionDoc(name: "storage", shortName: nil, help: "VM storage location to use", type: "String", defaultValue: nil, isOptional: true),

--- a/libs/lume/tests/CreateCommandTests.swift
+++ b/libs/lume/tests/CreateCommandTests.swift
@@ -1,0 +1,13 @@
+import Testing
+
+@testable import lume
+
+@Test("create uses a 100GB default disk for macOS")
+func createUsesMacOSDefaultDiskSize() {
+    #expect(Create.defaultDiskSize(for: "macOS") == 100 * 1024 * 1024 * 1024)
+}
+
+@Test("create keeps a 50GB default disk for Linux")
+func createUsesLinuxDefaultDiskSize() {
+    #expect(Create.defaultDiskSize(for: "linux") == 50 * 1024 * 1024 * 1024)
+}


### PR DESCRIPTION
## Summary

- default new macOS VM disks to 100GB in the CLI
- align the macOS-only MCP create tool with the same 100GB default
- preserve the existing 50GB Linux default and explicit disk-size overrides
- update generated command metadata and add regression coverage

## Why

The macOS VM creation defaults were inconsistent: the CLI used 50GB for every guest OS, while the MCP create tool used 64GB. A 100GB macOS default gives new VMs more practical headroom while retaining sparse-disk allocation behavior.

## Impact

New macOS VMs created without an explicit disk size receive a 100GB virtual disk. Linux defaults and explicit disk-size choices are unchanged.

## Validation

- rebased cleanly onto the latest `origin/main`
- `swift test` (61 tests passed)
