### PR TITLE
feat(cua-driver): add transient Wayland seats

### DIFF
--- a/.github/workflows/ci-nix-linux.yml
+++ b/.github/workflows/ci-nix-linux.yml
@@ -18,7 +18,8 @@ on:
       - "libs/cua-driver/rust/crates/pip-preview/**"
       - "libs/cua-driver/rust/crates/platform-linux/**"
       - "libs/cua-driver/wayland-helper/**"
-      - "libs/cua-driver/tests/fixtures/shared/web/index.html"
+      - "libs/cua-driver/tests/fixtures/shared/web/**"
+      - "libs/cua-driver/tests/fixtures/apps/cross-platform/electron/**"
       - ".github/workflows/ci-nix-linux.yml"
   push:
     branches: [main]
@@ -36,7 +37,8 @@ on:
       - "libs/cua-driver/rust/crates/pip-preview/**"
       - "libs/cua-driver/rust/crates/platform-linux/**"
       - "libs/cua-driver/wayland-helper/**"
-      - "libs/cua-driver/tests/fixtures/shared/web/index.html"
+      - "libs/cua-driver/tests/fixtures/shared/web/**"
+      - "libs/cua-driver/tests/fixtures/apps/cross-platform/electron/**"
       - ".github/workflows/ci-nix-linux.yml"
   workflow_dispatch:
 
@@ -66,6 +68,8 @@ jobs:
             attribute: cua-driver-policy-yaml
           - name: Rego policy VM
             attribute: cua-driver-policy-rego
+          - name: transient-seat container
+            attribute: cua-driver-transient-seat
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install Nix
@@ -73,8 +77,29 @@ jobs:
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
+            extra-experimental-features = auto-allocate-uids cgroups
+            auto-allocate-uids = true
+            extra-system-features = uid-range
       - name: Build ${{ matrix.name }}
         run: >-
           nix build
           .#checks.x86_64-linux.${{ matrix.attribute }}
-          --no-link --print-build-logs --show-trace
+          --out-link "result-${{ matrix.attribute }}" --print-build-logs --show-trace
+      - name: Upload transient-seat evidence
+        if: always() && matrix.attribute == 'cua-driver-transient-seat'
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: cua-driver-transient-seat-evidence
+          path: result-cua-driver-transient-seat
+          if-no-files-found: warn
+          compression-level: 0
+          retention-days: 14
+      - name: Verify transient-seat evidence and verdict
+        if: always() && matrix.attribute == 'cua-driver-transient-seat'
+        run: |
+          evidence=result-cua-driver-transient-seat
+          test -s "$evidence/transient-seat.gif"
+          test -s "$evidence/test.log"
+          test -s "$evidence/compositor.log"
+          test -s "$evidence/test-status"
+          test "$(cat "$evidence/test-status")" = 0

--- a/docs/superpowers/plans/2026-07-30-transient-seat-container-test.md
+++ b/docs/superpowers/plans/2026-07-30-transient-seat-container-test.md
@@ -1,0 +1,63 @@
+# Transient Seat Container Test Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a required, container-based NixOS integration test for Cua Driver transient Wayland seats with inspectable GIF and log evidence.
+
+**Architecture:** A NixOS `containers.machine` test provisions the headless Cua compositor and Rust test runtime, then invokes the existing ignored Rust transient-seat contract through the compositor injection socket. The Nix harness collects a GIF and logs before returning the Rust command's status; GitHub Actions uploads the produced evidence on both success and failure.
+
+**Tech Stack:** Nix flakes, NixOS test driver/systemd-nspawn, wlroots Cua compositor, Rust/Cargo E2E test, GitHub Actions artifacts.
+
+## Global Constraints
+
+- Keep transient-seat behavioral assertions exclusively in `transient_seat_behavior_test.rs`.
+- Use `containers.machine`; do not add QEMU or VM-only device dependencies.
+- Require the check in normal pull-request CI.
+- Export nonempty GIF and logs before a failed test aborts the Nix test driver.
+
+---
+
+### Task 1: Add the failing container integration check
+
+**Files:**
+- Create: `nix/cua-driver/tests/transient-seat.nix`
+- Modify: `flake.nix`
+- Test: `nix build .#checks.x86_64-linux.cua-driver-transient-seat`
+
+**Interfaces:**
+- Consumes: `cuaDriver`, `cuaCompositor`, and the Rust workspace source supplied by `flake.nix`.
+- Produces: `checks.cua-driver-transient-seat`, with GIF and log files in `$out`.
+
+- [ ] Define a `containers.machine` NixOS test that installs the compositor, Rust build/runtime inputs, and GIF capture tools.
+- [ ] Have `testScript` start a private D-Bus session, the headless compositor, and wait for both the Wayland and injection sockets.
+- [ ] Run `cargo test -p cua-driver --test transient_seat_behavior_test -- --ignored --nocapture --test-threads=1`, recording its exit status.
+- [ ] Stop the recorder, assert that the GIF is nonempty, copy evidence from the container, and only then fail for a nonzero Rust test status.
+- [ ] Register the new flake check and run the focused build; it must initially fail until CI wiring is added.
+
+### Task 2: Make evidence available in required PR CI
+
+**Files:**
+- Modify: `.github/workflows/ci-nix-linux.yml`
+- Test: pull-request workflow check selection and artifact upload paths
+
+**Interfaces:**
+- Consumes: the Nix derivation output from `cua-driver-transient-seat`.
+- Produces: a required check and retained GIF/log artifact for every run.
+
+- [ ] Add the transient-seat flake check to the Nix PR test matrix with the container runtime's `auto-allocate-uids`, `cgroups`, and `uid-range` features.
+- [ ] Upload its output directory with `if: always()` so failed runs retain GIF and logs.
+- [ ] Verify the workflow's check name matches the flake attribute exactly.
+
+### Task 3: Validate focused and structural contracts
+
+**Files:**
+- Modify: `nix/cua-driver/tests/README.md`
+- Test: Nix evaluation/build and workflow YAML parsing
+
+**Interfaces:**
+- Consumes: the check and workflow from Tasks 1-2.
+- Produces: documented container-test ownership boundaries.
+
+- [ ] Document that this check provisions a headless container session and delegates behavioral assertions to the typed Rust test.
+- [ ] Run the focused Nix check and inspect the output GIF/log files when Nix is available.
+- [ ] Run repository-available formatting or YAML validation without changing unrelated files.

--- a/docs/superpowers/specs/2026-07-30-transient-seat-container-test-design.md
+++ b/docs/superpowers/specs/2026-07-30-transient-seat-container-test-design.md
@@ -1,0 +1,24 @@
+# Transient Seat Container Test Design
+
+## Goal
+
+Make transient-seat behavior a required pull-request check using the NixOS
+container test runtime and retain visual and textual evidence from every run.
+
+## Scope
+
+- Run the existing ignored Rust transient-seat behavior test in a headless
+  NixOS container with the Cua compositor and its private injection socket.
+- Keep behavioral assertions in Rust; the Nix test owns environment setup,
+  evidence collection, and artifact export only.
+- Record a GIF, compositor log, and Rust test log before propagating the test
+  result, so failed runs remain inspectable.
+- Register the check in `flake.nix` and the normal pull-request Nix workflow.
+
+## Constraints
+
+- Use `containers.machine`, not QEMU `nodes.machine`.
+- Do not require `/dev/uinput`, DRM, or a logind seat; the compositor runs
+  headlessly through its control socket.
+- Copy artifacts from the test container into the derivation output, then make
+  CI upload that output even when the check fails.

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,8 @@
               ./libs/cua-driver/rust
               ./libs/cua-driver/wayland-helper
               ./libs/cua-driver/compat-fixtures
-              ./libs/cua-driver/tests/fixtures/shared/web/index.html
+              ./libs/cua-driver/tests/fixtures/shared/web
+              ./libs/cua-driver/tests/fixtures/apps/cross-platform/electron
             ];
           };
 
@@ -146,6 +147,11 @@
             cua-driver-policy-rego = import ./nix/cua-driver/tests/policy-rego.nix {
               inherit pkgs;
               cuaDriver = cuaDriverPackage;
+            };
+            cua-driver-transient-seat = import ./nix/cua-driver/tests/transient-seat.nix {
+              inherit pkgs;
+              src = rustTestSrc;
+              cuaCompositor = cuaCompositorPackage;
             };
           };
 

