### PR TITLE
docs(cua-driver): fix bounded manifest examples that cannot load

### DIFF
--- a/docs/content/docs/how-to-guides/driver/drive-a-web-page.mdx
+++ b/docs/content/docs/how-to-guides/driver/drive-a-web-page.mdx
@@ -97,7 +97,7 @@ resources:
     - bundle_id: com.google.Chrome
       launch: false
       windows: all
-      terminate: never
+      terminate: deny
   browser:
     profiles:
       - kind: existing_profile

--- a/docs/content/docs/how-to-guides/driver/write-a-bounded-manifest.mdx
+++ b/docs/content/docs/how-to-guides/driver/write-a-bounded-manifest.mdx
@@ -138,6 +138,13 @@ An agent that needs both a browser and generic desktop input needs two
 runtimes: this manifest for the browser, and a separate application-scoped
 manifest for the desktop work.
 
+Scope that second runtime so it cannot reach a browser window. A runtime that
+can click the browser makes the first runtime's origin list decorative, because
+nothing checks an origin on the generic input path. Give it a bounded manifest
+naming only the non-browser applications it needs, and keep
+`desktop.display: false`. A standard-mode runtime is not a substitute: standard
+allows input against any application, including the browser.
+
 ## 3. Choose desktop scope
 
 Application entries with `windows: all` authorize observation and input for

--- a/docs/content/docs/how-to-guides/driver/write-a-bounded-manifest.mdx
+++ b/docs/content/docs/how-to-guides/driver/write-a-bounded-manifest.mdx
@@ -8,7 +8,7 @@ stay inside a reviewed set of applications, browser origins, files, and tools.
 
 ## 1. Create the manifest
 
-Save this as `cua-session.yaml` and replace the example paths and origin:
+Save this as `cua-session.yaml` and replace the example paths:
 
 ```yaml
 version: 2
@@ -25,12 +25,6 @@ allow:
     - click
     - type_text
     - press_key
-    - browser_prepare
-    - get_browser_state
-    - browser_navigate
-    - browser_click
-    - browser_type
-    - browser_download
     - kill_app
 
 resources:
@@ -39,12 +33,6 @@ resources:
       launch: true
       windows: all
       terminate: driver_launched
-
-  browser:
-    profiles:
-      - kind: isolated
-    origins:
-      - https://app.example.com
 
   files:
     read:
@@ -57,6 +45,9 @@ resources:
   desktop:
     display: false
 ```
+
+This manifest drives a native application. Browser work uses a separate
+manifest, for the reason described in the next step.
 
 On macOS, replace `executable` with the application's `bundle_id`:
 
@@ -74,16 +65,61 @@ path.
 
 ## 2. Select browser access
 
+A bounded manifest that drives a browser is a separate, typed-browser-only
+manifest. It cannot also allow generic input or window observation.
+
+Every navigation is checked against `resources.browser.origins`, so a browser
+manifest must list at least one origin. Declaring origins then excludes the
+tools that could reach a page without crossing the typed browser adapter:
+`click`, `double_click`, `right_click`, `drag`, `scroll`, `type_text`,
+`press_key`, `hotkey`, `set_value`, the mouse primitives,
+`get_accessibility_tree`, `get_window_state`, `verify_state`,
+`get_desktop_state`, and `page`. Including any of them alongside origins is
+refused when the runtime starts:
+
+```text
+authorization startup error: origin-scoped bounded manifests cannot allow
+'click' because it bypasses the typed browser origin adapter
+```
+
+The check reads `allow.tools` alone, so it applies even when the manifest's
+application scope contains no browser. Use `list_windows` rather than
+`get_window_state` to find the `window_id` a browser call needs.
+
 For a driver-owned browser profile:
 
 ```yaml
+version: 2
+mode: bounded
+expires_after: 8h
+idle_timeout: 30m
+
+allow:
+  tools:
+    - start_session
+    - end_session
+    - launch_app
+    - list_windows
+    - browser_prepare
+    - get_browser_state
+    - browser_navigate
+    - browser_click
+    - browser_type
+    - browser_download
+
 resources:
   browser:
     profiles:
       - kind: isolated
+    origins:
+      - https://app.example.com
+
+  desktop:
+    display: false
 ```
 
