### PR TITLE
fix(cua-driver): quiesce idle Wayland overlay

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-testkit/src/daemon.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-testkit/src/daemon.rs
@@ -6,7 +6,7 @@ use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
-use crate::reaper::ChildReaper;
+use crate::reaper::{spawn_in_job, ChildReaper};
 
 #[cfg(not(unix))]
 static DAEMON_SEQUENCE: AtomicU64 = AtomicU64::new(1);
@@ -14,6 +14,7 @@ static DAEMON_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 /// Keeps the temporary socket directory alive for the daemon lifetime.
 pub(crate) struct TestDaemon {
     pub(crate) socket: String,
+    pub(crate) pid: u32,
     #[cfg(unix)]
     _socket_dir: tempfile::TempDir,
 }
@@ -85,16 +86,18 @@ impl TestDaemon {
         for (key, value) in env {
             command.env(key, value);
         }
-        reaper
-            .spawn(&mut command)
+        let child = spawn_in_job(&mut command)
             .inspect_err(|error| eprintln!("[testkit] daemon spawn failed: {error}"))
             .ok()?;
+        let pid = child.id();
+        reaper.push(child);
 
         let deadline = Instant::now() + Duration::from_secs(10);
         while Instant::now() < deadline {
             if daemon_is_listening(binary, &socket) {
                 return Some(Self {
                     socket,
+                    pid,
                     #[cfg(unix)]
                     _socket_dir: socket_dir,
                 });

--- a/libs/cua-driver/rust/crates/cua-driver-testkit/src/raw.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-testkit/src/raw.rs
@@ -27,6 +27,13 @@ pub struct RawDriver {
 }
 
 impl RawDriver {
+    /// Process id of the daemon that owns platform UI state, when this raw
+    /// transport is daemon-backed. Linux lifecycle tests use it to inspect
+    /// the daemon's kernel thread accounting without relying on `ps` races.
+    pub fn daemon_pid(&self) -> Option<u32> {
+        self._daemon.as_ref().map(|daemon| daemon.pid)
+    }
+
     /// Spawn the driver with piped stdio. Returns `None` (with a skip eprintln)
     /// if the binary isn't built — callers early-return so an un-built binary
     /// skips rather than fails.

--- a/libs/cua-driver/rust/crates/cua-driver/tests/wayland_overlay_idle_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/wayland_overlay_idle_test.rs
@@ -120,8 +120,13 @@ fn wayland_overlay_quiesces_and_recovers_after_capture_and_cursor_activity() {
     let pid = driver.daemon_pid().expect("daemon-backed driver pid");
     initialize(&mut driver);
 
-    // Exercise the reported trigger class: capture followed by cursor motion.
-    call(&mut driver, 2, "screenshot", serde_json::json!({}));
+    // Exercise the reported trigger class: native compositor capture followed
+    // by daemon-owned cursor motion. Call the Linux capture backend directly:
+    // `screenshot` is intentionally denied at the MCP authorization boundary
+    // until that tool has a reviewed risk classification.
+    let capture = platform_linux::wayland::screenshot_display_dispatch()
+        .expect("capture native Wayland display before overlay activity");
+    assert!(!capture.is_empty(), "native Wayland capture was empty");
     call(
         &mut driver,
         3,

--- a/libs/cua-driver/rust/crates/cua-driver/tests/wayland_overlay_idle_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/wayland_overlay_idle_test.rs
@@ -1,0 +1,173 @@
+//! Hosted native-Wayland lifecycle and CPU certification for the layer-shell
+//! cursor overlay. Run inside the repository's isolated Sway session.
+
+#![cfg(target_os = "linux")]
+
+use std::fs;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use cua_driver_testkit::RawDriver;
+
+const OVERLAY_THREAD: &str = "cua-overlay-wl";
+
+fn call(driver: &mut RawDriver, id: u64, name: &str, arguments: serde_json::Value) {
+    driver.send(&serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": { "name": name, "arguments": arguments }
+    }));
+    let response = driver.recv();
+    assert_eq!(response["id"], id, "unexpected response: {response:?}");
+    assert!(
+        !response["result"]["isError"].as_bool().unwrap_or(false),
+        "{name} failed: {response:?}"
+    );
+}
+
+fn initialize(driver: &mut RawDriver) {
+    driver.send(&serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}
+    }));
+    let response = driver.recv();
+    assert_eq!(response["id"], 1, "initialize failed: {response:?}");
+}
+
+fn overlay_tid(pid: u32) -> Option<u32> {
+    let tasks = fs::read_dir(format!("/proc/{pid}/task")).ok()?;
+    tasks.filter_map(Result::ok).find_map(|task| {
+        let comm = fs::read_to_string(task.path().join("comm")).ok()?;
+        (comm.trim() == OVERLAY_THREAD).then(|| {
+            task.file_name()
+                .to_string_lossy()
+                .parse::<u32>()
+                .expect("numeric Linux task id")
+        })
+    })
+}
+
+fn wait_for_overlay_tid(pid: u32) -> u32 {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if let Some(tid) = overlay_tid(pid) {
+            return tid;
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+    panic!("{OVERLAY_THREAD} did not start in daemon {pid}");
+}
+
+fn cpu_ticks(pid: u32, tid: u32) -> u64 {
+    let stat =
+        fs::read_to_string(format!("/proc/{pid}/task/{tid}/stat")).expect("read overlay task stat");
+    let suffix = stat.rsplit_once(") ").expect("parse task comm").1;
+    let fields: Vec<&str> = suffix.split_whitespace().collect();
+    let utime = fields[11].parse::<u64>().expect("parse task utime");
+    let stime = fields[12].parse::<u64>().expect("parse task stime");
+    utime + stime
+}
+
+fn assert_idle_tick_bound(pid: u32, tid: u32, window: Duration, bound: u64) {
+    let before = cpu_ticks(pid, tid);
+    thread::sleep(window);
+    let after = cpu_ticks(pid, tid);
+    let delta = after.saturating_sub(before);
+    eprintln!(
+        "wayland overlay idle evidence: pid={pid} tid={tid} window_ms={} tick_delta={delta} bound={bound}",
+        window.as_millis()
+    );
+    assert!(
+        delta <= bound,
+        "idle overlay used {delta} ticks (bound {bound})"
+    );
+}
+
+#[test]
+#[ignore]
+fn no_overlay_flag_never_starts_wayland_overlay_thread() {
+    let Some(mut driver) = RawDriver::spawn_with_env(&[
+        ("CUA_DRIVER_PERMISSION_MODE", "unrestricted"),
+        ("CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS", "1"),
+    ]) else {
+        panic!("source-built driver is required");
+    };
+    let pid = driver.daemon_pid().expect("daemon-backed driver pid");
+    initialize(&mut driver);
+    call(
+        &mut driver,
+        2,
+        "move_cursor",
+        serde_json::json!({"x": 300.0, "y": 240.0}),
+    );
+    thread::sleep(Duration::from_millis(300));
+    assert_eq!(
+        overlay_tid(pid),
+        None,
+        "--no-overlay daemon unexpectedly started {OVERLAY_THREAD}"
+    );
+}
+
+#[test]
+#[ignore]
+fn wayland_overlay_quiesces_and_recovers_after_capture_and_cursor_activity() {
+    let Some(mut driver) = RawDriver::spawn_with_overlay_and_env(&[
+        ("CUA_DRIVER_PERMISSION_MODE", "unrestricted"),
+        ("CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS", "1"),
+    ]) else {
+        panic!("source-built driver is required");
+    };
+    let pid = driver.daemon_pid().expect("daemon-backed driver pid");
+    initialize(&mut driver);
+
+    // Exercise the reported trigger class: capture followed by cursor motion.
+    call(&mut driver, 2, "screenshot", serde_json::json!({}));
+    call(
+        &mut driver,
+        3,
+        "set_agent_cursor_motion",
+        serde_json::json!({"glide_duration_ms": 700, "idle_hide_ms": 0}),
+    );
+    call(
+        &mut driver,
+        4,
+        "move_cursor",
+        serde_json::json!({"x": 500.0, "y": 360.0}),
+    );
+    let tid = wait_for_overlay_tid(pid);
+    thread::sleep(Duration::from_secs(2));
+    assert_idle_tick_bound(pid, tid, Duration::from_secs(2), 1);
+
+    call(
+        &mut driver,
+        5,
+        "set_agent_cursor_enabled",
+        serde_json::json!({"enabled": false}),
+    );
+    thread::sleep(Duration::from_millis(250));
+    assert_idle_tick_bound(pid, tid, Duration::from_secs(1), 1);
+
+    call(
+        &mut driver,
+        6,
+        "set_agent_cursor_enabled",
+        serde_json::json!({"enabled": true}),
+    );
+    let recovery_before = cpu_ticks(pid, tid);
+    call(
+        &mut driver,
+        7,
+        "move_cursor",
+        serde_json::json!({"x": 900.0, "y": 600.0}),
+    );
+    thread::sleep(Duration::from_millis(500));
+    let recovery_delta = cpu_ticks(pid, tid).saturating_sub(recovery_before);
+    eprintln!("wayland overlay recovery evidence: tick_delta={recovery_delta}");
+    assert!(
+        recovery_delta > 0,
+        "re-enabled overlay did not resume rendering"
+    );
+
+    thread::sleep(Duration::from_secs(2));
+    assert_idle_tick_bound(pid, tid, Duration::from_secs(2), 1);
+}

--- a/libs/cua-driver/rust/crates/platform-linux/src/lib.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/lib.rs
@@ -145,6 +145,8 @@ pub fn register_tools_with_cursor_and_provider(
 ) -> ToolRegistry {
     #[cfg(target_os = "linux")]
     wayland::ensure_nested_session();
+    #[cfg(target_os = "linux")]
+    wayland::overlay::set_config_enabled(cfg.enabled);
     if cfg.enabled {
         overlay::init(cfg.clone());
         overlay::run_on_thread();

--- a/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
@@ -378,8 +378,13 @@ pub fn remove_cursor(key: CursorKey) {
     if key.is_empty() {
         return;
     }
+    let msg = OverlayMsg::Remove(key);
     if let Some(tx) = CMD_TX.get() {
-        let _ = tx.try_send(OverlayMsg::Remove(key));
+        let _ = tx.try_send(msg.clone());
+    }
+    #[cfg(target_os = "linux")]
+    if crate::wayland::is_wayland() && !crate::wayland::shell_helper::available() {
+        let _ = crate::wayland::overlay::forward(&msg);
     }
 }
 

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
@@ -14,14 +14,16 @@
 //! Architecture mirrors the existing `wayland/persistent_vptr.rs`: one
 //! owner thread (`cua-overlay-wl`) holds the wayland Connection +
 //! EventQueue + layer surface; commands flow in over a `crossbeam-channel`.
-//! The render core is ticked at ~60Hz via a calloop timer so motion +
-//! spring physics + click pulse advance smoothly even when no new
-//! Position command has arrived.
+//! The render core wakes at frame cadence only while pixels can change;
+//! stable or hidden state blocks on the command channel without polling.
 
 use std::collections::HashMap;
-use std::sync::OnceLock;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    OnceLock,
+};
 use std::thread;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crossbeam_channel::{bounded, Receiver, Sender};
 use cursor_overlay::{CursorConfig, OverlayCommand, OverlayMsg, RenderStateCore};
@@ -54,6 +56,14 @@ enum WlOverlayCmd {
 }
 
 static TX: OnceLock<Sender<WlOverlayCmd>> = OnceLock::new();
+// Starts false deliberately: the platform registration path must explicitly
+// opt the native Wayland overlay in with the daemon's CursorConfig. This keeps
+// lazy forwarding from bypassing --no-overlay before any window exists.
+static CONFIG_ENABLED: AtomicBool = AtomicBool::new(false);
+
+pub fn set_config_enabled(enabled: bool) {
+    CONFIG_ENABLED.store(enabled, Ordering::Release);
+}
 
 fn tx() -> Option<&'static Sender<WlOverlayCmd>> {
     TX.get()
@@ -61,7 +71,10 @@ fn tx() -> Option<&'static Sender<WlOverlayCmd>> {
 
 /// Lazily start the owner thread. Idempotent — safe to call from every
 /// MCP tool invocation; subsequent calls are no-ops.
-pub fn ensure_started() {
+pub fn ensure_started() -> bool {
+    if !CONFIG_ENABLED.load(Ordering::Acquire) {
+        return false;
+    }
     TX.get_or_init(|| {
         let (tx, rx) = bounded::<WlOverlayCmd>(64);
         thread::Builder::new()
@@ -74,6 +87,7 @@ pub fn ensure_started() {
             .expect("spawn cua-overlay-wl thread");
         tx
     });
+    true
 }
 
 /// Translate a generic [`OverlayMsg`] (the cross-platform command shape)
@@ -81,13 +95,18 @@ pub fn ensure_started() {
 /// every variant the X11 path handles; only `ShowFocusRect` (macOS-only)
 /// is silently dropped here.
 pub fn forward(msg: &OverlayMsg) -> bool {
+    if !should_forward(CONFIG_ENABLED.load(Ordering::Acquire), msg) {
+        return false;
+    }
     // Lazy startup: spawning the layer-shell owner thread + connecting to
     // the Wayland compositor takes 100-300ms. Doing that at cua-driver mcp
     // boot (the old eager-init path) was tipping the borderline CI
     // cursor-click-gif test over its 20s budget. ensure_started is
     // idempotent so calling it on every forward is fine — the OnceLock
     // bypasses the spawn after the first call.
-    ensure_started();
+    if !ensure_started() {
+        return false;
+    }
     let Some(tx) = tx() else { return false };
     match msg {
         OverlayMsg::Remove(k) => {
@@ -105,6 +124,14 @@ pub fn forward(msg: &OverlayMsg) -> bool {
             true
         }
     }
+}
+
+fn should_forward(config_enabled: bool, msg: &OverlayMsg) -> bool {
+    config_enabled
+        && !matches!(
+            msg,
+            OverlayMsg::Cmd(kc) if matches!(&kc.cmd, OverlayCommand::ShowFocusRect(_))
+        )
 }
 
 /// Cleanly stop the owner thread. Tests use this; production code typically
@@ -251,20 +278,31 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
         state.output_w, state.output_h
     ));
 
-    // Main loop. Tick the render core at ~60Hz so motion + spring physics
-    // + click pulse animate smoothly; redraw every tick when the cursor is
-    // visible. Commands arriving via the channel update the render core
-    // first, then the next tick paints the result.
-    redraw(&mut state, &shm, &qh)?;
-    queue.roundtrip(&mut state)?;
-
-    let frame_dur = std::time::Duration::from_millis(16);
+    // Demand-driven main loop. A stable cursor blocks on the command channel;
+    // only active motion, click/fade animation, or the exact idle-fade
+    // deadline schedules a wake. This avoids display-sized SHM allocation and
+    // conversion at 60Hz when no pixel can change while preserving immediate
+    // command wakeups.
     let mut last_tick = Instant::now();
+    let mut frame_tick_needed = false;
     loop {
-        // Drain all pending commands without blocking.
+        let wait = next_wait(&state.core, frame_tick_needed);
+        let (first_cmd, timed_out) = match wait_for_work(&rx, wait) {
+            WlWake::Command(cmd) => (Some(cmd), None),
+            WlWake::Timeout => (None, Some(wait)),
+            WlWake::Disconnected => break,
+        };
+
+        let now = Instant::now();
+        let elapsed = now.duration_since(last_tick).as_secs_f64();
+        last_tick = now;
+
+        let mut dirty = false;
         let mut shutdown = false;
+        let mut pending = first_cmd;
         loop {
-            match rx.try_recv() {
+            let received = pending.take().map(Ok).unwrap_or_else(|| rx.try_recv());
+            match received {
                 Ok(WlOverlayCmd::Shutdown) => {
                     shutdown = true;
                     break;
@@ -294,13 +332,19 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
                     // apply_command_base consumes every variant the X11
                     // path handles. `move_to_snap_sentinel` / `click_pulse
                     // _sentinel_only` are both `false` here — same as X11.
-                    let _ = state.core.apply_command_base(cmd, false, false);
+                    let disabling = matches!(&cmd, OverlayCommand::SetEnabled(false));
+                    dirty |= state.core.apply_command_base(cmd, false, false);
+                    if disabling {
+                        quiesce_hidden(&mut state.core);
+                    }
                 }
                 Ok(WlOverlayCmd::Remove) => {
                     // Single-cursor overlay: removing the active cursor
                     // hides it. Multi-cursor wlroots support can layer on
                     // top of this in a follow-up if needed.
+                    dirty |= state.core.visible || state.core.pos.0 >= -100.0;
                     state.core.visible = false;
+                    quiesce_hidden(&mut state.core);
                 }
                 Err(crossbeam_channel::TryRecvError::Empty) => break,
                 Err(crossbeam_channel::TryRecvError::Disconnected) => {
@@ -313,28 +357,27 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
             break;
         }
 
-        // Tick animation forward and repaint if anything changed.
-        let now = Instant::now();
-        let dt = now.duration_since(last_tick).as_secs_f64().min(0.05);
-        last_tick = now;
-        state.core.tick_motion(dt);
-        if state.configured {
+        // Advance only on a scheduled animation/fade wake. A command wake
+        // applies the new state at dt=0, avoiding a jump proportional to how
+        // long the loop was parked.
+        if let Some(timeout_kind) = timed_out {
+            let dt = match timeout_kind {
+                WlWait::Frame => elapsed.min(0.05),
+                WlWait::Deadline(_) => elapsed,
+                WlWait::Block => unreachable!("a blocking receive cannot time out"),
+            };
+            state.core.tick_motion(dt);
+            dirty = true;
+        }
+        let next_frame_tick_needed = needs_frame_tick(&state.core);
+        if state.configured && (dirty || frame_tick_needed || next_frame_tick_needed) {
             redraw(&mut state, &shm, &qh)?;
+            // Flush the committed frame and dispatch wl_buffer.release before
+            // parking. The buffer map remains authoritative until release, so
+            // no mmap/fd can be reclaimed while the compositor still uses it.
+            queue.roundtrip(&mut state)?;
         }
-        // A surface commit only queues the request in wayland-client. A
-        // roundtrip flushes the new frame to the compositor and dispatches
-        // wl_buffer.release events so the previous full-screen buffer can be
-        // reclaimed. dispatch_pending alone never writes or reads the socket,
-        // which left the initial transparent frame on screen indefinitely.
-        queue.roundtrip(&mut state)?;
-
-        // Sleep for the remainder of the frame budget so the loop doesn't
-        // spin. Channel-driven wakeups would be lower-latency, but layer
-        // overlays only need to keep up with display refresh.
-        let elapsed = last_tick.elapsed();
-        if elapsed < frame_dur {
-            std::thread::sleep(frame_dur - elapsed);
-        }
+        frame_tick_needed = next_frame_tick_needed;
     }
 
     if let Some(ls) = state.layer_surface.take() {
@@ -345,6 +388,82 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
     }
     queue.roundtrip(&mut state)?;
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WlWait {
+    Block,
+    Frame,
+    Deadline(Duration),
+}
+
+enum WlWake {
+    Command(WlOverlayCmd),
+    Timeout,
+    Disconnected,
+}
+
+fn wait_for_work(rx: &Receiver<WlOverlayCmd>, wait: WlWait) -> WlWake {
+    match wait {
+        WlWait::Block => match rx.recv() {
+            Ok(cmd) => WlWake::Command(cmd),
+            Err(_) => WlWake::Disconnected,
+        },
+        WlWait::Frame => match rx.recv_timeout(Duration::from_millis(16)) {
+            Ok(cmd) => WlWake::Command(cmd),
+            Err(crossbeam_channel::RecvTimeoutError::Timeout) => WlWake::Timeout,
+            Err(crossbeam_channel::RecvTimeoutError::Disconnected) => WlWake::Disconnected,
+        },
+        WlWait::Deadline(timeout) => match rx.recv_timeout(timeout) {
+            Ok(cmd) => WlWake::Command(cmd),
+            Err(crossbeam_channel::RecvTimeoutError::Timeout) => WlWake::Timeout,
+            Err(crossbeam_channel::RecvTimeoutError::Disconnected) => WlWake::Disconnected,
+        },
+    }
+}
+
+fn next_wait(core: &RenderStateCore, frame_tick_needed: bool) -> WlWait {
+    if frame_tick_needed || needs_frame_tick(core) {
+        return WlWait::Frame;
+    }
+    idle_fade_wait(core)
+        .map(WlWait::Deadline)
+        .unwrap_or(WlWait::Block)
+}
+
+fn needs_frame_tick(core: &RenderStateCore) -> bool {
+    if !core.visible || core.pos.0 < -100.0 {
+        return false;
+    }
+    let fade_start = core.motion.idle_hide_ms / 1000.0;
+    core.path.is_some()
+        || core.spring.is_some()
+        || core.click_t.is_some()
+        || core.session_badge_needs_frame_tick()
+        || (core.motion.idle_hide_ms > 0.0
+            && core.idle_secs >= fade_start
+            && core.idle_alpha >= 0.004)
+}
+
+fn idle_fade_wait(core: &RenderStateCore) -> Option<Duration> {
+    if !core.visible
+        || core.pos.0 < -100.0
+        || core.motion.idle_hide_ms <= 0.0
+        || core.path.is_some()
+        || core.spring.is_some()
+        || core.click_t.is_some()
+    {
+        return None;
+    }
+    let remaining = core.motion.idle_hide_ms / 1000.0 - core.idle_secs;
+    (remaining.is_finite() && remaining > 0.0).then(|| Duration::from_secs_f64(remaining))
+}
+
+fn quiesce_hidden(core: &mut RenderStateCore) {
+    core.path = None;
+    core.spring = None;
+    core.spring_tgt = None;
+    core.click_t = None;
 }
 
 /// Render one cursor frame into a fresh wl_shm ARGB8888 buffer and attach
@@ -651,5 +770,93 @@ impl Dispatch<WlRegion, ()> for OverlayState {
         _: &Connection,
         _: &QueueHandle<Self>,
     ) {
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cursor_overlay::KeyedOverlayCommand;
+
+    fn message(cmd: OverlayCommand) -> OverlayMsg {
+        OverlayMsg::Cmd(KeyedOverlayCommand {
+            key: "test".to_owned(),
+            cmd,
+        })
+    }
+
+    fn positioned_core() -> RenderStateCore {
+        let mut core = RenderStateCore::new(CursorConfig::default());
+        core.pos = (100.0, 100.0);
+        core.motion.idle_hide_ms = 1_000.0;
+        core
+    }
+
+    #[test]
+    fn fresh_sentinel_overlay_blocks_without_frame_polling() {
+        let core = RenderStateCore::new(CursorConfig::default());
+        assert_eq!(next_wait(&core, false), WlWait::Block);
+        assert!(!needs_frame_tick(&core));
+    }
+
+    #[test]
+    fn stable_visible_overlay_sleeps_until_idle_fade_deadline() {
+        let mut core = positioned_core();
+        core.idle_secs = 0.25;
+        assert_eq!(
+            next_wait(&core, false),
+            WlWait::Deadline(Duration::from_millis(750))
+        );
+        assert!(!needs_frame_tick(&core));
+    }
+
+    #[test]
+    fn animation_and_fade_use_frame_cadence() {
+        let mut core = positioned_core();
+        core.click_t = Some(0.0);
+        assert!(needs_frame_tick(&core));
+        assert_eq!(next_wait(&core, false), WlWait::Frame);
+
+        core.click_t = None;
+        core.idle_secs = 1.0;
+        core.idle_alpha = 1.0;
+        assert!(needs_frame_tick(&core));
+        assert_eq!(next_wait(&core, false), WlWait::Frame);
+    }
+
+    #[test]
+    fn hidden_and_disabled_state_quiesces_deterministically() {
+        let mut core = positioned_core();
+        core.click_t = Some(0.25);
+        core.visible = false;
+        quiesce_hidden(&mut core);
+        assert!(core.click_t.is_none());
+        assert!(core.path.is_none());
+        assert!(core.spring.is_none());
+        assert_eq!(next_wait(&core, false), WlWait::Block);
+    }
+
+    #[test]
+    fn blocked_scheduler_wakes_on_command_arrival() {
+        let (tx, rx) = bounded(1);
+        tx.send(WlOverlayCmd::Remove).unwrap();
+        assert!(matches!(
+            wait_for_work(&rx, WlWait::Block),
+            WlWake::Command(WlOverlayCmd::Remove)
+        ));
+    }
+
+    #[test]
+    fn disabled_config_refuses_forwarding_and_thread_startup() {
+        set_config_enabled(false);
+        let msg = message(OverlayCommand::SnapTo {
+            x: 10.0,
+            y: 20.0,
+            heading_radians: None,
+        });
+        let had_thread = TX.get().is_some();
+        assert!(!should_forward(false, &msg));
+        assert!(!ensure_started());
+        assert_eq!(TX.get().is_some(), had_thread);
     }
 }

--- a/scripts/ci/linux/run-rust-e2e.sh
+++ b/scripts/ci/linux/run-rust-e2e.sh
@@ -213,6 +213,16 @@ if [[ "${SUITE}" == shared || "${SUITE}" == all ]]; then
 fi
 
 if [[ "${SUITE}" == native || "${SUITE}" == all ]]; then
+  run_test wayland-overlay-idle-no-overlay \
+    cargo test -p cua-driver "${CARGO_DRIVER_FEATURE_ARGS[@]}" \
+      --test wayland_overlay_idle_test -- \
+      --ignored --exact no_overlay_flag_never_starts_wayland_overlay_thread \
+      --nocapture --test-threads=1
+  run_test wayland-overlay-idle-recovery \
+    cargo test -p cua-driver "${CARGO_DRIVER_FEATURE_ARGS[@]}" \
+      --test wayland_overlay_idle_test -- \
+      --ignored --exact wayland_overlay_quiesces_and_recovers_after_capture_and_cursor_activity \
+      --nocapture --test-threads=1
   run_test agent-cursor-showcase \
     cargo test -p cua-driver "${CARGO_DRIVER_FEATURE_ARGS[@]}" \
       --test agent_cursor_showcase_test -- \


### PR DESCRIPTION
## Summary

- make the native Wayland cursor overlay block when stable instead of allocating, painting, and committing a full-output SHM buffer every 16 ms
- make the daemon's launch-time overlay configuration authoritative for lazy Wayland startup, including `--no-overlay`
- clear once and quiesce animation state on disable/remove, while preserving compositor-owned buffer release lifetimes
- certify idle CPU, disabled startup, and disable/re-enable recovery in the hosted native Sway lane

## Root cause

The Wayland owner loop redrew a full-screen buffer and forced a compositor roundtrip on every fixed 16 ms iteration, even when no render state could change. Separately, lazy `forward()` always called `ensure_started()`, so it did not retain the launch-time disabled configuration that kept the X11 overlay from starting.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p cua-driver-testkit --lib --locked` (49 passed)
- `cargo test -p cua-driver --test wayland_overlay_idle_test --no-run --locked`
- deterministic Linux scheduler/config tests cover sentinel idle, stable-visible deadline, animation/fade cadence, hidden/disabled quiescence, command wakeup, and disabled startup
- hosted [`E2E: Rust Linux Wayland` Sway/native run](https://github.com/trycua/cua/actions/runs/30904313637) passed at exact commit `bbb353b9dabb430910e959312b5c53aa4d67d690`

The hosted test triggers native display capture and cursor motion, samples `/proc/<pid>/task/<tid>/stat` for `cua-overlay-wl` over bounded idle windows, checks `--no-overlay` creates no overlay thread, and verifies disable/re-enable command recovery. Observed CPU tick deltas were `1` over the initial 2-second idle window, `0` over the disabled 1-second window, `20` during re-enabled animation, and `0` over the final 2-second idle window (idle bound: `1`). The existing 36-case GTK3 native matrix also passed.

Fixes #2804
