### PR TITLE
chore(cua-driver): publish skill as @cua/driver

### DIFF
--- a/.github/workflows/clawhub-cua-driver.yml
+++ b/.github/workflows/clawhub-cua-driver.yml
@@ -30,21 +30,61 @@ permissions:
 
 env:
   CLAWHUB_CLI_VERSION: "0.23.1"
+  CLAWHUB_SKILL_SLUG: "driver"
   SKILL_PATH: "libs/cua-driver/rust/Skills/cua-driver"
 
 jobs:
   dry-run:
-    name: Validate publish bundle
+    name: Validate @cua/driver publish bundle
     if: github.event_name == 'pull_request'
-    uses: openclaw/clawhub/.github/workflows/skill-publish.yml@b2f06028cff845974cfc9e528317ef879663935b
-    with:
-      skill_path: "libs/cua-driver/rust/Skills/cua-driver"
-      owner: "cua"
-      dry_run: true
-      ref: ${{ github.event.pull_request.head.sha }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Validate @cua/driver bundle
+        env:
+          SOURCE_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          VERSION="$(python3 - <<'PY'
+          import re
+          from pathlib import Path
+
+          skill_text = Path("libs/cua-driver/rust/Skills/cua-driver/SKILL.md").read_text()
+          frontmatter = skill_text.split("---", 2)[1]
+          match = re.search(r"^version:\s*([^\s#]+)", frontmatter, re.MULTILINE)
+          if not match:
+              raise SystemExit("SKILL.md frontmatter has no version")
+          print(match.group(1))
+          PY
+          )"
+          npx --yes "clawhub@${CLAWHUB_CLI_VERSION}" skill publish "${SKILL_PATH}" \
+            --slug "${CLAWHUB_SKILL_SLUG}" \
+            --name "Cua Driver" \
+            --owner cua \
+            --version "${VERSION}" \
+            --changelog "Cua Driver ${VERSION}" \
+            --tags latest \
+            --source-repo "${GITHUB_REPOSITORY}" \
+            --source-commit "$(git rev-parse HEAD)" \
+            --source-ref "${SOURCE_REF}" \
+            --source-path "${SKILL_PATH}" \
+            --dry-run \
+            --json | tee "${RUNNER_TEMP}/clawhub-dry-run.json"
+
+      - name: Upload dry-run result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: clawhub-driver-dry-run
+          path: ${{ runner.temp }}/clawhub-dry-run.json
+          if-no-files-found: ignore
 
   publish:
-    name: Publish ${{ inputs.version }} as @${{ inputs.owner }}/cua-driver
+    name: Publish ${{ inputs.version }} as @${{ inputs.owner }}/driver
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
@@ -104,17 +144,17 @@ jobs:
               env_file.write(f"CLAWHUB_CONFIG_PATH={path}\n")
           PY
 
-      - name: Publish cua-driver skill
+      - name: Publish @${{ inputs.owner }}/driver
         env:
           OWNER: ${{ inputs.owner }}
           VERSION: ${{ inputs.version }}
         run: |
           npx --yes "clawhub@${CLAWHUB_CLI_VERSION}" skill publish "${SKILL_PATH}" \
-            --slug cua-driver \
-            --name "CUA Driver" \
+            --slug "${CLAWHUB_SKILL_SLUG}" \
+            --name "Cua Driver" \
             --owner "${OWNER}" \
             --version "${VERSION}" \
-            --changelog "cua-driver ${VERSION}" \
+            --changelog "Cua Driver ${VERSION}" \
             --tags latest \
             --source-repo "${GITHUB_REPOSITORY}" \
             --source-commit "${GITHUB_SHA}" \
@@ -138,6 +178,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: clawhub-cua-driver-publish-${{ inputs.version }}
+          name: clawhub-driver-publish-${{ inputs.version }}
           path: ${{ runner.temp }}/clawhub-publish.json
           if-no-files-found: ignore

--- a/docs/content/docs/how-to-guides/driver/install-agent-skill.mdx
+++ b/docs/content/docs/how-to-guides/driver/install-agent-skill.mdx
@@ -16,7 +16,7 @@ The Cua Driver agent skill teaches an agent how to choose tools, address windows
 Run the command from your OpenClaw workspace:
 
 ```bash
-clawhub install @cua/cua-driver
+clawhub install @cua/driver
 ```
 
 ClawHub installs the skill under the workspace's `skills` directory. The bundle contains the shared instructions and the macOS, Windows, and Linux guides, so the agent can read the guide for its current host.
