### PR TITLE
fix(release): restrict package bumps to owner

### DIFF
--- a/.github/scripts/tests/test_release_bump_authorization.py
+++ b/.github/scripts/tests/test_release_bump_authorization.py
@@ -1,0 +1,58 @@
+"""Regression tests for package version-bump authorization."""
+
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class TestReleaseBumpAuthorization(unittest.TestCase):
+    """Verify that humans other than the release owner cannot bump packages."""
+
+    def test_bump_workflow_is_gated_before_write_access(self) -> None:
+        workflow = (
+            REPO_ROOT / ".github/workflows/release-bump-version.yml"
+        ).read_text()
+
+        self.assertIn("permissions: {}", workflow)
+        self.assertIn("  authorize:\n", workflow)
+        self.assertIn('ACTOR: ${{ github.actor }}', workflow)
+        self.assertIn('TRIGGERING_ACTOR: ${{ github.triggering_actor }}', workflow)
+        self.assertIn(
+            '"f-trycua:f-trycua"|'
+            '"cua-release-bot[bot]:cua-release-bot[bot]")',
+            workflow,
+        )
+        self.assertIn("  bump-version:\n    needs: authorize\n", workflow)
+        self.assertIn(
+            "    permissions:\n      contents: write\n    steps:\n",
+            workflow,
+        )
+
+    def test_auto_release_requires_owner_applied_labels(self) -> None:
+        workflow = (
+            REPO_ROOT / ".github/workflows/release-on-merge.yml"
+        ).read_text()
+
+        self.assertIn(
+            'LABEL_EVENTS=$(gh api --paginate --slurp \\\n'
+            '            "repos/$REPO/issues/$PR_NUMBER/events?per_page=100")',
+            workflow,
+        )
+        self.assertIn("label_was_applied_by_release_owner()", workflow)
+        self.assertIn('.actor.login == "f-trycua"', workflow)
+        self.assertIn(
+            'label_was_applied_by_release_owner "bump:major"', workflow
+        )
+        self.assertIn(
+            'label_was_applied_by_release_owner "bump:minor"', workflow
+        )
+        self.assertIn(
+            'label_was_applied_by_release_owner "$release_label"', workflow
+        )
+        self.assertIn("No owner-authorized release labels found", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci-test-scripts.yml
+++ b/.github/workflows/ci-test-scripts.yml
@@ -10,6 +10,8 @@ on:
       - ".github/workflows/cd-rust-cua-driver.yml"
       - ".github/workflows/cd-swift-lume.yml"
       - ".github/workflows/release-please.yml"
+      - ".github/workflows/release-bump-version.yml"
+      - ".github/workflows/release-on-merge.yml"
       - ".release-please-manifest.json"
       - "release-please-config.json"
       - ".github/workflows/ci-test-scripts.yml"

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -51,12 +51,33 @@ on:
         type: string
         default: "main"
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
-  bump-version:
+  authorize:
+    name: Authorize version bump
     runs-on: ubuntu-latest
+    steps:
+      - name: Allow only the release owner or trusted automation
+        env:
+          ACTOR: ${{ github.actor }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        run: |
+          case "$ACTOR:$TRIGGERING_ACTOR" in
+            "f-trycua:f-trycua"|"cua-release-bot[bot]:cua-release-bot[bot]")
+              echo "Version bump authorized for $ACTOR."
+              ;;
+            *)
+              echo "::error::Only f-trycua may manually bump package versions."
+              exit 1
+              ;;
+          esac
+
+  bump-version:
+    needs: authorize
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Set package directory and type
         id: package

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -36,11 +36,39 @@ jobs:
             exit 0
           fi
 
+          # A label only authorizes a release when its latest add/remove event
+          # shows that the release owner applied it and it remains present.
+          LABEL_EVENTS=$(gh api --paginate --slurp \
+            "repos/$REPO/issues/$PR_NUMBER/events?per_page=100")
+
+          label_was_applied_by_release_owner() {
+            local label=$1
+            jq -e --arg label "$label" '
+              [
+                .[][]
+                | select(
+                    (.event == "labeled" or .event == "unlabeled")
+                    and .label.name == $label
+                  )
+              ]
+              | last
+              | .event == "labeled" and .actor.login == "f-trycua"
+            ' <<< "$LABEL_EVENTS" > /dev/null
+          }
+
           # Determine bump type from labels (default: patch)
           BUMP_TYPE="patch"
           if echo "$LABELS" | grep -q '"bump:major"'; then
+            if ! label_was_applied_by_release_owner "bump:major"; then
+              echo "::warning::bump:major was not applied by f-trycua; skipping auto-release."
+              exit 0
+            fi
             BUMP_TYPE="major"
           elif echo "$LABELS" | grep -q '"bump:minor"'; then
+            if ! label_was_applied_by_release_owner "bump:minor"; then
+              echo "::warning::bump:minor was not applied by f-trycua; skipping auto-release."
+              exit 0
+            fi
             BUMP_TYPE="minor"
           fi
           echo "Bump type: $BUMP_TYPE"
@@ -102,13 +130,18 @@ jobs:
           # Collect labeled packages for auto-release
           LABELED=()
           for svc in "${!AFFECTED_MAP[@]}"; do
-            if echo "$LABELS" | grep -q "\"release:${svc}\""; then
-              LABELED+=("$svc")
+            release_label="release:${svc}"
+            if echo "$LABELS" | grep -q "\"${release_label}\""; then
+              if label_was_applied_by_release_owner "$release_label"; then
+                LABELED+=("$svc")
+              else
+                echo "::warning::$release_label was not applied by f-trycua; ignoring it."
+              fi
             fi
           done
 
           if [ ${#LABELED[@]} -eq 0 ]; then
-            echo "No release labels found. Daily digest will catch unreleased packages."
+            echo "No owner-authorized release labels found. Daily digest will catch unreleased packages."
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

- allow manual package version bumps only for `f-trycua` and trusted release automation
- require `release:*`, `bump:minor`, and `bump:major` labels to have been applied by `f-trycua` before auto-release honors them
- move write permissions behind the authorization gate and add regression coverage

## Root cause

The bump workflow accepted dispatches from any collaborator with Actions access, while the merge workflow trusted the current PR label set without checking who applied release-affecting labels. That allowed other collaborators to trigger patch or minor releases accidentally.

## Validation

- `actionlint` on the three affected workflows
- `pytest .github/scripts/tests -q` — 80 passed
- historical label-provenance check: PR #2236 is denied; an owner-labeled PR is allowed