### PR TITLE
feat(cua-driver): add client and modality telemetry

### DIFF
--- a/docs/content/docs/reference/cua-driver/telemetry.mdx
+++ b/docs/content/docs/reference/cua-driver/telemetry.mdx
@@ -54,11 +54,11 @@ cua-driver telemetry inspect cua_driver_agent_session_ended --json
 
 ## Common client event properties
 
-Every schema-v4 client event has this fixed envelope:
+Every schema-v3 client event has this fixed envelope:
 
 | Property                   | Meaning                                                   |
 | -------------------------- | --------------------------------------------------------- |
-| `telemetry_schema_version` | Fixed integer `4`                                         |
+| `telemetry_schema_version` | Fixed integer `3`                                         |
 | `product_version`          | Installed Cua Driver version                              |
 | `os_family`                | `macos`, `windows`, `linux`, or `other`                   |
 | `os_major`                 | Major operating-system version only                       |

--- a/docs/content/docs/reference/cua-driver/telemetry.mdx
+++ b/docs/content/docs/reference/cua-driver/telemetry.mdx
@@ -54,11 +54,11 @@ cua-driver telemetry inspect cua_driver_agent_session_ended --json
 
 ## Common client event properties
 
-Every schema-v3 client event has this fixed envelope:
+Every schema-v4 client event has this fixed envelope:
 
 | Property                   | Meaning                                                   |
 | -------------------------- | --------------------------------------------------------- |
-| `telemetry_schema_version` | Fixed integer `3`                                         |
+| `telemetry_schema_version` | Fixed integer `4`                                         |
 | `product_version`          | Installed Cua Driver version                              |
 | `os_family`                | `macos`, `windows`, `linux`, or `other`                   |
 | `os_major`                 | Major operating-system version only                       |
@@ -84,8 +84,8 @@ The client does not send an IP address as an event property. PostHog derives a c
 | `cua_driver_mcp_startup_completed`       | execution path, bounded daemon state, success, duration bucket, and `execution_mode`                                                                         |
 | `cua_driver_mcp_session_started`         | normalized MCP client and protocol, capability booleans, optional reported agent context, and `execution_mode`                                              |
 | `cua_driver_mcp_tool_completed`          | allowlisted tool, bounded compound-tool `operation`, `computer_action`, protocol success, error class, structured-refusal code, duration bucket, output shape and size buckets, and `execution_mode` |
-| `cua_driver_agent_session_started`       | declaration kind, revival flag, concurrent-session bucket, entry transport, and `execution_mode`                                                            |
-| `cua_driver_agent_session_ended`         | end reason, duration and count buckets, browser-refusal bucket, success flags, feature-family flags, multi-transport flag, and `execution_mode`              |
+| `cua_driver_agent_session_started`       | declaration kind, revival flag, concurrent-session bucket, entry transport, client kind, capture scope, and `execution_mode`                                 |
+| `cua_driver_agent_session_ended`         | end reason, duration and count buckets, browser-refusal bucket, success flags, feature-family flags, multi-transport flag, client kind, capture scope, bounded auto-escalation outcome, and `execution_mode` |
 | `cua_driver_permissions_gate_started`    | missing-permission booleans                                                                                                                                  |
 | `cua_driver_permissions_gate_dismissed`  | missing-permission booleans and duration bucket                                                                                                              |
 | `cua_driver_permissions_gate_completed`  | missing-permission booleans, panel and dismissal flags, fixed resolution, and duration bucket                                                               |
@@ -125,6 +125,10 @@ A Cua agent session is a non-empty caller-declared `session` value. The value `d
 The start event is emitted for a successful `start_session` declaration or the first known tool call that carries an explicit session. Repeated calls in the same live episode do not emit another start. Reusing an ID after explicit end or idle eviction creates a new episode with `revived=true`.
 
 The end event is emitted for `end_session` and idle eviction. It contains aggregate counters and booleans. When the platform has a cursor entry for that session, it also includes bounded cursor categories: enabled state, built-in/default/custom icon class, automatic/custom color source, label presence, motion customization, and an active-cursor count bucket. `cursor_outcome_observed=false` distinguishes sessions with no readable cursor entry from a disabled or default cursor. Cua Driver uses the caller session string only as a process-local map key. The string, a hash of it, and a replacement join token are absent from telemetry payloads.
+
+Both session events retain the episode's declared `capture_scope` (`window`, `desktop`, or `auto`) and its closed `client_kind` (`cli`, `direct`, `mcp`, `python_sdk`, or `typescript_sdk`). The Python and TypeScript package roots select their category automatically; applications cannot attach a free-form client label. `execution_mode` independently distinguishes `embedded` from `standalone` hosts.
+
+For `capture_scope=auto`, the end event sets `auto_escalated_to_desktop=true` only after a successful `escalate_session`. Its reason is limited to `ax_tree_pixel_mismatch`, `background_delivery_failed`, `foreground_ineffective`, `no_window_target`, or `other`; sessions without a successful auto escalation use `not_applicable`. Free-form escalation detail is never observed or sent.
 
 Computer-action success covers fixed pointer and keyboard capabilities, app launch and kill, window activation, state-changing `page` operations, and successful browser navigation, click, type, pointer, file-assignment, download, or dialog-resolution calls. A structured browser refusal does not count as a completed computer action. `get_browser_state` and `browser_dialog` inspection are reads for this classifier, and `browser_prepare` is tracked as browser use rather than a computer action because preparation may either reuse an endpoint or produce an approved visible side effect.
 
@@ -184,7 +188,7 @@ A browser refusal is a successful MCP exchange with a behavioral result of `refu
 
 ## Data that is never collected
 
-Routine telemetry excludes task text, prompts, tool arguments, tool response bodies, typed text, screenshots, accessibility trees, window titles, application names, file paths, URLs, arbitrary MCP metadata, raw cursor IDs, labels, colors, icon paths, numeric motion values, and raw error messages. Browser telemetry also excludes target, tab, frame, ref, process, window, and session identifiers; profile names and paths; queries and coordinates; approval tokens; endpoint URLs and ports; refusal messages and details; and requested or delivered text lengths.
+Routine telemetry excludes task text, prompts, tool arguments, tool response bodies, typed text, screenshots, accessibility trees, window titles, application names, free-form client labels, escalation detail, file paths, URLs, arbitrary MCP metadata, raw cursor IDs, labels, colors, icon paths, numeric motion values, and raw error messages. Browser telemetry also excludes target, tab, frame, ref, process, window, and session identifiers; profile names and paths; queries and coordinates; approval tokens; endpoint URLs and ports; refusal messages and details; and requested or delivered text lengths.
 
 Tool-completion events retain only coarse result shape: text, image, mixed, empty, or unknown; a size bucket; a duration bucket; a fixed error class; and, for reviewed structured browser refusals, the fixed code above. The content itself never crosses the telemetry observer boundary. A proxy and daemon negotiate one completion-event owner. Mixed-version pairs retain proxy ownership, which prevents duplicate events during upgrades.
 

