### PR TITLE
docs(cua-driver): refresh E2E coverage counts

### DIFF
--- a/libs/cua-driver/docs/action-support.md
+++ b/libs/cua-driver/docs/action-support.md
@@ -18,10 +18,10 @@ when that is the background-safe route.
 
 | Environment | Exact source | Accepted evidence |
 | --- | --- | --- |
-| Windows/Win32 | `6d7f02e4` | Run `29211506624`: 114/114 rows, 93 delivered and 21 exact refusals |
-| macOS/Quartz | `448d052f` | Logged-in local matrix: 133/133 rows with owned per-cell MP4 evidence |
-| Linux/X11 | `72083bb4` | Run `29213365684`: 108/108 rows, 71 delivered and 37 exact refusals |
-| Linux/Sway | `72083bb4` | Run `29213349962`: 108/108 rows, 71 delivered and 37 exact refusals |
+| Windows/Win32 | `64e82449` | Run `29257963004`: 122/122 rows, 99 delivered and 23 exact refusals |
+| macOS/Quartz | `0b9b5d94` and `64e82449` | Logged-in local matrix: 138 deliveries and 6 exact refusals passed; one cursor-interrupted row passed alone on the final head, for effective 145/145 coverage |
+| Linux/X11 | `268a6ab1` | Run `29254936043`: 116/116 rows, 75 delivered and 41 exact refusals |
+| Linux/Sway | `268a6ab1` and `64e82449` | Run `29255208927` passed native and capture 36/36; run `29257961614` passed shared 80/80, for effective 116/116 coverage |
 
 ## Shared web harnesses
 
@@ -36,12 +36,16 @@ Foreground rows listed here are delivered for both AX and PX.
 | macOS | WKWebView | left/right/double click AX/PX, type text AX/PX, press key AX/PX, hotkey AX/PX, scroll AX/PX, child window AX/PX, editor save AX | drag PX: `background_unavailable` |
 | Linux X11 | Electron | Background AX left click and child-window actions deliver with strict focus, z-order, cursor, and input-leak oracles | Background PX left click, AX/PX right and double click, PX child window and drag, AX/PX keyboard and scroll, and AX editor save return exact `background_unavailable` |
 | Linux X11 | Tauri | Background AX/PX left click and child-window actions deliver with strict focus, z-order, cursor, and input-leak oracles | Other background pointer, keyboard, scroll, drag, and editor-save shapes return exact `background_unavailable` |
-| Linux Sway | Electron | The full 36-cell catalog has accepted fixture-owned evidence; safe semantic and compositor routes deliver | Focus-bound and raw background shapes without a target-addressed route return their declared exact refusal |
-| Linux Sway | Tauri | The full 36-cell WebKitGTK catalog has accepted fixture-owned evidence, including live compositor geometry and roleless WebProcess targeting | Focus-bound and raw background shapes without a target-addressed route return their declared exact refusal |
+| Linux Sway | Electron | The full 40-cell catalog has accepted fixture-owned evidence; safe semantic and compositor routes deliver | Focus-bound and raw background shapes without a target-addressed route return their declared exact refusal |
+| Linux Sway | Tauri | The full 40-cell WebKitGTK catalog has accepted fixture-owned evidence, including live compositor geometry and roleless WebProcess targeting | Focus-bound and raw background shapes without a target-addressed route return their declared exact refusal |
 
