### PR TITLE
fix(release): force-fetch updated release branch

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -48,6 +48,10 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
             "gh pr list --state open --base main --limit 100 --json number",
             workflow,
         )
+        self.assertIn(
+            'git fetch origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"',
+            workflow,
+        )
         self.assertNotIn("if: steps.release.outputs.prs_created == 'true'", workflow)
         self.assertNotIn("RELEASE_PRS: ${{ steps.release.outputs.prs }}", workflow)
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -60,7 +60,9 @@ jobs:
               exit 1
             fi
 
-            git fetch origin "refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
+            # release-please updates the remote branch after checkout, so the
+            # checkout-created remote-tracking ref can no longer fast-forward.
+            git fetch origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
             git checkout -B "$BRANCH" "origin/$BRANCH"
             DRIVER_VERSION=$(tr -d '[:space:]' < libs/cua-driver/rust/VERSION)
             cargo update --manifest-path libs/cua-driver/rust/Cargo.toml \


### PR DESCRIPTION
## What changed

- force-refresh Release Please's generated Driver branch before checking it out
- add a wiring regression assertion for the forced refspec

## Why

Release Please updates its remote branch after `actions/checkout` creates a remote-tracking ref. The lockfile synchronization step then fetched the updated branch without force, so Git rejected the stale local ref as a non-fast-forward update before `Cargo.lock` could be synchronized.

This preserves the existing branch-owner and branch-name safety checks while allowing the trusted generated branch ref to refresh.

## Validation

- 50 release script and wiring tests pass
- Ruff check and format pass
- Actionlint passes for `.github/workflows/release-please.yml`
- `git diff --check` passes

Production failure: https://github.com/trycua/cua/actions/runs/29572214402
