### PR TITLE
fix(cua-driver): reset stale local TCC rows after ad-hoc rebuilds

### DIFF
--- a/libs/cua-driver/python/tests/test_install_local_signing.py
+++ b/libs/cua-driver/python/tests/test_install_local_signing.py
@@ -94,6 +94,62 @@ def test_certificate_requirement_is_classified_as_stable() -> None:
     assert "stable local identity" in result.stdout
 
 
+def test_changed_ad_hoc_requirement_resets_only_local_driver_services() -> None:
+    result = run_signing_policy(
+        r"""
+        RED= YELLOW= NORMAL=
+        calls=""
+        tccutil() { calls="${calls}${1}:${2}:${3}"$'\n'; }
+        reset_local_tcc_after_ad_hoc_change \
+            'cdhash H"OLD"' 'cdhash H"NEW"'
+        printf '%s' "$calls"
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == (
+        "reset:Accessibility:com.trycua.driver.local\n"
+        "reset:ScreenCapture:com.trycua.driver.local\n"
+    )
+    assert "cleared stale Accessibility and Screen Recording rows" in result.stderr
+    assert "cua-driver-local permissions grant" in result.stderr
+
+
+def test_unchanged_or_certificate_requirements_preserve_tcc_rows() -> None:
+    result = run_signing_policy(
+        r"""
+        RED= YELLOW= NORMAL=
+        tccutil() { echo unexpected >&2; return 99; }
+        reset_local_tcc_after_ad_hoc_change '' 'cdhash H"FIRST"'
+        reset_local_tcc_after_ad_hoc_change \
+            'cdhash H"SAME"' 'cdhash H"SAME"'
+        reset_local_tcc_after_ad_hoc_change \
+            'certificate leaf = H"OLD"' 'certificate leaf = H"NEW"'
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "unexpected" not in result.stderr
+
+
+def test_ad_hoc_tcc_reset_failure_is_actionable_and_fails_closed() -> None:
+    result = run_signing_policy(
+        r"""
+        RED= YELLOW= NORMAL=
+        tccutil() { [ "$2" != ScreenCapture ]; }
+        if reset_local_tcc_after_ad_hoc_change \
+            'cdhash H"OLD"' 'cdhash H"NEW"'; then
+            exit 90
+        fi
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "could not reset these TCC services" in result.stderr
+    assert "tccutil reset Accessibility com.trycua.driver.local" in result.stderr
+    assert "tccutil reset ScreenCapture com.trycua.driver.local" in result.stderr
+
+
 def test_installer_verifies_the_copied_designated_requirement() -> None:
     script = (SCRIPTS_DIR / "_install-local-rust.sh").read_text()
 
@@ -101,6 +157,8 @@ def test_installer_verifies_the_copied_designated_requirement() -> None:
     assert '[ "$INSTALLED_REQUIREMENT" = "$STAGED_REQUIREMENT" ]' in script
     assert "verified installed designated requirement: certificate-backed" in script
     assert "verified installed designated requirement: ad-hoc cdhash" in script
+    assert 'PREVIOUS_REQUIREMENT="$(designated_requirement "$APP_DEST")"' in script
+    assert "reset_local_tcc_after_ad_hoc_change" in script
 
 
 def test_local_installer_uses_a_separate_macos_identity() -> None:

--- a/libs/cua-driver/scripts/_install-local-rust.sh
+++ b/libs/cua-driver/scripts/_install-local-rust.sh
@@ -335,6 +335,10 @@ if [ "$OS" = "Darwin" ]; then
     chmod +x "$APP_STAGE/Contents/MacOS/cua-driver-local"
     chmod +x "$APP_STAGE/Contents/MacOS/cua-cursor-theme"
     rm -f "$APP_STAGE/Contents/MacOS/.gitkeep"
+    PREVIOUS_REQUIREMENT=""
+    if [ -d "$APP_DEST" ] && command -v codesign >/dev/null 2>&1; then
+        PREVIOUS_REQUIREMENT="$(designated_requirement "$APP_DEST")"
+    fi
     # Stamp the local build version so the bundle reports something sane.
     if command -v plutil >/dev/null 2>&1; then
         plutil -replace CFBundleShortVersionString -string "$VERSION_TAG" \
@@ -451,6 +455,17 @@ elif [ "$OS" = "Linux" ] && command -v systemctl >/dev/null 2>&1; then
     systemctl --user stop cua-driver-local.service >/dev/null 2>&1 || true
 fi
 pkill -x cua-driver-local >/dev/null 2>&1 || true
+
+# A changed ad-hoc cdhash leaves the old csreq attached to this bundle's TCC
+# rows. Once the new bundle is registered and old daemons are stopped, reset
+# only its Accessibility and ScreenCapture rows so `permissions grant` can
+# create entries for the new identity.
+if [ "$OS" = "Darwin" ]; then
+    if ! reset_local_tcc_after_ad_hoc_change \
+        "$PREVIOUS_REQUIREMENT" "$INSTALLED_REQUIREMENT"; then
+        exit 1
+    fi
+fi
 
 # Agent skill pack symlinks: NOT auto-created. Run
 # `cua-driver skills install --local` to symlink agent dirs to the

--- a/libs/cua-driver/scripts/_local-signing.sh
+++ b/libs/cua-driver/scripts/_local-signing.sh
@@ -113,6 +113,53 @@ classify_designated_requirement() {
     esac
 }
 
+# An ad-hoc signature's designated requirement is its cdhash. Replacing the
+# bundle with a different ad-hoc build leaves TCC rows carrying the old csreq;
+# toggling the visible System Settings entry does not reliably rewrite it.
+ad_hoc_requirement_changed() {
+    local previous_requirement="$1"
+    local installed_requirement="$2"
+
+    [ -n "$previous_requirement" ] \
+        && [ -n "$installed_requirement" ] \
+        && [ "$previous_requirement" != "$installed_requirement" ] \
+        && [ "$(classify_designated_requirement "$previous_requirement")" = "ad-hoc" ] \
+        && [ "$(classify_designated_requirement "$installed_requirement")" = "ad-hoc" ]
+}
+
+# Reset only the two TCC services used by Cua Driver Local, and only when an
+# actual ad-hoc cdhash transition was observed. The caller must register the
+# newly installed bundle with LaunchServices before invoking this function.
+reset_local_tcc_after_ad_hoc_change() {
+    local previous_requirement="$1"
+    local installed_requirement="$2"
+    local bundle_id="com.trycua.driver.local"
+    local service failed_services=""
+
+    ad_hoc_requirement_changed "$previous_requirement" "$installed_requirement" || return 0
+
+    if ! command -v tccutil >/dev/null 2>&1; then
+        echo "${RED}Error: tccutil is required to clear stale local-app permission rows after an ad-hoc cdhash change.${NORMAL}" >&2
+        return 1
+    fi
+
+    for service in Accessibility ScreenCapture; do
+        if ! tccutil reset "$service" "$bundle_id" >/dev/null 2>&1; then
+            failed_services="$failed_services $service"
+        fi
+    done
+    if [ -n "$failed_services" ]; then
+        echo "${RED}Error: could not reset these TCC services for $bundle_id:$failed_services.${NORMAL}" >&2
+        echo "The new app is installed, but its stale permission rows may remain. Run:" >&2
+        echo "  tccutil reset Accessibility $bundle_id" >&2
+        echo "  tccutil reset ScreenCapture $bundle_id" >&2
+        return 1
+    fi
+
+    echo "${YELLOW}The ad-hoc cdhash changed; cleared stale Accessibility and Screen Recording rows for $bundle_id.${NORMAL}" >&2
+    echo "Re-grant them to the new app with: cua-driver-local permissions grant" >&2
+}
+
 # Signs a staged local app without touching the live installation. Strict mode
 # refuses the ad-hoc path; non-strict mode keeps it available for casual local
 # development but makes the resulting TCC reset impossible to miss.


### PR DESCRIPTION
## What changed

- remember the installed local app's designated requirement before replacement
- detect only verified ad-hoc-to-ad-hoc cdhash changes
- after the new bundle is registered and old daemons are stopped, reset only the `Accessibility` and `ScreenCapture` rows for `com.trycua.driver.local`
- print the exact `cua-driver-local permissions grant` recovery step
- fail with manual exact-bundle reset commands if either reset cannot be completed

## Why

TCC rows retain the old ad-hoc signature's `csreq` after a rebuild changes the app cdhash. Toggling the existing System Settings row does not reliably rewrite that requirement, so the daemon continues to report Accessibility and Screen Recording as denied.

This is a narrow follow-up to #2494: certificate-backed rebuilds, unchanged ad-hoc builds, and first installs do not reset anything. The helper hard-codes the local bundle identifier and only touches the two permissions Cua Driver Local requires.

## Validation

- `uv run --with pytest python -m pytest libs/cua-driver/python/tests/test_install_local_signing.py libs/cua-driver/scripts/tests/test_install_local.py libs/cua-driver/scripts/tests/test_install_local_migration.py -q` (19 passed)
- `bash -n libs/cua-driver/scripts/_local-signing.sh libs/cua-driver/scripts/_install-local-rust.sh`
- `shellcheck libs/cua-driver/scripts/_local-signing.sh libs/cua-driver/scripts/_install-local-rust.sh`
- `git diff --check`
