### PR TITLE
fix(cua-driver): keep pre-1.0 releases pre-major

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -1,5 +1,6 @@
 """Regression tests for cua-driver-rs release and PyPI wiring."""
 
+import json
 from pathlib import Path
 import unittest
 
@@ -80,6 +81,13 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertIn("chore(lume): synchronize release documentation", workflow)
         self.assertNotIn("if: steps.release.outputs.prs_created == 'true'", workflow)
         self.assertNotIn("RELEASE_PRS: ${{ steps.release.outputs.prs }}", workflow)
+
+    def test_driver_breaking_changes_remain_pre_major(self) -> None:
+        config = json.loads(self.read("release-please-config.json"))
+        driver = config["packages"]["libs/cua-driver"]
+
+        self.assertTrue(driver["bump-minor-pre-major"])
+        self.assertNotIn("bump-minor-pre-major", config["packages"]["libs/lume"])
 
     def test_release_please_exposes_targeted_bump_dropdowns(self) -> None:
         workflow = self.read(".github/workflows/release-please.yml")

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,7 @@
       "release-type": "simple",
       "component": "cua-driver-rs",
       "package-name": "cua-driver-rs",
+      "bump-minor-pre-major": true,
       "version-file": "rust/VERSION",
       "changelog-path": "rust/CHANGELOG.md",
       "exclude-paths": [


### PR DESCRIPTION
## Summary

- keep Cua Driver breaking changes pre-major while its current version is below 1.0
- scope the Release Please policy to Cua Driver only
- add a regression test so Lume and other packages retain their existing behavior

This corrects the generated Cua Driver release from 1.0.0 to 0.11.0. The generated release PR must remain unmerged until #2426 lands.

## Verification

- `python3 .github/scripts/tests/test_cua_driver_release_wiring.py` (26 passed)
- `jq empty release-please-config.json`
- `git diff --check`