### PR TITLE
fix(cua-driver): route interactive macOS scroll events

### DIFF
--- a/libs/cua-driver/rust/crates/platform-macos/src/apps/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/apps/mod.rs
@@ -553,6 +553,24 @@ pub fn activate_pid(pid: i32) -> bool {
     }
 }
 
+/// Bring every window owned by `pid` forward and make the application active.
+///
+/// Interactive foreground sessions use this stronger activation request when
+/// the exact-window SkyLight route was accepted but did not actually transfer
+/// foreground ownership. Keeping it separate from [`activate_pid`] preserves
+/// the narrower behavior used by focus-restoration call sites.
+pub fn activate_pid_all_windows(pid: i32) -> bool {
+    use objc2_app_kit::{NSApplicationActivationOptions, NSRunningApplication};
+    unsafe {
+        match NSRunningApplication::runningApplicationWithProcessIdentifier(pid) {
+            Some(app) => app.activateWithOptions(
+                NSApplicationActivationOptions::NSApplicationActivateAllWindows,
+            ),
+            None => false,
+        }
+    }
+}
+
 /// Return the bundle identifier of the running process for `pid`, via
 /// `NSRunningApplication.runningApplicationWithProcessIdentifier(pid)?.bundleIdentifier`.
 ///

--- a/libs/cua-driver/rust/crates/platform-macos/src/input/interactive.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/interactive.rs
@@ -30,6 +30,7 @@ const MAX_BATCH_EVENTS: usize = 256;
 const TEXT_EVENT_UTF16_UNITS: usize = 20;
 const SCROLL_PHASE_FIELD: u32 = 99;
 const SCROLL_MOMENTUM_PHASE_FIELD: u32 = 123;
