### PR TITLE
feat(sandbox): reconcile Fleet pools through SDK

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/pool.py
+++ b/libs/python/cua-sandbox/cua_sandbox/pool.py
@@ -62,14 +62,7 @@ class Pool:
         )._pool_request()
         client = _FleetClient()
         try:
-            try:
-                resource = await client.get_pool(name)
-            except LookupError:
-                resource = await client.create_pool(desired)
-            else:
-                resource.spec = desired.spec
-                resource = await client.update_pool(resource)
-            return cls(resource)
+            return cls(await client.reconcile_pool(desired))
         finally:
             await client.close()
 

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -67,6 +67,9 @@ class _FleetClient:
     async def create_pool(self, request: CreatePoolRequest) -> Any:
         return await self._client.create_pool(request)
 
+    async def reconcile_pool(self, request: CreatePoolRequest) -> Any:
+        return await self._client.reconcile_pool(request)
+
     async def create_claim(self, request: CreateClaimRequest) -> Any:
         return await self._client.create_claim(request)
 

--- a/libs/python/cua-sandbox/pyproject.toml
+++ b/libs/python/cua-sandbox/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = ">=3.11,<3.14"
 dependencies = [
     "cua-core>=0.3.0,<0.4.0",
     "cua-auto>=0.1.2",
-    "cua-fleet==0.0.7",
+    "cua-fleet==0.0.8",
     "websockets>=12.0",
     "httpx>=0.27.0",
     "oras>=0.2.40",

--- a/libs/python/cua-sandbox/tests/test_fleet_sdk_packaging.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_sdk_packaging.py
@@ -19,7 +19,7 @@ class FleetSdkPackagingTests(unittest.TestCase):
 
         self.assertEqual(project["project"]["version"], "0.1.20")
         dependencies = project["project"]["dependencies"]
-        self.assertIn("cua-fleet==0.0.7", dependencies)
+        self.assertIn("cua-fleet==0.0.8", dependencies)
         self.assertFalse(any(dependency.startswith("cua-train") for dependency in dependencies))
         self.assertNotIn("cua-fleet", project["tool"]["uv"]["sources"])
         self.assertNotIn("cua-train", project["tool"]["uv"]["sources"])
@@ -50,7 +50,7 @@ class FleetSdkPackagingTests(unittest.TestCase):
         self.assertNotIn("cua-train", sandbox_dependencies)
         self.assertIn("cua-fleet", sandbox_requires_dist)
         self.assertNotIn("cua-train", sandbox_requires_dist)
-        self.assertEqual(packages["cua-fleet"]["version"], "0.0.7")
+        self.assertEqual(packages["cua-fleet"]["version"], "0.0.8")
         self.assertEqual(packages["cua-fleet"]["source"], {"registry": "https://pypi.org/simple"})
         self.assertNotIn("cua-train", fleet_dependencies)
         self.assertNotIn("cua-train", packages)

--- a/libs/python/cua-sandbox/tests/test_pool.py
+++ b/libs/python/cua-sandbox/tests/test_pool.py
@@ -21,33 +21,23 @@ class FakeFleetClient:
         self,
         *,
         existing: object | None = None,
-        create_error: Exception | None = None,
+        reconcile_error: Exception | None = None,
         release_error: Exception | None = None,
     ):
         self.existing = existing
-        self.create_error = create_error
+        self.reconcile_error = reconcile_error
         self.release_error = release_error
-        self.created: list[object] = []
-        self.updated: list[object] = []
+        self.reconciled: list[object] = []
         self.claims: list[object] = []
         self.released: list[object] = []
         self.service_requests: list[object] = []
         self.closed = False
 
-    async def get_pool(self, name: str) -> object:
-        if self.existing is None:
-            raise LookupError(name)
-        return self.existing
-
-    async def create_pool(self, request: object) -> object:
-        self.created.append(request)
-        if self.create_error:
-            raise self.create_error
-        return fleet_pool(request.namespace)
-
-    async def update_pool(self, pool: object) -> object:
-        self.updated.append(pool)
-        return pool
+    async def reconcile_pool(self, request: object) -> object:
+        self.reconciled.append(request)
+        if self.reconcile_error:
+            raise self.reconcile_error
+        return self.existing or fleet_pool(request.namespace)
 
     async def create_claim(self, request: object) -> object:
         self.claims.append(request)
@@ -96,6 +86,21 @@ async def test_fleet_client_get_pool_uses_name_lookup_without_listing() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fleet_client_reconcile_pool_delegates_to_generated_client() -> None:
+    expected = fleet_pool()
+
+    class GeneratedClient:
+        async def reconcile_pool(self, request: object) -> object:
+            assert request == "desired"
+            return expected
+
+    client = object.__new__(_FleetClient)
+    client._client = GeneratedClient()
+
+    assert await client.reconcile_pool("desired") is expected
+
+
+@pytest.mark.asyncio
 async def test_reconcile_creates_pool_from_registry_image(monkeypatch):
     client = FakeFleetClient()
     monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: client)
@@ -110,8 +115,8 @@ async def test_reconcile_creates_pool_from_registry_image(monkeypatch):
     assert pool.name == "foo"
     assert pool.resource.metadata.name == "foo"
     assert client.closed is True
