### PR TITLE
feat(lume): open native display by default

### DIFF
--- a/docs/content/docs/how-to-guides/lume/create-vanilla-vm.mdx
+++ b/docs/content/docs/how-to-guides/lume/create-vanilla-vm.mdx
@@ -37,9 +37,9 @@ lume ls
 lume ssh macos-tahoe 'sw_vers; id -un'
 ```
 
-`lume run` starts without opening a viewer while keeping VNC available. Use
-`lume attach macos-tahoe` to open the preferred viewer, or select one explicitly
-with `--display native` or `--display vnc`.
+`lume run` opens the native viewer by default while keeping VNC available for
+automation and remote access. Use `--display vnc` to open Screen Sharing instead,
+or `--display none` (or `--no-display`) to start without a viewer.
 
 ## Stop or remove it
 

--- a/docs/content/docs/how-to-guides/lume/manage-vms.mdx
+++ b/docs/content/docs/how-to-guides/lume/manage-vms.mdx
@@ -25,15 +25,16 @@ SSH availability when the VM is running.
 
 ## Run, attach to, and stop a VM
 
-Run Tahoe without automatically opening a viewer. The owning process remains
-attached to the terminal by default:
+Run Tahoe with the low-latency native viewer. VNC remains available for
+automation and remote access, and the owning process stays attached to the
+terminal:
 
 ```bash
 lume run macos-tahoe
 ```
 
-Use `--detach` to run it in the background. Lume prints its PID and writes logs
-to `~/Library/Logs/lume/macos-tahoe.log` by default:
+Use `--detach` to run it in the background without opening a viewer. Lume prints
+its PID and writes logs to `~/Library/Logs/lume/macos-tahoe.log` by default:
 
 ```bash
 lume run macos-tahoe --detach
@@ -54,11 +55,11 @@ lume attach macos-tahoe --display native
 lume attach macos-tahoe --display vnc
 ```
 
-You can also start and immediately open a viewer:
+Select Screen Sharing or suppress the startup viewer explicitly when needed:
 
 ```bash
-lume run macos-tahoe --display native
 lume run macos-tahoe --display vnc
