### PR TITLE
fix(security): override agent SDK Hono server

### DIFF
--- a/libs/cua-driver/examples/agent-sdks/package-lock.json
+++ b/libs/cua-driver/examples/agent-sdks/package-lock.json
@@ -632,13 +632,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
-      "license": "MIT",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.5.tgz",
+      "integrity": "sha512-yQFvDmyDo3y6rEOJZDUYPJ49DIKTPpIk4kGvm40xx4Ejne0Pu9a1+exxPN+C1UppWK/WGZX9F++/Xs231tE86g==",
       "peer": true,
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/libs/cua-driver/examples/agent-sdks/package.json
+++ b/libs/cua-driver/examples/agent-sdks/package.json
@@ -18,5 +18,8 @@
     "@types/node": "22.17.0",
     "tsx": "4.20.3",
     "typescript": "5.9.2"
+  },
+  "overrides": {
+    "@hono/node-server": "2.0.5"
   }
 }


### PR DESCRIPTION
The agent SDK examples pull `@hono/node-server` through the Model Context Protocol SDK. The lockfile currently resolves the vulnerable 1.19.14 release, while GitHub Dependabot reports 2.0.5 as the patched version.

- Add an npm override for `@hono/node-server` 2.0.5.
- Update the example lockfile to the patched package.
- Keep this change limited to the agent SDK example dependency graph.

The patched package requires Node 20 or newer. The draft stays open for a human to confirm that runtime requirement is acceptable for these examples.

## Validation

- `npx --yes npm@9.9.4 install --package-lock-only --ignore-scripts --no-audit --no-fund`
- `npm ls @hono/node-server --all --package-lock-only --json`
- `git diff --check`
- Confirmed the lockfile reports `@hono/node-server` 2.0.5 and `overridden: true`.

## Definition of Done

- [x] The visible agent SDK alert #1015 is mapped to this focused draft.
- [x] The lock graph resolves patched `@hono/node-server` 2.0.5.
- [ ] A human confirms the Node 20 requirement and reviews the draft.
- [ ] GitHub closes the alert after the reviewed fix reaches the default branch.
