### PR TITLE
Remove stale Swift driver bump target

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -39,6 +39,18 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
 
         self.assertIn('["libs/cua-driver/rust/"]="cua-driver-rs"', workflow)
 
+    def test_release_bump_version_only_exposes_rust_driver(self) -> None:
+        workflow = self.read(".github/workflows/release-bump-version.yml")
+
+        self.assertIn("          - cua-driver-rs\n", workflow)
+        self.assertIn('            "cua-driver-rs")\n', workflow)
+        self.assertIn(
+            'echo "directory=libs/cua-driver/rust" >> $GITHUB_OUTPUT', workflow
+        )
+        self.assertNotIn("          - cua-driver\n", workflow)
+        self.assertNotIn('            "cua-driver")\n', workflow)
+        self.assertNotIn("inputs.service == 'cua-driver'", workflow)
+
     def test_release_reminder_tracks_rust_driver(self) -> None:
         workflow = self.read(".github/workflows/ci-release-reminder.yml")
 

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -29,7 +29,6 @@ on:
           - npm/playground
           - npm/cuabot
           - lume
-          - cua-driver
           - cua-driver-rs
           - docker/cuabot
           - docker/kasm
@@ -146,10 +145,6 @@ jobs:
             "lume")
               echo "directory=libs/lume" >> $GITHUB_OUTPUT
               echo "type=lume" >> $GITHUB_OUTPUT
-              ;;
-            "cua-driver")
-              echo "directory=libs/cua-driver" >> $GITHUB_OUTPUT
-              echo "type=cua-driver" >> $GITHUB_OUTPUT
               ;;
             "cua-driver-rs")
               echo "directory=libs/cua-driver/rust" >> $GITHUB_OUTPUT
@@ -472,14 +467,6 @@ jobs:
         run: |
           VERSION=$(grep -oP 'static let current: String = "\K[^"]+' libs/lume/src/Main.swift)
           echo "lume version: $VERSION"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Capture bumped cua-driver version
-        if: ${{ inputs.service == 'cua-driver' }}
-        id: cua_driver_version
-        run: |
-          VERSION=$(grep -oP 'public static let version = "\K[^"]+' libs/cua-driver/Sources/CuaDriverCore/CuaDriverCore.swift)
-          echo "cua-driver version: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Capture bumped cua-driver-rs version


### PR DESCRIPTION
## Summary

- remove the retired Swift `cua-driver` option from the manual version-bump workflow
- remove its dead package mapping and version-capture step
- add a regression test that keeps `cua-driver-rs` as the only driver bump target

## Why

Commit `f58d4b00` retired the Swift cua-driver package and its release flow, but the shared bump workflow still exposed the old package. Selecting it mapped to a directory without a bump config and later read a deleted Swift source file.

## Impact

The manual bump workflow now exposes only the supported Rust driver package, `cua-driver-rs`. Existing Rust release wiring, installers, Python packaging, and historical Swift-release filters remain unchanged.

## Validation

- `uv run --with toml python -m unittest discover -s .github/scripts/tests -v` (31 passed)
- workflow YAML parsed successfully
- all 29 bump options have matching case mappings
- `git diff --check`