### PR TITLE
fix(lume): run macos installer on vm queue

### DIFF
--- a/libs/lume/src/Virtualization/VMVirtualizationService.swift
+++ b/libs/lume/src/Virtualization/VMVirtualizationService.swift
@@ -519,32 +519,33 @@ final class DarwinVirtualizationService: BaseVirtualizationService {
 
     func installMacOS(imagePath: Path, progressHandler: (@Sendable (Double) -> Void)?) async throws
     {
-        var observers: [NSKeyValueObservation] = []  // must hold observer references during installation to print process
+        let handle = virtualMachineHandle
         try await withCheckedThrowingContinuation {
             (continuation: CheckedContinuation<Void, Error>) in
-            Task {
+            handle.queue.async {
                 let installer = VZMacOSInstaller(
-                    virtualMachine: virtualMachine, restoringFromImageAt: imagePath.url)
+                    virtualMachine: handle.machine, restoringFromImageAt: imagePath.url)
                 Logger.info("Starting macOS installation")
 
-                if let progressHandler = progressHandler {
-                    let observer = installer.progress.observe(
+                let progressObserver = progressHandler.map { progressHandler in
+                    installer.progress.observe(
                         \.fractionCompleted, options: [.initial, .new]
                     ) { (progress, change) in
                         if let newValue = change.newValue {
                             progressHandler(newValue)
                         }
                     }
-                    observers.append(observer)
                 }
 
                 installer.install { result in
-                    switch result {
-                    case .success:
-                        continuation.resume()
-                    case .failure(let error):
-                        Logger.error("Failed to install, error=\(error))")
-                        continuation.resume(throwing: error)
+                    withExtendedLifetime(progressObserver) {
+                        switch result {
+                        case .success:
+                            continuation.resume()
+                        case .failure(let error):
+                            Logger.error("Failed to install, error=\(error))")
+                            continuation.resume(throwing: error)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## what changed

`DarwinVirtualizationService.installMacOS` now captures its `VirtualMachineHandle` and dispatches installer construction, progress-observer registration, and `install` through the virtual machine's private queue. The progress observer stays alive until the install completion callback.

## why

Issue #2670 reports a `dispatch_assert_queue` trap in `VZMacOSInstaller.init`. The virtual machine is created with a private serial queue, but the installer was created in an unqualified `Task` on the service's main actor. Virtualization requires installer setup on the virtual machine's queue.

## impact

`lume create` no longer constructs `VZMacOSInstaller` on the wrong queue after an IPSW download or local IPSW selection.

## validation

- `swift test --package-path libs/lume --filter VMVirtualizationServiceTests`
- result: build succeeded; 6 tests passed
- `git diff --check`

A live IPSW install was not run because this checkout has no prepared restore-image integration fixture. The package compile verifies the Swift 6 concurrency boundary, and the source change directly matches the framework queue assertion.