### PR TITLE
test(cua-driver): align desktop runners with product paths

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_gtk3_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_gtk3_test.rs
@@ -541,12 +541,7 @@ fn row_expects_refusal(row: CatalogRow) -> bool {
     }
     let focus_bound_pointer = matches!(
         row.operation,
-        Operation::PxClick {
-            button: "right",
-            ..
-        } | Operation::PxClick { count: 2, .. }
-            | Operation::Scroll { pixel: true, .. }
-            | Operation::Drag { .. }
+        Operation::PxClick { .. } | Operation::Scroll { pixel: true, .. } | Operation::Drag { .. }
     );
     if DisplayServer::current() == DisplayServer::X11
         && (focus_bound_pointer || matches!(row.operation, Operation::PxTypeText { .. }))

--- a/libs/cua-driver/tests/runners/macos-lume/run-all.sh
+++ b/libs/cua-driver/tests/runners/macos-lume/run-all.sh
@@ -213,7 +213,8 @@ RESTORE_STANDARD_DAEMON=1
 open -n -g /Applications/CuaDriverLocal.app --args \
   serve \
   --permission-mode unrestricted \
-  --dangerously-bypass-approvals
+  --dangerously-bypass-approvals \
+  >/dev/null 2>&1
 UNRESTRICTED_READY=0
 for _ in 1 2 3 4 5 6 7 8 9 10; do
   if "${INSTALLED_BIN}" status --socket "${CUA_E2E_MACOS_DAEMON_SOCKET}" \

--- a/scripts/ci/linux/run-rust-e2e-desktop.sh
+++ b/scripts/ci/linux/run-rust-e2e-desktop.sh
@@ -61,7 +61,8 @@ case "${ENVIRONMENT}" in
     ;;
 esac
 
-if [[ "${CUA_E2E_HARNESS_FILTER:-}" == *tauri* && ! -e /dev/dri/renderD128 ]]; then
+effective_harness_filter="${CUA_E2E_HARNESS_FILTER:-electron,tauri}"
+if [[ ",${effective_harness_filter}," == *,tauri,* && ! -e /dev/dri/renderD128 ]]; then
   echo "Tauri/WebKitGTK validation requires a representative DRM render node" >&2
   exit 2
 fi

--- a/scripts/ci/linux/run-rust-e2e.sh
+++ b/scripts/ci/linux/run-rust-e2e.sh
@@ -91,6 +91,14 @@ else
   export CUA_E2E_COMPOSITOR="${CUA_E2E_COMPOSITOR:-openbox-x11}"
   export CUA_E2E_INPUT_BACKENDS="${CUA_E2E_INPUT_BACKENDS:-atspi,xsend-event,xtest}"
 fi
+CARGO_DRIVER_FEATURE_ARGS=()
+if [[ ",${CUA_E2E_INPUT_BACKENDS}," == *,libei-portal,* ]]; then
+  # GNOME and KDE retain DISPLAY for XWayland while the product route remains
+  # native Wayland. Their representative lanes require the release-shipped
+  # RemoteDesktop/libei adapter, so every cua-driver build/test in this runner
+  # must compile the same portal-input feature instead of falling back to wtype.
+  CARGO_DRIVER_FEATURE_ARGS=(--features portal-input)
+fi
 if [[ "${SUITE}" == shared || "${SUITE}" == all ]]; then
   export CUA_ATSPI_DEBUG=1
 fi
@@ -106,7 +114,9 @@ command -v ffprobe >/dev/null || { echo "ffprobe is required for E2E trajectory 
 command -v jq >/dev/null || { echo "jq is required for E2E ownership validation" >&2; exit 1; }
 
 if [[ "${BUILD_FIXTURES}" == 1 ]]; then
-  cargo build --release -p cua-driver --manifest-path "${RUST_ROOT}/Cargo.toml"
+  cargo build --release -p cua-driver \
+    "${CARGO_DRIVER_FEATURE_ARGS[@]}" \
+    --manifest-path "${RUST_ROOT}/Cargo.toml"
   case "${SUITE}" in
     shared) FIXTURE_TARGETS="${CUA_E2E_HARNESS_FILTER:-electron,tauri}" ;;
     native|capture) FIXTURE_TARGETS="electron,gtk3" ;;
