### PR TITLE
fix(fleet): load promoted SDK in release smoke

### DIFF
--- a/libs/fleet/sdk-bindings/examples/python/live_app_controlled.py
+++ b/libs/fleet/sdk-bindings/examples/python/live_app_controlled.py
@@ -6,7 +6,7 @@ import time
 import urllib.error
 import urllib.request
 
-from cyclops_sdk import (
+from fleet_sdk import (
     CreateClaimRequest,
     CreatePoolRequest,
     CyclopsClient,


### PR DESCRIPTION
Repairs the `cua-fleet` 0.0.7 release smoke to import the promoted wheel's `fleet_sdk` module rather than the obsolete `cyclops_sdk` module.

Verification: repackaged the canonical Linux `cua-train==0.1.3` wheel locally; the example now reaches the expected missing `CUA_CLIENT_ID` boundary with no module or native-library load error.