### PR TITLE
docs: fix dead SDK README links

### DIFF
--- a/libs/python/cua/README.md
+++ b/libs/python/cua/README.md
@@ -64,6 +64,6 @@ agent = ComputerAgent(..., telemetry_enabled=False)
 
 ## Links
 
-- [Documentation](https://docs.trycua.com)
+- [Documentation](https://cua.ai/docs)
 - [GitHub](https://github.com/trycua/cua)
 - [Issues](https://github.com/trycua/cua/issues)

--- a/libs/python/som/README.md
+++ b/libs/python/som/README.md
@@ -75,10 +75,6 @@ for elem in result.elements:
         print(f"Text: '{elem.content}', confidence={elem.confidence:.3f}")
 ```
 
-## Docs
-
-- [Configuration](http://localhost:8090/docs/libraries/som/configuration)
-
 ## License
 
 MIT License - See LICENSE file for details.


### PR DESCRIPTION
## summary

- replace the legacy `docs.trycua.com` homepage link with the canonical `https://cua.ai/docs` URL
- remove the obsolete SoM configuration link to the deleted local docs app

addresses the dead-link items in https://github.com/trycua/cua/issues/2085

## verification

- `git diff --check`
- confirmed `https://cua.ai/docs` resolves directly with HTTP 200
- confirmed the existing `/docs/cua/...` URLs resolve through live redirects, so they are left unchanged

replaces https://github.com/trycua/cua/pull/2357 with a branch hosted directly in `trycua/cua`.
