### PR TITLE
docs: improve and restore Cua Driver demo videos

### DIFF
--- a/docs/content/docs/concepts/the-no-foreground-contract.mdx
+++ b/docs/content/docs/concepts/the-no-foreground-contract.mdx
@@ -45,8 +45,8 @@ The Linux recordings below make that separation visible. Synthetic pointers act 
 
 <div className="not-prose my-8 grid gap-5 md:grid-cols-2">
   <VideoDemo
-    src="https://github.com/user-attachments/assets/13ab4c27-246b-4370-ab48-0082e5449830"
-    poster="https://github.com/user-attachments/assets/d91bb946-700a-4a48-8e05-c08f5c103ea4"
+    src="https://video.twimg.com/amplify_video/2067633339243401216/vid/avc1/1280x720/Azw9Hq-dT5lh2aSP.mp4?tag=28"
+    poster="https://pbs.twimg.com/amplify_video_thumb/2067633339243401216/img/YzbdaelkpEIDyck2.jpg"
     title="Four pointers across two XFCE windows"
     sourceUrl="https://x.com/trycua/status/2067639340738761015"
   >
@@ -54,8 +54,8 @@ The Linux recordings below make that separation visible. Synthetic pointers act 
   </VideoDemo>
 
   <VideoDemo
-    src="https://github.com/user-attachments/assets/6ecc0826-4ecf-41d9-a8ae-6705a6af5e26"
-    poster="https://github.com/user-attachments/assets/4d84b685-3cba-488a-87e0-3a5b048ea4a8"
+    src="https://video.twimg.com/amplify_video/2067633453122879488/vid/avc1/960x540/61AOnEQ5cj582y2R.mp4?tag=28"
+    poster="https://pbs.twimg.com/amplify_video_thumb/2067633453122879488/img/OqG5pYLLRaut2MPX.jpg"
     title="Sixteen background windows on Wayland"
     sourceUrl="https://x.com/trycua/status/2067639344698179789"
   >

--- a/docs/content/docs/how-to-guides/driver/drive-a-web-page.mdx
+++ b/docs/content/docs/how-to-guides/driver/drive-a-web-page.mdx
@@ -12,8 +12,8 @@ binding.
 
 <VideoDemo
   className="my-8"
-  src="https://github.com/user-attachments/assets/e4208b4a-704a-4949-8660-4e25f3ed4db4"
-  poster="https://github.com/user-attachments/assets/92c71c18-76f6-4d1c-984d-6bc85c9fe0ac"
+  src="https://video.twimg.com/amplify_video/2047379829042065408/vid/avc1/1280x720/te2UgRiP_4gm8Giu.mp4?tag=21"
+  poster="https://pbs.twimg.com/amplify_video_thumb/2047379829042065408/img/CI-tPdl5xpLrT6du.jpg"
   title="Chrome remains behind the agent terminal"
   sourceUrl="https://x.com/trycua/status/2047383209244287350"
 >

--- a/docs/content/docs/how-to-guides/driver/record-and-render-a-trajectory.mdx
+++ b/docs/content/docs/how-to-guides/driver/record-and-render-a-trajectory.mdx
@@ -9,8 +9,8 @@ import { Steps, Step } from 'fumadocs-ui/components/steps';
 Record an agent-driven task when you need both the action evidence and a short product demo. Cua Driver saves each action with before-and-after state, screenshots, and arguments. With video enabled, it also captures the display so you can render the trajectory with zoom effects around each action.
 
 <VideoDemo
-  src="https://github.com/user-attachments/assets/df6076f5-b95f-4f34-a5ca-8cfd37140cbc"
-  poster="https://github.com/user-attachments/assets/60330293-9684-4541-b311-15ab833b3451"
+  src="https://video.twimg.com/amplify_video/2047379960906883072/vid/avc1/1280x720/_jOaJRNzaCA2SMXu.mp4?tag=21"
+  poster="https://pbs.twimg.com/amplify_video_thumb/2047379960906883072/img/4KwmUtfWSNjo9ovO.jpg"
   title="Turn an agent trajectory into a zoom-on-click demo"
   sourceUrl="https://x.com/trycua/status/2047383207612645426"
 >

