### PR TITLE
docs(cua-driver): correct skill-pack claims that disagree with the shipped driver

### DIFF
--- a/libs/cua-driver/rust/Skills/cua-driver/MACOS.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/MACOS.md
@@ -112,18 +112,19 @@ is safe even for apps that normally foreground on media-load
 | Enumerate an app's windows            | `list_windows({pid})` — or read the `windows` array `launch_app` already returns       | `osascript 'every window of app …'`                         |
 | Click / type / scroll / keys          | `click`, `type_text`, `scroll`, `press_key`, `hotkey`                                  | `osascript`, `cliclick`, raw `CGEvent`, `open <url>`        |
 | Drag / drag-and-drop / marquee select | `drag({pid, from_x, from_y, to_x, to_y})` (pixel-only — macOS AX has no semantic drag) | `cliclick dd:`, `osascript drag`                            |
-| Screenshot                            | `screenshot` or the PNG in `get_window_state`                                          | `screencapture`                                             |
+| Screenshot                            | the PNG in `get_window_state` (window), `get_desktop_state` (full display), or `zoom` (crop) — macOS has **no** `screenshot` tool, removed in #1692 | `screencapture`                                             |
 | Quit an app                           | ask the user first, then `hotkey({pid, keys:["cmd","q"]})`                             | `kill`, `killall`, `pkill`                                  |
+| Deliberately take **and hold** the foreground | `bring_to_front({pid, window_id?})` — steals focus by design and does **not** restore | `osascript 'tell app … to activate'`                        |
 | Hand a file/URL to an app             | `launch_app({bundle_id, urls:[<path>]})`                                               | `open -a <App> <path>`, `open <url>`                        |
 
 ### The narrow carve-out
 
