### PR TITLE
fix(ci): add ddupont808 to contributor attribution internal handles

### DIFF
--- a/.github/release-attribution-config.json
+++ b/.github/release-attribution-config.json
@@ -30,6 +30,7 @@
     "zongxin_yang@hms.harvard.edu": "z-x-yang"
   },
   "internalHandles": [
+    "ddupont808",
     "enchanted-koala",
     "f-trycua"
   ],


### PR DESCRIPTION
## Summary
- The `CI: Contributor attribution` (`pull_request_target`) check flagged review commits I pushed directly to contributor PR branches (e.g. #2644) as unattributed "salvaged" commits, since my commit author login (`ddupont808`) differed from the PR's original opener and wasn't listed in `internalHandles`.
- This check's actual intent is to catch cherry-picked/salvaged commits landed silently in someone else's PR without crediting the original author — not to flag a maintainer's own review commits on a contributor's branch.
- Adds `ddupont808` to `internalHandles` in `.github/release-attribution-config.json`, consistent with the existing entries for `enchanted-koala` and `f-trycua`.

## Test plan
- [ ] Confirm `CI: Contributor attribution` passes on a PR with a maintainer-pushed review commit