### PR TITLE
docs: add research citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,11 @@
+cff-version: 1.2.0
+message: "If you use Cua in your research, please cite it using this metadata."
+title: "Cua"
+type: software
+authors:
+  - name: "Cua AI, Inc."
+abstract: "Scale computer-use 2.0 with open-source drivers, cross-OS fleets, and benchmarks for training, evaluation, and data generation."
+date-released: 2025-01-31
+repository-code: "https://github.com/trycua/cua"
+url: "https://cua.ai"
+license: MIT

--- a/README.md
+++ b/README.md
@@ -175,6 +175,22 @@ of Setup Assistant on its first display boot; see [issue #2155](https://github.c
 - [Discord](https://discord.com/invite/mVnXXpdE85) — Community support and discussions
 - [GitHub Issues](https://github.com/trycua/cua/issues) — Bug reports and feature requests
 
+## Citation
+
+If Cua supports your research, please cite the software:
+
+```bibtex
+@software{cua2025,
+  author  = {{Cua AI, Inc.}},
+  title   = {Cua},
+  year    = {2025},
+  url     = {https://github.com/trycua/cua},
+  license = {MIT}
+}
+```
+
+For reproducibility, include the Cua release or commit used in your experiments. Citation metadata is also available in [`CITATION.cff`](CITATION.cff).
+
 ## Contributing
 
 We welcome contributions! See our [Contributing Guidelines](CONTRIBUTING.md) for details.


### PR DESCRIPTION
## What changed

- add a README section with a copyable BibTeX citation
- add machine-readable `CITATION.cff` metadata
- identify Cua AI, Inc. as the corporate author
- ask researchers to record the release or commit used for reproducibility

## Why

Researchers need a clear, consistent way to cite Cua. The CFF file also enables GitHub's citation export and citation-manager integrations.

## Validation

- `git diff --check`
- `pnpm exec prettier --check README.md`
- `uvx --from cffconvert cffconvert --validate`