### PR TITLE
feat(cua-driver): add TypeScript MCP skill server

### DIFF
--- a/.github/workflows/ci-cua-driver-contract-clients.yml
+++ b/.github/workflows/ci-cua-driver-contract-clients.yml
@@ -7,6 +7,7 @@ on:
       - "libs/cua-driver/compat-fixtures/**"
       - "libs/cua-driver/examples/agent-sdks/**"
       - "libs/cua-driver/typescript/**"
+      - "libs/cua-driver/mcp-typescript/**"
       - "libs/cua-driver/python/**"
       - "libs/cua-driver/rust/Cargo.toml"
       - "libs/cua-driver/rust/Cargo.lock"
@@ -33,6 +34,7 @@ on:
       - "libs/cua-driver/compat-fixtures/**"
       - "libs/cua-driver/examples/agent-sdks/**"
       - "libs/cua-driver/typescript/**"
+      - "libs/cua-driver/mcp-typescript/**"
       - "libs/cua-driver/python/**"
       - "libs/cua-driver/rust/Cargo.toml"
       - "libs/cua-driver/rust/Cargo.lock"
@@ -62,6 +64,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  mcp-typescript:
+    name: TypeScript MCP server
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: libs/cua-driver/mcp-typescript/package-lock.json
+      - name: Install MCP server dependencies
+        working-directory: libs/cua-driver/mcp-typescript
+        run: npm ci
+      - name: Test TypeScript MCP server
+        working-directory: libs/cua-driver/mcp-typescript
+        run: npm run format:check && npm run typecheck && npm test && npm audit --omit=dev --audit-level=high
+
   runtime-parity:
     name: Portable contract parity (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-cua-driver-contract-clients.yml
+++ b/.github/workflows/ci-cua-driver-contract-clients.yml
@@ -7,7 +7,6 @@ on:
       - "libs/cua-driver/compat-fixtures/**"
       - "libs/cua-driver/examples/agent-sdks/**"
       - "libs/cua-driver/typescript/**"
-      - "libs/cua-driver/mcp-typescript/**"
       - "libs/cua-driver/python/**"
       - "libs/cua-driver/rust/Cargo.toml"
       - "libs/cua-driver/rust/Cargo.lock"
@@ -34,7 +33,6 @@ on:
       - "libs/cua-driver/compat-fixtures/**"
       - "libs/cua-driver/examples/agent-sdks/**"
       - "libs/cua-driver/typescript/**"
-      - "libs/cua-driver/mcp-typescript/**"
       - "libs/cua-driver/python/**"
       - "libs/cua-driver/rust/Cargo.toml"
       - "libs/cua-driver/rust/Cargo.lock"
@@ -64,24 +62,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  mcp-typescript:
-    name: TypeScript MCP server
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: npm
-          cache-dependency-path: libs/cua-driver/mcp-typescript/package-lock.json
-      - name: Install MCP server dependencies
-        working-directory: libs/cua-driver/mcp-typescript
-        run: npm ci
-      - name: Test TypeScript MCP server
-        working-directory: libs/cua-driver/mcp-typescript
-        run: npm run format:check && npm run typecheck && npm test && npm audit --omit=dev --audit-level=high
-
   runtime-parity:
     name: Portable contract parity (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-cua-driver-mcp-typescript.yml
+++ b/.github/workflows/ci-cua-driver-mcp-typescript.yml
@@ -1,0 +1,39 @@
+name: "CI: cua-driver TypeScript MCP"
+
+on:
+  pull_request:
+    paths:
+      - "libs/cua-driver/mcp-typescript/**"
+      - ".github/workflows/ci-cua-driver-mcp-typescript.yml"
+  push:
+    branches: [main]
+    paths:
+      - "libs/cua-driver/mcp-typescript/**"
+      - ".github/workflows/ci-cua-driver-mcp-typescript.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-cua-driver-mcp-typescript-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: TypeScript MCP server
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: libs/cua-driver/mcp-typescript/package-lock.json
+      - name: Install dependencies
+        working-directory: libs/cua-driver/mcp-typescript
+        run: npm ci
+      - name: Test server
+        working-directory: libs/cua-driver/mcp-typescript
+        run: npm run format:check && npm run typecheck && npm test && npm audit --omit=dev --audit-level=high

--- a/libs/cua-driver/mcp-typescript/.gitignore
+++ b/libs/cua-driver/mcp-typescript/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/libs/cua-driver/mcp-typescript/.prettierignore
+++ b/libs/cua-driver/mcp-typescript/.prettierignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/libs/cua-driver/mcp-typescript/README.md
+++ b/libs/cua-driver/mcp-typescript/README.md
@@ -16,9 +16,10 @@ every platform tool in TypeScript.
 
 The server connects with `CuaDriver.connect()`. It does not normally call
 `CuaDriver.create()`, because a same-process runtime would move desktop
-ownership into Node and, on macOS, change the TCC responsibility identity. One
-generated client remains connected to one daemon socket for the MCP server's
-lifetime. Public session names, daemon state, consent decisions, desktop
+ownership into Node and, on macOS, change the TCC responsibility identity. The
+connection accepts both standalone and app-owned embedded daemons; the daemon
+process remains the execution boundary in either case. One generated client
+remains connected to one daemon socket for the MCP server's lifetime. Public session names, daemon state, consent decisions, desktop
 identity, and TCC attribution remain at the released daemon boundary. Destroying
 the client does not stop a daemon that it does not own.
 

--- a/libs/cua-driver/mcp-typescript/README.md
+++ b/libs/cua-driver/mcp-typescript/README.md
@@ -1,0 +1,78 @@
+# Cua Driver TypeScript MCP server
+
+This private package hosts Cua Driver through the official Model Context
+Protocol TypeScript SDK. It uses the generated TypeScript UniFFI package and
+the release-matched skill pack in `../rust/Skills/cua-driver`. It is not
+published and does not alter a release workflow.
+
+## Execution boundary
+
+The generated binding exposes the two open-ended methods a protocol adapter
+needs: `CuaDriver.listToolsJson()` returns the canonical platform inventory,
+and `CuaDriver.callTool()` returns a `ToolResult.rawJson` copy of the MCP result.
+The server therefore preserves dynamic input and output schemas, annotations,
+text and image content, structured content, and tool errors without rebuilding
+every platform tool in TypeScript.
+
+The server connects with `CuaDriver.connect()`. It does not normally call
+`CuaDriver.create()`, because a same-process runtime would move desktop
+ownership into Node and, on macOS, change the TCC responsibility identity. One
+generated client remains connected to one daemon socket for the MCP server's
+lifetime. Public session names, daemon state, consent decisions, desktop
+identity, and TCC attribution remain at the released daemon boundary. Destroying
+the client does not stop a daemon that it does not own.
+
+The generated JavaScript API does not expose three Rust-only adapter methods:
+`CuaDriver::inspect_host_tools`, `CuaDriver::connect_remote`, and
+`CuaDriver::call_tool_from_trusted_adapter`. Rust-only `DriverHostOptions` also
+contains `register_host_tools`, a function-pointer hook that UniFFI cannot
+represent. JavaScript therefore cannot register daemon administrative tools,
+provide an authenticated remote carrier, or inject the Rust MCP proxy's private
+transport-session evidence. The public generic call sanitizes reserved
+arguments. This package does not simulate those capabilities.
+
+The generated API currently has 19 typed desktop methods and four typed session
+methods. Those 23 methods are a portable typed subset. The generic inventory and
+call methods expose the full live platform registry through the daemon. The
+server uses the SDK's low-level `Server` API so it can forward the live JSON
+Schema and annotations without translating them through another schema system.
+
+## Skill pack
+
+Initialization instructions contain a compact `<available_skills>` catalog.
+The read-only `load-skill` tool loads `SKILL.md` on demand and may load a
+referenced Markdown companion such as `BROWSER.md`. Companion files are also
+read-only MCP resources. Paths use `realpath`, remain inside the bundled root,
+are restricted to Markdown, and reject absolute paths, traversal, and symlink
+escapes. Mutable local, GitHub, archive, and arbitrary remote skill sources are
+not enabled.
+
+## Run
+
+Build the sibling `../typescript` package and stage its release-matched native
+library. Start the installed Cua Driver daemon with the intended policy and TCC
+identity, then run:
+
+```bash
+npm install
+npm run build
+CUA_DRIVER_SOCKET=/path/to/cua-driver.sock node dist/cli.js
+```
+
+`CUA_DRIVER_TYPESCRIPT_MODULE` may point to another built copy of the same
+release-matched generated package for local validation.
+
+## Costs and limitations
+
+- Startup performs one daemon metadata check and one inventory request. Each
+  tool call adds a Node-to-UniFFI-to-local-socket hop.
+- The inventory is cached for the server lifetime. Restart after a daemon
+  generation or tool-set change; old generation connections are not reusable.
+- Cancellation and MCP transport-session evidence are not exported by the
+  public generic UniFFI call. Daemon tool and session policy still applies, but
+  this adapter cannot claim the Rust proxy's private trusted-evidence path.
+- Tests validate protocol and adapter contracts without a native desktop. Native
+  execution and macOS/Windows permission identity require release-matched
+  artifacts on those operating systems.
+- Skilljack's mutable discovery, watching, prompts, UI, subscriptions, and
+  remote-source features remain out of scope.

--- a/libs/cua-driver/mcp-typescript/package-lock.json
+++ b/libs/cua-driver/mcp-typescript/package-lock.json
@@ -1,0 +1,1233 @@
+{
+  "name": "@trycua/cua-driver-mcp-typescript",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@trycua/cua-driver-mcp-typescript",
+      "version": "0.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.30.0"
+      },
+      "bin": {
+        "cua-driver-mcp-typescript": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "prettier": "^3.6.2",
+        "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+      "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/libs/cua-driver/mcp-typescript/package.json
+++ b/libs/cua-driver/mcp-typescript/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@trycua/cua-driver-mcp-typescript",
+  "version": "0.0.0",
+  "private": true,
+  "description": "TypeScript MCP server for the Cua Driver daemon and bundled skill pack",
+  "type": "module",
+  "bin": {
+    "cua-driver-mcp-typescript": "dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "test": "npm run build && node --test test/*.test.mjs",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.30.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "prettier": "^3.6.2",
+    "typescript": "^5.7.0"
+  }
+}

--- a/libs/cua-driver/mcp-typescript/src/adapter.ts
+++ b/libs/cua-driver/mcp-typescript/src/adapter.ts
@@ -57,13 +57,7 @@ export class UniffiDaemonAdapter implements DriverAdapter {
     const module = (await import(
       pathToFileURL(options.modulePath).href
     )) as GeneratedCuaDriverModule;
-    const driver = module.CuaDriver.connect(options.socketPath);
-    const metadata = await driver.metadata();
-    if (metadata.embedded) {
-      driver.uniffiDestroy();
-      throw new Error('expected the canonical Cua Driver daemon, got an embedded runtime');
-    }
-    return new UniffiDaemonAdapter(driver);
+    return new UniffiDaemonAdapter(module.CuaDriver.connect(options.socketPath));
   }
 
   async listTools(): Promise<Tool[]> {

--- a/libs/cua-driver/mcp-typescript/src/adapter.ts
+++ b/libs/cua-driver/mcp-typescript/src/adapter.ts
@@ -1,0 +1,86 @@
+import { pathToFileURL } from 'node:url';
+import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { DriverAdapter, GeneratedCuaDriver, GeneratedCuaDriverModule } from './types.js';
+
+interface DaemonToolDefinition {
+  annotations?: Tool['annotations'];
+  capabilities?: unknown;
+  description?: string;
+  destructive?: boolean;
+  idempotent?: boolean;
+  input_schema?: Tool['inputSchema'];
+  name?: string;
+  open_world?: boolean;
+  output_schema?: Tool['outputSchema'];
+  read_only?: boolean;
+  risk?: unknown;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function mapDaemonInventory(value: unknown): Tool[] {
+  const definitions = isObject(value) && Array.isArray(value.tools) ? value.tools : undefined;
+  if (!definitions) throw new Error('Cua Driver returned an invalid tool inventory');
+
+  return definitions.map((raw) => {
+    const definition = raw as DaemonToolDefinition;
+    if (!definition.name || !definition.input_schema) {
+      throw new Error('Cua Driver returned an incomplete tool definition');
+    }
+    const tool: Tool & Record<string, unknown> = {
+      name: definition.name,
+      description: definition.description ?? '',
+      inputSchema: definition.input_schema,
+      annotations: definition.annotations ?? {
+        readOnlyHint: definition.read_only ?? false,
+        destructiveHint: definition.destructive ?? false,
+        idempotentHint: definition.idempotent ?? false,
+        openWorldHint: definition.open_world ?? false,
+      },
+    };
+    if (definition.output_schema) tool.outputSchema = definition.output_schema;
+    if (definition.capabilities !== undefined) tool.capabilities = definition.capabilities;
+    if (definition.risk !== undefined) tool.risk = definition.risk;
+    return tool;
+  });
+}
+
+export class UniffiDaemonAdapter implements DriverAdapter {
+  constructor(private readonly driver: GeneratedCuaDriver) {}
+
+  static async connect(options: {
+    modulePath: string;
+    socketPath?: string;
+  }): Promise<UniffiDaemonAdapter> {
+    const module = (await import(
+      pathToFileURL(options.modulePath).href
+    )) as GeneratedCuaDriverModule;
+    const driver = module.CuaDriver.connect(options.socketPath);
+    const metadata = await driver.metadata();
+    if (metadata.embedded) {
+      driver.uniffiDestroy();
+      throw new Error('expected the canonical Cua Driver daemon, got an embedded runtime');
+    }
+    return new UniffiDaemonAdapter(driver);
+  }
+
+  async listTools(): Promise<Tool[]> {
+    return mapDaemonInventory(JSON.parse(await this.driver.listToolsJson()));
+  }
+
+  async callTool(name: string, args: Record<string, unknown>): Promise<CallToolResult> {
+    const result = await this.driver.callTool(name, JSON.stringify(args));
+    const raw = JSON.parse(result.rawJson) as unknown;
+    if (!isObject(raw) || !Array.isArray(raw.content)) {
+      throw new Error(`Cua Driver returned an invalid result for ${name}`);
+    }
+    return raw as CallToolResult;
+  }
+
+  async close(): Promise<void> {
+    await this.driver.shutdown();
+    this.driver.uniffiDestroy();
+  }
+}

--- a/libs/cua-driver/mcp-typescript/src/cli.ts
+++ b/libs/cua-driver/mcp-typescript/src/cli.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { UniffiDaemonAdapter } from './adapter.js';
+import { createCuaMcpServer } from './server.js';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const componentRoot = resolve(packageRoot, '..');
+const adapter = await UniffiDaemonAdapter.connect({
+  modulePath:
+    process.env.CUA_DRIVER_TYPESCRIPT_MODULE ?? resolve(componentRoot, 'typescript/dist/index.js'),
+  ...(process.env.CUA_DRIVER_SOCKET ? { socketPath: process.env.CUA_DRIVER_SOCKET } : {}),
+});
+const server = await createCuaMcpServer({
+  adapter,
+  skillRoot: resolve(componentRoot, 'rust/Skills/cua-driver'),
+});
+const close = async (): Promise<void> => {
+  await server.close();
+  await adapter.close();
+};
+process.once('SIGINT', () => void close());
+process.once('SIGTERM', () => void close());
+await server.connect(new StdioServerTransport());

--- a/libs/cua-driver/mcp-typescript/src/server.ts
+++ b/libs/cua-driver/mcp-typescript/src/server.ts
@@ -1,0 +1,55 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  CallToolRequestSchema,
+  ListResourcesRequestSchema,
+  ListToolsRequestSchema,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import {
+  buildSkillInstructions,
+  listSkillResources,
+  LOAD_SKILL_TOOL,
+  loadSkill,
+  loadSkillTool,
+  readSkillResource,
+} from './skill-pack.js';
+import type { DriverAdapter } from './types.js';
+
+export async function createCuaMcpServer(options: {
+  adapter: DriverAdapter;
+  skillRoot: string;
+}): Promise<Server> {
+  const driverTools = await options.adapter.listTools();
+  const driverToolNames = new Set(driverTools.map((tool) => tool.name));
+  if (driverToolNames.has(LOAD_SKILL_TOOL))
+    throw new Error(`reserved tool collision: ${LOAD_SKILL_TOOL}`);
+
+  const server = new Server(
+    { name: 'cua-driver-mcp-typescript', version: '0.0.0' },
+    {
+      capabilities: { tools: {}, resources: {} },
+      instructions: await buildSkillInstructions(options.skillRoot),
+    }
+  );
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [...driverTools, loadSkillTool],
+  }));
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const args = request.params.arguments ?? {};
+    if (request.params.name === LOAD_SKILL_TOOL) return loadSkill(options.skillRoot, args);
+    if (!driverToolNames.has(request.params.name)) {
+      return {
+        content: [{ type: 'text', text: `Unknown tool: ${request.params.name}` }],
+        isError: true,
+      };
+    }
+    return options.adapter.callTool(request.params.name, args);
+  });
+  server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+    resources: await listSkillResources(options.skillRoot),
+  }));
+  server.setRequestHandler(ReadResourceRequestSchema, async (request) => ({
+    contents: [await readSkillResource(options.skillRoot, request.params.uri)],
+  }));
+  return server;
+}

--- a/libs/cua-driver/mcp-typescript/src/skill-pack.ts
+++ b/libs/cua-driver/mcp-typescript/src/skill-pack.ts
@@ -63,14 +63,24 @@ export async function loadSkill(
   skillRoot: string,
   args: Record<string, unknown>
 ): Promise<CallToolResult> {
+  const extraKeys = Object.keys(args).filter((key) => key !== 'name' && key !== 'path');
+  if (extraKeys.length > 0) {
+    return {
+      content: [{ type: 'text', text: `Unknown load-skill fields: ${extraKeys.join(', ')}` }],
+      isError: true,
+    };
+  }
   if (args.name !== SKILL_NAME) {
     return {
       content: [{ type: 'text', text: `Unknown skill: ${String(args.name)}` }],
       isError: true,
     };
   }
+  if (args.path !== undefined && typeof args.path !== 'string') {
+    return { content: [{ type: 'text', text: 'skill path must be a string' }], isError: true };
+  }
   try {
-    const requestedPath = typeof args.path === 'string' ? args.path : 'SKILL.md';
+    const requestedPath = args.path ?? 'SKILL.md';
     const path = await resolveSkillFile(skillRoot, requestedPath);
     if (!path.endsWith('.md')) throw new Error('only Markdown skill files are readable');
     return { content: [{ type: 'text', text: await readFile(path, 'utf8') }] };

--- a/libs/cua-driver/mcp-typescript/src/skill-pack.ts
+++ b/libs/cua-driver/mcp-typescript/src/skill-pack.ts
@@ -1,0 +1,107 @@
+import { realpath, readFile, readdir } from 'node:fs/promises';
+import { basename, isAbsolute, relative, resolve, sep } from 'node:path';
+import type { CallToolResult, Resource, Tool } from '@modelcontextprotocol/sdk/types.js';
+
+export const SKILL_NAME = 'cua-driver';
+export const LOAD_SKILL_TOOL = 'load-skill';
+export const SKILL_URI_PREFIX = 'cua-driver-skill://cua-driver/';
+
+function parseDescription(skill: string): string {
+  const frontmatter = skill.match(/^---\n([\s\S]*?)\n---/);
+  const metadata = frontmatter?.[1];
+  return metadata?.match(/^description:\s*(.+)$/m)?.[1]?.trim() ?? 'Operate Cua Driver.';
+}
+
+export async function buildSkillInstructions(skillRoot: string): Promise<string> {
+  const description = parseDescription(await readFile(resolve(skillRoot, 'SKILL.md'), 'utf8'));
+  return [
+    'This server exposes the release-matched Cua Driver skill through `load-skill`.',
+    'When relevant, call `load-skill` before acting. Load companion files only when SKILL.md references them.',
+    '',
+    '<available_skills>',
+    `<skill><name>${SKILL_NAME}</name><description>${description}</description></skill>`,
+    '</available_skills>',
+  ].join('\n');
+}
+
+async function resolveSkillFile(skillRoot: string, requestedPath: string): Promise<string> {
+  if (!requestedPath || isAbsolute(requestedPath)) throw new Error('skill path must be relative');
+  const normalized = requestedPath.replaceAll('\\', '/');
+  if (normalized.split('/').includes('..')) throw new Error('skill path traversal is not allowed');
+
+  const root = await realpath(skillRoot);
+  const candidate = await realpath(resolve(root, normalized));
+  const child = relative(root, candidate);
+  if (!child || child === '..' || child.startsWith(`..${sep}`) || isAbsolute(child)) {
+    throw new Error('skill path escapes the bundled skill root');
+  }
+  return candidate;
+}
+
+export const loadSkillTool: Tool = {
+  name: LOAD_SKILL_TOOL,
+  title: 'Load Cua Driver Skill',
+  description: 'Load bundled Cua Driver SKILL.md or a referenced companion Markdown file.',
+  inputSchema: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      name: { type: 'string', enum: [SKILL_NAME] },
+      path: { type: 'string', default: 'SKILL.md' },
+    },
+    required: ['name'],
+  },
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+};
+
+export async function loadSkill(
+  skillRoot: string,
+  args: Record<string, unknown>
+): Promise<CallToolResult> {
+  if (args.name !== SKILL_NAME) {
+    return {
+      content: [{ type: 'text', text: `Unknown skill: ${String(args.name)}` }],
+      isError: true,
+    };
+  }
+  try {
+    const requestedPath = typeof args.path === 'string' ? args.path : 'SKILL.md';
+    const path = await resolveSkillFile(skillRoot, requestedPath);
+    if (!path.endsWith('.md')) throw new Error('only Markdown skill files are readable');
+    return { content: [{ type: 'text', text: await readFile(path, 'utf8') }] };
+  } catch (error) {
+    return {
+      content: [{ type: 'text', text: error instanceof Error ? error.message : String(error) }],
+      isError: true,
+    };
+  }
+}
+
+export async function listSkillResources(skillRoot: string): Promise<Resource[]> {
+  const files = (await readdir(skillRoot, { withFileTypes: true }))
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.md') && entry.name !== 'SKILL.md')
+    .map((entry) => entry.name)
+    .sort();
+  return files.map((file) => ({
+    uri: `${SKILL_URI_PREFIX}${file}`,
+    name: `${SKILL_NAME}/${file}`,
+    title: basename(file, '.md'),
+    description: `Bundled companion file for the ${SKILL_NAME} skill.`,
+    mimeType: 'text/markdown',
+  }));
+}
+
+export async function readSkillResource(skillRoot: string, uri: string) {
+  if (!uri.startsWith(SKILL_URI_PREFIX)) throw new Error('unknown skill resource URI');
+  const requestedPath = decodeURIComponent(uri.slice(SKILL_URI_PREFIX.length));
+  const path = await resolveSkillFile(skillRoot, requestedPath);
+  if (!path.endsWith('.md') || path.endsWith(`${sep}SKILL.md`)) {
+    throw new Error('resource URI must identify a companion Markdown file');
+  }
+  return { uri, mimeType: 'text/markdown', text: await readFile(path, 'utf8') };
+}

--- a/libs/cua-driver/mcp-typescript/src/types.ts
+++ b/libs/cua-driver/mcp-typescript/src/types.ts
@@ -9,7 +9,6 @@ export interface DriverAdapter {
 export interface GeneratedCuaDriver {
   callTool(name: string, argumentsJson: string): Promise<{ rawJson: string }>;
   listToolsJson(): Promise<string>;
-  metadata(): Promise<{ embedded: boolean; hostBundleId?: string; pid: number }>;
   shutdown(): Promise<void>;
   uniffiDestroy(): void;
 }

--- a/libs/cua-driver/mcp-typescript/src/types.ts
+++ b/libs/cua-driver/mcp-typescript/src/types.ts
@@ -1,0 +1,19 @@
+import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js';
+
+export interface DriverAdapter {
+  listTools(): Promise<Tool[]>;
+  callTool(name: string, args: Record<string, unknown>): Promise<CallToolResult>;
+  close(): Promise<void>;
+}
+
+export interface GeneratedCuaDriver {
+  callTool(name: string, argumentsJson: string): Promise<{ rawJson: string }>;
+  listToolsJson(): Promise<string>;
+  metadata(): Promise<{ embedded: boolean; hostBundleId?: string; pid: number }>;
+  shutdown(): Promise<void>;
+  uniffiDestroy(): void;
+}
+
+export interface GeneratedCuaDriverModule {
+  CuaDriver: { connect(socketPath: string | undefined): GeneratedCuaDriver };
+}

--- a/libs/cua-driver/mcp-typescript/test/adapter.test.mjs
+++ b/libs/cua-driver/mcp-typescript/test/adapter.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mapDaemonInventory, UniffiDaemonAdapter } from '../dist/adapter.js';
+
+test('daemon inventory mapping preserves schemas, annotations, and extensions', () => {
+  const [tool] = mapDaemonInventory({
+    tools: [
+      {
+        name: 'click',
+        description: 'click',
+        input_schema: {
+          type: 'object',
+          properties: { x: { type: 'integer' } },
+          required: ['x'],
+        },
+        output_schema: { type: 'object' },
+        read_only: false,
+        destructive: true,
+        idempotent: false,
+        open_world: false,
+        capabilities: ['input.pointer.click'],
+        risk: { class: 'r2' },
+      },
+    ],
+  });
+  assert.equal(tool.inputSchema.required[0], 'x');
+  assert.equal(tool.outputSchema.type, 'object');
+  assert.equal(tool.annotations.destructiveHint, true);
+  assert.deepEqual(tool.capabilities, ['input.pointer.click']);
+  assert.deepEqual(tool.risk, { class: 'r2' });
+});
+
+test('UniFFI adapter preserves raw MCP content and releases only its client', async () => {
+  const calls = [];
+  const driver = {
+    async listToolsJson() {
+      return JSON.stringify({ tools: [] });
+    },
+    async callTool(name, args) {
+      calls.push({ name, args: JSON.parse(args) });
+      return {
+        rawJson: JSON.stringify({
+          content: [
+            { type: 'text', text: 'ok' },
+            { type: 'image', data: 'AA==', mimeType: 'image/png' },
+          ],
+          structuredContent: { ok: true },
+          isError: false,
+        }),
+      };
+    },
+    async metadata() {
+      return { embedded: false, pid: 42 };
+    },
+    async shutdown() {
+      calls.push({ shutdown: true });
+    },
+    uniffiDestroy() {
+      calls.push({ destroyed: true });
+    },
+  };
+  const adapter = new UniffiDaemonAdapter(driver);
+  const result = await adapter.callTool('get_desktop_state', { session: 'same' });
+  assert.equal(result.content[1].type, 'image');
+  assert.deepEqual(result.structuredContent, { ok: true });
+  await adapter.close();
+  assert.deepEqual(calls, [
+    { name: 'get_desktop_state', args: { session: 'same' } },
+    { shutdown: true },
+    { destroyed: true },
+  ]);
+});

--- a/libs/cua-driver/mcp-typescript/test/server.test.mjs
+++ b/libs/cua-driver/mcp-typescript/test/server.test.mjs
@@ -16,12 +16,15 @@ class FakeAdapter {
         name: 'get_screen_size',
         description: 'Real bounded Cua Driver route',
         inputSchema: { type: 'object', additionalProperties: false },
+        outputSchema: { type: 'object' },
         annotations: {
           readOnlyHint: true,
           destructiveHint: false,
           idempotentHint: true,
           openWorldHint: false,
         },
+        capabilities: ['screen.dimensions'],
+        risk: { class: 'r0' },
       },
     ];
   }
@@ -43,8 +46,14 @@ async function connectedPair(root = skillRoot) {
   const server = await createCuaMcpServer({ adapter, skillRoot: root });
   const client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: {} });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const responses = [];
+  const send = serverTransport.send.bind(serverTransport);
+  serverTransport.send = async (message, options) => {
+    responses.push(structuredClone(message));
+    return send(message, options);
+  };
   await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
-  return { adapter, client, server };
+  return { adapter, client, responses, server };
 }
 
 test('initialize instructions carry a compact bundled skill catalog', async (t) => {
@@ -58,14 +67,18 @@ test('initialize instructions carry a compact bundled skill catalog', async (t) 
 });
 
 test('tools/list and tools/call preserve driver and skill routing', async (t) => {
-  const { adapter, client, server } = await connectedPair();
+  const { adapter, client, responses, server } = await connectedPair();
   t.after(() => Promise.all([client.close(), server.close()]));
   const listed = await client.listTools();
   assert.deepEqual(
     listed.tools.map((tool) => tool.name),
     ['get_screen_size', 'load-skill']
   );
+  assert.equal(listed.tools[0].outputSchema.type, 'object');
   assert.equal(listed.tools[1].annotations.readOnlyHint, true);
+  const wireList = responses.find((message) => message.result?.tools);
+  assert.deepEqual(wireList.result.tools[0].capabilities, ['screen.dimensions']);
+  assert.deepEqual(wireList.result.tools[0].risk, { class: 'r0' });
   const result = await client.callTool({ name: 'get_screen_size', arguments: { session: 'poc' } });
   assert.deepEqual(adapter.calls, [{ name: 'get_screen_size', args: { session: 'poc' } }]);
   assert.equal(result.content[1].type, 'image');
@@ -84,6 +97,23 @@ test('load-skill returns SKILL.md and blocks path traversal', async (t) => {
   });
   assert.equal(blocked.isError, true);
   assert.match(blocked.content[0].text, /traversal/);
+});
+
+test('load-skill validates its closed input schema', async (t) => {
+  const { client, server } = await connectedPair();
+  t.after(() => Promise.all([client.close(), server.close()]));
+  const wrongType = await client.callTool({
+    name: 'load-skill',
+    arguments: { name: 'cua-driver', path: 1 },
+  });
+  assert.equal(wrongType.isError, true);
+  assert.match(wrongType.content[0].text, /must be a string/);
+  const extra = await client.callTool({
+    name: 'load-skill',
+    arguments: { name: 'cua-driver', ignored: true },
+  });
+  assert.equal(extra.isError, true);
+  assert.match(extra.content[0].text, /Unknown load-skill fields/);
 });
 
 test('load-skill rejects symlinks that escape the bundled root', async (t) => {

--- a/libs/cua-driver/mcp-typescript/test/server.test.mjs
+++ b/libs/cua-driver/mcp-typescript/test/server.test.mjs
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import test from 'node:test';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createCuaMcpServer } from '../dist/server.js';
+
+const skillRoot = resolve(import.meta.dirname, '../../rust/Skills/cua-driver');
+class FakeAdapter {
+  calls = [];
+  async listTools() {
+    return [
+      {
+        name: 'get_screen_size',
+        description: 'Real bounded Cua Driver route',
+        inputSchema: { type: 'object', additionalProperties: false },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        },
+      },
+    ];
+  }
+  async callTool(name, args) {
+    this.calls.push({ name, args });
+    return {
+      content: [
+        { type: 'text', text: '1920x1080' },
+        { type: 'image', data: 'aW1hZ2U=', mimeType: 'image/png' },
+      ],
+      structuredContent: { width: 1920, height: 1080 },
+    };
+  }
+  async close() {}
+}
+
+async function connectedPair(root = skillRoot) {
+  const adapter = new FakeAdapter();
+  const server = await createCuaMcpServer({ adapter, skillRoot: root });
+  const client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: {} });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return { adapter, client, server };
+}
+
+test('initialize instructions carry a compact bundled skill catalog', async (t) => {
+  const { client, server } = await connectedPair();
+  t.after(() => Promise.all([client.close(), server.close()]));
+  const instructions = client.getInstructions();
+  assert.match(instructions, /<available_skills>/);
+  assert.match(instructions, /<name>cua-driver<\/name>/);
+  assert.ok(instructions.length < 1600);
+  assert.doesNotMatch(instructions, /## Workflow/);
+});
+
+test('tools/list and tools/call preserve driver and skill routing', async (t) => {
+  const { adapter, client, server } = await connectedPair();
+  t.after(() => Promise.all([client.close(), server.close()]));
+  const listed = await client.listTools();
+  assert.deepEqual(
+    listed.tools.map((tool) => tool.name),
+    ['get_screen_size', 'load-skill']
+  );
+  assert.equal(listed.tools[1].annotations.readOnlyHint, true);
+  const result = await client.callTool({ name: 'get_screen_size', arguments: { session: 'poc' } });
+  assert.deepEqual(adapter.calls, [{ name: 'get_screen_size', args: { session: 'poc' } }]);
+  assert.equal(result.content[1].type, 'image');
+  assert.deepEqual(result.structuredContent, { width: 1920, height: 1080 });
+});
+
+test('load-skill returns SKILL.md and blocks path traversal', async (t) => {
+  const { client, server } = await connectedPair();
+  t.after(() => Promise.all([client.close(), server.close()]));
+  const loaded = await client.callTool({ name: 'load-skill', arguments: { name: 'cua-driver' } });
+  assert.equal(loaded.isError, undefined);
+  assert.match(loaded.content[0].text, /^---\nname: cua-driver/m);
+  const blocked = await client.callTool({
+    name: 'load-skill',
+    arguments: { name: 'cua-driver', path: '../VERSION' },
+  });
+  assert.equal(blocked.isError, true);
+  assert.match(blocked.content[0].text, /traversal/);
+});
+
+test('load-skill rejects symlinks that escape the bundled root', async (t) => {
+  const temporaryRoot = await mkdtemp(join(tmpdir(), 'cua-skill-test-'));
+  t.after(() => rm(temporaryRoot, { recursive: true, force: true }));
+  await symlink(resolve(skillRoot, 'SKILL.md'), join(temporaryRoot, 'SKILL.md'));
+  await symlink(resolve(skillRoot, '../../VERSION'), join(temporaryRoot, 'escape.md'));
+  const { client, server } = await connectedPair(temporaryRoot);
+  t.after(() => Promise.all([client.close(), server.close()]));
+  const blocked = await client.callTool({
+    name: 'load-skill',
+    arguments: { name: 'cua-driver', path: 'escape.md' },
+  });
+  assert.equal(blocked.isError, true);
+  assert.match(blocked.content[0].text, /escapes/);
+});
+
+test('resources expose and read bundled companion files', async (t) => {
+  const { client, server } = await connectedPair();
+  t.after(() => Promise.all([client.close(), server.close()]));
+  const resources = await client.listResources();
+  const browser = resources.resources.find((resource) => resource.uri.endsWith('/BROWSER.md'));
+  assert.ok(browser);
+  const loaded = await client.readResource({ uri: browser.uri });
+  assert.match(loaded.contents[0].text, /browser/i);
+});

--- a/libs/cua-driver/mcp-typescript/tsconfig.json
+++ b/libs/cua-driver/mcp-typescript/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What changed

- add a private TypeScript MCP server built on `@modelcontextprotocol/sdk@1.30.0`
- expose the live Cua Driver daemon inventory and dispatch through generated UniFFI `CuaDriver.connect()`, `listToolsJson()`, and `callTool()`
- preserve live schemas, annotations, Cua capability/risk extensions on the wire, text/image/structured results, and tool errors
- add a compact Skilljack-style initialize catalog, read-only `load-skill`, and bounded companion resources from the release-matched `rust/Skills/cua-driver` tree
- add focused protocol, adapter, traversal, symlink, and cleanup tests plus a lightweight contract-client CI job

## Architecture

The daemon remains the canonical execution boundary. The server does not use `CuaDriver.create()` as its normal path, so standalone and app-owned embedded daemons retain their session state, consent policy, desktop identity, and macOS TCC responsibility chain.

The generated JavaScript API does not expose Rust-only `inspect_host_tools`, `connect_remote`, `call_tool_from_trusted_adapter`, or the `register_host_tools` function-pointer hook. It also cannot inject the Rust MCP proxy's private transport-session evidence. The implementation documents these limits and does not simulate them.

## Validation

- `npm run format:check`
- `npm run typecheck`
- `npm test` — 8 passed
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- `npm pack --dry-run --json`
- `cargo test -p cua-driver-contract` — 30 passed
- existing `libs/cua-driver/typescript` typecheck passed

The existing generated-UniFFI freshness build is host-blocked here because `xi.pc`/`libxi-dev` is absent. The existing Electron test is likewise host-blocked because `xvfb-run` is absent. The repository CI installs those Linux dependencies.

## Scope

No Rust source, release workflow, publishing configuration, deployment, or release artifact is changed.
