### PR TITLE
fix(lume): bound stalled ARP lookups

### DIFF
--- a/libs/lume/src/Virtualization/DHCPLeaseParser.swift
+++ b/libs/lume/src/Virtualization/DHCPLeaseParser.swift
@@ -52,6 +52,7 @@ private struct DHCPLease {
 /// Parses DHCP lease files to retrieve IP addresses for VMs based on their MAC addresses
 enum DHCPLeaseParser {
     private static let leasePath = "/var/db/dhcpd_leases"
+    private static let arpTimeout: TimeInterval = 2
     
     /// Retrieves the IP address for a given MAC address.
     /// First checks vmnet's DHCP leases (for NAT mode), then falls back to the
@@ -91,22 +92,12 @@ enum DHCPLeaseParser {
     /// Used for bridged networking where the VM gets its IP from the physical
     /// network's DHCP server instead of vmnet.
     private static func getIPFromARP(forMAC macAddress: String) -> String? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/sbin/arp")
-        process.arguments = ["-an"]
-
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = Pipe()
-
-        do {
-            try process.run()
-            process.waitUntilExit()
-        } catch {
-            return nil
-        }
-
-        guard let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) else {
+        guard
+            let output = processOutput(
+                executableURL: URL(fileURLWithPath: "/usr/sbin/arp"),
+                arguments: ["-an"],
+                timeout: arpTimeout)
+        else {
             return nil
         }
 
@@ -124,6 +115,42 @@ enum DHCPLeaseParser {
         }
 
         return nil
+    }
+
+    /// Runs a small lookup process without allowing a stalled system utility to
+    /// block every VM status or clone operation indefinitely.
+    static func processOutput(
+        executableURL: URL,
+        arguments: [String],
+        timeout: TimeInterval
+    ) -> String? {
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = arguments
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while process.isRunning && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+
+        guard !process.isRunning else {
+            process.terminate()
+            return nil
+        }
+
+        return String(
+            data: pipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8)
     }
     
     /// Parses the contents of a DHCP lease file into lease entries
@@ -159,4 +186,4 @@ enum DHCPLeaseParser {
         
         return leases
     }
-} 
+}

--- a/libs/lume/tests/DHCPLeaseParserTests.swift
+++ b/libs/lume/tests/DHCPLeaseParserTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Testing
+
+@testable import lume
+
+struct DHCPLeaseParserTests {
+    @Test func processOutputReturnsCompletedCommandOutput() {
+        let output = DHCPLeaseParser.processOutput(
+            executableURL: URL(fileURLWithPath: "/bin/echo"),
+            arguments: ["reachable"],
+            timeout: 1)
+
+        #expect(output == "reachable\n")
+    }
+
+    @Test func processOutputReturnsWhenCommandStalls() {
+        let startedAt = Date()
+        let output = DHCPLeaseParser.processOutput(
+            executableURL: URL(fileURLWithPath: "/bin/sleep"),
+            arguments: ["10"],
+            timeout: 0.05)
+
+        #expect(output == nil)
+        #expect(Date().timeIntervalSince(startedAt) < 1)
+    }
+}


### PR DESCRIPTION
## Summary

- bound `/usr/sbin/arp -an` lookup time so a stalled host ARP utility cannot block VM status or clone operations indefinitely
- return the existing DHCP-lease fallback when ARP lookup does not complete
- add focused coverage for both completed and stalled child processes

## Reproduction

A stopped VM lookup during a disposable macOS certification clone remained blocked in `DHCPLeaseParser.getIPFromARP`, with the process waiting indefinitely in `Process.waitUntilExit()` while `/usr/sbin/arp -an` did not exit.

Expected: status/clone discovery remains bounded when the optional bridged-network ARP lookup stalls.

Actual: the whole operation waited indefinitely.

## Verification

- `swift test --filter DHCPLeaseParserTests`
- `swift build -c release --product lume`
- `git diff --check`
