### PR TITLE
ci: fail closed on installer certification

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -450,6 +450,14 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
             "validate:\n    needs: installer-compatibility",
             release_metadata,
         )
+        self.assertIn(
+            "needs: installer-compatibility\n    if: always()",
+            release_metadata,
+        )
+        self.assertIn(
+            'if [[ "$INSTALLER_CERTIFICATION_RESULT" != "success" ]]',
+            release_metadata,
+        )
 
     def test_lume_uses_the_same_draft_finalizer(self) -> None:
         workflow = self.read(".github/workflows/cd-swift-lume.yml")

--- a/.github/workflows/ci-release-metadata.yml
+++ b/.github/workflows/ci-release-metadata.yml
@@ -18,8 +18,18 @@ jobs:
 
   validate:
     needs: installer-compatibility
+    if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: Require successful installer certification
+        env:
+          INSTALLER_CERTIFICATION_RESULT: ${{ needs.installer-compatibility.result }}
+        run: |
+          if [[ "$INSTALLER_CERTIFICATION_RESULT" != "success" ]]; then
+            echo "Installer certification result: $INSTALLER_CERTIFICATION_RESULT" >&2
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Why

GitHub can treat a dependency-skipped required job as skipped rather than failed. The required `validate` context must fail explicitly when installer certification does not succeed.

## What

- run `validate` with `if: always()` after installer certification
- fail its first step unless the reusable certification result is exactly `success`
- cover the fail-closed wiring in the release workflow tests

A failed, cancelled, or skipped Linux/macOS/Windows installer certification now produces a failed required `validate` check.

## Validation

- 128 GitHub script tests passed
- actionlint v1.7.7 passed
- `git diff --check` passed