### PR TITLE
docs(cua-driver): add agent SDK action tutorials

### DIFF
--- a/.github/workflows/ci-cua-driver-contract-clients.yml
+++ b/.github/workflows/ci-cua-driver-contract-clients.yml
@@ -230,8 +230,18 @@ jobs:
           node --input-type=module -e \
             "const sdk = await import('@trycua/cua-driver'); const driver = sdk.CuaDriver.connect(undefined); console.log(driver.socketPath()); driver.uniffiDestroy(); const embedded = await import('@trycua/cua-driver/embedded'); if (embedded.EmbeddedCuaDriverHost !== sdk.EmbeddedCuaDriverHost) process.exit(1)"
 
-      - name: Check Python agent SDK example
-        run: python -m py_compile libs/cua-driver/examples/agent-sdks/claude_agent.py
+      - name: Install Python agent SDK example dependencies
+        working-directory: libs/cua-driver/examples/agent-sdks
+        run: python -m pip install -r requirements.txt
+
+      - name: Check Python agent SDK examples and fixture
+        working-directory: libs/cua-driver/examples/agent-sdks
+        run: |
+          python -m py_compile \
+            claude_agent.py codex_agent.py fixture_server.py \
+            native_driver.py native_tools.py test_fixture_server.py
+          python -m unittest test_fixture_server.py -v
+          python -c "import claude_agent_sdk, openai_codex, cua_driver"
 
       - name: Install agent SDK example dependencies
         working-directory: libs/cua-driver/examples/agent-sdks

--- a/docs/content/docs/concepts/sdk-mcp-and-hosting.mdx
+++ b/docs/content/docs/concepts/sdk-mcp-and-hosting.mdx
@@ -76,3 +76,18 @@ identity, not a different action implementation.
 See [Process model](/reference/cua-driver/process-model) for platform details
 and [Expose MCP from a desktop app](/how-to-guides/driver/expose-mcp-from-desktop-app)
 for the hosted-daemon procedure.
+
+## Agent SDK integration is intentionally asymmetric
+
+| Agent SDK | Native application callbacks | External MCP route |
+| --------- | ---------------------------- | ------------------ |
+| Claude Agent SDK | Supported in Python and TypeScript through its in-process custom-tool server | Supported in Python and TypeScript |
+| Codex SDK | No direct custom-tool callback boundary | Supported in Python and TypeScript |
+
+Claude's in-process custom-tool server is an adapter inside the host
+application; the callbacks still call the native Cua Driver SDK directly.
+Codex uses `cua-driver mcp` because MCP is its supported tool-extension
+boundary. Generating another language client would not add a new capability.
+
+See [Use Cua Driver with Claude Agent SDK](/how-to-guides/driver/use-claude-agent-sdk)
+and [Use Cua Driver with Codex SDK](/how-to-guides/driver/use-codex-sdk).

