### PR TITLE
fix(cua-driver): support Chrome 151 tab window correlation

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/engine.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/engine.rs
@@ -239,6 +239,14 @@ fn is_method_unsupported(error: &anyhow::Error) -> bool {
     error.to_string().contains("(-32601)")
 }
 
+/// Chrome 151 routes browser-window identity through the stable `tab` target
+/// while retaining `page` targets for renderer commands. The old page lookup
+/// now returns this exact server error instead of a window id.
+fn is_page_window_lookup_unsupported(error: &anyhow::Error) -> bool {
+    let message = error.to_string();
+    message.contains("(-32000)") && message.contains("Browser window not found")
+}
+
 fn is_semantic_document_size_error(error: &anyhow::Error) -> bool {
     let message = error.to_string().to_ascii_lowercase();
     [
@@ -972,6 +980,7 @@ impl BrowserEngine {
             })?;
 
         let mut out = Vec::new();
+        let mut tab_infos: Option<Vec<Value>> = None;
         for info in infos {
             if info.get("type").and_then(Value::as_str) != Some("page") {
                 continue;
@@ -1058,6 +1067,118 @@ impl BrowserEngine {
                 // shape; every transient/vanished-target error fails the
                 // whole proof rather than shrinking it to a false unique set.
                 Err(error) if is_method_unsupported(&error) => None,
+                Err(error) if is_page_window_lookup_unsupported(&error) => {
+                    let tabs = match &tab_infos {
+                        Some(tabs) => tabs,
+                        None => {
+                            let response = conn
+                                .call(
+                                    None,
+                                    "Target.getTargets",
+                                    json!({
+                                        "filter": [{ "type": "tab", "exclude": false }]
+                                    }),
+                                )
+                                .await
+                                .map_err(|error| {
+                                    route_err(
+                                        "Target.getTargets failed while resolving Chrome tab targets",
+                                        error,
+                                    )
+                                })?;
+                            let tabs = response
+                                .get("targetInfos")
+                                .and_then(Value::as_array)
+                                .cloned()
+                                .ok_or_else(|| {
+                                    refuse(
+                                        BrowserRefusalCode::BrowserRouteUnavailable,
+                                        "Target.getTargets returned no tab targetInfos array",
+                                    )
+                                })?;
+                            tab_infos.insert(tabs)
+                        }
+                    };
+                    let page_context = info.get("browserContextId").and_then(Value::as_str);
+                    let matches = tabs
+                        .iter()
+                        .filter(|tab| {
+                            tab.get("type").and_then(Value::as_str) == Some("tab")
+                                && tab.get("title").and_then(Value::as_str)
+                                    == info.get("title").and_then(Value::as_str)
+                                && tab.get("url").and_then(Value::as_str)
+                                    == info.get("url").and_then(Value::as_str)
+                                && tab.get("browserContextId").and_then(Value::as_str)
+                                    == page_context
+                        })
+                        .filter_map(|tab| tab.get("targetId").and_then(Value::as_str))
+                        .collect::<Vec<_>>();
+                    let [tab_target_id] = matches.as_slice() else {
+                        return Err(refuse(
+                            BrowserRefusalCode::BrowserRouteUnavailable,
+                            format!(
+                                "Chrome page target {target_id} has {} matching tab targets; exact window correlation requires one",
+                                matches.len()
+                            ),
+                        ));
+                    };
+                    let win = conn
+                        .call(
+                            None,
+                            "Browser.getWindowForTarget",
+                            json!({ "targetId": tab_target_id }),
+                        )
+                        .await
+                        .map_err(|error| {
+                            route_err(
+                                "Browser.getWindowForTarget failed for Chrome tab target",
+                                error,
+                            )
+                        })?;
+                    let window_id =
+                        win.get("windowId").and_then(Value::as_i64).ok_or_else(|| {
+                            refuse(
+                                BrowserRefusalCode::BrowserRouteUnavailable,
+                                "Browser.getWindowForTarget returned no windowId for Chrome tab target",
+                            )
+                        })?;
+                    let bounds_v = conn
+                        .call(
+                            None,
+                            "Browser.getWindowBounds",
+                            json!({ "windowId": window_id }),
+                        )
+                        .await
+                        .map_err(|error| {
+                            route_err(
+                                "Browser.getWindowBounds failed while proving the native window",
+                                error,
+                            )
+                        })?;
+                    let bounds = bounds_v.get("bounds").ok_or_else(|| {
+                        refuse(
+                            BrowserRefusalCode::BrowserRouteUnavailable,
+                            "Browser.getWindowBounds returned no bounds object",
+                        )
+                    })?;
+                    let number = |field: &str| {
+                        bounds.get(field).and_then(Value::as_f64).ok_or_else(|| {
+                            refuse(
+                                BrowserRefusalCode::BrowserRouteUnavailable,
+                                format!("Browser.getWindowBounds returned no numeric {field}"),
+                            )
+                        })
+                    };
+                    Some((
+                        window_id,
+                        Rect::new(
+                            number("left")?,
+                            number("top")?,
+                            number("width")?,
+                            number("height")?,
+                        ),
+                    ))
+                }
                 Err(error) => {
                     return Err(route_err(
                         "Browser.getWindowForTarget failed while proving the native window",

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/v2_tests.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/v2_tests.rs
@@ -43,6 +43,7 @@ use super::types::{
 /// navigations, frame removal, and capability regression.
 #[derive(Debug)]
 struct FixtureState {
+    chrome_tab_window_routing: bool,
     oopif_supported: bool,
     oopif_present: bool,
     emit_rogue_attach: bool,
@@ -69,6 +70,7 @@ struct FixtureState {
 impl Default for FixtureState {
     fn default() -> Self {
         Self {
+            chrome_tab_window_routing: false,
             oopif_supported: true,
             oopif_present: true,
             emit_rogue_attach: false,
@@ -423,6 +425,19 @@ fn fixture_handler(state: SharedState) -> MockHandler {
         let is_oopif = sess.starts_with("oopif-sess-");
 
         match call.method.as_str() {
+            "Target.getTargets"
+                if st.chrome_tab_window_routing && call.params["filter"][0]["type"] == "tab" =>
+            {
+                MockReply::ok(json!({
+                    "targetInfos": [{
+                        "targetId": "TAB1",
+                        "type": "tab",
+                        "title": "Fixture",
+                        "url": "https://fixture.test/",
+                        "attached": false,
+                    }]
+                }))
+            }
             "Target.getTargets" => MockReply::ok(json!({
                 "targetInfos": [{
                     "targetId": "T1",
@@ -432,6 +447,11 @@ fn fixture_handler(state: SharedState) -> MockHandler {
                     "attached": false,
                 }]
             })),
+            "Browser.getWindowForTarget"
+                if st.chrome_tab_window_routing && call.params["targetId"] == "T1" =>
+            {
+                MockReply::err(-32000, "Browser window not found")
+            }
             "Browser.getWindowForTarget" => MockReply::ok(json!({ "windowId": 11 })),
             "Browser.getWindowBounds" => MockReply::ok(json!({
                 "bounds": { "left": 0.0, "top": 0.0, "width": 800.0, "height": 600.0 }
@@ -886,7 +906,13 @@ async fn fixture() -> Fixture {
 }
 
 async fn existing_profile_only_fixture() -> Fixture {
-    let state = Arc::new(StdMutex::new(FixtureState::default()));
+    existing_profile_only_fixture_with(|_| {}).await
+}
+
+async fn existing_profile_only_fixture_with(configure: impl FnOnce(&mut FixtureState)) -> Fixture {
+    let mut initial = FixtureState::default();
+    configure(&mut initial);
+    let state = Arc::new(StdMutex::new(initial));
     let server = MockCdpServer::start(fixture_handler(state.clone())).await;
     let setup_invoked = Arc::new(AtomicBool::new(false));
     let engine = BrowserEngine::new(Arc::new(FixturePlatform {
@@ -1045,6 +1071,46 @@ async fn approved_existing_profile_attach_claims_then_binds_one_generation() {
         .await;
     assert_eq!(structured(&state)["status"], "ok", "{}", structured(&state));
     crate::session::fire_session_end("transport-v2-attach");
+}
+
+#[tokio::test]
+async fn existing_profile_uses_chrome_tab_target_for_window_correlation() {
+    let f = existing_profile_only_fixture_with(|state| {
+        state.chrome_tab_window_routing = true;
+    })
+    .await;
+    let token = super::approval::mint_existing_profile_approval(
+        super::approval::ExistingProfileApprovalScope {
+            pid: 1,
+            window_id: 7,
+            session: SESSION.to_owned(),
+        },
+    )
+    .unwrap();
+    let prepared = BrowserPrepareTool::new(f.engine.clone())
+        .invoke(json!({
+            "pid": 1,
+            "window_id": 7,
+            "session": SESSION,
+            "strategy": { "kind": "existing_profile" },
+            "approval_token": token
+        }))
+        .await;
+    assert_eq!(structured(&prepared)["status"], "ok");
+
+    let state = GetBrowserStateTool::new(f.engine.clone())
+        .invoke(json!({ "pid": 1, "window_id": 7, "session": SESSION }))
+        .await;
+    assert_eq!(structured(&state)["status"], "ok", "{}", structured(&state));
+    assert_eq!(structured(&state)["binding_quality"], "exact");
+
+    let calls = f.state.lock().unwrap().calls.clone();
+    assert!(calls.iter().any(|(_, method, params)| {
+        method == "Browser.getWindowForTarget" && params["targetId"] == "T1"
+    }));
+    assert!(calls.iter().any(|(_, method, params)| {
+        method == "Browser.getWindowForTarget" && params["targetId"] == "TAB1"
+    }));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- retain `page` targets for renderer and DOM operations
- when Chrome returns `-32000: Browser window not found` for a page target, resolve browser-window geometry through Chrome's stable `tab` target
- require a unique browser-context/title/URL match so duplicate or missing tab associations still refuse instead of guessing
- cover the Chrome 151 response shape through the approved existing-profile flow

## Root cause

Chrome 151 can expose page targets whose `WebContents` are no longer directly discoverable in the browser window's tab strip. `Browser.getWindowForTarget` therefore rejects the page target even though it remains valid for page-domain commands. Chrome's corresponding `tab` target retains the browser-window identity.

## Impact

Linux/X11 existing-profile sessions can bind and call `get_browser_state` on Chrome 151 while preserving the exact-or-refused native-window correlation contract.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- Added `existing_profile_uses_chrome_tab_target_for_window_correlation`
- Local Rust execution was attempted but the shared runner filesystem returned `ENOSPC` while compiling dependencies, before project code compiled; CI is required for executable test evidence.

Closes #2704
