### PR TITLE
feat(cua-driver): add macOS Spaces awareness to list_windows

### DIFF
--- a/libs/cua-driver/rust/crates/platform-macos/src/input/skylight.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/skylight.rs
@@ -569,6 +569,47 @@ pub fn with_foreground_assist(
     with_menu_shortcut_activation(target_pid, target_wid, body)
 }
 
+/// Activate an exact target window for a global HID keyboard action.
+///
+/// Unlike [`with_menu_shortcut_activation`], this helper must not run `action`
+/// when the private foreground SPI is unavailable: a global HID event has no
+/// pid addressing and would otherwise land in whichever application is
+/// currently frontmost. The short settles keep the target frontmost until
+/// WindowServer has routed both sides of the key chord, then restore the prior
+/// process even when the action fails.
+pub fn with_foreground_hid_activation(
+    target_pid: libc::pid_t,
+    target_wid: u32,
+    action: impl FnOnce() -> anyhow::Result<()>,
+) -> anyhow::Result<()> {
+    let set_front = set_front_process_fn()
+        .ok_or_else(|| anyhow::anyhow!("foreground HID delivery is unavailable"))?;
+
+    let mut prev_psn = [0u8; 8];
+    let prev_ok = get_front_process_fn()
+        .map(|f| unsafe { f(prev_psn.as_mut_ptr() as *mut c_void) } == 0)
+        .unwrap_or(false);
+
+    let mut target_psn = [0u8; 8];
+    if !get_process_psn_for_window(target_wid, target_pid, &mut target_psn) {
+        anyhow::bail!("could not resolve target window for foreground HID delivery");
+    }
+    let activated = unsafe { set_front(target_psn.as_ptr() as *const c_void, target_wid, 0x400) };
+    if activated != 0 {
+        anyhow::bail!("WindowServer rejected foreground HID activation");
+    }
+
+    std::thread::sleep(std::time::Duration::from_millis(40));
+    let result = action();
+    std::thread::sleep(std::time::Duration::from_millis(40));
+
+    if prev_ok {
+        unsafe { set_front(prev_psn.as_ptr() as *const c_void, 0, 0x400) };
+    }
+
+    result
+}
+
 /// Activate `target_pid`'s window `target_wid` for NSMenu key dispatch, run `action`,
 /// then immediately restore the prior frontmost process.
 ///

