### PR TITLE
ci: validate contributor attribution before merge

### DIFF
--- a/.github/scripts/release_attribution.py
+++ b/.github/scripts/release_attribution.py
@@ -9,6 +9,7 @@ It never infers GitHub handles from a git author display name.
 from __future__ import annotations
 
 import argparse
+import base64
 from collections import defaultdict
 from dataclasses import dataclass
 from hashlib import sha256
@@ -43,6 +44,18 @@ ISSUE_RE = re.compile(
 )
 SOURCE_PR_RE = re.compile(
     r"\b(?:adapted from|based on|salvaged from|source[- ]?pr)\s*:?[ \t]*(?:(?:https://github\.com/(?P<repository>[^/]+/[^/]+)/pull/)|#)(?P<number>\d+)",
+    re.IGNORECASE,
+)
+CHERRY_PICKED_SOURCE_PR_RE = re.compile(
+    r"\bfrom\s*:?[ \t]*(?:(?:https://github\.com/(?P<repository>[^/]+/[^/]+)/pull/)|#)(?P<number>\d+)\b[^\n]{0,200}\bcherry-picked\b",
+    re.IGNORECASE,
+)
+CHERRY_PICKED_FROM_PR_RE = re.compile(
+    r"\bcherry-picked\s+from\s*:?[ \t]*(?:(?:https://github\.com/(?P<repository>[^/]+/[^/]+)/pull/)|#)(?P<number>\d+)",
+    re.IGNORECASE,
+)
+VERIFIED_IDENTITY_PR_RE = re.compile(
+    r"\bidentity\s+is\s+verified\s+by\b[^\n]{0,80}?(?:(?:https://github\.com/(?P<repository>[^/]+/[^/]+)/pull/)|#)(?P<number>\d+)",
     re.IGNORECASE,
 )
 TRAILING_PR_RE = re.compile(r"\s+\(#(?P<number>\d+)\)\s*$")
@@ -125,6 +138,31 @@ class GitHubClient:
 
     def issue(self, repository: str, number: int) -> dict[str, Any]:
         return dict(self.get(f"repos/{repository}/issues/{number}"))
+
+    def pull_commits(self, repository: str, number: int) -> list[dict[str, Any]]:
+        commits: list[dict[str, Any]] = []
+        for page in range(1, 5):
+            batch = list(
+                self.get(f"repos/{repository}/pulls/{number}/commits?per_page=100&page={page}")
+            )
+            commits.extend(batch)
+            if len(batch) < 100:
+                return commits
+        raise ReleaseError(f"pull request #{number} has too many commits to validate safely")
+
+    def file_json(self, repository: str, path: str, ref: str) -> Mapping[str, Any]:
+        encoded_path = quote(path.strip("/"), safe="/")
+        payload = self.get(f"repos/{repository}/contents/{encoded_path}?ref={quote(ref, safe='')}")
+        if not isinstance(payload, Mapping) or payload.get("encoding") != "base64":
+            raise ReleaseError(f"GitHub returned an invalid payload for {path} at {ref}")
+        try:
+            content = base64.b64decode(str(payload.get("content") or ""), validate=False)
+            value = json.loads(content.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError) as error:
+            raise ReleaseError(f"{path} at {ref} is not valid JSON: {error}") from error
+        if not isinstance(value, Mapping):
+            raise ReleaseError(f"{path} at {ref} must contain a JSON object")
+        return value
 
 
 def run_git(repo_root: Path, *args: str) -> str:
