### PR TITLE
fix(cua-bench): await simulated 2048 operations

### DIFF
--- a/libs/cua-bench/cua_bench/tests/test_bundled_examples.py
+++ b/libs/cua-bench/cua_bench/tests/test_bundled_examples.py
@@ -1,0 +1,57 @@
+"""Regression tests for bundled example task definitions."""
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+TASK_PATH = Path(__file__).parents[2] / "example_tasks" / "2048_env_simulated" / "main.py"
+
+
+@pytest.fixture
+def simulated_2048_module():
+    spec = importlib.util.spec_from_file_location("test_simulated_2048", TASK_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.asyncio
+async def test_simulated_2048_setup_awaits_window_launch(simulated_2048_module):
+    session = SimpleNamespace(launch_window=AsyncMock(return_value=42))
+
+    await simulated_2048_module.start(None, session)
+
+    session.launch_window.assert_awaited_once()
+    assert simulated_2048_module.pid == 42
+
+
+@pytest.mark.asyncio
+async def test_simulated_2048_evaluate_awaits_max_tile_query(simulated_2048_module):
+    simulated_2048_module.pid = 42
+    session = SimpleNamespace(execute_javascript=AsyncMock(return_value=128))
+
+    result = await simulated_2048_module.evaluate(None, session)
+
+    session.execute_javascript.assert_awaited_once_with(42, "window.__max_tile || 0")
+    assert result == [0.0625]
+
+
+@pytest.mark.asyncio
+async def test_simulated_2048_solver_awaits_queries_and_steps(simulated_2048_module):
+    simulated_2048_module.pid = 42
+    step = AsyncMock()
+    session = SimpleNamespace(
+        env=SimpleNamespace(step=step),
+        execute_javascript=AsyncMock(side_effect=[False, "left", True]),
+    )
+
+    await simulated_2048_module.solve(None, session)
+
+    assert session.execute_javascript.await_count == 3
+    step.assert_awaited_once()
+    assert step.await_args.args[0].key == "left"

--- a/libs/cua-bench/example_tasks/2048_env_simulated/main.py
+++ b/libs/cua-bench/example_tasks/2048_env_simulated/main.py
@@ -36,9 +36,9 @@ pid = None
 
 # Called at start of task
 @cb.setup_task(split="train")
-def start(task_cfg, session: cb.DesktopSession | cb.MobileSession):
+async def start(task_cfg, session: cb.DesktopSession | cb.MobileSession):
     global pid
-    pid = session.launch_window(
+    pid = await session.launch_window(
         html=(Path(__file__).parent / "gui/index.html").read_text(),
         title="2048 Env",
         width=512,
@@ -48,12 +48,12 @@ def start(task_cfg, session: cb.DesktopSession | cb.MobileSession):
 
 # Called at end of task
 @cb.evaluate_task(split="train")
-def evaluate(task_cfg, session: cb.DesktopSession | cb.MobileSession) -> list[float]:
+async def evaluate(task_cfg, session: cb.DesktopSession | cb.MobileSession) -> list[float]:
     # Simple metric: normalize by max tile seen (0..2048 -> 0..1). Not strict.
     if pid is None:
         return [0.0]
     try:
-        m = session.execute_javascript(pid, "window.__max_tile || 0") or 0
+        m = await session.execute_javascript(pid, "window.__max_tile || 0") or 0
         score = min(max(int(m), 0), 2048) / 2048.0
         return [float(score)]
     except Exception:
@@ -62,16 +62,16 @@ def evaluate(task_cfg, session: cb.DesktopSession | cb.MobileSession) -> list[fl
 
 # Called after setup_task if run_solution is True
 @cb.solve_task(split="train")
-def solve(task_cfg, session: cb.DesktopSession | cb.MobileSession):
+async def solve(task_cfg, session: cb.DesktopSession | cb.MobileSession):
     global pid
     if pid is None:
         return
     # Greedy auto-player using window.__next_move()
     for _ in range(200):
-        lost = session.execute_javascript(pid, "window.__lost === true")
+        lost = await session.execute_javascript(pid, "window.__lost === true")
         if lost:
             break
-        direction = session.execute_javascript(
+        direction = await session.execute_javascript(
             pid, "(window.__next_move && window.__next_move()) || null"
         )
         if not direction:
@@ -85,4 +85,4 @@ def solve(task_cfg, session: cb.DesktopSession | cb.MobileSession):
         if not key:
             break
         if hasattr(session, "env") and session.env:
-            session.env.step(KeyAction(key=key))
+            await session.env.step(KeyAction(key=key))


### PR DESCRIPTION
## Problem

The bundled simulated 2048 task calls asynchronous session operations from synchronous lifecycle functions. The framework therefore receives ordinary return values while the window launch, JavaScript queries, and environment steps remain unawaited; the oracle does not play the game and evaluation falls back to `[0.0]`.

## Change

- Make the task setup, solver, and evaluator asynchronous and await every session operation.
- Add focused regression coverage for the resolved window id, JavaScript evaluation result, and solver step.

## Tests

- `uv run --with pytest pytest cua_bench/tests/test_bundled_examples.py -q`
- `uv run cb interact example_tasks/2048_env_simulated --variant-id 0 --oracle --no-wait` (completed without coroutine warnings; evaluation `[0.03125]`)
- `uv run --with pytest pytest cua_bench/tests/ -v --ignore=cua_bench/tests/test_worker_client.py --ignore=cua_bench/tests/test_worker_manager.py --ignore=cua_bench/tests/test_worker_server.py` (76 passed)
- `uv run --with ruff==0.14.1 ruff check cua_bench/tests/test_bundled_examples.py example_tasks/2048_env_simulated/main.py`
- `uv run --with black==25.9.0 black --check cua_bench/tests/test_bundled_examples.py example_tasks/2048_env_simulated/main.py`
- `uv run --with isort==7.0.0 isort --check-only cua_bench/tests/test_bundled_examples.py example_tasks/2048_env_simulated/main.py`

The three worker test modules could not be collected locally because PyTorch 2.12.1 has no macOS x86_64 wheel; they are unchanged by this patch.

Addresses the async lifecycle half of #2511. The separate CLI success-reporting behavior remains tracked in that issue.