### PR TITLE
feat(cua-bench): add Windows support to the Daytona provider

### DIFF
--- a/libs/cua-bench/README.md
+++ b/libs/cua-bench/README.md
@@ -89,3 +89,25 @@ Output:
 - Average step time
 - Average finish time
 - Step throughput (steps/sec)
+
+## Daytona provider
+
+On Linux, use `--provider-type daytona` with `DAYTONA_API_KEY` and a Daytona
+snapshot that starts supervisord and cua-computer-server. The environment and
+solver run together in that sandbox.
+
+### Windows
+
+For Windows, the Daytona sandbox is only the desktop. The solver runs locally
+against the sandbox's signed preview URL, so API keys and other solver secrets
+stay local.
+
+```bash
+DAYTONA_API_KEY=... cb run task <task-dir> --provider-type daytona --platform windows-qemu --image <windows-snapshot> --wait
+```
+
+Instead of `--image`, set `DAYTONA_WINDOWS_SNAPSHOT` to the Windows snapshot
+name. The snapshot builder, `python -m
+cua_bench.scripts.build_daytona_windows_snapshot`, creates
+`cua-bench-windows-v1` by default. Tasks with
+`setup_config.os_type == "windows"` automatically select the Windows platform.

--- a/libs/cua-bench/cua_bench/runner/daytona_harness.py
+++ b/libs/cua-bench/cua_bench/runner/daytona_harness.py
@@ -1,11 +1,12 @@
 """Daytona harness for cua-bench.
 
-Manages a single Daytona sandbox that runs both the env (KiCad desktop) and
-the solver.  Computer-use traffic stays on localhost:8000 inside the sandbox,
-so no base64-exec calls are needed during the agent loop.
+Manages a Daytona desktop sandbox with either a co-located Linux solver or a
+local solver for Windows. Computer-use traffic uses cua-computer-server on
+port 8000.
 """
 
 import os
+import subprocess
 import threading
 import time
 import urllib.request
@@ -272,6 +273,37 @@ class DaytonaHarness:
             if exit_code is not None:
                 logs = getattr(result, "output", "") or ""
                 return exit_code, logs
