### PR TITLE
test(cua-sandbox): cover default Fleet claim spec

### DIFF
--- a/libs/python/cua-sandbox/tests/test_pool.py
+++ b/libs/python/cua-sandbox/tests/test_pool.py
@@ -370,3 +370,21 @@ async def test_claim_forwards_native_claim_spec_unchanged(monkeypatch):
     request = claim_client.claims[0]
     assert request.pool is pool.resource
     assert request.spec is spec
+
+
+@pytest.mark.asyncio
+async def test_claim_without_spec_uses_operator_default(monkeypatch):
+    reconcile_client = FakeFleetClient()
+    claim_client = FakeFleetClient()
+    clients = iter([reconcile_client, claim_client])
+    monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: next(clients))
+    pool = await Pool.reconcile(pool_request())
+
+    async with pool.claim() as sandbox:
+        assert sandbox.name == "sandbox-1"
+
+    request = claim_client.claims[0]
+    assert request.pool is pool.resource
+    assert request.spec is None
+    assert claim_client.released == ["claim-1"]
+    assert claim_client.closed is True


### PR DESCRIPTION
Adds an explicit happy-path regression test for `async with pool.claim()` without arguments. It verifies the public default forwards `CreateClaimRequest(..., spec=None)` and completes claim cleanup.

Validation: `uv run --directory libs/python/cua-sandbox pytest tests/test_pool.py -q` (`18 passed`).