### PR TITLE
refactor(fleet): rename workspace pool public symbols

### DIFF
--- a/libs/fleet/backend/auth/middlewares.go
+++ b/libs/fleet/backend/auth/middlewares.go
@@ -229,7 +229,7 @@ func LoadOpa() {
 	_ = flagsData()
 }
 
-// EvalPoolAdmission validates an OSGymWorkspacePool write body before it is
+// EvalPoolAdmission validates an Pool write body before it is
 // forwarded to Kubernetes.
 func EvalPoolAdmission(ctx context.Context, method string, object map[string]any) (bool, error) {
 	res, err := opaPoolAdmissionQuery.Eval(ctx, rego.EvalInput(map[string]any{

--- a/libs/fleet/backend/handlers/k8s.go
+++ b/libs/fleet/backend/handlers/k8s.go
@@ -171,7 +171,7 @@ func macosPoolNeedsAdmin(ctx context.Context, user *auth.User, r *http.Request) 
 	return !isAdmin, nil
 }
 
-// bodyRequestsMacOS reports whether an OSGymWorkspacePool CR body opts into the
+// bodyRequestsMacOS reports whether an Pool CR body opts into the
 // macOS runtime — via spec.template.runtime=macos, or (defence in depth) the
 // macOS-only runtimeClass / nodeSelector that a macOS pod carries.
 func bodyRequestsMacOS(body []byte) bool {

--- a/libs/fleet/python-sdk/examples/create_pool_and_list_tools.py
+++ b/libs/fleet/python-sdk/examples/create_pool_and_list_tools.py
@@ -20,7 +20,7 @@ narrate every step so you can follow along in the console:
   1. exchange the client_credentials for a bearer token (``TrainClient.from_key``)
   2. create the per-user namespace (``POST /api/namespaces`` — same path the SPA
      uses, so Capsule sets up tenant ownership + RBAC; pool name == namespace)
-  3. create an ``OSGymWorkspacePool`` (``cua.ai/v1``) via the ``/api/k8s``
+  3. create an ``Pool`` (``cua.ai/v1``) via the ``/api/k8s``
      kubectl-proxy — image, replicas, and a service on the chosen port. The
      pool-operator's compat shim projects it into an ``OSGymSandboxTemplate``
      (``<pool>-template``) + ``OSGymSandboxWarmPool`` pair and warms the VMs.
@@ -94,7 +94,7 @@ DEFAULT_BASE_URL = "https://run.cua.ai"
 # 'amazon-feature-gym-uv-seed-openshot-<sha>-base' — Linux, cua-driver MCP on :3000.)
 DEFAULT_IMAGE = "296062593712.dkr.ecr.us-west-2.amazonaws.com/desktop-workspace:latest"
 
-# OSGymWorkspacePool — the legacy single-object pool CR the cyclops-cs SPA
+# Pool — the legacy single-object pool CR the cyclops-cs SPA
 # creates (cua.ai/v1). The pool-operator compat shim translates it into the
 # native OSGymSandboxTemplate + OSGymSandboxWarmPool pair.
 POOL_GROUP = "cua.ai"
@@ -178,7 +178,7 @@ def create_pool(
     port: int,
     readiness_port: int,
 ) -> None:
-    """Create the OSGymWorkspacePool. Mirrors cyclops-cs api.createPool exactly."""
+    """Create the Pool. Mirrors cyclops-cs api.createPool exactly."""
     template: dict = {
         "containerDiskImage": image,
         "imagePullSecret": "ecr-credentials",

--- a/libs/fleet/python-sdk/examples/provision_windows_and_drive_with_cua_sdk.py
+++ b/libs/fleet/python-sdk/examples/provision_windows_and_drive_with_cua_sdk.py
@@ -91,7 +91,7 @@ DEFAULT_BASE_URL = "https://run.cua.ai"
 # firmware (see --firmware below).
 DEFAULT_IMAGE = "296062593712.dkr.ecr.us-west-2.amazonaws.com/cua-server-windows:latest"
 
-# OSGymWorkspacePool — the legacy single-object pool CR the cyclops-cs SPA
+# Pool — the legacy single-object pool CR the cyclops-cs SPA
 # creates (cua.ai/v1). The pool-operator compat shim translates it into the
 # native OSGymSandboxTemplate + OSGymSandboxWarmPool pair.
 POOL_GROUP = "cua.ai"
@@ -173,7 +173,7 @@ def create_pool(
     port: int,
     readiness_port: int,
 ) -> None:
-    """Create the OSGymWorkspacePool. Mirrors cyclops-cs api.createPool exactly."""
+    """Create the Pool. Mirrors cyclops-cs api.createPool exactly."""
     template: dict = {
         "containerDiskImage": image,
         "imagePullSecret": "ecr-credentials",

--- a/libs/fleet/python-sdk/examples/provision_windows_and_list_mcp_tools.py
+++ b/libs/fleet/python-sdk/examples/provision_windows_and_list_mcp_tools.py
@@ -30,7 +30,7 @@ Lifecycle (every step is narrated so you can follow along in the console):
   1. exchange the client_credentials for a bearer token (``TrainClient.from_key``)
   2. create the per-user namespace (``POST /api/namespaces`` — same path the SPA
      uses, so Capsule sets up tenant ownership + RBAC; pool name == namespace)
-  3. create an ``OSGymWorkspacePool`` (``cua.ai/v1``) via the ``/api/k8s``
+  3. create an ``Pool`` (``cua.ai/v1``) via the ``/api/k8s``
      kubectl-proxy — the Windows image, **efi firmware**, and a service on :8000.
      The pool-operator's compat shim projects it into an ``OSGymSandboxTemplate``
      + ``OSGymSandboxWarmPool`` pair and warms the VM.
@@ -87,7 +87,7 @@ DEFAULT_BASE_URL = "https://run.cua.ai"
 # image, so the pool MUST boot it with efi firmware (see --firmware below).
 DEFAULT_IMAGE = "296062593712.dkr.ecr.us-west-2.amazonaws.com/cua-server-windows:latest"
 
-# OSGymWorkspacePool — the legacy single-object pool CR the cyclops-cs SPA
+# Pool — the legacy single-object pool CR the cyclops-cs SPA
 # creates (cua.ai/v1). The pool-operator compat shim translates it into the
 # native OSGymSandboxTemplate + OSGymSandboxWarmPool pair.
 POOL_GROUP = "cua.ai"
@@ -171,7 +171,7 @@ def create_pool(
     port: int,
     readiness_port: int,
 ) -> None:
-    """Create the OSGymWorkspacePool. Mirrors cyclops-cs api.createPool exactly."""
+    """Create the Pool. Mirrors cyclops-cs api.createPool exactly."""
     template: dict = {
         "containerDiskImage": image,
         "imagePullSecret": "ecr-credentials",

--- a/libs/fleet/python-sdk/examples/sample_agent.py
+++ b/libs/fleet/python-sdk/examples/sample_agent.py
@@ -27,7 +27,7 @@ Lifecycle (every step narrated in the console):
   1. exchange the client_credentials for a bearer token (``TrainClient.from_key``)
   2. create the per-user namespace (``POST /api/namespaces`` — Capsule tenant
      RBAC; pool name == namespace)
-  3. create an ``OSGymWorkspacePool`` (``cua.ai/v1``) with **one Service per MCP
+  3. create an ``Pool`` (``cua.ai/v1``) with **one Service per MCP
      server**. The pool-operator compat shim projects it into an
      ``OSGymSandboxTemplate`` (``<pool>-template``) + ``OSGymSandboxWarmPool`` pair.
   4. wait for a warm VM, then claim a sandbox (``OSGymSandboxClaim``)
@@ -84,7 +84,7 @@ from cua_train import TrainClient
 DEFAULT_TOKEN_URL = "https://auth.cua.ai/realms/cyclops-cs/protocol/openid-connect/token"
 DEFAULT_BASE_URL = "https://run.cua.ai"
 
-# OSGymWorkspacePool — the legacy single-object pool CR the cyclops-cs SPA
+# Pool — the legacy single-object pool CR the cyclops-cs SPA
 # creates (cua.ai/v1). The pool-operator compat shim translates it into the
 # native OSGymSandboxTemplate (<pool>-template) + OSGymSandboxWarmPool pair.
 POOL_GROUP, POOL_VERSION, POOL_PLURAL = "cua.ai", "v1", "osgymworkspacepools"
@@ -259,7 +259,7 @@ class ServiceSpec:
 
 OS_NAME = "windows"
 DEFAULT_IMAGE = "296062593712.dkr.ecr.us-west-2.amazonaws.com/cua-server-windows:latest"
-# KubeVirt VM firmware (OSGymWorkspacePool template field; CRD enum [bios, efi]).
+# KubeVirt VM firmware (Pool template field; CRD enum [bios, efi]).
 #   efi  — GPT/UEFI-only guest images (the dockur-built Windows desktop-workspace);
 #          the operator also flips on Hyper-V enlightenments + clock config for it.
 #   bios — KubeVirt's default; what the Linux workspace images boot with.
@@ -595,7 +595,7 @@ def create_pool(
     poll: float,
     allow_replace: bool = True,
 ) -> None:
-    """Create the OSGymWorkspacePool with MCP and auxiliary services.
+    """Create the Pool with MCP and auxiliary services.
 
     Each service becomes a per-sandbox Service ``<sandbox>-<name>`` (port 80 ->
     targetPort). The MCP services are used by the agent; auxiliary services such

--- a/libs/fleet/rbac-e2e/testdata/osgym-pool-crd.yaml
+++ b/libs/fleet/rbac-e2e/testdata/osgym-pool-crd.yaml
@@ -1,4 +1,4 @@
-# Minimal OSGymWorkspacePool CRD — just enough for the apiserver to serve the
+# Minimal Pool CRD — just enough for the apiserver to serve the
 # resource the RBAC test targets. Schema is irrelevant to authorization (RBAC
 # keys off apiGroup/resource/verb), so this mirrors the e2e fixture
 # (nixos/tenant-rbac/osgym-pool-crd.yaml) and keeps the test self-contained.

--- a/libs/fleet/scripts/check-workspace-pool-legacy-token.sh
+++ b/libs/fleet/scripts/check-workspace-pool-legacy-token.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+allowlist="$repo_root/libs/fleet/scripts/workspace-pool-legacy-token-allowlist.txt"
+legacy_token='OSGymWorkspacePool'
+
+mapfile -t actual < <(rg -l -I -F "$legacy_token" "$repo_root" | sed "s#^$repo_root/##" | LC_ALL=C sort)
+mapfile -t allowed < <(awk -F '\t' 'NF { print $1 }' "$allowlist" | LC_ALL=C sort)
+unexpected="$(comm -23 <(printf '%s\n' "${actual[@]}") <(printf '%s\n' "${allowed[@]}"))"
+missing="$(comm -13 <(printf '%s\n' "${actual[@]}") <(printf '%s\n' "${allowed[@]}"))"
+
+if [ -n "$unexpected" ] || [ -n "$missing" ]; then
+  echo "workspace-pool legacy-token allowlist drift" >&2
+  [ -z "$unexpected" ] || printf 'unexpected:\n%s\n' "$unexpected" >&2
+  [ -z "$missing" ] || printf 'missing:\n%s\n' "$missing" >&2
+  exit 1
+fi
+
+count="$(rg -n -I -F "$legacy_token" "$repo_root" | wc -l)"
+if [ "$count" -gt 46 ]; then
+  echo "workspace-pool legacy-token budget exceeded: $count > 46" >&2
+  exit 1
+fi

--- a/libs/fleet/scripts/generate-sdk-bindings.sh
+++ b/libs/fleet/scripts/generate-sdk-bindings.sh
@@ -184,6 +184,7 @@ module CyclopsSdk
   CyclopsSdkSchema.constants(false).each do |name|
     const_set(name, CyclopsSdkSchema.const_get(name)) unless const_defined?(name, false)
   end
+  OSGymWorkspacePoolStatus = PoolStatus
 RUBY_FACADE_HEADER
   write_ruby_method_array "SCHEMA_CHECK_LOWER_METHODS" "$temporary_output/ruby-check_lower-external" "$facade_file"
   write_ruby_method_array "SCHEMA_READ_METHODS" "$temporary_output/ruby-read-external" "$facade_file"
@@ -253,6 +254,9 @@ from . import _sdk as _sdk_component
 from ._sdk import *
 
 __all__ = [*_schema_component.__all__, *_sdk_component.__all__]
+
+OSGymWorkspacePoolStatus = PoolStatus
+__all__.append("OSGymWorkspacePoolStatus")
 
 del _schema_component
 del _sdk_component

--- a/libs/fleet/scripts/test-generate-sdk-bindings.sh
+++ b/libs/fleet/scripts/test-generate-sdk-bindings.sh
@@ -370,7 +370,7 @@ grep -Fq -- "    readTypePoolSpec" "$bindings_dir/ruby/cyclops_sdk.rb" || fail "
 if grep -Fq -- "OsGym" "$ruby_sdk_source"; then
   fail "Ruby SDK retains cross-crate OsGym helper names"
 fi
-grep -Fq -- "    readTypeOSGymWorkspacePoolStatus" "$bindings_dir/ruby/cyclops_sdk.rb" || fail "Ruby facade does not delegate schema optional readers"
+grep -Fq -- "    readTypePoolStatus" "$bindings_dir/ruby/cyclops_sdk.rb" || fail "Ruby facade does not delegate schema optional readers"
 if grep -Fq -- "return 0 if @handle.nil?" "$ruby_sdk_source"; then
   fail "Ruby callback bindings lower native callbacks to an invalid zero handle"
 fi
@@ -459,5 +459,7 @@ expect_transaction_signal after-new-live TERM "$baseline_hash"
 "$generator"
 assert_tree_unchanged "$baseline_hash" "normal root replacement"
 "$generator" --check
+
+"$workspace_dir/scripts/check-workspace-pool-legacy-token.sh"
 
 printf 'generate-sdk-bindings regression checks passed.\n'

--- a/libs/fleet/scripts/workspace-pool-legacy-token-allowlist.txt
+++ b/libs/fleet/scripts/workspace-pool-legacy-token-allowlist.txt
@@ -1,0 +1,29 @@
+libs/fleet/python-sdk/examples/create_pool_and_list_tools.py	wire JSON discriminator
+libs/fleet/python-sdk/examples/provision_windows_and_drive_with_cua_sdk.py	wire JSON discriminator
+libs/fleet/python-sdk/examples/provision_windows_and_list_mcp_tools.py	wire JSON discriminator
+libs/fleet/python-sdk/examples/sample_agent.py	wire JSON discriminator
+libs/fleet/rbac-e2e/pool_rbac_test.go	CRD write fixture
+libs/fleet/rbac-e2e/testdata/osgym-pool-crd.yaml	CRD kind
+libs/fleet/scripts/check-workspace-pool-legacy-token.sh	guard pattern
+libs/fleet/scripts/test-generate-sdk-bindings.sh	wire serialization fixture
+libs/fleet/sdk-bindings/examples/kotlin/AppControlled.kt	wire response fixture
+libs/fleet/sdk-bindings/examples/ruby/app_controlled.rb	wire response fixture
+libs/fleet/sdk-bindings/examples/swift/AppControlled.swift	wire response fixture
+libs/fleet/sdk-bindings/kotlin/tests/TestAsyncClient.kt	wire response fixture
+libs/fleet/sdk-bindings/python/contract_fixture.py	wire response fixture
+libs/fleet/sdk-bindings/ruby/tests/test_async_client.rb	wire response fixture
+libs/fleet/sdk-bindings/swift/tests/TestAsyncClient.swift	wire response fixture
+libs/fleet/sdk-schema/src/legacy_pool_compat.rs	deprecated Rust aliases
+libs/fleet/sdk-schema/src/workspace_pool.rs	Kubernetes CRD kind
+libs/fleet/sdk/src/pools.rs	Kubernetes JSON discriminator
+libs/fleet/sdk/tests/claim_flow.rs	wire response fixture
+libs/fleet/sdk/tests/pool_flow.rs	wire response fixture
+libs/fleet/sdk/tests/public_api.rs	legacy import compatibility test
+libs/fleet/src/api/cyclops.ts	Kubernetes JSON discriminator and event selector
+libs/fleet/terraform-provider-fleets/cmd/generate-pool-resource/main.go	CRD inspection errors
+libs/fleet/terraform-provider-fleets/internal/client/client_test.go	wire response fixture
+libs/fleet/terraform-provider-fleets/internal/client/pools.go	Kubernetes JSON discriminator
+libs/fleet/sdk-bindings/python/cyclops_sdk/__init__.py	deprecated Python status alias
+libs/fleet/sdk-bindings/ruby/cyclops_sdk.rb	deprecated Ruby status alias
+libs/fleet/sdk-bindings/ruby/cyclops_sdk/schema.rb	deprecated Ruby schema status alias
+libs/fleet/scripts/generate-sdk-bindings.sh	generated Python/Ruby compatibility aliases

--- a/libs/fleet/sdk-bindings/go-uniffi/cyclops_sdk/cyclops_sdk.go
+++ b/libs/fleet/sdk-bindings/go-uniffi/cyclops_sdk/cyclops_sdk.go
@@ -1877,13 +1877,13 @@ func (_ FfiDestroyerHttpResponse) Destroy(value HttpResponse) {
 }
 
 // UniFFI cannot emit aliases for external record types. Generated bindings use
-// `OSGymWorkspacePoolStatus` and `OSGymSandboxClaimStatus` from cyclops_sdk_schema.
+// `PoolStatus` and `OSGymSandboxClaimStatus` from cyclops_sdk_schema.
 type Pool struct {
 	ApiVersion string
 	Kind       string
 	Metadata   ResourceMetadata
 	Spec       cyclops_sdk_schema.PoolSpec
-	Status     *cyclops_sdk_schema.OsGymWorkspacePoolStatus
+	Status     *cyclops_sdk_schema.PoolStatus
 }
 
 func (r *Pool) Destroy() {
@@ -1891,7 +1891,7 @@ func (r *Pool) Destroy() {
 	FfiDestroyerString{}.Destroy(r.Kind)
 	FfiDestroyerResourceMetadata{}.Destroy(r.Metadata)
 	cyclops_sdk_schema.FfiDestroyerPoolSpec{}.Destroy(r.Spec)
-	FfiDestroyerOptionalOsGymWorkspacePoolStatus{}.Destroy(r.Status)
+	FfiDestroyerOptionalPoolStatus{}.Destroy(r.Status)
 }
 
 type FfiConverterPool struct{}
@@ -1908,7 +1908,7 @@ func (c FfiConverterPool) Read(reader io.Reader) Pool {
 		FfiConverterStringINSTANCE.Read(reader),
 		FfiConverterResourceMetadataINSTANCE.Read(reader),
 		cyclops_sdk_schema.FfiConverterPoolSpecINSTANCE.Read(reader),
-		FfiConverterOptionalOsGymWorkspacePoolStatusINSTANCE.Read(reader),
+		FfiConverterOptionalPoolStatusINSTANCE.Read(reader),
 	}
 }
 
@@ -1925,7 +1925,7 @@ func (c FfiConverterPool) Write(writer io.Writer, value Pool) {
 	FfiConverterStringINSTANCE.Write(writer, value.Kind)
 	FfiConverterResourceMetadataINSTANCE.Write(writer, value.Metadata)
 	cyclops_sdk_schema.FfiConverterPoolSpecINSTANCE.Write(writer, value.Spec)
-	FfiConverterOptionalOsGymWorkspacePoolStatusINSTANCE.Write(writer, value.Status)
+	FfiConverterOptionalPoolStatusINSTANCE.Write(writer, value.Status)
 }
 
 type FfiDestroyerPool struct{}
@@ -2752,44 +2752,44 @@ func (_ FfiDestroyerOptionalOsGymSandboxClaimStatus) Destroy(value *cyclops_sdk_
 	}
 }
 
-type FfiConverterOptionalOsGymWorkspacePoolStatus struct{}
+type FfiConverterOptionalPoolStatus struct{}
 
-var FfiConverterOptionalOsGymWorkspacePoolStatusINSTANCE = FfiConverterOptionalOsGymWorkspacePoolStatus{}
+var FfiConverterOptionalPoolStatusINSTANCE = FfiConverterOptionalPoolStatus{}
 
-func (c FfiConverterOptionalOsGymWorkspacePoolStatus) Lift(rb RustBufferI) *cyclops_sdk_schema.OsGymWorkspacePoolStatus {
-	return LiftFromRustBuffer[*cyclops_sdk_schema.OsGymWorkspacePoolStatus](c, rb)
+func (c FfiConverterOptionalPoolStatus) Lift(rb RustBufferI) *cyclops_sdk_schema.PoolStatus {
+	return LiftFromRustBuffer[*cyclops_sdk_schema.PoolStatus](c, rb)
 }
 
-func (_ FfiConverterOptionalOsGymWorkspacePoolStatus) Read(reader io.Reader) *cyclops_sdk_schema.OsGymWorkspacePoolStatus {
+func (_ FfiConverterOptionalPoolStatus) Read(reader io.Reader) *cyclops_sdk_schema.PoolStatus {
 	if readInt8(reader) == 0 {
 		return nil
 	}
-	temp := cyclops_sdk_schema.FfiConverterOsGymWorkspacePoolStatusINSTANCE.Read(reader)
+	temp := cyclops_sdk_schema.FfiConverterPoolStatusINSTANCE.Read(reader)
 	return &temp
 }
 
-func (c FfiConverterOptionalOsGymWorkspacePoolStatus) Lower(value *cyclops_sdk_schema.OsGymWorkspacePoolStatus) C.RustBuffer {
-	return LowerIntoRustBuffer[*cyclops_sdk_schema.OsGymWorkspacePoolStatus](c, value)
+func (c FfiConverterOptionalPoolStatus) Lower(value *cyclops_sdk_schema.PoolStatus) C.RustBuffer {
+	return LowerIntoRustBuffer[*cyclops_sdk_schema.PoolStatus](c, value)
 }
 
-func (c FfiConverterOptionalOsGymWorkspacePoolStatus) LowerExternal(value *cyclops_sdk_schema.OsGymWorkspacePoolStatus) ExternalCRustBuffer {
-	return RustBufferFromC(LowerIntoRustBuffer[*cyclops_sdk_schema.OsGymWorkspacePoolStatus](c, value))
+func (c FfiConverterOptionalPoolStatus) LowerExternal(value *cyclops_sdk_schema.PoolStatus) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[*cyclops_sdk_schema.PoolStatus](c, value))
 }
 
-func (_ FfiConverterOptionalOsGymWorkspacePoolStatus) Write(writer io.Writer, value *cyclops_sdk_schema.OsGymWorkspacePoolStatus) {
+func (_ FfiConverterOptionalPoolStatus) Write(writer io.Writer, value *cyclops_sdk_schema.PoolStatus) {
 	if value == nil {
 		writeInt8(writer, 0)
 	} else {
 		writeInt8(writer, 1)
-		cyclops_sdk_schema.FfiConverterOsGymWorkspacePoolStatusINSTANCE.Write(writer, *value)
+		cyclops_sdk_schema.FfiConverterPoolStatusINSTANCE.Write(writer, *value)
 	}
 }
 
-type FfiDestroyerOptionalOsGymWorkspacePoolStatus struct{}
+type FfiDestroyerOptionalPoolStatus struct{}
 
-func (_ FfiDestroyerOptionalOsGymWorkspacePoolStatus) Destroy(value *cyclops_sdk_schema.OsGymWorkspacePoolStatus) {
+func (_ FfiDestroyerOptionalPoolStatus) Destroy(value *cyclops_sdk_schema.PoolStatus) {
 	if value != nil {
-		cyclops_sdk_schema.FfiDestroyerOsGymWorkspacePoolStatus{}.Destroy(*value)
+		cyclops_sdk_schema.FfiDestroyerPoolStatus{}.Destroy(*value)
 	}
 }
 

--- a/libs/fleet/sdk-bindings/go-uniffi/cyclops_sdk_schema/cyclops_sdk_schema.go
+++ b/libs/fleet/sdk-bindings/go-uniffi/cyclops_sdk_schema/cyclops_sdk_schema.go
@@ -1189,30 +1189,30 @@ func (_ FfiDestroyerOsGymSandboxWarmPoolStatus) Destroy(value OsGymSandboxWarmPo
 	value.Destroy()
 }
 
-type OsGymWorkspacePoolStatus struct {
+type PoolStatus struct {
 	Phase          *string
 	TotalCount     *uint32
 	AvailableCount *uint32
 	ClaimedCount   *uint32
 }
 
-func (r *OsGymWorkspacePoolStatus) Destroy() {
+func (r *PoolStatus) Destroy() {
 	FfiDestroyerOptionalString{}.Destroy(r.Phase)
 	FfiDestroyerOptionalUint32{}.Destroy(r.TotalCount)
 	FfiDestroyerOptionalUint32{}.Destroy(r.AvailableCount)
 	FfiDestroyerOptionalUint32{}.Destroy(r.ClaimedCount)
 }
 
-type FfiConverterOsGymWorkspacePoolStatus struct{}
+type FfiConverterPoolStatus struct{}
 
-var FfiConverterOsGymWorkspacePoolStatusINSTANCE = FfiConverterOsGymWorkspacePoolStatus{}
+var FfiConverterPoolStatusINSTANCE = FfiConverterPoolStatus{}
 
-func (c FfiConverterOsGymWorkspacePoolStatus) Lift(rb RustBufferI) OsGymWorkspacePoolStatus {
-	return LiftFromRustBuffer[OsGymWorkspacePoolStatus](c, rb)
+func (c FfiConverterPoolStatus) Lift(rb RustBufferI) PoolStatus {
+	return LiftFromRustBuffer[PoolStatus](c, rb)
 }
 
-func (c FfiConverterOsGymWorkspacePoolStatus) Read(reader io.Reader) OsGymWorkspacePoolStatus {
-	return OsGymWorkspacePoolStatus{
+func (c FfiConverterPoolStatus) Read(reader io.Reader) PoolStatus {
+	return PoolStatus{
 		FfiConverterOptionalStringINSTANCE.Read(reader),
 		FfiConverterOptionalUint32INSTANCE.Read(reader),
 		FfiConverterOptionalUint32INSTANCE.Read(reader),
@@ -1220,24 +1220,24 @@ func (c FfiConverterOsGymWorkspacePoolStatus) Read(reader io.Reader) OsGymWorksp
 	}
 }
 
-func (c FfiConverterOsGymWorkspacePoolStatus) Lower(value OsGymWorkspacePoolStatus) C.RustBuffer {
-	return LowerIntoRustBuffer[OsGymWorkspacePoolStatus](c, value)
+func (c FfiConverterPoolStatus) Lower(value PoolStatus) C.RustBuffer {
+	return LowerIntoRustBuffer[PoolStatus](c, value)
 }
 
-func (c FfiConverterOsGymWorkspacePoolStatus) LowerExternal(value OsGymWorkspacePoolStatus) ExternalCRustBuffer {
-	return RustBufferFromC(LowerIntoRustBuffer[OsGymWorkspacePoolStatus](c, value))
+func (c FfiConverterPoolStatus) LowerExternal(value PoolStatus) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[PoolStatus](c, value))
 }
 
-func (c FfiConverterOsGymWorkspacePoolStatus) Write(writer io.Writer, value OsGymWorkspacePoolStatus) {
+func (c FfiConverterPoolStatus) Write(writer io.Writer, value PoolStatus) {
 	FfiConverterOptionalStringINSTANCE.Write(writer, value.Phase)
 	FfiConverterOptionalUint32INSTANCE.Write(writer, value.TotalCount)
 	FfiConverterOptionalUint32INSTANCE.Write(writer, value.AvailableCount)
 	FfiConverterOptionalUint32INSTANCE.Write(writer, value.ClaimedCount)
 }
 
-type FfiDestroyerOsGymWorkspacePoolStatus struct{}
+type FfiDestroyerPoolStatus struct{}
 
-func (_ FfiDestroyerOsGymWorkspacePoolStatus) Destroy(value OsGymWorkspacePoolStatus) {
+func (_ FfiDestroyerPoolStatus) Destroy(value PoolStatus) {
 	value.Destroy()
 }
 
@@ -2866,3 +2866,6 @@ func (_ FfiDestroyerMapStringString) Destroy(mapValue map[string]string) {
 		FfiDestroyerString{}.Destroy(value)
 	}
 }
+
+// Deprecated: use PoolStatus.
+type OsGymWorkspacePoolStatus = PoolStatus

--- a/libs/fleet/sdk-bindings/kotlin/ai/cua/cyclops/sdk/cyclops_sdk.kt
+++ b/libs/fleet/sdk-bindings/kotlin/ai/cua/cyclops/sdk/cyclops_sdk.kt
@@ -33,10 +33,10 @@ import java.util.concurrent.ConcurrentHashMap
 import ai.cua.cyclops.sdk.schema.ClaimSpec
 import ai.cua.cyclops.sdk.schema.FfiConverterTypeClaimSpec
 import ai.cua.cyclops.sdk.schema.FfiConverterTypeOSGymSandboxClaimStatus
-import ai.cua.cyclops.sdk.schema.FfiConverterTypeOSGymWorkspacePoolStatus
+import ai.cua.cyclops.sdk.schema.FfiConverterTypePoolStatus
 import ai.cua.cyclops.sdk.schema.FfiConverterTypePoolSpec
 import ai.cua.cyclops.sdk.schema.OsGymSandboxClaimStatus
-import ai.cua.cyclops.sdk.schema.OsGymWorkspacePoolStatus
+import ai.cua.cyclops.sdk.schema.PoolStatus
 import ai.cua.cyclops.sdk.schema.PoolSpec
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.resume
@@ -48,7 +48,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import ai.cua.cyclops.sdk.schema.RustBuffer as RustBufferClaimSpec
 import ai.cua.cyclops.sdk.schema.RustBuffer as RustBufferOSGymSandboxClaimStatus
-import ai.cua.cyclops.sdk.schema.RustBuffer as RustBufferOSGymWorkspacePoolStatus
+import ai.cua.cyclops.sdk.schema.RustBuffer as RustBufferPoolStatus
 import ai.cua.cyclops.sdk.schema.RustBuffer as RustBufferPoolSpec
 
 // This is a helper for safely working with byte buffers returned from the Rust code.
@@ -3313,7 +3313,7 @@ public object FfiConverterTypeHttpResponse: FfiConverterRustBuffer<HttpResponse>
 
 /**
  * UniFFI cannot emit aliases for external record types. Generated bindings use
- * `OSGymWorkspacePoolStatus` and `OSGymSandboxClaimStatus` from cyclops_sdk_schema.
+ * `PoolStatus` and `OSGymSandboxClaimStatus` from cyclops_sdk_schema.
  */
 data class Pool (
     var `apiVersion`: kotlin.String
@@ -3324,7 +3324,7 @@ data class Pool (
     ,
     var `spec`: PoolSpec
     ,
-    var `status`: OsGymWorkspacePoolStatus?
+    var `status`: PoolStatus?
 
 ){
 
@@ -3345,7 +3345,7 @@ public object FfiConverterTypePool: FfiConverterRustBuffer<Pool> {
             FfiConverterString.read(buf),
             FfiConverterTypeResourceMetadata.read(buf),
             FfiConverterTypePoolSpec.read(buf),
-            FfiConverterOptionalTypeOSGymWorkspacePoolStatus.read(buf),
+            FfiConverterOptionalTypePoolStatus.read(buf),
         )
     }
 
@@ -3354,7 +3354,7 @@ public object FfiConverterTypePool: FfiConverterRustBuffer<Pool> {
             FfiConverterString.allocationSize(value.`kind`) +
             FfiConverterTypeResourceMetadata.allocationSize(value.`metadata`) +
             FfiConverterTypePoolSpec.allocationSize(value.`spec`) +
-            FfiConverterOptionalTypeOSGymWorkspacePoolStatus.allocationSize(value.`status`)
+            FfiConverterOptionalTypePoolStatus.allocationSize(value.`status`)
     )
 
     override fun write(value: Pool, buf: ByteBuffer) {
@@ -3362,7 +3362,7 @@ public object FfiConverterTypePool: FfiConverterRustBuffer<Pool> {
             FfiConverterString.write(value.`kind`, buf)
             FfiConverterTypeResourceMetadata.write(value.`metadata`, buf)
             FfiConverterTypePoolSpec.write(value.`spec`, buf)
-            FfiConverterOptionalTypeOSGymWorkspacePoolStatus.write(value.`status`, buf)
+            FfiConverterOptionalTypePoolStatus.write(value.`status`, buf)
     }
 }
 
@@ -3958,28 +3958,28 @@ public object FfiConverterOptionalTypeOSGymSandboxClaimStatus: FfiConverterRustB
 /**
  * @suppress
  */
-public object FfiConverterOptionalTypeOSGymWorkspacePoolStatus: FfiConverterRustBuffer<OsGymWorkspacePoolStatus?> {
-    override fun read(buf: ByteBuffer): OsGymWorkspacePoolStatus? {
+public object FfiConverterOptionalTypePoolStatus: FfiConverterRustBuffer<PoolStatus?> {
+    override fun read(buf: ByteBuffer): PoolStatus? {
         if (buf.get().toInt() == 0) {
             return null
         }
-        return FfiConverterTypeOSGymWorkspacePoolStatus.read(buf)
+        return FfiConverterTypePoolStatus.read(buf)
     }
 
-    override fun allocationSize(value: OsGymWorkspacePoolStatus?): ULong {
+    override fun allocationSize(value: PoolStatus?): ULong {
         if (value == null) {
             return 1UL
         } else {
-            return 1UL + FfiConverterTypeOSGymWorkspacePoolStatus.allocationSize(value)
+            return 1UL + FfiConverterTypePoolStatus.allocationSize(value)
         }
     }
 
-    override fun write(value: OsGymWorkspacePoolStatus?, buf: ByteBuffer) {
+    override fun write(value: PoolStatus?, buf: ByteBuffer) {
         if (value == null) {
             buf.put(0)
         } else {
             buf.put(1)
-            FfiConverterTypeOSGymWorkspacePoolStatus.write(value, buf)
+            FfiConverterTypePoolStatus.write(value, buf)
         }
     }
 }

--- a/libs/fleet/sdk-bindings/kotlin/ai/cua/cyclops/sdk/schema/PoolCompatibility.kt
+++ b/libs/fleet/sdk-bindings/kotlin/ai/cua/cyclops/sdk/schema/PoolCompatibility.kt
@@ -1,0 +1,4 @@
+package ai.cua.cyclops.sdk.schema
+
+@Deprecated("Use PoolStatus")
+typealias OsGymWorkspacePoolStatus = PoolStatus

--- a/libs/fleet/sdk-bindings/kotlin/ai/cua/cyclops/sdk/schema/cyclops_sdk_schema.kt
+++ b/libs/fleet/sdk-bindings/kotlin/ai/cua/cyclops/sdk/schema/cyclops_sdk_schema.kt
@@ -1826,7 +1826,7 @@ public object FfiConverterTypeOSGymSandboxWarmPoolStatus: FfiConverterRustBuffer
 
 
 
-data class OsGymWorkspacePoolStatus (
+data class PoolStatus (
     var `phase`: kotlin.String?
     ,
     var `totalCount`: kotlin.UInt?
@@ -1847,9 +1847,9 @@ data class OsGymWorkspacePoolStatus (
 /**
  * @suppress
  */
-public object FfiConverterTypeOSGymWorkspacePoolStatus: FfiConverterRustBuffer<OsGymWorkspacePoolStatus> {
-    override fun read(buf: ByteBuffer): OsGymWorkspacePoolStatus {
-        return OsGymWorkspacePoolStatus(
+public object FfiConverterTypePoolStatus: FfiConverterRustBuffer<PoolStatus> {
+    override fun read(buf: ByteBuffer): PoolStatus {
+        return PoolStatus(
             FfiConverterOptionalString.read(buf),
             FfiConverterOptionalUInt.read(buf),
             FfiConverterOptionalUInt.read(buf),
@@ -1857,14 +1857,14 @@ public object FfiConverterTypeOSGymWorkspacePoolStatus: FfiConverterRustBuffer<O
         )
     }
 
-    override fun allocationSize(value: OsGymWorkspacePoolStatus) = (
+    override fun allocationSize(value: PoolStatus) = (
             FfiConverterOptionalString.allocationSize(value.`phase`) +
             FfiConverterOptionalUInt.allocationSize(value.`totalCount`) +
             FfiConverterOptionalUInt.allocationSize(value.`availableCount`) +
             FfiConverterOptionalUInt.allocationSize(value.`claimedCount`)
     )
 
-    override fun write(value: OsGymWorkspacePoolStatus, buf: ByteBuffer) {
+    override fun write(value: PoolStatus, buf: ByteBuffer) {
             FfiConverterOptionalString.write(value.`phase`, buf)
             FfiConverterOptionalUInt.write(value.`totalCount`, buf)
             FfiConverterOptionalUInt.write(value.`availableCount`, buf)

--- a/libs/fleet/sdk-bindings/python/cyclops_sdk/__init__.py
+++ b/libs/fleet/sdk-bindings/python/cyclops_sdk/__init__.py
@@ -2,13 +2,16 @@ from . import _schema as _schema_component
 from ._schema import *
 _UniffiFfiConverterTypeClaimSpec = _schema_component._UniffiFfiConverterTypeClaimSpec
 _UniffiFfiConverterTypeOSGymSandboxClaimStatus = _schema_component._UniffiFfiConverterTypeOSGymSandboxClaimStatus
-_UniffiFfiConverterTypeOSGymWorkspacePoolStatus = _schema_component._UniffiFfiConverterTypeOSGymWorkspacePoolStatus
+_UniffiFfiConverterTypePoolStatus = _schema_component._UniffiFfiConverterTypePoolStatus
 _UniffiFfiConverterTypePoolSpec = _schema_component._UniffiFfiConverterTypePoolSpec
 
 from . import _sdk as _sdk_component
 from ._sdk import *
 
 __all__ = [*_schema_component.__all__, *_sdk_component.__all__]
+
+OSGymWorkspacePoolStatus = PoolStatus
+__all__.append("OSGymWorkspacePoolStatus")
 
 del _schema_component
 del _sdk_component

--- a/libs/fleet/sdk-bindings/python/cyclops_sdk/_schema.py
+++ b/libs/fleet/sdk-bindings/python/cyclops_sdk/_schema.py
@@ -2405,7 +2405,7 @@ class _UniffiFfiConverterTypeOSGymSandboxWarmPoolStatus(_UniffiConverterRustBuff
         _UniffiFfiConverterOptionalString.write(value.selector, buf)
 
 @dataclass
-class OsGymWorkspacePoolStatus:
+class PoolStatus:
     def __init__(self, *, phase:typing.Optional[str], total_count:typing.Optional[int], available_count:typing.Optional[int], claimed_count:typing.Optional[int]):
         self.phase = phase
         self.total_count = total_count
@@ -2416,7 +2416,7 @@ class OsGymWorkspacePoolStatus:
 
 
     def __str__(self):
-        return "OsGymWorkspacePoolStatus(phase={}, total_count={}, available_count={}, claimed_count={})".format(self.phase, self.total_count, self.available_count, self.claimed_count)
+        return "PoolStatus(phase={}, total_count={}, available_count={}, claimed_count={})".format(self.phase, self.total_count, self.available_count, self.claimed_count)
     def __eq__(self, other):
         if self.phase != other.phase:
             return False
@@ -2428,10 +2428,10 @@ class OsGymWorkspacePoolStatus:
             return False
         return True
 
-class _UniffiFfiConverterTypeOSGymWorkspacePoolStatus(_UniffiConverterRustBuffer):
+class _UniffiFfiConverterTypePoolStatus(_UniffiConverterRustBuffer):
     @staticmethod
     def read(buf):
-        return OsGymWorkspacePoolStatus(
+        return PoolStatus(
             phase=_UniffiFfiConverterOptionalString.read(buf),
             total_count=_UniffiFfiConverterOptionalUInt32.read(buf),
             available_count=_UniffiFfiConverterOptionalUInt32.read(buf),
@@ -2737,7 +2737,7 @@ __all__ = [
     "WarmPoolAutoscaling",
     "OsGymSandboxWarmPoolSpec",
     "OsGymSandboxWarmPoolStatus",
-    "OsGymWorkspacePoolStatus",
+    "PoolStatus",
     "PoolTemplate",
     "PoolSpec",
     "PreservedJson",

--- a/libs/fleet/sdk-bindings/python/cyclops_sdk/_sdk.py
+++ b/libs/fleet/sdk-bindings/python/cyclops_sdk/_sdk.py
@@ -1365,11 +1365,11 @@ class _UniffiFfiConverterTypeClaim(_UniffiConverterRustBuffer):
 
 
 
-class _UniffiFfiConverterOptionalTypeOSGymWorkspacePoolStatus(_UniffiConverterRustBuffer):
+class _UniffiFfiConverterOptionalTypePoolStatus(_UniffiConverterRustBuffer):
     @classmethod
     def check_lower(cls, value):
         if value is not None:
-            cyclops_sdk._UniffiFfiConverterTypeOSGymWorkspacePoolStatus.check_lower(value)
+            cyclops_sdk._UniffiFfiConverterTypePoolStatus.check_lower(value)
 
     @classmethod
     def write(cls, value, buf):
@@ -1378,7 +1378,7 @@ class _UniffiFfiConverterOptionalTypeOSGymWorkspacePoolStatus(_UniffiConverterRu
             return
 
         buf.write_u8(1)
-        cyclops_sdk._UniffiFfiConverterTypeOSGymWorkspacePoolStatus.write(value, buf)
+        cyclops_sdk._UniffiFfiConverterTypePoolStatus.write(value, buf)
 
     @classmethod
     def read(cls, buf):
@@ -1386,7 +1386,7 @@ class _UniffiFfiConverterOptionalTypeOSGymWorkspacePoolStatus(_UniffiConverterRu
         if flag == 0:
             return None
         elif flag == 1:
-            return cyclops_sdk._UniffiFfiConverterTypeOSGymWorkspacePoolStatus.read(buf)
+            return cyclops_sdk._UniffiFfiConverterTypePoolStatus.read(buf)
         else:
             raise InternalError("Unexpected flag byte for optional type")
 
@@ -1394,9 +1394,9 @@ class _UniffiFfiConverterOptionalTypeOSGymWorkspacePoolStatus(_UniffiConverterRu
 class Pool:
     """
     UniFFI cannot emit aliases for external record types. Generated bindings use
-    `OSGymWorkspacePoolStatus` and `OSGymSandboxClaimStatus` from cyclops_sdk_schema.
+    `PoolStatus` and `OSGymSandboxClaimStatus` from cyclops_sdk_schema.
 """
-    def __init__(self, *, api_version:str, kind:str, metadata:ResourceMetadata, spec:cyclops_sdk.PoolSpec, status:typing.Optional[cyclops_sdk.OsGymWorkspacePoolStatus]):
+    def __init__(self, *, api_version:str, kind:str, metadata:ResourceMetadata, spec:cyclops_sdk.PoolSpec, status:typing.Optional[cyclops_sdk.PoolStatus]):
         self.api_version = api_version
         self.kind = kind
         self.metadata = metadata
@@ -1429,7 +1429,7 @@ class _UniffiFfiConverterTypePool(_UniffiConverterRustBuffer):
             kind=_UniffiFfiConverterString.read(buf),
             metadata=_UniffiFfiConverterTypeResourceMetadata.read(buf),
             spec=cyclops_sdk._UniffiFfiConverterTypePoolSpec.read(buf),
-            status=_UniffiFfiConverterOptionalTypeOSGymWorkspacePoolStatus.read(buf),
+            status=_UniffiFfiConverterOptionalTypePoolStatus.read(buf),
         )
 
     @staticmethod
@@ -1438,7 +1438,7 @@ class _UniffiFfiConverterTypePool(_UniffiConverterRustBuffer):
         _UniffiFfiConverterString.check_lower(value.kind)
         _UniffiFfiConverterTypeResourceMetadata.check_lower(value.metadata)
         cyclops_sdk._UniffiFfiConverterTypePoolSpec.check_lower(value.spec)
-        _UniffiFfiConverterOptionalTypeOSGymWorkspacePoolStatus.check_lower(value.status)
+        _UniffiFfiConverterOptionalTypePoolStatus.check_lower(value.status)
 
     @staticmethod
     def write(value, buf):
@@ -1446,7 +1446,7 @@ class _UniffiFfiConverterTypePool(_UniffiConverterRustBuffer):
         _UniffiFfiConverterString.write(value.kind, buf)
         _UniffiFfiConverterTypeResourceMetadata.write(value.metadata, buf)
         cyclops_sdk._UniffiFfiConverterTypePoolSpec.write(value.spec, buf)
-        _UniffiFfiConverterOptionalTypeOSGymWorkspacePoolStatus.write(value.status, buf)
+        _UniffiFfiConverterOptionalTypePoolStatus.write(value.status, buf)
 
 class _UniffiFfiConverterOptionalTypeClaimSpec(_UniffiConverterRustBuffer):
     @classmethod

--- a/libs/fleet/sdk-bindings/ruby/cyclops_sdk.rb
+++ b/libs/fleet/sdk-bindings/ruby/cyclops_sdk.rb
@@ -5,22 +5,23 @@ module CyclopsSdk
   CyclopsSdkSchema.constants(false).each do |name|
     const_set(name, CyclopsSdkSchema.const_get(name)) unless const_defined?(name, false)
   end
+  OSGymWorkspacePoolStatus = PoolStatus
   SCHEMA_CHECK_LOWER_METHODS = %i[
     check_lower_TypeClaimSpec
     check_lower_TypeOSGymSandboxClaimStatus
-    check_lower_TypeOSGymWorkspacePoolStatus
+    check_lower_TypePoolStatus
     check_lower_TypePoolSpec
   ].freeze
   SCHEMA_READ_METHODS = %i[
     readTypeClaimSpec
     readTypeOSGymSandboxClaimStatus
-    readTypeOSGymWorkspacePoolStatus
+    readTypePoolStatus
     readTypePoolSpec
   ].freeze
   SCHEMA_WRITE_METHODS = %i[
     write_TypeClaimSpec
     write_TypeOSGymSandboxClaimStatus
-    write_TypeOSGymWorkspacePoolStatus
+    write_TypePoolStatus
     write_TypePoolSpec
   ].freeze
 

--- a/libs/fleet/sdk-bindings/ruby/cyclops_sdk/schema.rb
+++ b/libs/fleet/sdk-bindings/ruby/cyclops_sdk/schema.rb
@@ -324,25 +324,25 @@ end
     end
   end
 
-  # The Record type OSGymWorkspacePoolStatus.
+  # The Record type PoolStatus.
 
-  def self.check_lower_TypeOSGymWorkspacePoolStatus(v)
+  def self.check_lower_TypePoolStatus(v)
     RustBuffer.check_lower_Optionalstring(v.phase)
     RustBuffer.check_lower_Optionalu32(v.total_count)
     RustBuffer.check_lower_Optionalu32(v.available_count)
     RustBuffer.check_lower_Optionalu32(v.claimed_count)
   end
 
-  def self.alloc_from_TypeOSGymWorkspacePoolStatus(v)
+  def self.alloc_from_TypePoolStatus(v)
     RustBuffer.allocWithBuilder do |builder|
-      builder.write_TypeOSGymWorkspacePoolStatus(v)
+      builder.write_TypePoolStatus(v)
       return builder.finalize
     end
   end
 
-  def consumeIntoTypeOSGymWorkspacePoolStatus
+  def consumeIntoTypePoolStatus
     consumeWithStream do |stream|
-      return stream.readTypeOSGymWorkspacePoolStatus
+      return stream.readTypePoolStatus
     end
   end
 
@@ -1238,10 +1238,10 @@ class RustBufferStream
     )
   end
 
-  # The Record type OSGymWorkspacePoolStatus.
+  # The Record type PoolStatus.
 
-  def readTypeOSGymWorkspacePoolStatus
-    OSGymWorkspacePoolStatus.new(
+  def readTypePoolStatus
+    PoolStatus.new(
       phase: readOptionalstring,
       total_count: readOptionalu32,
       available_count: readOptionalu32,
@@ -1917,9 +1917,9 @@ class RustBufferBuilder
     self.write_Optionalstring(v.selector)
   end
 
-  # The Record type OSGymWorkspacePoolStatus.
+  # The Record type PoolStatus.
 
-  def write_TypeOSGymWorkspacePoolStatus(v)
+  def write_TypePoolStatus(v)
     self.write_Optionalstring(v.phase)
     self.write_Optionalu32(v.total_count)
     self.write_Optionalu32(v.available_count)
@@ -2942,8 +2942,8 @@ class WarmPoolAutoscaling
   end
 end
 
-  # Record type OSGymWorkspacePoolStatus
-class OSGymWorkspacePoolStatus
+  # Record type PoolStatus
+class PoolStatus
   attr_reader :phase, :total_count, :available_count, :claimed_count
 
   def initialize(phase:, total_count:, available_count:, claimed_count:)
@@ -3126,3 +3126,6 @@ end
 end
 
 end
+
+  # Deprecated: use PoolStatus.
+  OSGymWorkspacePoolStatus = PoolStatus

--- a/libs/fleet/sdk-bindings/ruby/cyclops_sdk/sdk.rb
+++ b/libs/fleet/sdk-bindings/ruby/cyclops_sdk/sdk.rb
@@ -350,7 +350,7 @@ private_constant :UniffiHandleMap
 
     RustBuffer.check_lower_TypeResourceMetadata(v.metadata)
     RustBuffer.check_lower_TypePoolSpec(v.spec)
-    RustBuffer.check_lower_OptionalTypeOSGymWorkspacePoolStatus(v.status)
+    RustBuffer.check_lower_OptionalTypePoolStatus(v.status)
   end
 
   def self.alloc_from_TypePool(v)
@@ -478,24 +478,24 @@ private_constant :UniffiHandleMap
     end
   end
 
-  # The Optional<T> type for TypeOSGymWorkspacePoolStatus.
+  # The Optional<T> type for TypePoolStatus.
 
-  def self.check_lower_OptionalTypeOSGymWorkspacePoolStatus(v)
+  def self.check_lower_OptionalTypePoolStatus(v)
     if not v.nil?
-      RustBuffer.check_lower_TypeOSGymWorkspacePoolStatus(v)
+      RustBuffer.check_lower_TypePoolStatus(v)
     end
   end
 
-  def self.alloc_from_OptionalTypeOSGymWorkspacePoolStatus(v)
+  def self.alloc_from_OptionalTypePoolStatus(v)
     RustBuffer.allocWithBuilder do |builder|
-      builder.write_OptionalTypeOSGymWorkspacePoolStatus(v)
+      builder.write_OptionalTypePoolStatus(v)
       return builder.finalize()
     end
   end
 
-  def consumeIntoOptionalTypeOSGymWorkspacePoolStatus
+  def consumeIntoOptionalTypePoolStatus
     consumeWithStream do |stream|
-      return stream.readOptionalTypeOSGymWorkspacePoolStatus
+      return stream.readOptionalTypePoolStatus
     end
   end
 
@@ -829,7 +829,7 @@ class RustBufferStream
       kind: readString,
       metadata: readTypeResourceMetadata,
       spec: readTypePoolSpec,
-      status: readOptionalTypeOSGymWorkspacePoolStatus
+      status: readOptionalTypePoolStatus
     )
   end
 
@@ -1002,17 +1002,17 @@ class RustBufferStream
     end
   end
 
-  # The Optional<T> type for TypeOSGymWorkspacePoolStatus.
+  # The Optional<T> type for TypePoolStatus.
 
-  def readOptionalTypeOSGymWorkspacePoolStatus
+  def readOptionalTypePoolStatus
     flag = unpack_from 1, 'c'
 
     if flag == 0
       return nil
     elsif flag == 1
-      return readTypeOSGymWorkspacePoolStatus
+      return readTypePoolStatus
     else
-      raise InternalError, 'Unexpected flag byte for OptionalTypeOSGymWorkspacePoolStatus'
+      raise InternalError, 'Unexpected flag byte for OptionalTypePoolStatus'
     end
   end
 
@@ -1289,7 +1289,7 @@ class RustBufferBuilder
     self.write_String(v.kind)
     self.write_TypeResourceMetadata(v.metadata)
     self.write_TypePoolSpec(v.spec)
-    self.write_OptionalTypeOSGymWorkspacePoolStatus(v.status)
+    self.write_OptionalTypePoolStatus(v.status)
   end
 
   # The Record type ResourceMetadata.
@@ -1348,14 +1348,14 @@ class RustBufferBuilder
     end
   end
 
-  # The Optional<T> type for TypeOSGymWorkspacePoolStatus.
+  # The Optional<T> type for TypePoolStatus.
 
-  def write_OptionalTypeOSGymWorkspacePoolStatus(v)
+  def write_OptionalTypePoolStatus(v)
     if v.nil?
       pack_into(1, 'c', 0)
     else
       pack_into(1, 'c', 1)
-      self.write_TypeOSGymWorkspacePoolStatus(v)
+      self.write_TypePoolStatus(v)
     end
   end
 

--- a/libs/fleet/sdk-bindings/swift/CyclopsSdk.swift
+++ b/libs/fleet/sdk-bindings/swift/CyclopsSdk.swift
@@ -1940,18 +1940,18 @@ public func FfiConverterTypeHttpResponse_lower(_ value: HttpResponse) -> RustBuf
 
 /**
  * UniFFI cannot emit aliases for external record types. Generated bindings use
- * `OSGymWorkspacePoolStatus` and `OSGymSandboxClaimStatus` from cyclops_sdk_schema.
+ * `PoolStatus` and `OSGymSandboxClaimStatus` from cyclops_sdk_schema.
  */
 public struct Pool: Equatable, Hashable {
     public var apiVersion: String
     public var kind: String
     public var metadata: ResourceMetadata
     public var spec: PoolSpec
-    public var status: OsGymWorkspacePoolStatus?
+    public var status: PoolStatus?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(apiVersion: String, kind: String, metadata: ResourceMetadata, spec: PoolSpec, status: OsGymWorkspacePoolStatus?) {
+    public init(apiVersion: String, kind: String, metadata: ResourceMetadata, spec: PoolSpec, status: PoolStatus?) {
         self.apiVersion = apiVersion
         self.kind = kind
         self.metadata = metadata
@@ -1979,7 +1979,7 @@ public struct FfiConverterTypePool: FfiConverterRustBuffer {
                 kind: FfiConverterString.read(from: &buf),
                 metadata: FfiConverterTypeResourceMetadata.read(from: &buf),
                 spec: FfiConverterTypePoolSpec.read(from: &buf),
-                status: FfiConverterOptionTypeOSGymWorkspacePoolStatus.read(from: &buf)
+                status: FfiConverterOptionTypePoolStatus.read(from: &buf)
         )
     }
 
@@ -1988,7 +1988,7 @@ public struct FfiConverterTypePool: FfiConverterRustBuffer {
         FfiConverterString.write(value.kind, into: &buf)
         FfiConverterTypeResourceMetadata.write(value.metadata, into: &buf)
         FfiConverterTypePoolSpec.write(value.spec, into: &buf)
-        FfiConverterOptionTypeOSGymWorkspacePoolStatus.write(value.status, into: &buf)
+        FfiConverterOptionTypePoolStatus.write(value.status, into: &buf)
     }
 }
 
@@ -2522,8 +2522,8 @@ fileprivate struct FfiConverterOptionTypeOSGymSandboxClaimStatus: FfiConverterRu
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterOptionTypeOSGymWorkspacePoolStatus: FfiConverterRustBuffer {
-    typealias SwiftType = OsGymWorkspacePoolStatus?
+fileprivate struct FfiConverterOptionTypePoolStatus: FfiConverterRustBuffer {
+    typealias SwiftType = PoolStatus?
 
     public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
         guard let value = value else {
@@ -2531,13 +2531,13 @@ fileprivate struct FfiConverterOptionTypeOSGymWorkspacePoolStatus: FfiConverterR
             return
         }
         writeInt(&buf, Int8(1))
-        FfiConverterTypeOSGymWorkspacePoolStatus.write(value, into: &buf)
+        FfiConverterTypePoolStatus.write(value, into: &buf)
     }
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
         switch try readInt(&buf) as Int8 {
         case 0: return nil
-        case 1: return try FfiConverterTypeOSGymWorkspacePoolStatus.read(from: &buf)
+        case 1: return try FfiConverterTypePoolStatus.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }

--- a/libs/fleet/sdk-bindings/swift/CyclopsSdkSchema.swift
+++ b/libs/fleet/sdk-bindings/swift/CyclopsSdkSchema.swift
@@ -1246,7 +1246,7 @@ public func FfiConverterTypeOSGymSandboxWarmPoolStatus_lower(_ value: OsGymSandb
 }
 
 
-public struct OsGymWorkspacePoolStatus: Equatable, Hashable {
+public struct PoolStatus: Equatable, Hashable {
     public var phase: String?
     public var totalCount: UInt32?
     public var availableCount: UInt32?
@@ -1267,16 +1267,16 @@ public struct OsGymWorkspacePoolStatus: Equatable, Hashable {
 }
 
 #if compiler(>=6)
-extension OsGymWorkspacePoolStatus: Sendable {}
+extension PoolStatus: Sendable {}
 #endif
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-public struct FfiConverterTypeOSGymWorkspacePoolStatus: FfiConverterRustBuffer {
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> OsGymWorkspacePoolStatus {
+public struct FfiConverterTypePoolStatus: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PoolStatus {
         return
-            try OsGymWorkspacePoolStatus(
+            try PoolStatus(
                 phase: FfiConverterOptionString.read(from: &buf),
                 totalCount: FfiConverterOptionUInt32.read(from: &buf),
                 availableCount: FfiConverterOptionUInt32.read(from: &buf),
@@ -1284,7 +1284,7 @@ public struct FfiConverterTypeOSGymWorkspacePoolStatus: FfiConverterRustBuffer {
         )
     }
 
-    public static func write(_ value: OsGymWorkspacePoolStatus, into buf: inout [UInt8]) {
+    public static func write(_ value: PoolStatus, into buf: inout [UInt8]) {
         FfiConverterOptionString.write(value.phase, into: &buf)
         FfiConverterOptionUInt32.write(value.totalCount, into: &buf)
         FfiConverterOptionUInt32.write(value.availableCount, into: &buf)
@@ -1296,15 +1296,15 @@ public struct FfiConverterTypeOSGymWorkspacePoolStatus: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-public func FfiConverterTypeOSGymWorkspacePoolStatus_lift(_ buf: RustBuffer) throws -> OsGymWorkspacePoolStatus {
-    return try FfiConverterTypeOSGymWorkspacePoolStatus.lift(buf)
+public func FfiConverterTypePoolStatus_lift(_ buf: RustBuffer) throws -> PoolStatus {
+    return try FfiConverterTypePoolStatus.lift(buf)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-public func FfiConverterTypeOSGymWorkspacePoolStatus_lower(_ value: OsGymWorkspacePoolStatus) -> RustBuffer {
-    return FfiConverterTypeOSGymWorkspacePoolStatus.lower(value)
+public func FfiConverterTypePoolStatus_lower(_ value: PoolStatus) -> RustBuffer {
+    return FfiConverterTypePoolStatus.lower(value)
 }
 
 

--- a/libs/fleet/sdk-bindings/swift/PoolCompatibility.swift
+++ b/libs/fleet/sdk-bindings/swift/PoolCompatibility.swift
@@ -1,0 +1,2 @@
+@available(*, deprecated, renamed: "PoolStatus")
+public typealias OsGymWorkspacePoolStatus = PoolStatus

--- a/libs/fleet/sdk-bindings/ts-uniffi-browser/ts/cyclops_sdk.ts
+++ b/libs/fleet/sdk-bindings/ts-uniffi-browser/ts/cyclops_sdk.ts
@@ -16,7 +16,7 @@ import {
 import {
   type ClaimSpec,
   type OsGymSandboxClaimStatus,
-  type OsGymWorkspacePoolStatus,
+  type PoolStatus,
   type PoolSpec,
 } from "./cyclops_sdk_schema";
 import {
@@ -59,7 +59,7 @@ import uniffiCyclopsSdkSchemaModule from "./cyclops_sdk_schema";
 const {
   FfiConverterTypeClaimSpec,
   FfiConverterTypeOSGymSandboxClaimStatus,
-  FfiConverterTypeOSGymWorkspacePoolStatus,
+  FfiConverterTypePoolStatus,
   FfiConverterTypePoolSpec,
 } = uniffiCyclopsSdkSchemaModule.converters;
 // wasm1: wrap the wasm-bindgen namespace once so the codegen call sites can
@@ -213,14 +213,14 @@ const FfiConverterTypeClaim = (() => {
 
 /**
  * UniFFI cannot emit aliases for external record types. Generated bindings use
- * `OSGymWorkspacePoolStatus` and `OSGymSandboxClaimStatus` from cyclops_sdk_schema.
+ * `PoolStatus` and `OSGymSandboxClaimStatus` from cyclops_sdk_schema.
  */
 export type Pool = {
   apiVersion: string;
   kind: string;
   metadata: ResourceMetadata;
   spec: PoolSpec;
-  status?: OsGymWorkspacePoolStatus;
+  status?: PoolStatus;
 };
 
 /**
@@ -247,7 +247,7 @@ const FfiConverterTypePool = (() => {
         kind: FfiConverterString.read(from),
         metadata: FfiConverterTypeResourceMetadata.read(from),
         spec: FfiConverterTypePoolSpec.read(from),
-        status: FfiConverterOptionalTypeOSGymWorkspacePoolStatus.read(from),
+        status: FfiConverterOptionalTypePoolStatus.read(from),
       };
     }
     write(value: TypeName, into: RustBuffer): void {
@@ -255,7 +255,7 @@ const FfiConverterTypePool = (() => {
       FfiConverterString.write(value.kind, into);
       FfiConverterTypeResourceMetadata.write(value.metadata, into);
       FfiConverterTypePoolSpec.write(value.spec, into);
-      FfiConverterOptionalTypeOSGymWorkspacePoolStatus.write(
+      FfiConverterOptionalTypePoolStatus.write(
         value.status,
         into,
       );
@@ -266,7 +266,7 @@ const FfiConverterTypePool = (() => {
         FfiConverterString.allocationSize(value.kind) +
         FfiConverterTypeResourceMetadata.allocationSize(value.metadata) +
         FfiConverterTypePoolSpec.allocationSize(value.spec) +
-        FfiConverterOptionalTypeOSGymWorkspacePoolStatus.allocationSize(
+        FfiConverterOptionalTypePoolStatus.allocationSize(
           value.status,
         )
       );
@@ -2731,9 +2731,9 @@ const FfiConverterOptionalMapStringString = new FfiConverterOptional(
 const FfiConverterOptionalTypeOSGymSandboxClaimStatus =
   new FfiConverterOptional(FfiConverterTypeOSGymSandboxClaimStatus);
 
-// FfiConverter for OsGymWorkspacePoolStatus | undefined
-const FfiConverterOptionalTypeOSGymWorkspacePoolStatus =
-  new FfiConverterOptional(FfiConverterTypeOSGymWorkspacePoolStatus);
+// FfiConverter for PoolStatus | undefined
+const FfiConverterOptionalTypePoolStatus =
+  new FfiConverterOptional(FfiConverterTypePoolStatus);
 
 // FfiConverter for ClaimSpec | undefined
 const FfiConverterOptionalTypeClaimSpec = new FfiConverterOptional(

--- a/libs/fleet/sdk-bindings/ts-uniffi-browser/ts/cyclops_sdk_schema.ts
+++ b/libs/fleet/sdk-bindings/ts-uniffi-browser/ts/cyclops_sdk_schema.ts
@@ -1211,7 +1211,7 @@ const FfiConverterTypeOSGymSandboxWarmPoolStatus = (() => {
   return new FFIConverter();
 })();
 
-export type OsGymWorkspacePoolStatus = {
+export type PoolStatus = {
   phase?: string;
   totalCount?: number;
   availableCount?: number;
@@ -1219,13 +1219,13 @@ export type OsGymWorkspacePoolStatus = {
 };
 
 /**
- * Generated factory for {@link OsGymWorkspacePoolStatus} record objects.
+ * Generated factory for {@link PoolStatus} record objects.
  */
-export const OsGymWorkspacePoolStatus = (() => {
+export const PoolStatus = (() => {
   const defaults = () => ({});
   const create = (() => {
     return uniffiCreateRecord<
-      OsGymWorkspacePoolStatus,
+      PoolStatus,
       ReturnType<typeof defaults>
     >(defaults);
   })();
@@ -1233,12 +1233,12 @@ export const OsGymWorkspacePoolStatus = (() => {
     create,
     new: create,
     defaults: () =>
-      Object.freeze(defaults()) as Partial<OsGymWorkspacePoolStatus>,
+      Object.freeze(defaults()) as Partial<PoolStatus>,
   });
 })();
 
-const FfiConverterTypeOSGymWorkspacePoolStatus = (() => {
-  type TypeName = OsGymWorkspacePoolStatus;
+const FfiConverterTypePoolStatus = (() => {
+  type TypeName = PoolStatus;
   class FFIConverter extends AbstractFfiConverterByteArray<TypeName> {
     read(from: RustBuffer): TypeName {
       return {
@@ -1702,7 +1702,7 @@ export default Object.freeze({
     FfiConverterTypeOSGymSandboxTemplateSpec,
     FfiConverterTypeOSGymSandboxWarmPoolSpec,
     FfiConverterTypeOSGymSandboxWarmPoolStatus,
-    FfiConverterTypeOSGymWorkspacePoolStatus,
+    FfiConverterTypePoolStatus,
     FfiConverterTypeOidcConfig,
     FfiConverterTypePoolSpec,
     FfiConverterTypePoolTemplate,
@@ -1715,3 +1715,6 @@ export default Object.freeze({
     FfiConverterTypeWarmPoolAutoscaling,
   },
 });
+
+/** @deprecated Use PoolStatus. */
+export type OsGymWorkspacePoolStatus = PoolStatus;

--- a/libs/fleet/sdk-bindings/ts-uniffi/cyclops_sdk.ts
+++ b/libs/fleet/sdk-bindings/ts-uniffi/cyclops_sdk.ts
@@ -6,12 +6,12 @@
 import nativeModule from "./cyclops_sdk-ffi";
 import { type UniffiRustFutureContinuationCallback, type UniffiForeignFutureDroppedCallback, type UniffiForeignFutureDroppedCallbackStruct, type UniffiForeignFutureResultRustBuffer, type UniffiForeignFutureCompleterustBuffer, type UniffiVTableCallbackInterfaceCyclopsSdkHttpClient,
 } from "./cyclops_sdk-ffi";
-import { type ClaimSpec, type OsGymSandboxClaimStatus, type OsGymWorkspacePoolStatus, type PoolSpec,
+import { type ClaimSpec, type OsGymSandboxClaimStatus, type PoolStatus, type PoolSpec,
 } from "./cyclops_sdk_schema";
 import { type FfiConverter, type UniffiByteArray, type UniffiGcObject, type UniffiHandle, type UniffiObjectFactory, type UniffiReferenceHolder, type UniffiRustCallStatus, AbstractFfiConverterByteArray, FfiConverterArray, FfiConverterArrayBuffer, FfiConverterInt32, FfiConverterMap, FfiConverterObject, FfiConverterObjectWithCallbacks, FfiConverterOptional, FfiConverterUInt16, FfiConverterUInt32, FfiConverterUInt64, FfiConverterUInt8, RustBuffer, UniffiAbstractObject, UniffiError, UniffiInternalError, UniffiResult, UniffiRustCaller, destructorGuardSymbol, pointerLiteralSymbol, uniffiCreateFfiConverterString, uniffiCreateRecord, uniffiRustCallAsync, uniffiTraitInterfaceCallAsyncWithError, uniffiTypeNameSymbol, variantOrdinalSymbol,
 } from "@ubjs/core";
 import uniffiCyclopsSdkSchemaModule from "./cyclops_sdk_schema";
-const { FfiConverterTypeClaimSpec, FfiConverterTypeOSGymSandboxClaimStatus, FfiConverterTypeOSGymWorkspacePoolStatus, FfiConverterTypePoolSpec } = uniffiCyclopsSdkSchemaModule.converters;
+const { FfiConverterTypeClaimSpec, FfiConverterTypeOSGymSandboxClaimStatus, FfiConverterTypePoolStatus, FfiConverterTypePoolSpec } = uniffiCyclopsSdkSchemaModule.converters;
 const uniffiCaller = new UniffiRustCaller(() => ({ code: 0 }));
 
 const uniffiIsDebug =
@@ -148,14 +148,14 @@ const FfiConverterTypeClaim = (() => {
 
 /**
  * UniFFI cannot emit aliases for external record types. Generated bindings use
- * `OSGymWorkspacePoolStatus` and `OSGymSandboxClaimStatus` from cyclops_sdk_schema.
+ * `PoolStatus` and `OSGymSandboxClaimStatus` from cyclops_sdk_schema.
  */
 export type Pool = {
     apiVersion: string,
     kind: string,
     metadata: ResourceMetadata,
     spec: PoolSpec,
-    status?: OsGymWorkspacePoolStatus
+    status?: PoolStatus
 }
 
 /**
@@ -183,7 +183,7 @@ const FfiConverterTypePool = (() => {
                 kind: FfiConverterString.read(from), 
                 metadata: FfiConverterTypeResourceMetadata.read(from), 
                 spec: FfiConverterTypePoolSpec.read(from), 
-                status: FfiConverterOptionalTypeOSGymWorkspacePoolStatus.read(from)
+                status: FfiConverterOptionalTypePoolStatus.read(from)
             };
         }
         write(value: TypeName, into: RustBuffer): void {
@@ -191,14 +191,14 @@ const FfiConverterTypePool = (() => {
             FfiConverterString.write(value.kind, into);
             FfiConverterTypeResourceMetadata.write(value.metadata, into);
             FfiConverterTypePoolSpec.write(value.spec, into);
-            FfiConverterOptionalTypeOSGymWorkspacePoolStatus.write(value.status, into);
+            FfiConverterOptionalTypePoolStatus.write(value.status, into);
         }
         allocationSize(value: TypeName): number {
             return FfiConverterString.allocationSize(value.apiVersion) +
              FfiConverterString.allocationSize(value.kind) +
              FfiConverterTypeResourceMetadata.allocationSize(value.metadata) +
              FfiConverterTypePoolSpec.allocationSize(value.spec) +
-             FfiConverterOptionalTypeOSGymWorkspacePoolStatus.allocationSize(value.status);
+             FfiConverterOptionalTypePoolStatus.allocationSize(value.status);
             
         }
     };
@@ -2016,8 +2016,8 @@ const FfiConverterOptionalMapStringString = new FfiConverterOptional(FfiConverte
 // FfiConverter for OsGymSandboxClaimStatus | undefined
 const FfiConverterOptionalTypeOSGymSandboxClaimStatus = new FfiConverterOptional(FfiConverterTypeOSGymSandboxClaimStatus);
 
-// FfiConverter for OsGymWorkspacePoolStatus | undefined
-const FfiConverterOptionalTypeOSGymWorkspacePoolStatus = new FfiConverterOptional(FfiConverterTypeOSGymWorkspacePoolStatus);
+// FfiConverter for PoolStatus | undefined
+const FfiConverterOptionalTypePoolStatus = new FfiConverterOptional(FfiConverterTypePoolStatus);
 
 // FfiConverter for ClaimSpec | undefined
 const FfiConverterOptionalTypeClaimSpec = new FfiConverterOptional(FfiConverterTypeClaimSpec);

--- a/libs/fleet/sdk-bindings/ts-uniffi/cyclops_sdk_schema.ts
+++ b/libs/fleet/sdk-bindings/ts-uniffi/cyclops_sdk_schema.ts
@@ -1057,7 +1057,7 @@ const FfiConverterTypeOSGymSandboxWarmPoolStatus = (() => {
     return new FFIConverter();
 })();
 
-export type OsGymWorkspacePoolStatus = {
+export type PoolStatus = {
     phase?: string,
     totalCount?: number,
     availableCount?: number,
@@ -1065,23 +1065,23 @@ export type OsGymWorkspacePoolStatus = {
 }
 
 /**
- * Generated factory for {@link OsGymWorkspacePoolStatus} record objects.
+ * Generated factory for {@link PoolStatus} record objects.
  */
-export const OsGymWorkspacePoolStatus = (() => {
+export const PoolStatus = (() => {
     const defaults = () => ({
     });
     const create = (() => {
-        return uniffiCreateRecord<OsGymWorkspacePoolStatus, ReturnType<typeof defaults>>(defaults);
+        return uniffiCreateRecord<PoolStatus, ReturnType<typeof defaults>>(defaults);
     })();
     return Object.freeze({
         create,
         new: create,
-        defaults: () => Object.freeze(defaults()) as Partial<OsGymWorkspacePoolStatus>,
+        defaults: () => Object.freeze(defaults()) as Partial<PoolStatus>,
     });
 })();
 
-const FfiConverterTypeOSGymWorkspacePoolStatus = (() => {
-    type TypeName = OsGymWorkspacePoolStatus;
+const FfiConverterTypePoolStatus = (() => {
+    type TypeName = PoolStatus;
     class FFIConverter extends AbstractFfiConverterByteArray<TypeName> {
         read(from: RustBuffer): TypeName {
             return {
@@ -1474,7 +1474,7 @@ export default Object.freeze({
     FfiConverterTypeOSGymSandboxTemplateSpec,
     FfiConverterTypeOSGymSandboxWarmPoolSpec,
     FfiConverterTypeOSGymSandboxWarmPoolStatus,
-    FfiConverterTypeOSGymWorkspacePoolStatus,
+    FfiConverterTypePoolStatus,
     FfiConverterTypeOidcConfig,
     FfiConverterTypePoolSpec,
     FfiConverterTypePoolTemplate,
@@ -1487,3 +1487,5 @@ export default Object.freeze({
     FfiConverterTypeWarmPoolAutoscaling,
   }
 });
+/** @deprecated Use PoolStatus. */
+export type OsGymWorkspacePoolStatus = PoolStatus;

--- a/libs/fleet/sdk-schema/src/generate.rs
+++ b/libs/fleet/sdk-schema/src/generate.rs
@@ -1,5 +1,5 @@
 use crate::{
-    OSGymSandbox, OSGymSandboxClaim, OSGymSandboxTemplate, OSGymSandboxWarmPool, OSGymWorkspacePool,
+    OSGymSandbox, OSGymSandboxClaim, OSGymSandboxTemplate, OSGymSandboxWarmPool, Pool,
 };
 use anyhow::{Context, Result, bail};
 use kube::CustomResourceExt;
@@ -13,7 +13,7 @@ pub fn render_crds() -> Result<String> {
         serde_yaml::to_string(&OSGymSandboxTemplate::crd())?,
         serde_yaml::to_string(&OSGymSandboxWarmPool::crd())?,
         serde_yaml::to_string(&OSGymSandboxClaim::crd())?,
-        serde_yaml::to_string(&OSGymWorkspacePool::crd())?,
+        serde_yaml::to_string(&Pool::crd())?,
     ];
 
     Ok(resources.join("---\n"))

--- a/libs/fleet/sdk-schema/src/legacy_pool_compat.rs
+++ b/libs/fleet/sdk-schema/src/legacy_pool_compat.rs
@@ -1,0 +1,26 @@
+use super::PoolStatus;
+
+/// Canonical Rust name for the Kubernetes workspace-pool resource.
+pub type Pool = super::workspace_pool::OSGymWorkspacePool;
+
+#[deprecated(note = "use Pool")]
+pub type OSGymWorkspacePool = Pool;
+
+#[deprecated(note = "use PoolStatus")]
+pub type OSGymWorkspacePoolStatus = PoolStatus;
+
+#[cfg(test)]
+mod tests {
+    use super::{OSGymWorkspacePool, OSGymWorkspacePoolStatus, Pool, PoolStatus};
+
+    #[allow(deprecated)]
+    #[test]
+    fn legacy_names_are_type_aliases() {
+        fn pool(_: Pool) {}
+        fn legacy_pool(_: OSGymWorkspacePool) {}
+        fn status(_: Option<PoolStatus>) {}
+        fn legacy_status(_: Option<OSGymWorkspacePoolStatus>) {}
+
+        let _ = (pool, legacy_pool, status, legacy_status);
+    }
+}

--- a/libs/fleet/sdk-schema/src/lib.rs
+++ b/libs/fleet/sdk-schema/src/lib.rs
@@ -5,6 +5,7 @@ mod json;
 mod sandbox;
 mod warmpool;
 mod workspace_pool;
+mod legacy_pool_compat;
 
 pub use claim::{
     ClaimLifecycle, ClaimSpec, OSGymSandboxClaim, OSGymSandboxClaimCondition,
@@ -22,8 +23,7 @@ pub use sandbox::{
 pub use warmpool::{
     OSGymSandboxWarmPool, OSGymSandboxWarmPoolSpec, OSGymSandboxWarmPoolStatus, WarmPoolAutoscaling,
 };
-pub use workspace_pool::{
-    OSGymWorkspacePool, OSGymWorkspacePoolStatus, PoolSpec, PoolTemplate, WorkspacePoolAutoscaling,
-};
+pub use workspace_pool::{PoolSpec, PoolStatus, PoolTemplate, WorkspacePoolAutoscaling};
+pub use legacy_pool_compat::*;
 
 uniffi::setup_scaffolding!("cyclops_sdk_schema");

--- a/libs/fleet/sdk-schema/src/workspace_pool.rs
+++ b/libs/fleet/sdk-schema/src/workspace_pool.rs
@@ -104,7 +104,7 @@ pub struct PoolTemplate {
     plural = "osgymworkspacepools",
     namespaced,
     shortname = "owsp",
-    status = "OSGymWorkspacePoolStatus",
+    status = "PoolStatus",
     printcolumn(name = "Replicas", type_ = "integer", json_path = ".spec.replicas"),
     printcolumn(
         name = "Available",
@@ -179,7 +179,7 @@ fn hash_json_value<H: Hasher>(value: &serde_json::Value, state: &mut H) {
 
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize, JsonSchema, uniffi::Record)]
 #[serde(rename_all = "camelCase")]
-pub struct OSGymWorkspacePoolStatus {
+pub struct PoolStatus {
     #[schemars(default, schema_with = "string_schema")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub phase: Option<String>,

--- a/libs/fleet/sdk/src/types.rs
+++ b/libs/fleet/sdk/src/types.rs
@@ -1,4 +1,4 @@
-use cyclops_sdk_schema::{ClaimSpec, OSGymSandboxClaimStatus, OSGymWorkspacePoolStatus, PoolSpec};
+use cyclops_sdk_schema::{ClaimSpec, OSGymSandboxClaimStatus, PoolSpec, PoolStatus};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt, sync::Arc};
 
@@ -84,7 +84,7 @@ pub struct ResourceMetadata {
 }
 
 /// UniFFI cannot emit aliases for external record types. Generated bindings use
-/// `OSGymWorkspacePoolStatus` and `OSGymSandboxClaimStatus` from cyclops_sdk_schema.
+/// `PoolStatus` and `OSGymSandboxClaimStatus` from cyclops_sdk_schema.
 #[derive(Clone, Debug, Serialize, Deserialize, uniffi::Record)]
 #[serde(rename_all = "camelCase")]
 pub struct Pool {
@@ -92,7 +92,7 @@ pub struct Pool {
     pub kind: String,
     pub metadata: ResourceMetadata,
     pub spec: PoolSpec,
-    pub status: Option<OSGymWorkspacePoolStatus>,
+    pub status: Option<PoolStatus>,
 }
 
 impl PartialEq for Pool {

--- a/libs/fleet/sdk/tests/public_api.rs
+++ b/libs/fleet/sdk/tests/public_api.rs
@@ -5,7 +5,10 @@ use cyclops_sdk::{
     CyclopsCredentials, HttpClient, HttpError, HttpHeader, HttpRequest, HttpResponse, Pool,
     ResourceMetadata, Sandbox, SdkError,
 };
-use cyclops_sdk_schema::{ClaimSpec, OSGymSandboxClaimStatus, OSGymWorkspacePoolStatus, PoolSpec};
+use cyclops_sdk_schema::{
+    ClaimSpec, OSGymSandboxClaimStatus, OSGymWorkspacePool as LegacyPool,
+    OSGymWorkspacePoolStatus as LegacyPoolStatus, Pool as SchemaPool, PoolSpec, PoolStatus,
+};
 
 struct RecordingHttpClient;
 
@@ -200,7 +203,7 @@ fn resources_use_canonical_schema_specs_and_statuses() {
     };
     assert_eq!(metadata.namespace, "default");
 
-    fn pool_status(_: Option<OSGymWorkspacePoolStatus>) {}
+    fn pool_status(_: Option<PoolStatus>) {}
     fn claim_status(_: Option<OSGymSandboxClaimStatus>) {}
 
     fn assert_pool_types(pool: Pool) {
@@ -305,4 +308,15 @@ fn status_error_body_is_lossy_and_bounded_to_4096_bytes() {
         }
         _ => panic!("expected a status error"),
     }
+}
+
+#[allow(deprecated)]
+#[test]
+fn legacy_workspace_pool_imports_remain_type_aliases() {
+    fn legacy_pool(_: LegacyPool) {}
+    let _: fn(SchemaPool) = legacy_pool;
+
+    fn canonical_status(_: Option<PoolStatus>) {}
+    let legacy_status: Option<LegacyPoolStatus> = None;
+    canonical_status(legacy_status);
 }

--- a/libs/fleet/src/api/cyclops.ts
+++ b/libs/fleet/src/api/cyclops.ts
@@ -225,7 +225,7 @@ export const api = {
   // Pool CRUD via K8s API (kubectl-proxy sidecar with impersonation).
   // The proxy adds Impersonate-User/Group headers so Capsule enforces
   // tenant RBAC — users can only operate in their own namespaces.
-  // The pool-operator watches OSGymWorkspacePool CRs and creates all
+  // The pool-operator watches Pool CRs and creates all
   // resources (orchestrator, RBAC, namespace, etc.) automatically.
   createPool: async (name: string, values: {
     cpu: number; ram: string; ociImage: string; replicas: number;
@@ -477,7 +477,7 @@ export const api = {
         `${encodeURIComponent(namespace)}/pods/${encodeURIComponent(podName)}`,
     ),
 
-  // K8s events for OSGymWorkspacePool resources — what the pool-operator
+  // K8s events for Pool resources — what the pool-operator
   // emits via kopf for handler outcomes (Normal/Warning, reason, message).
   // Cluster-wide; filtered server-side by involvedObject.kind.
   listOperatorEvents: () =>

--- a/libs/fleet/src/pages/OperatorEvents.tsx
+++ b/libs/fleet/src/pages/OperatorEvents.tsx
@@ -68,7 +68,7 @@ export function OperatorEvents() {
         <Header
           variant="h1"
           counter={loading ? undefined : `(${events.length})`}
-          description="Kubernetes events emitted by the pool-operator on OSGymWorkspacePool resources."
+          description="Kubernetes events emitted by the pool-operator on Pool resources."
           actions={
             <Button iconName="refresh" onClick={load} disabled={loading} />
           }

--- a/libs/fleet/terraform-provider-fleets/MIGRATION.md
+++ b/libs/fleet/terraform-provider-fleets/MIGRATION.md
@@ -1,7 +1,7 @@
 # Migrating from the Cyclops provider
 
 `trycua/fleets` is the public Terraform Registry provider. The Cloud service
-APIs, OAuth environment variables, and `OSGymWorkspacePool` CRD remain
+APIs, OAuth environment variables, and `Pool` CRD remain
 unchanged.
 
 | Previous surface | Fleets surface | Migration |

--- a/libs/fleet/terraform-provider-fleets/README.md
+++ b/libs/fleet/terraform-provider-fleets/README.md
@@ -1,6 +1,6 @@
 # Terraform Provider for Cua Fleets
 
-This provider manages `OSGymWorkspacePool` resources through the Fleet API. It uses the same user-key OAuth credentials and tenant-scoped authorization as the Fleet Python SDK and dashboard.
+This provider manages `Pool` resources through the Fleet API. It uses the same user-key OAuth credentials and tenant-scoped authorization as the Fleet Python SDK and dashboard.
 
 ## Development
 
@@ -31,7 +31,7 @@ All provider arguments support environment variables:
 
 The Terraform models, schema, CRD-derived descriptions, enum validators, numeric validators, and nested object types are generated deterministically from:
 
-- `clusters/base/osgym/crd.yaml`, the production `OSGymWorkspacePool` CRD
+- `clusters/base/osgym/crd.yaml`, the production `Pool` CRD
 - `internal/provider/generate/pool_mapping.json`, the explicit CRD-to-Terraform shape mapping
 
 From `cyclops-cs/terraform-provider-fleets/`, run:

--- a/libs/fleet/terraform-provider-fleets/docs/resources/pool.md
+++ b/libs/fleet/terraform-provider-fleets/docs/resources/pool.md
@@ -6,7 +6,7 @@ description: |-
 
 # fleets_pool
 
-Creates an `OSGymWorkspacePool` and its same-named namespace. Destroy removes both. Import IDs are pool names.
+Creates an `Pool` and its same-named namespace. Destroy removes both. Import IDs are pool names.
 
 ```terraform
 resource "fleets_pool" "linux" {


### PR DESCRIPTION
## What changed
- Makes `Pool` and `PoolStatus` the canonical schema and generated binding names.
- Preserves the Kubernetes CRD kind, plural, JSON discriminator, and event selector.
- Retains explicit deprecated compatibility aliases at public Rust and binding boundaries.
- Adds an allowlisted legacy-token budget guard.

## Validation
- Passed `git diff --check`, shell syntax checks, generated-status static checks, CRD/wire static assertions, and the token guard.
- `cargo` and `rustc` are unavailable in this execution environment, so Cargo builds, generation, and language runtime tests were not run locally.

## Compatibility
- Exact legacy token: 145 -> 45 occurrences. Remaining occurrences are allowlisted wire contracts, wire fixtures, compatibility aliases, and the guard itself.