### PR TITLE
ci(fleet): show PyPI upload validation errors

### DIFF
--- a/.github/workflows/cd-py-fleet.yml
+++ b/.github/workflows/cd-py-fleet.yml
@@ -303,7 +303,7 @@ jobs:
             files+=("dist/$wheel")
           done
           TWINE_USERNAME="__token__" TWINE_PASSWORD="$PYPI_TOKEN" \
-            python -m twine upload "${files[@]}"
+            python -m twine upload --verbose "${files[@]}"
 
   create-release:
     needs: [prepare, publish]


### PR DESCRIPTION
Adds Twine verbose mode to the native Fleet publisher. The preceding 0.0.5 release validated all four wheels but PyPI returned an opaque HTTP 400 before any upload, tag, or release. This preserves the exact artifact/publish flow and exposes the non-secret PyPI validation response on the authorized retry.