### PR TITLE
fix(cua-driver): refuse disabled macOS AX actions

### DIFF
--- a/libs/cua-driver/rust/crates/platform-macos/src/input/ax_actions.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/ax_actions.rs
@@ -2,9 +2,30 @@
 
 use crate::ax::bindings::*;
 
+fn ensure_ax_enabled(enabled: Option<bool>, action: &str) -> anyhow::Result<()> {
+    if enabled == Some(false) {
+        anyhow::bail!(
+            "refusing {action}: the target reports AXEnabled=false. \
+             Retry this action with delivery_mode:\"foreground\" or call bring_to_front first"
+        );
+    }
+    Ok(())
+}
+
+/// Refuse AX actions that macOS reports as disabled.
+///
+/// This must be checked immediately before dispatch rather than trusting the
+/// cached snapshot value: foreground delivery can make a menu item live after
+/// it was resolved, while backgrounding can disable it in the other direction.
+pub fn ensure_ax_action_enabled(element_ptr: usize, action: &str) -> anyhow::Result<()> {
+    let enabled = unsafe { copy_bool_attr(element_ptr as AXUIElementRef, "AXEnabled") };
+    ensure_ax_enabled(enabled, action)
+}
+
 /// Perform an AX action on a cached element.
 pub fn perform_ax_action(element_ptr: usize, action: &str) -> anyhow::Result<()> {
     let ax_action = map_action(action);
+    ensure_ax_action_enabled(element_ptr, ax_action)?;
     let err = unsafe { perform_action(element_ptr as AXUIElementRef, ax_action) };
 
     if err == kAXErrorSuccess {
@@ -23,6 +44,26 @@ fn map_action(action: &str) -> &'static str {
         "cancel" => "AXCancel",
         "open" => "AXOpen",
         _ => "AXPress",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_elements_are_refused_before_dispatch() {
+        let error = ensure_ax_enabled(Some(false), "AXPick").unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("AXEnabled=false"));
+        assert!(message.contains("delivery_mode:\"foreground\""));
+        assert!(message.contains("bring_to_front"));
+    }
+
+    #[test]
+    fn enabled_or_unreported_state_is_allowed() {
+        assert!(ensure_ax_enabled(Some(true), "AXPress").is_ok());
+        assert!(ensure_ax_enabled(None, "AXPress").is_ok());
     }
 }
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/click.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/click.rs
@@ -969,6 +969,12 @@ fn perform_ax_click(
     let ax_action = map_action(action_str);
     let element = element_ptr as AXUIElementRef;
 
+    // Check the live value immediately before dispatch. Foreground assist can
+    // enable menu items that were disabled in the cached snapshot, while a
+    // background transition can disable them after that snapshot. macOS may
+    // otherwise return success for a disabled action that did nothing.
+    crate::input::ax_actions::ensure_ax_action_enabled(element_ptr, ax_action)?;
+
     // Capture advertised actions BEFORE dispatching so we can detect silent no-ops
     // (AX returns success even when the element doesn't advertise the action).
     let advertised = unsafe { copy_action_names(element) };


### PR DESCRIPTION
## Summary

- read the target's live `AXEnabled` value immediately before dispatching a macOS AX action
- refuse `AXEnabled=false` actions with explicit foreground-escalation guidance instead of trusting macOS's hollow success result
- keep unreported `AXEnabled` values backward-compatible
- cover disabled, enabled, and unreported states with focused unit tests

## Why the check is live

The cached snapshot can become stale in either direction. Foreground assist may enable a control after resolution, while backgrounding may disable it. The guard therefore runs inside the foreground-assist closure at the last safe point before `AXUIElementPerformAction`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p platform-macos ax_actions::tests --lib --locked` (2 passed)
- `git diff --check`
- exact-SHA macOS 26.5.2 certification in a disposable Lume VM:
  - source/build SHA `ad8775a2b51d2d8cc422707bd541d0e19c144ec6`
  - source-built binary SHA-256 `b386963d6e8b6cbd1516839d61cb3384299f53426c5a7bdeda8e6da89ce807dc`
  - installed in the pre-authorized `com.trycua.driver.local` test bundle and re-signed with the VM-local certificate
  - TextEdit `Window > Zoom` reported `AXEnabled=false` while backgrounded
  - the AX click returned the explicit refusal containing `AXEnabled=false`
  - before/after window bounds remained identical: `{"height":422.0,"width":656.0,"x":79.0,"y":55.0}`

Fixes #2619
