### PR TITLE
feat(cua-driver): expose trusted protected-consent hosts

### DIFF
--- a/libs/cua-driver/python/src/cua_driver/__init__.py
+++ b/libs/cua-driver/python/src/cua_driver/__init__.py
@@ -27,6 +27,11 @@ from ._native import (
     ImageContent,
     MacOsPermissionStatus,
     PrivateWorkerOptions,
+    ProtectedConsentAction,
+    ProtectedConsentDecision,
+    ProtectedConsentHost,
+    ProtectedConsentHostError,
+    ProtectedConsentRequest,
     RuntimeAuthorizationOptions,
     SdkClientKind,
     SessionPermissionMode,
@@ -85,6 +90,14 @@ def _create_configured_python_sdk(cls, options):
     return cls.create_configured_with_client_kind(options, SdkClientKind.PYTHON)
 
 
+def _create_configured_with_protected_host_python_sdk(cls, options, host):
+    """Create a trusted protected-host runtime tagged as a Python SDK host."""
+
+    return cls.create_configured_with_protected_host_and_client_kind(
+        options, host, SdkClientKind.PYTHON
+    )
+
+
 def _create_private_worker_python_sdk(cls, options):
     """Create a supervised worker runtime tagged as a Python SDK host."""
 
@@ -94,6 +107,9 @@ def _create_private_worker_python_sdk(cls, options):
 _NativeCuaDriver.connect = classmethod(_connect_python_sdk)
 _NativeCuaDriver.create = classmethod(_create_python_sdk)
 _NativeCuaDriver.create_configured = classmethod(_create_configured_python_sdk)
+_NativeCuaDriver.create_configured_with_protected_host = classmethod(
+    _create_configured_with_protected_host_python_sdk
+)
 _NativeCuaDriver.create_private_worker = classmethod(_create_private_worker_python_sdk)
 CuaDriver = _NativeCuaDriver
 
@@ -135,6 +151,11 @@ __all__ = [
     "MoveCursorInput",
     "Platform",
     "PrivateWorkerOptions",
+    "ProtectedConsentAction",
+    "ProtectedConsentDecision",
+    "ProtectedConsentHost",
+    "ProtectedConsentHostError",
+    "ProtectedConsentRequest",
     "PressKeyInput",
     "RuntimeAuthorizationOptions",
     "ScrollBy",

--- a/libs/cua-driver/python/src/cua_driver/_native.py
+++ b/libs/cua-driver/python/src/cua_driver/_native.py
@@ -498,6 +498,10 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured_with_client_kind() != 23819:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured_with_protected_host() != 2194:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured_with_protected_host_and_client_kind() != 59012:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_private_worker() != 8571:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_private_worker_with_client_kind() != 31571:
@@ -595,6 +599,14 @@ def _uniffi_check_api_checksums(lib):
     if lib.uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_stop() != 28521:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_wait_for_exit() != 21124:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_request_consent() != 10400:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_activate_indicator() != 36476:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_wait_for_indicator_stop() != 15179:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_deactivate_indicator() != 23864:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
 
 # A ctypes library to expose the extern-C FFI definitions.
@@ -889,6 +901,54 @@ _UniffiLib.uniffi_cua_driver_sdk_fn_free_embeddedcuadriverhost.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_cua_driver_sdk_fn_free_embeddedcuadriverhost.restype = None
+_UniffiLib.uniffi_cua_driver_sdk_fn_clone_protectedconsenthost.argtypes = (
+    ctypes.c_uint64,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_cua_driver_sdk_fn_clone_protectedconsenthost.restype = ctypes.c_uint64
+_UniffiLib.uniffi_cua_driver_sdk_fn_free_protectedconsenthost.argtypes = (
+    ctypes.c_uint64,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_cua_driver_sdk_fn_free_protectedconsenthost.restype = None
+class _UniffiForeignFutureResultRustBuffer(ctypes.Structure):
+    _fields_ = [
+        ("return_value", _UniffiRustBuffer),
+        ("call_status", _UniffiRustCallStatus),
+    ]
+_UNIFFI_FOREIGN_FUTURE_COMPLETERUST_BUFFER = ctypes.CFUNCTYPE(None,ctypes.c_uint64,_UniffiForeignFutureResultRustBuffer,
+)
+_UNIFFI_CALLBACK_INTERFACE_CUA_DRIVER_SDK_PROTECTED_CONSENT_HOST_METHOD0 = ctypes.CFUNCTYPE(None,ctypes.c_uint64,_UniffiRustBuffer,_UNIFFI_FOREIGN_FUTURE_COMPLETERUST_BUFFER,ctypes.c_uint64,ctypes.POINTER(_UniffiForeignFutureDroppedCallbackStruct),
+)
+_UNIFFI_CALLBACK_INTERFACE_CUA_DRIVER_SDK_PROTECTED_CONSENT_HOST_METHOD1 = ctypes.CFUNCTYPE(None,ctypes.c_uint64,_UniffiRustBuffer,_UNIFFI_FOREIGN_FUTURE_COMPLETERUST_BUFFER,ctypes.c_uint64,ctypes.POINTER(_UniffiForeignFutureDroppedCallbackStruct),
+)
+class _UniffiForeignFutureResultVoid(ctypes.Structure):
+    _fields_ = [
+        ("call_status", _UniffiRustCallStatus),
+    ]
+_UNIFFI_FOREIGN_FUTURE_COMPLETEVOID = ctypes.CFUNCTYPE(None,ctypes.c_uint64,_UniffiForeignFutureResultVoid,
+)
+_UNIFFI_CALLBACK_INTERFACE_CUA_DRIVER_SDK_PROTECTED_CONSENT_HOST_METHOD2 = ctypes.CFUNCTYPE(None,ctypes.c_uint64,_UniffiRustBuffer,_UNIFFI_FOREIGN_FUTURE_COMPLETEVOID,ctypes.c_uint64,ctypes.POINTER(_UniffiForeignFutureDroppedCallbackStruct),
+)
+_UNIFFI_CALLBACK_INTERFACE_CUA_DRIVER_SDK_PROTECTED_CONSENT_HOST_METHOD3 = ctypes.CFUNCTYPE(None,ctypes.c_uint64,_UniffiRustBuffer,_UNIFFI_FOREIGN_FUTURE_COMPLETEVOID,ctypes.c_uint64,ctypes.POINTER(_UniffiForeignFutureDroppedCallbackStruct),
+)
+_UNIFFI_CALLBACK_INTERFACE_CLONE_CUA_DRIVER_SDK_PROTECTED_CONSENT_HOST = ctypes.CFUNCTYPE(ctypes.c_uint64,ctypes.c_uint64,
+)
+_UNIFFI_CALLBACK_INTERFACE_FREE_CUA_DRIVER_SDK_PROTECTED_CONSENT_HOST = ctypes.CFUNCTYPE(None,ctypes.c_uint64,
+)
+class _UniffiVTableCallbackInterfaceCuaDriverSdkProtectedConsentHost(ctypes.Structure):
+    _fields_ = [
+        ("uniffi_free", _UNIFFI_CALLBACK_INTERFACE_FREE_CUA_DRIVER_SDK_PROTECTED_CONSENT_HOST),
+        ("uniffi_clone", _UNIFFI_CALLBACK_INTERFACE_CLONE_CUA_DRIVER_SDK_PROTECTED_CONSENT_HOST),
+        ("request_consent", _UNIFFI_CALLBACK_INTERFACE_CUA_DRIVER_SDK_PROTECTED_CONSENT_HOST_METHOD0),
+        ("activate_indicator", _UNIFFI_CALLBACK_INTERFACE_CUA_DRIVER_SDK_PROTECTED_CONSENT_HOST_METHOD1),
+        ("wait_for_indicator_stop", _UNIFFI_CALLBACK_INTERFACE_CUA_DRIVER_SDK_PROTECTED_CONSENT_HOST_METHOD2),
+        ("deactivate_indicator", _UNIFFI_CALLBACK_INTERFACE_CUA_DRIVER_SDK_PROTECTED_CONSENT_HOST_METHOD3),
+    ]
+_UniffiLib.uniffi_cua_driver_sdk_fn_init_callback_vtable_protectedconsenthost.argtypes = (
+    ctypes.POINTER(_UniffiVTableCallbackInterfaceCuaDriverSdkProtectedConsentHost),
+)
+_UniffiLib.uniffi_cua_driver_sdk_fn_init_callback_vtable_protectedconsenthost.restype = None
 _UniffiLib.uniffi_cua_driver_sdk_fn_func_create_trusted_session.argtypes = (
     ctypes.c_uint64,
     _UniffiRustBuffer,
@@ -934,6 +994,19 @@ _UniffiLib.uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_configured_with
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_configured_with_client_kind.restype = ctypes.c_uint64
+_UniffiLib.uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_configured_with_protected_host.argtypes = (
+    _UniffiRustBuffer,
+    ctypes.c_uint64,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_configured_with_protected_host.restype = ctypes.c_uint64
+_UniffiLib.uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_configured_with_protected_host_and_client_kind.argtypes = (
+    _UniffiRustBuffer,
+    ctypes.c_uint64,
+    _UniffiRustBuffer,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_configured_with_protected_host_and_client_kind.restype = ctypes.c_uint64
 _UniffiLib.uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_private_worker.argtypes = (
     _UniffiRustBuffer,
     ctypes.POINTER(_UniffiRustCallStatus),
@@ -1178,6 +1251,26 @@ _UniffiLib.uniffi_cua_driver_sdk_fn_method_embeddedcuadriverhost_wait_for_exit.a
     _UniffiRustBuffer,
 )
 _UniffiLib.uniffi_cua_driver_sdk_fn_method_embeddedcuadriverhost_wait_for_exit.restype = ctypes.c_uint64
+_UniffiLib.uniffi_cua_driver_sdk_fn_method_protectedconsenthost_request_consent.argtypes = (
+    ctypes.c_uint64,
+    _UniffiRustBuffer,
+)
+_UniffiLib.uniffi_cua_driver_sdk_fn_method_protectedconsenthost_request_consent.restype = ctypes.c_uint64
+_UniffiLib.uniffi_cua_driver_sdk_fn_method_protectedconsenthost_activate_indicator.argtypes = (
+    ctypes.c_uint64,
+    _UniffiRustBuffer,
+)
+_UniffiLib.uniffi_cua_driver_sdk_fn_method_protectedconsenthost_activate_indicator.restype = ctypes.c_uint64
+_UniffiLib.uniffi_cua_driver_sdk_fn_method_protectedconsenthost_wait_for_indicator_stop.argtypes = (
+    ctypes.c_uint64,
+    _UniffiRustBuffer,
+)
+_UniffiLib.uniffi_cua_driver_sdk_fn_method_protectedconsenthost_wait_for_indicator_stop.restype = ctypes.c_uint64
+_UniffiLib.uniffi_cua_driver_sdk_fn_method_protectedconsenthost_deactivate_indicator.argtypes = (
+    ctypes.c_uint64,
+    _UniffiRustBuffer,
+)
+_UniffiLib.uniffi_cua_driver_sdk_fn_method_protectedconsenthost_deactivate_indicator.restype = ctypes.c_uint64
 _UniffiLib.ffi_cua_driver_sdk_uniffi_contract_version.argtypes = (
 )
 _UniffiLib.ffi_cua_driver_sdk_uniffi_contract_version.restype = ctypes.c_uint32
@@ -1208,6 +1301,12 @@ _UniffiLib.uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configure
 _UniffiLib.uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured_with_client_kind.argtypes = (
 )
 _UniffiLib.uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured_with_client_kind.restype = ctypes.c_uint16
+_UniffiLib.uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured_with_protected_host.argtypes = (
+)
+_UniffiLib.uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured_with_protected_host.restype = ctypes.c_uint16
+_UniffiLib.uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured_with_protected_host_and_client_kind.argtypes = (
+)
+_UniffiLib.uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured_with_protected_host_and_client_kind.restype = ctypes.c_uint16
 _UniffiLib.uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_private_worker.argtypes = (
 )
 _UniffiLib.uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_private_worker.restype = ctypes.c_uint16
@@ -1355,6 +1454,18 @@ _UniffiLib.uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_stop.rest
 _UniffiLib.uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_wait_for_exit.argtypes = (
 )
 _UniffiLib.uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_wait_for_exit.restype = ctypes.c_uint16
+_UniffiLib.uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_request_consent.argtypes = (
+)
+_UniffiLib.uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_request_consent.restype = ctypes.c_uint16
+_UniffiLib.uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_activate_indicator.argtypes = (
+)
+_UniffiLib.uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_activate_indicator.restype = ctypes.c_uint16
+_UniffiLib.uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_wait_for_indicator_stop.argtypes = (
+)
+_UniffiLib.uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_wait_for_indicator_stop.restype = ctypes.c_uint16
+_UniffiLib.uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_deactivate_indicator.argtypes = (
+)
+_UniffiLib.uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_deactivate_indicator.restype = ctypes.c_uint16
 
 _uniffi_check_contract_api_version(_UniffiLib)
 # _uniffi_check_api_checksums(_UniffiLib)
@@ -1422,6 +1533,68 @@ async def _uniffi_rust_call_async(rust_future, ffi_poll, ffi_complete, ffi_free,
         )
     finally:
         ffi_free(rust_future)
+def _uniffi_trait_interface_call_async(make_call, uniffi_out_dropped_callback, handle_success, handle_error):
+    async def make_call_and_call_callback():
+        # Note: it's important we call either `handle_success` or `handle_error` exactly once.  Each
+        # call consumes an Arc reference, which means there should be no possibility of a double
+        # call.  The following code is structured so that will will never call both `handle_success`
+        # and `handle_error`, even in the face of weird exceptions.
+        #
+        # In extreme circumstances we may not call either, for example if we fail to make the ctypes
+        # call to `handle_success`.  This means we will leak the Arc reference, which is better than
+        # double-freeing it.
+        try:
+            call_result = await make_call()
+        except Exception as e:
+            print("UniFFI: Unhandled exception in trait interface call", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
+            handle_error(
+                _UniffiRustCallStatus.CALL_UNEXPECTED_ERROR,
+                _UniffiFfiConverterString.lower(repr(e)),
+            )
+        else:
+            handle_success(call_result)
+    eventloop = _uniffi_get_event_loop()
+    task = asyncio.run_coroutine_threadsafe(make_call_and_call_callback(), eventloop)
+    handle = _UNIFFI_FOREIGN_FUTURE_HANDLE_MAP.insert((eventloop, task))
+    uniffi_out_dropped_callback[0] = _UniffiForeignFutureDroppedCallbackStruct(handle, _uniffi_future_dropped_callback)
+
+def _uniffi_trait_interface_call_async_with_error(make_call, uniffi_out_dropped_callback, handle_success, handle_error, error_type, lower_error):
+    async def make_call_and_call_callback():
+        # See the note in _uniffi_trait_interface_call_async for details on `handle_success` and
+        # `handle_error`.
+        try:
+            try:
+                call_result = await make_call()
+            except error_type as e:
+                handle_error(
+                    _UniffiRustCallStatus.CALL_ERROR,
+                    lower_error(e),
+                )
+            else:
+                handle_success(call_result)
+        except Exception as e:
+            print("UniFFI: Unhandled exception in trait interface call", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
+            handle_error(
+                _UniffiRustCallStatus.CALL_UNEXPECTED_ERROR,
+                _UniffiFfiConverterString.lower(repr(e)),
+            )
+    eventloop = _uniffi_get_event_loop()
+    task = asyncio.run_coroutine_threadsafe(make_call_and_call_callback(), eventloop)
+    handle = _UNIFFI_FOREIGN_FUTURE_HANDLE_MAP.insert((eventloop, task))
+    uniffi_out_dropped_callback[0] = _UniffiForeignFutureDroppedCallbackStruct(handle, _uniffi_future_dropped_callback)
+
+_UNIFFI_FOREIGN_FUTURE_HANDLE_MAP = _UniffiHandleMap()
+
+@_UNIFFI_FOREIGN_FUTURE_DROPPED_CALLBACK
+def _uniffi_future_dropped_callback(handle):
+    (eventloop, task) = _UNIFFI_FOREIGN_FUTURE_HANDLE_MAP.remove(handle)
+    eventloop.call_soon(_uniffi_cancel_task, task)
+
+def _uniffi_cancel_task(task):
+    if not task.done():
+        task.cancel()
 
 # Public interface members begin here.
 
@@ -2423,6 +2596,210 @@ class _UniffiFfiConverterTypePrivateWorkerOptions(_UniffiConverterRustBuffer):
         _UniffiFfiConverterSequenceTypeEmbeddedEnvironmentVariable.write(value.environment, buf)
         _UniffiFfiConverterBoolean.write(value.inherit_stderr, buf)
 
+
+
+
+
+
+class ProtectedConsentAction(enum.Enum):
+
+    ACCEPT = 0
+
+    DECLINE = 1
+
+    CANCEL = 2
+
+
+
+class _UniffiFfiConverterTypeProtectedConsentAction(_UniffiConverterRustBuffer):
+    @staticmethod
+    def read(buf):
+        variant = buf.read_i32()
+        if variant == 1:
+            return ProtectedConsentAction.ACCEPT
+        if variant == 2:
+            return ProtectedConsentAction.DECLINE
+        if variant == 3:
+            return ProtectedConsentAction.CANCEL
+        raise InternalError("Raw enum value doesn't match any cases")
+
+    @staticmethod
+    def check_lower(value):
+        if value == ProtectedConsentAction.ACCEPT:
+            return
+        if value == ProtectedConsentAction.DECLINE:
+            return
+        if value == ProtectedConsentAction.CANCEL:
+            return
+        raise ValueError(value)
+
+    @staticmethod
+    def write(value, buf):
+        if value == ProtectedConsentAction.ACCEPT:
+            buf.write_i32(1)
+        if value == ProtectedConsentAction.DECLINE:
+            buf.write_i32(2)
+        if value == ProtectedConsentAction.CANCEL:
+            buf.write_i32(3)
+
+
+
+@dataclass
+class ProtectedConsentDecision:
+    def __init__(self, *, action:ProtectedConsentAction, request_digest:str):
+        self.action = action
+        self.request_digest = request_digest
+
+
+
+
+    def __str__(self):
+        return "ProtectedConsentDecision(action={}, request_digest={})".format(self.action, self.request_digest)
+    def __eq__(self, other):
+        if self.action != other.action:
+            return False
+        if self.request_digest != other.request_digest:
+            return False
+        return True
+
+class _UniffiFfiConverterTypeProtectedConsentDecision(_UniffiConverterRustBuffer):
+    @staticmethod
+    def read(buf):
+        return ProtectedConsentDecision(
+            action=_UniffiFfiConverterTypeProtectedConsentAction.read(buf),
+            request_digest=_UniffiFfiConverterString.read(buf),
+        )
+
+    @staticmethod
+    def check_lower(value):
+        _UniffiFfiConverterTypeProtectedConsentAction.check_lower(value.action)
+        _UniffiFfiConverterString.check_lower(value.request_digest)
+
+    @staticmethod
+    def write(value, buf):
+        _UniffiFfiConverterTypeProtectedConsentAction.write(value.action, buf)
+        _UniffiFfiConverterString.write(value.request_digest, buf)
+
+@dataclass
+class ProtectedConsentRequest:
+    """
+    Content-bounded request delivered only to trusted host code.
+
+    `resource_json` contains the canonical typed resource identity needed to
+    render the decision. Hosts must not log it or forward it to a model.
+"""
+    def __init__(self, *, schema:str, nonce:str, generation:int, daemon_instance:str, permission_mode:str, managed_policy_sha256:typing.Optional[str], user_policy_sha256:typing.Optional[str], operation:str, risk_class:str, public_session:str, transport_session:str, resource_json:str, human_summary:str, expires_unix_ms:int, request_digest:str):
+        self.schema = schema
+        self.nonce = nonce
+        self.generation = generation
+        self.daemon_instance = daemon_instance
+        self.permission_mode = permission_mode
+        self.managed_policy_sha256 = managed_policy_sha256
+        self.user_policy_sha256 = user_policy_sha256
+        self.operation = operation
+        self.risk_class = risk_class
+        self.public_session = public_session
+        self.transport_session = transport_session
+        self.resource_json = resource_json
+        self.human_summary = human_summary
+        self.expires_unix_ms = expires_unix_ms
+        self.request_digest = request_digest
+
+
+
+
+    def __str__(self):
+        return "ProtectedConsentRequest(schema={}, nonce={}, generation={}, daemon_instance={}, permission_mode={}, managed_policy_sha256={}, user_policy_sha256={}, operation={}, risk_class={}, public_session={}, transport_session={}, resource_json={}, human_summary={}, expires_unix_ms={}, request_digest={})".format(self.schema, self.nonce, self.generation, self.daemon_instance, self.permission_mode, self.managed_policy_sha256, self.user_policy_sha256, self.operation, self.risk_class, self.public_session, self.transport_session, self.resource_json, self.human_summary, self.expires_unix_ms, self.request_digest)
+    def __eq__(self, other):
+        if self.schema != other.schema:
+            return False
+        if self.nonce != other.nonce:
+            return False
+        if self.generation != other.generation:
+            return False
+        if self.daemon_instance != other.daemon_instance:
+            return False
+        if self.permission_mode != other.permission_mode:
+            return False
+        if self.managed_policy_sha256 != other.managed_policy_sha256:
+            return False
+        if self.user_policy_sha256 != other.user_policy_sha256:
+            return False
+        if self.operation != other.operation:
+            return False
+        if self.risk_class != other.risk_class:
+            return False
+        if self.public_session != other.public_session:
+            return False
+        if self.transport_session != other.transport_session:
+            return False
+        if self.resource_json != other.resource_json:
+            return False
+        if self.human_summary != other.human_summary:
+            return False
+        if self.expires_unix_ms != other.expires_unix_ms:
+            return False
+        if self.request_digest != other.request_digest:
+            return False
+        return True
+
+class _UniffiFfiConverterTypeProtectedConsentRequest(_UniffiConverterRustBuffer):
+    @staticmethod
+    def read(buf):
+        return ProtectedConsentRequest(
+            schema=_UniffiFfiConverterString.read(buf),
+            nonce=_UniffiFfiConverterString.read(buf),
+            generation=_UniffiFfiConverterUInt64.read(buf),
+            daemon_instance=_UniffiFfiConverterString.read(buf),
+            permission_mode=_UniffiFfiConverterString.read(buf),
+            managed_policy_sha256=_UniffiFfiConverterOptionalString.read(buf),
+            user_policy_sha256=_UniffiFfiConverterOptionalString.read(buf),
+            operation=_UniffiFfiConverterString.read(buf),
+            risk_class=_UniffiFfiConverterString.read(buf),
+            public_session=_UniffiFfiConverterString.read(buf),
+            transport_session=_UniffiFfiConverterString.read(buf),
+            resource_json=_UniffiFfiConverterString.read(buf),
+            human_summary=_UniffiFfiConverterString.read(buf),
+            expires_unix_ms=_UniffiFfiConverterUInt64.read(buf),
+            request_digest=_UniffiFfiConverterString.read(buf),
+        )
+
+    @staticmethod
+    def check_lower(value):
+        _UniffiFfiConverterString.check_lower(value.schema)
+        _UniffiFfiConverterString.check_lower(value.nonce)
+        _UniffiFfiConverterUInt64.check_lower(value.generation)
+        _UniffiFfiConverterString.check_lower(value.daemon_instance)
+        _UniffiFfiConverterString.check_lower(value.permission_mode)
+        _UniffiFfiConverterOptionalString.check_lower(value.managed_policy_sha256)
+        _UniffiFfiConverterOptionalString.check_lower(value.user_policy_sha256)
+        _UniffiFfiConverterString.check_lower(value.operation)
+        _UniffiFfiConverterString.check_lower(value.risk_class)
+        _UniffiFfiConverterString.check_lower(value.public_session)
+        _UniffiFfiConverterString.check_lower(value.transport_session)
+        _UniffiFfiConverterString.check_lower(value.resource_json)
+        _UniffiFfiConverterString.check_lower(value.human_summary)
+        _UniffiFfiConverterUInt64.check_lower(value.expires_unix_ms)
+        _UniffiFfiConverterString.check_lower(value.request_digest)
+
+    @staticmethod
+    def write(value, buf):
+        _UniffiFfiConverterString.write(value.schema, buf)
+        _UniffiFfiConverterString.write(value.nonce, buf)
+        _UniffiFfiConverterUInt64.write(value.generation, buf)
+        _UniffiFfiConverterString.write(value.daemon_instance, buf)
+        _UniffiFfiConverterString.write(value.permission_mode, buf)
+        _UniffiFfiConverterOptionalString.write(value.managed_policy_sha256, buf)
+        _UniffiFfiConverterOptionalString.write(value.user_policy_sha256, buf)
+        _UniffiFfiConverterString.write(value.operation, buf)
+        _UniffiFfiConverterString.write(value.risk_class, buf)
+        _UniffiFfiConverterString.write(value.public_session, buf)
+        _UniffiFfiConverterString.write(value.transport_session, buf)
+        _UniffiFfiConverterString.write(value.resource_json, buf)
+        _UniffiFfiConverterString.write(value.human_summary, buf)
+        _UniffiFfiConverterUInt64.write(value.expires_unix_ms, buf)
+        _UniffiFfiConverterString.write(value.request_digest, buf)
+
 class _UniffiFfiConverterSequenceTypeImageContent(_UniffiConverterRustBuffer):
     @classmethod
     def check_lower(cls, value):
@@ -3228,6 +3605,59 @@ class _UniffiFfiConverterTypeEmbeddedDriverHostState(_UniffiConverterRustBuffer)
 
 
 
+# ProtectedConsentHostError
+# We want to define each variant as a nested class that's also a subclass,
+# which is tricky in Python.  To accomplish this we're going to create each
+# class separately, then manually add the child classes to the base class's
+# __dict__.  All of this happens in dummy class to avoid polluting the module
+# namespace.
+class ProtectedConsentHostError(Exception):
+    pass
+
+_UniffiTempProtectedConsentHostError = ProtectedConsentHostError
+
+class ProtectedConsentHostError:  # type: ignore
+
+    class Failed(_UniffiTempProtectedConsentHostError):
+
+        def __init__(self, reason):
+            super().__init__(", ".join([
+                "reason={!r}".format(reason),
+            ]))
+            self.reason = reason
+
+        def __repr__(self):
+            return "ProtectedConsentHostError.Failed({})".format(str(self))
+    _UniffiTempProtectedConsentHostError.Failed = Failed # type: ignore
+
+ProtectedConsentHostError = _UniffiTempProtectedConsentHostError # type: ignore
+del _UniffiTempProtectedConsentHostError
+
+
+class _UniffiFfiConverterTypeProtectedConsentHostError(_UniffiConverterRustBuffer):
+    @staticmethod
+    def read(buf):
+        variant = buf.read_i32()
+        if variant == 1:
+            return ProtectedConsentHostError.Failed(
+                _UniffiFfiConverterString.read(buf),
+            )
+        raise InternalError("Raw enum value doesn't match any cases")
+
+    @staticmethod
+    def check_lower(value):
+        if isinstance(value, ProtectedConsentHostError.Failed):
+            _UniffiFfiConverterString.check_lower(value.reason)
+            return
+
+    @staticmethod
+    def write(value, buf):
+        if isinstance(value, ProtectedConsentHostError.Failed):
+            buf.write_i32(1)
+            _UniffiFfiConverterString.write(value.reason, buf)
+
+
+
 
 
 
@@ -3470,6 +3900,56 @@ class CuaDriver(CuaDriverProtocol):
         _uniffi_ffi_result = _uniffi_rust_call_with_error(
             _uniffi_error_converter,
             _UniffiLib.uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_configured_with_client_kind,
+            *_uniffi_lowered_args,
+        )
+        return cls._uniffi_make_instance(_uniffi_ffi_result)
+    @classmethod
+    def create_configured_with_protected_host(cls, options: ConfiguredDriverOptions,host: ProtectedConsentHost) -> CuaDriver:
+        """
+        Create a configured same-process runtime with protected approval and
+        persistent Stop UI supplied by trusted embedding-host code.
+
+        The callback object is immutable runtime configuration. Applications
+        must not expose it to an agent or implement it using ordinary MCP
+        elicitation, model-visible stdio, or an auto-accepting callback.
+"""
+
+        _UniffiFfiConverterTypeConfiguredDriverOptions.check_lower(options)
+
+        _UniffiFfiConverterTypeProtectedConsentHost.check_lower(host)
+        _uniffi_lowered_args = (
+            _UniffiFfiConverterTypeConfiguredDriverOptions.lower(options),
+            _UniffiFfiConverterTypeProtectedConsentHost.lower(host),
+        )
+        _uniffi_lift_return = _UniffiFfiConverterTypeCuaDriver.lift
+        _uniffi_error_converter = _UniffiFfiConverterTypeDriverError
+        _uniffi_ffi_result = _uniffi_rust_call_with_error(
+            _uniffi_error_converter,
+            _UniffiLib.uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_configured_with_protected_host,
+            *_uniffi_lowered_args,
+        )
+        return cls._uniffi_make_instance(_uniffi_ffi_result)
+    @classmethod
+    def create_configured_with_protected_host_and_client_kind(cls, options: ConfiguredDriverOptions,host: ProtectedConsentHost,client_kind: SdkClientKind) -> CuaDriver:
+        """
+        Language-package entry point for a configured protected-host runtime.
+"""
+
+        _UniffiFfiConverterTypeConfiguredDriverOptions.check_lower(options)
+
+        _UniffiFfiConverterTypeProtectedConsentHost.check_lower(host)
+
+        _UniffiFfiConverterTypeSdkClientKind.check_lower(client_kind)
+        _uniffi_lowered_args = (
+            _UniffiFfiConverterTypeConfiguredDriverOptions.lower(options),
+            _UniffiFfiConverterTypeProtectedConsentHost.lower(host),
+            _UniffiFfiConverterTypeSdkClientKind.lower(client_kind),
+        )
+        _uniffi_lift_return = _UniffiFfiConverterTypeCuaDriver.lift
+        _uniffi_error_converter = _UniffiFfiConverterTypeDriverError
+        _uniffi_ffi_result = _uniffi_rust_call_with_error(
+            _uniffi_error_converter,
+            _UniffiLib.uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_configured_with_protected_host_and_client_kind,
             *_uniffi_lowered_args,
         )
         return cls._uniffi_make_instance(_uniffi_ffi_result)
@@ -4533,6 +5013,343 @@ class _UniffiFfiConverterTypeEmbeddedCuaDriverHost:
     def write(cls, value: EmbeddedCuaDriverHost, buf: _UniffiRustBuffer):
         buf.write_u64(cls.lower(value))
 
+
+class ProtectedConsentHost():
+    """
+    Callback contract implemented by a trusted embedding application.
+
+    The host must render approval and persistent Stop state outside the
+    model/tool channel. Returning from `wait_for_indicator_stop` means Stop was
+    activated; returning an error also fails closed and revokes the grant.
+"""
+
+    async def request_consent(self, request: ProtectedConsentRequest) -> ProtectedConsentDecision:
+        raise NotImplementedError
+    async def activate_indicator(self, request: ProtectedConsentRequest) -> str:
+        raise NotImplementedError
+    async def wait_for_indicator_stop(self, indicator_id: str) -> None:
+        raise NotImplementedError
+    async def deactivate_indicator(self, indicator_id: str) -> None:
+        raise NotImplementedError
+
+class ProtectedConsentHostImpl(ProtectedConsentHost):
+    """
+    Callback contract implemented by a trusted embedding application.
+
+    The host must render approval and persistent Stop state outside the
+    model/tool channel. Returning from `wait_for_indicator_stop` means Stop was
+    activated; returning an error also fails closed and revokes the grant.
+"""
+
+    _handle: ctypes.c_uint64
+
+    def __init__(self, *args, **kwargs):
+        raise ValueError("This class has no default constructor")
+
+    def __del__(self):
+        # In case of partial initialization of instances.
+        handle = getattr(self, "_handle", None)
+        if handle is not None:
+            _uniffi_rust_call(_UniffiLib.uniffi_cua_driver_sdk_fn_free_protectedconsenthost, handle)
+
+    def _uniffi_clone_handle(self):
+        return _uniffi_rust_call(_UniffiLib.uniffi_cua_driver_sdk_fn_clone_protectedconsenthost, self._handle)
+
+    # Used by alternative constructors or any methods which return this type.
+    @classmethod
+    def _uniffi_make_instance(cls, handle):
+        # Lightly yucky way to bypass the usual __init__ logic
+        # and just create a new instance with the required handle.
+        inst = cls.__new__(cls)
+        inst._handle = handle
+        return inst
+    async def request_consent(self, request: ProtectedConsentRequest) -> ProtectedConsentDecision:
+
+        _UniffiFfiConverterTypeProtectedConsentRequest.check_lower(request)
+        _uniffi_lowered_args = (
+            self._uniffi_clone_handle(),
+            _UniffiFfiConverterTypeProtectedConsentRequest.lower(request),
+        )
+        _uniffi_lift_return = _UniffiFfiConverterTypeProtectedConsentDecision.lift
+        _uniffi_error_converter = _UniffiFfiConverterTypeProtectedConsentHostError
+        return await _uniffi_rust_call_async(
+            _UniffiLib.uniffi_cua_driver_sdk_fn_method_protectedconsenthost_request_consent(*_uniffi_lowered_args),
+            _UniffiLib.ffi_cua_driver_sdk_rust_future_poll_rust_buffer,
+            _UniffiLib.ffi_cua_driver_sdk_rust_future_complete_rust_buffer,
+            _UniffiLib.ffi_cua_driver_sdk_rust_future_free_rust_buffer,
+            _uniffi_lift_return,
+            _uniffi_error_converter,
+        )
+    async def activate_indicator(self, request: ProtectedConsentRequest) -> str:
+
+        _UniffiFfiConverterTypeProtectedConsentRequest.check_lower(request)
+        _uniffi_lowered_args = (
+            self._uniffi_clone_handle(),
+            _UniffiFfiConverterTypeProtectedConsentRequest.lower(request),
+        )
+        _uniffi_lift_return = _UniffiFfiConverterString.lift
+        _uniffi_error_converter = _UniffiFfiConverterTypeProtectedConsentHostError
+        return await _uniffi_rust_call_async(
+            _UniffiLib.uniffi_cua_driver_sdk_fn_method_protectedconsenthost_activate_indicator(*_uniffi_lowered_args),
+            _UniffiLib.ffi_cua_driver_sdk_rust_future_poll_rust_buffer,
+            _UniffiLib.ffi_cua_driver_sdk_rust_future_complete_rust_buffer,
+            _UniffiLib.ffi_cua_driver_sdk_rust_future_free_rust_buffer,
+            _uniffi_lift_return,
+            _uniffi_error_converter,
+        )
+    async def wait_for_indicator_stop(self, indicator_id: str) -> None:
+
+        _UniffiFfiConverterString.check_lower(indicator_id)
+        _uniffi_lowered_args = (
+            self._uniffi_clone_handle(),
+            _UniffiFfiConverterString.lower(indicator_id),
+        )
+        _uniffi_lift_return = lambda val: None
+        _uniffi_error_converter = _UniffiFfiConverterTypeProtectedConsentHostError
+        return await _uniffi_rust_call_async(
+            _UniffiLib.uniffi_cua_driver_sdk_fn_method_protectedconsenthost_wait_for_indicator_stop(*_uniffi_lowered_args),
+            _UniffiLib.ffi_cua_driver_sdk_rust_future_poll_void,
+            _UniffiLib.ffi_cua_driver_sdk_rust_future_complete_void,
+            _UniffiLib.ffi_cua_driver_sdk_rust_future_free_void,
+            _uniffi_lift_return,
+            _uniffi_error_converter,
+        )
+    async def deactivate_indicator(self, indicator_id: str) -> None:
+
+        _UniffiFfiConverterString.check_lower(indicator_id)
+        _uniffi_lowered_args = (
+            self._uniffi_clone_handle(),
+            _UniffiFfiConverterString.lower(indicator_id),
+        )
+        _uniffi_lift_return = lambda val: None
+        _uniffi_error_converter = _UniffiFfiConverterTypeProtectedConsentHostError
+        return await _uniffi_rust_call_async(
+            _UniffiLib.uniffi_cua_driver_sdk_fn_method_protectedconsenthost_deactivate_indicator(*_uniffi_lowered_args),
+            _UniffiLib.ffi_cua_driver_sdk_rust_future_poll_void,
+            _UniffiLib.ffi_cua_driver_sdk_rust_future_complete_void,
+            _UniffiLib.ffi_cua_driver_sdk_rust_future_free_void,
+            _uniffi_lift_return,
+            _uniffi_error_converter,
+        )
+
+
+
+
+# Put all the bits inside a class to keep the top-level namespace clean
+class _UniffiTraitImplProtectedConsentHostImpl:
+    # For each method, generate a callback function to pass to Rust
+
+    @_UNIFFI_CALLBACK_INTERFACE_CUA_DRIVER_SDK_PROTECTED_CONSENT_HOST_METHOD0
+    def request_consent(
+            uniffi_handle,
+            request,
+            uniffi_future_callback,
+            uniffi_callback_data,
+            uniffi_out_dropped_callback,
+        ):
+        uniffi_obj = _UniffiFfiConverterTypeProtectedConsentHost._handle_map.get(uniffi_handle)
+        def make_call():
+            uniffi_args = (_UniffiFfiConverterTypeProtectedConsentRequest.lift(request), )
+            uniffi_method = uniffi_obj.request_consent
+            return uniffi_method(*uniffi_args)
+        def handle_success(return_value):
+            uniffi_future_callback(
+                uniffi_callback_data,
+                _UniffiForeignFutureResultRustBuffer(
+                    _UniffiFfiConverterTypeProtectedConsentDecision.lower(return_value),
+                    _UniffiRustCallStatus.default()
+                )
+            )
+
+        def handle_error(status_code, rust_buffer):
+            uniffi_future_callback(
+                uniffi_callback_data,
+                _UniffiForeignFutureResultRustBuffer(
+                    _UniffiRustBuffer.default(),
+                    _UniffiRustCallStatus(status_code, rust_buffer),
+                )
+            )
+        _uniffi_trait_interface_call_async_with_error(
+            make_call,
+            uniffi_out_dropped_callback,
+            handle_success,
+            handle_error,
+            ProtectedConsentHostError,
+            _UniffiFfiConverterTypeProtectedConsentHostError.lower,
+        )
+
+    @_UNIFFI_CALLBACK_INTERFACE_CUA_DRIVER_SDK_PROTECTED_CONSENT_HOST_METHOD1
+    def activate_indicator(
+            uniffi_handle,
+            request,
+            uniffi_future_callback,
+            uniffi_callback_data,
+            uniffi_out_dropped_callback,
+        ):
+        uniffi_obj = _UniffiFfiConverterTypeProtectedConsentHost._handle_map.get(uniffi_handle)
+        def make_call():
+            uniffi_args = (_UniffiFfiConverterTypeProtectedConsentRequest.lift(request), )
+            uniffi_method = uniffi_obj.activate_indicator
+            return uniffi_method(*uniffi_args)
+        def handle_success(return_value):
+            uniffi_future_callback(
+                uniffi_callback_data,
+                _UniffiForeignFutureResultRustBuffer(
+                    _UniffiFfiConverterString.lower(return_value),
+                    _UniffiRustCallStatus.default()
+                )
+            )
+
+        def handle_error(status_code, rust_buffer):
+            uniffi_future_callback(
+                uniffi_callback_data,
+                _UniffiForeignFutureResultRustBuffer(
+                    _UniffiRustBuffer.default(),
+                    _UniffiRustCallStatus(status_code, rust_buffer),
+                )
+            )
+        _uniffi_trait_interface_call_async_with_error(
+            make_call,
+            uniffi_out_dropped_callback,
+            handle_success,
+            handle_error,
+            ProtectedConsentHostError,
+            _UniffiFfiConverterTypeProtectedConsentHostError.lower,
+        )
+
+    @_UNIFFI_CALLBACK_INTERFACE_CUA_DRIVER_SDK_PROTECTED_CONSENT_HOST_METHOD2
+    def wait_for_indicator_stop(
+            uniffi_handle,
+            indicator_id,
+            uniffi_future_callback,
+            uniffi_callback_data,
+            uniffi_out_dropped_callback,
+        ):
+        uniffi_obj = _UniffiFfiConverterTypeProtectedConsentHost._handle_map.get(uniffi_handle)
+        def make_call():
+            uniffi_args = (_UniffiFfiConverterString.lift(indicator_id), )
+            uniffi_method = uniffi_obj.wait_for_indicator_stop
+            return uniffi_method(*uniffi_args)
+        def handle_success(return_value):
+            uniffi_future_callback(
+                uniffi_callback_data,
+                _UniffiForeignFutureResultVoid(
+                    _UniffiRustCallStatus.default()
+                )
+            )
+
+        def handle_error(status_code, rust_buffer):
+            uniffi_future_callback(
+                uniffi_callback_data,
+                _UniffiForeignFutureResultVoid(
+                    _UniffiRustCallStatus(status_code, rust_buffer),
+                )
+            )
+        _uniffi_trait_interface_call_async_with_error(
+            make_call,
+            uniffi_out_dropped_callback,
+            handle_success,
+            handle_error,
+            ProtectedConsentHostError,
+            _UniffiFfiConverterTypeProtectedConsentHostError.lower,
+        )
+
+    @_UNIFFI_CALLBACK_INTERFACE_CUA_DRIVER_SDK_PROTECTED_CONSENT_HOST_METHOD3
+    def deactivate_indicator(
+            uniffi_handle,
+            indicator_id,
+            uniffi_future_callback,
+            uniffi_callback_data,
+            uniffi_out_dropped_callback,
+        ):
+        uniffi_obj = _UniffiFfiConverterTypeProtectedConsentHost._handle_map.get(uniffi_handle)
+        def make_call():
+            uniffi_args = (_UniffiFfiConverterString.lift(indicator_id), )
+            uniffi_method = uniffi_obj.deactivate_indicator
+            return uniffi_method(*uniffi_args)
+        def handle_success(return_value):
+            uniffi_future_callback(
+                uniffi_callback_data,
+                _UniffiForeignFutureResultVoid(
+                    _UniffiRustCallStatus.default()
+                )
+            )
+
+        def handle_error(status_code, rust_buffer):
+            uniffi_future_callback(
+                uniffi_callback_data,
+                _UniffiForeignFutureResultVoid(
+                    _UniffiRustCallStatus(status_code, rust_buffer),
+                )
+            )
+        _uniffi_trait_interface_call_async_with_error(
+            make_call,
+            uniffi_out_dropped_callback,
+            handle_success,
+            handle_error,
+            ProtectedConsentHostError,
+            _UniffiFfiConverterTypeProtectedConsentHostError.lower,
+        )
+
+    @_UNIFFI_CALLBACK_INTERFACE_FREE_CUA_DRIVER_SDK_PROTECTED_CONSENT_HOST
+    def _uniffi_free(uniffi_handle):
+        _UniffiFfiConverterTypeProtectedConsentHost._handle_map.remove(uniffi_handle)
+
+    @_UNIFFI_CALLBACK_INTERFACE_CLONE_CUA_DRIVER_SDK_PROTECTED_CONSENT_HOST
+    def _uniffi_clone(uniffi_handle):
+        return _UniffiFfiConverterTypeProtectedConsentHost._handle_map.clone(uniffi_handle)
+
+    # Generate the FFI VTable.  This has a field for each callback interface method.
+    _uniffi_vtable = _UniffiVTableCallbackInterfaceCuaDriverSdkProtectedConsentHost(
+        _uniffi_free,
+        _uniffi_clone,
+        request_consent,
+        activate_indicator,
+        wait_for_indicator_stop,
+        deactivate_indicator,
+    )
+    # Send Rust a pointer to the VTable.  Note: this means we need to keep the struct alive forever,
+    # or else bad things will happen when Rust tries to access it.
+    _UniffiLib.uniffi_cua_driver_sdk_fn_init_callback_vtable_protectedconsenthost(ctypes.byref(_uniffi_vtable))
+
+class _UniffiFfiConverterTypeProtectedConsentHost:
+    _handle_map = _UniffiHandleMap()
+
+    @staticmethod
+    def lift(value: int):
+        if (value & 1) == 0:
+            # Rust-generated handle, construct a new class that uses the handle to implement the
+            # interface
+            return ProtectedConsentHostImpl._uniffi_make_instance(value)
+        else:
+            # Python-generated handle, get the object from the handle map
+            return _UniffiFfiConverterTypeProtectedConsentHost._handle_map.remove(value)
+
+    @staticmethod
+    def check_lower(value: ProtectedConsentHost):
+        if not isinstance(value, ProtectedConsentHost):
+            raise TypeError("Expected ProtectedConsentHost subclass, {} found".format(type(value).__name__))
+
+    @staticmethod
+    def lower(value: ProtectedConsentHost):
+         if isinstance(value, ProtectedConsentHostImpl):
+            # Rust-implementated object.  Clone the handle and return it
+            return value._uniffi_clone_handle()
+         else:
+            # Python-implementated object, generate a new vtable handle and return that.
+            return _UniffiFfiConverterTypeProtectedConsentHost._handle_map.insert(value)
+
+    @classmethod
+    def read(cls, buf: _UniffiRustBuffer):
+        ptr = buf.read_u64()
+        if ptr == 0:
+            raise InternalError("Raw handle value was null")
+        return cls.lift(ptr)
+
+    @classmethod
+    def write(cls, value: ProtectedConsentHost, buf: _UniffiRustBuffer):
+        buf.write_u64(cls.lower(value))
+
 class _UniffiFfiConverterUInt8(_UniffiConverterPrimitiveInt):
     CLASS_NAME = "u8"
     VALUE_MIN = 0
@@ -4632,11 +5449,13 @@ __all__ = [
     "InternalError",
     "SessionPermissionMode",
     "EmbeddedPermissionMode",
+    "ProtectedConsentAction",
     "ActionCompletion",
     "DriverError",
     "DriverExecutionMode",
     "EmbeddedDriverError",
     "EmbeddedDriverHostState",
+    "ProtectedConsentHostError",
     "SdkClientKind",
     "RuntimeAuthorizationOptions",
     "ConfiguredDriverOptions",
@@ -4650,6 +5469,8 @@ __all__ = [
     "ImageContent",
     "MacOsPermissionStatus",
     "PrivateWorkerOptions",
+    "ProtectedConsentDecision",
+    "ProtectedConsentRequest",
     "ToolResult",
     "TrustedSessionOptions",
     "create_trusted_session",
@@ -4662,4 +5483,6 @@ __all__ = [
     "CuaDriverSessionProtocol",
     "EmbeddedCuaDriverHost",
     "EmbeddedCuaDriverHostProtocol",
+    "ProtectedConsentHostImpl",
+    "ProtectedConsentHost",
 ]

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/authorization.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/authorization.rs
@@ -84,6 +84,34 @@ pub struct EnforcementAdapterDescriptor {
     pub revocation_triggers: &'static [&'static str],
     pub refusal_code: Option<&'static str>,
     pub provider_requirement: &'static str,
+    /// Mode-specific truth. `state` remains the standard-mode value for
+    /// backward-compatible inventory consumers.
+    pub enforcement_by_mode: AdapterEnforcement,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct AdapterEnforcement {
+    pub standard: RiskEnforcement,
+    pub bounded: RiskEnforcement,
+    pub unrestricted: RiskEnforcement,
+}
+
+impl AdapterEnforcement {
+    pub const fn uniform(state: RiskEnforcement) -> Self {
+        Self {
+            standard: state,
+            bounded: state,
+            unrestricted: state,
+        }
+    }
+
+    pub const fn for_mode(self, mode: PermissionMode) -> RiskEnforcement {
+        match mode {
+            PermissionMode::Standard => self.standard,
+            PermissionMode::Bounded => self.bounded,
+            PermissionMode::Unrestricted => self.unrestricted,
+        }
+    }
 }
 
 const EXISTING_PROFILE_OPERATIONS: &[&str] = &["browser_prepare[strategy.kind=existing_profile]"];
@@ -113,13 +141,31 @@ const EXISTING_PROFILE_REVOCATION: &[&str] = &[
 ];
 
 const PRIVATE_OBSERVATION_OPERATIONS: &[&str] = &[
-    "get_desktop_state[without_file_output]",
+    "get_desktop_state",
     "get_accessibility_tree",
-    "get_window_state[without_file_output]",
+    "get_window_state",
+    "list_apps",
+    "list_windows",
+    "debug_window_info",
+    "get_browser_state",
+    "browser_dialog[action=inspect]",
     "page[action=get_text|query_dom]",
+    "escalate_session",
+    "zoom",
+    "start_recording",
 ];
-const PRIVATE_OBSERVATION_SCOPE_KEYS: &[&str] =
-    &["public_session", "pid", "window_id", "display_generation"];
+const PRIVATE_OBSERVATION_SCOPE_KEYS: &[&str] = &[
+    "daemon_generation",
+    "public_session",
+    "pid",
+    "process_fingerprint",
+    "window_id",
+    "display_generation",
+    "capture_scope",
+    "permission_mode",
+    "managed_policy_sha256",
+    "user_policy_sha256",
+];
 
 const DESKTOP_INPUT_OPERATIONS: &[&str] = &[
     "click",
@@ -132,6 +178,7 @@ const DESKTOP_INPUT_OPERATIONS: &[&str] = &[
     "mouse_button_up",
     "mouse_drag",
     "parallel_mouse_drag",
+    "replay_trajectory",
     "type_text",
     "type_text_chars",
     "press_key",
@@ -140,11 +187,16 @@ const DESKTOP_INPUT_OPERATIONS: &[&str] = &[
     "bring_to_front",
 ];
 const DESKTOP_INPUT_SCOPE_KEYS: &[&str] = &[
+    "daemon_generation",
     "public_session",
     "pid",
+    "process_fingerprint",
     "window_id",
     "display_generation",
     "delivery_mode_ceiling",
+    "permission_mode",
+    "managed_policy_sha256",
+    "user_policy_sha256",
 ];
 
 const FILE_TRANSFER_OPERATIONS: &[&str] = &[
@@ -152,21 +204,72 @@ const FILE_TRANSFER_OPERATIONS: &[&str] = &[
     "browser_download",
     "get_desktop_state[with_file_output]",
     "get_window_state[with_file_output]",
+    "start_recording",
+    "stop_recording",
+    "replay_trajectory",
+    "install_ffmpeg",
 ];
 const FILE_TRANSFER_SCOPE_KEYS: &[&str] = &[
+    "daemon_generation",
     "public_session",
     "browser_binding",
     "tab",
     "canonical_path",
     "destination_class",
+    "direction",
+    "permission_mode",
+    "managed_policy_sha256",
+    "user_policy_sha256",
 ];
 
 const CONSEQUENTIAL_OPERATIONS: &[&str] = &[
     "browser_dialog[action=accept|dismiss]",
     "page[action!=get_text|query_dom]",
 ];
-const CONSEQUENTIAL_SCOPE_KEYS: &[&str] =
-    &["public_session", "browser_binding", "tab", "action_kind"];
+const CONSEQUENTIAL_SCOPE_KEYS: &[&str] = &[
+    "daemon_generation",
+    "public_session",
+    "browser_binding",
+    "tab",
+    "origin",
+    "action_kind",
+    "permission_mode",
+    "managed_policy_sha256",
+    "user_policy_sha256",
+];
+
+const UNBOUNDED_SCRIPT_OPERATIONS: &[&str] = &["page[action=execute_javascript]"];
+
+const BROWSER_BOUND_INPUT_OPERATIONS: &[&str] = &[
+    "browser_navigate",
+    "browser_click",
+    "browser_type",
+    "browser_pointer",
+];
+const BROWSER_BOUND_INPUT_SCOPE_KEYS: &[&str] = &[
+    "daemon_generation",
+    "public_session",
+    "browser_binding",
+    "tab",
+    "origin",
+    "permission_mode",
+    "managed_policy_sha256",
+    "user_policy_sha256",
+];
+
+const PROCESS_CONTROL_OPERATIONS: &[&str] = &["kill_app"];
+const PROCESS_CONTROL_SCOPE_KEYS: &[&str] = &[
+    "daemon_generation",
+    "public_session",
+    "pid",
+    "process_fingerprint",
+    "permission_mode",
+    "managed_policy_sha256",
+    "user_policy_sha256",
+];
+
+const OS_PERMISSION_PROMPT_OPERATIONS: &[&str] = &["check_permissions[prompt=true]"];
+const DRIVER_CONFIGURATION_OPERATIONS: &[&str] = &["set_config"];
 
 const SESSION_REVOCATION: &[&str] = &[
     "indicator_stop",
@@ -193,6 +296,7 @@ pub const ENFORCEMENT_ADAPTERS: &[EnforcementAdapterDescriptor] = &[
         refusal_code: Some("browser_consent_required"),
         provider_requirement:
             "protected_consent_in_standard; protected_indicator_in_bounded; none_in_unrestricted",
+        enforcement_by_mode: AdapterEnforcement::uniform(RiskEnforcement::Active),
     },
     EnforcementAdapterDescriptor {
         id: "private_observation",
@@ -208,6 +312,7 @@ pub const ENFORCEMENT_ADAPTERS: &[EnforcementAdapterDescriptor] = &[
         revocation_triggers: SESSION_REVOCATION,
         refusal_code: None,
         provider_requirement: "certified_protected_host_not_implemented",
+        enforcement_by_mode: AdapterEnforcement::uniform(RiskEnforcement::MetadataOnly),
     },
     EnforcementAdapterDescriptor {
         id: "desktop_input",
@@ -223,6 +328,7 @@ pub const ENFORCEMENT_ADAPTERS: &[EnforcementAdapterDescriptor] = &[
         revocation_triggers: SESSION_REVOCATION,
         refusal_code: None,
         provider_requirement: "certified_protected_host_not_implemented",
+        enforcement_by_mode: AdapterEnforcement::uniform(RiskEnforcement::MetadataOnly),
     },
     EnforcementAdapterDescriptor {
         id: "file_transfer_and_output",
@@ -238,6 +344,7 @@ pub const ENFORCEMENT_ADAPTERS: &[EnforcementAdapterDescriptor] = &[
         revocation_triggers: SESSION_REVOCATION,
         refusal_code: None,
         provider_requirement: "certified_protected_host_not_implemented",
+        enforcement_by_mode: AdapterEnforcement::uniform(RiskEnforcement::MetadataOnly),
     },
     EnforcementAdapterDescriptor {
         id: "browser_consequential_action",
@@ -253,6 +360,108 @@ pub const ENFORCEMENT_ADAPTERS: &[EnforcementAdapterDescriptor] = &[
         revocation_triggers: SESSION_REVOCATION,
         refusal_code: None,
         provider_requirement: "certified_protected_host_not_implemented",
+        enforcement_by_mode: AdapterEnforcement::uniform(RiskEnforcement::MetadataOnly),
+    },
+    EnforcementAdapterDescriptor {
+        id: "browser_unbounded_script",
+        operations: UNBOUNDED_SCRIPT_OPERATIONS,
+        state: RiskEnforcement::MetadataOnly,
+        risk_class: RiskClass::R3,
+        resource_kind: "unbounded_authenticated_page_script",
+        scope_keys: &[],
+        grant_type: None,
+        idle_ttl_seconds: None,
+        absolute_ttl_seconds: None,
+        indicator_requirement: "not_grantable_in_standard_or_bounded",
+        revocation_triggers: &[],
+        refusal_code: None,
+        provider_requirement: "typed_bounded_adapter_required_before_activation",
+        enforcement_by_mode: AdapterEnforcement::uniform(RiskEnforcement::MetadataOnly),
+    },
+    EnforcementAdapterDescriptor {
+        id: "browser_bound_input",
+        operations: BROWSER_BOUND_INPUT_OPERATIONS,
+        state: RiskEnforcement::MetadataOnly,
+        risk_class: RiskClass::R2,
+        resource_kind: "authenticated_browser_binding_and_tab_input",
+        scope_keys: BROWSER_BOUND_INPUT_SCOPE_KEYS,
+        grant_type: None,
+        idle_ttl_seconds: None,
+        absolute_ttl_seconds: None,
+        indicator_requirement: "not_implemented",
+        revocation_triggers: SESSION_REVOCATION,
+        refusal_code: None,
+        provider_requirement: "certified_protected_host_not_implemented",
+        enforcement_by_mode: AdapterEnforcement::uniform(RiskEnforcement::MetadataOnly),
+    },
+    EnforcementAdapterDescriptor {
+        id: "process_control",
+        operations: PROCESS_CONTROL_OPERATIONS,
+        state: RiskEnforcement::MetadataOnly,
+        risk_class: RiskClass::R3,
+        resource_kind: "exact_process_termination",
+        scope_keys: PROCESS_CONTROL_SCOPE_KEYS,
+        grant_type: None,
+        idle_ttl_seconds: None,
+        absolute_ttl_seconds: None,
+        indicator_requirement: "not_implemented",
+        revocation_triggers: SESSION_REVOCATION,
+        refusal_code: None,
+        provider_requirement: "certified_protected_host_not_implemented",
+        enforcement_by_mode: AdapterEnforcement::uniform(RiskEnforcement::MetadataOnly),
+    },
+    EnforcementAdapterDescriptor {
+        id: "os_permission_prompt",
+        operations: OS_PERMISSION_PROMPT_OPERATIONS,
+        state: RiskEnforcement::MetadataOnly,
+        risk_class: RiskClass::R2,
+        resource_kind: "operating_system_permission_prompt",
+        scope_keys: &["daemon_generation", "permission_mode"],
+        grant_type: None,
+        idle_ttl_seconds: None,
+        absolute_ttl_seconds: None,
+        indicator_requirement: "never_agent_controllable",
+        revocation_triggers: &[],
+        refusal_code: None,
+        provider_requirement: "trusted_host_setup_required_before_activation",
+        enforcement_by_mode: AdapterEnforcement::uniform(RiskEnforcement::MetadataOnly),
+    },
+    EnforcementAdapterDescriptor {
+        id: "driver_configuration",
+        operations: DRIVER_CONFIGURATION_OPERATIONS,
+        state: RiskEnforcement::MetadataOnly,
+        risk_class: RiskClass::R2,
+        resource_kind: "persistent_driver_configuration",
+        scope_keys: &[
+            "daemon_generation",
+            "permission_mode",
+            "managed_policy_sha256",
+            "user_policy_sha256",
+        ],
+        grant_type: None,
+        idle_ttl_seconds: None,
+        absolute_ttl_seconds: None,
+        indicator_requirement: "not_implemented",
+        revocation_triggers: SESSION_REVOCATION,
+        refusal_code: None,
+        provider_requirement: "certified_protected_host_not_implemented",
+        enforcement_by_mode: AdapterEnforcement::uniform(RiskEnforcement::MetadataOnly),
+    },
+    EnforcementAdapterDescriptor {
+        id: "clipboard",
+        operations: &["clipboard_read", "clipboard_write"],
+        state: RiskEnforcement::NotExposed,
+        risk_class: RiskClass::Unclassified,
+        resource_kind: "system_clipboard",
+        scope_keys: &[],
+        grant_type: None,
+        idle_ttl_seconds: None,
+        absolute_ttl_seconds: None,
+        indicator_requirement: "required_before_exposure",
+        revocation_triggers: &[],
+        refusal_code: None,
+        provider_requirement: "capability_not_exposed",
+        enforcement_by_mode: AdapterEnforcement::uniform(RiskEnforcement::NotExposed),
     },
     EnforcementAdapterDescriptor {
         id: "devices",
@@ -268,6 +477,7 @@ pub const ENFORCEMENT_ADAPTERS: &[EnforcementAdapterDescriptor] = &[
         revocation_triggers: &[],
         refusal_code: None,
         provider_requirement: "capability_not_exposed",
+        enforcement_by_mode: AdapterEnforcement::uniform(RiskEnforcement::NotExposed),
     },
     EnforcementAdapterDescriptor {
         id: "shell_and_network",
@@ -283,6 +493,7 @@ pub const ENFORCEMENT_ADAPTERS: &[EnforcementAdapterDescriptor] = &[
         revocation_triggers: &[],
         refusal_code: None,
         provider_requirement: "capability_not_exposed",
+        enforcement_by_mode: AdapterEnforcement::uniform(RiskEnforcement::NotExposed),
     },
 ];
 
@@ -295,6 +506,130 @@ pub fn adapter_ids_with_state(state: RiskEnforcement) -> Vec<&'static str> {
         .iter()
         .filter(|adapter| adapter.state == state)
         .map(|adapter| adapter.id)
+        .collect()
+}
+
+pub fn adapter_ids_with_state_for_mode(
+    mode: PermissionMode,
+    state: RiskEnforcement,
+) -> Vec<&'static str> {
+    ENFORCEMENT_ADAPTERS
+        .iter()
+        .filter(|adapter| adapter.enforcement_by_mode.for_mode(mode) == state)
+        .map(|adapter| adapter.id)
+        .collect()
+}
+
+/// Return every resource adapter that composes the exact call.
+///
+/// A call may intentionally require more than one adapter: screenshot output
+/// is both private observation and a file write; trajectory recording is both
+/// observation and file output; arbitrary page script is both consequential
+/// and explicitly unbounded. Admission must satisfy the conjunction rather
+/// than picking the highest-risk adapter and dropping the other boundary.
+pub fn enforcement_adapters_for_call(
+    tool: &str,
+    args: &Value,
+) -> Vec<&'static EnforcementAdapterDescriptor> {
+    let mut ids = Vec::new();
+    let mut add = |id| {
+        if !ids.contains(&id) {
+            ids.push(id);
+        }
+    };
+
+    if tool == "browser_prepare"
+        && args.pointer("/strategy/kind").and_then(Value::as_str) == Some("existing_profile")
+    {
+        add("browser_prepare.existing_profile");
+    }
+
+    if matches!(
+        tool,
+        "get_desktop_state"
+            | "get_accessibility_tree"
+            | "get_window_state"
+            | "list_apps"
+            | "list_windows"
+            | "debug_window_info"
+            | "get_browser_state"
+            | "escalate_session"
+            | "zoom"
+            | "start_recording"
+    ) || (tool == "page"
+        && matches!(
+            args.get("action").and_then(Value::as_str),
+            Some("get_text" | "query_dom")
+        ))
+        || (tool == "browser_dialog"
+            && args.get("action").and_then(Value::as_str) == Some("inspect"))
+    {
+        add("private_observation");
+    }
+
+    if DESKTOP_INPUT_OPERATIONS.contains(&tool) {
+        add("desktop_input");
+    }
+
+    let writes_screenshot = matches!(tool, "get_desktop_state" | "get_window_state")
+        && args
+            .get("screenshot_out_file")
+            .and_then(Value::as_str)
+            .is_some_and(|path| !path.is_empty());
+    if matches!(
+        tool,
+        "browser_set_input_files"
+            | "browser_download"
+            | "start_recording"
+            | "stop_recording"
+            | "replay_trajectory"
+            | "install_ffmpeg"
+    ) || writes_screenshot
+    {
+        add("file_transfer_and_output");
+    }
+
+    if (tool == "browser_dialog"
+        && matches!(
+            args.get("action").and_then(Value::as_str),
+            Some("accept" | "dismiss")
+        ))
+        || (tool == "page"
+            && !matches!(
+                args.get("action").and_then(Value::as_str),
+                Some("get_text" | "query_dom")
+            ))
+    {
+        add("browser_consequential_action");
+    }
+
+    if tool == "page" && args.get("action").and_then(Value::as_str) == Some("execute_javascript") {
+        add("browser_unbounded_script");
+    }
+
+    if BROWSER_BOUND_INPUT_OPERATIONS.contains(&tool) {
+        add("browser_bound_input");
+    }
+
+    if PROCESS_CONTROL_OPERATIONS.contains(&tool) {
+        add("process_control");
+    }
+
+    if tool == "check_permissions" && args.get("prompt").and_then(Value::as_bool).unwrap_or(true) {
+        add("os_permission_prompt");
+    }
+
+    if DRIVER_CONFIGURATION_OPERATIONS.contains(&tool) {
+        add("driver_configuration");
+    }
+
+    ids.into_iter()
+        .map(|id| {
+            ENFORCEMENT_ADAPTERS
+                .iter()
+                .find(|adapter| adapter.id == id)
+                .expect("call mapping references a declared enforcement adapter")
+        })
         .collect()
 }
 
@@ -312,7 +647,6 @@ pub fn advertised_risk_for(tool: &str) -> RiskAssessment {
         // Public driver/OS metadata with no user-content payload.
         "get_screen_size"
         | "get_cursor_position"
-        | "check_permissions"
         | "get_config"
         | "get_session_state"
         | "get_agent_cursor_state"
@@ -338,22 +672,20 @@ pub fn advertised_risk_for(tool: &str) -> RiskAssessment {
         | "hotkey"
         | "set_value"
         | "launch_app"
-        | "list_apps"
-        | "kill_app"
-        | "list_windows"
         | "bring_to_front"
-        | "debug_window_info"
         | "start_session"
         | "end_session"
         | "set_agent_cursor_enabled"
         | "set_agent_cursor_motion"
-        | "set_agent_cursor_style"
-        | "stop_recording"
-        | "replay_trajectory" => RiskClass::R1,
+        | "set_agent_cursor_style" => RiskClass::R1,
 
         // Surfaces that can reveal or control sensitive local/authenticated
         // state. Most remain metadata-only until their resource adapters ship.
         "zoom"
+        | "list_apps"
+        | "list_windows"
+        | "debug_window_info"
+        | "check_permissions"
         | "get_accessibility_tree"
         | "set_config"
         | "escalate_session"
@@ -368,6 +700,9 @@ pub fn advertised_risk_for(tool: &str) -> RiskAssessment {
         // External/file side effects or generic compound action surfaces.
         "get_desktop_state"
         | "get_window_state"
+        | "kill_app"
+        | "stop_recording"
+        | "replay_trajectory"
         | "install_ffmpeg"
         | "page"
         | "browser_dialog"
@@ -379,14 +714,7 @@ pub fn advertised_risk_for(tool: &str) -> RiskAssessment {
     RiskAssessment {
         class,
         enforcement: RiskEnforcement::MetadataOnly,
-        operation_sensitive: matches!(
-            tool,
-            "browser_prepare"
-                | "browser_dialog"
-                | "page"
-                | "get_desktop_state"
-                | "get_window_state"
-        ),
+        operation_sensitive: matches!(class, RiskClass::R2 | RiskClass::R3 | RiskClass::R4),
     }
 }
 
@@ -447,6 +775,15 @@ pub fn classify_tool_call(tool: &str, args: &Value) -> RiskAssessment {
             },
             enforcement: RiskEnforcement::MetadataOnly,
             operation_sensitive: true,
+        },
+        "check_permissions" => RiskAssessment {
+            class: if args.get("prompt").and_then(Value::as_bool).unwrap_or(true) {
+                RiskClass::R2
+            } else {
+                RiskClass::R0
+            },
+            enforcement: RiskEnforcement::MetadataOnly,
+            operation_sensitive: args.get("prompt").and_then(Value::as_bool).unwrap_or(true),
         },
         _ => advertised_risk_for(tool),
     }
@@ -727,6 +1064,18 @@ pub fn status_json() -> serde_json::Value {
     let managed_policy = crate::policy::configured_managed_policy();
     let user_policy_sha256 = crate::policy::user_policy_sha256().ok().flatten();
     let managed_policy_sha256 = crate::policy::managed_policy_sha256().ok().flatten();
+    let effective_active_risk_enforcement = mode
+        .as_ref()
+        .map(|mode| adapter_ids_with_state_for_mode(*mode, RiskEnforcement::Active))
+        .unwrap_or_default();
+    let effective_metadata_only_risk_enforcement = mode
+        .as_ref()
+        .map(|mode| adapter_ids_with_state_for_mode(*mode, RiskEnforcement::MetadataOnly))
+        .unwrap_or_default();
+    let effective_not_exposed_risk_enforcement = mode
+        .as_ref()
+        .map(|mode| adapter_ids_with_state_for_mode(*mode, RiskEnforcement::NotExposed))
+        .unwrap_or_default();
     let session_policy = crate::session_manifest::configured_session_manifest();
     let session_policy_status = session_policy
         .as_ref()
@@ -766,6 +1115,9 @@ pub fn status_json() -> serde_json::Value {
         "active_risk_enforcement": adapter_ids_with_state(RiskEnforcement::Active),
         "metadata_only_risk_enforcement": adapter_ids_with_state(RiskEnforcement::MetadataOnly),
         "not_exposed_risk_enforcement": adapter_ids_with_state(RiskEnforcement::NotExposed),
+        "effective_active_risk_enforcement": effective_active_risk_enforcement,
+        "effective_metadata_only_risk_enforcement": effective_metadata_only_risk_enforcement,
+        "effective_not_exposed_risk_enforcement": effective_not_exposed_risk_enforcement,
         "enforcement_adapters": enforcement_adapter_inventory_json(),
         "protected_consent_collector": crate::consent::configured_provider_id(),
         "session_policy_configured": std::env::var_os(crate::session_manifest::SESSION_POLICY_FILE_ENV).is_some(),
@@ -899,6 +1251,24 @@ mod tests {
     }
 
     #[test]
+    fn os_permission_prompt_is_argument_sensitive() {
+        let read_only =
+            classify_tool_call("check_permissions", &serde_json::json!({"prompt": false}));
+        assert_eq!(read_only.class, RiskClass::R0);
+        assert!(!read_only.operation_sensitive);
+
+        for args in [serde_json::json!({}), serde_json::json!({"prompt": true})] {
+            let prompting = classify_tool_call("check_permissions", &args);
+            assert_eq!(prompting.class, RiskClass::R2);
+            assert!(prompting.operation_sensitive);
+        }
+        assert_eq!(
+            advertised_risk_for("check_permissions").class,
+            RiskClass::R2
+        );
+    }
+
+    #[test]
     fn process_targeted_tools_cannot_target_the_authorization_daemon() {
         let error = authorize_tool_call(
             "click",
@@ -922,6 +1292,11 @@ mod tests {
                 "adapter {} needs at least one operation selector",
                 adapter.id
             );
+            assert_eq!(
+                adapter.state, adapter.enforcement_by_mode.standard,
+                "legacy state must remain the standard-mode value for {}",
+                adapter.id
+            );
         }
 
         assert_eq!(
@@ -935,11 +1310,20 @@ mod tests {
                 "desktop_input",
                 "file_transfer_and_output",
                 "browser_consequential_action",
+                "browser_unbounded_script",
+                "browser_bound_input",
+                "process_control",
+                "os_permission_prompt",
+                "driver_configuration",
             ]
         );
         assert_eq!(
             adapter_ids_with_state(RiskEnforcement::NotExposed),
-            vec!["devices", "shell_and_network"]
+            vec!["clipboard", "devices", "shell_and_network"]
+        );
+        assert_eq!(
+            adapter_ids_with_state_for_mode(PermissionMode::Standard, RiskEnforcement::Active),
+            vec!["browser_prepare.existing_profile"]
         );
 
         let existing = ENFORCEMENT_ADAPTERS
@@ -949,6 +1333,72 @@ mod tests {
         assert_eq!(existing.idle_ttl_seconds, Some(30 * 60));
         assert_eq!(existing.absolute_ttl_seconds, Some(8 * 60 * 60));
         assert_eq!(existing.refusal_code, Some("browser_consent_required"));
+    }
+
+    #[test]
+    fn exact_call_inventory_composes_overlapping_resource_boundaries() {
+        let ids = |tool, args: Value| {
+            enforcement_adapters_for_call(tool, &args)
+                .into_iter()
+                .map(|adapter| adapter.id)
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(
+            ids(
+                "get_desktop_state",
+                serde_json::json!({"screenshot_out_file": "/tmp/capture.png"})
+            ),
+            vec!["private_observation", "file_transfer_and_output"]
+        );
+        assert_eq!(
+            ids("page", serde_json::json!({"action": "execute_javascript"})),
+            vec!["browser_consequential_action", "browser_unbounded_script"]
+        );
+        assert_eq!(
+            ids("start_recording", serde_json::json!({})),
+            vec!["private_observation", "file_transfer_and_output"]
+        );
+        assert_eq!(
+            ids("escalate_session", serde_json::json!({})),
+            vec!["private_observation"]
+        );
+        assert_eq!(
+            ids("type_text_chars", serde_json::json!({})),
+            vec!["desktop_input"]
+        );
+        assert_eq!(
+            ids("replay_trajectory", serde_json::json!({})),
+            vec!["desktop_input", "file_transfer_and_output"]
+        );
+        assert_eq!(
+            ids("get_browser_state", serde_json::json!({})),
+            vec!["private_observation"]
+        );
+        assert_eq!(
+            ids("browser_dialog", serde_json::json!({"action": "inspect"})),
+            vec!["private_observation"]
+        );
+        assert_eq!(
+            ids("browser_click", serde_json::json!({})),
+            vec!["browser_bound_input"]
+        );
+        assert_eq!(
+            ids("kill_app", serde_json::json!({})),
+            vec!["process_control"]
+        );
+        assert_eq!(
+            ids("check_permissions", serde_json::json!({"prompt": false})),
+            Vec::<&str>::new()
+        );
+        assert_eq!(
+            ids("check_permissions", serde_json::json!({})),
+            vec!["os_permission_prompt"]
+        );
+        assert_eq!(
+            ids("set_config", serde_json::json!({})),
+            vec!["driver_configuration"]
+        );
     }
 
     #[test]
@@ -964,8 +1414,25 @@ mod tests {
                 "private_observation",
                 "desktop_input",
                 "file_transfer_and_output",
-                "browser_consequential_action"
+                "browser_consequential_action",
+                "browser_unbounded_script",
+                "browser_bound_input",
+                "process_control",
+                "os_permission_prompt",
+                "driver_configuration"
             ])
+        );
+        assert_eq!(
+            status["not_exposed_risk_enforcement"],
+            serde_json::json!(["clipboard", "devices", "shell_and_network"])
+        );
+        assert_eq!(
+            status["effective_active_risk_enforcement"],
+            serde_json::json!(["browser_prepare.existing_profile"])
+        );
+        assert_eq!(
+            status["effective_metadata_only_risk_enforcement"],
+            status["metadata_only_risk_enforcement"]
         );
         assert_eq!(
             status["enforcement_adapters"],

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/authorization.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/authorization.rs
@@ -1059,6 +1059,16 @@ pub fn validate_startup_authorization() -> anyhow::Result<()> {
 
 /// Content-free authorization state suitable for status/health output.
 pub fn status_json() -> serde_json::Value {
+    status_json_with_provider(None)
+}
+
+/// Content-free authorization state for one runtime-owned provider.
+///
+/// Provider identity is runtime state, never a process-global first-writer
+/// value: multiple direct runtimes may install different trusted hosts.
+pub fn status_json_with_provider(
+    protected_consent_collector: Option<&'static str>,
+) -> serde_json::Value {
     let mode = configured_permission_mode();
     let policy = crate::policy::configured_policy();
     let managed_policy = crate::policy::configured_managed_policy();
@@ -1119,7 +1129,7 @@ pub fn status_json() -> serde_json::Value {
         "effective_metadata_only_risk_enforcement": effective_metadata_only_risk_enforcement,
         "effective_not_exposed_risk_enforcement": effective_not_exposed_risk_enforcement,
         "enforcement_adapters": enforcement_adapter_inventory_json(),
-        "protected_consent_collector": crate::consent::configured_provider_id(),
+        "protected_consent_collector": protected_consent_collector,
         "session_policy_configured": std::env::var_os(crate::session_manifest::SESSION_POLICY_FILE_ENV).is_some(),
         "session_policy_approved_at_startup": env_flag(crate::session_manifest::SESSION_POLICY_APPROVED_ENV),
         "session_policy_valid": session_policy.is_ok(),

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/engine.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/engine.rs
@@ -77,7 +77,7 @@ pub struct BrowserEngine {
     pub(crate) pool: CdpPool,
     pub(crate) managed_browsers: ManagedBrowsers,
     pub(crate) existing_profile_grants: ExistingProfileGrants,
-    pub(crate) approval_broker: crate::consent::ApprovalBroker,
+    pub(crate) approval_broker: Arc<crate::consent::ApprovalBroker>,
     mutation_gates: MutationGates,
     reconnect_gates: ReconnectGates,
     session_end_hook: Mutex<Option<crate::session::SessionEndHookRegistration>>,
@@ -525,7 +525,10 @@ impl BrowserEngine {
     /// capability store. Platform crates call this once and register
     /// the five tools via `register_browser_tools`.
     pub fn new(platform: Arc<dyn BrowserPlatform>) -> Arc<Self> {
-        Self::new_with_protected_consent_provider(platform, None)
+        Self::new_with_approval_broker(
+            platform,
+            Arc::new(crate::consent::ApprovalBroker::unavailable()),
+        )
     }
 
     /// Create an engine with a provider installed by a trusted embedding host
@@ -535,13 +538,25 @@ impl BrowserEngine {
         platform: Arc<dyn BrowserPlatform>,
         provider: Option<Arc<dyn crate::consent::ProtectedConsentProvider>>,
     ) -> Arc<Self> {
+        Self::new_with_approval_broker(
+            platform,
+            Arc::new(crate::consent::ApprovalBroker::new(provider)),
+        )
+    }
+
+    /// Create an engine using the runtime-owned broker shared by every
+    /// protected resource adapter.
+    pub fn new_with_approval_broker(
+        platform: Arc<dyn BrowserPlatform>,
+        approval_broker: Arc<crate::consent::ApprovalBroker>,
+    ) -> Arc<Self> {
         let engine = Arc::new(Self {
             platform,
             store: BrowserStore::new(),
             pool: CdpPool::new(),
             managed_browsers: Default::default(),
             existing_profile_grants: ExistingProfileGrants::new(),
-            approval_broker: crate::consent::ApprovalBroker::new(provider),
+            approval_broker,
             mutation_gates: MutationGates::new(),
             reconnect_gates: ReconnectGates::new(),
             session_end_hook: Mutex::new(None),

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/consent.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/consent.rs
@@ -7,9 +7,10 @@
 //! implementations must authenticate their private channel before adapting it
 //! to this interface.
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, OnceLock};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -20,11 +21,6 @@ use uuid::Uuid;
 use crate::authorization::{PermissionMode, RiskClass};
 
 const DEFAULT_REQUEST_TTL: Duration = Duration::from_secs(2 * 60);
-static CONFIGURED_PROVIDER_ID: OnceLock<&'static str> = OnceLock::new();
-
-pub fn configured_provider_id() -> Option<&'static str> {
-    CONFIGURED_PROVIDER_ID.get().copied()
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -147,9 +143,6 @@ impl ApprovalBroker {
     }
 
     pub fn new(provider: Option<Arc<dyn ProtectedConsentProvider>>) -> Self {
-        if let Some(provider) = provider.as_ref() {
-            let _ = CONFIGURED_PROVIDER_ID.set(provider.provider_id());
-        }
         Self {
             daemon_instance: Arc::from(Uuid::new_v4().to_string()),
             next_generation: Arc::new(AtomicU64::new(1)),
@@ -174,6 +167,32 @@ impl ApprovalBroker {
         resource: Value,
         human_summary: impl Into<String>,
     ) -> ConsentRequest {
+        self.request_bound(
+            permission_mode,
+            operation,
+            risk_class,
+            public_session,
+            transport_session,
+            resource,
+            human_summary,
+            crate::policy::managed_policy_sha256().ok().flatten(),
+            crate::policy::user_policy_sha256().ok().flatten(),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn request_bound(
+        &self,
+        permission_mode: PermissionMode,
+        operation: impl Into<String>,
+        risk_class: RiskClass,
+        public_session: impl Into<String>,
+        transport_session: impl Into<String>,
+        resource: Value,
+        human_summary: impl Into<String>,
+        managed_policy_sha256: Option<String>,
+        user_policy_sha256: Option<String>,
+    ) -> ConsentRequest {
         let expires_unix_ms = now_unix_ms() + DEFAULT_REQUEST_TTL.as_millis();
         let mut request = ConsentRequest {
             schema: "cua-protected-consent-request-v1",
@@ -181,8 +200,8 @@ impl ApprovalBroker {
             generation: self.next_generation.fetch_add(1, Ordering::Relaxed),
             daemon_instance: self.daemon_instance.to_string(),
             permission_mode,
-            managed_policy_sha256: crate::policy::managed_policy_sha256().ok().flatten(),
-            user_policy_sha256: crate::policy::user_policy_sha256().ok().flatten(),
+            managed_policy_sha256,
+            user_policy_sha256,
             operation: operation.into(),
             risk_class,
             public_session: public_session.into(),
@@ -280,6 +299,219 @@ impl ApprovalBroker {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ResourceGrantKey {
+    runtime_scope: String,
+    public_session: String,
+    transport_session: String,
+    adapter_id: String,
+    resource_digest: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResourceGrant {
+    pub adapter_id: String,
+    pub resource_digest: String,
+    pub protected: ProtectedGrant,
+    mode: PermissionMode,
+    managed_policy_sha256: Option<String>,
+    user_policy_sha256: Option<String>,
+    created_at: Instant,
+    last_used_at: Instant,
+    idle_ttl: Duration,
+    absolute_ttl: Duration,
+}
+
+impl ResourceGrant {
+    pub fn is_live(&self) -> bool {
+        self.protected.is_live()
+    }
+
+    fn expired(&self, now: Instant) -> bool {
+        !self.is_live()
+            || now.duration_since(self.last_used_at) >= self.idle_ttl
+            || now.duration_since(self.created_at) >= self.absolute_ttl
+    }
+}
+
+/// Per-runtime store and admission coordinator for every protected resource
+/// adapter beyond existing-profile attachment.
+///
+/// Only canonical resource digests become map keys. Raw paths, text, page
+/// content, selectors, and typed input are never retained by this store.
+pub struct ProtectedResourceGrants {
+    broker: Arc<ApprovalBroker>,
+    grants: Mutex<HashMap<ResourceGrantKey, ResourceGrant>>,
+    admission: tokio::sync::Mutex<()>,
+}
+
+impl ProtectedResourceGrants {
+    pub fn new(broker: Arc<ApprovalBroker>) -> Self {
+        Self {
+            broker,
+            grants: Mutex::new(HashMap::new()),
+            admission: tokio::sync::Mutex::new(()),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn authorize(
+        &self,
+        context: &crate::session_authorization::EffectiveAuthorizationContext,
+        adapter_id: &str,
+        risk_class: RiskClass,
+        lifecycle_session: Option<&str>,
+        resource: Value,
+        human_summary: &str,
+        idle_ttl: Duration,
+        absolute_ttl: Duration,
+    ) -> Result<Option<ResourceGrant>, ConsentError> {
+        if context.mode() == PermissionMode::Unrestricted {
+            return Ok(None);
+        }
+        let resource_digest = digest_resource(adapter_id, &resource);
+        let key = resource_grant_key(context, lifecycle_session, adapter_id, &resource_digest);
+        if let Some(grant) = self.lookup(&key, context) {
+            return Ok(Some(grant));
+        }
+
+        // Collapse concurrent requests for the same or different protected
+        // resources into a single provider turn. Re-check after waiting so a
+        // peer that just approved the same exact scope supplies the grant.
+        let _admission = self.admission.lock().await;
+        if let Some(grant) = self.lookup(&key, context) {
+            return Ok(Some(grant));
+        }
+
+        let public_session = context
+            .public_session()
+            .or(lifecycle_session)
+            .unwrap_or("compatibility");
+        let transport_session = context.transport_session().unwrap_or(public_session);
+        let request = self.broker.request_bound(
+            context.mode(),
+            adapter_id,
+            risk_class,
+            public_session,
+            transport_session,
+            resource,
+            human_summary,
+            context.managed_policy_sha256().map(str::to_owned),
+            context.user_policy_sha256().map(str::to_owned),
+        );
+        let protected = match context.mode() {
+            PermissionMode::Standard => self.broker.approve(&request).await?,
+            PermissionMode::Bounded => self.broker.activate_preapproved(&request).await?,
+            PermissionMode::Unrestricted => unreachable!("handled before protected admission"),
+        };
+        let now = Instant::now();
+        let grant = ResourceGrant {
+            adapter_id: adapter_id.to_owned(),
+            resource_digest,
+            protected,
+            mode: context.mode(),
+            managed_policy_sha256: context.managed_policy_sha256().map(str::to_owned),
+            user_policy_sha256: context.user_policy_sha256().map(str::to_owned),
+            created_at: now,
+            last_used_at: now,
+            idle_ttl,
+            absolute_ttl,
+        };
+        self.grants.lock().unwrap().insert(key, grant.clone());
+        Ok(Some(grant))
+    }
+
+    fn lookup(
+        &self,
+        key: &ResourceGrantKey,
+        context: &crate::session_authorization::EffectiveAuthorizationContext,
+    ) -> Option<ResourceGrant> {
+        let now = Instant::now();
+        let mut grants = self.grants.lock().unwrap();
+        let grant = grants.get_mut(key)?;
+        if grant.expired(now)
+            || grant.mode != context.mode()
+            || grant.managed_policy_sha256.as_deref() != context.managed_policy_sha256()
+            || grant.user_policy_sha256.as_deref() != context.user_policy_sha256()
+        {
+            if let Some(expired) = grants.remove(key) {
+                expired.protected.indicator.revoke();
+            }
+            return None;
+        }
+        grant.last_used_at = now;
+        Some(grant.clone())
+    }
+
+    pub fn revoke_session(&self, session: &str) -> Vec<ProtectedGrant> {
+        let mut removed = Vec::new();
+        self.grants.lock().unwrap().retain(|key, grant| {
+            let keep = key.public_session != session && key.transport_session != session;
+            if !keep {
+                grant.protected.indicator.revoke();
+                removed.push(grant.protected.clone());
+            }
+            keep
+        });
+        removed
+    }
+
+    pub fn revoke_all(&self) -> Vec<ProtectedGrant> {
+        let mut grants = self.grants.lock().unwrap();
+        let removed = grants
+            .drain()
+            .map(|(_, grant)| {
+                grant.protected.indicator.revoke();
+                grant.protected
+            })
+            .collect();
+        removed
+    }
+
+    pub fn broker(&self) -> &Arc<ApprovalBroker> {
+        &self.broker
+    }
+}
+
+impl Drop for ProtectedResourceGrants {
+    fn drop(&mut self) {
+        for (_, grant) in self.grants.get_mut().unwrap().drain() {
+            grant.protected.indicator.revoke();
+        }
+    }
+}
+
+fn resource_grant_key(
+    context: &crate::session_authorization::EffectiveAuthorizationContext,
+    lifecycle_session: Option<&str>,
+    adapter_id: &str,
+    resource_digest: &str,
+) -> ResourceGrantKey {
+    let public_session = context
+        .public_session()
+        .or(lifecycle_session)
+        .unwrap_or("compatibility");
+    ResourceGrantKey {
+        runtime_scope: context.runtime_scope_key(),
+        public_session: context.runtime_session_key(public_session),
+        transport_session: context
+            .transport_session()
+            .unwrap_or(public_session)
+            .to_owned(),
+        adapter_id: adapter_id.to_owned(),
+        resource_digest: resource_digest.to_owned(),
+    }
+}
+
+fn digest_resource(adapter_id: &str, resource: &Value) -> String {
+    let canonical = serde_json::json!({
+        "adapter_id": adapter_id,
+        "resource": resource,
+    });
+    let bytes = serde_json::to_vec(&canonical).expect("serialize protected resource");
+    format!("{:x}", Sha256::digest(bytes))
+}
+
 fn now_unix_ms() -> u128 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -323,7 +555,6 @@ fn digest_request(request: &ConsentRequest) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
 
     struct FakeProvider {
         action: ConsentAction,
@@ -397,6 +628,134 @@ mod tests {
             serde_json::json!({"pid": 42, "window_id": 7}),
             "Attach to Chromium window 7",
         )
+    }
+
+    fn authorization_context(
+        mode: PermissionMode,
+    ) -> Arc<crate::session_authorization::EffectiveAuthorizationContext> {
+        let ceiling = crate::session_authorization::SessionModeCeiling::for_trusted_sessions(
+            [mode],
+            mode == PermissionMode::Unrestricted,
+            Duration::from_secs(60),
+            Duration::from_secs(30),
+        )
+        .unwrap();
+        crate::session_authorization::SessionAuthorizationRegistry::with_ceiling(ceiling)
+            .compatibility_context(mode, None)
+            .unwrap()
+    }
+
+    #[test]
+    fn provider_identity_is_runtime_scoped() {
+        let with_provider = crate::tool::ToolRegistry::new_with_protected_consent_provider(Some(
+            provider(ConsentAction::Accept),
+        ));
+        let without_provider = crate::tool::ToolRegistry::new();
+
+        assert_eq!(
+            with_provider.authorization_status_json()["protected_consent_collector"],
+            "test.protected-provider"
+        );
+        assert_eq!(
+            without_provider.authorization_status_json()["protected_consent_collector"],
+            serde_json::Value::Null
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_resource_grants_are_reused_and_scope_changes_reprompt() {
+        let provider = provider(ConsentAction::Accept);
+        let broker = Arc::new(ApprovalBroker::new(Some(provider.clone())));
+        let grants = ProtectedResourceGrants::new(broker);
+        let context = authorization_context(PermissionMode::Standard);
+
+        let first = grants
+            .authorize(
+                &context,
+                "private_observation",
+                RiskClass::R2,
+                Some("public-a"),
+                serde_json::json!({"pid": 42, "window_id": 7}),
+                "Observe app window 7",
+                Duration::from_secs(30),
+                Duration::from_secs(60),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        let reused = grants
+            .authorize(
+                &context,
+                "private_observation",
+                RiskClass::R2,
+                Some("public-a"),
+                serde_json::json!({"pid": 42, "window_id": 7}),
+                "Observe app window 7",
+                Duration::from_secs(30),
+                Duration::from_secs(60),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(first.protected.id, reused.protected.id);
+        assert_eq!(provider.requests.load(Ordering::SeqCst), 1);
+
+        grants
+            .authorize(
+                &context,
+                "private_observation",
+                RiskClass::R2,
+                Some("public-a"),
+                serde_json::json!({"pid": 42, "window_id": 8}),
+                "Observe app window 8",
+                Duration::from_secs(30),
+                Duration::from_secs(60),
+            )
+            .await
+            .unwrap();
+        assert_eq!(provider.requests.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn revocation_is_immediate_and_unrestricted_skips_the_broker() {
+        let provider = provider(ConsentAction::Accept);
+        let broker = Arc::new(ApprovalBroker::new(Some(provider.clone())));
+        let grants = ProtectedResourceGrants::new(broker);
+        let standard = authorization_context(PermissionMode::Standard);
+        let live = grants
+            .authorize(
+                &standard,
+                "desktop_input",
+                RiskClass::R1,
+                Some("public-a"),
+                serde_json::json!({"pid": 42, "window_id": 7}),
+                "Control app window 7",
+                Duration::from_secs(30),
+                Duration::from_secs(60),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        let revoked = grants.revoke_session(&standard.runtime_session_key("public-a"));
+        assert_eq!(revoked.len(), 1);
+        assert!(!live.is_live());
+
+        let unrestricted = authorization_context(PermissionMode::Unrestricted);
+        assert!(grants
+            .authorize(
+                &unrestricted,
+                "desktop_input",
+                RiskClass::R1,
+                Some("public-b"),
+                serde_json::json!({"pid": 9, "window_id": 2}),
+                "Control app window 2",
+                Duration::from_secs(30),
+                Duration::from_secs(60),
+            )
+            .await
+            .unwrap()
+            .is_none());
+        assert_eq!(provider.requests.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/session_authorization.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/session_authorization.rs
@@ -232,6 +232,21 @@ impl EffectiveAuthorizationContext {
         self.public_session.as_deref()
     }
 
+    #[doc(hidden)]
+    pub fn transport_session(&self) -> Option<&str> {
+        self.transport_session.as_deref()
+    }
+
+    #[doc(hidden)]
+    pub fn user_policy_sha256(&self) -> Option<&str> {
+        self.user_policy_sha256.as_deref()
+    }
+
+    #[doc(hidden)]
+    pub fn managed_policy_sha256(&self) -> Option<&str> {
+        self.managed_policy_sha256.as_deref()
+    }
+
     pub fn is_expired(&self) -> bool {
         if self.revoked.load(Ordering::Acquire) {
             return true;

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -374,19 +374,75 @@ pub struct ToolRegistry {
     session_end_hooks: Vec<crate::session::SessionEndHookRegistration>,
     cursor_outcome_readers: Vec<crate::session::CursorOutcomeReaderRegistration>,
     runtime_cleanups: Vec<RuntimeCleanup>,
+    /// Runtime-owned protected-consent broker shared by every resource
+    /// adapter. Keeping it at the canonical dispatch boundary prevents
+    /// browser, desktop, and file adapters from growing independent provider
+    /// identities or grant lifecycles.
+    approval_broker: Arc<crate::consent::ApprovalBroker>,
+    protected_resource_grants: Arc<crate::consent::ProtectedResourceGrants>,
 }
 
 impl ToolRegistry {
     pub fn new() -> Self {
+        Self::new_with_protected_consent_provider(None)
+    }
+
+    /// Construct a registry with a provider installed by a trusted embedding
+    /// host. Public tool calls and transport metadata cannot replace it.
+    pub fn new_with_protected_consent_provider(
+        provider: Option<Arc<dyn crate::consent::ProtectedConsentProvider>>,
+    ) -> Self {
+        let approval_broker = Arc::new(crate::consent::ApprovalBroker::new(provider));
+        let protected_resource_grants = Arc::new(crate::consent::ProtectedResourceGrants::new(
+            approval_broker.clone(),
+        ));
+        let weak_grants = Arc::downgrade(&protected_resource_grants);
+        let session_end_hook =
+            crate::session::register_scoped_session_end_hook(move |session_id| {
+                let Some(grants) = weak_grants.upgrade() else {
+                    return;
+                };
+                let revoked = grants.revoke_session(session_id);
+                if revoked.is_empty() {
+                    return;
+                }
+                if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+                    runtime.spawn(async move {
+                        for grant in revoked {
+                            grants.broker().revoke(&grant).await;
+                        }
+                    });
+                }
+            });
         Self {
             tools: HashMap::new(),
             order: Vec::new(),
             recording: Arc::new(RecordingSession::new()),
             replay_registry: Arc::new(std::sync::Mutex::new(std::sync::Weak::new())),
-            session_end_hooks: Vec::new(),
+            session_end_hooks: vec![session_end_hook],
             cursor_outcome_readers: Vec::new(),
             runtime_cleanups: Vec::new(),
+            approval_broker,
+            protected_resource_grants,
         }
+    }
+
+    /// Return the runtime-owned broker for adapter construction.
+    ///
+    /// This is intentionally not exposed through MCP/CLI arguments. Platform
+    /// registries pass the clone to resource adapters while assembling one
+    /// trusted runtime.
+    pub fn approval_broker(&self) -> Arc<crate::consent::ApprovalBroker> {
+        self.approval_broker.clone()
+    }
+
+    pub fn protected_resource_grants(&self) -> Arc<crate::consent::ProtectedResourceGrants> {
+        self.protected_resource_grants.clone()
+    }
+
+    /// Content-free authorization status for this exact runtime.
+    pub fn authorization_status_json(&self) -> Value {
+        crate::authorization::status_json_with_provider(self.approval_broker.provider_id())
     }
 
     pub fn register(&mut self, tool: Box<dyn Tool>) {

--- a/libs/cua-driver/rust/crates/cua-driver-sdk/src/abi.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-sdk/src/abi.rs
@@ -1161,6 +1161,22 @@ impl NativeAbiDriver {
         })
     }
 
+    pub(crate) fn create_configured_with_protected_provider(
+        options: Value,
+        provider: Arc<dyn cua_driver_core::consent::ProtectedConsentProvider>,
+    ) -> Result<Self, DriverError> {
+        let options: AbiDriverOptions =
+            serde_json::from_value(options).map_err(|error| DriverError::Configuration {
+                reason: format!("invalid configured host options: {error}"),
+            })?;
+        let mut runtime_options =
+            runtime_options_from_abi(options).map_err(|error| DriverError::Configuration {
+                reason: error.message,
+            })?;
+        runtime_options.protected_consent_provider = Some(provider);
+        Self::create_for_host(runtime_options)
+    }
+
     pub(crate) fn create_for_host(options: RuntimeOptions) -> Result<Self, DriverError> {
         let runtime = DriverRuntime::create(options).map_err(map_runtime_create_error)?;
         let runtime_scope_key = runtime.runtime_scope_key();

--- a/libs/cua-driver/rust/crates/cua-driver-sdk/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-sdk/src/lib.rs
@@ -22,6 +22,7 @@ use thiserror::Error;
 
 mod abi;
 mod embedded;
+mod protected_host;
 pub mod remote;
 mod runtime;
 mod service_session;
@@ -29,6 +30,10 @@ mod service_session;
 pub mod worker;
 use abi::{NativeAbiDriver, NativeAbiSession};
 pub use embedded::*;
+pub use protected_host::{
+    ProtectedConsentAction, ProtectedConsentDecision, ProtectedConsentHost,
+    ProtectedConsentHostError, ProtectedConsentRequest,
+};
 use remote::{DriverEnvelopeChannel, RemoteBoundSession, RemoteDriverClient};
 use runtime::RuntimeOptions;
 use service_session::ServiceSessionClient;
@@ -351,6 +356,26 @@ pub struct ConfiguredDriverOptions {
     pub authorization: RuntimeAuthorizationOptions,
 }
 
+fn configured_driver_options_json(options: &ConfiguredDriverOptions) -> Value {
+    let allowed_modes = options
+        .authorization
+        .allowed_modes
+        .iter()
+        .map(|mode| mode.as_str())
+        .collect::<Vec<_>>();
+    serde_json::json!({
+        "claude_code_compatibility": options.claude_code_compatibility,
+        "authorization": {
+            "allowed_modes": allowed_modes,
+            "compatibility_mode": options.authorization.compatibility_mode.as_str(),
+            "compatibility_bounded_manifest_path": options.authorization.compatibility_bounded_manifest_path.clone(),
+            "unrestricted_acknowledged": options.authorization.unrestricted_acknowledged,
+            "max_session_ttl_seconds": options.authorization.max_session_ttl_seconds,
+            "max_idle_ttl_seconds": options.authorization.max_idle_ttl_seconds,
+        }
+    })
+}
+
 /// Trusted host request for one immutable, connection-bound action surface.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, uniffi::Record)]
 pub struct TrustedSessionOptions {
@@ -607,28 +632,52 @@ impl CuaDriver {
     /// agent tool. Existing `create()` callers remain unchanged.
     #[uniffi::constructor]
     pub fn create_configured(options: ConfiguredDriverOptions) -> Result<Arc<Self>, DriverError> {
-        let allowed_modes = options
-            .authorization
-            .allowed_modes
-            .iter()
-            .map(|mode| mode.as_str())
-            .collect::<Vec<_>>();
-        let native_options = serde_json::json!({
-            "claude_code_compatibility": options.claude_code_compatibility,
-            "authorization": {
-                "allowed_modes": allowed_modes,
-                "compatibility_mode": options.authorization.compatibility_mode.as_str(),
-                "compatibility_bounded_manifest_path": options.authorization.compatibility_bounded_manifest_path,
-                "unrestricted_acknowledged": options.authorization.unrestricted_acknowledged,
-                "max_session_ttl_seconds": options.authorization.max_session_ttl_seconds,
-                "max_idle_ttl_seconds": options.authorization.max_idle_ttl_seconds,
-            }
-        });
+        let native_options = configured_driver_options_json(&options);
         Ok(Arc::new(Self {
             backend: DriverBackend::Embedded(Arc::new(NativeAbiDriver::create_configured(
                 native_options,
             )?)),
             client_kind: DaemonClientKind::Unknown,
+        }))
+    }
+
+    /// Create a configured same-process runtime with protected approval and
+    /// persistent Stop UI supplied by trusted embedding-host code.
+    ///
+    /// The callback object is immutable runtime configuration. Applications
+    /// must not expose it to an agent or implement it using ordinary MCP
+    /// elicitation, model-visible stdio, or an auto-accepting callback.
+    #[uniffi::constructor]
+    pub fn create_configured_with_protected_host(
+        options: ConfiguredDriverOptions,
+        host: Arc<dyn ProtectedConsentHost>,
+    ) -> Result<Arc<Self>, DriverError> {
+        let provider = protected_host::SdkProtectedConsentProvider::new(host);
+        Ok(Arc::new(Self {
+            backend: DriverBackend::Embedded(Arc::new(
+                NativeAbiDriver::create_configured_with_protected_provider(
+                    configured_driver_options_json(&options),
+                    provider,
+                )?,
+            )),
+            client_kind: DaemonClientKind::Unknown,
+        }))
+    }
+
+    /// Language-package entry point for a configured protected-host runtime.
+    #[uniffi::constructor]
+    pub fn create_configured_with_protected_host_and_client_kind(
+        options: ConfiguredDriverOptions,
+        host: Arc<dyn ProtectedConsentHost>,
+        client_kind: SdkClientKind,
+    ) -> Result<Arc<Self>, DriverError> {
+        let driver = Self::create_configured_with_protected_host(options, host)?;
+        let DriverBackend::Embedded(runtime) = &driver.backend else {
+            unreachable!("protected-host constructor always returns an embedded runtime")
+        };
+        Ok(Arc::new(Self {
+            backend: DriverBackend::Embedded(runtime.clone()),
+            client_kind: client_kind.into(),
         }))
     }
 
@@ -785,6 +834,7 @@ impl CuaDriver {
             register_host_tools: options.register_host_tools,
             authorization_ceiling: None,
             compatibility_authorization: None,
+            protected_consent_provider: None,
         })
     }
 
@@ -891,6 +941,7 @@ impl CuaDriver {
                     register_host_tools: options.register_host_tools,
                     authorization_ceiling: None,
                     compatibility_authorization: None,
+                    protected_consent_provider: None,
                 },
             )?)),
             client_kind: DaemonClientKind::Unknown,
@@ -939,6 +990,7 @@ impl CuaDriver {
                     register_host_tools: options.register_host_tools,
                     authorization_ceiling: Some(ceiling),
                     compatibility_authorization: Some((mode, manifest)),
+                    protected_consent_provider: None,
                 },
             )?)),
             client_kind: DaemonClientKind::Unknown,

--- a/libs/cua-driver/rust/crates/cua-driver-sdk/src/protected_host.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-sdk/src/protected_host.rs
@@ -1,0 +1,355 @@
+//! Trusted host adapter for protected consent and persistent Stop UI.
+//!
+//! This callback surface is constructor-only host configuration. It must never
+//! be implemented by model-facing code, exposed as an MCP tool, or bridged to
+//! ordinary elicitation. The embedding application owns the protected
+//! renderer and indicator; Cua binds its decisions to the exact request digest
+//! and treats host failure as revocation.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use cua_driver_core::consent::{
+    ConsentAction, ConsentRequest, IndicatorLease, ProtectedConsentProvider, ProviderDecision,
+};
+use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum ProtectedConsentAction {
+    Accept,
+    Decline,
+    Cancel,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
+pub struct ProtectedConsentDecision {
+    pub action: ProtectedConsentAction,
+    pub request_digest: String,
+}
+
+/// Content-bounded request delivered only to trusted host code.
+///
+/// `resource_json` contains the canonical typed resource identity needed to
+/// render the decision. Hosts must not log it or forward it to a model.
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
+pub struct ProtectedConsentRequest {
+    pub schema: String,
+    pub nonce: String,
+    pub generation: u64,
+    pub daemon_instance: String,
+    pub permission_mode: String,
+    pub managed_policy_sha256: Option<String>,
+    pub user_policy_sha256: Option<String>,
+    pub operation: String,
+    pub risk_class: String,
+    pub public_session: String,
+    pub transport_session: String,
+    pub resource_json: String,
+    pub human_summary: String,
+    pub expires_unix_ms: u64,
+    pub request_digest: String,
+}
+
+#[derive(Debug, Error, uniffi::Error)]
+pub enum ProtectedConsentHostError {
+    #[error("protected host failed: {reason}")]
+    Failed { reason: String },
+}
+
+/// Callback contract implemented by a trusted embedding application.
+///
+/// The host must render approval and persistent Stop state outside the
+/// model/tool channel. Returning from `wait_for_indicator_stop` means Stop was
+/// activated; returning an error also fails closed and revokes the grant.
+#[uniffi::export(with_foreign)]
+#[async_trait]
+pub trait ProtectedConsentHost: Send + Sync {
+    async fn request_consent(
+        &self,
+        request: ProtectedConsentRequest,
+    ) -> Result<ProtectedConsentDecision, ProtectedConsentHostError>;
+
+    async fn activate_indicator(
+        &self,
+        request: ProtectedConsentRequest,
+    ) -> Result<String, ProtectedConsentHostError>;
+
+    async fn wait_for_indicator_stop(
+        &self,
+        indicator_id: String,
+    ) -> Result<(), ProtectedConsentHostError>;
+
+    async fn deactivate_indicator(
+        &self,
+        indicator_id: String,
+    ) -> Result<(), ProtectedConsentHostError>;
+}
+
+pub(crate) struct SdkProtectedConsentProvider {
+    host: Arc<dyn ProtectedConsentHost>,
+    indicators: Arc<Mutex<HashMap<String, Arc<AtomicBool>>>>,
+}
+
+impl SdkProtectedConsentProvider {
+    pub(crate) fn new(host: Arc<dyn ProtectedConsentHost>) -> Arc<Self> {
+        Arc::new(Self {
+            host,
+            indicators: Arc::new(Mutex::new(HashMap::new())),
+        })
+    }
+}
+
+#[async_trait]
+impl ProtectedConsentProvider for SdkProtectedConsentProvider {
+    fn provider_id(&self) -> &'static str {
+        "trusted_sdk_host_v1"
+    }
+
+    async fn request_consent(&self, request: &ConsentRequest) -> Result<ProviderDecision, String> {
+        let decision = self
+            .host
+            .request_consent(export_request(request)?)
+            .await
+            .map_err(|error| error.to_string())?;
+        Ok(ProviderDecision {
+            action: match decision.action {
+                ProtectedConsentAction::Accept => ConsentAction::Accept,
+                ProtectedConsentAction::Decline => ConsentAction::Decline,
+                ProtectedConsentAction::Cancel => ConsentAction::Cancel,
+            },
+            request_digest: decision.request_digest,
+        })
+    }
+
+    async fn activate_indicator(&self, request: &ConsentRequest) -> Result<IndicatorLease, String> {
+        let indicator_id = self
+            .host
+            .activate_indicator(export_request(request)?)
+            .await
+            .map_err(|error| error.to_string())?;
+        if indicator_id.trim().is_empty() {
+            return Err("protected host returned an empty indicator id".to_owned());
+        }
+
+        let revoked = Arc::new(AtomicBool::new(false));
+        {
+            let mut indicators = self.indicators.lock().unwrap();
+            if indicators.contains_key(&indicator_id) {
+                return Err("protected host reused a live indicator id".to_owned());
+            }
+            indicators.insert(indicator_id.clone(), revoked.clone());
+        }
+
+        // Two independent signals close the loop:
+        // - the host resolves `wait_for_indicator_stop` when the human presses
+        //   Stop (or on host/channel failure);
+        // - Cua flips the lease flag on session/runtime-side revocation.
+        // Either path deactivates the host surface and revokes the grant.
+        let host = self.host.clone();
+        let indicators = self.indicators.clone();
+        let indicator_for_task = indicator_id.clone();
+        let revoked_for_task = revoked.clone();
+        tokio::spawn(async move {
+            tokio::select! {
+                _ = host.wait_for_indicator_stop(indicator_for_task.clone()) => {
+                    revoked_for_task.store(true, Ordering::Release);
+                }
+                _ = async {
+                    while !revoked_for_task.load(Ordering::Acquire) {
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                    }
+                } => {}
+            }
+            revoked_for_task.store(true, Ordering::Release);
+            let was_live = indicators
+                .lock()
+                .unwrap()
+                .remove(&indicator_for_task)
+                .is_some();
+            if was_live {
+                let _ = host.deactivate_indicator(indicator_for_task).await;
+            }
+        });
+
+        Ok(IndicatorLease::new(indicator_id, revoked))
+    }
+
+    async fn deactivate_indicator(&self, indicator_id: &str) {
+        let revoked = self.indicators.lock().unwrap().remove(indicator_id);
+        if let Some(revoked) = revoked {
+            revoked.store(true, Ordering::Release);
+            let _ = self
+                .host
+                .deactivate_indicator(indicator_id.to_owned())
+                .await;
+        }
+    }
+}
+
+fn export_request(request: &ConsentRequest) -> Result<ProtectedConsentRequest, String> {
+    Ok(ProtectedConsentRequest {
+        schema: request.schema.to_owned(),
+        nonce: request.nonce.clone(),
+        generation: request.generation,
+        daemon_instance: request.daemon_instance.clone(),
+        permission_mode: request.permission_mode.as_str().to_owned(),
+        managed_policy_sha256: request.managed_policy_sha256.clone(),
+        user_policy_sha256: request.user_policy_sha256.clone(),
+        operation: request.operation.clone(),
+        risk_class: request.risk_class.as_str().to_owned(),
+        public_session: request.public_session.clone(),
+        transport_session: request.transport_session.clone(),
+        resource_json: serde_json::to_string(&request.resource)
+            .map_err(|error| format!("could not serialize protected resource: {error}"))?,
+        human_summary: request.human_summary.clone(),
+        expires_unix_ms: u64::try_from(request.expires_unix_ms).unwrap_or(u64::MAX),
+        request_digest: request.request_digest.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cua_driver_core::authorization::{PermissionMode, RiskClass};
+    use cua_driver_core::consent::ApprovalBroker;
+    use std::sync::atomic::AtomicUsize;
+    use tokio::sync::Notify;
+
+    struct FakeHost {
+        action: ProtectedConsentAction,
+        stop: Notify,
+        deactivated: AtomicUsize,
+        fail_indicator: bool,
+    }
+
+    #[async_trait]
+    impl ProtectedConsentHost for FakeHost {
+        async fn request_consent(
+            &self,
+            request: ProtectedConsentRequest,
+        ) -> Result<ProtectedConsentDecision, ProtectedConsentHostError> {
+            Ok(ProtectedConsentDecision {
+                action: self.action,
+                request_digest: request.request_digest,
+            })
+        }
+
+        async fn activate_indicator(
+            &self,
+            request: ProtectedConsentRequest,
+        ) -> Result<String, ProtectedConsentHostError> {
+            if self.fail_indicator {
+                return Err(ProtectedConsentHostError::Failed {
+                    reason: "indicator unavailable".to_owned(),
+                });
+            }
+            Ok(format!("indicator-{}", request.generation))
+        }
+
+        async fn wait_for_indicator_stop(
+            &self,
+            _indicator_id: String,
+        ) -> Result<(), ProtectedConsentHostError> {
+            self.stop.notified().await;
+            Ok(())
+        }
+
+        async fn deactivate_indicator(
+            &self,
+            _indicator_id: String,
+        ) -> Result<(), ProtectedConsentHostError> {
+            self.deactivated.fetch_add(1, Ordering::AcqRel);
+            Ok(())
+        }
+    }
+
+    fn host(action: ProtectedConsentAction, fail_indicator: bool) -> Arc<FakeHost> {
+        Arc::new(FakeHost {
+            action,
+            stop: Notify::new(),
+            deactivated: AtomicUsize::new(0),
+            fail_indicator,
+        })
+    }
+
+    fn request(broker: &ApprovalBroker, mode: PermissionMode) -> ConsentRequest {
+        broker.request(
+            mode,
+            "private_observation",
+            RiskClass::R2,
+            "public",
+            "transport",
+            serde_json::json!({"pid": 42, "window_id": 7}),
+            "Observe window 7 from process 42",
+        )
+    }
+
+    #[tokio::test]
+    async fn exact_standard_decision_activates_a_live_indicator() {
+        let host = host(ProtectedConsentAction::Accept, false);
+        let provider = SdkProtectedConsentProvider::new(host.clone());
+        let broker = ApprovalBroker::new(Some(provider));
+        let grant = broker
+            .approve(&request(&broker, PermissionMode::Standard))
+            .await
+            .unwrap();
+
+        assert!(grant.is_live());
+        host.stop.notify_one();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while grant.is_live() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(host.deactivated.load(Ordering::Acquire), 1);
+    }
+
+    #[tokio::test]
+    async fn decline_and_indicator_failure_fail_closed() {
+        let declining = host(ProtectedConsentAction::Decline, false);
+        let provider = SdkProtectedConsentProvider::new(declining);
+        let broker = ApprovalBroker::new(Some(provider));
+        assert!(matches!(
+            broker
+                .approve(&request(&broker, PermissionMode::Standard))
+                .await,
+            Err(cua_driver_core::consent::ConsentError::Declined)
+        ));
+
+        let broken = host(ProtectedConsentAction::Accept, true);
+        let provider = SdkProtectedConsentProvider::new(broken);
+        let broker = ApprovalBroker::new(Some(provider));
+        assert!(matches!(
+            broker
+                .approve(&request(&broker, PermissionMode::Standard))
+                .await,
+            Err(cua_driver_core::consent::ConsentError::Indicator(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn cua_side_revocation_deactivates_the_host_indicator() {
+        let host = host(ProtectedConsentAction::Accept, false);
+        let provider = SdkProtectedConsentProvider::new(host.clone());
+        let broker = ApprovalBroker::new(Some(provider));
+        let grant = broker
+            .activate_preapproved(&request(&broker, PermissionMode::Bounded))
+            .await
+            .unwrap();
+
+        broker.revoke(&grant).await;
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while host.deactivated.load(Ordering::Acquire) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        assert!(!grant.is_live());
+    }
+}

--- a/libs/cua-driver/rust/crates/cua-driver-sdk/src/runtime.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-sdk/src/runtime.rs
@@ -41,7 +41,7 @@ pub(crate) enum RuntimeCreateError {
     Unavailable(String),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct RuntimeOptions {
     pub cursor: CursorConfig,
     /// Whether the importing/embedding host owns macOS permission UX. Such a
@@ -54,6 +54,10 @@ pub(crate) struct RuntimeOptions {
     pub register_host_tools: Option<fn(&mut ToolRegistry)>,
     pub authorization_ceiling: Option<SessionModeCeiling>,
     pub compatibility_authorization: Option<(PermissionMode, Option<Arc<SessionManifest>>)>,
+    /// Constructor-only protected host. This object is never reachable from
+    /// public tool arguments or transport metadata.
+    pub protected_consent_provider:
+        Option<Arc<dyn cua_driver_core::consent::ProtectedConsentProvider>>,
 }
 
 impl RuntimeOptions {
@@ -70,6 +74,7 @@ impl RuntimeOptions {
             register_host_tools: None,
             authorization_ceiling: None,
             compatibility_authorization: None,
+            protected_consent_provider: None,
         }
     }
 
@@ -390,7 +395,8 @@ fn build_registry(options: &RuntimeOptions) -> ToolRegistry {
     #[cfg(target_os = "macos")]
     let mut registry = {
         configure_macos_runtime();
-        platform_macos::register_tools_with_cursor(
+        platform_macos::register_tools_with_cursor_and_provider(
+            options.protected_consent_provider.clone(),
             options.cursor.clone(),
             options.compatibility_mode,
             options.host_owns_permission_ux,
@@ -401,7 +407,8 @@ fn build_registry(options: &RuntimeOptions) -> ToolRegistry {
     #[cfg(target_os = "windows")]
     let mut registry = {
         configure_windows_runtime();
-        platform_windows::register_tools_with_cursor(
+        platform_windows::register_tools_with_cursor_and_provider(
+            options.protected_consent_provider.clone(),
             options.cursor.clone(),
             options.compatibility_mode,
         )
@@ -410,7 +417,8 @@ fn build_registry(options: &RuntimeOptions) -> ToolRegistry {
     #[cfg(target_os = "linux")]
     let mut registry = {
         configure_linux_runtime(options.prepare_desktop_environment);
-        platform_linux::register_tools_with_cursor(
+        platform_linux::register_tools_with_cursor_and_provider(
+            options.protected_consent_provider.clone(),
             options.cursor.clone(),
             options.compatibility_mode,
         )

--- a/libs/cua-driver/rust/crates/platform-linux/src/lib.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/lib.rs
@@ -133,13 +133,21 @@ pub fn register_tools() -> ToolRegistry {
 /// (pid + window_id required, JPEG @ 85%, text note pointing at pixel
 /// tools). See `tools::impl_::ScreenshotCompatTool`.
 pub fn register_tools_with_cursor(cfg: cursor_overlay::CursorConfig, compat: bool) -> ToolRegistry {
+    register_tools_with_cursor_and_provider(None, cfg, compat)
+}
+
+pub fn register_tools_with_cursor_and_provider(
+    provider: Option<std::sync::Arc<dyn cua_driver_core::consent::ProtectedConsentProvider>>,
+    cfg: cursor_overlay::CursorConfig,
+    compat: bool,
+) -> ToolRegistry {
     #[cfg(target_os = "linux")]
     wayland::ensure_nested_session();
     if cfg.enabled {
         overlay::init(cfg.clone());
         overlay::run_on_thread();
     }
-    tools::build_registry(compat)
+    tools::build_registry_with_provider(compat, provider)
 }
 
 #[cfg(test)]

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -7119,9 +7119,10 @@ pub fn build_registry(compat: bool) -> ToolRegistry {
     r.register(Box::new(cua_driver_core::page::PageTool::new(Arc::new(
         super::page::LinuxPageBackend::new(),
     ))));
-    let browser_engine = cua_driver_core::browser::BrowserEngine::new(Arc::new(
-        crate::browser_platform::LinuxBrowserPlatform,
-    ));
+    let browser_engine = cua_driver_core::browser::BrowserEngine::new_with_approval_broker(
+        Arc::new(crate::browser_platform::LinuxBrowserPlatform),
+        r.approval_broker(),
+    );
     cua_driver_core::browser::register_browser_tools(&browser_engine, &mut r);
     r.register_recording_tools();
     r.register_session_tools();

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -6958,6 +6958,13 @@ impl Tool for BringToFrontTool {
 // ── registry ─────────────────────────────────────────────────────────────────
 
 pub fn build_registry(compat: bool) -> ToolRegistry {
+    build_registry_with_provider(compat, None)
+}
+
+pub fn build_registry_with_provider(
+    compat: bool,
+    provider: Option<std::sync::Arc<dyn cua_driver_core::consent::ProtectedConsentProvider>>,
+) -> ToolRegistry {
     let state = ToolState::new();
     let cursor_outcome_reader = {
         let cursor_registry = state.cursor_registry.clone();
@@ -7010,7 +7017,7 @@ pub fn build_registry(compat: bool) -> ToolRegistry {
             crate::input::forget_master_pointer(session_id);
         })
     };
-    let mut r = ToolRegistry::new();
+    let mut r = ToolRegistry::new_with_protected_consent_provider(provider);
     r.retain_cursor_outcome_reader(cursor_outcome_reader);
     r.retain_session_end_hook(session_end_hook);
     if let Some(runtime_scope) = cua_driver_core::tool::current_dispatch_runtime_scope() {

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/mod.rs
@@ -14,12 +14,20 @@ pub(crate) mod page;
 mod stubs;
 
 pub fn build_registry(compat: bool) -> ToolRegistry {
+    build_registry_with_provider(compat, None)
+}
+
+pub fn build_registry_with_provider(
+    compat: bool,
+    provider: Option<std::sync::Arc<dyn cua_driver_core::consent::ProtectedConsentProvider>>,
+) -> ToolRegistry {
     #[cfg(target_os = "linux")]
-    return impl_::build_registry(compat);
+    return impl_::build_registry_with_provider(compat, provider);
 
     #[cfg(not(target_os = "linux"))]
     {
         let _ = compat;
+        let _ = provider;
         stubs::build_registry()
     }
 }

--- a/libs/cua-driver/rust/crates/platform-macos/src/lib.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/lib.rs
@@ -83,6 +83,26 @@ pub fn register_tools_with_cursor(
     host_owns_permission_ux: bool,
     host_bundle_id: Option<String>,
 ) -> ToolRegistry {
+    register_tools_with_cursor_and_provider(
+        None,
+        cfg,
+        compat,
+        host_owns_permission_ux,
+        host_bundle_id,
+    )
+}
+
+/// Register all macOS tools with a constructor-installed protected host.
+///
+/// This is used by the canonical SDK runtime. The original public constructor
+/// remains unchanged for callers that do not host protected consent.
+pub fn register_tools_with_cursor_and_provider(
+    provider: Option<std::sync::Arc<dyn cua_driver_core::consent::ProtectedConsentProvider>>,
+    cfg: cursor_overlay::CursorConfig,
+    compat: bool,
+    host_owns_permission_ux: bool,
+    host_bundle_id: Option<String>,
+) -> ToolRegistry {
     #[cfg(target_os = "macos")]
     {
         let cursor_overlay_available =
@@ -90,7 +110,7 @@ pub fn register_tools_with_cursor(
         if cursor_overlay_available {
             cursor::overlay::init(cfg);
         }
-        let mut r = ToolRegistry::new();
+        let mut r = ToolRegistry::new_with_protected_consent_provider(provider);
         tools::register_all(
             &mut r,
             compat,
@@ -106,6 +126,7 @@ pub fn register_tools_with_cursor(
         let _ = compat;
         let _ = host_owns_permission_ux;
         let _ = host_bundle_id;
+        let _ = provider;
         ToolRegistry::new()
     }
 }

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
@@ -682,9 +682,12 @@ pub fn register_all(
     registry.register(Box::new(cua_driver_core::page::PageTool::new(Arc::new(
         page::MacOsPageBackend::new(state.clone()),
     ))));
-    let browser_engine = cua_driver_core::browser::BrowserEngine::new(Arc::new(
-        crate::browser::MacOsBrowserPlatform::new(state.cursor_registry.clone()),
-    ));
+    let browser_engine = cua_driver_core::browser::BrowserEngine::new_with_approval_broker(
+        Arc::new(crate::browser::MacOsBrowserPlatform::new(
+            state.cursor_registry.clone(),
+        )),
+        registry.approval_broker(),
+    );
     cua_driver_core::browser::register_browser_tools(&browser_engine, registry);
     // Recording / replay + session-lifecycle tools are platform-independent.
     registry.register_recording_tools();

--- a/libs/cua-driver/rust/crates/platform-windows/src/lib.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/lib.rs
@@ -81,9 +81,17 @@ pub fn register_tools() -> ToolRegistry {
 /// (pid + window_id required, JPEG @ 85%, text note pointing at pixel
 /// tools). See `tools::impl_::ScreenshotCompatTool`.
 pub fn register_tools_with_cursor(cfg: cursor_overlay::CursorConfig, compat: bool) -> ToolRegistry {
+    register_tools_with_cursor_and_provider(None, cfg, compat)
+}
+
+pub fn register_tools_with_cursor_and_provider(
+    provider: Option<std::sync::Arc<dyn cua_driver_core::consent::ProtectedConsentProvider>>,
+    cfg: cursor_overlay::CursorConfig,
+    compat: bool,
+) -> ToolRegistry {
     if cfg.enabled {
         overlay::init(cfg.clone());
         overlay::run_on_thread();
     }
-    tools::build_registry(compat)
+    tools::build_registry_with_provider(compat, provider)
 }

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -8715,9 +8715,12 @@ pub fn build_registry(compat: bool) -> ToolRegistry {
     r.register(Box::new(cua_driver_core::page::PageTool::new(
         std::sync::Arc::new(super::page::WindowsPageBackend::new()),
     )));
-    let browser_engine = cua_driver_core::browser::BrowserEngine::new(std::sync::Arc::new(
-        crate::browser_platform::WindowsBrowserPlatform::new(state.cursor_registry.clone()),
-    ));
+    let browser_engine = cua_driver_core::browser::BrowserEngine::new_with_approval_broker(
+        std::sync::Arc::new(crate::browser_platform::WindowsBrowserPlatform::new(
+            state.cursor_registry.clone(),
+        )),
+        r.approval_broker(),
+    );
     cua_driver_core::browser::register_browser_tools(&browser_engine, &mut r);
     r.register_recording_tools();
     r.register_session_tools();

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -8537,6 +8537,13 @@ impl Tool for DebugWindowInfoTool {
 // ── registry builder ──────────────────────────────────────────────────────────
 
 pub fn build_registry(compat: bool) -> ToolRegistry {
+    build_registry_with_provider(compat, None)
+}
+
+pub fn build_registry_with_provider(
+    compat: bool,
+    provider: Option<std::sync::Arc<dyn cua_driver_core::consent::ProtectedConsentProvider>>,
+) -> ToolRegistry {
     let state = ToolState::new();
     let cursor_outcome_reader = {
         let cursor_registry = state.cursor_registry.clone();
@@ -8594,7 +8601,7 @@ pub fn build_registry(compat: bool) -> ToolRegistry {
             crate::overlay::remove_cursor(session_id.to_owned());
         });
 
-    let mut r = ToolRegistry::new();
+    let mut r = ToolRegistry::new_with_protected_consent_provider(provider);
     r.retain_cursor_outcome_reader(cursor_outcome_reader);
     r.retain_session_end_hook(session_end_hook);
     if let Some(runtime_scope) = cua_driver_core::tool::current_dispatch_runtime_scope() {

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/mod.rs
@@ -16,12 +16,20 @@ pub(crate) mod page_bookmark;
 mod stubs;
 
 pub fn build_registry(compat: bool) -> ToolRegistry {
+    build_registry_with_provider(compat, None)
+}
+
+pub fn build_registry_with_provider(
+    compat: bool,
+    provider: Option<std::sync::Arc<dyn cua_driver_core::consent::ProtectedConsentProvider>>,
+) -> ToolRegistry {
     #[cfg(target_os = "windows")]
-    return impl_::build_registry(compat);
+    return impl_::build_registry_with_provider(compat, provider);
 
     #[cfg(not(target_os = "windows"))]
     {
         let _ = compat;
+        let _ = provider;
         stubs::build_registry()
     }
 }

--- a/libs/cua-driver/typescript/src/index.ts
+++ b/libs/cua-driver/typescript/src/index.ts
@@ -13,6 +13,12 @@ CuaDriver.create = (options) =>
   CuaDriver.createWithClientKind(options, SdkClientKind.Typescript)
 CuaDriver.createConfigured = (options) =>
   CuaDriver.createConfiguredWithClientKind(options, SdkClientKind.Typescript)
+CuaDriver.createConfiguredWithProtectedHost = (options, host) =>
+  CuaDriver.createConfiguredWithProtectedHostAndClientKind(
+    options,
+    host,
+    SdkClientKind.Typescript,
+  )
 CuaDriver.createPrivateWorker = (options) =>
   CuaDriver.createPrivateWorkerWithClientKind(options, SdkClientKind.Typescript)
 CuaDriver.connect = (socketPath: string | undefined) =>

--- a/libs/cua-driver/typescript/src/native/cua_driver_sdk-ffi.ts
+++ b/libs/cua-driver/typescript/src/native/cua_driver_sdk-ffi.ts
@@ -293,6 +293,21 @@ const DEFINITIONS = {
       ret: FfiType.Void,
       hasRustCallStatus: true,
     },
+    "uniffi_cua_driver_sdk_fn_clone_protectedconsenthost": {
+      args: [FfiType.Handle],
+      ret: FfiType.Handle,
+      hasRustCallStatus: true,
+    },
+    "uniffi_cua_driver_sdk_fn_free_protectedconsenthost": {
+      args: [FfiType.Handle],
+      ret: FfiType.Void,
+      hasRustCallStatus: true,
+    },
+    "uniffi_cua_driver_sdk_fn_init_callback_vtable_protectedconsenthost": {
+      args: [FfiType.Reference(FfiType.Struct("VTableCallbackInterfaceCuaDriverSdkProtectedConsentHost"))],
+      ret: FfiType.Void,
+      hasRustCallStatus: false,
+    },
     "uniffi_cua_driver_sdk_fn_func_create_trusted_session": {
       args: [FfiType.Handle, FfiType.RustBuffer],
       ret: FfiType.Handle,
@@ -335,6 +350,16 @@ const DEFINITIONS = {
     },
     "uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_configured_with_client_kind": {
       args: [FfiType.RustBuffer, FfiType.RustBuffer],
+      ret: FfiType.Handle,
+      hasRustCallStatus: true,
+    },
+    "uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_configured_with_protected_host": {
+      args: [FfiType.RustBuffer, FfiType.Handle],
+      ret: FfiType.Handle,
+      hasRustCallStatus: true,
+    },
+    "uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_configured_with_protected_host_and_client_kind": {
+      args: [FfiType.RustBuffer, FfiType.Handle, FfiType.RustBuffer],
       ret: FfiType.Handle,
       hasRustCallStatus: true,
     },
@@ -583,6 +608,26 @@ const DEFINITIONS = {
       ret: FfiType.Handle,
       hasRustCallStatus: false,
     },
+    "uniffi_cua_driver_sdk_fn_method_protectedconsenthost_request_consent": {
+      args: [FfiType.Handle, FfiType.RustBuffer],
+      ret: FfiType.Handle,
+      hasRustCallStatus: false,
+    },
+    "uniffi_cua_driver_sdk_fn_method_protectedconsenthost_activate_indicator": {
+      args: [FfiType.Handle, FfiType.RustBuffer],
+      ret: FfiType.Handle,
+      hasRustCallStatus: false,
+    },
+    "uniffi_cua_driver_sdk_fn_method_protectedconsenthost_wait_for_indicator_stop": {
+      args: [FfiType.Handle, FfiType.RustBuffer],
+      ret: FfiType.Handle,
+      hasRustCallStatus: false,
+    },
+    "uniffi_cua_driver_sdk_fn_method_protectedconsenthost_deactivate_indicator": {
+      args: [FfiType.Handle, FfiType.RustBuffer],
+      ret: FfiType.Handle,
+      hasRustCallStatus: false,
+    },
     "ffi_cua_driver_sdk_uniffi_contract_version": {
       args: [],
       ret: FfiType.UInt32,
@@ -629,6 +674,16 @@ const DEFINITIONS = {
       hasRustCallStatus: false,
     },
     "uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured_with_client_kind": {
+      args: [],
+      ret: FfiType.UInt16,
+      hasRustCallStatus: false,
+    },
+    "uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured_with_protected_host": {
+      args: [],
+      ret: FfiType.UInt16,
+      hasRustCallStatus: false,
+    },
+    "uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured_with_protected_host_and_client_kind": {
       args: [],
       ret: FfiType.UInt16,
       hasRustCallStatus: false,
@@ -878,6 +933,26 @@ const DEFINITIONS = {
       ret: FfiType.UInt16,
       hasRustCallStatus: false,
     },
+    "uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_request_consent": {
+      args: [],
+      ret: FfiType.UInt16,
+      hasRustCallStatus: false,
+    },
+    "uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_activate_indicator": {
+      args: [],
+      ret: FfiType.UInt16,
+      hasRustCallStatus: false,
+    },
+    "uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_wait_for_indicator_stop": {
+      args: [],
+      ret: FfiType.UInt16,
+      hasRustCallStatus: false,
+    },
+    "uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_deactivate_indicator": {
+      args: [],
+      ret: FfiType.UInt16,
+      hasRustCallStatus: false,
+    },
   },
   callbacks: {
     "RustFutureContinuationCallback": {
@@ -890,11 +965,70 @@ const DEFINITIONS = {
       ret: FfiType.Void,
       hasRustCallStatus: false,
     },
+    "ForeignFutureCompleterust_buffer": {
+      args: [FfiType.Handle, FfiType.Struct("ForeignFutureResultRustBuffer")],
+      ret: FfiType.Void,
+      hasRustCallStatus: false,
+    },
+    "CallbackInterfaceCuaDriverSdkProtectedConsentHostMethod0": {
+      args: [FfiType.Handle, FfiType.RustBuffer, FfiType.Callback("ForeignFutureCompleterust_buffer"), FfiType.Handle],
+      ret: FfiType.Struct("ForeignFutureDroppedCallbackStruct"),
+      hasRustCallStatus: false,
+      outReturn: true,
+    },
+    "CallbackInterfaceCuaDriverSdkProtectedConsentHostMethod1": {
+      args: [FfiType.Handle, FfiType.RustBuffer, FfiType.Callback("ForeignFutureCompleterust_buffer"), FfiType.Handle],
+      ret: FfiType.Struct("ForeignFutureDroppedCallbackStruct"),
+      hasRustCallStatus: false,
+      outReturn: true,
+    },
+    "ForeignFutureCompletevoid": {
+      args: [FfiType.Handle, FfiType.Struct("ForeignFutureResultVoid")],
+      ret: FfiType.Void,
+      hasRustCallStatus: false,
+    },
+    "CallbackInterfaceCuaDriverSdkProtectedConsentHostMethod2": {
+      args: [FfiType.Handle, FfiType.RustBuffer, FfiType.Callback("ForeignFutureCompletevoid"), FfiType.Handle],
+      ret: FfiType.Struct("ForeignFutureDroppedCallbackStruct"),
+      hasRustCallStatus: false,
+      outReturn: true,
+    },
+    "CallbackInterfaceCuaDriverSdkProtectedConsentHostMethod3": {
+      args: [FfiType.Handle, FfiType.RustBuffer, FfiType.Callback("ForeignFutureCompletevoid"), FfiType.Handle],
+      ret: FfiType.Struct("ForeignFutureDroppedCallbackStruct"),
+      hasRustCallStatus: false,
+      outReturn: true,
+    },
+    "CallbackInterfaceCloneCuaDriverSdk_ProtectedConsentHost": {
+      args: [FfiType.Handle],
+      ret: FfiType.Handle,
+      hasRustCallStatus: false,
+    },
+    "CallbackInterfaceFreeCuaDriverSdk_ProtectedConsentHost": {
+      args: [FfiType.Handle],
+      ret: FfiType.Void,
+      hasRustCallStatus: false,
+    },
   },
   structs: {
     "ForeignFutureDroppedCallbackStruct": [
       { name: "handle", type: FfiType.Handle },
       { name: "free", type: FfiType.Callback("ForeignFutureDroppedCallback") },
+    ],
+    "ForeignFutureResultRustBuffer": [
+      { name: "return_value", type: FfiType.RustBuffer },
+      { name: "call_status", type: FfiType.RustCallStatus },
+    ],
+    "ForeignFutureResultVoid": [
+      { name: "call_status", type: FfiType.RustCallStatus },
+    ],
+    "VTableCallbackInterfaceCuaDriverSdkProtectedConsentHost": [
+      { name: "uniffi_free", type: FfiType.Callback("CallbackInterfaceFreeCuaDriverSdk_ProtectedConsentHost") },
+      { name: "uniffi_clone", type: FfiType.Callback("CallbackInterfaceCloneCuaDriverSdk_ProtectedConsentHost") },
+      { name: "request_consent", type: FfiType.Callback("CallbackInterfaceCuaDriverSdkProtectedConsentHostMethod0") },
+      { name: "activate_indicator", type: FfiType.Callback("CallbackInterfaceCuaDriverSdkProtectedConsentHostMethod1") },
+      { name: "wait_for_indicator_stop", type: FfiType.Callback("CallbackInterfaceCuaDriverSdkProtectedConsentHostMethod2") },
+      { name: "deactivate_indicator", type: FfiType.Callback("CallbackInterfaceCuaDriverSdkProtectedConsentHostMethod3") },
     ],
   },
 } as const;
@@ -954,6 +1088,9 @@ interface NativeModuleInterface {
     uniffi_cua_driver_sdk_fn_free_cuadriversession(ptr: bigint, uniffi_out_err: UniffiRustCallStatus): void;
     uniffi_cua_driver_sdk_fn_clone_embeddedcuadriverhost(ptr: bigint, uniffi_out_err: UniffiRustCallStatus): bigint;
     uniffi_cua_driver_sdk_fn_free_embeddedcuadriverhost(ptr: bigint, uniffi_out_err: UniffiRustCallStatus): void;
+    uniffi_cua_driver_sdk_fn_clone_protectedconsenthost(ptr: bigint, uniffi_out_err: UniffiRustCallStatus): bigint;
+    uniffi_cua_driver_sdk_fn_free_protectedconsenthost(ptr: bigint, uniffi_out_err: UniffiRustCallStatus): void;
+    uniffi_cua_driver_sdk_fn_init_callback_vtable_protectedconsenthost(vtable: UniffiVTableCallbackInterfaceCuaDriverSdkProtectedConsentHost): void;
     uniffi_cua_driver_sdk_fn_func_create_trusted_session(driver: bigint, options: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
     uniffi_cua_driver_sdk_fn_func_current_mac_os_permission_status(uniffi_out_err: UniffiRustCallStatus): Uint8Array;
     uniffi_cua_driver_sdk_fn_func_open_mac_os_screen_recording_settings(uniffi_out_err: UniffiRustCallStatus): void;
@@ -963,6 +1100,8 @@ interface NativeModuleInterface {
     uniffi_cua_driver_sdk_fn_constructor_cuadriver_create(options: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
     uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_configured(options: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
     uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_configured_with_client_kind(options: Uint8Array, clientKind: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
+    uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_configured_with_protected_host(options: Uint8Array, host: bigint, uniffi_out_err: UniffiRustCallStatus): bigint;
+    uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_configured_with_protected_host_and_client_kind(options: Uint8Array, host: bigint, clientKind: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
     uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_private_worker(options: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
     uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_private_worker_with_client_kind(options: Uint8Array, clientKind: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
     uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_with_client_kind(options: Uint8Array, clientKind: Uint8Array, uniffi_out_err: UniffiRustCallStatus): bigint;
@@ -1012,6 +1151,10 @@ interface NativeModuleInterface {
     uniffi_cua_driver_sdk_fn_method_embeddedcuadriverhost_state(uniffiSelf: bigint, uniffi_out_err: UniffiRustCallStatus): Uint8Array;
     uniffi_cua_driver_sdk_fn_method_embeddedcuadriverhost_stop(uniffiSelf: bigint): bigint;
     uniffi_cua_driver_sdk_fn_method_embeddedcuadriverhost_wait_for_exit(uniffiSelf: bigint, generation: Uint8Array): bigint;
+    uniffi_cua_driver_sdk_fn_method_protectedconsenthost_request_consent(uniffiSelf: bigint, request: Uint8Array): bigint;
+    uniffi_cua_driver_sdk_fn_method_protectedconsenthost_activate_indicator(uniffiSelf: bigint, request: Uint8Array): bigint;
+    uniffi_cua_driver_sdk_fn_method_protectedconsenthost_wait_for_indicator_stop(uniffiSelf: bigint, indicatorId: Uint8Array): bigint;
+    uniffi_cua_driver_sdk_fn_method_protectedconsenthost_deactivate_indicator(uniffiSelf: bigint, indicatorId: Uint8Array): bigint;
     ffi_cua_driver_sdk_uniffi_contract_version(): number;
     uniffi_cua_driver_sdk_checksum_func_create_trusted_session(): number;
     uniffi_cua_driver_sdk_checksum_func_current_mac_os_permission_status(): number;
@@ -1022,6 +1165,8 @@ interface NativeModuleInterface {
     uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create(): number;
     uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured(): number;
     uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured_with_client_kind(): number;
+    uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured_with_protected_host(): number;
+    uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured_with_protected_host_and_client_kind(): number;
     uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_private_worker(): number;
     uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_private_worker_with_client_kind(): number;
     uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_with_client_kind(): number;
@@ -1071,6 +1216,10 @@ interface NativeModuleInterface {
     uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_state(): number;
     uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_stop(): number;
     uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_wait_for_exit(): number;
+    uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_request_consent(): number;
+    uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_activate_indicator(): number;
+    uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_wait_for_indicator_stop(): number;
+    uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_deactivate_indicator(): number;
     // Codegen call sites use these via `nativeModule().rustbuffer_alloc(...)`
     // and `nativeModule().rustbuffer_free(...)`. The runtime's registered
     // module exposes them as method properties.
@@ -1100,4 +1249,27 @@ export type UniffiForeignFutureDroppedCallback = (handle: bigint) => void;
 export type UniffiForeignFutureDroppedCallbackStruct = {
   handle: bigint;
   free: UniffiForeignFutureDroppedCallback;
+};
+export type UniffiForeignFutureResultRustBuffer = {
+  return_value: Uint8Array;
+  call_status: UniffiRustCallStatus;
+};
+export type UniffiForeignFutureCompleterustBuffer = (callbackData: bigint, result: UniffiForeignFutureResultRustBuffer) => void;
+type UniffiCallbackInterfaceCuaDriverSdkProtectedConsentHostMethod0 = (uniffiHandle: bigint, request: Uint8Array, uniffiFutureCallback: UniffiForeignFutureCompleterustBuffer, uniffiCallbackData: bigint) => UniffiForeignFutureDroppedCallbackStruct;
+type UniffiCallbackInterfaceCuaDriverSdkProtectedConsentHostMethod1 = (uniffiHandle: bigint, request: Uint8Array, uniffiFutureCallback: UniffiForeignFutureCompleterustBuffer, uniffiCallbackData: bigint) => UniffiForeignFutureDroppedCallbackStruct;
+export type UniffiForeignFutureResultVoid = {
+  call_status: UniffiRustCallStatus;
+};
+export type UniffiForeignFutureCompletevoid = (callbackData: bigint, result: UniffiForeignFutureResultVoid) => void;
+type UniffiCallbackInterfaceCuaDriverSdkProtectedConsentHostMethod2 = (uniffiHandle: bigint, indicatorId: Uint8Array, uniffiFutureCallback: UniffiForeignFutureCompletevoid, uniffiCallbackData: bigint) => UniffiForeignFutureDroppedCallbackStruct;
+type UniffiCallbackInterfaceCuaDriverSdkProtectedConsentHostMethod3 = (uniffiHandle: bigint, indicatorId: Uint8Array, uniffiFutureCallback: UniffiForeignFutureCompletevoid, uniffiCallbackData: bigint) => UniffiForeignFutureDroppedCallbackStruct;
+type UniffiCallbackInterfaceCloneCuaDriverSdkProtectedConsentHost = (handle: bigint) => UniffiResult<void>;
+type UniffiCallbackInterfaceFreeCuaDriverSdkProtectedConsentHost = (handle: bigint) => void;
+export type UniffiVTableCallbackInterfaceCuaDriverSdkProtectedConsentHost = {
+  uniffi_free: UniffiCallbackInterfaceFreeCuaDriverSdkProtectedConsentHost;
+  uniffi_clone: UniffiCallbackInterfaceCloneCuaDriverSdkProtectedConsentHost;
+  request_consent: UniffiCallbackInterfaceCuaDriverSdkProtectedConsentHostMethod0;
+  activate_indicator: UniffiCallbackInterfaceCuaDriverSdkProtectedConsentHostMethod1;
+  wait_for_indicator_stop: UniffiCallbackInterfaceCuaDriverSdkProtectedConsentHostMethod2;
+  deactivate_indicator: UniffiCallbackInterfaceCuaDriverSdkProtectedConsentHostMethod3;
 };

--- a/libs/cua-driver/typescript/src/native/cua_driver_sdk.ts
+++ b/libs/cua-driver/typescript/src/native/cua_driver_sdk.ts
@@ -4,11 +4,11 @@
 /* eslint-disable */
 // @ts-nocheck
 import nativeModule from "./cua_driver_sdk-ffi.js";
-import { type UniffiRustFutureContinuationCallback, type UniffiForeignFutureDroppedCallback, type UniffiForeignFutureDroppedCallbackStruct,
+import { type UniffiRustFutureContinuationCallback, type UniffiForeignFutureDroppedCallback, type UniffiForeignFutureDroppedCallbackStruct, type UniffiForeignFutureResultRustBuffer, type UniffiForeignFutureCompleterustBuffer, type UniffiForeignFutureResultVoid, type UniffiForeignFutureCompletevoid, type UniffiVTableCallbackInterfaceCuaDriverSdkProtectedConsentHost,
 } from "./cua_driver_sdk-ffi.js";
 import { type ClickInput, type DragInput, type EndSessionInput, type EndSessionOutput, type EscalateSessionInput, type GetCursorPositionInput, type GetDesktopStateInput, type GetScreenSizeInput, type GetSessionStateInput, type HotkeyInput, type MoveCursorInput, type PressKeyInput, type ScrollInput, type SessionStateOutput, type StartSessionInput, type StartSessionOutput, type TypeTextInput,
 } from "./cua_driver_contract.js";
-import { type FfiConverter, type UniffiByteArray, type UniffiGcObject, type UniffiHandle, type UniffiObjectFactory, AbstractFfiConverterByteArray, FfiConverterArray, FfiConverterBool, FfiConverterInt32, FfiConverterObject, FfiConverterOptional, FfiConverterUInt32, FfiConverterUInt64, FfiConverterUInt8, RustBuffer, UniffiAbstractObject, UniffiEnum, UniffiError, UniffiInternalError, UniffiRustCaller, destructorGuardSymbol, pointerLiteralSymbol, uniffiCreateFfiConverterString, uniffiCreateRecord, uniffiRustCallAsync, uniffiTypeNameSymbol, variantOrdinalSymbol,
+import { type FfiConverter, type UniffiByteArray, type UniffiGcObject, type UniffiHandle, type UniffiObjectFactory, type UniffiReferenceHolder, type UniffiRustCallStatus, AbstractFfiConverterByteArray, FfiConverterArray, FfiConverterBool, FfiConverterInt32, FfiConverterObject, FfiConverterObjectWithCallbacks, FfiConverterOptional, FfiConverterUInt32, FfiConverterUInt64, FfiConverterUInt8, RustBuffer, UniffiAbstractObject, UniffiEnum, UniffiError, UniffiInternalError, UniffiResult, UniffiRustCaller, destructorGuardSymbol, pointerLiteralSymbol, uniffiCreateFfiConverterString, uniffiCreateRecord, uniffiRustCallAsync, uniffiTraitInterfaceCallAsyncWithError, uniffiTypeNameSymbol, variantOrdinalSymbol,
 } from "@ubjs/core";
 import uniffiCuaDriverContractModule from "./cua_driver_contract.js";
 const { FfiConverterTypeClickInput, FfiConverterTypeDragInput, FfiConverterTypeEndSessionInput, FfiConverterTypeEndSessionOutput, FfiConverterTypeEscalateSessionInput, FfiConverterTypeGetCursorPositionInput, FfiConverterTypeGetDesktopStateInput, FfiConverterTypeGetScreenSizeInput, FfiConverterTypeGetSessionStateInput, FfiConverterTypeHotkeyInput, FfiConverterTypeMoveCursorInput, FfiConverterTypePressKeyInput, FfiConverterTypeScrollInput, FfiConverterTypeSessionStateOutput, FfiConverterTypeStartSessionInput, FfiConverterTypeStartSessionOutput, FfiConverterTypeTypeTextInput } = uniffiCuaDriverContractModule.converters;
@@ -838,6 +838,182 @@ const FfiConverterTypePrivateWorkerOptions = (() => {
              FfiConverterTypeConfiguredDriverOptions.allocationSize(value.configuredDriver) +
              FfiConverterSequenceTypeEmbeddedEnvironmentVariable.allocationSize(value.environment) +
              FfiConverterBool.allocationSize(value.inheritStderr);
+
+        }
+    };
+    return new FFIConverter();
+})();
+
+export enum ProtectedConsentAction {
+    Accept,
+    Decline,
+    Cancel
+}
+
+const FfiConverterTypeProtectedConsentAction = (() => {
+    const ordinalConverter = FfiConverterInt32;
+    type TypeName = ProtectedConsentAction;
+    class FFIConverter extends AbstractFfiConverterByteArray<TypeName> {
+        read(from: RustBuffer): TypeName {
+            switch (ordinalConverter.read(from)) {
+                case 1: return ProtectedConsentAction.Accept;
+                case 2: return ProtectedConsentAction.Decline;
+                case 3: return ProtectedConsentAction.Cancel;
+                default: throw new UniffiInternalError.UnexpectedEnumCase();
+            }
+        }
+        write(value: TypeName, into: RustBuffer): void {
+            switch (value) {
+                case ProtectedConsentAction.Accept: return ordinalConverter.write(1, into);
+                case ProtectedConsentAction.Decline: return ordinalConverter.write(2, into);
+                case ProtectedConsentAction.Cancel: return ordinalConverter.write(3, into);
+            }
+        }
+        allocationSize(value: TypeName): number {
+            return ordinalConverter.allocationSize(0);
+        }
+    }
+    return new FFIConverter();
+})();
+
+export type ProtectedConsentDecision = {
+    action: ProtectedConsentAction,
+    requestDigest: string
+}
+
+/**
+ * Generated factory for {@link ProtectedConsentDecision} record objects.
+ */
+export const ProtectedConsentDecision = (() => {
+    const defaults = () => ({
+    });
+    const create = (() => {
+        return uniffiCreateRecord<ProtectedConsentDecision, ReturnType<typeof defaults>>(defaults);
+    })();
+    return Object.freeze({
+        create,
+        new: create,
+        defaults: () => Object.freeze(defaults()) as Partial<ProtectedConsentDecision>,
+    });
+})();
+
+const FfiConverterTypeProtectedConsentDecision = (() => {
+    type TypeName = ProtectedConsentDecision;
+    class FFIConverter extends AbstractFfiConverterByteArray<TypeName> {
+        read(from: RustBuffer): TypeName {
+            return {
+                action: FfiConverterTypeProtectedConsentAction.read(from),
+                requestDigest: FfiConverterString.read(from)
+            };
+        }
+        write(value: TypeName, into: RustBuffer): void {
+            FfiConverterTypeProtectedConsentAction.write(value.action, into);
+            FfiConverterString.write(value.requestDigest, into);
+        }
+        allocationSize(value: TypeName): number {
+            return FfiConverterTypeProtectedConsentAction.allocationSize(value.action) +
+             FfiConverterString.allocationSize(value.requestDigest);
+
+        }
+    };
+    return new FFIConverter();
+})();
+
+/**
+ * Content-bounded request delivered only to trusted host code.
+ *
+ * `resource_json` contains the canonical typed resource identity needed to
+ * render the decision. Hosts must not log it or forward it to a model.
+ */
+export type ProtectedConsentRequest = {
+    schema: string,
+    nonce: string,
+    generation: bigint,
+    daemonInstance: string,
+    permissionMode: string,
+    managedPolicySha256?: string,
+    userPolicySha256?: string,
+    operation: string,
+    riskClass: string,
+    publicSession: string,
+    transportSession: string,
+    resourceJson: string,
+    humanSummary: string,
+    expiresUnixMs: bigint,
+    requestDigest: string
+}
+
+/**
+ * Generated factory for {@link ProtectedConsentRequest} record objects.
+ */
+export const ProtectedConsentRequest = (() => {
+    const defaults = () => ({
+    });
+    const create = (() => {
+        return uniffiCreateRecord<ProtectedConsentRequest, ReturnType<typeof defaults>>(defaults);
+    })();
+    return Object.freeze({
+        create,
+        new: create,
+        defaults: () => Object.freeze(defaults()) as Partial<ProtectedConsentRequest>,
+    });
+})();
+
+const FfiConverterTypeProtectedConsentRequest = (() => {
+    type TypeName = ProtectedConsentRequest;
+    class FFIConverter extends AbstractFfiConverterByteArray<TypeName> {
+        read(from: RustBuffer): TypeName {
+            return {
+                schema: FfiConverterString.read(from),
+                nonce: FfiConverterString.read(from),
+                generation: FfiConverterUInt64.read(from),
+                daemonInstance: FfiConverterString.read(from),
+                permissionMode: FfiConverterString.read(from),
+                managedPolicySha256: FfiConverterOptionalString.read(from),
+                userPolicySha256: FfiConverterOptionalString.read(from),
+                operation: FfiConverterString.read(from),
+                riskClass: FfiConverterString.read(from),
+                publicSession: FfiConverterString.read(from),
+                transportSession: FfiConverterString.read(from),
+                resourceJson: FfiConverterString.read(from),
+                humanSummary: FfiConverterString.read(from),
+                expiresUnixMs: FfiConverterUInt64.read(from),
+                requestDigest: FfiConverterString.read(from)
+            };
+        }
+        write(value: TypeName, into: RustBuffer): void {
+            FfiConverterString.write(value.schema, into);
+            FfiConverterString.write(value.nonce, into);
+            FfiConverterUInt64.write(value.generation, into);
+            FfiConverterString.write(value.daemonInstance, into);
+            FfiConverterString.write(value.permissionMode, into);
+            FfiConverterOptionalString.write(value.managedPolicySha256, into);
+            FfiConverterOptionalString.write(value.userPolicySha256, into);
+            FfiConverterString.write(value.operation, into);
+            FfiConverterString.write(value.riskClass, into);
+            FfiConverterString.write(value.publicSession, into);
+            FfiConverterString.write(value.transportSession, into);
+            FfiConverterString.write(value.resourceJson, into);
+            FfiConverterString.write(value.humanSummary, into);
+            FfiConverterUInt64.write(value.expiresUnixMs, into);
+            FfiConverterString.write(value.requestDigest, into);
+        }
+        allocationSize(value: TypeName): number {
+            return FfiConverterString.allocationSize(value.schema) +
+             FfiConverterString.allocationSize(value.nonce) +
+             FfiConverterUInt64.allocationSize(value.generation) +
+             FfiConverterString.allocationSize(value.daemonInstance) +
+             FfiConverterString.allocationSize(value.permissionMode) +
+             FfiConverterOptionalString.allocationSize(value.managedPolicySha256) +
+             FfiConverterOptionalString.allocationSize(value.userPolicySha256) +
+             FfiConverterString.allocationSize(value.operation) +
+             FfiConverterString.allocationSize(value.riskClass) +
+             FfiConverterString.allocationSize(value.publicSession) +
+             FfiConverterString.allocationSize(value.transportSession) +
+             FfiConverterString.allocationSize(value.resourceJson) +
+             FfiConverterString.allocationSize(value.humanSummary) +
+             FfiConverterUInt64.allocationSize(value.expiresUnixMs) +
+             FfiConverterString.allocationSize(value.requestDigest);
 
         }
     };
@@ -2103,6 +2279,105 @@ const FfiConverterTypeEmbeddedDriverHostState = (() => {
     return new FFIConverter();
 })();
 
+
+// Error type: ProtectedConsentHostError
+export enum ProtectedConsentHostError_Tags {
+    Failed = "Failed"
+}
+export const ProtectedConsentHostError = (() => {
+
+    type Failed__interface = {
+        tag: ProtectedConsentHostError_Tags.Failed;
+        inner:
+Readonly<{reason: string}>
+    };
+    class Failed_ extends UniffiError implements Failed__interface {
+        /**
+         * @private
+         * This field is private and should not be used, use `tag` instead.
+         */
+        readonly [uniffiTypeNameSymbol] = "ProtectedConsentHostError";
+        readonly tag = ProtectedConsentHostError_Tags.Failed;
+        readonly inner:
+Readonly<{reason: string}>;
+        constructor(
+inner: {reason: string }) {
+            super("ProtectedConsentHostError", "Failed");
+
+            this.inner = Object.freeze(inner);
+        }
+        static new(
+inner: {reason: string }): Failed_ {
+            return new Failed_(inner);
+        }
+
+        static instanceOf(obj: any): obj is Failed_ {
+            return obj.tag === ProtectedConsentHostError_Tags.Failed;
+        }
+        static hasInner(obj: any): obj is Failed_ {
+            return Failed_.instanceOf(obj);
+        }
+
+        static getInner(obj: Failed_):
+Readonly<{reason: string}> {
+            return obj.inner;
+        }
+
+    }
+
+    function instanceOf(obj: any): obj is ProtectedConsentHostError {
+        return obj[uniffiTypeNameSymbol] === "ProtectedConsentHostError";
+    }
+
+    return Object.freeze({
+        instanceOf,
+  Failed: Failed_
+    });
+
+})();
+export type ProtectedConsentHostError = InstanceType<
+    typeof ProtectedConsentHostError['Failed']
+>;
+
+// FfiConverter for enum ProtectedConsentHostError
+const FfiConverterTypeProtectedConsentHostError = (() => {
+    const ordinalConverter = FfiConverterInt32;
+    type TypeName = ProtectedConsentHostError;
+    class FFIConverter extends AbstractFfiConverterByteArray<TypeName> {
+        read(from: RustBuffer): TypeName {
+            switch (ordinalConverter.read(from)) {
+                case 1: return new ProtectedConsentHostError.Failed({reason: FfiConverterString.read(from) });
+                default: throw new UniffiInternalError.UnexpectedEnumCase();
+            }
+        }
+        write(value: TypeName, into: RustBuffer): void {
+            switch (value.tag) {
+                case ProtectedConsentHostError_Tags.Failed: {
+                    ordinalConverter.write(1, into);
+                    const inner = value.inner;
+                    FfiConverterString.write(inner.reason, into);
+                    return;
+                }
+                default:
+                    // Throwing from here means that ProtectedConsentHostError_Tags hasn't matched an ordinal.
+                    throw new UniffiInternalError.UnexpectedEnumCase();
+            }
+        }
+        allocationSize(value: TypeName): number {
+            switch (value.tag) {
+                case ProtectedConsentHostError_Tags.Failed: {
+                    const inner = value.inner;
+                    let size = ordinalConverter.allocationSize(1);
+                    size += FfiConverterString.allocationSize(inner.reason);
+                    return size;
+                }
+                default: throw new UniffiInternalError.UnexpectedEnumCase();
+            }
+        }
+    }
+    return new FFIConverter();
+})();
+
 /**
  * Runtime that imported the shared UniFFI SDK library. The language package
  * selects this automatically at its root entry point; callers do not need to
@@ -2272,6 +2547,44 @@ private constructor(pointer: UniffiHandle) {
             /*caller:*/ (callStatus) => {
                 return nativeModule().uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_configured_with_client_kind(
         FfiConverterTypeConfiguredDriverOptions.lower(options, nativeModule().rustbuffer_alloc),
+        FfiConverterTypeSdkClientKind.lower(clientKind, nativeModule().rustbuffer_alloc),
+                callStatus);
+            },
+            /*liftString:*/ FfiConverterString.lift.bind(FfiConverterString),
+    ));
+    }
+
+/**
+ * Create a configured same-process runtime with protected approval and
+ * persistent Stop UI supplied by trusted embedding-host code.
+ *
+ * The callback object is immutable runtime configuration. Applications
+ * must not expose it to an agent or implement it using ordinary MCP
+ * elicitation, model-visible stdio, or an auto-accepting callback.
+ */
+    static createConfiguredWithProtectedHost(options: ConfiguredDriverOptions, host: ProtectedConsentHost): CuaDriverLike /*throws*/ {
+    return FfiConverterTypeCuaDriver.lift(uniffiCaller.rustCallWithError(
+            /*liftError:*/ FfiConverterTypeDriverError.lift.bind(FfiConverterTypeDriverError),
+            /*caller:*/ (callStatus) => {
+                return nativeModule().uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_configured_with_protected_host(
+        FfiConverterTypeConfiguredDriverOptions.lower(options, nativeModule().rustbuffer_alloc),
+        FfiConverterTypeProtectedConsentHost.lower(host, nativeModule().rustbuffer_alloc),
+                callStatus);
+            },
+            /*liftString:*/ FfiConverterString.lift.bind(FfiConverterString),
+    ));
+    }
+
+/**
+ * Language-package entry point for a configured protected-host runtime.
+ */
+    static createConfiguredWithProtectedHostAndClientKind(options: ConfiguredDriverOptions, host: ProtectedConsentHost, clientKind: SdkClientKind): CuaDriverLike /*throws*/ {
+    return FfiConverterTypeCuaDriver.lift(uniffiCaller.rustCallWithError(
+            /*liftError:*/ FfiConverterTypeDriverError.lift.bind(FfiConverterTypeDriverError),
+            /*caller:*/ (callStatus) => {
+                return nativeModule().uniffi_cua_driver_sdk_fn_constructor_cuadriver_create_configured_with_protected_host_and_client_kind(
+        FfiConverterTypeConfiguredDriverOptions.lower(options, nativeModule().rustbuffer_alloc),
+        FfiConverterTypeProtectedConsentHost.lower(host, nativeModule().rustbuffer_alloc),
         FfiConverterTypeSdkClientKind.lower(clientKind, nativeModule().rustbuffer_alloc),
                 callStatus);
             },
@@ -3973,6 +4286,439 @@ const uniffiTypeEmbeddedCuaDriverHostObjectFactory: UniffiObjectFactory<Embedded
 }})();
 const FfiConverterTypeEmbeddedCuaDriverHost = new FfiConverterObject(uniffiTypeEmbeddedCuaDriverHostObjectFactory);
 
+/**
+ * Callback contract implemented by a trusted embedding application.
+ *
+ * The host must render approval and persistent Stop state outside the
+ * model/tool channel. Returning from `wait_for_indicator_stop` means Stop was
+ * activated; returning an error also fails closed and revokes the grant.
+ */
+export interface ProtectedConsentHost {
+
+    requestConsent(request: ProtectedConsentRequest, asyncOpts_?: { signal: AbortSignal }) /*throws*/: Promise<ProtectedConsentDecision>;
+    activateIndicator(request: ProtectedConsentRequest, asyncOpts_?: { signal: AbortSignal }) /*throws*/: Promise<string>;
+    waitForIndicatorStop(indicatorId: string, asyncOpts_?: { signal: AbortSignal }) /*throws*/: Promise<void>;
+    deactivateIndicator(indicatorId: string, asyncOpts_?: { signal: AbortSignal }) /*throws*/: Promise<void>;
+}
+
+
+/**
+ * Callback contract implemented by a trusted embedding application.
+ *
+ * The host must render approval and persistent Stop state outside the
+ * model/tool channel. Returning from `wait_for_indicator_stop` means Stop was
+ * activated; returning an error also fails closed and revokes the grant.
+ */
+export class ProtectedConsentHostImpl extends UniffiAbstractObject implements ProtectedConsentHost {
+
+    readonly [uniffiTypeNameSymbol] = "ProtectedConsentHostImpl";
+    readonly [destructorGuardSymbol]: UniffiGcObject;
+    readonly [pointerLiteralSymbol]: UniffiHandle;
+    // No primary constructor declared for this class.
+private constructor(pointer: UniffiHandle) {
+    super();
+    this[pointerLiteralSymbol] = pointer;
+    this[destructorGuardSymbol] = uniffiTypeProtectedConsentHostImplObjectFactory.bless(pointer);
+}
+
+
+
+
+    async requestConsent(request: ProtectedConsentRequest, asyncOpts_?: { signal: AbortSignal }): Promise<ProtectedConsentDecision> /*throws*/ {
+    const __stack = uniffiIsDebug ? new Error().stack : undefined;
+    try {
+        return await uniffiRustCallAsync(
+            /*rustCaller:*/ uniffiCaller,
+            /*rustFutureFunc:*/ () => {
+                return nativeModule().uniffi_cua_driver_sdk_fn_method_protectedconsenthost_request_consent(
+                    uniffiTypeProtectedConsentHostImplObjectFactory.clonePointer(this),FfiConverterTypeProtectedConsentRequest.lower(request, nativeModule().rustbuffer_alloc)
+                );
+            },
+            /*pollFunc:*/ nativeModule().ffi_cua_driver_sdk_rust_future_poll_rust_buffer,
+            /*cancelFunc:*/ nativeModule().ffi_cua_driver_sdk_rust_future_cancel_rust_buffer,
+            /*completeFunc:*/ nativeModule().ffi_cua_driver_sdk_rust_future_complete_rust_buffer,
+            /*freeFunc:*/ nativeModule().ffi_cua_driver_sdk_rust_future_free_rust_buffer,
+            // Async returns always go through the JS-side converter: the
+            // FFI symbol returns the future handle (u64), and the user-level
+            // RustBuffer comes back via the shared `rust_future_complete_*`
+            // export. The bytes the runtime hands back must be deserialized
+            // here using the per-callable return-type converter.
+            /*liftFunc:*/ FfiConverterTypeProtectedConsentDecision.lift.bind(FfiConverterTypeProtectedConsentDecision),
+            /*liftString:*/ FfiConverterString.lift.bind(FfiConverterString),
+            /*asyncOpts:*/ asyncOpts_,
+            /*errorHandler:*/ FfiConverterTypeProtectedConsentHostError.lift.bind(FfiConverterTypeProtectedConsentHostError)
+        );
+    } catch (__error: any) {
+        if (uniffiIsDebug && __error instanceof Error) {
+            __error.stack = __stack;
+        }
+        throw __error;
+    }
+    }
+
+    async activateIndicator(request: ProtectedConsentRequest, asyncOpts_?: { signal: AbortSignal }): Promise<string> /*throws*/ {
+    const __stack = uniffiIsDebug ? new Error().stack : undefined;
+    try {
+        return await uniffiRustCallAsync(
+            /*rustCaller:*/ uniffiCaller,
+            /*rustFutureFunc:*/ () => {
+                return nativeModule().uniffi_cua_driver_sdk_fn_method_protectedconsenthost_activate_indicator(
+                    uniffiTypeProtectedConsentHostImplObjectFactory.clonePointer(this),FfiConverterTypeProtectedConsentRequest.lower(request, nativeModule().rustbuffer_alloc)
+                );
+            },
+            /*pollFunc:*/ nativeModule().ffi_cua_driver_sdk_rust_future_poll_rust_buffer,
+            /*cancelFunc:*/ nativeModule().ffi_cua_driver_sdk_rust_future_cancel_rust_buffer,
+            /*completeFunc:*/ nativeModule().ffi_cua_driver_sdk_rust_future_complete_rust_buffer,
+            /*freeFunc:*/ nativeModule().ffi_cua_driver_sdk_rust_future_free_rust_buffer,
+            // Async returns always go through the JS-side converter: the
+            // FFI symbol returns the future handle (u64), and the user-level
+            // RustBuffer comes back via the shared `rust_future_complete_*`
+            // export. The bytes the runtime hands back must be deserialized
+            // here using the per-callable return-type converter.
+            /*liftFunc:*/ FfiConverterString.lift.bind(FfiConverterString),
+            /*liftString:*/ FfiConverterString.lift.bind(FfiConverterString),
+            /*asyncOpts:*/ asyncOpts_,
+            /*errorHandler:*/ FfiConverterTypeProtectedConsentHostError.lift.bind(FfiConverterTypeProtectedConsentHostError)
+        );
+    } catch (__error: any) {
+        if (uniffiIsDebug && __error instanceof Error) {
+            __error.stack = __stack;
+        }
+        throw __error;
+    }
+    }
+
+    async waitForIndicatorStop(indicatorId: string, asyncOpts_?: { signal: AbortSignal }): Promise<void> /*throws*/ {
+    const __stack = uniffiIsDebug ? new Error().stack : undefined;
+    try {
+        return await uniffiRustCallAsync(
+            /*rustCaller:*/ uniffiCaller,
+            /*rustFutureFunc:*/ () => {
+                return nativeModule().uniffi_cua_driver_sdk_fn_method_protectedconsenthost_wait_for_indicator_stop(
+                    uniffiTypeProtectedConsentHostImplObjectFactory.clonePointer(this),FfiConverterString.lower(indicatorId, nativeModule().rustbuffer_alloc)
+                );
+            },
+            /*pollFunc:*/ nativeModule().ffi_cua_driver_sdk_rust_future_poll_void,
+            /*cancelFunc:*/ nativeModule().ffi_cua_driver_sdk_rust_future_cancel_void,
+            /*completeFunc:*/ nativeModule().ffi_cua_driver_sdk_rust_future_complete_void,
+            /*freeFunc:*/ nativeModule().ffi_cua_driver_sdk_rust_future_free_void,
+            /*liftFunc:*/ (_v) => {},
+            /*liftString:*/ FfiConverterString.lift.bind(FfiConverterString),
+            /*asyncOpts:*/ asyncOpts_,
+            /*errorHandler:*/ FfiConverterTypeProtectedConsentHostError.lift.bind(FfiConverterTypeProtectedConsentHostError)
+        );
+    } catch (__error: any) {
+        if (uniffiIsDebug && __error instanceof Error) {
+            __error.stack = __stack;
+        }
+        throw __error;
+    }
+    }
+
+    async deactivateIndicator(indicatorId: string, asyncOpts_?: { signal: AbortSignal }): Promise<void> /*throws*/ {
+    const __stack = uniffiIsDebug ? new Error().stack : undefined;
+    try {
+        return await uniffiRustCallAsync(
+            /*rustCaller:*/ uniffiCaller,
+            /*rustFutureFunc:*/ () => {
+                return nativeModule().uniffi_cua_driver_sdk_fn_method_protectedconsenthost_deactivate_indicator(
+                    uniffiTypeProtectedConsentHostImplObjectFactory.clonePointer(this),FfiConverterString.lower(indicatorId, nativeModule().rustbuffer_alloc)
+                );
+            },
+            /*pollFunc:*/ nativeModule().ffi_cua_driver_sdk_rust_future_poll_void,
+            /*cancelFunc:*/ nativeModule().ffi_cua_driver_sdk_rust_future_cancel_void,
+            /*completeFunc:*/ nativeModule().ffi_cua_driver_sdk_rust_future_complete_void,
+            /*freeFunc:*/ nativeModule().ffi_cua_driver_sdk_rust_future_free_void,
+            /*liftFunc:*/ (_v) => {},
+            /*liftString:*/ FfiConverterString.lift.bind(FfiConverterString),
+            /*asyncOpts:*/ asyncOpts_,
+            /*errorHandler:*/ FfiConverterTypeProtectedConsentHostError.lift.bind(FfiConverterTypeProtectedConsentHostError)
+        );
+    } catch (__error: any) {
+        if (uniffiIsDebug && __error instanceof Error) {
+            __error.stack = __stack;
+        }
+        throw __error;
+    }
+    }
+
+
+    uniffiDestroy(): void {
+        const ptr = (this as any)[destructorGuardSymbol];
+        if (ptr !== undefined) {
+            const pointer = uniffiTypeProtectedConsentHostImplObjectFactory.pointer(this);
+            uniffiTypeProtectedConsentHostImplObjectFactory.freePointer(pointer);
+            uniffiTypeProtectedConsentHostImplObjectFactory.unbless(ptr);
+            delete (this as any)[destructorGuardSymbol];
+        }
+    }
+
+    static instanceOf(obj_: any): obj_ is ProtectedConsentHostImpl {
+        return uniffiTypeProtectedConsentHostImplObjectFactory.isConcreteType(obj_);
+    }
+
+
+}
+
+const uniffiTypeProtectedConsentHostImplObjectFactory: UniffiObjectFactory<ProtectedConsentHost> = (() => {
+
+    /// <reference lib="es2021" />
+    const registry = typeof FinalizationRegistry !== 'undefined' ? new FinalizationRegistry<UniffiHandle>((heldValue: UniffiHandle) => {
+        uniffiTypeProtectedConsentHostImplObjectFactory.freePointer(heldValue);
+    }) : null;
+
+    return {
+    create(pointer: UniffiHandle): ProtectedConsentHost {
+        const instance = Object.create(ProtectedConsentHostImpl.prototype);
+        instance[pointerLiteralSymbol] = pointer;
+        instance[destructorGuardSymbol] = this.bless(pointer);
+        instance[uniffiTypeNameSymbol] = "ProtectedConsentHostImpl";
+        return instance;
+    },
+
+
+    bless(p: UniffiHandle): UniffiGcObject {
+        const ptr = {
+            p, // make sure this object doesn't get optimized away.
+            markDestroyed: () => undefined,
+        };
+        if (registry) {
+            registry.register(ptr, p, ptr);
+        }
+        return ptr;
+    },
+
+    unbless(ptr_: UniffiGcObject) {
+        if (registry) {
+            registry.unregister(ptr_);
+        }
+    },
+
+    pointer(obj_: ProtectedConsentHost): UniffiHandle {
+        if ((obj_ as any)[destructorGuardSymbol] === undefined) {
+            throw new UniffiInternalError.UnexpectedNullPointer();
+        }
+        return (obj_ as any)[pointerLiteralSymbol];
+    },
+
+    clonePointer(obj_: ProtectedConsentHost): UniffiHandle {
+        const pointer = this.pointer(obj_);
+        return uniffiCaller.rustCall(
+            /*caller:*/ (callStatus) => nativeModule().uniffi_cua_driver_sdk_fn_clone_protectedconsenthost(pointer, callStatus),
+            /*liftString:*/ FfiConverterString.lift
+        );
+    },
+
+    freePointer(pointer: UniffiHandle): void {
+        uniffiCaller.rustCall(
+            /*caller:*/ (callStatus) => nativeModule().uniffi_cua_driver_sdk_fn_free_protectedconsenthost(pointer, callStatus),
+            /*liftString:*/ FfiConverterString.lift
+        );
+    },
+
+    isConcreteType(obj_: any): obj_ is ProtectedConsentHost {
+        return obj_[destructorGuardSymbol] && obj_[uniffiTypeNameSymbol] === "ProtectedConsentHostImpl";
+    },
+}})();
+const FfiConverterTypeProtectedConsentHost = new FfiConverterObjectWithCallbacks(uniffiTypeProtectedConsentHostImplObjectFactory);
+
+// Add a vtable for the callbacks that go in ProtectedConsentHost.
+
+// Put the implementation in a struct so we don't pollute the top-level namespace
+const uniffiCallbackInterfaceProtectedConsentHost: { vtable: any; register: () => void; } = {
+    // Create the VTable using a series of closures.
+    // ts automatically converts these into C callback functions.
+    vtable: {
+        request_consent: (
+            uniffiHandle: bigint,
+            request: Uint8Array,
+            uniffiFutureCallback: UniffiForeignFutureCompleterustBuffer,
+            uniffiCallbackData: bigint) => {
+            const uniffiMakeCall =
+            async (signal: AbortSignal)
+            : Promise<ProtectedConsentDecision> => {
+                const jsCallback = FfiConverterTypeProtectedConsentHost.lift(uniffiHandle);
+                return await jsCallback.requestConsent(
+                    FfiConverterTypeProtectedConsentRequest.lift(request), { signal }
+                )
+            };
+            const uniffiHandleSuccess = (returnValue: ProtectedConsentDecision) => {
+                uniffiFutureCallback.call(
+                    uniffiFutureCallback,
+                    uniffiCallbackData,
+                    /* UniffiForeignFutureResultRustBuffer */{
+                        return_value: FfiConverterTypeProtectedConsentDecision.lower(returnValue, nativeModule().rustbuffer_alloc),
+                        call_status: uniffiCaller.createCallStatus()
+                    }
+                );
+            };
+            const uniffiHandleError = (code: number, errorBuf: UniffiByteArray) => {
+                uniffiFutureCallback.call(
+                    uniffiFutureCallback,
+                    uniffiCallbackData,
+                    /* UniffiForeignFutureResultRustBuffer */{
+                        return_value: /*empty*/ new Uint8Array(0),
+                        // TODO create callstatus with error.
+                        call_status: uniffiCaller.createErrorStatus(code, errorBuf),
+                    }
+                );
+            };
+            const uniffiForeignFuture = uniffiTraitInterfaceCallAsyncWithError(
+                /*makeCall:*/ uniffiMakeCall,
+                /*handleSuccess:*/ uniffiHandleSuccess,
+                /*handleError:*/ uniffiHandleError,
+                /*isErrorType:*/ ProtectedConsentHostError.instanceOf,
+                /*lowerError:*/ FfiConverterTypeProtectedConsentHostError.lower.bind(FfiConverterTypeProtectedConsentHostError),
+                /*lowerString:*/ FfiConverterString.lower.bind(FfiConverterString),
+                /*alloc:*/ nativeModule().rustbuffer_alloc,
+            );
+            return uniffiForeignFuture;
+        },
+        activate_indicator: (
+            uniffiHandle: bigint,
+            request: Uint8Array,
+            uniffiFutureCallback: UniffiForeignFutureCompleterustBuffer,
+            uniffiCallbackData: bigint) => {
+            const uniffiMakeCall =
+            async (signal: AbortSignal)
+            : Promise<string> => {
+                const jsCallback = FfiConverterTypeProtectedConsentHost.lift(uniffiHandle);
+                return await jsCallback.activateIndicator(
+                    FfiConverterTypeProtectedConsentRequest.lift(request), { signal }
+                )
+            };
+            const uniffiHandleSuccess = (returnValue: string) => {
+                uniffiFutureCallback.call(
+                    uniffiFutureCallback,
+                    uniffiCallbackData,
+                    /* UniffiForeignFutureResultRustBuffer */{
+                        return_value: FfiConverterString.lower(returnValue, nativeModule().rustbuffer_alloc),
+                        call_status: uniffiCaller.createCallStatus()
+                    }
+                );
+            };
+            const uniffiHandleError = (code: number, errorBuf: UniffiByteArray) => {
+                uniffiFutureCallback.call(
+                    uniffiFutureCallback,
+                    uniffiCallbackData,
+                    /* UniffiForeignFutureResultRustBuffer */{
+                        return_value: /*empty*/ new Uint8Array(0),
+                        // TODO create callstatus with error.
+                        call_status: uniffiCaller.createErrorStatus(code, errorBuf),
+                    }
+                );
+            };
+            const uniffiForeignFuture = uniffiTraitInterfaceCallAsyncWithError(
+                /*makeCall:*/ uniffiMakeCall,
+                /*handleSuccess:*/ uniffiHandleSuccess,
+                /*handleError:*/ uniffiHandleError,
+                /*isErrorType:*/ ProtectedConsentHostError.instanceOf,
+                /*lowerError:*/ FfiConverterTypeProtectedConsentHostError.lower.bind(FfiConverterTypeProtectedConsentHostError),
+                /*lowerString:*/ FfiConverterString.lower.bind(FfiConverterString),
+                /*alloc:*/ nativeModule().rustbuffer_alloc,
+            );
+            return uniffiForeignFuture;
+        },
+        wait_for_indicator_stop: (
+            uniffiHandle: bigint,
+            indicatorId: Uint8Array,
+            uniffiFutureCallback: UniffiForeignFutureCompletevoid,
+            uniffiCallbackData: bigint) => {
+            const uniffiMakeCall =
+            async (signal: AbortSignal)
+            : Promise<void> => {
+                const jsCallback = FfiConverterTypeProtectedConsentHost.lift(uniffiHandle);
+                return await jsCallback.waitForIndicatorStop(
+                    FfiConverterString.lift(indicatorId), { signal }
+                )
+            };
+            const uniffiHandleSuccess = (returnValue: void) => {
+                uniffiFutureCallback.call(
+                    uniffiFutureCallback,
+                    uniffiCallbackData,
+                    /* UniffiForeignFutureResultVoid */{
+                        call_status: uniffiCaller.createCallStatus()
+                    }
+                );
+            };
+            const uniffiHandleError = (code: number, errorBuf: UniffiByteArray) => {
+                uniffiFutureCallback.call(
+                    uniffiFutureCallback,
+                    uniffiCallbackData,
+                    /* UniffiForeignFutureResultVoid */{
+                        // TODO create callstatus with error.
+                        call_status: uniffiCaller.createErrorStatus(code, errorBuf),
+                    }
+                );
+            };
+            const uniffiForeignFuture = uniffiTraitInterfaceCallAsyncWithError(
+                /*makeCall:*/ uniffiMakeCall,
+                /*handleSuccess:*/ uniffiHandleSuccess,
+                /*handleError:*/ uniffiHandleError,
+                /*isErrorType:*/ ProtectedConsentHostError.instanceOf,
+                /*lowerError:*/ FfiConverterTypeProtectedConsentHostError.lower.bind(FfiConverterTypeProtectedConsentHostError),
+                /*lowerString:*/ FfiConverterString.lower.bind(FfiConverterString),
+                /*alloc:*/ nativeModule().rustbuffer_alloc,
+            );
+            return uniffiForeignFuture;
+        },
+        deactivate_indicator: (
+            uniffiHandle: bigint,
+            indicatorId: Uint8Array,
+            uniffiFutureCallback: UniffiForeignFutureCompletevoid,
+            uniffiCallbackData: bigint) => {
+            const uniffiMakeCall =
+            async (signal: AbortSignal)
+            : Promise<void> => {
+                const jsCallback = FfiConverterTypeProtectedConsentHost.lift(uniffiHandle);
+                return await jsCallback.deactivateIndicator(
+                    FfiConverterString.lift(indicatorId), { signal }
+                )
+            };
+            const uniffiHandleSuccess = (returnValue: void) => {
+                uniffiFutureCallback.call(
+                    uniffiFutureCallback,
+                    uniffiCallbackData,
+                    /* UniffiForeignFutureResultVoid */{
+                        call_status: uniffiCaller.createCallStatus()
+                    }
+                );
+            };
+            const uniffiHandleError = (code: number, errorBuf: UniffiByteArray) => {
+                uniffiFutureCallback.call(
+                    uniffiFutureCallback,
+                    uniffiCallbackData,
+                    /* UniffiForeignFutureResultVoid */{
+                        // TODO create callstatus with error.
+                        call_status: uniffiCaller.createErrorStatus(code, errorBuf),
+                    }
+                );
+            };
+            const uniffiForeignFuture = uniffiTraitInterfaceCallAsyncWithError(
+                /*makeCall:*/ uniffiMakeCall,
+                /*handleSuccess:*/ uniffiHandleSuccess,
+                /*handleError:*/ uniffiHandleError,
+                /*isErrorType:*/ ProtectedConsentHostError.instanceOf,
+                /*lowerError:*/ FfiConverterTypeProtectedConsentHostError.lower.bind(FfiConverterTypeProtectedConsentHostError),
+                /*lowerString:*/ FfiConverterString.lower.bind(FfiConverterString),
+                /*alloc:*/ nativeModule().rustbuffer_alloc,
+            );
+            return uniffiForeignFuture;
+        },
+        uniffi_free: (uniffiHandle: UniffiHandle): void => {
+            // this will throw a stale handle error if the handle isn't found.
+            FfiConverterTypeProtectedConsentHost.drop(uniffiHandle);
+        },
+        uniffi_clone: (uniffiHandle: UniffiHandle): UniffiHandle => {
+            return FfiConverterTypeProtectedConsentHost.clone(uniffiHandle);
+        }
+    },
+    register: () => {nativeModule().uniffi_cua_driver_sdk_fn_init_callback_vtable_protectedconsenthost(
+            uniffiCallbackInterfaceProtectedConsentHost.vtable
+        );
+    },
+};
+
 // FfiConverter for Array<SessionPermissionMode>
 const FfiConverterSequenceTypeSessionPermissionMode = new FfiConverterArray(FfiConverterTypeSessionPermissionMode);
 
@@ -4051,6 +4797,12 @@ function uniffiEnsureInitialized() {
     }
     if (nativeModule().uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured_with_client_kind() !== 23819) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured_with_client_kind");
+    }
+    if (nativeModule().uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured_with_protected_host() !== 2194) {
+        throw new UniffiInternalError.ApiChecksumMismatch("uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured_with_protected_host");
+    }
+    if (nativeModule().uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured_with_protected_host_and_client_kind() !== 59012) {
+        throw new UniffiInternalError.ApiChecksumMismatch("uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_configured_with_protected_host_and_client_kind");
     }
     if (nativeModule().uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_private_worker() !== 8571) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_cua_driver_sdk_checksum_constructor_cuadriver_create_private_worker");
@@ -4199,7 +4951,20 @@ function uniffiEnsureInitialized() {
     if (nativeModule().uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_wait_for_exit() !== 21124) {
         throw new UniffiInternalError.ApiChecksumMismatch("uniffi_cua_driver_sdk_checksum_method_embeddedcuadriverhost_wait_for_exit");
     }
+    if (nativeModule().uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_request_consent() !== 10400) {
+        throw new UniffiInternalError.ApiChecksumMismatch("uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_request_consent");
+    }
+    if (nativeModule().uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_activate_indicator() !== 36476) {
+        throw new UniffiInternalError.ApiChecksumMismatch("uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_activate_indicator");
+    }
+    if (nativeModule().uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_wait_for_indicator_stop() !== 15179) {
+        throw new UniffiInternalError.ApiChecksumMismatch("uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_wait_for_indicator_stop");
+    }
+    if (nativeModule().uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_deactivate_indicator() !== 23864) {
+        throw new UniffiInternalError.ApiChecksumMismatch("uniffi_cua_driver_sdk_checksum_method_protectedconsenthost_deactivate_indicator");
+    }
 
+    uniffiCallbackInterfaceProtectedConsentHost.register();
     }
 
 export default Object.freeze({
@@ -4225,6 +4990,11 @@ export default Object.freeze({
     FfiConverterTypeImageContent,
     FfiConverterTypeMacOsPermissionStatus,
     FfiConverterTypePrivateWorkerOptions,
+    FfiConverterTypeProtectedConsentAction,
+    FfiConverterTypeProtectedConsentDecision,
+    FfiConverterTypeProtectedConsentHost,
+    FfiConverterTypeProtectedConsentHostError,
+    FfiConverterTypeProtectedConsentRequest,
     FfiConverterTypeRuntimeAuthorizationOptions,
     FfiConverterTypeSdkClientKind,
     FfiConverterTypeSessionPermissionMode,


### PR DESCRIPTION
## Summary

Adds the protected embedding-host contract required before new #2385 adapters can become active. A trusted Python, TypeScript, or Rust application can install one immutable callback object at same-process runtime construction; the runtime converts it into the existing `ProtectedConsentProvider` seam and keeps the model-facing tool/MCP schemas unchanged.

The host receives exact digest-bound requests, renders approval and persistent Stop UI outside model control, and owns indicator teardown. Host Stop, callback/channel failure, Cua session/runtime revocation, digest mismatch, decline, cancellation, timeout, and indicator activation failure all fail closed.

## Security boundary

- This is trusted constructor configuration, not a tool argument, MCP elicitation, stdio message, environment switch, or auto-approval API.
- Integrators must not expose or implement the callback in model-facing code. If the agent is the embedding host, the protected-consent guarantee does not apply.
- No biometric requirement is introduced; the embedding host chooses its protected renderer.
- Provider identity and grants remain runtime-scoped, including with multiple direct runtimes.
- The callback surface is currently available to same-process SDK hosts. CLI/MCP/private-worker/service routes without a protected host continue to fail closed for adapters that require one.

## Verification

- Rust SDK: 42 unit tests + 2 runtime configuration tests pass.
- Protected-host tests cover accept, decline, indicator failure, bounded activation, local Stop, and Cua-side revocation.
- Python package: 28 passed, 3 skipped; live constructor smoke passed.
- TypeScript package: typecheck and 6 tests passed; live constructor smoke passed.
- Generated Python/TypeScript bindings are current.

Stacked on #2577, #2576, and #2575. Implements the embedded same-process portion of #2411 and unblocks active #2385 adapters.