### PR TITLE
fix(cua-bench): wire resolve_container_image into LocalEnvironmentProvider

### DIFF
--- a/libs/cua-bench/cua_bench/sessions/providers/local_environment.py
+++ b/libs/cua-bench/cua_bench/sessions/providers/local_environment.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from ...platforms import CONTAINER_PLATFORMS, PLATFORMS
+from ...platforms import CONTAINER_PLATFORMS, PLATFORMS, resolve_container_image
 
 if TYPE_CHECKING:
     import aiohttp
@@ -298,6 +298,7 @@ class LocalEnvironmentProvider:
         image_name = image_name or platform
 
         # Validate image exists (for QEMU types)
+        image_path: Optional[Path] = None
         if config["image_marker"]:
             image_path = get_image_path(image_name)
             marker_path = image_path / config["image_marker"]
@@ -327,7 +328,7 @@ class LocalEnvironmentProvider:
             vnc_port = find_free_port(8000, 9000)
 
         # Pull Docker image if needed
-        docker_image = config["image"]
+        docker_image = resolve_container_image(platform, image_name)
         if not check_image_exists(docker_image):
             pull_image(docker_image)
 
@@ -336,6 +337,7 @@ class LocalEnvironmentProvider:
             platform=platform,
             config=config,
             container_name=container_name,
+            docker_image=docker_image,
             image_path=image_path,
             worker_path=worker_path,
             api_port=api_port,
@@ -375,6 +377,7 @@ class LocalEnvironmentProvider:
         platform: str,
         config: dict,
         container_name: str,
+        docker_image: str,
         image_path: Optional[Path],
         worker_path: Optional[Path],
         api_port: int,
@@ -388,6 +391,7 @@ class LocalEnvironmentProvider:
             platform: Platform type
             config: Platform configuration from PLATFORM_CONFIGS
             container_name: Name for the container
+            docker_image: Resolved container image to run
             image_path: Path to image (QEMU types only)
             worker_path: Path to worker overlay directory (QEMU types with overlays)
             api_port: Host port for API
@@ -398,7 +402,6 @@ class LocalEnvironmentProvider:
         Returns:
             Docker command as list of strings
         """
-        docker_image = config["image"]
         internal_api = config["internal_api_port"]
         internal_vnc = config["internal_vnc_port"]
 

--- a/libs/cua-bench/cua_bench/tests/test_task_runner.py
+++ b/libs/cua-bench/cua_bench/tests/test_task_runner.py
@@ -36,7 +36,7 @@ async def test_linux_docker_container_uses_resolved_image(
             api_port=None,
         )
 
-assert start_container.await_args.kwargs["image"] == expected_image
+        assert start_container.await_args.kwargs["image"] == expected_image
 
 
 def test_resolve_container_image_qemu_ignores_disk_name() -> None:


### PR DESCRIPTION
## Summary
- `LocalEnvironmentProvider.start()` accepted an `image_name` override but always ran `config["image"]` for `linux-docker`, making the override a no-op even though `resolve_container_image()` was introduced in #2644.
- Threads the resolved image through to `_build_docker_cmd()` explicitly instead of re-deriving it from `config["image"]`.
- Fixes an indentation bug from #2644 where a test assertion sat outside the async function (causing `NameError` at collection time).

Recreated from #2648 as a new PR: that PR was opened by the Copilot coding agent bot and never got a single CI run — GitHub gates workflow runs for bot/first-time-contributor actors behind manual "Approve and run", so it was stuck with `no checks reported`. This carries over the same diff (last commit only; the branch's earlier commits duplicated content already merged via #2644) so CI can run normally.

Closes #2648.

## Test plan
- [ ] CI passes (build, contributor-attribution, etc.)