### PR TITLE
docs: remove duplicate rendered headings

### DIFF
--- a/docs/content/docs/concepts/browser-targeting-and-background-delivery.mdx
+++ b/docs/content/docs/concepts/browser-targeting-and-background-delivery.mdx
@@ -3,8 +3,6 @@ title: "Browser Targeting and Background Delivery"
 description: "Why browser automation needs an exact native-window-to-tab binding, and how CDP adds a full-background rung to Cua Driver."
 ---
 
-# Browser Targeting and Background Delivery
-
 A browser presents two identities at once. The desktop knows a native process
 and window; the browser runtime knows DevTools targets and tabs. Acting safely
 in the background requires proof that both identities describe the same

--- a/docs/content/docs/concepts/capture-and-delivery-modalities.mdx
+++ b/docs/content/docs/concepts/capture-and-delivery-modalities.mdx
@@ -3,8 +3,6 @@ title: "Capture and Delivery Modalities"
 description: "How Cua Driver observes and acts on an app. Perception returns both the accessibility tree and a screenshot; the action call chooses the ax or px rung, delivery mode, and scope."
 ---
 
-# Capture and Delivery Modalities
-
 Every Cua Driver action is shaped by four things: **what the agent observes**, **which rung delivers the action**, **how input is delivered**, and **what coordinate space the action targets**. Most callers use the defaults: background, per-window, accessibility-first automation. The key change from earlier versions is that perception is no longer a mode you pick. `get_window_state` returns *both* the accessibility tree and a screenshot in one call. The action call chooses `ax` or `px` by how it addresses the target.
 
 ## The Axes

--- a/docs/content/docs/concepts/how-cua-driver-is-validated.mdx
+++ b/docs/content/docs/concepts/how-cua-driver-is-validated.mdx
@@ -3,8 +3,6 @@ title: 'How Cua Driver Is Validated'
 description: 'Why Cua Driver uses source-built desktop harnesses, independent application oracles, and retained evidence to validate behavior between releases.'
 ---
 
-# How Cua Driver Is Validated
-
 Desktop automation crosses boundaries that ordinary unit tests cannot observe.
 A request can be valid, reach an operating-system API, and return success while
 the target application receives nothing. Cua Driver therefore treats protocol

--- a/docs/content/docs/concepts/the-no-foreground-contract.mdx
+++ b/docs/content/docs/concepts/the-no-foreground-contract.mdx
@@ -3,8 +3,6 @@ title: Best-effort background
 description: How Cua Driver tries to operate apps without taking focus, moving the cursor, or raising windows, and when it must fall back to foreground.
 ---
 
-# Best-effort background
-
 Best-effort background means Cua Driver tries to operate a target app while preserving the user's active desktop. The default paths do not move the real pointer, do not raise the target window, and do not switch the user's frontmost app.
 
 This is a best effort rather than an absolute promise. Most app automation can stay in the background through accessibility actions, routed input, and window-specific capture. A small set of apps and OS surfaces only accept real foreground input, so the driver reports that limit and lets the caller choose a foreground escalation for that specific action.

--- a/docs/content/docs/cuabench/index.mdx
+++ b/docs/content/docs/cuabench/index.mdx
@@ -3,8 +3,6 @@ title: What is Cua-Bench?
 description: Understand how Cua-Bench defines, runs, and scores verifiable computer-use tasks.
 ---
 
-# What is Cua-Bench?
-
 Cua-Bench is an MIT-licensed framework for computer-use benchmarks and reinforcement-learning
 environments. It packages the task, starting state, agent interface, and evaluator needed to run a
 repeatable experiment across Linux, Windows, Android, browser, or simulated environments.

--- a/docs/content/docs/how-to-guides/driver/drive-a-web-page.mdx
+++ b/docs/content/docs/how-to-guides/driver/drive-a-web-page.mdx
@@ -3,8 +3,6 @@ title: 'Drive a Web Page'
 description: 'Bind an exact browser window, inspect its active tab, and navigate, click, or type without foregrounding it.'
 ---
 
-# Drive a Web Page
-
 Use the browser tools when an agent must act inside Chromium or an Electron
 page without raising the native window. The tools bind the `(pid, window_id)`
 you selected to a DevTools target, then issue page input through that exact

