### PR TITLE
fix(cua-driver-rs)(macos): isolate and clean up window capture temp files

### DIFF
--- a/libs/cua-driver/rust/crates/platform-macos/src/capture.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/capture.rs
@@ -10,12 +10,42 @@
 //! approach is simpler to implement correctly and is reliable across OS versions.
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use std::path::PathBuf;
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static WINDOW_CAPTURE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+fn window_capture_temp_path(window_id: u32) -> PathBuf {
+    let sequence = WINDOW_CAPTURE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "cua-driver-rs-capture-{}-{window_id}-{sequence}.png",
+        std::process::id()
+    ))
+}
+
+struct WindowCaptureTempFile {
+    path: PathBuf,
+}
+
+impl WindowCaptureTempFile {
+    fn new(window_id: u32) -> Self {
+        Self {
+            path: window_capture_temp_path(window_id),
+        }
+    }
+}
+
+impl Drop for WindowCaptureTempFile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
 
 /// Capture a window by its `window_id` (CGWindowID).
 /// Returns raw PNG bytes or an error.
 pub fn screenshot_window_bytes(window_id: u32) -> anyhow::Result<Vec<u8>> {
-    let tmp_path = format!("/tmp/cua-driver-rs-capture-{}.png", window_id);
+    let tmp_file = WindowCaptureTempFile::new(window_id);
 
     let output = Command::new("screencapture")
         .args([
@@ -23,7 +53,7 @@ pub fn screenshot_window_bytes(window_id: u32) -> anyhow::Result<Vec<u8>> {
             &window_id.to_string(),
             "-x", // no sound
             "-o", // no shadow
-            &tmp_path,
+            tmp_file.path.to_string_lossy().as_ref(),
         ])
         .output()?;
 
@@ -41,8 +71,7 @@ pub fn screenshot_window_bytes(window_id: u32) -> anyhow::Result<Vec<u8>> {
         );
     }
 
-    let bytes = std::fs::read(&tmp_path)?;
-    let _ = std::fs::remove_file(&tmp_path);
+    let bytes = std::fs::read(&tmp_file.path)?;
 
     if bytes.is_empty() {
         anyhow::bail!("screencapture produced empty output for window {window_id}");
@@ -136,4 +165,31 @@ pub fn crosshair_png_bytes(png_bytes: &[u8], cx: f64, cy: f64) -> anyhow::Result
 /// Parse width and height from a PNG file's IHDR chunk.
 pub fn png_dimensions(data: &[u8]) -> anyhow::Result<(u32, u32)> {
     cua_driver_core::image_utils::png_dimensions(data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{window_capture_temp_path, WindowCaptureTempFile};
+
+    #[test]
+    fn window_capture_temp_path_is_unique_per_call() {
+        let first = window_capture_temp_path(129913);
+        let second = window_capture_temp_path(129913);
+
+        assert_ne!(first, second);
+        let first_name = first.file_name().unwrap().to_string_lossy();
+        assert!(first_name.contains("129913"));
+        assert!(first_name.starts_with("cua-driver-rs-capture-"));
+    }
+
+    #[test]
+    fn window_capture_temp_file_is_removed_on_drop() {
+        let temp_file = WindowCaptureTempFile::new(129913);
+        let path = temp_file.path.clone();
+        std::fs::write(&path, b"partial capture").unwrap();
+
+        drop(temp_file);
+
+        assert!(!path.exists());
+    }
 }


### PR DESCRIPTION
## Summary

- Generate a unique temporary path for every macOS window capture using the process ID, window ID, and a process-local atomic sequence.
- Own the path with an RAII guard so partial or unreadable capture files are removed on every return path.
- Add deterministic unit tests for per-call path uniqueness and cleanup-on-drop behavior.

## Why

Window capture currently reuses `/tmp/cua-driver-rs-capture-{window_id}.png`.

Concurrent captures of the same window can therefore overwrite, read, or remove each other's files. Cleanup also happens only after a successful file read, so a failed `screencapture` invocation or read can leave a partial file behind.

A per-capture path removes the same-window collision, while RAII cleanup keeps failure paths from leaking temporary files.

## Relation to #2104

This PR is intentionally separate from #2104.

#2104 adds display-asleep diagnostics and surfaces screenshot failures. This PR does not add or duplicate `screenshot_error`, text diagnostics, display-state detection, or action-result changes. It only hardens the temporary-file lifecycle used by window capture.

After #2104 is rebased onto current `main`, the changes remain complementary: its diagnostics run inside capture failure branches, while this PR ensures the associated temporary file is unique and removed when those branches return.

## Test Plan

- [x] `rustfmt --edition 2021 --check crates/platform-macos/src/capture.rs`
- [x] `cargo check -p platform-macos`
- [x] `cargo test -p platform-macos` — 134 passed, 0 failed
- [x] `git diff --check`

The new tests deterministically verify unique paths and cleanup-on-drop without requiring Screen Recording permission or live TCC changes.

## Caveats

- This focused change covers the window-capture temporary file extracted from the original fix; full-display capture handling is unchanged.
- A package-wide `cargo fmt -p platform-macos -- --check` currently reports pre-existing formatting drift in unrelated files, beginning with `src/apps/mod.rs`. The modified `capture.rs` passes a targeted rustfmt check, and unrelated formatting was intentionally left out of this PR.
- The current #2104 head predates capture error-handling changes already present on `main` and therefore requires rebasing independently of this PR.
