### PR TITLE
fix(cua-driver): refuse overlapping text input per pid

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-core/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/lib.rs
@@ -59,6 +59,7 @@ pub mod text_sanitize;
 pub mod tool;
 pub mod tool_args;
 pub mod tool_schema;
+pub mod type_text_lock;
 pub mod video;
 pub mod video_ffmpeg;
 

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/type_text_lock.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/type_text_lock.rs
@@ -5,6 +5,7 @@
 //! queueing would let stale text land after the caller's target has changed.
 
 use std::collections::HashSet;
+use std::future::Future;
 use std::sync::{Mutex, OnceLock};
 
 use crate::protocol::ToolResult;
@@ -41,6 +42,25 @@ pub fn try_acquire(pid: i64) -> Result<TypeTextGuard, ToolResult> {
 #[derive(Debug)]
 pub struct TypeTextGuard {
     pid: i64,
+}
+
+impl TypeTextGuard {
+    /// Runs the guarded operation in a detached task so cancellation of the
+    /// caller cannot release the pid while blocking input work is still active.
+    pub async fn run_until_complete<F>(self, operation: F) -> ToolResult
+    where
+        F: Future<Output = ToolResult> + Send + 'static,
+    {
+        match tokio::spawn(async move {
+            let _guard = self;
+            operation.await
+        })
+        .await
+        {
+            Ok(result) => result,
+            Err(error) => ToolResult::error(format!("type_text task failed: {error}")),
+        }
+    }
 }
 
 impl Drop for TypeTextGuard {
@@ -99,5 +119,49 @@ mod tests {
 
         drop(first);
         let _reacquired = try_acquire(first_pid).expect("dropped guard should release the pid");
+    }
+
+    #[tokio::test]
+    async fn cancellation_keeps_the_pid_busy_until_the_operation_finishes() {
+        let pid = 2_256_004;
+        let guard = try_acquire(pid).expect("operation should acquire the pid");
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+
+        let invocation = tokio::spawn(guard.run_until_complete(async move {
+            let _ = started_tx.send(());
+            let _ = release_rx.await;
+            ToolResult::text("done")
+        }));
+        started_rx.await.expect("guarded operation should start");
+
+        invocation.abort();
+        assert!(invocation
+            .await
+            .expect_err("invocation should be cancelled")
+            .is_cancelled());
+        let refusal = try_acquire(pid).expect_err("detached operation must retain the pid");
+        assert_eq!(
+            refusal
+                .structured_content
+                .as_ref()
+                .and_then(|value| value.get("code"))
+                .and_then(serde_json::Value::as_str),
+            Some("input_busy")
+        );
+
+        release_tx
+            .send(())
+            .expect("operation should still be running");
+        let _reacquired = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if let Ok(guard) = try_acquire(pid) {
+                    break guard;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("pid should be released when the detached operation finishes");
     }
 }

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/type_text_lock.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/type_text_lock.rs
@@ -1,0 +1,103 @@
+//! Process-wide, fail-fast serialization for generic desktop `type_text` calls.
+//!
+//! Text delivery can span focus changes and a character-by-character worker. A
+//! second call for the same process must be refused before it can change focus;
+//! queueing would let stale text land after the caller's target has changed.
+
+use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
+
+use crate::protocol::ToolResult;
+
+fn active_pids() -> &'static Mutex<HashSet<i64>> {
+    static ACTIVE: OnceLock<Mutex<HashSet<i64>>> = OnceLock::new();
+    ACTIVE.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Marks one pid as having an active generic desktop `type_text` operation.
+///
+/// This is intentionally process-wide rather than session-scoped: independent
+/// agents can share the daemon and still target the same OS process. Acquisition
+/// never waits, so a refused call can't become stale in a queue.
+pub fn try_acquire(pid: i64) -> Result<TypeTextGuard, ToolResult> {
+    let mut active = active_pids()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if !active.insert(pid) {
+        return Err(ToolResult::error(format!(
+            "type_text refused: input is already active for pid {pid}."
+        ))
+        .with_structured(serde_json::json!({
+            "code": "input_busy",
+            "operation": "type_text",
+            "pid": pid,
+        })));
+    }
+    Ok(TypeTextGuard { pid })
+}
+
+/// Removes the pid from the active set on every completed invocation path,
+/// including delivery-worker failures.
+#[derive(Debug)]
+pub struct TypeTextGuard {
+    pid: i64,
+}
+
+impl Drop for TypeTextGuard {
+    fn drop(&mut self) {
+        active_pids()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&self.pid);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn refuses_a_second_call_for_the_same_pid_without_queueing() {
+        let pid = 2_256_001;
+        let _first = try_acquire(pid).expect("first call should acquire the pid");
+        let refusal = try_acquire(pid).expect_err("second call should fail fast");
+
+        assert_eq!(refusal.is_error, Some(true));
+        assert_eq!(
+            refusal
+                .structured_content
+                .as_ref()
+                .and_then(serde_json::Value::as_object)
+                .map(serde_json::Map::len),
+            Some(3),
+            "the refusal payload must remain bounded"
+        );
+        assert_eq!(
+            refusal
+                .structured_content
+                .as_ref()
+                .and_then(|value| value.get("code"))
+                .and_then(serde_json::Value::as_str),
+            Some("input_busy")
+        );
+        assert_eq!(
+            refusal
+                .structured_content
+                .as_ref()
+                .and_then(|value| value.get("pid"))
+                .and_then(serde_json::Value::as_i64),
+            Some(pid)
+        );
+    }
+
+    #[test]
+    fn permits_different_pids_and_releases_on_drop() {
+        let first_pid = 2_256_002;
+        let second_pid = 2_256_003;
+        let first = try_acquire(first_pid).expect("first pid should acquire");
+        let _second = try_acquire(second_pid).expect("different pid should acquire concurrently");
+
+        drop(first);
+        let _reacquired = try_acquire(first_pid).expect("dropped guard should release the pid");
+    }
+}

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -2262,6 +2262,12 @@ impl Tool for TypeTextTool {
         // cua_driver_core::text_sanitize docs for rationale.
         let text = cua_driver_core::text_sanitize::strip_trailing_agent_protocol_tags(&text_raw)
             .into_owned();
+        // Fail before any element focus or pixel-click can redirect subsequent
+        // key events. The guard remains live until the delivery worker exits.
+        let _input_guard = match cua_driver_core::type_text_lock::try_acquire(pid as i64) {
+            Ok(guard) => guard,
+            Err(refusal) => return refusal,
+        };
         // Surface 6: resolve element_token / element_index for the
         // optional pre-typing focus glide below. The token also carries
         // the window_id when supplied so the caller can omit window_id.

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -2268,9 +2268,21 @@ impl Tool for TypeTextTool {
             Ok(guard) => guard,
             Err(refusal) => return refusal,
         };
-        let tool_state = self.state.clone();
         input_guard
-            .run_until_complete(async move {
+            .run_until_complete(Self::invoke_locked(self.state.clone(), args, pid, text))
+            .await
+    }
+}
+
+impl TypeTextTool {
+    async fn invoke_locked(
+        tool_state: Arc<ToolState>,
+        args: Value,
+        pid: u32,
+        text: String,
+    ) -> ToolResult {
+        use cua_driver_core::tool_args::ArgsExt;
+
         // Surface 6: resolve element_token / element_index for the
         // optional pre-typing focus glide below. The token also carries
         // the window_id when supplied so the caller can omit window_id.
@@ -2777,8 +2789,6 @@ impl Tool for TypeTextTool {
             Ok(Err(e)) => ToolResult::error(e.to_string()),
             Err(e) => ToolResult::error(format!("Task error: {e}")),
         }
-            })
-            .await
     }
 }
 

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -2264,10 +2264,13 @@ impl Tool for TypeTextTool {
             .into_owned();
         // Fail before any element focus or pixel-click can redirect subsequent
         // key events. The guard remains live until the delivery worker exits.
-        let _input_guard = match cua_driver_core::type_text_lock::try_acquire(pid as i64) {
+        let input_guard = match cua_driver_core::type_text_lock::try_acquire(pid as i64) {
             Ok(guard) => guard,
             Err(refusal) => return refusal,
         };
+        let tool_state = self.state.clone();
+        input_guard
+            .run_until_complete(async move {
         // Surface 6: resolve element_token / element_index for the
         // optional pre-typing focus glide below. The token also carries
         // the window_id when supplied so the caller can omit window_id.
@@ -2390,7 +2393,7 @@ impl Tool for TypeTextTool {
             }
             let from_zoom = args.bool_or("from_zoom", false);
             if let Err(e) = focus_by_pixel(
-                &self.state,
+                &tool_state,
                 pid,
                 Some(xid),
                 cx,
@@ -2774,6 +2777,8 @@ impl Tool for TypeTextTool {
             Ok(Err(e)) => ToolResult::error(e.to_string()),
             Err(e) => ToolResult::error(format!("Task error: {e}")),
         }
+            })
+            .await
     }
 }
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/type_text.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/type_text.rs
@@ -174,10 +174,13 @@ impl Tool for TypeTextTool {
             .into_owned();
         // Fail before any element focus or pixel-click can redirect subsequent
         // key events. The guard remains live until the delivery worker exits.
-        let _input_guard = match cua_driver_core::type_text_lock::try_acquire(pid as i64) {
+        let input_guard = match cua_driver_core::type_text_lock::try_acquire(pid as i64) {
             Ok(guard) => guard,
             Err(refusal) => return refusal,
         };
+        let tool_state = self.state.clone();
+        input_guard
+            .run_until_complete(async move {
         // Surface 6: element_token / element_index precedence resolution.
         let element_token_arg = args.opt_str("element_token");
         let window_id_arg = args.opt_u64("window_id").map(|v| v as u32);
@@ -223,7 +226,7 @@ impl Tool for TypeTextTool {
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
             if let Err(e) = super::focus_by_pixel(
-                &self.state,
+                &tool_state,
                 pid,
                 window_id,
                 cx,
@@ -252,7 +255,7 @@ impl Tool for TypeTextTool {
         // the blocking type below dereferences it (use-after-free → daemon
         // crash). The guard lives to method end, past type_text_blocking.
         let element_guard = if let (Some(idx), Some(wid)) = (element_index, window_id) {
-            match self.state.element_cache.get_element_retained(pid, wid, idx) {
+            match tool_state.element_cache.get_element_retained(pid, wid, idx) {
                 Some(e) => Some((e, idx)),
                 None => {
                     return ToolResult::error(format!(
@@ -418,6 +421,8 @@ impl Tool for TypeTextTool {
             Ok(Err(e)) => ToolResult::error(format!("type_text failed: {e}")),
             Err(e) => ToolResult::error(format!("Task error: {e}")),
         }
+            })
+            .await
     }
 }
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/type_text.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/type_text.rs
@@ -178,9 +178,21 @@ impl Tool for TypeTextTool {
             Ok(guard) => guard,
             Err(refusal) => return refusal,
         };
-        let tool_state = self.state.clone();
         input_guard
-            .run_until_complete(async move {
+            .run_until_complete(Self::invoke_locked(self.state.clone(), args, pid, text))
+            .await
+    }
+}
+
+impl TypeTextTool {
+    async fn invoke_locked(
+        tool_state: Arc<ToolState>,
+        args: Value,
+        pid: i32,
+        text: String,
+    ) -> ToolResult {
+        use cua_driver_core::tool_args::ArgsExt;
+
         // Surface 6: element_token / element_index precedence resolution.
         let element_token_arg = args.opt_str("element_token");
         let window_id_arg = args.opt_u64("window_id").map(|v| v as u32);
@@ -421,8 +433,6 @@ impl Tool for TypeTextTool {
             Ok(Err(e)) => ToolResult::error(format!("type_text failed: {e}")),
             Err(e) => ToolResult::error(format!("Task error: {e}")),
         }
-            })
-            .await
     }
 }
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/type_text.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/type_text.rs
@@ -172,6 +172,12 @@ impl Tool for TypeTextTool {
         // cua_driver_core::text_sanitize docs for rationale.
         let text = cua_driver_core::text_sanitize::strip_trailing_agent_protocol_tags(&text_raw)
             .into_owned();
+        // Fail before any element focus or pixel-click can redirect subsequent
+        // key events. The guard remains live until the delivery worker exits.
+        let _input_guard = match cua_driver_core::type_text_lock::try_acquire(pid as i64) {
+            Ok(guard) => guard,
+            Err(refusal) => return refusal,
+        };
         // Surface 6: element_token / element_index precedence resolution.
         let element_token_arg = args.opt_str("element_token");
         let window_id_arg = args.opt_u64("window_id").map(|v| v as u32);

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -3508,17 +3508,20 @@ impl Tool for TypeTextTool {
                 Err(error) => ToolResult::error(format!("desktop type task failed: {error}")),
             };
         }
-        let raw_pid = match args.require_i64("pid") {
+        let pid = match args.require_u32("pid") {
             Ok(v) => v,
             Err(e) => return e,
         };
-        let pid = raw_pid as u32;
+        let raw_pid = i64::from(pid);
         // Fail before any element focus or pixel-click can redirect subsequent
         // key events. The guard remains live until the delivery worker exits.
-        let _input_guard = match cua_driver_core::type_text_lock::try_acquire(raw_pid) {
+        let input_guard = match cua_driver_core::type_text_lock::try_acquire(raw_pid) {
             Ok(guard) => guard,
             Err(refusal) => return refusal,
         };
+        let tool_state = self.state.clone();
+        input_guard
+            .run_until_complete(async move {
         // Surface 6: element_token / element_index precedence resolution.
         let resolved = match cua_driver_core::element_token::resolve_element_args(
             pid as i32,
@@ -3564,7 +3567,7 @@ impl Tool for TypeTextTool {
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
                 if let Err(e) = focus_by_pixel(
-                    &self.state,
+                    &tool_state,
                     pid,
                     hwnd_opt,
                     cx,
@@ -3661,7 +3664,7 @@ impl Tool for TypeTextTool {
                         }
                     };
                 let (cx, cy) = match resolve_onscreen_point_with_scroll(
-                    &self.state.element_cache,
+                    &tool_state.element_cache,
                     pid,
                     hwnd,
                     idx as usize,
@@ -3721,7 +3724,7 @@ impl Tool for TypeTextTool {
         // the focused-element path has no resolvable position to point at.
         if let Some(idx) = elem_idx {
             if let Some((cx, cy)) =
-                self.state
+                tool_state
                     .element_cache
                     .get_element_center(pid, hwnd, idx as usize)
             {
@@ -3766,7 +3769,7 @@ impl Tool for TypeTextTool {
         //    (most legacy Win32 EDITs consume WM_CHAR fine without focus steal).
         if let Some(idx) = elem_idx {
             let idx = idx as usize;
-            let state = self.state.clone();
+            let state = tool_state.clone();
             let text_for_uia = text.clone();
             let set_ok = tokio::task::spawn_blocking(move || -> bool {
                 // Retain the element under the cache lock so a concurrent
@@ -3818,7 +3821,7 @@ impl Tool for TypeTextTool {
                 // (works regardless of which window is foreground), proving the
                 // a11y write actually took rather than trusting SetValue's
                 // return alone.
-                let state_rb = self.state.clone();
+                let state_rb = tool_state.clone();
                 let text_rb = text.clone();
                 let verify = tokio::task::spawn_blocking(move || {
                     match read_cached_element_value(&state_rb, pid, hwnd, idx) {
@@ -3931,7 +3934,7 @@ impl Tool for TypeTextTool {
         let text_for_post = text.clone();
         let verify_pid = pid;
         let verify_idx = elem_idx.map(|i| i as usize);
-        let state_rb = self.state.clone();
+        let state_rb = tool_state.clone();
         let result = tokio::task::spawn_blocking(move || {
             // Prefer a focus-independent read of the *specific* cached element
             // when we have its index; only fall back to the (flaky, focus-
@@ -4009,6 +4012,8 @@ impl Tool for TypeTextTool {
             Ok((Err(e), _, _)) => ToolResult::error(e.to_string()),
             Err(e) => ToolResult::error(format!("Task error: {e}")),
         }
+            })
+            .await
     }
 }
 

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -3513,6 +3513,12 @@ impl Tool for TypeTextTool {
             Err(e) => return e,
         };
         let pid = raw_pid as u32;
+        // Fail before any element focus or pixel-click can redirect subsequent
+        // key events. The guard remains live until the delivery worker exits.
+        let _input_guard = match cua_driver_core::type_text_lock::try_acquire(raw_pid) {
+            Ok(guard) => guard,
+            Err(refusal) => return refusal,
+        };
         // Surface 6: element_token / element_index precedence resolution.
         let resolved = match cua_driver_core::element_token::resolve_element_args(
             pid as i32,

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -3469,7 +3469,6 @@ impl Tool for TypeTextTool {
     }
 
     async fn invoke(&self, args: Value) -> ToolResult {
-        use crate::input::delivery::{DeliveryMode, EventKind};
         use cua_driver_core::tool_args::ArgsExt;
         let text_raw = match args.require_str("text") {
             Ok(v) => v,
@@ -3519,9 +3518,31 @@ impl Tool for TypeTextTool {
             Ok(guard) => guard,
             Err(refusal) => return refusal,
         };
-        let tool_state = self.state.clone();
         input_guard
-            .run_until_complete(async move {
+            .run_until_complete(Self::invoke_locked(
+                self.state.clone(),
+                args,
+                pid,
+                raw_pid,
+                text,
+                cursor_key,
+            ))
+            .await
+    }
+}
+
+impl TypeTextTool {
+    async fn invoke_locked(
+        tool_state: Arc<ToolState>,
+        args: Value,
+        pid: u32,
+        raw_pid: i64,
+        text: String,
+        cursor_key: String,
+    ) -> ToolResult {
+        use crate::input::delivery::{DeliveryMode, EventKind};
+        use cua_driver_core::tool_args::ArgsExt;
+
         // Surface 6: element_token / element_index precedence resolution.
         let resolved = match cua_driver_core::element_token::resolve_element_args(
             pid as i32,
@@ -3651,8 +3672,7 @@ impl Tool for TypeTextTool {
             // actuator used by an indexed click before sending Unicode input.
             if let Some(idx) = elem_idx {
                 let (cx, cy) =
-                    match self
-                        .state
+                    match tool_state
                         .element_cache
                         .get_element_center(pid, hwnd, idx as usize)
                     {
@@ -4012,8 +4032,6 @@ impl Tool for TypeTextTool {
             Ok((Err(e), _, _)) => ToolResult::error(e.to_string()),
             Err(e) => ToolResult::error(format!("Task error: {e}")),
         }
-            })
-            .await
     }
 }
 


### PR DESCRIPTION
## summary

- add a process-wide, per-pid guard for generic desktop `type_text`
- reject overlapping calls before element focus or pixel focus can change, rather than queueing stale input
- return a bounded structured refusal with `code: input_busy`, the operation, and target pid
- apply the same contract on macos, linux, and windows; first-class browser mutations remain on their existing browser-engine lock

## testing

- `cargo test -p cua-driver-core type_text_lock --lib`
- `cargo check -p platform-macos -p platform-linux -p platform-windows`

closes https://github.com/trycua/cua/issues/2256
