### PR TITLE
chore: map #2559 contributor attribution

### DIFF
--- a/.github/release-attribution-config.json
+++ b/.github/release-attribution-config.json
@@ -19,6 +19,7 @@
   },
   "identityOverrides": {
     "ddupont@mit.edu": "ddupont808",
+    "egnichtel@crosscode.com": "ngnichtel",
     "f@trycua.com": "f-trycua",
     "i@jyunko.cn": "HsiangNianian",
     "klymenko@adobe.com": "pavelklymenko",


### PR DESCRIPTION
## Summary

- map Edwin Gnichtel’s institutional commit email to the verified #2559 contributor account `@ngnichtel`
- unblock the 0.13.1 release-attribution preflight without changing product behavior

The identity is verified from the original contribution: PR #2559 was opened from `ngnichtel/cua`, and its commit author is `Edwin Gnichtel <egnichtel@crosscode.com>`.

## Verification

- `python3 -m json.tool .github/release-attribution-config.json`
- `uv run --with pytest python -m pytest .github/scripts/tests/test_release_attribution.py .github/scripts/tests/test_pr_attribution.py -q` (28 passed)
- `python3 .github/scripts/release_attribution.py validate-title --title "chore: map #2559 contributor attribution" --require-release --allow-non-release`
- `git diff --check`
