### PR TITLE
Use stable assets for docs videos

### DIFF
--- a/docs/content/docs/concepts/the-no-foreground-contract.mdx
+++ b/docs/content/docs/concepts/the-no-foreground-contract.mdx
@@ -45,8 +45,8 @@ The Linux recordings below make that separation visible. Synthetic pointers act 
 
 <div className="not-prose my-8 grid gap-5 md:grid-cols-2">
   <VideoDemo
-    src="https://video.twimg.com/amplify_video/2067633339243401216/vid/avc1/1280x720/Azw9Hq-dT5lh2aSP.mp4?tag=28"
-    poster="https://pbs.twimg.com/amplify_video_thumb/2067633339243401216/img/YzbdaelkpEIDyck2.jpg"
+    src="https://trycua.github.io/assets/videos/cua-driver/linux-multi-pointers.mp4"
+    poster="https://trycua.github.io/assets/posters/cua-driver/linux-multi-pointers.jpg"
     title="Four pointers across two XFCE windows"
     sourceUrl="https://x.com/trycua/status/2067639340738761015"
   >
@@ -54,14 +54,27 @@ The Linux recordings below make that separation visible. Synthetic pointers act 
   </VideoDemo>
 
   <VideoDemo
-    src="https://video.twimg.com/amplify_video/2067633453122879488/vid/avc1/960x540/61AOnEQ5cj582y2R.mp4?tag=28"
-    poster="https://pbs.twimg.com/amplify_video_thumb/2067633453122879488/img/OqG5pYLLRaut2MPX.jpg"
+    src="https://trycua.github.io/assets/videos/cua-driver/linux-wayland-16-cursors.mp4"
+    poster="https://trycua.github.io/assets/posters/cua-driver/linux-wayland-16-cursors.jpg"
     title="Sixteen background windows on Wayland"
     sourceUrl="https://x.com/trycua/status/2067639344698179789"
   >
     Sixteen pointers draw in separate windows around a foreground window that Cua Driver does not operate.
   </VideoDemo>
 </div>
+
+The next recording shows the same background behavior during a complete development loop on macOS.
+The agent tests and fixes an app while the terminal remains in front.
+
+<VideoDemo
+  className="my-8"
+  src="https://trycua.github.io/assets/videos/cua-driver/macos-background-dev-loop.mp4"
+  poster="https://trycua.github.io/assets/posters/cua-driver/macos-background-dev-loop.jpg"
+  title="Fix and check an app without taking over the desktop"
+  sourceUrl="https://x.com/trycua/status/2047383205444251889"
+>
+  The terminal stays active while Cua Driver operates Chrome and a native task app behind it.
+</VideoDemo>
 
 ## How fallback works
 

--- a/docs/content/docs/cuabench/index.mdx
+++ b/docs/content/docs/cuabench/index.mdx
@@ -1,0 +1,60 @@
+---
+title: What is Cua-Bench?
+description: Understand how Cua-Bench defines, runs, and scores verifiable computer-use tasks.
+---
+
+# What is Cua-Bench?
+
+Cua-Bench is an MIT-licensed framework for computer-use benchmarks and reinforcement-learning
+environments. It packages the task, starting state, agent interface, and evaluator needed to run a
+repeatable experiment across Linux, Windows, Android, browser, or simulated environments.
+
+<VideoDemo
+  className="my-8"
+  src="https://trycua.github.io/assets/videos/cua-bench/open-source-overview.mp4"
+  poster="https://trycua.github.io/assets/posters/cua-bench/open-source-overview.jpg"
+  title="An open-source registry and runner for computer-use tasks"
+  sourceUrl="https://x.com/trycua/status/2014406820887183512"
+>
+  The overview follows a task from the registry through variations, agent adapters, the CLI runner,
+  and self-hosted execution.
+</VideoDemo>
+
+## Why tasks are environments
+
+A computer-use score is meaningful only when the starting state and success condition are
+repeatable. A Cua-Bench task therefore defines more than a prompt. It prepares an environment,
+exposes observations and actions to an agent, and evaluates the final state with task-specific
+checks.
+
+Task variations test whether an agent can solve the same objective from different inputs or
+starting conditions. Datasets group related tasks so a run can use one agent configuration and
+produce comparable traces and scores.
+
+## How the pieces fit
+
+- **Tasks** define the prompt, setup, variations, and evaluator.
+- **Providers** supply the browser, simulated surface, container, VM, or hosted computer where the
+  task runs.
+- **Agent adapters** connect a model or agent implementation to the environment interface.
+- **The runner** executes one task or a dataset, records traces, and supports parallel workers.
+
+This separation lets the same task definition run against different agents and infrastructure. It
+also keeps evaluation logic independent from the model being tested.
+
+## Relationship to the rest of Cua
+
+Cua-Bench supplies the task and evaluation layer. Cua computer and sandbox components supply
+machine environments, while agent adapters translate model output into computer actions. The
+resulting trajectory can be inspected, scored, or used as training data.
+
+import { Card, Cards } from 'fumadocs-ui/components/card';
+
+<Cards>
+  <Card title="Browse the source" href="https://github.com/trycua/cua/tree/main/libs/cua-bench">
+    Read the package, task examples, CLI implementation, and test suite.
+  </Card>
+  <Card title="Browse the task registry" href="https://cuabench.ai/registry">
+    Explore published tasks and the applications they cover.
+  </Card>
+</Cards>

