### PR TITLE
docs(lume): escape generated MDX table values

### DIFF
--- a/docs/content/docs/reference/lume/cli-reference.mdx
+++ b/docs/content/docs/reference/lume/cli-reference.mdx
@@ -71,7 +71,7 @@ Run a virtual machine
 | `--registry` | String | ghcr.io | Container registry URL |
 | `--organization` | String | trycua | Organization to pull from |
 | `--display` | DisplayMode | native | Local viewer to open: vnc, native, or none. The VNC server remains available in every mode |
-| `--log-file` | String | ~/Library/Logs/lume/{vm}.log | Log path for --detach |
+| `--log-file` | String | ~/Library/Logs/lume/&#123;vm&#125;.log | Log path for --detach |
 | `--vnc-port` | Int | 0 | Port for VNC server (0 for auto-assign) |
 | `--recovery-mode` | Bool | false | For macOS VMs only, boot in recovery mode |
 | `--storage` | String | - | VM storage location to use |

--- a/scripts/docs-generators/lume.test.ts
+++ b/scripts/docs-generators/lume.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { generateCommandDoc, type CommandDoc } from './lume';
+
+test('escapes MDX expressions and table delimiters in generated CLI tables', () => {
+  const command: CommandDoc = {
+    name: 'run',
+    abstract: 'Run a virtual machine',
+    arguments: [],
+    options: [
+      {
+        name: 'log-file',
+        help: 'Log path for {vm} | detached runs',
+        type: 'String',
+        default_value: '~/Library/Logs/lume/{vm}.log',
+        is_optional: true,
+      },
+    ],
+    flags: [],
+    subcommands: [],
+  };
+
+  const mdx = generateCommandDoc(command, '###').join('\n');
+
+  assert.match(mdx, /~\/Library\/Logs\/lume\/&#123;vm&#125;\.log/);
+  assert.match(mdx, /Log path for &#123;vm&#125; \\| detached runs/);
+  assert.doesNotMatch(mdx, /\{vm\}/);
+});

--- a/scripts/docs-generators/lume.ts
+++ b/scripts/docs-generators/lume.ts
@@ -400,7 +400,9 @@ export function generateCommandDoc(cmd: CommandDoc, heading: string): string[] {
     lines.push('| ---- | ---- | -------- | ----------- |');
     for (const arg of cmd.arguments) {
       const required = arg.is_optional ? 'No' : 'Yes';
-      lines.push(`| \`<${arg.name}>\` | ${arg.type} | ${required} | ${arg.help} |`);
+      lines.push(
+        `| \`<${arg.name}>\` | ${escapeTableCell(arg.type)} | ${required} | ${escapeTableCell(arg.help)} |`
+      );
     }
     lines.push('');
   }
@@ -413,8 +415,10 @@ export function generateCommandDoc(cmd: CommandDoc, heading: string): string[] {
     lines.push('| ---- | ---- | ------- | ----------- |');
     for (const opt of cmd.options) {
       const shortFlag = opt.short_name ? `-${opt.short_name}, ` : '';
-      const defaultVal = opt.default_value || '-';
-      lines.push(`| \`${shortFlag}--${opt.name}\` | ${opt.type} | ${defaultVal} | ${opt.help} |`);
+      const defaultVal = opt.default_value ? escapeTableCell(opt.default_value) : '-';
+      lines.push(
+        `| \`${shortFlag}--${opt.name}\` | ${escapeTableCell(opt.type)} | ${defaultVal} | ${escapeTableCell(opt.help)} |`
+      );
     }
     lines.push('');
   }
@@ -427,7 +431,9 @@ export function generateCommandDoc(cmd: CommandDoc, heading: string): string[] {
     lines.push('| ---- | ------- | ----------- |');
     for (const flag of cmd.flags) {
       const shortFlag = flag.short_name ? `-${flag.short_name}, ` : '';
-      lines.push(`| \`${shortFlag}--${flag.name}\` | ${flag.default_value} | ${flag.help} |`);
+      lines.push(
+        `| \`${shortFlag}--${flag.name}\` | ${flag.default_value} | ${escapeTableCell(flag.help)} |`
+      );
     }
     lines.push('');
   }
@@ -461,6 +467,16 @@ export function generateCommandDoc(cmd: CommandDoc, heading: string): string[] {
   }
 
   return lines;
+}
+
+function escapeTableCell(value: string): string {
+  return value
+    .replace(/\n/g, ' ')
+    .replace(/\{/g, '&#123;')
+    .replace(/\}/g, '&#125;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\|/g, '\\|');
 }
 
 // ============================================================================
@@ -754,7 +770,9 @@ function getExamplePathValue(name: string): string {
 // Run
 // ============================================================================
 
-main().catch((error) => {
-  console.error('Error:', error);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('Error:', error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- escape generated Lume CLI table values before embedding them in MDX
- preserve literal brace placeholders and table delimiters without creating runtime expressions
- add a focused generator regression test

## Verification
- `npx --yes tsx --test scripts/docs-generators/lume.test.ts`
- `npx --yes prettier --check scripts/docs-generators/lume.ts scripts/docs-generators/lume.test.ts docs/content/docs/reference/lume/cli-reference.mdx`
- `git diff --check`