### PR TITLE
fix(cua-driver): retain country-only telemetry

### DIFF
--- a/docs/content/docs/reference/cua-driver/telemetry.mdx
+++ b/docs/content/docs/reference/cua-driver/telemetry.mdx
@@ -50,13 +50,13 @@ cua-driver telemetry inspect cua_driver_mcp_session_started --json
 cua-driver telemetry inspect cua_driver_mcp_tool_completed --json
 ```
 
-## Common event properties
+## Common client event properties
 
-Every schema-v2 client event has this fixed envelope:
+Every schema-v3 client event has this fixed envelope:
 
 | Property                   | Meaning                                                   |
 | -------------------------- | --------------------------------------------------------- |
-| `telemetry_schema_version` | Fixed integer `2`                                         |
+| `telemetry_schema_version` | Fixed integer `3`                                         |
 | `product_version`          | Installed Cua Driver version                              |
 | `os_family`                | `macos`, `windows`, `linux`, or `other`                   |
 | `os_major`                 | Major operating-system version only                       |
@@ -65,9 +65,10 @@ Every schema-v2 client event has this fixed envelope:
 | `transport`                | `cli`, `mcp_stdio`, `mcp_http`, or `unknown`              |
 | `process_session_id`       | Random ID created once per process and never persisted    |
 | `id_persisted`             | Whether the installation ID came from durable local state |
-| `$geoip_disable`           | Fixed `true`; PostHog GeoIP enrichment is disabled        |
 
 Client events set `$process_person_profile` to `false`. The installation UUID is used only as the PostHog `distinct_id`; it is not duplicated into event properties. This is pseudonymous installation telemetry, not anonymous telemetry.
+
+The client does not send an IP address as an event property. PostHog derives a country code and country name from the network request during ingestion, then discards the client IP before storing the event. A country-only transformation removes city, subdivision, postal-code, coordinate, accuracy-radius, and time-zone properties.
 
 ## Fixed events
 
@@ -114,6 +115,6 @@ Tool-completion events retain only coarse result shape: text, image, mixed, empt
 
 ## Region and deletion controls
 
-Client events are sent to PostHog's EU ingest endpoint with GeoIP enrichment disabled. PostHog does not create person profiles for these events. Network infrastructure may still process request metadata under the [Cua privacy policy](https://cua.ai/privacy-policy), but IP-derived location is not added to the telemetry event.
+Client events are sent to PostHog's EU ingest endpoint. PostHog processes the request IP long enough to derive country-level distribution, then discards the IP before event storage. Stored telemetry keeps only the derived country code and country name; it excludes city, subdivision, postal code, coordinates, accuracy radius, and time zone. PostHog does not create person profiles for these events.
 
 Retention and server-side deletion are governed by the [Cua privacy policy](https://cua.ai/privacy-policy); the client does not enforce a retention window or submit deletion requests. `telemetry reset-id` and uninstall purge controls remove local identity state only. Do not post the installation UUID in a public issue.

--- a/libs/cua-driver/rust/crates/cua-driver/src/telemetry.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/telemetry.rs
@@ -767,7 +767,7 @@ fn build_payload(
     transport: Transport,
 ) -> Value {
     let mut event_properties = properties.clone();
-    event_properties.insert("telemetry_schema_version".into(), Value::from(2));
+    event_properties.insert("telemetry_schema_version".into(), Value::from(3));
     event_properties
         .entry("product_version")
         .or_insert_with(|| Value::String(current_product_version().into()));
@@ -779,7 +779,6 @@ fn build_payload(
     event_properties.insert("process_session_id".into(), Value::String(process_session_id()));
     event_properties.insert("id_persisted".into(), Value::Bool(identity.persisted));
     event_properties.insert("$process_person_profile".into(), Value::Bool(false));
-    event_properties.insert("$geoip_disable".into(), Value::Bool(true));
     event_properties.insert("$lib".into(), Value::String("cua-driver-rs".into()));
     event_properties.insert("$lib_version".into(), Value::String(current_product_version().into()));
 
@@ -1586,7 +1585,7 @@ mod tests {
     }
 
     #[test]
-    fn v2_payload_has_exact_content_free_envelope_and_no_client_timestamp() {
+    fn v3_payload_allows_server_geoip_without_sending_an_ip_or_client_timestamp() {
         let identity = InstallationIdentity { id: "test-id".into(), persisted: true };
         let payload = build_payload(
             event::MCP_TOOL_COMPLETED,
@@ -1602,11 +1601,14 @@ mod tests {
         for required in [
             "telemetry_schema_version", "product_version", "os_family", "os_major",
             "arch", "is_ci", "transport", "process_session_id", "id_persisted",
-            "$process_person_profile", "$geoip_disable", "$lib", "$lib_version",
+            "$process_person_profile", "$lib", "$lib_version",
             "tool_name", "success",
         ] {
             assert!(properties.contains_key(required), "missing {required}");
         }
+        assert_eq!(properties["telemetry_schema_version"], 3);
+        assert!(!properties.contains_key("$geoip_disable"));
+        assert!(!properties.contains_key("$ip"));
         let serialized = serde_json::to_string(&payload).unwrap().to_ascii_lowercase();
         for forbidden in [
             "prompt", "task_text", "arguments", "result_text", "typed_text", "clipboard",


### PR DESCRIPTION
## Summary
- allow PostHog GeoIP enrichment for Cua Driver events
- bump the telemetry envelope to schema v3
- document transient IP processing and country-only retention

## PostHog configuration
- enabled Discard client IP data for the project
- verified active GeoIP runs before the active Property Filter
- scoped the filter to Library = cua-driver-rs
- retained only country code and country name from GeoIP output

## Validation
- cargo test -p cua-driver --locked
- cargo test -p cua-driver telemetry --locked after rebasing onto main
- pnpm docs:check-hygiene
- Cua Driver docs generator is up to date
- live source-built schema-v3 lifecycle events stored country code/name and no IP address property

## Baseline notes
- repository-wide Rust formatting already fails on pre-existing formatting in telemetry.rs and other files
- the combined docs generator reaches the unrelated Lume generator, which reports existing Lume CLI/HTTP reference drift