### PR TITLE
fix(cua-driver): accept owned foreground click surfaces

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/tests/standalone_browser_behavior_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/standalone_browser_behavior_test.rs
@@ -3734,6 +3734,29 @@ fn run_browser_owned_permission_prompt(spec: &BrowserSpec) {
                 "expand quiet permission indicator: {}",
                 expanded.raw
             );
+            assert_eq!(
+                expanded.action_effect(),
+                Some("unverifiable"),
+                "the desktop click has no trusted effect read-back: {}",
+                expanded.raw
+            );
+            assert_eq!(
+                expanded.structured()["route"],
+                "global_input",
+                "{}",
+                expanded.raw
+            );
+            assert_eq!(
+                expanded.structured()["delivery"]["mode"],
+                "not_applicable",
+                "{}",
+                expanded.raw
+            );
+            assert!(
+                expanded.structured().get("evidence").is_none(),
+                "SendInput acceptance must not become confirmation evidence: {}",
+                expanded.raw
+            );
             thread::sleep(Duration::from_millis(250));
             let recaptured_window = fixture.driver.call(
                 "get_window_state",

--- a/libs/cua-driver/rust/crates/platform-windows/src/foreground_activation.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/foreground_activation.rs
@@ -1,0 +1,46 @@
+/// Return whether the foreground window still belongs to the clicked target's
+/// activation family.
+///
+/// A click on browser chrome can synchronously open an owned top-level surface
+/// (for example Edge's quiet-permission panel). That surface has a different
+/// `GA_ROOT`, but the same `GA_ROOTOWNER` as the browser frame. Treating only
+/// exact root equality as success turns an externally delivered click into a
+/// tool error. Root-owner equality keeps the allowance narrow: an unrelated
+/// top-level window still fails the activation check.
+pub(crate) fn matches_target_family(
+    target_root: usize,
+    target_root_owner: usize,
+    foreground_root: usize,
+    foreground_root_owner: usize,
+) -> bool {
+    target_root != 0
+        && foreground_root != 0
+        && (target_root == foreground_root
+            || (target_root_owner != 0 && target_root_owner == foreground_root_owner))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::matches_target_family;
+
+    #[test]
+    fn accepts_exact_target_root() {
+        assert!(matches_target_family(0x10, 0x10, 0x10, 0x10));
+    }
+
+    #[test]
+    fn accepts_browser_owned_transient_surface() {
+        assert!(matches_target_family(0x10, 0x10, 0x20, 0x10));
+    }
+
+    #[test]
+    fn rejects_unrelated_foreground_window() {
+        assert!(!matches_target_family(0x10, 0x10, 0x20, 0x20));
+    }
+
+    #[test]
+    fn rejects_missing_window_identity() {
+        assert!(!matches_target_family(0, 0, 0x20, 0x20));
+        assert!(!matches_target_family(0x10, 0x10, 0, 0));
+    }
+}

--- a/libs/cua-driver/rust/crates/platform-windows/src/input/mouse.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/input/mouse.rs
@@ -18,8 +18,8 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
 use windows::Win32::UI::WindowsAndMessaging::{
     ChildWindowFromPointEx, GetAncestor, GetClassLongPtrW, GetCursorPos, GetForegroundWindow,
     GetSystemMetrics, GetWindowLongPtrW, PostMessageW, SetCursorPos, SetWindowPos, CS_DBLCLKS,
-    CWP_SKIPDISABLED, CWP_SKIPINVISIBLE, CWP_SKIPTRANSPARENT, GA_ROOT, GCL_STYLE, GWL_EXSTYLE,
-    HWND_NOTOPMOST, HWND_TOP, HWND_TOPMOST, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN,
+    CWP_SKIPDISABLED, CWP_SKIPINVISIBLE, CWP_SKIPTRANSPARENT, GA_ROOT, GA_ROOTOWNER, GCL_STYLE,
+    GWL_EXSTYLE, HWND_NOTOPMOST, HWND_TOP, HWND_TOPMOST, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN,
     SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, WM_LBUTTONDBLCLK,
     WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDBLCLK, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEMOVE,
     WM_RBUTTONDBLCLK, WM_RBUTTONDOWN, WM_RBUTTONUP, WS_EX_TOPMOST,
@@ -661,7 +661,14 @@ fn send_click_synthesized_mods_impl(
         if activate {
             let foreground_root = GetAncestor(GetForegroundWindow(), GA_ROOT);
             let target_root = GetAncestor(target, GA_ROOT);
-            if foreground_root != target_root {
+            let foreground_root_owner = GetAncestor(foreground_root, GA_ROOTOWNER);
+            let target_root_owner = GetAncestor(target_root, GA_ROOTOWNER);
+            if !crate::foreground_activation::matches_target_family(
+                target_root.0 as usize,
+                target_root_owner.0 as usize,
+                foreground_root.0 as usize,
+                foreground_root_owner.0 as usize,
+            ) {
                 bail!("The foreground click did not activate its target window.");
             }
         }

--- a/libs/cua-driver/rust/crates/platform-windows/src/lib.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/lib.rs
@@ -18,6 +18,8 @@
 
 use cua_driver_core::tool::ToolRegistry;
 
+mod foreground_activation;
+
 pub mod diagnostics;
 pub mod health_report;
 pub mod overlay;


### PR DESCRIPTION
## Summary

- accept a foreground window in the clicked target's Win32 root-owner family
- keep unrelated foreground windows as hard activation failures
- retain an honest narrow `ActionResult`: the desktop SendInput click remains `unverifiable` global input with no confirmation evidence
- extend the standalone Edge permission scenario to assert the action contract before its independent pixel and fixture-state oracles

## Root cause

The active Windows SendInput path required the post-click foreground `GA_ROOT` to equal the clicked target's root. Edge can synchronously open its quiet-permission panel as a distinct owned top-level window, so the click visibly delivered while the equality check returned a tool error.

The guard now compares exact roots first, then permits only windows sharing the target's `GA_ROOTOWNER`. This accounts for browser-owned transient surfaces without accepting unrelated top-level windows.

## Validation

- `cargo test -p platform-windows --lib` (44 passed)
- `cargo test -p cua-driver-core successful_foreground_pixel_branch_reports_actual_global_delivery --lib`
- `cargo test -p cua-driver-contract action_result --lib` (5 passed)
- `cargo test -p cua-driver --test schema_consistency_test` (4 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

The exact Windows/Edge standalone-browser scenario and Linux companion lane will run in GitHub Actions against this branch.

Fixes #2681