### PR TITLE
fix(cua-driver): reuse existing app windows before launching

### DIFF
--- a/docs/content/docs/reference/cua-driver/mcp-tools.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools.mdx
@@ -160,7 +160,7 @@ Browser DevTools setup belongs to `browser_prepare`, which can prove that a sepa
 
 Optional `webkit_inspector_port`: opens a WebKit inspector server on the specified port (sets WEBKIT_INSPECTOR_SERVER=127.0.0.1:N + TAURI_WEBVIEW_AUTOMATION=1). Use this for Tauri/WebKit-based apps.
 
-Optional `creates_new_application_instance`: when true, forces a new app instance even if one is already running (passes -n to open). Reach for this when another agent or session may drive the SAME app concurrently — it returns a fresh pid + window so each session acts on its own isolated window instead of clobbering one shared instance. Without it, single-instance apps (Calculator, many utilities) hand every caller the same window, so two sessions fight over it.
+Optional `creates_new_application_instance`: when true, requests a new app instance even if one is already running. Reach for this when another agent or session may drive the SAME app concurrently — it returns a fresh pid + window so each session acts on its own isolated window instead of clobbering one shared instance. Without it, single-instance apps (Calculator, many utilities) hand every caller the same window, so two sessions fight over it. Apps that cannot create an isolated process return `NEW_APPLICATION_INSTANCE_UNAVAILABLE`; retry without the option only when sharing the existing process is safe.
 
 Optional `additional_arguments`: extra argv strings appended after --args.
 
@@ -170,7 +170,7 @@ Returns the launched app's pid, bundle_id, name, and a `windows` array (same sha
 
 - `additional_arguments` (array of string, optional): Extra arguments appended after --args when launching.
 - `bundle_id` (string, optional): App bundle identifier, e.g. com.apple.calculator. Preferred over name.
-- `creates_new_application_instance` (boolean, optional): When true, force a new app instance even if already running (open -n). Use for concurrent multi-agent/multi-session work so each session gets an isolated instance + window instead of sharing one — on single-instance apps (e.g. Calculator) every caller otherwise gets the same window and the sessions clobber each other.
+- `creates_new_application_instance` (boolean, optional): When true, request a new app instance even if already running. Use for concurrent multi-agent/multi-session work so each session gets an isolated instance + window instead of sharing one. Apps that cannot create an isolated process return NEW_APPLICATION_INSTANCE_UNAVAILABLE; retry without this option only when sharing the existing process is safe.
 - `name` (string, optional): App display name. Used only when bundle_id is absent.
 - `urls` (array of string, optional): Optional file paths or URLs to open with the app (e.g. a folder path for Finder).
 - `webkit_inspector_port` (integer, optional): Open a WebKit inspector server on this port (sets WEBKIT_INSPECTOR_SERVER env var).

--- a/docs/content/docs/reference/cua-driver/mcp-tools.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools.mdx
@@ -150,7 +150,11 @@ Return the session cursor's theme, semantic playback, position, visibility, and 
 
 ### `launch_app`
 
-Launch a macOS app in the background — the target does NOT come to the foreground.
+Atomically acquire a macOS app in the background. The default
+`instance_policy: "reuse_or_launch"` first returns an exact existing app/window
+without sending a launch request; only when no candidate can satisfy the input
+does it ask macOS to launch. The target does NOT intentionally come to the
+foreground.
 
 Provide either `bundle_id` (preferred — unambiguous, e.g. `com.apple.calculator`) or `name` (e.g. "Calculator"). If both are given, bundle_id wins.
 
@@ -160,18 +164,40 @@ Browser DevTools setup belongs to `browser_prepare`, which can prove that a sepa
 
 Optional `webkit_inspector_port`: opens a WebKit inspector server on the specified port (sets WEBKIT_INSPECTOR_SERVER=127.0.0.1:N + TAURI_WEBVIEW_AUTOMATION=1). Use this for Tauri/WebKit-based apps.
 
-Optional `creates_new_application_instance`: when true, requests a new app instance even if one is already running. Reach for this when another agent or session may drive the SAME app concurrently — it returns a fresh pid + window so each session acts on its own isolated window instead of clobbering one shared instance. Without it, single-instance apps (Calculator, many utilities) hand every caller the same window, so two sessions fight over it. Apps that cannot create an isolated process return `NEW_APPLICATION_INSTANCE_UNAVAILABLE`; retry without the option only when sharing the existing process is safe.
+Optional `instance_policy` controls acquisition: `reuse_or_launch` (default)
+reuses an exact candidate before launching; `reuse_only` never sends a launch
+request; and `new` requires a distinct application instance. Reserve `new` for
+a verified need to drive the same app concurrently, not merely because an
+earlier or sequential session used it. Apps that cannot create an isolated
+process return `NEW_APPLICATION_INSTANCE_UNAVAILABLE`; retry with
+`reuse_or_launch` only when sharing the existing process is safe.
+
+`creates_new_application_instance: true` is the deprecated compatibility
+spelling for `instance_policy: "new"`.
 
 Optional `additional_arguments`: extra argv strings appended after --args.
 
-Returns the launched app's pid, bundle_id, name, and a `windows` array (same shape as `list_windows`) so callers can skip an extra round-trip before `get_window_state(pid, window_id)`. `launch_state` distinguishes whether the request was sent, the process is running, and a window is ready. When the focus-steal belt-and-braces demotion check ran (target pid ≠ prior frontmost), the response also includes `self_activation_suppressed: bool` — true if focus stayed with the prior frontmost, false if the launched app held focus despite the re-demote attempt.
+Returns the acquired app's pid, bundle_id, name, canonical `instance_policy`,
+and a `windows` array (same shape as `list_windows`) so callers can skip an
+extra round-trip before `get_window_state(pid, window_id)`. `launch_state`
+retains the legacy `requested`, `process_running`, and `window_ready` booleans
+and adds `request_sent`, `process_disposition`
+(`reused` | `created` | `none`), and `window_disposition`
+(`reused` | `materialized` | `none`). These fields distinguish a true reuse
+from a launch request and newly materialized state. When the focus-steal
+belt-and-braces demotion check ran (target pid ≠ prior frontmost), the response
+also includes `self_activation_suppressed: bool` — true if focus stayed with the
+prior frontmost, false if the launched app held focus despite the re-demote
+attempt.
 
 **Arguments:**
 
 - `additional_arguments` (array of string, optional): Extra arguments appended after --args when launching.
 - `bundle_id` (string, optional): App bundle identifier, e.g. com.apple.calculator. Preferred over name.
-- `creates_new_application_instance` (boolean, optional): When true, request a new app instance even if already running. Use for concurrent multi-agent/multi-session work so each session gets an isolated instance + window instead of sharing one. Apps that cannot create an isolated process return NEW_APPLICATION_INSTANCE_UNAVAILABLE; retry without this option only when sharing the existing process is safe.
+- `creates_new_application_instance` (boolean, optional, deprecated): Compatibility alias for `instance_policy: "new"`.
+- `instance_policy` (string, optional): `reuse_or_launch` (default), `reuse_only`, or `new`. Unsupported `new` requests return NEW_APPLICATION_INSTANCE_UNAVAILABLE rather than silently reusing an instance.
 - `name` (string, optional): App display name. Used only when bundle_id is absent.
+- `session` (string, optional): Public lifecycle label. A first ordinary call with a fresh label creates that session lazily; repeat it on every later call that accepts it. Do not call `start_session` merely to begin.
 - `urls` (array of string, optional): Optional file paths or URLs to open with the app (e.g. a folder path for Finder).
 - `webkit_inspector_port` (integer, optional): Open a WebKit inspector server on this port (sets WEBKIT_INSPECTOR_SERVER env var).
 

--- a/docs/content/docs/reference/cua-driver/mcp-tools.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools.mdx
@@ -110,7 +110,7 @@ Return the logical size of the main display in points plus its backing scale fac
 
 **Arguments:**
 
-- `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+- `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that accepts it. The first ordinary call carrying a fresh label creates that session lazily; do not call start_session merely to begin. Use start_session only to configure the initial session state or revive an ended label. Omit session to use the authenticated transport's implicit lifecycle session.
 
 ### `get_cursor_position`
 
@@ -118,7 +118,7 @@ Return the current mouse cursor position in screen points (origin top-left).
 
 **Arguments:**
 
-- `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+- `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that accepts it. The first ordinary call carrying a fresh label creates that session lazily; do not call start_session merely to begin. Use start_session only to configure the initial session state or revive an ended label. Omit session to use the authenticated transport's implicit lifecycle session.
 
 ### `get_config`
 
@@ -150,13 +150,11 @@ Return the session cursor's theme, semantic playback, position, visibility, and 
 
 ### `launch_app`
 
-Atomically acquire a macOS app in the background. The default
-`instance_policy: "reuse_or_launch"` first returns an exact existing app/window
-without sending a launch request; only when no candidate can satisfy the input
-does it ask macOS to launch. The target does NOT intentionally come to the
-foreground.
+Resolve or launch a macOS app in the background — the target does NOT come to the foreground.
 
 Provide either `bundle_id` (preferred — unambiguous, e.g. `com.apple.calculator`) or `name` (e.g. "Calculator"). If both are given, bundle_id wins.
+
+`instance_policy` controls acquisition: `reuse_or_launch` (default) atomically reuses one exact existing app window before sending a launch request, `reuse_only` refuses rather than launching, and `new` requests an isolated process. Multiple exact running candidates are reported as ambiguous instead of guessing.
 
 Optional `urls` are handed to the app as open targets — for Finder, pass a folder path to open a backgrounded Finder window there.
 
@@ -164,40 +162,20 @@ Browser DevTools setup belongs to `browser_prepare`, which can prove that a sepa
 
 Optional `webkit_inspector_port`: opens a WebKit inspector server on the specified port (sets WEBKIT_INSPECTOR_SERVER=127.0.0.1:N + TAURI_WEBVIEW_AUTOMATION=1). Use this for Tauri/WebKit-based apps.
 
-Optional `instance_policy` controls acquisition: `reuse_or_launch` (default)
-reuses an exact candidate before launching; `reuse_only` never sends a launch
-request; and `new` requires a distinct application instance. Reserve `new` for
-a verified need to drive the same app concurrently, not merely because an
-earlier or sequential session used it. Apps that cannot create an isolated
-process return `NEW_APPLICATION_INSTANCE_UNAVAILABLE`; retry with
-`reuse_or_launch` only when sharing the existing process is safe.
-
-`creates_new_application_instance: true` is the deprecated compatibility
-spelling for `instance_policy: "new"`.
+`creates_new_application_instance` is a deprecated compatibility alias: true maps to `instance_policy: "new"`. Apps that cannot create an isolated process return `NEW_APPLICATION_INSTANCE_UNAVAILABLE`; retry with reuse only when sharing is safe.
 
 Optional `additional_arguments`: extra argv strings appended after --args.
 
-Returns the acquired app's pid, bundle_id, name, canonical `instance_policy`,
-and a `windows` array (same shape as `list_windows`) so callers can skip an
-extra round-trip before `get_window_state(pid, window_id)`. `launch_state`
-retains the legacy `requested`, `process_running`, and `window_ready` booleans
-and adds `request_sent`, `process_disposition`
-(`reused` | `created` | `none`), and `window_disposition`
-(`reused` | `materialized` | `none`). These fields distinguish a true reuse
-from a launch request and newly materialized state. When the focus-steal
-belt-and-braces demotion check ran (target pid ≠ prior frontmost), the response
-also includes `self_activation_suppressed: bool` — true if focus stayed with the
-prior frontmost, false if the launched app held focus despite the re-demote
-attempt.
+Returns the launched app's pid, bundle_id, name, and a `windows` array (same shape as `list_windows`) so callers can skip an extra round-trip before `get_window_state(pid, window_id)`. `launch_state` distinguishes whether the request was sent, whether the process/window was reused or created/materialized, and whether a window is ready. When the focus-steal belt-and-braces demotion check ran (target pid ≠ prior frontmost), the response also includes `self_activation_suppressed: bool` — true if focus stayed with the prior frontmost, false if the launched app held focus despite the re-demote attempt.
 
 **Arguments:**
 
 - `additional_arguments` (array of string, optional): Extra arguments appended after --args when launching.
 - `bundle_id` (string, optional): App bundle identifier, e.g. com.apple.calculator. Preferred over name.
-- `creates_new_application_instance` (boolean, optional, deprecated): Compatibility alias for `instance_policy: "new"`.
-- `instance_policy` (string, optional): `reuse_or_launch` (default), `reuse_only`, or `new`. Unsupported `new` requests return NEW_APPLICATION_INSTANCE_UNAVAILABLE rather than silently reusing an instance.
+- `creates_new_application_instance` (boolean, optional): Deprecated compatibility alias. True maps to instance_policy="new"; false maps to the default reuse_or_launch when instance_policy is omitted.
+- `instance_policy` (string, optional): Application acquisition policy. `reuse_or_launch` (default) reuses an exact existing app/window before requesting a launch; `reuse_only` never launches; `new` requires a distinct application instance and returns an explicit limitation when the platform or app cannot provide one. default: `"reuse_or_launch"`
 - `name` (string, optional): App display name. Used only when bundle_id is absent.
-- `session` (string, optional): Public lifecycle label. A first ordinary call with a fresh label creates that session lazily; repeat it on every later call that accepts it. Do not call `start_session` merely to begin.
+- `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that accepts it. The first ordinary call carrying a fresh label creates that session lazily; do not call start_session merely to begin. Use start_session only to configure the initial session state or revive an ended label. Omit session to use the authenticated transport's implicit lifecycle session.
 - `urls` (array of string, optional): Optional file paths or URLs to open with the app (e.g. a folder path for Finder).
 - `webkit_inspector_port` (integer, optional): Open a WebKit inspector server on this port (sets WEBKIT_INSPECTOR_SERVER env var).
 
@@ -235,7 +213,10 @@ Set one exact top-level window's frame in the desktop-coordinate space reported 
 - `height` (number, required): range: 1–unbounded
 - `pid` (integer, required): range: 1–unbounded
 - `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that
-accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+not call start_session merely to begin. Use start_session only to configure the initial
+session state or revive an ended label. Omit session to use the authenticated transport's
+implicit lifecycle session.
 - `width` (number, required): range: 1–unbounded
 - `window_id` (integer, required): range: 1–unbounded
 - `x` (number, required)
@@ -609,7 +590,10 @@ List available system clipboard types and optionally return privacy-sensitive pl
 - `include_text` (boolean, optional): Return plain-text clipboard content in addition to the available types.
 Clipboard content is privacy-sensitive and is never retained in telemetry. default: `false`
 - `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that
-accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+not call start_session merely to begin. Use start_session only to configure the initial
+session state or revive an ended label. Omit session to use the authenticated transport's
+implicit lifecycle session.
 
 ### `clipboard_write`
 
@@ -620,7 +604,10 @@ Replace the system clipboard with exactly one value: plain text, an image from a
 - `file_path` (string, optional): Absolute path to a local file to place on the clipboard as a file URL.
 - `image_path` (string, optional): Absolute path to a local image to place on the clipboard.
 - `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that
-accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+not call start_session merely to begin. Use start_session only to configure the initial
+session state or revive an ended label. Omit session to use the authenticated transport's
+implicit lifecycle session.
 - `text` (string, optional): Plain text to place on the clipboard.
 
 ## Recording tools
@@ -701,7 +688,7 @@ Note: capture_mode is a per-call param (on get_window_state / click), not a stor
 
 ### `start_session`
 
-Optionally create or return a lifecycle session before acting. For multi-call work, prefer a short public `session` label and repeat it on every call that accepts it; an omitted value uses the authenticated transport lease's implicit session instead. This tool is optional because an ordinary action can create or reuse a named run directly. Use it to set the initial cursor theme before acting or to revive a public name after it has ended; ordinary actions never revive ended names. `capture_scope` is deprecated compatibility input; new callers select window or desktop modality per action. Idempotent.
+Configure or revive a lifecycle session explicitly. Do not call this tool merely to begin: the first ordinary call carrying a fresh public `session` label creates that session lazily, and later calls reuse it when they repeat the label. An omitted value uses the authenticated transport lease's implicit session instead. Use start_session to set the initial cursor theme before acting or to revive a public name after it has ended; ordinary actions never revive ended names. `capture_scope` is deprecated compatibility input; new callers select window or desktop modality per action. Idempotent.
 
 **Arguments:**
 
@@ -846,8 +833,10 @@ Deterministically verify bounded predicates against one exact window. The driver
 caller. The driver does not interpret that image.
 - `pid` (integer, required): Exact process whose window may be observed. range: 1–unbounded
 - `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that
-accepts it. Omit it to use the authenticated transport's implicit lifecycle session. This
-field never selects capture modality or authorization.
+accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+not call start_session merely to begin. Use start_session only to configure the initial
+session state or revive an ended label. Omit session to use the authenticated transport's
+implicit lifecycle session. This field never selects capture modality or authorization.
 - `stable_samples` (integer, optional): Consecutive satisfied samples required before returning success. default: `2`; range: 1–5
 - `timeout_ms` (integer, optional): Bounded wait. Zero performs one sample. default: `5000`; range: 0–10000
 - `window_id` (integer, required): Exact native window identifier.
@@ -865,7 +854,10 @@ Resolve an exact application-menu path one live native level at a time and invok
 - `path` (array of string, required): items: 1–16
 - `pid` (integer, required): range: 1–unbounded
 - `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that
-accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+not call start_session merely to begin. Use start_session only to configure the initial
+session state or revive an ended label. Omit session to use the authenticated transport's
+implicit lifecycle session.
 - `window_id` (integer, required): range: 1–unbounded
 
 ```json
@@ -897,7 +889,7 @@ Read-only browser inspection. Mode 1 (bind): pass pid + window_id of a native br
 - `pid` (integer, optional): Native browser process id (bind mode).
 - `query` (string, optional): Read-only semantic match over role, accessible name, and visible text.
 - `scope_ref` (string, optional): Current semantic/content ref whose subtree should be observed.
-- `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that accepts it. Omit it to use the authenticated transport's implicit lifecycle session. Browser targets, tabs, and refs belong to the resolved lifecycle session.
+- `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that accepts it. The first ordinary call carrying a fresh label creates that session lazily; do not call start_session merely to begin. Use start_session only to configure the initial session state or revive an ended label. Omit session to use the authenticated transport's implicit lifecycle session. Browser targets, tabs, and refs belong to the resolved lifecycle session.
 - `snapshot_format` (string, optional): Versioned snapshot contract. dom_refs_v1 remains the compatibility default.
 - `tab_id` (string, optional): Opaque tab id from get_browser_state (session-scoped).
 - `target_id` (string, optional): Opaque browser target id minted by get_browser_state (session-scoped; never a CDP id).
@@ -913,7 +905,7 @@ Explicitly prepare an owned DevTools endpoint for a browser pid. Existing endpoi
 - `approval_token` (string, optional): Legacy single-use setup token. Existing-profile use is disabled unless a trusted launcher explicitly enables the same-user-writable compatibility path.
 - `pid` (integer, required): Browser process id to prepare.
 - `profile` (object, optional)
-- `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that accepts it. Omit it to use the authenticated transport's implicit lifecycle session. Browser targets, tabs, and refs belong to the resolved lifecycle session.
+- `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that accepts it. The first ordinary call carrying a fresh label creates that session lazily; do not call start_session merely to begin. Use start_session only to configure the initial session state or revive an ended label. Omit session to use the authenticated transport's implicit lifecycle session. Browser targets, tabs, and refs belong to the resolved lifecycle session.
 - `strategy` (object, optional)
 - `window_id` (integer, optional): Exact native window approval anchor; required for strategy.kind=existing_profile.
 
@@ -927,7 +919,7 @@ Navigate one tab of an exactly-bound browser target to a new URL (http/https/abo
 
 **Arguments:**
 
-- `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that accepts it. Omit it to use the authenticated transport's implicit lifecycle session. Browser targets, tabs, and refs belong to the resolved lifecycle session.
+- `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that accepts it. The first ordinary call carrying a fresh label creates that session lazily; do not call start_session merely to begin. Use start_session only to configure the initial session state or revive an ended label. Omit session to use the authenticated transport's implicit lifecycle session. Browser targets, tabs, and refs belong to the resolved lifecycle session.
 - `tab_id` (string, required): Opaque tab id from get_browser_state (session-scoped).
 - `target_id` (string, required): Opaque browser target id minted by get_browser_state (session-scoped; never a CDP id).
 - `url` (string, required): Destination URL (http:, https:, or about:).
@@ -944,7 +936,7 @@ Click a page element (by ref) or viewport coordinates in an exactly-bound tab. D
 
 - `input_route` (string, optional): "trusted" (default): Input.dispatchMouseEvent. It refuses rather than foregrounding a standalone browser. "dom_event": synthetic full-background DOM click, only when explicitly requested. Dispatch does not prove the control activated; refresh page state and verify the expected postcondition.
 - `ref` (string, optional): Page element ref in the p&lt;snapshot&gt;:&lt;index&gt; namespace from get_browser_state. Refs are invalidated by navigation and by newer snapshots of the same tab.
-- `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that accepts it. Omit it to use the authenticated transport's implicit lifecycle session. Browser targets, tabs, and refs belong to the resolved lifecycle session.
+- `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that accepts it. The first ordinary call carrying a fresh label creates that session lazily; do not call start_session merely to begin. Use start_session only to configure the initial session state or revive an ended label. Omit session to use the authenticated transport's implicit lifecycle session. Browser targets, tabs, and refs belong to the resolved lifecycle session.
 - `tab_id` (string, required): Opaque tab id from get_browser_state (session-scoped).
 - `target_id` (string, required): Opaque browser target id minted by get_browser_state (session-scoped; never a CDP id).
 - `x` (number, optional): Viewport x (CSS px) — alternative to ref.
@@ -963,7 +955,7 @@ Type text into an exactly-bound tab via the Input domain. mode="insert_text" (de
 - `mode` (string, optional): insert_text (default): bulk Input.insertText. keystrokes: per-character Input.dispatchKeyEvent.
 - `ref` (string, required): Page element ref in the p&lt;snapshot&gt;:&lt;index&gt; namespace from get_browser_state. Refs are invalidated by navigation and by newer snapshots of the same tab.
 - `replace` (boolean, optional): false (default): insert at the caret, appending to whatever the field already holds. true: select the element's whole content first so the text replaces it — with an empty text this clears the field. Replacement goes through the selection, so beforeinput/input still fire and framework state stays consistent.
-- `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that accepts it. Omit it to use the authenticated transport's implicit lifecycle session. Browser targets, tabs, and refs belong to the resolved lifecycle session.
+- `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that accepts it. The first ordinary call carrying a fresh label creates that session lazily; do not call start_session merely to begin. Use start_session only to configure the initial session state or revive an ended label. Omit session to use the authenticated transport's implicit lifecycle session. Browser targets, tabs, and refs belong to the resolved lifecycle session.
 - `tab_id` (string, required): Opaque tab id from get_browser_state (session-scoped).
 - `target_id` (string, required): Opaque browser target id minted by get_browser_state (session-scoped; never a CDP id).
 - `text` (string, required): Text to type.
@@ -982,7 +974,7 @@ Inspect or resolve a page-owned JavaScript alert, confirm, prompt, or beforeunlo
 - `delivery_mode` (string, optional): Requested foreground posture for accept/dismiss. Linux Chromium requires foreground; inspect is read-only. default: `"background"`
 - `dialog_id` (string, optional): Opaque current dialog generation returned by action=inspect.
 - `prompt_text` (string, optional): Sensitive response text, valid only when accepting a prompt dialog.
-- `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that accepts it. Omit it to use the authenticated transport's implicit lifecycle session. Browser targets, tabs, and refs belong to the resolved lifecycle session.
+- `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that accepts it. The first ordinary call carrying a fresh label creates that session lazily; do not call start_session merely to begin. Use start_session only to configure the initial session state or revive an ended label. Omit session to use the authenticated transport's implicit lifecycle session. Browser targets, tabs, and refs belong to the resolved lifecycle session.
 - `tab_id` (string, required): Opaque tab id from get_browser_state (session-scoped).
 - `target_id` (string, required): Opaque browser target id minted by get_browser_state (session-scoped; never a CDP id).
 
@@ -998,7 +990,7 @@ Assign one or more explicit absolute local files to an exact live &lt;input type
 
 - `files` (array of string, required): items: 1–32
 - `ref` (string, required): Page element ref in the p&lt;snapshot&gt;:&lt;index&gt; namespace from get_browser_state. Refs are invalidated by navigation and by newer snapshots of the same tab.
-- `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that accepts it. Omit it to use the authenticated transport's implicit lifecycle session. Browser targets, tabs, and refs belong to the resolved lifecycle session.
+- `session` (string, optional): For multi-call work, prefer a short public session label and repeat it on every call that accepts it. The first ordinary call carrying a fresh label creates that session lazily; do not call start_session merely to begin. Use start_session only to configure the initial session state or revive an ended label. Omit session to use the authenticated transport's implicit lifecycle session. Browser targets, tabs, and refs belong to the resolved lifecycle session.
 - `tab_id` (string, required): Opaque tab id from get_browser_state (session-scoped).
 - `target_id` (string, required): Opaque browser target id minted by get_browser_state (session-scoped; never a CDP id).
 

