### PR TITLE
feat(cua-driver): add background UI testing API

### DIFF
--- a/docs/content/docs/reference/cua-driver/mcp-tools.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools.mdx
@@ -12,7 +12,7 @@ description: Reference for every MCP tool Cua Driver exposes
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-`cua-driver` exposes 49 MCP tools through a single stdio server (`cua-driver mcp`). Every tool is also callable from the shell as `cua-driver <name> '<JSON-args>'`.
+`cua-driver` exposes 51 MCP tools through a single stdio server (`cua-driver mcp`). Every tool is also callable from the shell as `cua-driver <name> '<JSON-args>'`.
 
 Tool names are `snake_case`. Responses are MCP `CallTool.Result` envelopes: a text content block prefixed with a `✅` summary (or the error reason on failure), plus optional image or structured-content blocks on tools that produce them. See the [CLI reference](/reference/cua-driver/cli-reference) for CLI-specific options like `--socket` and `--screenshot-out-file`.
 
@@ -61,7 +61,7 @@ Walk a running app's AX tree and return BOTH a structured `elements` array (pref
 
 INVARIANT: call get_window_state once per turn per (pid, window_id) before any element-indexed action. The index map is replaced by the next snapshot.
 
-PREFERRED CONSUMERS read `structuredContent.elements` (one entry per indexed row with `element_index`, `role`, `label`, `value` (the element's text/AXValue when present — use it to verify what a field holds), `frame: {x,y,w,h}`, `parent_index`, `depth`). The markdown `tree_markdown` stays available and unchanged in shape for existing text-parsing callers — but new fields will only be added to the structured side.
+PREFERRED CONSUMERS read `structuredContent.elements` (one entry per indexed row with `element_index`, `role`, `label`, `identifier` (AXIdentifier when present), `value` (the element's text/AXValue when present, used to verify what a field holds), `frame: {x,y,w,h}`, `parent_index`, `depth`). The markdown `tree_markdown` stays available and unchanged in shape for existing text-parsing callers — but new fields will only be added to the structured side.
 
 Always returns BOTH the element tree AND a screenshot — ground on both and cross-check (the tree lies on some surfaces: Electron echo-confirms, Catalyst null values, virtualized off-viewport rows with `h:1` frames). You choose the modality at ACTION time, not here: an element ax action (pass `element_index`/`element_token` → the accessibility rung) or an element px action (pass `x`,`y` → the pixel rung, read straight off this screenshot). `capture_mode` is deprecated and ignored. Pass `include_screenshot:false` to skip the grab and get the tree only — the cheap path when you're just re-indexing before an element ax action.
 
@@ -106,7 +106,7 @@ Capture a full-display vision screenshot in true screen pixels (no downscale), f
 
 ### `get_screen_size`
 
-Return the logical size of the main display in points plus its backing scale factor. Agents click in points; Retina displays have scale_factor 2.0. Requires no TCC permissions.
+Return every active display's global logical bounds, backing scale, and main/built-in/mirroring state. Top-level width, height, and scale_factor retain the main-display contract. Agents click in logical points; Retina displays commonly have scale_factor 2.0. Requires no TCC permissions.
 
 **Arguments:**
 
@@ -164,6 +164,8 @@ Optional `creates_new_application_instance`: when true, forces a new app instanc
 
 Optional `additional_arguments`: extra argv strings appended after --args.
 
+Optional `initial_window_position`: move the first matching window as soon as WindowServer publishes it, before the post-launch focus-suppression window finishes. The move uses AXPosition and does not activate or raise the app. Include `title` to require an exact window-title match.
+
 Returns the launched app's pid, bundle_id, name, and a `windows` array (same shape as `list_windows`) so callers can skip an extra round-trip before `get_window_state(pid, window_id)`. `launch_state` distinguishes whether the request was sent, the process is running, and a window is ready. When the focus-steal belt-and-braces demotion check ran (target pid ≠ prior frontmost), the response also includes `self_activation_suppressed: bool` — true if focus stayed with the prior frontmost, false if the launched app held focus despite the re-demote attempt.
 
 **Arguments:**
@@ -171,6 +173,7 @@ Returns the launched app's pid, bundle_id, name, and a `windows` array (same sha
 - `additional_arguments` (array of string, optional): Extra arguments appended after --args when launching.
 - `bundle_id` (string, optional): App bundle identifier, e.g. com.apple.calculator. Preferred over name.
 - `creates_new_application_instance` (boolean, optional): When true, force a new app instance even if already running (open -n). Use for concurrent multi-agent/multi-session work so each session gets an isolated instance + window instead of sharing one — on single-instance apps (e.g. Calculator) every caller otherwise gets the same window and the sessions clobber each other.
+- `initial_window_position` (object, optional): Move the first matching window at launch without activating or raising it.
 - `name` (string, optional): App display name. Used only when bundle_id is absent.
 - `urls` (array of string, optional): Optional file paths or URLs to open with the app (e.g. a folder path for Finder).
 - `webkit_inspector_port` (integer, optional): Open a WebKit inspector server on this port (sets WEBKIT_INSPECTOR_SERVER env var).
@@ -727,6 +730,27 @@ Install the ffmpeg binary used by start_recording's video capture (Linux/Windows
 - `confirm` (boolean, optional): Run the install command. Without it, only the planned command is reported.
 
 ## Other tools
+
+### `get_frontmost_app`
+
+Return the current frontmost macOS application's pid, name, and bundle identifier. This reads NSWorkspace directly and does not scan installed applications.
+
+**Arguments:** none.
+
+### `move_window`
+
+Move one macOS window to a global screen position without activating, raising, resizing, or changing the real cursor. The target is scoped by both pid and window_id. Coordinates use the same top-left global point space as list_windows and get_screen_size.displays.
+
+**Arguments:**
+
+- `pid` (integer, required): PID that owns the target window.
+- `window_id` (integer, required): CGWindowID from list_windows.
+- `x` (number, required): Requested global left edge in logical points.
+- `y` (number, required): Requested global top edge in logical points.
+
+```json
+{"pid":844,"window_id":10725,"x":100,"y":200}
+```
 
 ### `set_agent_cursor_theme`
 

--- a/libs/cua-driver/README.md
+++ b/libs/cua-driver/README.md
@@ -14,6 +14,10 @@ Background computer-use driver for any agents. Speaks MCP over stdio; drives nat
   the same in-process native runtime through generated UniFFI bindings. The
   safe Rust SDK and generated bindings sit above a versioned C ABI; they do not
   require a daemon for direct application use.
+- **Cua as a background UI test driver:** Python tests import
+  `cua_driver.testing` for app lifecycle, stable accessibility selectors,
+  waits, assertions, and failure artifacts. The test layer permits only
+  window-scoped background actions.
 
 The language packages are for client applications, not agents. They contain no
 language-native MCP facade and have no `/sdk`, `/mcp`, or `/native` public
@@ -87,6 +91,7 @@ Contributor documentation:
 - `docs/test-matrix.md` maps unit and canonical harness E2E suites.
 - `docs/action-support.md` is the empirical platform behavior ledger.
 - `docs/test-harnesses-guide.md` explains fixture and runner ownership.
+- `docs/ui-testing.md` documents the background-safe Python test layer.
 - `docs/linux-desktop-validation.md` covers representative Linux sessions.
 - `docs/linux-support-completion-plan.md` preserves the historical Linux plan.
 

--- a/libs/cua-driver/docs/ui-testing.md
+++ b/libs/cua-driver/docs/ui-testing.md
@@ -1,0 +1,124 @@
+# Background UI testing
+
+`cua_driver.testing` is a macOS UI test layer for apps that must remain behind
+the window a person is using. It supplies app lifecycle, stable element
+queries, polling waits, assertions, and failure artifacts on top of Cua
+Driver's accessibility and window-capture tools.
+
+## Install
+
+Install the Python test extra, then grant Accessibility and Screen Recording
+to the process macOS identifies when pytest starts. For local runs this is
+usually the terminal or Python host:
+
+```bash
+pip install "cua-driver[uitest]"
+```
+
+The test layer loads Cua Driver in the pytest process and binds one standard,
+window-scoped Cua session. That binding keeps launch ownership, actions, and
+cleanup on the same session.
+
+## Write a test
+
+```python
+import pytest
+
+from cua_driver.testing import CuaTestSession
+
+
+@pytest.mark.asyncio
+async def test_counter() -> None:
+    async with CuaTestSession.create() as cua:
+        app = await cua.launch(
+            bundle_id="com.example.Counter",
+            window_title="Counter",
+        )
+
+        await app.buttons.by_id("btn-increment").tap()
+        await app.wait_for_text("counter=1")
+```
+
+`launch()` always requests a new application instance, giving the test its own
+PID and window. The session kills only processes it launched. `attach(pid=...)`
+never kills the attached process.
+
+By default, the session reads every active display and centers the test window
+on a non-main display before the first action. It prefers a built-in secondary
+display, ignores mirrored displays, and verifies the resulting window bounds.
+The requested secondary origin is passed into `launch_app`, which moves the
+window as soon as WindowServer publishes it, before launch focus suppression
+finishes. The runner centers and verifies the window again after launch. Both
+moves use the accessibility API, so they do not activate or raise the app.
+Machines with one display leave the window in place. Use
+`CuaTestSession.create(placement="unchanged")` only when the test owns its
+screen arrangement. Pass `window_title=` for apps with splash screens or
+multiple top-level windows so early placement waits for the intended window.
+
+## Select elements
+
+Use accessibility identifiers for tests that must survive localization and UI
+copy changes:
+
+```python
+button = app.buttons.by_id("btn-increment")
+field = app.text_fields.by_id("txt-name")
+```
+
+Exact labels are useful for prototypes:
+
+```python
+button = app.buttons["Increment"]
+button = app.buttons.labeled("Increment")
+```
+
+Available role collections include `buttons`, `checkboxes`, `groups`, `links`,
+`menus`, `menu_items`, `radio_buttons`, `rows`, `sliders`, `tables`,
+`text_areas`, and `text_fields`. `app.elements` searches every actionable
+role. A label query that matches more than one element fails and prints the
+candidate roles, labels, identifiers, and values.
+
+## Act and wait
+
+```python
+await app.buttons.by_id("save").tap()
+await app.text_fields.by_id("name").type_text("Ada")
+await app.text_fields.by_id("name").set_value("Grace")
+await app.text_fields.by_id("name").wait_for_value("Grace")
+await app.wait_for_text("Saved")
+await app.buttons.by_id("spinner").wait_for_disappearance()
+```
+
+Each action obtains a fresh window snapshot and acts through its element token.
+Polling waits use fresh snapshots, so stale element handles do not leak between
+UI updates.
+
+## Background-only contract
+
+The test layer has no foreground escape hatch. It does not expose
+`bring_to_front`, screen-wide clicks, real cursor movement, or
+`delivery_mode: "foreground"`. Actions always include the target PID, window
+ID, and element token. Clicks and keyboard input explicitly request background
+delivery; value changes use the target control's accessibility action. Before
+and after each action, the runner reads the active app and WindowServer order.
+It fails if the target is already active, becomes active, rises above a
+visible window from the active app, or the active app cannot be identified.
+The same order check applies when the test window is parked on another display.
+Launch and attach also fail if placement changes the active app or the
+requested position cannot be verified.
+
+Some custom-rendered controls do not expose an accessibility action. Cua
+Driver returns a structured refusal for those controls. The test layer records
+the refusal and fails instead of escalating to a foreground pixel action.
+
+## Failure artifacts
+
+Timeouts, driver refusals, and foreground violations create a timestamped
+directory under `test-results/cua-ui/` containing:
+
+- `window.png`, the target window capture
+- `tree.txt`, the accessibility tree
+- `snapshot.json`, the structured elements and metadata
+
+Pass `artifacts_dir=` to `CuaTestSession.create()` to place them in a CI
+artifact directory.

--- a/libs/cua-driver/python/README.md
+++ b/libs/cua-driver/python/README.md
@@ -72,6 +72,49 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+## Background UI tests
+
+`cua_driver.testing` provides a pytest-friendly UI test layer for macOS apps.
+It launches a separate app instance in the background, resolves controls by
+accessibility identifier, polls the live accessibility tree, and saves a
+window screenshot plus tree on failure. When a non-main display is available,
+the runner asks `launch_app` to move the window there as soon as it appears,
+then re-verifies the final position before acting.
+
+```bash
+pip install "cua-driver[uitest]"
+```
+
+```python
+import pytest
+
+from cua_driver.testing import CuaTestSession
+
+
+@pytest.mark.asyncio
+async def test_increment_stays_in_background() -> None:
+    async with CuaTestSession.create() as cua:
+        app = await cua.launch(
+            bundle_id="com.example.Counter",
+            window_title="Counter",
+        )
+
+        await app.buttons.by_id("btn-increment").tap()
+
+        await app.wait_for_text("counter=1")
+```
+
+The test API does not expose `bring_to_front`, desktop-scoped input, or
+foreground delivery. Every action carries the target PID, window ID, and fresh
+element token. Clicks and keyboard input explicitly request background
+delivery. The test fails if the target becomes the active app. Window placement
+uses the driver's background-only `move_window` action and verifies that the
+window landed on the secondary display. A bound Cua session gives launch,
+actions, and process cleanup one identity, so teardown cannot terminate a
+foreign process or leave its own test app running. See
+[`docs/ui-testing.md`](../docs/ui-testing.md) for lifecycle, selectors, and
+failure artifacts.
+
 SDK operations are asynchronous. Desktop calls return a typed `ToolResult` with
 text, images, verification/error metadata, and `structured_json` / `raw_json`
 for platform-extensible results. Session lifecycle calls return dedicated

--- a/libs/cua-driver/python/pyproject.toml
+++ b/libs/cua-driver/python/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = []
 
 [project.optional-dependencies]
 test = ["pytest"]
+uitest = ["pytest>=8", "pytest-asyncio>=0.23"]
 
 [project.urls]
 Homepage = "https://github.com/trycua/cua"

--- a/libs/cua-driver/python/src/cua_driver/testing.py
+++ b/libs/cua-driver/python/src/cua_driver/testing.py
@@ -1,0 +1,1251 @@
+"""Background-safe UI testing primitives built on Cua Driver.
+
+The API deliberately exposes only window-scoped inspection and background
+delivery. Tests that need foreground input should use a VM or a different test
+runner instead of silently interrupting the user's desktop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import re
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from pathlib import Path
+from types import TracebackType
+from typing import Any, Literal, Protocol, Sequence
+from uuid import uuid4
+
+
+class _ImageLike(Protocol):
+    mime_type: str
+    data_base64: str
+
+
+class _ToolResultLike(Protocol):
+    text: str
+    images: Sequence[_ImageLike]
+    structured_json: str | None
+    is_error: bool
+    error_code: str | None
+
+
+class DriverLike(Protocol):
+    """The part of ``CuaDriver`` used by the test layer."""
+
+    async def call_tool(self, name: str, arguments_json: str) -> _ToolResultLike: ...
+
+
+class _OwnedDriverLike(Protocol):
+    async def shutdown(self) -> None: ...
+
+
+class CuaTestError(RuntimeError):
+    """Base error for the UI testing layer."""
+
+
+class CuaToolError(CuaTestError):
+    """A Cua Driver tool refused or failed an operation."""
+
+    def __init__(self, tool: str, message: str, error_code: str | None = None) -> None:
+        self.tool = tool
+        self.error_code = error_code
+        code = f" ({error_code})" if error_code else ""
+        super().__init__(f"{tool}{code}: {message}")
+
+
+class CuaQueryError(CuaTestError):
+    """An element query returned no unique match."""
+
+
+class CuaWaitTimeout(CuaTestError):
+    """A UI condition did not become true before its deadline."""
+
+
+class CuaForegroundViolation(CuaTestError):
+    """The target application became foreground during a background action."""
+
+
+class CuaWindowOrderViolation(CuaForegroundViolation):
+    """The target window rose above the user's active application."""
+
+
+@dataclass(frozen=True)
+class Frame:
+    x: float
+    y: float
+    width: float
+    height: float
+
+
+@dataclass(frozen=True)
+class ElementSnapshot:
+    element_index: int
+    element_token: str | None
+    role: str
+    label: str | None
+    value: str | None
+    identifier: str | None
+    enabled: bool | None
+    selected: bool | None
+    frame: Frame | None
+    raw: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class WindowSnapshot:
+    pid: int
+    window_id: int
+    title: str
+    app_name: str
+    is_on_screen: bool | None
+    frame: Frame | None
+    z_index: int | None
+
+
+@dataclass(frozen=True)
+class DisplaySnapshot:
+    display_id: int
+    frame: Frame
+    scale_factor: float
+    is_main: bool
+    is_builtin: bool
+    is_mirrored: bool
+
+
+@dataclass(frozen=True)
+class AppSnapshot:
+    elements: tuple[ElementSnapshot, ...]
+    tree: str
+    structured: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ArtifactBundle:
+    directory: Path
+    tree: Path
+    structured: Path
+    screenshot: Path | None
+
+
+_INDEX_RE = re.compile(r"^\s*-\s*\[(\d+)]\s+")
+_IDENTIFIER_RE = re.compile(r"(?:^|[\s\[])id=([^\s\]]+)")
+_SAFE_NAME_RE = re.compile(r"[^a-zA-Z0-9._-]+")
+PlacementPolicy = Literal["secondary", "unchanged"]
+
+
+def _slug(value: str) -> str:
+    cleaned = _SAFE_NAME_RE.sub("-", value).strip("-._")
+    return cleaned[:80] or "capture"
+
+
+def _structured(result: _ToolResultLike) -> dict[str, Any]:
+    if not result.structured_json:
+        return {}
+    value = json.loads(result.structured_json)
+    if not isinstance(value, dict):
+        raise CuaTestError("Cua Driver returned non-object structured content")
+    return value
+
+
+def _identifier_map(tree: str) -> dict[int, str]:
+    identifiers: dict[int, str] = {}
+    for line in tree.splitlines():
+        index_match = _INDEX_RE.match(line)
+        identifier_match = _IDENTIFIER_RE.search(line)
+        if index_match and identifier_match:
+            identifiers[int(index_match.group(1))] = identifier_match.group(1)
+    return identifiers
+
+
+def _role_key(role: str) -> str:
+    value = role.casefold().removeprefix("ax")
+    return "".join(character for character in value if character.isalnum())
+
+
+_ROLE_GROUPS: dict[str, frozenset[str]] = {
+    "buttons": frozenset({"button", "pushbutton", "togglebutton", "splitbutton"}),
+    "checkboxes": frozenset({"checkbox", "checkbutton"}),
+    "groups": frozenset({"group", "pane", "section"}),
+    "links": frozenset({"link", "hyperlink"}),
+    "menus": frozenset({"menu", "menubar"}),
+    "menu_items": frozenset({"menuitem", "menuitemcheckbox", "menuitemradio"}),
+    "radio_buttons": frozenset({"radiobutton", "radio"}),
+    "rows": frozenset({"row", "tablerow", "listitem"}),
+    "sliders": frozenset({"slider"}),
+    "tables": frozenset({"table", "grid", "list"}),
+    "text_areas": frozenset({"textarea", "documenttext"}),
+    "text_fields": frozenset({"textfield", "edit", "entry", "editabletext"}),
+}
+
+
+@dataclass(frozen=True)
+class _Selector:
+    roles: frozenset[str] | None = None
+    identifier: str | None = None
+    label: str | None = None
+    value: str | None = None
+    name: str | None = None
+
+    def matches(self, element: ElementSnapshot) -> bool:
+        if self.roles is not None and _role_key(element.role) not in self.roles:
+            return False
+        if self.identifier is not None and element.identifier != self.identifier:
+            return False
+        if self.label is not None and element.label != self.label:
+            return False
+        if self.value is not None and element.value != self.value:
+            return False
+        if self.name is not None and self.name not in {element.identifier, element.label}:
+            return False
+        return True
+
+    def describe(self) -> str:
+        parts = []
+        if self.roles is not None:
+            parts.append(f"roles={sorted(self.roles)!r}")
+        for key in ("identifier", "label", "value", "name"):
+            value = getattr(self, key)
+            if value is not None:
+                parts.append(f"{key}={value!r}")
+        return ", ".join(parts) or "any element"
+
+
+class ElementCollection:
+    """A role-filtered collection such as ``app.buttons``."""
+
+    def __init__(self, app: CuaApplication, roles: frozenset[str] | None) -> None:
+        self._app = app
+        self._roles = roles
+
+    def __getitem__(self, name: str) -> CuaElement:
+        """Match an accessibility identifier first, or an exact label."""
+
+        return CuaElement(self._app, _Selector(roles=self._roles, name=name))
+
+    def by_id(self, identifier: str) -> CuaElement:
+        return CuaElement(
+            self._app,
+            _Selector(roles=self._roles, identifier=identifier),
+        )
+
+    def labeled(self, label: str) -> CuaElement:
+        return CuaElement(self._app, _Selector(roles=self._roles, label=label))
+
+    def with_value(self, value: str) -> CuaElement:
+        return CuaElement(self._app, _Selector(roles=self._roles, value=value))
+
+
+class CuaElement:
+    """A live element query that re-snapshots before every action."""
+
+    def __init__(self, app: CuaApplication, selector: _Selector) -> None:
+        self._app = app
+        self._selector = selector
+
+    async def exists(self) -> bool:
+        snapshot = await self._app.snapshot()
+        return bool(self._matches(snapshot))
+
+    async def wait_for_exists(
+        self,
+        timeout: float = 5.0,
+        poll_interval: float = 0.1,
+    ) -> ElementSnapshot:
+        deadline = asyncio.get_running_loop().time() + timeout
+        while True:
+            snapshot = await self._app.snapshot()
+            matches = self._matches(snapshot)
+            if len(matches) == 1:
+                return matches[0]
+            if len(matches) > 1:
+                raise self._ambiguous(matches)
+            if asyncio.get_running_loop().time() >= deadline:
+                artifacts = await self._app.capture_failure("wait-for-element")
+                suffix = f"; artifacts: {artifacts.directory}" if artifacts else ""
+                raise CuaWaitTimeout(
+                    f"element did not appear within {timeout:.2f}s: "
+                    f"{self._selector.describe()}{suffix}"
+                )
+            await asyncio.sleep(poll_interval)
+
+    async def wait_for_disappearance(
+        self,
+        timeout: float = 5.0,
+        poll_interval: float = 0.1,
+    ) -> None:
+        deadline = asyncio.get_running_loop().time() + timeout
+        while True:
+            snapshot = await self._app.snapshot()
+            if not self._matches(snapshot):
+                return
+            if asyncio.get_running_loop().time() >= deadline:
+                artifacts = await self._app.capture_failure("wait-for-disappearance")
+                suffix = f"; artifacts: {artifacts.directory}" if artifacts else ""
+                raise CuaWaitTimeout(
+                    f"element still exists after {timeout:.2f}s: "
+                    f"{self._selector.describe()}{suffix}"
+                )
+            await asyncio.sleep(poll_interval)
+
+    async def value(self, timeout: float = 0.0) -> str | None:
+        return (await self._resolve(timeout)).value
+
+    async def tap(self, timeout: float = 5.0) -> None:
+        element = await self._resolve(timeout)
+        await self._app._element_action("click", element)
+
+    async def type_text(self, text: str, timeout: float = 5.0) -> None:
+        element = await self._resolve(timeout)
+        await self._app._element_action("type_text", element, text=text)
+
+    async def set_value(self, value: str, timeout: float = 5.0) -> None:
+        element = await self._resolve(timeout)
+        await self._app._element_action("set_value", element, value=value)
+
+    async def press_key(
+        self,
+        key: str,
+        modifiers: Sequence[str] = (),
+        timeout: float = 5.0,
+    ) -> None:
+        element = await self._resolve(timeout)
+        await self._app._element_action(
+            "press_key",
+            element,
+            key=key,
+            modifiers=list(modifiers),
+        )
+
+    async def wait_for_value(
+        self,
+        expected: str,
+        timeout: float = 5.0,
+        poll_interval: float = 0.1,
+    ) -> ElementSnapshot:
+        deadline = asyncio.get_running_loop().time() + timeout
+        while True:
+            snapshot = await self._app.snapshot()
+            matches = self._matches(snapshot)
+            if len(matches) > 1:
+                raise self._ambiguous(matches)
+            if matches and matches[0].value == expected:
+                return matches[0]
+            if asyncio.get_running_loop().time() >= deadline:
+                actual = matches[0].value if matches else None
+                artifacts = await self._app.capture_failure("wait-for-value")
+                suffix = f"; artifacts: {artifacts.directory}" if artifacts else ""
+                raise CuaWaitTimeout(
+                    f"element value did not become {expected!r} within {timeout:.2f}s; "
+                    f"actual={actual!r}; {self._selector.describe()}{suffix}"
+                )
+            await asyncio.sleep(poll_interval)
+
+    async def _resolve(self, timeout: float) -> ElementSnapshot:
+        if timeout > 0:
+            return await self.wait_for_exists(timeout)
+        snapshot = await self._app.snapshot()
+        matches = self._matches(snapshot)
+        if not matches:
+            raise CuaQueryError(f"no match for {self._selector.describe()}")
+        if len(matches) > 1:
+            raise self._ambiguous(matches)
+        return matches[0]
+
+    def _matches(self, snapshot: AppSnapshot) -> list[ElementSnapshot]:
+        matches = [element for element in snapshot.elements if self._selector.matches(element)]
+        if self._selector.name is not None:
+            identifier_matches = [
+                element for element in matches if element.identifier == self._selector.name
+            ]
+            if identifier_matches:
+                return identifier_matches
+        return matches
+
+    def _ambiguous(self, matches: Sequence[ElementSnapshot]) -> CuaQueryError:
+        identities = [
+            {
+                "role": match.role,
+                "identifier": match.identifier,
+                "label": match.label,
+                "value": match.value,
+            }
+            for match in matches
+        ]
+        return CuaQueryError(
+            f"query matched {len(matches)} elements: {self._selector.describe()}; "
+            f"matches={identities!r}"
+        )
+
+
+class CuaApplication:
+    """A PID/window-scoped application under background-safe test control."""
+
+    def __init__(
+        self,
+        session: CuaTestSession,
+        window: WindowSnapshot,
+        *,
+        owns_process: bool,
+        launch_metadata: dict[str, Any] | None = None,
+    ) -> None:
+        self._session = session
+        self.window = window
+        self.launch_metadata = launch_metadata or {}
+        self._owns_process = owns_process
+        self._closed = False
+
+    @property
+    def pid(self) -> int:
+        return self.window.pid
+
+    @property
+    def window_id(self) -> int:
+        return self.window.window_id
+
+    @property
+    def elements(self) -> ElementCollection:
+        return ElementCollection(self, None)
+
+    @property
+    def buttons(self) -> ElementCollection:
+        return self._collection("buttons")
+
+    @property
+    def checkboxes(self) -> ElementCollection:
+        return self._collection("checkboxes")
+
+    @property
+    def groups(self) -> ElementCollection:
+        return self._collection("groups")
+
+    @property
+    def links(self) -> ElementCollection:
+        return self._collection("links")
+
+    @property
+    def menus(self) -> ElementCollection:
+        return self._collection("menus")
+
+    @property
+    def menu_items(self) -> ElementCollection:
+        return self._collection("menu_items")
+
+    @property
+    def radio_buttons(self) -> ElementCollection:
+        return self._collection("radio_buttons")
+
+    @property
+    def rows(self) -> ElementCollection:
+        return self._collection("rows")
+
+    @property
+    def sliders(self) -> ElementCollection:
+        return self._collection("sliders")
+
+    @property
+    def tables(self) -> ElementCollection:
+        return self._collection("tables")
+
+    @property
+    def text_areas(self) -> ElementCollection:
+        return self._collection("text_areas")
+
+    @property
+    def text_fields(self) -> ElementCollection:
+        return self._collection("text_fields")
+
+    def _collection(self, name: str) -> ElementCollection:
+        return ElementCollection(self, _ROLE_GROUPS[name])
+
+    async def snapshot(
+        self,
+        *,
+        include_screenshot: bool = False,
+        screenshot_out_file: Path | None = None,
+    ) -> AppSnapshot:
+        arguments: dict[str, Any] = {
+            "pid": self.pid,
+            "window_id": self.window_id,
+            "include_screenshot": include_screenshot,
+        }
+        if screenshot_out_file is not None:
+            arguments["screenshot_out_file"] = str(screenshot_out_file)
+        result = await self._session._call("get_window_state", arguments)
+        data = _structured(result)
+        tree = str(data.get("tree_markdown", result.text))
+        identifiers = _identifier_map(tree)
+        elements = []
+        raw_elements = data.get("elements", [])
+        if not isinstance(raw_elements, list):
+            raise CuaTestError("get_window_state returned a non-array elements field")
+        for raw in raw_elements:
+            if not isinstance(raw, dict) or "element_index" not in raw:
+                continue
+            index = int(raw["element_index"])
+            frame = raw.get("frame")
+            parsed_frame = None
+            if isinstance(frame, dict):
+                parsed_frame = Frame(
+                    x=float(frame.get("x", 0)),
+                    y=float(frame.get("y", 0)),
+                    width=float(frame.get("w", frame.get("width", 0))),
+                    height=float(frame.get("h", frame.get("height", 0))),
+                )
+            elements.append(
+                ElementSnapshot(
+                    element_index=index,
+                    element_token=_optional_string(raw.get("element_token")),
+                    role=str(raw.get("role", "")),
+                    label=_optional_string(raw.get("label")),
+                    value=_optional_string(raw.get("value")),
+                    identifier=_optional_string(raw.get("identifier")) or identifiers.get(index),
+                    enabled=_optional_bool(raw.get("enabled")),
+                    selected=_optional_bool(raw.get("selected")),
+                    frame=parsed_frame,
+                    raw=raw,
+                )
+            )
+        return AppSnapshot(tuple(elements), tree, data)
+
+    async def contains_text(self, text: str) -> bool:
+        return text in (await self.snapshot()).tree
+
+    async def wait_for_text(
+        self,
+        text: str,
+        timeout: float = 5.0,
+        poll_interval: float = 0.1,
+    ) -> None:
+        deadline = asyncio.get_running_loop().time() + timeout
+        while True:
+            if await self.contains_text(text):
+                return
+            if asyncio.get_running_loop().time() >= deadline:
+                artifacts = await self.capture_failure("wait-for-text")
+                suffix = f"; artifacts: {artifacts.directory}" if artifacts else ""
+                raise CuaWaitTimeout(f"text did not appear within {timeout:.2f}s: {text!r}{suffix}")
+            await asyncio.sleep(poll_interval)
+
+    async def wait_for_text_to_disappear(
+        self,
+        text: str,
+        timeout: float = 5.0,
+        poll_interval: float = 0.1,
+    ) -> None:
+        deadline = asyncio.get_running_loop().time() + timeout
+        while True:
+            if not await self.contains_text(text):
+                return
+            if asyncio.get_running_loop().time() >= deadline:
+                artifacts = await self.capture_failure("wait-for-text-disappearance")
+                suffix = f"; artifacts: {artifacts.directory}" if artifacts else ""
+                raise CuaWaitTimeout(f"text still exists after {timeout:.2f}s: {text!r}{suffix}")
+            await asyncio.sleep(poll_interval)
+
+    async def capture_failure(self, name: str) -> ArtifactBundle | None:
+        return await self._session._capture(self, name)
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        if self._owns_process:
+            try:
+                await self._session._call("kill_app", {"pid": self.pid})
+            except CuaToolError as error:
+                if "No such process" not in str(error):
+                    raise
+        self._closed = True
+
+    async def _element_action(
+        self,
+        tool: str,
+        element: ElementSnapshot,
+        **arguments: Any,
+    ) -> None:
+        payload: dict[str, Any] = {
+            "pid": self.pid,
+            "window_id": self.window_id,
+            "element_index": element.element_index,
+            **arguments,
+        }
+        if element.element_token:
+            payload["element_token"] = element.element_token
+        if tool in {"click", "type_text", "press_key"}:
+            payload["delivery_mode"] = "background"
+        try:
+            await self._session._require_background_window(
+                self.window,
+                operation=f"{tool} preflight",
+            )
+        except CuaForegroundViolation as error:
+            artifacts = await self.capture_failure("target-already-foreground")
+            suffix = f"; artifacts: {artifacts.directory}" if artifacts else ""
+            raise type(error)(f"{error}{suffix}") from None
+        try:
+            await self._session._call(tool, payload)
+        except CuaToolError:
+            await self.capture_failure(tool)
+            raise
+        try:
+            self.window = await self._session._require_background_window(
+                self.window,
+                operation=tool,
+            )
+        except CuaForegroundViolation as error:
+            artifacts = await self.capture_failure("foreground-violation")
+            suffix = f"; artifacts: {artifacts.directory}" if artifacts else ""
+            raise type(error)(f"{error}{suffix}") from None
+
+
+class CuaTestSession:
+    """Owns a driver connection and applications launched by one UI test."""
+
+    def __init__(
+        self,
+        driver: DriverLike,
+        *,
+        artifacts_dir: str | Path = "test-results/cua-ui",
+        owns_driver: bool = False,
+        placement: PlacementPolicy = "secondary",
+        _owner_driver: _OwnedDriverLike | None = None,
+        _bound_session: Any | None = None,
+        _public_session: str | None = None,
+    ) -> None:
+        if placement not in {"secondary", "unchanged"}:
+            raise ValueError("placement must be 'secondary' or 'unchanged'")
+        self._driver = driver
+        self._artifacts_dir = Path(artifacts_dir)
+        self._owner_driver = _owner_driver or (driver if owns_driver else None)
+        self._bound_session = _bound_session
+        self._public_session = _public_session
+        self._session_started = False
+        self._placement = placement
+        self._apps: list[CuaApplication] = []
+        self._closed = False
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        artifacts_dir: str | Path = "test-results/cua-ui",
+        placement: PlacementPolicy = "secondary",
+    ) -> CuaTestSession:
+        """Create a same-process driver and bind one isolated test session."""
+
+        from . import (
+            ConfiguredDriverOptions,
+            CuaDriver,
+            RuntimeAuthorizationOptions,
+            SessionPermissionMode,
+        )
+
+        return cls._bind_native_driver(
+            CuaDriver.create_configured(
+                ConfiguredDriverOptions(
+                    claude_code_compatibility=False,
+                    authorization=RuntimeAuthorizationOptions(
+                        allowed_modes=[SessionPermissionMode.STANDARD],
+                        compatibility_mode=SessionPermissionMode.STANDARD,
+                        compatibility_bounded_manifest_path=None,
+                        unrestricted_acknowledged=False,
+                        max_session_ttl_seconds=60 * 60,
+                        max_idle_ttl_seconds=10 * 60,
+                    ),
+                )
+            ),
+            artifacts_dir=artifacts_dir,
+            placement=placement,
+        )
+
+    @classmethod
+    def _bind_native_driver(
+        cls,
+        owner: _OwnedDriverLike,
+        *,
+        artifacts_dir: str | Path,
+        placement: PlacementPolicy,
+    ) -> CuaTestSession:
+        from . import (
+            SessionPermissionMode,
+            TrustedSessionOptions,
+            create_trusted_session,
+        )
+
+        public_session = f"cua-ui-{uuid4().hex}"
+        bound = create_trusted_session(
+            owner,
+            TrustedSessionOptions(
+                public_session=public_session,
+                mode=SessionPermissionMode.STANDARD,
+                ttl_seconds=60 * 60,
+                idle_ttl_seconds=10 * 60,
+                bounded_manifest_path=None,
+            ),
+        )
+        return cls(
+            bound,
+            artifacts_dir=artifacts_dir,
+            placement=placement,
+            _owner_driver=owner,
+            _bound_session=bound,
+            _public_session=public_session,
+        )
+
+    async def __aenter__(self) -> CuaTestSession:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        await self.close()
+
+    async def launch(
+        self,
+        *,
+        bundle_id: str | None = None,
+        name: str | None = None,
+        window_title: str | None = None,
+        arguments: Sequence[str] = (),
+        urls: Sequence[str] = (),
+        timeout: float = 10.0,
+    ) -> CuaApplication:
+        if not bundle_id and not name:
+            raise ValueError("launch requires bundle_id or name")
+        payload: dict[str, Any] = {
+            "creates_new_application_instance": True,
+        }
+        if bundle_id:
+            payload["bundle_id"] = bundle_id
+        if name:
+            payload["name"] = name
+        if arguments:
+            payload["additional_arguments"] = list(arguments)
+        if urls:
+            payload["urls"] = list(urls)
+
+        secondary_display = (
+            await self._secondary_display() if self._placement == "secondary" else None
+        )
+        if secondary_display is not None:
+            initial_position: dict[str, Any] = {
+                "x": secondary_display.frame.x + 64,
+                "y": secondary_display.frame.y + 64,
+            }
+            if window_title is not None:
+                initial_position["title"] = window_title
+            payload["initial_window_position"] = initial_position
+
+        active_before = await self._require_active_pid()
+        result = await self._call("launch_app", payload)
+        data = _structured(result)
+        pid = int(data.get("pid", 0))
+        if pid <= 0:
+            raise CuaTestError(f"launch_app did not return a valid pid: {data!r}")
+        try:
+            if secondary_display is not None:
+                initial_placement = data.get("initial_window_placement")
+                initial_bounds = (
+                    _parse_frame(initial_placement.get("after_bounds"))
+                    if isinstance(initial_placement, dict)
+                    else None
+                )
+                if (
+                    not isinstance(initial_placement, dict)
+                    or initial_placement.get("verified") is not True
+                    or initial_bounds is None
+                    or not _frame_center_is_inside(
+                        initial_bounds,
+                        secondary_display.frame,
+                    )
+                ):
+                    raise CuaTestError(
+                        "launch_app did not verify early placement on secondary "
+                        f"display {secondary_display.display_id}: "
+                        f"{initial_placement!r}"
+                    )
+            if data.get("self_activation_suppressed") is False and active_before != pid:
+                raise CuaForegroundViolation(
+                    f"launch_app could not suppress activation of target pid {pid}"
+                )
+
+            windows = self._windows_from(data.get("windows", []))
+            window = self._select_window(windows, window_title)
+            if window is None:
+                window = await self._wait_for_window(pid, window_title, timeout)
+            window = await self._place_window(window)
+
+            active_after = await self._require_active_pid()
+            if active_after == pid:
+                raise CuaForegroundViolation(f"launch_app left target pid {pid} in the foreground")
+        except BaseException as launch_error:
+            try:
+                await self._call("kill_app", {"pid": pid})
+            except CuaToolError as cleanup_error:
+                raise CuaTestError(
+                    f"{launch_error}; test app cleanup also failed: {cleanup_error}"
+                ) from launch_error
+            raise
+
+        app = CuaApplication(
+            self,
+            window,
+            owns_process=True,
+            launch_metadata=data,
+        )
+        self._apps.append(app)
+        return app
+
+    async def attach(
+        self,
+        pid: int,
+        *,
+        window_id: int | None = None,
+        window_title: str | None = None,
+        timeout: float = 5.0,
+    ) -> CuaApplication:
+        windows = await self._list_windows(pid)
+        if window_id is not None:
+            window = next((item for item in windows if item.window_id == window_id), None)
+        else:
+            window = self._select_window(windows, window_title)
+        if window is None:
+            window = await self._wait_for_window(pid, window_title, timeout, window_id)
+        window = await self._place_window(window)
+        app = CuaApplication(self, window, owns_process=False)
+        self._apps.append(app)
+        return app
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        first_error: BaseException | None = None
+        for app in reversed(self._apps):
+            try:
+                await app.close()
+            except BaseException as error:
+                first_error = first_error or error
+        if self._session_started and self._public_session is not None:
+            try:
+                result = await self._driver.call_tool(
+                    "end_session",
+                    json.dumps({"session": self._public_session}, separators=(",", ":")),
+                )
+                if result.is_error:
+                    raise CuaToolError("end_session", result.text, result.error_code)
+            except BaseException as error:
+                first_error = first_error or error
+        if self._bound_session is not None:
+            try:
+                self._bound_session.close()
+            except BaseException as error:
+                first_error = first_error or error
+        if self._owner_driver is not None:
+            try:
+                await self._owner_driver.shutdown()
+            except BaseException as error:
+                first_error = first_error or error
+        if first_error is not None:
+            raise first_error
+
+    async def _call(self, name: str, arguments: dict[str, Any]) -> _ToolResultLike:
+        if not self._session_started and self._public_session is not None:
+            result = await self._driver.call_tool(
+                "start_session",
+                json.dumps(
+                    {
+                        "session": self._public_session,
+                        "capture_scope": "window",
+                    },
+                    separators=(",", ":"),
+                    sort_keys=True,
+                ),
+            )
+            if result.is_error:
+                raise CuaToolError("start_session", result.text, result.error_code)
+            self._session_started = True
+        result = await self._driver.call_tool(
+            name,
+            json.dumps(arguments, separators=(",", ":"), sort_keys=True),
+        )
+        if result.is_error:
+            raise CuaToolError(name, result.text, result.error_code)
+        return result
+
+    async def _active_pid(self) -> int | None:
+        try:
+            result = await self._call("get_frontmost_app", {})
+            value = _structured(result).get("pid")
+            pid = int(value)
+            if pid > 0:
+                return pid
+        except (CuaToolError, TypeError, ValueError):
+            pass
+        return None
+
+    async def _require_active_pid(self) -> int:
+        pid = await self._active_pid()
+        if pid is None:
+            raise CuaTestError(
+                "Cua Driver could not identify a frontmost app; "
+                "background safety cannot be verified"
+            )
+        return pid
+
+    async def _list_windows(self, pid: int | None = None) -> list[WindowSnapshot]:
+        arguments = {"pid": pid} if pid is not None else {}
+        result = await self._call("list_windows", arguments)
+        return self._windows_from(_structured(result).get("windows", []))
+
+    async def _place_window(self, window: WindowSnapshot) -> WindowSnapshot:
+        active_pid = await self._require_active_pid()
+        if active_pid == window.pid:
+            raise CuaForegroundViolation(
+                f"window placement refused because target pid {window.pid} " "is already foreground"
+            )
+        if self._placement == "unchanged":
+            return await self._require_background_window(
+                window,
+                operation="window placement preflight",
+            )
+        display = await self._secondary_display()
+        if display is None:
+            return await self._require_background_window(
+                window,
+                operation="window placement preflight",
+            )
+
+        refreshed = await self._list_windows(window.pid)
+        current = next(
+            (item for item in refreshed if item.window_id == window.window_id),
+            None,
+        )
+        frame = current.frame if current else window.frame
+        if frame is None or frame.width <= 0 or frame.height <= 0:
+            raise CuaTestError(
+                f"window {window.window_id} has no bounds; cannot place it on a secondary display"
+            )
+
+        x, y = _placement_origin(frame, display.frame)
+        result = await self._call(
+            "move_window",
+            {
+                "pid": window.pid,
+                "window_id": window.window_id,
+                "x": x,
+                "y": y,
+            },
+        )
+        after = _parse_frame(_structured(result).get("after_bounds"))
+        if after is None or not _frame_center_is_inside(after, display.frame):
+            raise CuaTestError(
+                f"move_window did not place window {window.window_id} on "
+                f"secondary display {display.display_id}"
+            )
+        current = await self._require_background_window(
+            window,
+            operation="move_window",
+        )
+        return replace(current, frame=after)
+
+    async def _require_background_window(
+        self,
+        target: WindowSnapshot,
+        *,
+        operation: str,
+    ) -> WindowSnapshot:
+        active_pid = await self._require_active_pid()
+        if active_pid == target.pid:
+            if operation.endswith("preflight"):
+                message = (
+                    f"{operation} refused because target pid {target.pid} " "is already foreground"
+                )
+            else:
+                message = (
+                    f"{operation} activated target pid {target.pid}; "
+                    "background-only contract failed"
+                )
+            raise CuaForegroundViolation(message)
+
+        windows = await self._list_windows()
+        current = next(
+            (
+                window
+                for window in windows
+                if window.pid == target.pid and window.window_id == target.window_id
+            ),
+            None,
+        )
+        if current is None:
+            raise CuaTestError(
+                f"{operation} could not find target window {target.window_id} "
+                f"for pid {target.pid}"
+            )
+        if current.is_on_screen is False:
+            return current
+        if current.z_index is None:
+            raise CuaTestError(
+                f"{operation} cannot verify target window order because z_index is missing"
+            )
+
+        active_windows = [
+            window
+            for window in windows
+            if window.pid == active_pid
+            and window.is_on_screen is not False
+            and window.z_index is not None
+            and window.frame is not None
+        ]
+        if not active_windows:
+            raise CuaTestError(
+                f"{operation} cannot verify window order because active pid "
+                f"{active_pid} has no visible window"
+            )
+        if current.frame is None:
+            raise CuaTestError(
+                f"{operation} cannot verify target window order because bounds are missing"
+            )
+        active_z_index = max(
+            window.z_index for window in active_windows if window.z_index is not None
+        )
+        if current.z_index >= active_z_index:
+            raise CuaWindowOrderViolation(
+                f"{operation} raised target window {target.window_id} above the "
+                f"active application's visible windows"
+            )
+        return current
+
+    async def _secondary_display(self) -> DisplaySnapshot | None:
+        topology_driver = self._owner_driver or self._driver
+        result = await topology_driver.call_tool("get_screen_size", "{}")
+        if result.is_error:
+            raise CuaToolError("get_screen_size", result.text, result.error_code)
+        data = _structured(result)
+        if "displays" not in data:
+            raise CuaTestError(
+                "Cua Driver does not expose display geometry required for safe test placement"
+            )
+        value = data["displays"]
+        if not isinstance(value, list):
+            raise CuaTestError("get_screen_size returned a non-array displays field")
+        displays = [
+            display
+            for raw in value
+            if isinstance(raw, dict)
+            for display in [_display_from(raw)]
+            if display is not None
+        ]
+        if not displays:
+            raise CuaTestError("Cua Driver reported no usable displays")
+        main = next((display for display in displays if display.is_main), None)
+        candidates = [
+            display
+            for display in displays
+            if not display.is_main
+            and not display.is_mirrored
+            and (main is None or display.frame != main.frame)
+        ]
+        if not candidates:
+            return None
+        return min(
+            candidates,
+            key=lambda display: (
+                not display.is_builtin,
+                -(display.frame.width * display.frame.height),
+                display.display_id,
+            ),
+        )
+
+    async def _wait_for_window(
+        self,
+        pid: int,
+        title: str | None,
+        timeout: float,
+        window_id: int | None = None,
+    ) -> WindowSnapshot:
+        deadline = asyncio.get_running_loop().time() + timeout
+        while True:
+            windows = await self._list_windows(pid)
+            if window_id is not None:
+                selected = next(
+                    (item for item in windows if item.window_id == window_id),
+                    None,
+                )
+            else:
+                selected = self._select_window(windows, title)
+            if selected is not None:
+                return selected
+            if asyncio.get_running_loop().time() >= deadline:
+                target = f"window_id={window_id}" if window_id is not None else f"title={title!r}"
+                raise CuaWaitTimeout(
+                    f"pid {pid} did not publish a matching window within {timeout:.2f}s ({target})"
+                )
+            await asyncio.sleep(0.1)
+
+    def _windows_from(self, value: Any) -> list[WindowSnapshot]:
+        if not isinstance(value, list):
+            return []
+        windows = []
+        for raw in value:
+            if not isinstance(raw, dict):
+                continue
+            try:
+                windows.append(
+                    WindowSnapshot(
+                        pid=int(raw["pid"]),
+                        window_id=int(raw["window_id"]),
+                        title=str(raw.get("title", "")),
+                        app_name=str(raw.get("app_name", raw.get("name", ""))),
+                        is_on_screen=_optional_bool(raw.get("is_on_screen")),
+                        frame=_parse_frame(raw.get("bounds")),
+                        z_index=_optional_int(raw.get("z_index")),
+                    )
+                )
+            except (KeyError, TypeError, ValueError):
+                continue
+        return windows
+
+    def _select_window(
+        self,
+        windows: Sequence[WindowSnapshot],
+        title: str | None,
+    ) -> WindowSnapshot | None:
+        if title is not None:
+            return next((window for window in windows if window.title == title), None)
+        return windows[0] if windows else None
+
+    async def _capture(
+        self,
+        app: CuaApplication,
+        name: str,
+    ) -> ArtifactBundle | None:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+        directory = self._artifacts_dir / f"{timestamp}-{_slug(name)}"
+        directory.mkdir(parents=True, exist_ok=False)
+        screenshot = directory / "window.png"
+        try:
+            result = await self._call(
+                "get_window_state",
+                {
+                    "pid": app.pid,
+                    "window_id": app.window_id,
+                    "include_screenshot": True,
+                    "screenshot_out_file": str(screenshot),
+                },
+            )
+        except CuaToolError as error:
+            (directory / "capture-error.txt").write_text(str(error), encoding="utf-8")
+            return None
+        data = _structured(result)
+        tree_path = directory / "tree.txt"
+        structured_path = directory / "snapshot.json"
+        tree_path.write_text(str(data.get("tree_markdown", result.text)), encoding="utf-8")
+        structured_path.write_text(
+            json.dumps(data, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        screenshot_path: Path | None = screenshot if screenshot.exists() else None
+        if screenshot_path is None and result.images:
+            first_image = result.images[0]
+            if first_image.mime_type == "image/png":
+                screenshot.write_bytes(base64.b64decode(first_image.data_base64))
+                screenshot_path = screenshot
+        return ArtifactBundle(directory, tree_path, structured_path, screenshot_path)
+
+
+def _optional_string(value: Any) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _optional_bool(value: Any) -> bool | None:
+    return value if isinstance(value, bool) else None
+
+
+def _optional_int(value: Any) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _parse_frame(value: Any) -> Frame | None:
+    if not isinstance(value, dict):
+        return None
+    try:
+        return Frame(
+            x=float(value.get("x", 0)),
+            y=float(value.get("y", 0)),
+            width=float(value.get("w", value.get("width", 0))),
+            height=float(value.get("h", value.get("height", 0))),
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def _display_from(value: dict[str, Any]) -> DisplaySnapshot | None:
+    frame = _parse_frame(value.get("bounds"))
+    try:
+        display_id = int(value["display_id"])
+        scale_factor = float(value.get("scale_factor", 1))
+    except (KeyError, TypeError, ValueError):
+        return None
+    if frame is None or frame.width <= 0 or frame.height <= 0:
+        return None
+    return DisplaySnapshot(
+        display_id=display_id,
+        frame=frame,
+        scale_factor=scale_factor,
+        is_main=value.get("is_main") is True,
+        is_builtin=value.get("is_builtin") is True,
+        is_mirrored=value.get("is_mirrored") is True,
+    )
+
+
+def _placement_origin(window: Frame, display: Frame, margin: float = 24.0) -> tuple[float, float]:
+    def centered(start: float, available: float, length: float) -> float:
+        if length + margin * 2 > available:
+            return start
+        desired = start + (available - length) / 2
+        return min(
+            max(desired, start + margin),
+            start + available - length - margin,
+        )
+
+    return (
+        centered(display.x, display.width, window.width),
+        centered(display.y, display.height, window.height),
+    )
+
+
+def _frame_center_is_inside(frame: Frame, display: Frame) -> bool:
+    center_x = frame.x + frame.width / 2
+    center_y = frame.y + frame.height / 2
+    return (
+        display.x <= center_x <= display.x + display.width
+        and display.y <= center_y <= display.y + display.height
+    )
+
+
+__all__ = [
+    "AppSnapshot",
+    "ArtifactBundle",
+    "CuaApplication",
+    "CuaElement",
+    "CuaForegroundViolation",
+    "CuaQueryError",
+    "CuaTestError",
+    "CuaTestSession",
+    "CuaToolError",
+    "CuaWaitTimeout",
+    "CuaWindowOrderViolation",
+    "DisplaySnapshot",
+    "DriverLike",
+    "ElementCollection",
+    "ElementSnapshot",
+    "Frame",
+    "PlacementPolicy",
+    "WindowSnapshot",
+]

--- a/libs/cua-driver/python/tests/test_testing.py
+++ b/libs/cua-driver/python/tests/test_testing.py
@@ -1,0 +1,553 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+MODULE_PATH = Path(__file__).parents[1] / "src" / "cua_driver" / "testing.py"
+SPEC = importlib.util.spec_from_file_location("cua_driver_testing", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+testing = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = testing
+SPEC.loader.exec_module(testing)
+
+
+@dataclass
+class FakeImage:
+    mime_type: str = "image/png"
+    data_base64: str = "iVBORw0KGgo="
+
+
+@dataclass
+class FakeResult:
+    text: str = "ok"
+    structured_json: str | None = None
+    is_error: bool = False
+    error_code: str | None = None
+    images: list[FakeImage] = field(default_factory=list)
+
+
+class FakeDriver:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.active_pid = 41
+        self.target_pid = 99
+        self.window_id = 700
+        self.window_x = 100.0
+        self.window_y = 100.0
+        self.target_on_screen = False
+        self.target_z_index = 1
+        self.counter = 0
+        self.value = ""
+        self.steal_on: str | None = None
+        self.raise_on: str | None = None
+        self.fail_on: str | None = None
+        self.hide_active = False
+        self.shutdown_called = False
+        self.initial_placement_verified = True
+
+    async def call_tool(self, name: str, arguments_json: str) -> FakeResult:
+        arguments = json.loads(arguments_json)
+        self.calls.append((name, arguments))
+        if name == self.fail_on:
+            return FakeResult(
+                text="fixture refusal",
+                is_error=True,
+                error_code="fixture_refusal",
+            )
+        if name == "get_frontmost_app":
+            return self._result(
+                {} if self.hide_active else {"pid": self.active_pid, "name": "Foreground"}
+            )
+        if name == "list_apps":
+            return self._result(
+                {
+                    "apps": (
+                        []
+                        if self.hide_active
+                        else [
+                            {
+                                "pid": self.active_pid,
+                                "name": "Foreground",
+                                "active": True,
+                            }
+                        ]
+                    )
+                }
+            )
+        if name == "launch_app":
+            initial_position = arguments.get("initial_window_position")
+            initial_placement = None
+            if isinstance(initial_position, dict):
+                before = self._bounds()
+                self.window_x = float(initial_position["x"])
+                self.window_y = float(initial_position["y"])
+                initial_placement = {
+                    "window_id": self.window_id,
+                    "requested_position": initial_position,
+                    "before_bounds": before,
+                    "after_bounds": self._bounds(),
+                    "verified": self.initial_placement_verified,
+                    "activated": False,
+                }
+            return self._result(
+                {
+                    "pid": self.target_pid,
+                    "bundle_id": "com.example.Counter",
+                    "name": "Counter",
+                    "self_activation_suppressed": True,
+                    "windows": [self._window()],
+                    "initial_window_placement": initial_placement,
+                }
+            )
+        if name == "list_windows":
+            pid = arguments.get("pid")
+            windows = [self._window()]
+            if pid is None and self.active_pid != self.target_pid:
+                windows.append(self._active_window())
+            elif pid == self.active_pid and self.active_pid != self.target_pid:
+                windows = [self._active_window()]
+            return self._result({"windows": windows})
+        if name == "get_screen_size":
+            return self._result(
+                {
+                    "width": 1920,
+                    "height": 1080,
+                    "scale_factor": 2,
+                    "displays": [
+                        {
+                            "display_id": 1,
+                            "bounds": {
+                                "x": 0,
+                                "y": 0,
+                                "width": 1920,
+                                "height": 1080,
+                            },
+                            "scale_factor": 2,
+                            "is_main": True,
+                            "is_builtin": False,
+                            "is_mirrored": False,
+                        },
+                        {
+                            "display_id": 2,
+                            "bounds": {
+                                "x": 1920,
+                                "y": 0,
+                                "width": 1280,
+                                "height": 1024,
+                            },
+                            "scale_factor": 2,
+                            "is_main": False,
+                            "is_builtin": True,
+                            "is_mirrored": False,
+                        },
+                    ],
+                }
+            )
+        if name == "move_window":
+            before = self._bounds()
+            self.window_x = float(arguments["x"])
+            self.window_y = float(arguments["y"])
+            return self._result(
+                {
+                    "before_bounds": before,
+                    "after_bounds": self._bounds(),
+                    "verified": True,
+                    "activated": False,
+                }
+            )
+        if name == "get_window_state":
+            return self._snapshot(arguments)
+        if name == "click":
+            self.counter += 1
+        if name in {"type_text", "set_value"}:
+            self.value = arguments.get("text", arguments.get("value", ""))
+        if name == self.steal_on:
+            self.active_pid = self.target_pid
+        if name == self.raise_on:
+            self.target_on_screen = True
+            self.target_z_index = 3
+        return self._result({"verified": True})
+
+    async def shutdown(self) -> None:
+        self.shutdown_called = True
+
+    def _window(self) -> dict[str, Any]:
+        return {
+            "pid": self.target_pid,
+            "window_id": self.window_id,
+            "title": "Counter",
+            "app_name": "Counter",
+            "is_on_screen": self.target_on_screen,
+            "bounds": self._bounds(),
+            "z_index": self.target_z_index,
+        }
+
+    def _active_window(self) -> dict[str, Any]:
+        return {
+            "pid": self.active_pid,
+            "window_id": 701,
+            "title": "Foreground",
+            "app_name": "Foreground",
+            "is_on_screen": True,
+            "bounds": {
+                "x": 50,
+                "y": 50,
+                "width": 1200,
+                "height": 900,
+            },
+            "z_index": 2,
+        }
+
+    def _bounds(self) -> dict[str, float]:
+        return {
+            "x": self.window_x,
+            "y": self.window_y,
+            "width": 700,
+            "height": 860,
+        }
+
+    def _snapshot(self, arguments: dict[str, Any]) -> FakeResult:
+        tree = (
+            '- [0] AXWindow "Counter" [id=counter-window]\n'
+            '  - [1] AXButton "Increment" [id=btn-increment actions=[press]]\n'
+            f'  - AXStaticText "counter={self.counter}"\n'
+            '  - [2] AXTextField "Input" = '
+            f'"{self.value}" [id=txt-input actions=[setvalue]]\n'
+        )
+        data = {
+            "pid": self.target_pid,
+            "window_id": self.window_id,
+            "tree_markdown": tree,
+            "elements": [
+                {
+                    "element_index": 0,
+                    "element_token": "snapshot:0",
+                    "role": "AXWindow",
+                    "label": "Counter",
+                    "identifier": "counter-window",
+                },
+                {
+                    "element_index": 1,
+                    "element_token": "snapshot:1",
+                    "role": "AXButton",
+                    "label": "Increment",
+                    # Omit the structured identifier to exercise the markdown
+                    # fallback used with older Cua Driver releases.
+                },
+                {
+                    "element_index": 2,
+                    "element_token": "snapshot:2",
+                    "role": "AXTextField",
+                    "label": "Input",
+                    "value": self.value,
+                },
+            ],
+        }
+        images = []
+        if arguments.get("include_screenshot"):
+            images = [FakeImage()]
+        return self._result(data, images)
+
+    @staticmethod
+    def _result(
+        structured: dict[str, Any],
+        images: list[FakeImage] | None = None,
+    ) -> FakeResult:
+        return FakeResult(
+            structured_json=json.dumps(structured),
+            images=images or [],
+        )
+
+
+def run(coroutine: Any) -> Any:
+    return asyncio.run(coroutine)
+
+
+def test_launch_tap_and_assert_text_without_foreground_delivery(tmp_path: Path) -> None:
+    driver = FakeDriver()
+
+    async def scenario() -> None:
+        async with testing.CuaTestSession(
+            driver,
+            artifacts_dir=tmp_path,
+            owns_driver=True,
+        ) as session:
+            app = await session.launch(bundle_id="com.example.Counter")
+            assert app.window.is_on_screen is False
+            assert app.window.frame is not None
+            assert app.window.frame.x >= 1920
+            assert await app.buttons.by_id("btn-increment").exists()
+            await app.buttons["Increment"].tap()
+            await app.wait_for_text("counter=1")
+
+    run(scenario())
+
+    launch = next(arguments for name, arguments in driver.calls if name == "launch_app")
+    click = next(arguments for name, arguments in driver.calls if name == "click")
+    moved = next(arguments for name, arguments in driver.calls if name == "move_window")
+    assert launch["creates_new_application_instance"] is True
+    assert launch["initial_window_position"]["x"] >= 1920
+    assert "title" not in launch["initial_window_position"]
+    assert moved["x"] >= 1920
+    assert driver.calls.index(("move_window", moved)) < driver.calls.index(("click", click))
+    assert click["pid"] == driver.target_pid
+    assert click["window_id"] == driver.window_id
+    assert click["element_token"] == "snapshot:1"
+    assert click["delivery_mode"] == "background"
+    assert "x" not in click and "y" not in click
+    assert not any(name == "bring_to_front" for name, _ in driver.calls)
+    assert any(name == "kill_app" for name, _ in driver.calls)
+    assert driver.shutdown_called
+
+
+def test_text_input_is_element_scoped_and_background_only(tmp_path: Path) -> None:
+    driver = FakeDriver()
+
+    async def scenario() -> None:
+        session = testing.CuaTestSession(driver, artifacts_dir=tmp_path)
+        app = await session.launch(bundle_id="com.example.Counter")
+        field = app.text_fields.by_id("txt-input")
+        await field.type_text("hello")
+        await field.wait_for_value("hello")
+        await session.close()
+
+    run(scenario())
+    typed = next(arguments for name, arguments in driver.calls if name == "type_text")
+    assert typed["text"] == "hello"
+    assert typed["element_token"] == "snapshot:2"
+    assert typed["delivery_mode"] == "background"
+
+
+def test_target_activation_fails_the_background_contract(tmp_path: Path) -> None:
+    driver = FakeDriver()
+    driver.steal_on = "click"
+
+    async def scenario() -> None:
+        session = testing.CuaTestSession(driver, artifacts_dir=tmp_path)
+        app = await session.launch(bundle_id="com.example.Counter")
+        with pytest.raises(testing.CuaForegroundViolation, match="activated target pid 99"):
+            await app.buttons.by_id("btn-increment").tap()
+        await session.close()
+
+    run(scenario())
+    assert list(tmp_path.glob("*-foreground-violation/snapshot.json"))
+    assert list(tmp_path.glob("*-foreground-violation/tree.txt"))
+    assert list(tmp_path.glob("*-foreground-violation/window.png"))
+
+
+def test_window_raise_fails_the_background_contract(tmp_path: Path) -> None:
+    driver = FakeDriver()
+    driver.target_on_screen = True
+    driver.raise_on = "click"
+
+    async def scenario() -> None:
+        session = testing.CuaTestSession(
+            driver,
+            artifacts_dir=tmp_path,
+            placement="unchanged",
+        )
+        app = await session.launch(bundle_id="com.example.Counter")
+        with pytest.raises(
+            testing.CuaWindowOrderViolation,
+            match="raised target window 700 above",
+        ):
+            await app.buttons.by_id("btn-increment").tap()
+        await session.close()
+
+    run(scenario())
+    assert list(tmp_path.glob("*-foreground-violation/snapshot.json"))
+
+
+def test_window_raise_on_secondary_display_also_fails(tmp_path: Path) -> None:
+    driver = FakeDriver()
+    driver.target_on_screen = True
+    driver.raise_on = "click"
+
+    async def scenario() -> None:
+        session = testing.CuaTestSession(driver, artifacts_dir=tmp_path)
+        app = await session.launch(bundle_id="com.example.Counter")
+        assert app.window.frame is not None
+        assert app.window.frame.x >= 1920
+        with pytest.raises(
+            testing.CuaWindowOrderViolation,
+            match="above the active application's visible windows",
+        ):
+            await app.buttons.by_id("btn-increment").tap()
+        await session.close()
+
+    run(scenario())
+
+
+def test_tool_failure_writes_failure_artifacts(tmp_path: Path) -> None:
+    driver = FakeDriver()
+    driver.fail_on = "click"
+
+    async def scenario() -> None:
+        session = testing.CuaTestSession(driver, artifacts_dir=tmp_path)
+        app = await session.launch(bundle_id="com.example.Counter")
+        with pytest.raises(testing.CuaToolError, match="fixture_refusal"):
+            await app.buttons.by_id("btn-increment").tap()
+        await session.close()
+
+    run(scenario())
+    assert list(tmp_path.glob("*-click/snapshot.json"))
+
+
+def test_ambiguous_label_requires_a_stable_identifier(tmp_path: Path) -> None:
+    driver = FakeDriver()
+    original_snapshot = driver._snapshot
+
+    def duplicate_snapshot(arguments: dict[str, Any]) -> FakeResult:
+        result = original_snapshot(arguments)
+        data = json.loads(result.structured_json or "{}")
+        duplicate = dict(data["elements"][1])
+        duplicate["element_index"] = 3
+        duplicate["element_token"] = "snapshot:3"
+        data["elements"].append(duplicate)
+        return FakeResult(structured_json=json.dumps(data))
+
+    driver._snapshot = duplicate_snapshot  # type: ignore[method-assign]
+
+    async def scenario() -> None:
+        session = testing.CuaTestSession(driver, artifacts_dir=tmp_path)
+        app = await session.launch(bundle_id="com.example.Counter")
+        with pytest.raises(testing.CuaQueryError, match="matched 2 elements"):
+            await app.buttons["Increment"].tap()
+        await app.buttons.by_id("btn-increment").tap()
+        await session.close()
+
+    run(scenario())
+
+
+def test_subscript_prefers_identifier_over_the_same_label(tmp_path: Path) -> None:
+    driver = FakeDriver()
+    original_snapshot = driver._snapshot
+
+    def conflicting_snapshot(arguments: dict[str, Any]) -> FakeResult:
+        result = original_snapshot(arguments)
+        data = json.loads(result.structured_json or "{}")
+        data["elements"].append(
+            {
+                "element_index": 3,
+                "element_token": "snapshot:3",
+                "role": "AXButton",
+                "label": "Different label",
+                "identifier": "Increment",
+            }
+        )
+        return FakeResult(structured_json=json.dumps(data))
+
+    driver._snapshot = conflicting_snapshot  # type: ignore[method-assign]
+
+    async def scenario() -> None:
+        session = testing.CuaTestSession(driver, artifacts_dir=tmp_path)
+        app = await session.launch(bundle_id="com.example.Counter")
+        await app.buttons["Increment"].tap()
+        await session.close()
+
+    run(scenario())
+    click = next(arguments for name, arguments in driver.calls if name == "click")
+    assert click["element_index"] == 3
+    assert click["element_token"] == "snapshot:3"
+
+
+def test_attach_does_not_kill_a_process_it_does_not_own(tmp_path: Path) -> None:
+    driver = FakeDriver()
+
+    async def scenario() -> None:
+        session = testing.CuaTestSession(driver, artifacts_dir=tmp_path)
+        app = await session.attach(driver.target_pid, window_id=driver.window_id)
+        assert await app.buttons.by_id("btn-increment").exists()
+        await session.close()
+
+    run(scenario())
+    assert not any(name == "kill_app" for name, _ in driver.calls)
+
+
+def test_placement_can_be_explicitly_left_unchanged(tmp_path: Path) -> None:
+    driver = FakeDriver()
+
+    async def scenario() -> None:
+        session = testing.CuaTestSession(
+            driver,
+            artifacts_dir=tmp_path,
+            placement="unchanged",
+        )
+        app = await session.attach(driver.target_pid, window_id=driver.window_id)
+        assert app.window.frame == testing.Frame(100, 100, 700, 860)
+        await session.close()
+
+    run(scenario())
+    assert not any(name == "move_window" for name, _ in driver.calls)
+
+
+def test_unverified_early_placement_fails_and_cleans_up(tmp_path: Path) -> None:
+    driver = FakeDriver()
+    driver.initial_placement_verified = False
+
+    async def scenario() -> None:
+        session = testing.CuaTestSession(driver, artifacts_dir=tmp_path)
+        with pytest.raises(testing.CuaTestError, match="did not verify early placement"):
+            await session.launch(bundle_id="com.example.Counter")
+        await session.close()
+
+    run(scenario())
+    assert any(name == "kill_app" for name, _ in driver.calls)
+    assert not any(name == "move_window" for name, _ in driver.calls)
+
+
+def test_action_fails_closed_when_frontmost_app_is_unknown(tmp_path: Path) -> None:
+    driver = FakeDriver()
+
+    async def scenario() -> None:
+        session = testing.CuaTestSession(driver, artifacts_dir=tmp_path)
+        app = await session.launch(bundle_id="com.example.Counter")
+        driver.hide_active = True
+        with pytest.raises(testing.CuaTestError, match="background safety cannot be verified"):
+            await app.buttons.by_id("btn-increment").tap()
+        await session.close()
+
+    run(scenario())
+    assert not any(name == "click" for name, _ in driver.calls)
+    assert not any(name == "list_apps" for name, _ in driver.calls)
+
+
+def test_action_refuses_a_target_that_is_already_foreground(tmp_path: Path) -> None:
+    driver = FakeDriver()
+
+    async def scenario() -> None:
+        session = testing.CuaTestSession(driver, artifacts_dir=tmp_path)
+        app = await session.launch(bundle_id="com.example.Counter")
+        driver.active_pid = driver.target_pid
+        with pytest.raises(testing.CuaForegroundViolation, match="already foreground"):
+            await app.buttons.by_id("btn-increment").tap()
+        await session.close()
+
+    run(scenario())
+    assert not any(name == "click" for name, _ in driver.calls)
+    assert list(tmp_path.glob("*-target-already-foreground/snapshot.json"))
+
+
+def test_kill_failure_still_shuts_down_the_owned_driver(tmp_path: Path) -> None:
+    driver = FakeDriver()
+    driver.fail_on = "kill_app"
+
+    async def scenario() -> None:
+        session = testing.CuaTestSession(
+            driver,
+            artifacts_dir=tmp_path,
+            owns_driver=True,
+        )
+        await session.launch(bundle_id="com.example.Counter")
+        with pytest.raises(testing.CuaToolError, match="fixture_refusal"):
+            await session.close()
+
+    run(scenario())
+    assert driver.shutdown_called

--- a/libs/cua-driver/python/tests/test_testing_macos_integration.py
+++ b/libs/cua-driver/python/tests/test_testing_macos_integration.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+DRIVER_ROOT = Path(__file__).parents[2]
+NATIVE_LIBRARY = DRIVER_ROOT / "python/src/cua_driver/libcua_driver_sdk.dylib"
+HARNESS_APP = DRIVER_ROOT / "rust/test-apps/harness-appkit/CuaTestHarness.AppKit.app"
+
+pytestmark = [
+    pytest.mark.skipif(sys.platform != "darwin", reason="macOS AppKit integration"),
+    pytest.mark.skipif(
+        os.environ.get("CUA_DRIVER_RUN_MACOS_INTEGRATION") != "1",
+        reason="set CUA_DRIVER_RUN_MACOS_INTEGRATION=1 to run",
+    ),
+]
+
+
+def test_real_appkit_click_moves_to_secondary_and_keeps_frontmost_app(
+    tmp_path: Path,
+) -> None:
+    if not NATIVE_LIBRARY.exists():
+        pytest.skip("host-native Python library is not staged")
+    if not HARNESS_APP.exists():
+        pytest.skip("AppKit test app is not built")
+
+    from cua_driver.testing import CuaTestSession
+
+    async def scenario() -> None:
+        session = CuaTestSession.create(
+            artifacts_dir=tmp_path,
+        )
+        target_pid: int | None = None
+        try:
+            frontmost_before_launch = await session._require_active_pid()
+            app = await session.launch(
+                bundle_id="com.trycua.harness.appkit",
+                window_title="CuaTestHarness AppKit",
+                timeout=10,
+            )
+            target_pid = app.pid
+            assert await session._require_active_pid() == frontmost_before_launch
+            initial_placement = app.launch_metadata["initial_window_placement"]
+            assert initial_placement["verified"] is True
+            assert initial_placement["activated"] is False
+            assert app.window.frame is not None
+            assert await _frame_is_on_secondary_display(session, app.window.frame)
+            frame_before_action = app.window.frame
+            z_index_before_action = app.window.z_index
+
+            await app.wait_for_text("counter=0")
+            button = await app.buttons.by_id("btn-increment").wait_for_exists()
+            assert button.identifier == "btn-increment"
+            assert button.raw["identifier"] == "btn-increment"
+            await app.buttons.by_id("btn-increment").tap()
+            await app.wait_for_text("counter=1")
+
+            field = app.text_fields.by_id("txt-input")
+            await field.type_text("background input")
+            await field.wait_for_value("background input")
+
+            assert app.window.frame == frame_before_action
+            assert app.window.z_index is not None
+            assert z_index_before_action is not None
+            await _assert_target_stays_below_active_app(session, app.window)
+            assert await _frame_is_on_secondary_display(session, app.window.frame)
+            assert await session._require_active_pid() == frontmost_before_launch
+        finally:
+            await session.close()
+            if target_pid is not None:
+                await _wait_for_process_exit(target_pid)
+
+    async def run_with_timeout() -> None:
+        async with asyncio.timeout(30):
+            await scenario()
+
+    asyncio.run(run_with_timeout())
+
+
+async def _wait_for_process_exit(pid: int) -> None:
+    for _ in range(50):
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        await asyncio.sleep(0.02)
+    raise AssertionError(f"test app pid {pid} was not terminated")
+
+
+async def _frame_is_on_secondary_display(session: Any, frame: Any) -> bool:
+    display = await session._secondary_display()
+    if display is None:
+        return False
+    center_x = frame.x + frame.width / 2
+    center_y = frame.y + frame.height / 2
+    return (
+        display.frame.x <= center_x <= display.frame.x + display.frame.width
+        and display.frame.y <= center_y <= display.frame.y + display.frame.height
+    )
+
+
+async def _assert_target_stays_below_active_app(session: Any, target: Any) -> None:
+    active_pid = await session._require_active_pid()
+    windows = await session._list_windows()
+    active_z_indexes = [
+        window.z_index
+        for window in windows
+        if window.pid == active_pid
+        and window.is_on_screen is not False
+        and window.z_index is not None
+    ]
+    assert active_z_indexes
+    assert target.z_index is not None
+    assert target.z_index < max(active_z_indexes)

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/authorization.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/authorization.rs
@@ -212,6 +212,7 @@ const PRIVATE_OBSERVATION_OPERATIONS: &[&str] = &[
     "get_desktop_state",
     "get_accessibility_tree",
     "get_window_state",
+    "get_frontmost_app",
     "list_apps",
     "list_windows",
     "debug_window_info",
@@ -253,6 +254,8 @@ const DESKTOP_INPUT_OPERATIONS: &[&str] = &[
     "hotkey",
     "set_value",
     "bring_to_front",
+    "move_window",
+    "launch_app[with_initial_window_position]",
 ];
 const DESKTOP_INPUT_SCOPE_KEYS: &[&str] = &[
     "daemon_generation",
@@ -689,6 +692,7 @@ pub fn enforcement_adapters_for_call(
         "get_desktop_state"
             | "get_accessibility_tree"
             | "get_window_state"
+            | "get_frontmost_app"
             | "list_apps"
             | "list_windows"
             | "debug_window_info"
@@ -707,7 +711,9 @@ pub fn enforcement_adapters_for_call(
         add("private_observation");
     }
 
-    if DESKTOP_INPUT_OPERATIONS.contains(&tool) {
+    if DESKTOP_INPUT_OPERATIONS.contains(&tool)
+        || (tool == "launch_app" && args.get("initial_window_position").is_some())
+    {
         add("desktop_input");
     }
 
@@ -829,6 +835,7 @@ pub fn advertised_risk_for(tool: &str) -> RiskAssessment {
         | "set_value"
         | "launch_app"
         | "bring_to_front"
+        | "move_window"
         | "start_session"
         | "end_session"
         | "set_agent_cursor_enabled"
@@ -839,6 +846,7 @@ pub fn advertised_risk_for(tool: &str) -> RiskAssessment {
         // state. Active adapters still decide their exact resource scope at
         // the canonical registry boundary before platform dispatch.
         "zoom"
+        | "get_frontmost_app"
         | "list_apps"
         | "list_windows"
         | "debug_window_info"
@@ -883,6 +891,15 @@ pub fn advertised_risk_for(tool: &str) -> RiskAssessment {
 /// retained by the returned value.
 pub fn classify_tool_call(tool: &str, args: &Value) -> RiskAssessment {
     match tool {
+        "launch_app" => RiskAssessment {
+            class: RiskClass::R1,
+            enforcement: if args.get("initial_window_position").is_some() {
+                RiskEnforcement::Active
+            } else {
+                RiskEnforcement::MetadataOnly
+            },
+            operation_sensitive: true,
+        },
         "browser_prepare" => {
             let existing =
                 args.pointer("/strategy/kind").and_then(Value::as_str) == Some("existing_profile");
@@ -946,6 +963,7 @@ pub fn classify_tool_call(tool: &str, args: &Value) -> RiskAssessment {
             operation_sensitive: true,
         },
         "get_accessibility_tree"
+        | "get_frontmost_app"
         | "list_apps"
         | "list_windows"
         | "debug_window_info"
@@ -1111,6 +1129,7 @@ fn enforce_hard_invariants(
             | "set_value"
             | "kill_app"
             | "bring_to_front"
+            | "move_window"
             | "get_accessibility_tree"
             | "get_window_state"
             | "page"
@@ -1659,6 +1678,16 @@ mod tests {
         );
         assert_eq!(
             ids("type_text_chars", serde_json::json!({})),
+            vec!["desktop_input"]
+        );
+        assert!(ids("launch_app", serde_json::json!({})).is_empty());
+        assert_eq!(
+            ids(
+                "launch_app",
+                serde_json::json!({
+                    "initial_window_position": {"x": 10, "y": 20}
+                })
+            ),
             vec!["desktop_input"]
         );
         assert_eq!(

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -161,8 +161,8 @@ impl ToolDef {
 ///   `accessibility.tree.bounded`, `accessibility.window_state`,
 ///   `accessibility.element_tokens` (Surface 6 — tool accepts the
 ///   opaque `element_token` arg alongside the integer `element_index`)
-/// - `app.launch`, `app.list`, `app.kill`, `window.list`,
-///   `window.activate`, `window.debug_info`
+/// - `app.launch`, `app.frontmost`, `app.list`, `app.kill`, `window.list`,
+///   `window.activate`, `window.move`, `window.debug_info`
 /// - `system.permissions.tcc`,
 ///   `system.permissions.tcc.accessibility`,
 ///   `system.permissions.tcc.screen_recording`
@@ -265,10 +265,12 @@ pub fn default_capabilities_for(tool_name: &str) -> Vec<String> {
 
         // ── apps / windows ───────────────────────────────────────────
         "launch_app" => &["app.launch"],
+        "get_frontmost_app" => &["app.frontmost"],
         "list_apps" => &["app.list"],
         "kill_app" => &["app.kill"],
         "list_windows" => &["window.list"],
         "bring_to_front" => &["window.activate"],
+        "move_window" => &["window.move"],
         "debug_window_info" => &["window.debug_info"],
 
         // ── permissions / config ─────────────────────────────────────
@@ -347,6 +349,13 @@ pub fn advertised_capabilities_for(tool_name: &str, input_schema: &Value) -> Vec
             .any(|capability| capability == "input.delivery_mode")
     {
         capabilities.push("input.delivery_mode".into());
+    }
+    let accepts_initial_window_position = tool_name == "launch_app"
+        && input_schema
+            .pointer("/properties/initial_window_position")
+            .is_some_and(Value::is_object);
+    if accepts_initial_window_position {
+        capabilities.push("window.move".into());
     }
     capabilities
 }
@@ -3734,10 +3743,12 @@ mod capability_tests {
         "get_window_state",
         // app / window
         "launch_app",
+        "get_frontmost_app",
         "list_apps",
         "kill_app",
         "list_windows",
         "bring_to_front",
+        "move_window",
         "debug_window_info",
         // permissions / config
         "check_permissions",
@@ -3811,10 +3822,12 @@ mod capability_tests {
         "accessibility.element_tokens",
         // app / window
         "app.launch",
+        "app.frontmost",
         "app.list",
         "app.kill",
         "window.list",
         "window.activate",
+        "window.move",
         "window.debug_info",
         // permissions
         "system.permissions.tcc",
@@ -3925,6 +3938,28 @@ mod capability_tests {
             !advertised_capabilities_for("press_key", &without_delivery_mode)
                 .iter()
                 .any(|capability| capability == "input.delivery_mode")
+        );
+    }
+
+    #[test]
+    fn launch_window_move_capability_is_derived_from_the_runtime_schema() {
+        let with_initial_position = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "initial_window_position": {"type": "object"}
+            }
+        });
+        let without_initial_position = serde_json::json!({"type": "object", "properties": {}});
+
+        assert!(
+            advertised_capabilities_for("launch_app", &with_initial_position)
+                .iter()
+                .any(|capability| capability == "window.move")
+        );
+        assert!(
+            !advertised_capabilities_for("launch_app", &without_initial_position)
+                .iter()
+                .any(|capability| capability == "window.move")
         );
     }
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/ax/bindings.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/ax/bindings.rs
@@ -111,12 +111,40 @@ pub unsafe fn element_at_screen_position(pid: i32, x: f64, y: f64) -> Option<AXU
 // ── AXValue functions ────────────────────────────────────────────────────────
 #[link(name = "ApplicationServices", kind = "framework")]
 extern "C" {
+    pub fn AXValueCreate(the_type: AXValueType, value_ptr: *const c_void) -> AXValueRef;
     pub fn AXValueGetType(value: AXValueRef) -> AXValueType;
     pub fn AXValueGetValue(
         value: AXValueRef,
         the_type: AXValueType,
         value_ptr: *mut c_void,
     ) -> bool;
+}
+
+/// Set a CGPoint-valued AX attribute.
+///
+/// # Safety
+///
+/// `element` must be a valid, live `AXUIElementRef` for the duration of the call.
+pub unsafe fn set_point_attr(element: AXUIElementRef, attr_name: &str, x: f64, y: f64) -> AXError {
+    #[repr(C)]
+    struct CGPoint {
+        x: f64,
+        y: f64,
+    }
+
+    let point = CGPoint { x, y };
+    let value = AXValueCreate(
+        kAXValueCGPointType,
+        &point as *const CGPoint as *const c_void,
+    );
+    if value.is_null() {
+        return kAXErrorFailure;
+    }
+    let attr = CFStr::new(attr_name);
+    let error =
+        AXUIElementSetAttributeValue(element, attr.as_concrete_TypeRef(), value as CFTypeRef);
+    CFRelease(value as CFTypeRef);
+    error
 }
 
 // ── Helper functions ──────────────────────────────────────────────────────────

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/get_frontmost_app.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/get_frontmost_app.rs
@@ -1,0 +1,84 @@
+use async_trait::async_trait;
+use cua_driver_core::{
+    protocol::ToolResult,
+    tool::{Tool, ToolDef},
+};
+use serde_json::Value;
+
+pub struct GetFrontmostAppTool;
+
+static DEF: std::sync::OnceLock<ToolDef> = std::sync::OnceLock::new();
+
+fn def() -> &'static ToolDef {
+    DEF.get_or_init(|| ToolDef {
+        name: "get_frontmost_app".into(),
+        description:
+            "Return the current frontmost macOS application's pid, name, and bundle identifier. \
+             This reads NSWorkspace directly and does not scan installed applications."
+                .into(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        }),
+        read_only: true,
+        destructive: false,
+        idempotent: true,
+        open_world: false,
+    })
+}
+
+#[async_trait]
+impl Tool for GetFrontmostAppTool {
+    fn def(&self) -> &ToolDef {
+        def()
+    }
+
+    async fn invoke(&self, _args: Value) -> ToolResult {
+        use objc2_app_kit::NSWorkspace;
+
+        let Some(app) = (unsafe { NSWorkspace::sharedWorkspace().frontmostApplication() }) else {
+            return ToolResult::error("macOS did not report a frontmost application");
+        };
+        let pid = unsafe { app.processIdentifier() };
+        if pid <= 0 {
+            return ToolResult::error("macOS reported an invalid frontmost application pid");
+        }
+        let name = unsafe {
+            app.localizedName()
+                .map(|value| value.to_string())
+                .unwrap_or_default()
+        };
+        let bundle_id = unsafe { app.bundleIdentifier().map(|value| value.to_string()) };
+
+        ToolResult::text(format!("Frontmost application: {name} (pid {pid})")).with_structured(
+            serde_json::json!({
+                "pid": pid,
+                "name": name,
+                "bundle_id": bundle_id,
+            }),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn definition_is_read_only_and_accepts_no_target() {
+        let definition = def();
+        assert!(definition.read_only);
+        assert!(!definition.destructive);
+        assert!(definition.idempotent);
+        assert!(!definition.open_world);
+        assert_eq!(
+            definition.input_schema["additionalProperties"],
+            serde_json::json!(false)
+        );
+        assert!(definition.input_schema["properties"]
+            .as_object()
+            .unwrap()
+            .is_empty());
+    }
+}

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/get_screen_size.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/get_screen_size.rs
@@ -13,11 +13,11 @@ static DEF: std::sync::OnceLock<ToolDef> = std::sync::OnceLock::new();
 
 fn def() -> &'static ToolDef {
     DEF.get_or_init(|| ToolDef {
-        // Matches `GetScreenSizeTool.swift` description verbatim.
         name: "get_screen_size".into(),
-        description: "Return the logical size of the main display in points plus its backing \
-            scale factor. Agents click in points; Retina displays have scale_factor 2.0. \
-            Requires no TCC permissions."
+        description: "Return every active display's global logical bounds, backing scale, and \
+            main/built-in/mirroring state. Top-level width, height, and scale_factor retain the \
+            main-display contract. Agents click in logical points; Retina displays commonly \
+            have scale_factor 2.0. Requires no TCC permissions."
             .into(),
         input_schema: serde_json::json!({"type":"object","properties":{
             "session": cua_driver_core::tool_schema::session_schema()
@@ -39,42 +39,107 @@ impl Tool for GetScreenSizeTool {
         if let Err(result) = parse_typed_input::<GetScreenSizeInput>("get_screen_size", args) {
             return result;
         }
-        match main_screen_size() {
-            Some((w, h, scale)) => {
-                // Matches Swift text format 1:1.
-                ToolResult::text(format!("✅ Main display: {w}x{h} points @ {scale}x"))
-                    .with_structured(serde_json::json!({
-                        "width": w, "height": h, "scale_factor": scale,
-                    }))
-            }
-            None => ToolResult::error("No main display detected."),
-        }
+        let displays = active_displays();
+        let Some(main) = displays.iter().find(|display| display.is_main) else {
+            return ToolResult::error("No main display detected.");
+        };
+        let structured_displays: Vec<Value> = displays.iter().map(display_json).collect();
+        ToolResult::text(format!(
+            "✅ {} active display(s); main display: {}x{} points @ {}x",
+            displays.len(),
+            main.width,
+            main.height,
+            main.scale_factor
+        ))
+        .with_structured(serde_json::json!({
+            "width": main.width,
+            "height": main.height,
+            "scale_factor": main.scale_factor,
+            "display_count": displays.len(),
+            "displays": structured_displays,
+        }))
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct DisplayInfo {
+    pub display_id: u32,
+    pub x: f64,
+    pub y: f64,
+    pub width: i64,
+    pub height: i64,
+    pub pixel_width: u64,
+    pub pixel_height: u64,
+    pub scale_factor: f64,
+    pub is_main: bool,
+    pub is_builtin: bool,
+    pub is_mirrored: bool,
+}
+
+pub(crate) fn active_displays() -> Vec<DisplayInfo> {
+    use core_graphics::display::{CGDisplay, CGGetActiveDisplayList};
+
+    const MAX_DISPLAYS: usize = 32;
+    let mut display_ids = [0u32; MAX_DISPLAYS];
+    let mut count = 0u32;
+    let error = unsafe {
+        CGGetActiveDisplayList(MAX_DISPLAYS as u32, display_ids.as_mut_ptr(), &mut count)
+    };
+    if error != 0 {
+        return vec![];
+    }
+
+    display_ids[..usize::try_from(count).unwrap_or(0).min(MAX_DISPLAYS)]
+        .iter()
+        .copied()
+        .filter(|display_id| *display_id != 0)
+        .map(|display_id| {
+            let display = CGDisplay::new(display_id);
+            let bounds = display.bounds();
+            let width = bounds.size.width.round() as i64;
+            let height = bounds.size.height.round() as i64;
+            DisplayInfo {
+                display_id,
+                x: bounds.origin.x,
+                y: bounds.origin.y,
+                width,
+                height,
+                pixel_width: display.pixels_wide(),
+                pixel_height: display.pixels_high(),
+                scale_factor: get_backing_scale(display_id, width),
+                is_main: display.is_main(),
+                is_builtin: display.is_builtin(),
+                is_mirrored: display.is_in_mirror_set(),
+            }
+        })
+        .collect()
+}
+
+fn display_json(display: &DisplayInfo) -> Value {
+    serde_json::json!({
+        "display_id": display.display_id,
+        "bounds": {
+            "x": display.x,
+            "y": display.y,
+            "width": display.width,
+            "height": display.height
+        },
+        "pixel_width": display.pixel_width,
+        "pixel_height": display.pixel_height,
+        "scale_factor": display.scale_factor,
+        "is_main": display.is_main,
+        "is_builtin": display.is_builtin,
+        "is_mirrored": display.is_mirrored
+    })
+}
+
 /// Returns `(width_points, height_points, backing_scale_factor)` from
-/// CoreGraphics — safe to call from any thread (no AppKit main-thread requirement).
-///
-/// The previous NSScreen-based implementation required `MainThreadMarker::new()`
-/// which always returns `None` on async tokio threads, causing the tool to
-/// return an error even when a display is attached.
+/// CoreGraphics, safe to call from any thread.
 pub(crate) fn main_screen_size() -> Option<(i64, i64, f64)> {
-    use core_graphics::display::{CGDisplayBounds, CGMainDisplayID};
-
-    // SAFETY: CGMainDisplayID / CGDisplayBounds are thread-safe CG APIs.
-    let display_id = unsafe { CGMainDisplayID() };
-    if display_id == 0 {
-        return None;
-    }
-    let bounds = unsafe { CGDisplayBounds(display_id) };
-    let w = bounds.size.width as i64;
-    let h = bounds.size.height as i64;
-    if w == 0 || h == 0 {
-        return None;
-    }
-
-    let scale = get_backing_scale(display_id, w);
-    Some((w, h, scale))
+    active_displays()
+        .into_iter()
+        .find(|display| display.is_main)
+        .map(|display| (display.width, display.height, display.scale_factor))
 }
 
 /// Estimate backing scale by comparing the display's pixel mode width to its
@@ -88,5 +153,47 @@ pub(crate) fn get_backing_scale(display_id: u32, logical_w: i64) -> f64 {
         (ratio * 2.0).round() / 2.0
     } else {
         1.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_has_no_pid_or_window_id_and_is_read_only() {
+        let definition = def();
+        assert!(definition.read_only);
+        assert!(!definition.destructive);
+        assert!(definition.idempotent);
+        assert!(!definition.open_world);
+
+        let properties = definition.input_schema["properties"].as_object().unwrap();
+        assert!(!properties.contains_key("pid"));
+        assert!(!properties.contains_key("window_id"));
+        assert!(properties.contains_key("session"));
+    }
+
+    #[test]
+    fn display_json_preserves_global_bounds_and_identity() {
+        let display = DisplayInfo {
+            display_id: 9,
+            x: -1728.0,
+            y: 120.0,
+            width: 1728,
+            height: 1117,
+            pixel_width: 3456,
+            pixel_height: 2234,
+            scale_factor: 2.0,
+            is_main: false,
+            is_builtin: true,
+            is_mirrored: false,
+        };
+        let value = display_json(&display);
+        assert_eq!(value["display_id"], 9);
+        assert_eq!(value["bounds"]["x"], -1728.0);
+        assert_eq!(value["bounds"]["y"], 120.0);
+        assert_eq!(value["is_builtin"], true);
+        assert_eq!(value["is_main"], false);
     }
 }

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/get_window_state.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/get_window_state.rs
@@ -31,9 +31,10 @@ fn def() -> &'static ToolDef {
             INVARIANT: call get_window_state once per turn per (pid, window_id) before any \
             element-indexed action. The index map is replaced by the next snapshot.\n\n\
             PREFERRED CONSUMERS read `structuredContent.elements` (one entry per \
-            indexed row with `element_index`, `role`, `label`, `value` (the \
-            element's text/AXValue when present — use it to verify what a field \
-            holds), `frame: {x,y,w,h}`, `parent_index`, `depth`). The markdown \
+            indexed row with `element_index`, `role`, `label`, `identifier` \
+            (AXIdentifier when present), `value` (the element's text/AXValue \
+            when present, used to verify what a field holds), \
+            `frame: {x,y,w,h}`, `parent_index`, `depth`). The markdown \
             `tree_markdown` stays available \
             and unchanged in shape for existing text-parsing callers — but new \
             fields will only be added to the structured side.\n\n\
@@ -694,8 +695,8 @@ fn degradation_for(
 /// Render the actionable nodes from the AX walk into the
 /// `structuredContent.elements` array shape described on the tool: one entry
 /// per node with an `element_index`, carrying role, label (built from
-/// title/description/value/identifier), frame, parent_index, depth, and —
-/// Surface 6 — an opaque `element_token` for the same row.
+/// title/description/value/identifier), identifier, frame, parent_index, depth, and
+/// an opaque `element_token` for the same row.
 ///
 /// Order matches the markdown rendering exactly (DFS, same indices). Only
 /// nodes that received an `element_index` (i.e. are addressable via
@@ -734,6 +735,11 @@ pub(crate) fn build_elements_array_with_token(
             });
             if let Some(label) = label {
                 entry["label"] = serde_json::Value::String(label);
+            }
+            // Keep the stable AXIdentifier separate from the human-readable
+            // label so UI tests survive localization and copy edits.
+            if let Some(identifier) = node.identifier.clone().filter(|value| !value.is_empty()) {
+                entry["identifier"] = serde_json::Value::String(identifier);
             }
             // Surface the element's AXValue separately from `label`. `label`
             // collapses title→description→value→identifier into one display
@@ -1134,6 +1140,10 @@ mod tests {
             "frame must be omitted when no rect was captured"
         );
         assert!(
+            entry.get("identifier").is_none(),
+            "identifier must be omitted when AXIdentifier is unavailable"
+        );
+        assert!(
             entry.get("parent_index").is_none(),
             "parent_index must be omitted at the root"
         );
@@ -1157,6 +1167,22 @@ mod tests {
         assert_eq!(elements[0]["label"], "from-desc");
         assert_eq!(elements[1]["label"], "from-val");
         assert_eq!(elements[2]["label"], "from-id");
+    }
+
+    #[test]
+    fn elements_surface_identifier_separately_from_label() {
+        let mut nodes = vec![node(
+            Some(0),
+            "AXButton",
+            Some("Localized title"),
+            1,
+            None,
+            None,
+        )];
+        nodes[0].identifier = Some("stable.submit.button".into());
+        let entry = &build_elements_array(&nodes)[0];
+        assert_eq!(entry["label"], "Localized title");
+        assert_eq!(entry["identifier"], "stable.submit.button");
     }
 
     /// Surface 6: every element entry must carry a non-empty

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/launch_app.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/launch_app.rs
@@ -31,6 +31,10 @@ fn def() -> &'static ToolDef {
              shared instance. Without it, single-instance apps (Calculator, many utilities) hand \
              every caller the same window, so two sessions fight over it.\n\n\
              Optional `additional_arguments`: extra argv strings appended after --args.\n\n\
+             Optional `initial_window_position`: move the first matching window as soon as \
+             WindowServer publishes it, before the post-launch focus-suppression window \
+             finishes. The move uses AXPosition and does not activate or raise the app. \
+             Include `title` to require an exact window-title match.\n\n\
              Returns the launched app's pid, bundle_id, name, and a `windows` array \
              (same shape as `list_windows`) so callers can skip an extra round-trip before \
              `get_window_state(pid, window_id)`. `launch_state` distinguishes whether the \
@@ -68,6 +72,26 @@ fn def() -> &'static ToolDef {
                     "type": "array",
                     "items": { "type": "string" },
                     "description": "Extra arguments appended after --args when launching."
+                },
+                "initial_window_position": {
+                    "type": "object",
+                    "required": ["x", "y"],
+                    "properties": {
+                        "x": {
+                            "type": "number",
+                            "description": "Requested global left edge in logical points."
+                        },
+                        "y": {
+                            "type": "number",
+                            "description": "Requested global top edge in logical points."
+                        },
+                        "title": {
+                            "type": "string",
+                            "description": "Optional exact window title to wait for and move."
+                        }
+                    },
+                    "additionalProperties": false,
+                    "description": "Move the first matching window at launch without activating or raising it."
                 }
             },
             "additionalProperties": false
@@ -100,6 +124,10 @@ impl Tool for LaunchAppTool {
         let webkit_inspector_port = args.opt_u64("webkit_inspector_port").map(|v| v as u16);
         let creates_new_instance = args.bool_or("creates_new_application_instance", false);
         let additional_arguments: Vec<String> = args.str_array("additional_arguments");
+        let initial_window_position = match parse_initial_window_position(&args) {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
         if additional_arguments
             .iter()
             .any(|argument| argument == super::check_permissions::PERMISSIONS_HOST_REQUEST_ARG)
@@ -205,10 +233,11 @@ impl Tool for LaunchAppTool {
         let slow_launch_path = !urls.is_empty()
             || !additional_arguments.is_empty()
             || !env.is_empty()
-            || creates_new_instance;
+            || creates_new_instance
+            || initial_window_position.is_some();
 
         // Move the launch closure inputs into spawn_blocking. The
-        // blocking task returns (pid, app_info, windows). Suppression
+        // blocking task returns pid, app info, windows, and optional placement. Suppression
         // upgrade happens AFTER the blocking call returns (back on the
         // async runtime), then we sleep holding the targeted lease.
         let launch_result = tokio::task::spawn_blocking(move || {
@@ -247,16 +276,20 @@ impl Tool for LaunchAppTool {
                 }
             };
 
-            // Retry loop: LaunchServices returns before WindowServer has
-            // registered the new windows. Poll up to 5x100ms.
-            let windows = resolve_windows_for_pid(pid);
+            let (windows, initial_window_placement) = if let Some(request) = initial_window_position
+            {
+                let (windows, placement) = place_initial_window(pid, request);
+                (windows, Some(placement))
+            } else {
+                (resolve_windows_for_pid(pid), None)
+            };
 
             let app_info: Option<crate::apps::AppInfo> = {
                 let apps = crate::apps::list_running_apps();
                 apps.into_iter().find(|a| a.pid == pid)
             };
 
-            Ok::<_, anyhow::Error>((pid, app_info, windows))
+            Ok::<_, anyhow::Error>((pid, app_info, windows, initial_window_placement))
         })
         .await;
 
@@ -273,7 +306,7 @@ impl Tool for LaunchAppTool {
         // Surfaced in the structured response so callers can observe
         // whether focus-steal prevention actually held.
         let mut self_activation_suppressed: Option<bool> = None;
-        if let Ok(Ok((pid, _, _))) = &launch_result {
+        if let Ok(Ok((pid, _, _, _))) = &launch_result {
             if let Some(prior) = prior_frontmost {
                 if *pid != prior {
                     let targeted_lease = crate::focus_steal::FocusStealPreventer::begin_suppression(
@@ -430,7 +463,7 @@ impl Tool for LaunchAppTool {
         }
 
         match launch_result {
-            Ok(Ok((pid, app_info, windows))) => {
+            Ok(Ok((pid, app_info, windows, initial_window_placement))) => {
                 let (app_name, bid) = response_identity(
                     app_info.as_ref(),
                     response_bundle_id.as_deref(),
@@ -453,6 +486,16 @@ impl Tool for LaunchAppTool {
                     summary.push_str(&format!(
                         "\n→ Call get_window_state(pid: {pid}, window_id) to inspect."
                     ));
+                }
+                if let Some(placement) = &initial_window_placement {
+                    if placement.verified {
+                        summary.push_str("\nInitial window placement verified.");
+                    } else {
+                        summary.push_str(&format!(
+                            "\nInitial window placement was not verified: {}",
+                            placement.error.as_deref().unwrap_or("unknown error")
+                        ));
+                    }
                 }
 
                 let windows_json: Vec<Value> = windows
@@ -487,6 +530,9 @@ impl Tool for LaunchAppTool {
                 if let Some(suppressed) = self_activation_suppressed {
                     structured["self_activation_suppressed"] = serde_json::Value::Bool(suppressed);
                 }
+                if let Some(placement) = initial_window_placement {
+                    structured["initial_window_placement"] = placement.to_json();
+                }
                 ToolResult::text(summary).with_structured(structured)
             }
             Ok(Err(e)) => structured_launch_failure(&e),
@@ -514,15 +560,163 @@ fn protected_host_launch_refusal() -> ToolResult {
 
 // ── Blocking helpers ──────────────────────────────────────────────────────────
 
+#[derive(Debug, Clone, PartialEq)]
+struct InitialWindowPosition {
+    x: f64,
+    y: f64,
+    title: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct InitialWindowPlacement {
+    request: InitialWindowPosition,
+    window_id: Option<u32>,
+    before: Option<crate::windows::WindowBounds>,
+    after: Option<crate::windows::WindowBounds>,
+    verified: bool,
+    error: Option<String>,
+}
+
+impl InitialWindowPlacement {
+    fn to_json(&self) -> Value {
+        let mut value = serde_json::json!({
+            "requested_position": {
+                "x": self.request.x,
+                "y": self.request.y,
+                "title": self.request.title.clone(),
+            },
+            "verified": self.verified,
+            "activated": false,
+        });
+        if let Some(window_id) = self.window_id {
+            value["window_id"] = serde_json::json!(window_id);
+        }
+        if let Some(before) = &self.before {
+            value["before_bounds"] = window_bounds_json(before);
+        }
+        if let Some(after) = &self.after {
+            value["after_bounds"] = window_bounds_json(after);
+        }
+        if let Some(error) = &self.error {
+            value["error"] = serde_json::json!(error);
+        }
+        value
+    }
+}
+
+fn parse_initial_window_position(
+    args: &Value,
+) -> Result<Option<InitialWindowPosition>, ToolResult> {
+    let Some(value) = args.get("initial_window_position") else {
+        return Ok(None);
+    };
+    let Some(object) = value.as_object() else {
+        return Err(ToolResult::error(
+            "launch_app `initial_window_position` must be an object",
+        ));
+    };
+    let Some(x) = object
+        .get("x")
+        .and_then(Value::as_f64)
+        .filter(|x| x.is_finite())
+    else {
+        return Err(ToolResult::error(
+            "launch_app `initial_window_position.x` must be a finite number",
+        ));
+    };
+    let Some(y) = object
+        .get("y")
+        .and_then(Value::as_f64)
+        .filter(|y| y.is_finite())
+    else {
+        return Err(ToolResult::error(
+            "launch_app `initial_window_position.y` must be a finite number",
+        ));
+    };
+    let title = match object.get("title") {
+        None => None,
+        Some(Value::String(title)) if !title.is_empty() => Some(title.clone()),
+        Some(_) => {
+            return Err(ToolResult::error(
+                "launch_app `initial_window_position.title` must be a non-empty string",
+            ))
+        }
+    };
+    Ok(Some(InitialWindowPosition { x, y, title }))
+}
+
+fn place_initial_window(
+    pid: i32,
+    request: InitialWindowPosition,
+) -> (Vec<crate::windows::WindowInfo>, InitialWindowPlacement) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(2500);
+    let mut last_window = None;
+    let mut last_error = None;
+
+    loop {
+        let windows = windows_for_pid(pid);
+        let candidate = windows.iter().find(|window| match &request.title {
+            Some(title) => window.title == title.as_str(),
+            None => true,
+        });
+        if let Some(window) = candidate {
+            last_window = Some((window.window_id, window.bounds.clone()));
+            match super::move_window::move_window(pid, window.window_id, request.x, request.y) {
+                Ok((before, after)) => {
+                    return (
+                        windows_for_pid(pid),
+                        InitialWindowPlacement {
+                            request,
+                            window_id: Some(window.window_id),
+                            before: Some(before),
+                            after: Some(after),
+                            verified: true,
+                            error: None,
+                        },
+                    );
+                }
+                Err(error) => last_error = Some(error.to_string()),
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            let (window_id, before) = last_window
+                .map(|(window_id, bounds)| (Some(window_id), Some(bounds)))
+                .unwrap_or((None, None));
+            let error = last_error.unwrap_or_else(|| match &request.title {
+                Some(title) => {
+                    format!("no window with title {title:?} was ready for background placement")
+                }
+                None => "no window was ready for background placement".to_owned(),
+            });
+            return (
+                windows,
+                InitialWindowPlacement {
+                    request,
+                    window_id,
+                    before,
+                    after: None,
+                    verified: false,
+                    error: Some(error),
+                },
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+}
+
+fn windows_for_pid(pid: i32) -> Vec<crate::windows::WindowInfo> {
+    crate::windows::all_windows()
+        .into_iter()
+        .filter(|window| window.pid == pid && window.layer == 0)
+        .filter(|window| window.bounds.width > 1.0 && window.bounds.height > 1.0)
+        .collect()
+}
+
 /// Poll for the pid's layer-0 windows, retrying up to 5x100ms to absorb
 /// LaunchServices → WindowServer latency (mirrors the Swift reference).
 fn resolve_windows_for_pid(pid: i32) -> Vec<crate::windows::WindowInfo> {
     for attempt in 0..5 {
-        let found: Vec<_> = crate::windows::all_windows()
-            .into_iter()
-            .filter(|w| w.pid == pid && w.layer == 0)
-            .filter(|w| w.bounds.width > 1.0 && w.bounds.height > 1.0)
-            .collect();
+        let found = windows_for_pid(pid);
         if !found.is_empty() {
             return found;
         }
@@ -531,6 +725,15 @@ fn resolve_windows_for_pid(pid: i32) -> Vec<crate::windows::WindowInfo> {
         }
     }
     vec![]
+}
+
+fn window_bounds_json(bounds: &crate::windows::WindowBounds) -> Value {
+    serde_json::json!({
+        "x": bounds.x,
+        "y": bounds.y,
+        "width": bounds.width,
+        "height": bounds.height,
+    })
 }
 
 fn structured_launch_error(code: &str, message: String, details: serde_json::Value) -> ToolResult {
@@ -710,7 +913,8 @@ fn hex_value(byte: u8) -> Option<u8> {
 mod tests {
     use super::{
         contains_remote_debugging_flag, is_cua_driver_bundle_id, local_file_target,
-        preflight_file_urls, response_identity, structured_launch_failure, LaunchAppTool,
+        parse_initial_window_position, preflight_file_urls, response_identity,
+        structured_launch_failure, InitialWindowPosition, LaunchAppTool,
     };
     use cua_driver_core::tool::Tool;
     use serde_json::json;
@@ -726,6 +930,37 @@ mod tests {
             local_file_target("relative/path.md"),
             Some(PathBuf::from("relative/path.md"))
         );
+    }
+
+    #[test]
+    fn initial_window_position_requires_finite_coordinates_and_optional_title() {
+        assert_eq!(
+            parse_initial_window_position(&json!({
+                "initial_window_position": {
+                    "x": -1728.0,
+                    "y": 24.0,
+                    "title": "Test window",
+                }
+            }))
+            .unwrap(),
+            Some(InitialWindowPosition {
+                x: -1728.0,
+                y: 24.0,
+                title: Some("Test window".to_owned()),
+            })
+        );
+
+        let missing_y = parse_initial_window_position(&json!({
+            "initial_window_position": {"x": 10.0}
+        }))
+        .unwrap_err();
+        assert_eq!(missing_y.is_error, Some(true));
+
+        let empty_title = parse_initial_window_position(&json!({
+            "initial_window_position": {"x": 10.0, "y": 20.0, "title": ""}
+        }))
+        .unwrap_err();
+        assert_eq!(empty_title.is_error, Some(true));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
@@ -26,9 +26,11 @@ mod get_accessibility_tree;
 mod get_config;
 mod get_cursor_position;
 mod get_desktop_state;
+mod get_frontmost_app;
 pub(crate) mod get_screen_size;
 mod health_report;
 mod move_cursor;
+mod move_window;
 mod page;
 pub(crate) mod px_frame;
 mod set_config;
@@ -635,6 +637,7 @@ pub fn register_all(
     }
 
     registry.register(Box::new(list_apps::ListAppsTool));
+    registry.register(Box::new(get_frontmost_app::GetFrontmostAppTool));
     registry.register(Box::new(list_windows::ListWindowsTool));
     registry.register(Box::new(get_window_state::GetWindowStateTool::new(
         state.clone(),
@@ -642,6 +645,7 @@ pub fn register_all(
     registry.register(Box::new(launch_app::LaunchAppTool));
     registry.register(Box::new(kill_app::KillAppTool));
     registry.register(Box::new(bring_to_front::BringToFrontTool));
+    registry.register(Box::new(move_window::MoveWindowTool));
     registry.register(Box::new(click::ClickTool::new(state.clone())));
     registry.register(Box::new(double_click::DoubleClickTool::new(state.clone())));
     registry.register(Box::new(right_click::RightClickTool::new(state.clone())));

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/move_window.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/move_window.rs
@@ -1,0 +1,239 @@
+//! Background-safe macOS window placement through the Accessibility API.
+
+use async_trait::async_trait;
+use core_foundation::base::{CFRelease, CFTypeRef};
+use cua_driver_core::{
+    protocol::ToolResult,
+    tool::{Tool, ToolDef},
+};
+use serde_json::Value;
+
+use crate::{
+    ax::bindings::{
+        ax_get_window_id, copy_ax_windows, kAXErrorSuccess, set_point_attr,
+        AXUIElementCreateApplication,
+    },
+    windows::{WindowBounds, WindowOwner},
+};
+
+pub struct MoveWindowTool;
+
+static DEF: std::sync::OnceLock<ToolDef> = std::sync::OnceLock::new();
+
+fn def() -> &'static ToolDef {
+    DEF.get_or_init(|| ToolDef {
+        name: "move_window".into(),
+        description:
+            "Move one macOS window to a global screen position without activating, raising, \
+             resizing, or changing the real cursor. The target is scoped by both pid and \
+             window_id. Coordinates use the same top-left global point space as \
+             list_windows and get_screen_size.displays."
+                .into(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "required": ["pid", "window_id", "x", "y"],
+            "properties": {
+                "pid": {
+                    "type": "integer",
+                    "description": "PID that owns the target window."
+                },
+                "window_id": {
+                    "type": "integer",
+                    "description": "CGWindowID from list_windows."
+                },
+                "x": {
+                    "type": "number",
+                    "description": "Requested global left edge in logical points."
+                },
+                "y": {
+                    "type": "number",
+                    "description": "Requested global top edge in logical points."
+                }
+            },
+            "additionalProperties": false
+        }),
+        read_only: false,
+        destructive: false,
+        idempotent: true,
+        open_world: false,
+    })
+}
+
+#[async_trait]
+impl Tool for MoveWindowTool {
+    fn def(&self) -> &ToolDef {
+        def()
+    }
+
+    async fn invoke(&self, args: Value) -> ToolResult {
+        let Some(pid_value) = args.get("pid").and_then(Value::as_i64) else {
+            return ToolResult::error("move_window requires integer field `pid`");
+        };
+        let Ok(pid) = i32::try_from(pid_value) else {
+            return ToolResult::error("move_window `pid` is outside the process-id range");
+        };
+        if pid <= 0 {
+            return ToolResult::error("move_window `pid` must be positive");
+        }
+        let Some(window_value) = args.get("window_id").and_then(Value::as_u64) else {
+            return ToolResult::error("move_window requires integer field `window_id`");
+        };
+        let Ok(window_id) = u32::try_from(window_value) else {
+            return ToolResult::error("move_window `window_id` is outside the CGWindowID range");
+        };
+        let Some(x) = args
+            .get("x")
+            .and_then(Value::as_f64)
+            .filter(|v| v.is_finite())
+        else {
+            return ToolResult::error("move_window requires finite numeric field `x`");
+        };
+        let Some(y) = args
+            .get("y")
+            .and_then(Value::as_f64)
+            .filter(|v| v.is_finite())
+        else {
+            return ToolResult::error("move_window requires finite numeric field `y`");
+        };
+
+        let result = tokio::task::spawn_blocking(move || move_window(pid, window_id, x, y)).await;
+        match result {
+            Ok(Ok((before, after))) => ToolResult::text(format!(
+                "Moved window {window_id} for pid {pid} to ({:.0}, {:.0}) without activation.",
+                after.x, after.y
+            ))
+            .with_structured(serde_json::json!({
+                "pid": pid,
+                "window_id": window_id,
+                "requested_position": {"x": x, "y": y},
+                "before_bounds": bounds_json(&before),
+                "after_bounds": bounds_json(&after),
+                "verified": true,
+                "activated": false
+            })),
+            Ok(Err(error)) => {
+                ToolResult::error(error.to_string()).with_structured(serde_json::json!({
+                    "pid": pid,
+                    "window_id": window_id,
+                    "requested_position": {"x": x, "y": y},
+                    "verified": false
+                }))
+            }
+            Err(error) => ToolResult::error(format!("move_window task failed: {error}")),
+        }
+    }
+}
+
+pub(crate) fn move_window(
+    pid: i32,
+    window_id: u32,
+    x: f64,
+    y: f64,
+) -> anyhow::Result<(WindowBounds, WindowBounds)> {
+    match crate::windows::resolve_window_owner(pid, window_id) {
+        WindowOwner::SamePid => {}
+        WindowOwner::ForeignPid {
+            owner_pid,
+            owner_app_name,
+        } => anyhow::bail!(
+            "move_window refused: window {window_id} belongs to pid {owner_pid} \
+             ({owner_app_name}), not requested pid {pid}"
+        ),
+        WindowOwner::Unknown => {
+            anyhow::bail!("move_window refused: window {window_id} no longer exists")
+        }
+    }
+
+    let before = crate::windows::window_bounds_by_id(window_id)
+        .ok_or_else(|| anyhow::anyhow!("move_window could not read the current window bounds"))?;
+
+    unsafe {
+        let application = AXUIElementCreateApplication(pid);
+        if application.is_null() {
+            anyhow::bail!(
+                "move_window could not create an accessibility application for pid {pid}"
+            );
+        }
+        let windows = copy_ax_windows(application);
+        CFRelease(application as CFTypeRef);
+
+        let mut matched = false;
+        let mut set_error = None;
+        for window in windows {
+            if ax_get_window_id(window) == Some(window_id) {
+                matched = true;
+                let error = set_point_attr(window, "AXPosition", x, y);
+                if error != kAXErrorSuccess {
+                    set_error = Some(error);
+                }
+            }
+            CFRelease(window as CFTypeRef);
+        }
+        if !matched {
+            anyhow::bail!(
+                "move_window could not match window {window_id} in pid {pid}'s accessibility windows"
+            );
+        }
+        if let Some(error) = set_error {
+            anyhow::bail!("move_window AXPosition write failed with error {error}");
+        }
+    }
+
+    for _ in 0..25 {
+        if let Some(after) = crate::windows::window_bounds_by_id(window_id) {
+            if position_matches(&after, x, y) {
+                return Ok((before, after));
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    let after = crate::windows::window_bounds_by_id(window_id)
+        .ok_or_else(|| anyhow::anyhow!("move_window lost the target window after the AX write"))?;
+    anyhow::bail!(
+        "move_window was not verified: requested ({x:.1}, {y:.1}), observed ({:.1}, {:.1})",
+        after.x,
+        after.y
+    )
+}
+
+fn position_matches(bounds: &WindowBounds, x: f64, y: f64) -> bool {
+    (bounds.x - x).abs() <= 2.0 && (bounds.y - y).abs() <= 2.0
+}
+
+fn bounds_json(bounds: &WindowBounds) -> Value {
+    serde_json::json!({
+        "x": bounds.x,
+        "y": bounds.y,
+        "width": bounds.width,
+        "height": bounds.height
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_requires_exact_window_and_global_position() {
+        let definition = def();
+        assert_eq!(
+            definition.input_schema["required"],
+            serde_json::json!(["pid", "window_id", "x", "y"])
+        );
+        assert!(!definition.read_only);
+        assert!(!definition.destructive);
+        assert!(definition.idempotent);
+    }
+
+    #[test]
+    fn verification_allows_window_server_rounding_only() {
+        let bounds = WindowBounds {
+            x: 101.5,
+            y: -39.0,
+            width: 800.0,
+            height: 600.0,
+        };
+        assert!(position_matches(&bounds, 100.0, -40.0));
+        assert!(!position_matches(&bounds, 97.0, -40.0));
+    }
+}

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -28,6 +28,53 @@ fn pin_overlay_above(key: &str, hwnd: u64) {
     );
 }
 
+fn structured_uia_elements(
+    nodes: &[crate::uia::UiaNode],
+    snapshot_id: u32,
+) -> Vec<serde_json::Value> {
+    use serde_json::json;
+
+    nodes
+        .iter()
+        .filter_map(|node| {
+            let index = node.element_index?;
+            let label = node
+                .name
+                .clone()
+                .or_else(|| node.value.clone())
+                .or_else(|| node.automation_id.clone())
+                .or_else(|| node.help_text.clone());
+            let mut entry = json!({
+                "element_index": index,
+                "element_token": cua_driver_core::element_token::token_for(snapshot_id, index),
+                "role": node.control_type,
+                "depth": node.depth,
+            });
+            if let Some(label) = label {
+                entry["label"] = json!(label);
+            }
+            if let Some(identifier) = node.automation_id.clone().filter(|value| !value.is_empty()) {
+                entry["identifier"] = json!(identifier);
+            }
+            if let Some(value) = node.value.clone().filter(|value| !value.is_empty()) {
+                entry["value"] = json!(value);
+            }
+            if let Some(parent) = node.parent_element_index {
+                entry["parent_index"] = json!(parent);
+            }
+            if let Some((left, top, right, bottom)) = node.rect {
+                entry["frame"] = json!({
+                    "x": left,
+                    "y": top,
+                    "w": (right - left).max(0),
+                    "h": (bottom - top).max(0),
+                });
+            }
+            Some(entry)
+        })
+        .collect()
+}
+
 /// Resolve the screen point a coordinate action should actuate at, scrolling
 /// the target element into view first when its cached center lands off-screen.
 ///
@@ -839,8 +886,9 @@ impl Tool for GetWindowStateTool {
                 any element-indexed action against that window. The index map is replaced by \
                 the next snapshot of the same (pid, window_id).\n\n\
                 PREFERRED CONSUMERS read `structuredContent.elements` (one entry per \
-                indexed row with `element_index`, `role`, `label`, `frame: {x,y,w,h}`, \
-                `parent_index`, `depth`). The markdown `tree_markdown` stays available \
+                indexed row with `element_index`, `role`, `label`, `identifier` \
+                (UIA AutomationId when present), `frame: {x,y,w,h}`, `parent_index`, \
+                `depth`). The markdown `tree_markdown` stays available \
                 and unchanged in shape for existing text-parsing callers — but new \
                 fields will only be added to the structured side.\n\n\
                 The UIA tree walked is the window's tree (HWND-scoped); the screenshot and \
@@ -1080,55 +1128,10 @@ impl Tool for GetWindowStateTool {
 
                     // Structured `elements` array — preferred consumption
                     // path. Shape matches the cross-platform spec:
-                    // `{element_index, element_token, role, label, depth,
+                    // `{element_index, element_token, role, label, identifier, depth,
                     // parent_index?, frame?: {x,y,w,h}}`. Frame is
                     // included when UIA reported a usable BoundingRectangle.
-                    let elements: Vec<serde_json::Value> = tr
-                        .nodes
-                        .iter()
-                        .filter_map(|n| {
-                            let idx = n.element_index?;
-                            // `label`: name → value → automation_id → help_text.
-                            let label = n.name.clone()
-                                .or_else(|| n.value.clone())
-                                .or_else(|| n.automation_id.clone())
-                                .or_else(|| n.help_text.clone());
-                            let mut entry = json!({
-                                "element_index": idx,
-                                // Surface 6: opaque token paired to the
-                                // integer index. See cua-driver-core's
-                                // `element_token` module for the format
-                                // and validity contract.
-                                "element_token": cua_driver_core::element_token::token_for(snapshot_id, idx),
-                                "role": n.control_type,
-                                "depth": n.depth,
-                            });
-                            if let Some(label) = label {
-                                entry["label"] = json!(label);
-                            }
-                            // Surface the element's value separately from `label`
-                            // (which collapses name→value→automation_id→help): a
-                            // control with both a name AND text (a ValuePattern
-                            // edit holding typed content) would otherwise hide the
-                            // text from a caller reading the structured side. See
-                            // the macOS get_window_state builder for the rationale.
-                            if let Some(value) = n.value.clone().filter(|v| !v.is_empty()) {
-                                entry["value"] = json!(value);
-                            }
-                            if let Some(parent) = n.parent_element_index {
-                                entry["parent_index"] = json!(parent);
-                            }
-                            if let Some((l, t, r, b)) = n.rect {
-                                entry["frame"] = json!({
-                                    "x": l,
-                                    "y": t,
-                                    "w": (r - l).max(0),
-                                    "h": (b - t).max(0),
-                                });
-                            }
-                            Some(entry)
-                        })
-                        .collect();
+                    let elements = structured_uia_elements(&tr.nodes, snapshot_id);
                     structured["elements"] = json!(elements);
                     // Surface 6: snapshot id mirror for debug correlation.
                     structured["snapshot_id"] =
@@ -8839,6 +8842,44 @@ mod launch_focus_restore_decision_tests {
         // Empty params (validated as an error before launch dispatch) — no
         // restore needed because nothing was launched.
         assert!(!should_restore_foreground_after_launch(empty()));
+    }
+}
+
+#[cfg(test)]
+mod structured_uia_element_tests {
+    use super::structured_uia_elements;
+
+    fn node(automation_id: Option<&str>) -> crate::uia::UiaNode {
+        crate::uia::UiaNode {
+            element_index: Some(7),
+            control_type: "Button".into(),
+            name: Some("Localized title".into()),
+            value: None,
+            automation_id: automation_id.map(str::to_owned),
+            help_text: None,
+            actions: vec!["Invoke".into()],
+            element_ptr: 0,
+            center_x: 20,
+            center_y: 30,
+            rect: Some((10, 20, 30, 40)),
+            msaa_role: None,
+            depth: 1,
+            parent_element_index: Some(0),
+            in_web_content: false,
+        }
+    }
+
+    #[test]
+    fn surfaces_automation_id_separately_from_label() {
+        let elements = structured_uia_elements(&[node(Some("stable.submit.button"))], 1);
+        assert_eq!(elements[0]["label"], "Localized title");
+        assert_eq!(elements[0]["identifier"], "stable.submit.button");
+    }
+
+    #[test]
+    fn omits_identifier_when_automation_id_is_missing() {
+        let elements = structured_uia_elements(&[node(None)], 1);
+        assert!(elements[0].get("identifier").is_none());
     }
 }
 


### PR DESCRIPTION
## Summary

- Add an XCUITest-shaped Python API for app lifecycle, stable accessibility queries, polling waits, assertions, and failure artifacts.
- Launch each test app in its own Cua session and move its first window to a secondary display as soon as WindowServer publishes it, then center and verify it after launch.
- Keep actions background-only and fail closed if the target becomes active or rises above the active app's visible windows.
- Expose stable AXIdentifier and UIA AutomationId values, full display topology, the frontmost app, and nonactivating macOS window movement.

## Verification

- Python: 42 passed, 4 skipped on Python 3.12; 14 UI-layer tests passed on Python 3.10.
- Real macOS AppKit harness: launch placement, stable ID query, click, text entry, frontmost PID, window order, and process cleanup passed.
- Rust: 420 core tests and 263 macOS tests passed.
- Windows library cross-build passed.
- Generated Cua Driver reference is current.
