### PR TITLE
ci: certify Cua Driver release installs

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -410,6 +410,36 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         )
         self.assertIn("} > checksums.txt", workflow)
 
+    def test_driver_release_verifies_archives_before_publish(self) -> None:
+        workflow = self.read(".github/workflows/cd-rust-cua-driver.yml")
+
+        self.assertIn("verify-release-artifacts:", workflow)
+        self.assertIn("name: release artifact contract", workflow)
+        self.assertIn("verify_cua_driver_release_archives.py", workflow)
+        self.assertIn("ref: ${{ github.workflow_sha }}", workflow)
+        self.assertIn(
+            "[build-linux, build-windows, build-macos-universal, "
+            "verify-release-artifacts]",
+            workflow,
+        )
+
+    def test_installer_compatibility_runs_current_installers_on_releases(
+        self,
+    ) -> None:
+        workflow = self.read(
+            ".github/workflows/ci-cua-driver-installer-compat.yml"
+        )
+
+        self.assertIn("pull_request:\n", workflow)
+        self.assertNotIn("pull_request:\n    paths:", workflow)
+        self.assertIn("Installer compatibility summary", workflow)
+        self.assertIn("ubuntu-latest, macos-26, windows-latest", workflow)
+        self.assertIn("repos/$GITHUB_REPOSITORY/releases?per_page=100", workflow)
+        self.assertIn("libs/cua-driver/scripts/install.sh", workflow)
+        self.assertIn("libs/cua-driver/scripts/install.ps1", workflow)
+        self.assertIn("-NoAutoStart", workflow)
+        self.assertIn('CUA_DRIVER_RS_TELEMETRY_ENABLED: "false"', workflow)
+
     def test_lume_uses_the_same_draft_finalizer(self) -> None:
         workflow = self.read(".github/workflows/cd-swift-lume.yml")
 

--- a/.github/scripts/tests/test_verify_cua_driver_release_archives.py
+++ b/.github/scripts/tests/test_verify_cua_driver_release_archives.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+import tarfile
+import zipfile
+
+import pytest
+
+from verify_cua_driver_release_archives import (
+    ArchiveContract,
+    ContractError,
+    release_contracts,
+    verify_release_archives,
+)
+
+
+VERSION = "9.8.7"
+
+
+def _write_tar(path: Path, contract: ArchiveContract) -> None:
+    with tarfile.open(path, "w:gz") as archive:
+        for name in contract.members:
+            payload = f"payload for {name}".encode()
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            info.mode = 0o755 if name in contract.executable_members else 0o644
+            archive.addfile(info, BytesIO(payload))
+
+
+def _write_zip(path: Path, contract: ArchiveContract) -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        for name in contract.members:
+            archive.writestr(name, f"payload for {name}")
+
+
+def _write_valid_release(root: Path) -> tuple[ArchiveContract, ...]:
+    contracts = release_contracts(VERSION)
+    for contract in contracts:
+        path = root / contract.filename
+        if path.name.endswith(".tar.gz"):
+            _write_tar(path, contract)
+        else:
+            _write_zip(path, contract)
+    return contracts
+
+
+def test_complete_release_archive_set_passes(tmp_path: Path) -> None:
+    contracts = _write_valid_release(tmp_path)
+
+    verified = verify_release_archives(tmp_path, VERSION)
+
+    assert len(verified) == len(contracts) == 12
+
+
+def test_missing_cursor_theme_fails_with_archive_and_member(
+    tmp_path: Path,
+) -> None:
+    contracts = _write_valid_release(tmp_path)
+    target = next(
+        contract for contract in contracts if contract.filename.endswith("darwin-universal.tar.gz")
+    )
+    missing = (
+        f"cua-driver-rs-{VERSION}-darwin-universal/CuaDriver.app/Contents/MacOS/cua-cursor-theme"
+    )
+    broken = ArchiveContract(
+        target.filename,
+        tuple(member for member in target.members if member != missing),
+        tuple(member for member in target.executable_members if member != missing),
+    )
+    _write_tar(tmp_path / target.filename, broken)
+
+    with pytest.raises(ContractError, match=rf"{target.filename} is missing {missing}"):
+        verify_release_archives(tmp_path, VERSION)
+
+
+def test_missing_archive_fails_closed(tmp_path: Path) -> None:
+    contracts = _write_valid_release(tmp_path)
+    missing = contracts[0].filename
+    (tmp_path / missing).unlink()
+
+    with pytest.raises(ContractError, match=rf"missing release archive: {missing}"):
+        verify_release_archives(tmp_path, VERSION)
+
+
+def test_non_executable_unix_binary_fails_closed(tmp_path: Path) -> None:
+    contracts = _write_valid_release(tmp_path)
+    target = next(
+        contract
+        for contract in contracts
+        if contract.filename.endswith("linux-x86_64-binary.tar.gz")
+    )
+    broken = ArchiveContract(target.filename, target.members)
+    _write_tar(tmp_path / target.filename, broken)
+
+    with pytest.raises(
+        ContractError,
+        match=rf"{target.filename} contains non-executable member cua-driver",
+    ):
+        verify_release_archives(tmp_path, VERSION)

