### PR TITLE
fix(cua-driver): install targets for pinned toolchain

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -231,9 +231,14 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
             "format('refs/tags/cua-driver-rs-v{0}', inputs.version) || github.ref"
         )
         self.assertEqual(workflow.count(immutable_ref), 4)
-        self.assertIn('rustup target add --toolchain stable "${{ matrix.target }}"', workflow)
         self.assertIn(
-            "rustup target add --toolchain stable \\\n"
+            "name: Ensure Rust target is installed\n"
+            "        working-directory: libs/cua-driver/rust",
+            workflow,
+        )
+        self.assertIn('rustup target add "${{ matrix.target }}"', workflow)
+        self.assertIn(
+            "rustup target add \\\n"
             "            aarch64-apple-darwin x86_64-apple-darwin",
             workflow,
         )

--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -180,9 +180,10 @@ jobs:
       # fail here instead of surfacing a misleading `can't find crate core`
       # error during the release build.
       - name: Ensure Rust target is installed
+        working-directory: libs/cua-driver/rust
         shell: bash
         run: |
-          rustup target add --toolchain stable "${{ matrix.target }}"
+          rustup target add "${{ matrix.target }}"
           rustup target list --installed | grep -Fx "${{ matrix.target }}"
       - uses: actions/cache@v4
         with:
@@ -300,8 +301,9 @@ jobs:
         with:
           targets: aarch64-apple-darwin, x86_64-apple-darwin
       - name: Ensure Rust targets are installed
+        working-directory: libs/cua-driver/rust
         run: |
-          rustup target add --toolchain stable \
+          rustup target add \
             aarch64-apple-darwin x86_64-apple-darwin
           rustup target list --installed | grep -Fx aarch64-apple-darwin
           rustup target list --installed | grep -Fx x86_64-apple-darwin


### PR DESCRIPTION
## Summary

- install release cross targets from the Rust workspace that owns `rust-toolchain.toml`
- ensure Rustup modifies the exact pinned toolchain Cargo will use
- strengthen the release-wiring regression test

## Why

The first recovery fix installed targets into the named `stable` toolchain from the repository root. Release builds run inside `libs/cua-driver/rust`, whose exact `1.97.1` override is a distinct Rustup toolchain. The target-list check therefore passed for one toolchain while Cargo still failed with `can't find crate for core` under the other.

Evidence: https://github.com/trycua/cua/actions/runs/29699338396

## Validation

- focused release-wiring tests: 19 passed
- workflow YAML parses successfully
- diff check passes