### PR TITLE
docs: update README positioning and Driver links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     </picture>
   </a>
 
-  <p align="center">Open-source computer-use infrastructure: background desktop drivers, cross-OS sandboxes, and benchmarks for agent training, evaluation, and data generation.</p>
+  <p align="center">Scale computer-use 2.0 with open-source drivers, cross-OS fleets, and benchmarks for training, evaluation, and data generation.</p>
 
   <p align="center">
     <a href="https://cua.ai" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/cua.ai-0ea5e9" alt="cua.ai"></a>
@@ -75,11 +75,7 @@ Drive native desktop apps **in the background**. Agents click, type, and verify 
 irm https://cua.ai/driver/install.ps1 | iex
 ```
 
-Then wire it into Claude Code as an MCP server and your agent can drive the desktop in the background:
-
-```bash
-claude mcp add --transport stdio cua-driver -- cua-driver mcp
-```
+Then follow the post-install instructions.
 
 **[Drive your first app](https://cua.ai/docs/tutorials/drive-your-first-app)** | **[Installation](https://cua.ai/docs/how-to-guides/driver/install)** | **[CLI Reference](https://cua.ai/docs/reference/cua-driver/cli-reference)**
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     </picture>
   </a>
 
-  <p align="center">Build, benchmark, and deploy agents that use computers</p>
+  <p align="center">Open-source computer-use infrastructure: background desktop drivers, cross-OS sandboxes, and benchmarks for agent training, evaluation, and data generation.</p>
 
   <p align="center">
     <a href="https://cua.ai" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/cua.ai-0ea5e9" alt="cua.ai"></a>
@@ -81,7 +81,9 @@ Then wire it into Claude Code as an MCP server and your agent can drive the desk
 claude mcp add --transport stdio cua-driver -- cua-driver mcp
 ```
 
-Full tool reference, architecture notes, and the optional agent skill pack live here: [`libs/cua-driver/README.md`](libs/cua-driver/README.md).
+**[Drive your first app](https://cua.ai/docs/tutorials/drive-your-first-app)** | **[Installation](https://cua.ai/docs/how-to-guides/driver/install)** | **[CLI Reference](https://cua.ai/docs/reference/cua-driver/cli-reference)**
+
+Source documentation, architecture notes, and the optional agent skill pack live in [`libs/cua-driver/README.md`](libs/cua-driver/README.md).
 
 ---
 


### PR DESCRIPTION
## Summary

- replace the README tagline with the new computer-use infrastructure description
- add direct links to the Cua Driver tutorial, installation guide, and CLI reference
- keep the in-repo Driver documentation link for source and architecture details

## Why

This brings the GitHub landing page in line with the current cua.ai positioning and gives Cua Driver users a clear path into the published documentation.

## Validation

- `git diff --check`
- verified each linked page on `cua.ai/docs`