### PR TITLE
ci(fleet): promote native wheels as cua-fleet

### DIFF
--- a/.github/scripts/repackage_cua_train_wheel.py
+++ b/.github/scripts/repackage_cua_train_wheel.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Repackage a verified native cua-train wheel as a cua-fleet wheel."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import hashlib
+from io import StringIO
+from pathlib import Path
+import re
+import sys
+import zipfile
+
+SOURCE_NAME = "cua-train"
+SOURCE_VERSION = "0.1.1"
+DESTINATION_NAME = "cua-fleet"
+WHEEL_FILENAME = re.compile(
+    r"^(?P<distribution>[A-Za-z0-9_]+)-(?P<version>[^-]+)-py3-none-(?P<platform>[^-]+)\.whl$"
+)
+
+
+class WheelError(ValueError):
+    """Raised when a wheel does not satisfy the promotion contract."""
+
+
+def wheel_stem(name: str) -> str:
+    return name.replace("-", "_")
+
+
+def sha256_record(data: bytes) -> tuple[str, str]:
+    digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode()
+    return f"sha256={digest}", str(len(data))
+
+
+def parse_filename(path: Path) -> tuple[str, str, str]:
+    match = WHEEL_FILENAME.fullmatch(path.name)
+    if match is None:
+        raise WheelError(f"unsupported wheel filename: {path.name}")
+    return match.group("distribution"), match.group("version"), match.group("platform")
+
+
+def parse_metadata(data: bytes) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for line in data.decode().splitlines():
+        if not line:
+            break
+        if ": " in line:
+            key, value = line.split(": ", 1)
+            fields.setdefault(key, value)
+    return fields
+
+
+def update_metadata(data: bytes, version: str) -> bytes:
+    lines = data.decode().splitlines(keepends=True)
+    found_name = found_version = False
+    updated: list[str] = []
+    for line in lines:
+        if line.startswith("Name: "):
+            updated.append(f"Name: {DESTINATION_NAME}\n")
+            found_name = True
+        elif line.startswith("Version: "):
+            updated.append(f"Version: {version}\n")
+            found_version = True
+        else:
+            updated.append(line)
+    if not found_name or not found_version:
+        raise WheelError("METADATA must contain Name and Version fields")
+    return "".join(updated).encode()
+
+
+def csv_bytes(rows: list[list[str]]) -> bytes:
+    output = StringIO()
+    csv.writer(output, lineterminator="\n").writerows(rows)
+    return output.getvalue().encode()
+
+
+def source_payloads(entries: dict[str, bytes]) -> dict[str, str]:
+    return {
+        name: hashlib.sha256(data).hexdigest()
+        for name, data in entries.items()
+        if ".dist-info/" not in name
+    }
+
+
+def repack(
+    source: Path, destination_version: str, output_directory: Path, expected_sha256: str | None
+) -> Path:
+    if expected_sha256 is not None:
+        actual_sha256 = hashlib.sha256(source.read_bytes()).hexdigest()
+        if actual_sha256 != expected_sha256:
+            raise WheelError(f"source SHA-256 mismatch for {source.name}: {actual_sha256}")
+
+    distribution, version, platform = parse_filename(source)
+    if distribution != wheel_stem(SOURCE_NAME) or version != SOURCE_VERSION:
+        raise WheelError(
+            f"expected {SOURCE_NAME}=={SOURCE_VERSION}, found {distribution}=={version}"
+        )
+
+    with zipfile.ZipFile(source) as archive:
+        entries = {
+            info.filename: archive.read(info.filename)
+            for info in archive.infolist()
+            if not info.is_dir() and not info.filename.endswith(".dist-info/RECORD")
+        }
+
+    source_dist_info = f"{wheel_stem(SOURCE_NAME)}-{SOURCE_VERSION}.dist-info"
+    destination_dist_info = f"{wheel_stem(DESTINATION_NAME)}-{destination_version}.dist-info"
+    metadata_name = f"{source_dist_info}/METADATA"
+    wheel_name = f"{source_dist_info}/WHEEL"
+    if metadata_name not in entries or wheel_name not in entries:
+        raise WheelError("wheel is missing METADATA or WHEEL")
+
+    metadata = parse_metadata(entries[metadata_name])
+    if metadata.get("Name") != SOURCE_NAME or metadata.get("Version") != SOURCE_VERSION:
+        raise WheelError("source METADATA does not identify cua-train==0.1.1")
+    wheel_metadata = entries[wheel_name].decode()
+    if (
+        "Root-Is-Purelib: false" not in wheel_metadata
+        or f"Tag: py3-none-{platform}" not in wheel_metadata
+    ):
+        raise WheelError("source WHEEL metadata does not match its native platform tag")
+
+    transformed: dict[str, bytes] = {}
+    for name, data in entries.items():
+        destination_name = name.replace(source_dist_info, destination_dist_info, 1)
+        transformed[destination_name] = (
+            update_metadata(data, destination_version) if name == metadata_name else data
+        )
+
+    record_name = f"{destination_dist_info}/RECORD"
+    records = []
+    for name in sorted(transformed):
+        digest, size = sha256_record(transformed[name])
+        records.append([name, digest, size])
+    records.append([record_name, "", ""])
+    transformed[record_name] = csv_bytes(records)
+
+    output_directory.mkdir(parents=True, exist_ok=True)
+    destination = (
+        output_directory
+        / f"{wheel_stem(DESTINATION_NAME)}-{destination_version}-py3-none-{platform}.whl"
+    )
+    with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for name in sorted(transformed):
+            archive.writestr(name, transformed[name])
+
+    verify(destination, source)
+    return destination
+
+
+def verify(path: Path, source: Path | None = None) -> None:
+    distribution, version, platform = parse_filename(path)
+    if distribution != wheel_stem(DESTINATION_NAME):
+        raise WheelError(f"wheel filename does not identify {DESTINATION_NAME}: {path.name}")
+
+    destination_dist_info = f"{wheel_stem(DESTINATION_NAME)}-{version}.dist-info"
+    with zipfile.ZipFile(path) as archive:
+        entries = {
+            info.filename: archive.read(info.filename)
+            for info in archive.infolist()
+            if not info.is_dir()
+        }
+
+    metadata_name = f"{destination_dist_info}/METADATA"
+    wheel_name = f"{destination_dist_info}/WHEEL"
+    record_name = f"{destination_dist_info}/RECORD"
+    if not {metadata_name, wheel_name, record_name}.issubset(entries):
+        raise WheelError("destination wheel is missing dist-info metadata")
+
+    metadata = parse_metadata(entries[metadata_name])
+    if metadata.get("Name") != DESTINATION_NAME or metadata.get("Version") != version:
+        raise WheelError("destination METADATA does not match the wheel filename")
+    wheel_metadata = entries[wheel_name].decode()
+    if (
+        "Root-Is-Purelib: false" not in wheel_metadata
+        or f"Tag: py3-none-{platform}" not in wheel_metadata
+    ):
+        raise WheelError("destination WHEEL metadata does not match the wheel filename")
+    if not any(name.startswith("cua_train/") for name in entries):
+        raise WheelError("destination wheel is missing cua_train")
+    if not any(name.startswith("cyclops_sdk/") for name in entries):
+        raise WheelError("destination wheel is missing cyclops_sdk")
+    if not any(name.startswith("cyclops_sdk/libcyclops_sdk.") for name in entries):
+        raise WheelError("destination wheel is missing the native cyclops library")
+
+    record_rows = list(csv.reader(entries[record_name].decode().splitlines()))
+    recorded = {row[0]: row[1:] for row in record_rows}
+    if len(recorded) != len(record_rows):
+        raise WheelError("RECORD contains duplicate entries")
+    if set(recorded) != set(entries):
+        raise WheelError("RECORD entries do not match wheel members")
+    for name, data in entries.items():
+        digest, size = recorded[name]
+        if name == record_name:
+            if digest or size:
+                raise WheelError("RECORD must have empty hash and size")
+        elif [digest, size] != list(sha256_record(data)):
+            raise WheelError(f"RECORD does not match {name}")
+
+    if source is not None:
+        with zipfile.ZipFile(source) as archive:
+            source_entries = {
+                info.filename: archive.read(info.filename)
+                for info in archive.infolist()
+                if not info.is_dir() and ".dist-info/" not in info.filename
+            }
+        destination_entries = {
+            name: data for name, data in entries.items() if ".dist-info/" not in name
+        }
+        if source_payloads(source_entries) != source_payloads(destination_entries):
+            raise WheelError("non-dist-info payload bytes changed during repackaging")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", type=Path)
+    parser.add_argument("--destination-version")
+    parser.add_argument("--outdir", type=Path)
+    parser.add_argument("--expected-sha256")
+    parser.add_argument("--verify", type=Path, nargs="+")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.verify is not None:
+            for path in args.verify:
+                verify(path)
+                print(f"Verified {path}")
+            return 0
+        if args.source is None or args.destination_version is None or args.outdir is None:
+            raise WheelError(
+                "--source, --destination-version, and --outdir are required when repacking"
+            )
+        destination = repack(
+            args.source, args.destination_version, args.outdir, args.expected_sha256
+        )
+    except (WheelError, OSError, zipfile.BadZipFile) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    print(destination)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_repackage_cua_train_wheel.py
+++ b/.github/scripts/tests/test_repackage_cua_train_wheel.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import base64
+import csv
+import hashlib
+from io import StringIO
+from pathlib import Path
+import sys
+import zipfile
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from repackage_cua_train_wheel import WheelError, repack, verify  # noqa: E402
+
+
+def _record(data: bytes) -> tuple[str, str]:
+    digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode()
+    return f"sha256={digest}", str(len(data))
+
+
+def _csv(rows: list[list[str]]) -> bytes:
+    output = StringIO()
+    csv.writer(output, lineterminator="\n").writerows(rows)
+    return output.getvalue().encode()
+
+
+def _write_source_wheel(path: Path) -> dict[str, bytes]:
+    dist_info = "cua_train-0.1.1.dist-info"
+    entries = {
+        "cua_train/__init__.py": b"TrainClient = object\n",
+        "cyclops_sdk/__init__.py": b"CyclopsClient = object\n",
+        "cyclops_sdk/libcyclops_sdk.so": b"native payload",
+        f"{dist_info}/METADATA": b"Metadata-Version: 2.4\nName: cua-train\nVersion: 0.1.1\n\n",
+        f"{dist_info}/WHEEL": b"Wheel-Version: 1.0\nRoot-Is-Purelib: false\nTag: py3-none-manylinux_2_34_x86_64\n",
+    }
+    record_name = f"{dist_info}/RECORD"
+    rows = [[name, *_record(data)] for name, data in sorted(entries.items())]
+    rows.append([record_name, "", ""])
+    entries[record_name] = _csv(rows)
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, data in entries.items():
+            archive.writestr(name, data)
+    return entries
+
+
+def test_repack_changes_only_distribution_metadata(tmp_path: Path):
+    source = tmp_path / "cua_train-0.1.1-py3-none-manylinux_2_34_x86_64.whl"
+    source_entries = _write_source_wheel(source)
+
+    destination = repack(
+        source, "0.0.5", tmp_path / "dist", hashlib.sha256(source.read_bytes()).hexdigest()
+    )
+
+    assert destination.name == "cua_fleet-0.0.5-py3-none-manylinux_2_34_x86_64.whl"
+    verify(destination, source)
+    with zipfile.ZipFile(destination) as archive:
+        assert archive.read("cua_train/__init__.py") == source_entries["cua_train/__init__.py"]
+        assert (
+            archive.read("cyclops_sdk/libcyclops_sdk.so")
+            == source_entries["cyclops_sdk/libcyclops_sdk.so"]
+        )
+        metadata = archive.read("cua_fleet-0.0.5.dist-info/METADATA").decode()
+        assert "Name: cua-fleet" in metadata
+        assert "Version: 0.0.5" in metadata
+
+
+def test_repack_rejects_unpinned_source(tmp_path: Path):
+    source = tmp_path / "cua_train-0.1.1-py3-none-manylinux_2_34_x86_64.whl"
+    _write_source_wheel(source)
+
+    with pytest.raises(WheelError, match="SHA-256 mismatch"):
+        repack(source, "0.0.5", tmp_path / "dist", "0" * 64)

