### PR TITLE
fix(security): keep PTY credentials out of WebSocket URLs

### DIFF
--- a/libs/python/computer-server/computer_server/main.py
+++ b/libs/python/computer-server/computer_server/main.py
@@ -981,9 +981,9 @@ async def pty_ws(
 ):
     """WebSocket endpoint for interactive PTY session *pid*.
 
-    Auth (when CONTAINER_NAME is set): pass ``api_key`` and
-    ``container_name`` as query parameters, e.g.
-    ``/pty/123/ws?api_key=…&container_name=…``.
+    Auth (when CONTAINER_NAME is set): pass ``X-API-Key`` and
+    ``X-Container-Name`` request headers. Credentials are deliberately not
+    accepted in the URL, where proxies and access logs may retain them.
 
     Client → Server messages (JSON):
     - ``{"type": "stdin",   "data": "<base64>"}``
@@ -994,8 +994,8 @@ async def pty_ws(
     - ``{"type": "output", "data": "<base64>"}``
     - ``{"type": "exit",   "code": N}``
     """
-    container_name = websocket.query_params.get("container_name")
-    api_key = websocket.query_params.get("api_key")
+    container_name = websocket.headers.get("X-Container-Name")
+    api_key = websocket.headers.get("X-API-Key")
     try:
         await _require_auth(container_name, api_key)
     except HTTPException:

