### PR TITLE
Add UTM import and export for Lume

### DIFF
--- a/docs/content/docs/reference/lume/cli-reference.mdx
+++ b/docs/content/docs/reference/lume/cli-reference.mdx
@@ -280,6 +280,28 @@ Convert a legacy Lume image to OCI-compliant format
 | `--dry-run` | false | Prepare files without uploading |
 | `--single-layer` | false | Push one kubelet-compatible disk layer |
 
+### lume import
+
+Import a virtual machine from another format
+
+**Subcommands:**
+
+- `lume import utm` - Import a stopped UTM Apple/macOS VM into Lume
+  - `<bundle>` - Path to the source .utm bundle
+  - `<name>` - Name for the imported Lume VM
+  - `--storage` - Destination Lume storage location
+
+### lume export
+
+Export a virtual machine to another format
+
+**Subcommands:**
+
+- `lume export utm` - Export a stopped Lume macOS VM as a UTM bundle
+  - `<name>` - Name of the source Lume VM
+  - `<output>` - Destination .utm bundle path
+  - `--storage` - Source Lume storage location
+
 ### lume ipsw
 
 Get macOS restore image IPSW URL

--- a/libs/lume/src/Commands/ExportUTM.swift
+++ b/libs/lume/src/Commands/ExportUTM.swift
@@ -1,0 +1,46 @@
+import ArgumentParser
+import Foundation
+
+struct Export: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "export",
+    abstract: "Export a virtual machine to another format",
+    subcommands: [ExportUTM.self]
+  )
+}
+
+struct ExportUTM: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "utm",
+    abstract: "Export a stopped Lume macOS VM as a UTM bundle",
+    discussion: """
+      Creates an independent UTM Apple/macOS .utm bundle using APFS
+      copy-on-write cloning when possible. A fresh machine identifier and
+      MAC address are generated so the source and export cannot collide.
+
+      The Lume VM must be fully shut down.
+
+      Example:
+        lume export utm my-mac "~/Virtual Machines/my-mac.utm"
+      """
+  )
+
+  @Argument(help: "Name of the source Lume VM", completion: .custom(completeVMName))
+  var name: String
+
+  @Argument(help: "Destination .utm bundle path", completion: .file())
+  var output: Path
+
+  @Option(name: .customLong("storage"), help: "Source Lume storage location")
+  var storage: String?
+
+  init() {}
+
+  @MainActor
+  func run() async throws {
+    TelemetryClient.shared.record(event: TelemetryEvent.exportUTM)
+    let source = try Home().getVMDirectory(name, storage: storage)
+    let outputURL = try UTMConverter().exportUTM(from: source, to: output.url)
+    print("Exported Lume VM '\(source.name)' to \(outputURL.path)")
+  }
+}

--- a/libs/lume/src/Commands/ImportUTM.swift
+++ b/libs/lume/src/Commands/ImportUTM.swift
@@ -1,0 +1,46 @@
+import ArgumentParser
+import Foundation
+
+struct Import: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "import",
+    abstract: "Import a virtual machine from another format",
+    subcommands: [ImportUTM.self]
+  )
+}
+
+struct ImportUTM: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "utm",
+    abstract: "Import a stopped UTM Apple/macOS VM into Lume",
+    discussion: """
+      Creates an independent Lume VM from a UTM .utm bundle. The raw disk,
+      auxiliary storage, and hardware model are preserved as a matched set.
+      A fresh machine identifier and MAC address are generated.
+
+      The UTM VM must be fully shut down, not suspended.
+
+      Example:
+        lume import utm "~/Virtual Machines/MyMac.utm" my-mac
+      """
+  )
+
+  @Argument(help: "Path to the source .utm bundle", completion: .file())
+  var bundle: Path
+
+  @Argument(help: "Name for the imported Lume VM")
+  var name: String
+
+  @Option(name: .customLong("storage"), help: "Destination Lume storage location")
+  var storage: String?
+
+  init() {}
+
+  @MainActor
+  func run() async throws {
+    TelemetryClient.shared.record(event: TelemetryEvent.importUTM)
+    let destination = try Home().getVMDirectory(name, storage: storage)
+    try UTMConverter().importUTM(from: bundle.url, named: name, to: destination)
+    print("Imported UTM VM as Lume VM '\(destination.name)' at \(destination.dir.path)")
+  }
+}

