### PR TITLE
fix(cua-bench): restore the public Linux Docker image

### DIFF
--- a/libs/cua-bench/cua_bench/runner/task_runner.py
+++ b/libs/cua-bench/cua_bench/runner/task_runner.py
@@ -32,10 +32,13 @@ from .docker_utils import (
 # Configuration
 # =============================================================================
 
+DEFAULT_LINUX_DOCKER_IMAGE = "trycua/cua-xfce:latest"
+DEFAULT_DAYTONA_SNAPSHOT = "nikri/kicad-snorkel:20260316b"
+
 # Environment type configurations
 ENV_CONFIGS = {
     "linux-docker": {
-        "image": "nikri/kicad-snorkel:20260316b",
+        "image": DEFAULT_LINUX_DOCKER_IMAGE,
         "internal_vnc_port": 6901,
         "internal_api_port": 8000,
         "requires_kvm": False,
@@ -67,6 +70,18 @@ ENV_CONFIGS = {
         "use_overlays": True,  # Protect golden QCOW2 disk
     },
 }
+
+
+def resolve_environment_container_image(
+    env_type: str,
+    golden_name: Optional[str],
+    config: dict,
+) -> str:
+    """Resolve the runtime image without conflating Docker images and QEMU disks."""
+    if not config["requires_kvm"] and golden_name and golden_name != env_type:
+        return golden_name
+    return config["image"]
+
 
 # Default agent image
 DEFAULT_AGENT_IMAGE = "cua-bench:latest"
@@ -297,7 +312,11 @@ class TaskRunner:
             "network": network_name,
             "env_container": env_container_name if not is_simulated else None,
             "agent_container": agent_container_name,
-            "env_image": config.get("image") if not is_simulated else None,
+            "env_image": (
+                resolve_environment_container_image(env_type, golden_name, config)
+                if not is_simulated
+                else None
+            ),
             "agent_image": self.agent_image,
             "remove_images": remove_images_after,
             "overlay_path": overlay_path,
@@ -518,7 +537,7 @@ class TaskRunner:
             "network": network_name,
             "env_container": env_container_name,
             "agent_container": None,  # No agent in interactive mode
-            "env_image": config["image"],
+            "env_image": resolve_environment_container_image(env_type, golden_name, config),
             "agent_image": None,
             "remove_images": False,
             "overlay_path": overlay_path,
@@ -678,8 +697,9 @@ class TaskRunner:
             devices.append("/dev/kvm")
 
         # Start container
+        container_image = resolve_environment_container_image(env_type, golden_name, config)
         return await start_container(
-            image=config["image"],
+            image=container_image,
             name=container_name,
             network=network_name,
             hostname=self.env_hostname,
@@ -1003,9 +1023,11 @@ class TaskRunner:
 
         harness = DaytonaHarness()
 
-        # Resolve env-type name → actual Docker image
+        # Daytona expects a snapshot name, not a Docker image.  Platform names
+        # therefore retain the provider-specific default, while an explicit
+        # --image value is treated as the requested Daytona snapshot.
         _raw = golden_name or env_type or ""
-        env_image = ENV_CONFIGS.get(_raw, {}).get("image") or _raw or "nikri/kicad-snorkel:20260316b"
+        env_image = _raw if _raw and _raw not in ENV_CONFIGS else DEFAULT_DAYTONA_SNAPSHOT
 
         # API keys and env vars to bake into the sandbox at creation time
         # (avoids passing secrets via process.exec env which triggers abuse detection)

--- a/libs/cua-bench/cua_bench/tests/test_task_runner_regressions.py
+++ b/libs/cua-bench/cua_bench/tests/test_task_runner_regressions.py
@@ -1,0 +1,25 @@
+from cua_bench.runner.task_runner import (
+    DEFAULT_LINUX_DOCKER_IMAGE,
+    ENV_CONFIGS,
+    resolve_environment_container_image,
+)
+
+
+def test_linux_docker_uses_the_public_cua_image() -> None:
+    assert DEFAULT_LINUX_DOCKER_IMAGE == "trycua/cua-xfce:latest"
+    assert ENV_CONFIGS["linux-docker"]["image"] == DEFAULT_LINUX_DOCKER_IMAGE
+    assert "nikri/" not in ENV_CONFIGS["linux-docker"]["image"]
+    assert (
+        resolve_environment_container_image(
+            "linux-docker", "linux-docker", ENV_CONFIGS["linux-docker"]
+        )
+        == DEFAULT_LINUX_DOCKER_IMAGE
+    )
+    assert (
+        resolve_environment_container_image(
+            "linux-docker",
+            "registry.example/custom:latest",
+            ENV_CONFIGS["linux-docker"],
+        )
+        == "registry.example/custom:latest"
+    )


### PR DESCRIPTION
## Summary

- restore `trycua/cua-xfce:latest` as the generic `linux-docker` default
- honor an explicit Docker image override instead of silently replacing it
- keep the Daytona snapshot default separate from Docker image resolution

## Why

The generic Linux Docker profile currently resolves to `nikri/kicad-snorkel:20260316b`. That image is task-specific and also conflates Docker image names with Daytona snapshot semantics, so ordinary Cua Bench runs can fail before a task starts.

## Validation

- `pytest cua_bench/tests/test_task_runner_regressions.py -q` — 1 passed
- `ruff check --no-fix --ignore F401 task_runner.py test_task_runner_regressions.py` — passed
  - `F401` excludes an existing unused `sys` import in `task_runner.py`; this PR does not mix in unrelated cleanup
- `ruff format --check test_task_runner_regressions.py` — passed
- `git diff --check origin/main...HEAD` — passed
- complete local fix set: real Docker `click-button` benchmark passed 3/3 with reward 1.0 using the public Cua XFCE image

## Known gap

`ruff format --check task_runner.py` reports existing full-file formatting drift. The file was not reformatted because that would create a large unrelated diff.