### PR TITLE
fix(cua-driver): bound tool telemetry volume

### DIFF
--- a/docs/content/docs/reference/cua-driver/telemetry.mdx
+++ b/docs/content/docs/reference/cua-driver/telemetry.mdx
@@ -177,6 +177,8 @@ Routine telemetry excludes task text, prompts, tool arguments, tool response bod
 
 Tool-completion events retain only coarse result shape: text, image, mixed, empty, or unknown; a size bucket; a duration bucket; a fixed error class; and, for reviewed structured browser refusals, the fixed code above. The content itself never crosses the telemetry observer boundary. A proxy and daemon negotiate one completion-event owner. Mixed-version pairs retain proxy ownership, which prevents duplicate events during upgrades.
 
+To bound client and ingestion load, each Cua Driver process emits at most 1,000 routine tool-completion events in an hour. If that ceiling is reached before a successful computer action, the process may emit that first value event as well. Lifecycle, permissions, and aggregate session events are not subject to this ceiling.
+
 A CLI `call` is always delegated to the daemon. The daemon owns the completion event and reports `transport=daemon`, so the event is emitted only once.
 
 ## Region and deletion controls

--- a/libs/cua-driver/rust/crates/cua-driver/src/telemetry.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/telemetry.rs
@@ -20,12 +20,14 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const POSTHOG_CAPTURE_URL: &str = "https://eu.i.posthog.com/capture/";
 const POSTHOG_API_KEY: &str = "phc_eSkLnbLxsnYFaXksif1ksbrNzYlJShr35miFLDppF14";
 const POSTHOG_TIMEOUT_SECS: u64 = 3;
 const LIFECYCLE_RETRY_BACKOFF_SECS: u64 = 15 * 60;
+const TOOL_TELEMETRY_LIMIT_PER_HOUR: usize = 1_000;
+const TOOL_TELEMETRY_WINDOW: Duration = Duration::from_secs(60 * 60);
 
 const HOME_SUBDIRECTORY: &str = ".cua-driver";
 const LEGACY_HOME_SUBDIRECTORY: &str = ".cua-driver-rs";
@@ -787,12 +789,62 @@ pub(crate) fn capture_tool_completed(
     outcome: cua_driver_core::server::ToolCompletionObservation,
     transport: Transport,
 ) {
+    let is_first_value_candidate =
+        outcome.computer_action && outcome.success && !outcome.refusal_code.is_refusal();
+    if !is_enabled() || !should_capture_tool_completion(Instant::now(), is_first_value_candidate) {
+        return;
+    }
     let mut properties = tool_completion_properties(outcome);
     properties.insert(
         "execution_mode".into(),
         Value::String(execution_mode().into()),
     );
     capture_bounded(event::MCP_TOOL_COMPLETED, properties, transport);
+}
+
+#[derive(Debug)]
+struct ToolTelemetryRateLimit {
+    window_started: Instant,
+    captured: usize,
+    captured_value_event: bool,
+}
+
+impl ToolTelemetryRateLimit {
+    fn new(now: Instant) -> Self {
+        Self {
+            window_started: now,
+            captured: 0,
+            captured_value_event: false,
+        }
+    }
+
+    fn allow(&mut self, now: Instant, is_value_event: bool) -> bool {
+        if now.duration_since(self.window_started) >= TOOL_TELEMETRY_WINDOW {
+            self.window_started = now;
+            self.captured = 0;
+            self.captured_value_event = false;
+        }
+        if self.captured >= TOOL_TELEMETRY_LIMIT_PER_HOUR {
+            if !is_value_event || self.captured_value_event {
+                return false;
+            }
+            self.captured_value_event = true;
+            return true;
+        }
+        self.captured += 1;
+        self.captured_value_event |= is_value_event;
+        true
+    }
+}
+
+static TOOL_TELEMETRY_RATE_LIMIT: OnceLock<Mutex<ToolTelemetryRateLimit>> = OnceLock::new();
+
+fn should_capture_tool_completion(now: Instant, is_value_event: bool) -> bool {
+    TOOL_TELEMETRY_RATE_LIMIT
+        .get_or_init(|| Mutex::new(ToolTelemetryRateLimit::new(now)))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .allow(now, is_value_event)
 }
 
 fn tool_completion_properties(
@@ -3061,6 +3113,20 @@ mod tests {
                 .contains_key(session_id));
             assert!(read_install_id().is_none());
         });
+    }
+
+    #[test]
+    fn tool_completion_rate_limit_resets_after_one_hour() {
+        let started = Instant::now();
+        let mut limit = ToolTelemetryRateLimit::new(started);
+
+        for _ in 0..TOOL_TELEMETRY_LIMIT_PER_HOUR {
+            assert!(limit.allow(started, false));
+        }
+        assert!(!limit.allow(started, false));
+        assert!(limit.allow(started, true));
+        assert!(!limit.allow(started, true));
+        assert!(limit.allow(started + TOOL_TELEMETRY_WINDOW, false));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- cap routine tool-completion telemetry per process and hour
- preserve the first successful computer action even when a high-volume process reaches the ceiling
- document the volume boundary and add reset/activation-preservation regression coverage

## Why

Tool-completion capture previously had no volume ceiling. A tight automation loop could generate excessive client requests and disproportionate ingestion while adding little value to installation-based product metrics.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p cua-driver telemetry --locked` (38 telemetry tests)