### PR TITLE
fix(cua-driver/linux): stop idle X11 overlay frame ticks

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
@@ -398,26 +398,15 @@ fn tick_render_map(map: &mut RenderMap, dt: f64) -> Vec<CursorKey> {
 }
 
 #[cfg(target_os = "linux")]
-fn scheduled_tick_dt(elapsed_dt: f64, maintenance_timeout: bool) -> f64 {
-    if maintenance_timeout {
-        // No animation is active while parked, so maintenance must advance the
-        // complete idle interval rather than the 50 ms animation safety cap.
-        elapsed_dt
-    } else {
-        elapsed_dt.min(0.05)
-    }
-}
-
-#[cfg(target_os = "linux")]
 fn apply_messages_after_wake(
     map: &mut RenderMap,
     first_msg: Option<OverlayMsg>,
     rx: &std::sync::mpsc::Receiver<OverlayMsg>,
     parked_elapsed: Option<f64>,
 ) -> (Vec<CursorKey>, bool) {
-    // Advance pre-existing quiescent state before commands mutate it. This
-    // preserves each cursor's independent idle clock while ensuring newly
-    // commanded animations render their initial frame at dt=0.
+    // For a parked wake, advance pre-existing quiescent state before commands
+    // mutate it. This preserves each cursor's independent idle clock while
+    // ensuring newly commanded animations render their initial frame at dt=0.
     let arrived = parked_elapsed
         .map(|dt| tick_render_map(map, dt))
         .unwrap_or_default();
@@ -433,6 +422,29 @@ fn apply_messages_after_wake(
         if let Some(key) = apply_msg(map, msg) {
             map.last_active = Some(key);
         }
+    }
+    (arrived, had_msg)
+}
+
+#[cfg(target_os = "linux")]
+fn process_render_wake(
+    map: &mut RenderMap,
+    first_msg: Option<OverlayMsg>,
+    rx: &std::sync::mpsc::Receiver<OverlayMsg>,
+    elapsed_dt: f64,
+    maintenance_timeout: bool,
+    frame_tick_needed: bool,
+) -> (Vec<CursorKey>, bool) {
+    // Command receives and maintenance timeouts both wake a parked loop. Tick
+    // the old state before draining the channel so even a command that arrives
+    // just after recv_timeout reports Timeout starts at dt=0. Active-frame
+    // wakes retain their existing apply-then-tick ordering; pre-ticking those
+    // could fire an old path's arrival waiter after a replacement is registered.
+    let parked_wake = first_msg.is_some() || maintenance_timeout;
+    let (mut arrived, had_msg) =
+        apply_messages_after_wake(map, first_msg, rx, parked_wake.then_some(elapsed_dt));
+    if !parked_wake && (frame_tick_needed || had_msg) {
+        arrived.extend(tick_render_map(map, elapsed_dt.min(0.05)));
     }
     (arrived, had_msg)
 }
@@ -649,10 +661,8 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
             OverlayWake::Disconnected => break,
         };
 
-        let woke_for_command = first_msg.is_some();
         let now = Instant::now();
         let elapsed_dt = now.duration_since(last_tick).as_secs_f64();
-        let tick_dt = scheduled_tick_dt(elapsed_dt, maintenance_timeout);
         last_tick = now;
 
         // Drain commands and tick.
