### PR TITLE
feat(agent): Yutori Navigator n1.5 support

### DIFF
--- a/libs/python/agent/cua_agent/adapters/yutori_adapter.py
+++ b/libs/python/agent/cua_agent/adapters/yutori_adapter.py
@@ -19,9 +19,15 @@ class YutoriAdapter(CustomLLM):
         self.api_key = api_key or os.environ.get("YUTORI_API_KEY")
 
     def _normalize_model(self, model: str) -> str:
-        """Strip the yutori/ prefix to get the bare model name."""
+        """Strip the yutori/ prefix and pin bare model names to their -latest alias.
+
+        The Yutori API only accepts versioned model names (e.g. "n1.5-latest",
+        "n1.5-20260428") and rejects bare names like "n1.5".
+        """
         if model.startswith("yutori/"):
-            return model[len("yutori/") :]
+            model = model[len("yutori/") :]
+        if "-" not in model:
+            model = f"{model}-latest"
         return model
 
     def _resolve_api_key(self, kwargs: dict | None = None) -> str:
@@ -48,7 +54,7 @@ class YutoriAdapter(CustomLLM):
         params = {
             "model": f"openai/{model}",
             "messages": kwargs.get("messages", []),
-            "api_base": self.base_url,
+            "api_base": kwargs.get("api_base") or self.base_url,
             "api_key": api_key,
             "extra_headers": extra_headers,
             "stream": False,
@@ -60,16 +66,21 @@ class YutoriAdapter(CustomLLM):
         if "tool_choice" in kwargs:
             params["tool_choice"] = kwargs["tool_choice"]
 
-        # Forward optional generation params
+        # Forward optional generation params. extra_body carries Yutori-specific
+        # request fields (tool_set, disable_tools, json_schema, prev_request_id).
         for key in (
             "temperature",
             "top_p",
             "max_completion_tokens",
-            "max_tokens",
             "response_format",
+            "extra_body",
         ):
             if key in kwargs:
                 params[key] = kwargs[key]
+
+        # The Yutori API rejects max_tokens; it requires max_completion_tokens.
+        if "max_tokens" in kwargs and "max_completion_tokens" not in params:
+            params["max_completion_tokens"] = kwargs["max_tokens"]
 
         if "optional_params" in kwargs:
             protected_keys = {"api_key", "extra_headers", "model", "api_base", "stream"}
@@ -93,7 +104,7 @@ class YutoriAdapter(CustomLLM):
         return response
 
     def streaming(self, *args, **kwargs) -> Iterator[GenericStreamingChunk]:
-        raise NotImplementedError("Yutori n1 does not support streaming.")
+        raise NotImplementedError("Yutori Navigator models do not support streaming.")
 
     async def astreaming(self, *args, **kwargs) -> AsyncIterator[GenericStreamingChunk]:
-        raise NotImplementedError("Yutori n1 does not support streaming.")
+        raise NotImplementedError("Yutori Navigator models do not support streaming.")

--- a/libs/python/agent/cua_agent/agent.py
+++ b/libs/python/agent/cua_agent/agent.py
@@ -33,6 +33,7 @@ from .adapters import (
     HuggingFaceLocalAdapter,
     HumanAdapter,
     MLXVLMAdapter,
+    YutoriAdapter,
 )
 from .callbacks import (
     BudgetManagerCallback,
@@ -364,12 +365,14 @@ class ComputerAgent:
         mlx_adapter = MLXVLMAdapter()
         cua_adapter = CUAAdapter()
         azure_ml_adapter = AzureMLAdapter()
+        yutori_adapter = YutoriAdapter()
         litellm.custom_provider_map = [
             {"provider": "huggingface-local", "custom_handler": hf_adapter},
             {"provider": "human", "custom_handler": human_adapter},
             {"provider": "mlx", "custom_handler": mlx_adapter},
             {"provider": "cua", "custom_handler": cua_adapter},
             {"provider": "azure_ml", "custom_handler": azure_ml_adapter},
+            {"provider": "yutori", "custom_handler": yutori_adapter},
         ]
         litellm.suppress_debug_info = True
 

--- a/libs/python/agent/cua_agent/callbacks/operator_validator.py
+++ b/libs/python/agent/cua_agent/callbacks/operator_validator.py
@@ -30,7 +30,7 @@ class OperatorNormalizerCallback(AsyncCallbackHandler):
                 continue
 
             # rename mouse click actions to "click"
-            for mouse_btn in ["left", "right", "wheel", "back", "forward"]:
+            for mouse_btn in ["left", "right", "middle", "wheel", "back", "forward"]:
                 if action.get("type", "") == f"{mouse_btn}_click":
                     action["type"] = "click"
                     action["button"] = mouse_btn
@@ -86,19 +86,21 @@ class OperatorNormalizerCallback(AsyncCallbackHandler):
                     action["keys"] = keys.replace("-", "+").split("+") if len(keys) > 1 else [keys]
             required_keys_by_type = {
                 # OpenAI actions
-                "click": ["type", "button", "x", "y"],
-                "double_click": ["type", "x", "y"],
+                # modifier: optional held modifier key (e.g. ctrl+click), used by Yutori n1.5
+                "click": ["type", "button", "x", "y", "modifier"],
+                "double_click": ["type", "x", "y", "modifier"],
                 "drag": ["type", "path"],
                 "keypress": ["type", "keys"],
                 "move": ["type", "x", "y"],
                 "screenshot": ["type"],
                 "scroll": ["type", "scroll_x", "scroll_y", "x", "y"],
                 "type": ["type", "text"],
-                "wait": ["type"],
+                # time: optional duration in seconds, used by FARA and Yutori n1.5
+                "wait": ["type", "time"],
                 # Anthropic actions
                 "left_mouse_down": ["type", "x", "y"],
                 "left_mouse_up": ["type", "x", "y"],
-                "triple_click": ["type", "button", "x", "y"],
+                "triple_click": ["type", "button", "x", "y", "modifier"],
             }
             keep = required_keys_by_type.get(action_type or "")
             if keep:

--- a/libs/python/agent/cua_agent/loops/yutori.py
+++ b/libs/python/agent/cua_agent/loops/yutori.py
@@ -1,8 +1,36 @@
 """
-Yutori n1 agent loop implementation using litellm.
+Yutori Navigator (n1.5) agent loop implementation using litellm.
 
-n1 is a browser-use model that outputs actions via tool_calls in OpenAI chat
-completions format. Coordinates are in a 1000x1000 normalized space.
+Navigator is a browser-use model that outputs actions via tool_calls in OpenAI
+chat completions format. Coordinates are in a 1000x1000 normalized space, and
+screenshots are best sent as 1280x800 WebP images.
+
+The default model is ``yutori/n1.5-latest``; dated snapshots such as
+``yutori/n1.5-20260428`` are also supported. (Navigator n1 is deprecated and
+rejected by the Yutori API.)
+
+Notes (see https://docs.yutori.com reference/n1-5):
+- key_press takes ``key`` in a lowercase key space, where "+" joins
+  simultaneous keys and spaces separate sequential presses
+  (e.g. "ctrl+c", "down down enter").
+- Click/scroll actions accept optional ``ref`` (DOM element reference) and
+  ``modifier`` (held modifier key) arguments.
+- Optional request params tool_set, disable_tools, json_schema and
+  prev_request_id are forwarded via extra_body, e.g.::
+
+      agent = ComputerAgent(
+          model="yutori/n1.5-latest",
+          tools=[computer],
+          tool_set="browser_tools_expanded-20260403",
+      )
+
+- The expanded tool set adds DOM tools (extract_elements, find,
+  set_element_value, execute_js). This loop executes them inline through the
+  computer handler's evaluate_js method, which requires a computer-server
+  recent enough to support the ``evaluate`` browser command.
+
+The Yutori API injects the browser tool definitions and the system prompt
+server-side, so this loop only forwards custom function tools.
 """
 
 from __future__ import annotations
@@ -28,22 +56,75 @@ from ..responses import (
     make_reasoning_item,
 )
 from ..types import AgentCapability
+from .yutori_js import (
+    EXECUTE_JS_SCRIPT,
+    EXTRACT_ELEMENTS_SCRIPT,
+    FIND_SCRIPT,
+    GET_ELEMENT_BY_REF_SCRIPT,
+    SET_ELEMENT_VALUE_SCRIPT,
+    build_tool_expression,
+    coerce_result,
+)
 
-# Target resolution for n1 (docs recommend 1280x800 WebP)
-N1_TARGET_WIDTH = 1280
-N1_TARGET_HEIGHT = 800
-N1_COORD_SPACE = 1000
+# Target resolution for Navigator models (docs recommend 1280x800 WebP)
+NAVIGATOR_TARGET_WIDTH = 1280
+NAVIGATOR_TARGET_HEIGHT = 800
+NAVIGATOR_COORD_SPACE = 1000
+
+# DOM tools from the expanded tool set, executed inline by this loop
+DOM_TOOL_NAMES = {"extract_elements", "find", "set_element_value", "execute_js"}
+
+# Yutori-specific request params forwarded to the API via extra_body
+YUTORI_EXTRA_BODY_PARAMS = ("tool_set", "disable_tools", "json_schema", "prev_request_id")
+
+# Map the Navigator key space to the pynput-style names understood by the
+# computer-server keyboard handlers, plus a few tolerant synonyms.
+_KEY_ALIASES = {
+    "meta": "cmd",
+    "command": "cmd",
+    "super": "cmd",
+    "win": "cmd",
+    "control": "ctrl",
+    "escape": "esc",
+    "pageup": "page_up",
+    "pagedown": "page_down",
+    "return": "enter",
+}
 
 
-def _prepare_image_for_n1(image_b64: str) -> str:
-    """Convert a base64 PNG screenshot to WebP at 1280x800 for optimal n1 performance."""
+def _map_key_token(token: str) -> str:
+    """Map a single Navigator key name to a pynput-style key name."""
+    token = token.strip()
+    if len(token) == 1:
+        return token
+    lowered = token.lower()
+    return _KEY_ALIASES.get(lowered, lowered)
+
+
+def _convert_key_expression(expr: str) -> List[List[str]]:
+    """Convert a Navigator key expression to a list of key combos.
+
+    "+" joins keys pressed simultaneously; whitespace separates sequential
+    presses. E.g. "down down enter" -> [["down"], ["down"], ["enter"]] and
+    "ctrl+shift+t" -> [["ctrl", "shift", "t"]].
+    """
+    combos = []
+    for combo in expr.split():
+        keys = [_map_key_token(k) for k in combo.split("+") if k.strip()]
+        if keys:
+            combos.append(keys)
+    return combos
+
+
+def _prepare_image_for_navigator(image_b64: str) -> str:
+    """Convert a base64 PNG screenshot to WebP at 1280x800 for optimal performance."""
     try:
         img_bytes = base64.b64decode(image_b64)
         img = Image.open(io.BytesIO(img_bytes))
 
-        # Resize to n1's recommended resolution
-        if img.size != (N1_TARGET_WIDTH, N1_TARGET_HEIGHT):
-            img = img.resize((N1_TARGET_WIDTH, N1_TARGET_HEIGHT), Image.LANCZOS)
+        # Resize to the recommended resolution
+        if img.size != (NAVIGATOR_TARGET_WIDTH, NAVIGATOR_TARGET_HEIGHT):
+            img = img.resize((NAVIGATOR_TARGET_WIDTH, NAVIGATOR_TARGET_HEIGHT), Image.LANCZOS)
 
         # Convert to WebP
         buf = io.BytesIO()
@@ -57,52 +138,72 @@ def _prepare_image_for_n1(image_b64: str) -> str:
 def _unnormalize_coordinates(
     coords: List[int], screen_width: int, screen_height: int
 ) -> Tuple[int, int]:
-    """Scale coordinates from n1's 1000x1000 space to actual screen pixels."""
-    x = max(0, min(screen_width, round((coords[0] / N1_COORD_SPACE) * screen_width)))
-    y = max(0, min(screen_height, round((coords[1] / N1_COORD_SPACE) * screen_height)))
+    """Scale coordinates from the 1000x1000 normalized space to actual screen pixels."""
+    x = max(0, min(screen_width, round((coords[0] / NAVIGATOR_COORD_SPACE) * screen_width)))
+    y = max(0, min(screen_height, round((coords[1] / NAVIGATOR_COORD_SPACE) * screen_height)))
     return x, y
 
 
-def _convert_n1_action_to_computer_action(
-    fn_name: str, args: Dict[str, Any], screen_width: int, screen_height: int
-) -> Optional[Dict[str, Any]]:
+def _convert_navigator_action(
+    fn_name: str,
+    args: Dict[str, Any],
+    screen_width: int,
+    screen_height: int,
+    ref_pixels: Optional[Tuple[int, int]] = None,
+) -> Optional[List[Dict[str, Any]]]:
     """
-    Convert an n1 tool call to the internal computer_call action schema.
+    Convert a Navigator tool call to a list of internal computer_call actions.
 
-    Returns None for actions that should be emitted as function_calls instead
-    (goto_url, go_back, refresh).
+    ref_pixels, when provided, are viewport pixel coordinates already resolved
+    from the action's ``ref`` argument and take precedence over the normalized
+    ``coordinates``.
+
+    Returns None for tool calls that are not computer actions (custom function
+    tools), so the caller can emit them as function_calls instead.
     """
-    # Actions with coordinates
-    coords = args.get("coordinates")
     x, y = None, None
-    if isinstance(coords, (list, tuple)) and len(coords) >= 2:
-        x, y = _unnormalize_coordinates(coords, screen_width, screen_height)
+    if ref_pixels is not None:
+        x, y = ref_pixels
+    else:
+        coords = args.get("coordinates")
+        if isinstance(coords, (list, tuple)) and len(coords) >= 2:
+            x, y = _unnormalize_coordinates(coords, screen_width, screen_height)
 
-    if fn_name == "left_click":
+    modifier = args.get("modifier")
+    modifier = _map_key_token(modifier) if isinstance(modifier, str) and modifier else None
+
+    def _with_modifier(action: Dict[str, Any]) -> Dict[str, Any]:
+        if modifier:
+            action["modifier"] = modifier
+        return action
+
+    if fn_name in ("left_click", "right_click", "middle_click"):
         if x is None or y is None:
             return None
-        return {"action": "left_click", "x": x, "y": y}
+        button = fn_name.split("_")[0]
+        return [_with_modifier({"action": "click", "button": button, "x": x, "y": y})]
 
     if fn_name == "double_click":
         if x is None or y is None:
             return None
-        return {"action": "double_click", "x": x, "y": y}
+        return [_with_modifier({"action": "double_click", "x": x, "y": y})]
 
     if fn_name == "triple_click":
-        # Approximate as double_click
         if x is None or y is None:
             return None
-        return {"action": "double_click", "x": x, "y": y}
+        return [_with_modifier({"action": "triple_click", "x": x, "y": y})]
 
-    if fn_name == "right_click":
+    if fn_name == "mouse_move":
         if x is None or y is None:
             return None
-        return {"action": "right_click", "x": x, "y": y}
+        return [{"action": "move", "x": x, "y": y}]
 
-    if fn_name == "hover":
-        if x is None or y is None:
-            return None
-        return {"action": "move", "x": x, "y": y}
+    if fn_name in ("mouse_down", "mouse_up"):
+        action: Dict[str, Any] = {"action": fn_name}
+        if x is not None and y is not None:
+            action["x"] = x
+            action["y"] = y
+        return [action]
 
     if fn_name == "drag":
         start_coords = args.get("start_coordinates")
@@ -114,13 +215,13 @@ def _convert_n1_action_to_computer_action(
         ):
             return None
         sx, sy = _unnormalize_coordinates(start_coords, screen_width, screen_height)
-        return {
-            "action": "drag",
-            "start_x": sx,
-            "start_y": sy,
-            "end_x": x,
-            "end_y": y,
-        }
+        return [
+            {
+                "action": "left_click_drag",
+                "start_coordinate": [sx, sy],
+                "end_coordinate": [x, y],
+            }
+        ]
 
     if fn_name == "scroll":
         direction = args.get("direction", "down")
@@ -141,39 +242,49 @@ def _convert_n1_action_to_computer_action(
         if x is not None and y is not None:
             out["x"] = x
             out["y"] = y
-        return out
+        return [out]
 
     if fn_name == "type":
-        text = args.get("text", "")
-        if args.get("press_enter_after"):
-            text = text + "\n"
-        # Note: clear_before_typing is not supported by the framework's type action.
-        # n1 rarely emits this flag; when it does, the field may already be empty.
-        return {"action": "type", "text": text}
+        return [{"action": "type", "text": args.get("text", "")}]
 
     if fn_name == "key_press":
-        key_comb = args.get("key_comb", "")
-        # n1 uses Playwright-compatible key combos like "Control+a", "Escape"
-        keys = [k.strip() for k in key_comb.split("+")]
-        return {"action": "keypress", "keys": keys}
+        combos = _convert_key_expression(args.get("key") or "")
+        if not combos:
+            return None
+        return [{"action": "keypress", "keys": keys} for keys in combos]
+
+    if fn_name == "hold_key":
+        key = args.get("key", "")
+        if not key:
+            return None
+        action = {"action": "hold_key", "key": _map_key_token(key)}
+        if args.get("duration") is not None:
+            action["duration"] = float(args["duration"])
+        return [action]
 
     if fn_name == "wait":
-        return {"action": "wait"}
+        action = {"action": "wait"}
+        if args.get("duration") is not None:
+            action["time"] = float(args["duration"])
+        return [action]
 
     if fn_name == "go_back":
-        return {"action": "history_back"}
+        return [{"action": "history_back"}]
+
+    if fn_name == "go_forward":
+        return [{"action": "history_forward"}]
 
     if fn_name == "refresh":
-        return {"action": "keypress", "keys": ["F5"]}
+        return [{"action": "refresh"}]
 
     if fn_name == "goto_url":
-        return {"action": "visit_url", "url": args.get("url", "")}
+        return [{"action": "visit_url", "url": args.get("url", "")}]
 
     return None
 
 
-def _convert_images_to_n1_format(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Convert all images in messages to WebP format optimized for n1."""
+def _convert_images_to_navigator_format(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Convert all images in messages to WebP format optimized for Navigator models."""
     for msg in messages:
         content = msg.get("content")
         if not isinstance(content, list):
@@ -183,18 +294,120 @@ def _convert_images_to_n1_format(messages: List[Dict[str, Any]]) -> List[Dict[st
                 url = ((part.get("image_url") or {}).get("url")) or ""
                 if url.startswith("data:") and "," in url:
                     b64 = url.split(",", 1)[1]
-                    converted = _prepare_image_for_n1(b64)
+                    converted = _prepare_image_for_navigator(b64)
                     part["image_url"]["url"] = f"data:image/webp;base64,{converted}"
     return messages
 
 
-@register_agent(models=r"(yutori/)?n1(-.*)?$", tool_type="browser")
-class YutoriN1Config(AsyncAgentConfig):
-    """
-    Yutori n1 browser-use agent loop.
+def _message_has_image(msg: Dict[str, Any]) -> bool:
+    content = msg.get("content")
+    if isinstance(content, list):
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "image_url":
+                return True
+    return False
 
-    n1 is a browser-only model that outputs actions as tool_calls.
-    Coordinates use a 1000x1000 normalized space.
+
+async def _evaluate_tool_script(computer_handler, script: str, *args: Any) -> Dict[str, Any]:
+    """Run a bundled JS tool script in the page via the computer handler.
+
+    Raises RuntimeError when the handler or the computer-server cannot
+    evaluate JS (e.g. servers predating the 'evaluate' browser command).
+    """
+    if not hasattr(computer_handler, "evaluate_js"):
+        raise RuntimeError(
+            "This computer handler does not support JavaScript evaluation "
+            "(expanded browser tools require a BrowserTool handler)."
+        )
+    result = await computer_handler.evaluate_js(build_tool_expression(script, *args))
+    if not isinstance(result, dict) or not result.get("success", False):
+        error = result.get("error") if isinstance(result, dict) else str(result)
+        raise RuntimeError(error or "JavaScript evaluation failed.")
+    return coerce_result(result.get("result"))
+
+
+async def _resolve_ref(computer_handler, ref: str) -> Optional[Tuple[int, int]]:
+    """Resolve a DOM element ref to viewport pixel coordinates.
+
+    Also scrolls the element into view. Returns None when resolution fails so
+    the caller can fall back to the action's normalized coordinates.
+    """
+    try:
+        result = await _evaluate_tool_script(computer_handler, GET_ELEMENT_BY_REF_SCRIPT, ref)
+    except Exception:
+        return None
+    if not result.get("success"):
+        return None
+    px = result.get("coordinates")
+    if not isinstance(px, (list, tuple)) or len(px) < 2:
+        return None
+    return int(px[0]), int(px[1])
+
+
+async def _execute_dom_tool(computer_handler, fn_name: str, args: Dict[str, Any]) -> str:
+    """Execute an expanded-tool-set DOM tool inline and format its result."""
+    try:
+        if fn_name == "extract_elements":
+            data = await _evaluate_tool_script(
+                computer_handler, EXTRACT_ELEMENTS_SCRIPT, args.get("filter", "visible")
+            )
+            result = data.get("pageContent", "")
+        elif fn_name == "find":
+            text = args.get("text", "")
+            data = await _evaluate_tool_script(computer_handler, FIND_SCRIPT, text)
+            if not data.get("success", False):
+                result = f"[ERROR] {data.get('message', 'find failed')}"
+            else:
+                matches = data.get("matches", [])
+                total_matches = int(data.get("totalMatches", len(matches)))
+                if total_matches:
+                    result = f'Found {total_matches} element(s) matching "{text}":\n' + "\n".join(
+                        matches[:20]
+                    )
+                else:
+                    result = f'No elements matching "{text}" found on the page.'
+        elif fn_name == "set_element_value":
+            data = await _evaluate_tool_script(
+                computer_handler,
+                SET_ELEMENT_VALUE_SCRIPT,
+                args.get("ref", ""),
+                args.get("value", ""),
+            )
+            result = data.get("message", "set_element_value completed")
+        elif fn_name == "execute_js":
+            data = await _evaluate_tool_script(
+                computer_handler, EXECUTE_JS_SCRIPT, args.get("text", "")
+            )
+            if not data.get("success", False):
+                result = f"[ERROR] {data.get('message', 'execute_js failed')}"
+            elif not data.get("hasResult"):
+                result = "undefined"
+            else:
+                result = str(data.get("result"))
+        else:
+            result = f"[ERROR] Unknown DOM tool: {fn_name}"
+    except Exception as e:
+        result = f"[ERROR] Error executing {fn_name}: {e}"
+
+    # Match the reference client: append the current URL to tool results
+    try:
+        current_url = await computer_handler.get_current_url()
+        if current_url:
+            result = f"{result}\nCurrent URL: {current_url}"
+    except Exception:
+        pass
+
+    return result
+
+
+@register_agent(models=r"(yutori/)?n1\.\d+(-.*)?$", tool_type="browser")
+class YutoriNavigatorConfig(AsyncAgentConfig):
+    """
+    Yutori Navigator (n1.5) browser-use agent loop.
+
+    Navigator is a browser-only model that outputs actions as tool_calls.
+    Coordinates use a 1000x1000 normalized space. Browser tool definitions and
+    the system prompt are injected server-side by the Yutori API.
     """
 
     async def predict_step(
@@ -212,11 +425,11 @@ class YutoriN1Config(AsyncAgentConfig):
         _on_screenshot=None,
         **kwargs,
     ) -> Dict[str, Any]:
-        """Predict the next browser action using Yutori n1."""
+        """Predict the next browser action using a Yutori Navigator model."""
         tools = tools or []
 
         # Get screen dimensions for coordinate denormalization
-        screen_width, screen_height = N1_TARGET_WIDTH, N1_TARGET_HEIGHT
+        screen_width, screen_height = NAVIGATOR_TARGET_WIDTH, NAVIGATOR_TARGET_HEIGHT
         if computer_handler:
             try:
                 screen_width, screen_height = await computer_handler.get_dimensions()
@@ -234,29 +447,24 @@ class YutoriN1Config(AsyncAgentConfig):
         )
 
         # Convert images to WebP at 1280x800
-        completion_messages = _convert_images_to_n1_format(completion_messages)
+        completion_messages = _convert_images_to_navigator_format(completion_messages)
 
-        # If there's no screenshot, take one and inject it
-        def _has_any_image(msgs: List[Dict[str, Any]]) -> bool:
-            for m in msgs:
-                content = m.get("content")
-                if isinstance(content, list):
-                    for p in content:
-                        if isinstance(p, dict) and p.get("type") == "image_url":
-                            return True
-            return False
-
-        pre_output_items: List[Dict[str, Any]] = []
-        if not _has_any_image(completion_messages):
+        # Navigator predicts actions from the current screen. If the latest
+        # message carries no screenshot (start of a task, a new user
+        # instruction, or a text-only DOM tool result), take one and inject it
+        # for this request only.
+        if not completion_messages or not _message_has_image(completion_messages[-1]):
             if computer_handler is None or not hasattr(computer_handler, "screenshot"):
                 raise RuntimeError(
-                    "No screenshots present and computer_handler.screenshot is not available."
+                    "No current screenshot and computer_handler.screenshot is not available."
                 )
             screenshot_b64 = await computer_handler.screenshot()
             if not screenshot_b64:
                 raise RuntimeError("Failed to capture screenshot from computer_handler.")
+            if _on_screenshot:
+                await _on_screenshot(screenshot_b64, "screenshot_before")
 
-            converted = _prepare_image_for_n1(screenshot_b64)
+            converted = _prepare_image_for_navigator(screenshot_b64)
             completion_messages.append(
                 {
                     "role": "user",
@@ -269,38 +477,38 @@ class YutoriN1Config(AsyncAgentConfig):
                     ],
                 }
             )
-            pre_output_items.append(
-                {
-                    "type": "message",
-                    "role": "assistant",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "Taking a screenshot to see the current browser screen.",
-                        }
-                    ],
-                }
-            )
 
-        # Build tool list: pass through any custom function tools
-        n1_tools = []
+        # Build tool list: pass through any custom function tools.
+        # Browser tools are injected server-side by the Yutori API.
+        custom_tools = []
+        custom_tool_names = set()
         for tool in tools:
             if tool.get("type") == "function":
                 func = tool.get("function")
                 if func:
-                    n1_tools.append({"type": "function", "function": func})
-            # Skip computer tools — n1 has built-in browser actions
+                    custom_tools.append({"type": "function", "function": func})
+                    if func.get("name"):
+                        custom_tool_names.add(func["name"])
+
+        # Collect Yutori-specific request params into extra_body
+        extra_body = dict(kwargs.pop("extra_body", None) or {})
+        for key in YUTORI_EXTRA_BODY_PARAMS:
+            value = kwargs.pop(key, None)
+            if value is not None:
+                extra_body[key] = value
 
         api_kwargs: Dict[str, Any] = {
             "model": model,
             "messages": completion_messages,
             "max_retries": max_retries,
-            "stream": False,  # n1 does not support streaming
+            "stream": False,  # Navigator models do not support streaming
             "temperature": kwargs.pop("temperature", 0.3),
         }
 
-        if n1_tools:
-            api_kwargs["tools"] = n1_tools
+        if custom_tools:
+            api_kwargs["tools"] = custom_tools
+        if extra_body:
+            api_kwargs["extra_body"] = extra_body
 
         # Pass through remaining kwargs (api_key, api_base, etc.)
         api_kwargs.update({k: v for k, v in kwargs.items()})
@@ -329,7 +537,7 @@ class YutoriN1Config(AsyncAgentConfig):
         message = choice.get("message") or {}
         content_text = message.get("content") or ""
         tool_calls_array = message.get("tool_calls") or []
-        reasoning_text = message.get("reasoning") or ""
+        reasoning_text = message.get("reasoning_content") or message.get("reasoning") or ""
 
         output_items: List[Dict[str, Any]] = []
 
@@ -349,30 +557,58 @@ class YutoriN1Config(AsyncAgentConfig):
                 except json.JSONDecodeError:
                     args = {}
 
-                # Try converting to a computer action
-                computer_action = _convert_n1_action_to_computer_action(
-                    fn_name, args, screen_width, screen_height
+                # Expanded tool set DOM tools are executed inline; emitting the
+                # call and its output together makes the agent skip re-execution.
+                # A user-provided function tool with the same name wins.
+                if fn_name in DOM_TOOL_NAMES and fn_name not in custom_tool_names:
+                    dom_result = await _execute_dom_tool(computer_handler, fn_name, args)
+                    output_items.append(make_function_call_item(fn_name, args, call_id=tc_id))
+                    output_items.append(
+                        {
+                            "type": "function_call_output",
+                            "call_id": tc_id,
+                            "output": dom_result,
+                        }
+                    )
+                    continue
+
+                # Resolve a DOM element ref to pixel coordinates when present;
+                # fall back to the action's normalized coordinates.
+                ref_pixels = None
+                ref = args.get("ref")
+                if ref and computer_handler is not None:
+                    ref_pixels = await _resolve_ref(computer_handler, ref)
+
+                computer_actions = _convert_navigator_action(
+                    fn_name, args, screen_width, screen_height, ref_pixels=ref_pixels
                 )
 
-                if computer_action is not None:
-                    # Build a fake completion message for the converter
-                    fake_cm = {
-                        "role": "assistant",
-                        "content": content_text or "",
-                        "tool_calls": [
-                            {
-                                "type": "function",
-                                "id": tc_id,
-                                "function": {
-                                    "name": "computer",
-                                    "arguments": json.dumps(computer_action),
-                                },
-                            }
-                        ],
-                    }
-                    output_items.extend(convert_completion_messages_to_responses_items([fake_cm]))
-                    # Only use content_text once
-                    content_text = ""
+                if computer_actions:
+                    for i, computer_action in enumerate(computer_actions):
+                        # A single Navigator tool call (e.g. the key sequence
+                        # "down down enter") may expand into several actions;
+                        # each needs a unique call_id.
+                        call_id = tc_id if i == 0 else f"{tc_id}-{i}"
+                        # Build a fake completion message for the converter
+                        fake_cm = {
+                            "role": "assistant",
+                            "content": content_text or "",
+                            "tool_calls": [
+                                {
+                                    "type": "function",
+                                    "id": call_id,
+                                    "function": {
+                                        "name": "computer",
+                                        "arguments": json.dumps(computer_action),
+                                    },
+                                }
+                            ],
+                        }
+                        output_items.extend(
+                            convert_completion_messages_to_responses_items([fake_cm])
+                        )
+                        # Only use content_text once
+                        content_text = ""
                 else:
                     # Custom tool — emit as function_call
                     output_items.append(make_function_call_item(fn_name, args, call_id=tc_id))
@@ -383,13 +619,13 @@ class YutoriN1Config(AsyncAgentConfig):
             else:
                 output_items.append(make_output_text_item("Task completed."))
 
-        return {"output": (pre_output_items + output_items), "usage": usage}
+        return {"output": output_items, "usage": usage}
 
     async def predict_click(
         self, model: str, image_b64: str, instruction: str, **kwargs
     ) -> Optional[Tuple[int, int]]:
         raise NotImplementedError(
-            "Yutori n1 does not support standalone click prediction. "
+            "Yutori Navigator models do not support standalone click prediction. "
             "Use predict_step for full browser automation."
         )
 

--- a/libs/python/agent/cua_agent/loops/yutori_js/__init__.py
+++ b/libs/python/agent/cua_agent/loops/yutori_js/__init__.py
@@ -1,0 +1,64 @@
+"""Bundled JS implementations of the Yutori Navigator n1.5 expanded browser tools.
+
+These scripts are vendored verbatim from the Apache-2.0 licensed Yutori Python
+SDK (https://github.com/yutori-ai/yutori-sdk-python, yutori/navigator/tools/js/).
+Each file contains a single JS function expression; build_tool_expression wraps
+it in an IIFE call with JSON-serialized arguments suitable for page.evaluate().
+"""
+
+from __future__ import annotations
+
+import json
+from importlib.resources import files
+from typing import Any, Dict
+
+
+def _load_script(name: str) -> str:
+    return (files(__package__) / name).read_text(encoding="utf-8")
+
+
+EXECUTE_JS_SCRIPT = _load_script("execute_js.js")
+EXTRACT_ELEMENTS_SCRIPT = _load_script("extract_elements.js")
+FIND_SCRIPT = _load_script("find.js")
+GET_ELEMENT_BY_REF_SCRIPT = _load_script("get_element_by_ref.js")
+SET_ELEMENT_VALUE_SCRIPT = _load_script("set_element_value.js")
+
+
+def build_tool_expression(script: str, *args: Any) -> str:
+    """Wrap a tool script in an IIFE call with JSON-serialized arguments."""
+    escaped_args = ", ".join(json.dumps(arg) for arg in args)
+    return f"({script})({escaped_args})"
+
+
+def coerce_result(raw: Any) -> Dict[str, Any]:
+    """Normalize a page.evaluate() result into a consistent dict.
+
+    - None -> {"success": False, "message": "Script returned no result"}
+    - dict -> passed through unchanged
+    - JSON string that parses to a dict -> that dict
+    - anything else -> {"value": raw}
+    """
+    if raw is None:
+        return {"success": False, "message": "Script returned no result"}
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return {"value": raw}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"value": parsed}
+    return {"value": raw}
+
+
+__all__ = [
+    "EXECUTE_JS_SCRIPT",
+    "EXTRACT_ELEMENTS_SCRIPT",
+    "FIND_SCRIPT",
+    "GET_ELEMENT_BY_REF_SCRIPT",
+    "SET_ELEMENT_VALUE_SCRIPT",
+    "build_tool_expression",
+    "coerce_result",
+]

--- a/libs/python/agent/cua_agent/loops/yutori_js/execute_js.js
+++ b/libs/python/agent/cua_agent/loops/yutori_js/execute_js.js
@@ -1,0 +1,52 @@
+(async function (source) {
+  try {
+    var AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
+    // Try expression-style first (e.g. "document.title", "2 + 2") by wrapping
+    // in "return (...)".  If that fails to parse, fall back to body-style
+    // (e.g. multi-statement code with its own return).
+    var fn;
+    try {
+      fn = new AsyncFunction("return (" + source + ")");
+    } catch (e) {
+      fn = new AsyncFunction(source);
+    }
+
+    var value = await fn();
+
+    if (value === undefined) {
+      return {
+        success: true,
+        hasResult: false,
+        result: null,
+      };
+    }
+
+    if (typeof value === "string") {
+      return {
+        success: true,
+        hasResult: true,
+        result: value,
+      };
+    }
+
+    try {
+      return {
+        success: true,
+        hasResult: true,
+        result: JSON.stringify(value),
+      };
+    } catch (error) {
+      return {
+        success: true,
+        hasResult: true,
+        result: String(value),
+      };
+    }
+  } catch (error) {
+    return {
+      success: false,
+      message: "Error executing JavaScript: " + (error.message || "Unknown error"),
+    };
+  }
+})

--- a/libs/python/agent/cua_agent/loops/yutori_js/extract_elements.js
+++ b/libs/python/agent/cua_agent/loops/yutori_js/extract_elements.js
@@ -1,0 +1,377 @@
+(function (filterType) {
+  var MAX_DEPTH = 15;
+  var SKIPPED_TAGS = {
+    script: true,
+    style: true,
+    meta: true,
+    link: true,
+    title: true,
+    noscript: true,
+  };
+  var INTERACTIVE_TAGS = {
+    a: true,
+    button: true,
+    input: true,
+    select: true,
+    textarea: true,
+    details: true,
+    summary: true,
+  };
+  var SEMANTIC_TAGS = {
+    h1: true,
+    h2: true,
+    h3: true,
+    h4: true,
+    h5: true,
+    h6: true,
+    nav: true,
+    main: true,
+    header: true,
+    footer: true,
+    section: true,
+    article: true,
+    aside: true,
+  };
+  var FUNCTIONAL_KEYWORDS = ["search", "dropdown", "menu", "modal", "dialog", "popup", "toolbar", "sidebar", "content", "text"];
+
+  // Keep a stable ref for each live element so later actions can target the same node.
+  function ensureStore() {
+    if (!window.__yutoriElementRefs) {
+      window.__yutoriElementRefs = {};
+    }
+    if (!window.__yutoriElementIds) {
+      window.__yutoriElementIds = new WeakMap();
+    }
+    if (!window.__yutoriRefCounter) {
+      window.__yutoriRefCounter = 0;
+    }
+  }
+
+  function compactWhitespace(value) {
+    return value ? value.replace(/\s+/g, " ").trim() : "";
+  }
+
+  function readDirectText(element) {
+    var chunks = [];
+    for (var i = 0; i < element.childNodes.length; i++) {
+      var node = element.childNodes[i];
+      if (node.nodeType === Node.TEXT_NODE && node.textContent) {
+        chunks.push(node.textContent);
+      }
+    }
+    return compactWhitespace(chunks.join(" "));
+  }
+
+  function getRole(element) {
+    var explicitRole = element.getAttribute("role");
+    if (explicitRole) {
+      return explicitRole;
+    }
+
+    var tag = element.tagName.toLowerCase();
+    if (tag === "input") {
+      var type = (element.getAttribute("type") || "").toLowerCase();
+      if (type === "submit" || type === "button" || type === "file") {
+        return "button";
+      }
+      if (type === "checkbox") {
+        return "checkbox";
+      }
+      if (type === "radio") {
+        return "radio";
+      }
+      return "textbox";
+    }
+
+    var tagRoles = {
+      a: "link",
+      button: "button",
+      select: "combobox",
+      textarea: "textbox",
+      h1: "heading",
+      h2: "heading",
+      h3: "heading",
+      h4: "heading",
+      h5: "heading",
+      h6: "heading",
+      img: "image",
+      nav: "navigation",
+      main: "main",
+      header: "banner",
+      footer: "contentinfo",
+      section: "region",
+      article: "article",
+      aside: "complementary",
+      form: "form",
+      table: "table",
+      ul: "list",
+      ol: "list",
+      li: "listitem",
+      label: "label",
+    };
+
+    return tagRoles[tag] || "generic";
+  }
+
+  function getName(element) {
+    var tag = element.tagName.toLowerCase();
+    var candidate = "";
+
+    if (tag === "select") {
+      var selectedOption = element.options[element.selectedIndex] || element.querySelector("option[selected]");
+      if (selectedOption && selectedOption.textContent) {
+        candidate = compactWhitespace(selectedOption.textContent);
+        if (candidate) {
+          return candidate;
+        }
+      }
+    }
+
+    var attributeNames = ["aria-label", "placeholder", "title", "alt"];
+    for (var i = 0; i < attributeNames.length; i++) {
+      candidate = compactWhitespace(element.getAttribute(attributeNames[i]) || "");
+      if (candidate) {
+        return candidate;
+      }
+    }
+
+    if (element.id) {
+      var label = document.querySelector('label[for="' + element.id.replace(/"/g, '\\"') + '"]');
+      candidate = label && label.textContent ? compactWhitespace(label.textContent) : "";
+      if (candidate) {
+        return candidate;
+      }
+    }
+
+    if (tag === "input") {
+      var type = (element.getAttribute("type") || "").toLowerCase();
+      var rawValue = compactWhitespace(element.getAttribute("value") || "");
+      if (type === "submit" && rawValue) {
+        return rawValue;
+      }
+
+      candidate = compactWhitespace(element.value || "");
+      if (candidate && candidate.length < 50) {
+        return candidate;
+      }
+    }
+
+    if (tag === "button" || tag === "a" || tag === "summary") {
+      candidate = readDirectText(element);
+      if (candidate) {
+        return candidate;
+      }
+    }
+
+    if (/^h[1-6]$/.test(tag)) {
+      candidate = compactWhitespace(element.textContent || "");
+      if (candidate) {
+        return candidate.slice(0, 100);
+      }
+    }
+
+    if (tag === "img") {
+      var src = element.getAttribute("src") || "";
+      if (src) {
+        var filename = src.split("/").pop() || "";
+        filename = filename.split("?")[0];
+        return "Image: " + filename;
+      }
+    }
+
+    candidate = readDirectText(element);
+    if (candidate && candidate.length >= 3) {
+      return candidate.length > 50 ? candidate.slice(0, 50) + "..." : candidate;
+    }
+
+    return "";
+  }
+
+  function isVisible(element) {
+    var style = window.getComputedStyle(element);
+    return (
+      style.display !== "none" &&
+      style.visibility !== "hidden" &&
+      style.opacity !== "0" &&
+      element.offsetWidth > 0 &&
+      element.offsetHeight > 0
+    );
+  }
+
+  function isInViewport(element) {
+    var rect = element.getBoundingClientRect();
+    return rect.top < window.innerHeight && rect.bottom > 0 && rect.left < window.innerWidth && rect.right > 0;
+  }
+
+  function isInteractive(element) {
+    var role = element.getAttribute("role");
+    var tag = element.tagName.toLowerCase();
+    return (
+      INTERACTIVE_TAGS[tag] === true ||
+      element.getAttribute("onclick") !== null ||
+      element.getAttribute("tabindex") !== null ||
+      role === "button" ||
+      role === "link" ||
+      element.getAttribute("contenteditable") === "true"
+    );
+  }
+
+  function isSemantic(element) {
+    return SEMANTIC_TAGS[element.tagName.toLowerCase()] === true || element.getAttribute("role") !== null;
+  }
+
+  function isContainer(element) {
+    var role = element.getAttribute("role") || "";
+    var tag = element.tagName.toLowerCase();
+    var id = (element.id || "").toLowerCase();
+    var className = compactWhitespace(typeof element.className === "string" ? element.className : "").toLowerCase();
+
+    if (
+      role === "search" ||
+      role === "form" ||
+      role === "group" ||
+      role === "toolbar" ||
+      role === "navigation" ||
+      tag === "form" ||
+      tag === "fieldset" ||
+      tag === "nav"
+    ) {
+      return true;
+    }
+
+    for (var i = 0; i < FUNCTIONAL_KEYWORDS.length; i++) {
+      var keyword = FUNCTIONAL_KEYWORDS[i];
+      if (id.indexOf(keyword) !== -1 || className.indexOf(keyword) !== -1) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  function shouldInclude(element) {
+    var tag = element.tagName.toLowerCase();
+    if (SKIPPED_TAGS[tag] || element.getAttribute("aria-hidden") === "true") {
+      return false;
+    }
+    if (!isVisible(element)) {
+      return false;
+    }
+    if (filterType !== "all" && !isInViewport(element)) {
+      return false;
+    }
+    if (filterType === "interactive") {
+      return isInteractive(element);
+    }
+    if (isInteractive(element) || isSemantic(element)) {
+      return true;
+    }
+
+    var cleanName = getName(element);
+    if (cleanName) {
+      return true;
+    }
+
+    if (getRole(element) === "generic" && (tag === "div" || tag === "span")) {
+      return isContainer(element);
+    }
+
+    return isContainer(element);
+  }
+
+  function getOrCreateRef(element) {
+    var existingRef = window.__yutoriElementIds.get(element);
+    if (existingRef && window.__yutoriElementRefs[existingRef] && window.__yutoriElementRefs[existingRef].deref() === element) {
+      return existingRef;
+    }
+
+    var ref = "ref_" + ++window.__yutoriRefCounter;
+    window.__yutoriElementIds.set(element, ref);
+    window.__yutoriElementRefs[ref] = new WeakRef(element);
+    return ref;
+  }
+
+  function quoteAttribute(value) {
+    return String(value)
+      .replace(/\\/g, "\\\\")
+      .replace(/\r/g, " ")
+      .replace(/\n/g, " ")
+      .replace(/\t/g, " ")
+      .replace(/"/g, '\\"');
+  }
+
+  function formatLine(element, depth) {
+    var role = getRole(element);
+    var name = getName(element);
+    var line = new Array(depth + 1).join("  ") + "- " + role;
+
+    if (name) {
+      line += ' "' + quoteAttribute(compactWhitespace(name).slice(0, 100)) + '"';
+    }
+
+    line += " [ref=" + getOrCreateRef(element) + "]";
+
+    if (element.id) {
+      line += ' id="' + quoteAttribute(element.id) + '"';
+    }
+    if (element.getAttribute("href")) {
+      line += ' href="' + quoteAttribute(element.getAttribute("href")) + '"';
+    }
+    if (element.getAttribute("type")) {
+      line += ' type="' + quoteAttribute(element.getAttribute("type")) + '"';
+    }
+    if (element.getAttribute("placeholder")) {
+      line += ' placeholder="' + quoteAttribute(element.getAttribute("placeholder")) + '"';
+    }
+
+    return line;
+  }
+
+  function walk(element, depth, output) {
+    if (!element || !element.tagName || depth > MAX_DEPTH) {
+      return;
+    }
+
+    var includeHere = depth === 0 || shouldInclude(element);
+    if (includeHere) {
+      output.push(formatLine(element, depth));
+    }
+
+    if (!element.children || depth >= MAX_DEPTH) {
+      return;
+    }
+
+    // Preserve the current indentation level when skipping a purely structural node.
+    var childDepth = includeHere ? depth + 1 : depth;
+    for (var i = 0; i < element.children.length; i++) {
+      walk(element.children[i], childDepth, output);
+    }
+  }
+
+  function pruneDeadRefs() {
+    // WeakRefs may outlive detached nodes in the map until we sweep them explicitly.
+    for (var ref in window.__yutoriElementRefs) {
+      if (!window.__yutoriElementRefs[ref].deref()) {
+        delete window.__yutoriElementRefs[ref];
+      }
+    }
+  }
+
+  ensureStore();
+
+  var lines = [];
+  if (document.body) {
+    walk(document.body, 0, lines);
+  }
+  pruneDeadRefs();
+
+  var filteredLines = lines.filter(function (line) {
+    return !/^\s*- generic \[ref=ref_\d+\]$/.test(line);
+  });
+
+  return {
+    success: true,
+    pageContent: filteredLines.join("\n"),
+    totalLines: filteredLines.length,
+  };
+})

--- a/libs/python/agent/cua_agent/loops/yutori_js/find.js
+++ b/libs/python/agent/cua_agent/loops/yutori_js/find.js
@@ -1,0 +1,193 @@
+(function (rawNeedle) {
+  var MAX_MATCHES = 20;
+  var SKIPPED_TAGS = {
+    html: true,
+    body: true,
+    head: true,
+    script: true,
+    style: true,
+    meta: true,
+    link: true,
+    title: true,
+    noscript: true,
+  };
+
+  function failure(message) {
+    return {
+      success: false,
+      message: message,
+      totalMatches: 0,
+      matches: [],
+      pageContent: "",
+    };
+  }
+
+  function ensureStore() {
+    if (!window.__yutoriElementRefs) {
+      window.__yutoriElementRefs = {};
+    }
+    if (!window.__yutoriElementIds) {
+      window.__yutoriElementIds = new WeakMap();
+    }
+    if (!window.__yutoriRefCounter) {
+      window.__yutoriRefCounter = 0;
+    }
+  }
+
+  function compactWhitespace(value) {
+    return value ? value.replace(/\s+/g, " ").trim() : "";
+  }
+
+  function isVisible(element) {
+    var style = window.getComputedStyle(element);
+    return (
+      style.display !== "none" &&
+      style.visibility !== "hidden" &&
+      style.opacity !== "0" &&
+      element.offsetWidth > 0 &&
+      element.offsetHeight > 0
+    );
+  }
+
+  function getOrCreateRef(element) {
+    var existingRef = window.__yutoriElementIds.get(element);
+    if (existingRef && window.__yutoriElementRefs[existingRef] && window.__yutoriElementRefs[existingRef].deref() === element) {
+      return existingRef;
+    }
+
+    var ref = "ref_" + ++window.__yutoriRefCounter;
+    window.__yutoriElementIds.set(element, ref);
+    window.__yutoriElementRefs[ref] = new WeakRef(element);
+    return ref;
+  }
+
+  function getRole(element) {
+    var explicitRole = element.getAttribute("role");
+    if (explicitRole) {
+      return explicitRole;
+    }
+
+    var tag = element.tagName.toLowerCase();
+    var tagRoles = {
+      a: "link",
+      button: "button",
+      input: "textbox",
+      select: "combobox",
+      textarea: "textbox",
+      h1: "heading",
+      h2: "heading",
+      h3: "heading",
+      h4: "heading",
+      h5: "heading",
+      h6: "heading",
+    };
+
+    return tagRoles[tag] || tag;
+  }
+
+  function getName(element) {
+    var candidates = [
+      element.getAttribute("aria-label"),
+      element.getAttribute("placeholder"),
+      element.getAttribute("title"),
+      element.value,
+      element.textContent,
+    ];
+    for (var i = 0; i < candidates.length; i += 1) {
+      var candidate = compactWhitespace(candidates[i] || "");
+      if (candidate) {
+        return candidate;
+      }
+    }
+    return "";
+  }
+
+  function describe(element) {
+    var role = getRole(element);
+    var name = getName(element);
+    var ref = getOrCreateRef(element);
+    return "- " + role + (name ? ' "' + name.slice(0, 120) + '"' : "") + " [ref=" + ref + "]";
+  }
+
+  function shouldInspect(element) {
+    var tag = element.tagName.toLowerCase();
+    return !SKIPPED_TAGS[tag] && isVisible(element);
+  }
+
+  function scrollIntoView(element) {
+    var htmlElement = document.documentElement;
+    var bodyElement = document.body;
+    var previousHtmlScrollBehavior = htmlElement.style.scrollBehavior;
+    var previousBodyScrollBehavior = bodyElement ? bodyElement.style.scrollBehavior : "";
+    try {
+      htmlElement.style.scrollBehavior = "auto";
+      if (bodyElement) bodyElement.style.scrollBehavior = "auto";
+      element.scrollIntoView({ behavior: "instant", block: "center", inline: "center" });
+      element.offsetHeight;
+    } finally {
+      htmlElement.style.scrollBehavior = previousHtmlScrollBehavior;
+      if (bodyElement) bodyElement.style.scrollBehavior = previousBodyScrollBehavior;
+    }
+  }
+
+  var needle = compactWhitespace(String(rawNeedle || "")).toLowerCase();
+  if (!needle) {
+    return failure("find requires non-empty text");
+  }
+
+  ensureStore();
+
+  var matches = [];
+  var firstMatch = null;
+  var nodes = document.querySelectorAll("*");
+  for (var i = 0; i < nodes.length; i += 1) {
+    var element = nodes[i];
+    if (!shouldInspect(element)) {
+      continue;
+    }
+
+    var haystack = compactWhitespace(
+      [
+        element.textContent || "",
+        element.getAttribute("aria-label") || "",
+        element.getAttribute("placeholder") || "",
+        element.getAttribute("title") || "",
+        element.value || "",
+      ].join(" "),
+    ).toLowerCase();
+
+    if (!haystack.includes(needle)) {
+      continue;
+    }
+
+    if (!firstMatch) {
+      firstMatch = element;
+    }
+    matches.push(describe(element));
+    if (matches.length >= MAX_MATCHES) {
+      break;
+    }
+  }
+
+  if (!matches.length) {
+    return {
+      success: true,
+      totalMatches: 0,
+      matches: [],
+      message: 'No visible matches found for "' + rawNeedle + '".',
+      pageContent: "",
+    };
+  }
+
+  if (firstMatch) {
+    scrollIntoView(firstMatch);
+  }
+
+  return {
+    success: true,
+    totalMatches: matches.length,
+    matches: matches,
+    message: 'Found ' + matches.length + ' visible match' + (matches.length === 1 ? "" : "es") + ' for "' + rawNeedle + '".',
+    pageContent: matches.join("\n"),
+  };
+})

--- a/libs/python/agent/cua_agent/loops/yutori_js/get_element_by_ref.js
+++ b/libs/python/agent/cua_agent/loops/yutori_js/get_element_by_ref.js
@@ -1,0 +1,86 @@
+(function (elementRef) {
+  function failure(message) {
+    return {
+      success: false,
+      action: "get_element_by_ref",
+      message: message,
+    };
+  }
+
+  function getTrackedElement(ref) {
+    if (!window.__yutoriElementRefs || !window.__yutoriElementRefs[ref]) {
+      return null;
+    }
+
+    var weakRef = window.__yutoriElementRefs[ref];
+    var element = weakRef.deref();
+    if (!element || !document.contains(element)) {
+      delete window.__yutoriElementRefs[ref];
+      return null;
+    }
+
+    return element;
+  }
+
+  function isViewportVisible(rect) {
+    var viewportWidth = window.innerWidth || document.documentElement.clientWidth;
+    var viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+    return (
+      rect.top < viewportHeight &&
+      rect.bottom > 0 &&
+      rect.left < viewportWidth &&
+      rect.right > 0 &&
+      rect.width > 0 &&
+      rect.height > 0
+    );
+  }
+
+  function isPointInViewport(x, y) {
+    var viewportWidth = window.innerWidth || document.documentElement.clientWidth;
+    var viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+    return x >= 0 && x <= viewportWidth && y >= 0 && y <= viewportHeight;
+  }
+
+  try {
+    var element = getTrackedElement(elementRef);
+    if (!element) {
+      return failure('No element found with reference: "' + elementRef + '". The element may have been removed from the page.');
+    }
+
+    var beforeScrollRect = element.getBoundingClientRect();
+    var wasVisibleBeforeScroll = isViewportVisible(beforeScrollRect);
+    var centerX = beforeScrollRect.left + beforeScrollRect.width / 2;
+    var centerY = beforeScrollRect.top + beforeScrollRect.height / 2;
+
+    var centerInViewport = isPointInViewport(centerX, centerY);
+
+    // Downstream actions click the element center, so partial visibility is not enough.
+    if (!wasVisibleBeforeScroll || !centerInViewport) {
+      var htmlEl = document.documentElement;
+      var bodyEl = document.body;
+      var prevHtml = htmlEl.style.scrollBehavior;
+      var prevBody = bodyEl ? bodyEl.style.scrollBehavior : "";
+      try {
+        // Some sites force smooth scrolling globally; temporarily disable it so coordinates settle immediately.
+        htmlEl.style.scrollBehavior = "auto";
+        if (bodyEl) bodyEl.style.scrollBehavior = "auto";
+
+        element.scrollIntoView({ behavior: "instant", block: "center", inline: "center" });
+
+        // Force layout so getBoundingClientRect reflects the post-scroll position.
+        element.offsetHeight;
+      } finally {
+        htmlEl.style.scrollBehavior = prevHtml;
+        if (bodyEl) bodyEl.style.scrollBehavior = prevBody;
+      }
+    }
+
+    var rect = element.getBoundingClientRect();
+    return {
+      success: true,
+      coordinates: [rect.left + rect.width / 2, rect.top + rect.height / 2],
+    };
+  } catch (error) {
+    return failure("Error finding element by reference: " + (error.message || "Unknown error"));
+  }
+})

--- a/libs/python/agent/cua_agent/loops/yutori_js/set_element_value.js
+++ b/libs/python/agent/cua_agent/loops/yutori_js/set_element_value.js
@@ -1,0 +1,227 @@
+(function (elementRef, inputValue) {
+  function response(success, payload) {
+    var result = {
+      success: success,
+      action: "set_element_value",
+    };
+    for (var key in payload) {
+      result[key] = payload[key];
+    }
+    return result;
+  }
+
+  function getTrackedElement(ref) {
+    if (!window.__yutoriElementRefs || !window.__yutoriElementRefs[ref]) {
+      return null;
+    }
+
+    var weakRef = window.__yutoriElementRefs[ref];
+    var element = weakRef.deref();
+    if (!element || !document.contains(element)) {
+      delete window.__yutoriElementRefs[ref];
+      return null;
+    }
+
+    return element;
+  }
+
+  function isInViewport(el) {
+    var rect = el.getBoundingClientRect();
+    return rect.top < window.innerHeight && rect.bottom > 0 && rect.left < window.innerWidth && rect.right > 0;
+  }
+
+  function ensureVisible(el) {
+    if (!isInViewport(el)) {
+      var htmlEl = document.documentElement;
+      var bodyEl = document.body;
+      var prevHtml = htmlEl.style.scrollBehavior;
+      var prevBody = bodyEl ? bodyEl.style.scrollBehavior : "";
+      try {
+        // Neutralize page-level smooth scrolling so form interactions happen against stable layout.
+        htmlEl.style.scrollBehavior = "auto";
+        if (bodyEl) bodyEl.style.scrollBehavior = "auto";
+
+        el.scrollIntoView({ behavior: "instant", block: "center", inline: "center" });
+        el.offsetHeight;
+      } finally {
+        htmlEl.style.scrollBehavior = prevHtml;
+        if (bodyEl) bodyEl.style.scrollBehavior = prevBody;
+      }
+    }
+  }
+
+  // Use the native setter to bypass framework interception (React, Vue, etc.)
+  // then dispatch events that frameworks actually listen to.
+  function setNativeValue(el, value) {
+    var prototype = null;
+    if (el instanceof HTMLTextAreaElement) {
+      prototype = HTMLTextAreaElement.prototype;
+    } else if (el instanceof HTMLInputElement) {
+      prototype = HTMLInputElement.prototype;
+    }
+
+    var descriptor = prototype ? Object.getOwnPropertyDescriptor(prototype, "value") : null;
+
+    if (descriptor && descriptor.set) {
+      descriptor.set.call(el, value);
+    } else {
+      el.value = value;
+    }
+  }
+
+  function emitInputEvents(el) {
+    // Only focus if not already focused — avoids unnecessary blur on other fields
+    if (document.activeElement !== el) {
+      el.focus();
+    }
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+  }
+
+  function selectOption(element, rawValue) {
+    var targetValue = String(rawValue);
+
+    for (var i = 0; i < element.options.length; i++) {
+      var option = element.options[i];
+      if (option.value === targetValue || option.text === targetValue) {
+        element.selectedIndex = i;
+        emitInputEvents(element);
+        return response(true, {
+          message: 'Selected option "' + targetValue + '" in dropdown',
+        });
+      }
+    }
+
+    var optionDescriptions = [];
+    for (var j = 0; j < element.options.length; j++) {
+      optionDescriptions.push('"' + element.options[j].text + '" (value: "' + element.options[j].value + '")');
+    }
+
+    return response(false, {
+      message: 'Option "' + targetValue + '" not found. Available options: ' + optionDescriptions.join(", "),
+    });
+  }
+
+  function updateCheckbox(element, rawValue) {
+    if (typeof rawValue !== "boolean" && rawValue !== "true" && rawValue !== "false") {
+      return response(false, {
+        message: "Checkbox requires a boolean value (true/false)",
+      });
+    }
+
+    var desiredState = rawValue === true || rawValue === "true";
+    // Prefer the native click path for toggles so app frameworks observe the change.
+    if (element.checked !== desiredState) {
+      element.click();
+    }
+
+    if (element.checked !== desiredState) {
+      return response(false, {
+        message: "Checkbox state did not change as requested",
+      });
+    }
+
+    return response(true, {
+      message: "Checkbox " + (element.checked ? "checked" : "unchecked"),
+    });
+  }
+
+  function updateRadio(element) {
+    // Radios are best driven through their native interaction path.
+    if (!element.checked) {
+      element.click();
+    }
+
+    if (!element.checked) {
+      return response(false, {
+        message: "Radio button could not be selected",
+      });
+    }
+
+    return response(true, {
+      message: "Radio button selected" + (element.name ? ' in group "' + element.name + '"' : ""),
+    });
+  }
+
+  function updateNumeric(element, kind, rawValue) {
+    var asNumber = Number(rawValue);
+    if (isNaN(asNumber) && !(kind === "number" && rawValue === "")) {
+      return response(false, {
+        message: (kind === "range" ? "Range" : "Number") + " input requires a numeric value",
+      });
+    }
+
+    setNativeValue(element, kind === "range" ? String(asNumber) : String(rawValue));
+    emitInputEvents(element);
+
+    return response(true, {
+      message:
+        kind === "range"
+          ? "Set range to " + element.value + " (min: " + element.min + ", max: " + element.max + ")"
+          : "Set number input to " + element.value,
+    });
+  }
+
+  function updateTextLike(element, elementType, rawValue) {
+    setNativeValue(element, String(rawValue));
+
+    if (typeof element.setSelectionRange === "function") {
+      try {
+        element.setSelectionRange(element.value.length, element.value.length);
+      } catch (e) {
+        // Some input types (email, number) don't support setSelectionRange
+      }
+    }
+
+    emitInputEvents(element);
+
+    return response(true, {
+      message: "Set " + elementType + ' value to "' + element.value + '"',
+    });
+  }
+
+  try {
+    var element = getTrackedElement(elementRef);
+    if (!element) {
+      return response(false, {
+        message: 'No element found with reference: "' + elementRef + '". The element may have been removed from the page.',
+      });
+    }
+
+    ensureVisible(element);
+
+    if (element instanceof HTMLSelectElement) {
+      return selectOption(element, inputValue);
+    }
+
+    if (element instanceof HTMLInputElement) {
+      var type = (element.type || "text").toLowerCase();
+
+      if (type === "checkbox") {
+        return updateCheckbox(element, inputValue);
+      }
+      if (type === "radio") {
+        return updateRadio(element);
+      }
+      if (type === "date" || type === "time" || type === "datetime-local" || type === "month" || type === "week") {
+        return updateTextLike(element, type, inputValue);
+      }
+      if (type === "range" || type === "number") {
+        return updateNumeric(element, type, inputValue);
+      }
+      return updateTextLike(element, type || "text", inputValue);
+    }
+
+    if (element instanceof HTMLTextAreaElement) {
+      return updateTextLike(element, "textarea", inputValue);
+    }
+
+    return response(false, {
+      message: 'Element type "' + element.tagName + '" is not a supported form input',
+    });
+  } catch (error) {
+    return response(false, {
+      message: "Error setting element value: " + (error.message || "Unknown error"),
+    });
+  }
+})

--- a/libs/python/agent/cua_agent/tools/browser_tool.py
+++ b/libs/python/agent/cua_agent/tools/browser_tool.py
@@ -15,6 +15,28 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Map lowercase modifier names (as emitted by Yutori n1.5 and pynput-style callers)
+# to the Playwright key names the computer-server's browser commands expect.
+_PLAYWRIGHT_MODIFIERS = {
+    "ctrl": "Control",
+    "control": "Control",
+    "shift": "Shift",
+    "alt": "Alt",
+    "cmd": "Meta",
+    "command": "Meta",
+    "meta": "Meta",
+    "super": "Meta",
+    "win": "Meta",
+}
+
+
+def _to_playwright_modifiers(modifier) -> list:
+    """Convert a modifier key (or list of them) to Playwright key names."""
+    if not modifier:
+        return []
+    mods = modifier if isinstance(modifier, (list, tuple)) else [modifier]
+    return [_PLAYWRIGHT_MODIFIERS.get(str(m).lower(), str(m)) for m in mods]
+
 
 @register_tool("computer_use")
 class BrowserTool(BaseComputerTool):
@@ -375,8 +397,12 @@ class BrowserTool(BaseComputerTool):
 
     async def _action_history_back(self, params: dict) -> dict:
         """Go back in browser history."""
-        # Press Alt+Left arrow key combination
         try:
+            result = await self.interface.playwright_exec("go_back", {})
+            if isinstance(result, dict) and result.get("success"):
+                return result
+            # Older computer-server versions lack the go_back command;
+            # fall back to the Alt+Left arrow key combination.
             await self.automation.hotkey("Alt", "ArrowLeft")
             return {"success": True, "message": "Navigated back in history"}
         except Exception as e:
@@ -433,26 +459,28 @@ class BrowserTool(BaseComputerTool):
         """Navigate to a URL."""
         return await self._action_visit_url({"url": url})
 
-    async def click(self, x: int = None, y: int = None, button: str = "left", **kwargs) -> dict:
+    async def click(
+        self, x: int = None, y: int = None, button: str = "left", modifier=None, **kwargs
+    ) -> dict:
         """Click at coordinates. Supports both positional (x, y) and kwargs (button, x, y).
 
         This is compatible with the normalized format from OperatorNormalizerCallback
         which transforms actions like {"type": "left_click", "coordinate": [x, y]}
         into {"type": "click", "button": "left", "x": x, "y": y}.
+
+        modifier optionally holds a modifier key (e.g. "ctrl") during the click.
         """
         if x is None or y is None:
             return {"success": False, "error": "x and y coordinates are required"}
+        params = {"x": x, "y": y}
         if button == "right":
-            return await self.interface.playwright_exec(
-                "click", {"x": x, "y": y, "button": "right"}
-            )
+            params["button"] = "right"
         elif button == "middle" or button == "wheel":
-            return await self.interface.playwright_exec(
-                "click", {"x": x, "y": y, "button": "middle"}
-            )
-        else:
-            # Default to left click
-            return await self._action_left_click({"coordinate": [x, y]})
+            params["button"] = "middle"
+        modifiers = _to_playwright_modifiers(modifier)
+        if modifiers:
+            params["modifiers"] = modifiers
+        return await self.interface.playwright_exec("click", params)
 
     async def type(self, text: str) -> dict:
         """Type text into the focused element."""
@@ -538,18 +566,30 @@ class BrowserTool(BaseComputerTool):
         result = await self.interface.playwright_exec("click", {"x": x, "y": y, "button": "middle"})
         return result
 
-    async def double_click(self, coordinate=None, x: int = None, y: int = None, **kwargs) -> dict:
+    async def double_click(
+        self, coordinate=None, x: int = None, y: int = None, modifier=None, **kwargs
+    ) -> dict:
         """Double click at coordinates. Supports coordinate array or x/y kwargs."""
         # Accept either coordinate array or x/y kwargs
         if coordinate and len(coordinate) >= 2:
             x, y = coordinate[0], coordinate[1]
         if x is None or y is None:
             return {"success": False, "error": "coordinate parameter [x, y] or x/y kwargs required"}
-        result = await self.interface.playwright_exec("dblclick", {"x": x, "y": y})
+        params = {"x": x, "y": y, "click_count": 2}
+        modifiers = _to_playwright_modifiers(modifier)
+        if modifiers:
+            params["modifiers"] = modifiers
+        result = await self.interface.playwright_exec("click", params)
         return result
 
     async def triple_click(
-        self, coordinate=None, x: int = None, y: int = None, button: str = None, **kwargs
+        self,
+        coordinate=None,
+        x: int = None,
+        y: int = None,
+        button: str = None,
+        modifier=None,
+        **kwargs,
     ) -> dict:
         """Triple click at coordinates. Supports coordinate array or x/y kwargs."""
         # Accept either coordinate array or x/y kwargs
@@ -557,8 +597,12 @@ class BrowserTool(BaseComputerTool):
             x, y = coordinate[0], coordinate[1]
         if x is None or y is None:
             return {"success": False, "error": "coordinate parameter [x, y] or x/y kwargs required"}
-        # Triple click is approximated as double click
-        return await self.double_click(x=x, y=y)
+        params = {"x": x, "y": y, "click_count": 3}
+        modifiers = _to_playwright_modifiers(modifier)
+        if modifiers:
+            params["modifiers"] = modifiers
+        result = await self.interface.playwright_exec("click", params)
+        return result
 
     async def mouse_move(self, coordinate=None, x: int = None, y: int = None, **kwargs) -> dict:
         """Move mouse to coordinates. Supports coordinate array or x/y kwargs."""
@@ -618,6 +662,86 @@ class BrowserTool(BaseComputerTool):
     async def history_back(self, **kwargs) -> dict:
         """Go back in browser history. FARA-compatible."""
         return await self._action_history_back({})
+
+    async def history_forward(self, **kwargs) -> dict:
+        """Go forward in browser history."""
+        try:
+            result = await self.interface.playwright_exec("go_forward", {})
+            if isinstance(result, dict) and result.get("success"):
+                return result
+            # Older computer-server versions lack the go_forward command;
+            # fall back to the Alt+Right arrow key combination.
+            await self.automation.hotkey("alt", "right")
+            return {"success": True, "message": "Navigated forward in history"}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    async def refresh(self, **kwargs) -> dict:
+        """Reload the current page."""
+        try:
+            result = await self.interface.playwright_exec("refresh", {})
+            if isinstance(result, dict) and result.get("success"):
+                return result
+            # Older computer-server versions lack the refresh command;
+            # fall back to pressing F5.
+            await self.automation.press_key("f5")
+            return {"success": True, "message": "Refreshed the page"}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    async def mouse_down(
+        self, coordinate=None, x: int = None, y: int = None, button: str = "left", **kwargs
+    ) -> dict:
+        """Press and hold a mouse button, optionally moving to coordinates first."""
+        if coordinate and len(coordinate) >= 2:
+            x, y = coordinate[0], coordinate[1]
+        try:
+            if x is not None and y is not None:
+                await self.automation.move_cursor(x, y)
+            await self.automation.mouse_down(x, y, button=button)
+            return {"success": True, "message": f"Mouse down ({button}) at ({x}, {y})"}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    async def mouse_up(
+        self, coordinate=None, x: int = None, y: int = None, button: str = "left", **kwargs
+    ) -> dict:
+        """Release a mouse button, optionally moving to coordinates first."""
+        if coordinate and len(coordinate) >= 2:
+            x, y = coordinate[0], coordinate[1]
+        try:
+            if x is not None and y is not None:
+                await self.automation.move_cursor(x, y)
+            await self.automation.mouse_up(x, y, button=button)
+            return {"success": True, "message": f"Mouse up ({button}) at ({x}, {y})"}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    async def hold_key(self, key: str = None, duration: float = None, **kwargs) -> dict:
+        """Hold a key down for a duration (in seconds), then release it."""
+        if not key:
+            return {"success": False, "error": "key parameter is required"}
+        duration = 1.0 if duration is None else float(duration)
+        try:
+            await self.automation.key_down(key)
+            try:
+                await asyncio.sleep(duration)
+            finally:
+                await self.automation.key_up(key)
+            return {"success": True, "message": f"Held key {key} for {duration} seconds"}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    async def evaluate_js(self, expression: str) -> dict:
+        """Evaluate a JavaScript expression in the current page.
+
+        Requires a computer-server with the 'evaluate' browser command; older
+        versions return {"success": False, "error": "Unknown command: evaluate"}.
+        """
+        try:
+            return await self.interface.playwright_exec("evaluate", {"expression": expression})
+        except Exception as e:
+            return {"success": False, "error": str(e)}
 
     async def terminate(self, status=None, **kwargs) -> dict:
         """Terminate and report status. FARA-compatible."""

--- a/libs/python/agent/example.py
+++ b/libs/python/agent/example.py
@@ -111,6 +111,9 @@ async def main():
             # == Omniparser + Any LLM ==
             # model="omniparser+..."
             # model="omniparser+anthropic/claude-opus-4-20250514",
+            # == Yutori Navigator (browser-only; requires YUTORI_API_KEY) ==
+            # model="yutori/n1.5-latest",
+            # model="yutori/n1.5-20260428",
             tools=[computer],
             only_n_most_recent_images=3,
             verbosity=logging.INFO,

--- a/libs/python/agent/tests/test_yutori.py
+++ b/libs/python/agent/tests/test_yutori.py
@@ -1,0 +1,443 @@
+"""
+Tests for the Yutori Navigator (n1.5) integration.
+
+Covers:
+1. Model routing — Navigator model names resolve to the Yutori loop
+2. YutoriAdapter — model name normalization and request param handling
+3. Action conversion — the n1.5 action space
+4. Normalizer compatibility — converted actions survive OperatorNormalizerCallback
+   and match BrowserTool method signatures
+5. predict_step — screenshot injection, extra_body params, inline DOM tools,
+   ref resolution, key sequences, terminal messages
+"""
+
+import base64
+import io
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from litellm.types.utils import ModelResponse
+from PIL import Image
+
+from cua_agent.adapters.yutori_adapter import YutoriAdapter
+from cua_agent.agent import assert_callable_with
+from cua_agent.callbacks.operator_validator import OperatorNormalizerCallback
+from cua_agent.decorators import find_agent_config
+from cua_agent.loops.yutori import (
+    YutoriNavigatorConfig,
+    _convert_key_expression,
+    _convert_navigator_action,
+)
+from cua_agent.responses import convert_completion_messages_to_responses_items
+from cua_agent.tools.browser_tool import BrowserTool
+
+SCREEN = (1280, 800)
+
+
+class TestModelRouting:
+    """The Yutori loop must match all published Navigator model names."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "yutori/n1.5",
+            "yutori/n1.5-latest",
+            "yutori/n1.5-20260428",
+            "n1.5-latest",
+        ],
+    )
+    def test_navigator_models_route_to_yutori_loop(self, model):
+        config = find_agent_config(model)
+        assert config is not None
+        assert config.agent_class is YutoriNavigatorConfig
+
+    # yutori/n1 is deprecated and no longer matched; the API rejects it with
+    # a clear model_deprecated error if a request is attempted.
+    @pytest.mark.parametrize("model", ["claude-sonnet-4-5", "gpt-5.4", "qwen3vl", "yutori/n1"])
+    def test_other_models_do_not_route_to_yutori_loop(self, model):
+        config = find_agent_config(model)
+        assert config is None or config.agent_class is not YutoriNavigatorConfig
+
+
+class TestYutoriAdapter:
+    def test_normalize_model_pins_bare_names_to_latest(self):
+        adapter = YutoriAdapter(api_key="test")
+        assert adapter._normalize_model("yutori/n1.5") == "n1.5-latest"
+        assert adapter._normalize_model("n1.5") == "n1.5-latest"
+        # Versioned names pass through unchanged
+        assert adapter._normalize_model("yutori/n1.5-latest") == "n1.5-latest"
+        assert adapter._normalize_model("n1.5-20260428") == "n1.5-20260428"
+
+    def test_build_params_forwards_extra_body(self):
+        adapter = YutoriAdapter(api_key="test")
+        params = adapter._build_params(
+            {
+                "model": "yutori/n1.5",
+                "messages": [],
+                "extra_body": {"tool_set": "browser_tools_core-20260403"},
+            }
+        )
+        assert params["model"] == "openai/n1.5-latest"
+        assert params["extra_body"] == {"tool_set": "browser_tools_core-20260403"}
+        assert params["extra_headers"]["Authorization"] == "Bearer test"
+
+    def test_build_params_translates_max_tokens(self):
+        # The Yutori API rejects max_tokens and requires max_completion_tokens
+        adapter = YutoriAdapter(api_key="test")
+        params = adapter._build_params({"model": "yutori/n1.5", "messages": [], "max_tokens": 512})
+        assert "max_tokens" not in params
+        assert params["max_completion_tokens"] == 512
+
+    def test_yutori_provider_registered_by_computer_agent(self):
+        import litellm
+
+        from cua_agent.agent import ComputerAgent
+
+        ComputerAgent(model="yutori/n1.5-latest", tools=[], telemetry_enabled=False)
+        providers = {entry["provider"] for entry in litellm.custom_provider_map}
+        assert "yutori" in providers
+
+
+class TestActionConversion:
+    """n1.5 action space conversion to internal computer_call actions."""
+
+    def test_clicks_with_modifier(self):
+        actions = _convert_navigator_action(
+            "left_click", {"coordinates": [500, 500], "modifier": "ctrl"}, *SCREEN
+        )
+        assert actions == [
+            {"action": "click", "button": "left", "x": 640, "y": 400, "modifier": "ctrl"}
+        ]
+
+    def test_middle_click(self):
+        actions = _convert_navigator_action("middle_click", {"coordinates": [500, 500]}, *SCREEN)
+        assert actions == [{"action": "click", "button": "middle", "x": 640, "y": 400}]
+
+    def test_mouse_move(self):
+        actions = _convert_navigator_action("mouse_move", {"coordinates": [100, 100]}, *SCREEN)
+        assert actions == [{"action": "move", "x": 128, "y": 80}]
+
+    def test_mouse_down_up(self):
+        assert _convert_navigator_action("mouse_down", {"coordinates": [10, 10]}, *SCREEN) == [
+            {"action": "mouse_down", "x": 13, "y": 8}
+        ]
+        assert _convert_navigator_action("mouse_up", {}, *SCREEN) == [{"action": "mouse_up"}]
+
+    def test_drag(self):
+        actions = _convert_navigator_action(
+            "drag", {"start_coordinates": [100, 100], "coordinates": [200, 200]}, *SCREEN
+        )
+        assert actions == [
+            {
+                "action": "left_click_drag",
+                "start_coordinate": [128, 80],
+                "end_coordinate": [256, 160],
+            }
+        ]
+
+    def test_key_press_lowercase_key_space(self):
+        actions = _convert_navigator_action("key_press", {"key": "ctrl+shift+t"}, *SCREEN)
+        assert actions == [{"action": "keypress", "keys": ["ctrl", "shift", "t"]}]
+
+    def test_key_press_sequence_expands_to_multiple_actions(self):
+        actions = _convert_navigator_action("key_press", {"key": "down down enter"}, *SCREEN)
+        assert actions == [
+            {"action": "keypress", "keys": ["down"]},
+            {"action": "keypress", "keys": ["down"]},
+            {"action": "keypress", "keys": ["enter"]},
+        ]
+
+    def test_key_aliases(self):
+        assert _convert_key_expression("meta+c escape pageup pagedown") == [
+            ["cmd", "c"],
+            ["esc"],
+            ["page_up"],
+            ["page_down"],
+        ]
+
+    def test_hold_key(self):
+        actions = _convert_navigator_action("hold_key", {"key": "shift", "duration": 2}, *SCREEN)
+        assert actions == [{"action": "hold_key", "key": "shift", "duration": 2.0}]
+
+    def test_wait_with_duration(self):
+        assert _convert_navigator_action("wait", {"duration": 5}, *SCREEN) == [
+            {"action": "wait", "time": 5.0}
+        ]
+        assert _convert_navigator_action("wait", {}, *SCREEN) == [{"action": "wait"}]
+
+    def test_navigation_actions(self):
+        assert _convert_navigator_action("go_back", {}, *SCREEN) == [{"action": "history_back"}]
+        assert _convert_navigator_action("go_forward", {}, *SCREEN) == [
+            {"action": "history_forward"}
+        ]
+        assert _convert_navigator_action("refresh", {}, *SCREEN) == [{"action": "refresh"}]
+        assert _convert_navigator_action("goto_url", {"url": "https://x.com"}, *SCREEN) == [
+            {"action": "visit_url", "url": "https://x.com"}
+        ]
+
+    def test_ref_pixels_take_precedence(self):
+        actions = _convert_navigator_action(
+            "left_click", {"ref": "e7", "coordinates": [500, 500]}, *SCREEN, ref_pixels=(321, 123)
+        )
+        assert actions == [{"action": "click", "button": "left", "x": 321, "y": 123}]
+
+    def test_custom_tool_returns_none(self):
+        assert _convert_navigator_action("my_custom_tool", {"a": 1}, *SCREEN) is None
+
+
+class TestNormalizerCompatibility:
+    """Every converted action must survive the operator normalizer and match a
+    BrowserTool method signature — this is exactly what the agent validates at
+    execution time."""
+
+    CASES = [
+        ("left_click", {"coordinates": [500, 500], "modifier": "ctrl"}),
+        ("right_click", {"coordinates": [500, 500]}),
+        ("middle_click", {"coordinates": [500, 500]}),
+        ("double_click", {"coordinates": [1, 2], "modifier": "shift"}),
+        ("triple_click", {"coordinates": [1, 2]}),
+        ("mouse_move", {"coordinates": [100, 100]}),
+        ("mouse_down", {"coordinates": [10, 10]}),
+        ("mouse_up", {}),
+        ("drag", {"start_coordinates": [100, 100], "coordinates": [200, 200]}),
+        ("scroll", {"coordinates": [500, 500], "direction": "down", "amount": 3}),
+        ("type", {"text": "hello"}),
+        ("key_press", {"key": "ctrl+a"}),
+        ("hold_key", {"key": "shift", "duration": 1.5}),
+        ("wait", {"duration": 4}),
+        ("goto_url", {"url": "https://x.com"}),
+        ("go_back", {}),
+        ("go_forward", {}),
+        ("refresh", {}),
+    ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("fn_name,args", CASES)
+    async def test_action_executable_on_browser_tool(self, fn_name, args):
+        normalizer = OperatorNormalizerCallback()
+        tool = BrowserTool.__new__(BrowserTool)  # methods only, no interface needed
+
+        actions = _convert_navigator_action(fn_name, args, *SCREEN)
+        assert actions, f"{fn_name} produced no actions"
+        for action in actions:
+            fake_cm = {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "id": "call_x",
+                        "function": {"name": "computer", "arguments": json.dumps(action)},
+                    }
+                ],
+            }
+            items = convert_completion_messages_to_responses_items([fake_cm])
+            items = await normalizer.on_llm_end(items)
+            computer_calls = [i for i in items if i.get("type") == "computer_call"]
+            assert computer_calls, f"{fn_name}: no computer_call after normalization"
+            normalized = computer_calls[0]["action"]
+            method = getattr(tool, normalized["type"], None)
+            assert method is not None, f"BrowserTool has no method {normalized['type']}"
+            action_args = {k: v for k, v in normalized.items() if k != "type"}
+            assert_callable_with(method, **action_args)
+
+    @pytest.mark.asyncio
+    async def test_normalizer_preserves_modifier_and_wait_time(self):
+        normalizer = OperatorNormalizerCallback()
+        items = [
+            {
+                "type": "computer_call",
+                "call_id": "c1",
+                "action": {"type": "click", "button": "left", "x": 1, "y": 2, "modifier": "ctrl"},
+            },
+            {
+                "type": "computer_call",
+                "call_id": "c2",
+                "action": {"type": "wait", "time": 5.0},
+            },
+        ]
+        items = await normalizer.on_llm_end(items)
+        assert items[0]["action"]["modifier"] == "ctrl"
+        assert items[1]["action"]["time"] == 5.0
+
+
+def _tiny_png_b64():
+    img = Image.new("RGB", (64, 40), "white")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+def _make_response(tool_calls=None, content="", reasoning=None):
+    message = {"role": "assistant", "content": content}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    if reasoning:
+        message["reasoning_content"] = reasoning
+    return ModelResponse(
+        id="chatcmpl-test",
+        choices=[{"index": 0, "message": message, "finish_reason": "stop"}],
+        model="n1.5-latest",
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    )
+
+
+def _tool_call(call_id, name, arguments):
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": json.dumps(arguments)},
+    }
+
+
+@pytest.fixture
+def navigator_handler():
+    handler = AsyncMock()
+    handler.screenshot = AsyncMock(return_value=_tiny_png_b64())
+    handler.get_dimensions = AsyncMock(side_effect=Exception("BrowserTool has no get_dimensions"))
+    handler.viewport_width = 1280
+    handler.viewport_height = 800
+    handler.get_current_url = AsyncMock(return_value="https://example.com")
+    handler.evaluate_js = AsyncMock(
+        return_value={"success": True, "result": {"pageContent": "[e1] <button> Submit"}}
+    )
+    return handler
+
+
+class TestPredictStep:
+    @pytest.mark.asyncio
+    async def test_click_step_with_extra_body_and_screenshot_injection(self, navigator_handler):
+        loop = YutoriNavigatorConfig()
+        captured = {}
+
+        async def on_api_start(kwargs):
+            captured.update(kwargs)
+
+        response = _make_response(
+            tool_calls=[
+                _tool_call("call_1", "left_click", {"coordinates": [500, 500], "modifier": "ctrl"})
+            ],
+            content="Clicking the button",
+            reasoning="I should click submit",
+        )
+        with patch("litellm.acompletion", new=AsyncMock(return_value=response)):
+            result = await loop.predict_step(
+                messages=[{"role": "user", "content": "click submit"}],
+                model="yutori/n1.5-latest",
+                computer_handler=navigator_handler,
+                tool_set="browser_tools_expanded-20260403",
+                api_key="test-key",
+                _on_api_start=on_api_start,
+            )
+
+        # Yutori-specific params travel in extra_body, not as top-level params
+        assert captured["extra_body"] == {"tool_set": "browser_tools_expanded-20260403"}
+        assert "tool_set" not in captured
+
+        # A screenshot is injected when the latest message carries no image
+        last_message = captured["messages"][-1]
+        assert last_message["role"] == "user"
+        assert any(part.get("type") == "image_url" for part in last_message["content"])
+
+        computer_calls = [i for i in result["output"] if i["type"] == "computer_call"]
+        assert computer_calls[0]["action"]["type"] == "click"
+        assert computer_calls[0]["action"]["modifier"] == "ctrl"
+        assert any(i["type"] == "reasoning" for i in result["output"])
+
+    @pytest.mark.asyncio
+    async def test_dom_tool_executed_inline(self, navigator_handler):
+        loop = YutoriNavigatorConfig()
+        response = _make_response(
+            tool_calls=[_tool_call("call_2", "extract_elements", {"filter": "interactive"})]
+        )
+        with patch("litellm.acompletion", new=AsyncMock(return_value=response)):
+            result = await loop.predict_step(
+                messages=[{"role": "user", "content": "list elements"}],
+                model="yutori/n1.5-latest",
+                computer_handler=navigator_handler,
+                api_key="test-key",
+            )
+
+        navigator_handler.evaluate_js.assert_awaited_once()
+        function_calls = [i for i in result["output"] if i["type"] == "function_call"]
+        outputs = [i for i in result["output"] if i["type"] == "function_call_output"]
+        assert len(function_calls) == 1 and len(outputs) == 1
+        # Matching call ids make the agent skip re-execution (ignore_call_ids)
+        assert function_calls[0]["call_id"] == outputs[0]["call_id"]
+        assert "[e1] <button> Submit" in outputs[0]["output"]
+        assert "Current URL: https://example.com" in outputs[0]["output"]
+
+    @pytest.mark.asyncio
+    async def test_dom_tool_unavailable_reports_error_to_model(self, navigator_handler):
+        loop = YutoriNavigatorConfig()
+        # Old computer-server without the 'evaluate' browser command
+        navigator_handler.evaluate_js = AsyncMock(
+            return_value={"success": False, "error": "Unknown command: evaluate"}
+        )
+        response = _make_response(
+            tool_calls=[_tool_call("call_2b", "execute_js", {"text": "document.title"})]
+        )
+        with patch("litellm.acompletion", new=AsyncMock(return_value=response)):
+            result = await loop.predict_step(
+                messages=[{"role": "user", "content": "get title"}],
+                model="yutori/n1.5-latest",
+                computer_handler=navigator_handler,
+                api_key="test-key",
+            )
+
+        outputs = [i for i in result["output"] if i["type"] == "function_call_output"]
+        assert outputs and outputs[0]["output"].startswith("[ERROR]")
+
+    @pytest.mark.asyncio
+    async def test_key_sequence_expands_with_unique_call_ids(self, navigator_handler):
+        loop = YutoriNavigatorConfig()
+        response = _make_response(
+            tool_calls=[_tool_call("call_3", "key_press", {"key": "down enter"})]
+        )
+        with patch("litellm.acompletion", new=AsyncMock(return_value=response)):
+            result = await loop.predict_step(
+                messages=[{"role": "user", "content": "press keys"}],
+                model="yutori/n1.5-latest",
+                computer_handler=navigator_handler,
+                api_key="test-key",
+            )
+
+        computer_calls = [i for i in result["output"] if i["type"] == "computer_call"]
+        assert len(computer_calls) == 2
+        assert len({c["call_id"] for c in computer_calls}) == 2
+        assert [c["action"]["keys"] for c in computer_calls] == [["down"], ["enter"]]
+
+    @pytest.mark.asyncio
+    async def test_ref_click_resolved_via_evaluate_js(self, navigator_handler):
+        loop = YutoriNavigatorConfig()
+        navigator_handler.evaluate_js = AsyncMock(
+            return_value={"success": True, "result": {"success": True, "coordinates": [321, 123]}}
+        )
+        response = _make_response(tool_calls=[_tool_call("call_5", "left_click", {"ref": "e7"})])
+        with patch("litellm.acompletion", new=AsyncMock(return_value=response)):
+            result = await loop.predict_step(
+                messages=[{"role": "user", "content": "click the ref"}],
+                model="yutori/n1.5-latest",
+                computer_handler=navigator_handler,
+                api_key="test-key",
+            )
+
+        computer_calls = [i for i in result["output"] if i["type"] == "computer_call"]
+        assert computer_calls[0]["action"]["x"] == 321
+        assert computer_calls[0]["action"]["y"] == 123
+
+    @pytest.mark.asyncio
+    async def test_no_tool_calls_is_terminal(self, navigator_handler):
+        loop = YutoriNavigatorConfig()
+        response = _make_response(content="The answer is 42.")
+        with patch("litellm.acompletion", new=AsyncMock(return_value=response)):
+            result = await loop.predict_step(
+                messages=[{"role": "user", "content": "question"}],
+                model="yutori/n1.5-latest",
+                computer_handler=navigator_handler,
+                api_key="test-key",
+            )
+
+        messages = [i for i in result["output"] if i["type"] == "message"]
+        assert messages[0]["content"][0]["text"] == "The answer is 42."

--- a/libs/python/computer-server/computer_server/browser.py
+++ b/libs/python/computer-server/computer_server/browser.py
@@ -169,7 +169,25 @@ class BrowserManager:
             y = params.get("y")
             if x is None or y is None:
                 return {"success": False, "error": "x and y parameters are required"}
-            await self.page.mouse.click(x, y)
+            button = params.get("button", "left")
+            click_count = params.get("click_count", 1)
+            # Playwright modifier key names, e.g. ["Control"] for ctrl+click
+            modifiers = params.get("modifiers") or []
+            for modifier in modifiers:
+                await self.page.keyboard.down(modifier)
+            try:
+                await self.page.mouse.click(x, y, button=button, click_count=click_count)
+            finally:
+                for modifier in reversed(modifiers):
+                    await self.page.keyboard.up(modifier)
+            return {"success": True}
+
+        elif cmd == "dblclick":
+            x = params.get("x")
+            y = params.get("y")
+            if x is None or y is None:
+                return {"success": False, "error": "x and y parameters are required"}
+            await self.page.mouse.dblclick(x, y)
             return {"success": True}
 
         elif cmd == "type":
@@ -214,6 +232,17 @@ class BrowserManager:
         elif cmd == "go_forward":
             await self.page.go_forward()
             return {"success": True, "url": self.page.url}
+
+        elif cmd == "refresh":
+            await self.page.reload(wait_until="domcontentloaded", timeout=30000)
+            return {"success": True, "url": self.page.url}
+
+        elif cmd == "evaluate":
+            expression = params.get("expression")
+            if not expression:
+                return {"success": False, "error": "expression parameter is required"}
+            result = await self.page.evaluate(expression)
+            return {"success": True, "result": result}
 
         else:
             return {"success": False, "error": f"Unknown command: {cmd}"}


### PR DESCRIPTION
## Summary

The Yutori integration currently doesn't work with Navigator n1.5 — and Navigator n1, which the integration was built for, has been deprecated and is rejected by the Yutori API ([docs](https://docs.yutori.com/reference/n1)). PR #1374 updated the docs to say `yutori/n1.5`, but the code had four independent issues that prevented that from working:

1. **Model routing**: `yutori/n1.5` didn't match the Yutori loop's regex (`(yutori/)?n1(-.*)?$`), so it silently fell through to the generic VLM fallback loop with a completely different prompting scheme.
2. **Provider registration**: `YutoriAdapter` was imported but never added to `litellm.custom_provider_map`, so any `yutori/*` model failed with `LLM Provider NOT provided` before reaching the API (this PR supersedes #1294).
3. **Model names**: the Yutori API only accepts versioned names (`n1.5-latest`, `n1.5-20260428`); the bare `n1.5` the adapter forwarded is rejected with `invalid_model`.
4. **Action space**: the loop implemented the deprecated n1 action space. n1.5 renamed `hover`→`mouse_move`, changed `key_press` from Playwright-style `key_comb` to a lowercase `key` space, removed `type`'s `press_enter_after`/`clear_before_typing`, and added `hold_key`, `middle_click`, `mouse_down`/`mouse_up`, `go_forward`, plus `ref`/`modifier` arguments on clicks and scroll ([n1.5 reference](https://docs.yutori.com/reference/n1-5)).

This PR makes the integration fully functional for n1.5:

```python
agent = ComputerAgent(
    model="yutori/n1.5-latest",
    tools=[computer],
    api_key=os.getenv("YUTORI_API_KEY"),
    # optional Navigator params, forwarded via extra_body:
    # tool_set="browser_tools_expanded-20260403",
    # json_schema={...},
)
```

## Changes by commit

- **fix(agent): register YutoriAdapter with litellm and normalize Navigator model names** — registers the `yutori` provider in `custom_provider_map`; the adapter pins bare names to `-latest`, forwards `extra_body` (carrying `tool_set` / `disable_tools` / `json_schema` / `prev_request_id`), translates `max_tokens` → `max_completion_tokens` (required by the API), and honors a caller-provided `api_base`.
- **feat(computer-server): extend browser commands** — `click` now honors `button` (right/middle clicks were silently executing as left), supports `click_count` and held modifier keys; new `dblclick`, `refresh`, and `evaluate` (`page.evaluate`) commands. `evaluate` is what enables client-side DOM tooling like the Navigator expanded tool set.
- **feat(agent): support Navigator n1.5 actions in BrowserTool and normalizer** — adds `mouse_down`/`mouse_up`/`hold_key`/`history_forward`/`refresh`/`evaluate_js` and modifier-held clicks; `history_back` now prefers the native `go_back` command (the old `Alt+ArrowLeft` hotkey used key names the Linux pynput handler rejects); `triple_click` uses `click_count=3` instead of a double-click approximation. The operator normalizer routes `middle_click` through the canonical `click` action and preserves the optional `modifier` (clicks) and `time` (wait) fields.
- **feat(agent): rewrite Yutori loop for Navigator n1.5** — new routing regex covering `yutori/n1.5*` names; full n1.5 action-space conversion including key combos (`ctrl+c`) and sequential key presses (`down down enter` expands to multiple actions with unique call ids); Navigator request params as plain `ComputerAgent` kwargs; a fresh screenshot injected whenever the latest turn carries no image. Browser tool definitions and the system prompt are injected server-side by the Yutori API, so the loop only forwards custom function tools.
- **test(agent): add Yutori Navigator n1.5 integration tests** — routing, adapter behavior, action conversion, normalizer compatibility (every converted action is validated against a `BrowserTool` method signature), and `predict_step` behavior with mocked responses.

## Expanded browser tool set

n1.5's expanded tool set ([docs](https://docs.yutori.com/reference/n1-5#tool-sets)) adds four DOM tools: `extract_elements`, `find`, `set_element_value`, `execute_js`. The loop executes these inline through the computer handler's `evaluate_js` and emits the `function_call` together with its `function_call_output`, so the agent's `ignore_call_ids` mechanism skips re-execution. The reference JS implementations are bundled from the Apache-2.0 [Yutori Python SDK](https://github.com/yutori-ai/yutori-sdk-python) (`cua_agent/loops/yutori_js/`). DOM element `ref` arguments on click/scroll actions resolve to viewport pixel coordinates, falling back to the action's normalized coordinates.

Opt in with `tool_set="browser_tools_expanded-20260403"`. On computer-server builds that predate the `evaluate` command, DOM tool calls return a descriptive `[ERROR]` message to the model instead of crashing; all coordinate-based actions work regardless.

## Compatibility notes

- `yutori/n1` and other n1 model names no longer route to the Yutori loop — Navigator n1 is deprecated and the API rejects it with `model_deprecated` ([migration notes](https://docs.yutori.com/reference/n1)).
- Against older computer-server builds: right/middle clicks and `click_count` degrade to plain left clicks (right/middle were already broken — they silently executed as left clicks), and the expanded DOM tools report an error to the model. New builds get the full behavior.

## Testing

- `libs/python/agent`: 80 tests pass (including the new `tests/test_yutori.py`); `ruff check`/`ruff format` clean.
- Live-verified against `api.yutori.com`: model-name normalization (bare names are rejected by the API, `-latest` pinning fixes it), request acceptance with `tool_set` in `extra_body`, and click grounding — a predicted click denormalized from Navigator's 1000×1000 space landed on the intended link.
- Full `ComputerAgent.run()` loop tested end-to-end against a local computer-server driving a visible Firefox: a navigation task with the core tool set, and an expanded-tool-set task where the model called `find`, the bundled JS executed in-page, and the model acted on the ref-tagged results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