--- a/libs/cua-driver/python/src/cua_driver/__init__.py
+++ b/libs/cua-driver/python/src/cua_driver/__init__.py
@@ -7,7 +7,7 @@ through their runtime's MCP client instead of importing a language MCP facade.
 __version__ = "0.11.0"  # x-release-please-version
 
 from ._native import (
-    CuaDriver,
+    CuaDriver as _NativeCuaDriver,
     DriverError,
     DriverMetadata,
     EmbeddedCuaDriverHost,
@@ -21,6 +21,7 @@ from ._native import (
     EmbeddedPermissionMode,
     ImageContent,
     MacOsPermissionStatus,
+    SdkClientKind,
     ToolResult,
     current_mac_os_permission_status,
     open_mac_os_screen_recording_settings,
@@ -54,6 +55,16 @@ from ._native_contract import (
     TypeTextInput,
 )
 from .wrapper import get_binary_path, run_cua_driver
+
+
+def _connect_python_sdk(cls, socket_path):
+    """Preserve ``CuaDriver.connect`` while tagging the imported runtime."""
+
+    return cls.connect_with_client_kind(socket_path, SdkClientKind.PYTHON)
+
+
+_NativeCuaDriver.connect = classmethod(_connect_python_sdk)
+CuaDriver = _NativeCuaDriver
 
 __all__ = [
     "CaptureScope",

--- a/libs/cua-driver/python/src/cua_driver/_native.py
+++ b/libs/cua-driver/python/src/cua_driver/_native.py
@@ -488,6 +488,8 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_cua_driver_sdk_checksum_constructor_cuadriver_connect() != 42154:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_cua_driver_sdk_checksum_constructor_cuadriver_connect_with_client_kind() != 43287:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_cua_driver_sdk_checksum_method_cuadriver_call_tool() != 31445:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_cua_driver_sdk_checksum_method_cuadriver_click() != 34118:
@@ -842,6 +844,12 @@ _UniffiLib.uniffi_cua_driver_sdk_fn_constructor_cuadriver_connect.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_cua_driver_sdk_fn_constructor_cuadriver_connect.restype = ctypes.c_uint64
+_UniffiLib.uniffi_cua_driver_sdk_fn_constructor_cuadriver_connect_with_client_kind.argtypes = (
+    _UniffiRustBuffer,
+    _UniffiRustBuffer,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_cua_driver_sdk_fn_constructor_cuadriver_connect_with_client_kind.restype = ctypes.c_uint64
 _UniffiLib.uniffi_cua_driver_sdk_fn_method_cuadriver_call_tool.argtypes = (
     ctypes.c_uint64,
     _UniffiRustBuffer,
@@ -1006,6 +1014,9 @@ _UniffiLib.uniffi_cua_driver_sdk_checksum_func_request_mac_os_permissions.restyp
 _UniffiLib.uniffi_cua_driver_sdk_checksum_constructor_cuadriver_connect.argtypes = (
 )
 _UniffiLib.uniffi_cua_driver_sdk_checksum_constructor_cuadriver_connect.restype = ctypes.c_uint16
+_UniffiLib.uniffi_cua_driver_sdk_checksum_constructor_cuadriver_connect_with_client_kind.argtypes = (
+)
+_UniffiLib.uniffi_cua_driver_sdk_checksum_constructor_cuadriver_connect_with_client_kind.restype = ctypes.c_uint16
 _UniffiLib.uniffi_cua_driver_sdk_checksum_method_cuadriver_call_tool.argtypes = (
 )
 _UniffiLib.uniffi_cua_driver_sdk_checksum_method_cuadriver_call_tool.restype = ctypes.c_uint16
@@ -2419,6 +2430,51 @@ class _UniffiFfiConverterTypeEmbeddedDriverHostState(_UniffiConverterRustBuffer)
 
 
 
+class SdkClientKind(enum.Enum):
+    """
+    Runtime that imported the shared UniFFI SDK library. The language package
+    selects this automatically at its root entry point; callers do not need to
+    supply telemetry metadata.
+"""
+
+    PYTHON = 0
+
+    TYPESCRIPT = 1
+
+
+
+class _UniffiFfiConverterTypeSdkClientKind(_UniffiConverterRustBuffer):
+    @staticmethod
+    def read(buf):
+        variant = buf.read_i32()
+        if variant == 1:
+            return SdkClientKind.PYTHON
+        if variant == 2:
+            return SdkClientKind.TYPESCRIPT
+        raise InternalError("Raw enum value doesn't match any cases")
+
+    @staticmethod
+    def check_lower(value):
+        if value == SdkClientKind.PYTHON:
+            return
+        if value == SdkClientKind.TYPESCRIPT:
+            return
+        raise ValueError(value)
+
+    @staticmethod
+    def write(value, buf):
+        if value == SdkClientKind.PYTHON:
+            buf.write_i32(1)
+        if value == SdkClientKind.TYPESCRIPT:
+            buf.write_i32(2)
+
+
+
+
+
+
+
+
 
 
 
@@ -2513,6 +2569,28 @@ class CuaDriver(CuaDriverProtocol):
         _uniffi_ffi_result = _uniffi_rust_call_with_error(
             _uniffi_error_converter,
             _UniffiLib.uniffi_cua_driver_sdk_fn_constructor_cuadriver_connect,
+            *_uniffi_lowered_args,
+        )
+        return cls._uniffi_make_instance(_uniffi_ffi_result)
+    @classmethod
+    def connect_with_client_kind(cls, socket_path: typing.Optional[str],client_kind: SdkClientKind) -> CuaDriver:
+        """
+        Language-package entry point that preserves the public `connect` API
+        while attaching a closed runtime category to daemon requests.
+"""
+
+        _UniffiFfiConverterOptionalString.check_lower(socket_path)
+
+        _UniffiFfiConverterTypeSdkClientKind.check_lower(client_kind)
+        _uniffi_lowered_args = (
+            _UniffiFfiConverterOptionalString.lower(socket_path),
+            _UniffiFfiConverterTypeSdkClientKind.lower(client_kind),
+        )
+        _uniffi_lift_return = _UniffiFfiConverterTypeCuaDriver.lift
+        _uniffi_error_converter = _UniffiFfiConverterTypeDriverError
+        _uniffi_ffi_result = _uniffi_rust_call_with_error(
+            _uniffi_error_converter,
+            _UniffiLib.uniffi_cua_driver_sdk_fn_constructor_cuadriver_connect_with_client_kind,
             *_uniffi_lowered_args,
         )
         return cls._uniffi_make_instance(_uniffi_ffi_result)
@@ -3106,6 +3184,7 @@ __all__ = [
     "DriverError",
     "EmbeddedDriverError",
     "EmbeddedDriverHostState",
+    "SdkClientKind",
     "DriverMetadata",
     "EmbeddedEnvironmentVariable",
     "EmbeddedMcpConfiguration",

--- a/libs/cua-driver/python/tests/test_uniffi_loader.py
+++ b/libs/cua-driver/python/tests/test_uniffi_loader.py
@@ -178,6 +178,7 @@ except FileNotFoundError:
         self.assertTrue(result.verified)
         self.assertEqual(captured[0]["name"], "get_desktop_state")
         self.assertEqual(captured[0]["args"], {"session": "python-run"})
+        self.assertEqual(captured[0]["client_kind"], "python_sdk")
 
 
 if os.environ.get("CUA_DRIVER_REQUIRE_UNIFFI") == "1" and not LIBRARY.exists():

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/binding.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/binding.rs
@@ -313,7 +313,7 @@ mod tests {
         assert!(matches!(
             correlate(
                 &native("Docs - Chrome", visible_frame),
-                &[candidate.clone()],
+                std::slice::from_ref(&candidate),
                 8.0
             ),
             BindingOutcome::Bound {

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/engine.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/engine.rs
@@ -2057,6 +2057,9 @@ impl BrowserEngine {
         Ok(document)
     }
 
+    // These values form one semantic snapshot envelope; keeping them explicit
+    // makes the stored reference index and reported metadata auditable together.
+    #[allow(clippy::too_many_arguments)]
     fn semantic_outcome(
         &self,
         snapshot_id: u64,

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/grant.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/grant.rs
@@ -83,6 +83,9 @@ impl ExistingProfileGrants {
         }
     }
 
+    // Minting deliberately captures the complete immutable browser grant in
+    // one call so partially initialized grants cannot enter the registry.
+    #[allow(clippy::too_many_arguments)]
     pub fn mint(
         &self,
         public_session: &str,

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/semantic.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/semantic.rs
@@ -963,11 +963,10 @@ fn remove_redundant_static_text(nodes: &mut Vec<SemanticNode>) {
         let Some(name) = node.name.as_deref() else {
             return false;
         };
-        !node
-            .parent_ax_id
+        node.parent_ax_id
             .as_ref()
             .and_then(|parent| names.get(parent))
-            .is_some_and(|parent_name| parent_name == name)
+            .is_none_or(|parent_name| parent_name != name)
     });
 }
 

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/cdp.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/cdp.rs
@@ -326,9 +326,7 @@ mod tests {
             let id = call["id"].as_u64().unwrap();
             websocket
                 .send(Message::Text(
-                    json!({ "method": "Runtime.consoleAPICalled", "params": {} })
-                        .to_string()
-                        .into(),
+                    json!({ "method": "Runtime.consoleAPICalled", "params": {} }).to_string(),
                 ))
                 .await
                 .unwrap();
@@ -338,8 +336,7 @@ mod tests {
                         "id": id,
                         "result": { "result": { "value": "compat" } }
                     })
-                    .to_string()
-                    .into(),
+                    .to_string(),
                 ))
                 .await
                 .unwrap();

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/daemon.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/daemon.rs
@@ -44,6 +44,18 @@ pub enum ToolObservationOrigin {
     Direct,
 }
 
+/// Closed, content-free identity for a direct daemon client. This is carried
+/// separately from `observation_origin` so older daemons safely ignore the
+/// additive field instead of rejecting a newer enum variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DaemonClientKind {
+    Cli,
+    PythonSdk,
+    TypescriptSdk,
+    Unknown,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DaemonRequest {
     pub method: String,
@@ -59,6 +71,11 @@ pub struct DaemonRequest {
     /// observation. Older peers ignore this additive field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub observation_origin: Option<ToolObservationOrigin>,
+    /// Privacy-bounded direct-client identity used only for aggregate product
+    /// telemetry. Raw package names, application names, and host identifiers
+    /// are never accepted here.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_kind: Option<DaemonClientKind>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -104,6 +121,7 @@ pub fn request_daemon_metadata(socket_path: &str) -> anyhow::Result<DaemonMetada
             args: None,
             session_id: None,
             observation_origin: None,
+            client_kind: None,
         },
     )?;
     if !response.ok {
@@ -173,6 +191,7 @@ pub fn is_daemon_listening(socket_path: &str) -> bool {
             args: None,
             session_id: None,
             observation_origin: None,
+            client_kind: None,
         };
         send_request(socket_path, &request)
             .ok()
@@ -275,8 +294,8 @@ pub fn send_request(socket_path: &str, request: &DaemonRequest) -> anyhow::Resul
 #[cfg(test)]
 mod tests {
     use super::{
-        current_daemon_metadata, socket_path_for_namespace, DaemonRequest, DaemonResponse,
-        ToolObservationOrigin,
+        current_daemon_metadata, socket_path_for_namespace, DaemonClientKind, DaemonRequest,
+        DaemonResponse, ToolObservationOrigin,
     };
 
     #[test]
@@ -295,6 +314,23 @@ mod tests {
         .unwrap();
         assert_eq!(request.session_id, None);
         assert_eq!(request.observation_origin, None);
+        assert_eq!(request.client_kind, None);
+    }
+
+    #[test]
+    fn direct_client_kind_is_bounded_and_snake_case() {
+        let request = DaemonRequest {
+            method: "call".into(),
+            name: Some("start_session".into()),
+            args: None,
+            session_id: None,
+            observation_origin: Some(ToolObservationOrigin::Direct),
+            client_kind: Some(DaemonClientKind::TypescriptSdk),
+        };
+        let value = serde_json::to_value(request).unwrap();
+        assert_eq!(value["client_kind"], "typescript_sdk");
+        assert!(value.get("application_name").is_none());
+        assert!(value.get("package_name").is_none());
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/health_report.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/health_report.rs
@@ -717,8 +717,8 @@ mod tests {
         // Every entry must carry hint + message.
         for entry in structured["checks"].as_array().unwrap() {
             assert_eq!(entry["status"], "fail");
-            assert!(entry["hint"].as_str().unwrap_or("").len() > 0);
-            assert!(entry["message"].as_str().unwrap_or("").len() > 0);
+            assert!(!entry["hint"].as_str().unwrap_or("").is_empty());
+            assert!(!entry["message"].as_str().unwrap_or("").is_empty());
         }
     }
 

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/lib.rs
@@ -79,4 +79,5 @@ pub mod tool_schema;
 pub mod video;
 pub mod video_ffmpeg;
 
+pub use cua_driver_contract::{CaptureScope, EscalationReason};
 pub use recording::RecordingSession;

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/recording_loader.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/recording_loader.rs
@@ -252,14 +252,12 @@ fn parse_click_turn(action_path: &Path) -> Option<ClickEvent> {
             (x, y)
         } else if let Some(cp) = v.get("click_point") {
             (double_value(cp.get("x"))?, double_value(cp.get("y"))?)
-        } else if let Some(screen) = parse_screen_from_summary(
-            v.get("result_summary")
-                .and_then(|s| s.as_str())
-                .unwrap_or(""),
-        ) {
-            screen
         } else {
-            return None;
+            parse_screen_from_summary(
+                v.get("result_summary")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or(""),
+            )?
         }
     } else if let Some(cp) = v.get("click_point") {
         (double_value(cp.get("x"))?, double_value(cp.get("y"))?)

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/recording_zoom.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/recording_zoom.rs
@@ -13,13 +13,7 @@ use serde::{Deserialize, Serialize};
 
 #[inline]
 pub fn clamp01(v: f64) -> f64 {
-    if v < 0.0 {
-        0.0
-    } else if v > 1.0 {
-        1.0
-    } else {
-        v
-    }
+    v.clamp(0.0, 1.0)
 }
 
 #[inline]

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/server.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/server.rs
@@ -579,7 +579,14 @@ pub fn session_tool_context(
     }
     let call = req.tool_call().ok()?;
     let known_tool = call.name == "type_text_chars" || registry.get_def(&call.name).is_some();
-    crate::session::begin_tool_call(&call.name, &call.args, known_tool, transport)
+    let client_kind = match transport {
+        crate::session::SessionTransport::Cli => crate::session::SessionClientKind::Cli,
+        crate::session::SessionTransport::Daemon => crate::session::SessionClientKind::Direct,
+        crate::session::SessionTransport::McpStdio | crate::session::SessionTransport::McpHttp => {
+            crate::session::SessionClientKind::Mcp
+        }
+    };
+    crate::session::begin_tool_call(&call.name, &call.args, known_tool, transport, client_kind)
 }
 
 fn notify_session_started(metadata: InitializeMetadata) {

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/session.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/session.rs
@@ -22,6 +22,8 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
+use cua_driver_contract::{CaptureScope, EscalationReason};
+
 type SessionEndHook = Box<dyn Fn(&str) + Send + Sync>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -46,11 +48,25 @@ pub enum SessionTransport {
     McpHttp,
 }
 
+/// Closed entry-surface category for one explicit session episode. This is
+/// deliberately independent from transport: Python and TypeScript SDKs both
+/// use the direct daemon transport, while MCP can use stdio or HTTP.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionClientKind {
+    Cli,
+    Direct,
+    Mcp,
+    PythonSdk,
+    TypescriptSdk,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SessionStartObservation {
     pub declaration: SessionDeclaration,
     pub revived: bool,
     pub transport: SessionTransport,
+    pub client_kind: SessionClientKind,
+    pub capture_scope: CaptureScope,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -137,6 +153,7 @@ pub trait SessionObserver: Send + Sync + 'static {
         session_id: &str,
         transport: SessionTransport,
         computer_action: bool,
+        escalation_reason: Option<EscalationReason>,
         outcome: &crate::server::ToolCompletionObservation,
     );
     fn on_session_ended(
@@ -173,6 +190,7 @@ pub struct SessionToolContext {
     session_id: String,
     transport: SessionTransport,
     computer_action: bool,
+    escalation_reason: Option<EscalationReason>,
 }
 
 impl SessionToolContext {
@@ -182,6 +200,7 @@ impl SessionToolContext {
                 &self.session_id,
                 self.transport,
                 self.computer_action,
+                self.escalation_reason,
                 outcome,
             );
         }
@@ -216,6 +235,7 @@ pub fn begin_tool_call(
     args: &serde_json::Value,
     known_tool: bool,
     transport: SessionTransport,
+    client_kind: SessionClientKind,
 ) -> Option<SessionToolContext> {
     if !known_tool {
         return None;
@@ -232,6 +252,20 @@ pub fn begin_tool_call(
     }
 
     touch_session(session_id);
+    let capture_scope = if is_start {
+        args.get("capture_scope")
+            .cloned()
+            .and_then(|value| serde_json::from_value(value).ok())
+            .unwrap_or_default()
+    } else {
+        crate::capture_scope::get_session(session_id)
+            .map(|state| state.policy)
+            .unwrap_or_default()
+    };
+    let escalation_reason = (tool_name == "escalate_session")
+        .then(|| args.get("reason").cloned())
+        .flatten()
+        .and_then(|value| serde_json::from_value(value).ok());
     if !is_end {
         if let Some(observer) = SESSION_OBSERVER.get() {
             observer.on_session_started(
@@ -244,6 +278,8 @@ pub fn begin_tool_call(
                     },
                     revived,
                     transport,
+                    client_kind,
+                    capture_scope,
                 },
             );
         }
@@ -256,6 +292,7 @@ pub fn begin_tool_call(
             tool_name,
             crate::server::tool_operation(tool_name, Some(args)),
         ),
+        escalation_reason,
     })
 }
 
@@ -435,6 +472,7 @@ mod tests {
             _: &str,
             _: SessionTransport,
             _: bool,
+            _: Option<EscalationReason>,
             _: &crate::server::ToolCompletionObservation,
         ) {
         }
@@ -636,6 +674,7 @@ mod tests {
             &serde_json::json!({"_session_id": "private-fallback"}),
             true,
             SessionTransport::McpStdio,
+            SessionClientKind::Mcp,
         )
         .is_none());
         assert!(begin_tool_call(
@@ -643,6 +682,7 @@ mod tests {
             &serde_json::json!({"session": "default"}),
             true,
             SessionTransport::McpStdio,
+            SessionClientKind::Mcp,
         )
         .is_none());
 
@@ -651,6 +691,7 @@ mod tests {
             &serde_json::json!({"session": "test-action-pointer-AB12"}),
             true,
             SessionTransport::McpStdio,
+            SessionClientKind::Mcp,
         )
         .unwrap();
         assert!(pointer.computer_action);
@@ -664,6 +705,7 @@ mod tests {
             }),
             true,
             SessionTransport::McpHttp,
+            SessionClientKind::Mcp,
         )
         .unwrap();
         assert!(page_write.computer_action);
@@ -678,6 +720,7 @@ mod tests {
             }),
             true,
             SessionTransport::McpHttp,
+            SessionClientKind::Mcp,
         )
         .unwrap();
         assert!(!page_read.computer_action);
@@ -687,9 +730,27 @@ mod tests {
             &serde_json::json!({"session": "test-action-read-GH78"}),
             true,
             SessionTransport::Daemon,
+            SessionClientKind::Direct,
         )
         .unwrap();
         assert!(!state_read.computer_action);
+
+        let escalation = begin_tool_call(
+            "escalate_session",
+            &serde_json::json!({
+                "session": "test-action-escalate-IJ90",
+                "reason": "no_window_target",
+                "detail": "private free-form detail is not observed"
+            }),
+            true,
+            SessionTransport::Daemon,
+            SessionClientKind::TypescriptSdk,
+        )
+        .unwrap();
+        assert_eq!(
+            escalation.escalation_reason,
+            Some(EscalationReason::NoWindowTarget)
+        );
     }
 
     #[test]
@@ -701,9 +762,10 @@ mod tests {
         let explicit = "test-observer-explicit-IJ90";
         begin_tool_call(
             "start_session",
-            &serde_json::json!({"session": explicit}),
+            &serde_json::json!({"session": explicit, "capture_scope": "desktop"}),
             true,
             SessionTransport::McpStdio,
+            SessionClientKind::Mcp,
         )
         .unwrap();
         end_session(explicit);
@@ -714,6 +776,7 @@ mod tests {
             &serde_json::json!({"session": idle}),
             true,
             SessionTransport::McpHttp,
+            SessionClientKind::Mcp,
         )
         .unwrap();
         end_session_with_reason(idle, SessionEndReason::IdleTimeout);
@@ -726,6 +789,7 @@ mod tests {
             &serde_json::json!({"session": revived}),
             true,
             SessionTransport::Daemon,
+            SessionClientKind::PythonSdk,
         )
         .unwrap();
 
@@ -735,6 +799,7 @@ mod tests {
             &serde_json::json!({"session": control}),
             true,
             SessionTransport::McpStdio,
+            SessionClientKind::Mcp,
         )
         .unwrap();
         fire_session_end(control);
@@ -744,6 +809,8 @@ mod tests {
             id == explicit
                 && observation.declaration == SessionDeclaration::StartSession
                 && !observation.revived
+                && observation.client_kind == SessionClientKind::Mcp
+                && observation.capture_scope == CaptureScope::Desktop
         }));
         assert!(starts.iter().any(|(id, observation)| {
             id == idle

--- a/libs/cua-driver/rust/crates/cua-driver-core/tests/session_lifecycle.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/tests/session_lifecycle.rs
@@ -4,9 +4,10 @@
 //! A session is a caller-declared identity that OWNS disposable per-run state:
 //! the agent cursor, per-session config overrides, and any recording it started.
 //! Those concrete registries live OUTSIDE this core crate:
-//!   * the agent cursor → `platform-macos::CursorRegistry` + the overlay,
-//!   * per-session config overrides → `platform-macos::SessionConfigRegistry`,
-//!   * the owned recording → stopped by `serve.rs`'s recording hook.
+//! - the agent cursor → `platform-macos::CursorRegistry` + the overlay,
+//! - per-session config overrides → `platform-macos::SessionConfigRegistry`,
+//! - the owned recording → stopped by `serve.rs`'s recording hook.
+//!
 //! None of them is reachable from a core-only test. They are ALL wired to
 //! disposal through ONE mechanism: each registers a `register_session_end_hook`,
 //! and BOTH teardown paths — `end_session` (explicit) and `evict_idle` (the
@@ -56,9 +57,10 @@ fn unique_id(tag: &str) -> String {
 
 /// The three disposal side-effects a session owns, each modelling one real
 /// production `register_session_end_hook` registration:
-///   * `cursor_removed`   → `platform-macos`: `CursorRegistry::remove` + overlay.
-///   * `config_cleared`   → `platform-macos`: `SessionConfigRegistry::clear`.
-///   * `recording_stopped`→ `serve.rs`: `RecordingSession::stop_owner(Some(sid))`.
+/// - `cursor_removed`   → `platform-macos`: `CursorRegistry::remove` + overlay.
+/// - `config_cleared`   → `platform-macos`: `SessionConfigRegistry::clear`.
+/// - `recording_stopped`→ `serve.rs`: `RecordingSession::stop_owner(Some(sid))`.
+///
 /// Each counts fires for ONE specific session id (hooks are process-global, so we
 /// filter). A correctly-disposed session shows all three == 1.
 struct Disposal {

--- a/libs/cua-driver/rust/crates/cua-driver-sdk/src/embedded.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-sdk/src/embedded.rs
@@ -142,7 +142,7 @@ enum HostPhase {
         generation: String,
         cancel: Arc<AtomicBool>,
     },
-    Ready(RunningProcess),
+    Ready(Box<RunningProcess>),
     Stopping {
         generation: String,
     },
@@ -326,7 +326,7 @@ impl EmbeddedCuaDriverHost {
             enum Action {
                 Done,
                 Wait,
-                Stop(RunningProcess),
+                Stop(Box<RunningProcess>),
             }
             let action = {
                 let mut inner = self.inner.lock().unwrap();
@@ -353,7 +353,7 @@ impl EmbeddedCuaDriverHost {
             match action {
                 Action::Done => return Ok(()),
                 Action::Wait => notified.await,
-                Action::Stop(running) => return self.clone().finish_stop(running).await,
+                Action::Stop(running) => return self.clone().finish_stop(*running).await,
             }
         }
     }
@@ -543,7 +543,7 @@ impl EmbeddedCuaDriverHost {
             );
             if still_starting {
                 inner.last_exit = None;
-                inner.phase = HostPhase::Ready(pending.take().unwrap());
+                inner.phase = HostPhase::Ready(Box::new(pending.take().unwrap()));
             }
             still_starting
         };
@@ -923,7 +923,7 @@ fn validate_socket_path(socket_path: &str) -> Result<(), EmbeddedDriverError> {
         if !std::path::Path::new(socket_path).is_absolute() {
             return configuration_error("Unix socket_path must be absolute");
         }
-        if socket_path.as_bytes().len() >= 104 {
+        if socket_path.len() >= 104 {
             return configuration_error(
                 "socket_path exceeds the portable Unix socket length limit",
             );

--- a/libs/cua-driver/rust/crates/cua-driver-sdk/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-sdk/src/lib.rs
@@ -70,10 +70,10 @@ pub struct MacOsPermissionStatus {
 pub fn current_mac_os_permission_status() -> MacOsPermissionStatus {
     #[cfg(target_os = "macos")]
     {
-        return MacOsPermissionStatus {
+        MacOsPermissionStatus {
             accessibility: mac_os_accessibility_granted(),
             screen_recording: mac_os_screen_recording_granted(),
-        };
+        }
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -88,10 +88,10 @@ pub fn current_mac_os_permission_status() -> MacOsPermissionStatus {
 pub fn request_mac_os_permissions() -> MacOsPermissionStatus {
     #[cfg(target_os = "macos")]
     {
-        return MacOsPermissionStatus {
+        MacOsPermissionStatus {
             accessibility: request_mac_os_accessibility(),
             screen_recording: request_mac_os_screen_recording(),
-        };
+        }
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -120,7 +120,7 @@ pub fn open_mac_os_screen_recording_settings() -> Result<(), DriverError> {
                 ),
             });
         }
-        return Ok(());
+        Ok(())
     }
     #[cfg(not(target_os = "macos"))]
     {

--- a/libs/cua-driver/rust/crates/cua-driver-sdk/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-sdk/src/lib.rs
@@ -13,7 +13,7 @@ use cua_driver_contract::{
 };
 use cua_driver_core::daemon::{
     is_daemon_listening, request_daemon_metadata, send_request, socket_path_for_namespace,
-    DaemonRequest, ToolObservationOrigin,
+    DaemonClientKind, DaemonRequest, ToolObservationOrigin,
 };
 use serde::Serialize;
 use serde_json::Value;
@@ -193,6 +193,25 @@ pub enum DriverError {
 #[derive(uniffi::Object)]
 pub struct CuaDriver {
     socket_path: String,
+    client_kind: DaemonClientKind,
+}
+
+/// Runtime that imported the shared UniFFI SDK library. The language package
+/// selects this automatically at its root entry point; callers do not need to
+/// supply telemetry metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum SdkClientKind {
+    Python,
+    Typescript,
+}
+
+impl From<SdkClientKind> for DaemonClientKind {
+    fn from(value: SdkClientKind) -> Self {
+        match value {
+            SdkClientKind::Python => Self::PythonSdk,
+            SdkClientKind::Typescript => Self::TypescriptSdk,
+        }
+    }
 }
 
 macro_rules! desktop_tool_methods {
@@ -252,7 +271,24 @@ impl CuaDriver {
                 reason: "socket_path must not be empty".into(),
             });
         }
-        Ok(Arc::new(Self { socket_path }))
+        Ok(Arc::new(Self {
+            socket_path,
+            client_kind: DaemonClientKind::Unknown,
+        }))
+    }
+
+    /// Language-package entry point that preserves the public `connect` API
+    /// while attaching a closed runtime category to daemon requests.
+    #[uniffi::constructor]
+    pub fn connect_with_client_kind(
+        socket_path: Option<String>,
+        client_kind: SdkClientKind,
+    ) -> Result<Arc<Self>, DriverError> {
+        let driver = Self::connect(socket_path)?;
+        Ok(Arc::new(Self {
+            socket_path: driver.socket_path.clone(),
+            client_kind: client_kind.into(),
+        }))
     }
 
     pub fn socket_path(&self) -> String {
@@ -299,6 +335,7 @@ impl CuaDriver {
             args: None,
             session_id: None,
             observation_origin: Some(ToolObservationOrigin::Direct),
+            client_kind: Some(self.client_kind),
         };
         let response =
             send_request(&self.socket_path, &request).map_err(|error| DriverError::Transport {
@@ -374,6 +411,7 @@ impl CuaDriver {
             args: Some(arguments),
             session_id: None,
             observation_origin: Some(ToolObservationOrigin::Direct),
+            client_kind: Some(self.client_kind),
         };
         let response =
             send_request(&self.socket_path, &request).map_err(|error| DriverError::Transport {
@@ -547,7 +585,8 @@ mod tests {
             }
         });
         let (_directory, socket, server) = serve_once(response);
-        let driver = CuaDriver::connect(Some(socket)).unwrap();
+        let driver =
+            CuaDriver::connect_with_client_kind(Some(socket), SdkClientKind::Python).unwrap();
         let result = driver
             .get_desktop_state(GetDesktopStateInput {
                 session: Some("run-1".into()),
@@ -563,6 +602,7 @@ mod tests {
         assert_eq!(request["name"], "get_desktop_state");
         assert_eq!(request["args"], serde_json::json!({"session": "run-1"}));
         assert_eq!(request["observation_origin"], "direct");
+        assert_eq!(request["client_kind"], "python_sdk");
     }
 
     #[test]
@@ -579,6 +619,7 @@ mod tests {
         let request = server.join().unwrap();
         assert_eq!(request["method"], "list");
         assert_eq!(request["observation_origin"], "direct");
+        assert_eq!(request["client_kind"], "unknown");
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -1771,6 +1771,7 @@ pub fn run_call(
             // CLI one-shot is its own ephemeral, anonymous/global session.
             session_id: None,
             observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
+            client_kind: Some(cua_driver_core::daemon::DaemonClientKind::Cli),
         };
         match crate::serve::send_request(&socket_path, &req) {
             Ok(resp) => {
@@ -1934,6 +1935,7 @@ pub fn run_recording_cmd(subcommand: &str, args: &[String], socket: Option<&str>
                 // nobody, so only an unconditional stop (CLI / manual) reaps it.
                 session_id: None,
                 observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
+                client_kind: Some(cua_driver_core::daemon::DaemonClientKind::Cli),
             };
             match crate::serve::send_request(&socket_path, &req) {
                 Ok(resp) if resp.ok => {
@@ -1945,6 +1947,7 @@ pub fn run_recording_cmd(subcommand: &str, args: &[String], socket: Option<&str>
                         args: Some(serde_json::json!({})),
                         session_id: None,
                         observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
+                        client_kind: Some(cua_driver_core::daemon::DaemonClientKind::Cli),
                     };
                     if let Ok(sr) = crate::serve::send_request(&socket_path, &state_req) {
                         if let Some(result) = sr.result {
@@ -1979,6 +1982,7 @@ pub fn run_recording_cmd(subcommand: &str, args: &[String], socket: Option<&str>
                 args: Some(serde_json::json!({})),
                 session_id: None,
                 observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
+                client_kind: Some(cua_driver_core::daemon::DaemonClientKind::Cli),
             };
             match crate::serve::send_request(&socket_path, &req) {
                 Ok(resp) if resp.ok => println!("Recording stopped."),
@@ -2002,6 +2006,7 @@ pub fn run_recording_cmd(subcommand: &str, args: &[String], socket: Option<&str>
                 args: Some(serde_json::json!({})),
                 session_id: None,
                 observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
+                client_kind: Some(cua_driver_core::daemon::DaemonClientKind::Cli),
             };
             match crate::serve::send_request(&socket_path, &req) {
                 Ok(resp) if resp.ok => {
@@ -2332,6 +2337,7 @@ fn run_permissions_status(json: bool) {
             args: Some(serde_json::json!({ "prompt": false })),
             session_id: None,
             observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
+            client_kind: Some(cua_driver_core::daemon::DaemonClientKind::Cli),
         };
         crate::serve::send_request(&socket, &req)
             .ok()
@@ -2465,6 +2471,7 @@ fn permission_check_request(
         })),
         session_id: None,
         observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
+        client_kind: Some(cua_driver_core::daemon::DaemonClientKind::Cli),
     }
 }
 
@@ -3107,6 +3114,7 @@ fn diagnose_tcc_section() -> String {
             args: Some(serde_json::json!({ "prompt": false })),
             session_id: None,
             observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
+            client_kind: Some(cua_driver_core::daemon::DaemonClientKind::Cli),
         })
         .and_then(|request| crate::serve::send_request(&socket, &request).ok())
         .filter(|response| response.ok)
@@ -3297,6 +3305,7 @@ pub fn run_config_cmd(
             args: Some(args),
             session_id: None,
             observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
+            client_kind: Some(cua_driver_core::daemon::DaemonClientKind::Cli),
         };
         let response = crate::serve::send_request(&socket_path, &req).unwrap_or_else(|error| {
             eprintln!("Cua Driver daemon request on {socket_path} failed: {error}");

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -1045,7 +1045,7 @@ pub fn run_describe(registry: &ToolRegistry, name: &str) {
             process::exit(64);
         }
         Some(def) => {
-            print!("name: {}\n", def.name);
+            println!("name: {}", def.name);
             if !def.description.is_empty() {
                 print!("\ndescription:\n{}", def.description);
                 if !def.description.ends_with('\n') {
@@ -1857,7 +1857,6 @@ pub fn run_call(
                             }
                         }
                     }
-                    return;
                 } else {
                     if let Some(err) = resp.error {
                         eprintln!("{err}");
@@ -2064,7 +2063,7 @@ pub fn run_recording_cmd(subcommand: &str, args: &[String], socket: Option<&str>
 fn run_recording_render(args: &[String]) {
     // First positional = input dir, second positional = output mp4.
     let positionals: Vec<&String> = args.iter().filter(|s| !s.starts_with("--")).collect();
-    let input_dir = match positionals.get(0) {
+    let input_dir = match positionals.first() {
         Some(s) if !s.is_empty() => std::path::PathBuf::from(s),
         _ => {
             eprintln!(
@@ -3361,9 +3360,8 @@ pub fn run_config_cmd(
             let config = get_config();
             // Support dotted key paths like "agent_cursor.enabled".
             let v = if key.contains('.') {
-                let mut parts = key.splitn(2, '.');
-                let parent = parts.next().unwrap();
-                let child = parts.next().unwrap();
+                let (parent, child) = key.split_once('.').unwrap();
+
                 config
                     .get(parent)
                     .and_then(|object| object.get(child))
@@ -3811,6 +3809,7 @@ mod tests {
 
     /// Every subcommand entry has the same JSON shape — name + description
     /// + args[] — so consumers can render the catalog uniformly without
+    ///
     /// per-subcommand branching.
     #[test]
     fn manifest_subcommands_have_uniform_shape() {
@@ -3861,7 +3860,7 @@ fn first_sentence(text: &str) -> String {
         return String::new();
     }
     let flat: String = trimmed
-        .splitn(3, "\n\n")
+        .split("\n\n")
         .next()
         .unwrap_or(trimmed)
         .split('\n')

--- a/libs/cua-driver/rust/crates/cua-driver/src/main.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/main.rs
@@ -289,27 +289,22 @@ fn main() {
     match command {
         cli::Command::Telemetry(command) => {
             run_telemetry_command(command);
-            return;
         }
         cli::Command::ListTools => {
             let reg = Arc::new(build_macos_registry());
             cli::run_list_tools(&reg);
-            return;
         }
         cli::Command::Describe(name) => {
             let reg = Arc::new(build_macos_registry());
             cli::run_describe(&reg, &name);
-            return;
         }
         cli::Command::McpConfig { client } => {
             cli::run_mcp_config(client.as_deref());
-            return;
         }
         cli::Command::Manifest { pretty } => {
             // Surface 8: machine-readable CLI manifest. Read-only — no
             // registry build needed, no daemon contact.
             cli::run_manifest(pretty);
-            return;
         }
         cli::Command::Call {
             tool,
@@ -318,7 +313,6 @@ fn main() {
             socket,
         } => {
             cli::run_call(&tool, json_args, screenshot_out_file, socket);
-            return;
         }
         cli::Command::Serve {
             socket,
@@ -514,12 +508,10 @@ fn main() {
             } else {
                 let _ = serve_handle.join();
             }
-            return;
         }
         cli::Command::Stop { socket } => {
             let sp = socket.unwrap_or_else(serve::default_socket_path);
             serve::run_stop_cmd(&sp);
-            return;
         }
         cli::Command::Revoke {
             socket,
@@ -528,13 +520,11 @@ fn main() {
         } => {
             let sp = socket.unwrap_or_else(serve::default_socket_path);
             serve::run_revoke_cmd(&sp, session.as_deref(), all);
-            return;
         }
         cli::Command::Status { socket } => {
             let sp = socket.unwrap_or_else(serve::default_socket_path);
             let pid_path = serve::default_pid_file_path();
             serve::run_status_cmd(&sp, &pid_path);
-            return;
         }
         cli::Command::Recording {
             subcommand,
@@ -542,20 +532,16 @@ fn main() {
             socket,
         } => {
             cli::run_recording_cmd(&subcommand, &args, socket.as_deref());
-            return;
         }
         cli::Command::DumpDocs { pretty, doc_type } => {
             let reg = Arc::new(build_macos_registry());
             cli::run_dump_docs_with_type(&reg, pretty, &doc_type);
-            return;
         }
         cli::Command::Update { apply, json } => {
             cli::run_update_cmd(apply, json);
-            return;
         }
         cli::Command::CheckUpdate { json, no_cache } => {
             cli::run_check_update_cmd(json, no_cache);
-            return;
         }
         cli::Command::Doctor { json } => {
             // Long-running interactive entry point — kick off the
@@ -566,23 +552,18 @@ fn main() {
                 version_check::maybe_announce_update();
             }
             cli::run_doctor_cmd(json);
-            return;
         }
         cli::Command::Diagnose => {
             cli::run_diagnose_cmd();
-            return;
         }
         cli::Command::Permissions { subcommand, json } => {
             cli::run_permissions_cmd(&subcommand, json);
-            return;
         }
         cli::Command::Autostart { subcommand } => {
             autostart::run_autostart_cmd(&subcommand);
-            return;
         }
         cli::Command::Skills { subcommand, flags } => {
             skills::run(&subcommand, &flags);
-            return;
         }
         cli::Command::BrowserApprove {
             pid,
@@ -600,7 +581,6 @@ fn main() {
                 profile_mode.as_deref(),
                 profile_name.as_deref(),
             );
-            return;
         }
         cli::Command::Config {
             subcommand,
@@ -614,7 +594,6 @@ fn main() {
                 value.as_deref(),
                 socket.as_deref(),
             );
-            return;
         }
         cli::Command::Mcp {
             socket,
@@ -639,7 +618,6 @@ fn main() {
                 std::process::exit(1);
             }
             telemetry::flush_pending(std::time::Duration::from_millis(750));
-            return;
         }
     }
 }

--- a/libs/cua-driver/rust/crates/cua-driver/src/mcp_http.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/mcp_http.rs
@@ -111,9 +111,7 @@ async fn dispatch(body: &[u8], registry: &Arc<ToolRegistry>) -> Option<String> {
         Ok(r) => r,
         Err(_) => return Some(serialize(&Response::parse_error())),
     };
-    if req.id.is_none() {
-        return None; // notification
-    }
+    req.id.as_ref()?;
     let initialize_metadata = req.initialize_metadata();
     let session_context = session_tool_context(
         &req,
@@ -145,7 +143,7 @@ fn http_tool_observation_timer(
     registry: &ToolRegistry,
 ) -> Option<cua_driver_core::server::ToolObservationTimer> {
     tool_observation_timer(
-        &req,
+        req,
         |name| name == "type_text_chars" || registry.get_def(name).is_some(),
         StdioExecutionPath::DirectDaemon,
     )

--- a/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
@@ -512,13 +512,12 @@ fn daemon_owns_tool_observation(result: &serde_json::Value) -> bool {
 
 /// JSON-RPC method dispatcher for the proxy. Mirrors
 /// `cua_driver_core::server::handle_request`:
-///   - `initialize`     → static `initialize_result()` (same envelope
-///                        as the core protocol server; the daemon's
-///                        identity is hidden from the MCP client).
-///   - `tools/list`     → return the cached daemon tool list.
-///   - `tools/call`     → forward to the daemon and reshape the
-///                        response into MCP's `CallTool.Result`.
-///   - other            → method-not-found.
+/// - `initialize` → static `initialize_result()` (same envelope as the core
+///   protocol server; the daemon's identity is hidden from the MCP client).
+/// - `tools/list` → return the cached daemon tool list.
+/// - `tools/call` → forward to the daemon and reshape the response into MCP's
+///   `CallTool.Result`.
+/// - other → method-not-found.
 async fn handle_proxy_request(
     req: Request,
     id: serde_json::Value,

--- a/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
@@ -140,6 +140,7 @@ pub async fn run_proxy(socket_path: String) -> anyhow::Result<()> {
                                 &call.args,
                                 known_tool,
                                 cua_driver_core::session::SessionTransport::McpStdio,
+                                cua_driver_core::session::SessionClientKind::Mcp,
                             )
                         })
                     })
@@ -238,6 +239,7 @@ async fn run_control_connection(
         args: None,
         session_id: Some(session_id.clone()),
         observation_origin: None,
+        client_kind: None,
     };
     let line = match serde_json::to_string(&begin) {
         Ok(s) => s + "\n",
@@ -376,6 +378,7 @@ fn fetch_tools_list_from_daemon(
         args: None,
         session_id: Some(session_id.to_owned()),
         observation_origin: None,
+        client_kind: None,
     };
     let resp = send_request(socket_path, &req)?;
     if !resp.ok {
@@ -581,6 +584,7 @@ async fn forward_tool_call(
         args: Some(args),
         session_id: Some(session_id.to_owned()),
         observation_origin: daemon_observes_tool_calls.then_some(ToolObservationOrigin::McpProxy),
+        client_kind: None,
     };
 
     // The daemon client is sync, so jump to a blocking thread to keep

--- a/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
@@ -357,6 +357,7 @@ async fn invoke_daemon_tool(
     req: DaemonRequest,
 ) -> DaemonResponse {
     let observation_transport = daemon_observation_transport(&req);
+    let direct_client_kind = req.client_kind;
     let raw_name = req.name.as_deref().unwrap_or("").to_owned();
     let tool_name = if raw_name == "type_text_chars" {
         eprintln!(
@@ -430,7 +431,30 @@ async fn invoke_daemon_tool(
                 cua_driver_core::session::SessionTransport::Daemon
             }
         };
-        cua_driver_core::session::begin_tool_call(&tool_name, &args, true, transport)
+        let client_kind = match transport {
+            cua_driver_core::session::SessionTransport::McpStdio
+            | cua_driver_core::session::SessionTransport::McpHttp => {
+                cua_driver_core::session::SessionClientKind::Mcp
+            }
+            cua_driver_core::session::SessionTransport::Cli => {
+                cua_driver_core::session::SessionClientKind::Cli
+            }
+            cua_driver_core::session::SessionTransport::Daemon => match direct_client_kind {
+                Some(cua_driver_core::daemon::DaemonClientKind::Cli) => {
+                    cua_driver_core::session::SessionClientKind::Cli
+                }
+                Some(cua_driver_core::daemon::DaemonClientKind::PythonSdk) => {
+                    cua_driver_core::session::SessionClientKind::PythonSdk
+                }
+                Some(cua_driver_core::daemon::DaemonClientKind::TypescriptSdk) => {
+                    cua_driver_core::session::SessionClientKind::TypescriptSdk
+                }
+                Some(cua_driver_core::daemon::DaemonClientKind::Unknown) | None => {
+                    cua_driver_core::session::SessionClientKind::Direct
+                }
+            },
+        };
+        cua_driver_core::session::begin_tool_call(&tool_name, &args, true, transport, client_kind)
     });
 
     let result = registry.invoke(&tool_name, args).await;
@@ -1578,6 +1602,7 @@ pub fn run_stop_cmd(socket_path: &str) {
         args: None,
         session_id: None,
         observation_origin: None,
+        client_kind: None,
     };
     match send_request(socket_path, &req) {
         Ok(_) => {
@@ -1625,6 +1650,7 @@ pub fn run_status_cmd(socket_path: &str, pid_file_path: &str) {
             args: None,
             session_id: None,
             observation_origin: Some(ToolObservationOrigin::Direct),
+            client_kind: None,
         };
         if let Ok(response) = send_request(socket_path, &request) {
             if let Some(status) = response.result {
@@ -1701,6 +1727,7 @@ pub fn run_revoke_cmd(socket_path: &str, session: Option<&str>, all: bool) {
         }),
         session_id: None,
         observation_origin: Some(ToolObservationOrigin::Direct),
+        client_kind: None,
     };
     match send_request(socket_path, &request) {
         Ok(response) if response.ok => {
@@ -1831,6 +1858,7 @@ mod gate_tests {
             args: Some(serde_json::json!({})),
             session_id: sid.map(|s| s.to_owned()),
             observation_origin: None,
+            client_kind: None,
         }
     }
 
@@ -1893,6 +1921,7 @@ mod gate_tests {
             args: None,
             session_id: Some(sid.to_owned()),
             observation_origin: None,
+            client_kind: None,
         };
         let resp = tokio::task::spawn_blocking(move || send_request(&socket2, &end))
             .await
@@ -1936,6 +1965,7 @@ mod gate_tests {
             args: Some(serde_json::json!({ "session": s3b.clone() })),
             session_id: Some(s3b),
             observation_origin: None,
+            client_kind: None,
         };
         let resp = tokio::task::spawn_blocking(move || send_request(&socket3b, &start))
             .await
@@ -1982,6 +2012,7 @@ mod gate_tests {
             args: None,
             session_id: None,
             observation_origin: None,
+            client_kind: None,
         };
         let _ = tokio::task::spawn_blocking(move || send_request(&socket5, &shutdown)).await;
         let _ = server.await;
@@ -2000,6 +2031,7 @@ mod telemetry_routing_tests {
             args: Some(serde_json::json!({})),
             session_id: Some("bounded-session".into()),
             observation_origin: origin,
+            client_kind: None,
         }
     }
 

--- a/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/serve.rs
@@ -1546,7 +1546,7 @@ pub fn run_serve_cmd(
     if is_daemon_listening(&socket_path) {
         let pid_hint = pid_file_path
             .as_deref()
-            .and_then(|p| read_pid_file(p))
+            .and_then(read_pid_file)
             .map(|pid| format!(" (pid {pid})"))
             .unwrap_or_default();
         eprintln!(

--- a/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
@@ -44,19 +44,16 @@
 //! - Claude Code: `~/.claude/skills/`
 //! - Codex:       `~/.agents/skills/`
 //! - OpenClaw:    `~/.openclaw/skills/`
-//! - OpenCode:    `~/.config/opencode/skills/` (macOS / Linux),
-//!                `%APPDATA%\opencode\skills\` (Windows)
+//! - OpenCode: `~/.config/opencode/skills/` (macOS / Linux),
+//!   `%APPDATA%\opencode\skills\` (Windows)
 //! - Antigravity: `~/.gemini/skills/` — shared between Antigravity CLI
-//!                (`agy`) and Antigravity IDE; same dir Google Gemini CLI
-//!                used before the May-2026 transition, so existing
-//!                installs migrate forward unchanged.
-//! - Hermes:      `~/.hermes/skills/` — NousResearch/hermes-agent.
-//!                The user-level skill space Hermes resolves at agent
-//!                load time (separate from the repo-bundled
-//!                `hermes-agent/skills/` tree, which is read-only and
-//!                version-controlled). Hermes' own `computer-use`
-//!                skill teaches its wrapper vocabulary; the
-//!                cua-driver pack provides the platform deep dives.
+//!   (`agy`) and Antigravity IDE; same dir Google Gemini CLI used before the
+//!   May-2026 transition, so existing installs migrate forward unchanged.
+//! - Hermes: `~/.hermes/skills/` — NousResearch/hermes-agent. The user-level
+//!   skill space Hermes resolves at agent load time (separate from the
+//!   repo-bundled `hermes-agent/skills/` tree, which is read-only and
+//!   version-controlled). Hermes' own `computer-use` skill teaches its wrapper
+//!   vocabulary; the cua-driver pack provides the platform deep dives.
 //!
 //! Only acts on a given agent when its parent skills dir already
 //! exists (i.e. the agent itself is installed). Never clobbers an
@@ -148,7 +145,7 @@ fn home_dir() -> Result<PathBuf> {
     #[cfg(not(windows))]
     {
         let home = std::env::var("HOME").map_err(|_| anyhow!("HOME not set"))?;
-        return Ok(PathBuf::from(home).join(crate::bundle::user_home_subdirectory()));
+        Ok(PathBuf::from(home).join(crate::bundle::user_home_subdirectory()))
     }
 }
 
@@ -338,9 +335,10 @@ fn install(flags: &[String], force: bool) -> Result<()> {
 
 /// Best-effort removal of any pre-rename skill pack. Three legacy
 /// locations are swept:
-///   1. `<HomeDir>/skills/cua-driver-rs/`       — old pack NAME under new home dir
-///   2. `<LegacyHomeDir>/skills/cua-driver/`    — new pack NAME under old home dir
-///   3. `<LegacyHomeDir>/skills/cua-driver-rs/` — old pack NAME under old home dir
+/// 1. `<HomeDir>/skills/cua-driver-rs/`       — old pack NAME under new home dir
+/// 2. `<LegacyHomeDir>/skills/cua-driver/`    — new pack NAME under old home dir
+/// 3. `<LegacyHomeDir>/skills/cua-driver-rs/` — old pack NAME under old home dir
+///
 /// Plus every `<agent_skills>/cua-driver-rs` symlink/junction.
 ///
 /// Then attempts to remove the empty `<LegacyHomeDir>/skills/` and
@@ -403,7 +401,7 @@ fn sweep_legacy_skill_pack() {
             Err(_) => continue,
         };
         let legacy_link = parent.join(LEGACY_SKILL_PACK_NAME);
-        if !parent.exists() || !legacy_link.symlink_metadata().is_ok() {
+        if !parent.exists() || legacy_link.symlink_metadata().is_err() {
             continue;
         }
         if !is_symlink_or_junction(&legacy_link) {

--- a/libs/cua-driver/rust/crates/cua-driver/src/telemetry.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/telemetry.rs
@@ -366,6 +366,8 @@ pub fn inspect_event(event_name: &str) -> Result<Value, String> {
             ("revived", Value::Bool(false)),
             ("concurrent_sessions_bucket", Value::String("1".into())),
             ("entry_transport", Value::String("mcp_stdio".into())),
+            ("client_kind", Value::String("mcp".into())),
+            ("capture_scope", Value::String("auto".into())),
             ("execution_mode", Value::String(execution_mode().into())),
         ]),
         event::AGENT_SESSION_ENDED => bounded_properties(&[
@@ -393,6 +395,10 @@ pub fn inspect_event(event_name: &str) -> Result<Value, String> {
             ("cursor_motion_customized", Value::Bool(false)),
             ("multi_cursor_bucket", Value::String("1".into())),
             ("observed_multiple_transports", Value::Bool(false)),
+            ("client_kind", Value::String("mcp".into())),
+            ("capture_scope", Value::String("auto".into())),
+            ("auto_escalated_to_desktop", Value::Bool(true)),
+            ("escalation_reason", Value::String("other".into())),
             ("execution_mode", Value::String(execution_mode().into())),
         ]),
         event::PERMISSIONS_GATE_STARTED => bounded_properties(&[
@@ -485,6 +491,10 @@ static AGENT_SESSIONS: OnceLock<Mutex<HashMap<String, AgentSessionState>>> = Onc
 struct AgentSessionState {
     started: std::time::Instant,
     entry_transport: Transport,
+    client_kind: cua_driver_core::session::SessionClientKind,
+    capture_scope: cua_driver_core::CaptureScope,
+    auto_escalated_to_desktop: bool,
+    escalation_reason: Option<cua_driver_core::EscalationReason>,
     transport_bits: u8,
     tool_count: u64,
     computer_action_count: u64,
@@ -500,10 +510,18 @@ struct AgentSessionState {
 }
 
 impl AgentSessionState {
-    fn new(entry_transport: Transport) -> Self {
+    fn new(
+        entry_transport: Transport,
+        client_kind: cua_driver_core::session::SessionClientKind,
+        capture_scope: cua_driver_core::CaptureScope,
+    ) -> Self {
         Self {
             started: std::time::Instant::now(),
             entry_transport,
+            client_kind,
+            capture_scope,
+            auto_escalated_to_desktop: false,
+            escalation_reason: None,
             transport_bits: transport_bit(entry_transport),
             tool_count: 0,
             computer_action_count: 0,
@@ -523,10 +541,20 @@ impl AgentSessionState {
         &mut self,
         transport: Transport,
         computer_action: bool,
+        escalation_reason: Option<cua_driver_core::EscalationReason>,
         outcome: &cua_driver_core::server::ToolCompletionObservation,
     ) {
         self.transport_bits |= transport_bit(transport);
         let tool_name = outcome.tool_name.as_str();
+        if tool_name == "escalate_session"
+            && outcome.success
+            && self.capture_scope == cua_driver_core::CaptureScope::Auto
+        {
+            if let Some(reason) = escalation_reason {
+                self.auto_escalated_to_desktop = true;
+                self.escalation_reason = Some(reason);
+            }
+        }
         if matches!(tool_name, "start_session" | "end_session") {
             return;
         }
@@ -655,6 +683,22 @@ impl AgentSessionState {
                 "observed_multiple_transports",
                 Value::Bool(self.transport_bits.count_ones() > 1),
             ),
+            (
+                "client_kind",
+                Value::String(session_client_kind(self.client_kind).into()),
+            ),
+            (
+                "capture_scope",
+                Value::String(capture_scope(self.capture_scope).into()),
+            ),
+            (
+                "auto_escalated_to_desktop",
+                Value::Bool(self.auto_escalated_to_desktop),
+            ),
+            (
+                "escalation_reason",
+                Value::String(escalation_reason(self.escalation_reason).into()),
+            ),
             ("execution_mode", Value::String(execution_mode().into())),
         ])
     }
@@ -675,6 +719,37 @@ fn session_transport(transport: cua_driver_core::session::SessionTransport) -> T
         cua_driver_core::session::SessionTransport::Daemon => Transport::Daemon,
         cua_driver_core::session::SessionTransport::McpStdio => Transport::McpStdio,
         cua_driver_core::session::SessionTransport::McpHttp => Transport::McpHttp,
+    }
+}
+
+fn session_client_kind(kind: cua_driver_core::session::SessionClientKind) -> &'static str {
+    match kind {
+        cua_driver_core::session::SessionClientKind::Cli => "cli",
+        cua_driver_core::session::SessionClientKind::Direct => "direct",
+        cua_driver_core::session::SessionClientKind::Mcp => "mcp",
+        cua_driver_core::session::SessionClientKind::PythonSdk => "python_sdk",
+        cua_driver_core::session::SessionClientKind::TypescriptSdk => "typescript_sdk",
+    }
+}
+
+fn capture_scope(scope: cua_driver_core::CaptureScope) -> &'static str {
+    match scope {
+        cua_driver_core::CaptureScope::Auto => "auto",
+        cua_driver_core::CaptureScope::Window => "window",
+        cua_driver_core::CaptureScope::Desktop => "desktop",
+    }
+}
+
+fn escalation_reason(reason: Option<cua_driver_core::EscalationReason>) -> &'static str {
+    match reason {
+        Some(cua_driver_core::EscalationReason::AxTreePixelMismatch) => "ax_tree_pixel_mismatch",
+        Some(cua_driver_core::EscalationReason::BackgroundDeliveryFailed) => {
+            "background_delivery_failed"
+        }
+        Some(cua_driver_core::EscalationReason::ForegroundIneffective) => "foreground_ineffective",
+        Some(cua_driver_core::EscalationReason::NoWindowTarget) => "no_window_target",
+        Some(cua_driver_core::EscalationReason::Other) => "other",
+        None => "not_applicable",
     }
 }
 
@@ -746,7 +821,14 @@ impl cua_driver_core::session::SessionObserver for TelemetryObserver {
             if sessions.len() >= MAX_TRACKED_AGENT_SESSIONS {
                 return;
             }
-            sessions.insert(session_id.to_owned(), AgentSessionState::new(transport));
+            sessions.insert(
+                session_id.to_owned(),
+                AgentSessionState::new(
+                    transport,
+                    observation.client_kind,
+                    observation.capture_scope,
+                ),
+            );
             sessions.len()
         };
         let declaration = match observation.declaration {
@@ -765,6 +847,14 @@ impl cua_driver_core::session::SessionObserver for TelemetryObserver {
                     Value::String(concurrent_sessions_bucket(concurrent).into()),
                 ),
                 ("entry_transport", Value::String(transport.as_str().into())),
+                (
+                    "client_kind",
+                    Value::String(session_client_kind(observation.client_kind).into()),
+                ),
+                (
+                    "capture_scope",
+                    Value::String(capture_scope(observation.capture_scope).into()),
+                ),
                 ("execution_mode", Value::String(execution_mode().into())),
             ]),
             transport,
@@ -776,6 +866,7 @@ impl cua_driver_core::session::SessionObserver for TelemetryObserver {
         session_id: &str,
         transport: cua_driver_core::session::SessionTransport,
         computer_action: bool,
+        escalation_reason: Option<cua_driver_core::EscalationReason>,
         outcome: &cua_driver_core::server::ToolCompletionObservation,
     ) {
         let sessions = AGENT_SESSIONS.get_or_init(|| Mutex::new(HashMap::new()));
@@ -785,7 +876,12 @@ impl cua_driver_core::session::SessionObserver for TelemetryObserver {
             return;
         }
         if let Some(state) = sessions.get_mut(session_id) {
-            state.observe(session_transport(transport), computer_action, outcome);
+            state.observe(
+                session_transport(transport),
+                computer_action,
+                escalation_reason,
+                outcome,
+            );
         }
     }
 
@@ -1946,7 +2042,7 @@ fn build_payload(
     transport: Transport,
 ) -> Value {
     let mut event_properties = properties.clone();
-    event_properties.insert("telemetry_schema_version".into(), Value::from(3));
+    event_properties.insert("telemetry_schema_version".into(), Value::from(4));
     event_properties
         .entry("product_version")
         .or_insert_with(|| Value::String(current_product_version().into()));
@@ -2934,7 +3030,7 @@ mod tests {
     }
 
     #[test]
-    fn v3_payload_allows_server_geoip_without_sending_an_ip_or_client_timestamp() {
+    fn v4_payload_allows_server_geoip_without_sending_an_ip_or_client_timestamp() {
         let _guard = ENV_LOCK.lock().unwrap();
         let identity = InstallationIdentity {
             id: "test-id".into(),
@@ -2970,7 +3066,7 @@ mod tests {
         ] {
             assert!(properties.contains_key(required), "missing {required}");
         }
-        assert_eq!(properties["telemetry_schema_version"], 3);
+        assert_eq!(properties["telemetry_schema_version"], 4);
         assert_eq!(properties["is_synthetic"], false);
         assert!(!properties.contains_key("$geoip_disable"));
         assert!(!properties.contains_key("$ip"));
@@ -3079,7 +3175,7 @@ mod tests {
         let permissions = inspect_event(event::PERMISSIONS_GATE_COMPLETED).unwrap();
         assert_eq!(permissions["properties"]["resolution"], "granted");
         for payload in [permissions_started, permissions_dismissed, permissions] {
-            assert_eq!(payload["properties"]["telemetry_schema_version"], 3);
+            assert_eq!(payload["properties"]["telemetry_schema_version"], 4);
             assert!(payload.get("timestamp").is_none());
             let serialized = serde_json::to_string(&payload)
                 .unwrap()
@@ -3195,11 +3291,16 @@ mod tests {
             DurationBucket, OutputSizeBucket, OutputType, ToolCompletionObservation, ToolErrorClass,
         };
 
-        let mut state = AgentSessionState::new(Transport::McpStdio);
+        let mut state = AgentSessionState::new(
+            Transport::McpStdio,
+            cua_driver_core::session::SessionClientKind::PythonSdk,
+            cua_driver_core::CaptureScope::Auto,
+        );
         state.started = std::time::Instant::now() - Duration::from_secs(75);
         state.observe(
             Transport::McpHttp,
             true,
+            None,
             &ToolCompletionObservation {
                 tool_name: "click".into(),
                 operation: cua_driver_core::server::ToolOperation::NotApplicable,
@@ -3215,6 +3316,23 @@ mod tests {
         state.observe(
             Transport::McpHttp,
             false,
+            Some(cua_driver_core::EscalationReason::NoWindowTarget),
+            &ToolCompletionObservation {
+                tool_name: "escalate_session".into(),
+                operation: cua_driver_core::server::ToolOperation::NotApplicable,
+                computer_action: false,
+                success: true,
+                error_class: ToolErrorClass::None,
+                refusal_code: cua_driver_core::server::ToolRefusalCode::None,
+                duration_bucket: DurationBucket::Under10Ms,
+                output_type: OutputType::Text,
+                output_size_bucket: OutputSizeBucket::Under1KiB,
+            },
+        );
+        state.observe(
+            Transport::McpHttp,
+            false,
+            None,
             &ToolCompletionObservation {
                 tool_name: "page".into(),
                 operation: cua_driver_core::server::ToolOperation::QueryDom,
@@ -3254,6 +3372,10 @@ mod tests {
         assert_eq!(properties["cursor_motion_customized"], true);
         assert_eq!(properties["multi_cursor_bucket"], "3_5");
         assert_eq!(properties["observed_multiple_transports"], true);
+        assert_eq!(properties["client_kind"], "python_sdk");
+        assert_eq!(properties["capture_scope"], "auto");
+        assert_eq!(properties["auto_escalated_to_desktop"], true);
+        assert_eq!(properties["escalation_reason"], "no_window_target");
 
         let serialized = serde_json::to_string(&properties)
             .unwrap()
@@ -3273,6 +3395,60 @@ mod tests {
                 "aggregate contains {forbidden}: {serialized}"
             );
         }
+    }
+
+    #[test]
+    fn failed_or_non_auto_escalation_is_not_counted() {
+        use cua_driver_core::server::{
+            DurationBucket, OutputSizeBucket, OutputType, ToolCompletionObservation,
+            ToolErrorClass, ToolOperation, ToolRefusalCode,
+        };
+
+        let failed = ToolCompletionObservation {
+            tool_name: "escalate_session".into(),
+            operation: ToolOperation::NotApplicable,
+            computer_action: false,
+            success: false,
+            error_class: ToolErrorClass::InvalidParams,
+            refusal_code: ToolRefusalCode::None,
+            duration_bucket: DurationBucket::Under10Ms,
+            output_type: OutputType::Text,
+            output_size_bucket: OutputSizeBucket::Under1KiB,
+        };
+        let mut auto = AgentSessionState::new(
+            Transport::Daemon,
+            cua_driver_core::session::SessionClientKind::TypescriptSdk,
+            cua_driver_core::CaptureScope::Auto,
+        );
+        auto.observe(
+            Transport::Daemon,
+            false,
+            Some(cua_driver_core::EscalationReason::Other),
+            &failed,
+        );
+        let properties =
+            auto.ended_properties(cua_driver_core::session::SessionEndReason::Explicit, None);
+        assert_eq!(properties["auto_escalated_to_desktop"], false);
+        assert_eq!(properties["escalation_reason"], "not_applicable");
+
+        let mut desktop = AgentSessionState::new(
+            Transport::Daemon,
+            cua_driver_core::session::SessionClientKind::PythonSdk,
+            cua_driver_core::CaptureScope::Desktop,
+        );
+        let mut successful = failed;
+        successful.success = true;
+        successful.error_class = ToolErrorClass::None;
+        desktop.observe(
+            Transport::Daemon,
+            false,
+            Some(cua_driver_core::EscalationReason::Other),
+            &successful,
+        );
+        let properties =
+            desktop.ended_properties(cua_driver_core::session::SessionEndReason::Explicit, None);
+        assert_eq!(properties["auto_escalated_to_desktop"], false);
+        assert_eq!(properties["escalation_reason"], "not_applicable");
     }
 
     #[test]
@@ -3302,8 +3478,12 @@ mod tests {
         );
         assert_eq!(event_properties["operation"], "browser_click_trusted");
 
-        let mut state = AgentSessionState::new(Transport::McpStdio);
-        state.observe(Transport::McpStdio, true, &outcome);
+        let mut state = AgentSessionState::new(
+            Transport::McpStdio,
+            cua_driver_core::session::SessionClientKind::Mcp,
+            cua_driver_core::CaptureScope::Window,
+        );
+        state.observe(Transport::McpStdio, true, None, &outcome);
         let session_properties =
             state.ended_properties(cua_driver_core::session::SessionEndReason::Explicit, None);
         assert_eq!(session_properties["computer_action_count_bucket"], "0");
@@ -3333,10 +3513,15 @@ mod tests {
                 ToolOperation::BrowserPointerDoubleClickDomEvent,
             ),
         ] {
-            let mut state = AgentSessionState::new(Transport::McpStdio);
+            let mut state = AgentSessionState::new(
+                Transport::McpStdio,
+                cua_driver_core::session::SessionClientKind::Mcp,
+                cua_driver_core::CaptureScope::Window,
+            );
             state.observe(
                 Transport::McpStdio,
                 true,
+                None,
                 &ToolCompletionObservation {
                     tool_name: tool_name.into(),
                     operation,
@@ -3386,7 +3571,7 @@ mod tests {
     fn agent_session_inspect_samples_expose_only_the_contract() {
         for event_name in [event::AGENT_SESSION_STARTED, event::AGENT_SESSION_ENDED] {
             let payload = inspect_event(event_name).unwrap();
-            assert_eq!(payload["properties"]["telemetry_schema_version"], 3);
+            assert_eq!(payload["properties"]["telemetry_schema_version"], 4);
             let properties = payload["properties"].as_object().unwrap();
             for forbidden_key in ["session", "session_id", "agent_session_id", "cursor_id"] {
                 assert!(!properties.contains_key(forbidden_key));
@@ -3430,6 +3615,8 @@ mod tests {
                     declaration: SessionDeclaration::StartSession,
                     revived: false,
                     transport: SessionTransport::McpStdio,
+                    client_kind: cua_driver_core::session::SessionClientKind::Mcp,
+                    capture_scope: cua_driver_core::CaptureScope::Auto,
                 },
             );
             capture_tool_completed(

--- a/libs/cua-driver/rust/crates/cua-driver/src/telemetry.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/telemetry.rs
@@ -2042,7 +2042,7 @@ fn build_payload(
     transport: Transport,
 ) -> Value {
     let mut event_properties = properties.clone();
-    event_properties.insert("telemetry_schema_version".into(), Value::from(4));
+    event_properties.insert("telemetry_schema_version".into(), Value::from(3));
     event_properties
         .entry("product_version")
         .or_insert_with(|| Value::String(current_product_version().into()));
@@ -3030,7 +3030,7 @@ mod tests {
     }
 
     #[test]
-    fn v4_payload_allows_server_geoip_without_sending_an_ip_or_client_timestamp() {
+    fn v3_payload_allows_server_geoip_without_sending_an_ip_or_client_timestamp() {
         let _guard = ENV_LOCK.lock().unwrap();
         let identity = InstallationIdentity {
             id: "test-id".into(),
@@ -3066,7 +3066,7 @@ mod tests {
         ] {
             assert!(properties.contains_key(required), "missing {required}");
         }
-        assert_eq!(properties["telemetry_schema_version"], 4);
+        assert_eq!(properties["telemetry_schema_version"], 3);
         assert_eq!(properties["is_synthetic"], false);
         assert!(!properties.contains_key("$geoip_disable"));
         assert!(!properties.contains_key("$ip"));
@@ -3175,7 +3175,7 @@ mod tests {
         let permissions = inspect_event(event::PERMISSIONS_GATE_COMPLETED).unwrap();
         assert_eq!(permissions["properties"]["resolution"], "granted");
         for payload in [permissions_started, permissions_dismissed, permissions] {
-            assert_eq!(payload["properties"]["telemetry_schema_version"], 4);
+            assert_eq!(payload["properties"]["telemetry_schema_version"], 3);
             assert!(payload.get("timestamp").is_none());
             let serialized = serde_json::to_string(&payload)
                 .unwrap()
@@ -3571,7 +3571,7 @@ mod tests {
     fn agent_session_inspect_samples_expose_only_the_contract() {
         for event_name in [event::AGENT_SESSION_STARTED, event::AGENT_SESSION_ENDED] {
             let payload = inspect_event(event_name).unwrap();
-            assert_eq!(payload["properties"]["telemetry_schema_version"], 4);
+            assert_eq!(payload["properties"]["telemetry_schema_version"], 3);
             let properties = payload["properties"].as_object().unwrap();
             for forbidden_key in ["session", "session_id", "agent_session_id", "cursor_id"] {
                 assert!(!properties.contains_key(forbidden_key));

--- a/libs/cua-driver/rust/crates/cua-driver/src/telemetry.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/telemetry.rs
@@ -266,11 +266,11 @@ pub fn reset_id() -> Result<(), String> {
 }
 
 fn reset_id_in_homes(home: &Path, legacy: Option<&Path>) -> Result<(), String> {
-    let lifecycle_lock = open_lock_file(&home, TELEMETRY_LIFECYCLE_LOCK_FILE_NAME)?;
+    let lifecycle_lock = open_lock_file(home, TELEMETRY_LIFECYCLE_LOCK_FILE_NAME)?;
     lifecycle_lock
         .lock()
         .map_err(|error| format!("failed to lock telemetry lifecycle: {error}"))?;
-    let identity_lock = open_lock_file(&home, TELEMETRY_IDENTITY_LOCK_FILE_NAME)?;
+    let identity_lock = open_lock_file(home, TELEMETRY_IDENTITY_LOCK_FILE_NAME)?;
     identity_lock
         .lock()
         .map_err(|error| format!("failed to lock telemetry identity: {error}"))?;
@@ -1805,7 +1805,7 @@ pub(crate) fn capture_cli_completed(
         event::CLI_COMPLETED,
         &bounded_properties(&[
             ("command", Value::String(command.into())),
-            ("tool_name", Value::String(tool_name.into())),
+            ("tool_name", Value::String(tool_name)),
             ("operation", Value::String(operation.into())),
             (
                 "computer_action",
@@ -2253,6 +2253,7 @@ fn open_lock_file(home: &Path, name: &str) -> Result<File, String> {
         .read(true)
         .write(true)
         .create(true)
+        .truncate(false)
         .open(home.join(name))
         .map_err(|error| format!("failed to open telemetry state lock: {error}"))
 }

--- a/libs/cua-driver/rust/crates/cua-driver/src/updater.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/updater.rs
@@ -1,8 +1,8 @@
 //! `cua-driver update --apply` implementation.
 //!
 //! Delegates the actual install work to the canonical installer scripts:
-//! - Unix:    `libs/cua-driver/scripts/install.sh` (delegates to
-//!            `_install-rust.sh` by default)
+//! - Unix: `libs/cua-driver/scripts/install.sh` (delegates to
+//!   `_install-rust.sh` by default)
 //! - Windows: `libs/cua-driver/scripts/install.ps1`
 //!
 //! Why not reimplement the download / atomic-swap / GC in Rust? Those scripts

--- a/libs/cua-driver/rust/crates/cua-driver/tests/cross_platform_behavior_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/cross_platform_behavior_test.rs
@@ -1131,11 +1131,7 @@ fn shared_case(spec: &HostSpec, action: &str, addressing: &str, delivery: &str) 
         Vec::new()
     };
     let expected_background_refusal = !expected_refusals.is_empty();
-    let mut oracles = if expected_background_refusal {
-        vec![OracleKind::FixtureState]
-    } else {
-        vec![OracleKind::FixtureState]
-    };
+    let mut oracles = vec![OracleKind::FixtureState];
     if delivery_kind == Delivery::Background {
         oracles.extend([
             OracleKind::Focus,

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_winui3_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_winui3_test.rs
@@ -6,12 +6,10 @@
 //! shows up in both suites.
 //!
 //! WinUI3-specific surfaces under test:
-//!   - CommandBarFlyout : popup hosted in same HWND, rendered via XAML
-//!                        Islands / DComp. Tests UIA descent into the
-//!                        flyout subtree.
-//!   - XAML Popup       : Popup primitive (NOT a separate HWND).
-//!                        Regression guard that the agent doesn't lose
-//!                        track of in-window flyouts.
+//! - CommandBarFlyout: popup hosted in same HWND, rendered via XAML Islands /
+//!   DComp. Tests UIA descent into the flyout subtree.
+//! - XAML Popup: Popup primitive (NOT a separate HWND). Regression guard that
+//!   the agent doesn't lose track of in-window flyouts.
 //!
 //! Run via:
 //!   ..\tests\runners\windows-sandbox\run-tests-in-sandbox.ps1 harness_winui3

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
@@ -5,15 +5,14 @@
 //! get mapped into the sandbox by the legacy Windows Sandbox runner.
 //!
 //! Each scenario covers a Win32 hosting pattern the agent should handle:
-//!   - counter        : UIA Invoke on a plain WPF button
-//!   - text_body      : get_window_state extracts known marker text
-//!   - message_box    : modal MessageBox enumeration
-//!   - bottom_strip   : Save/Cancel buttons present in the UIA tree
-//!                      (regression guard for the GetClientRect-vs-
-//!                      GetWindowRect capture bug fixed in #1696)
-//!   - owned_popup    : owned secondary window discovered via list_windows
-//!   - layered_popup  : WS_EX_LAYERED window enumerated and captured
-//!   - child_hwnd     : native Win32 BUTTON child HWND visible in tree
+//! - counter: UIA Invoke on a plain WPF button
+//! - text_body: get_window_state extracts known marker text
+//! - message_box: modal MessageBox enumeration
+//! - bottom_strip: Save/Cancel buttons present in the UIA tree (regression
+//!   guard for the GetClientRect-vs-GetWindowRect capture bug fixed in #1696)
+//! - owned_popup: owned secondary window discovered via list_windows
+//! - layered_popup: WS_EX_LAYERED window enumerated and captured
+//! - child_hwnd: native Win32 BUTTON child HWND visible in tree
 //!
 //! Run via the sandbox runner:
 //!   ..\tests\runners\windows-sandbox\run-tests-in-sandbox.ps1 harness_wpf

--- a/libs/cua-driver/rust/crates/cua-driver/tests/protocol_session_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/protocol_session_test.rs
@@ -66,7 +66,7 @@ fn concurrent_clients_with_cursor_moves() {
     }
 
     // Each process moves its cursor to different positions.
-    let positions = vec![(100.0_f64, 200.0_f64), (500.0, 600.0)];
+    let positions = [(100.0_f64, 200.0_f64), (500.0, 600.0)];
     for ((i, d), (px, py)) in drivers.iter_mut().enumerate().zip(positions.iter()) {
         d.send(&serde_json::json!({
             "jsonrpc":"2.0","id":2,"method":"tools/call",

--- a/libs/cua-driver/rust/crates/cua-driver/tests/standalone_browser_behavior_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/standalone_browser_behavior_test.rs
@@ -303,7 +303,7 @@ fn browser_specs() -> Vec<BrowserSpec> {
     #[cfg(target_os = "macos")]
     {
         let home = PathBuf::from(std::env::var_os("HOME").expect("HOME"));
-        return select_browser_products(
+        select_browser_products(
             [
                 (
                     "chrome",
@@ -330,7 +330,7 @@ fn browser_specs() -> Vec<BrowserSpec> {
             })
             .collect(),
             false,
-        );
+        )
     }
     #[cfg(target_os = "linux")]
     {
@@ -658,11 +658,11 @@ fn driver_profile_root() -> PathBuf {
     }
     #[cfg(target_os = "macos")]
     {
-        return PathBuf::from(std::env::var_os("HOME").expect("HOME"))
+        PathBuf::from(std::env::var_os("HOME").expect("HOME"))
             .join("Library")
             .join("Application Support")
             .join("CuaDriver")
-            .join("BrowserProfiles");
+            .join("BrowserProfiles")
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
@@ -2329,7 +2329,7 @@ fn run_multi_tab(spec: &BrowserSpec) {
         // This is setup instrumentation and runs before the background sentinel;
         // the driver action below must still leave the tab selected state and
         // native foreground unchanged.
-        let background_ws = cdp_page_websocket_for_url(fixture.cdp_port, &second_server.page_url());
+        let background_ws = cdp_page_websocket_for_url(fixture.cdp_port, second_server.page_url());
         harness_cdp_call_at_url(
             &background_ws,
             "Emulation.setDeviceMetricsOverride",
@@ -2357,7 +2357,7 @@ fn run_multi_tab(spec: &BrowserSpec) {
         // createTarget(background=true) on every host, but Page.bringToFront
         // reliably selects the fixture tab. No browser action below this
         // setup point may activate a target.
-        bring_harness_page_to_front(fixture.cdp_port, &fixture.server.page_url());
+        bring_harness_page_to_front(fixture.cdp_port, fixture.server.page_url());
 
         // Begin the background proof only after Chromium has honored the
         // explicit selected-tab setup and the first fixture is observably
@@ -2365,9 +2365,9 @@ fn run_multi_tab(spec: &BrowserSpec) {
         let setup_deadline = Instant::now() + Duration::from_secs(5);
         loop {
             let foreground_visibility =
-                harness_page_visibility(fixture.cdp_port, &fixture.server.page_url());
+                harness_page_visibility(fixture.cdp_port, fixture.server.page_url());
             let background_visibility =
-                harness_page_visibility(fixture.cdp_port, &second_server.page_url());
+                harness_page_visibility(fixture.cdp_port, second_server.page_url());
             if foreground_visibility == "visible" && background_visibility == "hidden" {
                 break;
             }
@@ -2698,7 +2698,7 @@ fn run_same_title_tabs(spec: &BrowserSpec) {
             );
             assert!(created["targetId"].is_string(), "{created}");
             wait_for_observed(&second_server, "WEB_HARNESS_MARKER_v1");
-            bring_harness_page_to_front(fixture.cdp_port, &fixture.server.page_url());
+            bring_harness_page_to_front(fixture.cdp_port, fixture.server.page_url());
 
             run_with_background_oracles(&mut fixture, |fixture| {
                 let deadline = Instant::now() + Duration::from_secs(5);

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/palette.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/palette.rs
@@ -163,7 +163,7 @@ fn lerp_rgba(a: [u8; 4], b: [u8; 4], t: f64) -> [u8; 4] {
 
 fn stable_index(id: &str, count: usize) -> usize {
     let suffix = id
-        .rfind(|c| c == '-' || c == '_' || c == '.')
+        .rfind(['-', '_', '.'])
         .map(|i| &id[i + 1..])
         .unwrap_or(id);
     if let Ok(n) = suffix.parse::<usize>() {

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/path_planner.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/path_planner.rs
@@ -141,6 +141,8 @@ impl PathPlanner {
     ///
     /// * `end_visual_heading` — the arrow heading at rest (for the rendered tip).
     /// * `turn_radius` — minimum turning radius in points (Swift default: 80).
+    // The flattened start/end poses are part of the cross-language overlay API.
+    #[allow(clippy::too_many_arguments)]
     pub fn plan(
         x0: f64,
         y0: f64,
@@ -291,6 +293,9 @@ fn dubins_lrl(d: f64, a: f64, b: f64) -> Option<DubinsSol> {
     })
 }
 
+// Keep this helper's arguments aligned with `PathPlanner::plan` so the fallback
+// and Dubins routes cannot accidentally swap pose components.
+#[allow(clippy::too_many_arguments)]
 fn plan_dubins(
     x0: f64,
     y0: f64,
@@ -312,7 +317,8 @@ fn plan_dubins(
     let a = mod2pi(th0 - theta);
     let b = mod2pi(th1 - theta);
 
-    let solvers: [fn(f64, f64, f64) -> Option<DubinsSol>; 6] = [
+    type DubinsSolver = fn(f64, f64, f64) -> Option<DubinsSol>;
+    let solvers: [DubinsSolver; 6] = [
         dubins_lsl, dubins_rsr, dubins_lsr, dubins_rsl, dubins_rlr, dubins_lrl,
     ];
 

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
@@ -602,9 +602,8 @@ pub fn paint_cursor(
     let bloom_outer = tiny_skia::Color::from_rgba8(or_, og, ob, (26.0 * alpha_scale) as u8);
     let bloom_zero = tiny_skia::Color::from_rgba8(or_, og, ob, 0);
 
-    let bloom_paint = {
-        let mut p = tiny_skia::Paint::default();
-        p.shader = tiny_skia::RadialGradient::new(
+    let bloom_paint = tiny_skia::Paint {
+        shader: tiny_skia::RadialGradient::new(
             tiny_skia::Point::from_xy(px as f32, py as f32),
             tiny_skia::Point::from_xy(px as f32, py as f32), // focal = center
             bloom_r,
@@ -616,9 +615,9 @@ pub fn paint_cursor(
             tiny_skia::SpreadMode::Pad,
             tiny_skia::Transform::identity(),
         )
-        .unwrap_or(tiny_skia::Shader::SolidColor(bloom_inner));
-        p.anti_alias = true;
-        p
+        .unwrap_or(tiny_skia::Shader::SolidColor(bloom_inner)),
+        anti_alias: true,
+        ..Default::default()
     };
 
     if let Some(r) = tiny_skia::Rect::from_xywh(
@@ -633,17 +632,21 @@ pub fn paint_cursor(
     if core.pressed {
         let [pr, pg, pb, _] = core.palette.cursor_mid;
         let ring_color = tiny_skia::Color::from_rgba8(pr, pg, pb, (210.0 * alpha_scale) as u8);
-        let mut ring_paint = tiny_skia::Paint::default();
-        ring_paint.shader = tiny_skia::Shader::SolidColor(ring_color);
-        ring_paint.anti_alias = true;
+        let ring_paint = tiny_skia::Paint {
+            shader: tiny_skia::Shader::SolidColor(ring_color),
+            anti_alias: true,
+            ..Default::default()
+        };
         let stroke = tiny_skia::Stroke {
             width: 3.0 * sf,
             ..Default::default()
         };
         let core_fill = tiny_skia::Color::from_rgba8(pr, pg, pb, (110.0 * alpha_scale) as u8);
-        let mut fill_paint = tiny_skia::Paint::default();
-        fill_paint.shader = tiny_skia::Shader::SolidColor(core_fill);
-        fill_paint.anti_alias = true;
+        let fill_paint = tiny_skia::Paint {
+            shader: tiny_skia::Shader::SolidColor(core_fill),
+            anti_alias: true,
+            ..Default::default()
+        };
         let mut pb = tiny_skia::PathBuilder::new();
         pb.push_circle(px as f32, py as f32, 6.5 * sf);
         if let Some(path) = pb.finish() {
@@ -686,16 +689,22 @@ pub fn paint_cursor(
             (fh * s) as f32,
         ) {
             // Faint fill
-            let mut fill_paint = tiny_skia::Paint::default();
-            fill_paint.shader =
-                tiny_skia::Shader::SolidColor(tiny_skia::Color::from_rgba8(cr, cg, cb, fill_a));
+            let fill_paint = tiny_skia::Paint {
+                shader: tiny_skia::Shader::SolidColor(tiny_skia::Color::from_rgba8(
+                    cr, cg, cb, fill_a,
+                )),
+                ..Default::default()
+            };
             pm.fill_rect(rect, &fill_paint, tiny_skia::Transform::identity(), None);
 
             // Border stroke (2px glow)
-            let mut border_paint = tiny_skia::Paint::default();
-            border_paint.shader =
-                tiny_skia::Shader::SolidColor(tiny_skia::Color::from_rgba8(cr, cg, cb, border_a));
-            border_paint.anti_alias = true;
+            let border_paint = tiny_skia::Paint {
+                shader: tiny_skia::Shader::SolidColor(tiny_skia::Color::from_rgba8(
+                    cr, cg, cb, border_a,
+                )),
+                anti_alias: true,
+                ..Default::default()
+            };
             let stroke = tiny_skia::Stroke {
                 width: 2.5 * sf,
                 ..Default::default()
@@ -722,9 +731,11 @@ pub fn paint_cursor(
         let alpha = ((1.0 - t) * 180.0 * alpha_scale as f64) as u8;
         let [cr, cg, cb, _] = core.palette.cursor_mid;
         let ring_color = tiny_skia::Color::from_rgba8(cr, cg, cb, alpha);
-        let mut ring_paint = tiny_skia::Paint::default();
-        ring_paint.shader = tiny_skia::Shader::SolidColor(ring_color);
-        ring_paint.anti_alias = true;
+        let ring_paint = tiny_skia::Paint {
+            shader: tiny_skia::Shader::SolidColor(ring_color),
+            anti_alias: true,
+            ..Default::default()
+        };
         let stroke = tiny_skia::Stroke {
             width: 2.0 * sf,
             ..Default::default()
@@ -810,8 +821,10 @@ pub fn paint_cursor(
         .post_scale(scale, scale)
         .post_rotate(rotation_deg)
         .post_translate(px as f32, py as f32);
-        let mut paint = tiny_skia::PixmapPaint::default();
-        paint.opacity = alpha_scale;
+        let paint = tiny_skia::PixmapPaint {
+            opacity: alpha_scale,
+            ..Default::default()
+        };
         pm.draw_pixmap(0, 0, pix, &paint, transform, None);
     }
 }
@@ -879,9 +892,8 @@ pub fn draw_default_arrow(
     };
 
     let a = (255.0 * alpha_scale) as u8;
-    let fill_paint = {
-        let mut p = tiny_skia::Paint::default();
-        p.shader = tiny_skia::LinearGradient::new(
+    let fill_paint = tiny_skia::Paint {
+        shader: tiny_skia::LinearGradient::new(
             tiny_skia::Point::from_xy(tip.0, tip.1),
             tiny_skia::Point::from_xy(tail.0, tail.1),
             vec![
@@ -894,9 +906,9 @@ pub fn draw_default_arrow(
         )
         .unwrap_or(tiny_skia::Shader::SolidColor(tiny_skia::Color::from_rgba8(
             r1, g1, b1, a,
-        )));
-        p.anti_alias = true;
-        p
+        ))),
+        anti_alias: true,
+        ..Default::default()
     };
 
     pm.fill_path(
@@ -908,10 +920,11 @@ pub fn draw_default_arrow(
     );
 
     // White outline (faded with alpha_scale).
-    let mut stroke_paint = tiny_skia::Paint::default();
-    stroke_paint.shader =
-        tiny_skia::Shader::SolidColor(tiny_skia::Color::from_rgba8(255, 255, 255, a));
-    stroke_paint.anti_alias = true;
+    let stroke_paint = tiny_skia::Paint {
+        shader: tiny_skia::Shader::SolidColor(tiny_skia::Color::from_rgba8(255, 255, 255, a)),
+        anti_alias: true,
+        ..Default::default()
+    };
     let stroke = tiny_skia::Stroke {
         width: 1.5,
         ..Default::default()

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/shape.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/shape.rs
@@ -12,7 +12,7 @@ use anyhow::{bail, Result};
 ///
 /// `Teardrop` is the default; opt back into the procedural arrow with
 /// `--cursor-shape arrow` (CLI) or `cursor_icon: "arrow"` (MCP).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum BuiltinShape {
     /// Procedural gradient diamond drawn from vector primitives — the
     /// original cua cursor. Sharp at any backing scale because nothing is
@@ -20,6 +20,7 @@ pub enum BuiltinShape {
     Arrow,
     /// Embedded `cursor-up` SVG (teardrop with notched bottom). Rasterised
     /// once into a 52 px RGBA buffer and blitted with a runtime transform.
+    #[default]
     Teardrop,
 }
 
@@ -58,12 +59,6 @@ impl BuiltinShape {
             .map(|n| format!("'{n}'"))
             .collect::<Vec<_>>()
             .join(" | ")
-    }
-}
-
-impl Default for BuiltinShape {
-    fn default() -> Self {
-        Self::Teardrop
     }
 }
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/apps/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/apps/mod.rs
@@ -362,7 +362,7 @@ pub fn list_all_apps() -> Vec<AppInfo> {
     installed.retain(|a| {
         !a.bundle_id
             .as_ref()
-            .map_or(false, |b| running_bundles.contains(b))
+            .is_some_and(|b| running_bundles.contains(b))
     });
 
     let mut all = running;

--- a/libs/cua-driver/rust/crates/platform-macos/src/apps/nsworkspace.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/apps/nsworkspace.rs
@@ -114,6 +114,9 @@ pub fn open_application(
     let config = build_configuration(cfg);
 
     let (tx, rx) = std::sync::mpsc::sync_channel::<CompletionResult>(1);
+    // NSWorkspace may invoke its completion on another thread; retain atomic
+    // callback ownership even though objc2 does not mark the retained app Send.
+    #[allow(clippy::arc_with_non_send_sync)]
     let tx = Arc::new(std::sync::Mutex::new(Some(tx)));
 
     let block = make_completion_block(tx);
@@ -152,6 +155,9 @@ pub fn open_urls_with_application(
     let ns_array = NSArray::from_vec(ns_urls);
 
     let (tx, rx) = std::sync::mpsc::sync_channel::<CompletionResult>(1);
+    // NSWorkspace may invoke its completion on another thread; retain atomic
+    // callback ownership even though objc2 does not mark the retained app Send.
+    #[allow(clippy::arc_with_non_send_sync)]
     let tx = Arc::new(std::sync::Mutex::new(Some(tx)));
 
     let block = make_completion_block(tx);
@@ -307,7 +313,7 @@ fn make_completion_block(
                 }
             };
             // Take the sender out so the channel closes after one send.
-            let sender = tx.lock().ok().and_then(|mut g| g.take());
+            let sender = tx.lock().ok().and_then(|mut guard| guard.take());
             if let Some(s) = sender {
                 let _ = s.send(result);
             }

--- a/libs/cua-driver/rust/crates/platform-macos/src/ax/bindings.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/ax/bindings.rs
@@ -93,6 +93,10 @@ extern "C" {
 
 /// Hit-test one process's accessibility tree at a screen point. The returned
 /// element is retained and must be released by the caller.
+///
+/// # Safety
+///
+/// The caller must release any returned element exactly once with `CFRelease`.
 pub unsafe fn element_at_screen_position(pid: i32, x: f64, y: f64) -> Option<AXUIElementRef> {
     let application = AXUIElementCreateApplication(pid);
     if application.is_null() {
@@ -120,6 +124,10 @@ extern "C" {
 use core_foundation::{array::CFArray, base::TCFType, string::CFString as CFStr};
 
 /// Copy a string attribute from an AX element. Returns `None` on any error.
+///
+/// # Safety
+///
+/// `element` must be a valid, live `AXUIElementRef` for the duration of the call.
 pub unsafe fn copy_string_attr(element: AXUIElementRef, attr_name: &str) -> Option<String> {
     let attr = CFStr::new(attr_name);
     let mut value: CFTypeRef = std::ptr::null();
@@ -140,6 +148,10 @@ pub unsafe fn copy_string_attr(element: AXUIElementRef, attr_name: &str) -> Opti
 /// any error or if the attribute is not a `CFNumber`. SwiftUI sliders expose a
 /// readable numeric `AXValue` even when that value is not settable — this lets
 /// the stepping fallback read the control's current position for feedback.
+///
+/// # Safety
+///
+/// `element` must be a valid, live `AXUIElementRef` for the duration of the call.
 pub unsafe fn copy_number_attr(element: AXUIElementRef, attr_name: &str) -> Option<f64> {
     use core_foundation::number::CFNumber;
     let attr = CFStr::new(attr_name);
@@ -158,6 +170,10 @@ pub unsafe fn copy_number_attr(element: AXUIElementRef, attr_name: &str) -> Opti
 }
 
 /// Get the action names for an AX element.
+///
+/// # Safety
+///
+/// `element` must be a valid, live `AXUIElementRef` for the duration of the call.
 pub unsafe fn copy_action_names(element: AXUIElementRef) -> Vec<String> {
     let mut names: CFArrayRef = std::ptr::null_mut();
     let err = AXUIElementCopyActionNames(element, &mut names);
@@ -177,6 +193,10 @@ pub unsafe fn copy_action_names(element: AXUIElementRef) -> Vec<String> {
 /// Read the on-screen center of an AX element (AXPosition + AXSize → center).
 /// Returns `(cx, cy)` in screen coordinates, or `None` if either attribute
 /// is unavailable or the element has zero size.
+///
+/// # Safety
+///
+/// `element` must be a valid, live `AXUIElementRef` for the duration of the call.
 pub unsafe fn element_screen_center(element: AXUIElementRef) -> Option<(f64, f64)> {
     // AXPosition → CGPoint
     let pos_attr = CFStr::new("AXPosition");
@@ -229,6 +249,10 @@ pub unsafe fn element_screen_center(element: AXUIElementRef) -> Option<(f64, f64
 
 /// Read the on-screen bounding rect of an AX element.
 /// Returns `[x, y, width, height]` in screen coordinates (top-left origin), or `None`.
+///
+/// # Safety
+///
+/// `element` must be a valid, live `AXUIElementRef` for the duration of the call.
 pub unsafe fn element_screen_rect(element: AXUIElementRef) -> Option<[f64; 4]> {
     // AXPosition → CGPoint
     let pos_attr = CFStr::new("AXPosition");
@@ -281,6 +305,10 @@ pub unsafe fn element_screen_rect(element: AXUIElementRef) -> Option<[f64; 4]> {
 
 /// Get the focused UI element of a running application by pid.
 /// Returns a retained `AXUIElementRef` that the caller must release, or `None`.
+///
+/// # Safety
+///
+/// The caller must release any returned element exactly once with `CFRelease`.
 pub unsafe fn focused_element_of_pid(pid: i32) -> Option<AXUIElementRef> {
     let app = AXUIElementCreateApplication(pid);
     if app.is_null() {
@@ -303,6 +331,10 @@ pub unsafe fn focused_element_of_pid(pid: i32) -> Option<AXUIElementRef> {
 }
 
 /// Get the children of an AX element.
+///
+/// # Safety
+///
+/// `element` must be valid, and the caller must release every returned element.
 pub unsafe fn copy_children(element: AXUIElementRef) -> Vec<AXUIElementRef> {
     let attr = CFStr::new("AXChildren");
     let mut value: CFTypeRef = std::ptr::null();
@@ -333,6 +365,10 @@ pub unsafe fn copy_children(element: AXUIElementRef) -> Vec<AXUIElementRef> {
 
 /// Copy an AX element-valued attribute. The returned element is retained and
 /// must be released by the caller.
+///
+/// # Safety
+///
+/// `element` must be valid, and the caller must release any returned element.
 pub unsafe fn copy_element_attr(
     element: AXUIElementRef,
     attr_name: &str,
@@ -351,12 +387,20 @@ pub unsafe fn copy_element_attr(
 }
 
 /// Perform an AX action using a string attribute name.
+///
+/// # Safety
+///
+/// `element` must be a valid, live `AXUIElementRef` for the duration of the call.
 pub unsafe fn perform_action(element: AXUIElementRef, action_name: &str) -> AXError {
     let action = CFStr::new(action_name);
     AXUIElementPerformAction(element, action.as_concrete_TypeRef())
 }
 
 /// Set an AX attribute to a CFString value.
+///
+/// # Safety
+///
+/// `element` must be a valid, live `AXUIElementRef` for the duration of the call.
 pub unsafe fn set_string_attr(element: AXUIElementRef, attr_name: &str, value: &str) -> AXError {
     let attr = CFStr::new(attr_name);
     let cf_value = CFStr::new(value);
@@ -368,6 +412,10 @@ pub unsafe fn set_string_attr(element: AXUIElementRef, attr_name: &str, value: &
 /// reject a `CFString` write — `-25200` (kAXErrorFailure, observed live on a
 /// SwiftUI `AXSlider`) or `-25201` (kAXErrorIllegalArgument); only a `CFNumber`
 /// is accepted. Text fields, by contrast, take a `CFString`.
+///
+/// # Safety
+///
+/// `element` must be a valid, live `AXUIElementRef` for the duration of the call.
 pub unsafe fn set_number_attr(element: AXUIElementRef, attr_name: &str, value: f64) -> AXError {
     use core_foundation::number::CFNumber;
     let attr = CFStr::new(attr_name);
@@ -376,6 +424,10 @@ pub unsafe fn set_number_attr(element: AXUIElementRef, attr_name: &str, value: f
 }
 
 /// Set an AX attribute to a CFBoolean true value.
+///
+/// # Safety
+///
+/// `element` must be a valid, live `AXUIElementRef` for the duration of the call.
 pub unsafe fn set_bool_attr_true(element: AXUIElementRef, attr_name: &str) -> AXError {
     use core_foundation::boolean::CFBoolean;
     let attr = CFStr::new(attr_name);
@@ -396,6 +448,10 @@ pub unsafe fn set_bool_attr_true(element: AXUIElementRef, attr_name: &str) -> AX
 /// effects; `AXEnhancedUserInterface` is the legacy fallback some Electron
 /// builds expose instead (the modern attribute returns
 /// `kAXErrorAttributeUnsupported` on those builds).
+///
+/// # Safety
+///
+/// `app_element` must be a valid, live application `AXUIElementRef`.
 pub unsafe fn enable_chromium_accessibility(app_element: AXUIElementRef) -> bool {
     let manual = set_bool_attr_true(app_element, "AXManualAccessibility");
     if manual == kAXErrorSuccess {
@@ -412,6 +468,10 @@ pub unsafe fn enable_chromium_accessibility(app_element: AXUIElementRef) -> bool
 
 /// Get the CGWindowID of an AX window element via the private `_AXUIElementGetWindow` SPI.
 /// Returns `None` if the element is not a composited window.
+///
+/// # Safety
+///
+/// `element` must be a valid, live window `AXUIElementRef`.
 pub unsafe fn ax_get_window_id(element: AXUIElementRef) -> Option<u32> {
     let mut wid: u32 = 0;
     let err = _AXUIElementGetWindow(element, &mut wid);
@@ -425,6 +485,10 @@ pub unsafe fn ax_get_window_id(element: AXUIElementRef) -> Option<u32> {
 /// Read the `AXWindows` attribute of an application element.
 /// Unlike `AXChildren`, this returns the window list regardless of whether
 /// the app is frontmost. Returns a Vec of retained AXUIElementRefs.
+///
+/// # Safety
+///
+/// `element` must be valid, and the caller must release every returned element.
 pub unsafe fn copy_ax_windows(element: AXUIElementRef) -> Vec<AXUIElementRef> {
     let attr = CFStr::new("AXWindows");
     let mut value: CFTypeRef = std::ptr::null();

--- a/libs/cua-driver/rust/crates/platform-macos/src/ax/tree.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/ax/tree.rs
@@ -216,7 +216,7 @@ pub fn walk_tree_bounded(
                 })
                 .collect()
         } else {
-            top_level.iter().copied().collect()
+            top_level.to_vec()
         };
 
         // Walk each top-level child at depth 0.
@@ -535,8 +535,8 @@ fn filter_tree(markdown: &str, query: &str) -> String {
             current_ancestor.push("");
             last_emitted_at.push(None);
         }
-        for deeper in (depth + 1)..current_ancestor.len() {
-            last_emitted_at[deeper] = None;
+        for emitted_at in last_emitted_at.iter_mut().skip(depth + 1) {
+            *emitted_at = None;
         }
         current_ancestor[depth] = line;
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/browser/browser_js.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/browser/browser_js.rs
@@ -134,7 +134,7 @@ fn native_window_target(window_id: u32) -> anyhow::Result<NativeWindowTarget> {
         .iter()
         .filter(|window| window.pid == target.pid && same_bounds(&window.bounds, &target.bounds))
         .collect::<Vec<_>>();
-    same_bounds.sort_by(|a, b| b.z_index.cmp(&a.z_index));
+    same_bounds.sort_by_key(|window| std::cmp::Reverse(window.z_index));
     let same_bounds_ordinal = same_bounds
         .iter()
         .position(|window| window.window_id == target.window_id)

--- a/libs/cua-driver/rust/crates/platform-macos/src/browser/consent_ui.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/browser/consent_ui.rs
@@ -58,7 +58,7 @@ fn consent_surface_ids(
                 && window.bounds.height > 0.0
         })
         .collect::<Vec<_>>();
-    windows.sort_by(|left, right| right.z_index.cmp(&left.z_index));
+    windows.sort_by_key(|window| std::cmp::Reverse(window.z_index));
     let mut seen = HashSet::new();
     iter::once(approved_window_id)
         .chain(windows.into_iter().map(|window| window.window_id))

--- a/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
@@ -310,10 +310,10 @@ pub async fn animate_cursor_to(key: CursorKey, x: f64, y: f64) {
     // never animates; an absent cursor (seed found nothing to prime) is skipped.
     let should_animate = {
         let guard = RENDER.lock().unwrap();
-        match guard.as_ref().and_then(|m| m.cursors.get(&key)) {
-            Some(rs) if rs.core.cfg.enabled && rs.core.pos.0 > -50.0 => true,
-            _ => false,
-        }
+        matches!(
+            guard.as_ref().and_then(|m| m.cursors.get(&key)),
+            Some(rs) if rs.core.cfg.enabled && rs.core.pos.0 > -50.0
+        )
     };
     if !should_animate {
         return;
@@ -510,13 +510,13 @@ unsafe fn run_appkit(_cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
     // the AppKit call returns a non-positive value, since downstream paint
     // math divides by this and a 0.0 would zero out the cursor.
     let mut backing_scale: f64 = msg_send![main_screen, backingScaleFactor];
-    if !(backing_scale > 0.0) {
+    if backing_scale.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
         use core_graphics::display::{CGDisplayBounds, CGMainDisplayID};
         let display_id = CGMainDisplayID();
         let bounds = CGDisplayBounds(display_id);
         backing_scale =
             crate::tools::get_screen_size::get_backing_scale(display_id, bounds.size.width as i64);
-        if !(backing_scale > 0.0) {
+        if backing_scale.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
             backing_scale = 1.0;
         }
     }
@@ -566,7 +566,7 @@ unsafe fn run_appkit(_cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
     let _: () = msg_send![layer, setContentsScale: backing_scale];
     // kCAGravityTopLeft — the string literal "topLeft"
     let gravity_ns: *mut AnyObject = msg_send![class!(NSString),
-        stringWithUTF8String: b"topLeft\0".as_ptr()
+        stringWithUTF8String: c"topLeft".as_ptr().cast::<u8>()
     ];
     let _: () = msg_send![layer, setContentsGravity: gravity_ns];
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/input/mouse.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/mouse.rs
@@ -154,6 +154,8 @@ extern "C" {
 /// Like `click_at_xy` but also stamps window-local `(wx, wy)` onto the event.
 /// When `wid` is provided, additionally stamps Chromium routing fields
 /// (f51 / f58 / f91 / f92) for better backgrounded-target delivery.
+// The flattened arguments mirror the native event fields used by existing callers.
+#[allow(clippy::too_many_arguments)]
 pub fn click_at_xy_with_window_local(
     pid: i32,
     x: f64,
@@ -279,6 +281,8 @@ fn click_at_xy_inner(
 ///
 /// Uses both SkyLight `SLEventPostToPid` AND `CGEvent::post_to_pid` (belt+suspenders)
 /// for AppKit / Catalyst target coverage.
+// The flattened arguments mirror the native event fields used by existing callers.
+#[allow(clippy::too_many_arguments)]
 pub fn click_at_xy_chromium(
     pid: i32,
     screen_x: f64,
@@ -298,7 +302,7 @@ pub fn click_at_xy_chromium(
     let win_local = (win_local_x, win_local_y);
     let off_local = (-1.0_f64, -1.0_f64);
     let flags = parse_modifier_flags(modifiers);
-    let click_pairs = count.max(1).min(2);
+    let click_pairs = count.clamp(1, 2);
     let window_id = wid as i64;
 
     // All 5 events share the same click-group ID so WindowServer / Chromium
@@ -421,6 +425,8 @@ pub fn click_at_xy_chromium(
 ///
 /// Like the Swift reference `MouseInput.drag`, uses the SkyLight path for
 /// backgrounded-target delivery.
+// The drag primitive deliberately exposes its complete native event contract.
+#[allow(clippy::too_many_arguments)]
 pub fn drag_at_xy(
     pid: i32,
     from_x: f64,
@@ -555,6 +561,8 @@ pub fn drag_at_xy(
 /// pointer capture and drag tracking. PID-routed `post_to_pid` events are
 /// suitable for background delivery, but they can be silently filtered by the
 /// renderer even when the target is frontmost.
+// The drag primitive deliberately exposes its complete native event contract.
+#[allow(clippy::too_many_arguments)]
 pub fn drag_at_xy_foreground(
     from_x: f64,
     from_y: f64,
@@ -824,6 +832,7 @@ fn right_click_at_xy_inner(
 /// - Fires `SLEventPostToPid` (SkyLight path — reaches backgrounded Chromium/Catalyst).
 /// - Also fires `CGEvent::post_to_pid` (public path — lands on AppKit targets where
 ///   SkyLight mouse delivery drops).
+///
 /// Both are always posted in sequence regardless of whether the other succeeded.
 ///
 /// Field stamps applied (always):
@@ -842,6 +851,8 @@ fn right_click_at_xy_inner(
 /// `button_number` MUST match the button encoded in the event type (right-down
 /// stamped with f3=0 routes as a left-click on the receiving side — this was the
 /// right-click-lands-as-nothing bug). Left=0, Right=1, Middle=2.
+// These arguments are the individual CGEvent fields stamped by this low-level primitive.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn post_mouse_event(
     pid: i32,
     event: &CGEvent,
@@ -945,6 +956,8 @@ fn post_mouse_moved_primer(
 /// `window_local`/`wid`: when known, stamp the window-local point and the
 /// Chromium window-routing fields (f51/f91/f92) for backgrounded delivery —
 /// identical in spirit to `post_mouse_event`.
+// These arguments are the individual wheel-event fields used by existing callers.
+#[allow(clippy::too_many_arguments)]
 pub fn scroll_wheel_at_xy(
     pid: i32,
     screen_x: f64,

--- a/libs/cua-driver/rust/crates/platform-macos/src/input/skylight.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/skylight.rs
@@ -261,7 +261,7 @@ unsafe fn extract_event_record(event_ptr: *mut c_void) -> *mut c_void {
 ///
 /// Returns `true` when `SLEventPostToPid` resolved and the post was attempted.
 /// Returns `false` when the SPI is absent — caller falls back to `CGEvent::post_to_pid`.
-pub fn post_to_pid(pid: pid_t, event_ptr: *mut c_void, attach_auth_message: bool) -> bool {
+pub(super) fn post_to_pid(pid: pid_t, event_ptr: *mut c_void, attach_auth_message: bool) -> bool {
     let post_fn = match post_to_pid_fn() {
         Some(f) => f,
         None => return false,
@@ -302,7 +302,7 @@ pub fn post_to_pid(pid: pid_t, event_ptr: *mut c_void, attach_auth_message: bool
 
 /// Stamp a window-local `(x, y)` point onto `event_ptr` via the private
 /// `CGEventSetWindowLocation` SPI. Returns `true` when the SPI resolved.
-pub fn set_window_location(event_ptr: *mut c_void, x: f64, y: f64) -> bool {
+pub(super) fn set_window_location(event_ptr: *mut c_void, x: f64, y: f64) -> bool {
     match set_window_loc_fn() {
         Some(f) => {
             unsafe { f(event_ptr, x, y) };
@@ -314,7 +314,7 @@ pub fn set_window_location(event_ptr: *mut c_void, x: f64, y: f64) -> bool {
 
 /// Stamp `value` onto `event_ptr` at raw SkyLight field index `field` via
 /// `SLEventSetIntegerValueField`. Returns `false` when SPI absent.
-pub fn set_integer_field(event_ptr: *mut c_void, field: u32, value: i64) -> bool {
+pub(super) fn set_integer_field(event_ptr: *mut c_void, field: u32, value: i64) -> bool {
     match set_int_field_fn() {
         Some(f) => {
             unsafe { f(event_ptr, field, value) };

--- a/libs/cua-driver/rust/crates/platform-macos/src/permissions/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/permissions/mod.rs
@@ -1,20 +1,20 @@
 //! macOS TCC permission checks + first-launch CLI gate.
 //!
 //! Two layers:
-//!   - [`status`] — low-level booleans for Accessibility / Screen Recording.
-//!   - [`gate`]   — startup-time interactive flow that walks the user through
-//!                  granting the missing permissions before `serve` binds.
+//! - [`status`] — low-level booleans for Accessibility / Screen Recording.
+//! - [`gate`]   — startup-time interactive flow that walks the user through
+//!   granting the missing permissions before `serve` binds.
 //!
 //! The gate is a Rust port of Swift's `PermissionsGate` (SwiftUI panel).
 //! Two presentation surfaces:
-//!   - native NSPanel (`panel`, Phase 1+) — used when the daemon is launched
-//!     from the bundled `.app` and the env-var opt-out is not set;
-//!   - terminal banner (`gate::wait_for_grants`) — fallback for bare-binary
-//!     invocations, headless environments, CI, and explicit opt-outs.
+//! - native NSPanel (`panel`, Phase 1+) — used when the daemon is launched
+//!   from the bundled `.app` and the env-var opt-out is not set;
+//! - terminal banner (`gate::wait_for_grants`) — fallback for bare-binary
+//!   invocations, headless environments, CI, and explicit opt-outs.
 //!
 //! Mirrors `libs/cua-driver/Sources/CuaDriverCore/Permissions/`:
-//!   - `Permissions.swift`      → `permissions::status`
-//!   - `PermissionsGate.swift`  → `permissions::gate` + `permissions::panel`
+//! - `Permissions.swift`      → `permissions::status`
+//! - `PermissionsGate.swift`  → `permissions::gate` + `permissions::panel`
 
 pub mod gate;
 pub mod status;

--- a/libs/cua-driver/rust/crates/platform-macos/src/terminal.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/terminal.rs
@@ -39,7 +39,7 @@ pub const TERMINAL_BUNDLE_IDS: &[&str] = &[
 /// from [`TERMINAL_BUNDLE_IDS`]. Case-sensitive, exact match — bundle
 /// ids are reverse-DNS and case-significant per Apple's convention.
 pub fn is_terminal_bundle_id(bundle_id: &str) -> bool {
-    TERMINAL_BUNDLE_IDS.iter().any(|b| *b == bundle_id)
+    TERMINAL_BUNDLE_IDS.contains(&bundle_id)
 }
 
 /// Returns `true` when `pid` belongs to a known terminal emulator.

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/get_desktop_state.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/get_desktop_state.rs
@@ -63,9 +63,9 @@ impl Tool for GetDesktopStateTool {
         };
         let screenshot_out_file = input.screenshot_out_file.map(|s| {
             // Expand ~ prefix (mirrors get_window_state).
-            if s.starts_with("~/") {
+            if let Some(relative) = s.strip_prefix("~/") {
                 let home = std::env::var("HOME").unwrap_or_default();
-                format!("{home}/{}", &s[2..])
+                format!("{home}/{relative}")
             } else {
                 s
             }

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/get_window_state.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/get_window_state.rs
@@ -111,9 +111,9 @@ impl Tool for GetWindowStateTool {
         let query = args.opt_str("query");
         let screenshot_out_file = args.opt_str("screenshot_out_file").map(|s| {
             // Expand ~ prefix.
-            if s.starts_with("~/") {
+            if let Some(relative) = s.strip_prefix("~/") {
                 let home = std::env::var("HOME").unwrap_or_default();
-                format!("{home}/{}", &s[2..])
+                format!("{home}/{relative}")
             } else {
                 s
             }

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/health_report.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/health_report.rs
@@ -126,11 +126,10 @@ pub(crate) fn check_bundle_identity() -> CheckEntry {
     let (message, hint) = match bid.as_deref() {
         None | Some("") => (
             "Process has no CFBundleIdentifier.".to_owned(),
-            format!(
-                "Run the binary inside CuaDriver.app so TCC grants attribute correctly. \
-                 Start the daemon with `open -n -g -a CuaDriver --args serve` and \
-                 connect via `cua-driver mcp`."
-            ),
+            "Run the binary inside CuaDriver.app so TCC grants attribute correctly. \
+             Start the daemon with `open -n -g -a CuaDriver --args serve` and \
+             connect via `cua-driver mcp`."
+                .to_owned(),
         ),
         Some(other) => (
             format!("Bundle is {other}, not {CANONICAL_BUNDLE_ID}."),

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
@@ -184,6 +184,12 @@ pub struct ZoomRegistry {
     inner: std::sync::Mutex<HashMap<i32, ZoomContext>>,
 }
 
+impl Default for ZoomRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ZoomRegistry {
     pub fn new() -> Self {
         Self {
@@ -207,6 +213,12 @@ impl ZoomRegistry {
 /// Mirrors Swift's `ImageResizeRegistry`.
 pub struct ResizeRegistry {
     inner: std::sync::Mutex<HashMap<i32, f64>>,
+}
+
+impl Default for ResizeRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ResizeRegistry {

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/page.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/page.rs
@@ -157,7 +157,7 @@ impl PageBackend for MacOsPageBackend {
         let cursor_key = "default".to_owned();
         crate::cursor::overlay::send_command(
             cursor_key.clone(),
-            cursor_overlay::OverlayCommand::PinAbove(window_id as u64),
+            cursor_overlay::OverlayCommand::PinAbove(window_id),
         );
         crate::cursor::overlay::animate_cursor_to(cursor_key.clone(), screen_x, screen_y).await;
         self.state

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/scroll.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/scroll.rs
@@ -555,12 +555,10 @@ impl Tool for ScrollTool {
 
                 tokio::task::spawn_blocking(move || {
                     for _ in 0..amount {
-                        if let Err(e) = crate::input::keyboard::press_key(pid, &key, &[]) {
-                            return Err(e);
-                        }
+                        crate::input::keyboard::press_key(pid, &key, &[])?;
                         std::thread::sleep(std::time::Duration::from_millis(50));
                     }
-                    Ok(())
+                    Ok::<(), anyhow::Error>(())
                 })
                 .await
             },

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/set_value.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/set_value.rs
@@ -452,14 +452,12 @@ fn set_select_via_js(
 
     let raw = String::from_utf8_lossy(&out.stdout).trim().to_string();
 
-    if raw.starts_with("SET:") {
-        let dom_val = &raw[4..];
+    if let Some(dom_val) = raw.strip_prefix("SET:") {
         Ok(format!(
             "✅ Set select [{element_index}] '{element_title}' to '{value}' via \
              Safari JavaScript (DOM value: \"{dom_val}\")."
         ))
-    } else if raw.starts_with("NOTFOUND:") {
-        let available = &raw[9..];
+    } else if let Some(available) = raw.strip_prefix("NOTFOUND:") {
         anyhow::bail!(
             "No <option> matching '{value}' found in any <select>. \
              Available (text|value): {available}"

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/type_text.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/type_text.rs
@@ -450,7 +450,7 @@ fn verify_typed(before: Option<&str>, after: Option<&str>, text: &str) -> bool {
         return true;
     }
     let Some(after) = after else { return false };
-    after.contains(text) || before.map_or(false, |b| after.chars().count() > b.chars().count())
+    after.contains(text) || before.is_some_and(|b| after.chars().count() > b.chars().count())
 }
 
 /// Read the focused/target field's `AXValue`, for before/after read-back.

--- a/libs/cua-driver/rust/crates/platform-macos/src/windows.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/windows.rs
@@ -250,7 +250,7 @@ pub fn resolve_main_window_id(pid: i32) -> anyhow::Result<u32> {
     }
     let mut on_screen: Vec<&&WindowInfo> = pid_windows.iter().filter(|w| w.is_on_screen).collect();
     if !on_screen.is_empty() {
-        on_screen.sort_by(|a, b| b.z_index.cmp(&a.z_index));
+        on_screen.sort_by_key(|window| std::cmp::Reverse(window.z_index));
         return Ok(on_screen[0].window_id);
     }
     let largest = pid_windows.iter().max_by(|a, b| {

--- a/libs/cua-driver/typescript/src/index.ts
+++ b/libs/cua-driver/typescript/src/index.ts
@@ -4,5 +4,13 @@
  * Agents should configure `cua-driver mcp` through their runtime's existing
  * MCP client instead of importing a language MCP facade.
  */
+import { CuaDriver, SdkClientKind } from "./native/cua_driver_sdk.js"
+
+// The same native library backs Python and TypeScript. Keep the public
+// CuaDriver.connect signature stable while attaching the importing runtime as
+// a closed, content-free category to direct daemon requests.
+CuaDriver.connect = (socketPath: string | undefined) =>
+  CuaDriver.connectWithClientKind(socketPath, SdkClientKind.Typescript)
+
 export * from "./native/index.js"
 export { default } from "./native/index.js"

--- a/libs/cua-driver/typescript/src/native/cua_driver_sdk-ffi.ts
+++ b/libs/cua-driver/typescript/src/native/cua_driver_sdk-ffi.ts
@@ -303,6 +303,11 @@ const DEFINITIONS = {
       ret: FfiType.Handle,
       hasRustCallStatus: true,
     },
+    "uniffi_cua_driver_sdk_fn_constructor_cuadriver_connect_with_client_kind": {
+      args: [FfiType.RustBuffer, FfiType.RustBuffer],
+      ret: FfiType.Handle,
+      hasRustCallStatus: true,
+    },
     "uniffi_cua_driver_sdk_fn_method_cuadriver_call_tool": {
       args: [FfiType.Handle, FfiType.RustBuffer, FfiType.RustBuffer],
       ret: FfiType.RustBuffer,
@@ -459,6 +464,11 @@ const DEFINITIONS = {
       hasRustCallStatus: false,
     },
     "uniffi_cua_driver_sdk_checksum_constructor_cuadriver_connect": {
+      args: [],
+      ret: FfiType.UInt16,
+      hasRustCallStatus: false,
+    },
+    "uniffi_cua_driver_sdk_checksum_constructor_cuadriver_connect_with_client_kind": {
       args: [],
       ret: FfiType.UInt16,
       hasRustCallStatus: false,
@@ -676,6 +686,7 @@ interface NativeModuleInterface {
     uniffi_cua_driver_sdk_fn_func_open_mac_os_screen_recording_settings(uniffi_out_err: UniffiRustCallStatus): void;
     uniffi_cua_driver_sdk_fn_func_request_mac_os_permissions(uniffi_out_err: UniffiRustCallStatus): Uint8Array;
     uniffi_cua_driver_sdk_fn_constructor_cuadriver_connect(socketPath: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
+    uniffi_cua_driver_sdk_fn_constructor_cuadriver_connect_with_client_kind(socketPath: Uint8Array, clientKind: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
     uniffi_cua_driver_sdk_fn_method_cuadriver_call_tool(uniffiSelf: bigint, name: Uint8Array, argumentsJson: Uint8Array, uniffi_out_err: UniffiRustCallStatus): Uint8Array;
     uniffi_cua_driver_sdk_fn_method_cuadriver_click(uniffiSelf: bigint, input: Uint8Array, uniffi_out_err: UniffiRustCallStatus): Uint8Array;
     uniffi_cua_driver_sdk_fn_method_cuadriver_drag(uniffiSelf: bigint, input: Uint8Array, uniffi_out_err: UniffiRustCallStatus): Uint8Array;
@@ -708,6 +719,7 @@ interface NativeModuleInterface {
     uniffi_cua_driver_sdk_checksum_func_open_mac_os_screen_recording_settings(): number;
     uniffi_cua_driver_sdk_checksum_func_request_mac_os_permissions(): number;
     uniffi_cua_driver_sdk_checksum_constructor_cuadriver_connect(): number;
+    uniffi_cua_driver_sdk_checksum_constructor_cuadriver_connect_with_client_kind(): number;
     uniffi_cua_driver_sdk_checksum_method_cuadriver_call_tool(): number;
     uniffi_cua_driver_sdk_checksum_method_cuadriver_click(): number;
     uniffi_cua_driver_sdk_checksum_method_cuadriver_drag(): number;

--- a/libs/cua-driver/typescript/src/native/cua_driver_sdk.ts
+++ b/libs/cua-driver/typescript/src/native/cua_driver_sdk.ts
@@ -1451,6 +1451,40 @@ const FfiConverterTypeEmbeddedDriverHostState = (() => {
     return new FFIConverter();
 })();
 
+/**
+ * Runtime that imported the shared UniFFI SDK library. The language package
+ * selects this automatically at its root entry point; callers do not need to
+ * supply telemetry metadata.
+ */
+export enum SdkClientKind {
+    Python,
+    Typescript
+}
+
+const FfiConverterTypeSdkClientKind = (() => {
+    const ordinalConverter = FfiConverterInt32;
+    type TypeName = SdkClientKind;
+    class FFIConverter extends AbstractFfiConverterByteArray<TypeName> {
+        read(from: RustBuffer): TypeName {
+            switch (ordinalConverter.read(from)) {
+                case 1: return SdkClientKind.Python;
+                case 2: return SdkClientKind.Typescript;
+                default: throw new UniffiInternalError.UnexpectedEnumCase();
+            }
+        }
+        write(value: TypeName, into: RustBuffer): void {
+            switch (value) {
+                case SdkClientKind.Python: return ordinalConverter.write(1, into);
+                case SdkClientKind.Typescript: return ordinalConverter.write(2, into);
+            }
+        }
+        allocationSize(value: TypeName): number {
+            return ordinalConverter.allocationSize(0);
+        }
+    }
+    return new FFIConverter();
+})();
+
 export interface CuaDriverLike {
 
 /**
@@ -1506,6 +1540,23 @@ private constructor(pointer: UniffiHandle) {
             /*caller:*/ (callStatus) => {
                 return nativeModule().uniffi_cua_driver_sdk_fn_constructor_cuadriver_connect(
         FfiConverterOptionalString.lower(socketPath, nativeModule().rustbuffer_alloc),
+                callStatus);
+            },
+            /*liftString:*/ FfiConverterString.lift.bind(FfiConverterString),
+    ));
+    }
+
+/**
+ * Language-package entry point that preserves the public `connect` API
+ * while attaching a closed runtime category to daemon requests.
+ */
+    static connectWithClientKind(socketPath: string | undefined, clientKind: SdkClientKind): CuaDriverLike /*throws*/ {
+    return FfiConverterTypeCuaDriver.lift(uniffiCaller.rustCallWithError(
+            /*liftError:*/ FfiConverterTypeDriverError.lift.bind(FfiConverterTypeDriverError),
+            /*caller:*/ (callStatus) => {
+                return nativeModule().uniffi_cua_driver_sdk_fn_constructor_cuadriver_connect_with_client_kind(
+        FfiConverterOptionalString.lower(socketPath, nativeModule().rustbuffer_alloc),
+        FfiConverterTypeSdkClientKind.lower(clientKind, nativeModule().rustbuffer_alloc),
                 callStatus);
             },
             /*liftString:*/ FfiConverterString.lift.bind(FfiConverterString),
@@ -2295,6 +2346,9 @@ function uniffiEnsureInitialized() {
     if (nativeModule().uniffi_cua_driver_sdk_checksum_constructor_cuadriver_connect() !== 42154) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_cua_driver_sdk_checksum_constructor_cuadriver_connect");
     }
+    if (nativeModule().uniffi_cua_driver_sdk_checksum_constructor_cuadriver_connect_with_client_kind() !== 43287) {
+        throw new UniffiInternalError.ApiChecksumMismatch("uniffi_cua_driver_sdk_checksum_constructor_cuadriver_connect_with_client_kind");
+    }
     if (nativeModule().uniffi_cua_driver_sdk_checksum_method_cuadriver_call_tool() !== 31445) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_cua_driver_sdk_checksum_method_cuadriver_call_tool");
     }
@@ -2396,6 +2450,7 @@ export default Object.freeze({
     FfiConverterTypeEmbeddedPermissionMode,
     FfiConverterTypeImageContent,
     FfiConverterTypeMacOsPermissionStatus,
+    FfiConverterTypeSdkClientKind,
     FfiConverterTypeToolResult,
   }
 });

--- a/libs/cua-driver/typescript/test/native-loader.test.mjs
+++ b/libs/cua-driver/typescript/test/native-loader.test.mjs
@@ -163,6 +163,7 @@ test(
       assert.equal(result.verified, true)
       assert.equal(request.name, "get_desktop_state")
       assert.deepEqual(request.args, { session: "node-run" })
+      assert.equal(request.client_kind, "typescript_sdk")
     } finally {
       fixture.kill()
       rmSync(directory, { recursive: true, force: true })


### PR DESCRIPTION
## Summary

- attribute agent sessions to the closed client surfaces `cli`, `direct`, `mcp`, `python_sdk`, and `typescript_sdk`
- record the session-level `capture_scope` and successful `auto` → desktop escalation outcome/reason
- tag Python and TypeScript automatically at their public package roots while preserving `CuaDriver.connect(...)`
- document the exact content-free privacy boundary
- restore a warning-free Rust 1.96 Clippy gate across the touched Driver workspace

Companion observability PR: trycua/cloud#5964

Closes #2442.

## Compatibility

The daemon request adds an optional `client_kind` field. Older daemons ignore it; newer daemons map missing/unknown values to `direct`. The existing `observation_origin` enum is unchanged, so mixed-version clients do not introduce an unknown enum variant.

The new agent-session properties are additive within telemetry schema v3. That schema number versions the common envelope/privacy semantics; it is not bumped for additive properties on an existing event.

## Privacy

Only closed enums and booleans cross the telemetry seam. Session IDs remain process-local. Application/package names, free-form client labels, escalation detail, tool arguments/results, screenshots, window/app data, and paths are not collected.

## Validation

- `cargo test -p cua-driver-core -p cua-driver-sdk -p cua-driver`
- `cargo clippy -p cua-driver-core -p cua-driver-sdk -p cua-driver --all-targets -- -D warnings`
- Python: `CUA_DRIVER_REQUIRE_UNIFFI=1 PYTHONPATH=src .venv/bin/python -m pytest -q` — 15 passed, 3 skipped
- TypeScript: `npm run typecheck && npm test` — 3 passed
- `npm run generate:uniffi:check` — generated bindings are current
