### PR TITLE
fix(release): unblock Cua Driver SDK package publishing

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -35,6 +35,22 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertIn("os: ubuntu-24.04-arm", workflow)
         self.assertIn("arch: arm64", workflow)
 
+    def test_python_publish_smokes_windows_arm64_on_arm64(self) -> None:
+        workflow = self.read(".github/workflows/cd-py-cua-driver.yml")
+
+        self.assertIn("os: windows-11-arm", workflow)
+        self.assertEqual(workflow.count("os: windows-latest"), 1)
+
+    def test_npm_publish_uses_explicit_local_tarball_paths(self) -> None:
+        workflow = self.read(".github/workflows/cd-py-cua-driver.yml")
+
+        self.assertIn('npm publish "./$package"', workflow)
+        self.assertIn(
+            'npm publish "./dist/trycua-cua-driver-$VERSION.tgz"',
+            workflow,
+        )
+        self.assertNotIn('npm publish "$package"', workflow)
+
     def test_macos_bundle_explains_screen_capture_and_automation_prompts(self) -> None:
         plist = self.read(
             "libs/cua-driver/rust/scripts/CuaDriverBundle/Contents/Info.plist"

--- a/.github/workflows/cd-py-cua-driver.yml
+++ b/.github/workflows/cd-py-cua-driver.yml
@@ -97,7 +97,7 @@ jobs:
           - os: windows-latest
             platform: windows
             arch: x86_64
-          - os: windows-latest
+          - os: windows-11-arm
             platform: windows
             arch: arm64
     steps:
@@ -290,7 +290,7 @@ jobs:
             if npm view "$NAME@$VERSION" version >/dev/null 2>&1; then
               echo "$NAME@$VERSION already published; skipping"
             else
-              npm publish "$package" --access public --provenance
+              npm publish "./$package" --access public --provenance
             fi
           done
       - name: Publish @trycua/cua-driver
@@ -301,7 +301,7 @@ jobs:
           if npm view "@trycua/cua-driver@$VERSION" version >/dev/null 2>&1; then
             echo "@trycua/cua-driver@$VERSION already published; skipping"
           else
-            npm publish "dist/trycua-cua-driver-$VERSION.tgz" --access public --provenance
+            npm publish "./dist/trycua-cua-driver-$VERSION.tgz" --access public --provenance
           fi
       - name: Attach npm packages to the Cua Driver release
         env:


### PR DESCRIPTION
## Summary

- run the Windows ARM64 wheel build/import smoke on GitHub's ARM64 Windows runner so pip evaluates the wheel with a matching interpreter architecture
- make native and root npm tarball arguments explicit local paths instead of slash-containing package specs
- keep the existing idempotent registry version checks for safe reruns

## Verification

- `.venv/bin/python -m pytest .github/scripts/tests/test_cua_driver_release_wiring.py -q` (28 passed)
- downloaded the exact 0.11.0 npm artifacts from failed run 29922102116 and successfully ran `npm publish --dry-run` against both a native package and the root package using the corrected path form
- GitHub documents `windows-11-arm` as an ARM64 hosted runner label

Closes #2434
Closes #2435