### PR TITLE
fix(cua-driver): restore release checksums

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -246,6 +246,16 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertIn('--tag "${{ steps.version.outputs.tag }}"', workflow)
         self.assertIn('--sha "${{ steps.version.outputs.sha }}"', workflow)
 
+    def test_driver_release_publishes_checksums_for_python_wheels(self) -> None:
+        workflow = self.read(".github/workflows/cd-rust-cua-driver.yml")
+
+        self.assertIn("name: Generate SHA256 checksums", workflow)
+        self.assertIn(
+            "shasum -a 256 cua-driver-rs-*.{tar.gz,zip}",
+            workflow,
+        )
+        self.assertIn("} > checksums.txt", workflow)
+
     def test_lume_uses_the_same_draft_finalizer(self) -> None:
         workflow = self.read(".github/workflows/cd-swift-lume.yml")
 

--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -545,6 +545,16 @@ jobs:
           echo "Release files:"
           ls -lh release-upload/
 
+      - name: Generate SHA256 checksums
+        run: |
+          cd release-upload
+          {
+            echo "## SHA256 Checksums"
+            echo '```'
+            shasum -a 256 cua-driver-rs-*.{tar.gz,zip} 2>/dev/null | sort
+            echo '```'
+          } > checksums.txt
+
       - name: Collect PR-first release attribution
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- restore the `checksums.txt` asset consumed by Python wheel packaging
- generate hashes from the exact staged CUA Driver archives before release attribution and publication
- add a release-wiring regression test

## Context

The `0.9.0` native release completed successfully, but the Python wheel workflow failed because the release-attribution refactor stopped staging `checksums.txt`. The live release has been repaired from GitHub’s recorded asset digests; this PR prevents recurrence.

## Verification

- `0.9.0` checksum asset fetched successfully by the retried wheel builders
- focused wiring check is included in this change

Related run: https://github.com/trycua/cua/actions/runs/29699935119