-The **only** legitimate use of `osascript -e 'tell app X to
-activate'` is when the user **explicitly** asked for frontmost
-state ("bring Chrome to the front", "make it frontmost", "I want
-to see X"). Reaching for it because a tool call returned something
-confusing is wrong — that's the skill's classic foot-in-the-door
-failure mode and it steals focus every time.
+When the user **explicitly** asks for frontmost state ("bring Chrome to
+the front", "make it frontmost", "I want to see X"), the tool for it is
+`bring_to_front({pid, window_id?})` — not `osascript`. Reaching for a
+shell activate because a tool call returned something confusing is
+wrong either way: that's the skill's classic foot-in-the-door failure
+mode and it steals focus every time.
 
 When a cua-driver call surprises you, diagnose cua-driver first:
 
@@ -483,24 +484,90 @@ the user requested genuinely requires frontmost (Preview rotate,
 View menu document manipulation, editor commands). If either
 check fails, don't activate.
 
-When both checks pass, the driver has no `activate` tool
-(deliberately — the whole point is backgroundable control), so
-this is the one legitimate `osascript` fallback:
+When both checks pass, use the driver's own foreground rungs rather
+than shelling out:
 
-```bash
-osascript -e 'tell application "<App Name>" to activate'
-```
+- **One menu pick or one shortcut** — put `delivery_mode:"foreground"`
+  on the action itself: `click({pid, window_id, element_index: N,
+  action: "pick", delivery_mode: "foreground"})`, or the same flag on
+  `hotkey` for the shortcut form (`⌘R`, `⌘+`). It briefly fronts the
+  window, acts, then restores the prior frontmost.
+- **The target must stay frontmost across several steps** —
+  `bring_to_front({pid, window_id})`. It returns `activated` plus the
+  path it used (`skylight` when given a `window_id`, `cocoa` otherwise).
+  It deliberately does **not** restore the previous app, which is why
+  `delivery_mode` is the better choice whenever one action will do; call
+  `bring_to_front` on the user's prior app to put things back.
 
 Then re-snapshot — the menu item loses its `DISABLED` tag — and
-`click({action: "pick"})` the item. Alternatively, a `hotkey`
-call delivered to the now-frontmost app works for the shortcut
-form (`⌘R`, `⌘+`, etc.).
+`click({action: "pick"})` the item.
 
 **Always name the focus steal in your response** so the user isn't
 surprised — "Briefly activating Preview to enable Tools → Rotate
 Right" or similar. Don't silently steal focus. You don't need to
 restore the previous frontmost afterwards unless the user asks —
 they can cmd-tab back.
+
+## Menu-bar-only apps (`LSUIElement`, status items, panels, popovers)
+
+An agent app with an `NSStatusItem` and no ordinary window returns
+`list_windows({pid}) -> []` forever, because `list_windows` enumerates
+**layer-0 windows only** (`windows.rs`, the single `kCGWindowLayer`
+filter). A status-bar `NSPanel` sits at level 25 and a popover creates
+another level-25 window, so neither is ever listed. It is easy to read
+that empty array as "cua-driver does not support this app". It is a
+discovery limit, not a capability limit — the whole flow works:
+
+```bash
+# an LSUIElement app is often absent from list_apps too
+PID=$(pgrep -x MyAgentApp)
+
+# AX: pass ANY integer as window_id. The walk is application-rooted, so the
+# status item comes back regardless of which id you name.
+cua-driver get_window_state '{"pid":'$PID',"window_id":1,"include_screenshot":false}'
+#   -> elements: [{element_index: 0, role: "AXMenuBarItem", label: "..."}]
+
+# Drive it: AXShowMenu, re-snapshot, AXPick the item.
+cua-driver right_click     '{"pid":'$PID',"window_id":1,"element_index":0}'
+cua-driver get_window_state '{"pid":'$PID',"window_id":1,"include_screenshot":false}'
+cua-driver click           '{"pid":'$PID',"window_id":1,"element_index":3,"action":"pick"}'
+
+# Pixels need the real CGWindowID, which CGWindowList has and list_windows
+# filters out. Reading it is not a GUI mutation, so it is outside the
+# osascript prohibition above.
+osascript -l JavaScript -e 'ObjC.import("CoreGraphics");ObjC.import("Foundation");
+  function run(a){const p=parseInt(a[0],10);
+  const w=ObjC.deepUnwrap(ObjC.castRefToObject($.CGWindowListCopyWindowInfo($.kCGWindowListOptionAll,$.kCGNullWindowID)));
+  return JSON.stringify(w.filter(x=>x.kCGWindowOwnerPID===p).map(x=>({id:x.kCGWindowNumber,layer:x.kCGWindowLayer})));}' $PID
+cua-driver get_window_state '{"pid":'$PID',"window_id":<thatId>,"screenshot_out_file":"/tmp/panel.png","max_elements":1}'
+```
+
+Four things decide whether this works:
+
+- **The AXMenuBar caution above does not apply to status items.** That rule
+  concerns an app's *application menu bar* (File/Edit/View), which the system
+  renders for whichever app is frontmost. An `NSStatusItem` is the app's own
+  menu-bar **extra**: `AXShowMenu` on it presents that item's own menu with no
+  frontmost requirement and no visual mis-attribution.
+- **Give actions their own cache key.** The element cache is keyed
+  `(pid, window_id)` and is replaced by every `get_window_state` on that key,
+  including an `include_screenshot:false` one. A capture loop pointed at the
+  same window as a pending action evicts its indices and the action fails with
+  `Element index N not found in cache` — while the screenshot still looks
+  plausible. Since the AX walk ignores `window_id`, park actions on a sentinel
+  key (`window_id: 1`) and leave real ids free for capture.
+- **`click({action:"pick"})` on an `AXMenuItem` blocks for ~2 s.** Fire it
+  synchronously and every frame you capture afterwards lands after the UI it
+  triggered has finished animating. To capture an entry animation, start the
+  capture loop first and let the pick run concurrently — which is only safe
+  with the separate cache key above.
+- **Check what the app exposes before promising to read text.** A quick
+  read-only oracle: `osascript -e 'tell application "System Events" to tell
+  process "X" to return count of windows'`. If that is `0`, the panel's
+  contents are invisible to every accessibility consumer — cua-driver and
+  VoiceOver alike — and pixels are the only route. That is an app-side
+  accessibility gap rather than a driver limitation, and worth reporting to
+  the app's owner.
 
 ## Browsers on macOS
 

--- a/libs/cua-driver/rust/Skills/cua-driver/RECORDING.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/RECORDING.md
@@ -17,10 +17,14 @@ turn folder under a caller-chosen output directory. Read-only tools
 permission probes, agent-cursor getters / setters, and the recording
 controls themselves) are not recorded.
 
-**Video on by default.** `start_recording` also captures the main
-display to `<output_dir>/recording.mp4` (H.264 / 30 fps) for the
-lifetime of the session. The mp4 is finalized on `stop_recording`. Opt
-out with `record_video: false` when you don't want video.
+**Video is opt-in — it is OFF by default.** Pass `record_video: true`
+to `start_recording` to also capture the main display to
+`<output_dir>/recording.mp4` (H.264). The mp4 is finalized on
+`stop_recording`.
+
+`recording_tools.rs` takes `args.bool_or("record_video", false)`, the
+tool's own description says "**Video is off by default.**", and a live
+run without the flag returns `last_video_path: null` and writes no mp4.
 
 **macOS — native ScreenCaptureKit, zero-config.** On macOS the daemon's
 recorder uses `SCStream` + `SCRecordingOutput`, so it inherits the daemon's
@@ -45,7 +49,7 @@ tools, or the friendlier `cua-driver recording` subcommand group
 cua-driver recording start ~/cua-trajectories/run-1
 # … run the workflow …
 cua-driver recording status    # -> enabled / disabled, next_turn, output_dir
-cua-driver recording stop      # -> "Recording stopped. (video → recording.mp4)"
+cua-driver recording stop      # -> "Recording stopped."
 ```
 
 Raw-tool equivalent:

--- a/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
@@ -110,20 +110,24 @@ vision/computer-use-style flow, they can register:
 cua-driver mcp-config --client claude   # then paste + run the printed line
 ```
 
-Observation: Claude Code vision flows appear to treat a screenshot
-MCP tool as the image-grounding anchor. This compatibility mode keeps
-the normal CuaDriver tools and changes only `screenshot`. The
-compatibility `screenshot` requires `pid` and `window_id`, captures
-only that target window, and returns the window-local pixel
-coordinate frame. Start with `launch_app` or `list_windows`, then
-call `screenshot({pid, window_id})`; do not assume desktop
-coordinates or a full-screen capture.
+What that registration changes is the MCP **server name** — it becomes
+`cua-computer-use`, which is what triggers Claude Code's
+computer-use tool injection. The tool surface is unchanged.
 
-Use MCP for this Claude Code vision/computer-use-style path. Do not
-shell out to `cua-driver screenshot` as a substitute: CLI screenshots
-still work as CuaDriver calls, but they do not expose the
-`mcp__cua-computer-use__screenshot` tool name that Claude Code
-appears to use as the image-grounding cue.
+**On macOS there is no `screenshot` tool to anchor on.** The standalone
+and compat `screenshot` tools were removed in #1692
+(`platform-macos/src/tools/mod.rs`), so `--claude-code-computer-use-compat`
+no longer gates any tool swap — `cua-driver --help` says as much. There is
+no `screenshot` in `list-tools`, no `mcp__cua-computer-use__screenshot`,
+and no `cua-driver screenshot` CLI subcommand. Ground on the surfaces that
+do exist:
+
+- `get_window_state({pid, window_id})` — one window, tree + PNG, capped
+  at 1568 px on the long side.
+- `get_desktop_state` — the full primary display at native resolution,
+  no AX walk.
+- `zoom({pid, window_id, x1,y1,x2,y2})` — a magnified JPEG crop, with
+  `from_zoom:true` on the follow-up click to translate coordinates back.
 
 ## Using cua-driver from the shell
 
@@ -247,9 +251,16 @@ cua-driver get_session_state '{"session":"research-1"}'
 ```
 
 Do not use `config set capture_scope` or `set_config`; that key is retired and
-stale values on disk are ignored. Always pass the public `session` field on
-state and action calls. Reserved fields such as `_session_id` are transport
-metadata and cannot create or change policy.
+stale values on disk are ignored.
+
+**The policy binds to a declared session, so it is opt-in.** An anonymous call —
+one with no `session` field — is subject to no scope at all: `get_desktop_state
+'{}'` returns a full-display capture even while a declared `window`-scope session
+in the same daemon is correctly rejected with `code:"desktop_scope_disabled"`.
+Omitting `session` does not inherit the default policy, it escapes it. Always
+pass the public `session` field on state and action calls. Reserved fields
+such as `_session_id` are transport metadata and cannot create or change
+policy.
 
 During a mixed-version rollout, require `tools/list` to advertise
 `session.capture_scope` (and `session.capture_scope.escalate` for `auto`). If an
@@ -264,11 +275,37 @@ panels. Concrete reproducer: IINA's OpenSubtitles helper (600×432
 off-screen) out-area'd the visible 320×240 player window, so
 `get_app_state(pid)` screenshot'd the invisible panel and clicks landed
 there silently. The new `get_window_state(pid, window_id)` makes the
-caller name the window explicitly — the driver validates that the
-window belongs to the pid and is on the current Space/desktop, then
-snapshots exactly what was asked for. Enumerate candidates via
+caller name the window explicitly. Enumerate candidates via
 `list_windows` or read the `windows` array `launch_app` already
 returns.
+
+**On macOS the two halves of the response treat `window_id`
+differently**, which is worth knowing before you rely on it:
+
+- The **screenshot** honours it. Only a window that genuinely belongs to
+  that pid is captured — but when it does not, the frame is **omitted
+  silently**: no error, no `has_screenshot:false`, the `screenshot_*`
+  keys are simply absent. Test for the key rather than assuming a frame.
+- The **AX tree ignores it.** The walk is application-rooted, so a
+  nonexistent id, `0`, and an id owned by a *different process* all
+  return the same tree (measured: one app returned the identical 248
+  elements for all three). For the tree, `window_id` is only the
+  element-cache key, and the documented
+  `window_id W belongs to pid P, not …` error does not fire on this path.
+
+Two things follow. First, an app with **no layer-0 window at all** is
+still drivable: `list_windows` returns only layer-0 windows
+(`windows.rs`, the single `kCGWindowLayer` filter), so an `LSUIElement`
+menu-bar agent yields `[]` forever — yet passing any integer as
+`window_id` still returns its application-rooted tree, status item
+included. See "Menu-bar-only apps" in `MACOS.md`. Second, since the
+element cache is keyed `(pid, window_id)` and is replaced by **every**
+`get_window_state` on that key — including an
+`include_screenshot:false` one — a capture loop aimed at the same window
+as an in-flight element action will evict that action's indices, and the
+action then fails with `Element index N not found in cache` while the
+screenshot still looks plausible. Giving actions their own `window_id`
+key keeps the two from colliding.
 
 ## Behavior matrix
 
@@ -304,8 +341,10 @@ capture, no mode flip.
 > effect** — both the tree and the screenshot come back regardless of
 > what you pass (`ax`, `vision`, `som`, anything). There is no
 > `ax`/`vision`/`som` capture choice anymore. Drop the word "vision"
-> for perception entirely. (The tool named `screenshot` is separate —
-> raw PNG, no AX walk — and unrelated.)
+> for perception entirely. (Linux and Windows register a separate
+> `screenshot` tool — raw PNG, no AX walk — and it is unrelated. **macOS
+> has no `screenshot` tool**; it was removed in #1692. For a raw
+> full-display PNG with no AX walk there, use `get_desktop_state`.)
 
 ### The modality is chosen at ACTION time — `ax` vs `px`
 
@@ -356,12 +395,21 @@ at a pixel." So: text → `type_text` (ax+px); non-text control values →
 
 **Action responses carry an effect/escalation verdict**
 
-Every action response keeps `verified` (did the driver read back a
-post-condition?) and adds two machine-readable fields so you know
-whether — and where — to climb the ladder:
+The pointer and keyboard families (`click`, `double_click`,
+`right_click`, `drag`, `scroll`, `type_text`, `press_key`, `hotkey`)
+keep `verified` (did the driver read back a post-condition?) and add two
+machine-readable fields so you know whether — and where — to climb the
+ladder. **`set_value`, `type_text_chars`, `zoom` and `bring_to_front`
+return a bare text result with none of the three** — treat a missing
+`effect` as `unverifiable` and confirm off the re-snapshot yourself:
 
 - `effect`: one of
   - `"confirmed"` — the driver read back the effect (`ax` rung only).
+    **Not reachable for `click`**, whose own schema states "A click is
+    never driver-verifiable (no read-back), so both report
+    `verified:false`" — a successful AX click on a button returns
+    `unverifiable`. Verify a click by tree diff, not by waiting for
+    `confirmed`.
   - `"unverifiable"` — dispatched, but the driver has no handle to
     read back (every `px`/CGEvent path; foreground rung). **You**
     confirm it off the screenshot — it is not a failure.
@@ -434,7 +482,10 @@ if resp.escalation.recommended == "foreground"
 # Reach this only after AX, window-pixel, browser-page (when available), and
 # foreground-window delivery have all been exhausted and verified ineffective.
 escalate_session(session,
-    reason="foreground_ineffective",       # or another advertised reason
+    reason="foreground_ineffective",       # one of: ax_tree_pixel_mismatch |
+                                           # background_delivery_failed |
+                                           # foreground_ineffective |
+                                           # no_window_target | other
     detail="bounded non-sensitive summary")
 get_desktop_state(session)                  # full primary display
 desktop_action(session, scope="desktop", ...)  # no pid/window_id
@@ -487,7 +538,12 @@ from that exact full-display image and omit `pid`/`window_id`. The global
 
 `launch_app` now returns a `windows` array alongside the pid, so the
 common case collapses to two calls (`launch_app` → `get_window_state`)
-without a separate `list_windows` hop.
+without a separate `list_windows` hop. **On a cold launch that array is
+empty** — the process exists before its window does, so `windows[0]`
+throws on an app that was not already running. Either poll
+`list_windows({pid})` (the window appeared within ~400 ms for
+Calculator) or simply call `launch_app` again: it is idempotent and the
+second call returns the populated array.
 
 **Declare a session.** A session is _your run's_ identity — a stable id
 you choose (`"research-1"`), declared with `start_session` and passed as
@@ -543,11 +599,21 @@ the grab (a perf knob, not a modality choice).
 
 The response carries:
 
-- `tree_markdown` — every actionable element tagged `[N]`. That `N`
-  is the `element_index`. The tree can be very large (Finder is
-  ~1600 elements, ~190 KB); when it exceeds token limits the MCP
-  harness saves it to a file and returns the path. Use `Bash` +
-  `jq -r '.tree_markdown'` + `grep` to pull the section you need.
+- `elements` — the structured array, and the surface the response's own
+  `_note` asks new consumers to prefer: `element_index`,
+  `element_token`, `role`, `label`, `value`, `frame`, `parent_index`,
+  `depth`, `enabled`. Note `label` is **omitted**, not null, when an
+  element has none.
+- `tree_markdown` — the same tree rendered for text-parsing callers,
+  every actionable element tagged `[N]`. That `N` is the
+  `element_index`.
+- **Bound the tree at the source rather than grepping it afterwards.**
+  The tree can be very large (Finder is ~1600 elements, ~190 KB), but
+  `get_window_state` takes `query` (filters `tree_markdown` to matching
+  lines plus their ancestor chain, indices unchanged — a 222-element
+  Calculator tree collapses to 2 lines), plus `max_elements` /
+  `max_depth` to cap the walk. `max_elements:1` is also the cheap way
+  to take a screenshot without paying for the AX walk.
 - `effect` / `escalation` / `degraded` — the verify-then-escalate
   signals (see the behavior matrix above): `degraded: true` means the
   tree came back empty (non-AX surface), so you act by **`px`** off the
@@ -736,9 +802,13 @@ For precise targeting on small / dense UIs:
    disk via `--screenshot-out-file <path>`.
 2. Look at the PNG. Since it matches what you see, pick the target
    pixel directly.
-3. When precision matters, draw a crosshair on the image (do
-   **not** crop — cropping loses the coordinate system) and verify
-   before clicking:
+3. When precision matters, let the driver draw the crosshair: pass
+   `debug_image_out:"/tmp/shot_annotated.png"` on the click itself. It
+   captures a fresh frame, marks exactly the `(x, y)` it is about to
+   use, and writes the PNG (requires `window_id`; incompatible with
+   `from_zoom`) — so your marker cannot disagree with the driver's
+   maths. Only when you need the marker *before* dispatching, draw it
+   yourself (do **not** crop — cropping loses the coordinate system):
 
 ```python
 from PIL import Image, ImageDraw
@@ -818,7 +888,9 @@ and training data. Only invoke when the user explicitly asks to
 record a session — the skill does not auto-enable this. CLI surface:
 `cua-driver recording start|stop|status`; raw tools:
 `start_recording` / `stop_recording`. Video capture (main display →
-`recording.mp4`) is on by default; pass `record_video: false` to opt out.
+`recording.mp4`) is **off** by default; pass `record_video: true` to
+enable it. Note the `cua-driver recording start` CLI never sends that
+field, so the raw tool is the only surface that can turn video on.
 
 See **`RECORDING.md`** for the full flow: enable/disable, turn folder
 contents, replay via `replay_trajectory`, and the element_index


