### PR TITLE
fix(cua-driver): redial Chrome after native consent

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/prepare.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/prepare.rs
@@ -49,6 +49,21 @@ where
     }
 }
 
+async fn retry_claim_after_accepted_consent<T, Retry>(
+    initial: anyhow::Result<T>,
+    accepted_consent: bool,
+    retry: Retry,
+) -> (anyhow::Result<T>, Option<anyhow::Error>)
+where
+    Retry: Future<Output = anyhow::Result<T>>,
+{
+    match initial {
+        Ok(value) => (Ok(value), None),
+        Err(initial_error) if accepted_consent => (retry.await, Some(initial_error)),
+        Err(error) => (Err(error), None),
+    }
+}
+
 fn with_setup_side_effects(
     mut error: BrowserRefusal,
     setup: &ExistingProfileSetupOutcome,
@@ -1108,7 +1123,19 @@ impl BrowserEngine {
                 }
             }
         };
-        if let Err(_error) = claimed {
+        // Chrome on Windows can reject the WebSocket handshake that was
+        // pending while its native remote-debugging consent prompt was open.
+        // After an explicit acceptance, make one fresh, bounded dial to the
+        // same attested endpoint under the same grant. The driver does not
+        // request consent again or broaden the approved target; the browser
+        // still owns any transport-level UI for the fresh connection.
+        let (claimed, initial_claim_error) = retry_claim_after_accepted_consent(
+            claimed,
+            displayed_consent_prompt,
+            self.pool.claim_existing(&endpoint.ws_url, grant.generation),
+        )
+        .await;
+        if let Err(_final_claim_error) = claimed {
             self.revoke_existing_profile_grant(
                 &request.session,
                 request.transport_session.as_deref(),
@@ -1119,7 +1146,11 @@ impl BrowserEngine {
                 refusal(
                     BrowserRefusalCode::BrowserReconnectExhausted,
                     "the approved browser socket could not be claimed",
-                ),
+                )
+                .with_detail(serde_json::json!({
+                    "retried_after_consent": initial_claim_error.is_some(),
+                    "fresh_claim_failed": initial_claim_error.is_some(),
+                })),
                 &setup,
                 displayed_consent_prompt,
             );
@@ -1221,6 +1252,75 @@ mod tests {
                 .expect("accepted consent should resume the existing claim");
         assert_eq!(result.unwrap(), 9);
         assert!(displayed);
+    }
+
+    #[tokio::test]
+    async fn accepted_consent_retries_one_failed_claim_with_a_fresh_dial() {
+        let (result, initial_error) = retry_claim_after_accepted_consent(
+            Err(anyhow::anyhow!("pre-consent handshake rejected")),
+            true,
+            async { Ok::<_, anyhow::Error>(11_u8) },
+        )
+        .await;
+        assert_eq!(result.unwrap(), 11);
+        assert_eq!(
+            initial_error.expect("initial error").to_string(),
+            "pre-consent handshake rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn claim_failure_without_accepted_consent_is_not_retried() {
+        let retry_polled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let retry_marker = retry_polled.clone();
+        let (result, initial_error) = retry_claim_after_accepted_consent(
+            Err::<u8, _>(anyhow::anyhow!("connection refused")),
+            false,
+            async move {
+                retry_marker.store(true, std::sync::atomic::Ordering::SeqCst);
+                Ok::<_, anyhow::Error>(12_u8)
+            },
+        )
+        .await;
+        assert_eq!(result.unwrap_err().to_string(), "connection refused");
+        assert!(initial_error.is_none());
+        assert!(!retry_polled.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn successful_claim_does_not_retry_after_accepted_consent() {
+        let retry_polled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let retry_marker = retry_polled.clone();
+        let (result, initial_error) =
+            retry_claim_after_accepted_consent(Ok::<_, anyhow::Error>(13_u8), true, async move {
+                retry_marker.store(true, std::sync::atomic::Ordering::SeqCst);
+                Ok::<_, anyhow::Error>(14_u8)
+            })
+            .await;
+        assert_eq!(result.unwrap(), 13);
+        assert!(initial_error.is_none());
+        assert!(!retry_polled.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn accepted_consent_limits_a_failed_fresh_dial_to_one_retry() {
+        let attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let attempt_counter = attempts.clone();
+        let (result, initial_error) = retry_claim_after_accepted_consent(
+            Err::<u8, _>(anyhow::anyhow!("pre-consent handshake rejected")),
+            true,
+            async move {
+                attempt_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Err::<u8, _>(anyhow::anyhow!("fresh handshake rejected"))
+            },
+        )
+        .await;
+        assert_eq!(result.unwrap_err().to_string(), "fresh handshake rejected");
+        assert_eq!(
+            initial_error.expect("initial error").to_string(),
+            "pre-consent handshake rejected"
+        );
+        assert_eq!(attempts.load(std::sync::atomic::Ordering::SeqCst), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- retry an existing-profile CDP claim once after explicit native consent when the pre-consent handshake fails
- keep the retry bound to the same attested endpoint and grant generation
- preserve fail-closed behavior when no consent was accepted
- add focused tests for success, no-retry, and bounded retry exhaustion

## Why

Chrome on Windows can reject a WebSocket handshake that was already pending while its native remote-debugging consent prompt was open. Edge accepts the pending handshake, so the shared path previously failed only for Chrome after the user allowed access.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p cua-driver-core`
- `cargo test -p cua-driver-core`
- exact-SHA standalone Chrome and Edge workflow will be attached before merge
