### PR TITLE
fix(agent): reject executable UITARS coordinates

### DIFF
--- a/libs/python/agent/cua_agent/loops/uitars.py
+++ b/libs/python/agent/cua_agent/loops/uitars.py
@@ -195,6 +195,27 @@ def parse_action(action_str):
         return None
 
 
+def parse_box_coordinates(box: str) -> Optional[Tuple[float, float, float, float]]:
+    """Parse a normalized UITARS coordinate box without evaluating code."""
+    try:
+        value = ast.literal_eval(box)
+    except (ValueError, SyntaxError, TypeError, MemoryError, RecursionError):
+        return None
+
+    if not isinstance(value, (list, tuple)) or len(value) != 4:
+        return None
+    if not all(
+        isinstance(number, (int, float)) and not isinstance(number, bool) for number in value
+    ):
+        return None
+
+    coordinates = tuple(float(number) for number in value)
+    if not all(math.isfinite(number) for number in coordinates):
+        return None
+
+    return coordinates[0], coordinates[1], coordinates[2], coordinates[3]
+
+
 def parse_uitars_response(text: str, image_width: int, image_height: int) -> List[Dict[str, Any]]:
     """Parse UITARS model response into structured actions."""
     text = text.strip()
@@ -303,7 +324,9 @@ def convert_to_computer_actions(
         elif action_type in ["click", "left_single"]:
             start_box = action_inputs.get("start_box")
             if start_box:
-                coords = eval(start_box)
+                coords = parse_box_coordinates(start_box)
+                if coords is None:
+                    continue
                 x = int((coords[0] + coords[2]) / 2 * image_width)
                 y = int((coords[1] + coords[3]) / 2 * image_height)
 
@@ -312,7 +335,9 @@ def convert_to_computer_actions(
         elif action_type in ["double_click", "left_double"]:
             start_box = action_inputs.get("start_box")
             if start_box:
-                coords = eval(start_box)
+                coords = parse_box_coordinates(start_box)
+                if coords is None:
+                    continue
                 x = int((coords[0] + coords[2]) / 2 * image_width)
                 y = int((coords[1] + coords[3]) / 2 * image_height)
 
@@ -321,7 +346,9 @@ def convert_to_computer_actions(
         elif action_type in ["right_click", "right_single"]:
             start_box = action_inputs.get("start_box")
             if start_box:
-                coords = eval(start_box)
+                coords = parse_box_coordinates(start_box)
+                if coords is None:
+                    continue
                 x = int((coords[0] + coords[2]) / 2 * image_width)
                 y = int((coords[1] + coords[3]) / 2 * image_height)
 
@@ -345,7 +372,9 @@ def convert_to_computer_actions(
             direction = action_inputs.get("direction", "down")
 
             if start_box:
-                coords = eval(start_box)
+                coords = parse_box_coordinates(start_box)
+                if coords is None:
+                    continue
                 x = int((coords[0] + coords[2]) / 2 * image_width)
                 y = int((coords[1] + coords[3]) / 2 * image_height)
             else:
@@ -359,8 +388,10 @@ def convert_to_computer_actions(
             end_box = action_inputs.get("end_box")
 
             if start_box and end_box:
-                start_coords = eval(start_box)
-                end_coords = eval(end_box)
+                start_coords = parse_box_coordinates(start_box)
+                end_coords = parse_box_coordinates(end_box)
+                if start_coords is None or end_coords is None:
+                    continue
 
                 start_x = int((start_coords[0] + start_coords[2]) / 2 * image_width)
                 start_y = int((start_coords[1] + start_coords[3]) / 2 * image_height)

--- a/libs/python/agent/tests/test_uitars_coordinate_security.py
+++ b/libs/python/agent/tests/test_uitars_coordinate_security.py
@@ -1,0 +1,82 @@
+"""Security regression tests for model-supplied UITARS coordinates."""
+
+import importlib
+
+import pytest
+
+uitars = importlib.import_module("cua_agent.loops.uitars")
+
+_EXECUTED = {"value": False}
+
+
+def _payload():
+    _EXECUTED["value"] = True
+    return (0.1, 0.1, 0.1, 0.1)
+
+
+@pytest.fixture(autouse=True)
+def reset_execution_sentinel():
+    _EXECUTED["value"] = False
+    yield
+    _EXECUTED["value"] = False
+
+
+def convert_model_action(action: str):
+    parsed = uitars.parse_uitars_response(f"Action: {action}", image_width=1000, image_height=1000)
+    return uitars.convert_to_computer_actions(parsed, image_width=1000, image_height=1000)
+
+
+@pytest.mark.parametrize(
+    "action",
+    [
+        'click(start_box="_payload()")',
+        'left_double(start_box="_payload()")',
+        'right_single(start_box="_payload()")',
+        'scroll(start_box="_payload()", direction="down")',
+        'drag(start_box="_payload()", end_box="[0.1, 0.1, 0.1, 0.1]")',
+        'drag(start_box="[0.1, 0.1, 0.1, 0.1]", end_box="_payload()")',
+    ],
+)
+def test_model_coordinate_expression_is_rejected(action, monkeypatch):
+    monkeypatch.setattr(uitars, "_payload", _payload, raising=False)
+
+    assert convert_model_action(action) == []
+    assert _EXECUTED["value"] is False
+
+
+@pytest.mark.parametrize(
+    "box",
+    [
+        "1 + 1",
+        "[1 + 1, 2, 3, 4]",
+        "__import__('os').getcwd()",
+        "_payload()",
+        "[True, 0.2, 0.3, 0.4]",
+        "[0.1, 0.2]",
+        "[0.1, 0.2, 0.3, 0.4, 0.5]",
+        "[float('nan'), 0.2, 0.3, 0.4]",
+        "[1e1000, 0.2, 0.3, 0.4]",
+    ],
+)
+def test_coordinate_parser_rejects_non_finite_or_non_numeric_boxes(box):
+    assert uitars.parse_box_coordinates(box) is None
+
+
+@pytest.mark.parametrize(
+    ("box", "expected"),
+    [
+        ("[0.1, 0.2, 0.3, 0.4]", (0.1, 0.2, 0.3, 0.4)),
+        ("(0, 1, 2, 3)", (0.0, 1.0, 2.0, 3.0)),
+    ],
+)
+def test_coordinate_parser_accepts_finite_four_number_sequences(box, expected):
+    assert uitars.parse_box_coordinates(box) == expected
+
+
+def test_valid_model_coordinate_still_produces_click():
+    actions = convert_model_action('click(start_box="(500, 500)")')
+
+    assert len(actions) == 1
+    assert actions[0]["type"] == "computer_call"
+    assert actions[0]["action"]["x"] == 500
+    assert actions[0]["action"]["y"] == 500


### PR DESCRIPTION
## Summary

- replace each `eval()` of model-supplied UITARS coordinate data with a literal-only parser
- accept only four finite numeric values and reject booleans, expressions, malformed lengths, and infinities
- skip malformed click, scroll, and drag actions instead of executing or partially applying them
- cover the complete model-response-to-computer-action path with regression tests

## Why

When coordinate normalization failed, the original model output reached `eval()` in `convert_to_computer_actions`. A malicious or compromised model response could therefore execute Python in the agent process. Coordinate boxes are data and should never be interpreted as code.

This is a current-main alternative to #1954. It also validates coordinate length and finiteness and fails closed for malformed scroll coordinates.

## Tests

- `uv run ruff check libs/python/agent/cua_agent/loops/uitars.py libs/python/agent/tests/test_uitars_coordinate_security.py`
- `CUA_TELEMETRY_ENABLED=false uv run --group test pytest libs/python/agent/tests -q` (48 passed)

Closes #1953