### PR TITLE
fix(release): harden generated release pull requests

### DIFF
--- a/.github/release-attribution-config.json
+++ b/.github/release-attribution-config.json
@@ -9,6 +9,7 @@
   ],
   "ignoredCoauthorEmails": [
     "claude@anthropic.com",
+    "coding-sub-agent@trycua.com",
     "codex@openai.com",
     "cua@cua.localdomain",
     "noreply@anthropic.com"

--- a/.github/scripts/release_attribution.py
+++ b/.github/scripts/release_attribution.py
@@ -45,6 +45,8 @@ SOURCE_PR_RE = re.compile(
     r"\b(?:adapted from|based on|salvaged from|source[- ]?pr)\s*:?[ \t]*(?:(?:https://github\.com/(?P<repository>[^/]+/[^/]+)/pull/)|#)(?P<number>\d+)",
     re.IGNORECASE,
 )
+TRAILING_PR_RE = re.compile(r"\s+\(#(?P<number>\d+)\)\s*$")
+LEGACY_RELEASE_BUMP_RE = re.compile(r"^Bump (?:cua-driver-rs|lume) to v\S+$", re.IGNORECASE)
 NOREPLY_RE = re.compile(
     r"^(?:\d+\+)?(?P<login>[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})(?:\[bot\])?)@users\.noreply\.github\.com$",
     re.IGNORECASE,
@@ -174,10 +176,11 @@ def parse_conventional_line(line: str) -> ConventionalEntry | None:
     match = CONVENTIONAL_RE.match(line.strip())
     if not match:
         return None
+    summary = TRAILING_PR_RE.sub("", match.group("summary").strip()).strip().rstrip(".")
     return ConventionalEntry(
         change_type=match.group("type"),
         scope=match.group("scope"),
-        summary=match.group("summary").strip().rstrip("."),
+        summary=summary,
         breaking=bool(match.group("breaking")),
     )
 
@@ -257,6 +260,31 @@ def select_pull(pulls: Sequence[Mapping[str, Any]], commit_sha: str) -> Mapping[
         candidates = list(pulls)
     candidates = sorted(candidates, key=lambda pull: int(pull.get("number", 0)))
     return candidates[-1]
+
+
+def resolve_pull_for_commit(
+    github: GitHubClient,
+    repository: str,
+    commit: CommitRecord,
+) -> Mapping[str, Any]:
+    """Resolve a commit to its merged PR, including an exact squash-title fallback."""
+    pulls = github.pulls_for_commit(repository, commit.sha)
+    if pulls:
+        selected = select_pull(pulls, commit.sha)
+        return github.pull(repository, int(selected["number"]))
+
+    reference = TRAILING_PR_RE.search(commit.subject)
+    if not reference:
+        raise ReleaseError(f"commit {commit.sha} is not associated with a pull request")
+
+    pull = github.pull(repository, int(reference.group("number")))
+    expected_title = TRAILING_PR_RE.sub("", commit.subject).strip()
+    if not pull.get("merged_at") or str(pull.get("title") or "").strip() != expected_title:
+        raise ReleaseError(
+            f"commit {commit.sha} has an unverified pull request suffix "
+            f"#{reference.group('number')}"
+        )
+    return pull
 
 
 def contributor(
@@ -447,15 +475,16 @@ def build_manifest(
     visual_requested = False
 
     for commit in commits_in_range(repo_root, previous_tag, current_ref, paths, exclude_paths):
-        if re.match(r"^chore(?:\([^)]+\))?: release\b", commit.subject, re.IGNORECASE):
+        if re.match(
+            r"^chore(?:\([^)]+\))?: release\b", commit.subject, re.IGNORECASE
+        ) or LEGACY_RELEASE_BUMP_RE.match(commit.subject):
             continue
         parsed_subject = parse_conventional_line(commit.subject)
         if parsed_subject and parsed_subject.change_type not in RELEASING_TYPES:
             continue
 
-        selected = select_pull(github.pulls_for_commit(repository, commit.sha), commit.sha)
-        pull_number = int(selected["number"])
-        pull = github.pull(repository, pull_number)
+        pull = resolve_pull_for_commit(github, repository, commit)
+        pull_number = int(pull["number"])
         entries = release_entries(commit.subject, commit.body, str(pull.get("body") or ""))
         if not entries:
             continue

--- a/.github/scripts/sync_lume_release_docs.py
+++ b/.github/scripts/sync_lume_release_docs.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Synchronize generated Lume reference-doc versions for a release branch."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import re
+from typing import Sequence
+
+
+DOC_PATHS = (
+    "docs/content/docs/reference/lume/cli-reference.mdx",
+    "docs/content/docs/reference/lume/http-api.mdx",
+)
+
+
+def replace_once(content: str, pattern: str, replacement: str, path: Path) -> str:
+    updated, count = re.subn(pattern, replacement, content, flags=re.MULTILINE)
+    if count != 1:
+        raise RuntimeError(f"expected one release-version marker in {path}; found {count}")
+    return updated
+
+
+def sync_lume_release_docs(root: Path) -> None:
+    version = (root / "libs/lume/VERSION").read_text().strip()
+    for relative in DOC_PATHS:
+        path = root / relative
+        content = path.read_text()
+        content = replace_once(content, r"^  Version: \S+$", f"  Version: {version}", path)
+        content = replace_once(
+            content,
+            r"Documented against Lume \*\*\S+\*\*\.",
+            f"Documented against Lume **{version}**.",
+            path,
+        )
+        path.write_text(content)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    args = parser.parse_args(argv)
+    try:
+        sync_lume_release_docs(args.repo_root.resolve())
+    except (OSError, RuntimeError) as error:
+        print(f"Lume release docs error: {error}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -52,6 +52,8 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
             'git fetch origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"',
             workflow,
         )
+        self.assertIn("sync_lume_release_docs.py", workflow)
+        self.assertIn("chore(lume): synchronize release documentation", workflow)
         self.assertNotIn("if: steps.release.outputs.prs_created == 'true'", workflow)
         self.assertNotIn("RELEASE_PRS: ${{ steps.release.outputs.prs }}", workflow)
 

--- a/.github/scripts/tests/test_release_attribution.py
+++ b/.github/scripts/tests/test_release_attribution.py
@@ -9,6 +9,7 @@ from jsonschema import Draft202012Validator
 
 from release_attribution import (
     CommitRecord,
+    LEGACY_RELEASE_BUMP_RE,
     ReleaseError,
     _change_contributors,
     build_manifest,
@@ -19,6 +20,7 @@ from release_attribution import (
     render_card_svg,
     render_card_alt_text,
     render_social,
+    resolve_pull_for_commit,
     source_pull_numbers,
     validate_pr_title,
 )
@@ -85,6 +87,9 @@ def test_title_validation_and_override_entries():
         ("feat", "add readiness"),
         ("fix", "keep focus"),
     ]
+    assert release_entries("feat(driver): add policies (#2235)", "", "")[0].summary == (
+        "add policies"
+    )
 
 
 def test_login_from_noreply_and_override():
@@ -104,6 +109,42 @@ def test_cross_repository_references_are_not_resolved_in_cua():
     )
     assert linked_issue_numbers(body, "trycua/cua") == [8]
     assert source_pull_numbers(body, "trycua/cua") == [10]
+
+
+def test_exact_squash_title_resolves_when_commit_association_is_missing():
+    class UnassociatedGitHub:
+        def pulls_for_commit(self, repository: str, commit_sha: str):
+            return []
+
+        def pull(self, repository: str, number: int):
+            assert repository == "trycua/cua"
+            assert number == 2235
+            return {
+                "number": 2235,
+                "title": "feat(driver): add YAML and Rego permission policies",
+                "merged_at": "2026-07-15T23:19:09Z",
+            }
+
+    commit = CommitRecord(
+        "abc123",
+        "feat(driver): add YAML and Rego permission policies (#2235)",
+        "",
+    )
+    pull = resolve_pull_for_commit(UnassociatedGitHub(), "trycua/cua", commit)
+    assert pull["number"] == 2235
+
+    with pytest.raises(ReleaseError, match="not associated"):
+        resolve_pull_for_commit(
+            UnassociatedGitHub(),
+            "trycua/cua",
+            CommitRecord("def456", "feat(driver): no pull suffix", ""),
+        )
+
+
+def test_legacy_release_bump_subject_is_recognized():
+    assert LEGACY_RELEASE_BUMP_RE.match("Bump cua-driver-rs to v0.8.3")
+    assert LEGACY_RELEASE_BUMP_RE.match("Bump lume to v0.3.16")
+    assert not LEGACY_RELEASE_BUMP_RE.match("feat(driver): bump reconnect retries")
 
 
 def test_manifest_is_pr_first_and_renders_deterministically(tmp_path: Path):

--- a/.github/scripts/tests/test_sync_lume_release_docs.py
+++ b/.github/scripts/tests/test_sync_lume_release_docs.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import shutil
+
+from sync_lume_release_docs import DOC_PATHS, sync_lume_release_docs
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_sync_lume_release_docs_updates_both_generated_markers(tmp_path: Path):
+    version_path = tmp_path / "libs/lume/VERSION"
+    version_path.parent.mkdir(parents=True)
+    version_path.write_text("9.9.9\n")
+
+    for relative in DOC_PATHS:
+        source = REPO_ROOT / relative
+        destination = tmp_path / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(source, destination)
+
+    sync_lume_release_docs(tmp_path)
+
+    for relative in DOC_PATHS:
+        content = (tmp_path / relative).read_text()
+        assert "Version: 9.9.9" in content
+        assert "Documented against Lume **9.9.9**." in content

--- a/.github/scripts/tests/test_validate_release_versions.py
+++ b/.github/scripts/tests/test_validate_release_versions.py
@@ -16,6 +16,8 @@ def copy_release_sources(destination: Path) -> None:
         target = destination / relative
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copytree(source, target)
+    docs = "docs/content/docs/reference/lume"
+    shutil.copytree(REPO_ROOT / docs, destination / docs)
 
 
 def test_current_release_versions_agree():
@@ -25,6 +27,7 @@ def test_current_release_versions_agree():
 def test_version_drift_fails_with_the_source_name(tmp_path: Path):
     copy_release_sources(tmp_path)
     path = tmp_path / "libs/lume/src/Main.swift"
-    path.write_text(path.read_text().replace('"0.3.16"', '"9.9.9"'))
+    current = (tmp_path / "libs/lume/VERSION").read_text().strip()
+    path.write_text(path.read_text().replace(f'"{current}"', '"9.9.9"'))
     with pytest.raises(VersionError, match="src/Main.swift=9.9.9"):
         validate(tmp_path, "lume")

--- a/.github/scripts/validate_release_versions.py
+++ b/.github/scripts/validate_release_versions.py
@@ -72,6 +72,7 @@ def driver_versions(root: Path) -> tuple[str, dict[str, str]]:
 
 def lume_versions(root: Path) -> tuple[str, dict[str, str]]:
     base = root / "libs/lume"
+    docs = root / "docs/content/docs/reference/lume"
     expected = (base / "VERSION").read_text().strip()
     return expected, {
         "src/Main.swift": read_match(
@@ -79,6 +80,16 @@ def lume_versions(root: Path) -> tuple[str, dict[str, str]]:
         ),
         "scripts/install.sh": read_match(
             base / "scripts/install.sh", r'^LUME_BAKED_VERSION="([^"]+)"'
+        ),
+        "docs/cli-reference.mdx:metadata": read_match(
+            docs / "cli-reference.mdx", r"^  Version: (\S+)$"
+        ),
+        "docs/cli-reference.mdx:body": read_match(
+            docs / "cli-reference.mdx", r"Documented against Lume \*\*(\S+)\*\*\."
+        ),
+        "docs/http-api.mdx:metadata": read_match(docs / "http-api.mdx", r"^  Version: (\S+)$"),
+        "docs/http-api.mdx:body": read_match(
+            docs / "http-api.mdx", r"Documented against Lume \*\*(\S+)\*\*\."
         ),
     }
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,15 +41,18 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      - name: Synchronize Cua Driver Cargo.lock on its release pull request
+      - name: Synchronize generated files on release pull requests
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           while read -r number; do
             PR=$(gh pr view "$number" --json headRefName,headRepositoryOwner,files)
-            if ! echo "$PR" | jq -e \
-              '.files | any(.path == "libs/cua-driver/rust/VERSION")' >/dev/null; then
+            DRIVER=$(echo "$PR" | jq -r \
+              '.files | any(.path == "libs/cua-driver/rust/VERSION")')
+            LUME=$(echo "$PR" | jq -r \
+              '.files | any(.path == "libs/lume/VERSION")')
+            if [[ "$DRIVER" != "true" && "$LUME" != "true" ]]; then
               continue
             fi
 
@@ -64,18 +67,27 @@ jobs:
             # checkout-created remote-tracking ref can no longer fast-forward.
             git fetch origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
             git checkout -B "$BRANCH" "origin/$BRANCH"
-            DRIVER_VERSION=$(tr -d '[:space:]' < libs/cua-driver/rust/VERSION)
-            cargo update --manifest-path libs/cua-driver/rust/Cargo.toml \
-              -p cua-driver --precise "$DRIVER_VERSION"
-            python3 .github/scripts/validate_release_versions.py --product driver
-            git add libs/cua-driver/rust/Cargo.lock
+            if [[ "$DRIVER" == "true" ]]; then
+              DRIVER_VERSION=$(tr -d '[:space:]' < libs/cua-driver/rust/VERSION)
+              cargo update --manifest-path libs/cua-driver/rust/Cargo.toml \
+                -p cua-driver --precise "$DRIVER_VERSION"
+              python3 .github/scripts/validate_release_versions.py --product driver
+              git add libs/cua-driver/rust/Cargo.lock
+              COMMIT_MESSAGE="chore(cua-driver-rs): synchronize release lockfile"
+            else
+              python3 .github/scripts/sync_lume_release_docs.py
+              python3 .github/scripts/validate_release_versions.py --product lume
+              git add docs/content/docs/reference/lume/cli-reference.mdx \
+                docs/content/docs/reference/lume/http-api.mdx
+              COMMIT_MESSAGE="chore(lume): synchronize release documentation"
+            fi
             if git diff --cached --quiet; then
-              echo "Cargo.lock already matches release PR #$number"
+              echo "Generated files already match release PR #$number"
               continue
             fi
             git config user.name "trycua-release[bot]"
             git config user.email "trycua-release[bot]@users.noreply.github.com"
-            git commit -m "chore(cua-driver-rs): synchronize release lockfile"
+            git commit -m "$COMMIT_MESSAGE"
             git push origin "HEAD:$BRANCH"
           done < <(gh pr list --state open --base main --limit 100 --json number --jq '.[].number')
 


### PR DESCRIPTION
## What changed

- resolve a missing GitHub commit association only when an exact trailing `(#PR)` matches a merged PR title
- ignore the legacy release-bump commit and a known coding-agent coauthor identity
- strip squash PR suffixes from release/social summaries
- synchronize Lume’s generated CLI/API version markers on its Release Please branch
- validate those generated doc versions alongside Lume’s other version sources
- make the version-drift test derive the current version instead of hard-coding 0.3.16

## Why

The first production Release Please run correctly created Driver 0.9.0 and Lume 0.4.0 PRs, then surfaced three release-only failures:

1. GitHub returns no commit-to-PR association for the historical #2235 squash commit even though its exact suffix and merged PR title agree.
2. Lume’s generated docs still identify 0.3.16 after the release version changes.
3. The version-drift regression test assumes 0.3.16 and becomes a no-op on the 0.4.0 release branch.

The fallback remains fail-closed: it requires an exact suffix, a merged PR, and an exact PR-title match. Lume’s sync updates only the four generated version markers and the validator verifies them before the bot pushes.

## Validation

- 53 release script and wiring tests pass
- Ruff check and format pass
- Actionlint passes for `.github/workflows/release-please.yml`
- production Driver 0.9.0 and Lume 0.4.0 branches both pass local attribution collection
- both release branches pass checked-in version validation after generated-file synchronization
- `git diff --check` passes

Production run: https://github.com/trycua/cua/actions/runs/29573460597
Generated release PRs: #2288 and #2289
