### PR TITLE
fix(cua-driver): make macOS SDK load standalone

### DIFF
--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -355,9 +355,13 @@ jobs:
             rust-cua-driver-rs-darwin-universal-
       - name: Build arm64
         working-directory: libs/cua-driver/rust
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "13.0"
         run: cargo build --locked -p cua-driver -p cua-driver-sdk --release --target aarch64-apple-darwin
       - name: Build x86_64
         working-directory: libs/cua-driver/rust
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "13.0"
         run: cargo build --locked -p cua-driver -p cua-driver-sdk --release --target x86_64-apple-darwin
       - name: Build Electron-compatible Node runtimes
         working-directory: libs/cua-driver
@@ -387,6 +391,12 @@ jobs:
           lipo -info release/universal/cua_driver_node_runtime.node
           test "$(otool -D release/universal/libcua_driver_sdk.dylib | tail -n 1)" = \
             '@rpath/libcua_driver_sdk.dylib'
+          otool -l release/universal/libcua_driver_sdk.dylib | \
+            grep -A2 LC_RPATH | grep -Fq 'path /usr/lib/swift'
+          otool -l release/universal/libcua_driver_sdk.dylib | \
+            grep -A2 LC_RPATH | grep -Fq 'path @loader_path'
+          test "$(otool -l release/universal/libcua_driver_sdk.dylib | \
+            awk '/LC_BUILD_VERSION/{seen=1} seen && $1 == "minos" {print $2; exit}')" = '13.0'
       - name: Codesign universal binary (hardened runtime)
         if: env.DO_NOTARIZE == 'true'
         working-directory: libs/cua-driver/rust

--- a/libs/cua-driver/python/README.md
+++ b/libs/cua-driver/python/README.md
@@ -130,7 +130,7 @@ exit_code = run_cua_driver(["mcp"])
 
 | Platform | Architecture | Status |
 | --- | --- | --- |
-| macOS | Universal (ARM64 + x86_64) | Supported |
+| macOS 13+ | Universal (ARM64 + x86_64) | Supported |
 | Linux | x86_64 | Supported |
 | Windows | x86_64 | Supported |
 | Windows | ARM64 | Supported |

--- a/libs/cua-driver/python/build_wheel.py
+++ b/libs/cua-driver/python/build_wheel.py
@@ -78,7 +78,8 @@ def get_platform_info(arch_override: str = None):
 def get_wheel_tag(platform_name: str, arch: str) -> str:
     """Return the Python wheel tag for the bundled binary target."""
     if platform_name == "darwin":
-        return "py3-none-macosx_11_0_universal2"
+        # Keep this aligned with the SDK dylib's LC_BUILD_VERSION minimum.
+        return "py3-none-macosx_13_0_universal2"
     if platform_name == "linux":
         # Rust Linux release binaries are built in debian:11, whose glibc floor is 2.31.
         if arch == "x86_64":

--- a/libs/cua-driver/python/tests/test_build_wheel.py
+++ b/libs/cua-driver/python/tests/test_build_wheel.py
@@ -16,7 +16,7 @@ def load_build_wheel_module():
 def test_wheel_tags_are_platform_specific():
     build_wheel = load_build_wheel_module()
 
-    assert build_wheel.get_wheel_tag("darwin", "universal") == "py3-none-macosx_11_0_universal2"
+    assert build_wheel.get_wheel_tag("darwin", "universal") == "py3-none-macosx_13_0_universal2"
     assert build_wheel.get_wheel_tag("linux", "x86_64") == "py3-none-manylinux_2_31_x86_64"
     assert build_wheel.get_wheel_tag("linux", "arm64") == "py3-none-manylinux_2_31_aarch64"
     assert build_wheel.get_wheel_tag("windows", "x86_64") == "py3-none-win_amd64"

--- a/libs/cua-driver/rust/crates/cua-driver-sdk/build.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-sdk/build.rs
@@ -1,5 +1,19 @@
 fn main() {
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
         println!("cargo:rustc-cdylib-link-arg=-Wl,-install_name,@rpath/libcua_driver_sdk.dylib");
+
+        // ScreenCaptureKit's Swift bridge links libswift_Concurrency through
+        // @rpath. Linker arguments emitted by a transitive dependency do not
+        // reach this final cdylib, so make the released SDK independently
+        // loadable by Python, Node, and other hosts. @loader_path also permits
+        // a future package to colocate a back-deployed Swift runtime without
+        // changing the public ABI or loader contract.
+        println!("cargo:rustc-cdylib-link-arg=-Wl,-rpath,/usr/lib/swift");
+        println!("cargo:rustc-cdylib-link-arg=-Wl,-rpath,@loader_path");
+
+        // Cargo links this crate's unit-test harness as an executable rather
+        // than a cdylib, so mirror the runtime paths for that final artifact.
+        println!("cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift");
+        println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path");
     }
 }

--- a/libs/cua-driver/tests/fixtures/apps/cross-platform/electron/preload.js
+++ b/libs/cua-driver/tests/fixtures/apps/cross-platform/electron/preload.js
@@ -30,6 +30,11 @@ if (sentinelMode) {
       </main>
     `;
     record('ready');
+    // Electron can already own native/DOM focus before this renderer's focus
+    // listener is ready. Re-activating an already focused window does not
+    // guarantee another DOM focus event, so explicitly publish the initial
+    // state and keep subsequent focus/blur transitions as separate oracles.
+    if (document.hasFocus()) record('focus');
   });
   window.addEventListener('focus', () => record('focus'));
   window.addEventListener('blur', () => record('blur'));

--- a/libs/cua-driver/typescript/README.md
+++ b/libs/cua-driver/typescript/README.md
@@ -58,7 +58,8 @@ try {
 ```
 
 SDK operations are asynchronous and require a native library matching the host
-OS and architecture. Desktop calls return a typed `ToolResult` with text,
+OS and architecture. The macOS native package requires macOS 13 or newer.
+Desktop calls return a typed `ToolResult` with text,
 images, verification/error metadata, and `structuredJson` / `rawJson` for
 platform-extensible results. Session lifecycle calls return dedicated generated
 records.


### PR DESCRIPTION
## Summary

- final-link the macOS UniFFI SDK dylib with `/usr/lib/swift` and `@loader_path` runtime paths so standalone Python/Node hosts can load it
- pin the release build and Python wheel metadata to the dylib's actual macOS 13 minimum, with release-time assertions
- remove an intermittent macOS E2E sentinel race by journaling focus already held when the renderer becomes ready
- document the macOS 13+ package requirement

Closes #2474.
Closes #2476.

## Verification

- `MACOSX_DEPLOYMENT_TARGET=13.0 cargo build --locked -p cua-driver-sdk --release --target aarch64-apple-darwin`
- source-built dylib: install name, both `LC_RPATH` entries, and `minos 13.0` inspected with `otool`
- standalone uv-managed Python loaded the source-built dylib without `DYLD_*` environment variables
- `cargo test --locked -p cua-driver-sdk` (16 passed)
- Python SDK tests with staged native package (19 passed; capture disabled for known #2475)
- TypeScript/Node SDK tests with staged native package (5 passed, including in-process and daemon-backed paths)
- clean Python wheel build produced `cua_driver-0.12.0-py3-none-macosx_13_0_universal2.whl`
- clean standalone virtualenv installed that wheel and created/shut down the in-process runtime
- `node --check` on the modified Electron fixture

## Release note

This is a user-visible package-loading correction and intentionally uses a release-producing `fix(cua-driver)` title.
