### PR TITLE
ci(cua-driver): require E2E before publication

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -355,6 +355,27 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertIn('--tag "${{ steps.version.outputs.tag }}"', workflow)
         self.assertIn('--sha "${{ steps.version.outputs.sha }}"', workflow)
 
+    def test_driver_tag_build_cannot_publish_before_manual_e2e_gate(self) -> None:
+        workflow = self.read(".github/workflows/cd-rust-cua-driver.yml")
+        self.assertIn(
+            "if: github.event_name == 'workflow_dispatch' && inputs.publish == true",
+            workflow,
+        )
+        self.assertNotIn(
+            "if: startsWith(github.ref, 'refs/tags/cua-driver-rs-v') || inputs.publish == true",
+            workflow,
+        )
+
+        linux = self.read(".github/workflows/e2e-rust-linux.yml")
+        self.assertIn('name: "Linux / install-local.sh smoke"', linux)
+        self.assertIn("bash libs/cua-driver/scripts/install-local.sh --release", linux)
+        self.assertIn("CUA_DRIVER_LOCAL_HOME: ${{ runner.temp }}/cua-driver-local-home", linux)
+
+        windows = self.read(".github/workflows/e2e-rust-windows.yml")
+        self.assertIn('name: "Windows / install-local.ps1 smoke"', windows)
+        self.assertIn("install-local.ps1 -NoAutoStart -NoPathUpdate", windows)
+        self.assertIn('CUA_DRIVER_LOCAL_HOME = Join-Path $env:RUNNER_TEMP', windows)
+
     def test_driver_release_publishes_checksums_for_python_wheels(self) -> None:
         workflow = self.read(".github/workflows/cd-rust-cua-driver.yml")
 

--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -510,9 +510,14 @@ jobs:
           if-no-files-found: error
 
   # ── Release ──────────────────────────────────────────────────────────────────
+  # Tag pushes build immutable candidate artifacts only. Publishing is an
+  # explicit second step after the exact tag SHA passes the interactive E2E
+  # matrices and install-local smokes. This keeps Release Please from making a
+  # GitHub release (and therefore PyPI/npm SDK packages) public before that
+  # evidence exists.
   release:
     needs: [build-linux, build-windows, build-macos-universal]
-    if: startsWith(github.ref, 'refs/tags/cua-driver-rs-v') || inputs.publish == true
+    if: github.event_name == 'workflow_dispatch' && inputs.publish == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e-rust-linux.yml
+++ b/.github/workflows/e2e-rust-linux.yml
@@ -17,6 +17,7 @@ on:
           - shared
           - native
           - capture
+          - installer
       cell_filter:
         description: "Optional shared-cell substring for targeted diagnostics"
         required: false
@@ -165,9 +166,68 @@ jobs:
           compression-level: 0
           retention-days: 14
 
+  installer:
+    if: inputs.lane == 'all' || inputs.lane == 'installer'
+    name: "Linux / install-local.sh smoke"
+    needs: source
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      CUA_E2E_SOURCE_SHA: ${{ needs.source.outputs.sha }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.source.outputs.sha }}
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            clang pkg-config libdbus-1-dev libpipewire-0.3-dev \
+            libspa-0.2-dev libei-dev libwayland-dev libxkbcommon-dev \
+            libx11-dev libxi-dev libxtst-dev libxext-dev
+      - name: Install into an isolated local namespace
+        shell: bash
+        env:
+          CUA_DRIVER_SOURCE_SHA: ${{ needs.source.outputs.sha }}
+          CUA_DRIVER_LOCAL_HOME: ${{ runner.temp }}/cua-driver-local-home
+          CUA_DRIVER_LOCAL_INSTALL_DIR: ${{ runner.temp }}/cua-driver-local-bin
+        run: |
+          set -euo pipefail
+          bash libs/cua-driver/scripts/install-local.sh --release
+          installed="$CUA_DRIVER_LOCAL_INSTALL_DIR/cua-driver-local"
+          test -x "$installed"
+          "$installed" --version | tee "$RUNNER_TEMP/cua-driver-local-version.txt"
+
+          socket="$RUNNER_TEMP/cua-driver-local.sock"
+          "$installed" serve --socket "$socket" \
+            >"$RUNNER_TEMP/cua-driver-local-daemon.log" 2>&1 &
+          daemon_pid=$!
+          trap 'kill "$daemon_pid" 2>/dev/null || true; wait "$daemon_pid" 2>/dev/null || true' EXIT
+          for _ in $(seq 1 30); do
+            [[ -S "$socket" ]] && break
+            kill -0 "$daemon_pid"
+            sleep 1
+          done
+          test -S "$socket"
+          "$installed" --socket "$socket" call get_config '{}' \
+            | tee "$RUNNER_TEMP/cua-driver-local-config.json"
+          grep -Fq "$CUA_DRIVER_SOURCE_SHA" "$RUNNER_TEMP/cua-driver-local-config.json"
+      - name: Upload installer evidence
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: rust-linux-install-local
+          path: |
+            ${{ runner.temp }}/cua-driver-local-version.txt
+            ${{ runner.temp }}/cua-driver-local-config.json
+            ${{ runner.temp }}/cua-driver-local-daemon.log
+          if-no-files-found: ignore
+          retention-days: 14
+
   summary:
     if: always()