@@ -261,7 +299,286 @@ def linked_issue_numbers(pull_body: str, repository: str | None = None) -> list[
 
 
 def source_pull_numbers(text: str, repository: str | None = None) -> list[int]:
-    return _local_reference_numbers(SOURCE_PR_RE, text, repository)
+    return sorted(
+        {
+            *_local_reference_numbers(SOURCE_PR_RE, text, repository),
+            *_local_reference_numbers(CHERRY_PICKED_SOURCE_PR_RE, text, repository),
+            *_local_reference_numbers(CHERRY_PICKED_FROM_PR_RE, text, repository),
+            *_local_reference_numbers(VERIFIED_IDENTITY_PR_RE, text, repository),
+        }
+    )
+
+
+def _normalized_map(config: Mapping[str, Any], key: str) -> dict[str, str]:
+    return {
+        str(identity).strip().lower(): str(login).strip()
+        for identity, login in dict(config.get(key, {})).items()
+    }
+
+
+def _normalized_set(config: Mapping[str, Any], key: str) -> set[str]:
+    return {str(item).strip().lower() for item in config.get(key, [])}
+
+
+def validate_pr_attribution(
+    *,
+    repository: str,
+    pull: Mapping[str, Any],
+    commits: Sequence[Mapping[str, Any]],
+    base_config: Mapping[str, Any],
+    head_config: Mapping[str, Any],
+    github: GitHubClient,
+) -> None:
+    """Fail closed when preserved human authorship cannot reach a GitHub login.
+
+    The base configuration is trusted policy. The pull request's configuration
+    may only satisfy a new identity mapping when an explicitly referenced,
+    same-repository source pull request verifies the exact GitHub login.
+    """
+
+    bots = _normalized_set(base_config, "bots")
+    internal = _normalized_set(base_config, "internalHandles")
+    opt_out = _normalized_set(base_config, "optOutHandles")
+    ignored = _normalized_set(base_config, "ignoredCoauthorEmails")
+    base_overrides = _normalized_map(base_config, "identityOverrides")
+    head_overrides = _normalized_map(head_config, "identityOverrides")
+    coauthor_overrides = _normalized_map(base_config, "coauthorOverrides")
+
+    changed_existing = {
+        email: (login, head_overrides.get(email))
+        for email, login in base_overrides.items()
+        if head_overrides.get(email) != login
+    }
+    if changed_existing:
+        details = ", ".join(
+            f"{email}={actual!r} (expected {expected!r})"
+            for email, (expected, actual) in sorted(changed_existing.items())
+        )
+        raise ReleaseError(
+            "the pull request removes or changes trusted identityOverrides: " + details
+        )
+
+    pull_number = int(pull.get("number") or 0)
+    pull_login = str((pull.get("user") or {}).get("login") or "").strip()
+    pull_body_sources = source_pull_numbers(str(pull.get("body") or ""), repository)
+    all_pr_sources = set(pull_body_sources)
+    unresolved: dict[str, dict[str, Any]] = {}
+    preserved_authors: list[dict[str, Any]] = []
+    early_errors: list[str] = []
+
+    def resolved_login(name: str, email: str, linked_login: str = "") -> str | None:
+        login = (
+            linked_login
+            or coauthor_overrides.get(f"{name.strip()} <{email}>".lower())
+            or login_from_email(email, base_overrides)
+        )
+        return login or None
+
+    def record_unresolved(
+        *, email: str, name: str, sha: str, kind: str, references: Sequence[int]
+    ) -> None:
+        normalized_email = email.strip().lower()
+        if not normalized_email:
+            raise ReleaseError(f"commit {sha} has a {kind} with no email address")
+        item = unresolved.setdefault(
+            normalized_email,
+            {"names": set(), "shas": set(), "kinds": set(), "references": set()},
+        )
+        item["names"].add(name.strip() or "unknown")
+        item["shas"].add(sha)
+        item["kinds"].add(kind)
+        item["references"].update(references)
+
+    for item in commits:
+        sha = str(item.get("sha") or "unknown")
+        commit = item.get("commit") or {}
+        message = str(commit.get("message") or "")
+        commit_sources = source_pull_numbers(message, repository)
+        all_pr_sources.update(commit_sources)
+        references = commit_sources or pull_body_sources
+
+        author = commit.get("author") or {}
+        author_name = str(author.get("name") or "")
+        author_email = str(author.get("email") or "").strip().lower()
+        linked_author = str((item.get("author") or {}).get("login") or "").strip()
+        author_login = resolved_login(author_name, author_email, linked_author)
+        committer = commit.get("committer") or {}
+        committer_email = str(committer.get("email") or "").strip().lower()
+        linked_committer = str((item.get("committer") or {}).get("login") or "").strip()
+        preserved_unlinked_author = (
+            not author_login
+            and bool(pull_login)
+            and linked_committer.lower() == pull_login.lower()
+            and author_email != committer_email
+        )
+        # An ordinary direct PR author is credited from pull-request metadata even
+        # when their commit email is private. A distinct unlinked author committed
+        # by the landing PR author is a strong cherry-pick/preservation signal.
+        if preserved_unlinked_author and author_email not in ignored:
+            record_unresolved(
+                email=author_email,
+                name=author_name,
+                sha=sha,
+                kind="commit author",
+                references=references,
+            )
+        elif author_login and (
+            author_login.lower() != pull_login.lower()
+            and not is_bot(author_login, bots)
+            and author_login.lower() not in internal
+            and author_login.lower() not in opt_out
+        ):
+            if not references:
+                early_errors.append(
+                    f"commit {sha} is authored by @{author_login}, distinct from landing "
+                    f"PR author @{pull_login or 'unknown'}, but has no explicit source PR; "
+                    "add `Salvaged from #<pr>` so release attribution preserves the author"
+                )
+            else:
+                preserved_authors.append(
+                    {
+                        "login": author_login,
+                        "sha": sha,
+                        "references": set(references),
+                    }
+                )
+
+        for match in COAUTHOR_RE.finditer(message):
+            name = match.group("name").strip()
+            email = match.group("email").strip().lower()
+            login = resolved_login(name, email)
+            if email in ignored:
+                continue
+            if login and (
+                is_bot(login, bots)
+                or login.lower() in internal
+                or login.lower() in opt_out
+                or login.lower() == pull_login.lower()
+            ):
+                continue
+            if not login:
+                record_unresolved(
+                    email=email,
+                    name=name,
+                    sha=sha,
+                    kind="coauthor",
+                    references=references,
+                )
+
+    new_overrides = {
+        email: login for email, login in head_overrides.items() if email not in base_overrides
+    }
+    if not unresolved and not new_overrides and not preserved_authors and not early_errors:
+        return
+
+    source_evidence: dict[int, tuple[str, set[str]]] = {}
+    all_references = sorted(
+        {
+            *all_pr_sources,
+            *{number for item in unresolved.values() for number in item["references"]},
+        }
+    )
+    for number in all_references:
+        if number == pull_number:
+            raise ReleaseError(f"source pull request #{number} is the landing pull request itself")
+        source = github.pull(repository, number)
+        if int(source.get("number") or 0) != number:
+            raise ReleaseError(f"source pull request #{number} could not be verified")
+        login = str((source.get("user") or {}).get("login") or "").strip()
+        if not login:
+            raise ReleaseError(f"source pull request #{number} has no GitHub author")
+        source_emails = {
+            str(((item.get("commit") or {}).get("author") or {}).get("email") or "").strip().lower()
+            for item in github.pull_commits(repository, number)
+        }
+        source_evidence[number] = (login, source_emails - {""})
+
+    suggestions: dict[str, str] = {}
+    errors: list[str] = list(early_errors)
+    identities = {
+        email: {
+            "references": set(identity["references"]),
+            "location": ", ".join(sorted(identity["shas"])),
+            "description": "/".join(sorted(identity["kinds"])),
+        }
+        for email, identity in unresolved.items()
+    }
+    for email in new_overrides:
+        identities.setdefault(
+            email,
+            {
+                "references": set(all_pr_sources),
+                "location": "the identityOverrides change",
+                "description": "new identity override",
+            },
+        )
+
+    for email, identity in sorted(identities.items()):
+        references = sorted(identity["references"])
+        if not references:
+            errors.append(
+                f"{email} ({identity['description']}; {identity['location']}) is "
+                "unresolved and has no explicit same-repository source PR; use a linked "
+                "GitHub/noreply email or add `Salvaged from #<pr>`"
+            )
+            continue
+        verified = {
+            source_evidence[number][0]
+            for number in references
+            if email in source_evidence[number][1]
+        }
+        if not verified:
+            refs = ", ".join(f"#{number}" for number in references)
+            errors.append(
+                f"{email} is not an exact commit-author email in the referenced source "
+                f"pull request(s) {refs}; use verifiable provenance instead of guessing"
+            )
+            continue
+        logins = verified
+        if len(logins) != 1:
+            refs = ", ".join(
+                f"#{number}=@{source_evidence[number][0]}"
+                for number in references
+                if email in source_evidence[number][1]
+            )
+            errors.append(
+                f"{email} has ambiguous source-PR authors ({refs}); reference exactly one "
+                "contributor identity"
+            )
+            continue
+        suggestions[email] = next(iter(logins))
+
+    for author in preserved_authors:
+        referenced_logins = {source_evidence[number][0] for number in author["references"]}
+        if author["login"] not in referenced_logins:
+            refs = ", ".join(
+                f"#{number}=@{source_evidence[number][0]}"
+                for number in sorted(author["references"])
+            )
+            errors.append(
+                f"commit {author['sha']} is authored by @{author['login']}, but its "
+                f"source reference(s) identify {refs}; reference that author's source PR"
+            )
+
+    for email, expected in sorted(suggestions.items()):
+        actual = head_overrides.get(email)
+        if actual != expected:
+            fragment = json.dumps(
+                {"identityOverrides": {email: expected}}, indent=2, sort_keys=True
+            )
+            if actual:
+                errors.append(
+                    f"identityOverrides maps {email} to @{actual}, but the verified source "
+                    f"PR author is @{expected}; use this exact JSON:\n{fragment}"
+                )
+            else:
+                errors.append(
+                    f"verified source PR maps {email} uniquely to @{expected}; add this exact "
+                    f"JSON to .github/release-attribution-config.json in this PR:\n{fragment}"
+                )
+
+    if errors:
+        raise ReleaseError("contributor attribution is not merge-ready:\n- " + "\n- ".join(errors))
 
 
 def select_pull(pulls: Sequence[Mapping[str, Any]], commit_sha: str) -> Mapping[str, Any]:
@@ -771,6 +1088,45 @@ def collect_command(args: argparse.Namespace) -> None:
     print(f"wrote {args.output} with {len(manifest['changes'])} changes")
 
 
+def validate_pr_command(args: argparse.Namespace) -> None:
+    event = json.loads(args.event.read_text())
+    event_pull = event.get("pull_request") or {}
+    repository = str((event.get("repository") or {}).get("full_name") or "")
+    number = int(event_pull.get("number") or event.get("number") or 0)
+    if not repository or not number:
+        raise ReleaseError("event does not identify a repository and pull request")
+
+    client = GitHubClient(
+        os.environ.get("GH_TOKEN", ""), os.environ.get("GITHUB_API_URL", "https://api.github.com")
+    )
+    pull = client.pull(repository, number)
+    head = pull.get("head") or {}
+    head_repository = str((head.get("repo") or {}).get("full_name") or "")
+    head_sha = str(head.get("sha") or "")
+    if not head_repository or not head_sha:
+        raise ReleaseError(f"pull request #{number} has no readable head repository")
+
+    commits = client.pull_commits(repository, number)
+    expected_commits = int(pull.get("commits") or len(commits))
+    if len(commits) != expected_commits:
+        raise ReleaseError(
+            f"GitHub returned {len(commits)} of {expected_commits} commits for pull request "
+            f"#{number}; refusing partial attribution validation"
+        )
+
+    base_config = json.loads(args.config.read_text())
+    head_config = client.file_json(head_repository, args.config.as_posix(), head_sha)
+    validate_pr_attribution(
+        repository=repository,
+        pull=pull,
+        commits=commits,
+        base_config=base_config,
+        head_config=head_config,
+        github=client,
+    )
+    print(f"contributor attribution is merge-ready for pull request #{number}")
+
+
 def render_command(args: argparse.Namespace) -> None:
     manifest = json.loads(args.manifest.read_text())
     if manifest.get("schemaVersion") != 1:
@@ -798,6 +1154,12 @@ def build_parser() -> argparse.ArgumentParser:
     validate.add_argument("--title", required=True)
     validate.add_argument("--require-release", action="store_true")
     validate.add_argument("--allow-non-release", action="store_true")
+
+    validate_pr = subparsers.add_parser("validate-pr")
+    validate_pr.add_argument("--event", type=Path, required=True)
+    validate_pr.add_argument(
+        "--config", type=Path, default=Path(".github/release-attribution-config.json")
+    )
 
     collect = subparsers.add_parser("collect")
     collect.add_argument("--repo-root", type=Path, default=Path.cwd())
@@ -840,6 +1202,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 allow_non_release=args.allow_non_release,
             )
             print("release title is valid")
