### PR TITLE
fix(cua-driver): stop after verified task completion

### DIFF
--- a/docs/content/docs/reference/cua-driver/mcp-tools.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools.mdx
@@ -730,7 +730,7 @@ Install the ffmpeg binary used by start_recording's video capture (Linux/Windows
 
 ### `verify_state`
 
-Deterministically verify bounded predicates against one exact window. The driver evaluates structured window/accessibility state and may return the final screenshot as uninterpreted visual evidence for a multimodal caller. Predicate results are satisfied, unsatisfied, or unknown; unknown never implies success. Accessibility projections are conservative: absence remains unknown unless the observed search domain is proven exhaustive.
+After each state-changing action, deterministically verify the actual task postconditions now checkable as bounded predicates against one exact window. Once all task postconditions are satisfied, stop issuing actions, end the session, and report completion. The driver evaluates structured window/accessibility state and may return the final screenshot as uninterpreted visual evidence for a multimodal caller. Predicate results are satisfied, unsatisfied, or unknown; unknown never implies success. Accessibility projections are conservative: absence remains unknown unless the observed search domain is proven exhaustive.
 
 **Arguments:**
 

--- a/libs/cua-driver/contract/manifest.json
+++ b/libs/cua-driver/contract/manifest.json
@@ -2316,7 +2316,7 @@
     },
     {
       "name": "verify_state",
-      "description": "Deterministically verify bounded predicates against one exact window. The driver evaluates structured window/accessibility state and may return the final screenshot as uninterpreted visual evidence for a multimodal caller. Predicate results are satisfied, unsatisfied, or unknown; unknown never implies success. Accessibility projections are conservative: absence remains unknown unless the observed search domain is proven exhaustive.",
+      "description": "After each state-changing action, deterministically verify the actual task postconditions now checkable as bounded predicates against one exact window. Once all task postconditions are satisfied, stop issuing actions, end the session, and report completion. The driver evaluates structured window/accessibility state and may return the final screenshot as uninterpreted visual evidence for a multimodal caller. Predicate results are satisfied, unsatisfied, or unknown; unknown never implies success. Accessibility projections are conservative: absence remains unknown unless the observed search domain is proven exhaustive.",
       "platforms": [
         "macos",
         "windows",

--- a/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
@@ -223,6 +223,13 @@ expressible window-scoped postcondition. In effective desktop scope,
 `verify_state` is intentionally refused with `window_scope_disabled`; verify
 with a fresh `get_desktop_state` result and agent-owned visual/semantic reading.
 
+After each state-changing action, verify the actual task postconditions now
+checkable, not only whether the action was delivered. Once all task
+postconditions are satisfied, stop issuing actions immediately, end the
+session, and report completion. Do
+not perform exploratory, corrective, or cleanup GUI actions after verified
+completion.
+
 - **Before** — the pre-action snapshot resolves the `element_index`
   you're about to use. Indices from previous turns are stale; the
   server replaces the element index map on every snapshot, keyed

--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/verification.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/verification.rs
@@ -223,7 +223,10 @@ impl ToolOutput for VerifyStateOutput {}
 pub fn contracts() -> Vec<ToolContract> {
     vec![ToolContract {
         name: VerifyStateInput::TOOL_NAME.into(),
-        description: "Deterministically verify bounded predicates against one exact window. \
+        description: "After each state-changing action, deterministically verify the actual task \
+            postconditions now checkable as bounded predicates against one exact window. Once all \
+            task postconditions are satisfied, stop issuing actions, end the session, and report \
+            completion. \
             The driver evaluates structured window/accessibility state and may return the final \
             screenshot as uninterpreted visual evidence for a multimodal caller. Predicate \
             results are satisfied, unsatisfied, or unknown; unknown never implies success. \
@@ -273,6 +276,16 @@ mod tests {
         assert_eq!(selector["properties"]["role"]["minLength"], 1);
         assert_eq!(selector["properties"]["label_contains"]["minLength"], 1);
         assert_eq!(schema["additionalProperties"], false);
+    }
+
+    #[test]
+    fn description_makes_satisfied_task_postconditions_terminal() {
+        let contract = contracts().pop().expect("verify_state contract");
+        assert!(contract
+            .description
+            .contains("After each state-changing action"));
+        assert!(contract.description.contains("stop issuing actions"));
+        assert!(contract.description.contains("end the session"));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/protocol.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/protocol.rs
@@ -376,7 +376,7 @@ Workflow per turn:
 1. `launch_app` returns pid and windows. Use `creates_new_application_instance:true` when another run may touch the app.
 2. `get_window_state(pid, window_id)` refreshes the tree and element indices.
 3. Act with the fresh index.
-4. `verify_state(pid, window_id, expect)` checks bounded structured postconditions. `unknown` is not success. Set `include_screenshot:true` when the multimodal agent should also read visual evidence and decide whether to stop, retry, or advance the ladder.
+4. After each state-changing action, `verify_state(pid, window_id, expect)` checks actual task postconditions. `unknown` is not success. Once all are satisfied, stop issuing actions, end the session, and report completion. Otherwise retry or advance; use `include_screenshot:true` for multimodal agent reading.
 
 A declared session owns a colored agent-cursor overlay; it never moves the real pointer. Pure accessibility actions show only a brief first pulse. Use `move_cursor` or a pixel action first when a recording needs a visible glide.
 
@@ -474,6 +474,8 @@ mod agent_instruction_tests {
         assert!(instructions.contains("verify_state"));
         assert!(instructions.contains("`unknown` is not success"));
         assert!(instructions.contains("multimodal agent"));
+        assert!(instructions.contains("stop issuing actions"));
+        assert!(instructions.contains("end the session"));
         assert!(
             instructions.split_whitespace().count() <= 200,
             "initialize instructions should stay within the documented context budget"

--- a/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
@@ -823,6 +823,25 @@ mod tests {
     }
 
     #[test]
+    fn canonical_skill_makes_verified_completion_terminal() {
+        let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let skill = std::fs::read_to_string(crate_dir.join("../../Skills/cua-driver/SKILL.md"))
+            .expect("canonical skill must be readable");
+        let normalized = skill.split_whitespace().collect::<Vec<_>>().join(" ");
+
+        for required in [
+            "After each state-changing action",
+            "stop issuing actions immediately",
+            "end the session",
+        ] {
+            assert!(
+                normalized.contains(required),
+                "canonical skill must contain terminal completion guidance: {required}"
+            );
+        }
+    }
+
+    #[test]
     fn macos_skill_keeps_ax_only_and_non_prompting_permission_guidance() {
         let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let macos = std::fs::read_to_string(crate_dir.join("../../Skills/cua-driver/MACOS.md"))


### PR DESCRIPTION
## Summary
- make the MCP initialize guidance require postcondition verification after each state-changing action
- make verified completion terminal: stop GUI actions, end the session, and report completion
- keep the canonical skill, portable verify_state description, generated manifest, and reference docs aligned

## Tests
- cargo fmt --all -- --check
- CARGO_PROFILE_DEV_DEBUG=0 CARGO_INCREMENTAL=0 cargo test -p cua-driver-contract description_makes_satisfied_task_postconditions_terminal
- CARGO_PROFILE_DEV_DEBUG=0 CARGO_INCREMENTAL=0 cargo test -p cua-driver-core agent_instruction_tests::instructions_route_structured_and_visual_verification_to_the_right_owner
- CARGO_PROFILE_DEV_DEBUG=0 CARGO_INCREMENTAL=0 cargo run -p cua-driver-contract --bin cua-contract-gen -- all --check
- normalized canonical skill terminal-guidance assertion