### PR TITLE
fix(cua-driver): prevent Linux uinput pointer panics

### DIFF
--- a/.github/workflows/ci-rust-linux.yml
+++ b/.github/workflows/ci-rust-linux.yml
@@ -67,6 +67,13 @@ jobs:
       - name: Run Linux Rust tests
         working-directory: libs/cua-driver/rust
         run: cargo test -p cua-driver -p cua-driver-contract -p cua-driver-core -p cua-driver-testkit -p cursor-overlay -p cursor-theme-cli -p platform-linux --all-targets --locked
+      - name: Run real uinput device-name regression
+        working-directory: libs/cua-driver/rust
+        run: |
+          sudo modprobe uinput
+          test -c /dev/uinput
+          sudo chmod a+rw /dev/uinput
+          cargo test -p platform-linux real_uinput_accepts_normalized_overlong_multibyte_name --locked -- --ignored --nocapture
       - name: Compile portable GNOME/KDE portal input
         working-directory: libs/cua-driver/rust
         run: cargo check -p cua-driver --features portal-input --locked

--- a/libs/cua-driver/rust/crates/platform-linux/src/input/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/input/mod.rs
@@ -126,6 +126,10 @@ static UINPUT_POINTERS: OnceLock<Mutex<HashMap<String, Arc<Mutex<VirtualDevice>>
     OnceLock::new();
 static XLIB_THREADS_READY: OnceLock<Result<(), String>> = OnceLock::new();
 static MPX_NAME_COUNTER: AtomicU64 = AtomicU64::new(1);
+// evdev 0.12.2 asserts `name.len() + 1 < UINPUT_MAX_NAME_SIZE` while building
+// a device. Linux defines UINPUT_MAX_NAME_SIZE as 80, leaving 78 usable bytes.
+const EVDEV_UINPUT_NAME_MAX_BYTES: usize = 78;
+const UINPUT_POINTER_SUFFIX: &str = " uinput pointer";
 
 fn mpx_pointers() -> &'static Mutex<HashMap<String, MasterPointerIds>> {
     MPX_POINTERS.get_or_init(|| Mutex::new(HashMap::new()))
