### PR TITLE
chore(cua-fleet): prepare 0.0.7 release

### DIFF
--- a/.github/scripts/repackage_cua_train_wheel.py
+++ b/.github/scripts/repackage_cua_train_wheel.py
@@ -185,9 +185,9 @@ def verify(path: Path, source: Path | None = None) -> None:
         raise WheelError("destination WHEEL metadata does not match the wheel filename")
     if not any(name.startswith("cua_train/") for name in entries):
         raise WheelError("destination wheel is missing cua_train")
-    if not any(name.startswith("cyclops_sdk/") for name in entries):
-        raise WheelError("destination wheel is missing cyclops_sdk")
-    if not any(name.startswith("cyclops_sdk/libcyclops_sdk.") for name in entries):
+    if not any(name.startswith("fleet_sdk/") for name in entries):
+        raise WheelError("destination wheel is missing fleet_sdk")
+    if not any(name.startswith("fleet_sdk/libcyclops_sdk.") for name in entries):
         raise WheelError("destination wheel is missing the native cyclops library")
 
     record_rows = list(csv.reader(entries[record_name].decode().splitlines()))

--- a/.github/scripts/repackage_cua_train_wheel.py
+++ b/.github/scripts/repackage_cua_train_wheel.py
@@ -14,7 +14,7 @@ import sys
 import zipfile
 
 SOURCE_NAME = "cua-train"
