### PR TITLE
feat(cua-sandbox): request named Fleet services

### DIFF
--- a/libs/python/cua-sandbox/README.md
+++ b/libs/python/cua-sandbox/README.md
@@ -106,6 +106,12 @@ pool = await Pool.reconcile({
 
 async with pool.claim() as sb:
     result = await sb.shell.run("echo hello")
+
+    # Requests use the same authenticated Fleet claim.
+    response = await sb.services.request(
+        "mcp", method="POST", path="/mcp", json={"jsonrpc": "2.0", "method": "tools/list", "id": 1}
+    )
+    response.raise_for_status()
 ```
 
 For scripts that use the synchronous facade:

--- a/libs/python/cua-sandbox/cua_sandbox/interfaces/__init__.py
+++ b/libs/python/cua-sandbox/cua_sandbox/interfaces/__init__.py
@@ -5,6 +5,7 @@ from cua_sandbox.interfaces.keyboard import Keyboard
 from cua_sandbox.interfaces.mobile import Mobile
 from cua_sandbox.interfaces.mouse import Mouse
 from cua_sandbox.interfaces.screen import Screen
+from cua_sandbox.interfaces.services import Services
 from cua_sandbox.interfaces.shell import Shell
 from cua_sandbox.interfaces.terminal import Terminal
 from cua_sandbox.interfaces.tunnel import Tunnel, TunnelInfo
@@ -19,6 +20,7 @@ __all__ = [
     "Mobile",
     "Mouse",
     "Screen",
+    "Services",
     "Shell",
     "Terminal",
     "Tunnel",

--- a/libs/python/cua-sandbox/cua_sandbox/interfaces/services.py
+++ b/libs/python/cua-sandbox/cua_sandbox/interfaces/services.py
@@ -1,0 +1,30 @@
+"""Named service interface for sandboxes that expose auxiliary endpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cua_sandbox.transport.base import Transport
+
+
+class Services:
+    """Request a named service exposed by the active sandbox connection."""
+
+    def __init__(self, transport: Transport):
+        self._transport = transport
+
+    async def request(
+        self,
+        name: str,
+        *,
+        method: str,
+        path: str,
+        json: Any = None,
+    ) -> Any:
+        """Send a request to a named service on this sandbox.
+
+        Fleet routes the request through the authenticated lease. Other
+        transports raise :class:`NotImplementedError` unless they expose named
+        services as well.
+        """
+        return await self._transport.request_service(name, method=method, path=path, json_body=json)

--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -66,6 +66,7 @@ from cua_sandbox.interfaces import (
     Mobile,
     Mouse,
     Screen,
+    Services,
     Shell,
     Terminal,
     Tunnel,
@@ -268,6 +269,7 @@ class Sandbox:
         self.terminal = Terminal(transport)
         self.mobile = Mobile(transport)
         self.tunnel = Tunnel(transport)
+        self.services = Services(transport)
         _os = _runtime_info.environment if _runtime_info and _runtime_info.environment else "linux"
         self.apps = Apps(transport, os_type=_os)
 

--- a/libs/python/cua-sandbox/cua_sandbox/transport/base.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/base.py
@@ -66,6 +66,17 @@ class Transport(ABC):
     async def get_environment(self) -> str:
         """Return 'windows', 'mac', 'linux', or 'browser'."""
 
+    async def request_service(
+        self,
+        name: str,
+        *,
+        method: str,
+        path: str,
+        json_body: Any = None,
+    ) -> Any:
+        """Request an auxiliary named service exposed by this sandbox."""
+        raise NotImplementedError(f"{type(self).__name__} does not support named service requests.")
+
     async def forward_tunnel(self, sandbox_port: int | str) -> "TunnelInfo":
         """Forward *sandbox_port* to an available host port and return info.
 

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
@@ -45,7 +45,26 @@ class FleetTransport(Transport):
     async def disconnect(self) -> None:
         self._connected = False
 
-    async def _request(self, method: str, path: str, *, json_body: Any = None) -> httpx.Response:
+    async def request_service(
+        self,
+        name: str,
+        *,
+        method: str,
+        path: str,
+        json_body: Any = None,
+    ) -> httpx.Response:
+        if name not in self._bound.services:
+            raise ValueError(f"Fleet sandbox does not expose service {name!r}")
+        return await self._request(method, path, json_body=json_body, service_name=name)
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Any = None,
+        service_name: str | None = None,
+    ) -> httpx.Response:
         assert self._connected, "Transport not connected"
         body = None if json_body is None else json.dumps(json_body).encode()
         headers = (
@@ -53,7 +72,7 @@ class FleetTransport(Transport):
         )
         result = await self._sdk.service_request(
             self._bound,
-            self._service_name,
+            service_name or self._service_name,
             path,
             HttpRequest(
                 method=method, url=f"https://service.invalid{path}", headers=headers, body=body

--- a/libs/python/cua-sandbox/tests/test_pool.py
+++ b/libs/python/cua-sandbox/tests/test_pool.py
@@ -31,6 +31,7 @@ class FakeFleetClient:
         self.updated: list[object] = []
         self.claims: list[object] = []
         self.released: list[object] = []
+        self.service_requests: list[object] = []
         self.closed = False
 
     async def get_pool(self, name: str) -> object:
@@ -54,7 +55,16 @@ class FakeFleetClient:
 
     async def wait_claim(self, claim: object) -> FleetSandbox:
         assert claim == "claim-1"
-        return FleetSandbox(namespace="foo", claim="claim-1", name="sandbox-1", services=["server"])
+        return FleetSandbox(
+            namespace="foo",
+            claim="claim-1",
+            name="sandbox-1",
+            services=["server", "mcp"],
+        )
+
+    async def service_request(self, sandbox, service, path, request):
+        self.service_requests.append((sandbox, service, path, request))
+        return SimpleNamespace(status=200, headers=[], body=b'{"result":"ok"}')
 
     async def delete_claim(self, claim: object) -> None:
         self.released.append(claim)
@@ -235,3 +245,25 @@ async def test_reconcile_preserves_replicas_and_named_services(monkeypatch):
         ("server", 8000),
         ("mcp", 3000),
     ]
+
+
+@pytest.mark.asyncio
+async def test_claim_exposes_named_service_requests(monkeypatch):
+    reconcile_client = FakeFleetClient()
+    claim_client = FakeFleetClient()
+    clients = iter([reconcile_client, claim_client])
+    monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: next(clients))
+    pool = await Pool.reconcile({"name": "foo", "image": Image.from_registry("example:latest")})
+
+    async with pool.claim() as sandbox:
+        response = await sandbox.services.request(
+            "mcp",
+            method="POST",
+            path="/mcp",
+            json={"jsonrpc": "2.0", "method": "tools/list", "id": 1},
+        )
+
+    assert response.status_code == 200
+    _, service, path, request = claim_client.service_requests[0]
+    assert (service, path, request.method) == ("mcp", "/mcp", "POST")
+    assert request.body == b'{"jsonrpc": "2.0", "method": "tools/list", "id": 1}'


### PR DESCRIPTION
Adds `sandbox.services.request(name, method=..., path=..., json=...)` for requests to a named Fleet service on the same active Pool claim. The Pool retains claim/client lifecycle ownership; consumers no longer need a raw Cyclops client to route MCP JSON-RPC to the named `mcp` service.

Validation: `uv run --no-sync pytest tests/test_pool.py tests/test_fleet_transport.py -q` (17 passed), plus focused Ruff check/format.