### PR TITLE
feat(cua-driver): unify tool telemetry ownership

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -1446,6 +1446,7 @@ pub fn run_call(
             args: Some(args_for_daemon),
             // CLI one-shot is its own ephemeral, anonymous/global session.
             session_id: None,
+            observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
         };
         match crate::serve::send_request(&socket_path, &req) {
             Ok(resp) => {
@@ -1689,6 +1690,7 @@ pub fn run_recording_cmd(subcommand: &str, args: &[String], socket: Option<&str>
                 // CLI `recording start` is anonymous — the recording is owned by
                 // nobody, so only an unconditional stop (CLI / manual) reaps it.
                 session_id: None,
+                observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
             };
             match crate::serve::send_request(&socket_path, &req) {
                 Ok(resp) if resp.ok => {
@@ -1699,6 +1701,7 @@ pub fn run_recording_cmd(subcommand: &str, args: &[String], socket: Option<&str>
                         name: Some("get_recording_state".into()),
                         args: Some(serde_json::json!({})),
                         session_id: None,
+                        observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
                     };
                     if let Ok(sr) = crate::serve::send_request(&socket_path, &state_req) {
                         if let Some(result) = sr.result {
@@ -1724,6 +1727,7 @@ pub fn run_recording_cmd(subcommand: &str, args: &[String], socket: Option<&str>
                 name: Some("stop_recording".into()),
                 args: Some(serde_json::json!({})),
                 session_id: None,
+                observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
             };
             match crate::serve::send_request(&socket_path, &req) {
                 Ok(resp) if resp.ok => println!("Recording stopped."),
@@ -1741,6 +1745,7 @@ pub fn run_recording_cmd(subcommand: &str, args: &[String], socket: Option<&str>
                 name: Some("get_recording_state".into()),
                 args: Some(serde_json::json!({})),
                 session_id: None,
+                observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
             };
             match crate::serve::send_request(&socket_path, &req) {
                 Ok(resp) if resp.ok => {
@@ -1982,6 +1987,7 @@ fn run_permissions_status(json: bool) {
             name: Some("check_permissions".into()),
             args: Some(serde_json::json!({ "prompt": false })),
             session_id: None,
+            observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
         };
         crate::serve::send_request(&socket, &req)
             .ok()
@@ -2109,6 +2115,7 @@ fn run_permissions_grant() {
             name: Some("check_permissions".into()),
             args: Some(serde_json::json!({ "prompt": false })),
             session_id: None,
+            observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
         };
         let poll_deadline =
             std::time::Instant::now() + std::time::Duration::from_secs(180);
@@ -2824,6 +2831,7 @@ pub fn run_config_cmd(
                     args: Some(serde_json::json!({})),
                     // CLI `config get` reads the persisted global (anonymous).
                     session_id: None,
+                    observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
                 };
                 if let Ok(resp) = crate::serve::send_request(&socket_path, &req) {
                     if resp.ok {
@@ -2905,6 +2913,7 @@ pub fn run_config_cmd(
                     // CLI `config set` is anonymous → writes the persisted
                     // global default (the only writer of the on-disk config).
                     session_id: None,
+                    observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
                 };
                 if let Ok(resp) = crate::serve::send_request(&socket_path, &req) {
                     if resp.ok {
@@ -2915,6 +2924,7 @@ pub fn run_config_cmd(
                             name: Some("get_config".into()),
                             args: Some(serde_json::json!({})),
                             session_id: None,
+                            observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
                         };
                         if let Ok(r2) = crate::serve::send_request(&socket_path, &req2) {
                             if let Some(result) = r2.result {

--- a/libs/cua-driver/rust/crates/cua-driver/src/mcp_http.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/mcp_http.rs
@@ -112,6 +112,7 @@ async fn dispatch(body: &[u8], registry: &Arc<ToolRegistry>) -> Option<String> {
     if req.id.is_none() {
         return None; // notification
     }
+    let initialize_metadata = req.initialize_metadata();
     let id = req.id.clone().unwrap_or(serde_json::Value::Null);
     apply_session_identity(&mut req);
     let timer = http_tool_observation_timer(&req, registry);
@@ -119,6 +120,12 @@ async fn dispatch(body: &[u8], registry: &Arc<ToolRegistry>) -> Option<String> {
     if let Some(timer) = timer {
         crate::telemetry::capture_tool_completed(
             timer.finish(&response),
+            crate::telemetry::Transport::McpHttp,
+        );
+    }
+    if let Some(metadata) = initialize_metadata {
+        crate::telemetry::capture_mcp_session_started(
+            metadata,
             crate::telemetry::Transport::McpHttp,
         );
     }

--- a/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
@@ -33,7 +33,9 @@ use cua_driver_core::server::{
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tracing::{debug, error, warn};
 
-use crate::serve::{is_daemon_listening, send_request, DaemonRequest};
+use crate::serve::{
+    is_daemon_listening, send_request, DaemonRequest, ToolObservationOrigin,
+};
 
 /// Run the MCP stdio proxy. Reads JSON-RPC lines from stdin, forwards
 /// the body of each `tools/list` / `tools/call` to the daemon at
@@ -97,7 +99,8 @@ pub async fn run_proxy(socket_path: String) -> anyhow::Result<()> {
     // static for the lifetime of the daemon, so polling on every
     // `tools/list` would waste a round-trip per call. Swift does the
     // same caching in `fetchProxyToolList`.
-    let cached_tools_list = fetch_tools_list_from_daemon(&socket_path, &session_id)?;
+    let (cached_tools_list, daemon_observes_tool_calls) =
+        fetch_tools_list_from_daemon(&socket_path, &session_id)?;
     let cached_tools_list = Arc::new(cached_tools_list);
 
     let stdin = tokio::io::stdin();
@@ -132,15 +135,25 @@ pub async fn run_proxy(socket_path: String) -> anyhow::Result<()> {
                 let initialize_metadata = (!session_observed)
                     .then(|| req.initialize_metadata())
                     .flatten();
-                let tool_timer = tool_observation_timer(
-                    &req,
-                    |name| proxy_knows_tool(&cached_tools_list, name),
-                    StdioExecutionPath::DaemonProxy,
-                );
+                let tool_timer = (!daemon_observes_tool_calls)
+                    .then(|| {
+                        tool_observation_timer(
+                            &req,
+                            |name| proxy_knows_tool(&cached_tools_list, name),
+                            StdioExecutionPath::DaemonProxy,
+                        )
+                    })
+                    .flatten();
                 let id = req.id.clone().unwrap_or(serde_json::Value::Null);
-                let response =
-                    handle_proxy_request(req, id, &socket_path, &cached_tools_list, &session_id)
-                        .await;
+                let response = handle_proxy_request(
+                    req,
+                    id,
+                    &socket_path,
+                    &cached_tools_list,
+                    &session_id,
+                    daemon_observes_tool_calls,
+                )
+                .await;
                 if let Some(metadata) = initialize_metadata {
                     observe_proxy_session_started(metadata);
                     session_observed = true;
@@ -207,6 +220,7 @@ async fn run_control_connection(socket_path: String, session_id: String) {
         name: None,
         args: None,
         session_id: Some(session_id.clone()),
+        observation_origin: None,
     };
     let line = match serde_json::to_string(&begin) {
         Ok(s) => s + "\n",
@@ -326,12 +340,13 @@ fn mint_session_id() -> String {
 fn fetch_tools_list_from_daemon(
     socket_path: &str,
     session_id: &str,
-) -> anyhow::Result<serde_json::Value> {
+) -> anyhow::Result<(serde_json::Value, bool)> {
     let req = DaemonRequest {
         method: "list".into(),
         name: None,
         args: None,
         session_id: Some(session_id.to_owned()),
+        observation_origin: None,
     };
     let resp = send_request(socket_path, &req)?;
     if !resp.ok {
@@ -422,11 +437,23 @@ fn fetch_tools_list_from_daemon(
         .cloned()
         .unwrap_or_else(|| serde_json::Value::String("1".to_owned()));
 
-    Ok(serde_json::json!({
-        "tools": mcp_tools,
-        "capability_version": capability_version,
-        "schema_version": schema_version,
-    }))
+    let daemon_observes_tool_calls = daemon_owns_tool_observation(&result);
+
+    Ok((
+        serde_json::json!({
+            "tools": mcp_tools,
+            "capability_version": capability_version,
+            "schema_version": schema_version,
+        }),
+        daemon_observes_tool_calls,
+    ))
+}
+
+fn daemon_owns_tool_observation(result: &serde_json::Value) -> bool {
+    result
+        .get("tool_observation_owner")
+        .and_then(serde_json::Value::as_str)
+        == Some("daemon")
 }
 
 /// JSON-RPC method dispatcher for the proxy. Mirrors
@@ -444,6 +471,7 @@ async fn handle_proxy_request(
     socket_path: &str,
     cached_tools_list: &Arc<serde_json::Value>,
     session_id: &str,
+    daemon_observes_tool_calls: bool,
 ) -> Response {
     match req.method.as_str() {
         "initialize" => Response::ok(id, initialize_result()),
@@ -452,7 +480,17 @@ async fn handle_proxy_request(
 
         "tools/call" => match req.tool_call() {
             Err(e) => Response::error(id, -32602, format!("Invalid params: {e}")),
-            Ok(call) => forward_tool_call(id, call.name, call.args, socket_path, session_id).await,
+            Ok(call) => {
+                forward_tool_call(
+                    id,
+                    call.name,
+                    call.args,
+                    socket_path,
+                    session_id,
+                    daemon_observes_tool_calls,
+                )
+                .await
+            }
         },
 
         other => {
@@ -481,12 +519,15 @@ async fn forward_tool_call(
     args: serde_json::Value,
     socket_path: &str,
     session_id: &str,
+    daemon_observes_tool_calls: bool,
 ) -> Response {
     let req = DaemonRequest {
         method: "call".into(),
         name: Some(name.clone()),
         args: Some(args),
         session_id: Some(session_id.to_owned()),
+        observation_origin: daemon_observes_tool_calls
+            .then_some(ToolObservationOrigin::McpProxy),
     };
 
     // The daemon client is sync, so jump to a blocking thread to keep
@@ -635,5 +676,16 @@ mod tests {
         assert!(proxy_knows_tool(&cached, "type_text_chars"), "deprecated alias stays bounded/known");
         assert!(!proxy_knows_tool(&cached, "click/private-user-value"));
         assert!(!proxy_knows_tool(&cached, ""));
+    }
+
+    #[test]
+    fn observation_ownership_requires_the_daemon_capability() {
+        assert!(daemon_owns_tool_observation(&serde_json::json!({
+            "tool_observation_owner": "daemon"
+        })));
+        assert!(!daemon_owns_tool_observation(&serde_json::json!({})));
+        assert!(!daemon_owns_tool_observation(&serde_json::json!({
+            "tool_observation_owner": "proxy"
+        })));
     }
 }

--- a/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
@@ -269,6 +269,13 @@ pub fn default_pid_file_path() -> String {
 
 // ── Protocol types ────────────────────────────────────────────────────────────
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolObservationOrigin {
+    McpProxy,
+    Direct,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DaemonRequest {
     pub method: String,
@@ -286,6 +293,12 @@ pub struct DaemonRequest {
     /// serde defaults a missing field to `None` on deserialize.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
+    /// Bounded internal routing metadata for exactly-once completion
+    /// observation. New proxies set `mcp_proxy` only after the daemon
+    /// advertises ownership; direct protocol clients may set `direct`.
+    /// Older peers ignore the additive field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observation_origin: Option<ToolObservationOrigin>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -306,6 +319,130 @@ impl DaemonResponse {
     pub fn err(msg: impl Into<String>, code: i32) -> Self {
         Self { ok: false, result: None, error: Some(msg.into()), exit_code: Some(code) }
     }
+}
+
+fn daemon_observation_transport(req: &DaemonRequest) -> Option<crate::telemetry::Transport> {
+    match req.observation_origin {
+        Some(ToolObservationOrigin::McpProxy) => Some(crate::telemetry::Transport::McpStdio),
+        Some(ToolObservationOrigin::Direct) => Some(crate::telemetry::Transport::Daemon),
+        // Legacy callers did not declare ownership. Leaving them unobserved
+        // preserves the legacy proxy as the single emitter during rollout;
+        // current direct callers explicitly select `Direct` above.
+        None => None,
+    }
+}
+
+fn observe_daemon_result(
+    observation: Option<(
+        cua_driver_core::server::ToolObservationTimer,
+        crate::telemetry::Transport,
+    )>,
+    result: serde_json::Value,
+) -> serde_json::Value {
+    let Some((timer, transport)) = observation else {
+        return result;
+    };
+    let response = cua_driver_core::protocol::Response::ok(serde_json::Value::Null, result);
+    crate::telemetry::capture_tool_completed(timer.finish(&response), transport);
+    match response.body {
+        cua_driver_core::protocol::ResponseBody::Result { result } => result,
+        cua_driver_core::protocol::ResponseBody::Error { .. } => unreachable!("constructed ok response"),
+    }
+}
+
+fn observe_daemon_error(
+    observation: Option<(
+        cua_driver_core::server::ToolObservationTimer,
+        crate::telemetry::Transport,
+    )>,
+    exit_code: i32,
+) {
+    let Some((timer, transport)) = observation else {
+        return;
+    };
+    let response = cua_driver_core::protocol::Response::ok(
+        serde_json::Value::Null,
+        serde_json::json!({
+            "content": [],
+            "isError": true,
+            "structuredContent": { "exit_code": exit_code },
+        }),
+    );
+    crate::telemetry::capture_tool_completed(timer.finish(&response), transport);
+}
+
+async fn invoke_daemon_tool(
+    registry: &std::sync::Arc<cua_driver_core::tool::ToolRegistry>,
+    req: DaemonRequest,
+) -> DaemonResponse {
+    let observation_transport = daemon_observation_transport(&req);
+    let raw_name = req.name.as_deref().unwrap_or("").to_owned();
+    let tool_name = if raw_name == "type_text_chars" {
+        eprintln!("[cua-driver-rs] deprecated tool name 'type_text_chars' — use 'type_text' instead.");
+        "type_text".to_owned()
+    } else {
+        raw_name
+    };
+    let known_tool = registry.get_def(&tool_name).is_some();
+    let observation = observation_transport.map(|transport| {
+        (
+            cua_driver_core::server::ToolObservationTimer::start(
+                tool_name.clone(),
+                known_tool,
+                true,
+                cua_driver_core::server::StdioExecutionPath::InProcess,
+            ),
+            transport,
+        )
+    });
+    let mut args = req
+        .args
+        .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
+    let effective_session = apply_session_identity(&mut args, &req.session_id);
+
+    if let Some(sid) = &effective_session {
+        if !is_session_lifecycle_tool(&tool_name)
+            && cua_driver_core::session::is_session_ended(sid)
+        {
+            observe_daemon_error(observation, 1);
+            return DaemonResponse::err(
+                format!(
+                    "session '{sid}' has ended; tool call '{tool_name}' was rejected. \
+                     Call start_session with this id to revive it before issuing further \
+                     actions, or use a new session id."
+                ),
+                1,
+            );
+        }
+    }
+
+    if !known_tool {
+        observe_daemon_error(observation, 64);
+        return DaemonResponse::err(format!("Unknown tool: {tool_name}"), 64);
+    }
+
+    let result = registry.invoke(&tool_name, args).await;
+    let is_error = result.is_error.unwrap_or(false);
+    let content: Vec<serde_json::Value> = result
+        .content
+        .iter()
+        .map(|item| match item {
+            cua_driver_core::protocol::Content::Text { text, .. } => {
+                serde_json::json!({"type":"text","text":text})
+            }
+            cua_driver_core::protocol::Content::Image {
+                data, mime_type, ..
+            } => serde_json::json!({"type":"image","data":data,"mimeType":mime_type}),
+        })
+        .collect();
+    let mut result_value = serde_json::json!({
+        "content": content,
+        "isError": is_error,
+    });
+    if let Some(structured) = result.structured_content {
+        result_value["structuredContent"] = structured;
+    }
+    DaemonResponse::ok(observe_daemon_result(observation, result_value))
 }
 
 // ── Client ────────────────────────────────────────────────────────────────────
@@ -350,7 +487,13 @@ pub fn is_daemon_listening(socket_path: &str) -> bool {
     }
     #[cfg(not(target_os = "windows"))]
     {
-        let req = DaemonRequest { method: "list".into(), name: None, args: None, session_id: None };
+        let req = DaemonRequest {
+            method: "list".into(),
+            name: None,
+            args: None,
+            session_id: None,
+            observation_origin: None,
+        };
         send_request(socket_path, &req)
             .ok()
             .map(|r| r.ok)
@@ -622,6 +765,7 @@ pub async fn run_serve(
                                     "tools": tools,
                                     "capability_version": cua_driver_core::tool::CAPABILITY_VERSION,
                                     "schema_version": "1",
+                                    "tool_observation_owner": "daemon",
                                 }));
                                 let _ = writer.write_all(
                                     (serde_json::to_string(&resp).unwrap() + "\n").as_bytes()
@@ -657,82 +801,7 @@ pub async fn run_serve(
                                     now_unix_secs(),
                                     std::sync::atomic::Ordering::Relaxed,
                                 );
-                                let raw_name = req.name.as_deref().unwrap_or("").to_owned();
-                                // Deprecated alias: `type_text_chars` → `type_text`.
-                                // Mirrors Swift's `ToolRegistry.call` aliasing.
-                                let tool_name = if raw_name == "type_text_chars" {
-                                    eprintln!("[cua-driver-rs] deprecated tool name 'type_text_chars' — use 'type_text' instead.");
-                                    "type_text".to_owned()
-                                } else { raw_name.clone() };
-                                let mut args = req.args.unwrap_or(serde_json::Value::Object(
-                                    serde_json::Map::new()
-                                ));
-                                // Apply the caller-declared session identity
-                                // (explicit `session` → `_session_id`; minted id
-                                // as the recording/config fallback only). See
-                                // `apply_session_identity` for the full rationale
-                                // and the cursor's explicit-required contract.
-                                let effective_session =
-                                    apply_session_identity(&mut args, &req.session_id);
-                                // Resurrection guard: a call whose effective
-                                // session has already ended (end_session / idle
-                                // TTL / control-connection EOF) must NOT run — it
-                                // would re-create session-owned state (cursor,
-                                // config override, recording) the reaper already
-                                // passed. Reject it LOUDLY (isError) so a stray
-                                // late action is visibly a failure, not a phantom
-                                // success a caller silently trusts. The session-
-                                // lifecycle tools are EXEMPT: `start_session`
-                                // revives an ended id (explicit, intentional reuse)
-                                // and `end_session` stays idempotent. Live and
-                                // anonymous calls pass through unchanged.
-                                if let Some(sid) = &effective_session {
-                                    if !is_session_lifecycle_tool(&tool_name)
-                                        && cua_driver_core::session::is_session_ended(sid)
-                                    {
-                                        let resp = DaemonResponse::err(
-                                            format!(
-                                                "session '{sid}' has ended; tool call '{tool_name}' was \
-                                                 rejected. Call start_session with this id to revive it \
-                                                 before issuing further actions, or use a new session id."
-                                            ),
-                                            1,
-                                        );
-                                        let _ = writer.write_all(
-                                            (serde_json::to_string(&resp).unwrap() + "\n").as_bytes()
-                                        ).await;
-                                        continue;
-                                    }
-                                }
-                                if reg.get_def(&tool_name).is_none() {
-                                    let resp = DaemonResponse::err(
-                                        format!("Unknown tool: {tool_name}"), 64
-                                    );
-                                    let _ = writer.write_all(
-                                        (serde_json::to_string(&resp).unwrap() + "\n").as_bytes()
-                                    ).await;
-                                    continue;
-                                }
-                                let result = reg.invoke(&tool_name, args).await;
-                                let is_err = result.is_error.unwrap_or(false);
-                                let content: Vec<serde_json::Value> = result.content.iter().map(|c| {
-                                    match c {
-                                        cua_driver_core::protocol::Content::Text { text, .. } =>
-                                            serde_json::json!({"type":"text","text":text}),
-                                        cua_driver_core::protocol::Content::Image { data, mime_type, .. } =>
-                                            serde_json::json!({"type":"image","data":data,"mimeType":mime_type}),
-                                    }
-                                }).collect();
-                                let mut result_obj = serde_json::json!({
-                                    "content": content,
-                                    "isError": is_err
-                                });
-                                if let Some(sc) = result.structured_content {
-                                    result_obj["structuredContent"] = sc;
-                                }
-                                // Preserve tool-level `isError` and structured
-                                // content inside a successful daemon transport.
-                                let resp = DaemonResponse::ok(result_obj);
+                                let resp = invoke_daemon_tool(&reg, req).await;
                                 let _ = writer.write_all(
                                     (serde_json::to_string(&resp).unwrap() + "\n").as_bytes()
                                 ).await;
@@ -1172,6 +1241,7 @@ pub async fn run_serve(
                                     "tools": tools,
                                     "capability_version": cua_driver_core::tool::CAPABILITY_VERSION,
                                     "schema_version": "1",
+                                    "tool_observation_owner": "daemon",
                                 }));
                                 let _ = writer.write_all(
                                     (serde_json::to_string(&resp).unwrap() + "\n").as_bytes()
@@ -1196,61 +1266,7 @@ pub async fn run_serve(
                                     now_unix_secs(),
                                     std::sync::atomic::Ordering::Relaxed,
                                 );
-                                let raw_name = req.name.as_deref().unwrap_or("").to_owned();
-                                let tool_name = if raw_name == "type_text_chars" {
-                                    eprintln!("[cua-driver-rs] deprecated tool name 'type_text_chars' — use 'type_text' instead.");
-                                    "type_text".to_owned()
-                                } else { raw_name.clone() };
-                                let mut args = req.args.unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
-                                // Apply the caller-declared session identity
-                                // (see the unix branch + apply_session_identity).
-                                let effective_session =
-                                    apply_session_identity(&mut args, &req.session_id);
-                                // Resurrection guard on the effective session
-                                // (see the unix branch for the full rationale):
-                                // reject a stray late action on a dead id LOUDLY,
-                                // but exempt the lifecycle tools so start_session
-                                // can revive and end_session stays idempotent.
-                                if let Some(sid) = &effective_session {
-                                    if !is_session_lifecycle_tool(&tool_name)
-                                        && cua_driver_core::session::is_session_ended(sid)
-                                    {
-                                        let resp = DaemonResponse::err(
-                                            format!(
-                                                "session '{sid}' has ended; tool call '{tool_name}' was \
-                                                 rejected. Call start_session with this id to revive it \
-                                                 before issuing further actions, or use a new session id."
-                                            ),
-                                            1,
-                                        );
-                                        let _ = writer.write_all(
-                                            (serde_json::to_string(&resp).unwrap() + "\n").as_bytes()
-                                        ).await;
-                                        continue;
-                                    }
-                                }
-                                if reg.get_def(&tool_name).is_none() {
-                                    let resp = DaemonResponse::err(format!("Unknown tool: {tool_name}"), 64);
-                                    let _ = writer.write_all(
-                                        (serde_json::to_string(&resp).unwrap() + "\n").as_bytes()
-                                    ).await;
-                                    continue;
-                                }
-                                let result = reg.invoke(&tool_name, args).await;
-                                let is_err = result.is_error.unwrap_or(false);
-                                let content: Vec<serde_json::Value> = result.content.iter().map(|c| match c {
-                                    cua_driver_core::protocol::Content::Text { text, .. } =>
-                                        serde_json::json!({"type":"text","text":text}),
-                                    cua_driver_core::protocol::Content::Image { data, mime_type, .. } =>
-                                        serde_json::json!({"type":"image","data":data,"mimeType":mime_type}),
-                                }).collect();
-                                let mut result_obj = serde_json::json!({"content": content, "isError": is_err});
-                                if let Some(sc) = result.structured_content {
-                                    result_obj["structuredContent"] = sc;
-                                }
-                                // Preserve tool-level `isError` and structured
-                                // content inside a successful daemon transport.
-                                let resp = DaemonResponse::ok(result_obj);
+                                let resp = invoke_daemon_tool(&reg, req).await;
                                 let _ = writer.write_all(
                                     (serde_json::to_string(&resp).unwrap() + "\n").as_bytes()
                                 ).await;
@@ -1426,7 +1442,13 @@ pub fn run_stop_cmd(socket_path: &str) {
         std::process::exit(1);
     }
 
-    let req = DaemonRequest { method: "shutdown".into(), name: None, args: None, session_id: None };
+    let req = DaemonRequest {
+        method: "shutdown".into(),
+        name: None,
+        args: None,
+        session_id: None,
+        observation_origin: None,
+    };
     match send_request(socket_path, &req) {
         Ok(_) => {
             // Poll until daemon stops responding (up to 2 seconds).
@@ -1536,6 +1558,7 @@ mod gate_tests {
             name: Some("probe".into()),
             args: Some(serde_json::json!({})),
             session_id: sid.map(|s| s.to_owned()),
+            observation_origin: None,
         }
     }
 
@@ -1596,6 +1619,7 @@ mod gate_tests {
             name: None,
             args: None,
             session_id: Some(sid.to_owned()),
+            observation_origin: None,
         };
         let resp = tokio::task::spawn_blocking(move || send_request(&socket2, &end))
             .await
@@ -1632,6 +1656,7 @@ mod gate_tests {
             name: Some("start_session".into()),
             args: Some(serde_json::json!({})),
             session_id: Some(s3b),
+            observation_origin: None,
         };
         let resp = tokio::task::spawn_blocking(move || send_request(&socket3b, &start))
             .await
@@ -1673,10 +1698,55 @@ mod gate_tests {
             name: None,
             args: None,
             session_id: None,
+            observation_origin: None,
         };
         let _ = tokio::task::spawn_blocking(move || send_request(&socket5, &shutdown)).await;
         let _ = server.await;
         let _ = std::fs::remove_file(&socket);
+    }
+}
+
+#[cfg(test)]
+mod telemetry_routing_tests {
+    use super::*;
+
+    fn request(origin: Option<ToolObservationOrigin>) -> DaemonRequest {
+        DaemonRequest {
+            method: "call".into(),
+            name: Some("click".into()),
+            args: Some(serde_json::json!({})),
+            session_id: Some("bounded-session".into()),
+            observation_origin: origin,
+        }
+    }
+
+    #[test]
+    fn observation_origin_selects_exactly_one_transport() {
+        assert_eq!(
+            daemon_observation_transport(&request(Some(ToolObservationOrigin::McpProxy))),
+            Some(crate::telemetry::Transport::McpStdio)
+        );
+        assert_eq!(
+            daemon_observation_transport(&request(Some(ToolObservationOrigin::Direct))),
+            Some(crate::telemetry::Transport::Daemon)
+        );
+        assert_eq!(daemon_observation_transport(&request(None)), None);
+    }
+
+    #[test]
+    fn observation_origin_is_additive_and_backward_compatible() {
+        let legacy: DaemonRequest = serde_json::from_value(serde_json::json!({
+            "method": "call",
+            "name": "click",
+            "args": {},
+            "session_id": "bounded-session"
+        }))
+        .unwrap();
+        assert_eq!(legacy.observation_origin, None);
+
+        let current = serde_json::to_value(request(Some(ToolObservationOrigin::McpProxy)))
+            .unwrap();
+        assert_eq!(current["observation_origin"], "mcp_proxy");
     }
 }
 

--- a/libs/cua-driver/rust/crates/cua-driver/src/telemetry.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/telemetry.rs
@@ -13,11 +13,12 @@
 
 use serde::Serialize;
 use serde_json::{Map, Value};
+use std::collections::HashSet;
 use std::fs::{File, OpenOptions, TryLockError};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::time::Duration;
 
@@ -235,6 +236,7 @@ pub fn inspect_event(event_name: &str) -> Result<Value, String> {
             ("reported_model", Value::String("unknown".into())),
             ("reported_agent", Value::String("unknown".into())),
             ("reported_agent_version_major", Value::String("unknown".into())),
+            ("execution_mode", Value::String(execution_mode().into())),
         ]),
         event::MCP_TOOL_COMPLETED => bounded_properties(&[
             ("tool_name", Value::String("other".into())),
@@ -243,12 +245,14 @@ pub fn inspect_event(event_name: &str) -> Result<Value, String> {
             ("duration_bucket", Value::String("lt_10ms".into())),
             ("output_type", Value::String("empty".into())),
             ("output_size_bucket", Value::String("0".into())),
+            ("execution_mode", Value::String(execution_mode().into())),
         ]),
         event::MCP_STARTUP_COMPLETED => bounded_properties(&[
             ("path", Value::String("in_process".into())),
             ("daemon", Value::String("not_applicable".into())),
             ("success", Value::Bool(true)),
             ("duration_bucket", Value::String("lt_100ms".into())),
+            ("execution_mode", Value::String(execution_mode().into())),
         ]),
         event::PERMISSIONS_GATE_STARTED => bounded_properties(&[
             ("missing_accessibility", Value::Bool(true)),
@@ -294,35 +298,19 @@ pub fn register_stdio_observer() {
     let _ = cua_driver_core::server::set_stdio_observer(Arc::new(TelemetryObserver));
 }
 
+fn execution_mode() -> &'static str {
+    if cua_driver_core::embedded_mode() {
+        "embedded"
+    } else {
+        "standalone"
+    }
+}
+
 struct TelemetryObserver;
 
 impl cua_driver_core::server::StdioObserver for TelemetryObserver {
     fn on_session_started(&self, metadata: cua_driver_core::protocol::InitializeMetadata) {
-        static OBSERVED: AtomicBool = AtomicBool::new(false);
-        if OBSERVED.swap(true, Ordering::SeqCst) {
-            return;
-        }
-        let context = metadata.reported_agent_context.unwrap_or_default();
-        let capabilities = metadata.capability_flags;
-        capture_bounded(
-            event::MCP_SESSION_STARTED,
-            bounded_properties(&[
-                ("mcp_client", Value::String(normalize_client(metadata.client_name.as_deref()))),
-                ("mcp_client_version_major", Value::String(version_major(metadata.client_version.as_deref()))),
-                ("protocol_version", Value::String(normalize_protocol(metadata.protocol_version.as_deref()))),
-                ("capability_tools", Value::Bool(capabilities.tools)),
-                ("capability_roots", Value::Bool(capabilities.roots)),
-                ("capability_sampling", Value::Bool(capabilities.sampling)),
-                ("capability_experimental", Value::Bool(capabilities.experimental)),
-                ("capability_elicitation_form", Value::Bool(capabilities.elicitation_form)),
-                ("capability_elicitation_url", Value::Bool(capabilities.elicitation_url)),
-                ("reported_provider", Value::String(normalize_provider(context.provider.as_deref()))),
-                ("reported_model", Value::String(normalize_model(context.model.as_deref()))),
-                ("reported_agent", Value::String(normalize_client(context.agent_name.as_deref()))),
-                ("reported_agent_version_major", Value::String(version_major(context.agent_version.as_deref()))),
-            ]),
-            Transport::McpStdio,
-        );
+        capture_mcp_session_started(metadata, Transport::McpStdio);
     }
 
     fn on_tool_completed(&self, outcome: cua_driver_core::server::ToolCompletionObservation) {
@@ -330,13 +318,65 @@ impl cua_driver_core::server::StdioObserver for TelemetryObserver {
     }
 }
 
+static MCP_SESSION_OBSERVED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+fn mcp_session_observation_key(transport: Transport, mcp_client: &str) -> String {
+    match transport {
+        Transport::McpHttp => format!("mcp_http:{mcp_client}"),
+        _ => transport.as_str().to_owned(),
+    }
+}
+
+pub(crate) fn capture_mcp_session_started(
+    metadata: cua_driver_core::protocol::InitializeMetadata,
+    transport: Transport,
+) {
+    if !is_enabled() {
+        return;
+    }
+    let mcp_client = normalize_client(metadata.client_name.as_deref());
+    let observation_key = mcp_session_observation_key(transport, &mcp_client);
+    let observed = MCP_SESSION_OBSERVED.get_or_init(|| Mutex::new(HashSet::new()));
+    if !observed.lock().unwrap().insert(observation_key) {
+        return;
+    }
+
+    let context = metadata.reported_agent_context.unwrap_or_default();
+    let capabilities = metadata.capability_flags;
+    capture_bounded(
+        event::MCP_SESSION_STARTED,
+        bounded_properties(&[
+            ("mcp_client", Value::String(mcp_client)),
+            ("mcp_client_version_major", Value::String(version_major(metadata.client_version.as_deref()))),
+            ("protocol_version", Value::String(normalize_protocol(metadata.protocol_version.as_deref()))),
+            ("capability_tools", Value::Bool(capabilities.tools)),
+            ("capability_roots", Value::Bool(capabilities.roots)),
+            ("capability_sampling", Value::Bool(capabilities.sampling)),
+            ("capability_experimental", Value::Bool(capabilities.experimental)),
+            ("capability_elicitation_form", Value::Bool(capabilities.elicitation_form)),
+            ("capability_elicitation_url", Value::Bool(capabilities.elicitation_url)),
+            ("reported_provider", Value::String(normalize_provider(context.provider.as_deref()))),
+            ("reported_model", Value::String(normalize_model(context.model.as_deref()))),
+            ("reported_agent", Value::String(normalize_client(context.agent_name.as_deref()))),
+            ("reported_agent_version_major", Value::String(version_major(context.agent_version.as_deref()))),
+            ("execution_mode", Value::String(execution_mode().into())),
+        ]),
+        transport,
+    );
+}
+
 pub(crate) fn capture_tool_completed(
     outcome: cua_driver_core::server::ToolCompletionObservation,
     transport: Transport,
 ) {
+    let mut properties = tool_completion_properties(outcome);
+    properties.insert(
+        "execution_mode".into(),
+        Value::String(execution_mode().into()),
+    );
     capture_bounded(
         event::MCP_TOOL_COMPLETED,
-        tool_completion_properties(outcome),
+        properties,
         transport,
     );
 }
@@ -425,6 +465,7 @@ pub(crate) fn capture_mcp_startup_completed(
             ("daemon", Value::String(daemon.into())),
             ("success", Value::Bool(success)),
             ("duration_bucket", Value::String(duration_bucket(elapsed).into())),
+            ("execution_mode", Value::String(execution_mode().into())),
         ]),
         Transport::McpStdio,
     );
@@ -1843,16 +1884,24 @@ mod tests {
             "capability_tools", "capability_roots", "capability_sampling",
             "capability_experimental", "capability_elicitation_form",
             "capability_elicitation_url", "reported_provider", "reported_model",
-            "reported_agent", "reported_agent_version_major",
+            "reported_agent", "reported_agent_version_major", "execution_mode",
         ] {
             assert!(session_properties.contains_key(field), "missing {field}");
         }
 
         let tool = inspect_event(event::MCP_TOOL_COMPLETED).unwrap();
         assert_eq!(tool["properties"]["duration_bucket"], "lt_10ms");
+        assert!(matches!(
+            tool["properties"]["execution_mode"].as_str(),
+            Some("embedded" | "standalone")
+        ));
         let mcp_start = inspect_event(event::MCP_STARTUP_COMPLETED).unwrap();
         assert_eq!(mcp_start["properties"]["transport"], "mcp_stdio");
         assert_eq!(mcp_start["properties"]["path"], "in_process");
+        assert_eq!(
+            mcp_start["properties"]["execution_mode"],
+            tool["properties"]["execution_mode"]
+        );
         let permissions_started = inspect_event(event::PERMISSIONS_GATE_STARTED).unwrap();
         assert_eq!(permissions_started["properties"]["transport"], "daemon");
         assert_eq!(
@@ -1904,6 +1953,22 @@ mod tests {
         }
         let serve_start = inspect_event(event::SERVE_START_LEGACY).unwrap();
         assert_eq!(serve_start["properties"]["transport"], "daemon");
+    }
+
+    #[test]
+    fn session_observation_keys_are_bounded_by_transport_and_client_category() {
+        assert_eq!(
+            mcp_session_observation_key(Transport::McpStdio, "claude_code"),
+            "mcp_stdio"
+        );
+        assert_eq!(
+            mcp_session_observation_key(Transport::McpHttp, "claude_code"),
+            "mcp_http:claude_code"
+        );
+        assert_eq!(
+            mcp_session_observation_key(Transport::McpHttp, "other"),
+            "mcp_http:other"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- negotiate a single tool-completion telemetry owner between the MCP proxy and daemon
- observe current direct daemon calls and MCP-over-HTTP initialization
- add a bounded `execution_mode` dimension to MCP startup, session, and tool events

## Compatibility
- new proxy + new daemon: daemon emits once
- old proxy + new daemon: proxy remains the emitter
- new proxy + old daemon: proxy remains the emitter
- the daemon protocol additions are optional and additive

## Privacy
- routing metadata uses a closed `mcp_proxy` / `direct` vocabulary and is never included in telemetry payloads
- HTTP initialization continues to normalize client, model, provider, protocol, and capability values into bounded categories
- no tool arguments, results, session identifiers, socket paths, or peer data are collected

## Validation
- `cargo test -p cua-driver --bin cua-driver --locked` (91 passed)
- `cargo check -p cua-driver --all-targets --locked`
- `git diff --check`
