### PR TITLE
fix(core): emit telemetry deprecation warning once

### DIFF
--- a/libs/python/core/cua_core/telemetry/otel.py
+++ b/libs/python/core/cua_core/telemetry/otel.py
@@ -30,6 +30,8 @@ DEFAULT_OTEL_ENDPOINT = "https://otel.cua.ai"
 _initialized = False
 _init_failed = False
 _init_lock = Lock()
+_deprecation_warning_emitted = False
+_deprecation_warning_lock = Lock()
 
 # OTEL components (lazily initialized)
 _meter: Optional[Any] = None
@@ -54,13 +56,20 @@ def is_otel_enabled() -> bool:
     """
     import warnings
 
+    global _deprecation_warning_emitted
+
     disabled_val = os.environ.get("CUA_TELEMETRY_DISABLED", "")
     if disabled_val:
-        warnings.warn(
-            "CUA_TELEMETRY_DISABLED is deprecated. " "Use CUA_TELEMETRY_ENABLED=false instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        if not _deprecation_warning_emitted:
+            with _deprecation_warning_lock:
+                if not _deprecation_warning_emitted:
+                    warnings.warn(
+                        "CUA_TELEMETRY_DISABLED is deprecated. "
+                        "Use CUA_TELEMETRY_ENABLED=false instead.",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
+                    _deprecation_warning_emitted = True
         if disabled_val.lower() in {"1", "true", "yes", "on"}:
             return False
 

--- a/libs/python/core/tests/test_telemetry.py
+++ b/libs/python/core/tests/test_telemetry.py
@@ -5,6 +5,7 @@ All external dependencies (PostHog, file system) are mocked.
 """
 
 import os
+import warnings
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, mock_open, patch
 
@@ -51,6 +52,26 @@ class TestTelemetryEnabled:
         from cua_core.telemetry import is_telemetry_enabled
 
         assert is_telemetry_enabled() is True
+
+
+class TestOtelEnabled:
+    """Test OpenTelemetry enable/disable logic."""
+
+    def test_deprecated_flag_warns_once(self, monkeypatch):
+        """Test repeated checks emit one warning for the deprecated flag."""
+        monkeypatch.setenv("CUA_TELEMETRY_DISABLED", "true")
+
+        from cua_core.telemetry import otel
+
+        monkeypatch.setattr(otel, "_deprecation_warning_emitted", False)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            results = [otel.is_otel_enabled() for _ in range(3)]
+
+        assert results == [False, False, False]
+        assert len(caught) == 1
+        assert caught[0].category is DeprecationWarning
 
 
 class TestPostHogTelemetryClient:


### PR DESCRIPTION
## summary

- guard the `CUA_TELEMETRY_DISABLED` warning with a thread-safe OpenTelemetry module-level flag so it is emitted only once
- preserve the deprecated environment variable's existing behavior
- add a focused regression test using the `always` warning filter

fixes https://github.com/trycua/cua/issues/2313

reported and initially proposed by @ASHUTOSH-KUMAR-RAO.

## testing

- `uv run --project libs/python/core pytest libs/python/core/tests`
- `uvx ruff check libs/python/core/cua_core/telemetry/otel.py libs/python/core/tests/test_telemetry.py`
- `uvx ruff format --check libs/python/core/cua_core/telemetry/otel.py libs/python/core/tests/test_telemetry.py`
