### PR TITLE
ci: make release reminders status-only

### DIFF
--- a/.github/scripts/tests/test_release_bump_authorization.py
+++ b/.github/scripts/tests/test_release_bump_authorization.py
@@ -54,6 +54,43 @@ class TestReleaseBumpAuthorization(unittest.TestCase):
         )
         self.assertIn("No owner-authorized release labels found", workflow)
 
+    def test_release_comments_cannot_authorize_or_render_release_checkboxes(
+        self,
+    ) -> None:
+        auto_release = (
+            REPO_ROOT / ".github/workflows/release-on-merge.yml"
+        ).read_text()
+        reminder = (
+            REPO_ROOT / ".github/workflows/ci-release-reminder.yml"
+        ).read_text()
+
+        auto_release_trigger = auto_release.split("permissions:", 1)[0]
+        self.assertIn("pull_request:\n    types: [closed]", auto_release_trigger)
+        self.assertNotIn("issue_comment", auto_release_trigger)
+        self.assertNotIn("pull_request_review_comment", auto_release_trigger)
+        self.assertNotIn("github.event.pull_request.body", auto_release)
+        self.assertNotIn("/comments", auto_release)
+        self.assertIn(
+            "Release authorization comes only from audited label events",
+            auto_release,
+        )
+
+        reminder_trigger = reminder.split("jobs:", 1)[0]
+        self.assertNotIn("issue_comment", reminder_trigger)
+        self.assertNotIn("pull_request_review_comment", reminder_trigger)
+        self.assertNotIn("- [x]", reminder)
+        self.assertNotIn("- [X]", reminder)
+        self.assertNotIn("- [ ]", reminder)
+        self.assertIn("This comment is status-only", reminder)
+        self.assertIn(
+            "Only owner-applied \\`release:<service>\\` labels can do that",
+            reminder,
+        )
+        self.assertIn(
+            "Ask the release owner to apply \\`release:<service>\\` labels",
+            reminder,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/tests/test_release_bump_authorization.py
+++ b/.github/scripts/tests/test_release_bump_authorization.py
@@ -90,6 +90,8 @@ class TestReleaseBumpAuthorization(unittest.TestCase):
             "Ask the release owner to apply \\`release:<service>\\` labels",
             reminder,
         )
+        self.assertIn("EXISTING_COMMENT_IDS=$(gh api --paginate", reminder)
+        self.assertNotIn("| head -1", reminder)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci-release-reminder.yml
+++ b/.github/workflows/ci-release-reminder.yml
@@ -112,12 +112,17 @@ jobs:
             BODY+="\nOr add \`no-release\` to skip."
           fi
 
-          # Delete previous reminder comment if exists, then post new one
-          EXISTING_COMMENT_ID=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-            --jq ".[] | select(.body | contains(\"${COMMENT_MARKER}\")) | .id" 2>/dev/null | head -1)
+          # Delete every previous generated reminder, including duplicates left by
+          # older workflow runs, then post one clean status comment.
+          EXISTING_COMMENT_IDS=$(gh api --paginate \
+            "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" \
+            --jq ".[] | select(.body | contains(\"${COMMENT_MARKER}\")) | .id" 2>/dev/null || true)
 
-          if [ -n "$EXISTING_COMMENT_ID" ]; then
-            gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/comments/${EXISTING_COMMENT_ID}" 2>/dev/null || true
-          fi
+          while IFS= read -r comment_id; do
+            if [ -n "$comment_id" ]; then
+              gh api -X DELETE \
+                "repos/${REPO}/issues/${PR_NUMBER}/comments/${comment_id}" 2>/dev/null || true
+            fi
+          done <<< "$EXISTING_COMMENT_IDS"
 
           echo -e "$BODY" | gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file -

--- a/.github/workflows/ci-release-reminder.yml
+++ b/.github/workflows/ci-release-reminder.yml
@@ -87,25 +87,27 @@ jobs:
           COMMENT_MARKER="<!-- release-reminder -->"
           BODY="${COMMENT_MARKER}\n"
           BODY+="### 📦 Publishable packages changed\n\n"
+          BODY+="This comment is status-only. Editing it or adding task-list checkboxes cannot authorize a release.\n"
+          BODY+="Only owner-applied \`release:<service>\` labels can do that.\n\n"
 
           if [ ${#LABELED[@]} -gt 0 ]; then
             for svc in "${LABELED[@]}"; do
-              BODY+="- [x] \`${svc}\` — will auto-release on merge\n"
+              BODY+="- ✅ \`${svc}\` — owner-authorized auto-release on merge\n"
             done
           fi
 
           if [ ${#UNLABELED[@]} -gt 0 ]; then
             for svc in "${UNLABELED[@]}"; do
               if [ "$HAS_NO_RELEASE" = "true" ]; then
-                BODY+="- [x] ~\`${svc}\`~ — skipped (no-release)\n"
+                BODY+="- ⏭️ ~\`${svc}\`~ — skipped (no-release)\n"
               else
-                BODY+="- [ ] \`${svc}\`\n"
+                BODY+="- ⏸️ \`${svc}\` — no owner-authorized release label\n"
               fi
             done
           fi
 
           if [ "$HAS_NO_RELEASE" = "false" ] && [ ${#UNLABELED[@]} -gt 0 ]; then
-            BODY+="\nAdd \`release:<service>\` labels to auto-release on merge"
+            BODY+="\nAsk the release owner to apply \`release:<service>\` labels to auto-release on merge"
             BODY+=" (+ optional \`bump:minor\` or \`bump:major\`, default is patch)."
             BODY+="\nOr add \`no-release\` to skip."
           fi

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -30,6 +30,9 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           REPO: ${{ github.repository }}
         run: |
+          # Release authorization comes only from audited label events. Never
+          # read PR bodies, comments, task lists, or checkbox state here.
+
           # Skip everything if no-release
           if echo "$LABELS" | grep -q '"no-release"'; then
             echo "no-release label found, skipping."


### PR DESCRIPTION
## Summary

- replace release reminder task-list checkboxes with non-interactive status icons
- state that comments and task lists cannot authorize releases
- direct contributors to ask the release owner for audited release labels
- remove every stale generated reminder before posting one clean status comment
- lock the comment/body authorization boundary and stale-cleanup behavior with regression coverage

## Authorization boundary

Auto-release still runs only after a PR is merged and only for `release:<service>` labels whose latest label event was applied by `f-trycua`. PR bodies, comments, and task-list state are not read.

## Validation

- `git diff --check`
- `uv run --with pytest python -m pytest .github/scripts/tests/test_release_bump_authorization.py -q` (3 passed)
- `uv run --with pytest python -m pytest .github/scripts/tests -q` (121 passed)

Validated locally at exact head `004b477c4523ce854d7f5b91dfc0e3908c0275f8`.

## Scope

CI/repository policy only; no release-tracked product files changed.