### PR TITLE
fix(cua-driver): register bundle in LaunchServices before tccutil reset (both installers)

### DIFF
--- a/libs/cua-driver/scripts/_install-local-rust.sh
+++ b/libs/cua-driver/scripts/_install-local-rust.sh
@@ -489,6 +489,20 @@ if [ "$OS" = "Darwin" ]; then
     fi
     echo "${GREEN}installed $APP_DEST${NORMAL}"
 
+    # --- Force LaunchServices registration of the freshly-copied bundle ----
+    #
+    # `ditto` drops the bundle on disk, but LaunchServices registers the new
+    # com.trycua.driver identity ASYNCHRONOUSLY (seconds later). Until it does,
+    # `tccutil reset com.trycua.driver` fails with -10814 ("No such bundle
+    # identifier") and the stale-grant reset below silently no-ops, and
+    # `open -n -g -a CuaDriver` (what `permissions grant` / the MCP proxy use to
+    # launch the daemon) fails with -1728. A synchronous `lsregister -f` closes
+    # that race so both the reset and the first launch resolve the bundle id.
+    LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister"
+    if [ -x "$LSREGISTER" ]; then
+        "$LSREGISTER" -f "$APP_DEST" >/dev/null 2>&1 || true
+    fi
+
     # --- Clear a TCC grant pinned to a PREVIOUS signing identity -----------
     #
     # TCC pins each Accessibility / Screen-Recording grant to the app's

--- a/libs/cua-driver/scripts/uninstall.sh
+++ b/libs/cua-driver/scripts/uninstall.sh
@@ -125,6 +125,21 @@ maybe_reset_tcc() {
         log "TCC reset: tccutil not found; skipping"
         return 0
     fi
+    # `tccutil reset <svc> com.trycua.driver` resolves the bundle id through
+    # LaunchServices. If the bundle isn't registered — or this runs AFTER the
+    # app was removed — tccutil fails with -10814 and the grant silently
+    # survives. This MUST run while /Applications/CuaDriver.app still exists;
+    # force a synchronous LaunchServices registration first so a present-but-
+    # not-yet-registered bundle (fresh install race) still resolves.
+    local app_bundle="/Applications/CuaDriver.app"
+    if [[ -d "$app_bundle" ]]; then
+        local lsregister="/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister"
+        if [[ -x "$lsregister" ]]; then
+            "$lsregister" -f "$app_bundle" >/dev/null 2>&1 || true
+        fi
+    else
+        log "  warning: CuaDriver.app already removed; TCC reset may not resolve the bundle id"
+    fi
     log "revoking TCC grants for com.trycua.driver"
     log "  note: com.trycua.driver is shared with the retired Swift driver;"
     log "  this clears grants for both. Pass --keep-tcc to preserve them."
@@ -293,6 +308,13 @@ if [[ "$USE_RUST_BACKEND" == "1" ]]; then
             log "no current or legacy LaunchAgent found (skipping)"
         fi
     fi
+
+    # --- Revoke TCC grants BEFORE removing the app ---
+    # tccutil resolves com.trycua.driver through LaunchServices, so the reset
+    # only works while /Applications/CuaDriver.app is still installed. Running
+    # it here (not at the closing message) is what makes the revoke actually
+    # take — otherwise it fails with -10814 and the grant silently survives.
+    maybe_reset_tcc
 
     # --- .app bundle (macOS only) ---
     # Legacy /Applications/CuaDriverRs.app is unambiguously Rust and
@@ -560,7 +582,8 @@ PY
     fi
 
     # --- Closing message ---
-    maybe_reset_tcc
+    # TCC grants were already revoked above, before the app was removed, so
+    # the reset could still resolve the bundle id through LaunchServices.
     if [[ "$OS" == "Darwin" ]]; then
         echo ""
         echo "cua-driver uninstalled."


### PR DESCRIPTION
## Problem

Both installers revoke TCC grants for `com.trycua.driver` with `tccutil reset <service> com.trycua.driver`, which resolves the bundle id through LaunchServices. Two races made the reset silently fail with `-10814` ("No such bundle identifier"), leaving a stale, identity-mismatched grant — the dead-end where the daemon reads "not granted" while System Settings shows the toggle ON.

1. **install-local** — `ditto` drops the bundle on disk, but LaunchServices registers the new identity asynchronously (seconds later). The `tccutil reset` (and the following `open -n -g -a CuaDriver` used by `permissions grant` / the MCP proxy, which fails `-1728`) fired before registration completed.
2. **uninstall.sh** — the TCC revoke ran at the closing message, *after* the app bundle was already `rm -rf`'d, so the bundle id no longer resolved at all. The `"Accessibility: nothing to reset (or reset failed)"` output was masking a real failure.

## Fix

- **install-local** (`_install-local-rust.sh`): force `lsregister -f "$APP_DEST"` immediately after the copy, before the stale-grant reset.
- **uninstall.sh**: move `maybe_reset_tcc` to run **before** the app bundle is removed; force `lsregister -f` inside it so a present-but-unregistered bundle still resolves; print an honest warning when the app is already gone.

## Verification (macOS)

Reproduced both `-10814` / `-1728` failures live. Forcing `lsregister -f` makes `tccutil reset com.trycua.driver` succeed and `open -a CuaDriver` resolve where both previously silently failed; the stale Accessibility row is then actually cleared.

## Related

Follow-up to #2360 (release↔local TCC identity transitions) — same class of dead-end, different trigger (LaunchServices registration timing rather than designated-requirement mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EevS5zmbQWpo7q1voWa5KH