### PR TITLE
fix(fleet): accept CUA SDK 0.1.2 source wheels

### DIFF
--- a/.github/scripts/repackage_cua_train_wheel.py
+++ b/.github/scripts/repackage_cua_train_wheel.py
@@ -14,7 +14,7 @@ import sys
 import zipfile
 
 SOURCE_NAME = "cua-train"
-SOURCE_VERSION = "0.1.1"
+SOURCE_VERSION = "0.1.2"
 DESTINATION_NAME = "cua-fleet"
 WHEEL_FILENAME = re.compile(
     r"^(?P<distribution>[A-Za-z0-9_]+)-(?P<version>[^-]+)-py3-none-(?P<platform>[^-]+)\.whl$"
@@ -119,7 +119,7 @@ def repack(
 
     metadata = parse_metadata(entries[metadata_name])
     if metadata.get("Name") != SOURCE_NAME or metadata.get("Version") != SOURCE_VERSION:
-        raise WheelError("source METADATA does not identify cua-train==0.1.1")
+        raise WheelError("source METADATA does not identify cua-train==0.1.2")
     wheel_metadata = entries[wheel_name].decode()
     if (
         "Root-Is-Purelib: false" not in wheel_metadata

--- a/.github/scripts/tests/test_repackage_cua_train_wheel.py
+++ b/.github/scripts/tests/test_repackage_cua_train_wheel.py
@@ -26,12 +26,12 @@ def _csv(rows: list[list[str]]) -> bytes:
 
 
 def _write_source_wheel(path: Path) -> dict[str, bytes]:
-    dist_info = "cua_train-0.1.1.dist-info"
+    dist_info = "cua_train-0.1.2.dist-info"
     entries = {
         "cua_train/__init__.py": b"TrainClient = object\n",
         "cyclops_sdk/__init__.py": b"CyclopsClient = object\n",
         "cyclops_sdk/libcyclops_sdk.so": b"native payload",
-        f"{dist_info}/METADATA": b"Metadata-Version: 2.4\nName: cua-train\nVersion: 0.1.1\nDescription-Content-Type: text/markdown\n\n",
+        f"{dist_info}/METADATA": b"Metadata-Version: 2.4\nName: cua-train\nVersion: 0.1.2\nDescription-Content-Type: text/markdown\n\n",
         f"{dist_info}/WHEEL": b"Wheel-Version: 1.0\nRoot-Is-Purelib: false\nTag: py3-none-manylinux_2_34_x86_64\n",
     }
     record_name = f"{dist_info}/RECORD"
@@ -45,7 +45,7 @@ def _write_source_wheel(path: Path) -> dict[str, bytes]:
 
 
 def test_repack_changes_only_distribution_metadata(tmp_path: Path):
-    source = tmp_path / "cua_train-0.1.1-py3-none-manylinux_2_34_x86_64.whl"
+    source = tmp_path / "cua_train-0.1.2-py3-none-manylinux_2_34_x86_64.whl"
     source_entries = _write_source_wheel(source)
 
     destination = repack(
@@ -67,7 +67,7 @@ def test_repack_changes_only_distribution_metadata(tmp_path: Path):
 
 
 def test_repack_rejects_unpinned_source(tmp_path: Path):
-    source = tmp_path / "cua_train-0.1.1-py3-none-manylinux_2_34_x86_64.whl"
+    source = tmp_path / "cua_train-0.1.2-py3-none-manylinux_2_34_x86_64.whl"
     _write_source_wheel(source)
 
     with pytest.raises(WheelError, match="SHA-256 mismatch"):


### PR DESCRIPTION
The cua-fleet 0.0.6 release failed because the repackaging script still rejected cua-train 0.1.2 after the source-wheel matrix was updated. Update the source version contract and focused fixture together.

Validation: `pytest -q .github/scripts/tests/test_repackage_cua_train_wheel.py` (2 passed).