### PR TITLE
ci(cua-driver): publish ClawHub skill after releases

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -29,6 +29,31 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertIn('default: ""', workflow)
         self.assertIn("libs/cua-driver/rust/Cargo.toml", workflow)
 
+    def test_clawhub_publish_follows_verified_driver_release(self) -> None:
+        workflow = self.read(".github/workflows/clawhub-cua-driver.yml")
+
+        self.assertIn('workflows: ["CD: Cua Driver (cross-platform)"]', workflow)
+        self.assertIn("github.event.workflow_run.conclusion == 'success'", workflow)
+        self.assertIn('git("tag", "--points-at", source_sha)', workflow)
+        self.assertIn('"gh",\n                      "release",\n                      "view"', workflow)
+        self.assertIn("needs.release-context.outputs.should_publish == 'true'", workflow)
+        self.assertIn("--source-commit \"${SOURCE_SHA}\"", workflow)
+        self.assertIn("--source-ref \"${SOURCE_REF}\"", workflow)
+        self.assertIn("Request ClawHub security scan", workflow)
+
+    def test_clawhub_manual_publish_keeps_rights_confirmation(self) -> None:
+        workflow = self.read(".github/workflows/clawhub-cua-driver.yml")
+
+        self.assertIn("confirm_mit0:", workflow)
+        self.assertIn(
+            'if os.environ["CONFIRM_MIT0"] != "true":',
+            workflow,
+        )
+        self.assertIn(
+            'if os.environ["GITHUB_REF"] != "refs/heads/main":',
+            workflow,
+        )
+
     def test_python_publish_builds_linux_arm64_wheel(self) -> None:
         workflow = self.read(".github/workflows/cd-py-cua-driver.yml")
 

--- a/.github/workflows/clawhub-cua-driver.yml
+++ b/.github/workflows/clawhub-cua-driver.yml
@@ -23,6 +23,14 @@ on:
         required: true
         default: false
         type: boolean
+  # Publish only after the cross-platform release workflow has built and
+  # published the immutable GitHub release successfully. The context job below
+  # rejects successful manual/diagnostic CD runs that are not attached to a
+  # cua-driver release tag.
+  workflow_run:
+    workflows: ["CD: Cua Driver (cross-platform)"]
+    types:
+      - completed
 
 permissions:
   contents: read
@@ -32,6 +40,7 @@ env:
   CLAWHUB_CLI_VERSION: "0.23.1"
   CLAWHUB_SKILL_SLUG: "driver"
   SKILL_PATH: "libs/cua-driver/rust/Skills/cua-driver"
+  AUTOMATED_PUBLISHER_OWNER: "cua"
 
 jobs:
   dry-run:
@@ -83,32 +92,118 @@ jobs:
           path: ${{ runner.temp }}/clawhub-dry-run.json
           if-no-files-found: ignore
 
