### PR TITLE
fix(cua-cli): honor forced Fleet token refresh

### DIFF
--- a/libs/python/cua-cli/cua_cli/auth/oidc.py
+++ b/libs/python/cua-cli/cua_cli/auth/oidc.py
@@ -10,6 +10,14 @@ from typing import Any
 import aiohttp
 from cua_cli.auth.store import OAuthCredentials, load_credentials, save_credentials
 
+try:
+    from cyclops_sdk import AccessTokenProvider as _FleetTokenProvider
+except ImportError:
+
+    class _FleetTokenProvider:
+        pass
+
+
 DEFAULT_RUN_API_BASE = "https://run.cua.ai"
 DEFAULT_OIDC_ISSUER = "https://auth.cua.ai/realms/cyclops-cs"
 DEFAULT_CLIENT_ID = "cua-cli"
@@ -226,15 +234,22 @@ def _error_description(payload: Mapping[str, Any], fallback: str) -> str:
     return str(description) if description else fallback
 
 
-async def get_access_token() -> str:
+async def get_access_token(*, force_refresh: bool = False) -> str:
     """Return a valid access token, refreshing and persisting it when needed."""
     credentials = load_credentials()
     if credentials is None:
         raise OidcError("Not logged in. Run 'cua auth login' first.")
-    if credentials.expires_at > datetime.now(UTC) + timedelta(seconds=60):
+    if not force_refresh and credentials.expires_at > datetime.now(UTC) + timedelta(seconds=60):
         return credentials.access_token
 
     client = OidcClient()
     refreshed = await client.refresh(await client.discover(), credentials)
     save_credentials(refreshed)
     return refreshed.access_token
+
+
+class FleetAccessTokenProvider(_FleetTokenProvider):
+    """Adapt CLI device credentials to the Fleet SDK token-provider callback."""
+
+    async def get_access_token(self, force_refresh: bool) -> str:
+        return await get_access_token(force_refresh=force_refresh)

--- a/libs/python/cua-cli/cua_cli/auth/oidc.py
+++ b/libs/python/cua-cli/cua_cli/auth/oidc.py
@@ -10,14 +10,6 @@ from typing import Any
 import aiohttp
 from cua_cli.auth.store import OAuthCredentials, load_credentials, save_credentials
 
-try:
-    from cyclops_sdk import AccessTokenProvider as _FleetTokenProvider
-except ImportError:
-
-    class _FleetTokenProvider:
-        pass
-
-
 DEFAULT_RUN_API_BASE = "https://run.cua.ai"
 DEFAULT_OIDC_ISSUER = "https://auth.cua.ai/realms/cyclops-cs"
 DEFAULT_CLIENT_ID = "cua-cli"
@@ -248,8 +240,21 @@ async def get_access_token(*, force_refresh: bool = False) -> str:
     return refreshed.access_token
 
 
-class FleetAccessTokenProvider(_FleetTokenProvider):
-    """Adapt CLI device credentials to the Fleet SDK token-provider callback."""
+def _fleet_access_token_provider_type() -> type[Any]:
+    try:
+        from cyclops_sdk import AccessTokenProvider
+    except (ImportError, OSError) as error:
+        raise OidcError(
+            "Fleet integration requires cua-cli[fleet] with its generated SDK bindings."
+        ) from error
 
-    async def get_access_token(self, force_refresh: bool) -> str:
-        return await get_access_token(force_refresh=force_refresh)
+    class FleetAccessTokenProvider(AccessTokenProvider):
+        async def get_access_token(self, force_refresh: bool) -> str:
+            return await get_access_token(force_refresh=force_refresh)
+
+    return FleetAccessTokenProvider
+
+
+def FleetAccessTokenProvider() -> Any:
+    """Create a generated Fleet SDK token provider backed by CLI device credentials."""
+    return _fleet_access_token_provider_type()()

