### PR TITLE
ci: allow r33drichards to bump legacy packages

### DIFF
--- a/.github/scripts/tests/test_release_bump_authorization.py
+++ b/.github/scripts/tests/test_release_bump_authorization.py
@@ -21,6 +21,7 @@ class TestReleaseBumpAuthorization(unittest.TestCase):
         self.assertIn('TRIGGERING_ACTOR: ${{ github.triggering_actor }}', workflow)
         self.assertIn(
             '"f-trycua:f-trycua"|'
+            '"r33drichards:r33drichards"|'
             '"cua-release-bot[bot]:cua-release-bot[bot]")',
             workflow,
         )

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -65,7 +65,7 @@ jobs:
           TRIGGERING_ACTOR: ${{ github.triggering_actor }}
         run: |
           case "$ACTOR:$TRIGGERING_ACTOR" in
-            "f-trycua:f-trycua"|"cua-release-bot[bot]:cua-release-bot[bot]")
+            "f-trycua:f-trycua"|"r33drichards:r33drichards"|"cua-release-bot[bot]:cua-release-bot[bot]")
               echo "Version bump authorized for $ACTOR."
               ;;
             *)


### PR DESCRIPTION
## Summary
- Allow `r33drichards` to dispatch the existing legacy package version-bump workflow.
- Preserve the existing `f-trycua` and `cua-release-bot[bot]` authorization paths.

## Validation
- `uvx --from PyYAML==6.0.2 python -` parses `.github/workflows/release-bump-version.yml`
- `npx --yes prettier@3.5.3 --check .github/workflows/release-bump-version.yml`
- `python3 .github/scripts/tests/test_release_bump_authorization.py`