+
+    def run_solver_locally(
+        self,
+        command: List[str],
+        env_vars: Dict[str, str],
+        timeout: Optional[int] = None,
+    ) -> tuple[int, str]:
+        """Run a local solver subprocess and return its exit code and output."""
+        print(
+            f"    [harness] Launching solver locally: {' '.join(command)}",
+            flush=True,
+        )
+        process = subprocess.Popen(
+            command,
+            env={**os.environ, **env_vars},
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        if timeout == 0:
+            timeout = None
+        try:
+            output, _ = process.communicate(timeout=timeout)
+            return process.returncode, output or ""
+        except subprocess.TimeoutExpired:
+            process.kill()
+            output, _ = process.communicate()
+            timeout_note = "[harness] Solver timed out.\n"
+            if output and not output.endswith("\n"):
+                output += "\n"
+            return -1, (output or "") + timeout_note
 
     async def cleanup(self) -> None:
         """Delete the sandbox."""

--- a/libs/cua-bench/cua_bench/runner/daytona_harness.py
+++ b/libs/cua-bench/cua_bench/runner/daytona_harness.py
@@ -6,6 +6,7 @@ port 8000.
 """
 
 import os
+import signal
 import subprocess
 import threading
 import time
@@ -291,14 +292,16 @@ class DaytonaHarness:
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
+            start_new_session=True,
         )
-        if timeout == 0:
-            timeout = None
         try:
             output, _ = process.communicate(timeout=timeout)
             return process.returncode, output or ""
         except subprocess.TimeoutExpired:
-            process.kill()
+            try:
+                os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                process.kill()
             output, _ = process.communicate()
             timeout_note = "[harness] Solver timed out.\n"
             if output and not output.endswith("\n"):

--- a/libs/cua-bench/cua_bench/runner/task_runner.py
+++ b/libs/cua-bench/cua_bench/runner/task_runner.py
@@ -9,7 +9,7 @@ import os
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional
 
 from ..sessions.providers.local_environment import check_image_exists, pull_image
 from .docker_utils import (
@@ -974,6 +974,77 @@ class TaskRunner:
             remove_on_exit=False,  # Don't auto-remove, we need logs
         )
 
+    def _build_daytona_solver_command(
+        self,
+        python_exe: str,
+        task_path: str,
+        task_index: int,
+        oracle: bool,
+        agent: Optional[str],
+        agent_import_path: Optional[str],
+        model: Optional[str],
+        max_steps: int,
+    ) -> List[str]:
+        """Build the solver argv shared by Linux and Windows Daytona runs."""
+        command = [python_exe, "-m", "cua_bench.batch.solver", task_path]
+        command.extend(["--task-index", str(task_index)])
+        if not oracle:
+            command.append("--eval")
+            if agent:
+                command.extend(["--agent", agent])
+            if agent_import_path:
+                command.extend(["--agent-import-path", agent_import_path])
+            if model:
+                command.extend(["--model", model])
+            if max_steps:
+                command.extend(["--max-steps", str(max_steps)])
+        return command
+
+    def _daytona_sigterm_guard(self, harness) -> Callable[[], None]:
+        """Install the Daytona cleanup SIGTERM handler and return its restorer."""
+        import signal
+
+        def _sigterm_handler(signum, frame):
+            import asyncio as _asyncio
+            import threading
+
+            def _cleanup():
+                loop = _asyncio.new_event_loop()
+                loop.run_until_complete(harness.cleanup())
+                loop.close()
+
+            thread = threading.Thread(target=_cleanup, daemon=True)
+            thread.start()
+            thread.join(timeout=15)
+            raise SystemExit(0)
+
+        old_handler = signal.signal(signal.SIGTERM, _sigterm_handler)
+
+        def _restore() -> None:
+            signal.signal(signal.SIGTERM, old_handler)
+
+        return _restore
+
+    def _daytona_task_result(
+        self,
+        exit_code: int,
+        agent_logs: str,
+        output_dir: Optional[str],
+    ) -> TaskResult:
+        """Persist Daytona solver logs and construct the successful run result."""
+        if output_dir and agent_logs:
+            log_file = Path(output_dir) / "run.log"
+            log_file.parent.mkdir(parents=True, exist_ok=True)
+            log_file.write_text(agent_logs, encoding="utf-8", errors="replace")
+
+        return TaskResult(
+            success=exit_code == 0,
+            exit_code=exit_code,
+            agent_logs=agent_logs,
+            env_logs="",
+            output_dir=output_dir,
+        )
+
     async def _run_task_daytona(
         self,
         env_path: Path,
@@ -990,19 +1061,28 @@ class TaskRunner:
         output_dir: Optional[str],
         timeout: Optional[int],
     ) -> "TaskResult":
-        """Run a task inside a single Daytona sandbox.
-
-        Both the env desktop (supervisord/VNC/cua-computer-server) and the
-        solver run inside the same sandbox.  Computer-use traffic stays on
-        localhost:8000, so no base64-exec calls are needed during the agent loop.
+        """Run a Daytona task: Linux co-locates desktop and solver in the sandbox;
+        Windows (environment types with ``os_type`` "windows") dispatches to
+        ``_run_task_daytona_windows``, where the sandbox is the desktop only and
+        the solver runs locally.
         """
-        import signal
-        import sys
-
         from .daytona_harness import DaytonaHarness
+
         os_type = ENV_CONFIGS.get(env_type or "", {}).get("os_type", "linux")
         if os_type == "windows":
-            return await self._run_task_daytona_windows(env_path, task_index, env_type, golden_name, agent, agent_image, agent_command, agent_import_path, model, max_steps, oracle, output_dir, timeout)
+            return await self._run_task_daytona_windows(
+                env_path=env_path,
+                task_index=task_index,
+                golden_name=golden_name,
+                agent=agent,
+                agent_command=agent_command,
+                agent_import_path=agent_import_path,
+                model=model,
+                max_steps=max_steps,
+                oracle=oracle,
+                output_dir=output_dir,
+                timeout=timeout,
+            )
 
         harness = DaytonaHarness()
 
@@ -1024,38 +1104,18 @@ class TaskRunner:
                 creation_env[key] = val
 
         # Build solver command (runs inside the sandbox, so use sandbox python)
-        if agent_command:
-            command = agent_command
-        else:
-            command = ["/opt/venv/bin/python3", "-m", "cua_bench.batch.solver", "/tmp/task_env"]
-            command.extend(["--task-index", str(task_index)])
-            if not oracle:
-                command.append("--eval")
-                if agent:
-                    command.extend(["--agent", agent])
-                if agent_import_path:
-                    command.extend(["--agent-import-path", agent_import_path])
-                if model:
-                    command.extend(["--model", model])
-                if max_steps:
-                    command.extend(["--max-steps", str(max_steps)])
+        command = agent_command or self._build_daytona_solver_command(
+            python_exe="/opt/venv/bin/python3",
+            task_path="/tmp/task_env",
+            task_index=task_index,
+            oracle=oracle,
+            agent=agent,
+            agent_import_path=agent_import_path,
+            model=model,
+            max_steps=max_steps,
+        )
 
-        # Register SIGTERM handler so cleanup runs even when the process is killed
-        def _sigterm_handler(signum, frame):
-            import asyncio as _asyncio
-            import threading
-
-            def _cleanup():
-                loop = _asyncio.new_event_loop()
-                loop.run_until_complete(harness.cleanup())
-                loop.close()
-
-            t = threading.Thread(target=_cleanup, daemon=True)
-            t.start()
-            t.join(timeout=15)
-            raise SystemExit(0)
-
-        old_handler = signal.signal(signal.SIGTERM, _sigterm_handler)
+        restore_sigterm = self._daytona_sigterm_guard(harness)
 
         try:
             # 1. Start sandbox (bootstraps supervisord, waits for computer-server ready)
@@ -1095,19 +1155,7 @@ class TaskRunner:
                 ),
             )
 
-            # 6. Write logs to local output_dir if requested
-            if output_dir and agent_logs:
-                log_file = Path(output_dir) / "run.log"
-                log_file.parent.mkdir(parents=True, exist_ok=True)
-                log_file.write_text(agent_logs, encoding="utf-8", errors="replace")
-
-            return TaskResult(
-                success=exit_code == 0,
-                exit_code=exit_code,
-                agent_logs=agent_logs,
-                env_logs="",
-                output_dir=output_dir,
-            )
+            return self._daytona_task_result(exit_code, agent_logs, output_dir)
 
         except Exception as e:
             return TaskResult(
@@ -1120,17 +1168,15 @@ class TaskRunner:
             )
 
         finally:
-            signal.signal(signal.SIGTERM, old_handler)
+            restore_sigterm()
             await harness.cleanup()
 
     async def _run_task_daytona_windows(
         self,
         env_path: Path,
         task_index: int,
-        env_type: str,
         golden_name: Optional[str],
         agent: Optional[str],
-        agent_image: Optional[str],
         agent_command: Optional[List[str]],
         agent_import_path: Optional[str],
         model: Optional[str],
@@ -1140,16 +1186,19 @@ class TaskRunner:
         timeout: Optional[int],
     ) -> "TaskResult":
         """Run a task locally against a Daytona Windows desktop sandbox."""
-        import signal
         import sys
 
         from .daytona_harness import DaytonaHarness
 
         _raw = golden_name or ""
-        windows_image = ENV_CONFIGS["windows-qemu"]["image"]
+        # Values that mean "no Daytona snapshot was chosen": env-type keys and
+        # Docker images are Docker-provider defaults, not Daytona snapshot names.
+        _non_snapshot = set(ENV_CONFIGS) | {
+            config["image"] for config in ENV_CONFIGS.values()
+        }
         snapshot = (
             _raw
-            if _raw and _raw not in ENV_CONFIGS and _raw != windows_image
+            if _raw and _raw not in _non_snapshot
             else os.environ.get("DAYTONA_WINDOWS_SNAPSHOT")
         )
         if not snapshot:
