### PR TITLE
fix(cua-driver): avoid accessibility advertise on Cinnamon

### DIFF
--- a/docs/content/docs/reference/cua-driver/limits.mdx
+++ b/docs/content/docs/reference/cua-driver/limits.mdx
@@ -270,6 +270,35 @@ When a pixel action is unavoidable, match the scope to the space:
 On macOS, `get_window_state` also reports `window_bounds`, which may be used in
 place of `list_windows` there. Windows and Linux report `screenshot_width` and
 `screenshot_height` only.
+---
+
+## Cinnamon leaves accessibility advertisement disabled
+
+On Linux, Cua Driver normally advertises accessibility support to the desktop
+session so Chromium, Electron, GTK, and Qt applications expose AT-SPI trees.
+Cinnamon treats the two session-wide accessibility flags as coupled settings:
+advertising a screen reader launches Orca, while advertising only generic
+accessibility can make the Cinnamon and GNOME settings schemas repeatedly
+overwrite each other.
+
+When `XDG_CURRENT_DESKTOP` identifies `Cinnamon` or `X-Cinnamon`, Cua Driver
+therefore leaves both accessibility flags unchanged. Screenshots and available
+CDP browser routes continue to work, but applications that have not enabled
+their own accessibility bridge may return a degraded or empty AT-SPI tree.
+
+The startup behavior can be overridden with
+`CUA_DRIVER_RS_A11Y_ADVERTISE_MODE`:
+
+| Value | Session status written | Cinnamon guidance |
+| --- | --- | --- |
+| `none` | Nothing | Safe; this is the Cinnamon default. |
+| `is_enabled_only` | `IsEnabled=true` | Unsafe on Cinnamon because it can trigger the settings write loop. |
+| `all` | `IsEnabled=true` and `ScreenReaderEnabled=true` | Unsafe on Cinnamon because it launches Orca. |
+
+The legacy `CUA_DRIVER_RS_DISABLE_A11Y_ADVERTISE=1` setting is equivalent to
+`none` and takes precedence over the mode variable. Explicit overrides are
+intended for controlled diagnostics; they should not be used to force either
+advertisement mode in a normal Cinnamon session.
 
 ---
 

--- a/docs/content/docs/reference/cua-driver/limits.mdx
+++ b/docs/content/docs/reference/cua-driver/limits.mdx
@@ -270,35 +270,20 @@ When a pixel action is unavoidable, match the scope to the space:
 On macOS, `get_window_state` also reports `window_bounds`, which may be used in
 place of `list_windows` there. Windows and Linux report `screenshot_width` and
 `screenshot_height` only.
+
 ---
 
-## Cinnamon leaves accessibility advertisement disabled
+## Cinnamon disables accessibility advertisement
 
-On Linux, Cua Driver normally advertises accessibility support to the desktop
-session so Chromium, Electron, GTK, and Qt applications expose AT-SPI trees.
-Cinnamon treats the two session-wide accessibility flags as coupled settings:
-advertising a screen reader launches Orca, while advertising only generic
-accessibility can make the Cinnamon and GNOME settings schemas repeatedly
-overwrite each other.
+On Cinnamon (`Cinnamon` or `X-Cinnamon`), Cua Driver leaves the session
+accessibility flags unchanged. Setting `ScreenReaderEnabled=true` launches
+Orca, while setting only `IsEnabled=true` can make the Cinnamon and GNOME
+settings schemas repeatedly overwrite each other.
 
-When `XDG_CURRENT_DESKTOP` identifies `Cinnamon` or `X-Cinnamon`, Cua Driver
-therefore leaves both accessibility flags unchanged. Screenshots and available
-CDP browser routes continue to work, but applications that have not enabled
-their own accessibility bridge may return a degraded or empty AT-SPI tree.
-
-The startup behavior can be overridden with
-`CUA_DRIVER_RS_A11Y_ADVERTISE_MODE`:
-
-| Value | Session status written | Cinnamon guidance |
-| --- | --- | --- |
-| `none` | Nothing | Safe; this is the Cinnamon default. |
-| `is_enabled_only` | `IsEnabled=true` | Unsafe on Cinnamon because it can trigger the settings write loop. |
-| `all` | `IsEnabled=true` and `ScreenReaderEnabled=true` | Unsafe on Cinnamon because it launches Orca. |
-
-The legacy `CUA_DRIVER_RS_DISABLE_A11Y_ADVERTISE=1` setting is equivalent to
-`none` and takes precedence over the mode variable. Explicit overrides are
-intended for controlled diagnostics; they should not be used to force either
-advertisement mode in a normal Cinnamon session.
+Applications that rely on Cua Driver to enable their accessibility bridge may
+therefore return a degraded or empty AT-SPI tree. Screenshots and available CDP
+browser routes continue to work. Do not set `CUA_DRIVER_RS_A11Y_ADVERTISE_MODE`
+to `all` or `is_enabled_only` in a normal Cinnamon session.
 
 ---
 

