### PR TITLE
fix(lume): refresh live folder shares

### DIFF
--- a/libs/lume/src/Virtualization/VMVirtualizationService.swift
+++ b/libs/lume/src/Virtualization/VMVirtualizationService.swift
@@ -175,7 +175,10 @@ class BaseVirtualizationService: VMVirtualizationService {
                             "The VM was not started with a live shared-folder device"))
                     return
                 }
-                device.share = Self.createDirectoryShare(sharedDirectories)
+                device.share = Self.createDirectoryShare(
+                    sharedDirectories,
+                    withLiveUpdatePlaceholder: true
+                )
                 continuation.resume()
             }
         }
@@ -277,17 +280,32 @@ class BaseVirtualizationService: VMVirtualizationService {
         -> [VZDirectorySharingDeviceConfiguration]
     {
         let grouped = Dictionary(grouping: sharedDirectories ?? [], by: \.tag)
+        let automountTag = VZVirtioFileSystemDeviceConfiguration.macOSGuestAutomountTag
         return grouped.map { tag, directories in
             let device = VZVirtioFileSystemDeviceConfiguration(tag: tag)
-            device.share = createDirectoryShare(directories)
+            device.share = createDirectoryShare(
+                directories,
+                withLiveUpdatePlaceholder: tag == automountTag
+            )
             return device
         }
     }
 
     nonisolated static func createDirectoryShare(
-        _ sharedDirectories: [SharedDirectory]
+        _ sharedDirectories: [SharedDirectory],
+        withLiveUpdatePlaceholder: Bool = false
     ) -> VZDirectoryShare {
         var directories: [String: VZSharedDirectory] = [:]
+        if withLiveUpdatePlaceholder {
+            // Live updates work reliably when VZMultipleDirectoryShare starts populated.
+            // Starting macOS with an entirely empty share leaves its automounted
+            // VirtioFS root stale after the first update. Keep one hidden, harmless
+            // entry so replacing the share invalidates the guest mount correctly.
+            directories[".lume-live-share"] = VZSharedDirectory(
+                url: URL(fileURLWithPath: "/var/empty", isDirectory: true),
+                readOnly: true
+            )
+        }
         for sharedDirectory in sharedDirectories {
             let url = URL(fileURLWithPath: sharedDirectory.hostPath)
             let directory = VZSharedDirectory(url: url, readOnly: sharedDirectory.readOnly)
@@ -443,8 +461,8 @@ final class DarwinVirtualizationService: BaseVirtualizationService {
             }
         }
 
-        // Directory sharing. Keep an empty macOS automount device available so the
-        // native toolbar can replace its share while the VM is running.
+        // Directory sharing. Keep a populated macOS automount device available so
+        // the native toolbar can replace its share while the VM is running.
         var directorySharingDevices = createDirectorySharingDevices(
             sharedDirectories: config.sharedDirectories)
         let automountTag = VZVirtioFileSystemDeviceConfiguration.macOSGuestAutomountTag
@@ -452,7 +470,7 @@ final class DarwinVirtualizationService: BaseVirtualizationService {
             ($0 as? VZVirtioFileSystemDeviceConfiguration)?.tag == automountTag
         }) {
             let device = VZVirtioFileSystemDeviceConfiguration(tag: automountTag)
-            device.share = createDirectoryShare([])
+            device.share = createDirectoryShare([], withLiveUpdatePlaceholder: true)
             directorySharingDevices.append(device)
         }
         vzConfig.directorySharingDevices = directorySharingDevices

--- a/libs/lume/src/Virtualization/VMVirtualizationService.swift
+++ b/libs/lume/src/Virtualization/VMVirtualizationService.swift
@@ -276,7 +276,10 @@ class BaseVirtualizationService: VMVirtualizationService {
         return network
     }
 
-    static func createDirectorySharingDevices(sharedDirectories: [SharedDirectory]?)
+    static func createDirectorySharingDevices(
+        sharedDirectories: [SharedDirectory]?,
+        withLiveUpdatePlaceholder: Bool = false
+    )
         -> [VZDirectorySharingDeviceConfiguration]
     {
         let grouped = Dictionary(grouping: sharedDirectories ?? [], by: \.tag)
@@ -285,7 +288,7 @@ class BaseVirtualizationService: VMVirtualizationService {
             let device = VZVirtioFileSystemDeviceConfiguration(tag: tag)
             device.share = createDirectoryShare(
                 directories,
-                withLiveUpdatePlaceholder: tag == automountTag
+                withLiveUpdatePlaceholder: withLiveUpdatePlaceholder && tag == automountTag
             )
             return device
         }
@@ -464,7 +467,9 @@ final class DarwinVirtualizationService: BaseVirtualizationService {
         // Directory sharing. Keep a populated macOS automount device available so
         // the native toolbar can replace its share while the VM is running.
         var directorySharingDevices = createDirectorySharingDevices(
-            sharedDirectories: config.sharedDirectories)
+            sharedDirectories: config.sharedDirectories,
+            withLiveUpdatePlaceholder: true
+        )
         let automountTag = VZVirtioFileSystemDeviceConfiguration.macOSGuestAutomountTag
         if !directorySharingDevices.contains(where: {
             ($0 as? VZVirtioFileSystemDeviceConfiguration)?.tag == automountTag

--- a/libs/lume/tests/VMVirtualizationServiceTests.swift
+++ b/libs/lume/tests/VMVirtualizationServiceTests.swift
@@ -72,7 +72,7 @@ func testVMVirtualizationServiceFailures() async throws {
 }
 
 @MainActor
-@Test("Shared directories with one tag use a disambiguated multiple-directory share")
+@Test("macOS automount directories keep a live-update placeholder and disambiguate names")
 func testSharedDirectoryGrouping() throws {
     let tag = VZVirtioFileSystemDeviceConfiguration.macOSGuestAutomountTag
     let sharedDirectories = [
@@ -89,7 +89,26 @@ func testSharedDirectoryGrouping() throws {
     #expect(devices.count == 1)
     #expect(device.tag == tag)
     let names = Swift.Set<String>(share.directories.keys)
-    #expect(names == Swift.Set(["Shared", "Shared (2)"]))
+    #expect(names == Swift.Set([".lume-live-share", "Shared", "Shared (2)"]))
+    #expect(share.directories[".lume-live-share"]?.isReadOnly == true)
+    #expect(share.directories[".lume-live-share"]?.url.path == "/var/empty")
     #expect(share.directories["Shared"]?.isReadOnly == false)
     #expect(share.directories["Shared (2)"]?.isReadOnly == true)
+}
+
+@MainActor
+@Test("Only live macOS automount shares receive the placeholder")
+func testLiveSharePlaceholderScope() throws {
+    let automountShare = try #require(
+        BaseVirtualizationService.createDirectoryShare(
+            [],
+            withLiveUpdatePlaceholder: true
+        ) as? VZMultipleDirectoryShare
+    )
+    let regularShare = try #require(
+        BaseVirtualizationService.createDirectoryShare([]) as? VZMultipleDirectoryShare
+    )
+
+    #expect(Swift.Set(automountShare.directories.keys) == [".lume-live-share"])
+    #expect(regularShare.directories.isEmpty)
 }

--- a/libs/lume/tests/VMVirtualizationServiceTests.swift
+++ b/libs/lume/tests/VMVirtualizationServiceTests.swift
@@ -81,7 +81,8 @@ func testSharedDirectoryGrouping() throws {
     ]
 
     let devices = BaseVirtualizationService.createDirectorySharingDevices(
-        sharedDirectories: sharedDirectories
+        sharedDirectories: sharedDirectories,
+        withLiveUpdatePlaceholder: true
     )
     let device = try #require(devices.first as? VZVirtioFileSystemDeviceConfiguration)
     let share = try #require(device.share as? VZMultipleDirectoryShare)
@@ -99,6 +100,7 @@ func testSharedDirectoryGrouping() throws {
 @MainActor
 @Test("Only live macOS automount shares receive the placeholder")
 func testLiveSharePlaceholderScope() throws {
+    let tag = VZVirtioFileSystemDeviceConfiguration.macOSGuestAutomountTag
     let automountShare = try #require(
         BaseVirtualizationService.createDirectoryShare(
             [],
@@ -111,4 +113,15 @@ func testLiveSharePlaceholderScope() throws {
 
     #expect(Swift.Set(automountShare.directories.keys) == [".lume-live-share"])
     #expect(regularShare.directories.isEmpty)
+
+    let regularDevices = BaseVirtualizationService.createDirectorySharingDevices(
+        sharedDirectories: [
+            SharedDirectory(hostPath: "/tmp/regular", tag: tag, readOnly: false)
+        ]
+    )
+    let regularDevice = try #require(
+        regularDevices.first as? VZVirtioFileSystemDeviceConfiguration
+    )
+    let regularDeviceShare = try #require(regularDevice.share as? VZMultipleDirectoryShare)
+    #expect(regularDeviceShare.directories[".lume-live-share"] == nil)
 }


### PR DESCRIPTION
## Summary

- keep a populated macOS VirtioFS automount device available when a VM starts without shared folders
- replace that device's share at runtime from the native **Share Folder** action
- disambiguate same-named host folders and retain read-only settings
- keep the live-share placeholder scoped to Darwin so Linux and generic share construction stay unchanged

Salvaged from #2401. The original implementation commit is retained with Madhava Jay as author and a `cherry-pick -x` source reference.

## Verification

- `swift test --filter VMVirtualizationServiceTests` — 6/6 passed
- debug build completed at exact source commit `08506d58dfbccb2ca635ed02a4a67b9111de9f98`
- exact ad-hoc-signed binary: Lume `0.4.0`, SHA-256 `db52e1795f1bdefe5faba4cfb6c759550090cc4f0e7bf79851a9e9da7ff63c7c`
- Cua Driver snapshot/action/snapshot proof on local macOS:
  - launched `cua-2401-native-85b1b5a` with `--display native`
  - activated **Share Folder** in the exact native window
  - selected `~/Documents/cua-2401-share-proof`
  - Lume recorded one live shared directory
- independent guest oracle over SSH:
  - `/Volumes/My Shared Files/cua-2401-share-proof/LIVE_SHARE_08506D58.txt`
  - contents: `exact-SHA live-share proof`
- exact binary stopped the VM after verification