@@ -137,11 +141,19 @@ fn uinput_pointers() -> &'static Mutex<HashMap<String, Arc<Mutex<VirtualDevice>>
 
 fn master_pointer_name(cursor_id: &str) -> String {
     let nonce = MPX_NAME_COUNTER.fetch_add(1, Ordering::Relaxed);
-    format!("CUA {cursor_id} mp-{}-{nonce}", std::process::id())
+    let prefix = "CUA ";
+    let suffix = format!(" mp-{}-{nonce}", std::process::id());
+    let max_cursor_bytes = EVDEV_UINPUT_NAME_MAX_BYTES
+        .saturating_sub(prefix.len() + suffix.len() + UINPUT_POINTER_SUFFIX.len());
+    let mut cursor_end = cursor_id.len().min(max_cursor_bytes);
+    while !cursor_id.is_char_boundary(cursor_end) {
+        cursor_end -= 1;
+    }
+    format!("{prefix}{}{suffix}", &cursor_id[..cursor_end])
 }
 
 fn slave_pointer_name(master_name: &str) -> String {
-    format!("{master_name} uinput pointer")
+    format!("{master_name}{UINPUT_POINTER_SUFFIX}")
 }
 
 fn master_pointer_device_name(master_name: &str) -> String {
@@ -2660,8 +2672,8 @@ exit 0"#,
 #[cfg(test)]
 mod path_tests {
     use super::{
-        modifiers_to_state, path_cumulative, point_on_path, real_pointer_capabilities_available,
-        sample_function,
+        master_pointer_name, modifiers_to_state, path_cumulative, point_on_path,
+        real_pointer_capabilities_available, sample_function, slave_pointer_name,
     };
     use x11rb::protocol::xproto::KeyButMask;
 
@@ -2677,6 +2689,23 @@ mod path_tests {
             modifiers_to_state(&["control", "alt"]),
             KeyButMask::from(u16::from(KeyButMask::CONTROL) | u16::from(KeyButMask::MOD1))
         );
+    }
+
+    #[test]
+    fn slave_pointer_name_fits_evdev_uinput_limit() {
+        for cursor_id in ["m".repeat(200), "cursor-鼠".repeat(50)] {
+            let name = slave_pointer_name(&master_pointer_name(&cursor_id));
+            assert!(
+                name.len() <= 78,
+                "evdev 0.12 requires uinput names to be at most 78 bytes, got {}",
+                name.len()
+            );
+        }
+
+        let cursor_id = "same-long-cursor".repeat(20);
+        let first = slave_pointer_name(&master_pointer_name(&cursor_id));
+        let second = slave_pointer_name(&master_pointer_name(&cursor_id));
+        assert_ne!(first, second, "truncation must retain the unique nonce");
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/input/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/input/mod.rs
@@ -21,6 +21,7 @@ use evdev::{AttributeSet, EventType, InputEvent, Key, RelativeAxisType};
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::fs;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::ptr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -130,6 +131,13 @@ static MPX_NAME_COUNTER: AtomicU64 = AtomicU64::new(1);
 // a device. Linux defines UINPUT_MAX_NAME_SIZE as 80, leaving 78 usable bytes.
 const EVDEV_UINPUT_NAME_MAX_BYTES: usize = 78;
 const UINPUT_POINTER_SUFFIX: &str = " uinput pointer";
+pub const UINPUT_UNAVAILABLE_CODE: &str = "uinput_unavailable";
+
+#[derive(Debug, thiserror::Error)]
+#[error("Linux uinput pointer unavailable: {reason}")]
+struct UinputUnavailable {
+    reason: String,
+}
 
 fn mpx_pointers() -> &'static Mutex<HashMap<String, MasterPointerIds>> {
     MPX_POINTERS.get_or_init(|| Mutex::new(HashMap::new()))
@@ -145,15 +153,66 @@ fn master_pointer_name(cursor_id: &str) -> String {
     let suffix = format!(" mp-{}-{nonce}", std::process::id());
     let max_cursor_bytes = EVDEV_UINPUT_NAME_MAX_BYTES
         .saturating_sub(prefix.len() + suffix.len() + UINPUT_POINTER_SUFFIX.len());
-    let mut cursor_end = cursor_id.len().min(max_cursor_bytes);
-    while !cursor_id.is_char_boundary(cursor_end) {
-        cursor_end -= 1;
-    }
-    format!("{prefix}{}{suffix}", &cursor_id[..cursor_end])
+    let cursor_id = sanitize_device_name(cursor_id);
+    format!(
+        "{prefix}{}{suffix}",
+        truncate_utf8(&cursor_id, max_cursor_bytes)
+    )
 }
 
 fn slave_pointer_name(master_name: &str) -> String {
     format!("{master_name}{UINPUT_POINTER_SUFFIX}")
+}
+
+fn truncate_utf8(value: &str, max_bytes: usize) -> &str {
+    let mut end = value.len().min(max_bytes);
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    &value[..end]
+}
+
+fn sanitize_device_name(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| if ch.is_control() { '_' } else { ch })
+        .collect()
+}
+
+fn normalize_uinput_device_name(name: &str) -> String {
+    let sanitized = sanitize_device_name(name);
+    truncate_utf8(&sanitized, EVDEV_UINPUT_NAME_MAX_BYTES).to_owned()
+}
+
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> &str {
+    payload
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("unknown panic")
+}
+
+pub(crate) fn uinput_unavailable(reason: impl Into<String>) -> anyhow::Error {
+    UinputUnavailable {
+        reason: reason.into(),
+    }
+    .into()
+}
+
+fn guarded_uinput_creation<T>(name: &str, create: impl FnOnce(&str) -> Result<T>) -> Result<T> {
+    let name = normalize_uinput_device_name(name);
+    match catch_unwind(AssertUnwindSafe(|| create(&name))) {
+        Ok(Ok(device)) => Ok(device),
+        Ok(Err(error)) => Err(uinput_unavailable(error.to_string())),
+        Err(payload) => Err(uinput_unavailable(format!(
+            "device creation panicked: {}",
+            panic_payload_message(payload.as_ref())
+        ))),
+    }
+}
+
+pub fn is_uinput_unavailable(error: &anyhow::Error) -> bool {
+    error.downcast_ref::<UinputUnavailable>().is_some()
 }
 
 fn master_pointer_device_name(master_name: &str) -> String {
@@ -384,7 +443,13 @@ fn ensure_master_pointer(cursor_id: &str) -> Result<MasterPointerIds> {
     // inexpensive availability probe above handles the normal permission
     // denial; this ordering also prevents a race or late open failure from
     // leaking a newly created master pair.
-    let uinput_device = create_uinput_pointer(&device_name)?;
+    let uinput_device = match create_uinput_pointer(&device_name) {
+        Ok(device) => device,
+        Err(error) => {
+            unsafe { x11::xlib::XCloseDisplay(display) };
+            return Err(error);
+        }
+    };
     let mut change = x11::xinput2::XIAnyHierarchyChangeInfo::default();
     let name = CString::new(base.clone())?;
     unsafe {
@@ -493,25 +558,28 @@ pub fn forget_master_pointer(cursor_id: &str) {
 }
 
 fn create_uinput_pointer(name: &str) -> Result<VirtualDevice> {
-    let mut keys = AttributeSet::<Key>::new();
-    keys.insert(Key::BTN_LEFT);
-    keys.insert(Key::BTN_RIGHT);
-    keys.insert(Key::BTN_MIDDLE);
+    guarded_uinput_creation(name, |name| {
+        let mut keys = AttributeSet::<Key>::new();
+        keys.insert(Key::BTN_LEFT);
+        keys.insert(Key::BTN_RIGHT);
+        keys.insert(Key::BTN_MIDDLE);
 
-    let mut rel_axes = AttributeSet::<RelativeAxisType>::new();
-    rel_axes.insert(RelativeAxisType::REL_X);
-    rel_axes.insert(RelativeAxisType::REL_Y);
-    // REL_WHEEL (vertical) and REL_HWHEEL (horizontal) so the same uinput slave
-    // can also drive scroll: libinput turns these into the XI2 smooth-scroll
-    // events GTK consumes, where synthetic Button4-7 XSendEvents are dropped.
-    rel_axes.insert(RelativeAxisType::REL_WHEEL);
-    rel_axes.insert(RelativeAxisType::REL_HWHEEL);
+        let mut rel_axes = AttributeSet::<RelativeAxisType>::new();
+        rel_axes.insert(RelativeAxisType::REL_X);
+        rel_axes.insert(RelativeAxisType::REL_Y);
+        // REL_WHEEL (vertical) and REL_HWHEEL (horizontal) so the same uinput
+        // slave can also drive scroll: libinput turns these into the XI2
+        // smooth-scroll events GTK consumes, where synthetic Button4-7
+        // XSendEvents are dropped.
+        rel_axes.insert(RelativeAxisType::REL_WHEEL);
+        rel_axes.insert(RelativeAxisType::REL_HWHEEL);
 
-    Ok(evdev::uinput::VirtualDeviceBuilder::new()?
-        .name(name)
-        .with_keys(&keys)?
-        .with_relative_axes(&rel_axes)?
-        .build()?)
+        Ok(evdev::uinput::VirtualDeviceBuilder::new()?
+            .name(name)
+            .with_keys(&keys)?
+            .with_relative_axes(&rel_axes)?
+            .build()?)
+    })
 }
 
 fn wait_for_slave_pointer_id(display: *mut x11::xlib::Display, device_name: &str) -> Result<i32> {
@@ -2672,8 +2740,10 @@ exit 0"#,
 #[cfg(test)]
 mod path_tests {
     use super::{
-        master_pointer_name, modifiers_to_state, path_cumulative, point_on_path,
+        create_uinput_pointer, guarded_uinput_creation, is_uinput_unavailable, master_pointer_name,
+        modifiers_to_state, normalize_uinput_device_name, path_cumulative, point_on_path,
         real_pointer_capabilities_available, sample_function, slave_pointer_name,
+        EVDEV_UINPUT_NAME_MAX_BYTES, UINPUT_POINTER_SUFFIX,
     };
     use x11rb::protocol::xproto::KeyButMask;
 
@@ -2706,6 +2776,78 @@ mod path_tests {
         let first = slave_pointer_name(&master_pointer_name(&cursor_id));
         let second = slave_pointer_name(&master_pointer_name(&cursor_id));
         assert_ne!(first, second, "truncation must retain the unique nonce");
+        assert!(first.ends_with(UINPUT_POINTER_SUFFIX));
+        assert!(second.ends_with(UINPUT_POINTER_SUFFIX));
+    }
+
+    #[test]
+    fn uinput_name_normalization_covers_byte_boundaries_and_multibyte_text() {
+        let exact = "a".repeat(EVDEV_UINPUT_NAME_MAX_BYTES);
+        assert_eq!(normalize_uinput_device_name(&exact), exact);
+
+        let overlong_ascii = "a".repeat(EVDEV_UINPUT_NAME_MAX_BYTES + 1);
+        assert_eq!(
+            normalize_uinput_device_name(&overlong_ascii),
+            "a".repeat(EVDEV_UINPUT_NAME_MAX_BYTES)
+        );
+
+        let exact_multibyte = format!("{}鼠", "a".repeat(75));
+        assert_eq!(exact_multibyte.len(), EVDEV_UINPUT_NAME_MAX_BYTES);
+        assert_eq!(
+            normalize_uinput_device_name(&exact_multibyte),
+            exact_multibyte
+        );
+
+        let split_multibyte = format!("{}鼠", "a".repeat(77));
+        let normalized = normalize_uinput_device_name(&split_multibyte);
+        assert_eq!(normalized, "a".repeat(77));
+        assert!(normalized.is_char_boundary(normalized.len()));
+
+        assert_eq!(
+            normalize_uinput_device_name("CUA\0pointer\n"),
+            "CUA_pointer_"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn uinput_creation_panic_is_contained_and_daemon_worker_remains_usable() {
+        let failed = tokio::task::spawn_blocking(|| {
+            guarded_uinput_creation::<()>("panic", |_| panic!("synthetic evdev panic"))
+        })
+        .await
+        .expect("the blocking worker must not unwind");
+        let error = failed.expect_err("the panic must become an error");
+        assert!(is_uinput_unavailable(&error));
+        assert!(error.to_string().contains("device creation panicked"));
+
+        let subsequent = tokio::task::spawn_blocking(|| {
+            guarded_uinput_creation("subsequent", |name| Ok(name.to_owned()))
+        })
+        .await
+        .expect("the runtime must remain usable after the contained panic")
+        .expect("a subsequent device operation must succeed");
+        assert_eq!(subsequent, "subsequent");
+    }
+
+    #[test]
+    fn uinput_creation_error_is_stably_typed() {
+        let error =
+            guarded_uinput_creation::<()>("failure", |_| anyhow::bail!("permission denied"))
+                .expect_err("the injected builder error must be returned");
+        assert!(is_uinput_unavailable(&error));
+        assert_eq!(
+            error.to_string(),
+            "Linux uinput pointer unavailable: permission denied"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires a writable /dev/uinput device"]
+    fn real_uinput_accepts_normalized_overlong_multibyte_name() {
+        let overlong_name = format!("CUA {}{UINPUT_POINTER_SUFFIX}", "鼠".repeat(100));
+        let device = create_uinput_pointer(&overlong_name)
+            .expect("normalized device name should create a real uinput pointer");
+        drop(device);
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -1552,11 +1552,37 @@ fn x11_pixel_click_no_focus_steal(
                 },
             ) {
                 Ok(()) => return Ok(()),
+                Err(error) if crate::input::is_uinput_unavailable(&error) => return Err(error),
                 Err(e) => tracing::warn!("MPX click fell back to XSendEvent: {e}"),
             }
         }
     }
     crate::input::send_click(xid, lx, ly, count, button)
+}
+
+fn linux_input_error(error: anyhow::Error) -> ToolResult {
+    if crate::input::is_uinput_unavailable(&error) {
+        ToolResult::error(error.to_string()).with_structured(json!({
+            "code": crate::input::UINPUT_UNAVAILABLE_CODE,
+        }))
+    } else {
+        ToolResult::error(error.to_string())
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn uinput_failure_has_a_stable_structured_code() {
+    let result = linux_input_error(crate::input::uinput_unavailable("synthetic failure"));
+    assert_eq!(result.is_error, Some(true));
+    assert_eq!(
+        result
+            .structured_content
+            .as_ref()
+            .and_then(|value| value.get("code"))
+            .and_then(Value::as_str),
+        Some(crate::input::UINPUT_UNAVAILABLE_CODE)
+    );
 }
 
 fn x11_pixel_click_no_focus_steal_modifiers(
@@ -2326,7 +2352,7 @@ impl Tool for ClickTool {
                 "✅ Clicked at ({x:.1}, {y:.1}) × {count} (delivery_mode={mode_label})."
             ))
             .with_structured(json!({ "path": path, "verified": false, "effect": "unverifiable" })),
-            Ok(Err(e)) => ToolResult::error(e.to_string()),
+            Ok(Err(e)) => linux_input_error(e),
             Err(e) => ToolResult::error(format!("Task error: {e}")),
         }
     }
@@ -4081,6 +4107,9 @@ impl Tool for ScrollTool {
                             },
                         ) {
                             Ok(()) => return Ok(()),
+                            Err(error) if crate::input::is_uinput_unavailable(&error) => {
+                                return Err(error)
+                            }
                             Err(e) => tracing::warn!("MPX scroll fell back to XSendEvent: {e}"),
                         }
                     }
@@ -4121,7 +4150,7 @@ impl Tool for ScrollTool {
                 "Scrolled {direction} {amount} ticks (delivery_mode={mode_label})."
             ))
             .with_structured(json!({ "verified": false, "delivery_mode": mode_label })),
-            Ok(Err(e)) => ToolResult::error(e.to_string()),
+            Ok(Err(e)) => linux_input_error(e),
             Err(e) => ToolResult::error(format!("Task error: {e}")),
         }
     }
@@ -4259,7 +4288,7 @@ impl Tool for DoubleClickTool {
                         Ok(Ok(())) => {
                             ToolResult::text(format!("✅ Double-clicked element [{idx}]."))
                         }
-                        Ok(Err(e)) => ToolResult::error(e.to_string()),
+                        Ok(Err(e)) => linux_input_error(e),
                         Err(e) => ToolResult::error(format!("Task error: {e}")),
                     }
                 }
@@ -4360,7 +4389,7 @@ impl Tool for DoubleClickTool {
                 "✅ Double-clicked at ({x:.1}, {y:.1}) (delivery_mode={mode_label})."
             ))
             .with_structured(json!({ "verified": false, "delivery_mode": mode_label })),
