### PR TITLE
fix(driver): enforce scope for mouse button actions

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-core/src/capture_scope.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/capture_scope.rs
@@ -335,7 +335,7 @@ pub fn enforce_tool(tool_name: &str, args: &Value) -> Result<(), ScopeViolation>
                 && tool_name == "mouse_button_up"
                 && ["pid", "window_id", "x", "y", "from_zoom"]
                     .iter()
-                    .all(|key| args.get(key).is_none()) =>
+                    .all(|key| args.get(key).is_none_or(Value::is_null)) =>
         {
             // Releasing a button held before one-way desktop escalation is
             // cleanup when it cannot retarget or reposition the release.
@@ -534,6 +534,18 @@ mod tests {
             "window_scope_disabled"
         );
         assert!(enforce_tool("mouse_button_up", &json!({"session": session})).is_ok());
+        assert!(enforce_tool(
+            "mouse_button_up",
+            &json!({
+                "session": session,
+                "pid": null,
+                "window_id": null,
+                "x": null,
+                "y": null,
+                "from_zoom": null
+            })
+        )
+        .is_ok());
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/capture_scope.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/capture_scope.rs
@@ -236,6 +236,8 @@ fn is_scoped_action(tool_name: &str) -> bool {
             | "right_click"
             | "scroll"
             | "drag"
+            | "mouse_button_down"
+            | "mouse_button_up"
             | "mouse_drag"
             | "parallel_mouse_drag"
             | "move_cursor"
@@ -328,6 +330,19 @@ pub fn enforce_tool(tool_name: &str, args: &Value) -> Result<(), ScopeViolation>
         (_, ToolScope::Unscoped)
         | (EffectiveCaptureScope::Window, ToolScope::Window)
         | (EffectiveCaptureScope::Desktop, ToolScope::Desktop) => Ok(()),
+        (EffectiveCaptureScope::Desktop, ToolScope::Window)
+            if state.policy == CaptureScopePolicy::Auto
+                && tool_name == "mouse_button_up"
+                && ["pid", "window_id", "x", "y", "from_zoom"]
+                    .iter()
+                    .all(|key| args.get(key).is_none()) =>
+        {
+            // Releasing a button held before one-way desktop escalation is
+            // cleanup when it cannot retarget or reposition the release.
+            // Strict desktop sessions have no window phase and therefore do
+            // not receive this exception.
+            Ok(())
+        }
         (EffectiveCaptureScope::Window, ToolScope::Desktop)
             if state.policy == CaptureScopePolicy::Auto =>
         {
@@ -462,6 +477,63 @@ mod tests {
             .code,
             "window_scope_disabled"
         );
+    }
+
+    #[test]
+    fn mouse_button_actions_respect_strict_scope() {
+        let window = fresh("strict-window-mouse-buttons");
+        let desktop = fresh("strict-desktop-mouse-buttons");
+        bind_session(&window, Some(CaptureScopePolicy::Window)).unwrap();
+        bind_session(&desktop, Some(CaptureScopePolicy::Desktop)).unwrap();
+
+        for tool_name in ["mouse_button_down", "mouse_button_up"] {
+            assert!(enforce_tool(
+                tool_name,
+                &json!({"session": window, "pid": 42, "window_id": 7, "x": 4, "y": 5})
+            )
+            .is_ok());
+            assert_eq!(
+                enforce_tool(
+                    tool_name,
+                    &json!({"session": desktop, "pid": 42, "window_id": 7, "x": 4, "y": 5})
+                )
+                .unwrap_err()
+                .code,
+                "window_scope_disabled"
+            );
+        }
+    }
+
+    #[test]
+    fn auto_escalation_preserves_mouse_button_cleanup() {
+        let session = fresh("auto-mouse-button-cleanup");
+        bind_session(&session, Some(CaptureScopePolicy::Auto)).unwrap();
+        let window_args = json!({"session": session, "pid": 42, "window_id": 7, "x": 4, "y": 5});
+
+        assert!(enforce_tool("mouse_button_down", &window_args).is_ok());
+        escalate_session(&session, EscalationReason::ForegroundIneffective, None).unwrap();
+        assert_eq!(
+            enforce_tool("mouse_button_down", &window_args)
+                .unwrap_err()
+                .code,
+            "window_scope_disabled"
+        );
+        assert_eq!(
+            enforce_tool("mouse_button_up", &window_args)
+                .unwrap_err()
+                .code,
+            "window_scope_disabled"
+        );
+        assert_eq!(
+            enforce_tool(
+                "mouse_button_up",
+                &json!({"session": session, "x": 8, "y": 9})
+            )
+            .unwrap_err()
+            .code,
+            "window_scope_disabled"
+        );
+        assert!(enforce_tool("mouse_button_up", &json!({"session": session})).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`mouse_button_down` and `mouse_button_up` bypass the per-session capture-scope classifier because they are missing from the scoped-action list. Window-targeted button actions can therefore run while a session is restricted to desktop scope.

## Change

- Classify both mouse button primitives with the existing window/desktop action policy.
- Preserve only targetless, positionless `mouse_button_up` cleanup after an auto session escalates to desktop, so a previously held button can be released without allowing another window action.
- Add regressions for strict modes, targeted and positioned release denial, and escalation cleanup.

## Test plan

- `cargo test -p cua-driver-core --locked`
- `cargo fmt --all -- --check`
- `cargo clippy -p cua-driver-core --all-targets --locked`

Closes #2368
