### PR TITLE
Restore jukebox demo to first app tutorial

### DIFF
--- a/docs/content/docs/tutorials/drive-your-first-app.mdx
+++ b/docs/content/docs/tutorials/drive-your-first-app.mdx
@@ -11,14 +11,14 @@ import { Callout } from 'fumadocs-ui/components/callout';
 You do not type **Cua Driver** CLI commands by hand. Cua Driver is a backend that an agent harness (Claude Code, Codex, Hermes, and others) drives for you. In this tutorial you install Cua Driver, connect your agent, and ask it in plain English to open a calculator and read a result back. Works the same on macOS, Windows, and Linux.
 
 <VideoDemo
-  src="https://trycua.github.io/assets/videos/cua-driver/linux-calculator-agent-qa.mp4"
-  poster="https://trycua.github.io/assets/posters/cua-driver/linux-calculator-agent-qa.jpg"
-  title="Build and check a calculator app on Linux"
-  sourceUrl="https://x.com/trycua/status/2067639342944985586"
+  src="https://trycua.github.io/assets/videos/cua-driver/windows-msbuild-piano.mp4"
+  poster="https://trycua.github.io/assets/posters/cua-driver/windows-msbuild-piano.jpg"
+  title="Preview: agents play a Windows piano app"
+  sourceUrl="https://x.com/francedot/status/2062231318294131130"
   className="my-8"
 >
-  Claude Code builds a calculator, drives it to 42, and reads the result while the terminal stays in
-  front. You will run the same task below with your own agent.
+  Cua Driver coordinates several agent cursors to play a Windows piano app at Microsoft Build. You
+  will start with a smaller Calculator task below.
 </VideoDemo>
 
 ## 1. Install Cua Driver


### PR DESCRIPTION
## Summary
- restore the Microsoft Build jukebox demo at the top of Drive your first app
- use the stable `trycua.github.io/assets` MP4 and poster
- keep the smaller calculator task in the tutorial steps

## Validation
- `pnpm --dir docs docs:check-hygiene`
- `pnpm --dir docs docs:check-links` (0 errors)
- `pnpm --dir docs build` (79 static pages)
- verified the MP4 and poster return the expected media types