### PR DESCRIPTION
## What this is

I ran the `cua-driver` skill pack as an actual agent harness against a real
macOS app, then checked every instruction it gave me against the shipped driver.
A number of them turned out to disagree with the binary. This PR fixes the
documentation half of that; the behaviour findings are listed at the bottom
rather than changed here, since they need maintainer judgement.

**Environment:** cua-driver 0.12.6 (release binary), macOS 26.5.1, source read at
`bdc3e41`. Every claim below was reproduced against the binary first and traced
to source second — none of it is inferred from reading the code alone.

## Documentation fixes

| Corrected | Evidence |
|---|---|
| `record_video` is **off** by default (SKILL.md + RECORDING.md said on) | `recording_tools.rs` → `bool_or("record_video", false)`; the tool's own description says "Video is off by default"; a run without the flag returns `last_video_path: null` and writes no mp4 |
| `cua-driver recording stop` prints a bare `Recording stopped.` | RECORDING.md showed a `(video → recording.mp4)` suffix the CLI never emits. That subcommand also cannot enable video at all — it never sends the field |
| `effect`/`escalation`/`verified` are not universal | `set_value`, `type_text_chars`, `zoom`, `bring_to_front` return bare text. Also flagged that `effect:"confirmed"` is unreachable for `click` — its own schema says a click is never driver-verifiable, so the ladder step gated on `confirmed` never fires |
| macOS **does** have an activate tool | MACOS.md said "the driver has no `activate` tool" and pointed at `osascript … to activate` — the exact focus-steal the same file forbids. `bring_to_front` is registered unconditionally. Replaced with `delivery_mode:"foreground"` for one action, `bring_to_front` to hold the foreground |
| macOS has no `screenshot` tool | Removed in #1692, yet MACOS.md's intent table listed it *first* and SKILL.md's compat section described calling it. Not in `list-tools`, not an MCP tool, not a CLI subcommand. **LINUX.md/WINDOWS.md untouched** — those platforms still register it and I did not test them |
| `get_window_state` does not validate `window_id` for the AX walk | A nonexistent id, `0`, and *another process's* window id all return the identical application-rooted tree (one app: same 248 elements for all three). Only the screenshot honours it — and it is dropped **silently** when the id doesn't match: no error, no `has_screenshot:false`, the `screenshot_*` keys are just absent |
| `launch_app`'s `windows` array is empty on a cold launch | The process exists before its window does, so the documented two-call shortcut throws on an app that wasn't already running. The idempotent second call returns it populated |
| `capture_scope` is opt-in | It binds to a *declared session*. `get_desktop_state '{}'` (no `session`) returns a full-display capture while a declared `window`-scope session in the same daemon is correctly rejected with `desktop_scope_disabled`. Omitting `session` escapes the policy rather than inheriting it |