-            Ok(Err(e)) => ToolResult::error(e.to_string()),
+            Ok(Err(e)) => linux_input_error(e),
             Err(e) => ToolResult::error(format!("Task error: {e}")),
         }
     }
@@ -4493,7 +4522,7 @@ impl Tool for RightClickTool {
                         Ok(Ok(())) => {
                             ToolResult::text(format!("✅ Right-clicked element [{idx}]."))
                         }
-                        Ok(Err(e)) => ToolResult::error(e.to_string()),
+                        Ok(Err(e)) => linux_input_error(e),
                         Err(e) => ToolResult::error(format!("Task error: {e}")),
                     }
                 }
@@ -4593,7 +4622,7 @@ impl Tool for RightClickTool {
                 "✅ Right-clicked at ({x:.1}, {y:.1}) (delivery_mode={mode_label})."
             ))
             .with_structured(json!({ "verified": false, "delivery_mode": mode_label })),
-            Ok(Err(e)) => ToolResult::error(e.to_string()),
+            Ok(Err(e)) => linux_input_error(e),
             Err(e) => ToolResult::error(format!("Task error: {e}")),
         }
     }
@@ -5828,7 +5857,7 @@ impl Tool for ParallelMouseDragTool {
                         cursor_overlay::OverlayCommand::SetPressed(false),
                     );
                 }