+        elif args.command == "validate-pr":
+            validate_pr_command(args)
         elif args.command == "collect":
             collect_command(args)
         elif args.command == "render":

--- a/.github/scripts/tests/test_pr_attribution.py
+++ b/.github/scripts/tests/test_pr_attribution.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import pytest
+
+from release_attribution import ReleaseError, source_pull_numbers, validate_pr_attribution
+
+
+def config(**overrides):
+    value = {
+        "bots": ["github-actions[bot]"],
+        "coauthorOverrides": {},
+        "ignoredCoauthorEmails": ["noreply@anthropic.com"],
+        "identityOverrides": {},
+        "internalHandles": ["maintainer"],
+        "optOutHandles": [],
+    }
+    value.update(overrides)
+    return value
+
+
+def pull(*, body: str = "", login: str = "landing-author", number: int = 50):
+    return {"number": number, "body": body, "user": {"login": login}}
+
+
+def commit(
+    *,
+    sha: str = "abc123",
+    name: str = "Contributor",
+    email: str = "contributor@example.com",
+    login: str | None = None,
+    committer_email: str | None = None,
+    committer_login: str | None = None,
+    message: str = "fix: preserve attribution",
+):
+    return {
+        "sha": sha,
+        "author": {"login": login} if login else None,
+        "committer": {"login": committer_login} if committer_login else None,
+        "commit": {
+            "author": {"name": name, "email": email},
+            "committer": {
+                "name": "Landing Author",
+                "email": committer_email or email,
+            },
+            "message": message,
+        },
+    }
+
+
+class SourceGitHub:
+    def __init__(self, authors, source_emails):
+        self.authors = authors
+        self.source_emails = source_emails
+
+    def pull(self, repository: str, number: int):
+        assert repository == "trycua/cua"
+        return {"number": number, "user": {"login": self.authors[number]}}
+
+    def pull_commits(self, repository: str, number: int):
+        assert repository == "trycua/cua"
+        return [
+            {"commit": {"author": {"email": email}}} for email in self.source_emails.get(number, [])
+        ]
+
+
+def validate(
+    *,
+    pull_value=None,
+    commits=None,
+    base=None,
+    head=None,
+    authors=None,
+    source_emails=None,
+):
+    base = base or config()
+    validate_pr_attribution(
+        repository="trycua/cua",
+        pull=pull_value or pull(),
+        commits=commits or [],
+        base_config=base,
+        head_config=head or base,
+        github=SourceGitHub(authors or {}, source_emails or {}),
+    )
+
+
+def test_resolvable_github_and_noreply_identities_pass():
+    validate(
+        commits=[
+            commit(
+                login="landing-author",
+                email="work@example.edu",
+                message=(
+                    "fix: pair safely\n\n"
+                    "Co-authored-by: Pair User "
+                    "<456+second-user@users.noreply.github.com>"
+                ),
+            ),
+        ]
+    )
+
+
+def test_distinct_resolvable_commit_author_requires_preserved_source():
+    external = commit(login="source-author", email="source@institution.example")
+    with pytest.raises(ReleaseError, match="distinct from landing PR author"):
+        validate(commits=[external])
+
+    validate(
+        pull_value=pull(body="Salvaged from #12"),
+        commits=[external],
+        authors={12: "source-author"},
+        source_emails={12: ["source@institution.example"]},
+    )
+
+
+def test_explicit_cherry_pick_source_reference_is_parsed_but_supersedes_is_not():
+    assert source_pull_numbers(
+        "Cert discovery (from #2280, thanks — cherry-picked to preserve authorship)",
+        "trycua/cua",
+    ) == [2280]
+    assert source_pull_numbers(
+        "The identity is verified by [PR #2280](https://github.com/trycua/cua/pull/2280)",
+        "trycua/cua",
+    ) == [2280]
+    assert source_pull_numbers("Supersedes #2280", "trycua/cua") == []
+
+
+def test_direct_contributor_with_unlinked_email_does_not_fail():
+    validate(
+        pull_value=pull(login="direct-contributor"),
+        commits=[commit(email="private@institution.example")],
+    )
+
+    validate(
+        pull_value=pull(
+            login="direct-contributor",
+            body="Based on #99 for the API shape",
+        ),
+        commits=[commit(email="private@institution.example")],
+    )
+
+
+def test_unlinked_author_committed_by_landing_author_requires_source_evidence():
+    with pytest.raises(ReleaseError, match="has no explicit same-repository source PR"):
+        validate(
+            commits=[
+                commit(
+                    email="source@university.example",
+                    committer_email="landing@example.com",
+                    committer_login="landing-author",
+                )
+            ]
+        )
+
+
+def test_unresolved_institutional_coauthor_requires_source_reference():
+    with pytest.raises(ReleaseError, match="has no explicit same-repository source PR"):
+        validate(
+            commits=[
+                commit(
+                    message=(
+                        "fix: preserve work\n\n"
+                        "Co-authored-by: External Person <person@university.example>"
+                    )
+                )
+            ]
+        )
+
+
+def test_verified_source_pr_produces_exact_override_and_accepts_it():
+    landing = pull(
+        body="Cert discovery (from #2280, thanks — cherry-picked to preserve authorship)",
+        number=2360,
+    )
+    commits = [
+        commit(
+            sha="a27753e",
+            name="Source Contributor",
+            email="source@university.example",
+            committer_email="landing@example.com",
+            committer_login="landing-author",
+        )
+    ]
+    with pytest.raises(ReleaseError) as error:
+        validate(
+            pull_value=landing,
+            commits=commits,
+            authors={2280: "source-login"},
+            source_emails={2280: ["source@university.example"]},
+        )
+    assert '"identityOverrides": {\n    "source@university.example": "source-login"\n  }' in str(
+        error.value
+    )
+
+    head = config(identityOverrides={"source@university.example": "source-login"})
+    validate(
+        pull_value=landing,
+        commits=commits,
+        head=head,
+        authors={2280: "source-login"},
+        source_emails={2280: ["source@university.example"]},
+    )
+
+
+def test_ambiguous_source_pr_authors_fail_closed():
+    with pytest.raises(ReleaseError, match="ambiguous source-PR authors"):
+        validate(
+            pull_value=pull(body="Salvaged from #10; based on #11"),
+            commits=[
+                commit(
+                    email="source@university.example",
+                    committer_email="landing@example.com",
+                    committer_login="landing-author",
+                )
+            ],
+            authors={10: "first-author", 11: "second-author"},
+            source_emails={
+                10: ["source@university.example"],
+                11: ["source@university.example"],
+            },
+        )
+
+
+def test_source_pr_author_without_exact_email_is_not_mapping_evidence():
+    with pytest.raises(ReleaseError, match="not an exact commit-author email"):
+        validate(
+            pull_value=pull(body="Salvaged from #10"),
+            commits=[
+                commit(
+                    email="fabricated@institution.example",
+                    committer_email="landing@example.com",
+                    committer_login="landing-author",
+                )
+            ],
+            authors={10: "source-author"},
+            source_emails={10: ["actual@institution.example"]},
+        )
+
+
+def test_mapping_only_override_requires_and_accepts_exact_source_evidence():
+    head = config(identityOverrides={"historic@institution.example": "historic-author"})
+    with pytest.raises(ReleaseError, match="has no explicit same-repository source PR"):
+        validate(head=head)
+
+    validate(
+        pull_value=pull(
+            body=("The identity is verified by [PR #20](https://github.com/trycua/cua/pull/20)")
+        ),
+        head=head,
+        authors={20: "historic-author"},
+        source_emails={20: ["historic@institution.example"]},
+    )
+
+
+def test_existing_identity_override_cannot_be_removed_or_changed():
+    base = config(identityOverrides={"known@institution.example": "known-author"})
+    with pytest.raises(ReleaseError, match="removes or changes trusted identityOverrides"):
+        validate(base=base, head=config())
+    with pytest.raises(ReleaseError, match="removes or changes trusted identityOverrides"):
+        validate(
+            base=base,
+            head=config(identityOverrides={"known@institution.example": "other-author"}),
+        )
+
+
+def test_internal_bot_and_ignored_coauthors_are_excluded():
+    validate(
+        commits=[
+            commit(
+                login="maintainer",
+                message=(
+                    "fix: generated and maintained\n\n"
+                    "Co-authored-by: Maintainer <123+maintainer@users.noreply.github.com>\n"
+                    "Co-authored-by: Actions "
+                    "<github-actions[bot]@users.noreply.github.com>\n"
+                    "Co-authored-by: Claude <noreply@anthropic.com>"
+                ),
+            ),
+            commit(
+                sha="bot123",
+                name="Actions",
+                email="github-actions[bot]@users.noreply.github.com",
+                login="github-actions[bot]",
+            ),
+        ]
+    )
+
+
+def test_coauthor_trailer_parsing_is_case_insensitive_and_multiline():
+    with pytest.raises(ReleaseError, match="pair@institution.example"):
+        validate(
+            commits=[
+                commit(
+                    message=(
+                        "fix: parse trailers\n\n"
+                        "co-AUTHORED-by: Pair Person <pair@institution.example>\n"
+                        "Signed-off-by: Landing Author <landing@example.com>"
+                    )
+                )
+            ]
+        )

