### PR TITLE
docs: add Cua Driver video demos

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -6,5 +6,7 @@ https://console.cloud.google.com/*
 https://www.hud.ai/*
 # openai.com returns 403 to automated checkers but resolves fine in-browser
 https://openai.com/*
+# GitHub user attachments require a browser session and return 404 to anonymous link checkers
+https://github.com/user-attachments/assets/*
 # Self-referential install.sh URL: resolves once this PR merges to main
 https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh

--- a/docs/content/docs/concepts/the-no-foreground-contract.mdx
+++ b/docs/content/docs/concepts/the-no-foreground-contract.mdx
@@ -41,6 +41,28 @@ The remaining Linux gap is raw keyboard injection into native Wayland apps. Typi
 
 Cua Driver does not move the user's real pointer to show agent activity. It renders a synthetic cursor overlay for supervision. The user can see where the agent is acting while their own cursor and active app stay untouched.
 
+The Linux recordings below make that separation visible. Synthetic pointers act on background windows while the foreground window remains untouched.
+
+<div className="not-prose my-8 grid gap-5 md:grid-cols-2">
+  <VideoDemo
+    src="https://github.com/user-attachments/assets/13ab4c27-246b-4370-ab48-0082e5449830"
+    poster="https://github.com/user-attachments/assets/d91bb946-700a-4a48-8e05-c08f5c103ea4"
+    title="Four pointers across two XFCE windows"
+    sourceUrl="https://x.com/trycua/status/2067639340738761015"
+  >
+    Four synthetic pointers draw in two paint windows while a small text window stays in front.
+  </VideoDemo>
+
+  <VideoDemo
+    src="https://github.com/user-attachments/assets/6ecc0826-4ecf-41d9-a8ae-6705a6af5e26"
+    poster="https://github.com/user-attachments/assets/4d84b685-3cba-488a-87e0-3a5b048ea4a8"
+    title="Sixteen background windows on Wayland"
+    sourceUrl="https://x.com/trycua/status/2067639344698179789"
+  >
+    Sixteen pointers draw in separate windows around a foreground window that Cua Driver does not operate.
+  </VideoDemo>
+</div>
+
 ## How fallback works
 
 The safest ladder is:

--- a/docs/content/docs/how-to-guides/driver/drive-a-web-page.mdx
+++ b/docs/content/docs/how-to-guides/driver/drive-a-web-page.mdx
@@ -10,6 +10,16 @@ page without raising the native window. The tools bind the `(pid, window_id)`
 you selected to a DevTools target, then issue page input through that exact
 binding.
 
+<VideoDemo
+  className="my-8"
+  src="https://github.com/user-attachments/assets/e4208b4a-704a-4949-8660-4e25f3ed4db4"
+  poster="https://github.com/user-attachments/assets/92c71c18-76f6-4d1c-984d-6bc85c9fe0ac"
+  title="Chrome remains behind the agent terminal"
+  sourceUrl="https://x.com/trycua/status/2047383209244287350"
+>
+  Claude Code starts a YouTube video in Chrome without raising the browser window.
+</VideoDemo>
+
 ## Inspect the selected browser first
 
 First use `list_apps` and `list_windows` as usual, then call

--- a/docs/content/docs/how-to-guides/driver/meta.json
+++ b/docs/content/docs/how-to-guides/driver/meta.json
@@ -6,6 +6,7 @@
     "run-tests-in-macos-lume-vm",
     "connect-your-agent",
     "drive-a-web-page",
+    "record-and-render-a-trajectory",
     "keep-running",
     "restrict-tool-access",
     "personalize-cursor",

