### PR TITLE
feat(cua-driver): add trusted KWin Wayland target activation

### DIFF
--- a/docs/content/docs/reference/cua-driver/browser-profile-attachment.mdx
+++ b/docs/content/docs/reference/cua-driver/browser-profile-attachment.mdx
@@ -176,8 +176,15 @@ GNOME Shell sessions, Cua Driver briefly focuses the exact
 compositor-attested window for fixed internal-page navigation and restores the
 previous window before continuing. GNOME requires the maintained WinRects
 helper API v4 and an immutable D-Bus owner that resolves to the current user's
-system-installed GNOME Shell process. Cua Driver refuses generic Wayland
-sessions that cannot prove exact process, window, and geometry identity.
+system-installed GNOME Shell process. KDE Plasma 6 requires the current-user
+protocol-v1 `cua-kwin@cua` package and a verified genuine `kwin_wayland` owner.
+The KDE route retains KWin's complete internal UUID, correlates it with the
+browser PID and AT-SPI geometry, verifies activation in a fresh snapshot, and
+restores and verifies the previous active UUID around the bounded setup or
+consent operation. This supplies the exact native prerequisite; products still
+need the platform-specific acceptance evidence listed above. Cua Driver refuses
+generic Wayland sessions that cannot prove exact process, window, and geometry
+identity.
 
 The setup adapters currently recognize the products' English accessibility
 labels. Other UI locales fail closed without toggling an unrecognized control.

--- a/docs/content/docs/reference/cua-driver/limits.mdx
+++ b/docs/content/docs/reference/cua-driver/limits.mdx
@@ -46,7 +46,7 @@ claim.
 | macOS Chrome and Edge | Existing-profile attachment is validated. Synthetic DOM actions can remain fully background; trusted standalone pointer routes refuse when Chromium would activate. |
 | Linux X11 Chrome and Edge | Validated for exact binding and synthetic DOM background routes. Trusted standalone pointer routes refuse when activation is unavoidable. |
 | Linux Sway with Chrome | Validated only when compositor identity, process, window, and geometry are exact. |
-| Generic GNOME or KDE Wayland | Read-only discovery or structured refusal; mutation is not claimed. |
+| Unattested GNOME or KDE Wayland | Read-only discovery or structured refusal; mutation is not claimed. |
 | Electron | Validated only for the bounded one-native-window to one-CDP-page shape. |
 | Brave, Vivaldi, Opera, Arc, and other detected Chromium derivatives | Detected but not release-accepted; use at your own risk. |
 | Safari, Firefox, WebView2, Tauri, WKWebView, and WebKitGTK | Typed mutation unsupported. Use documented native AX/PX fallbacks where available. |
@@ -76,11 +76,13 @@ Endpoint ownership must resolve to the approved browser PID; wrapper processes,
 ambiguous process trees, unsupported products, unrecognized UI locales, and
 generic Wayland identities are refused.
 
-On generic GNOME or KDE Wayland sessions, browser state may be discoverable
-without enough compositor evidence to correlate native and DevTools geometry
-exactly. That route stays read-only. X11 and the validated Sway configuration
-can authorize mutation when their ownership and geometry proofs agree. This
-does not imply arbitrary raw background PX delivery on Wayland.
+On a GNOME or KDE Wayland session without its supported, trusted compositor
+adapter, browser state may be discoverable without enough compositor evidence
+to correlate native and DevTools geometry exactly. That route stays read-only.
+KDE's protocol-v1 `cua-kwin@cua` package supplies exact KWin UUID, PID, geometry,
+activation, and restoration evidence, but product-specific browser acceptance
+still depends on the documented validation matrix. This does not imply
+arbitrary raw background PX delivery on Wayland.
 
 ---
 
@@ -169,6 +171,15 @@ compositor's active seat and requires a RemoteDesktop grant. The virtual
 keyboard used on wlroots compositors is also focus-bound, even though it does
 not require the same portal route.
 
+On KDE Plasma 6, installing the bundled protocol-v1 `cua-kwin@cua` package
+enables only a bounded foreground exception: cua-driver resolves the complete
+KWin internal UUID and PID, activates and verifies it in a fresh snapshot,
+runs one operation, then restores and verifies the previous UUID. Adapter
+absence, protocol mismatch, untrusted ownership, ambiguity, staleness, failed
+activation, or failed restoration is surfaced rather than bypassed. Install it
+with `~/.cua-driver/packages/current/wayland-helper/kwin/install.sh`; no
+logout/login is required because the installer reconfigures KWin live.
+
 **Workarounds:**
 
 1. Type into accessible text fields with `type_text`. AT-SPI `insertText` writes the field directly, with no synthetic key event involved.
@@ -196,7 +207,7 @@ client on Sway, GNOME, or KDE, and its capabilities are documented separately.
 
 **Cause:** GTK4's AT-SPI bridge returns `Component.GetExtents(SCREEN)` as `(0,0)` for every widget (GNOME/gtk issues #1564 / #1739). A naive consumer would collapse every element to the window's top-left corner.
 
-**How Cua Driver handles it:** it queries `CoordType::Window` (which GTK4 *does* report correctly per-widget) and adds the window's screen origin from `_GTK_FRAME_EXTENTS` on X11 or the `org.cua.WinRects` shell helper on Wayland. That reconstructs true screen coordinates, so no caller action is required.
+**How Cua Driver handles it:** it queries `CoordType::Window` (which GTK4 *does* report correctly per-widget) and adds the window's screen origin from `_GTK_FRAME_EXTENTS` on X11, the `org.cua.WinRects` Shell helper on GNOME Wayland, or the exact UUID/PID-correlated `cua-kwin@cua` snapshot on KDE Plasma 6 Wayland. That reconstructs true screen coordinates, so no caller action is required when the matching compositor adapter is trusted.
 
 ---
 

--- a/docs/content/docs/reference/cua-driver/platform-support.mdx
+++ b/docs/content/docs/reference/cua-driver/platform-support.mdx
@@ -77,7 +77,7 @@ capture, activation, and input protocols.
 | X11/Xorg                        | Supported             | Window discovery and capture, AT-SPI trees and actions, foreground pointer and keyboard input, semantic background delivery, desktop scope, and structured refusals                               | Raw background delivery depends on the target toolkit. X11 accepting an event does not prove the application handled it.                                                                                                                                   |
 | Sway (wlroots reference lane)   | Supported with limits | The complete typed Electron, Tauri, GTK, capture, and desktop-scope catalog, including foreground/background and AX/PX outcomes                                                                    | Focus-bound and raw background input shapes without a target-addressed protocol return structured refusals. Other wlroots compositors are expected to share protocol support but are not yet proven.                                                       |
 | GNOME/Mutter                    | Supported with limits | AT-SPI actions, GTK controls, compositor-backed window geometry and capture, verified foreground activation, and portal/libei foreground input                                                    | The bundled WinRects Shell helper and one Shell-session restart are prerequisites for authoritative geometry and activation. Portal video recording remains incomplete.                                                                                    |
-| KDE/KWin                        | Experimental          | Plasma 6 session startup, GTK AT-SPI discovery, generic discovery where exposed, and portal interface availability                                                                                | cua-driver does not yet have a target-addressable KWin activation adapter, and no complete behavioral matrix is accepted. Focus-bound input refuses rather than risking delivery to the wrong application.                                                  |
+| KDE Plasma 6/KWin               | Experimental          | GTK AT-SPI, protocol-v1 adapter-backed KWin UUID/PID/geometry discovery, exact activation readback, and bounded foreground portal/libei input                                                     | Requires the current-user `cua-kwin@cua` package and a portal grant. Missing, outdated, untrusted, ambiguous, or stale adapter identities refuse before input. The complete renderer and recording matrix is not yet accepted.                                 |
 | `cua-compositor` nested session | Experimental          | Native GTK behavior, capture and scope, private route metadata, independent observation, and per-cell video                                                                                       | The complete shared renderer matrix is not accepted. Unicode text and a canonical parallel-drag row remain unproven; this route does not establish a stock-Wayland capability.                                                                              |
 | XWayland                        | Supported with limits | X11 routes are used when the application exposes a real X11 window; native Wayland and AT-SPI fallbacks cover mixed sessions                                                                      | Capabilities depend on whether the application is actually using X11 or native Wayland.                                                                                                                                                                    |
 
@@ -99,6 +99,15 @@ standard Wayland compositor.** Reconstructing a window's coordinate system
 tells cua-driver where the target is, but portal/libei and virtual input still
 deliver through the compositor's active seat. An occluding surface therefore
 receives a raw event sent at that screen coordinate.
+
+On KDE Plasma 6, the bundled `cua-kwin@cua` package supplies a narrowly scoped
+foreground path. cua-driver retains KWin's complete internal window UUID,
+correlates it with the requested PID and numeric API identifier, verifies a
+fresh active-window snapshot before one portal/libei operation, then restores
+and verifies the previous active UUID. Install it for the current user with
+`~/.cua-driver/packages/current/wayland-helper/kwin/install.sh`; KWin can be
+reconfigured live and does not require logout/login. This is KWin-specific and
+does not establish generic Wayland support.
 
 cua-driver also contains an opt-in exception: the nested `cua-compositor`
 backend owns the compositor and can route `wl_pointer` and `wl_keyboard` events

