### PR TITLE
chore: scope code owner requests by area

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,16 @@
-# Require a core maintainer to approve every change.
-* @f-trycua @ddupont808 @r33drichards
-
-# Keep repository policy, automation, and release credentials under the owner.
+# Repository policy, automation, and releases.
 /.github/ @f-trycua
+/.release-please-manifest.json @f-trycua
+/release-please-config.json @f-trycua
+
+# Core products and SDKs.
+/libs/cua-driver/ @f-trycua
+/libs/lume/ @f-trycua
+/libs/python/ @ddupont808
+/libs/cua-bench/ @ddupont808
+
+# Platform infrastructure.
+/libs/fleet/ @r33drichards
+/nix/ @r33drichards
+/flake.nix @r33drichards
+/flake.lock @r33drichards


### PR DESCRIPTION
## summary

- remove the repository-wide review request
- route critical areas to the maintainer with the strongest contribution history

## ownership

- `f-trycua`: repository policy, releases, driver, and lume
- `ddupont808`: python sdks and cua-bench
- `r33drichards`: fleet and nix infrastructure

## why

the global wildcard added in [#2212](https://github.com/trycua/cua/issues/2212) subscribes every listed maintainer to every pull request. path-specific ownership preserves automatic review for critical areas without creating repository-wide notification noise. unowned changes still require one approval under the `main` ruleset.

## validation

- `git diff --check`
