### PR TITLE
feat(cua-driver): standardize computer action telemetry

### DIFF
--- a/docs/content/docs/reference/cua-driver/telemetry.mdx
+++ b/docs/content/docs/reference/cua-driver/telemetry.mdx
@@ -64,6 +64,7 @@ Every schema-v3 client event has this fixed envelope:
 | `os_major`                 | Major operating-system version only                       |
 | `arch`                     | Bounded CPU architecture                                  |
 | `is_ci`                    | Whether a recognized CI environment is present            |
+| `is_synthetic`             | Explicit Cua-owned test marker; `false` by default         |
 | `transport`                | `cli`, `daemon`, `mcp_stdio`, `mcp_http`, or `unknown`    |
 | `process_session_id`       | Random ID created once per process and never persisted    |
 | `id_persisted`             | Whether the installation ID came from durable local state |
@@ -79,10 +80,10 @@ The client does not send an IP address as an event property. PostHog derives a c
 | `cua_driver_installation_registered`     | `install_channel`                                                                                                                                           |
 | `cua_driver_release_installed`           | `install_channel`, `product_version`                                                                                                                        |
 | `cua_driver_serve`                       | None. Transitional process-start event for `cua-driver serve`; `transport` is `daemon`                                                                      |
-| `cua_driver_cli_completed`               | Fixed `command`, allowlisted tool for `call`, bounded `operation`, bounded MCP `client_kind`, `success`, `exit_class`, and `duration_bucket`                  |
+| `cua_driver_cli_completed`               | Fixed `command`, allowlisted tool for `call`, bounded `operation`, `computer_action`, bounded MCP `client_kind`, `success`, `exit_class`, and `duration_bucket` |
 | `cua_driver_mcp_startup_completed`       | execution path, bounded daemon state, success, duration bucket, and `execution_mode`                                                                         |
 | `cua_driver_mcp_session_started`         | normalized MCP client and protocol, capability booleans, optional reported agent context, and `execution_mode`                                              |
-| `cua_driver_mcp_tool_completed`          | allowlisted tool, bounded `operation`, protocol success, error class, structured-refusal code, duration bucket, output shape and size buckets, and `execution_mode` |
+| `cua_driver_mcp_tool_completed`          | allowlisted tool, bounded compound-tool `operation`, `computer_action`, protocol success, error class, structured-refusal code, duration bucket, output shape and size buckets, and `execution_mode` |
 | `cua_driver_agent_session_started`       | declaration kind, revival flag, concurrent-session bucket, entry transport, and `execution_mode`                                                            |
 | `cua_driver_agent_session_ended`         | end reason, duration and count buckets, browser-refusal bucket, success flags, feature-family flags, multi-transport flag, and `execution_mode`              |
 | `cua_driver_permissions_gate_started`    | missing-permission booleans                                                                                                                                  |
@@ -125,6 +126,8 @@ The end event is emitted for `end_session` and idle eviction. It contains aggreg
 Computer-action success covers fixed pointer and keyboard capabilities, app launch and kill, window activation, state-changing `page` operations, and successful `browser_navigate`, `browser_click`, and `browser_type` calls. A structured browser refusal does not count as a completed computer action. `get_browser_state` is a read, and `browser_prepare` is tracked as browser use rather than a computer action because preparation may either reuse an endpoint or produce an approved visible side effect.
 
 The end event includes `used_browser` and a bounded `browser_refusal_count_bucket`. It does not include browser targets, pages, profiles, or per-site information.
+
+Per-call `computer_action` is derived from the same fixed classifier used by the session aggregate. It describes the tool category; combine it with `success=true` when measuring value. Cua-owned automated tests can set `CUA_DRIVER_TELEMETRY_SYNTHETIC=true`. This marks every event from that process with `is_synthetic=true` so product metrics can exclude test traffic without relying on installation IDs. Third-party CI remains independently identified by `is_ci`.
 
 For finite CLI commands, `operation` distinguishes only reviewed verbs for recording, permissions, config, autostart, skills, and update. `client_kind` is populated only for `mcp-config`. Unknown values become `other`; commands without a meaningful sub-operation use `not_applicable`.
 

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/server.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/server.rs
@@ -231,6 +231,10 @@ pub struct ToolCompletionObservation {
     /// this through the registry allowlist and use an `unknown` fallback.
     pub tool_name: String,
     pub operation: ToolOperation,
+    /// Whether the fixed tool/operation category can change computer state.
+    /// This is derived before argument content is discarded; no argument
+    /// value is retained in the observation.
+    pub computer_action: bool,
     pub success: bool,
     pub error_class: ToolErrorClass,
     pub refusal_code: ToolRefusalCode,
@@ -347,6 +351,38 @@ pub fn tool_operation(tool_name: &str, args: Option<&serde_json::Value>) -> Tool
         }
         _ => ToolOperation::NotApplicable,
     }