--- a/libs/python/computer-server/tests/test_server.py
+++ b/libs/python/computer-server/tests/test_server.py
@@ -5,6 +5,7 @@ Following SRP: This file tests server initialization and basic operations.
 All external dependencies are mocked.
 """
 
+import asyncio
 import importlib.util
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
@@ -231,3 +232,71 @@ class TestMcpAcceptHeaderShim:
             )
             # Untouched: still exactly what the client sent.
             assert self._accept(seen["headers"]) == b"application/json"
+
+
+class TestPtyWebSocketAuthentication:
+    """Ensure PTY WebSocket credentials use headers and never query strings."""
+
+    @staticmethod
+    def _websocket(*, headers, query_params):
+        from fastapi import WebSocketDisconnect
+
+        websocket = Mock()
+        websocket.headers = headers
+        websocket.query_params = query_params
+        websocket.accept = AsyncMock()
+        websocket.close = AsyncMock()
+        websocket.receive_text = AsyncMock(side_effect=WebSocketDisconnect())
+        websocket.send_text = AsyncMock()
+        return websocket
+
+    @pytest.mark.asyncio
+    async def test_headers_are_passed_to_authentication(self):
+        try:
+            from computer_server import main
+        except ImportError:
+            pytest.skip("computer_server module not installed")
+        except Exception as e:
+            pytest.skip(f"Server initialization requires specific setup: {e}")
+
+        websocket = self._websocket(
+            headers={"X-Container-Name": "header-container", "X-API-Key": "header-key"},
+            query_params={"container_name": "query-container", "api_key": "query-key"},
+        )
+        queue = asyncio.Queue()
+
+        with (
+            patch.object(main, "_require_auth", new=AsyncMock()) as require_auth,
+            patch.object(main.pty_manager, "subscribe", return_value=queue),
+            patch.object(main.pty_manager, "unsubscribe"),
+        ):
+            await main.pty_ws(42, websocket)
+
+        require_auth.assert_awaited_once_with("header-container", "header-key")
+        websocket.accept.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_query_only_credentials_are_rejected(self):
+        try:
+            from computer_server import main
+            from fastapi import HTTPException
+        except ImportError:
+            pytest.skip("computer_server module not installed")
+        except Exception as e:
+            pytest.skip(f"Server initialization requires specific setup: {e}")
+
+        websocket = self._websocket(
+            headers={},
+            query_params={"container_name": "query-container", "api_key": "query-key"},
+        )
+
+        async def reject_missing_headers(container_name, api_key):
+            assert container_name is None
+            assert api_key is None
+            raise HTTPException(status_code=401)
+
+        with patch.object(main, "_require_auth", new=reject_missing_headers):
+            await main.pty_ws(42, websocket)
+
+        websocket.accept.assert_not_awaited()
+        websocket.close.assert_awaited_once_with(code=1008)

--- a/libs/python/computer/computer/pty.py
+++ b/libs/python/computer/computer/pty.py
@@ -328,15 +328,10 @@ class PtyInterface:
         sess = self._sessions.setdefault(pid, {})
         sess["stdin_queue"] = stdin_queue
 
-        params = {}
-        if self._api_key:
-            params["api_key"] = self._api_key
-        if self._vm_name:
-            params["container_name"] = self._vm_name
         ws_url = f"{self._ws_base}/pty/{pid}/ws"
         try:
             async with aiohttp.ClientSession() as http:
-                async with http.ws_connect(ws_url, params=params) as ws:
+                async with http.ws_connect(ws_url, headers=self._auth_headers()) as ws:
 
                     async def _write_stdin():
                         while True:

--- a/libs/python/computer/tests/test_pty.py
+++ b/libs/python/computer/tests/test_pty.py
@@ -1,0 +1,81 @@
+"""Tests for the PTY HTTP and WebSocket authentication contract."""
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
+import aiohttp
+import pytest
+
+
+class _WebSocketContext:
+    def __init__(self, websocket):
+        self.websocket = websocket
+
+    async def __aenter__(self):
+        return self.websocket
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _EmptyWebSocket:
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+    async def send_str(self, payload):
+        raise AssertionError(f"no stdin should be sent in this test: {payload}")
+
+
+class _Session:
+    def __init__(self, capture):
+        self.capture = capture
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def ws_connect(self, url, **kwargs):
+        self.capture["url"] = url
+        self.capture["kwargs"] = kwargs
+        return _WebSocketContext(_EmptyWebSocket())
+
+
+@pytest.mark.asyncio
+async def test_pty_websocket_auth_uses_headers_not_query_parameters(monkeypatch):
+    module_path = Path(__file__).parents[1] / "computer" / "pty.py"
+    spec = importlib.util.spec_from_file_location("_computer_pty_auth_test", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    capture = {}
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda: _Session(capture))
+
+    interface = module.PtyInterface(
+        "https://computer.example",
+        api_key="secret-api-key",
+        vm_name="container-123",
+    )
+    exit_event = asyncio.Event()
+
+    await interface._ws_reader(42, None, exit_event, [0])
+
+    assert capture["url"] == "wss://computer.example/pty/42/ws"
+    assert capture["kwargs"] == {
+        "headers": {
+            "X-API-Key": "secret-api-key",
+            "X-Container-Name": "container-123",
+        }
+    }
+    assert "secret-api-key" not in capture["url"]
+    assert "container-123" not in capture["url"]
+    assert exit_event.is_set()


### PR DESCRIPTION
## Problem
The PTY WebSocket client puts the API key and container name in the URL query string. URLs are commonly copied into proxy and access logs, so this can expose credentials even though the other PTY endpoints already use request headers.

## What changed
- Send PTY WebSocket credentials with `X-API-Key` and `X-Container-Name` headers.
- Read those headers on the computer-server WebSocket endpoint.
- Ignore query-string credentials so a query-only connection is rejected when authentication is required.
- Add focused client and server tests for the safe path and the query-only negative control.

## Definition of Done
- [x] PTY WebSocket URLs contain no API key or container name.
- [x] The server authenticates PTY WebSockets from the same headers used by the other PTY endpoints.
- [x] Query-only credentials are rejected when `CONTAINER_NAME` enables authentication.
- [x] Focused client and server tests cover both the accepted header path and the rejected query-only path.
- [ ] A maintainer reviews and advances this draft; this automation will not merge it or mark it ready.
- [ ] A deployed service confirms that its proxy and access-log configuration does not retain credentials from this connection path.

## Validation
- `python3 -m py_compile` for the changed Python files.
- `uv run --group test python -m pytest -q libs/python/computer-server/tests/test_server.py -k PtyWebSocketAuthentication`
- `uv run --with pytest --with pytest-asyncio --with aiohttp python -m pytest -q libs/python/computer/tests/test_pty.py`
- `git diff --check`

## Impact
This changes only PTY WebSocket authentication transport. Existing HTTP PTY calls keep their current headers. No live deployment or VM runtime proof was attempted in this unattended security loop.
