### PR TITLE
docs: fix stale SDK README links

### DIFF
--- a/libs/python/agent/README.md
+++ b/libs/python/agent/README.md
@@ -2,4 +2,4 @@
 
 Computer-Use framework with liteLLM integration for running agentic workflows on macOS, Windows, and Linux sandboxes.
 
-**[Documentation](https://cua.ai/docs/cua/reference/agent-sdk)** - Installation, guides, and configuration.
+**[Cua documentation](https://cua.ai/docs)** - Tutorials, guides, and reference documentation.

--- a/libs/python/computer-server/README.md
+++ b/libs/python/computer-server/README.md
@@ -2,7 +2,7 @@
 
 Server component for the Computer-Use Interface (CUI) framework providing low-level computer control primitives.
 
-**[Documentation](https://cua.ai/docs/cua/guide/advanced/local-computer-server)** - Installation, guides, and configuration.
+**[Cua documentation](https://cua.ai/docs)** - Tutorials, guides, and reference documentation.
 
 ## Interfaces
 

--- a/libs/python/computer/README.md
+++ b/libs/python/computer/README.md
@@ -2,4 +2,4 @@
 
 Computer-Use Interface (CUI) framework for interacting with local macOS and Linux sandboxes.
 
-**[Documentation](https://cua.ai/docs/cua/reference/computer-sdk)** - Installation, guides, and configuration.
+**[Sandbox SDK documentation](https://cua.ai/docs/reference/sandbox-sdk)** - API reference for creating and controlling sandboxes.

--- a/libs/python/computer/README.md
+++ b/libs/python/computer/README.md
@@ -2,4 +2,4 @@
 
 Computer-Use Interface (CUI) framework for interacting with local macOS and Linux sandboxes.
 
-**[Sandbox SDK documentation](https://cua.ai/docs/reference/sandbox-sdk)** - API reference for creating and controlling sandboxes.
+**[Cua documentation](https://cua.ai/docs)** - Tutorials, guides, and reference documentation.

--- a/libs/python/cua/README.md
+++ b/libs/python/cua/README.md
@@ -64,6 +64,6 @@ agent = ComputerAgent(..., telemetry_enabled=False)
 
 ## Links
 
-- [Documentation](https://docs.trycua.com)
+- [Documentation](https://cua.ai/docs)
 - [GitHub](https://github.com/trycua/cua)
 - [Issues](https://github.com/trycua/cua/issues)

--- a/libs/python/mcp-server/README.md
+++ b/libs/python/mcp-server/README.md
@@ -2,4 +2,4 @@
 
 MCP server for Computer-Use Agent (Cua), enabling Cua to run through MCP clients like Claude Desktop and Cursor.
 
-**[Cua Driver MCP tools](https://cua.ai/docs/reference/cua-driver/mcp-tools)** - Current MCP tool reference.
+**[Cua documentation](https://cua.ai/docs)** - Tutorials, guides, and reference documentation.

--- a/libs/python/mcp-server/README.md
+++ b/libs/python/mcp-server/README.md
@@ -2,4 +2,4 @@
 
 MCP server for Computer-Use Agent (Cua), enabling Cua to run through MCP clients like Claude Desktop and Cursor.
 
-**[Documentation](https://cua.ai/docs/cua/reference/mcp-server)** - Installation, guides, and configuration.
+**[Cua Driver MCP tools](https://cua.ai/docs/reference/cua-driver/mcp-tools)** - Current MCP tool reference.

--- a/libs/python/som/README.md
+++ b/libs/python/som/README.md
@@ -75,10 +75,6 @@ for elem in result.elements:
         print(f"Text: '{elem.content}', confidence={elem.confidence:.3f}")
 ```
 
-## Docs
-
-- [Configuration](http://localhost:8090/docs/libraries/som/configuration)
-
 ## License
 
 MIT License - See LICENSE file for details.

--- a/libs/typescript/agent/README.md
+++ b/libs/typescript/agent/README.md
@@ -2,4 +2,4 @@
 
 TypeScript SDK for Cua agent interaction via HTTP/HTTPS or peer-to-peer (WebRTC) connections.
 
-**[Documentation](https://cua.ai/docs/cua/reference/agent-sdk)** - Installation, guides, and configuration.
+**[Cua documentation](https://cua.ai/docs)** - Tutorials, guides, and reference documentation.

--- a/libs/typescript/computer/README.md
+++ b/libs/typescript/computer/README.md
@@ -2,4 +2,4 @@
 
 Computer-Use Interface (CUI) framework for interacting with local macOS and Linux sandboxes.
 
-**[Documentation](https://cua.ai/docs/cua/reference/computer-sdk)** - Installation, guides, and configuration.
+**[Sandbox SDK documentation](https://cua.ai/docs/reference/sandbox-sdk)** - API reference for creating and controlling sandboxes.

--- a/libs/typescript/computer/README.md
+++ b/libs/typescript/computer/README.md
@@ -2,4 +2,4 @@
 
 Computer-Use Interface (CUI) framework for interacting with local macOS and Linux sandboxes.
 
-**[Sandbox SDK documentation](https://cua.ai/docs/reference/sandbox-sdk)** - API reference for creating and controlling sandboxes.
+**[Cua documentation](https://cua.ai/docs)** - Tutorials, guides, and reference documentation.

--- a/libs/typescript/cua-cli/README.md
+++ b/libs/typescript/cua-cli/README.md
@@ -7,7 +7,6 @@
 > ```
 >
 > The Python CLI provides the same functionality with better integration into the Cua ecosystem.
-> See the [cloud sandbox tutorial](https://cua.ai/docs/tutorials/your-first-cloud-sandbox) for installation and usage.
 
 ---
 

--- a/libs/typescript/cua-cli/README.md
+++ b/libs/typescript/cua-cli/README.md
@@ -7,7 +7,7 @@
 > ```
 >
 > The Python CLI provides the same functionality with better integration into the Cua ecosystem.
-> See the [Quickstart Guide](https://cua.ai/docs/cua/guide/get-started/quickstart) for installation and usage.
+> See the [cloud sandbox tutorial](https://cua.ai/docs/tutorials/your-first-cloud-sandbox) for installation and usage.
 
 ---
 


### PR DESCRIPTION
## summary

- replace legacy `docs.trycua.com` and `/docs/cua/...` links in SDK readmes with canonical `cua.ai/docs` destinations
- use the docs homepage where no package-specific documentation exists, avoiding references to incompatible SDKs and MCP tools
- remove obsolete SoM and deprecated CLI documentation links because no corresponding pages exist in the current docs tree

fixes https://github.com/trycua/cua/issues/2085

## verification

- `git diff --check`
- searched the affected readmes for stale domains, URL shapes, and mismatched replacement targets
- confirmed `https://cua.ai/docs` resolves directly with HTTP 200
