### PR TITLE
fix(cua-driver): prefer direct foreground retry guidance

### DIFF
--- a/libs/cua-driver/rust/Skills/cua-driver/LINUX.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/LINUX.md
@@ -52,9 +52,9 @@ and Windows surface:
 **`bring_to_front`** (X11): persistent `_NET_ACTIVE_WINDOW` activation (the
 `wmctrl -a` equivalent), kept active. It is not the normal response to
 `background_unavailable`; retry that action directly with
-`delivery_mode:"foreground"`. Reserve `bring_to_front` for a known focus-proxy
-surface, such as a remote desktop client, that must stay active across several
-interactions.
+`delivery_mode:"foreground"`, the per-action foreground request. Reserve
+`bring_to_front` for a known focus-proxy surface, such as a remote desktop
+client, that must stay active across several interactions.
 
 **Read-back / `verified`** — `type_text` reports `{verified}`: the AT-SPI
 `EditableText.insertText` path (`path:"ax"`) is the **driver-verifiable** rung

--- a/libs/cua-driver/rust/Skills/cua-driver/LINUX.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/LINUX.md
@@ -50,8 +50,11 @@ and Windows surface:
   A brief focus swap unless the target was already active.
 
 **`bring_to_front`** (X11): persistent `_NET_ACTIVE_WINDOW` activation (the
-`wmctrl -a` equivalent), kept active. Call it before `delivery_mode:"foreground"`
-input to avoid a per-call flash, or to escalate when background didn't land.
+`wmctrl -a` equivalent), kept active. It is not the normal response to
+`background_unavailable`; retry that action directly with
+`delivery_mode:"foreground"`. Reserve `bring_to_front` for a known focus-proxy
+surface, such as a remote desktop client, that must stay active across several
+interactions.
 
 **Read-back / `verified`** — `type_text` reports `{verified}`: the AT-SPI
 `EditableText.insertText` path (`path:"ax"`) is the **driver-verifiable** rung

--- a/libs/cua-driver/rust/Skills/cua-driver/WINDOWS.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/WINDOWS.md
@@ -31,7 +31,7 @@ strict no-foreground:
 | `delivery_mode`          | Behavior on Windows                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `"background"` (DEFAULT) | Never fronts and **never raises/restacks** the target — macOS-aligned (mirrors CGEvent-to-pid). **Pixel clicks**: a UIA hit-test at the point first (accessibility-channel Invoke — works on UWP / WinUI3 / Win11 packaged apps, no flash); if that misses, coordinate-injected pen/touch, **but only when the target is the _visible_ window at that point**; PostMessage for plain Win32. It returns a structured `background_unavailable` error — rather than raising or fronting — when the target is **occluded** at the point, or the event kind is known-dropped (Chromium DOM mouse + key-combos, GTK buttons, VCL/LibreOffice accelerators, terminal / WPF text with no `element_index`). **No foreground swap and no z-order raise, ever.** |
-| `"foreground"`           | SendInput with action-scoped `SetForegroundWindow(target)` → act → restore. The explicit, agent-chosen rung where fronting IS allowed — required to reach occluded targets, Chromium DOM content, GTK buttons, VCL accelerators, WPF drag, terminals, and canvas / custom-drawn surfaces with no UIA peer. Implemented for **every** input tool — `type_text` (SendInput Unicode via `send_text_synthesized`) and `scroll` (SendInput wheel via `send_wheel_synthesized`) included. The target stays foreground only for that action.                                                                                                                                                                           |
+| `"foreground"`           | Per-action foreground request through SendInput. The explicit, agent-chosen rung where fronting IS allowed — required to reach occluded targets, Chromium DOM content, GTK buttons, VCL accelerators, WPF drag, terminals, and canvas / custom-drawn surfaces with no UIA peer. Implemented for **every** input tool — `type_text` (SendInput Unicode via `send_text_synthesized`) and `scroll` (SendInput wheel via `send_wheel_synthesized`) included. Unlike `bring_to_front`, it does not request persistent activation.                                                                                                                                                                                            |
 
 > **macOS is the source of truth — `background` never alters the screen.**
 > Earlier Windows builds "cheated" in background with three tricks that this
