### PR TITLE
fix(security): patch Cuabot brace expansion

### DIFF
--- a/libs/cuabot/package.json
+++ b/libs/cuabot/package.json
@@ -51,7 +51,7 @@
       "@hono/node-server": "1.19.13",
       "@modelcontextprotocol/sdk": "1.26.0",
       "ajv": "8.18.0",
-      "brace-expansion": "2.0.3",
+      "brace-expansion": "5.0.8",
       "fast-uri": "3.1.2",
       "hono": "4.12.25",
       "ip-address": "10.1.1",

--- a/libs/cuabot/pnpm-lock.yaml
+++ b/libs/cuabot/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   '@hono/node-server': 1.19.13
   '@modelcontextprotocol/sdk': 1.26.0
   ajv: 8.18.0
-  brace-expansion: 2.0.3
+  brace-expansion: 5.0.8
   fast-uri: 3.1.2
   hono: 4.12.25
   ip-address: 10.1.1
@@ -639,8 +639,9 @@ packages:
     resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -658,8 +659,9 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@2.0.3:
-    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -2125,7 +2127,7 @@ snapshots:
 
   auto-bind@5.0.1: {}
 
-  balanced-match@1.0.2:
+  balanced-match@4.0.4:
     optional: true
 
   base64-js@1.5.1: {}
@@ -2159,9 +2161,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@2.0.3:
+  brace-expansion@5.0.8:
     dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 4.0.4
     optional: true
 
   buffer@5.7.1:
@@ -2735,7 +2737,7 @@ snapshots:
 
   minimatch@9.0.7:
     dependencies:
-      brace-expansion: 2.0.3
+      brace-expansion: 5.0.8
     optional: true
 
   minimist@1.2.8: {}


### PR DESCRIPTION
## Problem
Cuabot currently forces `brace-expansion` 2.0.3. GitHub Dependabot reports two security advisories for this dependency graph, including a high alert whose patched release is in the 5.0.8 line.

## What changed
- Raise the Cuabot `brace-expansion` override to 5.0.8.
- Regenerate the Cuabot lockfile so the override and resolved `minimatch` dependency use the patched package.
- This focused draft covers the current visible alerts #881 and #1072, which share the Cuabot lock graph and require the same patched 5.0.8 resolution; it also preserves the earlier #1030 mapping for review history.

## Definition of Done
- [x] Current visible Cuabot brace-expansion alerts #881 and #1072 are mapped to this focused draft; historical #1030 coverage is retained for review context.
- [x] The lockfile resolves brace-expansion 5.0.8 and balanced-match 4.0.4, outside the reported vulnerable ranges.
- [x] The Cuabot TypeScript build passes.
- [ ] A maintainer reviews the Node 20 engine requirement introduced by brace-expansion 5.0.8 and advances this draft; this automation will not merge or mark it ready.
- [ ] GitHub closes the alerts after the reviewed fix reaches the default branch.

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts` in `libs/cuabot`.
- `pnpm run build` in `libs/cuabot`.
- `git diff --check`.

## Impact
This changes only the Cuabot dependency graph. The patched package requires Node 20 or newer; the repository's Cuabot release workflows use supported modern Node versions, but human review should confirm all published installation paths before merge.


