### PR TITLE
fix(fleet): pin cua-train to 0.1.1

### DIFF
--- a/libs/python/cua-fleet/pyproject.toml
+++ b/libs/python/cua-fleet/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 
-dependencies = ["cua-train>=0.1.2,<0.2.0"]
+dependencies = ["cua-train==0.1.1"]
 
 [project.urls]
 Homepage      = "https://github.com/trycua/cua"

--- a/libs/python/cua-fleet/tests/test_train_facade.py
+++ b/libs/python/cua-fleet/tests/test_train_facade.py
@@ -10,11 +10,11 @@ REPOSITORY_ROOT = PACKAGE_ROOT.parents[2]
 TRAIN_SOURCE_ROOT = REPOSITORY_ROOT / "libs/python/cua-train/src"
 
 
-def test_package_metadata_requires_compatible_cua_train() -> None:
+def test_package_metadata_pins_binding_bearing_cua_train() -> None:
     project = tomllib.loads((PACKAGE_ROOT / "pyproject.toml").read_text())["project"]
 
     assert project["requires-python"] == ">=3.10"
-    assert project["dependencies"] == ["cua-train>=0.1.2,<0.2.0"]
+    assert project["dependencies"] == ["cua-train==0.1.1"]
 
 
 def test_cua_fleet_reexports_train_client(monkeypatch) -> None:


### PR DESCRIPTION
Pins `cua-fleet` to the binding-bearing `cua-train==0.1.1`, preventing resolution of public `cua-train 0.1.2`, which lacks `cyclops_sdk`.

Validation: focused RED/GREEN facade tests; Ruff lint/format; built-wheel metadata inspection; fresh install of the built Fleet wheel using PyPI plus `https://wheels.cua.ai/simple`, resolving private `cua-train 0.1.1`; real imports of `cyclops_sdk` and the `cua_fleet.TrainClient` facade export.

Release order: a new `cua-fleet` patch release must be published and resolvable before the Sandbox consumer migration (Stage B) can use this correction. Stage B remains blocked. This PR does not modify Sandbox.