--- a/docs/content/docs/cuabench/meta.json
+++ b/docs/content/docs/cuabench/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Cua-Bench",
+  "pages": ["index"]
+}

--- a/docs/content/docs/how-to-guides/driver/drive-a-web-page.mdx
+++ b/docs/content/docs/how-to-guides/driver/drive-a-web-page.mdx
@@ -12,8 +12,8 @@ binding.
 
 <VideoDemo
   className="my-8"
-  src="https://video.twimg.com/amplify_video/2047379829042065408/vid/avc1/1280x720/te2UgRiP_4gm8Giu.mp4?tag=21"
-  poster="https://pbs.twimg.com/amplify_video_thumb/2047379829042065408/img/CI-tPdl5xpLrT6du.jpg"
+  src="https://trycua.github.io/assets/videos/cua-driver/macos-background-chrome.mp4"
+  poster="https://trycua.github.io/assets/posters/cua-driver/macos-background-chrome.jpg"
   title="Chrome remains behind the agent terminal"
   sourceUrl="https://x.com/trycua/status/2047383209244287350"
 >

--- a/docs/content/docs/how-to-guides/driver/record-and-render-a-trajectory.mdx
+++ b/docs/content/docs/how-to-guides/driver/record-and-render-a-trajectory.mdx
@@ -9,8 +9,8 @@ import { Steps, Step } from 'fumadocs-ui/components/steps';
 Record an agent-driven task when you need both the action evidence and a short product demo. Cua Driver saves each action with before-and-after state, screenshots, and arguments. With video enabled, it also captures the display so you can render the trajectory with zoom effects around each action.
 
 <VideoDemo
-  src="https://video.twimg.com/amplify_video/2047379960906883072/vid/avc1/1280x720/_jOaJRNzaCA2SMXu.mp4?tag=21"
-  poster="https://pbs.twimg.com/amplify_video_thumb/2047379960906883072/img/4KwmUtfWSNjo9ovO.jpg"
+  src="https://trycua.github.io/assets/videos/cua-driver/macos-trajectory-capture.mp4"
+  poster="https://trycua.github.io/assets/posters/cua-driver/macos-trajectory-capture.jpg"
   title="Turn an agent trajectory into a zoom-on-click demo"
   sourceUrl="https://x.com/trycua/status/2047383207612645426"
 >

--- a/docs/content/docs/how-to-guides/recipes/automate-a-legacy-windows-app-behind-a-vpn.mdx
+++ b/docs/content/docs/how-to-guides/recipes/automate-a-legacy-windows-app-behind-a-vpn.mdx
@@ -9,8 +9,8 @@ import { Steps, Step } from 'fumadocs-ui/components/steps';
 When a desktop app has **no API** and only runs **behind the corporate VPN**, drive it where it already runs, on the Windows box inside the network. **Cua Driver** runs on that machine and exposes the app through MCP stdio tools, so the desktop session, app traffic, and staged files stay inside the VPN boundary. **No data leaves the VPN boundary.**
 
 <VideoDemo
-  src="https://video.twimg.com/amplify_video/2059693201644978180/vid/avc1/1280x720/jKXB1bMW8aRG0dWs.mp4?tag=27"
-  poster="https://pbs.twimg.com/amplify_video_thumb/2059693201644978180/img/_AvWfXLcuStvWSlr.jpg"
+  src="https://trycua.github.io/assets/videos/cua-driver/windows-legacy-postal-app.mp4"
+  poster="https://trycua.github.io/assets/posters/cua-driver/windows-legacy-postal-app.jpg"
   title="Drive a legacy postal app while the terminal stays in front"
   sourceUrl="https://x.com/trycua/status/2059693301276565841"
 >

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: 'Cua documentation'
 description: 'Open-source computer-use automation for real machines and disposable cloud desktops.'
 ---
 
