### PR TITLE
test(cua-driver): derive Electron fixture version

### DIFF
--- a/libs/cua-driver/typescript/test/electron-main-fixture.mjs
+++ b/libs/cua-driver/typescript/test/electron-main-fixture.mjs
@@ -4,6 +4,9 @@ import path from "node:path"
 
 const directory = mkdtempSync(path.join(os.tmpdir(), "cua-driver-electron-host-"))
 const binaryPath = path.join(directory, "generic-driver-host")
+const packageVersion = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+).version
 
 writeFileSync(
   binaryPath,
@@ -23,7 +26,7 @@ const server = net.createServer(socket => {
     if (!buffer.includes("\\n")) return;
     const request = JSON.parse(buffer.split("\\n", 1)[0]);
     const result = request.method === "metadata" ? {
-      driver_version: "0.11.0",
+      driver_version: ${JSON.stringify(packageVersion)},
       contract_version: hostBundleId.endsWith(".failure") ? "incompatible" : "0.2.0",
       tools_list_schema_version: "1",
       capability_version: "1",
@@ -76,11 +79,10 @@ try {
     versions: {
       electron: process.versions.electron,
       node: process.versions.node,
-      package: JSON.parse(
-        readFileSync(new URL("../package.json", import.meta.url), "utf8"),
-      ).version,
+      package: packageVersion,
     },
     connection: {
+      driverVersion: connection.driverVersion,
       socketPathIsPrivate:
         socketPath.startsWith(os.tmpdir()) && path.basename(socketPath).startsWith("cua-"),
       pidMatchesChild: Number(readFileSync(path.join(directory, "com.example.electron-host.pid"), "utf8")) === pid,

--- a/libs/cua-driver/typescript/test/electron-main.test.mjs
+++ b/libs/cua-driver/typescript/test/electron-main.test.mjs
@@ -1,12 +1,15 @@
 import assert from "node:assert/strict"
 import { spawn } from "node:child_process"
-import { existsSync } from "node:fs"
+import { existsSync, readFileSync } from "node:fs"
 import path from "node:path"
 import test from "node:test"
 import { fileURLToPath } from "node:url"
 
 const testDirectory = path.dirname(fileURLToPath(import.meta.url))
 const electron = path.resolve(testDirectory, "../node_modules/.bin/electron")
+const packageVersion = JSON.parse(
+  readFileSync(path.resolve(testDirectory, "../package.json"), "utf8"),
+).version
 
 test(
   "Electron main receives embedded connection values and cleans up lifecycle",
@@ -29,7 +32,8 @@ test(
     assert.equal(code, 0, `stdout:\n${stdout}\nstderr:\n${stderr}`)
     const result = JSON.parse(stdout.trim().split("\n").at(-1))
     assert.equal(result.versions.electron, "43.2.0")
-    assert.equal(result.versions.package, "0.11.0")
+    assert.equal(result.versions.package, packageVersion)
+    assert.equal(result.connection.driverVersion, packageVersion)
     assert.equal(result.connection.socketPathIsPrivate, true)
     assert.equal(result.connection.pidMatchesChild, true)
     assert.equal(result.connection.stateIsReady, true)


### PR DESCRIPTION
## Summary

- derive the Electron fixture metadata version from the TypeScript package manifest
- assert the embedded connection reports the same package version
- keep the lifecycle test valid across Release Please version bumps

This fixes the generated-contract check exposed by the 0.12.0 release PR.

## Validation

- `npm run typecheck`
- `CUA_DRIVER_REQUIRE_UNIFFI=1 npm test` at 0.11.0
- the same suite with a temporary local 0.12.0 package-version bump (all 5 tests passed)

## Release impact

Test-only; no product behavior or public API changes.