### PR TITLE
fix(lume): distinguish running VMs from resize recovery

### DIFF
--- a/libs/lume/src/Errors/Errors.swift
+++ b/libs/lume/src/Errors/Errors.swift
@@ -253,7 +253,7 @@ enum DiskResizeError: Error, LocalizedError {
     var errorDescription: String? {
         switch self {
         case .vmRunning(let name):
-            return "Cannot resize the disk of \(name): the VM is running. Stop it first."
+            return "Cannot modify \(name): the VM is running. Stop it first."
         case .resizeInProgress(let name):
             return
                 "A previous disk resize of \(name) did not finish. Re-run the same command to roll it back and restore the disk from its backup."

--- a/libs/lume/src/LumeController.swift
+++ b/libs/lume/src/LumeController.swift
@@ -279,6 +279,14 @@ final class LumeController {
         }
     }
 
+    /// Classifies resize-guard contention using the transaction marker as the
+    /// authoritative signal. A running VM intentionally holds the guard for
+    /// its lifetime, so lock contention without a marker is not an interrupted
+    /// resize and must not suggest rollback.
+    private func resizeGuardContentionError(_ vmDir: VMDirectory, name: String) -> DiskResizeError {
+        vmDir.hasResizeMarker() ? .resizeInProgress(name) : .vmRunning(name)
+    }
+
     @MainActor
     public func clone(
         name: String, newName: String, sourceLocation: String? = nil, destLocation: String? = nil
@@ -301,7 +309,7 @@ final class LumeController {
             // Check if source VM is still being provisioned
             let sourceVmDir = try home.getVMDirectory(normalizedName, storage: actualSourceLocation)
             guard let resizeGuard = try sourceVmDir.tryAcquireResizeGuard(exclusive: false) else {
-                throw DiskResizeError.resizeInProgress(normalizedName)
+                throw resizeGuardContentionError(sourceVmDir, name: normalizedName)
             }
             defer {
                 flock(resizeGuard.fileDescriptor, LOCK_UN)
@@ -313,7 +321,7 @@ final class LumeController {
             let destinationVmDir = try home.getVMDirectory(normalizedNewName, storage: destLocation)
             guard let destinationGuard = try destinationVmDir.tryAcquireResizeGuard(exclusive: true)
             else {
-                throw DiskResizeError.resizeInProgress(normalizedNewName)
+                throw resizeGuardContentionError(destinationVmDir, name: normalizedNewName)
             }
             defer {
                 flock(destinationGuard.fileDescriptor, LOCK_UN)
@@ -909,7 +917,7 @@ final class LumeController {
             }
 
             guard let resizeGuard = try vmDir.tryAcquireResizeGuard(exclusive: true) else {
-                throw DiskResizeError.resizeInProgress(normalizedName)
+                throw resizeGuardContentionError(vmDir, name: normalizedName)
             }
             defer {
                 flock(resizeGuard.fileDescriptor, LOCK_UN)
@@ -1320,7 +1328,7 @@ final class LumeController {
             // Get the VM directory
             let vmDir = try home.getVMDirectory(name, storage: actualLocation)
             guard let resizeGuard = try vmDir.tryAcquireResizeGuard(exclusive: false) else {
-                throw DiskResizeError.resizeInProgress(name)
+                throw resizeGuardContentionError(vmDir, name: name)
             }
             defer {
                 flock(resizeGuard.fileDescriptor, LOCK_UN)

--- a/libs/lume/tests/LumeControllerTests.swift
+++ b/libs/lume/tests/LumeControllerTests.swift
@@ -165,6 +165,83 @@ func testClonePreservesPairedBootPolicyState() throws {
 }
 
 @MainActor
+@Test("delete classifies resize guard contention using the transaction marker")
+func testDeleteClassifiesResizeGuardContentionWithoutMarkerAsRunning() async throws {
+    let tempConfigDir = try createTempDirectory()
+    let tempHomeDir = try createTempDirectory()
+
+    defer {
+        try? FileManager.default.removeItem(at: tempConfigDir)
+        try? FileManager.default.removeItem(at: tempHomeDir)
+    }
+
+    let previousXDGConfigHome = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"]
+    setenv("XDG_CONFIG_HOME", tempConfigDir.path, 1)
+    defer {
+        if let previousXDGConfigHome {
+            setenv("XDG_CONFIG_HOME", previousXDGConfigHome, 1)
+        } else {
+            unsetenv("XDG_CONFIG_HOME")
+        }
+    }
+
+    let settingsManager = SettingsManager(fileManager: .default)
+    try settingsManager.setHomeDirectory(path: tempHomeDir.path)
+    let home = Home(settingsManager: settingsManager, fileManager: .default)
+    let controller = LumeController(home: home, vmFactory: TestVMFactory())
+    let vmDir = try home.getVMDirectory("running-guard")
+    try FileManager.default.createDirectory(
+        at: vmDir.dir.url,
+        withIntermediateDirectories: true
+    )
+    try Data(repeating: 0, count: 1024).write(to: vmDir.diskPath.url)
+    try Data(repeating: 0, count: 1024).write(to: vmDir.nvramPath.url)
+    try vmDir.saveConfig(
+        VMConfig(
+            os: "macOS",
+            cpuCount: 1,
+            memorySize: 1024,
+            diskSize: 1024,
+            display: "1024x768"
+        ))
+
+    let acquired = try vmDir.tryAcquireResizeGuard(exclusive: false)
+    let resizeGuard = try #require(acquired)
+    defer {
+        flock(resizeGuard.fileDescriptor, LOCK_UN)
+        try? resizeGuard.close()
+    }
+
+    do {
+        try await controller.delete(name: vmDir.name)
+        Issue.record("Expected delete to reject a VM holding the resize guard")
+    } catch DiskResizeError.vmRunning(let name) {
+        #expect(name == vmDir.name)
+    } catch {
+        Issue.record("Expected vmRunning but got \(error)")
+    }
+
+    try vmDir.saveResizeMarker(
+        ResizeMarker(
+            version: ResizeMarker.currentVersion,
+            phase: 1,
+            oldSizeBytes: 1024,
+            newSizeBytes: 2048,
+            backupDiskPath: vmDir.diskBackupPath.path,
+            startedAt: 0
+        ))
+
+    do {
+        try await controller.delete(name: vmDir.name)
+        Issue.record("Expected delete to reject an armed resize transaction")
+    } catch DiskResizeError.resizeInProgress(let name) {
+        #expect(name == vmDir.name)
+    } catch {
+        Issue.record("Expected resizeInProgress but got \(error)")
+    }
+}
+
+@MainActor
 @Test("run rejects primary and duplicate additional disk aliases")
 func testRunRejectsAdditionalDiskAliases() async throws {
     let tempConfigDir = try createTempDirectory()


### PR DESCRIPTION
## Summary

- classify resize-guard contention using the resize transaction marker as the authoritative signal
- report a running VM when the guard is busy without a marker instead of prescribing an impossible rollback
- keep the interrupted-resize recovery error when a transaction marker is present
- use operation-neutral wording for the existing `vmRunning` error because delete, clone, and push now use it

## Root cause

A running VM intentionally holds the resize guard for its lifetime. Controller operations treated every failed guard acquisition as an interrupted resize, even though the separate resize marker is what records an armed transaction. This sent users who had never resized the VM into a rollback loop.

## Validation

- exact head SHA `56944cffcdeb0756391797f4a58b787cb8ca64cf`
- source-built Lume 0.4.0 binary SHA-256 `1a6c028a01ad397694f61f71175162f5d651d84653358e7a1de6b432facd9b21`
- local running macOS 26 VM: exact-head `lume delete <running-vm> --force` refused with `Cannot modify <name>: the VM is running. Stop it first.` and exit 1
- VM remained running and SSH-available after the refusal; Cua Driver captured before/after Screen Sharing state and ended its isolated proof session
- `swift test --filter testDeleteClassifiesResizeGuardContentionWithoutMarkerAsRunning` (1 passed; covers both marker states)
- `swift test` (74 passed)
- `git diff --check`

Fixes #2491