### PR TITLE
fix(cua-driver): avoid SIGCHLD handler in doctor

### DIFF
--- a/libs/cua-driver/rust/Cargo.lock
+++ b/libs/cua-driver/rust/Cargo.lock
@@ -891,7 +891,6 @@ dependencies = [
  "tracing-subscriber",
  "ureq",
  "uuid",
- "wait-timeout",
  "windows 0.61.3",
 ]
 
@@ -4284,15 +4283,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
- "libc",
-]
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
  "libc",
 ]
 

--- a/libs/cua-driver/rust/crates/cua-driver/Cargo.toml
+++ b/libs/cua-driver/rust/crates/cua-driver/Cargo.toml
@@ -30,11 +30,6 @@ ureq = { version = "3", features = ["json"] }
 # pre-release tags (`-dev`, `-rc.1`) sort below their corresponding release
 # and we never recommend a pre-release as an "update".
 semver = "1"
-# Bounded `Child::wait_timeout` for the Linux AT-SPI / gdbus probe in
-# `doctor`. We can't rely on `gdbus introspect` returning quickly when the
-# session D-Bus is hung — without a timeout, `doctor` would block forever
-# on a broken accessibility stack. Tiny dep, exactly this use case.
-wait-timeout = "0.2"
 # Tarball extraction for `cua-driver skills install`. The verb fetches a
 # versioned `cua-driver-rs-v<v>-skills.tar.gz` release asset from GitHub
 # and unpacks it under `<HomeDir>/skills/cua-driver-rs/`. `tar` is the

--- a/libs/cua-driver/rust/crates/cua-driver/src/doctor.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/doctor.rs
@@ -379,7 +379,6 @@ fn append_platform_probes(report: &mut Report) {
 #[cfg(target_os = "linux")]
 fn probe_at_spi_bus_via_gdbus(timeout: std::time::Duration) -> bool {
     use std::process::{Command, Stdio};
-    use wait_timeout::ChildExt;
 
     let mut child = match Command::new("gdbus")
         .args([
@@ -397,20 +396,36 @@ fn probe_at_spi_bus_via_gdbus(timeout: std::time::Duration) -> bool {
         Ok(c) => c,
         Err(_) => return false,
     };
-    match child.wait_timeout(timeout) {
+    match wait_for_child(&mut child, timeout) {
         Ok(Some(status)) => status.success(),
-        Ok(None) => {
-            // Timed out — kill the stuck child so we don't leave a
+        Ok(None) | Err(_) => {
+            // Timed out or failed — kill the stuck child so we don't leave a
             // gdbus process hanging around after `doctor` exits.
             let _ = child.kill();
             let _ = child.wait();
             false
         }
-        Err(_) => {
-            let _ = child.kill();
-            let _ = child.wait();
-            false
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn wait_for_child(
+    child: &mut std::process::Child,
+    timeout: std::time::Duration,
+) -> std::io::Result<Option<std::process::ExitStatus>> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(Some(status));
         }
+
+        let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now()) else {
+            return Ok(None);
+        };
+        if remaining.is_zero() {
+            return Ok(None);
+        }
+        std::thread::sleep(remaining.min(std::time::Duration::from_millis(15)));
     }
 }
 
@@ -616,6 +631,29 @@ mod tests {
         let json = r.to_json();
         // Warnings do not fail the run — exit-code-driving flag stays true.
         assert_eq!(json["ok"], serde_json::Value::Bool(true));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn wait_for_child_reports_exit() {
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        let status = wait_for_child(&mut child, std::time::Duration::from_secs(1))
+            .unwrap()
+            .unwrap();
+        assert!(status.success());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn wait_for_child_times_out() {
+        let mut child = std::process::Command::new("sleep")
+            .arg("5")
+            .spawn()
+            .unwrap();
+        let status = wait_for_child(&mut child, std::time::Duration::from_millis(10)).unwrap();
+        assert!(status.is_none());
+        child.kill().unwrap();
+        child.wait().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Problem

On Linux, `wait-timeout` installs a process-wide `SIGCHLD` handler while the doctor probes the display server. That can interfere with applications embedding Cua Driver.

## Change

- replace `wait_timeout` with a bounded monotonic `Instant` / `try_wait` loop
- preserve timeout behavior, including killing and reaping the child
- remove the unused `wait-timeout` dependency

## Validation

- `cargo fmt -p cua-driver --check`
- `cargo metadata --locked --no-deps --format-version 1`
- confirmed `wait-timeout` is absent from the dependency tree
- `cargo test -p cua-driver --bin cua-driver --locked` (117 passed)
- `cargo test -p cua-driver --all-targets --locked`
- `cargo clippy -p cua-driver --bin cua-driver --locked --no-deps`

Closes #2348