### PR TITLE
docs: use MSBuild piano demo in first-app tutorial

### DIFF
--- a/docs/content/docs/tutorials/drive-your-first-app.mdx
+++ b/docs/content/docs/tutorials/drive-your-first-app.mdx
@@ -11,14 +11,14 @@ import { Callout } from 'fumadocs-ui/components/callout';
 You do not type **Cua Driver** CLI commands by hand. Cua Driver is a backend that an agent harness (Claude Code, Codex, Hermes, and others) drives for you. In this tutorial you install Cua Driver, connect your agent, and ask it in plain English to open a calculator and read a result back. Works the same on macOS, Windows, and Linux.
 
 <VideoDemo
-  src="https://video.twimg.com/amplify_video/2059682762781560834/vid/avc1/1280x720/GTmf25E5B9XqbXkc.mp4?tag=27"
-  poster="https://pbs.twimg.com/amplify_video_thumb/2059682762781560834/img/XxaxS_qC4z3Gbwko.jpg"
-  title="Preview: build, fix, and check a Windows app"
-  sourceUrl="https://x.com/trycua/status/2059688966085853245"
+  src="https://video.twimg.com/amplify_video/2062231125347778560/vid/avc1/1920x1080/UuLfTw3Fooc_kUcC.mp4?tag=27"
+  poster="https://pbs.twimg.com/amplify_video_thumb/2062231125347778560/img/vw_EYQR-x0H6bfYC.jpg"
+  title="Preview: agents play a Windows piano app"
+  sourceUrl="https://x.com/francedot/status/2062231318294131130"
   className="my-8"
 >
-  Claude Code builds a WPF CRM, drives its interface, fixes a problem, and checks the app again
-  while its terminal stays in front. You will start with a smaller Calculator task below.
+  Cua Driver coordinates several agent cursors to play a Windows piano app at Microsoft Build. You
+  will start with a smaller Calculator task below.
 </VideoDemo>
 
 ## 1. Install Cua Driver


### PR DESCRIPTION
## Summary

- replace the WPF preview in `Drive your first app` with Francesco’s MSBuild piano demo
- use the public 1080p X CDN MP4 and matching poster
- update the title, caption, and source attribution to describe the demo

## Why

The 45-second piano clip communicates Cua Driver visually from its opening frame and is a better introduction to GUI control than the longer WPF workflow.

## Validation

- MP4 returned `206 video/mp4` anonymously
- poster returned `206 image/jpeg` anonymously
- `./node_modules/.bin/next build` from `docs/`
- `git diff --check`