### PR TITLE
fix(cua-driver): declare WinRects support for GNOME Shell 49 and 50

### DIFF
--- a/libs/cua-driver/wayland-helper/winrects@cua/metadata.json
+++ b/libs/cua-driver/wayland-helper/winrects@cua/metadata.json
@@ -1,1 +1,1 @@
-{"uuid":"winrects@cua","name":"WinRects","description":"Expose window geometry, capture, cursor, and verified activation for cua-driver on Wayland.","shell-version":["45","46","47","48"],"version":6}
+{"uuid":"winrects@cua","name":"WinRects","description":"Expose window geometry, capture, cursor, and verified activation for cua-driver on Wayland.","shell-version":["45","46","47","48","49","50"],"version":6}


### PR DESCRIPTION
## Problem

`libs/cua-driver/wayland-helper/winrects@cua/metadata.json` declares
`shell-version: ["45","46","47","48"]`, so GNOME Shell 49 and 50 refuse to load
the helper.

Without the helper, cua-driver has no target-addressable activation adapter on
GNOME and — correctly — refuses foreground dispatch:

```
wayland_backend: The RemoteDesktop portal is reachable, but this compositor has
no verified target-activation adapter (foreign-toplevel=false, screencopy=false,
ext-image-copy=false, ext-output-source=false, virtual-pointer=false,
wl_shm=true). Portal/libei input is global and would otherwise affect whichever
window is focused, potentially the wrong application, so cua-driver refuses
foreground dispatch.
```

That makes Linux input effectively unavailable on current Ubuntu — 26.04 LTS
ships GNOME Shell 50.1.

## Change

Metadata only: `shell-version` gains `"49"` and `"50"`. No code change.

## Verification

The extension was installed **unmodified** (only this metadata line differs) on
Ubuntu 26.04 LTS, GNOME Shell 50.1, Wayland session, with cua-driver 0.12.6.
The full D-Bus surface was exercised:

| Method | Result on Shell 50.1 |
|---|---|
| load | `gnome-extensions info winrects@cua` -> `State: ACTIVE` |
| `GetVersion` | `u 4` |
| `GetRects` | frame + buffer origins, `focused`, `stacking`, `minimized` per window |
| `Capture` | valid PNG via the Shell screenshot API (correct signature, ~1.1 MB base64) |
| `Activate` | activates the target; `bring_to_front` then returns success where it previously failed with the message above |

End-to-end input, which is what the helper exists for:

```
bring_to_front -> type_text -> press_key Return
```

into a **native GTK4 Wayland** `zenity --entry` returned exactly the typed
string via zenity's stdout, layout-correct on a German QWERTZ keymap
(`Y`/`Z` not transposed, `_` correct).

## Note on 49

50.1 is the version actually tested. 49 is included because the APIs the
extension uses are unchanged across 48-50 — the ESM `Extension` class,
`global.get_window_actors`, `global.display.sort_windows_by_stacking`,
`Meta.Window.get_buffer_rect`, `Shell.Screenshot`,
`Main.layoutManager.addTopChrome`, `Gio.DBusExportedObject` — and a gap between
48 and 50 would be arbitrary. Happy to drop `"49"` if you would rather only
declare versions with a test run behind them.