+lume run macos-tahoe --display none
 ```
 
 Closing the native window only hides it; it does not stop the guest. Reopen it

--- a/docs/content/docs/reference/lume/cli-reference.mdx
+++ b/docs/content/docs/reference/lume/cli-reference.mdx
@@ -70,7 +70,7 @@ Run a virtual machine
 | `--disk` | [String] | - | Disk image to attach as a read-write virtio-blk device |
 | `--registry` | String | ghcr.io | Container registry URL |
 | `--organization` | String | trycua | Organization to pull from |
-| `--display` | DisplayMode | none | Local viewer to open: vnc, native, or none. The VNC server remains available in every mode |
+| `--display` | DisplayMode | native | Local viewer to open: vnc, native, or none. The VNC server remains available in every mode |
 | `--log-file` | String | ~/Library/Logs/lume/{vm}.log | Log path for --detach |
 | `--vnc-port` | Int | 0 | Port for VNC server (0 for auto-assign) |
 | `--recovery-mode` | Bool | false | For macOS VMs only, boot in recovery mode |

--- a/libs/lume/src/Commands/DetachedRun.swift
+++ b/libs/lume/src/Commands/DetachedRun.swift
@@ -85,6 +85,14 @@ enum DetachedVMRunner {
         }
       }
     }
+    let hasExplicitDisplay = childArguments.contains("--display")
+      || childArguments.contains("--no-display")
+      || childArguments.contains("-d")
+      || childArguments.contains(where: { $0.hasPrefix("--display=") })
+    if !hasExplicitDisplay {
+      childArguments += ["--display", "none"]
+    }
+
     return childArguments
   }
 

--- a/libs/lume/src/Commands/Run.swift
+++ b/libs/lume/src/Commands/Run.swift
@@ -15,7 +15,7 @@ struct Run: AsyncParsableCommand {
     @Option(
         help: "Local viewer to open: 'vnc', 'native', or 'none'. The VNC server remains available in every mode."
     )
-    var display: DisplayMode = .none
+    var display: DisplayMode = .native
 
     @Flag(
         name: [.customShort("d"), .customLong("no-display")],

--- a/libs/lume/src/Main.swift
+++ b/libs/lume/src/Main.swift
@@ -116,13 +116,14 @@ extension Lume {
         guard args.first == "run", !args.contains("--detach") else { return nil }
 
         let noDisplay = args.contains("--no-display") || args.contains("-d")
+        let inlineDisplay = args.first(where: { $0.hasPrefix("--display=") })
+            .map { String($0.dropFirst("--display=".count)) }
+        let separatedDisplay = args.indices.first(where: { index in
+            args[index] == "--display" && args.index(after: index) < args.endIndex
+        }).map { args[args.index(after: $0)] }
+        let requestedDisplay = inlineDisplay ?? separatedDisplay
         let usesNativeDisplay = !noDisplay
-            && (args.contains("--display=native")
-                || args.indices.contains { index in
-                    args[index] == "--display"
-                        && args.index(after: index) < args.endIndex
-                        && args[args.index(after: index)] == "native"
-                })
+            && (requestedDisplay == nil || requestedDisplay == DisplayMode.native.rawValue)
 
         // The conventional form is `lume run VM_NAME [options]`. ArgumentParser
         // still produces a useful validation error if the positional name is absent.

--- a/libs/lume/src/Utils/CommandDocExtractor.swift
+++ b/libs/lume/src/Utils/CommandDocExtractor.swift
@@ -345,7 +345,7 @@ enum CommandDocExtractor {
                 OptionDoc(name: "disk", shortName: nil, help: "Disk image to attach as a read-write virtio-blk device", type: "[String]", defaultValue: nil, isOptional: true),
                 OptionDoc(name: "registry", shortName: nil, help: "Container registry URL", type: "String", defaultValue: "ghcr.io", isOptional: false),
                 OptionDoc(name: "organization", shortName: nil, help: "Organization to pull from", type: "String", defaultValue: "trycua", isOptional: false),
-                OptionDoc(name: "display", shortName: nil, help: "Local viewer to open: vnc, native, or none. The VNC server remains available in every mode", type: "DisplayMode", defaultValue: "none", isOptional: false),
+                OptionDoc(name: "display", shortName: nil, help: "Local viewer to open: vnc, native, or none. The VNC server remains available in every mode", type: "DisplayMode", defaultValue: "native", isOptional: false),
                 OptionDoc(name: "log-file", shortName: nil, help: "Log path for --detach", type: "String", defaultValue: "~/Library/Logs/lume/{vm}.log", isOptional: true),
                 OptionDoc(name: "vnc-port", shortName: nil, help: "Port for VNC server (0 for auto-assign)", type: "Int", defaultValue: "0", isOptional: false),
                 OptionDoc(name: "recovery-mode", shortName: nil, help: "For macOS VMs only, boot in recovery mode", type: "Bool", defaultValue: "false", isOptional: true),

--- a/libs/lume/tests/DetachedRunTests.swift
+++ b/libs/lume/tests/DetachedRunTests.swift
@@ -27,6 +27,15 @@ func detachedChildArguments() {
     ])
 }
 
+@Test("Detached runs stay viewer-free when no display is explicitly requested")
+func detachedRunDefaultDisplay() {
+  let arguments = DetachedVMRunner.childArguments(from: [
+    "/path/to/lume", "run", "test-vm", "--detach",
+  ])
+
+  #expect(arguments == ["run", "test-vm", "--display", "none"])
+}
+
 @Test("Detached runs use a per-VM log in the user Library")
 func detachedDefaultLogPath() {
   let path = DetachedVMRunner.defaultLogURL(vmName: "example/vm:latest").path

--- a/libs/lume/tests/DisplayModeTests.swift
+++ b/libs/lume/tests/DisplayModeTests.swift
@@ -6,7 +6,7 @@ import Testing
 
 @Test("DisplayMode parses all supported values")
 func displayModeParsing() throws {
-  #expect(try Run.parse(["test-vm"]).display == .none)
+  #expect(try Run.parse(["test-vm"]).display == .native)
   #expect(try Run.parse(["test-vm", "--display", "vnc"]).display == .vnc)
   #expect(try Run.parse(["test-vm", "--display", "native"]).display == .native)
   #expect(try Run.parse(["test-vm", "--display", "none"]).display == .none)


### PR DESCRIPTION
## Summary

- make the native display the default for foreground `lume run`
- preserve detached execution without opening a viewer
- update CLI extraction and user documentation for the new default

Salvaged from #2401 with the contributor's original commit and authorship preserved via `cherry-pick -x`.

## Verification

- `swift test --filter DisplayModeTests` (3 passed)
- `swift test --filter DetachedRunTests` (4 passed)
- `swift test --filter CommandDocExtractorTests` (1 passed)
- regenerated Lume CLI and HTTP documentation with no drift
- exact-head release binary, ad-hoc signed with the repository's local entitlements:
  - invoking `lume run` without `--display` opened an on-screen native window titled for the test VM
  - Cua Driver accessibility inspection exposed the native Copy, Paste, Share Folder, and Capture Keys controls
  - an independent exact-binary SSH command returned the expected guest marker
  - stopping via the same exact binary removed the native window

## Release metadata

This changes the default user-visible display behavior, so the PR uses the release-producing `feat(lume)` title.