-Cua is an open-source MIT-licensed platform ([github.com/trycua/cua](https://github.com/trycua/cua)) for **computer-use automation**: letting AI agents operate real computers by clicking, typing, and reading the screen and accessibility tree. What we refer to as **Computer-Use 2.0** treats the GUI as one tool surface in an agent loop, alongside code, shell, files, and APIs. The main decision is whether to drive a machine you already have with Cua Driver, or spin up a fresh, isolated cloud desktop with Cua Sandbox.
+Cua is an open-source MIT-licensed platform ([github.com/trycua/cua](https://github.com/trycua/cua)) for **computer-use automation**: letting AI agents operate computers by clicking, typing, and reading the screen and accessibility tree. What we refer to as **Computer-Use 2.0** treats the GUI as one tool surface in an agent loop, alongside code, shell, files, and APIs. Use Cua Driver to drive a machine you already have, Cua Sandbox to start an isolated cloud desktop, or Cua-Bench to evaluate computer-use agents.
 
 import { Card, Cards } from 'fumadocs-ui/components/card';
 
@@ -17,6 +17,10 @@ import { Card, Cards } from 'fumadocs-ui/components/card';
     Start disposable full Linux, Windows, or macOS VMs with a GUI for an agent to drive when you
     want a fresh, isolated computer in the cloud instead of your own machine.
   </Card>
+  <Card title="Evaluate agents with Cua-Bench" href="/cuabench">
+    Define verifiable computer-use tasks, run agents across local or hosted environments, and score
+    the resulting trajectories.
+  </Card>
 </Cards>
 
 ## Cua Driver in action
@@ -25,36 +29,17 @@ These recordings show agents operating desktop apps while the user's active wind
 
 <div className="not-prose my-8 grid gap-5 md:grid-cols-2">
   <VideoDemo
-    src="https://video.twimg.com/amplify_video/2047379829042065408/vid/avc1/1280x720/te2UgRiP_4gm8Giu.mp4?tag=21"
-    poster="https://pbs.twimg.com/amplify_video_thumb/2047379829042065408/img/CI-tPdl5xpLrT6du.jpg"
-    title="Play media in a background Chrome window on macOS"
-    sourceUrl="https://x.com/trycua/status/2047383209244287350"
+    src="https://trycua.github.io/assets/videos/cua-driver/windows-wpf-agent-qa.mp4"
+    poster="https://trycua.github.io/assets/posters/cua-driver/windows-wpf-agent-qa.jpg"
+    title="Build and check a WPF app on Windows"
+    sourceUrl="https://x.com/trycua/status/2059688966085853245"
   >
-    Claude Code starts playback in Chrome while its terminal remains in front.
+    Claude Code builds a WPF CRM, runs it, patches the code, and checks the app again.
   </VideoDemo>
 
-<VideoDemo
-  src="https://video.twimg.com/amplify_video/2059682762781560834/vid/avc1/1280x720/GTmf25E5B9XqbXkc.mp4?tag=27"
-  poster="https://pbs.twimg.com/amplify_video_thumb/2059682762781560834/img/XxaxS_qC4z3Gbwko.jpg"
-  title="Build and check a WPF app on Windows"
-  sourceUrl="https://x.com/trycua/status/2059688966085853245"
->
-  Claude Code builds a WPF CRM, runs it, patches the code, and checks the app again.
-</VideoDemo>
-
-<VideoDemo
-  src="https://video.twimg.com/amplify_video/2067633385477111809/vid/avc1/1100x618/-Zg-HqPeUdErYRdB.mp4?tag=28"
-  poster="https://pbs.twimg.com/amplify_video_thumb/2067633385477111809/img/7Q_qNkKr3XqBe13V.jpg"
-  title="Check a calculator app on Linux"
-  sourceUrl="https://x.com/trycua/status/2067639342944985586"
->
-  Claude Code builds a calculator, drives it to 42, and reads the result while the terminal stays in
-  front.
-</VideoDemo>
-
   <VideoDemo
-    src="https://video.twimg.com/amplify_video/2067635305172336640/vid/avc1/1600x1000/1vqaHBn2lqWK1DT5.mp4?tag=28"
-    poster="https://pbs.twimg.com/amplify_video_thumb/2067635305172336640/img/62bV-2E7LuEyYIAt.jpg"
+    src="https://trycua.github.io/assets/videos/cua-driver/linux-headless-spreadsheet.mp4"
+    poster="https://trycua.github.io/assets/posters/cua-driver/linux-headless-spreadsheet.jpg"
     title="Fill a Linux spreadsheet over SSH"
     sourceUrl="https://x.com/trycua/status/2067639346719826213"
   >
@@ -67,6 +52,8 @@ These recordings show agents operating desktop apps while the user's active wind
 Tutorials: learn by doing. Start with [Tutorials](/tutorials).
 
 Concepts: understand how and why Cua works. Start with [Concepts](/concepts).
+
+Cua-Bench: define tasks and evaluate agents. Start with [Cua-Bench](/cuabench).
 
 How-to guides: recipes for a goal. Start with [How-to guides](/how-to-guides).
 

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Documentation",
   "root": true,
-  "pages": ["index", "---Learn---", "tutorials", "concepts", "---Do---", "how-to-guides", "reference"]
+  "pages": ["index", "---Learn---", "tutorials", "concepts", "cuabench", "---Do---", "how-to-guides", "reference"]
 }

--- a/docs/content/docs/reference/cua-driver/process-model.mdx
+++ b/docs/content/docs/reference/cua-driver/process-model.mdx
@@ -48,6 +48,17 @@ A daemon drives one physical machine. Multiple MCP clients can connect at the sa
 
 Session identity solves a narrower state problem. When a proxy starts, it mints a session identity and stamps forwarded calls with it. The daemon uses that identity to scope mutable state to one client lifetime. Recording ownership, per-session config overrides, and the agent-cursor overlay are all keyed by session.
 
+<VideoDemo
+  className="my-8"
+  src="https://trycua.github.io/assets/videos/cua-driver/windows-hermes-four-agent-windows.mp4"
+  poster="https://trycua.github.io/assets/posters/cua-driver/windows-hermes-four-agent-windows.jpg"
+  title="Four agent sessions share one Windows desktop"
+  sourceUrl="https://x.com/francedot/status/2061706670208897279"
+>
+  Four Hermes agents operate four app windows. Each session has its own cursor overlay, while all
+  four sessions still share the same desktop.
+</VideoDemo>
+
 Cleanup follows the proxy connection, not a final message. The proxy keeps a long-lived control connection open to the daemon. When the proxy exits, even from an ungraceful kill, the kernel closes that connection. The daemon sees EOF and removes state owned by that session. This prevents stale recordings, cursors, and temporary config overrides.
 
 ## Lifetimes and memory

--- a/docs/content/docs/tutorials/drive-your-first-app.mdx
+++ b/docs/content/docs/tutorials/drive-your-first-app.mdx
@@ -11,14 +11,14 @@ import { Callout } from 'fumadocs-ui/components/callout';
 You do not type **Cua Driver** CLI commands by hand. Cua Driver is a backend that an agent harness (Claude Code, Codex, Hermes, and others) drives for you. In this tutorial you install Cua Driver, connect your agent, and ask it in plain English to open a calculator and read a result back. Works the same on macOS, Windows, and Linux.
 
 <VideoDemo
-  src="/videos/agents-play-windows-piano.mp4"
-  poster="/videos/agents-play-windows-piano.jpg"
-  title="Preview: agents play a Windows piano app"
-  sourceUrl="https://x.com/francedot/status/2062231318294131130"
+  src="https://trycua.github.io/assets/videos/cua-driver/linux-calculator-agent-qa.mp4"
+  poster="https://trycua.github.io/assets/posters/cua-driver/linux-calculator-agent-qa.jpg"
+  title="Build and check a calculator app on Linux"
+  sourceUrl="https://x.com/trycua/status/2067639342944985586"
   className="my-8"
 >
-  Cua Driver coordinates several agent cursors to play a Windows piano app at Microsoft Build. You
-  will start with a smaller Calculator task below.
+  Claude Code builds a calculator, drives it to 42, and reads the result while the terminal stays in
+  front. You will run the same task below with your own agent.
 </VideoDemo>
 
 ## 1. Install Cua Driver


### PR DESCRIPTION
## Summary

- replace X CDN media URLs with stable trycua/assets GitHub Pages URLs
- replace the first-app piano preview with the task-matched calculator recording
- keep each of the 11 approved videos in one docs location
- add background-development and concurrent-session examples
- add a Cua-Bench overview page and docs navigation entry

## Why

X media URLs are external delivery links and can change. The approved recordings now live in trycua/assets, where GitHub Pages provides stable video and poster URLs. Task recordings belong on the matching tutorial or how-to page, while capability recordings belong in overview, concept, or reference context.

Assets were added and deployed in trycua/assets#1 before this pull request.

## Validation

- all 22 video and poster URLs return the expected media type
- pnpm docs:check-hygiene
- pnpm docs:check-links: 0 errors
- pnpm build: 79 static routes generated, including /cuabench
- confirmed all 11 source posts appear exactly once and no X CDN media URLs remain