--- a/.github/workflows/cd-py-fleet.yml
+++ b/.github/workflows/cd-py-fleet.yml
@@ -7,57 +7,306 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to publish (without v prefix)"
+        description: "Patch version to publish (without v prefix)"
         required: true
-        default: "0.0.1"
+        default: "0.0.5"
   workflow_call:
     inputs:
       version:
-        description: "Version to publish"
+        description: "Patch version to publish"
         required: true
         type: string
+    secrets:
+      PYPI_TOKEN:
+        required: true
 
 permissions:
   contents: write
 
 jobs:
   prepare:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Determine version
+      - name: Determine and validate patch version
         id: get-version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          DISPATCH_VERSION: ${{ github.event.inputs.version }}
+          GITHUB_REF: ${{ github.ref }}
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            VERSION=${{ inputs.version }}
-          elif [ "${{ github.event_name }}" == "push" ]; then
-            if [[ "${{ github.ref }}" =~ ^refs/tags/fleet-v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
-              VERSION=${BASH_REMATCH[1]}
-            else
-              echo "Invalid tag format for cua-fleet"
-              exit 1
-            fi
-          elif [ -n "${{ github.event.inputs.version }}" ]; then
-            VERSION=${{ github.event.inputs.version }}
+          set -euo pipefail
+          if [[ -n "$INPUT_VERSION" ]]; then
+            VERSION="$INPUT_VERSION"
+          elif [[ "$EVENT_NAME" == "push" && "$GITHUB_REF" =~ ^refs/tags/fleet-v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            VERSION="${BASH_REMATCH[1]}"
+          elif [[ -n "$DISPATCH_VERSION" ]]; then
+            VERSION="$DISPATCH_VERSION"
           else
-            echo "ERROR: No version found!"
+            echo "::error::No cua-fleet version was provided."
             exit 1
           fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          curl --fail --silent --show-error --location \
+            https://pypi.org/pypi/cua-fleet/json > /tmp/cua-fleet-pypi.json
+          python3 - "$VERSION" /tmp/cua-fleet-pypi.json <<'PY'
+          import json
+          import re
+          import sys
+
+          version, metadata_path = sys.argv[1:]
+          if not re.fullmatch(r"0\.0\.[0-9]+", version):
+              raise SystemExit("cua-fleet releases must be 0.0.x patches")
+
+          releases = json.load(open(metadata_path))["releases"]
+          stable = sorted(
+              int(match.group(1))
+              for candidate in releases
+              if (match := re.fullmatch(r"0\.0\.([0-9]+)", candidate))
+          )
+          if not stable:
+              raise SystemExit("PyPI does not contain a stable cua-fleet patch release")
+          latest = stable[-1]
+          proposed = int(version.rsplit(".", 1)[1])
+          if proposed not in {latest, latest + 1}:
+              raise SystemExit(f"expected 0.0.{latest + 1}, got {version}")
+          print(f"Validated cua-fleet patch version {version}")
+          PY
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  repackage:
+    needs: prepare
+    name: Repackage ${{ matrix.platform }} wheel
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-x86_64
+            runner: ubuntu-22.04
+            wheel: cua_train-0.1.1-py3-none-manylinux_2_34_x86_64.whl
+            sha256: 9ab37ae89ef6f95a1c0e315226af7716625bc6225e54770f94315905a744c5ad
+            library_suffix: .so
+            audit: auditwheel
+          - platform: linux-aarch64
+            runner: ubuntu-24.04-arm
+            wheel: cua_train-0.1.1-py3-none-manylinux_2_34_aarch64.whl
+            sha256: 6f8eb7f450f05d4a495de70a0a8f7acdb3dce20d842bae96f2aec27e2869fb85
+            library_suffix: .so
+            audit: auditwheel
+          - platform: macos-x86_64
+            runner: macos-15-intel
+            wheel: cua_train-0.1.1-py3-none-macosx_10_12_x86_64.whl
+            sha256: 1822fb9a63c6566d2763a9fb2e384ba4cc6a3771d97fb2cd3f1f9af66916e6df
+            library_suffix: .dylib
+            audit: delocate
+          - platform: macos-arm64
+            runner: macos-14
+            wheel: cua_train-0.1.1-py3-none-macosx_11_0_arm64.whl
+            sha256: 045b51e3ebebc7bf2107ec5a97801250b551e9617bcbbeec97a1e4f4c2ebd884
+            library_suffix: .dylib
+            audit: delocate
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Download and verify canonical native wheel
+        env:
+          WHEEL: ${{ matrix.wheel }}
+          SHA256: ${{ matrix.sha256 }}
+        run: |
+          set -euo pipefail
+          curl --fail --location --retry 3 \
+            --output "$WHEEL" \
+            "https://wheels.cua.ai/simple/cua-train/$WHEEL"
+
+      - name: Repackage as cua-fleet
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          WHEEL: ${{ matrix.wheel }}
+          SHA256: ${{ matrix.sha256 }}
+        run: |
+          python .github/scripts/repackage_cua_train_wheel.py \
+            --source "$WHEEL" \
+            --expected-sha256 "$SHA256" \
+            --destination-version "$VERSION" \
+            --outdir dist
+          python .github/scripts/repackage_cua_train_wheel.py --verify dist/*.whl
+
+      - name: Audit native dependencies without modifying the wheel
+        env:
+          AUDIT: ${{ matrix.audit }}
+        run: |
+          set -euo pipefail
+          if [[ "$AUDIT" == "auditwheel" ]]; then
+            python -m pip install --upgrade auditwheel
+            auditwheel show dist/*.whl
+          else
+            python -m pip install --upgrade delocate
+            delocate-listdeps dist/*.whl
+          fi
+
+      - name: Install only the promoted wheel and load native bindings
+        env:
+          LIBRARY_SUFFIX: ${{ matrix.library_suffix }}
+        run: |
+          set -euo pipefail
+          python -m venv /tmp/cua-fleet-wheel-smoke
+          /tmp/cua-fleet-wheel-smoke/bin/pip install --no-index --no-deps dist/*.whl
+          /tmp/cua-fleet-wheel-smoke/bin/python - "$LIBRARY_SUFFIX" <<'PY'
+          import ctypes
+          from pathlib import Path
+          import sys
+
+          import cyclops_sdk
+          from cyclops_sdk import (
+              CreateClaimRequest,
+              CreatePoolRequest,
+              CyclopsClient,
+              PoolSpec,
+              SandboxService,
+          )
+
+          package = Path(cyclops_sdk.__file__).resolve().parent
+          native = package / f"libcyclops_sdk{sys.argv[1]}"
+          assert native.is_file(), native
+          ctypes.CDLL(str(native))
+          assert all((
+              CyclopsClient,
+              CreatePoolRequest,
+              CreateClaimRequest,
+              PoolSpec,
+              SandboxService,
+          ))
+          PY
+
+      - name: Exercise the example startup boundary without credentials
+        run: |
+          set +e
+          env -i PATH="$PATH" HOME="$HOME" \
+            /tmp/cua-fleet-wheel-smoke/bin/python \
+            libs/fleet/sdk-bindings/examples/python/live_app_controlled.py \
+            > /tmp/live-app.stdout 2> /tmp/live-app.stderr
+          status=$?
+          set -e
+          test "$status" -ne 0
+          grep -Fq "KeyError: 'CUA_CLIENT_ID'" /tmp/live-app.stderr
+          if grep -Eq "ModuleNotFoundError|cannot open shared object|Library not loaded" /tmp/live-app.stderr; then
+            cat /tmp/live-app.stderr
+            exit 1
+          fi
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cua-fleet-${{ matrix.platform }}
+          path: dist/*.whl
+          if-no-files-found: error
+
+  validate:
+    needs: [prepare, repackage]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Verify four promoted wheels and packaging metadata
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade twine
+          python -m twine check dist/*.whl
+          python .github/scripts/repackage_cua_train_wheel.py --verify dist/*.whl
+          python - "${{ needs.prepare.outputs.version }}" dist <<'PY'
+          from pathlib import Path
+          import sys
+
+          version, dist_directory = sys.argv[1:]
+          wheels = sorted(Path(dist_directory).glob("*.whl"))
+          expected = {
+              f"cua_fleet-{version}-py3-none-manylinux_2_34_x86_64.whl",
+              f"cua_fleet-{version}-py3-none-manylinux_2_34_aarch64.whl",
+              f"cua_fleet-{version}-py3-none-macosx_10_12_x86_64.whl",
+              f"cua_fleet-{version}-py3-none-macosx_11_0_arm64.whl",
+          }
+          actual = {wheel.name for wheel in wheels}
+          assert actual == expected, (actual, expected)
+          PY
+
+  unsupported-windows:
+    needs: [prepare, repackage]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Reject native wheels on Windows
+        shell: pwsh
+        run: |
+          python -m pip install --no-index --no-deps --find-links dist cua-fleet==${{ needs.prepare.outputs.version }}
+          if ($LASTEXITCODE -eq 0) {
+            throw "Windows unexpectedly resolved a native cua-fleet wheel"
+          }
 
   publish:
-    needs: prepare
-    uses: ./.github/workflows/py-reusable-publish.yml
-    with:
-      package_name: "fleet"
-      package_dir: "libs/python/cua-fleet"
-      version: ${{ needs.prepare.outputs.version }}
-      base_package_name: "cua-fleet"
-    secrets:
-      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+    needs: [prepare, validate, unsupported-windows]
+    runs-on: ubuntu-latest
+    environment: pypi-fleet
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Reconcile PyPI state before publishing
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error --location \
+            https://pypi.org/pypi/cua-fleet/json > /tmp/cua-fleet-pypi.json
+          python - "$VERSION" dist /tmp/cua-fleet-pypi.json <<'PY'
+          import hashlib
+          import json
+          from pathlib import Path
+          import sys
+
+          version, dist_dir, metadata_path = sys.argv[1:]
+          expected = {wheel.name: hashlib.sha256(wheel.read_bytes()).hexdigest() for wheel in Path(dist_dir).glob("*.whl")}
+          releases = json.load(open(metadata_path))["releases"]
+          existing = {item["filename"]: item["digests"]["sha256"] for item in releases.get(version, [])}
+          unexpected = set(existing) - set(expected)
+          mismatched = {name for name, digest in existing.items() if expected.get(name) != digest}
+          if unexpected or mismatched:
+              raise SystemExit(f"PyPI {version} conflicts: unexpected={unexpected}, mismatched={mismatched}")
+          missing = sorted(set(expected) - set(existing))
+          Path("/tmp/cua-fleet-missing-wheels.txt").write_text("\n".join(missing))
+          PY
+      - name: Publish only missing verified wheels
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          set -euo pipefail
+          mapfile -t missing < /tmp/cua-fleet-missing-wheels.txt
+          if [[ "${#missing[@]}" -eq 0 ]]; then
+            echo "All cua-fleet wheels are already published with matching hashes."
+            exit 0
+          fi
+          python -m pip install --upgrade twine
+          files=()
+          for wheel in "${missing[@]}"; do
+            files+=("dist/$wheel")
+          done
+          TWINE_USERNAME="__token__" TWINE_PASSWORD="$PYPI_TOKEN" \
+            python -m twine upload "${files[@]}"
 
   create-release:
     needs: [prepare, publish]

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -18,7 +18,6 @@ on:
           - pypi/computer-server
           - pypi/cloud
           - pypi/core
-          - pypi/fleet
           - pypi/mcp-server
           - pypi/sandbox
           - pypi/sandbox-apps
@@ -122,10 +121,6 @@ jobs:
               ;;
             "pypi/core")
               echo "directory=libs/python/core" >> $GITHUB_OUTPUT
-              echo "type=python" >> $GITHUB_OUTPUT
-              ;;
-            "pypi/fleet")
-              echo "directory=libs/python/cua-fleet" >> $GITHUB_OUTPUT
               echo "type=python" >> $GITHUB_OUTPUT
               ;;
             "pypi/mcp-server")

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -93,7 +93,6 @@ jobs:
             ["libs/python/computer/"]="pypi/computer"
             ["libs/python/cua-cloud/"]="pypi/cloud"
             ["libs/python/core/"]="pypi/core"
-            ["libs/python/cua-fleet/"]="pypi/fleet"
             ["libs/python/som/"]="pypi/som"
             ["libs/python/bench-ui/"]="pypi/bench-ui"
             ["libs/cua-bench/"]="pypi/bench"


### PR DESCRIPTION
## Native wheel promotion

Promotes the existing four `cua-train==0.1.1` native wheels as `cua-fleet` patch releases without rebuilding the SDK.

- Repackages only wheel distribution identity (`filename`, `.dist-info`, `METADATA`, and `RECORD`); preserves `cua_train`, generated `cyclops_sdk`, and native library payload bytes.
- Pins each source wheel by SHA-256, validates all four platform tags, audits native dependencies, and runs clean local native-load/import smoke checks.
- Removes Fleet from legacy pure-facade bump/on-merge routing so only the checksum-pinned promotion pipeline can publish Fleet wheels.
- Enforces `0.0.x` patch-only publishing and reconciles PyPI hashes before any retry.

No wheel upload, tag, release, or package publication is performed by this PR.