### PR TITLE
fix(cua-driver): expose legacy macOS page fallback

### DIFF
--- a/docs/content/docs/reference/cua-driver/mcp-tools.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools.mdx
@@ -476,8 +476,8 @@ Legacy browser compatibility tool. Prefer get_browser_state and the typed browse
 
 Actions:
 - execute_javascript: Run JS and return the result.
-- get_text: Extract visible text from the page.
-- query_dom: Find elements matching a CSS selector.
+- get_text: Extract visible text from the page. On macOS, structuredContent.source identifies javascript, cdp, or ax_fallback; a successful AX fallback preserves the triggering error and truncation state in structuredContent.
+- query_dom: Find elements matching a CSS selector, with the same macOS fallback metadata contract as get_text.
 - click_element: Click a CSS-selected element AND animate the agent cursor to its on-screen center first (so the user sees what the agent is doing). Prefer over `execute_javascript('el.click()')` whenever you want visible cursor feedback.
 - insert_text: Insert `text` at whatever currently holds DOM focus in one native operation (CDP Input.insertText) — no synthesized key events, but more durable than a one-shot execute_javascript write since rich-text editors already have to treat it like an IME commit. Try this before type_keystrokes on a contenteditable that discarded an execute_javascript write. Click/focus the target field first.
 - type_keystrokes: Type `text` via real per-character keystroke events into whatever currently holds DOM focus. Slower than insert_text but the most durable rung — use it when insert_text also gets discarded, or the editor's own keydown/keyup handlers need to see real keys. Click/focus the target field first.

--- a/docs/content/docs/reference/cua-driver/mcp-tools.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools.mdx
@@ -546,8 +546,8 @@ Legacy browser compatibility tool. Prefer get_browser_state and the typed browse
 
 Actions:
 - execute_javascript: Run JS and return the result.
-- get_text: Extract visible text from the page.
-- query_dom: Find elements matching a CSS selector.
+- get_text: Extract visible text from the page. On macOS, structuredContent.source identifies javascript, cdp, or ax_fallback; a successful AX fallback preserves the triggering error and truncation state in structuredContent.
+- query_dom: Find elements matching a CSS selector, with the same macOS fallback metadata contract as get_text.
 - click_element: Click a CSS-selected element AND animate the agent cursor to its on-screen center first (so the user sees what the agent is doing). Prefer over `execute_javascript('el.click()')` whenever you want visible cursor feedback.
 - insert_text: Insert `text` at whatever currently holds DOM focus in one native operation (CDP Input.insertText) — no synthesized key events, but more durable than a one-shot execute_javascript write since rich-text editors already have to treat it like an IME commit. Try this before type_keystrokes on a contenteditable that discarded an execute_javascript write. Click/focus the target field first.
 - type_keystrokes: Type `text` via real per-character keystroke events into whatever currently holds DOM focus. Slower than insert_text but the most durable rung — use it when insert_text also gets discarded, or the editor's own keydown/keyup handlers need to see real keys. Click/focus the target field first.

--- a/libs/cua-driver/rust/Skills/cua-driver/BROWSER.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/BROWSER.md
@@ -327,6 +327,14 @@ operator can enable the temporary compatibility path with
 Driver after changing the flag. It does not add typed endpoint ownership,
 capabilities, or existing-profile consent.
 
+On macOS, legacy `page.get_text` and `page.query_dom` keep their original text
+payload but also report read provenance in `structuredContent.source`:
+`javascript`, `cdp`, or `ax_fallback`. When JavaScript or CDP fails and the AX
+fallback succeeds, `structuredContent.fallback_error` preserves the triggering
+error and `structuredContent.truncated` reports whether the bounded AX walk was
+cut short. A direct WKWebView/Tauri AX read has no `fallback_error` because no
+JavaScript or CDP route was attempted.
+
 ## Support boundaries
 
 | Surface | Typed state and mutation | Important boundary |

--- a/libs/cua-driver/rust/Skills/cua-driver/BROWSER.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/BROWSER.md
@@ -453,6 +453,14 @@ operator can enable the temporary compatibility path with
 Driver after changing the flag. It does not add typed endpoint ownership,
 capabilities, or existing-profile consent.
 
+On macOS, legacy `page.get_text` and `page.query_dom` keep their original text
+payload but also report read provenance in `structuredContent.source`:
+`javascript`, `cdp`, or `ax_fallback`. When JavaScript or CDP fails and the AX
+fallback succeeds, `structuredContent.fallback_error` preserves the triggering
+error and `structuredContent.truncated` reports whether the bounded AX walk was
+cut short. A direct WKWebView/Tauri AX read has no `fallback_error` because no
+JavaScript or CDP route was attempted.
+
 ## Support boundaries
 
 | Surface | Typed state and mutation | Important boundary |

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/page.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/page.rs
@@ -64,6 +64,54 @@ pub struct ClickElementResult {
     pub message: String,
 }
 
+/// Provenance for a successful legacy page read. macOS uses this to make its
+/// JavaScript/CDP-to-AX compatibility fallback explicit without changing the
+/// existing textual response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PageReadSource {
+    Javascript,
+    Cdp,
+    AxFallback,
+}
+
+/// Structured metadata attached to a legacy page read when the backend can
+/// identify its modality.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PageReadMetadata {
+    pub source: PageReadSource,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallback_error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub truncated: Option<bool>,
+}
+
+/// Compatibility result for `get_text` and `query_dom`. `content` remains the
+/// exact legacy text payload; metadata is emitted separately as MCP structured
+/// content. Backends without modality metadata can keep implementing the
+/// original string-returning methods.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PageReadResult {
+    pub content: String,
+    pub metadata: Option<PageReadMetadata>,
+}
+
+impl PageReadResult {
+    pub fn text(content: String) -> Self {
+        Self {
+            content,
+            metadata: None,
+        }
+    }
+
+    pub fn with_metadata(content: String, metadata: PageReadMetadata) -> Self {
+        Self {
+            content,
+            metadata: Some(metadata),
+        }
+    }
+}
+
 /// Platform-specific backend for the `page` tool.
 ///
 /// All methods take `(pid, window_id)` for consistency across actions.
