### PR TITLE
fix(cua-driver): require live capture permission

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -2448,6 +2448,24 @@ fn run_permissions_status(json: bool) {
     }
 }
 
+fn permission_flag(structured: &serde_json::Value, key: &str) -> bool {
+    structured
+        .get(key)
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false)
+}
+
+fn permission_grant_is_ready(structured: &serde_json::Value) -> bool {
+    permission_flag(structured, "accessibility")
+        && permission_flag(structured, "screen_recording")
+        && permission_flag(structured, "screen_recording_capturable")
+}
+
+fn permission_grant_has_stale_screen_recording(structured: &serde_json::Value) -> bool {
+    permission_flag(structured, "screen_recording")
+        && !permission_flag(structured, "screen_recording_capturable")
+}
+
 /// Launch CuaDriver via LaunchServices so the permission prompt attributes to
 /// com.trycua.driver, wait (user-paced) for the daemon to come up — its socket
 /// only appears once the permissions gate passes, i.e. the grant was given —
@@ -2456,7 +2474,8 @@ fn run_permissions_grant() {
     #[cfg(target_os = "macos")]
     {
         let socket = crate::serve::default_socket_path();
-        if crate::serve::is_daemon_listening(&socket) {
+        let daemon_was_running = crate::serve::is_daemon_listening(&socket);
+        if daemon_was_running {
             println!("CuaDriver daemon already running — checking its permissions…");
         } else {
             println!("Launching CuaDriver to request permissions.");
@@ -2477,7 +2496,8 @@ fn run_permissions_grant() {
         // Since #1761 the daemon binds its socket IMMEDIATELY — before the
         // permissions gate completes — so the first `check_permissions`
         // query returns "pending" while the grant is still missing. Poll
-        // the daemon until both grants flip true (success) or we time out.
+        // the daemon until both grants and the live capture probe flip true
+        // (success) or we time out.
         //
         // The gate re-execs the daemon (~every 25s) to pick up an
         // Accessibility grant — `AXIsProcessTrusted` is cached per process
@@ -2494,6 +2514,8 @@ fn run_permissions_grant() {
         let poll_deadline = std::time::Instant::now() + std::time::Duration::from_secs(180);
         let mut ax = false;
         let mut sr = false;
+        let mut cap = false;
+        let mut stale_screen_recording = false;
         loop {
             if let Some(structured) = crate::serve::send_request(&socket, &req)
                 .ok()
@@ -2501,15 +2523,18 @@ fn run_permissions_grant() {
                 .and_then(|r| r.result)
                 .and_then(|res| res.get("structuredContent").cloned())
             {
-                ax = structured
-                    .get("accessibility")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false);
-                sr = structured
-                    .get("screen_recording")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false);
-                if ax && sr {
+                ax = permission_flag(&structured, "accessibility");
+                sr = permission_flag(&structured, "screen_recording");
+                cap = permission_flag(&structured, "screen_recording_capturable");
+                if permission_grant_is_ready(&structured) {
+                    break;
+                }
+                // A daemon that was already running has had time to settle.
+                // If its cached preflight says Screen Recording is granted
+                // while the authoritative live probe fails, another prompt
+                // cannot repair the stale TCC decision until it is reset.
+                if daemon_was_running && permission_grant_has_stale_screen_recording(&structured) {
+                    stale_screen_recording = true;
                     break;
                 }
             }
@@ -2520,8 +2545,15 @@ fn run_permissions_grant() {
             }
             std::thread::sleep(std::time::Duration::from_secs(2));
         }
-        if ax && sr {
+        if ax && sr && cap {
             println!("\n✅ CuaDriver has Accessibility + Screen Recording. You're set.");
+        } else if stale_screen_recording || (sr && !cap) {
+            eprintln!("\n❌ Screen Recording looks granted, but CuaDriver cannot capture pixels.");
+            eprintln!("The cached macOS TCC decision is stale. Run:");
+            eprintln!("  tccutil reset ScreenCapture com.trycua.driver");
+            eprintln!("  cua-driver stop");
+            eprintln!("  cua-driver permissions grant");
+            process::exit(1);
         } else {
             let missing = match (ax, sr) {
                 (false, false) => "Accessibility + Screen Recording",
@@ -3556,6 +3588,40 @@ mod tests {
         assert_eq!(finite_client_kind_from_args(&args(&["mcp-config", "--client", "antigravity"])), "antigravity");
         assert_eq!(finite_client_kind_from_args(&args(&["mcp-config", "--client", "/private/client"])), "other");
         assert_eq!(finite_client_kind_from_args(&args(&["doctor", "--client", "claude"])), "not_applicable");
+    }
+
+    #[test]
+    fn permission_grant_requires_live_capture_probe() {
+        let stale = serde_json::json!({
+            "accessibility": true,
+            "screen_recording": true,
+            "screen_recording_capturable": false
+        });
+
+        assert!(!permission_grant_is_ready(&stale));
+        assert!(permission_grant_has_stale_screen_recording(&stale));
+    }
+
+    #[test]
+    fn permission_grant_accepts_all_live_checks() {
+        let ready = serde_json::json!({
+            "accessibility": true,
+            "screen_recording": true,
+            "screen_recording_capturable": true
+        });
+
+        assert!(permission_grant_is_ready(&ready));
+        assert!(!permission_grant_has_stale_screen_recording(&ready));
+    }
+
+    #[test]
+    fn permission_grant_missing_live_probe_is_not_ready() {
+        let incomplete = serde_json::json!({
+            "accessibility": true,
+            "screen_recording": true
+        });
+
+        assert!(!permission_grant_is_ready(&incomplete));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Require Accessibility, Screen Recording preflight, and the live
  `screen_recording_capturable` probe before `permissions grant` reports success.
- Detect a stale Screen Recording decision when an already-running daemon reports
  preflight access but cannot capture pixels.
- Return an actionable TCC reset sequence instead of a false success.
- Add unit coverage for ready, stale, and missing-probe responses.

## Why

`permissions status` already exposes the live capture probe, but
`permissions grant` currently stops as soon as Accessibility and Screen Recording
preflight both report true. A stale macOS TCC decision can therefore print
“You’re set” while the driver still cannot capture pixels.

## Test Plan

- [x] `cargo test -p cua-driver permission_grant`
      (`3 passed; 0 failed`)
- [x] `cargo check -p cua-driver`
- [x] `git diff --check 3db4a80fbe0283a8ca78ac4d093a82cc879a7ef1...HEAD`

## Platform / coverage caveats

The Rust tests and check ran on macOS. I did not execute the interactive
`permissions grant` / TCC reset flow because that would change the machine’s
system privacy state. The repository-wide `cargo fmt -p cua-driver -- --check`
currently reports pre-existing formatting differences outside this change; the
modified hunks were checked separately with rustfmt.
