### PR TITLE
feat(sandbox): expose native Fleet pool reconciliation

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/__init__.py
+++ b/libs/python/cua-sandbox/cua_sandbox/__init__.py
@@ -30,6 +30,14 @@ from cua_sandbox.runtime.compat import (
 )
 from cua_sandbox.sandbox import Sandbox, SandboxInfo, sandbox
 from cua_sandbox.transport.cloud import CloudTransport
+from fleet_sdk import (
+    CreatePoolRequest,
+    Firmware,
+    PoolSpec,
+    PoolTemplate,
+    SandboxService,
+    ServiceProtocol,
+)
 
 __all__ = [
     "configure",
@@ -37,6 +45,12 @@ __all__ = [
     "whoami",
     "Image",
     "Pool",
+    "CreatePoolRequest",
+    "PoolSpec",
+    "PoolTemplate",
+    "SandboxService",
+    "ServiceProtocol",
+    "Firmware",
     "Sandbox",
     "SandboxInfo",
     "sandbox",

--- a/libs/python/cua-sandbox/cua_sandbox/pool.py
+++ b/libs/python/cua-sandbox/cua_sandbox/pool.py
@@ -3,15 +3,14 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any, cast
 
-from cua_sandbox.image import Image
 from cua_sandbox.sandbox import Sandbox
 from cua_sandbox.transport.fleet import FleetTransport
-from cua_sandbox.transport.fleet_cloud import FleetCloudTransport, _FleetClient
-from fleet_sdk import CreateClaimRequest
+from cua_sandbox.transport.fleet_cloud import _FleetClient
+from fleet_sdk import CreateClaimRequest, CreatePoolRequest
 
 logger = logging.getLogger(__name__)
 
@@ -43,26 +42,18 @@ class Pool:
         return self._resource
 
     @classmethod
-    async def reconcile(cls, config: Mapping[str, Any]) -> "Pool":
-        """Create or update a Fleet pool from its desired configuration.
+    async def reconcile(cls, request: CreatePoolRequest) -> "Pool":
+        """Create or update a Fleet pool from a native Fleet request.
 
-        Repeated calls with the same configuration are idempotent: an existing
-        pool is updated in place rather than creating another pool. ``config``
-        requires a non-empty ``name`` and an ``image`` created with
-        :meth:`Image.from_registry`.
-
-        The Fleet client used to reconcile is closed before this method returns.
+        The request is passed unchanged to the generated Fleet client. Import
+        ``CreatePoolRequest`` and its nested schema types from ``cua_sandbox``
+        so callers do not depend on the generated binding package directly.
         """
-        name, image = cls._validate_config(config)
-        desired = FleetCloudTransport(
-            image=image,
-            name=name,
-            replicas=config.get("replicas", 1),
-            services=config.get("services"),
-        )._pool_request()
+        if not isinstance(request, CreatePoolRequest):
+            raise TypeError("Pool.reconcile requires a CreatePoolRequest")
         client = _FleetClient()
         try:
-            return cls(await client.reconcile_pool(desired))
+            return cls(await client.reconcile_pool(request))
         finally:
             await client.close()
 
@@ -118,18 +109,3 @@ class Pool:
 
             if cleanup_error is not None:
                 raise cleanup_error
-
-    @staticmethod
-    def _validate_config(config: Mapping[str, Any]) -> tuple[str, Image]:
-        if not isinstance(config, Mapping):
-            raise TypeError("Pool configuration must be a mapping")
-
-        name = config.get("name")
-        if not isinstance(name, str) or not name:
-            raise ValueError("Pool configuration requires a non-empty string 'name'")
-
-        image = config.get("image")
-        if not isinstance(image, Image):
-            raise TypeError("Pool configuration 'image' must be an Image.from_registry(...) value")
-        FleetCloudTransport._validate_image(image)
-        return name, image

--- a/libs/python/cua-sandbox/cua_sandbox/sync/__init__.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sync/__init__.py
@@ -18,12 +18,13 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import contextmanager
-from typing import Any, Iterator, Mapping, Optional
+from typing import Any, Iterator, Optional
 
 from cua_sandbox.image import Image
 from cua_sandbox.localhost import Localhost as _AsyncLocalhost
 from cua_sandbox.pool import Pool as _AsyncPool
 from cua_sandbox.sandbox import Sandbox as _AsyncSandbox
+from fleet_sdk import CreatePoolRequest
 
 
 def _get_or_create_loop() -> asyncio.AbstractEventLoop:
@@ -89,9 +90,9 @@ class Pool:
         return self._async_pool.name
 
     @classmethod
-    def reconcile(cls, config: Mapping[str, Any]) -> "Pool":
+    def reconcile(cls, request: CreatePoolRequest) -> "Pool":
         """Synchronously create or update a Fleet pool."""
-        return cls(_run(_AsyncPool.reconcile(config)))
+        return cls(_run(_AsyncPool.reconcile(request)))
 
     @contextmanager
     def claim(self) -> Iterator[_SyncProxy]:

--- a/libs/python/cua-sandbox/tests/test_pool.py
+++ b/libs/python/cua-sandbox/tests/test_pool.py
@@ -3,10 +3,54 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
-from cua_sandbox import Image, Pool
+from cua_sandbox import (
+    CreatePoolRequest,
+    Firmware,
+    Pool,
+    PoolSpec,
+    PoolTemplate,
+    SandboxService,
+    ServiceProtocol,
+)
 from cua_sandbox.sync import Pool as SyncPool
 from cua_sandbox.transport.fleet_cloud import _FleetClient
 from fleet_sdk import Sandbox as FleetSandbox
+
+
+def pool_request(
+    *,
+    name: str = "foo",
+    image: str = "example:latest",
+    replicas: int = 1,
+    services: dict[str, int] | None = None,
+    template: PoolTemplate | None = None,
+) -> CreatePoolRequest:
+    return CreatePoolRequest(
+        namespace=name,
+        spec=PoolSpec(
+            replicas=replicas,
+            services=[
+                SandboxService(name=service_name, target_port=port, protocol=ServiceProtocol.TCP)
+                for service_name, port in (services or {"server": 8000}).items()
+            ],
+            template=template
+            or PoolTemplate(
+                runtime=None,
+                runtime_class_name=None,
+                node_selector=None,
+                tolerations=None,
+                command=None,
+                container_disk_image=image,
+                image_pull_secret="ecr-credentials",
+                cpu_cores=None,
+                memory=None,
+                firmware=None,
+                probes=None,
+                oidc=None,
+            ),
+            autoscaling=None,
+        ),
+    )
 
 
 def fleet_pool(name: str = "foo") -> SimpleNamespace:
@@ -105,12 +149,11 @@ async def test_reconcile_creates_pool_from_registry_image(monkeypatch):
     client = FakeFleetClient()
     monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: client)
 
-    pool = await Pool.reconcile(
-        {
-            "name": "foo",
-            "image": Image.from_registry("registry.example/workspace:latest").expose(3000),
-        }
+    request = pool_request(
+        image="registry.example/workspace:latest",
+        services={"server": 8000, "port-3000": 3000},
     )
+    pool = await Pool.reconcile(request)
 
     assert pool.name == "foo"
     assert pool.resource.metadata.name == "foo"
@@ -131,7 +174,7 @@ async def test_reconcile_closes_temporary_client_when_reconciliation_fails(monke
     monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: client)
 
     with pytest.raises(RuntimeError, match="reconcile failed"):
-        await Pool.reconcile({"name": "foo", "image": Image.from_registry("example:latest")})
+        await Pool.reconcile(pool_request())
 
     assert client.closed is True
 
@@ -142,7 +185,7 @@ async def test_reconcile_updates_existing_pool_idempotently(monkeypatch):
     client = FakeFleetClient(existing=existing)
     monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: client)
 
-    pool = await Pool.reconcile({"name": "foo", "image": Image.from_registry("example:latest")})
+    pool = await Pool.reconcile(pool_request())
 
     assert pool.resource is existing
     assert len(client.reconciled) == 1
@@ -156,7 +199,7 @@ async def test_claim_releases_claim_and_client_after_block_exception(monkeypatch
     claim_client = FakeFleetClient()
     clients = iter([reconcile_client, claim_client])
     monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: next(clients))
-    pool = await Pool.reconcile({"name": "foo", "image": Image.from_registry("example:latest")})
+    pool = await Pool.reconcile(pool_request())
 
     with pytest.raises(RuntimeError, match="body failed"):
         async with pool.claim() as sandbox:
@@ -175,7 +218,7 @@ async def test_claim_preserves_block_exception_when_release_fails(monkeypatch):
     claim_client = FakeFleetClient(release_error=RuntimeError("release failed"))
     clients = iter([reconcile_client, claim_client])
     monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: next(clients))
-    pool = await Pool.reconcile({"name": "foo", "image": Image.from_registry("example:latest")})
+    pool = await Pool.reconcile(pool_request())
 
     with pytest.raises(ValueError, match="body failed"):
         async with pool.claim():
@@ -191,7 +234,7 @@ async def test_claim_raises_release_failure_without_block_exception(monkeypatch)
     claim_client = FakeFleetClient(release_error=RuntimeError("release failed"))
     clients = iter([reconcile_client, claim_client])
     monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: next(clients))
-    pool = await Pool.reconcile({"name": "foo", "image": Image.from_registry("example:latest")})
+    pool = await Pool.reconcile(pool_request())
 
     with pytest.raises(RuntimeError, match="release failed"):
         async with pool.claim():
@@ -200,19 +243,11 @@ async def test_claim_raises_release_failure_without_block_exception(monkeypatch)
     assert claim_client.closed is True
 
 
-@pytest.mark.parametrize(
-    "config, message",
-    [
-        ({"image": Image.from_registry("example:latest")}, "name"),
-        ({"name": "foo"}, "image"),
-        ({"name": "foo", "image": "example:latest"}, "Image.from_registry"),
-        ({"name": "foo", "image": Image.linux()}, "Image.from_registry"),
-    ],
-)
+@pytest.mark.parametrize("invalid_value", [None, {}, "not-a-request"])
 @pytest.mark.asyncio
-async def test_reconcile_rejects_invalid_config(config, message):
-    with pytest.raises((TypeError, ValueError), match=message):
-        await Pool.reconcile(config)
+async def test_reconcile_rejects_non_request(invalid_value):
+    with pytest.raises(TypeError, match="CreatePoolRequest"):
+        await Pool.reconcile(invalid_value)
 
 
 def test_sync_pool_matches_blocking_context_manager(monkeypatch):
@@ -221,7 +256,7 @@ def test_sync_pool_matches_blocking_context_manager(monkeypatch):
     clients = iter([reconcile_client, claim_client])
     monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: next(clients))
 
-    pool = SyncPool.reconcile({"name": "foo", "image": Image.from_registry("example:latest")})
+    pool = SyncPool.reconcile(pool_request())
     with pool.claim() as sandbox:
         assert sandbox.name == "sandbox-1"
 
@@ -234,14 +269,12 @@ async def test_reconcile_preserves_replicas_and_named_services(monkeypatch):
     client = FakeFleetClient()
     monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: client)
 
-    await Pool.reconcile(
-        {
-            "name": "foo",
-            "image": Image.from_registry("registry.example/workspace:latest"),
-            "replicas": 2,
-            "services": {"server": 8000, "mcp": 3000},
-        }
+    request = pool_request(
+        image="registry.example/workspace:latest",
+        replicas=2,
+        services={"server": 8000, "mcp": 3000},
     )
+    await Pool.reconcile(request)
 
     request = client.reconciled[0]
     assert request.spec.replicas == 2
@@ -252,12 +285,41 @@ async def test_reconcile_preserves_replicas_and_named_services(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_reconcile_forwards_native_create_pool_request_unchanged(monkeypatch):
+    client = FakeFleetClient()
+    monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: client)
+    request = pool_request(
+        image="registry.example/workspace:latest",
+        replicas=2,
+        services={"server": 8000, "mcp": 3000},
+        template=PoolTemplate(
+            runtime=None,
+            runtime_class_name=None,
+            node_selector=None,
+            tolerations=None,
+            command=None,
+            container_disk_image="registry.example/workspace:latest",
+            image_pull_secret="workspace-pull",
+            cpu_cores=10,
+            memory="20Gi",
+            firmware=Firmware.EFI,
+            probes=None,
+            oidc=None,
+        ),
+    )
+
+    await Pool.reconcile(request)
+
+    assert client.reconciled == [request]
+
+
+@pytest.mark.asyncio
 async def test_claim_exposes_named_service_requests(monkeypatch):
     reconcile_client = FakeFleetClient()
     claim_client = FakeFleetClient()
     clients = iter([reconcile_client, claim_client])
     monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: next(clients))
-    pool = await Pool.reconcile({"name": "foo", "image": Image.from_registry("example:latest")})
+    pool = await Pool.reconcile(pool_request())
 
     async with pool.claim() as sandbox:
         response = await sandbox.services.request(

--- a/libs/python/cua-sandbox/uv.lock
+++ b/libs/python/cua-sandbox/uv.lock
@@ -555,7 +555,7 @@ wheels = [
 
 [[package]]
 name = "cua-sandbox"
-version = "0.1.20"
+version = "0.1.21"
 source = { editable = "." }
 dependencies = [
     { name = "cua-auto" },


### PR DESCRIPTION
Exposes the native Fleet request schema through `cua_sandbox` and makes `Pool.reconcile(CreatePoolRequest)` forward the generated request unchanged.

Validation: `15` focused pool tests, Ruff lint, Ruff format, and `git diff --check`.