-                ToolResult::error(e.to_string())
+                linux_input_error(e)
             }
             Err(e) => {
                 for (session, _) in &drags {


### PR DESCRIPTION
## Summary

- bound Linux uinput pointer names to evdev 0.12's 78-byte ceiling, preserving the generated process/nonce suffix
- sanitize control characters and truncate multibyte UTF-8 only at character boundaries
- contain dependency panics and device-construction errors inside the blocking worker
- return `{"code":"uinput_unavailable"}` instead of unwinding the worker or silently claiming fallback success
- keep later daemon input work usable after a contained construction panic
- exercise the regression against a real `/dev/uinput` device on the hosted Linux runner

## Root cause

evdev 0.12 asserts during `VirtualDevice::build` when the supplied name exceeds its stricter limit. The name included a caller-controlled session/cursor identifier, so an overlong identifier unwound the Tokio blocking worker before the existing fallback could run. Device creation errors were otherwise swallowed by the XSendEvent fallback, which could report success despite the real-input route being unavailable.

## Validation

- `cargo fmt --package platform-linux -- --check`
- `cargo test --locked -p platform-linux` (16 host-runnable tests passed on macOS)
- [exact-SHA Linux unit run](https://github.com/trycua/cua/actions/runs/30899246353): passed at `d9abbf641962a2e667925892cca3bded70b78ca8`
- [exact-SHA Linux interactive run](https://github.com/trycua/cua/actions/runs/30899287375): source resolution, capture/desktop scope, Electron/Tauri, GTK3 native harness, install smoke, and matrix summary all passed

The real-uinput CI step loads the hosted runner's `uinput` module, grants access to the ephemeral device, and builds a pointer from an overlong multibyte name through the production function.

## Provenance

Salvaged from #2736's original bounded-name implementation; its source commit remains preserved through `cherry-pick -x`. Reported and diagnosed by @marvinbaudach in #2715.

Fixes #2715.
