### PR TITLE
fix(cua-driver): distinguish autostart query failures

### DIFF
--- a/docs/content/docs/how-to-guides/driver/keep-running.mdx
+++ b/docs/content/docs/how-to-guides/driver/keep-running.mdx
@@ -73,6 +73,11 @@ cua-driver autostart status
 # registered (running)
 ```
 
+Only `not-registered` confirms that the Scheduled Task is absent. A
+`permission-denied` or `unknown` result means the current process could not
+inspect Task Scheduler; the command exits non-zero and preserves the original
+diagnostic instead of telling you to re-register blindly.
+
 Remove the autostart registration:
 
 ```powershell

--- a/docs/content/docs/reference/cua-driver/cli-reference.mdx
+++ b/docs/content/docs/reference/cua-driver/cli-reference.mdx
@@ -348,6 +348,8 @@ Remove the autostart entry.
 
 Print whether autostart is registered and running.
 
+`not-registered` is emitted only when Task Scheduler explicitly reports that the named task does not exist. If the task cannot be inspected, the command exits non-zero and reports `permission-denied` or `unknown` together with the original diagnostic.
+
 #### `cua-driver autostart kick`
 
 Start the autostart entry now without re-logging.

--- a/libs/cua-driver/rust/Skills/cua-driver/WINDOWS.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/WINDOWS.md
@@ -805,11 +805,17 @@ trace back to one of these checks reading "false."
 `cua-driver autostart status` reports whether the daemon is
 registered to auto-start at logon AND whether it's currently running:
 
-- `not-registered` — install didn't set up autostart, or user
-  removed the task. Re-register via `cua-driver autostart enable`.
+- `not-registered` — Task Scheduler explicitly reported that the named task
+  does not exist. Re-register via `cua-driver autostart enable`.
 - `registered (not running)` — autostart task exists but no daemon
   process. Kick it with `cua-driver autostart kick`.
 - `registered (running)` — happy path.
+- `permission-denied` — the current process cannot inspect Task Scheduler;
+  registration is unknown. Re-run the status check from a context that can
+  read the task rather than re-registering it blindly.
+- `unknown` — the query failed for another reason. The command exits non-zero
+  and includes the original `schtasks` diagnostic; do not treat this as an
+  absent registration.
 
 ## Recording
 

--- a/libs/cua-driver/rust/crates/cua-driver/src/autostart.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/autostart.rs
@@ -63,6 +63,41 @@ impl Status {
     }
 }
 
+/// Outcome of asking `schtasks /HRESULT` whether the autostart task exists.
+///
+/// Keep query failures separate from `Status::NotRegistered`: a caller that
+/// cannot inspect Task Scheduler must not report that the task is absent.
+#[cfg(any(target_os = "windows", test))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TaskQueryOutcome {
+    Registered,
+    NotRegistered,
+    PermissionDenied,
+    Unknown,
+}
+
+#[cfg(any(target_os = "windows", test))]
+const HRESULT_FILE_NOT_FOUND: u32 = 0x8007_0002;
+
+#[cfg(any(target_os = "windows", test))]
+const HRESULT_ACCESS_DENIED: u32 = 0x8007_0005;
+
+#[cfg(any(target_os = "windows", test))]
+fn classify_task_query(success: bool, exit_code: Option<i32>) -> TaskQueryOutcome {
+    if success {
+        return TaskQueryOutcome::Registered;
+    }
+
+    // `/HRESULT` makes the process exit code carry the original Windows error
+    // instead of collapsing every failure to exit 1. Interpret the i32 as its
+    // raw u32 bit pattern because Windows HRESULTs have the high bit set.
+    match exit_code.map(|code| code as u32) {
+        Some(HRESULT_FILE_NOT_FOUND) => TaskQueryOutcome::NotRegistered,
+        Some(HRESULT_ACCESS_DENIED) => TaskQueryOutcome::PermissionDenied,
+        _ => TaskQueryOutcome::Unknown,
+    }
+}
+
 // ── Public API ────────────────────────────────────────────────────────────
 
 /// Register the platform-native autostart entry for `cua-driver serve`.
