### PR TITLE
feat(cua-driver): enforce desktop input grants

### DIFF
--- a/docs/content/docs/reference/cua-driver/permission-modes.mdx
+++ b/docs/content/docs/reference/cua-driver/permission-modes.mdx
@@ -18,7 +18,7 @@ allowed.
 
 | Mode | Startup | Human intervention | Existing logged-in profile |
 | --- | --- | --- | --- |
-| `standard` | Default | Once per exact user-owned observation scope and once for existing-profile attachment; grants are reused until expiry, scope change, or Stop | Requires a certified protected-consent provider and its persistent Stop indicator |
+| `standard` | Default | Once per exact user-owned observation or input scope and once for existing-profile attachment; grants are reused until expiry, scope change, or Stop | Requires a certified protected-consent provider and its persistent Stop indicator |
 | `bounded` | `--permission-mode bounded --session-policy <path> --approve-session-policy` | Once when a trusted launcher reviews and approves the bounded manifest | Allowed only when the manifest names the exact PID/window and a certified indicator provider is available |
 | `unrestricted` | `--dangerously-bypass-approvals` | Once at trusted launch; no runtime Cua approval prompts | May attach without a protected provider after the explicit launch warning |
 
@@ -61,7 +61,7 @@ The current inventory is intentionally narrow:
 | --- | --- | --- |
 | `browser_prepare.existing_profile` | `active` | Existing-profile attachment applies the mode-specific protected-consent or unrestricted path. |
 | `private_observation` | `active` | User-window, application, browser-target, and display observation requires an exact expiring grant. Proven driver-owned isolated browser resources remain prompt-light. |
-| `desktop_input` | `metadata_only` | Generic desktop input is classified but not protected by a shipped grant adapter. |
+| `desktop_input` | `active` | Window/application input is bound to the exact PID/window and delivery mode; desktop-coordinate input is bound to current display geometry. |
 | `file_transfer_and_output` | `metadata_only` | Uploads, downloads, and screenshot-to-file egress are classified but not protected by a shipped grant adapter. |
 | `browser_consequential_action` | `metadata_only` | Mutating dialogs and generic page actions are classified but not protected by a shipped grant adapter. |
 | `devices`, `shell_and_network` | `not_exposed` | Cua Driver does not expose these open-ended capabilities. |
@@ -84,8 +84,9 @@ provider activates a persistent indicator with a Stop control.
 Ordinary MCP elicitation, MCP tool arguments, inherited standard input, a TTY,
 environment variables, and files do not satisfy this contract. They are
 writable by the calling process. If the runtime has no certified provider,
-`standard` and `bounded` refuse user-owned private observation and
-existing-profile attachment before the platform backend can read the resource.
+`standard` and `bounded` refuse user-owned private observation, desktop input,
+and existing-profile attachment before the platform backend can access the
+resource.
 
 <Callout type="info">
   The current standalone CLI/MCP daemon has no certified Codex or Claude host

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/authorization.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/authorization.rs
@@ -318,18 +318,19 @@ pub const ENFORCEMENT_ADAPTERS: &[EnforcementAdapterDescriptor] = &[
     EnforcementAdapterDescriptor {
         id: "desktop_input",
         operations: DESKTOP_INPUT_OPERATIONS,
-        state: RiskEnforcement::MetadataOnly,
+        state: RiskEnforcement::Active,
         risk_class: RiskClass::R1,
         resource_kind: "user_window_or_display_input",
         scope_keys: DESKTOP_INPUT_SCOPE_KEYS,
-        grant_type: None,
-        idle_ttl_seconds: None,
-        absolute_ttl_seconds: None,
-        indicator_requirement: "not_implemented",
+        grant_type: Some("protected_resource_grant"),
+        idle_ttl_seconds: Some(30 * 60),
+        absolute_ttl_seconds: Some(8 * 60 * 60),
+        indicator_requirement: "required_in_standard_and_bounded",
         revocation_triggers: SESSION_REVOCATION,
-        refusal_code: None,
-        provider_requirement: "certified_protected_host_not_implemented",
-        enforcement_by_mode: AdapterEnforcement::uniform(RiskEnforcement::MetadataOnly),
+        refusal_code: Some("protected_consent_required"),
+        provider_requirement:
+            "protected_consent_in_standard; protected_indicator_in_bounded; none_in_unrestricted",
+        enforcement_by_mode: AdapterEnforcement::uniform(RiskEnforcement::Active),
     },
     EnforcementAdapterDescriptor {
         id: "file_transfer_and_output",
@@ -816,6 +817,11 @@ pub fn classify_tool_call(tool: &str, args: &Value) -> RiskAssessment {
             enforcement: RiskEnforcement::MetadataOnly,
             operation_sensitive: args.get("prompt").and_then(Value::as_bool).unwrap_or(true),
         },
+        tool if DESKTOP_INPUT_OPERATIONS.contains(&tool) && tool != "replay_trajectory" => {
+            let mut risk = advertised_risk_for(tool);
+            risk.enforcement = RiskEnforcement::Active;
+            risk
+        }
         _ => advertised_risk_for(tool),
     }
 }
