### PR TITLE
ci: enforce Cua Driver installer certification

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -430,8 +430,7 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
             ".github/workflows/ci-cua-driver-installer-compat.yml"
         )
 
-        self.assertIn("pull_request:\n", workflow)
-        self.assertNotIn("pull_request:\n    paths:", workflow)
+        self.assertIn("workflow_call:\n", workflow)
         self.assertIn("Installer compatibility summary", workflow)
         self.assertIn("ubuntu-latest, macos-26, windows-latest", workflow)
         self.assertIn("repos/$GITHUB_REPOSITORY/releases?per_page=100", workflow)
@@ -439,6 +438,18 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertIn("libs/cua-driver/scripts/install.ps1", workflow)
         self.assertIn("-NoAutoStart", workflow)
         self.assertIn('CUA_DRIVER_RS_TELEMETRY_ENABLED: "false"', workflow)
+
+        release_metadata = self.read(
+            ".github/workflows/ci-release-metadata.yml"
+        )
+        self.assertIn(
+            "uses: ./.github/workflows/ci-cua-driver-installer-compat.yml",
+            release_metadata,
+        )
+        self.assertIn(
+            "validate:\n    needs: installer-compatibility",
+            release_metadata,
+        )
 
     def test_lume_uses_the_same_draft_finalizer(self) -> None:
         workflow = self.read(".github/workflows/cd-swift-lume.yml")

--- a/.github/workflows/ci-cua-driver-installer-compat.yml
+++ b/.github/workflows/ci-cua-driver-installer-compat.yml
@@ -1,7 +1,13 @@
 name: "CI: Cua Driver installer compatibility"
 
 on:
-  pull_request:
+  workflow_call:
+    inputs:
+      versions:
+        description: "Comma-separated released versions; blank tests the newest two"
+        required: false
+        type: string
+        default: ""
   schedule:
     - cron: "17 9 * * 1"
   workflow_dispatch:

--- a/.github/workflows/ci-release-metadata.yml
+++ b/.github/workflows/ci-release-metadata.yml
@@ -10,7 +10,14 @@ permissions:
   pull-requests: read
 
 jobs:
+  installer-compatibility:
+    uses: ./.github/workflows/ci-cua-driver-installer-compat.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   validate:
+    needs: installer-compatibility
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-test-scripts.yml
+++ b/.github/workflows/ci-test-scripts.yml
@@ -9,6 +9,7 @@ on:
       - ".github/release-backfill/**"
       - ".github/workflows/cd-rust-cua-driver.yml"
       - ".github/workflows/ci-cua-driver-installer-compat.yml"
+      - ".github/workflows/ci-release-metadata.yml"
       - ".github/workflows/cd-swift-lume.yml"
       - ".github/workflows/release-please.yml"
       - ".github/workflows/release-bump-version.yml"


### PR DESCRIPTION
## Why

The installer certification added in #2605 should be merge-blocking, but adding a brand-new required status context directly to the ruleset would strand already-open pull requests that never received that check.

## What

- make the installer certification workflow reusable while retaining weekly and manual runs
- invoke it from `CI: Release metadata`
- make the existing required `validate` job depend on successful installer certification
- keep unrelated pull requests cheap through the existing scope-and-summary jobs

This gives new and updated pull requests an enforced Linux/macOS/Windows compatibility gate without changing the ruleset or invalidating existing successful `validate` checks.

## Validation

- 128 GitHub script tests passed
- actionlint v1.7.7 passed (ignoring only the existing macos-26 catalog warning)
- `git diff --check` passed