### PR TITLE
fix(cua-driver): honor Cargo target dir in local installs

### DIFF
--- a/libs/cua-driver/scripts/_install-local-rust.sh
+++ b/libs/cua-driver/scripts/_install-local-rust.sh
@@ -170,6 +170,16 @@ fi
 
 # --- Build --------------------------------------------------------------
 
+# Keep Cargo's output directory and the binary staged below on one path.
+# Cargo resolves a relative CARGO_TARGET_DIR from the workspace we build in,
+# so make that resolution explicit before invoking it.
+BUILD_TARGET_DIR="${CARGO_TARGET_DIR:-$REPO_ROOT/target}"
+case "$BUILD_TARGET_DIR" in
+    /*) ;;
+    *) BUILD_TARGET_DIR="$REPO_ROOT/$BUILD_TARGET_DIR" ;;
+esac
+export CARGO_TARGET_DIR="$BUILD_TARGET_DIR"
+
 echo "${BOLD}Building cua-driver ($BUILD_CONFIG)...${NORMAL}"
 cd "$REPO_ROOT"
 if [ "$BUILD_CONFIG" = "release" ]; then
@@ -178,7 +188,7 @@ else
     cargo build -p cua-driver
 fi
 
-BUILT_BINARY="$REPO_ROOT/target/$BUILD_CONFIG/cua-driver"
+BUILT_BINARY="$BUILD_TARGET_DIR/$BUILD_CONFIG/cua-driver"
 if [ ! -x "$BUILT_BINARY" ]; then
     echo "${RED}Error: build produced no binary at $BUILT_BINARY${NORMAL}"
     exit 1

--- a/libs/cua-driver/scripts/tests/test_install_local.py
+++ b/libs/cua-driver/scripts/tests/test_install_local.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+INSTALL_LOCAL = Path(__file__).resolve().parents[1] / "_install-local-rust.sh"
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"#!/bin/sh\n{body}", encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_installer_stages_binary_from_custom_cargo_target(tmp_path: Path) -> None:
+    fixture_root = tmp_path / "cua-driver"
+    scripts_dir = fixture_root / "scripts"
+    rust_dir = fixture_root / "rust"
+    scripts_dir.mkdir(parents=True)
+    rust_dir.mkdir()
+    shutil.copy2(INSTALL_LOCAL, scripts_dir / INSTALL_LOCAL.name)
+
+    stale_binary = rust_dir / "target/release/cua-driver"
+    _write_executable(stale_binary, "printf 'stale workspace target\\n'")
+
+    custom_target = tmp_path / "custom target"
+    fake_bin = tmp_path / "fake-bin"
+    _write_executable(
+        fake_bin / "cargo",
+        """set -eu
+test "${1:-}" = build
+mkdir -p "$CARGO_TARGET_DIR/release"
+printf 'fresh custom target\n' > "$CARGO_TARGET_DIR/release/cua-driver"
+chmod +x "$CARGO_TARGET_DIR/release/cua-driver"
+""",
+    )
+    _write_executable(
+        fake_bin / "uname",
+        """case "${1:-}" in
+    -s) printf 'Linux\n' ;;
+    -m) printf 'x86_64\n' ;;
+    *) exit 2 ;;
+esac
+""",
+    )
+    _write_executable(fake_bin / "systemctl", "exit 0")
+    _write_executable(fake_bin / "pkill", "exit 0")
+
+    local_home = tmp_path / "local-home"
+    install_bin = tmp_path / "install-bin"
+    env = os.environ.copy()
+    env.pop("SUDO_USER", None)
+    env.update(
+        {
+            "HOME": str(tmp_path / "home"),
+            "PATH": f"{fake_bin}:/usr/bin:/bin",
+            "CARGO_TARGET_DIR": str(custom_target),
+            "CUA_DRIVER_SOURCE_SHA": "a" * 40,
+            "CUA_DRIVER_LOCAL_HOME": str(local_home),
+            "CUA_DRIVER_LOCAL_INSTALL_DIR": str(install_bin),
+        }
+    )
+
+    result = subprocess.run(
+        ["/bin/bash", str(scripts_dir / INSTALL_LOCAL.name), "--release"],
+        cwd=fixture_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (custom_target / "release/cua-driver").read_text() == "fresh custom target\n"
+    assert (install_bin / "cua-driver-local").read_text() == "fresh custom target\n"

--- a/libs/cua-driver/scripts/tests/test_install_local.py
+++ b/libs/cua-driver/scripts/tests/test_install_local.py
@@ -5,7 +5,10 @@ import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
+
 INSTALL_LOCAL = Path(__file__).resolve().parents[1] / "_install-local-rust.sh"
+LOCAL_SIGNING = INSTALL_LOCAL.with_name("_local-signing.sh")
 
 
 def _write_executable(path: Path, body: str) -> None:
@@ -14,23 +17,33 @@ def _write_executable(path: Path, body: str) -> None:
     path.chmod(0o755)
 
 
-def test_installer_stages_binary_from_custom_cargo_target(tmp_path: Path) -> None:
+@pytest.mark.parametrize("relative_target", [False, True], ids=["absolute", "relative"])
+def test_installer_stages_binary_from_custom_cargo_target(
+    tmp_path: Path, relative_target: bool
+) -> None:
     fixture_root = tmp_path / "cua-driver"
     scripts_dir = fixture_root / "scripts"
     rust_dir = fixture_root / "rust"
     scripts_dir.mkdir(parents=True)
     rust_dir.mkdir()
     shutil.copy2(INSTALL_LOCAL, scripts_dir / INSTALL_LOCAL.name)
+    shutil.copy2(LOCAL_SIGNING, scripts_dir / LOCAL_SIGNING.name)
 
     stale_binary = rust_dir / "target/release/cua-driver"
     _write_executable(stale_binary, "printf 'stale workspace target\\n'")
 
-    custom_target = tmp_path / "custom target"
+    custom_target = (
+        rust_dir / "relative custom target" if relative_target else tmp_path / "custom target"
+    )
+    cargo_target_dir = (
+        str(custom_target.relative_to(rust_dir)) if relative_target else str(custom_target)
+    )
     fake_bin = tmp_path / "fake-bin"
     _write_executable(
         fake_bin / "cargo",
         """set -eu
 test "${1:-}" = build
+test "$CARGO_TARGET_DIR" = "$EXPECTED_CARGO_TARGET_DIR"
 mkdir -p "$CARGO_TARGET_DIR/release"
 printf 'fresh custom target\n' > "$CARGO_TARGET_DIR/release/cua-driver"
 chmod +x "$CARGO_TARGET_DIR/release/cua-driver"
@@ -56,7 +69,8 @@ esac
         {
             "HOME": str(tmp_path / "home"),
             "PATH": f"{fake_bin}:/usr/bin:/bin",
-            "CARGO_TARGET_DIR": str(custom_target),
+            "CARGO_TARGET_DIR": cargo_target_dir,
+            "EXPECTED_CARGO_TARGET_DIR": str(custom_target),
             "CUA_DRIVER_SOURCE_SHA": "a" * 40,
             "CUA_DRIVER_LOCAL_HOME": str(local_home),
             "CUA_DRIVER_LOCAL_INSTALL_DIR": str(install_bin),


### PR DESCRIPTION
## Problem

The Unix local installer lets Cargo build into `CARGO_TARGET_DIR` but always staged the binary from the workspace-local `target` directory. When that directory contained an older executable, a successful local build could still install stale bytes.

## Change

- Resolve one absolute build target directory and export it to Cargo.
- Use the same directory for the build-output check and staging copy.
- Add an isolated installer regression with stale workspace output and fresh custom-target output.

## Tests

- `uv run --no-project --python 3.13 --with pytest pytest -q libs/cua-driver/scripts/tests/test_install_local.py`
- `uv run --no-project --python 3.13 --with pytest pytest -q libs/cua-driver/scripts/tests libs/cua-driver/python/tests/test_install_local_signing.py`
- `/bin/bash -n libs/cua-driver/scripts/install-local.sh libs/cua-driver/scripts/_install-local-rust.sh`
- `uv run --no-project --python 3.13 --with ruff ruff check libs/cua-driver/scripts/tests/test_install_local.py`
- `uv run --no-project --python 3.13 --with black black --check libs/cua-driver/scripts/tests/test_install_local.py`
- `uv run --no-project --python 3.13 --with isort isort --check-only libs/cua-driver/scripts/tests/test_install_local.py`

Closes #2483