@@ -49,13 +49,13 @@ cua-driver permissions status
 Update the installed skill:
 
 ```bash
-clawhub update cua-driver
+clawhub update driver
 ```
 
 Remove it from the current workspace:
 
 ```bash
-clawhub uninstall cua-driver
+clawhub uninstall driver
 ```
 
 These commands change the agent instructions only. Use [`cua-driver update --apply`](/how-to-guides/driver/update) to update the executable.

--- a/libs/cua-driver/README.md
+++ b/libs/cua-driver/README.md
@@ -56,7 +56,7 @@ Directly spawning a raw `cua-driver` binary outside `CuaDriver.app` without embe
 ## Publishing the agent skill to ClawHub
 
 The canonical skill source is `rust/Skills/cua-driver`. It is published as one
-cross-platform ClawHub skill at `@cua/cua-driver`; the bundle includes the
+cross-platform ClawHub skill at `@cua/driver`; the bundle includes the
 macOS, Windows, and Linux documents. Direct installs through `cua-driver skills
 install` still keep only the host OS document unless `--all-platforms` is used.
 
@@ -65,8 +65,8 @@ under MIT, while every skill copy published through ClawHub is distributed
 under MIT-0. Before a release, retain an internal record that Cua AI has the
 right to distribute every bundled file under MIT-0.
 
-Pull requests that change the skill run a publish dry-run through ClawHub's
-pinned reusable workflow. A real release is available only through the
+Pull requests that change the skill run a publish dry-run with the pinned
+ClawHub CLI. A real release is available only through the
 `ClawHub: cua-driver skill` workflow's manual dispatch. The publish job requires
 all of the following:
 
@@ -78,19 +78,16 @@ all of the following:
    that can release under the selected owner. The default owner is `cua`.
 
 The workflow pins the ClawHub CLI, records the source repository, commit, ref,
-and path, and uploads the JSON publish result as an Actions artifact. When a
-`trycua` organization publisher becomes available, transfer the existing skill
-instead of creating a second listing, then change the workflow and this section
-in the same pull request.
+and path, and uploads the JSON publish result as an Actions artifact.
 
 After publishing, inspect and scan the exact version, then install it into an
 empty work directory:
 
 ```bash
-npx --yes clawhub@0.23.1 inspect @cua/cua-driver --version 0.8.3 --files
-npx --yes clawhub@0.23.1 scan --slug cua-driver --version 0.8.3 --update
+npx --yes clawhub@0.23.1 inspect @cua/driver --version 0.8.3 --files
+npx --yes clawhub@0.23.1 scan --slug driver --version 0.8.3 --update
 npx --yes clawhub@0.23.1 --workdir /tmp/cua-driver-clawhub-smoke \
-  install @cua/cua-driver
+  install @cua/driver
 ```
 
 Confirm that `MACOS.md`, `WINDOWS.md`, and `LINUX.md` are present, run

--- a/libs/cua-driver/rust/Skills/cua-driver/README.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/README.md
@@ -129,7 +129,7 @@ The skill is a drop-in directory. Same shape on every platform.
 **OpenClaw via ClawHub:**
 
 ```bash
-clawhub install @cua/cua-driver
+clawhub install @cua/driver
 ```
 
 ClawHub installs the complete cross-platform bundle. The agent reads the shared


### PR DESCRIPTION
## Summary

- change the ClawHub listing coordinate from `@cua/cua-driver` to `@cua/driver`
- make PR validation call the pinned ClawHub CLI with explicit owner `cua` and slug `driver`
- update public, bundled, and maintainer installation instructions

## Scope

The executable, Rust crate, source folder, and agent skill name remain `cua-driver`. This change affects only the ClawHub registry slug and ClawHub install/update commands. Neither registry coordinate has been published, so no remote listing needed deletion or migration.

## Validation

- authenticated `clawhub@0.23.1` dry-run returned `would-publish` for `@cua/driver@0.8.3` with 8 files
- confirmed both `@cua/cua-driver` and `@cua/driver` have no existing release
- `actionlint .github/workflows/clawhub-cua-driver.yml`
- workflow YAML parse
- Prettier check for every changed file
- `git diff --check`
- repository-wide stale-coordinate audit returned no `@cua/cua-driver` references

## Release safety

This PR does not publish the skill. The first release remains a manual workflow dispatch from `main` with the MIT-0 confirmation and repository `CLAWHUB_TOKEN`.

Refs #2264