-If the task must use a logged-in Chromium profile, make that choice explicit:
+If the task must use a logged-in Chromium profile, make that choice explicit by
+replacing the profile kind:
 
 ```yaml
 resources:
@@ -97,6 +133,10 @@ resources:
 An existing-profile entry authorizes attachment under bounded mode without a
 Cua modal or host callback. The typed browser tools still validate the live
 top-level origin before input.
+
+An agent that needs both a browser and generic desktop input needs two
+runtimes: this manifest for the browser, and a separate application-scoped
+manifest for the desktop work.
 
 ## 3. Choose desktop scope
 
@@ -185,6 +225,8 @@ before starting a new bounded run.
 - Ownership never bypasses the manifest.
 - Unknown tools and missing resources fail closed.
 - Browser origins match exact scheme, host, and port.
+- Declaring browser origins excludes generic input and window observation from
+  the same manifest.
 - `terminate: driver_launched` requires a fresh process fingerprint match.
 - `ask.tools` is denied in unattended use because an agent cannot approve its
   own request.

--- a/docs/content/docs/how-to-guides/driver/write-a-bounded-manifest.mdx
+++ b/docs/content/docs/how-to-guides/driver/write-a-bounded-manifest.mdx
@@ -226,6 +226,17 @@ cua-driver revoke --all
 `revoke --all` suspends the complete runtime generation. Restart the daemon
 before starting a new bounded run.
 
+## Know what the manifest is worth
+
+A manifest bounds one runtime's tool surface. It is not a sandbox around your
+machine, your browser, or your logged-in accounts. Another Cua Driver runtime,
+or any other process running as the same user, is unaffected by it — including
+a standard-mode runtime, which allows input against every application.
+
+Read [Permission modes](/reference/cua-driver/permission-modes#origin-scope-excludes-generic-input)
+before relying on a manifest as a security boundary rather than as a reviewed
+statement of what one agent run may do.
+
 ## Rules to remember
 
 - The manifest only narrows the built-in and configured policy ceilings.

--- a/docs/content/docs/reference/cua-driver/permission-modes.mdx
+++ b/docs/content/docs/reference/cua-driver/permission-modes.mdx
@@ -212,6 +212,14 @@ Every navigation is checked against the origin set, so a manifest that allows
 generic desktop input consequently belong to separate manifests and separate
 runtimes. Use `list_windows` for the `window_id` a browser call needs.
 
+An origin scope binds one runtime's tool surface. It is not a property of the
+browser, the profile, or the machine. A second runtime that can deliver generic
+input to a browser window — including any standard-mode runtime, which allows
+input against every application — voids the first runtime's origin scope
+without violating it. Scope a companion runtime to non-browser applications
+with `desktop.display: false`, and treat same-user processes outside Cua Driver
+as outside the boundary entirely.
+
 Version 1 manifests remain loadable. They may name exact PIDs, windows, and
 paths, but version 2 is preferred for pre-launch and unattended workflows.
 

--- a/docs/content/docs/reference/cua-driver/permission-modes.mdx
+++ b/docs/content/docs/reference/cua-driver/permission-modes.mdx
@@ -133,9 +133,7 @@ allow:
     - start_session
     - end_session
     - launch_app
-    - get_window_state
-    - click
-    - type_text
+    - list_windows
     - browser_prepare
     - get_browser_state
     - browser_navigate
@@ -179,6 +177,40 @@ process instance.
 Browser origins match exact scheme, host, and port. File roots are
 canonicalized and compared by path component, so a shared string prefix or a
 symlink escape does not grant access.
+
+### Origin scope excludes generic input
+
+`resources.browser.origins` binds the typed browser adapter only. A manifest
+that declares origins therefore cannot also allow a tool that reaches a page
+around that adapter, and the runtime refuses to start if it does:
+
+```text
+authorization startup error: origin-scoped bounded manifests cannot allow
+'click' because it bypasses the typed browser origin adapter
+```
+
+The excluded tools are `click`, `double_click`, `right_click`, `drag`,
+`scroll`, `type_text`, `press_key`, `hotkey`, `set_value`,
+`mouse_button_down`, `mouse_button_up`, `mouse_drag`, `parallel_mouse_drag`,
+`get_accessibility_tree`, `get_window_state`, `verify_state`,
+`get_desktop_state`, and `page`.
+
+The exclusion covers observation as well as input. A window screenshot or
+accessibility tree of a browser window exposes whichever tab is open,
+regardless of the origin allow-list, so where a browser window is in reach
+these tools bound neither what an agent may change nor what it may read.
+
+The check is evaluated at load time against `allow.tools` alone. It does not
+analyze whether the manifest's application scope actually puts a browser window
+in reach, so a manifest that names only a non-browser application is refused on
+the same terms. This is deliberate: deciding reachability would require the
+runtime to keep a list of browser identities, and a stale list would void the
+origin boundary silently instead of refusing loudly.
+
+Every navigation is checked against the origin set, so a manifest that allows
+`browser_navigate` with no origins refuses every navigation. Browser access and
+generic desktop input consequently belong to separate manifests and separate
+runtimes. Use `list_windows` for the `window_id` a browser call needs.
 
 Version 1 manifests remain loadable. They may name exact PIDs, windows, and
 paths, but version 2 is preferred for pre-launch and unattended workflows.


### PR DESCRIPTION
## Problem

Three published bounded-manifest examples are refused by the runtime at startup, so anyone following them gets a daemon that will not start.

| Page | Failure |
| --- | --- |
| `how-to-guides/driver/write-a-bounded-manifest.mdx` | `origin-scoped bounded manifests cannot allow 'click' because it bypasses the typed browser origin adapter` |
| `reference/cua-driver/permission-modes.mdx` | same refusal |
| `how-to-guides/driver/drive-a-web-page.mdx` | `unsupported application terminate scope 'never'; expected deny, driver_launched, or any` |

The first two paired `resources.browser.origins` with `click`, `type_text`, `press_key`, and `get_window_state`. `session_manifest.rs:813-841` rejects that combination at load time.

## Why the examples had to be restructured rather than trimmed

Every navigation is checked against the origin set (`session_manifest.rs:141`), so a manifest allowing `browser_navigate` with no origins refuses every navigation — verified live:

```
call browser_navigate {url: https://example.com}  # manifest declares no origins
→ Permission denied: the live browser origin is outside the bounded session policy
```

A browser manifest therefore always needs origins, and declaring origins always excludes generic input. Browser work and desktop work cannot share one manifest. The how-to now presents an application manifest in step 1 and a complete typed-browser-only manifest in step 2.

## Also documented

- The full excluded tool set.
- Why observation (`get_window_state`, `verify_state`, `get_desktop_state`) is excluded alongside input: a browser-window screenshot or AX tree exposes whichever tab is open, regardless of the allow-list.
- That the check reads `allow.tools` alone and does not analyze whether a browser is reachable, so a manifest naming only a non-browser application is refused on the same terms. Verified: a TextEdit-only manifest with `desktop.display: false` still cannot list `click` beside origins, even though `click` against an out-of-scope pid is independently refused with `bounded_resource_outside_manifest`. Noted as deliberate fail-closed behavior rather than presented as a tight invariant.
- `list_windows` as the substitute for `get_window_state` when a browser call needs a `window_id`.

## Verification

Every complete manifest example on all three pages was extracted from the MDX and loaded against cua-driver 0.17.0 in bounded mode. All four now start; before this change, three of four failed.

```
howto-0.yaml Cua Driver daemon listening on ...
howto-1.yaml Cua Driver daemon listening on ...
ref-0.yaml   Cua Driver daemon listening on ...
web-0.yaml   Cua Driver daemon listening on ...
```

Docs-only; no runtime behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)