### PR TITLE
fix(cua-bench): share platform image resolution

### DIFF
--- a/libs/cua-bench/cua_bench/cli/commands/platform.py
+++ b/libs/cua-bench/cua_bench/cli/commands/platform.py
@@ -13,75 +13,8 @@ import json
 import os
 import platform as sys_platform
 import subprocess
-from typing import Any, Dict, Optional
 
-# =============================================================================
-# Platform Configurations
-# =============================================================================
-
-PLATFORMS: Dict[str, Dict[str, Any]] = {
-    "linux-docker": {
-        "image": "trycua/cua-xfce:latest",
-        "description": "Linux GUI container (no KVM required)",
-        "internal_vnc_port": 6901,
-        "internal_api_port": 8000,
-        "requires_kvm": False,
-        "image_marker": None,
-        "os_type": "linux",
-        "boot_timeout": 60,
-        "use_overlays": False,
-    },
-    "linux-qemu": {
-        "image": "trycua/cua-qemu-linux:latest",
-        "description": "Linux VM with QEMU/KVM (OSWorld)",
-        "internal_vnc_port": 8006,
-        "internal_api_port": 5000,
-        "requires_kvm": True,
-        "image_marker": "linux.boot",
-        "os_type": "linux",
-        "boot_timeout": 120,
-        "use_overlays": True,
-    },
-    "windows-qemu": {
-        "image": "trycua/cua-qemu-windows:latest",
-        "description": "Windows VM with QEMU/KVM (Windows Arena)",
-        "internal_vnc_port": 8006,
-        "internal_api_port": 5000,
-        "requires_kvm": True,
-        "image_marker": "windows.boot",
-        "os_type": "windows",
-        "boot_timeout": 180,
-        "use_overlays": True,
-    },
-    "android-qemu": {
-        "image": "trycua/cua-qemu-android:latest",
-        "description": "Android VM with QEMU/KVM",
-        "internal_vnc_port": 8006,
-        "internal_api_port": 5000,
-        "requires_kvm": True,
-        "image_marker": "android.boot",
-        "os_type": "android",
-        "boot_timeout": 120,
-        "use_overlays": True,
-    },
-    "macos-lume": {
-        "image": None,
-        "description": "macOS VM with Apple Virtualization (Lume, Apple Silicon only)",
-        "internal_vnc_port": None,
-        "internal_api_port": 5000,
-        "requires_kvm": False,
-        "image_marker": None,
-        "os_type": "macos",
-        "boot_timeout": 120,
-        "use_overlays": False,
-        "requires_apple_silicon": True,
-    },
-}
-
-
-# =============================================================================
-# Helper Functions
-# =============================================================================
+from ...platforms import PLATFORMS, get_platform_config
 
 
 def check_docker() -> bool:
@@ -134,11 +67,6 @@ def check_image_exists(image_name: str) -> bool:
         return bool(result.stdout.strip())
     except Exception:
         return False
-
-
-def get_platform_config(platform_name: str) -> Optional[Dict[str, Any]]:
-    """Get platform configuration by name."""
-    return PLATFORMS.get(platform_name)
 
 
 # =============================================================================