--- a/libs/cua-driver/rust/crates/platform-linux/src/a11y.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/a11y.rs
@@ -15,9 +15,12 @@
 //! A real screen reader turns the Chromium signal on. Doing that ourselves is
 //! unsafe on GNOME and COSMIC: their session services treat the signal as a user
 //! request and launch Orca. Those desktops therefore get only the generic
-//! `IsEnabled` signal by default. Other desktops retain the Chromium signal for
-//! compatibility, and a caller can choose either policy explicitly with
-//! `CUA_DRIVER_RS_A11Y_ADVERTISE_MODE`.
+//! `IsEnabled` signal by default. Cinnamon cannot safely receive even that
+//! reduced signal: its settings daemon derives toolkit accessibility from the
+//! screen-reader setting and can enter a high-frequency settings write loop when
+//! they disagree. Cinnamon therefore receives no advertisement by default.
+//! Other desktops retain the Chromium signal for compatibility, and a caller
+//! can choose either policy explicitly with `CUA_DRIVER_RS_A11Y_ADVERTISE_MODE`.
 //!
 //! Everything here is best-effort. A session without an accessibility bus (some
 //! headless or minimal setups) just yields an error we log and ignore; enabling
@@ -153,13 +156,22 @@ fn advertise_mode_from(
 }
 
 fn desktop_default_mode(desktop: Option<&str>) -> AdvertiseMode {
-    let launches_screen_reader = desktop.is_some_and(|desktop| {
-        desktop
-            .split([':', ';'])
-            .map(str::trim)
-            .any(|part| part.eq_ignore_ascii_case("gnome") || part.eq_ignore_ascii_case("cosmic"))
-    });
-    if launches_screen_reader {
+    let has_desktop = |candidate: &str| {
+        desktop.is_some_and(|desktop| {
+            desktop
+                .split([':', ';'])
+                .map(str::trim)
+                .any(|part| part.eq_ignore_ascii_case(candidate))
+        })
+    };
+
+    // Cinnamon mirrors its GNOME and Cinnamon accessibility schemas and
+    // recomputes toolkit accessibility from the assistive-technology toggles.
+    // Advertising only IsEnabled can therefore livelock the settings daemons,
+    // while advertising ScreenReaderEnabled launches Orca. Fail closed.
+    if has_desktop("cinnamon") || has_desktop("x-cinnamon") {
+        AdvertiseMode::None
+    } else if has_desktop("gnome") || has_desktop("cosmic") {
         AdvertiseMode::IsEnabledOnly
     } else {
         AdvertiseMode::All
@@ -193,6 +205,25 @@ mod tests {
         assert_eq!(
             advertise_mode_from(false, None, Some("pop:COSMIC")),
             AdvertiseMode::IsEnabledOnly
+        );
+    }
+
+    #[test]
+    fn cinnamon_default_leaves_accessibility_status_untouched() {
+        for desktop in ["Cinnamon", "X-Cinnamon", "LinuxMint:X-Cinnamon"] {
+            assert_eq!(
+                advertise_mode_from(false, None, Some(desktop)),
+                AdvertiseMode::None,
+                "desktop={desktop}"
+            );
+        }
+    }
+
+    #[test]
+    fn cinnamon_safety_wins_in_composite_desktop_names() {
+        assert_eq!(
+            advertise_mode_from(false, None, Some("GNOME:X-Cinnamon")),
+            AdvertiseMode::None
         );
     }
 


### PR DESCRIPTION
## What changed

- recognize Cinnamon desktop identifiers in the Linux accessibility-advertise policy
- avoid enabling screen-reader accessibility advertisement on Cinnamon
- document the Cinnamon limitation and safe behavior

## Why

On Cinnamon, advertising screen-reader accessibility can flip the desktop screen-reader settings and launch Orca. Trying to retain toolkit accessibility while disabling the screen reader can also trigger a GSettings write livelock between GNOME and Cinnamon schemas.

## Root cause

The Linux desktop policy did not classify `XDG_CURRENT_DESKTOP=X-Cinnamon` as a desktop where accessibility advertisement must be avoided, so it fell through to the advertise path.

## Impact

Starting Cua Driver on Cinnamon no longer advertises screen-reader accessibility. This prevents the known Orca launch and settings-write storm while preserving the existing policy for other desktops.

## Verification

- Rust 1.97.1 built `platform-linux`
- all 7 accessibility policy tests passed
- the full `cua-driver` binary built
- an isolated D-Bus + Xvfb smoke test with `XDG_CURRENT_DESKTOP=X-Cinnamon` kept `ScreenReaderEnabled` at `false → false`
- the same smoke test kept `IsEnabled` at `false → false`

## Remaining gap

A real Cinnamon desktop end-to-end run has not been completed.

Fixes #2703