-    needs: [source, shared, native, capture]
+    needs: [source, shared, native, capture, installer]
     name: "Linux / matrix summary"
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/e2e-rust-windows.yml
+++ b/.github/workflows/e2e-rust-windows.yml
@@ -11,6 +11,17 @@ on:
         description: "Runner label; use the Azure RDP runner label for VM e2e"
         required: true
         default: "windows-latest"
+      lane:
+        description: "Diagnostic lane; canonical interactive dispatches use all"
+        required: false
+        type: choice
+        default: all
+        options:
+          - all
+          - shared
+          - native
+          - capture
+          - installer
 
 permissions:
   contents: read
@@ -38,6 +49,7 @@ jobs:
           echo "sha=${sha,,}" >> "$GITHUB_OUTPUT"
 
   shared:
+    if: inputs.lane == 'all' || inputs.lane == 'shared'
     name: "Windows / shared Electron + Tauri"
     needs: source
     runs-on: ${{ inputs.runner }}
@@ -76,6 +88,7 @@ jobs:
           retention-days: 14
 
   native:
+    if: inputs.lane == 'all' || inputs.lane == 'native'
     name: "Windows / native WPF + WinUI3 + WebView2"
     needs: source
     runs-on: ${{ inputs.runner }}
@@ -114,6 +127,7 @@ jobs:
           retention-days: 14
 
   capture:
+    if: inputs.lane == 'all' || inputs.lane == 'capture'
     name: "Windows / capture and desktop scope"
     needs: source
     runs-on: ${{ inputs.runner }}
@@ -151,9 +165,80 @@ jobs:
           compression-level: 0
           retention-days: 14
 
+  installer:
+    if: inputs.lane == 'all' || inputs.lane == 'installer'
+    name: "Windows / install-local.ps1 smoke"
+    needs: source
+    runs-on: windows-latest
+    timeout-minutes: 45
+    env:
+      CUA_E2E_SOURCE_SHA: ${{ needs.source.outputs.sha }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.source.outputs.sha }}
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install into an isolated local namespace
+        shell: pwsh
+        env:
+          CUA_DRIVER_SOURCE_SHA: ${{ needs.source.outputs.sha }}
+        run: |
+          $env:CUA_DRIVER_LOCAL_HOME = Join-Path $env:RUNNER_TEMP "cua-driver-local-home"
+          $env:CUA_DRIVER_LOCAL_INSTALL_DIR = Join-Path $env:RUNNER_TEMP "cua-driver-local-bin"
+          & .\libs\cua-driver\scripts\install-local.ps1 -NoAutoStart -NoPathUpdate
+
+          $installed = Join-Path $env:CUA_DRIVER_LOCAL_INSTALL_DIR "cua-driver-local.exe"
+          if (-not (Test-Path -LiteralPath $installed)) { throw "missing installed binary: $installed" }
+          & $installed --version | Tee-Object -FilePath (Join-Path $env:RUNNER_TEMP "cua-driver-local-version.txt")
+          if ($LASTEXITCODE -ne 0) { throw "installed binary --version failed with exit $LASTEXITCODE" }
+
+          $socket = "\\.\pipe\cua-driver-install-smoke-$env:GITHUB_RUN_ID"
+          $daemonOut = Join-Path $env:RUNNER_TEMP "cua-driver-local-daemon.out.log"
+          $daemonErr = Join-Path $env:RUNNER_TEMP "cua-driver-local-daemon.err.log"
+          $daemon = Start-Process -FilePath $installed `
+            -ArgumentList @('serve', '--socket', $socket) `
+            -RedirectStandardOutput $daemonOut -RedirectStandardError $daemonErr `
+            -NoNewWindow -PassThru
+          try {
+            $configPath = Join-Path $env:RUNNER_TEMP "cua-driver-local-config.json"
+            $connected = $false
+            foreach ($attempt in 1..30) {
+              if ($daemon.HasExited) { throw "installed daemon exited early with code $($daemon.ExitCode)" }
+              $config = (& $installed --socket $socket call get_config '{}' 2>$null | Out-String).Trim()
+              if ($LASTEXITCODE -eq 0) {
+                $config | Tee-Object -FilePath $configPath
+                $connected = $true
+                break
+              }
+              Start-Sleep -Seconds 1
+            }
+            if (-not $connected) { throw "installed binary could not connect to its daemon" }
+          }
+          finally {
+            if (-not $daemon.HasExited) {
+              Stop-Process -Id $daemon.Id -ErrorAction SilentlyContinue
+              $daemon.WaitForExit(5000) | Out-Null
+            }
+          }
+          if (-not (Select-String -LiteralPath (Join-Path $env:RUNNER_TEMP "cua-driver-local-config.json") -SimpleMatch $env:CUA_DRIVER_SOURCE_SHA -Quiet)) {
+            throw "installed binary did not report the expected source SHA"
+          }
+      - name: Upload installer evidence
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: rust-windows-install-local
+          path: |
+            ${{ runner.temp }}/cua-driver-local-version.txt
+            ${{ runner.temp }}/cua-driver-local-config.json
+            ${{ runner.temp }}/cua-driver-local-daemon.out.log
+            ${{ runner.temp }}/cua-driver-local-daemon.err.log
+          if-no-files-found: ignore
+          retention-days: 14
+
   summary:
     if: always()
-    needs: [source, shared, native, capture]
+    needs: [source, shared, native, capture, installer]
     name: "Windows / matrix summary"
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/docs/release-attribution-and-announcements-plan.md
+++ b/docs/release-attribution-and-announcements-plan.md
@@ -568,7 +568,7 @@ GitHub release: draft
 Target SHA: the merged release pull request commit
 ```
 
