### PR TITLE
feat(cua-driver): add bounded feature telemetry

### DIFF
--- a/docs/content/docs/reference/cua-driver/telemetry.mdx
+++ b/docs/content/docs/reference/cua-driver/telemetry.mdx
@@ -79,10 +79,10 @@ The client does not send an IP address as an event property. PostHog derives a c
 | `cua_driver_installation_registered`     | `install_channel`                                                                                                                                           |
 | `cua_driver_release_installed`           | `install_channel`, `product_version`                                                                                                                        |
 | `cua_driver_serve`                       | None. Transitional process-start event for `cua-driver serve`; `transport` is `daemon`                                                                      |
-| `cua_driver_cli_completed`               | Fixed `command`, allowlisted tool for `call`, `success`, `exit_class`, and `duration_bucket`                                                                |
+| `cua_driver_cli_completed`               | Fixed `command`, allowlisted tool for `call`, bounded `operation`, bounded MCP `client_kind`, `success`, `exit_class`, and `duration_bucket`                  |
 | `cua_driver_mcp_startup_completed`       | execution path, bounded daemon state, success, duration bucket, and `execution_mode`                                                                         |
 | `cua_driver_mcp_session_started`         | normalized MCP client and protocol, capability booleans, optional reported agent context, and `execution_mode`                                              |
-| `cua_driver_mcp_tool_completed`          | allowlisted tool, success, error class, duration bucket, output type, output-size bucket, and `execution_mode`                                               |
+| `cua_driver_mcp_tool_completed`          | allowlisted tool, bounded compound-tool `operation`, success, error class, duration bucket, output shape and size buckets, and `execution_mode`              |
 | `cua_driver_agent_session_started`       | declaration kind, revival flag, concurrent-session bucket, entry transport, and `execution_mode`                                                            |
 | `cua_driver_agent_session_ended`         | end reason, duration and count buckets, success flags, feature-family flags, multi-transport flag, and `execution_mode`                                      |
 | `cua_driver_permissions_gate_started`    | missing-permission booleans                                                                                                                                  |
