### PR TITLE
fix(release): synchronize driver skill versions

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -137,6 +137,7 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertIn('"path": "python/src/cua_driver/__init__.py"', config)
         self.assertIn('"path": "scripts/_install-rust.sh"', config)
         self.assertIn('"path": "scripts/install.ps1"', config)
+        self.assertIn('"path": "rust/Skills/cua-driver/SKILL.md"', config)
 
     def test_installers_preserve_legacy_telemetry_state_before_cleanup(self) -> None:
         for relative_path in (
@@ -173,9 +174,10 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         installer = self.read("libs/cua-driver/scripts/_install-local-rust.sh")
 
         self.assertIn(
-            'security find-identity -v -p codesigning "$kc"',
+            'security find-identity -p codesigning "$kc"',
             installer,
         )
+        self.assertNotIn('security find-identity -v -p codesigning "$kc"', installer)
         self.assertIn('SIGN_ID="$(ensure_local_signing_identity)"', installer)
         self.assertIn(
             'codesign_bounded 20 --force --deep --sign "$SIGN_ID" "$APP_STAGE"',

--- a/.github/scripts/validate_release_versions.py
+++ b/.github/scripts/validate_release_versions.py
@@ -53,6 +53,10 @@ def driver_versions(root: Path) -> tuple[str, dict[str, str]]:
             base / "scripts/install.ps1",
             r'^\$Script:CuaDriverRsBakedVersion\s*=\s*"([^"]+)"',
         ),
+        "rust/Skills/cua-driver/SKILL.md": read_match(
+            base / "rust/Skills/cua-driver/SKILL.md",
+            r"^version:\s*([^\s#]+)",
+        ),
         "docs/cli-reference.mdx:metadata": read_match(
             docs / "cli-reference.mdx", r"^  Version: (\S+)$"
         ),

--- a/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cua-driver
 description: Drive a native GUI app (macOS, Windows, Linux) via the cua-driver CLI (default) or MCP server; snapshot its accessibility tree, click/type/scroll by element_index or pixel coordinates, and verify via re-snapshot without bringing the target to the foreground. Use when the user asks you to operate, drive, automate, or perform a GUI task in a real application on the host.
-version: 0.8.3
+version: 0.8.3 # x-release-please-version
 metadata:
   openclaw:
     requires:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -39,6 +39,10 @@
         {
           "type": "generic",
           "path": "scripts/install.ps1"
+        },
+        {
+          "type": "generic",
+          "path": "rust/Skills/cua-driver/SKILL.md"
         }
       ]
     },


### PR DESCRIPTION
## Summary

- make Release Please update the bundled CUA Driver skill version alongside Rust, Python, installers, lockfile, and generated references
- make the release-version validator fail on stale skill frontmatter
- align the macOS signing regression test with the intentional self-signed identity lookup introduced in #2360

## Why

The generated 0.9.0 release PR correctly bumped the runtime surfaces but left `Skills/cua-driver/SKILL.md` at 0.8.3. Its script suite also inherited a stale assertion requiring `security find-identity -v`, even though #2360 deliberately removed the valid-only filter so the local self-signed identity can be found.

## Validation

- `uv run --with pytest --with jsonschema python -m pytest .github/scripts/tests -q` (80 passed)
- `python3 .github/scripts/validate_release_versions.py --product all`
- `python3 -m json.tool release-please-config.json`
- `git diff --check`

This is a release-automation prerequisite. It does not bump or publish a version by itself.