-SOURCE_VERSION = "0.1.2"
+SOURCE_VERSION = "0.1.3"
 DESTINATION_NAME = "cua-fleet"
 WHEEL_FILENAME = re.compile(
     r"^(?P<distribution>[A-Za-z0-9_]+)-(?P<version>[^-]+)-py3-none-(?P<platform>[^-]+)\.whl$"
@@ -119,7 +119,7 @@ def repack(
 
     metadata = parse_metadata(entries[metadata_name])
     if metadata.get("Name") != SOURCE_NAME or metadata.get("Version") != SOURCE_VERSION:
-        raise WheelError("source METADATA does not identify cua-train==0.1.2")
+        raise WheelError("source METADATA does not identify cua-train==0.1.3")
     wheel_metadata = entries[wheel_name].decode()
     if (
         "Root-Is-Purelib: false" not in wheel_metadata

--- a/.github/scripts/tests/test_repackage_cua_train_wheel.py
+++ b/.github/scripts/tests/test_repackage_cua_train_wheel.py
@@ -26,12 +26,12 @@ def _csv(rows: list[list[str]]) -> bytes:
 
 
 def _write_source_wheel(path: Path) -> dict[str, bytes]:
-    dist_info = "cua_train-0.1.2.dist-info"
+    dist_info = "cua_train-0.1.3.dist-info"
     entries = {
         "cua_train/__init__.py": b"TrainClient = object\n",
-        "cyclops_sdk/__init__.py": b"CyclopsClient = object\n",
-        "cyclops_sdk/libcyclops_sdk.so": b"native payload",
-        f"{dist_info}/METADATA": b"Metadata-Version: 2.4\nName: cua-train\nVersion: 0.1.2\nDescription-Content-Type: text/markdown\n\n",
+        "fleet_sdk/__init__.py": b"CyclopsClient = object\n",
+        "fleet_sdk/libcyclops_sdk.so": b"native payload",
+        f"{dist_info}/METADATA": b"Metadata-Version: 2.4\nName: cua-train\nVersion: 0.1.3\nDescription-Content-Type: text/markdown\n\n",
         f"{dist_info}/WHEEL": b"Wheel-Version: 1.0\nRoot-Is-Purelib: false\nTag: py3-none-manylinux_2_34_x86_64\n",
     }
     record_name = f"{dist_info}/RECORD"
@@ -45,7 +45,7 @@ def _write_source_wheel(path: Path) -> dict[str, bytes]:
 
 
 def test_repack_changes_only_distribution_metadata(tmp_path: Path):
-    source = tmp_path / "cua_train-0.1.2-py3-none-manylinux_2_34_x86_64.whl"
+    source = tmp_path / "cua_train-0.1.3-py3-none-manylinux_2_34_x86_64.whl"
     source_entries = _write_source_wheel(source)
 
     destination = repack(
@@ -57,8 +57,8 @@ def test_repack_changes_only_distribution_metadata(tmp_path: Path):
     with zipfile.ZipFile(destination) as archive:
         assert archive.read("cua_train/__init__.py") == source_entries["cua_train/__init__.py"]
         assert (
-            archive.read("cyclops_sdk/libcyclops_sdk.so")
-            == source_entries["cyclops_sdk/libcyclops_sdk.so"]
+            archive.read("fleet_sdk/libcyclops_sdk.so")
+            == source_entries["fleet_sdk/libcyclops_sdk.so"]
         )
         metadata = archive.read("cua_fleet-0.0.5.dist-info/METADATA").decode()
         assert "Name: cua-fleet" in metadata
@@ -67,7 +67,7 @@ def test_repack_changes_only_distribution_metadata(tmp_path: Path):
 
 
 def test_repack_rejects_unpinned_source(tmp_path: Path):
-    source = tmp_path / "cua_train-0.1.2-py3-none-manylinux_2_34_x86_64.whl"
+    source = tmp_path / "cua_train-0.1.3-py3-none-manylinux_2_34_x86_64.whl"
     _write_source_wheel(source)
 
     with pytest.raises(WheelError, match="SHA-256 mismatch"):

--- a/.github/workflows/cd-py-fleet.yml
+++ b/.github/workflows/cd-py-fleet.yml
@@ -86,26 +86,26 @@ jobs:
         include:
           - platform: linux-x86_64
             runner: ubuntu-22.04
-            wheel: cua_train-0.1.2-py3-none-manylinux_2_34_x86_64.whl
-            sha256: e1b22a88711f64d333d7d3cc52e15b39a7e6eec7fac2ac44b5aba3c59142dd5b
+            wheel: cua_train-0.1.3-py3-none-manylinux_2_34_x86_64.whl
+            sha256: 7e12c5c5e413cf927bafd443af572c74c8ce41fed889c9712e656c31b77c9a9a
             library_suffix: .so
             audit: auditwheel
           - platform: linux-aarch64
             runner: ubuntu-24.04-arm
-            wheel: cua_train-0.1.2-py3-none-manylinux_2_34_aarch64.whl
-            sha256: 05a0d248fc977ffdb6e07c4e8a897ca361c721814c82a4b76cbfbd38180eb323
+            wheel: cua_train-0.1.3-py3-none-manylinux_2_34_aarch64.whl
+            sha256: 360cba8ba294151a105009fde751be7fc231d69449905013333a05dbb4284cc2
             library_suffix: .so
             audit: auditwheel
           - platform: macos-x86_64
             runner: macos-15-intel
-            wheel: cua_train-0.1.2-py3-none-macosx_10_12_x86_64.whl
-            sha256: cdabd2dd18c76f6fd4b04dcc63366d7cf4c8bed0fab36fe13751d3bef5161f18
+            wheel: cua_train-0.1.3-py3-none-macosx_10_12_x86_64.whl
+            sha256: e173c7d8cadae2bd5df36216d9587d67d4f6cfa064b97afce153c9ac7435b745
             library_suffix: .dylib
             audit: delocate
           - platform: macos-arm64
             runner: macos-14
-            wheel: cua_train-0.1.2-py3-none-macosx_11_0_arm64.whl
-            sha256: 14bf1db6aec6f23313e7953b79e95f9b233e2526aeafe7fd3b6a90f7d6b844b4
+            wheel: cua_train-0.1.3-py3-none-macosx_11_0_arm64.whl
+            sha256: a04b30f94d27cd29538ca366f5926b5127b73e003fc8bf2bba7e53d69d5e8af0
             library_suffix: .dylib
             audit: delocate
     steps:
@@ -163,24 +163,38 @@ jobs:
           from pathlib import Path
           import sys
 
-          import cyclops_sdk
-          from cyclops_sdk import (
+          import fleet_sdk
+          from fleet_sdk import (
               CreateClaimRequest,
               CreatePoolRequest,
               CyclopsClient,
+              CyclopsConfiguration,
+              CyclopsCredentials,
+              Firmware,
+              HttpHeader,
+              HttpRequest,
               PoolSpec,
+              PoolTemplate,
+              RuntimeKind,
               SandboxService,
           )
 
-          package = Path(cyclops_sdk.__file__).resolve().parent
+          package = Path(fleet_sdk.__file__).resolve().parent
           native = package / f"libcyclops_sdk{sys.argv[1]}"
           assert native.is_file(), native
           ctypes.CDLL(str(native))
           assert all((
-              CyclopsClient,
-              CreatePoolRequest,
               CreateClaimRequest,
+              CreatePoolRequest,
+              CyclopsClient,
+              CyclopsConfiguration,
+              CyclopsCredentials,
+              Firmware,
+              HttpHeader,
+              HttpRequest,
               PoolSpec,
+              PoolTemplate,
+              RuntimeKind,
               SandboxService,
           ))
           PY

--- a/libs/python/cua-fleet/.bumpversion.cfg
+++ b/libs/python/cua-fleet/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.4
+current_version = 0.0.7
 commit = True
 tag = True
 tag_name = fleet-v{new_version}

--- a/libs/python/cua-fleet/cua_fleet/__init__.py
+++ b/libs/python/cua-fleet/cua_fleet/__init__.py
@@ -4,4 +4,4 @@ from cua_train import TrainClient
 
 __all__ = ["TrainClient"]
 
-__version__ = "0.0.4"
+__version__ = "0.0.7"

--- a/libs/python/cua-fleet/pyproject.toml
+++ b/libs/python/cua-fleet/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cua-fleet"
-version = "0.0.6"
+version = "0.0.7"
 description = "Cua Fleet facade for the Cua Cloud Python SDK"
 readme = "README.md"
 license = "MIT"
@@ -25,7 +25,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 
-dependencies = ["cua-train==0.1.2"]
+dependencies = ["cua-train==0.1.3"]
 
 [project.urls]
 Homepage      = "https://github.com/trycua/cua"

--- a/libs/python/cua-fleet/tests/test_train_facade.py
+++ b/libs/python/cua-fleet/tests/test_train_facade.py
@@ -13,9 +13,9 @@ TRAIN_SOURCE_ROOT = REPOSITORY_ROOT / "libs/python/cua-train/src"
 def test_package_metadata_pins_binding_bearing_cua_train() -> None:
     project = tomllib.loads((PACKAGE_ROOT / "pyproject.toml").read_text())["project"]
 
-    assert project["version"] == "0.0.6"
+    assert project["version"] == "0.0.7"
     assert project["requires-python"] == ">=3.10"
-    assert project["dependencies"] == ["cua-train==0.1.2"]
+    assert project["dependencies"] == ["cua-train==0.1.3"]
 
 
 def test_cua_fleet_reexports_train_client(monkeypatch) -> None:
@@ -29,3 +29,4 @@ def test_cua_fleet_reexports_train_client(monkeypatch) -> None:
 
     assert cua_fleet.TrainClient is cua_train.TrainClient
     assert cua_fleet.__all__ == ["TrainClient"]
+    assert cua_fleet.__version__ == "0.0.7"


### PR DESCRIPTION
## Changes
- Bump `cua-fleet` from `0.0.6` to `0.0.7` and pin its metadata contract to `cua-train==0.1.3`.
- Repackage the published, hash-verified `cua-train 0.1.3` native wheels.
- Validate the public `fleet_sdk` import contract while preserving the `libcyclops_sdk` native filename.

## Validation
- `uv run --no-project --with pytest python -m pytest .github/scripts/tests/test_repackage_cua_train_wheel.py -v` (2 passed)
- `uv run --no-project --with pytest --with httpx python -m pytest libs/python/cua-fleet/tests/ -v` (2 passed)

Release preparation only; publication follows only after this exact head passes CI and merges.