### PR TITLE
feat(fleet): re-export Cua TrainClient

### DIFF
--- a/libs/python/cua-fleet/README.md
+++ b/libs/python/cua-fleet/README.md
@@ -1,21 +1,16 @@
 # cua-fleet
 
-> **Name reservation** — this package name is reserved for **Cua Fleet**, an upcoming
-> component of the [Cua](https://github.com/trycua/cua) project for orchestrating fleets
-> of computer-use agents and sandboxes.
-
-This is a placeholder release: it installs an empty module and has no functionality yet.
-Watch [trycua/cua](https://github.com/trycua/cua) for the first real release.
-
-In the meantime, check out the unified Cua SDK:
+Cua Fleet facade for the [Cua Cloud](https://run.cua.ai) Python SDK.
 
 ```bash
-pip install cua
+pip install cua-fleet
 ```
 
-## Links
+```python
+from cua_fleet import TrainClient
 
-- Website: [cua.ai](https://cua.ai)
-- Documentation: [docs.trycua.com](https://docs.trycua.com)
-- Repository: [github.com/trycua/cua](https://github.com/trycua/cua)
-- Issues: [github.com/trycua/cua/issues](https://github.com/trycua/cua/issues)
+client = TrainClient.from_key(
+    client_id="ukey-...",
+    client_secret="...",
+)
+```

--- a/libs/python/cua-fleet/cua_fleet/__init__.py
+++ b/libs/python/cua-fleet/cua_fleet/__init__.py
@@ -1,13 +1,7 @@
-"""cua-fleet — reserved for Cua Fleet.
+"""Cua Fleet facade for the Cua Cloud Python SDK."""
 
-This package name is reserved for Cua Fleet, an upcoming component of the
-Cua project (https://github.com/trycua/cua) for orchestrating fleets of
-computer-use agents and sandboxes.
+from cua_train import TrainClient
 
-This is a placeholder release with no functionality yet. In the meantime,
-see the unified Cua SDK::
-
-    pip install cua
-"""
+__all__ = ["TrainClient"]
 
 __version__ = "0.0.2"

--- a/libs/python/cua-fleet/pyproject.toml
+++ b/libs/python/cua-fleet/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "cua-fleet"
 version = "0.0.2"
-description = "Reserved for Cua Fleet — fleet orchestration for computer-use agents and sandboxes"
+description = "Cua Fleet facade for the Cua Cloud Python SDK"
 readme = "README.md"
 license = "MIT"
 authors = [
@@ -23,9 +23,9 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
-dependencies = []
+dependencies = ["cua-train>=0.1.2,<0.2.0"]
 
 [project.urls]
 Homepage      = "https://github.com/trycua/cua"

--- a/libs/python/cua-fleet/tests/test_train_facade.py
+++ b/libs/python/cua-fleet/tests/test_train_facade.py
@@ -5,7 +5,6 @@ import sys
 import tomllib
 from pathlib import Path
 
-
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
 REPOSITORY_ROOT = PACKAGE_ROOT.parents[2]
 TRAIN_SOURCE_ROOT = REPOSITORY_ROOT / "libs/python/cua-train/src"

--- a/libs/python/cua-fleet/tests/test_train_facade.py
+++ b/libs/python/cua-fleet/tests/test_train_facade.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import tomllib
+from pathlib import Path
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+REPOSITORY_ROOT = PACKAGE_ROOT.parents[2]
+TRAIN_SOURCE_ROOT = REPOSITORY_ROOT / "libs/python/cua-train/src"
+
+
+def test_package_metadata_requires_compatible_cua_train() -> None:
+    project = tomllib.loads((PACKAGE_ROOT / "pyproject.toml").read_text())["project"]
+
+    assert project["requires-python"] == ">=3.10"
+    assert project["dependencies"] == ["cua-train>=0.1.2,<0.2.0"]
+
+
+def test_cua_fleet_reexports_train_client(monkeypatch) -> None:
+    monkeypatch.syspath_prepend(str(TRAIN_SOURCE_ROOT))
+    monkeypatch.syspath_prepend(str(PACKAGE_ROOT))
+    sys.modules.pop("cua_fleet", None)
+    sys.modules.pop("cua_train", None)
+
+    cua_fleet = importlib.import_module("cua_fleet")
+    cua_train = importlib.import_module("cua_train")
+
+    assert cua_fleet.TrainClient is cua_train.TrainClient
+    assert cua_fleet.__all__ == ["TrainClient"]


### PR DESCRIPTION
## What
- Make the existing `cua-fleet` distribution a minimal static facade over `cua-train`.
- Re-export only `TrainClient` from the existing `cua_fleet` import package.
- Require `cua-train>=0.1.2,<0.2.0` and align the Python floor to 3.10.

## Validation
- `uv run --with pytest --with pytest-asyncio --with ../cua-train pytest -q tests/test_train_facade.py`
- `uvx ruff check tests/test_train_facade.py cua_fleet/__init__.py`
- Built both `cua-train` and `cua-fleet` wheels; verified Fleet wheel `Requires-Dist` metadata.
- Installed both wheels into a fresh virtual environment and verified `cua_fleet.TrainClient is cua_train.TrainClient` and `cua_fleet.__all__ == ["TrainClient"]`.