--- a/docs/content/docs/how-to-guides/driver/meta.json
+++ b/docs/content/docs/how-to-guides/driver/meta.json
@@ -3,6 +3,8 @@
   "pages": [
     "install",
     "use-sdk-in-process",
+    "use-claude-agent-sdk",
+    "use-codex-sdk",
     "expose-mcp-from-desktop-app",
     "install-agent-skill",
     "run-in-macos-lume-vm",

--- a/docs/content/docs/how-to-guides/driver/use-claude-agent-sdk.mdx
+++ b/docs/content/docs/how-to-guides/driver/use-claude-agent-sdk.mdx
@@ -69,10 +69,9 @@ Every mutation returns a fresh desktop observation. If a call times out, the
 handler labels its outcome unknown and tells the model to inspect before any
 retry.
 
-See the complete
-[`claude_agent.py`](https://github.com/trycua/cua/blob/main/libs/cua-driver/examples/agent-sdks/claude_agent.py)
-and
-[`claude_agent.ts`](https://github.com/trycua/cua/blob/main/libs/cua-driver/examples/agent-sdks/claude_agent.ts).
+The complete executables live at
+`libs/cua-driver/examples/agent-sdks/claude_agent.py` and
+`libs/cua-driver/examples/agent-sdks/claude_agent.ts` in the Cua repository.
 
 ## Run the MCP route
 

--- a/docs/content/docs/how-to-guides/driver/use-claude-agent-sdk.mdx
+++ b/docs/content/docs/how-to-guides/driver/use-claude-agent-sdk.mdx
@@ -1,0 +1,107 @@
+---
+title: 'Use Cua Driver with Claude Agent SDK'
+description: 'Choose same-process native callbacks or the MCP agent boundary in Python and TypeScript.'
+---
+
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
+
+Claude Agent SDK supports both Cua Driver integration routes:
+
+- Use **native callbacks** when your application already owns the agent loop,
+  driver runtime, permissions, and session lifecycle.
+- Use **MCP** when Claude is an external agent or should discover the complete
+  Cua Driver tool catalog.
+
+The native callbacks are packaged by Claude Agent SDK as an in-process SDK MCP
+server. Despite that helper's name, it does not start a subprocess or use a
+socket; each callback calls `CuaDriver.create()` in the application process.
+
+## Install the executable examples
+
+From `libs/cua-driver/examples/agent-sdks`:
+
+<Tabs groupId="language" persist items={['Python', 'TypeScript']}>
+  <Tab value="Python">
+
+```bash
+python3.12 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+```
+
+  </Tab>
+  <Tab value="TypeScript">
+
+```bash
+npm install
+```
+
+  </Tab>
+</Tabs>
+
+Authenticate Claude Agent SDK using its normal local login or
+`ANTHROPIC_API_KEY`. Set `CLAUDE_MODEL` only when you need to override its
+default model.
+
+## Run the native callback route
+
+<Tabs groupId="language" persist items={['Python', 'TypeScript']}>
+  <Tab value="Python">
+
+```bash
+.venv/bin/python claude_agent.py --route native \
+  "Inspect the fixture, enter a short value, submit it, and verify the result"
+```
+
+  </Tab>
+  <Tab value="TypeScript">
+
+```bash
+npm run claude -- --route native \
+  "Inspect the fixture, enter a short value, submit it, and verify the result"
+```
+
+  </Tab>
+</Tabs>
+
+The examples expose only `observe_desktop`, `click_desktop`, `type_text`, and
+`press_key`. Their handlers call the same-process Python or TypeScript SDK.
+Every mutation returns a fresh desktop observation. If a call times out, the
+handler labels its outcome unknown and tells the model to inspect before any
+retry.
+
+See the complete
+[`claude_agent.py`](https://github.com/trycua/cua/blob/main/libs/cua-driver/examples/agent-sdks/claude_agent.py)
+and
+[`claude_agent.ts`](https://github.com/trycua/cua/blob/main/libs/cua-driver/examples/agent-sdks/claude_agent.ts).
+
+## Run the MCP route
+
+Install Cua Driver so `cua-driver` is on `PATH`, then run:
+
+<Tabs groupId="language" persist items={['Python', 'TypeScript']}>
+  <Tab value="Python">
+
+```bash
+CUA_CAPTURE_SCOPE=auto \
+  .venv/bin/python claude_agent.py --route mcp \
+  "Inspect the active app and summarize what is visible"
+```
+
+  </Tab>
+  <Tab value="TypeScript">
+
+```bash
+CUA_CAPTURE_SCOPE=auto \
+  npm run claude -- --route mcp \
+  "Inspect the active app and summarize what is visible"
+```
+
+  </Tab>
+</Tabs>
+
+The host creates the Cua session, supplies `cua-driver mcp` to Claude, and ends
+the session in `finally`. Claude discovers the full live MCP surface; the
+generated Cua language packages are not acting as MCP clients.
+
+Use only trusted tasks with these examples. They remove interactive approval
+prompts and deliberately exclude Claude Code's built-in shell and file tools.

--- a/docs/content/docs/how-to-guides/driver/use-codex-sdk.mdx
+++ b/docs/content/docs/how-to-guides/driver/use-codex-sdk.mdx
@@ -61,10 +61,9 @@ CUA_CAPTURE_SCOPE=window \
   </Tab>
 </Tabs>
 
-The complete scripts are
-[`codex_agent.py`](https://github.com/trycua/cua/blob/main/libs/cua-driver/examples/agent-sdks/codex_agent.py)
-and
-[`codex_agent.ts`](https://github.com/trycua/cua/blob/main/libs/cua-driver/examples/agent-sdks/codex_agent.ts).
+The complete scripts live at
+`libs/cua-driver/examples/agent-sdks/codex_agent.py` and
+`libs/cua-driver/examples/agent-sdks/codex_agent.ts` in the Cua repository.
 
 Both scripts:
 

--- a/docs/content/docs/how-to-guides/driver/use-codex-sdk.mdx
+++ b/docs/content/docs/how-to-guides/driver/use-codex-sdk.mdx
@@ -1,0 +1,79 @@
+---
+title: 'Use Cua Driver with Codex SDK'
+description: 'Configure Cua Driver MCP for the Python and TypeScript Codex SDKs.'
+---
+
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
+
+Codex SDK supports MCP servers but does not expose application-owned custom
+tool callbacks. Use `cua-driver mcp` as its Cua Driver boundary. Do not build a
+second tool loop that translates the native SDK back into an ad hoc protocol.
+
+## Install the executable examples
+
+From `libs/cua-driver/examples/agent-sdks`:
+
+<Tabs groupId="language" persist items={['Python', 'TypeScript']}>
+  <Tab value="Python">
+
+```bash
+python3.12 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+```
+
+This installs `openai-codex` and imports it as `openai_codex`.
+
+  </Tab>
+  <Tab value="TypeScript">
+
+```bash
+npm install
+```
+
+This installs `@openai/codex-sdk`.
+
+  </Tab>
+</Tabs>
+
+Install Cua Driver so `cua-driver` is on `PATH`, or set
+`CUA_DRIVER_BIN` to its absolute path.
+
+## Run a desktop task
+
+<Tabs groupId="language" persist items={['Python', 'TypeScript']}>
+  <Tab value="Python">
+
+```bash
+CUA_CAPTURE_SCOPE=window \
+  .venv/bin/python codex_agent.py \
+  "Inspect the active app and summarize what is visible without changing it"
+```
+
+  </Tab>
+  <Tab value="TypeScript">
+
+```bash
+CUA_CAPTURE_SCOPE=window \
+  npm run codex -- \
+  "Inspect the active app and summarize what is visible without changing it"
+```
+
+  </Tab>
+</Tabs>
+
+The complete scripts are
+[`codex_agent.py`](https://github.com/trycua/cua/blob/main/libs/cua-driver/examples/agent-sdks/codex_agent.py)
+and
+[`codex_agent.ts`](https://github.com/trycua/cua/blob/main/libs/cua-driver/examples/agent-sdks/codex_agent.ts).
+
+Both scripts:
+
+1. start a uniquely named Cua session outside Codex;
+2. mark the Cua MCP server required;
+3. run Codex in a read-only filesystem sandbox;
+4. instruct Codex to use only Cua tools for desktop work; and
+5. end the session in `finally`.
+
+The filesystem sandbox does not sandbox the separate desktop MCP server.
+Restrict the task itself, choose an appropriate Cua capture scope and policy,
+and never blindly retry a mutation after a timeout or disconnect.

--- a/docs/content/docs/reference/cua-driver/sdk-reference.mdx
+++ b/docs/content/docs/reference/cua-driver/sdk-reference.mdx
@@ -37,9 +37,12 @@ same-process runtime and `Daemon` for a socket-backed connection.
 | `is_available()`   | `isAvailable()`   | Whether the runtime can serve calls                     |
 | `shutdown()`       | `shutdown()`      | Stops admission and awaits admitted work                |
 
-In TypeScript, call `uniffiDestroy()` after `shutdown()` to release the binding
-handle. Python releases the handle during finalization, but applications should
-still await `shutdown()`.
+In TypeScript, `shutdown()` and `uniffiDestroy()` have separate jobs:
+`shutdown()` closes runtime admission and awaits admitted operations;
+`uniffiDestroy()` immediately frees the generated UniFFI object handle.
+JavaScript's `FinalizationRegistry` is only a nondeterministic fallback, so
+orderly applications call both, in that order. Python finalization releases its
+handle automatically, but applications must still await `shutdown()`.
 
 ## Session methods
 

--- a/docs/content/docs/tutorials/index.mdx
+++ b/docs/content/docs/tutorials/index.mdx
@@ -6,6 +6,7 @@ description: 'Learn Cua by following end-to-end builds.'
 Tutorials teach Cua by building something end to end. Start here if you are new to Cua. Each tutorial is *one happy path* you can follow from start to finish.
 
 - [Drive your first app](/tutorials/drive-your-first-app) - operate a native app in the background with Cua Driver.
+- [Verify a desktop action with Cua Driver](/tutorials/verify-a-desktop-action-with-cua-driver) - build a deterministic Python or TypeScript perceive, act, and verify loop.
 - [Your first cloud sandbox](/tutorials/your-first-cloud-sandbox) - spin up a disposable cloud computer.
 - [Create your first local macOS VM](/tutorials/create-your-first-lume-vm) - install Lume and boot a vanilla Tahoe guest.
 

--- a/docs/content/docs/tutorials/meta.json
+++ b/docs/content/docs/tutorials/meta.json
@@ -6,6 +6,7 @@
     "drive-your-first-app",
     "your-first-cua-driver-python-app",
     "your-first-cua-driver-typescript-app",
+    "verify-a-desktop-action-with-cua-driver",
     "your-first-cloud-sandbox",
     "create-your-first-lume-vm"
   ]

--- a/docs/content/docs/tutorials/verify-a-desktop-action-with-cua-driver.mdx
+++ b/docs/content/docs/tutorials/verify-a-desktop-action-with-cua-driver.mdx
@@ -40,7 +40,7 @@ python3.12 -m venv .venv
 ```
 
 The complete executable is
-[`native_driver.py`](https://github.com/trycua/cua/blob/main/libs/cua-driver/examples/agent-sdks/native_driver.py).
+`libs/cua-driver/examples/agent-sdks/native_driver.py`.
 
   </Tab>
   <Tab value="TypeScript">
@@ -51,7 +51,7 @@ npm run native
 ```
 
 The complete executable is
-[`native_driver.ts`](https://github.com/trycua/cua/blob/main/libs/cua-driver/examples/agent-sdks/native_driver.ts).
+`libs/cua-driver/examples/agent-sdks/native_driver.ts`.
 
   </Tab>
 </Tabs>

--- a/docs/content/docs/tutorials/verify-a-desktop-action-with-cua-driver.mdx
+++ b/docs/content/docs/tutorials/verify-a-desktop-action-with-cua-driver.mdx
@@ -1,0 +1,89 @@
+---
+title: 'Verify a desktop action with Cua Driver'
+description: 'Build a deterministic perceive, act, and verify loop in Python or TypeScript.'
+---
+
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
+
+In this tutorial, you will capture the desktop, enter a unique value in a local
+browser fixture, and prove that the page received it. The proof comes from a
+loopback state endpoint, not from trusting the action response.
+
+## Get the example
+
+Clone Cua and enter the executable example directory:
+
+```bash
+git clone https://github.com/trycua/cua.git
+cd cua/libs/cua-driver/examples/agent-sdks
+```
+
+The fixture listens only on `127.0.0.1`. Start it in one terminal:
+
+```bash
+python3 fixture_server.py
+```
+
+Your browser opens a page containing one autofocus input. Keep that window
+focused. On macOS, grant Screen Recording and Accessibility permission to the
+Python or Node process that imports Cua Driver.
+
+## Run the native SDK loop
+
+<Tabs groupId="language" persist items={['Python', 'TypeScript']}>
+  <Tab value="Python">
+
+```bash
+python3.12 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+.venv/bin/python native_driver.py
+```
+
+The complete executable is
+[`native_driver.py`](https://github.com/trycua/cua/blob/main/libs/cua-driver/examples/agent-sdks/native_driver.py).
+
+  </Tab>
+  <Tab value="TypeScript">
+
+```bash
+npm install
+npm run native
+```
+
+The complete executable is
+[`native_driver.ts`](https://github.com/trycua/cua/blob/main/libs/cua-driver/examples/agent-sdks/native_driver.ts).
+
+  </Tab>
+</Tabs>
+
+The program performs four observable steps:
+
+1. `CuaDriver.create()` loads the Rust runtime in the importing process.
+2. `get_desktop_state` returns the initial whole-desktop image.
+3. `type_text` and `press_key` submit a randomly generated value.
+4. The program polls the fixture's `/state` endpoint and captures the desktop
+   again only after the exact value appears.
+
+Successful output resembles:
+
+```text
+perceived desktop: image/png
+verified submitted value: cua-2ca7d7cc81
+```
+
+## See how uncertain actions are handled
+
+An input action can reach the OS even if the caller times out before receiving
+the response. The examples catch that condition but do not repeat the action.
+They check the independent fixture first. If the value is present, the
+postcondition resolves the unknown response; if it is absent, the run fails
+without silently replaying a mutation.
+
+## Shut down the fixture
+
+Press `Ctrl+C` in the fixture terminal. The SDK examples already end their
+session in `finally` and await runtime shutdown.
+
+Next, connect the same driver to
+[Claude Agent SDK](/how-to-guides/driver/use-claude-agent-sdk) or
+[Codex SDK](/how-to-guides/driver/use-codex-sdk).

--- a/libs/cua-driver/examples/agent-sdks/README.md
+++ b/libs/cua-driver/examples/agent-sdks/README.md
@@ -1,75 +1,108 @@
-# Use Cua Driver from agent SDKs
+# Cua Driver SDK and agent examples
 
-These examples show **Cua as an agent tool**. Codex and Claude connect directly
-to `cua-driver mcp`; the agent SDK is the MCP client and discovers the live tool
-surface through `tools/list`.
+These executable examples cover two intentionally different boundaries:
 
-This is intentionally different from **Cua as an imported SDK**. An application
-that wants typed, programmatic calls can import the Python `cua-driver` package
-or the TypeScript `@trycua/cua-driver` package. Those packages are Rust-backed
-UniFFI SDKs that call the daemon directly; they do not provide MCP clients.
+- **Native application route:** Python or Node imports `cua-driver` in process.
+  Claude Agent SDK can wrap a narrow set of those calls as in-process custom
+  tools.
+- **MCP agent route:** Claude or Codex launches `cua-driver mcp`. The agent SDK
+  already supplies the language-independent MCP client.
 
-## Prerequisites
+Codex SDK does not expose direct custom-tool callbacks. Its Cua Driver examples
+therefore use MCP rather than inventing a bespoke native adapter.
 
-1. Install Cua Driver, grant the host OS permissions, and ensure its daemon is
-   running.
-2. Put `cua-driver` on `PATH`, or set `CUA_DRIVER_BIN` to its absolute path.
-3. Authenticate the selected agent SDK. The Codex SDK can use an existing Codex
-   login or `CODEX_API_KEY`; the Claude Agent SDK can use an existing Claude
-   Code login or `ANTHROPIC_API_KEY`.
+## Deterministic perceive → act → verify fixture
 
-Both scripts create a unique Cua session with `cua-driver call start_session`,
-give that session ID to the agent, and call `end_session` in a `finally` block.
-The session's capture scope comes from `CUA_CAPTURE_SCOPE` and defaults to
-`auto`. Valid values are `auto`, `window`, and `desktop`.
-
-The examples let the model execute GUI actions without an interactive approval
-prompt. Run them only with a task you trust, and keep purchases, messages,
-deletions, credential entry, and other irreversible actions out of unattended
-prompts.
-
-## Python: Claude Agent SDK
+Start the loopback-only fixture in one terminal:
 
 ```bash
-cd libs/cua-driver/examples/agent-sdks
-python3.10 -m venv .venv
-.venv/bin/pip install -r requirements.txt
+python3 fixture_server.py
+```
 
-CUA_CAPTURE_SCOPE=auto \
-  .venv/bin/python claude_agent.py \
+It opens a page with one autofocus input. The native examples capture the
+desktop, type a unique value, press Enter, and verify the submitted value
+through the independent `/state` endpoint. A timeout after a mutation is
+treated as an unknown outcome: the examples observe the fixture before any
+retry.
+
+Python:
+
+```bash
+python3.12 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+.venv/bin/python native_driver.py
+```
+
+TypeScript:
+
+```bash
+npm install
+npm run native
+```
+
+Grant Screen Recording and Accessibility/Input permission to the importing
+Python or Node process. Keep the fixture browser window focused when the native
+example starts.
+
+## Claude Agent SDK: native or MCP
+
+Python:
+
+```bash
+.venv/bin/python claude_agent.py --route native \
+  "Enter a short value in the fixture and submit it"
+
+.venv/bin/python claude_agent.py --route mcp \
   "Open Calculator, compute 19 * 23, and report the result"
 ```
 
-`tools=[]` removes Claude Code's built-in tools, `strict_mcp_config=True`
-ignores unrelated user/project MCP servers, and the `cua_driver` server is the
-only tool source supplied to the run.
-
-## TypeScript: Codex SDK
+TypeScript:
 
 ```bash
-cd libs/cua-driver/examples/agent-sdks
-npm install
+npm run claude -- --route native \
+  "Enter a short value in the fixture and submit it"
 
-CUA_CAPTURE_SCOPE=window \
-  npm run codex -- \
+npm run claude -- --route mcp \
+  "Open Calculator, compute 19 * 23, and report the result"
+```
+
+The native route supplies four narrow in-process callbacks: observe, click,
+type, and key press. The MCP route discovers the complete live Cua Driver tool
+surface. Set `CLAUDE_MODEL` optionally.
+
+## Codex SDK: MCP
+
+Python:
+
+```bash
+.venv/bin/python codex_agent.py \
   "Inspect the active app and summarize what is visible without changing it"
 ```
 
-The Codex thread uses a read-only filesystem sandbox and `approvalPolicy:
-"never"`; desktop actions still happen through the separately configured
-`cua_driver` MCP server. The prompt tells Codex not to substitute shell or
-filesystem operations for the MCP tools.
-
-## Local checks without running an agent
-
-These checks do not require API credentials or a live desktop:
+TypeScript:
 
 ```bash
-python3.10 -m py_compile claude_agent.py
-npm run typecheck
+npm run codex -- \
+  "Inspect the active app and summarize what is visible without changing it"
 ```
 
-The examples intentionally do not import the Cua Driver language packages.
-That absence is the architectural point: an MCP-capable agent already has a
-runtime-neutral client. Use the packages only when application code wants
-typed direct calls rather than an agent-controlled tool loop.
+Set `CODEX_MODEL` optionally. Both scripts create a unique Cua session outside
+the agent, configure `cua-driver mcp`, and end the session in `finally`.
+
+## Environment and safety
+
+- Put `cua-driver` on `PATH`, or set `CUA_DRIVER_BIN` for MCP examples.
+- Set `CUA_CAPTURE_SCOPE` to `auto`, `window`, or `desktop` for MCP examples.
+- Authenticate the chosen agent SDK using its normal local login or API key.
+- Run only trusted tasks. These examples remove interactive approval prompts.
+- Keep purchases, messages, deletion, credential entry, and other irreversible
+  actions out of unattended prompts.
+
+## Credential-free checks
+
+```bash
+python3.12 -m py_compile \
+  claude_agent.py codex_agent.py fixture_server.py native_driver.py native_tools.py
+python3.12 -m unittest test_fixture_server.py
+npm run typecheck
+```

--- a/libs/cua-driver/examples/agent-sdks/claude_agent.py
+++ b/libs/cua-driver/examples/agent-sdks/claude_agent.py
@@ -1,4 +1,4 @@
-"""Run a Claude Agent SDK desktop task through Cua Driver's MCP server."""
+"""Run a Claude Agent SDK desktop task through Cua Driver native tools or MCP."""
 
 from __future__ import annotations
 
@@ -11,14 +11,29 @@ from pathlib import Path
 from typing import Literal, cast
 from uuid import uuid4
 
-from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient, ResultMessage
+from claude_agent_sdk import (
+    ClaudeAgentOptions,
+    ClaudeSDKClient,
+    ResultMessage,
+    create_sdk_mcp_server,
+    tool,
+)
+
+from native_tools import NativeDesktopTools
 
 CaptureScope = Literal["auto", "window", "desktop"]
+Route = Literal["native", "mcp"]
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("task", help="Trusted desktop task for Claude to perform")
+    parser.add_argument(
+        "--route",
+        choices=("native", "mcp"),
+        default="mcp",
+        help="same-process SDK callbacks or the external-agent MCP boundary",
+    )
     return parser.parse_args()
 
 
@@ -39,44 +54,130 @@ def capture_scope() -> CaptureScope:
     return cast(CaptureScope, value)
 
 
-async def driver_call(binary: str, tool: str, arguments: dict[str, str]) -> None:
+async def driver_call(binary: str, name: str, arguments: dict[str, str]) -> None:
     process = await asyncio.create_subprocess_exec(
         binary,
         "call",
-        tool,
+        name,
         json.dumps(arguments),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    stdout, stderr = await process.communicate()
+    try:
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=30)
+    except TimeoutError:
+        process.kill()
+        await process.wait()
+        raise RuntimeError(f"cua-driver call {name} timed out") from None
     if process.returncode != 0:
         detail = stderr.decode().strip() or stdout.decode().strip()
-        raise RuntimeError(f"cua-driver call {tool} failed: {detail}")
+        raise RuntimeError(f"cua-driver call {name} failed: {detail}")
 
 
-def agent_prompt(task: str, session: str, scope: CaptureScope) -> str:
-    return f"""Complete this desktop task through the cua_driver MCP server:
+def prompt(task: str, route: Route, session: str | None = None) -> str:
+    lifecycle = (
+        f"The host already started session {session!r}. Pass it to every Cua "
+        "tool that accepts a session; do not call start_session or end_session."
+        if session
+        else "The host owns the native driver session; the custom tools do not expose lifecycle."
+    )
+    return f"""Complete this trusted desktop task through Cua Driver:
 
 {task}
 
-The host has already started session {session!r} with capture scope {scope!r}.
-Use only cua_driver MCP tools for desktop observation and interaction. Do not
-substitute shell, filesystem, web, or code-execution tools. Pass session
-{session!r} to every Cua tool that accepts a session. Inspect state before each
-action and verify state after it. Do not call start_session or end_session; the
-host owns lifecycle cleanup. Do not perform purchases, send messages, delete
-data, expose credentials, or take another irreversible action unless the task
-explicitly requests that exact action. Return a concise result and mention any
-step you could not verify.
+Route: {route}. {lifecycle}
+Use only the supplied Cua tools for desktop observation and interaction. Inspect
+state before each action and verify state after it. A timeout after a mutation
+means the outcome is unknown: observe before retrying and never blindly replay.
+Do not purchase, send, delete, expose credentials, or perform another
+irreversible action unless the task explicitly requests that exact action.
+Return a concise result and mention any step you could not verify.
 """
 
 
-async def run(task: str) -> None:
+def native_server(runtime: NativeDesktopTools):
+    @tool(
+        "observe_desktop",
+        "Capture the whole desktop. Use before every action and to verify its result.",
+        {},
+    )
+    async def observe_desktop(_args):
+        return await runtime.observe()
+
+    @tool(
+        "click_desktop",
+        "Click an absolute desktop coordinate grounded in the latest screenshot.",
+        {"x": float, "y": float},
+    )
+    async def click_desktop(args):
+        return await runtime.click(args["x"], args["y"])
+
+    @tool(
+        "type_text",
+        "Type text into the currently focused desktop control, then re-observe.",
+        {"text": str},
+    )
+    async def type_text(args):
+        return await runtime.type_text(args["text"])
+
+    @tool(
+        "press_key",
+        "Press one named key in the desktop session, then re-observe.",
+        {"key": str},
+    )
+    async def press_key(args):
+        return await runtime.press_key(args["key"])
+
+    return create_sdk_mcp_server(
+        name="cua_native",
+        version="1.0.0",
+        tools=[observe_desktop, click_desktop, type_text, press_key],
+    )
+
+
+async def run_agent(options: ClaudeAgentOptions, task_prompt: str) -> None:
+    final_result: ResultMessage | None = None
+    async with ClaudeSDKClient(options=options) as client:
+        await client.query(task_prompt)
+        async for message in client.receive_response():
+            if isinstance(message, ResultMessage):
+                final_result = message
+    if final_result is None:
+        raise RuntimeError("Claude Agent SDK returned no final result")
+    if final_result.is_error:
+        raise RuntimeError(final_result.result or ", ".join(final_result.errors or []))
+    print(final_result.result or "Claude completed the task without a text result.")
+
+
+async def run_native(task: str) -> None:
+    runtime = NativeDesktopTools()
+    try:
+        await runtime.start()
+        options = ClaudeAgentOptions(
+            model=os.environ.get("CLAUDE_MODEL"),
+            cwd=Path.cwd(),
+            tools=[],
+            mcp_servers={"cua_native": native_server(runtime)},
+            strict_mcp_config=True,
+            allowed_tools=[
+                "mcp__cua_native__observe_desktop",
+                "mcp__cua_native__click_desktop",
+                "mcp__cua_native__type_text",
+                "mcp__cua_native__press_key",
+            ],
+            permission_mode="dontAsk",
+            max_turns=40,
+        )
+        await run_agent(options, prompt(task, "native"))
+    finally:
+        await runtime.close()
+
+
+async def run_mcp(task: str) -> None:
     binary = driver_binary()
     scope = capture_scope()
-    session = f"claude-agent-{uuid4().hex[:12]}"
+    session = f"claude-mcp-{uuid4().hex[:12]}"
     started = False
-
     try:
         await driver_call(
             binary,
@@ -84,7 +185,6 @@ async def run(task: str) -> None:
             {"session": session, "capture_scope": scope},
         )
         started = True
-
         options = ClaudeAgentOptions(
             model=os.environ.get("CLAUDE_MODEL"),
             cwd=Path.cwd(),
@@ -97,28 +197,25 @@ async def run(task: str) -> None:
                 }
             },
             strict_mcp_config=True,
+            # Claude's MCP allowlist accepts the server name to enable all
+            # tools from that server; wildcard tool-name globs are unsupported.
             allowed_tools=["mcp__cua_driver"],
             permission_mode="dontAsk",
             max_turns=40,
         )
-
-        final_result: ResultMessage | None = None
-        async with ClaudeSDKClient(options=options) as client:
-            await client.query(agent_prompt(task, session, scope))
-            async for message in client.receive_response():
-                if isinstance(message, ResultMessage):
-                    final_result = message
-
-        if final_result is None:
-            raise RuntimeError("Claude Agent SDK returned no final result")
-        if final_result.is_error:
-            raise RuntimeError(final_result.result or ", ".join(final_result.errors or []))
-        print(final_result.result or "Claude completed the task without a text result.")
+        await run_agent(options, prompt(task, "mcp", session))
     finally:
         if started:
             await driver_call(binary, "end_session", {"session": session})
 
 
+async def main() -> None:
+    args = parse_args()
+    if args.route == "native":
+        await run_native(args.task)
+    else:
+        await run_mcp(args.task)
+
+
 if __name__ == "__main__":
-    arguments = parse_args()
-    asyncio.run(run(arguments.task))
+    asyncio.run(main())

--- a/libs/cua-driver/examples/agent-sdks/claude_agent.ts
+++ b/libs/cua-driver/examples/agent-sdks/claude_agent.ts
@@ -1,0 +1,177 @@
+/** Run a Claude Agent SDK desktop task through native Cua tools or MCP. */
+
+import { execFile } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { promisify } from 'node:util';
+
+import {
+  createSdkMcpServer,
+  query,
+  tool,
+  type Options,
+  type SDKResultMessage,
+} from '@anthropic-ai/claude-agent-sdk';
+import { z } from 'zod';
+
+import { NativeDesktopTools } from './native-tools.js';
+
+type Route = 'native' | 'mcp';
+type CaptureScope = 'auto' | 'window' | 'desktop';
+
+const execFileAsync = promisify(execFile);
+
+function argumentsFromCli(): { route: Route; task: string } {
+  const args = process.argv.slice(2);
+  const routeIndex = args.indexOf('--route');
+  let route: Route = 'mcp';
+  if (routeIndex >= 0) {
+    const value = args[routeIndex + 1];
+    if (value !== 'native' && value !== 'mcp') {
+      throw new Error('--route must be native or mcp');
+    }
+    route = value;
+    args.splice(routeIndex, 2);
+  }
+  const task = args.join(' ').trim();
+  if (!task) throw new Error('usage: npm run claude -- [--route native|mcp] "<task>"');
+  return { route, task };
+}
+
+function captureScope(): CaptureScope {
+  const value = process.env.CUA_CAPTURE_SCOPE ?? 'auto';
+  if (value !== 'auto' && value !== 'window' && value !== 'desktop') {
+    throw new Error('CUA_CAPTURE_SCOPE must be auto, window, or desktop');
+  }
+  return value;
+}
+
+async function driverCall(
+  binary: string,
+  name: string,
+  args: Record<string, string>
+): Promise<void> {
+  await execFileAsync(binary, ['call', name, JSON.stringify(args)], { timeout: 30_000 });
+}
+
+async function runAgent(options: Options, prompt: string): Promise<void> {
+  let result: SDKResultMessage | undefined;
+  for await (const message of query({ prompt, options })) {
+    if (message.type === 'result') result = message;
+  }
+  if (!result) throw new Error('Claude Agent SDK returned no final result');
+  if (result.subtype !== 'success') {
+    throw new Error(result.errors.join(', ') || result.subtype);
+  }
+  console.log(result.result);
+}
+
+function nativeServer(runtime: NativeDesktopTools) {
+  return createSdkMcpServer({
+    name: 'cua_native',
+    version: '1.0.0',
+    tools: [
+      tool(
+        'observe_desktop',
+        'Capture the whole desktop. Use before every action and to verify its result.',
+        {},
+        async () => await runtime.observe()
+      ),
+      tool(
+        'click_desktop',
+        'Click an absolute desktop coordinate grounded in the latest screenshot.',
+        { x: z.number(), y: z.number() },
+        async ({ x, y }) => await runtime.click(x, y)
+      ),
+      tool(
+        'type_text',
+        'Type text into the focused desktop control, then re-observe.',
+        { text: z.string() },
+        async ({ text }) => await runtime.typeText(text)
+      ),
+      tool(
+        'press_key',
+        'Press one named key in the desktop session, then re-observe.',
+        { key: z.string() },
+        async ({ key }) => await runtime.pressKey(key)
+      ),
+    ],
+  });
+}
+
+function taskPrompt(task: string, route: Route, session?: string): string {
+  const lifecycle = session
+    ? `The host already started session ${JSON.stringify(session)}. Pass it to every Cua tool that accepts a session; do not call start_session or end_session.`
+    : 'The host owns the native driver session; custom tools do not expose lifecycle.';
+  return `Complete this trusted desktop task through Cua Driver:
+
+${task}
+
+Route: ${route}. ${lifecycle}
+Use only supplied Cua tools for desktop observation and interaction. Inspect
+before each action and verify afterward. If a mutation times out, observe before
+any retry; never blindly replay an action with an unknown outcome. Do not
+purchase, send, delete, expose credentials, or perform another irreversible
+action unless the task explicitly requests it. Name anything unverified.`;
+}
+
+async function runNative(task: string): Promise<void> {
+  const runtime = new NativeDesktopTools();
+  try {
+    await runtime.start();
+    await runAgent(
+      {
+        model: process.env.CLAUDE_MODEL,
+        tools: [],
+        mcpServers: { cua_native: nativeServer(runtime) },
+        strictMcpConfig: true,
+        allowedTools: [
+          'mcp__cua_native__observe_desktop',
+          'mcp__cua_native__click_desktop',
+          'mcp__cua_native__type_text',
+          'mcp__cua_native__press_key',
+        ],
+        permissionMode: 'dontAsk',
+        maxTurns: 40,
+      },
+      taskPrompt(task, 'native')
+    );
+  } finally {
+    await runtime.close();
+  }
+}
+
+async function runMcp(task: string): Promise<void> {
+  const binary = process.env.CUA_DRIVER_BIN ?? 'cua-driver';
+  const scope = captureScope();
+  const session = `claude-mcp-${randomUUID().slice(0, 12)}`;
+  let started = false;
+  try {
+    await driverCall(binary, 'start_session', { session, capture_scope: scope });
+    started = true;
+    await runAgent(
+      {
+        model: process.env.CLAUDE_MODEL,
+        tools: [],
+        mcpServers: {
+          cua_driver: { type: 'stdio', command: binary, args: ['mcp'] },
+        },
+        strictMcpConfig: true,
+        // A bare MCP server name enables all of its tools. Claude does not
+        // support wildcard tool-name globs in this allowlist.
+        allowedTools: ['mcp__cua_driver'],
+        permissionMode: 'dontAsk',
+        maxTurns: 40,
+      },
+      taskPrompt(task, 'mcp', session)
+    );
+  } finally {
+    if (started) await driverCall(binary, 'end_session', { session });
+  }
+}
+
+const args = argumentsFromCli();
+if (args.route === 'native') {
+  await runNative(args.task);
+} else {
+  await runMcp(args.task);
+}

--- a/libs/cua-driver/examples/agent-sdks/codex_agent.py
+++ b/libs/cua-driver/examples/agent-sdks/codex_agent.py
@@ -1,0 +1,107 @@
+"""Run a Codex Python SDK desktop task through Cua Driver's MCP boundary."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import shutil
+from typing import Literal, cast
+from uuid import uuid4
+
+from openai_codex import AsyncCodex, CodexConfig, Sandbox
+
+CaptureScope = Literal["auto", "window", "desktop"]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("task", help="Trusted desktop task for Codex to perform")
+    return parser.parse_args()
+
+
+def driver_binary() -> str:
+    configured = os.environ.get("CUA_DRIVER_BIN")
+    if configured:
+        return configured
+    discovered = shutil.which("cua-driver")
+    if discovered:
+        return discovered
+    raise RuntimeError("cua-driver is not on PATH; set CUA_DRIVER_BIN")
+
+
+def capture_scope() -> CaptureScope:
+    value = os.environ.get("CUA_CAPTURE_SCOPE", "auto")
+    if value not in {"auto", "window", "desktop"}:
+        raise ValueError("CUA_CAPTURE_SCOPE must be auto, window, or desktop")
+    return cast(CaptureScope, value)
+
+
+async def driver_call(binary: str, name: str, arguments: dict[str, str]) -> None:
+    process = await asyncio.create_subprocess_exec(
+        binary,
+        "call",
+        name,
+        json.dumps(arguments),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=30)
+    except TimeoutError:
+        process.kill()
+        await process.wait()
+        raise RuntimeError(f"cua-driver call {name} timed out") from None
+    if process.returncode != 0:
+        detail = stderr.decode().strip() or stdout.decode().strip()
+        raise RuntimeError(f"cua-driver call {name} failed: {detail}")
+
+
+async def main() -> None:
+    args = parse_args()
+    binary = driver_binary()
+    scope = capture_scope()
+    session = f"codex-python-{uuid4().hex[:12]}"
+    started = False
+
+    try:
+        await driver_call(
+            binary,
+            "start_session",
+            {"session": session, "capture_scope": scope},
+        )
+        started = True
+        config = CodexConfig(
+            config_overrides=(
+                f'mcp_servers.cua_driver.command={json.dumps(binary)}',
+                'mcp_servers.cua_driver.args=["mcp"]',
+                "mcp_servers.cua_driver.required=true",
+            )
+        )
+        async with AsyncCodex(config) as codex:
+            thread = await codex.thread_start(
+                model=os.environ.get("CODEX_MODEL"),
+                sandbox=Sandbox.read_only,
+            )
+            result = await thread.run(
+                f"""Complete this trusted desktop task through the cua_driver MCP server:
+
+{args.task}
+
+The host already started session {session!r} with capture scope {scope!r}.
+Use only cua_driver MCP tools for desktop observation and interaction. Pass
+session {session!r} to every tool that accepts a session. Inspect before each
+action and verify afterward. Do not call start_session or end_session. If a
+mutation times out, observe before any retry; never blindly replay an action
+with an unknown outcome. Return a concise result and name anything unverified.
+"""
+            )
+            print(result.final_response)
+    finally:
+        if started:
+            await driver_call(binary, "end_session", {"session": session})
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/libs/cua-driver/examples/agent-sdks/codex_agent.ts
+++ b/libs/cua-driver/examples/agent-sdks/codex_agent.ts
@@ -48,6 +48,7 @@ observation and interaction. Do not substitute shell, filesystem, web, or code
 execution. Pass session ${JSON.stringify(session)} to every Cua tool that
 accepts a session. Inspect state before each action and verify state after it.
 Do not call start_session or end_session; the host owns lifecycle cleanup. Do
+not blindly retry a mutation after a timeout or disconnect; observe first. Do
 not perform purchases, send messages, delete data, expose credentials, or take
 another irreversible action unless the task explicitly requests that exact
 action. Return a concise result and mention any step you could not verify.`;
@@ -74,6 +75,7 @@ async function main(): Promise<void> {
             command: binary,
             args: ['mcp'],
             startup_timeout_sec: 30,
+            required: true,
           },
         },
       },

--- a/libs/cua-driver/examples/agent-sdks/fixture_server.py
+++ b/libs/cua-driver/examples/agent-sdks/fixture_server.py
@@ -1,0 +1,141 @@
+"""Serve a deterministic desktop fixture for Cua Driver examples.
+
+The browser page has one autofocus input. Submitting it records the value on a
+loopback-only endpoint so examples can verify the GUI action independently of
+the driver's own response.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import threading
+import webbrowser
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs
+
+
+PAGE = """<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<title>Cua Driver action fixture</title>
+<style>
+  body { font: 20px system-ui; display: grid; min-height: 90vh; place-items: center; }
+  main { width: min(640px, 85vw); text-align: center; }
+  input, button { box-sizing: border-box; font: inherit; margin: 8px; padding: 16px; }
+  input { width: min(440px, 75vw); }
+  output { display: block; margin-top: 20px; font-family: monospace; }
+</style>
+<main>
+  <h1>Cua Driver action fixture</h1>
+  <p>Keep this window focused. The input below has autofocus.</p>
+  <form method="post" action="/submit">
+    <input name="value" autofocus required aria-label="verification value">
+    <button type="submit">Submit</button>
+  </form>
+  <output>status=waiting</output>
+</main>
+</html>
+"""
+
+
+def submitted_page(value: str) -> bytes:
+    safe = html.escape(value)
+    return f"""<!doctype html>
+<html lang="en"><meta charset="utf-8"><title>Cua Driver verified</title>
+<style>body {{ font: 24px system-ui; display:grid; min-height:90vh; place-items:center; }}</style>
+<main><h1>Action received</h1><output>status=submitted:{safe}</output></main>
+</html>""".encode()
+
+
+class FixtureState:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._submitted: str | None = None
+
+    def reset(self) -> None:
+        with self._lock:
+            self._submitted = None
+
+    def submit(self, value: str) -> None:
+        with self._lock:
+            self._submitted = value
+
+    def snapshot(self) -> dict[str, str | None]:
+        with self._lock:
+            return {"submitted": self._submitted}
+
+
+class FixtureHandler(BaseHTTPRequestHandler):
+    server: "FixtureServer"
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        if self.path == "/":
+            self._send(HTTPStatus.OK, "text/html; charset=utf-8", PAGE.encode())
+            return
+        if self.path == "/state":
+            payload = json.dumps(self.server.state.snapshot()).encode()
+            self._send(HTTPStatus.OK, "application/json", payload)
+            return
+        self.send_error(HTTPStatus.NOT_FOUND)
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        if self.path == "/reset":
+            self.server.state.reset()
+            self._send(HTTPStatus.NO_CONTENT, "text/plain", b"")
+            return
+        if self.path == "/submit":
+            length = int(self.headers.get("Content-Length", "0"))
+            values = parse_qs(self.rfile.read(length).decode())
+            value = values.get("value", [""])[0]
+            if not value:
+                self.send_error(HTTPStatus.BAD_REQUEST, "value is required")
+                return
+            self.server.state.submit(value)
+            self._send(HTTPStatus.OK, "text/html; charset=utf-8", submitted_page(value))
+            return
+        self.send_error(HTTPStatus.NOT_FOUND)
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+    def _send(self, status: HTTPStatus, content_type: str, payload: bytes) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+class FixtureServer(ThreadingHTTPServer):
+    def __init__(self, address: tuple[str, int]) -> None:
+        self.state = FixtureState()
+        super().__init__(address, FixtureHandler)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--no-open", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    server = FixtureServer(("127.0.0.1", args.port))
+    url = f"http://127.0.0.1:{server.server_port}/"
+    print(f"Fixture ready at {url}", flush=True)
+    if not args.no_open:
+        webbrowser.open(url)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/cua-driver/examples/agent-sdks/native-tools.ts
+++ b/libs/cua-driver/examples/agent-sdks/native-tools.ts
@@ -1,0 +1,165 @@
+/** Narrow agent-tool adapter over the same-process Cua Driver TypeScript SDK. */
+
+import { randomUUID } from 'node:crypto';
+
+import {
+  CaptureScope,
+  ClickButton,
+  ClickInput,
+  CuaDriver,
+  DesktopScope,
+  EndSessionInput,
+  GetDesktopStateInput,
+  PressKeyInput,
+  StartSessionInput,
+  ToolResult,
+  TypeTextInput,
+} from '@trycua/cua-driver';
+
+type McpContent =
+  | { type: 'text'; text: string }
+  | { type: 'image'; data: string; mimeType: string };
+
+export type NativeToolResult = {
+  content: McpContent[];
+  isError?: boolean;
+};
+
+export class NativeDesktopTools {
+  readonly driver = CuaDriver.create(undefined);
+  readonly session = `claude-native-${randomUUID().slice(0, 12)}`;
+  private started = false;
+
+  constructor(private readonly timeoutMs = 30_000) {}
+
+  async start(): Promise<void> {
+    await this.bounded(
+      this.driver.startSession(
+        StartSessionInput.new({
+          session: this.session,
+          captureScope: CaptureScope.Desktop,
+        })
+      ),
+      'start_session'
+    );
+    this.started = true;
+  }
+
+  async close(): Promise<void> {
+    try {
+      if (this.started) {
+        await this.bounded(
+          this.driver.endSession(EndSessionInput.new({ session: this.session })),
+          'end_session'
+        );
+        this.started = false;
+      }
+    } finally {
+      try {
+        await this.driver.shutdown();
+      } finally {
+        // Generated UniFFI bindings expose deterministic handle release
+        // separately from asynchronous runtime shutdown.
+        (this.driver as unknown as { uniffiDestroy(): void }).uniffiDestroy();
+      }
+    }
+  }
+
+  async observe(): Promise<NativeToolResult> {
+    const result = await this.bounded(
+      this.driver.getDesktopState(GetDesktopStateInput.new({ session: this.session })),
+      'get_desktop_state'
+    );
+    return this.content(result);
+  }
+
+  async click(x: number, y: number): Promise<NativeToolResult> {
+    return await this.mutateThenObserve(() =>
+      this.driver.click(
+        ClickInput.new({
+          x,
+          y,
+          scope: DesktopScope.Desktop,
+          session: this.session,
+          button: ClickButton.Left,
+          count: 1,
+        })
+      )
+    );
+  }
+
+  async typeText(text: string): Promise<NativeToolResult> {
+    return await this.mutateThenObserve(() =>
+      this.driver.typeText(
+        TypeTextInput.new({
+          text,
+          scope: DesktopScope.Desktop,
+          session: this.session,
+        })
+      )
+    );
+  }
+
+  async pressKey(key: string): Promise<NativeToolResult> {
+    return await this.mutateThenObserve(() =>
+      this.driver.pressKey(
+        PressKeyInput.new({
+          key,
+          scope: DesktopScope.Desktop,
+          session: this.session,
+        })
+      )
+    );
+  }
+
+  private async mutateThenObserve(operation: () => Promise<ToolResult>): Promise<NativeToolResult> {
+    let unknownDetail: string | undefined;
+    try {
+      const result = await this.bounded(operation(), 'desktop action');
+      if (result.isError) {
+        unknownDetail =
+          `Action reported an error and its outcome may be unknown (${result.text}). ` +
+          'A fresh observation follows. Do not retry until the observation proves ' +
+          'the action did not land.';
+      }
+    } catch (error) {
+      unknownDetail =
+        `Action outcome is unknown (${String(error)}). A fresh observation follows. ` +
+        'Do not retry until the observation proves the action did not land.';
+    }
+
+    const observation = await this.observe();
+    if (unknownDetail) {
+      observation.content.unshift({ type: 'text', text: unknownDetail });
+    }
+    return observation;
+  }
+
+  private async bounded<T>(operation: Promise<T>, label: string): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        operation,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(new Error(`${label} timed out`)), this.timeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  }
+
+  private content(result: ToolResult): NativeToolResult {
+    return {
+      content: [
+        { type: 'text', text: result.text },
+        ...result.images.map((image) => ({
+          type: 'image' as const,
+          data: image.dataBase64,
+          mimeType: image.mimeType,
+        })),
+      ],
+      isError: result.isError,
+    };
+  }
+}

--- a/libs/cua-driver/examples/agent-sdks/native_driver.py
+++ b/libs/cua-driver/examples/agent-sdks/native_driver.py
@@ -1,0 +1,127 @@
+"""Perceive, act, and externally verify with the same-process Python SDK."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from urllib.request import Request, urlopen
+from uuid import uuid4
+
+from cua_driver import (
+    CaptureScope,
+    CuaDriver,
+    DesktopScope,
+    EndSessionInput,
+    GetDesktopStateInput,
+    PressKeyInput,
+    StartSessionInput,
+    TypeTextInput,
+)
+
+
+def fixture_request(url: str, path: str, *, method: str = "GET") -> dict[str, str | None]:
+    with urlopen(Request(f"{url.rstrip('/')}{path}", method=method), timeout=2) as response:
+        if response.status == 204:
+            return {}
+        return json.loads(response.read())
+
+
+async def wait_for_submission(url: str, token: str, timeout: float) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        state = await asyncio.to_thread(fixture_request, url, "/state")
+        if state.get("submitted") == token:
+            return
+        await asyncio.sleep(0.1)
+    raise TimeoutError("the fixture did not observe the submitted value")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture", default="http://127.0.0.1:8765")
+    parser.add_argument("--timeout", type=float, default=10.0)
+    return parser.parse_args()
+
+
+async def main() -> None:
+    args = parse_args()
+    token = f"cua-{uuid4().hex[:10]}"
+    session = f"native-python-{uuid4().hex[:10]}"
+    await asyncio.to_thread(fixture_request, args.fixture, "/reset", method="POST")
+
+    driver = CuaDriver.create()
+    started = False
+    mutation_outcome_unknown = False
+    try:
+        await asyncio.wait_for(
+            driver.start_session(
+                StartSessionInput(session=session, capture_scope=CaptureScope.DESKTOP)
+            ),
+            args.timeout,
+        )
+        started = True
+
+        before = await asyncio.wait_for(
+            driver.get_desktop_state(
+                GetDesktopStateInput(session=session, screenshot_out_file=None)
+            ),
+            args.timeout,
+        )
+        if before.is_error or not before.images:
+            raise RuntimeError(before.text or "desktop capture returned no image")
+        print(f"perceived desktop: {before.images[0].mime_type}")
+
+        try:
+            typed = await asyncio.wait_for(
+                driver.type_text(
+                    TypeTextInput(
+                        text=token,
+                        scope=DesktopScope.DESKTOP,
+                        session=session,
+                    )
+                ),
+                args.timeout,
+            )
+            if typed.is_error:
+                raise RuntimeError(typed.text)
+            submitted = await asyncio.wait_for(
+                driver.press_key(
+                    PressKeyInput(
+                        key="ENTER",
+                        modifiers=None,
+                        scope=DesktopScope.DESKTOP,
+                        session=session,
+                    )
+                ),
+                args.timeout,
+            )
+            if submitted.is_error:
+                raise RuntimeError(submitted.text)
+        except (TimeoutError, ConnectionError, RuntimeError):
+            mutation_outcome_unknown = True
+
+        # Never blindly replay a mutation after a timeout or disconnect. Query
+        # the independent fixture first; it may have consumed the action.
+        await wait_for_submission(args.fixture, token, args.timeout)
+        after = await asyncio.wait_for(
+            driver.get_desktop_state(
+                GetDesktopStateInput(session=session, screenshot_out_file=None)
+            ),
+            args.timeout,
+        )
+        if after.is_error or not after.images:
+            raise RuntimeError(after.text or "post-action capture returned no image")
+        print(f"verified submitted value: {token}")
+        if mutation_outcome_unknown:
+            print("the driver response was uncertain; the external postcondition resolved it")
+    finally:
+        try:
+            if started:
+                await driver.end_session(EndSessionInput(session=session))
+        finally:
+            await driver.shutdown()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/libs/cua-driver/examples/agent-sdks/native_driver.ts
+++ b/libs/cua-driver/examples/agent-sdks/native_driver.ts
@@ -1,0 +1,134 @@
+/** Perceive, act, and externally verify with the same-process TypeScript SDK. */
+
+import { randomUUID } from 'node:crypto';
+
+import {
+  CaptureScope,
+  CuaDriver,
+  DesktopScope,
+  EndSessionInput,
+  GetDesktopStateInput,
+  PressKeyInput,
+  StartSessionInput,
+  TypeTextInput,
+} from '@trycua/cua-driver';
+
+const fixture = process.env.CUA_FIXTURE_URL ?? 'http://127.0.0.1:8765';
+const timeoutMs = 10_000;
+
+async function bounded<T>(promise: Promise<T>, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+async function resetFixture(): Promise<void> {
+  const response = await fetch(`${fixture}/reset`, { method: 'POST' });
+  if (!response.ok) throw new Error(`fixture reset failed: ${response.status}`);
+}
+
+async function waitForSubmission(token: string): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const response = await fetch(`${fixture}/state`);
+    const state = (await response.json()) as { submitted: string | null };
+    if (state.submitted === token) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error('the fixture did not observe the submitted value');
+}
+
+const token = `cua-${randomUUID().slice(0, 10)}`;
+const session = `native-typescript-${randomUUID().slice(0, 10)}`;
+await resetFixture();
+
+const driver = CuaDriver.create(undefined);
+let started = false;
+let mutationOutcomeUnknown = false;
+
+try {
+  await bounded(
+    driver.startSession(
+      StartSessionInput.new({
+        session,
+        captureScope: CaptureScope.Desktop,
+      })
+    ),
+    'start_session'
+  );
+  started = true;
+
+  const before = await bounded(
+    driver.getDesktopState(GetDesktopStateInput.new({ session })),
+    'get_desktop_state'
+  );
+  if (before.isError || before.images.length === 0) {
+    throw new Error(before.text || 'desktop capture returned no image');
+  }
+  console.log(`perceived desktop: ${before.images[0]?.mimeType}`);
+
+  try {
+    const typed = await bounded(
+      driver.typeText(
+        TypeTextInput.new({
+          text: token,
+          scope: DesktopScope.Desktop,
+          session,
+        })
+      ),
+      'type_text'
+    );
+    if (typed.isError) throw new Error(typed.text);
+
+    const submitted = await bounded(
+      driver.pressKey(
+        PressKeyInput.new({
+          key: 'ENTER',
+          scope: DesktopScope.Desktop,
+          session,
+        })
+      ),
+      'press_key'
+    );
+    if (submitted.isError) throw new Error(submitted.text);
+  } catch {
+    mutationOutcomeUnknown = true;
+  }
+
+  // A timed-out mutation may still have landed. Observe the independent
+  // fixture before considering any retry.
+  await waitForSubmission(token);
+  const after = await bounded(
+    driver.getDesktopState(GetDesktopStateInput.new({ session })),
+    'post-action get_desktop_state'
+  );
+  if (after.isError || after.images.length === 0) {
+    throw new Error(after.text || 'post-action capture returned no image');
+  }
+  console.log(`verified submitted value: ${token}`);
+  if (mutationOutcomeUnknown) {
+    console.log('the driver response was uncertain; the external postcondition resolved it');
+  }
+} finally {
+  try {
+    if (started) {
+      await driver.endSession(EndSessionInput.new({ session }));
+    }
+  } finally {
+    try {
+      await driver.shutdown();
+    } finally {
+      // shutdown() drains the runtime; this generated destructor releases the
+      // native UniFFI handle immediately instead of waiting for JavaScript GC.
+      (driver as unknown as { uniffiDestroy(): void }).uniffiDestroy();
+    }
+  }
+}

--- a/libs/cua-driver/examples/agent-sdks/native_tools.py
+++ b/libs/cua-driver/examples/agent-sdks/native_tools.py
@@ -1,0 +1,147 @@
+"""Narrow agent-tool adapter over the same-process Cua Driver Python SDK."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+from uuid import uuid4
+
+from cua_driver import (
+    CaptureScope,
+    ClickButton,
+    ClickInput,
+    CuaDriver,
+    DesktopScope,
+    EndSessionInput,
+    GetDesktopStateInput,
+    PressKeyInput,
+    StartSessionInput,
+    ToolResult,
+    TypeTextInput,
+)
+
+ToolContent = dict[str, object]
+T = TypeVar("T")
+
+
+class NativeDesktopTools:
+    """Own one in-process driver runtime and one desktop-scoped session."""
+
+    def __init__(self, timeout: float = 30.0) -> None:
+        self.driver = CuaDriver.create()
+        self.session = f"claude-native-{uuid4().hex[:12]}"
+        self.timeout = timeout
+        self.started = False
+
+    async def start(self) -> None:
+        await self._bounded(
+            self.driver.start_session(
+                StartSessionInput(
+                    session=self.session,
+                    capture_scope=CaptureScope.DESKTOP,
+                )
+            )
+        )
+        self.started = True
+
+    async def close(self) -> None:
+        try:
+            if self.started:
+                await self._bounded(
+                    self.driver.end_session(EndSessionInput(session=self.session))
+                )
+                self.started = False
+        finally:
+            await self.driver.shutdown()
+
+    async def observe(self) -> dict[str, object]:
+        result = await self._bounded(
+            self.driver.get_desktop_state(
+                GetDesktopStateInput(
+                    session=self.session,
+                    screenshot_out_file=None,
+                )
+            )
+        )
+        return self._content(result)
+
+    async def click(self, x: float, y: float) -> dict[str, object]:
+        return await self._mutate_then_observe(
+            lambda: self.driver.click(
+                ClickInput(
+                    x=x,
+                    y=y,
+                    scope=DesktopScope.DESKTOP,
+                    session=self.session,
+                    button=ClickButton.LEFT,
+                    count=1,
+                )
+            )
+        )
+
+    async def type_text(self, text: str) -> dict[str, object]:
+        return await self._mutate_then_observe(
+            lambda: self.driver.type_text(
+                TypeTextInput(
+                    text=text,
+                    scope=DesktopScope.DESKTOP,
+                    session=self.session,
+                )
+            )
+        )
+
+    async def press_key(self, key: str) -> dict[str, object]:
+        return await self._mutate_then_observe(
+            lambda: self.driver.press_key(
+                PressKeyInput(
+                    key=key,
+                    modifiers=None,
+                    scope=DesktopScope.DESKTOP,
+                    session=self.session,
+                )
+            )
+        )
+
+    async def _mutate_then_observe(
+        self,
+        operation: Callable[[], Awaitable[ToolResult]],
+    ) -> dict[str, object]:
+        unknown_detail: str | None = None
+        try:
+            result = await self._bounded(operation())
+            if result.is_error:
+                unknown_detail = (
+                    f"Action reported an error and its outcome may be unknown "
+                    f"({result.text}). A fresh observation follows. Do not retry "
+                    "until the observation proves the action did not land."
+                )
+        except Exception as error:
+            unknown_detail = (
+                f"Action outcome is unknown ({error}). A fresh observation follows. "
+                "Do not retry until the observation proves the action did not land."
+            )
+
+        observation = await self.observe()
+        if unknown_detail:
+            observation["content"] = [
+                {"type": "text", "text": unknown_detail},
+                *observation["content"],
+            ]
+        return observation
+
+    async def _bounded(self, operation: Awaitable[T]) -> T:
+        return await asyncio.wait_for(operation, self.timeout)
+
+    @staticmethod
+    def _content(result: ToolResult) -> dict[str, object]:
+        content: list[ToolContent] = [{"type": "text", "text": result.text}]
+        content.extend(
+            {
+                "type": "image",
+                "data": image.data_base64,
+                "mimeType": image.mime_type,
+            }
+            for image in result.images
+        )
+        return {"content": content, "isError": result.is_error}

--- a/libs/cua-driver/examples/agent-sdks/package-lock.json
+++ b/libs/cua-driver/examples/agent-sdks/package-lock.json
@@ -6,12 +6,187 @@
     "": {
       "name": "cua-driver-agent-sdk-examples",
       "dependencies": {
-        "@openai/codex-sdk": "0.145.0"
+        "@anthropic-ai/claude-agent-sdk": "0.3.218",
+        "@openai/codex-sdk": "0.145.0",
+        "@trycua/cua-driver": "0.12.2",
+        "zod": "4.1.12"
       },
       "devDependencies": {
         "@types/node": "22.17.0",
         "tsx": "4.20.3",
         "typescript": "5.9.2"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.218.tgz",
+      "integrity": "sha512-lbVOmgdzjBdSUCTbxElpoTxxP/u9jY8gpG/3cr5l1jSSvSY5FrANdRcze/z6gM330xo32SHH6WPGFd4+K0fMoQ==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.218",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.218",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.218",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.218",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.218",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.218",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.218",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.218"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.218.tgz",
+      "integrity": "sha512-foTI71ua2r5lJo7sfcw/3UafBCJYjxPmOXZ98wOz1UWIJxaP/Oq9Xp4sUavBd1efFVRxPnAcRnrZ5yrmXK1xUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.218.tgz",
+      "integrity": "sha512-rAdlR2ukJd01Osfsb7nPPv31MCVJBennBDaL7ZP/bv+dednwNuY6thuPO5PMFJUM+54Gbnziqm+hqoNTgndqDg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.218.tgz",
+      "integrity": "sha512-Y6vFEnz6wwd+rYpVGsPqgeXZuZP7NvQg6vjkC+N6cs1+I41LdKjfs+F+WG3daIqgt+vJBz/EB5Q0PByABkwufA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.218.tgz",
+      "integrity": "sha512-qfFBwOf0uh/mAtNGEkBJlLWt1XIgFqcQeeX966g2NexasCdSJGnwfc0YWA0QOeAAU/5xk6tSCW/Nn0zHGBO/3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.218.tgz",
+      "integrity": "sha512-gCq/i7yRXeuoQXidGQynuiw5AeczQXSIifxH5Vpr9OFDyHCBNotS1mQ8qutuclZeFpLOPkJ2ic/nvEgHJvfXdg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.218.tgz",
+      "integrity": "sha512-e47oi8dYWnS0wx2/F6FL3YhaD2HedMd2nhI/nududP4PBzytuXeaDE/sJ0eIqtUVkl6/bn5uBhtIEHHWoj37JQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.218.tgz",
+      "integrity": "sha512-D0UKI8jOpEsWO1A+i0DlIrgjXFKEZX3RrID2l49S4pShUlLsnSLJGMTPy4nQt6CCl5MzPqWiJDE/lCpImFTDcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.218.tgz",
+      "integrity": "sha512-pgE39WnKPPSRsiRJ2pm5NETxQgtVhrquqg7UByZxne0xQw2gNS0Qy+9ZumrsNBNlfrrnQCVDU1I2ks3ZLrEa8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.113.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.113.0.tgz",
+      "integrity": "sha512-8YKIP333ypmy8QjtSP691fIqdes3HL/rSXAT4FDZX/HRnkQaNG+iOVBfEQw4vjPNpYHeoy7FSYc2o/jb8b3AnA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -456,6 +631,60 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@openai/codex": {
       "version": "0.145.0",
       "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0.tgz",
@@ -590,6 +819,115 @@
         "node": ">=16"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@trycua/cua-driver": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@trycua/cua-driver/-/cua-driver-0.12.2.tgz",
+      "integrity": "sha512-Jbhb6KwyRWng6BFyoudxkUPGkJrdvw1TfSIpMNvQbQpcCPgQgc54r2aIoR+Kcl4P54JScY85dZFc5285qcHcKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ubjs/core": "0.31.0-3",
+        "@ubjs/node": "0.31.0-3"
+      },
+      "optionalDependencies": {
+        "@trycua/cua-driver-darwin-arm64": "0.12.2",
+        "@trycua/cua-driver-darwin-x64": "0.12.2",
+        "@trycua/cua-driver-linux-arm64-gnu": "0.12.2",
+        "@trycua/cua-driver-linux-x64-gnu": "0.12.2",
+        "@trycua/cua-driver-win32-arm64-msvc": "0.12.2",
+        "@trycua/cua-driver-win32-x64-msvc": "0.12.2"
+      }
+    },
+    "node_modules/@trycua/cua-driver-darwin-arm64": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@trycua/cua-driver-darwin-arm64/-/cua-driver-darwin-arm64-0.12.2.tgz",
+      "integrity": "sha512-rR4KpxaE/R/RAQ718YAIJ+YXuHewdAxq1kmtcPh0thhZCxcckTfVHk6sa6XSfwmqeNF1kTR82zKaeOhr55uBlw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT AND MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@trycua/cua-driver-darwin-x64": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@trycua/cua-driver-darwin-x64/-/cua-driver-darwin-x64-0.12.2.tgz",
+      "integrity": "sha512-BBFhMjmKZTvb24Z7NiYmWR2+yvTQgYat1biStxd6T+yPv6aTNFho/QE6YrVYxEzQTNHv3Rr6aa9Fu72mcmzBag==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT AND MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@trycua/cua-driver-linux-arm64-gnu": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@trycua/cua-driver-linux-arm64-gnu/-/cua-driver-linux-arm64-gnu-0.12.2.tgz",
+      "integrity": "sha512-XJPPLwnUroKsD0vh2dkE+NUaSElKwWNmjfy48cc/j/iLve8m2xZAFcmHgEug6Ps94AdRQ/Ko3w9z9jeCzJr72w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT AND MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@trycua/cua-driver-linux-x64-gnu": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@trycua/cua-driver-linux-x64-gnu/-/cua-driver-linux-x64-gnu-0.12.2.tgz",
+      "integrity": "sha512-JekaFKUol9DYJqw90Td8OISemRSDKyzOUoWfVRIQfLqm8YveySP3+sHGOovJDytTDXVuSKEJOIdV7q678gr4rA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT AND MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@trycua/cua-driver-win32-arm64-msvc": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@trycua/cua-driver-win32-arm64-msvc/-/cua-driver-win32-arm64-msvc-0.12.2.tgz",
+      "integrity": "sha512-0sU/GSGyfrIjBpOsc9UObi2bdD1oUcuaYqB/HIzWXIDdUmoMfXIsHPnPb0QvUnsm0EI6cFXjBzURlBKHhITKQQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT AND MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@trycua/cua-driver-win32-x64-msvc": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@trycua/cua-driver-win32-x64-msvc/-/cua-driver-win32-x64-msvc-0.12.2.tgz",
+      "integrity": "sha512-ZZC8EPvuDPxg+/aOy8LX53AirEdqlO6xd4Vqsm3uWmNjfis+D8Fg9Fko2mOO5LWbuGzBYePyQlHji4n4Kqe2Lw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT AND MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@types/node": {
       "version": "22.17.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.0.tgz",
@@ -598,6 +936,443 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@ubjs/core": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/@ubjs/core/-/core-0.31.0-3.tgz",
+      "integrity": "sha512-39XrJgUZ2VVb561sSnkXPhczNoeBsNiSRArecsV0JE7CJq69ajFkcn9/tBAUS2NpgHkLIDU+z6Ks2+1wXnboxg==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/@ubjs/node": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/@ubjs/node/-/node-0.31.0-3.tgz",
+      "integrity": "sha512-qNMpi2LICNwxGXZyRF8fSDBSpbezyZbEsydrbiMPJOmtOWr4tmZIEl7jkWGHVGShoBvHfFo4eHp5B4UVP928Cg==",
+      "license": "MPL-2.0",
+      "optionalDependencies": {
+        "@ubjs/node-darwin-arm64": "0.31.0-3",
+        "@ubjs/node-darwin-x64": "0.31.0-3",
+        "@ubjs/node-linux-arm64-gnu": "0.31.0-3",
+        "@ubjs/node-linux-arm64-musl": "0.31.0-3",
+        "@ubjs/node-linux-x64-gnu": "0.31.0-3",
+        "@ubjs/node-linux-x64-musl": "0.31.0-3",
+        "@ubjs/node-win32-arm64-msvc": "0.31.0-3",
+        "@ubjs/node-win32-x64-msvc": "0.31.0-3"
+      }
+    },
+    "node_modules/@ubjs/node-darwin-arm64": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/@ubjs/node-darwin-arm64/-/node-darwin-arm64-0.31.0-3.tgz",
+      "integrity": "sha512-GGQVPLkVo4Gc8qVLW4IGvS8bjl8eHXyeP4a97ntGmsAdXwE5gsS29o8xUEFROjhwHKD+9sgVeblCSWVG3CpHsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ubjs/node-darwin-x64": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/@ubjs/node-darwin-x64/-/node-darwin-x64-0.31.0-3.tgz",
+      "integrity": "sha512-2sc47u4XFYOsbmP5EW+Gx8m/yGrYnfFDFQm6+kz7goSWTNg84eEiz3COs9HKJDVuNJ5Khv5XipTO8CFadMLXCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ubjs/node-linux-arm64-gnu": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/@ubjs/node-linux-arm64-gnu/-/node-linux-arm64-gnu-0.31.0-3.tgz",
+      "integrity": "sha512-YStVXhYz/5jvlWf/p4fhiVT72unYAbGugifFC9QmO/+hnroQDAQ5t8SARbsc15G4olMcamdIB+GETiUB7gmaYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ubjs/node-linux-arm64-musl": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/@ubjs/node-linux-arm64-musl/-/node-linux-arm64-musl-0.31.0-3.tgz",
+      "integrity": "sha512-Izp4nvfy/LmibzFowAztkoDOksCR2fb2zl6fh1ojR1HEsg0rAGruxtI8d3fn8DI0lBXwqmn6SF///oD4mFNJPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ubjs/node-linux-x64-gnu": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/@ubjs/node-linux-x64-gnu/-/node-linux-x64-gnu-0.31.0-3.tgz",
+      "integrity": "sha512-Xdm21blyg5U/kW6s7OMvgrr8coGTkUlt26DVR9x8gKISif+E3YwdEskbFScWqystAiJnfjw7xHEc8UMu0Qlz7Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ubjs/node-linux-x64-musl": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/@ubjs/node-linux-x64-musl/-/node-linux-x64-musl-0.31.0-3.tgz",
+      "integrity": "sha512-fFQ9BWS6i2LUH9SJgD9oEiKXXo/say59vHy7usFe1t7C2xvwvP34f5SuxXmWP9R8fHyA0aC4kIZ+TTwyHSv1Kw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ubjs/node-win32-arm64-msvc": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/@ubjs/node-win32-arm64-msvc/-/node-win32-arm64-msvc-0.31.0-3.tgz",
+      "integrity": "sha512-ID6rSz1NmPsWTNBBNAw4OnJ5Dj8pcbtNJtdPB3OxcGigLBd/e0x7buhSI7os6Mo5iYtEdCynBRQHFJwub5XSPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@ubjs/node-win32-x64-msvc": {
+      "version": "0.31.0-3",
+      "resolved": "https://registry.npmjs.org/@ubjs/node-win32-x64-msvc/-/node-win32-x64-msvc-0.31.0-3.tgz",
+      "integrity": "sha512-wevs+Y+szwcCUT8IJFbB4/1nfxyRv/51l8oG7FGUPWD1xLPyuHfJBG27C+PDeC7KRzes/2n6aLo4DGZbr/LYTw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -642,6 +1417,183 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense",
+      "peer": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -657,6 +1609,55 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
@@ -670,6 +1671,407 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/jose": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -679,6 +2081,221 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.20.3",
@@ -698,6 +2315,39 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -720,6 +2370,68 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/zod": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
+      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peer": true,
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
     }
   }
 }

--- a/libs/cua-driver/examples/agent-sdks/package.json
+++ b/libs/cua-driver/examples/agent-sdks/package.json
@@ -3,11 +3,16 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "claude": "tsx claude_agent.ts",
     "codex": "tsx codex_agent.ts",
+    "native": "tsx native_driver.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@openai/codex-sdk": "0.145.0"
+    "@anthropic-ai/claude-agent-sdk": "0.3.218",
+    "@openai/codex-sdk": "0.145.0",
+    "@trycua/cua-driver": "0.12.2",
+    "zod": "4.1.12"
   },
   "devDependencies": {
     "@types/node": "22.17.0",

--- a/libs/cua-driver/examples/agent-sdks/requirements.txt
+++ b/libs/cua-driver/examples/agent-sdks/requirements.txt
@@ -1,1 +1,3 @@
 claude-agent-sdk==0.2.124
+openai-codex==0.144.4
+cua-driver==0.12.2

--- a/libs/cua-driver/examples/agent-sdks/test_fixture_server.py
+++ b/libs/cua-driver/examples/agent-sdks/test_fixture_server.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+import threading
+import unittest
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from fixture_server import FixtureServer
+
+
+class FixtureServerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.server = FixtureServer(("127.0.0.1", 0))
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.url = f"http://127.0.0.1:{self.server.server_port}"
+
+    def tearDown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+
+    def request(self, path: str, *, method: str = "GET", data: bytes | None = None):
+        return urlopen(Request(f"{self.url}{path}", method=method, data=data), timeout=2)
+
+    def test_submit_reset_and_state(self) -> None:
+        with self.request("/") as response:
+            self.assertIn(b"autofocus", response.read())
+
+        data = urlencode({"value": "verified-token"}).encode()
+        with self.request("/submit", method="POST", data=data) as response:
+            self.assertIn(b"Action received", response.read())
+
+        with self.request("/state") as response:
+            self.assertEqual(json.loads(response.read()), {"submitted": "verified-token"})
+
+        with self.request("/reset", method="POST") as response:
+            self.assertEqual(response.status, 204)
+        with self.request("/state") as response:
+            self.assertEqual(json.loads(response.read()), {"submitted": None})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/libs/cua-driver/examples/agent-sdks/tsconfig.json
+++ b/libs/cua-driver/examples/agent-sdks/tsconfig.json
@@ -1,12 +1,13 @@
 {
   "compilerOptions": {
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "noEmit": true,
+    "skipLibCheck": true,
     "strict": true,
     "target": "ES2022",
     "types": ["node"]
   },
-  "include": ["codex_agent.ts", "*.d.ts"]
+  "include": ["*.ts", "*.d.ts"]
 }


### PR DESCRIPTION
## Summary

- add one loopback-only perceive → act → externally verify fixture shared by the published Python and TypeScript Cua Driver SDKs
- add executable Claude Agent SDK examples for same-process native callbacks and the external MCP route
- add executable Codex SDK examples for its supported MCP boundary in Python and TypeScript, without inventing false native symmetry
- document lifecycle, permissions, timeouts, unknown mutation outcomes, and the separate TypeScript `shutdown()` / `uniffiDestroy()` responsibilities across Diátaxis tutorial, how-to, explanation, and reference pages
- compile/import the published SDKs and test the fixture in the existing contract-client CI

## Architecture represented

Claude’s SDK MCP helper is used only as an in-process custom-tool adapter: its callbacks call `CuaDriver.create()` directly and do not launch a socket or daemon. External Claude and Codex agent runs use `cua-driver mcp`, which remains the runtime-neutral agent boundary.

## Validation

- `python -m compileall -q .`
- `python -m unittest -v test_fixture_server.py`
- published-package imports for `cua-driver`, `openai-codex`, and `claude-agent-sdk`
- `npm run typecheck` against `@trycua/cua-driver`, `@openai/codex-sdk`, and `@anthropic-ai/claude-agent-sdk`
- Cua Driver generated-doc drift check
- docs internal link and public-hygiene checks
- production Next.js docs build (91 pages)

Provider-backed agent execution remains opt-in and no credentials are committed or required by CI.

Closes #2500