### PR TITLE
fix(docs): handle unsupported code languages

### DIFF
--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -25,6 +25,12 @@ export const docs = defineDocs({
 export default defineConfig({
   lastModifiedTime: 'git',
   mdxOptions: {
-    // MDX options
+    rehypeCodeOptions: {
+      fallbackLanguage: 'text',
+      themes: {
+        light: 'github-light',
+        dark: 'github-dark',
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary

- configure Fumadocs to render unsupported fenced-code languages as plain text
- retain the existing GitHub light and dark syntax themes
- prevent Rego policy examples from breaking production docs builds

## Root cause

The pinned Shiki language bundle does not include a Rego grammar. Fumadocs attempted to lazy-load `rego` during the production build and failed instead of falling back to an available language.

## Validation

- `./node_modules/.bin/next build` (73/73 static pages)
- `./node_modules/.bin/tsx scripts/check-links.ts`
- `./node_modules/.bin/tsx scripts/check-links.ts --external`
- `./node_modules/.bin/tsx scripts/check-hygiene.ts`
- `./node_modules/.bin/prettier --check source.config.ts`