### PR TITLE
fix: classify canceled svc proxy requests separately

### DIFF
--- a/libs/fleet/backend/handlers/svc.go
+++ b/libs/fleet/backend/handlers/svc.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -14,6 +16,15 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
+
+const statusClientClosedRequest = 499
+
+func svcProxyErrorStatus(err error) int {
+	if errors.Is(err, context.Canceled) {
+		return statusClientClosedRequest
+	}
+	return http.StatusBadGateway
+}
 
 // rewriteLocation prepends basePath to upstream Location header values
 // so browsers stay within the /api/svc proxy prefix. External URLs
@@ -117,10 +128,17 @@ func (h Handlers) Svc(w http.ResponseWriter, r *http.Request) {
 
 	rw := &statusCapture{ResponseWriter: w}
 	rp.ErrorHandler = func(rw http.ResponseWriter, _ *http.Request, err error) {
+		status := svcProxyErrorStatus(err)
+		if status == statusClientClosedRequest {
+			span.SetStatus(codes.Unset, "client canceled")
+			slog.Info("svc proxy canceled", "host", host, "path", upstreamPath, "err", err)
+			rw.WriteHeader(status)
+			return
+		}
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "upstream unavailable")
 		slog.Warn("svc proxy error", "host", host, "path", upstreamPath, "err", err)
-		http.Error(rw, "upstream unavailable", http.StatusBadGateway)
+		http.Error(rw, "upstream unavailable", status)
 	}
 
 	start := time.Now()

--- a/libs/fleet/backend/handlers/svc_test.go
+++ b/libs/fleet/backend/handlers/svc_test.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -54,5 +56,25 @@ func TestSvc_Unauthenticated(t *testing.T) {
 
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestSvcProxyErrorStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "client canceled", err: context.Canceled, want: 499},
+		{name: "wrapped client canceled", err: errors.Join(errors.New("proxy"), context.Canceled), want: 499},
+		{name: "other proxy error", err: errors.New("dial tcp: no route to host"), want: http.StatusBadGateway},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := svcProxyErrorStatus(tc.err); got != tc.want {
+				t.Fatalf("svcProxyErrorStatus(%v) = %d, want %d", tc.err, got, tc.want)
+			}
+		})
 	}
 }

--- a/libs/fleet/backend/handlers/svc_test.go
+++ b/libs/fleet/backend/handlers/svc_test.go
@@ -3,9 +3,15 @@ package handlers
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"sync"
 	"testing"
+	"time"
 
 	"cyclops-cs-backend/config"
 )
@@ -76,5 +82,113 @@ func TestSvcProxyErrorStatus(t *testing.T) {
 				t.Fatalf("svcProxyErrorStatus(%v) = %d, want %d", tc.err, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestSvcProxyErrorStatus_FromReverseProxyClientDisconnect(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(250 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer backend.Close()
+
+	target, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatalf("parse backend URL: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy.ErrorHandler = func(rw http.ResponseWriter, req *http.Request, err error) {
+		errCh <- err
+		rw.WriteHeader(svcProxyErrorStatus(err))
+	}
+
+	srv := &http.Server{Handler: proxy}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = srv.Serve(ln)
+	}()
+	defer func() {
+		_ = srv.Close()
+		wg.Wait()
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	_, _ = fmt.Fprintf(conn, "GET / HTTP/1.1\r\nHost: %s\r\n\r\n", ln.Addr().String())
+	time.Sleep(50 * time.Millisecond)
+	_ = conn.Close()
+
+	select {
+	case err := <-errCh:
+		if got := svcProxyErrorStatus(err); got != statusClientClosedRequest {
+			t.Fatalf("svcProxyErrorStatus(%v) = %d, want %d", err, got, statusClientClosedRequest)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for reverse proxy error")
+	}
+}
+
+func TestSvcProxyErrorStatus_FromReverseProxyDeadlineExceeded(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(250 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer backend.Close()
+
+	target, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatalf("parse backend URL: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy.ErrorHandler = func(rw http.ResponseWriter, req *http.Request, err error) {
+		errCh <- err
+		rw.WriteHeader(svcProxyErrorStatus(err))
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), 50*time.Millisecond)
+		defer cancel()
+		proxy.ServeHTTP(w, r.WithContext(ctx))
+	})
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("GET %s: %v", srv.URL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("response status = %d, want %d", resp.StatusCode, http.StatusBadGateway)
+	}
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected context deadline exceeded, got %v", err)
+		}
+		if got := svcProxyErrorStatus(err); got != http.StatusBadGateway {
+			t.Fatalf("svcProxyErrorStatus(%v) = %d, want %d", err, got, http.StatusBadGateway)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for reverse proxy error")
 	}
 }


### PR DESCRIPTION
## Summary
- classify svc proxy errors caused by context cancellation as 499 instead of 502
- keep real upstream failures on the existing 502 path
- add handler tests covering direct and wrapped cancellation errors

## Testing
- go test ./handlers -run TestSvc(ProxyErrorStatus|_Unauthenticated)
- go test ./handlers

Linear: CUA-937