### PR TITLE
fix(docs): resolve Tailwind CSS imports in local dev

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -1,16 +1,10 @@
 import { createMDX } from 'fumadocs-mdx/next';
-import { dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 const withMDX = createMDX();
-const docsRoot = dirname(fileURLToPath(import.meta.url));
 
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
-  turbopack: {
-    root: docsRoot,
-  },
   trailingSlash: false,
   basePath: '/docs',
   assetPrefix: '/docs',


### PR DESCRIPTION
removes the explicit `turbopack.root` override from the local docs preview.

when the configured turbopack root exactly matched the docs app directory, next.js 16 resolved css `@import` dependencies from the parent directory. as a result, `pnpm dev` failed to resolve `tailwindcss` even though it was installed in `docs/node_modules`.

without the override, `pnpm dev` compiles the docs route successfully.

tested:
- `cd docs && pnpm dev`
- requested `http://localhost:8090/docs` and received 200