### PR TITLE
fix(cua-driver): recover cross-target releases

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -223,6 +223,24 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertIn("https://cua.ai/driver/install.ps1", windows_skill)
         self.assertNotIn("/releases/latest/download/install.ps1", windows_skill)
 
+    def test_driver_cd_can_recover_an_existing_tag_with_cross_targets(self) -> None:
+        workflow = self.read(".github/workflows/cd-rust-cua-driver.yml")
+
+        immutable_ref = (
+            "github.event_name == 'workflow_dispatch' && inputs.publish && "
+            "format('refs/tags/cua-driver-rs-v{0}', inputs.version) || github.ref"
+        )
+        self.assertEqual(workflow.count(immutable_ref), 4)
+        self.assertIn('rustup target add --toolchain stable "${{ matrix.target }}"', workflow)
+        self.assertIn(
+            "rustup target add --toolchain stable \\\n"
+            "            aarch64-apple-darwin x86_64-apple-darwin",
+            workflow,
+        )
+        self.assertIn("inputs.publish == true", workflow)
+        self.assertIn('--tag "${{ steps.version.outputs.tag }}"', workflow)
+        self.assertIn('--sha "${{ steps.version.outputs.sha }}"', workflow)
+
     def test_lume_uses_the_same_draft_finalizer(self) -> None:
         workflow = self.read(".github/workflows/cd-swift-lume.yml")
 

--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -25,6 +25,11 @@ on:
         required: false
         type: boolean
         default: true
+      publish:
+        description: "Publish an existing immutable version tag after successful builds"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -89,6 +94,8 @@ jobs:
             libx11-dev libxi-dev libxtst-dev libxext-dev libwayland-dev \
             libxkbcommon-dev
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.publish && format('refs/tags/cua-driver-rs-v{0}', inputs.version) || github.ref }}
       - name: Determine version
         id: version
         shell: bash
@@ -153,6 +160,8 @@ jobs:
             target: aarch64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.publish && format('refs/tags/cua-driver-rs-v{0}', inputs.version) || github.ref }}
       - name: Determine version
         id: version
         shell: bash
@@ -166,6 +175,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      # rustup can drop non-host std components while updating an existing
+      # stable toolchain. Install the requested cross target explicitly and
+      # fail here instead of surfacing a misleading `can't find crate core`
+      # error during the release build.
+      - name: Ensure Rust target is installed
+        shell: bash
+        run: |
+          rustup target add --toolchain stable "${{ matrix.target }}"
+          rustup target list --installed | grep -Fx "${{ matrix.target }}"
       - uses: actions/cache@v4
         with:
           path: |
@@ -239,6 +257,8 @@ jobs:
       KEYCHAIN_PASSWORD: temporary-cd-keychain-pwd
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.publish && format('refs/tags/cua-driver-rs-v{0}', inputs.version) || github.ref }}
       - name: Determine version
         id: version
         shell: bash
@@ -279,6 +299,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-darwin, x86_64-apple-darwin
+      - name: Ensure Rust targets are installed
+        run: |
+          rustup target add --toolchain stable \
+            aarch64-apple-darwin x86_64-apple-darwin
+          rustup target list --installed | grep -Fx aarch64-apple-darwin
+          rustup target list --installed | grep -Fx x86_64-apple-darwin
       - uses: actions/cache@v4
         with:
           path: |
@@ -422,18 +448,32 @@ jobs:
   # ── Release ──────────────────────────────────────────────────────────────────
   release:
     needs: [build-linux, build-windows, build-macos-universal]
-    if: startsWith(github.ref, 'refs/tags/cua-driver-rs-v')
+    if: startsWith(github.ref, 'refs/tags/cua-driver-rs-v') || inputs.publish == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.publish && format('refs/tags/cua-driver-rs-v{0}', inputs.version) || github.ref }}
 
       - name: Determine version
         id: version
         run: |
-          VERSION="${GITHUB_REF#refs/tags/cua-driver-rs-v}"
+          if [[ "$GITHUB_REF" == refs/tags/cua-driver-rs-v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/cua-driver-rs-v}"
+          else
+            VERSION="${{ inputs.version }}"
+          fi
+          TAG="cua-driver-rs-v${VERSION}"
+          SHA=$(git rev-parse HEAD)
+          TAG_SHA=$(git rev-list -n 1 "$TAG")
+          if [[ "$SHA" != "$TAG_SHA" ]]; then
+            echo "Checked-out source $SHA does not match $TAG ($TAG_SHA)" >&2
+            exit 1
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -513,9 +553,9 @@ jobs:
             --product cua-driver-rs \
             --display-name "Cua Driver" \
             --version "${{ steps.version.outputs.version }}" \
-            --tag "${{ github.ref_name }}" \
+            --tag "${{ steps.version.outputs.tag }}" \
             --tag-prefix cua-driver-rs-v \
-            --sha "${{ github.sha }}" \
+            --sha "${{ steps.version.outputs.sha }}" \
             --path libs/cua-driver \
             --exclude-path libs/cua-driver/docs \
             --exclude-path libs/cua-driver/python \
@@ -556,8 +596,8 @@ jobs:
         run: |
           python3 .github/scripts/github_release.py \
             --repository "${{ github.repository }}" \
-            --tag "${{ github.ref_name }}" \
-            --sha "${{ github.sha }}" \
+            --tag "${{ steps.version.outputs.tag }}" \
+            --sha "${{ steps.version.outputs.sha }}" \
             --body release-metadata/release-body.md \
             --asset-dir release-upload \
             --prerelease


### PR DESCRIPTION
## Summary

- explicitly install and verify requested Rust cross-target standard libraries after toolchain updates
- add an opt-in `publish` recovery mode that checks out an existing immutable Driver tag
- bind release attribution and finalization to the checked-out tag SHA
- cover the recovery contract in the release-wiring tests

## Why

The `0.9.0` CD run exposed a toolchain-update regression: Rustup updated the host toolchain but dropped the Windows ARM64 and macOS x86_64 standard-library components, causing `can't find crate for core`. A normal workflow dispatch also could not finish an existing draft release because publishing was restricted to tag-push events.

## Validation

- focused release-wiring tests: 19 passed
- workflow YAML parses successfully
- canonical release versions agree at `0.9.0`
- initial failing evidence: https://github.com/trycua/cua/actions/runs/29698988407

The full local script suite reached 80 passed with one environmental failure when its fixture copy exhausted local temporary disk space; the focused test covering this change passed.