--- a/docs/content/docs/how-to-guides/recipes/automate-a-legacy-windows-app-behind-a-vpn.mdx
+++ b/docs/content/docs/how-to-guides/recipes/automate-a-legacy-windows-app-behind-a-vpn.mdx
@@ -9,8 +9,8 @@ import { Steps, Step } from 'fumadocs-ui/components/steps';
 When a desktop app has **no API** and only runs **behind the corporate VPN**, drive it where it already runs, on the Windows box inside the network. **Cua Driver** runs on that machine and exposes the app through MCP stdio tools, so the desktop session, app traffic, and staged files stay inside the VPN boundary. **No data leaves the VPN boundary.**
 
 <VideoDemo
-  src="https://github.com/user-attachments/assets/77dbfdb2-2b02-4a9d-8f7e-4710f59de803"
-  poster="https://github.com/user-attachments/assets/462a7309-87b4-4d50-b1fc-295314912861"
+  src="https://video.twimg.com/amplify_video/2059693201644978180/vid/avc1/1280x720/jKXB1bMW8aRG0dWs.mp4?tag=27"
+  poster="https://pbs.twimg.com/amplify_video_thumb/2059693201644978180/img/_AvWfXLcuStvWSlr.jpg"
   title="Drive a legacy postal app while the terminal stays in front"
   sourceUrl="https://x.com/trycua/status/2059693301276565841"
 >

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -25,8 +25,8 @@ These recordings show agents operating desktop apps while the user's active wind
 
 <div className="not-prose my-8 grid gap-5 md:grid-cols-2">
   <VideoDemo
-    src="https://github.com/user-attachments/assets/e4208b4a-704a-4949-8660-4e25f3ed4db4"
-    poster="https://github.com/user-attachments/assets/92c71c18-76f6-4d1c-984d-6bc85c9fe0ac"
+    src="https://video.twimg.com/amplify_video/2047379829042065408/vid/avc1/1280x720/te2UgRiP_4gm8Giu.mp4?tag=21"
+    poster="https://pbs.twimg.com/amplify_video_thumb/2047379829042065408/img/CI-tPdl5xpLrT6du.jpg"
     title="Play media in a background Chrome window on macOS"
     sourceUrl="https://x.com/trycua/status/2047383209244287350"
   >
@@ -34,8 +34,8 @@ These recordings show agents operating desktop apps while the user's active wind
   </VideoDemo>
 
 <VideoDemo
-  src="https://github.com/user-attachments/assets/0a094ad7-9c06-4b6f-9f44-f9ca7582ff73"
-  poster="https://github.com/user-attachments/assets/4b5f7c59-5973-4c34-966e-8aed24e3bde0"
+  src="https://video.twimg.com/amplify_video/2059682762781560834/vid/avc1/1280x720/GTmf25E5B9XqbXkc.mp4?tag=27"
+  poster="https://pbs.twimg.com/amplify_video_thumb/2059682762781560834/img/XxaxS_qC4z3Gbwko.jpg"
   title="Build and check a WPF app on Windows"
   sourceUrl="https://x.com/trycua/status/2059688966085853245"
 >
@@ -43,8 +43,8 @@ These recordings show agents operating desktop apps while the user's active wind
 </VideoDemo>
 
 <VideoDemo
-  src="https://github.com/user-attachments/assets/9217a8c0-8e5f-449d-939a-d8b245d27142"
-  poster="https://github.com/user-attachments/assets/5ff7a103-dc48-4781-ab37-c979a0c54d1a"
+  src="https://video.twimg.com/amplify_video/2067633385477111809/vid/avc1/1100x618/-Zg-HqPeUdErYRdB.mp4?tag=28"
+  poster="https://pbs.twimg.com/amplify_video_thumb/2067633385477111809/img/7Q_qNkKr3XqBe13V.jpg"
   title="Check a calculator app on Linux"
   sourceUrl="https://x.com/trycua/status/2067639342944985586"
 >
@@ -53,8 +53,8 @@ These recordings show agents operating desktop apps while the user's active wind
 </VideoDemo>
 
   <VideoDemo
