### PR TITLE
feat(macos): support per-call desktop capture and scrolling

### DIFF
--- a/libs/cua-driver/rust/crates/platform-macos/src/input/mouse.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/mouse.rs
@@ -929,15 +929,9 @@ pub fn scroll_wheel_at_xy(
         // into a bounded line delta for the event API.
         let wheel_y = (delta_y_per_tick / 120).clamp(-10, 10);
         let wheel_x = (delta_x_per_tick / 120).clamp(-10, 10);
-        let event = CGEvent::new_scroll_event(
-            source,
-            ScrollEventUnit::LINE,
-            2,
-            wheel_y,
-            wheel_x,
-            0,
-        )
-        .map_err(|_| anyhow::anyhow!("CGEvent::new_scroll_event failed"))?;
+        let event =
+            CGEvent::new_scroll_event(source, ScrollEventUnit::LINE, 2, wheel_y, wheel_x, 0)
+                .map_err(|_| anyhow::anyhow!("CGEvent::new_scroll_event failed"))?;
 
         let event_ptr = event.as_ptr() as *mut std::ffi::c_void;
 
@@ -966,6 +960,48 @@ pub fn scroll_wheel_at_xy(
         crate::input::skylight::post_to_pid(pid as libc::pid_t, event_ptr, false);
         event.post_to_pid(pid as libc::pid_t);
 
+        std::thread::sleep(std::time::Duration::from_millis(30));
+    }
+    Ok(())
+}
+
+/// Synthesize a screen-absolute wheel gesture at the global HID tap.
+///
+/// Unlike [`scroll_wheel_at_xy`], this is intentionally not routed or stamped
+/// to a pid/window: WindowServer delivers it to the visually topmost surface at
+/// the point, matching desktop-scope screenshot and click semantics.
+pub fn scroll_wheel_at_xy_desktop(
+    screen_x: f64,
+    screen_y: f64,
+    delta_y_per_tick: i32,
+    delta_x_per_tick: i32,
+    ticks: usize,
+) -> anyhow::Result<()> {
+    use core_graphics::{
+        display::CGDisplay,
+        event::{CGEventTapLocation, ScrollEventUnit},
+    };
+
+    let point = CGPoint::new(screen_x, screen_y);
+    let _ = CGDisplay::warp_mouse_cursor_position(point);
+    unsafe { CGAssociateMouseAndMouseCursorPosition(true) };
+    std::thread::sleep(std::time::Duration::from_millis(40));
+
+    for _ in 0..ticks.max(1) {
+        let source = CGEventSource::new(CGEventSourceStateID::HIDSystemState)
+            .map_err(|_| anyhow::anyhow!("CGEventSource::new failed"))?;
+        let event = CGEvent::new_scroll_event(
+            source,
+            ScrollEventUnit::LINE,
+            2,
+            (delta_y_per_tick / 120).clamp(-10, 10),
+            (delta_x_per_tick / 120).clamp(-10, 10),
+            0,
+        )
+        .map_err(|_| anyhow::anyhow!("CGEvent::new_scroll_event failed"))?;
+        let event_ptr = event.as_ptr() as *mut std::ffi::c_void;
+        unsafe { CGEventSetLocation(event_ptr, screen_x, screen_y) };
+        event.post(CGEventTapLocation::HID);
         std::thread::sleep(std::time::Duration::from_millis(30));
     }
     Ok(())

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/get_desktop_state.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/get_desktop_state.rs
@@ -3,7 +3,7 @@
 //! Vision-only desktop capture: grabs the ENTIRE main display at native
 //! pixel size (no downscale) so screen-absolute pixel picks land exactly,
 //! then reports the true screen size + backing scale. No AX walk, no
-//! pid/window_id — this is the capture surface for `capture_scope="desktop"`
+//! pid/window_id — this is the capture surface for per-call `scope="desktop"`
 //! GUI loops where the agent drives `click(x,y)` / `scroll(x,y)` against
 //! screen-absolute coordinates.
 //!
@@ -12,7 +12,10 @@
 //! `structuredContent` object.
 
 use async_trait::async_trait;
-use cua_driver_core::{protocol::{ToolResult, Content}, tool::{Tool, ToolDef}};
+use cua_driver_core::{
+    protocol::{Content, ToolResult},
+    tool::{Tool, ToolDef},
+};
 use serde_json::Value;
 
 use super::get_screen_size::main_screen_size;
@@ -34,6 +37,11 @@ fn def() -> &'static ToolDef {
             "type": "object",
             "properties": {
                 "session": { "type": "string", "description": "Optional session id." },
+                "scope": {
+                    "type": "string",
+                    "enum": ["desktop"],
+                    "description": "Per-call capture scope. Pass \"desktop\" for a full-display capture; when omitted, the legacy global capture_scope setting is used for backward compatibility."
+                },
                 "screenshot_out_file": { "type": "string", "description": "Write PNG here instead of base64." }
             },
             "additionalProperties": false
@@ -47,27 +55,28 @@ fn def() -> &'static ToolDef {
 
 #[async_trait]
 impl Tool for GetDesktopStateTool {
-    fn def(&self) -> &ToolDef { def() }
+    fn def(&self) -> &ToolDef {
+        def()
+    }
 
     async fn invoke(&self, args: Value) -> ToolResult {
         use cua_driver_core::tool_args::ArgsExt;
 
-        // Gate on the global capture_scope (re-read from the persisted config,
-        // the same value set_config writes): a full-display capture is a
-        // desktop-scope operation, available only under capture_scope="desktop".
-        let scope = super::load_driver_config().capture_scope;
+        // Prefer a call-scoped declaration so callers do not have to mutate the
+        // host-global persisted driver configuration. The global value remains
+        // a compatibility fallback for older clients that omit `scope`.
+        let scope = effective_scope(&args);
         if scope != "desktop" {
             return ToolResult::error(format!(
-                "get_desktop_state requires capture_scope=\"desktop\" (current scope is \
-                 \"{scope}\"). Full-display capture is a desktop-scope operation; call \
-                 set_config with capture_scope=desktop first (it also enables window-less \
-                 screen-absolute click/scroll). For a single window, use \
+                "get_desktop_state requires scope=\"desktop\" (effective scope is \
+                 \"{scope}\"). Full-display capture is a desktop-scope operation; pass \
+                 scope=desktop on this call. For a single window, use \
                  get_window_state(pid, window_id) instead."
             ))
             .with_structured(serde_json::json!({
                 "code": "desktop_scope_disabled",
-                "capture_scope": scope,
-                "suggestion": "set_config capture_scope=desktop",
+                "scope": scope,
+                "suggestion": "pass scope=desktop",
             }));
         }
 
@@ -134,8 +143,18 @@ impl Tool for GetDesktopStateTool {
             structured["screenshot_file_path"] = serde_json::json!(fp);
         }
 
-        ToolResult { content, is_error: None, structured_content: Some(structured) }
+        ToolResult {
+            content,
+            is_error: None,
+            structured_content: Some(structured),
+        }
     }
+}
+
+fn effective_scope(args: &Value) -> String {
+    use cua_driver_core::tool_args::ArgsExt;
+    args.opt_str("scope")
+        .unwrap_or_else(|| super::load_driver_config().capture_scope)
 }
 
 #[cfg(test)]
@@ -152,11 +171,30 @@ mod tests {
 
         let props = d.input_schema["properties"].as_object().unwrap();
         assert!(!props.contains_key("pid"), "must not accept pid");
-        assert!(!props.contains_key("window_id"), "must not accept window_id");
-        assert!(!props.contains_key("capture_mode"), "must not accept capture_mode");
+        assert!(
+            !props.contains_key("window_id"),
+            "must not accept window_id"
+        );
+        assert!(
+            !props.contains_key("capture_mode"),
+            "must not accept capture_mode"
+        );
         assert!(props.contains_key("session"));
         assert!(props.contains_key("screenshot_out_file"));
-        assert_eq!(d.input_schema["additionalProperties"], serde_json::json!(false));
+        assert_eq!(props["scope"]["enum"], serde_json::json!(["desktop"]));
+        assert_eq!(
+            d.input_schema["additionalProperties"],
+            serde_json::json!(false)
+        );
+    }
+
+    #[test]
+    fn desktop_scope_is_per_call() {
+        assert_eq!(
+            effective_scope(&serde_json::json!({"scope": "desktop"})),
+            "desktop"
+        );
+        assert_eq!(effective_scope(&serde_json::json!({})), "window");
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/scroll.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/scroll.rs
@@ -47,7 +47,7 @@ static DEF: std::sync::OnceLock<ToolDef> = std::sync::OnceLock::new();
 fn def() -> &'static ToolDef {
     DEF.get_or_init(|| ToolDef {
         name: "scroll".into(),
-        description: "Scroll the target pid. Two paths, picked by how you address the scroll:\n\n\
+        description: "Scroll a target window or the visible desktop. Paths are picked by how you address the scroll:\n\n\
             • **Targeted wheel path** — when you pass a target, either \
             `element_index`/`element_token` (preferred) or window-local `x, y` pixels: \
             the driver synthesizes a real mouse-wheel event (CGEventCreateScrollWheelEvent, \
@@ -88,10 +88,15 @@ fn def() -> &'static ToolDef {
                     "description": "Pixel-wheel path: number of wheel notches. Keystroke path: number of keystroke repetitions. Default: 3."
                 },
                 "window_id": { "type": "integer" },
+                "scope": {
+                    "type": "string",
+                    "enum": ["window", "desktop"],
+                    "description": "Coordinate frame (default window). Pass desktop with x,y and no pid/window_id for screen-absolute foreground scrolling."
+                },
                 "element_index": { "type": "integer", "description": "Element from last get_window_state. Routes through the pixel-wheel path AT this element's center — use it to scroll a nested overflow region you located in the AX tree." },
                 "element_token": { "type": "string", "description": "Opaque per-snapshot element handle from `structuredContent.elements[].element_token`. Takes precedence over element_index when both supplied. Returns an explicit \"stale\" error if the snapshot has been superseded. Routes through the pixel-wheel path at the element's center." },
-                "x": { "type": "number", "description": "Window-local screenshot X (top-left origin of the PNG from get_window_state). With `y`, routes through the pixel-wheel path at this point — use for a scrollable surface that isn't in the AX tree. Requires window_id to anchor the window→screen conversion." },
-                "y": { "type": "number", "description": "Window-local screenshot Y. See `x`." },
+                "x": { "type": "number", "description": "Screenshot X coordinate. Window scope uses window-local pixels from get_window_state and requires window_id; desktop scope uses native display pixels from get_desktop_state." },
+                "y": { "type": "number", "description": "Screenshot Y coordinate; see x." },
                 "delivery_mode": cua_driver_core::tool_schema::delivery_mode_schema()
             },
             "additionalProperties": false
@@ -111,6 +116,75 @@ impl Tool for ScrollTool {
 
     async fn invoke(&self, args: Value) -> ToolResult {
         use cua_driver_core::tool_args::ArgsExt;
+        let direction = match args.require_str("direction") {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        let by = args.str_or("by", "line");
+        let amount = args.u64_or("amount", 3) as usize;
+
+        match desktop_scroll_request(&args) {
+            Ok(Some((screenshot_x, screenshot_y))) => {
+                let step = if by == "page" {
+                    WHEEL_STEP_PAGE_PX
+                } else {
+                    WHEEL_STEP_LINE_PX
+                };
+                let (delta_y, delta_x): (i32, i32) = match direction.as_str() {
+                    "down" => (-step, 0),
+                    "up" => (step, 0),
+                    "right" => (0, -step),
+                    "left" => (0, step),
+                    _ => {
+                        return ToolResult::error(format!("Unknown scroll direction: {direction}"))
+                    }
+                };
+                let desktop_ratio = tokio::task::spawn_blocking(|| {
+                    let logical_w =
+                        super::get_screen_size::main_screen_size().map(|(w, _, _)| w as f64);
+                    let shot_w = crate::capture::screenshot_display_bytes()
+                        .ok()
+                        .and_then(|png| crate::capture::png_dimensions(&png).ok())
+                        .map(|(w, _)| w as f64);
+                    match (shot_w, logical_w) {
+                        (Some(sw), Some(lw)) if lw > 0.0 && sw > lw => sw / lw,
+                        _ => 1.0,
+                    }
+                })
+                .await
+                .unwrap_or(1.0);
+                let screen_x = screenshot_x / desktop_ratio;
+                let screen_y = screenshot_y / desktop_ratio;
+                let cursor_key = super::cursor_tools::resolve_cursor_key(&args);
+                crate::cursor::overlay::animate_cursor_to(cursor_key.clone(), screen_x, screen_y)
+                    .await;
+                self.state
+                    .cursor_registry
+                    .update_position(&cursor_key, screen_x, screen_y);
+                let result = tokio::task::spawn_blocking(move || {
+                    crate::input::mouse::scroll_wheel_at_xy_desktop(
+                        screen_x, screen_y, delta_y, delta_x, amount,
+                    )
+                })
+                .await;
+                return match result {
+                    Ok(Ok(())) => ToolResult::text(format!(
+                        "✅ Sent {direction} scroll by {by} × {amount} via desktop wheel at ({screen_x:.0}, {screen_y:.0})."
+                    ))
+                    .with_structured(serde_json::json!({
+                        "path": "cgevent_desktop",
+                        "scope": "desktop",
+                        "verified": false,
+                        "effect": "unverifiable"
+                    })),
+                    Ok(Err(error)) => ToolResult::error(format!("Desktop wheel scroll failed: {error}")),
+                    Err(error) => ToolResult::error(format!("Desktop wheel scroll task failed: {error}")),
+                };
+            }
+            Ok(None) => {}
+            Err(error) => return ToolResult::error(error),
+        }
+
         let pid = match args.require_i32("pid") {
             Ok(v) => v,
             Err(e) => return e,
@@ -127,12 +201,6 @@ impl Tool for ScrollTool {
             )
             .with_structured(serde_json::json!({ "code": "background_unavailable" }));
         }
-        let direction = match args.require_str("direction") {
-            Ok(v) => v,
-            Err(e) => return e,
-        };
-        let by = args.str_or("by", "line");
-        let amount = args.u64_or("amount", 3) as usize;
         // Surface 6: element_token / element_index precedence.
         let element_token_arg = args.opt_str("element_token");
         let window_id_arg = args.opt_u64("window_id").map(|v| v as u32);
@@ -538,6 +606,44 @@ impl Tool for ScrollTool {
     }
 }
 
+fn desktop_scroll_request(args: &Value) -> Result<Option<(f64, f64)>, String> {
+    use cua_driver_core::tool_args::ArgsExt;
+
+    let scope = args.str_or("scope", "window");
+    if scope == "window" {
+        return Ok(None);
+    }
+    if scope != "desktop" {
+        return Err(format!(
+            "scroll: unknown scope \"{scope}\"; expected window or desktop."
+        ));
+    }
+    if args.get("pid").is_some_and(|value| !value.is_null())
+        || args.get("window_id").is_some_and(|value| !value.is_null())
+        || args
+            .get("element_index")
+            .is_some_and(|value| !value.is_null())
+        || args
+            .get("element_token")
+            .is_some_and(|value| !value.is_null())
+    {
+        return Err(
+            "scroll: desktop scope cannot be combined with pid, window_id, element_index, or element_token."
+                .to_string(),
+        );
+    }
+    let x = args
+        .opt_f64("x")
+        .or_else(|| args.opt_i64("x").map(|value| value as f64));
+    let y = args
+        .opt_f64("y")
+        .or_else(|| args.opt_i64("y").map(|value| value as f64));
+    match (x, y) {
+        (Some(x), Some(y)) => Ok(Some((x, y))),
+        _ => Err("scroll: desktop scope requires numeric x and y coordinates.".to_string()),
+    }
+}
+
 unsafe fn scroll_native_text_area(
     element: AXUIElementRef,
     direction: &str,
@@ -601,5 +707,44 @@ unsafe fn collect_ax_buttons(
             collect_ax_buttons(child, depth + 1, buttons);
             CFRelease(child as CFTypeRef);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_supports_per_call_desktop_scope() {
+        let props = def().input_schema["properties"].as_object().unwrap();
+        assert_eq!(
+            props["scope"]["enum"],
+            serde_json::json!(["window", "desktop"])
+        );
+        assert!(!def().input_schema["required"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|value| value == "pid"));
+    }
+
+    #[test]
+    fn desktop_scroll_requires_coordinates_and_no_window_target() {
+        assert!(desktop_scroll_request(&serde_json::json!({
+            "scope": "desktop", "x": 100, "y": 200
+        }))
+        .is_ok());
+        assert!(desktop_scroll_request(&serde_json::json!({
+            "scope": "desktop", "x": 100
+        }))
+        .is_err());
+        assert!(desktop_scroll_request(&serde_json::json!({
+            "scope": "desktop", "x": 100, "y": 200, "pid": 123
+        }))
+        .is_err());
+        assert!(desktop_scroll_request(&serde_json::json!({
+            "scope": "desktop", "x": 100, "y": 200, "element_index": 4
+        }))
+        .is_err());
     }
 }


### PR DESCRIPTION
## Summary

- let `get_desktop_state` select desktop capture per invocation instead of requiring only the persisted global capture scope
- add a desktop branch to `scroll` that accepts native screenshot coordinates without `pid` or `window_id`
- convert native screenshot pixels to logical screen points and deliver foreground HID scroll events at the requested location
- retain the existing window-scoped behavior and reject mixed desktop/window targets explicitly

## Why

The driver could already capture the primary display, but callers could not request that behavior safely per operation. Desktop scrolling also contradicted the desktop-scope contract because it still required a process target. This forced integrations to mutate host-global configuration and made desktop screenshot coordinates unusable for scrolling.

## User impact

Clients can now use one operation-local `scope: "desktop"` contract for primary-display capture and scrolling. Desktop calls do not require or accept a process/window target, while existing window calls remain unchanged.

## Validation

- `rustfmt --edition 2021 --check` on the three changed Rust files
- `cargo test -p platform-macos tools:: --locked` — 49 passed
- full interactive macOS harness was not run because this worktree's source-built driver was not installed with the required TCC identity; unit/schema tests do not claim real-application delivery coverage

## Companion integration

[tutti-os/tutti#1218](https://github.com/tutti-os/tutti/pull/1218) consumes this per-call contract and exposes stable and capability-discovered computer commands.