@@ -63,8 +63,8 @@ turns the pixel coord into a UIA Invoke at that point and delivers
 through the accessibility channel — no flash, no focus steal. Only
 escalate to `delivery_mode:"foreground"` when you actually see a
 `background_unavailable` structured error. Retry that same action directly;
-the foreground swap is scoped to the action and restores the previous
-foreground before returning.
+`delivery_mode:"foreground"` is the per-action foreground request, not an
+opt-in to persistent activation.
 
 Empirical: pixel-clicks via `delivery_mode:"background"` against the UWP
 Calculator on Win11 (Number-pad buttons + operators) consistently
@@ -779,7 +779,7 @@ typed browser tools yet.
     failure signal, verify via screenshot if it matters.
     Escalate to `delivery_mode:"foreground"` for both (SendInput Unicode /
     accelerator). **But** foreground needs the swap to actually land — if the
-    daemon lacks UIAccess and the action-scoped foreground swap is rejected,
+    daemon lacks UIAccess and the foreground delivery attempt is rejected,
     you can't drive it by input at all:
     produce the artifact and `launch_app` it (build the `.xlsx` / `.docx` and
     open it) rather than typing into the GUI.

--- a/libs/cua-driver/rust/Skills/cua-driver/WINDOWS.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/WINDOWS.md
@@ -31,7 +31,7 @@ strict no-foreground:
 | `delivery_mode`          | Behavior on Windows                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `"background"` (DEFAULT) | Never fronts and **never raises/restacks** the target — macOS-aligned (mirrors CGEvent-to-pid). **Pixel clicks**: a UIA hit-test at the point first (accessibility-channel Invoke — works on UWP / WinUI3 / Win11 packaged apps, no flash); if that misses, coordinate-injected pen/touch, **but only when the target is the _visible_ window at that point**; PostMessage for plain Win32. It returns a structured `background_unavailable` error — rather than raising or fronting — when the target is **occluded** at the point, or the event kind is known-dropped (Chromium DOM mouse + key-combos, GTK buttons, VCL/LibreOffice accelerators, terminal / WPF text with no `element_index`). **No foreground swap and no z-order raise, ever.** |
-| `"foreground"`           | SendInput with brief `SetForegroundWindow(target)` → restore. The explicit, agent-chosen rung where fronting IS allowed — required to reach occluded targets, Chromium DOM content, GTK buttons, VCL accelerators, WPF drag, terminals, and canvas / custom-drawn surfaces with no UIA peer. Implemented for **every** input tool — `type_text` (SendInput Unicode via `send_text_synthesized`) and `scroll` (SendInput wheel via `send_wheel_synthesized`) included. Flashes the target visible unless `bring_to_front` was called first.                                                                                                                                                                                                            |
+| `"foreground"`           | SendInput with action-scoped `SetForegroundWindow(target)` → act → restore. The explicit, agent-chosen rung where fronting IS allowed — required to reach occluded targets, Chromium DOM content, GTK buttons, VCL accelerators, WPF drag, terminals, and canvas / custom-drawn surfaces with no UIA peer. Implemented for **every** input tool — `type_text` (SendInput Unicode via `send_text_synthesized`) and `scroll` (SendInput wheel via `send_wheel_synthesized`) included. The target stays foreground only for that action.                                                                                                                                                                           |
 
 > **macOS is the source of truth — `background` never alters the screen.**
 > Earlier Windows builds "cheated" in background with three tricks that this
@@ -62,9 +62,9 @@ PostMessage** (UWP Calculator, Win11 Notepad, WinUI3 apps, etc.). cua-driver
 turns the pixel coord into a UIA Invoke at that point and delivers
 through the accessibility channel — no flash, no focus steal. Only
 escalate to `delivery_mode:"foreground"` when you actually see a
