### PR TITLE
fix(cua-driver): request macOS permissions from running daemon

### DIFF
--- a/docs/content/docs/reference/cua-driver/mcp-tools.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools.mdx
@@ -678,10 +678,11 @@ All parameters are optional; omit any you do not want to change.
 
 Report TCC permission status for Accessibility and Screen Recording. By default also raises the system permission dialogs for any missing grants — Apple's request APIs are no-ops when the grant is already active, so this is safe to call repeatedly. Pass &#123;"prompt": false&#125; for a purely read-only status check.
 
-Returns: `accessibility` + `screen_recording` (booleans from the TCC preflight APIs), `screen_recording_capturable` (a live ScreenCaptureKit probe when `prompt` is true; null on read-only calls), `direct_capture_status` (`ready`, `unavailable`, `blocked_by_screen_recording`, or `not_checked`), and `source` (which TCC identity the booleans reflect: the CuaDriver daemon vs the launching terminal/IDE). macOS attributes grants to the responsible process, so a standalone call from a terminal reports the terminal's grants, not the driver's. The prompt-capable ScreenCaptureKit probe never runs when `prompt` is false.
+Returns: `accessibility` + `screen_recording` (booleans from the TCC preflight APIs), `screen_recording_capturable` (a live ScreenCaptureKit probe when `prompt` is true; null on read-only calls), `direct_capture_status` (`ready`, `unavailable`, `blocked_by_screen_recording`, or `not_checked`), and `source` (which TCC identity the booleans reflect: the CuaDriver daemon vs the launching terminal/IDE). macOS attributes grants to the responsible process, so a standalone call from a terminal reports the terminal's grants, not the driver's. The prompt-capable ScreenCaptureKit probe never runs when `prompt` is false. Pass `probe_direct_capture:false` with `prompt:true` to register/request only the two required TCC grants before separately explaining Tahoe's direct-capture consent.
 
 **Arguments:**
 
+- `probe_direct_capture` (boolean, optional): When prompting and Screen Recording is granted, also run the live ScreenCaptureKit probe that may raise Tahoe's direct-capture consent. Default true. Set false for a staged Accessibility/Screen Recording request.
 - `prompt` (boolean, optional): Raise the system permission prompts for missing grants. Default true.
 
 ### `health_report`

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -2445,6 +2445,22 @@ fn permission_grant_needs_direct_capture(structured: &serde_json::Value) -> bool
         && !permission_flag(structured, "screen_recording_capturable")
 }
 
+fn permission_check_request(
+    prompt: bool,
+    probe_direct_capture: bool,
+) -> crate::serve::DaemonRequest {
+    crate::serve::DaemonRequest {
+        method: "call".into(),
+        name: Some("check_permissions".into()),
+        args: Some(serde_json::json!({
+            "prompt": prompt,
+            "probe_direct_capture": probe_direct_capture,
+        })),
+        session_id: None,
+        observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
+    }
+}
+
 /// Launch CuaDriver via LaunchServices so the permission prompt attributes to
 /// com.trycua.driver, wait (user-paced) for the daemon to come up — its socket
 /// only appears once the permissions gate passes, i.e. the grant was given —