@@ -120,13 +120,17 @@ A Cua agent session is a non-empty caller-declared `session` value. The value `d
 
 The start event is emitted for a successful `start_session` declaration or the first known tool call that carries an explicit session. Repeated calls in the same live episode do not emit another start. Reusing an ID after explicit end or idle eviction creates a new episode with `revived=true`.
 
-The end event is emitted for `end_session` and idle eviction. It contains aggregate counters and booleans. Cua Driver uses the caller session string only as a process-local map key. The string, a hash of it, and a replacement join token are absent from telemetry payloads.
+The end event is emitted for `end_session` and idle eviction. It contains aggregate counters and booleans. When the platform has a cursor entry for that session, it also includes bounded cursor categories: enabled state, built-in/default/custom icon class, automatic/custom color source, label presence, motion customization, and an active-cursor count bucket. `cursor_outcome_observed=false` distinguishes sessions with no readable cursor entry from a disabled or default cursor. Cua Driver uses the caller session string only as a process-local map key. The string, a hash of it, and a replacement join token are absent from telemetry payloads.
 
 Computer-action success covers fixed pointer and keyboard capabilities, app launch and kill, window activation, and state-changing `page` operations. State reads, screenshots, health checks, update checks, and session lifecycle tools do not count as computer actions.
 
+For finite CLI commands, `operation` distinguishes only reviewed verbs for recording, permissions, config, autostart, skills, and update. `client_kind` is populated only for `mcp-config`. Unknown values become `other`; commands without a meaningful sub-operation use `not_applicable`.
+
+For the compound `page` tool, `operation` is one of `execute_javascript`, `get_text`, `query_dom`, `click_element`, `insert_text`, `type_keystrokes`, `enable_javascript_apple_events`, or `other`. Other tools use `not_applicable`.
+
 ## Data that is never collected
 
-Routine telemetry excludes task text, prompts, tool arguments, tool response bodies, typed text, screenshots, accessibility trees, window titles, application names, file paths, URLs, arbitrary MCP metadata, and raw error messages.
+Routine telemetry excludes task text, prompts, tool arguments, tool response bodies, typed text, screenshots, accessibility trees, window titles, application names, file paths, URLs, arbitrary MCP metadata, raw cursor IDs, labels, colors, icon paths, numeric motion values, and raw error messages.
 
 Tool-completion events retain only coarse result shape: text, image, mixed, empty, or unknown; a size bucket; a duration bucket; and a fixed error class. The content itself never crosses the telemetry observer boundary. A proxy and daemon negotiate one completion-event owner. Mixed-version pairs retain proxy ownership, which prevents duplicate events during upgrades.
 

--- a/docs/content/docs/reference/cua-driver/telemetry.mdx
+++ b/docs/content/docs/reference/cua-driver/telemetry.mdx
@@ -70,7 +70,7 @@ Every schema-v3 client event has this fixed envelope:
 
 Client events set `$process_person_profile` to `false`. The installation UUID is used only as the PostHog `distinct_id`; it is not duplicated into event properties. This is pseudonymous installation telemetry, not anonymous telemetry.
 
-The client does not send an IP address as an event property. PostHog derives a country code and country name from the network request during ingestion, then discards the client IP before storing the event. A country-only transformation removes city, subdivision, postal-code, coordinate, accuracy-radius, and time-zone properties.
+The client does not send an IP address as an event property. PostHog derives a country code and country name from the network request during ingestion, then discards the client IP before storing the event. A country-only transformation removes continent, city, subdivision, postal-code, coordinate, accuracy-radius, and time-zone properties.
 
 ## Fixed events
 
@@ -136,6 +136,6 @@ Tool-completion events retain only coarse result shape: text, image, mixed, empt
 
 ## Region and deletion controls
 
-Client events are sent to PostHog's EU ingest endpoint. PostHog processes the request IP long enough to derive country-level distribution, then discards the IP before event storage. Stored telemetry keeps only the derived country code and country name; it excludes city, subdivision, postal code, coordinates, accuracy radius, and time zone. PostHog does not create person profiles for these events.
+Client events are sent to PostHog's EU ingest endpoint. PostHog processes the request IP long enough to derive country-level distribution, then discards the IP before event storage. Stored telemetry keeps only the derived country code and country name; it excludes continent, city, subdivision, postal code, coordinates, accuracy radius, and time zone. PostHog does not create person profiles for these events.
 
 Retention and server-side deletion are governed by the [Cua privacy policy](https://cua.ai/privacy-policy); the client does not enforce a retention window or submit deletion requests. `telemetry reset-id` and uninstall purge controls remove local identity state only. Do not post the installation UUID in a public issue.

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/server.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/server.rs
@@ -125,17 +125,69 @@ impl ToolErrorClass {
     }
 }
 
-/// Privacy-bounded completion record for a stdio `tools/call` request.
+/// Privacy-bounded completion record for a known tool call on any transport.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolCompletionObservation {
     /// Still self-reported input at this layer. The telemetry consumer must map
     /// this through the registry allowlist and use an `unknown` fallback.
     pub tool_name: String,
+    pub operation: ToolOperation,
     pub success: bool,
     pub error_class: ToolErrorClass,
     pub duration_bucket: DurationBucket,
     pub output_type: OutputType,
     pub output_size_bucket: OutputSizeBucket,
+}
+
+/// Closed sub-operation vocabulary for compound tools. This enum is derived
+/// at the dispatch boundary and cannot retain selectors, scripts, typed text,
+/// or any other argument content.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolOperation {
+    NotApplicable,
+    ExecuteJavascript,
+    GetText,
+    QueryDom,
+    ClickElement,
+    InsertText,
+    TypeKeystrokes,
+    EnableJavascriptAppleEvents,
+    Other,
+}
+
+impl ToolOperation {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NotApplicable => "not_applicable",
+            Self::ExecuteJavascript => "execute_javascript",
+            Self::GetText => "get_text",
+            Self::QueryDom => "query_dom",
+            Self::ClickElement => "click_element",
+            Self::InsertText => "insert_text",
+            Self::TypeKeystrokes => "type_keystrokes",
+            Self::EnableJavascriptAppleEvents => "enable_javascript_apple_events",
+            Self::Other => "other",
+        }
+    }
+}
+
+pub fn tool_operation(tool_name: &str, args: Option<&serde_json::Value>) -> ToolOperation {
+    if tool_name != "page" {
+        return ToolOperation::NotApplicable;
+    }
+    match args
+        .and_then(|value| value.get("action"))
+        .and_then(serde_json::Value::as_str)
+    {
+        Some("execute_javascript") => ToolOperation::ExecuteJavascript,
+        Some("get_text") => ToolOperation::GetText,
+        Some("query_dom") => ToolOperation::QueryDom,
+        Some("click_element") => ToolOperation::ClickElement,
+        Some("insert_text") => ToolOperation::InsertText,
+        Some("type_keystrokes") => ToolOperation::TypeKeystrokes,
+        Some("enable_javascript_apple_events") => ToolOperation::EnableJavascriptAppleEvents,
+        _ => ToolOperation::Other,
+    }
 }
 
 /// Which stdio execution path produced a response. This only affects the
@@ -150,6 +202,7 @@ pub enum StdioExecutionPath {
 /// exactly the same privacy and bucketing logic as the in-process transport.
 pub struct ToolObservationTimer {
     tool_name: String,
+    operation: ToolOperation,
     known_tool: bool,
     valid_params: bool,
     path: StdioExecutionPath,
@@ -163,8 +216,25 @@ impl ToolObservationTimer {
         valid_params: bool,
         path: StdioExecutionPath,
     ) -> Self {
+        Self::start_with_operation(
+            tool_name,
+            ToolOperation::NotApplicable,
+            known_tool,
+            valid_params,
+            path,
+        )
+    }
+
+    pub fn start_with_operation(
+        tool_name: String,
+        operation: ToolOperation,
+        known_tool: bool,
+        valid_params: bool,
+        path: StdioExecutionPath,
+    ) -> Self {
         Self {
             tool_name,
+            operation,
             known_tool,
             valid_params,
             path,
@@ -280,8 +350,12 @@ pub fn tool_observation_timer(
         return None;
     }
     let parsed = req.tool_call();
-    let (tool_name, valid_params) = match parsed {
-        Ok(call) => (bounded_tool_name(&call.name), true),
+    let (tool_name, operation, valid_params) = match parsed {
+        Ok(call) => {
+            let tool_name = bounded_tool_name(&call.name);
+            let operation = tool_operation(&tool_name, Some(&call.args));
+            (tool_name, operation, true)
+        }
         Err(_) => {
             let name = req
                 .params
@@ -290,12 +364,14 @@ pub fn tool_observation_timer(
                 .and_then(serde_json::Value::as_str)
                 .map(bounded_tool_name)
                 .unwrap_or_else(|| "unknown".to_owned());
-            (name, false)
+            let operation = tool_operation(&name, None);
+            (name, operation, false)
         }
     };
     let known_tool = valid_params && is_known_tool(&tool_name);
-    Some(ToolObservationTimer::start(
+    Some(ToolObservationTimer::start_with_operation(
         tool_name,
+        operation,
         known_tool,
         valid_params,
         path,
@@ -396,6 +472,7 @@ fn classify_tool_completion(
 
     ToolCompletionObservation {
         tool_name: timer.tool_name,
+        operation: timer.operation,
         success,
         error_class,
         duration_bucket,
@@ -540,6 +617,40 @@ mod observation_tests {
         for forbidden in ["private task text", "private-base64", "result body"] {
             assert!(!debug.contains(forbidden), "observer leaked content: {debug}");
         }
+    }
+
+    #[test]
+    fn page_operation_is_closed_and_retains_no_argument_content() {
+        for (action, expected) in [
+            ("execute_javascript", ToolOperation::ExecuteJavascript),
+            ("get_text", ToolOperation::GetText),
+            ("query_dom", ToolOperation::QueryDom),
+            ("click_element", ToolOperation::ClickElement),
+            ("insert_text", ToolOperation::InsertText),
+            ("type_keystrokes", ToolOperation::TypeKeystrokes),
+            (
+                "enable_javascript_apple_events",
+                ToolOperation::EnableJavascriptAppleEvents,
+            ),
+            ("private-custom-action", ToolOperation::Other),
+        ] {
+            let args = serde_json::json!({
+                "action": action,
+                "selector": "private selector",
+                "script": "private script",
+                "text": "private typed text"
+            });
+            let operation = tool_operation("page", Some(&args));
+            assert_eq!(operation, expected);
+            let debug = format!("{operation:?}");
+            for forbidden in ["private selector", "private script", "private typed text"] {
+                assert!(!debug.contains(forbidden));
+            }
+        }
+        assert_eq!(
+            tool_operation("click", Some(&serde_json::json!({"action": "private"}))),
+            ToolOperation::NotApplicable
+        );
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/session.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/session.rs
@@ -53,6 +53,79 @@ pub struct SessionStartObservation {
     pub transport: SessionTransport,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CursorStyleCategory {
+    Default,
+    BuiltinArrow,
+    BuiltinTeardrop,
+    CustomIcon,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CursorColorSource {
+    AutomaticPalette,
+    Custom,
+    Unknown,
+}
+
+/// Platform-neutral, content-free cursor state captured immediately before a
+/// session's platform cleanup hooks remove the underlying cursor entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CursorOutcomeObservation {
+    pub observed: bool,
+    pub enabled: bool,
+    pub style: CursorStyleCategory,
+    pub color_source: CursorColorSource,
+    pub label_set: bool,
+    pub motion_customized: bool,
+    pub active_cursor_count: usize,
+}
+
+/// Convert platform cursor fields to fixed categories without retaining any
+/// raw icon, color, label, identifier, or motion value.
+pub fn bounded_cursor_outcome(
+    observed: bool,
+    enabled: bool,
+    icon: Option<&str>,
+    color: Option<&str>,
+    label: Option<&str>,
+    motion_customized: bool,
+    active_cursor_count: usize,
+) -> CursorOutcomeObservation {
+    let style = if !observed {
+        CursorStyleCategory::Unknown
+    } else {
+        match icon.map(str::trim).filter(|value| !value.is_empty()) {
+            None => CursorStyleCategory::Default,
+            Some(value) if value.eq_ignore_ascii_case("arrow") => {
+                CursorStyleCategory::BuiltinArrow
+            }
+            Some(value) if value.eq_ignore_ascii_case("teardrop") => {
+                CursorStyleCategory::BuiltinTeardrop
+            }
+            Some(_) => CursorStyleCategory::CustomIcon,
+        }
+    };
+    let color_source = if !observed {
+        CursorColorSource::Unknown
+    } else {
+        match color.map(str::trim).filter(|value| !value.is_empty()) {
+            None | Some("#00FFFF") | Some("#00ffff") => CursorColorSource::AutomaticPalette,
+            Some(_) => CursorColorSource::Custom,
+        }
+    };
+    CursorOutcomeObservation {
+        observed,
+        enabled: observed && enabled,
+        style,
+        color_source,
+        label_set: observed && label.is_some_and(|value| !value.trim().is_empty()),
+        motion_customized: observed && motion_customized,
+        active_cursor_count,
+    }
+}
+
 /// Process-local sink for bounded session telemetry.
 ///
 /// `session_id` is supplied only so an observer can update private in-memory
@@ -68,13 +141,31 @@ pub trait SessionObserver: Send + Sync + 'static {
         computer_action: bool,
         outcome: &crate::server::ToolCompletionObservation,
     );
-    fn on_session_ended(&self, session_id: &str, reason: SessionEndReason);
+    fn on_session_ended(
+        &self,
+        session_id: &str,
+        reason: SessionEndReason,
+        cursor: Option<CursorOutcomeObservation>,
+    );
 }
 
 static SESSION_OBSERVER: OnceLock<Arc<dyn SessionObserver>> = OnceLock::new();
+type CursorOutcomeReader = Arc<dyn Fn(&str) -> CursorOutcomeObservation + Send + Sync>;
+static CURSOR_OUTCOME_READER: OnceLock<Mutex<Option<CursorOutcomeReader>>> = OnceLock::new();
 
 pub fn set_session_observer(observer: Arc<dyn SessionObserver>) -> bool {
     SESSION_OBSERVER.set(observer).is_ok()
+}
+
+/// Register the platform's bounded cursor-state reader. The raw session key is
+/// used only for the synchronous process-local lookup; the callback returns a
+/// struct that cannot contain raw cursor values.
+pub fn set_cursor_outcome_reader(reader: CursorOutcomeReader) -> bool {
+    *CURSOR_OUTCOME_READER
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+        .unwrap() = Some(reader);
+    true
 }
 
 /// Private per-call context. The raw caller session id never crosses into a
@@ -294,9 +385,13 @@ fn end_session_with_reason(session_id: &str, reason: SessionEndReason) {
         return;
     }
     activity().lock().unwrap().remove(session_id);
+    let cursor_reader = CURSOR_OUTCOME_READER
+        .get()
+        .and_then(|reader| reader.lock().unwrap().clone());
+    let cursor = cursor_reader.map(|reader| reader(session_id));
     if fire_session_end(session_id) {
         if let Some(observer) = SESSION_OBSERVER.get() {
-            observer.on_session_ended(session_id, reason);
+            observer.on_session_ended(session_id, reason, cursor);
         }
     }
 }
@@ -336,7 +431,7 @@ mod tests {
     #[derive(Default)]
     struct ProbeObserver {
         starts: Mutex<Vec<(String, SessionStartObservation)>>,
-        ends: Mutex<Vec<(String, SessionEndReason)>>,
+        ends: Mutex<Vec<(String, SessionEndReason, Option<CursorOutcomeObservation>)>>,
     }
 
     impl SessionObserver for ProbeObserver {
@@ -351,8 +446,16 @@ mod tests {
             _: &crate::server::ToolCompletionObservation,
         ) {
         }
-        fn on_session_ended(&self, id: &str, reason: SessionEndReason) {
-            self.ends.lock().unwrap().push((id.to_owned(), reason));
+        fn on_session_ended(
+            &self,
+            id: &str,
+            reason: SessionEndReason,
+            cursor: Option<CursorOutcomeObservation>,
+        ) {
+            self.ends
+                .lock()
+                .unwrap()
+                .push((id.to_owned(), reason, cursor));
         }
     }
 
@@ -413,6 +516,43 @@ mod tests {
         // Neither shows up under a zero-TTL sweep (they were never inserted).
         let evicted = evict_idle(Duration::ZERO);
         assert!(!evicted.iter().any(|s| s == "default" || s.is_empty()));
+    }
+
+    #[test]
+    fn cursor_outcomes_are_fixed_categories_without_raw_values() {
+        let custom = bounded_cursor_outcome(
+            true,
+            true,
+            Some("/private/customer/cursor.svg"),
+            Some("private-brand-color"),
+            Some("private agent label"),
+            true,
+            7,
+        );
+        assert_eq!(custom.style, CursorStyleCategory::CustomIcon);
+        assert_eq!(custom.color_source, CursorColorSource::Custom);
+        assert!(custom.label_set);
+        assert!(custom.motion_customized);
+        assert_eq!(custom.active_cursor_count, 7);
+        let debug = format!("{custom:?}");
+        for forbidden in ["/private/customer", "private-brand", "private agent"] {
+            assert!(!debug.contains(forbidden), "cursor outcome leaked {forbidden}: {debug}");
+        }
+
+        let unknown = bounded_cursor_outcome(
+            false,
+            true,
+            Some("arrow"),
+            Some("#00FFFF"),
+            Some("label"),
+            true,
+            0,
+        );
+        assert_eq!(unknown.style, CursorStyleCategory::Unknown);
+        assert_eq!(unknown.color_source, CursorColorSource::Unknown);
+        assert!(!unknown.enabled);
+        assert!(!unknown.label_set);
+        assert!(!unknown.motion_customized);
     }
 
     #[test]
@@ -515,6 +655,9 @@ mod tests {
     #[test]
     fn observer_distinguishes_explicit_idle_revival_and_control_cleanup() {
         let probe = probe_observer();
+        let _ = set_cursor_outcome_reader(Arc::new(|_| {
+            bounded_cursor_outcome(true, true, Some("arrow"), None, None, false, 2)
+        }));
         let explicit = "test-observer-explicit-IJ90";
         begin_tool_call(
             "start_session",
@@ -571,12 +714,16 @@ mod tests {
         drop(starts);
 
         let ends = probe.ends.lock().unwrap();
-        assert!(ends.iter().any(|(id, reason)| {
+        assert!(ends.iter().any(|(id, reason, cursor)| {
             id == explicit && *reason == SessionEndReason::Explicit
+                && cursor.is_some_and(|value| {
+                    value.style == CursorStyleCategory::BuiltinArrow
+                        && value.active_cursor_count == 2
+                })
         }));
-        assert!(ends.iter().any(|(id, reason)| {
+        assert!(ends.iter().any(|(id, reason, _)| {
             id == idle && *reason == SessionEndReason::IdleTimeout
         }));
-        assert!(!ends.iter().any(|(id, _)| id == control));
+        assert!(!ends.iter().any(|(id, _, _)| id == control));
     }
 }

--- a/libs/cua-driver/rust/crates/cua-driver-testkit/src/mcp.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-testkit/src/mcp.rs
@@ -71,7 +71,12 @@ impl McpDriver {
         };
         cmd.stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(stderr);
+            .stderr(stderr)
+            // Product telemetry is default-on, but behavior harnesses should
+            // remain deterministic and must not send CI traffic to PostHog.
+            // A test that exercises telemetry can explicitly override this
+            // through `spawn_with_env` / `spawn_named_with_env` below.
+            .env("CUA_DRIVER_RS_TELEMETRY_ENABLED", "false");
         for (key, value) in env {
             cmd.env(key, value);
         }

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -211,6 +211,93 @@ pub fn finite_tool_name_from_argv() -> Option<String> {
     finite_tool_name_from_args(&args)
 }
 
+/// Return the bounded sub-operation for a finite command. This classifier
+/// reads only the command verb, a reviewed subcommand, and the presence of
+/// `--apply`; arbitrary values never leave this function.
+pub fn finite_operation_from_argv() -> &'static str {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    finite_operation_from_args(&args)
+}
+
+fn finite_operation_from_args(args: &[String]) -> &'static str {
+    let command = finite_command_name_from_args(args);
+    let positionals = positional_args(args);
+    let subcommand = positionals.get(1).copied();
+    match command {
+        Some("recording") => match subcommand.unwrap_or("status") {
+            "start" => "start",
+            "stop" => "stop",
+            "status" => "status",
+            "render" => "render",
+            _ => "other",
+        },
+        Some("permissions") => match subcommand.unwrap_or("status") {
+            "status" => "status",
+            "grant" => "grant",
+            _ => "other",
+        },
+        Some("config") => match subcommand.unwrap_or("show") {
+            "show" => "show",
+            "get" => "get",
+            "set" => "set",
+            "reset" => "reset",
+            _ => "other",
+        },
+        Some("autostart") => match subcommand.unwrap_or("") {
+            "enable" => "enable",
+            "disable" => "disable",
+            "status" => "status",
+            "kick" => "kick",
+            _ => "other",
+        },
+        Some("skills") => match subcommand.unwrap_or("status") {
+            "install" => "install",
+            "update" => "update",
+            "uninstall" => "uninstall",
+            "status" => "status",
+            "path" => "path",
+            _ => "other",
+        },
+        Some("update") if args.iter().any(|arg| arg == "--apply") => "apply",
+        Some("update") => "check_only",
+        _ => "not_applicable",
+    }
+}
+
+/// Return the configured MCP client as a closed category. Raw `--client`
+/// values are mapped to `other` before the detached worker is spawned.
+pub fn finite_client_kind_from_argv() -> &'static str {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    finite_client_kind_from_args(&args)
+}
+
+fn finite_client_kind_from_args(args: &[String]) -> &'static str {
+    if finite_command_name_from_args(args) != Some("mcp_config") {
+        return "not_applicable";
+    }
+    let value = args
+        .iter()
+        .position(|arg| arg == "--client")
+        .and_then(|index| args.get(index + 1))
+        .map(String::as_str)
+        .unwrap_or("");
+    match value {
+        "" => "generic",
+        "claude" | "claude-code" => "claude_code",
+        "codex" => "codex",
+        "cursor" => "cursor",
+        "openclaw" => "openclaw",
+        "opencode" => "opencode",
+        "hermes" => "hermes",
+        "pi" => "pi",
+        "antigravity" | "gemini" => "antigravity",
+        "qwen" | "qwen-code" => "qwen_code",
+        "droid" | "factory" => "factory_droid",
+        "zcode" => "zcode",
+        _ => "other",
+    }
+}
+
 fn finite_tool_name_from_args(args: &[String]) -> Option<String> {
     if finite_command_name_from_args(args) != Some("call") {
         return None;
@@ -1559,8 +1646,10 @@ pub fn run_call(
         true,
         cua_driver_core::session::SessionTransport::Cli,
     );
-    let observation_timer = cua_driver_core::server::ToolObservationTimer::start(
+    let operation = cua_driver_core::server::tool_operation(tool, Some(&args));
+    let observation_timer = cua_driver_core::server::ToolObservationTimer::start_with_operation(
         tool.to_owned(),
+        operation,
         true,
         true,
         cua_driver_core::server::StdioExecutionPath::InProcess,
@@ -3150,6 +3239,26 @@ mod tests {
             None
         );
         assert_eq!(finite_tool_name_from_args(&args(&["mcp"])), None);
+    }
+
+    #[test]
+    fn finite_operations_are_closed_and_ignore_values() {
+        assert_eq!(finite_operation_from_args(&args(&["recording", "start", "/private/path"])), "start");
+        assert_eq!(finite_operation_from_args(&args(&["config", "set", "private.key", "private-value"])), "set");
+        assert_eq!(finite_operation_from_args(&args(&["skills"])), "status");
+        assert_eq!(finite_operation_from_args(&args(&["update", "--apply"])), "apply");
+        assert_eq!(finite_operation_from_args(&args(&["update"])), "check_only");
+        assert_eq!(finite_operation_from_args(&args(&["doctor", "private-value"])), "not_applicable");
+        assert_eq!(finite_operation_from_args(&args(&["recording", "private-value"])), "other");
+    }
+
+    #[test]
+    fn finite_mcp_config_clients_are_closed_before_worker_handoff() {
+        assert_eq!(finite_client_kind_from_args(&args(&["mcp-config"])), "generic");
+        assert_eq!(finite_client_kind_from_args(&args(&["mcp-config", "--client", "claude-code"])), "claude_code");
+        assert_eq!(finite_client_kind_from_args(&args(&["mcp-config", "--client", "antigravity"])), "antigravity");
+        assert_eq!(finite_client_kind_from_args(&args(&["mcp-config", "--client", "/private/client"])), "other");
+        assert_eq!(finite_client_kind_from_args(&args(&["doctor", "--client", "claude"])), "not_applicable");
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver/src/main.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/main.rs
@@ -71,6 +71,8 @@ fn maybe_wrap_finite_command() {
     }
     let Some(command_name) = cli::finite_command_name_from_argv() else { return; };
     let tool_name = cli::finite_tool_name_from_argv();
+    let operation = cli::finite_operation_from_argv();
+    let client_kind = cli::finite_client_kind_from_argv();
     telemetry::spawn_first_run_registration_worker();
     let Ok(executable) = std::env::current_exe() else { return; };
     let started_at = std::time::Instant::now();
@@ -83,6 +85,8 @@ fn maybe_wrap_finite_command() {
     telemetry::spawn_cli_completion_worker(
         command_name,
         tool_name.as_deref(),
+        operation,
+        client_kind,
         exit_code,
         started_at.elapsed(),
     );

--- a/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
@@ -389,10 +389,16 @@ async fn invoke_daemon_tool(
         raw_name
     };
     let known_tool = registry.get_def(&tool_name).is_some();
+    let mut args = req
+        .args
+        .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
+    let effective_session = apply_session_identity(&mut args, &req.session_id);
+    let operation = cua_driver_core::server::tool_operation(&tool_name, Some(&args));
     let observation = observation_transport.map(|transport| {
         (
-            cua_driver_core::server::ToolObservationTimer::start(
+            cua_driver_core::server::ToolObservationTimer::start_with_operation(
                 tool_name.clone(),
+                operation,
                 known_tool,
                 true,
                 cua_driver_core::server::StdioExecutionPath::InProcess,
@@ -400,10 +406,6 @@ async fn invoke_daemon_tool(
             transport,
         )
     });
-    let mut args = req
-        .args
-        .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
-    let effective_session = apply_session_identity(&mut args, &req.session_id);
 
     if let Some(sid) = &effective_session {
         if !is_session_lifecycle_tool(&tool_name)

--- a/libs/cua-driver/rust/crates/cua-driver/src/telemetry.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/telemetry.rs
@@ -9,7 +9,7 @@
 //! Event builders in this module accept only fixed event names and bounded
 //! properties. They never receive prompts, tool arguments/results, typed text,
 //! screenshots, accessibility trees, application/window names, URLs, paths,
-//! or raw errors.
+//! raw cursor identifiers/configuration values, or raw errors.
 
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -47,6 +47,8 @@ const ENV_CLI_WRAPPED_CHILD: &str = "CUA_DRIVER_CLI_TELEMETRY_CHILD";
 const ENV_CLI_COMPLETION_WORKER: &str = "CUA_DRIVER_CLI_TELEMETRY_WORKER";
 const ENV_CLI_COMPLETION_COMMAND: &str = "CUA_DRIVER_CLI_TELEMETRY_COMMAND";
 const ENV_CLI_COMPLETION_TOOL: &str = "CUA_DRIVER_CLI_TELEMETRY_TOOL";
+const ENV_CLI_COMPLETION_OPERATION: &str = "CUA_DRIVER_CLI_TELEMETRY_OPERATION";
+const ENV_CLI_COMPLETION_CLIENT_KIND: &str = "CUA_DRIVER_CLI_TELEMETRY_CLIENT_KIND";
 const ENV_CLI_COMPLETION_EXIT_CODE: &str = "CUA_DRIVER_CLI_TELEMETRY_EXIT_CODE";
 const ENV_CLI_COMPLETION_DURATION_MS: &str = "CUA_DRIVER_CLI_TELEMETRY_DURATION_MS";
 const ENV_LIFECYCLE_WORKER: &str = "CUA_DRIVER_LIFECYCLE_TELEMETRY_WORKER";
@@ -222,6 +224,8 @@ pub fn inspect_event(event_name: &str) -> Result<Value, String> {
         event::CLI_COMPLETED => bounded_properties(&[
             ("command", Value::String("other".into())),
             ("tool_name", Value::String("not_applicable".into())),
+            ("operation", Value::String("not_applicable".into())),
+            ("client_kind", Value::String("not_applicable".into())),
             ("success", Value::Bool(true)),
             ("exit_class", Value::String("success".into())),
             ("duration_bucket", Value::String("lt_100ms".into())),
@@ -244,6 +248,7 @@ pub fn inspect_event(event_name: &str) -> Result<Value, String> {
         ]),
         event::MCP_TOOL_COMPLETED => bounded_properties(&[
             ("tool_name", Value::String("other".into())),
+            ("operation", Value::String("not_applicable".into())),
             ("success", Value::Bool(true)),
             ("error_class", Value::String("none".into())),
             ("duration_bucket", Value::String("lt_10ms".into())),
@@ -277,6 +282,13 @@ pub fn inspect_event(event_name: &str) -> Result<Value, String> {
             ("used_cursor_tools", Value::Bool(false)),
             ("used_recording", Value::Bool(false)),
             ("used_config_write", Value::Bool(false)),
+            ("cursor_outcome_observed", Value::Bool(true)),
+            ("cursor_overlay_enabled_at_end", Value::Bool(true)),
+            ("cursor_style", Value::String("default".into())),
+            ("cursor_color_source", Value::String("automatic_palette".into())),
+            ("cursor_label_set", Value::Bool(false)),
+            ("cursor_motion_customized", Value::Bool(false)),
+            ("multi_cursor_bucket", Value::String("1".into())),
             ("observed_multiple_transports", Value::Bool(false)),
             ("execution_mode", Value::String(execution_mode().into())),
         ]),
@@ -421,13 +433,35 @@ impl AgentSessionState {
     fn ended_properties(
         &self,
         reason: cua_driver_core::session::SessionEndReason,
+        cursor: Option<cua_driver_core::session::CursorOutcomeObservation>,
     ) -> Map<String, Value> {
-        use cua_driver_core::session::SessionEndReason;
+        use cua_driver_core::session::{CursorColorSource, CursorStyleCategory, SessionEndReason};
         let end_reason = match reason {
             SessionEndReason::Explicit => "explicit",
             SessionEndReason::IdleTimeout => "idle_timeout",
             SessionEndReason::ProcessExit => "process_exit",
             SessionEndReason::Unknown => "unknown",
+        };
+        let cursor = cursor.unwrap_or(cua_driver_core::session::CursorOutcomeObservation {
+            observed: false,
+            enabled: false,
+            style: CursorStyleCategory::Unknown,
+            color_source: CursorColorSource::Unknown,
+            label_set: false,
+            motion_customized: false,
+            active_cursor_count: 0,
+        });
+        let cursor_style = match cursor.style {
+            CursorStyleCategory::Default => "default",
+            CursorStyleCategory::BuiltinArrow => "builtin_arrow",
+            CursorStyleCategory::BuiltinTeardrop => "builtin_teardrop",
+            CursorStyleCategory::CustomIcon => "custom_icon",
+            CursorStyleCategory::Unknown => "unknown",
+        };
+        let cursor_color_source = match cursor.color_source {
+            CursorColorSource::AutomaticPalette => "automatic_palette",
+            CursorColorSource::Custom => "custom",
+            CursorColorSource::Unknown => "unknown",
         };
         bounded_properties(&[
             ("end_reason", Value::String(end_reason.into())),
@@ -441,6 +475,13 @@ impl AgentSessionState {
             ("used_cursor_tools", Value::Bool(self.used_cursor_tools)),
             ("used_recording", Value::Bool(self.used_recording)),
             ("used_config_write", Value::Bool(self.used_config_write)),
+            ("cursor_outcome_observed", Value::Bool(cursor.observed)),
+            ("cursor_overlay_enabled_at_end", Value::Bool(cursor.enabled)),
+            ("cursor_style", Value::String(cursor_style.into())),
+            ("cursor_color_source", Value::String(cursor_color_source.into())),
+            ("cursor_label_set", Value::Bool(cursor.label_set)),
+            ("cursor_motion_customized", Value::Bool(cursor.motion_customized)),
+            ("multi_cursor_bucket", Value::String(cursor_count_bucket(cursor.active_cursor_count).into())),
             ("observed_multiple_transports", Value::Bool(self.transport_bits.count_ones() > 1)),
             ("execution_mode", Value::String(execution_mode().into())),
         ])
@@ -466,6 +507,15 @@ fn session_transport(transport: cua_driver_core::session::SessionTransport) -> T
 }
 
 fn concurrent_sessions_bucket(count: usize) -> &'static str {
+    match count {
+        0 | 1 => "1",
+        2 => "2",
+        3..=5 => "3_5",
+        _ => "gte_6",
+    }
+}
+
+fn cursor_count_bucket(count: usize) -> &'static str {
     match count {
         0 | 1 => "1",
         2 => "2",
@@ -568,6 +618,7 @@ impl cua_driver_core::session::SessionObserver for TelemetryObserver {
         &self,
         session_id: &str,
         reason: cua_driver_core::session::SessionEndReason,
+        cursor: Option<cua_driver_core::session::CursorOutcomeObservation>,
     ) {
         let state = AGENT_SESSIONS
             .get_or_init(|| Mutex::new(HashMap::new()))
@@ -581,7 +632,7 @@ impl cua_driver_core::session::SessionObserver for TelemetryObserver {
         let transport = state.entry_transport;
         capture_bounded(
             event::AGENT_SESSION_ENDED,
-            state.ended_properties(reason),
+            state.ended_properties(reason, cursor),
             transport,
         );
     }
@@ -698,6 +749,7 @@ fn tool_completion_properties(
     };
     bounded_properties(&[
         ("tool_name", Value::String(tool_name)),
+        ("operation", Value::String(outcome.operation.as_str().into())),
         ("success", Value::Bool(outcome.success)),
         ("error_class", Value::String(error_class.into())),
         ("duration_bucket", Value::String(duration_bucket.into())),
@@ -1088,6 +1140,8 @@ pub(crate) fn capture_bounded(
 pub(crate) fn capture_cli_completed(
     command: &'static str,
     tool_name: Option<&str>,
+    operation: &str,
+    client_kind: &str,
     exit_code: i32,
     elapsed: Duration,
 ) {
@@ -1120,6 +1174,8 @@ pub(crate) fn capture_cli_completed(
     } else {
         "not_applicable".into()
     };
+    let operation = fixed_cli_operation(command, operation);
+    let client_kind = fixed_cli_client_kind(command, client_kind);
     let exit_class = match exit_code {
         0 => "success",
         1 => "tool_error",
@@ -1134,6 +1190,8 @@ pub(crate) fn capture_cli_completed(
         &bounded_properties(&[
             ("command", Value::String(command.into())),
             ("tool_name", Value::String(tool_name.into())),
+            ("operation", Value::String(operation.into())),
+            ("client_kind", Value::String(client_kind.into())),
             ("success", Value::Bool(success)),
             ("exit_class", Value::String(exit_class.into())),
             ("duration_bucket", Value::String(duration_bucket(elapsed).into())),
@@ -1173,13 +1231,24 @@ pub(crate) fn run_cli_completion_worker_if_requested() -> bool {
         .unwrap_or_default();
     let command = fixed_cli_command(&command);
     let tool_name = std::env::var(ENV_CLI_COMPLETION_TOOL).ok();
-    capture_cli_completed(command, tool_name.as_deref(), exit_code, elapsed);
+    let operation = std::env::var(ENV_CLI_COMPLETION_OPERATION).unwrap_or_default();
+    let client_kind = std::env::var(ENV_CLI_COMPLETION_CLIENT_KIND).unwrap_or_default();
+    capture_cli_completed(
+        command,
+        tool_name.as_deref(),
+        &operation,
+        &client_kind,
+        exit_code,
+        elapsed,
+    );
     true
 }
 
 pub(crate) fn spawn_cli_completion_worker(
     command: &'static str,
     tool_name: Option<&str>,
+    operation: &str,
+    client_kind: &str,
     exit_code: i32,
     elapsed: Duration,
 ) {
@@ -1191,6 +1260,8 @@ pub(crate) fn spawn_cli_completion_worker(
     worker
         .env(ENV_CLI_COMPLETION_WORKER, "1")
         .env(ENV_CLI_COMPLETION_COMMAND, fixed_cli_command(command))
+        .env(ENV_CLI_COMPLETION_OPERATION, fixed_cli_operation(command, operation))
+        .env(ENV_CLI_COMPLETION_CLIENT_KIND, fixed_cli_client_kind(command, client_kind))
         .env(ENV_CLI_COMPLETION_EXIT_CODE, exit_code.to_string())
         .env(ENV_CLI_COMPLETION_DURATION_MS, elapsed.as_millis().to_string());
     if let Some(tool_name) = tool_name {
@@ -1238,6 +1309,55 @@ fn fixed_tool_name(tool_name: &str) -> String {
         // arbitrary argv can reach this branch only when it matches that
         // compile-time registry vocabulary exactly.
         tool_name.to_owned()
+    }
+}
+
+fn fixed_cli_operation(command: &str, operation: &str) -> &'static str {
+    match command {
+        "recording" => match operation {
+            "start" => "start", "stop" => "stop", "status" => "status",
+            "render" => "render", _ => "other",
+        },
+        "permissions" => match operation {
+            "status" => "status", "grant" => "grant", _ => "other",
+        },
+        "config" => match operation {
+            "show" => "show", "get" => "get", "set" => "set",
+            "reset" => "reset", _ => "other",
+        },
+        "autostart" => match operation {
+            "enable" => "enable", "disable" => "disable", "status" => "status",
+            "kick" => "kick", _ => "other",
+        },
+        "skills" => match operation {
+            "install" => "install", "update" => "update", "uninstall" => "uninstall",
+            "status" => "status", "path" => "path", _ => "other",
+        },
+        "update" => match operation {
+            "apply" => "apply", "check_only" => "check_only", _ => "other",
+        },
+        _ => "not_applicable",
+    }
+}
+
+fn fixed_cli_client_kind(command: &str, client_kind: &str) -> &'static str {
+    if command != "mcp_config" {
+        return "not_applicable";
+    }
+    match client_kind {
+        "generic" => "generic",
+        "claude_code" => "claude_code",
+        "codex" => "codex",
+        "cursor" => "cursor",
+        "openclaw" => "openclaw",
+        "opencode" => "opencode",
+        "hermes" => "hermes",
+        "pi" => "pi",
+        "antigravity" => "antigravity",
+        "qwen_code" => "qwen_code",
+        "factory_droid" => "factory_droid",
+        "zcode" => "zcode",
+        _ => "other",
     }
 }
 
@@ -2160,6 +2280,7 @@ mod tests {
 
         let tool = inspect_event(event::MCP_TOOL_COMPLETED).unwrap();
         assert_eq!(tool["properties"]["duration_bucket"], "lt_10ms");
+        assert_eq!(tool["properties"]["operation"], "not_applicable");
         assert!(matches!(
             tool["properties"]["execution_mode"].as_str(),
             Some("embedded" | "standalone")
@@ -2279,6 +2400,7 @@ mod tests {
             true,
             &ToolCompletionObservation {
                 tool_name: "click".into(),
+                operation: cua_driver_core::server::ToolOperation::NotApplicable,
                 success: true,
                 error_class: ToolErrorClass::None,
                 duration_bucket: DurationBucket::Under10Ms,
@@ -2291,6 +2413,7 @@ mod tests {
             false,
             &ToolCompletionObservation {
                 tool_name: "page".into(),
+                operation: cua_driver_core::server::ToolOperation::QueryDom,
                 success: false,
                 error_class: ToolErrorClass::InternalError,
                 duration_bucket: DurationBucket::Ms50To249,
@@ -2300,6 +2423,15 @@ mod tests {
         );
         let properties = state.ended_properties(
             cua_driver_core::session::SessionEndReason::Explicit,
+            Some(cua_driver_core::session::CursorOutcomeObservation {
+                observed: true,
+                enabled: true,
+                style: cua_driver_core::session::CursorStyleCategory::CustomIcon,
+                color_source: cua_driver_core::session::CursorColorSource::Custom,
+                label_set: true,
+                motion_customized: true,
+                active_cursor_count: 3,
+            }),
         );
         assert_eq!(properties["duration_bucket"], "1_4min");
         assert_eq!(properties["tool_count_bucket"], "1_4");
@@ -2308,6 +2440,11 @@ mod tests {
         assert_eq!(properties["had_successful_tool"], true);
         assert_eq!(properties["had_successful_computer_action"], true);
         assert_eq!(properties["used_page"], true);
+        assert_eq!(properties["cursor_style"], "custom_icon");
+        assert_eq!(properties["cursor_color_source"], "custom");
+        assert_eq!(properties["cursor_label_set"], true);
+        assert_eq!(properties["cursor_motion_customized"], true);
+        assert_eq!(properties["multi_cursor_bucket"], "3_5");
         assert_eq!(properties["observed_multiple_transports"], true);
 
         let serialized = serde_json::to_string(&properties).unwrap().to_ascii_lowercase();
@@ -2394,6 +2531,7 @@ mod tests {
 
         let properties = tool_completion_properties(ToolCompletionObservation {
             tool_name: "click".into(),
+            operation: cua_driver_core::server::ToolOperation::NotApplicable,
             success: true,
             error_class: ToolErrorClass::None,
             duration_bucket: DurationBucket::Under10Ms,
@@ -2412,7 +2550,30 @@ mod tests {
 
         assert_eq!(payload["properties"]["transport"], "mcp_http");
         assert_eq!(payload["properties"]["tool_name"], "click");
+        assert_eq!(payload["properties"]["operation"], "not_applicable");
         assert_eq!(payload["properties"]["success"], true);
+    }
+
+    #[test]
+    fn compound_tool_operation_reaches_payload_as_a_fixed_value() {
+        use cua_driver_core::server::{
+            DurationBucket, OutputSizeBucket, OutputType, ToolCompletionObservation,
+            ToolErrorClass, ToolOperation,
+        };
+        let properties = tool_completion_properties(ToolCompletionObservation {
+            tool_name: "page".into(),
+            operation: ToolOperation::InsertText,
+            success: true,
+            error_class: ToolErrorClass::None,
+            duration_bucket: DurationBucket::Under10Ms,
+            output_type: OutputType::Text,
+            output_size_bucket: OutputSizeBucket::Under1KiB,
+        });
+        assert_eq!(properties["operation"], "insert_text");
+        let serialized = serde_json::to_string(&properties).unwrap();
+        for forbidden in ["selector", "private typed text", "script"] {
+            assert!(!serialized.contains(forbidden));
+        }
     }
 
     #[test]
@@ -2421,6 +2582,16 @@ mod tests {
         assert_eq!(fixed_tool_name("type_text_chars"), "type_text");
         assert_eq!(fixed_tool_name("../../private/secret"), "other");
         assert_eq!(fixed_tool_name("https://example.com/private"), "other");
+    }
+
+    #[test]
+    fn cli_operations_and_client_kinds_are_revalidated_in_the_worker() {
+        assert_eq!(fixed_cli_operation("recording", "start"), "start");
+        assert_eq!(fixed_cli_operation("recording", "/private/path"), "other");
+        assert_eq!(fixed_cli_operation("doctor", "start"), "not_applicable");
+        assert_eq!(fixed_cli_client_kind("mcp_config", "claude_code"), "claude_code");
+        assert_eq!(fixed_cli_client_kind("mcp_config", "/private/client"), "other");
+        assert_eq!(fixed_cli_client_kind("doctor", "claude_code"), "not_applicable");
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/lib.rs
@@ -222,6 +222,11 @@ impl CursorRegistry {
         }).clone()
     }
 
+    /// Read one cursor without materializing a new registry entry.
+    pub fn get(&self, cursor_id: &str) -> Option<CursorInstanceState> {
+        self.inner.lock().unwrap().get(cursor_id).cloned()
+    }
+
     pub fn update_position(&self, cursor_id: &str, x: f64, y: f64) {
         let mut inner = self.inner.lock().unwrap();
         let state = inner.entry(cursor_id.to_owned()).or_insert_with(|| CursorInstanceState {

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -6778,6 +6778,43 @@ pub fn build_registry(compat: bool) -> ToolRegistry {
     let state = ToolState::new();
     {
         let cursor_registry = state.cursor_registry.clone();
+        let _ = cua_driver_core::session::set_cursor_outcome_reader(std::sync::Arc::new(
+            move |session_id| {
+                let state = cursor_registry.get(session_id);
+                let motion_customized = state.is_some()
+                    && crate::overlay::current_motion_for(session_id)
+                        != cursor_overlay::MotionConfig::default();
+                let active_cursor_count = cursor_registry
+                    .all_states()
+                    .iter()
+                    .filter(|state| state.config.cursor_id != "default")
+                    .count()
+                    .max(1);
+                match state {
+                    Some(state) => cua_driver_core::session::bounded_cursor_outcome(
+                        true,
+                        state.config.enabled,
+                        state.config.cursor_icon.as_deref(),
+                        state.config.cursor_color.as_deref(),
+                        state.config.cursor_label.as_deref(),
+                        motion_customized,
+                        active_cursor_count,
+                    ),
+                    None => cua_driver_core::session::bounded_cursor_outcome(
+                        false,
+                        false,
+                        None,
+                        None,
+                        None,
+                        false,
+                        active_cursor_count,
+                    ),
+                }
+            },
+        ));
+    }
+    {
+        let cursor_registry = state.cursor_registry.clone();
         let state_for_session_end = state.clone();
         cua_driver_core::session::register_session_end_hook(move |session_id| {
             cursor_registry.remove(session_id);

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
@@ -369,6 +369,43 @@ impl Default for ToolState {
 /// note telling the caller to use pixel-addressed tools.
 pub fn register_all(registry: &mut ToolRegistry, compat: bool) {
     let state = Arc::new(ToolState::default());
+    {
+        let cursor_registry = state.cursor_registry.clone();
+        let _ = cua_driver_core::session::set_cursor_outcome_reader(std::sync::Arc::new(
+            move |session_id| {
+                let state = cursor_registry.get(session_id);
+                let motion_customized = state.is_some()
+                    && crate::cursor::overlay::current_motion(session_id)
+                        != cursor_overlay::MotionConfig::default();
+                let active_cursor_count = cursor_registry
+                    .all_states()
+                    .iter()
+                    .filter(|state| state.config.cursor_id != "default")
+                    .count()
+                    .max(1);
+                match state {
+                    Some(state) => cua_driver_core::session::bounded_cursor_outcome(
+                        true,
+                        state.config.enabled,
+                        state.config.cursor_icon.as_deref(),
+                        state.config.cursor_color.as_deref(),
+                        state.config.cursor_label.as_deref(),
+                        motion_customized,
+                        active_cursor_count,
+                    ),
+                    None => cua_driver_core::session::bounded_cursor_outcome(
+                        false,
+                        false,
+                        None,
+                        None,
+                        None,
+                        false,
+                        active_cursor_count,
+                    ),
+                }
+            },
+        ));
+    }
     // Share the element cache with the recording-hook layer so it can
     // resolve element_index → window-local screenshot coords for click.png.
     crate::recording_hooks::set_element_cache(state.element_cache.clone());

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -8358,6 +8358,43 @@ impl Tool for DebugWindowInfoTool {
 
 pub fn build_registry(compat: bool) -> ToolRegistry {
     let state = ToolState::new();
+    {
+        let cursor_registry = state.cursor_registry.clone();
+        let _ = cua_driver_core::session::set_cursor_outcome_reader(std::sync::Arc::new(
+            move |session_id| {
+                let state = cursor_registry.get(session_id);
+                let motion_customized = state.is_some()
+                    && crate::overlay::current_motion(session_id)
+                        != cursor_overlay::MotionConfig::default();
+                let active_cursor_count = cursor_registry
+                    .all_states()
+                    .iter()
+                    .filter(|state| state.config.cursor_id != "default")
+                    .count()
+                    .max(1);
+                match state {
+                    Some(state) => cua_driver_core::session::bounded_cursor_outcome(
+                        true,
+                        state.config.enabled,
+                        state.config.cursor_icon.as_deref(),
+                        state.config.cursor_color.as_deref(),
+                        state.config.cursor_label.as_deref(),
+                        motion_customized,
+                        active_cursor_count,
+                    ),
+                    None => cua_driver_core::session::bounded_cursor_outcome(
+                        false,
+                        false,
+                        None,
+                        None,
+                        None,
+                        false,
+                        active_cursor_count,
+                    ),
+                }
+            },
+        ));
+    }
     // Share the element cache with the recording-hook layer so it can
     // resolve element_index → window-local screenshot coords for click.png.
     crate::recording_hooks::set_element_cache(state.element_cache.clone());


### PR DESCRIPTION
## Summary
- classify reviewed finite CLI operations and MCP configuration client kinds before worker handoff
- add fixed operation categories for compound page calls
- capture cross-platform cursor outcome categories immediately before session cleanup
- expose an observed flag so missing cursor state is not interpreted as disabled
- isolate GUI behavior harnesses from live telemetry by default while retaining explicit opt-in
- document the expanded content-free telemetry contract

## Validation
- cargo test -p cua-driver-core --locked
- cargo test -p cua-driver --bin cua-driver --locked
- cargo test -p cursor-overlay --locked
- cargo test -p platform-macos cursor --locked
- cargo check -p cua-driver-testkit --locked
- cargo check across core, cursor overlay, all platform crates, and the binary
- npx tsx scripts/docs-generators/runner.ts --library cua-driver --check
- telemetry inspect for CLI, tool-completion, and session-end schemas