@@ -307,15 +342,45 @@ Register-ScheduledTask -TaskName 'cua-driver-serve' -Action $action -Trigger $tr
     }
 
     pub fn status() -> Result<Status> {
-        // schtasks /Query exits 0 with task details on stdout, or 1 with
-        // "ERROR: The system cannot find the file specified." on stderr.
+        // Without /HRESULT, schtasks collapses "task not found", permission
+        // failures, and other Task Scheduler errors to exit 1. /HRESULT keeps
+        // those cases distinct and is locale-independent: ERROR_FILE_NOT_FOUND
+        // means the named task is absent, while ERROR_PATH_NOT_FOUND means the
+        // scheduler namespace could not be inspected and therefore stays
+        // unknown.
         let out = Command::new("schtasks")
-            .args(["/Query", "/TN", TASK_NAME])
+            .args(["/Query", "/TN", TASK_NAME, "/HRESULT"])
             .output()
-            .map_err(|e| anyhow!("failed to invoke schtasks: {e}"))?;
-        if !out.status.success() {
-            return Ok(Status::NotRegistered);
+            .map_err(|e| anyhow!("unknown: failed to invoke schtasks: {e}"))?;
+
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        match classify_task_query(out.status.success(), out.status.code()) {
+            TaskQueryOutcome::Registered => {}
+            TaskQueryOutcome::NotRegistered => return Ok(Status::NotRegistered),
+            outcome @ (TaskQueryOutcome::PermissionDenied | TaskQueryOutcome::Unknown) => {
+                let tag = match outcome {
+                    TaskQueryOutcome::PermissionDenied => "permission-denied",
+                    TaskQueryOutcome::Unknown => "unknown",
+                    _ => unreachable!(),
+                };
+                let diagnostic = match (stdout.trim(), stderr.trim()) {
+                    ("", "") => "no diagnostic output".to_owned(),
+                    (stdout, "") => stdout.to_owned(),
+                    ("", stderr) => stderr.to_owned(),
+                    (stdout, stderr) => format!("{stdout}\n{stderr}"),
+                };
+                let hresult = out
+                    .status
+                    .code()
+                    .map(|code| format!("0x{:08X}", code as u32))
+                    .unwrap_or_else(|| "unavailable".to_owned());
+                return Err(anyhow!(
+                    "{tag}: schtasks /Query /HRESULT failed (HRESULT {hresult}): {diagnostic}"
+                ));
+            }
         }
+
         // Registered — now check whether `cua-driver serve` is running.
         // Avoid invoking `tasklist` (slow ~200ms on first run); use the
         // same registry the daemon's own status command uses via a
@@ -416,5 +481,58 @@ pub fn run_autostart_cmd(subcommand: &str) {
             eprintln!("cua-driver autostart {subcommand}: {e}");
             std::process::exit(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn successful_task_query_is_registered() {
+        assert_eq!(
+            classify_task_query(true, Some(0)),
+            TaskQueryOutcome::Registered
+        );
+        assert_eq!(
+            classify_task_query(true, Some(HRESULT_ACCESS_DENIED as i32)),
+            TaskQueryOutcome::Registered
+        );
+    }
+
+    #[test]
+    fn file_not_found_is_not_registered() {
+        assert_eq!(
+            classify_task_query(false, Some(HRESULT_FILE_NOT_FOUND as i32)),
+            TaskQueryOutcome::NotRegistered
+        );
+    }
+
+    #[test]
+    fn access_failure_is_permission_denied() {
+        assert_eq!(
+            classify_task_query(false, Some(HRESULT_ACCESS_DENIED as i32)),
+            TaskQueryOutcome::PermissionDenied
+        );
+    }
+
+    #[test]
+    fn unrecognized_failure_is_unknown() {
+        const HRESULT_PATH_NOT_FOUND: u32 = 0x8007_0003;
+        const HRESULT_RPC_SERVER_UNAVAILABLE: u32 = 0x8007_06BA;
+
+        assert_eq!(
+            classify_task_query(false, Some(HRESULT_PATH_NOT_FOUND as i32)),
+            TaskQueryOutcome::Unknown
+        );
+        assert_eq!(
+            classify_task_query(false, Some(HRESULT_RPC_SERVER_UNAVAILABLE as i32)),
+            TaskQueryOutcome::Unknown
+        );
+        assert_eq!(
+            classify_task_query(false, Some(1)),
+            TaskQueryOutcome::Unknown
+        );
+        assert_eq!(classify_task_query(false, None), TaskQueryOutcome::Unknown);
     }
 }

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -2644,7 +2644,7 @@ fn cli_docs_json() -> serde_json::Value {
                 "subcommands": [
                     {"name":"enable","abstract":"Register the autostart entry.","discussion":"","arguments":[],"options":[],"flags":[],"subcommands":[]},
                     {"name":"disable","abstract":"Remove the autostart entry.","discussion":"","arguments":[],"options":[],"flags":[],"subcommands":[]},
-                    {"name":"status","abstract":"Print whether autostart is registered and running.","discussion":"","arguments":[],"options":[],"flags":[],"subcommands":[]},
+                    {"name":"status","abstract":"Print whether autostart is registered and running.","discussion":"`not-registered` is emitted only when Task Scheduler explicitly reports that the named task does not exist. If the task cannot be inspected, the command exits non-zero and reports `permission-denied` or `unknown` together with the original diagnostic.","arguments":[],"options":[],"flags":[],"subcommands":[]},
                     {"name":"kick","abstract":"Start the autostart entry now without re-logging.","discussion":"","arguments":[],"options":[],"flags":[],"subcommands":[]}
                 ]
             },


### PR DESCRIPTION
## Summary

- query Windows Task Scheduler with `schtasks /HRESULT` instead of treating every non-zero exit as an absent task
- report only `0x80070002` (`ERROR_FILE_NOT_FOUND`) as `not-registered`, `0x80070005` as `permission-denied`, and other failures as `unknown`
- preserve the original diagnostic, return a non-zero CLI exit for non-authoritative results, and document the status contract

## Root cause

`platform::status()` previously returned `Status::NotRegistered` for every failed `schtasks /Query`. Windows uses the same ordinary exit code for a missing task, permission failures, and inaccessible Task Scheduler namespaces, so a query failure could incorrectly tell users to re-register an existing task.

`/HRESULT` exposes the underlying locale-independent Windows error code and keeps those cases distinct.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p cua-driver --bin cua-driver --locked` — 105 passed
- restricted-context smoke — `unknown`, HRESULT `0x80070003`, CLI exit 1
- normal Windows context smoke — `registered (running)`, CLI exit 0
- intentionally missing task query — HRESULT `0x80070002`
- CLI reference regenerated from `cli_docs_json()` with the official docs generator