-The Cua Driver CD workflow starts from the tag, builds the platform artifacts, looks up the matching draft by release ID, and uploads assets without changing its body or publication state. The attribution check confirms `@alice` as the pull request author and `@bob` as the linked issue reporter.
+The Cua Driver CD workflow starts from the tag and builds immutable candidate artifacts, but a tag push cannot publish the draft. A maintainer first dispatches the Linux, Windows, and macOS interactive E2E matrices against that exact tag SHA; the Linux and Windows matrices also exercise `install-local.sh` and `install-local.ps1` in isolated namespaces, while the canonical macOS Lume matrix installs through `install-local.sh` under the stable TCC identity. Only after that evidence passes does a `workflow_dispatch` with `publish: true` rebuild the same tag, upload the release assets, and finalize the draft. The attribution check confirms `@alice` as the pull request author and `@bob` as the linked issue reporter.
 
 #### Final GitHub release body
 
@@ -840,13 +840,15 @@ The cloud repository should consume the release manifest only after the core wor
 
 ### Publication
 
-1. Let the existing tag-triggered CD workflow build and test the exact tagged commit.
-2. List GitHub releases, include drafts, and match the unique draft by `tag_name`; retain its release ID and upload URL.
-3. Upload packages and checksums by release ID without writing the body, changing the draft flag, or creating a second release. Remove `softprops/action-gh-release` from these two CD paths unless a pinned version is fixture-proven to reuse the same draft safely.
-4. Attach the attribution manifest and optional visual to the same release ID.
-5. Let the **release finalizer job** be the only writer of the final body and the only job allowed to change `draft: true` to published. It waits for all required product artifacts and attribution checks, marks Cua Driver as a prerelease, and allows Lume to become the latest release.
-6. Verify that the release body matches the tag-pinned changelog data and that the manifest tag and SHA match the release target.
-7. Publish the GitHub release and produce the non-blocking social draft artifact.
+1. Let the tag-triggered CD workflow build candidate artifacts from the exact tagged commit; it must not publish the draft.
+2. Dispatch the canonical interactive E2E matrices with the full tag SHA. Require the Linux shared, native, capture, and `install-local.sh` lanes; the Windows interactive lanes on a GUI runner plus the hosted `install-local.ps1` lane; and the macOS Lume matrix, which includes its own signed `install-local.sh` and TCC checks.
+3. After those runs pass, dispatch the Cua Driver CD workflow for the immutable version with `publish: true`.
+4. List GitHub releases, include drafts, and match the unique draft by `tag_name`; retain its release ID and upload URL.
+5. Upload packages and checksums by release ID without writing the body, changing the draft flag, or creating a second release. Remove `softprops/action-gh-release` from these two CD paths unless a pinned version is fixture-proven to reuse the same draft safely.
+6. Attach the attribution manifest and optional visual to the same release ID.
+7. Let the **release finalizer job** be the only writer of the final body and the only job allowed to change `draft: true` to published. It waits for all required product artifacts and attribution checks, marks Cua Driver as a prerelease, and allows Lume to become the latest release.
+8. Verify that the release body matches the tag-pinned changelog data and that the manifest tag and SHA match the release target.
+9. Publish the GitHub release and produce the non-blocking social draft artifact.
 
 All jobs that mutate a release use a per-tag concurrency group. During the
 pilot, rendering failures leave the release in draft along with artifact,


### PR DESCRIPTION
## Summary

- keep tag-triggered Cua Driver builds as unpublished release candidates
- require an explicit publish dispatch after exact-SHA interactive E2E certification
- add isolated `install-local.sh` and `install-local.ps1` smoke lanes with provenance checks
- document the two-phase release flow and cover it with repository wiring tests

## Validation

- `python3 .github/scripts/tests/test_cua_driver_release_wiring.py`
- `actionlint` on the three changed workflows (with existing custom runner and style warnings ignored)
- `git diff --check`

This is CI/release-process hardening only and intentionally does not create another Cua Driver release.