### PR TITLE
fix(cua-driver): reuse self-signed local identity

### DIFF
--- a/libs/cua-driver/python/tests/test_install_local_signing.py
+++ b/libs/cua-driver/python/tests/test_install_local_signing.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_local_installer_accepts_untrusted_self_signed_identity() -> None:
+    """The installer-created self-signed cert is usable even before trust-chain validation."""
+    script = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "_install-local-rust.sh"
+    ).read_text()
+
+    assert "security find-identity -v -p codesigning" not in script
+    assert script.count("security find-identity -p codesigning") >= 2

--- a/libs/cua-driver/scripts/_install-local-rust.sh
+++ b/libs/cua-driver/scripts/_install-local-rust.sh
@@ -282,11 +282,14 @@ echo ""
 # this avoids image-specific login-keychain ACL failures. Local dev only;
 # releases are CI-signed.
 #
-# Echoes the `codesign --sign` argument: the valid identity's SHA-1 when
+# Echoes the `codesign --sign` argument: a matching identity's SHA-1 when
 # available, or "-" when it can't be created — no codesign/openssl, CI,
-# locked keychain. Use the identity hash rather than the certificate name:
-# stale certificate-only duplicates can share the same name and make codesign
-# reject an otherwise valid identity as ambiguous.
+# locked keychain. The installer creates a self-signed local certificate, which
+# `security find-identity -v` filters out as untrusted even when its private key
+# is present and codesign can use it. Query matching code-signing identities
+# without the valid-only filter; the bounded codesign call below remains the
+# authoritative usability check. Use the identity hash rather than the
+# certificate name because duplicate certificate names are ambiguous.
 CUA_LOCAL_SIGN_CN="CuaDriver Local Signing (cua-driver-rs)"
 ensure_local_signing_identity() {
     { [ "$OS" = "Darwin" ] && command -v codesign >/dev/null 2>&1; } || { printf -- '-'; return; }
@@ -296,7 +299,7 @@ ensure_local_signing_identity() {
     fi
     [ -f "$kc" ] || { printf -- '-'; return; }
     local identity
-    identity="$(security find-identity -v -p codesigning "$kc" 2>/dev/null \
+    identity="$(security find-identity -p codesigning "$kc" 2>/dev/null \
         | awk -v cn="$CUA_LOCAL_SIGN_CN" 'index($0, "\"" cn "\"") { print $2; exit }')"
     if [ -n "$identity" ]; then
         printf '%s' "$identity"; return
@@ -318,7 +321,7 @@ ensure_local_signing_identity() {
             || openssl pkcs12 -export -inkey "$tmp/key.pem" -in "$tmp/cert.pem" \
                 -out "$tmp/id.p12" -passout pass:"$pw" -name "$CUA_LOCAL_SIGN_CN" >/dev/null 2>&1; } \
        && security import "$tmp/id.p12" -k "$kc" -P "$pw" -A -T /usr/bin/codesign >/dev/null 2>&1; then
-        identity="$(security find-identity -v -p codesigning "$kc" 2>/dev/null \
+        identity="$(security find-identity -p codesigning "$kc" 2>/dev/null \
             | awk -v cn="$CUA_LOCAL_SIGN_CN" 'index($0, "\"" cn "\"") { print $2; exit }')"
         rm -rf "$tmp"
         if [ -n "$identity" ]; then


### PR DESCRIPTION
## Summary

- Query matching code-signing identities without the `find-identity -v`
  valid-only filter.
- Reuse the installer-created self-signed identity when its private key is
  present, even before trust-chain validation.
- Keep the existing bounded `codesign` invocation as the authoritative
  usability check.
- Add a regression test covering both identity lookups.

## Why

The local installer creates a self-signed code-signing certificate, but
`security find-identity -v -p codesigning` filters that identity out as
untrusted. Repeated installs can therefore miss the existing certificate,
fall back to another signing path, and lose the stable identity that allows
macOS TCC grants to survive rebuilds.

## Test Plan

- [x] `pytest tests/test_install_local_signing.py -q`
      (`1 passed`)
- [x] `bash -n libs/cua-driver/scripts/_install-local-rust.sh`
- [x] `git diff --check 3db4a80fbe0283a8ca78ac4d093a82cc879a7ef1...HEAD`

## Platform / coverage caveats

The regression test validates the installer contract and the shell script
passes syntax checking. I did not import a certificate, modify a macOS
Keychain, or run an end-to-end codesign operation, so actual identity usability
still depends on the target machine’s Keychain state and permissions.
