### PR TITLE
fix(cua-driver): make Linux process control observable

### DIFF
--- a/libs/cua-driver/rust/Cargo.lock
+++ b/libs/cua-driver/rust/Cargo.lock
@@ -2681,6 +2681,7 @@ dependencies = [
  "reis",
  "serde",
  "serde_json",
+ "shlex",
  "thiserror 1.0.69",
  "tiny-skia",
  "tokio",

--- a/libs/cua-driver/rust/crates/platform-linux/Cargo.toml
+++ b/libs/cua-driver/rust/crates/platform-linux/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 async-trait = "0.1"
+shlex = "1.3"
 cua-driver-core = { path = "../cua-driver-core" }
 cua-driver-contract = { path = "../cua-driver-contract" }
 cursor-overlay = { path = "../cursor-overlay" }

--- a/libs/cua-driver/rust/crates/platform-linux/src/installed_apps.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/installed_apps.rs
@@ -221,9 +221,8 @@ fn bool_key(section: &str, key: &str) -> bool {
 }
 
 /// Strip XDG `Exec=` field codes (`%f`, `%F`, `%u`, `%U`, `%i`, `%c`, `%k`)
-/// and return only the program token. We deliberately don't try to honor
-/// quoted argv reconstruction — the caller passes the result to
-/// `launch_app(launch_path=...)`, which spawns it through `sh -c`.
+/// and return the remaining launch command. `launch_app(launch_path=...)`
+/// performs shell-style argv parsing before directly spawning the program.
 fn strip_exec_field_codes(exec: &str) -> String {
     let mut out = String::with_capacity(exec.len());
     let mut chars = exec.chars().peekable();

--- a/libs/cua-driver/rust/crates/platform-linux/src/installed_apps.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/installed_apps.rs
@@ -19,8 +19,8 @@ pub struct InstalledApp {
     /// E.g. `org.gnome.Calculator.desktop` → `org.gnome.Calculator`;
     /// `kde4/konqbrowser.desktop` → `kde4-konqbrowser`.
     pub bundle_id: String,
-    /// Path the launcher would run — the unexpanded first token of `Exec=`
-    /// (field codes like `%U`, `%f` stripped). Pass to `launch_app(launch_path=...)`.
+    /// Normalized argv from `Exec=` with launch-time field codes removed.
+    /// Pass this value back to `launch_app(launch_path=...)` unchanged.
     pub launch_path: String,
     /// RFC3339 timestamp from the `.desktop` file's filesystem mtime, or
     /// `None` if the metadata could not be read.
@@ -133,10 +133,7 @@ fn parse_desktop_file(path: &Path, bundle_id: &str) -> Option<InstalledApp> {
 
     let name = string_key(&entry, "Name")?;
     let exec_raw = string_key(&entry, "Exec")?;
-    let launch_path = strip_exec_field_codes(&exec_raw);
-    if launch_path.is_empty() {
-        return None;
-    }
+    let launch_path = normalize_exec_command(&exec_raw)?;
 
     if bundle_id.is_empty() {
         return None;
@@ -220,21 +217,149 @@ fn bool_key(section: &str, key: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Strip XDG `Exec=` field codes (`%f`, `%F`, `%u`, `%U`, `%i`, `%c`, `%k`)
-/// and return the remaining launch command. `launch_app(launch_path=...)`
-/// performs shell-style argv parsing before directly spawning the program.
-fn strip_exec_field_codes(exec: &str) -> String {
-    let mut out = String::with_capacity(exec.len());
-    let mut chars = exec.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c == '%' {
-            // Consume the field-code letter, drop both.
-            chars.next();
+/// Parse an XDG `Exec=` value, remove field codes that require launch-time
+/// context, and serialize the remaining argv for `launch_app` to round-trip.
+fn normalize_exec_command(exec: &str) -> Option<String> {
+    let value = unescape_desktop_string(exec)?;
+    let argv = parse_exec_argv(&value)?;
+    if argv[0].is_empty() || argv[0].contains('=') {
+        return None;
+    }
+    let mut file_field_codes = 0;
+    let mut normalized = Vec::with_capacity(argv.len());
+    for argument in argv {
+        let (argument, argument_file_codes) = strip_exec_field_codes(&argument)?;
+        file_field_codes += argument_file_codes;
+        if file_field_codes > 1 {
+            return None;
+        }
+        if let Some(argument) = argument {
+            normalized.push(argument);
+        }
+    }
+    if normalized.is_empty() {
+        return None;
+    }
+    shlex::try_join(normalized.iter().map(String::as_str)).ok()
+}
+
+fn unescape_desktop_string(value: &str) -> Option<String> {
+    let mut out = String::with_capacity(value.len());
+    let mut chars = value.chars();
+    while let Some(character) = chars.next() {
+        if character != '\\' {
+            out.push(character);
             continue;
         }
-        out.push(c);
+        let escaped = chars.next()?;
+        match escaped {
+            's' => out.push(' '),
+            'n' => out.push('\n'),
+            't' => out.push('\t'),
+            'r' => out.push('\r'),
+            '\\' => out.push('\\'),
+            // Exec quoting has an additional escape layer for these
+            // characters, so leave the pair for parse_exec_argv.
+            '"' | '`' | '$' => {
+                out.push('\\');
+                out.push(escaped);
+            }
+            _ => return None,
+        }
     }
-    out.trim().to_owned()
+    Some(out)
+}
+
+fn parse_exec_argv(command: &str) -> Option<Vec<String>> {
+    let mut argv = Vec::new();
+    let mut argument = String::new();
+    let mut chars = command.chars();
+    let mut quoted = false;
+    let mut started = false;
+
+    while let Some(character) = chars.next() {
+        if quoted {
+            match character {
+                '"' => quoted = false,
+                '\\' => match chars.next()? {
+                    escaped @ ('"' | '`' | '$' | '\\') => argument.push(escaped),
+                    _ => return None,
+                },
+                '$' | '`' => return None,
+                _ => argument.push(character),
+            }
+            continue;
+        }
+
+        match character {
+            '"' => {
+                quoted = true;
+                started = true;
+            }
+            character if character.is_whitespace() => {
+                if started {
+                    argv.push(std::mem::take(&mut argument));
+                    started = false;
+                }
+            }
+            character if is_exec_reserved(character) => return None,
+            _ => {
+                argument.push(character);
+                started = true;
+            }
+        }
+    }
+    if quoted {
+        return None;
+    }
+    if started {
+        argv.push(argument);
+    }
+    (!argv.is_empty()).then_some(argv)
+}
+
+fn is_exec_reserved(character: char) -> bool {
+    matches!(
+        character,
+        '\'' | '\\' | '>' | '<' | '~' | '|' | '&' | ';' | '$' | '*' | '?' | '#' | '(' | ')' | '`'
+    )
+}
+
+fn strip_exec_field_codes(argument: &str) -> Option<(Option<String>, usize)> {
+    let mut out = String::with_capacity(argument.len());
+    let mut chars = argument.chars();
+    let mut file_field_codes = 0;
+    let mut removed_field_code = false;
+    while let Some(character) = chars.next() {
+        if character != '%' {
+            out.push(character);
+            continue;
+        }
+        match chars.next()? {
+            '%' => out.push('%'),
+            code @ ('F' | 'U' | 'i') => {
+                removed_field_code = true;
+                if argument != format!("%{code}") {
+                    return None;
+                }
+                if matches!(code, 'F' | 'U') {
+                    file_field_codes += 1;
+                }
+            }
+            'f' | 'u' => {
+                removed_field_code = true;
+                file_field_codes += 1;
+            }
+            'c' | 'k' | 'd' | 'D' | 'n' | 'N' | 'v' | 'm' => removed_field_code = true,
+            _ => return None,
+        }
+    }
+    let argument = if out.is_empty() && removed_field_code {
+        None
+    } else {
+        Some(out)
+    };
+    Some((argument, file_field_codes))
 }
 
 /// Format Unix epoch seconds as `YYYY-MM-DDTHH:MM:SSZ` (UTC).
@@ -268,13 +393,59 @@ mod tests {
     use super::*;
 
     #[test]
-    fn strips_field_codes() {
-        assert_eq!(strip_exec_field_codes("firefox %U"), "firefox");
+    fn normalizes_exec_field_codes() {
+        assert_eq!(normalize_exec_command("firefox %U"), Some("firefox".into()));
         assert_eq!(
-            strip_exec_field_codes("/usr/bin/gedit %f"),
-            "/usr/bin/gedit"
+            normalize_exec_command("/usr/bin/gedit %f"),
+            Some("/usr/bin/gedit".into())
         );
-        assert_eq!(strip_exec_field_codes("xterm -e %F"), "xterm -e");
+        assert_eq!(
+            normalize_exec_command("xterm -e %F"),
+            Some("xterm -e".into())
+        );
+    }
+
+    #[test]
+    fn normalizes_xdg_quoted_arguments_for_launch_round_trip() {
+        let command = normalize_exec_command(
+            "\"/opt/Demo App/bin/demo\" --profile \"two words\" --progress=100%% %U",
+        )
+        .expect("valid XDG Exec command");
+        assert_eq!(
+            shlex::split(&command).expect("normalized shell argv"),
+            vec![
+                "/opt/Demo App/bin/demo",
+                "--profile",
+                "two words",
+                "--progress=100%"
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_shell_quoting_in_xdg_exec_values() {
+        assert!(normalize_exec_command("sh -c 'exit 0'").is_none());
+    }
+
+    #[test]
+    fn preserves_an_explicit_empty_exec_argument() {
+        let command = normalize_exec_command("demo \"\"").expect("valid empty argument");
+        assert_eq!(
+            shlex::split(&command).expect("normalized shell argv"),
+            vec!["demo", ""]
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_or_repeated_file_field_codes() {
+        assert!(normalize_exec_command("demo %Z").is_none());
+        assert!(normalize_exec_command("demo %f %U").is_none());
+    }
+
+    #[test]
+    fn rejects_unescaped_exec_metacharacters_inside_quotes() {
+        assert!(normalize_exec_command("demo \"$HOME\"").is_none());
+        assert!(normalize_exec_command("demo \"`pwd`\"").is_none());
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -6819,18 +6819,7 @@ impl Tool for KillAppTool {
             }
         };
         let termination = tokio::task::spawn_blocking(move || -> std::io::Result<bool> {
-            let expected = super::process_control::observe_process(pid_i)?.ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    format!("pid {pid_i} does not exist"),
-                )
-            })?;
-            // SAFETY: libc::kill is a thin syscall wrapper, no thread-safety concerns.
-            let rc = unsafe { libc::kill(pid_i, libc::SIGKILL) };
-            if rc != 0 {
-                return Err(std::io::Error::last_os_error());
-            }
-            super::process_control::wait_for_termination(pid_i, expected)
+            super::process_control::terminate_process(pid_i)
         })
         .await;
         match termination {
@@ -6843,15 +6832,29 @@ impl Tool for KillAppTool {
                      was still alive after 2 seconds."
                 ),
             ),
-            Ok(Err(error)) => kill_app_failure(
-                pid_i,
-                "termination_failed",
-                format!(
-                    "kill_app: could not terminate pid {pid_i}: {error}. \
-                     The process may not exist, or the daemon may lack permission to inspect \
-                     or signal it."
-                ),
-            ),
+            Ok(Err(error)) => {
+                let unsupported = error.raw_os_error() == Some(libc::ENOSYS);
+                kill_app_failure(
+                    pid_i,
+                    if unsupported {
+                        "termination_unsupported"
+                    } else {
+                        "termination_failed"
+                    },
+                    if unsupported {
+                        format!(
+                            "kill_app: this Linux kernel or sandbox does not support \
+                             identity-bound pidfd termination for pid {pid_i}: {error}."
+                        )
+                    } else {
+                        format!(
+                            "kill_app: could not terminate pid {pid_i} through its identity-bound \
+                             pidfd: {error}. The process may not exist, or the daemon may lack \
+                             permission to signal it."
+                        )
+                    },
+                )
+            }
             Err(error) => kill_app_failure(
                 pid_i,
                 "verification_task_failed",

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -6786,16 +6786,35 @@ impl Tool for KillAppTool {
                 )
             }
         };
-        // SAFETY: libc::kill is a thin syscall wrapper, no thread-safety concerns.
-        let rc = unsafe { libc::kill(pid_i, libc::SIGKILL) };
-        if rc == 0 {
-            ToolResult::text(format!("✅ Sent SIGKILL to pid {pid_i}."))
-        } else {
-            let err = std::io::Error::last_os_error();
-            ToolResult::error(format!(
-                "kill_app: kill(pid={pid_i}, SIGKILL) failed: {err}. \
-                 The process may not exist, or the daemon lacks permission to signal it."
-            ))
+        let termination = tokio::task::spawn_blocking(move || -> std::io::Result<bool> {
+            let expected = super::process_control::observe_process(pid_i)?.ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("pid {pid_i} does not exist"),
+                )
+            })?;
+            // SAFETY: libc::kill is a thin syscall wrapper, no thread-safety concerns.
+            let rc = unsafe { libc::kill(pid_i, libc::SIGKILL) };
+            if rc != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            super::process_control::wait_for_termination(pid_i, expected)
+        })
+        .await;
+        match termination {
+            Ok(Ok(true)) => ToolResult::text(format!("✅ Terminated pid {pid_i}.")),
+            Ok(Ok(false)) => ToolResult::error(format!(
+                "kill_app: SIGKILL was accepted for pid {pid_i}, but the same process \
+                 was still alive after 2 seconds."
+            )),
+            Ok(Err(error)) => ToolResult::error(format!(
+                "kill_app: could not terminate pid {pid_i}: {error}. \
+                 The process may not exist, or the daemon may lack permission to inspect \
+                 or signal it."
+            )),
+            Err(error) => ToolResult::error(format!(
+                "kill_app: termination verification task failed for pid {pid_i}: {error}"
+            )),
         }
     }
 }

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -875,11 +875,7 @@ impl Tool for LaunchAppTool {
         }
 
         let result = tokio::task::spawn_blocking(
-            move || -> anyhow::Result<(
-                String,
-                Option<(u32, Option<super::process_control::ProcessObservation>)>,
-                String,
-            )> {
+            move || -> anyhow::Result<(String, Option<std::process::Child>, String)> {
                 // Open URLs via xdg-open.
                 if !urls.is_empty() {
                     for url in &urls {
@@ -907,11 +903,10 @@ impl Tool for LaunchAppTool {
                         extra_args.push("--force-renderer-accessibility".to_owned());
                     }
                     let child = super::process_control::spawn_launch_command(cmd, &extra_args)?;
-                    let (pid, identity) =
-                        super::process_control::track_launched_child(child)?;
+                    let pid = child.id();
                     return Ok((
                         format!("✅ Launched {cmd} (pid {pid}) in background."),
-                        Some((pid, identity)),
+                        Some(child),
                         cmd.to_owned(),
                     ));
                 }
@@ -939,11 +934,10 @@ impl Tool for LaunchAppTool {
                     }
                     match super::process_control::spawn_background(&mut launch) {
                         Ok(child) => {
-                            let (pid, identity) =
-                                super::process_control::track_launched_child(child)?;
+                            let pid = child.id();
                             return Ok((
                                 format!("✅ Launched {cmd} (pid {pid}) in background."),
-                                Some((pid, identity)),
+                                Some(child),
                                 cmd.to_owned(),
                             ));
                         }
@@ -969,29 +963,24 @@ impl Tool for LaunchAppTool {
 
         match result {
             Ok(Ok((message, process, name))) => {
-                if let Some((pid, identity)) = process {
+                if let Some(child) = process {
+                    let pid = child.id();
                     let observation = tokio::task::spawn_blocking(move || {
-                        let deadline =
-                            std::time::Instant::now() + std::time::Duration::from_secs(3);
-                        loop {
-                            let windows = crate::wayland::list_windows_dispatch(Some(pid));
-                            let running = super::process_control::process_still_running(
-                                pid as i32, identity,
-                            )?;
-                            if !windows.is_empty()
-                                || !running
-                                || std::time::Instant::now() >= deadline
-                            {
-                                return std::io::Result::Ok((
-                                    windows.iter().map(window_record_json).collect::<Vec<_>>(),
-                                    running,
-                                ));
-                            }
-                            std::thread::sleep(std::time::Duration::from_millis(100));
-                        }
+                        super::process_control::observe_launched_child(
+                            child,
+                            std::time::Duration::from_secs(3),
+                            |pid| {
+                                let windows = crate::wayland::list_windows_dispatch(Some(pid))
+                                    .iter()
+                                    .map(window_record_json)
+                                    .collect::<Vec<_>>();
+                                let ready = !windows.is_empty();
+                                (windows, ready)
+                            },
+                        )
                     })
                     .await;
-                    let (windows, running) = match observation {
+                    let (windows, completion) = match observation {
                         Ok(Ok(observation)) => observation,
                         Ok(Err(error)) => {
                             return ToolResult::error(format!(
@@ -1004,19 +993,7 @@ impl Tool for LaunchAppTool {
                             ))
                         }
                     };
-                    let message = if running {
-                        message
-                    } else {
-                        format!("{message} The process exited before creating a window.")
-                    };
-                    ToolResult::text(message).with_structured(json!({
-                        "pid": pid,
-                        "bundle_id": Value::Null,
-                        "name": name,
-                        "running": running,
-                        "active": false,
-                        "windows": windows,
-                    }))
+                    launch_app_process_result(pid, name, message, windows, completion)
                 } else {
                     ToolResult::text(message).with_structured(json!({
                         "pid": Value::Null,
@@ -1031,6 +1008,164 @@ impl Tool for LaunchAppTool {
             Ok(Err(e)) => ToolResult::error(format!("Failed to launch: {e}")),
             Err(e) => ToolResult::error(format!("Task error: {e}")),
         }
+    }
+}
+
+fn launch_app_process_result(
+    pid: u32,
+    name: String,
+    running_message: String,
+    windows: Vec<Value>,
+    completion: super::process_control::LaunchCompletion,
+) -> ToolResult {
+    use std::os::unix::process::ExitStatusExt;
+
+    match completion {
+        super::process_control::LaunchCompletion::Running => ToolResult::text(running_message)
+            .with_structured(json!({
+                "pid": pid,
+                "bundle_id": Value::Null,
+                "name": name,
+                "running": true,
+                "active": false,
+                "exit_code": Value::Null,
+                "term_signal": Value::Null,
+                "windows": windows,
+            })),
+        super::process_control::LaunchCompletion::Exited(status) => {
+            let exit_code = status.code();
+            let term_signal = status.signal();
+            let success = status.success();
+            let message = if success {
+                format!(
+                    "Launch command '{name}' (pid {pid}) completed successfully before creating a window."
+                )
+            } else {
+                format!(
+                    "Launch command '{name}' (pid {pid}) exited before creating a window \
+                     (exit_code={exit_code:?}, term_signal={term_signal:?})."
+                )
+            };
+            let structured = json!({
+                "pid": pid,
+                "bundle_id": Value::Null,
+                "name": name,
+                "running": false,
+                "active": false,
+                "exit_code": exit_code,
+                "term_signal": term_signal,
+                "windows": windows,
+            });
+            if success {
+                ToolResult::text(message).with_structured(structured)
+            } else {
+                ToolResult::error(message).with_structured(structured)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod process_control_tool_tests {
+    use super::{KillAppTool, LaunchAppTool};
+    use cua_driver_core::tool::Tool;
+    use serde_json::json;
+    use std::process::{Command, Stdio};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[tokio::test]
+    async fn launch_app_executes_a_quoted_command_and_reports_its_exit() {
+        let output = std::env::temp_dir().join(format!(
+            "cua-driver-public-launch-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system time after Unix epoch")
+                .as_nanos()
+        ));
+        let script = format!(
+            "printf '%s' 'quoted value' > {}",
+            output.to_str().expect("UTF-8 temp path")
+        );
+        let command = format!("sh -c {}", shell_quote(&script));
+
+        let result = LaunchAppTool.invoke(json!({"launch_path": command})).await;
+        assert!(result.is_error.is_none(), "{result:?}");
+        let structured = result.structured_content.expect("structured launch result");
+        assert_eq!(structured["running"], false);
+        assert_eq!(structured["exit_code"], 0);
+        assert_eq!(
+            std::fs::read_to_string(&output).expect("launch command output"),
+            "quoted value"
+        );
+        let _ = std::fs::remove_file(output);
+    }
+
+    #[tokio::test]
+    async fn launch_app_reports_a_nonzero_command_exit_as_an_error() {
+        let result = LaunchAppTool
+            .invoke(json!({"launch_path": "sh -c 'exit 17'"}))
+            .await;
+        assert_eq!(result.is_error, Some(true));
+        let structured = result
+            .structured_content
+            .expect("structured launch failure");
+        assert_eq!(structured["running"], false);
+        assert_eq!(structured["exit_code"], 17);
+    }
+
+    #[tokio::test]
+    async fn kill_app_returns_only_after_the_process_exits() {
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sleep process");
+        let pid = child.id();
+
+        let result = KillAppTool.invoke(json!({"pid": pid})).await;
+        assert!(result.is_error.is_none(), "{result:?}");
+        assert_eq!(
+            result.structured_content.expect("structured kill result")["terminated"],
+            true
+        );
+        child.wait().expect("reap terminated process");
+    }
+
+    #[tokio::test]
+    async fn kill_app_refuses_a_stale_approved_fingerprint_before_signaling() {
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sleep process");
+        let pid = child.id();
+
+        let result = KillAppTool
+            .invoke(json!({
+                "pid": pid,
+                "_protected_process_fingerprint": {
+                    "pid": pid,
+                    "start_time": "stale",
+                    "executable": "/not/the/process"
+                }
+            }))
+            .await;
+        assert_eq!(result.is_error, Some(true));
+        assert!(
+            child.try_wait().expect("poll refused process").is_none(),
+            "fingerprint refusal must not terminate the process"
+        );
+        child.kill().expect("clean up refused process");
+        child.wait().expect("reap refused process");
+    }
+
+    fn shell_quote(value: &str) -> String {
+        format!("'{}'", value.replace('\'', "'\\''"))
     }
 }
 
@@ -6790,6 +6925,25 @@ impl Tool for KillAppTool {
     }
 
     async fn invoke(&self, args: Value) -> ToolResult {
+        let pid_i = match args.get("pid").and_then(|v| v.as_i64()) {
+            Some(p) if p > 0 && p <= i32::MAX as i64 => p as i32,
+            Some(_) => {
+                return ToolResult::error("kill_app: `pid` must be a positive integer".to_string())
+            }
+            None => {
+                return ToolResult::error(
+                    "kill_app: missing required integer field `pid`".to_string(),
+                )
+            }
+        };
+        // Bind the numeric pid to a kernel process reference before checking
+        // the approval fingerprint. If the pid was reused, the fingerprint
+        // check refuses the new process; if it exits later, this handle cannot
+        // redirect the signal to a replacement.
+        let process = match super::process_control::ProcessHandle::open(pid_i) {
+            Ok(process) => process,
+            Err(error) => return kill_app_system_failure(pid_i, error),
+        };
         if let Some(expected) = args.get("_protected_process_fingerprint") {
             let current = match self
                 .protected_resource_scope("process_control", &args)
@@ -6805,21 +6959,7 @@ impl Tool for KillAppTool {
                 );
             }
         }
-        let pid_i = match args.get("pid").and_then(|v| v.as_i64()) {
-            Some(p) if p > 0 && p <= i32::MAX as i64 => p as i32,
-            Some(_) => {
-                return ToolResult::error("kill_app: `pid` must be a positive integer".to_string())
-            }
-            None => {
-                return ToolResult::error(
-                    "kill_app: missing required integer field `pid`".to_string(),
-                )
-            }
-        };
-        let termination = tokio::task::spawn_blocking(move || -> std::io::Result<bool> {
-            super::process_control::terminate_process(pid_i)
-        })
-        .await;
+        let termination = tokio::task::spawn_blocking(move || process.terminate()).await;
         match termination {
             Ok(Ok(true)) => kill_app_success(pid_i),
             Ok(Ok(false)) => kill_app_failure(
@@ -6830,29 +6970,7 @@ impl Tool for KillAppTool {
                      was still alive after 2 seconds."
                 ),
             ),
-            Ok(Err(error)) => {
-                let unsupported = error.raw_os_error() == Some(libc::ENOSYS);
-                kill_app_failure(
-                    pid_i,
-                    if unsupported {
-                        "termination_unsupported"
-                    } else {
-                        "termination_failed"
-                    },
-                    if unsupported {
-                        format!(
-                            "kill_app: this Linux kernel or sandbox does not support \
-                             identity-bound pidfd termination for pid {pid_i}: {error}."
-                        )
-                    } else {
-                        format!(
-                            "kill_app: could not terminate pid {pid_i} through its identity-bound \
-                             pidfd: {error}. The process may not exist, or the daemon may lack \
-                             permission to signal it."
-                        )
-                    },
-                )
-            }
+            Ok(Err(error)) => kill_app_system_failure(pid_i, error),
             Err(error) => kill_app_failure(
                 pid_i,
                 "verification_task_failed",
@@ -6860,6 +6978,29 @@ impl Tool for KillAppTool {
             ),
         }
     }
+}
+
+fn kill_app_system_failure(pid: i32, error: std::io::Error) -> ToolResult {
+    let unsupported = error.raw_os_error() == Some(libc::ENOSYS);
+    kill_app_failure(
+        pid,
+        if unsupported {
+            "termination_unsupported"
+        } else {
+            "termination_failed"
+        },
+        if unsupported {
+            format!(
+                "kill_app: this Linux kernel or sandbox does not support identity-bound pidfd \
+                 termination for pid {pid}: {error}."
+            )
+        } else {
+            format!(
+                "kill_app: could not terminate pid {pid} through its identity-bound pidfd: \
+                 {error}. The process may not exist, or the daemon may lack permission to signal it."
+            )
+        },
+    )
 }
 
 fn kill_app_success(pid: i32) -> ToolResult {

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -879,7 +879,10 @@ impl Tool for LaunchAppTool {
                 // Open URLs via xdg-open.
                 if !urls.is_empty() {
                     for url in &urls {
-                        std::process::Command::new("xdg-open").arg(url).spawn()?;
+                        let mut launch = std::process::Command::new("xdg-open");
+                        launch.arg(url);
+                        let child = super::process_control::spawn_background(&mut launch)?;
+                        super::process_control::track_child(child)?;
                     }
                     return Ok((
                         format!("Opened {} URL(s) via xdg-open.", urls.len()),
@@ -901,6 +904,7 @@ impl Tool for LaunchAppTool {
                     }
                     let child = super::process_control::spawn_shell_command(cmd, &extra_args)?;
                     let pid = child.id();
+                    super::process_control::track_child(child)?;
                     return Ok((
                         format!("✅ Launched {cmd} (pid {pid}) in background."),
                         Some(pid),
@@ -929,9 +933,10 @@ impl Tool for LaunchAppTool {
                     {
                         launch.arg("--force-renderer-accessibility");
                     }
-                    match launch.spawn() {
+                    match super::process_control::spawn_background(&mut launch) {
                         Ok(child) => {
                             let pid = child.id();
+                            super::process_control::track_child(child)?;
                             return Ok((
                                 format!("✅ Launched {cmd} (pid {pid}) in background."),
                                 Some(pid),
@@ -941,7 +946,10 @@ impl Tool for LaunchAppTool {
                         Err(_) => {
                             // Fall back to xdg-open for .desktop app names. xdg-open may
                             // spawn a helper and exit, so do not claim its pid is the app pid.
-                            std::process::Command::new("xdg-open").arg(cmd).spawn()?;
+                            let mut fallback = std::process::Command::new("xdg-open");
+                            fallback.arg(cmd);
+                            let child = super::process_control::spawn_background(&mut fallback)?;
+                            super::process_control::track_child(child)?;
                             return Ok((
                                 format!("Opened '{cmd}' via xdg-open."),
                                 None,

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -837,7 +837,7 @@ impl Tool for LaunchAppTool {
                 direct exec), bundle_id (ignored on Linux), or urls (list of URLs to open). \
                 Resolution precedence: launch_path > name > bundle_id.".into(),
             input_schema: json!({"type":"object","properties":{
-                "launch_path":{"type":"string","description":"Round-trip the `launch_path` returned by `list_apps` — the Exec= command from the .desktop file with XDG field codes already stripped. Highest precedence on Linux; spawned directly via the system shell."},
+                "launch_path":{"type":"string","description":"Round-trip the `launch_path` returned by `list_apps` — the Exec= command from the .desktop file with XDG field codes already stripped. Highest precedence on Linux; shell-style quoting is parsed before the program is spawned directly."},
                 "name":{"type":"string","description":"App name or command to launch."},
                 "bundle_id":{"type":"string","description":"Ignored on Linux (macOS/Windows concept)."},
                 "urls":{"type":"array","items":{"type":"string"},"description":"URLs to open via xdg-open."},
@@ -875,7 +875,11 @@ impl Tool for LaunchAppTool {
         }
 
         let result = tokio::task::spawn_blocking(
-            move || -> anyhow::Result<(String, Option<u32>, String)> {
+            move || -> anyhow::Result<(
+                String,
+                Option<(u32, Option<super::process_control::ProcessObservation>)>,
+                String,
+            )> {
                 // Open URLs via xdg-open.
                 if !urls.is_empty() {
                     for url in &urls {
@@ -902,12 +906,13 @@ impl Tool for LaunchAppTool {
                     {
                         extra_args.push("--force-renderer-accessibility".to_owned());
                     }
-                    let child = super::process_control::spawn_shell_command(cmd, &extra_args)?;
+                    let child = super::process_control::spawn_launch_command(cmd, &extra_args)?;
                     let pid = child.id();
+                    let identity = super::process_control::observe_process(pid as i32)?;
                     super::process_control::track_child(child)?;
                     return Ok((
                         format!("✅ Launched {cmd} (pid {pid}) in background."),
-                        Some(pid),
+                        Some((pid, identity)),
                         cmd.to_owned(),
                     ));
                 }
@@ -936,10 +941,11 @@ impl Tool for LaunchAppTool {
                     match super::process_control::spawn_background(&mut launch) {
                         Ok(child) => {
                             let pid = child.id();
+                            let identity = super::process_control::observe_process(pid as i32)?;
                             super::process_control::track_child(child)?;
                             return Ok((
                                 format!("✅ Launched {cmd} (pid {pid}) in background."),
-                                Some(pid),
+                                Some((pid, identity)),
                                 cmd.to_owned(),
                             ));
                         }
@@ -964,26 +970,52 @@ impl Tool for LaunchAppTool {
         .await;
 
         match result {
-            Ok(Ok((message, pid_opt, name))) => {
-                if let Some(pid) = pid_opt {
-                    let windows = tokio::task::spawn_blocking(move || {
+            Ok(Ok((message, process, name))) => {
+                if let Some((pid, identity)) = process {
+                    let observation = tokio::task::spawn_blocking(move || {
                         let deadline =
                             std::time::Instant::now() + std::time::Duration::from_secs(3);
                         loop {
                             let windows = crate::wayland::list_windows_dispatch(Some(pid));
-                            if !windows.is_empty() || std::time::Instant::now() >= deadline {
-                                return windows.iter().map(window_record_json).collect::<Vec<_>>();
+                            let running = super::process_control::process_still_running(
+                                pid as i32, identity,
+                            )?;
+                            if !windows.is_empty()
+                                || !running
+                                || std::time::Instant::now() >= deadline
+                            {
+                                return std::io::Result::Ok((
+                                    windows.iter().map(window_record_json).collect::<Vec<_>>(),
+                                    running,
+                                ));
                             }
                             std::thread::sleep(std::time::Duration::from_millis(100));
                         }
                     })
-                    .await
-                    .unwrap_or_default();
+                    .await;
+                    let (windows, running) = match observation {
+                        Ok(Ok(observation)) => observation,
+                        Ok(Err(error)) => {
+                            return ToolResult::error(format!(
+                                "Failed to verify launched pid {pid}: {error}"
+                            ))
+                        }
+                        Err(error) => {
+                            return ToolResult::error(format!(
+                                "Launch observation task failed for pid {pid}: {error}"
+                            ))
+                        }
+                    };
+                    let message = if running {
+                        message
+                    } else {
+                        format!("{message} The process exited before creating a window.")
+                    };
                     ToolResult::text(message).with_structured(json!({
                         "pid": pid,
                         "bundle_id": Value::Null,
                         "name": name,
-                        "running": true,
+                        "running": running,
                         "active": false,
                         "windows": windows,
                     }))

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -6802,21 +6802,47 @@ impl Tool for KillAppTool {
         })
         .await;
         match termination {
-            Ok(Ok(true)) => ToolResult::text(format!("✅ Terminated pid {pid_i}.")),
-            Ok(Ok(false)) => ToolResult::error(format!(
-                "kill_app: SIGKILL was accepted for pid {pid_i}, but the same process \
-                 was still alive after 2 seconds."
-            )),
-            Ok(Err(error)) => ToolResult::error(format!(
-                "kill_app: could not terminate pid {pid_i}: {error}. \
-                 The process may not exist, or the daemon may lack permission to inspect \
-                 or signal it."
-            )),
-            Err(error) => ToolResult::error(format!(
-                "kill_app: termination verification task failed for pid {pid_i}: {error}"
-            )),
+            Ok(Ok(true)) => kill_app_success(pid_i),
+            Ok(Ok(false)) => kill_app_failure(
+                pid_i,
+                "termination_unconfirmed",
+                format!(
+                    "kill_app: SIGKILL was accepted for pid {pid_i}, but the same process \
+                     was still alive after 2 seconds."
+                ),
+            ),
+            Ok(Err(error)) => kill_app_failure(
+                pid_i,
+                "termination_failed",
+                format!(
+                    "kill_app: could not terminate pid {pid_i}: {error}. \
+                     The process may not exist, or the daemon may lack permission to inspect \
+                     or signal it."
+                ),
+            ),
+            Err(error) => kill_app_failure(
+                pid_i,
+                "verification_task_failed",
+                format!("kill_app: termination verification task failed for pid {pid_i}: {error}"),
+            ),
         }
     }
+}
+
+fn kill_app_success(pid: i32) -> ToolResult {
+    ToolResult::text(format!("✅ Terminated pid {pid}.")).with_structured(json!({
+        "pid": pid,
+        "terminated": true,
+    }))
+}
+
+fn kill_app_failure(pid: i32, code: &str, message: String) -> ToolResult {
+    ToolResult::error(message.clone()).with_structured(json!({
+        "pid": pid,
+        "terminated": false,
+        "code": code,
+        "message": message,
+    }))
 }
 
 fn kill_app_stale_process_refusal(message: String) -> ToolResult {
@@ -6827,6 +6853,35 @@ fn kill_app_stale_process_refusal(message: String) -> ToolResult {
             "message": message,
         }
     }))
+}
+
+#[cfg(test)]
+mod kill_app_result_tests {
+    use super::{kill_app_failure, kill_app_success};
+
+    #[test]
+    fn success_exposes_a_confirmed_termination_verdict() {
+        let result = kill_app_success(42);
+        let structured = result.structured_content.expect("structured kill result");
+        assert_eq!(structured["pid"], 42);
+        assert_eq!(structured["terminated"], true);
+        assert!(result.is_error.is_none());
+    }
+
+    #[test]
+    fn failure_exposes_a_machine_readable_reason() {
+        let result = kill_app_failure(
+            42,
+            "termination_unconfirmed",
+            "process stayed alive".to_owned(),
+        );
+        let structured = result.structured_content.expect("structured kill failure");
+        assert_eq!(structured["pid"], 42);
+        assert_eq!(structured["terminated"], false);
+        assert_eq!(structured["code"], "termination_unconfirmed");
+        assert_eq!(structured["message"], "process stayed alive");
+        assert_eq!(result.is_error, Some(true));
+    }
 }
 
 // ── bring_to_front (Linux) ───────────────────────────────────────────────────

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -887,11 +887,28 @@ impl Tool for LaunchAppTool {
                         "xdg-open".to_owned(),
                     ));
                 }
-                // launch_path > name. Both go through the same direct-exec path
-                // (so XDG `Exec=` commands round-trip), but launch_path is the
-                // canonical form preferred by list_apps callers.
-                let command = launch_path_opt.as_deref().or(name_opt.as_deref());
-                if let Some(cmd) = command {
+                // launch_path round-trips the XDG Exec= command. Preserve its
+                // quoting and field structure through the documented shell path.
+                if let Some(cmd) = launch_path_opt.as_deref() {
+                    let mut extra_args = additional_arguments;
+                    if chromium_family_program(cmd)
+                        && !cmd.contains("--force-renderer-accessibility")
+                        && !extra_args
+                            .iter()
+                            .any(|arg| arg == "--force-renderer-accessibility")
+                    {
+                        extra_args.push("--force-renderer-accessibility".to_owned());
+                    }
+                    let child = super::process_control::spawn_shell_command(cmd, &extra_args)?;
+                    let pid = child.id();
+                    return Ok((
+                        format!("✅ Launched {cmd} (pid {pid}) in background."),
+                        Some(pid),
+                        cmd.to_owned(),
+                    ));
+                }
+                // Names retain the direct-exec path and xdg-open fallback.
+                if let Some(cmd) = name_opt.as_deref() {
                     let mut parts = cmd.split_whitespace();
                     let prog = parts.next().unwrap_or(cmd);
                     let mut rest: Vec<String> = parts.map(str::to_owned).collect();

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -907,9 +907,8 @@ impl Tool for LaunchAppTool {
                         extra_args.push("--force-renderer-accessibility".to_owned());
                     }
                     let child = super::process_control::spawn_launch_command(cmd, &extra_args)?;
-                    let pid = child.id();
-                    let identity = super::process_control::observe_process(pid as i32)?;
-                    super::process_control::track_child(child)?;
+                    let (pid, identity) =
+                        super::process_control::track_launched_child(child)?;
                     return Ok((
                         format!("✅ Launched {cmd} (pid {pid}) in background."),
                         Some((pid, identity)),
@@ -940,9 +939,8 @@ impl Tool for LaunchAppTool {
                     }
                     match super::process_control::spawn_background(&mut launch) {
                         Ok(child) => {
-                            let pid = child.id();
-                            let identity = super::process_control::observe_process(pid as i32)?;
-                            super::process_control::track_child(child)?;
+                            let (pid, identity) =
+                                super::process_control::track_launched_child(child)?;
                             return Ok((
                                 format!("✅ Launched {cmd} (pid {pid}) in background."),
                                 Some((pid, identity)),

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/mod.rs
@@ -5,6 +5,8 @@
 
 use cua_driver_core::tool::ToolRegistry;
 
+mod process_control;
+
 #[cfg(target_os = "linux")]
 mod impl_;
 #[cfg(target_os = "linux")]

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/mod.rs
@@ -5,6 +5,7 @@
 
 use cua_driver_core::tool::ToolRegistry;
 
+#[cfg(any(target_os = "linux", test))]
 mod process_control;
 
 #[cfg(target_os = "linux")]

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/process_control.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/process_control.rs
@@ -1,6 +1,8 @@
 use std::io;
 #[cfg(target_os = "linux")]
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+#[cfg(target_os = "linux")]
+use std::process::ExitStatus;
 use std::process::{Child, Command, Stdio};
 use std::sync::{
     mpsc::{self, Receiver, RecvTimeoutError, Sender},
@@ -18,6 +20,13 @@ const TERMINATION_TIMEOUT: Duration = Duration::from_secs(2);
 pub(super) struct ProcessObservation {
     pub(super) state: char,
     pub(super) start_time: u64,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug)]
+pub(super) enum LaunchCompletion {
+    Running,
+    Exited(ExitStatus),
 }
 
 impl ProcessObservation {
@@ -71,25 +80,6 @@ pub(super) fn track_child(child: Child) -> io::Result<()> {
             ))
         }
     }
-}
-
-#[cfg(target_os = "linux")]
-pub(super) fn track_launched_child(child: Child) -> io::Result<(u32, Option<ProcessObservation>)> {
-    track_launched_child_with(child, observe_process)
-}
-
-#[cfg(target_os = "linux")]
-fn track_launched_child_with<F>(
-    child: Child,
-    observe: F,
-) -> io::Result<(u32, Option<ProcessObservation>)>
-where
-    F: FnOnce(i32) -> io::Result<Option<ProcessObservation>>,
-{
-    let pid = child.id();
-    let identity = observe(pid as i32);
-    track_child(child)?;
-    Ok((pid, identity?))
 }
 
 fn child_reaper() -> io::Result<&'static Sender<Child>> {
@@ -148,15 +138,81 @@ pub(super) fn observe_process(pid: i32) -> io::Result<Option<ProcessObservation>
 }
 
 #[cfg(target_os = "linux")]
-pub(super) fn process_still_running(
-    pid: i32,
-    expected: Option<ProcessObservation>,
-) -> io::Result<bool> {
-    let Some(expected) = expected else {
-        return Ok(false);
-    };
-    Ok(observe_process(pid)?
-        .is_some_and(|current| !current.is_terminal() && current.start_time == expected.start_time))
+pub(super) fn observe_launched_child<T, F>(
+    child: Child,
+    timeout: Duration,
+    snapshot: F,
+) -> io::Result<(T, LaunchCompletion)>
+where
+    T: Default,
+    F: FnMut(u32) -> (T, bool),
+{
+    observe_launched_child_with(child, timeout, snapshot, observe_process)
+}
+
+#[cfg(target_os = "linux")]
+fn observe_launched_child_with<T, F, O>(
+    mut child: Child,
+    timeout: Duration,
+    mut snapshot: F,
+    mut observe: O,
+) -> io::Result<(T, LaunchCompletion)>
+where
+    T: Default,
+    F: FnMut(u32) -> (T, bool),
+    O: FnMut(i32) -> io::Result<Option<ProcessObservation>>,
+{
+    let pid = child.id();
+    let observation = (|| {
+        // Retaining Child prevents a completed process from being reaped and
+        // its numeric pid reused until the initial identity is captured.
+        let identity = observe(pid as i32)?;
+        let deadline = Instant::now() + timeout;
+        let mut latest_snapshot = T::default();
+        loop {
+            if let Some(status) = child.try_wait()? {
+                return Ok((latest_snapshot, LaunchCompletion::Exited(status)));
+            }
+
+            let (next_snapshot, ready) = snapshot(pid);
+            latest_snapshot = next_snapshot;
+            if ready {
+                return Ok((latest_snapshot, LaunchCompletion::Running));
+            }
+
+            let same_process = match identity {
+                Some(expected) => observe(pid as i32)?.is_some_and(|current| {
+                    !current.is_terminal() && current.start_time == expected.start_time
+                }),
+                None => false,
+            };
+            if !same_process {
+                if let Some(status) = child.try_wait()? {
+                    return Ok((latest_snapshot, LaunchCompletion::Exited(status)));
+                }
+                return Err(io::Error::other(format!(
+                    "launched pid {pid} could not be matched to its original process identity"
+                )));
+            }
+
+            if Instant::now() >= deadline {
+                return Ok((latest_snapshot, LaunchCompletion::Running));
+            }
+            std::thread::sleep(REAP_INTERVAL);
+        }
+    })();
+
+    match observation {
+        Ok((snapshot, LaunchCompletion::Running)) => {
+            track_child(child)?;
+            Ok((snapshot, LaunchCompletion::Running))
+        }
+        Ok(exited) => Ok(exited),
+        Err(observation_error) => {
+            track_child(child)?;
+            Err(observation_error)
+        }
+    }
 }
 
 fn parse_proc_stat(stat: &str) -> io::Result<ProcessObservation> {
@@ -184,17 +240,15 @@ fn parse_proc_stat(stat: &str) -> io::Result<ProcessObservation> {
 
 #[cfg(target_os = "linux")]
 pub(super) fn terminate_process(pid: i32) -> io::Result<bool> {
-    let process = PidFd::open(pid)?;
-    process.send_signal(libc::SIGKILL)?;
-    process.wait_for_exit(TERMINATION_TIMEOUT)
+    ProcessHandle::open(pid)?.terminate()
 }
 
 #[cfg(target_os = "linux")]
-struct PidFd(OwnedFd);
+pub(super) struct ProcessHandle(OwnedFd);
 
 #[cfg(target_os = "linux")]
-impl PidFd {
-    fn open(pid: i32) -> io::Result<Self> {
+impl ProcessHandle {
+    pub(super) fn open(pid: i32) -> io::Result<Self> {
         // SAFETY: pidfd_open takes a numeric pid and zero flags. On success the
         // returned descriptor is uniquely owned and transferred to OwnedFd.
         let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0u32) };
@@ -203,6 +257,11 @@ impl PidFd {
         }
         // SAFETY: the successful syscall returned a fresh owned descriptor.
         Ok(Self(unsafe { OwnedFd::from_raw_fd(fd as i32) }))
+    }
+
+    pub(super) fn terminate(&self) -> io::Result<bool> {
+        self.send_signal(libc::SIGKILL)?;
+        self.wait_for_exit(TERMINATION_TIMEOUT)
     }
 
     fn send_signal(&self, signal: i32) -> io::Result<()> {
@@ -375,12 +434,17 @@ mod tests {
     fn observation_failure_still_hands_child_to_reaper() {
         let child = spawn_launch_command("true", &[]).expect("spawn short-lived child");
         let pid = child.id();
-        let error = super::track_launched_child_with(child, |_| {
-            Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                "simulated /proc restriction",
-            ))
-        })
+        let error = super::observe_launched_child_with(
+            child,
+            Duration::from_secs(2),
+            |_| ((), false),
+            |_| {
+                Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "simulated /proc restriction",
+                ))
+            },
+        )
         .expect_err("observation failure must be returned");
         assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
 
@@ -392,6 +456,21 @@ mod tests {
             );
             std::thread::sleep(Duration::from_millis(10));
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn launch_observation_reports_nonzero_exit_status() {
+        use super::LaunchCompletion;
+
+        let child = spawn_launch_command("sh -c 'exit 17'", &[]).expect("spawn failing command");
+        let (_, completion) =
+            super::observe_launched_child(child, Duration::from_secs(2), |_| ((), false))
+                .expect("observe launch completion");
+        let LaunchCompletion::Exited(status) = completion else {
+            panic!("short-lived command remained running");
+        };
+        assert_eq!(status.code(), Some(17));
     }
 
     fn shell_quote(value: &str) -> String {

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/process_control.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/process_control.rs
@@ -1,5 +1,12 @@
 use std::io;
-use std::process::{Child, Command};
+use std::process::{Child, Command, Stdio};
+use std::sync::{
+    mpsc::{self, Receiver, RecvTimeoutError, Sender},
+    OnceLock,
+};
+use std::time::Duration;
+
+const REAP_INTERVAL: Duration = Duration::from_millis(50);
 
 pub(super) fn spawn_shell_command(command: &str, additional_args: &[String]) -> io::Result<Child> {
     let mut launch = Command::new("sh");
@@ -13,14 +20,83 @@ pub(super) fn spawn_shell_command(command: &str, additional_args: &[String]) -> 
         .args(additional_args)
         .env("ACCESSIBILITY_ENABLED", "1")
         .env("NO_AT_BRIDGE", "0");
-    launch.spawn()
+    spawn_background(&mut launch)
+}
+
+pub(super) fn spawn_background(command: &mut Command) -> io::Result<Child> {
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+}
+
+pub(super) fn track_child(child: Child) -> io::Result<()> {
+    match child_reaper()?.send(child) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            let mut child = error.0;
+            let _ = child.kill();
+            let _ = child.wait();
+            Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "Linux launch child reaper stopped",
+            ))
+        }
+    }
+}
+
+fn child_reaper() -> io::Result<&'static Sender<Child>> {
+    static REAPER: OnceLock<Result<Sender<Child>, String>> = OnceLock::new();
+    match REAPER.get_or_init(start_child_reaper) {
+        Ok(sender) => Ok(sender),
+        Err(message) => Err(io::Error::other(message.clone())),
+    }
+}
+
+fn start_child_reaper() -> Result<Sender<Child>, String> {
+    let (sender, receiver) = mpsc::channel();
+    std::thread::Builder::new()
+        .name("cua-driver-child-reaper".to_owned())
+        .spawn(move || child_reaper_loop(receiver))
+        .map_err(|error| format!("failed to start Linux launch child reaper: {error}"))?;
+    Ok(sender)
+}
+
+fn child_reaper_loop(receiver: Receiver<Child>) {
+    let mut children = Vec::new();
+    loop {
+        match receiver.recv_timeout(REAP_INTERVAL) {
+            Ok(child) => children.push(child),
+            Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Disconnected) => return,
+        }
+        children.extend(receiver.try_iter());
+        reap_finished_children(&mut children);
+    }
+}
+
+fn reap_finished_children(children: &mut Vec<Child>) {
+    let mut index = 0;
+    while index < children.len() {
+        match children[index].try_wait() {
+            Ok(Some(_)) => {
+                children.swap_remove(index);
+            }
+            Ok(None) => index += 1,
+            Err(error) => {
+                tracing::warn!(%error, "failed to poll directly launched child");
+                children.swap_remove(index);
+            }
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-    use super::spawn_shell_command;
+    use super::{spawn_shell_command, track_child};
 
     #[test]
     fn launch_path_preserves_shell_quoting() {
@@ -71,7 +147,27 @@ mod tests {
         let _ = std::fs::remove_file(output);
     }
 
+    #[test]
+    fn launched_children_are_reaped_after_exit() {
+        let child = spawn_shell_command("true", &[]).expect("spawn short-lived child");
+        let pid = child.id();
+        track_child(child).expect("hand child to reaper");
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while process_exists(pid) {
+            assert!(Instant::now() < deadline, "child {pid} was not reaped");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
     fn shell_quote(value: &str) -> String {
         format!("'{}'", value.replace('\'', "'\\''"))
+    }
+
+    fn process_exists(pid: u32) -> bool {
+        std::process::Command::new("ps")
+            .args(["-p", &pid.to_string(), "-o", "state="])
+            .output()
+            .is_ok_and(|output| output.status.success() && !output.stdout.is_empty())
     }
 }

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/process_control.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/process_control.rs
@@ -4,9 +4,25 @@ use std::sync::{
     mpsc::{self, Receiver, RecvTimeoutError, Sender},
     OnceLock,
 };
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const REAP_INTERVAL: Duration = Duration::from_millis(50);
+#[cfg(target_os = "linux")]
+const TERMINATION_POLL_INTERVAL: Duration = Duration::from_millis(10);
+#[cfg(target_os = "linux")]
+const TERMINATION_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ProcessObservation {
+    pub(super) state: char,
+    pub(super) start_time: u64,
+}
+
+impl ProcessObservation {
+    fn is_terminal(self) -> bool {
+        matches!(self.state, 'Z' | 'X' | 'x')
+    }
+}
 
 pub(super) fn spawn_shell_command(command: &str, additional_args: &[String]) -> io::Result<Child> {
     let mut launch = Command::new("sh");
@@ -92,11 +108,84 @@ fn reap_finished_children(children: &mut Vec<Child>) {
     }
 }
 
+#[cfg(target_os = "linux")]
+pub(super) fn observe_process(pid: i32) -> io::Result<Option<ProcessObservation>> {
+    match std::fs::read_to_string(format!("/proc/{pid}/stat")) {
+        Ok(stat) => parse_proc_stat(&stat).map(Some),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn parse_proc_stat(stat: &str) -> io::Result<ProcessObservation> {
+    let fields = stat
+        .rfind(") ")
+        .and_then(|name_end| stat.get(name_end + 2..))
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "malformed /proc stat"))?;
+    let mut fields = fields.split_whitespace();
+    let state = fields
+        .next()
+        .and_then(|value| value.chars().next())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing process state"))?;
+    let start_time = fields
+        .nth(18)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing process start time"))?
+        .parse()
+        .map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("invalid process start time: {error}"),
+            )
+        })?;
+    Ok(ProcessObservation { state, start_time })
+}
+
+#[cfg(target_os = "linux")]
+pub(super) fn wait_for_termination(pid: i32, expected: ProcessObservation) -> io::Result<bool> {
+    wait_for_termination_with(
+        Some(expected),
+        TERMINATION_TIMEOUT,
+        TERMINATION_POLL_INTERVAL,
+        || observe_process(pid),
+    )
+}
+
+fn wait_for_termination_with<F>(
+    expected: Option<ProcessObservation>,
+    timeout: Duration,
+    poll_interval: Duration,
+    mut observe: F,
+) -> io::Result<bool>
+where
+    F: FnMut() -> io::Result<Option<ProcessObservation>>,
+{
+    let deadline = Instant::now() + timeout;
+    loop {
+        let current = observe()?;
+        if current.is_none_or(|process| {
+            process.is_terminal()
+                || expected.is_some_and(|expected| process.start_time != expected.start_time)
+        }) {
+            return Ok(true);
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            return Ok(false);
+        }
+        std::thread::sleep(poll_interval.min(deadline - now));
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+    use std::io;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-    use super::{spawn_shell_command, track_child};
+    use super::{
+        parse_proc_stat, spawn_shell_command, track_child, wait_for_termination_with,
+        ProcessObservation,
+    };
 
     #[test]
     fn launch_path_preserves_shell_quoting() {
@@ -158,6 +247,93 @@ mod tests {
             assert!(Instant::now() < deadline, "child {pid} was not reaped");
             std::thread::sleep(Duration::from_millis(10));
         }
+    }
+
+    #[test]
+    fn proc_stat_parser_handles_spaces_and_parentheses_in_process_names() {
+        let stat = format!(
+            "123 (worker ) with spaces) S {} 4242",
+            vec!["0"; 18].join(" ")
+        );
+        assert_eq!(
+            parse_proc_stat(&stat).expect("parse process stat"),
+            ProcessObservation {
+                state: 'S',
+                start_time: 4242,
+            }
+        );
+    }
+
+    #[test]
+    fn termination_poll_accepts_terminal_state_and_pid_reuse() {
+        let original = ProcessObservation {
+            state: 'R',
+            start_time: 42,
+        };
+        let mut observations = VecDeque::from([
+            Some(original),
+            Some(ProcessObservation {
+                state: 'Z',
+                start_time: 42,
+            }),
+        ]);
+        assert!(wait_for_termination_with(
+            Some(original),
+            Duration::from_secs(1),
+            Duration::ZERO,
+            || Ok(observations.pop_front().expect("next observation")),
+        )
+        .expect("poll terminal process"));
+
+        assert!(
+            wait_for_termination_with(Some(original), Duration::ZERO, Duration::ZERO, || {
+                Ok(Some(ProcessObservation {
+                    state: 'R',
+                    start_time: 99,
+                }))
+            },)
+            .expect("detect pid reuse")
+        );
+    }
+
+    #[test]
+    fn termination_poll_reports_live_timeout_and_probe_errors() {
+        let original = ProcessObservation {
+            state: 'D',
+            start_time: 42,
+        };
+        assert!(
+            !wait_for_termination_with(Some(original), Duration::ZERO, Duration::ZERO, || Ok(
+                Some(original)
+            ),)
+            .expect("poll live process")
+        );
+        assert!(
+            wait_for_termination_with(Some(original), Duration::ZERO, Duration::ZERO, || Err(
+                io::Error::other("unreadable proc stat")
+            ),)
+            .is_err()
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn sigkill_reaches_a_terminal_process_state() {
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn sleep process");
+        let pid = child.id() as i32;
+        let expected = super::observe_process(pid)
+            .expect("read process state")
+            .expect("sleep process exists");
+        // SAFETY: the test owns this child process and passes its valid pid.
+        assert_eq!(unsafe { libc::kill(pid, libc::SIGKILL) }, 0);
+        assert!(
+            super::wait_for_termination(pid, expected).expect("verify process termination"),
+            "SIGKILLed process remained live"
+        );
+        let _ = child.wait();
     }
 
     fn shell_quote(value: &str) -> String {

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/process_control.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/process_control.rs
@@ -73,6 +73,25 @@ pub(super) fn track_child(child: Child) -> io::Result<()> {
     }
 }
 
+#[cfg(target_os = "linux")]
+pub(super) fn track_launched_child(child: Child) -> io::Result<(u32, Option<ProcessObservation>)> {
+    track_launched_child_with(child, observe_process)
+}
+
+#[cfg(target_os = "linux")]
+fn track_launched_child_with<F>(
+    child: Child,
+    observe: F,
+) -> io::Result<(u32, Option<ProcessObservation>)>
+where
+    F: FnOnce(i32) -> io::Result<Option<ProcessObservation>>,
+{
+    let pid = child.id();
+    let identity = observe(pid as i32);
+    track_child(child)?;
+    Ok((pid, identity?))
+}
+
 fn child_reaper() -> io::Result<&'static Sender<Child>> {
     static REAPER: OnceLock<Result<Sender<Child>, String>> = OnceLock::new();
     match REAPER.get_or_init(start_child_reaper) {
@@ -349,6 +368,30 @@ mod tests {
             "SIGKILLed process remained live"
         );
         let _ = child.wait();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn observation_failure_still_hands_child_to_reaper() {
+        let child = spawn_launch_command("true", &[]).expect("spawn short-lived child");
+        let pid = child.id();
+        let error = super::track_launched_child_with(child, |_| {
+            Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "simulated /proc restriction",
+            ))
+        })
+        .expect_err("observation failure must be returned");
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while process_exists(pid) {
+            assert!(
+                Instant::now() < deadline,
+                "child {pid} was not reaped after observation failure"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
     }
 
     fn shell_quote(value: &str) -> String {

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/process_control.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/process_control.rs
@@ -24,15 +24,23 @@ impl ProcessObservation {
     }
 }
 
-pub(super) fn spawn_shell_command(command: &str, additional_args: &[String]) -> io::Result<Child> {
-    let mut launch = Command::new("sh");
+pub(super) fn spawn_launch_command(command: &str, additional_args: &[String]) -> io::Result<Child> {
+    let mut argv = shlex::split(command).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "launch_path contains an unmatched shell quote",
+        )
+    })?;
+    if argv.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "launch_path must contain a program",
+        ));
+    }
+    let program = argv.remove(0);
+    let mut launch = Command::new(program);
     launch
-        .arg("-c")
-        // `exec` keeps the returned pid bound to the launched application for
-        // ordinary desktop-entry commands. `"$@"` appends caller-provided
-        // arguments without interpolating them into the shell program.
-        .arg(format!("exec {command} \"$@\""))
-        .arg("cua-driver-launch")
+        .args(argv)
         .args(additional_args)
         .env("ACCESSIBILITY_ENABLED", "1")
         .env("NO_AT_BRIDGE", "0");
@@ -117,6 +125,18 @@ pub(super) fn observe_process(pid: i32) -> io::Result<Option<ProcessObservation>
     }
 }
 
+#[cfg(target_os = "linux")]
+pub(super) fn process_still_running(
+    pid: i32,
+    expected: Option<ProcessObservation>,
+) -> io::Result<bool> {
+    let Some(expected) = expected else {
+        return Ok(false);
+    };
+    Ok(observe_process(pid)?
+        .is_some_and(|current| !current.is_terminal() && current.start_time == expected.start_time))
+}
+
 fn parse_proc_stat(stat: &str) -> io::Result<ProcessObservation> {
     let fields = stat
         .rfind(") ")
@@ -183,7 +203,7 @@ mod tests {
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     use super::{
-        parse_proc_stat, spawn_shell_command, track_child, wait_for_termination_with,
+        parse_proc_stat, spawn_launch_command, track_child, wait_for_termination_with,
         ProcessObservation,
     };
 
@@ -197,11 +217,12 @@ mod tests {
                 .expect("system time after Unix epoch")
                 .as_nanos()
         ));
-        let command = format!(
+        let script = format!(
             "printf '%s' 'quoted value' > {}",
             shell_quote(output_path.to_str().expect("UTF-8 temp path"))
         );
-        let mut child = spawn_shell_command(&command, &[]).expect("spawn launch command");
+        let command = format!("sh -c {}", shell_quote(&script));
+        let mut child = spawn_launch_command(&command, &[]).expect("spawn launch command");
         let deadline = Instant::now() + Duration::from_secs(2);
         loop {
             if child.try_wait().expect("poll launch command").is_some() {
@@ -219,12 +240,13 @@ mod tests {
     fn launch_path_appends_arguments_without_shell_interpolation() {
         let output =
             std::env::temp_dir().join(format!("cua-driver-launch-args-{}", std::process::id()));
-        let command = format!(
-            "printf '%s' > {}",
+        let script = format!(
+            "printf '%s' \"$0\" > {}",
             shell_quote(output.to_str().expect("UTF-8 temp path"))
         );
+        let command = format!("sh -c {}", shell_quote(&script));
         let arguments = vec!["value with spaces; $(false)".to_owned()];
-        let mut child = spawn_shell_command(&command, &arguments).expect("spawn launch command");
+        let mut child = spawn_launch_command(&command, &arguments).expect("spawn launch command");
         assert!(
             child.wait().expect("wait for launch command").success(),
             "launch command failed"
@@ -238,7 +260,7 @@ mod tests {
 
     #[test]
     fn launched_children_are_reaped_after_exit() {
-        let child = spawn_shell_command("true", &[]).expect("spawn short-lived child");
+        let child = spawn_launch_command("true", &[]).expect("spawn short-lived child");
         let pid = child.id();
         track_child(child).expect("hand child to reaper");
 
@@ -247,6 +269,13 @@ mod tests {
             assert!(Instant::now() < deadline, "child {pid} was not reaped");
             std::thread::sleep(Duration::from_millis(10));
         }
+    }
+
+    #[test]
+    fn launch_path_rejects_unmatched_quotes_before_spawning() {
+        let error = spawn_launch_command("sh -c 'unterminated", &[])
+            .expect_err("unmatched quote must fail");
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/process_control.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/process_control.rs
@@ -1,14 +1,16 @@
 use std::io;
+#[cfg(target_os = "linux")]
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::process::{Child, Command, Stdio};
 use std::sync::{
     mpsc::{self, Receiver, RecvTimeoutError, Sender},
     OnceLock,
 };
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(target_os = "linux")]
+use std::time::Instant;
 
 const REAP_INTERVAL: Duration = Duration::from_millis(50);
-#[cfg(target_os = "linux")]
-const TERMINATION_POLL_INTERVAL: Duration = Duration::from_millis(10);
 #[cfg(target_os = "linux")]
 const TERMINATION_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -19,6 +21,7 @@ pub(super) struct ProcessObservation {
 }
 
 impl ProcessObservation {
+    #[cfg(target_os = "linux")]
     fn is_terminal(self) -> bool {
         matches!(self.state, 'Z' | 'X' | 'x')
     }
@@ -161,51 +164,91 @@ fn parse_proc_stat(stat: &str) -> io::Result<ProcessObservation> {
 }
 
 #[cfg(target_os = "linux")]
-pub(super) fn wait_for_termination(pid: i32, expected: ProcessObservation) -> io::Result<bool> {
-    wait_for_termination_with(
-        Some(expected),
-        TERMINATION_TIMEOUT,
-        TERMINATION_POLL_INTERVAL,
-        || observe_process(pid),
-    )
+pub(super) fn terminate_process(pid: i32) -> io::Result<bool> {
+    let process = PidFd::open(pid)?;
+    process.send_signal(libc::SIGKILL)?;
+    process.wait_for_exit(TERMINATION_TIMEOUT)
 }
 
-fn wait_for_termination_with<F>(
-    expected: Option<ProcessObservation>,
-    timeout: Duration,
-    poll_interval: Duration,
-    mut observe: F,
-) -> io::Result<bool>
-where
-    F: FnMut() -> io::Result<Option<ProcessObservation>>,
-{
-    let deadline = Instant::now() + timeout;
-    loop {
-        let current = observe()?;
-        if current.is_none_or(|process| {
-            process.is_terminal()
-                || expected.is_some_and(|expected| process.start_time != expected.start_time)
-        }) {
-            return Ok(true);
+#[cfg(target_os = "linux")]
+struct PidFd(OwnedFd);
+
+#[cfg(target_os = "linux")]
+impl PidFd {
+    fn open(pid: i32) -> io::Result<Self> {
+        // SAFETY: pidfd_open takes a numeric pid and zero flags. On success the
+        // returned descriptor is uniquely owned and transferred to OwnedFd.
+        let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0u32) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
         }
-        let now = Instant::now();
-        if now >= deadline {
-            return Ok(false);
+        // SAFETY: the successful syscall returned a fresh owned descriptor.
+        Ok(Self(unsafe { OwnedFd::from_raw_fd(fd as i32) }))
+    }
+
+    fn send_signal(&self, signal: i32) -> io::Result<()> {
+        // SAFETY: the pidfd remains owned by self for the duration of the
+        // syscall; a null siginfo pointer and zero flags are the documented
+        // pidfd_send_signal form for ordinary signals.
+        let result = unsafe {
+            libc::syscall(
+                libc::SYS_pidfd_send_signal,
+                self.0.as_raw_fd(),
+                signal,
+                std::ptr::null::<libc::siginfo_t>(),
+                0u32,
+            )
+        };
+        if result < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
         }
-        std::thread::sleep(poll_interval.min(deadline - now));
+    }
+
+    fn wait_for_exit(&self, timeout: Duration) -> io::Result<bool> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let timeout_ms = if remaining.is_zero() {
+                0
+            } else {
+                remaining.as_millis().clamp(1, i32::MAX as u128) as i32
+            };
+            let mut descriptor = libc::pollfd {
+                fd: self.0.as_raw_fd(),
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            // SAFETY: descriptor points to one initialized pollfd for the
+            // duration of the call; the timeout is bounded to i32 milliseconds.
+            let result = unsafe { libc::poll(&mut descriptor, 1, timeout_ms) };
+            if result > 0 {
+                if descriptor.revents & libc::POLLNVAL != 0 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "pidfd became invalid while waiting for process exit",
+                    ));
+                }
+                return Ok(descriptor.revents & (libc::POLLIN | libc::POLLHUP) != 0);
+            }
+            if result == 0 {
+                return Ok(false);
+            }
+            let error = io::Error::last_os_error();
+            if error.kind() != io::ErrorKind::Interrupted {
+                return Err(error);
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::VecDeque;
     use std::io;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-    use super::{
-        parse_proc_stat, spawn_launch_command, track_child, wait_for_termination_with,
-        ProcessObservation,
-    };
+    use super::{parse_proc_stat, spawn_launch_command, track_child, ProcessObservation};
 
     #[test]
     fn launch_path_preserves_shell_quoting() {
@@ -293,73 +336,16 @@ mod tests {
         );
     }
 
-    #[test]
-    fn termination_poll_accepts_terminal_state_and_pid_reuse() {
-        let original = ProcessObservation {
-            state: 'R',
-            start_time: 42,
-        };
-        let mut observations = VecDeque::from([
-            Some(original),
-            Some(ProcessObservation {
-                state: 'Z',
-                start_time: 42,
-            }),
-        ]);
-        assert!(wait_for_termination_with(
-            Some(original),
-            Duration::from_secs(1),
-            Duration::ZERO,
-            || Ok(observations.pop_front().expect("next observation")),
-        )
-        .expect("poll terminal process"));
-
-        assert!(
-            wait_for_termination_with(Some(original), Duration::ZERO, Duration::ZERO, || {
-                Ok(Some(ProcessObservation {
-                    state: 'R',
-                    start_time: 99,
-                }))
-            },)
-            .expect("detect pid reuse")
-        );
-    }
-
-    #[test]
-    fn termination_poll_reports_live_timeout_and_probe_errors() {
-        let original = ProcessObservation {
-            state: 'D',
-            start_time: 42,
-        };
-        assert!(
-            !wait_for_termination_with(Some(original), Duration::ZERO, Duration::ZERO, || Ok(
-                Some(original)
-            ),)
-            .expect("poll live process")
-        );
-        assert!(
-            wait_for_termination_with(Some(original), Duration::ZERO, Duration::ZERO, || Err(
-                io::Error::other("unreadable proc stat")
-            ),)
-            .is_err()
-        );
-    }
-
     #[cfg(target_os = "linux")]
     #[test]
-    fn sigkill_reaches_a_terminal_process_state() {
+    fn pidfd_sigkill_reaches_a_terminal_process_state() {
         let mut child = std::process::Command::new("sleep")
             .arg("30")
             .spawn()
             .expect("spawn sleep process");
         let pid = child.id() as i32;
-        let expected = super::observe_process(pid)
-            .expect("read process state")
-            .expect("sleep process exists");
-        // SAFETY: the test owns this child process and passes its valid pid.
-        assert_eq!(unsafe { libc::kill(pid, libc::SIGKILL) }, 0);
         assert!(
-            super::wait_for_termination(pid, expected).expect("verify process termination"),
+            super::terminate_process(pid).expect("terminate process through pidfd"),
             "SIGKILLed process remained live"
         );
         let _ = child.wait();

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/process_control.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/process_control.rs
@@ -1,0 +1,77 @@
+use std::io;
+use std::process::{Child, Command};
+
+pub(super) fn spawn_shell_command(command: &str, additional_args: &[String]) -> io::Result<Child> {
+    let mut launch = Command::new("sh");
+    launch
+        .arg("-c")
+        // `exec` keeps the returned pid bound to the launched application for
+        // ordinary desktop-entry commands. `"$@"` appends caller-provided
+        // arguments without interpolating them into the shell program.
+        .arg(format!("exec {command} \"$@\""))
+        .arg("cua-driver-launch")
+        .args(additional_args)
+        .env("ACCESSIBILITY_ENABLED", "1")
+        .env("NO_AT_BRIDGE", "0");
+    launch.spawn()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+    use super::spawn_shell_command;
+
+    #[test]
+    fn launch_path_preserves_shell_quoting() {
+        let output_path = std::env::temp_dir().join(format!(
+            "cua-driver-launch-quoting-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system time after Unix epoch")
+                .as_nanos()
+        ));
+        let command = format!(
+            "printf '%s' 'quoted value' > {}",
+            shell_quote(output_path.to_str().expect("UTF-8 temp path"))
+        );
+        let mut child = spawn_shell_command(&command, &[]).expect("spawn launch command");
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if child.try_wait().expect("poll launch command").is_some() {
+                break;
+            }
+            assert!(Instant::now() < deadline, "launch command did not exit");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let actual = std::fs::read_to_string(&output_path).expect("launch output");
+        assert_eq!(actual, "quoted value");
+        let _ = std::fs::remove_file(output_path);
+    }
+
+    #[test]
+    fn launch_path_appends_arguments_without_shell_interpolation() {
+        let output =
+            std::env::temp_dir().join(format!("cua-driver-launch-args-{}", std::process::id()));
+        let command = format!(
+            "printf '%s' > {}",
+            shell_quote(output.to_str().expect("UTF-8 temp path"))
+        );
+        let arguments = vec!["value with spaces; $(false)".to_owned()];
+        let mut child = spawn_shell_command(&command, &arguments).expect("spawn launch command");
+        assert!(
+            child.wait().expect("wait for launch command").success(),
+            "launch command failed"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&output).expect("launch output"),
+            arguments[0]
+        );
+        let _ = std::fs::remove_file(output);
+    }
+
+    fn shell_quote(value: &str) -> String {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
+}


### PR DESCRIPTION
## Problem

On Linux, `launch_app` lost quoted `launch_path` arguments and dropped the spawned child handle. `kill_app` reported success as soon as the kernel accepted SIGKILL, even when the process was still alive.

## What changed

- parse XDG `Exec=` values into normalized argv and preserve shell-style quoting for explicit `launch_path` commands
- spawn launch commands directly with detached stdio, keep their child handles, and reap every exit path
- observe a window, a clean command exit, or a three-second deadline; return exit code/signal details and mark nonzero exits as errors
- open a pidfd before rechecking the approved process fingerprint, then signal and wait through that same identity-bound handle
- return structured failures when termination is unsupported, fails, or cannot be confirmed

## Tests

- `cargo test -p platform-linux --lib --locked` on Linux after the process-control changes: 171 passed
- `cargo test -p platform-linux installed_apps::tests --locked` on Linux at final HEAD: 12 passed
- `cargo test -p platform-linux tools::process_control::tests --locked` on macOS: 5 passed
- `cargo fmt --all -- --check`

Representative X11 and Wayland sessions and the reporter's gVisor environment were not available here. This PR stays draft until those live checks are completed, and it does not claim the reported gVisor setup is fixed yet.

Addresses #2661