-    src="https://github.com/user-attachments/assets/e10c0534-f0f7-45f6-91f7-3b28fd751e7c"
-    poster="https://github.com/user-attachments/assets/52cfc4a4-1e5a-4cb7-873b-734ebb857958"
+    src="https://video.twimg.com/amplify_video/2067635305172336640/vid/avc1/1600x1000/1vqaHBn2lqWK1DT5.mp4?tag=28"
+    poster="https://pbs.twimg.com/amplify_video_thumb/2067635305172336640/img/62bV-2E7LuEyYIAt.jpg"
     title="Fill a Linux spreadsheet over SSH"
     sourceUrl="https://x.com/trycua/status/2067639346719826213"
   >

--- a/docs/content/docs/tutorials/drive-your-first-app.mdx
+++ b/docs/content/docs/tutorials/drive-your-first-app.mdx
@@ -11,14 +11,14 @@ import { Callout } from 'fumadocs-ui/components/callout';
 You do not type **Cua Driver** CLI commands by hand. Cua Driver is a backend that an agent harness (Claude Code, Codex, Hermes, and others) drives for you. In this tutorial you install Cua Driver, connect your agent, and ask it in plain English to open a calculator and read a result back. Works the same on macOS, Windows, and Linux.
 
 <VideoDemo
-  src="https://github.com/user-attachments/assets/9217a8c0-8e5f-449d-939a-d8b245d27142"
-  poster="https://github.com/user-attachments/assets/5ff7a103-dc48-4781-ab37-c979a0c54d1a"
-  title="Preview: ask an agent to calculate 6 × 7"
-  sourceUrl="https://x.com/trycua/status/2067639342944985586"
+  src="https://github.com/user-attachments/assets/0a094ad7-9c06-4b6f-9f44-f9ca7582ff73"
+  poster="https://github.com/user-attachments/assets/4b5f7c59-5973-4c34-966e-8aed24e3bde0"
+  title="Preview: build, fix, and check a Windows app"
+  sourceUrl="https://x.com/trycua/status/2059688966085853245"
   className="my-8"
 >
-  This Linux recording shows the result you will reproduce: an agent drives Calculator to 42 while
-  the terminal stays in front. The same prompt works on macOS and Windows.
+  Claude Code builds a WPF CRM, drives its interface, fixes a problem, and checks the app again
+  while its terminal stays in front. You will start with a smaller Calculator task below.
 </VideoDemo>
 
 ## 1. Install Cua Driver

--- a/docs/content/docs/tutorials/drive-your-first-app.mdx
+++ b/docs/content/docs/tutorials/drive-your-first-app.mdx
@@ -11,8 +11,8 @@ import { Callout } from 'fumadocs-ui/components/callout';
 You do not type **Cua Driver** CLI commands by hand. Cua Driver is a backend that an agent harness (Claude Code, Codex, Hermes, and others) drives for you. In this tutorial you install Cua Driver, connect your agent, and ask it in plain English to open a calculator and read a result back. Works the same on macOS, Windows, and Linux.
 
 <VideoDemo
-  src="https://github.com/user-attachments/assets/0a094ad7-9c06-4b6f-9f44-f9ca7582ff73"
-  poster="https://github.com/user-attachments/assets/4b5f7c59-5973-4c34-966e-8aed24e3bde0"
+  src="https://video.twimg.com/amplify_video/2059682762781560834/vid/avc1/1280x720/GTmf25E5B9XqbXkc.mp4?tag=27"
+  poster="https://pbs.twimg.com/amplify_video_thumb/2059682762781560834/img/XxaxS_qC4z3Gbwko.jpg"
   title="Preview: build, fix, and check a Windows app"
   sourceUrl="https://x.com/trycua/status/2059688966085853245"
   className="my-8"


### PR DESCRIPTION
## Summary

- replace the weak Linux calculator preview in `Drive your first app` with the clearer Windows WPF build-fix-check recording
- serve all eight embedded Cua Driver demos and their posters from the public X media CDN
- keep each caption and original X post link attached to the corresponding recording

## Why

The tutorial needed a stronger opening example, and the GitHub user-attachment URLs used by the docs were returning 404 responses to anonymous clients. The original highest-resolution X media variants load publicly without signed, expiring URLs.

## Validation

- all 8 `video.twimg.com` MP4 URLs returned `206 video/mp4` anonymously
- all 8 `pbs.twimg.com` poster URLs returned `206 image/jpeg` anonymously
- `./node_modules/.bin/next build` from `docs/`
- `git diff --check`