### PR TITLE
chore: define repository code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Require a core maintainer to approve every change.
+* @f-trycua @ddupont808 @r33drichards
+
+# Keep repository policy, automation, and release credentials under the owner.
+/.github/ @f-trycua


### PR DESCRIPTION
## Summary

- require a core maintainer to own every repository change
- reserve `.github`, workflow, and repository-policy changes for `@f-trycua`

## Why

Establish review boundaries before granting external collaborators write access.

## Validation

- verified all listed owners have admin access to `trycua/cua`
- `git diff --check`