## Documented capabilities the pack was talking people out of

- **`get_window_state` takes `query` / `max_elements` / `max_depth`**, and its
  own `_note` asks consumers to prefer `elements`. The docs instead told agents
  to dump `tree_markdown` to a file and pipe it through `jq` + `grep`.
  `query:"Seven"` collapses a 222-element Calculator tree to 2 lines with
  indices intact.
- **`click` takes `debug_image_out`** — it captures a fresh frame and marks
  exactly the coordinate it is about to use. The docs shipped a PIL snippet for
  the agent to hand-roll the same crosshair, which can disagree with the
  driver's own maths.
- **The full `escalate_session` reason enum** (the docs showed one value).
- **A macOS recipe for menu-bar-only apps.** This is the one I'd most like
  reviewed. `list_windows` is layer-0 only, so an `LSUIElement` status-item app
  returns `[]` and reads as unsupported. It isn't: the AX walk is
  application-rooted so any `window_id` reaches the status item, and
  `CGWindowListCopyWindowInfo` yields the real id for the level-25 panel, which
  captures normally. I drove such an app end to end — opened its status menu,
  picked an item, and captured the resulting transient panel mid-animation —
  with the frontmost app and the real cursor unchanged throughout.

## Behaviour findings — not changed here

These are code, not docs. I've left them out to keep the PR focused and because
I can't run your Rust test suite; happy to open separate issues, or to attempt
any of them if you'd like.

