### PR TITLE
ci: handle merge authors in contributor attribution

### DIFF
--- a/.github/scripts/release_attribution.py
+++ b/.github/scripts/release_attribution.py
@@ -374,6 +374,16 @@ def validate_pr_attribution(
         )
         return login or None
 
+    commit_shas = {str(item.get("sha") or "") for item in commits}
+    credited_coauthors: set[str] = set()
+    for item in commits:
+        message = str((item.get("commit") or {}).get("message") or "")
+        for match in COAUTHOR_RE.finditer(message):
+            email = match.group("email").strip().lower()
+            login = resolved_login(match.group("name"), email)
+            if login and email not in ignored:
+                credited_coauthors.add(login.lower())
+
     def record_unresolved(
         *, email: str, name: str, sha: str, kind: str, references: Sequence[int]
     ) -> None:
@@ -405,20 +415,38 @@ def validate_pr_attribution(
         committer = commit.get("committer") or {}
         committer_email = str(committer.get("email") or "").strip().lower()
         linked_committer = str((item.get("committer") or {}).get("login") or "").strip()
-        is_merge = len(item.get("parents") or []) > 1
+        parents = [str(parent.get("sha") or "") for parent in item.get("parents") or []]
+        is_base_sync_merge = len(parents) > 1 and any(
+            parent and parent not in commit_shas for parent in parents[1:]
+        )
         preserved_unlinked_author = (
             not author_login
             and bool(pull_login)
             and linked_committer.lower() == pull_login.lower()
             and author_email != committer_email
         )
+        distinct_external_author = bool(author_login) and (
+            author_login.lower() != pull_login.lower()
+            and not is_bot(author_login, bots)
+            and author_login.lower() not in internal
+            and author_login.lower() not in opt_out
+        )
         # An ordinary direct PR author is credited from pull-request metadata even
         # when their commit email is private. A distinct unlinked author committed
         # by the landing PR author is a strong cherry-pick/preservation signal.
         #
-        # A merge author records the integration action; authorship remains on
-        # the parent commits. Coauthor trailers are still validated below.
-        if not is_merge and preserved_unlinked_author and author_email not in ignored:
+        # A base synchronization merge imports a parent outside the PR commit set,
+        # so it is not salvaged contributor work. Its distinct author must still
+        # have explicit coauthor credit elsewhere in the PR.
+        if is_base_sync_merge and distinct_external_author:
+            if author_login.lower() not in credited_coauthors:
+                trailer = f"Co-authored-by: {author_name} <{author_email}>"
+                early_errors.append(
+                    f"base synchronization merge {sha} is authored by @{author_login}, "
+                    "distinct from the landing PR author, but that contribution is not "
+                    f"credited; add `{trailer}` to a commit in this PR"
+                )
+        elif preserved_unlinked_author and author_email not in ignored:
             record_unresolved(
                 email=author_email,
                 name=author_name,
@@ -426,12 +454,7 @@ def validate_pr_attribution(
                 kind="commit author",
                 references=references,
             )
-        elif not is_merge and author_login and (
-            author_login.lower() != pull_login.lower()
-            and not is_bot(author_login, bots)
-            and author_login.lower() not in internal
-            and author_login.lower() not in opt_out
-        ):
+        elif distinct_external_author:
             if not references:
                 early_errors.append(
                     f"commit {sha} is authored by @{author_login}, distinct from landing "

--- a/.github/scripts/release_attribution.py
+++ b/.github/scripts/release_attribution.py
@@ -405,6 +405,7 @@ def validate_pr_attribution(
         committer = commit.get("committer") or {}
         committer_email = str(committer.get("email") or "").strip().lower()
         linked_committer = str((item.get("committer") or {}).get("login") or "").strip()
+        is_merge = len(item.get("parents") or []) > 1
         preserved_unlinked_author = (
             not author_login
             and bool(pull_login)
@@ -414,7 +415,10 @@ def validate_pr_attribution(
         # An ordinary direct PR author is credited from pull-request metadata even
         # when their commit email is private. A distinct unlinked author committed
         # by the landing PR author is a strong cherry-pick/preservation signal.
-        if preserved_unlinked_author and author_email not in ignored:
+        #
+        # A merge author records the integration action; authorship remains on
+        # the parent commits. Coauthor trailers are still validated below.
+        if not is_merge and preserved_unlinked_author and author_email not in ignored:
             record_unresolved(
                 email=author_email,
                 name=author_name,
@@ -422,7 +426,7 @@ def validate_pr_attribution(
                 kind="commit author",
                 references=references,
             )
-        elif author_login and (
+        elif not is_merge and author_login and (
             author_login.lower() != pull_login.lower()
             and not is_bot(author_login, bots)
             and author_login.lower() not in internal

--- a/.github/scripts/tests/test_pr_attribution.py
+++ b/.github/scripts/tests/test_pr_attribution.py
@@ -31,13 +31,13 @@ def commit(
     committer_email: str | None = None,
     committer_login: str | None = None,
     message: str = "fix: preserve attribution",
-    parent_count: int = 1,
+    parent_shas: tuple[str, ...] = ("base-parent",),
 ):
     return {
         "sha": sha,
         "author": {"login": login} if login else None,
         "committer": {"login": committer_login} if committer_login else None,
-        "parents": [{"sha": f"parent-{index}"} for index in range(parent_count)],
+        "parents": [{"sha": parent} for parent in parent_shas],
         "commit": {
             "author": {"name": name, "email": email},
             "committer": {
@@ -114,25 +114,67 @@ def test_distinct_resolvable_commit_author_requires_preserved_source():
     )
 
 
-def test_merge_author_does_not_require_a_source_pr():
+def test_credited_base_sync_merge_author_does_not_require_a_source_pr():
     validate(
         commits=[
             commit(
+                sha="feature-tip",
+                login="landing-author",
+                message=(
+                    "fix: preserve merge credit\n\n"
+                    "Co-authored-by: Merge Author "
+                    "<123+merge-author@users.noreply.github.com>"
+                ),
+            ),
+            commit(
+                sha="sync-merge",
                 login="merge-author",
                 email="merge-author@example.com",
-                parent_count=2,
-            )
+                parent_shas=("feature-tip", "main-tip"),
+            ),
         ]
     )
+
+
+def test_uncredited_base_sync_merge_author_is_rejected():
+    with pytest.raises(ReleaseError, match="base synchronization merge"):
+        validate(
+            commits=[
+                commit(sha="feature-tip", login="landing-author"),
+                commit(
+                    sha="sync-merge",
+                    login="merge-author",
+                    email="merge-author@example.com",
+                    parent_shas=("feature-tip", "main-tip"),
+                ),
+            ]
+        )
+
+
+def test_other_merge_authors_still_require_preserved_source():
+    with pytest.raises(ReleaseError, match="distinct from landing PR author"):
+        validate(
+            commits=[
+                commit(sha="feature-tip", login="landing-author"),
+                commit(sha="side-tip", login="landing-author"),
+                commit(
+                    sha="feature-merge",
+                    login="merge-author",
+                    parent_shas=("feature-tip", "side-tip"),
+                ),
+            ]
+        )
 
 
 def test_merge_coauthor_still_requires_source_evidence():
     with pytest.raises(ReleaseError, match="has no explicit same-repository source PR"):
         validate(
             commits=[
+                commit(sha="feature-tip", login="landing-author"),
                 commit(
-                    login="merge-author",
-                    parent_count=2,
+                    sha="sync-merge",
+                    login="landing-author",
+                    parent_shas=("feature-tip", "main-tip"),
                     message=(
                         "Merge main\n\n"
                         "Co-authored-by: Contributor <contributor@institution.example>"

--- a/.github/scripts/tests/test_pr_attribution.py
+++ b/.github/scripts/tests/test_pr_attribution.py
@@ -31,11 +31,13 @@ def commit(
     committer_email: str | None = None,
     committer_login: str | None = None,
     message: str = "fix: preserve attribution",
+    parent_count: int = 1,
 ):
     return {
         "sha": sha,
         "author": {"login": login} if login else None,
         "committer": {"login": committer_login} if committer_login else None,
+        "parents": [{"sha": f"parent-{index}"} for index in range(parent_count)],
         "commit": {
             "author": {"name": name, "email": email},
             "committer": {
@@ -110,6 +112,34 @@ def test_distinct_resolvable_commit_author_requires_preserved_source():
         authors={12: "source-author"},
         source_emails={12: ["source@institution.example"]},
     )
+
+
+def test_merge_author_does_not_require_a_source_pr():
+    validate(
+        commits=[
+            commit(
+                login="merge-author",
+                email="merge-author@example.com",
+                parent_count=2,
+            )
+        ]
+    )
+
+
+def test_merge_coauthor_still_requires_source_evidence():
+    with pytest.raises(ReleaseError, match="has no explicit same-repository source PR"):
+        validate(
+            commits=[
+                commit(
+                    login="merge-author",
+                    parent_count=2,
+                    message=(
+                        "Merge main\n\n"
+                        "Co-authored-by: Contributor <contributor@institution.example>"
+                    ),
+                )
+            ]
+        )
 
 
 def test_explicit_cherry_pick_source_reference_is_parsed_but_supersedes_is_not():


### PR DESCRIPTION
## Problem

When a PR is updated by merging `main`, GitHub includes the synchronization merge in the PR's commit list. If someone other than the PR author performs that merge, the validator mistakes the merge author for salvaged work and requires an unrelated source PR. This incorrectly blocked #2429.

## Change

- identify base-synchronization merges by a non-first parent outside the PR commit set
- waive the source-PR requirement only when the distinct merge author already has a resolved `Co-authored-by` trailer in the PR
- continue rejecting uncredited synchronization authors, other merge authors without provenance, and unresolved coauthors
- leave ordinary commit attribution unchanged

## Verification

- `python -m pytest .github/scripts/tests -q` — 120 passed
- revised validator against live #2429 metadata — merge-ready