### PR TITLE
fix(cua-driver): preserve verified selection readbacks

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-core/src/action_record.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/action_record.rs
@@ -588,12 +588,25 @@ fn browser_refusal_escalation(code: &str) -> Option<ActionEscalation> {
 }
 
 /// Legacy `verified` was not a sufficient proof by itself: some action
-/// producers used it as a delivery acknowledgement, and clicks have no
-/// independent postcondition read-back. Only value-changing tools whose
-/// platform implementations compare a fresh value against the request may
-/// promote that legacy bit to publishable evidence.
+/// producers used it as a delivery acknowledgement. Value-changing tools may
+/// promote that bit when their platform implementation compares a fresh value
+/// against the request. A click may do so only when the producer also declares
+/// explicit accessibility read-back evidence, as the macOS collection-item
+/// selection fallback does after observing `AXSelected`.
 fn legacy_has_publishable_readback(tool_name: &str, structured: &serde_json::Value) -> bool {
-    matches!(tool_name, "type_text" | "type_text_chars" | "set_value")
+    let value_readback_tool = matches!(tool_name, "type_text" | "type_text_chars" | "set_value");
+    let click_selection_readback = tool_name == "click"
+        && structured
+            .get("evidence")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|evidence| {
+                evidence.iter().any(|item| {
+                    item.get("kind").and_then(serde_json::Value::as_str)
+                        == Some("accessibility_readback")
+                })
+            });
+
+    (value_readback_tool || click_selection_readback)
         && structured
             .get("verified")
             .and_then(serde_json::Value::as_bool)
@@ -1438,6 +1451,34 @@ mod tests {
             );
             assert!(record.evidence.is_empty());
         }
+    }
+
+    #[test]
+    fn click_selection_readback_preserves_confirmed_effect() {
+        let record = ActionExecutionRecord::from_legacy(
+            "click",
+            &serde_json::json!({"delivery_mode": "background"}),
+            &serde_json::json!({
+                "path": "cgevent",
+                "verified": true,
+                "effect": "confirmed",
+                "evidence": [{"kind": "accessibility_readback"}],
+            }),
+        )
+        .expect("verified selection click should normalize");
+
+        assert_eq!(record.effect, ActionEffect::Confirmed);
+        assert_eq!(record.evidence.len(), 1);
+        assert_eq!(record.evidence[0].kind, EvidenceKind::AccessibilityReadback);
+        assert_eq!(
+            serde_json::to_value(record.public_result().expect("public result")).unwrap(),
+            serde_json::json!({
+                "effect": "confirmed",
+                "route": "synthetic_events",
+                "delivery": {"mode": "background"},
+                "evidence": [{"kind": "value_readback"}],
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve an explicitly evidenced macOS collection-selection read-back when the canonical action truth adapter closes the legacy click payload
- keep ordinary pointer/key delivery acknowledgements downgraded to `effect: unverifiable`
- add a focused regression for the exact public `ActionResult` projection

## Root cause

The macOS Finder selection fallback introduced by #2755 emits `verified: true`, `effect: confirmed`, and explicit `accessibility_readback` evidence after observing `AXSelected`. The canonical compatibility adapter only allowed value-changing tools to publish read-back evidence, so it discarded this independent click postcondition and downgraded the public result to `effect: unverifiable`.

## Verification

- `cargo test -p cua-driver-core --locked` — 474 unit tests, 2 contract parity tests, and 3 session lifecycle tests passed
- `cargo fmt --all -- --check`
- `git diff --check`
- fresh Lume macOS 26.5.2 exact-head verification at `f75943668168e20e0630a3b0d3113eeab09924bf` (`get_config.source_sha` matched; signed binary SHA-256 `8fe19af2709cef1d5dcaa3ea1da43baaca897db39f7873dbfe7b607f447e96ab`): selecting Finder list-row `alpha.txt` returned public `effect: confirmed`, `route: accessibility`, and `evidence: [{kind: value_readback}]`; the next Cua snapshot showed only `alpha.txt` selected

## Scope

Only `click` may promote a confirmed legacy result through this path, and only when the producer supplies the explicit `accessibility_readback` evidence marker. Existing delivery-only pointer and key acknowledgements remain unverified.