### PR TITLE
fix(cua-driver): accept owned foreground windows after clicks

### DIFF
--- a/libs/cua-driver/rust/crates/platform-windows/src/input/mouse.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/input/mouse.rs
@@ -18,8 +18,8 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
 use windows::Win32::UI::WindowsAndMessaging::{
     ChildWindowFromPointEx, GetAncestor, GetClassLongPtrW, GetCursorPos, GetForegroundWindow,
     GetSystemMetrics, GetWindowLongPtrW, PostMessageW, SetCursorPos, SetWindowPos, CS_DBLCLKS,
-    CWP_SKIPDISABLED, CWP_SKIPINVISIBLE, CWP_SKIPTRANSPARENT, GA_ROOT, GCL_STYLE, GWL_EXSTYLE,
-    HWND_NOTOPMOST, HWND_TOP, HWND_TOPMOST, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN,
+    CWP_SKIPDISABLED, CWP_SKIPINVISIBLE, CWP_SKIPTRANSPARENT, GA_ROOT, GA_ROOTOWNER, GCL_STYLE,
+    GWL_EXSTYLE, HWND_NOTOPMOST, HWND_TOP, HWND_TOPMOST, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN,
     SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, WM_LBUTTONDBLCLK,
     WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDBLCLK, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEMOVE,
     WM_RBUTTONDBLCLK, WM_RBUTTONDOWN, WM_RBUTTONUP, WS_EX_TOPMOST,
@@ -30,6 +30,25 @@ const MK_MBUTTON: u32 = 0x0010;
 const MK_RBUTTON: u32 = 0x0002;
 
 const CLICK_DELAY_MS: u64 = 35;
+
+fn activation_families_match(
+    foreground_root: usize,
+    foreground_root_owner: usize,
+    target_root: usize,
+    target_root_owner: usize,
+) -> bool {
+    let foreground_family = if foreground_root_owner == 0 {
+        foreground_root
+    } else {
+        foreground_root_owner
+    };
+    let target_family = if target_root_owner == 0 {
+        target_root
+    } else {
+        target_root_owner
+    };
+    foreground_family != 0 && foreground_family == target_family
+}
 
 fn posted_press_message(down: u32, double: u32, click_index: usize, wants_double: bool) -> u32 {
     if wants_double && click_index % 2 == 1 {
@@ -659,9 +678,23 @@ fn send_click_synthesized_mods_impl(
             bail!("SendInput inserted fewer mouse events than expected for the foreground click.");
         }
         if activate {
-            let foreground_root = GetAncestor(GetForegroundWindow(), GA_ROOT);
+            let foreground = GetForegroundWindow();
+            let foreground_root = GetAncestor(foreground, GA_ROOT);
+            let foreground_root_owner = GetAncestor(foreground, GA_ROOTOWNER);
             let target_root = GetAncestor(target, GA_ROOT);
-            if foreground_root != target_root {
+            let target_root_owner = GetAncestor(target, GA_ROOTOWNER);
+            // Browser-owned chrome can move foreground status to a transient
+            // owned window after the click. Its GA_ROOT differs from the
+            // clicked browser root even though both belong to the same Win32
+            // activation family. Compare root owners so successful clicks do
+            // not become false errors, while unrelated foreground windows
+            // still fail this delivery postcondition.
+            if !activation_families_match(
+                foreground_root.0 as usize,
+                foreground_root_owner.0 as usize,
+                target_root.0 as usize,
+                target_root_owner.0 as usize,
+            ) {
                 bail!("The foreground click did not activate its target window.");
             }
         }
@@ -1033,8 +1066,28 @@ mod nc_hit_tests {
 
 #[cfg(test)]
 mod wheel_tests {
-    use super::{posted_press_message, wheel_mouse_data, WHEEL_DELTA};
+    use super::{activation_families_match, posted_press_message, wheel_mouse_data, WHEEL_DELTA};
     use windows::Win32::UI::WindowsAndMessaging::{WM_LBUTTONDBLCLK, WM_LBUTTONDOWN};
+
+    #[test]
+    fn foreground_click_accepts_same_root_activation() {
+        assert!(activation_families_match(0x10, 0x10, 0x10, 0x10));
+    }
+
+    #[test]
+    fn foreground_click_accepts_transient_window_with_same_root_owner() {
+        assert!(activation_families_match(0x20, 0x10, 0x10, 0x10));
+    }
+
+    #[test]
+    fn foreground_click_rejects_unrelated_activation_family() {
+        assert!(!activation_families_match(0x20, 0x20, 0x10, 0x10));
+    }
+
+    #[test]
+    fn foreground_click_rejects_missing_foreground_window() {
+        assert!(!activation_families_match(0, 0, 0x10, 0x10));
+    }
 
     #[test]
     fn posted_double_click_uses_the_win32_double_click_message() {


### PR DESCRIPTION
## What changed

- compare the foreground window and click target by Win32 root-owner activation family after a foreground click
- accept browser-owned transient windows, such as Edge's permission panel, when they belong to the clicked browser
- retain the failure for missing or unrelated foreground windows
- add focused Windows regression coverage for same-root, owned-transient, unrelated, and missing-foreground cases

## Root cause

The click was delivered and Edge opened its browser-owned permission panel, but the postcondition compared `GA_ROOT` handles. Owned transient browser chrome can have a different root handle from the browser window even though both are in the same activation family, producing a false delivery error.

## Impact

Successful foreground clicks that open browser-owned transient chrome no longer report a false activation failure. Clicks that leave an unrelated window foreground still fail closed.

## Checks

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --locked -p platform-windows`
- `cargo test --locked -p platform-windows --lib` (40 passed on macOS)
- all automatic PR checks passed, including native Windows Rust unit/compile and `CI: Release metadata`
- [native standalone-browser certification](https://github.com/trycua/cua/actions/runs/30473386863) passed at exact SHA `21db9e6969e2797d6b08e1731f0e716b9fffa6de`
  - Windows: 32 delivered, 2 expected refusals, 0 failed, 0 skipped
  - Edge `browser_owned_permission`: delivered; fixture-state and pixel oracles passed
  - Chrome `browser_owned_permission`: delivered; fixture-state and pixel oracles passed
  - Linux X11 Chrome matrix passed

Fixes #2681