### PR TITLE
chore(release): resolve local contributor identity

### DIFF
--- a/.github/release-attribution-config.json
+++ b/.github/release-attribution-config.json
@@ -23,6 +23,7 @@
     "i@jyunko.cn": "HsiangNianian",
     "klymenko@adobe.com": "pavelklymenko",
     "m.fuechtenkoetter@posteo.de": "ai-ag2026",
+    "manfred@ubuntu26.04-vm": "ai-ag2026",
     "robert@trycua.com": "enchanted-koala",
     "sarinajin.li@gmail.com": "sarinali",
     "zane.chee.2023@scis.smu.edu.sg": "injaneity",


### PR DESCRIPTION
## Summary

- map the machine-local commit email recorded on #2624 to the verified GitHub identity `@ai-ag2026`
- unblock trusted release attribution for Cua Driver 0.13.0
- preserve the contributor credit already present in the merged browser commit

Salvaged from #2624

## Verification

- `uv run --with pytest pytest .github/scripts/tests/test_release_attribution.py .github/scripts/tests/test_pr_attribution.py` (28 passed)
- `python3 -m json.tool .github/release-attribution-config.json`
- `git diff --check`

No product behavior or release version changes.