### PR TITLE
chore(cua-driver): use @cua ClawHub publisher

### DIFF
--- a/.github/workflows/clawhub-cua-driver.yml
+++ b/.github/workflows/clawhub-cua-driver.yml
@@ -16,7 +16,7 @@ on:
       owner:
         description: "ClawHub publisher handle"
         required: true
-        default: "f-trycua"
+        default: "cua"
         type: string
       confirm_mit0:
         description: "Cua AI has authority to publish every bundled file under MIT-0"
@@ -39,7 +39,7 @@ jobs:
     uses: openclaw/clawhub/.github/workflows/skill-publish.yml@b2f06028cff845974cfc9e528317ef879663935b
     with:
       skill_path: "libs/cua-driver/rust/Skills/cua-driver"
-      owner: "f-trycua"
+      owner: "cua"
       dry_run: true
       ref: ${{ github.event.pull_request.head.sha }}
 

--- a/docs/content/docs/how-to-guides/driver/connect-your-agent.mdx
+++ b/docs/content/docs/how-to-guides/driver/connect-your-agent.mdx
@@ -77,6 +77,8 @@ cua-driver skills install
 cua-driver skills status
 ```
 
+See [Install the Cua Driver agent skill](/how-to-guides/driver/install-agent-skill) for the ClawHub and direct-install paths.
+
 ## Cursor
 
 Generate the Cursor snippet:

--- a/docs/content/docs/how-to-guides/driver/install-agent-skill.mdx
+++ b/docs/content/docs/how-to-guides/driver/install-agent-skill.mdx
@@ -1,0 +1,82 @@
+---
+title: Install the Cua Driver agent skill
+description: Install Cua Driver instructions for OpenClaw from ClawHub, or install them directly for another supported agent.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+The Cua Driver agent skill teaches an agent how to choose tools, address windows and elements, preserve focus, and verify each action on macOS, Windows, or Linux.
+
+<Callout type="info">
+  The skill contains agent instructions. It does not install the `cua-driver` executable. [Install Cua Driver](/how-to-guides/driver/install) on the same machine first.
+</Callout>
+
+## Install from ClawHub
+
+Run the command from your OpenClaw workspace:
+
+```bash
+clawhub install @cua/cua-driver
+```
+
+ClawHub installs the skill under the workspace's `skills` directory. The bundle contains the shared instructions and the macOS, Windows, and Linux guides, so the agent can read the guide for its current host.
+
+Confirm that ClawHub tracks the install:
+
+```bash
+clawhub list
+```
+
+Restart OpenClaw or start a new agent session so it discovers the installed skill.
+
+## Verify Cua Driver
+
+Check the executable and host requirements separately:
+
+```bash
+cua-driver --version
+cua-driver doctor
+```
+
+On macOS, also confirm that Cua Driver has Accessibility and Screen Recording permission:
+
+```bash
+cua-driver permissions status
+```
+
+## Update or remove the ClawHub skill
+
+Update the installed skill:
+
+```bash
+clawhub update cua-driver
+```
+
+Remove it from the current workspace:
+
+```bash
+clawhub uninstall cua-driver
+```
+
+These commands change the agent instructions only. Use [`cua-driver update --apply`](/how-to-guides/driver/update) to update the executable.
+
+## Install directly for another agent
+
+Cua Driver can install its bundled skill into supported agent directories without ClawHub:
+
+```bash
+cua-driver skills install
+cua-driver skills status
+```
+
+Direct installation keeps only the current host's OS guide by default. Pass `--all-platforms` when the same skill directory must cover macOS, Windows, and Linux:
+
+```bash
+cua-driver skills install --all-platforms
+```
+
+## Next steps
+
+- [Connect your agent to Cua Driver](/how-to-guides/driver/connect-your-agent): register the MCP server when the agent uses MCP.
+- [Keep Cua Driver running](/how-to-guides/driver/keep-running): configure the daemon to return after restarts.
+- [Agent action policy](/reference/cua-driver/action-selection-policy): review the behavior an agent wrapper should follow.

--- a/docs/content/docs/how-to-guides/driver/install.mdx
+++ b/docs/content/docs/how-to-guides/driver/install.mdx
@@ -119,6 +119,7 @@ cua-driver permissions status
 
 ## Next steps
 
+- [Install the Cua Driver agent skill](/how-to-guides/driver/install-agent-skill): add the cross-platform instructions from ClawHub or install them directly for another agent.
 - [Keep Cua Driver running](/how-to-guides/driver/keep-running): configure autostart so the daemon comes back after reboots.
 - [Connect Cua Driver to an MCP client](/how-to-guides/driver/connect-your-agent): register it with Claude Code, Cursor, Codex, and other clients.
 - [Update Cua Driver](/how-to-guides/driver/update): check for new releases and apply them.

--- a/docs/content/docs/how-to-guides/driver/meta.json
+++ b/docs/content/docs/how-to-guides/driver/meta.json
@@ -2,6 +2,7 @@
   "title": "Driver",
   "pages": [
     "install",
+    "install-agent-skill",
     "run-in-macos-lume-vm",
     "run-tests-in-macos-lume-vm",
     "connect-your-agent",

--- a/libs/cua-driver/README.md
+++ b/libs/cua-driver/README.md
@@ -56,7 +56,7 @@ Directly spawning a raw `cua-driver` binary outside `CuaDriver.app` without embe
 ## Publishing the agent skill to ClawHub
 
 The canonical skill source is `rust/Skills/cua-driver`. It is published as one
-cross-platform ClawHub skill at `@f-trycua/cua-driver`; the bundle includes the
+cross-platform ClawHub skill at `@cua/cua-driver`; the bundle includes the
 macOS, Windows, and Linux documents. Direct installs through `cua-driver skills
 install` still keep only the host OS document unless `--all-platforms` is used.
 
@@ -75,7 +75,7 @@ all of the following:
    in `rust/Skills/cua-driver/SKILL.md`.
 3. Confirm the MIT-0 rights check in the workflow form.
 4. Configure a repository Actions secret named `CLAWHUB_TOKEN` for a publisher
-   that can release under the selected owner. The default owner is `f-trycua`.
+   that can release under the selected owner. The default owner is `cua`.
 
 The workflow pins the ClawHub CLI, records the source repository, commit, ref,
 and path, and uploads the JSON publish result as an Actions artifact. When a
@@ -87,10 +87,10 @@ After publishing, inspect and scan the exact version, then install it into an
 empty work directory:
 
 ```bash
