### PR TITLE
feat(xfce): install Cua Driver SDK in container images

### DIFF
--- a/.github/workflows/cd-container-xfce.yml
+++ b/.github/workflows/cd-container-xfce.yml
@@ -14,5 +14,7 @@ jobs:
       context_dir: libs/xfce
       tag_prefix: docker-xfce-v
       docker_hub_org: trycua
+      # kicad/kicad:9.0 currently publishes an amd64 image only.
+      skip_arm64: true
     secrets:
       DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/ci-container-xfce.yml
+++ b/.github/workflows/ci-container-xfce.yml
@@ -13,3 +13,5 @@ jobs:
     with:
       image_name: cua-xfce
       context_dir: libs/xfce
+      # kicad/kicad:9.0 currently publishes an amd64 image only.
+      skip_arm64: true

--- a/libs/xfce/Development.md
+++ b/libs/xfce/Development.md
@@ -25,4 +25,17 @@ docker tag cua-xfce:dev cua-xfce:latest
 docker run -p 6901:6901 -p 8000:8000 cua-xfce:dev
 ```
 
+Verify that the image contains both the Python SDK and bundled executable:
+
+```bash
+docker run --rm cua-xfce:dev cua-driver --version
+docker run --rm cua-xfce:dev \
+  python -c "from cua_driver import CuaDriver, get_binary_path; print(get_binary_path())"
+```
+
+Installing Cua Driver does not replace or start another GUI service. The image
+continues to expose computer-server on port 8000. A future transport adapter can
+host the typed Python SDK without coupling the base image to HTTP, gRPC, or
+another remote protocol.
+
 Access noVNC at: http://localhost:6901

--- a/libs/xfce/Dockerfile
+++ b/libs/xfce/Dockerfile
@@ -80,6 +80,7 @@ RUN pip3 install --break-system-packages uv && \
     uv venv /opt/venv --python 3.13 && \
     ln -sf /opt/venv/bin/python3 /usr/local/bin/python3 && \
     ln -sf /opt/venv/bin/python3 /usr/local/bin/python
+ENV PATH="/opt/venv/bin:${PATH}"
 
 # Remove screensavers and power manager to avoid popups and lock screens
 RUN apt-get remove -y \
@@ -125,6 +126,15 @@ RUN uv pip install --python /opt/venv/bin/python3 \
     "datasets>=3.0.0" \
     "matplotlib>=3.8.0" \
     "anthropic>=0.26.0"
+
+# Install the typed Cua Driver SDK and its bundled executable. The image keeps
+# computer-server as its active remote API until a transport adapter is chosen.
+COPY requirements-cua-driver.txt /tmp/requirements-cua-driver.txt
+RUN uv pip install --python /opt/venv/bin/python3 --no-cache-dir \
+        -r /tmp/requirements-cua-driver.txt && \
+    /opt/venv/bin/python3 -c \
+        "from pathlib import Path; from cua_driver import CuaDriver, get_binary_path; assert Path(get_binary_path()).is_file()" && \
+    /opt/venv/bin/cua-driver --version
 
 # Copy startup scripts
 COPY src/supervisor/ /etc/supervisor/conf.d/

--- a/libs/xfce/Dockerfile.dev
+++ b/libs/xfce/Dockerfile.dev
@@ -147,6 +147,16 @@ RUN uv pip install --system cua-bench-ui>=0.7.0 --no-cache-dir
 RUN uv pip install --system playwright && \
     python3.12 -m playwright install --with-deps firefox
 
+# Install the same released Cua Driver SDK used by the production image. This
+# makes the Python API and bundled executable available without changing the
+# existing computer-server runtime or port contract.
+COPY xfce/requirements-cua-driver.txt /tmp/requirements-cua-driver.txt
+RUN uv pip install --system --no-cache-dir \
+        -r /tmp/requirements-cua-driver.txt && \
+    python3.12 -c \
+        "from pathlib import Path; from cua_driver import CuaDriver, get_binary_path; assert Path(get_binary_path()).is_file()" && \
+    cua-driver --version
+
 # Fix any cache files created by pip
 RUN chown -R cua:cua /home/cua/.cache
 

--- a/libs/xfce/README.md
+++ b/libs/xfce/README.md
@@ -2,4 +2,11 @@
 
 Vanilla XFCE desktop container for Computer-Using Agents.
 
+The image includes both `cua-computer-server` and the released `cua-driver`
+Python SDK with its bundled executable. Computer-server remains the active
+remote API on port 8000; Cua Driver is installed for co-located applications
+and future transport-adapter experiments but is not started automatically.
+The pinned Driver version is declared in
+[`requirements-cua-driver.txt`](requirements-cua-driver.txt).
+
 **[Documentation](https://cua.ai/docs/cua/reference/desktop-sandbox/linux-container/xfce)** - Setup and configuration.

--- a/libs/xfce/requirements-cua-driver.txt
+++ b/libs/xfce/requirements-cua-driver.txt
@@ -1,0 +1,2 @@
+# Keep this pinned so released XFCE image builds are reproducible.
+cua-driver==0.12.3


### PR DESCRIPTION
## Summary

- install the released `cua-driver==0.12.3` Python SDK and bundled executable in production and development XFCE images
- keep `cua-computer-server` as the existing auto-started remote API on port 8000
- share one pinned requirements file and document local SDK/binary smoke checks
- mark XFCE build and publish workflows amd64-only because the upstream `kicad/kicad:9.0` base currently has no arm64 manifest

This deliberately does not choose HTTP, gRPC, or another Driver transport. A separate adapter/recipe can host the typed SDK later without coupling the base image to a protocol.

## Verification

- **CI: Container XFCE** builds the complete `linux/amd64` production image successfully
- production build installs `cua-driver==0.12.3` from PyPI, imports `CuaDriver`, resolves its bundled executable, and runs `cua-driver --version` during the image build
- workflow YAML parses successfully
- `git diff --check` passes

Local Docker Desktop reproduced the same successful Driver install/import/version layer. The local build later stopped in the pre-existing recursive `/home/cua` ownership layer after Docker VM storage exhausted the host’s remaining disk; CI provides the complete-image proof.