-  publish:
-    name: Publish ${{ inputs.version }} as @${{ inputs.owner }}/driver
-    if: github.event_name == 'workflow_dispatch'
+  release-context:
+    name: Resolve trusted ClawHub release context
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      owner: ${{ steps.release.outputs.owner }}
+      should_publish: ${{ steps.release.outputs.should_publish }}
+      source_ref: ${{ steps.release.outputs.source_ref }}
+      source_sha: ${{ steps.release.outputs.source_sha }}
+      version: ${{ steps.release.outputs.version }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
 
-      - name: Validate release inputs
+      - name: Resolve and validate release
+        id: release
         env:
           CONFIRM_MIT0: ${{ inputs.confirm_mit0 }}
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_OWNER: ${{ inputs.owner }}
           REQUESTED_VERSION: ${{ inputs.version }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           python3 - <<'PY'
           import os
           import re
+          import subprocess
           import tomllib
           from pathlib import Path
 
-          if os.environ["CONFIRM_MIT0"] != "true":
-              raise SystemExit("confirm_mit0 must be checked before a public release")
-          if os.environ["GITHUB_REF"] != "refs/heads/main":
-              raise SystemExit("ClawHub releases must be dispatched from the main branch")
+          def git(*args: str) -> str:
+              return subprocess.check_output(["git", *args], text=True).strip()
 
-          requested = os.environ["REQUESTED_VERSION"].strip()
+          event_name = os.environ["EVENT_NAME"]
+          source_sha = git("rev-parse", "HEAD")
+
+          if event_name == "workflow_dispatch":
+              if os.environ["CONFIRM_MIT0"] != "true":
+                  raise SystemExit(
+                      "confirm_mit0 must be checked before a public release"
+                  )
+              if os.environ["GITHUB_REF"] != "refs/heads/main":
+                  raise SystemExit(
+                      "ClawHub releases must be dispatched from the main branch"
+                  )
+              requested = os.environ["REQUESTED_VERSION"].strip()
+              owner = os.environ["MANUAL_OWNER"].strip()
+              source_ref = os.environ["GITHUB_REF"]
+          else:
+              expected_sha = os.environ["WORKFLOW_HEAD_SHA"].strip()
+              if not re.fullmatch(r"[0-9a-f]{40}", expected_sha):
+                  raise SystemExit(f"invalid triggering workflow SHA: {expected_sha!r}")
+              if source_sha != expected_sha:
+                  raise SystemExit(
+                      f"checked-out source {source_sha} does not match trigger {expected_sha}"
+                  )
+
+              tags = [
+                  tag
+                  for tag in git("tag", "--points-at", source_sha).splitlines()
+                  if re.fullmatch(
+                      r"cua-driver-rs-v[0-9]+\.[0-9]+\.[0-9]+"
+                      r"(?:-[0-9A-Za-z.-]+)?",
+                      tag,
+                  )
+              ]
+              if not tags:
+                  print(
+                      "Successful Driver CD run is not attached to a release tag; "
+                      "skipping ClawHub publish."
+                  )
+                  with Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+                      output.write("should_publish=false\n")
+                  raise SystemExit(0)
+              if len(tags) != 1:
+                  raise SystemExit(
+                      f"expected one Driver release tag at {source_sha}, found {tags}"
+                  )
+
+              tag = tags[0]
+              requested = tag.removeprefix("cua-driver-rs-v")
+              owner = os.environ["AUTOMATED_PUBLISHER_OWNER"]
+              source_ref = f"refs/tags/{tag}"
+
+              release = subprocess.run(
+                  [
+                      "gh",
+                      "release",
+                      "view",
+                      tag,
+                      "--repo",
+                      os.environ["GITHUB_REPOSITORY"],
+                      "--json",
+                      "isDraft,tagName",
+                      "--jq",
+                      'select(.isDraft == false) | .tagName',
+                  ],
+                  check=True,
+                  text=True,
+                  capture_output=True,
+              ).stdout.strip()
+              if release != tag:
+                  raise SystemExit(f"published GitHub release {tag} is not available")
+
           cargo = tomllib.loads(Path("libs/cua-driver/rust/Cargo.toml").read_text())
           cargo_version = cargo["workspace"]["package"]["version"]
           skill_text = Path(os.environ["SKILL_PATH"], "SKILL.md").read_text()
@@ -123,7 +218,34 @@ jobs:
                   "version mismatch: "
                   f"requested={requested}, Cargo.toml={cargo_version}, SKILL.md={skill_version}"
               )
+
+          if not owner:
+              raise SystemExit("ClawHub publisher owner is empty")
+
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+              output.write(f"owner={owner}\n")
+              output.write("should_publish=true\n")
+              output.write(f"source_ref={source_ref}\n")
+              output.write(f"source_sha={source_sha}\n")
+              output.write(f"version={requested}\n")
           PY
+
+  publish:
+    name: Publish ${{ needs.release-context.outputs.version }} as @${{ needs.release-context.outputs.owner }}/driver
+    needs: release-context
+    if: needs.release-context.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-context.outputs.source_ref }}
+
+      - name: Verify immutable release checkout
+        env:
+          EXPECTED_SHA: ${{ needs.release-context.outputs.source_sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
 
       - name: Configure ClawHub authentication
         env:
@@ -144,10 +266,12 @@ jobs:
               env_file.write(f"CLAWHUB_CONFIG_PATH={path}\n")
           PY
 
-      - name: Publish @${{ inputs.owner }}/driver
+      - name: Publish @${{ needs.release-context.outputs.owner }}/driver
         env:
-          OWNER: ${{ inputs.owner }}
-          VERSION: ${{ inputs.version }}
+          OWNER: ${{ needs.release-context.outputs.owner }}
+          SOURCE_REF: ${{ needs.release-context.outputs.source_ref }}
+          SOURCE_SHA: ${{ needs.release-context.outputs.source_sha }}
+          VERSION: ${{ needs.release-context.outputs.version }}
         run: |
           npx --yes "clawhub@${CLAWHUB_CLI_VERSION}" skill publish "${SKILL_PATH}" \
             --slug "${CLAWHUB_SKILL_SLUG}" \
@@ -157,10 +281,20 @@ jobs:
             --changelog "Cua Driver ${VERSION}" \
             --tags latest \
             --source-repo "${GITHUB_REPOSITORY}" \
-            --source-commit "${GITHUB_SHA}" \
-            --source-ref "${GITHUB_REF}" \
+            --source-commit "${SOURCE_SHA}" \
+            --source-ref "${SOURCE_REF}" \
             --source-path "${SKILL_PATH}" \
             --json | tee "${RUNNER_TEMP}/clawhub-publish.json"
+
+      - name: Request ClawHub security scan
+        env:
+          VERSION: ${{ needs.release-context.outputs.version }}
+        run: |
+          npx --yes "clawhub@${CLAWHUB_CLI_VERSION}" scan \
+            --slug "${CLAWHUB_SKILL_SLUG}" \
+            --version "${VERSION}" \
+            --update \
+            --json | tee "${RUNNER_TEMP}/clawhub-scan.json"
 
       - name: Summarize release
         if: always()
@@ -173,11 +307,21 @@ jobs:
               echo '```'
             } >> "${GITHUB_STEP_SUMMARY}"
           fi
+          if [[ -f "${RUNNER_TEMP}/clawhub-scan.json" ]]; then
+            {
+              echo '## ClawHub scan result'
+              echo '```json'
+              cat "${RUNNER_TEMP}/clawhub-scan.json"
+              echo '```'
+            } >> "${GITHUB_STEP_SUMMARY}"
+          fi
 
       - name: Upload publish result
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: clawhub-driver-publish-${{ inputs.version }}
-          path: ${{ runner.temp }}/clawhub-publish.json
+          name: clawhub-driver-publish-${{ needs.release-context.outputs.version }}
+          path: |
+            ${{ runner.temp }}/clawhub-publish.json
+            ${{ runner.temp }}/clawhub-scan.json
           if-no-files-found: ignore

--- a/libs/cua-driver/README.md
+++ b/libs/cua-driver/README.md
@@ -103,9 +103,18 @@ under MIT-0. Before a release, retain an internal record that Cua AI has the
 right to distribute every bundled file under MIT-0.
 
 Pull requests that change the skill run a publish dry-run with the pinned
-ClawHub CLI. A real release is available only through the
-`ClawHub: cua-driver skill` workflow's manual dispatch. The publish job requires
-all of the following:
+ClawHub CLI. After the cross-platform Driver CD workflow publishes a successful,
+immutable `cua-driver-rs-v*` GitHub release, the `ClawHub: cua-driver skill`
+workflow automatically publishes the matching skill and requests its security
+scan. Successful diagnostic CD runs without a matching tag and GitHub release
+are ignored.
+
+Merging a Driver skill change confirms that Cua AI may distribute every bundled
+file under MIT-0 when the next Driver release is cut. Keep the supporting rights
+record internally. If that invariant cannot be confirmed for a change, do not
+merge it into the published skill directory.
+
+Manual dispatch remains the recovery path. It requires all of the following:
 
 1. Dispatch the workflow from `main`.
 2. Enter a version that matches both `rust/Cargo.toml` and the `version` field
@@ -114,8 +123,11 @@ all of the following:
 4. Configure a repository Actions secret named `CLAWHUB_TOKEN` for a publisher
    that can release under the selected owner. The default owner is `cua`.
 
-The workflow pins the ClawHub CLI, records the source repository, commit, ref,
-and path, and uploads the JSON publish result as an Actions artifact.
+Both paths pin the ClawHub CLI, verify that Cargo and skill versions match,
+record the source repository, commit, ref, and path, request a security scan,
+and upload the publish and scan results as Actions artifacts. The automatic path
+also requires a successful Driver CD run, a unique Driver release tag at the
+triggering SHA, and a non-draft GitHub release for that tag.
 
 After publishing, inspect and scan the exact version, then install it into an
 empty work directory:


### PR DESCRIPTION
## Summary

- publish `@cua/driver` automatically after the cross-platform Driver CD workflow completes successfully for an immutable release tag
- retain the guarded manual-dispatch path for recovery
- request the ClawHub security scan and preserve publish/scan evidence as workflow artifacts
- document the MIT-0 release invariant and automatic release flow

## Root cause

The existing workflow only published on `workflow_dispatch`. Driver release pull requests ran a ClawHub dry-run, but releases `0.9.0` through `0.11.0` never invoked a real publish job.

## Safeguards

The automatic path requires all of the following before the ClawHub token is used:

- successful completion of `CD: Cua Driver (cross-platform)`
- one valid `cua-driver-rs-v*` tag at the triggering SHA
- a non-draft GitHub release for that tag
- matching tag, Cargo workspace, and `SKILL.md` versions
- checkout provenance matching the triggering release SHA

Successful diagnostic/manual CD runs without a matching release tag are skipped. Manual ClawHub recovery publishes still require an explicit MIT-0 confirmation and dispatch from `main`.

## Verification

- `python3 .github/scripts/tests/test_cua_driver_release_wiring.py` — 31 passed
- isolated `.github/scripts/tests` suite — 117 passed
- `python3 .github/scripts/validate_release_versions.py --product driver`
- Actionlint 1.7.12 on `.github/workflows/clawhub-cua-driver.yml`
- Ruby YAML syntax parse
- `git diff --check`

Closes #2264