### PR TITLE
chore(cua-sandbox): prepare 0.1.20 release

### DIFF
--- a/libs/python/cua-sandbox/pyproject.toml
+++ b/libs/python/cua-sandbox/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cua-sandbox"
-version = "0.1.19"
+version = "0.1.20"
 description = "CUA Sandbox — ephemeral and persistent sandboxed computer environments"
 readme = "README.md"
 license = "MIT"

--- a/libs/python/cua-sandbox/tests/test_fleet_sdk_packaging.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_sdk_packaging.py
@@ -17,6 +17,7 @@ class FleetSdkPackagingTests(unittest.TestCase):
         with PYPROJECT_PATH.open("rb") as pyproject_file:
             project = tomllib.load(pyproject_file)
 
+        self.assertEqual(project["project"]["version"], "0.1.20")
         dependencies = project["project"]["dependencies"]
         self.assertIn("cua-fleet==0.0.7", dependencies)
         self.assertFalse(any(dependency.startswith("cua-train") for dependency in dependencies))

--- a/libs/python/cua-sandbox/uv.lock
+++ b/libs/python/cua-sandbox/uv.lock
@@ -555,7 +555,7 @@ wheels = [
 
 [[package]]
 name = "cua-sandbox"
-version = "0.1.19"
+version = "0.1.20"
 source = { editable = "." }
 dependencies = [
     { name = "cua-auto" },


### PR DESCRIPTION
Prepares the merged Fleet SDK and named-service API for `cua-sandbox 0.1.20`.

The first 0.1.20 publish dispatch failed because `pyproject.toml` remained at 0.1.19; the release workflow requires an exact match.

Validation:
- Red: static packaging contract fails at 0.1.19.
- Green: `python3 tests/test_fleet_sdk_packaging.py` (4 tests).
- `.github/scripts/get_pyproject_version.py pyproject.toml 0.1.20` passes.
- `python3 -m compileall -q cua_sandbox` and `git diff --check` pass.