### PR TITLE
fix(release): rebase generated branches onto main

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -52,6 +52,9 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
             'git fetch origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"',
             workflow,
         )
+        self.assertIn("git rebase origin/main", workflow)
+        self.assertIn('--force-with-lease="refs/heads/$BRANCH:$REMOTE_HEAD"', workflow)
+        self.assertNotIn("git push --force ", workflow)
         self.assertIn("sync_lume_release_docs.py", workflow)
         self.assertIn("chore(lume): synchronize release documentation", workflow)
         self.assertNotIn("if: steps.release.outputs.prs_created == 'true'", workflow)
@@ -96,9 +99,7 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
 
         self.assertNotIn('      - "libs/cua-driver/rust/**"', workflow)
         self.assertEqual(
-            workflow.count(
-                '      - ".github/workflows/ci-distro-compat-cua-driver.yml"'
-            ),
+            workflow.count('      - ".github/workflows/ci-distro-compat-cua-driver.yml"'),
             2,
         )
         self.assertIn('      - "cua-driver-rs-v*"', workflow)
@@ -111,9 +112,7 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
             ".github/workflows/ci-rust-windows.yml",
         ):
             workflow = self.read(relative_path)
-            self.assertNotIn(
-                '      - "libs/cua-driver/rust/**"', workflow, relative_path
-            )
+            self.assertNotIn('      - "libs/cua-driver/rust/**"', workflow, relative_path)
             self.assertIn(
                 '      - "libs/cua-driver/rust/crates/cua-driver/**"',
                 workflow,

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -63,10 +63,16 @@ jobs:
               exit 1
             fi
 
-            # release-please updates the remote branch after checkout, so the
-            # checkout-created remote-tracking ref can no longer fast-forward.
+            # Release Please can update an existing branch that predates the
+            # current workflow. Refresh it, then replay only this trusted bot
+            # branch onto main so validation uses the current release tooling.
+            git fetch origin "+refs/heads/main:refs/remotes/origin/main"
             git fetch origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
+            REMOTE_HEAD=$(git rev-parse "origin/$BRANCH")
             git checkout -B "$BRANCH" "origin/$BRANCH"
+            git config user.name "trycua-release[bot]"
+            git config user.email "trycua-release[bot]@users.noreply.github.com"
+            git rebase origin/main
             if [[ "$DRIVER" == "true" ]]; then
               DRIVER_VERSION=$(tr -d '[:space:]' < libs/cua-driver/rust/VERSION)
               cargo update --manifest-path libs/cua-driver/rust/Cargo.toml \
@@ -83,12 +89,13 @@ jobs:
             fi
             if git diff --cached --quiet; then
               echo "Generated files already match release PR #$number"
-              continue
+            else
+              git commit -m "$COMMIT_MESSAGE"
             fi
-            git config user.name "trycua-release[bot]"
-            git config user.email "trycua-release[bot]@users.noreply.github.com"
-            git commit -m "$COMMIT_MESSAGE"
-            git push origin "HEAD:$BRANCH"
+            if [[ "$(git rev-parse HEAD)" != "$REMOTE_HEAD" ]]; then
+              git push --force-with-lease="refs/heads/$BRANCH:$REMOTE_HEAD" \
+                origin "HEAD:refs/heads/$BRANCH"
+            fi
           done < <(gh pr list --state open --base main --limit 100 --json number --jq '.[].number')
 
       - name: Verify repository release versions


### PR DESCRIPTION
## What changed

- refresh both `main` and the trusted Release Please branch before generated-file work
- rebase the bot-owned release branch onto current `main`
- push the rebased/generated head with an exact `--force-with-lease` expectation
- push a rebase even when Cargo.lock or docs already match
- retain the existing organization-owner and `release-please--branches--*` safety checks

## Why

The current Driver and Lume release branches were opened before the follow-up release tooling landed. Release Please updated their release commits without rebasing their parent, so checking out Lume’s existing branch removed `sync_lume_release_docs.py` and its current validator.

Rebasing these trusted bot branches before synchronization makes every open release PR validate with the current main-branch tooling. The exact remote-head lease prevents overwriting concurrent updates.

## Validation

- 55 release script and wiring tests pass
- Ruff check and format pass
- Actionlint passes for `.github/workflows/release-please.yml`
- Driver 0.9.0 production branch rebases cleanly, updates Cargo.lock, and passes version validation
- Lume 0.4.0 production branch rebases cleanly, synchronizes both generated docs, and passes version validation
- no plain `git push --force` is permitted by the wiring regression assertion
- `git diff --check` passes

Production failure: https://github.com/trycua/cua/actions/runs/29574332920
