### PR TITLE
fix(cua-driver): preserve Windows autostart path quoting

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -268,6 +268,27 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertIn('$CursorThemeRequiredFrom = [version]"0.12.7"', powershell)
         self.assertIn("[version]$version -ge $CursorThemeRequiredFrom", powershell)
 
+    def test_windows_installer_elevates_autostart_binary_without_command_string(
+        self,
+    ) -> None:
+        powershell = self.read("libs/cua-driver/scripts/install.ps1")
+        block = powershell.split(
+            "function Register-CuaDriverAutostart {", maxsplit=1
+        )[1].split(
+            "# ---------- Concurrent-install lockfile", maxsplit=1
+        )[0]
+
+        self.assertIn(
+            "Start-Process -FilePath $InstalledBinary",
+            block,
+        )
+        self.assertIn(
+            '-ArgumentList @("autostart", "enable")',
+            block,
+        )
+        self.assertNotIn("$elevCmd", block)
+        self.assertNotIn("Read-Host", block)
+
     def test_local_installer_does_not_clean_release_or_legacy_homes(self) -> None:
         installer = self.read("libs/cua-driver/scripts/_install-local-rust.sh")
 

--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -622,10 +622,14 @@ function Register-CuaDriverAutostart {
     Write-Host "The task itself runs silently at every logon afterwards." -ForegroundColor Yellow
     Write-Host ""
 
-    $elevCmd = "& `"$InstalledBinary`" autostart enable; `$ec = `$LASTEXITCODE; if (`$ec -ne 0) { Read-Host 'cua-driver autostart enable failed; press Enter to close' }; exit `$ec"
     try {
-        $proc = Start-Process -FilePath "powershell.exe" `
-            -ArgumentList "-NoProfile","-ExecutionPolicy","Bypass","-Command",$elevCmd `
+        # Elevate the installed executable directly. Passing a quoted command
+        # string through Start-Process -ArgumentList loses the executable's
+        # outer quotes when PowerShell joins the arguments, so profile paths
+        # containing spaces are split before the elevated shell can invoke
+        # the binary.
+        $proc = Start-Process -FilePath $InstalledBinary `
+            -ArgumentList @("autostart", "enable") `
             -Verb RunAs -Wait -PassThru -ErrorAction Stop
         if ($proc.ExitCode -ne 0) {
             throw "cua-driver autostart enable failed in elevated session (exit $($proc.ExitCode))"


### PR DESCRIPTION
## Summary

- elevate the installed `cua-driver.exe` directly when registering Windows autostart
- pass `autostart enable` as a typed argument list instead of a nested PowerShell command string
- remove the interactive failure `Read-Host` that can block non-interactive installers
- add release-wiring coverage for the direct executable boundary and the absence of the blocking prompt

## Root cause

`Start-Process -ArgumentList` joins its values into a command line. The nested `powershell.exe -Command` route lost the executable path's outer quotes, so profiles such as `C:\Users\First Last` were split before the elevated shell invoked the driver.

## Validation

- `python3 .github/scripts/tests/test_cua_driver_release_wiring.py` (34 passed)
- `git diff --check`
- Azure Windows 11 PowerShell validation at exact head SHA `850dd7f80d71345f287eb4709df0395591d2e699`
- exact `install.ps1` parsed with zero PowerShell AST errors
- extracted `Register-CuaDriverAutostart` passed the spaced `FilePath` and typed `autostart`, `enable` argument list across its mocked `RunAs` boundary
- a real compiled probe executable launched from `%TEMP%\Cua Driver 2564\probe.exe` and received exactly `autostart|enable`

Fixes #2564