--- a/libs/cua-bench/cua_bench/platforms.py
+++ b/libs/cua-bench/cua_bench/platforms.py
@@ -1,0 +1,98 @@
+"""Built-in platform definitions shared by CUA-Bench runners and CLI commands."""
+
+from typing import Any, Dict, Optional
+
+
+PLATFORMS: Dict[str, Dict[str, Any]] = {
+    "linux-docker": {
+        "image": "trycua/cua-xfce:latest",
+        "description": "Linux GUI container (no KVM required)",
+        "internal_vnc_port": 6901,
+        "internal_api_port": 8000,
+        "requires_kvm": False,
+        "image_marker": None,
+        "os_type": "linux",
+        "boot_timeout": 60,
+        "use_overlays": False,
+    },
+    "linux-qemu": {
+        "image": "trycua/cua-qemu-linux:latest",
+        "description": "Linux VM with QEMU/KVM (OSWorld)",
+        "internal_vnc_port": 8006,
+        "internal_api_port": 5000,
+        "requires_kvm": True,
+        "image_marker": "linux.boot",
+        "os_type": "linux",
+        "boot_timeout": 120,
+        "use_overlays": True,
+    },
+    "windows-qemu": {
+        "image": "trycua/cua-qemu-windows:latest",
+        "description": "Windows VM with QEMU/KVM (Windows Arena)",
+        "internal_vnc_port": 8006,
+        "internal_api_port": 5000,
+        "requires_kvm": True,
+        "image_marker": "windows.boot",
+        "os_type": "windows",
+        "boot_timeout": 180,
+        "use_overlays": True,
+    },
+    "android-qemu": {
+        "image": "trycua/cua-qemu-android:latest",
+        "description": "Android VM with QEMU/KVM",
+        "internal_vnc_port": 8006,
+        "internal_api_port": 5000,
+        "requires_kvm": True,
+        "image_marker": "android.boot",
+        "os_type": "android",
+        "boot_timeout": 120,
+        "use_overlays": True,
+    },
+    "macos-lume": {
+        "image": None,
+        "description": "macOS VM with Apple Virtualization (Lume, Apple Silicon only)",
+        "internal_vnc_port": None,
+        "internal_api_port": 5000,
+        "requires_kvm": False,
+        "image_marker": None,
+        "os_type": "macos",
+        "boot_timeout": 120,
+        "use_overlays": False,
+        "requires_apple_silicon": True,
+    },
+}
+
+CONTAINER_PLATFORMS = (
+    "linux-docker",
+    "linux-qemu",
+    "windows-qemu",
+    "android-qemu",
+)
+
+
+def get_platform_config(platform_name: str) -> Optional[Dict[str, Any]]:
+    """Get a built-in platform configuration by name."""
+    return PLATFORMS.get(platform_name)
+
+
+def resolve_container_image(platform_name: str, image_name: Optional[str] = None) -> str:
+    """Resolve the container image used to host a built-in platform.
+
+    For Docker-native platforms, an explicit image URI replaces the built-in
+    default. For QEMU platforms, ``image_name`` identifies the stored guest
+    disk while the platform's container image remains the QEMU host.
+    """
+    if platform_name not in CONTAINER_PLATFORMS:
+        raise ValueError(
+            f"Unknown container platform: {platform_name}. "
+            f"Valid platforms: {list(CONTAINER_PLATFORMS)}"
+        )
+
+    config = PLATFORMS[platform_name]
+    default_image = config["image"]
+    if not isinstance(default_image, str):
+        raise ValueError(f"Platform {platform_name!r} has no container image")
+
+    if not config["use_overlays"] and image_name and image_name != platform_name:
+        return image_name
+    return default_image

--- a/libs/cua-bench/cua_bench/runner/task_runner.py
+++ b/libs/cua-bench/cua_bench/runner/task_runner.py
@@ -11,6 +11,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from ..platforms import (
+    CONTAINER_PLATFORMS,
+    PLATFORMS,
+    resolve_container_image,
+)
 from ..sessions.providers.local_environment import check_image_exists, pull_image
 from .docker_utils import (
     ContainerInfo,
@@ -27,46 +32,6 @@ from .docker_utils import (
     stop_container,
     wait_for_container,
 )
-
-# =============================================================================
-# Configuration
-# =============================================================================
-
-# Environment type configurations
-ENV_CONFIGS = {
-    "linux-docker": {
-        "image": "nikri/kicad-snorkel:20260316b",
-        "internal_vnc_port": 6901,
-        "internal_api_port": 8000,
-        "requires_kvm": False,
-        "os_type": "linux",
-        "use_overlays": False,  # Stateless container, no disk to protect
-    },
-    "linux-qemu": {
-        "image": "trycua/cua-qemu-linux:latest",
-        "internal_vnc_port": 8006,
-        "internal_api_port": 5000,
-        "requires_kvm": True,
-        "os_type": "linux",
-        "use_overlays": True,  # Protect golden QCOW2 disk
-    },
-    "windows-qemu": {
-        "image": "trycua/cua-qemu-windows:latest",
-        "internal_vnc_port": 8006,
-        "internal_api_port": 5000,
-        "requires_kvm": True,
-        "os_type": "windows",
-        "use_overlays": True,  # Protect golden QCOW2 disk
-    },
-    "android-qemu": {
-        "image": "trycua/cua-qemu-android:latest",
-        "internal_vnc_port": 8006,
-        "internal_api_port": 5000,
-        "requires_kvm": True,
-        "os_type": "android",
-        "use_overlays": True,  # Protect golden QCOW2 disk
-    },
-}
 
 # Default agent image
 DEFAULT_AGENT_IMAGE = "cua-bench:latest"
@@ -273,12 +238,12 @@ class TaskRunner:
             )
 
         # Validate env_type (skip validation for simulated since we don't use it)