@@ -1342,12 +1348,15 @@ mod tests {
 
         assert_eq!(
             adapter_ids_with_state(RiskEnforcement::Active),
-            vec!["browser_prepare.existing_profile", "private_observation"]
+            vec![
+                "browser_prepare.existing_profile",
+                "private_observation",
+                "desktop_input"
+            ]
         );
         assert_eq!(
             adapter_ids_with_state(RiskEnforcement::MetadataOnly),
             vec![
-                "desktop_input",
                 "file_transfer_and_output",
                 "browser_consequential_action",
                 "browser_unbounded_script",
@@ -1363,7 +1372,11 @@ mod tests {
         );
         assert_eq!(
             adapter_ids_with_state_for_mode(PermissionMode::Standard, RiskEnforcement::Active),
-            vec!["browser_prepare.existing_profile", "private_observation"]
+            vec![
+                "browser_prepare.existing_profile",
+                "private_observation",
+                "desktop_input"
+            ]
         );
 
         let existing = ENFORCEMENT_ADAPTERS
@@ -1446,12 +1459,15 @@ mod tests {
         let status = status_json();
         assert_eq!(
             status["active_risk_enforcement"],
-            serde_json::json!(["browser_prepare.existing_profile", "private_observation"])
+            serde_json::json!([
+                "browser_prepare.existing_profile",
+                "private_observation",
+                "desktop_input"
+            ])
         );
         assert_eq!(
             status["metadata_only_risk_enforcement"],
             serde_json::json!([
-                "desktop_input",
                 "file_transfer_and_output",
                 "browser_consequential_action",
                 "browser_unbounded_script",
@@ -1467,7 +1483,11 @@ mod tests {
         );
         assert_eq!(
             status["effective_active_risk_enforcement"],
-            serde_json::json!(["browser_prepare.existing_profile", "private_observation"])
+            serde_json::json!([
+                "browser_prepare.existing_profile",
+                "private_observation",
+                "desktop_input"
+            ])
         );
         assert_eq!(
             status["effective_metadata_only_risk_enforcement"],

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/engine.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/engine.rs
@@ -78,6 +78,7 @@ pub struct BrowserEngine {
     pub(crate) managed_browsers: ManagedBrowsers,
     pub(crate) existing_profile_grants: ExistingProfileGrants,
     pub(crate) approval_broker: Arc<crate::consent::ApprovalBroker>,
+    pub(crate) protected_resource_ownership: Arc<crate::consent::ProtectedResourceOwnershipStore>,
     mutation_gates: MutationGates,
     reconnect_gates: ReconnectGates,
     session_end_hook: Mutex<Option<crate::session::SessionEndHookRegistration>>,
@@ -525,9 +526,10 @@ impl BrowserEngine {
     /// capability store. Platform crates call this once and register
     /// the five tools via `register_browser_tools`.
     pub fn new(platform: Arc<dyn BrowserPlatform>) -> Arc<Self> {
-        Self::new_with_approval_broker(
+        Self::new_with_runtime_services(
             platform,
             Arc::new(crate::consent::ApprovalBroker::unavailable()),
+            Arc::new(crate::consent::ProtectedResourceOwnershipStore::default()),
         )
     }
 
@@ -538,9 +540,10 @@ impl BrowserEngine {
         platform: Arc<dyn BrowserPlatform>,
         provider: Option<Arc<dyn crate::consent::ProtectedConsentProvider>>,
     ) -> Arc<Self> {
-        Self::new_with_approval_broker(
+        Self::new_with_runtime_services(
             platform,
             Arc::new(crate::consent::ApprovalBroker::new(provider)),
+            Arc::new(crate::consent::ProtectedResourceOwnershipStore::default()),
         )
     }
 
@@ -550,6 +553,18 @@ impl BrowserEngine {
         platform: Arc<dyn BrowserPlatform>,
         approval_broker: Arc<crate::consent::ApprovalBroker>,
     ) -> Arc<Self> {
+        Self::new_with_runtime_services(
+            platform,
+            approval_broker,
+            Arc::new(crate::consent::ProtectedResourceOwnershipStore::default()),
+        )
+    }
+
+    pub fn new_with_runtime_services(
+        platform: Arc<dyn BrowserPlatform>,
+        approval_broker: Arc<crate::consent::ApprovalBroker>,
+        protected_resource_ownership: Arc<crate::consent::ProtectedResourceOwnershipStore>,
+    ) -> Arc<Self> {
         let engine = Arc::new(Self {
             platform,
             store: BrowserStore::new(),
@@ -557,6 +572,7 @@ impl BrowserEngine {
             managed_browsers: Default::default(),
             existing_profile_grants: ExistingProfileGrants::new(),
             approval_broker,
+            protected_resource_ownership,
             mutation_gates: MutationGates::new(),
             reconnect_gates: ReconnectGates::new(),
             session_end_hook: Mutex::new(None),

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/prepare.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/prepare.rs
@@ -605,6 +605,7 @@ impl BrowserEngine {
     }
 
     pub(crate) fn cleanup_prepared_session(&self, session: &str) {
+        self.protected_resource_ownership.remove_session(session);
         self.managed_browsers
             .lock()
             .unwrap()
@@ -715,6 +716,10 @@ impl BrowserEngine {
             if !owner_sessions.contains(&transport_session) {
                 owner_sessions.push(transport_session);
             }
+        }
+        for owner in &owner_sessions {
+            self.protected_resource_ownership
+                .mark_driver_owned_pid(owner, prepared_pid);
         }
         self.managed_browsers.lock().unwrap().push(ManagedBrowser {
             child,

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/tools.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/tools.rs
@@ -101,13 +101,19 @@ fn browser_resource_ownership(engine: &BrowserEngine, args: &Value) -> Protected
     else {
         return ProtectedResourceOwnership::UserOwned;
     };
+    let runtime_session = crate::tool::current_dispatch_authorization_context()
+        .map(|context| context.runtime_session_key(session))
+        .unwrap_or_else(|| session.to_owned());
     let pid = args.get("pid").and_then(Value::as_i64).or_else(|| {
         args.get("target_id")
             .and_then(Value::as_str)
-            .and_then(|target_id| engine.store.get_target(session, target_id).ok())
+            .and_then(|target_id| engine.store.get_target(&runtime_session, target_id).ok())
             .map(|target| target.pid)
     });
-    if pid.is_some_and(|pid| engine.is_driver_owned_pid_for_session(session, pid)) {
+    if pid.is_some_and(|pid| {
+        engine.is_driver_owned_pid_for_session(&runtime_session, pid)
+            || engine.is_driver_owned_pid_for_session(session, pid)
+    }) {
         ProtectedResourceOwnership::DriverOwned
     } else {
         ProtectedResourceOwnership::UserOwned

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/consent.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/consent.rs
@@ -7,7 +7,7 @@
 //! implementations must authenticate their private channel before adapting it
 //! to this interface.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -343,6 +343,39 @@ pub struct ProtectedResourceGrants {
     broker: Arc<ApprovalBroker>,
     grants: Mutex<HashMap<ResourceGrantKey, ResourceGrant>>,
     admission: tokio::sync::Mutex<()>,
+}
+
+/// Runtime-owned proof that a process was created and remains managed by Cua.
+///
+/// Tool arguments can select a PID but can never populate this store. The
+/// browser engine records only an attested isolated process that it launched,
+/// and removes that proof with the owning lifecycle session.
+#[derive(Default)]
+pub struct ProtectedResourceOwnershipStore {
+    pids_by_session: Mutex<HashMap<String, HashSet<i64>>>,
+}
+
+impl ProtectedResourceOwnershipStore {
+    pub fn mark_driver_owned_pid(&self, session: &str, pid: i64) {
+        self.pids_by_session
+            .lock()
+            .unwrap()
+            .entry(session.to_owned())
+            .or_default()
+            .insert(pid);
+    }
+
+    pub fn is_driver_owned_pid(&self, session: &str, pid: i64) -> bool {
+        self.pids_by_session
+            .lock()
+            .unwrap()
+            .get(session)
+            .is_some_and(|pids| pids.contains(&pid))
+    }
+
+    pub fn remove_session(&self, session: &str) {
+        self.pids_by_session.lock().unwrap().remove(session);
+    }
 }
 
 impl ProtectedResourceGrants {

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -401,6 +401,7 @@ pub struct ToolRegistry {
     /// identities or grant lifecycles.
     approval_broker: Arc<crate::consent::ApprovalBroker>,
     protected_resource_grants: Arc<crate::consent::ProtectedResourceGrants>,
+    protected_resource_ownership: Arc<crate::consent::ProtectedResourceOwnershipStore>,
 }
 
 impl ToolRegistry {
@@ -417,9 +418,15 @@ impl ToolRegistry {
         let protected_resource_grants = Arc::new(crate::consent::ProtectedResourceGrants::new(
             approval_broker.clone(),
         ));
+        let protected_resource_ownership =
+            Arc::new(crate::consent::ProtectedResourceOwnershipStore::default());
         let weak_grants = Arc::downgrade(&protected_resource_grants);
+        let weak_ownership = Arc::downgrade(&protected_resource_ownership);
         let session_end_hook =
             crate::session::register_scoped_session_end_hook(move |session_id| {
+                if let Some(ownership) = weak_ownership.upgrade() {
+                    ownership.remove_session(session_id);
+                }
                 let Some(grants) = weak_grants.upgrade() else {
                     return;
                 };
@@ -445,6 +452,7 @@ impl ToolRegistry {
             runtime_cleanups: Vec::new(),
             approval_broker,
             protected_resource_grants,
+            protected_resource_ownership,
         }
     }
 
@@ -459,6 +467,12 @@ impl ToolRegistry {
 
     pub fn protected_resource_grants(&self) -> Arc<crate::consent::ProtectedResourceGrants> {
         self.protected_resource_grants.clone()
+    }
+
+    pub fn protected_resource_ownership(
+        &self,
+    ) -> Arc<crate::consent::ProtectedResourceOwnershipStore> {
+        self.protected_resource_ownership.clone()
     }
 
     /// Content-free authorization status for this exact runtime.
@@ -705,9 +719,24 @@ impl ToolRegistry {
         // avoids prompting for a call the session policy will refuse, while
         // preserving the public arguments in the grant scope and the private
         // runtime session key in its revocation lifecycle.
+        let runtime_proves_driver_owned = runtime_session
+            .as_deref()
+            .zip(public_args.get("pid").and_then(Value::as_i64))
+            .is_some_and(|(session, pid)| {
+                self.protected_resource_ownership
+                    .is_driver_owned_pid(session, pid)
+                    || public_args
+                        .get("session")
+                        .and_then(Value::as_str)
+                        .is_some_and(|public_session| {
+                            self.protected_resource_ownership
+                                .is_driver_owned_pid(public_session, pid)
+                        })
+            });
         if crate::authorization::enforcement_adapters_for_call(resolved_name, &public_args)
             .iter()
             .any(|adapter| adapter.id == "private_observation")
+            && !runtime_proves_driver_owned
             && tool
                 .protected_resource_ownership("private_observation", &public_args)
                 .await
@@ -715,6 +744,23 @@ impl ToolRegistry {
         {
             if let Err(error) = self
                 .authorize_private_observation(
+                    resolved_name,
+                    &public_args,
+                    context,
+                    runtime_session.as_deref(),
+                )
+                .await
+            {
+                return protected_consent_refusal(error);
+            }
+        }
+        if crate::authorization::enforcement_adapters_for_call(resolved_name, &public_args)
+            .iter()
+            .any(|adapter| adapter.id == "desktop_input")
+            && !runtime_proves_driver_owned
+        {
+            if let Err(error) = self
+                .authorize_desktop_input(
                     resolved_name,
                     &public_args,
                     context,
@@ -852,6 +898,9 @@ impl ToolRegistry {
         context: &crate::session_authorization::EffectiveAuthorizationContext,
         lifecycle_session: Option<&str>,
     ) -> Result<(), crate::consent::ConsentError> {
+        if context.mode() == crate::authorization::PermissionMode::Unrestricted {
+            return Ok(());
+        }
         let browser_target = args.get("target_id").and_then(Value::as_str);
         let browser_tab = args.get("tab_id").and_then(Value::as_str);
         let (resource, summary) = if let Some(target_id) = browser_target {
@@ -956,6 +1005,100 @@ impl ToolRegistry {
                 context,
                 "private_observation",
                 crate::authorization::RiskClass::R2,
+                lifecycle_session,
+                resource,
+                &format!("{summary} using {tool_name}"),
+                Duration::from_secs(30 * 60),
+                Duration::from_secs(8 * 60 * 60),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn authorize_desktop_input(
+        &self,
+        tool_name: &str,
+        args: &Value,
+        context: &crate::session_authorization::EffectiveAuthorizationContext,
+        lifecycle_session: Option<&str>,
+    ) -> Result<(), crate::consent::ConsentError> {
+        if context.mode() == crate::authorization::PermissionMode::Unrestricted {
+            return Ok(());
+        }
+        let delivery_mode = if tool_name == "bring_to_front" {
+            "foreground"
+        } else {
+            args.get("delivery_mode")
+                .and_then(Value::as_str)
+                .unwrap_or("background")
+        };
+        let (resource, summary) = if let Some(window_id) =
+            args.get("window_id").and_then(Value::as_u64)
+        {
+            let pid = args.get("pid").and_then(Value::as_i64);
+            (
+                    serde_json::json!({
+                        "kind": "window_input",
+                        "pid": pid,
+                        "window_id": window_id,
+                        "delivery_mode_ceiling": delivery_mode,
+                    }),
+                    match pid {
+                        Some(pid) => format!(
+                            "Allow Cua to control window {window_id} of process {pid} in {delivery_mode} mode"
+                        ),
+                        None => format!(
+                            "Allow Cua to control window {window_id} in {delivery_mode} mode"
+                        ),
+                    },
+                )
+        } else if let Some(pid) = args.get("pid").and_then(Value::as_i64) {
+            (
+                serde_json::json!({
+                    "kind": "application_input",
+                    "pid": pid,
+                    "delivery_mode_ceiling": delivery_mode,
+                }),
+                format!("Allow Cua to control process {pid} in {delivery_mode} mode"),
+            )
+        } else {
+            let display = self
+                .tools
+                .get("get_screen_size")
+                .ok_or_else(|| {
+                    crate::consent::ConsentError::Provider(
+                        "display identity is unavailable".to_owned(),
+                    )
+                })?
+                .invoke(serde_json::json!({}))
+                .await;
+            if display.is_error == Some(true) {
+                return Err(crate::consent::ConsentError::Provider(
+                    "display identity could not be read".to_owned(),
+                ));
+            }
+            let display = display.structured_content.ok_or_else(|| {
+                crate::consent::ConsentError::Provider(
+                    "display identity was not returned".to_owned(),
+                )
+            })?;
+            (
+                serde_json::json!({
+                    "kind": "display_input",
+                    "width": display.get("width").and_then(Value::as_u64),
+                    "height": display.get("height").and_then(Value::as_u64),
+                    "scale_factor": display.get("scale_factor").and_then(Value::as_f64),
+                    "delivery_mode_ceiling": delivery_mode,
+                }),
+                format!("Allow Cua to control the current desktop in {delivery_mode} mode"),
+            )
+        };
+
+        self.protected_resource_grants
+            .authorize(
+                context,
+                "desktop_input",
+                crate::authorization::RiskClass::R1,
                 lifecycle_session,
                 resource,
                 &format!("{summary} using {tool_name}"),
@@ -1109,6 +1252,19 @@ mod runtime_isolation_tests {
             .unwrap()
     }
 
+    fn unrestricted_context() -> Arc<crate::session_authorization::EffectiveAuthorizationContext> {
+        let ceiling = SessionModeCeiling::for_trusted_sessions(
+            [PermissionMode::Unrestricted],
+            true,
+            Duration::from_secs(60),
+            Duration::from_secs(30),
+        )
+        .unwrap();
+        SessionAuthorizationRegistry::with_ceiling(ceiling)
+            .compatibility_context(PermissionMode::Unrestricted, None)
+            .unwrap()
+    }
+
     struct ReplayProbe {
         hits: Arc<AtomicUsize>,
         def: super::ToolDef,
@@ -1186,6 +1342,26 @@ mod runtime_isolation_tests {
         Arc::new(registry)
     }
 
+    fn input_registry(
+        provider: Option<Arc<dyn ProtectedConsentProvider>>,
+        hits: Arc<AtomicUsize>,
+    ) -> Arc<super::ToolRegistry> {
+        let mut registry = super::ToolRegistry::new_with_protected_consent_provider(provider);
+        registry.register(Box::new(ObservationProbe {
+            hits,
+            def: super::ToolDef {
+                name: "click".into(),
+                description: "test input".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+                read_only: false,
+                destructive: false,
+                idempotent: false,
+                open_world: false,
+            },
+        }));
+        Arc::new(registry)
+    }
+
     #[async_trait::async_trait]
     impl super::Tool for ReplayProbe {
         fn def(&self) -> &super::ToolDef {
@@ -1227,7 +1403,7 @@ mod runtime_isolation_tests {
         let hits_b = Arc::new(AtomicUsize::new(0));
         let registry_a = replay_registry(hits_a.clone());
         let registry_b = replay_registry(hits_b.clone());
-        let context_b = standard_context();
+        let context_b = unrestricted_context();
         let trajectory = tempfile::tempdir().unwrap();
         let turn = trajectory.path().join("turn-00001");
         std::fs::create_dir(&turn).unwrap();
@@ -1340,6 +1516,87 @@ mod runtime_isolation_tests {
         assert_ne!(result.is_error, Some(true));
         assert_eq!(hits.load(Ordering::SeqCst), 1);
         assert_eq!(provider.requests.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn desktop_input_refuses_before_dispatch_and_scopes_foreground_separately() {
+        let denied_hits = Arc::new(AtomicUsize::new(0));
+        let denied = input_registry(None, denied_hits.clone())
+            .invoke_with_context(
+                "click",
+                serde_json::json!({
+                    "pid": 42,
+                    "window_id": 7,
+                    "session": "control",
+                    "x": 10,
+                    "y": 20
+                }),
+                standard_context(),
+            )
+            .await;
+        assert_eq!(denied_hits.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            denied
+                .structured_content
+                .as_ref()
+                .and_then(|value| value.pointer("/refusal/code"))
+                .and_then(serde_json::Value::as_str),
+            Some("protected_consent_required")
+        );
+
+        let hits = Arc::new(AtomicUsize::new(0));
+        let provider = Arc::new(AcceptingProvider {
+            requests: AtomicUsize::new(0),
+        });
+        let registry = input_registry(Some(provider.clone()), hits.clone());
+        let context = standard_context();
+        for delivery_mode in ["background", "background", "foreground"] {
+            let result = registry
+                .invoke_with_context(
+                    "click",
+                    serde_json::json!({
+                        "pid": 42,
+                        "window_id": 7,
+                        "session": "control",
+                        "delivery_mode": delivery_mode,
+                        "x": 10,
+                        "y": 20
+                    }),
+                    context.clone(),
+                )
+                .await;
+            assert_ne!(result.is_error, Some(true));
+        }
+        assert_eq!(hits.load(Ordering::SeqCst), 3);
+        assert_eq!(provider.requests.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn runtime_owned_pid_is_prompt_light_and_session_revocation_removes_provenance() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let registry = input_registry(None, hits.clone());
+        let context = standard_context();
+        let runtime_session = context.runtime_session_key("isolated");
+        registry
+            .protected_resource_ownership()
+            .mark_driver_owned_pid(&runtime_session, 42);
+        let args = serde_json::json!({
+            "pid": 42,
+            "window_id": 7,
+            "session": "isolated",
+            "x": 10,
+            "y": 20
+        });
+        let first = registry
+            .invoke_with_context("click", args.clone(), context.clone())
+            .await;
+        assert_ne!(first.is_error, Some(true));
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+
+        crate::session::fire_session_end(&runtime_session);
+        let after_end = registry.invoke_with_context("click", args, context).await;
+        assert_eq!(after_end.is_error, Some(true));
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/libs/cua-driver/rust/crates/cua-driver-sdk/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-sdk/src/lib.rs
@@ -1544,6 +1544,22 @@ mod tests {
         .unwrap()
     }
 
+    #[cfg(target_os = "macos")]
+    fn configured_unrestricted_driver() -> Arc<CuaDriver> {
+        CuaDriver::create_configured(ConfiguredDriverOptions {
+            claude_code_compatibility: false,
+            authorization: RuntimeAuthorizationOptions {
+                allowed_modes: vec![SessionPermissionMode::Unrestricted],
+                compatibility_mode: SessionPermissionMode::Unrestricted,
+                compatibility_bounded_manifest_path: None,
+                unrestricted_acknowledged: true,
+                max_session_ttl_seconds: 60,
+                max_idle_ttl_seconds: 30,
+            },
+        })
+        .unwrap()
+    }
+
     struct SlowHostTool;
 
     static SLOW_HOST_TOOL_DEF: std::sync::OnceLock<cua_driver_core::tool::ToolDef> =
@@ -2411,7 +2427,10 @@ mod tests {
     #[tokio::test]
     async fn direct_macos_runtime_reports_cursor_overlay_facility_unavailable() {
         let _runtime_test = crate::runtime::TEST_RUNTIME_LOCK.lock().unwrap();
-        let driver = CuaDriver::create(None).unwrap();
+        // This test is about the unavailable host-owned cursor facility, not
+        // protected input admission. Use an explicitly acknowledged
+        // unrestricted runtime so the call reaches that platform invariant.
+        let driver = configured_unrestricted_driver();
         for (tool, arguments) in [
             (
                 "set_agent_cursor_enabled",

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -7126,9 +7126,10 @@ pub fn build_registry_with_provider(
     r.register(Box::new(cua_driver_core::page::PageTool::new(Arc::new(
         super::page::LinuxPageBackend::new(),
     ))));
-    let browser_engine = cua_driver_core::browser::BrowserEngine::new_with_approval_broker(
+    let browser_engine = cua_driver_core::browser::BrowserEngine::new_with_runtime_services(
         Arc::new(crate::browser_platform::LinuxBrowserPlatform),
         r.approval_broker(),
+        r.protected_resource_ownership(),
     );
     cua_driver_core::browser::register_browser_tools(&browser_engine, &mut r);
     r.register_recording_tools();

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
@@ -682,11 +682,12 @@ pub fn register_all(
     registry.register(Box::new(cua_driver_core::page::PageTool::new(Arc::new(
         page::MacOsPageBackend::new(state.clone()),
     ))));
-    let browser_engine = cua_driver_core::browser::BrowserEngine::new_with_approval_broker(
+    let browser_engine = cua_driver_core::browser::BrowserEngine::new_with_runtime_services(
         Arc::new(crate::browser::MacOsBrowserPlatform::new(
             state.cursor_registry.clone(),
         )),
         registry.approval_broker(),
+        registry.protected_resource_ownership(),
     );
     cua_driver_core::browser::register_browser_tools(&browser_engine, registry);
     // Recording / replay + session-lifecycle tools are platform-independent.

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -8722,11 +8722,12 @@ pub fn build_registry_with_provider(
     r.register(Box::new(cua_driver_core::page::PageTool::new(
         std::sync::Arc::new(super::page::WindowsPageBackend::new()),
     )));
-    let browser_engine = cua_driver_core::browser::BrowserEngine::new_with_approval_broker(
+    let browser_engine = cua_driver_core::browser::BrowserEngine::new_with_runtime_services(
         std::sync::Arc::new(crate::browser_platform::WindowsBrowserPlatform::new(
             state.cursor_registry.clone(),
         )),
         r.approval_broker(),
+        r.protected_resource_ownership(),
     );
     cua_driver_core::browser::register_browser_tools(&browser_engine, &mut r);
     r.register_recording_tools();


### PR DESCRIPTION
## Summary
- activate the desktop-input permission adapter for standard, bounded, and unrestricted modes
- scope protected grants to exact process/window or current display geometry and delivery mode
- keep only internally attested driver-owned isolated browser processes prompt-light and revoke ownership with the session
- document the newly active boundary and fail-closed standalone behavior

## Validation
- cargo fmt --all -- --check
- cargo check -p platform-linux --locked
- cargo test -p cua-driver-core --lib --locked (389 passed)
- cargo test -p cua-driver-sdk --lib --locked (42 passed)
- git diff --check

## Stack
Depends on #2579. This PR is intentionally draft until the dependency stack lands and platform E2E is rerun at the rebased exact SHA.

No release or tag is created by this PR.