### PR TITLE
docs(cua-driver): align 0.13.0 install and upgrade guidance

### DIFF
--- a/docs/content/docs/how-to-guides/driver/install.mdx
+++ b/docs/content/docs/how-to-guides/driver/install.mdx
@@ -59,7 +59,15 @@ sudo apt install libxi6 at-spi2-core
 
 The installer downloads the binary to `~/.cua-driver/packages/releases/`, points `~/.cua-driver/packages/current` at that release, and creates the `~/.local/bin/cua-driver` symlink. It does not use sudo.
 
-X11 is fully supported. Native Wayland input and capture remain opt-in with `CUA_DRIVER_RS_ENABLE_WAYLAND=1` and are still maturing; Wayland sessions use XWayland by default. After installation, run `cua-driver doctor` to check distro-specific requirements such as the AT-SPI bus and the display server.
+X11 is fully supported. Native Wayland remains opt-in with
+`CUA_DRIVER_RS_ENABLE_WAYLAND=1` and has compositor-specific limits. Sway is
+supported with limits, GNOME requires the maintained WinRects helper, and KDE
+remains experimental. Without the opt-in, Wayland sessions use XWayland routes
+where the target exposes a real X11 window. See
+[Platform support](/reference/cua-driver/platform-support#linux-window-systems)
+for the exact accepted surfaces. After installation, run `cua-driver doctor`
+to check distro-specific requirements such as the AT-SPI bus and display
+server.
 
   </Tab>
 </Tabs>
@@ -68,14 +76,14 @@ X11 is fully supported. Native Wayland input and capture remain opt-in with `CUA
 
 ```bash
 cua-driver --version
-# cua-driver 0.7.0
+# cua-driver 0.13.0
 ```
 
 For a full environment and install report:
 
 ```bash
 cua-driver doctor
-# [ok  ] binary: cua-driver 0.7.0 (aarch64-macos)
+# [ok  ] binary: cua-driver 0.13.0 (aarch64-macos)
 # [ok  ] install dir: /Users/you/.local/bin/cua-driver
 # [ok  ] home dir: /Users/you/.cua-driver (3 release dirs cached)
 # ...

--- a/docs/content/docs/how-to-guides/driver/update.mdx
+++ b/docs/content/docs/how-to-guides/driver/update.mdx
@@ -42,18 +42,18 @@ cua-driver check-update
 When you're behind:
 
 ```
-Current: 0.6.9
-Latest:  0.7.0
+Current: 0.12.6
+Latest:  0.13.0
 
 Update available. Run `cua-driver update --apply` to install.
-Release notes: https://github.com/trycua/cua/releases/tag/cua-driver-rs-v0.7.0
+Release notes: https://github.com/trycua/cua/releases/tag/cua-driver-rs-v0.13.0
 ```
 
 When you're current:
 
 ```
-Current: 0.7.0
-Latest:  0.7.0
+Current: 0.13.0
+Latest:  0.13.0
 
 You're on the latest release.
 ```
@@ -73,11 +73,11 @@ cua-driver update --apply
 Output:
 
 ```
-Current version: 0.6.9
+Current version: 0.12.6
 Checking for updates…
-New version available: 0.7.0
-Downloading and installing Cua Driver 0.7.0…
-Installed Cua Driver 0.7.0.
+New version available: 0.13.0
+Downloading and installing Cua Driver 0.13.0…
+Installed Cua Driver 0.13.0.
 ```
 
 `update --apply` calls the canonical installer script, the same one-line installer used for the first install.
@@ -98,14 +98,14 @@ cua-driver check-update --json
 
 ```json
 {
-  "current_version": "0.6.9",
-  "latest_version": "0.7.0",
+  "current_version": "0.12.6",
+  "latest_version": "0.13.0",
   "update_available": true,
   "source": "github_releases",
   "checked_at": "2026-07-01T14:30:00Z",
   "cache_hit": false,
   "install_command": "curl -fsSL https://cua.ai/driver/install.sh | bash",
-  "release_notes_url": "https://github.com/trycua/cua/releases/tag/cua-driver-rs-v0.7.0",
+  "release_notes_url": "https://github.com/trycua/cua/releases/tag/cua-driver-rs-v0.13.0",
   "error": null
 }
 ```
@@ -128,9 +128,9 @@ The same payload is available over MCP through the `check_for_update` tool. MCP 
 Every `cua-driver mcp`, `serve`, and `doctor` invocation starts a background version check. If it finds a newer release, Cua Driver prints a two-line banner to stderr:
 
 ```
-✨ cua-driver v0.7.0 is available (you have v0.6.9).
+✨ cua-driver v0.13.0 is available (you have v0.12.6).
    Update with: cua-driver update
-   Release notes: https://github.com/trycua/cua/releases/tag/cua-driver-rs-v0.7.0
+   Release notes: https://github.com/trycua/cua/releases/tag/cua-driver-rs-v0.13.0
 ```
 
 The check uses a 20-hour cache and never blocks startup. One-shot commands such as `--version`, `call`, and `list-tools` skip it so piped output remains clean.


### PR DESCRIPTION
## Summary

- update the install and update examples for Cua Driver 0.13.0
- replace the stale generic Wayland wording with the certified Sway, GNOME, KDE, and XWayland boundaries
- link installation guidance to the detailed platform-support reference

## Verification

- `npm run docs:check-hygiene`
- `npm run docs:check-links`
- `git diff --check`

This is documentation-only and does not change product behavior or release metadata.