### PR TITLE
fix(lume): prevent SSH promise lifecycle crash

### DIFF
--- a/libs/lume/Package.swift
+++ b/libs/lume/Package.swift
@@ -47,6 +47,7 @@ let package = Package(
             name: "lumeTests",
             dependencies: [
                 "lume",
+                .product(name: "NIOEmbedded", package: "swift-nio"),
                 .product(name: "Testing", package: "swift-testing")
             ],
             path: "tests")

--- a/libs/lume/src/SSH/SSHClient.swift
+++ b/libs/lume/src/SSH/SSHClient.swift
@@ -48,28 +48,39 @@ public actor SSHClient {
         let resultPromise = channel.eventLoop.makePromise(of: SSHResult.self)
         let resultState = CommandResultState(promise: resultPromise)
 
-        // Create the SSH child channel for command execution.
-        // We keep handler access + createChannel on the event loop to avoid
-        // crossing a Sendable boundary with NIOSSHHandler.
-        let childChannelPromise = channel.eventLoop.makePromise(of: Channel.self)
-        let childChannelFuture = channel.pipeline.handler(type: NIOSSHHandler.self).flatMap { sshHandler -> EventLoopFuture<Channel> in
-            sshHandler.createChannel(childChannelPromise) { childChannel, channelType in
-                guard channelType == .session else {
-                    return channel.eventLoop.makeFailedFuture(SSHError.connectionFailed("Invalid channel type"))
-                }
+        // Create the child promise only after locating NIOSSHHandler. If the
+        // connection closes first, flatMap is skipped; a promise created outside
+        // this closure would then be released unfulfilled and SwiftNIO traps in
+        // EventLoopFuture.deinit.
+        let childChannel: Channel
+        do {
+            childChannel = try await Self.makeChildChannelFuture(
+                handlerFuture: channel.pipeline.handler(type: NIOSSHHandler.self),
+                eventLoop: channel.eventLoop
+            ) { sshHandler, childChannelPromise in
+                sshHandler.createChannel(childChannelPromise) { childChannel, channelType in
+                    guard channelType == .session else {
+                        return channel.eventLoop.makeFailedFuture(
+                            SSHError.connectionFailed("Invalid channel type")
+                        )
+                    }
 
-                return childChannel.eventLoop.makeCompletedFuture {
-                    let execHandler = CommandExecHandler(
-                        command: command,
-                        resultState: resultState
-                    )
-                    try childChannel.pipeline.syncOperations.addHandler(execHandler)
+                    return childChannel.eventLoop.makeCompletedFuture {
+                        let execHandler = CommandExecHandler(
+                            command: command,
+                            resultState: resultState
+                        )
+                        try childChannel.pipeline.syncOperations.addHandler(execHandler)
+                    }
                 }
-            }
-            return childChannelPromise.futureResult
+            }.get()
+        } catch {
+            // The command handler never took ownership of resultState, so resolve
+            // its promise before unwinding this operation.
+            resultState.fail(error)
+            try? await channel.close().get()
+            throw error
         }
-
-        let childChannel = try await childChannelFuture.get()
 
         // Set up timeout if specified
         if timeout > 0 {
@@ -100,27 +111,35 @@ public actor SSHClient {
     public func interactive() async throws {
         let channel = try await connect()
 
-        // Create the SSH child channel for interactive session.
-        // We keep handler access + createChannel on the event loop to avoid
-        // crossing a Sendable boundary with NIOSSHHandler.
-        let childChannelPromise = channel.eventLoop.makePromise(of: Channel.self)
+        // As in execute(), do not allocate the child promise until handler
+        // lookup succeeds or a disconnect race can leak an unfulfilled promise.
         let sessionCompletePromise = channel.eventLoop.makePromise(of: Void.self)
+        let childChannel: Channel
+        do {
+            childChannel = try await Self.makeChildChannelFuture(
+                handlerFuture: channel.pipeline.handler(type: NIOSSHHandler.self),
+                eventLoop: channel.eventLoop
+            ) { sshHandler, childChannelPromise in
+                sshHandler.createChannel(childChannelPromise) { childChannel, channelType in
+                    guard channelType == .session else {
+                        return channel.eventLoop.makeFailedFuture(
+                            SSHError.connectionFailed("Invalid channel type")
+                        )
+                    }
 
-        let childChannelFuture = channel.pipeline.handler(type: NIOSSHHandler.self).flatMap { sshHandler -> EventLoopFuture<Channel> in
-            sshHandler.createChannel(childChannelPromise) { childChannel, channelType in
-                guard channelType == .session else {
-                    return channel.eventLoop.makeFailedFuture(SSHError.connectionFailed("Invalid channel type"))
+                    return childChannel.eventLoop.makeCompletedFuture {
+                        let interactiveHandler = InteractiveSessionHandler(
+                            completePromise: sessionCompletePromise
+                        )
+                        try childChannel.pipeline.syncOperations.addHandler(interactiveHandler)
+                    }
                 }
-
-                return childChannel.eventLoop.makeCompletedFuture {
-                    let interactiveHandler = InteractiveSessionHandler(completePromise: sessionCompletePromise)
-                    try childChannel.pipeline.syncOperations.addHandler(interactiveHandler)
-                }
-            }
-            return childChannelPromise.futureResult
+            }.get()
+        } catch {
+            sessionCompletePromise.fail(error)
+            try? await channel.close().get()
+            throw error
         }
-
-        let childChannel = try await childChannelFuture.get()
 
         // Wait for the session to complete
         try await sessionCompletePromise.futureResult.get()
@@ -128,6 +147,21 @@ public actor SSHClient {
         // Clean up
         try? await childChannel.closeFuture.get()
         try? await channel.close().get()
+    }
+
+    /// Creates the child promise only after handler lookup succeeds. SwiftNIO
+    /// deliberately traps when an unfulfilled promise is deallocated, so callers
+    /// must not allocate this promise before the prerequisite future completes.
+    static func makeChildChannelFuture(
+        handlerFuture: EventLoopFuture<NIOSSHHandler>,
+        eventLoop: EventLoop,
+        initialize: @escaping (NIOSSHHandler, EventLoopPromise<Channel>) -> Void
+    ) -> EventLoopFuture<Channel> {
+        handlerFuture.flatMap { sshHandler in
+            let childChannelPromise = eventLoop.makePromise(of: Channel.self)
+            initialize(sshHandler, childChannelPromise)
+            return childChannelPromise.futureResult
+        }
     }
 
     /// Connect to the SSH server and return the channel

--- a/libs/lume/tests/SSHClientTests.swift
+++ b/libs/lume/tests/SSHClientTests.swift
@@ -1,0 +1,32 @@
+@preconcurrency import NIOCore
+@preconcurrency import NIOEmbedded
+@preconcurrency import NIOSSH
+import Testing
+
+@testable import lume
+
+private enum SSHClientFutureTestError: Error {
+    case handlerLookupFailed
+}
+
+@Test("SSH child promise is not created when handler lookup fails")
+func childPromiseIsCreatedAfterHandlerLookup() throws {
+    let eventLoop = EmbeddedEventLoop()
+    let handlerFuture = eventLoop.makeFailedFuture(
+        SSHClientFutureTestError.handlerLookupFailed
+    ) as EventLoopFuture<NIOSSHHandler>
+    var initializerCalled = false
+
+    let childFuture = SSHClient.makeChildChannelFuture(
+        handlerFuture: handlerFuture,
+        eventLoop: eventLoop
+    ) { _, promise in
+        initializerCalled = true
+        promise.fail(SSHClientFutureTestError.handlerLookupFailed)
+    }
+
+    #expect(throws: SSHClientFutureTestError.self) {
+        try childFuture.wait()
+    }
+    #expect(!initializerCalled)
+}


### PR DESCRIPTION
## Summary

- preserve and land the independent SSH lifecycle correction from #2401
- avoid creating a child-channel promise until the matching channel handler is available
- keep the original contributor as commit author via `cherry-pick -x`
- add the contributor's focused regression test

## Validation

- `swift test --filter SSHClientTests`
  - 1 passed
- clean cherry-pick onto current `origin/main` at `8f9c2dfd422a14a29fa49870e26f790c0c0ef211`

## Attribution

Salvaged from #2401, commit `f36e64bc2a22ee652393533d11c69ce2f777f1a8`.
Original author: Madhava Jay.

This is the first independent slice of #2401; the native-display and transfer features remain in separate certification/landing tracks.
