### PR TITLE
fix(cua-driver): accept verified commit attribution links

### DIFF
--- a/.github/scripts/release_attribution.py
+++ b/.github/scripts/release_attribution.py
@@ -778,6 +778,29 @@ def extract_changelog_section(changelog: Path, version: str) -> str:
     return match.group(0).rstrip() + "\n"
 
 
+def changelog_references_change(
+    changelog_section: str,
+    pull_number: int,
+    commit_shas: Iterable[str],
+) -> bool:
+    """Accept Release Please's PR link or its verified commit-link fallback."""
+    if f"#{pull_number}" in changelog_section or f"/pull/{pull_number}" in changelog_section:
+        return True
+    return any(commit_sha in changelog_section for commit_sha in commit_shas)
+
+
+def release_bump(changes: Sequence[Mapping[str, Any]], version: str) -> str:
+    """Classify a release using the same pre-major policy as Release Please."""
+    major_match = re.match(r"^(?P<major>0|[1-9]\d*)\.", version)
+    if not major_match:
+        raise ReleaseError(f"release version is not semantic: {version}")
+    if any(change["breaking"] for change in changes):
+        return "minor" if int(major_match.group("major")) == 0 else "major"
+    if any(change["type"] == "feat" for change in changes):
+        return "minor"
+    return "patch"
+
+
 def build_manifest(
     *,
     repo_root: Path,
@@ -805,6 +828,7 @@ def build_manifest(
 
     changes: list[dict[str, Any]] = []
     seen_changes: set[tuple[int, str, str]] = set()
+    pull_commits: dict[int, set[str]] = defaultdict(set)
     all_contributors: list[dict[str, Any]] = []
     visual_requested = False
 
@@ -829,6 +853,7 @@ def build_manifest(
         if not subject_is_releasing and not OVERRIDE_RE.search(pull_body):
             continue
         pull_number = int(pull["number"])
+        pull_commits[pull_number].add(commit.sha)
         entries = release_entries(commit.subject, commit.body, pull_body)
         if not entries:
             continue
@@ -863,18 +888,17 @@ def build_manifest(
         {
             int(change["pr"])
             for change in changes
-            if f"#{change['pr']}" not in changelog_section
-            and f"/pull/{change['pr']}" not in changelog_section
+            if not changelog_references_change(
+                changelog_section,
+                int(change["pr"]),
+                pull_commits[int(change["pr"])],
+            )
         }
     )
     if missing_prs:
         raise ReleaseError(f"changelog section is missing pull requests: {missing_prs}")
 
-    bump = "patch"
-    if any(change["breaking"] for change in changes):
-        bump = "major"
-    elif any(change["type"] == "feat" for change in changes):
-        bump = "minor"
+    bump = release_bump(changes, version)
 
     owner, repo = repository.split("/", 1)
     compare_url = (

--- a/.github/scripts/tests/test_release_attribution.py
+++ b/.github/scripts/tests/test_release_attribution.py
@@ -13,8 +13,10 @@ from release_attribution import (
     ReleaseError,
     _change_contributors,
     build_manifest,
+    changelog_references_change,
     linked_issue_numbers,
     login_from_email,
+    release_bump,
     release_entries,
     render_body,
     render_card_svg,
@@ -254,6 +256,28 @@ def test_legacy_release_bump_subject_is_recognized():
     assert LEGACY_RELEASE_BUMP_RE.match("Bump cua-driver-rs to v0.8.3")
     assert LEGACY_RELEASE_BUMP_RE.match("Bump lume to v0.3.16")
     assert not LEGACY_RELEASE_BUMP_RE.match("feat(driver): bump reconnect retries")
+
+
+def test_changelog_accepts_verified_commit_link_when_pr_suffix_is_missing():
+    commit_sha = "2dad3e519e17b27eaa793151b8671957f578072c"
+    section = (
+        "## [0.11.0] (2026-07-22)\n\n"
+        "* **cua-driver:** add persistent sessions "
+        f"([{commit_sha[:7]}](https://github.com/trycua/cua/commit/{commit_sha}))\n"
+    )
+
+    assert changelog_references_change(section, 2339, [commit_sha])
+    assert changelog_references_change(section + "* fix ([#2408](url))\n", 2408, [])
+    assert not changelog_references_change(section, 9999, ["f" * 40])
+
+
+def test_breaking_change_remains_minor_before_one_dot_zero():
+    changes = [{"type": "feat", "breaking": True}]
+
+    assert release_bump(changes, "0.11.0") == "minor"
+    assert release_bump(changes, "1.0.0") == "major"
+    with pytest.raises(ReleaseError, match="not semantic"):
+        release_bump(changes, "next")
 
 
 def test_manifest_is_pr_first_and_renders_deterministically(tmp_path: Path):


### PR DESCRIPTION
## Summary

- allow the release-attribution preflight to accept Release Please's verified full commit link when a squash commit lacks a `(#PR)` suffix
- retain GitHub commit-to-PR resolution as the source of contributor identity
- classify breaking pre-1.0 releases as minor, matching the Cua Driver Release Please policy
- add regressions for both behaviors

This clears the false #2339 attribution failure on the draft 0.11.0 release PR without weakening attribution: an unrelated or abbreviated commit reference still fails closed.

## Verification

- `.venv/bin/python -m pytest .github/scripts/tests/test_release_attribution.py -q` — 11 passed
- `.venv/bin/python -m pytest .github/scripts/tests/test_cua_driver_release_wiring.py -q` — 26 passed
- live `collect` preflight against #2403 head `fcb06baa` — 8 changes, #2339 resolved, bump `minor`
- `git diff --check`