--- a/libs/cua-driver/rust/Cargo.lock
+++ b/libs/cua-driver/rust/Cargo.lock
@@ -2982,6 +2982,7 @@ dependencies = [
  "reis",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 1.0.69",
  "tiny-skia",
  "tokio",

--- a/libs/cua-driver/rust/Skills/cua-driver/LINUX.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/LINUX.md
@@ -207,8 +207,13 @@ driver selects a backend from compositor capabilities:
   wlr-screencopy, virtual pointer, and virtual keyboard protocols.
 - GNOME/Mutter uses the bundled WinRects Shell helper for target geometry and
   activation, plus portal/libei for foreground raw input.
-- KDE/KWin uses AT-SPI and portal facilities where available. Target-specific
-  foreground activation remains experimental, so unsafe raw input refuses.
+- KDE Plasma 6/KWin uses the bundled protocol-v1 `cua-kwin@cua` script for
+  compositor-owned UUID/PID/geometry snapshots and exact activation, plus
+  portal/libei for foreground raw input. Install or update it for the current
+  user with
+  `~/.cua-driver/packages/current/wayland-helper/kwin/install.sh`; KWin
+  reconfigures without a logout. Missing, outdated, or untrusted adapter state
+  refuses before input.
 - The optional `cua-compositor` is a separate nested session enabled
   explicitly for controlled automation. GNOME and KDE never switch into it.
 
@@ -229,6 +234,14 @@ the selected target through a verified compositor adapter before dispatch. If
 the compositor has no target-addressable activation or input backend, the call
 refuses before sending input. Reconstructing coordinates alone does not make
 raw background PX possible on a standard compositor.
+
+On KDE, the bounded foreground transaction keeps KWin's complete internal
+UUID: snapshot and remember the exact active window, resolve the requested
+numeric ID back to its UUID and PID, activate it, verify a fresh KWin snapshot,
+run one operation, then restore and verify the prior UUID. Run the packaged
+`wayland-helper/kwin/diagnose.sh` for package/load diagnostics and
+`cua-driver doctor` for the trusted owner, protocol, activation, and portal
+checks. Remove it with the packaged `wayland-helper/kwin/uninstall.sh`.
 
 ## Quick triage
 
@@ -269,7 +282,7 @@ ask the user.
 | X11/Openbox | AT-SPI trees and actions, foreground pointer and keyboard input, window and desktop capture, and video | Raw background delivery remains toolkit-specific; unsupported shapes refuse |
 | Sway/wlroots | AT-SPI, native discovery, full-display and cropped-window screencopy, foreground input, semantic background actions, and video | Raw background pointer and keyboard input remains focus-bound |
 | GNOME/Mutter | AT-SPI, WinRects geometry and activation, capture, and portal/libei foreground input | Requires the helper and portal grant; portal video parity remains open |
-| KDE/KWin | AT-SPI and generic discovery where exposed | Target-specific activation and behavioral coverage remain experimental |
+| KDE Plasma 6/KWin | AT-SPI, adapter-backed exact UUID/PID/geometry discovery and verified bounded foreground portal/libei input | Requires protocol-v1 `cua-kwin@cua` and a portal grant; the complete renderer/recording matrix remains experimental |
 | Nested `cua-compositor` | Versioned direct per-surface input, native GTK 31/31, capture/scope 5/5, and partial Electron coverage | The complete shared matrix remains experimental; do not infer standard-Wayland support |
 
 See `SKILL.md` for the cross-platform loop (snapshot-before-AND-after,

--- a/libs/cua-driver/rust/crates/cua-driver/src/doctor.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/doctor.rs
@@ -430,6 +430,205 @@ fn wait_for_child(
 }
 
 #[cfg(target_os = "linux")]
+#[derive(Debug, Clone, Copy)]
+struct KwinDoctorFacts<'a> {
+    installed: bool,
+    protocol_supported: bool,
+    owner_trusted: bool,
+    enumeration_available: bool,
+    activation_verified: bool,
+    fully_available: bool,
+    message: &'a str,
+}
+
+#[cfg(target_os = "linux")]
+fn kwin_remediation(message: &str) -> String {
+    format!(
+        "{message}\nRun: {}",
+        platform_linux::wayland::kwin_adapter::INSTALL_COMMAND
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn probe_kwin_portal_for_doctor() -> Result<bool, String> {
+    // `doctor` is invoked from the async CLI runtime, while the platform
+    // probe intentionally owns a small current-thread runtime. Keep the two
+    // runtimes on different OS threads so this synchronous report cannot
+    // panic with Tokio's nested-runtime guard.
+    std::thread::spawn(platform_linux::health_report::probe_portal_remote_desktop)
+        .join()
+        .map_err(|_| "xdg-desktop-portal RemoteDesktop probe panicked".to_owned())?
+        .map_err(|error| error.to_string())
+}
+
+/// Run the trusted KWin adapter diagnosis for `doctor`.
+///
+/// The adapter talks to KWin over zbus's blocking API, which (with the `tokio`
+/// backend) requires an ambient Tokio runtime for its background tasks yet
+/// panics if its own `block_on` runs on a runtime *worker* thread. `doctor`
+/// runs on a plain synchronous thread with no runtime at all. Own a private
+/// multi-thread runtime and run the blocking probe on one of its blocking
+/// threads — the same context the async tool dispatch uses in the daemon — on a
+/// dedicated OS thread so this stays correct even if `doctor` is ever invoked
+/// from within another runtime.
+#[cfg(target_os = "linux")]
+fn diagnose_kwin_for_doctor() -> platform_linux::wayland::kwin_adapter::AdapterDiagnostic {
+    std::thread::spawn(|| {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("build KWin doctor probe runtime");
+        runtime.block_on(async {
+            tokio::task::spawn_blocking(platform_linux::wayland::kwin_adapter::diagnose)
+                .await
+                .expect("KWin diagnosis task panicked")
+        })
+    })
+    .join()
+    .unwrap_or_else(
+        |_| platform_linux::wayland::kwin_adapter::AdapterDiagnostic {
+            message: "kwin_adapter_unavailable: KWin diagnosis thread panicked".to_owned(),
+            ..Default::default()
+        },
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn append_kwin_adapter_probes(
+    report: &mut Report,
+    facts: KwinDoctorFacts<'_>,
+    portal_compiled: bool,
+    portal_probe: Result<bool, String>,
+) {
+    let every_required_fact = facts.installed
+        && facts.protocol_supported
+        && facts.owner_trusted
+        && facts.enumeration_available
+        && facts.activation_verified;
+    let fully_available = facts.fully_available && every_required_fact;
+
+    if facts.installed {
+        report.push(Probe::ok(
+            "KWin adapter installed",
+            "current-user KWin target adapter is installed",
+        ));
+    } else {
+        report.push(
+            Probe::warn(
+                "KWin adapter installed",
+                "current-user KWin target adapter is absent",
+            )
+            .with_detail(kwin_remediation(facts.message)),
+        );
+    }
+
+    if facts.protocol_supported {
+        report.push(Probe::ok(
+            "KWin adapter protocol",
+            "adapter protocol version is supported",
+        ));
+    } else {
+        report.push(
+            Probe::warn(
+                "KWin adapter protocol",
+                "adapter protocol is absent, malformed, or unsupported",
+            )
+            .with_detail(kwin_remediation(facts.message)),
+        );
+    }
+
+    if facts.owner_trusted {
+        report.push(Probe::ok(
+            "KWin adapter owner/process",
+            "immutable session owner, UID, KWin process, and executable trust checks passed",
+        ));
+    } else {
+        report.push(
+            Probe::warn(
+                "KWin adapter owner/process",
+                "adapter owner, UID, KWin process, or executable trust could not be proven",
+            )
+            .with_detail(kwin_remediation(facts.message)),
+        );
+    }
+
+    if facts.enumeration_available {
+        report.push(Probe::ok(
+            "KWin exact enumeration",
+            "authoritative compositor window enumeration succeeded",
+        ));
+    } else {
+        report.push(
+            Probe::warn(
+                "KWin exact enumeration",
+                "authoritative compositor window enumeration is unavailable",
+            )
+            .with_detail(kwin_remediation(facts.message)),
+        );
+    }
+
+    if facts.activation_verified {
+        report.push(Probe::ok(
+            "KWin activation verification",
+            "exact active-window identity was verified through a fresh compositor snapshot",
+        ));
+    } else {
+        report.push(
+            Probe::warn(
+                "KWin activation verification",
+                "exact target activation could not be verified through a fresh compositor snapshot",
+            )
+            .with_detail(kwin_remediation(facts.message)),
+        );
+    }
+
+    if !portal_compiled {
+        report.push(
+            Probe::warn(
+                "KWin portal/libei input",
+                "this build does not include the portal/libei input backend",
+            )
+            .with_detail(
+                "Install a release build or rebuild cua-driver with --features portal-input.",
+            ),
+        );
+        return;
+    }
+
+    match portal_probe {
+        Err(error) => report.push(
+            Probe::warn(
+                "KWin portal/libei input",
+                "xdg-desktop-portal RemoteDesktop probe failed",
+            )
+            .with_detail(format!(
+                "{error}\nEnsure xdg-desktop-portal and xdg-desktop-portal-kde are running in this user session."
+            )),
+        ),
+        Ok(false) => report.push(
+            Probe::warn(
+                "KWin portal/libei input",
+                "xdg-desktop-portal RemoteDesktop is not reachable",
+            )
+            .with_detail(
+                "Ensure xdg-desktop-portal and xdg-desktop-portal-kde are running in this user session.",
+            ),
+        ),
+        Ok(true) if fully_available => report.push(Probe::ok(
+            "KWin portal/libei input",
+            "RemoteDesktop is reachable and global input is gated by verified exact KWin activation and restoration",
+        )),
+        Ok(true) => report.push(
+            Probe::warn(
+                "KWin portal/libei input",
+                "RemoteDesktop is reachable, but global input remains blocked until the full trusted KWin path verifies",
+            )
+            .with_detail(kwin_remediation(facts.message)),
+        ),
+    }
+}
+
+#[cfg(target_os = "linux")]
 fn append_platform_probes(report: &mut Report) {
     // Display server probe. Order matters: Wayland wins when both are set
     // (XWayland leaves DISPLAY pointing at the X server XWayland exposes,
@@ -517,6 +716,33 @@ fn append_platform_probes(report: &mut Report) {
                 );
             }
         }
+    }
+
+    // KDE/KWin portal input is global to the compositor's active seat. Surface
+    // each trust gate separately so a reachable portal can never be mistaken
+    // for safe target-addressable input.
+    if platform_linux::wayland::kwin_adapter::is_kde_wayland_session() {
+        let diagnosis = diagnose_kwin_for_doctor();
+        let portal_compiled = platform_linux::wayland::PORTAL_INPUT_ENABLED;
+        let portal_probe = if portal_compiled {
+            probe_kwin_portal_for_doctor()
+        } else {
+            Ok(false)
+        };
+        append_kwin_adapter_probes(
+            report,
+            KwinDoctorFacts {
+                installed: diagnosis.installed,
+                protocol_supported: diagnosis.protocol_supported,
+                owner_trusted: diagnosis.owner_trusted,
+                enumeration_available: diagnosis.enumeration_available,
+                activation_verified: diagnosis.activation_verified,
+                fully_available: diagnosis.fully_available(),
+                message: &diagnosis.message,
+            },
+            portal_compiled,
+            portal_probe,
+        );
     }
 }
 
@@ -654,6 +880,145 @@ mod tests {
         assert!(status.is_none());
         child.kill().unwrap();
         child.wait().unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    fn kwin_facts(
+        installed: bool,
+        protocol_supported: bool,
+        owner_trusted: bool,
+        enumeration_available: bool,
+        activation_verified: bool,
+    ) -> KwinDoctorFacts<'static> {
+        KwinDoctorFacts {
+            installed,
+            protocol_supported,
+            owner_trusted,
+            enumeration_available,
+            activation_verified,
+            fully_available: installed
+                && protocol_supported
+                && owner_trusted
+                && enumeration_available
+                && activation_verified,
+            message: "fixture KWin diagnosis",
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn kwin_doctor_reports_every_trust_gate_and_portal_success() {
+        let mut report = Report::default();
+        append_kwin_adapter_probes(
+            &mut report,
+            kwin_facts(true, true, true, true, true),
+            true,
+            Ok(true),
+        );
+
+        assert_eq!(report.probes.len(), 6);
+        assert!(report.probes.iter().all(|probe| probe.status == Status::Ok));
+        let labels = report
+            .probes
+            .iter()
+            .map(|probe| probe.label.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            labels,
+            [
+                "KWin adapter installed",
+                "KWin adapter protocol",
+                "KWin adapter owner/process",
+                "KWin exact enumeration",
+                "KWin activation verification",
+                "KWin portal/libei input",
+            ]
+        );
+        assert!(report.probes[5].message.contains("verified exact KWin"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn kwin_doctor_missing_adapter_is_fail_closed_with_exact_remediation() {
+        let mut report = Report::default();
+        append_kwin_adapter_probes(
+            &mut report,
+            kwin_facts(false, false, false, false, false),
+            true,
+            Ok(true),
+        );
+
+        assert_eq!(report.probes.len(), 6);
+        assert!(report
+            .probes
+            .iter()
+            .all(|probe| probe.status == Status::Warn));
+        assert!(report.probes[5].message.contains("remains blocked"));
+        assert!(report.probes.iter().any(|probe| {
+            probe
+                .detail
+                .as_deref()
+                .unwrap_or_default()
+                .contains(platform_linux::wayland::kwin_adapter::INSTALL_COMMAND)
+        }));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn kwin_doctor_outdated_or_untrusted_adapter_never_unlocks_portal_input() {
+        for facts in [
+            kwin_facts(true, false, true, true, true),
+            kwin_facts(true, true, false, true, true),
+            kwin_facts(true, true, true, false, true),
+            kwin_facts(true, true, true, true, false),
+        ] {
+            let mut report = Report::default();
+            append_kwin_adapter_probes(&mut report, facts, true, Ok(true));
+
+            let portal = report.probes.last().expect("portal probe");
+            assert_eq!(portal.status, Status::Warn);
+            assert!(portal.message.contains("remains blocked"));
+            assert!(portal
+                .detail
+                .as_deref()
+                .unwrap_or_default()
+                .contains(platform_linux::wayland::kwin_adapter::INSTALL_COMMAND));
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn kwin_doctor_distinguishes_missing_build_and_missing_portal() {
+        let ready = kwin_facts(true, true, true, true, true);
+
+        let mut no_feature = Report::default();
+        append_kwin_adapter_probes(&mut no_feature, ready, false, Ok(false));
+        assert_eq!(
+            no_feature.probes.last().unwrap().message,
+            "this build does not include the portal/libei input backend"
+        );
+
+        let mut no_portal = Report::default();
+        append_kwin_adapter_probes(&mut no_portal, ready, true, Ok(false));
+        assert_eq!(
+            no_portal.probes.last().unwrap().message,
+            "xdg-desktop-portal RemoteDesktop is not reachable"
+        );
+
+        let mut probe_error = Report::default();
+        append_kwin_adapter_probes(
+            &mut probe_error,
+            ready,
+            true,
+            Err("fixture failure".to_owned()),
+        );
+        assert!(probe_error
+            .probes
+            .last()
+            .unwrap()
+            .detail
+            .as_deref()
+            .is_some_and(|detail| detail.contains("fixture failure")));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/Cargo.toml
+++ b/libs/cua-driver/rust/crates/platform-linux/Cargo.toml
@@ -61,7 +61,8 @@ ashpd = { version = "0.13", default-features = false, features = ["tokio", "scre
 # zbus is pulled transitively via ashpd + atspi but declared directly so
 # the portal-probe path in wayland::portal_screenshot can talk to the
 # session bus without going through ashpd's higher-level builders.
-zbus = { version = "5", default-features = false, features = ["tokio"] }
+zbus = { version = "5", default-features = false, features = ["tokio", "blocking-api"] }
+sha2 = { workspace = true }
 # Parse `file://` URIs returned by org.freedesktop.portal.Screenshot.
 # ashpd re-exports `url` transitively; declared explicitly so ashpd
 # version bumps cannot silently break the resolver.

--- a/libs/cua-driver/rust/crates/platform-linux/src/health_report.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/health_report.rs
@@ -20,6 +20,16 @@ use cua_driver_core::health_report::{
 /// virtual-pointer / wl_shm). Linux-specific; skipped when not on Wayland.
 pub const NAME_WAYLAND_BACKEND: &str = "wayland_backend";
 
+/// KDE Plasma/KWin-specific trusted target adapter status. Kept separate from
+/// the generic Wayland manager probe so a reachable portal can never obscure
+/// an absent, outdated, or untrusted compositor activation path.
+pub const NAME_KWIN_TARGET_ADAPTER: &str = "kwin_target_adapter";
+
+/// KDE portal/libei readiness after the trusted target adapter gate is
+/// applied. RemoteDesktop proxy reachability alone is not sufficient because
+/// portal input follows the compositor's active seat.
+pub const NAME_KWIN_PORTAL_INPUT: &str = "kwin_portal_libei_input";
+
 /// Linux canonical check names — same Swift-PR contract, with TCC /
 /// bundle entries surfaced as `skip("not applicable on Linux")`. The
 /// full set of entries always appears so cross-platform consumers see
@@ -34,6 +44,8 @@ pub const LINUX_CHECK_NAMES: &[&str] = &[
     NAME_AX_CAPABILITY,
     NAME_SCREEN_CAPTURE_CAPABILITY,
     NAME_WAYLAND_BACKEND,
+    NAME_KWIN_TARGET_ADAPTER,
+    NAME_KWIN_PORTAL_INPUT,
 ];
 
 pub struct LinuxHealthProvider;
@@ -59,6 +71,8 @@ impl HealthCheckProvider for LinuxHealthProvider {
             NAME_AX_CAPABILITY => check_ax_capability().await,
             NAME_SCREEN_CAPTURE_CAPABILITY => check_screen_capture_capability().await,
             NAME_WAYLAND_BACKEND => check_wayland_backend().await,
+            NAME_KWIN_TARGET_ADAPTER => check_kwin_target_adapter().await,
+            NAME_KWIN_PORTAL_INPUT => check_kwin_portal_input().await,
             other => CheckEntry::skip(
                 other.to_owned(),
                 "Unknown check name (not implemented on this platform).",
@@ -311,11 +325,209 @@ async fn check_wayland_backend() -> CheckEntry {
     } else {
         false
     };
+    // `target_activation_available` may run the blocking KWin diagnosis on KDE,
+    // which drives zbus's global Tokio runtime; keep it on a blocking-pool
+    // thread so it cannot panic the async health-check worker.
+    let target_activation = tokio::task::spawn_blocking(target_activation_available)
+        .await
+        .unwrap_or(false);
     classify_wayland_backend(
         &snap,
         portal_input_enabled(),
         remote_desktop_portal_reachable,
-        target_activation_available(),
+        target_activation,
+    )
+}
+
+#[derive(Debug, Clone, Copy)]
+struct KwinAdapterHealth<'a> {
+    installed: bool,
+    protocol_supported: bool,
+    owner_trusted: bool,
+    enumeration_available: bool,
+    activation_verified: bool,
+    fully_available: bool,
+    message: &'a str,
+}
+
+/// Run the KWin adapter diagnosis off the async runtime.
+///
+/// zbus's blocking API drives a global Tokio runtime through
+/// `Runtime::block_on`, which panics if it is invoked on a thread that is
+/// already inside the driver's async runtime (every health check is). Moving it
+/// onto a `spawn_blocking` thread makes the nested `block_on` legal — the same
+/// pattern the portal probes above already use.
+#[cfg(target_os = "linux")]
+async fn kwin_diagnosis() -> crate::wayland::kwin_adapter::AdapterDiagnostic {
+    tokio::task::spawn_blocking(crate::wayland::kwin_adapter::diagnose)
+        .await
+        .unwrap_or_else(|_| crate::wayland::kwin_adapter::AdapterDiagnostic {
+            message: "kwin_adapter_unavailable: KWin diagnosis task failed to complete".to_owned(),
+            ..Default::default()
+        })
+}
+
+#[cfg(target_os = "linux")]
+async fn check_kwin_target_adapter() -> CheckEntry {
+    if !crate::wayland::kwin_adapter::is_kde_wayland_session() {
+        return CheckEntry::skip(
+            NAME_KWIN_TARGET_ADAPTER,
+            "Not a KDE Plasma/KWin Wayland session.",
+        );
+    }
+
+    let diagnosis = kwin_diagnosis().await;
+    classify_kwin_target_adapter(KwinAdapterHealth {
+        installed: diagnosis.installed,
+        protocol_supported: diagnosis.protocol_supported,
+        owner_trusted: diagnosis.owner_trusted,
+        enumeration_available: diagnosis.enumeration_available,
+        activation_verified: diagnosis.activation_verified,
+        fully_available: diagnosis.fully_available(),
+        message: &diagnosis.message,
+    })
+}
+
+#[cfg(not(target_os = "linux"))]
+async fn check_kwin_target_adapter() -> CheckEntry {
+    CheckEntry::skip(
+        NAME_KWIN_TARGET_ADAPTER,
+        "KDE Plasma/KWin integration is only available on Linux.",
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn kwin_install_command() -> &'static str {
+    crate::wayland::kwin_adapter::INSTALL_COMMAND
+}
+
+#[cfg(not(target_os = "linux"))]
+fn kwin_install_command() -> &'static str {
+    "KWin adapter installation is only available on Linux"
+}
+
+fn classify_kwin_target_adapter(facts: KwinAdapterHealth<'_>) -> CheckEntry {
+    let summary = format!(
+        "installed={installed}, protocol-supported={protocol}, \
+         owner-process-trusted={trusted}, enumeration={enumeration}, \
+         activation-verified={activation}: {message}",
+        installed = facts.installed,
+        protocol = facts.protocol_supported,
+        trusted = facts.owner_trusted,
+        enumeration = facts.enumeration_available,
+        activation = facts.activation_verified,
+        message = facts.message,
+    );
+    let every_required_fact = facts.installed
+        && facts.protocol_supported
+        && facts.owner_trusted
+        && facts.enumeration_available
+        && facts.activation_verified;
+    if facts.fully_available && every_required_fact {
+        CheckEntry::pass(
+            NAME_KWIN_TARGET_ADAPTER,
+            format!("Trusted KDE Plasma/KWin target adapter is fully available ({summary})."),
+        )
+    } else {
+        CheckEntry::fail(
+            NAME_KWIN_TARGET_ADAPTER,
+            format!(
+                "KDE Plasma/KWin foreground input remains fail-closed because the trusted \
+                 target adapter is not fully available ({summary})."
+            ),
+            format!(
+                "Install or update the current-user KWin adapter, then reload KWin: {}",
+                kwin_install_command()
+            ),
+        )
+    }
+}
+
+#[cfg(target_os = "linux")]
+async fn check_kwin_portal_input() -> CheckEntry {
+    if !crate::wayland::kwin_adapter::is_kde_wayland_session() {
+        return CheckEntry::skip(
+            NAME_KWIN_PORTAL_INPUT,
+            "Not a KDE Plasma/KWin Wayland session.",
+        );
+    }
+
+    if !portal_input_enabled() {
+        return classify_kwin_portal_input(false, false, false, None);
+    }
+
+    let portal_probe = tokio::task::spawn_blocking(probe_portal_remote_desktop).await;
+    let (portal_reachable, probe_error) = match portal_probe {
+        Ok(Ok(reachable)) => (reachable, None),
+        Ok(Err(error)) => (false, Some(error.to_string())),
+        Err(error) => (false, Some(format!("portal probe task failed: {error}"))),
+    };
+    let diagnosis = kwin_diagnosis().await;
+    let adapter_available = diagnosis.fully_available()
+        && diagnosis.installed
+        && diagnosis.protocol_supported
+        && diagnosis.owner_trusted
+        && diagnosis.enumeration_available
+        && diagnosis.activation_verified;
+    classify_kwin_portal_input(
+        true,
+        portal_reachable,
+        adapter_available,
+        probe_error.as_deref(),
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+async fn check_kwin_portal_input() -> CheckEntry {
+    CheckEntry::skip(
+        NAME_KWIN_PORTAL_INPUT,
+        "KDE portal/libei integration is only available on Linux.",
+    )
+}
+
+fn classify_kwin_portal_input(
+    compiled: bool,
+    portal_reachable: bool,
+    adapter_available: bool,
+    probe_error: Option<&str>,
+) -> CheckEntry {
+    if !compiled {
+        return CheckEntry::fail(
+            NAME_KWIN_PORTAL_INPUT,
+            "This build does not include the portal/libei input backend required by KDE Plasma/KWin.",
+            "Install a release build or rebuild cua-driver with --features portal-input.",
+        );
+    }
+    if !portal_reachable {
+        let detail = probe_error
+            .map(|error| format!(" ({error})"))
+            .unwrap_or_default();
+        return CheckEntry::fail(
+            NAME_KWIN_PORTAL_INPUT,
+            format!(
+                "The xdg-desktop-portal RemoteDesktop interface is not reachable{detail}; \
+                 portal/libei input is unavailable."
+            ),
+            "Start xdg-desktop-portal and xdg-desktop-portal-kde in this user session.",
+        );
+    }
+    if !adapter_available {
+        return CheckEntry::fail(
+            NAME_KWIN_PORTAL_INPUT,
+            "The RemoteDesktop portal is reachable, but portal/libei input remains blocked \
+             because exact KWin activation and restoration are not fully verified.",
+            format!(
+                "Install or update the current-user KWin adapter, then reload KWin: {}",
+                kwin_install_command()
+            ),
+        );
+    }
+
+    CheckEntry::pass(
+        NAME_KWIN_PORTAL_INPUT,
+        "The RemoteDesktop portal is reachable and portal/libei input is gated by the fully \
+         trusted KWin activation-and-restoration path. The doctor probe does not open a \
+         RemoteDesktop session or trigger a consent prompt.",
     )
 }
 
@@ -367,10 +579,13 @@ fn classify_wayland_backend(
                      focused, potentially the wrong application, so cua-driver \
                      refuses foreground dispatch."
                 ),
-                "On GNOME, install and enable the bundled WinRects Shell helper, then \
-                 log out and back in. KDE foreground input remains unavailable until \
-                 a target-addressable KWin activation adapter is installed; AX actions \
-                 and exact background refusals remain usable.",
+                format!(
+                    "On GNOME, install and enable the bundled WinRects Shell helper, then \
+                     log out and back in. On KDE Plasma/KWin, install or update the trusted \
+                     current-user target adapter and reload KWin with: {}. AX actions and \
+                     exact background refusals remain usable until the full path verifies.",
+                    kwin_install_command()
+                ),
             );
         }
         if portal_libei_enabled {
@@ -521,7 +736,17 @@ fn portal_input_enabled() -> bool {
 
 #[cfg(target_os = "linux")]
 fn target_activation_available() -> bool {
-    crate::wayland::shell_helper::list_windows(None).is_some()
+    if crate::wayland::kwin_adapter::is_kde_wayland_session() {
+        let diagnosis = crate::wayland::kwin_adapter::diagnose();
+        diagnosis.fully_available()
+            && diagnosis.installed
+            && diagnosis.protocol_supported
+            && diagnosis.owner_trusted
+            && diagnosis.enumeration_available
+            && diagnosis.activation_verified
+    } else {
+        crate::wayland::shell_helper::list_windows(None).is_some()
+    }
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -556,7 +781,7 @@ fn probe_portal_screenshot() -> anyhow::Result<bool> {
 }
 
 #[cfg(target_os = "linux")]
-fn probe_portal_remote_desktop() -> anyhow::Result<bool> {
+pub fn probe_portal_remote_desktop() -> anyhow::Result<bool> {
     #[cfg(feature = "portal-input")]
     {
         use ashpd::desktop::remote_desktop::RemoteDesktop;
@@ -601,7 +826,7 @@ fn probe_portal_remote_desktop() -> anyhow::Result<bool> {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn probe_portal_remote_desktop() -> anyhow::Result<bool> {
+pub fn probe_portal_remote_desktop() -> anyhow::Result<bool> {
     Ok(false)
 }
 
@@ -675,6 +900,111 @@ mod tests {
         }
     }
 
+    fn kwin_health(
+        installed: bool,
+        protocol_supported: bool,
+        owner_trusted: bool,
+        enumeration_available: bool,
+        activation_verified: bool,
+    ) -> KwinAdapterHealth<'static> {
+        KwinAdapterHealth {
+            installed,
+            protocol_supported,
+            owner_trusted,
+            enumeration_available,
+            activation_verified,
+            fully_available: installed
+                && protocol_supported
+                && owner_trusted
+                && enumeration_available
+                && activation_verified,
+            message: "fixture diagnosis",
+        }
+    }
+
+    #[test]
+    fn kwin_adapter_health_pass_requires_every_security_gate() {
+        let entry = classify_kwin_target_adapter(kwin_health(true, true, true, true, true));
+
+        assert_eq!(entry.status, CheckStatus::Pass);
+        assert!(
+            entry.message.contains("fully available"),
+            "{}",
+            entry.message
+        );
+        for fact in [
+            "installed=true",
+            "protocol-supported=true",
+            "owner-process-trusted=true",
+            "enumeration=true",
+            "activation-verified=true",
+        ] {
+            assert!(entry.message.contains(fact), "{}", entry.message);
+        }
+    }
+
+    #[test]
+    fn kwin_adapter_health_fails_closed_for_missing_outdated_or_untrusted_adapter() {
+        for facts in [
+            kwin_health(false, false, false, false, false),
+            kwin_health(true, false, true, true, true),
+            kwin_health(true, true, false, true, true),
+            kwin_health(true, true, true, false, true),
+            kwin_health(true, true, true, true, false),
+        ] {
+            let entry = classify_kwin_target_adapter(facts);
+            assert_eq!(entry.status, CheckStatus::Fail, "{}", entry.message);
+            assert!(entry.message.contains("fail-closed"), "{}", entry.message);
+            assert!(
+                entry
+                    .hint
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains(kwin_install_command()),
+                "{:?}",
+                entry.hint
+            );
+        }
+    }
+
+    #[test]
+    fn kwin_adapter_health_does_not_trust_an_inconsistent_ready_claim() {
+        let mut facts = kwin_health(true, true, true, true, false);
+        facts.fully_available = true;
+
+        let entry = classify_kwin_target_adapter(facts);
+
+        assert_eq!(entry.status, CheckStatus::Fail);
+    }
+
+    #[test]
+    fn kwin_portal_health_requires_build_proxy_and_trusted_activation() {
+        let no_feature = classify_kwin_portal_input(false, false, false, None);
+        assert_eq!(no_feature.status, CheckStatus::Fail);
+        assert!(no_feature.message.contains("does not include"));
+
+        let no_proxy =
+            classify_kwin_portal_input(true, false, true, Some("fixture portal unavailable"));
+        assert_eq!(no_proxy.status, CheckStatus::Fail);
+        assert!(no_proxy.message.contains("fixture portal unavailable"));
+
+        let no_adapter = classify_kwin_portal_input(true, true, false, None);
+        assert_eq!(no_adapter.status, CheckStatus::Fail);
+        assert!(no_adapter.message.contains("remains blocked"));
+        assert!(no_adapter
+            .hint
+            .as_deref()
+            .unwrap_or_default()
+            .contains(kwin_install_command()));
+
+        let ready = classify_kwin_portal_input(true, true, true, None);
+        assert_eq!(ready.status, CheckStatus::Pass);
+        assert!(ready.message.contains("fully trusted"));
+        assert!(ready
+            .message
+            .contains("does not open a RemoteDesktop session"));
+    }
+
     #[test]
     fn wayland_backend_passes_on_non_wlroots_when_portal_libei_backend_is_reachable() {
         let snap = WaylandManagers {
@@ -738,6 +1068,15 @@ mod tests {
             entry.message.contains("wrong application"),
             "{}",
             entry.message
+        );
+        assert!(
+            entry
+                .hint
+                .as_deref()
+                .unwrap_or_default()
+                .contains(kwin_install_command()),
+            "{:?}",
+            entry.hint
         );
     }
 

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/kwin_adapter.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/kwin_adapter.rs
@@ -1,0 +1,1606 @@
+//! Trusted KDE Plasma/KWin Wayland window identity and activation adapter.
+//!
+//! KWin does not expose wlroots foreign-toplevel activation.  Its supported
+//! privileged window API is the KWin JavaScript environment, and scripts can
+//! only make outbound D-Bus calls.  For each request we therefore load a
+//! bounded one-shot script into the *verified KWin process*.  The script calls
+//! directly back to a short-lived object on this process's unique bus name.
+//! The callback accepts only the immutable KWin unique name pinned at the
+//! beginning of the transaction.
+//!
+//! Titles, PIDs, and geometry are correlation metadata.  The only compositor
+//! identity is KWin's complete `Window.internalId` UUID.  Public numeric window
+//! IDs are collision-checked handles bound to one KWin/package incarnation;
+//! the UUID is retained in both directions and stale handles are tombstoned.
+
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::os::fd::{AsFd, OwnedFd};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{mpsc, Mutex, OnceLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, Context};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use zbus::blocking::{fdo::DBusProxy, Connection, Proxy};
+use zbus::message::Header;
+use zbus::names::BusName;
+
+use crate::x11::WindowInfo;
+
+pub const PROTOCOL_VERSION: u32 = 1;
+pub const INSTALL_COMMAND: &str = "~/.cua-driver/packages/current/wayland-helper/kwin/install.sh";
+pub const PLUGIN_ID: &str = "cua-kwin.cua";
+
+const KWIN_DEST: &str = "org.kde.KWin";
+const SCRIPTING_PATH: &str = "/Scripting";
+const SCRIPTING_IFACE: &str = "org.kde.kwin.Scripting";
+const SCRIPT_IFACE: &str = "org.kde.kwin.Script";
+const CALLBACK_PATH: &str = "/org/cua/KWinAdapter/Callback";
+const CALLBACK_IFACE: &str = "org.cua.KWinAdapter.Callback";
+const RESPONSE_LIMIT: usize = 1024 * 1024;
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(3);
+const KWIN_ID_NAMESPACE: u32 = 0xE000_0000;
+const KWIN_ID_MASK: u32 = 0x0FFF_FFFF;
+
+const BUNDLED_SOURCE: &str =
+    include_str!("../../../../../wayland-helper/kwin/cua-kwin@cua/contents/code/main.js");
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct AdapterDiagnostic {
+    pub installed: bool,
+    pub protocol_supported: bool,
+    pub owner_trusted: bool,
+    pub enumeration_available: bool,
+    pub activation_verified: bool,
+    pub message: String,
+}
+
+impl AdapterDiagnostic {
+    pub fn fully_available(&self) -> bool {
+        self.installed
+            && self.protocol_supported
+            && self.owner_trusted
+            && self.enumeration_available
+            && self.activation_verified
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct KWinWindow {
+    uuid: String,
+    pid: u32,
+    title: String,
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+    active: bool,
+    minimized: bool,
+    hidden: bool,
+    visible: bool,
+    stacking: usize,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct Snapshot {
+    protocol_version: u32,
+    active_window_uuid: Option<String>,
+    windows: Vec<KWinWindow>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ActivationReply {
+    protocol_version: u32,
+    accepted: bool,
+    target_uuid: String,
+}
+
+struct TrustedSession {
+    owner: String,
+    pid: u32,
+    instance: String,
+    source: &'static str,
+    // The bus-provided pidfd, when supported, pins the process across the
+    // complete focus transaction and closes PID-reuse races.
+    _process_fd: Option<OwnedFd>,
+}
+
+#[derive(Clone, Debug)]
+struct VerifiedGuard {
+    pid: u32,
+    numeric_id: u32,
+}
+
+thread_local! {
+    static VERIFIED_GUARD: RefCell<Option<VerifiedGuard>> = const { RefCell::new(None) };
+}
+
+/// Whether the current thread is executing inside a freshly verified KWin
+/// focus transaction.  Targetless portal operations are allowed only inside
+/// this scope on KDE.
+pub fn verified_focus_guard_active() -> bool {
+    VERIFIED_GUARD.with(|guard| guard.borrow().is_some())
+}
+
+pub fn verified_focus_guard_matches(pid: u32, window_id: u64) -> bool {
+    let Ok(window_id) = u32::try_from(window_id) else {
+        return false;
+    };
+    VERIFIED_GUARD.with(|guard| {
+        guard
+            .borrow()
+            .as_ref()
+            .is_some_and(|guard| guard.pid == pid && guard.numeric_id == window_id)
+    })
+}
+
+fn with_verified_guard<T>(
+    guard: VerifiedGuard,
+    body: impl FnOnce() -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    VERIFIED_GUARD.with(|cell| {
+        let previous = cell.replace(Some(guard));
+        let result = body();
+        cell.replace(previous);
+        result
+    })
+}
+
+pub fn is_kde_wayland_session() -> bool {
+    detect_kde_wayland(
+        std::env::var("XDG_SESSION_TYPE").ok().as_deref(),
+        std::env::var("XDG_CURRENT_DESKTOP").ok().as_deref(),
+        std::env::var_os("WAYLAND_DISPLAY").is_some(),
+    )
+}
+
+fn detect_kde_wayland(
+    session_type: Option<&str>,
+    current_desktop: Option<&str>,
+    has_wayland_display: bool,
+) -> bool {
+    has_wayland_display
+        && session_type.is_some_and(|value| value.eq_ignore_ascii_case("wayland"))
+        && current_desktop.is_some_and(|value| {
+            value
+                .split([':', ';'])
+                .any(|part| part.trim().eq_ignore_ascii_case("kde"))
+        })
+}
+
+#[derive(Debug)]
+struct InstalledAdapter {
+    source_hash: String,
+}
+
+fn data_home() -> Option<PathBuf> {
+    std::env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".local/share")))
+}
+
+fn installed_package_root() -> Option<PathBuf> {
+    Some(data_home()?.join("kwin/scripts").join(PLUGIN_ID))
+}
+
+fn secure_regular_file(path: &Path, expected_uid: u32) -> anyhow::Result<()> {
+    let metadata = std::fs::metadata(path)
+        .with_context(|| format!("kwin_adapter_missing: {} is not installed", path.display()))?;
+    if !metadata.is_file() {
+        anyhow::bail!(
+            "kwin_adapter_untrusted: {} is not a regular file",
+            path.display()
+        );
+    }
+    if metadata.uid() != expected_uid && metadata.uid() != 0 {
+        anyhow::bail!(
+            "kwin_adapter_untrusted: {} is owned by uid {}",
+            path.display(),
+            metadata.uid()
+        );
+    }
+    if metadata.permissions().mode() & 0o022 != 0 {
+        anyhow::bail!(
+            "kwin_adapter_untrusted: {} is group/world writable",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+fn installed_adapter() -> anyhow::Result<InstalledAdapter> {
+    let root = installed_package_root().ok_or_else(|| {
+        anyhow!(
+            "kwin_adapter_missing: HOME/XDG_DATA_HOME does not identify the user data directory"
+        )
+    })?;
+    let source_path = root.join("contents/code/main.js");
+    let metadata_path = root.join("metadata.json");
+    let uid = current_uid();
+    secure_regular_file(&source_path, uid)?;
+    secure_regular_file(&metadata_path, uid)?;
+
+    let source = std::fs::read_to_string(&source_path).with_context(|| {
+        format!(
+            "kwin_adapter_missing: could not read {}",
+            source_path.display()
+        )
+    })?;
+    if source != BUNDLED_SOURCE {
+        anyhow::bail!(
+            "kwin_adapter_outdated: installed KWin adapter source does not match this cua-driver build"
+        );
+    }
+    let metadata: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(&metadata_path)
+            .with_context(|| format!("could not read {}", metadata_path.display()))?,
+    )
+    .context("kwin_adapter_malformed: metadata.json is invalid")?;
+    let plugin_id = metadata
+        .pointer("/KPlugin/Id")
+        .and_then(serde_json::Value::as_str);
+    let protocol = metadata
+        .get("X-Cua-Protocol-Version")
+        .and_then(serde_json::Value::as_u64);
+    if plugin_id != Some(PLUGIN_ID) || protocol != Some(u64::from(PROTOCOL_VERSION)) {
+        anyhow::bail!(
+            "kwin_adapter_outdated: installed metadata has an unsupported id or protocol version"
+        );
+    }
+
+    Ok(InstalledAdapter {
+        source_hash: hex_digest(source.as_bytes()),
+    })
+}
+
+fn current_uid() -> u32 {
+    std::fs::metadata("/proc/self")
+        .map(|metadata| metadata.uid())
+        .unwrap_or(u32::MAX)
+}
+
+#[derive(Clone, Debug)]
+struct OwnerFacts {
+    unique_name: String,
+    pid: u32,
+    uid: u32,
+    comm: String,
+    argv0: Option<PathBuf>,
+    argv0_uid: Option<u32>,
+    argv0_mode: Option<u32>,
+    executable: Option<PathBuf>,
+    executable_uid: Option<u32>,
+    executable_mode: Option<u32>,
+    cgroup: String,
+    parent_argv0: Option<PathBuf>,
+    parent_executable_uid: Option<u32>,
+    parent_executable_mode: Option<u32>,
+    start_time: u64,
+}
+
+fn validate_secure_binary(
+    path: Option<&Path>,
+    uid: Option<u32>,
+    mode: Option<u32>,
+    expected_name: &str,
+) -> bool {
+    path.and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+        == Some(expected_name)
+        && uid == Some(0)
+        && mode.is_some_and(|mode| mode & 0o022 == 0)
+}
+
+fn validate_owner_facts(facts: &OwnerFacts, expected_uid: u32) -> anyhow::Result<()> {
+    if !facts.unique_name.starts_with(':') {
+        anyhow::bail!("kwin_adapter_untrusted_owner: KWin has no immutable unique bus name");
+    }
+    if facts.uid != expected_uid {
+        anyhow::bail!(
+            "kwin_adapter_wrong_uid: KWin bus owner uid {} does not match current uid {expected_uid}",
+            facts.uid
+        );
+    }
+    if facts.pid == 0 || facts.comm.trim() != "kwin_wayland" || facts.start_time == 0 {
+        anyhow::bail!("kwin_adapter_wrong_process: bus owner is not kwin_wayland");
+    }
+
+    let direct = validate_secure_binary(
+        facts.executable.as_deref(),
+        facts.executable_uid,
+        facts.executable_mode,
+        "kwin_wayland",
+    );
+    let argv_binary = validate_secure_binary(
+        facts.argv0.as_deref(),
+        facts.argv0_uid,
+        facts.argv0_mode,
+        "kwin_wayland",
+    );
+    let systemd_chain = argv_binary
+        && facts
+            .cgroup
+            .lines()
+            .any(|line| line.ends_with("/plasma-kwin_wayland.service"))
+        && validate_secure_binary(
+            facts.parent_argv0.as_deref(),
+            facts.parent_executable_uid,
+            facts.parent_executable_mode,
+            "kwin_wayland_wrapper",
+        );
+    if !direct && !systemd_chain {
+        anyhow::bail!(
+            "kwin_adapter_wrong_executable: KWin executable ownership and systemd wrapper identity could not be proven"
+        );
+    }
+    Ok(())
+}
+
+fn proc_stat_fields(pid: u32) -> Option<(u32, u64)> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let (_, fields) = stat.rsplit_once(") ")?;
+    let fields = fields.split_whitespace().collect::<Vec<_>>();
+    // fields[0] is state (field 3), fields[1] is ppid (field 4), and
+    // fields[19] is starttime (field 22).
+    Some((fields.get(1)?.parse().ok()?, fields.get(19)?.parse().ok()?))
+}
+
+fn argv0(pid: u32) -> Option<PathBuf> {
+    let bytes = std::fs::read(format!("/proc/{pid}/cmdline")).ok()?;
+    let first = bytes.split(|byte| *byte == 0).next()?;
+    (!first.is_empty()).then(|| PathBuf::from(std::ffi::OsStr::from_bytes(first)))
+}
+
+use std::os::unix::ffi::OsStrExt;
+
+fn binary_metadata(path: Option<&Path>) -> (Option<u32>, Option<u32>) {
+    path.and_then(|path| std::fs::metadata(path).ok())
+        .map(|metadata| (Some(metadata.uid()), Some(metadata.permissions().mode())))
+        .unwrap_or((None, None))
+}
+
+fn owner_facts(owner: &str, pid: u32, uid: u32) -> anyhow::Result<OwnerFacts> {
+    let executable = std::fs::read_link(format!("/proc/{pid}/exe")).ok();
+    let (executable_uid, executable_mode) = binary_metadata(executable.as_deref());
+    let process_argv0 = argv0(pid);
+    let (argv0_uid, argv0_mode) = binary_metadata(process_argv0.as_deref());
+    let (parent_pid, start_time) = proc_stat_fields(pid).ok_or_else(|| {
+        anyhow!("kwin_adapter_wrong_process: could not read KWin process identity")
+    })?;
+    let parent_argv0 = argv0(parent_pid);
+    let (parent_executable_uid, parent_executable_mode) = binary_metadata(parent_argv0.as_deref());
+    Ok(OwnerFacts {
+        unique_name: owner.to_owned(),
+        pid,
+        uid,
+        comm: std::fs::read_to_string(format!("/proc/{pid}/comm")).unwrap_or_default(),
+        argv0: process_argv0,
+        argv0_uid,
+        argv0_mode,
+        executable,
+        executable_uid,
+        executable_mode,
+        cgroup: std::fs::read_to_string(format!("/proc/{pid}/cgroup")).unwrap_or_default(),
+        parent_argv0,
+        parent_executable_uid,
+        parent_executable_mode,
+        start_time,
+    })
+}
+
+fn trusted_session_on(connection: &Connection) -> anyhow::Result<TrustedSession> {
+    let installed = installed_adapter()?;
+    let dbus = DBusProxy::new(connection).context("kwin_adapter_unavailable: session bus")?;
+    let owner = dbus
+        .get_name_owner(BusName::try_from(KWIN_DEST)?)
+        .context("kwin_adapter_missing: org.kde.KWin has no owner")?;
+    let owner_name = owner.to_string();
+    let owner_bus = BusName::try_from(owner_name.as_str())?;
+    let credentials = dbus
+        .get_connection_credentials(owner_bus.clone())
+        .context("kwin_adapter_untrusted_owner: could not obtain KWin D-Bus credentials")?;
+    let pid = credentials
+        .process_id()
+        .or_else(|| dbus.get_connection_unix_process_id(owner_bus.clone()).ok())
+        .ok_or_else(|| anyhow!("kwin_adapter_untrusted_owner: KWin PID is unavailable"))?;
+    let uid = credentials
+        .unix_user_id()
+        .or_else(|| dbus.get_connection_unix_user(owner_bus).ok())
+        .ok_or_else(|| anyhow!("kwin_adapter_untrusted_owner: KWin UID is unavailable"))?;
+    let facts = owner_facts(&owner_name, pid, uid)?;
+    validate_owner_facts(&facts, current_uid())?;
+    let process_fd = credentials
+        .process_fd()
+        .and_then(|fd| fd.as_fd().try_clone_to_owned().ok());
+    let instance = hex_digest(
+        format!(
+            "{}\0{}\0{}\0{}",
+            owner_name, facts.start_time, PROTOCOL_VERSION, installed.source_hash
+        )
+        .as_bytes(),
+    );
+    Ok(TrustedSession {
+        owner: owner_name,
+        pid,
+        instance,
+        source: BUNDLED_SOURCE,
+        _process_fd: process_fd,
+    })
+}
+
+fn revalidate_owner(connection: &Connection, session: &TrustedSession) -> anyhow::Result<()> {
+    let dbus = DBusProxy::new(connection)?;
+    let current = dbus.get_name_owner(BusName::try_from(KWIN_DEST)?)?;
+    if current.as_str() != session.owner {
+        anyhow::bail!("kwin_adapter_restarted: KWin owner changed during the transaction");
+    }
+    let pid = dbus.get_connection_unix_process_id(BusName::try_from(session.owner.as_str())?)?;
+    if pid != session.pid {
+        anyhow::bail!("kwin_adapter_restarted: KWin process changed during the transaction");
+    }
+    Ok(())
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn request_token() -> String {
+    static NEXT: AtomicU64 = AtomicU64::new(1);
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    hex_digest(
+        format!(
+            "{}:{now}:{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        )
+        .as_bytes(),
+    )
+}
+
+struct Callback {
+    expected_sender: String,
+    expected_token: String,
+    sender: mpsc::SyncSender<anyhow::Result<String>>,
+}
+
+#[zbus::interface(name = "org.cua.KWinAdapter.Callback")]
+impl Callback {
+    fn reply(
+        &self,
+        token: &str,
+        payload: &str,
+        #[zbus(header)] header: Header<'_>,
+    ) -> zbus::fdo::Result<()> {
+        let sender = header.sender().map(ToString::to_string);
+        if sender.as_deref() != Some(self.expected_sender.as_str()) {
+            return Err(zbus::fdo::Error::AccessDenied(
+                "callback sender is not the pinned KWin owner".to_owned(),
+            ));
+        }
+        if token != self.expected_token {
+            return Err(zbus::fdo::Error::AccessDenied(
+                "callback nonce does not match the request".to_owned(),
+            ));
+        }
+        if payload.len() > RESPONSE_LIMIT {
+            let _ = self.sender.try_send(Err(anyhow!(
+                "kwin_adapter_malformed: response exceeded {RESPONSE_LIMIT} bytes"
+            )));
+            return Ok(());
+        }
+        let _ = self.sender.try_send(Ok(payload.to_owned()));
+        Ok(())
+    }
+}
+
+struct TempScript {
+    path: PathBuf,
+    _file: File,
+}
+
+impl TempScript {
+    fn create(contents: &str, token: &str) -> anyhow::Result<Self> {
+        let runtime = std::env::var_os("XDG_RUNTIME_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(std::env::temp_dir);
+        let path = runtime.join(format!("cua-kwin-{token}.js"));
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&path)
+            .with_context(|| format!("could not create one-shot KWin script {}", path.display()))?;
+        file.write_all(contents.as_bytes())?;
+        file.sync_all()?;
+        Ok(Self { path, _file: file })
+    }
+}
+
+impl Drop for TempScript {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+fn js_string(value: &str) -> anyhow::Result<String> {
+    serde_json::to_string(value).context("could not quote KWin script value")
+}
+
+enum ScriptRequest<'a> {
+    Snapshot,
+    Activate(&'a str),
+}
+
+fn generated_script(
+    session: &TrustedSession,
+    destination: &str,
+    token: &str,
+    request: ScriptRequest<'_>,
+) -> anyhow::Result<String> {
+    let expression = match request {
+        ScriptRequest::Snapshot => "cuaKWinSnapshot()".to_owned(),
+        ScriptRequest::Activate(uuid) => format!("cuaKWinActivate({})", js_string(uuid)?),
+    };
+    Ok(format!(
+        "{}\ntry {{\n  const __cuaResult = {};\n  callDBus({}, {}, {}, \"Reply\", {}, JSON.stringify(__cuaResult));\n}} catch (__cuaError) {{\n  callDBus({}, {}, {}, \"Reply\", {}, JSON.stringify({{protocol_version:{}, error:String(__cuaError)}}));\n}}\n",
+        session.source,
+        expression,
+        js_string(destination)?,
+        js_string(CALLBACK_PATH)?,
+        js_string(CALLBACK_IFACE)?,
+        js_string(token)?,
+        js_string(destination)?,
+        js_string(CALLBACK_PATH)?,
+        js_string(CALLBACK_IFACE)?,
+        js_string(token)?,
+        PROTOCOL_VERSION,
+    ))
+}
+
+struct LoadedScript<'a> {
+    proxy: Proxy<'a>,
+    script_proxy: Proxy<'a>,
+    name: String,
+}
+
+impl Drop for LoadedScript<'_> {
+    fn drop(&mut self) {
+        let _: Result<(), _> = self.script_proxy.call("stop", &());
+        let _: Result<bool, _> = self.proxy.call("unloadScript", &(self.name.as_str(),));
+    }
+}
+
+fn run_script(session: &TrustedSession, request: ScriptRequest<'_>) -> anyhow::Result<String> {
+    let connection = Connection::session().context("kwin_adapter_unavailable: session bus")?;
+    revalidate_owner(&connection, session)?;
+    let token = request_token();
+    let destination = connection
+        .unique_name()
+        .ok_or_else(|| anyhow!("kwin_adapter_untrusted_owner: callback has no unique bus name"))?
+        .to_string();
+    let (sender, receiver) = mpsc::sync_channel(1);
+    connection.object_server().at(
+        CALLBACK_PATH,
+        Callback {
+            expected_sender: session.owner.clone(),
+            expected_token: token.clone(),
+            sender,
+        },
+    )?;
+    let contents = generated_script(session, &destination, &token, request)?;
+    let temp = TempScript::create(&contents, &token)?;
+    let script_name = format!("cua-kwin-request-{}", &token[..16]);
+    let scripting = Proxy::new(
+        &connection,
+        session.owner.as_str(),
+        SCRIPTING_PATH,
+        SCRIPTING_IFACE,
+    )?;
+    let path = temp
+        .path
+        .to_str()
+        .ok_or_else(|| anyhow!("KWin adapter path is not UTF-8"))?;
+    let script_id: i32 = scripting.call("loadScript", &(path, script_name.as_str()))?;
+    if script_id < 0 {
+        anyhow::bail!("kwin_adapter_unavailable: KWin refused to load the one-shot adapter");
+    }
+    let object_path = format!("/Scripting/Script{script_id}");
+    let script_proxy = Proxy::new(
+        &connection,
+        session.owner.as_str(),
+        object_path.as_str(),
+        SCRIPT_IFACE,
+    )?;
+    let loaded = LoadedScript {
+        proxy: scripting,
+        script_proxy,
+        name: script_name,
+    };
+    let _: () = loaded.script_proxy.call("run", &())?;
+    let result = receiver
+        .recv_timeout(REQUEST_TIMEOUT)
+        .map_err(|_| anyhow!("kwin_adapter_timeout: KWin did not return a response"))??;
+    revalidate_owner(&connection, session)?;
+    drop(loaded);
+    drop(temp);
+    Ok(result)
+}
+
+fn parse_snapshot(raw: &str) -> anyhow::Result<Snapshot> {
+    let snapshot: Snapshot =
+        serde_json::from_str(raw).context("kwin_adapter_malformed: invalid snapshot JSON")?;
+    validate_snapshot(snapshot)
+}
+
+fn validate_snapshot(snapshot: Snapshot) -> anyhow::Result<Snapshot> {
+    if snapshot.protocol_version != PROTOCOL_VERSION {
+        anyhow::bail!(
+            "kwin_adapter_protocol_unsupported: expected {}, received {}",
+            PROTOCOL_VERSION,
+            snapshot.protocol_version
+        );
+    }
+    let mut uuids = HashSet::with_capacity(snapshot.windows.len());
+    let mut active = None;
+    for (index, window) in snapshot.windows.iter().enumerate() {
+        if !valid_uuid(&window.uuid) {
+            anyhow::bail!(
+                "kwin_adapter_malformed: invalid KWin UUID {:?}",
+                window.uuid
+            );
+        }
+        if !uuids.insert(window.uuid.as_str()) {
+            anyhow::bail!(
+                "kwin_adapter_malformed: duplicate KWin UUID {}",
+                window.uuid
+            );
+        }
+        if window.stacking != index {
+            anyhow::bail!("kwin_adapter_malformed: non-contiguous stacking positions");
+        }
+        if window.visible
+            && (window.minimized || window.hidden || window.width == 0 || window.height == 0)
+        {
+            anyhow::bail!(
+                "kwin_adapter_malformed: inconsistent visibility for {}",
+                window.uuid
+            );
+        }
+        if window.active && active.replace(window.uuid.as_str()).is_some() {
+            anyhow::bail!("kwin_adapter_malformed: multiple active KWin windows");
+        }
+    }
+    if active != snapshot.active_window_uuid.as_deref() {
+        anyhow::bail!("kwin_adapter_malformed: active UUID disagrees with window state");
+    }
+    if snapshot
+        .active_window_uuid
+        .as_deref()
+        .is_some_and(|uuid| !valid_uuid(uuid) || !uuids.contains(uuid))
+    {
+        anyhow::bail!("kwin_adapter_malformed: active UUID is absent from the snapshot");
+    }
+    Ok(snapshot)
+}
+
+fn valid_uuid(value: &str) -> bool {
+    let inner = value
+        .strip_prefix('{')
+        .and_then(|value| value.strip_suffix('}'))
+        .unwrap_or(value);
+    if inner.len() != 36 {
+        return false;
+    }
+    inner.char_indices().all(|(index, character)| match index {
+        8 | 13 | 18 | 23 => character == '-',
+        _ => character.is_ascii_hexdigit(),
+    }) && !inner
+        .chars()
+        .all(|character| character == '0' || character == '-')
+}
+
+fn snapshot_for(session: &TrustedSession) -> anyhow::Result<Snapshot> {
+    parse_snapshot(&run_script(session, ScriptRequest::Snapshot)?)
+}
+
+fn activate_uuid(session: &TrustedSession, uuid: &str) -> anyhow::Result<()> {
+    let raw = run_script(session, ScriptRequest::Activate(uuid))?;
+    let reply: ActivationReply =
+        serde_json::from_str(&raw).context("kwin_adapter_malformed: invalid activation reply")?;
+    if reply.protocol_version != PROTOCOL_VERSION {
+        anyhow::bail!("kwin_adapter_protocol_unsupported: activation reply version");
+    }
+    if reply.target_uuid != uuid {
+        anyhow::bail!("kwin_adapter_malformed: activation reply changed target UUID");
+    }
+    if !reply.accepted {
+        anyhow::bail!("kwin_adapter_target_disappeared: KWin did not find the exact target UUID");
+    }
+    Ok(())
+}
+
+#[derive(Default)]
+struct IdRegistry {
+    instance: Option<String>,
+    by_uuid: HashMap<String, u32>,
+    by_id: HashMap<u32, String>,
+    stale: HashSet<u32>,
+}
+
+impl IdRegistry {
+    fn begin_instance(&mut self, instance: &str) {
+        if self
+            .instance
+            .as_deref()
+            .is_some_and(|known| known != instance)
+        {
+            self.stale.extend(self.by_id.keys().copied());
+            self.by_uuid.clear();
+            self.by_id.clear();
+        }
+        self.instance = Some(instance.to_owned());
+    }
+
+    fn candidate(instance: &str, uuid: &str) -> u32 {
+        let digest = Sha256::digest(format!("{instance}\0{uuid}").as_bytes());
+        let raw = u32::from_be_bytes([digest[0], digest[1], digest[2], digest[3]]);
+        KWIN_ID_NAMESPACE | (raw & KWIN_ID_MASK)
+    }
+
+    fn id_for(&mut self, instance: &str, uuid: &str) -> anyhow::Result<u32> {
+        let candidate = Self::candidate(instance, uuid);
+        self.id_for_candidate(instance, uuid, candidate)
+    }
+
+    fn id_for_candidate(
+        &mut self,
+        instance: &str,
+        uuid: &str,
+        candidate: u32,
+    ) -> anyhow::Result<u32> {
+        self.begin_instance(instance);
+        if let Some(id) = self.by_uuid.get(uuid) {
+            return Ok(*id);
+        }
+        if self.stale.contains(&candidate) {
+            anyhow::bail!(
+                "kwin_adapter_id_collision: new adapter incarnation would reuse stale id {candidate}"
+            );
+        }
+        if let Some(other) = self.by_id.get(&candidate) {
+            anyhow::bail!(
+                "kwin_adapter_id_collision: UUIDs {other} and {uuid} map to numeric id {candidate}"
+            );
+        }
+        self.by_uuid.insert(uuid.to_owned(), candidate);
+        self.by_id.insert(candidate, uuid.to_owned());
+        Ok(candidate)
+    }
+
+    fn uuid_for(&mut self, instance: &str, id: u32) -> anyhow::Result<String> {
+        self.begin_instance(instance);
+        if let Some(uuid) = self.by_id.get(&id) {
+            return Ok(uuid.clone());
+        }
+        if self.stale.contains(&id) {
+            anyhow::bail!("kwin_adapter_stale_id: numeric window id {id} belongs to an older adapter incarnation");
+        }
+        anyhow::bail!("kwin_adapter_unknown_id: numeric window id {id} is not known to KWin")
+    }
+}
+
+fn registry() -> &'static Mutex<IdRegistry> {
+    static REGISTRY: OnceLock<Mutex<IdRegistry>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(IdRegistry::default()))
+}
+
+fn register_snapshot(session: &TrustedSession, snapshot: &Snapshot) -> anyhow::Result<()> {
+    let mut registry = registry()
+        .lock()
+        .map_err(|_| anyhow!("kwin_adapter_unavailable: id registry lock poisoned"))?;
+    registry.begin_instance(&session.instance);
+    for window in &snapshot.windows {
+        registry.id_for(&session.instance, &window.uuid)?;
+    }
+    Ok(())
+}
+
+fn numeric_id(session: &TrustedSession, uuid: &str) -> anyhow::Result<u32> {
+    registry()
+        .lock()
+        .map_err(|_| anyhow!("kwin_adapter_unavailable: id registry lock poisoned"))?
+        .id_for(&session.instance, uuid)
+}
+
+fn resolve_uuid(
+    session: &TrustedSession,
+    snapshot: &Snapshot,
+    pid: u32,
+    window_id: u64,
+) -> anyhow::Result<String> {
+    let id = u32::try_from(window_id)
+        .map_err(|_| anyhow!("kwin_adapter_unknown_id: window id is outside the u32 contract"))?;
+    register_snapshot(session, snapshot)?;
+    let uuid = registry()
+        .lock()
+        .map_err(|_| anyhow!("kwin_adapter_unavailable: id registry lock poisoned"))?
+        .uuid_for(&session.instance, id)?;
+    let window = snapshot
+        .windows
+        .iter()
+        .find(|window| window.uuid == uuid)
+        .ok_or_else(|| anyhow!("kwin_adapter_stale_id: target window was destroyed"))?;
+    if window.pid != pid {
+        anyhow::bail!(
+            "kwin_adapter_wrong_pid: exact KWin window {} belongs to pid {}, not {pid}",
+            uuid,
+            window.pid
+        );
+    }
+    Ok(uuid)
+}
+
+fn window_info(session: &TrustedSession, window: &KWinWindow) -> anyhow::Result<WindowInfo> {
+    let id = numeric_id(session, &window.uuid)?;
+    Ok(WindowInfo {
+        xid: u64::from(id),
+        pid: (window.pid != 0).then_some(window.pid),
+        app_name: window.title.clone(),
+        title: window.title.clone(),
+        is_on_screen: window.visible && !window.minimized && !window.hidden,
+        z_index: Some(window.stacking),
+        x: window.x,
+        y: window.y,
+        width: window.width,
+        height: window.height,
+    })
+}
+
+pub fn list_windows(filter_pid: Option<u32>) -> anyhow::Result<Vec<WindowInfo>> {
+    let connection = Connection::session()?;
+    let session = trusted_session_on(&connection)?;
+    let snapshot = snapshot_for(&session)?;
+    register_snapshot(&session, &snapshot)?;
+    snapshot
+        .windows
+        .iter()
+        .filter(|window| filter_pid.is_none_or(|pid| window.pid == pid))
+        .map(|window| window_info(&session, window))
+        .collect()
+}
+
+pub fn trusted_window_for_id(pid: u32, window_id: u64) -> anyhow::Result<Option<WindowInfo>> {
+    let connection = Connection::session()?;
+    let session = trusted_session_on(&connection)?;
+    let snapshot = snapshot_for(&session)?;
+    let uuid = resolve_uuid(&session, &snapshot, pid, window_id)?;
+    snapshot
+        .windows
+        .iter()
+        .find(|window| window.uuid == uuid)
+        .map(|window| window_info(&session, window))
+        .transpose()
+}
+
+pub fn trusted_window_ids_for_pid(pid: u32) -> anyhow::Result<Vec<u64>> {
+    let connection = Connection::session()?;
+    let session = trusted_session_on(&connection)?;
+    let snapshot = snapshot_for(&session)?;
+    register_snapshot(&session, &snapshot)?;
+    snapshot
+        .windows
+        .iter()
+        .filter(|window| window.pid == pid)
+        .map(|window| numeric_id(&session, &window.uuid).map(u64::from))
+        .collect()
+}
+
+/// Resolve a numeric KWin handle back to its compositor-attested PID.  This is
+/// an exact UUID lookup; it never guesses from a title, geometry, or PID-only
+/// match.
+pub fn pid_for_window_id(window_id: u64) -> anyhow::Result<u32> {
+    let id = u32::try_from(window_id)
+        .map_err(|_| anyhow!("kwin_adapter_unknown_id: window id is outside the u32 contract"))?;
+    let connection = Connection::session()?;
+    let session = trusted_session_on(&connection)?;
+    let snapshot = snapshot_for(&session)?;
+    register_snapshot(&session, &snapshot)?;
+    let uuid = registry()
+        .lock()
+        .map_err(|_| anyhow!("kwin_adapter_unavailable: id registry lock poisoned"))?
+        .uuid_for(&session.instance, id)?;
+    snapshot
+        .windows
+        .iter()
+        .find(|window| window.uuid == uuid)
+        .map(|window| window.pid)
+        .ok_or_else(|| anyhow!("kwin_adapter_stale_id: target window was destroyed"))
+}
+
+pub fn unique_window_for_pid(pid: u32) -> anyhow::Result<WindowInfo> {
+    let windows = list_windows(Some(pid))?;
+    match windows.as_slice() {
+        [window] => Ok(window.clone()),
+        [] => anyhow::bail!("kwin_adapter_unknown_pid: KWin exposes no window for pid {pid}"),
+        _ => anyhow::bail!(
+            "kwin_adapter_ambiguous_pid: KWin exposes {} windows for pid {pid}; an exact compositor id is required",
+            windows.len()
+        ),
+    }
+}
+
+pub fn window_origin_for_pid(pid: u32) -> Option<(i32, i32)> {
+    unique_window_for_pid(pid)
+        .ok()
+        .map(|window| (window.x, window.y))
+}
+
+trait FocusTransport {
+    fn snapshot(&mut self) -> anyhow::Result<Snapshot>;
+    fn activate(&mut self, uuid: &str) -> anyhow::Result<()>;
+}
+
+struct LiveTransport<'a> {
+    session: &'a TrustedSession,
+}
+
+impl FocusTransport for LiveTransport<'_> {
+    fn snapshot(&mut self) -> anyhow::Result<Snapshot> {
+        snapshot_for(self.session)
+    }
+
+    fn activate(&mut self, uuid: &str) -> anyhow::Result<()> {
+        activate_uuid(self.session, uuid)
+    }
+}
+
+fn exact_window<'a>(
+    snapshot: &'a Snapshot,
+    uuid: &str,
+    pid: u32,
+) -> anyhow::Result<&'a KWinWindow> {
+    let window = snapshot
+        .windows
+        .iter()
+        .find(|window| window.uuid == uuid)
+        .ok_or_else(|| anyhow!("kwin_adapter_target_disappeared: exact target was destroyed"))?;
+    if window.pid != pid {
+        anyhow::bail!("kwin_adapter_wrong_pid: exact target changed process ownership");
+    }
+    Ok(window)
+}
+
+fn verify_active(snapshot: &Snapshot, uuid: &str, pid: u32) -> anyhow::Result<()> {
+    let window = exact_window(snapshot, uuid, pid)?;
+    if snapshot.active_window_uuid.as_deref() != Some(uuid) || !window.active {
+        anyhow::bail!(
+            "kwin_adapter_activation_not_verified: KWin accepted activation but exact target is not active"
+        );
+    }
+    if window.minimized || window.hidden || !window.visible {
+        anyhow::bail!(
+            "kwin_adapter_activation_not_verified: exact target is active but not input-visible"
+        );
+    }
+    Ok(())
+}
+
+fn combine_operation_and_restore<T>(
+    operation: anyhow::Result<T>,
+    restoration: anyhow::Result<()>,
+) -> anyhow::Result<T> {
+    match (operation, restoration) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Err(error), Ok(())) => Err(error),
+        (Ok(_), Err(restore)) => Err(anyhow!(
+            "kwin_adapter_restoration_failed: operation succeeded but prior focus was not restored: {restore}"
+        )),
+        (Err(operation), Err(restore)) => Err(anyhow!(
+            "{operation}; kwin_adapter_restoration_failed: prior focus was not restored: {restore}"
+        )),
+    }
+}
+
+fn focus_transaction<T>(
+    transport: &mut impl FocusTransport,
+    pid: u32,
+    numeric_id: u32,
+    uuid: &str,
+    body: impl FnOnce() -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    let before = transport.snapshot()?;
+    let target = exact_window(&before, uuid, pid)?;
+    let previous = before.active_window_uuid.clone().ok_or_else(|| {
+        anyhow!("kwin_adapter_no_focused_window: KWin exposes no restorable active window")
+    })?;
+    let guard = VerifiedGuard { pid, numeric_id };
+
+    if target.active && previous == uuid {
+        verify_active(&before, uuid, pid)?;
+        return with_verified_guard(guard, body);
+    }
+
+    transport.activate(uuid)?;
+    let activated = transport.snapshot()?;
+    verify_active(&activated, uuid, pid)?;
+    let operation = with_verified_guard(guard, body);
+
+    let restoration = (|| {
+        transport.activate(&previous)?;
+        let restored = transport.snapshot()?;
+        if restored.active_window_uuid.as_deref() != Some(previous.as_str())
+            || !restored
+                .windows
+                .iter()
+                .any(|window| window.uuid == previous && window.active)
+        {
+            anyhow::bail!("fresh KWin snapshot did not confirm the previous UUID active");
+        }
+        Ok(())
+    })();
+    combine_operation_and_restore(operation, restoration)
+}
+
+pub fn with_focused_window<T>(
+    pid: u32,
+    window_id: u64,
+    body: impl FnOnce() -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    let numeric_id = u32::try_from(window_id)
+        .map_err(|_| anyhow!("kwin_adapter_unknown_id: window id is outside the u32 contract"))?;
+    let connection = Connection::session()?;
+    let session = trusted_session_on(&connection)?;
+    let before = snapshot_for(&session)?;
+    let uuid = resolve_uuid(&session, &before, pid, window_id)?;
+    // The lifecycle obtains its own fresh pre-operation snapshot.  This is
+    // intentional: numeric resolution cannot double as the focus proof.
+    let mut transport = LiveTransport { session: &session };
+    focus_transaction(&mut transport, pid, numeric_id, &uuid, body)
+}
+
+/// Persistently activate an exact KWin window (used only by explicit
+/// bring-to-front style operations).  Unlike the bounded wrapper, this does not
+/// restore focus, but it still requires a fresh exact-UUID verification.
+pub fn activate_window(pid: u32, window_id: u64) -> anyhow::Result<()> {
+    let connection = Connection::session()?;
+    let session = trusted_session_on(&connection)?;
+    let before = snapshot_for(&session)?;
+    let uuid = resolve_uuid(&session, &before, pid, window_id)?;
+    activate_uuid(&session, &uuid)?;
+    let after = snapshot_for(&session)?;
+    verify_active(&after, &uuid, pid)
+}
+
+pub fn diagnose() -> AdapterDiagnostic {
+    let mut diagnostic = AdapterDiagnostic::default();
+    let installed = match installed_adapter() {
+        Ok(_) => {
+            diagnostic.installed = true;
+            diagnostic.protocol_supported = true;
+            true
+        }
+        Err(error) => {
+            let text = error.to_string();
+            diagnostic.installed = !text.contains("kwin_adapter_missing");
+            diagnostic.protocol_supported = false;
+            diagnostic.message = format!("{text}. Run {INSTALL_COMMAND}");
+            false
+        }
+    };
+    if !installed {
+        return diagnostic;
+    }
+
+    let connection = match Connection::session() {
+        Ok(connection) => connection,
+        Err(error) => {
+            diagnostic.message = format!("KWin session bus unavailable: {error}");
+            return diagnostic;
+        }
+    };
+    let session = match trusted_session_on(&connection) {
+        Ok(session) => {
+            diagnostic.owner_trusted = true;
+            session
+        }
+        Err(error) => {
+            diagnostic.message = error.to_string();
+            return diagnostic;
+        }
+    };
+    let snapshot = match snapshot_for(&session) {
+        Ok(snapshot) => {
+            diagnostic.enumeration_available = true;
+            snapshot
+        }
+        Err(error) => {
+            diagnostic.message = error.to_string();
+            return diagnostic;
+        }
+    };
+    let Some(active) = snapshot.active_window_uuid.as_deref() else {
+        diagnostic.message =
+            "kwin_adapter_no_focused_window: enumeration works, but activation cannot be verified without an active window".to_owned();
+        return diagnostic;
+    };
+    let Some(window) = snapshot.windows.iter().find(|window| window.uuid == active) else {
+        diagnostic.message = "kwin_adapter_malformed: active UUID is absent".to_owned();
+        return diagnostic;
+    };
+    match activate_uuid(&session, active)
+        .and_then(|()| snapshot_for(&session))
+        .and_then(|fresh| verify_active(&fresh, active, window.pid))
+    {
+        Ok(()) => {
+            diagnostic.activation_verified = true;
+            diagnostic.message = format!(
+                "trusted KWin adapter protocol v{PROTOCOL_VERSION}; exact enumeration and activation verification succeeded"
+            );
+        }
+        Err(error) => diagnostic.message = error.to_string(),
+    }
+    diagnostic
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+
+    const A: &str = "{11111111-1111-4111-8111-111111111111}";
+    const B: &str = "{22222222-2222-4222-8222-222222222222}";
+
+    fn window(uuid: &str, pid: u32, active: bool) -> KWinWindow {
+        KWinWindow {
+            uuid: uuid.to_owned(),
+            pid,
+            title: format!("window-{pid}"),
+            x: 10,
+            y: 20,
+            width: 800,
+            height: 600,
+            active,
+            minimized: false,
+            hidden: false,
+            visible: true,
+            stacking: 0,
+        }
+    }
+
+    fn snapshot(active: Option<&str>, mut windows: Vec<KWinWindow>) -> Snapshot {
+        for (index, window) in windows.iter_mut().enumerate() {
+            window.stacking = index;
+            window.active = active == Some(window.uuid.as_str());
+        }
+        Snapshot {
+            protocol_version: PROTOCOL_VERSION,
+            active_window_uuid: active.map(str::to_owned),
+            windows,
+        }
+    }
+
+    fn raw_snapshot() -> String {
+        serde_json::json!({
+            "protocol_version": 1,
+            "active_window_uuid": A,
+            "windows": [{
+                "uuid": A,
+                "pid": 42,
+                "title": "Konsole",
+                "x": 10,
+                "y": 20,
+                "width": 800,
+                "height": 600,
+                "active": true,
+                "minimized": false,
+                "hidden": false,
+                "visible": true,
+                "stacking": 0
+            }]
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn detects_only_kde_wayland() {
+        assert!(detect_kde_wayland(Some("wayland"), Some("KDE"), true));
+        assert!(detect_kde_wayland(
+            Some("WAYLAND"),
+            Some("KDE:PLASMA"),
+            true
+        ));
+        assert!(!detect_kde_wayland(Some("x11"), Some("KDE"), true));
+        assert!(!detect_kde_wayland(Some("wayland"), Some("GNOME"), true));
+        assert!(!detect_kde_wayland(Some("wayland"), Some("KDE"), false));
+    }
+
+    #[test]
+    fn parses_valid_snapshot_and_rejects_malformed_response() {
+        let parsed = parse_snapshot(&raw_snapshot()).expect("valid snapshot");
+        assert_eq!(parsed.windows[0].uuid, A);
+        assert!(parse_snapshot("not-json").is_err());
+
+        let mut unknown = serde_json::from_str::<serde_json::Value>(&raw_snapshot()).unwrap();
+        unknown["unexpected"] = serde_json::json!(true);
+        assert!(parse_snapshot(&unknown.to_string()).is_err());
+
+        let mut duplicate = serde_json::from_str::<serde_json::Value>(&raw_snapshot()).unwrap();
+        let first = duplicate["windows"][0].clone();
+        duplicate["windows"].as_array_mut().unwrap().push(first);
+        assert!(parse_snapshot(&duplicate.to_string()).is_err());
+    }
+
+    #[test]
+    fn rejects_protocol_version_and_inconsistent_active_identity() {
+        let mut wrong = serde_json::from_str::<serde_json::Value>(&raw_snapshot()).unwrap();
+        wrong["protocol_version"] = serde_json::json!(2);
+        assert!(parse_snapshot(&wrong.to_string())
+            .unwrap_err()
+            .to_string()
+            .contains("protocol_unsupported"));
+
+        let mut active = serde_json::from_str::<serde_json::Value>(&raw_snapshot()).unwrap();
+        active["windows"][0]["active"] = serde_json::json!(false);
+        assert!(parse_snapshot(&active.to_string()).is_err());
+    }
+
+    fn secure_facts() -> OwnerFacts {
+        OwnerFacts {
+            unique_name: ":1.15".to_owned(),
+            pid: 2560,
+            uid: 1000,
+            comm: "kwin_wayland\n".to_owned(),
+            argv0: Some(PathBuf::from("/usr/bin/kwin_wayland")),
+            argv0_uid: Some(0),
+            argv0_mode: Some(0o100755),
+            executable: Some(PathBuf::from("/usr/bin/kwin_wayland")),
+            executable_uid: Some(0),
+            executable_mode: Some(0o100755),
+            cgroup: "0::/session.slice/plasma-kwin_wayland.service\n".to_owned(),
+            parent_argv0: Some(PathBuf::from("/usr/bin/kwin_wayland_wrapper")),
+            parent_executable_uid: Some(0),
+            parent_executable_mode: Some(0o100755),
+            start_time: 123,
+        }
+    }
+
+    #[test]
+    fn rejects_untrusted_owner_wrong_uid_process_and_executable() {
+        let facts = secure_facts();
+        validate_owner_facts(&facts, 1000).unwrap();
+
+        let mut owner = facts.clone();
+        owner.unique_name = "org.kde.KWin".to_owned();
+        assert!(validate_owner_facts(&owner, 1000).is_err());
+
+        let mut uid = facts.clone();
+        uid.uid = 1001;
+        assert!(validate_owner_facts(&uid, 1000)
+            .unwrap_err()
+            .to_string()
+            .contains("wrong_uid"));
+
+        let mut process = facts.clone();
+        process.comm = "fake-kwin".to_owned();
+        assert!(validate_owner_facts(&process, 1000)
+            .unwrap_err()
+            .to_string()
+            .contains("wrong_process"));
+
+        let mut executable = facts;
+        executable.executable_uid = Some(1000);
+        executable.cgroup.clear();
+        assert!(validate_owner_facts(&executable, 1000)
+            .unwrap_err()
+            .to_string()
+            .contains("wrong_executable"));
+    }
+
+    #[test]
+    fn validates_fedora_systemd_chain_when_proc_exe_is_unreadable() {
+        let mut facts = secure_facts();
+        facts.executable = None;
+        facts.executable_uid = None;
+        facts.executable_mode = None;
+        validate_owner_facts(&facts, 1000).unwrap();
+    }
+
+    #[test]
+    fn uuid_mapping_retains_identity_and_rejects_collision() {
+        let mut registry = IdRegistry::default();
+        assert_eq!(
+            registry.id_for_candidate("one", A, 0xE000_0001).unwrap(),
+            0xE000_0001
+        );
+        assert_eq!(registry.uuid_for("one", 0xE000_0001).unwrap(), A);
+        let collision = registry
+            .id_for_candidate("one", B, 0xE000_0001)
+            .unwrap_err()
+            .to_string();
+        assert!(collision.contains("id_collision"));
+    }
+
+    #[test]
+    fn helper_restart_tombstones_old_ids() {
+        let mut registry = IdRegistry::default();
+        registry.id_for_candidate("one", A, 0xE000_0001).unwrap();
+        registry.begin_instance("two");
+        let stale = registry
+            .uuid_for("two", 0xE000_0001)
+            .unwrap_err()
+            .to_string();
+        assert!(stale.contains("stale_id"));
+        assert!(registry
+            .id_for_candidate("two", A, 0xE000_0001)
+            .unwrap_err()
+            .to_string()
+            .contains("id_collision"));
+    }
+
+    #[test]
+    fn destroyed_window_is_stale_and_pid_only_is_ambiguous() {
+        let before = snapshot(Some(A), vec![window(A, 42, true), window(B, 42, false)]);
+        assert_eq!(
+            before
+                .windows
+                .iter()
+                .filter(|window| window.pid == 42)
+                .count(),
+            2
+        );
+        let mut registry = IdRegistry::default();
+        let id = registry.id_for_candidate("one", B, 0xE000_0002).unwrap();
+        assert_eq!(registry.uuid_for("one", id).unwrap(), B);
+        let after = snapshot(Some(A), vec![window(A, 42, true)]);
+        assert!(!after.windows.iter().any(|window| window.uuid == B));
+    }
+
+    struct MockTransport {
+        snapshots: VecDeque<anyhow::Result<Snapshot>>,
+        activations: VecDeque<anyhow::Result<()>>,
+        activated: Vec<String>,
+    }
+
+    impl MockTransport {
+        fn new(snapshots: Vec<Snapshot>) -> Self {
+            Self {
+                snapshots: snapshots.into_iter().map(Ok).collect(),
+                activations: VecDeque::new(),
+                activated: Vec::new(),
+            }
+        }
+    }
+
+    impl FocusTransport for MockTransport {
+        fn snapshot(&mut self) -> anyhow::Result<Snapshot> {
+            self.snapshots
+                .pop_front()
+                .unwrap_or_else(|| Err(anyhow!("unexpected snapshot")))
+        }
+
+        fn activate(&mut self, uuid: &str) -> anyhow::Result<()> {
+            self.activated.push(uuid.to_owned());
+            self.activations.pop_front().unwrap_or(Ok(()))
+        }
+    }
+
+    fn before() -> Snapshot {
+        snapshot(Some(A), vec![window(A, 1, true), window(B, 2, false)])
+    }
+
+    fn target_active() -> Snapshot {
+        snapshot(Some(B), vec![window(A, 1, false), window(B, 2, true)])
+    }
+
+    fn restored() -> Snapshot {
+        before()
+    }
+
+    #[test]
+    fn successful_activation_operation_and_restoration() {
+        let mut transport = MockTransport::new(vec![before(), target_active(), restored()]);
+        let value = focus_transaction(&mut transport, 2, 9, B, || Ok(7)).unwrap();
+        assert_eq!(value, 7);
+        assert_eq!(transport.activated, vec![B, A]);
+    }
+
+    #[test]
+    fn activation_accepted_without_focus_never_runs_operation() {
+        let mut transport = MockTransport::new(vec![before(), before()]);
+        let called = std::cell::Cell::new(false);
+        let error = focus_transaction(&mut transport, 2, 9, B, || {
+            called.set(true);
+            Ok(())
+        })
+        .unwrap_err();
+        assert!(!called.get());
+        assert!(error.to_string().contains("activation_not_verified"));
+    }
+
+    #[test]
+    fn target_already_focused_runs_without_restore() {
+        let already = target_active();
+        let mut transport = MockTransport::new(vec![already]);
+        focus_transaction(&mut transport, 2, 9, B, || Ok(())).unwrap();
+        assert!(transport.activated.is_empty());
+    }
+
+    #[test]
+    fn target_disappearing_during_activation_is_refused() {
+        let disappeared = snapshot(Some(A), vec![window(A, 1, true)]);
+        let mut transport = MockTransport::new(vec![before(), disappeared]);
+        let called = std::cell::Cell::new(false);
+        assert!(focus_transaction(&mut transport, 2, 9, B, || {
+            called.set(true);
+            Ok(())
+        })
+        .unwrap_err()
+        .to_string()
+        .contains("target_disappeared"));
+        assert!(!called.get());
+    }
+
+    #[test]
+    fn minimized_target_must_become_visible_before_operation() {
+        let mut minimized = window(B, 2, false);
+        minimized.minimized = true;
+        minimized.visible = false;
+        let before = snapshot(Some(A), vec![window(A, 1, true), minimized.clone()]);
+        let still_minimized = snapshot(
+            Some(B),
+            vec![window(A, 1, false), {
+                minimized.active = true;
+                minimized
+            }],
+        );
+        let mut transport = MockTransport::new(vec![before, still_minimized]);
+        assert!(focus_transaction(&mut transport, 2, 9, B, || Ok(()))
+            .unwrap_err()
+            .to_string()
+            .contains("not input-visible"));
+    }
+
+    #[test]
+    fn no_focused_window_refuses_before_activation() {
+        let none = snapshot(None, vec![window(B, 2, false)]);
+        let mut transport = MockTransport::new(vec![none]);
+        assert!(focus_transaction(&mut transport, 2, 9, B, || Ok(()))
+            .unwrap_err()
+            .to_string()
+            .contains("no_focused_window"));
+        assert!(transport.activated.is_empty());
+    }
+
+    #[test]
+    fn operation_failure_with_successful_restore_preserves_operation_error() {
+        let mut transport = MockTransport::new(vec![before(), target_active(), restored()]);
+        let error = focus_transaction::<() /* result */>(&mut transport, 2, 9, B, || {
+            anyhow::bail!("operation failed")
+        })
+        .unwrap_err();
+        assert_eq!(error.to_string(), "operation failed");
+    }
+
+    #[test]
+    fn operation_success_with_failed_restore_reports_restoration() {
+        let mut transport = MockTransport::new(vec![before(), target_active(), target_active()]);
+        let error = focus_transaction(&mut transport, 2, 9, B, || Ok(())).unwrap_err();
+        assert!(error.to_string().contains("restoration_failed"));
+        assert!(error.to_string().contains("operation succeeded"));
+    }
+
+    #[test]
+    fn operation_and_restoration_failures_are_combined() {
+        let mut transport = MockTransport::new(vec![before(), target_active(), target_active()]);
+        let error = focus_transaction::<()>(&mut transport, 2, 9, B, || {
+            anyhow::bail!("operation failed")
+        })
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("operation failed"));
+        assert!(error.contains("restoration_failed"));
+    }
+
+    #[test]
+    fn valid_uuid_accepts_braced_and_bare_and_rejects_degenerate_forms() {
+        assert!(valid_uuid(A));
+        assert!(valid_uuid("11111111-1111-4111-8111-111111111111"));
+        // The compositor UUID must be a real identity: all-zero, wrong length,
+        // and misplaced separators are rejected so a spoofed handle cannot pass.
+        assert!(!valid_uuid("{00000000-0000-0000-0000-000000000000}"));
+        assert!(!valid_uuid("00000000-0000-0000-0000-000000000000"));
+        assert!(!valid_uuid("{1111-1111-4111-8111-111111111111}"));
+        assert!(!valid_uuid("11111111x1111-4111-8111-111111111111"));
+        assert!(!valid_uuid("{11111111-1111-4111-8111-11111111111g}"));
+        assert!(!valid_uuid(""));
+    }
+
+    #[test]
+    fn validate_snapshot_rejects_noncontiguous_stacking() {
+        let mut window = window(A, 42, true);
+        window.stacking = 3;
+        let snapshot = Snapshot {
+            protocol_version: PROTOCOL_VERSION,
+            active_window_uuid: Some(A.to_owned()),
+            windows: vec![window],
+        };
+        assert!(validate_snapshot(snapshot)
+            .unwrap_err()
+            .to_string()
+            .contains("non-contiguous stacking"));
+    }
+
+    #[test]
+    fn validate_snapshot_rejects_multiple_active_windows() {
+        let snapshot = Snapshot {
+            protocol_version: PROTOCOL_VERSION,
+            active_window_uuid: Some(A.to_owned()),
+            windows: vec![window(A, 1, true), {
+                let mut second = window(B, 2, true);
+                second.stacking = 1;
+                second
+            }],
+        };
+        assert!(validate_snapshot(snapshot)
+            .unwrap_err()
+            .to_string()
+            .contains("multiple active"));
+    }
+
+    #[test]
+    fn validate_snapshot_rejects_inconsistent_visibility() {
+        let mut window = window(A, 42, true);
+        window.minimized = true;
+        window.visible = true;
+        let snapshot = Snapshot {
+            protocol_version: PROTOCOL_VERSION,
+            active_window_uuid: Some(A.to_owned()),
+            windows: vec![window],
+        };
+        assert!(validate_snapshot(snapshot)
+            .unwrap_err()
+            .to_string()
+            .contains("inconsistent visibility"));
+    }
+
+    #[test]
+    fn validate_snapshot_rejects_active_uuid_absent_from_windows() {
+        let snapshot = Snapshot {
+            protocol_version: PROTOCOL_VERSION,
+            active_window_uuid: Some(B.to_owned()),
+            windows: vec![window(A, 1, false)],
+        };
+        assert!(validate_snapshot(snapshot).is_err());
+    }
+
+    #[test]
+    fn source_contains_exact_current_kwin_api_and_no_top_level_request() {
+        assert!(BUNDLED_SOURCE.contains("workspace.stackingOrder"));
+        assert!(BUNDLED_SOURCE.contains("workspace.activeWindow"));
+        assert!(BUNDLED_SOURCE.contains("internalId.toString()"));
+        assert!(BUNDLED_SOURCE.contains("function cuaKWinSnapshot"));
+        assert!(BUNDLED_SOURCE.contains("function cuaKWinActivate"));
+        assert!(!BUNDLED_SOURCE.contains("org.cua.KWinAdapter.Callback"));
+        // KWin frame geometry is fractional under fractional scaling; the
+        // snapshot contract is integer pixels, so the script must round every
+        // geometry field or the driver rejects the snapshot as malformed.
+        assert!(BUNDLED_SOURCE.contains("Math.round(Number(geometry.x))"));
+        assert!(BUNDLED_SOURCE.contains("Math.round(Number(geometry.y))"));
+        assert!(BUNDLED_SOURCE.contains("Math.round(Number(geometry.width))"));
+        assert!(BUNDLED_SOURCE.contains("Math.round(Number(geometry.height))"));
+    }
+}

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
@@ -12,12 +12,14 @@
 
 pub mod ext_screencopy;
 pub mod ext_toplevel;
+pub mod kwin_adapter;
 pub mod overlay;
 pub mod persistent_vptr;
 pub(crate) mod portal;
 pub mod portal_screenshot;
 pub mod shell_helper;
 pub mod sway_ipc;
+pub mod target_adapter;
 mod virtual_keyboard;
 // RemoteDesktop/libei input is portable and ships in release binaries.
 // PipeWire ScreenCast capture remains separately gated for modern/Nix builds.
@@ -1062,6 +1064,84 @@ fn with_libei_fallback<T>(
     }
 }
 
+/// Run one focus-bound portal/libei operation.  KDE requires the complete
+/// KWin UUID activation/verification/restoration transaction; GNOME retains
+/// its existing verified activation path and wlroots never reaches this
+/// fallback.  A nested call inside an already-verified KWin browser operation
+/// reuses that bounded guard rather than changing focus twice.
+///
+/// Compiled in every build (not just `portal-input`): the pointer and keyboard
+/// dispatch seams reference it from closures that must type-check even when the
+/// libei fallback is inert, and its body only calls always-available adapter
+/// and activation helpers.  The nested `cua-compositor` inject backend keeps
+/// its own routing, so inject mode defers to `activate_window_for_input`
+/// instead of taking the KWin path.
+fn with_verified_portal_target<T>(
+    window_id: u64,
+    body: impl FnOnce() -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    if !is_inject_mode() && kwin_adapter::is_kde_wayland_session() {
+        let pid = kwin_adapter::pid_for_window_id(window_id)?;
+        if kwin_adapter::verified_focus_guard_matches(pid, window_id) {
+            return body();
+        }
+        return kwin_adapter::with_focused_window(pid, window_id, body);
+    }
+    activate_window_for_input(window_id)?;
+    body()
+}
+
+/// Targetless desktop portal calls are safe on KWin only while an outer exact
+/// target transaction is active (browser consent/setup use this form after
+/// resolving screen coordinates through AT-SPI).  Compiled in every build for
+/// the same closure-type-checking reason as [`with_verified_portal_target`].
+fn with_verified_portal_desktop<T>(body: impl FnOnce() -> anyhow::Result<T>) -> anyhow::Result<T> {
+    if !is_inject_mode()
+        && kwin_adapter::is_kde_wayland_session()
+        && !kwin_adapter::verified_focus_guard_active()
+    {
+        anyhow::bail!(
+            "foreground_unavailable: KDE portal input requires an exact verified KWin target"
+        );
+    }
+    body()
+}
+
+/// Establish the portal/EIS pointer device before a KWin focus transaction.
+/// The first portal consent dialog may take focus; preparing first ensures the
+/// subsequent compositor snapshot sees the real post-consent foreground.
+pub fn prepare_portal_pointer() -> anyhow::Result<()> {
+    if !kwin_adapter::is_kde_wayland_session() {
+        return Ok(());
+    }
+    #[cfg(feature = "portal-input")]
+    {
+        return libei_wait_pointer_ready();
+    }
+    #[cfg(not(feature = "portal-input"))]
+    {
+        anyhow::bail!(
+            "foreground_unavailable: this cua-driver build has no portal/libei input backend"
+        )
+    }
+}
+
+pub fn prepare_portal_keyboard() -> anyhow::Result<()> {
+    if !kwin_adapter::is_kde_wayland_session() {
+        return Ok(());
+    }
+    #[cfg(feature = "portal-input")]
+    {
+        return libei_wait_keyboard_ready();
+    }
+    #[cfg(not(feature = "portal-input"))]
+    {
+        anyhow::bail!(
+            "foreground_unavailable: this cua-driver build has no portal/libei input backend"
+        )
+    }
+}
+
 /// Live virtual-pointer session: connection + queue + the bound objects every
 /// pointer op (click, scroll, drag) needs. Returned by [`open_vptr_session`].
 pub struct VptrSession {
@@ -1284,8 +1364,7 @@ pub fn click(window_id: u64, x: i32, y: i32, count: u32, button: u8) -> anyhow::
         || click_vptr(Some(window_id), x, y, count, button),
         || {
             libei_wait_pointer_ready()?;
-            activate_window_for_input(window_id)?;
-            libei_click(x, y, count, button)
+            with_verified_portal_target(window_id, || libei_click(x, y, count, button))
         },
     )
 }
@@ -1300,7 +1379,10 @@ pub fn click_desktop(x: i32, y: i32, count: u32, button: u8) -> anyhow::Result<(
     }
     with_libei_fallback(
         || click_vptr(None, x, y, count, button),
-        || libei_click(x, y, count, button),
+        || {
+            libei_wait_pointer_ready()?;
+            with_verified_portal_desktop(|| libei_click(x, y, count, button))
+        },
     )
 }
 
@@ -1445,11 +1527,12 @@ pub fn scroll_at(
         || scroll_vptr(Some(window_id), point, &direction, amount),
         || {
             libei_wait_scroll_ready()?;
-            activate_window_for_input(window_id)?;
-            if let Some((x, y)) = point {
-                libei_move_absolute(x, y)?;
-            }
-            libei_scroll(&direction, amount)
+            with_verified_portal_target(window_id, || {
+                if let Some((x, y)) = point {
+                    libei_move_absolute(x, y)?;
+                }
+                libei_scroll(&direction, amount)
+            })
         },
     )
 }
@@ -1464,8 +1547,10 @@ pub fn scroll_desktop(x: i32, y: i32, direction: &str, amount: u32) -> anyhow::R
         || scroll_vptr(None, Some((x, y)), &direction, amount),
         || {
             libei_wait_scroll_ready()?;
-            libei_move_absolute(x, y)?;
-            libei_scroll(&direction, amount)
+            with_verified_portal_desktop(|| {
+                libei_move_absolute(x, y)?;
+                libei_scroll(&direction, amount)
+            })
         },
     )
 }
@@ -1549,7 +1634,15 @@ pub fn last_synth_cursor_pos() -> Option<(i32, i32)> {
 pub fn move_cursor_absolute(window_id: Option<u64>, x: i32, y: i32) -> anyhow::Result<()> {
     with_libei_fallback(
         || move_cursor_absolute_vptr(window_id, x, y),
-        || libei_move_absolute(x, y),
+        || {
+            libei_wait_pointer_ready()?;
+            match window_id {
+                Some(window_id) => {
+                    with_verified_portal_target(window_id, || libei_move_absolute(x, y))
+                }
+                None => with_verified_portal_desktop(|| libei_move_absolute(x, y)),
+            }
+        },
     )
 }
 
@@ -1587,8 +1680,9 @@ pub fn drag(
         || drag_vptr(Some(window_id), from_x, from_y, to_x, to_y, steps, button),
         || {
             libei_wait_pointer_ready()?;
-            activate_window_for_input(window_id)?;
-            libei_drag(from_x, from_y, to_x, to_y, steps, duration_ms, button)
+            with_verified_portal_target(window_id, || {
+                libei_drag(from_x, from_y, to_x, to_y, steps, duration_ms, button)
+            })
         },
     )
 }
@@ -1607,7 +1701,9 @@ pub fn drag_desktop(
         || drag_vptr(None, from_x, from_y, to_x, to_y, steps, button),
         || {
             libei_wait_pointer_ready()?;
-            libei_drag(from_x, from_y, to_x, to_y, steps, duration_ms, button)
+            with_verified_portal_desktop(|| {
+                libei_drag(from_x, from_y, to_x, to_y, steps, duration_ms, button)
+            })
         },
     )
 }
@@ -1679,31 +1775,37 @@ pub fn type_text(window_id: u64, text: &str) -> anyhow::Result<()> {
     if text.is_empty() {
         return Ok(());
     }
-    activate_window_for_input(window_id)?;
-    // Lead with a no-op Shift_L tap: on a freshly-focused window under a headless
-    // seat (notably sway), the compositor needs the first virtual-keyboard event
-    // to wire up keyboard routing, and that first key is dropped. Sacrificing a
-    // modifier tap (no character) absorbs the drop so the real text lands intact;
-    // it's harmless where routing is already live (labwc).
-    let result = std::process::Command::new("wtype")
-        .args(["-k", "Shift_L", "--"])
-        .arg(text)
-        .output();
-    match result {
-        Ok(out) if out.status.success() => Ok(()),
-        // `wtype` relies on `zwp_virtual_keyboard_v1`, which KWin/Plasma and
-        // Mutter/GNOME don't implement (and the binary may be missing wtype
-        // entirely). On a portal-input build, route typing through libei's
-        // `ei_text` interface instead. See #1982.
-        other => with_wtype_libei_fallback(
-            || {
-                libei_wait_keyboard_ready()?;
-                activate_window_for_input(window_id)?;
-                libei_type_text(text)
-            },
-            other.map(|o| String::from_utf8_lossy(&o.stderr).into_owned()),
-        ),
-    }
+    // Hold the exact target focused for the whole keyboard lifetime. On KDE this
+    // is the verified KWin activation/verification/restoration transaction; on
+    // wlroots/GNOME and the nested inject backend it is the prior
+    // `activate_window_for_input` path. Focus must not change between the
+    // sacrificial primer and the real text.
+    with_verified_portal_target(window_id, || {
+        // Lead with a no-op Shift_L tap: on a freshly-focused window under a
+        // headless seat (notably sway), the compositor needs the first
+        // virtual-keyboard event to wire up keyboard routing, and that first key
+        // is dropped. Sacrificing a modifier tap (no character) absorbs the drop
+        // so the real text lands intact; it's harmless where routing is already
+        // live (labwc).
+        let result = std::process::Command::new("wtype")
+            .args(["-k", "Shift_L", "--"])
+            .arg(text)
+            .output();
+        match result {
+            Ok(out) if out.status.success() => Ok(()),
+            // `wtype` relies on `zwp_virtual_keyboard_v1`, which KWin/Plasma and
+            // Mutter/GNOME don't implement (and the binary may be missing wtype
+            // entirely). On a portal-input build, route typing through libei's
+            // `ei_text` interface instead. See #1982.
+            other => with_wtype_libei_fallback(
+                || {
+                    libei_wait_keyboard_ready()?;
+                    libei_type_text(text)
+                },
+                other.map(|o| String::from_utf8_lossy(&o.stderr).into_owned()),
+            ),
+        }
+    })
 }
 
 /// Type into a surface whose exact Sway container is already held focused by
@@ -1755,25 +1857,26 @@ pub fn type_text_then_key_focused(text: &str, key: &str) -> anyhow::Result<()> {
 
 /// Press a single named key into the focused Wayland surface via `wtype -k`.
 pub fn press_key(window_id: u64, key: &str) -> anyhow::Result<()> {
-    activate_window_for_input(window_id)?;
     let keysym = key_to_keysym(key);
-    // Keep the sacrificial modifier and requested key in one virtual-keyboard
-    // lifetime. Starting a second wtype process creates a fresh protocol object,
-    // causing headless seats to drop the requested key as their first event.
-    let result = std::process::Command::new("wtype")
-        .args(["-k", "Shift_L", "-k", &keysym])
-        .output();
-    match result {
-        Ok(out) if out.status.success() => Ok(()),
-        other => with_wtype_libei_fallback(
-            || {
-                libei_wait_keyboard_ready()?;
-                activate_window_for_input(window_id)?;
-                libei_press_key(key)
-            },
-            other.map(|o| String::from_utf8_lossy(&o.stderr).into_owned()),
-        ),
-    }
+    with_verified_portal_target(window_id, || {
+        // Keep the sacrificial modifier and requested key in one virtual-keyboard
+        // lifetime. Starting a second wtype process creates a fresh protocol
+        // object, causing headless seats to drop the requested key as their first
+        // event.
+        let result = std::process::Command::new("wtype")
+            .args(["-k", "Shift_L", "-k", &keysym])
+            .output();
+        match result {
+            Ok(out) if out.status.success() => Ok(()),
+            other => with_wtype_libei_fallback(
+                || {
+                    libei_wait_keyboard_ready()?;
+                    libei_press_key(key)
+                },
+                other.map(|o| String::from_utf8_lossy(&o.stderr).into_owned()),
+            ),
+        }
+    })
 }
 
 /// Press one key while an outer exact-container focus guard is active.
@@ -1804,39 +1907,39 @@ pub fn press_key_focused(key: &str) -> anyhow::Result<()> {
 /// straight to wtype's `-k` so single-character keys and X keysym names work
 /// as-is. This is the Wayland equivalent of the X11 `send_key` modifier mask.
 pub fn hotkey(window_id: u64, keys: &[String]) -> anyhow::Result<()> {
-    activate_window_for_input(window_id)?;
     let (mods, final_key) = partition_modifiers(keys)?;
-    if let Ok(()) = virtual_keyboard::hotkey(&mods, &final_key) {
-        return Ok(());
-    }
-    let keysym = key_to_keysym(&final_key);
-    let args = wtype_hotkey_args(&mods, &keysym);
-    let result = std::process::Command::new("wtype").args(&args).output();
-    match result {
-        Ok(out) if out.status.success() => Ok(()),
-        other => {
-            let stderr = other.map(|o| String::from_utf8_lossy(&o.stderr).into_owned());
-            #[cfg(feature = "portal-input")]
-            {
-                return with_wtype_libei_fallback(
-                    || {
-                        libei::wait_keyboard_ready()?;
-                        activate_window_for_input(window_id)?;
-                        libei_hotkey(&mods, &final_key)
-                    },
-                    stderr,
-                );
-            }
-            #[cfg(not(feature = "portal-input"))]
-            {
-                anyhow::bail!(
-                    "wtype {} failed: {}",
-                    args.join(" "),
-                    stderr.unwrap_or_else(|_| "wtype unavailable".into())
-                );
+    with_verified_portal_target(window_id, || {
+        if let Ok(()) = virtual_keyboard::hotkey(&mods, &final_key) {
+            return Ok(());
+        }
+        let keysym = key_to_keysym(&final_key);
+        let args = wtype_hotkey_args(&mods, &keysym);
+        let result = std::process::Command::new("wtype").args(&args).output();
+        match result {
+            Ok(out) if out.status.success() => Ok(()),
+            other => {
+                let stderr = other.map(|o| String::from_utf8_lossy(&o.stderr).into_owned());
+                #[cfg(feature = "portal-input")]
+                {
+                    return with_wtype_libei_fallback(
+                        || {
+                            libei::wait_keyboard_ready()?;
+                            libei_hotkey(&mods, &final_key)
+                        },
+                        stderr,
+                    );
+                }
+                #[cfg(not(feature = "portal-input"))]
+                {
+                    anyhow::bail!(
+                        "wtype {} failed: {}",
+                        args.join(" "),
+                        stderr.unwrap_or_else(|_| "wtype unavailable".into())
+                    );
+                }
             }
         }
-    }
+    })
 }
 
 /// Send a chord while an outer exact-container focus guard is active.

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/target_adapter.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/target_adapter.rs
@@ -1,0 +1,71 @@
+//! Explicit compositor dispatch for trusted target-addressable Wayland helpers.
+//!
+//! This intentionally does not pretend that every Wayland compositor shares a
+//! generic control protocol.  KDE uses the KWin UUID adapter, GNOME uses the
+//! Shell stable-sequence helper, and wlroots/Sway remains on its native path.
+
+use crate::x11::WindowInfo;
+
+pub fn list_windows(filter_pid: Option<u32>) -> Option<Vec<WindowInfo>> {
+    if super::kwin_adapter::is_kde_wayland_session() {
+        match super::kwin_adapter::list_windows(filter_pid) {
+            Ok(windows) => Some(windows),
+            Err(error) => {
+                tracing::debug!("trusted KWin enumeration unavailable: {error}");
+                None
+            }
+        }
+    } else {
+        super::shell_helper::list_windows(filter_pid)
+    }
+}
+
+pub fn trusted_window_for_id(pid: u32, window_id: u64) -> anyhow::Result<Option<WindowInfo>> {
+    if super::kwin_adapter::is_kde_wayland_session() {
+        super::kwin_adapter::trusted_window_for_id(pid, window_id)
+    } else {
+        Ok(super::shell_helper::trusted_window_for_id(pid, window_id))
+    }
+}
+
+pub fn trusted_window_ids_for_pid(pid: u32) -> anyhow::Result<Option<Vec<u64>>> {
+    if super::kwin_adapter::is_kde_wayland_session() {
+        super::kwin_adapter::trusted_window_ids_for_pid(pid).map(Some)
+    } else {
+        Ok(super::shell_helper::trusted_window_ids_for_pid(pid))
+    }
+}
+
+pub fn window_origin_for_pid(pid: u32) -> Option<(i32, i32)> {
+    if super::kwin_adapter::is_kde_wayland_session() {
+        super::kwin_adapter::window_origin_for_pid(pid)
+    } else {
+        super::shell_helper::window_origin_for_pid(pid)
+    }
+}
+
+pub fn with_focused_window<T>(
+    pid: u32,
+    window_id: u64,
+    body: impl FnOnce() -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    if super::kwin_adapter::is_kde_wayland_session() {
+        super::kwin_adapter::with_focused_window(pid, window_id, body)
+    } else {
+        super::shell_helper::with_focused_window(pid, window_id, body)
+    }
+}
+
+pub fn activate_window(pid: u32, window_id: u64) -> anyhow::Result<()> {
+    if super::kwin_adapter::is_kde_wayland_session() {
+        return super::kwin_adapter::activate_window(pid, window_id);
+    }
+    super::shell_helper::trusted_window_for_id(pid, window_id).ok_or_else(|| {
+        anyhow::anyhow!("foreground_unavailable: no exact GNOME Shell window owns the target")
+    })?;
+    if super::shell_helper::activate_window(window_id) {
+        Ok(())
+    } else {
+        anyhow::bail!("foreground_unavailable: GNOME Shell did not verify exact activation")
+    }
+}

--- a/libs/cua-driver/wayland-helper/README.md
+++ b/libs/cua-driver/wayland-helper/README.md
@@ -1,4 +1,11 @@
-# cua WinRects — GNOME Shell helper extension (Wayland)
+# cua compositor helpers — GNOME and KDE Wayland
+
+These packages provide compositor-owned window identity and activation where
+ordinary Wayland clients cannot. They are desktop-specific: WinRects targets
+GNOME Shell/Mutter, and the KWin adapter targets KDE Plasma 6/KWin. Installing
+either package does not claim support for other Wayland compositors.
+
+## GNOME Shell/Mutter: WinRects
 
 A small GNOME Shell extension that lets cua-driver get **pixel coordinates**,
 activate an exact target window, capture the compositor stage, and draw the
@@ -35,7 +42,7 @@ It exposes `org.cua.WinRects` on the session bus:
 It runs in the shell's privileged context, so **no xdg-desktop-portal grant** is
 needed (unlike libei/RemoteDesktop).
 
-## Install
+### Install on GNOME
 
 ```
 ~/.cua-driver/packages/current/wayland-helper/install.sh
@@ -63,6 +70,67 @@ focused Shell window is restored and verified.
 wlroots compositors such as Sway and labwc do not need it: cua-driver uses
 foreign-toplevel activation, virtual-pointer input, and layer-shell there.
 
-KDE Plasma Wayland needs an equivalent target-addressable KWin activation
-adapter; it is not yet provided. Portal reachability alone is insufficient
-because RemoteDesktop/libei input is global to the compositor focus.
+## KDE Plasma 6/KWin: exact target adapter
+
+The adapter source at `kwin/cua-kwin@cua` is a passive KWin 6 script with
+protocol version 1. KDE's KPackage ID grammar does not permit `@`, so its
+installed KWin package ID is the equivalent `cua-kwin.cua`; metadata retains
+`cua-kwin@cua` as the adapter ID. It defines two primitives in KWin's own
+scripting context:
+
+- `cuaKWinSnapshot()` returns KWin's current stacking order, exact unmodified
+  `KWin::Window.internalId` UUID, PID, frame geometry, caption,
+  active/minimized/hidden/visible state, and the active-window UUID.
+- `cuaKWinActivate(uuid)` resolves one complete internal UUID and asks KWin to
+  unminimize, raise, and activate only that window. Its acknowledgement is not
+  treated as proof of focus; cua-driver obtains another fresh snapshot and
+  compares the complete UUID before any portal/libei input is sent.
+
+Merely enabling the package performs no enumeration, activation, signal
+registration, or other mutation. cua-driver invokes one primitive at a time
+through the verified current user's genuine `kwin_wayland` process. The driver
+retains each complete internal UUID behind its numeric API identifier, rejects
+collisions, stale or unknown identifiers, and ambiguous PID-only targeting.
+
+For a foreground operation, cua-driver records the exact active UUID, activates
+and verifies the requested UUID, runs one bounded focus-sensitive operation,
+then restores and verifies the prior UUID. Any missing, malformed, outdated, or
+untrusted adapter state fails closed before global input.
+
+### Install or update on KDE
+
+```bash
+~/.cua-driver/packages/current/wayland-helper/kwin/install.sh
+# From a source checkout:
+./libs/cua-driver/wayland-helper/kwin/install.sh
+./libs/cua-driver/wayland-helper/kwin/diagnose.sh
+cua-driver doctor
+```
+
+Installation uses Plasma's current-user KPackage directory and updates only
+the adapter's `cua-kwin.cuaEnabled` KWin setting. It never needs root and does
+not edit unrelated KWin settings. A running KWin session is reconfigured over
+its session-bus API, so logout/login is not required. If KWin is not running,
+the enabled package is loaded at the next ordinary Plasma session start.
+
+Re-run `kwin/install.sh` to update the package. The diagnostic is read-only and
+reports the session type, package/protocol state, KWin reachability, enabled
+state, and whether KWin loaded the script. `cua-driver doctor` performs the
+stronger owner/process, enumeration, exact-activation, and portal checks.
+
+### Uninstall on KDE
+
+```bash
+~/.cua-driver/packages/current/wayland-helper/kwin/uninstall.sh
+# From a source checkout:
+./libs/cua-driver/wayland-helper/kwin/uninstall.sh
+```
+
+The uninstaller disables and unloads only the `cua-kwin@cua` adapter's
+`cua-kwin.cua` KWin package, removes its
+current-user KPackage, and reconfigures KWin. No logout/login is required.
+
+Portal reachability by itself is never sufficient: RemoteDesktop/libei input
+is global to KWin's current focus. If the adapter or its supported protocol is
+absent, cua-driver continues to allow safe AT-SPI actions but refuses
+focus-bound foreground input rather than guessing a target.

--- a/libs/cua-driver/wayland-helper/kwin/cua-kwin@cua/contents/code/main.js
+++ b/libs/cua-driver/wayland-helper/kwin/cua-kwin@cua/contents/code/main.js
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Cua contributors
+ * SPDX-License-Identifier: MIT
+ *
+ * Passive KWin 6 adapter primitives for cua-driver. Loading this package does
+ * not enumerate, activate, raise, minimize, or otherwise mutate any window.
+ * The trusted driver transport invokes exactly one function per request and
+ * JSON-encodes its returned object.
+ */
+
+const CUA_KWIN_PROTOCOL_VERSION = 1;
+
+function cuaKWinWindowUuid(window) {
+  if (!window || window.internalId === null || window.internalId === undefined) {
+    return '';
+  }
+  if (typeof window.internalId === 'string') {
+    return window.internalId;
+  }
+  return window.internalId.toString();
+}
+
+/**
+ * Return a fresh, compositor-owned snapshot. Later entries in `stackingOrder`
+ * cover earlier entries, so the array index is the authoritative stacking
+ * position for this snapshot.
+ */
+function cuaKWinSnapshot() {
+  const stackingOrder = workspace.stackingOrder;
+  const windows = [];
+
+  for (let stacking = 0; stacking < stackingOrder.length; stacking += 1) {
+    const window = stackingOrder[stacking];
+    const geometry = window.frameGeometry;
+    const minimized = Boolean(window.minimized);
+    const hidden = Boolean(window.hidden);
+
+    windows.push({
+      uuid: cuaKWinWindowUuid(window),
+      pid: Number(window.pid),
+      title: window.caption === null || window.caption === undefined ? '' : String(window.caption),
+      // KWin reports frame geometry in logical pixels that are fractional under
+      // fractional display scaling. cua-driver's snapshot contract is integer
+      // screen pixels, so round here rather than emit a float the driver would
+      // reject as a malformed snapshot.
+      x: Math.round(Number(geometry.x)),
+      y: Math.round(Number(geometry.y)),
+      width: Math.round(Number(geometry.width)),
+      height: Math.round(Number(geometry.height)),
+      active: Boolean(window.active),
+      minimized,
+      hidden,
+      visible: !minimized && !hidden,
+      stacking,
+    });
+  }
+
+  const activeWindow = workspace.activeWindow;
+  const activeWindowUuid = activeWindow ? cuaKWinWindowUuid(activeWindow) : null;
+  return {
+    protocol_version: CUA_KWIN_PROTOCOL_VERSION,
+    active_window_uuid: activeWindowUuid || null,
+    windows,
+  };
+}
+
+/**
+ * Request activation of exactly one full KWin internal UUID. The return value
+ * only reports whether KWin accepted the request; cua-driver must take a new
+ * snapshot and verify `active_window_uuid` before sending global input.
+ */
+function cuaKWinActivate(uuid) {
+  const requestedUuid = typeof uuid === 'string' ? uuid : '';
+  const response = {
+    protocol_version: CUA_KWIN_PROTOCOL_VERSION,
+    accepted: false,
+    target_uuid: requestedUuid,
+  };
+  if (requestedUuid.length === 0) {
+    return response;
+  }
+
+  const stackingOrder = workspace.stackingOrder;
+  const matches = [];
+  for (let index = 0; index < stackingOrder.length; index += 1) {
+    const window = stackingOrder[index];
+    if (cuaKWinWindowUuid(window) === requestedUuid) {
+      matches.push(window);
+    }
+  }
+  if (matches.length !== 1) {
+    return response;
+  }
+
+  const target = matches[0];
+  try {
+    if (target.minimized) {
+      target.minimized = false;
+    }
+    workspace.raiseWindow(target);
+    workspace.activeWindow = target;
+    response.accepted = true;
+  } catch (_error) {
+    response.accepted = false;
+  }
+  return response;
+}

--- a/libs/cua-driver/wayland-helper/kwin/cua-kwin@cua/metadata.json
+++ b/libs/cua-driver/wayland-helper/kwin/cua-kwin@cua/metadata.json
@@ -1,0 +1,22 @@
+{
+  "KPackageStructure": "KWin/Script",
+  "KPlugin": {
+    "Authors": [
+      {
+        "Name": "Cua contributors"
+      }
+    ],
+    "Description": "Expose exact KWin window snapshots and activation primitives to cua-driver.",
+    "EnabledByDefault": false,
+    "Icon": "preferences-system-windows",
+    "Id": "cua-kwin.cua",
+    "License": "MIT",
+    "Name": "Cua KWin Target Adapter",
+    "Version": "1.0.0",
+    "Website": "https://github.com/trycua/cua"
+  },
+  "X-Cua-Adapter-Id": "cua-kwin@cua",
+  "X-Cua-Protocol-Version": 1,
+  "X-Plasma-API": "javascript",
+  "X-Plasma-MainScript": "code/main.js"
+}

--- a/libs/cua-driver/wayland-helper/kwin/diagnose.sh
+++ b/libs/cua-driver/wayland-helper/kwin/diagnose.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Read-only installation and live-session diagnostics for the cua KWin adapter.
+set -uo pipefail
+
+readonly ADAPTER_ID="cua-kwin@cua"
+readonly PLUGIN_ID="cua-kwin.cua"
+readonly PROTOCOL_VERSION="1"
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly PACKAGE_DIR="$SCRIPT_DIR/$ADAPTER_ID"
+readonly DATA_HOME="${XDG_DATA_HOME:-${HOME:?HOME is required}/.local/share}"
+readonly DEST="$DATA_HOME/kwin/scripts/$PLUGIN_ID"
+status=0
+
+pass() { printf 'ok: %s\n' "$1"; }
+fail() { printf 'error: %s\n' "$1" >&2; status=1; }
+note() { printf 'note: %s\n' "$1"; }
+
+if [[ "${XDG_SESSION_TYPE:-}" == "wayland" && -n "${WAYLAND_DISPLAY:-}" ]]; then
+  pass "Wayland session detected (${WAYLAND_DISPLAY})."
+else
+  fail "This is not a live Wayland session (XDG_SESSION_TYPE=${XDG_SESSION_TYPE:-unset}, WAYLAND_DISPLAY=${WAYLAND_DISPLAY:-unset})."
+fi
+case ";${XDG_CURRENT_DESKTOP:-};" in
+  *';KDE;'*|*';KDE:'*|*':KDE;'*) pass "KDE Plasma desktop detected." ;;
+  *) fail "KDE Plasma was not detected (XDG_CURRENT_DESKTOP=${XDG_CURRENT_DESKTOP:-unset})." ;;
+esac
+
+if [[ -f "$DEST/metadata.json" && -f "$DEST/contents/code/main.js" ]]; then
+  pass "Adapter package is installed for the current user at $DEST."
+else
+  fail "Adapter package is missing or incomplete at $DEST."
+fi
+if [[ -f "$DEST/metadata.json" ]] \
+  && grep -Eq '"X-Cua-Protocol-Version"[[:space:]]*:[[:space:]]*1([[:space:]}]|,)' "$DEST/metadata.json"; then
+  pass "Installed metadata declares supported protocol v$PROTOCOL_VERSION."
+else
+  fail "Installed metadata does not declare supported protocol v$PROTOCOL_VERSION."
+fi
+if [[ -f "$PACKAGE_DIR/metadata.json" && -f "$PACKAGE_DIR/contents/code/main.js" \
+  && -f "$DEST/metadata.json" && -f "$DEST/contents/code/main.js" ]]; then
+  if cmp -s "$PACKAGE_DIR/metadata.json" "$DEST/metadata.json" \
+    && cmp -s "$PACKAGE_DIR/contents/code/main.js" "$DEST/contents/code/main.js"; then
+    pass "Installed adapter matches this packaged source."
+  else
+    fail "Installed adapter differs from this packaged source (update required)."
+  fi
+fi
+
+if command -v kreadconfig6 >/dev/null 2>&1; then
+  enabled="$(kreadconfig6 --file kwinrc --group Plugins --key "${PLUGIN_ID}Enabled" --default false 2>/dev/null)"
+  if [[ "$enabled" == "true" || "$enabled" == "1" ]]; then
+    pass "Adapter is enabled in the current user's kwinrc."
+  else
+    fail "Adapter is not enabled in the current user's kwinrc."
+  fi
+else
+  fail "kreadconfig6 is unavailable, so the enabled setting cannot be checked."
+fi
+
+qdbus_bin=""
+if command -v qdbus6 >/dev/null 2>&1; then
+  qdbus_bin="$(command -v qdbus6)"
+elif command -v qdbus >/dev/null 2>&1; then
+  qdbus_bin="$(command -v qdbus)"
+fi
+if [[ -n "$qdbus_bin" ]] && "$qdbus_bin" org.kde.KWin /KWin org.freedesktop.DBus.Peer.Ping >/dev/null 2>&1; then
+  pass "The KWin well-known service is reachable on the current session bus."
+  loaded="$($qdbus_bin org.kde.KWin /Scripting org.kde.kwin.Scripting.isScriptLoaded "$PLUGIN_ID" 2>/dev/null)"
+  if [[ "$loaded" == "true" || "$loaded" == "1" ]]; then
+    pass "KWin reports $ADAPTER_ID loaded as package $PLUGIN_ID."
+  else
+    fail "KWin does not report $ADAPTER_ID loaded as package $PLUGIN_ID."
+  fi
+elif command -v gdbus >/dev/null 2>&1 \
+  && gdbus call --session --dest org.kde.KWin --object-path /KWin \
+    --method org.freedesktop.DBus.Peer.Ping >/dev/null 2>&1; then
+  pass "The KWin well-known service is reachable on the current session bus."
+  loaded="$(gdbus call --session --dest org.kde.KWin --object-path /Scripting \
+    --method org.kde.kwin.Scripting.isScriptLoaded "$PLUGIN_ID" 2>/dev/null)"
+  if [[ "$loaded" == *true* ]]; then
+    pass "KWin reports $ADAPTER_ID loaded as package $PLUGIN_ID."
+  else
+    fail "KWin does not report $ADAPTER_ID loaded as package $PLUGIN_ID."
+  fi
+else
+  fail "org.kde.KWin is not reachable on this session bus."
+fi
+
+if (( status != 0 )); then
+  note "Remediation: $SCRIPT_DIR/install.sh"
+else
+  note "Packaging checks passed. Run the locally built 'cua-driver doctor' for owner, protocol, enumeration, activation, and portal/libei checks."
+fi
+exit "$status"

--- a/libs/cua-driver/wayland-helper/kwin/install.sh
+++ b/libs/cua-driver/wayland-helper/kwin/install.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Install or update the cua KWin adapter for the current desktop user.
+set -euo pipefail
+
+readonly ADAPTER_ID="cua-kwin@cua"
+readonly PLUGIN_ID="cua-kwin.cua"
+readonly PROTOCOL_VERSION="1"
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly PACKAGE_DIR="$SCRIPT_DIR/$ADAPTER_ID"
+readonly DATA_HOME="${XDG_DATA_HOME:-${HOME:?HOME is required}/.local/share}"
+readonly DEST="$DATA_HOME/kwin/scripts/$PLUGIN_ID"
+
+if [[ "$(id -u)" == "0" ]]; then
+  echo "Refusing to install a desktop-session KWin script as root." >&2
+  echo "Run this script as the user who owns the Plasma session." >&2
+  exit 1
+fi
+if [[ ! -f "$PACKAGE_DIR/metadata.json" || ! -f "$PACKAGE_DIR/contents/code/main.js" ]]; then
+  echo "The packaged KWin adapter is incomplete: $PACKAGE_DIR" >&2
+  exit 1
+fi
+if ! grep -Eq '"X-Cua-Protocol-Version"[[:space:]]*:[[:space:]]*1([[:space:]}]|,)' \
+  "$PACKAGE_DIR/metadata.json"; then
+  echo "The packaged KWin adapter does not declare protocol v$PROTOCOL_VERSION." >&2
+  exit 1
+fi
+if ! command -v kpackagetool6 >/dev/null 2>&1; then
+  echo "kpackagetool6 is required (install the Plasma 6 KPackage tools)." >&2
+  exit 1
+fi
+if ! command -v kwriteconfig6 >/dev/null 2>&1; then
+  echo "kwriteconfig6 is required (install the Plasma 6 configuration tools)." >&2
+  exit 1
+fi
+
+if [[ -e "$DEST" ]]; then
+  kpackagetool6 --type KWin/Script --upgrade "$PACKAGE_DIR"
+  action="Updated"
+else
+  kpackagetool6 --type KWin/Script --install "$PACKAGE_DIR"
+  action="Installed"
+fi
+kwriteconfig6 \
+  --file kwinrc \
+  --group Plugins \
+  --key "${PLUGIN_ID}Enabled" \
+  --type bool \
+  true
+
+reload_result="KWin is not reachable on the session bus; it will load the adapter at the next Plasma session start."
+qdbus_bin=""
+if command -v qdbus6 >/dev/null 2>&1; then
+  qdbus_bin="$(command -v qdbus6)"
+elif command -v qdbus >/dev/null 2>&1; then
+  qdbus_bin="$(command -v qdbus)"
+fi
+
+qdbus_script_loaded() {
+  local loaded
+  loaded="$("$qdbus_bin" org.kde.KWin /Scripting \
+    org.kde.kwin.Scripting.isScriptLoaded "$PLUGIN_ID" 2>/dev/null)"
+  [[ "$loaded" == "true" || "$loaded" == "1" ]]
+}
+
+gdbus_script_loaded() {
+  local loaded
+  loaded="$(gdbus call --session --dest org.kde.KWin --object-path /Scripting \
+    --method org.kde.kwin.Scripting.isScriptLoaded "$PLUGIN_ID" 2>/dev/null)"
+  [[ "$loaded" == *true* ]]
+}
+
+if [[ -n "$qdbus_bin" ]] && "$qdbus_bin" org.kde.KWin /KWin org.freedesktop.DBus.Peer.Ping >/dev/null 2>&1; then
+  # Unload only this package so an upgrade cannot leave its old source alive.
+  "$qdbus_bin" org.kde.KWin /Scripting org.kde.kwin.Scripting.unloadScript "$PLUGIN_ID" >/dev/null 2>&1 || true
+  "$qdbus_bin" org.kde.KWin /KWin org.kde.KWin.reconfigure >/dev/null
+  for _attempt in {1..20}; do
+    qdbus_script_loaded && break
+    sleep 0.05
+  done
+  if ! qdbus_script_loaded; then
+    # KWin can cache its package inventory across a live install. Its public
+    # scripting API can register this exact installed entry point immediately;
+    # the enabled kwinrc key makes the same package persistent next session.
+    "$qdbus_bin" org.kde.KWin /Scripting org.kde.kwin.Scripting.loadScript \
+      "$DEST/contents/code/main.js" "$PLUGIN_ID" >/dev/null
+    "$qdbus_bin" org.kde.KWin /Scripting org.kde.kwin.Scripting.start >/dev/null
+  fi
+  for _attempt in {1..20}; do
+    qdbus_script_loaded && break
+    sleep 0.05
+  done
+  if qdbus_script_loaded; then
+    reload_result="KWin reconfigured and the adapter was loaded; no logout or login is required."
+  else
+    echo "KWin did not report $ADAPTER_ID loaded after reconfiguration." >&2
+    echo "The package remains installed and enabled for the next Plasma session start." >&2
+    exit 1
+  fi
+elif command -v gdbus >/dev/null 2>&1 \
+  && gdbus call --session --dest org.kde.KWin --object-path /KWin \
+    --method org.freedesktop.DBus.Peer.Ping >/dev/null 2>&1; then
+  gdbus call --session --dest org.kde.KWin --object-path /Scripting \
+    --method org.kde.kwin.Scripting.unloadScript "$PLUGIN_ID" >/dev/null 2>&1 || true
+  gdbus call --session --dest org.kde.KWin --object-path /KWin \
+    --method org.kde.KWin.reconfigure >/dev/null
+  for _attempt in {1..20}; do
+    gdbus_script_loaded && break
+    sleep 0.05
+  done
+  if ! gdbus_script_loaded; then
+    gdbus call --session --dest org.kde.KWin --object-path /Scripting \
+      --method org.kde.kwin.Scripting.loadScript \
+      "$DEST/contents/code/main.js" "$PLUGIN_ID" >/dev/null
+    gdbus call --session --dest org.kde.KWin --object-path /Scripting \
+      --method org.kde.kwin.Scripting.start >/dev/null
+  fi
+  for _attempt in {1..20}; do
+    gdbus_script_loaded && break
+    sleep 0.05
+  done
+  if gdbus_script_loaded; then
+    reload_result="KWin reconfigured and the adapter was loaded; no logout or login is required."
+  else
+    echo "KWin did not report $ADAPTER_ID loaded after reconfiguration." >&2
+    echo "The package remains installed and enabled for the next Plasma session start." >&2
+    exit 1
+  fi
+fi
+
+echo "$action $ADAPTER_ID (KWin package $PLUGIN_ID) for the current user at $DEST."
+echo "$reload_result"
+echo "Verify with: $SCRIPT_DIR/diagnose.sh"

--- a/libs/cua-driver/wayland-helper/kwin/uninstall.sh
+++ b/libs/cua-driver/wayland-helper/kwin/uninstall.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Disable and remove only the current user's cua KWin adapter package.
+set -euo pipefail
+
+readonly ADAPTER_ID="cua-kwin@cua"
+readonly PLUGIN_ID="cua-kwin.cua"
+readonly DATA_HOME="${XDG_DATA_HOME:-${HOME:?HOME is required}/.local/share}"
+readonly DEST="$DATA_HOME/kwin/scripts/$PLUGIN_ID"
+
+if [[ "$(id -u)" == "0" ]]; then
+  echo "Refusing to modify a desktop-session KWin configuration as root." >&2
+  echo "Run this script as the user who owns the Plasma session." >&2
+  exit 1
+fi
+if ! command -v kpackagetool6 >/dev/null 2>&1; then
+  echo "kpackagetool6 is required (install the Plasma 6 KPackage tools)." >&2
+  exit 1
+fi
+if ! command -v kwriteconfig6 >/dev/null 2>&1; then
+  echo "kwriteconfig6 is required (install the Plasma 6 configuration tools)." >&2
+  exit 1
+fi
+
+kwriteconfig6 \
+  --file kwinrc \
+  --group Plugins \
+  --key "${PLUGIN_ID}Enabled" \
+  --type bool \
+  false
+
+qdbus_bin=""
+if command -v qdbus6 >/dev/null 2>&1; then
+  qdbus_bin="$(command -v qdbus6)"
+elif command -v qdbus >/dev/null 2>&1; then
+  qdbus_bin="$(command -v qdbus)"
+fi
+if [[ -n "$qdbus_bin" ]] && "$qdbus_bin" org.kde.KWin /KWin org.freedesktop.DBus.Peer.Ping >/dev/null 2>&1; then
+  "$qdbus_bin" org.kde.KWin /Scripting org.kde.kwin.Scripting.unloadScript "$PLUGIN_ID" >/dev/null 2>&1 || true
+elif command -v gdbus >/dev/null 2>&1 \
+  && gdbus call --session --dest org.kde.KWin --object-path /KWin \
+    --method org.freedesktop.DBus.Peer.Ping >/dev/null 2>&1; then
+  gdbus call --session --dest org.kde.KWin --object-path /Scripting \
+    --method org.kde.kwin.Scripting.unloadScript "$PLUGIN_ID" >/dev/null 2>&1 || true
+fi
+
+if [[ -e "$DEST" ]]; then
+  kpackagetool6 --type KWin/Script --remove "$PLUGIN_ID"
+else
+  echo "$PLUGIN_ID is not installed at $DEST."
+fi
+
+if [[ -n "$qdbus_bin" ]] && "$qdbus_bin" org.kde.KWin /KWin org.freedesktop.DBus.Peer.Ping >/dev/null 2>&1; then
+  "$qdbus_bin" org.kde.KWin /KWin org.kde.KWin.reconfigure >/dev/null
+  echo "KWin reconfigured; no logout or login is required."
+elif command -v gdbus >/dev/null 2>&1 \
+  && gdbus call --session --dest org.kde.KWin --object-path /KWin \
+    --method org.freedesktop.DBus.Peer.Ping >/dev/null 2>&1; then
+  gdbus call --session --dest org.kde.KWin --object-path /KWin \
+    --method org.kde.KWin.reconfigure >/dev/null
+  echo "KWin reconfigured; no logout or login is required."
+else
+  echo "KWin is not reachable; the disabled setting takes effect at the next Plasma session start."
+fi
+echo "Removed the current-user $ADAPTER_ID adapter (KWin package $PLUGIN_ID)."


### PR DESCRIPTION
## Summary

Adds a trusted KDE Plasma 6/KWin Wayland **target adapter** so cua-driver can
resolve an exact compositor window identity, briefly activate it, run one
focus-sensitive portal/libei operation, and restore the previously focused
window — instead of refusing all foreground input on KDE. This is the KWin
analogue of the accepted GNOME WinRects route and follows the
[Wayland compositor identity plan](https://github.com/trycua/cua/blob/main/libs/cua-driver/docs/wayland-compositor-identity-plan.md).

`Addresses #2283` (exact existing-profile setup across Wayland compositors) and
`Addresses #1982` (KDE Plasma foreground input dispatch). Refs #2004.

This is KWin-specific and does **not** claim generic Wayland support. It supplies
the exact native prerequisite; product-specific browser acceptance still depends
on the documented validation matrix.

## Architecture

- A passive, protocol-v1 `cua-kwin@cua` KWin 6 script exposes two primitives
  (`cuaKWinSnapshot`, `cuaKWinActivate`). Loading the package performs no
  enumeration, activation, or mutation. The driver injects a bounded one-shot
  request into the **verified genuine `kwin_wayland` process** and reads the
  reply back on its own unique bus name, pinned to the KWin owner and a
  per-request nonce.
- The only compositor identity is KWin's complete `internalId` UUID. Public
  numeric window ids are collision-checked handles bound to one KWin/package
  incarnation; UUIDs are retained in both directions and stale handles are
  tombstoned across restarts.

## Security guarantees (fail-closed)

- Verify an immutable unique D-Bus owner whose uid, `kwin_wayland` comm, and
  root-owned/non-writable executable (direct, or the systemd
  `plasma-kwin_wayland.service` wrapper chain) all check out; re-verify owner and
  pid around the transaction to close restart / PID-reuse races.
- Reject malformed, duplicate, non-contiguous, visibility-inconsistent,
  multi-active, stale, unknown, colliding, or PID-mismatched window identities.
- Activate an exact UUID, then verify focus with a **fresh** snapshot before any
  input; run exactly one bounded operation; restore and re-verify the prior
  active UUID. Restoration failures are surfaced, not swallowed.
- Portal/libei pointer and keyboard input is gated behind that verified
  transaction on KDE; targetless desktop input is allowed only inside an active
  verified guard. The driver never injects into whichever window happens to be
  focused, and no unsafe generic switch is introduced.

## Integration

Wayland input dispatch (click/scroll/drag/move and type/press_key/hotkey),
browser setup/consent focus, `cua-driver doctor`, the structured health report,
packaging (`install.sh` / `diagnose.sh` / `uninstall.sh`), and reference docs.

## Testing

- `cargo fmt --all -- --check`: clean.
- `cargo test -p platform-linux --all-targets --locked`: 190 passed (default);
  194 passed with `--features portal-input`. Includes new coverage for UUID
  validation, snapshot consistency (stacking/visibility/active), the
  activate→verify→restore transaction and all failure/restore combinations, id
  collision/staleness, owner-facts trust, and the fractional-geometry contract.
- `cargo test -p cua-driver-core --locked`: 488 passed.
- `cargo test -p cua-driver --features portal-input --bins doctor::`: 11 passed.
- `cargo check -p cua-driver --features portal-input --locked`: clean.

## Live validation (KDE Plasma 6.7.3 Wayland)

`cua-driver doctor` on a real KWin 6.7.3 session, adapter installed via
`install.sh`:

```
[ok] KWin adapter installed
[ok] KWin adapter protocol
[ok] KWin adapter owner/process   (immutable owner, uid, kwin_wayland, executable/systemd-wrapper trust)
[ok] KWin exact enumeration
[ok] KWin activation verification (exact active-window verified via a fresh snapshot)
[ok] KWin portal/libei input      (gated by verified exact activation + restoration)
```

`install.sh` / `diagnose.sh` / `uninstall.sh` all verified live with KWin
reconfigured over D-Bus (no logout required).

Fractional display scaling makes KWin frame geometry fractional; the script now
rounds geometry to integer pixels so the driver does not reject the snapshot as
malformed (caught and fixed during live validation).

## Limitations

- Full portal/libei input **injection** was not exercised live because it
  requires an interactive RemoteDesktop consent prompt; the entire trusted path
  up to the portal gate is verified. `doctor` deliberately does not open a
  RemoteDesktop session.
- The complete standalone-browser renderer/recording acceptance matrix on KDE is
  not yet run; this PR provides the exact native prerequisite only.
- Clippy was not run in the authoring sandbox (component unavailable offline; the
  repo's Rust CI enforces `cargo fmt` and the unit/compile gates, which pass).