--- a/libs/lume/src/Telemetry/TelemetryClient.swift
+++ b/libs/lume/src/Telemetry/TelemetryClient.swift
@@ -486,6 +486,8 @@ enum TelemetryEvent {
   static let clone = "lume_clone"
   static let pull = "lume_pull"
   static let push = "lume_push"
+  static let importUTM = "lume_import_utm"
+  static let exportUTM = "lume_export_utm"
   static let serve = "lume_serve"
   static let setup = "lume_setup"
   static let config = "lume_config"

--- a/libs/lume/src/UTM/UTMConverter.swift
+++ b/libs/lume/src/UTM/UTMConverter.swift
@@ -1,0 +1,892 @@
+import Darwin
+import Foundation
+import Virtualization
+
+enum UTMConversionError: Error, LocalizedError {
+  case bundleNotFound(String)
+  case invalidBundle(String)
+  case invalidFile(String)
+  case unsupportedBackend(String)
+  case unsupportedVersion(Int)
+  case unsupportedGuest(String)
+  case unsupportedConfiguration(String)
+  case missingFile(String)
+  case sourceInUse(String)
+  case destinationExists(String)
+  case invalidVMName(String)
+  case copyFailed(source: String, destination: String, reason: String)
+
+  var errorDescription: String? {
+    switch self {
+    case .bundleNotFound(let path):
+      return "UTM bundle not found: \(path)"
+    case .invalidBundle(let reason):
+      return "Invalid UTM bundle: \(reason)"
+    case .invalidFile(let reason):
+      return "Invalid VM file: \(reason)"
+    case .unsupportedBackend(let backend):
+      return "Unsupported UTM backend '\(backend)'. Only Apple macOS VMs can be imported into Lume."
+    case .unsupportedVersion(let version):
+      return
+        "Unsupported UTM configuration version \(version). This Lume build supports version \(UTMBundleConfiguration.supportedVersion)."
+    case .unsupportedGuest(let guest):
+      return "Unsupported UTM guest '\(guest)'. Only Apple/macOS guests can be imported into Lume."
+    case .unsupportedConfiguration(let reason):
+      return "Unsupported UTM configuration: \(reason)"
+    case .missingFile(let path):
+      return "Required VM file not found: \(path)"
+    case .sourceInUse(let path):
+      return
+        "VM source is in use: \(path). Fully shut down the VM before importing or exporting it."
+    case .destinationExists(let path):
+      return "Destination already exists: \(path)"
+    case .invalidVMName(let name):
+      return "Invalid VM name '\(name)'. Use a single directory name without '/'."
+    case .copyFailed(let source, let destination, let reason):
+      return "Could not copy \(source) to \(destination): \(reason)"
+    }
+  }
+}
+
+/// The version-4 UTM Apple configuration fields used by the converter.
+/// Unknown UI-only plist fields are intentionally ignored.
+struct UTMBundleConfiguration: Codable {
+  static let supportedVersion = 4
+
+  var backend: String
+  var configurationVersion: Int
+  var information: Information
+  var system: System
+  var virtualization: Virtualization
+  var displays: [Display]
+  var drives: [Drive]
+  var networks: [Network]
+  var serials: [Serial]
+
+  enum CodingKeys: String, CodingKey {
+    case backend = "Backend"
+    case configurationVersion = "ConfigurationVersion"
+    case information = "Information"
+    case system = "System"
+    case virtualization = "Virtualization"
+    case displays = "Display"
+    case drives = "Drive"
+    case networks = "Network"
+    case serials = "Serial"
+  }
+
+  struct Information: Codable {
+    var name: String
+    var iconCustom: Bool
+    var uuid: UUID
+
+    enum CodingKeys: String, CodingKey {
+      case name = "Name"
+      case iconCustom = "IconCustom"
+      case uuid = "UUID"
+    }
+  }
+
+  struct System: Codable {
+    var architecture: String
+    var cpuCount: Int
+    /// UTM stores guest memory in MiB.
+    var memorySize: Int
+    var boot: Boot
+    var macPlatform: MacPlatform?
+
+    enum CodingKeys: String, CodingKey {
+      case architecture = "Architecture"
+      case cpuCount = "CPUCount"
+      case memorySize = "MemorySize"
+      case boot = "Boot"
+      case macPlatform = "MacPlatform"
+    }
+  }
+
+  struct Boot: Codable {
+    var operatingSystem: String
+    var uefiBoot: Bool
+
+    enum CodingKeys: String, CodingKey {
+      case operatingSystem = "OperatingSystem"
+      case uefiBoot = "UEFIBoot"
+    }
+
+    init(operatingSystem: String, uefiBoot: Bool) {
+      self.operatingSystem = operatingSystem
+      self.uefiBoot = uefiBoot
+    }
+
+    init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      operatingSystem = try values.decode(String.self, forKey: .operatingSystem)
+      uefiBoot = try values.decodeIfPresent(Bool.self, forKey: .uefiBoot) ?? false
+    }
+  }
+
+  struct MacPlatform: Codable {
+    var hardwareModel: Data
+    var machineIdentifier: Data
+    var auxiliaryStoragePath: String?
+
+    enum CodingKeys: String, CodingKey {
+      case hardwareModel = "HardwareModel"
+      case machineIdentifier = "MachineIdentifier"
+      case auxiliaryStoragePath = "AuxiliaryStoragePath"
+    }
+  }
+
+  struct Virtualization: Codable {
+    var audio: Bool
+    var balloon: Bool
+    var entropy: Bool
+    var keyboard: String
+    var pointer: String
+    var rosetta: Bool?
+    var clipboardSharing: Bool
+
+    enum CodingKeys: String, CodingKey {
+      case audio = "Audio"
+      case balloon = "Balloon"
+      case entropy = "Entropy"
+      case keyboard = "Keyboard"
+      case pointer = "Pointer"
+      case trackpad = "Trackpad"
+      case rosetta = "Rosetta"
+      case clipboardSharing = "ClipboardSharing"
+    }
+
+    init(
+      audio: Bool,
+      balloon: Bool,
+      entropy: Bool,
+      keyboard: String,
+      pointer: String,
+      rosetta: Bool?,
+      clipboardSharing: Bool
+    ) {
+      self.audio = audio
+      self.balloon = balloon
+      self.entropy = entropy
+      self.keyboard = keyboard
+      self.pointer = pointer
+      self.rosetta = rosetta
+      self.clipboardSharing = clipboardSharing
+    }
+
+    init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      audio = try values.decodeIfPresent(Bool.self, forKey: .audio) ?? false
+      balloon = try values.decodeIfPresent(Bool.self, forKey: .balloon) ?? true
+      entropy = try values.decodeIfPresent(Bool.self, forKey: .entropy) ?? true
+      if let value = try? values.decode(String.self, forKey: .keyboard) {
+        keyboard = value
+      } else {
+        keyboard =
+          (try values.decodeIfPresent(Bool.self, forKey: .keyboard) ?? false)
+          ? "Generic" : "Disabled"
+      }
+      if let value = try? values.decode(String.self, forKey: .pointer) {
+        pointer = value
+      } else if try values.decodeIfPresent(Bool.self, forKey: .trackpad) ?? false {
+        pointer = "Trackpad"
+      } else {
+        pointer =
+          (try values.decodeIfPresent(Bool.self, forKey: .pointer) ?? false)
+          ? "Mouse" : "Disabled"
+      }
+      rosetta = try values.decodeIfPresent(Bool.self, forKey: .rosetta)
+      clipboardSharing =
+        try values.decodeIfPresent(Bool.self, forKey: .clipboardSharing) ?? false
+    }
+
+    func encode(to encoder: Encoder) throws {
+      var values = encoder.container(keyedBy: CodingKeys.self)
+      try values.encode(audio, forKey: .audio)
+      try values.encode(balloon, forKey: .balloon)
+      try values.encode(entropy, forKey: .entropy)
+      try values.encode(keyboard, forKey: .keyboard)
+      try values.encode(pointer, forKey: .pointer)
+      try values.encodeIfPresent(rosetta, forKey: .rosetta)
+      try values.encode(clipboardSharing, forKey: .clipboardSharing)
+    }
+  }
+
+  struct Display: Codable {
+    var widthPixels: Int
+    var heightPixels: Int
+    var pixelsPerInch: Int
+    var dynamicResolution: Bool
+
+    enum CodingKeys: String, CodingKey {
+      case widthPixels = "WidthPixels"
+      case heightPixels = "HeightPixels"
+      case pixelsPerInch = "PixelsPerInch"
+      case dynamicResolution = "DynamicResolution"
+    }
+
+    init(
+      widthPixels: Int,
+      heightPixels: Int,
+      pixelsPerInch: Int,
+      dynamicResolution: Bool
+    ) {
+      self.widthPixels = widthPixels
+      self.heightPixels = heightPixels
+      self.pixelsPerInch = pixelsPerInch
+      self.dynamicResolution = dynamicResolution
+    }
+
+    init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      widthPixels = try values.decode(Int.self, forKey: .widthPixels)
+      heightPixels = try values.decode(Int.self, forKey: .heightPixels)
+      pixelsPerInch = try values.decode(Int.self, forKey: .pixelsPerInch)
+      dynamicResolution =
+        try values.decodeIfPresent(Bool.self, forKey: .dynamicResolution) ?? true
+    }
+  }
+
+  struct Drive: Codable {
+    var identifier: String
+    var imageName: String?
+    var readOnly: Bool
+    var nvme: Bool
+
+    enum CodingKeys: String, CodingKey {
+      case identifier = "Identifier"
+      case imageName = "ImageName"
+      case readOnly = "ReadOnly"
+      case nvme = "Nvme"
+    }
+
+    init(identifier: String, imageName: String?, readOnly: Bool, nvme: Bool) {
+      self.identifier = identifier
+      self.imageName = imageName
+      self.readOnly = readOnly
+      self.nvme = nvme
+    }
+
+    init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      identifier = try values.decode(String.self, forKey: .identifier)
+      imageName = try values.decodeIfPresent(String.self, forKey: .imageName)
+      readOnly = try values.decodeIfPresent(Bool.self, forKey: .readOnly) ?? (imageName == nil)
+      nvme = try values.decodeIfPresent(Bool.self, forKey: .nvme) ?? false
+    }
+  }
+
+  struct Network: Codable {
+    var mode: String
+    var macAddress: String
+    var bridgeInterface: String?
+
+    enum CodingKeys: String, CodingKey {
+      case mode = "Mode"
+      case macAddress = "MacAddress"
+      case bridgeInterface = "BridgeInterface"
+    }
+  }
+
+  struct Serial: Codable {
+    var mode: String?
+
+    enum CodingKeys: String, CodingKey {
+      case mode = "Mode"
+    }
+  }
+}
+
+struct UTMConverter {
+  private static let bytesPerMiB = UInt64(1_048_576)
+  private static let qcowMagic = Data([0x51, 0x46, 0x49, 0xfb])
+  private static let asifMagic = Data("shdw".utf8)
+  private static let udifMagic = Data("koly".utf8)
+
+  private let fileManager: FileManager
+  private let filesAreInUse: ([URL]) throws -> Bool
+
+  init(
+    fileManager: FileManager = .default,
+    filesAreInUse: @escaping ([URL]) throws -> Bool = UTMConverter.defaultFilesAreInUse
+  ) {
+    self.fileManager = fileManager
+    self.filesAreInUse = filesAreInUse
+  }
+
+  /// Imports a stopped UTM Apple/macOS bundle into a new Lume VM directory.
+  /// The requested name is passed separately so path normalization cannot turn
+  /// a parent-relative name into an apparently valid destination basename.
+  func importUTM(from bundleURL: URL, named requestedName: String, to destination: VMDirectory)
+    throws
+  {
+    try validateVMName(requestedName)
+    guard destination.name == requestedName else {
+      throw UTMConversionError.invalidVMName(requestedName)
+    }
+    guard !entryExists(at: destination.dir.url) else {
+      throw UTMConversionError.destinationExists(destination.dir.path)
+    }
+
+    let source = try loadBundle(at: bundleURL)
+    try validateImportConfiguration(source.configuration, rawPropertyList: source.rawPropertyList)
+
+    guard let platform = source.configuration.system.macPlatform else {
+      throw UTMConversionError.unsupportedConfiguration("missing macOS platform metadata")
+    }
+    _ = try validateHardwareModel(platform.hardwareModel)
+    guard VZMacMachineIdentifier(dataRepresentation: platform.machineIdentifier) != nil else {
+      throw UTMConversionError.unsupportedConfiguration("invalid Mac machine identifier")
+    }
+
+    guard source.configuration.drives.count == 1 else {
+      throw UTMConversionError.unsupportedConfiguration(
+        "expected exactly one internal boot disk; found \(source.configuration.drives.count)")
+    }
+    let drive = source.configuration.drives[0]
+    guard let imageName = drive.imageName else {
+      throw UTMConversionError.unsupportedConfiguration(
+        "external or removable disks are not supported")
+    }
+    guard !drive.readOnly else {
+      throw UTMConversionError.unsupportedConfiguration("the boot disk must be writable")
+    }
+    guard !drive.nvme else {
+      throw UTMConversionError.unsupportedConfiguration("NVMe disks are not supported")
+    }
+
+    guard let auxiliaryStoragePath = platform.auxiliaryStoragePath else {
+      throw UTMConversionError.unsupportedConfiguration(
+        "missing configured auxiliary-storage file")
+    }
+    let diskURL = try resolveDataFile(named: imageName, in: source.dataURL)
+    let auxiliaryURL = try resolveDataFile(named: auxiliaryStoragePath, in: source.dataURL)
+    guard diskURL != auxiliaryURL else {
+      throw UTMConversionError.invalidBundle(
+        "the boot disk and auxiliary storage refer to the same file")
+    }
+
+    let stateURL = source.dataURL.appendingPathComponent("vmstate", isDirectory: false)
+    if entryExists(at: stateURL) {
+      throw UTMConversionError.unsupportedConfiguration(
+        "the bundle contains suspended state; resume and fully shut down the UTM VM first")
+    }
+    if try filesAreInUse([source.configURL, diskURL, auxiliaryURL]) {
+      throw UTMConversionError.sourceInUse(bundleURL.path)
+    }
+
+    try validateRawDiskImage(at: diskURL)
+    _ = VZMacAuxiliaryStorage(url: auxiliaryURL)
+
+    let display = source.configuration.displays[0]
+    let network = source.configuration.networks[0]
+    let networkMode: NetworkMode
+    switch network.mode {
+    case "Shared":
+      networkMode = .nat
+    case "Bridged":
+      if let interface = network.bridgeInterface, interface.isEmpty {
+        throw UTMConversionError.unsupportedConfiguration("bridged interface identifier is empty")
+      }
+      networkMode = .bridged(interface: network.bridgeInterface)
+    default:
+      throw UTMConversionError.unsupportedConfiguration("unknown network mode '\(network.mode)'")
+    }
+
+    guard let memoryMiB = UInt64(exactly: source.configuration.system.memorySize),
+      memoryMiB <= UInt64.max / Self.bytesPerMiB
+    else {
+      throw UTMConversionError.unsupportedConfiguration("invalid guest memory size")
+    }
+    let memoryBytes = memoryMiB * Self.bytesPerMiB
+    try validateCPUAndMemory(
+      cpuCount: source.configuration.system.cpuCount, memorySize: memoryBytes)
+
+    let diskSize = try regularFileSize(at: diskURL)
+    let config = try VMConfig(
+      os: "macOS",
+      cpuCount: source.configuration.system.cpuCount,
+      memorySize: memoryBytes,
+      diskSize: diskSize,
+      macAddress: Self.generateFreshMacAddress(excluding: network.macAddress),
+      display: "\(display.widthPixels)x\(display.heightPixels)",
+      hardwareModel: platform.hardwareModel,
+      machineIdentifier: Self.generateFreshMachineIdentifier(excluding: platform.machineIdentifier),
+      networkMode: networkMode
+    )
+
+    try createAtomically(at: destination.dir.url) { temporaryURL in
+      let temporary = VMDirectory(Path(temporaryURL))
+      try cloneOrCopyFile(from: diskURL, to: temporary.diskPath.url)
+      try cloneOrCopyFile(from: auxiliaryURL, to: temporary.nvramPath.url)
+      try temporary.saveConfig(config)
+    }
+  }
+
+  /// Exports a fully initialized, stopped Lume macOS VM as an independent UTM bundle.
+  func exportUTM(from source: VMDirectory, to requestedOutputURL: URL) throws -> URL {
+    let outputURL =
+      requestedOutputURL.pathExtension.lowercased() == "utm"
+      ? requestedOutputURL
+      : requestedOutputURL.appendingPathExtension("utm")
+    guard !entryExists(at: outputURL) else {
+      throw UTMConversionError.destinationExists(outputURL.path)
+    }
+    guard !source.provisioningPath.exists(), !source.hasResizeMarker() else {
+      throw UTMConversionError.unsupportedConfiguration(
+        "the Lume VM is provisioning or has an incomplete disk-resize transaction")
+    }
+
+    let configSize = try regularFileSize(at: source.configPath.url)
+    guard configSize > 0 else {
+      throw VMError.notInitialized(source.name)
+    }
+    let diskSize = try regularFileSize(at: source.diskPath.url)
+    _ = try regularFileSize(at: source.nvramPath.url)
+
+    let configLock: FileHandle
+    do {
+      configLock = try FileHandle(forUpdating: source.configPath.url)
+    } catch {
+      throw VMError.notInitialized(source.name)
+    }
+    defer { try? configLock.close() }
+    guard flock(configLock.fileDescriptor, LOCK_EX | LOCK_NB) == 0 else {
+      throw UTMConversionError.sourceInUse(source.dir.path)
+    }
+    defer { flock(configLock.fileDescriptor, LOCK_UN) }
+
+    if try filesAreInUse([source.diskPath.url, source.nvramPath.url]) {
+      throw UTMConversionError.sourceInUse(source.dir.path)
+    }
+
+    let config = try source.loadConfig()
+    guard config.os == "macOS" else {
+      throw UTMConversionError.unsupportedGuest(config.os)
+    }
+    guard let hardwareModelData = config.hardwareModel else {
+      throw UTMConversionError.unsupportedConfiguration("missing Mac hardware model")
+    }
+    _ = try validateHardwareModel(hardwareModelData)
+    guard let originalMachineIdentifier = config.machineIdentifier,
+      VZMacMachineIdentifier(dataRepresentation: originalMachineIdentifier) != nil
+    else {
+      throw UTMConversionError.unsupportedConfiguration("invalid or missing Mac machine identifier")
+    }
+    guard let originalMacAddress = config.macAddress,
+      VZMACAddress(string: originalMacAddress) != nil
+    else {
+      throw UTMConversionError.unsupportedConfiguration("invalid or missing network MAC address")
+    }
+    guard let cpuCount = config.cpuCount, let memorySize = config.memorySize else {
+      throw UTMConversionError.unsupportedConfiguration("missing CPU or memory configuration")
+    }
+    try validateCPUAndMemory(cpuCount: cpuCount, memorySize: memorySize)
+    guard memorySize % Self.bytesPerMiB == 0 else {
+      throw UTMConversionError.unsupportedConfiguration(
+        "guest memory must be an exact whole number of MiB for UTM")
+    }
+    guard let configuredDiskSize = config.diskSize, configuredDiskSize == diskSize else {
+      throw UTMConversionError.unsupportedConfiguration(
+        "configured disk size does not match disk.img")
+    }
+    guard config.display.width > 0, config.display.height > 0 else {
+      throw UTMConversionError.unsupportedConfiguration("invalid display dimensions")
+    }
+
+    try validateRawDiskImage(at: source.diskPath.url)
+    _ = VZMacAuxiliaryStorage(url: source.nvramPath.url)
+
+    guard let memoryMiB = Int(exactly: memorySize / Self.bytesPerMiB) else {
+      throw UTMConversionError.unsupportedConfiguration("guest memory size is too large")
+    }
+    let bundleConfig = UTMBundleConfiguration(
+      backend: "Apple",
+      configurationVersion: UTMBundleConfiguration.supportedVersion,
+      information: .init(name: source.name, iconCustom: false, uuid: UUID()),
+      system: .init(
+        architecture: "aarch64",
+        cpuCount: cpuCount,
+        memorySize: memoryMiB,
+        boot: .init(operatingSystem: "macOS", uefiBoot: false),
+        macPlatform: .init(
+          hardwareModel: hardwareModelData,
+          machineIdentifier: Self.generateFreshMachineIdentifier(
+            excluding: originalMachineIdentifier),
+          auxiliaryStoragePath: "AuxiliaryStorage")
+      ),
+      virtualization: .init(
+        audio: true,
+        balloon: false,
+        entropy: true,
+        keyboard: "Mac",
+        pointer: "Trackpad",
+        rosetta: false,
+        clipboardSharing: true
+      ),
+      displays: [
+        .init(
+          widthPixels: config.display.width,
+          heightPixels: config.display.height,
+          pixelsPerInch: 80,
+          dynamicResolution: true)
+      ],
+      drives: [
+        .init(
+          identifier: UUID().uuidString,
+          imageName: "disk.img",
+          readOnly: false,
+          nvme: false)
+      ],
+      networks: [makeUTMNetwork(from: config.networkMode, excluding: originalMacAddress)],
+      serials: []
+    )
+
+    try createAtomically(at: outputURL) { temporaryURL in
+      let dataURL = temporaryURL.appendingPathComponent("Data", isDirectory: true)
+      try fileManager.createDirectory(at: dataURL, withIntermediateDirectories: false)
+      try cloneOrCopyFile(
+        from: source.diskPath.url,
+        to: dataURL.appendingPathComponent("disk.img", isDirectory: false))
+      try cloneOrCopyFile(
+        from: source.nvramPath.url,
+        to: dataURL.appendingPathComponent("AuxiliaryStorage", isDirectory: false))
+
+      let encoder = PropertyListEncoder()
+      encoder.outputFormat = .xml
+      let plist = try encoder.encode(bundleConfig)
+      try plist.write(
+        to: temporaryURL.appendingPathComponent("config.plist", isDirectory: false),
+        options: .atomic)
+    }
+    return outputURL
+  }
+
+  private func loadBundle(at bundleURL: URL) throws -> (
+    configuration: UTMBundleConfiguration,
+    configURL: URL,
+    dataURL: URL,
+    rawPropertyList: [String: Any]
+  ) {
+    var isDirectory: ObjCBool = false
+    guard fileManager.fileExists(atPath: bundleURL.path, isDirectory: &isDirectory),
+      isDirectory.boolValue
+    else {
+      throw UTMConversionError.bundleNotFound(bundleURL.path)
+    }
+
+    let configURL = bundleURL.appendingPathComponent("config.plist", isDirectory: false)
+    let dataURL = bundleURL.appendingPathComponent("Data", isDirectory: true)
+    _ = try regularFileSize(at: configURL)
+    try requireDirectoryWithoutSymlink(at: dataURL)
+
+    do {
+      let plistData = try Data(contentsOf: configURL)
+      guard
+        let rawPropertyList = try PropertyListSerialization.propertyList(
+          from: plistData,
+          options: [],
+          format: nil
+        ) as? [String: Any]
+      else {
+        throw UTMConversionError.invalidBundle("config.plist is not a dictionary")
+      }
+      guard let backend = rawPropertyList["Backend"] as? String else {
+        throw UTMConversionError.invalidBundle("missing or invalid Backend")
+      }
+      guard backend == "Apple" else {
+        throw UTMConversionError.unsupportedBackend(backend)
+      }
+      guard let version = rawPropertyList["ConfigurationVersion"] as? Int else {
+        throw UTMConversionError.invalidBundle("missing or invalid ConfigurationVersion")
+      }
+      guard version == UTMBundleConfiguration.supportedVersion else {
+        throw UTMConversionError.unsupportedVersion(version)
+      }
+
+      let configuration = try PropertyListDecoder().decode(
+        UTMBundleConfiguration.self,
+        from: plistData)
+      return (configuration, configURL, dataURL, rawPropertyList)
+    } catch let error as UTMConversionError {
+      throw error
+    } catch {
+      throw UTMConversionError.invalidBundle(error.localizedDescription)
+    }
+  }
+
+  private func validateImportConfiguration(
+    _ configuration: UTMBundleConfiguration,
+    rawPropertyList: [String: Any]
+  ) throws {
+    guard configuration.backend == "Apple" else {
+      throw UTMConversionError.unsupportedBackend(configuration.backend)
+    }
+    guard configuration.configurationVersion == UTMBundleConfiguration.supportedVersion else {
+      throw UTMConversionError.unsupportedVersion(configuration.configurationVersion)
+    }
+    guard configuration.system.architecture == "aarch64" else {
+      throw UTMConversionError.unsupportedConfiguration(
+        "architecture '\(configuration.system.architecture)' is not Apple Silicon")
+    }
+    guard configuration.system.boot.operatingSystem == "macOS" else {
+      throw UTMConversionError.unsupportedGuest(configuration.system.boot.operatingSystem)
+    }
+    guard !configuration.system.boot.uefiBoot else {
+      throw UTMConversionError.unsupportedConfiguration("UEFI boot is not valid for a macOS guest")
+    }
+    guard configuration.system.macPlatform != nil else {
+      throw UTMConversionError.unsupportedConfiguration("missing macOS platform metadata")
+    }
+    guard configuration.displays.count == 1 else {
+      throw UTMConversionError.unsupportedConfiguration(
+        "Lume currently supports one display; found \(configuration.displays.count)")
+    }
+    let display = configuration.displays[0]
+    guard display.widthPixels > 0, display.heightPixels > 0, display.pixelsPerInch > 0 else {
+      throw UTMConversionError.unsupportedConfiguration(
+        "invalid display dimensions or pixel density")
+    }
+    guard configuration.networks.count == 1 else {
+      throw UTMConversionError.unsupportedConfiguration(
+        "Lume currently supports one network adapter; found \(configuration.networks.count)")
+    }
+    guard VZMACAddress(string: configuration.networks[0].macAddress) != nil else {
+      throw UTMConversionError.unsupportedConfiguration("invalid network MAC address")
+    }
+    guard configuration.serials.isEmpty else {
+      throw UTMConversionError.unsupportedConfiguration("serial devices are not supported")
+    }
+    if let sharedDirectories = rawPropertyList["SharedDirectory"] {
+      guard let sharedDirectories = sharedDirectories as? [Any] else {
+        throw UTMConversionError.invalidBundle("SharedDirectory is not an array")
+      }
+      guard sharedDirectories.isEmpty else {
+        throw UTMConversionError.unsupportedConfiguration(
+          "shared directories must be removed before import")
+      }
+    }
+  }
+
+  private func validateHardwareModel(_ data: Data) throws -> VZMacHardwareModel {
+    guard let model = VZMacHardwareModel(dataRepresentation: data) else {
+      throw UTMConversionError.unsupportedConfiguration("invalid Mac hardware model")
+    }
+    guard model.isSupported else {
+      throw UTMConversionError.unsupportedConfiguration(
+        "the Mac hardware model is not supported on this host")
+    }
+    return model
+  }
+
+  private func validateCPUAndMemory(cpuCount: Int, memorySize: UInt64) throws {
+    guard cpuCount >= VZVirtualMachineConfiguration.minimumAllowedCPUCount,
+      cpuCount <= VZVirtualMachineConfiguration.maximumAllowedCPUCount
+    else {
+      throw UTMConversionError.unsupportedConfiguration(
+        "CPU count \(cpuCount) is outside the supported range \(VZVirtualMachineConfiguration.minimumAllowedCPUCount)...\(VZVirtualMachineConfiguration.maximumAllowedCPUCount)"
+      )
+    }
+    guard memorySize >= VZVirtualMachineConfiguration.minimumAllowedMemorySize,
+      memorySize <= VZVirtualMachineConfiguration.maximumAllowedMemorySize,
+      memorySize % Self.bytesPerMiB == 0
+    else {
+      throw UTMConversionError.unsupportedConfiguration(
+        "guest memory size is outside the Virtualization.framework range or is not MiB-aligned")
+    }
+  }
+
+  private func makeUTMNetwork(
+    from mode: NetworkMode,
+    excluding originalMacAddress: String
+  ) -> UTMBundleConfiguration.Network {
+    switch mode {
+    case .nat:
+      return .init(
+        mode: "Shared",
+        macAddress: Self.generateFreshMacAddress(excluding: originalMacAddress),
+        bridgeInterface: nil)
+    case .bridged(let interface):
+      return .init(
+        mode: "Bridged",
+        macAddress: Self.generateFreshMacAddress(excluding: originalMacAddress),
+        bridgeInterface: interface)
+    }
+  }
+
+  private func validateVMName(_ name: String) throws {
+    guard !name.isEmpty,
+      name != ".",
+      name != "..",
+      !name.contains("/"),
+      !name.utf8.contains(0)
+    else {
+      throw UTMConversionError.invalidVMName(name)
+    }
+  }
+
+  private func resolveDataFile(named name: String, in dataURL: URL) throws -> URL {
+    guard !name.isEmpty,
+      name != ".",
+      name != "..",
+      name == URL(fileURLWithPath: name).lastPathComponent
+    else {
+      throw UTMConversionError.invalidBundle("unsafe Data path '\(name)'")
+    }
+
+    let standardizedDataURL = dataURL.standardizedFileURL
+    let url = standardizedDataURL.appendingPathComponent(name, isDirectory: false)
+      .standardizedFileURL
+    guard url.deletingLastPathComponent() == standardizedDataURL else {
+      throw UTMConversionError.invalidBundle("unsafe Data path '\(name)'")
+    }
+    _ = try regularFileSize(at: url)
+    return url
+  }
+
+  private func requireDirectoryWithoutSymlink(at url: URL) throws {
+    var info = stat()
+    let result: Int32 = url.withUnsafeFileSystemRepresentation { path in
+      guard let path else { return -1 }
+      return lstat(path, &info)
+    }
+    guard result == 0 else {
+      throw UTMConversionError.missingFile(url.path)
+    }
+    guard (info.st_mode & S_IFMT) == S_IFDIR else {
+      throw UTMConversionError.invalidBundle("not a real directory: \(url.path)")
+    }
+  }
+
+  private func regularFileSize(at url: URL) throws -> UInt64 {
+    var info = stat()
+    let result: Int32 = url.withUnsafeFileSystemRepresentation { path in
+      guard let path else { return -1 }
+      return lstat(path, &info)
+    }
+    guard result == 0 else {
+      throw UTMConversionError.missingFile(url.path)
+    }
+    guard (info.st_mode & S_IFMT) == S_IFREG, info.st_size > 0 else {
+      throw UTMConversionError.invalidFile("not a non-empty regular file: \(url.path)")
+    }
+    return UInt64(info.st_size)
+  }
+
+  private func validateRawDiskImage(at url: URL) throws {
+    let handle = try FileHandle(forReadingFrom: url)
+    defer { try? handle.close() }
+
+    let prefix = try handle.read(upToCount: 4) ?? Data()
+    if prefix == Self.qcowMagic {
+      throw UTMConversionError.unsupportedConfiguration("QCOW2 disk images are not supported")
+    }
+    if prefix == Self.asifMagic {
+      throw UTMConversionError.unsupportedConfiguration("ASIF disk images are not supported")
+    }
+
+    let size = try handle.seekToEnd()
+    if size >= 512 {
+      try handle.seek(toOffset: size - 512)
+      let suffixMagic = try handle.read(upToCount: 4) ?? Data()
+      if suffixMagic == Self.udifMagic {
+        throw UTMConversionError.unsupportedConfiguration("UDIF disk images are not supported")
+      }
+    }
+  }
+
+  private func entryExists(at url: URL) -> Bool {
+    var info = stat()
+    return url.withUnsafeFileSystemRepresentation { path in
+      guard let path else { return false }
+      return lstat(path, &info) == 0
+    }
+  }
+
+  private func createAtomically(at destinationURL: URL, populate: (URL) throws -> Void) throws {
+    guard !entryExists(at: destinationURL) else {
+      throw UTMConversionError.destinationExists(destinationURL.path)
+    }
+    let parentURL = destinationURL.deletingLastPathComponent()
+    var isDirectory: ObjCBool = false
+    guard fileManager.fileExists(atPath: parentURL.path, isDirectory: &isDirectory),
+      isDirectory.boolValue
+    else {
+      throw UTMConversionError.missingFile(parentURL.path)
+    }
+
+    let temporaryURL = parentURL.appendingPathComponent(
+      ".partial-\(UUID().uuidString)",
+      isDirectory: true)
+    try fileManager.createDirectory(at: temporaryURL, withIntermediateDirectories: false)
+    do {
+      try populate(temporaryURL)
+      guard !entryExists(at: destinationURL) else {
+        throw UTMConversionError.destinationExists(destinationURL.path)
+      }
+      try fileManager.moveItem(at: temporaryURL, to: destinationURL)
+    } catch {
+      try? fileManager.removeItem(at: temporaryURL)
+      throw error
+    }
+  }
+
+  private func cloneOrCopyFile(from sourceURL: URL, to destinationURL: URL) throws {
+    guard !entryExists(at: destinationURL) else {
+      throw UTMConversionError.destinationExists(destinationURL.path)
+    }
+    if Darwin.clonefile(sourceURL.path, destinationURL.path, 0) == 0 {
+      return
+    }
+
+    let cloneError = errno
+    try? fileManager.removeItem(at: destinationURL)
+    do {
+      try fileManager.copyItem(at: sourceURL, to: destinationURL)
+    } catch {
+      throw UTMConversionError.copyFailed(
+        source: sourceURL.path,
+        destination: destinationURL.path,
+        reason: "clonefile errno \(cloneError); copy failed: \(error.localizedDescription)")
+    }
+  }
+
+  private static func generateFreshMacAddress(excluding original: String) -> String {
+    var generated: String
+    repeat {
+      generated = VZMACAddress.randomLocallyAdministered().string
+    } while generated.caseInsensitiveCompare(original) == .orderedSame
+    return generated
+  }
+
+  private static func generateFreshMachineIdentifier(excluding original: Data) -> Data {
+    var generated: Data
+    repeat {
+      generated = VZMacMachineIdentifier().dataRepresentation
+    } while generated == original
+    return generated
+  }
+
+  static func defaultFilesAreInUse(_ urls: [URL]) throws -> Bool {
+    for url in urls {
+      let process = Process()
+      process.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
+      process.arguments = ["-t", url.path]
+      let output = Pipe()
+      process.standardOutput = output
+      process.standardError = Pipe()
+      try process.run()
+      let data = try output.fileHandleForReading.readToEnd() ?? Data()
+      process.waitUntilExit()
+      if process.terminationStatus == 0 && !data.isEmpty {
+        return true
+      }
+      if process.terminationStatus != 0 && process.terminationStatus != 1 {
+        throw UTMConversionError.invalidBundle(
+          "could not determine whether \(url.path) is in use")
+      }
+    }
+    return false
+  }
+}