1. **`element_token` never reports staleness, contradicting its own schema.**
   The schema promises *"Returns an explicit `stale` error if the snapshot has
   been superseded"*. It doesn't — a token minted in snapshot `s0078` dispatched
   successfully after four further snapshots, because it resolves by index
   against the current cache. On a UI whose indices shifted between snapshots
   this silently actuates the wrong element, which is the failure the token
   exists to prevent.

2. **A background px click is silently promoted back to the AX rung.**
   `click.rs` (~L631-665): a background left-click carrying `window_id`,
   `count:1` and no `modifier` hit-tests the point and performs `AXPress` on
   whatever it finds, returning `path:"ax"`. This quietly defeats the documented
   ladder — rung 2 is "the AX press no-op'd, so escalate to px", and SKILL.md
   additionally *recommends* passing `window_id` alongside `x,y`. Following both
   yields another `AXPress` on the same element. Reproduced deterministically:
   the same coordinate returns `ax` bare, and `cgevent` as soon as any one of
   `modifier` / `count:2` / no-`window_id` / `delivery_mode:"foreground"` is
   added. I left the docs silent on this rather than documenting a workaround
   for what may be a bug.

3. **`get_screen_size` reports `scale_factor: 1.0` on a 2× display** —
   `{width:1512, height:982, scale_factor:1.0}` on a panel whose
   `get_desktop_state` frame is `3024x1964`. Anything computing
   `pixels = points * scale_factor` is off by 2×.

