### PR TITLE
feat(agent): add Yutori Navigator n2 computer-use support

### DIFF
--- a/libs/python/agent/cua_agent/adapters/yutori_adapter.py
+++ b/libs/python/agent/cua_agent/adapters/yutori_adapter.py
@@ -19,15 +19,15 @@ class YutoriAdapter(CustomLLM):
         self.api_key = api_key or os.environ.get("YUTORI_API_KEY")
 
     def _normalize_model(self, model: str) -> str:
-        """Strip the yutori/ prefix and pin the stable bare n1.5 alias.
+        """Strip the yutori/ prefix and pin bare stable-family aliases.
 
         n2 intentionally has no bare ``n2`` → ``n2-latest`` alias; preview
         callers must request ``n2-preview`` explicitly.
         """
         if model.startswith("yutori/"):
             model = model[len("yutori/") :]
-        if model == "n1.5":
-            model = "n1.5-latest"
+        if "-" not in model and model != "n2":
+            model = f"{model}-latest"
         return model
 
     def _resolve_api_key(self, kwargs: dict | None = None) -> str:

--- a/libs/python/agent/cua_agent/adapters/yutori_adapter.py
+++ b/libs/python/agent/cua_agent/adapters/yutori_adapter.py
@@ -19,15 +19,15 @@ class YutoriAdapter(CustomLLM):
         self.api_key = api_key or os.environ.get("YUTORI_API_KEY")
 
     def _normalize_model(self, model: str) -> str:
-        """Strip the yutori/ prefix and pin bare model names to their -latest alias.
+        """Strip the yutori/ prefix and pin the stable bare n1.5 alias.
 
-        The Yutori API only accepts versioned model names (e.g. "n1.5-latest",
-        "n1.5-20260428") and rejects bare names like "n1.5".
+        n2 intentionally has no bare ``n2`` → ``n2-latest`` alias; preview
+        callers must request ``n2-preview`` explicitly.
         """
         if model.startswith("yutori/"):
             model = model[len("yutori/") :]
-        if "-" not in model:
-            model = f"{model}-latest"
+        if model == "n1.5":
+            model = "n1.5-latest"
         return model
 
     def _resolve_api_key(self, kwargs: dict | None = None) -> str:

--- a/libs/python/agent/cua_agent/adapters/yutori_adapter.py
+++ b/libs/python/agent/cua_agent/adapters/yutori_adapter.py
@@ -19,9 +19,15 @@ class YutoriAdapter(CustomLLM):
         self.api_key = api_key or os.environ.get("YUTORI_API_KEY")
 
     def _normalize_model(self, model: str) -> str:
-        """Strip the yutori/ prefix to get the bare model name."""
+        """Strip the yutori/ prefix and pin bare model names to their -latest alias.
+
+        The Yutori API only accepts versioned model names (e.g. "n1.5-latest",
+        "n1.5-20260428") and rejects bare names like "n1.5".
+        """
         if model.startswith("yutori/"):
-            return model[len("yutori/") :]
+            model = model[len("yutori/") :]
+        if "-" not in model:
+            model = f"{model}-latest"
         return model
 
     def _resolve_api_key(self, kwargs: dict | None = None) -> str:
