### PR TITLE
feat(cua-driver): add macOS Spaces awareness to list_windows

### DIFF
--- a/docs/content/docs/reference/cua-driver/mcp-tools.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tools.mdx
@@ -48,7 +48,7 @@ Use this for "is X installed?" as well as "is X running?". For per-window state 
 
 List all layer-0 top-level windows currently known to WindowServer. Includes off-screen windows (minimized, on another Space, hidden-launched). Use this to find a window_id before calling get_window_state.
 
-Per-record fields: window_id, pid, app_name, title, bounds (x/y/width/height, top-left origin), z_index (integer or null; higher values are closer to the front; null means stacking order is unavailable and callers must not infer one), is_on_screen, on_current_space. To select a frontmost candidate, take the maximum integer z_index; if every value is null, use an explicit fallback instead of relying on array order.
+Per-record fields: window_id, pid, app_name, title, bounds (x/y/width/height, top-left origin), z_index (integer or null; higher values are closer to the front; null means stacking order is unavailable and callers must not infer one), is_on_screen, space_ids, current_space_id (the active Space on that window's display), and on_current_space. The top-level current_space_id is WindowServer's main/global active Space and can differ from a record's current_space_id when displays use independent Spaces. To select a frontmost candidate, take the maximum integer z_index; if every value is null, use an explicit fallback instead of relying on array order.
 
 **Arguments:**
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/browser/consent_ui.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/browser/consent_ui.rs
@@ -320,6 +320,7 @@ mod tests {
             layer: 0,
             z_index,
             is_on_screen: true,
+            current_space_id: None,
             on_current_space: Some(true),
             space_ids: None,
         };

--- a/libs/cua-driver/rust/crates/platform-macos/src/browser/platform.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/browser/platform.rs
@@ -939,6 +939,7 @@ mod tests {
             layer: 0,
             z_index: 0,
             is_on_screen: true,
+            current_space_id: None,
             on_current_space: Some(true),
             space_ids: None,
         }

--- a/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
@@ -1223,6 +1223,7 @@ mod tests {
             layer: 0,
             z_index,
             is_on_screen: true,
+            current_space_id: None,
             on_current_space: None,
             space_ids: None,
         }

--- a/libs/cua-driver/rust/crates/platform-macos/src/input/skylight.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/skylight.rs
@@ -44,8 +44,14 @@ type ConnectionIDFn = unsafe extern "C" fn() -> u32;
 /// `uint64_t CGSGetActiveSpace(uint32_t cid)`
 type GetActiveSpaceFn = unsafe extern "C" fn(u32) -> u64;
 
-/// `CFArrayRef CGSCopySpacesForWindows(uint32_t cid, uint32_t options, CFArrayRef windowIDs)`
-type CopySpacesForWindowsFn = unsafe extern "C" fn(u32, u32, *const c_void) -> *mut c_void;
+/// `CFArrayRef SLSCopySpacesForWindows(uint32_t cid, int selector, CFArrayRef windowIDs)`
+type CopySpacesForWindowsFn = unsafe extern "C" fn(u32, i32, *const c_void) -> *mut c_void;
+
+/// `CFStringRef SLSCopyManagedDisplayForWindow(uint32_t cid, uint32_t wid)`
+type CopyManagedDisplayForWindowFn = unsafe extern "C" fn(u32, u32) -> *mut c_void;
+
+/// `uint64_t SLSManagedDisplayGetCurrentSpace(uint32_t cid, CFStringRef display)`
+type ManagedDisplayGetCurrentSpaceFn = unsafe extern "C" fn(u32, *const c_void) -> u64;
 
 // ── NSMenu shortcut activation SPIs ──────────────────────────────────────────
 
@@ -148,12 +154,38 @@ fn connection_id_fn() -> Option<ConnectionIDFn> {
 
 fn get_active_space_fn() -> Option<GetActiveSpaceFn> {
     static SYM: OnceLock<Option<GetActiveSpaceFn>> = OnceLock::new();
-    *SYM.get_or_init(|| find_sym(b"CGSGetActiveSpace\0").map(|p| unsafe { as_fn(p) }))
+    *SYM.get_or_init(|| {
+        find_sym(b"SLSGetActiveSpace\0")
+            .or_else(|| find_sym(b"CGSGetActiveSpace\0"))
+            .map(|p| unsafe { as_fn(p) })
+    })
 }
 
 fn copy_spaces_for_windows_fn() -> Option<CopySpacesForWindowsFn> {
     static SYM: OnceLock<Option<CopySpacesForWindowsFn>> = OnceLock::new();
-    *SYM.get_or_init(|| find_sym(b"CGSCopySpacesForWindows\0").map(|p| unsafe { as_fn(p) }))
+    *SYM.get_or_init(|| {
+        find_sym(b"SLSCopySpacesForWindows\0")
+            .or_else(|| find_sym(b"CGSCopySpacesForWindows\0"))
+            .map(|p| unsafe { as_fn(p) })
+    })
+}
+
+fn copy_managed_display_for_window_fn() -> Option<CopyManagedDisplayForWindowFn> {
+    static SYM: OnceLock<Option<CopyManagedDisplayForWindowFn>> = OnceLock::new();
+    *SYM.get_or_init(|| {
+        find_sym(b"SLSCopyManagedDisplayForWindow\0")
+            .or_else(|| find_sym(b"CGSCopyManagedDisplayForWindow\0"))
+            .map(|p| unsafe { as_fn(p) })
+    })
+}
+
+fn managed_display_get_current_space_fn() -> Option<ManagedDisplayGetCurrentSpaceFn> {
+    static SYM: OnceLock<Option<ManagedDisplayGetCurrentSpaceFn>> = OnceLock::new();
+    *SYM.get_or_init(|| {
+        find_sym(b"SLSManagedDisplayGetCurrentSpace\0")
+            .or_else(|| find_sym(b"CGSManagedDisplayGetCurrentSpace\0"))
+            .map(|p| unsafe { as_fn(p) })
+    })
 }
 
 fn factory_msg_send_fn() -> Option<FactoryMsgSendFn> {
@@ -354,100 +386,104 @@ pub fn main_connection_id() -> Option<u32> {
 /// when the symbol is unavailable (future macOS version that removes it).
 pub fn get_active_space() -> Option<u64> {
     let cid = main_connection_id()?;
-    get_active_space_fn().map(|f| unsafe { f(cid) })
+    nonzero_space_id(get_active_space_fn().map(|f| unsafe { f(cid) }))
 }
 
-/// Return the Space ID for a specific window.
-///
-/// Uses the private `CGSCopySpacesForWindows` SPI from SkyLight.  This
-/// function queries one window at a time — it creates a temporary CFArray
-/// with the single window ID, calls `CGSCopySpacesForWindows`, and extracts
-/// the first (only) space ID from the result.  Returns `None` when the symbol
-/// is unavailable or the query produces no result.
-pub fn get_window_space(window_id: u32) -> Option<u64> {
-    use core_foundation::{
-        array::CFArray,
-        base::{CFTypeRef, TCFType},
-        number::CFNumber,
-    };
-
-    let cid = main_connection_id()?;
-    let f = copy_spaces_for_windows_fn()?;
-
-    let num = CFNumber::from(window_id as i64);
-    let num_ref: *const c_void = num.as_concrete_TypeRef() as *const c_void;
-    let arr = unsafe { CFArray::<CFTypeRef>::from_copyable(&[num_ref]) };
-
-    let result_ptr: *mut c_void = unsafe { f(cid, 7, arr.as_concrete_TypeRef() as *const c_void) };
-    if result_ptr.is_null() {
-        return None;
-    }
-
-    let result: CFArray<CFTypeRef> = unsafe { CFArray::wrap_under_create_rule(result_ptr as _) };
-    if result.len() == 0 {
-        return None;
-    }
-
-    let space_ptr = unsafe { *result.get(0)? };
-    let space_num = unsafe { CFNumber::wrap_under_get_rule(space_ptr as _) };
-    space_num.to_i64().map(|v| v as u64)
+fn nonzero_space_id(space_id: Option<u64>) -> Option<u64> {
+    space_id.filter(|id| *id != 0)
 }
 
-/// Return Space IDs for multiple windows in a single SPI call.
-///
-/// Batches all window IDs into one `CGSCopySpacesForWindows` call
-/// instead of N separate calls. Returns a Vec where `result[i]`
-/// corresponds to `window_ids[i]`. Entries are `None` when the
-/// window has no space assignment or the SPI is unavailable.
-pub fn get_window_spaces(window_ids: &[u32]) -> Vec<Option<u64>> {
-    if window_ids.is_empty() {
-        return vec![];
+/// A consistent WindowServer connection and active-Space snapshot for one
+/// enumeration. Space membership must be queried one window at a time:
+/// `SLSCopySpacesForWindows` returns the set union for its input window list,
+/// not a positionally aligned result.
+pub(crate) struct SpaceQuery {
+    connection_id: u32,
+    current_space_id: Option<u64>,
+    copy_spaces_for_windows: Option<CopySpacesForWindowsFn>,
+    copy_managed_display_for_window: Option<CopyManagedDisplayForWindowFn>,
+    managed_display_get_current_space: Option<ManagedDisplayGetCurrentSpaceFn>,
+}
+
+impl SpaceQuery {
+    pub(crate) fn new() -> Option<Self> {
+        let connection_id = main_connection_id()?;
+        let current_space_id =
+            nonzero_space_id(get_active_space_fn().map(|f| unsafe { f(connection_id) }));
+        Some(Self {
+            connection_id,
+            current_space_id,
+            copy_spaces_for_windows: copy_spaces_for_windows_fn(),
+            copy_managed_display_for_window: copy_managed_display_for_window_fn(),
+            managed_display_get_current_space: managed_display_get_current_space_fn(),
+        })
     }
 
-    let cid = match main_connection_id() {
-        Some(cid) => cid,
-        None => return vec![None; window_ids.len()],
-    };
-    let f = match copy_spaces_for_windows_fn() {
-        Some(f) => f,
-        None => return vec![None; window_ids.len()],
-    };
-
-    use core_foundation::{
-        array::CFArray,
-        base::{CFTypeRef, TCFType},
-        number::CFNumber,
-    };
-
-    let nums: Vec<CFNumber> = window_ids
-        .iter()
-        .map(|&id| CFNumber::from(id as i64))
-        .collect();
-    let refs: Vec<*const c_void> = nums
-        .iter()
-        .map(|n| n.as_concrete_TypeRef() as *const c_void)
-        .collect();
-    let arr = unsafe { CFArray::<CFTypeRef>::from_copyable(&refs) };
-
-    let result_ptr = unsafe { f(cid, 7, arr.as_concrete_TypeRef() as *const c_void) };
-    if result_ptr.is_null() {
-        return vec![None; window_ids.len()];
+    pub(crate) fn current_space_id(&self) -> Option<u64> {
+        self.current_space_id
     }
 
-    let result: CFArray<CFTypeRef> = unsafe { CFArray::wrap_under_create_rule(result_ptr as _) };
+    /// Return every Space containing `window_id`.
+    pub(crate) fn window_space_ids(&self, window_id: u32) -> Option<Vec<u64>> {
+        use core_foundation::{
+            array::CFArray,
+            base::{CFGetTypeID, CFTypeRef, TCFType},
+            number::CFNumber,
+        };
 
-    let mut spaces = Vec::with_capacity(window_ids.len());
-    for i in 0..result.len() {
-        let item = unsafe { result.get(i) };
-        match item {
-            Some(ptr) => {
-                let num = unsafe { CFNumber::wrap_under_get_rule(*ptr as _) };
-                spaces.push(num.to_i64().map(|v| v as u64));
-            }
-            None => spaces.push(None),
+        let copy_spaces = self.copy_spaces_for_windows?;
+        let window_number = CFNumber::from(window_id as i64);
+        let window_ref = window_number.as_concrete_TypeRef() as *const c_void;
+        let windows = CFArray::<CFTypeRef>::from_copyable(&[window_ref]);
+        let result_ptr = unsafe {
+            copy_spaces(
+                self.connection_id,
+                0x7,
+                windows.as_concrete_TypeRef() as *const c_void,
+            )
+        };
+        if result_ptr.is_null() {
+            return None;
         }
+
+        let result: CFArray<CFTypeRef> =
+            unsafe { CFArray::wrap_under_create_rule(result_ptr as _) };
+        let mut space_ids = Vec::with_capacity(result.len() as usize);
+        for item in result.iter() {
+            let item = *item;
+            if unsafe { CFGetTypeID(item) } != CFNumber::type_id() {
+                return None;
+            }
+            let number = unsafe { CFNumber::wrap_under_get_rule(item as _) };
+            let space_id = u64::try_from(number.to_i64()?).ok()?;
+            if space_id != 0 {
+                space_ids.push(space_id);
+            }
+        }
+
+        (!space_ids.is_empty()).then_some(space_ids)
     }
-    spaces
+
+    /// Return the active Space on the display WindowServer associates with
+    /// `window_id`. This avoids comparing every window against the main
+    /// display's active Space when displays use independent Spaces.
+    pub(crate) fn current_space_for_window(&self, window_id: u32) -> Option<u64> {
+        use core_foundation::{base::TCFType, string::CFString};
+
+        let copy_display = self.copy_managed_display_for_window?;
+        let get_current_space = self.managed_display_get_current_space?;
+        let display_ptr = unsafe { copy_display(self.connection_id, window_id) };
+        if display_ptr.is_null() {
+            return None;
+        }
+        let display = unsafe { CFString::wrap_under_create_rule(display_ptr as _) };
+        nonzero_space_id(Some(unsafe {
+            get_current_space(
+                self.connection_id,
+                display.as_concrete_TypeRef() as *const c_void,
+            )
+        }))
+    }
 }
 
 // ── Focus-without-raise ───────────────────────────────────────────────────────

--- a/libs/cua-driver/rust/crates/platform-macos/src/input/skylight.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/input/skylight.rs
@@ -41,6 +41,12 @@ type SetIntFieldFn = unsafe extern "C" fn(*mut c_void, u32, i64);
 /// `uint32_t CGSMainConnectionID(void)`
 type ConnectionIDFn = unsafe extern "C" fn() -> u32;
 
+/// `uint64_t CGSGetActiveSpace(uint32_t cid)`
+type GetActiveSpaceFn = unsafe extern "C" fn(u32) -> u64;
+
+/// `CFArrayRef CGSCopySpacesForWindows(uint32_t cid, uint32_t options, CFArrayRef windowIDs)`
+type CopySpacesForWindowsFn = unsafe extern "C" fn(u32, u32, *const c_void) -> *mut c_void;
+
 // ── NSMenu shortcut activation SPIs ──────────────────────────────────────────
 
 /// `OSStatus SLPSSetFrontProcessWithOptions(const void *psn, uint32_t windowID, uint32_t options)`
@@ -138,6 +144,16 @@ fn set_int_field_fn() -> Option<SetIntFieldFn> {
 fn connection_id_fn() -> Option<ConnectionIDFn> {
     static SYM: OnceLock<Option<ConnectionIDFn>> = OnceLock::new();
     *SYM.get_or_init(|| find_sym(b"CGSMainConnectionID\0").map(|p| unsafe { as_fn(p) }))
+}
+
+fn get_active_space_fn() -> Option<GetActiveSpaceFn> {
+    static SYM: OnceLock<Option<GetActiveSpaceFn>> = OnceLock::new();
+    *SYM.get_or_init(|| find_sym(b"CGSGetActiveSpace\0").map(|p| unsafe { as_fn(p) }))
+}
+
+fn copy_spaces_for_windows_fn() -> Option<CopySpacesForWindowsFn> {
+    static SYM: OnceLock<Option<CopySpacesForWindowsFn>> = OnceLock::new();
+    *SYM.get_or_init(|| find_sym(b"CGSCopySpacesForWindows\0").map(|p| unsafe { as_fn(p) }))
 }
 
 fn factory_msg_send_fn() -> Option<FactoryMsgSendFn> {
@@ -330,6 +346,108 @@ pub(super) fn set_integer_field(event_ptr: *mut c_void, field: u32, value: i64) 
 /// Return the Skylight main connection ID for the current process.
 pub fn main_connection_id() -> Option<u32> {
     connection_id_fn().map(|f| unsafe { f() })
+}
+
+/// Return the current active macOS Space (desktop) ID.
+///
+/// Uses the private `CGSGetActiveSpace` SPI from SkyLight.  Returns `None`
+/// when the symbol is unavailable (future macOS version that removes it).
+pub fn get_active_space() -> Option<u64> {
+    let cid = main_connection_id()?;
+    get_active_space_fn().map(|f| unsafe { f(cid) })
+}
+
+/// Return the Space ID for a specific window.
+///
+/// Uses the private `CGSCopySpacesForWindows` SPI from SkyLight.  This
+/// function queries one window at a time — it creates a temporary CFArray
+/// with the single window ID, calls `CGSCopySpacesForWindows`, and extracts
+/// the first (only) space ID from the result.  Returns `None` when the symbol
+/// is unavailable or the query produces no result.
+pub fn get_window_space(window_id: u32) -> Option<u64> {
+    use core_foundation::{
+        array::CFArray,
+        base::{CFTypeRef, TCFType},
+        number::CFNumber,
+    };
+
+    let cid = main_connection_id()?;
+    let f = copy_spaces_for_windows_fn()?;
+
+    let num = CFNumber::from(window_id as i64);
+    let num_ref: *const c_void = num.as_concrete_TypeRef() as *const c_void;
+    let arr = unsafe { CFArray::<CFTypeRef>::from_copyable(&[num_ref]) };
+
+    let result_ptr: *mut c_void = unsafe { f(cid, 7, arr.as_concrete_TypeRef() as *const c_void) };
+    if result_ptr.is_null() {
+        return None;
+    }
+
+    let result: CFArray<CFTypeRef> = unsafe { CFArray::wrap_under_create_rule(result_ptr as _) };
+    if result.len() == 0 {
+        return None;
+    }
+
+    let space_ptr = unsafe { *result.get(0)? };
+    let space_num = unsafe { CFNumber::wrap_under_get_rule(space_ptr as _) };
+    space_num.to_i64().map(|v| v as u64)
+}
+
+/// Return Space IDs for multiple windows in a single SPI call.
+///
+/// Batches all window IDs into one `CGSCopySpacesForWindows` call
+/// instead of N separate calls. Returns a Vec where `result[i]`
+/// corresponds to `window_ids[i]`. Entries are `None` when the
+/// window has no space assignment or the SPI is unavailable.
+pub fn get_window_spaces(window_ids: &[u32]) -> Vec<Option<u64>> {
+    if window_ids.is_empty() {
+        return vec![];
+    }
+
+    let cid = match main_connection_id() {
+        Some(cid) => cid,
+        None => return vec![None; window_ids.len()],
+    };
+    let f = match copy_spaces_for_windows_fn() {
+        Some(f) => f,
+        None => return vec![None; window_ids.len()],
+    };
+
+    use core_foundation::{
+        array::CFArray,
+        base::{CFTypeRef, TCFType},
+        number::CFNumber,
+    };
+
+    let nums: Vec<CFNumber> = window_ids
+        .iter()
+        .map(|&id| CFNumber::from(id as i64))
+        .collect();
+    let refs: Vec<*const c_void> = nums
+        .iter()
+        .map(|n| n.as_concrete_TypeRef() as *const c_void)
+        .collect();
+    let arr = unsafe { CFArray::<CFTypeRef>::from_copyable(&refs) };
+
+    let result_ptr = unsafe { f(cid, 7, arr.as_concrete_TypeRef() as *const c_void) };
+    if result_ptr.is_null() {
+        return vec![None; window_ids.len()];
+    }
+
+    let result: CFArray<CFTypeRef> = unsafe { CFArray::wrap_under_create_rule(result_ptr as _) };
+
+    let mut spaces = Vec::with_capacity(window_ids.len());
+    for i in 0..result.len() {
+        let item = unsafe { result.get(i) };
+        match item {
+            Some(ptr) => {
+                let num = unsafe { CFNumber::wrap_under_get_rule(*ptr as _) };
+                spaces.push(num.to_i64().map(|v| v as u64));
+            }
+            None => spaces.push(None),
+        }
+    }
+    spaces
 }
 
 // ── Focus-without-raise ───────────────────────────────────────────────────────

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/list_windows.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/list_windows.rs
@@ -65,10 +65,12 @@ impl Tool for ListWindowsTool {
 
         let windows_json: Vec<Value> = windows.iter().map(window_record_json).collect();
 
+        let current_space_id = crate::input::skylight::get_active_space();
+
         ToolResult::text(format!("Found {} window(s).", windows_json.len())).with_structured(
             serde_json::json!({
                 "windows": windows_json,
-                "current_space_id": null
+                "current_space_id": current_space_id
             }),
         )
     }

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/list_windows.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/list_windows.rs
@@ -18,7 +18,10 @@ fn def() -> &'static ToolDef {
             Per-record fields: window_id, pid, app_name, title, bounds \
             (x/y/width/height, top-left origin), z_index (integer or null; higher values are \
             closer to the front; null means stacking order is unavailable and callers must not \
-            infer one), is_on_screen, on_current_space. To select a frontmost candidate, take the \
+            infer one), is_on_screen, space_ids, current_space_id (the active Space on that \
+            window's display), and on_current_space. The top-level current_space_id is \
+            WindowServer's main/global active Space and can differ from a record's \
+            current_space_id when displays use independent Spaces. To select a frontmost candidate, take the \
             maximum integer z_index; if every value is null, use an explicit fallback instead of \
             relying on array order.".into(),
         input_schema: serde_json::json!({
@@ -91,6 +94,7 @@ pub(super) fn window_record_json(w: &crate::windows::WindowInfo) -> Value {
         "layer": w.layer,
         "z_index": w.z_index,
         "is_on_screen": w.is_on_screen,
+        "current_space_id": w.current_space_id,
         "on_current_space": w.on_current_space,
         "space_ids": w.space_ids,
     })
@@ -116,10 +120,19 @@ mod tests {
             layer: 0,
             z_index: 7,
             is_on_screen: true,
+            current_space_id: Some(1),
             on_current_space: Some(true),
             space_ids: Some(vec![1]),
         };
 
         assert_eq!(window_record_json(&window)["z_index"], serde_json::json!(7));
+        assert_eq!(
+            window_record_json(&window)["current_space_id"],
+            serde_json::json!(1)
+        );
+        assert_eq!(
+            window_record_json(&window)["on_current_space"],
+            serde_json::json!(true)
+        );
     }
 }

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/list_windows.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/list_windows.rs
@@ -53,19 +53,19 @@ impl Tool for ListWindowsTool {
         let pid_filter: Option<i32> = args.opt_i64("pid").map(|v| v as i32);
         let on_screen_only = args.bool_or("on_screen_only", false);
 
-        let mut windows = if on_screen_only {
-            crate::windows::visible_windows()
+        let enumeration = if on_screen_only {
+            crate::windows::visible_windows_with_space_snapshot()
         } else {
-            crate::windows::all_windows()
+            crate::windows::all_windows_with_space_snapshot()
         };
+        let current_space_id = enumeration.current_space_id;
+        let mut windows = enumeration.windows;
 
         if let Some(pid) = pid_filter {
             windows.retain(|w| w.pid == pid);
         }
 
         let windows_json: Vec<Value> = windows.iter().map(window_record_json).collect();
-
-        let current_space_id = crate::input::skylight::get_active_space();
 
         ToolResult::text(format!("Found {} window(s).", windows_json.len())).with_structured(
             serde_json::json!({

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
@@ -90,6 +90,7 @@ mod pid_window_target_tests {
             layer: 0,
             z_index: 1,
             is_on_screen: true,
+            current_space_id: None,
             on_current_space: None,
             space_ids: None,
         }

--- a/libs/cua-driver/rust/crates/platform-macos/src/window_change_detector.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/window_change_detector.rs
@@ -379,6 +379,7 @@ mod tests {
             layer: 0,
             z_index: 0,
             is_on_screen: true,
+            current_space_id: None,
             on_current_space: None,
             space_ids: None,
         }

--- a/libs/cua-driver/rust/crates/platform-macos/src/windows.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/windows.rs
@@ -23,6 +23,9 @@ pub struct WindowInfo {
     pub layer: i32,
     pub z_index: usize,
     pub is_on_screen: bool,
+    /// Active Space on the display WindowServer associates with this window.
+    /// This can differ between windows when displays use independent Spaces.
+    pub current_space_id: Option<u64>,
     pub on_current_space: Option<bool>,
     pub space_ids: Option<Vec<u64>>,
 }
@@ -243,6 +246,7 @@ fn enumerate_windows(options: u32, layers: LayerFilter) -> WindowEnumeration {
             layer,
             z_index,
             is_on_screen,
+            current_space_id: None,
             on_current_space: None,
             space_ids: None,
         });
@@ -260,9 +264,7 @@ fn enumerate_windows(options: u32, layers: LayerFilter) -> WindowEnumeration {
             let display_space_id = space_ids
                 .as_ref()
                 .and_then(|_| query.current_space_for_window(window.window_id));
-            window.on_current_space =
-                window_on_current_space(space_ids.as_deref(), display_space_id);
-            window.space_ids = space_ids;
+            apply_window_space_metadata(window, space_ids, display_space_id);
         }
     }
 
@@ -270,6 +272,16 @@ fn enumerate_windows(options: u32, layers: LayerFilter) -> WindowEnumeration {
         windows: results,
         current_space_id,
     }
+}
+
+fn apply_window_space_metadata(
+    window: &mut WindowInfo,
+    space_ids: Option<Vec<u64>>,
+    current_space_id: Option<u64>,
+) {
+    window.on_current_space = window_on_current_space(space_ids.as_deref(), current_space_id);
+    window.current_space_id = current_space_id;
+    window.space_ids = space_ids;
 }
 
 fn window_on_current_space(
@@ -412,6 +424,24 @@ mod tests {
         assert_eq!(window_on_current_space(Some(&[4]), None), None);
     }
 
+    #[test]
+    fn per_window_current_space_is_the_one_used_for_membership() {
+        let mut secondary_display_window = window(42, 800, "TextEdit");
+        apply_window_space_metadata(&mut secondary_display_window, Some(vec![2, 4]), Some(4));
+
+        assert_eq!(secondary_display_window.current_space_id, Some(4));
+        assert_eq!(secondary_display_window.space_ids, Some(vec![2, 4]));
+        assert_eq!(secondary_display_window.on_current_space, Some(true));
+        assert!(secondary_display_window
+            .space_ids
+            .as_deref()
+            .is_some_and(|spaces| spaces.contains(
+                &secondary_display_window
+                    .current_space_id
+                    .expect("display Space must be present")
+            )));
+    }
+
     fn window(window_id: u32, pid: i32, app_name: &str) -> WindowInfo {
         WindowInfo {
             window_id,
@@ -427,6 +457,7 @@ mod tests {
             layer: 0,
             z_index: 1,
             is_on_screen: true,
+            current_space_id: None,
             on_current_space: None,
             space_ids: None,
         }

--- a/libs/cua-driver/rust/crates/platform-macos/src/windows.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/windows.rs
@@ -102,6 +102,11 @@ fn enumerate_windows(options: u32, layers: LayerFilter) -> Vec<WindowInfo> {
     };
     use std::os::raw::c_void;
 
+    // Capture the current active space once so every window in this batch is
+    // compared against the same snapshot.  Spurious dlopen/dlsym calls on every
+    // window are also avoided.
+    let current_space = crate::input::skylight::get_active_space();
+
     let raw_ref = unsafe { CGWindowListCopyWindowInfo(options, kCGNullWindowID) };
     if raw_ref.is_null() {
         return vec![];
@@ -109,7 +114,8 @@ fn enumerate_windows(options: u32, layers: LayerFilter) -> Vec<WindowInfo> {
 
     let raw: CFArray<CFTypeRef> = unsafe { CFArray::wrap_under_create_rule(raw_ref as _) };
     let total = raw.len() as usize;
-    let mut result = Vec::new();
+    let mut results = Vec::new();
+    let mut layer0_wids: Vec<u32> = Vec::new();
 
     for (idx, item) in raw.iter().enumerate() {
         let item = *item;
@@ -211,7 +217,7 @@ fn enumerate_windows(options: u32, layers: LayerFilter) -> Vec<WindowInfo> {
         // z_index: CGWindowList front-to-back → assign reverse index.
         let z_index = z_index_from_front_to_back(total, idx);
 
-        result.push(WindowInfo {
+        results.push(WindowInfo {
             window_id,
             pid,
             app_name,
@@ -223,9 +229,19 @@ fn enumerate_windows(options: u32, layers: LayerFilter) -> Vec<WindowInfo> {
             on_current_space: None,
             space_ids: None,
         });
+        layer0_wids.push(window_id);
     }
 
-    result
+    // Batch query spaces for all layer-0 windows in one SPI call.
+    let space_results = crate::input::skylight::get_window_spaces(&layer0_wids);
+    for (i, win) in results.iter_mut().enumerate() {
+        if let Some(space_id) = space_results.get(i).copied().flatten() {
+            win.space_ids = Some(vec![space_id]);
+            win.on_current_space = current_space.map(|cur| space_id == cur);
+        }
+    }
+
+    results
 }
 
 fn z_index_from_front_to_back(total: usize, position: usize) -> usize {

--- a/libs/cua-driver/rust/crates/platform-macos/src/windows.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/windows.rs
@@ -27,6 +27,11 @@ pub struct WindowInfo {
     pub space_ids: Option<Vec<u64>>,
 }
 
+pub(crate) struct WindowEnumeration {
+    pub(crate) windows: Vec<WindowInfo>,
+    pub(crate) current_space_id: Option<u64>,
+}
+
 // ── CGWindow option flags ─────────────────────────────────────────────────────
 // Apple-canonical kCG* naming preserved to match the public Apple headers — the
 // upper-case-globals lint would rename them to KCG_..., which would silently
@@ -58,11 +63,19 @@ extern "C" {
 
 /// Enumerate all windows (including off-screen).
 pub fn all_windows() -> Vec<WindowInfo> {
+    all_windows_with_space_snapshot().windows
+}
+
+pub(crate) fn all_windows_with_space_snapshot() -> WindowEnumeration {
     enumerate_windows(kCGWindowListExcludeDesktopElements, LayerFilter::ZeroOnly)
 }
 
 /// Enumerate only on-screen windows.
 pub fn visible_windows() -> Vec<WindowInfo> {
+    visible_windows_with_space_snapshot().windows
+}
+
+pub(crate) fn visible_windows_with_space_snapshot() -> WindowEnumeration {
     enumerate_windows(
         kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements,
         LayerFilter::ZeroOnly,
@@ -79,7 +92,7 @@ pub fn visible_windows() -> Vec<WindowInfo> {
 /// `get_window_state` tell "no such window" apart from "exists, but is not a
 /// layer-0 window" (issue #2237).
 fn all_windows_any_layer() -> Vec<WindowInfo> {
-    enumerate_windows(kCGWindowListExcludeDesktopElements, LayerFilter::AnyLayer)
+    enumerate_windows(kCGWindowListExcludeDesktopElements, LayerFilter::AnyLayer).windows
 }
 
 /// Which CGWindow layers an enumeration admits.
@@ -91,7 +104,7 @@ enum LayerFilter {
     AnyLayer,
 }
 
-fn enumerate_windows(options: u32, layers: LayerFilter) -> Vec<WindowInfo> {
+fn enumerate_windows(options: u32, layers: LayerFilter) -> WindowEnumeration {
     use core_foundation::{
         array::CFArray,
         base::{CFGetTypeID, CFTypeRef, TCFType},
@@ -102,20 +115,24 @@ fn enumerate_windows(options: u32, layers: LayerFilter) -> Vec<WindowInfo> {
     };
     use std::os::raw::c_void;
 
-    // Capture the current active space once so every window in this batch is
-    // compared against the same snapshot.  Spurious dlopen/dlsym calls on every
-    // window are also avoided.
-    let current_space = crate::input::skylight::get_active_space();
+    let space_query = (layers == LayerFilter::ZeroOnly)
+        .then(crate::input::skylight::SpaceQuery::new)
+        .flatten();
+    let current_space_id = space_query
+        .as_ref()
+        .and_then(|query| query.current_space_id());
 
     let raw_ref = unsafe { CGWindowListCopyWindowInfo(options, kCGNullWindowID) };
     if raw_ref.is_null() {
-        return vec![];
+        return WindowEnumeration {
+            windows: vec![],
+            current_space_id,
+        };
     }
 
     let raw: CFArray<CFTypeRef> = unsafe { CFArray::wrap_under_create_rule(raw_ref as _) };
     let total = raw.len() as usize;
     let mut results = Vec::new();
-    let mut layer0_wids: Vec<u32> = Vec::new();
 
     for (idx, item) in raw.iter().enumerate() {
         let item = *item;
@@ -229,19 +246,37 @@ fn enumerate_windows(options: u32, layers: LayerFilter) -> Vec<WindowInfo> {
             on_current_space: None,
             space_ids: None,
         });
-        layer0_wids.push(window_id);
     }
 
-    // Batch query spaces for all layer-0 windows in one SPI call.
-    let space_results = crate::input::skylight::get_window_spaces(&layer0_wids);
-    for (i, win) in results.iter_mut().enumerate() {
-        if let Some(space_id) = space_results.get(i).copied().flatten() {
-            win.space_ids = Some(vec![space_id]);
-            win.on_current_space = current_space.map(|cur| space_id == cur);
+    if layers == LayerFilter::ZeroOnly {
+        let Some(query) = &space_query else {
+            return WindowEnumeration {
+                windows: results,
+                current_space_id,
+            };
+        };
+        for window in &mut results {
+            let space_ids = query.window_space_ids(window.window_id);
+            let display_space_id = space_ids
+                .as_ref()
+                .and_then(|_| query.current_space_for_window(window.window_id));
+            window.on_current_space =
+                window_on_current_space(space_ids.as_deref(), display_space_id);
+            window.space_ids = space_ids;
         }
     }
 
-    results
+    WindowEnumeration {
+        windows: results,
+        current_space_id,
+    }
+}
+
+fn window_on_current_space(
+    space_ids: Option<&[u64]>,
+    current_space_id: Option<u64>,
+) -> Option<bool> {
+    Some(space_ids?.contains(&current_space_id?))
 }
 
 fn z_index_from_front_to_back(total: usize, position: usize) -> usize {
@@ -363,6 +398,18 @@ mod tests {
             .collect();
         assert_eq!(indices, vec![3, 2, 1]);
         assert!(indices[0] > indices[2]);
+    }
+
+    #[test]
+    fn space_membership_checks_all_spaces_for_a_window() {
+        assert_eq!(window_on_current_space(Some(&[2, 4]), Some(4)), Some(true));
+        assert_eq!(window_on_current_space(Some(&[2, 4]), Some(3)), Some(false));
+    }
+
+    #[test]
+    fn space_membership_stays_unknown_without_either_side() {
+        assert_eq!(window_on_current_space(None, Some(4)), None);
+        assert_eq!(window_on_current_space(Some(&[4]), None), None);
     }
 
     fn window(window_id: u32, pid: i32, app_name: &str) -> WindowInfo {


### PR DESCRIPTION
## Summary

- expose macOS Space membership and current-Space state from `list_windows`
- query membership per window because the SkyLight batch API returns a set union, not a positional result
- compare each window against the active Space for that window's managed display
- publish the comparison Space as per-window `current_space_id`, while retaining the top-level main/global active Space
- preserve multi-Space membership and explicit unknowns when WindowServer cannot establish Space facts

## Regression coverage

- added a pure metadata mapping boundary so membership and current-Space semantics are testable without private framework calls
- added coverage that the per-window comparison Space is exactly the value used to derive `on_current_space`
- covered current, non-current, multi-Space, and unknown membership outcomes

## Verification

Exact source: `6f2301ac20d91f02ede2f5847bd05be6b432fc1a`

- `cargo test --manifest-path libs/cua-driver/rust/Cargo.toml -p platform-macos --lib` (310 passed)
- focused Space tests (10 passed)
- `cargo fmt --manifest-path libs/cua-driver/rust/Cargo.toml --all -- --check`
- `git diff --check`
- `npx tsx scripts/docs-generators/runner.ts --library cua-driver --check`

## Native macOS certification

Certified from the exact source SHA on a disposable macOS 26.5.2 arm64 Lume guest using a signed Cua Driver 0.17.0 candidate.

- installed binary SHA-256: `34deaf6a22ba3461359df9f8a07f936d1aeee386341e0b5dea9cbab08e616140`
- designated requirement leaf: `d78483e2cab099da4b14bed941d479b902fee005`
- exact source provenance confirmed through `get_config.source_sha`
- Mission Control independently established Desktop 1 and Desktop 2 and moved one AppKit harness window between them
- on Desktop 1: top-level Space `1`; moved window had `space_ids: [71]`, per-window `current_space_id: 1`, `on_current_space: false`, and `is_on_screen: false`
- on Desktop 2: top-level Space `71`; the same window had `space_ids: [71]`, per-window `current_space_id: 71`, `on_current_space: true`, and `is_on_screen: true`
- all 33 rows with known Space facts satisfied `on_current_space == space_ids.contains(current_space_id)` on both desktops; unknown rows remained explicitly null