--- a/libs/cua-driver/contract/manifest.json
+++ b/libs/cua-driver/contract/manifest.json
@@ -51,7 +51,7 @@
             "description": "Deprecated flat desktop target retained for wire compatibility."
           },
           "session": {
-            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. Omit it to use the authenticated transport's implicit lifecycle session.",
+            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. The first ordinary call carrying a fresh label creates that session lazily; do\nnot call start_session merely to begin. Use start_session only to configure the initial\nsession state or revive an ended label. Omit session to use the authenticated transport's\nimplicit lifecycle session.",
             "type": "string"
           },
           "target": {
@@ -267,7 +267,7 @@
             "type": "boolean"
           },
           "session": {
-            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. Omit it to use the authenticated transport's implicit lifecycle session.",
+            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. The first ordinary call carrying a fresh label creates that session lazily; do\nnot call start_session merely to begin. Use start_session only to configure the initial\nsession state or revive an ended label. Omit session to use the authenticated transport's\nimplicit lifecycle session.",
             "type": "string"
           }
         },
@@ -350,7 +350,7 @@
             "type": "string"
           },
           "session": {
-            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. Omit it to use the authenticated transport's implicit lifecycle session.",
+            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. The first ordinary call carrying a fresh label creates that session lazily; do\nnot call start_session merely to begin. Use start_session only to configure the initial\nsession state or revive an ended label. Omit session to use the authenticated transport's\nimplicit lifecycle session.",
             "type": "string"
           },
           "text": {
@@ -447,7 +447,7 @@
             "description": "Deprecated flat desktop target retained for wire compatibility."
           },
           "session": {
-            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. Omit it to use the authenticated transport's implicit lifecycle session.",
+            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. The first ordinary call carrying a fresh label creates that session lazily; do\nnot call start_session merely to begin. Use start_session only to configure the initial\nsession state or revive an ended label. Omit session to use the authenticated transport's\nimplicit lifecycle session.",
             "type": "string"
           },
           "steps": {
@@ -1050,7 +1050,7 @@
         "additionalProperties": false,
         "properties": {
           "session": {
-            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. Omit it to use the authenticated transport's implicit lifecycle session.",
+            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. The first ordinary call carrying a fresh label creates that session lazily; do\nnot call start_session merely to begin. Use start_session only to configure the initial\nsession state or revive an ended label. Omit session to use the authenticated transport's\nimplicit lifecycle session.",
             "type": "string"
           }
         },
@@ -1106,7 +1106,7 @@
             "type": "string"
           },
           "session": {
-            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. Omit it to use the authenticated transport's implicit lifecycle session.",
+            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. The first ordinary call carrying a fresh label creates that session lazily; do\nnot call start_session merely to begin. Use start_session only to configure the initial\nsession state or revive an ended label. Omit session to use the authenticated transport's\nimplicit lifecycle session.",
             "type": "string"
           }
         },
@@ -1187,7 +1187,7 @@
         "additionalProperties": false,
         "properties": {
           "session": {
-            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. Omit it to use the authenticated transport's implicit lifecycle session.",
+            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. The first ordinary call carrying a fresh label creates that session lazily; do\nnot call start_session merely to begin. Use start_session only to configure the initial\nsession state or revive an ended label. Omit session to use the authenticated transport's\nimplicit lifecycle session.",
             "type": "string"
           }
         },
