### PR TITLE
docs: link computer-use overview from related guides

### DIFF
--- a/docs/content/docs/concepts/how-sandboxes-work.mdx
+++ b/docs/content/docs/concepts/how-sandboxes-work.mdx
@@ -7,6 +7,8 @@ A Cua Sandbox is a **full, isolated computer**, not a remote desktop session. In
 
 Those are two complementary halves of the same computer. The code half and the GUI half share one filesystem, one set of processes, and one OS state. The value is that they live in the same place. An agent can click through an app and then run a Python function against the files or process state that app produced. It can also set up state in code and then automate the UI over that state.
 
+For the broader model that combines code, structured tools, and graphical interfaces, read [What is computer use?](/concepts/what-is-computer-use).
+
 ## Sandboxes and real machines
 
 Cua Driver operates a real machine you already have. It can observe and control that machine, so its actions happen in the same desktop environment you use.

--- a/docs/content/docs/how-to-guides/driver/connect-your-agent.mdx
+++ b/docs/content/docs/how-to-guides/driver/connect-your-agent.mdx
@@ -5,7 +5,7 @@ description: Register Cua Driver as an MCP server so an agent can drive the host
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-`cua-driver mcp` runs Cua Driver as a stdio MCP server. Register it when you want an MCP-capable agent to drive the **host desktop**: installed apps, signed-in browser sessions, local files opened in apps, and the current OS user session.
+`cua-driver mcp` runs Cua Driver as a stdio MCP server. Register it when you want an MCP-capable [computer-use agent](/concepts/what-is-computer-use) to drive the **host desktop**: installed apps, signed-in browser sessions, local files opened in apps, and the current OS user session.
 
 <Callout type="info">
   This connects an agent to Cua Driver on the current machine. To create disposable cloud desktops, use [Cua Sandbox](/tutorials/your-first-cloud-sandbox) instead.

--- a/docs/content/docs/tutorials/drive-your-first-app.mdx
+++ b/docs/content/docs/tutorials/drive-your-first-app.mdx
@@ -10,6 +10,8 @@ import { Callout } from 'fumadocs-ui/components/callout';
 
 You do not type **Cua Driver** CLI commands by hand. Cua Driver is a backend that an agent harness (Claude Code, Codex, Hermes, and others) drives for you. In this tutorial you install Cua Driver, connect your agent, and ask it in plain English to open a calculator and read a result back. Works the same on macOS, Windows, and Linux.
 
+New to agents that operate applications? Start with [What is computer use?](/concepts/what-is-computer-use) for the model behind the workflow, then return here to build one.
+
 <VideoDemo
   src="https://trycua.github.io/assets/videos/cua-driver/windows-msbuild-piano.mp4"
   poster="https://trycua.github.io/assets/posters/cua-driver/windows-msbuild-piano.jpg"


### PR DESCRIPTION
## Summary

- link the computer-use overview from the first-app tutorial
- link it from the agent connection guide and sandbox concept page
- complete the remaining contextual-link scope from #2332; the substantive overview rewrite already landed in #2325

The website routing follow-up is tracked separately in trycua/cloud#5871.

## Validation

- `pnpm docs:check-hygiene`
- `pnpm docs:check-links`
- `pnpm build` (79 static pages)

Closes #2332