--- a/libs/cua-driver/rust/crates/platform-macos/src/input/skylight.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/skylight.rs
@@ -362,32 +362,7 @@ pub fn get_active_space() -> Option<u64> {
 /// the first (only) space ID from the result.  Returns `None` when the symbol
 /// is unavailable or the query produces no result.
 pub fn get_window_space(window_id: u32) -> Option<u64> {
-    use core_foundation::{
-        array::CFArray,
-        base::{CFTypeRef, TCFType},
-        number::CFNumber,
-    };
-
-    let cid = main_connection_id()?;
-    let f = copy_spaces_for_windows_fn()?;
-
-    let num = CFNumber::from(window_id as i64);
-    let num_ref: *const c_void = num.as_concrete_TypeRef() as *const c_void;
-    let arr = unsafe { CFArray::<CFTypeRef>::from_copyable(&[num_ref]) };
-
-    let result_ptr: *mut c_void = unsafe { f(cid, 7, arr.as_concrete_TypeRef() as *const c_void) };
-    if result_ptr.is_null() {
-        return None;
-    }
-
-    let result: CFArray<CFTypeRef> = unsafe { CFArray::wrap_under_create_rule(result_ptr as _) };
-    if result.len() == 0 {
-        return None;
-    }
-
-    let space_ptr = unsafe { *result.get(0)? };
-    let space_num = unsafe { CFNumber::wrap_under_get_rule(space_ptr as _) };
-    space_num.to_i64().map(|v| v as u64)
+    get_window_spaces(&[window_id]).into_iter().next().flatten()
 }
 
 /// Return Space IDs for multiple windows in a single SPI call.
@@ -412,7 +387,7 @@ pub fn get_window_spaces(window_ids: &[u32]) -> Vec<Option<u64>> {
 
     use core_foundation::{
         array::CFArray,
-        base::{CFTypeRef, TCFType},
+        base::{CFGetTypeID, CFTypeRef, TCFType},
         number::CFNumber,
     };
 
@@ -433,18 +408,27 @@ pub fn get_window_spaces(window_ids: &[u32]) -> Vec<Option<u64>> {
 
     let result: CFArray<CFTypeRef> = unsafe { CFArray::wrap_under_create_rule(result_ptr as _) };
 
-    let mut spaces = Vec::with_capacity(window_ids.len());
-    for i in 0..result.len() {
-        let item = unsafe { result.get(i) };
-        match item {
-            Some(ptr) => {
-                let num = unsafe { CFNumber::wrap_under_get_rule(*ptr as _) };
-                spaces.push(num.to_i64().map(|v| v as u64));
+    let num_type_id = CFNumber::type_id();
+    let spaces: Vec<Option<u64>> = (0..result.len())
+        .map(|i| unsafe {
+            let item = result.get(i)?;
+            if CFGetTypeID(*item) != num_type_id {
+                return None;
             }
-            None => spaces.push(None),
-        }
+            let num = CFNumber::wrap_under_get_rule(*item as _);
+            num.to_i64().map(|v| v as u64)
+        })
+        .collect();
+
+    // Ensure result length matches input — pad with None if SPI returned fewer
+    // entries than requested.
+    if spaces.len() < window_ids.len() {
+        let mut padded = spaces;
+        padded.resize(window_ids.len(), None);
+        padded
+    } else {
+        spaces
     }
-    spaces
 }
 
 // ── Focus-without-raise ───────────────────────────────────────────────────────

--- a/libs/cua-driver/rust/crates/platform-macos/src/input/skylight.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/skylight.rs
@@ -41,6 +41,12 @@ type SetIntFieldFn = unsafe extern "C" fn(*mut c_void, u32, i64);
 /// `uint32_t CGSMainConnectionID(void)`
 type ConnectionIDFn = unsafe extern "C" fn() -> u32;
 
+/// `uint64_t CGSGetActiveSpace(uint32_t cid)`
+type GetActiveSpaceFn = unsafe extern "C" fn(u32) -> u64;
+
+/// `CFArrayRef CGSCopySpacesForWindows(uint32_t cid, uint32_t options, CFArrayRef windowIDs)`
+type CopySpacesForWindowsFn = unsafe extern "C" fn(u32, u32, *const c_void) -> *mut c_void;
+
 // ── NSMenu shortcut activation SPIs ──────────────────────────────────────────
 
 /// `OSStatus SLPSSetFrontProcessWithOptions(const void *psn, uint32_t windowID, uint32_t options)`
@@ -138,6 +144,16 @@ fn set_int_field_fn() -> Option<SetIntFieldFn> {
 fn connection_id_fn() -> Option<ConnectionIDFn> {
     static SYM: OnceLock<Option<ConnectionIDFn>> = OnceLock::new();
     *SYM.get_or_init(|| find_sym(b"CGSMainConnectionID\0").map(|p| unsafe { as_fn(p) }))
+}
+
+fn get_active_space_fn() -> Option<GetActiveSpaceFn> {
+    static SYM: OnceLock<Option<GetActiveSpaceFn>> = OnceLock::new();
+    *SYM.get_or_init(|| find_sym(b"CGSGetActiveSpace\0").map(|p| unsafe { as_fn(p) }))
+}
+
+fn copy_spaces_for_windows_fn() -> Option<CopySpacesForWindowsFn> {
+    static SYM: OnceLock<Option<CopySpacesForWindowsFn>> = OnceLock::new();
+    *SYM.get_or_init(|| find_sym(b"CGSCopySpacesForWindows\0").map(|p| unsafe { as_fn(p) }))
 }
 
 fn factory_msg_send_fn() -> Option<FactoryMsgSendFn> {
@@ -329,6 +345,108 @@ pub fn main_connection_id() -> Option<u32> {
     connection_id_fn().map(|f| unsafe { f() })
 }
 
+/// Return the current active macOS Space (desktop) ID.
+///
+/// Uses the private `CGSGetActiveSpace` SPI from SkyLight.  Returns `None`
+/// when the symbol is unavailable (future macOS version that removes it).
+pub fn get_active_space() -> Option<u64> {
+    let cid = main_connection_id()?;
+    get_active_space_fn().map(|f| unsafe { f(cid) })
+}
+
+/// Return the Space ID for a specific window.
+///
+/// Uses the private `CGSCopySpacesForWindows` SPI from SkyLight.  This
+/// function queries one window at a time — it creates a temporary CFArray
+/// with the single window ID, calls `CGSCopySpacesForWindows`, and extracts
+/// the first (only) space ID from the result.  Returns `None` when the symbol
+/// is unavailable or the query produces no result.
+pub fn get_window_space(window_id: u32) -> Option<u64> {
+    use core_foundation::{
+        array::CFArray,
+        base::{CFTypeRef, TCFType},
+        number::CFNumber,
+    };
+
+    let cid = main_connection_id()?;
+    let f = copy_spaces_for_windows_fn()?;
+
+    let num = CFNumber::from(window_id as i64);
+    let num_ref: *const c_void = num.as_concrete_TypeRef() as *const c_void;
+    let arr = unsafe { CFArray::<CFTypeRef>::from_copyable(&[num_ref]) };
+
+    let result_ptr: *mut c_void = unsafe { f(cid, 7, arr.as_concrete_TypeRef() as *const c_void) };
+    if result_ptr.is_null() {
+        return None;
+    }
+
+    let result: CFArray<CFTypeRef> = unsafe { CFArray::wrap_under_create_rule(result_ptr as _) };
+    if result.len() == 0 {
+        return None;
+    }
+
+    let space_ptr = unsafe { *result.get(0)? };
+    let space_num = unsafe { CFNumber::wrap_under_get_rule(space_ptr as _) };
+    space_num.to_i64().map(|v| v as u64)
+}
+
+/// Return Space IDs for multiple windows in a single SPI call.
+///
+/// Batches all window IDs into one `CGSCopySpacesForWindows` call
+/// instead of N separate calls. Returns a Vec where `result[i]`
+/// corresponds to `window_ids[i]`. Entries are `None` when the
+/// window has no space assignment or the SPI is unavailable.
+pub fn get_window_spaces(window_ids: &[u32]) -> Vec<Option<u64>> {
+    if window_ids.is_empty() {
+        return vec![];
+    }
+
+    let cid = match main_connection_id() {
+        Some(cid) => cid,
+        None => return vec![None; window_ids.len()],
+    };
+    let f = match copy_spaces_for_windows_fn() {
+        Some(f) => f,
+        None => return vec![None; window_ids.len()],
+    };
+
+    use core_foundation::{
+        array::CFArray,
+        base::{CFTypeRef, TCFType},
+        number::CFNumber,
+    };
+
+    let nums: Vec<CFNumber> = window_ids
+        .iter()
+        .map(|&id| CFNumber::from(id as i64))
+        .collect();
+    let refs: Vec<*const c_void> = nums
+        .iter()
+        .map(|n| n.as_concrete_TypeRef() as *const c_void)
+        .collect();
+    let arr = unsafe { CFArray::<CFTypeRef>::from_copyable(&refs) };
+
+    let result_ptr = unsafe { f(cid, 7, arr.as_concrete_TypeRef() as *const c_void) };
+    if result_ptr.is_null() {
+        return vec![None; window_ids.len()];
+    }
+
+    let result: CFArray<CFTypeRef> = unsafe { CFArray::wrap_under_create_rule(result_ptr as _) };
+
+    let mut spaces = Vec::with_capacity(window_ids.len());
+    for i in 0..result.len() {
+        let item = unsafe { result.get(i) };
+        match item {
+            Some(ptr) => {
+                let num = unsafe { CFNumber::wrap_under_get_rule(*ptr as _) };
+                spaces.push(num.to_i64().map(|v| v as u64));
+            }
+            None => spaces.push(None),
+        }
+    }
+    spaces
+}
+
 // ── Focus-without-raise ───────────────────────────────────────────────────────
 
 /// Activate `target_pid`'s window `target_wid` without raising any windows
@@ -465,47 +583,6 @@ pub fn with_foreground_assist(
     body: impl FnOnce() -> anyhow::Result<()>,
 ) -> anyhow::Result<bool> {
     with_menu_shortcut_activation(target_pid, target_wid, body)
-}
-
-/// Activate an exact target window for a global HID keyboard action.
-///
-/// Unlike [`with_menu_shortcut_activation`], this helper must not run `action`
-/// when the private foreground SPI is unavailable: a global HID event has no
-/// pid addressing and would otherwise land in whichever application is
-/// currently frontmost. The short settles keep the target frontmost until
-/// WindowServer has routed both sides of the key chord, then restore the prior
-/// process even when the action fails.
-pub fn with_foreground_hid_activation(
-    target_pid: libc::pid_t,
-    target_wid: u32,
-    action: impl FnOnce() -> anyhow::Result<()>,
-) -> anyhow::Result<()> {
-    let set_front = set_front_process_fn()
-        .ok_or_else(|| anyhow::anyhow!("foreground HID delivery is unavailable"))?;
-
-    let mut prev_psn = [0u8; 8];
-    let prev_ok = get_front_process_fn()
-        .map(|f| unsafe { f(prev_psn.as_mut_ptr() as *mut c_void) } == 0)
-        .unwrap_or(false);
-
-    let mut target_psn = [0u8; 8];
-    if !get_process_psn_for_window(target_wid, target_pid, &mut target_psn) {
-        anyhow::bail!("could not resolve target window for foreground HID delivery");
-    }
-    let activated = unsafe { set_front(target_psn.as_ptr() as *const c_void, target_wid, 0x400) };
-    if activated != 0 {
-        anyhow::bail!("WindowServer rejected foreground HID activation");
-    }
-
-    std::thread::sleep(std::time::Duration::from_millis(40));
-    let result = action();
-    std::thread::sleep(std::time::Duration::from_millis(40));
-
-    if prev_ok {
-        unsafe { set_front(prev_psn.as_ptr() as *const c_void, 0, 0x400) };
-    }
-
-    result
 }
 
 /// Activate `target_pid`'s window `target_wid` for NSMenu key dispatch, run `action`,

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/list_windows.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/list_windows.rs
@@ -83,10 +83,12 @@ impl Tool for ListWindowsTool {
             })
             .collect();
 
+        let current_space_id = crate::input::skylight::get_active_space();
+
         ToolResult::text(format!("Found {} window(s).", windows_json.len())).with_structured(
             serde_json::json!({
                 "windows": windows_json,
-                "current_space_id": null
+                "current_space_id": current_space_id
             }),
         )
     }

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/list_windows.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/list_windows.rs
@@ -50,6 +50,8 @@ impl Tool for ListWindowsTool {
         let pid_filter: Option<i32> = args.opt_i64("pid").map(|v| v as i32);
         let on_screen_only = args.bool_or("on_screen_only", false);
 
+        let current_space_id = crate::input::skylight::get_active_space();
+
         let mut windows = if on_screen_only {
             crate::windows::visible_windows()
         } else {
@@ -82,8 +84,6 @@ impl Tool for ListWindowsTool {
                 })
             })
             .collect();
-
-        let current_space_id = crate::input::skylight::get_active_space();
 
         ToolResult::text(format!("Found {} window(s).", windows_json.len())).with_structured(
             serde_json::json!({

--- a/libs/cua-driver/rust/crates/platform-macos/src/windows.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/windows.rs
@@ -77,6 +77,11 @@ fn enumerate_windows(options: u32) -> Vec<WindowInfo> {
     };
     use std::os::raw::c_void;
 
+    // Capture the current active space once so every window in this batch is
+    // compared against the same snapshot.  Spurious dlopen/dlsym calls on every
+    // window are also avoided.
+    let current_space = crate::input::skylight::get_active_space();
+
     let raw_ref = unsafe { CGWindowListCopyWindowInfo(options, kCGNullWindowID) };
     if raw_ref.is_null() {
         return vec![];
@@ -84,7 +89,8 @@ fn enumerate_windows(options: u32) -> Vec<WindowInfo> {
 
     let raw: CFArray<CFTypeRef> = unsafe { CFArray::wrap_under_create_rule(raw_ref as _) };
     let total = raw.len() as usize;
-    let mut result = Vec::new();
+    let mut results = Vec::new();
+    let mut layer0_wids: Vec<u32> = Vec::new();
 
     for (idx, item) in raw.iter().enumerate() {
         let item = *item;
@@ -186,7 +192,7 @@ fn enumerate_windows(options: u32) -> Vec<WindowInfo> {
         // z_index: CGWindowList front-to-back → assign reverse index.
         let z_index = total - idx;
 
-        result.push(WindowInfo {
+        results.push(WindowInfo {
             window_id,
             pid,
             app_name,
@@ -198,9 +204,19 @@ fn enumerate_windows(options: u32) -> Vec<WindowInfo> {
             on_current_space: None,
             space_ids: None,
         });
+        layer0_wids.push(window_id);
     }
 
-    result
+    // Batch query spaces for all layer-0 windows in one SPI call.
+    let space_results = crate::input::skylight::get_window_spaces(&layer0_wids);
+    for (i, win) in results.iter_mut().enumerate() {
+        if let Some(space_id) = space_results.get(i).copied().flatten() {
+            win.space_ids = Some(vec![space_id]);
+            win.on_current_space = current_space.map(|cur| space_id == cur);
+        }
+    }
+
+    results
 }
 
 fn get_bounds_num(


### PR DESCRIPTION
# macOS Spaces awareness (read-only)

Adds per-window space attribution to `list_windows` output using private SkyLight SPIs.

## Problem

`cua-driver` is space-unaware: agents have no way to tell which macOS Space (desktop) a window belongs to, and `list_windows` provides no signal about the current active space. This makes it impossible to reason about multi-desktop layouts.

## Solution

Three small changes, all read-only:

### 1. `src/input/skylight.rs` — new SPI bridge functions

Adds lazy-resolved function pointers and public wrappers for two private SkyLight APIs:

- **`CGSGetActiveSpace(cid)`** — returns the current active Space ID (`u64`).
- **`CGSCopySpacesForWindows(cid, options, windowIDs)`** — returns the Space ID(s) for one or more windows. Exposed as:

  - `get_active_space() -> Option<u64>`
  - `get_window_space(window_id) -> Option<u64>` (single-window convenience)
  - `get_window_spaces(&[u32]) -> Vec<Option<u64>>` (**batched** — one SPI call for N windows instead of N calls)

The batched variant is the primary internal consumer. Both follow the existing `dlopen`/`dlsym`/`OnceLock` pattern used by all other SkyLight symbols in the file.

### 2. `src/windows.rs` — `WindowInfo` extension + batched space query

**`WindowInfo` struct** gains two new `Option` fields:

- `on_current_space: Option<bool>`
- `space_ids: Option<Vec<u64>>`

**`enumerate_windows()`** now snapshots the current active space once at the top, then after collecting all layer-0 window IDs, makes a single `get_window_spaces()` call and back-fills both fields. This is O(1) SPI calls per enumeration instead of O(N).

### 3. `src/tools/list_windows.rs` — emit space fields

- Each window record now includes `on_current_space` and `space_ids`.
- Top-level response adds `current_space_id`.
- Description updated to mention the new fields.

## Example output

```json
{
  "windows": [
    {
      "window_id": 12345,
      "app_name": "Terminal",
      "on_current_space": true,
      "space_ids": [3]
    },
    {
      "window_id": 12346,
      "app_name": "Spotify",
      "on_current_space": false,
      "space_ids": [2]
    }
  ],
  "current_space_id": 3
}
```

## Backward compatibility

**Fully backward compatible.** The two new `WindowInfo` fields are `Option` — serialized as `null` when the SPI is unavailable or the window has no space assignment. No tool signatures changed; no new tools added. All existing callers continue to work.