### PR TITLE
chore(release): resolve contributor attribution

### DIFF
--- a/.github/release-attribution-config.json
+++ b/.github/release-attribution-config.json
@@ -22,6 +22,7 @@
     "f@trycua.com": "f-trycua",
     "i@jyunko.cn": "HsiangNianian",
     "klymenko@adobe.com": "pavelklymenko",
+    "m.fuechtenkoetter@posteo.de": "ai-ag2026",
     "robert@trycua.com": "enchanted-koala",
     "sarinajin.li@gmail.com": "sarinali",
     "zane.chee.2023@scis.smu.edu.sg": "injaneity",


### PR DESCRIPTION
## Summary

- map the contributor email recorded on #2573 to the verified GitHub identity `@ai-ag2026`
- unblock the trusted Release Please attribution check for Cua Driver 0.13.0
- preserve the contributor credit already present in the merged commit

Salvaged from #2573

## Verification

- `uv run --with pytest pytest .github/scripts/tests/test_release_attribution.py .github/scripts/tests/test_pr_attribution.py` (28 passed)
- `python3 -m json.tool .github/release-attribution-config.json`
- `git diff --check`

No product behavior or release version changes.