### PR TITLE
fix(release): synchronize driver reference versions

### DIFF
--- a/.github/scripts/sync_driver_release_docs.py
+++ b/.github/scripts/sync_driver_release_docs.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Synchronize generated Cua Driver reference-doc versions for a release branch."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import re
+from typing import Sequence
+
+
+DOC_PATHS = (
+    "docs/content/docs/reference/cua-driver/cli-reference.mdx",
+    "docs/content/docs/reference/cua-driver/mcp-tools.mdx",
+)
+
+
+def replace_once(content: str, pattern: str, replacement: str, path: Path) -> str:
+    updated, count = re.subn(pattern, replacement, content, flags=re.MULTILINE)
+    if count != 1:
+        raise RuntimeError(f"expected one release-version marker in {path}; found {count}")
+    return updated
+
+
+def sync_driver_release_docs(root: Path) -> None:
+    version = (root / "libs/cua-driver/rust/VERSION").read_text().strip()
+    for relative in DOC_PATHS:
+        path = root / relative
+        content = path.read_text()
+        content = replace_once(content, r"^  Version: \S+$", f"  Version: {version}", path)
+        if relative.endswith("cli-reference.mdx"):
+            content = replace_once(
+                content,
+                r"Documented against Cua Driver \*\*\S+\*\*\.",
+                f"Documented against Cua Driver **{version}**.",
+                path,
+            )
+        path.write_text(content)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    args = parser.parse_args(argv)
+    try:
+        sync_driver_release_docs(args.repo_root.resolve())
+    except (OSError, RuntimeError) as error:
+        print(f"Cua Driver release docs error: {error}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -55,6 +55,11 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertIn("git rebase origin/main", workflow)
         self.assertIn('--force-with-lease="refs/heads/$BRANCH:$REMOTE_HEAD"', workflow)
         self.assertNotIn("git push --force ", workflow)
+        self.assertIn("sync_driver_release_docs.py", workflow)
+        self.assertIn(
+            "chore(cua-driver-rs): synchronize generated release files",
+            workflow,
+        )
         self.assertIn("sync_lume_release_docs.py", workflow)
         self.assertIn("chore(lume): synchronize release documentation", workflow)
         self.assertNotIn("if: steps.release.outputs.prs_created == 'true'", workflow)

--- a/.github/scripts/tests/test_sync_driver_release_docs.py
+++ b/.github/scripts/tests/test_sync_driver_release_docs.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import shutil
+
+from sync_driver_release_docs import DOC_PATHS, sync_driver_release_docs
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_sync_driver_release_docs_updates_generated_markers(tmp_path: Path):
+    version_path = tmp_path / "libs/cua-driver/rust/VERSION"
+    version_path.parent.mkdir(parents=True)
+    version_path.write_text("9.9.9\n")
+
+    for relative in DOC_PATHS:
+        source = REPO_ROOT / relative
+        destination = tmp_path / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(source, destination)
+
+    sync_driver_release_docs(tmp_path)
+
+    cli = (tmp_path / DOC_PATHS[0]).read_text()
+    mcp = (tmp_path / DOC_PATHS[1]).read_text()
+    assert "Version: 9.9.9" in cli
+    assert "Documented against Cua Driver **9.9.9**." in cli
+    assert "Version: 9.9.9" in mcp

--- a/.github/scripts/tests/test_validate_release_versions.py
+++ b/.github/scripts/tests/test_validate_release_versions.py
@@ -16,8 +16,9 @@ def copy_release_sources(destination: Path) -> None:
         target = destination / relative
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copytree(source, target)
-    docs = "docs/content/docs/reference/lume"
-    shutil.copytree(REPO_ROOT / docs, destination / docs)
+    for product in ("cua-driver", "lume"):
+        docs = f"docs/content/docs/reference/{product}"
+        shutil.copytree(REPO_ROOT / docs, destination / docs)
 
 
 def test_current_release_versions_agree():

--- a/.github/scripts/validate_release_versions.py
+++ b/.github/scripts/validate_release_versions.py
@@ -36,6 +36,7 @@ def require_equal(product: str, expected: str, values: dict[str, str]) -> None:
 
 def driver_versions(root: Path) -> tuple[str, dict[str, str]]:
     base = root / "libs/cua-driver"
+    docs = root / "docs/content/docs/reference/cua-driver"
     expected = (base / "rust/VERSION").read_text().strip()
     cargo = tomllib.loads((base / "rust/Cargo.toml").read_text())
     python_project = tomllib.loads((base / "python/pyproject.toml").read_text())
@@ -51,6 +52,15 @@ def driver_versions(root: Path) -> tuple[str, dict[str, str]]:
         "scripts/install.ps1": read_match(
             base / "scripts/install.ps1",
             r'^\$Script:CuaDriverRsBakedVersion\s*=\s*"([^"]+)"',
+        ),
+        "docs/cli-reference.mdx:metadata": read_match(
+            docs / "cli-reference.mdx", r"^  Version: (\S+)$"
+        ),
+        "docs/cli-reference.mdx:body": read_match(
+            docs / "cli-reference.mdx", r"Documented against Cua Driver \*\*(\S+)\*\*\."
+        ),
+        "docs/mcp-tools.mdx:metadata": read_match(
+            docs / "mcp-tools.mdx", r"^  Version: (\S+)$"
         ),
     }
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -77,9 +77,12 @@ jobs:
               DRIVER_VERSION=$(tr -d '[:space:]' < libs/cua-driver/rust/VERSION)
               cargo update --manifest-path libs/cua-driver/rust/Cargo.toml \
                 -p cua-driver --precise "$DRIVER_VERSION"
+              python3 .github/scripts/sync_driver_release_docs.py
               python3 .github/scripts/validate_release_versions.py --product driver
-              git add libs/cua-driver/rust/Cargo.lock
-              COMMIT_MESSAGE="chore(cua-driver-rs): synchronize release lockfile"
+              git add libs/cua-driver/rust/Cargo.lock \
+                docs/content/docs/reference/cua-driver/cli-reference.mdx \
+                docs/content/docs/reference/cua-driver/mcp-tools.mdx
+              COMMIT_MESSAGE="chore(cua-driver-rs): synchronize generated release files"
             else
               python3 .github/scripts/sync_lume_release_docs.py
               python3 .github/scripts/validate_release_versions.py --product lume


### PR DESCRIPTION
## Summary

- synchronize the allowlisted Cua Driver version markers on Release Please branches
- validate those generated docs alongside the Driver manifests and lockfile
- cover the sync and workflow wiring with regression tests

## Why

The production `cua-driver-rs` 0.9.0 release PR correctly synchronized `Cargo.lock`, but its docs check found three stale `0.8.3` markers in the generated CLI and MCP references. The full generator confirms these are the only differences.

## Validation

- `uvx --from pytest --with jsonschema --with pytest-asyncio pytest .github/scripts/tests -q` (56 passed)
- `.venv/bin/ruff check ...`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release-please.yml`
- applied the sync to PR #2289 locally; release version validation passes and output matches the full docs generator

Production follow-up to #2267, #2290, #2292, and #2293.