### PR TITLE
feat(cua-driver): add static Fleet access tokens

### DIFF
--- a/docs/content/docs/how-to-guides/sandbox/fleet-device-auth.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/fleet-device-auth.mdx
@@ -1,0 +1,28 @@
+---
+title: Fleet Device Authentication
+---
+
+# Fleet Device Authentication
+
+For short-lived interactive Fleet prototyping, pass a caller-supplied device access token through the public SDK:
+
+```python
+import cua_sandbox as cua
+
+# Keep this temporary token in application memory. Do not write it to a file,
+# environment variable, terminal output, or logs.
+cua.configure(access_token=device_access_token)
+```
+
+The token is temporary and the SDK never refreshes it. If Fleet returns an unauthorized or expired-token error, authenticate again using your approved device-login flow and supply the new token with `cua.configure(access_token=...)`.
+
+Do not use private Fleet client imports or modify SDK internals. The Sandbox SDK does not read the CLI keyring or provide a token-export command; your application remains responsible for a credential-safe handoff.
+
+For long-lived or unattended Fleet workloads, prefer OAuth client credentials:
+
+```python
+import cua_sandbox as cua
+cua.configure(client_id="client-id", client_secret="client-secret")
+```
+
+An explicit per-call `api_key` continues to use the legacy cloud API. A configured temporary access token takes precedence over configured client credentials for Fleet operations.

--- a/docs/content/docs/how-to-guides/sandbox/fleet-device-auth.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/fleet-device-auth.mdx
@@ -2,7 +2,6 @@
 title: Fleet Device Authentication
 ---
 
-# Fleet Device Authentication
 
 For short-lived interactive Fleet prototyping, pass a caller-supplied device access token through the public SDK:
 

--- a/docs/content/docs/how-to-guides/sandbox/meta.json
+++ b/docs/content/docs/how-to-guides/sandbox/meta.json
@@ -1,1 +1,1 @@
-{ "title": "Sandbox", "pages": ["lifecycle", "secrets", "scale-out", "tunneling", "images", "interactive-shell"] }
+{ "title": "Sandbox", "pages": ["lifecycle", "fleet-device-auth", "secrets", "scale-out", "tunneling", "images", "interactive-shell"] }

--- a/libs/python/cua-sandbox/cua_sandbox/_config.py
+++ b/libs/python/cua-sandbox/cua_sandbox/_config.py
@@ -19,6 +19,7 @@ class _Config:
     token_url: str = _DEFAULT_TOKEN_URL
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
+    access_token: Optional[str] = None
 
 
 _global_config = _Config()
@@ -32,11 +33,13 @@ def configure(
     token_url: Optional[str] = None,
     client_id: Optional[str] = None,
     client_secret: Optional[str] = None,
+    access_token: Optional[str] = None,
 ) -> None:
     """Set global configuration for cloud sandboxes.
 
     API-key cloud operations use ``base_url``. Fleet uses ``fleet_base_url`` and
-    OAuth client credentials.
+    OAuth client credentials. ``access_token`` is a temporary caller-supplied
+    device token and is never refreshed automatically.
     """
     if api_key is not None:
         _global_config.api_key = api_key
