### PR TITLE
fix(fleet): render empty descriptions as plain text

### DIFF
--- a/.github/scripts/repackage_cua_train_wheel.py
+++ b/.github/scripts/repackage_cua_train_wheel.py
@@ -53,10 +53,15 @@ def parse_metadata(data: bytes) -> dict[str, str]:
 
 
 def update_metadata(data: bytes, version: str) -> bytes:
-    lines = data.decode().splitlines(keepends=True)
+    text = data.decode()
+    _, _, description = text.partition("\n\n")
+    lines = text.splitlines(keepends=True)
     found_name = found_version = False
     updated: list[str] = []
     for line in lines:
+        if not description.strip() and line.startswith("Description-Content-Type: "):
+            updated.append("Description-Content-Type: text/plain\n")
+            continue
         if line.startswith("Name: "):
             updated.append(f"Name: {DESTINATION_NAME}\n")
             found_name = True

--- a/.github/scripts/tests/test_repackage_cua_train_wheel.py
+++ b/.github/scripts/tests/test_repackage_cua_train_wheel.py
@@ -31,7 +31,7 @@ def _write_source_wheel(path: Path) -> dict[str, bytes]:
         "cua_train/__init__.py": b"TrainClient = object\n",
         "cyclops_sdk/__init__.py": b"CyclopsClient = object\n",
         "cyclops_sdk/libcyclops_sdk.so": b"native payload",
-        f"{dist_info}/METADATA": b"Metadata-Version: 2.4\nName: cua-train\nVersion: 0.1.1\n\n",
+        f"{dist_info}/METADATA": b"Metadata-Version: 2.4\nName: cua-train\nVersion: 0.1.1\nDescription-Content-Type: text/markdown\n\n",
         f"{dist_info}/WHEEL": b"Wheel-Version: 1.0\nRoot-Is-Purelib: false\nTag: py3-none-manylinux_2_34_x86_64\n",
     }
     record_name = f"{dist_info}/RECORD"
@@ -63,6 +63,7 @@ def test_repack_changes_only_distribution_metadata(tmp_path: Path):
         metadata = archive.read("cua_fleet-0.0.5.dist-info/METADATA").decode()
         assert "Name: cua-fleet" in metadata
         assert "Version: 0.0.5" in metadata
+        assert "Description-Content-Type: text/plain" in metadata
 
 
 def test_repack_rejects_unpinned_source(tmp_path: Path):


### PR DESCRIPTION
PyPI rejected the otherwise validated native `cua-fleet==0.0.5` wheels because their empty description declared `text/markdown`. The promotion repacker now rewrites that orphaned header to `text/plain`, preserving all description bytes and native/package payload files.

Validated with the exact checksum-pinned macOS x86_64 source wheel: repack/RECORD verify, payload-file SHA-256 identity, native dylib presence, and `twine check`; unit tests pass (`2 passed`).