### PR TITLE
chore(cua-driver): update audited undici lockfile

### DIFF
--- a/libs/cua-driver/typescript/package-lock.json
+++ b/libs/cua-driver/typescript/package-lock.json
@@ -322,9 +322,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Summary

- update the optional development-time `undici` lock entry from 7.28.0 to 7.29.0
- clear the high-severity audit advisory currently failing the Cua Driver contract-client job
- keep the change lockfile-only and non-releasing

## Validation

- `npm ci --ignore-scripts`
- `npm audit --audit-level=high` (0 vulnerabilities)
- `npm run typecheck`
- `git diff --check`

The full SDK test requires the workflow-staged host-native UniFFI library and is left to the repository workflow.