### PR TITLE
release(cua-fleet): 0.0.9 — repin to cua-train 0.1.5 (native-CRD fleet_sdk)

### DIFF
--- a/.github/scripts/repackage_cua_train_wheel.py
+++ b/.github/scripts/repackage_cua_train_wheel.py
@@ -14,7 +14,7 @@ import sys
 import zipfile
 
 SOURCE_NAME = "cua-train"
-SOURCE_VERSION = "0.1.4"
+SOURCE_VERSION = "0.1.5"
 DESTINATION_NAME = "cua-fleet"
 WHEEL_FILENAME = re.compile(
     r"^(?P<distribution>[A-Za-z0-9_]+)-(?P<version>[^-]+)-py3-none-(?P<platform>[^-]+)\.whl$"
@@ -119,7 +119,7 @@ def repack(
 
     metadata = parse_metadata(entries[metadata_name])
     if metadata.get("Name") != SOURCE_NAME or metadata.get("Version") != SOURCE_VERSION:
-        raise WheelError("source METADATA does not identify cua-train==0.1.4")
+        raise WheelError("source METADATA does not identify cua-train==0.1.5")
     wheel_metadata = entries[wheel_name].decode()
     if (
         "Root-Is-Purelib: false" not in wheel_metadata

--- a/.github/scripts/tests/test_cua_fleet_release_wiring.py
+++ b/.github/scripts/tests/test_cua_fleet_release_wiring.py
@@ -10,17 +10,17 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 class TestCuaFleetReleaseWiring(unittest.TestCase):
     """Keep Fleet's promotion workflow aligned with the published train wheel."""
 
-    def test_publisher_promotes_cua_train_0_1_4(self) -> None:
+    def test_publisher_promotes_cua_train_0_1_5(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/cd-py-fleet.yml").read_text()
         repackager = (REPO_ROOT / ".github/scripts/repackage_cua_train_wheel.py").read_text()
         expected_sources = {
-            "cua_train-0.1.4-py3-none-manylinux_2_34_x86_64.whl": "8b2c20a603772408ad25629e5fa16bfc36bb81ed6a876fd99f1ccfab5c242252",
-            "cua_train-0.1.4-py3-none-manylinux_2_34_aarch64.whl": "d0ea3e67a67c394ca05fad227ddd53987b53fbfbff907e43aa2ac6476f941df4",
-            "cua_train-0.1.4-py3-none-macosx_10_12_x86_64.whl": "20e59a46ae5bc20bc48e34bc8b0c8b623682068be5c31b430477bdf57e946745",
-            "cua_train-0.1.4-py3-none-macosx_11_0_arm64.whl": "cf5f4e26f77b4438849b5e6216829422980150439a88aa9a62a78dab74a95eb6",
+            "cua_train-0.1.5-py3-none-manylinux_2_34_x86_64.whl": "72824b317888d1bbf21585907c8291ce648007e052e92c1e4cd8d475750b57a5",
+            "cua_train-0.1.5-py3-none-manylinux_2_34_aarch64.whl": "d6adca168fbd9777ef3fccf21f0d39b180cde440494f8f0ff7d47a46de2e6d5a",
+            "cua_train-0.1.5-py3-none-macosx_10_12_x86_64.whl": "605cdd794edbd04a88f5a99f3713fd5b87fa8c634285839015a61894544cd1d1",
+            "cua_train-0.1.5-py3-none-macosx_11_0_arm64.whl": "82ec2795fad892dc6238fcbcabb861e78d214f6603d765419a2b10fddef05fda",
         }
 
-        self.assertIn('SOURCE_VERSION = "0.1.4"', repackager)
+        self.assertIn('SOURCE_VERSION = "0.1.5"', repackager)
         for wheel, digest in expected_sources.items():
             self.assertIn(f"wheel: {wheel}\n            sha256: {digest}", workflow)
 

--- a/.github/scripts/tests/test_repackage_cua_train_wheel.py
+++ b/.github/scripts/tests/test_repackage_cua_train_wheel.py
@@ -26,12 +26,12 @@ def _csv(rows: list[list[str]]) -> bytes:
 
 
 def _write_source_wheel(path: Path) -> dict[str, bytes]:
-    dist_info = "cua_train-0.1.4.dist-info"
+    dist_info = "cua_train-0.1.5.dist-info"
     entries = {
         "cua_train/__init__.py": b"TrainClient = object\n",
         "fleet_sdk/__init__.py": b"CyclopsClient = object\n",
         "fleet_sdk/libcyclops_sdk.so": b"native payload",
-        f"{dist_info}/METADATA": b"Metadata-Version: 2.4\nName: cua-train\nVersion: 0.1.4\nDescription-Content-Type: text/markdown\n\n",
+        f"{dist_info}/METADATA": b"Metadata-Version: 2.4\nName: cua-train\nVersion: 0.1.5\nDescription-Content-Type: text/markdown\n\n",
         f"{dist_info}/WHEEL": b"Wheel-Version: 1.0\nRoot-Is-Purelib: false\nTag: py3-none-manylinux_2_34_x86_64\n",
     }
     record_name = f"{dist_info}/RECORD"
@@ -45,7 +45,7 @@ def _write_source_wheel(path: Path) -> dict[str, bytes]:
 
 
 def test_repack_changes_only_distribution_metadata(tmp_path: Path):
-    source = tmp_path / "cua_train-0.1.4-py3-none-manylinux_2_34_x86_64.whl"
+    source = tmp_path / "cua_train-0.1.5-py3-none-manylinux_2_34_x86_64.whl"
     source_entries = _write_source_wheel(source)
 
     destination = repack(
@@ -67,7 +67,7 @@ def test_repack_changes_only_distribution_metadata(tmp_path: Path):
 
 
 def test_repack_rejects_unpinned_source(tmp_path: Path):
-    source = tmp_path / "cua_train-0.1.4-py3-none-manylinux_2_34_x86_64.whl"
+    source = tmp_path / "cua_train-0.1.5-py3-none-manylinux_2_34_x86_64.whl"
     _write_source_wheel(source)
 
     with pytest.raises(WheelError, match="SHA-256 mismatch"):

--- a/.github/workflows/cd-py-fleet.yml
+++ b/.github/workflows/cd-py-fleet.yml
@@ -173,8 +173,8 @@ jobs:
               Firmware,
               HttpHeader,
               HttpRequest,
-              PoolSpec,
-              PoolTemplate,
+              OsGymSandboxTemplateSpec,
+              OsGymSandboxWarmPoolSpec,
               RuntimeKind,
               SandboxService,
           )
@@ -192,8 +192,8 @@ jobs:
               Firmware,
               HttpHeader,
               HttpRequest,
-              PoolSpec,
-              PoolTemplate,
+              OsGymSandboxTemplateSpec,
+              OsGymSandboxWarmPoolSpec,
               RuntimeKind,
               SandboxService,
           ))

--- a/.github/workflows/cd-py-fleet.yml
+++ b/.github/workflows/cd-py-fleet.yml
@@ -9,7 +9,7 @@ on:
       version:
         description: "Patch version to publish (without v prefix)"
         required: true
-        default: "0.0.5"
+        default: "0.0.9"
   workflow_call:
     inputs:
       version:
@@ -86,26 +86,26 @@ jobs:
         include:
           - platform: linux-x86_64
             runner: ubuntu-22.04
-            wheel: cua_train-0.1.4-py3-none-manylinux_2_34_x86_64.whl
-            sha256: 8b2c20a603772408ad25629e5fa16bfc36bb81ed6a876fd99f1ccfab5c242252
+            wheel: cua_train-0.1.5-py3-none-manylinux_2_34_x86_64.whl
+            sha256: 72824b317888d1bbf21585907c8291ce648007e052e92c1e4cd8d475750b57a5
             library_suffix: .so
             audit: auditwheel
           - platform: linux-aarch64
             runner: ubuntu-24.04-arm
-            wheel: cua_train-0.1.4-py3-none-manylinux_2_34_aarch64.whl
-            sha256: d0ea3e67a67c394ca05fad227ddd53987b53fbfbff907e43aa2ac6476f941df4
+            wheel: cua_train-0.1.5-py3-none-manylinux_2_34_aarch64.whl
+            sha256: d6adca168fbd9777ef3fccf21f0d39b180cde440494f8f0ff7d47a46de2e6d5a
             library_suffix: .so
             audit: auditwheel
           - platform: macos-x86_64
             runner: macos-15-intel
-            wheel: cua_train-0.1.4-py3-none-macosx_10_12_x86_64.whl
-            sha256: 20e59a46ae5bc20bc48e34bc8b0c8b623682068be5c31b430477bdf57e946745
+            wheel: cua_train-0.1.5-py3-none-macosx_10_12_x86_64.whl
+            sha256: 605cdd794edbd04a88f5a99f3713fd5b87fa8c634285839015a61894544cd1d1
             library_suffix: .dylib
             audit: delocate
           - platform: macos-arm64
             runner: macos-14
-            wheel: cua_train-0.1.4-py3-none-macosx_11_0_arm64.whl
-            sha256: cf5f4e26f77b4438849b5e6216829422980150439a88aa9a62a78dab74a95eb6
+            wheel: cua_train-0.1.5-py3-none-macosx_11_0_arm64.whl
+            sha256: 82ec2795fad892dc6238fcbcabb861e78d214f6603d765419a2b10fddef05fda
             library_suffix: .dylib
             audit: delocate
     steps:

--- a/libs/python/cua-fleet/.bumpversion.cfg
+++ b/libs/python/cua-fleet/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.7
+current_version = 0.0.9
 commit = True
 tag = True
 tag_name = fleet-v{new_version}

--- a/libs/python/cua-fleet/cua_fleet/__init__.py
+++ b/libs/python/cua-fleet/cua_fleet/__init__.py
@@ -4,4 +4,4 @@ from cua_train import TrainClient
 
 __all__ = ["TrainClient"]
 
-__version__ = "0.0.7"
+__version__ = "0.0.9"

--- a/libs/python/cua-fleet/pyproject.toml
+++ b/libs/python/cua-fleet/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cua-fleet"
-version = "0.0.7"
+version = "0.0.9"
 description = "Cua Fleet facade for the Cua Cloud Python SDK"
 readme = "README.md"
 license = "MIT"
@@ -25,7 +25,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 
-dependencies = ["cua-train==0.1.3"]
+dependencies = ["cua-train==0.1.5"]
 
 [project.urls]
 Homepage      = "https://github.com/trycua/cua"

--- a/libs/python/cua-fleet/tests/test_train_facade.py
+++ b/libs/python/cua-fleet/tests/test_train_facade.py
@@ -13,9 +13,9 @@ TRAIN_SOURCE_ROOT = REPOSITORY_ROOT / "libs/python/cua-train/src"
 def test_package_metadata_pins_binding_bearing_cua_train() -> None:
     project = tomllib.loads((PACKAGE_ROOT / "pyproject.toml").read_text())["project"]
 
-    assert project["version"] == "0.0.7"
+    assert project["version"] == "0.0.9"
     assert project["requires-python"] == ">=3.10"
-    assert project["dependencies"] == ["cua-train==0.1.3"]
+    assert project["dependencies"] == ["cua-train==0.1.5"]
 
 
 def test_cua_fleet_reexports_train_client(monkeypatch) -> None:
@@ -29,4 +29,4 @@ def test_cua_fleet_reexports_train_client(monkeypatch) -> None:
 
     assert cua_fleet.TrainClient is cua_train.TrainClient
     assert cua_fleet.__all__ == ["TrainClient"]
-    assert cua_fleet.__version__ == "0.0.7"
+    assert cua_fleet.__version__ == "0.0.9"


### PR DESCRIPTION
Ports the trycua/cloud fleet release into this repo's publish conventions (this repo's `cd-py-fleet.yml` + `PYPI_TOKEN` is the working PyPI path; the cloud repo's `pypi-fleet` token is dead).

- `cua-train` 0.1.5 wheels are live on wheels.cua.ai (built from cloud main after trycua/cloud#6316 — fleet_sdk speaks the native `osgym.cua.ai` CRDs).
- Matrix wheel names + sha256s updated to 0.1.5; repackage script `SOURCE_VERSION` bumped; package version 0.0.9 with `cua-train==0.1.5`.
- After merge: tag `fleet-v0.0.9` to publish. Then #2840 (cua-sandbox 0.1.25) can release (`sandbox-v0.1.25`) after its `uv.lock` + packaging-test refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)