### PR TITLE
fix(cua-driver): prevent silent ad-hoc local signing

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -280,19 +280,19 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertNotIn("launches CuaDriver", shared_hints)
 
     def test_local_macos_signing_uses_an_unambiguous_identity_hash(self) -> None:
-        installer = self.read("libs/cua-driver/scripts/_install-local-rust.sh")
+        signing = self.read("libs/cua-driver/scripts/_local-signing.sh")
 
         self.assertIn(
             'security find-identity -p codesigning "$kc"',
-            installer,
+            signing,
         )
-        self.assertNotIn('security find-identity -v -p codesigning "$kc"', installer)
-        self.assertIn('SIGN_ID="$(ensure_local_signing_identity)"', installer)
+        self.assertNotIn('security find-identity -v -p codesigning "$kc"', signing)
+        self.assertIn('sign_id="$(ensure_local_signing_identity)"', signing)
         self.assertIn(
-            'codesign_bounded 20 --force --deep --sign "$SIGN_ID" "$APP_STAGE"',
-            installer,
+            'codesign_bounded 20 --force --deep --sign "$sign_id" "$app_stage"',
+            signing,
         )
-        self.assertNotIn("printf '%s' \"$CUA_LOCAL_SIGN_CN\"; return", installer)
+        self.assertNotIn("printf '%s' \"$CUA_LOCAL_SIGN_CN\"; return", signing)
 
     def test_release_installers_persist_channel_before_binary_swap(self) -> None:
         shell = self.read("libs/cua-driver/scripts/_install-rust.sh")

--- a/libs/cua-driver/python/tests/test_install_local_signing.py
+++ b/libs/cua-driver/python/tests/test_install_local_signing.py
@@ -1,16 +1,106 @@
 from pathlib import Path