--- a/.github/scripts/verify_cua_driver_release_archives.py
+++ b/.github/scripts/verify_cua_driver_release_archives.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Verify that Cua Driver release archives satisfy the installer contract."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+import tarfile
+import zipfile
+
+
+class ContractError(RuntimeError):
+    """Raised when a release archive is missing or malformed."""
+
+
+@dataclass(frozen=True)
+class ArchiveContract:
+    filename: str
+    members: tuple[str, ...]
+    executable_members: tuple[str, ...] = ()
+
+
+def release_contracts(version: str) -> tuple[ArchiveContract, ...]:
+    """Return every archive and member required for a driver release."""
+
+    contracts: list[ArchiveContract] = []
+
+    linux_payload = (
+        "cua-driver",
+        "cua-cursor-theme",
+        "libcua_driver_sdk.so",
+        "cua_driver_node_runtime.node",
+        "cua_driver_abi.h",
+    )
+    for arch in ("x86_64", "arm64"):
+        stage = f"cua-driver-rs-{version}-linux-{arch}"
+        contracts.extend(
+            (
+                ArchiveContract(
+                    f"{stage}.tar.gz",
+                    tuple(f"{stage}/{member}" for member in linux_payload),
+                    (
+                        f"{stage}/cua-driver",
+                        f"{stage}/cua-cursor-theme",
+                    ),
+                ),
+                ArchiveContract(
+                    f"{stage}-binary.tar.gz",
+                    linux_payload,
+                    ("cua-driver", "cua-cursor-theme"),
+                ),
+            )
+        )
+
+    windows_payload = (
+        "cua-driver.exe",
+        "cua-cursor-theme.exe",
+        "cua-driver-uia.exe",
+        "cua_driver_sdk.dll",
+        "cua_driver_node_runtime.node",
+        "cua_driver_abi.h",
+    )
+    for arch in ("x86_64", "arm64"):
+        stage = f"cua-driver-rs-{version}-windows-{arch}"
+        contracts.extend(
+            (
+                ArchiveContract(
+                    f"{stage}.zip",
+                    tuple(f"{stage}/{member}" for member in windows_payload),
+                ),
+                ArchiveContract(f"{stage}-binary.zip", windows_payload),
+            )
+        )
+
+    macos_payload = (
+        "cua-driver",
+        "cua-cursor-theme",
+        "libcua_driver_sdk.dylib",
+        "cua_driver_node_runtime.node",
+        "cua_driver_abi.h",
+        "CuaDriver.app/Contents/Info.plist",
+        "CuaDriver.app/Contents/MacOS/cua-driver",
+        "CuaDriver.app/Contents/MacOS/cua-cursor-theme",
+    )
+    for label in ("darwin-arm64", "darwin-x86_64", "darwin-universal"):
+        stage = f"cua-driver-rs-{version}-{label}"
+        contracts.append(
+            ArchiveContract(
+                f"{stage}.tar.gz",
+                tuple(f"{stage}/{member}" for member in macos_payload),
+                (
+                    f"{stage}/cua-driver",
+                    f"{stage}/cua-cursor-theme",
+                    f"{stage}/CuaDriver.app/Contents/MacOS/cua-driver",
+                    f"{stage}/CuaDriver.app/Contents/MacOS/cua-cursor-theme",
+                ),
+            )
+        )
+
+    contracts.append(
+        ArchiveContract(
+            f"cua-driver-rs-{version}-darwin-universal-binary.tar.gz",
+            (
+                "cua-driver",
+                "cua-cursor-theme",
+                "libcua_driver_sdk.dylib",
+                "cua_driver_node_runtime.node",
+                "cua_driver_abi.h",
+            ),
+            ("cua-driver", "cua-cursor-theme"),
+        )
+    )
+    return tuple(contracts)
+
+
+def _normalize_member(name: str) -> str:
+    normalized = str(PurePosixPath(name.replace("\\", "/")))
+    return normalized.removeprefix("./").rstrip("/")
+
+
+def _find_archive(root: Path, filename: str) -> Path:
+    matches = sorted(path for path in root.rglob(filename) if path.is_file())
+    if not matches:
+        raise ContractError(f"missing release archive: {filename}")
+    if len(matches) != 1:
+        rendered = ", ".join(str(path) for path in matches)
+        raise ContractError(f"duplicate release archive {filename}: {rendered}")
+    return matches[0]
+
+
+def _verify_tar(path: Path, contract: ArchiveContract) -> None:
+    with tarfile.open(path, "r:gz") as archive:
+        members = {
+            _normalize_member(member.name): member
+            for member in archive.getmembers()
+            if member.isfile()
+        }
+
+        for expected in contract.members:
+            member = members.get(expected)
+            if member is None:
+                raise ContractError(f"{path.name} is missing {expected}")
+            if member.size <= 0:
+                raise ContractError(f"{path.name} contains empty member {expected}")
+
+        for expected in contract.executable_members:
+            member = members.get(expected)
+            if member is None or member.mode & 0o111 == 0:
+                raise ContractError(f"{path.name} contains non-executable member {expected}")
+
+
+def _verify_zip(path: Path, contract: ArchiveContract) -> None:
+    with zipfile.ZipFile(path) as archive:
+        members = {
+            _normalize_member(info.filename): info
+            for info in archive.infolist()
+            if not info.is_dir()
+        }
+
+        for expected in contract.members:
+            member = members.get(expected)
+            if member is None:
+                raise ContractError(f"{path.name} is missing {expected}")
+            if member.file_size <= 0:
+                raise ContractError(f"{path.name} contains empty member {expected}")
+
+
+def verify_release_archives(root: Path, version: str) -> tuple[Path, ...]:
+    """Verify all archives for *version* below *root*."""
+
+    verified: list[Path] = []
+    for contract in release_contracts(version):
+        path = _find_archive(root, contract.filename)
+        if path.name.endswith(".tar.gz"):
+            _verify_tar(path, contract)
+        elif path.suffix == ".zip":
+            _verify_zip(path, contract)
+        else:  # pragma: no cover - contracts above define supported formats.
+            raise ContractError(f"unsupported archive format: {path}")
+        verified.append(path)
+    return tuple(verified)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--artifacts", type=Path, required=True)
+    parser.add_argument("--version", required=True)
+    args = parser.parse_args()
+
+    try:
+        verified = verify_release_archives(args.artifacts, args.version)
+    except (ContractError, tarfile.TarError, zipfile.BadZipFile) as error:
+        parser.error(str(error))
+
+    print(f"Verified {len(verified)} Cua Driver release archives:")
+    for path in verified:
+        print(f"  - {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -532,6 +532,44 @@ jobs:
           path: libs/cua-driver/rust/release/cua-driver-rs-*-darwin-*.tar.gz
           if-no-files-found: error
 
+  # Verify the exact candidate archives before a release can publish. This is
+  # intentionally separate from the build steps: artifact upload/download is
+  # part of the release boundary, and checking only the staging directories
+  # would miss an incomplete upload or archive member list.
+  verify-release-artifacts:
+    name: release artifact contract
+    needs: [build-linux, build-windows, build-macos-universal]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Keep the verifier available when maintainers recover an older
+          # immutable tag that predates this script. Candidate artifacts still
+          # come from that exact tag; the release control comes from the commit
+          # that defined this workflow run.
+          ref: ${{ github.workflow_sha }}
+
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/cua-driver-rs-v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/cua-driver-rs-v}"
+          else
+            VERSION="${{ inputs.version }}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download candidate archives
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Verify installer-facing archive contract
+        run: |
+          python3 .github/scripts/verify_cua_driver_release_archives.py \
+            --artifacts artifacts \
+            --version "${{ steps.version.outputs.version }}"
+
   # ── Release ──────────────────────────────────────────────────────────────────
   # Tag pushes build immutable candidate artifacts only. Publishing is an
   # explicit second step after the exact tag SHA passes the interactive E2E
