### PR TITLE
fix(cua-driver): bound Linux AT-SPI listener startup

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/tests/atspi_listener_startup_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/atspi_listener_startup_test.rs
@@ -1,0 +1,91 @@
+//! Linux process-level readiness when AT-SPI accepts a connection but stalls.
+
+#![cfg(target_os = "linux")]
+
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::process::{Command, Stdio};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::time::{Duration, Instant};
+
+use cua_driver_testkit::{spawn_in_job, ChildReaper};
+
+#[test]
+fn serve_binds_while_reachable_atspi_initialization_is_stalled() {
+    let directory = tempfile::Builder::new()
+        .prefix("cua-atspi-startup-")
+        .tempdir_in("/tmp")
+        .expect("temporary startup-test directory");
+    let bus_path = directory.path().join("stalled-session-bus.sock");
+    let daemon_socket = directory.path().join("driver.sock");
+    let bus = UnixListener::bind(&bus_path).expect("bind reachable stalled bus");
+    bus.set_nonblocking(true)
+        .expect("make stalled bus listener nonblocking");
+    let accepted = Arc::new(AtomicBool::new(false));
+    let accepted_in_server = accepted.clone();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let bus_server = std::thread::spawn(move || {
+        let accept_deadline = Instant::now() + Duration::from_secs(10);
+        let connection = loop {
+            match bus.accept() {
+                Ok((connection, _)) => break Some(connection),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    if Instant::now() >= accept_deadline {
+                        break None;
+                    }
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => panic!("accept driver bus connection: {error}"),
+            }
+        };
+        if connection.is_some() {
+            accepted_in_server.store(true, Ordering::SeqCst);
+            let _ = release_rx.recv_timeout(Duration::from_secs(10));
+        }
+    });
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_cua-driver"));
+    command
+        .args([
+            "serve",
+            "--socket",
+            daemon_socket.to_str().expect("UTF-8 daemon socket"),
+            "--no-overlay",
+            "--no-permissions-gate",
+        ])
+        .env(
+            "DBUS_SESSION_BUS_ADDRESS",
+            format!("unix:path={}", bus_path.display()),
+        )
+        .env("CUA_DRIVER_RS_DISABLE_A11Y_ADVERTISE", "1")
+        .env("CUA_DRIVER_RS_TELEMETRY_ENABLED", "false")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+
+    let mut reaper = ChildReaper::new();
+    let child = spawn_in_job(&mut command).expect("spawn cua-driver serve");
+    reaper.push(child);
+
+    let readiness_deadline = Instant::now() + Duration::from_secs(6);
+    while Instant::now() < readiness_deadline {
+        if UnixStream::connect(&daemon_socket).is_ok() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+
+    let ready = UnixStream::connect(&daemon_socket).is_ok();
+    let _ = release_tx.send(());
+    bus_server.join().expect("join stalled bus server");
+    assert!(
+        accepted.load(Ordering::SeqCst),
+        "driver never reached the listening session-bus socket"
+    );
+    assert!(
+        ready && daemon_socket.exists(),
+        "serve did not bind after the bounded AT-SPI readiness wait"
+    );
+}

--- a/libs/cua-driver/rust/crates/platform-linux/src/atspi/native.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/atspi/native.rs
@@ -27,6 +27,12 @@ use super::AtspiNode;
 const CALL_TIMEOUT: Duration = Duration::from_secs(3);
 /// Overall budget for one tree walk / operation.
 const OP_TIMEOUT: Duration = Duration::from_secs(25);
+/// Startup may run before `serve` binds its socket or MCP reads stdin. A
+/// reachable but wedged accessibility bus must not hold either entry point
+/// forever. The worker is deliberately left running after this readiness
+/// budget so a late registry reply can still establish the process-lifetime
+/// listener.
+const LISTENER_STARTUP_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// Run `fut` with [`CALL_TIMEOUT`]; `None` on timeout so the caller can skip
 /// the node and keep walking rather than blocking forever.
@@ -105,17 +111,109 @@ async fn shared_connection() -> Result<&'static AccessibilityConnection> {
 /// Establish the process-lifetime listener before accessibility-aware apps are
 /// launched. Idempotent; later calls reuse the same connection.
 pub fn ensure_listener_active() -> Result<()> {
-    let connect = || runtime().block_on(async { shared_connection().await.map(|_| ()) });
-    if tokio::runtime::Handle::try_current().is_ok() {
-        // The daemon builds its registry from its Tokio entry-point. Calling
-        // Runtime::block_on there panics even though this module owns a separate
-        // runtime, so initialize the AT-SPI connection on a plain thread and
-        // wait for it before accessibility-aware apps can launch.
-        std::thread::spawn(connect)
-            .join()
-            .map_err(|_| anyhow!("AT-SPI listener initialization thread panicked"))?
-    } else {
-        connect()
+    wait_for_listener_startup(LISTENER_STARTUP_TIMEOUT, || {
+        runtime().block_on(async { shared_connection().await.map(|_| ()) })
+    })
+}
+
+fn wait_for_listener_startup(
+    timeout: Duration,
+    connect: impl FnOnce() -> Result<()> + Send + 'static,
+) -> Result<()> {
+    let (completed_tx, completed_rx) = std::sync::mpsc::sync_channel(1);
+    std::thread::Builder::new()
+        .name("cua-atspi-listener".into())
+        .spawn(move || {
+            let _ = completed_tx.send(connect());
+        })
+        .map_err(|error| anyhow!("could not spawn AT-SPI listener initialization: {error}"))?;
+
+    match completed_rx.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Err(anyhow!(
+            "AT-SPI listener initialization did not complete within {} ms; continuing in the background",
+            timeout.as_millis()
+        )),
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            Err(anyhow!("AT-SPI listener initialization thread panicked"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod listener_startup_tests {
+    use super::wait_for_listener_startup;
+    use anyhow::anyhow;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Condvar, Mutex,
+    };
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn healthy_listener_initialization_completes_before_readiness_returns() {
+        let initialized = Arc::new(AtomicBool::new(false));
+        let initialized_in_worker = initialized.clone();
+
+        wait_for_listener_startup(Duration::from_secs(1), move || {
+            initialized_in_worker.store(true, Ordering::SeqCst);
+            Ok(())
+        })
+        .expect("healthy listener startup");
+
+        assert!(initialized.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn unreachable_listener_initialization_returns_its_error() {
+        let error = wait_for_listener_startup(Duration::from_secs(1), || {
+            Err(anyhow!("synthetic AT-SPI connection failure"))
+        })
+        .expect_err("unreachable listener must fail");
+
+        assert!(error
+            .to_string()
+            .contains("synthetic AT-SPI connection failure"));
+    }
+
+    #[test]
+    fn stalled_listener_is_bounded_and_keeps_initializing_in_background() {
+        let gate = Arc::new((Mutex::new(false), Condvar::new()));
+        let gate_in_worker = gate.clone();
+        let completed = Arc::new(AtomicBool::new(false));
+        let completed_in_worker = completed.clone();
+        let started_at = Instant::now();
+
+        let error = wait_for_listener_startup(Duration::from_millis(50), move || {
+            let (lock, ready) = &*gate_in_worker;
+            let released = lock.lock().expect("listener gate lock");
+            drop(
+                ready
+                    .wait_while(released, |released| !*released)
+                    .expect("listener gate wait"),
+            );
+            completed_in_worker.store(true, Ordering::SeqCst);
+            Ok(())
+        })
+        .expect_err("stalled listener must exceed the readiness budget");
+
+        assert!(error.to_string().contains("continuing in the background"));
+        assert!(
+            started_at.elapsed() < Duration::from_secs(1),
+            "stalled initialization exceeded its bounded wait"
+        );
+        let (lock, ready) = &*gate;
+        *lock.lock().expect("release listener gate") = true;
+        ready.notify_one();
+
+        let completion_deadline = Instant::now() + Duration::from_secs(1);
+        while !completed.load(Ordering::SeqCst) && Instant::now() < completion_deadline {
+            std::thread::yield_now();
+        }
+        assert!(
+            completed.load(Ordering::SeqCst),
+            "timed-out initialization worker was not allowed to finish"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- bound Linux persistent AT-SPI listener startup to a three-second readiness budget
- keep the initializer running after that budget so a late registry reply can still establish the process-lifetime listener
- preserve immediate success and immediate connection-error behavior

## Root cause

Linux runtime construction spawned the AT-SPI initializer on a helper thread and then joined it without a deadline. If the session and accessibility buses accepted the connection but stopped replying during `AccessibilityConnection::new()` or registry event registration, runtime construction never returned. `serve` therefore never bound its socket, and direct MCP never reached protocol initialization.

## Behavior

Healthy and unreachable buses retain their existing eager result. A stalled initialization now emits the existing best-effort startup warning after three seconds and continues in the background. The shared connection remains stored in the process-lifetime `OnceCell` if initialization completes later.

## Tests

- deterministic unit contracts for healthy, unreachable, and reachable-but-stalled initialization, including late background completion
- Linux real-process readiness contract: `cua-driver serve` must bind its Unix socket while a reachable D-Bus endpoint accepts the connection and then stops replying
- local host: `cargo fmt --all -- --check`
- local host: `cargo test -p platform-linux --all-targets --locked` (16 host-applicable tests passed; Linux-only rows compile but require Linux CI to execute)
- [exact-SHA Linux unit run](https://github.com/trycua/cua/actions/runs/30899165529): passed at `a3e4075486021d88f3c5e830aff62014006c4565`
- [exact-SHA Nix run](https://github.com/trycua/cua/actions/runs/30899165905): compositor build, driver package, Rust unit tests, YAML policy VM, and Rego policy VM all passed

Fixes #2820