@@ -75,6 +123,14 @@ pub trait PageBackend: Send + Sync {
     /// `document.body.innerText`).
     async fn get_text(&self, pid: i32, window_id: u64) -> anyhow::Result<String>;
 
+    /// Metadata-aware form used by the shared dispatcher. The default keeps
+    /// existing platform backends source-compatible and returns plain text.
+    async fn get_text_result(&self, pid: i32, window_id: u64) -> anyhow::Result<PageReadResult> {
+        self.get_text(pid, window_id)
+            .await
+            .map(PageReadResult::text)
+    }
+
     /// Find elements matching `css_selector` and return a formatted-text
     /// response (same human-readable shape macOS already emits).
     async fn query_dom(
@@ -84,6 +140,20 @@ pub trait PageBackend: Send + Sync {
         css_selector: &str,
         attributes: &[String],
     ) -> anyhow::Result<String>;
+
+    /// Metadata-aware form used by the shared dispatcher. See
+    /// [`PageBackend::get_text_result`].
+    async fn query_dom_result(
+        &self,
+        pid: i32,
+        window_id: u64,
+        css_selector: &str,
+        attributes: &[String],
+    ) -> anyhow::Result<PageReadResult> {
+        self.query_dom(pid, window_id, css_selector, attributes)
+            .await
+            .map(PageReadResult::text)
+    }
 
     /// Evaluate `javascript` against the page and return the stringified
     /// result. Backends without a JS path should return an actionable error.
@@ -266,8 +336,11 @@ fn def() -> &'static ToolDef {
             --remote-debugging-port is set), and WKWebView/Tauri/AT-SPI fallbacks.\n\n\
             Actions:\n\
             - execute_javascript: Run JS and return the result.\n\
-            - get_text: Extract visible text from the page.\n\
-            - query_dom: Find elements matching a CSS selector.\n\
+            - get_text: Extract visible text from the page. On macOS, structuredContent.source \
+              identifies javascript, cdp, or ax_fallback; a successful AX fallback preserves \
+              the triggering error and truncation state in structuredContent.\n\
+            - query_dom: Find elements matching a CSS selector, with the same macOS fallback \
+              metadata contract as get_text.\n\
             - click_element: Click a CSS-selected element AND animate the agent cursor \
               to its on-screen center first (so the user sees what the agent is doing). \
               Prefer over `execute_javascript('el.click()')` whenever you want visible \
@@ -458,8 +531,8 @@ impl Tool for PageTool {
                 }
             }
 
-            "get_text" => match self.backend.get_text(pid, window_id).await {
-                Ok(text) => ToolResult::text(text),
+            "get_text" => match self.backend.get_text_result(pid, window_id).await {
+                Ok(result) => page_read_tool_result(result),
                 Err(e) => ToolResult::error(format!("Page text extraction failed: {e}")),
             },
 
@@ -547,16 +620,26 @@ impl Tool for PageTool {
                     .unwrap_or_default();
                 match self
                     .backend
-                    .query_dom(pid, window_id, &selector, &attributes)
+                    .query_dom_result(pid, window_id, &selector, &attributes)
                     .await
                 {
-                    Ok(text) => ToolResult::text(text),
+                    Ok(result) => page_read_tool_result(result),
                     Err(e) => ToolResult::error(format!("DOM query failed: {e}")),
                 }
             }
 
             other => ToolResult::error(format!("Unknown action: {other}")),
         }
+    }
+}
+
+fn page_read_tool_result(result: PageReadResult) -> ToolResult {
+    let tool_result = ToolResult::text(result.content);
+    match result.metadata {
+        Some(metadata) => tool_result.with_structured(
+            serde_json::to_value(metadata).expect("page read metadata must serialize"),
+        ),
+        None => tool_result,
     }
 }
 
@@ -628,6 +711,74 @@ mod tests {
             ));
             Ok("targeted".to_owned())
         }
+    }
+
+    struct ProvenanceBackend;
+
+    #[async_trait]
+    impl PageBackend for ProvenanceBackend {
+        async fn get_text(&self, _pid: i32, _window_id: u64) -> anyhow::Result<String> {
+            Ok("legacy payload".to_owned())
+        }
+
+        async fn get_text_result(
+            &self,
+            _pid: i32,
+            _window_id: u64,
+        ) -> anyhow::Result<PageReadResult> {
+            Ok(PageReadResult::with_metadata(
+                "legacy payload".to_owned(),
+                PageReadMetadata {
+                    source: PageReadSource::AxFallback,
+                    fallback_error: Some("JavaScript from Apple Events is disabled".to_owned()),
+                    truncated: Some(true),
+                },
+            ))
+        }
+
+        async fn query_dom(
+            &self,
+            _pid: i32,
+            _window_id: u64,
+            _css_selector: &str,
+            _attributes: &[String],
+        ) -> anyhow::Result<String> {
+            Ok(String::new())
+        }
+
+        async fn execute_javascript(
+            &self,
+            _pid: i32,
+            _window_id: u64,
+            _javascript: &str,
+        ) -> anyhow::Result<String> {
+            anyhow::bail!("unused")
+        }
+    }
+
+    #[tokio::test]
+    async fn read_preserves_text_and_attaches_backend_provenance() {
+        let tool = PageTool::new(Arc::new(ProvenanceBackend));
+        let result = tool
+            .invoke(serde_json::json!({
+                "pid": 42,
+                "window_id": 7,
+                "action": "get_text"
+            }))
+            .await;
+
+        assert!(matches!(
+            &result.content[0],
+            crate::protocol::Content::Text { text, .. } if text == "legacy payload"
+        ));
+        assert_eq!(
+            result.structured_content,
+            Some(serde_json::json!({
+                "source": "ax_fallback",
+                "fallback_error": "JavaScript from Apple Events is disabled",
+                "truncated": true
+            }))
+        );
     }
 
     #[tokio::test]

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/page.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/page.rs
@@ -75,39 +75,42 @@ pub enum PageReadSource {
     AxFallback,
 }
 
-/// Structured metadata attached to a legacy page read when the backend can
-/// identify its modality.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PageReadMetadata {
-    pub source: PageReadSource,
+/// Compatibility result for `get_text` and `query_dom`. `content` remains the
+/// exact legacy text payload while the optional fields serialize as MCP
+/// structured content. Backends without provenance return [`PageReadResult::text`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PageReadResult {
+    #[serde(skip)]
+    pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<PageReadSource>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fallback_error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub truncated: Option<bool>,
 }
 