@@ -666,15 +676,14 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
         ) = {
             let mut guard = RENDER.lock().unwrap();
             if let Some(map) = guard.as_mut() {
-                let (mut arrived, had_msg) = apply_messages_after_wake(
+                let (arrived, had_msg) = process_render_wake(
                     map,
                     first_msg,
                     &rx,
-                    woke_for_command.then_some(elapsed_dt),
+                    elapsed_dt,
+                    maintenance_timeout,
+                    frame_tick_needed,
                 );
-                if !woke_for_command && (frame_tick_needed || had_msg || maintenance_timeout) {
-                    arrived.extend(tick_render_map(map, tick_dt));
-                }
                 let pinned_wid = map
                     .last_active
                     .as_ref()
@@ -1020,8 +1029,17 @@ mod tests {
 
     #[test]
     fn maintenance_tick_advances_the_full_elapsed_interval() {
-        assert_eq!(scheduled_tick_dt(0.08, true), 0.08);
-        assert_eq!(scheduled_tick_dt(0.08, false), 0.05);
+        let mut map = default_render_map();
+        let cursor = map.cursors.get_mut("default").unwrap();
+        cursor.core.pos = (10.0, 10.0);
+        cursor.core.motion.idle_hide_ms = 500.0;
+        let (_tx, rx) = std::sync::mpsc::channel();
+
+        let (arrived, had_msg) = process_render_wake(&mut map, None, &rx, 0.08, true, false);
+
+        assert!(arrived.is_empty());
+        assert!(!had_msg);
+        assert_eq!(map.cursors["default"].core.idle_secs, 0.08);
     }
 
     #[test]
@@ -1123,14 +1141,16 @@ mod tests {
         // elapsed time must advance all existing cursors before each unrelated
         // command is applied.
         for _ in 0..5 {
-            let (arrived, had_msg) = apply_messages_after_wake(
+            let (arrived, had_msg) = process_render_wake(
                 &mut map,
                 Some(OverlayMsg::Cmd(KeyedOverlayCommand {
                     key: "other".to_owned(),
                     cmd: OverlayCommand::SetPalette(Palette::for_instance("other")),
                 })),
                 &rx,
-                Some(0.1),
+                0.1,
+                false,
+                false,
             );
             assert!(arrived.is_empty());
             assert!(had_msg);
@@ -1140,6 +1160,42 @@ mod tests {
         assert!(cursor.core.idle_secs >= 0.5);
         assert!(cursor.needs_frame_tick());
         assert_eq!(cursor.core.idle_alpha, 1.0);
+    }
+
+    #[test]
+    fn command_drained_after_maintenance_timeout_starts_at_zero_dt() {
+        let mut map = default_render_map();
+        {
+            let cursor = map.cursors.get_mut("default").unwrap();
+            cursor.core.pos = (10.0, 10.0);
+            cursor.core.motion.idle_hide_ms = 500.0;
+        }
+        let mut other = render_state_for_key(&map.template, "other");
+        other.core.pos = (20.0, 20.0);
+        map.cursors.insert("other".to_owned(), other);
+
+        // Model a command arriving after recv_timeout returned Timeout but
+        // before the render loop's try_recv drain.
+        let (tx, rx) = std::sync::mpsc::channel();
+        tx.send(OverlayMsg::Cmd(KeyedOverlayCommand {
+            key: "other".to_owned(),
+            cmd: OverlayCommand::MoveTo {
+                x: 250.0,
+                y: 150.0,
+                end_heading_radians: 0.0,
+            },
+        }))
+        .unwrap();
+
+        let (arrived, had_msg) = process_render_wake(&mut map, None, &rx, 0.08, true, false);
+
+        assert!(arrived.is_empty());
+        assert!(had_msg);
+        assert_eq!(map.cursors["default"].core.idle_secs, 0.08);
+        let other = &map.cursors["other"].core;
+        assert!(other.path.is_some());
+        assert_eq!(other.pos, (20.0, 20.0));
+        assert_eq!(other.dist, 0.0);
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
@@ -1078,6 +1078,38 @@ mod tests {
     }
 
     #[test]
+    fn disabling_settled_cursor_clears_once_then_parks() {
+        let mut map = default_render_map();
+        let cursor = map.cursors.get_mut("default").unwrap();
+        cursor.core.pos = (100.0, 100.0);
+        cursor.core.motion.idle_hide_ms = 0.0;
+        let (_tx, rx) = std::sync::mpsc::channel();
+
+        assert!(!render_map_needs_frame_tick(&map));
+        assert!(render_map_needs_z_order_tick(&map));
+
+        let (arrived, had_msg) = process_render_wake(
+            &mut map,
+            Some(OverlayMsg::Cmd(KeyedOverlayCommand {
+                key: "default".to_owned(),
+                cmd: OverlayCommand::SetEnabled(false),
+            })),
+            &rx,
+            0.08,
+            false,
+            false,
+        );
+
+        assert!(arrived.is_empty());
+        // The production render gate includes `had_msg`, so disabling paints
+        // one final transparent frame before both scheduler paths park.
+        assert!(had_msg);
+        assert!(!map.cursors["default"].core.visible);
+        assert!(!render_map_needs_frame_tick(&map));
+        assert!(!render_map_needs_z_order_tick(&map));
+    }
+
+    #[test]
     fn active_cursor_requires_frame_ticks() {
         let mut map = default_render_map();
         let cursor = map.cursors.get_mut("default").unwrap();

--- a/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
@@ -355,6 +355,61 @@ impl RenderState {
         // the visual update silently so callers don't see an error.
         let _ = self.core.apply_command_base(cmd, false, false);
     }
+
+    /// True while the render loop must wake at frame cadence because the next
+    /// tick can change pixels. A brand-new sentinel cursor is deliberately
+    /// quiescent, so an idle MCP server can block on the command channel
+    /// instead of repainting a full-screen X11 pixmap at 60 fps.
+    fn needs_frame_tick(&self) -> bool {
+        self.core.path.is_some()
+            || self.core.spring.is_some()
+            || self.core.click_t.is_some()
+            || (self.core.motion.idle_hide_ms > 0.0
+                && self.core.visible
+                && self.core.pos.0 >= -100.0
+                && self.core.idle_alpha >= 0.004)
+    }
+}
+
+fn render_map_needs_frame_tick(map: &RenderMap) -> bool {
+    map.cursors.values().any(RenderState::needs_frame_tick)
+}
+
+fn render_map_needs_z_order_tick(map: &RenderMap) -> bool {
+    map.cursors
+        .values()
+        .any(|rs| rs.core.visible && rs.core.idle_alpha >= 0.004 && rs.core.pos.0 >= -100.0)
+}
+
+enum OverlayWake {
+    Frame,
+    Message(OverlayMsg),
+    ZOrderTimeout,
+    Disconnected,
+}
+
+fn wait_for_overlay_work(
+    rx: &std::sync::mpsc::Receiver<OverlayMsg>,
+    frame_tick_needed: bool,
+    z_order_tick_needed: bool,
+    z_order_interval: Duration,
+) -> OverlayWake {
+    if frame_tick_needed {
+        return OverlayWake::Frame;
+    }
+
+    if z_order_tick_needed {
+        return match rx.recv_timeout(z_order_interval) {
+            Ok(msg) => OverlayWake::Message(msg),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => OverlayWake::ZOrderTimeout,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => OverlayWake::Disconnected,
+        };
+    }
+
+    match rx.recv() {
+        Ok(msg) => OverlayWake::Message(msg),
+        Err(_) => OverlayWake::Disconnected,
+    }
 }
 
 // ── X11 thread ────────────────────────────────────────────────────────────
@@ -467,30 +522,67 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
     conn.map_window(win).ok();
     conn.flush().ok();
 
-    // Main render loop at ~60Hz.
+    // Main render loop at ~60 Hz while pixels can change. When every cursor is
+    // quiescent, block on the command channel and leave the last frame intact.
     let frame_dur = Duration::from_millis(16);
     let mut last_tick = Instant::now();
     let mut last_ztick = Instant::now();
+    let mut frame_tick_needed = false;
+    let mut z_order_tick_needed = false;
+    let mut last_pinned: Option<u64> = None;
     let z_enforcer = X11ZOrderEnforcer { conn: &conn, win };
 
     loop {
+        // Idle fast path: no full-screen Pixmap allocation, RGBA→BGRA copy,
+        // XShape update, or XPutImage until a command arrives. A resting visible
+        // cursor still wakes cheaply every 80 ms to preserve the documented
+        // X11 z-order contract without repainting.
+        let (first_msg, z_order_timeout) = match wait_for_overlay_work(
+            &rx,
+            frame_tick_needed,
+            z_order_tick_needed,
+            Duration::from_millis(80),
+        ) {
+            OverlayWake::Frame => (None, false),
+            OverlayWake::Message(msg) => (Some(msg), false),
+            OverlayWake::ZOrderTimeout => (None, true),
+            OverlayWake::Disconnected => break,
+        };
+
+        let woke_from_idle = first_msg.is_some() || z_order_timeout;
         let now = Instant::now();
-        let dt = now.duration_since(last_tick).as_secs_f64().min(0.05);
+        let dt = if woke_from_idle {
+            // A blocking receive can span an arbitrarily long idle period. Do
+            // not fast-forward the first animation frame after waking.
+            0.0
+        } else {
+            now.duration_since(last_tick).as_secs_f64().min(0.05)
+        };
         last_tick = now;
 
         // Drain commands and tick.
-        let (arrived, pinned_wid) = {
+        let (arrived, pinned_wid, had_msg, next_frame_tick_needed, next_z_order_tick_needed) = {
             let mut guard = RENDER.lock().unwrap();
             if let Some(map) = guard.as_mut() {
+                let mut had_msg = false;
+                if let Some(msg) = first_msg {
+                    had_msg = true;
+                    if let Some(key) = apply_msg(map, msg) {
+                        map.last_active = Some(key);
+                    }
+                }
                 while let Ok(msg) = rx.try_recv() {
+                    had_msg = true;
                     if let Some(key) = apply_msg(map, msg) {
                         map.last_active = Some(key);
                     }
                 }
                 let mut arrived = Vec::new();
-                for (key, rs) in map.cursors.iter_mut() {
-                    if rs.tick(dt) {
-                        arrived.push(key.clone());
+                if frame_tick_needed || had_msg {
+                    for (key, rs) in map.cursors.iter_mut() {
+                        if rs.tick(dt) {
+                            arrived.push(key.clone());
+                        }
                     }
                 }
                 let pinned_wid = map
@@ -498,53 +590,77 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
                     .as_ref()
                     .and_then(|key| map.cursors.get(key))
                     .and_then(|rs| rs.core.pinned_wid);
-                (arrived, pinned_wid)
+                let next_frame_tick_needed = render_map_needs_frame_tick(map);
+                let next_z_order_tick_needed = render_map_needs_z_order_tick(map);
+                (
+                    arrived,
+                    pinned_wid,
+                    had_msg,
+                    next_frame_tick_needed,
+                    next_z_order_tick_needed,
+                )
             } else {
-                (Vec::new(), None)
+                break;
             }
         };
 
-        // Render and paint.
-        let pixmap = {
-            let guard = RENDER.lock().unwrap();
-            guard.as_ref().map(|map| {
-                let mut pm = tiny_skia::Pixmap::new(map.scr_w.max(1), map.scr_h.max(1))
-                    .unwrap_or_else(|| tiny_skia::Pixmap::new(1, 1).unwrap());
-                for rs in map.cursors.values() {
-                    // TODO: thread X11/Wayland scale-factor here so cursors
-                    // render at native resolution on HiDPI Linux displays
-                    // (`XRRGetCrtcInfo` reports per-output DPI; the GNOME
-                    // scale-factor setting is exposed via the screen-scaling
-                    // protocol). For now we default to 1.0 — preserves
-                    // pre-retina-fix behaviour on Linux.
-                    cursor_overlay::paint_cursor(&mut pm, &rs.core, 0.0, 0.0, None, 1.0);
-                }
-                pm
-            })
-        };
-
-        if let Some(pm) = pixmap {
-            paint_x11(&conn, win, scr_w, scr_h, depth, visual_id, &pm);
-        }
-
-        for key in &arrived {
-            arrival_fire(key);
-        }
-
-        // Z-order maintenance every 80ms — delegate to the cross-platform
-        // ZOrderEnforcer so the contract for "z+1 of the application under
-        // test" is documented once in `cursor_overlay::z_order`.
-        if last_ztick.elapsed() >= Duration::from_millis(80) {
+        // Reassert immediately after a command or target change, then every
+        // 80 ms while animation/fade frames are active. Quiescent cursors keep
+        // their last z-order until a new command wakes the loop.
+        let pin_changed = pinned_wid != last_pinned;
+        last_pinned = pinned_wid;
+        if had_msg
+            || pin_changed
+            || z_order_timeout
+            || (frame_tick_needed && last_ztick.elapsed() >= Duration::from_millis(80))
+        {
             last_ztick = Instant::now();
             z_enforcer.reassert(pinned_wid);
+        }
+
+        // Render after a command, during an active animation/fade, and once
+        // more as the final active state settles. This leaves the X11 window in
+        // its completed/cleared state before the next blocking receive.
+        if had_msg || frame_tick_needed || next_frame_tick_needed {
+            let pixmap = {
+                let guard = RENDER.lock().unwrap();
+                guard.as_ref().map(|map| {
+                    let mut pm = tiny_skia::Pixmap::new(map.scr_w.max(1), map.scr_h.max(1))
+                        .unwrap_or_else(|| tiny_skia::Pixmap::new(1, 1).unwrap());
+                    for rs in map.cursors.values() {
+                        // TODO: thread X11/Wayland scale-factor here so cursors
+                        // render at native resolution on HiDPI Linux displays
+                        // (`XRRGetCrtcInfo` reports per-output DPI; the GNOME
+                        // scale-factor setting is exposed via the screen-scaling
+                        // protocol). For now we default to 1.0 — preserves
+                        // pre-retina-fix behaviour on Linux.
+                        cursor_overlay::paint_cursor(&mut pm, &rs.core, 0.0, 0.0, None, 1.0);
+                    }
+                    pm
+                })
+            };
+
+            if let Some(pm) = pixmap {
+                paint_x11(&conn, win, scr_w, scr_h, depth, visual_id, &pm);
+            }
+        }
+
+        // Preserve the original ordering: callers waiting on arrival only
+        // resume after the destination frame has reached the X11 window.
+        for key in &arrived {
+            arrival_fire(key);
         }
 
         // Drain any X events (needed to avoid blocking).
         while let Ok(Some(_)) = conn.poll_for_event() {}
 
-        let elapsed = Instant::now().duration_since(last_tick);
-        if let Some(remaining) = frame_dur.checked_sub(elapsed) {
-            std::thread::sleep(remaining);
+        frame_tick_needed = next_frame_tick_needed;
+        z_order_tick_needed = next_z_order_tick_needed;
+        if frame_tick_needed {
+            let elapsed = Instant::now().duration_since(last_tick);
+            if let Some(remaining) = frame_dur.checked_sub(elapsed) {
+                std::thread::sleep(remaining);
+            }
         }
     }
 }
@@ -729,7 +845,160 @@ fn bgra_and_visible_shape(
 
 #[cfg(all(test, target_os = "linux"))]
 mod tests {
-    use super::bgra_and_visible_shape;
+    use super::*;
+
+    fn default_render_map() -> RenderMap {
+        let cfg = CursorConfig::default();
+        let mut cursors = HashMap::new();
+        cursors.insert("default".to_owned(), RenderState::new(cfg.clone()));
+        RenderMap {
+            cursors,
+            scr_w: 100,
+            scr_h: 100,
+            template: cfg,
+            ended: HashSet::new(),
+            last_active: None,
+        }
+    }
+
+    fn test_message() -> OverlayMsg {
+        OverlayMsg::Cmd(KeyedOverlayCommand {
+            key: "default".to_owned(),
+            cmd: OverlayCommand::SetEnabled(true),
+        })
+    }
+
+    #[test]
+    fn active_frame_wake_does_not_consume_queued_command() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        tx.send(test_message()).unwrap();
+
+        assert!(matches!(
+            wait_for_overlay_work(&rx, true, false, Duration::from_millis(1)),
+            OverlayWake::Frame
+        ));
+        assert!(rx.try_recv().is_ok());
+    }
+
+    #[test]
+    fn idle_wait_wakes_for_command() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        tx.send(test_message()).unwrap();
+
+        match wait_for_overlay_work(&rx, false, false, Duration::from_millis(1)) {
+            OverlayWake::Message(OverlayMsg::Cmd(keyed)) => assert_eq!(keyed.key, "default"),
+            _ => panic!("idle wait did not return the queued command"),
+        }
+    }
+
+    #[test]
+    fn resting_cursor_wait_times_out_for_z_order_maintenance() {
+        let (_tx, rx) = std::sync::mpsc::channel();
+        assert!(matches!(
+            wait_for_overlay_work(&rx, false, true, Duration::from_millis(1)),
+            OverlayWake::ZOrderTimeout
+        ));
+    }
+
+    #[test]
+    fn idle_wait_reports_disconnected_sender_in_both_modes() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        drop(tx);
+        assert!(matches!(
+            wait_for_overlay_work(&rx, false, false, Duration::from_millis(1)),
+            OverlayWake::Disconnected
+        ));
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        drop(tx);
+        assert!(matches!(
+            wait_for_overlay_work(&rx, false, true, Duration::from_millis(1)),
+            OverlayWake::Disconnected
+        ));
+    }
+
+    #[test]
+    fn sentinel_default_cursor_does_not_require_frame_ticks() {
+        let map = default_render_map();
+        assert!(!render_map_needs_frame_tick(&map));
+        assert!(!render_map_needs_z_order_tick(&map));
+    }
+
+    #[test]
+    fn resting_visible_cursor_only_requires_cheap_z_order_ticks() {
+        let mut map = default_render_map();
+        let cursor = map.cursors.get_mut("default").unwrap();
+        cursor.core.pos = (100.0, 100.0);
+        cursor.core.motion.idle_hide_ms = 0.0;
+
+        assert!(!render_map_needs_frame_tick(&map));
+        assert!(render_map_needs_z_order_tick(&map));
+    }
+
+    #[test]
+    fn active_cursor_requires_frame_ticks() {
+        let mut map = default_render_map();
+        let cursor = map.cursors.get_mut("default").unwrap();
+        cursor.apply_command(OverlayCommand::MoveTo {
+            x: 250.0,
+            y: 150.0,
+            end_heading_radians: 0.0,
+        });
+        assert!(render_map_needs_frame_tick(&map));
+    }
+
+    #[test]
+    fn completed_move_and_idle_fade_return_to_quiescence() {
+        let mut map = default_render_map();
+        let cursor = map.cursors.get_mut("default").unwrap();
+        // The public animate path seeds a newly created cursor near its target
+        // before sending MoveTo; mirror that valid on-screen starting state.
+        cursor.core.pos = (100.0, 100.0);
+        cursor.core.motion.idle_hide_ms = 500.0;
+        cursor.apply_command(OverlayCommand::MoveTo {
+            x: 250.0,
+            y: 150.0,
+            end_heading_radians: 0.0,
+        });
+
+        for _ in 0..1200 {
+            cursor.tick(1.0 / 60.0);
+            if !cursor.needs_frame_tick() {
+                break;
+            }
+        }
+
+        assert!(
+            !cursor.needs_frame_tick(),
+            "cursor did not quiesce: path={}, spring={}, click={}, idle_secs={:.3}, idle_alpha={:.3}, pos={:?}",
+            cursor.core.path.is_some(),
+            cursor.core.spring.is_some(),
+            cursor.core.click_t.is_some(),
+            cursor.core.idle_secs,
+            cursor.core.idle_alpha,
+            cursor.core.pos,
+        );
+        assert!(!render_map_needs_frame_tick(&map));
+    }
+
+    #[test]
+    fn completed_click_pulse_returns_to_quiescence() {
+        let mut map = default_render_map();
+        let cursor = map.cursors.get_mut("default").unwrap();
+        cursor.core.motion.idle_hide_ms = 0.0;
+        cursor.apply_command(OverlayCommand::ClickPulse { x: 20.0, y: 30.0 });
+        assert!(cursor.needs_frame_tick());
+
+        for _ in 0..600 {
+            cursor.tick(1.0 / 60.0);
+            if !cursor.needs_frame_tick() {
+                break;
+            }
+        }
+
+        assert!(!cursor.needs_frame_tick());
+        assert!(!render_map_needs_frame_tick(&map));
+    }
 
     #[test]
     fn visible_shape_contains_only_nontransparent_runs() {

--- a/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
@@ -361,12 +361,14 @@ impl RenderState {
     /// quiescent, so an idle MCP server can block on the command channel
     /// instead of repainting a full-screen X11 pixmap at 60 fps.
     fn needs_frame_tick(&self) -> bool {
+        let fade_start = self.core.motion.idle_hide_ms / 1000.0;
         self.core.path.is_some()
             || self.core.spring.is_some()
             || self.core.click_t.is_some()
             || (self.core.motion.idle_hide_ms > 0.0
                 && self.core.visible
                 && self.core.pos.0 >= -100.0
+                && self.core.idle_secs >= fade_start
                 && self.core.idle_alpha >= 0.004)
     }
 }
@@ -381,10 +383,31 @@ fn render_map_needs_z_order_tick(map: &RenderMap) -> bool {
         .any(|rs| rs.core.visible && rs.core.idle_alpha >= 0.004 && rs.core.pos.0 >= -100.0)
 }
 
+fn render_map_idle_wait_interval(map: &RenderMap, max_interval: Duration) -> Duration {
+    map.cursors
+        .values()
+        .filter_map(|rs| {
+            let core = &rs.core;
+            if !core.visible
+                || core.pos.0 < -100.0
+                || core.motion.idle_hide_ms <= 0.0
+                || core.path.is_some()
+                || core.spring.is_some()
+                || core.click_t.is_some()
+            {
+                return None;
+            }
+
+            let remaining = core.motion.idle_hide_ms / 1000.0 - core.idle_secs;
+            (remaining.is_finite() && remaining > 0.0).then(|| Duration::from_secs_f64(remaining))
+        })
+        .fold(max_interval, Duration::min)
+}
+
 enum OverlayWake {
     Frame,
     Message(OverlayMsg),
-    ZOrderTimeout,
+    MaintenanceTimeout,
     Disconnected,
 }
 
@@ -392,16 +415,16 @@ fn wait_for_overlay_work(
     rx: &std::sync::mpsc::Receiver<OverlayMsg>,
     frame_tick_needed: bool,
     z_order_tick_needed: bool,
-    z_order_interval: Duration,
+    maintenance_interval: Duration,
 ) -> OverlayWake {
     if frame_tick_needed {
         return OverlayWake::Frame;
     }
 
     if z_order_tick_needed {
-        return match rx.recv_timeout(z_order_interval) {
+        return match rx.recv_timeout(maintenance_interval) {
             Ok(msg) => OverlayWake::Message(msg),
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => OverlayWake::ZOrderTimeout,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => OverlayWake::MaintenanceTimeout,
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => OverlayWake::Disconnected,
         };
     }
@@ -504,20 +527,24 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
     )
     .ok();
 
-    // Make the window fully click-through using the Shape extension (empty input region).
-    // This is the X11 equivalent of WS_EX_TRANSPARENT on Windows. Note that
-    // ShapeMask with a None pixmap would *reset* the input shape to the full
-    // window — an empty rectangle list is how an empty region is expressed.
-    conn.shape_rectangles(
-        SO::SET,
-        SK::INPUT,
-        x11rb::protocol::xproto::ClipOrdering::UNSORTED,
-        win,
-        0,
-        0,
-        &[],
-    )
-    .ok();
+    // Start with empty input AND bounding regions before mapping. The empty
+    // input region makes the window click-through. The empty bounding region
+    // prevents a zero-filled full-screen window from appearing opaque black on
+    // bare/non-composited X servers before the first cursor command paints a
+    // real visible shape. ShapeMask with a None pixmap would reset either
+    // region to the full window; an empty rectangle list expresses emptiness.
+    for shape_kind in [SK::INPUT, SK::BOUNDING] {
+        conn.shape_rectangles(
+            SO::SET,
+            shape_kind,
+            x11rb::protocol::xproto::ClipOrdering::UNSORTED,
+            win,
+            0,
+            0,
+            &[],
+        )
+        .ok();
+    }
 
     conn.map_window(win).ok();
     conn.flush().ok();
@@ -525,10 +552,12 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
     // Main render loop at ~60 Hz while pixels can change. When every cursor is
     // quiescent, block on the command channel and leave the last frame intact.
     let frame_dur = Duration::from_millis(16);
+    let z_order_interval = Duration::from_millis(80);
     let mut last_tick = Instant::now();
     let mut last_ztick = Instant::now();
     let mut frame_tick_needed = false;
     let mut z_order_tick_needed = false;
+    let mut maintenance_interval = z_order_interval;
     let mut last_pinned: Option<u64> = None;
     let z_enforcer = X11ZOrderEnforcer { conn: &conn, win };
 
@@ -537,31 +566,43 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
         // XShape update, or XPutImage until a command arrives. A resting visible
         // cursor still wakes cheaply every 80 ms to preserve the documented
         // X11 z-order contract without repainting.
-        let (first_msg, z_order_timeout) = match wait_for_overlay_work(
+        let (first_msg, maintenance_timeout) = match wait_for_overlay_work(
             &rx,
             frame_tick_needed,
             z_order_tick_needed,
-            Duration::from_millis(80),
+            maintenance_interval,
         ) {
             OverlayWake::Frame => (None, false),
             OverlayWake::Message(msg) => (Some(msg), false),
-            OverlayWake::ZOrderTimeout => (None, true),
+            OverlayWake::MaintenanceTimeout => (None, true),
             OverlayWake::Disconnected => break,
         };
 
-        let woke_from_idle = first_msg.is_some() || z_order_timeout;
+        let woke_for_command = first_msg.is_some();
         let now = Instant::now();
-        let dt = if woke_from_idle {
+        let dt = if woke_for_command {
             // A blocking receive can span an arbitrarily long idle period. Do
             // not fast-forward the first animation frame after waking.
             0.0
+        } else if maintenance_timeout {
+            // A maintenance wake is the cheap clock for both z-order and a
+            // future idle-hide deadline. No animation is active in this branch,
+            // so it is safe to advance the full elapsed interval without painting.
+            now.duration_since(last_tick).as_secs_f64()
         } else {
             now.duration_since(last_tick).as_secs_f64().min(0.05)
         };
         last_tick = now;
 
         // Drain commands and tick.
-        let (arrived, pinned_wid, had_msg, next_frame_tick_needed, next_z_order_tick_needed) = {
+        let (
+            arrived,
+            pinned_wid,
+            had_msg,
+            next_frame_tick_needed,
+            next_z_order_tick_needed,
+            next_maintenance_interval,
+        ) = {
             let mut guard = RENDER.lock().unwrap();
             if let Some(map) = guard.as_mut() {
                 let mut had_msg = false;
@@ -578,7 +619,7 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
                     }
                 }
                 let mut arrived = Vec::new();
-                if frame_tick_needed || had_msg {
+                if frame_tick_needed || had_msg || maintenance_timeout {
                     for (key, rs) in map.cursors.iter_mut() {
                         if rs.tick(dt) {
                             arrived.push(key.clone());
@@ -592,28 +633,27 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
                     .and_then(|rs| rs.core.pinned_wid);
                 let next_frame_tick_needed = render_map_needs_frame_tick(map);
                 let next_z_order_tick_needed = render_map_needs_z_order_tick(map);
+                let next_maintenance_interval =
+                    render_map_idle_wait_interval(map, z_order_interval);
                 (
                     arrived,
                     pinned_wid,
                     had_msg,
                     next_frame_tick_needed,
                     next_z_order_tick_needed,
+                    next_maintenance_interval,
                 )
             } else {
                 break;
             }
         };
 
-        // Reassert immediately after a command or target change, then every
-        // 80 ms while animation/fade frames are active. Quiescent cursors keep
-        // their last z-order until a new command wakes the loop.
+        // Reassert immediately after a command or target change, then at most
+        // every 80 ms while any cursor remains visible. Maintenance wakes keep
+        // that stacking contract without authorizing a repaint.
         let pin_changed = pinned_wid != last_pinned;
         last_pinned = pinned_wid;
-        if had_msg
-            || pin_changed
-            || z_order_timeout
-            || (frame_tick_needed && last_ztick.elapsed() >= Duration::from_millis(80))
-        {
+        if had_msg || pin_changed || last_ztick.elapsed() >= z_order_interval {
             last_ztick = Instant::now();
             z_enforcer.reassert(pinned_wid);
         }
@@ -656,6 +696,7 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
 
         frame_tick_needed = next_frame_tick_needed;
         z_order_tick_needed = next_z_order_tick_needed;
+        maintenance_interval = next_maintenance_interval;
         if frame_tick_needed {
             let elapsed = Instant::now().duration_since(last_tick);
             if let Some(remaining) = frame_dur.checked_sub(elapsed) {
@@ -892,11 +933,11 @@ mod tests {
     }
 
     #[test]
-    fn resting_cursor_wait_times_out_for_z_order_maintenance() {
+    fn resting_cursor_wait_times_out_for_maintenance() {
         let (_tx, rx) = std::sync::mpsc::channel();
         assert!(matches!(
             wait_for_overlay_work(&rx, false, true, Duration::from_millis(1)),
-            OverlayWake::ZOrderTimeout
+            OverlayWake::MaintenanceTimeout
         ));
     }
 
@@ -948,7 +989,7 @@ mod tests {
     }
 
     #[test]
-    fn completed_move_and_idle_fade_return_to_quiescence() {
+    fn completed_move_parks_during_opaque_idle_delay() {
         let mut map = default_render_map();
         let cursor = map.cursors.get_mut("default").unwrap();
         // The public animate path seeds a newly created cursor near its target
@@ -978,7 +1019,53 @@ mod tests {
             cursor.core.idle_alpha,
             cursor.core.pos,
         );
+        assert_eq!(cursor.core.idle_alpha, 1.0);
         assert!(!render_map_needs_frame_tick(&map));
+        assert!(render_map_needs_z_order_tick(&map));
+    }
+
+    #[test]
+    fn idle_heartbeat_starts_fade_then_frames_return_to_quiescence() {
+        let mut map = default_render_map();
+        {
+            let cursor = map.cursors.get_mut("default").unwrap();
+            cursor.core.pos = (100.0, 100.0);
+            cursor.core.motion.idle_hide_ms = 500.0;
+
+            // Cheap 80 ms z-order heartbeats advance the idle clock without
+            // requesting expensive frame paints during the opaque delay.
+            for _ in 0..6 {
+                cursor.tick(0.08);
+                assert!(!cursor.needs_frame_tick());
+                assert_eq!(cursor.core.idle_alpha, 1.0);
+            }
+        }
+
+        // Shorten the final maintenance wait to the exact fade deadline rather
+        // than overshooting by another 80 ms and jumping the first alpha frame.
+        let deadline_wait = render_map_idle_wait_interval(&map, Duration::from_millis(80));
+        assert!(deadline_wait >= Duration::from_millis(19));
+        assert!(deadline_wait <= Duration::from_millis(21));
+
+        let cursor = map.cursors.get_mut("default").unwrap();
+        cursor.tick(deadline_wait.as_secs_f64());
+        assert!(cursor.needs_frame_tick());
+        assert_eq!(cursor.core.idle_alpha, 1.0);
+
+        cursor.tick(1.0 / 60.0);
+        assert!(cursor.core.idle_alpha < 1.0);
+
+        for _ in 0..60 {
+            cursor.tick(1.0 / 60.0);
+            if !cursor.needs_frame_tick() {
+                break;
+            }
+        }
+
+        assert!(!cursor.needs_frame_tick());
+        assert_eq!(cursor.core.idle_alpha, 0.0);
+        assert!(!render_map_needs_frame_tick(&map));
+        assert!(!render_map_needs_z_order_tick(&map));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
@@ -360,6 +360,7 @@ impl RenderState {
     /// tick can change pixels. A brand-new sentinel cursor is deliberately
     /// quiescent, so an idle MCP server can block on the command channel
     /// instead of repainting a full-screen X11 pixmap at 60 fps.
+    #[cfg(target_os = "linux")]
     fn needs_frame_tick(&self) -> bool {
         let fade_start = self.core.motion.idle_hide_ms / 1000.0;
         self.core.path.is_some()
@@ -373,17 +374,71 @@ impl RenderState {
     }
 }
 
+#[cfg(target_os = "linux")]
 fn render_map_needs_frame_tick(map: &RenderMap) -> bool {
     map.cursors.values().any(RenderState::needs_frame_tick)
 }
 
+#[cfg(target_os = "linux")]
 fn render_map_needs_z_order_tick(map: &RenderMap) -> bool {
     map.cursors
         .values()
         .any(|rs| rs.core.visible && rs.core.idle_alpha >= 0.004 && rs.core.pos.0 >= -100.0)
 }
 
-fn render_map_idle_wait_interval(map: &RenderMap, max_interval: Duration) -> Duration {
+#[cfg(target_os = "linux")]
+fn tick_render_map(map: &mut RenderMap, dt: f64) -> Vec<CursorKey> {
+    let mut arrived = Vec::new();
+    for (key, rs) in map.cursors.iter_mut() {
+        if rs.tick(dt) {
+            arrived.push(key.clone());
+        }
+    }
+    arrived
+}
+
+#[cfg(target_os = "linux")]
+fn scheduled_tick_dt(elapsed_dt: f64, maintenance_timeout: bool) -> f64 {
+    if maintenance_timeout {
+        // No animation is active while parked, so maintenance must advance the
+        // complete idle interval rather than the 50 ms animation safety cap.
+        elapsed_dt
+    } else {
+        elapsed_dt.min(0.05)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn apply_messages_after_wake(
+    map: &mut RenderMap,
+    first_msg: Option<OverlayMsg>,
+    rx: &std::sync::mpsc::Receiver<OverlayMsg>,
+    parked_elapsed: Option<f64>,
+) -> (Vec<CursorKey>, bool) {
+    // Advance pre-existing quiescent state before commands mutate it. This
+    // preserves each cursor's independent idle clock while ensuring newly
+    // commanded animations render their initial frame at dt=0.
+    let arrived = parked_elapsed
+        .map(|dt| tick_render_map(map, dt))
+        .unwrap_or_default();
+    let mut had_msg = false;
+    if let Some(msg) = first_msg {
+        had_msg = true;
+        if let Some(key) = apply_msg(map, msg) {
+            map.last_active = Some(key);
+        }
+    }
+    while let Ok(msg) = rx.try_recv() {
+        had_msg = true;
+        if let Some(key) = apply_msg(map, msg) {
+            map.last_active = Some(key);
+        }
+    }
+    (arrived, had_msg)
+}
+
+#[cfg(target_os = "linux")]
+fn render_map_idle_wait_interval(map: &RenderMap) -> Option<Duration> {
     map.cursors
         .values()
         .filter_map(|rs| {
@@ -401,9 +456,23 @@ fn render_map_idle_wait_interval(map: &RenderMap, max_interval: Duration) -> Dur
             let remaining = core.motion.idle_hide_ms / 1000.0 - core.idle_secs;
             (remaining.is_finite() && remaining > 0.0).then(|| Duration::from_secs_f64(remaining))
         })
-        .fold(max_interval, Duration::min)
+        .min()
 }
 
+#[cfg(target_os = "linux")]
+fn next_maintenance_deadline(
+    last_tick: Instant,
+    last_z_order_tick: Instant,
+    z_order_interval: Duration,
+    idle_wait_interval: Option<Duration>,
+) -> Instant {
+    let z_order_deadline = last_z_order_tick + z_order_interval;
+    idle_wait_interval
+        .map(|interval| (last_tick + interval).min(z_order_deadline))
+        .unwrap_or(z_order_deadline)
+}
+
+#[cfg(target_os = "linux")]
 enum OverlayWake {
     Frame,
     Message(OverlayMsg),
@@ -411,18 +480,20 @@ enum OverlayWake {
     Disconnected,
 }
 
+#[cfg(target_os = "linux")]
 fn wait_for_overlay_work(
     rx: &std::sync::mpsc::Receiver<OverlayMsg>,
     frame_tick_needed: bool,
     z_order_tick_needed: bool,
-    maintenance_interval: Duration,
+    maintenance_deadline: Instant,
 ) -> OverlayWake {
     if frame_tick_needed {
         return OverlayWake::Frame;
     }
 
     if z_order_tick_needed {
-        return match rx.recv_timeout(maintenance_interval) {
+        let timeout = maintenance_deadline.saturating_duration_since(Instant::now());
+        return match rx.recv_timeout(timeout) {
             Ok(msg) => OverlayWake::Message(msg),
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => OverlayWake::MaintenanceTimeout,
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => OverlayWake::Disconnected,
@@ -557,7 +628,7 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
     let mut last_ztick = Instant::now();
     let mut frame_tick_needed = false;
     let mut z_order_tick_needed = false;
-    let mut maintenance_interval = z_order_interval;
+    let mut maintenance_deadline = last_ztick + z_order_interval;
     let mut last_pinned: Option<u64> = None;
     let z_enforcer = X11ZOrderEnforcer { conn: &conn, win };
 
@@ -570,7 +641,7 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
             &rx,
             frame_tick_needed,
             z_order_tick_needed,
-            maintenance_interval,
+            maintenance_deadline,
         ) {
             OverlayWake::Frame => (None, false),
             OverlayWake::Message(msg) => (Some(msg), false),
@@ -580,18 +651,8 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
 
         let woke_for_command = first_msg.is_some();
         let now = Instant::now();
-        let dt = if woke_for_command {
-            // A blocking receive can span an arbitrarily long idle period. Do
-            // not fast-forward the first animation frame after waking.
-            0.0
-        } else if maintenance_timeout {
-            // A maintenance wake is the cheap clock for both z-order and a
-            // future idle-hide deadline. No animation is active in this branch,
-            // so it is safe to advance the full elapsed interval without painting.
-            now.duration_since(last_tick).as_secs_f64()
-        } else {
-            now.duration_since(last_tick).as_secs_f64().min(0.05)
-        };
+        let elapsed_dt = now.duration_since(last_tick).as_secs_f64();
+        let tick_dt = scheduled_tick_dt(elapsed_dt, maintenance_timeout);
         last_tick = now;
 
         // Drain commands and tick.
@@ -601,30 +662,18 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
             had_msg,
             next_frame_tick_needed,
             next_z_order_tick_needed,
-            next_maintenance_interval,
+            next_idle_wait_interval,
         ) = {
             let mut guard = RENDER.lock().unwrap();
             if let Some(map) = guard.as_mut() {
-                let mut had_msg = false;
-                if let Some(msg) = first_msg {
-                    had_msg = true;
-                    if let Some(key) = apply_msg(map, msg) {
-                        map.last_active = Some(key);
-                    }
-                }
-                while let Ok(msg) = rx.try_recv() {
-                    had_msg = true;
-                    if let Some(key) = apply_msg(map, msg) {
-                        map.last_active = Some(key);
-                    }
-                }
-                let mut arrived = Vec::new();
-                if frame_tick_needed || had_msg || maintenance_timeout {
-                    for (key, rs) in map.cursors.iter_mut() {
-                        if rs.tick(dt) {
-                            arrived.push(key.clone());
-                        }
-                    }
+                let (mut arrived, had_msg) = apply_messages_after_wake(
+                    map,
+                    first_msg,
+                    &rx,
+                    woke_for_command.then_some(elapsed_dt),
+                );
+                if !woke_for_command && (frame_tick_needed || had_msg || maintenance_timeout) {
+                    arrived.extend(tick_render_map(map, tick_dt));
                 }
                 let pinned_wid = map
                     .last_active
@@ -633,15 +682,14 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
                     .and_then(|rs| rs.core.pinned_wid);
                 let next_frame_tick_needed = render_map_needs_frame_tick(map);
                 let next_z_order_tick_needed = render_map_needs_z_order_tick(map);
-                let next_maintenance_interval =
-                    render_map_idle_wait_interval(map, z_order_interval);
+                let next_idle_wait_interval = render_map_idle_wait_interval(map);
                 (
                     arrived,
                     pinned_wid,
                     had_msg,
                     next_frame_tick_needed,
                     next_z_order_tick_needed,
-                    next_maintenance_interval,
+                    next_idle_wait_interval,
                 )
             } else {
                 break;
@@ -696,7 +744,12 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
 
         frame_tick_needed = next_frame_tick_needed;
         z_order_tick_needed = next_z_order_tick_needed;
-        maintenance_interval = next_maintenance_interval;
+        maintenance_deadline = next_maintenance_deadline(
+            last_tick,
+            last_ztick,
+            z_order_interval,
+            next_idle_wait_interval,
+        );
         if frame_tick_needed {
             let elapsed = Instant::now().duration_since(last_tick);
             if let Some(remaining) = frame_dur.checked_sub(elapsed) {
@@ -915,7 +968,7 @@ mod tests {
         tx.send(test_message()).unwrap();
 
         assert!(matches!(
-            wait_for_overlay_work(&rx, true, false, Duration::from_millis(1)),
+            wait_for_overlay_work(&rx, true, false, Instant::now()),
             OverlayWake::Frame
         ));
         assert!(rx.try_recv().is_ok());
@@ -926,7 +979,7 @@ mod tests {
         let (tx, rx) = std::sync::mpsc::channel();
         tx.send(test_message()).unwrap();
 
-        match wait_for_overlay_work(&rx, false, false, Duration::from_millis(1)) {
+        match wait_for_overlay_work(&rx, false, false, Instant::now()) {
             OverlayWake::Message(OverlayMsg::Cmd(keyed)) => assert_eq!(keyed.key, "default"),
             _ => panic!("idle wait did not return the queued command"),
         }
@@ -936,9 +989,39 @@ mod tests {
     fn resting_cursor_wait_times_out_for_maintenance() {
         let (_tx, rx) = std::sync::mpsc::channel();
         assert!(matches!(
-            wait_for_overlay_work(&rx, false, true, Duration::from_millis(1)),
+            wait_for_overlay_work(&rx, false, true, Instant::now() + Duration::from_millis(1)),
             OverlayWake::MaintenanceTimeout
         ));
+    }
+
+    #[test]
+    fn expired_maintenance_deadline_times_out_immediately() {
+        let (_tx, rx) = std::sync::mpsc::channel();
+        let deadline = Instant::now() - Duration::from_millis(1);
+        assert!(matches!(
+            wait_for_overlay_work(&rx, false, true, deadline),
+            OverlayWake::MaintenanceTimeout
+        ));
+    }
+
+    #[test]
+    fn idle_deadline_is_anchored_to_the_state_tick() {
+        let state_tick = Instant::now();
+        let z_order_tick = state_tick + Duration::from_millis(5);
+        let deadline = next_maintenance_deadline(
+            state_tick,
+            z_order_tick,
+            Duration::from_millis(80),
+            Some(Duration::from_millis(20)),
+        );
+
+        assert_eq!(deadline, state_tick + Duration::from_millis(20));
+    }
+
+    #[test]
+    fn maintenance_tick_advances_the_full_elapsed_interval() {
+        assert_eq!(scheduled_tick_dt(0.08, true), 0.08);
+        assert_eq!(scheduled_tick_dt(0.08, false), 0.05);
     }
 
     #[test]
@@ -946,14 +1029,14 @@ mod tests {
         let (tx, rx) = std::sync::mpsc::channel();
         drop(tx);
         assert!(matches!(
-            wait_for_overlay_work(&rx, false, false, Duration::from_millis(1)),
+            wait_for_overlay_work(&rx, false, false, Instant::now()),
             OverlayWake::Disconnected
         ));
 
         let (tx, rx) = std::sync::mpsc::channel();
         drop(tx);
         assert!(matches!(
-            wait_for_overlay_work(&rx, false, true, Duration::from_millis(1)),
+            wait_for_overlay_work(&rx, false, true, Instant::now()),
             OverlayWake::Disconnected
         ));
     }
@@ -1025,6 +1108,41 @@ mod tests {
     }
 
     #[test]
+    fn commands_for_one_cursor_do_not_starve_another_cursors_idle_deadline() {
+        let mut map = default_render_map();
+        {
+            let cursor = map.cursors.get_mut("default").unwrap();
+            cursor.core.pos = (10.0, 10.0);
+            cursor.core.motion.idle_hide_ms = 500.0;
+        }
+        let other = render_state_for_key(&map.template, "other");
+        map.cursors.insert("other".to_owned(), other);
+        let (_tx, rx) = std::sync::mpsc::channel();
+
+        // Model five command-channel wakeups at 100 ms intervals. The parked
+        // elapsed time must advance all existing cursors before each unrelated
+        // command is applied.
+        for _ in 0..5 {
+            let (arrived, had_msg) = apply_messages_after_wake(
+                &mut map,
+                Some(OverlayMsg::Cmd(KeyedOverlayCommand {
+                    key: "other".to_owned(),
+                    cmd: OverlayCommand::SetPalette(Palette::for_instance("other")),
+                })),
+                &rx,
+                Some(0.1),
+            );
+            assert!(arrived.is_empty());
+            assert!(had_msg);
+        }
+
+        let cursor = map.cursors.get("default").unwrap();
+        assert!(cursor.core.idle_secs >= 0.5);
+        assert!(cursor.needs_frame_tick());
+        assert_eq!(cursor.core.idle_alpha, 1.0);
+    }
+
+    #[test]
     fn idle_heartbeat_starts_fade_then_frames_return_to_quiescence() {
         let mut map = default_render_map();
         {
@@ -1043,7 +1161,7 @@ mod tests {
 
         // Shorten the final maintenance wait to the exact fade deadline rather
         // than overshooting by another 80 ms and jumping the first alpha frame.
-        let deadline_wait = render_map_idle_wait_interval(&map, Duration::from_millis(80));
+        let deadline_wait = render_map_idle_wait_interval(&map).unwrap();
         assert!(deadline_wait >= Duration::from_millis(19));
         assert!(deadline_wait <= Duration::from_millis(21));
 

--- a/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
@@ -1199,6 +1199,66 @@ mod tests {
     }
 
     #[test]
+    fn click_pulse_drained_after_maintenance_timeout_starts_at_zero_dt() {
+        let mut map = default_render_map();
+        let cursor = map.cursors.get_mut("default").unwrap();
+        cursor.core.pos = (20.0, 20.0);
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        tx.send(OverlayMsg::Cmd(KeyedOverlayCommand {
+            key: "default".to_owned(),
+            cmd: OverlayCommand::ClickPulse { x: 40.0, y: 50.0 },
+        }))
+        .unwrap();
+
+        let (arrived, had_msg) = process_render_wake(&mut map, None, &rx, 0.08, true, false);
+
+        assert!(arrived.is_empty());
+        assert!(had_msg);
+        let cursor = &map.cursors["default"].core;
+        assert_eq!(cursor.pos, (40.0, 50.0));
+        assert_eq!(cursor.click_t, Some(0.0));
+    }
+
+    #[test]
+    fn active_frame_replacement_does_not_return_stale_arrival() {
+        let mut map = default_render_map();
+        {
+            let cursor = map.cursors.get_mut("default").unwrap();
+            cursor.core.pos = (20.0, 20.0);
+            cursor.apply_command(OverlayCommand::MoveTo {
+                x: 80.0,
+                y: 80.0,
+                end_heading_radians: 0.0,
+            });
+            let old_path_len = cursor.core.path.as_ref().unwrap().length.max(1.0);
+            // The old path would finish on the next 16 ms tick if active-frame
+            // wakes were globally changed to tick before applying commands.
+            cursor.core.dist = old_path_len - 0.001;
+        }
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        tx.send(OverlayMsg::Cmd(KeyedOverlayCommand {
+            key: "default".to_owned(),
+            cmd: OverlayCommand::MoveTo {
+                x: 250.0,
+                y: 150.0,
+                end_heading_radians: 0.0,
+            },
+        }))
+        .unwrap();
+
+        let (arrived, had_msg) = process_render_wake(&mut map, None, &rx, 0.016, false, true);
+
+        assert!(arrived.is_empty());
+        assert!(had_msg);
+        let cursor = &map.cursors["default"].core;
+        let replacement_path_len = cursor.path.as_ref().unwrap().length.max(1.0);
+        assert!(cursor.dist > 0.0);
+        assert!(cursor.dist < replacement_path_len);
+    }
+
+    #[test]
     fn idle_heartbeat_starts_fade_then_frames_return_to_quiescence() {
         let mut map = default_render_map();
         {


### PR DESCRIPTION
## Summary

- make the Linux/X11 cursor overlay event-driven when no cursor pixels can change
- retain a cheap 80 ms z-order heartbeat for a visible resting cursor without rebuilding or uploading the full-screen pixmap
- park through the default opaque idle-hide delay, then wake at the exact fade deadline and resume frame cadence only for the 180 ms fade
- preserve each cursor's idle clock when unrelated cursor commands wake the shared loop
- map the initial full-screen X11 window with an empty bounding shape so it cannot appear black before the first command
- preserve final-frame-before-arrival ordering and add focused scheduler/quiescence regression coverage

Fixes #2204.

## Context

The X11 overlay loop currently allocates and paints a full-screen `tiny_skia::Pixmap`, converts RGBA to BGRA, updates the X Shape region, and calls `XPutImage` every 16 ms even when the default cursor is still at its off-screen sentinel or all cursors have settled. It also keeps painting unchanged pixels throughout the default 20-second opaque idle-hide delay after an action.

That is the Linux equivalent of the idle render-loop problem addressed for macOS in #1865 and Windows in #1933. It leaves `cua-overlay-x11` consuming a substantial fraction of one core while an MCP session is idle.

## Implementation

- Add `needs_frame_tick` state detection for active animation, spring settle, click pulse, and the actual 180 ms idle fade.
- Block on the overlay command channel when no cursor needs another frame.
- Advance pre-existing quiescent cursors by the full parked interval before applying a command, while starting newly commanded animations at `dt = 0`, including commands drained immediately after a maintenance timeout.
- Drain queued command bursts before ticking and rendering.
- Render commands, active animation/fade frames, and the final settle/clear frame only.
- Fire arrival notifications after the destination frame has been painted, preserving the prior ordering contract.
- Keep X11 z-order maintenance active for visible resting cursors through an 80 ms bounded receive, but do not repaint on maintenance-only wakeups.
- Use absolute `Instant` deadlines for z-order maintenance and idle fade. The remaining timeout is calculated immediately before blocking, so synchronous X11 maintenance cannot extend the deadline.
- Advance the full elapsed interval on maintenance wakes rather than applying the 50 ms active-animation safety cap.
- Keep scheduler-only helpers and time imports Linux-gated so the crate's non-Linux stubs continue to compile.
- Set both `SK::INPUT` and `SK::BOUNDING` to empty before mapping the initial overlay window, preventing an opaque black full-screen window on bare/non-composited X servers.
- Exit cleanly when all command senders disconnect.

## Regression coverage

Added focused Linux tests for:

- sentinel/default cursor quiescence
- active cursor frame requirements
- completed move parking during the opaque idle-hide delay
- deadline-aligned transition into idle fade and final fade quiescence
- completed click-pulse quiescence
- visible resting cursor z-order-only scheduling
- active-frame command preservation
- idle command wakeup
- maintenance timeout wakeup
- absolute deadline anchoring and expired-deadline handling
- full elapsed-time accounting on maintenance wakes
- multi-cursor idle-deadline progress during unrelated command traffic
- timeout-boundary command drains starting `MoveTo` and `ClickPulse` at `dt = 0`
- active-frame replacement ordering without stale arrival completion
- disconnected sender handling in blocking and timeout modes
- explicit `SetEnabled(false)` final-clear rendering followed by frame- and z-order-scheduler parking

## Validation boundary

The exact patched build passed the scheduler suite and isolated Xvfb startup, idle, action, and settle checks. A later live 1920×2160 X11 Hermes session became unusable after an unreturned high-level Chrome hotkey request and required an orderly reboot. No kernel lockup, OOM, GPU fault, or coredump evidence survived, and the hotkey is not itself an overlay animation command, so I cannot attribute that incident to this patch. I am recording it as a validation boundary rather than a regression claim: this PR proves quiescent overlay parking, not full live desktop/input-stack safety. `--no-overlay` remains the safest operational fallback pending broader watchdog-backed live validation.

## Follow-ups / out of scope

- **Active renderer optimization:** active animation still allocates, scans, shapes, and uploads a full-root BGRA frame at roughly 60 Hz. On a 1920×2160 root that is 15.82 MiB per frame, or about 0.93 GiB/s of raw pixel data before allocation, shape, GC, and compositor overhead. Dirty-region or cursor-sized uploads, GC reuse, shape simplification, and lazy X11 overlay startup should be handled separately rather than expanding this scheduler-focused fix.
- **X11 telemetry and fail-safe behavior:** the current paint path discards `shape_rectangles`, `put_image`, `free_gc`, and `flush` failures. Rate-limited diagnostics, sampled asynchronous error checks, and a safe clear/unmap/park policy after repeated failures belong in a focused follow-up.
- One-shot CLI/CDP/AT-SPI/background-input errors are separate from this overlay loop and should not be conflated with the idle-render fix.

## Validation

The exact PR diff was replayed, independently reviewed, and full-workspace tested on current `upstream/main` at `763a6ea21b86ad5f8a70ab2581edee1dd7370efa`. The published head is `12fc510c7` and remains mergeable. Current upstream main has since advanced to `95c68886`; a fresh merge-tree check is clean, and upstream has not changed `platform-linux/src/overlay.rs` since this PR's base. Issue #2204 remains open, current main still contains the unconditional 16 ms X11 paint loop, and open-PR searches found no competing Linux idle-overlay repair. The latest upstream commit only changes browser telemetry files; it does not touch the Linux overlay.

- `cargo test --workspace` on the patch replayed onto current main — passed
- `cargo test --workspace --no-run` on the patch replayed onto current main — passed
- `cargo test --workspace -- --test-threads=1` on the exact published branch — passed
- `cargo test -p platform-linux --lib` — 113 passed
- `cargo test -p platform-linux overlay --lib` — 19 scheduler/overlay tests passed
- `cargo check -p platform-linux --target x86_64-pc-windows-gnu` — passed; the previous head failed with unresolved `Duration` references
- `cargo test -p cursor-overlay` — 12 passed; doc tests passed
- `cargo build -p cua-driver` — passed
- `rustfmt --edition 2021 crates/platform-linux/src/overlay.rs --check` — passed
- `git diff --check` — passed

The repository-wide `cargo fmt --all --check` and strict Clippy gates are not green on current upstream main because of pre-existing formatting and lint debt outside this diff. The changed Linux overlay file passes its focused formatter check, and strict Clippy reported no diagnostic in the newly added scheduler/deadline code.

Isolated Xvfb verification used bare 1920×2160 debug builds and sampled the `cua-overlay-x11` thread from `/proc/<pid>/task`:

| State | Overlay thread CPU | CPU ticks over sample |
| --- | ---: | ---: |
| Unpatched `upstream/main` (`b088628a`; overlay identical at current `763a6ea2`), initial MCP idle | 97.0% | 194 over 2 s |
| Patched, initial MCP idle | 0.0% | 0 over 2 s |
| Patched, active/settling cursor | 96.99% | 97 over 1 s |
| Patched, opaque portion of default idle-hide delay after an action | 0.0% | 0 over 2 s |

Before the first command, `xwininfo -shape` reported `Window shape extents: 0x0+0+0`, proving the mapped startup overlay has an empty bounding region. The MCP initialize and `move_cursor` calls succeeded, the patched driver remained alive, and all Xvfb/driver processes were cleaned up afterward.
