### PR TITLE
fix(cua-driver): classify health_report as read-only diagnostics

### DIFF
--- a/libs/cua-driver/docs/test-matrix.md
+++ b/libs/cua-driver/docs/test-matrix.md
@@ -46,7 +46,7 @@ These run without the repo-local GUI applications:
 | Core driver logic | `rust/crates/*/src/**` | Protocol values, sessions, schemas, image helpers, input helpers, configuration, telemetry, CLI behavior |
 | MCP and CLI boundary | `rust/crates/cua-driver/tests/protocol_*` | Handshake, tool registration, tool calls, media, sessions, and errors |
 | Session capture scope | `session_capture_scope_test.rs` plus core `capture_scope` tests | Per-session isolation, immutable live policy, explicit auto escalation, end/revive race safety, transport-mirror refusal, and retired persistent key |
-| Schema gate | `schema_consistency_test.rs` | Shared tool schema parity across OS backends |
+| Tool-contract gate | `schema_consistency_test.rs` | Shared tool schema parity and reviewed risk metadata across OS backends |
 | Configuration transport | `transport_config_persistence_test.rs` | CLI and MCP configuration persistence |
 | Token and protocol surfaces | `protocol_element_token_test.rs`, related tests | JSON-RPC-visible contract behavior |
 | Permission modes and policy startup | `permission_policy_startup_test.rs`, `daemon_required_test.rs`, core `authorization`, `policy`, and `session_manifest` tests | Fail-before-bind policy loading, managed/user intersection, immutable standard/autonomous/unrestricted startup, danger acknowledgement, admin disable, deny-by-default manifests, and canonical daemon dispatch |

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/authorization.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/authorization.rs
@@ -83,6 +83,7 @@ pub fn advertised_risk_for(tool: &str) -> RiskAssessment {
         | "get_agent_cursor_state"
         | "get_recording_state"
         | "check_for_update"
+        | "health_report"
         | "probe" => RiskClass::R0,
 
         // Local reversible control and lifecycle operations.
@@ -584,6 +585,14 @@ mod tests {
         assert!(error
             .to_string()
             .contains("no reviewed risk classification"));
+    }
+
+    #[test]
+    fn health_report_is_r0_read_only_diagnostics() {
+        let risk = advertised_risk_for("health_report");
+        assert_eq!(risk.class, RiskClass::R0);
+        assert_eq!(risk.enforcement, RiskEnforcement::MetadataOnly);
+        assert!(!risk.operation_sensitive);
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver/tests/schema_consistency_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/schema_consistency_test.rs
@@ -1,12 +1,13 @@
-//! Cross-platform tool-schema consistency gate.
+//! Cross-platform tool-contract consistency gate.
 //!
 //! Spawns the active backend, asks it for `tools/list`, and runs every tool's
 //! `inputSchema` through [`cua_driver_core::tool_schema::shared_schema_violations`].
+//! It also verifies that every registered tool has a reviewed risk class.
 //! Because this test compiles+runs against whichever platform crate is active,
 //! the SAME file guards macOS, Linux, and Windows in their respective CI lanes:
 //! the moment one platform's hand-written schema drifts from the shared canon
 //! (a stale `capture_mode` enum, a `session` param with the wrong shape, a
-//! `required` set that diverges), this fails.
+//! `required` set that diverges), or registers an unclassified tool, this fails.
 //!
 //! This is the codified form of the manual macOS↔Windows diff that surfaced the
 //! drift in the first place. It is NOT `#[ignore]`d — `tools/list` needs no GUI,
@@ -17,7 +18,7 @@ use cua_driver_testkit::RawDriver;
 use serde_json::json;
 
 #[test]
-fn shared_tool_params_match_canon_on_active_backend() {
+fn registered_tool_contracts_match_on_active_backend() {
     let Some(mut driver) = RawDriver::spawn() else {
         // Binary not built — testkit already printed a skip note.
         return;
@@ -45,6 +46,14 @@ fn shared_tool_params_match_canon_on_active_backend() {
     let mut violations: Vec<String> = Vec::new();
     for tool in tools {
         let name = tool["name"].as_str().unwrap_or("<unnamed>");
+        match tool.pointer("/risk/class").and_then(|value| value.as_str()) {
+            Some("unclassified") => {
+                violations.push(format!("{name}: risk class is unclassified"));
+            }
+            Some(_) => {}
+            None => violations.push(format!("{name}: risk class is missing")),
+        }
+
         // MCP standard key is `inputSchema`; accept the snake_case fallback too.
         let schema = tool
             .get("inputSchema")
@@ -56,8 +65,43 @@ fn shared_tool_params_match_canon_on_active_backend() {
 
     assert!(
         violations.is_empty(),
-        "shared-param schema drift on this backend ({} violation(s)):\n  {}",
+        "tool-contract drift on this backend ({} violation(s)):\n  {}",
         violations.len(),
         violations.join("\n  ")
+    );
+}
+
+#[test]
+fn health_report_is_callable_through_authorized_mcp_surface() {
+    let Some(mut driver) = RawDriver::spawn() else {
+        // Binary not built — testkit already printed a skip note.
+        return;
+    };
+
+    driver.send(&json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "health-report-risk-gate", "version": "1" }
+        }
+    }));
+    let _ = driver.recv();
+
+    driver.send(&json!({
+        "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+        "params": { "name": "health_report", "arguments": {} }
+    }));
+    let resp = driver.recv();
+    let result = &resp["result"];
+
+    assert_ne!(
+        result["isError"].as_bool(),
+        Some(true),
+        "health_report must remain callable under the standard risk gate: {resp:?}"
+    );
+    assert_eq!(
+        result["structuredContent"]["schema_version"], "1",
+        "health_report must preserve its stable schema_version=1 contract: {resp:?}"
     );
 }


### PR DESCRIPTION
## Summary

- classify the stable `health_report` diagnostic tool as R0 read-only metadata
- reject missing or `unclassified` risk metadata for every tool exposed by the active platform registry
- exercise `health_report` through the authorized MCP surface and preserve its `schema_version="1"` non-error contract

## Root cause and impact

The permission-mode rollout added a fail-closed risk classifier but omitted `health_report` from the reviewed map. Cua Driver 0.10.0 therefore advertised the tool with `risk.class="unclassified"` and denied every MCP and CLI invocation before dispatch. That broke downstream health clients despite the tool itself being explicitly read-only.

## Validation

- `cargo test -p cua-driver-core` — 323 unit tests and 3 integration tests passed
- `cargo test -p cua-driver --test schema_consistency_test` — 2 passed
- `cargo test -p cua-driver --test protocol_handshake_test` — 6 passed
- `cargo fmt --check --all`

Fixes #2399