### PR TITLE
fix(security): patch docs tar dependency

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -47,7 +47,8 @@
   },
   "pnpm": {
     "overrides": {
-      "postcss": "8.5.10"
+      "postcss": "8.5.10",
+      "tar": "7.5.18"
     }
   }
 }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   postcss: 8.5.10
+  tar: 7.5.18
 
 importers:
 
@@ -2075,8 +2076,8 @@ packages:
     resolution: {integrity: sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==}
     engines: {node: '>=6'}
 
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+  tar@7.5.18:
+    resolution: {integrity: sha512-PwA+nJl+AzsS9hRqtNRRq8/kTdNPoOLEPXpz9WBaErNm4+TFedJyQFJLITWdsmIBnwNS/TwXf1NV5Ak1KITc8g==}
     engines: {node: '>=18'}
 
   tinyexec@1.0.2:
@@ -3020,7 +3021,7 @@ snapshots:
   '@tailwindcss/oxide@4.1.10':
     dependencies:
       detect-libc: 2.0.4
-      tar: 7.5.16
+      tar: 7.5.18
     optionalDependencies:
       '@tailwindcss/oxide-android-arm64': 4.1.10
       '@tailwindcss/oxide-darwin-arm64': 4.1.10
@@ -4337,7 +4338,7 @@ snapshots:
 
   tapable@2.2.2: {}
 
-  tar@7.5.16:
+  tar@7.5.18:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0


### PR DESCRIPTION
The documentation site was resolving `tar` 7.5.16 through Tailwind's native build dependency. GitHub Dependabot reports a security alert for that version.

- Add a focused docs override for `tar` 7.5.18.
- Regenerate the docs lockfile so the resolved package and snapshot use the patched release.
- Keep the change limited to the docs dependency graph.

## Validation

- `npx --yes pnpm@9.0.4 install --lockfile-only --ignore-scripts` from `docs/`
- `git diff --check`
- Confirmed `docs/pnpm-lock.yaml` has no `tar@7.5.16` entry.

## Definition of Done

- [x] The visible docs `tar` alert #910 is mapped to this focused draft.
- [x] The docs lock graph resolves `tar` 7.5.18, outside the reported vulnerable range.
- [ ] A human reviews and merges the draft; this automation does not advance drafts.
- [ ] GitHub closes the alert after the reviewed fix reaches the default branch.



---

This draft is a duplicate of the existing focused docs dependency draft [#2451](https://github.com/trycua/cua/pull/2451). Review #2451 instead; this PR is retained as a draft for traceability and will not be advanced by the automation.
