### PR TITLE
fix(computer-server): harden unauthenticated network access

### DIFF
--- a/libs/python/computer-server/README.md
+++ b/libs/python/computer-server/README.md
@@ -32,15 +32,19 @@ python -m computer_server
 # Or with custom port
 python -m computer_server --port 8080
 
-# Allow external access explicitly
-python -m computer_server --host 0.0.0.0
+# Authenticated sandbox/cloud deployments can bind externally
+CONTAINER_NAME=my-sandbox python -m computer_server --host 0.0.0.0
 
 # With resolution scaling (useful for Retina displays or VMs)
 python -m computer_server --width 1512 --height 982
 ```
 
 By default the server binds to `127.0.0.1`. Deployments that need access from
-other hosts should pass `--host 0.0.0.0` or another explicit interface.
+other hosts must configure `CONTAINER_NAME` authentication before passing
+`--host 0.0.0.0` or another non-loopback interface. Local mode has no request
+authentication, so remote binds are refused by default. For isolated development
+networks only, `CUA_ALLOW_UNAUTHENTICATED_REMOTE=1` explicitly acknowledges the
+remote shell and filesystem exposure.
 
 This provides:
 

--- a/libs/python/computer-server/computer_server/cli.py
+++ b/libs/python/computer-server/computer_server/cli.py
@@ -8,6 +8,8 @@ import os
 import sys
 from typing import List, Optional
 
+from .network_security import InsecureBindError, resolve_bind_host
+
 logger = logging.getLogger(__name__)
 
 
@@ -32,7 +34,10 @@ def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--host",
         default="127.0.0.1",
-        help="Host to bind the server to (default: 127.0.0.1; use 0.0.0.0 for external access)",
+        help=(
+            "Host to bind the server to (default: 127.0.0.1). Unauthenticated "
+            "non-loopback binds are refused unless explicitly acknowledged."
+        ),
     )
     parser.add_argument(
         "--port", type=int, default=8000, help="Port to bind the server to (default: 8000)"
@@ -111,8 +116,14 @@ def main() -> None:
         vnc_host = args.vnc_host or os.environ.get("CUA_VNC_HOST")
         logger.info(f"VNC backend enabled → {vnc_host}:{args.vnc_port}")
 
+    try:
+        bind_host = resolve_bind_host(args.host)
+    except InsecureBindError as exc:
+        logger.error(str(exc))
+        sys.exit(2)
+
     # Create and start the server
-    logger.info(f"Starting Cua Computer API server on {args.host}:{args.port}...")
+    logger.info(f"Starting Cua Computer API server on {bind_host}:{args.port}...")
     logger.info("HTTP API available at /ws, /cmd, /status endpoints")
     logger.info("MCP server available at /mcp endpoint (if fastmcp installed)")
 
@@ -135,7 +146,7 @@ def main() -> None:
     # the module-level handler factory runs in main.py.
     from .server import Server
 
-    server = Server(host=args.host, port=args.port, log_level=args.log_level, **ssl_args)
+    server = Server(host=bind_host, port=args.port, log_level=args.log_level, **ssl_args)
 
     try:
         server.start()

--- a/libs/python/computer-server/computer_server/main.py
+++ b/libs/python/computer-server/computer_server/main.py
@@ -11,6 +11,7 @@ import traceback
 from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 from typing import Any, Dict, List, Literal, Optional, Union, cast
+from urllib.parse import urlsplit
 
 import aiohttp
 import uvicorn
@@ -28,6 +29,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from .browser import get_browser_manager
 from .handlers.factory import OS_TYPE, HandlerFactory
+from .network_security import is_loopback_host
 
 # Try to import MCP server for SSE integration
 try:
@@ -177,6 +179,59 @@ class UnavailableWithoutContainerMiddleware:
 
 
 app.add_middleware(UnavailableWithoutContainerMiddleware)
+
+
+class LocalOriginGuard:
+    """Block web pages from driving an unauthenticated local server."""
+
+    _DETAIL = "Cross-site browser access to the local computer server is not allowed"
+
+    def __init__(self, app):
+        self.app = app
+
+    @classmethod
+    def _origin_allowed(cls, origin: str) -> bool:
+        try:
+            hostname = urlsplit(origin).hostname
+        except ValueError:
+            return False
+        return bool(hostname and is_loopback_host(hostname))
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") not in ("http", "websocket") or os.environ.get("CONTAINER_NAME"):
+            await self.app(scope, receive, send)
+            return
+
+        origins = [
+            value.decode("latin-1")
+            for key, value in scope.get("headers", [])
+            if key.lower() == b"origin"
+        ]
+        if not origins or all(self._origin_allowed(origin) for origin in origins):
+            await self.app(scope, receive, send)
+            return
+
+        if scope["type"] == "http":
+            body = json.dumps({"detail": self._DETAIL}).encode()
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 403,
+                    "headers": [
+                        (b"content-type", b"application/json"),
+                        (b"content-length", str(len(body)).encode()),
+                    ],
+                }
+            )
+            await send({"type": "http.response.body", "body": body})
+            return
+
+        event = await receive()
+        if event.get("type") == "websocket.connect":
+            await send({"type": "websocket.close", "code": 1008})
+
+
+app.add_middleware(LocalOriginGuard)
 
 # CORS configuration
 origins = ["*"]
@@ -1430,4 +1485,4 @@ async def playwright_exec_endpoint(
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host="127.0.0.1", port=8000)

--- a/libs/python/computer-server/computer_server/network_security.py
+++ b/libs/python/computer-server/computer_server/network_security.py
@@ -1,0 +1,40 @@
+"""Network exposure checks for the computer-control server."""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+
+
+class InsecureBindError(ValueError):
+    """Raised when unauthenticated local mode would bind a remote interface."""
+
+
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes", "y", "on")
+
+
+def is_loopback_host(host: str) -> bool:
+    """Return whether a bind or origin host is unambiguously loopback-only."""
+    normalized = host.strip().lower().strip("[]")
+    if normalized == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def resolve_bind_host(host: str) -> str:
+    """Refuse unauthenticated non-loopback binds unless explicitly enabled."""
+    if os.environ.get("CONTAINER_NAME") or is_loopback_host(host):
+        return host
+    if _env_truthy("CUA_ALLOW_UNAUTHENTICATED_REMOTE"):
+        return host
+
+    raise InsecureBindError(
+        f"Refusing to bind {host!r} while local authentication is disabled. "
+        "Use a loopback host, configure CONTAINER_NAME authentication, or set "
+        "CUA_ALLOW_UNAUTHENTICATED_REMOTE=1 to acknowledge the remote shell and "
+        "filesystem exposure."
+    )

--- a/libs/python/computer-server/computer_server/server.py
+++ b/libs/python/computer-server/computer_server/server.py
@@ -11,6 +11,7 @@ import uvicorn
 from fastapi import FastAPI
 
 from .main import app as fastapi_app
+from .network_security import resolve_bind_host
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +53,7 @@ class Server:
             ssl_keyfile: Path to SSL private key file (for HTTPS)
             ssl_certfile: Path to SSL certificate file (for HTTPS)
         """
-        self.host = host
+        self.host = resolve_bind_host(host)
         self.port = port
         self.log_level = log_level
         self.ssl_keyfile = ssl_keyfile

--- a/libs/python/computer-server/tests/test_network_security.py
+++ b/libs/python/computer-server/tests/test_network_security.py
@@ -1,0 +1,111 @@
+"""Security regression tests for computer-server network exposure."""
+
+from __future__ import annotations
+
+import pytest
+from computer_server.network_security import (
+    InsecureBindError,
+    is_loopback_host,
+    resolve_bind_host,
+)
+
+
+@pytest.fixture
+def clean_network_env(monkeypatch):
+    for name in ("CONTAINER_NAME", "CUA_ALLOW_UNAUTHENTICATED_REMOTE"):
+        monkeypatch.delenv(name, raising=False)
+    return monkeypatch
+
+
+@pytest.mark.parametrize("host", ["localhost", "127.0.0.1", "127.0.0.42", "::1", "[::1]"])
+def test_loopback_hosts_are_recognized(host):
+    assert is_loopback_host(host) is True
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "::", "192.168.1.10", "example.com", ""])
+def test_remote_hosts_are_not_treated_as_loopback(host):
+    assert is_loopback_host(host) is False
+
+
+def test_local_mode_refuses_remote_bind(clean_network_env):
+    with pytest.raises(InsecureBindError, match="local authentication is disabled"):
+        resolve_bind_host("0.0.0.0")
+
+
+def test_authenticated_container_allows_remote_bind(clean_network_env):
+    clean_network_env.setenv("CONTAINER_NAME", "sandbox-1")
+    assert resolve_bind_host("0.0.0.0") == "0.0.0.0"
+
+
+def test_explicit_override_allows_remote_bind(clean_network_env):
+    clean_network_env.setenv("CUA_ALLOW_UNAUTHENTICATED_REMOTE", "true")
+    assert resolve_bind_host("0.0.0.0") == "0.0.0.0"
+
+
+def test_programmatic_server_uses_same_bind_guard(clean_network_env):
+    from computer_server.server import Server
+
+    with pytest.raises(InsecureBindError):
+        Server(host="0.0.0.0")
+
+
+async def run_origin_guard(monkeypatch, *, origin=None, scope_type="http", container_name=None):
+    from computer_server.main import LocalOriginGuard
+
+    if container_name is None:
+        monkeypatch.delenv("CONTAINER_NAME", raising=False)
+    else:
+        monkeypatch.setenv("CONTAINER_NAME", container_name)
+
+    called = False
+    sent = []
+
+    async def inner(scope, receive, send):
+        nonlocal called
+        called = True
+
+    headers = [] if origin is None else [(b"origin", origin.encode("latin-1"))]
+    scope = {"type": scope_type, "path": "/mcp", "headers": headers}
+
+    async def receive():
+        return {"type": "websocket.connect"}
+
+    async def send(message):
+        sent.append(message)
+
+    await LocalOriginGuard(inner)(scope, receive, send)
+    return called, sent
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("origin", [None, "http://localhost:3000", "http://127.0.0.1"])
+async def test_native_and_loopback_clients_reach_local_server(monkeypatch, origin):
+    called, sent = await run_origin_guard(monkeypatch, origin=origin)
+    assert called is True
+    assert sent == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("origin", ["https://attacker.example", "null", "not a URL"])
+async def test_cross_site_http_is_rejected_in_local_mode(monkeypatch, origin):
+    called, sent = await run_origin_guard(monkeypatch, origin=origin)
+    assert called is False
+    assert sent[0]["status"] == 403
+
+
+@pytest.mark.asyncio
+async def test_cross_site_websocket_is_rejected_in_local_mode(monkeypatch):
+    called, sent = await run_origin_guard(
+        monkeypatch, origin="https://attacker.example", scope_type="websocket"
+    )
+    assert called is False
+    assert sent == [{"type": "websocket.close", "code": 1008}]
+
+
+@pytest.mark.asyncio
+async def test_authenticated_container_keeps_external_origin_support(monkeypatch):
+    called, sent = await run_origin_guard(
+        monkeypatch, origin="https://control.cua.ai", container_name="sandbox-1"
+    )
+    assert called is True
+    assert sent == []


### PR DESCRIPTION
## Summary

- refuse non-loopback binds when local request authentication is disabled
- apply the same bind check to the CLI and programmatic `Server` API
- make direct `main.py` execution bind to loopback
- reject non-loopback browser origins across local HTTP, WebSocket, MCP, PTY, shell, file, agent, and Playwright routes
- document authenticated remote deployment and the explicit development-only override

## Why

Local mode intentionally permits requests without a `CONTAINER_NAME`, but the server exposes shell execution, arbitrary filesystem access, PTYs, browser control, and desktop input. Binding that mode to a network interface turns the service into unauthenticated remote code execution. Binding to loopback alone also leaves it reachable from a malicious web page unless browser origins are checked.

Current `main` already defaults the normal CLI to `127.0.0.1`. This change closes the remaining startup paths, prevents an explicit remote bind from silently disabling the protection, and covers the mounted MCP and other control routes that were not included in #1899. Authenticated container deployments keep their existing external-origin behavior. An isolated development setup can acknowledge the risk with `CUA_ALLOW_UNAUTHENTICATED_REMOTE=1`.

## Tests

- Black and Ruff checks for all changed Python files
- `CUA_TELEMETRY_ENABLED=false uv run --group test pytest libs/python/computer-server/tests -q` (75 passed)

Closes #1892