### PR TITLE
fix(release): prevent skipped component releases

### DIFF
--- a/.github/scripts/release_attribution.py
+++ b/.github/scripts/release_attribution.py
@@ -197,7 +197,12 @@ def release_entries(subject: str, commit_body: str, pull_body: str) -> list[Conv
     return [entry for entry in entries if entry.change_type in RELEASING_TYPES]
 
 
-def validate_pr_title(title: str) -> None:
+def validate_pr_title(
+    title: str,
+    *,
+    require_release: bool = False,
+    allow_non_release: bool = False,
+) -> None:
     entry = parse_conventional_line(title)
     if not entry:
         raise ReleaseError(
@@ -208,6 +213,14 @@ def validate_pr_title(title: str) -> None:
         allowed = ", ".join(sorted(ALLOWED_TITLE_TYPES))
         raise ReleaseError(
             f"unsupported pull request type '{entry.change_type}'; use one of: {allowed}"
+        )
+    if require_release and entry.change_type not in RELEASING_TYPES and not allow_non_release:
+        raise ReleaseError(
+            f"pull request type '{entry.change_type}' makes Release Please skip changes to "
+            "release-tracked product files; use 'fix(scope): ...' for a patch, "
+            "'feat(scope): ...' for a minor release, 'feat(scope)!: ...' for a breaking "
+            "release, or add the 'no-release' label when the change is intentionally "
+            "non-releasing"
         )
 
 
@@ -769,6 +782,8 @@ def build_parser() -> argparse.ArgumentParser:
 
     validate = subparsers.add_parser("validate-title")
     validate.add_argument("--title", required=True)
+    validate.add_argument("--require-release", action="store_true")
+    validate.add_argument("--allow-non-release", action="store_true")
 
     collect = subparsers.add_parser("collect")
     collect.add_argument("--repo-root", type=Path, default=Path.cwd())
@@ -805,7 +820,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         if args.command == "validate-title":
-            validate_pr_title(args.title)
+            validate_pr_title(
+                args.title,
+                require_release=args.require_release,
+                allow_non_release=args.allow_non_release,
+            )
             print("release title is valid")
         elif args.command == "collect":
             collect_command(args)

--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -85,6 +85,10 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertNotIn("    paths:", trigger)
         self.assertIn("Determine product release scope", workflow)
         self.assertIn("if: steps.scope.outputs.product_changed == 'true'", workflow)
+        self.assertIn("--require-release", workflow)
+        self.assertIn('index("no-release") != null', workflow)
+        self.assertIn('"$HEAD_REF" == release-please--branches--*', workflow)
+        self.assertIn("labeled, unlabeled", workflow)
 
     def test_legacy_release_routes_exclude_driver_and_lume(self) -> None:
         workflow = self.read(".github/workflows/release-bump-version.yml")

--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -90,6 +90,14 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertIn('"$HEAD_REF" == release-please--branches--*', workflow)
         self.assertIn("labeled, unlabeled", workflow)
 
+    def test_agent_and_human_guidance_explain_the_release_title_contract(self) -> None:
+        for path in ("AGENTS.md", "CONTRIBUTING.md"):
+            guide = self.read(path)
+            self.assertIn("fix(cua-driver):", guide, path)
+            self.assertIn("feat(lume):", guide, path)
+            self.assertIn("no-release", guide, path)
+            self.assertIn("squash", guide, path)
+
     def test_legacy_release_routes_exclude_driver_and_lume(self) -> None:
         workflow = self.read(".github/workflows/release-bump-version.yml")
         self.assertIn('name: "Legacy packages: Bump Version"', workflow)

--- a/.github/scripts/tests/test_release_attribution.py
+++ b/.github/scripts/tests/test_release_attribution.py
@@ -92,6 +92,28 @@ def test_title_validation_and_override_entries():
     )
 
 
+def test_release_tracked_changes_require_a_releasing_title_or_explicit_opt_out():
+    for title in (
+        "fix(cua-driver): preserve browser attachment",
+        "feat(lume): add resumable pulls",
+        "perf(cua-driver): reduce snapshot latency",
+        "revert(lume): restore prior network setup",
+    ):
+        validate_pr_title(title, require_release=True)
+
+    with pytest.raises(ReleaseError, match="makes Release Please skip"):
+        validate_pr_title(
+            "test(cua-driver): harden browser certification",
+            require_release=True,
+        )
+
+    validate_pr_title(
+        "style(cua-driver): apply deterministic formatting",
+        require_release=True,
+        allow_non_release=True,
+    )
+
+
 def test_login_from_noreply_and_override():
     assert login_from_email("123+octo-user@users.noreply.github.com", {}) == "octo-user"
     assert (

--- a/.github/workflows/ci-release-metadata.yml
+++ b/.github/workflows/ci-release-metadata.yml
@@ -2,7 +2,7 @@ name: "CI: Release metadata"
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -47,10 +47,22 @@ jobs:
       - name: Validate squash-release title
         if: steps.scope.outputs.product_changed == 'true'
         env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
           PR_TITLE: ${{ github.event.pull_request.title }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          python3 .github/scripts/release_attribution.py validate-title \
-            --title "$PR_TITLE"
+          set -euo pipefail
+          ARGS=(validate-title --title "$PR_TITLE" --require-release)
+          if jq -e 'index("no-release") != null' <<<"$PR_LABELS" >/dev/null; then
+            ARGS+=(--allow-non-release)
+          fi
+          if [[ "$HEAD_REPOSITORY" == "$REPOSITORY" && \
+                "$HEAD_REF" == release-please--branches--* ]]; then
+            ARGS+=(--allow-non-release)
+          fi
+          python3 .github/scripts/release_attribution.py "${ARGS[@]}"
 
       - name: Validate checked-in release versions
         run: python3 .github/scripts/validate_release_versions.py --product all

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,3 +16,28 @@ Preserve contributor credit when external code or design ships in Cua.
   disclosure is permitted.
 
 Do not reimplement submitted work solely to remove its authorship history.
+
+## Pull request titles and component releases
+
+Pull requests are squash-merged, so the pull request title becomes the commit
+subject on `main`. Release Please uses that subject to decide whether Cua Driver
+or Lume receives a release. Treat the live pull request title as release
+metadata, not as a cosmetic summary.
+
+- Use `fix(cua-driver): ...` or `fix(lume): ...` for user-visible corrections
+  that require a patch release.
+- Use `feat(cua-driver): ...` or `feat(lume): ...` for new capabilities that
+  require a minor release. Add `!` before `:` for a breaking release.
+- `perf` and `revert` also produce releases. `test`, `docs`, `chore`, `ci`,
+  `build`, `refactor`, and `style` do not.
+- If release-tracked product files changed but the work is intentionally
+  non-releasing, keep the accurate non-releasing type and add the `no-release`
+  label. Do not use that label to hide a user-visible change.
+- A pull request that mixes tests with production behavior must be titled for
+  the production behavior. For example, browser fixes plus certification tests
+  use `fix(cua-driver): ...`, not `test(cua-driver): ...`.
+
+Before declaring a pull request ready or merging it, inspect its final changed
+files and query its current GitHub title. Correct the title yourself when the
+scope or release impact changed during implementation, and wait for
+`CI: Release metadata` to pass. Do not leave title correction for a maintainer.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,11 +33,17 @@ workarounds when known.
 6. Open a focused pull request that explains behavior, validation, and known gaps.
 
 Use a Conventional Commit title because the squash-merge title becomes the
-release entry. `fix(driver): preserve input while reconnecting` produces a
+release entry. `fix(cua-driver): preserve input while reconnecting` produces a
 patch release, `feat(lume): add a VM readiness probe` produces a minor release,
-and `feat(driver)!: remove the legacy event endpoint` marks a breaking change.
-Use `docs`, `test`, `ci`, or `chore` when the pull request has no user-facing
-release entry.
+and `feat(cua-driver)!: remove the legacy event endpoint` marks a breaking
+change. `perf` and `revert` also produce releases.
+
+Use `docs`, `test`, `ci`, `chore`, `build`, `refactor`, or `style` only when the
+pull request has no user-facing release entry. A pull request that adds tests
+while changing production behavior must be titled for the production change,
+not the tests. If release-tracked Cua Driver or Lume files changed but the work
+is intentionally non-releasing, add the `no-release` label. The
+`CI: Release metadata` check enforces this contract before squash merge.
 
 ## Preserve Contributor Authorship
 


### PR DESCRIPTION
## Summary

- require release-producing Conventional Commit titles when a PR changes release-tracked Cua Driver or Lume files
- allow an explicit `no-release` opt-out for genuinely non-releasing formatting, refactor, test, or build work
- exempt trusted generated Release Please branches and rerun the guard when labels change
- document the squash-title release contract for agents in root `AGENTS.md` and for humans in `CONTRIBUTING.md`

## Why

Release Please reads the squash commit subject on `main`. A PR containing production browser changes was merged with a `test(cua-driver): ...` title, so the automatic release workflow correctly treated the commit as non-releasing. An explicit version override could not create a candidate because there was no release-producing commit.

This change makes that mismatch fail before merge. CI does not guess whether a change is a feature or fix; the author or agent must select the correct semantic title, with `no-release` available only as an explicit opt-out.

This prevents future skipped releases but does not itself retroactively publish the pending Cua Driver 0.9.1 release. That release will be prepared separately with PR #2367 retained as source evidence.

## Validation

- `uv run --with pytest --with jsonschema --with pyyaml pytest .github/scripts/tests -q` (89 passed)
- direct regression check rejects `test(cua-driver): harden cross-platform browser certification` with `--require-release`
- corrected `fix(cua-driver): ...` and explicit non-release paths pass
- `python3 .github/scripts/validate_release_versions.py --product all`
- parsed `.github/workflows/ci-release-metadata.yml` with PyYAML and verified all PR event types
- `git diff --check`