+import os
+import subprocess
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+SIGNING_HELPER = SCRIPTS_DIR / "_local-signing.sh"
+
+
+def run_signing_policy(shell_body: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["SIGNING_HELPER"] = str(SIGNING_HELPER)
+    return subprocess.run(
+        ["/bin/bash", "-c", 'set -euo pipefail; source "$SIGNING_HELPER"; ' + shell_body],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
 
 
 def test_local_installer_accepts_untrusted_self_signed_identity() -> None:
     """The installer-created self-signed cert is usable even before trust-chain validation."""
-    script = (
-        Path(__file__).resolve().parents[2]
-        / "scripts"
-        / "_install-local-rust.sh"
-    ).read_text()
+    script = (SIGNING_HELPER).read_text()
 
     assert "security find-identity -v -p codesigning" not in script
     assert script.count("security find-identity -p codesigning") >= 2
+
+
+def test_strict_local_signing_fails_before_ad_hoc_fallback() -> None:
+    result = run_signing_policy(
+        r"""
+        OS=Darwin
+        RED= GREEN= YELLOW= NORMAL=
+        CUA_DRIVER_REQUIRE_STABLE_SIGNING=1
+        ensure_local_signing_identity() { printf '%s' -; }
+        clean_partial_bundle_signature() { :; }
+        codesign_bounded() { echo "unexpected ad-hoc signing" >&2; return 99; }
+        if sign_staged_local_app /staged.app /live.app; then exit 90; fi
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "stable macOS signing is required" in result.stderr
+    assert "live installation was not changed" in result.stderr
+    assert "--require-stable-signing" in result.stderr
+    assert "unexpected ad-hoc signing" not in result.stderr
+
+
+def test_ad_hoc_fallback_is_prominent_and_reports_cdhash() -> None:
+    result = run_signing_policy(
+        r"""
+        OS=Darwin
+        RED= GREEN= YELLOW= NORMAL=
+        CUA_DRIVER_REQUIRE_STABLE_SIGNING=0
+        ensure_local_signing_identity() { printf '%s' -; }
+        clean_partial_bundle_signature() { :; }
+        codesign_bounded() { return 0; }
+        codesign() {
+            if [ "$1" = "-d" ]; then
+                echo '# designated => cdhash H"0123456789ABCDEF"'
+            fi
+            return 0
+        }
+        sign_staged_local_app /staged.app /missing-live.app
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "WARNING: CuaDriverLocal.app was signed ad-hoc" in result.stderr
+    assert "WILL become invalid on the next rebuild" in result.stderr
+    assert "designated requirement uses cdhash" in result.stderr
+
+
+def test_certificate_requirement_is_classified_as_stable() -> None:
+    result = run_signing_policy(
+        r"""
+        OS=Darwin
+        RED= GREEN= YELLOW= NORMAL=
+        CUA_DRIVER_REQUIRE_STABLE_SIGNING=1
+        ensure_local_signing_identity() { printf '%s' ABCDEF; }
+        codesign_bounded() { return 0; }
+        codesign() {
+            if [ "$1" = "-d" ]; then
+                echo 'designated => anchor trusted and certificate leaf[subject.CN] = "CuaDriver Local Signing (cua-driver-rs)"' >&2
+            fi
+            return 0
+        }
+        sign_staged_local_app /staged.app /missing-live.app
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "stable local identity" in result.stdout
+
+
+def test_installer_verifies_the_copied_designated_requirement() -> None:
+    script = (SCRIPTS_DIR / "_install-local-rust.sh").read_text()
+
+    assert 'INSTALLED_REQUIREMENT="$(designated_requirement "$APP_DEST")"' in script
+    assert '[ "$INSTALLED_REQUIREMENT" = "$STAGED_REQUIREMENT" ]' in script
+    assert "verified installed designated requirement: certificate-backed" in script
+    assert "verified installed designated requirement: ad-hoc cdhash" in script
 
 
 def test_local_installer_uses_a_separate_macos_identity() -> None:
@@ -32,7 +122,7 @@ def test_unix_local_installer_uses_separate_paths_and_autostart() -> None:
     ).read_text()
 
     assert 'HOME_DIR="${CUA_DRIVER_LOCAL_HOME:-$HOME/.cua-driver-local}"' in script
-    assert 'BIN_DIR/cua-driver-local' in script
+    assert "BIN_DIR/cua-driver-local" in script
     assert "com.trycua.cua-driver-local.plist" in script
     assert "cua-driver-local.service" in script
     assert "stop_cua_driver_daemons" not in script
@@ -53,9 +143,7 @@ def test_unix_local_installer_always_embeds_source_provenance() -> None:
 
 def test_windows_local_installer_always_embeds_source_provenance() -> None:
     """The Windows developer installer follows the same provenance contract."""
-    script = (
-        Path(__file__).resolve().parents[2] / "scripts" / "install-local.ps1"
-    ).read_text()
+    script = (Path(__file__).resolve().parents[2] / "scripts" / "install-local.ps1").read_text()
 
     assert "IsNullOrWhiteSpace($env:CUA_DRIVER_SOURCE_SHA)" in script
     assert "rev-parse --verify 'HEAD^{commit}'" in script
@@ -64,9 +152,7 @@ def test_windows_local_installer_always_embeds_source_provenance() -> None:
 
 
 def test_windows_local_installer_uses_separate_paths_and_autostart() -> None:
-    script = (
-        Path(__file__).resolve().parents[2] / "scripts" / "install-local.ps1"
-    ).read_text()
+    script = (Path(__file__).resolve().parents[2] / "scripts" / "install-local.ps1").read_text()
 
     assert '$BinaryName  = "cua-driver-local.exe"' in script
     assert '"Programs\\Cua\\cua-driver-local\\bin"' in script

--- a/libs/cua-driver/scripts/README.md
+++ b/libs/cua-driver/scripts/README.md
@@ -13,6 +13,54 @@ Install, uninstall, local-build, and VM sync helpers for cua-driver.
 | `sync-vm-worktree.sh` | Sync this checkout to verification VMs and pull artifacts back |
 | `post-install-hints.txt` | User-facing hints printed by install scripts |
 
+## Stable macOS local signing
+
+macOS Accessibility and Screen Recording grants are tied to an app's
+designated requirement. An ad-hoc signature uses a `cdhash` requirement that
+changes on every rebuild, so its grants do not survive the next local install.
+The installer now reports whether the installed requirement is
+`certificate-backed` or `ad-hoc cdhash`; an ad-hoc install always prints a
+prominent warning and bootstrap instructions.
+
+For behavior or E2E verification, require the stable path:
+
+```bash
+bash libs/cua-driver/scripts/install-local.sh \
+  --release --autostart --require-stable-signing
+```
+
+`CUA_DRIVER_REQUIRE_STABLE_SIGNING=1` is the environment equivalent. Strict
+mode stops before replacing the live app when no usable certificate-backed
+identity is available.
+
+For the most reliable non-interactive rebuilds, use a dedicated keychain:
+
+```bash
+SIGNING_KEYCHAIN="$HOME/Library/Keychains/cua-driver-signing.keychain-db"
+security create-keychain "$SIGNING_KEYCHAIN"  # first time only
+security set-keychain-settings "$SIGNING_KEYCHAIN"
+security unlock-keychain "$SIGNING_KEYCHAIN"
+export CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN="$SIGNING_KEYCHAIN"
+```
+
+The first install creates `CuaDriver Local Signing (cua-driver-rs)` in that
+keychain. If `codesign` cannot use its private key non-interactively, unlock
+the keychain, trust the certificate in Keychain Access, and authorize Apple
+code-signing tools:
+
+```bash
+read -r -s -p 'Keychain password: ' KEYCHAIN_PASSWORD; echo
+security set-key-partition-list \
+  -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" \
+  "$SIGNING_KEYCHAIN"
+unset KEYCHAIN_PASSWORD
+```
+
+Then rerun the strict installer and grant Accessibility and Screen Recording
+once. When the dedicated default keychain above exists, the installer prefers
+it automatically; exporting `CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN` remains the
+most explicit choice.
+
 Released installers show a telemetry notice before asking the installed binary
 to record anything. Telemetry is enabled by default and can be persistently
 disabled with `cua-driver telemetry disable`. Installation events use the same

--- a/libs/cua-driver/scripts/_install-local-rust.sh
+++ b/libs/cua-driver/scripts/_install-local-rust.sh
@@ -77,6 +77,15 @@ fi
 
 BUILD_CONFIG="debug"
 INSTALL_AUTOSTART=false
+case "${CUA_DRIVER_REQUIRE_STABLE_SIGNING:-0}" in
+    0|false|no|"") CUA_DRIVER_REQUIRE_STABLE_SIGNING=0 ;;
+    1|true|yes) CUA_DRIVER_REQUIRE_STABLE_SIGNING=1 ;;
+    *)
+        echo "${RED}Error: CUA_DRIVER_REQUIRE_STABLE_SIGNING must be 0 or 1.${NORMAL}" >&2
+        exit 2
+        ;;
+esac
+export CUA_DRIVER_REQUIRE_STABLE_SIGNING
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -85,6 +94,10 @@ while [ "$#" -gt 0 ]; do
             ;;
         --autostart)
             INSTALL_AUTOSTART=true
+            ;;
+        --require-stable-signing)
+            CUA_DRIVER_REQUIRE_STABLE_SIGNING=1
+            export CUA_DRIVER_REQUIRE_STABLE_SIGNING
             ;;
         --help|-h)
             echo "${BOLD}${BLUE}cua-driver-rs local installer${NORMAL}"
@@ -99,6 +112,10 @@ while [ "$#" -gt 0 ]; do
             echo "                is attributed to com.trycua.driver.local (not your terminal),"
             echo "                so you grant Accessibility + Screen Recording once and"
             echo "                every cua-driver-local call/mcp routes through it correctly."
+            echo "  --require-stable-signing"
+            echo "                On macOS, stop before replacing the installed app unless"
+            echo "                a certificate-backed identity is available. Recommended"
+            echo "                for behavior and E2E verification."
             echo "  --help        Show this help."
             echo ""
             echo "Examples:"
@@ -245,107 +262,11 @@ echo ""
 
 # --- macOS: stable local code-signing identity (so TCC grants survive rebuilds) ---
 #
-# Ad-hoc signing (`codesign --sign -`) keys the TCC grant
-# (Accessibility / Screen Recording) on the binary's *cdhash*, which changes
-# on EVERY rebuild — so the grant silently invalidates on each install-local
-# and the daemon re-prompts ("I already granted!"). Signing with a certificate
-# keys the grant on the cert identity instead, which is stable across rebuilds.
-# We create a self-signed code-signing cert once (idempotent, in the login
-# keychain by default) and reuse it. A maintainer VM may point
-# CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN at a dedicated, already-unlocked keychain;
-# this avoids image-specific login-keychain ACL failures. Local dev only;
-# releases are CI-signed.
-#
-# Echoes the `codesign --sign` argument: a matching identity's SHA-1 when
-# available, or "-" when it can't be created — no codesign/openssl, CI,
-# locked keychain. The installer creates a self-signed local certificate, which
-# `security find-identity -v` filters out as untrusted even when its private key
-# is present and codesign can use it. Query matching code-signing identities
-# without the valid-only filter; the bounded codesign call below remains the
-# authoritative usability check. Use the identity hash rather than the
-# certificate name because duplicate certificate names are ambiguous.
-CUA_LOCAL_SIGN_CN="CuaDriver Local Signing (cua-driver-rs)"
-ensure_local_signing_identity() {
-    { [ "$OS" = "Darwin" ] && command -v codesign >/dev/null 2>&1; } || { printf -- '-'; return; }
-    local kc="${CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN:-$HOME/Library/Keychains/login.keychain-db}"
-    if [ -z "${CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN:-}" ] && [ ! -f "$kc" ]; then
-        kc="$HOME/Library/Keychains/login.keychain"
-    fi
-    [ -f "$kc" ] || { printf -- '-'; return; }
-    local identity
-    identity="$(security find-identity -p codesigning "$kc" 2>/dev/null \
-        | awk -v cn="$CUA_LOCAL_SIGN_CN" 'index($0, "\"" cn "\"") { print $2; exit }')"
-    if [ -n "$identity" ]; then
-        printf '%s' "$identity"; return
-    fi
-    command -v openssl >/dev/null 2>&1 || { printf -- '-'; return; }
-    local tmp; tmp="$(mktemp -d)" || { printf -- '-'; return; }
-    printf '[req]\ndistinguished_name=dn\nx509_extensions=ext\nprompt=no\n[dn]\nCN=%s\n[ext]\nbasicConstraints=critical,CA:FALSE\nkeyUsage=critical,digitalSignature\nextendedKeyUsage=critical,codeSigning\n' \
-        "$CUA_LOCAL_SIGN_CN" > "$tmp/req.cnf"
-    # Transient password for the p12 handoff (deleted right after import).
-    # Apple's `security` rejects the empty-password p12 that openssl 3.x emits
-    # by default ("MAC verification failed"), so use a real password + `-legacy`
-    # PBE (Apple-compatible). Fall back to non-legacy for LibreSSL/older openssl
-    # which lacks `-legacy` but already writes a compatible p12.
-    local pw="cua-local-$$"
-    if openssl req -x509 -newkey rsa:2048 -keyout "$tmp/key.pem" -out "$tmp/cert.pem" \
-            -days 3650 -nodes -config "$tmp/req.cnf" >/dev/null 2>&1 \
-       && { openssl pkcs12 -export -legacy -inkey "$tmp/key.pem" -in "$tmp/cert.pem" \
-                -out "$tmp/id.p12" -passout pass:"$pw" -name "$CUA_LOCAL_SIGN_CN" >/dev/null 2>&1 \
-            || openssl pkcs12 -export -inkey "$tmp/key.pem" -in "$tmp/cert.pem" \
-                -out "$tmp/id.p12" -passout pass:"$pw" -name "$CUA_LOCAL_SIGN_CN" >/dev/null 2>&1; } \
-       && security import "$tmp/id.p12" -k "$kc" -P "$pw" -A -T /usr/bin/codesign >/dev/null 2>&1; then
-        identity="$(security find-identity -p codesigning "$kc" 2>/dev/null \
-            | awk -v cn="$CUA_LOCAL_SIGN_CN" 'index($0, "\"" cn "\"") { print $2; exit }')"
-        rm -rf "$tmp"
-        if [ -n "$identity" ]; then
-            printf '%s' "$identity"; return
-        fi
-        printf -- '-'; return
-    fi
-    rm -rf "$tmp"
-    printf -- '-'
-}
-
-# Keychain-backed codesign can wait forever for a GUI authorization prompt when
-# install-local is launched from a headless shell. Keep the install bounded;
-# ad-hoc signing remains a usable fallback for local development.
-codesign_bounded() {
-    local timeout_seconds="$1"
-    shift
-    if command -v gtimeout >/dev/null 2>&1; then
-        if [ -n "${CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN:-}" ]; then
-            gtimeout "$timeout_seconds" codesign \
-                --keychain "$CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN" "$@"
-        else
-            gtimeout "$timeout_seconds" codesign "$@"
-        fi
-    elif command -v perl >/dev/null 2>&1; then
-        if [ -n "${CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN:-}" ]; then
-            perl -e 'alarm shift; exec @ARGV' "$timeout_seconds" codesign \
-                --keychain "$CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN" "$@"
-        else
-            perl -e 'alarm shift; exec @ARGV' "$timeout_seconds" codesign "$@"
-        fi
-    else
-        if [ -n "${CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN:-}" ]; then
-            codesign --keychain "$CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN" "$@"
-        else
-            codesign "$@"
-        fi
-    fi
-}
-
-clean_partial_bundle_signature() {
-    local app="$1"
-    # A certificate-backed codesign killed by the timeout can leave both a
-    # partial resource seal and `<executable>.cstemp`. Signing over that state
-    # seals the transient file; when the interrupted signer removes it later,
-    # the fallback bundle becomes invalid. Always restart fallback signing from
-    # the unsigned staged bundle.
-    rm -rf "$app/Contents/_CodeSignature"
-    find "$app" -type f -name '*.cstemp' -delete
-}
+# Keep policy in a sourceable helper so strict/fallback behavior can be tested
+# without building or installing the app.
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=_local-signing.sh
+. "$SCRIPT_DIR/_local-signing.sh"
 
 # --- macOS: wrap the binary in CuaDriverLocal.app for a stable TCC identity ---
 #
@@ -393,31 +314,18 @@ if [ "$OS" = "Darwin" ]; then
     # never downgrade an existing certificate-signed installation to ad-hoc,
     # because that would invalidate its working TCC grants.
     if command -v codesign >/dev/null 2>&1; then
-        SIGN_ID="$(ensure_local_signing_identity)"
-        if [ "$SIGN_ID" != "-" ] \
-           && codesign_bounded 20 --force --deep --sign "$SIGN_ID" "$APP_STAGE" 2>/dev/null; then
-            echo "${GREEN}signed staged app with a stable local identity — TCC grants survive future install-local rebuilds${NORMAL}"
-        elif [ -d "$APP_DEST" ] \
-             && codesign -d -r- "$APP_DEST" 2>&1 | grep -q 'certificate leaf'; then
-            echo "${RED}Error: stable signing failed; preserving the existing certificate-signed $APP_DEST and its TCC grants.${NORMAL}" >&2
-            echo "Unlock/authorize the configured signing-keychain key, then rerun install-local." >&2
+        if ! sign_staged_local_app "$APP_STAGE" "$APP_DEST"; then
             exit 1
-        else
-            clean_partial_bundle_signature "$APP_STAGE"
-            if codesign_bounded 20 --force --deep --sign - "$APP_STAGE" 2>/dev/null; then
-                if [ "$SIGN_ID" != "-" ]; then
-                    echo "${YELLOW}note: stable-identity signing failed; signed ad-hoc instead (Accessibility/Screen Recording will reset on the next rebuild)${NORMAL}" >&2
-                fi
-            else
-                clean_partial_bundle_signature "$APP_STAGE"
-                echo "${RED}Error: codesign of staged CuaDriverLocal.app failed; live installation was not changed.${NORMAL}" >&2
-                exit 1
-            fi
         fi
         if ! codesign --verify --deep --strict "$APP_STAGE" 2>/dev/null; then
             echo "${RED}Error: staged CuaDriverLocal.app failed signature verification; live installation was not changed.${NORMAL}" >&2
             exit 1
         fi
+        STAGED_REQUIREMENT="$(designated_requirement "$APP_STAGE")"
+        STAGED_SIGNING_CLASS="$(classify_designated_requirement "$STAGED_REQUIREMENT")"
+    else
+        echo "${RED}Error: codesign is required to install CuaDriverLocal.app safely.${NORMAL}" >&2
+        exit 1
     fi
 
     # Install to /Applications (user-writable for admins; no sudo — same as
@@ -428,17 +336,33 @@ if [ "$OS" = "Darwin" ]; then
     if [ -d "$APP_DEST" ]; then
         mv "$APP_DEST" "$APP_BACKUP"
     fi
-    if ditto "$APP_STAGE" "$APP_DEST"; then
+    install_valid=false
+    if ditto "$APP_STAGE" "$APP_DEST" \
+       && codesign --verify --deep --strict "$APP_DEST" 2>/dev/null; then
+        INSTALLED_REQUIREMENT="$(designated_requirement "$APP_DEST")"
+        INSTALLED_SIGNING_CLASS="$(classify_designated_requirement "$INSTALLED_REQUIREMENT")"
+        if [ "$INSTALLED_REQUIREMENT" = "$STAGED_REQUIREMENT" ] \
+           && [ "$INSTALLED_SIGNING_CLASS" = "$STAGED_SIGNING_CLASS" ] \
+           && [ "$INSTALLED_SIGNING_CLASS" != "unknown" ]; then
+            install_valid=true
+        fi
+    fi
+    if [ "$install_valid" = true ]; then
         rm -rf "$APP_BACKUP"
     else
         rm -rf "$APP_DEST"
         if [ -d "$APP_BACKUP" ]; then
             mv "$APP_BACKUP" "$APP_DEST"
         fi
-        echo "${RED}Error: failed to install CuaDriverLocal.app; restored the previous bundle.${NORMAL}" >&2
+        echo "${RED}Error: installed CuaDriverLocal.app did not preserve its verified signing identity; restored the previous bundle.${NORMAL}" >&2
         exit 1
     fi
     echo "${GREEN}installed $APP_DEST${NORMAL}"
+    if [ "$INSTALLED_SIGNING_CLASS" = "certificate-backed" ]; then
+        echo "${GREEN}verified installed designated requirement: certificate-backed (stable across rebuilds)${NORMAL}"
+    else
+        echo "${YELLOW}verified installed designated requirement: ad-hoc cdhash (changes on rebuild)${NORMAL}" >&2
+    fi
 
     # --- Force LaunchServices registration of the freshly-copied bundle ----
     #

--- a/libs/cua-driver/scripts/_local-signing.sh
+++ b/libs/cua-driver/scripts/_local-signing.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+#
+# macOS local-development signing helpers for _install-local-rust.sh.
+# This file has no top-level side effects so its policy can be exercised by
+# focused shell tests without building or installing cua-driver.
+
+CUA_LOCAL_SIGN_CN="CuaDriver Local Signing (cua-driver-rs)"
+
+local_signing_keychain() {
+    if [ -n "${CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN:-}" ]; then
+        printf '%s' "$CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN"
+    elif [ -f "$HOME/Library/Keychains/cua-driver-signing.keychain-db" ]; then
+        printf '%s' "$HOME/Library/Keychains/cua-driver-signing.keychain-db"
+    elif [ -f "$HOME/Library/Keychains/login.keychain-db" ]; then
+        printf '%s' "$HOME/Library/Keychains/login.keychain-db"
+    else
+        printf '%s' "$HOME/Library/Keychains/login.keychain"
+    fi
+}
+
+print_local_signing_bootstrap() {
+    echo "Create and unlock a dedicated development signing keychain, then rerun:" >&2
+    echo "  SIGNING_KEYCHAIN=\"\$HOME/Library/Keychains/cua-driver-signing.keychain-db\"" >&2
+    echo "  security create-keychain \"\$SIGNING_KEYCHAIN\"  # first time only; prompts for a password" >&2
+    echo "  security set-keychain-settings \"\$SIGNING_KEYCHAIN\"" >&2
+    echo "  security unlock-keychain \"\$SIGNING_KEYCHAIN\"" >&2
+    echo "  export CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN=\"\$SIGNING_KEYCHAIN\"" >&2
+    echo "  bash libs/cua-driver/scripts/install-local.sh --require-stable-signing" >&2
+    echo "If the certificate is newly created, authorize its private key for codesign as described in:" >&2
+    echo "  libs/cua-driver/scripts/README.md#stable-macos-local-signing" >&2
+}
+
+# Echoes the `codesign --sign` argument: a matching identity's SHA-1 when
+# available, or "-" when it cannot be created or found.
+ensure_local_signing_identity() {
+    { [ "$OS" = "Darwin" ] && command -v codesign >/dev/null 2>&1; } \
+        || { printf -- '-'; return; }
+    local kc
+    kc="$(local_signing_keychain)"
+    [ -f "$kc" ] || { printf -- '-'; return; }
+    local identity
+    identity="$(security find-identity -p codesigning "$kc" 2>/dev/null \
+        | awk -v cn="$CUA_LOCAL_SIGN_CN" 'index($0, "\"" cn "\"") { print $2; exit }')"
+    if [ -n "$identity" ]; then
+        printf '%s' "$identity"
+        return
+    fi
+    command -v openssl >/dev/null 2>&1 || { printf -- '-'; return; }
+    local tmp
+    tmp="$(mktemp -d)" || { printf -- '-'; return; }
+    printf '[req]\ndistinguished_name=dn\nx509_extensions=ext\nprompt=no\n[dn]\nCN=%s\n[ext]\nbasicConstraints=critical,CA:FALSE\nkeyUsage=critical,digitalSignature\nextendedKeyUsage=critical,codeSigning\n' \
+        "$CUA_LOCAL_SIGN_CN" > "$tmp/req.cnf"
+    local pw="cua-local-$$"
+    if openssl req -x509 -newkey rsa:2048 -keyout "$tmp/key.pem" -out "$tmp/cert.pem" \
+            -days 3650 -nodes -config "$tmp/req.cnf" >/dev/null 2>&1 \
+       && { openssl pkcs12 -export -legacy -inkey "$tmp/key.pem" -in "$tmp/cert.pem" \
+                -out "$tmp/id.p12" -passout pass:"$pw" -name "$CUA_LOCAL_SIGN_CN" >/dev/null 2>&1 \
+            || openssl pkcs12 -export -inkey "$tmp/key.pem" -in "$tmp/cert.pem" \
+                -out "$tmp/id.p12" -passout pass:"$pw" -name "$CUA_LOCAL_SIGN_CN" >/dev/null 2>&1; } \
+       && security import "$tmp/id.p12" -k "$kc" -P "$pw" -A -T /usr/bin/codesign >/dev/null 2>&1; then
+        identity="$(security find-identity -p codesigning "$kc" 2>/dev/null \
+            | awk -v cn="$CUA_LOCAL_SIGN_CN" 'index($0, "\"" cn "\"") { print $2; exit }')"
+        rm -rf "$tmp"
+        if [ -n "$identity" ]; then
+            printf '%s' "$identity"
+            return
+        fi
+        printf -- '-'
+        return
+    fi
+    rm -rf "$tmp"
+    printf -- '-'
+}
+
+# Keychain-backed codesign can wait forever for a GUI authorization prompt.
+codesign_bounded() {
+    local timeout_seconds="$1"
+    shift
+    local kc=""
+    if [ -n "${CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN:-}" ]; then
+        kc="$CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN"
+    elif [ -f "$HOME/Library/Keychains/cua-driver-signing.keychain-db" ]; then
+        kc="$HOME/Library/Keychains/cua-driver-signing.keychain-db"
+    fi
+    if [ -n "$kc" ]; then
+        set -- --keychain "$kc" "$@"
+    fi
+    if command -v gtimeout >/dev/null 2>&1; then
+        gtimeout "$timeout_seconds" codesign "$@"
+    elif command -v perl >/dev/null 2>&1; then
+        perl -e 'alarm shift; exec @ARGV' "$timeout_seconds" codesign "$@"
+    else
+        codesign "$@"
+    fi
+}
+
+clean_partial_bundle_signature() {
+    local app="$1"
+    rm -rf "$app/Contents/_CodeSignature"
+    find "$app" -type f -name '*.cstemp' -delete
+}
+
+designated_requirement() {
+    codesign -d -r- "$1" 2>&1 \
+        | sed -n -e 's/^designated => //p' -e 's/^# designated => //p'
+}
+
+classify_designated_requirement() {
+    case "$1" in
+        *"certificate leaf"*) printf '%s' "certificate-backed" ;;
+        *cdhash*) printf '%s' "ad-hoc" ;;
+        *) printf '%s' "unknown" ;;
+    esac
+}
+
+# Signs a staged local app without touching the live installation. Strict mode
+# refuses the ad-hoc path; non-strict mode keeps it available for casual local
+# development but makes the resulting TCC reset impossible to miss.
+sign_staged_local_app() {
+    local app_stage="$1"
+    local app_dest="$2"
+    local sign_id requirement signing_class
+    sign_id="$(ensure_local_signing_identity)"
+
+    if [ "$sign_id" != "-" ] \
+       && codesign_bounded 20 --force --deep --sign "$sign_id" "$app_stage" 2>/dev/null; then
+        requirement="$(designated_requirement "$app_stage")"
+        signing_class="$(classify_designated_requirement "$requirement")"
+        if [ "$signing_class" = "certificate-backed" ]; then
+            echo "${GREEN}signed staged app with a stable local identity — TCC grants survive future install-local rebuilds${NORMAL}"
+            return 0
+        fi
+        echo "${YELLOW}warning: the requested stable identity produced a non-certificate designated requirement${NORMAL}" >&2
+    fi
+
+    if [ "${CUA_DRIVER_REQUIRE_STABLE_SIGNING:-0}" = "1" ]; then
+        clean_partial_bundle_signature "$app_stage"
+        echo "${RED}Error: stable macOS signing is required, but no usable certificate-backed identity was available.${NORMAL}" >&2
+        echo "The live installation was not changed." >&2
+        print_local_signing_bootstrap
+        return 1
+    fi
+
+    if [ -d "$app_dest" ]; then
+        requirement="$(designated_requirement "$app_dest")"
+        if [ "$(classify_designated_requirement "$requirement")" = "certificate-backed" ]; then
+            clean_partial_bundle_signature "$app_stage"
+            echo "${RED}Error: stable signing failed; preserving the existing certificate-signed $app_dest and its TCC grants.${NORMAL}" >&2
+            print_local_signing_bootstrap
+            return 1
+        fi
+    fi
+
+    clean_partial_bundle_signature "$app_stage"
+    if ! codesign_bounded 20 --force --deep --sign - "$app_stage" 2>/dev/null; then
+        clean_partial_bundle_signature "$app_stage"
+        echo "${RED}Error: codesign of staged CuaDriverLocal.app failed; live installation was not changed.${NORMAL}" >&2
+        return 1
+    fi
+    requirement="$(designated_requirement "$app_stage")"
+    if [ "$(classify_designated_requirement "$requirement")" != "ad-hoc" ]; then
+        echo "${RED}Error: could not verify the staged app's ad-hoc designated requirement; live installation was not changed.${NORMAL}" >&2
+        return 1
+    fi
+    echo "${YELLOW}WARNING: CuaDriverLocal.app was signed ad-hoc (designated requirement uses cdhash).${NORMAL}" >&2
+    echo "${YELLOW}Accessibility and Screen Recording grants WILL become invalid on the next rebuild.${NORMAL}" >&2
+    print_local_signing_bootstrap
+}

--- a/libs/cua-driver/scripts/install-local.sh
+++ b/libs/cua-driver/scripts/install-local.sh
@@ -9,6 +9,8 @@
 #   --release              build the release configuration (default: debug)
 #   --autostart            register an auto-start daemon (macOS: LaunchAgent;
 #                          Linux: systemd user unit). Default off.
+#   --require-stable-signing
+#                          on macOS, refuse to install an ad-hoc-signed app
 #   --bin-dir <path>       override the symlink destination (default ~/.local/bin)
 #   --backend=rust         explicit Rust backend (no-op; Rust is the only option)
 #   --experimental-rust    legacy alias for --backend=rust (no-op)

--- a/libs/cua-driver/tests/runners/macos-lume/README.md
+++ b/libs/cua-driver/tests/runners/macos-lume/README.md
@@ -134,10 +134,10 @@ security unlock-keychain "$SIGNING_KEYCHAIN"
 export CUA_DRIVER_LOCAL_SIGNING_KEYCHAIN="$SIGNING_KEYCHAIN"
 ```
 
-The first local install creates and imports the self-signed identity. It may
-fall back to an ad-hoc signature until the new certificate is trusted; this is
-safe only because TCC has not been granted yet. Run it once, then open Keychain
-Access in the VM display, select the `cua-driver-signing` keychain, open
+The first strict local install creates and imports the self-signed identity,
+then stops without replacing the app if the new certificate is not usable yet.
+Run it once, then open Keychain Access in the VM display, select the
+`cua-driver-signing` keychain, open
 `CuaDriver Local Signing (cua-driver-rs)`, and set Trust to Always Trust. Back
 in Terminal, give Apple tooling access to the private key without storing the
 keychain password in the image or repository:
@@ -145,7 +145,8 @@ keychain password in the image or repository:
 ```bash
 cd ~/cua
 export CUA_DRIVER_SOURCE_SHA="$(cat .cua-e2e-source-sha)"
-bash libs/cua-driver/scripts/install-local.sh --release --autostart
+bash libs/cua-driver/scripts/install-local.sh \
+  --release --autostart --require-stable-signing
 
 read -r -s -p 'Keychain password: ' KEYCHAIN_PASSWORD; echo
 security set-key-partition-list \
@@ -158,7 +159,8 @@ Rerun the installer and require its `signed staged app with a stable local
 identity` message before granting permissions through the app-owned flow:
 
 ```bash
-bash libs/cua-driver/scripts/install-local.sh --release --autostart
+bash libs/cua-driver/scripts/install-local.sh \
+  --release --autostart --require-stable-signing
 ~/.local/bin/cua-driver-local permissions grant
 ```
 

--- a/libs/cua-driver/tests/runners/macos-lume/run-all.sh
+++ b/libs/cua-driver/tests/runners/macos-lume/run-all.sh
@@ -137,7 +137,8 @@ echo "[BUILD IDENTITY] Invalidating the macOS backend for ${SOURCE_SHA}"
 cargo clean --manifest-path "${RUST_ROOT}/Cargo.toml" -p platform-macos
 
 echo "[INSTALL] Building and installing ${SOURCE_SHA} with the golden signing identity"
-bash "${DRIVER_ROOT}/scripts/install-local.sh" --release --autostart \
+bash "${DRIVER_ROOT}/scripts/install-local.sh" \
+  --release --autostart --require-stable-signing \
   2>&1 | tee "${ARTIFACT_DIR}/install-local.log"
 
 codesign -d -r- /Applications/CuaDriverLocal.app \


### PR DESCRIPTION
## Summary

- make every macOS ad-hoc local-signing fallback prominent and explain that Accessibility and Screen Recording grants will be invalidated on rebuild
- add `--require-stable-signing` / `CUA_DRIVER_REQUIRE_STABLE_SIGNING=1` so behavior and E2E lanes stop before replacing the live app without a certificate-backed identity
- prefer an existing dedicated local signing keychain and document the bootstrap/partition-list flow
- verify the staged and copied designated requirements, restoring the prior app if the installed signature differs
- run the macOS behavior lane with strict stable-signing enforcement

## Root cause

When local identity discovery or certificate-backed `codesign` failed with no existing certificate-signed app, the installer could silently sign ad-hoc. That creates a `cdhash` designated requirement which changes on every rebuild, invalidating TCC grants while leaving stale enabled-looking rows in System Settings.

## User impact

Normal local development can still opt into ad-hoc signing, but it is no longer silent. Strict verification lanes fail safely with actionable dedicated-keychain bootstrap instructions, and successful installs report whether their designated requirement is stable or rebuild-dependent.

Fixes #2494.

## Validation

- `bash -n` on the local installer, signing helper, dispatcher, and macOS runner
- `shellcheck -x` on the same shell files
- `uv run --frozen --group test pytest libs/cua-driver/python/tests/test_install_local_signing.py -q` (11 passed)
- `uv run --frozen --group test pytest .github/scripts/tests/ -q` (116 passed)
- `uv run --frozen --group dev ruff check libs/cua-driver/python/tests/test_install_local_signing.py`
- `uv run --frozen --group dev ruff format --check libs/cua-driver/python/tests/test_install_local_signing.py`
- real macOS ad-hoc `codesign -d -r-` probe classified as `ad-hoc`
- `install-local.sh --help` exposes the strict flag
- all triggered GitHub checks pass, including release metadata, Test Scripts, generated contract/SDK bindings, and portable contract parity on macOS, Linux, and Windows

## Limitations

The full app replacement and TCC persistence flow was not run on this development host; the repository macOS behavior runner now enforces the strict path for that representative end-to-end lane.