-        if not is_simulated and env_type not in ENV_CONFIGS:
+        if not is_simulated and env_type not in CONTAINER_PLATFORMS:
             raise ValueError(
-                f"Unknown env_type: {env_type}. Valid types: {list(ENV_CONFIGS.keys())}"
+                f"Unknown env_type: {env_type}. Valid types: {list(CONTAINER_PLATFORMS)}"
             )
 
-        config = ENV_CONFIGS.get(env_type, {}) if not is_simulated else {}
+        config = PLATFORMS.get(env_type, {}) if not is_simulated else {}
         golden_name = golden_name or env_type if not is_simulated else "simulated"
 
         # Generate unique task ID
@@ -297,7 +262,11 @@ class TaskRunner:
             "network": network_name,
             "env_container": env_container_name if not is_simulated else None,
             "agent_container": agent_container_name,
-            "env_image": config.get("image") if not is_simulated else None,
+            "env_image": (
+                resolve_container_image(env_type, golden_name)
+                if not is_simulated
+                else None
+            ),
             "agent_image": self.agent_image,
             "remove_images": remove_images_after,
             "overlay_path": overlay_path,
@@ -486,12 +455,12 @@ class TaskRunner:
             await full_cleanup()
 
         # Validate env_type
-        if env_type not in ENV_CONFIGS:
+        if env_type not in CONTAINER_PLATFORMS:
             raise ValueError(
-                f"Unknown env_type: {env_type}. Valid types: {list(ENV_CONFIGS.keys())}"
+                f"Unknown env_type: {env_type}. Valid types: {list(CONTAINER_PLATFORMS)}"
             )
 
-        config = ENV_CONFIGS[env_type]
+        config = PLATFORMS[env_type]
         golden_name = golden_name or env_type
 
         # Auto-allocate ports if requested and not specified
@@ -518,7 +487,7 @@ class TaskRunner:
             "network": network_name,
             "env_container": env_container_name,
             "agent_container": None,  # No agent in interactive mode
-            "env_image": config["image"],
+            "env_image": resolve_container_image(env_type, golden_name),
             "agent_image": None,
             "remove_images": False,
             "overlay_path": overlay_path,
