### PR TITLE
fix(cua-driver): expose skill install failure details

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -328,6 +328,21 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertNotIn("softprops/action-gh-release", workflow)
         self.assertNotIn("bake version into install scripts", workflow.lower())
 
+        skill_installer = self.read(
+            "libs/cua-driver/rust/crates/cua-driver/src/skills.rs"
+        )
+        self.assertIn(
+            "releases/download/cua-driver-rs-v{version}/"
+            "cua-driver-rs-v{version}-skills.tar.gz",
+            skill_installer,
+        )
+        self.assertIn(
+            "raw.githubusercontent.com/trycua/cua/main/"
+            "libs/cua-driver/rust/Skills/cua-driver",
+            skill_installer,
+        )
+        self.assertNotIn("releases/latest", skill_installer)
+
         windows_skill = self.read("libs/cua-driver/rust/Skills/cua-driver/WINDOWS.md")
         self.assertIn("https://cua.ai/driver/install.ps1", windows_skill)
         self.assertNotIn("/releases/latest/download/install.ps1", windows_skill)

--- a/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
@@ -278,7 +278,10 @@ pub fn run(subcommand: &str, flags: &[String]) {
     match result {
         Ok(()) => {}
         Err(e) => {
-            eprintln!("cua-driver skills {subcommand}: {e}");
+            // `anyhow::Error`'s default Display only prints the outermost
+            // context. Use alternate Display so failures include the source
+            // URL and the underlying HTTP, extraction, or filesystem error.
+            eprintln!("cua-driver skills {subcommand}: {e:#}");
             std::process::exit(1);
         }
     }


### PR DESCRIPTION
## Summary

- print the full chained error when `cua-driver skills install` or `update` fails
- preserve the attempted URL and underlying HTTP, archive, or filesystem cause
- guard the skill installer against repository-wide `/releases/latest` resolution

## Root cause

The installer already pins release downloads to the running binary's `cua-driver-rs-v<version>` tag, and `--from main` reads from the raw main branch. The failure in #2503 was opaque because `anyhow::Error` used its default display form, which emitted only the outermost context. This made an unrelated repository-wide latest release look causal even though the skill fetch path never uses that endpoint.

Closes #2503.

## User impact

Failed skill installs now identify the exact source URL and underlying HTTP, extraction, or filesystem error, making environment-specific failures actionable.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p cua-driver skills::tests` (8 passed)
- `python3 .github/scripts/tests/test_cua_driver_release_wiring.py` (30 passed)
- forced filesystem failure confirms the full causal chain is printed