-All shared background rows require fixture state, focus, z-order, cursor, and
-no-leaked-input evidence. Foreground rows require fixture state and retain a
-video plus before/after turn evidence.
+All shared background rows require fixture state, focus, z-order, and
+no-leaked-input evidence. Windows, macOS, and X11 also require cursor
+preservation. Wayland reports the cursor oracle as unsupported until the
+environment can prove it; [issue #2194](https://github.com/trycua/cua/issues/2194)
+tracks possible observer routes.
+Foreground rows require fixture state and retain a video plus before/after turn
+evidence.
 
 ## Native Windows
 
@@ -61,7 +65,7 @@ integrity-level harness can exercise it.
 | --- | --- | --- |
 | AppKit | AX tree/capture; AX background left click, set value, and type text; PX background left/right/double click; PX foreground right/double click and slider drag; AX foreground/background scroll; desktop PX foreground left click | PX background slider drag returns exact `background_unavailable`. Native press key, hotkey, AX-addressed right/double click, and broader control combinations remain unproven. |
 | SwiftUI | AX tree/capture; AX background left click and set value; foreground popover-trigger activation | The fixture proves `popover_open=true`, but the transient panel remains absent from targeted AX enumeration. Other native pointer and keyboard combinations remain unproven. |
-| WKWebView | Full 36-cell shared-web catalog through the dedicated repo-local native host | PX background drag returns exact `background_unavailable`; the other 35 shared cells deliver. Native host-specific controls are outside this fixture. |
+| WKWebView | Full 40-cell shared-web catalog through the dedicated repo-local native host | PX background drag returns exact `background_unavailable`; the other 39 shared cells deliver. Native host-specific controls are outside this fixture. |
 
 ## Native Linux
 
@@ -70,8 +74,8 @@ are capabilities, not one uniform API.
 
 | Environment | Proven contracts | Refusals and gaps |
 | --- | --- | --- |
-| X11/Openbox | Exact run `29213365684` passed all 108 declared outcomes: 71 deliveries and 37 exact refusals. GTK3 AT-SPI actions and values, foreground XTest pointer/keyboard routes, capture, desktop scope, and the complete Electron/Tauri catalog all reached fixture-owned oracles. | Xvfb does not prove the real-Xorg MPX/uinput background pointer route. Toolkits that reject XSendEvent retain exact refusals. |
-| Sway/wlroots | Exact run `29213349962` passed the same 108 outcomes as X11: 71 deliveries and 37 exact refusals. The complete Electron, Tauri, GTK3, capture, and desktop-scope catalogs use live Sway identity/geometry and external fixture oracles. | Stock Wayland cannot target raw focus-bound input at an occluded surface. Those rows retain exact refusals; another wlroots compositor is not assumed equivalent until a material divergence is reported and tested. |
+| X11/Openbox | Exact run `29254936043` passed all 116 declared outcomes: 75 deliveries and 41 exact refusals. GTK3 AT-SPI actions and values, foreground XTest pointer/keyboard routes, capture, desktop scope, and the complete Electron/Tauri catalog all reached fixture-owned oracles. | Xvfb does not prove the real-Xorg MPX/uinput background pointer route. Toolkits that reject XSendEvent retain exact refusals. |
+| Sway/wlroots | Runs `29255208927` and `29257961614` passed the complete 116 outcomes: native and capture 36/36, then shared 80/80. The Electron, Tauri, GTK3, capture, and desktop-scope catalogs use live Sway identity/geometry and external fixture oracles. | Stock Wayland cannot target raw focus-bound input at an occluded surface. Those rows retain exact refusals; another wlroots compositor is not assumed equivalent until a material divergence is reported and tested. Exact cursor preservation remains unproven and is tracked in [issue #2194](https://github.com/trycua/cua/issues/2194). |
 | GNOME/Mutter | A real GNOME 46 Wayland run passed the full GTK3 matrix, 31/31. The WinRects helper supplies stable window ids, frame and buffer geometry, stacking, verified activation, stage capture, and the compositor cursor. AT-SPI handles semantic actions; persistent portal/libei sessions deliver foreground PX click, right/double click, drag, scroll, type, key, and hotkey. Background rows either deliver through AT-SPI with focus and leak guards or return the declared exact refusal. | The helper requires installation plus one Shell-session restart. Without it, target-bound foreground input refuses. Portal video and a shared Electron/Tauri GNOME run remain open. |
 | KDE/KWin | A Plasma 6 session reached GTK AT-SPI discovery, generic toplevel discovery, and portal-interface preflight. Portal input is compiled into release binaries. | No behavioral matrix is accepted. A target-addressable KWin activation adapter is not implemented, so foreground portal/libei input refuses instead of injecting into the wrong focused app. |
 | Nested `cua-compositor` | The optional backend owns its nested session and is covered by typed shared, native, and capture catalogs. Run `29197643541` passed native GTK3 31/31; run `29197887387` passed capture/scope 5/5. Full shared run `29199596935` passed 26/36 Electron rows before the occluded-subtree and wheel-frame repairs. | The lane remains experimental. The accepted full shared run still has 10 failures; focused replacement runs reduce that set but do not promote the environment. Unicode text and a canonical parallel-drag row remain unproven. This private route is not evidence of a stock-Wayland capability. |

--- a/libs/cua-driver/docs/test-harness-convergence-plan.md
+++ b/libs/cua-driver/docs/test-harness-convergence-plan.md
@@ -64,8 +64,8 @@ environment or backend gaps separately.
 
 ### Implemented
 
-- `cross_platform_behavior_test.rs` has one typed 36-cell catalog per shared
-  harness application: 72 shared cells across Electron and Tauri per platform.
+- `cross_platform_behavior_test.rs` has one typed 40-cell catalog per shared
+  harness application: 80 shared cells across Electron and Tauri per platform.
   It covers AX and PX with foreground and background delivery for click,
   text, keyboard, scroll, and child-window actions; PX drag and AX editor-save
   each cover both delivery modes.
@@ -79,10 +79,12 @@ environment or backend gaps separately.
   Chromium PX background keeps its targeted-injection route metadata, while a
   fully occluded target expects the exact `background_occluded` refusal because
   temporarily raising the window would violate the desktop-side-effect contract.
-- Every background shared cell attaches independent focus, z-order, real
-  cursor, leaked-input, and fixture-state observations. Windows, macOS, and X11
-  use direct testkit observers; an occluding Electron sentinel supplies the
-  focus and leaked-input journal. Unsupported Wayland observations fail closed.
+- Every background shared cell attaches independent focus, z-order,
+  leaked-input, and fixture-state observations. Windows, macOS, and X11 also
+  attach the real-cursor observer. An occluding Electron sentinel supplies the
+  focus and leaked-input journal across target frameworks. Wayland leaves the
+  cursor oracle explicitly unsupported while issue #2194 investigates a
+  capability-checked observer.
 - Electron and Tauri use repo-local builds of the same shared web fixture.
 - Windows, Linux, and macOS runners have strict source, fixture, AX, capture,
   and video preflights. Shell runners no longer synthesize behavioral rows.
@@ -194,7 +196,7 @@ driver route:
 5. Every omitted combination names an `equivalent_to` cell or an unsupported
    contract reason.
 
-The shared catalog currently declares 36 cells per harness application, or 72
+The shared catalog currently declares 40 cells per harness application, or 80
 cells across Electron and Tauri per platform. Add a missing combination when it
 reaches a different driver route. Remove a combination only when another cell
 proves the same route with an equal or stronger oracle.

--- a/libs/cua-driver/docs/test-harnesses-guide.md
+++ b/libs/cua-driver/docs/test-harnesses-guide.md
@@ -215,7 +215,9 @@ itself is not evidence that input can be sent safely to a named window.
 Standard Wayland does not expose the physical pointer position, so canonical
 Wayland rows do not claim the real-cursor preservation oracle. Focus, full
 occlusion, sentinel input isolation, liveness, and fixture-state oracles remain
-mandatory.
+mandatory. [Issue #2194](https://github.com/trycua/cua/issues/2194) tracks
+compositor, portal/libei, sentinel, and capture-based ways to add a proven
+cursor observer where the environment supports one.
 
 ## AX, PX, and Delivery
 

--- a/libs/cua-driver/docs/test-matrix.md
+++ b/libs/cua-driver/docs/test-matrix.md
@@ -118,7 +118,7 @@ background delivery and attach desktop-side-effect oracles.
 | --- | --- | --- |
 | AppKit | `harness_appkit_test.rs` | AX tree/capture, AX value/text, AX scroll, PX clicks, and foreground slider drag across the proven delivery modes; background drag is an exact refusal |
 | SwiftUI | `harness_swiftui_test.rs` | AX tree/capture, background click/value, and foreground popover-trigger state |
-| WKWebView | `cross_platform_behavior_test.rs` | Dedicated native host running the full 36-cell shared web catalog |
+| WKWebView | `cross_platform_behavior_test.rs` | Dedicated native host running the full 40-cell shared web catalog |
 | Installed-app launch/focus | `installed_app_launch_macos_test.rs` | Real Calculator/TextEdit launch and focus behavior in the canonical logged-in lane |
 | Installed-app text | `installed_app_textedit_macos_test.rs` | Real TextEdit AX background write and verification in the canonical logged-in lane |
 


### PR DESCRIPTION
## Summary

- update the live CUA Driver support ledger with the accepted Windows, macOS, X11, and Sway evidence from #2193
- replace stale 36-cell shared-harness references with the current 40-cell catalog and 80-cell Electron/Tauri totals
- clarify that the Electron foreground sentinel is cross-cutting instrumentation used while testing shared and native target frameworks
- document that Wayland cursor equality remains an explicit unsupported oracle and link the investigation in #2194

## Why

The shared catalog gained four type-then-Return cells per harness in #2193. Some current reference sections still described the earlier 36-cell catalog, while one statement incorrectly implied that Wayland required the same global cursor-position oracle as Windows, macOS, and X11.

Historical journals and landing records keep their original counts because they describe earlier exact runs.

## Validation

- Windows run `29257963004`: 122/122 outcomes passed
- Linux X11 run `29254936043`: 116/116 outcomes passed
- Sway runs `29255208927` and `29257961614`: native/capture 36/36 and shared 80/80 passed
- `git diff --check`

## Scope

Documentation only. This PR does not change driver, fixture, test, or CI behavior.
