### PR TITLE
feat(cua-driver): track update funnel telemetry

### DIFF
--- a/docs/content/docs/reference/cua-driver/telemetry.mdx
+++ b/docs/content/docs/reference/cua-driver/telemetry.mdx
@@ -89,6 +89,9 @@ The client does not send an IP address as an event property. PostHog derives a c
 | `cua_driver_permissions_gate_started`    | missing-permission booleans                                                                                                                                  |
 | `cua_driver_permissions_gate_dismissed`  | missing-permission booleans and duration bucket                                                                                                              |
 | `cua_driver_permissions_gate_completed`  | missing-permission booleans, panel and dismissal flags, fixed resolution, and duration bucket                                                               |
+| `cua_driver_update_checked`              | fixed source and outcome, strict public target release version or `unknown`, and cache-hit flag                                                              |
+| `cua_driver_update_apply_started`        | strict public target release version and whether a daemon was running                                                                                        |
+| `cua_driver_update_apply_completed`      | strict public target release version or `unknown`, fixed outcome and failure class, prior daemon state, and duration bucket                                   |
 
 The transitional `cua_driver_serve` event carries the common event properties and no additional properties. It does not contain command arguments or process output.
 
@@ -130,6 +133,14 @@ The end event includes `used_browser` and a bounded `browser_refusal_count_bucke
 Per-call `computer_action` is derived from the same fixed classifier used by the session aggregate. It describes the tool category; combine it with `success=true` when measuring value. Cua-owned automated tests can set `CUA_DRIVER_TELEMETRY_SYNTHETIC=true`. This marks every event from that process with `is_synthetic=true` so product metrics can exclude test traffic without relying on installation IDs. Third-party CI remains independently identified by `is_ci`.
 
 For finite CLI commands, `operation` distinguishes only reviewed verbs for recording, permissions, config, autostart, skills, and update. `client_kind` is populated only for `mcp-config`. Unknown values become `other`; commands without a meaningful sub-operation use `not_applicable`.
+
+## Update funnel
+
+Explicit CLI and MCP update checks emit `cua_driver_update_checked`. Its `source` is `cli` or `mcp`; its `outcome` is `up_to_date`, `available`, or `unavailable`. Background checks emit only `available` on the freshness-bounded network path, rather than on every startup. Cached startup banners do not emit another event.
+
+`cua-driver update --apply` emits `cua_driver_update_apply_started` immediately before launching the canonical installer and `cua_driver_update_apply_completed` after the attempt. Completion outcomes are `installed`, `already_current`, or `failed`. Failure classes are limited to `none`, `check_failed`, `installer_exit`, or `installer_launch`; raw errors and exit codes are not collected.
+
+The common `product_version` is the version that initiated the check or update. `target_version` is accepted only when it is a strict public SemVer value. The existing `cua_driver_release_installed` event with `install_channel=update_apply` independently confirms that the new binary recorded the installed release. Together these events support the funnel from update availability through apply and first use of the installed release.
 
 For the compound `page` tool, `operation` is one of `execute_javascript`, `get_text`, `query_dom`, `click_element`, `insert_text`, `type_keystrokes`, `enable_javascript_apple_events`, or `other`.
 

--- a/libs/cua-driver/rust/crates/cua-driver/src/check_update_tool.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/check_update_tool.rs
@@ -63,6 +63,10 @@ impl Tool for CheckForUpdateTool {
         let state = tokio::task::spawn_blocking(|| crate::version_check::check_update_state(false))
             .await
             .expect("version_check::check_update_state never panics");
+        crate::version_check::capture_update_state(
+            &state,
+            crate::telemetry::UpdateCheckSource::Mcp,
+        );
 
         let summary = if let Some(err) = &state.error {
             format!("Update check failed: {err}")

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -2113,6 +2113,8 @@ fn run_recording_render(args: &[String]) {
 /// installer script — see [`crate::updater`] for why we go through the script
 /// instead of re-implementing the asset resolution + atomic swap + GC in Rust.
 pub fn run_update_cmd(apply: bool, json: bool) {
+    let apply_started_at = std::time::Instant::now();
+    let daemon_was_running = apply && crate::updater::daemon_is_running();
     // `--json` short-circuits the text path entirely so scripted callers
     // get a parseable payload regardless of `--apply`. The check itself
     // routes through the same `check_update_state` the `check-update`
@@ -2126,6 +2128,10 @@ pub fn run_update_cmd(apply: bool, json: bool) {
         // pre-install snapshot. Returning here when apply is false keeps
         // the existing "check + suggest" behaviour off the JSON path.
         if !apply {
+            crate::version_check::capture_update_state(
+                &state,
+                crate::telemetry::UpdateCheckSource::Cli,
+            );
             return;
         }
     }
@@ -2139,6 +2145,21 @@ pub fn run_update_cmd(apply: bool, json: bool) {
     let latest = crate::version_check::fetch_latest_version();
     match latest {
         Err(e) => {
+            crate::telemetry::capture_update_checked(
+                crate::telemetry::UpdateCheckSource::Cli,
+                crate::telemetry::UpdateCheckOutcome::Unavailable,
+                None,
+                false,
+            );
+            if apply {
+                crate::telemetry::capture_update_apply_completed(
+                    None,
+                    crate::telemetry::UpdateApplyOutcome::Failed,
+                    crate::telemetry::UpdateFailureClass::CheckFailed,
+                    daemon_was_running,
+                    apply_started_at.elapsed(),
+                );
+            }
             // The shared helper returns a human-readable error string for
             // the CLI surface — pass it through so the user can see why
             // (timeout, parse error, etc.) instead of just "unreachable".
@@ -2149,11 +2170,32 @@ pub fn run_update_cmd(apply: bool, json: bool) {
             process::exit(1);
         }
         Ok(v) if !crate::version_check::is_newer(&v, current) => {
+            crate::telemetry::capture_update_checked(
+                crate::telemetry::UpdateCheckSource::Cli,
+                crate::telemetry::UpdateCheckOutcome::UpToDate,
+                Some(&v),
+                false,
+            );
+            if apply {
+                crate::telemetry::capture_update_apply_completed(
+                    Some(&v),
+                    crate::telemetry::UpdateApplyOutcome::AlreadyCurrent,
+                    crate::telemetry::UpdateFailureClass::None,
+                    daemon_was_running,
+                    apply_started_at.elapsed(),
+                );
+            }
             if !json {
                 println!("Already up to date.");
             }
         }
         Ok(v) => {
+            crate::telemetry::capture_update_checked(
+                crate::telemetry::UpdateCheckSource::Cli,
+                crate::telemetry::UpdateCheckOutcome::Available,
+                Some(&v),
+                false,
+            );
             if !json {
                 println!("New version available: {v}");
             }
@@ -2173,9 +2215,16 @@ pub fn run_update_cmd(apply: bool, json: bool) {
             if !json {
                 println!("Downloading and installing cua-driver {v}…");
             }
-            let daemon_was_running = crate::updater::daemon_is_running();
+            crate::telemetry::capture_update_apply_started(&v, daemon_was_running);
             match crate::updater::run_install_script(&v) {
                 Ok(s) if s.success() => {
+                    crate::telemetry::capture_update_apply_completed(
+                        Some(&v),
+                        crate::telemetry::UpdateApplyOutcome::Installed,
+                        crate::telemetry::UpdateFailureClass::None,
+                        daemon_was_running,
+                        apply_started_at.elapsed(),
+                    );
                     if !json {
                         println!("Installed cua-driver {v}.");
                     }
@@ -2189,6 +2238,13 @@ pub fn run_update_cmd(apply: bool, json: bool) {
                     }
                 }
                 Ok(s) => {
+                    crate::telemetry::capture_update_apply_completed(
+                        Some(&v),
+                        crate::telemetry::UpdateApplyOutcome::Failed,
+                        crate::telemetry::UpdateFailureClass::InstallerExit,
+                        daemon_was_running,
+                        apply_started_at.elapsed(),
+                    );
                     eprintln!(
                         "Installation failed (exit {}). Re-run install manually:",
                         s.code().unwrap_or(1)
@@ -2197,6 +2253,13 @@ pub fn run_update_cmd(apply: bool, json: bool) {
                     process::exit(s.code().unwrap_or(1));
                 }
                 Err(e) => {
+                    crate::telemetry::capture_update_apply_completed(
+                        Some(&v),
+                        crate::telemetry::UpdateApplyOutcome::Failed,
+                        crate::telemetry::UpdateFailureClass::InstallerLaunch,
+                        daemon_was_running,
+                        apply_started_at.elapsed(),
+                    );
                     eprintln!("Failed to launch installer: {e}");
                     #[cfg(windows)]
                     eprintln!("  (is powershell.exe on PATH?)");
@@ -2449,6 +2512,7 @@ fn run_permissions_grant() {
 /// the payload.
 pub fn run_check_update_cmd(json: bool, no_cache: bool) {
     let state = crate::version_check::check_update_state(no_cache);
+    crate::version_check::capture_update_state(&state, crate::telemetry::UpdateCheckSource::Cli);
 
     if json {
         let val = serde_json::to_value(&state).unwrap_or_else(|_| serde_json::json!({}));

--- a/libs/cua-driver/rust/crates/cua-driver/src/main.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/main.rs
@@ -274,6 +274,9 @@ fn main() {
     if telemetry::run_lifecycle_worker_if_requested() {
         return;
     }
+    if telemetry::run_update_event_worker_if_requested() {
+        return;
+    }
     maybe_wrap_finite_command();
 
     // ── CLI subcommand dispatch ──────────────────────────────────────────────
@@ -650,6 +653,9 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
     if telemetry::run_lifecycle_worker_if_requested() {
+        return Ok(());
+    }
+    if telemetry::run_update_event_worker_if_requested() {
         return Ok(());
     }
     maybe_wrap_finite_command();

--- a/libs/cua-driver/rust/crates/cua-driver/src/telemetry.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/telemetry.rs
@@ -56,6 +56,15 @@ const ENV_CLI_COMPLETION_CLIENT_KIND: &str = "CUA_DRIVER_CLI_TELEMETRY_CLIENT_KI
 const ENV_CLI_COMPLETION_EXIT_CODE: &str = "CUA_DRIVER_CLI_TELEMETRY_EXIT_CODE";
 const ENV_CLI_COMPLETION_DURATION_MS: &str = "CUA_DRIVER_CLI_TELEMETRY_DURATION_MS";
 const ENV_LIFECYCLE_WORKER: &str = "CUA_DRIVER_LIFECYCLE_TELEMETRY_WORKER";
+const ENV_UPDATE_EVENT_WORKER: &str = "CUA_DRIVER_UPDATE_TELEMETRY_WORKER";
+const ENV_UPDATE_EVENT_NAME: &str = "CUA_DRIVER_UPDATE_TELEMETRY_EVENT";
+const ENV_UPDATE_SOURCE: &str = "CUA_DRIVER_UPDATE_TELEMETRY_SOURCE";
+const ENV_UPDATE_OUTCOME: &str = "CUA_DRIVER_UPDATE_TELEMETRY_OUTCOME";
+const ENV_UPDATE_TARGET_VERSION: &str = "CUA_DRIVER_UPDATE_TELEMETRY_TARGET_VERSION";
+const ENV_UPDATE_CACHE_HIT: &str = "CUA_DRIVER_UPDATE_TELEMETRY_CACHE_HIT";
+const ENV_UPDATE_DAEMON_WAS_RUNNING: &str = "CUA_DRIVER_UPDATE_TELEMETRY_DAEMON_RUNNING";
+const ENV_UPDATE_FAILURE_CLASS: &str = "CUA_DRIVER_UPDATE_TELEMETRY_FAILURE_CLASS";
+const ENV_UPDATE_DURATION_MS: &str = "CUA_DRIVER_UPDATE_TELEMETRY_DURATION_MS";
 pub const ENV_INSTALL_CHANNEL: &str = "CUA_DRIVER_INSTALL_CHANNEL";
 pub const ENV_RELEASE_VERSION: &str = "CUA_DRIVER_RELEASE_VERSION";
 
@@ -72,6 +81,9 @@ pub mod event {
     pub const PERMISSIONS_GATE_STARTED: &str = "cua_driver_permissions_gate_started";
     pub const PERMISSIONS_GATE_DISMISSED: &str = "cua_driver_permissions_gate_dismissed";
     pub const PERMISSIONS_GATE_COMPLETED: &str = "cua_driver_permissions_gate_completed";
+    pub const UPDATE_CHECKED: &str = "cua_driver_update_checked";
+    pub const UPDATE_APPLY_STARTED: &str = "cua_driver_update_apply_started";
+    pub const UPDATE_APPLY_COMPLETED: &str = "cua_driver_update_apply_completed";
 }
 
 const INSPECTABLE_EVENTS: &[&str] = &[
@@ -87,7 +99,80 @@ const INSPECTABLE_EVENTS: &[&str] = &[
     event::PERMISSIONS_GATE_STARTED,
     event::PERMISSIONS_GATE_DISMISSED,
     event::PERMISSIONS_GATE_COMPLETED,
+    event::UPDATE_CHECKED,
+    event::UPDATE_APPLY_STARTED,
+    event::UPDATE_APPLY_COMPLETED,
 ];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum UpdateCheckSource {
+    Background,
+    Cli,
+    Mcp,
+}
+
+impl UpdateCheckSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Background => "background",
+            Self::Cli => "cli",
+            Self::Mcp => "mcp",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum UpdateCheckOutcome {
+    UpToDate,
+    Available,
+    Unavailable,
+}
+
+impl UpdateCheckOutcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::UpToDate => "up_to_date",
+            Self::Available => "available",
+            Self::Unavailable => "unavailable",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum UpdateApplyOutcome {
+    Installed,
+    AlreadyCurrent,
+    Failed,
+}
+
+impl UpdateApplyOutcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Installed => "installed",
+            Self::AlreadyCurrent => "already_current",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum UpdateFailureClass {
+    None,
+    CheckFailed,
+    InstallerExit,
+    InstallerLaunch,
+}
+
+impl UpdateFailureClass {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::CheckFailed => "check_failed",
+            Self::InstallerExit => "installer_exit",
+            Self::InstallerLaunch => "installer_launch",
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Transport {
@@ -323,6 +408,23 @@ pub fn inspect_event(event_name: &str) -> Result<Value, String> {
             ("panel_shown", Value::Bool(true)),
             ("dismissed", Value::Bool(false)),
             ("resolution", Value::String("granted".into())),
+            ("duration_bucket", Value::String("2s_9_999ms".into())),
+        ]),
+        event::UPDATE_CHECKED => bounded_properties(&[
+            ("source", Value::String("cli".into())),
+            ("outcome", Value::String("available".into())),
+            ("target_version", Value::String("1.2.3".into())),
+            ("cache_hit", Value::Bool(false)),
+        ]),
+        event::UPDATE_APPLY_STARTED => bounded_properties(&[
+            ("target_version", Value::String("1.2.3".into())),
+            ("daemon_was_running", Value::Bool(false)),
+        ]),
+        event::UPDATE_APPLY_COMPLETED => bounded_properties(&[
+            ("target_version", Value::String("1.2.3".into())),
+            ("outcome", Value::String("installed".into())),
+            ("failure_class", Value::String("none".into())),
+            ("daemon_was_running", Value::Bool(false)),
             ("duration_bucket", Value::String("2s_9_999ms".into())),
         ]),
         _ => Map::new(),
@@ -1350,6 +1452,203 @@ pub(crate) fn capture_bounded(
     };
     let payload = build_payload(event_name, &properties, &identity, transport);
     spawn_payload(event_name, payload);
+}
+
+/// Record an explicit or freshness-bounded update check. A detached worker
+/// owns delivery because CLI checks are one-shot processes and must not wait
+/// on PostHog before returning to the user.
+pub(crate) fn capture_update_checked(
+    source: UpdateCheckSource,
+    outcome: UpdateCheckOutcome,
+    target_version: Option<&str>,
+    cache_hit: bool,
+) {
+    spawn_update_event_worker(
+        event::UPDATE_CHECKED,
+        Some(source.as_str()),
+        Some(outcome.as_str()),
+        target_version,
+        Some(cache_hit),
+        None,
+        None,
+        None,
+    );
+}
+
+pub(crate) fn capture_update_apply_started(target_version: &str, daemon_was_running: bool) {
+    spawn_update_event_worker(
+        event::UPDATE_APPLY_STARTED,
+        None,
+        None,
+        Some(target_version),
+        None,
+        Some(daemon_was_running),
+        None,
+        None,
+    );
+}
+
+pub(crate) fn capture_update_apply_completed(
+    target_version: Option<&str>,
+    outcome: UpdateApplyOutcome,
+    failure_class: UpdateFailureClass,
+    daemon_was_running: bool,
+    elapsed: Duration,
+) {
+    spawn_update_event_worker(
+        event::UPDATE_APPLY_COMPLETED,
+        None,
+        Some(outcome.as_str()),
+        target_version,
+        None,
+        Some(daemon_was_running),
+        Some(failure_class.as_str()),
+        Some(elapsed),
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_update_event_worker(
+    event_name: &'static str,
+    source: Option<&str>,
+    outcome: Option<&str>,
+    target_version: Option<&str>,
+    cache_hit: Option<bool>,
+    daemon_was_running: Option<bool>,
+    failure_class: Option<&str>,
+    elapsed: Option<Duration>,
+) {
+    if !is_enabled() {
+        return;
+    }
+    let Ok(executable) = std::env::current_exe() else {
+        return;
+    };
+    let mut worker = std::process::Command::new(executable);
+    worker
+        .env(ENV_UPDATE_EVENT_WORKER, "1")
+        .env(ENV_UPDATE_EVENT_NAME, event_name)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    if let Some(source) = source {
+        worker.env(ENV_UPDATE_SOURCE, source);
+    }
+    if let Some(outcome) = outcome {
+        worker.env(ENV_UPDATE_OUTCOME, outcome);
+    }
+    if let Some(version) = target_version.and_then(strict_release_version) {
+        worker.env(ENV_UPDATE_TARGET_VERSION, version);
+    }
+    if let Some(cache_hit) = cache_hit {
+        worker.env(ENV_UPDATE_CACHE_HIT, if cache_hit { "1" } else { "0" });
+    }
+    if let Some(daemon_was_running) = daemon_was_running {
+        worker.env(
+            ENV_UPDATE_DAEMON_WAS_RUNNING,
+            if daemon_was_running { "1" } else { "0" },
+        );
+    }
+    if let Some(failure_class) = failure_class {
+        worker.env(ENV_UPDATE_FAILURE_CLASS, failure_class);
+    }
+    if let Some(elapsed) = elapsed {
+        worker.env(ENV_UPDATE_DURATION_MS, elapsed.as_millis().to_string());
+    }
+    let _ = worker.spawn();
+}
+
+/// Run the hidden update-event delivery worker before CLI parsing. Every
+/// environment value is revalidated into a closed enum or strict SemVer before
+/// it can enter a payload.
+pub(crate) fn run_update_event_worker_if_requested() -> bool {
+    if !parse_env_bool(ENV_UPDATE_EVENT_WORKER).unwrap_or(false) {
+        return false;
+    }
+    let event_name = std::env::var(ENV_UPDATE_EVENT_NAME).unwrap_or_default();
+    let target_version = std::env::var(ENV_UPDATE_TARGET_VERSION)
+        .ok()
+        .and_then(|value| strict_release_version(&value))
+        .unwrap_or_else(|| "unknown".into());
+    let properties = match event_name.as_str() {
+        event::UPDATE_CHECKED => {
+            let source = match std::env::var(ENV_UPDATE_SOURCE).as_deref() {
+                Ok("background") => "background",
+                Ok("cli") => "cli",
+                Ok("mcp") => "mcp",
+                _ => return true,
+            };
+            let outcome = match std::env::var(ENV_UPDATE_OUTCOME).as_deref() {
+                Ok("up_to_date") => "up_to_date",
+                Ok("available") => "available",
+                Ok("unavailable") => "unavailable",
+                _ => return true,
+            };
+            bounded_properties(&[
+                ("source", Value::String(source.into())),
+                ("outcome", Value::String(outcome.into())),
+                ("target_version", Value::String(target_version)),
+                (
+                    "cache_hit",
+                    Value::Bool(parse_env_bool(ENV_UPDATE_CACHE_HIT).unwrap_or(false)),
+                ),
+            ])
+        }
+        event::UPDATE_APPLY_STARTED => bounded_properties(&[
+            ("target_version", Value::String(target_version)),
+            (
+                "daemon_was_running",
+                Value::Bool(parse_env_bool(ENV_UPDATE_DAEMON_WAS_RUNNING).unwrap_or(false)),
+            ),
+        ]),
+        event::UPDATE_APPLY_COMPLETED => {
+            let outcome = match std::env::var(ENV_UPDATE_OUTCOME).as_deref() {
+                Ok("installed") => "installed",
+                Ok("already_current") => "already_current",
+                Ok("failed") => "failed",
+                _ => return true,
+            };
+            let failure_class = match std::env::var(ENV_UPDATE_FAILURE_CLASS).as_deref() {
+                Ok("none") => "none",
+                Ok("check_failed") => "check_failed",
+                Ok("installer_exit") => "installer_exit",
+                Ok("installer_launch") => "installer_launch",
+                _ => return true,
+            };
+            let elapsed = std::env::var(ENV_UPDATE_DURATION_MS)
+                .ok()
+                .and_then(|value| value.parse::<u64>().ok())
+                .map(Duration::from_millis)
+                .unwrap_or_default();
+            bounded_properties(&[
+                ("target_version", Value::String(target_version)),
+                ("outcome", Value::String(outcome.into())),
+                ("failure_class", Value::String(failure_class.into())),
+                (
+                    "daemon_was_running",
+                    Value::Bool(parse_env_bool(ENV_UPDATE_DAEMON_WAS_RUNNING).unwrap_or(false)),
+                ),
+                (
+                    "duration_bucket",
+                    Value::String(duration_bucket(elapsed).into()),
+                ),
+            ])
+        }
+        _ => return true,
+    };
+    if !is_enabled() {
+        return true;
+    }
+    let Some(identity) = get_or_create_install_id() else {
+        return true;
+    };
+    let payload = build_payload(&event_name, &properties, &identity, Transport::Cli);
+    if let Err(error) =
+        post_to_posthog_with_timeout(&payload, Duration::from_secs(POSTHOG_TIMEOUT_SECS))
+    {
+        debug_log(format_args!("{event_name} failed: {error}"));
+    }
+    true
 }
 
 /// Record a finite CLI command only after its outcome is known. This is
@@ -2806,6 +3105,45 @@ mod tests {
         }
         let serve_start = inspect_event(event::SERVE_START_LEGACY).unwrap();
         assert_eq!(serve_start["properties"]["transport"], "daemon");
+    }
+
+    #[test]
+    fn update_events_expose_only_bounded_funnel_properties() {
+        let checked = inspect_event(event::UPDATE_CHECKED).unwrap();
+        assert_eq!(checked["properties"]["source"], "cli");
+        assert_eq!(checked["properties"]["outcome"], "available");
+        assert_eq!(checked["properties"]["target_version"], "1.2.3");
+        assert_eq!(checked["properties"]["cache_hit"], false);
+
+        let started = inspect_event(event::UPDATE_APPLY_STARTED).unwrap();
+        assert_eq!(started["properties"]["target_version"], "1.2.3");
+        assert_eq!(started["properties"]["daemon_was_running"], false);
+
+        let completed = inspect_event(event::UPDATE_APPLY_COMPLETED).unwrap();
+        assert_eq!(completed["properties"]["outcome"], "installed");
+        assert_eq!(completed["properties"]["failure_class"], "none");
+        assert_eq!(completed["properties"]["duration_bucket"], "2s_9_999ms");
+
+        for payload in [checked, started, completed] {
+            let serialized = serde_json::to_string(&payload)
+                .unwrap()
+                .to_ascii_lowercase();
+            for forbidden in [
+                "raw_error",
+                "exit_code",
+                "install_command",
+                "release_notes_url",
+                "file_path",
+                "arguments",
+                "prompt",
+                "$ip",
+            ] {
+                assert!(
+                    !serialized.contains(forbidden),
+                    "update payload contains {forbidden}: {serialized}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver/src/version_check.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/version_check.rs
@@ -92,7 +92,7 @@ pub fn maybe_announce_update() {
     let current = env!("CARGO_PKG_VERSION").to_owned();
 
     let task = move || {
-        run_check_and_announce(&current, fetch_latest_version, std::io::stderr());
+        run_check_and_announce(&current, fetch_latest_version, std::io::stderr(), true);
     };
 
     if tokio::runtime::Handle::try_current().is_ok() {
@@ -139,6 +139,28 @@ pub struct UpdateState {
     /// Human-readable error string when the network fetch failed AND no
     /// cache was available. `None` on success / cache fallback.
     pub error: Option<String>,
+}
+
+/// Emit the bounded result of an explicit update check. The structured state
+/// remains the source of truth for CLI/MCP output; telemetry receives only a
+/// closed outcome, a strict public release version, and the cache flag.
+pub(crate) fn capture_update_state(
+    state: &UpdateState,
+    source: crate::telemetry::UpdateCheckSource,
+) {
+    let outcome = if state.update_available {
+        crate::telemetry::UpdateCheckOutcome::Available
+    } else if state.latest_version.is_some() {
+        crate::telemetry::UpdateCheckOutcome::UpToDate
+    } else {
+        crate::telemetry::UpdateCheckOutcome::Unavailable
+    };
+    crate::telemetry::capture_update_checked(
+        source,
+        outcome,
+        state.latest_version.as_deref(),
+        state.cache_hit,
+    );
 }
 
 /// Build the canonical install one-liner for the current target.
@@ -275,7 +297,7 @@ pub fn dismiss_version(version: &str) {
 /// against a stubbed fetcher and capture the banner into an in-memory
 /// buffer. Errors here never propagate — the function consumes them
 /// and converts to `tracing::debug!` lines.
-fn run_check_and_announce<F, W>(current: &str, fetch: F, mut writer: W)
+fn run_check_and_announce<F, W>(current: &str, fetch: F, mut writer: W, capture_telemetry: bool)
 where
     F: FnOnce() -> Result<String, String>,
     W: std::io::Write,
@@ -289,7 +311,7 @@ where
         .map(|t| now.saturating_sub(t) >= CACHE_REFRESH_SECONDS)
         .unwrap_or(true);
 
-    let latest = if needs_refresh {
+    let (latest, cache_hit) = if needs_refresh {
         match fetch() {
             Ok(v) => {
                 // Persist on success so the next launch re-uses the answer.
@@ -303,7 +325,7 @@ where
                     tracing::debug!(target: "cua_driver::version_check",
                                     "failed to write cache: {e}");
                 }
-                v
+                (v, false)
             }
             Err(e) => {
                 tracing::debug!(target: "cua_driver::version_check",
@@ -311,14 +333,14 @@ where
                 // Fall back to the cached value if any — better an old
                 // banner than none on a brief network blip.
                 match cached.latest_version.clone() {
-                    Some(v) => v,
+                    Some(v) => (v, true),
                     None => return,
                 }
             }
         }
     } else {
         match cached.latest_version.clone() {
-            Some(v) => v,
+            Some(v) => (v, true),
             None => return,
         }
     };
@@ -336,6 +358,17 @@ where
         tracing::debug!(target: "cua_driver::version_check",
                         "newer version {latest} dismissed; skipping banner");
         return;
+    }
+
+    // Background entry points can be hot-restarted. Record availability only
+    // on the freshness-bounded network check, not on every cached banner.
+    if capture_telemetry && !cache_hit {
+        crate::telemetry::capture_update_checked(
+            crate::telemetry::UpdateCheckSource::Background,
+            crate::telemetry::UpdateCheckOutcome::Available,
+            Some(&latest),
+            false,
+        );
     }
 
     let banner = format_banner(&latest, current);
@@ -764,6 +797,7 @@ mod tests {
                     Ok("0.1.4".to_owned()) // newer version returned by network
                 },
                 &mut buf,
+                false,
             );
 
             assert_eq!(
@@ -800,6 +834,7 @@ mod tests {
                     Ok("0.1.5".to_owned())
                 },
                 &mut buf,
+                false,
             );
 
             assert_eq!(
@@ -829,7 +864,7 @@ mod tests {
             write_cache(&cache).unwrap();
 
             let mut buf: Vec<u8> = Vec::new();
-            run_check_and_announce("0.1.3", || Ok("0.1.4".to_owned()), &mut buf);
+            run_check_and_announce("0.1.3", || Ok("0.1.4".to_owned()), &mut buf, false);
             assert!(buf.is_empty(), "dismissed version must suppress banner");
         });
     }


### PR DESCRIPTION
## Summary

- add bounded events for update checks, apply starts, and apply outcomes
- distinguish CLI, MCP, and freshness-bounded background discovery
- retain only strict public release versions, fixed outcomes/failure classes, booleans, and duration buckets
- document how update events join to the existing release-installed event

## Why

Version distribution and successful release installs were already observable, but update availability, apply conversion, and bounded failure causes were not. This adds that funnel without collecting raw errors, commands, paths, URLs, prompts, or installer output.

## Behavior

Explicit CLI and MCP checks record up-to-date, available, or unavailable outcomes. Background checks record availability only on the freshness-bounded network path, avoiding an event for every cached startup banner. Update apply records start and completion, including installed, already-current, and fixed failure categories. Delivery uses a detached worker so telemetry does not add network latency to one-shot commands.

## Validation

- `cargo check -p cua-driver`
- `cargo test -p cua-driver --bin cua-driver` (109 passed)
- focused telemetry tests (37 passed)
- focused version-check tests (22 passed)
- `cargo fmt --all -- --check`
- inspected all three new event payloads through `cua-driver telemetry inspect`