@@ -1451,7 +1451,7 @@
             "description": "Deprecated flat desktop target retained for wire compatibility."
           },
           "session": {
-            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. Omit it to use the authenticated transport's implicit lifecycle session.",
+            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. The first ordinary call carrying a fresh label creates that session lazily; do\nnot call start_session merely to begin. Use start_session only to configure the initial\nsession state or revive an ended label. Omit session to use the authenticated transport's\nimplicit lifecycle session.",
             "type": "string"
           },
           "target": {
@@ -1670,7 +1670,7 @@
             "type": "integer"
           },
           "session": {
-            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. Omit it to use the authenticated transport's implicit lifecycle session.",
+            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. The first ordinary call carrying a fresh label creates that session lazily; do\nnot call start_session merely to begin. Use start_session only to configure the initial\nsession state or revive an ended label. Omit session to use the authenticated transport's\nimplicit lifecycle session.",
             "type": "string"
           },
           "window_id": {
@@ -1966,7 +1966,7 @@
             "description": "Deprecated flat desktop target retained for wire compatibility."
           },
           "session": {
-            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. Omit it to use the authenticated transport's implicit lifecycle session.",
+            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. The first ordinary call carrying a fresh label creates that session lazily; do\nnot call start_session merely to begin. Use start_session only to configure the initial\nsession state or revive an ended label. Omit session to use the authenticated transport's\nimplicit lifecycle session.",
             "type": "string"
           },
           "target": {
@@ -2191,7 +2191,7 @@
             "description": "Deprecated flat desktop target retained for wire compatibility."
           },
           "session": {
-            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. Omit it to use the authenticated transport's implicit lifecycle session.",
+            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. The first ordinary call carrying a fresh label creates that session lazily; do\nnot call start_session merely to begin. Use start_session only to configure the initial\nsession state or revive an ended label. Omit session to use the authenticated transport's\nimplicit lifecycle session.",
             "type": "string"
           },
           "target": {
@@ -2420,7 +2420,7 @@
             "description": "Deprecated flat desktop target retained for wire compatibility."
           },
           "session": {
-            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. Omit it to use the authenticated transport's implicit lifecycle session.",
+            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. The first ordinary call carrying a fresh label creates that session lazily; do\nnot call start_session merely to begin. Use start_session only to configure the initial\nsession state or revive an ended label. Omit session to use the authenticated transport's\nimplicit lifecycle session.",
             "type": "string"
           },
           "target": {
@@ -2947,7 +2947,7 @@
             "type": "integer"
           },
           "session": {
-            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. Omit it to use the authenticated transport's implicit lifecycle session.",
+            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. The first ordinary call carrying a fresh label creates that session lazily; do\nnot call start_session merely to begin. Use start_session only to configure the initial\nsession state or revive an ended label. Omit session to use the authenticated transport's\nimplicit lifecycle session.",
             "type": "string"
           },
           "width": {
@@ -3092,7 +3092,7 @@
     },
     {
       "name": "start_session",
-      "description": "Optionally create or return a lifecycle session before acting. For multi-call work, prefer a short public `session` label and repeat it on every call that accepts it; an omitted value uses the authenticated transport lease's implicit session instead. This tool is optional because an ordinary action can create or reuse a named run directly. Use it to set the initial cursor theme before acting or to revive a public name after it has ended; ordinary actions never revive ended names. `capture_scope` is deprecated compatibility input; new callers select window or desktop modality per action. Idempotent.",
+      "description": "Configure or revive a lifecycle session explicitly. Do not call this tool merely to begin: the first ordinary call carrying a fresh public `session` label creates that session lazily, and later calls reuse it when they repeat the label. An omitted value uses the authenticated transport lease's implicit session instead. Use start_session to set the initial cursor theme before acting or to revive a public name after it has ended; ordinary actions never revive ended names. `capture_scope` is deprecated compatibility input; new callers select window or desktop modality per action. Idempotent.",
       "platforms": [
         "macos",
         "windows",
@@ -3258,7 +3258,7 @@
             "description": "Deprecated flat desktop target retained for wire compatibility."
           },
           "session": {
-            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. Omit it to use the authenticated transport's implicit lifecycle session.",
+            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. The first ordinary call carrying a fresh label creates that session lazily; do\nnot call start_session merely to begin. Use start_session only to configure the initial\nsession state or revive an ended label. Omit session to use the authenticated transport's\nimplicit lifecycle session.",
             "type": "string"
           },
           "target": {
@@ -3588,7 +3588,7 @@
             "type": "integer"
           },
           "session": {
-            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. Omit it to use the authenticated transport's implicit lifecycle session. This\nfield never selects capture modality or authorization.",
+            "description": "For multi-call work, prefer a short public session label and repeat it on every call that\naccepts it. The first ordinary call carrying a fresh label creates that session lazily; do\nnot call start_session merely to begin. Use start_session only to configure the initial\nsession state or revive an ended label. Omit session to use the authenticated transport's\nimplicit lifecycle session. This field never selects capture modality or authorization.",
             "type": "string"
           },
           "stable_samples": {

--- a/libs/cua-driver/python/src/cua_driver/_native_contract.py
+++ b/libs/cua-driver/python/src/cua_driver/_native_contract.py
@@ -5244,6 +5244,62 @@ class _UniffiFfiConverterTypeVerifyStateOutput(_UniffiConverterRustBuffer):
 
 
 
+class InstancePolicy(enum.Enum):
+    """
+    How `launch_app` acquires an application process/window.
+
+    The portable default reuses an exact existing candidate before asking the
+    operating system to launch anything. Callers that require a stronger
+    guarantee must opt into `reuse_only` or `new` explicitly; a platform that
+    cannot honor `new` reports that limitation instead of silently degrading.
+"""
+
+    REUSE_OR_LAUNCH = 0
+
+    REUSE_ONLY = 1
+
+    NEW = 2
+
+
+
+class _UniffiFfiConverterTypeInstancePolicy(_UniffiConverterRustBuffer):
+    @staticmethod
+    def read(buf):
+        variant = buf.read_i32()
+        if variant == 1:
+            return InstancePolicy.REUSE_OR_LAUNCH
+        if variant == 2:
+            return InstancePolicy.REUSE_ONLY
+        if variant == 3:
+            return InstancePolicy.NEW
+        raise InternalError("Raw enum value doesn't match any cases")
+
+    @staticmethod
+    def check_lower(value):
+        if value == InstancePolicy.REUSE_OR_LAUNCH:
+            return
+        if value == InstancePolicy.REUSE_ONLY:
+            return
+        if value == InstancePolicy.NEW:
+            return
+        raise ValueError(value)
+
+    @staticmethod
+    def write(value, buf):
+        if value == InstancePolicy.REUSE_OR_LAUNCH:
+            buf.write_i32(1)
+        if value == InstancePolicy.REUSE_ONLY:
+            buf.write_i32(2)
+        if value == InstancePolicy.NEW:
+            buf.write_i32(3)
+
+
+
+
+
+
+
+
 class Platform(enum.Enum):
 
     MACOS = 0
@@ -5323,6 +5379,7 @@ __all__ = [
     "ScrollBy",
     "CaptureScope",
     "EffectiveScope",
+    "InstancePolicy",
     "Platform",
     "ActionDelivery",
     "ActionEscalation",

--- a/libs/cua-driver/rust/Skills/cua-driver/BROWSER.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/BROWSER.md
@@ -15,8 +15,7 @@ mints session-scoped tab and element capabilities.
 The canonical loop is:
 
 ```text
-start_session(session?)                                  # optional; can name before acting
-list_windows or launch_app
+launch_app(..., session?, instance_policy=reuse_or_launch) # first named call creates session lazily
 get_browser_state(pid, window_id, session?)               # bind
 get_browser_state(target_id, tab_id, session?,
                   snapshot_format=semantic_v2)            # snapshot
@@ -28,13 +27,16 @@ end_session(session?)                                     # optional cleanup
 ```
 
 For a multi-call browser workflow, prefer a short `session` label and pass the
-same value on every call that accepts it. Passing it once is not sticky; a later
-omitted value uses the transport's implicit session. One long-lived MCP or SDK
-transport may omit `session` for one-off or deliberately unlabeled work; its
-first admitted call creates one implicit session and later unnamed calls reuse
-it. Direct one-shot CLI calls use disposable transports. Never substitute a raw
-CDP target id, tab ordinal, URL match, or remembered ref for a capability
-returned by `get_browser_state`.
+same value on the first ordinary call and every later call that accepts it. The
+first named call creates that session lazily; do not call `start_session` merely
+to begin. Passing a label once is not sticky; a later omitted value uses the
+transport's implicit session. Use `start_session` only for initial configuration
+or to revive an ended label. One long-lived MCP or SDK transport may omit
+`session` for one-off or deliberately unlabeled work; its first admitted call
+creates one implicit session and later unnamed calls reuse it.
+Direct one-shot CLI calls use disposable transports. Never substitute a raw CDP target id, tab
+ordinal, URL match, or remembered ref for a capability returned by
+`get_browser_state`.
 
 ### Copy page content to the system clipboard
 
@@ -78,11 +80,18 @@ Start or discover the app with the native tools and select one returned
 `window_id`:
 
 ```bash
-cua-driver start_session '{"session":"browser-run-1"}'
-cua-driver list_windows '{"pid":4242}'
+cua-driver launch_app \
+  '{"bundle_id":"com.google.Chrome","session":"browser-run-1"}'
+# Use pid and window_id from launch_app's reuse-or-launch result.
 cua-driver get_browser_state \
   '{"pid":4242,"window_id":991,"session":"browser-run-1"}'
 ```
+
+Do not call `list_apps` or `list_windows` merely to decide whether to launch.
+`launch_app` performs that acquisition atomically: its default
+`instance_policy:"reuse_or_launch"` returns an exact existing app/window when
+available, then requests a launch only when needed. Use `list_windows` when you
+already have a long-lived pid and need to choose among its current windows.
 
 Continue to mutation only when the bind result reports:
 

--- a/libs/cua-driver/rust/Skills/cua-driver/MACOS.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/MACOS.md
@@ -88,9 +88,11 @@ element action when the same command has an ordinary control, and prefer
 menu bars” below.
 
 **"Open \<app\>" in user speech means launch, not activate.**
-`cua-driver launch_app` is the one correct path for process
-startup — it's idempotent (no-op on a running app), returns the
-pid, and has an internal `FocusRestoreGuard` that catches
+`cua-driver launch_app` is the one correct path for acquiring the target. Its
+default `reuse_or_launch` policy returns an exact existing app/window without
+sending a launch request when the requested inputs permit reuse. Otherwise it
+starts or opens through the background launch path, returns the pid, and uses
+an internal `FocusRestoreGuard` that catches
 `NSApp.activate(ignoringOtherApps:)` calls the target makes during
 `application(_:open:)` and clobbers the frontmost back to what it
 was before the launch. That guard is why `launch_app` with `urls`
@@ -243,23 +245,31 @@ editor state.
      the user should click **+**, add `/Applications/CuaDriver.app` (or
      `/Applications/CuaDriverLocal.app`), enable it, and rerun the command.
 
-## Resolve target pid — always via `launch_app`
+## Acquire the target — always via `launch_app`
 
 **Always start with `launch_app`**, whether or not the target is already
-running. It's idempotent (relaunching returns the existing pid with no
-side effects) and gives you the pid in one call — no `list_apps` hop.
+running. Its default `instance_policy: "reuse_or_launch"` atomically checks for
+an exact reusable app/window and returns it without a launch request; only when
+none is reusable does it ask macOS to launch. This gives you the pid and windows
+in one call without a racy `list_apps` / `list_windows` preflight.
 
 - `launch_app({bundle_id: "com.apple.finder"})` — preferred, unambiguous.
 - `launch_app({name: "Calculator"})` — when bundle_id isn't known.
 
-`launch_app` is a **hidden-launch primitive by design** — that's the
-entire point of cua-driver: agents drive apps in the background while
-the user keeps typing in their real foreground app. The target's
-window is initialized (AX tree fully populated, clickable via
-`element_index`, the pid appears in `list_apps`) but not drawn on
-screen. The driver never activates or unhides apps on its own; that
-would violate the no-foreground contract the whole driver exists to
-protect.
+Use `instance_policy: "reuse_only"` when the task must not start anything. Use
+`instance_policy: "new"` only after verifying that another live run must drive
+the same app concurrently. If macOS or the app cannot create a distinct
+process, the tool returns `NEW_APPLICATION_INSTANCE_UNAVAILABLE`; never pretend
+the shared existing instance is isolated. The legacy
+`creates_new_application_instance: true` spelling remains compatible.
+
+When a launch request is necessary, `launch_app` is a **hidden-launch primitive
+by design** — that's the entire point of cua-driver: agents drive apps in the
+background while the user keeps typing in their real foreground app. A reused
+window keeps its existing visibility and geometry; a newly materialized target
+is initialized for background control. The driver never intentionally activates
+or unhides apps on its own; that would violate the no-foreground contract the
+whole driver exists to protect.
 
 If the user explicitly wants the window visible (usually for a demo
 or recording), they unhide it themselves — Dock click, Cmd-Tab, or
@@ -496,9 +506,10 @@ starting point for new browser workflows.
 
 1. `launch_app({bundle_id: "com.apple.finder", urls: ["~/Downloads"]})`
    → `{pid: 844, windows: [{window_id: 6123, title: "Downloads", ...}]}`.
-   Idempotent launch; plus Finder opens a hidden window rooted at
-   `~/Downloads` via `application(_:open:)` — zero activation, no
-   focus steal. The `windows` array lets you skip a `list_windows` hop.
+   Because the URL must be delivered, Finder opens a background window rooted
+   at `~/Downloads` via `application(_:open:)`; the result reports whether the
+   process was reused and whether a request was sent. The `windows` array lets
+   you skip a `list_windows` hop.
 2. `get_window_state({pid: 844, window_id: 6123})` → verify an
    `AXWindow` whose title contains "Downloads" is present with a
    populated AX subtree (sidebar, list view, files).

--- a/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
@@ -223,12 +223,12 @@ launch idioms in the per-OS companion file):
 
 ```bash
 cua-driver serve
-cua-driver launch_app '{"bundle_id":"..."}'
+cua-driver launch_app '{"bundle_id":"...","session":"example"}'
 # → {pid: 844, windows: [{window_id: 10725, ...}]}
-cua-driver get_window_state '{"pid":844,"window_id":10725}'
+cua-driver get_window_state '{"pid":844,"window_id":10725,"session":"example"}'
 # Use the returned structuredContent.elements[].element_token:
-cua-driver click '{"pid":844,"element_token":"s0000002a:14"}'
-cua-driver verify_state '{"pid":844,"window_id":10725,"expect":[{"element":{"selector":{"label_contains":"Saved"},"exists":true}}]}'
+cua-driver click '{"pid":844,"element_token":"s0000002a:14","session":"example"}'
+cua-driver verify_state '{"pid":844,"window_id":10725,"session":"example","expect":[{"element":{"selector":{"label_contains":"Saved"},"exists":true}}]}'
 cua-driver stop
 ```
 
@@ -381,13 +381,14 @@ The window target uses window-local coordinates and the background/foreground
 delivery ladder. The desktop target uses screen coordinates and foreground
 delivery. A desktop action does not disable window tools for later calls.
 
-`start_session` is optional. For a multi-call run, prefer a short public
-`session` label and pass the same label on every call that accepts it. The label
-is call-scoped: if a later call omits it, that call uses the authenticated
-transport's implicit session instead. Unnamed calls on one transport reuse that
-implicit identity. The default idle TTL is five minutes. Call
-`start_session(session)` to name or configure a run before acting, or to revive
-an ended name.
+For a multi-call run, pass a short public `session` label on the first ordinary
+call and repeat the same label on every call that accepts it. That first action
+creates a fresh named session lazily, so do not call `start_session` merely to
+begin. The label is call-scoped: if a later call omits it, that call uses the
+authenticated transport's implicit session instead. Unnamed calls on one
+transport reuse that implicit identity. The default idle TTL is five minutes.
+Use `start_session(session)` only when initial configuration (such as a cursor
+theme) must exist before the first action, or to revive an ended name.
 
 Do not use `config set capture_scope` or `set_config`; that key is retired and
 stale values on disk are ignored. `start_session.capture_scope`,
@@ -648,7 +649,7 @@ last resort.
 
 ```
 # for multi-call work, repeat the same session label on every call that accepts it
-launch_app(target, session)
+launch_app(target, session, instance_policy="reuse_or_launch")
   → pick window_id from the returned `windows` array
     (or call list_windows(pid) separately)
   → get_window_state(pid, window_id)
@@ -667,25 +668,37 @@ common case collapses to two calls (`launch_app` → `get_window_state`)
 without a separate `list_windows` hop.
 
 **Prefer a named session for multi-call work.** Choose a short label (for
-example, `session: "research-1"`) and pass the same value on every call that
-accepts it. Passing it once is not sticky: a later call that omits `session`
-uses the transport's implicit session. Call `start_session(session)` when you
-need to name or configure the run before acting, or to revive a name after
-`end_session`. For one-off or deliberately unlabeled work, omission is valid
-and the transport still gets one private lifecycle identity and visible agent
-cursor. A public label makes inspection and cleanup easier, but it is not a
-credential. End with `end_session` when useful; transport close or the
+example, `session: "research-1"`) and pass it on the first ordinary call. That
+call creates the named session lazily; repeat the value on every later call
+that accepts it. Passing it once is not sticky: a later call that omits
+`session` uses the transport's implicit session. Do not call `start_session`
+merely to begin; use it only for initial configuration or to revive a name
+after `end_session`. For one-off or deliberately unlabeled work, omission is
+valid and the transport still gets one private lifecycle identity and visible
+agent cursor. A public label makes inspection and cleanup easier, but it is not
+a credential. End with `end_session` when useful; transport close or the
 five-minute idle TTL also reclaims it.
 
+**Acquire the app atomically.** Call `launch_app` directly with its default
+`instance_policy: "reuse_or_launch"`. It first resolves an exact existing
+process/window and returns it without sending a launch request; only when none
+is reusable does it ask the OS to launch. Do not preflight with `list_apps` or
+`list_windows`: an extra read adds latency and can race the acquisition. Use
+`reuse_only` when launching is forbidden and handle its typed no-match result.
+Use `new` only when the task has a verified need for a distinct process that
+will be driven concurrently; unsupported apps/platforms return an explicit
+limitation. The legacy `creates_new_application_instance: true` input remains
+a compatibility spelling for `instance_policy: "new"` where supported.
+
 **Concurrent runs/subagents:** each transport gets its own implicit session.
-Also,
-`launch_app` is idempotent — two runs that
-launch the same app get the **same** instance (and on single-instance apps
-like Calculator, the same window), so they clobber each other. Give each run
-its **own connection** (for independent lifecycle/cursor ownership) AND pass
-`creates_new_application_instance: true` to `launch_app` (→ its own window).
-The element cache is keyed on `(pid, window_id)` and the cursor on the private
-lifecycle session, so distinct instances and transports keep the runs isolated.
+Default `reuse_or_launch` intentionally returns the same exact existing
+instance/window, so simultaneous agents would clobber each other. Only after
+verifying that two live runs must drive the same app at the same time, give each
+run its **own connection** (for independent lifecycle/cursor ownership) and
+pass `instance_policy: "new"`. Do not request `new` merely because an earlier
+session existed or sequential work uses another label. The element cache is
+keyed on `(pid, window_id)` and the cursor on the private lifecycle session, so
+distinct supported instances and transports keep concurrent runs isolated.
 
 **Parallelism vs. ordering.** Distinct sessions give distinct _cursors_, not
 distinct _connections_. Subagents that share one `cua-driver mcp` (stdio)
@@ -701,8 +714,8 @@ serves connections concurrently; per-connection ordering keeps each agent's own
 sequence (e.g. `3 → + → 1 → =`) correct.
 
 `list_apps` is for app-level discovery (answering "what's installed /
-running / frontmost?") — not part of the core action loop. Skip it
-in the loop. For **window-level** questions — "does this app have a
+running / frontmost?") — not an app-acquisition preflight and not part of the
+core action loop. Skip it in the loop. For **window-level** questions — "does this app have a
 visible window?", "which desktop is this window on?", "which of this
 pid's windows is the main one?" — call `list_windows` instead; the
 app record doesn't carry window state on purpose. In the common
@@ -839,7 +852,8 @@ coordinates only when the accessibility tree can't.
 
 ## Cross-platform parameter contract
 
-The capture, dispatch, and addressing params — `session`,
+The acquisition, capture, dispatch, and addressing params — `session`,
+`instance_policy`,
 `delivery_mode`, `capture_mode` (deprecated/ignored — see the behavior
 matrix; still in the schema only so old callers don't error), `scope`,
 `modifier`, `button`, `element_index`, `snapshot_id`, `element_token` — are a **shared
@@ -861,6 +875,10 @@ Two consequences for callers:
   schema-accepted everywhere else — so the same `session` you pass on
   macOS is no longer _rejected_ by Windows/Linux, which previously
   refused unknown keys via `additionalProperties:false`.
+- **`instance_policy` is accepted by `launch_app` on all three platforms.**
+  Its portable default is `reuse_or_launch`; `reuse_only` never launches, and
+  `new` either returns a distinct instance or an explicit unsupported
+  limitation. A backend must not silently weaken the requested policy.
 - **`delivery_mode` (`"background"` default / `"foreground"`) is on the
   whole input family** — `click`, `double_click`, `right_click`, `drag`,
   `scroll`, `type_text`, `press_key`, `hotkey` — uniformly. The
@@ -1068,12 +1086,13 @@ respective companion files.
 
 **User:** "Open the Downloads folder in the system file manager."
 
-1. `launch_app({bundle_id: "com.apple.finder", urls: ["~/Downloads"]})`
+1. `launch_app({bundle_id: "com.apple.finder", urls: ["~/Downloads"],
+   session: "downloads"})`
    on macOS, or `launch_app({name: "explorer", args: ["%USERPROFILE%\\Downloads"]})`
    on Windows. Returns `{pid, windows: [{window_id, title, ...}]}`.
-   Idempotent launch; the driver opens a hidden window via the
-   platform's launch primitive — zero activation, no focus steal.
-2. `get_window_state({pid, window_id})` → verify the expected window
+   The default reuse-first policy returns an exact existing app/window when it
+   can and otherwise requests a background launch.
+2. `get_window_state({pid, window_id, session: "downloads"})` → verify the expected window
    title is present with a populated tree (sidebar, list view, files).
 3. Done.
 

--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/inputs.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/inputs.rs
@@ -60,7 +60,10 @@ fn string_schema(generator: &mut SchemaGenerator) -> Schema {
 
 pub const MULTI_CALL_SESSION_DESCRIPTION: &str =
     "For multi-call work, prefer a short public session label and repeat it on every call that \
-     accepts it. Omit it to use the authenticated transport's implicit lifecycle session.";
+     accepts it. The first ordinary call carrying a fresh label creates that session lazily; do \
+     not call start_session merely to begin. Use start_session only to configure the initial \
+     session state or revive an ended label. Omit session to use the authenticated transport's \
+     implicit lifecycle session.";
 
 fn string_list_schema(generator: &mut SchemaGenerator) -> Schema {
     Vec::<String>::json_schema(generator)
@@ -153,6 +156,48 @@ impl CaptureScope {
             Self::Window => "window",
             Self::Desktop => "desktop",
         }
+    }
+}
+
+/// How `launch_app` acquires an application process/window.
+///
+/// The portable default reuses an exact existing candidate before asking the
+/// operating system to launch anything. Callers that require a stronger
+/// guarantee must opt into `reuse_only` or `new` explicitly; a platform that
+/// cannot honor `new` reports that limitation instead of silently degrading.
+#[derive(
+    Debug, Clone, Copy, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq, uniffi::Enum,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum InstancePolicy {
+    #[default]
+    ReuseOrLaunch,
+    ReuseOnly,
+    New,
+}
+
+impl InstancePolicy {
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "reuse_or_launch" => Some(Self::ReuseOrLaunch),
+            "reuse_only" => Some(Self::ReuseOnly),
+            "new" => Some(Self::New),
+            _ => None,
+        }
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ReuseOrLaunch => "reuse_or_launch",
+            Self::ReuseOnly => "reuse_only",
+            Self::New => "new",
+        }
+    }
+}
+
+impl std::fmt::Display for InstancePolicy {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
     }
 }
 
@@ -444,7 +489,10 @@ impl ToolInput for EndSessionInput {
 #[serde(deny_unknown_fields)]
 pub struct GetDesktopStateInput {
     /// For multi-call work, prefer a short public session label and repeat it on every call that
-    /// accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+    /// accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+    /// not call start_session merely to begin. Use start_session only to configure the initial
+    /// session state or revive an ended label. Omit session to use the authenticated transport's
+    /// implicit lifecycle session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(schema_with = "string_schema")]
     pub session: Option<String>,
@@ -462,7 +510,10 @@ impl ToolInput for GetDesktopStateInput {
 #[serde(deny_unknown_fields)]
 pub struct GetScreenSizeInput {
     /// For multi-call work, prefer a short public session label and repeat it on every call that
-    /// accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+    /// accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+    /// not call start_session merely to begin. Use start_session only to configure the initial
+    /// session state or revive an ended label. Omit session to use the authenticated transport's
+    /// implicit lifecycle session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(schema_with = "string_schema")]
     pub session: Option<String>,
@@ -476,7 +527,10 @@ impl ToolInput for GetScreenSizeInput {
 #[serde(deny_unknown_fields)]
 pub struct GetCursorPositionInput {
     /// For multi-call work, prefer a short public session label and repeat it on every call that
-    /// accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+    /// accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+    /// not call start_session merely to begin. Use start_session only to configure the initial
+    /// session state or revive an ended label. Omit session to use the authenticated transport's
+    /// implicit lifecycle session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(schema_with = "string_schema")]
     pub session: Option<String>,
@@ -501,7 +555,10 @@ pub struct MoveCursorInput {
     #[schemars(schema_with = "desktop_scope_schema")]
     pub scope: Option<DesktopScope>,
     /// For multi-call work, prefer a short public session label and repeat it on every call that
-    /// accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+    /// accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+    /// not call start_session merely to begin. Use start_session only to configure the initial
+    /// session state or revive an ended label. Omit session to use the authenticated transport's
+    /// implicit lifecycle session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(schema_with = "string_schema")]
     pub session: Option<String>,
@@ -523,7 +580,10 @@ pub struct SetWindowFrameInput {
     #[schemars(schema_with = "positive_number_schema")]
     pub height: f64,
     /// For multi-call work, prefer a short public session label and repeat it on every call that
-    /// accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+    /// accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+    /// not call start_session merely to begin. Use start_session only to configure the initial
+    /// session state or revive an ended label. Omit session to use the authenticated transport's
+    /// implicit lifecycle session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(schema_with = "string_schema")]
     pub session: Option<String>,
@@ -546,7 +606,10 @@ pub struct InvokeMenuInput {
     #[schemars(schema_with = "menu_path_schema")]
     pub path: Vec<String>,
     /// For multi-call work, prefer a short public session label and repeat it on every call that
-    /// accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+    /// accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+    /// not call start_session merely to begin. Use start_session only to configure the initial
+    /// session state or revive an ended label. Omit session to use the authenticated transport's
+    /// implicit lifecycle session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(schema_with = "string_schema")]
     pub session: Option<String>,
@@ -574,7 +637,10 @@ pub struct ClickInput {
     #[schemars(schema_with = "desktop_scope_schema")]
     pub scope: Option<DesktopScope>,
     /// For multi-call work, prefer a short public session label and repeat it on every call that
-    /// accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+    /// accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+    /// not call start_session merely to begin. Use start_session only to configure the initial
+    /// session state or revive an ended label. Omit session to use the authenticated transport's
+    /// implicit lifecycle session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(schema_with = "string_schema")]
     pub session: Option<String>,
@@ -608,7 +674,10 @@ pub struct DragInput {
     #[schemars(schema_with = "desktop_scope_schema")]
     pub scope: Option<DesktopScope>,
     /// For multi-call work, prefer a short public session label and repeat it on every call that
-    /// accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+    /// accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+    /// not call start_session merely to begin. Use start_session only to configure the initial
+    /// session state or revive an ended label. Omit session to use the authenticated transport's
+    /// implicit lifecycle session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(schema_with = "string_schema")]
     pub session: Option<String>,
@@ -645,7 +714,10 @@ pub struct ScrollInput {
     #[schemars(schema_with = "desktop_scope_schema")]
     pub scope: Option<DesktopScope>,
     /// For multi-call work, prefer a short public session label and repeat it on every call that
-    /// accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+    /// accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+    /// not call start_session merely to begin. Use start_session only to configure the initial
+    /// session state or revive an ended label. Omit session to use the authenticated transport's
+    /// implicit lifecycle session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(schema_with = "string_schema")]
     pub session: Option<String>,
@@ -672,7 +744,10 @@ pub struct TypeTextInput {
     #[schemars(schema_with = "desktop_scope_schema")]
     pub scope: Option<DesktopScope>,
     /// For multi-call work, prefer a short public session label and repeat it on every call that
-    /// accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+    /// accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+    /// not call start_session merely to begin. Use start_session only to configure the initial
+    /// session state or revive an ended label. Omit session to use the authenticated transport's
+    /// implicit lifecycle session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(schema_with = "string_schema")]
     pub session: Option<String>,
@@ -690,7 +765,10 @@ pub struct ClipboardReadInput {
     #[serde(default)]
     pub include_text: bool,
     /// For multi-call work, prefer a short public session label and repeat it on every call that
-    /// accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+    /// accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+    /// not call start_session merely to begin. Use start_session only to configure the initial
+    /// session state or revive an ended label. Omit session to use the authenticated transport's
+    /// implicit lifecycle session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(schema_with = "string_schema")]
     pub session: Option<String>,
@@ -716,7 +794,10 @@ pub struct ClipboardWriteInput {
     #[schemars(schema_with = "string_schema")]
     pub file_path: Option<String>,
     /// For multi-call work, prefer a short public session label and repeat it on every call that
-    /// accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+    /// accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+    /// not call start_session merely to begin. Use start_session only to configure the initial
+    /// session state or revive an ended label. Omit session to use the authenticated transport's
+    /// implicit lifecycle session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(schema_with = "string_schema")]
     pub session: Option<String>,
@@ -737,7 +818,10 @@ pub struct PressKeyInput {
     #[schemars(schema_with = "desktop_scope_schema")]
     pub scope: Option<DesktopScope>,
     /// For multi-call work, prefer a short public session label and repeat it on every call that
-    /// accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+    /// accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+    /// not call start_session merely to begin. Use start_session only to configure the initial
+    /// session state or revive an ended label. Omit session to use the authenticated transport's
+    /// implicit lifecycle session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(schema_with = "string_schema")]
     pub session: Option<String>,
@@ -762,7 +846,10 @@ pub struct HotkeyInput {
     #[schemars(schema_with = "desktop_scope_schema")]
     pub scope: Option<DesktopScope>,
     /// For multi-call work, prefer a short public session label and repeat it on every call that
-    /// accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+    /// accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+    /// not call start_session merely to begin. Use start_session only to configure the initial
+    /// session state or revive an ended label. Omit session to use the authenticated transport's
+    /// implicit lifecycle session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(schema_with = "string_schema")]
     pub session: Option<String>,

--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/lib.rs
@@ -30,9 +30,9 @@ pub use inputs::{
     action_target_schema, ActionTarget, CaptureScope, ClickButton, ClickInput, ClipboardReadInput,
     ClipboardWriteInput, DesktopScope, DragInput, EndSessionInput, EscalateSessionInput,
     EscalationReason, GetAgentCursorStateInput, GetCursorPositionInput, GetDesktopStateInput,
-    GetScreenSizeInput, GetSessionInput, GetSessionStateInput, HotkeyInput, InvokeMenuInput,
-    ListSessionsInput, MoveCursorInput, PressKeyInput, ScrollBy, ScrollDirection, ScrollInput,
-    SetAgentCursorEnabledInput, SetAgentCursorMotionInput, SetAgentCursorThemeInput,
+    GetScreenSizeInput, GetSessionInput, GetSessionStateInput, HotkeyInput, InstancePolicy,
+    InvokeMenuInput, ListSessionsInput, MoveCursorInput, PressKeyInput, ScrollBy, ScrollDirection,
+    ScrollInput, SetAgentCursorEnabledInput, SetAgentCursorMotionInput, SetAgentCursorThemeInput,
     SetWindowFrameInput, StartSessionInput, ToolInput, TypeTextInput,
     MULTI_CALL_SESSION_DESCRIPTION,
 };

--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/session.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/session.rs
@@ -39,7 +39,7 @@ fn contract<I: ToolInput, O: ToolOutput>(
 fn start() -> ToolContract {
     contract::<StartSessionInput, StartSessionOutput>(
         "start_session",
-        "Optionally create or return a lifecycle session before acting. For multi-call work, prefer a short public `session` label and repeat it on every call that accepts it; an omitted value uses the authenticated transport lease's implicit session instead. This tool is optional because an ordinary action can create or reuse a named run directly. Use it to set the initial cursor theme before acting or to revive a public name after it has ended; ordinary actions never revive ended names. `capture_scope` is deprecated compatibility input; new callers select window or desktop modality per action. Idempotent.",
+        "Configure or revive a lifecycle session explicitly. Do not call this tool merely to begin: the first ordinary call carrying a fresh public `session` label creates that session lazily, and later calls reuse it when they repeat the label. An omitted value uses the authenticated transport lease's implicit session instead. Use start_session to set the initial cursor theme before acting or to revive a public name after it has ended; ordinary actions never revive ended names. `capture_scope` is deprecated compatibility input; new callers select window or desktop modality per action. Idempotent.",
         &["session.lifecycle.start", "session.capture_scope"],
         ToolAnnotations {
             read_only: false,
@@ -127,8 +127,10 @@ mod tests {
     #[test]
     fn start_description_explains_direct_naming_and_explicit_revival() {
         let description = start().description;
-        assert!(description.contains("prefer a short public `session` label"));
-        assert!(description.contains("repeat it on every call that accepts it"));
+        assert!(description.contains("Do not call this tool merely to begin"));
+        assert!(description
+            .contains("first ordinary call carrying a fresh public `session` label creates"));
+        assert!(description.contains("later calls reuse it when they repeat the label"));
         assert!(description.contains("omitted value uses the authenticated transport"));
         assert!(description.contains("revive a public name after it has ended"));
         assert!(description.contains("ordinary actions never revive ended names"));

--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/verification.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/verification.rs
@@ -157,8 +157,10 @@ pub struct VerifyStateInput {
     #[schemars(length(min = 1, max = 8))]
     pub expect: Vec<StatePredicate>,
     /// For multi-call work, prefer a short public session label and repeat it on every call that
-    /// accepts it. Omit it to use the authenticated transport's implicit lifecycle session. This
-    /// field never selects capture modality or authorization.
+    /// accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+    /// not call start_session merely to begin. Use start_session only to configure the initial
+    /// session state or revive an ended label. Omit session to use the authenticated transport's
+    /// implicit lifecycle session. This field never selects capture modality or authorization.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(schema_with = "string_schema")]
     pub session: Option<String>,

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/app_acquisition.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/app_acquisition.rs
@@ -1,0 +1,254 @@
+//! Shared, platform-neutral application acquisition result vocabulary.
+//!
+//! Platform adapters own native discovery and launch mechanics, but publish
+//! the same additive `launch_state` object. Keeping its dispositions typed here
+//! prevents a backend from silently inventing another spelling or weakening a
+//! requested acquisition policy.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::protocol::ToolResult;
+use cua_driver_contract::InstancePolicy;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProcessDisposition {
+    Reused,
+    Created,
+    None,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WindowDisposition {
+    Reused,
+    Materialized,
+    None,
+}
+
+/// Canonical additive state nested under a `launch_app` result's
+/// `launch_state` key.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AppLaunchState {
+    /// Legacy compatibility field. Always identical to `request_sent`.
+    pub requested: bool,
+    pub process_running: bool,
+    pub window_ready: bool,
+    pub request_sent: bool,
+    pub process_disposition: ProcessDisposition,
+    pub window_disposition: WindowDisposition,
+}
+
+impl AppLaunchState {
+    pub const fn new(
+        request_sent: bool,
+        process_running: bool,
+        window_ready: bool,
+        process_disposition: ProcessDisposition,
+        window_disposition: WindowDisposition,
+    ) -> Self {
+        Self {
+            requested: request_sent,
+            process_running,
+            window_ready,
+            request_sent,
+            process_disposition,
+            window_disposition,
+        }
+    }
+}
+
+/// Build the canonical JSON value composed into platform `launch_app`
+/// responses.
+pub fn launch_state_json(
+    request_sent: bool,
+    process_running: bool,
+    window_ready: bool,
+    process_disposition: ProcessDisposition,
+    window_disposition: WindowDisposition,
+) -> Value {
+    serde_json::to_value(AppLaunchState::new(
+        request_sent,
+        process_running,
+        window_ready,
+        process_disposition,
+        window_disposition,
+    ))
+    .expect("AppLaunchState is JSON-serializable")
+}
+
+/// Parse the canonical `launch_app` acquisition policy, including the
+/// deprecated boolean compatibility alias.
+///
+/// `creates_new_application_instance=true` maps to `new`. It may accompany an
+/// explicit `new` during migration, but conflicts with any explicit non-new
+/// policy. Wrong JSON types are rejected instead of silently selecting the
+/// default.
+#[allow(clippy::result_large_err)]
+pub fn resolve_instance_policy(args: &Value) -> Result<InstancePolicy, ToolResult> {
+    let explicit = match args.get("instance_policy") {
+        None => None,
+        Some(Value::String(value)) => InstancePolicy::parse(value).map(Some).ok_or_else(|| {
+            instance_policy_error(
+                "INVALID_INSTANCE_POLICY",
+                format!(
+                    "Unknown instance_policy '{value}'; expected reuse_or_launch, reuse_only, or new."
+                ),
+                json!({ "instance_policy": value }),
+            )
+        })?,
+        Some(value) => {
+            return Err(instance_policy_error(
+                "INVALID_INSTANCE_POLICY",
+                "instance_policy must be a string: reuse_or_launch, reuse_only, or new."
+                    .to_owned(),
+                json!({ "instance_policy": value }),
+            ));
+        }
+    };
+
+    let legacy_new = match args.get("creates_new_application_instance") {
+        None => false,
+        Some(Value::Bool(value)) => *value,
+        Some(value) => {
+            return Err(instance_policy_error(
+                "INVALID_INSTANCE_POLICY",
+                "creates_new_application_instance must be a boolean when provided.".to_owned(),
+                json!({ "creates_new_application_instance": value }),
+            ));
+        }
+    };
+
+    if legacy_new && explicit.is_some_and(|policy| policy != InstancePolicy::New) {
+        return Err(instance_policy_error(
+            "INSTANCE_POLICY_CONFLICT",
+            "creates_new_application_instance=true conflicts with the explicit non-new instance_policy. Remove the deprecated alias or use instance_policy=\"new\"."
+                .to_owned(),
+            json!({
+                "instance_policy": explicit.map(InstancePolicy::as_str),
+                "creates_new_application_instance": true,
+            }),
+        ));
+    }
+
+    Ok(explicit.unwrap_or(if legacy_new {
+        InstancePolicy::New
+    } else {
+        InstancePolicy::ReuseOrLaunch
+    }))
+}
+
+fn instance_policy_error(code: &str, message: String, details: Value) -> ToolResult {
+    let mut payload = json!({ "error": code });
+    if let (Some(payload), Some(details)) = (payload.as_object_mut(), details.as_object()) {
+        payload.extend(details.clone());
+    }
+    ToolResult::error(message).with_structured(payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn launch_state_json_keeps_legacy_fields_and_typed_dispositions() {
+        assert_eq!(
+            launch_state_json(
+                false,
+                true,
+                true,
+                ProcessDisposition::Reused,
+                WindowDisposition::Reused,
+            ),
+            serde_json::json!({
+                "requested": false,
+                "process_running": true,
+                "window_ready": true,
+                "request_sent": false,
+                "process_disposition": "reused",
+                "window_disposition": "reused",
+            })
+        );
+
+        assert_eq!(
+            launch_state_json(
+                true,
+                true,
+                false,
+                ProcessDisposition::Created,
+                WindowDisposition::None,
+            ),
+            serde_json::json!({
+                "requested": true,
+                "process_running": true,
+                "window_ready": false,
+                "request_sent": true,
+                "process_disposition": "created",
+                "window_disposition": "none",
+            })
+        );
+
+        assert_eq!(
+            serde_json::to_value(WindowDisposition::Materialized).unwrap(),
+            "materialized"
+        );
+        assert_eq!(
+            serde_json::to_value(ProcessDisposition::None).unwrap(),
+            "none"
+        );
+    }
+
+    #[test]
+    fn instance_policy_parser_defaults_and_maps_the_legacy_alias() {
+        assert_eq!(
+            resolve_instance_policy(&json!({})).unwrap(),
+            InstancePolicy::ReuseOrLaunch
+        );
+        assert_eq!(
+            resolve_instance_policy(&json!({"instance_policy": "reuse_only"})).unwrap(),
+            InstancePolicy::ReuseOnly
+        );
+        assert_eq!(
+            resolve_instance_policy(&json!({"creates_new_application_instance": true})).unwrap(),
+            InstancePolicy::New
+        );
+        assert_eq!(
+            resolve_instance_policy(&json!({
+                "instance_policy": "new",
+                "creates_new_application_instance": true
+            }))
+            .unwrap(),
+            InstancePolicy::New
+        );
+    }
+
+    #[test]
+    fn instance_policy_parser_returns_shared_structured_errors() {
+        for args in [
+            json!({"instance_policy": 7}),
+            json!({"instance_policy": "sometimes"}),
+            json!({"creates_new_application_instance": "true"}),
+        ] {
+            let error = resolve_instance_policy(&args).unwrap_err();
+            assert_eq!(
+                error
+                    .structured_content
+                    .as_ref()
+                    .and_then(|value| value.get("error"))
+                    .and_then(Value::as_str),
+                Some("INVALID_INSTANCE_POLICY")
+            );
+        }
+
+        let conflict = resolve_instance_policy(&json!({
+            "instance_policy": "reuse_only",
+            "creates_new_application_instance": true
+        }))
+        .unwrap_err();
+        assert_eq!(
+            conflict.structured_content.unwrap()["error"],
+            "INSTANCE_POLICY_CONFLICT"
+        );
+    }
+}

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/lib.rs
@@ -47,6 +47,7 @@ pub fn parent_liveness_stdin_enabled() -> bool {
 
 pub mod action_record;
 pub mod action_target;
+pub mod app_acquisition;
 pub mod authorization;
 pub mod background_input;
 pub mod browser;
@@ -89,5 +90,9 @@ pub mod video_ffmpeg;
 pub mod window_inspection;
 pub mod window_target;
 
-pub use cua_driver_contract::{CaptureScope, EscalationReason};
+pub use app_acquisition::{
+    launch_state_json, resolve_instance_policy, AppLaunchState, ProcessDisposition,
+    WindowDisposition,
+};
+pub use cua_driver_contract::{CaptureScope, EscalationReason, InstancePolicy};
 pub use recording::RecordingSession;

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/protocol.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/protocol.rs
@@ -367,17 +367,17 @@ fn agent_instructions() -> String {
     };
 
     format!(
-        r#"cua-driver: cross-platform background computer-use automation.
+        r#"cua-driver: native GUI automation.
 
-Before starting UI work, classify the desired postcondition. For a non-GUI outcome, prefer a client-provided app API/SDK, headless/background interface, CLI, or filesystem operation and read the result back in that semantic domain. This server has no shell.
+For a non-GUI outcome, prefer a client-provided app API/SDK, headless/background interface, CLI, or filesystem operation, then read it back in that semantic domain. This server has no shell.
 
-For an app or window outcome, use the narrowest semantic Cua route first: `set_window_frame` plus `list_windows` readback for geometry, typed browser tools for supported page content, and clipboard tools for clipboard state. Then climb through background `element_index` ({tree_kind}), background pixels, foreground delivery, and desktop fallback. Never advance on transport success alone.
+Use the narrowest semantic Cua route first: `set_window_frame` plus `list_windows` readback, typed browser tools for supported page content, or clipboard tools for clipboard state. Then try background `element_index` ({tree_kind})/pixels, foreground, desktop. Never advance on transport success alone.
 
 Workflow per turn:
-0. `start_session` is optional. For multi-call work, prefer a short `session` label and repeat it on every call that accepts it. Unnamed calls use the transport's implicit session. Only `start_session` revives an ended name; `end_session` explicitly cleans up.
-1. `launch_app`, then `get_window_state(pid, window_id)` to refresh element indices.
+0. Pass a short `session` label on the first ordinary call and repeat it on every call that accepts it; the first call creates the session lazily. Do not call `start_session` merely to begin. Use it only for initial configuration or to revive an ended label. Omission uses the transport's implicit session; `end_session` explicitly cleans up.
+1. `launch_app`'s default `reuse_or_launch` policy reuses an exact existing app/window before launch. Do not preflight with `list_apps`/`list_windows`. Reserve `new` for verified concurrent isolation. Then call `get_window_state(pid, window_id)` to refresh indices.
 2. Act with the fresh index.
-3. `verify_state(pid, window_id, expect)` checks bounded postconditions. `unknown` is not success; `include_screenshot:true` lets the multimodal agent judge visual evidence.
+3. `verify_state(pid, window_id, expect)` checks postconditions. `unknown` is not success; `include_screenshot:true` gives the multimodal agent visual evidence.
 
 If the `cua-driver` skill is loaded, follow SKILL.md plus {platform_skill_pointer}."#
     )
@@ -475,7 +475,7 @@ mod agent_instruction_tests {
         assert!(instructions.contains("multimodal agent"));
         assert!(instructions.contains("client-provided app API/SDK"));
         assert!(instructions.contains("headless/background interface"));
-        assert!(instructions.contains("read the result back in that semantic domain"));
+        assert!(instructions.contains("then read it back in that semantic domain"));
         assert!(instructions.contains("narrowest semantic Cua route first"));
         assert!(instructions.contains("`set_window_frame` plus `list_windows` readback"));
         assert!(instructions.contains("typed browser tools for supported page content"));
@@ -498,16 +498,26 @@ mod agent_instruction_tests {
             .as_str()
             .expect("initialize result should carry agent instructions");
 
-        assert!(instructions.contains("`start_session` is optional"));
-        assert!(instructions.contains("prefer a short `session` label"));
+        assert!(instructions.contains("Pass a short `session` label on the first ordinary call"));
         assert!(instructions.contains("repeat it on every call that accepts it"));
+        assert!(instructions.contains("first call creates the session lazily"));
+        assert!(instructions.contains("Do not call `start_session` merely to begin"));
         assert!(instructions.contains("transport's implicit session"));
-        assert!(instructions.contains("Only `start_session` revives an ended name"));
+        assert!(instructions.contains("revive an ended label"));
         assert!(instructions.contains("`end_session` explicitly cleans up"));
         assert!(
             !instructions.contains("`start_session(session)` once"),
             "initialize instructions must not require explicit session setup"
         );
+    }
+
+    #[test]
+    fn initialize_instructions_prefer_atomic_reuse_before_launch() {
+        let instructions = agent_instructions();
+        assert!(instructions.contains("default `reuse_or_launch` policy"));
+        assert!(instructions.contains("reuses an exact existing app/window"));
+        assert!(instructions.contains("Do not preflight with `list_apps`/`list_windows`"));
+        assert!(instructions.contains("Reserve `new` for verified concurrent isolation"));
     }
 }
 

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -3035,6 +3035,45 @@ mod runtime_isolation_tests {
     }
 
     #[tokio::test]
+    async fn first_ordinary_call_lazily_creates_a_fresh_named_session() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let registry = observation_registry(None, hits.clone());
+        let context = standard_context();
+        let label = "lazy-first-action";
+        let runtime_session = context.runtime_session_key(label);
+
+        let runtime_prefix = context.runtime_session_key("");
+        assert!(!crate::session::list_session_snapshots_with_prefix(
+            &runtime_prefix,
+            crate::session::DEFAULT_SESSION_IDLE_TTL,
+        )
+        .iter()
+        .any(|snapshot| snapshot.runtime_id == runtime_session));
+
+        let result = registry
+            .invoke_with_context(
+                "get_window_state",
+                serde_json::json!({"pid": 42, "window_id": 7, "session": label}),
+                context,
+            )
+            .await;
+
+        assert_ne!(result.is_error, Some(true));
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+        let snapshot = crate::session::list_session_snapshots_with_prefix(
+            &runtime_prefix,
+            crate::session::DEFAULT_SESSION_IDLE_TTL,
+        )
+        .into_iter()
+        .find(|snapshot| snapshot.runtime_id == runtime_session)
+        .expect("first ordinary call should create the named session");
+        assert_eq!(snapshot.public_label.as_deref(), Some(label));
+        assert!(!snapshot.implicit);
+
+        crate::session::end_session(&runtime_session);
+    }
+
+    #[tokio::test]
     async fn bounded_observation_uses_only_the_manifest_without_a_protected_host() {
         let hits = Arc::new(AtomicUsize::new(0));
         let registry = attested_registry("get_window_state", None, hits.clone(), false);

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool_schema.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool_schema.rs
@@ -43,6 +43,20 @@ pub fn session_schema_with(note: &str) -> Value {
     schema
 }
 
+/// `instance_policy` — whether launch_app may reuse or create an instance.
+///
+/// Every platform advertises this exact shape. Backends that cannot honor a
+/// requested guarantee return an explicit limitation instead of selecting a
+/// weaker policy.
+pub fn instance_policy_schema() -> Value {
+    json!({
+        "type": "string",
+        "enum": ["reuse_or_launch", "reuse_only", "new"],
+        "default": "reuse_or_launch",
+        "description": "Application acquisition policy. `reuse_or_launch` (default) reuses an exact existing app/window before requesting a launch; `reuse_only` never launches; `new` requires a distinct application instance and returns an explicit limitation when the platform or app cannot provide one."
+    })
+}
+
 /// `delivery_mode` — the best-effort-background ladder rung. The prose varies by
 /// tool (the surface it injects through differs), so callers may pass their own
 /// `description`; the shape is fixed here.
@@ -131,6 +145,7 @@ pub fn element_token_schema() -> Value {
 fn shared_param_canonical(name: &str) -> Option<Value> {
     let v = match name {
         "session" => session_schema(),
+        "instance_policy" => instance_policy_schema(),
         "delivery_mode" => delivery_mode_schema(),
         "modifier" => modifier_schema(),
         "button" => button_schema(),
@@ -141,7 +156,7 @@ fn shared_param_canonical(name: &str) -> Option<Value> {
         "capture_mode" => crate::capture_mode::capture_mode_schema(),
         _ => return None,
     };
-    Some(structural(&v))
+    Some(structural_for_param(name, &v))
 }
 
 /// The canonical `required` array for tools whose required-set drifted across
@@ -163,8 +178,8 @@ fn required_canonical(tool: &str) -> Option<&'static [&'static str]> {
 }
 
 /// Reduce a param schema to the parts that govern client compatibility —
-/// `type`, `enum`, and (recursively) `items` — dropping `description` and any
-/// other prose so per-tool wording differences don't trip the gate.
+/// `type`, `enum`, and (recursively) `items` — dropping `description` and other
+/// prose so per-tool wording differences don't trip the gate.
 fn structural(schema: &Value) -> Value {
     let mut out = serde_json::Map::new();
     if let Some(t) = schema.get("type") {
@@ -177,6 +192,20 @@ fn structural(schema: &Value) -> Value {
         out.insert("items".into(), structural(items));
     }
     Value::Object(out)
+}
+
+fn structural_for_param(name: &str, schema: &Value) -> Value {
+    let mut out = structural(schema);
+    // Reuse-first is observable launch behavior, not a prose hint. Existing
+    // shared parameters have historically varied in whether they publish an
+    // equivalent JSON Schema default, so keep this stricter check scoped to
+    // the new acquisition contract.
+    if name == "instance_policy" {
+        if let (Some(out), Some(default)) = (out.as_object_mut(), schema.get("default")) {
+            out.insert("default".into(), default.clone());
+        }
+    }
+    out
 }
 
 fn session_guidance_is_exempt(tool_name: &str) -> bool {
@@ -216,7 +245,7 @@ pub fn shared_schema_violations(tool_name: &str, input_schema: &Value) -> Vec<St
     if let Some(props) = input_schema.get("properties").and_then(|p| p.as_object()) {
         for (pname, pschema) in props {
             if let Some(canon) = shared_param_canonical(pname) {
-                let got = structural(pschema);
+                let got = structural_for_param(pname, pschema);
                 if got != canon {
                     violations.push(format!(
                         "{tool_name}.{pname}: shape {got} diverges from shared canon {canon}"
@@ -279,7 +308,61 @@ mod tests {
             .expect("session schema should carry agent guidance");
         assert!(description.contains("prefer a short public session label"));
         assert!(description.contains("repeat it on every call that accepts it"));
+        assert!(description.contains("first ordinary call carrying a fresh label creates"));
+        assert!(description.contains("do not call start_session merely to begin"));
         assert!(description.contains("implicit lifecycle session"));
+    }
+
+    #[test]
+    fn instance_policy_defaults_to_reuse_first() {
+        let schema = instance_policy_schema();
+        assert_eq!(schema["type"], "string");
+        assert_eq!(schema["default"], "reuse_or_launch");
+        assert_eq!(
+            schema["enum"],
+            json!(["reuse_or_launch", "reuse_only", "new"])
+        );
+        for policy in ["reuse_or_launch", "reuse_only", "new"] {
+            assert_eq!(
+                cua_driver_contract::InstancePolicy::parse(policy)
+                    .expect("canonical policy parses")
+                    .as_str(),
+                policy
+            );
+        }
+    }
+
+    #[test]
+    fn instance_policy_default_drift_is_flagged() {
+        let tool = json!({
+            "type": "object",
+            "properties": {
+                "instance_policy": {
+                    "type": "string",
+                    "enum": ["reuse_or_launch", "reuse_only", "new"],
+                    "default": "new"
+                }
+            }
+        });
+        let violations = shared_schema_violations("launch_app", &tool);
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].contains("default"));
+        assert!(violations[0].contains("reuse_or_launch"));
+    }
+
+    #[test]
+    fn legacy_shared_parameter_defaults_remain_outside_the_gate() {
+        let tool = json!({
+            "type": "object",
+            "properties": {
+                "scope": {
+                    "type": "string",
+                    "enum": ["window", "desktop"],
+                    "default": "window"
+                }
+            }
+        });
+        assert!(shared_schema_violations("move_cursor", &tool).is_empty());
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
@@ -968,10 +968,11 @@ mod tests {
         for required in [
             "Choose the target on each action",
             "transport's implicit session",
-            "prefer a short public",
-            "pass the same label on every call that accepts it",
+            "pass a short public `session` label on the first ordinary",
+            "creates a fresh named session lazily",
+            "do not call `start_session` merely to",
             "Passing it once is not sticky",
-            "revive a name after",
+            "Use `start_session(session)` only when initial configuration",
             "There is no `deescalate_session`",
             "--capability-manifest",
             "--approve-capability-manifest",
@@ -986,7 +987,7 @@ mod tests {
         for forbidden in [
             "one-way session phase",
             "if session policy allows",
-            "Pass `session` on the first action",
+            "Call `start_session(session)` when you need to name",
         ] {
             assert!(
                 !skill.contains(forbidden),
@@ -994,17 +995,53 @@ mod tests {
             );
         }
         for required in [
-            "start_session(session?)",
-            "optional; can name before acting",
-            "prefer a short `session` label",
-            "Passing it once is not sticky",
-            "one-shot CLI calls use disposable transports",
+            "first named call creates session lazily",
+            "do not call `start_session` merely",
+            "Use `start_session` only for initial configuration",
+            "Passing a label once is not sticky",
+            "Direct one-shot CLI calls use disposable transports",
         ] {
             assert!(
                 browser.contains(required),
                 "browser skill lost required session guidance: {required}"
             );
         }
+    }
+
+    #[test]
+    fn bundled_skill_prefers_atomic_reuse_before_launch() {
+        let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let skill = std::fs::read_to_string(crate_dir.join("../../Skills/cua-driver/SKILL.md"))
+            .expect("canonical skill must be readable");
+        let macos = std::fs::read_to_string(crate_dir.join("../../Skills/cua-driver/MACOS.md"))
+            .expect("canonical macOS skill must be readable");
+        let browser = std::fs::read_to_string(crate_dir.join("../../Skills/cua-driver/BROWSER.md"))
+            .expect("canonical browser skill must be readable");
+
+        for required in [
+            "instance_policy: \"reuse_or_launch\"",
+            "Do not preflight with `list_apps` or",
+            "`reuse_only` when launching is forbidden",
+            "verified need for a distinct process",
+            "Do not request `new` merely because an earlier",
+        ] {
+            assert!(
+                skill.contains(required),
+                "skill lost required reuse-first acquisition guidance: {required}"
+            );
+        }
+        for required in [
+            "an exact reusable app/window and returns it without a launch request",
+            "without a racy `list_apps` / `list_windows` preflight",
+            "NEW_APPLICATION_INSTANCE_UNAVAILABLE",
+        ] {
+            assert!(
+                macos.contains(required),
+                "macOS skill lost required reuse-first acquisition guidance: {required}"
+            );
+        }
+        assert!(browser.contains("Do not call `list_apps` or `list_windows` merely"));
+        assert!(browser.contains("performs that acquisition atomically"));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -7,10 +7,13 @@ use cua_driver_contract::{
     TypeTextInput,
 };
 use cua_driver_core::{
+    launch_state_json,
     protocol::ToolResult,
+    resolve_instance_policy,
     tool::{Tool, ToolDef, ToolRegistry},
     tool_args::{parse_typed_input, parse_typed_projection, ArgsExt},
     window_target::{PidOnlyWindowTargetGuard, WindowTargetCandidate, WindowTargetCandidates},
+    InstancePolicy, ProcessDisposition, WindowDisposition,
 };
 use serde_json::{json, Value};
 use std::fs;
@@ -945,10 +948,151 @@ impl Tool for GetWindowStateTool {
 
 pub struct LaunchAppTool;
 static LAUNCH_DEF: std::sync::OnceLock<ToolDef> = std::sync::OnceLock::new();
+static LAUNCH_ACQUISITION_LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> =
+    std::sync::OnceLock::new();
 
 fn contains_remote_debugging_flag(value: &str) -> bool {
     let lower = value.to_ascii_lowercase();
     lower.contains("--remote-debugging-port") || lower.contains("--remote-debugging-pipe")
+}
+
+fn launch_policy_error(
+    code: &str,
+    message: impl Into<String>,
+    policy: InstancePolicy,
+) -> ToolResult {
+    ToolResult::error(message.into()).with_structured(json!({
+        "error": code,
+        "instance_policy": policy.as_str(),
+        "platform": "linux",
+        "launch_state": launch_state_json(
+            false,
+            false,
+            false,
+            ProcessDisposition::None,
+            WindowDisposition::None,
+        ),
+    }))
+}
+
+fn launch_request_error(
+    code: &str,
+    message: impl Into<String>,
+    policy: InstancePolicy,
+) -> ToolResult {
+    ToolResult::error(message.into()).with_structured(json!({
+        "error": code,
+        "instance_policy": policy.as_str(),
+        "platform": "linux",
+        "launch_state": launch_state_json(
+            true,
+            false,
+            false,
+            ProcessDisposition::None,
+            WindowDisposition::None,
+        ),
+    }))
+}
+
+fn command_basename(command: &str) -> Option<String> {
+    let executable = command
+        .split_whitespace()
+        .next()?
+        .trim_matches(|character| character == '\'' || character == '"');
+    let basename = std::path::Path::new(executable)
+        .file_name()
+        .and_then(|name| name.to_str())?
+        .trim()
+        .to_ascii_lowercase();
+    (!basename.is_empty()).then_some(basename)
+}
+
+fn process_matches_command(process: &crate::proc_fs::ProcessInfo, command: &str) -> bool {
+    let Some(target) = command_basename(command) else {
+        return false;
+    };
+    let process_name = process.name.to_ascii_lowercase();
+    let argv0 = command_basename(&process.cmdline).unwrap_or_default();
+    process_name == target || argv0 == target
+}
+
+fn reusable_linux_processes(command: &str) -> Vec<(u32, String, Vec<Value>)> {
+    let processes: Vec<_> = crate::proc_fs::list_processes()
+        .into_iter()
+        .filter(|process| process_matches_command(process, command))
+        .collect();
+    if processes.is_empty() {
+        return Vec::new();
+    }
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+    loop {
+        let candidates: Vec<_> = processes
+            .iter()
+            .map(|process| {
+                let windows = crate::wayland::list_windows_dispatch(Some(process.pid));
+                (
+                    process.pid,
+                    process.name.clone(),
+                    windows.iter().map(window_record_json).collect(),
+                )
+            })
+            .collect();
+        if candidates.len() > 1
+            || candidates
+                .first()
+                .is_some_and(|(_, _, windows): &(u32, String, Vec<Value>)| !windows.is_empty())
+            || std::time::Instant::now() >= deadline
+        {
+            return candidates;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
+fn linux_reuse_command(launch_path: Option<&str>, name: Option<&str>) -> Option<String> {
+    if let Some(launch_path) = launch_path {
+        return Some(launch_path.to_owned());
+    }
+    let name = name?;
+    let installed = crate::installed_apps::list_installed_apps();
+    Some(
+        match_installed_app(&installed, name)
+            .map(|app| app.launch_path.clone())
+            .unwrap_or_else(|| name.to_owned()),
+    )
+}
+
+fn reused_linux_app_result(
+    pid: u32,
+    name: String,
+    windows: Vec<Value>,
+    instance_policy: InstancePolicy,
+) -> ToolResult {
+    let mut summary = format!("✅ Reused {name} (pid {pid}); no launch request was sent.");
+    if !windows.is_empty() {
+        summary.push_str("\n\nWindows:");
+        for window in &windows {
+            let title = window["title"].as_str().unwrap_or("");
+            let window_id = window["window_id"].as_u64().unwrap_or(0);
+            summary.push_str(&format!("\n- \"{title}\" [window_id: {window_id}]"));
+        }
+    }
+    ToolResult::text(summary).with_structured(json!({
+        "pid": pid,
+        "bundle_id": Value::Null,
+        "name": name,
+        "running": true,
+        "active": false,
+        "windows": windows,
+        "instance_policy": instance_policy.as_str(),
+        "launch_state": launch_state_json(
+            false,
+            true,
+            true,
+            ProcessDisposition::Reused,
+            WindowDisposition::Reused,
+        ),
+    }))
 }
 
 /// Spawn a launcher command line (an executable plus arguments, e.g. an XDG
@@ -1181,6 +1325,73 @@ mod launch_app_tests {
         assert!(match_installed_app(&apps, "gnome-calculator").is_none());
         assert!(match_installed_app(&apps, "").is_none());
     }
+
+    #[test]
+    fn process_matching_uses_exact_executable_basename() {
+        let process = crate::proc_fs::ProcessInfo {
+            pid: 41,
+            name: "galculator".to_owned(),
+            cmdline: "/usr/bin/galculator".to_owned(),
+        };
+        assert!(process_matches_command(
+            &process,
+            "/usr/bin/galculator --session demo"
+        ));
+        assert!(!process_matches_command(&process, "calculator"));
+    }
+
+    #[test]
+    fn launch_schema_exposes_lazy_session_and_instance_policy() {
+        let schema = LaunchAppTool.def().input_schema.clone();
+        assert_eq!(schema["properties"]["session"]["type"], "string");
+        assert_eq!(
+            schema["properties"]["instance_policy"]["default"],
+            "reuse_or_launch"
+        );
+        assert_eq!(
+            schema["properties"]["instance_policy"]["enum"],
+            json!(["reuse_or_launch", "reuse_only", "new"])
+        );
+        assert_eq!(
+            schema["properties"]["creates_new_application_instance"]["deprecated"],
+            true
+        );
+    }
+
+    #[test]
+    fn legacy_new_conflicts_with_explicit_reuse() {
+        let result = resolve_instance_policy(&json!({
+            "instance_policy": "reuse_only",
+            "creates_new_application_instance": true,
+        }));
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn explicit_new_fails_before_sending_a_launch_request() {
+        let result = LaunchAppTool
+            .invoke(json!({"name": "galculator", "instance_policy": "new"}))
+            .await;
+        let structured = result.structured_content.expect("structured error");
+        assert_eq!(result.is_error, Some(true));
+        assert_eq!(structured["error"], "NEW_APPLICATION_INSTANCE_UNAVAILABLE");
+        assert_eq!(structured["launch_state"]["request_sent"], false);
+    }
+
+    #[tokio::test]
+    async fn reuse_only_with_arguments_fails_before_sending_a_request() {
+        let result = LaunchAppTool
+            .invoke(json!({
+                "name": "galculator",
+                "instance_policy": "reuse_only",
+                "additional_arguments": ["--example"],
+            }))
+            .await;
+        let structured = result.structured_content.expect("structured error");
+        assert_eq!(result.is_error, Some(true));
+        assert_eq!(structured["error"], "APP_REUSE_UNAVAILABLE");
+        assert_eq!(structured["launch_state"]["request_sent"], false);
+    }
 }
 
 #[async_trait]
@@ -1188,7 +1399,9 @@ impl Tool for LaunchAppTool {
     fn def(&self) -> &ToolDef {
         LAUNCH_DEF.get_or_init(|| ToolDef {
             name: "launch_app".into(),
-            description: "Launch a Linux app in the background. Provide launch_path (preferred — \
+            description: "Resolve or launch a Linux app in the background. By default, reuse one \
+                exact running process with a window when it can be identified without ambiguity; \
+                otherwise launch. Provide launch_path (preferred — \
                 round-trip the value from list_apps), name (tried as a direct command, then \
                 matched against installed .desktop applications, then handed to xdg-open if it \
                 is a URL or existing file path), bundle_id (ignored on Linux), or urls (list of \
@@ -1199,9 +1412,12 @@ impl Tool for LaunchAppTool {
                 "name":{"type":"string","description":"App name or command to launch. Tried as a direct command first, then matched against installed .desktop applications (exact display name, desktop-file id, or Exec basename; else an unambiguous display-name substring)."},
                 "bundle_id":{"type":"string","description":"Ignored on Linux (macOS/Windows concept)."},
                 "urls":{"type":"array","items":{"type":"string"},"description":"URLs to open via xdg-open."},
-                "additional_arguments":{"type":"array","items":{"type":"string"},"description":"Extra command-line arguments passed to the launched process."}
+                "additional_arguments":{"type":"array","items":{"type":"string"},"description":"Extra command-line arguments passed to the launched process. Supplying arguments requires a launch request and therefore cannot be combined with instance_policy=reuse_only."},
+                "session": cua_driver_core::tool_schema::session_schema(),
+                "instance_policy": cua_driver_core::tool_schema::instance_policy_schema(),
+                "creates_new_application_instance":{"type":"boolean","deprecated":true,"description":"Deprecated compatibility alias. true maps to instance_policy=new; false maps to reuse_or_launch. Linux cannot guarantee a distinct live instance and returns NEW_APPLICATION_INSTANCE_UNAVAILABLE before sending a launch request."}
             },"additionalProperties":false}),
-            read_only: false, destructive: false, idempotent: false, open_world: true,
+            read_only: false, destructive: false, idempotent: true, open_world: true,
         })
     }
 
@@ -1211,6 +1427,10 @@ impl Tool for LaunchAppTool {
         let name_opt = args.opt_str("name");
         let urls: Vec<String> = args.str_array("urls");
         let additional_arguments: Vec<String> = args.str_array("additional_arguments");
+        let instance_policy = match resolve_instance_policy(&args) {
+            Ok(policy) => policy,
+            Err(error) => return error,
+        };
         if args.get("cdp_debugging_port").is_some() {
             return ToolResult::error(
                 "cdp_debugging_port moved to browser_prepare so DevTools is never enabled on an unproven user profile",
@@ -1230,6 +1450,85 @@ impl Tool for LaunchAppTool {
 
         if launch_path_opt.is_none() && name_opt.is_none() && urls.is_empty() {
             return ToolResult::error("Provide at least one of: launch_path, name, or urls.");
+        }
+
+        // Serialize the resolve/reuse-or-launch decision through request
+        // dispatch. Otherwise two concurrent calls can both observe no
+        // reusable window and spawn before either new window is enumerable.
+        let acquisition_guard = LAUNCH_ACQUISITION_LOCK
+            .get_or_init(|| tokio::sync::Mutex::new(()))
+            .lock()
+            .await;
+
+        if instance_policy == InstancePolicy::New {
+            return launch_policy_error(
+                "NEW_APPLICATION_INSTANCE_UNAVAILABLE",
+                "Linux launchers and desktop portals may hand a request to an existing single-instance process, so Cua Driver cannot guarantee instance_policy=\"new\". No launch request was sent.",
+                instance_policy,
+            );
+        }
+
+        let carries_launch_modifiers = !urls.is_empty() || !additional_arguments.is_empty();
+        if instance_policy == InstancePolicy::ReuseOnly && carries_launch_modifiers {
+            return launch_policy_error(
+                "APP_REUSE_UNAVAILABLE",
+                "instance_policy=\"reuse_only\" cannot deliver URLs or additional_arguments without sending a launch request. No launch request was sent.",
+                instance_policy,
+            );
+        }
+
+        if !carries_launch_modifiers {
+            let reuse_command =
+                linux_reuse_command(launch_path_opt.as_deref(), name_opt.as_deref());
+            if let Some(reuse_command) = reuse_command {
+                let candidates =
+                    tokio::task::spawn_blocking(move || reusable_linux_processes(&reuse_command))
+                        .await
+                        .unwrap_or_default();
+                match candidates.as_slice() {
+                    [(pid, name, windows)] if !windows.is_empty() => {
+                        return reused_linux_app_result(
+                            *pid,
+                            name.clone(),
+                            windows.clone(),
+                            instance_policy,
+                        )
+                    }
+                    [] | [(_, _, _)] => {}
+                    _ => {
+                        let candidate_payload: Vec<Value> = candidates
+                            .iter()
+                            .map(|(pid, name, windows)| {
+                                json!({"pid": pid, "name": name, "windows": windows})
+                            })
+                            .collect();
+                        return ToolResult::error(
+                            "More than one exact running Linux process matches the requested app; choose a candidate pid/window_id instead of launching another instance.",
+                        )
+                        .with_structured(json!({
+                            "error": "APP_TARGET_AMBIGUOUS",
+                            "instance_policy": instance_policy.as_str(),
+                            "platform": "linux",
+                            "candidates": candidate_payload,
+                            "launch_state": launch_state_json(
+                                false,
+                                true,
+                                false,
+                                ProcessDisposition::None,
+                                WindowDisposition::None,
+                            ),
+                        }));
+                    }
+                }
+            }
+        }
+
+        if instance_policy == InstancePolicy::ReuseOnly {
+            return launch_policy_error(
+                "APP_REUSE_UNAVAILABLE",
+                "No exact running Linux process with a reusable window matched the requested app. No launch request was sent.",
+                instance_policy,
+            );
         }
 
         let result = tokio::task::spawn_blocking(
@@ -1323,6 +1622,7 @@ impl Tool for LaunchAppTool {
             },
         )
         .await;
+        drop(acquisition_guard);
 
         match result {
             Ok(Ok((message, pid_opt, name))) => {
@@ -1340,13 +1640,27 @@ impl Tool for LaunchAppTool {
                     })
                     .await
                     .unwrap_or_default();
+                    let window_ready = !windows.is_empty();
+                    let process_running = crate::proc_fs::is_process_live(pid);
                     ToolResult::text(message).with_structured(json!({
                         "pid": pid,
                         "bundle_id": Value::Null,
                         "name": name,
-                        "running": true,
+                        "running": process_running,
                         "active": false,
                         "windows": windows,
+                        "instance_policy": instance_policy.as_str(),
+                        "launch_state": launch_state_json(
+                            true,
+                            process_running,
+                            window_ready,
+                            ProcessDisposition::Created,
+                            if window_ready {
+                                WindowDisposition::Materialized
+                            } else {
+                                WindowDisposition::None
+                            },
+                        ),
                     }))
                 } else {
                     ToolResult::text(message).with_structured(json!({
@@ -1356,11 +1670,27 @@ impl Tool for LaunchAppTool {
                         "running": Value::Null,
                         "active": false,
                         "windows": [],
+                        "instance_policy": instance_policy.as_str(),
+                        "launch_state": launch_state_json(
+                            true,
+                            false,
+                            false,
+                            ProcessDisposition::None,
+                            WindowDisposition::None,
+                        ),
                     }))
                 }
             }
-            Ok(Err(e)) => ToolResult::error(format!("Failed to launch: {e}")),
-            Err(e) => ToolResult::error(format!("Task error: {e}")),
+            Ok(Err(e)) => launch_request_error(
+                "APP_LAUNCH_FAILED",
+                format!("Failed to launch: {e}"),
+                instance_policy,
+            ),
+            Err(e) => launch_request_error(
+                "APP_LAUNCH_TASK_FAILED",
+                format!("Launch worker outcome is unavailable: {e}"),
+                instance_policy,
+            ),
         }
     }
 }

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/launch_app.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/launch_app.rs
@@ -1,22 +1,30 @@
 use async_trait::async_trait;
 use cua_driver_core::{
+    launch_state_json,
     protocol::ToolResult,
+    resolve_instance_policy,
     tool::{Tool, ToolDef},
+    InstancePolicy, ProcessDisposition, WindowDisposition,
 };
 use serde_json::Value;
-use std::path::PathBuf;
+use std::{collections::HashSet, path::PathBuf};
 
 pub struct LaunchAppTool;
 
 static DEF: std::sync::OnceLock<ToolDef> = std::sync::OnceLock::new();
+static APP_ACQUISITION_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 fn def() -> &'static ToolDef {
     DEF.get_or_init(|| ToolDef {
         name: "launch_app".into(),
         description:
-            "Launch a macOS app in the background — the target does NOT come to the foreground.\n\n\
+            "Resolve or launch a macOS app in the background — the target does NOT come to the foreground.\n\n\
              Provide either `bundle_id` (preferred — unambiguous, e.g. `com.apple.calculator`) \
              or `name` (e.g. \"Calculator\"). If both are given, bundle_id wins.\n\n\
+             `instance_policy` controls acquisition: `reuse_or_launch` (default) atomically \
+             reuses one exact existing app window before sending a launch request, `reuse_only` \
+             refuses rather than launching, and `new` requests an isolated process. Multiple \
+             exact running candidates are reported as ambiguous instead of guessing.\n\n\
              Optional `urls` are handed to the app as open targets — for Finder, pass a folder \
              path to open a backgrounded Finder window there.\n\n\
              Browser DevTools setup belongs to `browser_prepare`, which can prove that a \
@@ -24,19 +32,15 @@ fn def() -> &'static ToolDef {
              Optional `webkit_inspector_port`: opens a WebKit inspector server on the specified \
              port (sets WEBKIT_INSPECTOR_SERVER=127.0.0.1:N + TAURI_WEBVIEW_AUTOMATION=1). \
              Use this for Tauri/WebKit-based apps.\n\n\
-             Optional `creates_new_application_instance`: when true, requests a new app instance \
-             even if one is already running. Reach for this when another \
-             agent or session may drive the SAME app concurrently — it returns a fresh pid + \
-             window so each session acts on its own isolated window instead of clobbering one \
-             shared instance. Without it, single-instance apps (Calculator, many utilities) hand \
-             every caller the same window, so two sessions fight over it. Apps that cannot create \
-             an isolated process return `NEW_APPLICATION_INSTANCE_UNAVAILABLE`; retry without the \
-             option only when sharing the existing process is safe.\n\n\
+             `creates_new_application_instance` is a deprecated compatibility alias: true maps \
+             to `instance_policy: \"new\"`. Apps that cannot create an isolated process return \
+             `NEW_APPLICATION_INSTANCE_UNAVAILABLE`; retry with reuse only when sharing is safe.\n\n\
              Optional `additional_arguments`: extra argv strings appended after --args.\n\n\
              Returns the launched app's pid, bundle_id, name, and a `windows` array \
              (same shape as `list_windows`) so callers can skip an extra round-trip before \
              `get_window_state(pid, window_id)`. `launch_state` distinguishes whether the \
-             request was sent, the process is running, and a window is ready. When the \
+             request was sent, whether the process/window was reused or created/materialized, \
+             and whether a window is ready. When the \
              focus-steal belt-and-braces \
              demotion check ran (target pid ≠ prior frontmost), the response also includes \
              `self_activation_suppressed: bool` — true if focus stayed with the prior \
@@ -62,9 +66,12 @@ fn def() -> &'static ToolDef {
                     "type": "integer",
                     "description": "Open a WebKit inspector server on this port (sets WEBKIT_INSPECTOR_SERVER env var)."
                 },