@@ -1162,43 +1211,18 @@ class TaskRunner:
 
         harness = DaytonaHarness()
 
-        if agent_command:
-            command = agent_command
-        else:
-            command = [
-                sys.executable,
-                "-m",
-                "cua_bench.batch.solver",
-                str(env_path.resolve()),
-                "--task-index",
-                str(task_index),
-            ]
-            if not oracle:
-                command.append("--eval")
-                if agent:
-                    command.extend(["--agent", agent])
-                if agent_import_path:
-                    command.extend(["--agent-import-path", agent_import_path])
-                if model:
-                    command.extend(["--model", model])
-                if max_steps:
-                    command.extend(["--max-steps", str(max_steps)])
+        command = agent_command or self._build_daytona_solver_command(
+            python_exe=sys.executable,
+            task_path=str(env_path.resolve()),
+            task_index=task_index,
+            oracle=oracle,
+            agent=agent,
+            agent_import_path=agent_import_path,
+            model=model,
+            max_steps=max_steps,
+        )
 
-        def _sigterm_handler(signum, frame):
-            import asyncio as _asyncio
-            import threading
-
-            def _cleanup():
-                loop = _asyncio.new_event_loop()
-                loop.run_until_complete(harness.cleanup())
-                loop.close()
-
-            t = threading.Thread(target=_cleanup, daemon=True)
-            t.start()
-            t.join(timeout=15)
-            raise SystemExit(0)
-
-        old_handler = signal.signal(signal.SIGTERM, _sigterm_handler)
+        restore_sigterm = self._daytona_sigterm_guard(harness)
 
         try:
             # The solver runs locally, so secrets never enter the sandbox.
@@ -1222,22 +1246,11 @@ class TaskRunner:
                 lambda: harness.run_solver_locally(
                     command=command,
                     env_vars=solver_env,
-                    timeout=timeout or 0,
+                    timeout=timeout,
                 ),
             )
 
-            if output_dir and agent_logs:
-                log_file = Path(output_dir) / "run.log"
-                log_file.parent.mkdir(parents=True, exist_ok=True)
-                log_file.write_text(agent_logs, encoding="utf-8", errors="replace")
-
-            return TaskResult(
-                success=exit_code == 0,
-                exit_code=exit_code,
-                agent_logs=agent_logs,
-                env_logs="",
-                output_dir=output_dir,
-            )
+            return self._daytona_task_result(exit_code, agent_logs, output_dir)
 
         except Exception as e:
             return TaskResult(
@@ -1250,7 +1263,7 @@ class TaskRunner:
             )
 
         finally:
-            signal.signal(signal.SIGTERM, old_handler)
+            restore_sigterm()
             await harness.cleanup()
 
     async def _cleanup_task(self, task_id: str) -> None:

--- a/libs/cua-bench/cua_bench/runner/task_runner.py
+++ b/libs/cua-bench/cua_bench/runner/task_runner.py
@@ -1000,6 +1000,9 @@ class TaskRunner:
         import sys
 
         from .daytona_harness import DaytonaHarness
+        os_type = ENV_CONFIGS.get(env_type or "", {}).get("os_type", "linux")
+        if os_type == "windows":
+            return await self._run_task_daytona_windows(env_path, task_index, env_type, golden_name, agent, agent_image, agent_command, agent_import_path, model, max_steps, oracle, output_dir, timeout)
 
         harness = DaytonaHarness()
 
@@ -1093,6 +1096,136 @@ class TaskRunner:
             )
 
             # 6. Write logs to local output_dir if requested
