### PR TITLE
feat(cua-sandbox): configure Fleet pool services

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/pool.py
+++ b/libs/python/cua-sandbox/cua_sandbox/pool.py
@@ -54,7 +54,12 @@ class Pool:
         The Fleet client used to reconcile is closed before this method returns.
         """
         name, image = cls._validate_config(config)
-        desired = FleetCloudTransport(image=image, name=name)._pool_request()
+        desired = FleetCloudTransport(
+            image=image,
+            name=name,
+            replicas=config.get("replicas", 1),
+            services=config.get("services"),
+        )._pool_request()
         client = _FleetClient()
         try:
             try:

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -192,7 +192,14 @@ class FleetCloudTransport(FleetTransport):
         if services is not None and (
             not isinstance(services, Mapping)
             or not services
-            or any(not isinstance(name, str) or not name or not isinstance(port, int) or port < 1 or port > 65535 for name, port in services.items())
+            or any(
+                not isinstance(name, str)
+                or not name
+                or not isinstance(port, int)
+                or port < 1
+                or port > 65535
+                for name, port in services.items()
+            )
         ):
             raise ValueError("services must map non-empty names to TCP ports")
         self._image = image
@@ -336,7 +343,10 @@ class FleetCloudTransport(FleetTransport):
 
     def _pool_request(self) -> CreatePoolRequest:
         assert self._image is not None
-        service_ports = self._services or {"server": 8000, **{f"port-{port}": port for port in self._image._ports if port != 8000}}
+        service_ports = self._services or {
+            "server": 8000,
+            **{f"port-{port}": port for port in self._image._ports if port != 8000},
+        }
         services = [
             SandboxService(name=name, target_port=port, protocol=ServiceProtocol.TCP)
             for name, port in service_ports.items()

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Mapping, Optional
 from urllib.parse import urlparse
 
 from cua_sandbox._config import (
@@ -180,17 +180,29 @@ class FleetCloudTransport(FleetTransport):
         region: str = "us-east-1",
         time_to_start: Optional[float] = None,
         request_timeout: Optional[float] = None,
+        replicas: int = 1,
+        services: Mapping[str, int] | None = None,
     ) -> None:
         if disk_gb is not None:
             raise ValueError("disk_gb is not supported by the Fleet cloud transport")
         if region != "us-east-1":
             raise ValueError("Fleet cloud sandboxes currently support only region='us-east-1'")
+        if isinstance(replicas, bool) or not isinstance(replicas, int) or replicas < 1:
+            raise ValueError("replicas must be a positive integer")
+        if services is not None and (
+            not isinstance(services, Mapping)
+            or not services
+            or any(not isinstance(name, str) or not name or not isinstance(port, int) or port < 1 or port > 65535 for name, port in services.items())
+        ):
+            raise ValueError("services must map non-empty names to TCP ports")
         self._image = image
         self._name = name
         self._cpu = cpu
         self._memory_mb = memory_mb
         self._time_to_start = time_to_start if time_to_start is not None else 600.0
         self._request_timeout = request_timeout or 30.0
+        self._replicas = replicas
+        self._services = dict(services) if services is not None else None
         self._provisioned = False
         self._owns_resources = image is not None
         self._pool: Any = None
@@ -324,16 +336,15 @@ class FleetCloudTransport(FleetTransport):
 
     def _pool_request(self) -> CreatePoolRequest:
         assert self._image is not None
-        services = [SandboxService(name="server", target_port=8000, protocol=ServiceProtocol.TCP)]
-        services.extend(
-            SandboxService(name=f"port-{port}", target_port=port, protocol=ServiceProtocol.TCP)
-            for port in self._image._ports
-            if port != 8000
-        )
+        service_ports = self._services or {"server": 8000, **{f"port-{port}": port for port in self._image._ports if port != 8000}}
+        services = [
+            SandboxService(name=name, target_port=port, protocol=ServiceProtocol.TCP)
+            for name, port in service_ports.items()
+        ]
         return CreatePoolRequest(
             namespace=self._name,
             spec=PoolSpec(
-                replicas=1,
+                replicas=self._replicas,
                 services=services,
                 template=PoolTemplate(
                     runtime=None,

--- a/libs/python/cua-sandbox/tests/test_pool.py
+++ b/libs/python/cua-sandbox/tests/test_pool.py
@@ -213,3 +213,24 @@ def test_sync_pool_matches_blocking_context_manager(monkeypatch):
 
     assert claim_client.released == ["claim-1"]
     assert claim_client.closed is True
+
+@pytest.mark.asyncio
+async def test_reconcile_preserves_replicas_and_named_services(monkeypatch):
+    client = FakeFleetClient()
+    monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: client)
+
+    await Pool.reconcile(
+        {
+            "name": "foo",
+            "image": Image.from_registry("registry.example/workspace:latest"),
+            "replicas": 2,
+            "services": {"server": 8000, "mcp": 3000},
+        }
+    )
+
+    request = client.created[0]
+    assert request.spec.replicas == 2
+    assert [(service.name, service.target_port) for service in request.spec.services] == [
+        ("server", 8000),
+        ("mcp", 3000),
+    ]

--- a/libs/python/cua-sandbox/tests/test_pool.py
+++ b/libs/python/cua-sandbox/tests/test_pool.py
@@ -214,6 +214,7 @@ def test_sync_pool_matches_blocking_context_manager(monkeypatch):
     assert claim_client.released == ["claim-1"]
     assert claim_client.closed is True
 
+
 @pytest.mark.asyncio
 async def test_reconcile_preserves_replicas_and_named_services(monkeypatch):
     client = FakeFleetClient()

--- a/libs/python/cua-sandbox/uv.lock
+++ b/libs/python/cua-sandbox/uv.lock
@@ -555,7 +555,7 @@ wheels = [
 
 [[package]]
 name = "cua-sandbox"
-version = "0.1.17"
+version = "0.1.18"
 source = { editable = "." }
 dependencies = [
     { name = "cua-auto" },


### PR DESCRIPTION
Extends the public Pool reconciliation contract with optional replicas and named TCP services, preserving the Hermes two-replica / mcp service topology. Focused Pool tests and Ruff pass.