--- a/docs/content/docs/how-to-guides/driver/record-and-render-a-trajectory.mdx
+++ b/docs/content/docs/how-to-guides/driver/record-and-render-a-trajectory.mdx
@@ -1,0 +1,110 @@
+---
+title: Record and render a Cua Driver trajectory
+description: Capture an agent's Cua Driver actions and turn the trajectory into a zoom-on-click MP4.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Steps, Step } from 'fumadocs-ui/components/steps';
+
+Record an agent-driven task when you need both the action evidence and a short product demo. Cua Driver saves each action with before-and-after state, screenshots, and arguments. With video enabled, it also captures the display so you can render the trajectory with zoom effects around each action.
+
+<VideoDemo
+  src="https://github.com/user-attachments/assets/df6076f5-b95f-4f34-a5ca-8cfd37140cbc"
+  poster="https://github.com/user-attachments/assets/60330293-9684-4541-b311-15ab833b3451"
+  title="Turn an agent trajectory into a zoom-on-click demo"
+  sourceUrl="https://x.com/trycua/status/2047383207612645426"
+>
+  The agent clicks cells in a numbered grid, then Cua Driver renders the recorded actions as a
+  focused product demo.
+</VideoDemo>
+
+<Callout type="info">
+  This guide records an agent's Cua Driver actions. To record a task you perform by hand over VNC
+  and turn it into a reusable skill, see [Record a demonstration as a
+  skill](/how-to-guides/skills/record-a-demonstration).
+</Callout>
+
+## Before you start
+
+- [Install Cua Driver](/how-to-guides/driver/install) and [connect your agent](/how-to-guides/driver/connect-your-agent).
+- Install `ffmpeg`. Rendering requires it on every platform. Video capture also requires it on Windows and Linux. macOS 15 and later use ScreenCaptureKit for capture.
+
+```bash tab="macOS"
+brew install ffmpeg
+```
+
+```powershell tab="Windows"
+winget install Gyan.FFmpeg
+```
+
+```bash tab="Linux"
+sudo apt install ffmpeg
+```
+
+<Steps>
+  <Step>
+    ### Start recording with video enabled
+
+    Ask your MCP client to call `start_recording` before the agent begins the task:
+
+    ```json
+    {
+      "output_dir": "~/cua-trajectories/calendar-demo",
+      "record_video": true
+    }
+    ```
+
+    The recording directory will contain one `turn-NNNNN` folder for each action and a display capture named `recording.mp4`.
+
+    <Callout type="warn">
+      `cua-driver recording start` records per-action evidence but does not enable display video. Use the MCP tool with `record_video: true` when you plan to render an MP4.
+    </Callout>
+
+  </Step>
+
+  <Step>
+    ### Let the agent complete the task
+
+    Continue with the usual Cua Driver tools. Actions such as `click`, `type_text`, `press_key`, and `scroll` are added to the trajectory automatically.
+
+    Keep the task focused. A short trajectory produces a clearer demo and makes the evidence easier to inspect.
+
+  </Step>
+
+  <Step>
+    ### Stop and finalize the recording
+
+    Ask the MCP client to call `stop_recording` with no arguments:
+
+    ```json
+    {}
+    ```
+
+    Wait for this call to finish before opening or rendering `recording.mp4`. It finalizes the video file and returns its path.
+
+  </Step>
+
+  <Step>
+    ### Render the demo
+
+    Render the trajectory from the command line:
+
+    ```bash
+    cua-driver recording render \
+      ~/cua-trajectories/calendar-demo \
+      ~/cua-trajectories/calendar-demo.mp4
+    ```
+
+    The renderer uses the recorded action coordinates to add zoom effects around each interaction. Use `--scale` to adjust their strength, or `--no-zoom` for a plain render:
+
+    ```bash
+    cua-driver recording render \
+      ~/cua-trajectories/calendar-demo \
+      ~/cua-trajectories/calendar-demo.mp4 \
+      --scale 2.5
+    ```
+
+  </Step>
+</Steps>
+
+For the complete recording schemas and render options, see [MCP recording tools](/reference/cua-driver/mcp-tools#recording-tools) and the [`cua-driver recording` CLI reference](/reference/cua-driver/cli-reference#trajectory-recording).

--- a/docs/content/docs/how-to-guides/recipes/automate-a-legacy-windows-app-behind-a-vpn.mdx
+++ b/docs/content/docs/how-to-guides/recipes/automate-a-legacy-windows-app-behind-a-vpn.mdx
@@ -8,8 +8,21 @@ import { Steps, Step } from 'fumadocs-ui/components/steps';
 
 When a desktop app has **no API** and only runs **behind the corporate VPN**, drive it where it already runs, on the Windows box inside the network. **Cua Driver** runs on that machine and exposes the app through MCP stdio tools, so the desktop session, app traffic, and staged files stay inside the VPN boundary. **No data leaves the VPN boundary.**
 
+<VideoDemo
+  src="https://github.com/user-attachments/assets/77dbfdb2-2b02-4a9d-8f7e-4710f59de803"
+  poster="https://github.com/user-attachments/assets/462a7309-87b4-4d50-b1fc-295314912861"
+  title="Drive a legacy postal app while the terminal stays in front"
+  sourceUrl="https://x.com/trycua/status/2059693301276565841"
+>
+  Claude Code fills shipment details and prints receipts in a Windows desktop app with no API. The
+  [original launch thread](https://x.com/trycua/status/2059688960838828391) explains the use case.
+</VideoDemo>
+
 <Callout type="info">
-  Before you start: [install Cua Driver](/how-to-guides/driver/install), [connect your agent](/how-to-guides/driver/connect-your-agent), and configure [Keep Cua Driver running](/how-to-guides/driver/keep-running). If you connect over SSH, also read [Drive a Windows app over SSH](/how-to-guides/driver/windows-ssh).
+  Before you start: [install Cua Driver](/how-to-guides/driver/install), [connect your
+  agent](/how-to-guides/driver/connect-your-agent), and configure [Keep Cua Driver
+  running](/how-to-guides/driver/keep-running). If you connect over SSH, also read [Drive a Windows
+  app over SSH](/how-to-guides/driver/windows-ssh).
 </Callout>
 
 <Steps>
@@ -25,6 +38,7 @@ When a desktop app has **no API** and only runs **behind the corporate VPN**, dr
     ```
 
     Confirm the app is installed or reachable from that desktop session before you install anything. For this recipe, assume the payroll client opens normally when you launch it by hand.
+
   </Step>
 
   <Step>
@@ -44,6 +58,7 @@ When a desktop app has **no API** and only runs **behind the corporate VPN**, dr
     ```
 
     Empty output usually means the command is running outside the interactive desktop. Recheck `cua-driver status`, `query session`, and the autostart task.
+
   </Step>
 
   <Step>
@@ -58,6 +73,7 @@ When a desktop app has **no API** and only runs **behind the corporate VPN**, dr
     ```
 
     The agent should use `launch_app` to open the client, `list_apps` and `list_windows` to find the running process and target window, `get_window_state` to inspect the UI (it returns the accessibility tree and a screenshot), then `click` and `type_text` to complete the workflow.
+
   </Step>
 </Steps>
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -8,19 +8,59 @@ Cua is an open-source MIT-licensed platform ([github.com/trycua/cua](https://git
 import { Card, Cards } from 'fumadocs-ui/components/card';
 
 <Cards>
-  <Card
-    title="Drive a real app — Cua Driver"
-    href="/tutorials/drive-your-first-app"
-  >
-    Run a background driver on macOS, Windows, or Linux so an agent can operate native GUI apps you already have without bringing them to the foreground or moving the real mouse. It speaks MCP over stdio and is also a plain CLI.
+  <Card title="Drive a real app — Cua Driver" href="/tutorials/drive-your-first-app">
+    Run a background driver on macOS, Windows, or Linux so an agent can operate native GUI apps you
+    already have without bringing them to the foreground or moving the real mouse. It speaks MCP
+    over stdio and is also a plain CLI.
   </Card>
-  <Card
-    title="Spin up a cloud desktop — Cua Sandbox"
-    href="/tutorials/your-first-cloud-sandbox"
-  >
-    Start disposable full Linux, Windows, or macOS VMs with a GUI for an agent to drive when you want a fresh, isolated computer in the cloud instead of your own machine.
+  <Card title="Spin up a cloud desktop — Cua Sandbox" href="/tutorials/your-first-cloud-sandbox">
+    Start disposable full Linux, Windows, or macOS VMs with a GUI for an agent to drive when you
+    want a fresh, isolated computer in the cloud instead of your own machine.
   </Card>
 </Cards>
+
+## Cua Driver in action
+
+These recordings show agents operating desktop apps while the user's active window stays in place. Each demo was recorded by the Cua team on the named platform.
+
+<div className="not-prose my-8 grid gap-5 md:grid-cols-2">
+  <VideoDemo
+    src="https://github.com/user-attachments/assets/e4208b4a-704a-4949-8660-4e25f3ed4db4"
+    poster="https://github.com/user-attachments/assets/92c71c18-76f6-4d1c-984d-6bc85c9fe0ac"
+    title="Play media in a background Chrome window on macOS"
+    sourceUrl="https://x.com/trycua/status/2047383209244287350"
+  >
+    Claude Code starts playback in Chrome while its terminal remains in front.
+  </VideoDemo>
+
+<VideoDemo
+  src="https://github.com/user-attachments/assets/0a094ad7-9c06-4b6f-9f44-f9ca7582ff73"
+  poster="https://github.com/user-attachments/assets/4b5f7c59-5973-4c34-966e-8aed24e3bde0"
+  title="Build and check a WPF app on Windows"
+  sourceUrl="https://x.com/trycua/status/2059688966085853245"
+>
+  Claude Code builds a WPF CRM, runs it, patches the code, and checks the app again.
+</VideoDemo>
+
+<VideoDemo
+  src="https://github.com/user-attachments/assets/9217a8c0-8e5f-449d-939a-d8b245d27142"
+  poster="https://github.com/user-attachments/assets/5ff7a103-dc48-4781-ab37-c979a0c54d1a"
+  title="Check a calculator app on Linux"
+  sourceUrl="https://x.com/trycua/status/2067639342944985586"
+>
+  Claude Code builds a calculator, drives it to 42, and reads the result while the terminal stays in
+  front.
+</VideoDemo>
+
+  <VideoDemo
+    src="https://github.com/user-attachments/assets/e10c0534-f0f7-45f6-91f7-3b28fd751e7c"
+    poster="https://github.com/user-attachments/assets/52cfc4a4-1e5a-4cb7-873b-734ebb857958"
+    title="Fill a Linux spreadsheet over SSH"
+    sourceUrl="https://x.com/trycua/status/2067639346719826213"
+  >
+    An agent enters a monthly budget in Gnumeric on a remote machine with no attached display or GPU.
+  </VideoDemo>
+</div>
 
 ## How these docs are organised
 

--- a/docs/content/docs/tutorials/drive-your-first-app.mdx
+++ b/docs/content/docs/tutorials/drive-your-first-app.mdx
@@ -10,6 +10,17 @@ import { Callout } from 'fumadocs-ui/components/callout';
 
 You do not type **Cua Driver** CLI commands by hand. Cua Driver is a backend that an agent harness (Claude Code, Codex, Hermes, and others) drives for you. In this tutorial you install Cua Driver, connect your agent, and ask it in plain English to open a calculator and read a result back. Works the same on macOS, Windows, and Linux.
 
+<VideoDemo
+  src="https://github.com/user-attachments/assets/9217a8c0-8e5f-449d-939a-d8b245d27142"
+  poster="https://github.com/user-attachments/assets/5ff7a103-dc48-4781-ab37-c979a0c54d1a"
+  title="Preview: ask an agent to calculate 6 × 7"
+  sourceUrl="https://x.com/trycua/status/2067639342944985586"
+  className="my-8"
+>
+  This Linux recording shows the result you will reproduce: an agent drives Calculator to 42 while
+  the terminal stays in front. The same prompt works on macOS and Windows.
+</VideoDemo>
+
 ## 1. Install Cua Driver
 
 Use the same one-line installer on every platform; it picks the right path for the host and needs no administrator access.

--- a/docs/src/components/video-demo.tsx
+++ b/docs/src/components/video-demo.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from 'react';
+
+interface VideoDemoProps {
+  src: string;
+  poster: string;
+  title: string;
+  sourceUrl?: string;
+  className?: string;
+  children?: ReactNode;
+}
+
+function withDocsBasePath(path: string) {
+  if (!path.startsWith('/') || path.startsWith('/docs/')) return path;
+  return `/docs${path}`;
+}
+
+export function VideoDemo({ src, poster, title, sourceUrl, className, children }: VideoDemoProps) {
+  const mediaSrc = withDocsBasePath(src);
+  const mediaPoster = withDocsBasePath(poster);
+
+  return (
+    <figure
+      className={[
+        'not-prose overflow-hidden rounded-xl border border-fd-border bg-fd-card',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <video
+        aria-label={title}
+        className="block aspect-video w-full bg-black object-contain"
+        controls
+        playsInline
+        poster={mediaPoster}
+        preload="metadata"
+      >
+        <source src={mediaSrc} type="video/mp4" />
+        <a href={mediaSrc}>Open the video.</a>
+      </video>
+      <figcaption className="space-y-1.5 border-t border-fd-border px-4 py-3 text-sm">
+        <div className="font-medium text-fd-foreground">{title}</div>
+        {children ? <div className="text-fd-muted-foreground">{children}</div> : null}
+        {sourceUrl ? (
+          <a
+            className="inline-block text-fd-primary underline underline-offset-4"
+            href={sourceUrl}
+            rel="noreferrer noopener"
+            target="_blank"
+          >
+            View the original post on X
+          </a>
+        ) : null}
+      </figcaption>
+    </figure>
+  );
+}

--- a/docs/src/mdx-components.tsx
+++ b/docs/src/mdx-components.tsx
@@ -1,6 +1,7 @@
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import * as TabsComponents from 'fumadocs-ui/components/tabs';
 import type { MDXComponents } from 'mdx/types';
+import { VideoDemo } from '@/components/video-demo';
 
 // Local MDX preview: fumadocs defaults + Tabs (the only custom component the
 // content uses). Hero/IOU/Mermaid/editable-code-block were unused by any page.
@@ -8,6 +9,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
     ...TabsComponents,
+    VideoDemo,
     ...components,
   };
 }


### PR DESCRIPTION
## Summary

- add a reusable `VideoDemo` MDX component
- show GitHub-hosted Cua Driver demos on the docs homepage and relevant background, browser, and Windows workflow pages
- add a how-to guide for recording and rendering an agent trajectory
- link every demo back to its original X post for context
- exclude GitHub `user-attachments` from anonymous lychee checks because GitHub gates those URLs outside a browser session

## Why

The existing docs explain background desktop control, synthetic cursors, and trajectory recording in prose. These short cross-platform recordings make those behaviors visible at the point where readers need them.

## Impact

Docs readers get playable macOS, Windows, and Linux examples without adding the video binaries to the repository.

## Validation

- `npx --yes pnpm@9.0.4 docs:check-hygiene`
- `npx --yes pnpm@9.0.4 docs:check-links`
- `npx --yes pnpm@9.0.4 docs:check-links:external`
- `npx --yes pnpm@9.0.4 build`
- `git diff --check`
- desktop and narrow-layout production preview review