### PR TITLE
test(cua-driver): repair macOS Lume gate contracts

### DIFF
--- a/libs/cua-driver/tests/runners/macos-lume/run-all.sh
+++ b/libs/cua-driver/tests/runners/macos-lume/run-all.sh
@@ -3,7 +3,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../.." && pwd)"
+# A copied runner may target a clean, exact source tree during release certification.
+REPO_ROOT="${CUA_E2E_REPO_ROOT:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 DRIVER_ROOT="${REPO_ROOT}/libs/cua-driver"
 RUST_ROOT="${DRIVER_ROOT}/rust"
 ARTIFACT_DIR="${REPO_ROOT}/artifacts/cua-driver/macos"
@@ -173,8 +174,9 @@ LIVE_PERMISSIONS_FILE="${ARTIFACT_DIR}/permissions-live-capture.json"
 if ! "${INSTALLED_BIN}" call check_permissions '{"prompt":true}' \
     > "${LIVE_PERMISSIONS_FILE}" \
     || ! jq -e '
-      .structuredContent.screen_recording_capturable == true
-      and .structuredContent.direct_capture_status == "ready"
+      (.structuredContent // .) as $permissions
+      | $permissions.screen_recording_capturable == true
+      and $permissions.direct_capture_status == "ready"
     ' "${LIVE_PERMISSIONS_FILE}" >/dev/null; then
   cat "${LIVE_PERMISSIONS_FILE}" >&2 || true
   echo "The cloned golden image does not have usable direct ScreenCaptureKit consent" >&2
@@ -186,6 +188,9 @@ if ! "${INSTALLED_BIN}" list_apps '{}' > "${ARTIFACT_DIR}/driver-list-apps.json"
   echo "CuaDriver cannot enumerate applications" >&2
   exit 2
 fi
+
+# install-local.sh intentionally uses a separate namespace from release installs.
+export CUA_E2E_MACOS_DAEMON_SOCKET="${CUA_E2E_MACOS_DAEMON_SOCKET:-${HOME}/Library/Caches/cua-driver-local/cua-driver-local.sock}"
 
 echo "[E2E] Running the canonical macOS matrix"
 if [[ "${NO_BUILD}" == 1 ]]; then


### PR DESCRIPTION
## Summary

- normalize the macOS Lume live permission probe across the direct CLI payload and legacy `structuredContent` envelope
- point the matrix at the local-install daemon socket while preserving explicit overrides
- keep the capability and exact-source assertions unchanged

Closes #2473.
Closes #2487.

## Verification

- `bash -n libs/cua-driver/tests/runners/macos-lume/run-all.sh`
- direct-payload jq fixture passes
- enveloped jq fixture passes
- negative jq fixture fails
- default and explicitly overridden socket fixtures pass
- `shellcheck libs/cua-driver/tests/runners/macos-lume/run-all.sh`
- `git diff --check`

This is a test-harness correction only; it does not change shipped Cua Driver behavior.