+                "session": cua_driver_core::tool_schema::session_schema(),
+                "instance_policy": cua_driver_core::tool_schema::instance_policy_schema(),
                 "creates_new_application_instance": {
                     "type": "boolean",
-                    "description": "When true, request a new app instance even if already running. Use for concurrent multi-agent/multi-session work so each session gets an isolated instance + window instead of sharing one. Apps that cannot create an isolated process return NEW_APPLICATION_INSTANCE_UNAVAILABLE; retry without this option only when sharing the existing process is safe."
+                    "deprecated": true,
+                    "description": "Deprecated compatibility alias. True maps to instance_policy=\"new\"; false maps to the default reuse_or_launch when instance_policy is omitted."
                 },
                 "additional_arguments": {
                     "type": "array",
@@ -104,7 +111,11 @@ impl Tool for LaunchAppTool {
             );
         }
         let webkit_inspector_port = args.opt_u64("webkit_inspector_port").map(|v| v as u16);
-        let creates_new_instance = args.bool_or("creates_new_application_instance", false);
+        let instance_policy = match resolve_instance_policy(&args) {
+            Ok(policy) => policy,
+            Err(error) => return error,
+        };
+        let creates_new_instance = matches!(&instance_policy, InstancePolicy::New);
         let additional_arguments: Vec<String> = args.str_array("additional_arguments");
         if additional_arguments
             .iter()
