### PR TITLE
feat(release): add component bump selectors

### DIFF
--- a/.github/scripts/resolve_release_please_request.py
+++ b/.github/scripts/resolve_release_please_request.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Resolve a targeted Release Please component and optional SemVer bump."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+
+COMPONENT_PATHS = {
+    "cua-driver-rs": "libs/cua-driver",
+    "lume": "libs/lume",
+}
+SEMVER = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+BUMP_TYPES = {"automatic", "patch", "minor", "major"}
+
+
+def bump_version(version: str, bump: str) -> str | None:
+    """Return the requested stable SemVer, or None for automatic inference."""
+    if bump not in BUMP_TYPES:
+        raise ValueError(f"unsupported bump type: {bump}")
+    if bump == "automatic":
+        return None
+
+    match = SEMVER.fullmatch(version)
+    if not match:
+        raise ValueError(f"manifest version is not stable SemVer: {version}")
+    major, minor, patch = (int(part) for part in match.groups())
+    if bump == "patch":
+        patch += 1
+    elif bump == "minor":
+        minor += 1
+        patch = 0
+    else:
+        major += 1
+        minor = 0
+        patch = 0
+    return f"{major}.{minor}.{patch}"
+
+
+def resolve_request(manifest: dict[str, Any], component: str, bump: str) -> dict[str, Any]:
+    """Resolve a user-facing component name into Release Please inputs."""
+    try:
+        path = COMPONENT_PATHS[component]
+    except KeyError as exc:
+        raise ValueError(f"unsupported component: {component}") from exc
+
+    version = manifest.get(path)
+    if not isinstance(version, str):
+        raise ValueError(f"manifest does not contain a version for {path}")
+    return {
+        "component": component,
+        "path": path,
+        "current_version": version,
+        "release_as": bump_version(version, bump),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--component", required=True)
+    parser.add_argument("--bump", required=True)
+    args = parser.parse_args()
+
+    manifest = json.loads(args.manifest.read_text())
+    if not isinstance(manifest, dict):
+        raise ValueError("release manifest must be a JSON object")
+    print(json.dumps(resolve_request(manifest, args.component, args.bump), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -65,6 +65,19 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertNotIn("if: steps.release.outputs.prs_created == 'true'", workflow)
         self.assertNotIn("RELEASE_PRS: ${{ steps.release.outputs.prs }}", workflow)
 
+    def test_release_please_exposes_targeted_bump_dropdowns(self) -> None:
+        workflow = self.read(".github/workflows/release-please.yml")
+
+        for option in ("automatic", "cua-driver-rs", "lume"):
+            self.assertIn(f"          - {option}\n", workflow)
+        for bump in ("patch", "minor", "major"):
+            self.assertIn(f"          - {bump}\n", workflow)
+        self.assertIn("resolve_release_please_request.py", workflow)
+        self.assertIn('"--path=$RELEASE_PATH"', workflow)
+        self.assertIn('ARGS+=("--release-as=$RELEASE_AS")', workflow)
+        self.assertIn("release-please@17.3.0", workflow)
+        self.assertIn("EXPECTED_INTEGRITY=", workflow)
+
     def test_required_release_metadata_check_runs_for_every_pull_request(self) -> None:
         workflow = self.read(".github/workflows/ci-release-metadata.yml")
 
@@ -75,6 +88,8 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
 
     def test_legacy_release_routes_exclude_driver_and_lume(self) -> None:
         workflow = self.read(".github/workflows/release-bump-version.yml")
+        self.assertIn('name: "Legacy packages: Bump Version"', workflow)
+        self.assertIn("Cua Driver and Lume use Release Please", workflow)
         self.assertNotIn("          - cua-driver-rs\n", workflow)
         self.assertNotIn("          - lume\n", workflow)
         self.assertNotIn("gh api -X DELETE", workflow)

--- a/.github/scripts/tests/test_resolve_release_please_request.py
+++ b/.github/scripts/tests/test_resolve_release_please_request.py
@@ -1,0 +1,49 @@
+"""Tests for targeted Release Please request resolution."""
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "resolve_release_please_request.py"
+SPEC = importlib.util.spec_from_file_location("resolve_release_please_request", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class TestResolveReleasePleaseRequest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.manifest = {
+            "libs/cua-driver": "0.9.0",
+            "libs/lume": "0.4.7",
+        }
+
+    def test_resolves_each_component_path(self) -> None:
+        driver = MODULE.resolve_request(self.manifest, "cua-driver-rs", "automatic")
+        lume = MODULE.resolve_request(self.manifest, "lume", "automatic")
+
+        self.assertEqual(driver["path"], "libs/cua-driver")
+        self.assertEqual(lume["path"], "libs/lume")
+        self.assertIsNone(driver["release_as"])
+
+    def test_calculates_patch_minor_and_major_versions(self) -> None:
+        self.assertEqual(MODULE.bump_version("0.9.0", "patch"), "0.9.1")
+        self.assertEqual(MODULE.bump_version("0.9.0", "minor"), "0.10.0")
+        self.assertEqual(MODULE.bump_version("0.9.0", "major"), "1.0.0")
+
+    def test_rejects_unknown_components_and_bumps(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsupported component"):
+            MODULE.resolve_request(self.manifest, "other", "patch")
+        with self.assertRaisesRegex(ValueError, "unsupported bump type"):
+            MODULE.resolve_request(self.manifest, "lume", "other")
+
+    def test_rejects_missing_or_non_stable_manifest_versions(self) -> None:
+        with self.assertRaisesRegex(ValueError, "does not contain"):
+            MODULE.resolve_request({}, "lume", "patch")
+        with self.assertRaisesRegex(ValueError, "not stable SemVer"):
+            MODULE.bump_version("1.0.0-rc.1", "patch")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -1,10 +1,10 @@
-name: "CD: Bump Version"
+name: "Legacy packages: Bump Version"
 
 on:
   workflow_dispatch:
     inputs:
       service:
-        description: "Service/Package to bump"
+        description: "Legacy package (Cua Driver and Lume use Release Please)"
         required: true
         type: choice
         options:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,26 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      component:
+        description: "Component to prepare (automatic checks both)"
+        required: true
+        type: choice
+        default: automatic
+        options:
+          - automatic
+          - cua-driver-rs
+          - lume
+      bump:
+        description: "Version bump for the selected component"
+        required: true
+        type: choice
+        default: automatic
+        options:
+          - automatic
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: write
@@ -32,14 +52,72 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      # release-please-action v4.4.1, embedding release-please ^17.3.0.
-      - name: Open or update release pull requests
-        id: release
+      - name: Reject an ambiguous manual release request
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          inputs.component == 'automatic' &&
+          inputs.bump != 'automatic'
+        run: |
+          echo "::error::Select cua-driver-rs or lume when forcing a bump type."
+          exit 1
+
+      - name: Resolve targeted release request
+        id: request
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          inputs.component != 'automatic'
+        run: |
+          REQUEST=$(python3 .github/scripts/resolve_release_please_request.py \
+            --manifest .release-please-manifest.json \
+            --component "${{ inputs.component }}" \
+            --bump "${{ inputs.bump }}")
+          echo "path=$(jq -r .path <<<"$REQUEST")" >> "$GITHUB_OUTPUT"
+          echo "current_version=$(jq -r .current_version <<<"$REQUEST")" >> "$GITHUB_OUTPUT"
+          echo "release_as=$(jq -r '.release_as // ""' <<<"$REQUEST")" >> "$GITHUB_OUTPUT"
+
+      # release-please-action v4.4.1, embedding release-please 17.3.0.
+      - name: Open or update automatic release pull requests
+        id: release-auto
+        if: >-
+          github.event_name == 'push' ||
+          (inputs.component == 'automatic' && inputs.bump == 'automatic')
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071
         with:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Open or update the targeted release pull request
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          inputs.component != 'automatic'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          NPM_CONFIG_IGNORE_SCRIPTS: "true"
+          RELEASE_PATH: ${{ steps.request.outputs.path }}
+          RELEASE_AS: ${{ steps.request.outputs.release_as }}
+        run: |
+          set -euo pipefail
+          EXPECTED_INTEGRITY='sha512-dB7HsFUpAvU1Wj9RGCINUz8Zi2qQDZiGbDEEVnJ7baNfJmk5XdYhuUFL6RcuDGjReGhp1gzY8Tc2g7vHlM4zpg=='
+          ACTUAL_INTEGRITY=$(npm view release-please@17.3.0 dist.integrity)
+          if [[ "$ACTUAL_INTEGRITY" != "$EXPECTED_INTEGRITY" ]]; then
+            echo "::error::release-please@17.3.0 integrity mismatch"
+            exit 1
+          fi
+
+          ARGS=(
+            release-pr
+            "--token=$GH_TOKEN"
+            "--repo-url=$GITHUB_REPOSITORY"
+            "--target-branch=${{ github.event.repository.default_branch }}"
+            "--config-file=release-please-config.json"
+            "--manifest-file=.release-please-manifest.json"
+            "--path=$RELEASE_PATH"
+          )
+          if [[ -n "$RELEASE_AS" ]]; then
+            ARGS+=("--release-as=$RELEASE_AS")
+          fi
+          npx --yes release-please@17.3.0 "${ARGS[@]}"
 
       - name: Synchronize generated files on release pull requests
         env:
@@ -102,5 +180,4 @@ jobs:
           done < <(gh pr list --state open --base main --limit 100 --json number --jq '.[].number')
 
       - name: Verify repository release versions
-        if: steps.release.outputs.prs_created != 'true'
         run: python3 .github/scripts/validate_release_versions.py --product all


### PR DESCRIPTION
## Summary

- add component and bump-type dropdowns to the shared Release Please workflow
- target only CUA Driver or Lume when explicitly selected
- preserve automatic conventional-commit behavior for pushes and the default manual mode
- label the old bump workflow as legacy and make clear that CUA Driver and Lume are excluded

## Safety

- targeted runs use Release Please 17.3.0, matching the pinned Action bundle
- the npm package integrity is pinned and lifecycle scripts are disabled
- ambiguous requests such as `automatic + minor` fail closed
- the selected version is calculated from `.release-please-manifest.json`

## Verification

- focused resolver tests: 4 passed
- release-wiring tests: 21 passed
- full `.github/scripts/tests` suite passed with CI dependencies
- Ruff lint and format checks passed
- workflow YAML parsed successfully
- pinned Release Please CLI dry-run confirmed `--path=libs/cua-driver` isolates the CUA Driver strategy

The legacy bump workflow still serves the other Python, npm, and container packages. Its CUA Driver and Lume choices were already removed and remain regression-tested.