### PR TITLE
fix(cua-sandbox): use name lookup for Fleet pools

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -104,10 +104,7 @@ class _FleetClient:
         return await self._client.service_request(sandbox, service, path, request)
 
     async def get_pool(self, name: str) -> Any:
-        for pool in await self.list_pools():
-            if pool.metadata.name == name:
-                return pool
-        raise LookupError(f"Fleet pool {name!r} was not found")
+        return await self._client.get_pool(name)
 
     async def get_claim(self, pool: Any) -> Any:
         expected = f"{pool.metadata.name}-claim"

--- a/libs/python/cua-sandbox/pyproject.toml
+++ b/libs/python/cua-sandbox/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = ">=3.11,<3.14"
 dependencies = [
     "cua-core>=0.3.0,<0.4.0",
     "cua-auto>=0.1.2",
-    "cua-fleet==0.0.4",
+    "cua-fleet==0.0.6",
     "websockets>=12.0",
     "httpx>=0.27.0",
     "oras>=0.2.40",

--- a/libs/python/cua-sandbox/tests/test_pool.py
+++ b/libs/python/cua-sandbox/tests/test_pool.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import pytest
 from cua_sandbox import Image, Pool
 from cua_sandbox.sync import Pool as SyncPool
+from cua_sandbox.transport.fleet_cloud import _FleetClient
 from cyclops_sdk import Sandbox as FleetSandbox
 
 
@@ -62,6 +63,26 @@ class FakeFleetClient:
 
     async def close(self) -> None:
         self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_fleet_client_get_pool_uses_name_lookup_without_listing() -> None:
+    expected = fleet_pool()
+
+    class GeneratedClient:
+        async def get_pool(self, name: str) -> object:
+            assert name == "foo"
+            return expected
+
+    client = object.__new__(_FleetClient)
+    client._client = GeneratedClient()
+
+    async def fail_if_listed() -> list[object]:
+        raise AssertionError("get_pool must not list pools")
+
+    client.list_pools = fail_if_listed
+
+    assert await client.get_pool("foo") is expected
 
 
 @pytest.mark.asyncio

--- a/libs/python/cua-sandbox/uv.lock
+++ b/libs/python/cua-sandbox/uv.lock
@@ -539,14 +539,18 @@ dev = [{ name = "pytest", specifier = ">=8.3.5" }]
 
 [[package]]
 name = "cua-fleet"
-version = "0.0.4"
+version = "0.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cua-train" },
+    { name = "attrs" },
+    { name = "httpx" },
+    { name = "python-dateutil" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/2e/c629e6c5c80034fdf3e0274c370670a02e3decd4a716ae55fd426f52c0fe/cua_fleet-0.0.4.tar.gz", hash = "sha256:3c6a922fa800d6cd7fdc35c60a9d77f8f25b7b7b154ddd3b3f6053b5ce28581f", size = 3811, upload-time = "2026-07-26T17:02:18.455Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/84/f6be9349312eeb16a85fde9968979af2af042e846ffc26ccd5e17aa27ff3/cua_fleet-0.0.4-py3-none-any.whl", hash = "sha256:8a26610ae663eb231f2444ac4a03f8f8c41803679726e949ea7889ba1fe48766", size = 2393, upload-time = "2026-07-26T17:02:17.52Z" },
+    { url = "https://files.pythonhosted.org/packages/33/12/e0e08eb6b56e421c92815654f162ee1bcd9e5abb7dbc1e26e12f316dff46/cua_fleet-0.0.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4a292b0519eaa172c4d4d081e771e0a66e6cb964a2bb01fc2cbd68020c302c8a", size = 2123635, upload-time = "2026-08-01T02:21:37.116Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/53/398c64149eaf467e9d97fb0958ec97f5fab22a4c08a0a8c47cb72412532a/cua_fleet-0.0.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ed310ad529c6655a9fde8455fc764c2b7e53f5ca2581e39aec9e878296a0de6e", size = 2037302, upload-time = "2026-08-01T02:21:38.393Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c2/ac127bde7f2ffe1b2affe49e11b48d4053728c15d700b2b96190768d2296/cua_fleet-0.0.6-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:612c3d2cfe4b4a1356503a0ddee6518f9cc1d8e5c410124b68627a8650977237", size = 2300923, upload-time = "2026-08-01T02:21:39.561Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e1/67de4257140bc9d22f14cb9ee4d627d5e25cf0544aa323d4d6ff33a25c8e/cua_fleet-0.0.6-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:4d5119b7ff46bd2af9af1a2310c16b6993787bafa94f308512463929eddcc45a", size = 2355463, upload-time = "2026-08-01T02:21:40.87Z" },
 ]
 
 [[package]]
@@ -588,7 +592,7 @@ dev = [
 requires-dist = [
     { name = "cua-auto", specifier = ">=0.1.2" },
     { name = "cua-core", specifier = ">=0.3.0,<0.4.0" },
-    { name = "cua-fleet", specifier = "==0.0.4" },
+    { name = "cua-fleet", specifier = "==0.0.6" },
     { name = "grpcio", specifier = "==1.78.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "oras", specifier = ">=0.2.40" },
@@ -609,22 +613,6 @@ dev = [
     { name = "cua-agent", editable = "../agent" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
-]
-
-[[package]]
-name = "cua-train"
-version = "0.1.1"
-source = { registry = "https://wheels.cua.ai/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "httpx" },
-    { name = "python-dateutil" },
-]
-wheels = [
-    { url = "https://wheels.cua.ai/simple/cua-train/cua_train-0.1.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:1822fb9a63c6566d2763a9fb2e384ba4cc6a3771d97fb2cd3f1f9af66916e6df" },
-    { url = "https://wheels.cua.ai/simple/cua-train/cua_train-0.1.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:045b51e3ebebc7bf2107ec5a97801250b551e9617bcbbeec97a1e4f4c2ebd884" },
-    { url = "https://wheels.cua.ai/simple/cua-train/cua_train-0.1.1-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:6f8eb7f450f05d4a495de70a0a8f7acdb3dce20d842bae96f2aec27e2869fb85" },
-    { url = "https://wheels.cua.ai/simple/cua-train/cua_train-0.1.1-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:9ab37ae89ef6f95a1c0e315226af7716625bc6225e54770f94315905a744c5ad" },
 ]
 
 [[package]]


### PR DESCRIPTION
Uses the name-only `cua-fleet==0.0.6` `get_pool(name)` API instead of listing namespaces/pools. Adds a regression test that fails if lookup lists pools.