### PR TITLE
feat(cua-driver): expose element AX actions in structured elements

### DIFF
--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/get_window_state.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/get_window_state.rs
@@ -33,7 +33,10 @@ fn def() -> &'static ToolDef {
             PREFERRED CONSUMERS read `structuredContent.elements` (one entry per \
             indexed row with `element_index`, `role`, `label`, `value` (the \
             element's text/AXValue when present — use it to verify what a field \
-            holds), `frame: {x,y,w,h}`, `parent_index`, `depth`). The markdown \
+            holds), `actions` (the AX actions this element exposes, e.g. \
+            AXPress/AXShowMenu — pass one of these to `perform_action` rather \
+            than guessing a name; omitted for non-actionable rows), \
+            `frame: {x,y,w,h}`, `parent_index`, `depth`). The markdown \
             `tree_markdown` stays available \
             and unchanged in shape for existing text-parsing callers — but new \
             fields will only be added to the structured side.\n\n\
@@ -471,6 +474,15 @@ pub(crate) fn build_elements_array_with_token(
             if let Some(parent) = node.parent_element_index {
                 entry["parent_index"] = serde_json::json!(parent);
             }
+            // The AX actions this element actually exposes (AXPress, AXShowMenu,
+            // AXIncrement, …). The walk already collects them; without emitting
+            // them a caller has to guess an action name for `perform_action`,
+            // and a wrong guess is indistinguishable from an element that
+            // simply refused. Omitted when empty so rows for non-actionable
+            // nodes stay small.
+            if !node.actions.is_empty() {
+                entry["actions"] = serde_json::json!(node.actions);
+            }
             Some(entry)
         })
         .collect()
@@ -736,6 +748,33 @@ mod tests {
     /// Surface 6: every element entry must carry a non-empty
     /// `element_token` alongside its integer `element_index`. The
     /// integer field stays unchanged — the token is purely additive.
+    #[test]
+    fn build_elements_array_emits_exposed_actions() {
+        let reg = cua_driver_core::element_token::global();
+        let pid = 0x6abc_0002_i32;
+        let sid = reg.register_snapshot(pid, /* window_id = */ 11, 2);
+        let mut pressable = node(Some(0), "AXButton", Some("Go"), 1, None, None);
+        pressable.actions = vec!["AXPress".to_string(), "AXShowMenu".to_string()];
+        let inert = node(Some(1), "AXStaticText", Some("Label"), 1, None, None);
+
+        let entries = build_elements_array_with_token(&[pressable, inert], sid);
+        assert_eq!(entries.len(), 2);
+
+        let actions = entries[0]
+            .get("actions")
+            .and_then(|v| v.as_array())
+            .expect("an actionable element must expose its AX actions");
+        let names: Vec<&str> = actions.iter().filter_map(|v| v.as_str()).collect();
+        assert_eq!(names, vec!["AXPress", "AXShowMenu"]);
+
+        // Rows for non-actionable nodes stay small: the key is omitted rather
+        // than emitted as an empty array.
+        assert!(
+            entries[1].get("actions").is_none(),
+            "element with no AX actions must not carry an empty actions key"
+        );
+    }
+
     #[test]
     fn build_elements_array_with_token_emits_element_token_per_row() {
         let reg = cua_driver_core::element_token::global();


### PR DESCRIPTION
## Summary

`get_window_state` already collects each element's exposed AX actions. `AXNode.actions` is populated during the walk (`ax/tree.rs`) and rendered into `tree_markdown`:

```text
INDENT- [N] AXRole "Title" [value="..." actions=[...]]
```

The structured `elements` array never carried them. A caller reading `structuredContent` therefore cannot tell which action a given element supports, and has to guess a name for `perform_action` — where a wrong guess is indistinguishable from an element that legitimately refused.

## This is the same gap that was already closed for `value`

The comment above the `value` field in `build_elements_array_with_token` states the problem and the fix:

> the value is shadowed and invisible to a caller reading the structured side — it only showed up in `tree_markdown`, forcing a markdown grep to verify what landed. Emit it explicitly so the verify-then-escalate loop can read the typed text structurally.

`actions` has exactly that shape today: present in the markdown, absent from the structured side, forcing a markdown grep for something the walk already knows.

It also matches what the tool description already promises about where new information goes:

> new fields will only be added to the structured side.

## Change

```diff
  if let Some(parent) = node.parent_element_index {
      entry["parent_index"] = serde_json::json!(parent);
  }
+ if !node.actions.is_empty() {
+     entry["actions"] = serde_json::json!(node.actions);
+ }
```

Before / after for one row:

```json
// before
{"element_index": 4, "element_token": "s0a1b:4", "role": "AXButton",
 "label": "Send", "depth": 3, "frame": {...}}

// after
{"element_index": 4, "element_token": "s0a1b:4", "role": "AXButton",
 "label": "Send", "depth": 3, "frame": {...},
 "actions": ["AXPress", "AXShowMenu"]}
```

Additive only — no existing field changes shape. The key is omitted when an element exposes no actions, so rows for inert nodes (`AXStaticText` and friends) do not grow.

## Platform scope

macOS only. The Linux (AT-SPI) and Windows (UIA) element builders do not collect an equivalent action list today, so there is nothing to emit there yet — the field is optional per platform rather than a new cross-platform contract. If it's preferred to land this as a cross-platform field, I'm happy to look at what AT-SPI / UIA expose and extend it in a follow-up.

## Test

- `cargo test -p platform-macos` — 184 passed, 0 failed
- `cargo fmt -p platform-macos -- --check` — clean
- `cua-contract-gen all --check` — generated manifest already up to date

New test asserts both directions: an actionable element carries its action list, and an element with no actions omits the key rather than emitting an empty array.

## Note

Independent of #2608 and #2621. Also split out of #2210, which is now a tracking draft.