--- a/libs/lume/src/Utils/CommandDocExtractor.swift
+++ b/libs/lume/src/Utils/CommandDocExtractor.swift
@@ -79,6 +79,8 @@ enum CommandDocExtractor {
             pullDoc,
             pushDoc,
             convertDoc,
+            importDoc,
+            exportDoc,
             imagesDoc,
             cloneDoc,
             getDoc,
@@ -223,6 +225,68 @@ enum CommandDocExtractor {
                 FlagDoc(name: "dry-run", shortName: nil, help: "Prepare files without uploading", defaultValue: false),
                 FlagDoc(name: "single-layer", shortName: nil, help: "Push one kubelet-compatible disk layer", defaultValue: false),
             ],
+            subcommands: []
+        )
+    }
+
+    // MARK: - Import
+
+    private static var importDoc: CommandDoc {
+        CommandDoc(
+            name: "import",
+            abstract: "Import a virtual machine from another format",
+            discussion: nil,
+            arguments: [],
+            options: [],
+            flags: [],
+            subcommands: [importUTMDoc]
+        )
+    }
+
+    private static var importUTMDoc: CommandDoc {
+        CommandDoc(
+            name: "utm",
+            abstract: "Import a stopped UTM Apple/macOS VM into Lume",
+            discussion: "Creates an independent Lume VM from a UTM .utm bundle while preserving the raw disk, auxiliary storage, and hardware model. The imported VM receives a fresh machine identifier and MAC address.",
+            arguments: [
+                ArgumentDoc(name: "bundle", help: "Path to the source .utm bundle", type: "Path", isOptional: false),
+                ArgumentDoc(name: "name", help: "Name for the imported Lume VM", type: "String", isOptional: false),
+            ],
+            options: [
+                OptionDoc(name: "storage", shortName: nil, help: "Destination Lume storage location", type: "String", defaultValue: nil, isOptional: true),
+            ],
+            flags: [],
+            subcommands: []
+        )
+    }
+
+    // MARK: - Export
+
+    private static var exportDoc: CommandDoc {
+        CommandDoc(
+            name: "export",
+            abstract: "Export a virtual machine to another format",
+            discussion: nil,
+            arguments: [],
+            options: [],
+            flags: [],
+            subcommands: [exportUTMDoc]
+        )
+    }
+
+    private static var exportUTMDoc: CommandDoc {
+        CommandDoc(
+            name: "utm",
+            abstract: "Export a stopped Lume macOS VM as a UTM bundle",
+            discussion: "Creates an independent UTM Apple/macOS .utm bundle while preserving the raw disk, auxiliary storage, and hardware model. The exported VM receives a fresh machine identifier and MAC address.",
+            arguments: [
+                ArgumentDoc(name: "name", help: "Name of the source Lume VM", type: "String", isOptional: false),
+                ArgumentDoc(name: "output", help: "Destination .utm bundle path", type: "Path", isOptional: false),
+            ],
+            options: [
+                OptionDoc(name: "storage", shortName: nil, help: "Source Lume storage location", type: "String", defaultValue: nil, isOptional: true),
+            ],
+            flags: [],
             subcommands: []
         )
     }

