### PR TITLE
fix(cua-cli): reject unsafe OAuth endpoints

### DIFF
--- a/libs/python/cua-cli/cua_cli/auth/oidc.py
+++ b/libs/python/cua-cli/cua_cli/auth/oidc.py
@@ -6,6 +6,7 @@ from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from urllib.parse import urlsplit
 
 import aiohttp
 from cua_cli.auth.store import OAuthCredentials, load_credentials, save_credentials
@@ -25,6 +26,24 @@ HttpRequest = Callable[[str, str, Mapping[str, str] | None], Awaitable[tuple[int
 Sleep = Callable[[float], Awaitable[None]]
 
 
+def _require_https_url(value: Any) -> str:
+    if not isinstance(value, str):
+        raise OidcError("OIDC issuer returned an unsafe URL.")
+    try:
+        parsed = urlsplit(value)
+    except ValueError as error:
+        raise OidcError("OIDC issuer returned an unsafe URL.") from error
+    if (
+        parsed.scheme != "https"
+        or not parsed.netloc
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+    ):
+        raise OidcError("OIDC issuer returned an unsafe URL.")
+    return value
+
+
 @dataclass(frozen=True)
 class OidcDiscovery:
     """Relevant endpoints published by OIDC discovery."""
@@ -37,10 +56,14 @@ class OidcDiscovery:
     def from_response(cls, value: Mapping[str, Any]) -> "OidcDiscovery":
         try:
             return cls(
-                token_endpoint=str(value["token_endpoint"]),
-                device_authorization_endpoint=str(value["device_authorization_endpoint"]),
+                token_endpoint=_require_https_url(value["token_endpoint"]),
+                device_authorization_endpoint=_require_https_url(
+                    value["device_authorization_endpoint"]
+                ),
                 revocation_endpoint=(
-                    str(value["revocation_endpoint"]) if value.get("revocation_endpoint") else None
+                    _require_https_url(value["revocation_endpoint"])
+                    if value.get("revocation_endpoint")
+                    else None
                 ),
             )
         except (KeyError, TypeError) as error:
@@ -64,9 +87,9 @@ class DeviceCode:
             return cls(
                 device_code=str(value["device_code"]),
                 user_code=str(value["user_code"]),
-                verification_uri=str(value["verification_uri"]),
+                verification_uri=_require_https_url(value["verification_uri"]),
                 verification_uri_complete=(
-                    str(value["verification_uri_complete"])
+                    _require_https_url(value["verification_uri_complete"])
                     if value.get("verification_uri_complete")
                     else None
                 ),

--- a/libs/python/cua-cli/tests/auth/test_oidc.py
+++ b/libs/python/cua-cli/tests/auth/test_oidc.py
@@ -34,6 +34,7 @@ def test_rejects_unsafe_discovery_and_device_verification_urls() -> None:
     }
     for endpoint, unsafe_url in (
         ("token_endpoint", "http://auth.cua.ai/token"),
+        ("token_endpoint", "https://user:pass@auth.cua.ai/token"),
         ("device_authorization_endpoint", "/device/code"),
         ("revocation_endpoint", "javascript:alert(1)"),
     ):

--- a/libs/python/cua-cli/tests/auth/test_oidc.py
+++ b/libs/python/cua-cli/tests/auth/test_oidc.py
@@ -4,7 +4,13 @@ from collections.abc import Mapping
 from datetime import UTC, datetime
 
 import pytest
-from cua_cli.auth.oidc import DEVICE_GRANT_TYPE, OidcClient
+from cua_cli.auth.oidc import (
+    DEVICE_GRANT_TYPE,
+    DeviceCode,
+    OidcClient,
+    OidcDiscovery,
+    OidcError,
+)
 from cua_cli.auth.store import OAuthCredentials
 
 
@@ -18,6 +24,35 @@ class ScriptedRequester:
     ) -> tuple[int, dict]:
         self.calls.append((method, url, form))
         return self.responses.pop(0)
+
+
+def test_rejects_unsafe_discovery_and_device_verification_urls() -> None:
+    discovery = {
+        "token_endpoint": "https://auth.cua.ai/realms/cyclops-cs/protocol/openid-connect/token",
+        "device_authorization_endpoint": "https://auth.cua.ai/realms/cyclops-cs/protocol/openid-connect/device/code",
+        "revocation_endpoint": "https://auth.cua.ai/realms/cyclops-cs/protocol/openid-connect/revoke",
+    }
+    for endpoint, unsafe_url in (
+        ("token_endpoint", "http://auth.cua.ai/token"),
+        ("device_authorization_endpoint", "/device/code"),
+        ("revocation_endpoint", "javascript:alert(1)"),
+    ):
+        with pytest.raises(OidcError):
+            OidcDiscovery.from_response({**discovery, endpoint: unsafe_url})
+
+    device_code = {
+        "device_code": "device-code",
+        "user_code": "ABCD-EFGH",
+        "verification_uri": "https://run.cua.ai/device",
+        "verification_uri_complete": "https://run.cua.ai/device?user_code=ABCD-EFGH",
+        "expires_in": 600,
+    }
+    for field, unsafe_url in (
+        ("verification_uri", "http://run.cua.ai/device"),
+        ("verification_uri_complete", "//run.cua.ai/device?user_code=ABCD-EFGH"),
+    ):
+        with pytest.raises(OidcError):
+            DeviceCode.from_response({**device_code, field: unsafe_url})
 
 
 @pytest.mark.asyncio
@@ -142,3 +177,20 @@ async def test_poll_slow_down_increases_interval() -> None:
     await OidcClient(request=requester, sleep=sleep).poll_for_tokens(discovery, device_code)
 
     assert delays == [8]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error", ["access_denied", "expired_token"])
+async def test_poll_stops_on_terminal_device_authorization_errors(error: str) -> None:
+    requester = ScriptedRequester([(400, {"error": error})])
+    discovery = type(
+        "Discovery",
+        (),
+        {"token_endpoint": "https://auth.cua.ai/realms/cyclops-cs/protocol/openid-connect/token"},
+    )()
+    device_code = type("Device", (), {"device_code": "device", "expires_in": 600, "interval": 3})()
+
+    with pytest.raises(OidcError):
+        await OidcClient(request=requester).poll_for_tokens(discovery, device_code)
+
+    assert len(requester.calls) == 1

--- a/libs/python/cua-cli/tests/commands/test_auth.py
+++ b/libs/python/cua-cli/tests/commands/test_auth.py
@@ -82,3 +82,17 @@ def test_status_does_not_expose_token(capsys, monkeypatch) -> None:
     output = capsys.readouterr().out
     assert "secret-access-token" not in output
     assert "secret-refresh-token" not in output
+
+
+def test_login_does_not_open_browser_without_an_interactive_terminal(monkeypatch) -> None:
+    monkeypatch.setattr(auth, "OidcClient", FakeOidcClient)
+    monkeypatch.setattr(auth, "run_async", run)
+    monkeypatch.setattr(auth, "save_credentials", lambda _credentials: None)
+    monkeypatch.setattr(auth.sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(auth.sys.stdout, "isatty", lambda: False)
+
+    with patch.object(auth.webbrowser, "open") as browser_open:
+        result = auth.cmd_login(argparse.Namespace(no_browser=False))
+
+    assert result == 0
+    browser_open.assert_not_called()


### PR DESCRIPTION
## What
- Reject non-HTTPS, relative, malformed, and credential-bearing URLs from OIDC discovery and device authorization responses.
- Preserve standard RFC 8628 terminal polling behavior and avoid browser launches in noninteractive terminals.

## Validation
- `uv run pytest libs/python/cua-cli/tests/auth/test_oidc.py libs/python/cua-cli/tests/commands/test_auth.py` (10 passed)
- `uv run black --check libs/python/cua-cli`
- `uv run isort --check-only libs/python/cua-cli`
- `uv run ruff check libs/python/cua-cli`
- `uv run pytest libs/python/cua-cli/tests` (131 passed; 26 existing sandbox failures)
- The same broad suite on untouched `origin/main`: 127 passed; the same 26 sandbox failures.

The unrelated sandbox failures expect removed `create` and `_get_provider` interfaces. No production or release actions were performed.