### PR TITLE
fix(ci): align workflow Python version with requires-python

### DIFF
--- a/.github/workflows/cd-py-agent.yml
+++ b/.github/workflows/cd-py-agent.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Update dependencies to latest versions
         id: update-deps

--- a/.github/workflows/cd-py-computer-server.yml
+++ b/.github/workflows/cd-py-computer-server.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
   publish:
     needs: prepare

--- a/.github/workflows/cd-py-computer.yml
+++ b/.github/workflows/cd-py-computer.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Update dependencies to latest versions
         id: update-deps

--- a/.github/workflows/cd-py-mcp-server.yml
+++ b/.github/workflows/cd-py-mcp-server.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Update dependencies to latest versions
         id: update-deps

--- a/.github/workflows/ci-check-docs.yml
+++ b/.github/workflows/ci-check-docs.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install Python doc dependencies
         run: pip install -r scripts/docs-generators/requirements.txt

--- a/.github/workflows/ci-test-scripts.yml
+++ b/.github/workflows/ci-test-scripts.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/py-reusable-build.yml
+++ b/.github/workflows/py-reusable-build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Create root pdm.lock file
         run: touch pdm.lock
@@ -29,7 +29,7 @@ jobs:
       - name: Install PDM
         uses: pdm-project/setup-pdm@v3
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: true
 
       - name: Initialize PDM in package directory

--- a/.github/workflows/py-reusable-publish.yml
+++ b/.github/workflows/py-reusable-publish.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Create root pdm.lock file
         run: |
@@ -60,7 +60,7 @@ jobs:
       - name: Install PDM
         uses: pdm-project/setup-pdm@v3
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: true
 
       - name: Set version

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -216,7 +216,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install bump2version
         run: pip install bump2version


### PR DESCRIPTION
## Why
Package metadata declares `requires-python` / `.python-version` as `<3.14,>=3.12`, but CI workflows still pin `python-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `python-version` pins so they satisfy `<3.14,>=3.12` (using `3.12` where a concrete pin is needed).

- `.github/workflows/cd-py-agent.yml`
  - `python-version: "3.11"` → `python-version: "3.12"`
- `.github/workflows/cd-py-computer-server.yml`
  - `python-version: "3.10"` → `python-version: "3.12"`
- `.github/workflows/cd-py-computer.yml`
  - `python-version: "3.11"` → `python-version: "3.12"`
- `.github/workflows/cd-py-mcp-server.yml`
  - `python-version: "3.11"` → `python-version: "3.12"`
- `.github/workflows/ci-check-docs.yml`
  - `python-version: "3.11"` → `python-version: "3.12"`
- `.github/workflows/ci-test-scripts.yml`
  - `python-version: "3.11"` → `python-version: "3.12"`
- `.github/workflows/py-reusable-build.yml`
  - `python-version: "3.11"` → `python-version: "3.12"`
  - `python-version: "3.11"` → `python-version: "3.12"`
- `.github/workflows/py-reusable-publish.yml`
  - `python-version: "3.11"` → `python-version: "3.12"`
  - `python-version: "3.11"` → `python-version: "3.12"`
- `.github/workflows/release-bump-version.yml`
  - `python-version: "3.11"` → `python-version: "3.12"`

## Test plan
- [ ] Package `requires-python` / `.python-version` is still `<3.14,>=3.12`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.
