### PR TITLE
ci: map Zongxin Yang release attribution

### DIFF
--- a/.github/release-attribution-config.json
+++ b/.github/release-attribution-config.json
@@ -22,7 +22,8 @@
     "f@trycua.com": "f-trycua",
     "klymenko@adobe.com": "pavelklymenko",
     "robert@trycua.com": "enchanted-koala",
-    "sarinajin.li@gmail.com": "sarinali"
+    "sarinajin.li@gmail.com": "sarinali",
+    "zongxin_yang@hms.harvard.edu": "z-x-yang"
   },
   "internalHandles": [
     "enchanted-koala",


### PR DESCRIPTION
## What changed

- map `zongxin_yang@hms.harvard.edu` to GitHub user `@z-x-yang` in the exceptional release-attribution overrides

## Why

The Cua Driver 0.11.0 release preflight cannot resolve that human coauthor email and fails closed. The identity is verified by [PR #2280](https://github.com/trycua/cua/pull/2280): its author is `@z-x-yang`, the profile name is Zongxin Yang, and its contributed commit uses the same email. [PR #2360](https://github.com/trycua/cua/pull/2360) documents that the commit was cherry-picked from #2280 to preserve authorship.

This restores the contributor's GitHub attribution rather than suppressing or misassigning the credit.

## Validation

- `uv run --with pytest --with jsonschema --with toml pytest .github/scripts/tests/ -q` (93 passed)
- `uv run --with pytest --with jsonschema --with toml pytest libs/cua-driver/scripts/tests/ -q` (9 passed)
- `uv run --with jsonschema python3 .github/scripts/release_backfill.py validate` (146 candidates and 36 explicit skips)
- exact Cua Driver 0.11.0 attribution preflight advances past the unresolved-email failure to the next independent release-data guard: the generated changelog needs a PR #2339 link
- JSON parse and `git diff --check`
