### PR TITLE
fix(cua-driver): diagnose stale release MCP registrations

### DIFF
--- a/libs/cua-driver/scripts/_install-local-rust.sh
+++ b/libs/cua-driver/scripts/_install-local-rust.sh
@@ -488,6 +488,23 @@ else
     echo "Docs: https://github.com/trycua/cua/tree/main/libs/cua-driver/rust"
 fi
 
+# The local/release identity split deliberately stopped source installs from
+# creating or repairing the published `cua-driver` name. Make the resulting
+# migration state explicit when only the local product is present: otherwise
+# an existing MCP client can keep launching a now-missing release path even
+# though this install completed successfully. Do not create a compatibility
+# symlink here; that would collapse the separate product identities again.
+RELEASE_BIN="$BIN_DIR/cua-driver"
+if [ ! -e "$RELEASE_BIN" ]; then
+    echo ""
+    echo "${YELLOW}Migration note: the published cua-driver CLI is not installed at $RELEASE_BIN.${NORMAL}" >&2
+    echo "  Existing MCP clients configured for 'cua-driver' will not use this local build." >&2
+    echo "  To configure Codex for the local build, run:" >&2
+    echo "    $INSTALLED_BIN mcp-config --client codex" >&2
+    echo "  To restore the published product instead, run:" >&2
+    echo '    /bin/bash -c "$(curl -fsSL https://cua.ai/driver/install.sh)"' >&2
+fi
+
 # OS-specific autostart hint (kept inline; per-shell natural location).
 if [ "$INSTALL_AUTOSTART" != true ]; then
     echo ""

--- a/libs/cua-driver/scripts/install-local.ps1
+++ b/libs/cua-driver/scripts/install-local.ps1
@@ -364,6 +364,22 @@ if (Test-Path -LiteralPath $HintsTxt) {
     Write-Host "Docs: https://github.com/trycua/cua/tree/main/libs/cua-driver/rust"
 }
 
+# The local/release identity split deliberately stopped source installs from
+# creating or repairing the published cua-driver.exe path. Surface the
+# migration state when only the local product is present so an existing MCP
+# client does not keep launching a missing release command. Do not create an
+# alias here: local and published products must retain separate identities.
+$releaseBinary = Join-Path $env:LOCALAPPDATA "Programs\Cua\cua-driver\bin\cua-driver.exe"
+if (-not (Test-Path -LiteralPath $releaseBinary -PathType Leaf)) {
+    Write-Host ""
+    Write-Host "Migration note: the published cua-driver CLI is not installed at $releaseBinary." -ForegroundColor Yellow
+    Write-Host "  Existing MCP clients configured for 'cua-driver' will not use this local build." -ForegroundColor Yellow
+    Write-Host "  To configure Codex for the local build, run:"
+    Write-Host "    $installedBinary mcp-config --client codex"
+    Write-Host "  To restore the published product instead, run:"
+    Write-Host "    irm https://cua.ai/driver/install.ps1 | iex"
+}
+
 # Windows-specific autostart hint (kept inline; per-shell natural location).
 if ($AutoStart) {
     # Default branch: autostart was enabled (either by default or explicitly).

--- a/libs/cua-driver/scripts/tests/test_install_local_migration.py
+++ b/libs/cua-driver/scripts/tests/test_install_local_migration.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SCRIPTS = REPO_ROOT / "libs/cua-driver/scripts"
+
+
+def test_unix_local_install_reports_missing_release_cli_without_aliasing_it() -> None:
+    installer = (SCRIPTS / "_install-local-rust.sh").read_text()
+
+    warning = installer.index('if [ ! -e "$RELEASE_BIN" ]; then')
+    assert installer.index('RELEASE_BIN="$BIN_DIR/cua-driver"') < warning
+    assert installer.index('INSTALLED_BIN="$BIN_DIR/cua-driver-local"') < warning
+    assert (
+        "Existing MCP clients configured for 'cua-driver' will not use this local build."
+        in installer
+    )
+    assert "$INSTALLED_BIN mcp-config --client codex" in installer
+    assert "https://cua.ai/driver/install.sh" in installer
+    assert 'ln -sf "$INSTALLED_BIN" "$RELEASE_BIN"' not in installer
+    assert 'ln -s "$INSTALLED_BIN" "$RELEASE_BIN"' not in installer
+
+
+def test_windows_local_install_reports_missing_release_cli_without_aliasing_it() -> None:
+    installer = (SCRIPTS / "install-local.ps1").read_text(encoding="utf-8-sig")
+
+    warning = installer.index("if (-not (Test-Path -LiteralPath $releaseBinary -PathType Leaf))")
+    assert (
+        installer.index(
+            "$releaseBinary = Join-Path $env:LOCALAPPDATA "
+            '"Programs\\Cua\\cua-driver\\bin\\cua-driver.exe"'
+        )
+        < warning
+    )
+    assert installer.index("$installedBinary = Join-Path $VisibleBinDir $BinaryName") < warning
+    assert (
+        "Existing MCP clients configured for 'cua-driver' will not use this local build."
+        in installer
+    )
+    assert "$installedBinary mcp-config --client codex" in installer
+    assert "irm https://cua.ai/driver/install.ps1 | iex" in installer
+    assert "New-Item -ItemType SymbolicLink" not in installer[warning:]
+
+
+def test_migration_warning_runs_after_shared_post_install_hints() -> None:
+    unix = (SCRIPTS / "_install-local-rust.sh").read_text()
+    windows = (SCRIPTS / "install-local.ps1").read_text(encoding="utf-8-sig")
+
+    assert unix.index('sed "s|{{BINARY}}|$INSTALLED_BIN|g" "$HINTS_TXT"') < unix.index(
+        'if [ ! -e "$RELEASE_BIN" ]; then'
+    )
+    assert windows.index("$hintsRaw -replace") < windows.index(
+        "if (-not (Test-Path -LiteralPath $releaseBinary -PathType Leaf))"
+    )


### PR DESCRIPTION
## Summary

- detect when `install-local` completes but the published `cua-driver` CLI is absent
- explain that existing MCP clients configured for the release identity will not use `cua-driver-local`
- print exact commands to configure Codex for the local product or reinstall the published product
- preserve the local/release ownership boundary: no compatibility alias and no silent client-config mutation
- cover Unix/macOS and Windows installer output with regression tests

Closes #2497.

## Validation

- `uv run --with pytest python -m pytest libs/cua-driver/scripts/tests/ -q` — 12 passed
- `/bin/bash -n libs/cua-driver/scripts/_install-local-rust.sh libs/cua-driver/scripts/install-local.sh`
- `uv run ruff check libs/cua-driver/scripts/tests/test_install_local_migration.py`
- `uv run black --check libs/cua-driver/scripts/tests/test_install_local_migration.py`
- `git diff --check`

PowerShell is not installed on the development host, so the Windows script received source-contract regression coverage here and remains subject to the repository's Windows CI parser/test jobs.

## Scope

This PR changes installer diagnostics only. It does not install, uninstall, or replace either product on the development host.