-npx --yes clawhub@0.23.1 inspect @f-trycua/cua-driver --version 0.8.3 --files
+npx --yes clawhub@0.23.1 inspect @cua/cua-driver --version 0.8.3 --files
 npx --yes clawhub@0.23.1 scan --slug cua-driver --version 0.8.3 --update
 npx --yes clawhub@0.23.1 --workdir /tmp/cua-driver-clawhub-smoke \
-  install @f-trycua/cua-driver
+  install @cua/cua-driver
 ```
 
 Confirm that `MACOS.md`, `WINDOWS.md`, and `LINUX.md` are present, run

--- a/libs/cua-driver/rust/Skills/cua-driver/README.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/README.md
@@ -129,7 +129,7 @@ The skill is a drop-in directory. Same shape on every platform.
 **OpenClaw via ClawHub:**
 
 ```bash
-clawhub install @f-trycua/cua-driver
+clawhub install @cua/cua-driver
 ```
 
 ClawHub installs the complete cross-platform bundle. The agent reads the shared


### PR DESCRIPTION
## Summary

- switch the ClawHub publisher default and PR dry-run from `@f-trycua` to the new `@cua` organization publisher
- update contributor and bundled skill documentation to use `@cua/cua-driver`
- add a public how-to for installing, verifying, updating, and removing the Cua Driver agent skill

## Validation

- created ClawHub publisher `@cua` under the maintainer account
- configured the repository `CLAWHUB_TOKEN` secret without exposing its value
- `clawhub@0.23.1 skill publish ... --owner cua --version 0.8.3 --dry-run --json` returned `would-publish` with 8 files
- ClawHub reusable PR validation passed under `@cua` on commit `193078c3`
- Prettier passed for all changed files
- workflow YAML parsed successfully
- `git diff --check` passed
- full docs link and hygiene checks are running in GitHub Actions on the latest head

## Release safety

This PR does not publish the skill. Publication remains a manual workflow dispatch from `main` with an explicit version and MIT-0 confirmation.

Refs #2264