### PR TITLE
fix(release): honor merged PR changelog overrides

### DIFF
--- a/.github/scripts/release_attribution.py
+++ b/.github/scripts/release_attribution.py
@@ -279,7 +279,9 @@ def resolve_pull_for_commit(
     github: GitHubClient,
     repository: str,
     commit: CommitRecord,
-) -> Mapping[str, Any]:
+    *,
+    required: bool = True,
+) -> Mapping[str, Any] | None:
     """Resolve a commit to its merged PR, including an exact squash-title fallback."""
     pulls = github.pulls_for_commit(repository, commit.sha)
     if pulls:
@@ -288,6 +290,8 @@ def resolve_pull_for_commit(
 
     reference = TRAILING_PR_RE.search(commit.subject)
     if not reference:
+        if not required:
+            return None
         raise ReleaseError(f"commit {commit.sha} is not associated with a pull request")
 
     pull = github.pull(repository, int(reference.group("number")))
@@ -493,12 +497,22 @@ def build_manifest(
         ) or LEGACY_RELEASE_BUMP_RE.match(commit.subject):
             continue
         parsed_subject = parse_conventional_line(commit.subject)
-        if parsed_subject and parsed_subject.change_type not in RELEASING_TYPES:
+        subject_is_releasing = bool(
+            parsed_subject and parsed_subject.change_type in RELEASING_TYPES
+        )
+        pull = resolve_pull_for_commit(
+            github,
+            repository,
+            commit,
+            required=subject_is_releasing,
+        )
+        if pull is None:
             continue
-
-        pull = resolve_pull_for_commit(github, repository, commit)
+        pull_body = str(pull.get("body") or "")
+        if not subject_is_releasing and not OVERRIDE_RE.search(pull_body):
+            continue
         pull_number = int(pull["number"])
-        entries = release_entries(commit.subject, commit.body, str(pull.get("body") or ""))
+        entries = release_entries(commit.subject, commit.body, pull_body)
         if not entries:
             continue
         contributors, issues, pull_visual = _change_contributors(

--- a/.github/scripts/tests/test_release_attribution.py
+++ b/.github/scripts/tests/test_release_attribution.py
@@ -161,6 +161,93 @@ def test_exact_squash_title_resolves_when_commit_association_is_missing():
             "trycua/cua",
             CommitRecord("def456", "feat(driver): no pull suffix", ""),
         )
+    assert (
+        resolve_pull_for_commit(
+            UnassociatedGitHub(),
+            "trycua/cua",
+            CommitRecord("def456", "test(driver): no pull suffix", ""),
+            required=False,
+        )
+        is None
+    )
+
+
+def test_merged_pr_override_recovers_a_non_releasing_squash_title(tmp_path: Path):
+    git(tmp_path, "init")
+    git(tmp_path, "config", "user.name", "Release Test")
+    git(tmp_path, "config", "user.email", "release@example.com")
+    product = tmp_path / "libs/cua-driver/rust"
+    product.mkdir(parents=True)
+    (product / "CHANGELOG.md").write_text("# Changelog\n")
+    (product / "driver.txt").write_text("initial\n")
+    git(tmp_path, "add", ".")
+    git(tmp_path, "commit", "-m", "chore: seed fixture")
+    git(tmp_path, "tag", "cua-driver-rs-v0.9.0")
+
+    (product / "driver.txt").write_text("hardened\n")
+    (product / "CHANGELOG.md").write_text(
+        "# Changelog\n\n"
+        "## [0.9.1] (2026-07-20)\n\n"
+        "* harden exact-profile browser attachment (#2367)\n"
+    )
+    git(tmp_path, "add", ".")
+    git(tmp_path, "commit", "-m", "test(cua-driver): harden browser certification (#2367)")
+    release_sha = git(tmp_path, "rev-parse", "HEAD")
+    git(tmp_path, "tag", "cua-driver-rs-v0.9.1")
+
+    class OverrideGitHub:
+        def pulls_for_commit(self, repository: str, commit_sha: str):
+            assert repository == "trycua/cua"
+            assert commit_sha == release_sha
+            return [{"number": 2367, "merge_commit_sha": commit_sha, "merged_at": "now"}]
+
+        def pull(self, repository: str, number: int):
+            assert repository == "trycua/cua"
+            assert number == 2367
+            return {
+                "number": 2367,
+                "user": {"login": "browser-author"},
+                "author_association": "MEMBER",
+                "body": (
+                    "BEGIN_COMMIT_OVERRIDE\n"
+                    "fix(cua-driver): harden exact-profile browser attachment\n\n"
+                    "fix(cua-driver): fail closed for unsupported browser routes\n"
+                    "END_COMMIT_OVERRIDE"
+                ),
+                "labels": [],
+            }
+
+        def issue(self, repository: str, number: int):
+            raise AssertionError("the override fixture does not reference issues")
+
+    manifest = build_manifest(
+        repo_root=tmp_path,
+        repository="trycua/cua",
+        product="cua-driver-rs",
+        display_name="Cua Driver",
+        version="0.9.1",
+        tag="cua-driver-rs-v0.9.1",
+        previous_tag="cua-driver-rs-v0.9.0",
+        expected_sha=release_sha,
+        paths=("libs/cua-driver",),
+        changelog_path=product / "CHANGELOG.md",
+        attribution_config={
+            "bots": [],
+            "coauthorOverrides": {},
+            "ignoredCoauthorEmails": [],
+            "identityOverrides": {},
+            "internalHandles": ["browser-author"],
+            "optOutHandles": [],
+        },
+        github=OverrideGitHub(),
+    )
+
+    assert [
+        (change["type"], change["summary"], change["pr"]) for change in manifest["changes"]
+    ] == [
+        ("fix", "harden exact-profile browser attachment", 2367),
+        ("fix", "fail closed for unsupported browser routes", 2367),
+    ]
 
 
 def test_legacy_release_bump_subject_is_recognized():


### PR DESCRIPTION
## Summary

- inspect an associated merged pull request for `BEGIN_COMMIT_OVERRIDE` before discarding a non-releasing squash title
- retain the existing fail-closed attribution requirement for release-producing commits
- continue ignoring direct, unassociated non-release commits
- prove that a merged `test(cua-driver)` PR can recover multiple `fix(cua-driver)` entries with its original PR number and author

## Why

PR #2367 contained production browser hardening but was squash-merged with a `test(cua-driver): ...` title. Release Please officially supports correcting that case through a commit override in the merged PR body. Our attribution collector had a premature type filter that made the supported recovery path unusable.

PR #2367 now contains three corrective patch entries in its merged body. Once this compatibility fix lands, Release Please can prepare Cua Driver 0.9.1 while retaining #2367 as the source pull request.

## Validation

- `uv run --with pytest --with jsonschema --with pyyaml pytest .github/scripts/tests -q` (90 passed)
- `uv run --with ruff ruff format --check ...`
- `uv run --with ruff ruff check ...`
- `python3 .github/scripts/validate_release_versions.py --product all`
- `git diff --check`