+            if output_dir and agent_logs:
+                log_file = Path(output_dir) / "run.log"
+                log_file.parent.mkdir(parents=True, exist_ok=True)
+                log_file.write_text(agent_logs, encoding="utf-8", errors="replace")
+
+            return TaskResult(
+                success=exit_code == 0,
+                exit_code=exit_code,
+                agent_logs=agent_logs,
+                env_logs="",
+                output_dir=output_dir,
+            )
+
+        except Exception as e:
+            return TaskResult(
+                success=False,
+                exit_code=-1,
+                agent_logs="",
+                env_logs="",
+                output_dir=output_dir,
+                error=str(e),
+            )
+
+        finally:
+            signal.signal(signal.SIGTERM, old_handler)
+            await harness.cleanup()
+
+    async def _run_task_daytona_windows(
+        self,
+        env_path: Path,
+        task_index: int,
+        env_type: str,
+        golden_name: Optional[str],
+        agent: Optional[str],
+        agent_image: Optional[str],
+        agent_command: Optional[List[str]],
+        agent_import_path: Optional[str],
+        model: Optional[str],
+        max_steps: int,
+        oracle: bool,
+        output_dir: Optional[str],
+        timeout: Optional[int],
+    ) -> "TaskResult":
+        """Run a task locally against a Daytona Windows desktop sandbox."""
+        import signal
+        import sys
+
+        from .daytona_harness import DaytonaHarness
+
+        _raw = golden_name or ""
+        windows_image = ENV_CONFIGS["windows-qemu"]["image"]
+        snapshot = (
+            _raw
+            if _raw and _raw not in ENV_CONFIGS and _raw != windows_image
+            else os.environ.get("DAYTONA_WINDOWS_SNAPSHOT")
+        )
+        if not snapshot:
+            raise ValueError(
+                "Windows on Daytona needs a Daytona Windows snapshot with "
+                "cua-computer-server baked in; pass --image <snapshot> or set "
+                "DAYTONA_WINDOWS_SNAPSHOT. See the snapshot build script: "
+                "python -m cua_bench.scripts.build_daytona_windows_snapshot"
+            )
+
+        harness = DaytonaHarness()
+
+        if agent_command:
+            command = agent_command
+        else:
+            command = [
+                sys.executable,
+                "-m",
+                "cua_bench.batch.solver",
+                str(env_path.resolve()),
+                "--task-index",
+                str(task_index),
+            ]
+            if not oracle:
+                command.append("--eval")
+                if agent:
+                    command.extend(["--agent", agent])
+                if agent_import_path:
+                    command.extend(["--agent-import-path", agent_import_path])
+                if model:
+                    command.extend(["--model", model])
+                if max_steps:
+                    command.extend(["--max-steps", str(max_steps)])
+
+        def _sigterm_handler(signum, frame):
+            import asyncio as _asyncio
+            import threading
+
+            def _cleanup():
+                loop = _asyncio.new_event_loop()
+                loop.run_until_complete(harness.cleanup())
+                loop.close()
+
+            t = threading.Thread(target=_cleanup, daemon=True)
+            t.start()
+            t.join(timeout=15)
+            raise SystemExit(0)
+
+        old_handler = signal.signal(signal.SIGTERM, _sigterm_handler)
+
+        try:
+            # The solver runs locally, so secrets never enter the sandbox.
+            api_url = await harness.start_env_sandbox(image=snapshot, env_vars={})
+
+            solver_env: Dict[str, str] = {
+                "CUA_ENV_API_URL": api_url,
+                "CUA_ENV_VNC_URL": "",
+                "CUA_ENV_TYPE": "windows",
+                "CUA_PROVIDER": "daytona",
+                "BATCH_TASK_INDEX": str(task_index),
+                "BATCH_TASK_COUNT": "1",
+                "CUA_TELEMETRY_DISABLED": "1",
+            }
+            if output_dir:
+                solver_env["CUA_OUTPUT_DIR"] = output_dir
+
+            loop = asyncio.get_event_loop()
+            exit_code, agent_logs = await loop.run_in_executor(
+                None,
+                lambda: harness.run_solver_locally(
+                    command=command,
+                    env_vars=solver_env,
+                    timeout=timeout or 0,
+                ),
+            )
+
             if output_dir and agent_logs:
                 log_file = Path(output_dir) / "run.log"
                 log_file.parent.mkdir(parents=True, exist_ok=True)