@@ -2457,8 +2473,13 @@ fn run_permissions_grant() {
         let app_path = crate::bundle::app_bundle_path();
         let bundle_id = crate::bundle::bundle_id();
         let socket = crate::serve::default_socket_path();
-        if crate::serve::is_daemon_listening(&socket) {
+        let daemon_already_running = crate::serve::is_daemon_listening(&socket);
+        if daemon_already_running {
             println!("{app_name} daemon already running — checking its permissions…");
+            println!(
+                "Requesting any missing Accessibility and Screen Recording grants now. \
+                 macOS may show a prompt or add {app_name} to System Settings."
+            );
         } else {
             println!("Launching {app_name} to request permissions.");
             println!(
@@ -2487,17 +2508,22 @@ fn run_permissions_grant() {
         // and only a fresh process image sees a later grant. During each
         // restart the socket briefly disappears, so tolerate transient
         // connection failures rather than bailing on the first one.
-        let req = crate::serve::DaemonRequest {
-            method: "call".into(),
-            name: Some("check_permissions".into()),
-            args: Some(serde_json::json!({ "prompt": false })),
-            session_id: None,
-            observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
-        };
+        let req = permission_check_request(false, false);
+        // A daemon that is already inside the permission gate may be a
+        // prompt-suppressed re-exec. Merely polling it cannot register a
+        // missing Screen Recording row. Re-raise the two required TCC requests
+        // through the daemon identity, but deliberately defer Tahoe's separate
+        // direct-capture probe until after the explanation below.
+        let prompt_req = permission_check_request(true, false);
         let poll_deadline = std::time::Instant::now() + std::time::Duration::from_secs(180);
         let mut ax = false;
         let mut sr = false;
+        let mut required_prompts_requested = !daemon_already_running;
         loop {
+            if !required_prompts_requested {
+                required_prompts_requested = crate::serve::send_request(&socket, &prompt_req)
+                    .is_ok_and(|response| response.ok);
+            }
             if let Some(structured) = crate::serve::send_request(&socket, &req)
                 .ok()
                 .filter(|r| r.ok)
@@ -2548,13 +2574,7 @@ fn run_permissions_grant() {
         );
         println!("Choose Allow to request and verify direct capture now…");
 
-        let direct_req = crate::serve::DaemonRequest {
-            method: "call".into(),
-            name: Some("check_permissions".into()),
-            args: Some(serde_json::json!({ "prompt": true })),
-            session_id: None,
-            observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
-        };
+        let direct_req = permission_check_request(true, true);
         let direct_deadline = std::time::Instant::now() + std::time::Duration::from_secs(180);
         let mut direct_status = None;
         loop {
@@ -3649,6 +3669,24 @@ mod tests {
         });
 
         assert!(!permission_grant_is_ready(&incomplete));
+    }
+
+    #[test]
+    fn permission_grant_stages_required_prompts_before_direct_capture() {
+        let staged = permission_check_request(true, false);
+        let staged_args = staged.args.expect("staged request args");
+        assert_eq!(staged_args.get("prompt"), Some(&serde_json::json!(true)));
+        assert_eq!(
+            staged_args.get("probe_direct_capture"),
+            Some(&serde_json::json!(false))
+        );
+
+        let direct = permission_check_request(true, true);
+        let direct_args = direct.args.expect("direct request args");
+        assert_eq!(
+            direct_args.get("probe_direct_capture"),
+            Some(&serde_json::json!(true))
+        );
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/check_permissions.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/check_permissions.rs
@@ -38,8 +38,12 @@ fn screen_recording_capturable() -> bool {
         .unwrap_or(false)
 }
 
-fn should_probe_direct_capture(should_prompt: bool, screen_recording: bool) -> bool {
-    should_prompt && screen_recording
+fn should_probe_direct_capture(
+    should_prompt: bool,
+    screen_recording: bool,
+    probe_direct_capture: bool,
+) -> bool {
+    should_prompt && screen_recording && probe_direct_capture
 }
 
 /// (B) Which TCC identity the booleans in this response reflect.
@@ -145,13 +149,20 @@ fn def() -> &'static ToolDef {
             booleans reflect: the CuaDriver daemon vs the launching terminal/IDE). \
             macOS attributes grants to the responsible process, so a standalone call \
             from a terminal reports the terminal's grants, not the driver's. The \
-            prompt-capable ScreenCaptureKit probe never runs when `prompt` is false.".into(),
+            prompt-capable ScreenCaptureKit probe never runs when `prompt` is false. \
+            Pass `probe_direct_capture:false` with `prompt:true` to register/request only \
+            the two required TCC grants before separately explaining Tahoe's direct-capture \
+            consent.".into(),
         input_schema: serde_json::json!({
             "type": "object",
             "properties": {
                 "prompt": {
                     "type": "boolean",
                     "description": "Raise the system permission prompts for missing grants. Default true.",
+                },
+                "probe_direct_capture": {
+                    "type": "boolean",
+                    "description": "When prompting and Screen Recording is granted, also run the live ScreenCaptureKit probe that may raise Tahoe's direct-capture consent. Default true. Set false for a staged Accessibility/Screen Recording request.",
                 }
             },
             "additionalProperties": false,
@@ -179,6 +190,7 @@ impl Tool for CheckPermissionsTool {
         // `request_*` call sites, so both being gated makes prompts
         // unreachable when embedded.
         let should_prompt = args.bool_or("prompt", true) && !cua_driver_core::embedded_mode();
+        let probe_direct_capture = args.bool_or("probe_direct_capture", true);
         if should_prompt {
             let _ = request_accessibility();
             let _ = request_screen_recording();
@@ -194,14 +206,15 @@ impl Tool for CheckPermissionsTool {
             (None, "not_checked")
         } else if !screen_recording {
             (None, "blocked_by_screen_recording")
-        } else if should_probe_direct_capture(should_prompt, screen_recording) {
+        } else if should_probe_direct_capture(should_prompt, screen_recording, probe_direct_capture)
+        {
             let capturable = screen_recording_capturable();
             (
                 Some(capturable),
                 if capturable { "ready" } else { "unavailable" },
             )
         } else {
-            unreachable!("all non-probing direct-capture states were handled")
+            (None, "not_checked")
         };
         // (B) Which identity the booleans above belong to.
         let source = permission_source();
@@ -230,11 +243,12 @@ impl Tool for CheckPermissionsTool {
                 "\n⚠️  Screen Recording reads granted but a live capture probe failed — \
                  the grant likely belongs to a different process, not this one.",
             );
-        } else if screen_recording_capturable.is_none() && !should_prompt {
+        } else if screen_recording_capturable.is_none() && (!should_prompt || !probe_direct_capture)
+        {
             summary.push_str(
                 "\nℹ️  Direct ScreenCaptureKit readiness was not probed because this is a \
-                 read-only check. Run `cua-driver permissions grant` to request and \
-                 verify direct capture explicitly.",
+                 staged or read-only check. Run `cua-driver permissions grant` to request \
+                 and verify direct capture explicitly.",
             );
         }
         // Make the attribution explicit when answering for a host or caller
@@ -311,10 +325,16 @@ mod tests {
 
     #[test]
     fn read_only_checks_never_run_the_prompt_capable_direct_capture_probe() {
-        assert!(!should_probe_direct_capture(false, false));
-        assert!(!should_probe_direct_capture(false, true));
-        assert!(!should_probe_direct_capture(true, false));
-        assert!(should_probe_direct_capture(true, true));
+        assert!(!should_probe_direct_capture(false, false, true));
+        assert!(!should_probe_direct_capture(false, true, true));
+        assert!(!should_probe_direct_capture(true, false, true));
+        assert!(should_probe_direct_capture(true, true, true));
+    }
+
+    #[test]
+    fn staged_prompt_never_runs_the_direct_capture_probe() {
+        assert!(!should_probe_direct_capture(true, false, false));
+        assert!(!should_probe_direct_capture(true, true, false));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- make `permissions grant` explicitly re-request missing Accessibility and Screen Recording grants when the daemon is already running
- add a staged `probe_direct_capture: false` mode so the required TCC registrations happen before Tahoe's separate direct-capture consent
- retry the staged request across the daemon's permission-gate re-exec/socket transition
- preserve the existing default behavior for other `check_permissions` callers

## Root cause

When the daemon was already running, `permissions grant` only polled `check_permissions` with `prompt: false`. A prompt-suppressed daemon re-exec therefore had no path to register a missing Screen Recording row in System Settings, leaving users to add the app manually.

## User impact

`cua-driver permissions grant` can now recover an already-running local or release daemon and register both required macOS permission identities without requiring users to manually add the app through the System Settings `+` picker. The direct-capture consent remains a separate, explained step.

## Validation

- `cargo test -p platform-macos` — 154 passed
- `cargo test -p cua-driver` — full package and protocol suites passed
- `cargo fmt --all -- --check`
- `git diff --check`

Strict workspace Clippy with `-D warnings` remains blocked by pre-existing warnings in untouched cursor-overlay, cua-driver-core, and platform-macos code.