### PR TITLE
fix(fleet): allow expected Windows wheel rejection

### DIFF
--- a/.github/workflows/cd-py-fleet.yml
+++ b/.github/workflows/cd-py-fleet.yml
@@ -252,10 +252,7 @@ jobs:
       - name: Reject native wheels on Windows
         shell: pwsh
         run: |
-          python -m pip install --no-index --no-deps --find-links dist cua-fleet==${{ needs.prepare.outputs.version }}
-          if ($LASTEXITCODE -eq 0) {
-            throw "Windows unexpectedly resolved a native cua-fleet wheel"
-          }
+          python -c "import subprocess, sys; result = subprocess.run([sys.executable, '-m', 'pip', 'install', '--no-index', '--no-deps', '--find-links', 'dist', 'cua-fleet==${{ needs.prepare.outputs.version }}']); raise SystemExit('Windows unexpectedly resolved a native cua-fleet wheel' if result.returncode == 0 else 0)"
 
   publish:
     needs: [prepare, validate, unsupported-windows]


### PR DESCRIPTION
Fixes the failed `unsupported-windows` release gate from the 0.0.5 promotion run. The gate now executes the expected failing pip resolution in a Python subprocess, preserving failure when Windows unexpectedly resolves a native wheel while returning success for the expected unsupported-platform resolution.

Validation: YAML parse; both gate branches; `2 passed` repacker tests.