### PR TITLE
ci: use current trusted attribution validator

### DIFF
--- a/.github/workflows/ci-contributor-attribution.yml
+++ b/.github/workflows/ci-contributor-attribution.yml
@@ -13,14 +13,14 @@ jobs:
     name: contributor-attribution
     runs-on: ubuntu-latest
     steps:
-      # pull_request_target supplies a read token for fork PR metadata. Check out
-      # only the trusted base commit; the PR head is read as inert API data and is
-      # never executed or checked out in this job.
+      # For pull_request_target, github.sha is the current commit on the trusted
+      # base branch. The PR's recorded base.sha can be stale after main advances.
+      # The PR head remains inert API data and is never checked out or executed.
       - name: Check out trusted base validator
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - name: Set up Python


### PR DESCRIPTION
## What changed

- check out `${{ github.sha }}` in the `pull_request_target` attribution job
- document that this SHA is the current trusted base-branch workflow commit
- retain read-only permissions, disabled credential persistence, and API-only inspection of the PR head

## Why

`pull_request.base.sha` is the base commit recorded when a pull request was opened or last synchronized and can remain stale after `main` advances. That can load a validator predating the `validate-pr` command and block otherwise valid pull requests.

For `pull_request_target`, `github.sha` identifies the latest commit on the trusted base branch for the workflow run, so the job executes the current trusted validator without checking out or executing untrusted PR code.

## Validation

- parsed `.github/workflows/ci-contributor-attribution.yml` as YAML
- asserted the checkout uses `${{ github.sha }}` and contains no `github.event.pull_request.base.sha`
- `uvx --with jsonschema pytest .github/scripts/tests/ -q` — 106 passed
- `git diff --check`


Post-merge verification: the corrected trusted-base checkout is live on `main`, and `contributor-attribution` is required by the main ruleset.