### PR TITLE
Refine Cua Fleets waitlist copy

### DIFF
--- a/blog/computer-use-2-ai-engineer-worlds-fair.md
+++ b/blog/computer-use-2-ai-engineer-worlds-fair.md
@@ -176,7 +176,7 @@ The same reservation works for longer jobs. A run can keep its sandbox for as lo
 
 _Cua Fleets spans Linux, Windows, and Android, with macOS in Labs preview on Cua's virtualization stack._
 
-If sandbox startup is already leaving accelerator time on the table, [join the Cua Fleets waitlist](https://cua.ai/signup?redirect_url=%2Fwaitlist).
+If your startup needs to run GUI sandboxes at scale for evaluations or RL, [join the Cua Fleets waitlist](https://cua.ai/signup?redirect_url=%2Fwaitlist).
 
 The code and docs behind the talk are here:
 


### PR DESCRIPTION
## What changed

Rewrites the Cua Fleets waitlist call to address startups that need GUI sandboxes at scale for evaluations or reinforcement learning.

## Why

The previous sentence focused on accelerator idle time. The revised copy states the intended audience and workload more directly.

## Impact

Copy-only change to the Computer-Use 2.0 blog post. No product behavior changes.

## Checks

- `git diff --check`
- Verified the Cua Fleets waitlist URL returns HTTP 200