-`background_unavailable` structured error, and only with the
-`bring_to_front` flow described below so the agent pays the flash cost
-once instead of per-call.
+`background_unavailable` structured error. Retry that same action directly;
+the foreground swap is scoped to the action and restores the previous
+foreground before returning.
 
 Empirical: pixel-clicks via `delivery_mode:"background"` against the UWP
 Calculator on Win11 (Number-pad buttons + operators) consistently
@@ -84,7 +84,7 @@ costlier path; only use it for surfaces with no UIA peer.
     "target_class": "Chrome_WidgetWin_1",
     "event_kind": "mouse_click",
     "escalation": { "recommended": "foreground", "reason": "occluded / known-dropped event kind" },
-    "suggestion": "Either call bring_to_front then retry with delivery_mode:\"foreground\", or accept the foreground swap by setting delivery_mode:\"foreground\" directly."
+    "suggestion": "Retry this action with delivery_mode:\"foreground\"."
   }
 }
 ```
@@ -95,16 +95,16 @@ recommendation is `"foreground"` — the dropped event needs the fronting
 rung. (Contrast macOS / X11, where a background px click can still land
 in the background, so there the hint is `px`.)
 
-The recommended flow when an agent gets that error:
+The recommended flow when an agent gets that error is one step:
 
-1. `bring_to_front(pid)` — activates the target ONCE (visible flicker).
-2. Subsequent input calls with `delivery_mode:"foreground"` deliver via
-   SendInput WITHOUT a per-call flash (the SetForegroundWindow swap
-   inside SendInput is a no-op because the target is already frontmost).
-3. When done, leave the target as the user's foreground or call
-   `hotkey({pid: original_fg_pid, keys: ["alt","tab"]})` to put their
-   prior window back. **There is no "restore" tool** — you brought
-   the target forward deliberately; restoring is your responsibility.
+1. Retry the same action with `delivery_mode:"foreground"`.
+
+`bring_to_front` is a separate persistent-activation tool, not the normal next
+rung. Use it only when a known focus-proxy surface, such as a remote desktop
+client, must stay foreground across several interactions. In that special
+case, subsequent input calls still use `delivery_mode:"foreground"`; the
+target remains foreground when the sequence ends, so restoring the user's
+previous window is the caller's responsibility.
 
 The `bring_to_front` tool uses an `AttachThreadInput` trick to _attempt_
 the foreground swap even when the daemon isn't at UIAccess integrity (the
@@ -275,8 +275,8 @@ neither carries live keyboard state — so a `modifier` (Ctrl/Shift/etc.)
 passed alongside a `delivery_mode:"background"` click **is not honored**
 on Windows. The `modifier` _param_ is part of the shared schema and is
 accepted everywhere; it only takes effect on the SendInput rung, i.e. a
-`delivery_mode:"foreground"` (or `bring_to_front`-then-foreground) click,
-where SendInput sets real modifier state. If you need a modifier-click on
+`delivery_mode:"foreground"` click, where SendInput sets real modifier state.
+If you need a modifier-click on
 Windows, escalate that one action to `foreground`.
 
 ### Cross-platform schema residuals (Windows)
@@ -779,8 +779,8 @@ typed browser tools yet.
     failure signal, verify via screenshot if it matters.
     Escalate to `delivery_mode:"foreground"` for both (SendInput Unicode /
     accelerator). **But** foreground needs the swap to actually land — if the
-    daemon lacks UIAccess and `bring_to_front` returns `landed_on_target:false`
-    (or it reverts before the next call), you can't drive it by input at all:
+    daemon lacks UIAccess and the action-scoped foreground swap is rejected,
+    you can't drive it by input at all:
     produce the artifact and `launch_app` it (build the `.xlsx` / `.docx` and
     open it) rather than typing into the GUI.
 - **Edge / Chrome shows tab switching even though I used pid-scoped

--- a/libs/cua-driver/rust/Skills/cua-driver/WINDOWS.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/WINDOWS.md
@@ -299,17 +299,17 @@ Windows-relevant notes:
   overloaded for AUMIDs); macOS takes `bundle_id` / `urls`. `name` is the
   portable fallback. See the AUMID section below.
 
-**Chromium pixel-click foreground polling restore.** `click({pid, x, y})`
-on a Chromium target falls through to `send_click_synthesized`
-(SendInput + brief foreground swap) because Chromium's input thread filters by
-  queue-origin and PostMessage-delivered clicks don't fire DOM events. The
-  synchronous restore inside `send_click_synthesized` covers the
-  immediate swap; an additional polling guard (same shape as `launch_app`'s
-  `FocusRestoreGuard`) catches the **asynchronous** Chromium re-activation
-  that can happen as the renderer's input handler processes the click
-  (focus().activate() / WebContents::Activate() — 100-500 ms later). The
-  guard is gated on `GetWindowThreadProcessId(fg_now) == pid` so user
-  Alt-Tabs are respected.
+**Chromium pixel-click foreground restore is best-effort.** Supported
+`delivery_mode:"background"` paths do not request target activation. An
+explicit foreground pixel click uses `send_click_synthesized_active_mods`
+because Chromium's input thread filters by queue origin and
+PostMessage-delivered clicks do not fire DOM events. After injection, the tool
+schedules `restore_foreground_polling_best_effort` to catch both the immediate
+activation and any later renderer re-activation. That polling guard is
+asynchronous and best-effort, so the tool response is not proof that the
+previous foreground has already been restored. The guard changes focus only
+while `GetWindowThreadProcessId(fg_now) == pid`, so it does not undo a user
+Alt-Tab.
 
 ## Defaults — always prefer cua-driver over shell shims
 

--- a/libs/cua-driver/rust/crates/platform-linux/src/input/delivery.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/input/delivery.rs
@@ -145,16 +145,13 @@ pub fn background_unavailable_error(
 ) -> cua_driver_core::protocol::ToolResult {
     let detail = reason.detail();
     cua_driver_core::protocol::ToolResult::error(format!(
-        "Background delivery is not available: {detail}. Either call bring_to_front \
-         then retry with delivery_mode:\"foreground\", or accept activation by \
-         setting delivery_mode:\"foreground\" directly."
+        "Background delivery is not available: {detail}. Retry this action with \
+         delivery_mode:\"foreground\"."
     ))
     .with_structured(serde_json::json!({
         "code": reason.code(),
         "detail": detail,
-        "suggestion":
-            "Either call bring_to_front then retry with delivery_mode:\"foreground\", \
-             or set delivery_mode:\"foreground\" directly.",
+        "suggestion": "Retry this action with delivery_mode:\"foreground\".",
     }))
 }
 
@@ -223,5 +220,29 @@ mod tests {
             r.structured_content.as_ref().unwrap()["code"],
             serde_json::json!("background_unavailable")
         );
+    }
+
+    #[test]
+    fn background_unavailable_prefers_action_scoped_foreground_retry() {
+        for reason in [
+            BackgroundUnavailable::NoLibeiBackend,
+            BackgroundUnavailable::ChromiumInput,
+            BackgroundUnavailable::FocusedInputOnly,
+            BackgroundUnavailable::WebKitSyntheticInput,
+        ] {
+            let result = background_unavailable_error(reason);
+            let structured = result.structured_content.as_ref().expect("structured");
+            assert_eq!(
+                structured["suggestion"].as_str(),
+                Some("Retry this action with delivery_mode:\"foreground\".")
+            );
+
+            let text = match &result.content[0] {
+                cua_driver_core::protocol::Content::Text { text, .. } => text,
+                _ => panic!("expected text content"),
+            };
+            assert!(text.contains("Retry this action with delivery_mode:\"foreground\"."));
+            assert!(!text.contains("bring_to_front"));
+        }
     }
 }

--- a/libs/cua-driver/rust/crates/platform-linux/src/input/delivery.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/input/delivery.rs
@@ -79,11 +79,11 @@ pub fn delivery_mode_schema() -> Value {
          Wayland's security model has no per-window background targeting, so a \
          specific non-focused window cannot be aimed at; when no libei backend \
          is available the tool returns a structured background_unavailable \
-         error. 'foreground' is the explicit escalation: activate the target \
-         (X11 _NET_ACTIVE_WINDOW; Wayland compositor activate), inject, then \
-         restore the prior active window — a brief focus swap unless the \
-         target was already active. Retry a refused action directly with \
-         'foreground'. Use bring_to_front only for a known focus-proxy surface \
+         error. 'foreground' is the explicit per-action escalation: request \
+         target activation (X11 _NET_ACTIVE_WINDOW; Wayland compositor \
+         activate), then inject. Retry a refused action directly with \
+         'foreground'; unlike bring_to_front, it does not request persistent \
+         activation. Use bring_to_front only for a known focus-proxy surface \
          that must stay foreground across interactions. Matches the macOS / \
          Windows delivery_mode surface.",
     );
@@ -216,6 +216,7 @@ mod tests {
             .as_str()
             .expect("delivery_mode description");
         assert!(description.contains("Retry a refused action directly with 'foreground'"));
+        assert!(description.contains("does not request persistent activation"));
         assert!(description.contains("known focus-proxy surface"));
         assert!(!description.contains("Call bring_to_front first"));
     }

--- a/libs/cua-driver/rust/crates/platform-linux/src/input/delivery.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/input/delivery.rs
@@ -82,8 +82,10 @@ pub fn delivery_mode_schema() -> Value {
          error. 'foreground' is the explicit escalation: activate the target \
          (X11 _NET_ACTIVE_WINDOW; Wayland compositor activate), inject, then \
          restore the prior active window — a brief focus swap unless the \
-         target was already active. Call bring_to_front first to avoid the \
-         flash. Matches the macOS / Windows delivery_mode surface.",
+         target was already active. Retry a refused action directly with \
+         'foreground'. Use bring_to_front only for a known focus-proxy surface \
+         that must stay foreground across interactions. Matches the macOS / \
+         Windows delivery_mode surface.",
     );
     v["default"] = serde_json::json!("background");
     v
@@ -210,6 +212,12 @@ mod tests {
             .collect();
         assert_eq!(en, vec!["background", "foreground"]);
         assert_eq!(s["default"], "background");
+        let description = s["description"]
+            .as_str()
+            .expect("delivery_mode description");
+        assert!(description.contains("Retry a refused action directly with 'foreground'"));
+        assert!(description.contains("known focus-proxy surface"));
+        assert!(!description.contains("Call bring_to_front first"));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -6744,8 +6744,9 @@ impl Tool for BringToFrontTool {
             description:
                 "Persistently activate a window so it stays foreground across interactions. \
                  For a generic `background_unavailable` response, retry the same action \
-                 directly with `delivery_mode:\"foreground\"`; that activation is scoped to \
-                 one action and restores the previous foreground. Use `bring_to_front` only \
+                 directly with `delivery_mode:\"foreground\"`; that is the per-action \
+                 foreground request rather than a request for persistent activation. Use \
+                 `bring_to_front` only \
                  when a known focus-proxy surface, such as a remote desktop client, must \
                  remain active across multiple interactions. \
                  X11: EWMH _NET_ACTIVE_WINDOW activation (the `wmctrl -a` equivalent, \

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -6742,11 +6742,14 @@ impl Tool for BringToFrontTool {
         BTF_DEF.get_or_init(|| ToolDef {
             name: "bring_to_front".into(),
             description:
-                "Persistently activate a window so subsequent input lands on it. \
+                "Persistently activate a window so it stays foreground across interactions. \
+                 For a generic `background_unavailable` response, retry the same action \
+                 directly with `delivery_mode:\"foreground\"`; that activation is scoped to \
+                 one action and restores the previous foreground. Use `bring_to_front` only \
+                 when a known focus-proxy surface, such as a remote desktop client, must \
+                 remain active across multiple interactions. \
                  X11: EWMH _NET_ACTIVE_WINDOW activation (the `wmctrl -a` equivalent, \
-                 proper timestamp handling to beat focus-stealing prevention) — call \
-                 it before `delivery_mode:\"foreground\"` input to avoid a per-call \
-                 flash, or to escalate when background injection didn't land. \
+                 with proper timestamp handling to beat focus-stealing prevention). \
                  Wayland: activates through a target-addressable compositor adapter \
                  (wlroots foreign-toplevel or the GNOME Shell helper) and refuses \
                  when the compositor offers no safe adapter. Matches the macOS / \

--- a/libs/cua-driver/rust/crates/platform-windows/src/input/delivery.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/input/delivery.rs
@@ -119,7 +119,9 @@ pub fn delivery_mode_schema() -> Value {
          the tool returns a structured background_unavailable error rather than \
          fronting. 'foreground' is the explicit escalation: a brief \
          SetForegroundWindow swap + SendInput, restoring the prior foreground \
-         afterward (call bring_to_front first to avoid the flash). \
+         afterward. Retry a refused action directly with 'foreground'. Use \
+         bring_to_front only for a known focus-proxy surface that must stay \
+         foreground across interactions. \
          IMPORTANT: 'background' is not a hint to weigh — it is the mandatory \
          first attempt. Do NOT pass 'foreground' preemptively because a target \
          'looks like' GTK/Chromium/Electron; the DRIVER decides when background \
@@ -451,6 +453,16 @@ mod tests {
             DeliveryMode::from_args(&serde_json::json!({"delivery_mode": null})),
             DeliveryMode::Background
         );
+    }
+
+    #[test]
+    fn delivery_mode_schema_separates_scoped_and_persistent_foreground() {
+        let description = delivery_mode_schema()["description"]
+            .as_str()
+            .expect("delivery_mode description");
+        assert!(description.contains("Retry a refused action directly with 'foreground'"));
+        assert!(description.contains("known focus-proxy surface"));
+        assert!(!description.contains("call bring_to_front first"));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-windows/src/input/delivery.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/input/delivery.rs
@@ -9,7 +9,7 @@
 //! - `background` (DEFAULT) — PostMessage / UIA path only, never fronts. If
 //!   `would_be_silently_dropped(target, event_kind)` returns true, the tool
 //!   returns a structured `background_unavailable` error so the caller can
-//!   `bring_to_front` then retry with `delivery_mode:"foreground"`. This is
+//!   retry the action with `delivery_mode:"foreground"`. This is
 //!   the default because cua-driver's value proposition is that input never
 //!   steals foreground — surfacing an honest error beats silently fronting.
 //!
@@ -331,24 +331,21 @@ pub fn background_unavailable_error(
     let class = read_class_name(hwnd);
     let text = format!(
         "Background delivery is not available for target window class \
-         '{class}' on this event kind ({}). Either call bring_to_front \
-         then retry with delivery_mode:\"foreground\", or accept the foreground \
-         swap directly by setting delivery_mode:\"foreground\".",
+         '{class}' on this event kind ({}). Retry this action with \
+         delivery_mode:\"foreground\".",
         kind.name()
     );
     cua_driver_core::protocol::ToolResult::error(text).with_structured(serde_json::json!({
         "code": "background_unavailable",
         "target_class": class,
         "event_kind": kind.name(),
-        "suggestion":
-            "Either call bring_to_front then retry with delivery_mode:\"foreground\", \
-             or accept the foreground swap by setting delivery_mode:\"foreground\" directly.",
+        "suggestion": "Retry this action with delivery_mode:\"foreground\".",
         // Windows analog of the macOS escalation signal: this surface drops
         // background input, so the deliberate next rung is foreground delivery.
         "escalation": {
             "recommended": "foreground",
             "reason": "background input is dropped by this surface — re-call \
-                       delivery_mode:\"foreground\" (or bring_to_front first).",
+                       this action with delivery_mode:\"foreground\".",
         },
     }))
 }
@@ -374,7 +371,8 @@ pub fn background_unavailable_error_with_cause(
     };
     let text = format!(
         "Background delivery is not available for target window class \
-         '{class}' on this event kind ({}): {cause}",
+         '{class}' on this event kind ({}): {cause}. Retry this action with \
+         delivery_mode:\"foreground\".",
         kind.name()
     );
     cua_driver_core::protocol::ToolResult::error(text).with_structured(serde_json::json!({
@@ -382,13 +380,11 @@ pub fn background_unavailable_error_with_cause(
         "target_class": class,
         "event_kind": kind.name(),
         "cause": cause,
-        "suggestion":
-            "Either call bring_to_front then retry with delivery_mode:\"foreground\", \
-             or accept the foreground swap by setting delivery_mode:\"foreground\" directly.",
+        "suggestion": "Retry this action with delivery_mode:\"foreground\".",
         "escalation": {
             "recommended": "foreground",
             "reason": "background input could not be delivered by the coordinate actuator — \
-                       re-call delivery_mode:\"foreground\" (or bring_to_front first).",
+                       re-call this action with delivery_mode:\"foreground\".",
         },
     }))
 }
@@ -490,5 +486,40 @@ mod tests {
                 .and_then(|v| v["code"].as_str()),
             Some("background_uipi_blocked")
         );
+    }
+
+    #[test]
+    fn background_unavailable_prefers_action_scoped_foreground_retry() {
+        let results = [
+            background_unavailable_error(0, EventKind::Keystroke),
+            background_unavailable_error_with_cause(
+                0,
+                EventKind::MouseClick,
+                "target point is occluded by another window",
+            ),
+        ];
+
+        for result in results {
+            let structured = result.structured_content.as_ref().expect("structured");
+            assert_eq!(
+                structured["suggestion"].as_str(),
+                Some("Retry this action with delivery_mode:\"foreground\".")
+            );
+            assert_eq!(
+                structured["escalation"]["recommended"].as_str(),
+                Some("foreground")
+            );
+            assert!(!structured["escalation"]["reason"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("bring_to_front"));
+
+            let text = match &result.content[0] {
+                cua_driver_core::protocol::Content::Text { text, .. } => text,
+                _ => panic!("expected text content"),
+            };
+            assert!(text.contains("Retry this action with delivery_mode:\"foreground\"."));
+            assert!(!text.contains("bring_to_front"));
+        }
     }
 }

--- a/libs/cua-driver/rust/crates/platform-windows/src/input/delivery.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/input/delivery.rs
@@ -117,9 +117,10 @@ pub fn delivery_mode_schema() -> Value {
          raised. For targets whose input stack silently drops posted events \
          (Chromium/Electron content, GTK buttons, VCL/LibreOffice accelerators) \
          the tool returns a structured background_unavailable error rather than \
-         fronting. 'foreground' is the explicit escalation: a brief \
-         SetForegroundWindow swap + SendInput, restoring the prior foreground \
-         afterward. Retry a refused action directly with 'foreground'. Use \
+         fronting. 'foreground' is the explicit per-action escalation through \
+         SetForegroundWindow + SendInput. Retry a refused action directly with \
+         'foreground'; unlike bring_to_front, it does not request persistent \
+         activation. Use \
          bring_to_front only for a known focus-proxy surface that must stay \
          foreground across interactions. \
          IMPORTANT: 'background' is not a hint to weigh — it is the mandatory \
@@ -456,11 +457,12 @@ mod tests {
     }
 
     #[test]
-    fn delivery_mode_schema_separates_scoped_and_persistent_foreground() {
+    fn delivery_mode_schema_separates_per_action_and_persistent_foreground() {
         let description = delivery_mode_schema()["description"]
             .as_str()
             .expect("delivery_mode description");
         assert!(description.contains("Retry a refused action directly with 'foreground'"));
+        assert!(description.contains("does not request persistent activation"));
         assert!(description.contains("known focus-proxy surface"));
         assert!(!description.contains("call bring_to_front first"));
     }

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -7782,8 +7782,9 @@ impl Tool for BringToFrontTool {
                 the OS foreground. \n\n\
                 **This deliberately breaks the no-foreground contract and keeps the target \
                 foreground.** For a generic `background_unavailable` response, retry the same \
-                action directly with `delivery_mode:\"foreground\"`; that activation is scoped \
-                to one action and restores the previous foreground. Use `bring_to_front` only \
+                action directly with `delivery_mode:\"foreground\"`; that is the per-action \
+                foreground request rather than a request for persistent activation. Use \
+                `bring_to_front` only \
                 when a known focus-proxy surface, such as a remote desktop client, must stay \
                 foreground across multiple interactions. Subsequent input calls still use \
                 `delivery_mode:\"foreground\"` for SendInput.\n\n\

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -7780,17 +7780,13 @@ impl Tool for BringToFrontTool {
             name: "bring_to_front".into(),
             description: "Activate `pid`'s window (or `window_id` if specified) -- bring it to \
                 the OS foreground. \n\n\
-                **This deliberately breaks the no-foreground contract.** Use only when an \
-                agent is about to drive a sequence of operations against a target whose input \
-                stack silently drops PostMessage (Chromium DOM content, GTK button widgets) \
-                and the agent wants to pay the foreground cost once instead of per call. \n\n\
-                Pairs with the `delivery_mode` field on input tools:\n\
-                  1. Try `click(..., delivery_mode:\"background\")`. If it returns \
-                     `background_unavailable`, the target needs foreground delivery.\n\
-                  2. Call `bring_to_front(pid)` so the target is foreground.\n\
-                  3. Subsequent input calls with `delivery_mode:\"foreground\"` deliver via \
-                     SendInput WITHOUT visible flashing -- the SetForegroundWindow swap \
-                     inside SendInput is a no-op since target is already foreground.\n\n\
+                **This deliberately breaks the no-foreground contract and keeps the target \
+                foreground.** For a generic `background_unavailable` response, retry the same \
+                action directly with `delivery_mode:\"foreground\"`; that activation is scoped \
+                to one action and restores the previous foreground. Use `bring_to_front` only \
+                when a known focus-proxy surface, such as a remote desktop client, must stay \
+                foreground across multiple interactions. Subsequent input calls still use \
+                `delivery_mode:\"foreground\"` for SendInput.\n\n\
                 Implementation uses the `AttachThreadInput` trick to bypass Windows' \
                 foreground-lock when the daemon is not at UIAccess integrity. Returns \
                 structured `{previous_fg_hwnd, now_fg_hwnd}` so callers can later restore. \


### PR DESCRIPTION
## Problem

Generic `background_unavailable` responses on Windows and Linux recommended `bring_to_front` before a foreground retry. That turns a one-action escalation into persistent activation and encourages an unnecessary tool call.

## Change

- make the primary remediation `Retry this action with delivery_mode:"foreground".`
- cover both Windows refusal builders and every Linux refusal reason
- reserve `bring_to_front` guidance for known focus-proxy workflows
- align MCP descriptions and platform docs, including the current best-effort Windows restore timing

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p cua-driver-core -p platform-windows -p platform-linux`
- `cargo test -p cua-driver --test schema_consistency_test`
- `python3 .github/scripts/tests/test_cua_driver_release_wiring.py`

The platform-specific refusal tests are `cfg`-gated on this macOS host and will run in the Windows and Linux CI jobs.

Closes #2617