--- a/docs/content/docs/reference/cua-driver/action-selection-policy.mdx
+++ b/docs/content/docs/reference/cua-driver/action-selection-policy.mdx
@@ -3,8 +3,6 @@ title: "Agent action policy"
 description: "Behavior an agent should follow when choosing element, pixel, page, and foreground actions in Cua Driver."
 ---
 
-# Agent action policy
-
 This policy describes how an agent should choose Cua Driver action parameters. It is meant for agent prompts, wrappers, and evaluators. It is not a user walkthrough.
 
 Use it when the agent must decide what to pass to `click`, `type_text`, `get_window_state`, and related tools: `element_index` versus `x, y`, `delivery_mode: background` versus `foreground`, and window versus desktop scope.

--- a/docs/content/docs/reference/cua-driver/browser-profile-attachment.mdx
+++ b/docs/content/docs/reference/cua-driver/browser-profile-attachment.mdx
@@ -3,8 +3,6 @@ title: Browser Profile Attachment
 description: Contract, lifetimes, refusals, and platform scope for attaching Cua Driver to an existing Chromium profile.
 ---
 
-# Browser Profile Attachment
-
 Existing-profile attachment is an additive `browser_prepare` strategy. It does
 not change the lifecycle of driver-owned `isolated_new` and `isolated_named`
 profiles.

--- a/docs/content/docs/tutorials/drive-your-first-app.mdx
+++ b/docs/content/docs/tutorials/drive-your-first-app.mdx
@@ -6,8 +6,6 @@ description: Install Cua Driver, connect your agent, and ask it in plain English
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
 import { Callout } from 'fumadocs-ui/components/callout';
 
-# Drive your first app
-
 You do not type **Cua Driver** CLI commands by hand. Cua Driver is a backend that an agent harness (Claude Code, Codex, Hermes, and others) drives for you. In this tutorial you install Cua Driver, connect your agent, and ask it in plain English to open a calculator and read a result back. Works the same on macOS, Windows, and Linux.
 
 New to agents that operate applications? Start with [What is computer use?](/concepts/what-is-computer-use) for the model behind the workflow, then return here to build one.

--- a/docs/content/docs/tutorials/your-first-cloud-sandbox.mdx
+++ b/docs/content/docs/tutorials/your-first-cloud-sandbox.mdx
@@ -5,8 +5,6 @@ description: Create a cloud Linux sandbox with the Python SDK, run one command, 
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-# Your first cloud sandbox
-
 In this tutorial, you create an *ephemeral* cloud Linux sandbox, run `uname -a` inside it, touch the sandbox clipboard, and save a screenshot from the sandbox to your current directory.
 
 <Callout type="info">

--- a/docs/scripts/check-hygiene.ts
+++ b/docs/scripts/check-hygiene.ts
@@ -27,8 +27,20 @@ async function main() {
     const abs = path.join(CONTENT_DIR, file);
     const content = await fs.readFile(abs, 'utf8');
     const lines = content.split(/\r?\n/);
+    let inFence = false;
 
     for (const [lineIndex, line] of lines.entries()) {
+      if (/^\s*(?:```|~~~)/.test(line)) {
+        inFence = !inFence;
+        continue;
+      }
+
+      if (!inFence && /^#\s+/.test(line)) {
+        failures.push(
+          `${file}:${lineIndex + 1}: body-level H1 duplicates the renderer-owned frontmatter title: ${line.trim()}`
+        );
+      }
+
       for (const [pattern, reason] of bannedPatterns) {
         if (pattern.test(line)) {
           failures.push(`${file}:${lineIndex + 1}: ${reason}: ${line.trim()}`);


### PR DESCRIPTION
## Summary

- remove body-level H1 headings that duplicate frontmatter titles rendered by the docs shell
- include the driver web-page guide found during the repository-wide check
- add a fence-aware hygiene rule preventing body-level H1 regressions while allowing examples inside code fences

## Validation

- `docs:check-hygiene`
- `docs:check-links` (0 errors)
- Prettier check
- full docs production build (80 static pages)

Addresses #2390