### PR TITLE
chore: delegate cua-driver code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,10 +4,34 @@
 /release-please-config.json @f-trycua
 
 # Core products and SDKs.
-/libs/cua-driver/ @f-trycua
+/libs/cua-driver/ @f-trycua @injaneity
 /libs/lume/ @f-trycua
 /libs/python/ @ddupont808
 /libs/cua-bench/ @ddupont808
+
+# Cua Driver documentation and driver-only release/CI automation.
+/docs/content/docs/reference/cua-driver/ @f-trycua @injaneity
+/scripts/docs-generators/cua-driver.ts @f-trycua @injaneity
+/.github/release-notes/cua-driver-rs.md @f-trycua @injaneity
+/.github/scripts/sync_driver_release_docs.py @f-trycua @injaneity
+/.github/scripts/verify_cua_driver_release_archives.py @f-trycua @injaneity
+/.github/scripts/tests/test_cua_driver_release_wiring.py @f-trycua @injaneity
+/.github/scripts/tests/test_sync_driver_release_docs.py @f-trycua @injaneity
+/.github/scripts/tests/test_verify_cua_driver_release_archives.py @f-trycua @injaneity
+/.github/workflows/cd-cua-driver-docs.yml @f-trycua @injaneity
+/.github/workflows/cd-py-cua-driver.yml @f-trycua @injaneity
+/.github/workflows/cd-rust-cua-driver.yml @f-trycua @injaneity
+/.github/workflows/ci-cua-driver-contract-clients.yml @f-trycua @injaneity
+/.github/workflows/ci-cua-driver-installer-compat.yml @f-trycua @injaneity
+/.github/workflows/ci-distro-compat-cua-driver.yml @f-trycua @injaneity
+/.github/workflows/ci-rust-format.yml @f-trycua @injaneity
+/.github/workflows/ci-rust-linux.yml @f-trycua @injaneity
+/.github/workflows/ci-rust-windows.yml @f-trycua @injaneity
+/.github/workflows/clawhub-cua-driver.yml @f-trycua @injaneity
+/.github/workflows/e2e-rust-linux-wayland.yml @f-trycua @injaneity
+/.github/workflows/e2e-rust-linux.yml @f-trycua @injaneity
+/.github/workflows/e2e-rust-standalone-browsers.yml @f-trycua @injaneity
+/.github/workflows/e2e-rust-windows.yml @f-trycua @injaneity
 
 # Platform infrastructure.
 /libs/fleet/ @r33drichards


### PR DESCRIPTION
## What changed

- add `@injaneity` alongside `@f-trycua` as a direct CODEOWNER for `libs/cua-driver/`
- extend the same ownership to Cua Driver documentation and driver-only release/CI automation
- keep shared repository policy and shared release configuration under their existing owners

## Why

`@injaneity` already has direct write access to `trycua/cua`, but was not a CODEOWNER for Cua Driver. This lets either designated maintainer satisfy the required CODEOWNER review without making `@injaneity` an organization member or expanding access to other private/internal repositories.

PRs that also touch another CODEOWNED component continue to require that component’s owner.

## Validation

- `git diff --check`
- verified every added CODEOWNERS path exists on current `origin/main`
- verified `@injaneity` has repository role `write` on `trycua/cua` and is not an organization member