+}
+
+/// Classify a tool and its already-bounded operation as a computer action.
+///
+/// Keeping this at the dispatch boundary gives session aggregates and
+/// per-call telemetry one definition without retaining selectors, text, URLs,
+/// or any other tool argument.
+pub fn is_computer_action(tool_name: &str, operation: ToolOperation) -> bool {
+    if tool_name == "page" {
+        return matches!(
+            operation,
+            ToolOperation::ClickElement
+                | ToolOperation::InsertText
+                | ToolOperation::TypeKeystrokes
+                | ToolOperation::EnableJavascriptAppleEvents
+        );
+    }
+    crate::tool::default_capabilities_for(tool_name)
+        .iter()
+        .any(|capability| {
+            capability.starts_with("input.pointer.")
+                || capability.starts_with("input.keyboard.")
+                || matches!(
+                    capability.as_str(),
+                    "app.launch"
+                        | "app.kill"
+                        | "window.activate"
+                        | "browser.navigate"
+                        | "browser.input.click"
+                        | "browser.input.type"
+                )
+        })
 }
 
 /// Which stdio execution path produced a response. This only affects the
@@ -632,6 +668,7 @@ fn classify_tool_completion(
         .unwrap_or(OutputSizeBucket::Empty);
 
     ToolCompletionObservation {
+        computer_action: is_computer_action(&timer.tool_name, timer.operation),
         tool_name: timer.tool_name,
         operation: timer.operation,
         success,
@@ -873,18 +910,19 @@ mod observation_tests {
 
     #[test]
     fn page_operation_is_closed_and_retains_no_argument_content() {
-        for (action, expected) in [
-            ("execute_javascript", ToolOperation::ExecuteJavascript),
-            ("get_text", ToolOperation::GetText),
-            ("query_dom", ToolOperation::QueryDom),
-            ("click_element", ToolOperation::ClickElement),
-            ("insert_text", ToolOperation::InsertText),
-            ("type_keystrokes", ToolOperation::TypeKeystrokes),
+        for (action, expected, computer_action) in [
+            ("execute_javascript", ToolOperation::ExecuteJavascript, false),
+            ("get_text", ToolOperation::GetText, false),
+            ("query_dom", ToolOperation::QueryDom, false),
+            ("click_element", ToolOperation::ClickElement, true),
+            ("insert_text", ToolOperation::InsertText, true),
+            ("type_keystrokes", ToolOperation::TypeKeystrokes, true),
             (
                 "enable_javascript_apple_events",
                 ToolOperation::EnableJavascriptAppleEvents,
+                true,
             ),
-            ("private-custom-action", ToolOperation::Other),
+            ("private-custom-action", ToolOperation::Other, false),
         ] {
             let args = serde_json::json!({
                 "action": action,
@@ -894,6 +932,7 @@ mod observation_tests {
             });
             let operation = tool_operation("page", Some(&args));
             assert_eq!(operation, expected);
+            assert_eq!(is_computer_action("page", operation), computer_action);
             let debug = format!("{operation:?}");
             for forbidden in ["private selector", "private script", "private typed text"] {
                 assert!(!debug.contains(forbidden));
@@ -903,6 +942,11 @@ mod observation_tests {
             tool_operation("click", Some(&serde_json::json!({"action": "private"}))),
             ToolOperation::NotApplicable
         );
+        assert!(is_computer_action("click", ToolOperation::NotApplicable));
+        assert!(!is_computer_action(
+            "get_window_state",
+            ToolOperation::NotApplicable
+        ));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/session.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/session.rs
@@ -210,35 +210,6 @@ fn is_trackable(id: &str) -> bool {
     !id.is_empty() && id != "default"
 }
 
-fn is_computer_action(tool_name: &str, args: &serde_json::Value) -> bool {
-    if tool_name == "page" {
-        return matches!(
-            args.get("action").and_then(serde_json::Value::as_str),
-            Some(
-                "click_element"
-                    | "insert_text"
-                    | "type_keystrokes"
-                    | "enable_javascript_apple_events"
-            )
-        );
-    }
-    crate::tool::default_capabilities_for(tool_name)
-        .iter()
-        .any(|capability| {
-            capability.starts_with("input.pointer.")
-                || capability.starts_with("input.keyboard.")
-                || matches!(
-                    capability.as_str(),
-                    "app.launch"
-                        | "app.kill"
-                        | "window.activate"
-                        | "browser.navigate"
-                        | "browser.input.click"
-                        | "browser.input.type"
-                )
-        })
-}
-
 /// Begin bounded observation for a known tool call carrying a public,
 /// caller-declared `session`. Reserved `_session_id` fallbacks and anonymous
 /// identities are deliberately ignored.
@@ -283,7 +254,10 @@ pub fn begin_tool_call(
     SESSION_OBSERVER.get().map(|_| SessionToolContext {
         session_id: session_id.to_owned(),
         transport,
-        computer_action: is_computer_action(tool_name, args),
+        computer_action: crate::server::is_computer_action(
+            tool_name,
+            crate::server::tool_operation(tool_name, Some(args)),
+        ),
     })
 }
 
@@ -479,10 +453,18 @@ mod tests {
     fn browser_mutations_are_computer_actions_but_reads_and_prepare_are_not() {
         let args = serde_json::json!({"session": "test-session"});
         for tool_name in ["browser_navigate", "browser_click", "browser_type"] {
-            assert!(is_computer_action(tool_name, &args), "tool={tool_name}");
+            let operation = crate::server::tool_operation(tool_name, Some(&args));
+            assert!(
+                crate::server::is_computer_action(tool_name, operation),
+                "tool={tool_name}"
+            );
         }
         for tool_name in ["get_browser_state", "browser_prepare"] {
-            assert!(!is_computer_action(tool_name, &args), "tool={tool_name}");
+            let operation = crate::server::tool_operation(tool_name, Some(&args));
+            assert!(
+                !crate::server::is_computer_action(tool_name, operation),
+                "tool={tool_name}"
+            );
         }
     }
 

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -268,6 +268,28 @@ pub fn finite_tool_name_from_argv() -> Option<String> {
     finite_tool_name_from_args(&args)
 }
 
+/// Return whether a finite `call` targets a fixed computer-action category.
+/// JSON is inspected only long enough to classify the closed `page.action`
+/// vocabulary and is never retained or passed to telemetry.
+pub fn finite_computer_action_from_argv() -> bool {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    finite_computer_action_from_args(&args)
+}
+
+fn finite_computer_action_from_args(args: &[String]) -> bool {
+    let Some(tool_name) = finite_tool_name_from_args(args) else {
+        return false;
+    };
+    let positionals = positional_args(args);
+    let json_arg = match positionals.as_slice() {
+        ["call", _, json, ..] | [_, json, ..] => Some(*json),
+        _ => None,
+    };
+    let parsed_args = json_arg.and_then(|json| serde_json::from_str(json).ok());
+    let operation = cua_driver_core::server::tool_operation(&tool_name, parsed_args.as_ref());
+    cua_driver_core::server::is_computer_action(&tool_name, operation)
+}
+
 /// Return the bounded sub-operation for a finite command. This classifier
 /// reads only the command verb, a reviewed subcommand, and the presence of
 /// `--apply`; arbitrary values never leave this function.
@@ -3607,6 +3629,28 @@ mod tests {
             None
         );
         assert_eq!(finite_tool_name_from_args(&args(&["mcp"])), None);
+    }
+
+    #[test]
+    fn finite_computer_action_discards_arguments_after_fixed_classification() {
+        assert!(finite_computer_action_from_args(&args(&[
+            "call",
+            "click",
+            r#"{"x":1,"private":"discarded"}"#,
+        ])));
+        assert!(finite_computer_action_from_args(&args(&[
+            "call",
+            "page",
+            r#"{"action":"insert_text","text":"private"}"#,
+        ])));
+        assert!(!finite_computer_action_from_args(&args(&[
+            "call",
+            "page",
+            r#"{"action":"query_dom","selector":"private"}"#,
+        ])));
+        assert!(!finite_computer_action_from_args(&args(&[
+            "call", "page", "not-json",
+        ])));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver/src/main.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/main.rs
@@ -70,6 +70,7 @@ fn maybe_wrap_finite_command() {
         return;
     };
     let tool_name = cli::finite_tool_name_from_argv();
+    let computer_action = cli::finite_computer_action_from_argv();
     let operation = cli::finite_operation_from_argv();
     let client_kind = cli::finite_client_kind_from_argv();
     telemetry::spawn_first_run_registration_worker();
@@ -88,6 +89,7 @@ fn maybe_wrap_finite_command() {
     telemetry::spawn_cli_completion_worker(
         command_name,
         tool_name.as_deref(),
+        computer_action,
         operation,
         client_kind,
         exit_code,

--- a/libs/cua-driver/rust/crates/cua-driver/src/telemetry.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/telemetry.rs
@@ -42,11 +42,13 @@ const RELEASE_RECORDED_DIRECTORY: &str = ".release_installed";
 pub const ENV_TELEMETRY_ENABLED: &str = "CUA_DRIVER_RS_TELEMETRY_ENABLED";
 const ENV_TELEMETRY_ENABLED_COMPAT: &str = "CUA_TELEMETRY_ENABLED";
 const ENV_TELEMETRY_DEBUG: &str = "CUA_DRIVER_RS_TELEMETRY_DEBUG";
+const ENV_TELEMETRY_SYNTHETIC: &str = "CUA_DRIVER_TELEMETRY_SYNTHETIC";
 const ENV_TELEMETRY_HOME: &str = "CUA_DRIVER_TELEMETRY_HOME";
 const ENV_CLI_WRAPPED_CHILD: &str = "CUA_DRIVER_CLI_TELEMETRY_CHILD";
 const ENV_CLI_COMPLETION_WORKER: &str = "CUA_DRIVER_CLI_TELEMETRY_WORKER";
 const ENV_CLI_COMPLETION_COMMAND: &str = "CUA_DRIVER_CLI_TELEMETRY_COMMAND";
 const ENV_CLI_COMPLETION_TOOL: &str = "CUA_DRIVER_CLI_TELEMETRY_TOOL";
+const ENV_CLI_COMPLETION_COMPUTER_ACTION: &str = "CUA_DRIVER_CLI_TELEMETRY_COMPUTER_ACTION";
 const ENV_CLI_COMPLETION_OPERATION: &str = "CUA_DRIVER_CLI_TELEMETRY_OPERATION";
 const ENV_CLI_COMPLETION_CLIENT_KIND: &str = "CUA_DRIVER_CLI_TELEMETRY_CLIENT_KIND";
 const ENV_CLI_COMPLETION_EXIT_CODE: &str = "CUA_DRIVER_CLI_TELEMETRY_EXIT_CODE";
@@ -225,6 +227,7 @@ pub fn inspect_event(event_name: &str) -> Result<Value, String> {
             ("command", Value::String("other".into())),
             ("tool_name", Value::String("not_applicable".into())),
             ("operation", Value::String("not_applicable".into())),
+            ("computer_action", Value::Bool(false)),
             ("client_kind", Value::String("not_applicable".into())),
             ("success", Value::Bool(true)),
             ("exit_class", Value::String("success".into())),
@@ -249,6 +252,7 @@ pub fn inspect_event(event_name: &str) -> Result<Value, String> {
         event::MCP_TOOL_COMPLETED => bounded_properties(&[
             ("tool_name", Value::String("other".into())),
             ("operation", Value::String("not_applicable".into())),
+            ("computer_action", Value::Bool(false)),
             ("success", Value::Bool(true)),
             ("error_class", Value::String("none".into())),
             ("refusal_code", Value::String("none".into())),
@@ -773,6 +777,7 @@ fn tool_completion_properties(
     bounded_properties(&[
         ("tool_name", Value::String(tool_name)),
         ("operation", Value::String(outcome.operation.as_str().into())),
+        ("computer_action", Value::Bool(outcome.computer_action)),
         ("success", Value::Bool(outcome.success)),
         ("error_class", Value::String(error_class.into())),
         ("refusal_code", Value::String(outcome.refusal_code.as_str().into())),
@@ -1164,6 +1169,7 @@ pub(crate) fn capture_bounded(
 pub(crate) fn capture_cli_completed(
     command: &'static str,
     tool_name: Option<&str>,
+    computer_action: bool,
     operation: &str,
     client_kind: &str,
     exit_code: i32,
@@ -1215,6 +1221,7 @@ pub(crate) fn capture_cli_completed(
             ("command", Value::String(command.into())),
             ("tool_name", Value::String(tool_name.into())),
             ("operation", Value::String(operation.into())),
+            ("computer_action", Value::Bool(command == "call" && computer_action)),
             ("client_kind", Value::String(client_kind.into())),
             ("success", Value::Bool(success)),
             ("exit_class", Value::String(exit_class.into())),
@@ -1255,11 +1262,13 @@ pub(crate) fn run_cli_completion_worker_if_requested() -> bool {
         .unwrap_or_default();
     let command = fixed_cli_command(&command);
     let tool_name = std::env::var(ENV_CLI_COMPLETION_TOOL).ok();
+    let computer_action = parse_env_bool(ENV_CLI_COMPLETION_COMPUTER_ACTION).unwrap_or(false);
     let operation = std::env::var(ENV_CLI_COMPLETION_OPERATION).unwrap_or_default();
     let client_kind = std::env::var(ENV_CLI_COMPLETION_CLIENT_KIND).unwrap_or_default();
     capture_cli_completed(
         command,
         tool_name.as_deref(),
+        computer_action,
         &operation,
         &client_kind,
         exit_code,
@@ -1271,6 +1280,7 @@ pub(crate) fn run_cli_completion_worker_if_requested() -> bool {
 pub(crate) fn spawn_cli_completion_worker(
     command: &'static str,
     tool_name: Option<&str>,
+    computer_action: bool,
     operation: &str,
     client_kind: &str,
     exit_code: i32,
@@ -1284,6 +1294,7 @@ pub(crate) fn spawn_cli_completion_worker(
     worker
         .env(ENV_CLI_COMPLETION_WORKER, "1")
         .env(ENV_CLI_COMPLETION_COMMAND, fixed_cli_command(command))
+        .env(ENV_CLI_COMPLETION_COMPUTER_ACTION, if computer_action { "1" } else { "0" })
         .env(ENV_CLI_COMPLETION_OPERATION, fixed_cli_operation(command, operation))
         .env(ENV_CLI_COMPLETION_CLIENT_KIND, fixed_cli_client_kind(command, client_kind))
         .env(ENV_CLI_COMPLETION_EXIT_CODE, exit_code.to_string())
@@ -1414,6 +1425,10 @@ fn build_payload(
     event_properties.insert("os_major".into(), Value::String(os_major()));
     event_properties.insert("arch".into(), Value::String(arch().into()));
     event_properties.insert("is_ci".into(), Value::Bool(is_ci()));
+    event_properties.insert(
+        "is_synthetic".into(),
+        Value::Bool(parse_env_bool(ENV_TELEMETRY_SYNTHETIC).unwrap_or(false)),
+    );
     event_properties.insert("transport".into(), Value::String(transport.as_str().into()));
     event_properties.insert("process_session_id".into(), Value::String(process_session_id()));
     event_properties.insert("id_persisted".into(), Value::Bool(identity.persisted));
@@ -2269,13 +2284,14 @@ mod tests {
         let properties = payload["properties"].as_object().unwrap();
         for required in [
             "telemetry_schema_version", "product_version", "os_family", "os_major",
-            "arch", "is_ci", "transport", "process_session_id", "id_persisted",
+            "arch", "is_ci", "is_synthetic", "transport", "process_session_id", "id_persisted",
             "$process_person_profile", "$lib", "$lib_version",
             "tool_name", "success",
         ] {
             assert!(properties.contains_key(required), "missing {required}");
         }
         assert_eq!(properties["telemetry_schema_version"], 3);
+        assert_eq!(properties["is_synthetic"], false);
         assert!(!properties.contains_key("$geoip_disable"));
         assert!(!properties.contains_key("$ip"));
         let serialized = serde_json::to_string(&payload).unwrap().to_ascii_lowercase();
@@ -2285,6 +2301,23 @@ mod tests {
             "url", "raw_error", "stack_trace", "initialize_payload",
         ] {
             assert!(!serialized.contains(forbidden), "payload contains {forbidden}: {serialized}");
+        }
+    }
+
+    #[test]
+    fn synthetic_marker_is_explicit_and_common_to_all_events() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os(ENV_TELEMETRY_SYNTHETIC);
+        unsafe {
+            std::env::set_var(ENV_TELEMETRY_SYNTHETIC, "true");
+        }
+        let payload = inspect_event(event::MCP_TOOL_COMPLETED).unwrap();
+        assert_eq!(payload["properties"]["is_synthetic"], true);
+        unsafe {
+            match original {
+                Some(value) => std::env::set_var(ENV_TELEMETRY_SYNTHETIC, value),
+                None => std::env::remove_var(ENV_TELEMETRY_SYNTHETIC),
+            }
         }
     }
 
@@ -2306,6 +2339,7 @@ mod tests {
         assert_eq!(tool["properties"]["duration_bucket"], "lt_10ms");
         assert_eq!(tool["properties"]["operation"], "not_applicable");
         assert_eq!(tool["properties"]["refusal_code"], "none");
+        assert_eq!(tool["properties"]["computer_action"], false);
         assert!(matches!(
             tool["properties"]["execution_mode"].as_str(),
             Some("embedded" | "standalone")
@@ -2426,6 +2460,7 @@ mod tests {
             &ToolCompletionObservation {
                 tool_name: "click".into(),
                 operation: cua_driver_core::server::ToolOperation::NotApplicable,
+                computer_action: true,
                 success: true,
                 error_class: ToolErrorClass::None,
                 refusal_code: cua_driver_core::server::ToolRefusalCode::None,
@@ -2440,6 +2475,7 @@ mod tests {
             &ToolCompletionObservation {
                 tool_name: "page".into(),
                 operation: cua_driver_core::server::ToolOperation::QueryDom,
+                computer_action: false,
                 success: false,
                 error_class: ToolErrorClass::InternalError,
                 refusal_code: cua_driver_core::server::ToolRefusalCode::None,
@@ -2501,6 +2537,7 @@ mod tests {
         let outcome = ToolCompletionObservation {
             tool_name: "browser_click".into(),
             operation: ToolOperation::BrowserClickTrusted,
+            computer_action: true,
             success: true,
             error_class: ToolErrorClass::None,
             refusal_code: ToolRefusalCode::BrowserInputTrustUnavailable,
@@ -2590,6 +2627,7 @@ mod tests {
                 ToolCompletionObservation {
                     tool_name: "browser_prepare".into(),
                     operation: ToolOperation::BrowserPrepareExistingProfile,
+                    computer_action: false,
                     success: true,
                     error_class: ToolErrorClass::None,
                     refusal_code: ToolRefusalCode::BrowserConsentRevoked,
@@ -2618,6 +2656,7 @@ mod tests {
         let properties = tool_completion_properties(ToolCompletionObservation {
             tool_name: "click".into(),
             operation: cua_driver_core::server::ToolOperation::NotApplicable,
+            computer_action: true,
             success: true,
             error_class: ToolErrorClass::None,
             refusal_code: cua_driver_core::server::ToolRefusalCode::None,
@@ -2638,6 +2677,7 @@ mod tests {
         assert_eq!(payload["properties"]["transport"], "mcp_http");
         assert_eq!(payload["properties"]["tool_name"], "click");
         assert_eq!(payload["properties"]["operation"], "not_applicable");
+        assert_eq!(payload["properties"]["computer_action"], true);
         assert_eq!(payload["properties"]["success"], true);
     }
 
@@ -2650,6 +2690,7 @@ mod tests {
         let properties = tool_completion_properties(ToolCompletionObservation {
             tool_name: "page".into(),
             operation: ToolOperation::InsertText,
+            computer_action: true,
             success: true,
             error_class: ToolErrorClass::None,
             refusal_code: cua_driver_core::server::ToolRefusalCode::None,
@@ -2658,6 +2699,7 @@ mod tests {
             output_size_bucket: OutputSizeBucket::Under1KiB,
         });
         assert_eq!(properties["operation"], "insert_text");
+        assert_eq!(properties["computer_action"], true);
         let serialized = serde_json::to_string(&properties).unwrap();
         for forbidden in ["selector", "private typed text", "script"] {
             assert!(!serialized.contains(forbidden));


### PR DESCRIPTION
## Summary

- classify privacy-bounded computer actions consistently across MCP, CLI, and session telemetry
- add an explicit synthetic-event marker so QA traffic can be excluded
- document the event contract and cover it with regression tests
- preserve structured browser refusals so refused actions do not become successful value events

## Validation

- `cargo test -p cua-driver-core --lib`
- `cargo test -p cua-driver --bin cua-driver`
- `git diff --check`