### PR TITLE
fix(cua-driver): align browser prepare pid contract

### DIFF
--- a/docs/content/docs/reference/cua-driver/mcp-tools.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools.mdx
@@ -786,7 +786,7 @@ Explicitly prepare an owned DevTools endpoint for a browser pid. Existing endpoi
 
 - `allow_launch` (boolean, optional): Allow a separate driver-owned isolated Chromium process to be launched (default false).
 - `approval_token` (string, optional): Legacy single-use setup token. Existing-profile use is disabled unless a trusted launcher explicitly enables the same-user-writable compatibility path.
-- `pid` (integer, required): Browser process id to prepare.
+- `pid` (integer, required): Browser process id to prepare. range: 1–unbounded
 - `profile` (object, optional)
 - `session` (string, optional): Stable caller-declared session id. Browser targets, tabs, and refs are scoped to this session.
 - `strategy` (object, optional)

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/tools.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/tools.rs
@@ -609,7 +609,11 @@ impl BrowserPrepareTool {
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "pid": { "type": "integer", "description": "Browser process id to prepare." },
+                    "pid": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Browser process id to prepare."
+                    },
                     "window_id": { "type": "integer", "description": "Exact native window approval anchor; required for strategy.kind=existing_profile." },
                     "approval_token": {
                         "type": "string",
@@ -658,7 +662,12 @@ impl Tool for BrowserPrepareTool {
 
     async fn invoke(&self, args: Value) -> ToolResult {
         let pid = match args.require_i64("pid") {
-            Ok(v) => v,
+            Ok(v) if v > 0 => v,
+            Ok(v) => {
+                return ToolResult::error(format!(
+                    "Field pid is out of range for a process id: {v}"
+                ))
+            }
             Err(e) => return e,
         };
         let session = match require_explicit_session(&args) {

--- a/libs/cua-driver/rust/crates/cua-driver/tests/protocol_schema_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/protocol_schema_test.rs
@@ -110,6 +110,47 @@ fn tools_list_schema_shape() {
         }
     }
 
+    let browser_prepare = tools
+        .iter()
+        .find(|tool| tool["name"] == "browser_prepare")
+        .expect("browser_prepare not found in tools/list");
+    assert_eq!(
+        browser_prepare["inputSchema"]["properties"]["pid"]["type"], "integer",
+        "browser_prepare.pid must be advertised as an integer"
+    );
+    assert_eq!(
+        browser_prepare["inputSchema"]["properties"]["pid"]["minimum"], 1,
+        "browser_prepare.pid must exclude the non-process pid 0"
+    );
+    for (id, arguments, expected_error) in [
+        (
+            3,
+            serde_json::json!({}),
+            "Missing required integer field: pid",
+        ),
+        (
+            4,
+            serde_json::json!({"pid": 0}),
+            "Field pid is out of range for a process id: 0",
+        ),
+    ] {
+        d.send(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "tools/call",
+            "params": {"name": "browser_prepare", "arguments": arguments}
+        }));
+        let response = d.recv();
+        assert_eq!(
+            response["result"]["isError"], true,
+            "browser_prepare must reject a missing or invalid pid: {response:?}"
+        );
+        assert_eq!(
+            response["result"]["content"][0]["text"], expected_error,
+            "browser_prepare must reject pid before platform dispatch"
+        );
+    }
+
     const DELIVERY_MODE_TOOLS: &[&str] = &[
         "click",
         "double_click",


### PR DESCRIPTION
## Summary

- constrain `browser_prepare.pid` to positive integers in its exported MCP schema
- reject non-positive PIDs in the shared handler before platform dispatch
- exercise the spawned-driver MCP surface so missing and invalid PIDs cannot regress on Windows or other supported platforms

## Root cause

The live 0.14.1 schema already names `pid` as a required integer, but it did not describe the positive process-ID constraint and the cross-platform MCP regression only checked the required-field list. That left the concrete schema and pre-dispatch rejection behavior insufficiently pinned.

## Impact

MCP clients receive an explicit positive integer process-ID contract, and missing or non-positive PIDs fail consistently before reaching platform-specific browser setup. Larger positive values remain platform-validated so existing structured browser refusals are preserved.

## Validation

- `cargo test -p cua-driver --test protocol_schema_test`
- `cargo test -p cua-driver --test daemon_required_test unrestricted_mode_skips_runtime_existing_profile_consent`
- `cargo test -p cua-driver-core tool_annotations_and_schemas --lib`
- `cargo fmt --all -- --check`
- `git diff --check`

Windows-native validation remains for GitHub Actions because this macOS checkout does not have a Windows Rust target installed.

Fixes #2714.