### PR TITLE
fix(release): dedupe contributor thanks by GitHub login

### DIFF
--- a/.github/scripts/release_attribution.py
+++ b/.github/scripts/release_attribution.py
@@ -660,8 +660,9 @@ def merge_contributors(items: Iterable[Mapping[str, Any]]) -> list[dict[str, Any
     by_login: dict[str, dict[str, Any]] = {}
     for item in items:
         login = str(item["login"])
+        key = login.lower()
         existing = by_login.setdefault(
-            login,
+            key,
             {"login": login, "roles": set(), "external": bool(item.get("external", True))},
         )
         existing["roles"].add(str(item["role"]))
@@ -960,21 +961,30 @@ def build_manifest(
 
 
 def _thanks(change: Mapping[str, Any]) -> str:
-    external = [
-        item
-        for item in change.get("contributors", [])
-        if item.get("external") and item.get("role") in {"author", "coauthor"}
-    ]
-    reporters = [
-        item
-        for item in change.get("contributors", [])
-        if item.get("external") and item.get("role") == "reporter"
-    ]
+    external: dict[str, Mapping[str, Any]] = {}
+    reporters: dict[str, Mapping[str, Any]] = {}
+    for item in change.get("contributors", []):
+        if not item.get("external"):
+            continue
+        login = str(item["login"])
+        key = login.lower()
+        if item.get("role") in {"author", "coauthor"}:
+            external.setdefault(key, item)
+        elif item.get("role") == "reporter":
+            reporters.setdefault(key, item)
+    for key in external:
+        reporters.pop(key, None)
+
     parts: list[str] = []
     if external:
-        parts.append("Thanks " + ", ".join(f"@{item['login']}" for item in external))
+        parts.append(
+            "Thanks " + ", ".join(f"@{item['login']}" for item in external.values())
+        )
     if reporters:
-        parts.append("reported by " + ", ".join(f"@{item['login']}" for item in reporters))
+        parts.append(
+            "reported by "
+            + ", ".join(f"@{item['login']}" for item in reporters.values())
+        )
     return "; ".join(parts)
 
 

--- a/.github/scripts/tests/test_release_attribution.py
+++ b/.github/scripts/tests/test_release_attribution.py
@@ -16,6 +16,7 @@ from release_attribution import (
     changelog_references_change,
     linked_issue_numbers,
     login_from_email,
+    merge_contributors,
     release_bump,
     release_entries,
     render_body,
@@ -124,6 +125,54 @@ def test_login_from_noreply_and_override():
     )
     assert login_from_email("person@example.com", {"person@example.com": "person"}) == "person"
     assert login_from_email("person@example.com", {}) is None
+
+
+def test_release_notes_dedupe_contributors_across_roles_and_login_case():
+    contributors = [
+        {"login": "ngnichtel", "role": "author", "external": True},
+        {"login": "ngnichtel", "role": "coauthor", "external": True},
+        {"login": "goldenfish123321", "role": "coauthor", "external": True},
+        {"login": "GoldenFish123321", "role": "reporter", "external": True},
+    ]
+    assert merge_contributors(contributors) == [
+        {
+            "login": "goldenfish123321",
+            "roles": ["coauthor", "reporter"],
+            "external": True,
+        },
+        {
+            "login": "ngnichtel",
+            "roles": ["author", "coauthor"],
+            "external": True,
+        },
+    ]
+
+    manifest = {
+        "displayName": "Cua Driver",
+        "version": "0.13.1",
+        "repository": "trycua/cua",
+        "tag": "cua-driver-rs-v0.13.1",
+        "compareUrl": (
+            "https://github.com/trycua/cua/compare/"
+            "cua-driver-rs-v0.12.6...cua-driver-rs-v0.13.1"
+        ),
+        "visualRequested": False,
+        "changes": [
+            {
+                "type": "fix",
+                "summary": "preserve contributor credit",
+                "pr": 2559,
+                "contributors": contributors,
+            }
+        ],
+        "contributors": merge_contributors(contributors),
+    }
+    body = render_body(manifest)
+    assert "Thanks @ngnichtel, @goldenfish123321." in body
+    assert "reported by @GoldenFish123321" not in body
+    assert body.count("@ngnichtel") == 2
+    assert body.count("@goldenfish123321") == 2
+    assert "@GoldenFish123321" not in body
 
 
 def test_cross_repository_references_are_not_resolved_in_cua():


### PR DESCRIPTION
## Summary

- merge contributor roles case-insensitively by GitHub login
- thank one contributor once even when they are both author and coauthor
- avoid repeating the same person as both contributor and reporter

This keeps the generated 0.13.1 release notes complete without duplicate acknowledgements.

## Verification

- `uv run --with pytest --with jsonschema python -m pytest .github/scripts/tests/test_release_attribution.py .github/scripts/tests/test_pr_attribution.py -q` (29 passed)
- rendered the 0.13.1 candidate manifest and verified each per-change acknowledgement is unique
- `python3 -m compileall -q .github/scripts/release_attribution.py .github/scripts/tests/test_release_attribution.py`
- `git diff --check`