### PR TITLE
fix(cua-fleet): import fleet SDK in live example

### DIFF
--- a/libs/fleet/sdk-bindings/examples/python/live_app_controlled.py
+++ b/libs/fleet/sdk-bindings/examples/python/live_app_controlled.py
@@ -6,7 +6,7 @@ import time
 import urllib.error
 import urllib.request
 
-from cyclops_sdk import (
+from fleet_sdk import (
     CreateClaimRequest,
     CreatePoolRequest,
     CyclopsClient,


### PR DESCRIPTION
Fix the release smoke example to import the published public `fleet_sdk` package. Validated by repackaging the published `cua-train 0.1.3` Linux wheel and confirming the clean installed example reaches `KeyError: 'CUA_CLIENT_ID'` without import or native-load failures.