@@ -129,31 +140,25 @@ impl Tool for LaunchAppTool {
         if bundle_id.as_deref().is_some_and(is_cua_driver_bundle_id) {
             return protected_host_launch_refusal();
         }
-        if let Some(ref bid) = bundle_id {
-            if crate::apps::resolve_bundle_id_to_locator(bid).is_none() {
-                return structured_launch_error(
-                    "APP_NOT_INSTALLED",
-                    format!("No installed macOS app found for bundle_id '{bid}'."),
-                    serde_json::json!({ "bundle_id": bid }),
-                );
-            }
+        let target_is_launchable = if let Some(ref bid) = bundle_id {
+            crate::apps::resolve_bundle_id_to_locator(bid).is_some()
         } else if let Some(ref n) = name {
-            let Some(locator) = crate::apps::locate_by_name(n) else {
-                return structured_launch_error(
-                    "APP_NOT_INSTALLED",
-                    format!("No installed macOS app found for name '{n}'."),
-                    serde_json::json!({ "name": n }),
-                );
-            };
-            let (_, resolved_bundle_id) = locator.app_ref_and_bundle_id();
-            response_bundle_id = resolved_bundle_id.clone();
-            if resolved_bundle_id
-                .as_deref()
-                .is_some_and(is_cua_driver_bundle_id)
-            {
-                return protected_host_launch_refusal();
+            if let Some(locator) = crate::apps::locate_by_name(n) {
+                let (_, resolved_bundle_id) = locator.app_ref_and_bundle_id();
+                response_bundle_id = resolved_bundle_id.clone();
+                if resolved_bundle_id
+                    .as_deref()
+                    .is_some_and(is_cua_driver_bundle_id)
+                {
+                    return protected_host_launch_refusal();
+                }
+                true
+            } else {
+                false
             }
-        }
+        } else {
+            false
+        };
         if let Some(err) = preflight_file_urls(&urls) {
             return err;
         }
@@ -175,6 +180,91 @@ impl Tool for LaunchAppTool {
             }
             s
         };
+
+        // Serialize the exact resolve/reuse/launch decision inside one driver
+        // runtime. Without this critical section, two concurrent MCP calls can
+        // both observe "not running" and issue duplicate launches.
+        let acquisition_guard = APP_ACQUISITION_LOCK.lock().await;
+        let existing_apps = matching_running_apps(
+            crate::apps::list_running_apps(),
+            response_bundle_id.as_deref(),
+            response_requested_name.as_deref(),
+        );
+        let existing_candidates: Vec<_> = existing_apps
+            .iter()
+            .map(|app| (app.clone(), windows_for_pid(app.pid)))
+            .collect();
+        let has_launch_directives = !urls.is_empty()
+            || !additional_arguments.is_empty()
+            || !env.is_empty()
+            || webkit_inspector_port.is_some();
+
+        match prelaunch_decision(
+            &instance_policy,
+            has_launch_directives,
+            &existing_candidates,
+        ) {
+            PrelaunchDecision::Ambiguous => {
+                return ambiguous_app_target(&instance_policy, &existing_candidates);
+            }
+            PrelaunchDecision::Reuse => {
+                let (app, windows) = existing_candidates
+                    .first()
+                    .expect("reuse decision requires exactly one reusable candidate");
+                let (app_name, bid) = response_identity(
+                    Some(app),
+                    response_bundle_id.as_deref(),
+                    response_requested_name.as_deref(),
+                );
+                return successful_acquisition(
+                    app.pid,
+                    app_name,
+                    bid,
+                    windows,
+                    &port_summary,
+                    false,
+                    ProcessDisposition::Reused,
+                    WindowDisposition::Reused,
+                    None,
+                    &instance_policy,
+                );
+            }
+            PrelaunchDecision::ReuseUnavailable => {
+                return reuse_only_unavailable(
+                    existing_candidates.first(),
+                    has_launch_directives,
+                    &instance_policy,
+                );
+            }
+            PrelaunchDecision::SendRequest => {}
+        }
+
+        // A running app can still be reused even when LaunchServices cannot
+        // currently resolve its installed bundle (for example, an app on an
+        // unmounted registration path). Only require an installed launch
+        // target once this call actually needs to send a request.
+        if !target_is_launchable {
+            return if let Some(ref bid) = bundle_id {
+                structured_launch_error(
+                    "APP_NOT_INSTALLED",
+                    format!("No installed macOS app found for bundle_id '{bid}'."),
+                    serde_json::json!({ "bundle_id": bid }),
+                )
+            } else {
+                let requested_name = name.as_deref().unwrap_or("?");
+                structured_launch_error(
+                    "APP_NOT_INSTALLED",
+                    format!("No installed macOS app found for name '{requested_name}'."),
+                    serde_json::json!({ "name": requested_name }),
+                )
+            };
+        }
+
+        let preexisting_pids: HashSet<i32> = existing_apps.iter().map(|app| app.pid).collect();
+        let preexisting_window_ids: HashSet<u32> = existing_candidates
+            .iter()
+            .flat_map(|(_, windows)| windows.iter().map(|window| window.window_id))
+            .collect();
 
         // ── Layer-3 focus-steal suppression (3-phase wrap) ───────────────
         //
@@ -228,6 +318,7 @@ impl Tool for LaunchAppTool {
         // blocking task returns (pid, app_info, windows). Suppression
         // upgrade happens AFTER the blocking call returns (back on the
         // async runtime), then we sleep holding the targeted lease.
+        let validation_pids = preexisting_pids.clone();
         let launch_result = tokio::task::spawn_blocking(move || {
             let pid = if let Some(ref bid) = bundle_id {
                 if urls.is_empty()
@@ -264,7 +355,7 @@ impl Tool for LaunchAppTool {
                 }
             };
 
-            let pid = validate_launched_pid(pid, creates_new_instance)?;
+            let pid = validate_launched_pid(pid, creates_new_instance, &validation_pids)?;
 
             // Retry loop: LaunchServices returns before WindowServer has
             // registered the new windows. Poll up to 5x100ms.
@@ -278,6 +369,7 @@ impl Tool for LaunchAppTool {
             Ok::<_, anyhow::Error>((pid, app_info, windows))
         })
         .await;
+        drop(acquisition_guard);
 
         // Upgrade to targeted suppression now that we know the real pid.
         // Keep the wildcard lease alive until immediately AFTER we've
@@ -456,56 +548,40 @@ impl Tool for LaunchAppTool {
                     response_requested_name.as_deref(),
                 );
 
-                let mut summary =
-                    format!("Launched {app_name} (pid {pid}) in background.{port_summary}");
-
-                if !windows.is_empty() {
-                    summary.push_str("\n\nWindows:");
-                    for w in &windows {
-                        let title = if w.title.is_empty() {
-                            "(no title)".to_owned()
-                        } else {
-                            format!("\"{}\"", w.title)
-                        };
-                        summary.push_str(&format!("\n- {title} [window_id: {}]", w.window_id));
-                    }
-                    summary.push_str(&format!(
-                        "\n→ Call get_window_state(pid: {pid}, window_id) to inspect."
-                    ));
-                }
-
-                let windows_json: Vec<Value> = windows
+                let process_disposition = if preexisting_pids.contains(&pid) {
+                    ProcessDisposition::Reused
+                } else {
+                    ProcessDisposition::Created
+                };
+                let window_disposition = if windows.is_empty() {
+                    WindowDisposition::None
+                } else if windows
                     .iter()
-                    .map(super::list_windows::window_record_json)
-                    .collect();
+                    .any(|window| !preexisting_window_ids.contains(&window.window_id))
+                {
+                    WindowDisposition::Materialized
+                } else {
+                    WindowDisposition::Reused
+                };
 
-                let mut structured = serde_json::json!({
-                    "pid": pid,
-                    "bundle_id": bid,
-                    "name": app_name,
-                    "windows": windows_json,
-                    "launch_state": launch_state(true, true, !windows.is_empty()),
-                });
-                // Only emit `self_activation_suppressed` when the
-                // belt-and-braces demotion check actually ran. `None`
-                // means the launch didn't enter the focus-steal path
-                // (no prior frontmost, or pid == prior) — surfacing
-                // a stale `false` would be misleading.
-                if let Some(suppressed) = self_activation_suppressed {
-                    structured["self_activation_suppressed"] = serde_json::Value::Bool(suppressed);
-                }
-                ToolResult::text(summary).with_structured(structured)
+                successful_acquisition(
+                    pid,
+                    app_name,
+                    bid,
+                    &windows,
+                    &port_summary,
+                    true,
+                    process_disposition,
+                    window_disposition,
+                    self_activation_suppressed,
+                    &instance_policy,
+                )
             }
             Ok(Err(e)) => {
                 let existing_app = creates_new_instance
-                    .then(|| {
-                        existing_running_app(
-                            response_bundle_id.as_deref(),
-                            response_requested_name.as_deref(),
-                        )
-                    })
+                    .then(|| existing_apps.first())
                     .flatten();
-                structured_launch_failure(&e, existing_app.as_ref())
+                structured_launch_failure(&e, existing_app)
             }
             Err(e) => ToolResult::error(format!("Task error: {e}")),
         }
@@ -535,11 +611,7 @@ fn protected_host_launch_refusal() -> ToolResult {
 /// LaunchServices → WindowServer latency (mirrors the Swift reference).
 fn resolve_windows_for_pid(pid: i32) -> Vec<crate::windows::WindowInfo> {
     for attempt in 0..5 {
-        let found: Vec<_> = crate::windows::all_windows()
-            .into_iter()
-            .filter(|w| w.pid == pid && w.layer == 0)
-            .filter(|w| w.bounds.width > 1.0 && w.bounds.height > 1.0)
-            .collect();
+        let found = windows_for_pid(pid);
         if !found.is_empty() {
             return found;
         }
@@ -548,6 +620,14 @@ fn resolve_windows_for_pid(pid: i32) -> Vec<crate::windows::WindowInfo> {
         }
     }
     vec![]
+}
+
+fn windows_for_pid(pid: i32) -> Vec<crate::windows::WindowInfo> {
+    crate::windows::all_windows()
+        .into_iter()
+        .filter(|window| window.pid == pid && window.layer == 0)
+        .filter(|window| window.bounds.width > 1.0 && window.bounds.height > 1.0)
+        .collect()
 }
 
 fn structured_launch_error(code: &str, message: String, details: serde_json::Value) -> ToolResult {
@@ -571,12 +651,191 @@ fn structured_launch_error(code: &str, message: String, details: serde_json::Val
     ToolResult::error(message).with_structured(payload)
 }
 
-fn launch_state(requested: bool, process_running: bool, window_ready: bool) -> serde_json::Value {
+fn matching_running_apps(
+    apps: Vec<crate::apps::AppInfo>,
+    requested_bundle_id: Option<&str>,
+    requested_name: Option<&str>,
+) -> Vec<crate::apps::AppInfo> {
+    let normalized_name = requested_app_name(requested_name, requested_bundle_id);
+    apps.into_iter()
+        .filter(|app| {
+            requested_bundle_id.map_or_else(
+                || app.name.eq_ignore_ascii_case(&normalized_name),
+                |bundle_id| {
+                    app.bundle_id.as_deref().is_some_and(|running_bundle_id| {
+                        running_bundle_id.eq_ignore_ascii_case(bundle_id)
+                    })
+                },
+            )
+        })
+        .collect()
+}
+
+fn candidate_json(app: &crate::apps::AppInfo, windows: &[crate::windows::WindowInfo]) -> Value {
     serde_json::json!({
-        "requested": requested,
-        "process_running": process_running,
-        "window_ready": window_ready,
+        "pid": app.pid,
+        "bundle_id": app.bundle_id,
+        "name": app.name,
+        "windows": windows
+            .iter()
+            .map(super::list_windows::window_record_json)
+            .collect::<Vec<_>>(),
     })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PrelaunchDecision {
+    Reuse,
+    Ambiguous,
+    ReuseUnavailable,
+    SendRequest,
+}
+
+fn prelaunch_decision(
+    policy: &InstancePolicy,
+    has_launch_directives: bool,
+    candidates: &[(crate::apps::AppInfo, Vec<crate::windows::WindowInfo>)],
+) -> PrelaunchDecision {
+    if matches!(policy, InstancePolicy::New) {
+        return PrelaunchDecision::SendRequest;
+    }
+    if candidates.len() > 1 {
+        return PrelaunchDecision::Ambiguous;
+    }
+    if candidates
+        .first()
+        .is_some_and(|(_, windows)| !has_launch_directives && !windows.is_empty())
+    {
+        return PrelaunchDecision::Reuse;
+    }
+    if matches!(policy, InstancePolicy::ReuseOnly) {
+        return PrelaunchDecision::ReuseUnavailable;
+    }
+    PrelaunchDecision::SendRequest
+}
+
+fn ambiguous_app_target(
+    policy: &InstancePolicy,
+    candidates: &[(crate::apps::AppInfo, Vec<crate::windows::WindowInfo>)],
+) -> ToolResult {
+    structured_launch_error(
+        "APP_TARGET_AMBIGUOUS",
+        format!(
+            "launch_app found {} exact running app processes. Choose an explicit pid/window from candidates or use instance_policy=\"new\" when isolation is required.",
+            candidates.len()
+        ),
+        serde_json::json!({
+            "instance_policy": policy.as_str(),
+            "candidates": candidates
+                .iter()
+                .map(|(app, windows)| candidate_json(app, windows))
+                .collect::<Vec<_>>(),
+            "launch_state": launch_state_json(
+                false,
+                true,
+                false,
+                ProcessDisposition::None,
+                WindowDisposition::None,
+            ),
+        }),
+    )
+}
+
+fn reuse_only_unavailable(
+    candidate: Option<&(crate::apps::AppInfo, Vec<crate::windows::WindowInfo>)>,
+    has_launch_directives: bool,
+    policy: &InstancePolicy,
+) -> ToolResult {
+    let message = match candidate {
+        Some(_) if has_launch_directives => {
+            "instance_policy=\"reuse_only\" cannot deliver urls, arguments, or environment without sending an app-open request. No request was sent."
+        }
+        Some(_) => {
+            "The exact app process is running but has no reusable layer-0 window, and instance_policy=\"reuse_only\" forbids an app-open request."
+        }
+        None => {
+            "No exact running app process with a reusable window was found, and instance_policy=\"reuse_only\" forbids launching one."
+        }
+    };
+    let process_running = candidate.is_some();
+    let mut details = serde_json::json!({
+        "instance_policy": policy.as_str(),
+        "launch_state": launch_state_json(
+            false,
+            process_running,
+            false,
+            if process_running {
+                ProcessDisposition::Reused
+            } else {
+                ProcessDisposition::None
+            },
+            WindowDisposition::None,
+        ),
+    });
+    if let Some((app, windows)) = candidate {
+        details["candidate"] = candidate_json(app, windows);
+    }
+    structured_launch_error("APP_REUSE_UNAVAILABLE", message.to_owned(), details)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn successful_acquisition(
+    pid: i32,
+    app_name: String,
+    bundle_id: String,
+    windows: &[crate::windows::WindowInfo],
+    port_summary: &str,
+    request_sent: bool,
+    process_disposition: ProcessDisposition,
+    window_disposition: WindowDisposition,
+    self_activation_suppressed: Option<bool>,
+    policy: &InstancePolicy,
+) -> ToolResult {
+    let mut summary = match (request_sent, process_disposition) {
+        (false, _) => format!("Reused {app_name} (pid {pid}) without sending a launch request."),
+        (true, ProcessDisposition::Reused) => {
+            format!("Opened {app_name} through its existing process (pid {pid}) in background.{port_summary}")
+        }
+        _ => format!("Launched {app_name} (pid {pid}) in background.{port_summary}"),
+    };
+
+    if !windows.is_empty() {
+        summary.push_str("\n\nWindows:");
+        for window in windows {
+            let title = if window.title.is_empty() {
+                "(no title)".to_owned()
+            } else {
+                format!("\"{}\"", window.title)
+            };
+            summary.push_str(&format!("\n- {title} [window_id: {}]", window.window_id));
+        }
+        summary.push_str(&format!(
+            "\n→ Call get_window_state(pid: {pid}, window_id) to inspect."
+        ));
+    }
+
+    let windows_json: Vec<Value> = windows
+        .iter()
+        .map(super::list_windows::window_record_json)
+        .collect();
+    let mut structured = serde_json::json!({
+        "pid": pid,
+        "bundle_id": bundle_id,
+        "name": app_name,
+        "windows": windows_json,
+        "instance_policy": policy.as_str(),
+        "launch_state": launch_state_json(
+            request_sent,
+            true,
+            !windows.is_empty(),
+            process_disposition,
+            window_disposition,
+        ),
+    });
+    if let Some(suppressed) = self_activation_suppressed {
+        structured["self_activation_suppressed"] = Value::Bool(suppressed);
+    }
+    ToolResult::text(summary).with_structured(structured)
 }
 
 fn response_identity(
@@ -619,24 +878,19 @@ fn requested_app_name(requested_name: Option<&str>, requested_bundle_id: Option<
         .to_owned()
 }
 
-fn existing_running_app(
-    requested_bundle_id: Option<&str>,
-    requested_name: Option<&str>,
-) -> Option<crate::apps::AppInfo> {
-    crate::apps::list_running_apps().into_iter().find(|app| {
-        requested_bundle_id.is_some_and(|bundle_id| {
-            app.bundle_id
-                .as_deref()
-                .is_some_and(|running_bundle_id| running_bundle_id.eq_ignore_ascii_case(bundle_id))
-        }) || (requested_bundle_id.is_none()
-            && requested_name.is_some_and(|name| app.name.eq_ignore_ascii_case(name)))
-    })
-}
-
-fn validate_launched_pid(pid: i32, creates_new_instance: bool) -> anyhow::Result<i32> {
+fn validate_launched_pid(
+    pid: i32,
+    creates_new_instance: bool,
+    preexisting_pids: &HashSet<i32>,
+) -> anyhow::Result<i32> {
     if creates_new_instance && pid <= 0 {
         anyhow::bail!(
             "macOS returned invalid process identifier {pid} for the requested new application instance"
+        );
+    }
+    if creates_new_instance && preexisting_pids.contains(&pid) {
+        anyhow::bail!(
+            "macOS returned existing process identifier {pid} instead of creating the requested new application instance"
         );
     }
     Ok(pid)
@@ -663,7 +917,14 @@ fn structured_launch_failure(
                     "name": existing_app.name,
                     "pid": existing_app.pid,
                     "creates_new_application_instance": true,
-                    "launch_state": launch_state(true, true, false),
+                    "instance_policy": "new",
+                    "launch_state": launch_state_json(
+                        true,
+                        true,
+                        false,
+                        ProcessDisposition::Reused,
+                        WindowDisposition::None,
+                    ),
                 }),
             );
         }
@@ -684,7 +945,13 @@ fn structured_launch_failure(
         code,
         format!("Launch failed: {error:#}"),
         serde_json::json!({
-            "launch_state": launch_state(requested, false, false),
+            "launch_state": launch_state_json(
+                requested,
+                false,
+                false,
+                ProcessDisposition::None,
+                WindowDisposition::None,
+            ),
         }),
     )
 }
@@ -780,14 +1047,192 @@ fn hex_value(byte: u8) -> Option<u8> {
 mod tests {
     use super::{
         contains_remote_debugging_flag, is_cua_driver_bundle_id, local_file_target,
-        normalize_launch_url, preflight_file_urls, response_identity, structured_launch_failure,
-        validate_launched_pid,
-        LaunchAppTool,
+        matching_running_apps, normalize_launch_url, preflight_file_urls, prelaunch_decision,
+        response_identity, reuse_only_unavailable, structured_launch_failure,
+        successful_acquisition, validate_launched_pid, LaunchAppTool, PrelaunchDecision,
     };
     use cua_driver_core::protocol::Content;
+    use cua_driver_core::resolve_instance_policy;
     use cua_driver_core::tool::Tool;
+    use cua_driver_core::{InstancePolicy, ProcessDisposition, WindowDisposition};
     use serde_json::json;
-    use std::path::PathBuf;
+    use std::{collections::HashSet, path::PathBuf};
+
+    fn app(name: &str, pid: i32, bundle_id: Option<&str>) -> crate::apps::AppInfo {
+        crate::apps::AppInfo {
+            name: name.to_owned(),
+            pid,
+            bundle_id: bundle_id.map(str::to_owned),
+            running: true,
+            active: false,
+            launch_path: None,
+            kind: Some("desktop".to_owned()),
+            last_used: None,
+        }
+    }
+
+    fn window(pid: i32, window_id: u32) -> crate::windows::WindowInfo {
+        crate::windows::WindowInfo {
+            window_id,
+            pid,
+            app_name: "Example".to_owned(),
+            title: "Document".to_owned(),
+            bounds: crate::windows::WindowBounds {
+                x: 0.0,
+                y: 0.0,
+                width: 800.0,
+                height: 600.0,
+            },
+            layer: 0,
+            z_index: 0,
+            is_on_screen: true,
+            current_space_id: Some(1),
+            on_current_space: Some(true),
+            space_ids: Some(vec![1]),
+        }
+    }
+
+    #[test]
+    fn launch_schema_exposes_session_and_canonical_instance_policy() {
+        let properties = LaunchAppTool
+            .def()
+            .input_schema
+            .get("properties")
+            .expect("properties");
+        assert_eq!(
+            properties["session"],
+            cua_driver_core::tool_schema::session_schema()
+        );
+        assert_eq!(
+            properties["instance_policy"],
+            cua_driver_core::tool_schema::instance_policy_schema()
+        );
+    }
+
+    #[test]
+    fn instance_policy_maps_legacy_new_and_rejects_conflicts() {
+        assert_eq!(
+            resolve_instance_policy(&json!({}))
+                .expect("default policy")
+                .as_str(),
+            "reuse_or_launch"
+        );
+        assert_eq!(
+            resolve_instance_policy(&json!({"creates_new_application_instance": true}))
+                .expect("legacy true")
+                .as_str(),
+            "new"
+        );
+        assert_eq!(
+            resolve_instance_policy(&json!({
+                "instance_policy": "new",
+                "creates_new_application_instance": false
+            }))
+            .expect("explicit policy wins over legacy false")
+            .as_str(),
+            "new"
+        );
+
+        let error = resolve_instance_policy(&json!({
+            "instance_policy": "reuse_only",
+            "creates_new_application_instance": true
+        }))
+        .expect_err("conflicting policy must fail");
+        assert_eq!(
+            error.structured_content.expect("structured error")["error"],
+            "INSTANCE_POLICY_CONFLICT"
+        );
+    }
+
+    #[test]
+    fn exact_running_match_prefers_bundle_id_and_normalizes_app_name() {
+        let apps = vec![
+            app("Example", 10, Some("com.example.Editor")),
+            app("Example Helper", 11, Some("com.example.Editor.Helper")),
+        ];
+        let matched =
+            matching_running_apps(apps.clone(), Some("COM.EXAMPLE.EDITOR"), Some("Wrong Name"));
+        assert_eq!(matched.len(), 1);
+        assert_eq!(matched[0].pid, 10);
+
+        let matched = matching_running_apps(apps, None, Some("/Applications/Example.app"));
+        assert_eq!(matched.len(), 1);
+        assert_eq!(matched[0].pid, 10);
+    }
+
+    #[test]
+    fn reuse_first_decision_avoids_requests_and_refuses_ambiguity() {
+        let one_window = vec![(
+            app("Example", 10, Some("com.example.Editor")),
+            vec![window(10, 20)],
+        )];
+        assert_eq!(
+            prelaunch_decision(&InstancePolicy::ReuseOrLaunch, false, &one_window),
+            PrelaunchDecision::Reuse
+        );
+        assert_eq!(
+            prelaunch_decision(&InstancePolicy::ReuseOnly, false, &one_window),
+            PrelaunchDecision::Reuse
+        );
+        assert_eq!(
+            prelaunch_decision(&InstancePolicy::ReuseOnly, true, &one_window),
+            PrelaunchDecision::ReuseUnavailable
+        );
+
+        let multiple = vec![
+            (
+                app("Example", 10, Some("com.example.Editor")),
+                vec![window(10, 20)],
+            ),
+            (
+                app("Example", 11, Some("com.example.Editor")),
+                vec![window(11, 21)],
+            ),
+        ];
+        assert_eq!(
+            prelaunch_decision(&InstancePolicy::ReuseOrLaunch, false, &multiple),
+            PrelaunchDecision::Ambiguous
+        );
+        assert_eq!(
+            prelaunch_decision(&InstancePolicy::New, false, &multiple),
+            PrelaunchDecision::SendRequest
+        );
+    }
+
+    #[test]
+    fn reused_success_reports_that_no_launch_request_was_sent() {
+        let result = successful_acquisition(
+            10,
+            "Example".to_owned(),
+            "com.example.Editor".to_owned(),
+            &[window(10, 20)],
+            "",
+            false,
+            ProcessDisposition::Reused,
+            WindowDisposition::Reused,
+            None,
+            &InstancePolicy::ReuseOrLaunch,
+        );
+        let structured = result.structured_content.expect("structured result");
+        assert_eq!(structured["launch_state"]["requested"], false);
+        assert_eq!(structured["launch_state"]["request_sent"], false);
+        assert_eq!(structured["launch_state"]["process_disposition"], "reused");
+        assert_eq!(structured["launch_state"]["window_disposition"], "reused");
+        assert!(result.content.iter().any(|content| matches!(
+            content,
+            Content::Text { text, .. } if text.contains("Reused Example")
+        )));
+    }
+
+    #[test]
+    fn reuse_only_refusal_never_claims_a_request_was_sent() {
+        let candidate = (app("Example", 10, Some("com.example.Editor")), vec![]);
+        let result = reuse_only_unavailable(Some(&candidate), false, &InstancePolicy::ReuseOnly);
+        let structured = result.structured_content.expect("structured error");
+        assert_eq!(structured["error"], "APP_REUSE_UNAVAILABLE");
+        assert_eq!(structured["launch_state"]["request_sent"], false);
+        assert_eq!(structured["launch_state"]["process_running"], true);
+    }
 
     #[test]
     fn local_file_target_treats_plain_paths_as_files() {
@@ -930,11 +1375,17 @@ mod tests {
 
     #[test]
     fn new_instance_cannot_report_success_without_a_process() {
-        let error = validate_launched_pid(-1, true).expect_err("invalid pid must fail");
+        let existing = HashSet::from([4242]);
+        let error = validate_launched_pid(-1, true, &existing).expect_err("invalid pid must fail");
         assert!(error
             .to_string()
             .contains("invalid process identifier -1 for the requested new application instance"));
-        assert_eq!(validate_launched_pid(4242, true).unwrap(), 4242);
+        let error = validate_launched_pid(4242, true, &existing)
+            .expect_err("existing pid cannot satisfy an isolated launch");
+        assert!(error
+            .to_string()
+            .contains("existing process identifier 4242"));
+        assert_eq!(validate_launched_pid(4243, true, &existing).unwrap(), 4243);
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/launch_app.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/launch_app.rs
@@ -24,12 +24,14 @@ fn def() -> &'static ToolDef {
              Optional `webkit_inspector_port`: opens a WebKit inspector server on the specified \
              port (sets WEBKIT_INSPECTOR_SERVER=127.0.0.1:N + TAURI_WEBVIEW_AUTOMATION=1). \
              Use this for Tauri/WebKit-based apps.\n\n\
-             Optional `creates_new_application_instance`: when true, forces a new app instance \
-             even if one is already running (passes -n to open). Reach for this when another \
+             Optional `creates_new_application_instance`: when true, requests a new app instance \
+             even if one is already running. Reach for this when another \
              agent or session may drive the SAME app concurrently — it returns a fresh pid + \
              window so each session acts on its own isolated window instead of clobbering one \
              shared instance. Without it, single-instance apps (Calculator, many utilities) hand \
-             every caller the same window, so two sessions fight over it.\n\n\
+             every caller the same window, so two sessions fight over it. Apps that cannot create \
+             an isolated process return `NEW_APPLICATION_INSTANCE_UNAVAILABLE`; retry without the \
+             option only when sharing the existing process is safe.\n\n\
              Optional `additional_arguments`: extra argv strings appended after --args.\n\n\
              Returns the launched app's pid, bundle_id, name, and a `windows` array \
              (same shape as `list_windows`) so callers can skip an extra round-trip before \
@@ -62,7 +64,7 @@ fn def() -> &'static ToolDef {
                 },
                 "creates_new_application_instance": {
                     "type": "boolean",
-                    "description": "When true, force a new app instance even if already running (open -n). Use for concurrent multi-agent/multi-session work so each session gets an isolated instance + window instead of sharing one — on single-instance apps (e.g. Calculator) every caller otherwise gets the same window and the sessions clobber each other."
+                    "description": "When true, request a new app instance even if already running. Use for concurrent multi-agent/multi-session work so each session gets an isolated instance + window instead of sharing one. Apps that cannot create an isolated process return NEW_APPLICATION_INSTANCE_UNAVAILABLE; retry without this option only when sharing the existing process is safe."
                 },
                 "additional_arguments": {
                     "type": "array",
@@ -261,6 +263,8 @@ impl Tool for LaunchAppTool {
                     )?
                 }
             };
+
+            let pid = validate_launched_pid(pid, creates_new_instance)?;
 
             // Retry loop: LaunchServices returns before WindowServer has
             // registered the new windows. Poll up to 5x100ms.
@@ -492,7 +496,17 @@ impl Tool for LaunchAppTool {
                 }
                 ToolResult::text(summary).with_structured(structured)
             }
-            Ok(Err(e)) => structured_launch_failure(&e),
+            Ok(Err(e)) => {
+                let existing_app = creates_new_instance
+                    .then(|| {
+                        existing_running_app(
+                            response_bundle_id.as_deref(),
+                            response_requested_name.as_deref(),
+                        )
+                    })
+                    .flatten();
+                structured_launch_failure(&e, existing_app.as_ref())
+            }
             Err(e) => ToolResult::error(format!("Task error: {e}")),
         }
     }
@@ -605,10 +619,57 @@ fn requested_app_name(requested_name: Option<&str>, requested_bundle_id: Option<
         .to_owned()
 }
 
-fn structured_launch_failure(error: &anyhow::Error) -> ToolResult {
+fn existing_running_app(
+    requested_bundle_id: Option<&str>,
+    requested_name: Option<&str>,
+) -> Option<crate::apps::AppInfo> {
+    crate::apps::list_running_apps().into_iter().find(|app| {
+        requested_bundle_id.is_some_and(|bundle_id| {
+            app.bundle_id
+                .as_deref()
+                .is_some_and(|running_bundle_id| running_bundle_id.eq_ignore_ascii_case(bundle_id))
+        }) || (requested_bundle_id.is_none()
+            && requested_name.is_some_and(|name| app.name.eq_ignore_ascii_case(name)))
+    })
+}
+
+fn validate_launched_pid(pid: i32, creates_new_instance: bool) -> anyhow::Result<i32> {
+    if creates_new_instance && pid <= 0 {
+        anyhow::bail!(
+            "macOS returned invalid process identifier {pid} for the requested new application instance"
+        );
+    }
+    Ok(pid)
+}
+
+fn structured_launch_failure(
+    error: &anyhow::Error,
+    existing_app: Option<&crate::apps::AppInfo>,
+) -> ToolResult {
     use crate::apps::nsworkspace::LaunchError;
 
-    let (code, requested) = if let Some(launch_error) = error.downcast_ref::<LaunchError>() {
+    let launch_error = error.downcast_ref::<LaunchError>();
+    if !matches!(launch_error, Some(LaunchError::BadUrl(_))) {
+        if let Some(existing_app) = existing_app {
+            let bundle_id = existing_app.bundle_id.as_deref().unwrap_or("?");
+            return structured_launch_error(
+                "NEW_APPLICATION_INSTANCE_UNAVAILABLE",
+                format!(
+                    "macOS did not create a new application instance for {}. The existing process (pid {}) is still running; retry without creates_new_application_instance or choose an app that supports multiple instances. Underlying launch error: {error:#}",
+                    existing_app.name, existing_app.pid
+                ),
+                serde_json::json!({
+                    "bundle_id": bundle_id,
+                    "name": existing_app.name,
+                    "pid": existing_app.pid,
+                    "creates_new_application_instance": true,
+                    "launch_state": launch_state(true, true, false),
+                }),
+            );
+        }
+    }
+
+    let (code, requested) = if let Some(launch_error) = launch_error {
         match launch_error {
             LaunchError::Cocoa(_) => ("NSWORKSPACE_LAUNCH_FAILED", true),
             LaunchError::NoApp => ("LAUNCH_RESULT_MISSING", true),
@@ -720,8 +781,10 @@ mod tests {
     use super::{
         contains_remote_debugging_flag, is_cua_driver_bundle_id, local_file_target,
         normalize_launch_url, preflight_file_urls, response_identity, structured_launch_failure,
+        validate_launched_pid,
         LaunchAppTool,
     };
+    use cua_driver_core::protocol::Content;
     use cua_driver_core::tool::Tool;
     use serde_json::json;
     use std::path::PathBuf;
@@ -805,7 +868,7 @@ mod tests {
     fn launch_timeout_reports_requested_without_process_or_window() {
         let error = anyhow::Error::new(crate::apps::nsworkspace::LaunchError::Timeout)
             .context("Failed to launch com.example.App");
-        let result = structured_launch_failure(&error);
+        let result = structured_launch_failure(&error, None);
         let structured = result.structured_content.expect("structured error");
 
         assert_eq!(result.is_error, Some(true));
@@ -821,13 +884,57 @@ mod tests {
             "bad url".to_owned(),
         ))
         .context("Failed to launch com.example.App");
-        let result = structured_launch_failure(&error);
+        let result = structured_launch_failure(&error, None);
         let structured = result.structured_content.expect("structured error");
 
         assert_eq!(structured["error"], "APP_URL_INVALID");
         assert_eq!(structured["launch_state"]["requested"], false);
         assert_eq!(structured["launch_state"]["process_running"], false);
         assert_eq!(structured["launch_state"]["window_ready"], false);
+    }
+
+    #[test]
+    fn unavailable_new_instance_reports_existing_process_and_retry() {
+        let error = anyhow::Error::new(crate::apps::nsworkspace::LaunchError::Cocoa(
+            "The application could not be launched because it was not found.".to_owned(),
+        ))
+        .context("Failed to launch com.example.SingleInstance");
+        let existing_app = crate::apps::AppInfo {
+            name: "Single Instance".to_owned(),
+            pid: 4242,
+            bundle_id: Some("com.example.SingleInstance".to_owned()),
+            running: true,
+            active: false,
+            launch_path: None,
+            kind: Some("desktop".to_owned()),
+            last_used: None,
+        };
+
+        let result = structured_launch_failure(&error, Some(&existing_app));
+        let structured = result.structured_content.expect("structured error");
+
+        assert_eq!(result.is_error, Some(true));
+        assert_eq!(structured["error"], "NEW_APPLICATION_INSTANCE_UNAVAILABLE");
+        assert_eq!(structured["bundle_id"], "com.example.SingleInstance");
+        assert_eq!(structured["pid"], 4242);
+        assert_eq!(structured["creates_new_application_instance"], true);
+        assert_eq!(structured["launch_state"]["requested"], true);
+        assert_eq!(structured["launch_state"]["process_running"], true);
+        assert_eq!(structured["launch_state"]["window_ready"], false);
+        assert!(result.content.iter().any(|content| matches!(
+            content,
+            Content::Text { text, .. }
+                if text.contains("retry without creates_new_application_instance")
+        )));
+    }
+
+    #[test]
+    fn new_instance_cannot_report_success_without_a_process() {
+        let error = validate_launched_pid(-1, true).expect_err("invalid pid must fail");
+        assert!(error
+            .to_string()
+            .contains("invalid process identifier -1 for the requested new application instance"));
+        assert_eq!(validate_launched_pid(4242, true).unwrap(), 4242);
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/launch_app.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/launch_app.rs
@@ -24,12 +24,14 @@ fn def() -> &'static ToolDef {
              Optional `webkit_inspector_port`: opens a WebKit inspector server on the specified \
              port (sets WEBKIT_INSPECTOR_SERVER=127.0.0.1:N + TAURI_WEBVIEW_AUTOMATION=1). \
              Use this for Tauri/WebKit-based apps.\n\n\
-             Optional `creates_new_application_instance`: when true, forces a new app instance \
-             even if one is already running (passes -n to open). Reach for this when another \
+             Optional `creates_new_application_instance`: when true, requests a new app instance \
+             even if one is already running. Reach for this when another \
              agent or session may drive the SAME app concurrently — it returns a fresh pid + \
              window so each session acts on its own isolated window instead of clobbering one \
              shared instance. Without it, single-instance apps (Calculator, many utilities) hand \
-             every caller the same window, so two sessions fight over it.\n\n\
+             every caller the same window, so two sessions fight over it. Apps that cannot create \
+             an isolated process return `NEW_APPLICATION_INSTANCE_UNAVAILABLE`; retry without the \
+             option only when sharing the existing process is safe.\n\n\
              Optional `additional_arguments`: extra argv strings appended after --args.\n\n\
              Returns the launched app's pid, bundle_id, name, and a `windows` array \
              (same shape as `list_windows`) so callers can skip an extra round-trip before \
@@ -62,7 +64,7 @@ fn def() -> &'static ToolDef {
                 },
                 "creates_new_application_instance": {
                     "type": "boolean",
-                    "description": "When true, force a new app instance even if already running (open -n). Use for concurrent multi-agent/multi-session work so each session gets an isolated instance + window instead of sharing one — on single-instance apps (e.g. Calculator) every caller otherwise gets the same window and the sessions clobber each other."
+                    "description": "When true, request a new app instance even if already running. Use for concurrent multi-agent/multi-session work so each session gets an isolated instance + window instead of sharing one. Apps that cannot create an isolated process return NEW_APPLICATION_INSTANCE_UNAVAILABLE; retry without this option only when sharing the existing process is safe."
                 },
                 "additional_arguments": {
                     "type": "array",
@@ -246,6 +248,8 @@ impl Tool for LaunchAppTool {
                     )?
                 }
             };
+
+            let pid = validate_launched_pid(pid, creates_new_instance)?;
 
             // Retry loop: LaunchServices returns before WindowServer has
             // registered the new windows. Poll up to 5x100ms.
@@ -489,7 +493,17 @@ impl Tool for LaunchAppTool {
                 }
                 ToolResult::text(summary).with_structured(structured)
             }
-            Ok(Err(e)) => structured_launch_failure(&e),
+            Ok(Err(e)) => {
+                let existing_app = creates_new_instance
+                    .then(|| {
+                        existing_running_app(
+                            response_bundle_id.as_deref(),
+                            response_requested_name.as_deref(),
+                        )
+                    })
+                    .flatten();
+                structured_launch_failure(&e, existing_app.as_ref())
+            }
             Err(e) => ToolResult::error(format!("Task error: {e}")),
         }
     }
@@ -602,10 +616,57 @@ fn requested_app_name(requested_name: Option<&str>, requested_bundle_id: Option<
         .to_owned()
 }
 
-fn structured_launch_failure(error: &anyhow::Error) -> ToolResult {
+fn existing_running_app(
+    requested_bundle_id: Option<&str>,
+    requested_name: Option<&str>,
+) -> Option<crate::apps::AppInfo> {
+    crate::apps::list_running_apps().into_iter().find(|app| {
+        requested_bundle_id.is_some_and(|bundle_id| {
+            app.bundle_id
+                .as_deref()
+                .is_some_and(|running_bundle_id| running_bundle_id.eq_ignore_ascii_case(bundle_id))
+        }) || (requested_bundle_id.is_none()
+            && requested_name.is_some_and(|name| app.name.eq_ignore_ascii_case(name)))
+    })
+}
+
+fn validate_launched_pid(pid: i32, creates_new_instance: bool) -> anyhow::Result<i32> {
+    if creates_new_instance && pid <= 0 {
+        anyhow::bail!(
+            "macOS returned invalid process identifier {pid} for the requested new application instance"
+        );
+    }
+    Ok(pid)
+}
+
+fn structured_launch_failure(
+    error: &anyhow::Error,
+    existing_app: Option<&crate::apps::AppInfo>,
+) -> ToolResult {
     use crate::apps::nsworkspace::LaunchError;
 
-    let (code, requested) = if let Some(launch_error) = error.downcast_ref::<LaunchError>() {
+    let launch_error = error.downcast_ref::<LaunchError>();
+    if !matches!(launch_error, Some(LaunchError::BadUrl(_))) {
+        if let Some(existing_app) = existing_app {
+            let bundle_id = existing_app.bundle_id.as_deref().unwrap_or("?");
+            return structured_launch_error(
+                "NEW_APPLICATION_INSTANCE_UNAVAILABLE",
+                format!(
+                    "macOS did not create a new application instance for {}. The existing process (pid {}) is still running; retry without creates_new_application_instance or choose an app that supports multiple instances. Underlying launch error: {error:#}",
+                    existing_app.name, existing_app.pid
+                ),
+                serde_json::json!({
+                    "bundle_id": bundle_id,
+                    "name": existing_app.name,
+                    "pid": existing_app.pid,
+                    "creates_new_application_instance": true,
+                    "launch_state": launch_state(true, true, false),
+                }),
+            );
+        }
+    }
+
+    let (code, requested) = if let Some(launch_error) = launch_error {
         match launch_error {
             LaunchError::Cocoa(_) => ("NSWORKSPACE_LAUNCH_FAILED", true),
             LaunchError::NoApp => ("LAUNCH_RESULT_MISSING", true),
@@ -710,8 +771,10 @@ fn hex_value(byte: u8) -> Option<u8> {
 mod tests {
     use super::{
         contains_remote_debugging_flag, is_cua_driver_bundle_id, local_file_target,
-        preflight_file_urls, response_identity, structured_launch_failure, LaunchAppTool,
+        preflight_file_urls, response_identity, structured_launch_failure, validate_launched_pid,
+        LaunchAppTool,
     };
+    use cua_driver_core::protocol::Content;
     use cua_driver_core::tool::Tool;
     use serde_json::json;
     use std::path::PathBuf;
@@ -781,7 +844,7 @@ mod tests {
     fn launch_timeout_reports_requested_without_process_or_window() {
         let error = anyhow::Error::new(crate::apps::nsworkspace::LaunchError::Timeout)
             .context("Failed to launch com.example.App");
-        let result = structured_launch_failure(&error);
+        let result = structured_launch_failure(&error, None);
         let structured = result.structured_content.expect("structured error");
 
         assert_eq!(result.is_error, Some(true));
@@ -797,13 +860,57 @@ mod tests {
             "bad url".to_owned(),
         ))
         .context("Failed to launch com.example.App");
-        let result = structured_launch_failure(&error);
+        let result = structured_launch_failure(&error, None);
         let structured = result.structured_content.expect("structured error");
 
         assert_eq!(structured["error"], "APP_URL_INVALID");
         assert_eq!(structured["launch_state"]["requested"], false);
         assert_eq!(structured["launch_state"]["process_running"], false);
         assert_eq!(structured["launch_state"]["window_ready"], false);
+    }
+
+    #[test]
+    fn unavailable_new_instance_reports_existing_process_and_retry() {
+        let error = anyhow::Error::new(crate::apps::nsworkspace::LaunchError::Cocoa(
+            "The application could not be launched because it was not found.".to_owned(),
+        ))
+        .context("Failed to launch com.example.SingleInstance");
+        let existing_app = crate::apps::AppInfo {
+            name: "Single Instance".to_owned(),
+            pid: 4242,
+            bundle_id: Some("com.example.SingleInstance".to_owned()),
+            running: true,
+            active: false,
+            launch_path: None,
+            kind: Some("desktop".to_owned()),
+            last_used: None,
+        };
+
+        let result = structured_launch_failure(&error, Some(&existing_app));
+        let structured = result.structured_content.expect("structured error");
+
+        assert_eq!(result.is_error, Some(true));
+        assert_eq!(structured["error"], "NEW_APPLICATION_INSTANCE_UNAVAILABLE");
+        assert_eq!(structured["bundle_id"], "com.example.SingleInstance");
+        assert_eq!(structured["pid"], 4242);
+        assert_eq!(structured["creates_new_application_instance"], true);
+        assert_eq!(structured["launch_state"]["requested"], true);
+        assert_eq!(structured["launch_state"]["process_running"], true);
+        assert_eq!(structured["launch_state"]["window_ready"], false);
+        assert!(result.content.iter().any(|content| matches!(
+            content,
+            Content::Text { text, .. }
+                if text.contains("retry without creates_new_application_instance")
+        )));
+    }
+
+    #[test]
+    fn new_instance_cannot_report_success_without_a_process() {
+        let error = validate_launched_pid(-1, true).expect_err("invalid pid must fail");
+        assert!(error
+            .to_string()
+            .contains("invalid process identifier -1 for the requested new application instance"));
+        assert_eq!(validate_launched_pid(4242, true).unwrap(), 4242);
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -321,10 +321,13 @@ use cua_driver_contract::{
     ScrollDirection, ScrollInput, TypeTextInput,
 };
 use cua_driver_core::{
+    launch_state_json,
     protocol::ToolResult,
+    resolve_instance_policy,
     tool::{Tool, ToolDef, ToolRegistry},
     tool_args::{parse_typed_input, parse_typed_projection},
     window_target::{PidOnlyWindowTargetGuard, WindowTargetCandidate, WindowTargetCandidates},
+    InstancePolicy, ProcessDisposition, WindowDisposition,
 };
 use serde_json::{json, Value};
 use std::sync::{Arc, RwLock};
@@ -1865,10 +1868,244 @@ async fn restore_foreground_polling_best_effort(prior_foreground_addr: usize, sp
 
 pub struct LaunchAppTool;
 static LAUNCH_DEF: std::sync::OnceLock<ToolDef> = std::sync::OnceLock::new();
+static LAUNCH_ACQUISITION_LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> =
+    std::sync::OnceLock::new();
 
 fn contains_remote_debugging_flag(value: &str) -> bool {
     let lower = value.to_ascii_lowercase();
     lower.contains("--remote-debugging-port") || lower.contains("--remote-debugging-pipe")
+}
+
+fn launch_policy_error(
+    code: &str,
+    message: impl Into<String>,
+    policy: InstancePolicy,
+) -> ToolResult {
+    ToolResult::error(message.into()).with_structured(json!({
+        "error": code,
+        "instance_policy": policy.as_str(),
+        "platform": "windows",
+        "launch_state": launch_state_json(
+            false,
+            false,
+            false,
+            ProcessDisposition::None,
+            WindowDisposition::None,
+        ),
+    }))
+}
+
+fn launch_request_error(
+    code: &str,
+    message: impl Into<String>,
+    policy: InstancePolicy,
+) -> ToolResult {
+    ToolResult::error(message.into()).with_structured(json!({
+        "error": code,
+        "instance_policy": policy.as_str(),
+        "platform": "windows",
+        "launch_state": launch_state_json(
+            true,
+            false,
+            false,
+            ProcessDisposition::None,
+            WindowDisposition::None,
+        ),
+    }))
+}
+
+fn windows_process_stem(target: &str) -> Option<String> {
+    if target.to_ascii_lowercase().starts_with("shell:") || target.contains('!') {
+        return None;
+    }
+    let (file, _) = split_launchable_target(target);
+    let basename = file
+        .rsplit(|character| character == '\\' || character == '/')
+        .next()?
+        .trim_matches(|character| character == '\'' || character == '"')
+        .trim();
+    let lowercase = basename.to_ascii_lowercase();
+    let stem = lowercase
+        .strip_suffix(".exe")
+        .unwrap_or(&lowercase)
+        .to_owned();
+    (!stem.is_empty()).then_some(stem)
+}
+
+fn process_matches_windows_target(process: &crate::win32::ProcessInfo, target: &str) -> bool {
+    let Some(target_stem) = windows_process_stem(target) else {
+        return false;
+    };
+    let lowercase = process.name.to_ascii_lowercase();
+    let process_stem = lowercase.strip_suffix(".exe").unwrap_or(&lowercase);
+    process_stem == target_stem.as_str()
+}
+
+fn windows_records_json(windows: &[crate::win32::WindowInfo]) -> Vec<Value> {
+    let window_count = windows.len();
+    windows
+        .iter()
+        .enumerate()
+        .map(|(position, window)| {
+            json!({
+                "window_id": window.hwnd,
+                "title": window.title,
+                "bounds": {
+                    "x": window.x,
+                    "y": window.y,
+                    "width": window.width,
+                    "height": window.height,
+                },
+                "layer": 0,
+                "z_index": z_index_from_front_to_back(window_count, position),
+                "is_on_screen": window.is_on_screen,
+            })
+        })
+        .collect()
+}
+
+fn reusable_windows_processes(target: &str) -> Vec<(u32, String, Vec<Value>)> {
+    let processes: Vec<_> = crate::win32::list_processes()
+        .into_iter()
+        .filter(|process| process_matches_windows_target(process, target))
+        .collect();
+    if processes.is_empty() {
+        return Vec::new();
+    }
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+    loop {
+        let candidates: Vec<_> = processes
+            .iter()
+            .map(|process| {
+                let windows = crate::win32::list_windows(Some(process.pid));
+                (
+                    process.pid,
+                    process.name.clone(),
+                    windows_records_json(&windows),
+                )
+            })
+            .collect();
+        if candidates.len() > 1
+            || candidates
+                .first()
+                .is_some_and(|(_, _, windows): &(u32, String, Vec<Value>)| !windows.is_empty())
+            || std::time::Instant::now() >= deadline
+        {
+            return candidates;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
+fn reused_windows_app_result(
+    pid: u32,
+    name: String,
+    windows: Vec<Value>,
+    instance_policy: InstancePolicy,
+) -> ToolResult {
+    let mut summary = format!("✅ Reused {name} (pid {pid}); no launch request was sent.");
+    summary.push_str("\n\nWindows:");
+    for window in &windows {
+        let title = window["title"].as_str().unwrap_or("");
+        let window_id = window["window_id"].as_u64().unwrap_or(0);
+        summary.push_str(&format!("\n- \"{title}\" [window_id: {window_id}]"));
+    }
+    summary.push_str(&format!(
+        "\n→ Call get_window_state(pid: {pid}, window_id) to inspect."
+    ));
+    ToolResult::text(summary).with_structured(json!({
+        "pid": pid,
+        "bundle_id": Value::Null,
+        "name": name,
+        "running": true,
+        "active": false,
+        "windows": windows,
+        "instance_policy": instance_policy.as_str(),
+        "launch_state": launch_state_json(
+            false,
+            true,
+            true,
+            ProcessDisposition::Reused,
+            WindowDisposition::Reused,
+        ),
+    }))
+}
+
+#[cfg(test)]
+mod launch_acquisition_tests {
+    use super::*;
+
+    #[test]
+    fn process_matching_uses_exact_executable_stem() {
+        let process = crate::win32::ProcessInfo {
+            pid: 41,
+            parent_pid: 1,
+            name: "notepad.exe".to_owned(),
+        };
+        assert!(process_matches_windows_target(
+            &process,
+            r#"C:\Windows\System32\notepad.exe"#
+        ));
+        assert!(process_matches_windows_target(&process, "Notepad"));
+        assert!(!process_matches_windows_target(&process, "Notepad++"));
+        assert!(!process_matches_windows_target(
+            &process,
+            "Microsoft.WindowsNotepad_8wekyb3d8bbwe!App"
+        ));
+    }
+
+    #[test]
+    fn launch_schema_exposes_lazy_session_and_instance_policy() {
+        let schema = LaunchAppTool.def().input_schema.clone();
+        assert_eq!(schema["properties"]["session"]["type"], "string");
+        assert_eq!(
+            schema["properties"]["instance_policy"]["default"],
+            "reuse_or_launch"
+        );
+        assert_eq!(
+            schema["properties"]["instance_policy"]["enum"],
+            json!(["reuse_or_launch", "reuse_only", "new"])
+        );
+        assert_eq!(
+            schema["properties"]["creates_new_application_instance"]["deprecated"],
+            true
+        );
+    }
+
+    #[test]
+    fn legacy_new_conflicts_with_explicit_reuse() {
+        let result = resolve_instance_policy(&json!({
+            "instance_policy": "reuse_only",
+            "creates_new_application_instance": true,
+        }));
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn explicit_new_fails_before_sending_a_launch_request() {
+        let result = LaunchAppTool
+            .invoke(json!({"name": "notepad", "instance_policy": "new"}))
+            .await;
+        let structured = result.structured_content.expect("structured error");
+        assert_eq!(result.is_error, Some(true));
+        assert_eq!(structured["error"], "NEW_APPLICATION_INSTANCE_UNAVAILABLE");
+        assert_eq!(structured["launch_state"]["request_sent"], false);
+    }
+
+    #[tokio::test]
+    async fn reuse_only_with_arguments_fails_before_sending_a_request() {
+        let result = LaunchAppTool
+            .invoke(json!({
+                "name": "notepad",
+                "instance_policy": "reuse_only",
+                "additional_arguments": ["example.txt"],
+            }))
+            .await;
+        let structured = result.structured_content.expect("structured error");
+        assert_eq!(result.is_error, Some(true));
+        assert_eq!(structured["error"], "APP_REUSE_UNAVAILABLE");
+        assert_eq!(structured["launch_state"]["request_sent"], false);
+    }
 }
 
 #[async_trait]
@@ -1884,7 +2121,9 @@ impl Tool for LaunchAppTool {
             // route through `IApplicationActivationManager` so packaged
             // (Microsoft Store / UWP / MSIX) apps return the real
             // process pid instead of a stub-redirect pid.
-            description: "Launch a Windows app hidden — the driver never brings the target to \
+            description: "Resolve or launch a Windows app hidden. By default, reuse one exact \
+                running desktop process with a window when its executable identity is available \
+                without ambiguity; otherwise send a launch request. The driver never brings the target to \
                 the foreground, the target's window is launched with SW_SHOWNOACTIVATE so it \
                 does not steal focus from whatever is currently frontmost.\n\n\
                 Provide either `bundle_id` / `name` / `aumid` (resolved as below) or `path` \
@@ -1906,11 +2145,10 @@ impl Tool for LaunchAppTool {
                 `null` for ShellExecuteEx launches.\n\n\
                 Windows-only field: `path` (Swift uses `bundle_id` since macOS apps resolve via \
                 LaunchServices; Windows has no LaunchServices, so `path` is the canonical form). \
-                The macOS-specific `webkit_inspector_port`, \
-                `creates_new_application_instance`, and `additional_arguments` fields are \
-                accepted; `additional_arguments` is honored (forwarded as ShellExecuteEx \
-                parameters or as the AUMID activation arguments string). \
-                The remaining macOS-only fields currently no-op on Windows.".into(),
+                `additional_arguments` is honored (forwarded as ShellExecuteEx parameters or as \
+                the AUMID activation arguments string). Windows shell activation cannot guarantee \
+                a distinct live process for single-instance desktop or packaged apps, so \
+                instance_policy=new fails before sending a request instead of silently degrading.".into(),
             input_schema: json!({"type":"object","properties":{
                 "bundle_id":{"type":"string","description":"App User Model ID (AUMID) for a packaged app — pattern `{PackageFamilyName}!{ApplicationId}`, e.g. `Microsoft.WindowsNotepad_8wekyb3d8bbwe!App`. Falls back to a `name` alias if no `!` is present. Either bundle_id, name, aumid, path, or launch_path must be provided."},
                 "aumid":{"type":"string","description":"Explicit AUMID for a packaged app. Cleaner alternative to overloading `bundle_id`. Takes precedence over `bundle_id` / `name` when present."},
@@ -1920,7 +2158,9 @@ impl Tool for LaunchAppTool {
                 "urls":{"type":"array","items":{"type":"string"},"description":"URLs to open in the default browser via ShellExecuteEx (no activation)."},
                 "additional_arguments":{"type":"array","items":{"type":"string"},"description":"Extra command-line arguments passed to the launched process (or activation arguments for packaged apps)."},
                 "webkit_inspector_port":{"type":"integer","description":"Accepted for cross-platform parity; no-op on Windows."},
-                "creates_new_application_instance":{"type":"boolean","description":"Accepted for parity; no-op on Windows (ShellExecuteEx always creates a new process)."},
+                "session": cua_driver_core::tool_schema::session_schema(),
+                "instance_policy": cua_driver_core::tool_schema::instance_policy_schema(),
+                "creates_new_application_instance":{"type":"boolean","deprecated":true,"description":"Deprecated compatibility alias. true maps to instance_policy=new; false maps to reuse_or_launch. Windows cannot guarantee a distinct live process and returns NEW_APPLICATION_INSTANCE_UNAVAILABLE before sending a request."},
                 "start_minimized":{"type":"boolean","description":"When true, launch the app's window minimized to the taskbar instead of restored-but-not-activated. Use this when the agent wants to drive the app entirely in the background — the user's previously-frontmost window (e.g. terminal) stays visually on top. Desktop launches hold the foreground lock through startup and use SW_SHOWMINNOACTIVE; packaged-app activation remains broker-controlled and receives a best-effort SW_SHOWMINNOACTIVE post-pass. UIA / background dispatch still work on a minimized window; only `screenshot` and `delivery_mode:\"foreground\"` need it restored."}
             },"additionalProperties":false}),
             read_only: false, destructive: false, idempotent: true, open_world: true,
@@ -1951,6 +2191,10 @@ impl Tool for LaunchAppTool {
                     .collect()
             })
             .unwrap_or_default();
+        let instance_policy = match resolve_instance_policy(&args) {
+            Ok(policy) => policy,
+            Err(error) => return error,
+        };
         let start_minimized = args
             .get("start_minimized")
             .and_then(|v| v.as_bool())
@@ -1968,25 +2212,6 @@ impl Tool for LaunchAppTool {
         } else {
             windows::Win32::UI::WindowsAndMessaging::SW_SHOWNOACTIVATE.0
         };
-        // Snapshot the set of currently-running pids BEFORE we launch. The
-        // detached start_minimized polling task uses this to detect "any
-        // process that came into existence as a result of our launch", so
-        // it can minimize their windows too — covers the launcher-stub
-        // case (LibreOffice swriter.exe → soffice.bin, GIMP gimp-3.exe →
-        // gimp-3.2.exe, etc.) where the launched pid exits and a child
-        // process with a different name owns the actual window. Captured
-        // here (before the launch) so the new soffice.bin pid won't be
-        // in the snapshot.
-        let pre_launch_pids: std::sync::Arc<std::collections::HashSet<u32>> = if start_minimized {
-            let pids: std::collections::HashSet<u32> = crate::win32::list_processes()
-                .into_iter()
-                .map(|p| p.pid)
-                .collect();
-            std::sync::Arc::new(pids)
-        } else {
-            std::sync::Arc::new(std::collections::HashSet::new())
-        };
-
         // Capture the foreground window BEFORE any launch path runs so the
         // post-spawn polling restore (below) has a target HWND to flip back
         // to. Mirrors the macOS `FocusRestoreGuard` behavior. Best-effort —
@@ -2025,6 +2250,7 @@ impl Tool for LaunchAppTool {
                     .collect()
             })
             .unwrap_or_default();
+        let caller_has_additional_arguments = !extra_args.is_empty();
         if args.get("cdp_debugging_port").is_some() {
             return ToolResult::error(
                 "cdp_debugging_port moved to browser_prepare so DevTools is never enabled on an unproven user profile",
@@ -2086,6 +2312,100 @@ impl Tool for LaunchAppTool {
             );
         }
 
+        // Serialize the resolve/reuse-or-launch decision through request
+        // dispatch. Otherwise two concurrent calls can both observe no
+        // reusable window and launch before either new window is enumerable.
+        let acquisition_guard = LAUNCH_ACQUISITION_LOCK
+            .get_or_init(|| tokio::sync::Mutex::new(()))
+            .lock()
+            .await;
+        if instance_policy == InstancePolicy::New {
+            return launch_policy_error(
+                "NEW_APPLICATION_INSTANCE_UNAVAILABLE",
+                "Windows shell and packaged-app activation may route to an existing single-instance process, so Cua Driver cannot guarantee instance_policy=\"new\". No launch request was sent.",
+                instance_policy,
+            );
+        }
+
+        let carries_launch_modifiers = !urls.is_empty()
+            || caller_has_additional_arguments
+            || start_minimized
+            || args.get("webkit_inspector_port").is_some();
+        if instance_policy == InstancePolicy::ReuseOnly && carries_launch_modifiers {
+            return launch_policy_error(
+                "APP_REUSE_UNAVAILABLE",
+                "instance_policy=\"reuse_only\" cannot deliver URLs, launch arguments, inspector settings, or start_minimized without a launch request. No launch request was sent.",
+                instance_policy,
+            );
+        }
+
+        // Snapshot only after acquiring the mutex and validating fail-closed
+        // policies: a prior serialized call may have launched while this call
+        // was waiting. These identities anchor both the process/window
+        // disposition and the minimized launcher-family guard below.
+        let pre_launch_pids: std::sync::Arc<std::collections::HashSet<u32>> = std::sync::Arc::new(
+            crate::win32::list_processes()
+                .into_iter()
+                .map(|process| process.pid)
+                .collect(),
+        );
+        let pre_launch_hwnds: std::collections::HashSet<u64> = crate::win32::list_windows(None)
+            .into_iter()
+            .map(|window| window.hwnd)
+            .collect();
+
+        if !carries_launch_modifiers {
+            if let Some(reuse_target) = target.clone() {
+                let candidates =
+                    tokio::task::spawn_blocking(move || reusable_windows_processes(&reuse_target))
+                        .await
+                        .unwrap_or_default();
+                match candidates.as_slice() {
+                    [(pid, name, windows)] if !windows.is_empty() => {
+                        return reused_windows_app_result(
+                            *pid,
+                            name.clone(),
+                            windows.clone(),
+                            instance_policy,
+                        )
+                    }
+                    [] | [(_, _, _)] => {}
+                    _ => {
+                        let candidate_payload: Vec<Value> = candidates
+                            .iter()
+                            .map(|(pid, name, windows)| {
+                                json!({"pid": pid, "name": name, "windows": windows})
+                            })
+                            .collect();
+                        return ToolResult::error(
+                            "More than one exact running Windows process matches the requested app; choose a candidate pid/window_id instead of launching another instance.",
+                        )
+                        .with_structured(json!({
+                            "error": "APP_TARGET_AMBIGUOUS",
+                            "instance_policy": instance_policy.as_str(),
+                            "platform": "windows",
+                            "candidates": candidate_payload,
+                            "launch_state": launch_state_json(
+                                false,
+                                true,
+                                false,
+                                ProcessDisposition::None,
+                                WindowDisposition::None,
+                            ),
+                        }));
+                    }
+                }
+            }
+        }
+
+        if instance_policy == InstancePolicy::ReuseOnly {
+            return launch_policy_error(
+                "APP_REUSE_UNAVAILABLE",
+                "No exact running Windows desktop process with a reusable window matched the requested app. AUMID targets cannot be correlated to a process without activating the package. No launch request was sent.",
+                instance_policy,
+            );
+        }
+
         // ── Packaged-app (UWP / MSIX) routing decision ──────────────────────
         //
         // Routing precedence — most explicit signal wins:
@@ -2137,19 +2457,25 @@ impl Tool for LaunchAppTool {
                     None
                 }
                 Err(crate::launch_uwp::AppsFolderLookupError::Timeout) => {
-                    return ToolResult::error(format!(
-                        "App name lookup for {n:?} is temporarily unavailable: Windows did not respond to the shell:AppsFolder query within 4s. No app was launched; retry after the shell recovers, or pass an explicit path or aumid."
-                    ))
+                    return launch_policy_error(
+                        "APP_TARGET_RESOLUTION_UNAVAILABLE",
+                        format!("App name lookup for {n:?} is temporarily unavailable: Windows did not respond to the shell:AppsFolder query within 4s. No app was launched; retry after the shell recovers, or pass an explicit path or aumid."),
+                        instance_policy,
+                    )
                 }
                 Err(crate::launch_uwp::AppsFolderLookupError::Busy) => {
-                    return ToolResult::error(format!(
-                        "App name lookup for {n:?} is temporarily unavailable because a prior Windows shell lookup is still running or cooling down. No app was launched; retry later, or pass an explicit path or aumid."
-                    ))
+                    return launch_policy_error(
+                        "APP_TARGET_RESOLUTION_UNAVAILABLE",
+                        format!("App name lookup for {n:?} is temporarily unavailable because a prior Windows shell lookup is still running or cooling down. No app was launched; retry later, or pass an explicit path or aumid."),
+                        instance_policy,
+                    )
                 }
                 Err(crate::launch_uwp::AppsFolderLookupError::Unavailable) => {
-                    return ToolResult::error(format!(
-                        "App name lookup for {n:?} is unavailable because the Windows shell lookup worker failed. No app was launched; pass an explicit path or aumid."
-                    ))
+                    return launch_policy_error(
+                        "APP_TARGET_RESOLUTION_UNAVAILABLE",
+                        format!("App name lookup for {n:?} is unavailable because the Windows shell lookup worker failed. No app was launched; pass an explicit path or aumid."),
+                        instance_policy,
+                    )
                 }
             }
         } else {
@@ -2214,8 +2540,18 @@ impl Tool for LaunchAppTool {
             )
             .with_structured(json!({
                 "code": "background_unavailable",
+                "error": "BACKGROUND_LAUNCH_UNAVAILABLE",
                 "delivery_mode": "background",
                 "event_kind": "app_launch",
+                "instance_policy": instance_policy.as_str(),
+                "platform": "windows",
+                "launch_state": launch_state_json(
+                    false,
+                    false,
+                    false,
+                    ProcessDisposition::None,
+                    WindowDisposition::None,
+                ),
             }));
         }
 
@@ -2233,11 +2569,19 @@ impl Tool for LaunchAppTool {
             match activation {
                 Ok(Ok(p)) => p,
                 Ok(Err(e)) => {
-                    return ToolResult::error(format!(
-                        "Failed to activate packaged app {aumid:?}: {e}"
-                    ))
+                    return launch_request_error(
+                        "APP_LAUNCH_FAILED",
+                        format!("Failed to activate packaged app {aumid:?}: {e}"),
+                        instance_policy,
+                    )
                 }
-                Err(e) => return ToolResult::error(format!("Task error: {e}")),
+                Err(e) => {
+                    return launch_request_error(
+                        "APP_LAUNCH_TASK_FAILED",
+                        format!("Packaged-app launch task failed: {e}"),
+                        instance_policy,
+                    )
+                }
             }
         } else {
             // Legacy ShellExecuteExW path — unchanged behavior for plain
@@ -2382,25 +2726,53 @@ impl Tool for LaunchAppTool {
             match result {
                 Ok(Ok(Ok(p))) => p,
                 Ok(Ok(Err(e))) if name_lookup_missed => {
-                    return ToolResult::error(format!(
-                        "App {:?} was not found in shell:AppsFolder or by Windows PATH/association lookup: {e}",
-                        name_opt.as_deref().unwrap_or("")
-                    ))
+                    return launch_request_error(
+                        "APP_LAUNCH_FAILED",
+                        format!(
+                            "App {:?} was not found in shell:AppsFolder or by Windows PATH/association lookup: {e}",
+                            name_opt.as_deref().unwrap_or("")
+                        ),
+                        instance_policy,
+                    )
                 }
-                Ok(Ok(Err(e))) => return ToolResult::error(format!("Failed to launch: {e}")),
-                Ok(Err(e)) => return ToolResult::error(format!("Task error: {e}")),
+                Ok(Ok(Err(e))) => {
+                    return launch_request_error(
+                        "APP_LAUNCH_FAILED",
+                        format!("Failed to launch: {e}"),
+                        instance_policy,
+                    )
+                }
+                Ok(Err(e)) => {
+                    return launch_request_error(
+                        "APP_LAUNCH_TASK_FAILED",
+                        format!("Launch task failed: {e}"),
+                        instance_policy,
+                    )
+                }
                 Err(_elapsed) => {
-                    return ToolResult::error(format!(
-                        "Launch of {:?} timed out after 15s — the target likely has no \
+                    return launch_request_error(
+                        "APP_LAUNCH_TIMEOUT",
+                        format!(
+                            "Launch of {:?} timed out after 15s — the target likely has no \
                      registered handler and a blocking shell dialog appeared on the \
                      session desktop; aborted to keep the daemon responsive.",
-                        target_file_opt
-                            .as_deref()
-                            .or_else(|| urls.first().map(|s| s.as_str()))
-                            .unwrap_or("")
-                    ))
+                            target_file_opt
+                                .as_deref()
+                                .or_else(|| urls.first().map(|s| s.as_str()))
+                                .unwrap_or("")
+                        ),
+                        instance_policy,
+                    )
                 }
             }
+        };
+        drop(acquisition_guard);
+        let process_disposition = if pid == 0 {
+            ProcessDisposition::None
+        } else if pre_launch_pids.contains(&pid) {
+            ProcessDisposition::Reused
+        } else {
+            ProcessDisposition::Created
         };
 
         // Best-effort foreground-restore for the legacy ShellExecuteExW
@@ -2768,7 +3140,17 @@ impl Tool for LaunchAppTool {
         }
 
         // Match Swift text format 1:1.
-        let mut summary = format!("✅ Launched {display} (pid {pid}) in background.");
+        let mut summary = match process_disposition {
+            ProcessDisposition::Created => {
+                format!("✅ Launched {display} (pid {pid}) in background.")
+            }
+            ProcessDisposition::Reused => format!(
+                "✅ Sent a Windows launch request for {display} and reused process {pid} in background."
+            ),
+            ProcessDisposition::None => {
+                format!("✅ Sent a Windows launch request for {display}.")
+            }
+        };
         if !windows_json.is_empty() {
             summary.push_str("\n\nWindows:");
             for w in &windows_json {
@@ -2793,13 +3175,44 @@ impl Tool for LaunchAppTool {
             Some(a) => serde_json::Value::String(a.clone()),
             None => serde_json::Value::Null,
         };
+        let window_ready = !windows_json.is_empty();
+        let process_running = if pid == 0 {
+            false
+        } else {
+            tokio::task::spawn_blocking(move || {
+                crate::win32::list_processes()
+                    .into_iter()
+                    .any(|process| process.pid == pid)
+            })
+            .await
+            .unwrap_or(false)
+        };
+        let window_disposition = if !window_ready {
+            WindowDisposition::None
+        } else if windows_json.iter().any(|window| {
+            window["window_id"]
+                .as_u64()
+                .is_some_and(|hwnd| !pre_launch_hwnds.contains(&hwnd))
+        }) {
+            WindowDisposition::Materialized
+        } else {
+            WindowDisposition::Reused
+        };
         let structured = json!({
             "pid":       pid,
             "bundle_id": bundle_id_response,
             "name":      display,
-            "running":   true,
+            "running":   process_running,
             "active":    false,  // SW_SHOWNOACTIVATE — Swift's background-launch invariant
             "windows":   windows_json,
+            "instance_policy": instance_policy.as_str(),
+            "launch_state": launch_state_json(
+                true,
+                process_running,
+                window_ready,
+                process_disposition,
+                window_disposition,
+            ),
         });
         ToolResult::text(summary).with_structured(structured)
     }

--- a/libs/cua-driver/typescript/src/native/cua_driver_contract.ts
+++ b/libs/cua-driver/typescript/src/native/cua_driver_contract.ts
@@ -712,7 +712,10 @@ export type ClickInput = {
     scope?: DesktopScope,
     /**
      * For multi-call work, prefer a short public session label and repeat it on every call that
-     * accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+     * accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+     * not call start_session merely to begin. Use start_session only to configure the initial
+     * session state or revive an ended label. Omit session to use the authenticated transport's
+     * implicit lifecycle session.
      */
     session?: string,
     button?: ClickButton,
@@ -780,7 +783,10 @@ export type ClipboardReadInput = {
     includeText: boolean,
     /**
      * For multi-call work, prefer a short public session label and repeat it on every call that
-     * accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+     * accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+     * not call start_session merely to begin. Use start_session only to configure the initial
+     * session state or revive an ended label. Omit session to use the authenticated transport's
+     * implicit lifecycle session.
      */
     session?: string
 }
@@ -893,7 +899,10 @@ export type ClipboardWriteInput = {
     filePath?: string,
     /**
      * For multi-call work, prefer a short public session label and repeat it on every call that
-     * accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+     * accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+     * not call start_session merely to begin. Use start_session only to configure the initial
+     * session state or revive an ended label. Omit session to use the authenticated transport's
+     * implicit lifecycle session.
      */
     session?: string
 }
@@ -1371,7 +1380,10 @@ export type DragInput = {
     scope?: DesktopScope,
     /**
      * For multi-call work, prefer a short public session label and repeat it on every call that
-     * accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+     * accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+     * not call start_session merely to begin. Use start_session only to configure the initial
+     * session state or revive an ended label. Omit session to use the authenticated transport's
+     * implicit lifecycle session.
      */
     session?: string,
     durationMs?: bigint,
@@ -1828,7 +1840,10 @@ const FfiConverterTypeGetAgentCursorStateOutput = (() => {
 export type GetCursorPositionInput = {
     /**
      * For multi-call work, prefer a short public session label and repeat it on every call that
-     * accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+     * accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+     * not call start_session merely to begin. Use start_session only to configure the initial
+     * session state or revive an ended label. Omit session to use the authenticated transport's
+     * implicit lifecycle session.
      */
     session?: string
 }
@@ -1871,7 +1886,10 @@ const FfiConverterTypeGetCursorPositionInput = (() => {
 export type GetDesktopStateInput = {
     /**
      * For multi-call work, prefer a short public session label and repeat it on every call that
-     * accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+     * accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+     * not call start_session merely to begin. Use start_session only to configure the initial
+     * session state or revive an ended label. Omit session to use the authenticated transport's
+     * implicit lifecycle session.
      */
     session?: string,
     /**
@@ -1921,7 +1939,10 @@ const FfiConverterTypeGetDesktopStateInput = (() => {
 export type GetScreenSizeInput = {
     /**
      * For multi-call work, prefer a short public session label and repeat it on every call that
-     * accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+     * accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+     * not call start_session merely to begin. Use start_session only to configure the initial
+     * session state or revive an ended label. Omit session to use the authenticated transport's
+     * implicit lifecycle session.
      */
     session?: string
 }
@@ -2056,7 +2077,10 @@ export type HotkeyInput = {
     scope?: DesktopScope,
     /**
      * For multi-call work, prefer a short public session label and repeat it on every call that
-     * accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+     * accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+     * not call start_session merely to begin. Use start_session only to configure the initial
+     * session state or revive an ended label. Omit session to use the authenticated transport's
+     * implicit lifecycle session.
      */
     session?: string
 }
@@ -2116,7 +2140,10 @@ export type InvokeMenuInput = {
     path: Array<string>,
     /**
      * For multi-call work, prefer a short public session label and repeat it on every call that
-     * accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+     * accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+     * not call start_session merely to begin. Use start_session only to configure the initial
+     * session state or revive an ended label. Omit session to use the authenticated transport's
+     * implicit lifecycle session.
      */
     session?: string
 }
@@ -2450,7 +2477,10 @@ export type MoveCursorInput = {
     scope?: DesktopScope,
     /**
      * For multi-call work, prefer a short public session label and repeat it on every call that
-     * accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+     * accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+     * not call start_session merely to begin. Use start_session only to configure the initial
+     * session state or revive an ended label. Omit session to use the authenticated transport's
+     * implicit lifecycle session.
      */
     session?: string
 }
@@ -2641,7 +2671,10 @@ export type PressKeyInput = {
     scope?: DesktopScope,
     /**
      * For multi-call work, prefer a short public session label and repeat it on every call that
-     * accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+     * accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+     * not call start_session merely to begin. Use start_session only to configure the initial
+     * session state or revive an ended label. Omit session to use the authenticated transport's
+     * implicit lifecycle session.
      */
     session?: string,
     modifiers?: Array<string>
@@ -2769,7 +2802,10 @@ export type ScrollInput = {
     scope?: DesktopScope,
     /**
      * For multi-call work, prefer a short public session label and repeat it on every call that
-     * accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+     * accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+     * not call start_session merely to begin. Use start_session only to configure the initial
+     * session state or revive an ended label. Omit session to use the authenticated transport's
+     * implicit lifecycle session.
      */
     session?: string,
     by?: ScrollBy,
@@ -3258,7 +3294,10 @@ export type SetWindowFrameInput = {
     height: number,
     /**
      * For multi-call work, prefer a short public session label and repeat it on every call that
-     * accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+     * accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+     * not call start_session merely to begin. Use start_session only to configure the initial
+     * session state or revive an ended label. Omit session to use the authenticated transport's
+     * implicit lifecycle session.
      */
     session?: string
 }
@@ -3521,7 +3560,10 @@ export type TypeTextInput = {
     scope?: DesktopScope,
     /**
      * For multi-call work, prefer a short public session label and repeat it on every call that
-     * accepts it. Omit it to use the authenticated transport's implicit lifecycle session.
+     * accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+     * not call start_session merely to begin. Use start_session only to configure the initial
+     * session state or revive an ended label. Omit session to use the authenticated transport's
+     * implicit lifecycle session.
      */
     session?: string
 }
@@ -3585,8 +3627,10 @@ export type VerifyStateInput = {
     expect: Array<StatePredicate>,
     /**
      * For multi-call work, prefer a short public session label and repeat it on every call that
-     * accepts it. Omit it to use the authenticated transport's implicit lifecycle session. This
-     * field never selects capture modality or authorization.
+     * accepts it. The first ordinary call carrying a fresh label creates that session lazily; do
+     * not call start_session merely to begin. Use start_session only to configure the initial
+     * session state or revive an ended label. Omit session to use the authenticated transport's
+     * implicit lifecycle session. This field never selects capture modality or authorization.
      */
     session?: string,
     /**
@@ -3709,6 +3753,46 @@ const FfiConverterTypeVerifyStateOutput = (() => {
 
         }
     };
+    return new FFIConverter();
+})();
+
+/**
+ * How `launch_app` acquires an application process/window.
+ *
+ * The portable default reuses an exact existing candidate before asking the
+ * operating system to launch anything. Callers that require a stronger
+ * guarantee must opt into `reuse_only` or `new` explicitly; a platform that
+ * cannot honor `new` reports that limitation instead of silently degrading.
+ */
+export enum InstancePolicy {
+    ReuseOrLaunch,
+    ReuseOnly,
+    New
+}
+
+const FfiConverterTypeInstancePolicy = (() => {
+    const ordinalConverter = FfiConverterInt32;
+    type TypeName = InstancePolicy;
+    class FFIConverter extends AbstractFfiConverterByteArray<TypeName> {
+        read(from: RustBuffer): TypeName {
+            switch (ordinalConverter.read(from)) {
+                case 1: return InstancePolicy.ReuseOrLaunch;
+                case 2: return InstancePolicy.ReuseOnly;
+                case 3: return InstancePolicy.New;
+                default: throw new UniffiInternalError.UnexpectedEnumCase();
+            }
+        }
+        write(value: TypeName, into: RustBuffer): void {
+            switch (value) {
+                case InstancePolicy.ReuseOrLaunch: return ordinalConverter.write(1, into);
+                case InstancePolicy.ReuseOnly: return ordinalConverter.write(2, into);
+                case InstancePolicy.New: return ordinalConverter.write(3, into);
+            }
+        }
+        allocationSize(value: TypeName): number {
+            return ordinalConverter.allocationSize(0);
+        }
+    }
     return new FFIConverter();
 })();
 
@@ -3890,6 +3974,7 @@ export default Object.freeze({
     FfiConverterTypeGetSessionInput,
     FfiConverterTypeGetSessionStateInput,
     FfiConverterTypeHotkeyInput,
+    FfiConverterTypeInstancePolicy,
     FfiConverterTypeInvokeMenuInput,
     FfiConverterTypeListSessionsInput,
     FfiConverterTypeListSessionsOutput,


### PR DESCRIPTION
## Summary

This draft expands the existing isolated-launch refusal fix into one cross-platform app-acquisition and lifecycle correction:

- preserve typed **NEW_APPLICATION_INSTANCE_UNAVAILABLE** reporting for macOS isolated-launch failures
- let **launch_app** carry the public session label so the first ordinary call lazily creates the named session
- make default acquisition atomically reuse one exact existing process/window before requesting a launch
- add **instance_policy: reuse_or_launch | reuse_only | new** and canonical reuse-versus-launch disposition
- replace silent unsupported/no-op instance behavior with truthful structured results
- align MCP initialization instructions, generated contracts, reference docs, and bundled Cua Driver skills

## Behavior

**reuse_or_launch** is the default on macOS, Windows, and Linux. **reuse_only** never sends a launch request. **new** requires a distinct process: macOS verifies that the returned PID is new, while Windows and Linux fail closed because their shell/desktop activation paths cannot guarantee a distinct live app instance.

Successful results retain **requested**, **process_running**, and **window_ready**, and add:

- **request_sent**
- **process_disposition: reused | created | none**
- **window_disposition: reused | materialized | none**

The deprecated **creates_new_application_instance: true** spelling maps to **instance_policy: new**.

## Root causes fixed

The lifecycle runtime already created sessions on first ordinary dispatch, but the MCP and skill prose still presented **start_session** as a normal step zero. **launch_app** was session-managed internally while all three public schemas rejected **session**.

App launch semantics also drifted by platform: macOS always sent an open request, Windows accepted the new-instance field as a no-op, Linux advertised non-idempotent launch behavior, and responses did not identify reuse versus creation.

## Scope and progress

- [x] retain the original macOS unavailable-isolated-instance refusal
- [x] add shared lazy-session launch schema and guidance
- [x] add shared instance policy, strict compatibility parsing, and typed launch-state disposition
- [x] implement atomic reuse-first acquisition on macOS
- [x] implement exact executable/process reuse on Windows and Linux when identity is provable
- [x] fail closed for reuse-only misses, ambiguity, and unsupported distinct-instance guarantees
- [x] update MCP initialization instructions, generated contract, reference docs, and bundled skills
- [x] add focused core, schema, platform, and skill tests

## Validation

- **cargo fmt --all -- --check**
- **cargo test -q -p cua-driver-contract** — 32 unit + 1 generator test passed
- **cargo run -q -p cua-driver-contract --bin cua-contract-gen -- all --check**
- **cargo test -q -p cua-driver-core** — 542 unit + 5 integration passed; 1 unrelated test ignored
- **cargo test -q -p platform-macos --lib** — 345 passed
- **cargo test -q -p cua-driver --test schema_consistency_test** — 4 passed
- **cargo check -p platform-linux -p platform-windows** — host adapter checks passed
- **ZSTD_SYS_USE_PKG_CONFIG=1 PKG_CONFIG_ALLOW_CROSS=1 cargo +stable check -p platform-windows --tests --target x86_64-pc-windows-msvc** — real Windows implementation and tests compiled
- **git diff --check**
- **documentation generator --check** — generated reference docs are current
- **UniFFI bindings generator --check** — Python and TypeScript bindings are current

The native Linux cross-target check is blocked on this Mac before platform compilation because the host lacks **xtst.pc**; canonical Linux CI remains required. Windows packaged-app identity cannot be correlated to a running PID without activation, and Linux reuse depends on compositor/window PID metadata, so those cases fail closed under **reuse_only**.

The exact candidate SHA is **628cc196210278c028b3795afdbe59cc78afcb7c**. Canonical Linux run [31889546023](https://github.com/trycua/cua/actions/runs/31889546023) and Windows run [31889545981](https://github.com/trycua/cua/actions/runs/31889545981) are in progress. The PR remains draft: macOS certification still requires the versioned, TCC-authorized private Lume seed, which is not present on the current host.

Closes #3183
