### PR TITLE
fix(computer): reject commands on WebSocket disconnect

### DIFF
--- a/libs/typescript/computer/src/interface/base.ts
+++ b/libs/typescript/computer/src/interface/base.ts
@@ -260,23 +260,61 @@ export abstract class BaseComputerInterface {
         }
 
         return new Promise<{ [key: string]: unknown }>((innerResolve, innerReject) => {
+          const socket = this.ws;
+          let settled = false;
+
+          const cleanup = () => {
+            socket.off('message', messageHandler);
+            socket.off('error', errorHandler);
+            socket.off('close', closeHandler);
+          };
+
+          const resolveCommand = (response: { [key: string]: unknown }) => {
+            if (settled) return;
+            settled = true;
+            cleanup();
+            innerResolve(response);
+          };
+
+          const rejectCommand = (error: unknown) => {
+            if (settled) return;
+            settled = true;
+            cleanup();
+            innerReject(error);
+          };
+
           const messageHandler = (data: WebSocket.RawData) => {
             try {
               const response = JSON.parse(data.toString());
               if (response.error) {
-                innerReject(new Error(response.error));
+                rejectCommand(new Error(response.error));
               } else {
-                innerResolve(response);
+                resolveCommand(response);
               }
             } catch (error) {
-              innerReject(error);
+              rejectCommand(error);
             }
-            this.ws.off('message', messageHandler);
           };
 
-          this.ws.on('message', messageHandler);
+          const errorHandler = (error: Error) => rejectCommand(error);
+          const closeHandler = (code: number, reason: Buffer) => {
+            const detail = reason.length > 0 ? `: ${reason.toString()}` : '';
+            rejectCommand(
+              new Error(`WebSocket closed before receiving a response (${code}${detail})`)
+            );
+          };
+
+          socket.on('message', messageHandler);
+          socket.on('error', errorHandler);
+          socket.on('close', closeHandler);
           const wsCommand = { command, params };
-          this.ws.send(JSON.stringify(wsCommand));
+          try {
+            socket.send(JSON.stringify(wsCommand), (error) => {
+              if (error) rejectCommand(error);
+            });
+          } catch (error) {
+            rejectCommand(error);
+          }
         });
       };
 

--- a/libs/typescript/computer/tests/interface/macos.test.ts
+++ b/libs/typescript/computer/tests/interface/macos.test.ts
@@ -897,6 +897,69 @@ describe('MacOSComputerInterface', () => {
       });
     });
 
+    it('should reject a command when the WebSocket closes before responding', async () => {
+      const disconnectingWss = new WebSocketServer({ port: 0 });
+      const disconnectingPort = (disconnectingWss.address() as { port: number }).port;
+      let connectionCount = 0;
+      let commandCount = 0;
+
+      disconnectingWss.on('connection', (ws) => {
+        connectionCount += 1;
+        const connectionNumber = connectionCount;
+
+        ws.on('message', () => {
+          commandCount += 1;
+          if (connectionNumber === 1) {
+            ws.close(1011, 'test disconnect');
+            return;
+          }
+          ws.send(JSON.stringify({ success: true }));
+        });
+      });
+
+      const macosInterface = new MacOSComputerInterface(
+        `localhost:${disconnectingPort}`,
+        testParams.username,
+        testParams.password,
+        undefined,
+        testParams.vmName
+      );
+      const settleWithinTwoSeconds = <T>(promise: Promise<T>): Promise<T> =>
+        new Promise((resolve, reject) => {
+          const timeout = setTimeout(
+            () => reject(new Error('Command did not settle within two seconds')),
+            2000
+          );
+          promise.then(
+            (value) => {
+              clearTimeout(timeout);
+              resolve(value);
+            },
+            (error) => {
+              clearTimeout(timeout);
+              reject(error);
+            }
+          );
+        });
+
+      try {
+        await macosInterface.connect();
+        await expect(settleWithinTwoSeconds(macosInterface.leftClick(100, 100))).rejects.toThrow(
+          'WebSocket closed before receiving a response'
+        );
+        await expect(
+          settleWithinTwoSeconds(macosInterface.leftClick(100, 100))
+        ).resolves.toBeUndefined();
+        expect(connectionCount).toBe(2);
+        expect(commandCount).toBe(2);
+      } finally {
+        macosInterface.disconnect();
+        await new Promise<void>((resolve) => {
+          disconnectingWss.close(() => resolve());
+        });
+      }
+    });
+
     it('should handle disconnection gracefully', async () => {
       const macosInterface = new MacOSComputerInterface(
         testParams.ipAddress,


### PR DESCRIPTION
## Summary

- reject an in-flight Computer SDK command when its active WebSocket errors or closes before a response
- remove command-local listeners on every settlement path
- verify that the next queued command reconnects and that no command is replayed

## Root cause

`BaseComputerInterface.sendCommand` waited only for a `message` event. If the connection closed before replying, the command promise never settled and the serialized command queue remained blocked indefinitely.

The fix captures the socket that owns the command and rejects on its `error`, `close`, or send failure. Commands are reported as failed rather than retried, so non-idempotent actions are not duplicated.

## Validation

- `corepack pnpm --filter @trycua/computer exec vitest run` — 56 tests passed
- `corepack pnpm --filter @trycua/computer typecheck`
- `corepack pnpm --filter @trycua/computer lint`
- `corepack pnpm --filter @trycua/computer build`
- `corepack pnpm -r test` — core 5, computer 56, agent 5; playground has no tests
- `corepack pnpm -r typecheck`
- `corepack pnpm format:check`
