### PR TITLE
feat(cua-driver): public observe_window_changes opt-out for the post-action window poll

### DIFF
--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/click.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/click.rs
@@ -133,6 +133,7 @@ fn def() -> &'static ToolDef {
             // cua_driver_core::tool_schema.)
             "required": [],
             "properties": {
+                "observe_window_changes": { "type": "boolean", "default": true, "description": "Set false to skip the post-action window-change poll (up to ~1s) — for deterministic callers (macro replay, harnesses) that already know what the next action expects. The result then omits new-window/foreground-change notes." },
                 "session": { "type": "string", "description": "Optional session id: declares/uses the agent cursor and per-session state for this run. The same id works over MCP, the CLI, or the raw socket, and follows the run across apps/windows. Omit to run cursor-less." },
                 "pid":           { "type": "integer", "description": "Target process ID." },
                 "window_id":     { "type": "integer", "description": "Target window ID. Required for element_index. Optional when element_token is supplied (the token carries it)." },

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/drag.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/drag.rs
@@ -56,6 +56,7 @@ fn def() -> &'static ToolDef {
             "type": "object",
             "required": ["from_x", "from_y", "to_x", "to_y"],
             "properties": {
+                "observe_window_changes": { "type": "boolean", "default": true, "description": "Set false to skip the post-action window-change poll (up to ~1s) — for deterministic callers (macro replay, harnesses) that already know what the next action expects. The result then omits new-window/foreground-change notes." },
                 "session": { "type": "string", "description": "Optional session id: declares/uses the agent cursor and per-session state for this run. The same id works over MCP, the CLI, or the raw socket, and follows the run across apps/windows. Omit to run cursor-less." },
                 "pid": { "type": "integer", "description": "Target process ID." },
                 "window_id": {

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/hotkey.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/hotkey.rs
@@ -59,6 +59,7 @@ fn def() -> &'static ToolDef {
             "type": "object",
             "required": ["keys"],
             "properties": {
+                "observe_window_changes": { "type": "boolean", "default": true, "description": "Set false to skip the post-action window-change poll (up to ~1s) — for deterministic callers (macro replay, harnesses) that already know what the next action expects. The result then omits new-window/foreground-change notes." },
                 "session": { "type": "string", "description": "Optional session id: declares/uses the agent cursor and per-session state for this run. The same id works over MCP, the CLI, or the raw socket, and follows the run across apps/windows. Omit to run cursor-less." },
                 "pid": { "type": "integer", "description": "Target process ID." },
                 "keys": {

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
@@ -109,10 +109,22 @@ pub(crate) async fn finish_window_observation(
     snapshot: crate::window_change_detector::Snapshot,
     args: &serde_json::Value,
 ) -> crate::window_change_detector::Changes {
-    if args
-        .get("_skip_window_change_detection")
+    // Public per-call opt-out: deterministic callers (macro replayers, test
+    // harnesses) know what the next action expects and don't need the
+    // up-to-1s post-action window-change poll — for them it is pure latency
+    // on every input action. Additive and backwards-compatible: omitted or
+    // true keeps today's behavior. Distinct from the transport-reserved
+    // underscore flag below, which public callers cannot send
+    // (sanitize_reserved_args strips it).
+    let observe = args
+        .get("observe_window_changes")
         .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false)
+        .unwrap_or(true);
+    if !observe
+        || args
+            .get("_skip_window_change_detection")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
     {
         drop(snapshot);
         crate::window_change_detector::Changes::no_change()
@@ -134,6 +146,25 @@ mod interactive_observation_tests {
         )
         .await;
         assert!(!changes.needs_restore());
+    }
+
+    /// The public opt-out must skip the poll exactly like the internal flag:
+    /// a caller passing observe_window_changes:false gets an immediate
+    /// no-change result instead of the up-to-1s detect poll.
+    #[tokio::test]
+    async fn public_observe_window_changes_false_skips_polling() {
+        let snapshot = crate::window_change_detector::WindowChangeDetector::snapshot(None);
+        let started = std::time::Instant::now();
+        let changes = finish_window_observation(
+            snapshot,
+            &serde_json::json!({"observe_window_changes": false}),
+        )
+        .await;
+        assert!(!changes.needs_restore());
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(500),
+            "opt-out must not run the detect poll"
+        );
     }
 }
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/press_key.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/press_key.rs
@@ -48,6 +48,7 @@ fn def() -> &'static ToolDef {
             "type": "object",
             "required": ["key"],
             "properties": {
+                "observe_window_changes": { "type": "boolean", "default": true, "description": "Set false to skip the post-action window-change poll (up to ~1s) — for deterministic callers (macro replay, harnesses) that already know what the next action expects. The result then omits new-window/foreground-change notes." },
                 "session": { "type": "string", "description": "Optional session id: declares/uses the agent cursor and per-session state for this run. The same id works over MCP, the CLI, or the raw socket, and follows the run across apps/windows. Omit to run cursor-less." },
                 "pid": { "type": "integer" },
                 "key": { "type": "string", "description": "Key name: return, tab, escape, up, down, etc." },

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/scroll.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/scroll.rs
@@ -71,6 +71,7 @@ fn def() -> &'static ToolDef {
             // schema — keeps the contract consistent across platforms.
             "required": ["direction"],
             "properties": {
+                "observe_window_changes": { "type": "boolean", "default": true, "description": "Set false to skip the post-action window-change poll (up to ~1s) — for deterministic callers (macro replay, harnesses) that already know what the next action expects. The result then omits new-window/foreground-change notes." },
                 "session": { "type": "string", "description": "Optional session id: declares/uses the agent cursor and per-session state for this run. The same id works over MCP, the CLI, or the raw socket, and follows the run across apps/windows. Omit to run cursor-less." },
                 "pid": { "type": "integer" },
                 "direction": {

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/type_text.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/type_text.rs
@@ -86,6 +86,7 @@ fn def() -> &'static ToolDef {
             "type": "object",
             "required": ["text"],
             "properties": {
+                "observe_window_changes": { "type": "boolean", "default": true, "description": "Set false to skip the post-action window-change poll (up to ~1s) — for deterministic callers (macro replay, harnesses) that already know what the next action expects. The result then omits new-window/foreground-change notes." },
                 "session": { "type": "string", "description": "Optional session id: declares/uses the agent cursor and per-session state for this run. The same id works over MCP, the CLI, or the raw socket, and follows the run across apps/windows. Omit to run cursor-less." },
                 "pid":  { "type": "integer", "description": "Target process ID." },
                 "text": { "type": "string",  "description": "Text to insert at the target's cursor." },


### PR DESCRIPTION
## Behavior

Every input tool (`click`, `drag`, `press_key`, `type_text`, `hotkey`, `scroll`) runs a post-action window-change poll (`WindowChangeDetector::detect`) that early-exits only when a change appears — a quiet action always pays the full `DEFAULT_TIMEOUT` (1s). For agent loops that's useful observation; for **deterministic callers** (macro replay, test harnesses) that already know what the next action expects, it's pure latency on every action.

This adds a public, additive, backwards-compatible opt-out: pass `observe_window_changes: false` on any of those tools to skip the poll (the result then omits new-window/foreground-change notes). Omitted or `true` keeps today's behavior exactly. It is deliberately distinct from the transport-reserved `_skip_window_change_detection`, which `sanitize_reserved_args` strips from public callers.

## Validation

- New unit test `public_observe_window_changes_false_skips_polling` (asserts the no-poll fast path, with a timing bound) alongside the existing internal-flag test; `cargo test -p platform-macos --locked`: 242 passed, 0 failed.
- `cargo fmt -p platform-macos` clean.
- Measured downstream (axstream, a macro-replay client, on a real Mac): a 5-op macro replay went from 3.4s to 1.50s p50; a single `press_key` from ~1017ms to ~12ms.

## Known gaps

- macOS only: the schema property + logic are added where the poll exists today (`platform-macos`). Windows/Linux parity can follow if the same observation lands there.
- The flag is per-call by design (mirrors `scope`); no config/global variant included to keep the diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)