### PR TITLE
fix(release): map salvaged Lume contributor identity

### DIFF
--- a/.github/release-attribution-config.json
+++ b/.github/release-attribution-config.json
@@ -25,6 +25,7 @@
     "klymenko@adobe.com": "pavelklymenko",
     "m.fuechtenkoetter@posteo.de": "ai-ag2026",
     "manfred@ubuntu26.04-vm": "ai-ag2026",
+    "me@madhavajay.com": "madhavajay",
     "robert@trycua.com": "enchanted-koala",
     "sarinajin.li@gmail.com": "sarinali",
     "zane.chee.2023@scis.smu.edu.sg": "injaneity",


### PR DESCRIPTION
## Summary

- map the preserved `me@madhavajay.com` coauthor identity to `@madhavajay`
- unblock trusted contributor-attribution generation for the Lume 0.5.0 release
- preserve public credit across all eight slices salvaged from #2401

## Root cause

The release attribution validator intentionally rejects human coauthor emails that cannot be verified to a GitHub identity. The original contributor's public commit and PR #2401 verify this mapping, but it was missing from the repository's exceptional identity overrides.

## Verification

- full `lume-v0.4.0..0.5.0` attribution collection: 9 release entries, all resolved
- verified all eight salvaged slices credit `@madhavajay`
- `uv run --with pytest python -m pytest .github/scripts/tests/test_release_attribution.py .github/scripts/tests/test_pr_attribution.py -q` — 29 passed
- `git diff --check`