-/// Compatibility result for `get_text` and `query_dom`. `content` remains the
-/// exact legacy text payload; metadata is emitted separately as MCP structured
-/// content. Backends without modality metadata can keep implementing the
-/// original string-returning methods.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PageReadResult {
-    pub content: String,
-    pub metadata: Option<PageReadMetadata>,
-}
-
 impl PageReadResult {
     pub fn text(content: String) -> Self {
         Self {
             content,
-            metadata: None,
+            source: None,
+            fallback_error: None,
+            truncated: None,
         }
     }
 
-    pub fn with_metadata(content: String, metadata: PageReadMetadata) -> Self {
+    pub fn sourced(
+        content: String,
+        source: PageReadSource,
+        fallback_error: Option<String>,
+        truncated: Option<bool>,
+    ) -> Self {
         Self {
             content,
-            metadata: Some(metadata),
+            source: Some(source),
+            fallback_error,
+            truncated,
         }
     }
 }
@@ -120,40 +123,18 @@ impl PageReadResult {
 #[async_trait]
 pub trait PageBackend: Send + Sync {
     /// Returns the visible text of the page (rough analog of
-    /// `document.body.innerText`).
-    async fn get_text(&self, pid: i32, window_id: u64) -> anyhow::Result<String>;
+    /// `document.body.innerText`) plus optional backend provenance.
+    async fn get_text(&self, pid: i32, window_id: u64) -> anyhow::Result<PageReadResult>;
 
-    /// Metadata-aware form used by the shared dispatcher. The default keeps
-    /// existing platform backends source-compatible and returns plain text.
-    async fn get_text_result(&self, pid: i32, window_id: u64) -> anyhow::Result<PageReadResult> {
-        self.get_text(pid, window_id)
-            .await
-            .map(PageReadResult::text)
-    }
-
-    /// Find elements matching `css_selector` and return a formatted-text
-    /// response (same human-readable shape macOS already emits).
+    /// Find elements matching `css_selector` and return the legacy formatted
+    /// text response plus optional backend provenance.
     async fn query_dom(
         &self,
         pid: i32,
         window_id: u64,
         css_selector: &str,
         attributes: &[String],
-    ) -> anyhow::Result<String>;
-
-    /// Metadata-aware form used by the shared dispatcher. See
-    /// [`PageBackend::get_text_result`].
-    async fn query_dom_result(
-        &self,
-        pid: i32,
-        window_id: u64,
-        css_selector: &str,
-        attributes: &[String],
-    ) -> anyhow::Result<PageReadResult> {
-        self.query_dom(pid, window_id, css_selector, attributes)
-            .await
-            .map(PageReadResult::text)
-    }
+    ) -> anyhow::Result<PageReadResult>;
 
     /// Evaluate `javascript` against the page and return the stringified
     /// result. Backends without a JS path should return an actionable error.
@@ -531,7 +512,7 @@ impl Tool for PageTool {
                 }
             }
 
-            "get_text" => match self.backend.get_text_result(pid, window_id).await {
+            "get_text" => match self.backend.get_text(pid, window_id).await {
                 Ok(result) => page_read_tool_result(result),
                 Err(e) => ToolResult::error(format!("Page text extraction failed: {e}")),
             },
@@ -620,7 +601,7 @@ impl Tool for PageTool {
                     .unwrap_or_default();
                 match self
                     .backend
-                    .query_dom_result(pid, window_id, &selector, &attributes)
+                    .query_dom(pid, window_id, &selector, &attributes)
                     .await
                 {
                     Ok(result) => page_read_tool_result(result),
@@ -634,11 +615,12 @@ impl Tool for PageTool {
 }
 
 fn page_read_tool_result(result: PageReadResult) -> ToolResult {
+    let structured = result
+        .source
+        .map(|_| serde_json::to_value(&result).expect("page read metadata must serialize"));
     let tool_result = ToolResult::text(result.content);
-    match result.metadata {
-        Some(metadata) => tool_result.with_structured(
-            serde_json::to_value(metadata).expect("page read metadata must serialize"),
-        ),
+    match structured {
+        Some(metadata) => tool_result.with_structured(metadata),
         None => tool_result,
     }
 }
@@ -671,8 +653,8 @@ mod tests {
 
     #[async_trait]
     impl PageBackend for RecordingBackend {
-        async fn get_text(&self, _pid: i32, _window_id: u64) -> anyhow::Result<String> {
-            Ok(String::new())
+        async fn get_text(&self, _pid: i32, _window_id: u64) -> anyhow::Result<PageReadResult> {
+            Ok(PageReadResult::text(String::new()))
         }
 
         async fn query_dom(
@@ -681,8 +663,8 @@ mod tests {
             _window_id: u64,
             _css_selector: &str,
             _attributes: &[String],
-        ) -> anyhow::Result<String> {
-            Ok(String::new())
+        ) -> anyhow::Result<PageReadResult> {
+            Ok(PageReadResult::text(String::new()))
         }
 
         async fn execute_javascript(
@@ -717,22 +699,12 @@ mod tests {
 
     #[async_trait]
     impl PageBackend for ProvenanceBackend {
-        async fn get_text(&self, _pid: i32, _window_id: u64) -> anyhow::Result<String> {
-            Ok("legacy payload".to_owned())
-        }
-
-        async fn get_text_result(
-            &self,
-            _pid: i32,
-            _window_id: u64,
-        ) -> anyhow::Result<PageReadResult> {
-            Ok(PageReadResult::with_metadata(
+        async fn get_text(&self, _pid: i32, _window_id: u64) -> anyhow::Result<PageReadResult> {
+            Ok(PageReadResult::sourced(
                 "legacy payload".to_owned(),
-                PageReadMetadata {
-                    source: PageReadSource::AxFallback,
-                    fallback_error: Some("JavaScript from Apple Events is disabled".to_owned()),
-                    truncated: Some(true),
-                },
+                PageReadSource::AxFallback,
+                Some("JavaScript from Apple Events is disabled".to_owned()),
+                Some(true),
             ))
         }
 
@@ -742,8 +714,8 @@ mod tests {
             _window_id: u64,
             _css_selector: &str,
             _attributes: &[String],
-        ) -> anyhow::Result<String> {
-            Ok(String::new())
+        ) -> anyhow::Result<PageReadResult> {
+            Ok(PageReadResult::text(String::new()))
         }
 
         async fn execute_javascript(

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/page.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/page.rs
@@ -6,7 +6,7 @@
 //! `--remote-debugging-port=N` for that to succeed.
 
 use async_trait::async_trait;
-use cua_driver_core::page::PageBackend;
+use cua_driver_core::page::{PageBackend, PageReadResult};
 
 pub struct LinuxPageBackend;
 
@@ -24,13 +24,15 @@ impl Default for LinuxPageBackend {
 
 #[async_trait]
 impl PageBackend for LinuxPageBackend {
-    async fn get_text(&self, pid: i32, window_id: u64) -> anyhow::Result<String> {
+    async fn get_text(&self, pid: i32, window_id: u64) -> anyhow::Result<PageReadResult> {
         let pid_u = pid as u32;
         let xid = window_id;
         let result = tokio::task::spawn_blocking(move || crate::atspi::walk_tree(pid_u, xid, None))
             .await
             .map_err(|e| anyhow::anyhow!("AT-SPI walk task failed: {e}"))?;
-        Ok(extract_text_from_markdown(&result.tree_markdown))
+        Ok(PageReadResult::text(extract_text_from_markdown(
+            &result.tree_markdown,
+        )))
     }
 
     async fn query_dom(
@@ -39,7 +41,7 @@ impl PageBackend for LinuxPageBackend {
         window_id: u64,
         css_selector: &str,
         _attributes: &[String],
-    ) -> anyhow::Result<String> {
+    ) -> anyhow::Result<PageReadResult> {
         let pid_u = pid as u32;
         let xid = window_id;
         let selector = css_selector.to_owned();
@@ -95,11 +97,12 @@ impl PageBackend for LinuxPageBackend {
             })
             .collect();
 
-        if lines.is_empty() {
-            Ok("No elements found.".to_owned())
+        let content = if lines.is_empty() {
+            "No elements found.".to_owned()
         } else {
-            Ok(lines.join("\n"))
-        }
+            lines.join("\n")
+        };
+        Ok(PageReadResult::text(content))
     }
 
     async fn execute_javascript(

--- a/libs/cua-driver/rust/crates/platform-macos/src/ax/tree.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/ax/tree.rs
@@ -94,8 +94,14 @@ pub struct AXNode {
 pub struct TreeWalkResult {
     pub tree_markdown: String,
     pub nodes: Vec<AXNode>,
-    /// True when the walk was cut short by the MAX_ELEMENTS cap.
+    /// True when the walk was cut short by either the element or depth cap.
     pub truncated: bool,
+}
+
+#[derive(Default)]
+struct WalkTruncation {
+    element_limit: bool,
+    depth_limit: bool,
 }
 
 /// Walk the AX tree of `pid`, optionally filtered to a specific window.
@@ -142,9 +148,9 @@ pub fn walk_tree_bounded(
     let mut index_counter = 0usize;
     // Shared visited-node counter passed into walk_element to enforce the cap.
     let mut visited_count = 0usize;
-    // Set to true only when walk_element actually stops early due to the cap —
-    // avoids a false-positive when the tree naturally ends on exactly the cap.
-    let mut truncated = false;
+    // Record only bounds that actually omit a node, avoiding a false-positive
+    // when the tree naturally ends exactly on either bound.
+    let mut truncated = WalkTruncation::default();
 
     unsafe {
         let app_elem = AXUIElementCreateApplication(pid);
@@ -243,7 +249,7 @@ pub fn walk_tree_bounded(
         CFRelease(app_elem as CFTypeRef);
     }
 
-    let truncated_flag = truncated;
+    let truncated_flag = truncated.element_limit || truncated.depth_limit;
     let raw_markdown = render_lines(&lines);
     let mut tree_markdown = if let Some(q) = query {
         filter_tree(&raw_markdown, q)
@@ -251,10 +257,16 @@ pub fn walk_tree_bounded(
         raw_markdown
     };
 
-    if truncated_flag {
+    if truncated.element_limit {
         tree_markdown.push_str(&format!(
             "\n⚠️  AX tree truncated at {max_elements} nodes \
              (app has a very large accessibility tree — Arc, Electron, or similar). \
+             Element indices above are still valid. Use pixel clicks for elements \
+             not visible in this partial tree."
+        ));
+    } else if truncated.depth_limit {
+        tree_markdown.push_str(&format!(
+            "\n⚠️  AX tree truncated beyond depth {max_depth}. \
              Element indices above are still valid. Use pixel clicks for elements \
              not visible in this partial tree."
         ));
@@ -276,17 +288,18 @@ unsafe fn walk_element(
     lines: &mut Vec<(usize, String)>,
     counter: &mut usize,
     visited_count: &mut usize,
-    truncated: &mut bool,
+    truncated: &mut WalkTruncation,
     max_elements: usize,
     max_depth: usize,
 ) {
     if depth > max_depth {
+        truncated.depth_limit = true;
         return;
     }
     // Enforce total-node cap — mirrors Swift's maxElements guard.
     // Set the truncated flag only when we actually stop early.
     if *visited_count >= max_elements {
-        *truncated = true;
+        truncated.element_limit = true;
         return;
     }
     *visited_count += 1;

--- a/libs/cua-driver/rust/crates/platform-macos/src/ax/tree.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/ax/tree.rs
@@ -135,7 +135,7 @@ fn is_addressable(actions_present: bool, value_settable: bool, enabled: Option<b
 pub struct TreeWalkResult {
     pub tree_markdown: String,
     pub nodes: Vec<AXNode>,
-    /// True when the walk was cut short by the MAX_ELEMENTS cap.
+    /// True when the walk was cut short by either the element or depth cap.
     pub truncated: bool,
     /// Whether the requested `window_id` actually resolved to an AX surface,
     /// and if not, why. `None` when no `window_id` was requested.
@@ -146,6 +146,12 @@ pub struct TreeWalkResult {
     /// [`WindowScope::Matched`] comes with an EMPTY walk, so `nodes` never
     /// describes a window other than the requested one.
     pub window_scope: Option<WindowScope>,
+}
+
+#[derive(Default)]
+struct WalkTruncation {
+    element_limit: bool,
+    depth_limit: bool,
 }
 
 /// Walk the AX tree of `pid`, optionally filtered to a specific window.
@@ -192,9 +198,9 @@ pub fn walk_tree_bounded(
     let mut index_counter = 0usize;
     // Shared visited-node counter passed into walk_element to enforce the cap.
     let mut visited_count = 0usize;
-    // Set to true only when walk_element actually stops early due to the cap —
-    // avoids a false-positive when the tree naturally ends on exactly the cap.
-    let mut truncated = false;
+    // Record only bounds that actually omit a node, avoiding a false-positive
+    // when the tree naturally ends exactly on either bound.
+    let mut truncated = WalkTruncation::default();
     let mut window_scope: Option<WindowScope> = None;
 
     unsafe {
@@ -312,7 +318,7 @@ pub fn walk_tree_bounded(
         CFRelease(app_elem as CFTypeRef);
     }
 
-    let truncated_flag = truncated;
+    let truncated_flag = truncated.element_limit || truncated.depth_limit;
     let raw_markdown = render_lines(&lines);
     let mut tree_markdown = if let Some(q) = query {
         filter_tree(&raw_markdown, q)
@@ -320,10 +326,16 @@ pub fn walk_tree_bounded(
         raw_markdown
     };
 
-    if truncated_flag {
+    if truncated.element_limit {
         tree_markdown.push_str(&format!(
             "\n⚠️  AX tree truncated at {max_elements} nodes \
              (app has a very large accessibility tree — Arc, Electron, or similar). \
+             Element indices above are still valid. Use pixel clicks for elements \
+             not visible in this partial tree."
+        ));
+    } else if truncated.depth_limit {
+        tree_markdown.push_str(&format!(
+            "\n⚠️  AX tree truncated beyond depth {max_depth}. \
              Element indices above are still valid. Use pixel clicks for elements \
              not visible in this partial tree."
         ));
@@ -347,17 +359,18 @@ unsafe fn walk_element(
     lines: &mut Vec<(usize, String)>,
     counter: &mut usize,
     visited_count: &mut usize,
-    truncated: &mut bool,
+    truncated: &mut WalkTruncation,
     max_elements: usize,
     max_depth: usize,
 ) {
     if depth > max_depth {
+        truncated.depth_limit = true;
         return;
     }
     // Enforce total-node cap — mirrors Swift's maxElements guard.
     // Set the truncated flag only when we actually stop early.
     if *visited_count >= max_elements {
-        *truncated = true;
+        truncated.element_limit = true;
         return;
     }
     *visited_count += 1;

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/page.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/page.rs
@@ -10,8 +10,10 @@
 //! `cua_driver_core::page` — this file only implements the backend.
 
 use async_trait::async_trait;
-use cua_driver_core::page::{ClickElementResult, PageBackend};
-use std::sync::Arc;
+use cua_driver_core::page::{
+    ClickElementResult, PageBackend, PageReadMetadata, PageReadResult, PageReadSource,
+};
+use std::{future::Future, sync::Arc};
 
 use super::ToolState;
 use crate::browser::{is_wk_web_view_app, AXPageReader, BrowserJs, CdpClient, ElectronJs};
@@ -42,6 +44,10 @@ impl MacOsPageBackend {
 #[async_trait]
 impl PageBackend for MacOsPageBackend {
     async fn get_text(&self, pid: i32, window_id: u64) -> anyhow::Result<String> {
+        Ok(self.get_text_result(pid, window_id).await?.content)
+    }
+
+    async fn get_text_result(&self, pid: i32, window_id: u64) -> anyhow::Result<PageReadResult> {
         let bundle_id = Self::bundle_id_for(pid).await;
 
         let use_ax_fallback = !BrowserJs::supports(&bundle_id)
@@ -50,14 +56,18 @@ impl PageBackend for MacOsPageBackend {
                 .unwrap_or(false);
 
         if use_ax_fallback {
-            return ax_text_fallback(pid, window_id).await;
+            return ax_text_fallback(pid, window_id)
+                .await
+                .map(AxFallbackRead::into_page_result);
         }
 
-        // Try JS path first; on error, fall back to AX walk.
-        match execute_js("document.body.innerText", &bundle_id, pid, window_id).await {
-            Ok(result) => Ok(result),
-            Err(_) => ax_text_fallback(pid, window_id).await,
-        }
+        let source = primary_source(&bundle_id);
+        read_with_ax_fallback(
+            source,
+            execute_js("document.body.innerText", &bundle_id, pid, window_id),
+            || ax_text_fallback(pid, window_id),
+        )
+        .await
     }
 
     async fn query_dom(
@@ -67,6 +77,19 @@ impl PageBackend for MacOsPageBackend {
         css_selector: &str,
         attributes: &[String],
     ) -> anyhow::Result<String> {
+        Ok(self
+            .query_dom_result(pid, window_id, css_selector, attributes)
+            .await?
+            .content)
+    }
+
+    async fn query_dom_result(
+        &self,
+        pid: i32,
+        window_id: u64,
+        css_selector: &str,
+        attributes: &[String],
+    ) -> anyhow::Result<PageReadResult> {
         let bundle_id = Self::bundle_id_for(pid).await;
 
         let use_ax_fallback = !BrowserJs::supports(&bundle_id)
@@ -75,18 +98,17 @@ impl PageBackend for MacOsPageBackend {
                 .unwrap_or(false);
 
         if use_ax_fallback {
-            let results = ax_query_fallback(pid, window_id, css_selector).await?;
-            return Ok(format_ax_elements(&results));
+            return ax_query_fallback(pid, window_id, css_selector)
+                .await
+                .map(AxFallbackRead::into_page_result);
         }
 
         let js = build_query_selector_js(css_selector, attributes);
-        match execute_js(&js, &bundle_id, pid, window_id).await {
-            Ok(result) => Ok(result),
-            Err(_) => {
-                let results = ax_query_fallback(pid, window_id, css_selector).await?;
-                Ok(format_ax_elements(&results))
-            }
-        }
+        let source = primary_source(&bundle_id);
+        read_with_ax_fallback(source, execute_js(&js, &bundle_id, pid, window_id), || {
+            ax_query_fallback(pid, window_id, css_selector)
+        })
+        .await
     }
 
     async fn execute_javascript(
@@ -283,31 +305,116 @@ async fn execute_js(js: &str, bundle_id: &str, pid: i32, window_id: u64) -> anyh
     anyhow::bail!("Unsupported browser: bundle_id={bundle_id}");
 }
 
-/// Extract page text via the AX tree.
-async fn ax_text_fallback(pid: i32, window_id: u64) -> anyhow::Result<String> {
-    let window_id = u32::try_from(window_id)
-        .map_err(|_| anyhow::anyhow!("macOS window_id {window_id} is out of u32 range"))?;
-    let result =
-        tokio::task::spawn_blocking(move || crate::ax::tree::walk_tree(pid, Some(window_id), None))
-            .await
-            .map_err(|e| anyhow::anyhow!("AX walk task failed: {e}"))?;
-    Ok(AXPageReader::extract_text(&result.tree_markdown))
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AxFallbackRead {
+    content: String,
+    truncated: bool,
 }
 
-/// Query AX tree by CSS selector.
+impl AxFallbackRead {
+    fn into_page_result(self) -> PageReadResult {
+        PageReadResult::with_metadata(
+            self.content,
+            PageReadMetadata {
+                source: PageReadSource::AxFallback,
+                fallback_error: None,
+                truncated: Some(self.truncated),
+            },
+        )
+    }
+}
+
+fn primary_source(bundle_id: &str) -> PageReadSource {
+    if BrowserJs::supports(bundle_id) {
+        PageReadSource::Javascript
+    } else {
+        PageReadSource::Cdp
+    }
+}
+
+async fn read_with_ax_fallback<P, F, A>(
+    primary_source: PageReadSource,
+    primary: P,
+    ax_fallback: F,
+) -> anyhow::Result<PageReadResult>
+where
+    P: Future<Output = anyhow::Result<String>>,
+    F: FnOnce() -> A,
+    A: Future<Output = anyhow::Result<AxFallbackRead>>,
+{
+    match primary.await {
+        Ok(content) => Ok(PageReadResult::with_metadata(
+            content,
+            PageReadMetadata {
+                source: primary_source,
+                fallback_error: None,
+                truncated: None,
+            },
+        )),
+        Err(error) => {
+            let fallback = ax_fallback().await.map_err(|fallback_error| {
+                anyhow::anyhow!(
+                    "AX fallback failed after {primary_source:?} read failed: {error}; \
+                     AX fallback error: {fallback_error}"
+                )
+            })?;
+            Ok(PageReadResult::with_metadata(
+                fallback.content,
+                PageReadMetadata {
+                    source: PageReadSource::AxFallback,
+                    fallback_error: Some(error.to_string()),
+                    truncated: Some(fallback.truncated),
+                },
+            ))
+        }
+    }
+}
+
+/// Extract page text via the bounded AX tree.
+async fn ax_text_fallback(pid: i32, window_id: u64) -> anyhow::Result<AxFallbackRead> {
+    let window_id = u32::try_from(window_id)
+        .map_err(|_| anyhow::anyhow!("macOS window_id {window_id} is out of u32 range"))?;
+    let result = tokio::task::spawn_blocking(move || {
+        crate::ax::tree::walk_tree_bounded(
+            pid,
+            Some(window_id),
+            None,
+            crate::ax::tree::DEFAULT_MAX_ELEMENTS,
+            crate::ax::tree::DEFAULT_MAX_DEPTH,
+        )
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("AX walk task failed: {e}"))?;
+    Ok(AxFallbackRead {
+        content: AXPageReader::extract_text(&result.tree_markdown),
+        truncated: result.truncated,
+    })
+}
+
+/// Query the bounded AX tree by CSS selector.
 async fn ax_query_fallback(
     pid: i32,
     window_id: u64,
     selector: &str,
-) -> anyhow::Result<Vec<crate::browser::ax_page_reader::AXElement>> {
+) -> anyhow::Result<AxFallbackRead> {
     let window_id = u32::try_from(window_id)
         .map_err(|_| anyhow::anyhow!("macOS window_id {window_id} is out of u32 range"))?;
     let sel = selector.to_owned();
-    let result =
-        tokio::task::spawn_blocking(move || crate::ax::tree::walk_tree(pid, Some(window_id), None))
-            .await
-            .map_err(|e| anyhow::anyhow!("AX walk task failed: {e}"))?;
-    Ok(AXPageReader::query(&sel, &result.tree_markdown))
+    let result = tokio::task::spawn_blocking(move || {
+        crate::ax::tree::walk_tree_bounded(
+            pid,
+            Some(window_id),
+            None,
+            crate::ax::tree::DEFAULT_MAX_ELEMENTS,
+            crate::ax::tree::DEFAULT_MAX_DEPTH,
+        )
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("AX walk task failed: {e}"))?;
+    Ok(AxFallbackRead {
+        content: format_ax_elements(&AXPageReader::query(&sel, &result.tree_markdown)),
+        truncated: result.truncated,
+    })
 }
 
 fn format_ax_elements(elements: &[crate::browser::ax_page_reader::AXElement]) -> String {
@@ -396,4 +503,125 @@ fn required_finite(value: &serde_json::Value, key: &str, raw: &str) -> anyhow::R
                 "click_element: probe JSON missing/invalid required field '{key}' (raw: {raw:?})"
             )
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ax(content: &str, truncated: bool) -> anyhow::Result<AxFallbackRead> {
+        Ok(AxFallbackRead {
+            content: content.to_owned(),
+            truncated,
+        })
+    }
+
+    #[tokio::test]
+    async fn apple_events_disabled_preserves_error_on_successful_ax_fallback() {
+        let result = read_with_ax_fallback(
+            PageReadSource::Javascript,
+            async { anyhow::bail!("JavaScript from Apple Events is disabled") },
+            || async { ax("visible text", false) },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.content, "visible text");
+        assert_eq!(
+            result.metadata,
+            Some(PageReadMetadata {
+                source: PageReadSource::AxFallback,
+                fallback_error: Some("JavaScript from Apple Events is disabled".to_owned()),
+                truncated: Some(false),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn cdp_unavailable_preserves_error_and_ax_truncation() {
+        let result = read_with_ax_fallback(
+            PageReadSource::Cdp,
+            async { anyhow::bail!("Could not find Electron inspector port") },
+            || async { ax("partial query", true) },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.content, "partial query");
+        assert_eq!(
+            result.metadata,
+            Some(PageReadMetadata {
+                source: PageReadSource::AxFallback,
+                fallback_error: Some("Could not find Electron inspector port".to_owned()),
+                truncated: Some(true),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_ax_fallback_reports_both_errors() {
+        let error = read_with_ax_fallback(
+            PageReadSource::Cdp,
+            async { anyhow::bail!("CDP unavailable") },
+            || async { anyhow::bail!("AX permission denied") },
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("CDP unavailable"));
+        assert!(error.contains("AX permission denied"));
+    }
+
+    #[test]
+    fn wkwebview_direct_fallback_has_no_triggering_error() {
+        let result = AxFallbackRead {
+            content: "tauri text".to_owned(),
+            truncated: false,
+        }
+        .into_page_result();
+
+        assert_eq!(
+            result.metadata,
+            Some(PageReadMetadata {
+                source: PageReadSource::AxFallback,
+                fallback_error: None,
+                truncated: Some(false),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn successful_javascript_query_reports_javascript_source() {
+        let result = read_with_ax_fallback(
+            PageReadSource::Javascript,
+            async { Ok("[{\"tagName\":\"BUTTON\"}]".to_owned()) },
+            || async { ax("must not run", false) },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.content, "[{\"tagName\":\"BUTTON\"}]");
+        assert_eq!(
+            result.metadata,
+            Some(PageReadMetadata {
+                source: PageReadSource::Javascript,
+                fallback_error: None,
+                truncated: None,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn successful_electron_query_reports_cdp_source() {
+        let result = read_with_ax_fallback(
+            PageReadSource::Cdp,
+            async { Ok("[]".to_owned()) },
+            || async { ax("must not run", false) },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.metadata.unwrap().source, PageReadSource::Cdp);
+    }
 }

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/page.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/page.rs
@@ -10,9 +10,7 @@
 //! `cua_driver_core::page` — this file only implements the backend.
 
 use async_trait::async_trait;
-use cua_driver_core::page::{
-    ClickElementResult, PageBackend, PageReadMetadata, PageReadResult, PageReadSource,
-};
+use cua_driver_core::page::{ClickElementResult, PageBackend, PageReadResult, PageReadSource};
 use std::{future::Future, sync::Arc};
 
 use super::ToolState;
@@ -43,28 +41,14 @@ impl MacOsPageBackend {
 
 #[async_trait]
 impl PageBackend for MacOsPageBackend {
-    async fn get_text(&self, pid: i32, window_id: u64) -> anyhow::Result<String> {
-        Ok(self.get_text_result(pid, window_id).await?.content)
-    }
-
-    async fn get_text_result(&self, pid: i32, window_id: u64) -> anyhow::Result<PageReadResult> {
+    async fn get_text(&self, pid: i32, window_id: u64) -> anyhow::Result<PageReadResult> {
         let bundle_id = Self::bundle_id_for(pid).await;
-
-        let use_ax_fallback = !BrowserJs::supports(&bundle_id)
-            && tokio::task::spawn_blocking(move || is_wk_web_view_app(pid))
-                .await
-                .unwrap_or(false);
-
-        if use_ax_fallback {
-            return ax_text_fallback(pid, window_id)
-                .await
-                .map(AxFallbackRead::into_page_result);
-        }
-
-        let source = primary_source(&bundle_id);
-        read_with_ax_fallback(
-            source,
-            execute_js("document.body.innerText", &bundle_id, pid, window_id),
+        read_page(
+            resolve_page_read_route(&bundle_id, pid).await?,
+            &bundle_id,
+            pid,
+            window_id,
+            "document.body.innerText",
             || ax_text_fallback(pid, window_id),
         )
         .await
@@ -76,38 +60,17 @@ impl PageBackend for MacOsPageBackend {
         window_id: u64,
         css_selector: &str,
         attributes: &[String],
-    ) -> anyhow::Result<String> {
-        Ok(self
-            .query_dom_result(pid, window_id, css_selector, attributes)
-            .await?
-            .content)
-    }
-
-    async fn query_dom_result(
-        &self,
-        pid: i32,
-        window_id: u64,
-        css_selector: &str,
-        attributes: &[String],
     ) -> anyhow::Result<PageReadResult> {
         let bundle_id = Self::bundle_id_for(pid).await;
-
-        let use_ax_fallback = !BrowserJs::supports(&bundle_id)
-            && tokio::task::spawn_blocking(move || is_wk_web_view_app(pid))
-                .await
-                .unwrap_or(false);
-
-        if use_ax_fallback {
-            return ax_query_fallback(pid, window_id, css_selector)
-                .await
-                .map(AxFallbackRead::into_page_result);
-        }
-
         let js = build_query_selector_js(css_selector, attributes);
-        let source = primary_source(&bundle_id);
-        read_with_ax_fallback(source, execute_js(&js, &bundle_id, pid, window_id), || {
-            ax_query_fallback(pid, window_id, css_selector)
-        })
+        read_page(
+            resolve_page_read_route(&bundle_id, pid).await?,
+            &bundle_id,
+            pid,
+            window_id,
+            &js,
+            || ax_query_fallback(pid, window_id, css_selector),
+        )
         .await
     }
 
@@ -305,30 +268,65 @@ async fn execute_js(js: &str, bundle_id: &str, pid: i32, window_id: u64) -> anyh
     anyhow::bail!("Unsupported browser: bundle_id={bundle_id}");
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct AxFallbackRead {
-    content: String,
-    truncated: bool,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PageReadRoute {
+    Javascript,
+    Cdp,
+    Ax,
 }
 
-impl AxFallbackRead {
-    fn into_page_result(self) -> PageReadResult {
-        PageReadResult::with_metadata(
-            self.content,
-            PageReadMetadata {
-                source: PageReadSource::AxFallback,
-                fallback_error: None,
-                truncated: Some(self.truncated),
-            },
-        )
+async fn resolve_page_read_route(bundle_id: &str, pid: i32) -> anyhow::Result<PageReadRoute> {
+    let javascript_supported = BrowserJs::supports(bundle_id);
+    let is_electron = if javascript_supported {
+        false
+    } else {
+        tokio::task::spawn_blocking(move || ElectronJs::is_electron(pid)).await?
+    };
+    Ok(classify_page_read_route(javascript_supported, is_electron))
+}
+
+fn classify_page_read_route(javascript_supported: bool, is_electron: bool) -> PageReadRoute {
+    if javascript_supported {
+        PageReadRoute::Javascript
+    } else if is_electron {
+        PageReadRoute::Cdp
+    } else {
+        PageReadRoute::Ax
     }
 }
 
-fn primary_source(bundle_id: &str) -> PageReadSource {
-    if BrowserJs::supports(bundle_id) {
-        PageReadSource::Javascript
-    } else {
-        PageReadSource::Cdp
+async fn read_page<F, A>(
+    route: PageReadRoute,
+    bundle_id: &str,
+    pid: i32,
+    window_id: u64,
+    javascript: &str,
+    ax_fallback: F,
+) -> anyhow::Result<PageReadResult>
+where
+    F: FnOnce() -> A,
+    A: Future<Output = anyhow::Result<PageReadResult>>,
+{
+    match route {
+        PageReadRoute::Javascript => {
+            let window_id = u32::try_from(window_id)
+                .map_err(|_| anyhow::anyhow!("macOS window_id {window_id} is out of u32 range"))?;
+            read_with_ax_fallback(
+                PageReadSource::Javascript,
+                BrowserJs::execute(javascript, bundle_id, window_id),
+                ax_fallback,
+            )
+            .await
+        }
+        PageReadRoute::Cdp => {
+            read_with_ax_fallback(
+                PageReadSource::Cdp,
+                ElectronJs::execute(javascript, pid),
+                ax_fallback,
+            )
+            .await
+        }
+        PageReadRoute::Ax => ax_fallback().await,
     }
 }
 
@@ -340,38 +338,28 @@ async fn read_with_ax_fallback<P, F, A>(
 where
     P: Future<Output = anyhow::Result<String>>,
     F: FnOnce() -> A,
-    A: Future<Output = anyhow::Result<AxFallbackRead>>,
+    A: Future<Output = anyhow::Result<PageReadResult>>,
 {
     match primary.await {
-        Ok(content) => Ok(PageReadResult::with_metadata(
-            content,
-            PageReadMetadata {
-                source: primary_source,
-                fallback_error: None,
-                truncated: None,
-            },
-        )),
+        Ok(content) => Ok(PageReadResult::sourced(content, primary_source, None, None)),
         Err(error) => {
-            let fallback = ax_fallback().await.map_err(|fallback_error| {
+            let mut fallback = ax_fallback().await.map_err(|fallback_error| {
                 anyhow::anyhow!(
                     "AX fallback failed after {primary_source:?} read failed: {error}; \
                      AX fallback error: {fallback_error}"
                 )
             })?;
-            Ok(PageReadResult::with_metadata(
-                fallback.content,
-                PageReadMetadata {
-                    source: PageReadSource::AxFallback,
-                    fallback_error: Some(error.to_string()),
-                    truncated: Some(fallback.truncated),
-                },
-            ))
+            if fallback.source != Some(PageReadSource::AxFallback) {
+                anyhow::bail!("AX fallback omitted read provenance");
+            }
+            fallback.fallback_error = Some(error.to_string());
+            Ok(fallback)
         }
     }
 }
 
 /// Extract page text via the bounded AX tree.
-async fn ax_text_fallback(pid: i32, window_id: u64) -> anyhow::Result<AxFallbackRead> {
+async fn ax_text_fallback(pid: i32, window_id: u64) -> anyhow::Result<PageReadResult> {
     let window_id = u32::try_from(window_id)
         .map_err(|_| anyhow::anyhow!("macOS window_id {window_id} is out of u32 range"))?;
     let result = tokio::task::spawn_blocking(move || {
@@ -385,10 +373,11 @@ async fn ax_text_fallback(pid: i32, window_id: u64) -> anyhow::Result<AxFallback
     })
     .await
     .map_err(|e| anyhow::anyhow!("AX walk task failed: {e}"))?;
-    Ok(AxFallbackRead {
-        content: AXPageReader::extract_text(&result.tree_markdown),
-        truncated: result.truncated,
-    })
+    require_ax_window_scope(result.window_scope.as_ref(), pid, window_id)?;
+    Ok(ax_page_read(
+        AXPageReader::extract_text(&result.tree_markdown),
+        result.truncated,
+    ))
 }
 
 /// Query the bounded AX tree by CSS selector.
@@ -396,7 +385,7 @@ async fn ax_query_fallback(
     pid: i32,
     window_id: u64,
     selector: &str,
-) -> anyhow::Result<AxFallbackRead> {
+) -> anyhow::Result<PageReadResult> {
     let window_id = u32::try_from(window_id)
         .map_err(|_| anyhow::anyhow!("macOS window_id {window_id} is out of u32 range"))?;
     let sel = selector.to_owned();
@@ -411,10 +400,38 @@ async fn ax_query_fallback(
     })
     .await
     .map_err(|e| anyhow::anyhow!("AX walk task failed: {e}"))?;
-    Ok(AxFallbackRead {
-        content: format_ax_elements(&AXPageReader::query(&sel, &result.tree_markdown)),
-        truncated: result.truncated,
-    })
+    require_ax_window_scope(result.window_scope.as_ref(), pid, window_id)?;
+    Ok(ax_page_read(
+        format_ax_elements(&AXPageReader::query(&sel, &result.tree_markdown)),
+        result.truncated,
+    ))
+}
+
+fn ax_page_read(content: String, truncated: bool) -> PageReadResult {
+    PageReadResult::sourced(content, PageReadSource::AxFallback, None, Some(truncated))
+}
+
+fn require_ax_window_scope(
+    scope: Option<&crate::ax::WindowScope>,
+    pid: i32,
+    window_id: u32,
+) -> anyhow::Result<()> {
+    match scope {
+        Some(crate::ax::WindowScope::Matched) => Ok(()),
+        Some(crate::ax::WindowScope::NotFound) => {
+            anyhow::bail!("macOS window_id {window_id} no longer exists")
+        }
+        Some(crate::ax::WindowScope::OwnerPidMismatch {
+            owner_pid,
+            owner_app_name,
+        }) => anyhow::bail!(
+            "macOS window_id {window_id} belongs to pid {owner_pid} ({owner_app_name}), not pid {pid}"
+        ),
+        Some(crate::ax::WindowScope::AxUnresolved { ax_window_count }) => anyhow::bail!(
+            "macOS window_id {window_id} belongs to pid {pid}, but its AX surface could not be resolved among {ax_window_count} window(s)"
+        ),
+        None => anyhow::bail!("macOS AX walk did not report scope for window_id {window_id}"),
+    }
 }
 
 fn format_ax_elements(elements: &[crate::browser::ax_page_reader::AXElement]) -> String {
@@ -509,11 +526,8 @@ fn required_finite(value: &serde_json::Value, key: &str, raw: &str) -> anyhow::R
 mod tests {
     use super::*;
 
-    fn ax(content: &str, truncated: bool) -> anyhow::Result<AxFallbackRead> {
-        Ok(AxFallbackRead {
-            content: content.to_owned(),
-            truncated,
-        })
+    fn ax(content: &str, truncated: bool) -> anyhow::Result<PageReadResult> {
+        Ok(ax_page_read(content.to_owned(), truncated))
     }
 
     #[tokio::test]
@@ -527,14 +541,12 @@ mod tests {
         .unwrap();
 
         assert_eq!(result.content, "visible text");
+        assert_eq!(result.source, Some(PageReadSource::AxFallback));
         assert_eq!(
-            result.metadata,
-            Some(PageReadMetadata {
-                source: PageReadSource::AxFallback,
-                fallback_error: Some("JavaScript from Apple Events is disabled".to_owned()),
-                truncated: Some(false),
-            })
+            result.fallback_error.as_deref(),
+            Some("JavaScript from Apple Events is disabled")
         );
+        assert_eq!(result.truncated, Some(false));
     }
 
     #[tokio::test]
@@ -548,14 +560,12 @@ mod tests {
         .unwrap();
 
         assert_eq!(result.content, "partial query");
+        assert_eq!(result.source, Some(PageReadSource::AxFallback));
         assert_eq!(
-            result.metadata,
-            Some(PageReadMetadata {
-                source: PageReadSource::AxFallback,
-                fallback_error: Some("Could not find Electron inspector port".to_owned()),
-                truncated: Some(true),
-            })
+            result.fallback_error.as_deref(),
+            Some("Could not find Electron inspector port")
         );
+        assert_eq!(result.truncated, Some(true));
     }
 
     #[tokio::test]
@@ -573,22 +583,50 @@ mod tests {
         assert!(error.contains("AX permission denied"));
     }
 
-    #[test]
-    fn wkwebview_direct_fallback_has_no_triggering_error() {
-        let result = AxFallbackRead {
-            content: "tauri text".to_owned(),
-            truncated: false,
-        }
-        .into_page_result();
+    #[tokio::test]
+    async fn direct_ax_route_has_no_triggering_error() {
+        let result = read_page(
+            PageReadRoute::Ax,
+            "com.example.Native",
+            42,
+            7,
+            "unused",
+            || async { ax("native text", false) },
+        )
+        .await
+        .unwrap();
 
+        assert_eq!(result.content, "native text");
+        assert_eq!(result.source, Some(PageReadSource::AxFallback));
+        assert_eq!(result.fallback_error, None);
+        assert_eq!(result.truncated, Some(false));
+    }
+
+    #[test]
+    fn route_classification_never_calls_unknown_native_apps_cdp() {
         assert_eq!(
-            result.metadata,
-            Some(PageReadMetadata {
-                source: PageReadSource::AxFallback,
-                fallback_error: None,
-                truncated: Some(false),
-            })
+            classify_page_read_route(true, false),
+            PageReadRoute::Javascript
         );
+        assert_eq!(classify_page_read_route(false, true), PageReadRoute::Cdp);
+        assert_eq!(classify_page_read_route(false, false), PageReadRoute::Ax);
+    }
+
+    #[test]
+    fn ax_page_read_refuses_foreign_window_scope() {
+        let error = require_ax_window_scope(
+            Some(&crate::ax::WindowScope::OwnerPidMismatch {
+                owner_pid: 900,
+                owner_app_name: "Open and Save Panel Service".to_owned(),
+            }),
+            800,
+            41,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("belongs to pid 900"));
+        assert!(error.contains("not pid 800"));
     }
 
     #[tokio::test]
@@ -602,14 +640,9 @@ mod tests {
         .unwrap();
 
         assert_eq!(result.content, "[{\"tagName\":\"BUTTON\"}]");
-        assert_eq!(
-            result.metadata,
-            Some(PageReadMetadata {
-                source: PageReadSource::Javascript,
-                fallback_error: None,
-                truncated: None,
-            })
-        );
+        assert_eq!(result.source, Some(PageReadSource::Javascript));
+        assert_eq!(result.fallback_error, None);
+        assert_eq!(result.truncated, None);
     }
 
     #[tokio::test]
@@ -622,6 +655,6 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(result.metadata.unwrap().source, PageReadSource::Cdp);
+        assert_eq!(result.source, Some(PageReadSource::Cdp));
     }
 }

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/page.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/page.rs
@@ -28,7 +28,7 @@
 //!        Returns an actionable error if neither path works.
 
 use async_trait::async_trait;
-use cua_driver_core::page::{ClickElementResult, PageBackend};
+use cua_driver_core::page::{ClickElementResult, PageBackend, PageReadResult};
 
 use windows::core::Interface;
 use windows::Win32::Foundation::HWND;
@@ -60,11 +60,12 @@ impl Default for WindowsPageBackend {
 
 #[async_trait]
 impl PageBackend for WindowsPageBackend {
-    async fn get_text(&self, _pid: i32, window_id: u64) -> anyhow::Result<String> {
+    async fn get_text(&self, _pid: i32, window_id: u64) -> anyhow::Result<PageReadResult> {
         let hwnd = window_id;
-        tokio::task::spawn_blocking(move || unsafe { get_text_blocking(hwnd) })
+        let content = tokio::task::spawn_blocking(move || unsafe { get_text_blocking(hwnd) })
             .await
-            .map_err(|e| anyhow::anyhow!("join error: {e}"))?
+            .map_err(|e| anyhow::anyhow!("join error: {e}"))??;
+        Ok(PageReadResult::text(content))
     }
 
     async fn query_dom(
@@ -73,13 +74,16 @@ impl PageBackend for WindowsPageBackend {
         window_id: u64,
         css_selector: &str,
         attributes: &[String],
-    ) -> anyhow::Result<String> {
+    ) -> anyhow::Result<PageReadResult> {
         let hwnd = window_id;
         let selector = css_selector.to_owned();
         let attrs: Vec<String> = attributes.to_vec();
-        tokio::task::spawn_blocking(move || unsafe { query_dom_blocking(hwnd, &selector, &attrs) })
-            .await
-            .map_err(|e| anyhow::anyhow!("join error: {e}"))?
+        let content = tokio::task::spawn_blocking(move || unsafe {
+            query_dom_blocking(hwnd, &selector, &attrs)
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("join error: {e}"))??;
+        Ok(PageReadResult::text(content))
     }
 
     async fn execute_javascript(


### PR DESCRIPTION
## summary

- preserve the legacy `page.get_text` and `page.query_dom` text payload while attaching macOS read provenance in `structuredContent`
- resolve each macOS read once as Apple Events JavaScript, Electron CDP, or direct AX instead of inferring CDP from every non-browser bundle
- preserve the triggering JavaScript/CDP error, report element- and depth-bounded AX truncation, and retain both errors if AX fallback also fails
- keep current fail-closed window ownership checks, so AX fallback cannot return another process's window
- use one `PageBackend` result path across macOS, Linux, and Windows instead of parallel legacy and metadata-aware methods
- document the compatibility-only fallback contract

fixes https://github.com/trycua/cua/issues/2245

## validation

exact candidate: `11aa96f72c5efdc4db461706df2d209b9b9fec27`

- `cargo test -p cua-driver-core --lib` — 587 passed
- `cargo test -p platform-macos tools::page::tests --lib` — 8 passed
- `cargo check -p platform-linux`
- `cargo check -p platform-windows`
- `cargo fmt --all -- --check`
- `git diff --check`

macOS emitted the existing duplicate Swift bridge linker warning while the focused platform tests passed. Linux and Windows checks emitted only pre-existing unused/dead-code warnings outside this change.

## remaining acceptance evidence

exact-head macOS GUI coverage is still required for Safari JavaScript success, Electron CDP success, JavaScript and CDP failure falling back to AX, and direct WKWebView AX behavior. The canonical Lume run is currently environment-blocked because this host has no prepared private, TCC-authorized seed; no reduced smoke is being substituted for that gate.