--- a/.github/workflows/ci-contributor-attribution.yml
+++ b/.github/workflows/ci-contributor-attribution.yml
@@ -1,0 +1,36 @@
+name: "CI: Contributor attribution"
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  contributor-attribution:
+    name: contributor-attribution
+    runs-on: ubuntu-latest
+    steps:
+      # pull_request_target supplies a read token for fork PR metadata. Check out
+      # only the trusted base commit; the PR head is read as inert API data and is
+      # never executed or checked out in this job.
+      - name: Check out trusted base validator
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate contributor attribution
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python3 .github/scripts/release_attribution.py validate-pr
+          --event "$GITHUB_EVENT_PATH"

--- a/.github/workflows/ci-test-scripts.yml
+++ b/.github/workflows/ci-test-scripts.yml
@@ -15,6 +15,7 @@ on:
       - ".release-please-manifest.json"
       - "release-please-config.json"
       - ".github/workflows/ci-test-scripts.yml"
+      - ".github/workflows/ci-contributor-attribution.yml"
       - "docs/release-backfill-runbook.md"
       - "libs/cua-driver/scripts/**"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,9 +56,16 @@ If a maintainer adapts material parts of a contribution in a new commit,
 include a `Co-authored-by` trailer with the contributor's GitHub no-reply email
 and link the source pull request in the landing pull request. Use a line such as
 `Salvaged from #123` so release automation can recover the source author.