@@ -50,6 +53,8 @@ def configure(
         _global_config.client_id = client_id
     if client_secret is not None:
         _global_config.client_secret = client_secret
+    if access_token is not None:
+        _global_config.access_token = access_token
 
 
 def get_api_key(override: Optional[str] = None) -> Optional[str]:
@@ -62,6 +67,11 @@ def get_api_key(override: Optional[str] = None) -> Optional[str]:
     if credential:
         return credential
     return os.environ.get("CUA_API_KEY")
+
+
+def get_access_token() -> Optional[str]:
+    """Return the temporary caller-supplied Fleet device token, if configured."""
+    return _global_config.access_token
 
 
 def get_base_url() -> str:

--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -56,7 +56,7 @@ except ImportError:
         pass
 
 
-from cua_sandbox._config import get_client_id, get_client_secret
+from cua_sandbox._config import get_access_token, get_client_id, get_client_secret
 from cua_sandbox.image import Image
 from cua_sandbox.interfaces import (
     Apps,
@@ -696,8 +696,10 @@ class Sandbox:
 
     @staticmethod
     def _uses_fleet(api_key: Optional[str]) -> bool:
-        """Choose Fleet only for OAuth-configured calls without an explicit API key."""
-        return api_key is None and bool(get_client_id() and get_client_secret())
+        """Choose Fleet when configured auth is present and no API key overrides it."""
+        return api_key is None and bool(
+            get_access_token() or (get_client_id() and get_client_secret())
+        )
 
     @classmethod
     async def _list_cloud(cls, *, api_key: Optional[str] = None) -> "list[SandboxInfo]":
@@ -1081,7 +1083,7 @@ class Sandbox:
             runtime = _auto_runtime(image)
         if image and not runtime and not local:
             # image without runtime and not local → cloud creation
-            if not any([ws_url, http_url]) and not api_key:
+            if not any([ws_url, http_url]) and cls._uses_fleet(api_key):
                 transport = FleetCloudTransport(
                     image=image,
                     name=name or _random_name(),

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -131,7 +131,7 @@ class _FleetClient:
                 return claim
         raise LookupError(f"Fleet claim {expected!r} was not found")
 
-    async def list_pools(self) -> list[Any]:
+    async def _list_namespaces(self) -> list[str]:
         headers = []
         if self._access_token:
             headers = [HttpHeader(name="Authorization", value=f"Bearer {self._access_token}")]
@@ -150,16 +150,22 @@ class _FleetClient:
             raise RuntimeError(f"Fleet namespace listing failed with HTTP {response.status}")
         payload = json.loads(response.body)
         items = payload if isinstance(payload, list) else payload.get("items", [])
-        namespaces = [
-            (
-                item
-                if isinstance(item, str)
-                else item.get("name") or item.get("metadata", {}).get("name")
-            )
+        return [
+            namespace
             for item in items
+            if (
+                namespace := (
+                    item
+                    if isinstance(item, str)
+                    else item.get("name") or item.get("metadata", {}).get("name")
+                )
+            )
         ]
+
+    async def list_pools(self) -> list[Any]:
+        namespaces = await self._list_namespaces()
         pools = await asyncio.gather(
-            *(self._client.list_pools(namespace) for namespace in namespaces if namespace)
+            *(self._client.list_pools(namespace) for namespace in namespaces)
         )
         return [pool for namespace_pools in pools for pool in namespace_pools]
 

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import urlparse
 
 from cua_sandbox._config import (
+    get_access_token,
     get_client_id,
     get_client_secret,
     get_fleet_base_url,
@@ -23,6 +24,8 @@ from cyclops_sdk import (
     CyclopsClient,
     CyclopsConfiguration,
     CyclopsCredentials,
+    CyclopsTokenProviderConfiguration,
+    HttpHeader,
     HttpRequest,
     PoolSpec,
     PoolTemplate,
@@ -41,15 +44,30 @@ class _FleetClient:
     """Thin async facade over the generated Cyclops SDK."""
 
     def __init__(self) -> None:
+        self._access_token = get_access_token()
+        self._base_url = get_fleet_base_url().rstrip("/")
+        self._http_client = CyclopsHttpClient()
+        if self._access_token:
+            configuration = CyclopsTokenProviderConfiguration(
+                base_url=self._base_url,
+                pool_poll_interval_ms=2000,
+                pool_poll_limit=300,
+                claim_poll_interval_ms=2000,
+                claim_poll_limit=300,
+            )
+            self._client = CyclopsClient.connect_with_access_token(
+                configuration, self._access_token, self._http_client
+            )
+            return
+
         client_id = get_client_id()
         client_secret = get_client_secret()
         if not client_id or not client_secret:
             raise ValueError(
-                "Fleet cloud sandboxes require CUA_CLIENT_ID and CUA_CLIENT_SECRET, "
-                "or cua.configure(client_id=..., client_secret=...)."
+                "Fleet cloud sandboxes require a temporary access token or CUA_CLIENT_ID and "
+                "CUA_CLIENT_SECRET. Configure cua.configure(access_token=...) or "
+                "cua.configure(client_id=..., client_secret=...)."
             )
-        self._base_url = get_fleet_base_url().rstrip("/")
-        self._http_client = CyclopsHttpClient()
         configuration = CyclopsConfiguration(
             base_url=self._base_url,
             token_url=get_token_url(),
@@ -114,9 +132,20 @@ class _FleetClient:
         raise LookupError(f"Fleet claim {expected!r} was not found")
 
     async def list_pools(self) -> list[Any]:
+        headers = []
+        if self._access_token:
+            headers = [HttpHeader(name="Authorization", value=f"Bearer {self._access_token}")]
         response = await self._http_client.execute(
-            HttpRequest(method="GET", url=f"{self._base_url}/api/namespaces", headers=[], body=None)
+            HttpRequest(
+                method="GET", url=f"{self._base_url}/api/namespaces", headers=headers, body=None
+            )
         )
+        if response.status == 401 and self._access_token:
+            raise RuntimeError(
+                "Fleet device access token is expired or unauthorized. Please authenticate again through "
+                "the supported device-login flow, then call cua.configure(access_token=...) with "
+                "a new temporary token."
+            )
         if not 200 <= response.status < 300:
             raise RuntimeError(f"Fleet namespace listing failed with HTTP {response.status}")
         payload = json.loads(response.body)

--- a/libs/python/cua-sandbox/tests/test_config.py
+++ b/libs/python/cua-sandbox/tests/test_config.py
@@ -3,6 +3,7 @@
 from cua_sandbox._config import (
     _global_config,
     configure,
+    get_access_token,
     get_api_key,
     get_base_url,
     get_client_id,
@@ -10,6 +11,7 @@ from cua_sandbox._config import (
     get_fleet_base_url,
     get_token_url,
 )
+from cua_sandbox.sandbox import Sandbox
 
 
 class TestConfig:
@@ -22,6 +24,7 @@ class TestConfig:
         )
         _global_config.client_id = None
         _global_config.client_secret = None
+        _global_config.access_token = None
 
     def test_configure_client_credentials_uses_fleet_defaults(self):
         configure(client_id="client-id", client_secret="client-secret")
@@ -37,6 +40,24 @@ class TestConfig:
     def test_configure_api_key(self):
         configure(api_key="sk-test-123")
         assert get_api_key() == "sk-test-123"
+
+    def test_configure_static_access_token(self):
+        configure(access_token="temporary-device-token")
+
+        assert get_access_token() == "temporary-device-token"
+
+    def test_fleet_authentication_precedence(self, monkeypatch):
+        monkeypatch.delenv("CUA_CLIENT_ID", raising=False)
+        monkeypatch.delenv("CUA_CLIENT_SECRET", raising=False)
+
+        assert not Sandbox._uses_fleet(None)
+
+        configure(client_id="client-id", client_secret="client-secret")
+        assert Sandbox._uses_fleet(None)
+
+        configure(access_token="temporary-device-token")
+        assert Sandbox._uses_fleet(None)
+        assert not Sandbox._uses_fleet("sk-explicit-legacy-key")
 
     def test_configure_base_url(self):
         configure(base_url="http://localhost:9000")

--- a/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
@@ -82,6 +82,7 @@ async def test_list_pools_enumerates_namespaces_with_static_bearer_token():
     client._access_token = "temporary-device-token"
     client._http_client = Http()
     client._client = SDK()
+    assert await client._list_namespaces() == ["one", "two"]
     assert await client.list_pools() == ["one", "two"]
 
 

--- a/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
@@ -1,6 +1,5 @@
-import pytest
-
 import cua_sandbox.transport.fleet_cloud as fleet_cloud
+import pytest
 from cua_sandbox._config import _global_config, configure
 from cua_sandbox.transport.fleet_cloud import _FleetClient
 

--- a/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
@@ -1,14 +1,76 @@
 import pytest
+
+import cua_sandbox.transport.fleet_cloud as fleet_cloud
+from cua_sandbox._config import _global_config, configure
 from cua_sandbox.transport.fleet_cloud import _FleetClient
 
 
+@pytest.fixture(autouse=True)
+def reset_config():
+    _global_config.access_token = None
+    _global_config.client_id = None
+    _global_config.client_secret = None
+
+
+def test_static_access_token_constructs_generated_client(monkeypatch):
+    configure(
+        access_token="temporary-device-token",
+        client_id="client-id",
+        client_secret="client-secret",
+    )
+    generated_client = object()
+    calls = []
+
+    monkeypatch.setattr(fleet_cloud, "CyclopsHttpClient", lambda: object())
+    monkeypatch.setattr(
+        fleet_cloud.CyclopsClient,
+        "connect_with_access_token",
+        classmethod(
+            lambda cls, configuration, access_token, http_client: calls.append(
+                (configuration, access_token, http_client)
+            )
+            or generated_client
+        ),
+    )
+
+    client = _FleetClient()
+
+    assert client._client is generated_client
+    assert calls[0][0].base_url == "https://run.cua.ai"
+    assert calls[0][1] == "temporary-device-token"
+
+
+def test_client_credentials_remain_the_fallback(monkeypatch):
+    configure(client_id="client-id", client_secret="client-secret")
+    generated_client = object()
+    calls = []
+
+    monkeypatch.setattr(fleet_cloud, "CyclopsHttpClient", lambda: object())
+    monkeypatch.setattr(
+        fleet_cloud.CyclopsClient,
+        "connect",
+        classmethod(
+            lambda cls, configuration, http_client: calls.append((configuration, http_client))
+            or generated_client
+        ),
+    )
+
+    client = _FleetClient()
+
+    assert client._client is generated_client
+    assert calls[0][0].credentials.client_id == "client-id"
+
+
 @pytest.mark.asyncio
-async def test_list_pools_enumerates_namespaces(monkeypatch):
+async def test_list_pools_enumerates_namespaces_with_static_bearer_token():
     client = _FleetClient.__new__(_FleetClient)
 
     class Http:
         async def execute(self, request):
             assert request.url.endswith("/api/namespaces")
+            assert [(header.name, header.value) for header in request.headers] == [
+                ("Authorization", "Bearer temporary-device-token")
+            ]
             return type(
                 "Response", (), {"status": 200, "body": b'{"items":[{"name":"one"},"two"]}'}
             )()
@@ -18,9 +80,31 @@ async def test_list_pools_enumerates_namespaces(monkeypatch):
             return [namespace]
 
     client._base_url = "https://fleet.example"
+    client._access_token = "temporary-device-token"
     client._http_client = Http()
     client._client = SDK()
     assert await client.list_pools() == ["one", "two"]
+
+
+@pytest.mark.asyncio
+async def test_list_pools_401_requires_reauthentication_without_retry():
+    client = _FleetClient.__new__(_FleetClient)
+    requests = []
+
+    class Http:
+        async def execute(self, request):
+            requests.append(request)
+            return type("Response", (), {"status": 401, "body": b"expired"})()
+
+    client._base_url = "https://fleet.example"
+    client._access_token = "temporary-device-token"
+    client._http_client = Http()
+
+    with pytest.raises(RuntimeError, match="authenticate again") as error:
+        await client.list_pools()
+
+    assert len(requests) == 1
+    assert "temporary-device-token" not in str(error.value)
 
 
 @pytest.mark.asyncio

--- a/libs/python/cua-sandbox/tests/test_fleet_cloud_transport.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_cloud_transport.py
@@ -1,5 +1,7 @@
 import pytest
 from cua_sandbox import Image
+from cua_sandbox._config import _global_config, configure
+from cua_sandbox.sandbox import Sandbox as PublicSandbox
 from cua_sandbox.transport import fleet_cloud
 from cua_sandbox.transport.fleet_cloud import FleetCloudTransport
 from cyclops_sdk import Sandbox
@@ -20,6 +22,16 @@ def test_registry_image_becomes_typed_pool_request():
         ("server", 8000),
         ("port-3000", 3000),
     ]
+
+
+def test_fleet_routing_requires_configured_fleet_auth(monkeypatch):
+    _global_config.access_token = _global_config.client_id = _global_config.client_secret = None
+    monkeypatch.delenv("CUA_CLIENT_ID", raising=False)
+    monkeypatch.delenv("CUA_CLIENT_SECRET", raising=False)
+    assert not PublicSandbox._uses_fleet(None)
+    configure(access_token="temporary-device-token")
+    assert PublicSandbox._uses_fleet(None)
+    assert not PublicSandbox._uses_fleet("sk-explicit-legacy-key")
 
 
 @pytest.mark.parametrize(
@@ -59,6 +71,26 @@ async def test_connect_uses_generated_pool_template_claim_default(monkeypatch):
 
     assert len(requests) == 1
     assert requests[0].spec is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_deletes_claim_before_pool():
+    transport = FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo")
+    calls = []
+
+    class Client:
+        async def delete_claim(self, claim):
+            calls.append(("claim", claim))
+
+        async def delete_pool(self, pool):
+            calls.append(("pool", pool))
+
+    transport._sdk = Client()
+    transport._claim = "claim"
+    transport._pool = "pool"
+    await transport._cleanup_resources()
+    assert calls == [("claim", "claim"), ("pool", "pool")]
+    assert transport._claim is None and transport._pool is None
 
 
 @pytest.mark.asyncio

--- a/tests/integration/sandbox_sdk/test_fleet_cli_device_auth.py
+++ b/tests/integration/sandbox_sdk/test_fleet_cli_device_auth.py
@@ -1,20 +1,32 @@
-"""Opt-in Fleet device-auth integration coverage.
+"""Opt-in Fleet device-auth integration coverage using public SDK APIs only."""
 
-A credential-safe public CLI-to-SDK token handoff is not available on current
-main. Keep this test as an explicit gate until that public surface exists;
-never add a token environment variable, keyring read, or token-printing helper.
-"""
+from __future__ import annotations
 
 import os
+import uuid
 
 import pytest
+from cua_sandbox import Image, Sandbox, configure
+
+
+def _safe_device_access_token() -> str:
+    pytest.skip(
+        "A credential-safe public CLI device-token handoff is not available; the live Fleet test remains gated to avoid reading, exporting, or logging credentials."
+    )
 
 
 @pytest.mark.asyncio
-async def test_fleet_cli_device_auth_requires_safe_public_handoff():
-    if not os.environ.get("CUA_FLEET_TEST_IMAGE"):
+async def test_fleet_cli_device_auth_create_use_delete_and_verify_absence():
+    image = os.environ.get("CUA_FLEET_TEST_IMAGE")
+    if not image:
         pytest.skip("CUA_FLEET_TEST_IMAGE must name an approved Fleet image")
-    pytest.skip(
-        "A credential-safe public CLI device-token handoff is not available; "
-        "the live Fleet test remains gated to avoid reading, exporting, or logging credentials."
-    )
+    configure(access_token=_safe_device_access_token())
+    name = f"fleet-device-auth-{uuid.uuid4().hex[:12]}"
+    try:
+        sandbox = await Sandbox.create(Image.from_registry(image), name=name)
+        result = await sandbox.shell.run("printf fleet-device-auth-ok")
+        assert result.success
+        assert result.stdout == "fleet-device-auth-ok"
+    finally:
+        await Sandbox.delete(name)
+        assert name not in {sandbox_info.name for sandbox_info in await Sandbox.list()}

--- a/tests/integration/sandbox_sdk/test_fleet_cli_device_auth.py
+++ b/tests/integration/sandbox_sdk/test_fleet_cli_device_auth.py
@@ -1,0 +1,20 @@
+"""Opt-in Fleet device-auth integration coverage.
+
+A credential-safe public CLI-to-SDK token handoff is not available on current
+main. Keep this test as an explicit gate until that public surface exists;
+never add a token environment variable, keyring read, or token-printing helper.
+"""
+
+import os
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_fleet_cli_device_auth_requires_safe_public_handoff():
+    if not os.environ.get("CUA_FLEET_TEST_IMAGE"):
+        pytest.skip("CUA_FLEET_TEST_IMAGE must name an approved Fleet image")
+    pytest.skip(
+        "A credential-safe public CLI device-token handoff is not available; "
+        "the live Fleet test remains gated to avoid reading, exporting, or logging credentials."
+    )


### PR DESCRIPTION
Linear: https://linear.app/trycua/issue/CUA-954/expose-fleet-device-authentication-through-the-public-cua-sandbox-api

Implements approved plan #2520.

- Adds public in-memory `cua.configure(access_token=...)` for temporary Fleet device tokens.
- Preserves explicit per-call `api_key` legacy routing; static tokens take precedence over client credentials.
- Uses the generated static-token Fleet constructor and attaches the bearer token to raw namespace discovery.
- Returns one credential-safe re-authentication error for static-token `401`s without refresh/retry behavior.
- Adds focused unit coverage and an opt-in live E2E gate. The live test skips until an approved `CUA_FLEET_TEST_IMAGE` and a credential-safe public CLI-to-SDK handoff exist; it does not read, export, print, or persist credentials.

Salvaged from #2520.