### PR TITLE
fix(fleet): depend on immutable CUA SDK wheel

### DIFF
--- a/libs/python/cua-fleet/pyproject.toml
+++ b/libs/python/cua-fleet/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cua-fleet"
-version = "0.0.4"
+version = "0.0.5"
 description = "Cua Fleet facade for the Cua Cloud Python SDK"
 readme = "README.md"
 license = "MIT"
@@ -25,7 +25,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 
-dependencies = ["cua-train==0.1.1"]
+dependencies = ["cua-train==0.1.2"]
 
 [project.urls]
 Homepage      = "https://github.com/trycua/cua"

--- a/libs/python/cua-fleet/tests/test_train_facade.py
+++ b/libs/python/cua-fleet/tests/test_train_facade.py
@@ -14,7 +14,7 @@ def test_package_metadata_pins_binding_bearing_cua_train() -> None:
     project = tomllib.loads((PACKAGE_ROOT / "pyproject.toml").read_text())["project"]
 
     assert project["requires-python"] == ">=3.10"
-    assert project["dependencies"] == ["cua-train==0.1.1"]
+    assert project["dependencies"] == ["cua-train==0.1.2"]
 
 
 def test_cua_fleet_reexports_train_client(monkeypatch) -> None:


### PR DESCRIPTION
Release `cua-fleet==0.0.5` with an exact `cua-train==0.1.2` pin. The prior `0.1.1` wheel set was mixed because pre-existing same-version artifacts were skipped by s3pypi; `0.1.2` is the verified public SDK that exposes `get_pool(name: str)`.