--- a/libs/lume/src/Utils/CommandRegistry.swift
+++ b/libs/lume/src/Utils/CommandRegistry.swift
@@ -7,6 +7,8 @@ enum CommandRegistry {
             Pull.self,
             Push.self,
             Convert.self,
+            Import.self,
+            Export.self,
             Images.self,
             Clone.self,
             Get.self,

--- a/libs/lume/tests/CommandDocExtractorTests.swift
+++ b/libs/lume/tests/CommandDocExtractorTests.swift
@@ -8,5 +8,12 @@ func commandDocumentationCoversRegistry() {
 
     #expect(coverage.missing.isEmpty)
     #expect(coverage.extra.isEmpty)
-    #expect(CommandDocExtractor.extractAll().commands.contains { $0.name == "sip" })
+    let commands = CommandDocExtractor.extractAll().commands
+    #expect(commands.contains { $0.name == "sip" })
+
+    let importDoc = commands.first { $0.name == "import" }
+    let exportDoc = commands.first { $0.name == "export" }
+    #expect(importDoc?.subcommands.contains { $0.name == "utm" } == true)
+    #expect(exportDoc?.subcommands.contains { $0.name == "utm" } == true)
+    #expect(!commands.contains { $0.name == "import-utm" || $0.name == "export-utm" })
 }

--- a/libs/lume/tests/UTMConverterTests.swift
+++ b/libs/lume/tests/UTMConverterTests.swift
@@ -1,0 +1,863 @@
+import Darwin
+import Foundation
+import Testing
+import Virtualization
+
+@testable import lume
+
+@Suite("UTM converter")
+struct UTMConverterTests {
+  @Test("Lume to UTM to Lume preserves boot state and refreshes identity")
+  func roundTripPreservesBootStateAndRefreshesIdentity() throws {
+    let root = try UTMConverterFixtures.makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let source = try UTMConverterFixtures.makeLumeVM(
+      in: root,
+      name: "source-macos",
+      networkMode: .bridged(interface: "en7")
+    )
+    let converter = UTMConverter(filesAreInUse: { _ in false })
+
+    let bundleURL = try converter.exportUTM(
+      from: source.directory,
+      to: root.appendingPathComponent("round-trip")
+    )
+    #expect(bundleURL.pathExtension == "utm")
+
+    let bundle = try UTMConverterFixtures.loadConfiguration(from: bundleURL)
+    let platform = try #require(bundle.system.macPlatform)
+    let exportedNetwork = try #require(bundle.networks.first)
+
+    #expect(bundle.backend == "Apple")
+    #expect(bundle.configurationVersion == UTMBundleConfiguration.supportedVersion)
+    #expect(bundle.system.architecture == "aarch64")
+    #expect(bundle.system.cpuCount == source.config.cpuCount)
+    #expect(bundle.system.memorySize == 8 * 1024)
+    #expect(bundle.system.boot.operatingSystem == "macOS")
+    #expect(platform.hardwareModel == source.config.hardwareModel)
+    #expect(platform.machineIdentifier != source.config.machineIdentifier)
+    #expect(VZMacMachineIdentifier(dataRepresentation: platform.machineIdentifier) != nil)
+    #expect(exportedNetwork.mode == "Bridged")
+    #expect(exportedNetwork.bridgeInterface == "en7")
+    #expect(exportedNetwork.macAddress != source.config.macAddress)
+    #expect(VZMACAddress(string: exportedNetwork.macAddress) != nil)
+    #expect(
+      try Data(contentsOf: bundleURL.appendingPathComponent("Data/disk.img"))
+        == source.diskData
+    )
+    #expect(
+      try Data(contentsOf: bundleURL.appendingPathComponent("Data/AuxiliaryStorage"))
+        == source.auxiliaryData
+    )
+    #expect(
+      try UTMConverterFixtures.inode(of: bundleURL.appendingPathComponent("Data/disk.img"))
+        != UTMConverterFixtures.inode(of: source.directory.diskPath.url)
+    )
+    #expect(
+      try UTMConverterFixtures.inode(
+        of: bundleURL.appendingPathComponent("Data/AuxiliaryStorage"))
+        != UTMConverterFixtures.inode(of: source.directory.nvramPath.url)
+    )
+
+    let importedDirectory = VMDirectory(
+      Path(root.appendingPathComponent("imported-macos").path)
+    )
+    try converter.importUTM(from: bundleURL, named: importedDirectory.name, to: importedDirectory)
+
+    let importedConfig = try importedDirectory.loadConfig()
+    #expect(try Data(contentsOf: importedDirectory.diskPath.url) == source.diskData)
+    #expect(try Data(contentsOf: importedDirectory.nvramPath.url) == source.auxiliaryData)
+    #expect(importedConfig.os == "macOS")
+    #expect(importedConfig.cpuCount == source.config.cpuCount)
+    #expect(importedConfig.memorySize == source.config.memorySize)
+    #expect(importedConfig.diskSize == UInt64(source.diskData.count))
+    #expect(importedConfig.display.string == source.config.display.string)
+    #expect(importedConfig.networkMode == source.config.networkMode)
+    #expect(importedConfig.hardwareModel == source.config.hardwareModel)
+    #expect(importedConfig.machineIdentifier != source.config.machineIdentifier)
+    #expect(importedConfig.machineIdentifier != platform.machineIdentifier)
+    #expect(importedConfig.macAddress != source.config.macAddress)
+    #expect(importedConfig.macAddress != exportedNetwork.macAddress)
+    #expect(
+      importedConfig.machineIdentifier.flatMap(VZMacMachineIdentifier.init(dataRepresentation:))
+        != nil
+    )
+    #expect(importedConfig.macAddress.flatMap(VZMACAddress.init(string:)) != nil)
+    #expect(
+      try UTMConverterFixtures.inode(of: importedDirectory.diskPath.url)
+        != UTMConverterFixtures.inode(of: bundleURL.appendingPathComponent("Data/disk.img"))
+    )
+    #expect(
+      try UTMConverterFixtures.inode(of: importedDirectory.nvramPath.url)
+        != UTMConverterFixtures.inode(
+          of: bundleURL.appendingPathComponent("Data/AuxiliaryStorage"))
+    )
+
+    let unchangedSourceConfig = try source.directory.loadConfig()
+    #expect(unchangedSourceConfig.machineIdentifier == source.config.machineIdentifier)
+    #expect(unchangedSourceConfig.macAddress == source.config.macAddress)
+  }
+
+  @Test("Import rejects incompatible and unsafe UTM configurations")
+  func importRejectsIncompatibleAndUnsafeConfigurations() throws {
+    let root = try UTMConverterFixtures.makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let source = try UTMConverterFixtures.makeLumeVM(in: root, name: "rejection-source")
+    let converter = UTMConverter(filesAreInUse: { _ in false })
+
+    for rejection in ImportRejection.allCases {
+      let bundleURL = try converter.exportUTM(
+        from: source.directory,
+        to: root.appendingPathComponent("reject-\(rejection.rawValue).utm")
+      )
+      var configuration = try UTMConverterFixtures.loadConfiguration(from: bundleURL)
+      rejection.mutate(&configuration)
+      try UTMConverterFixtures.saveConfiguration(configuration, to: bundleURL)
+
+      let destination = VMDirectory(
+        Path(root.appendingPathComponent("destination-\(rejection.rawValue)").path)
+      )
+      let error = try #require(
+        UTMConverterFixtures.captureConversionError {
+          try converter.importUTM(from: bundleURL, named: destination.name, to: destination)
+        }
+      )
+
+      #expect(rejection.matches(error), "Unexpected error for \(rejection): \(error)")
+      #expect(!destination.exists())
+    }
+  }
+
+  @Test("Import rejects suspended state without leaving a partial VM")
+  func importRejectsSuspendedStateAtomically() throws {
+    let root = try UTMConverterFixtures.makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let source = try UTMConverterFixtures.makeLumeVM(in: root, name: "suspended-source")
+    let converter = UTMConverter(filesAreInUse: { _ in false })
+    let bundleURL = try converter.exportUTM(
+      from: source.directory,
+      to: root.appendingPathComponent("suspended.utm")
+    )
+    try Data([0x01]).write(
+      to: bundleURL.appendingPathComponent("Data/vmstate", isDirectory: false)
+    )
+
+    let destination = VMDirectory(Path(root.appendingPathComponent("suspended-import").path))
+    let error = try #require(
+      UTMConverterFixtures.captureConversionError {
+        try converter.importUTM(from: bundleURL, named: destination.name, to: destination)
+      }
+    )
+
+    guard case .unsupportedConfiguration(let reason) = error else {
+      Issue.record("Expected suspended-state rejection, got \(error)")
+      return
+    }
+    #expect(reason.contains("suspended state"))
+    #expect(!destination.exists())
+    #expect(
+      try FileManager.default.contentsOfDirectory(at: root, includingPropertiesForKeys: nil)
+        .allSatisfy { !$0.lastPathComponent.contains(".partial-") }
+    )
+  }
+
+  @Test("In-use checks reject export and import before committing destinations")
+  func inUseChecksRejectWithoutPartialDestinations() throws {
+    let root = try UTMConverterFixtures.makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let source = try UTMConverterFixtures.makeLumeVM(in: root, name: "busy-source")
+    let freeConverter = UTMConverter(filesAreInUse: { _ in false })
+    let busyConverter = UTMConverter(filesAreInUse: { _ in true })
+
+    let rejectedExportURL = root.appendingPathComponent("busy-export.utm")
+    let exportError = try #require(
+      UTMConverterFixtures.captureConversionError {
+        _ = try busyConverter.exportUTM(from: source.directory, to: rejectedExportURL)
+      }
+    )
+    guard case .sourceInUse(let exportSource) = exportError else {
+      Issue.record("Expected source-in-use export error, got \(exportError)")
+      return
+    }
+    #expect(exportSource == source.directory.dir.path)
+    #expect(!FileManager.default.fileExists(atPath: rejectedExportURL.path))
+
+    let importBundleURL = try freeConverter.exportUTM(
+      from: source.directory,
+      to: root.appendingPathComponent("busy-import-source.utm")
+    )
+    let rejectedImport = VMDirectory(
+      Path(root.appendingPathComponent("busy-import-destination").path)
+    )
+    let importError = try #require(
+      UTMConverterFixtures.captureConversionError {
+        try busyConverter.importUTM(
+          from: importBundleURL, named: rejectedImport.name, to: rejectedImport)
+      }
+    )
+    guard case .sourceInUse(let importSource) = importError else {
+      Issue.record("Expected source-in-use import error, got \(importError)")
+      return
+    }
+    #expect(importSource == importBundleURL.path)
+    #expect(!rejectedImport.exists())
+  }
+
+  @Test("Advisory locks and open source files are detected")
+  func realSourceUseChecksAreEnforced() throws {
+    let root = try UTMConverterFixtures.makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let source = try UTMConverterFixtures.makeLumeVM(in: root, name: "real-lock-source")
+    let configHandle = try FileHandle(forUpdating: source.directory.configPath.url)
+    defer { try? configHandle.close() }
+    try #require(flock(configHandle.fileDescriptor, LOCK_EX | LOCK_NB) == 0)
+    defer { flock(configHandle.fileDescriptor, LOCK_UN) }
+
+    let lockedOutput = root.appendingPathComponent("locked.utm")
+    let lockError = try #require(
+      UTMConverterFixtures.captureConversionError {
+        _ = try UTMConverter(filesAreInUse: { _ in false }).exportUTM(
+          from: source.directory,
+          to: lockedOutput)
+      }
+    )
+    guard case .sourceInUse = lockError else {
+      Issue.record("Expected config lock rejection, got \(lockError)")
+      return
+    }
+    #expect(!FileManager.default.fileExists(atPath: lockedOutput.path))
+
+    flock(configHandle.fileDescriptor, LOCK_UN)
+    let bundleURL = try UTMConverter(filesAreInUse: { _ in false }).exportUTM(
+      from: source.directory,
+      to: root.appendingPathComponent("open-source.utm")
+    )
+    let openDisk = try FileHandle(
+      forReadingFrom: bundleURL.appendingPathComponent("Data/disk.img"))
+    defer { try? openDisk.close() }
+
+    let destination = VMDirectory(Path(root.appendingPathComponent("open-source-import").path))
+    let openError = try #require(
+      UTMConverterFixtures.captureConversionError {
+        try UTMConverter().importUTM(
+          from: bundleURL,
+          named: destination.name,
+          to: destination)
+      }
+    )
+    guard case .sourceInUse = openError else {
+      Issue.record("Expected open file rejection, got \(openError)")
+      return
+    }
+    #expect(!destination.exists())
+    try UTMConverterFixtures.expectNoPartialItems(in: root)
+  }
+
+  @Test("Import accepts UTM version-4 defaulted and legacy device fields")
+  func importAcceptsVersion4Defaults() throws {
+    let root = try UTMConverterFixtures.makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let source = try UTMConverterFixtures.makeLumeVM(in: root, name: "defaults-source")
+    let converter = UTMConverter(filesAreInUse: { _ in false })
+    let bundleURL = try converter.exportUTM(
+      from: source.directory,
+      to: root.appendingPathComponent("defaults.utm")
+    )
+    try UTMConverterFixtures.applyVersion4Defaults(to: bundleURL)
+
+    let destination = VMDirectory(Path(root.appendingPathComponent("defaults-import").path))
+    try converter.importUTM(
+      from: bundleURL,
+      named: destination.name,
+      to: destination)
+
+    #expect(destination.initialized())
+    #expect(try Data(contentsOf: destination.diskPath.url) == source.diskData)
+    #expect(try Data(contentsOf: destination.nvramPath.url) == source.auxiliaryData)
+  }
+
+  @Test("Import rejects symlink escapes and shared directories")
+  func importRejectsSymlinkEscapesAndSharedDirectories() throws {
+    let root = try UTMConverterFixtures.makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let source = try UTMConverterFixtures.makeLumeVM(in: root, name: "symlink-source")
+    let converter = UTMConverter(filesAreInUse: { _ in false })
+
+    let symlinkBundle = try converter.exportUTM(
+      from: source.directory,
+      to: root.appendingPathComponent("symlink.utm")
+    )
+    let outsideDisk = root.appendingPathComponent("outside.img")
+    try Data([0x01, 0x02]).write(to: outsideDisk)
+    let linkedDisk = symlinkBundle.appendingPathComponent("Data/linked.img")
+    try FileManager.default.createSymbolicLink(at: linkedDisk, withDestinationURL: outsideDisk)
+    var symlinkConfig = try UTMConverterFixtures.loadConfiguration(from: symlinkBundle)
+    symlinkConfig.drives[0].imageName = "linked.img"
+    try UTMConverterFixtures.saveConfiguration(symlinkConfig, to: symlinkBundle)
+
+    let symlinkDestination = VMDirectory(Path(root.appendingPathComponent("symlink-import").path))
+    let symlinkError = try #require(
+      UTMConverterFixtures.captureConversionError {
+        try converter.importUTM(
+          from: symlinkBundle,
+          named: symlinkDestination.name,
+          to: symlinkDestination)
+      }
+    )
+    guard case .invalidFile(let symlinkReason) = symlinkError else {
+      Issue.record("Expected symlink bundle rejection, got \(symlinkError)")
+      return
+    }
+    #expect(symlinkReason.contains("regular file"))
+    #expect(!symlinkDestination.exists())
+
+    let sharedBundle = try converter.exportUTM(
+      from: source.directory,
+      to: root.appendingPathComponent("shared-directory.utm")
+    )
+    try UTMConverterFixtures.addSharedDirectory(to: sharedBundle)
+    let sharedDestination = VMDirectory(Path(root.appendingPathComponent("shared-import").path))
+    let sharedError = try #require(
+      UTMConverterFixtures.captureConversionError {
+        try converter.importUTM(
+          from: sharedBundle,
+          named: sharedDestination.name,
+          to: sharedDestination)
+      }
+    )
+    guard case .unsupportedConfiguration(let sharedReason) = sharedError else {
+      Issue.record("Expected shared-directory rejection, got \(sharedError)")
+      return
+    }
+    #expect(sharedReason.contains("shared directories"))
+    #expect(!sharedDestination.exists())
+    try UTMConverterFixtures.expectNoPartialItems(in: root)
+  }
+
+  @Test("Import and export reject unsupported disk image formats")
+  func rejectsUnsupportedDiskFormats() throws {
+    let root = try UTMConverterFixtures.makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    for diskFormat in UnsupportedDiskFormat.allCases {
+      let source = try UTMConverterFixtures.makeLumeVM(
+        in: root,
+        name: "format-source-\(diskFormat.rawValue)")
+      try diskFormat.writeSignature(to: source.directory.diskPath.url)
+      let converter = UTMConverter(filesAreInUse: { _ in false })
+      let output = root.appendingPathComponent("format-export-\(diskFormat.rawValue).utm")
+      let exportError = try #require(
+        UTMConverterFixtures.captureConversionError {
+          _ = try converter.exportUTM(from: source.directory, to: output)
+        }
+      )
+      guard case .unsupportedConfiguration(let reason) = exportError else {
+        Issue.record("Expected disk format rejection, got \(exportError)")
+        continue
+      }
+      #expect(reason.contains(diskFormat.errorName))
+      #expect(!FileManager.default.fileExists(atPath: output.path))
+    }
+    try UTMConverterFixtures.expectNoPartialItems(in: root)
+  }
+
+  @Test("Existing destinations and invalid requested names are never overwritten")
+  func existingDestinationsAndInvalidNamesAreRejected() throws {
+    let root = try UTMConverterFixtures.makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let source = try UTMConverterFixtures.makeLumeVM(in: root, name: "destination-source")
+    let converter = UTMConverter(filesAreInUse: { _ in false })
+    let existingOutput = root.appendingPathComponent("existing.utm")
+    try Data("keep".utf8).write(to: existingOutput)
+
+    let exportError = try #require(
+      UTMConverterFixtures.captureConversionError {
+        _ = try converter.exportUTM(from: source.directory, to: existingOutput)
+      }
+    )
+    guard case .destinationExists = exportError else {
+      Issue.record("Expected existing export rejection, got \(exportError)")
+      return
+    }
+    #expect(try Data(contentsOf: existingOutput) == Data("keep".utf8))
+
+    let bundleURL = try converter.exportUTM(
+      from: source.directory,
+      to: root.appendingPathComponent("import-source.utm")
+    )
+    let existingImport = VMDirectory(Path(root.appendingPathComponent("existing-import").path))
+    try FileManager.default.createDirectory(
+      at: existingImport.dir.url,
+      withIntermediateDirectories: false)
+    let importError = try #require(
+      UTMConverterFixtures.captureConversionError {
+        try converter.importUTM(
+          from: bundleURL,
+          named: existingImport.name,
+          to: existingImport)
+      }
+    )
+    guard case .destinationExists = importError else {
+      Issue.record("Expected existing import rejection, got \(importError)")
+      return
+    }
+
+    let normalizedDestination = VMDirectory(
+      Path(root.appendingPathComponent("escaped-name").path)
+    )
+    let nameError = try #require(
+      UTMConverterFixtures.captureConversionError {
+        try converter.importUTM(
+          from: bundleURL,
+          named: "../escaped-name",
+          to: normalizedDestination)
+      }
+    )
+    guard case .invalidVMName("../escaped-name") = nameError else {
+      Issue.record("Expected invalid name rejection, got \(nameError)")
+      return
+    }
+    #expect(!normalizedDestination.exists())
+    try UTMConverterFixtures.expectNoPartialItems(in: root)
+  }
+
+  @Test("Copy failures remove temporary output")
+  func copyFailureRemovesTemporaryOutput() throws {
+    let root = try UTMConverterFixtures.makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let source = try UTMConverterFixtures.makeLumeVM(in: root, name: "copy-failure-source")
+    let output = root.appendingPathComponent("copy-failure.utm")
+    let converter = UTMConverter(filesAreInUse: { _ in
+      try FileManager.default.removeItem(at: source.directory.nvramPath.url)
+      return false
+    })
+
+    let error = try #require(
+      UTMConverterFixtures.captureConversionError {
+        _ = try converter.exportUTM(from: source.directory, to: output)
+      }
+    )
+    guard case .copyFailed = error else {
+      Issue.record("Expected copy failure, got \(error)")
+      return
+    }
+    #expect(!FileManager.default.fileExists(atPath: output.path))
+    try UTMConverterFixtures.expectNoPartialItems(in: root)
+  }
+
+  @Test("Export validates lossless memory and source metadata")
+  func exportValidatesSourceMetadata() throws {
+    let root = try UTMConverterFixtures.makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    for rejection in ExportRejection.allCases {
+      let source = try UTMConverterFixtures.makeLumeVM(
+        in: root,
+        name: "export-rejection-\(rejection.rawValue)")
+      var config = source.config
+      rejection.mutate(&config)
+      try source.directory.saveConfig(config)
+
+      let output = root.appendingPathComponent("export-rejected-\(rejection.rawValue).utm")
+      let error = try #require(
+        UTMConverterFixtures.captureConversionError {
+          _ = try UTMConverter(filesAreInUse: { _ in false }).exportUTM(
+            from: source.directory,
+            to: output)
+        }
+      )
+      #expect(rejection.matches(error), "Unexpected error for \(rejection): \(error)")
+      #expect(!FileManager.default.fileExists(atPath: output.path))
+    }
+    try UTMConverterFixtures.expectNoPartialItems(in: root)
+  }
+
+  @MainActor
+  @Test("Import and export UTM subcommands parse storage options")
+  func commandsParseStorageOptions() throws {
+    let importRoot = try Lume.parseAsRoot([
+      "import", "utm", "/tmp/Test.utm", "imported", "--storage", "/tmp/vms",
+    ])
+    let importCommand = try #require(importRoot as? ImportUTM)
+    #expect(importCommand.bundle.url.path == "/tmp/Test.utm")
+    #expect(importCommand.name == "imported")
+    #expect(importCommand.storage == "/tmp/vms")
+
+    let exportRoot = try Lume.parseAsRoot([
+      "export", "utm", "source", "/tmp/Test.utm", "--storage", "external",
+    ])
+    let exportCommand = try #require(exportRoot as? ExportUTM)
+    #expect(exportCommand.name == "source")
+    #expect(exportCommand.output.url.path == "/tmp/Test.utm")
+    #expect(exportCommand.storage == "external")
+  }
+}
+
+private enum ImportRejection: String, CaseIterable {
+  case backend
+  case version
+  case guest
+  case architecture
+  case uefi
+  case zeroCPU
+  case zeroMemory
+  case unsafeDiskPath
+  case nestedDiskPath
+  case absoluteDiskPath
+  case unsafeAuxiliaryPath
+  case invalidHardwareModel
+  case invalidMachineIdentifier
+  case invalidMacAddress
+  case missingDiskImage
+  case readOnlyDisk
+  case nvmeDisk
+  case multipleDisks
+  case multipleDisplays
+  case multipleNetworks
+  case serialDevice
+  case unsupportedNetworkMode
+
+  func mutate(_ configuration: inout UTMBundleConfiguration) {
+    switch self {
+    case .backend:
+      configuration.backend = "QEMU"
+    case .version:
+      configuration.configurationVersion = UTMBundleConfiguration.supportedVersion + 1
+    case .guest:
+      configuration.system.boot.operatingSystem = "Linux"
+    case .architecture:
+      configuration.system.architecture = "x86_64"
+    case .uefi:
+      configuration.system.boot.uefiBoot = true
+    case .zeroCPU:
+      configuration.system.cpuCount = 0
+    case .zeroMemory:
+      configuration.system.memorySize = 0
+    case .unsafeDiskPath:
+      configuration.drives[0].imageName = "../disk.img"
+    case .nestedDiskPath:
+      configuration.drives[0].imageName = "nested/disk.img"
+    case .absoluteDiskPath:
+      configuration.drives[0].imageName = "/tmp/disk.img"
+    case .unsafeAuxiliaryPath:
+      configuration.system.macPlatform?.auxiliaryStoragePath = ".."
+    case .invalidHardwareModel:
+      configuration.system.macPlatform?.hardwareModel = Data([0x00])
+    case .invalidMachineIdentifier:
+      configuration.system.macPlatform?.machineIdentifier = Data([0x00])
+    case .invalidMacAddress:
+      configuration.networks[0].macAddress = "invalid"
+    case .missingDiskImage:
+      configuration.drives[0].imageName = nil
+    case .readOnlyDisk:
+      configuration.drives[0].readOnly = true
+    case .nvmeDisk:
+      configuration.drives[0].nvme = true
+    case .multipleDisks:
+      configuration.drives.append(configuration.drives[0])
+    case .multipleDisplays:
+      configuration.displays.append(configuration.displays[0])
+    case .multipleNetworks:
+      configuration.networks.append(configuration.networks[0])
+    case .serialDevice:
+      configuration.serials.append(.init(mode: "Ptty"))
+    case .unsupportedNetworkMode:
+      configuration.networks[0].mode = "HostOnly"
+    }
+  }
+
+  func matches(_ error: UTMConversionError) -> Bool {
+    switch (self, error) {
+    case (.backend, .unsupportedBackend("QEMU")):
+      return true
+    case (.version, .unsupportedVersion(5)):
+      return true
+    case (.guest, .unsupportedGuest("Linux")):
+      return true
+    case (.architecture, .unsupportedConfiguration(let reason)):
+      return reason.contains("not Apple Silicon")
+    case (.uefi, .unsupportedConfiguration(let reason)):
+      return reason.contains("UEFI")
+    case (.zeroCPU, .unsupportedConfiguration(let reason)):
+      return reason.contains("CPU count")
+    case (.zeroMemory, .unsupportedConfiguration(let reason)):
+      return reason.contains("guest memory")
+    case (.unsafeDiskPath, .invalidBundle(let reason)),
+      (.nestedDiskPath, .invalidBundle(let reason)),
+      (.absoluteDiskPath, .invalidBundle(let reason)),
+      (.unsafeAuxiliaryPath, .invalidBundle(let reason)):
+      return reason.contains("unsafe Data path")
+    case (.invalidHardwareModel, .unsupportedConfiguration(let reason)):
+      return reason == "invalid Mac hardware model"
+    case (.invalidMachineIdentifier, .unsupportedConfiguration(let reason)):
+      return reason == "invalid Mac machine identifier"
+    case (.invalidMacAddress, .unsupportedConfiguration(let reason)):
+      return reason == "invalid network MAC address"
+    case (.missingDiskImage, .unsupportedConfiguration(let reason)):
+      return reason.contains("external or removable")
+    case (.readOnlyDisk, .unsupportedConfiguration(let reason)):
+      return reason.contains("writable")
+    case (.nvmeDisk, .unsupportedConfiguration(let reason)):
+      return reason.contains("NVMe")
+    case (.multipleDisks, .unsupportedConfiguration(let reason)):
+      return reason.contains("exactly one internal boot disk")
+    case (.multipleDisplays, .unsupportedConfiguration(let reason)):
+      return reason.contains("one display")
+    case (.multipleNetworks, .unsupportedConfiguration(let reason)):
+      return reason.contains("one network adapter")
+    case (.serialDevice, .unsupportedConfiguration(let reason)):
+      return reason.contains("serial devices")
+    case (.unsupportedNetworkMode, .unsupportedConfiguration(let reason)):
+      return reason.contains("unknown network mode")
+    default:
+      return false
+    }
+  }
+}
+
+private enum ExportRejection: String, CaseIterable {
+  case zeroCPU
+  case unalignedMemory
+  case diskSizeMismatch
+  case invalidHardwareModel
+  case invalidMachineIdentifier
+  case invalidMacAddress
+
+  func mutate(_ configuration: inout VMConfig) {
+    switch self {
+    case .zeroCPU:
+      configuration.setCpuCount(0)
+    case .unalignedMemory:
+      configuration.setMemorySize(8 * 1024 * 1024 * 1024 + 1)
+    case .diskSizeMismatch:
+      configuration.setDiskSize((configuration.diskSize ?? 0) + 1)
+    case .invalidHardwareModel:
+      configuration.setHardwareModel(Data([0x00]))
+    case .invalidMachineIdentifier:
+      configuration.setMachineIdentifier(Data([0x00]))
+    case .invalidMacAddress:
+      configuration.setMacAddress("invalid")
+    }
+  }
+
+  func matches(_ error: UTMConversionError) -> Bool {
+    guard case .unsupportedConfiguration(let reason) = error else {
+      return false
+    }
+    switch self {
+    case .zeroCPU:
+      return reason.contains("CPU count")
+    case .unalignedMemory:
+      return reason.contains("MiB")
+    case .diskSizeMismatch:
+      return reason.contains("disk size")
+    case .invalidHardwareModel:
+      return reason.contains("hardware model")
+    case .invalidMachineIdentifier:
+      return reason.contains("machine identifier")
+    case .invalidMacAddress:
+      return reason.contains("MAC address")
+    }
+  }
+}
+
+private enum UnsupportedDiskFormat: String, CaseIterable {
+  case qcow2
+  case asif
+  case udif
+
+  var errorName: String {
+    rawValue.uppercased()
+  }
+
+  func writeSignature(to url: URL) throws {
+    let handle = try FileHandle(forWritingTo: url)
+    defer { try? handle.close() }
+    switch self {
+    case .qcow2:
+      try handle.write(contentsOf: Data([0x51, 0x46, 0x49, 0xfb]))
+    case .asif:
+      try handle.write(contentsOf: Data("shdw".utf8))
+    case .udif:
+      let size = try handle.seekToEnd()
+      try handle.seek(toOffset: size - 512)
+      try handle.write(contentsOf: Data("koly".utf8))
+    }
+  }
+}
+
+private enum UTMConverterFixtures {
+  struct LumeVM {
+    let directory: VMDirectory
+    let config: VMConfig
+    let diskData: Data
+    let auxiliaryData: Data
+  }
+
+  enum FixtureError: Error {
+    case invalidHardwareModelFixture
+  }
+
+  static func makeTemporaryDirectory() throws -> URL {
+    let url = FileManager.default.temporaryDirectory.appendingPathComponent(
+      "UTMConverterTests-\(UUID().uuidString)",
+      isDirectory: true
+    )
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
+    return url
+  }
+
+  static func makeLumeVM(
+    in root: URL,
+    name: String,
+    networkMode: NetworkMode = .nat
+  ) throws -> LumeVM {
+    let directory = VMDirectory(Path(root.appendingPathComponent(name).path))
+    try FileManager.default.createDirectory(
+      at: directory.dir.url,
+      withIntermediateDirectories: false
+    )
+
+    let diskData = Data((0..<16_384).map { UInt8(($0 * 31) % 251) })
+    let auxiliaryData = Data((0..<4_096).map { UInt8(($0 * 17) % 253) })
+    try diskData.write(to: directory.diskPath.url)
+    try auxiliaryData.write(to: directory.nvramPath.url)
+
+    let hardwareModel = try validHardwareModelData()
+    let machineIdentifier = VZMacMachineIdentifier().dataRepresentation
+    let config = try VMConfig(
+      os: "macOS",
+      cpuCount: 6,
+      memorySize: 8 * 1024 * 1024 * 1024,
+      diskSize: UInt64(diskData.count),
+      macAddress: "02:00:00:00:00:11",
+      display: "1920x1080",
+      hardwareModel: hardwareModel,
+      machineIdentifier: machineIdentifier,
+      networkMode: networkMode
+    )
+    try directory.saveConfig(config)
+    return LumeVM(
+      directory: directory,
+      config: config,
+      diskData: diskData,
+      auxiliaryData: auxiliaryData
+    )
+  }
+
+  static func loadConfiguration(from bundleURL: URL) throws -> UTMBundleConfiguration {
+    let data = try Data(
+      contentsOf: bundleURL.appendingPathComponent("config.plist", isDirectory: false)
+    )
+    return try PropertyListDecoder().decode(UTMBundleConfiguration.self, from: data)
+  }
+
+  static func saveConfiguration(
+    _ configuration: UTMBundleConfiguration,
+    to bundleURL: URL
+  ) throws {
+    let encoder = PropertyListEncoder()
+    encoder.outputFormat = .xml
+    let data = try encoder.encode(configuration)
+    try data.write(
+      to: bundleURL.appendingPathComponent("config.plist", isDirectory: false),
+      options: .atomic
+    )
+  }
+
+  static func captureConversionError(_ operation: () throws -> Void) -> UTMConversionError? {
+    do {
+      try operation()
+      Issue.record("Expected UTM conversion to fail")
+      return nil
+    } catch let error as UTMConversionError {
+      return error
+    } catch {
+      Issue.record("Expected UTMConversionError, got \(error)")
+      return nil
+    }
+  }
+
+  static func inode(of url: URL) throws -> UInt64 {
+    let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+    return try #require((attributes[.systemFileNumber] as? NSNumber)?.uint64Value)
+  }
+
+  static func addSharedDirectory(to bundleURL: URL) throws {
+    try updateRawConfiguration(in: bundleURL) { plist in
+      plist["SharedDirectory"] = [
+        ["Path": "/tmp/shared", "ReadOnly": true]
+      ]
+    }
+  }
+
+  static func applyVersion4Defaults(to bundleURL: URL) throws {
+    try updateRawConfiguration(in: bundleURL) { plist in
+      var system = try #require(plist["System"] as? [String: Any])
+      var boot = try #require(system["Boot"] as? [String: Any])
+      boot.removeValue(forKey: "UEFIBoot")
+      system["Boot"] = boot
+      plist["System"] = system
+
+      var displays = try #require(plist["Display"] as? [[String: Any]])
+      displays[0].removeValue(forKey: "DynamicResolution")
+      plist["Display"] = displays
+
+      var drives = try #require(plist["Drive"] as? [[String: Any]])
+      drives[0].removeValue(forKey: "ReadOnly")
+      drives[0].removeValue(forKey: "Nvme")
+      plist["Drive"] = drives
+
+      var virtualization = try #require(plist["Virtualization"] as? [String: Any])
+      virtualization["Keyboard"] = true
+      virtualization["Pointer"] = true
+      virtualization["Trackpad"] = true
+      virtualization.removeValue(forKey: "ClipboardSharing")
+      plist["Virtualization"] = virtualization
+    }
+  }
+
+  static func expectNoPartialItems(in root: URL) throws {
+    let items = try FileManager.default.contentsOfDirectory(
+      at: root,
+      includingPropertiesForKeys: nil)
+    #expect(items.allSatisfy { !$0.lastPathComponent.hasPrefix(".partial-") })
+  }
+
+  private static func updateRawConfiguration(
+    in bundleURL: URL,
+    update: (inout [String: Any]) throws -> Void
+  ) throws {
+    let configURL = bundleURL.appendingPathComponent("config.plist")
+    let data = try Data(contentsOf: configURL)
+    var plist = try #require(
+      try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+    )
+    try update(&plist)
+    let updated = try PropertyListSerialization.data(
+      fromPropertyList: plist,
+      format: .xml,
+      options: 0)
+    try updated.write(to: configURL, options: .atomic)
+  }
+
+  private static func validHardwareModelData() throws -> Data {
+    let encoded =
+      "YnBsaXN0MDDTAQIDBAQFXxAZRGF0YVJlcHJlc2VudGF0aW9uVmVyc2lvbl8QD1BsYXRmb3JtVmVyc2lvbl8QEk1pbmltdW1TdXBwb3J0ZWRPUxACowYHBxANEAAIDys9UlRYWgAAAAAAAAEBAAAAAAAAAAgAAAAAAAAAAAAAAAAAAABc"
+    guard let data = Data(base64Encoded: encoded),
+      VZMacHardwareModel(dataRepresentation: data) != nil
+    else {
+      throw FixtureError.invalidHardwareModelFixture
+    }
+    return data
+  }
+}