-Preserve human coauthor trailers during rebases and squash merges. Honor public
-credit opt-out requests and keep security-report attribution private until the
-report can be disclosed.
+Prefer a commit email linked to the contributor's GitHub account, especially a
+GitHub no-reply address. If preserved authorship uses an email GitHub cannot
+resolve, add the verified email-to-login entry to
+`.github/release-attribution-config.json` in the same pull request. The
+contributor-attribution check provides the exact `identityOverrides` JSON when
+one explicitly referenced source pull request proves a unique mapping; it never
+guesses from a name or email. Attribution preservation and resolvability must
+land together. Preserve human coauthor trailers during rebases and squash
+merges. Honor public credit opt-out requests and keep security-report
+attribution private until the report can be disclosed.
 
 Root pre-commit hooks are optional local helpers. Install them with:
 


### PR DESCRIPTION
## What changed

- add an API-only pre-merge contributor-attribution guard that runs from trusted base code on `pull_request_target`
- reuse release-attribution identity, bot, internal, coauthor, and source-reference rules
- require exact source-PR commit-email evidence before accepting or suggesting a new `identityOverrides` mapping
- preserve direct-contributor behavior while detecting distinct linked authors and the unlinked-author/landing-committer cherry-pick shape
- document how contributor attribution and resolvability land together

## Why

Unresolved human attribution currently fails closed during release collection, after the responsible pull request has already merged. This moves the actionable validation to PR landing time while retaining the release-time check as defense in depth.

The workflow uses read-only permissions, checks out only the trusted base SHA with credentials disabled, and treats fork PR commits, metadata, and the head attribution config as inert GitHub API data. No untrusted PR code is checked out or executed.

## Validation

- `uvx --with jsonschema pytest .github/scripts/tests/ -q` — 106 passed
- `uvx ruff check .github/scripts/release_attribution.py .github/scripts/tests/test_pr_attribution.py`
- `uvx ruff format --check .github/scripts/release_attribution.py .github/scripts/tests/test_pr_attribution.py`
- Python bytecode compilation for the validator and focused tests
- Ruby YAML parse for both changed workflows
- JSON parse for `.github/release-attribution-config.json`
- `git diff --check`

The new workflow is intentionally unfiltered and exposes the unique required-check job name `contributor-attribution`.
