### PR TITLE
docs: fix Fleets Terraform guide navigation

### DIFF
--- a/docs/content/docs/how-to-guides/(fleets)/configure-run-cua-fleets.mdx
+++ b/docs/content/docs/how-to-guides/(fleets)/configure-run-cua-fleets.mdx
@@ -1,5 +1,5 @@
 ---
-title: Configure run.cua.ai fleets with Terraform
+title: Configure Fleets with Terraform
 description: Create Linux and Windows run.cua.ai fleets with the temporary local Cua Fleets provider installation.
 ---
 

--- a/docs/content/docs/how-to-guides/(fleets)/meta.json
+++ b/docs/content/docs/how-to-guides/(fleets)/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Fleets",
+  "pages": ["configure-run-cua-fleets"]
+}

--- a/docs/content/docs/how-to-guides/meta.json
+++ b/docs/content/docs/how-to-guides/meta.json
@@ -5,7 +5,7 @@
     "index",
     "driver",
     "sandbox",
-    "configure-run-cua-fleets",
+    "(fleets)",
     "lume",
     "cua-bench",
     "recipes",


### PR DESCRIPTION
## What changed

- rename the guide to **Configure Fleets with Terraform**
- place it in a route-preserving **Fleets** sidebar group
- keep the existing `/how-to-guides/configure-run-cua-fleets` URL

## Validation

- `node` JSON parse for both changed metadata files
- `corepack pnpm --dir docs exec prettier --check ...`
- `corepack pnpm --dir docs exec fumadocs-mdx`
- `corepack pnpm --dir docs build` compiled and generated the requested page; the broader build later stopped on the pre-existing `/reference/lume/cli-reference` prerender error (`ReferenceError: vm is not defined`)
- verified `docs/.next/server/app/how-to-guides/configure-run-cua-fleets.html` contains the new title and Fleets menu label, with no nested `/fleets/` route