--- a/scripts/docs-generators/lume.ts
+++ b/scripts/docs-generators/lume.ts
@@ -334,7 +334,7 @@ export function generateCLIReferenceMDX(docs: CLIDocumentation): string {
     { title: 'VM Information and Configuration', commands: ['ls', 'get', 'set'] },
     {
       title: 'Image Management',
-      commands: ['images', 'pull', 'push', 'convert', 'ipsw', 'prune'],
+      commands: ['images', 'pull', 'push', 'convert', 'import', 'export', 'ipsw', 'prune'],
     },
     { title: 'Guest Access and Security', commands: ['ssh', 'setup', 'sip'] },
     {
@@ -354,7 +354,9 @@ export function generateCLIReferenceMDX(docs: CLIDocumentation): string {
 
   if (duplicateAssignments.length > 0 || ungroupedCommands.length > 0) {
     throw new Error(
-      `CLI command grouping mismatch. Ungrouped: ${[...new Set(ungroupedCommands)].sort().join(', ') || 'none'}; duplicated: ${[...new Set(duplicateAssignments)].sort().join(', ') || 'none'}`
+      `CLI command grouping mismatch. Ungrouped: ${
+        [...new Set(ungroupedCommands)].sort().join(', ') || 'none'
+      }; duplicated: ${[...new Set(duplicateAssignments)].sort().join(', ') || 'none'}`
     );
   }
 


### PR DESCRIPTION
Hi, this is an awesome project. I am using it to provision and manage Mac VMs.

## Problem
- I have existing UTM vms and wanted to bring them over or to be able to export lume to UTM as well and figured others might like this
- moving Apple/macOS VMs between UTM and Lume currently requires manually rebuilding bundles and configuration
- manual copying can mix disk and auxiliary-storage state or duplicate VM identities

## API
I chose a cli naming convention:
```
lume import utm
lume export utm
```

So that there could be other formats in future on other system types, but if you prefer a different command arg naming let me know.

## Changes

- add `lume import utm` for stopped UTM Apple/macOS bundles
- add `lume export utm` for stopped Lume macOS VMs
- preserve disk, auxiliary storage, hardware model, CPU, memory, display, and network settings
- generate fresh machine identifiers and MAC addresses to prevent collisions
- use APFS copy-on-write cloning when available, with normal copy fallback
- reject running, suspended, unsafe, lossy, or unsupported configurations without leaving partial output

## Validation
- I have tested this by hand by exporting a lume VM to UTM and vica versa both worked
- `swift test`
- focused UTM converter suite
- `swift build --configuration release`
- targeted Swift format lint and generator TypeScript Prettier check
- docs generator, hygiene, internal links, and production build
- real stopped-VM `lume export utm` → `lume import utm` round trip with plist, identity, disk, and NVRAM verification

## Known gaps

- supports UTM configuration v4 Apple/aarch64 macOS VMs only
- requires one raw writable boot disk, one display, one network, and no shared or serial devices
- QCOW2, ASIF, UDIF, NVMe, removable disks, and suspended state are rejected
- not yet boot-tested in UTM or against a UTM-originated macOS bundle
```

Thanks for the time revewing.