@@ -539,7 +577,8 @@ jobs:
   # GitHub release (and therefore PyPI/npm SDK packages) public before that
   # evidence exists.
   release:
-    needs: [build-linux, build-windows, build-macos-universal]
+    needs:
+      [build-linux, build-windows, build-macos-universal, verify-release-artifacts]
     if: github.event_name == 'workflow_dispatch' && inputs.publish == true
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-cua-driver-installer-compat.yml
+++ b/.github/workflows/ci-cua-driver-installer-compat.yml
@@ -1,0 +1,170 @@
+name: "CI: Cua Driver installer compatibility"
+
+on:
+  pull_request:
+  schedule:
+    - cron: "17 9 * * 1"
+  workflow_dispatch:
+    inputs:
+      versions:
+        description: "Comma-separated released versions; blank tests the newest two"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  scope:
+    name: Resolve installer compatibility scope
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.scope.outputs.should_run }}
+      versions: ${{ steps.versions.outputs.versions }}
+    steps:
+      - name: Decide whether installer compatibility is affected
+        id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          SHOULD_RUN=true
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            CHANGED_FILES=$(gh api --paginate \
+              "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" \
+              --jq '.[].filename')
+            if ! grep -Eq \
+              '^(\.github/scripts/verify_cua_driver_release_archives\.py|\.github/scripts/tests/test_verify_cua_driver_release_archives\.py|\.github/workflows/(cd-rust-cua-driver|ci-cua-driver-installer-compat)\.yml|libs/cua-driver/scripts/(_install-common|_install-rust|install)\.sh|libs/cua-driver/scripts/install\.ps1|release-please-config\.json)$' \
+              <<< "$CHANGED_FILES"; then
+              SHOULD_RUN=false
+            fi
+          fi
+          echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve released versions
+        id: versions
+        if: steps.scope.outputs.should_run == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_VERSIONS: ${{ inputs.versions }}
+        run: |
+          if [[ -n "$INPUT_VERSIONS" ]]; then
+            VERSIONS=$(tr ', ' '\n' <<< "$INPUT_VERSIONS" |
+              sed '/^$/d' |
+              jq -Rsc 'split("\n") | map(select(length > 0)) | unique')
+          else
+            VERSIONS=$(gh api --paginate --slurp \
+              "repos/$GITHUB_REPOSITORY/releases?per_page=100" |
+              jq -c '[
+                .[][]
+                | select(.draft == false)
+                | .tag_name
+                | select(startswith("cua-driver-rs-v"))
+                | ltrimstr("cua-driver-rs-v")
+              ][0:2]')
+          fi
+
+          if [[ "$(jq 'length' <<< "$VERSIONS")" -eq 0 ]]; then
+            echo "No published Cua Driver release was found" >&2
+            exit 1
+          fi
+          while IFS= read -r version; do
+            if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Invalid released version: $version" >&2
+              exit 1
+            fi
+          done < <(jq -r '.[]' <<< "$VERSIONS")
+          echo "versions=$VERSIONS" >> "$GITHUB_OUTPUT"
+          echo "Testing released versions: $(jq -r 'join(", ")' <<< "$VERSIONS")"
+
+  install:
+    name: "${{ matrix.os }} / v${{ matrix.version }}"
+    needs: scope
+    if: needs.scope.outputs.should_run == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-26, windows-latest]
+        version: ${{ fromJSON(needs.scope.outputs.versions) }}
+    runs-on: ${{ matrix.os }}
+    env:
+      CUA_DRIVER_RS_VERSION: ${{ matrix.version }}
+      CUA_DRIVER_RS_KEEP_VERSIONS: "0"
+      CUA_DRIVER_RS_TELEMETRY_ENABLED: "false"
+      CUA_TELEMETRY_ENABLED: "false"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Linux runtime libraries
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libx11-6 libxi6 libxtst6 libxext6 libwayland-client0 libxkbcommon0
+
+      - name: Run the current macOS/Linux installer against the release
+        if: runner.os != 'Windows'
+        env:
+          CUA_DRIVER_RS_HOME: ${{ runner.temp }}/cua-driver-home
+          CUA_DRIVER_RS_INSTALL_DIR: ${{ runner.temp }}/cua-driver-bin
+          CUA_DRIVER_RS_NO_MODIFY_PATH: "1"
+        run: |
+          bash libs/cua-driver/scripts/install.sh --no-modify-path
+          INSTALLED="$CUA_DRIVER_RS_INSTALL_DIR/cua-driver"
+          test -x "$INSTALLED"
+          VERSION_OUTPUT=$("$INSTALLED" --version)
+          echo "$VERSION_OUTPUT"
+          grep -Fq "${CUA_DRIVER_RS_VERSION}" <<< "$VERSION_OUTPUT"
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            test -x /Applications/CuaDriver.app/Contents/MacOS/cua-driver
+            /usr/libexec/PlistBuddy -c Print:CFBundleIdentifier \
+              /Applications/CuaDriver.app/Contents/Info.plist |
+              grep -Fx com.trycua.driver
+          fi
+
+      - name: Run the current Windows installer against the release
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $root = Join-Path $env:RUNNER_TEMP "cua-driver-installer"
+          $env:CUA_DRIVER_RS_HOME = Join-Path $root "home"
+          $env:CUA_DRIVER_RS_INSTALL_DIR = Join-Path $root "bin"
+          & ./libs/cua-driver/scripts/install.ps1 `
+            -Release $env:CUA_DRIVER_RS_VERSION `
+            -NoAutoStart `
+            -NoPathUpdate
+          $binary = Join-Path $env:CUA_DRIVER_RS_INSTALL_DIR "cua-driver.exe"
+          if (-not (Test-Path -LiteralPath $binary)) {
+            throw "installer did not create $binary"
+          }
+          $versionOutput = & $binary --version
+          if ($LASTEXITCODE -ne 0) {
+            throw "installed binary exited with $LASTEXITCODE"
+          }
+          Write-Host $versionOutput
+          if ($versionOutput -notmatch [regex]::Escape($env:CUA_DRIVER_RS_VERSION)) {
+            throw "installed binary version does not match $env:CUA_DRIVER_RS_VERSION"
+          }
+
+  installer-compatibility:
+    name: Installer compatibility summary
+    needs: [scope, install]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report result
+        run: |
+          echo "scope:   ${{ needs.scope.result }}"
+          echo "install: ${{ needs.install.result }}"
+          echo "selected: ${{ needs.scope.outputs.should_run }}"
+          if [[ "${{ needs.scope.result }}" != "success" ]]; then
+            exit 1
+          fi
+          if [[ "${{ needs.scope.outputs.should_run }}" == "true" &&
+                "${{ needs.install.result }}" != "success" ]]; then
+            exit 1
+          fi
+          if [[ "${{ needs.scope.outputs.should_run }}" != "true" ]]; then
+            echo "Installer compatibility is unaffected by this pull request."
+          fi

--- a/.github/workflows/ci-test-scripts.yml
+++ b/.github/workflows/ci-test-scripts.yml
@@ -8,6 +8,7 @@ on:
       - ".github/release-manifest.schema.json"
       - ".github/release-backfill/**"
       - ".github/workflows/cd-rust-cua-driver.yml"
+      - ".github/workflows/ci-cua-driver-installer-compat.yml"
       - ".github/workflows/cd-swift-lume.yml"
       - ".github/workflows/release-please.yml"
       - ".github/workflows/release-bump-version.yml"


### PR DESCRIPTION
## Why

The v0.12.5/v0.12.6 regression was caused by a new installer assumption being applied to already-published archives. Package-shape checks alone cannot catch that compatibility boundary.

## What

- run the current public installers against the two newest published Cua Driver releases on Linux, macOS 26, and Windows
- run the compatibility matrix on relevant pull requests, weekly, and on manual dispatch
- expose a stable `Installer compatibility summary` check that safely skips unrelated pull requests
- verify all 12 candidate release archives and their installer-required members before publication
- fail on missing, empty, duplicate, or non-executable required payloads

## Validation

- 128 GitHub script tests passed
- 14 installer script tests passed
- actionlint v1.7.7 passed (ignoring only the existing macos-26 catalog warning and pre-existing SC2129)
- Ruff lint and format checks passed
- shell syntax and `git diff --check` passed

This would have exercised the exact current-installer/older-release combination behind #2592 before the installer change merged.