@@ -151,7 +161,9 @@ run_report() {
 
 echo "[PREFLIGHT] Linux desktop, fixture, AX, capture, and video"
 set +e
-(cd "${RUST_ROOT}" && cargo test -p cua-driver --test e2e_environment_preflight_test -- \
+(cd "${RUST_ROOT}" && cargo test -p cua-driver \
+  "${CARGO_DRIVER_FEATURE_ARGS[@]}" \
+  --test e2e_environment_preflight_test -- \
   --ignored --exact canonical_e2e_environment_is_ready --nocapture --test-threads=1) \
   2>&1 | tee "${ARTIFACT_DIR}/environment-preflight.log"
 PREFLIGHT_EXIT=${PIPESTATUS[0]}
@@ -179,35 +191,42 @@ run_test() {
 
 if [[ "${SUITE}" == shared || "${SUITE}" == all ]]; then
   run_test protected-permission-prompt-socket \
-    cargo test -p cua-driver --test permission_prompt_authorization_test -- --test-threads=1
+    cargo test -p cua-driver "${CARGO_DRIVER_FEATURE_ARGS[@]}" \
+      --test permission_prompt_authorization_test -- --test-threads=1
   run_test sdk-runtime-contract \
     cargo test -p cua-driver-sdk --lib -- --test-threads=1
   run_test sdk-runtime-configuration \
     cargo test -p cua-driver-sdk --test runtime_configuration -- --test-threads=1
   run_test private-worker-lifecycle \
-    cargo test -p cua-driver --test private_worker_test -- --test-threads=1
+    cargo test -p cua-driver "${CARGO_DRIVER_FEATURE_ARGS[@]}" \
+      --test private_worker_test -- --test-threads=1
   run_test shared-behavior-matrix \
-    cargo test -p cua-driver --test cross_platform_behavior_test -- \
+    cargo test -p cua-driver "${CARGO_DRIVER_FEATURE_ARGS[@]}" \
+      --test cross_platform_behavior_test -- \
       --ignored --exact shared_web_action_matrix_is_state_verified \
       --nocapture --test-threads=1
   run_test embedded-browser-routes \
-    cargo test -p cua-driver --test cross_platform_behavior_test -- \
+    cargo test -p cua-driver "${CARGO_DRIVER_FEATURE_ARGS[@]}" \
+      --test cross_platform_behavior_test -- \
       --ignored --exact embedded_browser_routes_are_exact_or_refused \
       --nocapture --test-threads=1
 fi
 
 if [[ "${SUITE}" == native || "${SUITE}" == all ]]; then
   run_test gtk3-native-harness \
-    cargo test -p cua-driver --test harness_gtk3_test -- \
+    cargo test -p cua-driver "${CARGO_DRIVER_FEATURE_ARGS[@]}" \
+      --test harness_gtk3_test -- \
       --ignored --nocapture --test-threads=1
 fi
 
 if [[ "${SUITE}" == capture || "${SUITE}" == all ]]; then
   run_test capture-contract \
-    cargo test -p cua-driver --test capture_contract_test -- \
+    cargo test -p cua-driver "${CARGO_DRIVER_FEATURE_ARGS[@]}" \
+      --test capture_contract_test -- \
       --ignored --nocapture --test-threads=1
   run_test desktop-scope \
-    cargo test -p cua-driver --test desktop_scope_linux_test -- \
+    cargo test -p cua-driver "${CARGO_DRIVER_FEATURE_ARGS[@]}" \
+      --test desktop_scope_linux_test -- \
       --ignored --nocapture --test-threads=1
 fi
 


### PR DESCRIPTION
## What

- detach the macOS LaunchServices daemon from inherited runner output pipes
- compile the Linux desktop runner with `portal-input` when the representative wrapper declares the `libei-portal` product path
- resolve the effective default harness set before preflight, so an implicitly selected Tauri/WebKitGTK run fails clearly when no DRM render node is available
- classify GTK3 pixel-background click on Wayland as the product's expected `background_unavailable` refusal

## Why

Cross-platform consent certification exposed three runner defects:

- a daemon launched through `open` could inherit a remote shell pipe and later panic on a broken stdout/stderr stream
- the GNOME wrapper advertised the libei portal path while compiling the driver without that feature, allowing a misleading fallback
- the Linux wrapper validated only an explicit harness filter even though its default also selected Tauri

These changes keep the test harness aligned with the product path and turn an unrepresentative Tauri environment into an early, actionable refusal.

## Validation

- `bash -n` on all changed shell scripts
- `git diff --check`
- `cargo fmt --all -- --check`
- complete native and standalone-browser runs on a disposable macOS VM
- complete native desktop matrix in a non-Session-0 Windows RDP session
- representative native GNOME/Mutter Wayland run through AT-SPI plus the release `portal-input`/libei path
- corrected GTK3 `Px/Background` single-click case passed at this PR's exact head with a finalized behavioral recording
- standalone-browser GNOME run completed 16 of 17 cases; the repeatable multi-tab occlusion failure and two unrelated native product failures are tracked in #2594
- Linux default-harness preflight verified to refuse when the required DRM render node is absent

No release is requested.