-    assert len(client.created) == 1
-    request = client.created[0]
+    assert len(client.reconciled) == 1
+    request = client.reconciled[0]
     assert request.namespace == "foo"
     assert request.spec.template.container_disk_image == "registry.example/workspace:latest"
     assert [(service.name, service.target_port) for service in request.spec.services] == [
@@ -121,11 +126,11 @@ async def test_reconcile_creates_pool_from_registry_image(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_reconcile_closes_temporary_client_when_creation_fails(monkeypatch):
-    client = FakeFleetClient(create_error=RuntimeError("create failed"))
+async def test_reconcile_closes_temporary_client_when_reconciliation_fails(monkeypatch):
+    client = FakeFleetClient(reconcile_error=RuntimeError("reconcile failed"))
     monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: client)
 
-    with pytest.raises(RuntimeError, match="create failed"):
+    with pytest.raises(RuntimeError, match="reconcile failed"):
         await Pool.reconcile({"name": "foo", "image": Image.from_registry("example:latest")})
 
     assert client.closed is True
@@ -140,9 +145,8 @@ async def test_reconcile_updates_existing_pool_idempotently(monkeypatch):
     pool = await Pool.reconcile({"name": "foo", "image": Image.from_registry("example:latest")})
 
     assert pool.resource is existing
-    assert client.created == []
-    assert client.updated == [existing]
-    assert existing.spec.template.container_disk_image == "example:latest"
+    assert len(client.reconciled) == 1
+    assert client.reconciled[0].spec.template.container_disk_image == "example:latest"
     assert client.closed is True
 
 
@@ -239,7 +243,7 @@ async def test_reconcile_preserves_replicas_and_named_services(monkeypatch):
         }
     )
 
-    request = client.created[0]
+    request = client.reconciled[0]
     assert request.spec.replicas == 2
     assert [(service.name, service.target_port) for service in request.spec.services] == [
         ("server", 8000),

--- a/libs/python/cua-sandbox/uv.lock
+++ b/libs/python/cua-sandbox/uv.lock
@@ -539,7 +539,7 @@ dev = [{ name = "pytest", specifier = ">=8.3.5" }]
 
 [[package]]
 name = "cua-fleet"
-version = "0.0.7"
+version = "0.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -547,10 +547,10 @@ dependencies = [
     { name = "python-dateutil" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/ad/a8519f33efcc467a6f1e15ded9881e8c8c793614dcc62cd40eac7833066c/cua_fleet-0.0.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3f76c64cd6d8abd42ca322bac1b184c202ed1fc7bfa47ef7d503949d304013b8", size = 2123635, upload-time = "2026-08-02T01:59:23.577Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/83/7e2dfe9d95925851298da4c1fca4b6b3c9cdf69278aaf0394669fe9bc9d1/cua_fleet-0.0.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:64972b5750fe512f7f60fac6cd98f7472a68d209d117615136402055d890c3df", size = 2037284, upload-time = "2026-08-02T01:59:25.091Z" },
-    { url = "https://files.pythonhosted.org/packages/39/06/4b2b819236aa3a1f381e3e749805bdc063d2f8b84f43c545a6bae76d75d6/cua_fleet-0.0.7-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:372f46232c819751c8ad0469a1ea86a53da02203bfb251d15826178c81984097", size = 2300936, upload-time = "2026-08-02T01:59:26.369Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/40/d6777691c2ede5f657469ed1a66af127948bc8d00ee841aa9f3afb822982/cua_fleet-0.0.7-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:0eb19f50b3fe745b3e8177a20905a536b91121e4b85ddb5ca8b30bc2682119fd", size = 2355501, upload-time = "2026-08-02T01:59:27.814Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9d/f1f800c746c3f4137d21864293db3d2cded36125dc4fd0547c9def35beff/cua_fleet-0.0.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d62ba6b263e858ff7157e1dfb317b1526a7b6fe2dba76479621490393efb2f8e", size = 2126597, upload-time = "2026-08-02T17:12:56.242Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ce/dedd4f4847bc1c7da18bd1f58d75c0c03da1fa50f30d0720a74dcf6705e3/cua_fleet-0.0.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4a3fd42fe75520ae0070935d13ce22e28b5c121852d6e39d65eed3df35cb3dd0", size = 2040766, upload-time = "2026-08-02T17:12:57.96Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/97/09faebc28ce1b2d7e6882861e6f9f1a3788abe5bc286e23a55e8d9b1caac/cua_fleet-0.0.8-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:776a1287c474362d76a5240dfd868be3ad29d36a51114519d2b06c8061f51036", size = 2304088, upload-time = "2026-08-02T17:13:00.066Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/36/0cd2f82e1cdd56e7330094ff3aa57ae9ab670b56e4e4500eb91e3e3f8580/cua_fleet-0.0.8-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:dee669f487ad3dafa176d80d236c5b5a89df0af8d46f86e756c720a1f683af36", size = 2357881, upload-time = "2026-08-02T17:13:01.999Z" },
 ]
 
 [[package]]
@@ -592,7 +592,7 @@ dev = [
 requires-dist = [
     { name = "cua-auto", specifier = ">=0.1.2" },
     { name = "cua-core", specifier = ">=0.3.0,<0.4.0" },
-    { name = "cua-fleet", specifier = "==0.0.7" },
+    { name = "cua-fleet", specifier = "==0.0.8" },
     { name = "grpcio", specifier = "==1.78.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "oras", specifier = ">=0.2.40" },


### PR DESCRIPTION
Routes `cua_sandbox.Pool.reconcile()` through the published UniFFI `CyclopsClient.reconcile_pool()` API.

This removes Sandbox-local get/create/update orchestration and preserves the no-list pool invariant. The package now pins the published `cua-fleet==0.0.8` wheel.

Verification:
- `fleet_sdk.CyclopsClient.reconcile_pool` is available from the installed published wheel.
- `ruff check` on changed files.
- `pytest -q tests/test_fleet_sdk_packaging.py tests/test_pool.py` — 19 passed.