### PR TITLE
test(cua-driver): make macOS certification hermetic

### DIFF
--- a/.github/workflows/ci-test-scripts.yml
+++ b/.github/workflows/ci-test-scripts.yml
@@ -20,6 +20,11 @@ on:
       - ".github/workflows/ci-contributor-attribution.yml"
       - "docs/release-backfill-runbook.md"
       - "libs/cua-driver/scripts/**"
+      - "libs/cua-driver/tests/fixtures/apps/cross-platform/electron/build.sh"
+      - "libs/cua-driver/tests/fixtures/apps/cross-platform/electron/package-lock.json"
+      - "libs/cua-driver/tests/fixtures/apps/cross-platform/tauri/build.sh"
+      - "libs/cua-driver/tests/runners/macos-lume/**"
+      - "scripts/ci/macos/run-rust-e2e.sh"
 
 jobs:
   test:

--- a/libs/cua-driver/scripts/tests/test_macos_lume_runner.py
+++ b/libs/cua-driver/scripts/tests/test_macos_lume_runner.py
@@ -1,0 +1,1162 @@
+"""Focused tests for the macOS Lume release-certification runner.
+
+These exercise the runner's shell helpers directly by sourcing each script in
+library-only mode (``CUA_E2E_RUNNER_LIB_ONLY=1``), so status matching, build
+namespace selection, option validation, retry bookkeeping, and daemon
+restoration are covered without a macOS GUI session.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+RUN_ALL = REPO_ROOT / "libs/cua-driver/tests/runners/macos-lume/run-all.sh"
+RUN_RUST_E2E = REPO_ROOT / "scripts/ci/macos/run-rust-e2e.sh"
+ELECTRON_BUILD = (
+    REPO_ROOT / "libs/cua-driver/tests/fixtures/apps/cross-platform/electron/build.sh"
+)
+ELECTRON_LOCK = (
+    REPO_ROOT
+    / "libs/cua-driver/tests/fixtures/apps/cross-platform/electron/package-lock.json"
+)
+TAURI_BUILD = REPO_ROOT / "libs/cua-driver/tests/fixtures/apps/cross-platform/tauri/build.sh"
+
+requires_jq = pytest.mark.skipif(shutil.which("jq") is None, reason="jq is required")
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"#!/bin/sh\n{body}", encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run(
+    script: Path,
+    snippet: str,
+    env: dict[str, str] | None = None,
+    args: list[str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Source ``script`` in library-only mode and run ``snippet`` against it."""
+    merged = os.environ.copy()
+    merged["CUA_E2E_RUNNER_LIB_ONLY"] = "1"
+    merged.update(env or {})
+    body = f'source "{script}"\n{snippet}\n'
+    return subprocess.run(
+        ["bash", "-c", body, "runner-test", *(args or [])],
+        capture_output=True,
+        text=True,
+        env=merged,
+        check=False,
+    )
+
+
+# The runner derives the installed daemon path from HOME on purpose, so tests
+# rebind it after sourcing instead of adding an environment seam to the runner.
+INSTALLED_BIN_PRELUDE = 'INSTALLED_BIN="$TEST_INSTALLED_BIN"\n'
+
+
+def _fields(output: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for line in output.splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            fields[key] = value
+    return fields
+
+
+# --------------------------------------------------------------------------
+# Syntax
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "script",
+    [RUN_ALL, RUN_RUST_E2E, ELECTRON_BUILD, TAURI_BUILD],
+    ids=lambda path: f"{path.parent.name}/{path.name}",
+)
+def test_runner_scripts_have_valid_bash_syntax(script: Path) -> None:
+    assert subprocess.run(["bash", "-n", str(script)], check=False).returncode == 0
+
+
+@pytest.mark.parametrize("script", [RUN_ALL, RUN_RUST_E2E], ids=lambda path: path.name)
+def test_library_only_mode_fails_closed_when_script_is_executed(script: Path) -> None:
+    completed = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "CUA_E2E_RUNNER_LIB_ONLY": "1"},
+        check=False,
+    )
+    assert completed.returncode == 2
+    assert "valid only when this script is sourced" in completed.stderr
+
+
+# --------------------------------------------------------------------------
+# Status matching cannot break the producer's stdout
+# --------------------------------------------------------------------------
+
+
+def _noisy_status_bin(tmp_path: Path) -> Path:
+    """A CLI that reports the mode and then keeps writing to stdout.
+
+    The real driver CLI panics when its stdout closes mid-write, so a status
+    check that short-circuits the producer turns a match into a failure under
+    ``pipefail``.
+    """
+    fake = tmp_path / "fake-bin/cua-driver-local"
+    _write_executable(
+        fake,
+        """printf 'permission mode: unrestricted\n'
+i=0
+while [ "$i" -lt 20000 ]; do
+    printf 'status noise line %s\n' "$i" || exit 101
+    i=$((i + 1))
+done
+exit 0
+""",
+    )
+    return fake
+
+
+def test_short_circuiting_the_producer_would_fail_under_pipefail(tmp_path: Path) -> None:
+    fake = _noisy_status_bin(tmp_path)
+    completed = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'set -o pipefail; "$1" status | grep -Fq "permission mode: unrestricted"',
+            "pipe-test",
+            str(fake),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode != 0, "expected the closed-pipe producer to fail"
+
+
+def test_status_match_captures_output_before_matching(tmp_path: Path) -> None:
+    fake = _noisy_status_bin(tmp_path)
+    completed = _run(
+        RUN_ALL,
+        INSTALLED_BIN_PRELUDE
+        + 'if daemon_reports_permission_mode unrestricted; then echo "matched=yes"; '
+        'else echo "matched=no"; fi',
+        env={
+            "TEST_INSTALLED_BIN": str(fake),
+            "CUA_E2E_MACOS_DAEMON_SOCKET": str(tmp_path / "driver.sock"),
+        },
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "matched=yes" in completed.stdout
+
+
+def test_status_match_rejects_the_wrong_mode_and_a_failing_cli(tmp_path: Path) -> None:
+    standard = tmp_path / "fake-bin/standard"
+    _write_executable(standard, "printf 'permission mode: standard\n'\n")
+    broken = tmp_path / "fake-bin/broken"
+    _write_executable(broken, "printf 'permission mode: unrestricted\n'\nexit 3\n")
+
+    for binary, expected in ((standard, "matched=no"), (broken, "matched=no")):
+        completed = _run(
+            RUN_ALL,
+            INSTALLED_BIN_PRELUDE
+            + 'if daemon_reports_permission_mode unrestricted; then echo "matched=yes"; '
+            'else echo "matched=no"; fi',
+            env={"TEST_INSTALLED_BIN": str(binary)},
+        )
+        assert completed.returncode == 0, completed.stderr
+        assert expected in completed.stdout
+
+
+@pytest.mark.parametrize("script", [RUN_ALL, RUN_RUST_E2E], ids=lambda path: path.name)
+def test_no_permission_mode_check_pipes_into_grep(script: Path) -> None:
+    text = script.read_text(encoding="utf-8")
+    assert re.search(r"\|\s*grep\s+[^\n]*-q", text) is None
+
+
+# --------------------------------------------------------------------------
+# Build namespace selection
+# --------------------------------------------------------------------------
+
+SHA_A = "1111111111111111111111111111111111111111"
+SHA_B = "2222222222222222222222222222222222222222"
+
+
+def test_target_dir_is_owned_by_source_sha_and_run(tmp_path: Path) -> None:
+    env = {"CUA_E2E_CARGO_TARGET_ROOT": str(tmp_path / "cargo-target")}
+    first = _run(RUN_ALL, f'resolve_cargo_target_dir "{SHA_A}" "run-1"', env=env)
+    second = _run(RUN_ALL, f'resolve_cargo_target_dir "{SHA_A}" "run-2"', env=env)
+    other = _run(RUN_ALL, f'resolve_cargo_target_dir "{SHA_B}" "run-1"', env=env)
+    assert first.returncode == 0, first.stderr
+    assert first.stdout != second.stdout
+    assert first.stdout.strip() == str(tmp_path / "cargo-target" / SHA_A / "run-1")
+    assert second.stdout.strip() == str(tmp_path / "cargo-target" / SHA_A / "run-2")
+    assert other.stdout.strip() == str(tmp_path / "cargo-target" / SHA_B / "run-1")
+
+
+def test_target_dir_never_lands_in_the_workspace(tmp_path: Path) -> None:
+    completed = _run(
+        RUN_ALL,
+        f'resolve_cargo_target_dir "{SHA_A}" "run-1"',
+        env={"CUA_E2E_CARGO_TARGET_ROOT": str(tmp_path / "cargo-target")},
+    )
+    resolved = Path(completed.stdout.strip())
+    assert resolved.is_absolute()
+    assert REPO_ROOT not in resolved.parents
+
+
+def test_consecutive_same_sha_runs_get_distinct_namespaces(tmp_path: Path) -> None:
+    env = {"CUA_E2E_CARGO_TARGET_ROOT": str(tmp_path / "cargo-target")}
+    first = _run(RUN_ALL, f'resolve_cargo_target_dir "{SHA_A}" "run-1"', env=env)
+    second = _run(RUN_ALL, f'resolve_cargo_target_dir "{SHA_A}" "run-2"', env=env)
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+    assert first.stdout != second.stdout
+
+
+def test_relative_target_root_is_refused() -> None:
+    completed = _run(
+        RUN_ALL,
+        f'resolve_cargo_target_dir "{SHA_A}" "run-1"',
+        env={"CUA_E2E_CARGO_TARGET_ROOT": "relative/target"},
+    )
+    assert completed.returncode == 2
+    assert "absolute path" in completed.stderr
+
+
+def test_unsafe_run_id_is_refused(tmp_path: Path) -> None:
+    completed = _run(
+        RUN_ALL,
+        f'resolve_cargo_target_dir "{SHA_A}" "../shared"',
+        env={"CUA_E2E_CARGO_TARGET_ROOT": str(tmp_path / "cargo-target")},
+    )
+    assert completed.returncode == 2
+    assert "unsafe run id" in completed.stderr
+
+
+def test_non_sha_build_namespace_is_refused(tmp_path: Path) -> None:
+    completed = _run(
+        RUN_ALL,
+        'resolve_cargo_target_dir "not-a-sha" "run-1"',
+        env={"CUA_E2E_CARGO_TARGET_ROOT": str(tmp_path / "cargo-target")},
+    )
+    assert completed.returncode == 2
+    assert "build namespace" in completed.stderr
+
+
+def test_previous_artifact_run_is_preserved_without_mixing_results(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "macos"
+    history_root = tmp_path / "macos-history"
+    artifact_dir.mkdir()
+    (artifact_dir / "results.jsonl").write_text('{"cell_id":"old"}\n', encoding="utf-8")
+    completed = _run(
+        RUN_ALL,
+        'ARTIFACT_DIR="$TEST_ARTIFACT_DIR"\n'
+        'ARTIFACT_HISTORY_ROOT="$TEST_HISTORY_ROOT"\n'
+        'preserve_previous_artifacts "run-2"\n',
+        env={
+            "TEST_ARTIFACT_DIR": str(artifact_dir),
+            "TEST_HISTORY_ROOT": str(history_root),
+        },
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert artifact_dir.is_dir()
+    assert not any(artifact_dir.iterdir())
+    assert (history_root / "run-2/results.jsonl").read_text(encoding="utf-8") == (
+        '{"cell_id":"old"}\n'
+    )
+
+
+def test_artifact_history_is_never_overwritten(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "macos"
+    history_root = tmp_path / "macos-history"
+    artifact_dir.mkdir()
+    (artifact_dir / "results.jsonl").write_text("{}\n", encoding="utf-8")
+    (history_root / "run-2").mkdir(parents=True)
+    completed = _run(
+        RUN_ALL,
+        'ARTIFACT_DIR="$TEST_ARTIFACT_DIR"\n'
+        'ARTIFACT_HISTORY_ROOT="$TEST_HISTORY_ROOT"\n'
+        'preserve_previous_artifacts "run-2"\n',
+        env={
+            "TEST_ARTIFACT_DIR": str(artifact_dir),
+            "TEST_HISTORY_ROOT": str(history_root),
+        },
+    )
+    assert completed.returncode == 2
+    assert "refusing to overwrite" in completed.stderr
+    assert (artifact_dir / "results.jsonl").is_file()
+
+
+def test_run_rust_e2e_reads_binaries_from_the_configured_target_dir(tmp_path: Path) -> None:
+    rust_root = REPO_ROOT / "libs/cua-driver/rust"
+    default = _run(RUN_RUST_E2E, "resolved_build_target_dir", env={"CARGO_TARGET_DIR": ""})
+    absolute = _run(
+        RUN_RUST_E2E, "resolved_build_target_dir", env={"CARGO_TARGET_DIR": str(tmp_path / "t")}
+    )
+    relative = _run(RUN_RUST_E2E, "resolved_build_target_dir", env={"CARGO_TARGET_DIR": "nested"})
+    assert default.stdout.strip() == str(rust_root / "target")
+    assert absolute.stdout.strip() == str(tmp_path / "t")
+    assert relative.returncode == 2
+    assert "must be absolute" in relative.stderr
+    assert 'CUA_TEST_DRIVER_BIN="${BUILD_TARGET_DIR}/release/cua-driver"' in RUN_RUST_E2E.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_fixture_builds_use_fresh_run_owned_state() -> None:
+    tauri = TAURI_BUILD.read_text(encoding="utf-8")
+    electron = ELECTRON_BUILD.read_text(encoding="utf-8")
+    assert ELECTRON_LOCK.is_file()
+    assert 'tauriTargetDir="${CARGO_TARGET_DIR:-' in tauri
+    assert 'srcBin="$tauriTargetDir/release/' in tauri
+    assert 'CUA_E2E_FRESH_FIXTURE_STATE:-0}" == 1' in electron
+    assert "npm ci --silent" in electron
+
+
+# --------------------------------------------------------------------------
+# Option validation
+# --------------------------------------------------------------------------
+
+REPORT_OPTIONS = (
+    "status=0\n"
+    'parse_arguments "$@" || status=$?\n'
+    'printf "status=%s\\n" "$status"\n'
+    'printf "cell=%s\\n" "$RETRY_CELL"\n'
+    'printf "harness=%s\\n" "$RETRY_HARNESS"\n'
+    'printf "attempts=%s\\n" "$RETRY_ATTEMPTS"\n'
+    'printf "only=%s\\n" "$RETRY_ONLY"\n'
+    'printf "standalone=%s\\n" "$RUN_STANDALONE_BROWSER"\n'
+    'printf "nobuild=%s\\n" "$NO_BUILD"\n'
+)
+
+
+def _parse(args: list[str]) -> dict[str, str]:
+    completed = _run(RUN_ALL, REPORT_OPTIONS, args=args)
+    assert completed.returncode == 0, completed.stderr
+    return _fields(completed.stdout)
+
+
+def test_default_invocation_runs_the_full_matrix() -> None:
+    fields = _parse([])
+    assert fields["status"] == "0"
+    assert fields["cell"] == ""
+    assert fields["only"] == "0"
+    assert fields["standalone"] == "0"
+    assert fields["nobuild"] == "0"
+
+
+def test_full_retry_selection_is_accepted() -> None:
+    fields = _parse(
+        [
+            "--retry-cell",
+            "macos-electron-drag-px-foreground",
+            "--retry-harness",
+            "electron",
+            "--retry-attempts",
+            "3",
+            "--retry-only",
+        ]
+    )
+    assert fields["status"] == "0"
+    assert fields["cell"] == "macos-electron-drag-px-foreground"
+    assert fields["harness"] == "electron"
+    assert fields["attempts"] == "3"
+    assert fields["only"] == "1"
+
+
+def test_retry_attempts_default_to_one() -> None:
+    fields = _parse(["--retry-cell=macos-electron-drag-px-foreground"])
+    assert fields["status"] == "0"
+    assert fields["attempts"] == "1"
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param(["--retry-harness", "electron"], id="harness-without-cell"),
+        pytest.param(["--retry-attempts", "2"], id="attempts-without-cell"),
+        pytest.param(["--retry-only"], id="retry-only-without-cell"),
+        pytest.param(["--retry-cell", "a,b"], id="cell-list"),
+        pytest.param(["--retry-cell", "../escape"], id="cell-path-traversal"),
+        pytest.param(["--retry-cell", "cell", "--retry-attempts", "0"], id="zero-attempts"),
+        pytest.param(["--retry-cell", "cell", "--retry-attempts", "4"], id="too-many-attempts"),
+        pytest.param(
+            ["--retry-cell", "cell", "--retry-attempts", "two"], id="non-numeric-attempts"
+        ),
+        pytest.param(["--retry-cell", "cell", "--retry-harness", "Electron!"], id="bad-harness"),
+        pytest.param(["--retry-cell"], id="missing-cell-value"),
+        pytest.param(["--retry-cell", "--retry-only"], id="flag-as-cell-value"),
+        pytest.param(
+            ["--retry-cell", "cell", "--retry-only", "--standalone-browser"],
+            id="retry-only-with-standalone-browser",
+        ),
+        pytest.param(["--unknown"], id="unknown-argument"),
+    ],
+)
+def test_invalid_options_are_refused(args: list[str]) -> None:
+    fields = _parse(args)
+    assert fields["status"] == "2"
+
+
+def test_help_exits_without_running() -> None:
+    completed = _run(RUN_ALL, REPORT_OPTIONS, args=["--help"])
+    fields = _fields(completed.stdout)
+    assert fields["status"] == "3"
+    assert "--retry-cell" in completed.stdout
+
+
+def test_full_matrix_clears_inherited_retry_filters(tmp_path: Path) -> None:
+    fake_repo = tmp_path / "repo"
+    output = tmp_path / "filters.txt"
+    _write_executable(
+        fake_repo / "scripts/ci/macos/run-rust-e2e.sh",
+        """printf 'cell=%s\nharness=%s\nlane=%s\n' \\
+    "${CUA_E2E_CELL_FILTER:-}" "${CUA_E2E_HARNESS_FILTER:-}" \\
+    "${CUA_E2E_INTERNAL_LANE:-}" > "$CUA_TEST_FILTER_OUTPUT"
+""",
+    )
+    completed = _run(
+        RUN_ALL,
+        'REPO_ROOT="$TEST_FAKE_REPO"\nrun_full_matrix\n',
+        env={
+            "TEST_FAKE_REPO": str(fake_repo),
+            "CUA_TEST_FILTER_OUTPUT": str(output),
+            "CUA_E2E_CELL_FILTER": "stale-cell",
+            "CUA_E2E_HARNESS_FILTER": "electron",
+            "CUA_E2E_INTERNAL_LANE": "shared",
+        },
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert output.read_text(encoding="utf-8") == "cell=\nharness=\nlane=\n"
+
+
+# --------------------------------------------------------------------------
+# Retry bookkeeping
+# --------------------------------------------------------------------------
+
+
+def _result_row(cell_id: str, status: str, harness: str = "electron") -> dict[str, object]:
+    return {
+        "schema": "cua-driver/e2e-result@v1",
+        "cell_id": cell_id,
+        "harness": harness,
+        "test_status": status,
+    }
+
+
+def _write_results(path: Path, rows: list[dict[str, object]]) -> None:
+    path.write_text("".join(f"{json.dumps(row)}\n" for row in rows), encoding="utf-8")
+
+
+def _write_failures(path: Path, **overrides: object) -> None:
+    record: dict[str, object] = {
+        "schema": "cua-driver/e2e-failures@v1",
+        "suite": "all",
+        "filters": {"cell": "", "harness": ""},
+        "failure_count": 1,
+        "preflight_failed": False,
+        "report_failed": False,
+        "lanes": ["shared-app-matrix"],
+        "video_failures": [],
+    }
+    record.update(overrides)
+    path.write_text(json.dumps(record), encoding="utf-8")
+
+
+CHECK_ELIGIBILITY = (
+    "RETRY_CELL=\"$RETRY_CELL_UNDER_TEST\"\n"
+    "RETRY_HARNESS=\"$RETRY_HARNESS_UNDER_TEST\"\n"
+    "status=0\n"
+    'retry_selection_is_eligible "$RESULTS" "$FAILURES" || status=$?\n'
+    'printf "status=%s\\n" "$status"\n'
+    'printf "cells=%s\\n" "${RETRY_INITIAL_CELLS[*]:-}"\n'
+    'printf "lanes=%s\\n" "$RETRY_INITIAL_LANES_JSON"\n'
+)
+
+
+def _eligibility(
+    tmp_path: Path,
+    rows: list[dict[str, object]],
+    cell: str = "macos-electron-drag-px-foreground",
+    harness: str = "",
+    failures: dict[str, object] | None = None,
+    write_failures: bool = True,
+) -> dict[str, str]:
+    results = tmp_path / "results.jsonl"
+    failures_file = tmp_path / "failures.json"
+    _write_results(results, rows)
+    if write_failures:
+        _write_failures(failures_file, **(failures or {}))
+    completed = _run(
+        RUN_ALL,
+        CHECK_ELIGIBILITY,
+        env={
+            "RESULTS": str(results),
+            "FAILURES": str(failures_file),
+            "RETRY_CELL_UNDER_TEST": cell,
+            "RETRY_HARNESS_UNDER_TEST": harness,
+        },
+    )
+    assert completed.returncode == 0, completed.stderr
+    fields = _fields(completed.stdout)
+    fields["stderr"] = completed.stderr
+    return fields
+
+
+@requires_jq
+def test_single_cell_failure_is_retryable(tmp_path: Path) -> None:
+    fields = _eligibility(
+        tmp_path,
+        [
+            _result_row("macos-electron-click-ax-background", "pass"),
+            _result_row("macos-electron-drag-px-foreground", "fail"),
+        ],
+        harness="electron",
+    )
+    assert fields["status"] == "0"
+    assert fields["cells"] == "macos-electron-drag-px-foreground"
+    assert fields["lanes"] == '["shared-app-matrix"]'
+
+
+@requires_jq
+def test_two_failing_cells_are_not_retryable(tmp_path: Path) -> None:
+    fields = _eligibility(
+        tmp_path,
+        [
+            _result_row("macos-electron-drag-px-foreground", "fail"),
+            _result_row("macos-tauri-scroll-px-background", "fail"),
+        ],
+    )
+    assert fields["status"] == "1"
+    assert "are not exactly" in fields["stderr"]
+
+
+@requires_jq
+def test_a_different_failing_cell_is_not_retryable(tmp_path: Path) -> None:
+    fields = _eligibility(tmp_path, [_result_row("macos-tauri-drag-px-foreground", "fail")])
+    assert fields["status"] == "1"
+
+
+@requires_jq
+def test_a_skipped_cell_counts_as_a_failure(tmp_path: Path) -> None:
+    fields = _eligibility(
+        tmp_path,
+        [
+            _result_row("macos-electron-drag-px-foreground", "fail"),
+            _result_row("macos-electron-click-ax-background", "skip"),
+        ],
+    )
+    assert fields["status"] == "1"
+
+
+@requires_jq
+def test_harness_mismatch_is_not_retryable(tmp_path: Path) -> None:
+    fields = _eligibility(
+        tmp_path,
+        [_result_row("macos-electron-drag-px-foreground", "fail", harness="wkwebview")],
+        harness="electron",
+    )
+    assert fields["status"] == "1"
+    assert "belongs to harness" in fields["stderr"]
+
+
+@requires_jq
+@pytest.mark.parametrize(
+    ("failures", "expected"),
+    [
+        pytest.param({"preflight_failed": True}, "preflight", id="preflight"),
+        pytest.param(
+            {"report_failed": True, "failure_count": 2},
+            "report validation",
+            id="report-validation",
+        ),
+        pytest.param({"video_failures": ["orphan:recordings/x"]}, "video", id="video"),
+        pytest.param({"failure_count": 2}, "failure signals", id="extra-failure-signal"),
+        pytest.param(
+            {"lanes": ["shared-app-matrix", "capture-contract"]}, "lanes failed", id="two-lanes"
+        ),
+        pytest.param({"lanes": ["capture-contract"]}, "not retryable", id="non-retryable-lane"),
+        pytest.param(
+            {"lanes": ["embedded-browser-routes"]}, "not retryable", id="embedded-browser-lane"
+        ),
+        pytest.param({"lanes": []}, "lanes failed", id="no-lane"),
+    ],
+)
+def test_non_cell_failures_are_never_retryable(
+    tmp_path: Path, failures: dict[str, object], expected: str
+) -> None:
+    fields = _eligibility(
+        tmp_path, [_result_row("macos-electron-drag-px-foreground", "fail")], failures=failures
+    )
+    assert fields["status"] == "1"
+    assert expected in fields["stderr"]
+
+
+@requires_jq
+def test_missing_failure_record_blocks_the_retry(tmp_path: Path) -> None:
+    fields = _eligibility(
+        tmp_path,
+        [_result_row("macos-electron-drag-px-foreground", "fail")],
+        write_failures=False,
+    )
+    assert fields["status"] == "1"
+    assert "machine-readable failure record" in fields["stderr"]
+
+
+@requires_jq
+def test_missing_results_block_the_retry(tmp_path: Path) -> None:
+    completed = _run(
+        RUN_ALL,
+        CHECK_ELIGIBILITY,
+        env={
+            "RESULTS": str(tmp_path / "absent.jsonl"),
+            "FAILURES": str(tmp_path / "absent.json"),
+            "RETRY_CELL_UNDER_TEST": "macos-electron-drag-px-foreground",
+            "RETRY_HARNESS_UNDER_TEST": "",
+        },
+    )
+    assert _fields(completed.stdout)["status"] == "1"
+    assert "no typed result rows" in completed.stderr
+
+
+@requires_jq
+def test_retry_attempt_records_keep_every_attempt(tmp_path: Path) -> None:
+    completed = _run(RUN_ALL, "RETRY_EXIT_CODES=(1 1 0)\nretry_attempts_json")
+    assert completed.returncode == 0, completed.stderr
+    attempts = json.loads(completed.stdout)
+    assert [attempt["status"] for attempt in attempts] == ["fail", "fail", "pass"]
+    assert [attempt["evidence"] for attempt in attempts] == [
+        "attempts/retry-1",
+        "attempts/retry-2",
+        ".",
+    ]
+    empty = _run(RUN_ALL, "RETRY_EXIT_CODES=()\nretry_attempts_json")
+    assert json.loads(empty.stdout) == []
+
+
+@requires_jq
+def test_retry_result_must_be_exactly_one_selected_cell(tmp_path: Path) -> None:
+    results = tmp_path / "results.jsonl"
+    selected = "macos-electron-drag-px-foreground"
+    _write_results(results, [_result_row(selected, "pass")])
+    completed = _run(
+        RUN_ALL,
+        'ARTIFACT_DIR="$TEST_ARTIFACT_DIR"\n'
+        'RETRY_CELL="$TEST_RETRY_CELL"\n'
+        "status=0\nretry_result_is_exact || status=$?\n"
+        'printf "status=%s\\n" "$status"\n',
+        env={"TEST_ARTIFACT_DIR": str(tmp_path), "TEST_RETRY_CELL": selected},
+    )
+    assert _fields(completed.stdout)["status"] == "0"
+
+    _write_results(
+        results,
+        [
+            _result_row(selected, "pass"),
+            _result_row(f"{selected}-extra", "pass"),
+        ],
+    )
+    completed = _run(
+        RUN_ALL,
+        'ARTIFACT_DIR="$TEST_ARTIFACT_DIR"\n'
+        'RETRY_CELL="$TEST_RETRY_CELL"\n'
+        "status=0\nretry_result_is_exact || status=$?\n"
+        'printf "status=%s\\n" "$status"\n',
+        env={"TEST_ARTIFACT_DIR": str(tmp_path), "TEST_RETRY_CELL": selected},
+    )
+    assert _fields(completed.stdout)["status"] == "1"
+
+
+@requires_jq
+def test_retry_record_keeps_the_initial_failure(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    (artifact_dir / "summary.md").write_text("# macOS E2E\n\nall green\n", encoding="utf-8")
+    initial = json.dumps(
+        {
+            "status": "fail",
+            "exit_code": 1,
+            "failing_cells": ["macos-electron-drag-px-foreground"],
+            "lanes": ["shared-app-matrix"],
+            "evidence": "attempts/attempt-1-full-matrix",
+        }
+    )
+    completed = _run(
+        RUN_ALL,
+        'ARTIFACT_DIR="$TEST_ARTIFACT_DIR"\n'
+        'RETRY_CELL="macos-electron-drag-px-foreground"\n'
+        'RETRY_HARNESS="electron"\n'
+        "RETRY_ATTEMPTS=2\n"
+        "RETRY_EXIT_CODES=(1 0)\n"
+        'write_retry_record pass-after-retry "$INITIAL_JSON"\n',
+        env={"TEST_ARTIFACT_DIR": str(artifact_dir), "INITIAL_JSON": initial},
+    )
+    assert completed.returncode == 0, completed.stderr
+
+    record = json.loads((artifact_dir / "retry-record.json").read_text(encoding="utf-8"))
+    assert record["schema"] == "cua-driver/e2e-retry-record@v1"
+    assert record["mode"] == "after-full-matrix"
+    assert record["final_status"] == "pass-after-retry"
+    assert record["selection"] == {
+        "cell_id": "macos-electron-drag-px-foreground",
+        "harness": "electron",
+        "internal_lane": "shared",
+        "allowed_attempts": 2,
+    }
+    assert record["initial_attempt"]["status"] == "fail"
+    assert record["initial_attempt"]["failing_cells"] == ["macos-electron-drag-px-foreground"]
+    assert [attempt["status"] for attempt in record["retry_attempts"]] == ["fail", "pass"]
+
+    summary = (artifact_dir / "summary.md").read_text(encoding="utf-8")
+    assert "all green" in summary
+    assert "Retry provenance" in summary
+    assert "Initial full matrix: FAILED on `macos-electron-drag-px-foreground`" in summary
+    assert "#1 fail" in summary and "#2 pass" in summary
+
+
+@requires_jq
+def test_retry_only_record_states_that_no_full_matrix_ran(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    completed = _run(
+        RUN_ALL,
+        'ARTIFACT_DIR="$TEST_ARTIFACT_DIR"\n'
+        'RETRY_CELL="macos-electron-drag-px-foreground"\n'
+        "RETRY_ONLY=1\n"
+        "RETRY_ATTEMPTS=1\n"
+        "RETRY_EXIT_CODES=(1)\n"
+        "write_retry_record fail-retry-only null\n",
+        env={"TEST_ARTIFACT_DIR": str(artifact_dir)},
+    )
+    assert completed.returncode == 0, completed.stderr
+    record = json.loads((artifact_dir / "retry-record.json").read_text(encoding="utf-8"))
+    assert record["mode"] == "retry-only"
+    assert record["initial_attempt"] is None
+    assert record["final_status"] == "fail-retry-only"
+    summary = (artifact_dir / "summary.md").read_text(encoding="utf-8")
+    assert "not run in this invocation" in summary
+
+
+def test_archiving_evidence_preserves_the_previous_attempt(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "artifacts"
+    (artifact_dir / "recordings/cell-a").mkdir(parents=True)
+    (artifact_dir / "recordings/cell-a/recording.mp4").write_text("mp4", encoding="utf-8")
+    (artifact_dir / "results.jsonl").write_text("{}\n", encoding="utf-8")
+    (artifact_dir / "cases.jsonl").write_text("{}\n", encoding="utf-8")
+    (artifact_dir / "summary.md").write_text("summary\n", encoding="utf-8")
+    (artifact_dir / "shared-app-matrix.log").write_text("log\n", encoding="utf-8")
+    (artifact_dir / "failures.json").write_text("{}\n", encoding="utf-8")
+
+    completed = _run(
+        RUN_ALL,
+        'ARTIFACT_DIR="$TEST_ARTIFACT_DIR"\n'
+        "archive_attempt_evidence attempt-1-full-matrix\n"
+        'printf "path=%s\\n" "$ATTEMPT_EVIDENCE_PATH"\n',
+        env={"TEST_ARTIFACT_DIR": str(artifact_dir)},
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert _fields(completed.stdout)["path"] == "attempts/attempt-1-full-matrix"
+
+    archived = artifact_dir / "attempts/attempt-1-full-matrix"
+    assert (archived / "recordings/cell-a/recording.mp4").read_text(encoding="utf-8") == "mp4"
+    copied = (
+        "results.jsonl",
+        "cases.jsonl",
+        "summary.md",
+        "shared-app-matrix.log",
+        "failures.json",
+    )
+    for name in copied:
+        assert (archived / name).exists(), name
+        # Copies keep the root readable; nothing is deleted to make room.
+        assert (artifact_dir / name).exists(), name
+    # Only the recordings directory moves, so the next attempt starts empty.
+    assert not (artifact_dir / "recordings").exists()
+
+
+# --------------------------------------------------------------------------
+# Daemon ownership and restoration
+# --------------------------------------------------------------------------
+
+
+def _daemon_fakes(tmp_path: Path, initial_mode: str = "standard") -> tuple[Path, dict[str, str]]:
+    """Fake driver CLI, launchctl, and open that record what the runner did."""
+    fake_bin = tmp_path / "fake-bin"
+    mode_file = tmp_path / "mode"
+    mode_file.write_text(f"{initial_mode}\n", encoding="utf-8")
+    calls = tmp_path / "calls.txt"
+
+    _write_executable(
+        fake_bin / "cua-driver-local",
+        """case "${1:-}" in
+    status) printf 'permission mode: %s\n' "$(cat "$CUA_TEST_MODE_FILE")" ;;
+    stop) printf 'stop\n' >> "$CUA_TEST_CALLS"; printf 'stopped\n' > "$CUA_TEST_MODE_FILE" ;;
+    *) printf 'unsupported %s\n' "${1:-}" >&2; exit 2 ;;
+esac
+exit 0
+""",
+    )
+    _write_executable(
+        fake_bin / "launchctl",
+        """printf 'launchctl %s\n' "$*" >> "$CUA_TEST_CALLS"
+if [ "${1:-}" = print ] && [ "${CUA_TEST_GUI_UNAVAILABLE:-0}" = 1 ]; then
+    exit 125
+fi
+if [ "${1:-}" = load ]; then
+    printf '%s\n' "${CUA_TEST_LOAD_MODE:-standard}" > "$CUA_TEST_MODE_FILE"
+fi
+exit 0
+""",
+    )
+    _write_executable(
+        fake_bin / "open",
+        """printf 'open %s\n' "$*" >> "$CUA_TEST_CALLS"
+printf '%s\n' "${CUA_TEST_START_MODE:-unrestricted}" > "$CUA_TEST_MODE_FILE"
+exit 0
+""",
+    )
+    env = {
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "TEST_INSTALLED_BIN": str(fake_bin / "cua-driver-local"),
+        "CUA_TEST_MODE_FILE": str(mode_file),
+        "CUA_TEST_CALLS": str(calls),
+        "CUA_E2E_DAEMON_WAIT_ATTEMPTS": "1",
+    }
+    return calls, env
+
+
+def test_ensure_unrestricted_daemon_starts_and_verifies_the_mode(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    calls, env = _daemon_fakes(tmp_path)
+    env["TEST_ARTIFACT_DIR"] = str(artifact_dir)
+    completed = _run(
+        RUN_ALL,
+        INSTALLED_BIN_PRELUDE + 'ARTIFACT_DIR="$TEST_ARTIFACT_DIR"\n'
+        "status=0\n"
+        "ensure_unrestricted_daemon || status=$?\n"
+        "stop_unrestricted_watchdog\n"
+        'printf "status=%s\\n" "$status"\n'
+        'printf "restore=%s\\n" "$RESTORE_STANDARD_DAEMON"\n',
+        env=env,
+    )
+    assert completed.returncode == 0, completed.stderr
+    fields = _fields(completed.stdout)
+    assert fields["status"] == "0"
+    assert fields["restore"] == "1"
+    recorded = calls.read_text(encoding="utf-8")
+    assert "launchctl unload" in recorded
+    assert "--permission-mode unrestricted" in recorded
+    assert "--dangerously-bypass-approvals" in recorded
+
+
+def test_ensure_unrestricted_daemon_fails_when_the_mode_never_appears(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    _calls, env = _daemon_fakes(tmp_path)
+    env["TEST_ARTIFACT_DIR"] = str(artifact_dir)
+    env["CUA_TEST_START_MODE"] = "standard"
+    completed = _run(
+        RUN_ALL,
+        INSTALLED_BIN_PRELUDE + 'ARTIFACT_DIR="$TEST_ARTIFACT_DIR"\n'
+        "status=0\n"
+        "ensure_unrestricted_daemon || status=$?\n"
+        "stop_unrestricted_watchdog\n"
+        'printf "status=%s\\n" "$status"\n',
+        env=env,
+    )
+    assert _fields(completed.stdout)["status"] == "1"
+    assert "could not start its unrestricted worker daemon" in completed.stderr
+
+
+def test_a_targeted_retry_reclaims_the_daemon_before_running(tmp_path: Path) -> None:
+    """A retry must not inherit whatever mode the worker happens to be in."""
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    calls, env = _daemon_fakes(tmp_path)
+    env["TEST_ARTIFACT_DIR"] = str(artifact_dir)
+    # A stub matrix keeps this test on the daemon and filter contract.
+    fake_repo = tmp_path / "fake-repo"
+    _write_executable(
+        fake_repo / "scripts/ci/macos/run-rust-e2e.sh",
+        """printf 'matrix lane=%s cell=%s harness=%s args=[%s]\n' \\
+    "$CUA_E2E_INTERNAL_LANE" "$CUA_E2E_CELL_FILTER" "$CUA_E2E_HARNESS_FILTER" "$*" \\
+    >> "$CUA_TEST_CALLS"
+printf '{"cell_id":"%s","test_status":"pass"}\n' "$CUA_E2E_CELL_FILTER" \\
+    > "$CUA_TEST_RESULTS_FILE"
+exit 0
+""",
+    )
+    env["TEST_FAKE_REPO"] = str(fake_repo)
+    env["CUA_TEST_RESULTS_FILE"] = str(artifact_dir / "results.jsonl")
+    completed = _run(
+        RUN_ALL,
+        INSTALLED_BIN_PRELUDE + 'ARTIFACT_DIR="$TEST_ARTIFACT_DIR"\n'
+        'REPO_ROOT="$TEST_FAKE_REPO"\n'
+        'RETRY_CELL="macos-electron-drag-px-foreground"\n'
+        'RETRY_HARNESS="electron"\n'
+        "RETRY_ATTEMPTS=1\n"
+        "status=0\n"
+        "run_retry_sequence || status=$?\n"
+        "stop_unrestricted_watchdog\n"
+        'printf "status=%s\\n" "$status"\n',
+        env=env,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert _fields(completed.stdout)["status"] == "0"
+    recorded = calls.read_text(encoding="utf-8")
+    assert "--permission-mode unrestricted" in recorded
+    assert (
+        "matrix lane=shared cell=macos-electron-drag-px-foreground harness=electron args=[]"
+        in recorded
+    )
+    # The daemon is claimed and verified before the retry runs.
+    assert recorded.index("--permission-mode unrestricted") < recorded.index("matrix lane=")
+
+
+def test_a_persistent_failure_exhausts_the_bounded_attempts(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    calls, env = _daemon_fakes(tmp_path)
+    env["TEST_ARTIFACT_DIR"] = str(artifact_dir)
+    completed = _run(
+        RUN_ALL,
+        INSTALLED_BIN_PRELUDE + 'ARTIFACT_DIR="$TEST_ARTIFACT_DIR"\n'
+        'RETRY_CELL="macos-electron-drag-px-foreground"\n'
+        "RETRY_ATTEMPTS=3\n"
+        'run_retry_matrix() { printf "attempt\\n" >> "$CUA_TEST_CALLS"; return 1; }\n'
+        "status=0\n"
+        "run_retry_sequence || status=$?\n"
+        "stop_unrestricted_watchdog\n"
+        'printf "status=%s\\n" "$status"\n'
+        'printf "codes=%s\\n" "${RETRY_EXIT_CODES[*]}"\n',
+        env=env,
+    )
+    fields = _fields(completed.stdout)
+    assert fields["status"] == "1", completed.stderr
+    assert fields["codes"] == "1 1 1"
+    assert calls.read_text(encoding="utf-8").count("attempt\n") == 3
+
+
+def test_retry_records_a_daemon_start_failure_as_an_attempt() -> None:
+    completed = _run(
+        RUN_ALL,
+        'RETRY_CELL="macos-electron-drag-px-foreground"\n'
+        "RETRY_ATTEMPTS=2\n"
+        "ensure_unrestricted_daemon() { return 1; }\n"
+        "status=0\n"
+        "run_retry_sequence || status=$?\n"
+        'printf "status=%s\\n" "$status"\n'
+        'printf "codes=%s\\n" "${RETRY_EXIT_CODES[*]}"\n',
+    )
+    fields = _fields(completed.stdout)
+    assert fields["status"] == "1"
+    assert fields["codes"] == "1"
+
+
+def test_watchdog_does_not_restart_after_one_transient_probe_failure(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    calls, env = _daemon_fakes(tmp_path, initial_mode="unrestricted")
+    probe_count = tmp_path / "probe-count"
+    probe_count.write_text("0\n", encoding="utf-8")
+    env["CUA_TEST_PROBE_COUNT"] = str(probe_count)
+    env["TEST_ARTIFACT_DIR"] = str(artifact_dir)
+    _write_executable(
+        Path(env["TEST_INSTALLED_BIN"]),
+        """case "${1:-}" in
+    status)
+        count=$(cat "$CUA_TEST_PROBE_COUNT")
+        count=$((count + 1))
+        printf '%s\n' "$count" > "$CUA_TEST_PROBE_COUNT"
+        if [ "$count" -eq 1 ]; then exit 3; fi
+        printf 'permission mode: unrestricted\n'
+        ;;
+    stop) printf 'stop\n' >> "$CUA_TEST_CALLS" ;;
+esac
+exit 0
+""",
+    )
+    completed = _run(
+        RUN_ALL,
+        INSTALLED_BIN_PRELUDE
+        + 'ARTIFACT_DIR="$TEST_ARTIFACT_DIR"\n'
+        "watchdog_check_once\n",
+        env=env,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert not calls.exists() or "stop" not in calls.read_text(encoding="utf-8")
+    assert probe_count.read_text(encoding="utf-8").strip() == "2"
+
+
+@pytest.mark.parametrize("body_status", [0, 7], ids=["success", "failure"])
+def test_the_trap_restores_the_standard_daemon_and_keeps_the_status(
+    tmp_path: Path, body_status: int
+) -> None:
+    calls, env = _daemon_fakes(tmp_path, initial_mode="unrestricted")
+    completed = _run(
+        RUN_ALL,
+        INSTALLED_BIN_PRELUDE + "RESTORE_STANDARD_DAEMON=1\n"
+        "install_daemon_restore_traps\n"
+        'exit "$TEST_BODY_STATUS"\n',
+        env={**env, "TEST_BODY_STATUS": str(body_status)},
+    )
+    assert completed.returncode == body_status, completed.stderr
+    recorded = calls.read_text(encoding="utf-8")
+    assert "stop" in recorded
+    assert "launchctl load" in recorded
+
+
+def test_sigterm_restores_standard_daemon_and_preserves_signal_status(tmp_path: Path) -> None:
+    calls, env = _daemon_fakes(tmp_path, initial_mode="unrestricted")
+    completed = _run(
+        RUN_ALL,
+        INSTALLED_BIN_PRELUDE
+        + "RESTORE_STANDARD_DAEMON=1\n"
+        "install_daemon_restore_traps\n"
+        "kill -TERM $$\n",
+        env=env,
+    )
+    assert completed.returncode == 143, completed.stderr
+    recorded = calls.read_text(encoding="utf-8")
+    assert "stop" in recorded
+    assert "launchctl load" in recorded
+
+
+def test_sighup_defers_standard_daemon_until_the_next_gui_login(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    plist = tmp_path / "com.trycua.cua-driver-local.plist"
+    plist.write_text("launch agent", encoding="utf-8")
+    calls, env = _daemon_fakes(tmp_path, initial_mode="unrestricted")
+    env.update(
+        {
+            "CUA_TEST_GUI_UNAVAILABLE": "1",
+            "TEST_ARTIFACT_DIR": str(artifact_dir),
+            "TEST_LOCAL_PLIST": str(plist),
+        }
+    )
+    completed = _run(
+        RUN_ALL,
+        INSTALLED_BIN_PRELUDE
+        + 'ARTIFACT_DIR="$TEST_ARTIFACT_DIR"\n'
+        + 'LOCAL_PLIST="$TEST_LOCAL_PLIST"\n'
+        + "RESTORE_STANDARD_DAEMON=1\n"
+        + "install_daemon_restore_traps\n"
+        + "kill -HUP $$\n",
+        env=env,
+    )
+    assert completed.returncode == 129, completed.stderr
+    recorded = calls.read_text(encoding="utf-8")
+    assert "launchctl print" in recorded
+    assert "launchctl load" not in recorded
+    marker = artifact_dir / "standard-daemon-restore-deferred.txt"
+    assert marker.read_text(encoding="utf-8") == (
+        "status=deferred-until-next-gui-login\nexit_status=129\n"
+    )
+
+
+def test_a_failed_restoration_fails_an_otherwise_green_run(tmp_path: Path) -> None:
+    _calls, env = _daemon_fakes(tmp_path, initial_mode="unrestricted")
+    env["CUA_TEST_LOAD_MODE"] = "unrestricted"
+    completed = _run(
+        RUN_ALL,
+        INSTALLED_BIN_PRELUDE
+        + "RESTORE_STANDARD_DAEMON=1\ninstall_daemon_restore_traps\nexit 0\n",
+        env=env,
+    )
+    assert completed.returncode == 1
+    assert "could not restore its standard autostart daemon" in completed.stderr
+
+
+def test_the_trap_leaves_an_unclaimed_daemon_alone(tmp_path: Path) -> None:
+    calls, env = _daemon_fakes(tmp_path)
+    completed = _run(
+        RUN_ALL,
+        INSTALLED_BIN_PRELUDE
+        + "RESTORE_STANDARD_DAEMON=0\ninstall_daemon_restore_traps\nexit 4\n",
+        env=env,
+    )
+    assert completed.returncode == 4
+    assert not calls.exists() or "launchctl load" not in calls.read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# Machine-readable failure record produced by the matrix runner
+# --------------------------------------------------------------------------
+
+
+@requires_jq
+def test_failure_record_separates_cells_lanes_videos_and_preflight(tmp_path: Path) -> None:
+    record_file = tmp_path / "failures.json"
+    completed = _run(
+        RUN_RUST_E2E,
+        'SUITE=shared\nCUA_E2E_CELL_FILTER="macos-electron-drag-px-foreground"\n'
+        'CUA_E2E_HARNESS_FILTER="electron"\n'
+        "note_lane_failure shared-app-matrix\n"
+        "note_video_failure orphan:recordings/x/recording.mp4\n"
+        "REPORT_FAILED=1\n"
+        "FAILURE_COUNT=$((FAILURE_COUNT + 1))\n"
+        'write_failure_record "$RECORD_FILE"\n',
+        env={"RECORD_FILE": str(record_file)},
+    )
+    assert completed.returncode == 0, completed.stderr
+    record = json.loads(record_file.read_text(encoding="utf-8"))
+    assert record["schema"] == "cua-driver/e2e-failures@v1"
+    assert record["suite"] == "shared"
+    assert record["filters"] == {
+        "cell": "macos-electron-drag-px-foreground",
+        "harness": "electron",
+    }
+    assert record["lanes"] == ["shared-app-matrix"]
+    assert record["video_failures"] == ["orphan:recordings/x/recording.mp4"]
+    assert record["preflight_failed"] is False
+    assert record["report_failed"] is True
+    assert record["failure_count"] == 3
+
+
+@requires_jq
+def test_a_green_run_writes_an_empty_failure_record(tmp_path: Path) -> None:
+    record_file = tmp_path / "failures.json"
+    completed = _run(
+        RUN_RUST_E2E,
+        'write_failure_record "$RECORD_FILE"',
+        env={"RECORD_FILE": str(record_file)},
+    )
+    assert completed.returncode == 0, completed.stderr
+    record = json.loads(record_file.read_text(encoding="utf-8"))
+    assert record["failure_count"] == 0
+    assert record["lanes"] == []
+    assert record["video_failures"] == []
+    assert record["preflight_failed"] is False
+    assert record["report_failed"] is False
+
+
+def test_lane_bookkeeping_records_only_failing_lanes(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    completed = _run(
+        RUN_RUST_E2E,
+        'ARTIFACT_DIR="$TEST_ARTIFACT_DIR"\nRUST_ROOT="$TEST_ARTIFACT_DIR"\n'
+        "run_test green true\n"
+        "run_test red false\n"
+        'printf "count=%s\\n" "$FAILURE_COUNT"\n'
+        'printf "lanes=%s\\n" "${FAILED_LANES[*]}"\n',
+        env={"TEST_ARTIFACT_DIR": str(artifact_dir)},
+    )
+    assert completed.returncode == 0, completed.stderr
+    fields = _fields(completed.stdout)
+    assert fields["count"] == "1"
+    assert fields["lanes"] == "red"
+    assert (artifact_dir / "green.log").exists()
+    assert (artifact_dir / "red.log").exists()

--- a/libs/cua-driver/tests/fixtures/apps/cross-platform/electron/.gitignore
+++ b/libs/cua-driver/tests/fixtures/apps/cross-platform/electron/.gitignore
@@ -1,4 +1,3 @@
 node_modules/
 dist/
 web/
-package-lock.json

--- a/libs/cua-driver/tests/fixtures/apps/cross-platform/electron/build.sh
+++ b/libs/cua-driver/tests/fixtures/apps/cross-platform/electron/build.sh
@@ -30,6 +30,26 @@ cd "$elecDir"
 mkdir -p "$elecDir/web"
 cp -r "$harnessDir/shared/web/." "$elecDir/web/"
 
+# Certification runs archive any inherited dependency tree and reinstall from
+# the lockfile. This keeps a same-SHA rerun independent of worker state without
+# deleting evidence from the previous fixture build.
+if [[ "${CUA_E2E_FRESH_FIXTURE_STATE:-0}" == 1 ]]; then
+  fixtureRunId="${CUA_E2E_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
+  fixtureArchiveRoot="${TMPDIR:-/tmp}/cua-electron-fixture-archive"
+  fixtureArchive="${fixtureArchiveRoot}/node_modules.${fixtureRunId}"
+  if [[ -e "$fixtureArchive" ]]; then
+    echo "[ERROR] refusing to overwrite fixture archive: $fixtureArchive" >&2
+    exit 2
+  fi
+  if [[ -d "$elecDir/node_modules" ]]; then
+    mkdir -p "$fixtureArchiveRoot"
+    mv "$elecDir/node_modules" "$fixtureArchive"
+    echo "[EVIDENCE] Archived inherited Electron dependencies at $fixtureArchive"
+  fi
+  echo "[INSTALL] npm ci from the pinned lockfile..."
+  npm ci --silent
+fi
+
 # install the Electron runtime for the current platform
 if [ "$platform" = "Darwin" ]; then
   electronBin="$elecDir/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron"
@@ -49,7 +69,7 @@ electron_install_complete() {
   fi
 }
 
-if ! electron_install_complete; then
+if [[ "${CUA_E2E_FRESH_FIXTURE_STATE:-0}" != 1 ]] && ! electron_install_complete; then
   echo "[INSTALL] npm install (first run)..."
   npm install --silent
 fi

--- a/libs/cua-driver/tests/fixtures/apps/cross-platform/electron/package-lock.json
+++ b/libs/cua-driver/tests/fixtures/apps/cross-platform/electron/package-lock.json
@@ -1,0 +1,5252 @@
+{
+  "name": "cua-test-harness-electron",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cua-test-harness-electron",
+      "version": "1.0.0",
+      "devDependencies": {
+        "electron": "39.8.5",
+        "electron-builder": "25.0.5"
+      }
+    },
+    "node_modules/@develar/schema-utils": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
+      "integrity": "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.0",
+        "ajv-keywords": "^3.4.1"
+      },
+      "engines": {
+        "node": ">= 8.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@electron/asar": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
+      "integrity": "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^5.0.0",
+        "glob": "^7.1.6",
+        "minimatch": "^3.0.4"
+      },
+      "bin": {
+        "asar": "bin/asar.js"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@electron/asar/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@electron/notarize": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.3.2.tgz",
+      "integrity": "sha512-zfayxCe19euNwRycCty1C7lF7snk9YwfRpB5M8GLr1a4ICH63znxaPNAubrMvj0yDvVozqfgsdYpXVUnpWBDpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1",
+        "promise-retry": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/osx-sign": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.1.tgz",
+      "integrity": "sha512-BAfviURMHpmb1Yb50YbCxnOY0wfwaLXH5KJ4+80zS0gUkzDX3ec23naTlEqKsN+PwYn+a1cCzM7BJ4Wcd3sGzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "compare-version": "^0.1.2",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.0.0",
+        "isbinaryfile": "^4.0.8",
+        "minimist": "^1.2.6",
+        "plist": "^3.0.5"
+      },
+      "bin": {
+        "electron-osx-flat": "bin/electron-osx-flat.js",
+        "electron-osx-sign": "bin/electron-osx-sign.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+      "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/rebuild": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.6.0.tgz",
+      "integrity": "sha512-zF4x3QupRU3uNGaP5X1wjpmcjfw1H87kyqZ00Tc3HvriV+4gmOGuvQjGNkrJuXdsApssdNyVwLsy+TaeTGGcVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "chalk": "^4.0.0",
+        "debug": "^4.1.1",
+        "detect-libc": "^2.0.1",
+        "fs-extra": "^10.0.0",
+        "got": "^11.7.0",
+        "node-abi": "^3.45.0",
+        "node-api-version": "^0.2.0",
+        "node-gyp": "^9.0.0",
+        "ora": "^5.1.0",
+        "read-binary-file-arch": "^1.0.6",
+        "semver": "^7.3.5",
+        "tar": "^6.0.5",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "electron-rebuild": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/universal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.1.tgz",
+      "integrity": "sha512-fKpv9kg4SPmt+hY7SVBnIYULE9QJl8L3sCfcBsnqbJwwBwAeTLokJ9TRt9y7bK0JAzIW2y78TVVjvnQEms/yyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/asar": "^3.2.7",
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "debug": "^4.3.1",
+        "dir-compare": "^4.2.0",
+        "fs-extra": "^11.1.1",
+        "minimatch": "^9.0.3",
+        "plist": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.4"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@electron/universal/node_modules/brace-expansion": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/fs-extra": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@gar/promisify": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@malept/cross-spawn-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+      "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+      "integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.0",
+        "lodash": "^4.17.15",
+        "tmp-promise": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
+      "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promisify": "^1.1.3",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@npmcli/fs/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@npmcli/move-file": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
+      "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/plist": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
+      "integrity": "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*",
+        "xmlbuilder": ">=11.0.1"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/verror": {
+      "version": "1.10.11",
+      "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
+      "integrity": "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/7zip-bin": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
+      "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/app-builder-bin": {
+      "version": "5.0.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.7.tgz",
+      "integrity": "sha512-ww2mK4ITUvqisnqOuUWAeHzokpPidyZ7a0ZkwW+V7sF5/Pdi2OldkRjAWqEzn6Xtmj3SLVT84as4wB59A6jJ4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/app-builder-lib": {
+      "version": "25.0.5",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-25.0.5.tgz",
+      "integrity": "sha512-rxgxMx1f7I4ZAP0jA5+5iB7X6x6MJvGF7GauRzQBnIVihwXX2HOiAE7yenyY9Ry5YAiH47MnCxdq413Wq6XOcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@develar/schema-utils": "~2.6.5",
+        "@electron/notarize": "2.3.2",
+        "@electron/osx-sign": "1.3.1",
+        "@electron/rebuild": "3.6.0",
+        "@electron/universal": "2.0.1",
+        "@malept/flatpak-bundler": "^0.4.0",
+        "@types/fs-extra": "9.0.13",
+        "async-exit-hook": "^2.0.1",
+        "bluebird-lst": "^1.0.9",
+        "builder-util": "25.0.3",
+        "builder-util-runtime": "9.2.5",
+        "chromium-pickle-js": "^0.2.0",
+        "debug": "^4.3.4",
+        "ejs": "^3.1.8",
+        "electron-publish": "25.0.3",
+        "form-data": "^4.0.0",
+        "fs-extra": "^10.1.0",
+        "hosted-git-info": "^4.1.0",
+        "is-ci": "^3.0.0",
+        "isbinaryfile": "^5.0.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "minimatch": "^10.0.0",
+        "read-config-file": "6.4.0",
+        "resedit": "^1.7.0",
+        "sanitize-filename": "^1.6.3",
+        "semver": "^7.3.8",
+        "tar": "^6.1.12",
+        "temp-file": "^3.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "dmg-builder": "25.0.5",
+        "electron-builder-squirrel-windows": "25.0.5"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-exit-hook": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bluebird-lst": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz",
+      "integrity": "sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "^3.5.5"
+      }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/builder-util": {
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-25.0.3.tgz",
+      "integrity": "sha512-eH5c1ukdY2xjtFQWQ6jlzEuXuqcuAVc3UQ6V6fdYu9Kg3CkDbCR82Mox42uaJDmee9WXSbP/88cOworFdOHPhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.6",
+        "7zip-bin": "~5.2.0",
+        "app-builder-bin": "5.0.0-alpha.7",
+        "bluebird-lst": "^1.0.9",
+        "builder-util-runtime": "9.2.5",
+        "chalk": "^4.1.2",
+        "cross-spawn": "^7.0.3",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.1.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-ci": "^3.0.0",
+        "js-yaml": "^4.1.0",
+        "source-map-support": "^0.5.19",
+        "stat-mode": "^1.0.0",
+        "temp-file": "^3.4.0"
+      }
+    },
+    "node_modules/builder-util-runtime": {
+      "version": "9.2.5",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.5.tgz",
+      "integrity": "sha512-HjIDfhvqx/8B3TDN4GbABQcgpewTU4LMRTQPkVpKYV3lsuxEJoIfvg09GyWTNmfVNSUAYf+fbTN//JX4TH20pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/builder-util/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/builder-util/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/builder-util/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/cacache": {
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
+      "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/move-file": "^2.0.0",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^9.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/cacache/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cacache/node_modules/brace-expansion": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/cacache/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/cacache/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cacache/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/chromium-pickle-js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+      "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/compare-version": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
+      "integrity": "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/config-file-ts": {
+      "version": "0.2.8-rc1",
+      "resolved": "https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.8-rc1.tgz",
+      "integrity": "sha512-GtNECbVI82bT4RiDIzBSVuTKoSHufnU7Ce7/42bkWZJZFLjmDF2WBpVsvRkhKCfKBnTBb3qZrBwPpFBU/Myvhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.3.12",
+        "typescript": "^5.4.3"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/config-file-ts/node_modules/brace-expansion": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.1.0"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/dir-compare": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
+      "integrity": "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^3.0.5",
+        "p-limit": "^3.1.0 "
+      }
+    },
+    "node_modules/dir-compare/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dir-compare/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/dir-compare/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/dmg-builder": {
+      "version": "25.0.5",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-25.0.5.tgz",
+      "integrity": "sha512-ocnZV44ZqInoSFaY54fF7BlCtw+WtbrjyPrkBhaB+Ztn7GPKjmFgRbIKytifJ8h9Cib8jdFRMgjCUtkU45Y6DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "app-builder-lib": "25.0.5",
+        "builder-util": "25.0.3",
+        "builder-util-runtime": "9.2.5",
+        "fs-extra": "^10.1.0",
+        "iconv-lite": "^0.6.2",
+        "js-yaml": "^4.1.0"
+      },
+      "optionalDependencies": {
+        "dmg-license": "^1.0.11"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/dmg-license": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
+      "integrity": "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "@types/plist": "^3.0.1",
+        "@types/verror": "^1.10.3",
+        "ajv": "^6.10.0",
+        "crc": "^3.8.0",
+        "iconv-corefoundation": "^1.1.7",
+        "plist": "^3.0.4",
+        "smart-buffer": "^4.0.2",
+        "verror": "^1.10.0"
+      },
+      "bin": {
+        "dmg-license": "bin/dmg-license.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+      "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/electron": {
+      "version": "39.8.5",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.5.tgz",
+      "integrity": "sha512-q6+LiQIcTadSyvtPgLDQkCtVA9jQJXQVMrQcctfOJILh6OFMN+UJJLRkuUTy8CZDYeCIBn1ZycqsL1dAXugxZA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^22.7.7",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/electron-builder": {
+      "version": "25.0.5",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-25.0.5.tgz",
+      "integrity": "sha512-Uj5LFRbUqNiVajsgqcwlKe+CHtwubK3hcoJsW5C2YiWodej2mmxM+LrTqga0rrWWHVMNmrcmGcS/WHpKwy6KEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "app-builder-lib": "25.0.5",
+        "builder-util": "25.0.3",
+        "builder-util-runtime": "9.2.5",
+        "chalk": "^4.1.2",
+        "dmg-builder": "25.0.5",
+        "fs-extra": "^10.1.0",
+        "is-ci": "^3.0.0",
+        "lazy-val": "^1.0.5",
+        "read-config-file": "6.4.0",
+        "simple-update-notifier": "2.0.0",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "electron-builder": "cli.js",
+        "install-app-deps": "install-app-deps.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows": {
+      "version": "25.0.5",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-25.0.5.tgz",
+      "integrity": "sha512-N2U7LGSdt4hmEhjEeIV2XJbjj2YIrTL6enfsGKfOhGTpL6GEejUmT3gjdKUqKBS5+NBx0GWhnEwD3MpO2P6Nfg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "app-builder-lib": "25.0.5",
+        "archiver": "^5.3.1",
+        "builder-util": "25.0.3",
+        "fs-extra": "^10.1.0"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-builder/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-builder/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-builder/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-publish": {
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-25.0.3.tgz",
+      "integrity": "sha512-wSGm+TFK2lArswIFBPLuIRHbo945s3MCvG5y1xVC57zL/PsrElUkaGH2ERtRrcKNpaDNq77rDA9JnMJhAFJjUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/fs-extra": "^9.0.11",
+        "builder-util": "25.0.3",
+        "builder-util-runtime": "9.2.5",
+        "chalk": "^4.1.2",
+        "fs-extra": "^10.1.0",
+        "lazy-val": "^1.0.5",
+        "mime": "^2.5.2"
+      }
+    },
+    "node_modules/electron-publish/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-publish/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-publish/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extsprintf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/filelist": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-corefoundation": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
+      "integrity": "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "cli-truncate": "^2.1.0",
+        "node-addon-api": "^1.6.3"
+      },
+      "engines": {
+        "node": "^8.11.2 || >=10"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+      "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-ci": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^3.2.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/isbinaryfile": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
+      "integrity": "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.6",
+        "filelist": "^1.0.4",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lazy-val": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
+      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-fetch-happen": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
+      "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "agentkeepalive": "^4.2.1",
+        "cacache": "^16.1.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^2.0.3",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^7.0.0",
+        "ssri": "^9.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
+      "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.1.6",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-api-version": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
+      "integrity": "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/node-api-version/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-gyp": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
+      "integrity": "sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^10.0.3",
+        "nopt": "^6.0.0",
+        "npmlog": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^12.13 || ^14.13 || >=16"
+      }
+    },
+    "node_modules/node-gyp/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
+      "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^1.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.3",
+        "set-blocking": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/pe-library": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
+      "integrity": "sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/plist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
+      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.10",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-binary-file-arch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
+      "integrity": "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "bin": {
+        "read-binary-file-arch": "cli.js"
+      }
+    },
+    "node_modules/read-config-file": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-6.4.0.tgz",
+      "integrity": "sha512-uB5QOBeF84PT61GlV11OTV4jUGHAO3iDEOP6v9ygxhG6Bs9PLg7WsjNT6mtIX2G+x8lJTr4ZWNeG6LDTKkNf2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "config-file-ts": "0.2.8-rc1",
+        "dotenv": "^16.4.5",
+        "dotenv-expand": "^11.0.6",
+        "js-yaml": "^4.1.0",
+        "json5": "^2.2.3",
+        "lazy-val": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resedit": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
+      "integrity": "sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pe-library": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
+      "dev": true,
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-update-notifier/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/ssri": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+      "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/stat-mode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
+      "integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/temp-file": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
+      "integrity": "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-exit-hook": "^2.0.1",
+        "fs-extra": "^10.0.0"
+      }
+    },
+    "node_modules/temp-file/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/temp-file/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/temp-file/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "dev": true,
+      "license": "WTFPL",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unique-filename": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
+      "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
+      "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/verror": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    }
+  }
+}

--- a/libs/cua-driver/tests/fixtures/apps/cross-platform/tauri/build.sh
+++ b/libs/cua-driver/tests/fixtures/apps/cross-platform/tauri/build.sh
@@ -13,6 +13,7 @@ harnessDir="$(dirname "$appsDir")"
 cuaDriverDir="$(cd "$harnessDir/../.." && pwd)"
 outDir="$cuaDriverDir/rust/test-apps/harness-tauri"
 platform="$(uname -s)"
+tauriTargetDir="${CARGO_TARGET_DIR:-$tauriDir/src-tauri/target}"
 
 if ! command -v cargo >/dev/null 2>&1; then
   echo "[ERROR] cargo not on PATH. Install Rust first." >&2
@@ -23,7 +24,7 @@ mkdir -p "$tauriDir/web"
 cp -r "$harnessDir/shared/web/." "$tauriDir/web/"
 
 echo "[BUILD] cargo build --release --features custom-protocol ..."
-CARGO_TARGET_DIR="$tauriDir/src-tauri/target" \
+CARGO_TARGET_DIR="$tauriTargetDir" \
   cargo build --release --features custom-protocol \
     --manifest-path "$tauriDir/src-tauri/Cargo.toml"
 
@@ -31,7 +32,7 @@ rm -rf "$outDir"
 mkdir -p "$outDir"
 
 if [ "$platform" = "Darwin" ]; then
-  srcBin="$tauriDir/src-tauri/target/release/cua-test-harness-tauri"
+  srcBin="$tauriTargetDir/release/cua-test-harness-tauri"
   [ -x "$srcBin" ] || { echo "[ERROR] Tauri binary missing after build" >&2; exit 1; }
 
   bundle="$outDir/CuaTestHarness.Tauri.app"
@@ -68,7 +69,7 @@ PLIST
   codesign --force --deep --sign - "$bundle"
   echo "[OK]    Staged: $bundle"
 else
-  srcBin="$tauriDir/src-tauri/target/release/cua-test-harness-tauri"
+  srcBin="$tauriTargetDir/release/cua-test-harness-tauri"
   [ -x "$srcBin" ] || { echo "[ERROR] Tauri binary missing after build" >&2; exit 1; }
 
   cp "$srcBin" "$outDir/CuaTestHarness.Tauri"

--- a/libs/cua-driver/tests/runners/macos-lume/README.md
+++ b/libs/cua-driver/tests/runners/macos-lume/README.md
@@ -313,6 +313,100 @@ unidentified source, missing dependencies, ad-hoc signature, stale installed
 daemon, unusable TCC grants, or missing Terminal/CuaDriver Automation grants.
 It reinstalls the exact source commit and then runs the canonical macOS matrix.
 
+## Build isolation across reruns
+
+The entrypoint builds in a Cargo target directory owned by one invocation,
+nested under the exact source SHA:
+
+```
+~/Library/Caches/cua-driver-e2e/cargo-target/<source-sha>/<run-id>
+```
+
+Nothing is ever deleted to make that true. The seed image's `rust/target`, and
+every previous invocation's namespace stay untouched and unused. A rerun cannot
+inherit build state from another commit or an earlier run of the same commit,
+which is the shape that produced duplicate Swift bridge symbols during 0.13.0
+certification. The Tauri harness inherits the same run-owned Cargo namespace.
+The Electron harness archives any inherited `node_modules` tree and reinstalls
+from its lockfile for the current run.
+
+- `CUA_E2E_CARGO_TARGET_ROOT=<absolute dir>` moves the namespace root, for
+  example onto a larger volume.
+
+The runner records the namespace it used in
+`artifacts/cua-driver/macos/cargo-target-dir.txt`, and the matrix reads the
+built driver binary out of that same directory. Before a new invocation starts,
+the runner moves the previous canonical artifact directory to
+`artifacts/cua-driver/macos-history/<run-id>`, so logs and retry evidence from
+the prior run cannot be mistaken for the current run.
+
+## Retry exactly one flaky cell
+
+The runner has no automatic retries. A retry has to be authorized on the command
+line for one exact cell, and it can never convert a real persistent failure into
+a pass.
+
+```bash
+cd ~/cua
+# Full matrix, plus at most one retry of one cell if that cell is the only failure.
+libs/cua-driver/tests/runners/macos-lume/run-all.sh \
+  --retry-cell macos-electron-drag-px-foreground \
+  --retry-harness electron \
+  --retry-attempts 2
+```
+
+Cell ids are the ones in `results.jsonl` and `summary.md`, such as
+`macos-electron-drag-px-foreground`. `--retry-attempts` accepts 1-3 and defaults
+to 1. `--retry-harness` is optional and must match the failing row's harness.
+
+After a failing full matrix the runner retries only when all of these hold:
+
+- exactly one typed cell did not pass, and it is the `--retry-cell` selection;
+- the only failing lane is `shared-app-matrix`;
+- the environment preflight, typed report validation, and trajectory-video
+  checks all passed;
+- the failure record contains exactly one failure signal.
+
+Otherwise it prints why the retry was refused and exits with the matrix's
+failure. Only shared web-action cells are retryable: they are the cells a
+single-cell filter can select without leaving another lane with no cells to run.
+Reproduce a native, capture, or embedded-browser failure with a full rerun.
+
+To rerun just that cell later in the same booted worker after the first run
+already restored standard mode, use `--retry-only`. It reinstalls the exact
+commit, then starts and verifies the unrestricted worker daemon before running
+the selection, so the retry cannot silently execute against the standard daemon:
+
+```bash
+cd ~/cua
+libs/cua-driver/tests/runners/macos-lume/run-all.sh \
+  --retry-only \
+  --retry-cell macos-electron-drag-px-foreground \
+  --retry-harness electron \
+  --retry-attempts 3
+```
+
+Every attempt keeps its own evidence under `artifacts/cua-driver/macos/`:
+
+- `attempts/attempt-1-full-matrix/` holds the failing full matrix's typed rows,
+  summary, logs, and MP4 trajectories.
+- `attempts/retry-<n>/` holds each superseded retry attempt.
+- The artifact root holds the final attempt.
+- `retry-record.json` records the selection, the initial failing cells and
+  lanes, every attempt with its exit code and evidence path, and a
+  `final_status` of `pass-after-retry`, `fail-persistent`, `pass-retry-only`, or
+  `fail-retry-only`.
+- `summary.md` gains a **Retry provenance** section, so the human-facing report
+  still states the initial failure that a green retry followed.
+- `failures.json` classifies what failed in the last attempt: failing lanes,
+  video failures, preflight, and report validation.
+
+The run exits non-zero when the selected cell fails every allowed attempt.
+It also exits non-zero if the filter produces anything other than exactly that
+one cell, so the retry record never overstates the precision of the rerun.
+Report a retried pass as a retried pass, with the record above; a cell that
+needs a retry on every certification run is a defect, not a flake.
+
 Pull evidence before deleting the worker, even after a failed run:
 
 ```bash
@@ -328,9 +422,35 @@ lume delete "$WORKER" --force
 ```
 
 The host stores the pulled summary, typed JSONL rows, environment record, logs,
-screenshots, and MP4 trajectories under `artifacts/cua-driver/vm/`, which Git
-ignores. A setup failure is an environment failure, not permission to report a
-smaller green matrix.
+screenshots, MP4 trajectories, and any retry record under
+`artifacts/cua-driver/vm/`, which Git ignores. A setup failure is an environment
+failure, not permission to report a smaller green matrix.
+
+The runner owns the worker daemon's lifecycle through one code path: it unloads
+the standard autostart agent, starts the unrestricted daemon, verifies the mode,
+watchdogs it, and restores the standard autostart daemon from an `EXIT` trap
+after success or failure. A restoration that does not come back in standard mode
+fails an otherwise green run. Every matrix attempt, including a targeted retry,
+goes through that same owner.
+
+If the GUI login session ends while the trap is running, launchd has no GUI
+domain in which to start the daemon. The runner records
+`standard-daemon-restore-deferred.txt` and leaves the installed LaunchAgent in
+place so macOS loads it in standard mode at the next GUI login. This is the only
+deferred restoration case; a live GUI session that cannot return to standard
+mode still fails the run.
+
+## Test the runner itself
+
+The runner's shell helpers, including status matching, build-namespace selection,
+option validation, retry bookkeeping, evidence archiving, and daemon restoration, are
+covered by host-side tests that need no VM:
+
+```bash
+python -m pytest libs/cua-driver/scripts/tests/test_macos_lume_runner.py -v
+bash -n libs/cua-driver/tests/runners/macos-lume/run-all.sh
+bash -n scripts/ci/macos/run-rust-e2e.sh
+```
 
 ## Validate the SIP-on permission flow
 

--- a/libs/cua-driver/tests/runners/macos-lume/run-all.sh
+++ b/libs/cua-driver/tests/runners/macos-lume/run-all.sh
@@ -8,13 +8,35 @@ REPO_ROOT="${CUA_E2E_REPO_ROOT:-$(cd "${SCRIPT_DIR}/../../../../.." && pwd)}"
 DRIVER_ROOT="${REPO_ROOT}/libs/cua-driver"
 RUST_ROOT="${DRIVER_ROOT}/rust"
 ARTIFACT_DIR="${REPO_ROOT}/artifacts/cua-driver/macos"
+ARTIFACT_HISTORY_ROOT="${REPO_ROOT}/artifacts/cua-driver/macos-history"
 SOURCE_MARKER="${CUA_E2E_SOURCE_MARKER:-${REPO_ROOT}/.cua-e2e-source-sha}"
 SIGNING_KEYCHAIN="${CUA_E2E_SIGNING_KEYCHAIN:-${HOME}/Library/Keychains/cua-driver-signing.keychain-db}"
 SIGNING_CN="CuaDriver Local Signing (cua-driver-rs)"
+LOCAL_APP="/Applications/CuaDriverLocal.app"
+# install-local.sh intentionally uses a separate namespace from release installs.
+INSTALLED_BIN="${HOME}/.local/bin/cua-driver-local"
+LOCAL_PLIST="${HOME}/Library/LaunchAgents/com.trycua.cua-driver-local.plist"
+CUA_E2E_MACOS_DAEMON_SOCKET="${CUA_E2E_MACOS_DAEMON_SOCKET:-${HOME}/Library/Caches/cua-driver-local/cua-driver-local.sock}"
+# A run-owned Cargo namespace keeps a certification build off the seed image's
+# and any other commit's target state without deleting a shared cache.
+CARGO_TARGET_ROOT="${CUA_E2E_CARGO_TARGET_ROOT:-${HOME}/Library/Caches/cua-driver-e2e/cargo-target}"
+# Only the shared web-action lanes honor cell and harness filters, so a targeted
+# retry always reruns that internal lane.
+RETRY_INTERNAL_LANE=shared
+RETRY_ATTEMPTS_LIMIT=3
+# How long to wait for a daemon mode transition, in one-second polls.
+DAEMON_MODE_WAIT_ATTEMPTS="${CUA_E2E_DAEMON_WAIT_ATTEMPTS:-10}"
+# Lanes whose failure is attributable to one typed matrix cell that an exact
+# single-cell rerun can reproduce. The embedded-browser lane is excluded on
+# purpose: filtering to one of its cells leaves the shared web-action lane with
+# no selected cells, which that lane reports as a failure of its own.
+RETRYABLE_LANES=(shared-app-matrix)
 
 usage() {
   cat <<'EOF'
 Usage: run-all.sh [--no-build] [--standalone-browser]
+                  [--retry-cell <cell-id> [--retry-harness <harness>]
+                   [--retry-attempts <1-3>] [--retry-only]]
 
 Run the canonical cua-driver macOS GUI E2E matrix in a disposable clone of
 the maintainer Lume golden image. Start this command from Terminal in the VM's
@@ -22,19 +44,573 @@ logged-in desktop session, not over SSH.
 
 --standalone-browser also runs the optional installed Chrome/Edge browser-tool
 matrix after the canonical repo-local harness matrix.
+
+--retry-cell authorizes exactly one bounded retry selection. After a failing
+full matrix the runner retries that single cell only when it was the matrix's
+only failure, preserves the first-attempt evidence under
+artifacts/cua-driver/macos/attempts/, and records the initial failure plus every
+retry attempt in retry-record.json and summary.md. Any other failure, and a cell
+that keeps failing, still fails the run.
+
+--retry-harness names the harness that owns the retried cell and must match the
+failing row. --retry-attempts bounds the retries (1-3, default 1). --retry-only
+skips the full matrix and runs just the selection, starting and verifying the
+unrestricted worker daemon first.
 EOF
 }
 
 RUN_STANDALONE_BROWSER=0
 NO_BUILD=0
-for arg in "$@"; do
-  case "${arg}" in
-    --no-build) NO_BUILD=1 ;;
-    --standalone-browser) RUN_STANDALONE_BROWSER=1 ;;
-    -h|--help) usage; exit 0 ;;
-    *) echo "unknown argument: ${arg}" >&2; usage >&2; exit 2 ;;
-  esac
-done
+RETRY_CELL=""
+RETRY_HARNESS=""
+RETRY_ATTEMPTS=""
+RETRY_ONLY=0
+
+parse_arguments() {
+  RUN_STANDALONE_BROWSER=0
+  NO_BUILD=0
+  RETRY_CELL=""
+  RETRY_HARNESS=""
+  RETRY_ATTEMPTS=""
+  RETRY_ONLY=0
+  while (($#)); do
+    case "$1" in
+      --no-build) NO_BUILD=1 ;;
+      --standalone-browser) RUN_STANDALONE_BROWSER=1 ;;
+      --retry-only) RETRY_ONLY=1 ;;
+      --retry-cell=*) RETRY_CELL="${1#*=}" ;;
+      --retry-harness=*) RETRY_HARNESS="${1#*=}" ;;
+      --retry-attempts=*) RETRY_ATTEMPTS="${1#*=}" ;;
+      --retry-cell|--retry-harness|--retry-attempts)
+        if (($# < 2)) || [[ -z "$2" || "$2" == -* ]]; then
+          echo "$1 requires a value" >&2
+          return 2
+        fi
+        case "$1" in
+          --retry-cell) RETRY_CELL="$2" ;;
+          --retry-harness) RETRY_HARNESS="$2" ;;
+          --retry-attempts) RETRY_ATTEMPTS="$2" ;;
+        esac
+        shift
+        ;;
+      -h|--help) usage; return 3 ;;
+      *) echo "unknown argument: $1" >&2; return 2 ;;
+    esac
+    shift
+  done
+  validate_arguments
+}
+
+validate_arguments() {
+  if [[ -z "${RETRY_CELL}" ]]; then
+    if [[ -n "${RETRY_HARNESS}" ]]; then
+      echo "--retry-harness requires --retry-cell" >&2
+      return 2
+    fi
+    if [[ -n "${RETRY_ATTEMPTS}" ]]; then
+      echo "--retry-attempts requires --retry-cell" >&2
+      return 2
+    fi
+    if [[ "${RETRY_ONLY}" == 1 ]]; then
+      echo "--retry-only requires --retry-cell" >&2
+      return 2
+    fi
+    return 0
+  fi
+
+  # One exact cell keeps the retry auditable; a list cannot be matched against a
+  # single failing row.
+  if [[ ! "${RETRY_CELL}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+    echo "--retry-cell must be one artifact-safe cell id, got: ${RETRY_CELL}" >&2
+    return 2
+  fi
+  if [[ -n "${RETRY_HARNESS}" && ! "${RETRY_HARNESS}" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+    echo "--retry-harness must be one harness name, got: ${RETRY_HARNESS}" >&2
+    return 2
+  fi
+  if [[ -z "${RETRY_ATTEMPTS}" ]]; then
+    RETRY_ATTEMPTS=1
+  fi
+  if [[ ! "${RETRY_ATTEMPTS}" =~ ^[1-9][0-9]*$ ]] \
+      || ((RETRY_ATTEMPTS > RETRY_ATTEMPTS_LIMIT)); then
+    echo "--retry-attempts must be between 1 and ${RETRY_ATTEMPTS_LIMIT}" >&2
+    return 2
+  fi
+  if [[ "${RETRY_ONLY}" == 1 && "${RUN_STANDALONE_BROWSER}" == 1 ]]; then
+    echo "--retry-only cannot be combined with --standalone-browser" >&2
+    return 2
+  fi
+}
+
+# Capture a command's full output before matching it. Piping a producer into
+# `grep -q` closes its stdout mid-write, the driver CLI can panic on that broken
+# pipe, and `pipefail` then reports the panic as the pipeline's status even when
+# the pattern matched.
+CAPTURED_OUTPUT=""
+capture_command_output() {
+  local status=0
+  CAPTURED_OUTPUT=""
+  CAPTURED_OUTPUT="$("$@" 2>&1)" || status=$?
+  return "${status}"
+}
+
+output_contains() {
+  local needle="$1"
+  shift
+  local status=0
+  capture_command_output "$@" || status=$?
+  if ((status != 0)); then
+    return 1
+  fi
+  [[ "${CAPTURED_OUTPUT}" == *"${needle}"* ]]
+}
+
+json_string_array() {
+  local item
+  local result=''
+  for item in "$@"; do
+    result="${result:+${result},}$(jq -n --arg value "${item}" '$value')"
+  done
+  printf '[%s]\n' "${result}"
+}
+
+resolve_cargo_target_dir() {
+  local source_sha="$1"
+  local run_id="$2"
+  if [[ "${CARGO_TARGET_ROOT}" != /* ]]; then
+    echo "CUA_E2E_CARGO_TARGET_ROOT must be an absolute path" >&2
+    return 2
+  fi
+  local normalized_sha
+  normalized_sha="$(printf '%s' "${source_sha}" | tr '[:upper:]' '[:lower:]')"
+  if [[ ! "${normalized_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "refusing to derive a build namespace from ${source_sha}" >&2
+    return 2
+  fi
+  if [[ ! "${run_id}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+    echo "refusing unsafe run id: ${run_id}" >&2
+    return 2
+  fi
+  printf '%s/%s/%s\n' "${CARGO_TARGET_ROOT}" "${normalized_sha}" "${run_id}"
+}
+
+preserve_previous_artifacts() {
+  local run_id="$1"
+  if [[ ! -d "${ARTIFACT_DIR}" ]] \
+      || [[ -z "$(find "${ARTIFACT_DIR}" -mindepth 1 -print -quit)" ]]; then
+    mkdir -p "${ARTIFACT_DIR}"
+    return 0
+  fi
+  local destination="${ARTIFACT_HISTORY_ROOT}/${run_id}"
+  if [[ -e "${destination}" ]]; then
+    echo "refusing to overwrite an existing artifact history: ${destination}" >&2
+    return 2
+  fi
+  mkdir -p "${ARTIFACT_HISTORY_ROOT}"
+  mv "${ARTIFACT_DIR}" "${destination}"
+  mkdir -p "${ARTIFACT_DIR}"
+  echo "[EVIDENCE] Preserved the previous certification run at ${destination}"
+}
+
+RESTORE_STANDARD_DAEMON=0
+UNRESTRICTED_WATCHDOG_PID=""
+
+daemon_reports_permission_mode() {
+  local mode="$1"
+  output_contains "permission mode: ${mode}" \
+    "${INSTALLED_BIN}" status --socket "${CUA_E2E_MACOS_DAEMON_SOCKET}"
+}
+
+wait_for_permission_mode() {
+  local mode="$1"
+  local attempts="${2:-10}"
+  local attempt
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if daemon_reports_permission_mode "${mode}"; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+stop_worker_daemon() {
+  "${INSTALLED_BIN}" stop --socket "${CUA_E2E_MACOS_DAEMON_SOCKET}" >/dev/null 2>&1 || true
+}
+
+start_unrestricted_daemon() {
+  open -n -g "${LOCAL_APP}" --args \
+    serve \
+    --permission-mode unrestricted \
+    --dangerously-bypass-approvals \
+    >/dev/null 2>&1
+}
+
+keep_unrestricted_daemon_alive() {
+  while true; do
+    watchdog_check_once
+    sleep 3
+  done
+}
+
+watchdog_check_once() {
+  if daemon_reports_permission_mode unrestricted; then
+    return 0
+  fi
+  printf '%s daemon status probe failed; confirming before restart\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '%s\n' "${CAPTURED_OUTPUT}"
+  if ! wait_for_permission_mode unrestricted 3; then
+    printf '%s daemon was unavailable or used the wrong mode; restarting\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf '%s\n' "${CAPTURED_OUTPUT}"
+    stop_worker_daemon
+    start_unrestricted_daemon
+    if ! wait_for_permission_mode unrestricted "${DAEMON_MODE_WAIT_ATTEMPTS}"; then
+      printf '%s daemon restart did not reach unrestricted mode\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      printf '%s\n' "${CAPTURED_OUTPUT}"
+    fi
+  fi
+  return 0
+}
+
+start_unrestricted_watchdog() {
+  if [[ -n "${UNRESTRICTED_WATCHDOG_PID}" ]]; then
+    return 0
+  fi
+  keep_unrestricted_daemon_alive \
+    >> "${ARTIFACT_DIR}/unrestricted-daemon-watchdog.log" 2>&1 &
+  UNRESTRICTED_WATCHDOG_PID=$!
+}
+
+stop_unrestricted_watchdog() {
+  if [[ -z "${UNRESTRICTED_WATCHDOG_PID}" ]]; then
+    return 0
+  fi
+  kill "${UNRESTRICTED_WATCHDOG_PID}" >/dev/null 2>&1 || true
+  wait "${UNRESTRICTED_WATCHDOG_PID}" 2>/dev/null || true
+  UNRESTRICTED_WATCHDOG_PID=""
+}
+
+# Every matrix attempt, including a targeted retry, claims the worker daemon
+# through this one owner, so no attempt can run against the restored standard
+# daemon or against a mode this runner did not verify.
+ensure_unrestricted_daemon() {
+  if [[ "${RESTORE_STANDARD_DAEMON}" == 1 ]] && daemon_reports_permission_mode unrestricted; then
+    start_unrestricted_watchdog
+    return 0
+  fi
+  echo "[AUTHORIZATION] Starting the disposable worker daemon in unrestricted mode"
+  stop_unrestricted_watchdog
+  launchctl unload "${LOCAL_PLIST}" 2>/dev/null || true
+  stop_worker_daemon
+  RESTORE_STANDARD_DAEMON=1
+  start_unrestricted_daemon
+  if ! wait_for_permission_mode unrestricted "${DAEMON_MODE_WAIT_ATTEMPTS}"; then
+    printf '%s\n' "${CAPTURED_OUTPUT}" >&2
+    echo "The macOS behavior matrix could not start its unrestricted worker daemon" >&2
+    return 1
+  fi
+  start_unrestricted_watchdog
+}
+
+restore_standard_daemon() {
+  local command_status=$?
+  trap - EXIT
+  stop_unrestricted_watchdog
+  if [[ "${RESTORE_STANDARD_DAEMON}" != 1 ]]; then
+    exit "${command_status}"
+  fi
+  set +e
+  echo "[AUTHORIZATION] Restoring the worker's standard autostart daemon"
+  stop_worker_daemon
+  if ! launchctl print "gui/$(id -u)" >/dev/null 2>&1; then
+    if [[ ! -f "${LOCAL_PLIST}" ]]; then
+      echo "The standard autostart LaunchAgent is missing: ${LOCAL_PLIST}" >&2
+      exit 1
+    fi
+    {
+      printf 'status=deferred-until-next-gui-login\n'
+      printf 'exit_status=%s\n' "${command_status}"
+    } > "${ARTIFACT_DIR}/standard-daemon-restore-deferred.txt"
+    echo "[AUTHORIZATION] The GUI login session ended; the standard LaunchAgent will load at the next login"
+    RESTORE_STANDARD_DAEMON=0
+    exit "${command_status}"
+  fi
+  launchctl load "${LOCAL_PLIST}"
+  if ! wait_for_permission_mode standard "${DAEMON_MODE_WAIT_ATTEMPTS}"; then
+    printf '%s\n' "${CAPTURED_OUTPUT}" >&2
+    echo "The disposable worker could not restore its standard autostart daemon" >&2
+    if [[ "${command_status}" == 0 ]]; then
+      command_status=1
+    fi
+  fi
+  RESTORE_STANDARD_DAEMON=0
+  set -e
+  exit "${command_status}"
+}
+
+install_daemon_restore_traps() {
+  trap restore_standard_daemon EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+  trap 'exit 129' HUP
+}
+
+ATTEMPT_EVIDENCE_PATH=""
+# Move the evidence an attempt left at the artifact root into its own directory
+# so the next attempt cannot overwrite it. Recordings move; the typed rows,
+# summary, and logs are copied, so preserving evidence never deletes anything.
+archive_attempt_evidence() {
+  local label="$1"
+  local destination="${ARTIFACT_DIR}/attempts/${label}"
+  local entry
+  mkdir -p "${destination}"
+  if [[ -d "${ARTIFACT_DIR}/recordings" ]]; then
+    mv "${ARTIFACT_DIR}/recordings" "${destination}/recordings"
+  fi
+  shopt -s nullglob
+  for entry in "${ARTIFACT_DIR}"/*.jsonl "${ARTIFACT_DIR}"/*.log \
+      "${ARTIFACT_DIR}/summary.md" "${ARTIFACT_DIR}/failures.json"; do
+    cp -p "${entry}" "${destination}/"
+  done
+  shopt -u nullglob
+  ATTEMPT_EVIDENCE_PATH="attempts/${label}"
+  echo "[EVIDENCE] Preserved attempt evidence at ${ATTEMPT_EVIDENCE_PATH}"
+}
+
+failing_cells_from_results() {
+  local results_file="$1"
+  [[ -f "${results_file}" ]] || return 1
+  jq -r 'select(.test_status != "pass") | .cell_id' "${results_file}"
+}
+
+RETRY_INITIAL_CELLS=()
+RETRY_INITIAL_LANES_JSON="[]"
+
+# A single-cell retry may only repair a single-cell failure. Anything else in the
+# initial attempt would be hidden by a green retry, so it stays fatal.
+retry_selection_is_eligible() {
+  local results_file="$1"
+  local failures_file="$2"
+  local cell
+  RETRY_INITIAL_CELLS=()
+  RETRY_INITIAL_LANES_JSON="[]"
+
+  local failing_cells=""
+  if ! failing_cells="$(failing_cells_from_results "${results_file}")"; then
+    echo "[RETRY] Refusing the retry: no typed result rows at ${results_file}" >&2
+    return 1
+  fi
+  while IFS= read -r cell; do
+    if [[ -n "${cell}" ]]; then
+      RETRY_INITIAL_CELLS+=("${cell}")
+    fi
+  done <<< "${failing_cells}"
+  if ((${#RETRY_INITIAL_CELLS[@]} != 1)) \
+      || [[ "${RETRY_INITIAL_CELLS[0]}" != "${RETRY_CELL}" ]]; then
+    echo "[RETRY] Refusing the retry: initial failing cells (${RETRY_INITIAL_CELLS[*]:-none}) are not exactly ${RETRY_CELL}" >&2
+    return 1
+  fi
+  if [[ -n "${RETRY_HARNESS}" ]]; then
+    local failing_harness
+    failing_harness="$(jq -r --arg cell "${RETRY_CELL}" \
+      'select(.test_status != "pass" and .cell_id == $cell) | .harness' "${results_file}")"
+    if [[ "${failing_harness}" != "${RETRY_HARNESS}" ]]; then
+      echo "[RETRY] Refusing the retry: ${RETRY_CELL} belongs to harness ${failing_harness:-unknown}, not ${RETRY_HARNESS}" >&2
+      return 1
+    fi
+  fi
+  if [[ ! -f "${failures_file}" ]]; then
+    echo "[RETRY] Refusing the retry: the matrix wrote no machine-readable failure record" >&2
+    return 1
+  fi
+  local reason
+  reason="$(jq -r --argjson retryable "$(json_string_array "${RETRYABLE_LANES[@]}")" '
+    if .preflight_failed then "the environment preflight failed"
+    elif .report_failed then "the typed result report validation failed"
+    elif (.video_failures | length) > 0 then
+      "trajectory video validation failed: \(.video_failures | join(", "))"
+    elif .failure_count != 1 then
+      "\(.failure_count) failure signals were recorded"
+    elif (.lanes | length) != 1 then
+      "\(.lanes | length) lanes failed: \(.lanes | join(", "))"
+    elif ((.lanes[0]) as $lane | ($retryable | index($lane)) == null) then
+      "lane \(.lanes[0]) is not retryable by an exact single-cell rerun"
+    else "" end' "${failures_file}")"
+  if [[ -n "${reason}" ]]; then
+    echo "[RETRY] Refusing the retry: ${reason}" >&2
+    return 1
+  fi
+  RETRY_INITIAL_LANES_JSON="$(jq -c '.lanes' "${failures_file}")"
+}
+
+run_full_matrix() {
+  local status=0
+  local -a matrix_command=("${REPO_ROOT}/scripts/ci/macos/run-rust-e2e.sh")
+  if [[ "${NO_BUILD}" == 1 ]]; then
+    matrix_command+=(--no-build)
+  fi
+  (
+    unset CUA_E2E_CELL_FILTER CUA_E2E_HARNESS_FILTER CUA_E2E_INTERNAL_LANE
+    "${matrix_command[@]}"
+  ) || status=$?
+  return "${status}"
+}
+
+RETRY_BUILD_DONE=0
+run_retry_matrix() {
+  local status=0
+  local -a matrix_command=("${REPO_ROOT}/scripts/ci/macos/run-rust-e2e.sh")
+  # The first retry attempt of a --retry-only invocation still needs fixtures.
+  if [[ "${NO_BUILD}" == 1 || "${RETRY_BUILD_DONE}" == 1 ]]; then
+    matrix_command+=(--no-build)
+  fi
+  CUA_E2E_INTERNAL_LANE="${RETRY_INTERNAL_LANE}" \
+    CUA_E2E_CELL_FILTER="${RETRY_CELL}" \
+    CUA_E2E_HARNESS_FILTER="${RETRY_HARNESS}" \
+    "${matrix_command[@]}" || status=$?
+  if ! retry_result_is_exact; then
+    echo "[RETRY] The filtered run did not produce exactly the selected cell ${RETRY_CELL}" >&2
+    status=1
+  fi
+  RETRY_BUILD_DONE=1
+  return "${status}"
+}
+
+retry_result_is_exact() {
+  local results_file="${ARTIFACT_DIR}/results.jsonl"
+  [[ -f "${results_file}" ]] || return 1
+  jq -s -e --arg cell "${RETRY_CELL}" \
+    'length == 1 and .[0].cell_id == $cell' "${results_file}" >/dev/null
+}
+
+RETRY_EXIT_CODES=()
+retry_attempts_json() {
+  local total=${#RETRY_EXIT_CODES[@]}
+  local index evidence
+  local -a records=()
+  if ((total == 0)); then
+    printf '[]\n'
+    return 0
+  fi
+  for ((index = 0; index < total; index++)); do
+    # Only the last attempt still owns the artifact root; earlier ones were
+    # archived before the next attempt started.
+    if ((index == total - 1)); then
+      evidence="."
+    else
+      evidence="attempts/retry-$((index + 1))"
+    fi
+    records+=("$(jq -n \
+      --argjson attempt "$((index + 1))" \
+      --argjson exit_code "${RETRY_EXIT_CODES[index]}" \
+      --arg evidence "${evidence}" \
+      '{attempt: $attempt, exit_code: $exit_code,
+        status: (if $exit_code == 0 then "pass" else "fail" end),
+        evidence: $evidence}')")
+  done
+  printf '%s\n' "${records[@]}" | jq -s '.'
+}
+
+retry_mode_name() {
+  if [[ "${RETRY_ONLY}" == 1 ]]; then
+    printf 'retry-only\n'
+  else
+    printf 'after-full-matrix\n'
+  fi
+}
+
+write_retry_record() {
+  local final_status="$1"
+  local initial_json="$2"
+  local attempts_json
+  attempts_json="$(retry_attempts_json)"
+  jq -n \
+    --arg schema 'cua-driver/e2e-retry-record@v1' \
+    --arg source_sha "${CUA_E2E_SOURCE_SHA:-}" \
+    --arg mode "$(retry_mode_name)" \
+    --arg cell "${RETRY_CELL}" \
+    --arg harness "${RETRY_HARNESS}" \
+    --arg lane "${RETRY_INTERNAL_LANE}" \
+    --argjson allowed_attempts "${RETRY_ATTEMPTS}" \
+    --argjson initial_attempt "${initial_json}" \
+    --argjson retry_attempts "${attempts_json}" \
+    --arg final_status "${final_status}" \
+    '{schema: $schema, source_sha: $source_sha, mode: $mode,
+      selection: {cell_id: $cell, harness: $harness, internal_lane: $lane,
+                  allowed_attempts: $allowed_attempts},
+      initial_attempt: $initial_attempt, retry_attempts: $retry_attempts,
+      final_status: $final_status}' \
+    > "${ARTIFACT_DIR}/retry-record.json"
+
+  # The regenerated summary only describes the last attempt, so state the
+  # initial failure in the human-facing report as well.
+  {
+    printf '\n## Retry provenance\n\n'
+    printf -- '- Retry selection: cell `%s`' "${RETRY_CELL}"
+    if [[ -n "${RETRY_HARNESS}" ]]; then
+      printf ', harness `%s`' "${RETRY_HARNESS}"
+    fi
+    printf ', internal lane `%s`, up to %s attempt(s)\n' \
+      "${RETRY_INTERNAL_LANE}" "${RETRY_ATTEMPTS}"
+    if [[ "${RETRY_ONLY}" == 1 ]]; then
+      printf -- '- Initial full matrix: not run in this invocation (--retry-only)\n'
+    else
+      printf -- '- Initial full matrix: FAILED on `%s` (evidence: `attempts/attempt-1-full-matrix`)\n' \
+        "${RETRY_CELL}"
+    fi
+    printf -- '- Retry attempts: %s\n' \
+      "$(jq -r '[.[] | "#\(.attempt) \(.status) (evidence: \(.evidence))"] | join("; ")' \
+        <<< "${attempts_json}")"
+    printf -- '- Final status: %s\n' "${final_status}"
+  } >> "${ARTIFACT_DIR}/summary.md"
+  echo "[RETRY] Recorded ${final_status} in ${ARTIFACT_DIR}/retry-record.json"
+}
+
+# Run the authorized selection until it passes or the bounded attempts run out.
+run_retry_sequence() {
+  local attempt status
+  RETRY_EXIT_CODES=()
+  for ((attempt = 1; attempt <= RETRY_ATTEMPTS; attempt++)); do
+    if ((attempt > 1)); then
+      archive_attempt_evidence "retry-$((attempt - 1))"
+    fi
+    echo "[RETRY] Attempt ${attempt} of ${RETRY_ATTEMPTS} for cell ${RETRY_CELL}"
+    if ! ensure_unrestricted_daemon; then
+      RETRY_EXIT_CODES+=(1)
+      return 1
+    fi
+    status=0
+    run_retry_matrix || status=$?
+    RETRY_EXIT_CODES+=("${status}")
+    if ((status == 0)); then
+      return 0
+    fi
+    echo "[RETRY] Attempt ${attempt} failed with exit ${status}" >&2
+  done
+  return 1
+}
+
+if [[ "${CUA_E2E_RUNNER_LIB_ONLY:-0}" == 1 ]]; then
+  # Sourced by the focused runner tests, which exercise the helpers above
+  # without a macOS GUI session.
+  if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    echo "CUA_E2E_RUNNER_LIB_ONLY is valid only when this script is sourced" >&2
+    exit 2
+  fi
+  return 0
+fi
+
+PARSE_STATUS=0
+parse_arguments "$@" || PARSE_STATUS=$?
+if ((PARSE_STATUS == 3)); then
+  exit 0
+elif ((PARSE_STATUS != 0)); then
+  usage >&2
+  exit 2
+fi
 
 [[ "$(uname -s)" == Darwin ]] || {
   echo "The Lume macOS runner must run in a macOS guest" >&2
@@ -57,7 +633,7 @@ launchctl print "gui/$(id -u)" >/dev/null 2>&1 || {
 }
 
 SIP_STATUS="$(csrutil status 2>&1)"
-if ! printf '%s\n' "${SIP_STATUS}" | grep -Fq "System Integrity Protection status: disabled."; then
+if [[ "${SIP_STATUS}" != *"System Integrity Protection status: disabled."* ]]; then
   printf '%s\n' "${SIP_STATUS}" >&2
   echo "The canonical Lume behavior lane requires the SIP-off golden image" >&2
   exit 2
@@ -82,8 +658,8 @@ if [[ -n "${CUA_E2E_SIGNING_KEYCHAIN_PASSWORD:-}" ]]; then
 else
   security unlock-keychain "${SIGNING_KEYCHAIN}"
 fi
-if ! security find-identity -v -p codesigning "${SIGNING_KEYCHAIN}" 2>/dev/null \
-    | grep -Fq "\"${SIGNING_CN}\""; then
+if ! output_contains "\"${SIGNING_CN}\"" \
+    security find-identity -v -p codesigning "${SIGNING_KEYCHAIN}"; then
   echo "The dedicated keychain has no valid ${SIGNING_CN} identity" >&2
   exit 2
 fi
@@ -109,7 +685,10 @@ fi
 
 export CUA_E2E_SOURCE_SHA="${SOURCE_SHA}"
 export CUA_DRIVER_SOURCE_SHA="${SOURCE_SHA}"
-mkdir -p "${ARTIFACT_DIR}"
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+export CUA_E2E_RUN_ID="${RUN_ID}"
+export CUA_E2E_FRESH_FIXTURE_STATE=1
+preserve_previous_artifacts "${RUN_ID}"
 printf '%s\n' "${SIP_STATUS}" > "${ARTIFACT_DIR}/sip-status.txt"
 printf '%s\n' "${SOURCE_SHA}" > "${ARTIFACT_DIR}/requested-source-sha.txt"
 {
@@ -120,6 +699,19 @@ printf '%s\n' "${SOURCE_SHA}" > "${ARTIFACT_DIR}/requested-source-sha.txt"
   printf 'xcode_select:\t%s\n' "$(xcode-select -p)"
 } > "${ARTIFACT_DIR}/golden-environment.txt"
 
+# Keep this invocation's Cargo output out of the seed image and every previous
+# run, including a prior run of the same source SHA. Nothing here deletes or
+# mutates an existing build directory.
+CARGO_TARGET_DIR="$(resolve_cargo_target_dir "${SOURCE_SHA}" "${RUN_ID}")"
+export CARGO_TARGET_DIR
+if [[ -e "${CARGO_TARGET_DIR}" ]]; then
+  echo "refusing to reuse an existing Cargo target directory: ${CARGO_TARGET_DIR}" >&2
+  exit 2
+fi
+mkdir -p "${CARGO_TARGET_DIR}"
+printf '%s\n' "${CARGO_TARGET_DIR}" > "${ARTIFACT_DIR}/cargo-target-dir.txt"
+echo "[BUILD NAMESPACE] Building in ${CARGO_TARGET_DIR}"
+
 echo "[AUTOMATION] Verifying Terminal can read frontmost state through System Events"
 if ! osascript -e \
     'tell application "System Events" to get name of first application process whose frontmost is true' \
@@ -128,30 +720,20 @@ if ! osascript -e \
   exit 2
 fi
 
-# CUA_DRIVER_SOURCE_SHA is consumed by option_env! in platform-macos. Cargo
-# does not treat arbitrary compile-time environment variables as an input when
-# deciding whether an otherwise unchanged crate is fresh. Force that crate and
-# its dependent driver binary to rebuild so a doc-only commit cannot inherit a
-# stale embedded source SHA from the seed or a previous worker run.
-echo "[BUILD IDENTITY] Invalidating the macOS backend for ${SOURCE_SHA}"
-cargo clean --manifest-path "${RUST_ROOT}/Cargo.toml" -p platform-macos
-
 echo "[INSTALL] Building and installing ${SOURCE_SHA} with the golden signing identity"
 bash "${DRIVER_ROOT}/scripts/install-local.sh" \
   --release --autostart --require-stable-signing \
   2>&1 | tee "${ARTIFACT_DIR}/install-local.log"
 
-codesign -d -r- /Applications/CuaDriverLocal.app \
+codesign -d -r- "${LOCAL_APP}" \
   > "${ARTIFACT_DIR}/codesign-requirement.txt" 2>&1
 if ! grep -Fq "certificate leaf" "${ARTIFACT_DIR}/codesign-requirement.txt"; then
   echo "CuaDriverLocal.app is not signed with the golden image's stable certificate identity" >&2
   exit 1
 fi
 
-INSTALLED_BIN="${HOME}/.local/bin/cua-driver-local"
 export CUA_E2E_INSTALLED_DRIVER_BIN="${INSTALLED_BIN}"
-# install-local.sh intentionally uses a separate namespace from release installs.
-export CUA_E2E_MACOS_DAEMON_SOCKET="${CUA_E2E_MACOS_DAEMON_SOCKET:-${HOME}/Library/Caches/cua-driver-local/cua-driver-local.sock}"
+export CUA_E2E_MACOS_DAEMON_SOCKET
 PERMISSIONS_FILE="${ARTIFACT_DIR}/permissions.json"
 PERMISSIONS_READY=0
 for _ in 1 2 3 4 5 6 7 8 9 10; do
@@ -174,86 +756,8 @@ if [[ "${PERMISSIONS_READY}" != 1 ]]; then
   exit 1
 fi
 
-LOCAL_PLIST="${HOME}/Library/LaunchAgents/com.trycua.cua-driver-local.plist"
-RESTORE_STANDARD_DAEMON=0
-UNRESTRICTED_WATCHDOG_PID=""
-restore_standard_daemon() {
-  local command_status=$?
-  trap - EXIT
-  if [[ -n "${UNRESTRICTED_WATCHDOG_PID}" ]]; then
-    kill "${UNRESTRICTED_WATCHDOG_PID}" >/dev/null 2>&1 || true
-    wait "${UNRESTRICTED_WATCHDOG_PID}" 2>/dev/null || true
-  fi
-  if [[ "${RESTORE_STANDARD_DAEMON}" != 1 ]]; then
-    exit "${command_status}"
-  fi
-  set +e
-  echo "[AUTHORIZATION] Restoring the worker's standard autostart daemon"
-  "${INSTALLED_BIN}" stop --socket "${CUA_E2E_MACOS_DAEMON_SOCKET}" >/dev/null 2>&1
-  launchctl load "${LOCAL_PLIST}"
-  local standard_ready=0
-  for _ in 1 2 3 4 5 6 7 8 9 10; do
-    if "${INSTALLED_BIN}" status --socket "${CUA_E2E_MACOS_DAEMON_SOCKET}" \
-        | grep -Fq "permission mode: standard"; then
-      standard_ready=1
-      break
-    fi
-    sleep 1
-  done
-  if [[ "${standard_ready}" != 1 ]]; then
-    echo "The disposable worker could not restore its standard autostart daemon" >&2
-    if [[ "${command_status}" == 0 ]]; then
-      command_status=1
-    fi
-  fi
-  set -e
-  exit "${command_status}"
-}
-trap restore_standard_daemon EXIT
-
-start_unrestricted_daemon() {
-  open -n -g /Applications/CuaDriverLocal.app --args \
-    serve \
-    --permission-mode unrestricted \
-    --dangerously-bypass-approvals \
-    >/dev/null 2>&1
-}
-
-keep_unrestricted_daemon_alive() {
-  while true; do
-    local status
-    status="$("${INSTALLED_BIN}" status --socket "${CUA_E2E_MACOS_DAEMON_SOCKET}" 2>&1 || true)"
-    if ! grep -Fq "permission mode: unrestricted" <<< "${status}"; then
-      printf '%s daemon was unavailable or used the wrong mode; restarting\n' \
-        "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-      "${INSTALLED_BIN}" stop --socket "${CUA_E2E_MACOS_DAEMON_SOCKET}" >/dev/null 2>&1 || true
-      start_unrestricted_daemon
-    fi
-    sleep 3
-  done
-}
-
-echo "[AUTHORIZATION] Starting the disposable worker daemon in unrestricted mode"
-launchctl unload "${LOCAL_PLIST}" 2>/dev/null || true
-"${INSTALLED_BIN}" stop --socket "${CUA_E2E_MACOS_DAEMON_SOCKET}" >/dev/null 2>&1 || true
-RESTORE_STANDARD_DAEMON=1
-start_unrestricted_daemon
-UNRESTRICTED_READY=0
-for _ in 1 2 3 4 5 6 7 8 9 10; do
-  if "${INSTALLED_BIN}" status --socket "${CUA_E2E_MACOS_DAEMON_SOCKET}" \
-      | grep -Fq "permission mode: unrestricted"; then
-    UNRESTRICTED_READY=1
-    break
-  fi
-  sleep 1
-done
-if [[ "${UNRESTRICTED_READY}" != 1 ]]; then
-  echo "The macOS behavior matrix could not start its unrestricted worker daemon" >&2
-  exit 1
-fi
-keep_unrestricted_daemon_alive \
-  >> "${ARTIFACT_DIR}/unrestricted-daemon-watchdog.log" 2>&1 &
-UNRESTRICTED_WATCHDOG_PID=$!
+install_daemon_restore_traps
+ensure_unrestricted_daemon
 
 echo "[APP DISCOVERY] Verifying the installed CuaDriver can enumerate apps"
 if ! "${INSTALLED_BIN}" list_apps '{}' > "${ARTIFACT_DIR}/driver-list-apps.json"; then
@@ -261,11 +765,56 @@ if ! "${INSTALLED_BIN}" list_apps '{}' > "${ARTIFACT_DIR}/driver-list-apps.json"
   exit 2
 fi
 
+RESULTS_FILE="${ARTIFACT_DIR}/results.jsonl"
+FAILURES_FILE="${ARTIFACT_DIR}/failures.json"
+
+if [[ "${RETRY_ONLY}" == 1 ]]; then
+  echo "[E2E] Running only the authorized retry selection for ${RETRY_CELL}"
+  RETRY_STATUS=0
+  run_retry_sequence || RETRY_STATUS=$?
+  if [[ "${RETRY_STATUS}" != 0 ]]; then
+    write_retry_record 'fail-retry-only' 'null'
+    echo "The authorized retry selection ${RETRY_CELL} failed every attempt" >&2
+    exit 1
+  fi
+  write_retry_record 'pass-retry-only' 'null'
+  echo "macOS retry-only run passed the authorized selection ${RETRY_CELL}"
+  exit 0
+fi
+
 echo "[E2E] Running the canonical macOS matrix"
-if [[ "${NO_BUILD}" == 1 ]]; then
-  "${REPO_ROOT}/scripts/ci/macos/run-rust-e2e.sh" --no-build
-else
-  "${REPO_ROOT}/scripts/ci/macos/run-rust-e2e.sh"
+MATRIX_STATUS=0
+run_full_matrix || MATRIX_STATUS=$?
+# The full matrix left this commit's binaries and fixtures in place, so a retry
+# does not need to rebuild them.
+RETRY_BUILD_DONE=1
+
+if [[ "${MATRIX_STATUS}" != 0 ]]; then
+  if [[ -z "${RETRY_CELL}" ]]; then
+    exit "${MATRIX_STATUS}"
+  fi
+  if ! retry_selection_is_eligible "${RESULTS_FILE}" "${FAILURES_FILE}"; then
+    echo "The macOS matrix failure is not the authorized single-cell retry selection" >&2
+    exit "${MATRIX_STATUS}"
+  fi
+  INITIAL_ATTEMPT_JSON="$(jq -n \
+    --argjson failing_cells "$(json_string_array "${RETRY_INITIAL_CELLS[@]}")" \
+    --argjson lanes "${RETRY_INITIAL_LANES_JSON}" \
+    --argjson exit_code "${MATRIX_STATUS}" \
+    '{status: "fail", exit_code: $exit_code, failing_cells: $failing_cells,
+      lanes: $lanes, evidence: "attempts/attempt-1-full-matrix"}')"
+  archive_attempt_evidence attempt-1-full-matrix
+  RETRY_STATUS=0
+  run_retry_sequence || RETRY_STATUS=$?
+  if [[ "${RETRY_STATUS}" != 0 ]]; then
+    write_retry_record 'fail-persistent' "${INITIAL_ATTEMPT_JSON}"
+    echo "The macOS matrix cell ${RETRY_CELL} failed its initial attempt and every retry" >&2
+    exit 1
+  fi
+  write_retry_record 'pass-after-retry' "${INITIAL_ATTEMPT_JSON}"
+  echo "macOS matrix passed after retrying only ${RETRY_CELL}; the initial failure is recorded"
+elif [[ -n "${RETRY_CELL}" ]]; then
+  echo "[RETRY] The full matrix passed; no retry of ${RETRY_CELL} was needed"
 fi
 
 if [[ "${RUN_STANDALONE_BROWSER}" == 1 ]]; then
@@ -277,6 +826,7 @@ if [[ "${RUN_STANDALONE_BROWSER}" == 1 ]]; then
     mv "${BROWSER_ARTIFACT_DIR}" "${BROWSER_ARTIFACT_ARCHIVE}/macos-standalone-browser"
     echo "Previous standalone-browser evidence preserved at ${BROWSER_ARTIFACT_ARCHIVE}/macos-standalone-browser"
   fi
+  ensure_unrestricted_daemon
   set +e
   CUA_E2E_ARTIFACT_DIR="${BROWSER_ARTIFACT_DIR}" \
     "${REPO_ROOT}/scripts/ci/run-rust-standalone-browser-e2e.sh"

--- a/scripts/ci/macos/run-rust-e2e.sh
+++ b/scripts/ci/macos/run-rust-e2e.sh
@@ -25,6 +25,124 @@ The contributor-facing command always runs the complete matrix.
 EOF
 }
 
+# Capture a command's full output before matching it. Piping a producer into
+# `grep -q` closes its stdout mid-write, the driver CLI can panic on that broken
+# pipe, and `pipefail` then reports the panic as the pipeline's status even when
+# the pattern matched.
+CAPTURED_OUTPUT=""
+capture_command_output() {
+  local status=0
+  CAPTURED_OUTPUT=""
+  CAPTURED_OUTPUT="$("$@" 2>&1)" || status=$?
+  return "${status}"
+}
+
+output_contains() {
+  local needle="$1"
+  shift
+  local status=0
+  capture_command_output "$@" || status=$?
+  if ((status != 0)); then
+    return 1
+  fi
+  [[ "${CAPTURED_OUTPUT}" == *"${needle}"* ]]
+}
+
+json_string_array() {
+  local item
+  local result=''
+  for item in "$@"; do
+    result="${result:+${result},}$(jq -n --arg value "${item}" '$value')"
+  done
+  printf '[%s]\n' "${result}"
+}
+
+# The Lume runner points CARGO_TARGET_DIR at an absolute, per-invocation
+# namespace instead of the inherited rust/target directory. Refuse relative
+# values because this script invokes Cargo from more than one working directory.
+resolved_build_target_dir() {
+  local configured="${CARGO_TARGET_DIR:-}"
+  if [[ -z "${configured}" ]]; then
+    printf '%s/target\n' "${RUST_ROOT}"
+    return 0
+  fi
+  case "${configured}" in
+    /*) printf '%s\n' "${configured}" ;;
+    *)
+      echo "CARGO_TARGET_DIR must be absolute for macOS E2E: ${configured}" >&2
+      return 2
+      ;;
+  esac
+}
+
+FAILURE_COUNT=0
+FAILED_LANES=()
+VIDEO_FAILURES=()
+PREFLIGHT_FAILED=0
+REPORT_FAILED=0
+
+note_lane_failure() {
+  FAILURE_COUNT=$((FAILURE_COUNT + 1))
+  FAILED_LANES+=("$1")
+}
+
+note_video_failure() {
+  FAILURE_COUNT=$((FAILURE_COUNT + 1))
+  VIDEO_FAILURES+=("$1")
+}
+
+json_bool() {
+  if [[ "$1" == 1 ]]; then
+    printf 'true\n'
+  else
+    printf 'false\n'
+  fi
+}
+
+# One machine-readable record of what failed, so a caller can tell a single
+# typed cell failure apart from a lane, video, preflight, or report failure.
+write_failure_record() {
+  local failures_file="$1"
+  jq -n \
+    --arg schema 'cua-driver/e2e-failures@v1' \
+    --arg suite "${SUITE}" \
+    --arg cell_filter "${CUA_E2E_CELL_FILTER:-}" \
+    --arg harness_filter "${CUA_E2E_HARNESS_FILTER:-}" \
+    --argjson failure_count "${FAILURE_COUNT}" \
+    --argjson preflight_failed "$(json_bool "${PREFLIGHT_FAILED}")" \
+    --argjson report_failed "$(json_bool "${REPORT_FAILED}")" \
+    --argjson lanes "$(json_string_array ${FAILED_LANES[@]+"${FAILED_LANES[@]}"})" \
+    --argjson video_failures "$(json_string_array ${VIDEO_FAILURES[@]+"${VIDEO_FAILURES[@]}"})" \
+    '{schema: $schema, suite: $suite,
+      filters: {cell: $cell_filter, harness: $harness_filter},
+      failure_count: $failure_count, preflight_failed: $preflight_failed,
+      report_failed: $report_failed, lanes: $lanes,
+      video_failures: $video_failures}' \
+    > "${failures_file}"
+}
+
+run_test() {
+  local name="$1"; shift
+  echo "[RUN] ${name}"
+  set +e
+  (cd "${RUST_ROOT}" && "$@") 2>&1 | tee "${ARTIFACT_DIR}/${name}.log"
+  local exit_code=${PIPESTATUS[0]}
+  set -e
+  if [[ "${exit_code}" != 0 ]]; then
+    note_lane_failure "${name}"
+  fi
+}
+
+if [[ "${CUA_E2E_RUNNER_LIB_ONLY:-0}" == 1 ]]; then
+  # Sourced by the focused runner tests, which exercise the helpers above
+  # without a live macOS desktop.
+  if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    echo "CUA_E2E_RUNNER_LIB_ONLY is valid only when this script is sourced" >&2
+    exit 2
+  fi
+  return 0
+fi
+
 while (($#)); do
   case "$1" in
     --no-build) BUILD_FIXTURES=0 ;;
@@ -81,18 +199,22 @@ RESULTS_FILE="${ARTIFACT_DIR}/results.jsonl"
 DECLARATIONS_FILE="${ARTIFACT_DIR}/cases.jsonl"
 ENVIRONMENT_FILE="${ARTIFACT_DIR}/environment.jsonl"
 SUMMARY_FILE="${ARTIFACT_DIR}/summary.md"
+FAILURES_FILE="${ARTIFACT_DIR}/failures.json"
 mkdir -p "${ARTIFACT_DIR}"
 : > "${DECLARATIONS_FILE}"
 : > "${ENVIRONMENT_FILE}"
 : > "${RESULTS_FILE}"
 rm -f "${SUMMARY_FILE}"
+# A record from a previous attempt must never describe this one.
+rm -f "${FAILURES_FILE}"
 
 export CUA_E2E_DECLARATIONS_FILE="${DECLARATIONS_FILE}"
 export CUA_E2E_ENVIRONMENT_FILE="${ENVIRONMENT_FILE}"
 export CUA_E2E_RESULTS_FILE="${RESULTS_FILE}"
 export CUA_E2E_RECORDINGS_ROOT="${RECORDING_ROOT}"
 export CUA_TEST_WORKSPACE_ROOT="${RUST_ROOT}"
-export CUA_TEST_DRIVER_BIN="${RUST_ROOT}/target/release/cua-driver"
+BUILD_TARGET_DIR="$(resolved_build_target_dir)"
+export CUA_TEST_DRIVER_BIN="${BUILD_TARGET_DIR}/release/cua-driver"
 export CUA_TEST_APPS_ROOT="${RUST_ROOT}/test-apps"
 export CUA_TEST_REQUIRE_FIXTURES=1
 export CUA_TEST_DRIVER_STDERR=1
@@ -119,8 +241,9 @@ if [[ ! -x "${CUA_TEST_DRIVER_BIN}" ]]; then
 fi
 MACOS_DAEMON_SOCKET="${CUA_E2E_MACOS_DAEMON_SOCKET:-${HOME}/Library/Caches/cua-driver/cua-driver.sock}"
 MACOS_DAEMON_BIN="${CUA_E2E_INSTALLED_DRIVER_BIN:-${CUA_TEST_DRIVER_BIN}}"
-if ! "${MACOS_DAEMON_BIN}" status --socket "${MACOS_DAEMON_SOCKET}" \
-    | grep -Fq "permission mode: unrestricted"; then
+if ! output_contains "permission mode: unrestricted" \
+    "${MACOS_DAEMON_BIN}" status --socket "${MACOS_DAEMON_SOCKET}"; then
+  printf '%s\n' "${CAPTURED_OUTPUT}" >&2
   echo "macOS canonical E2E requires an explicitly unrestricted disposable worker daemon" >&2
   echo "Use tests/runners/macos-lume/run-all.sh, which restores standard mode afterward" >&2
   exit 1
@@ -144,8 +267,6 @@ for fixture in "${required_fixtures[@]}"; do
   [[ -d "${fixture}" ]] || { echo "Required fixture missing: ${fixture}" >&2; exit 1; }
 done
 
-FAILURE_COUNT=0
-
 run_report() {
   (cd "${RUST_ROOT}" && cargo run -p cua-driver-testkit --bin cua-e2e-report -- \
     --declarations "${DECLARATIONS_FILE}" \
@@ -164,24 +285,15 @@ set +e
 PREFLIGHT_EXIT=${PIPESTATUS[0]}
 set -e
 if [[ "${PREFLIGHT_EXIT}" != 0 ]]; then
+  PREFLIGHT_FAILED=1
+  FAILURE_COUNT=$((FAILURE_COUNT + 1))
   set +e
   run_report
   set -e
+  write_failure_record "${FAILURES_FILE}"
   echo "macOS E2E environment preflight failed" >&2
   exit 1
 fi
-
-run_test() {
-  local name="$1"; shift
-  echo "[RUN] ${name}"
-  set +e
-  (cd "${RUST_ROOT}" && "$@") 2>&1 | tee "${ARTIFACT_DIR}/${name}.log"
-  local exit_code=${PIPESTATUS[0]}
-  set -e
-  if [[ "${exit_code}" != 0 ]]; then
-    FAILURE_COUNT=$((FAILURE_COUNT + 1))
-  fi
-}
 
 if [[ "${SUITE}" == shared || "${SUITE}" == all ]]; then
   run_test protected-permission-prompt-socket cargo test -p cua-driver \
@@ -248,20 +360,20 @@ while IFS= read -r -d '' video; do
   if ! ffprobe -v error -show_entries format=duration \
       -of default=noprint_wrappers=1:nokey=1 "${video}" >/dev/null; then
     echo "[VIDEO FAIL] Unplayable trajectory: ${video}" >&2
-    FAILURE_COUNT=$((FAILURE_COUNT + 1))
+    note_video_failure "unplayable:${video#"${ARTIFACT_DIR}/"}"
   fi
 done < <(find "${RECORDING_ROOT}" -type f -name recording.mp4 -print0)
 
 OWNED_VIDEOS="$(mktemp)"
 jq -r 'select(.evidence.video != null) | .evidence.video' "${RESULTS_FILE}" > "${OWNED_VIDEOS}"
 while IFS= read -r -d '' video; do
-  relative="${video#${ARTIFACT_DIR}/}"
+  relative="${video#"${ARTIFACT_DIR}/"}"
   if [[ "${relative}" == recordings/environment-preflight-*/recording.mp4 ]]; then
     continue
   fi
   if ! grep -Fxq -- "${relative}" "${OWNED_VIDEOS}"; then
     echo "[VIDEO FAIL] Orphan trajectory has no typed result row: ${relative}" >&2
-    FAILURE_COUNT=$((FAILURE_COUNT + 1))
+    note_video_failure "orphan:${relative}"
   fi
 done < <(find "${RECORDING_ROOT}" -type f -name recording.mp4 -print0)
 rm -f "${OWNED_VIDEOS}"
@@ -269,12 +381,12 @@ rm -f "${OWNED_VIDEOS}"
 while IFS= read -r -d '' error_file; do
   echo "[VIDEO FAIL] ${error_file}" >&2
   cat "${error_file}" >&2
-  FAILURE_COUNT=$((FAILURE_COUNT + 1))
+  note_video_failure "recording-error:${error_file#"${ARTIFACT_DIR}/"}"
 done < <(find "${RECORDING_ROOT}" -type f -name recording-error.txt -print0)
 
 if [[ "${video_count}" == 0 ]]; then
   echo "[VIDEO FAIL] No E2E trajectory videos were produced" >&2
-  FAILURE_COUNT=$((FAILURE_COUNT + 1))
+  note_video_failure "no-trajectories"
 fi
 
 set +e
@@ -283,11 +395,14 @@ REPORT_EXIT=$?
 set -e
 if [[ "${REPORT_EXIT}" != 0 ]]; then
   echo "macOS E2E result validation failed" >&2
+  REPORT_FAILED=1
   FAILURE_COUNT=$((FAILURE_COUNT + 1))
 fi
 
+write_failure_record "${FAILURES_FILE}"
+
 if [[ "${FAILURE_COUNT}" != 0 ]]; then
-  echo "macOS Rust E2E suite had ${FAILURE_COUNT} failing lane(s)" >&2
+  echo "macOS Rust E2E suite had ${FAILURE_COUNT} failure signal(s)" >&2
   exit 1
 fi
 echo "macOS Rust E2E suite completed: ${SUITE}"


### PR DESCRIPTION
Closes #2655.

## Summary

- isolate every macOS certification invocation in a fresh Cargo namespace and preserve prior artifacts in run history
- keep Electron and Tauri fixture builds independent of inherited worker state
- capture daemon status output before matching it, and own unrestricted daemon startup, watchdog, signal handling, and standard-mode restoration
- add an opt-in exact-cell retry that refuses unrelated failures, preserves every attempt, and records retry provenance
- add focused shell-helper coverage and make the script-test workflow watch the certification runner and fixture builders

## Verification

- final head `00d066116e0740067105e43ca5153e440ebcd064`
- GitHub Actions passed for script tests, release metadata, Linux Rust, Windows Rust, contributor attribution, and the fleet mirror guard
- focused runner suite passed in GitHub Actions: 88 tests
- local `git diff --check`, `bash -n`, and `shellcheck --severity=error` passed
- macOS Lume full certification run 1: 143 delivered, 8 expected refusals, 0 failed, 0 skipped across 151 declared cases, with required videos
- macOS Lume full certification run 2: 143 delivered, 8 expected refusals, 0 failed, 0 skipped across 151 declared cases, with required videos
- both macOS runs used the exact final head and restored the standard-mode daemon afterward