@@ -679,7 +648,7 @@ class TaskRunner:
 
         # Start container
         return await start_container(
-            image=config["image"],
+            image=resolve_container_image(env_type, golden_name),
             name=container_name,
             network=network_name,
             hostname=self.env_hostname,
@@ -997,15 +966,13 @@ class TaskRunner:
         localhost:8000, so no base64-exec calls are needed during the agent loop.
         """
         import signal
-        import sys
 
         from .daytona_harness import DaytonaHarness
 
         harness = DaytonaHarness()
 
         # Resolve env-type name → actual Docker image
-        _raw = golden_name or env_type or ""
-        env_image = ENV_CONFIGS.get(_raw, {}).get("image") or _raw or "nikri/kicad-snorkel:20260316b"
+        env_image = resolve_container_image(env_type, golden_name)
 
         # API keys and env vars to bake into the sandbox at creation time
         # (avoids passing secrets via process.exec env which triggers abuse detection)

--- a/libs/cua-bench/cua_bench/sessions/providers/local_environment.py
+++ b/libs/cua-bench/cua_bench/sessions/providers/local_environment.py
@@ -30,6 +30,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
+from ...platforms import CONTAINER_PLATFORMS, PLATFORMS
+
 if TYPE_CHECKING:
     import aiohttp
 
@@ -64,49 +66,7 @@ class EnvironmentInfo:
 # Container prefix for environments started by this provider
 CONTAINER_PREFIX = "cua-bench-env-"
 
-# Platform configurations
-PLATFORM_CONFIGS = {
-    "linux-docker": {
-        "image": "trycua/cua-xfce:latest",
-        "internal_vnc_port": 6901,
-        "internal_api_port": 8000,
-        "requires_kvm": False,
-        "image_marker": None,
-        "os_type": "linux",
-        "boot_timeout": 60,  # Fast, no VM boot
-        "use_overlays": False,  # Stateless container
-    },
-    "linux-qemu": {
-        "image": "trycua/cua-qemu-linux:latest",
-        "internal_vnc_port": 8006,
-        "internal_api_port": 5000,
-        "requires_kvm": True,
-        "image_marker": "linux.boot",
-        "os_type": "linux",
-        "boot_timeout": 120,  # QEMU VM boot
-        "use_overlays": True,  # Enable QCOW2 overlays for fast reset
-    },
-    "windows-qemu": {
-        "image": "trycua/cua-qemu-windows:latest",
-        "internal_vnc_port": 8006,
-        "internal_api_port": 5000,
-        "requires_kvm": True,
-        "image_marker": "windows.boot",
-        "os_type": "windows",
-        "boot_timeout": 180,  # Windows is slow to boot
-        "use_overlays": True,  # Enable QCOW2 overlays for fast reset
-    },
-    "android-qemu": {
-        "image": "trycua/cua-qemu-android:latest",
-        "internal_vnc_port": 8006,
-        "internal_api_port": 5000,
-        "requires_kvm": True,
-        "image_marker": "android.boot",
-        "os_type": "android",
-        "boot_timeout": 120,  # Android VM boot
-        "use_overlays": True,  # Enable QCOW2 overlays for fast reset
-    },
-}
+PLATFORM_CONFIGS = {name: PLATFORMS[name] for name in CONTAINER_PLATFORMS}
 
 
 # =============================================================================

--- a/libs/cua-bench/cua_bench/tests/test_task_runner.py
+++ b/libs/cua-bench/cua_bench/tests/test_task_runner.py
@@ -1,0 +1,39 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cua_bench.platforms import PLATFORMS
+from cua_bench.runner.task_runner import TaskRunner
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("golden_name", "expected_image"),
+    [
+        ("linux-docker", "trycua/cua-xfce:latest"),
+        ("ghcr.io/example/custom-xfce@sha256:abc", "ghcr.io/example/custom-xfce@sha256:abc"),
+    ],
+)
+async def test_linux_docker_container_uses_resolved_image(
+    golden_name: str,
+    expected_image: str,
+) -> None:
+    runner = TaskRunner()
+
+    with patch(
+        "cua_bench.runner.task_runner.start_container",
+        new_callable=AsyncMock,
+    ) as start_container:
+        await runner._start_env_container(
+            task_id="task-id",
+            network_name="network",
+            env_type="linux-docker",
+            golden_name=golden_name,
+            config=PLATFORMS["linux-docker"],
+            memory="8G",
+            cpus="8",
+            vnc_port=None,
+            api_port=None,
+        )
+
+    assert start_container.await_args.kwargs["image"] == expected_image

--- a/libs/cua-bench/cua_bench/tests/test_task_runner.py
+++ b/libs/cua-bench/cua_bench/tests/test_task_runner.py
@@ -36,4 +36,19 @@ async def test_linux_docker_container_uses_resolved_image(
             api_port=None,
         )
 
-    assert start_container.await_args.kwargs["image"] == expected_image
+assert start_container.await_args.kwargs["image"] == expected_image
+
+
+def test_resolve_container_image_qemu_ignores_disk_name() -> None:
+    from cua_bench.platforms import resolve_container_image
+
+    assert resolve_container_image("linux-qemu", image_name="my-golden-disk") == PLATFORMS["linux-qemu"][
+        "image"
+    ]
+
+
+def test_resolve_container_image_unknown_platform_raises() -> None:
+    from cua_bench.platforms import resolve_container_image
+
+    with pytest.raises(ValueError, match=r"Unknown container platform"):
+        resolve_container_image("not-a-platform")

--- a/libs/xfce/src/scripts/start-computer-server.sh
+++ b/libs/xfce/src/scripts/start-computer-server.sh
@@ -10,4 +10,4 @@ echo "X server is ready"
 
 # Start computer-server from the venv
 export DISPLAY=:1
-/opt/venv/bin/python3 -m computer_server --port ${API_PORT:-8000}
+/opt/venv/bin/python3 -m computer_server --host 0.0.0.0 --port ${API_PORT:-8000}

--- a/libs/xfce/src/scripts/start-computer-server.sh
+++ b/libs/xfce/src/scripts/start-computer-server.sh
@@ -10,4 +10,4 @@ echo "X server is ready"
 
 # Start computer-server from the venv
 export DISPLAY=:1
-/opt/venv/bin/python3 -m computer_server --host 0.0.0.0 --port ${API_PORT:-8000}
+/opt/venv/bin/python3 -m computer_server --host 0.0.0.0 --port "${API_PORT:-8000}"


### PR DESCRIPTION
## What

- Add one shared registry for CUA-Bench's built-in platform configuration.
- Use it from the CLI, local environment provider, two-container runner, interactive
  runner, and Daytona runner.
- Preserve explicit Docker image overrides while keeping QEMU guest-disk names
  separate from the host container image.
- Bind the XFCE `computer_server` to `0.0.0.0` so its published Docker port is
  reachable.

## Why

A real KiCad task exposed two independent failures before task execution:

1. CUA-Bench had three platform maps that disagreed. The CLI and local provider
   resolved `linux-docker` to `trycua/cua-xfce:latest`, while `TaskRunner` resolved it
   to the unavailable `nikri/kicad-snorkel:20260316b` image.
2. After selecting the public XFCE image, its Computer API still could not be reached
   through Docker. The current `computer_server` defaults to `127.0.0.1` and requires
   `--host 0.0.0.0` for external access.

This meant `cb run task ... --platform linux-docker` could not reach task setup even
though the repository already contained a suitable public KiCad image.

## How

- Move the built-in definitions to `cua_bench.platforms`.
- Resolve a platform's container image through `resolve_container_image()` at every
  runner boundary.
- For `linux-docker`, let an explicit image URI replace the built-in default.
- For QEMU platforms, continue treating the supplied image name as the guest disk
  identity and use the platform's configured host image.
- Start the XFCE Computer API with `--host 0.0.0.0`.

Unknown platforms and inaccessible explicit images still fail explicitly. There is no
fallback to a different image.

## Validation

Automated checks:

- `uv run --directory libs/cua-bench ruff check cua_bench`
- `uv run --directory libs/cua-bench pytest cua_bench/tests -q`: **140 passed**
- `bash -n libs/xfce/src/scripts/start-computer-server.sh`
- `git diff --check`

Live positive control:

- Ran `cua-bench-kicad/55f2eefb` through the real two-container
  `cb run task --oracle --wait` path.
- Task setup completed and captured a 222,131-byte screenshot.
- The declared oracle completed.
- Native netlist evaluation passed components, nets, and net names, returning **1.0**.
- The trace was persisted and the task containers and network were cleaned up.

The published `trycua/cua-xfce:latest` manifest is currently amd64-only, so the Apple
Silicon validation used `linux/amd64`. Multi-architecture publication is a separate
packaging concern from the resolver and API binding fixes in this PR.
