### PR TITLE
fix(cua-driver): isolate Wayland portal connections

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/health_report.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/health_report.rs
@@ -569,9 +569,18 @@ fn probe_portal_remote_desktop() -> anyhow::Result<bool> {
             })?;
 
         rt.block_on(async {
-            match RemoteDesktop::new().await {
-                Ok(_) => Ok(true),
-                Err(e) => {
+            let probe = tokio::time::timeout(crate::wayland::portal::PROBE_TIMEOUT, async {
+                let connection = crate::wayland::portal::fresh_session_connection().await?;
+                RemoteDesktop::with_connection(connection)
+                    .await
+                    .map_err(anyhow::Error::from)
+            })
+            .await;
+
+            match probe {
+                Err(_) => Err(anyhow::anyhow!("portal RemoteDesktop probe timed out")),
+                Ok(Ok(_)) => Ok(true),
+                Ok(Err(e)) => {
                     let msg = format!("{e}");
                     if msg.contains("ServiceUnknown")
                         || msg.contains("NameHasNoOwner")

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/libei.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/libei.rs
@@ -479,7 +479,8 @@ fn open_eis_context() -> anyhow::Result<(reis::ei::Context, PortalKeepAlive)> {
         .map_err(|e| anyhow::anyhow!("failed to build tokio runtime for ashpd: {e}"))?;
 
     let (fd, proxy, session) = rt.block_on(async {
-        let proxy = RemoteDesktop::new()
+        let connection = super::portal::fresh_session_connection().await?;
+        let proxy = RemoteDesktop::with_connection(connection)
             .await
             .map_err(|e| anyhow::anyhow!("portal RemoteDesktop proxy unreachable: {e}. Install xdg-desktop-portal-gnome / xdg-desktop-portal-kde."))?;
         let session = proxy

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
@@ -14,6 +14,7 @@ pub mod ext_screencopy;
 pub mod ext_toplevel;
 pub mod overlay;
 pub mod persistent_vptr;
+pub(crate) mod portal;
 pub mod portal_screenshot;
 pub mod shell_helper;
 pub mod sway_ipc;

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/portal.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/portal.rs
@@ -1,0 +1,18 @@
+//! Shared xdg-desktop-portal connection helpers.
+//!
+//! ashpd's convenience constructors cache their first session-bus connection
+//! process-wide. That is unsafe for our portal callers because several of them
+//! deliberately use short-lived Tokio runtimes: once the first runtime is
+//! dropped, the cached zbus connection no longer has a running executor and a
+//! later portal call can wait forever. Always give ashpd an explicit
+//! connection whose lifetime is owned by the caller's runtime instead.
+
+use std::time::Duration;
+
+pub(crate) const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+pub(crate) async fn fresh_session_connection() -> anyhow::Result<zbus::Connection> {
+    zbus::Connection::session()
+        .await
+        .map_err(|e| anyhow::anyhow!("xdg-desktop-portal session bus unreachable: {e}"))
+}

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/portal_screenshot.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/portal_screenshot.rs
@@ -41,9 +41,11 @@ fn screenshot_via_portal_blocking() -> anyhow::Result<Vec<u8>> {
         .build()
         .map_err(|e| anyhow::anyhow!("failed to build tokio runtime for ashpd: {e}"))?;
     let uri = rt.block_on(async {
+        let connection = super::portal::fresh_session_connection().await?;
         Screenshot::request()
             .interactive(false)
             .modal(false)
+            .connection(Some(connection))
             .send()
             .await
             .map_err(map_ashpd_err)?
@@ -116,23 +118,25 @@ pub fn probe_portal() -> anyhow::Result<bool> {
         .build()
         .map_err(|e| anyhow::anyhow!("failed to build tokio runtime for ashpd probe: {e}"))?;
     rt.block_on(async {
-        // Cheapest possible probe: open a session bus and check that the
-        // portal name has an owner. We avoid Screenshot::request() because
-        // that would cache a (potentially undesired) consent grant.
-        let conn = zbus::Connection::session()
-            .await
-            .map_err(|e| anyhow::anyhow!("session bus unreachable: {e}"))?;
-        let proxy = zbus::fdo::DBusProxy::new(&conn)
-            .await
-            .map_err(|e| anyhow::anyhow!("dbus proxy creation failed: {e}"))?;
-        let has_owner = proxy
-            .name_has_owner(
-                "org.freedesktop.portal.Desktop"
-                    .try_into()
-                    .map_err(|e| anyhow::anyhow!("bus name parse failed: {e}"))?,
-            )
-            .await
-            .map_err(|e| anyhow::anyhow!("name_has_owner failed: {e}"))?;
-        Ok(has_owner)
+        tokio::time::timeout(super::portal::PROBE_TIMEOUT, async {
+            // Cheapest possible probe: open a session bus and check that the
+            // portal name has an owner. We avoid Screenshot::request() because
+            // that would cache a (potentially undesired) consent grant.
+            let conn = super::portal::fresh_session_connection().await?;
+            let proxy = zbus::fdo::DBusProxy::new(&conn)
+                .await
+                .map_err(|e| anyhow::anyhow!("dbus proxy creation failed: {e}"))?;
+            let has_owner = proxy
+                .name_has_owner(
+                    "org.freedesktop.portal.Desktop"
+                        .try_into()
+                        .map_err(|e| anyhow::anyhow!("bus name parse failed: {e}"))?,
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("name_has_owner failed: {e}"))?;
+            Ok(has_owner)
+        })
+        .await
+        .map_err(|_| anyhow::anyhow!("xdg-desktop-portal availability probe timed out"))?
     })
 }


### PR DESCRIPTION
## Summary

- give each one-shot xdg-desktop-portal operation an explicit runtime-owned D-Bus connection
- keep screenshot and RemoteDesktop probes out of ashpd's process-global connection cache
- bound read-only portal health probes to two seconds
- isolate the long-lived libei portal session on its own explicit connection

## Root cause

The Wayland screenshot path creates a short-lived Tokio runtime, while ashpd's convenience constructors cache their first session-bus connection process-wide. After the first portal screenshot completed and its runtime was dropped, `health_report` could reuse the cached connection without a live executor and wait forever on the consumed request path.

## Impact

`health_report` and downstream doctor calls return after a prior portal screenshot instead of hanging indefinitely on GNOME/Wayland. Other portal workflows no longer inherit a connection created by an unrelated runtime.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p platform-linux` (16 passed)
- `cargo test -p cua-driver-core health_report` (17 passed)
- Linux x86_64 cross-check for `platform-linux` with `portal-input`

A post-merge exact-main interactive Linux/Wayland release flight will run before the patch release.

Fixes #2543