### PR TITLE
fix(fleet): promote cua-train 0.1.4 wheels

### DIFF
--- a/.github/scripts/repackage_cua_train_wheel.py
+++ b/.github/scripts/repackage_cua_train_wheel.py
@@ -14,7 +14,7 @@ import sys
 import zipfile
 
 SOURCE_NAME = "cua-train"
-SOURCE_VERSION = "0.1.3"
+SOURCE_VERSION = "0.1.4"
 DESTINATION_NAME = "cua-fleet"
 WHEEL_FILENAME = re.compile(
     r"^(?P<distribution>[A-Za-z0-9_]+)-(?P<version>[^-]+)-py3-none-(?P<platform>[^-]+)\.whl$"
@@ -119,7 +119,7 @@ def repack(
 
     metadata = parse_metadata(entries[metadata_name])
     if metadata.get("Name") != SOURCE_NAME or metadata.get("Version") != SOURCE_VERSION:
-        raise WheelError("source METADATA does not identify cua-train==0.1.3")
+        raise WheelError("source METADATA does not identify cua-train==0.1.4")
     wheel_metadata = entries[wheel_name].decode()
     if (
         "Root-Is-Purelib: false" not in wheel_metadata

--- a/.github/scripts/tests/test_cua_fleet_release_wiring.py
+++ b/.github/scripts/tests/test_cua_fleet_release_wiring.py
@@ -1,0 +1,29 @@
+"""Regression tests for the canonical cua-fleet PyPI release workflow."""
+
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class TestCuaFleetReleaseWiring(unittest.TestCase):
+    """Keep Fleet's promotion workflow aligned with the published train wheel."""
+
+    def test_publisher_promotes_cua_train_0_1_4(self) -> None:
+        workflow = (REPO_ROOT / ".github/workflows/cd-py-fleet.yml").read_text()
+        repackager = (REPO_ROOT / ".github/scripts/repackage_cua_train_wheel.py").read_text()
+        expected_sources = {
+            "cua_train-0.1.4-py3-none-manylinux_2_34_x86_64.whl": "8b2c20a603772408ad25629e5fa16bfc36bb81ed6a876fd99f1ccfab5c242252",
+            "cua_train-0.1.4-py3-none-manylinux_2_34_aarch64.whl": "d0ea3e67a67c394ca05fad227ddd53987b53fbfbff907e43aa2ac6476f941df4",
+            "cua_train-0.1.4-py3-none-macosx_10_12_x86_64.whl": "20e59a46ae5bc20bc48e34bc8b0c8b623682068be5c31b430477bdf57e946745",
+            "cua_train-0.1.4-py3-none-macosx_11_0_arm64.whl": "cf5f4e26f77b4438849b5e6216829422980150439a88aa9a62a78dab74a95eb6",
+        }
+
+        self.assertIn('SOURCE_VERSION = "0.1.4"', repackager)
+        for wheel, digest in expected_sources.items():
+            self.assertIn(f"wheel: {wheel}\n            sha256: {digest}", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_repackage_cua_train_wheel.py
+++ b/.github/scripts/tests/test_repackage_cua_train_wheel.py
@@ -26,12 +26,12 @@ def _csv(rows: list[list[str]]) -> bytes:
 
 
 def _write_source_wheel(path: Path) -> dict[str, bytes]:
-    dist_info = "cua_train-0.1.3.dist-info"
+    dist_info = "cua_train-0.1.4.dist-info"
     entries = {
         "cua_train/__init__.py": b"TrainClient = object\n",
         "fleet_sdk/__init__.py": b"CyclopsClient = object\n",
         "fleet_sdk/libcyclops_sdk.so": b"native payload",
-        f"{dist_info}/METADATA": b"Metadata-Version: 2.4\nName: cua-train\nVersion: 0.1.3\nDescription-Content-Type: text/markdown\n\n",
+        f"{dist_info}/METADATA": b"Metadata-Version: 2.4\nName: cua-train\nVersion: 0.1.4\nDescription-Content-Type: text/markdown\n\n",
         f"{dist_info}/WHEEL": b"Wheel-Version: 1.0\nRoot-Is-Purelib: false\nTag: py3-none-manylinux_2_34_x86_64\n",
     }
     record_name = f"{dist_info}/RECORD"
@@ -45,7 +45,7 @@ def _write_source_wheel(path: Path) -> dict[str, bytes]:
 
 
 def test_repack_changes_only_distribution_metadata(tmp_path: Path):
-    source = tmp_path / "cua_train-0.1.3-py3-none-manylinux_2_34_x86_64.whl"
+    source = tmp_path / "cua_train-0.1.4-py3-none-manylinux_2_34_x86_64.whl"
     source_entries = _write_source_wheel(source)
 
     destination = repack(
@@ -67,7 +67,7 @@ def test_repack_changes_only_distribution_metadata(tmp_path: Path):
 
 
 def test_repack_rejects_unpinned_source(tmp_path: Path):
-    source = tmp_path / "cua_train-0.1.3-py3-none-manylinux_2_34_x86_64.whl"
+    source = tmp_path / "cua_train-0.1.4-py3-none-manylinux_2_34_x86_64.whl"
     _write_source_wheel(source)
 
     with pytest.raises(WheelError, match="SHA-256 mismatch"):

--- a/.github/workflows/cd-py-fleet.yml
+++ b/.github/workflows/cd-py-fleet.yml
@@ -86,26 +86,26 @@ jobs:
         include:
           - platform: linux-x86_64
             runner: ubuntu-22.04
-            wheel: cua_train-0.1.3-py3-none-manylinux_2_34_x86_64.whl
-            sha256: 7e12c5c5e413cf927bafd443af572c74c8ce41fed889c9712e656c31b77c9a9a
+            wheel: cua_train-0.1.4-py3-none-manylinux_2_34_x86_64.whl
+            sha256: 8b2c20a603772408ad25629e5fa16bfc36bb81ed6a876fd99f1ccfab5c242252
             library_suffix: .so
             audit: auditwheel
           - platform: linux-aarch64
             runner: ubuntu-24.04-arm
-            wheel: cua_train-0.1.3-py3-none-manylinux_2_34_aarch64.whl
-            sha256: 360cba8ba294151a105009fde751be7fc231d69449905013333a05dbb4284cc2
+            wheel: cua_train-0.1.4-py3-none-manylinux_2_34_aarch64.whl
+            sha256: d0ea3e67a67c394ca05fad227ddd53987b53fbfbff907e43aa2ac6476f941df4
             library_suffix: .so
             audit: auditwheel
           - platform: macos-x86_64
             runner: macos-15-intel
-            wheel: cua_train-0.1.3-py3-none-macosx_10_12_x86_64.whl
-            sha256: e173c7d8cadae2bd5df36216d9587d67d4f6cfa064b97afce153c9ac7435b745
+            wheel: cua_train-0.1.4-py3-none-macosx_10_12_x86_64.whl
+            sha256: 20e59a46ae5bc20bc48e34bc8b0c8b623682068be5c31b430477bdf57e946745
             library_suffix: .dylib
             audit: delocate
           - platform: macos-arm64
             runner: macos-14
-            wheel: cua_train-0.1.3-py3-none-macosx_11_0_arm64.whl
-            sha256: a04b30f94d27cd29538ca366f5926b5127b73e003fc8bf2bba7e53d69d5e8af0
+            wheel: cua_train-0.1.4-py3-none-macosx_11_0_arm64.whl
+            sha256: cf5f4e26f77b4438849b5e6216829422980150439a88aa9a62a78dab74a95eb6
             library_suffix: .dylib
             audit: delocate
     steps:


### PR DESCRIPTION
Updates the canonical CUA Fleet PyPI publisher for the `cua-train 0.1.4` SDK release.

The mirrored Fleet package was already updated to `0.0.8` / `cua-train==0.1.4`, but `cd-py-fleet.yml` and its repackage helper still referenced `0.1.3` wheels and hashes.

This PR changes only CUA release automation (outside `libs/fleet/`) and adds a regression test covering all four published source-wheel hashes.

Verification:
- `python3 .github/scripts/tests/test_cua_fleet_release_wiring.py -v`
- Real Linux `cua-train 0.1.4` download, repackage to `cua-fleet 0.0.8`, and wheel verification.