--- a/libs/python/cua-cli/pyproject.toml
+++ b/libs/python/cua-cli/pyproject.toml
@@ -53,9 +53,13 @@ mcp = [
 skills = [
     "litellm==1.86.2",
 ]
+# Fleet SDK integration
+fleet = [
+    "cua-train==0.1.1",
+]
 # Full installation
 all = [
-    "cua-cli[mcp,skills]",
+    "cua-cli[mcp,skills,fleet]",
 ]
 # Development
 dev = [
@@ -109,6 +113,14 @@ target-version = "py312"
 [tool.ruff.lint]
 select = ["E", "F", "W"]
 ignore = ["E501"]
+
+[[tool.uv.index]]
+name = "cua-wheels"
+url = "https://wheels.cua.ai/simple/"
+explicit = true
+
+[tool.uv.sources]
+cua-train = { index = "cua-wheels" }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/libs/python/cua-cli/tests/auth/test_oidc.py
+++ b/libs/python/cua-cli/tests/auth/test_oidc.py
@@ -1,10 +1,15 @@
 """Tests for the Keycloak OIDC device flow used by run.cua.ai."""
 
 from collections.abc import Mapping
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
-from cua_cli.auth.oidc import DEVICE_GRANT_TYPE, OidcClient
+from cua_cli.auth.oidc import (
+    DEVICE_GRANT_TYPE,
+    FleetAccessTokenProvider,
+    OidcClient,
+    get_access_token,
+)
 from cua_cli.auth.store import OAuthCredentials
 
 
@@ -142,3 +147,52 @@ async def test_poll_slow_down_increases_interval() -> None:
     await OidcClient(request=requester, sleep=sleep).poll_for_tokens(discovery, device_code)
 
     assert delays == [8]
+
+
+@pytest.mark.asyncio
+async def test_get_access_token_forces_refresh_of_an_unexpired_token(monkeypatch) -> None:
+    credentials = OAuthCredentials(
+        access_token="cached-token",
+        refresh_token="refresh-token",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+    refreshed = OAuthCredentials(
+        access_token="refreshed-token",
+        refresh_token="refresh-token",
+        expires_at=credentials.expires_at,
+    )
+    refresh_calls = []
+
+    class RefreshingClient:
+        async def discover(self):
+            return object()
+
+        async def refresh(self, discovery, received_credentials):
+            assert discovery is not None
+            assert received_credentials is credentials
+            refresh_calls.append(True)
+            return refreshed
+
+    monkeypatch.setattr("cua_cli.auth.oidc.load_credentials", lambda: credentials)
+    monkeypatch.setattr("cua_cli.auth.oidc.OidcClient", RefreshingClient)
+    monkeypatch.setattr("cua_cli.auth.oidc.save_credentials", lambda value: None)
+
+    assert await get_access_token(force_refresh=True) == refreshed.access_token
+    assert refresh_calls == [True]
+
+
+@pytest.mark.asyncio
+async def test_fleet_access_token_provider_forwards_force_refresh(monkeypatch) -> None:
+    refresh_requests = []
+
+    async def access_token(*, force_refresh: bool = False) -> str:
+        refresh_requests.append(force_refresh)
+        return "token"
+
+    monkeypatch.setattr("cua_cli.auth.oidc.get_access_token", access_token)
+    provider = FleetAccessTokenProvider()
+
+    await provider.get_access_token(False)
+    await provider.get_access_token(True)
+
+    assert refresh_requests == [False, True]

--- a/libs/python/cua-cli/tests/auth/test_oidc.py
+++ b/libs/python/cua-cli/tests/auth/test_oidc.py
@@ -2,11 +2,14 @@
 
 from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
+from importlib.metadata import version
+import builtins
 
 import pytest
 from cua_cli.auth.oidc import (
     DEVICE_GRANT_TYPE,
     FleetAccessTokenProvider,
+    OidcError,
     OidcClient,
     get_access_token,
 )
@@ -183,6 +186,9 @@ async def test_get_access_token_forces_refresh_of_an_unexpired_token(monkeypatch
 
 @pytest.mark.asyncio
 async def test_fleet_access_token_provider_forwards_force_refresh(monkeypatch) -> None:
+    from cyclops_sdk import AccessTokenProvider
+    from cyclops_sdk._sdk import _UniffiFfiConverterTypeAccessTokenProvider
+
     refresh_requests = []
 
     async def access_token(*, force_refresh: bool = False) -> str:
@@ -192,7 +198,26 @@ async def test_fleet_access_token_provider_forwards_force_refresh(monkeypatch) -
     monkeypatch.setattr("cua_cli.auth.oidc.get_access_token", access_token)
     provider = FleetAccessTokenProvider()
 
+    assert isinstance(provider, AccessTokenProvider)
+    _UniffiFfiConverterTypeAccessTokenProvider.check_lower(provider)
+
     await provider.get_access_token(False)
     await provider.get_access_token(True)
 
     assert refresh_requests == [False, True]
+
+
+def test_fleet_provider_fails_closed_without_its_generated_binding(monkeypatch) -> None:
+    assert version("cua-train") == "0.1.1"
+
+    original_import = builtins.__import__
+
+    def import_without_cyclops_sdk(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "cyclops_sdk" or name.startswith("cyclops_sdk."):
+            raise ModuleNotFoundError("No module named 'cyclops_sdk'", name="cyclops_sdk")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_cyclops_sdk)
+
+    with pytest.raises(OidcError, match=r"cua-cli\[fleet\]"):
+        FleetAccessTokenProvider()

--- a/libs/python/cua-cli/tests/auth/test_oidc.py
+++ b/libs/python/cua-cli/tests/auth/test_oidc.py
@@ -1,16 +1,16 @@
 """Tests for the Keycloak OIDC device flow used by run.cua.ai."""
 
+import builtins
 from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
 from importlib.metadata import version
-import builtins
 
 import pytest
 from cua_cli.auth.oidc import (
     DEVICE_GRANT_TYPE,
     FleetAccessTokenProvider,
-    OidcError,
     OidcClient,
+    OidcError,
     get_access_token,
 )
 from cua_cli.auth.store import OAuthCredentials

--- a/libs/python/cua-cli/uv.lock
+++ b/libs/python/cua-cli/uv.lock
@@ -428,6 +428,7 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "cua-train" },
     { name = "fastmcp" },
     { name = "litellm" },
 ]
@@ -437,6 +438,9 @@ dev = [
     { name = "pytest-cov" },
     { name = "respx" },
     { name = "ruff" },
+]
+fleet = [
+    { name = "cua-train" },
 ]
 mcp = [
     { name = "fastmcp" },
@@ -449,9 +453,10 @@ skills = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0" },
     { name = "cua-auto", extras = ["all"], specifier = ">=0.1.0" },
-    { name = "cua-cli", extras = ["mcp", "skills"], marker = "extra == 'all'" },
+    { name = "cua-cli", extras = ["mcp", "skills", "fleet"], marker = "extra == 'all'" },
     { name = "cua-computer", specifier = ">=0.5.0" },
     { name = "cua-core", specifier = ">=0.3.0,<0.4.0" },
+    { name = "cua-train", marker = "extra == 'fleet'", specifier = "==0.1.1", index = "https://wheels.cua.ai/simple/" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.0" },
     { name = "keyring", specifier = ">=25.0" },
     { name = "litellm", marker = "extra == 'skills'", specifier = "==1.86.2" },
@@ -464,7 +469,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "websockets", specifier = ">=12.0" },
 ]
-provides-extras = ["mcp", "skills", "all", "dev"]
+provides-extras = ["mcp", "skills", "fleet", "all", "dev"]
 
 [[package]]
 name = "cua-computer"
@@ -494,6 +499,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/82/ec371bde395bbbd326a3467a1702b34ab629defa0cc89bd81ac78507ca5a/cua_core-0.3.1.tar.gz", hash = "sha256:a8fc4204981b9d5b604bd2a34de0bb41cf926309e4dd9f364c827750a86408da", size = 10710, upload-time = "2026-04-15T21:39:49.172Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/90/5148998a26671855539e2c3a620f72ef51f83118beffdfb7e77893d4730b/cua_core-0.3.1-py3-none-any.whl", hash = "sha256:9191b8abf5e02ea6bf8ba21237e747d4e3b319f6f24d4e66e04b7606fcc449f6", size = 10239, upload-time = "2026-04-15T21:39:48.265Z" },
+]
+
+[[package]]
+name = "cua-train"
+version = "0.1.1"
+source = { registry = "https://wheels.cua.ai/simple/" }
+dependencies = [
+    { name = "attrs" },
+    { name = "httpx" },
+    { name = "python-dateutil" },
+]
+wheels = [
+    { url = "https://wheels.cua.ai/simple/cua-train/cua_train-0.1.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:1822fb9a63c6566d2763a9fb2e384ba4cc6a3771d97fb2cd3f1f9af66916e6df" },
+    { url = "https://wheels.cua.ai/simple/cua-train/cua_train-0.1.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:045b51e3ebebc7bf2107ec5a97801250b551e9617bcbbeec97a1e4f4c2ebd884" },
+    { url = "https://wheels.cua.ai/simple/cua-train/cua_train-0.1.1-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:6f8eb7f450f05d4a495de70a0a8f7acdb3dce20d842bae96f2aec27e2869fb85" },
+    { url = "https://wheels.cua.ai/simple/cua-train/cua_train-0.1.1-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:9ab37ae89ef6f95a1c0e315226af7716625bc6225e54770f94315905a744c5ad" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes CUA-955.

## Root cause

The generated Fleet SDK retries a control-plane 401 by calling its access-token provider with `force_refresh=True`. The CLI device-auth helper now honors that flag, but the initial provider adapter assumed an independently installed top-level binding and silently fell back to a plain Python class. That fallback cannot satisfy the generated UniFFI callback converter.

## Changes

- Keep `force_refresh` flowing through the CLI device-token helper.
- Add the `fleet` extra, pin `cua-train==0.1.1`, and resolve it explicitly from `https://wheels.cua.ai/simple/`.
- Defer Fleet-provider construction so ordinary CLI auth imports without Fleet installed; requesting Fleet without the generated binding now raises a clear `OidcError`.
- Construct a subclass of the generated `cyclops_sdk.AccessTokenProvider` exported by the published `cua-train` wheel, preserving the SDK callback contract.
- Cover forced refresh, callback flag propagation, UniFFI converter acceptance, and fail-closed optional-package behavior.

## Validation

- PASS: RED (before fix): `python -m pytest tests/auth/test_oidc.py -q` -> `1 failed, 5 passed`; the missing-binding regression did not raise `OidcError`.
- PASS: GREEN: `python -m pytest tests/auth/test_oidc.py -q` -> `6 passed`.
- PASS: `python -m ruff check cua_cli tests/auth/test_oidc.py`.
- PASS: `python -m ruff format --check cua_cli/auth/oidc.py tests/auth/test_oidc.py`.
- PASS: clean built `cua-cli` wheel import without Fleet: ordinary auth imports and Fleet construction fails closed.
- PASS: clean built `cua-cli` wheel plus the published `cua-train==0.1.1` Linux wheel: native binding loads and the generated UniFFI converter accepts the provider.