@@ -48,7 +54,7 @@ class YutoriAdapter(CustomLLM):
         params = {
             "model": f"openai/{model}",
             "messages": kwargs.get("messages", []),
-            "api_base": self.base_url,
+            "api_base": kwargs.get("api_base") or self.base_url,
             "api_key": api_key,
             "extra_headers": extra_headers,
             "stream": False,
@@ -60,16 +66,21 @@ class YutoriAdapter(CustomLLM):
         if "tool_choice" in kwargs:
             params["tool_choice"] = kwargs["tool_choice"]
 
-        # Forward optional generation params
+        # Forward optional generation params. extra_body carries Yutori-specific
+        # request fields (tool_set, disable_tools, json_schema, prev_request_id).
         for key in (
             "temperature",
             "top_p",
             "max_completion_tokens",
-            "max_tokens",
             "response_format",
+            "extra_body",
         ):
             if key in kwargs:
                 params[key] = kwargs[key]
+
+        # The Yutori API rejects max_tokens; it requires max_completion_tokens.
+        if "max_tokens" in kwargs and "max_completion_tokens" not in params:
+            params["max_completion_tokens"] = kwargs["max_tokens"]
 
         if "optional_params" in kwargs:
             protected_keys = {"api_key", "extra_headers", "model", "api_base", "stream"}
@@ -93,7 +104,7 @@ class YutoriAdapter(CustomLLM):
         return response
 
     def streaming(self, *args, **kwargs) -> Iterator[GenericStreamingChunk]:
-        raise NotImplementedError("Yutori n1 does not support streaming.")
+        raise NotImplementedError("Yutori Navigator models do not support streaming.")
 
     async def astreaming(self, *args, **kwargs) -> AsyncIterator[GenericStreamingChunk]:
-        raise NotImplementedError("Yutori n1 does not support streaming.")
+        raise NotImplementedError("Yutori Navigator models do not support streaming.")

--- a/libs/python/agent/cua_agent/agent.py
+++ b/libs/python/agent/cua_agent/agent.py
@@ -33,6 +33,7 @@ from .adapters import (
     HuggingFaceLocalAdapter,
     HumanAdapter,
     MLXVLMAdapter,
+    YutoriAdapter,
 )
 from .callbacks import (
     BudgetManagerCallback,
@@ -364,12 +365,14 @@ class ComputerAgent:
         mlx_adapter = MLXVLMAdapter()
         cua_adapter = CUAAdapter()
         azure_ml_adapter = AzureMLAdapter()
+        yutori_adapter = YutoriAdapter()
         litellm.custom_provider_map = [
             {"provider": "huggingface-local", "custom_handler": hf_adapter},
             {"provider": "human", "custom_handler": human_adapter},
             {"provider": "mlx", "custom_handler": mlx_adapter},
             {"provider": "cua", "custom_handler": cua_adapter},
             {"provider": "azure_ml", "custom_handler": azure_ml_adapter},
+            {"provider": "yutori", "custom_handler": yutori_adapter},
         ]
         litellm.suppress_debug_info = True
 

--- a/libs/python/agent/cua_agent/agent.py
+++ b/libs/python/agent/cua_agent/agent.py
@@ -279,6 +279,7 @@ class ComputerAgent:
         trust_remote_code: Optional[bool] = False,
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
+        action_confirmation_callback: Optional[Callable[[Dict[str, Any]], Any]] = None,
         **additional_generation_kwargs,
     ):
         """
@@ -301,6 +302,8 @@ class ComputerAgent:
             trust_remote_code: If set, trust remote code when loading local models. Disabled by default.
             api_key: Optional API key override for the model provider
             api_base: Optional API base URL override for the model provider
+            action_confirmation_callback: Optional sync or async callback for
+                model actions explicitly marked as requiring confirmation.
             **additional_generation_kwargs: Additional arguments passed to the model provider
         """
         # If the loop is "human/human", we need to prefix a grounding model fallback
@@ -323,6 +326,7 @@ class ComputerAgent:
         self.trust_remote_code = trust_remote_code
         self.api_key = api_key
         self.api_base = api_base
+        self.action_confirmation_callback = action_confirmation_callback
 
         # == Add built-in callbacks ==
 
@@ -442,6 +446,8 @@ class ComputerAgent:
                 args_provided.append("api_key")
             if api_base:
                 args_provided.append("api_base")
+            if action_confirmation_callback:
+                args_provided.append("action_confirmation_callback")
             if additional_generation_kwargs:
                 args_provided.extend(additional_generation_kwargs.keys())
 
@@ -730,6 +736,139 @@ class ComputerAgent:
     # AGENT OUTPUT PROCESSING
     # ============================================================================
 
+    async def _confirm_computer_item(self, item: Dict[str, Any]) -> bool:
+        """Run the opt-in confirmation hook for a fully validated action item."""
+        if not item.get("_requires_confirmation") or self.action_confirmation_callback is None:
+            return True
+        request = {
+            "call_id": item.get("call_id"),
+            "tool_name": item.get("name"),
+            "arguments": item.get("arguments"),
+            "actions": item.get("_batch_actions") or item.get("_computer_actions") or [],
+        }
+        decision = self.action_confirmation_callback(request)
+        if inspect.isawaitable(decision):
+            decision = await decision
+        return bool(decision)
+
+    async def _handle_attached_computer_actions(
+        self,
+        item: Dict[str, Any],
+        computer: Optional[AsyncComputerHandler],
+    ) -> List[Dict[str, Any]]:
+        """Execute one validated Yutori call and capture exactly one result frame."""
+        call_id = item.get("call_id")
+        if not computer:
+            return [
+                make_tool_error_item("Computer handler is required for computer calls", call_id)
+            ]
+
+        await self._on_computer_call_start(item)
+        if not await self._confirm_computer_item(item):
+            result = [
+                {
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": "[ERROR] Action was not confirmed by the user.",
+                }
+            ]
+            await self._on_computer_call_end(item, result)
+            return result
+
+        actions = item.get("_computer_actions") or []
+        batch_actions = item.get("_batch_actions")
+        batch_size = len(batch_actions) if isinstance(batch_actions, list) else 1
+        action_counts: Dict[int, int] = {}
+        if isinstance(batch_actions, list):
+            for action in actions:
+                batch_index = action.get("batch_index")
+                if isinstance(batch_index, int):
+                    action_counts[batch_index] = action_counts.get(batch_index, 0) + 1
+        else:
+            action_counts[0] = len(actions)
+
+        completed_members: Set[int] = set()
+        failed_index: Optional[int] = None
+        stopped_reason: Optional[str] = None
+        screenshot_base64: Optional[str] = None
+        started_at = time.monotonic()
+
+        for action in actions:
+            current_task = asyncio.current_task()
+            if current_task is not None and current_task.cancelling():
+                stopped_reason = "cancelled"
+                break
+            deadline = item.get("_execution_deadline")
+            if isinstance(deadline, (int, float)) and time.monotonic() >= deadline:
+                stopped_reason = "deadline_reached"
+                break
+
+            action_type = action.get("type")
+            batch_index = action.get("batch_index")
+            action_args = {
+                key: value for key, value in action.items() if key not in {"type", "batch_index"}
+            }
+            try:
+                if action_type == "screenshot":
+                    screenshot_base64 = await computer.screenshot()
+                    action_result = None
+                else:
+                    computer_method = getattr(computer, action_type, None)
+                    if computer_method is None:
+                        raise ToolError(f"Unknown computer action: {action_type}")
+                    assert_callable_with(computer_method, **action_args)
+                    action_result = await computer_method(**action_args)
+                    if isinstance(action_result, dict) and action_result.get("success") is False:
+                        raise ToolError(str(action_result.get("error") or action_result))
+
+                member_index = batch_index if isinstance(batch_index, int) else 0
+                action_counts[member_index] -= 1
+                if action_counts[member_index] == 0:
+                    completed_members.add(member_index)
+
+                if self.telemetry_enabled and is_telemetry_enabled():
+                    record_event(
+                        "computer_action_executed",
+                        {"action_type": action_type, "batch_length": batch_size},
+                    )
+            except Exception as error:
+                failed_index = batch_index if isinstance(batch_index, int) else 0
+                stopped_reason = str(error)
+                break
+
+        if screenshot_base64 is None:
+            if self.screenshot_delay and self.screenshot_delay > 0:
+                await asyncio.sleep(self.screenshot_delay)
+            screenshot_base64 = await computer.screenshot()
+        await self._on_screenshot(screenshot_base64, "screenshot_after")
+
+        completed = len(completed_members)
+        failed = 1 if failed_index is not None else 0
+        skipped = max(0, batch_size - completed - failed)
+        metadata = {
+            "completed": completed,
+            "failed": failed,
+            "skipped": skipped,
+            "failed_action_index": failed_index,
+            "status": "completed" if stopped_reason is None else "stopped",
+            "error": stopped_reason,
+            "duration_ms": round((time.monotonic() - started_at) * 1000),
+        }
+        output = {
+            "type": "input_image",
+            "image_url": f"data:image/png;base64,{screenshot_base64}",
+            "result": metadata,
+        }
+        result = [
+            {
+                "type": "function_call_output",
+                "call_id": call_id,
+                "output": output,
+            }
+        ]
+        await self._on_computer_call_end(item, result)
+        return result
+
     async def _handle_item(
         self,
         item: Any,
@@ -742,6 +881,9 @@ class ComputerAgent:
             return []
 
         item_type = item.get("type", None)
+
+        if item_type == "function_call" and item.get("_computer_actions") is not None:
+            return await self._handle_attached_computer_actions(item, computer)
 
         if item_type == "message":
             await self._on_text(item)

--- a/libs/python/agent/cua_agent/callbacks/operator_validator.py
+++ b/libs/python/agent/cua_agent/callbacks/operator_validator.py
@@ -30,7 +30,7 @@ class OperatorNormalizerCallback(AsyncCallbackHandler):
                 continue
 
             # rename mouse click actions to "click"
-            for mouse_btn in ["left", "right", "wheel", "back", "forward"]:
+            for mouse_btn in ["left", "right", "middle", "wheel", "back", "forward"]:
                 if action.get("type", "") == f"{mouse_btn}_click":
                     action["type"] = "click"
                     action["button"] = mouse_btn
@@ -86,19 +86,21 @@ class OperatorNormalizerCallback(AsyncCallbackHandler):
                     action["keys"] = keys.replace("-", "+").split("+") if len(keys) > 1 else [keys]
             required_keys_by_type = {
                 # OpenAI actions
-                "click": ["type", "button", "x", "y"],
-                "double_click": ["type", "x", "y"],
+                # modifier: optional held modifier key (e.g. ctrl+click), used by Yutori n1.5
+                "click": ["type", "button", "x", "y", "modifier"],
+                "double_click": ["type", "x", "y", "modifier"],
                 "drag": ["type", "path"],
                 "keypress": ["type", "keys"],
                 "move": ["type", "x", "y"],
                 "screenshot": ["type"],
                 "scroll": ["type", "scroll_x", "scroll_y", "x", "y"],
                 "type": ["type", "text"],
-                "wait": ["type"],
+                # time: optional duration in seconds, used by FARA and Yutori n1.5
+                "wait": ["type", "time"],
                 # Anthropic actions
                 "left_mouse_down": ["type", "x", "y"],
                 "left_mouse_up": ["type", "x", "y"],
-                "triple_click": ["type", "button", "x", "y"],
+                "triple_click": ["type", "button", "x", "y", "modifier"],
             }
             keep = required_keys_by_type.get(action_type or "")
             if keep:

--- a/libs/python/agent/cua_agent/computers/cua.py
+++ b/libs/python/agent/cua_agent/computers/cua.py
@@ -53,9 +53,11 @@ class cuaComputerHandler(AsyncComputerHandler):
             await self.interface.left_click(x, y)
         elif button == "right":
             await self.interface.right_click(x, y)
+        elif button == "middle":
+            await self.interface.mouse_down(x, y, button="middle")
+            await self.interface.mouse_up(x, y, button="middle")
         else:
-            # Default to left click for unknown buttons
-            await self.interface.left_click(x, y)
+            raise ValueError(f"Unsupported mouse button: {button}")
 
     async def double_click(self, x: int, y: int) -> None:
         """Double click at coordinates."""

--- a/libs/python/agent/cua_agent/loops/__init__.py
+++ b/libs/python/agent/cua_agent/loops/__init__.py
@@ -24,6 +24,7 @@ from . import (
     uitars,
     uitars2,
     yutori,
+    yutori_n2,
 )
 
 __all__ = [
@@ -47,4 +48,5 @@ __all__ = [
     "uitars",
     "uitars2",
     "yutori",
+    "yutori_n2",
 ]

--- a/libs/python/agent/cua_agent/loops/yutori.py
+++ b/libs/python/agent/cua_agent/loops/yutori.py
@@ -1,8 +1,36 @@
 """
-Yutori n1 agent loop implementation using litellm.
+Yutori Navigator (n1.5) agent loop implementation using litellm.
 
-n1 is a browser-use model that outputs actions via tool_calls in OpenAI chat
-completions format. Coordinates are in a 1000x1000 normalized space.
+Navigator is a browser-use model that outputs actions via tool_calls in OpenAI
+chat completions format. Coordinates are in a 1000x1000 normalized space, and
+screenshots are best sent as 1280x800 WebP images.
+
+The default model is ``yutori/n1.5-latest``; dated snapshots such as
+``yutori/n1.5-20260428`` are also supported. (Navigator n1 is deprecated and
+rejected by the Yutori API.)
+
+Notes (see https://docs.yutori.com reference/n1-5):
+- key_press takes ``key`` in a lowercase key space, where "+" joins
+  simultaneous keys and spaces separate sequential presses
+  (e.g. "ctrl+c", "down down enter").
+- Click/scroll actions accept optional ``ref`` (DOM element reference) and
+  ``modifier`` (held modifier key) arguments.
+- Optional request params tool_set, disable_tools, json_schema and
+  prev_request_id are forwarded via extra_body, e.g.::
+
+      agent = ComputerAgent(
+          model="yutori/n1.5-latest",
+          tools=[computer],
+          tool_set="browser_tools_expanded-20260403",
+      )
+
+- The expanded tool set adds DOM tools (extract_elements, find,
+  set_element_value, execute_js). This loop executes them inline through the
+  computer handler's evaluate_js method, which requires a computer-server
+  recent enough to support the ``evaluate`` browser command.
+
+The Yutori API injects the browser tool definitions and the system prompt
+server-side, so this loop only forwards custom function tools.
 """
 
 from __future__ import annotations
@@ -28,22 +56,75 @@ from ..responses import (
     make_reasoning_item,
 )
 from ..types import AgentCapability
+from .yutori_js import (
+    EXECUTE_JS_SCRIPT,
+    EXTRACT_ELEMENTS_SCRIPT,
+    FIND_SCRIPT,
+    GET_ELEMENT_BY_REF_SCRIPT,
+    SET_ELEMENT_VALUE_SCRIPT,
+    build_tool_expression,
+    coerce_result,
+)
 
-# Target resolution for n1 (docs recommend 1280x800 WebP)
-N1_TARGET_WIDTH = 1280
-N1_TARGET_HEIGHT = 800
-N1_COORD_SPACE = 1000
+# Target resolution for Navigator models (docs recommend 1280x800 WebP)
+NAVIGATOR_TARGET_WIDTH = 1280
+NAVIGATOR_TARGET_HEIGHT = 800
+NAVIGATOR_COORD_SPACE = 1000
+
+# DOM tools from the expanded tool set, executed inline by this loop
+DOM_TOOL_NAMES = {"extract_elements", "find", "set_element_value", "execute_js"}
+
+# Yutori-specific request params forwarded to the API via extra_body
+YUTORI_EXTRA_BODY_PARAMS = ("tool_set", "disable_tools", "json_schema", "prev_request_id")
+
+# Map the Navigator key space to the pynput-style names understood by the
+# computer-server keyboard handlers, plus a few tolerant synonyms.
+_KEY_ALIASES = {
+    "meta": "cmd",
+    "command": "cmd",
+    "super": "cmd",
+    "win": "cmd",
+    "control": "ctrl",
+    "escape": "esc",
+    "pageup": "page_up",
+    "pagedown": "page_down",
+    "return": "enter",
+}
 
 
-def _prepare_image_for_n1(image_b64: str) -> str:
-    """Convert a base64 PNG screenshot to WebP at 1280x800 for optimal n1 performance."""
+def _map_key_token(token: str) -> str:
+    """Map a single Navigator key name to a pynput-style key name."""
+    token = token.strip()
+    if len(token) == 1:
+        return token
+    lowered = token.lower()
+    return _KEY_ALIASES.get(lowered, lowered)
+
+
+def _convert_key_expression(expr: str) -> List[List[str]]:
+    """Convert a Navigator key expression to a list of key combos.
+
+    "+" joins keys pressed simultaneously; whitespace separates sequential
+    presses. E.g. "down down enter" -> [["down"], ["down"], ["enter"]] and
+    "ctrl+shift+t" -> [["ctrl", "shift", "t"]].
+    """
+    combos = []
+    for combo in expr.split():
+        keys = [_map_key_token(k) for k in combo.split("+") if k.strip()]
+        if keys:
+            combos.append(keys)
+    return combos
+
+
+def _prepare_image_for_navigator(image_b64: str) -> str:
+    """Convert a base64 PNG screenshot to WebP at 1280x800 for optimal performance."""
     try:
         img_bytes = base64.b64decode(image_b64)
         img = Image.open(io.BytesIO(img_bytes))
 
-        # Resize to n1's recommended resolution
-        if img.size != (N1_TARGET_WIDTH, N1_TARGET_HEIGHT):
-            img = img.resize((N1_TARGET_WIDTH, N1_TARGET_HEIGHT), Image.LANCZOS)
+        # Resize to the recommended resolution
+        if img.size != (NAVIGATOR_TARGET_WIDTH, NAVIGATOR_TARGET_HEIGHT):
+            img = img.resize((NAVIGATOR_TARGET_WIDTH, NAVIGATOR_TARGET_HEIGHT), Image.LANCZOS)
 
         # Convert to WebP
         buf = io.BytesIO()
@@ -57,52 +138,72 @@ def _prepare_image_for_n1(image_b64: str) -> str:
 def _unnormalize_coordinates(
     coords: List[int], screen_width: int, screen_height: int
 ) -> Tuple[int, int]:
-    """Scale coordinates from n1's 1000x1000 space to actual screen pixels."""
-    x = max(0, min(screen_width, round((coords[0] / N1_COORD_SPACE) * screen_width)))
-    y = max(0, min(screen_height, round((coords[1] / N1_COORD_SPACE) * screen_height)))
+    """Scale coordinates from the 1000x1000 normalized space to actual screen pixels."""
+    x = max(0, min(screen_width, round((coords[0] / NAVIGATOR_COORD_SPACE) * screen_width)))
+    y = max(0, min(screen_height, round((coords[1] / NAVIGATOR_COORD_SPACE) * screen_height)))
     return x, y
 
 
-def _convert_n1_action_to_computer_action(
-    fn_name: str, args: Dict[str, Any], screen_width: int, screen_height: int
-) -> Optional[Dict[str, Any]]:
+def _convert_navigator_action(
+    fn_name: str,
+    args: Dict[str, Any],
+    screen_width: int,
+    screen_height: int,
+    ref_pixels: Optional[Tuple[int, int]] = None,
+) -> Optional[List[Dict[str, Any]]]:
     """
-    Convert an n1 tool call to the internal computer_call action schema.
+    Convert a Navigator tool call to a list of internal computer_call actions.
 
-    Returns None for actions that should be emitted as function_calls instead
-    (goto_url, go_back, refresh).
+    ref_pixels, when provided, are viewport pixel coordinates already resolved
+    from the action's ``ref`` argument and take precedence over the normalized
+    ``coordinates``.
+
+    Returns None for tool calls that are not computer actions (custom function
+    tools), so the caller can emit them as function_calls instead.
     """
-    # Actions with coordinates
-    coords = args.get("coordinates")
     x, y = None, None
-    if isinstance(coords, (list, tuple)) and len(coords) >= 2:
-        x, y = _unnormalize_coordinates(coords, screen_width, screen_height)
+    if ref_pixels is not None:
+        x, y = ref_pixels
+    else:
+        coords = args.get("coordinates")
+        if isinstance(coords, (list, tuple)) and len(coords) >= 2:
+            x, y = _unnormalize_coordinates(coords, screen_width, screen_height)
 
-    if fn_name == "left_click":
+    modifier = args.get("modifier")
+    modifier = _map_key_token(modifier) if isinstance(modifier, str) and modifier else None
+
+    def _with_modifier(action: Dict[str, Any]) -> Dict[str, Any]:
+        if modifier:
+            action["modifier"] = modifier
+        return action
+
+    if fn_name in ("left_click", "right_click", "middle_click"):
         if x is None or y is None:
             return None
-        return {"action": "left_click", "x": x, "y": y}
+        button = fn_name.split("_")[0]
+        return [_with_modifier({"action": "click", "button": button, "x": x, "y": y})]
 
     if fn_name == "double_click":
         if x is None or y is None:
             return None
-        return {"action": "double_click", "x": x, "y": y}
+        return [_with_modifier({"action": "double_click", "x": x, "y": y})]
 
     if fn_name == "triple_click":
-        # Approximate as double_click
         if x is None or y is None:
             return None
-        return {"action": "double_click", "x": x, "y": y}
+        return [_with_modifier({"action": "triple_click", "x": x, "y": y})]
 
-    if fn_name == "right_click":
+    if fn_name == "mouse_move":
         if x is None or y is None:
             return None
-        return {"action": "right_click", "x": x, "y": y}
+        return [{"action": "move", "x": x, "y": y}]
 
-    if fn_name == "hover":
-        if x is None or y is None:
-            return None
-        return {"action": "move", "x": x, "y": y}
+    if fn_name in ("mouse_down", "mouse_up"):
+        action: Dict[str, Any] = {"action": fn_name}
+        if x is not None and y is not None:
+            action["x"] = x
+            action["y"] = y
+        return [action]
 
     if fn_name == "drag":
         start_coords = args.get("start_coordinates")
@@ -114,13 +215,13 @@ def _convert_n1_action_to_computer_action(
         ):
             return None
         sx, sy = _unnormalize_coordinates(start_coords, screen_width, screen_height)
-        return {
-            "action": "drag",
-            "start_x": sx,
-            "start_y": sy,
-            "end_x": x,
-            "end_y": y,
-        }
+        return [
+            {
+                "action": "left_click_drag",
+                "start_coordinate": [sx, sy],
+                "end_coordinate": [x, y],
+            }
+        ]
 
     if fn_name == "scroll":
         direction = args.get("direction", "down")
@@ -141,39 +242,49 @@ def _convert_n1_action_to_computer_action(
         if x is not None and y is not None:
             out["x"] = x
             out["y"] = y
-        return out
+        return [out]
 
     if fn_name == "type":
-        text = args.get("text", "")
-        if args.get("press_enter_after"):
-            text = text + "\n"
-        # Note: clear_before_typing is not supported by the framework's type action.
-        # n1 rarely emits this flag; when it does, the field may already be empty.
-        return {"action": "type", "text": text}
+        return [{"action": "type", "text": args.get("text", "")}]
 
     if fn_name == "key_press":
-        key_comb = args.get("key_comb", "")
-        # n1 uses Playwright-compatible key combos like "Control+a", "Escape"
-        keys = [k.strip() for k in key_comb.split("+")]
-        return {"action": "keypress", "keys": keys}
+        combos = _convert_key_expression(args.get("key") or "")
+        if not combos:
+            return None
+        return [{"action": "keypress", "keys": keys} for keys in combos]
+
+    if fn_name == "hold_key":
+        key = args.get("key", "")
+        if not key:
+            return None
+        action = {"action": "hold_key", "key": _map_key_token(key)}
+        if args.get("duration") is not None:
+            action["duration"] = float(args["duration"])
+        return [action]
 
     if fn_name == "wait":
-        return {"action": "wait"}
+        action = {"action": "wait"}
+        if args.get("duration") is not None:
+            action["time"] = float(args["duration"])
+        return [action]
 
     if fn_name == "go_back":
-        return {"action": "history_back"}
+        return [{"action": "history_back"}]
+
+    if fn_name == "go_forward":
+        return [{"action": "history_forward"}]
 
     if fn_name == "refresh":
-        return {"action": "keypress", "keys": ["F5"]}
+        return [{"action": "refresh"}]
 
     if fn_name == "goto_url":
-        return {"action": "visit_url", "url": args.get("url", "")}
+        return [{"action": "visit_url", "url": args.get("url", "")}]
 
     return None
 
 
-def _convert_images_to_n1_format(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Convert all images in messages to WebP format optimized for n1."""
+def _convert_images_to_navigator_format(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Convert all images in messages to WebP format optimized for Navigator models."""
     for msg in messages:
         content = msg.get("content")
         if not isinstance(content, list):
@@ -183,18 +294,120 @@ def _convert_images_to_n1_format(messages: List[Dict[str, Any]]) -> List[Dict[st
                 url = ((part.get("image_url") or {}).get("url")) or ""
                 if url.startswith("data:") and "," in url:
                     b64 = url.split(",", 1)[1]
-                    converted = _prepare_image_for_n1(b64)
+                    converted = _prepare_image_for_navigator(b64)
                     part["image_url"]["url"] = f"data:image/webp;base64,{converted}"
     return messages
 
 
-@register_agent(models=r"(yutori/)?n1(-.*)?$", tool_type="browser")
-class YutoriN1Config(AsyncAgentConfig):
-    """
-    Yutori n1 browser-use agent loop.
+def _message_has_image(msg: Dict[str, Any]) -> bool:
+    content = msg.get("content")
+    if isinstance(content, list):
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "image_url":
+                return True
+    return False
 
-    n1 is a browser-only model that outputs actions as tool_calls.
-    Coordinates use a 1000x1000 normalized space.
+
+async def _evaluate_tool_script(computer_handler, script: str, *args: Any) -> Dict[str, Any]:
+    """Run a bundled JS tool script in the page via the computer handler.
+
+    Raises RuntimeError when the handler or the computer-server cannot
+    evaluate JS (e.g. servers predating the 'evaluate' browser command).
+    """
+    if not hasattr(computer_handler, "evaluate_js"):
+        raise RuntimeError(
+            "This computer handler does not support JavaScript evaluation "
+            "(expanded browser tools require a BrowserTool handler)."
+        )
+    result = await computer_handler.evaluate_js(build_tool_expression(script, *args))
+    if not isinstance(result, dict) or not result.get("success", False):
+        error = result.get("error") if isinstance(result, dict) else str(result)
+        raise RuntimeError(error or "JavaScript evaluation failed.")
+    return coerce_result(result.get("result"))
+
+
+async def _resolve_ref(computer_handler, ref: str) -> Optional[Tuple[int, int]]:
+    """Resolve a DOM element ref to viewport pixel coordinates.
+
+    Also scrolls the element into view. Returns None when resolution fails so
+    the caller can fall back to the action's normalized coordinates.
+    """
+    try:
+        result = await _evaluate_tool_script(computer_handler, GET_ELEMENT_BY_REF_SCRIPT, ref)
+    except Exception:
+        return None
+    if not result.get("success"):
+        return None
+    px = result.get("coordinates")
+    if not isinstance(px, (list, tuple)) or len(px) < 2:
+        return None
+    return int(px[0]), int(px[1])
+
+
+async def _execute_dom_tool(computer_handler, fn_name: str, args: Dict[str, Any]) -> str:
+    """Execute an expanded-tool-set DOM tool inline and format its result."""
+    try:
+        if fn_name == "extract_elements":
+            data = await _evaluate_tool_script(
+                computer_handler, EXTRACT_ELEMENTS_SCRIPT, args.get("filter", "visible")
+            )
+            result = data.get("pageContent", "")
+        elif fn_name == "find":
+            text = args.get("text", "")
+            data = await _evaluate_tool_script(computer_handler, FIND_SCRIPT, text)
+            if not data.get("success", False):
+                result = f"[ERROR] {data.get('message', 'find failed')}"
+            else:
+                matches = data.get("matches", [])
+                total_matches = int(data.get("totalMatches", len(matches)))
+                if total_matches:
+                    result = f'Found {total_matches} element(s) matching "{text}":\n' + "\n".join(
+                        matches[:20]
+                    )
+                else:
+                    result = f'No elements matching "{text}" found on the page.'
+        elif fn_name == "set_element_value":
+            data = await _evaluate_tool_script(
+                computer_handler,
+                SET_ELEMENT_VALUE_SCRIPT,
+                args.get("ref", ""),
+                args.get("value", ""),
+            )
+            result = data.get("message", "set_element_value completed")
+        elif fn_name == "execute_js":
+            data = await _evaluate_tool_script(
+                computer_handler, EXECUTE_JS_SCRIPT, args.get("text", "")
+            )
+            if not data.get("success", False):
+                result = f"[ERROR] {data.get('message', 'execute_js failed')}"
+            elif not data.get("hasResult"):
+                result = "undefined"
+            else:
+                result = str(data.get("result"))
+        else:
+            result = f"[ERROR] Unknown DOM tool: {fn_name}"
+    except Exception as e:
+        result = f"[ERROR] Error executing {fn_name}: {e}"
+
+    # Match the reference client: append the current URL to tool results
+    try:
+        current_url = await computer_handler.get_current_url()
+        if current_url:
+            result = f"{result}\nCurrent URL: {current_url}"
+    except Exception:
+        pass
+
+    return result
+
+
+@register_agent(models=r"(yutori/)?n1\.\d+(-.*)?$", tool_type="browser")
+class YutoriNavigatorConfig(AsyncAgentConfig):
+    """
+    Yutori Navigator (n1.5) browser-use agent loop.
+
+    Navigator is a browser-only model that outputs actions as tool_calls.
+    Coordinates use a 1000x1000 normalized space. Browser tool definitions and
+    the system prompt are injected server-side by the Yutori API.
     """
 
     async def predict_step(
@@ -212,11 +425,11 @@ class YutoriN1Config(AsyncAgentConfig):
         _on_screenshot=None,
         **kwargs,
     ) -> Dict[str, Any]:
-        """Predict the next browser action using Yutori n1."""
+        """Predict the next browser action using a Yutori Navigator model."""
         tools = tools or []
 
         # Get screen dimensions for coordinate denormalization
-        screen_width, screen_height = N1_TARGET_WIDTH, N1_TARGET_HEIGHT
+        screen_width, screen_height = NAVIGATOR_TARGET_WIDTH, NAVIGATOR_TARGET_HEIGHT
         if computer_handler:
             try:
                 screen_width, screen_height = await computer_handler.get_dimensions()
@@ -234,29 +447,24 @@ class YutoriN1Config(AsyncAgentConfig):
         )
 
         # Convert images to WebP at 1280x800
-        completion_messages = _convert_images_to_n1_format(completion_messages)
+        completion_messages = _convert_images_to_navigator_format(completion_messages)
 
-        # If there's no screenshot, take one and inject it
-        def _has_any_image(msgs: List[Dict[str, Any]]) -> bool:
-            for m in msgs:
-                content = m.get("content")
-                if isinstance(content, list):
-                    for p in content:
-                        if isinstance(p, dict) and p.get("type") == "image_url":
-                            return True
-            return False
-
-        pre_output_items: List[Dict[str, Any]] = []
-        if not _has_any_image(completion_messages):
+        # Navigator predicts actions from the current screen. If the latest
+        # message carries no screenshot (start of a task, a new user
+        # instruction, or a text-only DOM tool result), take one and inject it
+        # for this request only.
+        if not completion_messages or not _message_has_image(completion_messages[-1]):
             if computer_handler is None or not hasattr(computer_handler, "screenshot"):
                 raise RuntimeError(
-                    "No screenshots present and computer_handler.screenshot is not available."
+                    "No current screenshot and computer_handler.screenshot is not available."
                 )
             screenshot_b64 = await computer_handler.screenshot()
             if not screenshot_b64:
                 raise RuntimeError("Failed to capture screenshot from computer_handler.")
+            if _on_screenshot:
+                await _on_screenshot(screenshot_b64, "screenshot_before")
 
-            converted = _prepare_image_for_n1(screenshot_b64)
+            converted = _prepare_image_for_navigator(screenshot_b64)
             completion_messages.append(
                 {
                     "role": "user",
@@ -269,38 +477,38 @@ class YutoriN1Config(AsyncAgentConfig):
                     ],
                 }
             )
-            pre_output_items.append(
-                {
-                    "type": "message",
-                    "role": "assistant",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "Taking a screenshot to see the current browser screen.",
-                        }
-                    ],
-                }
-            )
 
-        # Build tool list: pass through any custom function tools
-        n1_tools = []
+        # Build tool list: pass through any custom function tools.
+        # Browser tools are injected server-side by the Yutori API.
+        custom_tools = []
+        custom_tool_names = set()
         for tool in tools:
             if tool.get("type") == "function":
                 func = tool.get("function")
                 if func:
-                    n1_tools.append({"type": "function", "function": func})
-            # Skip computer tools — n1 has built-in browser actions
+                    custom_tools.append({"type": "function", "function": func})
+                    if func.get("name"):
+                        custom_tool_names.add(func["name"])
+
+        # Collect Yutori-specific request params into extra_body
+        extra_body = dict(kwargs.pop("extra_body", None) or {})
+        for key in YUTORI_EXTRA_BODY_PARAMS:
+            value = kwargs.pop(key, None)
+            if value is not None:
+                extra_body[key] = value
 
         api_kwargs: Dict[str, Any] = {
             "model": model,
             "messages": completion_messages,
             "max_retries": max_retries,
-            "stream": False,  # n1 does not support streaming
+            "stream": False,  # Navigator models do not support streaming
             "temperature": kwargs.pop("temperature", 0.3),
         }
 
-        if n1_tools:
-            api_kwargs["tools"] = n1_tools
+        if custom_tools:
+            api_kwargs["tools"] = custom_tools
+        if extra_body:
+            api_kwargs["extra_body"] = extra_body
 
         # Pass through remaining kwargs (api_key, api_base, etc.)
         api_kwargs.update({k: v for k, v in kwargs.items()})
@@ -329,7 +537,7 @@ class YutoriN1Config(AsyncAgentConfig):
         message = choice.get("message") or {}
         content_text = message.get("content") or ""
         tool_calls_array = message.get("tool_calls") or []
-        reasoning_text = message.get("reasoning") or ""
+        reasoning_text = message.get("reasoning_content") or message.get("reasoning") or ""
 
         output_items: List[Dict[str, Any]] = []
 
@@ -349,30 +557,58 @@ class YutoriN1Config(AsyncAgentConfig):
                 except json.JSONDecodeError:
                     args = {}
 
-                # Try converting to a computer action
-                computer_action = _convert_n1_action_to_computer_action(
-                    fn_name, args, screen_width, screen_height
+                # Expanded tool set DOM tools are executed inline; emitting the
+                # call and its output together makes the agent skip re-execution.
+                # A user-provided function tool with the same name wins.
+                if fn_name in DOM_TOOL_NAMES and fn_name not in custom_tool_names:
+                    dom_result = await _execute_dom_tool(computer_handler, fn_name, args)
+                    output_items.append(make_function_call_item(fn_name, args, call_id=tc_id))
+                    output_items.append(
+                        {
+                            "type": "function_call_output",
+                            "call_id": tc_id,
+                            "output": dom_result,
+                        }
+                    )
+                    continue
+
+                # Resolve a DOM element ref to pixel coordinates when present;
+                # fall back to the action's normalized coordinates.
+                ref_pixels = None
+                ref = args.get("ref")
+                if ref and computer_handler is not None:
+                    ref_pixels = await _resolve_ref(computer_handler, ref)
+
+                computer_actions = _convert_navigator_action(
+                    fn_name, args, screen_width, screen_height, ref_pixels=ref_pixels
                 )
 
-                if computer_action is not None:
-                    # Build a fake completion message for the converter
-                    fake_cm = {
-                        "role": "assistant",
-                        "content": content_text or "",
-                        "tool_calls": [
-                            {
-                                "type": "function",
-                                "id": tc_id,
-                                "function": {
-                                    "name": "computer",
-                                    "arguments": json.dumps(computer_action),
-                                },
-                            }
-                        ],
-                    }
-                    output_items.extend(convert_completion_messages_to_responses_items([fake_cm]))
-                    # Only use content_text once
-                    content_text = ""
+                if computer_actions:
+                    for i, computer_action in enumerate(computer_actions):
+                        # A single Navigator tool call (e.g. the key sequence
+                        # "down down enter") may expand into several actions;
+                        # each needs a unique call_id.
+                        call_id = tc_id if i == 0 else f"{tc_id}-{i}"
+                        # Build a fake completion message for the converter
+                        fake_cm = {
+                            "role": "assistant",
+                            "content": content_text or "",
+                            "tool_calls": [
+                                {
+                                    "type": "function",
+                                    "id": call_id,
+                                    "function": {
+                                        "name": "computer",
+                                        "arguments": json.dumps(computer_action),
+                                    },
+                                }
+                            ],
+                        }
+                        output_items.extend(
+                            convert_completion_messages_to_responses_items([fake_cm])
+                        )
+                        # Only use content_text once
+                        content_text = ""
                 else:
                     # Custom tool — emit as function_call
                     output_items.append(make_function_call_item(fn_name, args, call_id=tc_id))
@@ -383,13 +619,13 @@ class YutoriN1Config(AsyncAgentConfig):
             else:
                 output_items.append(make_output_text_item("Task completed."))
 
-        return {"output": (pre_output_items + output_items), "usage": usage}
+        return {"output": output_items, "usage": usage}
 
     async def predict_click(
         self, model: str, image_b64: str, instruction: str, **kwargs
     ) -> Optional[Tuple[int, int]]:
         raise NotImplementedError(
-            "Yutori n1 does not support standalone click prediction. "
+            "Yutori Navigator models do not support standalone click prediction. "
             "Use predict_step for full browser automation."
         )
 

--- a/libs/python/agent/cua_agent/loops/yutori_js/__init__.py
+++ b/libs/python/agent/cua_agent/loops/yutori_js/__init__.py
@@ -1,0 +1,64 @@
+"""Bundled JS implementations of the Yutori Navigator n1.5 expanded browser tools.
+
+These scripts are vendored verbatim from the Apache-2.0 licensed Yutori Python
+SDK (https://github.com/yutori-ai/yutori-sdk-python, yutori/navigator/tools/js/).
+Each file contains a single JS function expression; build_tool_expression wraps
+it in an IIFE call with JSON-serialized arguments suitable for page.evaluate().
+"""
+
+from __future__ import annotations
+
+import json
+from importlib.resources import files
+from typing import Any, Dict
+
+
+def _load_script(name: str) -> str:
+    return (files(__package__) / name).read_text(encoding="utf-8")
+
+
+EXECUTE_JS_SCRIPT = _load_script("execute_js.js")
+EXTRACT_ELEMENTS_SCRIPT = _load_script("extract_elements.js")
+FIND_SCRIPT = _load_script("find.js")
+GET_ELEMENT_BY_REF_SCRIPT = _load_script("get_element_by_ref.js")
+SET_ELEMENT_VALUE_SCRIPT = _load_script("set_element_value.js")
+
+
+def build_tool_expression(script: str, *args: Any) -> str:
+    """Wrap a tool script in an IIFE call with JSON-serialized arguments."""
+    escaped_args = ", ".join(json.dumps(arg) for arg in args)
+    return f"({script})({escaped_args})"
+
+
+def coerce_result(raw: Any) -> Dict[str, Any]:
+    """Normalize a page.evaluate() result into a consistent dict.
+
+    - None -> {"success": False, "message": "Script returned no result"}
+    - dict -> passed through unchanged
+    - JSON string that parses to a dict -> that dict
+    - anything else -> {"value": raw}
+    """
+    if raw is None:
+        return {"success": False, "message": "Script returned no result"}
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return {"value": raw}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"value": parsed}
+    return {"value": raw}
+
+
+__all__ = [
+    "EXECUTE_JS_SCRIPT",
+    "EXTRACT_ELEMENTS_SCRIPT",
+    "FIND_SCRIPT",
+    "GET_ELEMENT_BY_REF_SCRIPT",
+    "SET_ELEMENT_VALUE_SCRIPT",
+    "build_tool_expression",
+    "coerce_result",
+]

--- a/libs/python/agent/cua_agent/loops/yutori_js/execute_js.js
+++ b/libs/python/agent/cua_agent/loops/yutori_js/execute_js.js
@@ -1,0 +1,52 @@
+(async function (source) {
+  try {
+    var AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
+    // Try expression-style first (e.g. "document.title", "2 + 2") by wrapping
+    // in "return (...)".  If that fails to parse, fall back to body-style
+    // (e.g. multi-statement code with its own return).
+    var fn;
+    try {
+      fn = new AsyncFunction("return (" + source + ")");
+    } catch (e) {
+      fn = new AsyncFunction(source);
+    }
+
+    var value = await fn();
+
+    if (value === undefined) {
+      return {
+        success: true,
+        hasResult: false,
+        result: null,
+      };
+    }
+
+    if (typeof value === "string") {
+      return {
+        success: true,
+        hasResult: true,
+        result: value,
+      };
+    }
+
+    try {
+      return {
+        success: true,
+        hasResult: true,
+        result: JSON.stringify(value),
+      };
+    } catch (error) {
+      return {
+        success: true,
+        hasResult: true,
+        result: String(value),
+      };
+    }
+  } catch (error) {
+    return {
+      success: false,
+      message: "Error executing JavaScript: " + (error.message || "Unknown error"),
+    };
+  }
+})

--- a/libs/python/agent/cua_agent/loops/yutori_js/extract_elements.js
+++ b/libs/python/agent/cua_agent/loops/yutori_js/extract_elements.js
@@ -1,0 +1,377 @@
+(function (filterType) {
+  var MAX_DEPTH = 15;
+  var SKIPPED_TAGS = {
+    script: true,
+    style: true,
+    meta: true,
+    link: true,
+    title: true,
+    noscript: true,
+  };
+  var INTERACTIVE_TAGS = {
+    a: true,
+    button: true,
+    input: true,
+    select: true,
+    textarea: true,
+    details: true,
+    summary: true,
+  };
+  var SEMANTIC_TAGS = {
+    h1: true,
+    h2: true,
+    h3: true,
+    h4: true,
+    h5: true,
+    h6: true,
+    nav: true,
+    main: true,
+    header: true,
+    footer: true,
+    section: true,
+    article: true,
+    aside: true,
+  };
+  var FUNCTIONAL_KEYWORDS = ["search", "dropdown", "menu", "modal", "dialog", "popup", "toolbar", "sidebar", "content", "text"];
+
+  // Keep a stable ref for each live element so later actions can target the same node.
+  function ensureStore() {
+    if (!window.__yutoriElementRefs) {
+      window.__yutoriElementRefs = {};
+    }
+    if (!window.__yutoriElementIds) {
+      window.__yutoriElementIds = new WeakMap();
+    }
+    if (!window.__yutoriRefCounter) {
+      window.__yutoriRefCounter = 0;
+    }
+  }
+
+  function compactWhitespace(value) {
+    return value ? value.replace(/\s+/g, " ").trim() : "";
+  }
+
+  function readDirectText(element) {
+    var chunks = [];
+    for (var i = 0; i < element.childNodes.length; i++) {
+      var node = element.childNodes[i];
+      if (node.nodeType === Node.TEXT_NODE && node.textContent) {
+        chunks.push(node.textContent);
+      }
+    }
+    return compactWhitespace(chunks.join(" "));
+  }
+
+  function getRole(element) {
+    var explicitRole = element.getAttribute("role");
+    if (explicitRole) {
+      return explicitRole;
+    }
+
+    var tag = element.tagName.toLowerCase();
+    if (tag === "input") {
+      var type = (element.getAttribute("type") || "").toLowerCase();
+      if (type === "submit" || type === "button" || type === "file") {
+        return "button";
+      }
+      if (type === "checkbox") {
+        return "checkbox";
+      }
+      if (type === "radio") {
+        return "radio";
+      }
+      return "textbox";
+    }
+
+    var tagRoles = {
+      a: "link",
+      button: "button",
+      select: "combobox",
+      textarea: "textbox",
+      h1: "heading",
+      h2: "heading",
+      h3: "heading",
+      h4: "heading",
+      h5: "heading",
+      h6: "heading",
+      img: "image",
+      nav: "navigation",
+      main: "main",
+      header: "banner",
+      footer: "contentinfo",
+      section: "region",
+      article: "article",
+      aside: "complementary",
+      form: "form",
+      table: "table",
+      ul: "list",
+      ol: "list",
+      li: "listitem",
+      label: "label",
+    };
+
+    return tagRoles[tag] || "generic";
+  }
+
+  function getName(element) {
+    var tag = element.tagName.toLowerCase();
+    var candidate = "";
+
+    if (tag === "select") {
+      var selectedOption = element.options[element.selectedIndex] || element.querySelector("option[selected]");
+      if (selectedOption && selectedOption.textContent) {
+        candidate = compactWhitespace(selectedOption.textContent);
+        if (candidate) {
+          return candidate;
+        }
+      }
+    }
+
+    var attributeNames = ["aria-label", "placeholder", "title", "alt"];
+    for (var i = 0; i < attributeNames.length; i++) {
+      candidate = compactWhitespace(element.getAttribute(attributeNames[i]) || "");
+      if (candidate) {
+        return candidate;
+      }
+    }
+
+    if (element.id) {
+      var label = document.querySelector('label[for="' + element.id.replace(/"/g, '\\"') + '"]');
+      candidate = label && label.textContent ? compactWhitespace(label.textContent) : "";
+      if (candidate) {
+        return candidate;
+      }
+    }
+
+    if (tag === "input") {
+      var type = (element.getAttribute("type") || "").toLowerCase();
+      var rawValue = compactWhitespace(element.getAttribute("value") || "");
+      if (type === "submit" && rawValue) {
+        return rawValue;
+      }
+
+      candidate = compactWhitespace(element.value || "");
+      if (candidate && candidate.length < 50) {
+        return candidate;
+      }
+    }
+
+    if (tag === "button" || tag === "a" || tag === "summary") {
+      candidate = readDirectText(element);
+      if (candidate) {
+        return candidate;
+      }
+    }
+
+    if (/^h[1-6]$/.test(tag)) {
+      candidate = compactWhitespace(element.textContent || "");
+      if (candidate) {
+        return candidate.slice(0, 100);
+      }
+    }
+
+    if (tag === "img") {
+      var src = element.getAttribute("src") || "";
+      if (src) {
+        var filename = src.split("/").pop() || "";
+        filename = filename.split("?")[0];
+        return "Image: " + filename;
+      }
+    }
+
+    candidate = readDirectText(element);
+    if (candidate && candidate.length >= 3) {
+      return candidate.length > 50 ? candidate.slice(0, 50) + "..." : candidate;
+    }
+
+    return "";
+  }
+
+  function isVisible(element) {
+    var style = window.getComputedStyle(element);
+    return (
+      style.display !== "none" &&
+      style.visibility !== "hidden" &&
+      style.opacity !== "0" &&
+      element.offsetWidth > 0 &&
+      element.offsetHeight > 0
+    );
+  }
+
+  function isInViewport(element) {
+    var rect = element.getBoundingClientRect();
+    return rect.top < window.innerHeight && rect.bottom > 0 && rect.left < window.innerWidth && rect.right > 0;
+  }
+
+  function isInteractive(element) {
+    var role = element.getAttribute("role");
+    var tag = element.tagName.toLowerCase();
+    return (
+      INTERACTIVE_TAGS[tag] === true ||
+      element.getAttribute("onclick") !== null ||
+      element.getAttribute("tabindex") !== null ||
+      role === "button" ||
+      role === "link" ||
+      element.getAttribute("contenteditable") === "true"
+    );
+  }
+
+  function isSemantic(element) {
+    return SEMANTIC_TAGS[element.tagName.toLowerCase()] === true || element.getAttribute("role") !== null;
+  }
+
+  function isContainer(element) {
+    var role = element.getAttribute("role") || "";
+    var tag = element.tagName.toLowerCase();
+    var id = (element.id || "").toLowerCase();
+    var className = compactWhitespace(typeof element.className === "string" ? element.className : "").toLowerCase();
+
+    if (
+      role === "search" ||
+      role === "form" ||
+      role === "group" ||
+      role === "toolbar" ||
+      role === "navigation" ||
+      tag === "form" ||
+      tag === "fieldset" ||
+      tag === "nav"
+    ) {
+      return true;
+    }
+
+    for (var i = 0; i < FUNCTIONAL_KEYWORDS.length; i++) {
+      var keyword = FUNCTIONAL_KEYWORDS[i];
+      if (id.indexOf(keyword) !== -1 || className.indexOf(keyword) !== -1) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  function shouldInclude(element) {
+    var tag = element.tagName.toLowerCase();
+    if (SKIPPED_TAGS[tag] || element.getAttribute("aria-hidden") === "true") {
+      return false;
+    }
+    if (!isVisible(element)) {
+      return false;
+    }
+    if (filterType !== "all" && !isInViewport(element)) {
+      return false;
+    }
+    if (filterType === "interactive") {
+      return isInteractive(element);
+    }
+    if (isInteractive(element) || isSemantic(element)) {
+      return true;
+    }
+
+    var cleanName = getName(element);
+    if (cleanName) {
+      return true;
+    }
+
+    if (getRole(element) === "generic" && (tag === "div" || tag === "span")) {
+      return isContainer(element);
+    }
+
+    return isContainer(element);
+  }
+
+  function getOrCreateRef(element) {
+    var existingRef = window.__yutoriElementIds.get(element);
+    if (existingRef && window.__yutoriElementRefs[existingRef] && window.__yutoriElementRefs[existingRef].deref() === element) {
+      return existingRef;
+    }
+
+    var ref = "ref_" + ++window.__yutoriRefCounter;
+    window.__yutoriElementIds.set(element, ref);
+    window.__yutoriElementRefs[ref] = new WeakRef(element);
+    return ref;
+  }
+
+  function quoteAttribute(value) {
+    return String(value)
+      .replace(/\\/g, "\\\\")
+      .replace(/\r/g, " ")
+      .replace(/\n/g, " ")
+      .replace(/\t/g, " ")
+      .replace(/"/g, '\\"');
+  }
+
+  function formatLine(element, depth) {
+    var role = getRole(element);
+    var name = getName(element);
+    var line = new Array(depth + 1).join("  ") + "- " + role;
+
+    if (name) {
+      line += ' "' + quoteAttribute(compactWhitespace(name).slice(0, 100)) + '"';
+    }
+
+    line += " [ref=" + getOrCreateRef(element) + "]";
+
+    if (element.id) {
+      line += ' id="' + quoteAttribute(element.id) + '"';
+    }
+    if (element.getAttribute("href")) {
+      line += ' href="' + quoteAttribute(element.getAttribute("href")) + '"';
+    }
+    if (element.getAttribute("type")) {
+      line += ' type="' + quoteAttribute(element.getAttribute("type")) + '"';
+    }
+    if (element.getAttribute("placeholder")) {
+      line += ' placeholder="' + quoteAttribute(element.getAttribute("placeholder")) + '"';
+    }
+
+    return line;
+  }
+
+  function walk(element, depth, output) {
+    if (!element || !element.tagName || depth > MAX_DEPTH) {
+      return;
+    }
+
+    var includeHere = depth === 0 || shouldInclude(element);
+    if (includeHere) {
+      output.push(formatLine(element, depth));
+    }
+
+    if (!element.children || depth >= MAX_DEPTH) {
+      return;
+    }
+
+    // Preserve the current indentation level when skipping a purely structural node.
+    var childDepth = includeHere ? depth + 1 : depth;
+    for (var i = 0; i < element.children.length; i++) {
+      walk(element.children[i], childDepth, output);
+    }
+  }
+
+  function pruneDeadRefs() {
+    // WeakRefs may outlive detached nodes in the map until we sweep them explicitly.
+    for (var ref in window.__yutoriElementRefs) {
+      if (!window.__yutoriElementRefs[ref].deref()) {
+        delete window.__yutoriElementRefs[ref];
+      }
+    }
+  }
+
+  ensureStore();
+
+  var lines = [];
+  if (document.body) {
+    walk(document.body, 0, lines);
+  }
+  pruneDeadRefs();
+
+  var filteredLines = lines.filter(function (line) {
+    return !/^\s*- generic \[ref=ref_\d+\]$/.test(line);
+  });
+
+  return {
+    success: true,
+    pageContent: filteredLines.join("\n"),
+    totalLines: filteredLines.length,
+  };
+})

--- a/libs/python/agent/cua_agent/loops/yutori_js/find.js
+++ b/libs/python/agent/cua_agent/loops/yutori_js/find.js
@@ -1,0 +1,193 @@
+(function (rawNeedle) {
+  var MAX_MATCHES = 20;
+  var SKIPPED_TAGS = {
+    html: true,
+    body: true,
+    head: true,
+    script: true,
+    style: true,
+    meta: true,
+    link: true,
+    title: true,
+    noscript: true,
+  };
+
+  function failure(message) {
+    return {
+      success: false,
+      message: message,
+      totalMatches: 0,
+      matches: [],
+      pageContent: "",
+    };
+  }
+
+  function ensureStore() {
+    if (!window.__yutoriElementRefs) {
+      window.__yutoriElementRefs = {};
+    }
+    if (!window.__yutoriElementIds) {
+      window.__yutoriElementIds = new WeakMap();
+    }
+    if (!window.__yutoriRefCounter) {
+      window.__yutoriRefCounter = 0;
+    }
+  }
+
+  function compactWhitespace(value) {
+    return value ? value.replace(/\s+/g, " ").trim() : "";
+  }
+
+  function isVisible(element) {
+    var style = window.getComputedStyle(element);
+    return (
+      style.display !== "none" &&
+      style.visibility !== "hidden" &&
+      style.opacity !== "0" &&
+      element.offsetWidth > 0 &&
+      element.offsetHeight > 0
+    );
+  }
+
+  function getOrCreateRef(element) {
+    var existingRef = window.__yutoriElementIds.get(element);
+    if (existingRef && window.__yutoriElementRefs[existingRef] && window.__yutoriElementRefs[existingRef].deref() === element) {
+      return existingRef;
+    }
+
+    var ref = "ref_" + ++window.__yutoriRefCounter;
+    window.__yutoriElementIds.set(element, ref);
+    window.__yutoriElementRefs[ref] = new WeakRef(element);
+    return ref;
+  }
+
+  function getRole(element) {
+    var explicitRole = element.getAttribute("role");
+    if (explicitRole) {
+      return explicitRole;
+    }
+
+    var tag = element.tagName.toLowerCase();
+    var tagRoles = {
+      a: "link",
+      button: "button",
+      input: "textbox",
+      select: "combobox",
+      textarea: "textbox",
+      h1: "heading",
+      h2: "heading",
+      h3: "heading",
+      h4: "heading",
+      h5: "heading",
+      h6: "heading",
+    };
+
+    return tagRoles[tag] || tag;
+  }
+
+  function getName(element) {
+    var candidates = [
+      element.getAttribute("aria-label"),
+      element.getAttribute("placeholder"),
+      element.getAttribute("title"),
+      element.value,
+      element.textContent,
+    ];
+    for (var i = 0; i < candidates.length; i += 1) {
+      var candidate = compactWhitespace(candidates[i] || "");
+      if (candidate) {
+        return candidate;
+      }
+    }
+    return "";
+  }
+
+  function describe(element) {
+    var role = getRole(element);
+    var name = getName(element);
+    var ref = getOrCreateRef(element);
+    return "- " + role + (name ? ' "' + name.slice(0, 120) + '"' : "") + " [ref=" + ref + "]";
+  }
+
+  function shouldInspect(element) {
+    var tag = element.tagName.toLowerCase();
+    return !SKIPPED_TAGS[tag] && isVisible(element);
+  }
+
+  function scrollIntoView(element) {
+    var htmlElement = document.documentElement;
+    var bodyElement = document.body;
+    var previousHtmlScrollBehavior = htmlElement.style.scrollBehavior;
+    var previousBodyScrollBehavior = bodyElement ? bodyElement.style.scrollBehavior : "";
+    try {
+      htmlElement.style.scrollBehavior = "auto";
+      if (bodyElement) bodyElement.style.scrollBehavior = "auto";
+      element.scrollIntoView({ behavior: "instant", block: "center", inline: "center" });
+      element.offsetHeight;
+    } finally {
+      htmlElement.style.scrollBehavior = previousHtmlScrollBehavior;
+      if (bodyElement) bodyElement.style.scrollBehavior = previousBodyScrollBehavior;
+    }
+  }
+
+  var needle = compactWhitespace(String(rawNeedle || "")).toLowerCase();
+  if (!needle) {
+    return failure("find requires non-empty text");
+  }
+
+  ensureStore();
+
+  var matches = [];
+  var firstMatch = null;
+  var nodes = document.querySelectorAll("*");
+  for (var i = 0; i < nodes.length; i += 1) {
+    var element = nodes[i];
+    if (!shouldInspect(element)) {
+      continue;
+    }
+
+    var haystack = compactWhitespace(
+      [
+        element.textContent || "",
+        element.getAttribute("aria-label") || "",
+        element.getAttribute("placeholder") || "",
+        element.getAttribute("title") || "",
+        element.value || "",
+      ].join(" "),
+    ).toLowerCase();
+
+    if (!haystack.includes(needle)) {
+      continue;
+    }
+
+    if (!firstMatch) {
+      firstMatch = element;
+    }
+    matches.push(describe(element));
+    if (matches.length >= MAX_MATCHES) {
+      break;
+    }
+  }
+
+  if (!matches.length) {
+    return {
+      success: true,
+      totalMatches: 0,
+      matches: [],
+      message: 'No visible matches found for "' + rawNeedle + '".',
+      pageContent: "",
+    };
+  }
+
+  if (firstMatch) {
+    scrollIntoView(firstMatch);
+  }
+
+  return {
+    success: true,
+    totalMatches: matches.length,
+    matches: matches,
+    message: 'Found ' + matches.length + ' visible match' + (matches.length === 1 ? "" : "es") + ' for "' + rawNeedle + '".',
+    pageContent: matches.join("\n"),
+  };
+})

--- a/libs/python/agent/cua_agent/loops/yutori_js/get_element_by_ref.js
+++ b/libs/python/agent/cua_agent/loops/yutori_js/get_element_by_ref.js
@@ -1,0 +1,86 @@
+(function (elementRef) {
+  function failure(message) {
+    return {
+      success: false,
+      action: "get_element_by_ref",
+      message: message,
+    };
+  }
+
+  function getTrackedElement(ref) {
+    if (!window.__yutoriElementRefs || !window.__yutoriElementRefs[ref]) {
+      return null;
+    }
+
+    var weakRef = window.__yutoriElementRefs[ref];
+    var element = weakRef.deref();
+    if (!element || !document.contains(element)) {
+      delete window.__yutoriElementRefs[ref];
+      return null;
+    }
+
+    return element;
+  }
+
+  function isViewportVisible(rect) {
+    var viewportWidth = window.innerWidth || document.documentElement.clientWidth;
+    var viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+    return (
+      rect.top < viewportHeight &&
+      rect.bottom > 0 &&
+      rect.left < viewportWidth &&
+      rect.right > 0 &&
+      rect.width > 0 &&
+      rect.height > 0
+    );
+  }
+
+  function isPointInViewport(x, y) {
+    var viewportWidth = window.innerWidth || document.documentElement.clientWidth;
+    var viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+    return x >= 0 && x <= viewportWidth && y >= 0 && y <= viewportHeight;
+  }
+
+  try {
+    var element = getTrackedElement(elementRef);
+    if (!element) {
+      return failure('No element found with reference: "' + elementRef + '". The element may have been removed from the page.');
+    }
+
+    var beforeScrollRect = element.getBoundingClientRect();
+    var wasVisibleBeforeScroll = isViewportVisible(beforeScrollRect);
+    var centerX = beforeScrollRect.left + beforeScrollRect.width / 2;
+    var centerY = beforeScrollRect.top + beforeScrollRect.height / 2;
+
+    var centerInViewport = isPointInViewport(centerX, centerY);
+
+    // Downstream actions click the element center, so partial visibility is not enough.
+    if (!wasVisibleBeforeScroll || !centerInViewport) {
+      var htmlEl = document.documentElement;
+      var bodyEl = document.body;
+      var prevHtml = htmlEl.style.scrollBehavior;
+      var prevBody = bodyEl ? bodyEl.style.scrollBehavior : "";
+      try {
+        // Some sites force smooth scrolling globally; temporarily disable it so coordinates settle immediately.
+        htmlEl.style.scrollBehavior = "auto";
+        if (bodyEl) bodyEl.style.scrollBehavior = "auto";
+
+        element.scrollIntoView({ behavior: "instant", block: "center", inline: "center" });
+
+        // Force layout so getBoundingClientRect reflects the post-scroll position.
+        element.offsetHeight;
+      } finally {
+        htmlEl.style.scrollBehavior = prevHtml;
+        if (bodyEl) bodyEl.style.scrollBehavior = prevBody;
+      }
+    }
+
+    var rect = element.getBoundingClientRect();
+    return {
+      success: true,
+      coordinates: [rect.left + rect.width / 2, rect.top + rect.height / 2],
+    };
+  } catch (error) {
+    return failure("Error finding element by reference: " + (error.message || "Unknown error"));
+  }
+})

--- a/libs/python/agent/cua_agent/loops/yutori_js/set_element_value.js
+++ b/libs/python/agent/cua_agent/loops/yutori_js/set_element_value.js
@@ -1,0 +1,227 @@
+(function (elementRef, inputValue) {
+  function response(success, payload) {
+    var result = {
+      success: success,
+      action: "set_element_value",
+    };
+    for (var key in payload) {
+      result[key] = payload[key];
+    }
+    return result;
+  }
+
+  function getTrackedElement(ref) {
+    if (!window.__yutoriElementRefs || !window.__yutoriElementRefs[ref]) {
+      return null;
+    }
+
+    var weakRef = window.__yutoriElementRefs[ref];
+    var element = weakRef.deref();
+    if (!element || !document.contains(element)) {
+      delete window.__yutoriElementRefs[ref];
+      return null;
+    }
+
+    return element;
+  }
+
+  function isInViewport(el) {
+    var rect = el.getBoundingClientRect();
+    return rect.top < window.innerHeight && rect.bottom > 0 && rect.left < window.innerWidth && rect.right > 0;
+  }
+
+  function ensureVisible(el) {
+    if (!isInViewport(el)) {
+      var htmlEl = document.documentElement;
+      var bodyEl = document.body;
+      var prevHtml = htmlEl.style.scrollBehavior;
+      var prevBody = bodyEl ? bodyEl.style.scrollBehavior : "";
+      try {
+        // Neutralize page-level smooth scrolling so form interactions happen against stable layout.
+        htmlEl.style.scrollBehavior = "auto";
+        if (bodyEl) bodyEl.style.scrollBehavior = "auto";
+
+        el.scrollIntoView({ behavior: "instant", block: "center", inline: "center" });
+        el.offsetHeight;
+      } finally {
+        htmlEl.style.scrollBehavior = prevHtml;
+        if (bodyEl) bodyEl.style.scrollBehavior = prevBody;
+      }
+    }
+  }
+
+  // Use the native setter to bypass framework interception (React, Vue, etc.)
+  // then dispatch events that frameworks actually listen to.
+  function setNativeValue(el, value) {
+    var prototype = null;
+    if (el instanceof HTMLTextAreaElement) {
+      prototype = HTMLTextAreaElement.prototype;
+    } else if (el instanceof HTMLInputElement) {
+      prototype = HTMLInputElement.prototype;
+    }
+
+    var descriptor = prototype ? Object.getOwnPropertyDescriptor(prototype, "value") : null;
+
+    if (descriptor && descriptor.set) {
+      descriptor.set.call(el, value);
+    } else {
+      el.value = value;
+    }
+  }
+
+  function emitInputEvents(el) {
+    // Only focus if not already focused — avoids unnecessary blur on other fields
+    if (document.activeElement !== el) {
+      el.focus();
+    }
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+  }
+
+  function selectOption(element, rawValue) {
+    var targetValue = String(rawValue);
+
+    for (var i = 0; i < element.options.length; i++) {
+      var option = element.options[i];
+      if (option.value === targetValue || option.text === targetValue) {
+        element.selectedIndex = i;
+        emitInputEvents(element);
+        return response(true, {
+          message: 'Selected option "' + targetValue + '" in dropdown',
+        });
+      }
+    }
+
+    var optionDescriptions = [];
+    for (var j = 0; j < element.options.length; j++) {
+      optionDescriptions.push('"' + element.options[j].text + '" (value: "' + element.options[j].value + '")');
+    }
+
+    return response(false, {
+      message: 'Option "' + targetValue + '" not found. Available options: ' + optionDescriptions.join(", "),
+    });
+  }
+
+  function updateCheckbox(element, rawValue) {
+    if (typeof rawValue !== "boolean" && rawValue !== "true" && rawValue !== "false") {
+      return response(false, {
+        message: "Checkbox requires a boolean value (true/false)",
+      });
+    }
+
+    var desiredState = rawValue === true || rawValue === "true";
+    // Prefer the native click path for toggles so app frameworks observe the change.
+    if (element.checked !== desiredState) {
+      element.click();
+    }
+
+    if (element.checked !== desiredState) {
+      return response(false, {
+        message: "Checkbox state did not change as requested",
+      });
+    }
+
+    return response(true, {
+      message: "Checkbox " + (element.checked ? "checked" : "unchecked"),
+    });
+  }
+
+  function updateRadio(element) {
+    // Radios are best driven through their native interaction path.
+    if (!element.checked) {
+      element.click();
+    }
+
+    if (!element.checked) {
+      return response(false, {
+        message: "Radio button could not be selected",
+      });
+    }
+
+    return response(true, {
+      message: "Radio button selected" + (element.name ? ' in group "' + element.name + '"' : ""),
+    });
+  }
+
+  function updateNumeric(element, kind, rawValue) {
+    var asNumber = Number(rawValue);
+    if (isNaN(asNumber) && !(kind === "number" && rawValue === "")) {
+      return response(false, {
+        message: (kind === "range" ? "Range" : "Number") + " input requires a numeric value",
+      });
+    }
+
+    setNativeValue(element, kind === "range" ? String(asNumber) : String(rawValue));
+    emitInputEvents(element);
+
+    return response(true, {
+      message:
+        kind === "range"
+          ? "Set range to " + element.value + " (min: " + element.min + ", max: " + element.max + ")"
+          : "Set number input to " + element.value,
+    });
+  }
+
+  function updateTextLike(element, elementType, rawValue) {
+    setNativeValue(element, String(rawValue));
+
+    if (typeof element.setSelectionRange === "function") {
+      try {
+        element.setSelectionRange(element.value.length, element.value.length);
+      } catch (e) {
+        // Some input types (email, number) don't support setSelectionRange
+      }
+    }
+
+    emitInputEvents(element);
+
+    return response(true, {
+      message: "Set " + elementType + ' value to "' + element.value + '"',
+    });
+  }
+
+  try {
+    var element = getTrackedElement(elementRef);
+    if (!element) {
+      return response(false, {
+        message: 'No element found with reference: "' + elementRef + '". The element may have been removed from the page.',
+      });
+    }
+
+    ensureVisible(element);
+
+    if (element instanceof HTMLSelectElement) {
+      return selectOption(element, inputValue);
+    }
+
+    if (element instanceof HTMLInputElement) {
+      var type = (element.type || "text").toLowerCase();
+
+      if (type === "checkbox") {
+        return updateCheckbox(element, inputValue);
+      }
+      if (type === "radio") {
+        return updateRadio(element);
+      }
+      if (type === "date" || type === "time" || type === "datetime-local" || type === "month" || type === "week") {
+        return updateTextLike(element, type, inputValue);
+      }
+      if (type === "range" || type === "number") {
+        return updateNumeric(element, type, inputValue);
+      }
+      return updateTextLike(element, type || "text", inputValue);
+    }
+
+    if (element instanceof HTMLTextAreaElement) {
+      return updateTextLike(element, "textarea", inputValue);
+    }
+
+    return response(false, {
+      message: 'Element type "' + element.tagName + '" is not a supported form input',
+    });
+  } catch (error) {
+    return response(false, {
+      message: "Error setting element value: " + (error.message || "Unknown error"),
+    });
+  }
+})

--- a/libs/python/agent/cua_agent/loops/yutori_n2.py
+++ b/libs/python/agent/cua_agent/loops/yutori_n2.py
@@ -248,10 +248,12 @@ def _coordinate(value: Any, path: str) -> Tuple[int, int]:
 
 
 def _native_point(value: Any, path: str, width: int, height: int) -> Tuple[int, int]:
+    if width <= 0 or height <= 0:
+        raise N2ActionValidationError("native screenshot dimensions must be positive")
     x, y = _coordinate(value, path)
     return (
-        round((x / N2_COORDINATE_SCALE) * width),
-        round((y / N2_COORDINATE_SCALE) * height),
+        min(width - 1, round((x / N2_COORDINATE_SCALE) * width)),
+        min(height - 1, round((y / N2_COORDINATE_SCALE) * height)),
     )
 
 

--- a/libs/python/agent/cua_agent/loops/yutori_n2.py
+++ b/libs/python/agent/cua_agent/loops/yutori_n2.py
@@ -1,0 +1,621 @@
+"""Yutori Navigator n2-preview computer-use loop.
+
+The Yutori API injects its versioned computer-use tools server-side. This loop
+keeps the public Chat Completions tool-call/result shape intact while attaching
+validated, executor-only actions to each internal function-call item.
+"""
+
+from __future__ import annotations
+
+import base64
+import copy
+import io
+import json
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import litellm
+from litellm.responses.litellm_completion_transformation.transformation import (
+    LiteLLMCompletionResponsesConfig,
+)
+from PIL import Image
+
+from ..decorators import register_agent
+from ..loops.base import AsyncAgentConfig
+from ..responses import (
+    convert_responses_items_to_completion_messages,
+    make_function_call_item,
+    make_output_text_item,
+    make_reasoning_item,
+)
+from ..types import AgentCapability
+
+N2_COORDINATE_SCALE = 1000
+N2_MODEL_IMAGE_MAX_WIDTH = 1280
+N2_MODEL_IMAGE_MAX_HEIGHT = 800
+N2_MODEL_IMAGE_QUALITY = 75
+N2_MAX_BATCH_ACTIONS = 20
+N2_MAX_WAIT_SECONDS = 10
+
+MAX_REQUEST_BODY_BYTES = 10_000_000
+REQUEST_ENVELOPE_ALLOWANCE_BYTES = 500_000
+DEFAULT_MAX_MESSAGES_BYTES = MAX_REQUEST_BODY_BYTES - REQUEST_ENVELOPE_ALLOWANCE_BYTES
+
+TOOL_SET_COMPUTER_USE = "computer_use_tools-20260708"
+TOOL_SET_COMPUTER_USE_BATCH = "computer_use_tools-20260716"
+_SUPPORTED_TOOL_SETS = {TOOL_SET_COMPUTER_USE, TOOL_SET_COMPUTER_USE_BATCH}
+
+_SAFE_WITHOUT_CONFIRMATION = {"screenshot", "wait", "mouse_move", "scroll"}
+
+_PUNCTUATION_KEYS = {
+    "minus": "-",
+    "plus": "+",
+    "equal": "=",
+    "comma": ",",
+    "period": ".",
+    "slash": "/",
+    "backslash": "\\",
+    "semicolon": ";",
+    "quote": "'",
+    "backquote": "`",
+    "bracketleft": "[",
+    "bracketright": "]",
+}
+
+_KEY_ALIASES = {
+    "meta": "cmd",
+    "command": "cmd",
+    "super": "cmd",
+    "win": "cmd",
+    "control": "ctrl",
+    "escape": "esc",
+    "pageup": "page_up",
+    "pagedown": "page_down",
+    "return": "enter",
+    **_PUNCTUATION_KEYS,
+}
+
+_NAMED_KEYS = {
+    "ctrl",
+    "shift",
+    "alt",
+    "cmd",
+    "enter",
+    "esc",
+    "tab",
+    "space",
+    "backspace",
+    "delete",
+    "up",
+    "down",
+    "left",
+    "right",
+    "home",
+    "end",
+    "page_up",
+    "page_down",
+    *{f"f{i}" for i in range(1, 13)},
+}
+
+_ACTION_FIELDS = {
+    "left_click": {"coordinates"},
+    "double_click": {"coordinates"},
+    "triple_click": {"coordinates"},
+    "middle_click": {"coordinates"},
+    "right_click": {"coordinates"},
+    "mouse_move": {"coordinates"},
+    "drag": {"start_coordinates", "coordinates"},
+    "scroll": {"coordinates", "direction", "amount"},
+    "type": {"text"},
+    "key_press": {"key"},
+    "wait": {"duration"},
+    "screenshot": set(),
+}
+
+
+class N2ActionValidationError(ValueError):
+    """Raised when an n2 action cannot be safely executed."""
+
+
+def _map_key_token(token: str) -> str:
+    token = token.strip().lower()
+    if not token:
+        raise N2ActionValidationError("key expressions cannot contain empty keys")
+    if len(token) == 1:
+        return token
+    mapped = _KEY_ALIASES.get(token, token)
+    if mapped not in _NAMED_KEYS and mapped not in _PUNCTUATION_KEYS.values():
+        raise N2ActionValidationError(f"unknown key name: {token}")
+    return mapped
+
+
+def parse_n2_key_expression(expression: str) -> List[List[str]]:
+    """Parse Yutori's ``+`` combo and space-separated sequence grammar."""
+    if not isinstance(expression, str) or not expression.strip():
+        raise N2ActionValidationError("key must be a non-empty string")
+    sequence: List[List[str]] = []
+    for raw_combo in expression.split():
+        raw_keys = raw_combo.split("+")
+        if any(not key.strip() for key in raw_keys):
+            raise N2ActionValidationError(f"invalid key combination: {raw_combo}")
+        sequence.append([_map_key_token(key) for key in raw_keys])
+    return sequence
+
+
+def _decode_data_url(url: str) -> Tuple[bytes, str]:
+    if not isinstance(url, str) or not url.startswith("data:") or "," not in url:
+        raise ValueError("n2 screenshots must be base64 data URLs")
+    header, encoded = url.split(",", 1)
+    if ";base64" not in header:
+        raise ValueError("n2 screenshots must use base64 data URLs")
+    return base64.b64decode(encoded), header[5:].split(";", 1)[0]
+
+
+def _image_dimensions(url: str) -> Tuple[int, int]:
+    image_bytes, _ = _decode_data_url(url)
+    with Image.open(io.BytesIO(image_bytes)) as image:
+        return image.size
+
+
+def prepare_n2_image_data_url(url: str) -> str:
+    """Return a full-frame, aspect-preserving JPEG bounded by 1280x800."""
+    image_bytes, _ = _decode_data_url(url)
+    with Image.open(io.BytesIO(image_bytes)) as source:
+        image = source.convert("RGB")
+        image.thumbnail(
+            (N2_MODEL_IMAGE_MAX_WIDTH, N2_MODEL_IMAGE_MAX_HEIGHT),
+            Image.Resampling.LANCZOS,
+        )
+        output = io.BytesIO()
+        image.save(output, format="JPEG", quality=N2_MODEL_IMAGE_QUALITY)
+    return f"data:image/jpeg;base64,{base64.b64encode(output.getvalue()).decode('ascii')}"
+
+
+def _message_image_parts(message: Dict[str, Any]) -> List[Dict[str, Any]]:
+    content = message.get("content")
+    if not isinstance(content, list):
+        return []
+    return [part for part in content if isinstance(part, dict) and part.get("type") == "image_url"]
+
+
+def _latest_image_url(messages: List[Dict[str, Any]]) -> Optional[str]:
+    for message in reversed(messages):
+        for part in reversed(_message_image_parts(message)):
+            image_url = part.get("image_url")
+            if isinstance(image_url, dict) and isinstance(image_url.get("url"), str):
+                return image_url["url"]
+    return None
+
+
+def _strip_images_from_message(message: Dict[str, Any]) -> None:
+    content = message.get("content")
+    if not isinstance(content, list):
+        return
+    message["content"] = [
+        part for part in content if not (isinstance(part, dict) and part.get("type") == "image_url")
+    ]
+
+
+def _serialized_messages_bytes(messages: List[Dict[str, Any]]) -> int:
+    return len(json.dumps(messages, separators=(",", ":"), ensure_ascii=False).encode("utf-8"))
+
+
+def retain_n2_request_images(
+    messages: List[Dict[str, Any]],
+    max_messages_bytes: int = DEFAULT_MAX_MESSAGES_BYTES,
+) -> List[Dict[str, Any]]:
+    """Return a request-local copy with images in at most two newest image messages."""
+    request_messages = copy.deepcopy(messages)
+    image_indices = [
+        index for index, message in enumerate(request_messages) if _message_image_parts(message)
+    ]
+    for index in image_indices[:-2]:
+        _strip_images_from_message(request_messages[index])
+
+    if _serialized_messages_bytes(request_messages) <= max_messages_bytes:
+        return request_messages
+
+    retained_indices = image_indices[-2:]
+    if len(retained_indices) == 2:
+        _strip_images_from_message(request_messages[retained_indices[0]])
+    if _serialized_messages_bytes(request_messages) <= max_messages_bytes:
+        return request_messages
+
+    raise ValueError(
+        "The newest n2 screenshot message cannot fit within the serialized messages budget. "
+        "Reduce screenshot dimensions/quality or shorten non-image request content."
+    )
+
+
+def _convert_request_images(messages: List[Dict[str, Any]]) -> None:
+    for message in messages:
+        for part in _message_image_parts(message):
+            image_url = part.get("image_url")
+            if not isinstance(image_url, dict) or not isinstance(image_url.get("url"), str):
+                raise ValueError("n2 image_url content must contain a string url")
+            image_url["url"] = prepare_n2_image_data_url(image_url["url"])
+
+
+def _coordinate(value: Any, path: str) -> Tuple[int, int]:
+    if (
+        not isinstance(value, (list, tuple))
+        or len(value) != 2
+        or any(isinstance(component, bool) or not isinstance(component, int) for component in value)
+        or any(component < 0 or component > N2_COORDINATE_SCALE for component in value)
+    ):
+        raise N2ActionValidationError(f"{path} must be two integers in the inclusive 0-1000 range")
+    return int(value[0]), int(value[1])
+
+
+def _native_point(value: Any, path: str, width: int, height: int) -> Tuple[int, int]:
+    x, y = _coordinate(value, path)
+    return (
+        round((x / N2_COORDINATE_SCALE) * width),
+        round((y / N2_COORDINATE_SCALE) * height),
+    )
+
+
+def _validate_fields(action: str, args: Dict[str, Any]) -> None:
+    if action not in _ACTION_FIELDS:
+        raise N2ActionValidationError(f"unsupported n2 action: {action}")
+    unknown = set(args) - _ACTION_FIELDS[action]
+    if unknown:
+        raise N2ActionValidationError(
+            f"{action} received unsupported field(s): {', '.join(sorted(unknown))}"
+        )
+
+
+def translate_n2_action(
+    action: str,
+    args: Dict[str, Any],
+    native_width: int,
+    native_height: int,
+    *,
+    batch_index: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Strictly validate and translate one Yutori action to Cua handler calls."""
+    if not isinstance(args, dict):
+        raise N2ActionValidationError(f"{action} arguments must be an object")
+    _validate_fields(action, args)
+
+    def internal(action_type: str, **kwargs: Any) -> Dict[str, Any]:
+        result = {"type": action_type, **kwargs}
+        if batch_index is not None:
+            result["batch_index"] = batch_index
+        return result
+
+    if action in {
+        "left_click",
+        "double_click",
+        "triple_click",
+        "middle_click",
+        "right_click",
+        "mouse_move",
+    }:
+        x, y = _native_point(
+            args.get("coordinates"), f"{action}.coordinates", native_width, native_height
+        )
+        if action == "left_click":
+            return [internal("click", x=x, y=y, button="left")]
+        if action == "right_click":
+            return [internal("click", x=x, y=y, button="right")]
+        if action == "middle_click":
+            return [internal("click", x=x, y=y, button="middle")]
+        if action == "double_click":
+            return [internal("double_click", x=x, y=y)]
+        if action == "triple_click":
+            return [
+                internal("double_click", x=x, y=y),
+                internal("click", x=x, y=y, button="left"),
+            ]
+        return [internal("move", x=x, y=y)]
+
+    if action == "drag":
+        start_x, start_y = _native_point(
+            args.get("start_coordinates"),
+            "drag.start_coordinates",
+            native_width,
+            native_height,
+        )
+        end_x, end_y = _native_point(
+            args.get("coordinates"), "drag.coordinates", native_width, native_height
+        )
+        return [
+            internal(
+                "drag",
+                path=[{"x": start_x, "y": start_y}, {"x": end_x, "y": end_y}],
+            )
+        ]
+
+    if action == "scroll":
+        x, y = _native_point(
+            args.get("coordinates"), "scroll.coordinates", native_width, native_height
+        )
+        direction = args.get("direction")
+        if direction not in {"up", "down", "left", "right"}:
+            raise N2ActionValidationError("scroll.direction must be up, down, left, or right")
+        amount = args.get("amount")
+        if isinstance(amount, bool) or not isinstance(amount, int):
+            raise N2ActionValidationError("scroll.amount must be an integer")
+        scroll_x = scroll_y = 0
+        if direction in {"left", "right"}:
+            scroll_x = round(amount * native_width * 0.1) * (1 if direction == "right" else -1)
+        else:
+            scroll_y = round(amount * native_height * 0.1) * (1 if direction == "down" else -1)
+        return [internal("scroll", x=x, y=y, scroll_x=scroll_x, scroll_y=scroll_y)]
+
+    if action == "type":
+        text = args.get("text")
+        if not isinstance(text, str):
+            raise N2ActionValidationError("type.text must be a string")
+        return [internal("type", text=text)]
+
+    if action == "key_press":
+        return [
+            internal("keypress", keys=keys) for keys in parse_n2_key_expression(args.get("key"))
+        ]
+
+    if action == "wait":
+        duration = args.get("duration", 1)
+        if (
+            isinstance(duration, bool)
+            or not isinstance(duration, (int, float))
+            or not 0 <= duration <= N2_MAX_WAIT_SECONDS
+        ):
+            raise N2ActionValidationError(
+                f"wait.duration must be between 0 and {N2_MAX_WAIT_SECONDS} seconds"
+            )
+        return [internal("wait", ms=round(float(duration) * 1000))]
+
+    if action == "screenshot":
+        return [internal("screenshot")]
+
+    raise N2ActionValidationError(f"unsupported n2 action: {action}")
+
+
+def translate_n2_batch(
+    args: Dict[str, Any], native_width: int, native_height: int
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Validate a complete batch before returning any executable actions."""
+    if not isinstance(args, dict) or set(args) != {"actions"}:
+        raise N2ActionValidationError("computer_batch requires exactly one actions field")
+    raw_actions = args.get("actions")
+    if not isinstance(raw_actions, list) or not 1 <= len(raw_actions) <= N2_MAX_BATCH_ACTIONS:
+        raise N2ActionValidationError(
+            f"computer_batch.actions must contain 1-{N2_MAX_BATCH_ACTIONS} actions"
+        )
+
+    translated: List[Dict[str, Any]] = []
+    validated: List[Dict[str, Any]] = []
+    for index, raw_action in enumerate(raw_actions):
+        if not isinstance(raw_action, dict):
+            raise N2ActionValidationError(f"computer_batch.actions[{index}] must be an object")
+        action = raw_action.get("action")
+        if not isinstance(action, str):
+            raise N2ActionValidationError(f"computer_batch.actions[{index}].action is required")
+        if action == "screenshot":
+            raise N2ActionValidationError("screenshot is not allowed inside computer_batch")
+        member_args = {key: value for key, value in raw_action.items() if key != "action"}
+        translated.extend(
+            translate_n2_action(
+                action,
+                member_args,
+                native_width,
+                native_height,
+                batch_index=index,
+            )
+        )
+        validated.append(copy.deepcopy(raw_action))
+    return validated, translated
+
+
+def _function_call_with_execution(
+    name: str,
+    args: Dict[str, Any],
+    call_id: str,
+    actions: List[Dict[str, Any]],
+    *,
+    batch_actions: Optional[List[Dict[str, Any]]] = None,
+    execution_deadline: Optional[float] = None,
+) -> Dict[str, Any]:
+    item = dict(make_function_call_item(name, args, call_id=call_id))
+    item["_computer_actions"] = actions
+    item["_requires_confirmation"] = (
+        any(action.get("action") not in _SAFE_WITHOUT_CONFIRMATION for action in batch_actions)
+        if batch_actions is not None
+        else name not in _SAFE_WITHOUT_CONFIRMATION
+    )
+    if batch_actions is not None:
+        item["_batch_actions"] = batch_actions
+    if execution_deadline is not None:
+        item["_execution_deadline"] = execution_deadline
+    return item
+
+
+def _request_body_bytes(api_kwargs: Dict[str, Any]) -> int:
+    body_fields = {
+        key: value
+        for key, value in api_kwargs.items()
+        if key
+        not in {
+            "api_key",
+            "api_base",
+            "extra_headers",
+            "headers",
+            "max_retries",
+        }
+    }
+    extra_body = body_fields.pop("extra_body", None)
+    if isinstance(extra_body, dict):
+        body_fields.update(extra_body)
+    return len(json.dumps(body_fields, separators=(",", ":"), ensure_ascii=False).encode("utf-8"))
+
+
+@register_agent(models=r"^(yutori/)?n2-preview$", tool_type="computer", priority=10)
+class YutoriN2Config(AsyncAgentConfig):
+    """Yutori n2-preview desktop computer-use loop."""
+
+    async def predict_step(
+        self,
+        messages: List[Dict[str, Any]],
+        model: str,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        max_retries: Optional[int] = None,
+        stream: bool = False,
+        computer_handler=None,
+        use_prompt_caching: Optional[bool] = False,
+        _on_api_start=None,
+        _on_api_end=None,
+        _on_usage=None,
+        _on_screenshot=None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        del tools, stream, use_prompt_caching
+
+        completion_messages = convert_responses_items_to_completion_messages(
+            copy.deepcopy(messages), allow_images_in_tool_results=True
+        )
+
+        latest_url = _latest_image_url(completion_messages)
+        if latest_url is None:
+            if computer_handler is None or not hasattr(computer_handler, "screenshot"):
+                raise RuntimeError(
+                    "No current screenshot and computer_handler.screenshot is unavailable."
+                )
+            screenshot_b64 = await computer_handler.screenshot()
+            if not screenshot_b64:
+                raise RuntimeError("Failed to capture screenshot from computer_handler.")
+            if _on_screenshot:
+                await _on_screenshot(screenshot_b64, "screenshot_before")
+            latest_url = f"data:image/png;base64,{screenshot_b64}"
+            completion_messages.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": latest_url}},
+                        {"type": "text", "text": "Current desktop screen"},
+                    ],
+                }
+            )
+
+        native_width, native_height = _image_dimensions(latest_url)
+        _convert_request_images(completion_messages)
+        completion_messages = retain_n2_request_images(completion_messages)
+
+        extra_body = dict(kwargs.pop("extra_body", None) or {})
+        tool_set = kwargs.pop("tool_set", None)
+        if tool_set is not None:
+            if tool_set not in _SUPPORTED_TOOL_SETS:
+                raise ValueError(f"Unsupported n2 tool_set: {tool_set}")
+            extra_body["tool_set"] = tool_set
+
+        execution_deadline = kwargs.pop("execution_deadline", None)
+        if execution_deadline is not None and not isinstance(execution_deadline, (int, float)):
+            raise ValueError("execution_deadline must be a monotonic timestamp in seconds")
+
+        api_kwargs: Dict[str, Any] = {
+            "model": model,
+            "messages": completion_messages,
+            "max_retries": max_retries,
+            "stream": False,
+            "temperature": kwargs.pop("temperature", 0.0),
+        }
+        if extra_body:
+            api_kwargs["extra_body"] = extra_body
+        api_kwargs.update(kwargs)
+
+        request_size = _request_body_bytes(api_kwargs)
+        if request_size > MAX_REQUEST_BODY_BYTES:
+            raise ValueError(
+                f"Serialized n2 request is {request_size} bytes, above the "
+                f"{MAX_REQUEST_BODY_BYTES}-byte request limit."
+            )
+
+        if _on_api_start:
+            await _on_api_start(api_kwargs)
+        response = await litellm.acompletion(**api_kwargs)
+        if _on_api_end:
+            await _on_api_end(api_kwargs, response)
+
+        usage = {
+            **LiteLLMCompletionResponsesConfig._transform_chat_completion_usage_to_responses_usage(  # type: ignore
+                response.usage
+            ).model_dump(),
+            "response_cost": response._hidden_params.get("response_cost", 0.0),
+        }
+        if _on_usage:
+            await _on_usage(usage)
+
+        response_dict = response.model_dump()  # type: ignore
+        message = (response_dict.get("choices") or [{}])[0].get("message") or {}
+        content_text = message.get("content") or ""
+        reasoning_text = message.get("reasoning_content") or message.get("reasoning") or ""
+        tool_calls = message.get("tool_calls") or []
+        output: List[Dict[str, Any]] = []
+
+        if reasoning_text:
+            output.append(dict(make_reasoning_item(reasoning_text)))
+        if tool_calls and content_text:
+            output.append(dict(make_output_text_item(content_text)))
+
+        for tool_call in tool_calls:
+            function = tool_call.get("function") or {}
+            name = function.get("name") or ""
+            arguments = function.get("arguments", "{}")
+            call_id = tool_call.get("id") or "call_0"
+            call_item: Dict[str, Any] = {
+                "type": "function_call",
+                "id": tool_call.get("id") or call_id,
+                "call_id": call_id,
+                "name": name,
+                "arguments": arguments if isinstance(arguments, str) else json.dumps(arguments),
+                "status": "completed",
+            }
+            try:
+                args = json.loads(arguments) if isinstance(arguments, str) else arguments
+                if not isinstance(args, dict):
+                    raise N2ActionValidationError(f"{name} arguments must be an object")
+                if name == "computer_batch":
+                    batch_actions, translated = translate_n2_batch(
+                        args, native_width, native_height
+                    )
+                    call_item = _function_call_with_execution(
+                        name,
+                        args,
+                        call_id,
+                        translated,
+                        batch_actions=batch_actions,
+                        execution_deadline=execution_deadline,
+                    )
+                else:
+                    translated = translate_n2_action(name, args, native_width, native_height)
+                    call_item = _function_call_with_execution(
+                        name,
+                        args,
+                        call_id,
+                        translated,
+                        execution_deadline=execution_deadline,
+                    )
+                output.append(call_item)
+            except (json.JSONDecodeError, N2ActionValidationError, TypeError, ValueError) as error:
+                output.append(call_item)
+                output.append(
+                    {
+                        "type": "function_call_output",
+                        "call_id": call_id,
+                        "output": f"[ERROR] Invalid {name} call: {error}",
+                    }
+                )
+
+        if not tool_calls:
+            output.append(dict(make_output_text_item(content_text or "Task completed.")))
+
+        return {"output": output, "usage": usage}
+
+    async def predict_click(
+        self, model: str, image_b64: str, instruction: str, **kwargs
+    ) -> Optional[Tuple[int, int]]:
+        raise NotImplementedError("Yutori n2-preview supports step prediction only.")
+
+    def get_capabilities(self) -> List[AgentCapability]:
+        return ["step"]

--- a/libs/python/agent/cua_agent/responses.py
+++ b/libs/python/agent/cua_agent/responses.py
@@ -284,7 +284,6 @@ def replace_failed_computer_calls_with_function_calls(
     # Replace computer_call items that have matching call_ids
     for i, msg in enumerate(messages):
         if msg.get("type") == "computer_call" and msg.get("call_id") in failed_call_ids:
-
             # Extract action from computer_call
             action = msg.get("action", {})
             call_id = msg.get("call_id")
@@ -392,7 +391,6 @@ def convert_computer_calls_xy2desc(
                     and "x" in end_point
                     and "y" in end_point
                 ):
-
                     start_coords = (start_point["x"], start_point["y"])
                     end_coords = (end_point["x"], end_point["y"])
 
@@ -459,9 +457,9 @@ def convert_responses_items_to_completion_messages(
     """
     # Assert that allow_images_in_tool_results is False when use_xml_tools is True
     if use_xml_tools:
-        assert (
-            not allow_images_in_tool_results
-        ), "allow_images_in_tool_results must be False when use_xml_tools is True"
+        assert not allow_images_in_tool_results, (
+            "allow_images_in_tool_results must be False when use_xml_tools is True"
+        )
     completion_messages = []
 
     for i, message in enumerate(messages):
@@ -626,16 +624,30 @@ def convert_responses_items_to_completion_messages(
                 if isinstance(output, dict) and output.get("type") == "input_image":
                     if allow_images_in_tool_results:
                         # Handle image output as tool response (may not work with all APIs)
+                        content = []
+                        result_metadata = output.get("result")
+                        if result_metadata is not None:
+                            content.append(
+                                {
+                                    "type": "text",
+                                    "text": json.dumps(
+                                        result_metadata,
+                                        separators=(",", ":"),
+                                        ensure_ascii=False,
+                                    ),
+                                }
+                            )
+                        content.append(
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": output.get("image_url")},
+                            }
+                        )
                         completion_messages.append(
                             {
                                 "role": "tool",
                                 "tool_call_id": call_id,
-                                "content": [
-                                    {
-                                        "type": "image_url",
-                                        "image_url": {"url": output.get("image_url")},
-                                    }
-                                ],
+                                "content": content,
                             }
                         )
                     else:

--- a/libs/python/agent/cua_agent/tools/browser_tool.py
+++ b/libs/python/agent/cua_agent/tools/browser_tool.py
@@ -15,6 +15,28 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Map lowercase modifier names (as emitted by Yutori n1.5 and pynput-style callers)
+# to the Playwright key names the computer-server's browser commands expect.
+_PLAYWRIGHT_MODIFIERS = {
+    "ctrl": "Control",
+    "control": "Control",
+    "shift": "Shift",
+    "alt": "Alt",
+    "cmd": "Meta",
+    "command": "Meta",
+    "meta": "Meta",
+    "super": "Meta",
+    "win": "Meta",
+}
+
+
+def _to_playwright_modifiers(modifier) -> list:
+    """Convert a modifier key (or list of them) to Playwright key names."""
+    if not modifier:
+        return []
+    mods = modifier if isinstance(modifier, (list, tuple)) else [modifier]
+    return [_PLAYWRIGHT_MODIFIERS.get(str(m).lower(), str(m)) for m in mods]
+
 
 @register_tool("computer_use")
 class BrowserTool(BaseComputerTool):
@@ -375,8 +397,12 @@ class BrowserTool(BaseComputerTool):
 
     async def _action_history_back(self, params: dict) -> dict:
         """Go back in browser history."""
-        # Press Alt+Left arrow key combination
         try:
+            result = await self.interface.playwright_exec("go_back", {})
+            if isinstance(result, dict) and result.get("success"):
+                return result
+            # Older computer-server versions lack the go_back command;
+            # fall back to the Alt+Left arrow key combination.
             await self.automation.hotkey("Alt", "ArrowLeft")
             return {"success": True, "message": "Navigated back in history"}
         except Exception as e:
@@ -433,26 +459,28 @@ class BrowserTool(BaseComputerTool):
         """Navigate to a URL."""
         return await self._action_visit_url({"url": url})
 
-    async def click(self, x: int = None, y: int = None, button: str = "left", **kwargs) -> dict:
+    async def click(
+        self, x: int = None, y: int = None, button: str = "left", modifier=None, **kwargs
+    ) -> dict:
         """Click at coordinates. Supports both positional (x, y) and kwargs (button, x, y).
 
         This is compatible with the normalized format from OperatorNormalizerCallback
         which transforms actions like {"type": "left_click", "coordinate": [x, y]}
         into {"type": "click", "button": "left", "x": x, "y": y}.
+
+        modifier optionally holds a modifier key (e.g. "ctrl") during the click.
         """
         if x is None or y is None:
             return {"success": False, "error": "x and y coordinates are required"}
+        params = {"x": x, "y": y}
         if button == "right":
-            return await self.interface.playwright_exec(
-                "click", {"x": x, "y": y, "button": "right"}
-            )
+            params["button"] = "right"
         elif button == "middle" or button == "wheel":
-            return await self.interface.playwright_exec(
-                "click", {"x": x, "y": y, "button": "middle"}
-            )
-        else:
-            # Default to left click
-            return await self._action_left_click({"coordinate": [x, y]})
+            params["button"] = "middle"
+        modifiers = _to_playwright_modifiers(modifier)
+        if modifiers:
+            params["modifiers"] = modifiers
+        return await self.interface.playwright_exec("click", params)
 
     async def type(self, text: str) -> dict:
         """Type text into the focused element."""
@@ -538,18 +566,30 @@ class BrowserTool(BaseComputerTool):
         result = await self.interface.playwright_exec("click", {"x": x, "y": y, "button": "middle"})
         return result
 
-    async def double_click(self, coordinate=None, x: int = None, y: int = None, **kwargs) -> dict:
+    async def double_click(
+        self, coordinate=None, x: int = None, y: int = None, modifier=None, **kwargs
+    ) -> dict:
         """Double click at coordinates. Supports coordinate array or x/y kwargs."""
         # Accept either coordinate array or x/y kwargs
         if coordinate and len(coordinate) >= 2:
             x, y = coordinate[0], coordinate[1]
         if x is None or y is None:
             return {"success": False, "error": "coordinate parameter [x, y] or x/y kwargs required"}
-        result = await self.interface.playwright_exec("dblclick", {"x": x, "y": y})
+        params = {"x": x, "y": y, "click_count": 2}
+        modifiers = _to_playwright_modifiers(modifier)
+        if modifiers:
+            params["modifiers"] = modifiers
+        result = await self.interface.playwright_exec("click", params)
         return result
 
     async def triple_click(
-        self, coordinate=None, x: int = None, y: int = None, button: str = None, **kwargs
+        self,
+        coordinate=None,
+        x: int = None,
+        y: int = None,
+        button: str = None,
+        modifier=None,
+        **kwargs,
     ) -> dict:
         """Triple click at coordinates. Supports coordinate array or x/y kwargs."""
         # Accept either coordinate array or x/y kwargs
@@ -557,8 +597,12 @@ class BrowserTool(BaseComputerTool):
             x, y = coordinate[0], coordinate[1]
         if x is None or y is None:
             return {"success": False, "error": "coordinate parameter [x, y] or x/y kwargs required"}
-        # Triple click is approximated as double click
-        return await self.double_click(x=x, y=y)
+        params = {"x": x, "y": y, "click_count": 3}
+        modifiers = _to_playwright_modifiers(modifier)
+        if modifiers:
+            params["modifiers"] = modifiers
+        result = await self.interface.playwright_exec("click", params)
+        return result
 
     async def mouse_move(self, coordinate=None, x: int = None, y: int = None, **kwargs) -> dict:
         """Move mouse to coordinates. Supports coordinate array or x/y kwargs."""
@@ -618,6 +662,86 @@ class BrowserTool(BaseComputerTool):
     async def history_back(self, **kwargs) -> dict:
         """Go back in browser history. FARA-compatible."""
         return await self._action_history_back({})
+
+    async def history_forward(self, **kwargs) -> dict:
+        """Go forward in browser history."""
+        try:
+            result = await self.interface.playwright_exec("go_forward", {})
+            if isinstance(result, dict) and result.get("success"):
+                return result
+            # Older computer-server versions lack the go_forward command;
+            # fall back to the Alt+Right arrow key combination.
+            await self.automation.hotkey("alt", "right")
+            return {"success": True, "message": "Navigated forward in history"}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    async def refresh(self, **kwargs) -> dict:
+        """Reload the current page."""
+        try:
+            result = await self.interface.playwright_exec("refresh", {})
+            if isinstance(result, dict) and result.get("success"):
+                return result
+            # Older computer-server versions lack the refresh command;
+            # fall back to pressing F5.
+            await self.automation.press_key("f5")
+            return {"success": True, "message": "Refreshed the page"}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    async def mouse_down(
+        self, coordinate=None, x: int = None, y: int = None, button: str = "left", **kwargs
+    ) -> dict:
+        """Press and hold a mouse button, optionally moving to coordinates first."""
+        if coordinate and len(coordinate) >= 2:
+            x, y = coordinate[0], coordinate[1]
+        try:
+            if x is not None and y is not None:
+                await self.automation.move_cursor(x, y)
+            await self.automation.mouse_down(x, y, button=button)
+            return {"success": True, "message": f"Mouse down ({button}) at ({x}, {y})"}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    async def mouse_up(
+        self, coordinate=None, x: int = None, y: int = None, button: str = "left", **kwargs
+    ) -> dict:
+        """Release a mouse button, optionally moving to coordinates first."""
+        if coordinate and len(coordinate) >= 2:
+            x, y = coordinate[0], coordinate[1]
+        try:
+            if x is not None and y is not None:
+                await self.automation.move_cursor(x, y)
+            await self.automation.mouse_up(x, y, button=button)
+            return {"success": True, "message": f"Mouse up ({button}) at ({x}, {y})"}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    async def hold_key(self, key: str = None, duration: float = None, **kwargs) -> dict:
+        """Hold a key down for a duration (in seconds), then release it."""
+        if not key:
+            return {"success": False, "error": "key parameter is required"}
+        duration = 1.0 if duration is None else float(duration)
+        try:
+            await self.automation.key_down(key)
+            try:
+                await asyncio.sleep(duration)
+            finally:
+                await self.automation.key_up(key)
+            return {"success": True, "message": f"Held key {key} for {duration} seconds"}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    async def evaluate_js(self, expression: str) -> dict:
+        """Evaluate a JavaScript expression in the current page.
+
+        Requires a computer-server with the 'evaluate' browser command; older
+        versions return {"success": False, "error": "Unknown command: evaluate"}.
+        """
+        try:
+            return await self.interface.playwright_exec("evaluate", {"expression": expression})
+        except Exception as e:
+            return {"success": False, "error": str(e)}
 
     async def terminate(self, status=None, **kwargs) -> dict:
         """Terminate and report status. FARA-compatible."""

--- a/libs/python/agent/example.py
+++ b/libs/python/agent/example.py
@@ -111,6 +111,9 @@ async def main():
             # == Omniparser + Any LLM ==
             # model="omniparser+..."
             # model="omniparser+anthropic/claude-opus-4-20250514",
+            # == Yutori Navigator (browser-only; requires YUTORI_API_KEY) ==
+            # model="yutori/n1.5-latest",
+            # model="yutori/n1.5-20260428",
             tools=[computer],
             only_n_most_recent_images=3,
             verbosity=logging.INFO,

--- a/libs/python/agent/tests/test_yutori.py
+++ b/libs/python/agent/tests/test_yutori.py
@@ -1,0 +1,443 @@
+"""
+Tests for the Yutori Navigator (n1.5) integration.
+
+Covers:
+1. Model routing — Navigator model names resolve to the Yutori loop
+2. YutoriAdapter — model name normalization and request param handling
+3. Action conversion — the n1.5 action space
+4. Normalizer compatibility — converted actions survive OperatorNormalizerCallback
+   and match BrowserTool method signatures
+5. predict_step — screenshot injection, extra_body params, inline DOM tools,
+   ref resolution, key sequences, terminal messages
+"""
+
+import base64
+import io
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from litellm.types.utils import ModelResponse
+from PIL import Image
+
+from cua_agent.adapters.yutori_adapter import YutoriAdapter
+from cua_agent.agent import assert_callable_with
+from cua_agent.callbacks.operator_validator import OperatorNormalizerCallback
+from cua_agent.decorators import find_agent_config
+from cua_agent.loops.yutori import (
+    YutoriNavigatorConfig,
+    _convert_key_expression,
+    _convert_navigator_action,
+)
+from cua_agent.responses import convert_completion_messages_to_responses_items
+from cua_agent.tools.browser_tool import BrowserTool
+
+SCREEN = (1280, 800)
+
+
+class TestModelRouting:
+    """The Yutori loop must match all published Navigator model names."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "yutori/n1.5",
+            "yutori/n1.5-latest",
+            "yutori/n1.5-20260428",
+            "n1.5-latest",
+        ],
+    )
+    def test_navigator_models_route_to_yutori_loop(self, model):
+        config = find_agent_config(model)
+        assert config is not None
+        assert config.agent_class is YutoriNavigatorConfig
+
+    # yutori/n1 is deprecated and no longer matched; the API rejects it with
+    # a clear model_deprecated error if a request is attempted.
+    @pytest.mark.parametrize("model", ["claude-sonnet-4-5", "gpt-5.4", "qwen3vl", "yutori/n1"])
+    def test_other_models_do_not_route_to_yutori_loop(self, model):
+        config = find_agent_config(model)
+        assert config is None or config.agent_class is not YutoriNavigatorConfig
+
+
+class TestYutoriAdapter:
+    def test_normalize_model_pins_bare_names_to_latest(self):
+        adapter = YutoriAdapter(api_key="test")
+        assert adapter._normalize_model("yutori/n1.5") == "n1.5-latest"
+        assert adapter._normalize_model("n1.5") == "n1.5-latest"
+        # Versioned names pass through unchanged
+        assert adapter._normalize_model("yutori/n1.5-latest") == "n1.5-latest"
+        assert adapter._normalize_model("n1.5-20260428") == "n1.5-20260428"
+
+    def test_build_params_forwards_extra_body(self):
+        adapter = YutoriAdapter(api_key="test")
+        params = adapter._build_params(
+            {
+                "model": "yutori/n1.5",
+                "messages": [],
+                "extra_body": {"tool_set": "browser_tools_core-20260403"},
+            }
+        )
+        assert params["model"] == "openai/n1.5-latest"
+        assert params["extra_body"] == {"tool_set": "browser_tools_core-20260403"}
+        assert params["extra_headers"]["Authorization"] == "Bearer test"
+
+    def test_build_params_translates_max_tokens(self):
+        # The Yutori API rejects max_tokens and requires max_completion_tokens
+        adapter = YutoriAdapter(api_key="test")
+        params = adapter._build_params({"model": "yutori/n1.5", "messages": [], "max_tokens": 512})
+        assert "max_tokens" not in params
+        assert params["max_completion_tokens"] == 512
+
+    def test_yutori_provider_registered_by_computer_agent(self):
+        import litellm
+
+        from cua_agent.agent import ComputerAgent
+
+        ComputerAgent(model="yutori/n1.5-latest", tools=[], telemetry_enabled=False)
+        providers = {entry["provider"] for entry in litellm.custom_provider_map}
+        assert "yutori" in providers
+
+
+class TestActionConversion:
+    """n1.5 action space conversion to internal computer_call actions."""
+
+    def test_clicks_with_modifier(self):
+        actions = _convert_navigator_action(
+            "left_click", {"coordinates": [500, 500], "modifier": "ctrl"}, *SCREEN
+        )
+        assert actions == [
+            {"action": "click", "button": "left", "x": 640, "y": 400, "modifier": "ctrl"}
+        ]
+
+    def test_middle_click(self):
+        actions = _convert_navigator_action("middle_click", {"coordinates": [500, 500]}, *SCREEN)
+        assert actions == [{"action": "click", "button": "middle", "x": 640, "y": 400}]
+
+    def test_mouse_move(self):
+        actions = _convert_navigator_action("mouse_move", {"coordinates": [100, 100]}, *SCREEN)
+        assert actions == [{"action": "move", "x": 128, "y": 80}]
+
+    def test_mouse_down_up(self):
+        assert _convert_navigator_action("mouse_down", {"coordinates": [10, 10]}, *SCREEN) == [
+            {"action": "mouse_down", "x": 13, "y": 8}
+        ]
+        assert _convert_navigator_action("mouse_up", {}, *SCREEN) == [{"action": "mouse_up"}]
+
+    def test_drag(self):
+        actions = _convert_navigator_action(
+            "drag", {"start_coordinates": [100, 100], "coordinates": [200, 200]}, *SCREEN
+        )
+        assert actions == [
+            {
+                "action": "left_click_drag",
+                "start_coordinate": [128, 80],
+                "end_coordinate": [256, 160],
+            }
+        ]
+
+    def test_key_press_lowercase_key_space(self):
+        actions = _convert_navigator_action("key_press", {"key": "ctrl+shift+t"}, *SCREEN)
+        assert actions == [{"action": "keypress", "keys": ["ctrl", "shift", "t"]}]
+
+    def test_key_press_sequence_expands_to_multiple_actions(self):
+        actions = _convert_navigator_action("key_press", {"key": "down down enter"}, *SCREEN)
+        assert actions == [
+            {"action": "keypress", "keys": ["down"]},
+            {"action": "keypress", "keys": ["down"]},
+            {"action": "keypress", "keys": ["enter"]},
+        ]
+
+    def test_key_aliases(self):
+        assert _convert_key_expression("meta+c escape pageup pagedown") == [
+            ["cmd", "c"],
+            ["esc"],
+            ["page_up"],
+            ["page_down"],
+        ]
+
+    def test_hold_key(self):
+        actions = _convert_navigator_action("hold_key", {"key": "shift", "duration": 2}, *SCREEN)
+        assert actions == [{"action": "hold_key", "key": "shift", "duration": 2.0}]
+
+    def test_wait_with_duration(self):
+        assert _convert_navigator_action("wait", {"duration": 5}, *SCREEN) == [
+            {"action": "wait", "time": 5.0}
+        ]
+        assert _convert_navigator_action("wait", {}, *SCREEN) == [{"action": "wait"}]
+
+    def test_navigation_actions(self):
+        assert _convert_navigator_action("go_back", {}, *SCREEN) == [{"action": "history_back"}]
+        assert _convert_navigator_action("go_forward", {}, *SCREEN) == [
+            {"action": "history_forward"}
+        ]
+        assert _convert_navigator_action("refresh", {}, *SCREEN) == [{"action": "refresh"}]
+        assert _convert_navigator_action("goto_url", {"url": "https://x.com"}, *SCREEN) == [
+            {"action": "visit_url", "url": "https://x.com"}
+        ]
+
+    def test_ref_pixels_take_precedence(self):
+        actions = _convert_navigator_action(
+            "left_click", {"ref": "e7", "coordinates": [500, 500]}, *SCREEN, ref_pixels=(321, 123)
+        )
+        assert actions == [{"action": "click", "button": "left", "x": 321, "y": 123}]
+
+    def test_custom_tool_returns_none(self):
+        assert _convert_navigator_action("my_custom_tool", {"a": 1}, *SCREEN) is None
+
+
+class TestNormalizerCompatibility:
+    """Every converted action must survive the operator normalizer and match a
+    BrowserTool method signature — this is exactly what the agent validates at
+    execution time."""
+
+    CASES = [
+        ("left_click", {"coordinates": [500, 500], "modifier": "ctrl"}),
+        ("right_click", {"coordinates": [500, 500]}),
+        ("middle_click", {"coordinates": [500, 500]}),
+        ("double_click", {"coordinates": [1, 2], "modifier": "shift"}),
+        ("triple_click", {"coordinates": [1, 2]}),
+        ("mouse_move", {"coordinates": [100, 100]}),
+        ("mouse_down", {"coordinates": [10, 10]}),
+        ("mouse_up", {}),
+        ("drag", {"start_coordinates": [100, 100], "coordinates": [200, 200]}),
+        ("scroll", {"coordinates": [500, 500], "direction": "down", "amount": 3}),
+        ("type", {"text": "hello"}),
+        ("key_press", {"key": "ctrl+a"}),
+        ("hold_key", {"key": "shift", "duration": 1.5}),
+        ("wait", {"duration": 4}),
+        ("goto_url", {"url": "https://x.com"}),
+        ("go_back", {}),
+        ("go_forward", {}),
+        ("refresh", {}),
+    ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("fn_name,args", CASES)
+    async def test_action_executable_on_browser_tool(self, fn_name, args):
+        normalizer = OperatorNormalizerCallback()
+        tool = BrowserTool.__new__(BrowserTool)  # methods only, no interface needed
+
+        actions = _convert_navigator_action(fn_name, args, *SCREEN)
+        assert actions, f"{fn_name} produced no actions"
+        for action in actions:
+            fake_cm = {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "id": "call_x",
+                        "function": {"name": "computer", "arguments": json.dumps(action)},
+                    }
+                ],
+            }
+            items = convert_completion_messages_to_responses_items([fake_cm])
+            items = await normalizer.on_llm_end(items)
+            computer_calls = [i for i in items if i.get("type") == "computer_call"]
+            assert computer_calls, f"{fn_name}: no computer_call after normalization"
+            normalized = computer_calls[0]["action"]
+            method = getattr(tool, normalized["type"], None)
+            assert method is not None, f"BrowserTool has no method {normalized['type']}"
+            action_args = {k: v for k, v in normalized.items() if k != "type"}
+            assert_callable_with(method, **action_args)
+
+    @pytest.mark.asyncio
+    async def test_normalizer_preserves_modifier_and_wait_time(self):
+        normalizer = OperatorNormalizerCallback()
+        items = [
+            {
+                "type": "computer_call",
+                "call_id": "c1",
+                "action": {"type": "click", "button": "left", "x": 1, "y": 2, "modifier": "ctrl"},
+            },
+            {
+                "type": "computer_call",
+                "call_id": "c2",
+                "action": {"type": "wait", "time": 5.0},
+            },
+        ]
+        items = await normalizer.on_llm_end(items)
+        assert items[0]["action"]["modifier"] == "ctrl"
+        assert items[1]["action"]["time"] == 5.0
+
+
+def _tiny_png_b64():
+    img = Image.new("RGB", (64, 40), "white")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+def _make_response(tool_calls=None, content="", reasoning=None):
+    message = {"role": "assistant", "content": content}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    if reasoning:
+        message["reasoning_content"] = reasoning
+    return ModelResponse(
+        id="chatcmpl-test",
+        choices=[{"index": 0, "message": message, "finish_reason": "stop"}],
+        model="n1.5-latest",
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    )
+
+
+def _tool_call(call_id, name, arguments):
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": json.dumps(arguments)},
+    }
+
+
+@pytest.fixture
+def navigator_handler():
+    handler = AsyncMock()
+    handler.screenshot = AsyncMock(return_value=_tiny_png_b64())
+    handler.get_dimensions = AsyncMock(side_effect=Exception("BrowserTool has no get_dimensions"))
+    handler.viewport_width = 1280
+    handler.viewport_height = 800
+    handler.get_current_url = AsyncMock(return_value="https://example.com")
+    handler.evaluate_js = AsyncMock(
+        return_value={"success": True, "result": {"pageContent": "[e1] <button> Submit"}}
+    )
+    return handler
+
+
+class TestPredictStep:
+    @pytest.mark.asyncio
+    async def test_click_step_with_extra_body_and_screenshot_injection(self, navigator_handler):
+        loop = YutoriNavigatorConfig()
+        captured = {}
+
+        async def on_api_start(kwargs):
+            captured.update(kwargs)
+
+        response = _make_response(
+            tool_calls=[
+                _tool_call("call_1", "left_click", {"coordinates": [500, 500], "modifier": "ctrl"})
+            ],
+            content="Clicking the button",
+            reasoning="I should click submit",
+        )
+        with patch("litellm.acompletion", new=AsyncMock(return_value=response)):
+            result = await loop.predict_step(
+                messages=[{"role": "user", "content": "click submit"}],
+                model="yutori/n1.5-latest",
+                computer_handler=navigator_handler,
+                tool_set="browser_tools_expanded-20260403",
+                api_key="test-key",
+                _on_api_start=on_api_start,
+            )
+
+        # Yutori-specific params travel in extra_body, not as top-level params
+        assert captured["extra_body"] == {"tool_set": "browser_tools_expanded-20260403"}
+        assert "tool_set" not in captured
+
+        # A screenshot is injected when the latest message carries no image
+        last_message = captured["messages"][-1]
+        assert last_message["role"] == "user"
+        assert any(part.get("type") == "image_url" for part in last_message["content"])
+
+        computer_calls = [i for i in result["output"] if i["type"] == "computer_call"]
+        assert computer_calls[0]["action"]["type"] == "click"
+        assert computer_calls[0]["action"]["modifier"] == "ctrl"
+        assert any(i["type"] == "reasoning" for i in result["output"])
+
+    @pytest.mark.asyncio
+    async def test_dom_tool_executed_inline(self, navigator_handler):
+        loop = YutoriNavigatorConfig()
+        response = _make_response(
+            tool_calls=[_tool_call("call_2", "extract_elements", {"filter": "interactive"})]
+        )
+        with patch("litellm.acompletion", new=AsyncMock(return_value=response)):
+            result = await loop.predict_step(
+                messages=[{"role": "user", "content": "list elements"}],
+                model="yutori/n1.5-latest",
+                computer_handler=navigator_handler,
+                api_key="test-key",
+            )
+
+        navigator_handler.evaluate_js.assert_awaited_once()
+        function_calls = [i for i in result["output"] if i["type"] == "function_call"]
+        outputs = [i for i in result["output"] if i["type"] == "function_call_output"]
+        assert len(function_calls) == 1 and len(outputs) == 1
+        # Matching call ids make the agent skip re-execution (ignore_call_ids)
+        assert function_calls[0]["call_id"] == outputs[0]["call_id"]
+        assert "[e1] <button> Submit" in outputs[0]["output"]
+        assert "Current URL: https://example.com" in outputs[0]["output"]
+
+    @pytest.mark.asyncio
+    async def test_dom_tool_unavailable_reports_error_to_model(self, navigator_handler):
+        loop = YutoriNavigatorConfig()
+        # Old computer-server without the 'evaluate' browser command
+        navigator_handler.evaluate_js = AsyncMock(
+            return_value={"success": False, "error": "Unknown command: evaluate"}
+        )
+        response = _make_response(
+            tool_calls=[_tool_call("call_2b", "execute_js", {"text": "document.title"})]
+        )
+        with patch("litellm.acompletion", new=AsyncMock(return_value=response)):
+            result = await loop.predict_step(
+                messages=[{"role": "user", "content": "get title"}],
+                model="yutori/n1.5-latest",
+                computer_handler=navigator_handler,
+                api_key="test-key",
+            )
+
+        outputs = [i for i in result["output"] if i["type"] == "function_call_output"]
+        assert outputs and outputs[0]["output"].startswith("[ERROR]")
+
+    @pytest.mark.asyncio
+    async def test_key_sequence_expands_with_unique_call_ids(self, navigator_handler):
+        loop = YutoriNavigatorConfig()
+        response = _make_response(
+            tool_calls=[_tool_call("call_3", "key_press", {"key": "down enter"})]
+        )
+        with patch("litellm.acompletion", new=AsyncMock(return_value=response)):
+            result = await loop.predict_step(
+                messages=[{"role": "user", "content": "press keys"}],
+                model="yutori/n1.5-latest",
+                computer_handler=navigator_handler,
+                api_key="test-key",
+            )
+
+        computer_calls = [i for i in result["output"] if i["type"] == "computer_call"]
+        assert len(computer_calls) == 2
+        assert len({c["call_id"] for c in computer_calls}) == 2
+        assert [c["action"]["keys"] for c in computer_calls] == [["down"], ["enter"]]
+
+    @pytest.mark.asyncio
+    async def test_ref_click_resolved_via_evaluate_js(self, navigator_handler):
+        loop = YutoriNavigatorConfig()
+        navigator_handler.evaluate_js = AsyncMock(
+            return_value={"success": True, "result": {"success": True, "coordinates": [321, 123]}}
+        )
+        response = _make_response(tool_calls=[_tool_call("call_5", "left_click", {"ref": "e7"})])
+        with patch("litellm.acompletion", new=AsyncMock(return_value=response)):
+            result = await loop.predict_step(
+                messages=[{"role": "user", "content": "click the ref"}],
+                model="yutori/n1.5-latest",
+                computer_handler=navigator_handler,
+                api_key="test-key",
+            )
+
+        computer_calls = [i for i in result["output"] if i["type"] == "computer_call"]
+        assert computer_calls[0]["action"]["x"] == 321
+        assert computer_calls[0]["action"]["y"] == 123
+
+    @pytest.mark.asyncio
+    async def test_no_tool_calls_is_terminal(self, navigator_handler):
+        loop = YutoriNavigatorConfig()
+        response = _make_response(content="The answer is 42.")
+        with patch("litellm.acompletion", new=AsyncMock(return_value=response)):
+            result = await loop.predict_step(
+                messages=[{"role": "user", "content": "question"}],
+                model="yutori/n1.5-latest",
+                computer_handler=navigator_handler,
+                api_key="test-key",
+            )
+
+        messages = [i for i in result["output"] if i["type"] == "message"]
+        assert messages[0]["content"][0]["text"] == "The answer is 42."

--- a/libs/python/agent/tests/test_yutori_n2.py
+++ b/libs/python/agent/tests/test_yutori_n2.py
@@ -1,0 +1,485 @@
+"""Contract tests for the Yutori n2-preview computer-use integration."""
+
+import base64
+import copy
+import io
+import json
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from litellm.types.utils import ModelResponse
+from PIL import Image
+
+from cua_agent.adapters.yutori_adapter import YutoriAdapter
+from cua_agent.agent import ComputerAgent
+from cua_agent.decorators import find_agent_config
+from cua_agent.loops.yutori import YutoriNavigatorConfig
+from cua_agent.loops.yutori_n2 import (
+    N2ActionValidationError,
+    N2_MODEL_IMAGE_MAX_HEIGHT,
+    N2_MODEL_IMAGE_MAX_WIDTH,
+    TOOL_SET_COMPUTER_USE_BATCH,
+    YutoriN2Config,
+    _function_call_with_execution,
+    parse_n2_key_expression,
+    prepare_n2_image_data_url,
+    retain_n2_request_images,
+    translate_n2_action,
+    translate_n2_batch,
+)
+from cua_agent.responses import convert_responses_items_to_completion_messages
+
+
+def _png_data_url(width=64, height=40, color="white"):
+    image = Image.new("RGB", (width, height), color)
+    output = io.BytesIO()
+    image.save(output, format="PNG")
+    return f"data:image/png;base64,{base64.b64encode(output.getvalue()).decode()}"
+
+
+def _response(tool_calls=None, content="", reasoning=None):
+    message = {"role": "assistant", "content": content}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    if reasoning:
+        message["reasoning_content"] = reasoning
+    return ModelResponse(
+        id="chatcmpl-test",
+        choices=[{"index": 0, "message": message, "finish_reason": "stop"}],
+        model="n2-preview",
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    )
+
+
+def _tool_call(call_id, name, arguments):
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": arguments if isinstance(arguments, str) else json.dumps(arguments),
+        },
+    }
+
+
+class TestRouting:
+    @pytest.mark.parametrize("model", ["yutori/n2-preview", "n2-preview"])
+    def test_exact_preview_models_use_n2_computer_loop(self, model):
+        config = find_agent_config(model)
+
+        assert config is not None
+        assert config.agent_class is YutoriN2Config
+        assert config.tool_type == "computer"
+
+    @pytest.mark.parametrize("model", ["yutori/n2", "n2", "yutori/n2-latest", "n2-latest"])
+    def test_no_bare_or_stable_n2_alias(self, model):
+        config = find_agent_config(model)
+
+        assert config is None or config.agent_class is not YutoriN2Config
+
+    def test_n1_5_routing_is_unchanged(self):
+        assert find_agent_config("yutori/n1.5-latest").agent_class is YutoriNavigatorConfig
+
+    def test_adapter_does_not_invent_n2_latest_alias(self):
+        adapter = YutoriAdapter(api_key="test")
+
+        assert adapter._normalize_model("yutori/n1.5") == "n1.5-latest"
+        assert adapter._normalize_model("yutori/n2") == "n2"
+        assert adapter._normalize_model("yutori/n2-preview") == "n2-preview"
+
+
+class TestKeyGrammar:
+    def test_combos_sequences_aliases_and_punctuation(self):
+        assert parse_n2_key_expression("ctrl+c down enter") == [
+            ["ctrl", "c"],
+            ["down"],
+            ["enter"],
+        ]
+        assert parse_n2_key_expression("meta+plus command+bracketleft") == [
+            ["cmd", "+"],
+            ["cmd", "["],
+        ]
+        assert parse_n2_key_expression(
+            "minus equal comma period slash backslash semicolon quote backquote bracketright"
+        ) == [["-"], ["="], [","], ["."], ["/"], ["\\"], [";"], ["'"], ["`"], ["]"]]
+
+    @pytest.mark.parametrize("expression", ["hyper+c", "ctrl++c", "", "unknown"])
+    def test_unknown_or_malformed_keys_are_rejected(self, expression):
+        with pytest.raises(N2ActionValidationError):
+            parse_n2_key_expression(expression)
+
+
+class TestTranslation:
+    def test_retina_coordinates_use_native_screenshot_pixels(self):
+        actions = translate_n2_action("left_click", {"coordinates": [500, 500]}, 2880, 1800)
+
+        assert actions == [{"type": "click", "x": 1440, "y": 900, "button": "left"}]
+
+    @pytest.mark.parametrize(
+        ("action", "arguments", "expected_type"),
+        [
+            ("double_click", {"coordinates": [0, 0]}, "double_click"),
+            ("middle_click", {"coordinates": [0, 0]}, "click"),
+            ("right_click", {"coordinates": [0, 0]}, "click"),
+            ("mouse_move", {"coordinates": [0, 0]}, "move"),
+            (
+                "drag",
+                {"start_coordinates": [0, 0], "coordinates": [1000, 1000]},
+                "drag",
+            ),
+            (
+                "scroll",
+                {"coordinates": [500, 500], "direction": "left", "amount": 2},
+                "scroll",
+            ),
+            ("type", {"text": "hello"}, "type"),
+            ("key_press", {"key": "cmd+c"}, "keypress"),
+            ("wait", {"duration": 10}, "wait"),
+            ("screenshot", {}, "screenshot"),
+        ],
+    )
+    def test_all_individual_actions_translate(self, action, arguments, expected_type):
+        translated = translate_n2_action(action, arguments, 1280, 800)
+
+        assert translated[0]["type"] == expected_type
+
+    def test_triple_click_stays_one_yutori_call_with_two_internal_actions(self):
+        translated = translate_n2_action("triple_click", {"coordinates": [500, 500]}, 1280, 800)
+
+        assert [action["type"] for action in translated] == ["double_click", "click"]
+
+    def test_batch_prevalidates_every_member_and_forbids_screenshot(self):
+        valid, translated = translate_n2_batch(
+            {
+                "actions": [
+                    {"action": "mouse_move", "coordinates": [0, 0]},
+                    {"action": "wait"},
+                ]
+            },
+            1280,
+            800,
+        )
+
+        assert len(valid) == 2
+        assert [action["batch_index"] for action in translated] == [0, 1]
+        with pytest.raises(N2ActionValidationError, match="screenshot"):
+            translate_n2_batch({"actions": [{"action": "screenshot"}]}, 1280, 800)
+
+    @pytest.mark.parametrize(
+        ("action", "arguments"),
+        [
+            ("left_click", {"coordinates": [-1, 0]}),
+            ("left_click", {"coordinates": [1, 2], "unknown": True}),
+            ("scroll", {"coordinates": [1, 2], "direction": "diagonal", "amount": 1}),
+            ("wait", {"duration": 10.1}),
+            ("key_press", {"key": "hyper+c"}),
+            ("unknown", {}),
+        ],
+    )
+    def test_invalid_actions_are_rejected(self, action, arguments):
+        with pytest.raises(N2ActionValidationError):
+            translate_n2_action(action, arguments, 1280, 800)
+
+
+class TestScreenshotsAndRetention:
+    @pytest.mark.parametrize(
+        ("source_size", "expected_size"),
+        [
+            ((2880, 1800), (1280, 800)),
+            ((1600, 1200), (1067, 800)),
+            ((640, 400), (640, 400)),
+        ],
+    )
+    def test_model_image_is_jpeg_aspect_preserving_and_never_upscaled(
+        self, source_size, expected_size
+    ):
+        result = prepare_n2_image_data_url(_png_data_url(*source_size))
+        encoded = result.split(",", 1)[1]
+        with Image.open(io.BytesIO(base64.b64decode(encoded))) as image:
+            assert image.format == "JPEG"
+            assert image.size == expected_size
+            assert image.width <= N2_MODEL_IMAGE_MAX_WIDTH
+            assert image.height <= N2_MODEL_IMAGE_MAX_HEIGHT
+
+    def test_retention_keeps_all_images_in_two_newest_image_messages_only(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "old"},
+                    {"type": "image_url", "image_url": {"url": "old-1"}},
+                    {"type": "image_url", "image_url": {"url": "old-2"}},
+                ],
+            },
+            {"role": "assistant", "content": "reasoning remains"},
+            {
+                "role": "tool",
+                "tool_call_id": "one",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "recent-1"}},
+                    {"type": "image_url", "image_url": {"url": "recent-2"}},
+                ],
+            },
+            {"role": "assistant", "content": "text does not consume a slot"},
+            {
+                "role": "tool",
+                "tool_call_id": "two",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "latest-1"}},
+                    {"type": "image_url", "image_url": {"url": "latest-2"}},
+                ],
+            },
+        ]
+        original = copy.deepcopy(messages)
+
+        retained = retain_n2_request_images(messages, max_messages_bytes=100_000)
+        urls = [
+            part["image_url"]["url"]
+            for message in retained
+            for part in message.get("content", [])
+            if isinstance(part, dict) and part.get("type") == "image_url"
+        ]
+
+        assert urls == ["recent-1", "recent-2", "latest-1", "latest-2"]
+        assert retained[1]["content"] == "reasoning remains"
+        assert retained[3]["content"] == "text does not consume a slot"
+        assert messages == original
+
+    def test_budget_drops_older_retained_message_but_never_partial_newest(self):
+        messages = [
+            {
+                "role": "tool",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "a" * 1000}},
+                ],
+            },
+            {
+                "role": "tool",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "b" * 1000}},
+                    {"type": "image_url", "image_url": {"url": "c" * 1000}},
+                ],
+            },
+        ]
+
+        retained = retain_n2_request_images(messages, max_messages_bytes=2300)
+
+        assert retained[0]["content"] == []
+        assert len(retained[1]["content"]) == 2
+        with pytest.raises(ValueError, match="newest n2 screenshot message"):
+            retain_n2_request_images(messages, max_messages_bytes=100)
+
+
+class TestPredictStep:
+    @pytest.mark.asyncio
+    async def test_server_injected_tools_and_native_coordinate_mapping(self):
+        loop = YutoriN2Config()
+        handler = AsyncMock()
+        handler.screenshot.return_value = _png_data_url(200, 100).split(",", 1)[1]
+        captured = {}
+        response = _response(
+            [_tool_call("call-1", "left_click", {"coordinates": [500, 500]})],
+            content="Clicking",
+        )
+
+        async def on_api_start(kwargs):
+            captured.update(kwargs)
+
+        with patch("litellm.acompletion", new=AsyncMock(return_value=response)):
+            result = await loop.predict_step(
+                messages=[{"role": "user", "content": "click"}],
+                model="yutori/n2-preview",
+                computer_handler=handler,
+                tools=[{"type": "computer", "display_width": 999}],
+                tool_set=TOOL_SET_COMPUTER_USE_BATCH,
+                api_key="test",
+                _on_api_start=on_api_start,
+            )
+
+        assert "tools" not in captured
+        assert captured["stream"] is False
+        assert captured["temperature"] == 0.0
+        assert captured["extra_body"] == {"tool_set": TOOL_SET_COMPUTER_USE_BATCH}
+        image_url = next(
+            part["image_url"]["url"]
+            for message in captured["messages"]
+            for part in message.get("content", [])
+            if isinstance(part, dict) and part.get("type") == "image_url"
+        )
+        assert image_url.startswith("data:image/jpeg;base64,")
+        call = next(item for item in result["output"] if item["type"] == "function_call")
+        assert call["name"] == "left_click"
+        assert call["_computer_actions"] == [{"type": "click", "x": 100, "y": 50, "button": "left"}]
+
+    @pytest.mark.asyncio
+    async def test_batch_is_one_internal_item_and_invalid_batch_is_inline_error(self):
+        loop = YutoriN2Config()
+        image_message = {
+            "role": "user",
+            "content": [
+                {"type": "input_image", "image_url": _png_data_url(1280, 800)},
+                {"type": "input_text", "text": "go"},
+            ],
+        }
+        valid_response = _response(
+            [
+                _tool_call(
+                    "batch-1",
+                    "computer_batch",
+                    {
+                        "actions": [
+                            {"action": "mouse_move", "coordinates": [1, 2]},
+                            {"action": "wait", "duration": 0},
+                        ]
+                    },
+                )
+            ]
+        )
+        invalid_response = _response(
+            [_tool_call("batch-2", "computer_batch", {"actions": [{"action": "screenshot"}]})]
+        )
+
+        with patch(
+            "litellm.acompletion",
+            new=AsyncMock(side_effect=[valid_response, invalid_response]),
+        ):
+            valid = await loop.predict_step(
+                messages=[image_message], model="yutori/n2-preview", computer_handler=AsyncMock()
+            )
+            invalid = await loop.predict_step(
+                messages=[image_message], model="yutori/n2-preview", computer_handler=AsyncMock()
+            )
+
+        valid_calls = [item for item in valid["output"] if item["type"] == "function_call"]
+        assert len(valid_calls) == 1
+        assert len(valid_calls[0]["_computer_actions"]) == 2
+        assert [item["type"] for item in invalid["output"]] == [
+            "function_call",
+            "function_call_output",
+        ]
+        assert "screenshot" in invalid["output"][1]["output"]
+
+
+def _bare_agent(confirmation=None):
+    agent = ComputerAgent.__new__(ComputerAgent)
+    agent.callbacks = []
+    agent.action_confirmation_callback = confirmation
+    agent.screenshot_delay = 0
+    agent.telemetry_enabled = False
+    return agent
+
+
+class TestOrchestration:
+    @pytest.mark.asyncio
+    async def test_batch_executes_in_order_and_returns_one_screenshot_result(self):
+        order = []
+        computer = AsyncMock()
+        computer.move.side_effect = lambda **_: order.append("move")
+        computer.type.side_effect = lambda **_: order.append("type")
+        computer.screenshot.return_value = "fresh"
+        item = _function_call_with_execution(
+            "computer_batch",
+            {
+                "actions": [
+                    {"action": "mouse_move", "coordinates": [1, 2]},
+                    {"action": "type", "text": "hello"},
+                ]
+            },
+            "batch-1",
+            [
+                {"type": "move", "x": 1, "y": 2, "batch_index": 0},
+                {"type": "type", "text": "hello", "batch_index": 1},
+            ],
+            batch_actions=[
+                {"action": "mouse_move", "coordinates": [1, 2]},
+                {"action": "type", "text": "hello"},
+            ],
+        )
+
+        result = await _bare_agent()._handle_item(item, computer)
+
+        assert order == ["move", "type"]
+        computer.screenshot.assert_awaited_once()
+        metadata = result[0]["output"]["result"]
+        assert metadata["completed"] == 2
+        assert metadata["failed"] == 0
+        messages = convert_responses_items_to_completion_messages(
+            [item, result[0]], allow_images_in_tool_results=True
+        )
+        assert messages[0]["tool_calls"][0]["function"]["name"] == "computer_batch"
+        assert messages[1]["role"] == "tool"
+        assert len(messages[1]["content"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_runtime_failure_stops_remaining_members(self):
+        computer = AsyncMock()
+        computer.move.return_value = None
+        computer.type.side_effect = RuntimeError("keyboard offline")
+        computer.keypress.return_value = None
+        computer.screenshot.return_value = "fresh"
+        item = _function_call_with_execution(
+            "computer_batch",
+            {"actions": []},
+            "batch-1",
+            [
+                {"type": "move", "x": 1, "y": 2, "batch_index": 0},
+                {"type": "type", "text": "hello", "batch_index": 1},
+                {"type": "keypress", "keys": ["enter"], "batch_index": 2},
+            ],
+            batch_actions=[{"action": "move"}, {"action": "type"}, {"action": "key_press"}],
+        )
+
+        result = await _bare_agent()._handle_item(item, computer)
+
+        computer.keypress.assert_not_awaited()
+        assert result[0]["output"]["result"]["completed"] == 1
+        assert result[0]["output"]["result"]["failed"] == 1
+        assert result[0]["output"]["result"]["skipped"] == 1
+        assert result[0]["output"]["result"]["failed_action_index"] == 1
+
+    @pytest.mark.asyncio
+    async def test_confirmation_once_and_screenshot_action_not_duplicated(self):
+        confirmation = AsyncMock(return_value=False)
+        computer = AsyncMock()
+        item = _function_call_with_execution(
+            "computer_batch",
+            {"actions": [{"action": "type", "text": "secret"}]},
+            "batch-1",
+            [{"type": "type", "text": "secret", "batch_index": 0}],
+            batch_actions=[{"action": "type", "text": "secret"}],
+        )
+
+        denied = await _bare_agent(confirmation)._handle_item(item, computer)
+
+        confirmation.assert_awaited_once()
+        computer.type.assert_not_awaited()
+        computer.screenshot.assert_not_awaited()
+        assert "not confirmed" in denied[0]["output"]
+
+        screenshot_item = _function_call_with_execution(
+            "screenshot", {}, "shot-1", [{"type": "screenshot"}]
+        )
+        computer.screenshot.return_value = "only-shot"
+        result = await _bare_agent()._handle_item(screenshot_item, computer)
+        computer.screenshot.assert_awaited_once()
+        assert result[0]["output"]["image_url"].endswith("only-shot")
+
+    @pytest.mark.asyncio
+    async def test_deadline_is_checked_before_each_batch_member(self):
+        computer = AsyncMock()
+        computer.screenshot.return_value = "fresh"
+        item = _function_call_with_execution(
+            "computer_batch",
+            {"actions": [{"action": "wait"}]},
+            "batch-1",
+            [{"type": "wait", "ms": 0, "batch_index": 0}],
+            batch_actions=[{"action": "wait"}],
+            execution_deadline=time.monotonic() - 1,
+        )
+
+        result = await _bare_agent()._handle_item(item, computer)
+
+        computer.wait.assert_not_awaited()
+        assert result[0]["output"]["result"]["error"] == "deadline_reached"
+        assert result[0]["output"]["result"]["skipped"] == 1

--- a/libs/python/agent/tests/test_yutori_n2.py
+++ b/libs/python/agent/tests/test_yutori_n2.py
@@ -84,6 +84,7 @@ class TestRouting:
     def test_adapter_does_not_invent_n2_latest_alias(self):
         adapter = YutoriAdapter(api_key="test")
 
+        assert adapter._normalize_model("yutori/n1") == "n1-latest"
         assert adapter._normalize_model("yutori/n1.5") == "n1.5-latest"
         assert adapter._normalize_model("yutori/n2") == "n2"
         assert adapter._normalize_model("yutori/n2-preview") == "n2-preview"
@@ -115,6 +116,17 @@ class TestTranslation:
         actions = translate_n2_action("left_click", {"coordinates": [500, 500]}, 2880, 1800)
 
         assert actions == [{"type": "click", "x": 1440, "y": 900, "button": "left"}]
+
+    def test_coordinate_corners_are_valid_native_pixel_indices(self):
+        top_left = translate_n2_action("mouse_move", {"coordinates": [0, 0]}, 1280, 800)
+        bottom_right = translate_n2_action("mouse_move", {"coordinates": [1000, 1000]}, 1280, 800)
+
+        assert top_left == [{"type": "move", "x": 0, "y": 0}]
+        assert bottom_right == [{"type": "move", "x": 1279, "y": 799}]
+
+    def test_non_positive_native_dimensions_are_rejected(self):
+        with pytest.raises(N2ActionValidationError, match="dimensions must be positive"):
+            translate_n2_action("mouse_move", {"coordinates": [500, 500]}, 0, 800)
 
     @pytest.mark.parametrize(
         ("action", "arguments", "expected_type"),

--- a/libs/python/computer-server/computer_server/browser.py
+++ b/libs/python/computer-server/computer_server/browser.py
@@ -169,7 +169,25 @@ class BrowserManager:
             y = params.get("y")
             if x is None or y is None:
                 return {"success": False, "error": "x and y parameters are required"}
-            await self.page.mouse.click(x, y)
+            button = params.get("button", "left")
+            click_count = params.get("click_count", 1)
+            # Playwright modifier key names, e.g. ["Control"] for ctrl+click
+            modifiers = params.get("modifiers") or []
+            for modifier in modifiers:
+                await self.page.keyboard.down(modifier)
+            try:
+                await self.page.mouse.click(x, y, button=button, click_count=click_count)
+            finally:
+                for modifier in reversed(modifiers):
+                    await self.page.keyboard.up(modifier)
+            return {"success": True}
+
+        elif cmd == "dblclick":
+            x = params.get("x")
+            y = params.get("y")
+            if x is None or y is None:
+                return {"success": False, "error": "x and y parameters are required"}
+            await self.page.mouse.dblclick(x, y)
             return {"success": True}
 
         elif cmd == "type":
@@ -214,6 +232,17 @@ class BrowserManager:
         elif cmd == "go_forward":
             await self.page.go_forward()
             return {"success": True, "url": self.page.url}
+
+        elif cmd == "refresh":
+            await self.page.reload(wait_until="domcontentloaded", timeout=30000)
+            return {"success": True, "url": self.page.url}
+
+        elif cmd == "evaluate":
+            expression = params.get("expression")
+            if not expression:
+                return {"success": False, "error": "expression parameter is required"}
+            result = await self.page.evaluate(expression)
+            return {"success": True, "result": result}
 
         else:
             return {"success": False, "error": f"Unknown command: {cmd}"}


### PR DESCRIPTION
## Summary

- add exact `yutori/n2-preview` routing through a distinct computer-use loop
- translate and validate all n2 desktop actions, Cua key grammar, normalized coordinates, and ordered `computer_batch` calls
- resize model screenshots without changing native execution coordinates
- retain images from the two newest image-bearing messages without deleting reasoning or action history
- bound complete request size and add confirmation/stop-on-error behavior

## Dependency

This draft is stacked on #2234, which fixes and tests the Yutori Navigator n1.5 integration. Until #2234 merges, this PR's diff against upstream main also includes that prerequisite. The n2 commits themselves are `bf910b43` and `257783cd`.

## Validation

- 95 focused Yutori n1.5/n2 tests
- Ruff on the n2 loop and tests
- live batch execution against `trycua/cua-xfce:latest`
- live non-batch task completed in 5 model turns and 4 executed actions; the agent created and read `/tmp/n2_multiturn.txt`, and an independent container check verified `N2_MULTI_TURN_OK`
- every model request retained at most two screenshots
