### PR TITLE
fix(cua-driver): harden Windows discovery and foreground input

### DIFF
--- a/libs/cua-driver/rust/crates/platform-windows/src/browser_platform.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/browser_platform.rs
@@ -936,9 +936,7 @@ impl BrowserPlatform for WindowsBrowserPlatform {
             )
         })?;
         let window = tokio::task::spawn_blocking(move || {
-            crate::win32::list_windows(Some(pid_u32))
-                .into_iter()
-                .find(|window| window.hwnd == window_id)
+            crate::win32::find_window_by_pid_and_handle(pid_u32, window_id)
         })
         .await
         .ok()
@@ -980,7 +978,7 @@ impl BrowserPlatform for WindowsBrowserPlatform {
             )
         })?;
         let windows = tokio::task::spawn_blocking(move || {
-            crate::win32::list_windows(Some(pid_u32))
+            crate::win32::list_windows_via_win32(Some(pid_u32))
                 .into_iter()
                 .map(|window| window.hwnd)
                 .collect::<Vec<_>>()

--- a/libs/cua-driver/rust/crates/platform-windows/src/browser_setup_ui.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/browser_setup_ui.rs
@@ -130,29 +130,7 @@ unsafe fn set_value(element_ptr: usize, value: &str) -> Result<(), BrowserRefusa
 }
 
 fn force_setup_foreground(target: windows::Win32::Foundation::HWND) -> (bool, bool) {
-    use windows::Win32::UI::Input::KeyboardAndMouse::{
-        keybd_event, KEYBD_EVENT_FLAGS, KEYEVENTF_KEYUP,
-    };
-
-    if unsafe { crate::input::force_foreground_attached(target) } {
-        return (true, false);
-    }
-
-    // The approved setup transition is allowed to be visible. Claim the
-    // foreground-lock token with Windows' reserved no-name key, which has no
-    // application action, then retry the exact HWND a bounded number of times.
-    const VK_NONAME: u8 = 0xFC;
-    unsafe {
-        keybd_event(VK_NONAME, 0, KEYBD_EVENT_FLAGS(0), 0);
-        keybd_event(VK_NONAME, 0, KEYEVENTF_KEYUP, 0);
-    }
-    for _ in 0..3 {
-        if unsafe { crate::input::force_foreground_attached(target) } {
-            return (true, true);
-        }
-        std::thread::sleep(Duration::from_millis(25));
-    }
-    (false, true)
+    unsafe { crate::input::force_foreground_assisted(target) }
 }
 
 fn confirm_setup_navigation(

--- a/libs/cua-driver/rust/crates/platform-windows/src/input/inject.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/input/inject.rs
@@ -39,6 +39,9 @@ use windows::Win32::UI::Controls::{
     CreateSyntheticPointerDevice, DestroySyntheticPointerDevice, HSYNTHETICPOINTERDEVICE,
     POINTER_FEEDBACK_DEFAULT, POINTER_TYPE_INFO, POINTER_TYPE_INFO_0,
 };
+use windows::Win32::UI::Input::KeyboardAndMouse::{
+    keybd_event, KEYBD_EVENT_FLAGS, KEYEVENTF_KEYUP,
+};
 use windows::Win32::UI::Input::Pointer::{
     InjectSyntheticPointerInput, POINTER_FLAG_DOWN, POINTER_FLAG_INCONTACT, POINTER_FLAG_INRANGE,
     POINTER_FLAG_UP, POINTER_FLAG_UPDATE, POINTER_INFO, POINTER_PEN_INFO, POINTER_TOUCH_INFO,
@@ -127,6 +130,28 @@ pub(crate) unsafe fn force_foreground_attached(target: HWND) -> bool {
         let _ = AttachThreadInput(my_tid, cur_tid, false);
     }
     GetForegroundWindow() == target
+}
+
+/// Retry an explicit visible foreground transition after a reserved no-name
+/// key grants this process the most-recent-input token. The key has no
+/// application meaning; the retry count keeps the transition bounded.
+pub(crate) unsafe fn force_foreground_assisted(target: HWND) -> (bool, bool) {
+    if unsafe { force_foreground_attached(target) } {
+        return (true, false);
+    }
+
+    const VK_NONAME: u8 = 0xFC;
+    unsafe {
+        keybd_event(VK_NONAME, 0, KEYBD_EVENT_FLAGS(0), 0);
+        keybd_event(VK_NONAME, 0, KEYEVENTF_KEYUP, 0);
+    }
+    for _ in 0..3 {
+        if unsafe { force_foreground_attached(target) } {
+            return (true, true);
+        }
+        sleep(Duration::from_millis(25));
+    }
+    (false, true)
 }
 
 /// RAII guard that makes a specific target window **unable to become the

--- a/libs/cua-driver/rust/crates/platform-windows/src/input/keyboard.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/input/keyboard.rs
@@ -462,7 +462,7 @@ pub fn send_key_synthesized(hwnd: u64, key: &str, modifiers: &[&str]) -> Result<
         // bring_to_front / macOS with_foreground_assist) — a bare
         // SetForegroundWindow is denied by the foreground-lock without UIAccess.
         // Restored to prev_fg below.
-        let _ = crate::input::inject::force_foreground_attached(target);
+        let _ = crate::input::force_foreground_assisted(target);
         // Brief settle so the foreground swap is processed before we send.
         sleep(Duration::from_millis(8));
 
@@ -581,7 +581,7 @@ pub fn send_text_synthesized(hwnd: u64, text: &str) -> Result<()> {
         // bring_to_front / macOS with_foreground_assist) — a bare
         // SetForegroundWindow is denied by the foreground-lock without UIAccess.
         // Restored to prev_fg below.
-        let _ = crate::input::inject::force_foreground_attached(target);
+        let _ = crate::input::force_foreground_assisted(target);
         sleep(Duration::from_millis(8));
         let actual_fg = GetForegroundWindow();
         if actual_fg != target {

--- a/libs/cua-driver/rust/crates/platform-windows/src/input/keyboard.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/input/keyboard.rs
@@ -478,7 +478,7 @@ pub fn send_key_synthesized(hwnd: u64, key: &str, modifiers: &[&str]) -> Result<
         if actual_fg != target {
             // Don't restore — prev_fg is presumably still foreground anyway.
             bail!(
-                "Foreground swap to target HWND {:?} was rejected by Windows \
+                "foreground_unavailable: foreground swap to exact target HWND {:?} was rejected by Windows \
                  (actual foreground is HWND {:?}). This daemon is not at \
                  UIAccess integrity, so SetForegroundWindow is subject to the \
                  foreground-lock and the swap silently fails. Without the \
@@ -586,7 +586,7 @@ pub fn send_text_synthesized(hwnd: u64, text: &str) -> Result<()> {
         let actual_fg = GetForegroundWindow();
         if actual_fg != target {
             bail!(
-                "Foreground swap to target HWND {:?} was rejected by Windows \
+                "foreground_unavailable: foreground swap to exact target HWND {:?} was rejected by Windows \
                  (actual foreground is HWND {:?}). This daemon is not at \
                  UIAccess integrity, so SetForegroundWindow is subject to the \
                  foreground-lock and the swap silently fails. Without the swap, \

--- a/libs/cua-driver/rust/crates/platform-windows/src/input/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/input/mod.rs
@@ -14,7 +14,7 @@ pub mod inject;
 pub mod keyboard;
 pub mod mouse;
 
-pub(crate) use inject::force_foreground_attached;
+pub(crate) use inject::{force_foreground_assisted, force_foreground_attached};
 pub use inject::{
     inject_click_screen, point_in_window_bounds, ForegroundLockGuard, NoActivateGuard,
 };

--- a/libs/cua-driver/rust/crates/platform-windows/src/input/mouse.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/input/mouse.rs
@@ -585,6 +585,18 @@ fn send_click_synthesized_mods_impl(
                 actual.0
             );
         }
+        let foreground_target = if activate {
+            match crate::win32::capture_post_action_foreground_target(target.0 as usize as u64) {
+                Some(target) => Some(target),
+                None => bail!(
+                    "foreground_unavailable: exact target HWND {:?} disappeared before mouse \
+                     input could be sent",
+                    target.0
+                ),
+            }
+        } else {
+            None
+        };
         let noactivate = (!activate).then(|| crate::input::NoActivateGuard::arm(target));
         if !activate {
             let _ = SetWindowPos(
@@ -685,12 +697,12 @@ fn send_click_synthesized_mods_impl(
         if activate {
             let actual = GetForegroundWindow();
             if !crate::win32::post_action_foreground_matches(
-                target.0 as usize as u64,
+                foreground_target.expect("foreground target captured before input"),
                 actual.0 as usize as u64,
             ) {
                 bail!(
-                    "foreground_unavailable: exact target HWND {:?} or one of its verified \
-                     same-process owned transients was not foreground after the click \
+                    "foreground_unavailable: exact target HWND {:?} or a verified same-process \
+                     post-action window was not foreground after the click \
                      (actual foreground HWND {:?})",
                     target.0,
                     actual.0

--- a/libs/cua-driver/rust/crates/platform-windows/src/input/mouse.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/input/mouse.rs
@@ -576,7 +576,8 @@ fn send_click_synthesized_mods_impl(
         // Capture whether the target was ALREADY always-on-top so we don't strip
         // that state on restore — only demote below if WE promoted it.
         let was_topmost = (GetWindowLongPtrW(target, GWL_EXSTYLE) as u32) & WS_EX_TOPMOST.0 != 0;
-        let foreground_attach_failed = activate && !crate::input::force_foreground_attached(target);
+        let foreground_attach_failed =
+            activate && !crate::input::force_foreground_assisted(target).0;
         let noactivate = (!activate).then(|| crate::input::NoActivateGuard::arm(target));
         if !activate || foreground_attach_failed {
             let flags = if activate {

--- a/libs/cua-driver/rust/crates/platform-windows/src/input/mouse.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/input/mouse.rs
@@ -576,16 +576,26 @@ fn send_click_synthesized_mods_impl(
         // Capture whether the target was ALREADY always-on-top so we don't strip
         // that state on restore — only demote below if WE promoted it.
         let was_topmost = (GetWindowLongPtrW(target, GWL_EXSTYLE) as u32) & WS_EX_TOPMOST.0 != 0;
-        let foreground_attach_failed =
-            activate && !crate::input::force_foreground_assisted(target).0;
+        if activate && !crate::input::force_foreground_assisted(target).0 {
+            let actual = GetForegroundWindow();
+            bail!(
+                "foreground_unavailable: Windows did not activate exact target HWND {:?} \
+                 (actual foreground HWND {:?}); no mouse input was sent",
+                target.0,
+                actual.0
+            );
+        }
         let noactivate = (!activate).then(|| crate::input::NoActivateGuard::arm(target));
-        if !activate || foreground_attach_failed {
-            let flags = if activate {
-                SWP_NOMOVE | SWP_NOSIZE
-            } else {
-                SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE
-            };
-            let _ = SetWindowPos(target, HWND_TOPMOST, 0, 0, 0, 0, flags);
+        if !activate {
+            let _ = SetWindowPos(
+                target,
+                HWND_TOPMOST,
+                0,
+                0,
+                0,
+                0,
+                SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE,
+            );
         }
 
         // Move the cursor so the OS hover state matches before the click; the
@@ -640,7 +650,7 @@ fn send_click_synthesized_mods_impl(
         // lose the click if the real cursor is warped away while those queued
         // messages are still being dispatched.
         sleep(Duration::from_millis(if activate { 120 } else { 40 }));
-        if !was_topmost && (!activate || foreground_attach_failed) {
+        if !was_topmost && !activate {
             let _ = SetWindowPos(
                 target,
                 HWND_NOTOPMOST,
@@ -673,10 +683,18 @@ fn send_click_synthesized_mods_impl(
             );
         }
         if activate {
-            let foreground_root = GetAncestor(GetForegroundWindow(), GA_ROOT);
-            let target_root = GetAncestor(target, GA_ROOT);
-            if foreground_root != target_root {
-                bail!("The foreground click did not activate its target window.");
+            let actual = GetForegroundWindow();
+            if !crate::win32::post_action_foreground_matches(
+                target.0 as usize as u64,
+                actual.0 as usize as u64,
+            ) {
+                bail!(
+                    "foreground_unavailable: exact target HWND {:?} or one of its verified \
+                     same-process owned transients was not foreground after the click \
+                     (actual foreground HWND {:?})",
+                    target.0,
+                    actual.0
+                );
             }
         }
     }

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -8114,26 +8114,12 @@ fn menu_refusal(message: String) -> ToolResult {
 /// input, allowing a bounded retry without sending a real shortcut or text to
 /// whichever application currently has focus.
 fn activate_window_for_menu(hwnd: windows::Win32::Foundation::HWND) -> Result<bool, String> {
-    use windows::Win32::UI::Input::KeyboardAndMouse::{
-        keybd_event, KEYBD_EVENT_FLAGS, KEYEVENTF_KEYUP,
-    };
-
-    if unsafe { crate::input::force_foreground_attached(hwnd) } {
-        return Ok(false);
+    let (activated, assisted) = unsafe { crate::input::force_foreground_assisted(hwnd) };
+    if activated {
+        Ok(assisted)
+    } else {
+        Err("invoke_menu: target window could not be activated".to_owned())
     }
-
-    const VK_NONAME: u8 = 0xFC;
-    unsafe {
-        keybd_event(VK_NONAME, 0, KEYBD_EVENT_FLAGS(0), 0);
-        keybd_event(VK_NONAME, 0, KEYEVENTF_KEYUP, 0);
-    }
-    for _ in 0..3 {
-        if unsafe { crate::input::force_foreground_attached(hwnd) } {
-            return Ok(true);
-        }
-        std::thread::sleep(std::time::Duration::from_millis(25));
-    }
-    Err("invoke_menu: target window could not be activated".to_owned())
 }
 
 #[async_trait]
@@ -8486,11 +8472,10 @@ impl Tool for BringToFrontTool {
             tokio::task::spawn_blocking(move || -> Result<(u64, u64, bool, bool), String> {
                 use windows::Win32::Foundation::HWND;
                 use windows::Win32::Graphics::Dwm::DwmFlush;
-                use windows::Win32::System::Threading::{AttachThreadInput, GetCurrentThreadId};
                 use windows::Win32::UI::WindowsAndMessaging::{
-                    GetForegroundWindow, GetWindowThreadProcessId, IsIconic, IsWindow,
-                    SetForegroundWindow, SetWindowPos, ShowWindowAsync, HWND_NOTOPMOST,
-                    HWND_TOPMOST, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SW_RESTORE,
+                    GetForegroundWindow, IsIconic, IsWindow, SetWindowPos, ShowWindowAsync,
+                    HWND_NOTOPMOST, HWND_TOPMOST, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE,
+                    SW_RESTORE,
                 };
 
                 let target = HWND(hwnd as *mut _);
@@ -8550,22 +8535,9 @@ impl Tool for BringToFrontTool {
                     a && b
                 };
 
-                // Then best-effort focus/activation (needed for keyboard) via the
-                // AttachThreadInput trick — inherits the current FG thread's FG-lock
-                // token so SetForegroundWindow can succeed at Medium IL. Still denied
-                // on a maxed lock without UIAccess; the z-raise already made the
-                // window visible regardless.
-                let my_tid = unsafe { GetCurrentThreadId() };
-                let mut fg_pid = 0u32;
-                let fg_tid = unsafe { GetWindowThreadProcessId(prev_fg, Some(&mut fg_pid)) };
-                let attached = fg_tid != 0 && fg_tid != my_tid;
-                if attached {
-                    let _ = unsafe { AttachThreadInput(my_tid, fg_tid, true) };
-                }
-                let _ = unsafe { SetForegroundWindow(target) };
-                if attached {
-                    let _ = unsafe { AttachThreadInput(my_tid, fg_tid, false) };
-                }
+                // The caller explicitly requested a visible transition, so the
+                // shared foreground helper may claim the most-recent-input token.
+                let _ = unsafe { crate::input::force_foreground_assisted(target) };
                 let now_fg = unsafe { GetForegroundWindow() };
 
                 // A restored HWND can stop reporting iconic before its compositor

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -518,7 +518,7 @@ impl Tool for ListAppsTool {
             // log level — enable with `RUST_LOG=cua_driver=debug` when debugging
             // a slow list_apps invocation).
             let t0 = std::time::Instant::now();
-            let wins = crate::win32::list_windows(None);
+            let wins = crate::win32::list_windows_via_win32(None);
             tracing::debug!(target: "list_apps", "step 1 list_windows: {} wins ({}ms)", wins.len(), t0.elapsed().as_millis());
             let mut seen_pids = std::collections::HashSet::new();
             let mut running_pids: Vec<u32> = Vec::new();

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -2940,7 +2940,7 @@ impl Tool for ClickTool {
                 let activate = delivery == DeliveryMode::Foreground;
                 let send_result = tokio::task::spawn_blocking(move || {
                     let mod_refs: Vec<&str> = mods_owned.iter().map(String::as_str).collect();
-                    if activate && !mod_refs.is_empty() {
+                    if activate {
                         crate::input::send_click_synthesized_active_mods(
                             hwnd, tx, ty, count, &btn_fg, &mod_refs,
                         )
@@ -3093,13 +3093,9 @@ impl Tool for ClickTool {
                 };
                 let send_result = tokio::task::spawn_blocking(move || {
                     let mod_refs: Vec<&str> = mods_owned.iter().map(String::as_str).collect();
-                    if mod_refs.is_empty() {
-                        crate::input::send_click_synthesized(hwnd, cx, cy, count, &btn_fg)
-                    } else {
-                        crate::input::send_click_synthesized_active_mods(
-                            hwnd, cx, cy, count, &btn_fg, &mod_refs,
-                        )
-                    }
+                    crate::input::send_click_synthesized_active_mods(
+                        hwnd, cx, cy, count, &btn_fg, &mod_refs,
+                    )
                 })
                 .await;
                 tokio::spawn(restore_foreground_polling_best_effort(prev_fg_addr, pid));
@@ -3404,15 +3400,9 @@ impl Tool for ClickTool {
                 let mods_owned = modifiers.clone();
                 let send_result = tokio::task::spawn_blocking(move || {
                     let mod_refs: Vec<&str> = mods_owned.iter().map(String::as_str).collect();
-                    if mod_refs.is_empty() {
-                        crate::input::send_click_synthesized(
-                            hwnd, sx as i32, sy as i32, count, &btn,
-                        )
-                    } else {
-                        crate::input::send_click_synthesized_active_mods(
-                            hwnd, sx as i32, sy as i32, count, &btn, &mod_refs,
-                        )
-                    }
+                    crate::input::send_click_synthesized_active_mods(
+                        hwnd, sx as i32, sy as i32, count, &btn, &mod_refs,
+                    )
                 })
                 .await;
                 tokio::spawn(restore_foreground_polling_best_effort(prev_fg_addr, pid));
@@ -3927,7 +3917,7 @@ impl Tool for TypeTextTool {
                     Err(message) => return ToolResult::error(message),
                 };
                 let focus_result = tokio::task::spawn_blocking(move || {
-                    crate::input::send_click_synthesized(hwnd, cx, cy, 1, "left")
+                    crate::input::send_click_synthesized_active_mods(hwnd, cx, cy, 1, "left", &[])
                 })
                 .await;
                 match focus_result {
@@ -6010,7 +6000,7 @@ impl Tool for DoubleClickTool {
                     windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow().0 as usize
                 };
                 let send_result = tokio::task::spawn_blocking(move || {
-                    crate::input::send_click_synthesized(hwnd, cx, cy, 2, "left")
+                    crate::input::send_click_synthesized_active_mods(hwnd, cx, cy, 2, "left", &[])
                 })
                 .await;
                 tokio::spawn(restore_foreground_polling_best_effort(prev_fg_addr, pid));
@@ -6112,7 +6102,14 @@ impl Tool for DoubleClickTool {
                     windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow().0 as usize
                 };
                 let send_result = tokio::task::spawn_blocking(move || {
-                    crate::input::send_click_synthesized(hwnd, sx_i, sy_i, 2, "left")
+                    crate::input::send_click_synthesized_active_mods(
+                        hwnd,
+                        sx_i,
+                        sy_i,
+                        2,
+                        "left",
+                        &[],
+                    )
                 })
                 .await;
                 tokio::spawn(restore_foreground_polling_best_effort(prev_fg_addr, pid));
@@ -6344,7 +6341,7 @@ impl Tool for RightClickTool {
                     windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow().0 as usize
                 };
                 let send_result = tokio::task::spawn_blocking(move || {
-                    crate::input::send_click_synthesized(hwnd, cx, cy, 1, "right")
+                    crate::input::send_click_synthesized_active_mods(hwnd, cx, cy, 1, "right", &[])
                 })
                 .await;
                 tokio::spawn(restore_foreground_polling_best_effort(prev_fg_addr, pid));
@@ -6443,7 +6440,14 @@ impl Tool for RightClickTool {
                     windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow().0 as usize
                 };
                 let send_result = tokio::task::spawn_blocking(move || {
-                    crate::input::send_click_synthesized(hwnd, sx_i, sy_i, 1, "right")
+                    crate::input::send_click_synthesized_active_mods(
+                        hwnd,
+                        sx_i,
+                        sy_i,
+                        1,
+                        "right",
+                        &[],
+                    )
                 })
                 .await;
                 tokio::spawn(restore_foreground_polling_best_effort(prev_fg_addr, pid));

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -274,17 +274,116 @@ fn pid_window_target_candidates(pid: i64) -> Vec<WindowTargetCandidate> {
     let Ok(pid) = u32::try_from(pid) else {
         return Vec::new();
     };
-    window_target_candidates_for_pid(crate::win32::list_windows(Some(pid)), pid)
+    window_target_candidates_for_pid(crate::win32::list_windows_via_win32(Some(pid)), pid)
+}
+
+struct ExactPidWindowTargetGuard {
+    inner: Box<dyn Tool>,
+}
+
+fn exact_window_ownership_result(
+    pid: u32,
+    window_id: u64,
+    owner_pid: Option<u32>,
+) -> Result<(), ToolResult> {
+    match owner_pid {
+        Some(owner_pid) if owner_pid == pid => Ok(()),
+        Some(owner_pid) => Err(ToolResult::error(format!(
+            "window_id {window_id} belongs to pid {owner_pid}, not pid {pid}."
+        ))
+        .with_structured(json!({
+            "code": "window_target_mismatch",
+            "effect": "refused",
+            "pid": pid,
+            "window_id": window_id,
+            "owner_pid": owner_pid,
+        }))),
+        None => Err(ToolResult::error(format!(
+            "window_id {window_id} is closed, stale, or invalid."
+        ))
+        .with_structured(json!({
+            "code": "window_target_not_found",
+            "effect": "refused",
+            "pid": pid,
+            "window_id": window_id,
+        }))),
+    }
+}
+
+#[async_trait]
+impl Tool for ExactPidWindowTargetGuard {
+    fn def(&self) -> &ToolDef {
+        self.inner.def()
+    }
+
+    async fn protected_resource_ownership(
+        &self,
+        adapter_id: &str,
+        args: &Value,
+    ) -> cua_driver_core::tool::ProtectedResourceOwnership {
+        self.inner
+            .protected_resource_ownership(adapter_id, args)
+            .await
+    }
+
+    async fn protected_resource_scope(
+        &self,
+        adapter_id: &str,
+        args: &Value,
+    ) -> Result<Option<Value>, String> {
+        self.inner.protected_resource_scope(adapter_id, args).await
+    }
+
+    async fn validate_protected_resource_scope(
+        &self,
+        adapter_id: &str,
+        args: &Value,
+        approved_scope: &Value,
+    ) -> Result<(), String> {
+        self.inner
+            .validate_protected_resource_scope(adapter_id, args, approved_scope)
+            .await
+    }
+
+    async fn invoke(&self, args: Value) -> ToolResult {
+        if args.get("scope").and_then(Value::as_str) != Some("desktop") {
+            if let (Some(pid), Some(window_id)) = (
+                args.get("pid").and_then(Value::as_u64),
+                args.get("window_id").and_then(Value::as_u64),
+            ) {
+                let Ok(pid) = u32::try_from(pid) else {
+                    return ToolResult::error("pid is outside the Windows process-id range.")
+                        .with_structured(json!({
+                            "code": "window_target_mismatch",
+                            "effect": "refused",
+                            "pid": pid,
+                            "window_id": window_id,
+                        }));
+                };
+                let owner_pid =
+                    tokio::task::spawn_blocking(move || crate::win32::window_owner_pid(window_id))
+                        .await
+                        .ok()
+                        .flatten();
+                if let Err(result) = exact_window_ownership_result(pid, window_id, owner_pid) {
+                    return result;
+                }
+            }
+        }
+        self.inner.invoke(args).await
+    }
 }
 
 fn pid_window_guarded<T: Tool + 'static>(
     tool: T,
     candidates: &WindowTargetCandidates,
 ) -> Box<dyn Tool> {
-    Box::new(PidOnlyWindowTargetGuard::new(
-        Box::new(tool),
-        candidates.clone(),
-    ))
+    Box::new(ExactPidWindowTargetGuard {
+        inner: Box::new(PidOnlyWindowTargetGuard::new(
+            Box::new(tool),
+            candidates.clone(),
+        )),
+    })
 }
 
 /// The cursor key for an anonymous (cursor-less) call. A run opts into a cursor
@@ -857,7 +956,7 @@ fn z_index_from_front_to_back(total: usize, position: usize) -> usize {
 
 #[cfg(test)]
 mod list_windows_z_index_tests {
-    use super::z_index_from_front_to_back;
+    use super::{exact_window_ownership_result, z_index_from_front_to_back};
 
     #[test]
     fn enum_windows_front_to_back_order_normalizes_to_higher_is_frontmost() {
@@ -866,6 +965,25 @@ mod list_windows_z_index_tests {
             .collect();
         assert_eq!(indices, vec![2, 1, 0]);
         assert!(indices[0] > indices[2]);
+    }
+
+    #[test]
+    fn explicit_pid_hwnd_guard_refuses_wrong_or_stale_owners() {
+        assert!(exact_window_ownership_result(42, 7, Some(42)).is_ok());
+
+        let wrong = exact_window_ownership_result(42, 7, Some(99)).unwrap_err();
+        assert_eq!(wrong.is_error, Some(true));
+        assert_eq!(
+            wrong.structured_content.as_ref().unwrap()["code"],
+            "window_target_mismatch"
+        );
+        assert_eq!(wrong.structured_content.as_ref().unwrap()["owner_pid"], 99);
+
+        let stale = exact_window_ownership_result(42, 7, None).unwrap_err();
+        assert_eq!(
+            stale.structured_content.as_ref().unwrap()["code"],
+            "window_target_not_found"
+        );
     }
 }
 
@@ -2843,10 +2961,11 @@ impl Tool for ClickTool {
         let hwnd = match hwnd_opt {
             Some(h) => h,
             None => {
-                let windows =
-                    tokio::task::spawn_blocking(move || crate::win32::list_windows(Some(pid)))
-                        .await
-                        .unwrap_or_default();
+                let windows = tokio::task::spawn_blocking(move || {
+                    crate::win32::list_windows_via_win32(Some(pid))
+                })
+                .await
+                .unwrap_or_default();
                 match windows.first() {
                     Some(w) => w.hwnd,
                     None => {
@@ -8558,10 +8677,8 @@ impl Tool for BringToFrontTool {
                     format!("✅ bring_to_front: pid {pid} hwnd 0x{hwnd:x} is now foreground (was 0x{prev:x}).")
                 } else if raised {
                     format!(
-                        "✅ bring_to_front: pid {pid} hwnd 0x{hwnd:x} raised to the visible front \
-                         (z-order, no focus steal), but the foreground-lock denied keyboard focus — \
-                         focus is still 0x{now:x}. A delivery_mode:\"foreground\" pointer click will \
-                         land; for keyboard focus run the cua-driver-uia worker."
+                        "bring_to_front: exact target hwnd 0x{hwnd:x} was raised in z-order, but \
+                         Windows kept foreground on hwnd 0x{now:x}; foreground activation failed."
                     )
                 } else {
                     format!(
@@ -8569,19 +8686,35 @@ impl Tool for BringToFrontTool {
                          foreground 0x{now:x})."
                     )
                 };
-                let r = if focused || raised {
-                    ToolResult::text(msg)
+                let structured = if focused {
+                    json!({
+                        "previous_fg_hwnd": format!("0x{prev:x}"),
+                        "now_fg_hwnd": format!("0x{now:x}"),
+                        "target_hwnd": format!("0x{hwnd:x}"),
+                        "landed_on_target": true,
+                        "raised": raised,
+                        "restored": restored,
+                    })
                 } else {
-                    ToolResult::error(msg)
+                    json!({
+                        "code": "foreground_unavailable",
+                        "effect": "refused",
+                        "pid": pid,
+                        "window_id": hwnd,
+                        "actual_foreground_window_id": now,
+                        "previous_fg_hwnd": format!("0x{prev:x}"),
+                        "now_fg_hwnd": format!("0x{now:x}"),
+                        "target_hwnd": format!("0x{hwnd:x}"),
+                        "landed_on_target": false,
+                        "raised": raised,
+                        "restored": restored,
+                    })
                 };
-                r.with_structured(json!({
-                    "previous_fg_hwnd": format!("0x{prev:x}"),
-                    "now_fg_hwnd":      format!("0x{now:x}"),
-                    "target_hwnd":      format!("0x{hwnd:x}"),
-                    "landed_on_target": focused,
-                    "raised":           raised,
-                    "restored":         restored,
-                }))
+                if focused {
+                    ToolResult::text(msg).with_structured(structured)
+                } else {
+                    ToolResult::error(msg).with_structured(structured)
+                }
             }
             Ok(Err(e)) => ToolResult::error(format!("bring_to_front: {e}")),
             Err(join) => {

--- a/libs/cua-driver/rust/crates/platform-windows/src/win32/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/win32/mod.rs
@@ -6,4 +6,5 @@ pub mod windows;
 
 pub use apps::{list_descendants, list_processes, related_processes, ProcessInfo};
 pub use installed_apps::{list_installed_apps, InstalledApp};
+pub(crate) use windows::{find_window_by_pid_and_handle, list_windows_via_win32};
 pub use windows::{list_windows, resolve_uwp_host_window, WindowInfo};

--- a/libs/cua-driver/rust/crates/platform-windows/src/win32/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/win32/mod.rs
@@ -6,5 +6,8 @@ pub mod windows;
 
 pub use apps::{list_descendants, list_processes, related_processes, ProcessInfo};
 pub use installed_apps::{list_installed_apps, InstalledApp};
-pub(crate) use windows::{find_window_by_pid_and_handle, list_windows_via_win32};
+pub(crate) use windows::{
+    find_window_by_pid_and_handle, list_windows_via_win32, post_action_foreground_matches,
+    window_owner_pid,
+};
 pub use windows::{list_windows, resolve_uwp_host_window, WindowInfo};

--- a/libs/cua-driver/rust/crates/platform-windows/src/win32/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/win32/mod.rs
@@ -7,7 +7,7 @@ pub mod windows;
 pub use apps::{list_descendants, list_processes, related_processes, ProcessInfo};
 pub use installed_apps::{list_installed_apps, InstalledApp};
 pub(crate) use windows::{
-    find_window_by_pid_and_handle, list_windows_via_win32, post_action_foreground_matches,
-    window_owner_pid,
+    capture_post_action_foreground_target, find_window_by_pid_and_handle, list_windows_via_win32,
+    post_action_foreground_matches, window_owner_pid,
 };
 pub use windows::{list_windows, resolve_uwp_host_window, WindowInfo};

--- a/libs/cua-driver/rust/crates/platform-windows/src/win32/windows.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/win32/windows.rs
@@ -56,7 +56,7 @@ struct EnumState {
 /// EnumWindows already reported). The pid filter is applied to the merged
 /// list.
 pub fn list_windows(filter_pid: Option<u32>) -> Vec<WindowInfo> {
-    let win32_windows = enumerate_via_enum_windows();
+    let win32_windows = list_windows_via_win32(None);
     let uia_windows = crate::uia::enumerate_top_level_windows();
 
     let mut seen: HashSet<u64> = HashSet::with_capacity(uia_windows.len() + win32_windows.len());
@@ -81,6 +81,25 @@ pub fn list_windows(filter_pid: Option<u32>) -> Vec<WindowInfo> {
         merged.retain(|w| w.pid == fp);
     }
     merged
+}
+
+/// Resolve one exact Win32 window without entering the global UIA tree.
+///
+/// Exact `(pid, HWND)` callers already have a native identity anchor. Avoiding
+/// the UIA union keeps an unrelated unresponsive provider from blocking that
+/// ownership check.
+pub(crate) fn find_window_by_pid_and_handle(pid: u32, hwnd: u64) -> Option<WindowInfo> {
+    list_windows_via_win32(Some(pid))
+        .into_iter()
+        .find(|window| window.hwnd == hwnd)
+}
+
+pub(crate) fn list_windows_via_win32(filter_pid: Option<u32>) -> Vec<WindowInfo> {
+    let mut windows = enumerate_via_enum_windows();
+    if let Some(pid) = filter_pid {
+        windows.retain(|window| window.pid == pid);
+    }
+    windows
 }
 
 /// Walk `EnumWindows` and collect every visible, non-empty-titled

--- a/libs/cua-driver/rust/crates/platform-windows/src/win32/windows.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/win32/windows.rs
@@ -24,8 +24,8 @@ use std::sync::Mutex;
 use windows::Win32::Foundation::{BOOL, HWND, LPARAM, RECT, TRUE};
 use windows::Win32::Graphics::Dwm::{DwmGetWindowAttribute, DWMWA_EXTENDED_FRAME_BOUNDS};
 use windows::Win32::UI::WindowsAndMessaging::{
-    EnumChildWindows, EnumWindows, GetClassNameW, GetWindowRect, GetWindowTextLengthW,
-    GetWindowTextW, GetWindowThreadProcessId, IsIconic, IsWindowVisible,
+    EnumChildWindows, EnumWindows, GetClassNameW, GetWindow, GetWindowRect, GetWindowTextLengthW,
+    GetWindowTextW, GetWindowThreadProcessId, IsIconic, IsWindow, IsWindowVisible, GW_OWNER,
 };
 
 #[derive(Debug, Clone)]
@@ -89,9 +89,127 @@ pub fn list_windows(filter_pid: Option<u32>) -> Vec<WindowInfo> {
 /// the UIA union keeps an unrelated unresponsive provider from blocking that
 /// ownership check.
 pub(crate) fn find_window_by_pid_and_handle(pid: u32, hwnd: u64) -> Option<WindowInfo> {
-    list_windows_via_win32(Some(pid))
-        .into_iter()
-        .find(|window| window.hwnd == hwnd)
+    exact_window_from_probe(pid, hwnd, window_info_by_handle)
+}
+
+fn exact_window_from_probe(
+    pid: u32,
+    hwnd: u64,
+    probe: impl FnOnce(u64) -> Option<WindowInfo>,
+) -> Option<WindowInfo> {
+    probe(hwnd).filter(|window| window.pid == pid && window.hwnd == hwnd)
+}
+
+/// Return the native owner of one exact HWND without enumerating Win32 or UIA.
+pub(crate) fn window_owner_pid(hwnd: u64) -> Option<u32> {
+    let hwnd = HWND(hwnd as *mut _);
+    if hwnd.0.is_null() || !unsafe { IsWindow(hwnd) }.as_bool() {
+        return None;
+    }
+    let mut pid = 0;
+    let thread_id = unsafe { GetWindowThreadProcessId(hwnd, Some(&mut pid)) };
+    (thread_id != 0 && pid != 0).then_some(pid)
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PostActionForegroundRelation {
+    exact_match: bool,
+    target_live: bool,
+    actual_live: bool,
+    actual_visible: bool,
+    same_pid: bool,
+    ownership_reaches_target: bool,
+}
+
+fn post_action_foreground_allowed(relation: PostActionForegroundRelation) -> bool {
+    relation.target_live
+        && relation.actual_live
+        && relation.actual_visible
+        && relation.same_pid
+        && (relation.exact_match || relation.ownership_reaches_target)
+}
+
+fn owner_chain_reaches_target(
+    target: u64,
+    actual: u64,
+    mut owner_of: impl FnMut(u64) -> Option<u64>,
+) -> bool {
+    let mut current = actual;
+    for _ in 0..64 {
+        let Some(owner) = owner_of(current) else {
+            return false;
+        };
+        if owner == target {
+            return true;
+        }
+        if owner == current || owner == actual {
+            return false;
+        }
+        current = owner;
+    }
+    false
+}
+
+/// Verify the foreground after an exact-target pointer action.
+///
+/// The requested HWND must become foreground before input is sent. The action
+/// may then legitimately open a same-process owned popup or modal, so the
+/// post-action check accepts that transient only when it is still a live,
+/// visible HWND and its complete `GW_OWNER` chain reaches the exact target.
+/// Unrelated same-process siblings and foreign foreground windows fail closed.
+pub(crate) fn post_action_foreground_matches(target: u64, actual: u64) -> bool {
+    let target_pid = window_owner_pid(target);
+    let actual_pid = window_owner_pid(actual);
+    let actual_hwnd = HWND(actual as *mut _);
+    let actual_visible = actual_pid.is_some() && unsafe { IsWindowVisible(actual_hwnd) }.as_bool();
+    let ownership_reaches_target = target != actual
+        && owner_chain_reaches_target(target, actual, |hwnd| {
+            let owner = unsafe { GetWindow(HWND(hwnd as *mut _), GW_OWNER) }
+                .ok()
+                .unwrap_or_default();
+            (!owner.0.is_null()).then_some(owner.0 as usize as u64)
+        });
+
+    post_action_foreground_allowed(PostActionForegroundRelation {
+        exact_match: target == actual,
+        target_live: target_pid.is_some(),
+        actual_live: actual_pid.is_some(),
+        actual_visible,
+        same_pid: target_pid.is_some() && target_pid == actual_pid,
+        ownership_reaches_target,
+    })
+}
+
+fn window_info_by_handle(hwnd: u64) -> Option<WindowInfo> {
+    let native = HWND(hwnd as *mut _);
+    let pid = window_owner_pid(hwnd)?;
+    if !unsafe { IsWindowVisible(native) }.as_bool() {
+        return None;
+    }
+    let title_len = unsafe { GetWindowTextLengthW(native) };
+    if title_len == 0 {
+        return None;
+    }
+    let mut buf = vec![0u16; (title_len + 1) as usize];
+    unsafe { GetWindowTextW(native, &mut buf) };
+    let title_len = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
+    let title = String::from_utf16_lossy(&buf[..title_len]);
+    if title.trim().is_empty() {
+        return None;
+    }
+    let minimized = unsafe { IsIconic(native) }.as_bool();
+    let (x, y, width, height) = get_window_bounds(native);
+    Some(WindowInfo {
+        hwnd,
+        pid,
+        title,
+        x,
+        y,
+        width,
+        height,
+        is_on_screen: !minimized,
+        minimized,
+    })
 }
 
 pub(crate) fn list_windows_via_win32(filter_pid: Option<u32>) -> Vec<WindowInfo> {
@@ -183,6 +301,106 @@ fn get_window_bounds(hwnd: HWND) -> (i32, i32, i32, i32) {
             rect.right - rect.left,
             rect.bottom - rect.top,
         )
+    }
+}
+
+#[cfg(test)]
+mod exact_window_tests {
+    use super::{
+        exact_window_from_probe, owner_chain_reaches_target, post_action_foreground_allowed,
+        PostActionForegroundRelation, WindowInfo,
+    };
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn window(pid: u32, hwnd: u64) -> WindowInfo {
+        WindowInfo {
+            hwnd,
+            pid,
+            title: "Exact target".into(),
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 100,
+            is_on_screen: true,
+            minimized: false,
+        }
+    }
+
+    #[test]
+    fn exact_lookup_probes_only_the_requested_native_handle() {
+        let calls = AtomicUsize::new(0);
+        let found = exact_window_from_probe(42, 0x1234, |hwnd| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            assert_eq!(hwnd, 0x1234);
+            Some(window(42, hwnd))
+        });
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(found.map(|window| window.hwnd), Some(0x1234));
+    }
+
+    #[test]
+    fn exact_lookup_rejects_wrong_pid_or_handle() {
+        assert!(exact_window_from_probe(42, 7, |_| Some(window(43, 7))).is_none());
+        assert!(exact_window_from_probe(42, 7, |_| Some(window(42, 8))).is_none());
+    }
+
+    fn relation(
+        exact_match: bool,
+        same_pid: bool,
+        ownership_reaches_target: bool,
+    ) -> PostActionForegroundRelation {
+        PostActionForegroundRelation {
+            exact_match,
+            target_live: true,
+            actual_live: true,
+            actual_visible: true,
+            same_pid,
+            ownership_reaches_target,
+        }
+    }
+
+    #[test]
+    fn exact_or_owned_modal_foreground_is_allowed() {
+        assert!(post_action_foreground_allowed(relation(true, true, false)));
+        assert!(post_action_foreground_allowed(relation(false, true, true)));
+    }
+
+    #[test]
+    fn nested_owned_popup_chain_reaches_exact_target() {
+        let owners = [(30, 20), (20, 10)];
+        assert!(owner_chain_reaches_target(10, 30, |hwnd| {
+            owners
+                .iter()
+                .find_map(|(child, owner)| (*child == hwnd).then_some(*owner))
+        }));
+    }
+
+    #[test]
+    fn unrelated_same_pid_sibling_and_foreign_foreground_are_denied() {
+        assert!(!post_action_foreground_allowed(relation(
+            false, true, false
+        )));
+        assert!(!post_action_foreground_allowed(relation(
+            false, false, true
+        )));
+        assert!(!owner_chain_reaches_target(10, 30, |hwnd| {
+            (hwnd == 30).then_some(40)
+        }));
+    }
+
+    #[test]
+    fn stale_invisible_or_cyclic_foreground_is_denied() {
+        let mut stale = relation(false, true, true);
+        stale.target_live = false;
+        assert!(!post_action_foreground_allowed(stale));
+        stale.target_live = true;
+        stale.actual_live = false;
+        assert!(!post_action_foreground_allowed(stale));
+        stale.actual_live = true;
+        stale.actual_visible = false;
+        assert!(!post_action_foreground_allowed(stale));
+        assert!(!owner_chain_reaches_target(10, 30, |_| Some(30)));
     }
 }
 

--- a/libs/cua-driver/rust/crates/platform-windows/src/win32/windows.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/win32/windows.rs
@@ -114,19 +114,22 @@ pub(crate) fn window_owner_pid(hwnd: u64) -> Option<u32> {
 #[derive(Clone, Copy, Debug)]
 struct PostActionForegroundRelation {
     exact_match: bool,
-    target_live: bool,
+    target_identity_live: bool,
+    target_gone: bool,
     actual_live: bool,
     actual_visible: bool,
     same_pid: bool,
     ownership_reaches_target: bool,
+    actual_is_prior_owner: bool,
 }
 
 fn post_action_foreground_allowed(relation: PostActionForegroundRelation) -> bool {
-    relation.target_live
-        && relation.actual_live
+    relation.actual_live
         && relation.actual_visible
         && relation.same_pid
-        && (relation.exact_match || relation.ownership_reaches_target)
+        && ((relation.target_identity_live
+            && (relation.exact_match || relation.ownership_reaches_target))
+            || (relation.target_gone && relation.actual_is_prior_owner))
 }
 
 fn owner_chain_reaches_target(
@@ -150,20 +153,48 @@ fn owner_chain_reaches_target(
     false
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PostActionForegroundTarget {
+    hwnd: u64,
+    pid: u32,
+    owner: Option<u64>,
+}
+
+/// Snapshot the exact target identity and owner before pointer input is sent.
+pub(crate) fn capture_post_action_foreground_target(
+    target: u64,
+) -> Option<PostActionForegroundTarget> {
+    let pid = window_owner_pid(target)?;
+    let owner = unsafe { GetWindow(HWND(target as *mut _), GW_OWNER) }
+        .ok()
+        .filter(|owner| !owner.0.is_null())
+        .map(|owner| owner.0 as usize as u64);
+    Some(PostActionForegroundTarget {
+        hwnd: target,
+        pid,
+        owner,
+    })
+}
+
 /// Verify the foreground after an exact-target pointer action.
 ///
 /// The requested HWND must become foreground before input is sent. The action
 /// may then legitimately open a same-process owned popup or modal, so the
 /// post-action check accepts that transient only when it is still a live,
 /// visible HWND and its complete `GW_OWNER` chain reaches the exact target.
+/// A dismiss action may instead destroy the requested owned modal; that is
+/// accepted only when foreground returns to its snapshotted same-process owner.
 /// Unrelated same-process siblings and foreign foreground windows fail closed.
-pub(crate) fn post_action_foreground_matches(target: u64, actual: u64) -> bool {
-    let target_pid = window_owner_pid(target);
+pub(crate) fn post_action_foreground_matches(
+    target: PostActionForegroundTarget,
+    actual: u64,
+) -> bool {
+    let current_target_pid = window_owner_pid(target.hwnd);
     let actual_pid = window_owner_pid(actual);
     let actual_hwnd = HWND(actual as *mut _);
     let actual_visible = actual_pid.is_some() && unsafe { IsWindowVisible(actual_hwnd) }.as_bool();
-    let ownership_reaches_target = target != actual
-        && owner_chain_reaches_target(target, actual, |hwnd| {
+    let ownership_reaches_target = target.hwnd != actual
+        && owner_chain_reaches_target(target.hwnd, actual, |hwnd| {
             let owner = unsafe { GetWindow(HWND(hwnd as *mut _), GW_OWNER) }
                 .ok()
                 .unwrap_or_default();
@@ -171,12 +202,14 @@ pub(crate) fn post_action_foreground_matches(target: u64, actual: u64) -> bool {
         });
 
     post_action_foreground_allowed(PostActionForegroundRelation {
-        exact_match: target == actual,
-        target_live: target_pid.is_some(),
+        exact_match: target.hwnd == actual,
+        target_identity_live: current_target_pid == Some(target.pid),
+        target_gone: current_target_pid.is_none(),
         actual_live: actual_pid.is_some(),
         actual_visible,
-        same_pid: target_pid.is_some() && target_pid == actual_pid,
+        same_pid: actual_pid == Some(target.pid),
         ownership_reaches_target,
+        actual_is_prior_owner: target.owner == Some(actual),
     })
 }
 
@@ -352,11 +385,13 @@ mod exact_window_tests {
     ) -> PostActionForegroundRelation {
         PostActionForegroundRelation {
             exact_match,
-            target_live: true,
+            target_identity_live: true,
+            target_gone: false,
             actual_live: true,
             actual_visible: true,
             same_pid,
             ownership_reaches_target,
+            actual_is_prior_owner: false,
         }
     }
 
@@ -390,11 +425,27 @@ mod exact_window_tests {
     }
 
     #[test]
-    fn stale_invisible_or_cyclic_foreground_is_denied() {
+    fn dismissed_owned_modal_may_return_to_its_snapshotted_owner_only() {
+        let mut dismissed = relation(false, true, false);
+        dismissed.target_identity_live = false;
+        dismissed.target_gone = true;
+        dismissed.actual_is_prior_owner = true;
+        assert!(post_action_foreground_allowed(dismissed));
+
+        dismissed.actual_is_prior_owner = false;
+        assert!(!post_action_foreground_allowed(dismissed));
+
+        dismissed.actual_is_prior_owner = true;
+        dismissed.same_pid = false;
+        assert!(!post_action_foreground_allowed(dismissed));
+    }
+
+    #[test]
+    fn stale_reused_invisible_or_cyclic_foreground_is_denied() {
         let mut stale = relation(false, true, true);
-        stale.target_live = false;
+        stale.target_identity_live = false;
         assert!(!post_action_foreground_allowed(stale));
-        stale.target_live = true;
+        stale.target_identity_live = true;
         stale.actual_live = false;
         assert!(!post_action_foreground_allowed(stale));
         stale.actual_live = true;


### PR DESCRIPTION
## Summary

- use direct Win32 ownership probes for exact `(PID, HWND)` discovery and Win32-only enumeration for PID-scoped action targeting
- keep the Win32 + UIA union for general window inventory while ensuring unrelated or wedged UIA providers cannot block exact native discovery
- centralize the bounded `VK_NONAME` foreground assist across browser setup, native menus, mouse, keyboard, and bring-to-front paths
- refuse explicit PID/HWND mismatches before input and fail closed when Windows keeps a different HWND foreground
- permit modal dismissal only when the requested live HWND disappears and foreground returns to its snapshotted visible same-process owner

## Behavior

Exact native discovery no longer enters the global UIA tree or scans unrelated windows. Explicit foreground actions now either activate the exact target HWND or return a typed failure; pointer delivery sends no input when activation fails, and `bring_to_front` no longer reports a z-order-only raise as foreground success.

Post-click verification accepts a live exact target or a live visible same-process transient whose `GW_OWNER` chain reaches it. When a dismissal destroys the target, success additionally requires foreground to return to the exact owner captured before input. Unrelated same-process siblings, foreign windows, stale handles, and reused HWNDs remain refused.

Background delivery and general accessibility-backed discovery are unchanged. This intentionally does not modify UIA worker timeout or hard-bound behavior.

## Validation

Final candidate: `3c05c72ae4ddb2efa2b7910c34eefd0a969b5486`

- `cargo fmt --all -- --check`
- deterministic unit coverage for direct exact-handle selection, typed PID/HWND mismatch, live owned transients, verified owner return after dismissal, and sibling/foreign/reused-handle refusal
- regular PR checks passed, including Windows unit/compile, cross-platform formatting, generated contract/client parity, release metadata, documentation sync, and contributor attribution
- authoritative exact-candidate hosted Windows native run [30910003859, attempt 2](https://github.com/trycua/cua/actions/runs/30910003859) passed:
  - WPF: 24 passed, 0 failed
  - WinUI3: 8 passed, 0 failed
  - WebView2: 4 passed, 0 failed
  - typed report: 37 delivered, 3 refused, 0 failed, 0 skipped
  - WPF modal MessageBox dismissal: delivered with fixture-state and accessibility-state oracles
  - all trajectory videos and the strict matrix reporter passed

The first post-integration attempt exercised the merged UIA worker guard during a transient cold-provider timeout. The guard correctly entered its recovery cooldown, so the later WebView2 route assertion could not use UIA and failed without a product-side false success. The exact retry completed the same candidate with the full matrix green and no UIA timeout/cooldown event.

Cross-target compilation from macOS requires a Windows C toolchain for `zstd-sys`; the successful hosted Windows run is the authoritative compile and behavior proof.

## Attribution

All contributor commits retain Hal/loonghao as author. Adaptation commits retain the human coauthor trailer. This updates and lands the existing contributor PR rather than replacing it.
