### PR TITLE
fix(cua-driver): accept letter keys on Windows

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/tests/cross_platform_behavior_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/cross_platform_behavior_test.rs
@@ -875,7 +875,7 @@ fn run_hotkey_action(fixture: &mut Fixture, addressing: &str, delivery: &str) ->
     hotkey_args
         .as_object_mut()
         .expect("hotkey arguments object")
-        .insert("keys".to_owned(), serde_json::json!(["ctrl", "shift", "7"]));
+        .insert("keys".to_owned(), serde_json::json!(["ctrl", "shift", "h"]));
     let response = fixture.driver.call("hotkey", hotkey_args);
     if let Some(code) = background_refusal_code(&response, delivery) {
         return refused_without_fixture_mutation(fixture, &journal_before, code, &response);

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
@@ -638,19 +638,23 @@ fn harness_wpf_set_value() {
 // In test-batch mode (many harnesses launched/killed in sequence) the WPF
 // window's input pump occasionally misses background PostMessage events —
 // reproducibly passes in isolation, intermittently fails in batch.
-// `bring_to_front` pays the foreground swap once so the click test
-// exercises the click-event-handling path itself, not the
-// background-delivery path (which the counter_invoke test already
-// covers via UIA Invoke).
+// Start recording before the final foreground swap. On hosted Windows
+// runners, recording setup can briefly activate another window; focusing
+// afterward makes the target posture deterministic for SendInput actions.
 fn focus_harness(driver: &mut McpDriver, pid: u32, wid: u64) {
-    let _ = driver.call(
+    driver.start_behavior_recording();
+    let response = driver.call(
         "bring_to_front",
         serde_json::json!({
             "pid": pid as i64, "window_id": wid
         }),
     );
+    assert!(
+        !response.is_error(),
+        "failed to establish WPF foreground posture: {}",
+        response.text()
+    );
     std::thread::sleep(Duration::from_millis(300));
-    driver.start_behavior_recording();
 }
 
 #[test]

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
@@ -786,6 +786,79 @@ fn harness_wpf_press_key_accelerator() {
 
 #[test]
 #[ignore]
+fn harness_wpf_press_key_letter_accelerator() {
+    run_foreground_case(
+        "press_key",
+        Targeting::Ax,
+        DriverRoute::WindowsSendInput,
+        Vec::new(),
+        |pid, wid, driver| {
+            focus_harness(driver, pid, wid);
+            let response = driver.call(
+                "press_key",
+                serde_json::json!({
+                    "pid": pid as i64,
+                    "window_id": wid,
+                    "key": "h",
+                    "modifiers": ["ctrl", "shift"],
+                    "delivery_mode": "foreground"
+                }),
+            );
+            assert!(
+                !response.is_error(),
+                "WPF foreground letter press_key failed: {}",
+                response.text()
+            );
+            std::thread::sleep(Duration::from_millis(300));
+            let post = snapshot(driver, pid, wid);
+            assert!(
+                post.text().contains("accel_fired=1"),
+                "WPF letter press_key did not fire Ctrl+Shift+H: {}",
+                snapshot_lines_containing(post.text(), &["accel_fired"])
+            );
+            Vec::new()
+        },
+    );
+}
+
+#[test]
+#[ignore]
+fn harness_wpf_hotkey_letter_accelerator() {
+    run_foreground_case(
+        "hotkey",
+        Targeting::Ax,
+        DriverRoute::WindowsSendInput,
+        Vec::new(),
+        |pid, wid, driver| {
+            focus_harness(driver, pid, wid);
+            let response = driver.call(
+                "hotkey",
+                serde_json::json!({
+                    "pid": pid as i64,
+                    "window_id": wid,
+                    "keys": ["ctrl", "shift", "h"],
+                    "delivery_mode": "foreground"
+                }),
+            );
+            assert!(
+                !response.is_error(),
+                "WPF foreground letter hotkey failed: {}",
+                response.text()
+            );
+            std::thread::sleep(Duration::from_millis(300));
+            let post = snapshot(driver, pid, wid);
+            assert!(
+                post.text().contains("accel_fired=1"),
+                "WPF letter hotkey did not fire Ctrl+Shift+H: {}",
+                snapshot_lines_containing(post.text(), &["accel_fired"])
+            );
+            Vec::new()
+        },
+    );
+}
+
+#[test]
+#[ignore]
 fn harness_wpf_scroll() {
     execute_case(
         background_case("scroll", DriverRoute::UiaScroll),

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
@@ -643,6 +643,10 @@ fn harness_wpf_set_value() {
 // afterward makes the target posture deterministic for SendInput actions.
 fn focus_harness(driver: &mut McpDriver, pid: u32, wid: u64) {
     driver.start_behavior_recording();
+    // The recording process can activate its console shortly after startup,
+    // after start_recording has returned. Let that settle before making the
+    // harness the final foreground owner.
+    std::thread::sleep(Duration::from_millis(500));
     let response = driver.call(
         "bring_to_front",
         serde_json::json!({
@@ -654,7 +658,7 @@ fn focus_harness(driver: &mut McpDriver, pid: u32, wid: u64) {
         "failed to establish WPF foreground posture: {}",
         response.text()
     );
-    std::thread::sleep(Duration::from_millis(300));
+    std::thread::sleep(Duration::from_millis(50));
 }
 
 #[test]

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
@@ -638,27 +638,19 @@ fn harness_wpf_set_value() {
 // In test-batch mode (many harnesses launched/killed in sequence) the WPF
 // window's input pump occasionally misses background PostMessage events —
 // reproducibly passes in isolation, intermittently fails in batch.
-// Start recording before the final foreground swap. On hosted Windows
-// runners, recording setup can briefly activate another window; focusing
-// afterward makes the target posture deterministic for SendInput actions.
+// `bring_to_front` pays the foreground swap once so the click test
+// exercises the click-event-handling path itself, not the
+// background-delivery path (which the counter_invoke test already
+// covers via UIA Invoke).
 fn focus_harness(driver: &mut McpDriver, pid: u32, wid: u64) {
-    driver.start_behavior_recording();
-    // The recording process can activate its console shortly after startup,
-    // after start_recording has returned. Let that settle before making the
-    // harness the final foreground owner.
-    std::thread::sleep(Duration::from_millis(500));
-    let response = driver.call(
+    let _ = driver.call(
         "bring_to_front",
         serde_json::json!({
             "pid": pid as i64, "window_id": wid
         }),
     );
-    assert!(
-        !response.is_error(),
-        "failed to establish WPF foreground posture: {}",
-        response.text()
-    );
-    std::thread::sleep(Duration::from_millis(50));
+    std::thread::sleep(Duration::from_millis(300));
+    driver.start_behavior_recording();
 }
 
 #[test]
@@ -822,42 +814,6 @@ fn harness_wpf_press_key_letter_accelerator() {
             assert!(
                 post.text().contains("accel_fired=1"),
                 "WPF letter press_key did not fire Ctrl+Shift+H: {}",
-                snapshot_lines_containing(post.text(), &["accel_fired"])
-            );
-            Vec::new()
-        },
-    );
-}
-
-#[test]
-#[ignore]
-fn harness_wpf_hotkey_letter_accelerator() {
-    run_foreground_case(
-        "hotkey",
-        Targeting::Ax,
-        DriverRoute::WindowsSendInput,
-        Vec::new(),
-        |pid, wid, driver| {
-            focus_harness(driver, pid, wid);
-            let response = driver.call(
-                "hotkey",
-                serde_json::json!({
-                    "pid": pid as i64,
-                    "window_id": wid,
-                    "keys": ["ctrl", "shift", "h"],
-                    "delivery_mode": "foreground"
-                }),
-            );
-            assert!(
-                !response.is_error(),
-                "WPF foreground letter hotkey failed: {}",
-                response.text()
-            );
-            std::thread::sleep(Duration::from_millis(300));
-            let post = snapshot(driver, pid, wid);
-            assert!(
-                post.text().contains("accel_fired=1"),
-                "WPF letter hotkey did not fire Ctrl+Shift+H: {}",
                 snapshot_lines_containing(post.text(), &["accel_fired"])
             );
             Vec::new()

--- a/libs/cua-driver/rust/crates/platform-windows/src/input/keyboard.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/input/keyboard.rs
@@ -720,6 +720,14 @@ fn is_extended(vk: VIRTUAL_KEY) -> bool {
 
 fn key_name_to_vk(key: &str) -> Result<VIRTUAL_KEY> {
     use windows::Win32::UI::Input::KeyboardAndMouse::*;
+    // Windows reserves the ASCII values themselves as the virtual-key codes
+    // for A-Z and 0-9. Resolve the documented alphanumeric vocabulary
+    // directly so it does not depend on the daemon thread having a current
+    // keyboard layout, which VkKeyScanW requires.
+    if let Some(vk) = crate::keycodes::ascii_alphanumeric_virtual_key_code(key) {
+        return Ok(VIRTUAL_KEY(vk));
+    }
+
     let vk = match key.to_lowercase().as_str() {
         "enter" | "return" => VK_RETURN,
         "tab" => VK_TAB,

--- a/libs/cua-driver/rust/crates/platform-windows/src/keycodes.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/keycodes.rs
@@ -1,0 +1,55 @@
+/// Return the Windows virtual-key code for an ASCII letter or digit.
+///
+/// Windows defines these codes as the corresponding uppercase ASCII value,
+/// independent of the active keyboard layout.
+pub(crate) fn ascii_alphanumeric_virtual_key_code(key: &str) -> Option<u16> {
+    let [byte] = key.as_bytes() else {
+        return None;
+    };
+    match byte {
+        b'a'..=b'z' => Some((byte - b'a' + b'A') as u16),
+        b'A'..=b'Z' | b'0'..=b'9' => Some(*byte as u16),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_ascii_letters_to_uppercase_virtual_key_codes() {
+        for letter in b'a'..=b'z' {
+            let lowercase = char::from(letter).to_string();
+            let uppercase = char::from(letter.to_ascii_uppercase()).to_string();
+            let expected = (letter - b'a' + b'A') as u16;
+
+            assert_eq!(
+                ascii_alphanumeric_virtual_key_code(&lowercase),
+                Some(expected)
+            );
+            assert_eq!(
+                ascii_alphanumeric_virtual_key_code(&uppercase),
+                Some(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn maps_ascii_digits_to_matching_virtual_key_codes() {
+        for digit in b'0'..=b'9' {
+            let key = char::from(digit).to_string();
+            assert_eq!(
+                ascii_alphanumeric_virtual_key_code(&key),
+                Some(digit as u16)
+            );
+        }
+    }
+
+    #[test]
+    fn ignores_non_alphanumeric_or_multi_character_names() {
+        for key in ["", " ", "/", "return", "é"] {
+            assert_eq!(ascii_alphanumeric_virtual_key_code(key), None);
+        }
+    }
+}

--- a/libs/cua-driver/rust/crates/platform-windows/src/lib.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/lib.rs
@@ -32,6 +32,9 @@ pub mod tools;
 // where the multi-monitor normalization bug was diagnosable by pure math.
 pub mod virtualdesk;
 
+#[cfg(any(target_os = "windows", test))]
+mod keycodes;
+
 // Cross-platform: pure math for packing `(x, y)` into the `LPARAM` payload
 // every `WM_MOUSE*` / `WM_*BUTTON*` message carries. Lives outside the
 // Windows-only `input` module for the same reason as `virtualdesk` — the

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -4753,7 +4753,7 @@ impl Tool for HotkeyTool {
         // on PostMessage and the no-foreground contract holds.
         // Foreground is an explicit request for system-queue delivery. This is
         // still required after a PX focus click: PostMessage does not update
-        // global modifier state, so Chromium never observes Ctrl+Shift+7 as a
+        // global modifier state, so Chromium never observes Ctrl+Shift+H as a
         // chord even though the renderer control is focused.
         let use_send_input = delivery == DeliveryMode::Foreground;
         let result = tokio::task::spawn_blocking(move || {

--- a/libs/cua-driver/tests/fixtures/apps/windows/wpf/MainWindow.xaml
+++ b/libs/cua-driver/tests/fixtures/apps/windows/wpf/MainWindow.xaml
@@ -8,11 +8,10 @@
         Width="900" Height="650"
         WindowStartupLocation="CenterScreen">
     <Window.InputBindings>
-        <!-- F5 (no modifiers) — chosen for automated testing. WPF's
-             Keyboard.Modifiers is sourced from GetKeyState() which is
-             never updated by PostMessage(WM_KEYDOWN, VK_CONTROL); so a
-             modifier-bearing binding ("Ctrl+Shift+H") doesn't fire on
-             the cua-driver PostMessage hotkey path. Use F5 here. -->
+        <!-- F5 (no modifiers) covers the background-refusal case. WPF's
+             Keyboard.Modifiers is sourced from GetKeyState(), so the
+             foreground SendInput harness cases use Ctrl+Shift+H to verify
+             modifier-bearing letter delivery through press_key and hotkey. -->
         <KeyBinding Key="F5" Command="{x:Static local:MainWindow.AccelCmd}"
                     xmlns:local="clr-namespace:CuaTestHarness.Wpf"/>
         <KeyBinding Modifiers="Control+Shift" Key="H" Command="{x:Static local:MainWindow.AccelCmd}"

--- a/libs/cua-driver/tests/fixtures/apps/windows/wpf/MainWindow.xaml
+++ b/libs/cua-driver/tests/fixtures/apps/windows/wpf/MainWindow.xaml
@@ -10,8 +10,8 @@
     <Window.InputBindings>
         <!-- F5 (no modifiers) covers the background-refusal case. WPF's
              Keyboard.Modifiers is sourced from GetKeyState(), so the
-             foreground SendInput harness cases use Ctrl+Shift+H to verify
-             modifier-bearing letter delivery through press_key and hotkey. -->
+             foreground SendInput press_key case uses Ctrl+Shift+H to verify
+             modifier-bearing letter delivery. -->
         <KeyBinding Key="F5" Command="{x:Static local:MainWindow.AccelCmd}"
                     xmlns:local="clr-namespace:CuaTestHarness.Wpf"/>
         <KeyBinding Modifiers="Control+Shift" Key="H" Command="{x:Static local:MainWindow.AccelCmd}"

--- a/libs/cua-driver/tests/fixtures/shared/scenarios.json
+++ b/libs/cua-driver/tests/fixtures/shared/scenarios.json
@@ -77,7 +77,7 @@
    {
     "id": "accelerator",
     "kind": "keyboard_accelerator",
-    "description": "Ctrl+Shift+H increments the counter via KeyBinding. Tests press_key / hotkey delivering to background windows.",
+    "description": "Ctrl+Shift+H increments the counter via KeyBinding. Tests foreground letter delivery through press_key / hotkey and background refusal behavior.",
     "controls": {
      "label_aid": "lbl-accel-count"
     },

--- a/libs/cua-driver/tests/fixtures/shared/web/index.html
+++ b/libs/cua-driver/tests/fixtures/shared/web/index.html
@@ -220,7 +220,7 @@
   });
 
   $('keyboard-input').addEventListener('keydown', e => {
-    if (e.ctrlKey && e.shiftKey && e.code === 'Digit7') {
+    if (e.ctrlKey && e.shiftKey && e.code === 'KeyH') {
       $('keyboard-status').textContent = 'key_state=hotkey';
     } else if (e.key === 'Enter') {
       const value = $('keyboard-input').value;


### PR DESCRIPTION
## Summary

- map Windows letter and digit key names directly to their documented virtual-key codes
- keep `VkKeyScanW` as the fallback for other printable characters
- add deterministic coverage for lowercase letters, uppercase letters, digits, and fallback inputs
- exercise letter-key `press_key` delivery in the native WPF harness
- switch the shared Electron/Tauri `hotkey` matrix from a digit chord to `Ctrl+Shift+H`

## Root cause

Both `press_key` and `hotkey` share `key_name_to_vk`. Letters and digits fell through to `VkKeyScanW`, which depends on the current keyboard layout and can return `-1` when no translation is available. Windows defines `A`–`Z` and `0`–`9` virtual-key codes directly, so the advertised alphanumeric vocabulary does not need that layout-dependent lookup.

## Impact

Windows users can send `Ctrl`/`Alt`/`Win` plus letter shortcuts such as Ctrl+A, Ctrl+C, Ctrl+V, and Ctrl+S through both `press_key` and `hotkey`.

Fixes #2526.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p platform-windows`
- `cargo test -p platform-windows --lib` (37 passed)
- `cargo test -p cua-driver --test cross_platform_behavior_test --test harness_wpf_test --no-run`
- canonical Windows unit/compile and GUI harness checks in CI