### PR TITLE
fix(ci): keep ECR credentials out of pull-request builds

### DIFF
--- a/.github/workflows/docs-mcp-server-build-push.yml
+++ b/.github/workflows/docs-mcp-server-build-push.yml
@@ -30,8 +30,41 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  # Pull requests build the Docker context without any OIDC capability. The
+  # trusted release job below is the only job that can assume the ECR role.
+  pull-request-build:
+    if: github.event_name == 'pull_request'
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build only (PR)
+        uses: docker/build-push-action@v5
+        with:
+          context: ./${{ env.SERVICE_DIR }}
+          file: ./${{ env.SERVICE_DIR }}/Dockerfile
+          push: false
+          platforms: ${{ matrix.platform }}
+
+  build:
+    if: github.event_name != 'pull_request'
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -51,16 +84,6 @@ jobs:
         run: |
           TAG=$(echo "${{ matrix.platform }}" | sed 's/\//-/g')
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::296062593712:role/github-actions-ecr-push-cua
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -93,6 +116,18 @@ jobs:
           else
             echo "push=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Configure AWS credentials
+        if: steps.push-check.outputs.push == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::296062593712:role/github-actions-ecr-push-cua
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        if: steps.push-check.outputs.push == 'true'
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Build only (PR)
         if: steps.push-check.outputs.push == 'false'


### PR DESCRIPTION
## Problem

A pull request could run its Docker build inside the same job that had permission to request AWS credentials. Even though publishing was decided later, untrusted pull-request code had already reached the credentialed job.

## What changed

- Pull requests now use a separate build-only job with read-only repository access and no AWS identity permission.
- The ECR publishing job is skipped for pull requests.
- Trusted `main` and manually forced release paths keep the existing publish behavior, but request AWS identity only after the publish decision is true.
- Pull-request builds no longer write to the shared BuildKit cache.

## Definition of Done

- [x] **Pull-request builds have no AWS role or OIDC permission.** They use the unprivileged build-only job.
- [x] **ECR role assumption and login occur only on the trusted publish path.** Both happen after the push gate.
- [x] **Trusted release behavior remains available.** Main-branch and explicitly forced releases keep the existing image path.
- [x] **The draft is based on current `main`.** It was rebuilt without unrelated files.
- [x] **GitHub Actions validate the refreshed head.** All seven settled non-Vercel checks pass.
- [ ] **A maintainer reviews a real trusted publishing run.** Static and PR checks do not prove production AWS configuration.
- [ ] **A human reviews and advances the draft.** The loop will never merge, approve, enable auto-merge, or mark this ready.

## Validation

- Parsed the edited workflow as YAML and checked it with `actionlint` when available.
- `git diff --check`.
- All non-Vercel GitHub Actions checks pass on the current-main head.

## Impact

Pull requests still build the image, but cannot receive AWS/ECR credentials or write to the shared release cache. Trusted release builds retain their existing publishing path. This draft does not claim a production credentialed run.

Codex Security finding: `cua:codex-security/v1:sha256:f5adf63bd2261f7cf42783b103df8a9e9b99ac60947c146827b3bf140bdce2fc`
