### PR TITLE
fix(lume): verify vm owner before stopping

### DIFF
--- a/libs/lume/src/Errors/Errors.swift
+++ b/libs/lume/src/Errors/Errors.swift
@@ -175,6 +175,7 @@ enum VMError: Error, LocalizedError {
     case notFound(String)
     case notInitialized(String)
     case notRunning(String)
+    case unverifiedProcessOwner(String)
     case alreadyRunning(String)
     case installNotStarted(String)
     case stopTimeout(String)
@@ -196,6 +197,9 @@ enum VMError: Error, LocalizedError {
             return "Virtual machine not initialized: \(name)"
         case .notRunning(let name):
             return "Virtual machine not running: \(name)"
+        case .unverifiedProcessOwner(let name):
+            return "Cannot safely identify the process running virtual machine \(name); "
+                + "stop it from the terminal that started it"
         case .alreadyRunning(let name):
             return "Virtual machine already running: \(name)"
         case .installNotStarted(let name):

--- a/libs/lume/src/VM/NativeDisplayAttachService.swift
+++ b/libs/lume/src/VM/NativeDisplayAttachService.swift
@@ -15,20 +15,20 @@ enum NativeDisplayAttachError: LocalizedError {
   }
 }
 
-private struct NativeDisplayOwner: Codable {
-  let processIdentifier: Int32
+private struct NativeDisplayOwner: Codable, Equatable {
+  let vmProcessOwner: VMProcessOwner
 }
 
 /// Provides a small, process-local control channel for revealing the native viewer.
 ///
-/// The owning `lume run` process registers SIGUSR1 and writes its PID into the VM
-/// directory. An `attach` process verifies that PID still owns the VM configuration
-/// lock before signaling it. The signal never crosses into an unrelated Lume daemon.
+/// The owning `lume run` process registers SIGUSR1 and records its verified VM-owner
+/// identity. An `attach` process signals it only while that exact process is still alive.
 @MainActor
 enum NativeDisplayAttachService {
   private nonisolated static let ownerFileName = ".native-display-owner.json"
   private static var signalSource: DispatchSourceSignal?
   private static var ownerFileURL: URL?
+  private static var registeredOwner: NativeDisplayOwner?
   private static var showAction: (@MainActor @Sendable () async -> Void)?
 
   static func register(
@@ -37,7 +37,10 @@ enum NativeDisplayAttachService {
   ) throws {
     unregister()
 
-    let owner = NativeDisplayOwner(processIdentifier: getpid())
+    guard let vmProcessOwner = VMProcessOwnerRegistry.validatedOwner(for: vmDirectory) else {
+      throw NativeDisplayAttachError.unavailable
+    }
+    let owner = NativeDisplayOwner(vmProcessOwner: vmProcessOwner)
     let fileURL = ownerURL(for: vmDirectory)
     let data = try JSONEncoder().encode(owner)
     try data.write(to: fileURL, options: .atomic)
@@ -45,6 +48,7 @@ enum NativeDisplayAttachService {
 
     showAction = show
     ownerFileURL = fileURL
+    registeredOwner = owner
     signal(SIGUSR1, SIG_IGN)
 
     let source = DispatchSource.makeSignalSource(signal: SIGUSR1, queue: .main)
@@ -62,26 +66,27 @@ enum NativeDisplayAttachService {
     signalSource = nil
     showAction = nil
 
-    if let ownerFileURL,
+    if let ownerFileURL, let registeredOwner,
       let data = try? Data(contentsOf: ownerFileURL),
       let owner = try? JSONDecoder().decode(NativeDisplayOwner.self, from: data),
-      owner.processIdentifier == getpid()
+      owner == registeredOwner
     {
       try? FileManager.default.removeItem(at: ownerFileURL)
     }
     ownerFileURL = nil
+    registeredOwner = nil
   }
 
   nonisolated static func isAvailable(vmDirectory: VMDirectory) -> Bool {
     guard let owner = validatedOwner(for: vmDirectory) else { return false }
-    return kill(owner.processIdentifier, 0) == 0
+    return kill(owner.vmProcessOwner.processIdentifier, 0) == 0
   }
 
   nonisolated static func requestNativeDisplay(vmDirectory: VMDirectory) throws {
     guard let owner = validatedOwner(for: vmDirectory) else {
       throw NativeDisplayAttachError.unavailable
     }
-    guard kill(owner.processIdentifier, SIGUSR1) == 0 else {
+    guard kill(owner.vmProcessOwner.processIdentifier, SIGUSR1) == 0 else {
       throw NativeDisplayAttachError.requestFailed
     }
   }
@@ -92,8 +97,7 @@ enum NativeDisplayAttachService {
     let fileURL = ownerURL(for: vmDirectory)
     guard let data = try? Data(contentsOf: fileURL),
       let owner = try? JSONDecoder().decode(NativeDisplayOwner.self, from: data),
-      owner.processIdentifier > 0,
-      owner.processIdentifier == lockOwnerPID(for: vmDirectory.configPath.url)
+      owner.vmProcessOwner == VMProcessOwnerRegistry.validatedOwner(for: vmDirectory)
     else {
       return nil
     }
@@ -104,28 +108,4 @@ enum NativeDisplayAttachService {
     vmDirectory.dir.file(ownerFileName).url
   }
 
-  private nonisolated static func lockOwnerPID(for configURL: URL) -> Int32? {
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
-    process.arguments = ["-t", configURL.path]
-    let output = Pipe()
-    process.standardOutput = output
-    process.standardError = FileHandle.nullDevice
-
-    do {
-      try process.run()
-      process.waitUntilExit()
-      guard process.terminationStatus == 0,
-        let data = try output.fileHandleForReading.readToEnd(),
-        let value = String(data: data, encoding: .utf8)?
-          .split(whereSeparator: \.isNewline).first,
-        let pid = Int32(value)
-      else {
-        return nil
-      }
-      return pid
-    } catch {
-      return nil
-    }
-  }
 }

--- a/libs/lume/src/VM/NativeDisplayAttachService.swift
+++ b/libs/lume/src/VM/NativeDisplayAttachService.swift
@@ -15,20 +15,20 @@ enum NativeDisplayAttachError: LocalizedError {
   }
 }
 
-private struct NativeDisplayOwner: Codable, Equatable {
-  let vmProcessOwner: VMProcessOwner
+private struct NativeDisplayOwner: Codable {
+  let processIdentifier: Int32
 }
 
 /// Provides a small, process-local control channel for revealing the native viewer.
 ///
-/// The owning `lume run` process registers SIGUSR1 and records its verified VM-owner
-/// identity. An `attach` process signals it only while that exact process is still alive.
+/// The owning `lume run` process registers SIGUSR1 and writes its PID into the VM
+/// directory. An `attach` process verifies that PID still owns the VM configuration
+/// lock before signaling it. The signal never crosses into an unrelated Lume daemon.
 @MainActor
 enum NativeDisplayAttachService {
   private nonisolated static let ownerFileName = ".native-display-owner.json"
   private static var signalSource: DispatchSourceSignal?
   private static var ownerFileURL: URL?
-  private static var registeredOwner: NativeDisplayOwner?
   private static var showAction: (@MainActor @Sendable () async -> Void)?
 
   static func register(
@@ -37,10 +37,7 @@ enum NativeDisplayAttachService {
   ) throws {
     unregister()
 
-    guard let vmProcessOwner = VMProcessOwnerRegistry.validatedOwner(for: vmDirectory) else {
-      throw NativeDisplayAttachError.unavailable
-    }
-    let owner = NativeDisplayOwner(vmProcessOwner: vmProcessOwner)
+    let owner = NativeDisplayOwner(processIdentifier: getpid())
     let fileURL = ownerURL(for: vmDirectory)
     let data = try JSONEncoder().encode(owner)
     try data.write(to: fileURL, options: .atomic)
@@ -48,7 +45,6 @@ enum NativeDisplayAttachService {
 
     showAction = show
     ownerFileURL = fileURL
-    registeredOwner = owner
     signal(SIGUSR1, SIG_IGN)
 
     let source = DispatchSource.makeSignalSource(signal: SIGUSR1, queue: .main)
@@ -66,27 +62,26 @@ enum NativeDisplayAttachService {
     signalSource = nil
     showAction = nil
 
-    if let ownerFileURL, let registeredOwner,
+    if let ownerFileURL,
       let data = try? Data(contentsOf: ownerFileURL),
       let owner = try? JSONDecoder().decode(NativeDisplayOwner.self, from: data),
-      owner == registeredOwner
+      owner.processIdentifier == getpid()
     {
       try? FileManager.default.removeItem(at: ownerFileURL)
     }
     ownerFileURL = nil
-    registeredOwner = nil
   }
 
   nonisolated static func isAvailable(vmDirectory: VMDirectory) -> Bool {
     guard let owner = validatedOwner(for: vmDirectory) else { return false }
-    return kill(owner.vmProcessOwner.processIdentifier, 0) == 0
+    return kill(owner.processIdentifier, 0) == 0
   }
 
   nonisolated static func requestNativeDisplay(vmDirectory: VMDirectory) throws {
     guard let owner = validatedOwner(for: vmDirectory) else {
       throw NativeDisplayAttachError.unavailable
     }
-    guard kill(owner.vmProcessOwner.processIdentifier, SIGUSR1) == 0 else {
+    guard kill(owner.processIdentifier, SIGUSR1) == 0 else {
       throw NativeDisplayAttachError.requestFailed
     }
   }
@@ -97,7 +92,8 @@ enum NativeDisplayAttachService {
     let fileURL = ownerURL(for: vmDirectory)
     guard let data = try? Data(contentsOf: fileURL),
       let owner = try? JSONDecoder().decode(NativeDisplayOwner.self, from: data),
-      owner.vmProcessOwner == VMProcessOwnerRegistry.validatedOwner(for: vmDirectory)
+      owner.processIdentifier > 0,
+      owner.processIdentifier == lockOwnerPID(for: vmDirectory.configPath.url)
     else {
       return nil
     }
@@ -108,4 +104,28 @@ enum NativeDisplayAttachService {
     vmDirectory.dir.file(ownerFileName).url
   }
 
+  private nonisolated static func lockOwnerPID(for configURL: URL) -> Int32? {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
+    process.arguments = ["-t", configURL.path]
+    let output = Pipe()
+    process.standardOutput = output
+    process.standardError = FileHandle.nullDevice
+
+    do {
+      try process.run()
+      process.waitUntilExit()
+      guard process.terminationStatus == 0,
+        let data = try output.fileHandleForReading.readToEnd(),
+        let value = String(data: data, encoding: .utf8)?
+          .split(whereSeparator: \.isNewline).first,
+        let pid = Int32(value)
+      else {
+        return nil
+      }
+      return pid
+    } catch {
+      return nil
+    }
+  }
 }

--- a/libs/lume/src/VM/VM.swift
+++ b/libs/lume/src/VM/VM.swift
@@ -272,6 +272,10 @@ class VM {
             flock(fileHandle.fileDescriptor, LOCK_UN)
             try? fileHandle.close()
         }
+        let processOwner = try VMProcessOwnerRegistry.register(vmDirectory: vmDirContext.dir)
+        defer {
+            VMProcessOwnerRegistry.unregister(processOwner, vmDirectory: vmDirContext.dir)
+        }
         sessionCleanedUp = false
         activeVNCPolicy = vncPolicy
         activeNoVNCSession = nil
@@ -763,44 +767,21 @@ class VM {
             }
         }
 
-        // Try to open config file to get file descriptor
-        Logger.info(
-            "Attempting to access config file lock",
-            metadata: [
-                "path": vmDirContext.dir.configPath.path,
-                "name": vmDirContext.name,
-            ])
-        let fileHandle = try? FileHandle(forReadingFrom: vmDirContext.dir.configPath.url)
-        guard let fileHandle = fileHandle else {
-            Logger.info(
-                "Failed to open config file - VM may not be running",
-                metadata: ["name": vmDirContext.name])
-
-            // Even though we couldn't open the file, try to force unlock anyway
-            unlockConfigFile()
-
-            throw VMError.notRunning(vmDirContext.name)
-        }
-
-        // Get the PID of the process holding the lock
-        Logger.info(
-            "Finding process holding lock on config file", metadata: ["name": vmDirContext.name])
-        guard let pid = runLockProbe.lockOwnerPID(ofFileAt: vmDirContext.dir.configPath.path)
+        guard
+            let owner = VMProcessOwnerRegistry.validatedLockOwner(
+                for: vmDirContext.dir, using: runLockProbe)
         else {
-            try? fileHandle.close()
-            Logger.info(
-                "Failed to find process holding lock - VM may not be running",
-                metadata: ["name": vmDirContext.name])
-
-            // Even though we couldn't find the process, try to force unlock
-            unlockConfigFile()
-
-            throw VMError.notRunning(vmDirContext.name)
+            let reason = VMProcessOwnerRegistry.ownerRecordExists(for: vmDirContext.dir)
+                ? "an unverified VM owner process"
+                : "a legacy VM without a verified owner record"
+            Logger.error(
+                "Refusing to signal \(reason)", metadata: ["name": vmDirContext.name])
+            throw VMError.unverifiedProcessOwner(vmDirContext.name)
         }
+        let pid = owner.processIdentifier
 
         Logger.info(
-            "Found process \(pid) holding lock on config file",
-            metadata: ["name": vmDirContext.name])
+            "Found verified VM owner process \(pid)", metadata: ["name": vmDirContext.name])
 
         // First try graceful shutdown with SIGINT
         if kill(pid, SIGINT) == 0 {
@@ -821,8 +802,6 @@ class VM {
                 Logger.info("Process \(pid) has terminated", metadata: ["name": vmDirContext.name])
                 virtualizationService = nil
                 vncService.stop()
-                try? fileHandle.close()
-
                 // Force unlock the config file
                 unlockConfigFile()
 
@@ -834,7 +813,21 @@ class VM {
             attempts += 1
         }
 
-        // If graceful shutdown failed, force kill the process
+        // The PID may have been recycled while graceful shutdown was pending.
+        // Revalidate both its process instance and lock ownership before SIGKILL.
+        guard
+            VMProcessOwnerRegistry.validatedLockOwner(
+                for: vmDirContext.dir, using: runLockProbe) == owner
+        else {
+            Logger.info(
+                "VM owner exited before forced termination",
+                metadata: ["name": vmDirContext.name])
+            virtualizationService = nil
+            vncService.stop()
+            unlockConfigFile()
+            return
+        }
+
         Logger.info(
             "Graceful shutdown failed, forcing termination of process \(pid)",
             metadata: ["name": vmDirContext.name])
@@ -847,8 +840,6 @@ class VM {
             // Do final cleanup
             virtualizationService = nil
             vncService.stop()
-            try? fileHandle.close()
-
             // Force unlock the config file
             unlockConfigFile()
 
@@ -857,7 +848,6 @@ class VM {
         }
 
         // If we get here, something went very wrong
-        try? fileHandle.close()
         Logger.error(
             "Failed to stop VM - could not terminate process \(pid)",
             metadata: ["name": vmDirContext.name])

--- a/libs/lume/src/VM/VM.swift
+++ b/libs/lume/src/VM/VM.swift
@@ -229,7 +229,15 @@ class VM {
                 flock(retryHandle.fileDescriptor, LOCK_EX | LOCK_NB) == 0
             {
                 Logger.info("Emergency lock cleanup worked", metadata: ["name": vmDirContext.name])
-                fileHandle = retryHandle
+                // Continue with a fresh file handle
+                try? retryHandle.close()
+                // Get a completely new file handle to be safe
+                guard let newHandle = try? FileHandle(forWritingTo: vmDirContext.dir.configPath.url)
+                else {
+                    throw VMError.internalError("Failed to open file handle after lock cleanup")
+                }
+                // Update our main file handle
+                fileHandle = newHandle
             } else {
                 // If we still can't get the lock, give up
                 Logger.error(
@@ -702,32 +710,12 @@ class VM {
             }
         }
 
-        // Try to open config file to get file descriptor
-        Logger.info(
-            "Attempting to access config file lock",
-            metadata: [
-                "path": vmDirContext.dir.configPath.path,
-                "name": vmDirContext.name,
-            ])
-        let fileHandle = try? FileHandle(forReadingFrom: vmDirContext.dir.configPath.url)
-        guard let fileHandle = fileHandle else {
-            Logger.info(
-                "Failed to open config file - VM may not be running",
-                metadata: ["name": vmDirContext.name])
-
-            // Even though we couldn't open the file, try to force unlock anyway
-            unlockConfigFile()
-
-            throw VMError.notRunning(vmDirContext.name)
-        }
-
         let pid: pid_t
         if let owner = VMProcessOwnerRegistry.validatedOwner(for: vmDirContext.dir) {
             pid = owner.processIdentifier
             Logger.info(
                 "Found verified VM owner process \(pid)", metadata: ["name": vmDirContext.name])
         } else if VMProcessOwnerRegistry.ownerRecordExists(for: vmDirContext.dir) {
-            try? fileHandle.close()
             Logger.error(
                 "Refusing to signal an unverified VM owner process",
                 metadata: ["name": vmDirContext.name])
@@ -751,7 +739,6 @@ class VM {
                 let legacyPID = Self.legacyLockHolderPID(
                     fromLsofOutput: outputString, excluding: getpid())
             else {
-                try? fileHandle.close()
                 Logger.info(
                     "Failed to find legacy VM process holding lock",
                     metadata: ["name": vmDirContext.name])
@@ -783,8 +770,6 @@ class VM {
                 Logger.info("Process \(pid) has terminated", metadata: ["name": vmDirContext.name])
                 virtualizationService = nil
                 vncService.stop()
-                try? fileHandle.close()
-
                 // Force unlock the config file
                 unlockConfigFile()
 
@@ -809,8 +794,6 @@ class VM {
             // Do final cleanup
             virtualizationService = nil
             vncService.stop()
-            try? fileHandle.close()
-
             // Force unlock the config file
             unlockConfigFile()
 
@@ -819,7 +802,6 @@ class VM {
         }
 
         // If we get here, something went very wrong
-        try? fileHandle.close()
         Logger.error(
             "Failed to stop VM - could not terminate process \(pid)",
             metadata: ["name": vmDirContext.name])

--- a/libs/lume/src/VM/VM.swift
+++ b/libs/lume/src/VM/VM.swift
@@ -740,8 +740,7 @@ class VM {
 
         let outputData = try outputPipe.fileHandleForReading.readToEnd() ?? Data()
         guard let outputString = String(data: outputData, encoding: .utf8),
-            let pidString = outputString.split(separator: "\n").first?.dropFirst(),  // Drop the 'p' prefix
-            let pid = pid_t(pidString)
+            let pid = Self.lockHolderPID(fromLsofOutput: outputString, excluding: getpid())
         else {
             try? fileHandle.close()
             Logger.info(
@@ -822,6 +821,19 @@ class VM {
         unlockConfigFile()
 
         throw VMError.internalError("Failed to stop VM process")
+    }
+
+    nonisolated static func lockHolderPID(
+        fromLsofOutput output: String, excluding excludedPID: pid_t
+    )
+        -> pid_t?
+    {
+        output.split(separator: "\n")
+            .compactMap { line -> pid_t? in
+                guard line.first == "p" else { return nil }
+                return pid_t(line.dropFirst())
+            }
+            .first { $0 != excludedPID }
     }
 
     // Helper method to forcibly clear any locks on the config file

--- a/libs/lume/src/VM/VM.swift
+++ b/libs/lume/src/VM/VM.swift
@@ -229,15 +229,7 @@ class VM {
                 flock(retryHandle.fileDescriptor, LOCK_EX | LOCK_NB) == 0
             {
                 Logger.info("Emergency lock cleanup worked", metadata: ["name": vmDirContext.name])
-                // Continue with a fresh file handle
-                try? retryHandle.close()
-                // Get a completely new file handle to be safe
-                guard let newHandle = try? FileHandle(forWritingTo: vmDirContext.dir.configPath.url)
-                else {
-                    throw VMError.internalError("Failed to open file handle after lock cleanup")
-                }
-                // Update our main file handle
-                fileHandle = newHandle
+                fileHandle = retryHandle
             } else {
                 // If we still can't get the lock, give up
                 Logger.error(
@@ -250,6 +242,10 @@ class VM {
         defer {
             flock(fileHandle.fileDescriptor, LOCK_UN)
             try? fileHandle.close()
+        }
+        let processOwner = try VMProcessOwnerRegistry.register(vmDirectory: vmDirContext.dir)
+        defer {
+            VMProcessOwnerRegistry.unregister(processOwner, vmDirectory: vmDirContext.dir)
         }
         sessionCleanedUp = false
         activeSharedDirectories = sharedDirectories
@@ -725,32 +721,43 @@ class VM {
             throw VMError.notRunning(vmDirContext.name)
         }
 
-        // Get the PID of the process holding the lock using lsof command
-        Logger.info(
-            "Finding process holding lock on config file", metadata: ["name": vmDirContext.name])
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
-        task.arguments = ["-F", "p", vmDirContext.dir.configPath.path]
-
-        let outputPipe = Pipe()
-        task.standardOutput = outputPipe
-
-        try task.run()
-        task.waitUntilExit()
-
-        let outputData = try outputPipe.fileHandleForReading.readToEnd() ?? Data()
-        guard let outputString = String(data: outputData, encoding: .utf8),
-            let pid = Self.lockHolderPID(fromLsofOutput: outputString, excluding: getpid())
-        else {
-            try? fileHandle.close()
+        let pid: pid_t
+        if let owner = VMProcessOwnerRegistry.validatedOwner(for: vmDirContext.dir) {
+            pid = owner.processIdentifier
             Logger.info(
-                "Failed to find process holding lock - VM may not be running",
+                "Found verified VM owner process \(pid)", metadata: ["name": vmDirContext.name])
+        } else if VMProcessOwnerRegistry.ownerRecordExists(for: vmDirContext.dir) {
+            try? fileHandle.close()
+            Logger.error(
+                "Refusing to signal an unverified VM owner process",
                 metadata: ["name": vmDirContext.name])
-
-            // Even though we couldn't find the process, try to force unlock
-            unlockConfigFile()
-
             throw VMError.notRunning(vmDirContext.name)
+        } else {
+            // VMs started by older Lume versions have no owner record.
+            Logger.info(
+                "Finding legacy VM process holding the config lock",
+                metadata: ["name": vmDirContext.name])
+            let task = Process()
+            task.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
+            task.arguments = ["-F", "p", vmDirContext.dir.configPath.path]
+
+            let outputPipe = Pipe()
+            task.standardOutput = outputPipe
+            try task.run()
+            task.waitUntilExit()
+
+            let outputData = try outputPipe.fileHandleForReading.readToEnd() ?? Data()
+            guard let outputString = String(data: outputData, encoding: .utf8),
+                let legacyPID = Self.legacyLockHolderPID(
+                    fromLsofOutput: outputString, excluding: getpid())
+            else {
+                try? fileHandle.close()
+                Logger.info(
+                    "Failed to find legacy VM process holding lock",
+                    metadata: ["name": vmDirContext.name])
+                throw VMError.notRunning(vmDirContext.name)
+            }
+            pid = legacyPID
         }
 
         Logger.info(
@@ -823,7 +830,7 @@ class VM {
         throw VMError.internalError("Failed to stop VM process")
     }
 
-    nonisolated static func lockHolderPID(
+    nonisolated static func legacyLockHolderPID(
         fromLsofOutput output: String, excluding excludedPID: pid_t
     )
         -> pid_t?

--- a/libs/lume/src/VM/VMProcessOwner.swift
+++ b/libs/lume/src/VM/VMProcessOwner.swift
@@ -1,0 +1,80 @@
+import Darwin
+import Foundation
+
+struct VMProcessOwner: Codable, Equatable {
+  let processIdentifier: Int32
+  let startTimeSeconds: UInt64
+  let startTimeMicroseconds: UInt64
+
+  nonisolated static func current(processIdentifier: Int32 = getpid()) -> Self? {
+    guard processIdentifier > 0 else { return nil }
+
+    var processInfo = proc_bsdinfo()
+    let expectedSize = Int32(MemoryLayout<proc_bsdinfo>.size)
+    let actualSize = withUnsafeMutablePointer(to: &processInfo) { pointer in
+      proc_pidinfo(processIdentifier, PROC_PIDTBSDINFO, 0, pointer, expectedSize)
+    }
+    guard actualSize == expectedSize else { return nil }
+
+    return Self(
+      processIdentifier: processIdentifier,
+      startTimeSeconds: UInt64(processInfo.pbi_start_tvsec),
+      startTimeMicroseconds: UInt64(processInfo.pbi_start_tvusec)
+    )
+  }
+}
+
+enum VMProcessOwnerRegistry {
+  private nonisolated static let ownerFileName = ".vm-process-owner.json"
+
+  nonisolated static func register(vmDirectory: VMDirectory) throws -> VMProcessOwner {
+    guard let owner = VMProcessOwner.current() else {
+      throw VMError.internalError("Failed to identify the VM owner process")
+    }
+
+    let fileURL = ownerURL(for: vmDirectory)
+    try JSONEncoder().encode(owner).write(to: fileURL, options: .atomic)
+    chmod(fileURL.path, S_IRUSR | S_IWUSR)
+    return owner
+  }
+
+  nonisolated static func unregister(_ owner: VMProcessOwner, vmDirectory: VMDirectory) {
+    let fileURL = ownerURL(for: vmDirectory)
+    guard read(from: fileURL) == owner else { return }
+    try? FileManager.default.removeItem(at: fileURL)
+  }
+
+  nonisolated static func validatedOwner(for vmDirectory: VMDirectory) -> VMProcessOwner? {
+    guard let owner = read(from: ownerURL(for: vmDirectory)),
+      VMProcessOwner.current(processIdentifier: owner.processIdentifier) == owner
+    else {
+      return nil
+    }
+    return owner
+  }
+
+  nonisolated static func validatedLockOwner(
+    for vmDirectory: VMDirectory, using runLockProbe: RunLockProbe
+  ) -> VMProcessOwner? {
+    guard let owner = validatedOwner(for: vmDirectory),
+      runLockProbe.isLiveLockHolder(
+        pid: owner.processIdentifier, ofFileAt: vmDirectory.configPath.path) == true
+    else {
+      return nil
+    }
+    return owner
+  }
+
+  nonisolated static func ownerRecordExists(for vmDirectory: VMDirectory) -> Bool {
+    FileManager.default.fileExists(atPath: ownerURL(for: vmDirectory).path)
+  }
+
+  private nonisolated static func read(from fileURL: URL) -> VMProcessOwner? {
+    guard let data = try? Data(contentsOf: fileURL) else { return nil }
+    return try? JSONDecoder().decode(VMProcessOwner.self, from: data)
+  }
+
+  private nonisolated static func ownerURL(for vmDirectory: VMDirectory) -> URL {
+    vmDirectory.dir.file(ownerFileName).url
+  }
+}

--- a/libs/lume/src/VM/VMProcessOwner.swift
+++ b/libs/lume/src/VM/VMProcessOwner.swift
@@ -1,11 +1,10 @@
 import Darwin
 import Foundation
 
-struct VMProcessFingerprint: Codable, Equatable {
+struct VMProcessOwner: Codable, Equatable {
   let processIdentifier: Int32
   let startTimeSeconds: UInt64
   let startTimeMicroseconds: UInt64
-  let executablePath: String
 
   nonisolated static func current(processIdentifier: Int32 = getpid()) -> Self? {
     guard processIdentifier > 0 else { return nil }
@@ -17,38 +16,22 @@ struct VMProcessFingerprint: Codable, Equatable {
     }
     guard actualSize == expectedSize else { return nil }
 
-    var executablePath = [CChar](repeating: 0, count: 4 * Int(MAXPATHLEN))
-    guard proc_pidpath(processIdentifier, &executablePath, UInt32(executablePath.count)) > 0 else {
-      return nil
-    }
-
-    let executableLength = executablePath.firstIndex(of: 0) ?? executablePath.endIndex
     return Self(
       processIdentifier: processIdentifier,
       startTimeSeconds: UInt64(processInfo.pbi_start_tvsec),
-      startTimeMicroseconds: UInt64(processInfo.pbi_start_tvusec),
-      executablePath: String(
-        decoding: executablePath[..<executableLength].map(UInt8.init(bitPattern:)), as: UTF8.self)
+      startTimeMicroseconds: UInt64(processInfo.pbi_start_tvusec)
     )
   }
-}
-
-struct VMProcessOwner: Codable, Equatable {
-  let fingerprint: VMProcessFingerprint
-  let generation: UUID
-
-  var processIdentifier: Int32 { fingerprint.processIdentifier }
 }
 
 enum VMProcessOwnerRegistry {
   private nonisolated static let ownerFileName = ".vm-process-owner.json"
 
   nonisolated static func register(vmDirectory: VMDirectory) throws -> VMProcessOwner {
-    guard let fingerprint = VMProcessFingerprint.current() else {
+    guard let owner = VMProcessOwner.current() else {
       throw VMError.internalError("Failed to identify the VM owner process")
     }
 
-    let owner = VMProcessOwner(fingerprint: fingerprint, generation: UUID())
     let fileURL = ownerURL(for: vmDirectory)
     try JSONEncoder().encode(owner).write(to: fileURL, options: .atomic)
     chmod(fileURL.path, S_IRUSR | S_IWUSR)
@@ -63,7 +46,7 @@ enum VMProcessOwnerRegistry {
 
   nonisolated static func validatedOwner(for vmDirectory: VMDirectory) -> VMProcessOwner? {
     guard let owner = read(from: ownerURL(for: vmDirectory)),
-      VMProcessFingerprint.current(processIdentifier: owner.processIdentifier) == owner.fingerprint
+      VMProcessOwner.current(processIdentifier: owner.processIdentifier) == owner
     else {
       return nil
     }

--- a/libs/lume/src/VM/VMProcessOwner.swift
+++ b/libs/lume/src/VM/VMProcessOwner.swift
@@ -1,0 +1,85 @@
+import Darwin
+import Foundation
+
+struct VMProcessFingerprint: Codable, Equatable {
+  let processIdentifier: Int32
+  let startTimeSeconds: UInt64
+  let startTimeMicroseconds: UInt64
+  let executablePath: String
+
+  nonisolated static func current(processIdentifier: Int32 = getpid()) -> Self? {
+    guard processIdentifier > 0 else { return nil }
+
+    var processInfo = proc_bsdinfo()
+    let expectedSize = Int32(MemoryLayout<proc_bsdinfo>.size)
+    let actualSize = withUnsafeMutablePointer(to: &processInfo) { pointer in
+      proc_pidinfo(processIdentifier, PROC_PIDTBSDINFO, 0, pointer, expectedSize)
+    }
+    guard actualSize == expectedSize else { return nil }
+
+    var executablePath = [CChar](repeating: 0, count: 4 * Int(MAXPATHLEN))
+    guard proc_pidpath(processIdentifier, &executablePath, UInt32(executablePath.count)) > 0 else {
+      return nil
+    }
+
+    let executableLength = executablePath.firstIndex(of: 0) ?? executablePath.endIndex
+    return Self(
+      processIdentifier: processIdentifier,
+      startTimeSeconds: UInt64(processInfo.pbi_start_tvsec),
+      startTimeMicroseconds: UInt64(processInfo.pbi_start_tvusec),
+      executablePath: String(
+        decoding: executablePath[..<executableLength].map(UInt8.init(bitPattern:)), as: UTF8.self)
+    )
+  }
+}
+
+struct VMProcessOwner: Codable, Equatable {
+  let fingerprint: VMProcessFingerprint
+  let generation: UUID
+
+  var processIdentifier: Int32 { fingerprint.processIdentifier }
+}
+
+enum VMProcessOwnerRegistry {
+  private nonisolated static let ownerFileName = ".vm-process-owner.json"
+
+  nonisolated static func register(vmDirectory: VMDirectory) throws -> VMProcessOwner {
+    guard let fingerprint = VMProcessFingerprint.current() else {
+      throw VMError.internalError("Failed to identify the VM owner process")
+    }
+
+    let owner = VMProcessOwner(fingerprint: fingerprint, generation: UUID())
+    let fileURL = ownerURL(for: vmDirectory)
+    try JSONEncoder().encode(owner).write(to: fileURL, options: .atomic)
+    chmod(fileURL.path, S_IRUSR | S_IWUSR)
+    return owner
+  }
+
+  nonisolated static func unregister(_ owner: VMProcessOwner, vmDirectory: VMDirectory) {
+    let fileURL = ownerURL(for: vmDirectory)
+    guard read(from: fileURL) == owner else { return }
+    try? FileManager.default.removeItem(at: fileURL)
+  }
+
+  nonisolated static func validatedOwner(for vmDirectory: VMDirectory) -> VMProcessOwner? {
+    guard let owner = read(from: ownerURL(for: vmDirectory)),
+      VMProcessFingerprint.current(processIdentifier: owner.processIdentifier) == owner.fingerprint
+    else {
+      return nil
+    }
+    return owner
+  }
+
+  nonisolated static func ownerRecordExists(for vmDirectory: VMDirectory) -> Bool {
+    FileManager.default.fileExists(atPath: ownerURL(for: vmDirectory).path)
+  }
+
+  private nonisolated static func read(from fileURL: URL) -> VMProcessOwner? {
+    guard let data = try? Data(contentsOf: fileURL) else { return nil }
+    return try? JSONDecoder().decode(VMProcessOwner.self, from: data)
+  }
+
+  private nonisolated static func ownerURL(for vmDirectory: VMDirectory) -> URL {
+    vmDirectory.dir.file(ownerFileName).url
+  }
+}

--- a/libs/lume/tests/VMTests.swift
+++ b/libs/lume/tests/VMTests.swift
@@ -11,6 +11,14 @@ class MockProcessRunner: ProcessRunner {
     }
 }
 
+private struct VMOwnerRunLockProbe: RunLockProbe {
+    let processIdentifiers: [pid_t]
+
+    func lockHolderPIDs(ofFileAt path: String) -> [pid_t]? {
+        processIdentifiers
+    }
+}
+
 private func setupVMDirectory(_ tempDir: URL) throws -> VMDirectory {
     let vmDir = VMDirectory(Path(tempDir.path))
 
@@ -109,6 +117,104 @@ func testVMRunAndStop() async throws {
     // Test stopping VM
     try await vm.stop()
     runTask.cancel()
+}
+
+@MainActor
+@Test("Legacy VM stop does not signal an unrelated config reader")
+func testLegacyVMStopRefusesUnverifiedConfigReaders() async throws {
+    let tempDir = try createTempDirectory()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+    let vmDir = try setupVMDirectory(tempDir)
+    let lockHandle = try FileHandle(forWritingTo: vmDir.configPath.url)
+    #expect(flock(lockHandle.fileDescriptor, LOCK_EX | LOCK_NB) == 0)
+    defer {
+        flock(lockHandle.fileDescriptor, LOCK_UN)
+        try? lockHandle.close()
+    }
+
+    let readerHandle = try FileHandle(forReadingFrom: vmDir.configPath.url)
+    let unrelatedReader = Process()
+    unrelatedReader.executableURL = URL(fileURLWithPath: "/bin/sleep")
+    unrelatedReader.arguments = ["60"]
+    unrelatedReader.standardInput = readerHandle
+    try unrelatedReader.run()
+    try readerHandle.close()
+    defer {
+        if unrelatedReader.isRunning {
+            unrelatedReader.terminate()
+        }
+        unrelatedReader.waitUntilExit()
+    }
+
+    let context = VMDirContext(
+        dir: vmDir,
+        config: try vmDir.loadConfig(),
+        home: Home(fileManager: FileManager.default),
+        storage: nil)
+    let vm = MockVM(
+        vmDirContext: context,
+        virtualizationServiceFactory: { _ in MockVMVirtualizationService() },
+        vncServiceFactory: { MockVNCService(vmDirectory: $0) }
+    )
+
+    do {
+        try await vm.stop()
+        Issue.record("Expected stop to reject the unverified legacy VM")
+    } catch VMError.unverifiedProcessOwner(let name) {
+        #expect(name == vmDir.name)
+    } catch {
+        Issue.record("Unexpected stop error: \(error)")
+    }
+    #expect(unrelatedReader.isRunning)
+}
+
+@Test("VM owner registry validates the current process and removes its record")
+func testVMOwnerRegistryLifecycle() throws {
+    let tempDir = try createTempDirectory()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+    let vmDirectory = VMDirectory(Path(tempDir.path))
+
+    let owner = try VMProcessOwnerRegistry.register(vmDirectory: vmDirectory)
+    #expect(VMProcessOwnerRegistry.validatedOwner(for: vmDirectory) == owner)
+    #expect(owner.processIdentifier == getpid())
+
+    VMProcessOwnerRegistry.unregister(owner, vmDirectory: vmDirectory)
+    #expect(!VMProcessOwnerRegistry.ownerRecordExists(for: vmDirectory))
+}
+
+@Test("VM owner registry requires the recorded process to hold the run lock")
+func testVMOwnerRegistryRequiresRunLockOwnership() throws {
+    let tempDir = try createTempDirectory()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+    let vmDirectory = VMDirectory(Path(tempDir.path))
+    let owner = try VMProcessOwnerRegistry.register(vmDirectory: vmDirectory)
+
+    let ownerProbe = VMOwnerRunLockProbe(processIdentifiers: [owner.processIdentifier])
+    #expect(
+        VMProcessOwnerRegistry.validatedLockOwner(for: vmDirectory, using: ownerProbe) == owner)
+
+    let unrelatedReaderProbe = VMOwnerRunLockProbe(
+        processIdentifiers: [owner.processIdentifier + 1])
+    #expect(
+        VMProcessOwnerRegistry.validatedLockOwner(
+            for: vmDirectory, using: unrelatedReaderProbe) == nil)
+}
+
+@Test("VM owner registry rejects a reused process identifier")
+func testVMOwnerRegistryRejectsReusedProcessIdentifier() throws {
+    let tempDir = try createTempDirectory()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+    let vmDirectory = VMDirectory(Path(tempDir.path))
+    let owner = try VMProcessOwnerRegistry.register(vmDirectory: vmDirectory)
+    let staleOwner = VMProcessOwner(
+        processIdentifier: owner.processIdentifier,
+        startTimeSeconds: owner.startTimeSeconds + 1,
+        startTimeMicroseconds: owner.startTimeMicroseconds)
+    let ownerFile = vmDirectory.dir.file(".vm-process-owner.json").url
+    try JSONEncoder().encode(staleOwner).write(to: ownerFile, options: .atomic)
+
+    #expect(VMProcessOwnerRegistry.validatedOwner(for: vmDirectory) == nil)
+    #expect(VMProcessOwnerRegistry.ownerRecordExists(for: vmDirectory))
 }
 
 @MainActor

--- a/libs/lume/tests/VMTests.swift
+++ b/libs/lume/tests/VMTests.swift
@@ -111,6 +111,33 @@ func testVMRunAndStop() async throws {
     runTask.cancel()
 }
 
+@Test("VM lock holder selection excludes the stopping process")
+func testVMLockHolderSelectionExcludesSelf() {
+    let output = """
+        p91633
+        p98700
+        """
+
+    #expect(VM.lockHolderPID(fromLsofOutput: output, excluding: 91633) == 98700)
+}
+
+@Test("VM lock holder selection ignores malformed lsof records")
+func testVMLockHolderSelectionIgnoresMalformedRecords() {
+    let output = """
+        f12
+        pnot-a-pid
+        nconfig.json
+        p98700
+        """
+
+    #expect(VM.lockHolderPID(fromLsofOutput: output, excluding: 91633) == 98700)
+}
+
+@Test("VM lock holder selection rejects an output containing only self")
+func testVMLockHolderSelectionRejectsOnlySelf() {
+    #expect(VM.lockHolderPID(fromLsofOutput: "p91633\n", excluding: 91633) == nil)
+}
+
 @MainActor
 @Test("VM configuration updates")
 func testVMConfigurationUpdates() async throws {

--- a/libs/lume/tests/VMTests.swift
+++ b/libs/lume/tests/VMTests.swift
@@ -111,44 +111,21 @@ func testVMRunAndStop() async throws {
     runTask.cancel()
 }
 
-@Test("VM lock holder selection excludes the stopping process")
-func testVMLockHolderSelectionExcludesSelf() {
-    let output = """
-        p91633
-        p98700
-        """
-
-    #expect(VM.legacyLockHolderPID(fromLsofOutput: output, excluding: 91633) == 98700)
-}
-
-@Test("VM lock holder selection ignores malformed lsof records")
-func testVMLockHolderSelectionIgnoresMalformedRecords() {
+@Test("Legacy VM lock holder selection excludes self and malformed records")
+func testLegacyVMLockHolderSelection() {
     let output = """
         f12
+        p91633
         pnot-a-pid
         nconfig.json
         p98700
         """
 
     #expect(VM.legacyLockHolderPID(fromLsofOutput: output, excluding: 91633) == 98700)
-}
-
-@Test("VM lock holder selection rejects an output containing only self")
-func testVMLockHolderSelectionRejectsOnlySelf() {
     #expect(VM.legacyLockHolderPID(fromLsofOutput: "p91633\n", excluding: 91633) == nil)
 }
 
-@Test("VM process fingerprint identifies the current process instance")
-func testVMProcessFingerprintIdentifiesCurrentProcess() throws {
-    let first = try #require(VMProcessFingerprint.current())
-    let second = try #require(VMProcessFingerprint.current())
-
-    #expect(first == second)
-    #expect(first.processIdentifier == getpid())
-    #expect(!first.executablePath.isEmpty)
-}
-
-@Test("VM owner registry validates and removes its own record")
+@Test("VM owner registry validates the current process and removes its record")
 func testVMOwnerRegistryLifecycle() throws {
     let tempDir = try createTempDirectory()
     defer { try? FileManager.default.removeItem(at: tempDir) }
@@ -156,22 +133,10 @@ func testVMOwnerRegistryLifecycle() throws {
 
     let owner = try VMProcessOwnerRegistry.register(vmDirectory: vmDirectory)
     #expect(VMProcessOwnerRegistry.validatedOwner(for: vmDirectory) == owner)
+    #expect(owner.processIdentifier == getpid())
 
     VMProcessOwnerRegistry.unregister(owner, vmDirectory: vmDirectory)
     #expect(!VMProcessOwnerRegistry.ownerRecordExists(for: vmDirectory))
-}
-
-@Test("VM owner cleanup preserves a replacement generation")
-func testVMOwnerCleanupPreservesReplacementGeneration() throws {
-    let tempDir = try createTempDirectory()
-    defer { try? FileManager.default.removeItem(at: tempDir) }
-    let vmDirectory = VMDirectory(Path(tempDir.path))
-
-    let oldOwner = try VMProcessOwnerRegistry.register(vmDirectory: vmDirectory)
-    let replacementOwner = try VMProcessOwnerRegistry.register(vmDirectory: vmDirectory)
-    VMProcessOwnerRegistry.unregister(oldOwner, vmDirectory: vmDirectory)
-
-    #expect(VMProcessOwnerRegistry.validatedOwner(for: vmDirectory) == replacementOwner)
 }
 
 @Test("VM owner registry rejects a reused process identifier")
@@ -180,13 +145,10 @@ func testVMOwnerRegistryRejectsReusedProcessIdentifier() throws {
     defer { try? FileManager.default.removeItem(at: tempDir) }
     let vmDirectory = VMDirectory(Path(tempDir.path))
     let owner = try VMProcessOwnerRegistry.register(vmDirectory: vmDirectory)
-    let staleFingerprint = VMProcessFingerprint(
-        processIdentifier: owner.processIdentifier,
-        startTimeSeconds: owner.fingerprint.startTimeSeconds + 1,
-        startTimeMicroseconds: owner.fingerprint.startTimeMicroseconds,
-        executablePath: owner.fingerprint.executablePath)
     let staleOwner = VMProcessOwner(
-        fingerprint: staleFingerprint, generation: owner.generation)
+        processIdentifier: owner.processIdentifier,
+        startTimeSeconds: owner.startTimeSeconds + 1,
+        startTimeMicroseconds: owner.startTimeMicroseconds)
     let ownerFile = vmDirectory.dir.file(".vm-process-owner.json").url
     try JSONEncoder().encode(staleOwner).write(to: ownerFile, options: .atomic)
 

--- a/libs/lume/tests/VMTests.swift
+++ b/libs/lume/tests/VMTests.swift
@@ -118,7 +118,7 @@ func testVMLockHolderSelectionExcludesSelf() {
         p98700
         """
 
-    #expect(VM.lockHolderPID(fromLsofOutput: output, excluding: 91633) == 98700)
+    #expect(VM.legacyLockHolderPID(fromLsofOutput: output, excluding: 91633) == 98700)
 }
 
 @Test("VM lock holder selection ignores malformed lsof records")
@@ -130,12 +130,68 @@ func testVMLockHolderSelectionIgnoresMalformedRecords() {
         p98700
         """
 
-    #expect(VM.lockHolderPID(fromLsofOutput: output, excluding: 91633) == 98700)
+    #expect(VM.legacyLockHolderPID(fromLsofOutput: output, excluding: 91633) == 98700)
 }
 
 @Test("VM lock holder selection rejects an output containing only self")
 func testVMLockHolderSelectionRejectsOnlySelf() {
-    #expect(VM.lockHolderPID(fromLsofOutput: "p91633\n", excluding: 91633) == nil)
+    #expect(VM.legacyLockHolderPID(fromLsofOutput: "p91633\n", excluding: 91633) == nil)
+}
+
+@Test("VM process fingerprint identifies the current process instance")
+func testVMProcessFingerprintIdentifiesCurrentProcess() throws {
+    let first = try #require(VMProcessFingerprint.current())
+    let second = try #require(VMProcessFingerprint.current())
+
+    #expect(first == second)
+    #expect(first.processIdentifier == getpid())
+    #expect(!first.executablePath.isEmpty)
+}
+
+@Test("VM owner registry validates and removes its own record")
+func testVMOwnerRegistryLifecycle() throws {
+    let tempDir = try createTempDirectory()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+    let vmDirectory = VMDirectory(Path(tempDir.path))
+
+    let owner = try VMProcessOwnerRegistry.register(vmDirectory: vmDirectory)
+    #expect(VMProcessOwnerRegistry.validatedOwner(for: vmDirectory) == owner)
+
+    VMProcessOwnerRegistry.unregister(owner, vmDirectory: vmDirectory)
+    #expect(!VMProcessOwnerRegistry.ownerRecordExists(for: vmDirectory))
+}
+
+@Test("VM owner cleanup preserves a replacement generation")
+func testVMOwnerCleanupPreservesReplacementGeneration() throws {
+    let tempDir = try createTempDirectory()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+    let vmDirectory = VMDirectory(Path(tempDir.path))
+
+    let oldOwner = try VMProcessOwnerRegistry.register(vmDirectory: vmDirectory)
+    let replacementOwner = try VMProcessOwnerRegistry.register(vmDirectory: vmDirectory)
+    VMProcessOwnerRegistry.unregister(oldOwner, vmDirectory: vmDirectory)
+
+    #expect(VMProcessOwnerRegistry.validatedOwner(for: vmDirectory) == replacementOwner)
+}
+
+@Test("VM owner registry rejects a reused process identifier")
+func testVMOwnerRegistryRejectsReusedProcessIdentifier() throws {
+    let tempDir = try createTempDirectory()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+    let vmDirectory = VMDirectory(Path(tempDir.path))
+    let owner = try VMProcessOwnerRegistry.register(vmDirectory: vmDirectory)
+    let staleFingerprint = VMProcessFingerprint(
+        processIdentifier: owner.processIdentifier,
+        startTimeSeconds: owner.fingerprint.startTimeSeconds + 1,
+        startTimeMicroseconds: owner.fingerprint.startTimeMicroseconds,
+        executablePath: owner.fingerprint.executablePath)
+    let staleOwner = VMProcessOwner(
+        fingerprint: staleFingerprint, generation: owner.generation)
+    let ownerFile = vmDirectory.dir.file(".vm-process-owner.json").url
+    try JSONEncoder().encode(staleOwner).write(to: ownerFile, options: .atomic)
+
+    #expect(VMProcessOwnerRegistry.validatedOwner(for: vmDirectory) == nil)
+    #expect(VMProcessOwnerRegistry.ownerRecordExists(for: vmDirectory))
 }
 
 @MainActor


### PR DESCRIPTION
## what changed

`lume run` now writes a per-vm owner record after acquiring the config lock. the record contains the process id and macos process start time.

`lume stop` removes its unnecessary read-only config handle, validates the recorded process identity, and proves that process still holds the vm config lock before sending sigint. it repeats both checks before sigkill, so a recycled pid cannot receive either signal.

vms started by older lume builds have no trustworthy owner record. `lume stop` now refuses to guess their process from `lsof` output and tells the user to stop the vm from the terminal that started it.

## root cause

the stop process opened the config file and then treated the first process reported by `lsof` as the lock owner. `lsof` reports every process with the file open, so lume could signal itself or an unrelated editor, indexer, or reader. the new path records the owner when the lock is acquired instead of inferring ownership from arbitrary file openers.

## impact

new vm runs stop only through a verified owner identity. existing running vms started by older lume builds fail closed and must be stopped from their originating terminal.

## related issues

closes #2695.

## validation

- exact-head `CI: Lume` at `c096a299ac193d621e36537de33bf15766e2fa0a`: release build and `swift test` passed ([run](https://github.com/trycua/cua/actions/runs/32404517773))
- `git diff --check`
