### PR TITLE
fix(release): reconcile component manifests during sync

### DIFF
--- a/.github/scripts/merge_release_please_manifests.py
+++ b/.github/scripts/merge_release_please_manifests.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Reconcile a component release manifest with the latest main manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+COMPONENT_PATHS = {
+    "cua-driver-rs": "libs/cua-driver",
+    "lume": "libs/lume",
+}
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as manifest_file:
+        manifest = json.load(manifest_file)
+    if not isinstance(manifest, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return manifest
+
+
+def merge_component_versions(
+    main_manifest: dict[str, Any],
+    release_manifest: dict[str, Any],
+    components: list[str],
+) -> dict[str, Any]:
+    """Keep main's versions except for the component(s) owned by this release PR."""
+
+    merged = dict(main_manifest)
+    for component in components:
+        component_path = COMPONENT_PATHS[component]
+        if component_path not in release_manifest:
+            raise ValueError(
+                f"release manifest does not contain {component_path!r} for {component}"
+            )
+        merged[component_path] = release_manifest[component_path]
+    return merged
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--main", type=Path, required=True)
+    parser.add_argument("--release", type=Path, required=True)
+    parser.add_argument(
+        "--component",
+        action="append",
+        choices=sorted(COMPONENT_PATHS),
+        required=True,
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    merged = merge_component_versions(
+        load_manifest(args.main),
+        load_manifest(args.release),
+        args.component,
+    )
+    print(json.dumps(merged, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -70,6 +70,9 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
             workflow,
         )
         self.assertIn("git rebase origin/main", workflow)
+        self.assertIn("merge_release_please_manifests.py", workflow)
+        self.assertIn('git diff --name-only --diff-filter=U', workflow)
+        self.assertIn("git rebase --abort", workflow)
         self.assertIn('--force-with-lease="refs/heads/$BRANCH:$REMOTE_HEAD"', workflow)
         self.assertNotIn("git push --force ", workflow)
         self.assertIn("sync_driver_release_docs.py", workflow)

--- a/.github/scripts/tests/test_merge_release_please_manifests.py
+++ b/.github/scripts/tests/test_merge_release_please_manifests.py
@@ -1,0 +1,78 @@
+"""Tests for reconciling independent Release Please component branches."""
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1] / "merge_release_please_manifests.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "merge_release_please_manifests", SCRIPT_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class TestMergeReleasePleaseManifests(unittest.TestCase):
+    def test_lume_release_keeps_newer_driver_version_from_main(self) -> None:
+        main_manifest = {
+            "libs/cua-driver": "0.11.0",
+            "libs/lume": "0.3.16",
+        }
+        stale_lume_release_manifest = {
+            "libs/cua-driver": "0.10.0",
+            "libs/lume": "0.4.0",
+        }
+
+        merged = MODULE.merge_component_versions(
+            main_manifest,
+            stale_lume_release_manifest,
+            ["lume"],
+        )
+
+        self.assertEqual(
+            merged,
+            {
+                "libs/cua-driver": "0.11.0",
+                "libs/lume": "0.4.0",
+            },
+        )
+
+    def test_driver_release_keeps_newer_lume_version_from_main(self) -> None:
+        main_manifest = {
+            "libs/cua-driver": "0.10.0",
+            "libs/lume": "0.4.0",
+        }
+        stale_driver_release_manifest = {
+            "libs/cua-driver": "0.11.0",
+            "libs/lume": "0.3.16",
+        }
+
+        merged = MODULE.merge_component_versions(
+            main_manifest,
+            stale_driver_release_manifest,
+            ["cua-driver-rs"],
+        )
+
+        self.assertEqual(
+            merged,
+            {
+                "libs/cua-driver": "0.11.0",
+                "libs/lume": "0.4.0",
+            },
+        )
+
+    def test_missing_component_version_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "does not contain 'libs/lume'"):
+            MODULE.merge_component_versions(
+                {"libs/cua-driver": "0.11.0", "libs/lume": "0.3.16"},
+                {"libs/cua-driver": "0.10.0"},
+                ["lume"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -150,7 +150,41 @@ jobs:
             git checkout -B "$BRANCH" "origin/$BRANCH"
             git config user.name "trycua-release[bot]"
             git config user.email "trycua-release[bot]@users.noreply.github.com"
-            git rebase origin/main
+            if ! git rebase origin/main; then
+              mapfile -t CONFLICTS < <(git diff --name-only --diff-filter=U)
+              if [[ "${#CONFLICTS[@]}" -ne 1 || \
+                    "${CONFLICTS[0]}" != ".release-please-manifest.json" ]]; then
+                git rebase --abort
+                echo "::error::Release branch has conflicts beyond the shared manifest"
+                exit 1
+              fi
+
+              # Each component release PR rewrites the shared manifest from
+              # its original base. Keep main's versions for other components
+              # and carry forward only the version(s) owned by this PR.
+              git show origin/main:.release-please-manifest.json \
+                > "$RUNNER_TEMP/main-release-manifest.json"
+              git show "origin/$BRANCH:.release-please-manifest.json" \
+                > "$RUNNER_TEMP/branch-release-manifest.json"
+              COMPONENT_ARGS=()
+              if [[ "$DRIVER" == "true" ]]; then
+                COMPONENT_ARGS+=(--component cua-driver-rs)
+              fi
+              if [[ "$LUME" == "true" ]]; then
+                COMPONENT_ARGS+=(--component lume)
+              fi
+              python3 .github/scripts/merge_release_please_manifests.py \
+                --main "$RUNNER_TEMP/main-release-manifest.json" \
+                --release "$RUNNER_TEMP/branch-release-manifest.json" \
+                "${COMPONENT_ARGS[@]}" \
+                > .release-please-manifest.json
+              git add .release-please-manifest.json
+              if ! GIT_EDITOR=true git rebase --continue; then
+                git rebase --abort
+                echo "::error::Release branch still conflicts after manifest reconciliation"
+                exit 1
+              fi
+            fi
             if [[ "$DRIVER" == "true" ]]; then
               DRIVER_VERSION=$(tr -d '[:space:]' < libs/cua-driver/rust/VERSION)
               cargo update --manifest-path libs/cua-driver/rust/Cargo.toml \


### PR DESCRIPTION
## Summary

- reconcile the shared Release Please manifest when independent component release branches are rebased
- preserve current `main` versions for unrelated components and apply only the version owned by the release PR
- fail closed if any conflict exists beyond the expected shared manifest
- add regression coverage for Driver-after-Lume and Lume-after-Driver release ordering

## Verification

- `.venv/bin/python -m pytest .github/scripts/tests/test_merge_release_please_manifests.py .github/scripts/tests/test_cua_driver_release_wiring.py -q` (29 passed)
- reproduced and resolved the live two-commit Lume release-branch rebase against the Driver 0.11.0 release commit; final manifest retained Driver 0.11.0 and Lume 0.4.0

Closes #2432