--- a/libs/cua-bench/cua_bench/scripts/build_daytona_windows_snapshot.py
+++ b/libs/cua-bench/cua_bench/scripts/build_daytona_windows_snapshot.py
@@ -1,0 +1,585 @@
+#!/usr/bin/env python3
+"""Build and validate the Daytona Windows snapshot used by cua-bench.
+
+The base Windows VM must have an unlocked interactive desktop. Toolbox commands
+run as SYSTEM, so this builder installs cua-computer-server system-wide and
+registers an interactive logon task for the desktop user.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+from daytona_sdk import (
+    CreateSandboxFromSnapshotParams,
+    Daytona,
+    DaytonaConfig,
+    DaytonaNotFoundError,
+)
+
+DEFAULT_NAME = "cua-bench-windows-v1"
+DEFAULT_BASE = "windows-medium"
+SERVER_PORT = 8000
+PYTHON_PATH = r"C:\Program Files\Python313\python.exe"
+SERVER_DIR = r"C:\ProgramData\cua-bench"
+LAUNCHER_PATH = SERVER_DIR + r"\start-computer-server.ps1"
+SERVER_LOG_PATH = SERVER_DIR + r"\computer-server.log"
+TASK_NAME = "Cua-Computer-Server"
+PYTHON_INSTALLER_URL = (
+    "https://www.python.org/ftp/python/3.13.9/python-3.13.9-amd64.exe"
+)
+
+
+@dataclass(frozen=True)
+class Timeouts:
+    create: float
+    command: int
+    health: float
+    snapshot: float
+    cleanup: float
+
+
+@dataclass(frozen=True)
+class ScreenshotEvidence:
+    status_code: int
+    encoded_size: int
+    decoded_size: int
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--name", default=DEFAULT_NAME, help="snapshot name")
+    parser.add_argument("--base", default=DEFAULT_BASE, help="base Windows snapshot")
+    parser.add_argument(
+        "--keep-sandbox",
+        action="store_true",
+        help="keep the builder sandbox after the run for debugging",
+    )
+    parser.add_argument("--create-timeout", type=float, default=600)
+    parser.add_argument("--command-timeout", type=int, default=900)
+    parser.add_argument("--health-timeout", type=float, default=600)
+    parser.add_argument("--snapshot-timeout", type=float, default=1_200)
+    parser.add_argument("--cleanup-timeout", type=float, default=300)
+    return parser.parse_args()
+
+
+def make_client() -> Daytona:
+    """Create a Daytona client from the same environment variables as the harness."""
+    api_key = os.environ.get("DAYTONA_API_KEY")
+    if not api_key:
+        raise RuntimeError("DAYTONA_API_KEY is required")
+    api_url = os.environ.get("DAYTONA_API_URL")
+    config = (
+        DaytonaConfig(api_key=api_key, api_url=api_url)
+        if api_url
+        else DaytonaConfig(api_key=api_key)
+    )
+    return Daytona(config)
+
+
+def powershell_command(script: str) -> str:
+    """Encode a PowerShell command without relying on shell quoting."""
+    script = "$ProgressPreference = 'SilentlyContinue'\n" + script
+    encoded = base64.b64encode(script.encode("utf-16-le")).decode("ascii")
+    return (
+        "powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass "
+        f"-EncodedCommand {encoded}"
+    )
+
+
+def exec_checked(sandbox: Any, command: str, timeout: int, description: str) -> str:
+    """Run one synchronous toolbox command and require a zero exit code."""
+    response = sandbox.process.exec(command, timeout=timeout)
+    output = response.result or ""
+    if response.exit_code != 0:
+        raise RuntimeError(
+            f"{description} failed with exit code {response.exit_code}:\n{output}"
+        )
+    return output
+
+
+def discover_interactive_user(sandbox: Any, timeout: int) -> tuple[str, str]:
+    """Return the interactive username and the diagnostic query output."""
+    query_output = exec_checked(
+        sandbox,
+        powershell_command("query user 2>&1; exit 0"),
+        timeout,
+        "interactive-user query",
+    )
+    for line in query_output.splitlines():
+        columns = line.lstrip().lstrip(">").split()
+        if columns and any(column.lower() == "active" for column in columns[1:]):
+            return columns[0].split("\\")[-1], query_output
+
+    fallback = exec_checked(
+        sandbox,
+        powershell_command(
+            "$user = (Get-CimInstance Win32_ComputerSystem).UserName; "
+            "if (-not $user) { throw 'No interactive desktop user is logged on' }; $user"
+        ),
+        timeout,
+        "interactive-user fallback",
+    ).strip()
+    if not fallback:
+        raise RuntimeError(f"No active interactive user found. query user output:\n{query_output}")
+    return fallback.split("\\")[-1], query_output
+
+
+def install_server(sandbox: Any, timeout: int) -> None:
+    """Ensure system Python exists, then install and import-check the server."""
+    exec_checked(
+        sandbox,
+        powershell_command(
+            f"""
+$ErrorActionPreference = 'Stop'
+if (-not (Test-Path '{PYTHON_PATH}')) {{
+    $installer = Join-Path $env:TEMP 'python-3.13.9-amd64.exe'
+    try {{
+        Invoke-WebRequest -UseBasicParsing -Uri '{PYTHON_INSTALLER_URL}' -OutFile $installer
+        $arguments = '/quiet InstallAllUsers=1 PrependPath=1 Include_launcher=1 Include_pip=1 TargetDir="C:\\Program Files\\Python313"'
+        $process = Start-Process -FilePath $installer -ArgumentList $arguments -Wait -PassThru
+        if ($process.ExitCode -ne 0) {{
+            throw "Python installer exited with code $($process.ExitCode)"
+        }}
+    }} finally {{
+        Remove-Item $installer -Force -ErrorAction SilentlyContinue
+    }}
+}}
+if (-not (Test-Path '{PYTHON_PATH}')) {{
+    throw 'System Python was not found after installation'
+}}
+& '{PYTHON_PATH}' --version
+if (-not $?) {{ throw 'System Python did not execute' }}
+"""
+        ),
+        timeout,
+        "system Python verification",
+    )
+    # The all-users installer restarts guest services after returning. Let the
+    # toolbox settle before starting the comparatively long dependency install.
+    time.sleep(15)
+    exec_checked(
+        sandbox,
+        "cmd.exe /d /c echo toolbox-ready",
+        timeout,
+        "post-Python-install toolbox check",
+    )
+    exec_checked(
+        sandbox,
+        powershell_command(
+            f"& '{PYTHON_PATH}' -m pip install --upgrade --quiet "
+            "--disable-pip-version-check --no-warn-script-location "
+            "--progress-bar off cua-computer-server; "
+            "if (-not $?) { throw 'pip install failed' }"
+        ),
+        timeout,
+        "cua-computer-server installation",
+    )
+    exec_checked(
+        sandbox,
+        powershell_command(
+            f"& '{PYTHON_PATH}' -c \"import computer_server\"; "
+            "if (-not $?) { throw 'computer_server import failed' }"
+        ),
+        timeout,
+        "computer_server import check",
+    )
+
+
+def launcher_contents() -> bytes:
+    """Return the restart-forever server launcher stored in the snapshot."""
+    script = f"""$ErrorActionPreference = 'Continue'
+$env:PYTHONUNBUFFERED = '1'
+$LogFile = '{SERVER_LOG_PATH}'
+while ($true) {{
+    "[$(Get-Date -Format o)] Starting cua-computer-server" | Out-File -FilePath $LogFile -Append -Encoding utf8
+    & '{PYTHON_PATH}' -m computer_server --host 0.0.0.0 --port {SERVER_PORT} --log-level info 2>&1 | Out-File -FilePath $LogFile -Append -Encoding utf8
+    $code = $LASTEXITCODE
+    "[$(Get-Date -Format o)] Server exited with code $code; restarting in 5 seconds" | Out-File -FilePath $LogFile -Append -Encoding utf8
+    Start-Sleep -Seconds 5
+}}
+"""
+    return script.encode("utf-8-sig")
+
+
+def configure_autostart(sandbox: Any, username: str, timeout: int) -> None:
+    """Open the firewall and register the interactive scheduled task."""
+    exec_checked(
+        sandbox,
+        powershell_command(
+            f"New-Item -ItemType Directory -Path '{SERVER_DIR}' -Force | Out-Null; "
+            "$rule = Get-NetFirewallRule -DisplayName 'Cua Computer Server 8000' "
+            "-ErrorAction SilentlyContinue; if ($rule) { $rule | Remove-NetFirewallRule }; "
+            "New-NetFirewallRule -DisplayName 'Cua Computer Server 8000' "
+            f"-Direction Inbound -Action Allow -Protocol TCP -LocalPort {SERVER_PORT} | Out-Null"
+        ),
+        timeout,
+        "firewall configuration",
+    )
+    sandbox.fs.upload_file(launcher_contents(), LAUNCHER_PATH, timeout=timeout)
+
+    setup_script = f"""
+$ErrorActionPreference = 'Stop'
+$TaskName = '{TASK_NAME}'
+$UserId = "$env:COMPUTERNAME\\{username}"
+$existing = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if ($existing) {{
+    Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+}}
+$action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument '-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "{LAUNCHER_PATH}"'
+$trigger = New-ScheduledTaskTrigger -AtLogOn -User $UserId
+$principal = New-ScheduledTaskPrincipal -UserId $UserId -LogonType Interactive -RunLevel Highest
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 1) -ExecutionTimeLimit (New-TimeSpan -Days 365) -Hidden
+Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Force | Out-Null
+Start-ScheduledTask -TaskName $TaskName
+Start-Sleep -Seconds 2
+Get-ScheduledTask -TaskName $TaskName | Select-Object TaskName, State | Format-List
+"""
+    output = exec_checked(
+        sandbox,
+        powershell_command(setup_script),
+        timeout,
+        "scheduled-task configuration",
+    )
+    print(f"Scheduled task registered for {username}:\n{output.strip()}", flush=True)
+
+
+def open_json(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+    """GET a JSON endpoint and return its status and decoded object."""
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return response.status, json.loads(response.read().decode("utf-8"))
+
+
+def wait_for_health(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+    """Poll the external signed preview URL until the Windows server is healthy."""
+    deadline = time.monotonic() + timeout
+    last_error = "no response"
+    while time.monotonic() < deadline:
+        try:
+            status_code, payload = open_json(f"{url.rstrip('/')}/status", timeout=15)
+            if (
+                status_code == 200
+                and payload.get("status") == "ok"
+                and payload.get("os_type") == "windows"
+            ):
+                return status_code, payload
+            last_error = f"HTTP {status_code}: {payload!r}"
+        except (OSError, ValueError, urllib.error.HTTPError) as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+        time.sleep(5)
+    raise TimeoutError(f"computer-server health check timed out: {last_error}")
+
+
+def screenshot_check(url: str) -> ScreenshotEvidence:
+    """Prove the server can capture the interactive desktop through /cmd."""
+    body = json.dumps({"command": "screenshot", "params": {}}).encode("utf-8")
+    request = urllib.request.Request(
+        f"{url.rstrip('/')}/cmd",
+        data=body,
+        headers={"Accept": "text/plain", "Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=120) as response:
+        status_code = response.status
+        response_text = response.read().decode("utf-8")
+
+    payloads = []
+    for line in response_text.splitlines():
+        if line.startswith("data:"):
+            payloads.append(json.loads(line.removeprefix("data:").strip()))
+    if not payloads:
+        raise RuntimeError(f"screenshot response was not an SSE data payload: {response_text[:1000]}")
+    payload = payloads[-1]
+    image_data = payload.get("image_data")
+    if payload.get("success") is not True or not isinstance(image_data, str):
+        raise RuntimeError(f"screenshot command failed: {payload!r}")
+    try:
+        decoded = base64.b64decode(image_data, validate=True)
+    except (ValueError, binascii.Error) as exc:
+        raise RuntimeError("screenshot image_data is not valid base64") from exc
+    if len(decoded) < 10_000:
+        raise RuntimeError(f"screenshot was unexpectedly small: {len(decoded)} decoded bytes")
+    return ScreenshotEvidence(status_code, len(image_data), len(decoded))
+
+
+def print_diagnostics(sandbox: Any, query_output: str, timeout: int) -> None:
+    """Print actionable Windows desktop and server diagnostics after a failure."""
+    print(f"query user output:\n{query_output.strip()}", file=sys.stderr, flush=True)
+    try:
+        task_output = exec_checked(
+            sandbox,
+            powershell_command(
+                f"Get-ScheduledTask -TaskName '{TASK_NAME}' -ErrorAction SilentlyContinue | "
+                "Get-ScheduledTaskInfo | Format-List *; "
+                f"Get-ScheduledTask -TaskName '{TASK_NAME}' -ErrorAction SilentlyContinue | "
+                "Select-Object TaskName,State,Principal | Format-List"
+            ),
+            timeout,
+            "scheduled-task diagnostics",
+        )
+        print(f"scheduled task diagnostics:\n{task_output.strip()}", file=sys.stderr, flush=True)
+    except Exception as exc:
+        print(f"scheduled task diagnostics failed: {exc}", file=sys.stderr, flush=True)
+    try:
+        log = sandbox.fs.download_file(SERVER_LOG_PATH, timeout).decode(
+            "utf-8", errors="replace"
+        )
+        print(f"server log tail:\n{log[-8_000:]}", file=sys.stderr, flush=True)
+    except Exception as exc:
+        print(f"server log download failed: {exc}", file=sys.stderr, flush=True)
+
+
+def delete_existing_snapshot(daytona: Daytona, name: str, timeout: float) -> None:
+    """Delete an existing owned snapshot so this build is deterministic."""
+    try:
+        snapshot = daytona.snapshot.get(name)
+    except DaytonaNotFoundError:
+        return
+    print(f"Deleting existing snapshot {name!r}", flush=True)
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            daytona.snapshot.delete(snapshot)
+            return
+        except DaytonaNotFoundError:
+            return
+        except Exception:
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(5)
+            try:
+                snapshot = daytona.snapshot.get(name)
+            except DaytonaNotFoundError:
+                return
+
+
+def state_value(state: Any) -> str:
+    """Normalize SDK string enums across daytona-sdk versions."""
+    return str(getattr(state, "value", state)).lower()
+
+
+def wait_for_active_snapshot(
+    daytona: Daytona,
+    sandbox: Any,
+    name: str,
+    started_at: float,
+    timeout: float,
+) -> Any:
+    """Wait for a live-sandbox snapshot record, treating initial 404s as pending."""
+    deadline = started_at + timeout
+    absent_after_transition_at: float | None = None
+    last_state = "unknown"
+    while time.monotonic() < deadline:
+        try:
+            snapshot = daytona.snapshot.get(name)
+        except DaytonaNotFoundError:
+            sandbox.refresh_data()
+            last_state = state_value(sandbox.state)
+            if last_state != "snapshotting":
+                absent_after_transition_at = absent_after_transition_at or time.monotonic()
+                if time.monotonic() - absent_after_transition_at > 60:
+                    raise RuntimeError(
+                        f"snapshot {name!r} never appeared after sandbox left "
+                        f"snapshotting (state={last_state})"
+                    )
+            time.sleep(5)
+            continue
+
+        state = state_value(snapshot.state)
+        if state == "active":
+            return snapshot
+        if state in {"error", "build_failed", "failed"}:
+            raise RuntimeError(f"snapshot {name!r} failed with state={snapshot.state}")
+        absent_after_transition_at = None
+        last_state = state
+        time.sleep(5)
+    raise TimeoutError(f"snapshot {name!r} did not become active; last state={last_state}")
+
+
+def create_live_snapshot(
+    daytona: Daytona,
+    sandbox: Any,
+    name: str,
+    timeout: float,
+) -> Any:
+    """Stop the VM, snapshot its disk, and wait for the record to become active."""
+    started_at = time.monotonic()
+    sandbox.stop(timeout=min(timeout, 300))
+    remaining = max(1, timeout - (time.monotonic() - started_at))
+    sandbox._experimental_create_snapshot(name, timeout=remaining)
+    return wait_for_active_snapshot(daytona, sandbox, name, started_at, timeout)
+
+
+def delete_sandbox(daytona: Daytona, sandbox: Any, timeout: float) -> None:
+    """Delete a sandbox, retrying while it is in a transitional state."""
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            sandbox.delete(timeout=min(60, max(1, deadline - time.monotonic())), wait=True)
+            return
+        except DaytonaNotFoundError:
+            return
+        except Exception as exc:
+            last_error = exc
+            time.sleep(5)
+            try:
+                sandbox = daytona.get(sandbox.id)
+            except DaytonaNotFoundError:
+                return
+    raise TimeoutError(f"failed to delete sandbox {sandbox.id}: {last_error}")
+
+
+def create_sandbox(daytona: Daytona, snapshot: str, label: str, timeout: float) -> Any:
+    """Create a no-autostop sandbox from a snapshot and wait for it to start."""
+    params = CreateSandboxFromSnapshotParams(
+        snapshot=snapshot,
+        auto_stop_interval=0,
+        labels={label: "true"},
+    )
+    sandbox = daytona.create(params, timeout=timeout)
+    sandbox.wait_for_sandbox_start(timeout=timeout)
+    try:
+        sandbox.set_autostop_interval(0)
+    except Exception as exc:
+        print(f"Warning: could not enforce auto-stop interval: {exc}", flush=True)
+    return sandbox
+
+
+def validate_snapshot(daytona: Daytona, name: str, timeouts: Timeouts) -> None:
+    """Restore one fresh VM and prove server autostart plus interactive capture."""
+    sandbox = None
+    try:
+        sandbox = create_sandbox(
+            daytona,
+            name,
+            "cua-bench-snapshot-validator",
+            timeouts.create,
+        )
+        signed = sandbox.create_signed_preview_url(
+            SERVER_PORT,
+            expires_in_seconds=max(3_600, int(timeouts.health + 600)),
+        )
+        status_code, status = wait_for_health(signed.url, timeouts.health)
+        screenshot = screenshot_check(signed.url)
+        print(
+            "Validation evidence: "
+            f"/status HTTP {status_code} {status!r}; "
+            f"screenshot HTTP {screenshot.status_code}, "
+            f"base64_chars={screenshot.encoded_size}, "
+            f"decoded_bytes={screenshot.decoded_size}",
+            flush=True,
+        )
+    finally:
+        if sandbox is not None:
+            delete_sandbox(daytona, sandbox, timeouts.cleanup)
+
+
+def main() -> int:
+    """Build, externally verify, snapshot, restore, and validate the Windows VM."""
+    args = parse_args()
+    timeouts = Timeouts(
+        create=args.create_timeout,
+        command=args.command_timeout,
+        health=args.health_timeout,
+        snapshot=args.snapshot_timeout,
+        cleanup=args.cleanup_timeout,
+    )
+    daytona = make_client()
+    timings: dict[str, float] = {}
+    builder = None
+    snapshot = None
+    query_output = "query user was not run"
+
+    delete_existing_snapshot(daytona, args.name, timeouts.cleanup)
+    try:
+        phase = time.monotonic()
+        builder = create_sandbox(
+            daytona,
+            args.base,
+            "cua-bench-snapshot-builder",
+            timeouts.create,
+        )
+        timings["create"] = time.monotonic() - phase
+        print(f"Builder sandbox: {builder.id}", flush=True)
+
+        username, query_output = discover_interactive_user(builder, timeouts.command)
+        print(f"Interactive user: {username}\n{query_output.strip()}", flush=True)
+
+        phase = time.monotonic()
+        install_server(builder, timeouts.command)
+        timings["install"] = time.monotonic() - phase
+
+        phase = time.monotonic()
+        configure_autostart(builder, username, timeouts.command)
+        signed = builder.create_signed_preview_url(
+            SERVER_PORT,
+            expires_in_seconds=max(3_600, int(timeouts.snapshot + timeouts.health + 600)),
+        )
+        try:
+            status_code, status = wait_for_health(signed.url, timeouts.health)
+            screenshot = screenshot_check(signed.url)
+        except Exception:
+            print_diagnostics(builder, query_output, timeouts.command)
+            raise
+        timings["configure_and_probe"] = time.monotonic() - phase
+        print(
+            "Builder evidence: "
+            f"/status HTTP {status_code} {status!r}; "
+            f"screenshot HTTP {screenshot.status_code}, "
+            f"base64_chars={screenshot.encoded_size}, "
+            f"decoded_bytes={screenshot.decoded_size}",
+            flush=True,
+        )
+
+        phase = time.monotonic()
+        snapshot = create_live_snapshot(daytona, builder, args.name, timeouts.snapshot)
+        timings["snapshot"] = time.monotonic() - phase
+        print(f"Snapshot active: {snapshot.name} state={snapshot.state}", flush=True)
+    finally:
+        if builder is not None and not args.keep_sandbox:
+            phase = time.monotonic()
+            delete_sandbox(daytona, builder, timeouts.cleanup)
+            timings["builder_cleanup"] = time.monotonic() - phase
+        elif builder is not None:
+            print(f"Keeping builder sandbox {builder.id}", flush=True)
+
+    if snapshot is None:
+        return 1
+
+    try:
+        phase = time.monotonic()
+        validate_snapshot(daytona, args.name, timeouts)
+        timings["validate"] = time.monotonic() - phase
+    except Exception:
+        print("Validation failed; deleting the unusable snapshot", file=sys.stderr, flush=True)
+        try:
+            daytona.snapshot.delete(snapshot)
+        except Exception as exc:
+            print(f"Snapshot cleanup also failed: {exc}", file=sys.stderr, flush=True)
+        raise
+
+    print(
+        "Timings: " + ", ".join(f"{name}={seconds:.3f}s" for name, seconds in timings.items()),
+        flush=True,
+    )
+    print(f"Snapshot ready: {args.name}", flush=True)
+    print(f"Usage: export DAYTONA_WINDOWS_SNAPSHOT={args.name}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds Windows support to cua-bench's Daytona provider. Linux runs are untouched: the existing co-located path (desktop + solver in one sandbox) still handles every non-Windows env type; Windows dispatches to a new flow.

## Design: the sandbox is the desktop, the solver stays local

The Docker provider's Windows route (`windows-qemu`, QEMU + KVM inside a container) cannot run on Daytona: sandboxes there do not expose `/dev/kvm`. Daytona does, however, offer native Windows VM sandboxes (`windows` sandbox class). So on Windows:

- The Daytona sandbox is a Windows VM created from a snapshot that auto-starts `cua-computer-server` on port 8000.
- The solver runs as a local subprocess where the harness runs, with `CUA_ENV_API_URL` pointed at the sandbox's signed preview URL. This matches the Docker provider's default topology (solver outside the env, talking HTTP).
- The agent loop makes zero Daytona exec calls — the original reason the Linux path co-locates the solver (SDK base64-exec wrapping tripping abuse detection) does not apply to plain HTTP against the preview URL.
- LLM API keys never enter the sandbox; on the Linux path they are baked into sandbox env at creation, on Windows they stay in the local solver process.

No changes were needed in `solver.py`, `computers/remote.py`, or `libs/python/computer`: the solver already reads `CUA_ENV_API_URL`/`CUA_ENV_TYPE` from env, and Daytona preview URLs carry their auth token in the hostname (`https://8000-<token>.<proxy-domain>`), so `RemoteDesktopSession`'s hostname/port URL reconstruction preserves it.

## Usage

```bash
export DAYTONA_API_KEY=...
cb run task <task-dir> --provider-type daytona --platform windows-qemu --image <windows-snapshot> --wait
```

`--image` names a Daytona Windows snapshot (falls back to `DAYTONA_WINDOWS_SNAPSHOT`; a clear error explains both if neither is set). Tasks whose `setup_config.os_type` is `windows` auto-select the platform, as with the Docker provider.

## Snapshot builder

`python -m cua_bench.scripts.build_daytona_windows_snapshot` produces the snapshot from a stock Daytona Windows base (`windows-medium` by default): installs CPython 3.13 if absent, `pip install cua-computer-server`, opens TCP 8000, and registers a Scheduled Task (`-LogonType Interactive`, restart-forever launcher) modeled on `libs/qemu-docker/windows/src/vm/setup/setup-cua-server.ps1` — with `--host 0.0.0.0` added, since the current CLI default binds 127.0.0.1 (the windows-qemu setup script omits `--host` and would have the same reachability problem against the current server). The builder then validates the artifact by creating a fresh sandbox from the finished snapshot and requiring `/status` → `{"status":"ok","os_type":"windows"}` plus a real screenshot (>10 KB decoded) through the preview URL, proving the server auto-starts on a restored VM. Builder and validation sandboxes are deleted afterwards.

Platform behaviors the builder works around (all observed live, July 2026; may age as Daytona's daemon updates):

- The process **sessions** API does not work on Windows guests: session commands never report an exit code, and subsequent commands fail with `failed to write command: write |1: The pipe is being closed.` The builder uses synchronous `process.exec` exclusively.
- Filesystem snapshots of a running Windows VM are rejected with `Filesystem-only snapshots require the VM sandbox to be stopped (STOPPED)`; the builder stops the VM before snapshotting.
- After the snapshot request, the snapshot record 404s while the job is queued/running; the builder treats 404 as pending and detects failure by the sandbox leaving the snapshotting state without a record appearing.
- The computer-server needs an interactive, unlocked desktop for capture and input (a Session-0 service cannot screenshot), hence the Interactive-logon Scheduled Task rather than a Windows service.

## Verification (live, Daytona cloud)

- End-to-end through the real CLI: `cb run task <smoke-task> --provider-type daytona --platform windows-qemu --image cua-bench-windows-v1 --oracle --wait` — sandbox ready in ~40 s from command start (~23 s create→ready), solver launched locally, remote desktop reported 1024×768, screenshots ~430 KB PNG, a mouse move and an ESC key press executed through `WindowsComputerInterface` without error, evaluation returned 1.0, process exit 0, and the sandbox was confirmed deleted afterwards. Total wall time ~62 s including cleanup. Run twice (before and after review-driven refactoring).
- Negative control: with no `--image` and no `DAYTONA_WINDOWS_SNAPSHOT`, the run fails before creating any sandbox with guidance naming both options and the builder module.
- Local-solver timeout kills the whole process group (`start_new_session` + `killpg`); verified with a solver that spawned a child holding the stdout pipe.
- Linux behavior preservation: the solver argv builder shared by both paths was asserted byte-identical to the previous inline construction for oracle, full-flag, and `max_steps=0` cases.

## Limitations

- Requires the org to have Windows sandbox-class access on Daytona (currently US region).
- The built-in custom-computer agents (`cua_agent`, `opencua_agent`, `qwen35_agent`, `qwen3vl_agent`) advertise their environment as `"linux"` regardless of session OS — pre-existing hardcoding, unchanged here; oracle/eval runs and agents that read the session directly are unaffected.
- The Windows snapshot carries a bare desktop plus the computer-server; task-specific applications need builder extensions.
