### PR TITLE
feat(cua-sandbox): accept native claim specs

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/__init__.py
+++ b/libs/python/cua-sandbox/cua_sandbox/__init__.py
@@ -31,12 +31,14 @@ from cua_sandbox.runtime.compat import (
 from cua_sandbox.sandbox import Sandbox, SandboxInfo, sandbox
 from cua_sandbox.transport.cloud import CloudTransport
 from fleet_sdk import (
+    ClaimSpec,
     CreatePoolRequest,
     Firmware,
     PoolSpec,
     PoolTemplate,
     RuntimeKind,
     SandboxService,
+    SandboxTemplateRef,
     ServiceProtocol,
 )
 
@@ -47,6 +49,8 @@ __all__ = [
     "Image",
     "Pool",
     "CreatePoolRequest",
+    "ClaimSpec",
+    "SandboxTemplateRef",
     "PoolSpec",
     "RuntimeKind",
     "PoolTemplate",

--- a/libs/python/cua-sandbox/cua_sandbox/pool.py
+++ b/libs/python/cua-sandbox/cua_sandbox/pool.py
@@ -10,7 +10,12 @@ from typing import Any, cast
 from cua_sandbox.sandbox import Sandbox
 from cua_sandbox.transport.fleet import FleetTransport
 from cua_sandbox.transport.fleet_cloud import _FleetClient
-from fleet_sdk import ClaimSpec, CreateClaimRequest, CreatePoolRequest, SandboxTemplateRef
+from fleet_sdk import (
+    ClaimSpec,
+    CreateClaimRequest,
+    CreatePoolRequest,
+    SandboxTemplateRef,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/libs/python/cua-sandbox/cua_sandbox/pool.py
+++ b/libs/python/cua-sandbox/cua_sandbox/pool.py
@@ -10,7 +10,7 @@ from typing import Any, cast
 from cua_sandbox.sandbox import Sandbox
 from cua_sandbox.transport.fleet import FleetTransport
 from cua_sandbox.transport.fleet_cloud import _FleetClient
-from fleet_sdk import CreateClaimRequest, CreatePoolRequest
+from fleet_sdk import ClaimSpec, CreateClaimRequest, CreatePoolRequest, SandboxTemplateRef
 
 logger = logging.getLogger(__name__)
 
@@ -58,8 +58,11 @@ class Pool:
             await client.close()
 
     @asynccontextmanager
-    async def claim(self) -> AsyncIterator[Sandbox]:
+    async def claim(self, *, bind_deadline: int | None = None) -> AsyncIterator[Sandbox]:
         """Lease a sandbox and release its Fleet claim when the block exits.
+
+        ``bind_deadline`` overrides the Fleet operator deadline in seconds.
+        Leave it as ``None`` to use the operator default.
 
         A claim is released after both normal and exceptional block exits. If
         release fails while the block is already raising, the original block
@@ -73,7 +76,15 @@ class Pool:
         cleanup_error: Exception | None = None
 
         try:
-            claim = await client.create_claim(CreateClaimRequest(pool=self._resource, spec=None))
+            spec = None
+            if bind_deadline is not None:
+                spec = ClaimSpec(
+                    sandbox_template_ref=SandboxTemplateRef(name=self.name),
+                    warmpool=None,
+                    bind_deadline=bind_deadline,
+                    lifecycle=None,
+                )
+            claim = await client.create_claim(CreateClaimRequest(pool=self._resource, spec=spec))
             bound = await client.wait_claim(claim)
             sandbox = Sandbox(
                 FleetTransport(sdk=client, bound=bound, service_name="server"), name=bound.name

--- a/libs/python/cua-sandbox/cua_sandbox/pool.py
+++ b/libs/python/cua-sandbox/cua_sandbox/pool.py
@@ -14,7 +14,6 @@ from fleet_sdk import (
     ClaimSpec,
     CreateClaimRequest,
     CreatePoolRequest,
-    SandboxTemplateRef,
 )
 
 logger = logging.getLogger(__name__)
@@ -63,11 +62,8 @@ class Pool:
             await client.close()
 
     @asynccontextmanager
-    async def claim(self, *, bind_deadline: int | None = None) -> AsyncIterator[Sandbox]:
+    async def claim(self, *, spec: ClaimSpec | None = None) -> AsyncIterator[Sandbox]:
         """Lease a sandbox and release its Fleet claim when the block exits.
-
-        ``bind_deadline`` overrides the Fleet operator deadline in seconds.
-        Leave it as ``None`` to use the operator default.
 
         A claim is released after both normal and exceptional block exits. If
         release fails while the block is already raising, the original block
@@ -81,14 +77,6 @@ class Pool:
         cleanup_error: Exception | None = None
 
         try:
-            spec = None
-            if bind_deadline is not None:
-                spec = ClaimSpec(
-                    sandbox_template_ref=SandboxTemplateRef(name=self.name),
-                    warmpool=None,
-                    bind_deadline=bind_deadline,
-                    lifecycle=None,
-                )
             claim = await client.create_claim(CreateClaimRequest(pool=self._resource, spec=spec))
             bound = await client.wait_claim(claim)
             sandbox = Sandbox(

--- a/libs/python/cua-sandbox/cua_sandbox/sync/__init__.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sync/__init__.py
@@ -95,9 +95,9 @@ class Pool:
         return cls(_run(_AsyncPool.reconcile(request)))
 
     @contextmanager
-    def claim(self) -> Iterator[_SyncProxy]:
+    def claim(self, *, bind_deadline: int | None = None) -> Iterator[_SyncProxy]:
         """Synchronously lease a sandbox and release the claim on exit."""
-        context = self._async_pool.claim()
+        context = self._async_pool.claim(bind_deadline=bind_deadline)
         sandbox = _run(context.__aenter__())
         try:
             yield _SyncProxy(sandbox)

--- a/libs/python/cua-sandbox/cua_sandbox/sync/__init__.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sync/__init__.py
@@ -24,7 +24,7 @@ from cua_sandbox.image import Image
 from cua_sandbox.localhost import Localhost as _AsyncLocalhost
 from cua_sandbox.pool import Pool as _AsyncPool
 from cua_sandbox.sandbox import Sandbox as _AsyncSandbox
-from fleet_sdk import CreatePoolRequest
+from fleet_sdk import ClaimSpec, CreatePoolRequest
 
 
 def _get_or_create_loop() -> asyncio.AbstractEventLoop:
@@ -95,9 +95,9 @@ class Pool:
         return cls(_run(_AsyncPool.reconcile(request)))
 
     @contextmanager
-    def claim(self, *, bind_deadline: int | None = None) -> Iterator[_SyncProxy]:
+    def claim(self, *, spec: ClaimSpec | None = None) -> Iterator[_SyncProxy]:
         """Synchronously lease a sandbox and release the claim on exit."""
-        context = self._async_pool.claim(bind_deadline=bind_deadline)
+        context = self._async_pool.claim(spec=spec)
         sandbox = _run(context.__aenter__())
         try:
             yield _SyncProxy(sandbox)

--- a/libs/python/cua-sandbox/tests/test_pool.py
+++ b/libs/python/cua-sandbox/tests/test_pool.py
@@ -262,9 +262,10 @@ def test_sync_pool_matches_blocking_context_manager(monkeypatch):
     monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: next(clients))
 
     pool = SyncPool.reconcile(pool_request())
-    with pool.claim() as sandbox:
+    with pool.claim(bind_deadline=900) as sandbox:
         assert sandbox.name == "sandbox-1"
 
+    assert claim_client.claims[0].spec.bind_deadline == 900
     assert claim_client.released == ["claim-1"]
     assert claim_client.closed is True
 
@@ -338,3 +339,21 @@ async def test_claim_exposes_named_service_requests(monkeypatch):
     _, service, path, request = claim_client.service_requests[0]
     assert (service, path, request.method) == ("mcp", "/mcp", "POST")
     assert request.body == b'{"jsonrpc": "2.0", "method": "tools/list", "id": 1}'
+
+@pytest.mark.asyncio
+async def test_claim_forwards_bind_deadline_to_fleet(monkeypatch):
+    reconcile_client = FakeFleetClient()
+    claim_client = FakeFleetClient()
+    clients = iter([reconcile_client, claim_client])
+    monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: next(clients))
+    pool = await Pool.reconcile(pool_request())
+
+    async with pool.claim(bind_deadline=900) as sandbox:
+        assert sandbox.name == "sandbox-1"
+
+    request = claim_client.claims[0]
+    assert request.pool is pool.resource
+    assert request.spec.bind_deadline == 900
+    assert request.spec.sandbox_template_ref.name == pool.name
+    assert request.spec.warmpool is None
+    assert request.spec.lifecycle is None

--- a/libs/python/cua-sandbox/tests/test_pool.py
+++ b/libs/python/cua-sandbox/tests/test_pool.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 from cua_sandbox import (
+    ClaimSpec,
     CreatePoolRequest,
     Firmware,
     Pool,
@@ -11,6 +12,7 @@ from cua_sandbox import (
     PoolTemplate,
     RuntimeKind,
     SandboxService,
+    SandboxTemplateRef,
     ServiceProtocol,
 )
 from cua_sandbox.sync import Pool as SyncPool
@@ -262,10 +264,16 @@ def test_sync_pool_matches_blocking_context_manager(monkeypatch):
     monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: next(clients))
 
     pool = SyncPool.reconcile(pool_request())
-    with pool.claim(bind_deadline=900) as sandbox:
+    spec = ClaimSpec(
+        sandbox_template_ref=SandboxTemplateRef(name=pool.name),
+        warmpool=None,
+        bind_deadline=900,
+        lifecycle=None,
+    )
+    with pool.claim(spec=spec) as sandbox:
         assert sandbox.name == "sandbox-1"
 
-    assert claim_client.claims[0].spec.bind_deadline == 900
+    assert claim_client.claims[0].spec is spec
     assert claim_client.released == ["claim-1"]
     assert claim_client.closed is True
 
@@ -340,20 +348,25 @@ async def test_claim_exposes_named_service_requests(monkeypatch):
     assert (service, path, request.method) == ("mcp", "/mcp", "POST")
     assert request.body == b'{"jsonrpc": "2.0", "method": "tools/list", "id": 1}'
 
+
 @pytest.mark.asyncio
-async def test_claim_forwards_bind_deadline_to_fleet(monkeypatch):
+async def test_claim_forwards_native_claim_spec_unchanged(monkeypatch):
     reconcile_client = FakeFleetClient()
     claim_client = FakeFleetClient()
     clients = iter([reconcile_client, claim_client])
     monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: next(clients))
     pool = await Pool.reconcile(pool_request())
 
-    async with pool.claim(bind_deadline=900) as sandbox:
+    spec = ClaimSpec(
+        sandbox_template_ref=SandboxTemplateRef(name=pool.name),
+        warmpool=None,
+        bind_deadline=900,
+        lifecycle=None,
+    )
+
+    async with pool.claim(spec=spec) as sandbox:
         assert sandbox.name == "sandbox-1"
 
     request = claim_client.claims[0]
     assert request.pool is pool.resource
-    assert request.spec.bind_deadline == 900
-    assert request.spec.sandbox_template_ref.name == pool.name
-    assert request.spec.warmpool is None
-    assert request.spec.lifecycle is None
+    assert request.spec is spec


### PR DESCRIPTION
Adds `Pool.claim(spec=ClaimSpec | None)` to the public async and sync CUA Sandbox APIs.

`ClaimSpec` and `SandboxTemplateRef` are public `cua_sandbox` exports. The provided spec is forwarded unchanged into `CreateClaimRequest`, so Hermes can configure `bind_deadline=900` and future generated claim fields without importing `fleet_sdk`.

Validation:
- `uv run --directory libs/python/cua-sandbox pytest tests/test_pool.py -q` (`17 passed`)
- isort, Black, and Ruff on touched source/tests