### PR TITLE
fix(fleet): release immutable CUA SDK dependency

### DIFF
--- a/libs/python/cua-fleet/pyproject.toml
+++ b/libs/python/cua-fleet/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cua-fleet"
-version = "0.0.5"
+version = "0.0.6"
 description = "Cua Fleet facade for the Cua Cloud Python SDK"
 readme = "README.md"
 license = "MIT"

--- a/libs/python/cua-fleet/tests/test_train_facade.py
+++ b/libs/python/cua-fleet/tests/test_train_facade.py
@@ -13,6 +13,7 @@ TRAIN_SOURCE_ROOT = REPOSITORY_ROOT / "libs/python/cua-train/src"
 def test_package_metadata_pins_binding_bearing_cua_train() -> None:
     project = tomllib.loads((PACKAGE_ROOT / "pyproject.toml").read_text())["project"]
 
+    assert project["version"] == "0.0.6"
     assert project["requires-python"] == ">=3.10"
     assert project["dependencies"] == ["cua-train==0.1.2"]
 


### PR DESCRIPTION
PyPI already contains cua-fleet 0.0.5, so the corrected cua-train==0.1.2 dependency must ship as the next immutable patch, cua-fleet==0.0.6.