### PR TITLE
build(cua-driver): declare npm provenance repository

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -51,6 +51,27 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         )
         self.assertNotIn('npm publish "$package"', workflow)
 
+    def test_npm_packages_declare_and_verify_provenance_repository(self) -> None:
+        workflow = self.read(".github/workflows/cd-py-cua-driver.yml")
+        package = json.loads(
+            self.read("libs/cua-driver/typescript/package.json")
+        )
+        package_lock = json.loads(
+            self.read("libs/cua-driver/typescript/package-lock.json")
+        )
+        expected = {
+            "type": "git",
+            "url": "git+https://github.com/trycua/cua.git",
+        }
+
+        self.assertEqual(package["repository"], expected)
+        self.assertEqual(package_lock["packages"][""]["repository"], expected)
+        self.assertIn("npm pkg set repository.type=git", workflow)
+        self.assertIn(
+            'test "$REPOSITORY" = "git+https://github.com/trycua/cua.git"',
+            workflow,
+        )
+
     def test_macos_bundle_explains_screen_capture_and_automation_prompts(self) -> None:
         plist = self.read(
             "libs/cua-driver/rust/scripts/CuaDriverBundle/Contents/Info.plist"

--- a/.github/workflows/cd-py-cua-driver.yml
+++ b/.github/workflows/cd-py-cua-driver.yml
@@ -202,6 +202,11 @@ jobs:
           cache-dependency-path: libs/cua-driver/typescript/package-lock.json
       - name: Verify one release version
         run: python3 .github/scripts/validate_release_versions.py --product driver
+      - name: Ensure npm provenance identifies the canonical repository
+        working-directory: libs/cua-driver/typescript
+        run: |
+          npm pkg set repository.type=git \
+            repository.url=git+https://github.com/trycua/cua.git
       - name: Install and build TypeScript SDK
         working-directory: libs/cua-driver/typescript
         run: |
@@ -245,6 +250,10 @@ jobs:
             --version "${{ needs.get-version.outputs.version }}" \
             --native-dir "$RUNNER_TEMP/cua-driver-native" \
             --output-dir "$RUNNER_TEMP/cua-driver-npm"
+          ROOT_PACKAGE="$RUNNER_TEMP/cua-driver-npm/trycua-cua-driver-${{ needs.get-version.outputs.version }}.tgz"
+          REPOSITORY=$(tar -xOf "$ROOT_PACKAGE" package/package.json | node -e \
+            "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.parse(s).repository?.url ?? ''))")
+          test "$REPOSITORY" = "git+https://github.com/trycua/cua.git"
           ls -lh "$RUNNER_TEMP/cua-driver-npm"/*.tgz
       - name: Smoke-test the packed Linux SDK
         run: |

--- a/libs/cua-driver/typescript/package-lock.json
+++ b/libs/cua-driver/typescript/package-lock.json
@@ -8,6 +8,10 @@
       "name": "@trycua/cua-driver",
       "version": "0.11.0",
       "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/trycua/cua.git"
+      },
       "dependencies": {
         "@ubjs/core": "0.31.0-3",
         "@ubjs/node": "0.31.0-3"

--- a/libs/cua-driver/typescript/package.json
+++ b/libs/cua-driver/typescript/package.json
@@ -4,6 +4,10 @@
   "description": "Rust-backed Cua Driver SDK and embedded Node host",
   "type": "module",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/trycua/cua.git"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary

- declare the canonical Git repository in the root TypeScript package and lockfile
- repair repository metadata while rebuilding an existing immutable release tag
- inspect the packed root tarball and fail before publication if its provenance repository is absent or wrong

This completes the interrupted 0.11.0 publication without introducing runtime behavior or a new package version.

## Verification

- `.venv/bin/python -m pytest .github/scripts/tests/test_cua_driver_release_wiring.py -q` (29 passed)
- native 0.11.0 npm packages already published with the same repository form and verified provenance

Closes #2438