### PR TITLE
feat(cua-sandbox): add direct Fleet provider

### DIFF
--- a/libs/python/cua-sandbox/README.md
+++ b/libs/python/cua-sandbox/README.md
@@ -77,3 +77,50 @@ async with Localhost.connect() as host:
     await host.shell.run("echo hello")
     await host.screenshot()
 ```
+
+## Fleet provider
+
+Provision directly through the Cyclops Fleet SDK. Each Sandbox owns one
+`replicas=1` pool and one claim; the bound sandbox's named `api` service routes
+the existing computer-server protocol.
+
+```python
+from cyclops_sdk import connect
+from cua_sandbox import FleetProvider, Image, Sandbox
+
+sdk = connect({
+    "base_url": "https://run.cua.ai",
+    "oauth": {
+        "token_url": "https://auth.cua.ai/realms/cyclops-cs/protocol/openid-connect/token",
+        "client_id": "...",
+        "client_secret": "...",
+    },
+})
+provider = FleetProvider(
+    sdk=sdk,
+    templates={
+        "linux": {
+            "containerDiskImage": "registry.example/desktop-workspace-duo@sha256:...",
+            "imagePullSecret": "registry-credentials",
+            "cpuCores": 4,
+            "memory": "4Gi",
+        },
+    },
+)
+
+try:
+    async with Sandbox.ephemeral(
+        Image.linux(),
+        name="fleet-demo",
+        provider=provider,
+    ) as sb:
+        await sb.shell.run("uname -a")
+        await sb.screenshot()
+finally:
+    sdk.close()
+```
+
+The caller owns the Cyclops SDK lifetime. `Sandbox.destroy()` and ephemeral
+cleanup delete the claim before the pool. Fleet templates must be supplied
+explicitly; `Image` install layers, snapshots, custom disk sizes, and non-default
+regions are not yet supported by `FleetProvider`.

--- a/libs/python/cua-sandbox/cua_sandbox/__init__.py
+++ b/libs/python/cua-sandbox/cua_sandbox/__init__.py
@@ -22,6 +22,7 @@ from cua_sandbox._auth import login, whoami
 from cua_sandbox._config import configure
 from cua_sandbox.image import Image
 from cua_sandbox.localhost import Localhost, localhost
+from cua_sandbox.providers import FleetProvider, SandboxProvider
 from cua_sandbox.runtime.compat import (
     RuntimeSupport,
     check_local_support,
@@ -41,6 +42,8 @@ __all__ = [
     "Localhost",
     "localhost",
     "CloudTransport",
+    "FleetProvider",
+    "SandboxProvider",
     "RuntimeSupport",
     "check_local_support",
     "skip_if_unsupported",

--- a/libs/python/cua-sandbox/cua_sandbox/providers/__init__.py
+++ b/libs/python/cua-sandbox/cua_sandbox/providers/__init__.py
@@ -1,0 +1,9 @@
+from cua_sandbox.providers.base import ProvisionedSandbox, SandboxProvider
+from cua_sandbox.providers.fleet import FleetProvider, FleetSandboxHandle
+
+__all__ = [
+    "ProvisionedSandbox",
+    "SandboxProvider",
+    "FleetProvider",
+    "FleetSandboxHandle",
+]

--- a/libs/python/cua-sandbox/cua_sandbox/providers/base.py
+++ b/libs/python/cua-sandbox/cua_sandbox/providers/base.py
@@ -1,0 +1,38 @@
+"""Provider lifecycle contracts for remotely managed sandboxes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional, Protocol
+
+if TYPE_CHECKING:
+    from cua_sandbox.image import Image
+    from cua_sandbox.transport.base import Transport
+
+
+@dataclass
+class ProvisionedSandbox:
+    """Transport and opaque lifecycle handle returned by a provider."""
+
+    name: str
+    transport: "Transport"
+    handle: Any
+
+
+class SandboxProvider(Protocol):
+    """Lifecycle operations required by Sandbox.create() and destroy()."""
+
+    async def create(
+        self,
+        image: "Image",
+        *,
+        name: str,
+        cpu: Optional[int] = None,
+        memory_mb: Optional[int] = None,
+        disk_gb: Optional[int] = None,
+        region: str = "us-east-1",
+        time_to_start: Optional[float] = None,
+        request_timeout: Optional[float] = None,
+    ) -> ProvisionedSandbox: ...
+
+    async def destroy(self, handle: Any) -> None: ...

--- a/libs/python/cua-sandbox/cua_sandbox/providers/fleet.py
+++ b/libs/python/cua-sandbox/cua_sandbox/providers/fleet.py
@@ -41,7 +41,9 @@ class FleetProvider:
         service_port: int = 8000,
     ) -> None:
         self._sdk = sdk
-        self._templates = {os_type: copy.deepcopy(template) for os_type, template in templates.items()}
+        self._templates = {
+            os_type: copy.deepcopy(template) for os_type, template in templates.items()
+        }
         self._service_name = service_name
         self._service_port = service_port
         self._call_lock = threading.Lock()

--- a/libs/python/cua-sandbox/cua_sandbox/providers/fleet.py
+++ b/libs/python/cua-sandbox/cua_sandbox/providers/fleet.py
@@ -1,0 +1,153 @@
+"""Fleet-backed Sandbox provider using the Cyclops Python SDK."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import logging
+import threading
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+from cua_sandbox.image import Image
+from cua_sandbox.providers.base import ProvisionedSandbox
+from cua_sandbox.transport.fleet import FleetTransport
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FleetSandboxHandle:
+    """Fleet resources owned by one Sandbox instance."""
+
+    pool: Any
+    claim: Any
+    bound: Any
+
+
+class FleetProvider:
+    """Provision one Fleet pool and claim for each Sandbox.
+
+    The caller owns the supplied Cyclops SDK and must close it after all
+    sandboxes using this provider have been disconnected or destroyed.
+    """
+
+    def __init__(
+        self,
+        *,
+        sdk: Any,
+        templates: Mapping[str, Mapping[str, Any]],
+        service_name: str = "api",
+        service_port: int = 8000,
+    ) -> None:
+        self._sdk = sdk
+        self._templates = {os_type: copy.deepcopy(template) for os_type, template in templates.items()}
+        self._service_name = service_name
+        self._service_port = service_port
+        self._call_lock = threading.Lock()
+
+    async def create(
+        self,
+        image: Image,
+        *,
+        name: str,
+        cpu: Optional[int] = None,
+        memory_mb: Optional[int] = None,
+        disk_gb: Optional[int] = None,
+        region: str = "us-east-1",
+        time_to_start: Optional[float] = None,
+        request_timeout: Optional[float] = None,
+    ) -> ProvisionedSandbox:
+        self._validate_image(image)
+        if not name:
+            raise ValueError("Fleet sandboxes require a name")
+        if disk_gb is not None:
+            raise ValueError("disk_gb is not supported by FleetProvider")
+        if region != "us-east-1":
+            raise ValueError("region is not supported by FleetProvider")
+        if time_to_start is not None:
+            raise ValueError("time_to_start is not configurable through FleetProvider")
+
+        configured_template = self._templates.get(image.os_type)
+        if configured_template is None:
+            raise ValueError(f"No Fleet template configured for {image.os_type!r}")
+        template = copy.deepcopy(configured_template)
+        if cpu is not None:
+            template["cpuCores"] = cpu
+        if memory_mb is not None:
+            template["memory"] = f"{memory_mb}Mi"
+
+        pool_request = {
+            "namespace": name,
+            "spec": {
+                "replicas": 1,
+                "services": [
+                    {
+                        "name": self._service_name,
+                        "targetPort": self._service_port,
+                        "protocol": "TCP",
+                    }
+                ],
+                "template": template,
+            },
+        }
+
+        pool = await self._run(self._sdk.create_pool, pool_request)
+        claim = None
+        try:
+            claim = await self._run(self._sdk.create_claim, {"pool": pool})
+            bound = await self._run(self._sdk.wait_claim, claim)
+        except BaseException:
+            if claim is not None:
+                await self._best_effort(self._sdk.delete_claim, claim, resource="claim")
+            await self._best_effort(self._sdk.delete_pool, pool, resource="pool")
+            raise
+
+        handle = FleetSandboxHandle(pool=pool, claim=claim, bound=bound)
+        transport = FleetTransport(
+            sdk=self._sdk,
+            bound=bound,
+            service_name=self._service_name,
+            timeout=request_timeout or 30.0,
+            call_lock=self._call_lock,
+        )
+        return ProvisionedSandbox(name=name, transport=transport, handle=handle)
+
+    async def destroy(self, handle: FleetSandboxHandle) -> None:
+        claim_error = None
+        try:
+            await self._run(self._sdk.delete_claim, handle.claim)
+        except Exception as error:
+            claim_error = error
+        try:
+            await self._run(self._sdk.delete_pool, handle.pool)
+        except Exception:
+            if claim_error is not None:
+                logger.warning("Failed to delete Fleet claim before pool cleanup: %s", claim_error)
+            raise
+        if claim_error is not None:
+            raise claim_error
+
+    async def _best_effort(self, operation: Any, resource_value: Any, *, resource: str) -> None:
+        try:
+            await self._run(operation, resource_value)
+        except Exception:
+            logger.warning("Failed to clean up Fleet %s after provisioning error", resource)
+
+    async def _run(self, operation: Any, *args: Any, **kwargs: Any) -> Any:
+        return await asyncio.to_thread(self._call_locked, operation, args, kwargs)
+
+    def _call_locked(self, operation: Any, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+        with self._call_lock:
+            return operation(*args, **kwargs)
+
+    @staticmethod
+    def _validate_image(image: Image) -> None:
+        if image._snapshot_source:
+            raise ValueError("FleetProvider does not support snapshot images")
+        if image._layers or image._env or image._ports or image._files:
+            raise ValueError("FleetProvider does not yet support Image mutations")
+        if image._disk_path:
+            raise ValueError("FleetProvider does not support local disk images")
+        if image._registry:
+            raise ValueError("FleetProvider uses explicit templates, not registry Images")

--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -76,6 +76,7 @@ from cua_sandbox.transport.http import HTTPTransport
 from cua_sandbox.transport.websocket import WebSocketTransport
 
 if TYPE_CHECKING:
+    from cua_sandbox.providers.base import SandboxProvider
     from cua_sandbox.runtime.base import Runtime, RuntimeInfo
 
 logger = logging.getLogger(__name__)
@@ -248,6 +249,8 @@ class Sandbox:
         _runtime_info: Optional[RuntimeInfo] = None,
         _ephemeral: Optional[bool] = None,
         _telemetry_enabled: bool = True,
+        _provider: Optional["SandboxProvider"] = None,
+        _provider_handle: Any = None,
     ):
         self._transport = transport
         self.name = name
@@ -256,6 +259,8 @@ class Sandbox:
         self._ephemeral = _ephemeral
         self._has_snapshots = False
         self.telemetry_enabled = _telemetry_enabled
+        self._provider = _provider
+        self._provider_handle = _provider_handle
         self.screen = Screen(transport)
         self.mouse = Mouse(transport)
         self.keyboard = Keyboard(transport)
@@ -333,7 +338,14 @@ class Sandbox:
             await self._transport.disconnect()
         except Exception:
             logger.warning("Failed to disconnect transport for sandbox %r", self.name)
-        if isinstance(self._transport, CloudTransport):
+        if self._provider is not None and self._provider_handle is not None:
+            try:
+                await self._provider.destroy(self._provider_handle)
+            except Exception:
+                logger.warning("Failed to delete provider resources for sandbox %r", self.name)
+            finally:
+                self._provider_handle = None
+        elif isinstance(self._transport, CloudTransport):
             try:
                 await self._transport.delete_vm()
             except Exception:
@@ -403,6 +415,7 @@ class Sandbox:
         api_key: Optional[str] = None,
         local: bool = False,
         runtime: Optional["Runtime"] = None,
+        provider: Optional["SandboxProvider"] = None,
         cpu: Optional[int] = None,
         memory_mb: Optional[int] = None,
         disk_gb: Optional[int] = None,
@@ -449,6 +462,7 @@ class Sandbox:
             api_key=api_key,
             local=local,
             runtime=runtime,
+            provider=provider,
             cpu=cpu,
             memory_mb=memory_mb,
             disk_gb=disk_gb,
@@ -527,6 +541,7 @@ class Sandbox:
         api_key: Optional[str] = None,
         local: bool = False,
         runtime: Optional["Runtime"] = None,
+        provider: Optional["SandboxProvider"] = None,
         cpu: Optional[int] = None,
         memory_mb: Optional[int] = None,
         disk_gb: Optional[int] = None,
@@ -567,6 +582,7 @@ class Sandbox:
             api_key=api_key,
             local=local,
             runtime=runtime,
+            provider=provider,
             cpu=cpu,
             memory_mb=memory_mb,
             disk_gb=disk_gb,
@@ -980,6 +996,7 @@ class Sandbox:
         container_name: Optional[str] = None,
         image: Optional[Image] = None,
         runtime: Optional["Runtime"] = None,
+        provider: Optional["SandboxProvider"] = None,
         name: Optional[str] = None,
         ephemeral: Optional[bool] = None,
         cpu: Optional[int] = None,
@@ -996,6 +1013,48 @@ class Sandbox:
             ephemeral = bool(image)
 
         rt_info = None
+        if provider is not None:
+            if image is None:
+                raise ValueError("An image is required when using a Sandbox provider")
+            if local or runtime is not None or ws_url or http_url:
+                raise ValueError(
+                    "provider cannot be combined with local, runtime, ws_url, or http_url"
+                )
+            sb_name = name or _random_name()
+            provisioned = await provider.create(
+                image,
+                name=sb_name,
+                cpu=cpu,
+                memory_mb=memory_mb,
+                disk_gb=disk_gb,
+                region=region,
+                time_to_start=time_to_start,
+                request_timeout=request_timeout,
+            )
+            sb = cls(
+                provisioned.transport,
+                name=provisioned.name,
+                _ephemeral=ephemeral,
+                _telemetry_enabled=telemetry_enabled,
+                _provider=provider,
+                _provider_handle=provisioned.handle,
+            )
+            try:
+                await sb._connect()
+            except BaseException:
+                try:
+                    await provider.destroy(provisioned.handle)
+                except Exception:
+                    logger.warning(
+                        "Failed to clean up provider resources for sandbox %r after connect failure",
+                        provisioned.name,
+                    )
+                raise
+            _record_sandbox_create(
+                sb, image=image, local=False, ephemeral=bool(ephemeral), t_start=_t_start
+            )
+            return sb
+
         if image and image.kind is None and image._registry:
             from cua_sandbox.registry.resolve import resolve_image_kind
 

--- a/libs/python/cua-sandbox/cua_sandbox/transport/__init__.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/__init__.py
@@ -1,6 +1,7 @@
 from cua_sandbox.transport.adb import ADBTransport
 from cua_sandbox.transport.base import Transport
 from cua_sandbox.transport.cloud import CloudTransport
+from cua_sandbox.transport.fleet import FleetTransport
 from cua_sandbox.transport.http import HTTPTransport
 from cua_sandbox.transport.local import LocalTransport
 from cua_sandbox.transport.osworld import OSWorldTransport
@@ -16,6 +17,7 @@ __all__ = [
     "WebSocketTransport",
     "HTTPTransport",
     "CloudTransport",
+    "FleetTransport",
     "QMPTransport",
     "OSWorldTransport",
     "ADBTransport",

--- a/libs/python/cua-sandbox/cua_sandbox/transport/computer_server.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/computer_server.py
@@ -36,9 +36,7 @@ def decode_screenshot_response(payload: Dict[str, Any]) -> bytes:
     """Decode computer-server's accepted screenshot response shapes."""
     encoded = payload.get("image_data", payload.get("base64_image", payload.get("result", "")))
     if isinstance(encoded, dict):
-        encoded = encoded.get(
-            "image_data", encoded.get("base64_image", encoded.get("base64", ""))
-        )
+        encoded = encoded.get("image_data", encoded.get("base64_image", encoded.get("base64", "")))
     return base64.b64decode(encoded)
 
 

--- a/libs/python/cua-sandbox/cua_sandbox/transport/computer_server.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/computer_server.py
@@ -1,0 +1,55 @@
+"""Shared response handling for computer-server HTTP transports."""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any, Dict
+
+
+def parse_command_response(text: str) -> Dict[str, Any]:
+    """Extract and validate the first JSON data frame from an SSE response."""
+    for line in text.splitlines():
+        if not line.startswith("data: "):
+            continue
+        payload = json.loads(line[6:])
+        if isinstance(payload, dict) and not payload.get("success", True):
+            if "error" in payload:
+                raise RuntimeError(f"Remote error: {payload['error']}")
+            parts = []
+            return_code = payload.get("return_code")
+            if return_code is not None:
+                parts.append(f"return_code={return_code}")
+            stderr = (payload.get("stderr") or "").strip()
+            if stderr:
+                parts.append(f"stderr={stderr!r}")
+            stdout = (payload.get("stdout") or "").strip()
+            if stdout and not stderr:
+                parts.append(f"stdout={stdout!r}")
+            detail = ", ".join(parts) or "no detail"
+            raise RuntimeError(f"Remote error: {detail}")
+        return payload
+    raise RuntimeError(f"No SSE data frame in response: {text[:200]}")
+
+
+def decode_screenshot_response(payload: Dict[str, Any]) -> bytes:
+    """Decode computer-server's accepted screenshot response shapes."""
+    encoded = payload.get("image_data", payload.get("base64_image", payload.get("result", "")))
+    if isinstance(encoded, dict):
+        encoded = encoded.get(
+            "image_data", encoded.get("base64_image", encoded.get("base64", ""))
+        )
+    return base64.b64decode(encoded)
+
+
+def normalize_screen_size(payload: Dict[str, Any]) -> Dict[str, int]:
+    """Normalize nested computer-server screen-size response shapes."""
+    data: Any = payload
+    if isinstance(data, dict):
+        data = data.get("size", data.get("result", data))
+    if isinstance(data, dict):
+        width = data.get("width") or data.get("screen_width") or data.get("w")
+        height = data.get("height") or data.get("screen_height") or data.get("h")
+        if width is not None and height is not None:
+            return {"width": int(width), "height": int(height)}
+    raise KeyError(f"Cannot extract screen size from response: {payload}")

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
@@ -7,7 +7,6 @@ import threading
 from typing import Any, Dict, Optional
 
 import httpx
-
 from cua_sandbox.transport.base import Transport
 from cua_sandbox.transport.computer_server import (
     decode_screenshot_response,

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
@@ -1,0 +1,138 @@
+"""Computer-server transport routed through Cyclops named services."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any, Dict, Optional
+
+import httpx
+
+from cua_sandbox.transport.base import Transport
+from cua_sandbox.transport.computer_server import (
+    decode_screenshot_response,
+    normalize_screen_size,
+    parse_command_response,
+)
+
+_CMD_MAX_RETRIES = 3
+_CMD_RETRY_BACKOFF_S = 0.5
+
+
+class FleetTransport(Transport):
+    """Route computer-server requests through ``SDK.service_client``."""
+
+    def __init__(
+        self,
+        *,
+        sdk: Any,
+        bound: Any,
+        service_name: str = "api",
+        timeout: float = 30.0,
+        call_lock: Optional[threading.Lock] = None,
+    ) -> None:
+        self._sdk = sdk
+        self._bound = bound
+        self._service_name = service_name
+        self._timeout = timeout
+        self._call_lock = call_lock or threading.Lock()
+        self._client: Any = None
+
+    async def connect(self) -> None:
+        if self._client is None:
+            self._client = await self._run(
+                self._sdk.service_client, self._bound, self._service_name
+            )
+
+    async def disconnect(self) -> None:
+        if self._client is not None:
+            await self._run(self._client.close)
+            self._client = None
+
+    async def _cmd(self, command: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        client = self._require_client()
+        body: Dict[str, Any] = {"command": command}
+        if params:
+            body["params"] = params
+        server_timeout = (params or {}).get("timeout")
+        timeout = (
+            httpx.Timeout(self._timeout, read=float(server_timeout) + 10)
+            if server_timeout is not None
+            else None
+        )
+        response = None
+        for attempt in range(_CMD_MAX_RETRIES):
+            response = await self._run(client.post, "/cmd", json=body, timeout=timeout)
+            if response.status_code < 500 or attempt == _CMD_MAX_RETRIES - 1:
+                break
+            await asyncio.sleep(_CMD_RETRY_BACKOFF_S * (2**attempt))
+        response.raise_for_status()
+        return parse_command_response(response.text)
+
+    async def send(self, action: str, **params: Any) -> Any:
+        result = await self._cmd(action, params if params else None)
+        return result.get("result", result)
+
+    async def screenshot(self, format: str = "png", quality: int = 95) -> bytes:
+        params = None if format == "png" else {"format": format, "quality": quality}
+        return decode_screenshot_response(await self._cmd("screenshot", params))
+
+    async def get_screen_size(self) -> Dict[str, int]:
+        return normalize_screen_size(await self._cmd("get_screen_size"))
+
+    async def get_environment(self) -> str:
+        try:
+            response = await self._run(self._require_client().get, "/status")
+            response.raise_for_status()
+            payload = response.json()
+            return payload.get("os_type", payload.get("platform", "linux"))
+        except Exception:
+            return "linux"
+
+    async def pty_create(
+        self,
+        command: Optional[str] = None,
+        cols: int = 120,
+        rows: int = 40,
+        cwd: Optional[str] = None,
+        envs: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {"cols": cols, "rows": rows}
+        if command is not None:
+            body["command"] = command
+        if cwd is not None:
+            body["cwd"] = cwd
+        if envs is not None:
+            body["envs"] = envs
+        response = await self._run(self._require_client().post, "/pty", json=body)
+        response.raise_for_status()
+        return response.json()
+
+    async def pty_send(self, pid: int, data: str) -> None:
+        response = await self._run(
+            self._require_client().post, f"/pty/{pid}/stdin", json={"data": data}
+        )
+        response.raise_for_status()
+
+    async def pty_kill(self, pid: int) -> bool:
+        response = await self._run(self._require_client().delete, f"/pty/{pid}")
+        response.raise_for_status()
+        return bool(response.json().get("killed", True))
+
+    async def pty_info(self, pid: int) -> Optional[Dict[str, Any]]:
+        response = await self._run(self._require_client().get, f"/pty/{pid}")
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        return response.json()
+
+    async def _run(self, operation: Any, *args: Any, **kwargs: Any) -> Any:
+        return await asyncio.to_thread(self._call_locked, operation, args, kwargs)
+
+    def _call_locked(self, operation: Any, args: tuple[Any, ...], kwargs: Dict[str, Any]) -> Any:
+        with self._call_lock:
+            return operation(*args, **kwargs)
+
+    def _require_client(self) -> Any:
+        assert self._client is not None, "Transport not connected"
+        return self._client

--- a/libs/python/cua-sandbox/cua_sandbox/transport/http.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/http.py
@@ -7,13 +7,16 @@ and returns an SSE stream with a single ``data: {...}`` frame containing the res
 from __future__ import annotations
 
 import asyncio
-import base64
-import json
 import logging
 from typing import Any, Dict, Optional
 
 import httpx
 from cua_sandbox.transport.base import Transport
+from cua_sandbox.transport.computer_server import (
+    decode_screenshot_response,
+    normalize_screen_size,
+    parse_command_response,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -112,55 +115,7 @@ class HTTPTransport(Transport):
         resp.raise_for_status()
         return self._parse_sse(resp.text)
 
-    @staticmethod
-    def _parse_sse(text: str) -> Dict[str, Any]:
-        """Extract the first ``data: {...}`` frame from an SSE response.
-
-        The server returns one of two failure shapes when ``success`` is
-        false:
-
-        1. Generic handler error — ``{"success": false, "error": "<msg>"}``
-        2. Shell-command shape — ``{"success": false, "stdout": "...",
-           "stderr": "...", "return_code": <n>}`` (no ``error`` key)
-
-        The old code stringified ``payload.get('error', 'unknown')`` for
-        both shapes, which turned every shell-command failure into
-        ``Remote error: unknown`` and hid the actual ``stderr`` + exit
-        code.  That masking made ``Command timed out after 10s``,
-        ``UI hierchary dump failed``, and similar concrete failures
-        indistinguishable from a genuine internal error — the common
-        pattern where ``await sb.shell.run(cmd)`` returned non-zero
-        became a debugging dead end.
-
-        This rewrite preserves the ``error``-key path verbatim and falls
-        back to a composite ``return_code=...`` / ``stderr=...`` /
-        ``stdout=...`` string when no ``error`` key is present.
-        """
-        for line in text.splitlines():
-            if line.startswith("data: "):
-                payload = json.loads(line[6:])
-                if isinstance(payload, dict) and not payload.get("success", True):
-                    if "error" in payload:
-                        raise RuntimeError(f"Remote error: {payload['error']}")
-                    # Shell-command shape: surface return_code/stderr/stdout.
-                    parts = []
-                    rc = payload.get("return_code")
-                    if rc is not None:
-                        parts.append(f"return_code={rc}")
-                    stderr = (payload.get("stderr") or "").strip()
-                    if stderr:
-                        parts.append(f"stderr={stderr!r}")
-                    stdout = (payload.get("stdout") or "").strip()
-                    if stdout and not stderr:
-                        # Only surface stdout when there's nothing on
-                        # stderr — saves bloating the message for noisy
-                        # successful-output commands that happened to
-                        # return non-zero.
-                        parts.append(f"stdout={stdout!r}")
-                    detail = ", ".join(parts) or "no detail"
-                    raise RuntimeError(f"Remote error: {detail}")
-                return payload
-        raise RuntimeError(f"No SSE data frame in response: {text[:200]}")
+    _parse_sse = staticmethod(parse_command_response)
 
     async def send(self, action: str, **params: Any) -> Any:
         result = await self._cmd(action, params if params else None)
@@ -169,25 +124,11 @@ class HTTPTransport(Transport):
     async def screenshot(self, format: str = "png", quality: int = 95) -> bytes:
         params = None if format == "png" else {"format": format, "quality": quality}
         result = await self._cmd("screenshot", params)
-        # computer-server returns {"success": true, "image_data": "..."}
-        b64 = result.get("image_data", result.get("base64_image", result.get("result", "")))
-        if isinstance(b64, dict):
-            b64 = b64.get("image_data", b64.get("base64_image", b64.get("base64", "")))
-        return base64.b64decode(b64)
+        return decode_screenshot_response(result)
 
     async def get_screen_size(self) -> Dict[str, int]:
         result = await self._cmd("get_screen_size")
-        # Flatten nested responses and normalize key names
-        data = result
-        if isinstance(data, dict):
-            # Unwrap nested: {"result": {...}}, {"size": {...}}
-            data = data.get("size", data.get("result", data))
-        if isinstance(data, dict):
-            w = data.get("width") or data.get("screen_width") or data.get("w")
-            h = data.get("height") or data.get("screen_height") or data.get("h")
-            if w is not None and h is not None:
-                return {"width": int(w), "height": int(h)}
-        raise KeyError(f"Cannot extract screen size from response: {result}")
+        return normalize_screen_size(result)
 
     # ── PTY over dedicated /pty_* routes ────────────────────────────────
     async def pty_create(

--- a/libs/python/cua-sandbox/tests/test_computer_server_transport.py
+++ b/libs/python/cua-sandbox/tests/test_computer_server_transport.py
@@ -1,7 +1,6 @@
 import base64
 
 import pytest
-
 from cua_sandbox.transport.computer_server import (
     decode_screenshot_response,
     normalize_screen_size,
@@ -10,7 +9,9 @@ from cua_sandbox.transport.computer_server import (
 
 
 def test_parse_command_response_returns_sse_payload():
-    result = parse_command_response('event: result\ndata: {"success": true, "result": {"ok": 1}}\n\n')
+    result = parse_command_response(
+        'event: result\ndata: {"success": true, "result": {"ok": 1}}\n\n'
+    )
 
     assert result == {"success": True, "result": {"ok": 1}}
 

--- a/libs/python/cua-sandbox/tests/test_computer_server_transport.py
+++ b/libs/python/cua-sandbox/tests/test_computer_server_transport.py
@@ -1,0 +1,45 @@
+import base64
+
+import pytest
+
+from cua_sandbox.transport.computer_server import (
+    decode_screenshot_response,
+    normalize_screen_size,
+    parse_command_response,
+)
+
+
+def test_parse_command_response_returns_sse_payload():
+    result = parse_command_response('event: result\ndata: {"success": true, "result": {"ok": 1}}\n\n')
+
+    assert result == {"success": True, "result": {"ok": 1}}
+
+
+def test_parse_command_response_raises_remote_error():
+    with pytest.raises(RuntimeError, match="return_code=2"):
+        parse_command_response(
+            'data: {"success": false, "return_code": 2, "stderr": "bad command"}\n\n'
+        )
+
+
+def test_parse_command_response_requires_data_frame():
+    with pytest.raises(RuntimeError, match="No SSE data frame"):
+        parse_command_response("event: keepalive\n\n")
+
+
+def test_decode_screenshot_response_accepts_nested_payload():
+    encoded = base64.b64encode(b"png-data").decode()
+
+    assert decode_screenshot_response({"result": {"image_data": encoded}}) == b"png-data"
+
+
+def test_normalize_screen_size_accepts_nested_aliases():
+    assert normalize_screen_size({"result": {"screen_width": "1280", "screen_height": 720}}) == {
+        "width": 1280,
+        "height": 720,
+    }
+
+
+def test_normalize_screen_size_rejects_unknown_shape():
+    with pytest.raises(KeyError, match="Cannot extract screen size"):
+        normalize_screen_size({"result": {"unexpected": True}})

--- a/libs/python/cua-sandbox/tests/test_fleet_provider.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_provider.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from copy import deepcopy
 
 import pytest
-
 from cua_sandbox import Image
 from cua_sandbox.providers.fleet import FleetProvider
 from cua_sandbox.transport.fleet import FleetTransport
@@ -159,12 +158,14 @@ async def test_create_rejects_unsupported_disk_size(linux_template):
     with pytest.raises(ValueError, match="disk_gb is not supported"):
         await provider.create(Image.linux(), name="demo", disk_gb=20)
 
+
 @pytest.mark.asyncio
 async def test_create_rejects_registry_image_in_favor_of_explicit_template(linux_template):
     provider = FleetProvider(sdk=FakeSDK(), templates={"linux": linux_template})
 
     with pytest.raises(ValueError, match="uses explicit templates"):
         await provider.create(Image.from_registry("registry.example/custom:latest"), name="demo")
+
 
 @pytest.mark.asyncio
 async def test_create_rejects_custom_start_timeout(linux_template):

--- a/libs/python/cua-sandbox/tests/test_fleet_provider.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_provider.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from cua_sandbox import Image
+from cua_sandbox.providers.fleet import FleetProvider
+from cua_sandbox.transport.fleet import FleetTransport
+
+
+class FakeSDK:
+    def __init__(self, *, create_claim_error=None, wait_claim_error=None):
+        self.calls = []
+        self.create_claim_error = create_claim_error
+        self.wait_claim_error = wait_claim_error
+        self.pool = {
+            "apiVersion": "cua.ai/v1",
+            "kind": "OSGymWorkspacePool",
+            "metadata": {"namespace": "demo", "name": "demo"},
+            "spec": {},
+        }
+        self.claim = {
+            "apiVersion": "osgym.cua.ai/v1alpha1",
+            "kind": "OSGymSandboxClaim",
+            "metadata": {"namespace": "demo", "name": "claim-demo"},
+            "spec": {},
+        }
+        self.bound = {
+            "namespace": "demo",
+            "claim": "claim-demo",
+            "sandbox": "sandbox-demo",
+            "services": ["api"],
+        }
+
+    def create_pool(self, request):
+        self.calls.append(("create_pool", deepcopy(request)))
+        pool = deepcopy(self.pool)
+        pool["spec"] = deepcopy(request["spec"])
+        return pool
+
+    def create_claim(self, request):
+        self.calls.append(("create_claim", request))
+        if self.create_claim_error:
+            raise self.create_claim_error
+        return self.claim
+
+    def wait_claim(self, claim):
+        self.calls.append(("wait_claim", claim))
+        if self.wait_claim_error:
+            raise self.wait_claim_error
+        return self.bound
+
+    def delete_claim(self, claim):
+        self.calls.append(("delete_claim", claim))
+
+    def delete_pool(self, pool):
+        self.calls.append(("delete_pool", pool))
+
+
+@pytest.fixture
+def linux_template():
+    return {
+        "containerDiskImage": "registry.example/desktop-workspace-duo@sha256:abc",
+        "cpuCores": 4,
+        "memory": "4Gi",
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_provisions_one_pool_and_one_claim(linux_template):
+    sdk = FakeSDK()
+    provider = FleetProvider(sdk=sdk, templates={"linux": linux_template})
+
+    provisioned = await provider.create(
+        Image.linux(),
+        name="demo",
+        cpu=8,
+        memory_mb=8192,
+        disk_gb=None,
+        region="us-east-1",
+        request_timeout=45,
+    )
+
+    assert [call[0] for call in sdk.calls] == ["create_pool", "create_claim", "wait_claim"]
+    pool_request = sdk.calls[0][1]
+    assert pool_request == {
+        "namespace": "demo",
+        "spec": {
+            "replicas": 1,
+            "services": [{"name": "api", "targetPort": 8000, "protocol": "TCP"}],
+            "template": {
+                "containerDiskImage": "registry.example/desktop-workspace-duo@sha256:abc",
+                "cpuCores": 8,
+                "memory": "8192Mi",
+            },
+        },
+    }
+    assert linux_template["cpuCores"] == 4
+    assert provisioned.name == "demo"
+    assert isinstance(provisioned.transport, FleetTransport)
+    assert provisioned.handle.pool["metadata"]["name"] == "demo"
+    assert provisioned.handle.claim["metadata"]["name"] == "claim-demo"
+    assert provisioned.handle.bound["sandbox"] == "sandbox-demo"
+
+
+@pytest.mark.asyncio
+async def test_destroy_deletes_claim_before_pool(linux_template):
+    sdk = FakeSDK()
+    provider = FleetProvider(sdk=sdk, templates={"linux": linux_template})
+    provisioned = await provider.create(Image.linux(), name="demo")
+    sdk.calls.clear()
+
+    await provider.destroy(provisioned.handle)
+
+    assert [call[0] for call in sdk.calls] == ["delete_claim", "delete_pool"]
+
+
+@pytest.mark.asyncio
+async def test_claim_creation_failure_rolls_back_pool(linux_template):
+    sdk = FakeSDK(create_claim_error=RuntimeError("claim failed"))
+    provider = FleetProvider(sdk=sdk, templates={"linux": linux_template})
+
+    with pytest.raises(RuntimeError, match="claim failed"):
+        await provider.create(Image.linux(), name="demo")
+
+    assert [call[0] for call in sdk.calls] == ["create_pool", "create_claim", "delete_pool"]
+
+
+@pytest.mark.asyncio
+async def test_claim_wait_failure_deletes_claim_then_pool(linux_template):
+    sdk = FakeSDK(wait_claim_error=RuntimeError("bind failed"))
+    provider = FleetProvider(sdk=sdk, templates={"linux": linux_template})
+
+    with pytest.raises(RuntimeError, match="bind failed"):
+        await provider.create(Image.linux(), name="demo")
+
+    assert [call[0] for call in sdk.calls] == [
+        "create_pool",
+        "create_claim",
+        "wait_claim",
+        "delete_claim",
+        "delete_pool",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_requires_explicit_os_template():
+    provider = FleetProvider(sdk=FakeSDK(), templates={})
+
+    with pytest.raises(ValueError, match="No Fleet template configured for 'windows'"):
+        await provider.create(Image.windows(), name="demo")
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_unsupported_disk_size(linux_template):
+    provider = FleetProvider(sdk=FakeSDK(), templates={"linux": linux_template})
+
+    with pytest.raises(ValueError, match="disk_gb is not supported"):
+        await provider.create(Image.linux(), name="demo", disk_gb=20)
+
+@pytest.mark.asyncio
+async def test_create_rejects_registry_image_in_favor_of_explicit_template(linux_template):
+    provider = FleetProvider(sdk=FakeSDK(), templates={"linux": linux_template})
+
+    with pytest.raises(ValueError, match="uses explicit templates"):
+        await provider.create(Image.from_registry("registry.example/custom:latest"), name="demo")
+
+@pytest.mark.asyncio
+async def test_create_rejects_custom_start_timeout(linux_template):
+    provider = FleetProvider(sdk=FakeSDK(), templates={"linux": linux_template})
+
+    with pytest.raises(ValueError, match="time_to_start is not configurable"):
+        await provider.create(Image.linux(), name="demo", time_to_start=120)

--- a/libs/python/cua-sandbox/tests/test_fleet_sandbox.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_sandbox.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cua_sandbox import Image, Sandbox
+from cua_sandbox.providers.base import ProvisionedSandbox
+
+
+class FakeProvider:
+    def __init__(self, transport):
+        self.transport = transport
+        self.create_calls = []
+        self.destroy_calls = []
+        self.handle = object()
+
+    async def create(self, image, **kwargs):
+        self.create_calls.append((image, kwargs))
+        return ProvisionedSandbox(name=kwargs["name"], transport=self.transport, handle=self.handle)
+
+    async def destroy(self, handle):
+        self.destroy_calls.append(handle)
+
+
+def make_transport():
+    transport = AsyncMock()
+    transport.get_environment.return_value = "linux"
+    return transport
+
+
+@pytest.mark.asyncio
+async def test_create_uses_explicit_provider_instead_of_cloud_transport():
+    transport = make_transport()
+    provider = FakeProvider(transport)
+
+    with patch("cua_sandbox.sandbox.CloudTransport", side_effect=AssertionError("unexpected cloud")):
+        sandbox = await Sandbox.create(
+            Image.linux(),
+            name="fleet-demo",
+            provider=provider,
+            cpu=8,
+            memory_mb=8192,
+            request_timeout=60,
+            telemetry_enabled=False,
+        )
+
+    assert sandbox.name == "fleet-demo"
+    transport.connect.assert_awaited_once()
+    assert len(provider.create_calls) == 1
+    image, kwargs = provider.create_calls[0]
+    assert image.os_type == "linux"
+    assert kwargs == {
+        "name": "fleet-demo",
+        "cpu": 8,
+        "memory_mb": 8192,
+        "disk_gb": None,
+        "region": "us-east-1",
+        "time_to_start": None,
+        "request_timeout": 60,
+    }
+
+
+@pytest.mark.asyncio
+async def test_destroy_disconnects_then_deletes_provider_resources():
+    events = []
+    transport = make_transport()
+
+    async def disconnect():
+        events.append("disconnect")
+
+    transport.disconnect.side_effect = disconnect
+    provider = FakeProvider(transport)
+
+    async def destroy(handle):
+        assert handle is provider.handle
+        events.append("destroy")
+
+    provider.destroy = destroy
+    sandbox = await Sandbox.create(
+        Image.linux(), name="fleet-demo", provider=provider, telemetry_enabled=False
+    )
+
+    await sandbox.destroy()
+
+    assert events == ["disconnect", "destroy"]
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_destroys_provider_resources_on_normal_exit():
+    transport = make_transport()
+    provider = FakeProvider(transport)
+
+    async with Sandbox.ephemeral(
+        Image.linux(), name="fleet-demo", provider=provider, telemetry_enabled=False
+    ):
+        pass
+
+    assert provider.destroy_calls == [provider.handle]
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_destroys_provider_resources_on_error_exit():
+    transport = make_transport()
+    provider = FakeProvider(transport)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        async with Sandbox.ephemeral(
+            Image.linux(), name="fleet-demo", provider=provider, telemetry_enabled=False
+        ):
+            raise RuntimeError("boom")
+
+    assert provider.destroy_calls == [provider.handle]
+
+
+@pytest.mark.asyncio
+async def test_provider_creation_gets_generated_name():
+    transport = make_transport()
+    provider = FakeProvider(transport)
+
+    sandbox = await Sandbox.create(Image.linux(), provider=provider, telemetry_enabled=False)
+
+    assert sandbox.name
+    assert provider.create_calls[0][1]["name"] == sandbox.name
+
+@pytest.mark.asyncio
+async def test_connect_failure_deletes_provisioned_resources():
+    transport = make_transport()
+    transport.connect.side_effect = RuntimeError("connect failed")
+    provider = FakeProvider(transport)
+
+    with pytest.raises(RuntimeError, match="connect failed"):
+        await Sandbox.create(
+            Image.linux(), name="fleet-demo", provider=provider, telemetry_enabled=False
+        )
+
+    assert provider.destroy_calls == [provider.handle]

--- a/libs/python/cua-sandbox/tests/test_fleet_sandbox.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_sandbox.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, patch
 
 import pytest
-
 from cua_sandbox import Image, Sandbox
 from cua_sandbox.providers.base import ProvisionedSandbox
 
@@ -34,7 +33,9 @@ async def test_create_uses_explicit_provider_instead_of_cloud_transport():
     transport = make_transport()
     provider = FakeProvider(transport)
 
-    with patch("cua_sandbox.sandbox.CloudTransport", side_effect=AssertionError("unexpected cloud")):
+    with patch(
+        "cua_sandbox.sandbox.CloudTransport", side_effect=AssertionError("unexpected cloud")
+    ):
         sandbox = await Sandbox.create(
             Image.linux(),
             name="fleet-demo",
@@ -122,6 +123,7 @@ async def test_provider_creation_gets_generated_name():
 
     assert sandbox.name
     assert provider.create_calls[0][1]["name"] == sandbox.name
+
 
 @pytest.mark.asyncio
 async def test_connect_failure_deletes_provisioned_resources():

--- a/libs/python/cua-sandbox/tests/test_fleet_transport.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_transport.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import base64
+
+import httpx
+import pytest
+
+from cua_sandbox.transport.fleet import FleetTransport
+
+
+class FakeResponse:
+    def __init__(self, *, status_code=200, text="", payload=None):
+        self.status_code = status_code
+        self.text = text
+        self._payload = payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            request = httpx.Request("GET", "https://cyclops.invalid/test")
+            response = httpx.Response(self.status_code, request=request)
+            raise httpx.HTTPStatusError("failed", request=request, response=response)
+
+    def json(self):
+        return self._payload
+
+
+class FakeServiceClient:
+    def __init__(self):
+        self.calls = []
+        self.responses = []
+        self.closed = False
+
+    def queue(self, response):
+        self.responses.append(response)
+
+    def _response(self):
+        return self.responses.pop(0)
+
+    def post(self, path, **kwargs):
+        self.calls.append(("post", path, kwargs))
+        return self._response()
+
+    def get(self, path, **kwargs):
+        self.calls.append(("get", path, kwargs))
+        return self._response()
+
+    def delete(self, path, **kwargs):
+        self.calls.append(("delete", path, kwargs))
+        return self._response()
+
+    def close(self):
+        self.closed = True
+
+
+class FakeSDK:
+    def __init__(self, client):
+        self.client = client
+        self.calls = []
+
+    def service_client(self, bound, service):
+        self.calls.append((bound, service))
+        return self.client
+
+
+BOUND = {
+    "namespace": "demo",
+    "claim": "claim-demo",
+    "sandbox": "sandbox-demo",
+    "services": ["api"],
+}
+
+
+@pytest.mark.asyncio
+async def test_connect_selects_named_api_service():
+    client = FakeServiceClient()
+    sdk = FakeSDK(client)
+    transport = FleetTransport(sdk=sdk, bound=BOUND, service_name="api")
+
+    await transport.connect()
+
+    assert sdk.calls == [(BOUND, "api")]
+
+
+@pytest.mark.asyncio
+async def test_send_posts_computer_server_command():
+    client = FakeServiceClient()
+    client.queue(FakeResponse(text='data: {"success": true, "result": {"stdout": "ok"}}\n\n'))
+    transport = FleetTransport(sdk=FakeSDK(client), bound=BOUND)
+    await transport.connect()
+
+    result = await transport.send("run_command", command="echo ok", timeout=10)
+
+    assert result == {"stdout": "ok"}
+    method, path, kwargs = client.calls[0]
+    assert (method, path) == ("post", "/cmd")
+    assert kwargs["json"] == {
+        "command": "run_command",
+        "params": {"command": "echo ok", "timeout": 10},
+    }
+    assert isinstance(kwargs["timeout"], httpx.Timeout)
+
+
+@pytest.mark.asyncio
+async def test_screenshot_and_screen_size_use_shared_codec():
+    client = FakeServiceClient()
+    encoded = base64.b64encode(b"png-data").decode()
+    client.queue(FakeResponse(text=f'data: {{"success": true, "image_data": "{encoded}"}}\n\n'))
+    client.queue(
+        FakeResponse(text='data: {"success": true, "result": {"width": 1024, "height": 768}}\n\n')
+    )
+    transport = FleetTransport(sdk=FakeSDK(client), bound=BOUND)
+    await transport.connect()
+
+    assert await transport.screenshot() == b"png-data"
+    assert await transport.get_screen_size() == {"width": 1024, "height": 768}
+
+
+@pytest.mark.asyncio
+async def test_environment_and_pty_routes():
+    client = FakeServiceClient()
+    client.queue(FakeResponse(payload={"os_type": "linux"}))
+    client.queue(FakeResponse(payload={"pid": 42, "cols": 120, "rows": 40}))
+    client.queue(FakeResponse(payload={"ok": True}))
+    client.queue(FakeResponse(payload={"killed": True}))
+    client.queue(FakeResponse(payload={"pid": 42}))
+    transport = FleetTransport(sdk=FakeSDK(client), bound=BOUND)
+    await transport.connect()
+
+    assert await transport.get_environment() == "linux"
+    assert await transport.pty_create(command="bash") == {"pid": 42, "cols": 120, "rows": 40}
+    await transport.pty_send(42, "ls\n")
+    assert await transport.pty_kill(42) is True
+    assert await transport.pty_info(42) == {"pid": 42}
+    assert [(method, path) for method, path, _ in client.calls] == [
+        ("get", "/status"),
+        ("post", "/pty"),
+        ("post", "/pty/42/stdin"),
+        ("delete", "/pty/42"),
+        ("get", "/pty/42"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_disconnect_closes_service_client():
+    client = FakeServiceClient()
+    transport = FleetTransport(sdk=FakeSDK(client), bound=BOUND)
+    await transport.connect()
+
+    await transport.disconnect()
+
+    assert client.closed is True
+
+@pytest.mark.asyncio
+async def test_concurrent_requests_are_serialized_for_shared_sdk_runner():
+    import threading
+    import time
+
+    class ConcurrentClient(FakeServiceClient):
+        def __init__(self):
+            super().__init__()
+            self.active = 0
+            self.max_active = 0
+            self.guard = threading.Lock()
+
+        def post(self, path, **kwargs):
+            with self.guard:
+                self.active += 1
+                self.max_active = max(self.max_active, self.active)
+            time.sleep(0.02)
+            with self.guard:
+                self.active -= 1
+            return FakeResponse(text='data: {"success": true, "result": "ok"}\n\n')
+
+    client = ConcurrentClient()
+    transport = FleetTransport(sdk=FakeSDK(client), bound=BOUND)
+    await transport.connect()
+
+    first, second = await __import__("asyncio").gather(
+        transport.send("first"), transport.send("second")
+    )
+
+    assert (first, second) == ("ok", "ok")
+    assert client.max_active == 1

--- a/libs/python/cua-sandbox/tests/test_fleet_transport.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_transport.py
@@ -4,7 +4,6 @@ import base64
 
 import httpx
 import pytest
-
 from cua_sandbox.transport.fleet import FleetTransport
 
 
@@ -149,6 +148,7 @@ async def test_disconnect_closes_service_client():
     await transport.disconnect()
 
     assert client.closed is True
+
 
 @pytest.mark.asyncio
 async def test_concurrent_requests_are_serialized_for_shared_sdk_runner():


### PR DESCRIPTION
## Summary

- add a `SandboxProvider` lifecycle contract and direct `FleetProvider` backed by an injected `cyclops_sdk.SDK`
- create one `replicas=1` pool, one claim, wait for binding, and delete claim before pool
- add `FleetTransport` that routes the existing computer-server protocol through `sdk.service_client(bound, "api")`
- share computer-server SSE/screenshot/screen-size decoding with `HTTPTransport`
- support explicit providers in `Sandbox.create()` and `Sandbox.ephemeral()` while preserving existing local and CUA Cloud behavior
- document caller-owned SDK lifetime and explicit per-OS Fleet templates

## Design Notes

- Fleet endpoint URLs and OAuth tokens stay encapsulated by `cyclops_sdk`
- synchronous SDK/service calls run through `asyncio.to_thread()`
- calls sharing one Cyclops core runner are serialized to protect its stdin/stdout request protocol
- unsupported Fleet settings fail explicitly: snapshots, image mutations, registry `Image` objects, disk sizing, non-default regions, and custom startup timeouts

## Testing

- `ruff check libs/python/cua-sandbox/cua_sandbox libs/python/cua-sandbox/tests`
- non-live `cua-sandbox` unit suite: **118 passed, 78 skipped**
- package compile/import smoke test, including importing `FleetProvider` without importing or launching `cyclops_sdk`

The full directory also contains host-control/live integration tests that require a graphical host or cloud credentials; those were not treated as local unit verification.
