### PR TITLE
fix(driver): remove current autostart services on uninstall

### DIFF
--- a/.github/workflows/ci-test-scripts.yml
+++ b/.github/workflows/ci-test-scripts.yml
@@ -16,6 +16,7 @@ on:
       - "release-please-config.json"
       - ".github/workflows/ci-test-scripts.yml"
       - "docs/release-backfill-runbook.md"
+      - "libs/cua-driver/scripts/**"
 
 jobs:
   test:
@@ -39,6 +40,9 @@ jobs:
         run: |
           cd .github/scripts
           pytest tests/ -v
+
+      - name: Test Cua Driver uninstall scripts
+        run: python -m pytest libs/cua-driver/scripts/tests/ -v
 
       - name: Validate historical release backfill
         run: python3 .github/scripts/release_backfill.py validate

--- a/libs/cua-driver/scripts/tests/test_uninstall_autostart.py
+++ b/libs/cua-driver/scripts/tests/test_uninstall_autostart.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+UNINSTALL = REPO_ROOT / "libs/cua-driver/scripts/uninstall.sh"
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(f"#!/bin/sh\n{body}", encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _sandbox(tmp_path: Path, os_name: str) -> tuple[Path, Path, dict[str, str]]:
+    home = tmp_path / "home"
+    fake_bin = tmp_path / "bin"
+    calls = tmp_path / "calls.log"
+    home.mkdir()
+    fake_bin.mkdir()
+
+    _write_executable(fake_bin / "uname", f"printf '%s\\n' '{os_name}'\n")
+    for command in ("launchctl", "systemctl", "tccutil", "sudo"):
+        _write_executable(
+            fake_bin / command,
+            f"printf '%s:%s\\n' '{command}' \"$*\" >> '{calls}'\n",
+        )
+
+    # The uninstaller contains intentional recursive removal for real install
+    # directories. Tests must never be able to reach those paths on a
+    # developer machine, so the shim removes regular files/symlinks only when
+    # they are below the sandbox HOME and records every outside request as a
+    # no-op.
+    _write_executable(
+        fake_bin / "rm",
+        f"""for argument in "$@"; do
+    case "$argument" in
+        -*) ;;
+        '{home}'/*)
+            if [ -d "$argument" ] && [ ! -L "$argument" ]; then
+                printf 'rm-refused-directory:%s\\n' "$argument" >> '{calls}'
+                exit 97
+            fi
+            /bin/rm -f -- "$argument"
+            ;;
+        *) printf 'rm-outside-noop:%s\\n' "$argument" >> '{calls}' ;;
+    esac
+done
+""",
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "PATH": f"{fake_bin}:/usr/bin:/bin",
+        }
+    )
+    env.pop("CUA_DRIVER_HOME", None)
+    env.pop("CUA_DRIVER_RS_HOME", None)
+    return home, calls, env
+
+
+def _run_uninstall(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["/bin/bash", str(UNINSTALL)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    return result
+
+
+@pytest.mark.parametrize(
+    ("os_name", "relative_paths", "expected_calls"),
+    [
+        (
+            "Darwin",
+            [
+                "Library/LaunchAgents/com.trycua.cua-driver.plist",
+                "Library/LaunchAgents/com.trycua.cua-driver-rs.plist",
+            ],
+            [
+                "launchctl:unload {home}/Library/LaunchAgents/com.trycua.cua-driver.plist",
+                "launchctl:unload {home}/Library/LaunchAgents/com.trycua.cua-driver-rs.plist",
+            ],
+        ),
+        (
+            "Linux",
+            [
+                ".config/systemd/user/cua-driver.service",
+                ".config/systemd/user/cua-driver-rs.service",
+            ],
+            [
+                "systemctl:--user stop cua-driver.service",
+                "systemctl:--user disable cua-driver.service",
+                "systemctl:--user stop cua-driver-rs.service",
+                "systemctl:--user disable cua-driver-rs.service",
+                "systemctl:--user daemon-reload",
+            ],
+        ),
+    ],
+)
+def test_uninstall_removes_current_and_legacy_autostart(
+    tmp_path: Path,
+    os_name: str,
+    relative_paths: list[str],
+    expected_calls: list[str],
+) -> None:
+    home, calls, env = _sandbox(tmp_path, os_name)
+    targets = [home / relative_path for relative_path in relative_paths]
+    for target in targets:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("fixture\n", encoding="utf-8")
+
+    _run_uninstall(env)
+
+    assert all(not target.exists() for target in targets)
+    call_lines = calls.read_text(encoding="utf-8").splitlines()
+    for expected_call in expected_calls:
+        assert expected_call.format(home=home) in call_lines
+
+
+@pytest.mark.parametrize(
+    ("os_name", "current_autostart_path"),
+    [
+        ("Darwin", "Library/LaunchAgents/com.trycua.cua-driver.plist"),
+        ("Linux", ".config/systemd/user/cua-driver.service"),
+    ],
+)
+def test_current_autostart_file_is_a_rust_install_marker(
+    tmp_path: Path,
+    os_name: str,
+    current_autostart_path: str,
+) -> None:
+    home, _calls, env = _sandbox(tmp_path, os_name)
+    autostart_file = home / current_autostart_path
+    autostart_file.parent.mkdir(parents=True, exist_ok=True)
+    autostart_file.write_text("fixture\n", encoding="utf-8")
+
+    skill_link = home / ".agents/skills/cua-driver"
+    skill_link.parent.mkdir(parents=True)
+    skill_link.symlink_to(home / ".cua-driver/skills/cua-driver")
+
+    _run_uninstall(env)
+
+    assert not autostart_file.exists()
+    assert not skill_link.is_symlink()

--- a/libs/cua-driver/scripts/uninstall.sh
+++ b/libs/cua-driver/scripts/uninstall.sh
@@ -26,8 +26,9 @@
 #     - versioned packages/current symlink under ~/.cua-driver/
 #     - telemetry id, preference, and registration markers are preserved by
 #       default so a reinstall remains the same pseudonymous installation
-#     - ~/.config/systemd/user/cua-driver-rs.service (if --autostart
-#       was used via install-local.sh — stop + disable + remove)
+#     - ~/.config/systemd/user/cua-driver.service (if --autostart
+#       was used via install-local.sh — stop + disable + remove), plus the
+#       legacy cua-driver-rs.service unit
 #     - Skill symlinks under ~/.claude/skills/cua-driver(-rs), ~/.agents/
 #       skills/…, ~/.openclaw/skills/…, ~/.config/opencode/skills/…
 #   macOS:
@@ -36,8 +37,9 @@
 #       /Applications/CuaDriver.app)
 #     - runtime payloads under ~/.cua-driver/ and legacy ~/.cua-driver-rs/;
 #       telemetry state remains unless --purge is passed
-#     - ~/Library/LaunchAgents/com.trycua.cua-driver-rs.plist (if
-#       --autostart was used via install-local.sh — unload + remove)
+#     - ~/Library/LaunchAgents/com.trycua.cua-driver.plist (if --autostart
+#       was used via install-local.sh — unload + remove), plus the legacy
+#       com.trycua.cua-driver-rs.plist LaunchAgent
 #     - Skill symlinks under ~/.claude/skills/cua-driver(-rs), etc.
 #
 # Shared-path safety: /Applications/CuaDriver.app + its ~/.local/bin
@@ -179,8 +181,10 @@ if [[ "$USE_RUST_BACKEND" == "1" ]]; then
     # one unambiguous on-disk Rust discriminator now that the .app bundle +
     # bundle id are shared with Swift.
     PACKAGES_DIR="$HOME_DIR/packages"
-    LAUNCHAGENT_PLIST="$HOME/Library/LaunchAgents/com.trycua.cua-driver-rs.plist"
-    SYSTEMD_USER_UNIT="$HOME/.config/systemd/user/cua-driver-rs.service"
+    LAUNCHAGENT_PLIST="$HOME/Library/LaunchAgents/com.trycua.cua-driver.plist"
+    LEGACY_LAUNCHAGENT_PLIST="$HOME/Library/LaunchAgents/com.trycua.cua-driver-rs.plist"
+    SYSTEMD_USER_UNIT="$HOME/.config/systemd/user/cua-driver.service"
+    LEGACY_SYSTEMD_USER_UNIT="$HOME/.config/systemd/user/cua-driver-rs.service"
     SKILL_PACK_NAME="cua-driver"
     # Pre-rename skill pack name — swept alongside the current one so
     # users who installed under the legacy name end up clean after
@@ -199,11 +203,12 @@ if [[ "$USE_RUST_BACKEND" == "1" ]]; then
     #   - ~/.cua-driver/packages/ exists (Rust install-local / updater store)
     #   - ~/.cua-driver-rs/ exists (legacy Rust state dir, pre-rename)
     #   - /Applications/CuaDriverRs.app exists (legacy bundle, pre-rename)
-    #   - LaunchAgent plist / systemd unit exists (autostart was used)
+    #   - current or legacy LaunchAgent plist / systemd unit exists
+    #     (autostart was used)
     #   - current telemetry identity/registration marker exists (release
     #     installs on macOS live in /Applications and have no packages dir)
     RUST_INSTALL_PRESENT=0
-    if [[ -d "$PACKAGES_DIR" || -d "$LEGACY_HOME_DIR" || -d "$LEGACY_APP_BUNDLE" || -f "$LAUNCHAGENT_PLIST" || -f "$SYSTEMD_USER_UNIT" || -f "$HOME_DIR/.telemetry_id" || -f "$HOME_DIR/.installation_recorded" ]]; then
+    if [[ -d "$PACKAGES_DIR" || -d "$LEGACY_HOME_DIR" || -d "$LEGACY_APP_BUNDLE" || -f "$LAUNCHAGENT_PLIST" || -f "$LEGACY_LAUNCHAGENT_PLIST" || -f "$SYSTEMD_USER_UNIT" || -f "$LEGACY_SYSTEMD_USER_UNIT" || -f "$HOME_DIR/.telemetry_id" || -f "$HOME_DIR/.installation_recorded" ]]; then
         RUST_INSTALL_PRESENT=1
     fi
 
@@ -243,34 +248,50 @@ if [[ "$USE_RUST_BACKEND" == "1" ]]; then
 
     # --- Autostart (Linux systemd --user) ---
     # install-local.sh --autostart registers
-    # ~/.config/systemd/user/cua-driver-rs.service. Stop + disable +
-    # remove if present so the daemon doesn't come back at next logon.
+    # ~/.config/systemd/user/cua-driver.service. Stop + disable + remove it,
+    # plus the pre-rename cua-driver-rs.service when present, so neither daemon
+    # comes back at next logon.
     # systemctl --user no-ops gracefully on a non-systemd host.
-    if [[ "$OS" == "Linux" && -f "$SYSTEMD_USER_UNIT" ]]; then
-        if command -v systemctl >/dev/null 2>&1; then
-            systemctl --user stop    cua-driver-rs.service 2>/dev/null || true
-            systemctl --user disable cua-driver-rs.service 2>/dev/null || true
-            log "stopped + disabled systemd --user unit cua-driver-rs.service"
-        fi
-        rm -f "$SYSTEMD_USER_UNIT"
-        log "removed $SYSTEMD_USER_UNIT"
-        if command -v systemctl >/dev/null 2>&1; then
+    if [[ "$OS" == "Linux" ]]; then
+        FOUND_SYSTEMD_USER_UNIT=0
+        for SYSTEMD_USER_UNIT_PATH in "$SYSTEMD_USER_UNIT" "$LEGACY_SYSTEMD_USER_UNIT"; do
+            if [[ -f "$SYSTEMD_USER_UNIT_PATH" ]]; then
+                FOUND_SYSTEMD_USER_UNIT=1
+                SYSTEMD_USER_UNIT_NAME="${SYSTEMD_USER_UNIT_PATH##*/}"
+                if command -v systemctl >/dev/null 2>&1; then
+                    systemctl --user stop "$SYSTEMD_USER_UNIT_NAME" 2>/dev/null || true
+                    systemctl --user disable "$SYSTEMD_USER_UNIT_NAME" 2>/dev/null || true
+                    log "stopped + disabled systemd --user unit $SYSTEMD_USER_UNIT_NAME"
+                fi
+                rm -f "$SYSTEMD_USER_UNIT_PATH"
+                log "removed $SYSTEMD_USER_UNIT_PATH"
+            fi
+        done
+        if [[ "$FOUND_SYSTEMD_USER_UNIT" == "0" ]]; then
+            log "no current or legacy systemd --user unit found (skipping)"
+        elif command -v systemctl >/dev/null 2>&1; then
             systemctl --user daemon-reload 2>/dev/null || true
         fi
-    elif [[ "$OS" == "Linux" ]]; then
-        log "no systemd --user unit at $SYSTEMD_USER_UNIT (skipping)"
     fi
 
     # --- Autostart (macOS LaunchAgent) ---
     # install-local.sh --autostart on macOS registers
-    # ~/Library/LaunchAgents/com.trycua.cua-driver-rs.plist. Unload (so
-    # the running daemon stops) + remove the plist.
-    if [[ "$OS" == "Darwin" && -f "$LAUNCHAGENT_PLIST" ]]; then
-        launchctl unload "$LAUNCHAGENT_PLIST" 2>/dev/null || true
-        rm -f "$LAUNCHAGENT_PLIST"
-        log "removed LaunchAgent $LAUNCHAGENT_PLIST"
-    elif [[ "$OS" == "Darwin" ]]; then
-        log "no LaunchAgent at $LAUNCHAGENT_PLIST (skipping)"
+    # ~/Library/LaunchAgents/com.trycua.cua-driver.plist. Unload (so the
+    # running daemon stops) + remove it, plus the pre-rename
+    # com.trycua.cua-driver-rs.plist when present.
+    if [[ "$OS" == "Darwin" ]]; then
+        FOUND_LAUNCHAGENT_PLIST=0
+        for LAUNCHAGENT_PLIST_PATH in "$LAUNCHAGENT_PLIST" "$LEGACY_LAUNCHAGENT_PLIST"; do
+            if [[ -f "$LAUNCHAGENT_PLIST_PATH" ]]; then
+                FOUND_LAUNCHAGENT_PLIST=1
+                launchctl unload "$LAUNCHAGENT_PLIST_PATH" 2>/dev/null || true
+                rm -f "$LAUNCHAGENT_PLIST_PATH"
+                log "removed LaunchAgent $LAUNCHAGENT_PLIST_PATH"
+            fi
+        done
+        if [[ "$FOUND_LAUNCHAGENT_PLIST" == "0" ]]; then
+            log "no current or legacy LaunchAgent found (skipping)"
+        fi
     fi
 
     # --- .app bundle (macOS only) ---
@@ -301,7 +322,7 @@ if [[ "$USE_RUST_BACKEND" == "1" ]]; then
                 $SUDO rm -rf "$APP_BUNDLE"
                 log "removed $APP_BUNDLE"
             else
-                log "$APP_BUNDLE exists but no Rust marker on disk (~/.cua-driver/packages/, ~/.cua-driver-rs/, CuaDriverRs.app, LaunchAgent, systemd unit); leaving it (looks like a Swift-only install)"
+                log "$APP_BUNDLE exists but no Rust marker on disk (~/.cua-driver/packages/, ~/.cua-driver-rs/, CuaDriverRs.app, current/legacy LaunchAgent or systemd unit); leaving it (looks like a Swift-only install)"
             fi
         else
             log "no app bundle at $APP_BUNDLE (skipping)"


### PR DESCRIPTION
## Summary

- remove both the current and legacy macOS LaunchAgents during Cua Driver uninstall
- stop, disable, and remove both the current and legacy Linux systemd user units
- recognize either supervisor generation as an unambiguous Rust-install marker
- run sandboxed Unix uninstall regression coverage in the existing script CI workflow

## Root cause

[PR #1711](https://github.com/trycua/cua/pull/1711) renamed the dev installer's autostart outputs on May 26, 2026:

- `com.trycua.cua-driver-rs.plist` → `com.trycua.cua-driver.plist`
- `cua-driver-rs.service` → `cua-driver.service`

The coordinated update did not include `uninstall.sh`, which continued checking only the legacy names established in [PR #1665](https://github.com/trycua/cua/pull/1665). [PR #1758](https://github.com/trycua/cua/pull/1758) later repaired the app bundle and package-home uninstall paths but did not cover autostart supervisors.

The mismatch was present from `v0.3.0` through `v0.8.3`. Practical impact is scoped to local/dev installations created with `install-local.sh --autostart`: uninstall removed the app and CLI but could leave the current supervisor loaded and its daemon resident.

## Safety

- current and legacy compatibility paths are both retained
- cleanup uses exact plist/unit paths; there are no globs or broad service matches
- supervisors are unloaded/stopped before their files are removed
- the fix does not add a broad `pkill`, so active editor-owned MCP processes are not indiscriminately terminated
- regression tests replace `rm`, `sudo`, `launchctl`, `systemctl`, `tccutil`, and `uname` with bounded shims; they cannot mutate real install or permission state

## Validation

- Python 3.11 regression suite: 4 passed
  - current + legacy macOS LaunchAgents
  - current + legacy Linux systemd units
  - current supervisor files independently prove a Rust install on both OS families
- `bash -n libs/cua-driver/scripts/uninstall.sh`
- ShellCheck passes with the pre-existing unrelated `SC2043` warning excluded
- Ruff check and format check
- workflow YAML parse
- `git diff --check`