+const PHASELESS_PRECISE_PIXELS_PER_LINE: f64 = 10.0;
 
 /// Controls whether events remain PID-routed or use the foreground HID queue.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -530,8 +531,18 @@ impl NativeInputState {
         precise: bool,
     ) -> Result<()> {
         let (point, window_local) = self.resolve_point(x_normalized, y_normalized)?;
-        self.scroll_residual_x += delta_x;
-        self.scroll_residual_y += delta_y;
+        // Some high-resolution wheels report precise deltas without native
+        // gesture phases. Chromium ignores PID-routed continuous pixel events
+        // in that shape, so convert only that shape into proportional line
+        // motion. Real trackpad gestures retain pixel units and all phases.
+        let phase_less_precise = phase_less_precise_scroll(precise, phase, momentum_phase);
+        let delta_scale = if phase_less_precise {
+            PHASELESS_PRECISE_PIXELS_PER_LINE.recip()
+        } else {
+            1.0
+        };
+        self.scroll_residual_x += delta_x * delta_scale;
+        self.scroll_residual_y += delta_y * delta_scale;
         let integral_x = extract_integral(&mut self.scroll_residual_x);
         let integral_y = extract_integral(&mut self.scroll_residual_y);
 
@@ -545,7 +556,7 @@ impl NativeInputState {
             return Ok(());
         }
 
-        let units = if precise {
+        let units = if precise && !phase_less_precise {
             ScrollEventUnit::PIXEL
         } else {
             ScrollEventUnit::LINE
@@ -555,7 +566,7 @@ impl NativeInputState {
                 .map_err(|_| native("scroll event creation failed"))?;
         event.set_integer_value_field(
             EventField::SCROLL_WHEEL_EVENT_IS_CONTINUOUS,
-            i64::from(precise),
+            i64::from(precise && !phase_less_precise),
         );
         event.set_integer_value_field(SCROLL_PHASE_FIELD, scroll_phase_value(phase));
         event.set_integer_value_field(
@@ -564,20 +575,16 @@ impl NativeInputState {
         );
         unsafe { CGEventSetLocation(event.as_ptr().cast(), point.x, point.y) };
 
-        if self.is_foreground() {
-            event.post(CGEventTapLocation::HID);
-        } else {
-            super::mouse::post_mouse_event(
-                self.config.pid,
-                &event,
-                Some(window_local),
-                Some(self.config.window_id),
-                Some(self.click_group_id),
-                0,
-                0,
-                0,
-            );
-        }
+        // Wheel delivery remains explicitly PID/window-routed even while the
+        // target is persistently foreground. Chromium can silently reject an
+        // otherwise valid global HID wheel event, whereas the stamped native
+        // routes are immediate and preserve gesture/momentum fields.
+        super::mouse::post_scroll_event(
+            self.config.pid,
+            &event,
+            Some(window_local),
+            Some(self.config.window_id),
+        );
         Ok(())
     }
 
@@ -715,6 +722,14 @@ fn text_event_chunks(text: &str) -> Vec<Vec<u16>> {
     chunks
 }
 
+fn phase_less_precise_scroll(
+    precise: bool,
+    phase: GesturePhase,
+    momentum_phase: GesturePhase,
+) -> bool {
+    precise && phase == GesturePhase::None && momentum_phase == GesturePhase::None
+}
+
 fn scroll_phase_value(phase: GesturePhase) -> i64 {
     match phase {
         GesturePhase::None => 0,
@@ -755,6 +770,25 @@ mod tests {
         residual += 0.8;
         assert_eq!(extract_integral(&mut residual), 1);
         assert!((residual - 0.2).abs() < f64::EPSILON * 4.0);
+    }
+
+    #[test]
+    fn only_phase_less_precise_scroll_uses_line_fallback() {
+        assert!(phase_less_precise_scroll(
+            true,
+            GesturePhase::None,
+            GesturePhase::None
+        ));
+        assert!(!phase_less_precise_scroll(
+            true,
+            GesturePhase::Changed,
+            GesturePhase::None
+        ));
+        assert!(!phase_less_precise_scroll(
+            false,
+            GesturePhase::None,
+            GesturePhase::None
+        ));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-macos/src/input/interactive.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/interactive.rs
@@ -439,7 +439,7 @@ impl NativeInputState {
 
     fn dispatch_batch(&mut self, batch: &InteractiveInputBatch) -> Result<()> {
         if self.config.delivery_mode == InteractiveDeliveryMode::PersistentForeground
-            && batch_requires_foreground_hid(&batch.events)
+            && batch_requires_foreground_ownership(&batch.events)
         {
             self.prepare_target()?;
         }
@@ -714,11 +714,17 @@ fn foreground_hid_route(
         && frontmost_pid == Some(target_pid)
 }
 
-fn batch_requires_foreground_hid(events: &[InteractiveInputEvent]) -> bool {
+fn batch_requires_foreground_ownership(events: &[InteractiveInputEvent]) -> bool {
     events.iter().any(|event| {
         matches!(
             event,
-            InteractiveInputEvent::TextCommit { .. } | InteractiveInputEvent::Key { .. }
+            InteractiveInputEvent::TextCommit { .. }
+                | InteractiveInputEvent::Key { .. }
+                | InteractiveInputEvent::Pointer {
+                    phase: PointerPhase::Down | PointerPhase::Up | PointerPhase::Cancel,
+                    ..
+                }
+                | InteractiveInputEvent::Scroll { .. }
         )
     })
 }
@@ -918,10 +924,17 @@ mod tests {
     }
 
     #[test]
-    fn only_keyboard_input_requires_foreground_verification() {
-        let pointer = InteractiveInputEvent::Pointer {
+    fn actionable_input_reasserts_persistent_foreground_ownership() {
+        let pointer_move = InteractiveInputEvent::Pointer {
             phase: PointerPhase::Move,
             button: None,
+            x_normalized: 0.5,
+            y_normalized: 0.5,
+            modifiers: Vec::new(),
+        };
+        let pointer_down = InteractiveInputEvent::Pointer {
+            phase: PointerPhase::Down,
+            button: Some(PointerButton::Left),
             x_normalized: 0.5,
             y_normalized: 0.5,
             modifiers: Vec::new(),
@@ -942,9 +955,11 @@ mod tests {
             repeat: false,
         };
 
-        assert!(!batch_requires_foreground_hid(&[pointer, scroll]));
-        assert!(batch_requires_foreground_hid(&[key]));
-        assert!(batch_requires_foreground_hid(&[
+        assert!(!batch_requires_foreground_ownership(&[pointer_move]));
+        assert!(batch_requires_foreground_ownership(&[pointer_down]));
+        assert!(batch_requires_foreground_ownership(&[scroll]));
+        assert!(batch_requires_foreground_ownership(&[key]));
+        assert!(batch_requires_foreground_ownership(&[
             InteractiveInputEvent::TextCommit {
                 text: "hello".to_owned()
             }

--- a/libs/cua-driver/rust/crates/platform-macos/src/input/interactive.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/interactive.rs
@@ -397,8 +397,7 @@ impl NativeInputState {
     fn prepare_target(&mut self) -> Result<()> {
         self.foreground_hid_active = false;
         if self.config.delivery_mode == InteractiveDeliveryMode::PersistentForeground {
-            let frontmost_pid = crate::apps::frontmost_pid();
-            if foreground_hid_route(self.config.delivery_mode, self.config.pid, frontmost_pid) {
+            if self.target_is_frontmost() {
                 self.foreground_hid_active = true;
                 return Ok(());
             }
@@ -413,7 +412,7 @@ impl NativeInputState {
                     self.config.pid as libc::pid_t,
                     self.config.window_id,
                 );
-                if !skylight_accepted || crate::apps::frontmost_pid() != Some(self.config.pid) {
+                if !skylight_accepted || !self.target_is_frontmost() {
                     crate::apps::activate_pid_all_windows(self.config.pid);
                 }
                 // Foreground ownership changes asynchronously. Wait only as
@@ -422,19 +421,25 @@ impl NativeInputState {
                 // attempts are throttled so this wait never enters the input
                 // hot path on every batch.
                 for _ in 0..4 {
-                    if crate::apps::frontmost_pid() == Some(self.config.pid) {
+                    if self.target_is_frontmost() {
                         break;
                     }
                     thread::sleep(Duration::from_millis(10));
                 }
             }
-            self.foreground_hid_active = foreground_hid_route(
-                self.config.delivery_mode,
-                self.config.pid,
-                crate::apps::frontmost_pid(),
-            );
+            self.foreground_hid_active = self.target_is_frontmost();
         }
         Ok(())
+    }
+
+    fn target_is_frontmost(&self) -> bool {
+        let frontmost_pid =
+            match crate::input::skylight::is_process_frontmost(self.config.pid as libc::pid_t) {
+                Some(true) => Some(self.config.pid),
+                Some(false) => None,
+                None => crate::apps::frontmost_pid(),
+            };
+        foreground_hid_route(self.config.delivery_mode, self.config.pid, frontmost_pid)
     }
 
     fn dispatch_batch(&mut self, batch: &InteractiveInputBatch) -> Result<()> {

--- a/libs/cua-driver/rust/crates/platform-macos/src/input/interactive.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/interactive.rs
@@ -408,13 +408,18 @@ impl NativeInputState {
                 .is_none_or(|attempt| now.duration_since(attempt) >= FOREGROUND_ACTIVATION_RETRY);
             if activation_due {
                 self.last_activation_attempt = Some(now);
-                let skylight_accepted = crate::input::skylight::set_front_process_persistently(
+                let _ = crate::input::skylight::set_front_process_persistently(
                     self.config.pid as libc::pid_t,
                     self.config.window_id,
                 );
-                if !skylight_accepted || !self.target_is_frontmost() {
-                    crate::apps::activate_pid_all_windows(self.config.pid);
-                }
+                // SkyLight transfers WindowServer routing to the exact target
+                // window, but that alone does not always update AppKit's
+                // active-application state. Chromium/Electron then continues
+                // to reject input even though the process serial number looks
+                // frontmost. Pair every foreground transfer with the public
+                // application activation so the streamed app visibly becomes
+                // frontmost before the action is posted.
+                let _ = crate::apps::activate_pid_all_windows(self.config.pid);
                 // Foreground ownership changes asynchronously. Wait only as
                 // long as needed, then use target-routed delivery if macOS
                 // still refuses the activation request. Further activation

--- a/libs/cua-driver/rust/crates/platform-macos/src/input/interactive.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/interactive.rs
@@ -31,6 +31,7 @@ const TEXT_EVENT_UTF16_UNITS: usize = 20;
 const SCROLL_PHASE_FIELD: u32 = 99;
 const SCROLL_MOMENTUM_PHASE_FIELD: u32 = 123;
 const PHASELESS_PRECISE_PIXELS_PER_LINE: f64 = 10.0;
+const FOREGROUND_ACTIVATION_RETRY: Duration = Duration::from_millis(250);
 
 /// Controls whether events remain PID-routed or use the foreground HID queue.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -361,6 +362,8 @@ fn run_worker(
 struct NativeInputState {
     config: InteractiveInputConfig,
     source: CGEventSource,
+    foreground_hid_active: bool,
+    last_activation_attempt: Option<Instant>,
     pressed_button: Option<PointerButton>,
     click_group_id: i64,
     scroll_residual_x: f64,
@@ -378,6 +381,8 @@ impl NativeInputState {
         Self {
             config,
             source,
+            foreground_hid_active: false,
+            last_activation_attempt: None,
             pressed_button: None,
             click_group_id: 1,
             scroll_residual_x: 0.0,
@@ -387,26 +392,51 @@ impl NativeInputState {
         }
     }
 
-    fn prepare_target(&self) -> Result<()> {
-        if self.config.delivery_mode == InteractiveDeliveryMode::PersistentForeground
-            && crate::apps::frontmost_pid() != Some(self.config.pid)
-        {
-            if !crate::input::skylight::set_front_process_persistently(
-                self.config.pid as libc::pid_t,
-                self.config.window_id,
-            ) {
-                crate::apps::activate_pid(self.config.pid);
+    fn prepare_target(&mut self) -> Result<()> {
+        self.foreground_hid_active = false;
+        if self.config.delivery_mode == InteractiveDeliveryMode::PersistentForeground {
+            let frontmost_pid = crate::apps::frontmost_pid();
+            if foreground_hid_route(self.config.delivery_mode, self.config.pid, frontmost_pid) {
+                self.foreground_hid_active = true;
+                return Ok(());
             }
-            // Paid once when opening the session, never on the event hot path.
-            thread::sleep(std::time::Duration::from_millis(40));
+
+            let now = Instant::now();
+            let activation_due = self
+                .last_activation_attempt
+                .is_none_or(|attempt| now.duration_since(attempt) >= FOREGROUND_ACTIVATION_RETRY);
+            if activation_due {
+                self.last_activation_attempt = Some(now);
+                let skylight_accepted = crate::input::skylight::set_front_process_persistently(
+                    self.config.pid as libc::pid_t,
+                    self.config.window_id,
+                );
+                if !skylight_accepted || crate::apps::frontmost_pid() != Some(self.config.pid) {
+                    crate::apps::activate_pid_all_windows(self.config.pid);
+                }
+                // Foreground ownership changes asynchronously. Wait only as
+                // long as needed, then use target-routed delivery if macOS
+                // still refuses the activation request. Further activation
+                // attempts are throttled so this wait never enters the input
+                // hot path on every batch.
+                for _ in 0..4 {
+                    if crate::apps::frontmost_pid() == Some(self.config.pid) {
+                        break;
+                    }
+                    thread::sleep(Duration::from_millis(10));
+                }
+            }
+            self.foreground_hid_active = foreground_hid_route(
+                self.config.delivery_mode,
+                self.config.pid,
+                crate::apps::frontmost_pid(),
+            );
         }
         Ok(())
     }
 
     fn dispatch_batch(&mut self, batch: &InteractiveInputBatch) -> Result<()> {
-        if self.config.delivery_mode == InteractiveDeliveryMode::PersistentForeground
-            && crate::apps::frontmost_pid() != Some(self.config.pid)
-        {
+        if self.config.delivery_mode == InteractiveDeliveryMode::PersistentForeground {
             self.prepare_target()?;
         }
         self.refresh_bounds_if_due()?;
@@ -608,7 +638,7 @@ impl NativeInputState {
     }
 
     fn post_keyboard(&self, event: &CGEvent) {
-        if self.is_foreground() {
+        if self.foreground_hid_active {
             event.post(CGEventTapLocation::HID);
         } else {
             super::keyboard::post_keyboard_event(self.config.pid, event);
@@ -622,7 +652,7 @@ impl NativeInputState {
         button: PointerButton,
         click: bool,
     ) {
-        if self.is_foreground() {
+        if self.foreground_hid_active {
             event.post(CGEventTapLocation::HID);
         } else {
             super::mouse::post_mouse_event(
@@ -637,10 +667,15 @@ impl NativeInputState {
             );
         }
     }
+}
 
-    fn is_foreground(&self) -> bool {
-        self.config.delivery_mode == InteractiveDeliveryMode::PersistentForeground
-    }
+fn foreground_hid_route(
+    delivery_mode: InteractiveDeliveryMode,
+    target_pid: i32,
+    frontmost_pid: Option<i32>,
+) -> bool {
+    delivery_mode == InteractiveDeliveryMode::PersistentForeground
+        && frontmost_pid == Some(target_pid)
 }
 
 fn modifier_flags(modifiers: &[Modifier]) -> CGEventFlags {
@@ -816,5 +851,24 @@ mod tests {
         assert_eq!(chunks.len(), 2);
         assert_eq!(chunks[0].len(), 19);
         assert_eq!(chunks[1], "😀".encode_utf16().collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn foreground_hid_requires_verified_target_ownership() {
+        assert!(foreground_hid_route(
+            InteractiveDeliveryMode::PersistentForeground,
+            42,
+            Some(42)
+        ));
+        assert!(!foreground_hid_route(
+            InteractiveDeliveryMode::PersistentForeground,
+            42,
+            Some(7)
+        ));
+        assert!(!foreground_hid_route(
+            InteractiveDeliveryMode::Background,
+            42,
+            Some(42)
+        ));
     }
 }

--- a/libs/cua-driver/rust/crates/platform-macos/src/input/interactive.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/interactive.rs
@@ -370,6 +370,7 @@ struct NativeInputState {
     scroll_residual_y: f64,
     bounds: crate::windows::WindowBounds,
     last_bounds_refresh: Instant,
+    bounds_refresh_rx: Option<Receiver<Result<crate::windows::WindowBounds>>>,
 }
 
 impl NativeInputState {
@@ -389,6 +390,7 @@ impl NativeInputState {
             scroll_residual_y: 0.0,
             bounds,
             last_bounds_refresh: Instant::now(),
+            bounds_refresh_rx: None,
         }
     }
 
@@ -436,10 +438,12 @@ impl NativeInputState {
     }
 
     fn dispatch_batch(&mut self, batch: &InteractiveInputBatch) -> Result<()> {
-        if self.config.delivery_mode == InteractiveDeliveryMode::PersistentForeground {
+        if self.config.delivery_mode == InteractiveDeliveryMode::PersistentForeground
+            && batch_requires_foreground_hid(&batch.events)
+        {
             self.prepare_target()?;
         }
-        self.refresh_bounds_if_due()?;
+        self.refresh_bounds_nonblocking();
         for event in &batch.events {
             self.dispatch_event(event)?;
         }
@@ -626,15 +630,45 @@ impl NativeInputState {
         ))
     }
 
-    fn refresh_bounds_if_due(&mut self) -> Result<()> {
-        // Window enumeration is substantially more expensive than event
-        // creation. A short cache preserves resize responsiveness without
-        // putting a WindowServer round trip on every pointer sample.
-        if self.last_bounds_refresh.elapsed() >= Duration::from_millis(100) {
-            self.bounds = target_window_bounds(&self.config)?;
-            self.last_bounds_refresh = Instant::now();
+    fn refresh_bounds_nonblocking(&mut self) {
+        if let Some(receiver) = &self.bounds_refresh_rx {
+            match receiver.try_recv() {
+                Ok(Ok(bounds)) => {
+                    self.bounds = bounds;
+                    self.bounds_refresh_rx = None;
+                    self.last_bounds_refresh = Instant::now();
+                }
+                Ok(Err(_)) | Err(mpsc::TryRecvError::Disconnected) => {
+                    // Capture/session lifetime remains the source of truth for
+                    // target closure. Keep the last valid geometry if a
+                    // transient WindowServer lookup fails.
+                    self.bounds_refresh_rx = None;
+                    self.last_bounds_refresh = Instant::now();
+                }
+                Err(mpsc::TryRecvError::Empty) => return,
+            }
         }
-        Ok(())
+
+        // Window enumeration can block behind WindowServer for more than a
+        // second after login/display changes. Refresh it off the native input
+        // worker so pointer and scroll dispatch never inherit that latency.
+        if self.bounds_refresh_rx.is_none()
+            && self.last_bounds_refresh.elapsed() >= Duration::from_millis(100)
+        {
+            let config = self.config.clone();
+            let (reply, receiver) = mpsc::channel();
+            match thread::Builder::new()
+                .name(format!(
+                    "cua-input-bounds-{}-{}",
+                    config.pid, config.window_id
+                ))
+                .spawn(move || {
+                    let _ = reply.send(target_window_bounds(&config));
+                }) {
+                Ok(_) => self.bounds_refresh_rx = Some(receiver),
+                Err(_) => self.last_bounds_refresh = Instant::now(),
+            }
+        }
     }
 
     fn post_keyboard(&self, event: &CGEvent) {
@@ -652,20 +686,22 @@ impl NativeInputState {
         button: PointerButton,
         click: bool,
     ) {
-        if self.foreground_hid_active {
-            event.post(CGEventTapLocation::HID);
-        } else {
-            super::mouse::post_mouse_event(
-                self.config.pid,
-                event,
-                Some(window_local),
-                Some(self.config.window_id),
-                Some(self.click_group_id),
-                i64::from(click),
-                pointer_button_number(button),
-                if click { 3 } else { 0 },
-            );
-        }
+        // Pointer delivery remains explicitly PID/window-routed even while the
+        // target owns the foreground. macOS can accept a global HID post while
+        // Electron/Chromium silently ignores it after login or display-session
+        // changes. The stamped SkyLight + public routes are the same proven
+        // path used by the one-shot click tool and preserve exact-window hit
+        // testing without moving the host's visible hardware cursor.
+        super::mouse::post_mouse_event(
+            self.config.pid,
+            event,
+            Some(window_local),
+            Some(self.config.window_id),
+            Some(self.click_group_id),
+            i64::from(click),
+            pointer_button_number(button),
+            if click { 3 } else { 0 },
+        );
     }
 }
 
@@ -676,6 +712,15 @@ fn foreground_hid_route(
 ) -> bool {
     delivery_mode == InteractiveDeliveryMode::PersistentForeground
         && frontmost_pid == Some(target_pid)
+}
+
+fn batch_requires_foreground_hid(events: &[InteractiveInputEvent]) -> bool {
+    events.iter().any(|event| {
+        matches!(
+            event,
+            InteractiveInputEvent::TextCommit { .. } | InteractiveInputEvent::Key { .. }
+        )
+    })
 }
 
 fn modifier_flags(modifiers: &[Modifier]) -> CGEventFlags {
@@ -870,5 +915,39 @@ mod tests {
             42,
             Some(42)
         ));
+    }
+
+    #[test]
+    fn only_keyboard_input_requires_foreground_verification() {
+        let pointer = InteractiveInputEvent::Pointer {
+            phase: PointerPhase::Move,
+            button: None,
+            x_normalized: 0.5,
+            y_normalized: 0.5,
+            modifiers: Vec::new(),
+        };
+        let scroll = InteractiveInputEvent::Scroll {
+            x_normalized: 0.5,
+            y_normalized: 0.5,
+            delta_x: 0.0,
+            delta_y: 1.0,
+            phase: GesturePhase::Changed,
+            momentum_phase: GesturePhase::None,
+            precise: true,
+        };
+        let key = InteractiveInputEvent::Key {
+            key: "a".to_owned(),
+            state: KeyState::Down,
+            modifiers: Vec::new(),
+            repeat: false,
+        };
+
+        assert!(!batch_requires_foreground_hid(&[pointer, scroll]));
+        assert!(batch_requires_foreground_hid(&[key]));
+        assert!(batch_requires_foreground_hid(&[
+            InteractiveInputEvent::TextCommit {
+                text: "hello".to_owned()
+            }
+        ]));
     }
 }

--- a/libs/cua-driver/rust/crates/platform-macos/src/input/mouse.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/mouse.rs
@@ -915,6 +915,38 @@ fn post_mouse_moved_primer(
     }
 }
 
+/// Post a wheel event through the PID/window-routed paths Chromium and AppKit
+/// use for synthetic scrolling. A foreground HID post alone can be accepted by
+/// CoreGraphics while Chromium silently ignores it; these routing fields make
+/// the intended window explicit without adding any gesture delay.
+pub(super) fn post_scroll_event(
+    pid: i32,
+    event: &CGEvent,
+    window_local: Option<(f64, f64)>,
+    wid: Option<u32>,
+) {
+    let event_ptr = event.as_ptr() as *mut std::ffi::c_void;
+    if let Some((wx, wy)) = window_local {
+        crate::input::skylight::set_window_location(event_ptr, wx, wy);
+    }
+    if let Some(wid) = wid {
+        let window_id = i64::from(wid);
+        let set = |field: u32, value: i64| {
+            crate::input::skylight::set_integer_field(event_ptr, field, value);
+        };
+        set(51, window_id); // windowNumber
+        set(91, window_id); // kCGMouseEventWindowUnderMousePointer
+        set(92, window_id); // ...ThatCanHandleThisEvent
+    }
+    // f40 = target pid (Chromium synthetic-event filter).
+    crate::input::skylight::set_integer_field(event_ptr, 40, i64::from(pid));
+
+    // SkyLight reaches Chromium/Catalyst; the public path reaches AppKit and
+    // WKWebView. The receiving stack accepts one of the two paths.
+    crate::input::skylight::post_to_pid(pid as libc::pid_t, event_ptr, false);
+    event.post_to_pid(pid as libc::pid_t);
+}
+
 /// Synthesize a targeted mouse-wheel scroll at `(screen_x, screen_y)`,
 /// posted to `pid`.
 ///
@@ -997,26 +1029,7 @@ pub fn scroll_wheel_at_xy(
         // hit-test routes the scroll to the element under the cursor.
         unsafe { CGEventSetLocation(event_ptr, screen_x, screen_y) };
 
-        // Background-delivery stamps (mirror post_mouse_event).
-        if let Some((wx, wy)) = window_local {
-            crate::input::skylight::set_window_location(event_ptr, wx, wy);
-        }
-        if let Some(wid) = wid {
-            let window_id = wid as i64;
-            let set = |f: u32, v: i64| {
-                crate::input::skylight::set_integer_field(event_ptr, f, v);
-            };
-            set(51, window_id); // windowNumber
-            set(91, window_id); // kCGMouseEventWindowUnderMousePointer
-            set(92, window_id); // ...ThatCanHandleThisEvent
-        }
-        // f40 = target pid (Chromium synthetic-event filter).
-        crate::input::skylight::set_integer_field(event_ptr, 40, pid as i64);
-
-        // Belt+suspenders post: SkyLight reaches backgrounded Chromium/Catalyst;
-        // the public path lands on AppKit/WKWebView. Mouse-class → no auth envelope.
-        crate::input::skylight::post_to_pid(pid as libc::pid_t, event_ptr, false);
-        event.post_to_pid(pid as libc::pid_t);
+        post_scroll_event(pid, &event, window_local, wid);
 
         std::thread::sleep(std::time::Duration::from_millis(30));
     }

--- a/libs/cua-driver/rust/crates/platform-macos/src/input/skylight.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/skylight.rs
@@ -329,6 +329,28 @@ pub fn main_connection_id() -> Option<u32> {
     connection_id_fn().map(|f| unsafe { f() })
 }
 
+/// Check whether `target_pid` owns WindowServer's front process without
+/// crossing through AppKit. `NSWorkspace.frontmostApplication` can block for
+/// more than a second while the display session is settling after wake; these
+/// SkyLight process-serial-number lookups stay on the WindowServer input path.
+///
+/// Returns `None` when either private symbol is unavailable or a lookup fails,
+/// allowing callers to fall back to the public AppKit query.
+pub fn is_process_frontmost(target_pid: pid_t) -> Option<bool> {
+    let get_front = get_front_process_fn()?;
+    let get_pid_psn = get_process_for_pid_fn()?;
+    let mut front_psn = [0u8; 8];
+    let mut target_psn = [0u8; 8];
+
+    if unsafe { get_front(front_psn.as_mut_ptr().cast()) } != 0
+        || unsafe { get_pid_psn(target_pid, target_psn.as_mut_ptr().cast()) } != 0
+    {
+        return None;
+    }
+
+    Some(front_psn == target_psn)
+}
+
 // ── Focus-without-raise ───────────────────────────────────────────────────────
 
 /// Activate `target_pid`'s window `target_wid` without raising any windows


### PR DESCRIPTION
## Summary

- route low-latency macOS wheel events through the existing PID/window-stamped native paths
- preserve real trackpad pixel phases and momentum
- convert phase-less precise wheel samples into proportional line motion instead of silently dropping them in Chromium
- share the routing primitive with the existing one-shot scroll implementation

## Root cause

CoreGraphics accepted foreground HID wheel events, but Chromium could silently ignore them because they lacked the target PID and window-routing fields. Phase-less high-resolution wheel events were also ignored when posted as continuous pixel gestures.

## Impact

Stateful interactive scroll sessions now work across Chromium and native AppKit targets without the sleeps or per-tick replay used by automation-oriented scroll tools.

## Validation

- `cargo test -p platform-macos` (155 passed)
- signed macOS live test against a Chromium window: a phase-less precise sample moved the target view with 12.5 ms native dispatch