4. **`bring_to_front`'s description names a parameter that doesn't exist** — it
   says `dispatch:"foreground"`; the parameter is `delivery_mode` everywhere.

5. **CLI response encoding is inconsistent.** `click` prints JSON; an AX
   `right_click` prints prose (`Shown menu for [0] AXMenuBarItem "" (AXShowMenu).`).
   Since SKILL.md makes the CLI the *default* transport and simultaneously
   requires branching on `resp.effect` / `resp.escalation.recommended`, the
   default transport can't execute the skill's core algorithm for those tools. A
   `--json` flag on tool invocations would close it.

6. **Two undocumented recording artifacts** — `session.json` and `cursor.jsonl`
   (a ~27 Hz cursor trace, genuinely useful for demos) are written at the session
   root. Separately, an action with no `window_id` produces an evidence-less turn
   (`capture_failed` / `no_target_pid`, no PNGs).

7. **Packaging:** the shipped pack documents `set_agent_cursor_style`, which the
   0.12.6 binary has, while `main` has renamed it to `set_agent_cursor_theme`.
   Both trees carry `VERSION 0.12.6`, so `skills install --from main` would
   install docs for a tool the user's binary doesn't expose, with no warning.

## Notes

- Docs only — no code, no tests, no release entry, hence the `docs` title.
- `LINUX.md` and `WINDOWS.md` are deliberately untouched: several findings are
  macOS-specific and I only had a macOS host to verify against.
- Happy to split this per-file or per-claim if that's easier to review.
