### PR TITLE
fix(cua-driver): seed the Windows session cursor before move_cursor

### DIFF
--- a/libs/cua-driver/rust/crates/platform-windows/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/overlay.rs
@@ -369,7 +369,7 @@ pub fn current_position(key: &str) -> (f64, f64) {
 /// `MoveTo` glides INTO the target instead of silently snapping. No-op when the
 /// cursor is already on-screen or its session already ended. Returns true if a
 /// seed was applied. Mirrors `platform_macos::cursor::overlay::seed_start_*`.
-fn seed_start_if_sentinel(key: &CursorKey, target_x: f64, target_y: f64) -> bool {
+pub(crate) fn seed_start_if_sentinel(key: &CursorKey, target_x: f64, target_y: f64) -> bool {
     let mut guard = RENDER.lock().unwrap();
     let Some(map) = guard.as_mut() else {
         return false;

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -7128,6 +7128,16 @@ impl Tool for MoveCursorTool {
                 .cursor_registry
                 .update_position(&cursor_key, x, y);
         }
+        // A brand-new session cursor still sits at the off-screen sentinel
+        // (-200, -200). `render_state` only snaps that away on macOS
+        // (`move_to_snap_sentinel`), and the Windows equivalent —
+        // `seed_start_if_sentinel` — is otherwise reached only via
+        // `animate_cursor_to`, which this tool does not use. Without the seed the
+        // path below is planned from off-screen and a single move_cursor paints
+        // nothing.
+        if !cursor_key.is_empty() {
+            crate::overlay::seed_start_if_sentinel(&cursor_key, x, y);
+        }
         // End pointing upper-left (45°) — matches Swift's
         // `AgentCursor.animateAndWait(endAngleDegrees: 45)` convention so
         // the cursor settles to the natural macOS-style pose.

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -7127,15 +7127,13 @@ impl Tool for MoveCursorTool {
             self.state
                 .cursor_registry
                 .update_position(&cursor_key, x, y);
-        }
-        // A brand-new session cursor still sits at the off-screen sentinel
-        // (-200, -200). `render_state` only snaps that away on macOS
-        // (`move_to_snap_sentinel`), and the Windows equivalent —
-        // `seed_start_if_sentinel` — is otherwise reached only via
-        // `animate_cursor_to`, which this tool does not use. Without the seed the
-        // path below is planned from off-screen and a single move_cursor paints
-        // nothing.
-        if !cursor_key.is_empty() {
+            // A brand-new session cursor still sits at the off-screen sentinel
+            // (-200, -200). `render_state` only snaps that away on macOS
+            // (`move_to_snap_sentinel`), and the Windows equivalent —
+            // `seed_start_if_sentinel` — is otherwise reached only via
+            // `animate_cursor_to`, which this tool does not use. Without the seed
+            // the path below is planned from off-screen and a single move_cursor
+            // paints nothing.
             crate::overlay::seed_start_if_sentinel(&cursor_key, x, y);
         }
         // End pointing upper-left (45°) — matches Swift's


### PR DESCRIPTION
## Summary

- seed a brand-new session cursor on-screen before the `MoveTo` issued by the `move_cursor` tool on Windows
- expose `overlay::seed_start_if_sentinel` to the tools module (`pub(crate)`)

Related to #2802 (this does **not** fix the visibility problem there — see the root-cause comment on that issue: the overlay window is created without `WS_EX_TOPMOST` and is simply covered by ordinary windows).

## Why

A single `move_cursor` call for a freshly declared session paints nothing on
Windows, while the tool reports success. Firing the tool 25–40 times in a row
*does* render a moving cursor, so the overlay window and its render thread are
alive — it is the single-call path that is broken.

A new cursor starts at the off-screen sentinel `(-200, -200)`. Two mechanisms
are supposed to bring it on-screen, and `move_cursor` reaches neither:

1. `cursor-overlay/src/render_state.rs` snaps the sentinel onto the target only
   when `move_to_snap_sentinel` is set, which the comment marks as macOS-only:

   ```rust
   // macOS-only: if the cursor is still at the initial off-screen
   // sentinel, snap it to the offset target so the path starts on-screen.
   if move_to_snap_sentinel && self.pos.0 < -50.0 { self.pos = (tx, ty); }
   ```

2. On Windows the equivalent is `platform-windows/src/overlay.rs::seed_start_if_sentinel`,
   but it is called only from `animate_cursor_to`. The `move_cursor` tool does not
   go through it — it sends `OverlayCommand::MoveTo` straight to the overlay
   channel, so the path is planned from off-screen.

The click path already handles this case explicitly (`current_position` → snap on
first use), which is why `click` behaves differently from a bare `move_cursor`.

This patch calls the existing Windows seed helper from the tool, matching what
`animate_cursor_to` already does — no new behaviour, just the missing first step.

## What this does and does not do

Instrumented builds confirm the seed itself works: after the change the cursor leaves
the sentinel and animates in from an on-screen start point instead of being planned
from `(-200,-200)`. It does **not** make the cursor reliably visible — that is a
separate z-order issue tracked in #2802 / #1806.

## Reproduction (before the change)

```
cua-driver call start_session '{"session":"demo"}'
cua-driver call move_cursor   '{"x":900,"y":600,"scope":"window","session":"demo"}'
  → "Agent cursor 'demo' moved to (900.0, 600.0)."   # reported success, nothing painted
cua-driver call get_agent_cursor_state '{"session":"demo"}'
  → "enabled": true, "position": null
```

Verified against 0.14.1, 0.16.0 and 0.17.0 on Windows 11 (3840×2160 @ 200 %) and
Windows 10 (1920×1080 @ 100 %), with a full-screen capture rather than by eye.
Ruled out: fresh daemon, fresh session, explicit `set_agent_cursor_enabled(true)`,
daemon restart, z-order (the overlay window is above all others) and overlay
geometry.

## Validation

- `cargo check -p platform-windows` on the pinned 1.97.1 toolchain

## Note

`get_agent_cursor_state` reports `"position": null` for a sentinel cursor, which
makes the state surface unhelpful while diagnosing exactly this class of problem
(`enabled` does update through the same channel). Left alone here — happy to
follow up if you'd like the sentinel surfaced explicitly instead.
