### PR TITLE
fix(security): patch docs js-yaml dependency

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -47,7 +47,8 @@
   },
   "pnpm": {
     "overrides": {
-      "postcss": "8.5.10"
+      "postcss": "8.5.10",
+      "js-yaml": "4.3.0"
     }
   }
 }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   postcss: 8.5.10
+  js-yaml: 4.3.0
 
 importers:
 
@@ -1543,8 +1544,8 @@ packages:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   lightningcss-darwin-arm64@1.30.1:
@@ -3340,7 +3341,7 @@ snapshots:
       esbuild: 0.25.12
       estree-util-value-to-estree: 3.5.0
       fumadocs-core: 16.0.8(@types/react@19.1.8)(lucide-react@0.525.0(react@19.2.0))(next@16.2.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       lru-cache: 11.2.2
       mdast-util-to-markdown: 2.1.2
       picocolors: 1.1.1
@@ -3501,7 +3502,7 @@ snapshots:
 
   jiti@2.4.2: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -4021,7 +4022,7 @@ snapshots:
 
   next-validate-link@1.6.6(@types/mdast@4.0.4)(@types/unist@3.0.3):
     dependencies:
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       picocolors: 1.1.1
       remark: 15.0.1
       remark-gfm: 4.0.1


### PR DESCRIPTION
The documentation site was resolving `js-yaml` 4.2.0 through its Markdown link checker. GitHub Dependabot reports a security alert for that version.

- Add a focused docs override for `js-yaml` 4.3.0.
- Regenerate the docs lockfile so all affected snapshots use the patched release.
- Keep the change limited to the docs dependency graph.

## Validation

- `npx --yes pnpm@9.0.4 install --lockfile-only --ignore-scripts` from `docs/`
- `git diff --check`
- Confirmed `docs/pnpm-lock.yaml` has no `js-yaml@4.2.0` entry.

## Definition of Done

- [x] The visible docs `js-yaml` alert #906 is mapped to this focused draft.
- [x] The docs lock graph resolves `js-yaml` 4.3.0, outside the reported vulnerable range.
- [ ] A human reviews and merges the draft; this automation does not advance drafts.
- [ ] GitHub closes the alert after the reviewed fix reaches the default branch.



---

This draft is a duplicate of the existing focused docs dependency draft [#2451](https://github.com/trycua/cua/pull/2451). Review #2451 instead; this PR is retained as a draft for traceability and will not be advanced by the automation.
