### PR TITLE
fix(cua-sandbox): use pool template for Fleet claims

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -18,7 +18,6 @@ from cua_sandbox.image import Image
 from cua_sandbox.transport.cyclops_http_client import CyclopsHttpClient
 from cua_sandbox.transport.fleet import FleetTransport
 from cyclops_sdk import (
-    ClaimSpec,
     CreateClaimRequest,
     CreatePoolRequest,
     CyclopsClient,
@@ -29,7 +28,6 @@ from cyclops_sdk import (
     PoolTemplate,
     PreservedJson,
     SandboxService,
-    SandboxTemplateRef,
     ServiceProtocol,
 )
 
@@ -220,17 +218,7 @@ class FleetCloudTransport(FleetTransport):
                         self._claim = await self._sdk.get_claim(self._pool)
                     else:
                         self._claim = await self._sdk.create_claim(
-                            CreateClaimRequest(
-                                pool=self._pool,
-                                spec=ClaimSpec(
-                                    sandbox_template_ref=SandboxTemplateRef(
-                                        name=self._pool.metadata.name
-                                    ),
-                                    warmpool=None,
-                                    bind_deadline=600,
-                                    lifecycle=None,
-                                ),
-                            )
+                            CreateClaimRequest(pool=self._pool, spec=None)
                         )
                 bound = await self._sdk.wait_claim(self._claim)
                 await self._sdk.wait_service_ready(bound, "server", self._time_to_start)

--- a/libs/python/cua-sandbox/tests/test_fleet_cloud_transport.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_cloud_transport.py
@@ -1,5 +1,6 @@
 import pytest
 from cua_sandbox import Image
+from cua_sandbox.transport import fleet_cloud
 from cua_sandbox.transport.fleet_cloud import FleetCloudTransport
 from cyclops_sdk import Sandbox
 
@@ -27,6 +28,37 @@ def test_registry_image_becomes_typed_pool_request():
 def test_rejects_unsupported_images(image):
     with pytest.raises(ValueError):
         FleetCloudTransport._validate_image(image)
+
+
+@pytest.mark.asyncio
+async def test_connect_uses_generated_pool_template_claim_default(monkeypatch):
+    pool = type("Pool", (), {"metadata": type("Metadata", (), {"name": "demo"})()})()
+    requests = []
+
+    class Client:
+        async def create_pool(self, request):
+            return pool
+
+        async def wait_pool(self, created_pool):
+            return created_pool
+
+        async def create_claim(self, request):
+            requests.append(request)
+            return "claim"
+
+        async def wait_claim(self, claim):
+            return Sandbox(namespace="demo", claim=claim, name="sandbox", services=["server"])
+
+        async def wait_service_ready(self, sandbox, service, time_to_start):
+            assert service == "server"
+
+    client = Client()
+    monkeypatch.setattr(fleet_cloud, "_FleetClient", lambda: client)
+
+    await FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo").connect()
+
+    assert len(requests) == 1
+    assert requests[0].spec is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Root Cause

The live E2E pool `cua-pr2519-e2e-1784871193` was healthy enough to boot, but its claim used the wrong template key:

- Authoritative Loki evidence shows the operator created `ecr-credentials` and Sandbox `cua-pr2519-e2e-1784871193-ddca1963` at 05:33:44 UTC. KubeVirt started the domain around 05:34:40 UTC; the guest agent, network, qemu-guest-agent, noVNC, and computer services then started.
- The claim started at 05:35:49 UTC but repeatedly reported an empty warm pool until its 600-second bind deadline; cleanup completed at 05:45:57 UTC.
- `FleetCloudTransport` passed `sandboxTemplateRef.name = pool.metadata.name`, while the generated Cyclops SDK's default claim path uses `<pool>-template`. The controller hashes that ref to select `WARM_QUEUE`, so the explicit pool name searched a different queue than the Ready sandbox's template.

This is not the already-fixed per-pool `ExternalSecret` regression in Cloud PR #5780.

## Fix

- Let `CyclopsClient.create_claim` apply its canonical `spec=None` default, which derives `<pool>-template` from the pool name.
- Add a regression test that exercises `FleetCloudTransport.connect()` and asserts no mismatched explicit claim spec is sent.

## Validation

- RED before the fix: `tests/test_fleet_cloud_transport.py::test_connect_uses_generated_pool_template_claim_default` failed with `ClaimSpec()` instead of `None`.
- GREEN after the fix: the same test passed.
- `PYTHONPATH=. /tmp/cua-pr2519-fleet-test-venv/bin/python -m pytest -q tests/test_fleet_cloud_transport.py tests/test_fleet_cloud_client.py` - `10 passed`.
- Ruff check and format check passed for both changed files; `compileall` passed.

## Constraints

- The broad local `cua-sandbox` suite is not a valid signal in this container: 110 passed, 83 skipped, 29 failed, and 19 errored due to absent local-runtime dependencies / an incompatible test loop environment. `uv lock --check` also fails on unchanged `main` because the lockfile is stale. No packaging or timeout changes are included.
- A live rerun requires deployment of this PR plus authorized Fleet credentials that can create and delete an isolated pool/claim. No live E2E was run from this branch.
