### PR TITLE
fix(lume): handle macOS 26 authorized-user prompt in SIP automation

### DIFF
--- a/libs/lume/src/Commands/Sip.swift
+++ b/libs/lume/src/Commands/Sip.swift
@@ -449,23 +449,44 @@ struct Sip: AsyncParsableCommand {
         try await pause(seconds: 3, operation: "csrutil prompt", heartbeat: heartbeat, timeout: timeout)
         try driver.snapshot("05-csrutil-prompt")
 
-        let accountPrompt = "enter password for user \(adminUser):"
+        // Older macOS prompts directly for "enter password for user <admin>:".
+        // macOS 26 (Tahoe) Recovery first asks for an authorized username
+        // ("authorized user:"), then a password. Handle both.
+        let legacyPasswordPrompt = "enter password for user \(adminUser):"
+        let usernamePrompt = "authorized user"
         let promptText = try await driver.waitForText(
-            containing: ["[y/n]", accountPrompt],
+            containing: ["[y/n]", legacyPasswordPrompt, usernamePrompt],
             rejecting: ["no administrator was found", "failed to authenticate", "authentication failure"],
             deadlineSeconds: try timeout(15, "csrutil prompt"), label: "csrutil prompt", heartbeat: heartbeat)
 
-        if !promptText.lowercased().contains(accountPrompt.lowercased()) {
+        var authText = promptText
+        if promptText.lowercased().contains("[y/n]")
+            && !promptText.lowercased().contains(legacyPasswordPrompt)
+            && !promptText.lowercased().contains(usernamePrompt) {
             try driver.key("y")
+            try driver.key("enter")
+            try await pause(seconds: 3, operation: "csrutil auth prompt", heartbeat: heartbeat, timeout: timeout)
+            authText = try await driver.waitForText(
+                containing: [legacyPasswordPrompt, usernamePrompt],
+                rejecting: ["no administrator was found", "failed to authenticate", "authentication failure"],
+                deadlineSeconds: try timeout(20, "csrutil account prompt"), label: "csrutil account prompt",
+                heartbeat: heartbeat)
+        }
+        try driver.snapshot("06-account-prompt")
+
+        // macOS 26: type the authorized username, then wait for the password prompt.
+        if authText.lowercased().contains(usernamePrompt)
+            && !authText.lowercased().contains(legacyPasswordPrompt) {
+            try driver.type(adminUser)
             try driver.key("enter")
             try await pause(seconds: 3, operation: "csrutil password prompt", heartbeat: heartbeat, timeout: timeout)
             _ = try await driver.waitForText(
-                containing: [accountPrompt],
-                rejecting: ["no administrator was found", "failed to authenticate", "authentication failure"],
-                deadlineSeconds: try timeout(15, "csrutil account prompt"), label: "csrutil account prompt",
+                containing: ["password"],
+                rejecting: ["no administrator was found", "failed to authenticate", "authentication failure", "incorrect password"],
+                deadlineSeconds: try timeout(20, "csrutil password prompt"), label: "csrutil password prompt",
                 heartbeat: heartbeat)
         }
-        try driver.snapshot("06-password-prompt")
+        try driver.snapshot("06b-password-prompt")
 
         try driver.typeSensitive(adminPassword)
         try driver.key("enter")


### PR DESCRIPTION
## Problem
`lume sip off/on` drives `csrutil` in the guest's paired Recovery over VNC. On **macOS 26 (Tahoe)**, `csrutil disable`/`enable` changed its prompt flow: after the `[y/n]` confirmation it first asks for an **authorized administrator username** (`authorized user:`) and *then* a password, instead of going straight to `enter password for user <admin>:`.

The automation only matched the legacy password prompt, so on macOS 26 guests it answered `[y/n]` with `y` and then timed out:

```
Error: VNC driver timeout: Framebuffer for 'csrutil account prompt' did not contain expected text;
last OCR text: ... [y/n]: y authorized user: ...
```

## Fix
Handle both prompt styles. After the `[y/n]` confirmation, wait for either the legacy `enter password for user <admin>:` prompt **or** the new `authorized user` username prompt; when the username prompt appears, type the admin user, then wait for the password prompt before entering the password. Adds `06-account-prompt` / `06b-password-prompt` screenshots for debugging.

## Testing
Verified end-to-end on a macOS 26.4 guest: `lume sip off <vm>` now completes through the `authorized user:` → password flow and the follow-up normal boot reports `System Integrity Protection status: disabled.` (`SIP is disabled.`). Backward-compatible with older guests that use the single password prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)