### PR TITLE
fix(sandbox): align bump config with package version

### DIFF
--- a/.github/scripts/tests/test_cua_sandbox_release_wiring.py
+++ b/.github/scripts/tests/test_cua_sandbox_release_wiring.py
@@ -1,0 +1,26 @@
+"""Regression tests for cua-sandbox release-bump wiring."""
+
+import configparser
+from pathlib import Path
+import tomllib
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SANDBOX_ROOT = REPO_ROOT / "libs/python/cua-sandbox"
+
+
+class TestCuaSandboxReleaseWiring(unittest.TestCase):
+    """Keep the legacy bump configuration synchronized with package metadata."""
+
+    def test_bump_config_tracks_the_current_package_version(self) -> None:
+        config = configparser.ConfigParser()
+        config.read(SANDBOX_ROOT / ".bumpversion.cfg")
+        with (SANDBOX_ROOT / "pyproject.toml").open("rb") as pyproject_file:
+            project = tomllib.load(pyproject_file)["project"]
+
+        self.assertEqual(config["bumpversion"]["current_version"], project["version"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/libs/python/cua-sandbox/.bumpversion.cfg
+++ b/libs/python/cua-sandbox/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.19
+current_version = 0.1.20
 commit = True
 tag = True
 tag_name = sandbox-v{new_version}


### PR DESCRIPTION
Fixes the authorized `pypi/sandbox` patch-release failure.

`libs/python/cua-sandbox/.bumpversion.cfg` still declared `0.1.19`, but the package version is `0.1.20`, causing `bump2version` to fail before creating `sandbox-v0.1.21`.

Adds a regression test that keeps the legacy bump config synchronized with `pyproject.toml`.

Verification:
- `python3 .github/scripts/tests/test_cua_sandbox_release_wiring.py -v`
- `bump2version --allow-dirty --dry-run --list patch` resolves `new_version=0.1.21`.