--- a/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
@@ -130,15 +130,6 @@ fn wait_for_fixture(journal: &FixtureJournal, marker: &str) {
 #[test]
 #[ignore = "requires the cua-compositor nested Wayland E2E environment"]
 fn transient_seats_are_isolated_and_destroyable() {
-    // Electron discovers Wayland seats at startup, so create transient seats
-    // before each fixture binds the registry globals.
-    assert_eq!(
-        exchange(&["seat create agent-a".to_owned()]),
-        vec!["ok"],
-        "missing transient-seat lifecycle capability"
-    );
-    assert_eq!(exchange(&["seat create agent-b".to_owned()]), vec!["ok"]);
-
     let fixture_a = launch_fixture("agent-a");
     let fixture_b = launch_fixture("agent-b");
     wait_for_target(&fixture_a);
@@ -146,6 +137,13 @@ fn transient_seats_are_isolated_and_destroyable() {
     let target_a = target(&fixture_a);
     let target_b = target(&fixture_b);
     let default_focus_before = exchange(&["q 0".to_owned()]).remove(0);
+
+    assert_eq!(
+        exchange(&["seat create agent-a".to_owned()]),
+        vec!["ok"],
+        "missing transient-seat lifecycle capability"
+    );
+    assert_eq!(exchange(&["seat create agent-b".to_owned()]), vec!["ok"]);
 
     // The shared Electron fixture is a three-column grid. This point lands in
     // the third-column keyboard control instead of the older stacked layout's
@@ -162,6 +160,8 @@ fn transient_seats_are_isolated_and_destroyable() {
         vec!["ok"; 6],
         "seat-scoped pointer input must be accepted"
     );
+    // Chromium processes the Wayland pointer click asynchronously. Let it
+    // establish DOM focus before routing the typed strings.
     thread::sleep(Duration::from_millis(100));
     assert_eq!(
         exchange(&[

--- a/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
@@ -5,6 +5,7 @@
 
 #![cfg(target_os = "linux")]
 
+use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixStream;
 use std::process::{Child, Command, Stdio};
@@ -67,7 +68,8 @@ fn launch_fixture(label: &str) -> Fixture {
     );
     let journal = FixtureJournal::start();
     let fixture_stderr = if std::env::var_os("CUA_TRANSIENT_SEAT_WAYLAND_DEBUG").is_some() {
-        Stdio::inherit()
+        let path = format!("/tmp/transient-seat-evidence/wayland-{label}.log");
+        Stdio::from(File::create(path).expect("create per-fixture Wayland protocol log"))
     } else {
         Stdio::null()
     };

--- a/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
@@ -130,6 +130,8 @@ fn wait_for_fixture(journal: &FixtureJournal, marker: &str) {
 #[test]
 #[ignore = "requires the cua-compositor nested Wayland E2E environment"]
 fn transient_seats_are_isolated_and_destroyable() {
+    // Electron binds its Wayland globals at startup, so the transient seats
+    // must exist before either fixture initializes its registry.
     let fixture_a = launch_fixture("agent-a");
     let fixture_b = launch_fixture("agent-b");
     wait_for_target(&fixture_a);

--- a/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
@@ -130,6 +130,15 @@ fn wait_for_fixture(journal: &FixtureJournal, marker: &str) {
 #[test]
 #[ignore = "requires the cua-compositor nested Wayland E2E environment"]
 fn transient_seats_are_isolated_and_destroyable() {
+    // Electron discovers Wayland seats at startup, so create transient seats
+    // before each fixture binds the registry globals.
+    assert_eq!(
+        exchange(&["seat create agent-a".to_owned()]),
+        vec!["ok"],
+        "missing transient-seat lifecycle capability"
+    );
+    assert_eq!(exchange(&["seat create agent-b".to_owned()]), vec!["ok"]);
+
     let fixture_a = launch_fixture("agent-a");
     let fixture_b = launch_fixture("agent-b");
     wait_for_target(&fixture_a);
@@ -137,16 +146,6 @@ fn transient_seats_are_isolated_and_destroyable() {
     let target_a = target(&fixture_a);
     let target_b = target(&fixture_b);
     let default_focus_before = exchange(&["q 0".to_owned()]).remove(0);
-
-    // Intentional RED assertion: current cua-compositor only has its physical
-    // seat0, so this must fail as `err unknown-command` until lifecycle support
-    // is implemented.
-    assert_eq!(
-        exchange(&["seat create agent-a".to_owned()]),
-        vec!["ok"],
-        "missing transient-seat lifecycle capability"
-    );
-    assert_eq!(exchange(&["seat create agent-b".to_owned()]), vec!["ok"]);
 
     // The shared Electron fixture is a three-column grid. This point lands in
     // the third-column keyboard control instead of the older stacked layout's
@@ -156,14 +155,21 @@ fn transient_seats_are_isolated_and_destroyable() {
             format!("sm agent-a {target_a} 0 700 95"),
             format!("sb agent-a {target_a} 0 272 1"),
             format!("sb agent-a {target_a} 0 272 0"),
-            format!("st agent-a {target_a} {}", hex("seat-a")),
             format!("sm agent-b {target_b} 0 700 95"),
             format!("sb agent-b {target_b} 0 272 1"),
             format!("sb agent-b {target_b} 0 272 0"),
+        ]),
+        vec!["ok"; 6],
+        "seat-scoped pointer input must be accepted"
+    );
+    thread::sleep(Duration::from_millis(100));
+    assert_eq!(
+        exchange(&[
+            format!("st agent-a {target_a} {}", hex("seat-a")),
             format!("st agent-b {target_b} {}", hex("seat-b")),
         ]),
-        vec!["ok"; 8],
-        "seat-scoped clicks and typing must be accepted"
+        vec!["ok"; 2],
+        "seat-scoped keyboard input must be accepted"
     );
     wait_for_fixture(&fixture_a.journal, "seat-a");
     wait_for_fixture(&fixture_b.journal, "seat-b");

--- a/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
@@ -1,0 +1,186 @@
+//! External behavioral contract for independently destroyable Wayland seats.
+//!
+//! The control socket and fixture journals are separate oracles. The test does
+//! not accept a driver response as evidence that an event reached a fixture.
+
+#![cfg(target_os = "linux")]
+
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixStream;
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use cua_driver_testkit::{harness_app, FixtureJournal};
+
+const HELLO: &str = "cua-inject-v1";
+
+struct Fixture {
+    child: Child,
+    pid: u32,
+    journal: FixtureJournal,
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn line(reader: &mut impl BufRead) -> String {
+    let mut response = String::new();
+    reader
+        .read_line(&mut response)
+        .expect("read compositor response");
+    assert!(!response.is_empty(), "compositor closed the control socket");
+    response.trim().to_owned()
+}
+
+fn exchange(commands: &[String]) -> Vec<String> {
+    let socket = std::env::var("CUA_INJECT_SOCKET")
+        .expect("transient-seat E2E requires the cua-compositor socket");
+    let stream = UnixStream::connect(socket).expect("connect cua-compositor socket");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("set compositor read timeout");
+    let mut reader = BufReader::new(stream.try_clone().expect("clone compositor socket"));
+    let mut writer = stream;
+    writeln!(writer, "{HELLO}").expect("write protocol hello");
+    writer.flush().expect("flush protocol hello");
+    assert_eq!(line(&mut reader), HELLO, "compositor protocol handshake");
+    commands
+        .iter()
+        .map(|command| {
+            writeln!(writer, "{command}").expect("write compositor command");
+            writer.flush().expect("flush compositor command");
+            line(&mut reader)
+        })
+        .collect()
+}
+
+fn launch_fixture(label: &str) -> Fixture {
+    let executable = harness_app("harness-electron", "CuaTestHarness.Electron");
+    assert!(
+        executable.exists(),
+        "required Electron fixture is missing: {executable:?}"
+    );
+    let journal = FixtureJournal::start();
+    let child = Command::new(executable)
+        .args([
+            "--no-sandbox",
+            "--disable-gpu",
+            "--force-renderer-accessibility",
+        ])
+        .env("CUA_E2E_FIXTURE_JOURNAL_URL", journal.url())
+        .env("CUA_E2E_TRANSIENT_SEAT_LABEL", label)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("launch Electron fixture");
+    Fixture {
+        pid: child.id(),
+        child,
+        journal,
+    }
+}
+
+fn target(fixture: &Fixture) -> String {
+    format!("root:{}", fixture.pid)
+}
+
+fn hex(text: &str) -> String {
+    text.as_bytes()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn wait_for_fixture(journal: &FixtureJournal, marker: &str) {
+    let deadline = Instant::now() + Duration::from_secs(8);
+    while Instant::now() < deadline {
+        if journal.contains(marker) {
+            return;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    panic!(
+        "fixture journal did not observe {marker:?}; latest={}",
+        journal.snapshot()
+    );
+}
+
+#[test]
+#[ignore = "requires the cua-compositor nested Wayland E2E environment"]
+fn transient_seats_are_isolated_and_destroyable() {
+    let fixture_a = launch_fixture("agent-a");
+    let fixture_b = launch_fixture("agent-b");
+    let target_a = target(&fixture_a);
+    let target_b = target(&fixture_b);
+    let default_focus_before = exchange(&["q 0".to_owned()]).remove(0);
+
+    // Intentional RED assertion: current cua-compositor only has its physical
+    // seat0, so this must fail as `err unknown-command` until lifecycle support
+    // is implemented.
+    assert_eq!(
+        exchange(&["seat create agent-a".to_owned()]),
+        vec!["ok"],
+        "missing transient-seat lifecycle capability"
+    );
+    assert_eq!(exchange(&["seat create agent-b".to_owned()]), vec!["ok"]);
+
+    assert_eq!(
+        exchange(&[
+            format!("sm agent-a {target_a} 0 160 420"),
+            format!("sb agent-a {target_a} 0 272 1"),
+            format!("sb agent-a {target_a} 0 272 0"),
+            format!("st agent-a {target_a} {}", hex("seat-a")),
+            format!("sm agent-b {target_b} 0 160 420"),
+            format!("sb agent-b {target_b} 0 272 1"),
+            format!("sb agent-b {target_b} 0 272 0"),
+            format!("st agent-b {target_b} {}", hex("seat-b")),
+        ]),
+        vec!["ok"; 8],
+        "seat-scoped clicks and typing must be accepted"
+    );
+    wait_for_fixture(&fixture_a.journal, "seat-a");
+    wait_for_fixture(&fixture_b.journal, "seat-b");
+    assert_eq!(
+        exchange(&["q 0".to_owned()]).remove(0),
+        default_focus_before
+    );
+
+    let drag_a = target_a.clone();
+    let drag_b = target_b.clone();
+    let agent_a = thread::spawn(move || {
+        exchange(&[
+            format!("sm agent-a {drag_a} 0 20 20"),
+            format!("sb agent-a {drag_a} 0 272 1"),
+            format!("sm agent-a {drag_a} 0 220 120"),
+            format!("sb agent-a {drag_a} 0 272 0"),
+        ])
+    });
+    let agent_b = thread::spawn(move || {
+        exchange(&[
+            format!("sm agent-b {drag_b} 0 20 20"),
+            format!("sb agent-b {drag_b} 0 272 1"),
+            format!("sm agent-b {drag_b} 0 220 120"),
+            format!("sb agent-b {drag_b} 0 272 0"),
+        ])
+    });
+    assert_eq!(agent_a.join().expect("agent A drag"), vec!["ok"; 4]);
+    assert_eq!(agent_b.join().expect("agent B drag"), vec!["ok"; 4]);
+
+    assert_eq!(exchange(&["seat destroy agent-a".to_owned()]), vec!["ok"]);
+    assert_eq!(
+        exchange(&[format!("st agent-b {target_b} {}", hex("-still-b"))]),
+        vec!["ok"],
+        "destroying agent A must leave agent B functional"
+    );
+    wait_for_fixture(&fixture_b.journal, "seat-b-still-b");
+    assert_eq!(
+        exchange(&["q 0".to_owned()]).remove(0),
+        default_focus_before
+    );
+}

--- a/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
@@ -132,6 +132,13 @@ fn wait_for_fixture(journal: &FixtureJournal, marker: &str) {
 fn transient_seats_are_isolated_and_destroyable() {
     // Electron binds its Wayland globals at startup, so the transient seats
     // must exist before either fixture initializes its registry.
+    assert_eq!(
+        exchange(&["seat create agent-a".to_owned()]),
+        vec!["ok"],
+        "missing transient-seat lifecycle capability"
+    );
+    assert_eq!(exchange(&["seat create agent-b".to_owned()]), vec!["ok"]);
+
     let fixture_a = launch_fixture("agent-a");
     let fixture_b = launch_fixture("agent-b");
     wait_for_target(&fixture_a);

--- a/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
@@ -148,13 +148,16 @@ fn transient_seats_are_isolated_and_destroyable() {
     );
     assert_eq!(exchange(&["seat create agent-b".to_owned()]), vec!["ok"]);
 
+    // The shared Electron fixture is a three-column grid. This point lands in
+    // the third-column keyboard control instead of the older stacked layout's
+    // now-unrelated lower-left position.
     assert_eq!(
         exchange(&[
-            format!("sm agent-a {target_a} 0 160 420"),
+            format!("sm agent-a {target_a} 0 700 95"),
             format!("sb agent-a {target_a} 0 272 1"),
             format!("sb agent-a {target_a} 0 272 0"),
             format!("st agent-a {target_a} {}", hex("seat-a")),
-            format!("sm agent-b {target_b} 0 160 420"),
+            format!("sm agent-b {target_b} 0 700 95"),
             format!("sb agent-b {target_b} 0 272 1"),
             format!("sb agent-b {target_b} 0 272 0"),
             format!("st agent-b {target_b} {}", hex("seat-b")),

--- a/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
@@ -66,6 +66,11 @@ fn launch_fixture(label: &str) -> Fixture {
         "required Electron fixture is missing: {executable:?}"
     );
     let journal = FixtureJournal::start();
+    let fixture_stderr = if std::env::var_os("CUA_TRANSIENT_SEAT_WAYLAND_DEBUG").is_some() {
+        Stdio::inherit()
+    } else {
+        Stdio::null()
+    };
     let child = Command::new(executable)
         .args([
             "--no-sandbox",
@@ -76,7 +81,7 @@ fn launch_fixture(label: &str) -> Fixture {
         .env("CUA_E2E_TRANSIENT_SEAT_LABEL", label)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(fixture_stderr)
         .spawn()
         .expect("launch Electron fixture");
     Fixture {

--- a/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
@@ -147,13 +147,6 @@ fn transient_seats_are_isolated_and_destroyable() {
     let target_b = target(&fixture_b);
     let default_focus_before = exchange(&["q 0".to_owned()]).remove(0);
 
-    assert_eq!(
-        exchange(&["seat create agent-a".to_owned()]),
-        vec!["ok"],
-        "missing transient-seat lifecycle capability"
-    );
-    assert_eq!(exchange(&["seat create agent-b".to_owned()]), vec!["ok"]);
-
     // The shared Electron fixture is a three-column grid. This point lands in
     // the third-column keyboard control instead of the older stacked layout's
     // now-unrelated lower-left position.

--- a/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
@@ -90,6 +90,22 @@ fn target(fixture: &Fixture) -> String {
     format!("root:{}", fixture.pid)
 }
 
+fn wait_for_target(fixture: &Fixture) {
+    let deadline = Instant::now() + Duration::from_secs(8);
+    let query = format!("g {}", fixture.pid);
+    while Instant::now() < deadline {
+        let response = exchange(&[query.clone()]).remove(0);
+        if response.starts_with("geometry ") {
+            return;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    panic!(
+        "fixture root PID {} never mapped into cua-compositor",
+        fixture.pid
+    );
+}
+
 fn hex(text: &str) -> String {
     text.as_bytes()
         .iter()
@@ -116,6 +132,8 @@ fn wait_for_fixture(journal: &FixtureJournal, marker: &str) {
 fn transient_seats_are_isolated_and_destroyable() {
     let fixture_a = launch_fixture("agent-a");
     let fixture_b = launch_fixture("agent-b");
+    wait_for_target(&fixture_a);
+    wait_for_target(&fixture_b);
     let target_a = target(&fixture_a);
     let target_b = target(&fixture_b);
     let default_focus_before = exchange(&["q 0".to_owned()]).remove(0);

--- a/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/transient_seat_behavior_test.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 
 use cua_driver_testkit::{harness_app, FixtureJournal};
 
-const HELLO: &str = "cua-inject-v1";
+const HELLO: &str = "cua-inject v1";
 
 struct Fixture {
     child: Child,

--- a/libs/cua-driver/tests/fixtures/shared/web/index.html
+++ b/libs/cua-driver/tests/fixtures/shared/web/index.html
@@ -232,9 +232,11 @@
     }
   });
 
-  window.addEventListener("focus", () => {
+  const focusKeyboardInput = () => {
     $("keyboard-input").focus();
-  });
+  };
+  window.addEventListener("DOMContentLoaded", focusKeyboardInput);
+  window.addEventListener("focus", focusKeyboardInput);
 
   $('sld-value').addEventListener('input', e => {
     $('lbl-slider-value').textContent = `slider_value=${e.target.value}`;

--- a/libs/cua-driver/tests/fixtures/shared/web/index.html
+++ b/libs/cua-driver/tests/fixtures/shared/web/index.html
@@ -232,6 +232,10 @@
     }
   });
 
+  window.addEventListener("focus", () => {
+    $("keyboard-input").focus();
+  });
+
   $('sld-value').addEventListener('input', e => {
     $('lbl-slider-value').textContent = `slider_value=${e.target.value}`;
   });

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -57,8 +57,8 @@ INCLUDES = r"""#include <stdint.h>
 struct cua_devstate { struct wlr_surface *entered; };
 static struct cua_devstate cua_ptr[CUA_MAXDEV];
 static struct cua_devstate cua_kbd_state[CUA_MAXDEV];
-/* The physical compositor seat remains server->seat outside a command. Each
- * transient entry owns a wlroots seat and an isolated range in cua_ptr. */
+/* Transient entries retain lifecycle identity and isolated logical device ranges.
+ * Injection uses the physical seat because clients bind its wl_pointer/wl_keyboard. */
 struct cua_transient_seat {
 	char name[64];
 	struct wlr_seat *seat;
@@ -300,7 +300,7 @@ static const char *cua_transient_seat_create(struct tinywl_server *server, const
 		wlr_seat_set_capabilities(entry->seat,
 			WL_SEAT_CAPABILITY_POINTER | WL_SEAT_CAPABILITY_KEYBOARD);
 		snprintf(entry->name, sizeof entry->name, "%s", name);
-		entry->device_base = (i + 1) * CUA_TRANSIENT_SEAT_STRIDE;
+		entry->device_base = i * CUA_TRANSIENT_SEAT_STRIDE + 1;
 		return NULL;
 	}
 	return "seat-limit";
@@ -648,7 +648,6 @@ static const char *cua_handle_cmd(struct tinywl_server *server, char *line) {
 	} else if (!strcmp(cmd, "sm") || !strcmp(cmd, "sb") || !strcmp(cmd, "st")) {
 		char seat_name[64];
 		struct cua_transient_seat *entry;
-		struct wlr_seat *physical = server->seat;
 		int idx, device;
 		bool ok = false;
 		if (!strcmp(cmd, "sm")) {
@@ -657,7 +656,7 @@ static const char *cua_handle_cmd(struct tinywl_server *server, char *line) {
 			if (!(entry = cua_transient_seat_find(seat_name))) return "unknown-seat";
 			if (!cua_transient_device(entry, idx, &device)) return "bad-device";
 			if (!(t = cua_resolve_target(server, app, &err))) return err;
-			server->seat = entry->seat; ok = cua_motion(server, t, device, x, y); server->seat = physical;
+			ok = cua_motion(server, t, device, x, y);
 			return ok ? NULL : "no-pointer-resource";
 		}
 		if (!strcmp(cmd, "sb")) {
@@ -666,14 +665,14 @@ static const char *cua_handle_cmd(struct tinywl_server *server, char *line) {
 			if (!(entry = cua_transient_seat_find(seat_name))) return "unknown-seat";
 			if (!cua_transient_device(entry, idx, &device)) return "bad-device";
 			if (!(t = cua_resolve_target(server, app, &err))) return err;
-			server->seat = entry->seat; ok = cua_button(server, t, device, button, pressed != 0); server->seat = physical;
+			ok = cua_button(server, t, device, button, pressed != 0);
 			return ok ? NULL : "no-pointer-resource";
 		}
 		char hex[8192];
 		if (sscanf(line, "st %63s %127s %8191s", seat_name, app, hex) != 3) return "bad-args";
 		if (!(entry = cua_transient_seat_find(seat_name))) return "unknown-seat";
 		if (!(t = cua_resolve_target(server, app, &err))) return err;
-		server->seat = entry->seat; ok = cua_type_hex(server, t, hex); server->seat = physical;
+		ok = cua_type_hex(server, t, hex);
 		return ok ? NULL : "no-keyboard-resource";
 	} else if (!strcmp(cmd, "d")) {
 		double x, y; unsigned count, btn;

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -596,6 +596,8 @@ static void cua_kbd_key_target(struct tinywl_server *server, struct tinywl_tople
 static bool cua_type_cp(struct tinywl_server *server, struct tinywl_toplevel *t, int idx, uint32_t cp) {
 	if (cp >= 128 || !g_chartab[cp].valid) return false;
 	struct wlr_seat_client *sc = cua_kbd_enter(server, t, idx);
+	wlr_log(WLR_INFO, "[cua] key idx=%d target=%d keyboard-client=%s", idx,
+		(int)cua_toplevel_pid(t), sc ? "yes" : "no");
 	if (!sc) return false;
 	struct cua_keyent e = g_chartab[cp];
 	if (e.shift) cua_kbd_mods(sc, g_shift_mask);
@@ -621,6 +623,8 @@ static bool cua_type_hex(struct tinywl_server *server, struct tinywl_toplevel *t
 		if (surface == restore_root) { restore_toplevel = candidate; break; }
 	}
 	bool restore_focus = idx != 0 && restore_root != target_root;
+	wlr_log(WLR_INFO, "[cua] type idx=%d target=%d restore=%d", idx,
+		(int)cua_toplevel_pid(t), restore_focus);
 	if (restore_focus) {
 		/* Coalesce consecutive logical-seat strings so they restore the original
 		 * physical focus rather than an intermediate transient target. */

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -308,8 +308,10 @@ static const char *cua_transient_seat_create(struct tinywl_server *server, const
 static const char *cua_transient_seat_destroy(const char *name) {
 	struct cua_transient_seat *entry = cua_transient_seat_find(name);
 	if (!entry) return "unknown-seat";
-	for (int i = 0; i < CUA_TRANSIENT_SEAT_STRIDE; i++)
+	for (int i = 0; i < CUA_TRANSIENT_SEAT_STRIDE; i++) {
 		cua_ptr[entry->device_base + i].entered = NULL;
+		cua_kbd_state[entry->device_base + i].entered = NULL;
+	}
 	wlr_seat_destroy(entry->seat);
 	memset(entry, 0, sizeof *entry);
 	return NULL;
@@ -498,20 +500,21 @@ static void cua_init_keymap(struct tinywl_server *server) {
 	xkb_keymap_unref(km); xkb_context_unref(ctx);
 	wlr_log(WLR_INFO, "[cua] xkb keymap + chartab ready (%zu bytes)", g_keymap_size);
 }
-/* Ensure the target client's keyboard has had keymap + enter sent once (focus
- * free). idx 0 is the typing keyboard. */
-static struct wlr_seat_client *cua_kbd_enter(struct tinywl_server *server, struct tinywl_toplevel *t) {
+/* Ensure the target client's keyboard has had keymap + enter sent once for this
+ * logical keyboard. Index zero remains the physical/default keyboard. */
+static struct wlr_seat_client *cua_kbd_enter(struct tinywl_server *server, struct tinywl_toplevel *t, int idx) {
+	if (idx < 0 || idx >= CUA_MAXDEV) return NULL;
 	struct wlr_surface *surface = t->xdg_toplevel->base->surface;
 	struct wlr_seat_client *sc = wlr_seat_client_for_wl_client(server->seat, wl_resource_get_client(surface->resource));
 	if (!sc || wl_list_empty(&sc->keyboards)) return NULL;
 	struct wlr_surface *focused = server->seat->keyboard_state.focused_surface;
-	if (focused && wlr_surface_get_root_surface(focused) == surface) {
+	if (idx == 0 && focused && wlr_surface_get_root_surface(focused) == surface) {
 		/* Foreground delivery already has a protocol-complete seat enter. The
 		 * key path below uses wlr_seat_keyboard_notify_key for this target. */
-		cua_kbd_state[0].entered = surface;
+		cua_kbd_state[idx].entered = surface;
 		return sc;
 	}
-	if (cua_kbd_state[0].entered != surface) {
+	if (cua_kbd_state[idx].entered != surface) {
 		struct wl_resource *res; struct wl_array keys; wl_array_init(&keys);
 		wl_resource_for_each(res, &sc->keyboards) {
 			wl_keyboard_send_keymap(res, WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1, g_keymap_fd, g_keymap_size);
@@ -519,7 +522,7 @@ static struct wlr_seat_client *cua_kbd_enter(struct tinywl_server *server, struc
 			wl_keyboard_send_modifiers(res, wlr_seat_client_next_serial(sc), 0, 0, 0, 0);
 		}
 		wl_array_release(&keys);
-		cua_kbd_state[0].entered = surface;
+		cua_kbd_state[idx].entered = surface;
 	}
 	return sc;
 }
@@ -541,35 +544,35 @@ static void cua_kbd_key(struct wlr_seat_client *sc, uint32_t keycode, bool press
  * resource can be acknowledged while never reaching the renderer. Background
  * targets retain the direct resource path that makes focus-free input possible. */
 static void cua_kbd_key_target(struct tinywl_server *server, struct tinywl_toplevel *t,
-		struct wlr_seat_client *sc, uint32_t keycode, bool pressed) {
+		struct wlr_seat_client *sc, int idx, uint32_t keycode, bool pressed) {
 	struct wlr_surface *target = wlr_surface_get_root_surface(t->xdg_toplevel->base->surface);
 	struct wlr_surface *focused = server->seat->keyboard_state.focused_surface;
 	struct wlr_surface *focused_root = focused ? wlr_surface_get_root_surface(focused) : NULL;
-	if (target == focused_root) {
+	if (idx == 0 && target == focused_root) {
 		wlr_seat_keyboard_notify_key(server->seat, cua_now_ms(), keycode,
 			pressed ? WL_KEYBOARD_KEY_STATE_PRESSED : WL_KEYBOARD_KEY_STATE_RELEASED);
 	} else {
 		cua_kbd_key(sc, keycode, pressed);
 	}
 }
-static bool cua_type_cp(struct tinywl_server *server, struct tinywl_toplevel *t, uint32_t cp) {
+static bool cua_type_cp(struct tinywl_server *server, struct tinywl_toplevel *t, int idx, uint32_t cp) {
 	if (cp >= 128 || !g_chartab[cp].valid) return false;
-	struct wlr_seat_client *sc = cua_kbd_enter(server, t);
+	struct wlr_seat_client *sc = cua_kbd_enter(server, t, idx);
 	if (!sc) return false;
 	struct cua_keyent e = g_chartab[cp];
 	if (e.shift) cua_kbd_mods(sc, g_shift_mask);
-	cua_kbd_key_target(server, t, sc, e.keycode, true);
-	cua_kbd_key_target(server, t, sc, e.keycode, false);
+	cua_kbd_key_target(server, t, sc, idx, e.keycode, true);
+	cua_kbd_key_target(server, t, sc, idx, e.keycode, false);
 	if (e.shift) cua_kbd_mods(sc, 0);
 	return true;
 }
 /* Decode a hex-encoded ASCII string and type it focus-free into `t`. */
-static bool cua_type_hex(struct tinywl_server *server, struct tinywl_toplevel *t, const char *hex) {
+static bool cua_type_hex(struct tinywl_server *server, struct tinywl_toplevel *t, int idx, const char *hex) {
 	if (!t) return false;
 	for (const char *p = hex; p[0] && p[1]; p += 2) {
 		int hi = (p[0] <= '9') ? p[0] - '0' : (p[0] | 0x20) - 'a' + 10;
 		int lo = (p[1] <= '9') ? p[1] - '0' : (p[1] | 0x20) - 'a' + 10;
-		if (!cua_type_cp(server, t, (uint32_t)((hi << 4) | lo))) return false;
+		if (!cua_type_cp(server, t, idx, (uint32_t)((hi << 4) | lo))) return false;
 	}
 	return true;
 }
@@ -598,10 +601,10 @@ static int cua_key_named(struct tinywl_server *server, struct tinywl_toplevel *t
 	if (!t) return 0;
 	uint32_t kc = cua_named_keycode(name);
 	if (!kc) return 0;
-	struct wlr_seat_client *sc = cua_kbd_enter(server, t);
+	struct wlr_seat_client *sc = cua_kbd_enter(server, t, 0);
 	if (!sc) return -1;
-	cua_kbd_key_target(server, t, sc, kc, true);
-	cua_kbd_key_target(server, t, sc, kc, false);
+	cua_kbd_key_target(server, t, sc, 0, kc, true);
+	cua_kbd_key_target(server, t, sc, 0, kc, false);
 	return 1;
 }
 static int cua_hotkey(struct tinywl_server *server, struct tinywl_toplevel *t, const char *mods, const char *key) {
@@ -622,11 +625,11 @@ static int cua_hotkey(struct tinywl_server *server, struct tinywl_toplevel *t, c
 		else if (!strcasecmp(mod, "meta") || !strcasecmp(mod, "super") || !strcasecmp(mod, "win") || !strcasecmp(mod, "cmd")) mask |= g_logo_mask;
 		else return 0;
 	}
-	struct wlr_seat_client *sc = cua_kbd_enter(server, t);
+	struct wlr_seat_client *sc = cua_kbd_enter(server, t, 0);
 	if (!sc) return -1;
 	cua_kbd_mods(sc, mask);
-	cua_kbd_key_target(server, t, sc, kc, true);
-	cua_kbd_key_target(server, t, sc, kc, false);
+	cua_kbd_key_target(server, t, sc, 0, kc, true);
+	cua_kbd_key_target(server, t, sc, 0, kc, false);
 	cua_kbd_mods(sc, 0);
 	return 1;
 }
@@ -672,7 +675,7 @@ static const char *cua_handle_cmd(struct tinywl_server *server, char *line) {
 		if (sscanf(line, "st %63s %127s %8191s", seat_name, app, hex) != 3) return "bad-args";
 		if (!(entry = cua_transient_seat_find(seat_name))) return "unknown-seat";
 		if (!(t = cua_resolve_target(server, app, &err))) return err;
-		ok = cua_type_hex(server, t, hex);
+		ok = cua_type_hex(server, t, entry->device_base, hex);
 		return ok ? NULL : "no-keyboard-resource";
 	} else if (!strcmp(cmd, "d")) {
 		double x, y; unsigned count, btn;
@@ -699,7 +702,7 @@ static const char *cua_handle_cmd(struct tinywl_server *server, char *line) {
 		char hex[8192];
 		if (sscanf(line, "t %127s %8191s", app, hex) != 2) return "bad-args";
 		if (!(t = cua_resolve_target(server, app, &err))) return err;
-		if (!cua_type_hex(server, t, hex)) return "no-keyboard-resource";
+		if (!cua_type_hex(server, t, 0, hex)) return "no-keyboard-resource";
 		return NULL;
 	} else if (!strcmp(cmd, "k")) {
 		char key[32];

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -401,9 +401,9 @@ static bool cua_motion(struct tinywl_server *server, struct wlr_seat *seat,
 	/* Chromium consumes pointer input through wlroots' seat pointer state. Raw
 	 * wl_pointer resource sends are sufficient for GTK, but Chromium can ACK
 	 * them without dispatching DOM mouse events because the compositor-side
-	 * focus/grab state was never updated. Device 0 is the normal single-pointer
-	 * route, so use the protocol-complete seat notifications there. Higher
-	 * logical device indices retain direct delivery for independent cursors. */
+	 * focus/grab state was never updated. Each transient wl_seat and physical
+	 * device zero use the protocol-complete notification path; other physical
+	 * logical devices retain direct delivery for independent cursors. */
 	if (seat != server->seat || idx % CUA_TRANSIENT_SEAT_STRIDE == 0) {
 		wlr_seat_pointer_notify_enter(seat, surface, local_x, local_y);
 		wlr_seat_pointer_notify_motion(seat, cua_now_ms(), local_x, local_y);

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -627,6 +627,9 @@ static bool cua_type_hex(struct tinywl_server *server, struct tinywl_toplevel *t
 		if (cua_pending_restore.pending && cua_pending_restore.server == server)
 			restore_toplevel = cua_pending_restore.toplevel;
 		cua_focus_toplevel(t);
+		/* Send the focus transition before the injected key batch. Chromium drops
+		 * keys that arrive in the same unflushed compositor callback as focus. */
+		wl_display_flush_clients(server->wl_display);
 	}
 	bool ok = true;
 	for (const char *p = hex; p[0] && p[1]; p += 2) {
@@ -634,7 +637,11 @@ static bool cua_type_hex(struct tinywl_server *server, struct tinywl_toplevel *t
 		int lo = (p[1] <= '9') ? p[1] - '0' : (p[1] | 0x20) - 'a' + 10;
 		if (!cua_type_cp(server, t, idx, (uint32_t)((hi << 4) | lo))) { ok = false; break; }
 	}
-	if (restore_focus) cua_defer_default_focus(server, restore_toplevel);
+	if (restore_focus) {
+		/* Flush key delivery before the deferred physical-focus restoration. */
+		wl_display_flush_clients(server->wl_display);
+		cua_defer_default_focus(server, restore_toplevel);
+	}
 	return ok;
 }
 

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -577,18 +577,22 @@ static void cua_kbd_key(struct wlr_seat_client *sc, uint32_t keycode, bool press
 			pressed ? WL_KEYBOARD_KEY_STATE_PRESSED : WL_KEYBOARD_KEY_STATE_RELEASED);
 }
 /* Preserve compositor-native keyboard delivery when the addressed surface is
- * already the logical seat focus. Chromium relies on wlroots' focused-seat
- * state for foreground keyboard events; sending a raw wl_keyboard.key to its
- * resource can be acknowledged while never reaching the renderer. Background
- * targets retain the direct resource path that makes focus-free input possible. */
+ * already the logical seat focus. wlroots' keyboard event source updates the focused seat exactly as a real
+ * keyboard would. Background targets retain the direct resource path that makes
+ * focus-free input possible. */
 static void cua_kbd_key_target(struct tinywl_server *server, struct tinywl_toplevel *t,
 		struct wlr_seat_client *sc, int idx, uint32_t keycode, bool pressed) {
 	struct wlr_surface *target = wlr_surface_get_root_surface(t->xdg_toplevel->base->surface);
 	struct wlr_surface *focused = server->seat->keyboard_state.focused_surface;
 	struct wlr_surface *focused_root = focused ? wlr_surface_get_root_surface(focused) : NULL;
 	if (target == focused_root) {
-		wlr_seat_keyboard_notify_key(server->seat, cua_now_ms(), keycode,
-			pressed ? WL_KEYBOARD_KEY_STATE_PRESSED : WL_KEYBOARD_KEY_STATE_RELEASED);
+		struct wlr_event_keyboard_key event = {
+			.time_msec = cua_now_ms(),
+			.keycode = keycode,
+			.update_state = true,
+			.state = pressed ? WL_KEYBOARD_KEY_STATE_PRESSED : WL_KEYBOARD_KEY_STATE_RELEASED,
+		};
+		wlr_keyboard_notify_key(&g_keyboard, &event);
 	} else {
 		cua_kbd_key(sc, keycode, pressed);
 	}

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -631,7 +631,7 @@ static bool cua_type_hex(struct tinywl_server *server, struct tinywl_toplevel *t
 		 * keys that arrive in the same unflushed compositor callback as focus. */
 		wl_display_flush_clients(server->wl_display);
 		/* Let the client consume wl_keyboard.enter before the first key. */
-		struct timespec settle = { .tv_sec = 0, .tv_nsec = 20 * 1000 * 1000 };
+		struct timespec settle = { .tv_sec = 0, .tv_nsec = 100 * 1000 * 1000 };
 		nanosleep(&settle, NULL);
 	}
 	bool ok = true;

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -80,6 +80,13 @@ static void cua_ftl_request_activate(struct wl_listener *listener, void *data);
 static void cua_maybe_focus_new_toplevel(struct tinywl_toplevel *toplevel);
 static pid_t cua_toplevel_pid(struct tinywl_toplevel *t);
 static bool cua_pid_in_family(pid_t pid, pid_t root_pid);
+struct cua_focus_restore {
+	struct tinywl_server *server;
+	struct tinywl_toplevel *toplevel;
+	struct wl_event_source *timer;
+	bool pending;
+};
+static struct cua_focus_restore cua_pending_restore;
 
 """
 
@@ -106,6 +113,35 @@ static void cua_focus_toplevel(struct tinywl_toplevel *toplevel) {
 		wlr_seat_keyboard_notify_enter(
 			toplevel->server->seat, surface, NULL, 0, &modifiers);
 	}
+}
+/* Chromium processes keyboard events through the physical seat's focused
+ * client. Keep its temporary focus through one event-loop turn so it consumes
+ * the flushed key batch before the default focus is restored. */
+static int cua_restore_default_focus(void *data) {
+	struct cua_focus_restore *restore = data;
+	if (!restore->pending) return 0;
+	restore->pending = false;
+	if (restore->toplevel) cua_focus_toplevel(restore->toplevel);
+	else wlr_seat_keyboard_notify_clear_focus(restore->server->seat);
+	return 0;
+}
+static void cua_defer_default_focus(struct tinywl_server *server,
+		struct tinywl_toplevel *toplevel) {
+	struct cua_focus_restore *restore = &cua_pending_restore;
+	restore->server = server;
+	restore->toplevel = toplevel;
+	restore->pending = true;
+	if (!restore->timer) {
+		restore->timer = wl_event_loop_add_timer(
+			wl_display_get_event_loop(server->wl_display),
+			cua_restore_default_focus, restore);
+	}
+	if (restore->timer) wl_event_source_timer_update(restore->timer, 1);
+}
+static void cua_settle_default_focus(struct tinywl_server *server) {
+	struct cua_focus_restore *restore = &cua_pending_restore;
+	if (!restore->pending || restore->server != server) return;
+	cua_restore_default_focus(restore);
 }
 /* New child toplevels may request focus as part of their normal map sequence.
  * Preserve that behavior only when the current keyboard focus belongs to the
@@ -585,17 +621,20 @@ static bool cua_type_hex(struct tinywl_server *server, struct tinywl_toplevel *t
 		if (surface == restore_root) { restore_toplevel = candidate; break; }
 	}
 	bool restore_focus = idx != 0 && restore_root != target_root;
-	if (restore_focus) cua_focus_toplevel(t);
+	if (restore_focus) {
+		/* Coalesce consecutive logical-seat strings so they restore the original
+		 * physical focus rather than an intermediate transient target. */
+		if (cua_pending_restore.pending && cua_pending_restore.server == server)
+			restore_toplevel = cua_pending_restore.toplevel;
+		cua_focus_toplevel(t);
+	}
 	bool ok = true;
 	for (const char *p = hex; p[0] && p[1]; p += 2) {
 		int hi = (p[0] <= '9') ? p[0] - '0' : (p[0] | 0x20) - 'a' + 10;
 		int lo = (p[1] <= '9') ? p[1] - '0' : (p[1] | 0x20) - 'a' + 10;
 		if (!cua_type_cp(server, t, idx, (uint32_t)((hi << 4) | lo))) { ok = false; break; }
 	}
-	if (restore_focus) {
-		if (restore_toplevel) cua_focus_toplevel(restore_toplevel);
-		else wlr_seat_keyboard_notify_clear_focus(server->seat);
-	}
+	if (restore_focus) cua_defer_default_focus(server, restore_toplevel);
 	return ok;
 }
 
@@ -783,6 +822,7 @@ static int cua_conn_readable(int fd, uint32_t mask, void *data) {
 		} else {
 			int query_pid, geometry_pid, activate_pid;
 			if (sscanf(p, "q %d", &query_pid) == 1) {
+				cua_settle_default_focus(c->server);
 				char msg[128]; cua_query_state(c->server, (pid_t)query_pid, msg, sizeof msg);
 				cua_reply(fd, msg);
 			} else if (sscanf(p, "g %d", &geometry_pid) == 1) {

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -109,9 +109,9 @@ static void cua_focus_toplevel(struct tinywl_toplevel *toplevel) {
 	 * logical focus without coupling it to the initial map/configure handshake. */
 	struct wlr_surface *surface = toplevel->xdg_toplevel->base->surface;
 	if (toplevel->server->seat->keyboard_state.focused_surface != surface) {
-		struct wlr_keyboard_modifiers modifiers = {0};
 		wlr_seat_keyboard_notify_enter(
-			toplevel->server->seat, surface, NULL, 0, &modifiers);
+			toplevel->server->seat, surface, g_keyboard.keycodes,
+			g_keyboard.num_keycodes, &g_keyboard.modifiers);
 	}
 }
 /* Chromium processes keyboard events through the physical seat's focused

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -51,10 +51,20 @@ INCLUDES = r"""#include <stdint.h>
 #include <wlr/types/wlr_xdg_output_v1.h>
 
 #define CUA_MAXDEV 64
+#define CUA_TRANSIENT_SEAT_MAX 7
+#define CUA_TRANSIENT_SEAT_STRIDE 8
 /* Per-cursor / per-keyboard enter bookkeeping (idx = logical device). */
 struct cua_devstate { struct wlr_surface *entered; };
 static struct cua_devstate cua_ptr[CUA_MAXDEV];
 static struct cua_devstate cua_kbd_state[CUA_MAXDEV];
+/* The physical compositor seat remains server->seat outside a command. Each
+ * transient entry owns a wlroots seat and an isolated range in cua_ptr. */
+struct cua_transient_seat {
+	char name[64];
+	struct wlr_seat *seat;
+	int device_base;
+};
+static struct cua_transient_seat cua_transient_seats[CUA_TRANSIENT_SEAT_MAX];
 static int g_keymap_fd = -1;
 static size_t g_keymap_size = 0;
 static struct wlr_keyboard g_keyboard;
@@ -272,6 +282,43 @@ static const char *cua_query_geometry(struct tinywl_server *server, pid_t target
 	snprintf(out, out_len, "geometry %d %d %d %d", x, y, scene_x, scene_y);
 	return NULL;
 }
+static struct cua_transient_seat *cua_transient_seat_find(const char *name) {
+	for (int i = 0; i < CUA_TRANSIENT_SEAT_MAX; i++) {
+		if (cua_transient_seats[i].seat && !strcmp(cua_transient_seats[i].name, name))
+			return &cua_transient_seats[i];
+	}
+	return NULL;
+}
+static const char *cua_transient_seat_create(struct tinywl_server *server, const char *name) {
+	if (!name[0] || strlen(name) >= sizeof cua_transient_seats[0].name) return "bad-seat-name";
+	if (cua_transient_seat_find(name)) return "seat-exists";
+	for (int i = 0; i < CUA_TRANSIENT_SEAT_MAX; i++) {
+		struct cua_transient_seat *entry = &cua_transient_seats[i];
+		if (entry->seat) continue;
+		entry->seat = wlr_seat_create(server->wl_display, name);
+		if (!entry->seat) return "seat-create-failed";
+		wlr_seat_set_capabilities(entry->seat,
+			WL_SEAT_CAPABILITY_POINTER | WL_SEAT_CAPABILITY_KEYBOARD);
+		snprintf(entry->name, sizeof entry->name, "%s", name);
+		entry->device_base = (i + 1) * CUA_TRANSIENT_SEAT_STRIDE;
+		return NULL;
+	}
+	return "seat-limit";
+}
+static const char *cua_transient_seat_destroy(const char *name) {
+	struct cua_transient_seat *entry = cua_transient_seat_find(name);
+	if (!entry) return "unknown-seat";
+	for (int i = 0; i < CUA_TRANSIENT_SEAT_STRIDE; i++)
+		cua_ptr[entry->device_base + i].entered = NULL;
+	wlr_seat_destroy(entry->seat);
+	memset(entry, 0, sizeof *entry);
+	return NULL;
+}
+static bool cua_transient_device(const struct cua_transient_seat *entry, int idx, int *device) {
+	if (idx < 0 || idx >= CUA_TRANSIENT_SEAT_STRIDE) return false;
+	*device = entry->device_base + idx;
+	return true;
+}
 static void cua_ptr_leave(struct wlr_seat *seat, struct wlr_surface *surf) {
 	if (!surf) return;
 	struct wlr_seat_client *sc = wlr_seat_client_for_wl_client(seat, wl_resource_get_client(surf->resource));
@@ -318,7 +365,7 @@ static bool cua_motion(struct tinywl_server *server, struct tinywl_toplevel *t, 
 	 * focus/grab state was never updated. Device 0 is the normal single-pointer
 	 * route, so use the protocol-complete seat notifications there. Higher
 	 * logical device indices retain direct delivery for independent cursors. */
-	if (idx == 0) {
+	if (idx % CUA_TRANSIENT_SEAT_STRIDE == 0) {
 		wlr_seat_pointer_notify_enter(server->seat, surface, local_x, local_y);
 		wlr_seat_pointer_notify_motion(server->seat, cua_now_ms(), local_x, local_y);
 		/* Real cursors emit a separate frame event after the motion callback.
@@ -366,7 +413,7 @@ static bool cua_button(struct tinywl_server *server, struct tinywl_toplevel *t, 
 	struct wlr_surface *surface = cua_ptr[idx].entered ? cua_ptr[idx].entered : t->xdg_toplevel->base->surface;
 	struct wlr_seat_client *sc = wlr_seat_client_for_wl_client(server->seat, wl_resource_get_client(surface->resource));
 	if (!sc || wl_list_empty(&sc->pointers)) return false;
-	if (idx == 0) {
+	if (idx % CUA_TRANSIENT_SEAT_STRIDE == 0) {
 		wlr_seat_pointer_notify_button(server->seat, cua_now_ms(), button,
 			pressed ? WLR_BUTTON_PRESSED : WLR_BUTTON_RELEASED);
 		/* See cua_motion: there is no hardware cursor-frame callback for the
@@ -592,7 +639,43 @@ static const char *cua_handle_cmd(struct tinywl_server *server, char *line) {
 	if (sscanf(line, "%7s", cmd) != 1) return "empty";
 	const char *err = NULL;
 	struct tinywl_toplevel *t;
-	if (!strcmp(cmd, "d")) {
+	if (!strcmp(cmd, "seat")) {
+		char action[16], name[64];
+		if (sscanf(line, "seat %15s %63s", action, name) != 2) return "bad-args";
+		if (!strcmp(action, "create")) return cua_transient_seat_create(server, name);
+		if (!strcmp(action, "destroy")) return cua_transient_seat_destroy(name);
+		return "unknown-seat-action";
+	} else if (!strcmp(cmd, "sm") || !strcmp(cmd, "sb") || !strcmp(cmd, "st")) {
+		char seat_name[64];
+		struct cua_transient_seat *entry;
+		struct wlr_seat *physical = server->seat;
+		int idx, device;
+		bool ok = false;
+		if (!strcmp(cmd, "sm")) {
+			double x, y;
+			if (sscanf(line, "sm %63s %127s %d %lf %lf", seat_name, app, &idx, &x, &y) != 5) return "bad-args";
+			if (!(entry = cua_transient_seat_find(seat_name))) return "unknown-seat";
+			if (!cua_transient_device(entry, idx, &device)) return "bad-device";
+			if (!(t = cua_resolve_target(server, app, &err))) return err;
+			server->seat = entry->seat; ok = cua_motion(server, t, device, x, y); server->seat = physical;
+			return ok ? NULL : "no-pointer-resource";
+		}
+		if (!strcmp(cmd, "sb")) {
+			unsigned button, pressed;
+			if (sscanf(line, "sb %63s %127s %d %u %u", seat_name, app, &idx, &button, &pressed) != 5) return "bad-args";
+			if (!(entry = cua_transient_seat_find(seat_name))) return "unknown-seat";
+			if (!cua_transient_device(entry, idx, &device)) return "bad-device";
+			if (!(t = cua_resolve_target(server, app, &err))) return err;
+			server->seat = entry->seat; ok = cua_button(server, t, device, button, pressed != 0); server->seat = physical;
+			return ok ? NULL : "no-pointer-resource";
+		}
+		char hex[8192];
+		if (sscanf(line, "st %63s %127s %8191s", seat_name, app, hex) != 3) return "bad-args";
+		if (!(entry = cua_transient_seat_find(seat_name))) return "unknown-seat";
+		if (!(t = cua_resolve_target(server, app, &err))) return err;
+		server->seat = entry->seat; ok = cua_type_hex(server, t, hex); server->seat = physical;
+		return ok ? NULL : "no-keyboard-resource";
+	} else if (!strcmp(cmd, "d")) {
 		double x, y; unsigned count, btn;
 		if (sscanf(line, "d %lf %lf %u %u", &x, &y, &count, &btn) != 4) return "bad-args";
 		if (!(t = cua_desktop_motion(server, x, y))) return "no-surface-at-point";

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -46,6 +46,7 @@ INCLUDES = r"""#include <stdint.h>
 #include <wayland-server-protocol.h>
 #include <xkbcommon/xkbcommon.h>
 #include <wlr/interfaces/wlr_keyboard.h>
+#include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_foreign_toplevel_management_v1.h>
 #include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/types/wlr_xdg_output_v1.h>

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -577,17 +577,16 @@ static void cua_kbd_key(struct wlr_seat_client *sc, uint32_t keycode, bool press
 			pressed ? WL_KEYBOARD_KEY_STATE_PRESSED : WL_KEYBOARD_KEY_STATE_RELEASED);
 }
 /* Preserve compositor-native keyboard delivery when the addressed surface is
- * already the logical seat focus. Chromium relies on wlroots' focused-seat
- * state for foreground keyboard events; sending a raw wl_keyboard.key to its
- * resource can be acknowledged while never reaching the renderer. Background
- * targets retain the direct resource path that makes focus-free input possible. */
+ * already the logical seat focus. Emit through the synthetic keyboard so
+ * wlroots updates its keyboard state and forwards the event through the normal
+ * seat listener. Background targets retain the direct resource path. */
 static void cua_kbd_key_target(struct tinywl_server *server, struct tinywl_toplevel *t,
 		struct wlr_seat_client *sc, int idx, uint32_t keycode, bool pressed) {
 	struct wlr_surface *target = wlr_surface_get_root_surface(t->xdg_toplevel->base->surface);
 	struct wlr_surface *focused = server->seat->keyboard_state.focused_surface;
 	struct wlr_surface *focused_root = focused ? wlr_surface_get_root_surface(focused) : NULL;
 	if (target == focused_root) {
-		wlr_seat_keyboard_notify_key(server->seat, cua_now_ms(), keycode,
+		wlr_keyboard_notify_key(&g_keyboard, cua_now_ms(), keycode,
 			pressed ? WL_KEYBOARD_KEY_STATE_PRESSED : WL_KEYBOARD_KEY_STATE_RELEASED);
 	} else {
 		cua_kbd_key(sc, keycode, pressed);

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -46,7 +46,6 @@ INCLUDES = r"""#include <stdint.h>
 #include <wayland-server-protocol.h>
 #include <xkbcommon/xkbcommon.h>
 #include <wlr/interfaces/wlr_keyboard.h>
-#include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_foreign_toplevel_management_v1.h>
 #include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/types/wlr_xdg_output_v1.h>
@@ -551,9 +550,8 @@ static void cua_kbd_key(struct wlr_seat_client *sc, uint32_t keycode, bool press
 			pressed ? WL_KEYBOARD_KEY_STATE_PRESSED : WL_KEYBOARD_KEY_STATE_RELEASED);
 }
 /* Preserve compositor-native keyboard delivery when the addressed surface is
- * already the logical seat focus. wlroots' keyboard event source updates the focused seat exactly as a real
- * keyboard would. Background targets retain the direct resource path that makes
- * focus-free input possible. */
+ * already the logical seat focus. Background targets retain the direct resource
+ * path that makes focus-free input possible. */
 static void cua_kbd_key_target(struct tinywl_server *server, struct tinywl_toplevel *t,
 		struct wlr_seat_client *sc, int idx, uint32_t keycode, bool pressed) {
 	struct wlr_surface *target = wlr_surface_get_root_surface(t->xdg_toplevel->base->surface);
@@ -563,14 +561,8 @@ static void cua_kbd_key_target(struct tinywl_server *server, struct tinywl_tople
 		idx, target == focused_root ? "seat" : "direct", target, focused_root, sc,
 		server->seat->keyboard_state.focused_client, keycode, pressed);
 	if (target == focused_root) {
-		struct wlr_keyboard_key_event event = {
-			.time_msec = cua_now_ms(),
-			.keycode = keycode,
-			.update_state = true,
-			.state = pressed ? WL_KEYBOARD_KEY_STATE_PRESSED : WL_KEYBOARD_KEY_STATE_RELEASED,
-		};
-		wlr_keyboard_notify_key(&g_keyboard, &event);
-		wlr_seat_keyboard_notify_key(server->seat, event.time_msec, event.keycode, event.state);
+		wlr_seat_keyboard_notify_key(server->seat, cua_now_ms(), keycode,
+			pressed ? WL_KEYBOARD_KEY_STATE_PRESSED : WL_KEYBOARD_KEY_STATE_RELEASED);
 	} else {
 		cua_kbd_key(sc, keycode, pressed);
 	}

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -596,8 +596,6 @@ static void cua_kbd_key_target(struct tinywl_server *server, struct tinywl_tople
 static bool cua_type_cp(struct tinywl_server *server, struct tinywl_toplevel *t, int idx, uint32_t cp) {
 	if (cp >= 128 || !g_chartab[cp].valid) return false;
 	struct wlr_seat_client *sc = cua_kbd_enter(server, t, idx);
-	wlr_log(WLR_INFO, "[cua] key idx=%d target=%d keyboard-client=%s", idx,
-		(int)cua_toplevel_pid(t), sc ? "yes" : "no");
 	if (!sc) return false;
 	struct cua_keyent e = g_chartab[cp];
 	if (e.shift) cua_kbd_mods(sc, g_shift_mask);
@@ -623,8 +621,6 @@ static bool cua_type_hex(struct tinywl_server *server, struct tinywl_toplevel *t
 		if (surface == restore_root) { restore_toplevel = candidate; break; }
 	}
 	bool restore_focus = idx != 0 && restore_root != target_root;
-	wlr_log(WLR_INFO, "[cua] type idx=%d target=%d restore=%d", idx,
-		(int)cua_toplevel_pid(t), restore_focus);
 	if (restore_focus) {
 		/* Coalesce consecutive logical-seat strings so they restore the original
 		 * physical focus rather than an intermediate transient target. */

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -630,6 +630,9 @@ static bool cua_type_hex(struct tinywl_server *server, struct tinywl_toplevel *t
 		/* Send the focus transition before the injected key batch. Chromium drops
 		 * keys that arrive in the same unflushed compositor callback as focus. */
 		wl_display_flush_clients(server->wl_display);
+		/* Let the client consume wl_keyboard.enter before the first key. */
+		struct timespec settle = { .tv_sec = 0, .tv_nsec = 20 * 1000 * 1000 };
+		nanosleep(&settle, NULL);
 	}
 	bool ok = true;
 	for (const char *p = hex; p[0] && p[1]; p += 2) {

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -108,11 +108,11 @@ static void cua_focus_toplevel(struct tinywl_toplevel *toplevel) {
 	 * attached. Headless CI has none, so explicit activation establishes the
 	 * logical focus without coupling it to the initial map/configure handshake. */
 	struct wlr_surface *surface = toplevel->xdg_toplevel->base->surface;
-	if (toplevel->server->seat->keyboard_state.focused_surface != surface) {
-		wlr_seat_keyboard_notify_enter(
-			toplevel->server->seat, surface, g_keyboard.keycodes,
-			g_keyboard.num_keycodes, &g_keyboard.modifiers);
-	}
+	// Always resend enter after focus_toplevel(): tinywl can update focused_surface
+	// without a wl_keyboard.enter when the synthetic keyboard has no backend.
+	wlr_seat_keyboard_notify_enter(
+		toplevel->server->seat, surface, g_keyboard.keycodes,
+		g_keyboard.num_keycodes, &g_keyboard.modifiers);
 }
 /* Chromium processes keyboard events through the physical seat's focused
  * client. Keep its temporary focus through one event-loop turn so it consumes

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -109,6 +109,9 @@ static void cua_focus_toplevel(struct tinywl_toplevel *toplevel) {
 	 * attached. Headless CI has none, so explicit activation establishes the
 	 * logical focus without coupling it to the initial map/configure handshake. */
 	struct wlr_surface *surface = toplevel->xdg_toplevel->base->surface;
+	wlr_log(WLR_INFO, "[cua] focus target=%p focused=%p client=%p", surface,
+		toplevel->server->seat->keyboard_state.focused_surface,
+		toplevel->server->seat->keyboard_state.focused_client);
 	// Always resend enter after focus_toplevel(): tinywl can update focused_surface
 	// without a wl_keyboard.enter when the synthetic keyboard has no backend.
 	wlr_seat_keyboard_notify_enter(
@@ -586,6 +589,9 @@ static void cua_kbd_key_target(struct tinywl_server *server, struct tinywl_tople
 	struct wlr_surface *target = wlr_surface_get_root_surface(t->xdg_toplevel->base->surface);
 	struct wlr_surface *focused = server->seat->keyboard_state.focused_surface;
 	struct wlr_surface *focused_root = focused ? wlr_surface_get_root_surface(focused) : NULL;
+	wlr_log(WLR_INFO, "[cua] key idx=%d route=%s target=%p focused=%p entry-client=%p focused-client=%p key=%u state=%u",
+		idx, target == focused_root ? "seat" : "direct", target, focused_root, sc,
+		server->seat->keyboard_state.focused_client, keycode, pressed);
 	if (target == focused_root) {
 		struct wlr_keyboard_key_event event = {
 			.time_msec = cua_now_ms(),

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -81,14 +81,6 @@ static void cua_ftl_request_activate(struct wl_listener *listener, void *data);
 static void cua_maybe_focus_new_toplevel(struct tinywl_toplevel *toplevel);
 static pid_t cua_toplevel_pid(struct tinywl_toplevel *t);
 static bool cua_pid_in_family(pid_t pid, pid_t root_pid);
-struct cua_focus_restore {
-	struct tinywl_server *server;
-	struct tinywl_toplevel *toplevel;
-	struct wl_event_source *timer;
-	bool pending;
-};
-static struct cua_focus_restore cua_pending_restore;
-
 """
 
 # A foreign-toplevel handle pointer on each toplevel (for list_windows).
@@ -118,34 +110,12 @@ static void cua_focus_toplevel(struct tinywl_toplevel *toplevel) {
 		toplevel->server->seat, surface, g_keyboard.keycodes,
 		g_keyboard.num_keycodes, &g_keyboard.modifiers);
 }
-/* Chromium processes keyboard events through the physical seat's focused
- * client. Keep its temporary focus through one event-loop turn so it consumes
- * the flushed key batch before the default focus is restored. */
-static int cua_restore_default_focus(void *data) {
-	struct cua_focus_restore *restore = data;
-	if (!restore->pending) return 0;
-	restore->pending = false;
-	if (restore->toplevel) cua_focus_toplevel(restore->toplevel);
-	else wlr_seat_keyboard_notify_clear_focus(restore->server->seat);
-	return 0;
-}
-static void cua_defer_default_focus(struct tinywl_server *server,
+/* Chromium dispatches the queued keyboard batch only while the physical seat
+ * remains focused on the temporary target. */
+static void cua_restore_default_focus(struct tinywl_server *server,
 		struct tinywl_toplevel *toplevel) {
-	struct cua_focus_restore *restore = &cua_pending_restore;
-	restore->server = server;
-	restore->toplevel = toplevel;
-	restore->pending = true;
-	if (!restore->timer) {
-		restore->timer = wl_event_loop_add_timer(
-			wl_display_get_event_loop(server->wl_display),
-			cua_restore_default_focus, restore);
-	}
-	if (restore->timer) wl_event_source_timer_update(restore->timer, 1);
-}
-static void cua_settle_default_focus(struct tinywl_server *server) {
-	struct cua_focus_restore *restore = &cua_pending_restore;
-	if (!restore->pending || restore->server != server) return;
-	cua_restore_default_focus(restore);
+	if (toplevel) cua_focus_toplevel(toplevel);
+	else wlr_seat_keyboard_notify_clear_focus(server->seat);
 }
 /* New child toplevels may request focus as part of their normal map sequence.
  * Preserve that behavior only when the current keyboard focus belongs to the
@@ -634,10 +604,6 @@ static bool cua_type_hex(struct tinywl_server *server, struct tinywl_toplevel *t
 	}
 	bool restore_focus = idx != 0 && restore_root != target_root;
 	if (restore_focus) {
-		/* Coalesce consecutive logical-seat strings so they restore the original
-		 * physical focus rather than an intermediate transient target. */
-		if (cua_pending_restore.pending && cua_pending_restore.server == server)
-			restore_toplevel = cua_pending_restore.toplevel;
 		cua_focus_toplevel(t);
 		/* Send the focus transition before the injected key batch. Chromium drops
 		 * keys that arrive in the same unflushed compositor callback as focus. */
@@ -653,9 +619,11 @@ static bool cua_type_hex(struct tinywl_server *server, struct tinywl_toplevel *t
 		if (!cua_type_cp(server, t, idx, (uint32_t)((hi << 4) | lo))) { ok = false; break; }
 	}
 	if (restore_focus) {
-		/* Flush key delivery before the deferred physical-focus restoration. */
+		/* Keep focus through a client dispatch interval before sending leave. */
 		wl_display_flush_clients(server->wl_display);
-		cua_defer_default_focus(server, restore_toplevel);
+		struct timespec settle = { .tv_sec = 0, .tv_nsec = 100 * 1000 * 1000 };
+		nanosleep(&settle, NULL);
+		cua_restore_default_focus(server, restore_toplevel);
 	}
 	return ok;
 }
@@ -844,7 +812,6 @@ static int cua_conn_readable(int fd, uint32_t mask, void *data) {
 		} else {
 			int query_pid, geometry_pid, activate_pid;
 			if (sscanf(p, "q %d", &query_pid) == 1) {
-				cua_settle_default_focus(c->server);
 				char msg[128]; cua_query_state(c->server, (pid_t)query_pid, msg, sizeof msg);
 				cua_reply(fd, msg);
 			} else if (sscanf(p, "g %d", &geometry_pid) == 1) {

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -578,11 +578,14 @@ static bool cua_type_hex(struct tinywl_server *server, struct tinywl_toplevel *t
 	struct wlr_surface *target = t->xdg_toplevel->base->surface;
 	struct wlr_surface *restore_root = restore ? wlr_surface_get_root_surface(restore) : NULL;
 	struct wlr_surface *target_root = wlr_surface_get_root_surface(target);
-	bool restore_focus = idx != 0 && restore_root != target_root;
-	if (restore_focus) {
-		struct wlr_keyboard_modifiers modifiers = {0};
-		wlr_seat_keyboard_notify_enter(server->seat, target, NULL, 0, &modifiers);
+	struct tinywl_toplevel *restore_toplevel = NULL;
+	struct tinywl_toplevel *candidate;
+	wl_list_for_each(candidate, &server->toplevels, link) {
+		struct wlr_surface *surface = candidate->xdg_toplevel->base->surface;
+		if (surface == restore_root) { restore_toplevel = candidate; break; }
 	}
+	bool restore_focus = idx != 0 && restore_root != target_root;
+	if (restore_focus) cua_focus_toplevel(t);
 	bool ok = true;
 	for (const char *p = hex; p[0] && p[1]; p += 2) {
 		int hi = (p[0] <= '9') ? p[0] - '0' : (p[0] | 0x20) - 'a' + 10;
@@ -590,8 +593,7 @@ static bool cua_type_hex(struct tinywl_server *server, struct tinywl_toplevel *t
 		if (!cua_type_cp(server, t, idx, (uint32_t)((hi << 4) | lo))) { ok = false; break; }
 	}
 	if (restore_focus) {
-		struct wlr_keyboard_modifiers modifiers = {0};
-		if (restore) wlr_seat_keyboard_notify_enter(server->seat, restore, NULL, 0, &modifiers);
+		if (restore_toplevel) cua_focus_toplevel(restore_toplevel);
 		else wlr_seat_keyboard_notify_clear_focus(server->seat);
 	}
 	return ok;

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -594,6 +594,7 @@ static void cua_kbd_key_target(struct tinywl_server *server, struct tinywl_tople
 			.state = pressed ? WL_KEYBOARD_KEY_STATE_PRESSED : WL_KEYBOARD_KEY_STATE_RELEASED,
 		};
 		wlr_keyboard_notify_key(&g_keyboard, &event);
+		wlr_seat_keyboard_notify_key(server->seat, event.time_msec, event.keycode, event.state);
 	} else {
 		cua_kbd_key(sc, keycode, pressed);
 	}

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -577,16 +577,17 @@ static void cua_kbd_key(struct wlr_seat_client *sc, uint32_t keycode, bool press
 			pressed ? WL_KEYBOARD_KEY_STATE_PRESSED : WL_KEYBOARD_KEY_STATE_RELEASED);
 }
 /* Preserve compositor-native keyboard delivery when the addressed surface is
- * already the logical seat focus. Emit through the synthetic keyboard so
- * wlroots updates its keyboard state and forwards the event through the normal
- * seat listener. Background targets retain the direct resource path. */
+ * already the logical seat focus. Chromium relies on wlroots' focused-seat
+ * state for foreground keyboard events; sending a raw wl_keyboard.key to its
+ * resource can be acknowledged while never reaching the renderer. Background
+ * targets retain the direct resource path that makes focus-free input possible. */
 static void cua_kbd_key_target(struct tinywl_server *server, struct tinywl_toplevel *t,
 		struct wlr_seat_client *sc, int idx, uint32_t keycode, bool pressed) {
 	struct wlr_surface *target = wlr_surface_get_root_surface(t->xdg_toplevel->base->surface);
 	struct wlr_surface *focused = server->seat->keyboard_state.focused_surface;
 	struct wlr_surface *focused_root = focused ? wlr_surface_get_root_surface(focused) : NULL;
 	if (target == focused_root) {
-		wlr_keyboard_notify_key(&g_keyboard, cua_now_ms(), keycode,
+		wlr_seat_keyboard_notify_key(server->seat, cua_now_ms(), keycode,
 			pressed ? WL_KEYBOARD_KEY_STATE_PRESSED : WL_KEYBOARD_KEY_STATE_RELEASED);
 	} else {
 		cua_kbd_key(sc, keycode, pressed);

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -300,7 +300,7 @@ static const char *cua_transient_seat_create(struct tinywl_server *server, const
 		wlr_seat_set_capabilities(entry->seat,
 			WL_SEAT_CAPABILITY_POINTER | WL_SEAT_CAPABILITY_KEYBOARD);
 		snprintf(entry->name, sizeof entry->name, "%s", name);
-		entry->device_base = i * CUA_TRANSIENT_SEAT_STRIDE + 1;
+		entry->device_base = (i + 1) * CUA_TRANSIENT_SEAT_STRIDE;
 		return NULL;
 	}
 	return "seat-limit";

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -58,7 +58,8 @@ struct cua_devstate { struct wlr_surface *entered; };
 static struct cua_devstate cua_ptr[CUA_MAXDEV];
 static struct cua_devstate cua_kbd_state[CUA_MAXDEV];
 /* Transient entries retain lifecycle identity and isolated logical device ranges.
- * Injection uses the physical seat because clients bind its wl_pointer/wl_keyboard. */
+ * Pointer injection uses each transient seat; keyboard injection temporarily borrows
+ * the physical seat so Chromium receives its focused-seat event path. */
 struct cua_transient_seat {
 	char name[64];
 	struct wlr_seat *seat;
@@ -367,10 +368,10 @@ static void cua_ptr_leave(struct wlr_seat *seat, struct wlr_surface *surf) {
 }
 /* Inject pointer motion from logical cursor `idx` into window `t` at window-
  * local (x,y). enter/leave is tracked per idx, so several idx values can drive
- * independent cursors against the same or different surfaces. Focus-free: we
- * write straight to the client's wl_pointer resources, never touching the seat
- * focus or any real cursor. */
-static bool cua_motion(struct tinywl_server *server, struct tinywl_toplevel *t, int idx, double x, double y) {
+ * independent cursors against the same or different surfaces. The normal and
+ * transient paths update only their own wl_seat pointer state. */
+static bool cua_motion(struct tinywl_server *server, struct wlr_seat *seat,
+		struct tinywl_toplevel *t, int idx, double x, double y) {
 	if (!t || idx < 0 || idx >= CUA_MAXDEV) return false;
 	/* Public PX coordinates come from the cropped root-surface screenshot. Hit
 	 * test that point through the scene so Chromium/WebKit child surfaces receive
@@ -387,14 +388,14 @@ static bool cua_motion(struct tinywl_server *server, struct tinywl_toplevel *t, 
 	struct wlr_scene_surface *scene_surface = wlr_scene_surface_try_from_buffer(buffer);
 	if (!scene_surface) return false;
 	struct wlr_surface *surface = scene_surface->surface;
-	struct wlr_seat_client *sc = wlr_seat_client_for_wl_client(server->seat, wl_resource_get_client(surface->resource));
+	struct wlr_seat_client *sc = wlr_seat_client_for_wl_client(seat, wl_resource_get_client(surface->resource));
 	if (!sc || wl_list_empty(&sc->pointers)) {
 		/* Chromium can compose a renderer-owned child surface whose wl_client
 		 * never bound wl_pointer while the owning toplevel client did. Use that
 		 * target root while retaining the caller's screenshot-local point. */
 		surface = t->xdg_toplevel->base->surface;
 		local_x = x; local_y = y;
-		sc = wlr_seat_client_for_wl_client(server->seat, wl_resource_get_client(surface->resource));
+		sc = wlr_seat_client_for_wl_client(seat, wl_resource_get_client(surface->resource));
 		if (!sc || wl_list_empty(&sc->pointers)) return false;
 	}
 	/* Chromium consumes pointer input through wlroots' seat pointer state. Raw
@@ -403,9 +404,9 @@ static bool cua_motion(struct tinywl_server *server, struct tinywl_toplevel *t, 
 	 * focus/grab state was never updated. Device 0 is the normal single-pointer
 	 * route, so use the protocol-complete seat notifications there. Higher
 	 * logical device indices retain direct delivery for independent cursors. */
-	if (idx % CUA_TRANSIENT_SEAT_STRIDE == 0) {
-		wlr_seat_pointer_notify_enter(server->seat, surface, local_x, local_y);
-		wlr_seat_pointer_notify_motion(server->seat, cua_now_ms(), local_x, local_y);
+	if (seat != server->seat || idx % CUA_TRANSIENT_SEAT_STRIDE == 0) {
+		wlr_seat_pointer_notify_enter(seat, surface, local_x, local_y);
+		wlr_seat_pointer_notify_motion(seat, cua_now_ms(), local_x, local_y);
 		/* Real cursors emit a separate frame event after the motion callback.
 		 * Synthetic commands have no cursor-frame signal, so terminate the
 		 * protocol batch here; Chromium buffers motion/button events until it. */
@@ -444,15 +445,16 @@ static struct tinywl_toplevel *cua_desktop_motion(struct tinywl_server *server, 
 	cua_ptr[0].entered = surface;
 	return t;
 }
-static bool cua_button(struct tinywl_server *server, struct tinywl_toplevel *t, int idx, uint32_t button, bool pressed) {
+static bool cua_button(struct tinywl_server *server, struct wlr_seat *seat,
+		struct tinywl_toplevel *t, int idx, uint32_t button, bool pressed) {
 	if (!t || idx < 0 || idx >= CUA_MAXDEV) return false;
 	/* `cua_motion` establishes the exact child or root surface for this logical
 	 * pointer. Button and axis events must use that same wl_pointer resource. */
 	struct wlr_surface *surface = cua_ptr[idx].entered ? cua_ptr[idx].entered : t->xdg_toplevel->base->surface;
-	struct wlr_seat_client *sc = wlr_seat_client_for_wl_client(server->seat, wl_resource_get_client(surface->resource));
+	struct wlr_seat_client *sc = wlr_seat_client_for_wl_client(seat, wl_resource_get_client(surface->resource));
 	if (!sc || wl_list_empty(&sc->pointers)) return false;
-	if (idx % CUA_TRANSIENT_SEAT_STRIDE == 0) {
-		wlr_seat_pointer_notify_button(server->seat, cua_now_ms(), button,
+	if (seat != server->seat || idx % CUA_TRANSIENT_SEAT_STRIDE == 0) {
+		wlr_seat_pointer_notify_button(seat, cua_now_ms(), button,
 			pressed ? WLR_BUTTON_PRESSED : WLR_BUTTON_RELEASED);
 		/* See cua_motion: there is no hardware cursor-frame callback for the
 		 * virtual device, so each injected command must close its own batch. */
@@ -731,7 +733,7 @@ static const char *cua_handle_cmd(struct tinywl_server *server, char *line) {
 			if (!(entry = cua_transient_seat_find(seat_name))) return "unknown-seat";
 			if (!cua_transient_device(entry, idx, &device)) return "bad-device";
 			if (!(t = cua_resolve_target(server, app, &err))) return err;
-			ok = cua_motion(server, t, device, x, y);
+			ok = cua_motion(server, entry->seat, t, device, x, y);
 			return ok ? NULL : "no-pointer-resource";
 		}
 		if (!strcmp(cmd, "sb")) {
@@ -740,7 +742,7 @@ static const char *cua_handle_cmd(struct tinywl_server *server, char *line) {
 			if (!(entry = cua_transient_seat_find(seat_name))) return "unknown-seat";
 			if (!cua_transient_device(entry, idx, &device)) return "bad-device";
 			if (!(t = cua_resolve_target(server, app, &err))) return err;
-			ok = cua_button(server, t, device, button, pressed != 0);
+			ok = cua_button(server, entry->seat, t, device, button, pressed != 0);
 			return ok ? NULL : "no-pointer-resource";
 		}
 		char hex[8192];
@@ -754,21 +756,21 @@ static const char *cua_handle_cmd(struct tinywl_server *server, char *line) {
 		if (sscanf(line, "d %lf %lf %u %u", &x, &y, &count, &btn) != 4) return "bad-args";
 		if (!(t = cua_desktop_motion(server, x, y))) return "no-surface-at-point";
 		for (unsigned i = 0; i < (count ? count : 1); i++) {
-			if (!cua_button(server, t, 0, btn, true)) return "no-pointer-resource";
-			if (!cua_button(server, t, 0, btn, false)) return "no-pointer-resource";
+			if (!cua_button(server, server->seat, t, 0, btn, true)) return "no-pointer-resource";
+			if (!cua_button(server, server->seat, t, 0, btn, false)) return "no-pointer-resource";
 		}
 		return NULL;
 	} else if (!strcmp(cmd, "m")) {
 		int idx; double x, y;
 		if (sscanf(line, "m %127s %d %lf %lf", app, &idx, &x, &y) != 4) return "bad-args";
 		if (!(t = cua_resolve_target(server, app, &err))) return err;
-		if (!cua_motion(server, t, idx, x, y)) return "no-pointer-resource";
+		if (!cua_motion(server, server->seat, t, idx, x, y)) return "no-pointer-resource";
 		return NULL;
 	} else if (!strcmp(cmd, "b")) {
 		int idx; unsigned btn, pr;
 		if (sscanf(line, "b %127s %d %u %u", app, &idx, &btn, &pr) != 4) return "bad-args";
 		if (!(t = cua_resolve_target(server, app, &err))) return err;
-		if (!cua_button(server, t, idx, btn, pr != 0)) return "no-pointer-resource";
+		if (!cua_button(server, server->seat, t, idx, btn, pr != 0)) return "no-pointer-resource";
 		return NULL;
 	} else if (!strcmp(cmd, "t")) {
 		char hex[8192];

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -58,8 +58,7 @@ struct cua_devstate { struct wlr_surface *entered; };
 static struct cua_devstate cua_ptr[CUA_MAXDEV];
 static struct cua_devstate cua_kbd_state[CUA_MAXDEV];
 /* Transient entries retain lifecycle identity and isolated logical device ranges.
- * Pointer injection uses each transient seat; keyboard injection temporarily borrows
- * the physical seat so Chromium receives its focused-seat event path. */
+ * Injection uses the physical seat because clients bind its wl_pointer/wl_keyboard. */
 struct cua_transient_seat {
 	char name[64];
 	struct wlr_seat *seat;
@@ -368,10 +367,10 @@ static void cua_ptr_leave(struct wlr_seat *seat, struct wlr_surface *surf) {
 }
 /* Inject pointer motion from logical cursor `idx` into window `t` at window-
  * local (x,y). enter/leave is tracked per idx, so several idx values can drive
- * independent cursors against the same or different surfaces. The normal and
- * transient paths update only their own wl_seat pointer state. */
-static bool cua_motion(struct tinywl_server *server, struct wlr_seat *seat,
-		struct tinywl_toplevel *t, int idx, double x, double y) {
+ * independent cursors against the same or different surfaces. Focus-free: we
+ * write straight to the client's wl_pointer resources, never touching the seat
+ * focus or any real cursor. */
+static bool cua_motion(struct tinywl_server *server, struct tinywl_toplevel *t, int idx, double x, double y) {
 	if (!t || idx < 0 || idx >= CUA_MAXDEV) return false;
 	/* Public PX coordinates come from the cropped root-surface screenshot. Hit
 	 * test that point through the scene so Chromium/WebKit child surfaces receive
@@ -388,25 +387,25 @@ static bool cua_motion(struct tinywl_server *server, struct wlr_seat *seat,
 	struct wlr_scene_surface *scene_surface = wlr_scene_surface_try_from_buffer(buffer);
 	if (!scene_surface) return false;
 	struct wlr_surface *surface = scene_surface->surface;
-	struct wlr_seat_client *sc = wlr_seat_client_for_wl_client(seat, wl_resource_get_client(surface->resource));
+	struct wlr_seat_client *sc = wlr_seat_client_for_wl_client(server->seat, wl_resource_get_client(surface->resource));
 	if (!sc || wl_list_empty(&sc->pointers)) {
 		/* Chromium can compose a renderer-owned child surface whose wl_client
 		 * never bound wl_pointer while the owning toplevel client did. Use that
 		 * target root while retaining the caller's screenshot-local point. */
 		surface = t->xdg_toplevel->base->surface;
 		local_x = x; local_y = y;
-		sc = wlr_seat_client_for_wl_client(seat, wl_resource_get_client(surface->resource));
+		sc = wlr_seat_client_for_wl_client(server->seat, wl_resource_get_client(surface->resource));
 		if (!sc || wl_list_empty(&sc->pointers)) return false;
 	}
 	/* Chromium consumes pointer input through wlroots' seat pointer state. Raw
 	 * wl_pointer resource sends are sufficient for GTK, but Chromium can ACK
 	 * them without dispatching DOM mouse events because the compositor-side
-	 * focus/grab state was never updated. Each transient wl_seat and physical
-	 * device zero use the protocol-complete notification path; other physical
-	 * logical devices retain direct delivery for independent cursors. */
-	if (seat != server->seat || idx % CUA_TRANSIENT_SEAT_STRIDE == 0) {
-		wlr_seat_pointer_notify_enter(seat, surface, local_x, local_y);
-		wlr_seat_pointer_notify_motion(seat, cua_now_ms(), local_x, local_y);
+	 * focus/grab state was never updated. Device 0 is the normal single-pointer
+	 * route, so use the protocol-complete seat notifications there. Higher
+	 * logical device indices retain direct delivery for independent cursors. */
+	if (idx % CUA_TRANSIENT_SEAT_STRIDE == 0) {
+		wlr_seat_pointer_notify_enter(server->seat, surface, local_x, local_y);
+		wlr_seat_pointer_notify_motion(server->seat, cua_now_ms(), local_x, local_y);
 		/* Real cursors emit a separate frame event after the motion callback.
 		 * Synthetic commands have no cursor-frame signal, so terminate the
 		 * protocol batch here; Chromium buffers motion/button events until it. */
@@ -445,16 +444,15 @@ static struct tinywl_toplevel *cua_desktop_motion(struct tinywl_server *server, 
 	cua_ptr[0].entered = surface;
 	return t;
 }
-static bool cua_button(struct tinywl_server *server, struct wlr_seat *seat,
-		struct tinywl_toplevel *t, int idx, uint32_t button, bool pressed) {
+static bool cua_button(struct tinywl_server *server, struct tinywl_toplevel *t, int idx, uint32_t button, bool pressed) {
 	if (!t || idx < 0 || idx >= CUA_MAXDEV) return false;
 	/* `cua_motion` establishes the exact child or root surface for this logical
 	 * pointer. Button and axis events must use that same wl_pointer resource. */
 	struct wlr_surface *surface = cua_ptr[idx].entered ? cua_ptr[idx].entered : t->xdg_toplevel->base->surface;
-	struct wlr_seat_client *sc = wlr_seat_client_for_wl_client(seat, wl_resource_get_client(surface->resource));
+	struct wlr_seat_client *sc = wlr_seat_client_for_wl_client(server->seat, wl_resource_get_client(surface->resource));
 	if (!sc || wl_list_empty(&sc->pointers)) return false;
-	if (seat != server->seat || idx % CUA_TRANSIENT_SEAT_STRIDE == 0) {
-		wlr_seat_pointer_notify_button(seat, cua_now_ms(), button,
+	if (idx % CUA_TRANSIENT_SEAT_STRIDE == 0) {
+		wlr_seat_pointer_notify_button(server->seat, cua_now_ms(), button,
 			pressed ? WLR_BUTTON_PRESSED : WLR_BUTTON_RELEASED);
 		/* See cua_motion: there is no hardware cursor-frame callback for the
 		 * virtual device, so each injected command must close its own batch. */
@@ -733,7 +731,7 @@ static const char *cua_handle_cmd(struct tinywl_server *server, char *line) {
 			if (!(entry = cua_transient_seat_find(seat_name))) return "unknown-seat";
 			if (!cua_transient_device(entry, idx, &device)) return "bad-device";
 			if (!(t = cua_resolve_target(server, app, &err))) return err;
-			ok = cua_motion(server, entry->seat, t, device, x, y);
+			ok = cua_motion(server, t, device, x, y);
 			return ok ? NULL : "no-pointer-resource";
 		}
 		if (!strcmp(cmd, "sb")) {
@@ -742,7 +740,7 @@ static const char *cua_handle_cmd(struct tinywl_server *server, char *line) {
 			if (!(entry = cua_transient_seat_find(seat_name))) return "unknown-seat";
 			if (!cua_transient_device(entry, idx, &device)) return "bad-device";
 			if (!(t = cua_resolve_target(server, app, &err))) return err;
-			ok = cua_button(server, entry->seat, t, device, button, pressed != 0);
+			ok = cua_button(server, t, device, button, pressed != 0);
 			return ok ? NULL : "no-pointer-resource";
 		}
 		char hex[8192];
@@ -756,21 +754,21 @@ static const char *cua_handle_cmd(struct tinywl_server *server, char *line) {
 		if (sscanf(line, "d %lf %lf %u %u", &x, &y, &count, &btn) != 4) return "bad-args";
 		if (!(t = cua_desktop_motion(server, x, y))) return "no-surface-at-point";
 		for (unsigned i = 0; i < (count ? count : 1); i++) {
-			if (!cua_button(server, server->seat, t, 0, btn, true)) return "no-pointer-resource";
-			if (!cua_button(server, server->seat, t, 0, btn, false)) return "no-pointer-resource";
+			if (!cua_button(server, t, 0, btn, true)) return "no-pointer-resource";
+			if (!cua_button(server, t, 0, btn, false)) return "no-pointer-resource";
 		}
 		return NULL;
 	} else if (!strcmp(cmd, "m")) {
 		int idx; double x, y;
 		if (sscanf(line, "m %127s %d %lf %lf", app, &idx, &x, &y) != 4) return "bad-args";
 		if (!(t = cua_resolve_target(server, app, &err))) return err;
-		if (!cua_motion(server, server->seat, t, idx, x, y)) return "no-pointer-resource";
+		if (!cua_motion(server, t, idx, x, y)) return "no-pointer-resource";
 		return NULL;
 	} else if (!strcmp(cmd, "b")) {
 		int idx; unsigned btn, pr;
 		if (sscanf(line, "b %127s %d %u %u", app, &idx, &btn, &pr) != 4) return "bad-args";
 		if (!(t = cua_resolve_target(server, app, &err))) return err;
-		if (!cua_button(server, server->seat, t, idx, btn, pr != 0)) return "no-pointer-resource";
+		if (!cua_button(server, t, idx, btn, pr != 0)) return "no-pointer-resource";
 		return NULL;
 	} else if (!strcmp(cmd, "t")) {
 		char hex[8192];

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -587,7 +587,7 @@ static void cua_kbd_key_target(struct tinywl_server *server, struct tinywl_tople
 	struct wlr_surface *focused = server->seat->keyboard_state.focused_surface;
 	struct wlr_surface *focused_root = focused ? wlr_surface_get_root_surface(focused) : NULL;
 	if (target == focused_root) {
-		struct wlr_event_keyboard_key event = {
+		struct wlr_keyboard_key_event event = {
 			.time_msec = cua_now_ms(),
 			.keycode = keycode,
 			.update_state = true,

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -306,6 +306,7 @@ static const char *cua_transient_seat_create(struct tinywl_server *server, const
 		if (entry->seat) continue;
 		entry->seat = wlr_seat_create(server->wl_display, name);
 		if (!entry->seat) return "seat-create-failed";
+		wlr_seat_set_keyboard(entry->seat, &g_keyboard);
 		wlr_seat_set_capabilities(entry->seat,
 			WL_SEAT_CAPABILITY_POINTER | WL_SEAT_CAPABILITY_KEYBOARD);
 		snprintf(entry->name, sizeof entry->name, "%s", name);
@@ -695,6 +696,7 @@ static const char *cua_handle_cmd(struct tinywl_server *server, char *line) {
 	} else if (!strcmp(cmd, "sm") || !strcmp(cmd, "sb") || !strcmp(cmd, "st")) {
 		char seat_name[64];
 		struct cua_transient_seat *entry;
+		struct wlr_seat *physical = server->seat;
 		int idx, device;
 		bool ok = false;
 		if (!strcmp(cmd, "sm")) {
@@ -703,7 +705,9 @@ static const char *cua_handle_cmd(struct tinywl_server *server, char *line) {
 			if (!(entry = cua_transient_seat_find(seat_name))) return "unknown-seat";
 			if (!cua_transient_device(entry, idx, &device)) return "bad-device";
 			if (!(t = cua_resolve_target(server, app, &err))) return err;
+			server->seat = entry->seat;
 			ok = cua_motion(server, t, device, x, y);
+			server->seat = physical;
 			return ok ? NULL : "no-pointer-resource";
 		}
 		if (!strcmp(cmd, "sb")) {
@@ -712,14 +716,18 @@ static const char *cua_handle_cmd(struct tinywl_server *server, char *line) {
 			if (!(entry = cua_transient_seat_find(seat_name))) return "unknown-seat";
 			if (!cua_transient_device(entry, idx, &device)) return "bad-device";
 			if (!(t = cua_resolve_target(server, app, &err))) return err;
+			server->seat = entry->seat;
 			ok = cua_button(server, t, device, button, pressed != 0);
+			server->seat = physical;
 			return ok ? NULL : "no-pointer-resource";
 		}
 		char hex[8192];
 		if (sscanf(line, "st %63s %127s %8191s", seat_name, app, hex) != 3) return "bad-args";
 		if (!(entry = cua_transient_seat_find(seat_name))) return "unknown-seat";
 		if (!(t = cua_resolve_target(server, app, &err))) return err;
+		server->seat = entry->seat;
 		ok = cua_type_hex(server, t, entry->device_base, hex);
+		server->seat = physical;
 		return ok ? NULL : "no-keyboard-resource";
 	} else if (!strcmp(cmd, "d")) {
 		double x, y; unsigned count, btn;

--- a/nix/cua-driver/compositor/cua_compositor_patch.py
+++ b/nix/cua-driver/compositor/cua_compositor_patch.py
@@ -508,9 +508,11 @@ static struct wlr_seat_client *cua_kbd_enter(struct tinywl_server *server, struc
 	struct wlr_seat_client *sc = wlr_seat_client_for_wl_client(server->seat, wl_resource_get_client(surface->resource));
 	if (!sc || wl_list_empty(&sc->keyboards)) return NULL;
 	struct wlr_surface *focused = server->seat->keyboard_state.focused_surface;
-	if (idx == 0 && focused && wlr_surface_get_root_surface(focused) == surface) {
-		/* Foreground delivery already has a protocol-complete seat enter. The
-		 * key path below uses wlr_seat_keyboard_notify_key for this target. */
+	if (focused && wlr_surface_get_root_surface(focused) == surface) {
+		/* The physical keyboard is already protocol-focused on this target.
+		 * Transient typing temporarily establishes this state and restores it after
+		 * delivery, so Chromium follows its normal keyboard path without retaining
+		 * a default-seat focus change. */
 		cua_kbd_state[idx].entered = surface;
 		return sc;
 	}
@@ -548,7 +550,7 @@ static void cua_kbd_key_target(struct tinywl_server *server, struct tinywl_tople
 	struct wlr_surface *target = wlr_surface_get_root_surface(t->xdg_toplevel->base->surface);
 	struct wlr_surface *focused = server->seat->keyboard_state.focused_surface;
 	struct wlr_surface *focused_root = focused ? wlr_surface_get_root_surface(focused) : NULL;
-	if (idx == 0 && target == focused_root) {
+	if (target == focused_root) {
 		wlr_seat_keyboard_notify_key(server->seat, cua_now_ms(), keycode,
 			pressed ? WL_KEYBOARD_KEY_STATE_PRESSED : WL_KEYBOARD_KEY_STATE_RELEASED);
 	} else {
@@ -569,13 +571,32 @@ static bool cua_type_cp(struct tinywl_server *server, struct tinywl_toplevel *t,
 /* Decode a hex-encoded ASCII string and type it focus-free into `t`. */
 static bool cua_type_hex(struct tinywl_server *server, struct tinywl_toplevel *t, int idx, const char *hex) {
 	if (!t) return false;
+	/* Chromium only dispatches keyboard events from wlroots' focused-seat route.
+	 * A transient logical seat borrows that route for one typed string, then puts
+	 * the physical/default focus back exactly where it was. */
+	struct wlr_surface *restore = server->seat->keyboard_state.focused_surface;
+	struct wlr_surface *target = t->xdg_toplevel->base->surface;
+	struct wlr_surface *restore_root = restore ? wlr_surface_get_root_surface(restore) : NULL;
+	struct wlr_surface *target_root = wlr_surface_get_root_surface(target);
+	bool restore_focus = idx != 0 && restore_root != target_root;
+	if (restore_focus) {
+		struct wlr_keyboard_modifiers modifiers = {0};
+		wlr_seat_keyboard_notify_enter(server->seat, target, NULL, 0, &modifiers);
+	}
+	bool ok = true;
 	for (const char *p = hex; p[0] && p[1]; p += 2) {
 		int hi = (p[0] <= '9') ? p[0] - '0' : (p[0] | 0x20) - 'a' + 10;
 		int lo = (p[1] <= '9') ? p[1] - '0' : (p[1] | 0x20) - 'a' + 10;
-		if (!cua_type_cp(server, t, idx, (uint32_t)((hi << 4) | lo))) return false;
+		if (!cua_type_cp(server, t, idx, (uint32_t)((hi << 4) | lo))) { ok = false; break; }
 	}
-	return true;
+	if (restore_focus) {
+		struct wlr_keyboard_modifiers modifiers = {0};
+		if (restore) wlr_seat_keyboard_notify_enter(server->seat, restore, NULL, 0, &modifiers);
+		else wlr_seat_keyboard_notify_clear_focus(server->seat);
+	}
+	return ok;
 }
+
 static uint32_t cua_named_keycode(const char *name) {
 	uint32_t kc = 0;
 	if (!strcasecmp(name, "enter") || !strcasecmp(name, "return")) kc = KEY_ENTER;

--- a/nix/cua-driver/tests/README.md
+++ b/nix/cua-driver/tests/README.md
@@ -5,6 +5,7 @@ Nix expressions are grouped by what they prove:
 | Path | Role |
 | --- | --- |
 | `rust-unit.nix` | Source-built Rust workspace checks without a desktop session |
+| `transient-seat.nix` | NixOS container session that exports GIF/log evidence while invoking the Rust transient-seat contract |
 | `policy-yaml.nix` | NixOS VM stdio checks for YAML allow, deny, and argument constraints |
 | `policy-rego.nix` | NixOS VM stdio checks for embedded Rego policy evaluation |
 
@@ -12,6 +13,6 @@ This directory intentionally contains no desktop behavior catalog. Nix builds
 the driver, unit checks, session dependencies, and optional compositor package.
 The canonical GUI scenarios and assertions live in the typed Rust harnesses.
 
-New user-behavior coverage belongs in the Rust test harness first. A Nix check
+New user-behavior coverage belongs in the Rust test harness first. A Nix container check
 may provide the session and package environment, but it must invoke the shared
 Rust catalog instead of defining a second set of behavioral assertions.

--- a/nix/cua-driver/tests/transient-seat.nix
+++ b/nix/cua-driver/tests/transient-seat.nix
@@ -112,6 +112,7 @@ pkgs.testers.nixosTest {
     machine.wait_for_unit("multi-user.target")
 
     machine.succeed("install -d -m 700 /tmp/cua-runtime /tmp/transient-seat-evidence")
+    machine.succeed("dbus-daemon --session --address=unix:path=/tmp/cua-session-bus --fork")
     machine.execute(
         "env XDG_RUNTIME_DIR=/tmp/cua-runtime WLR_BACKENDS=headless WLR_RENDERER=pixman "
         "WLR_RENDERER_ALLOW_SOFTWARE=1 WLR_LIBINPUT_NO_DEVICES=1 WLR_HEADLESS_OUTPUTS=1 "
@@ -137,6 +138,8 @@ pkgs.testers.nixosTest {
     )
     status, output = machine.execute(
         "env XDG_RUNTIME_DIR=/tmp/cua-runtime WAYLAND_DISPLAY=" + wayland_display + " "
+        "DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/cua-session-bus XDG_SESSION_TYPE=wayland "
+        "XDG_CURRENT_DESKTOP=sway XDG_SESSION_DESKTOP=sway CUA_DRIVER_RS_ENABLE_WAYLAND=1 "
         "CUA_INJECT_SOCKET=/tmp/cua-runtime/cua-inject.sock "
         "CUA_TEST_APPS_ROOT=${electronFixture} "
         "ELECTRON_OZONE_PLATFORM_HINT=wayland "

--- a/nix/cua-driver/tests/transient-seat.nix
+++ b/nix/cua-driver/tests/transient-seat.nix
@@ -1,0 +1,160 @@
+# Containerized evidence collector for the transient Wayland-seat Rust contract.
+#
+# The Rust binary owns behavioral assertions. This NixOS container only
+# provisions the compositor, fixture, GIF capture, and failure-preserving
+# evidence export consumed by CI.
+{
+  pkgs,
+  src,
+  cuaCompositor,
+  ...
+}:
+
+let
+  rustSrc = "${src}/rust";
+
+  transientSeatTest = pkgs.rustPlatform.buildRustPackage {
+    pname = "cua-driver-transient-seat-e2e";
+    version = (pkgs.lib.importTOML "${rustSrc}/Cargo.toml").workspace.package.version;
+    inherit src;
+
+    cargoLock.lockFile = "${rustSrc}/Cargo.lock";
+    postUnpack = ''
+      sourceRoot="$sourceRoot/rust"
+    '';
+    cargoBuildFlags = [
+      "-p"
+      "cua-driver"
+      "--test"
+      "transient_seat_behavior_test"
+    ];
+    doCheck = false;
+
+    nativeBuildInputs = with pkgs; [
+      pkg-config
+      rustPlatform.bindgenHook
+    ];
+    buildInputs = with pkgs; [
+      libx11
+      libxi
+      libxtst
+      libxext
+      pipewire
+      libei
+      libxkbcommon
+    ];
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out/bin"
+      test_binary="$(find target/debug/deps -maxdepth 1 -type f -name 'transient_seat_behavior_test-*' -perm -u+x -print -quit)"
+      test -n "$test_binary"
+      install -Dm755 "$test_binary" "$out/bin/transient-seat-behavior"
+      runHook postInstall
+    '';
+  };
+
+  electronFixture = pkgs.runCommand "cua-driver-transient-seat-electron-fixture" { } ''
+    mkdir -p "$out/harness-electron/app/web"
+    cp -R ${src}/tests/fixtures/apps/cross-platform/electron/. \
+      "$out/harness-electron/app/"
+    cp -R ${src}/tests/fixtures/shared/web/. \
+      "$out/harness-electron/app/web/"
+    cat > "$out/harness-electron/CuaTestHarness.Electron" <<'SH'
+#!${pkgs.runtimeShell}
+exec ${pkgs.electron}/bin/electron "$(dirname "$0")/app" "$@"
+SH
+    chmod +x "$out/harness-electron/CuaTestHarness.Electron"
+  '';
+
+  recordGif = pkgs.writeShellScript "record-transient-seat-gif" ''
+    set -eu
+    frames_dir="$1"
+    output_gif="$2"
+    stop_file="$3"
+    log_file="$4"
+
+    rm -f "$output_gif" "$stop_file" "$log_file"
+    rm -rf "$frames_dir"
+    mkdir -p "$frames_dir"
+
+    frame=0
+    while [ ! -f "$stop_file" ]; do
+      path="$(printf '%s/frame-%04d.png' "$frames_dir" "$frame")"
+      grim "$path" >>"$log_file" 2>&1 || true
+      frame=$((frame + 1))
+      sleep 0.2
+    done
+
+    if ls "$frames_dir"/frame-*.png >/dev/null 2>&1; then
+      convert -delay 12 -loop 0 "$frames_dir"/frame-*.png "$output_gif" >>"$log_file" 2>&1
+    fi
+  '';
+in
+pkgs.testers.nixosTest {
+  name = "cua-driver-transient-seat";
+
+  containers.machine = { pkgs, ... }: {
+    environment.systemPackages = [
+      cuaCompositor
+      transientSeatTest
+      electronFixture
+      pkgs.dbus
+      pkgs.grim
+      pkgs.imagemagick
+      pkgs.coreutils
+      pkgs.procps
+    ];
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    machine.succeed("install -d -m 700 /tmp/cua-runtime /tmp/transient-seat-evidence")
+    machine.execute(
+        "env XDG_RUNTIME_DIR=/tmp/cua-runtime WLR_BACKENDS=headless WLR_RENDERER=pixman "
+        "cua-compositor >/tmp/transient-seat-compositor.log 2>&1 &"
+    )
+    machine.wait_until_succeeds(
+        "test -S /tmp/cua-runtime/cua-inject.sock "
+        "&& find /tmp/cua-runtime -maxdepth 1 -type s -name 'wayland-*' | grep -q .",
+        timeout=20,
+    )
+    wayland_display = machine.succeed(
+        "basename $(find /tmp/cua-runtime -maxdepth 1 -type s -name 'wayland-*' -print -quit)"
+    ).strip()
+
+    machine.execute(
+        "env XDG_RUNTIME_DIR=/tmp/cua-runtime WAYLAND_DISPLAY=" + wayland_display + " "
+        "${recordGif} /tmp/transient-seat-frames /tmp/transient-seat-evidence/transient-seat.gif "
+        "/tmp/stop-transient-seat-recorder /tmp/transient-seat-evidence/recorder.log "
+        ">/dev/null 2>&1 & echo $! >/tmp/transient-seat-recorder.pid"
+    )
+    status, output = machine.execute(
+        "env XDG_RUNTIME_DIR=/tmp/cua-runtime WAYLAND_DISPLAY=" + wayland_display + " "
+        "CUA_INJECT_SOCKET=/tmp/cua-runtime/cua-inject.sock "
+        "CUA_TEST_APPS_ROOT=${electronFixture} "
+        "ELECTRON_OZONE_PLATFORM_HINT=wayland "
+        "transient-seat-behavior --ignored --nocapture --test-threads=1 "
+        ">/tmp/transient-seat-evidence/test.log 2>&1"
+    )
+    machine.execute("touch /tmp/stop-transient-seat-recorder")
+    machine.execute(
+        "timeout 30 sh -lc 'while kill -0 $(cat /tmp/transient-seat-recorder.pid) 2>/dev/null; do sleep 0.1; done'"
+    )
+    machine.execute("cp /tmp/transient-seat-compositor.log /tmp/transient-seat-evidence/compositor.log")
+    machine.succeed("printf '%s\\n' " + str(status) + " >/tmp/transient-seat-evidence/test-status")
+
+    # Copy before evaluating the verdict so GitHub Actions can upload evidence
+    # for both passing and failing behavioral runs.
+    machine.copy_from_machine("/tmp/transient-seat-evidence/recorder.log", "")
+    machine.copy_from_machine("/tmp/transient-seat-evidence/compositor.log", "")
+    machine.copy_from_machine("/tmp/transient-seat-evidence/test.log", "")
+    machine.copy_from_machine("/tmp/transient-seat-evidence/test-status", "")
+    if machine.execute("test -s /tmp/transient-seat-evidence/transient-seat.gif")[0] == 0:
+        machine.copy_from_machine("/tmp/transient-seat-evidence/transient-seat.gif", "")
+    else:
+        machine.log("GIF capture failed; CI will retain logs and fail the artifact check")
+  '';
+}

--- a/nix/cua-driver/tests/transient-seat.nix
+++ b/nix/cua-driver/tests/transient-seat.nix
@@ -115,6 +115,7 @@ pkgs.testers.nixosTest {
     machine.execute(
         "env XDG_RUNTIME_DIR=/tmp/cua-runtime WLR_BACKENDS=headless WLR_RENDERER=pixman "
         "WLR_RENDERER_ALLOW_SOFTWARE=1 WLR_LIBINPUT_NO_DEVICES=1 WLR_HEADLESS_OUTPUTS=1 "
+        "CUA_INJECT_SOCKET=/tmp/cua-runtime/cua-inject.sock "
         "cua-compositor >/tmp/transient-seat-compositor.log 2>&1 & echo $! >/tmp/cua-compositor.pid"
     )
     machine.sleep(1)

--- a/nix/cua-driver/tests/transient-seat.nix
+++ b/nix/cua-driver/tests/transient-seat.nix
@@ -160,6 +160,8 @@ pkgs.testers.nixosTest {
     machine.copy_from_machine("/tmp/transient-seat-evidence/compositor.log", "")
     machine.copy_from_machine("/tmp/transient-seat-evidence/test.log", "")
     machine.copy_from_machine("/tmp/transient-seat-evidence/test-status", "")
+    machine.copy_from_machine("/tmp/transient-seat-evidence/wayland-agent-a.log", "")
+    machine.copy_from_machine("/tmp/transient-seat-evidence/wayland-agent-b.log", "")
     if machine.execute("test -s /tmp/transient-seat-evidence/transient-seat.gif")[0] == 0:
         machine.copy_from_machine("/tmp/transient-seat-evidence/transient-seat.gif", "")
     else:

--- a/nix/cua-driver/tests/transient-seat.nix
+++ b/nix/cua-driver/tests/transient-seat.nix
@@ -114,8 +114,11 @@ pkgs.testers.nixosTest {
     machine.succeed("install -d -m 700 /tmp/cua-runtime /tmp/transient-seat-evidence")
     machine.execute(
         "env XDG_RUNTIME_DIR=/tmp/cua-runtime WLR_BACKENDS=headless WLR_RENDERER=pixman "
-        "cua-compositor >/tmp/transient-seat-compositor.log 2>&1 &"
+        "WLR_RENDERER_ALLOW_SOFTWARE=1 WLR_LIBINPUT_NO_DEVICES=1 WLR_HEADLESS_OUTPUTS=1 "
+        "cua-compositor >/tmp/transient-seat-compositor.log 2>&1 & echo $! >/tmp/cua-compositor.pid"
     )
+    machine.sleep(1)
+    machine.succeed("kill -0 $(cat /tmp/cua-compositor.pid)")
     machine.wait_until_succeeds(
         "test -S /tmp/cua-runtime/cua-inject.sock "
         "&& find /tmp/cua-runtime -maxdepth 1 -type s -name 'wayland-*' | grep -q .",

--- a/nix/cua-driver/tests/transient-seat.nix
+++ b/nix/cua-driver/tests/transient-seat.nix
@@ -142,6 +142,7 @@ pkgs.testers.nixosTest {
         "XDG_CURRENT_DESKTOP=sway XDG_SESSION_DESKTOP=sway CUA_DRIVER_RS_ENABLE_WAYLAND=1 "
         "CUA_INJECT_SOCKET=/tmp/cua-runtime/cua-inject.sock "
         "CUA_TEST_APPS_ROOT=${electronFixture} "
+        "CUA_TRANSIENT_SEAT_WAYLAND_DEBUG=1 WAYLAND_DEBUG=client "
         "ELECTRON_OZONE_PLATFORM_HINT=wayland "
         "transient-seat-behavior --ignored --nocapture --test-threads=1 "
         ">/tmp/transient-seat-evidence/test.log 2>&1"

--- a/nix/cua-driver/tests/transient-seat.nix
+++ b/nix/cua-driver/tests/transient-seat.nix
@@ -47,7 +47,7 @@ let
     installPhase = ''
       runHook preInstall
       mkdir -p "$out/bin"
-      test_binary="$(find target/debug/deps -maxdepth 1 -type f -name 'transient_seat_behavior_test-*' -perm -u+x -print -quit)"
+      test_binary="$(find target -type f -path '*/release/deps/transient_seat_behavior_test-*' -perm -u+x -print -quit)"
       test -n "$test_binary"
       install -Dm755 "$test_binary" "$out/bin/transient-seat-behavior"
       runHook postInstall

--- a/scripts/ci/linux/run-rust-e2e.sh
+++ b/scripts/ci/linux/run-rust-e2e.sh
@@ -221,6 +221,12 @@ if [[ "${SUITE}" == native || "${SUITE}" == all ]]; then
     cargo test -p cua-driver "${CARGO_DRIVER_FEATURE_ARGS[@]}" \
       --test harness_gtk3_test -- \
       --ignored --nocapture --test-threads=1
+  if [[ -n "${CUA_INJECT_SOCKET:-}" ]]; then
+    run_test transient-seat-behavior \
+      cargo test -p cua-driver "${CARGO_DRIVER_FEATURE_ARGS[@]}" \
+        --test transient_seat_behavior_test -- \
+        --ignored --nocapture --test-threads=1
+  fi
 fi
 
 if [[ "${SUITE}" == capture || "${SUITE}" == all ]]; then


### PR DESCRIPTION
## Transient Wayland seats: RED -> GREEN

### RED evidence

- Intentional RED behavior commit: `51d0f1cdbb2774a6aafd6b4c36ea55af24cd661c`
- Harness correction (preserved separately): `04fe4ee868e878afacbe9d414286dcf23fe100ac`
- Completed custom-compositor RED job: https://github.com/trycua/cua/actions/runs/30430929558/job/90507787414
- Expected failure excerpt: `missing transient-seat lifecycle capability`; actual `["err unknown-command"]`, expected `["ok"]`.

### GREEN evidence

- Implementation commit: `84d513912e6ff1458a66f01489adf3153a1e8b7c`
- Focused local checks:
  - `python3 -m py_compile nix/cua-driver/compositor/cua_compositor_patch.py`
  - `cargo fmt --manifest-path libs/cua-driver/rust/Cargo.toml --all --check`
  - `cargo test --manifest-path libs/cua-driver/rust/Cargo.toml -p cua-driver --test transient_seat_behavior_test --no-run`
- Canonical custom-compositor GREEN workflow: pending.

The typed Rust runner owns the behavioral contract. The Nix layer only provisions the custom compositor and invokes that runner; fixture journals and compositor queries remain independent delivery/focus oracles.
