### PR TITLE
release(cua-fleet): 0.0.10 — repin to cua-train 0.1.6 (petname claim names)

### DIFF
--- a/.github/scripts/repackage_cua_train_wheel.py
+++ b/.github/scripts/repackage_cua_train_wheel.py
@@ -14,7 +14,7 @@ import sys
 import zipfile
 
 SOURCE_NAME = "cua-train"
-SOURCE_VERSION = "0.1.5"
+SOURCE_VERSION = "0.1.6"
 DESTINATION_NAME = "cua-fleet"
 WHEEL_FILENAME = re.compile(
     r"^(?P<distribution>[A-Za-z0-9_]+)-(?P<version>[^-]+)-py3-none-(?P<platform>[^-]+)\.whl$"
@@ -119,7 +119,7 @@ def repack(
 
     metadata = parse_metadata(entries[metadata_name])
     if metadata.get("Name") != SOURCE_NAME or metadata.get("Version") != SOURCE_VERSION:
-        raise WheelError("source METADATA does not identify cua-train==0.1.5")
+        raise WheelError("source METADATA does not identify cua-train==0.1.6")
     wheel_metadata = entries[wheel_name].decode()
     if (
         "Root-Is-Purelib: false" not in wheel_metadata

--- a/.github/scripts/tests/test_cua_fleet_release_wiring.py
+++ b/.github/scripts/tests/test_cua_fleet_release_wiring.py
@@ -14,13 +14,13 @@ class TestCuaFleetReleaseWiring(unittest.TestCase):
         workflow = (REPO_ROOT / ".github/workflows/cd-py-fleet.yml").read_text()
         repackager = (REPO_ROOT / ".github/scripts/repackage_cua_train_wheel.py").read_text()
         expected_sources = {
-            "cua_train-0.1.5-py3-none-manylinux_2_34_x86_64.whl": "72824b317888d1bbf21585907c8291ce648007e052e92c1e4cd8d475750b57a5",
-            "cua_train-0.1.5-py3-none-manylinux_2_34_aarch64.whl": "d6adca168fbd9777ef3fccf21f0d39b180cde440494f8f0ff7d47a46de2e6d5a",
-            "cua_train-0.1.5-py3-none-macosx_10_12_x86_64.whl": "605cdd794edbd04a88f5a99f3713fd5b87fa8c634285839015a61894544cd1d1",
-            "cua_train-0.1.5-py3-none-macosx_11_0_arm64.whl": "82ec2795fad892dc6238fcbcabb861e78d214f6603d765419a2b10fddef05fda",
+            "cua_train-0.1.6-py3-none-manylinux_2_34_x86_64.whl": "418db974949f4020fae2f3ed2f5a8d0db6ddce38e34f5db89283ac479d816a55",
+            "cua_train-0.1.6-py3-none-manylinux_2_34_aarch64.whl": "80526bf94ed535383b3dddd9a7da800da9fcb32837c21c2e2caa39390e3548c9",
+            "cua_train-0.1.6-py3-none-macosx_10_12_x86_64.whl": "87cb4220054514ac5f44118d490ae404fbca5c97d2b964cd4fcaf1facd391fc0",
+            "cua_train-0.1.6-py3-none-macosx_11_0_arm64.whl": "17563c0504c9270e570332924f3092faec3dcdbf48557a70ee830e165ac7751c",
         }
 
-        self.assertIn('SOURCE_VERSION = "0.1.5"', repackager)
+        self.assertIn('SOURCE_VERSION = "0.1.6"', repackager)
         for wheel, digest in expected_sources.items():
             self.assertIn(f"wheel: {wheel}\n            sha256: {digest}", workflow)
 

--- a/.github/scripts/tests/test_repackage_cua_train_wheel.py
+++ b/.github/scripts/tests/test_repackage_cua_train_wheel.py
@@ -26,12 +26,12 @@ def _csv(rows: list[list[str]]) -> bytes:
 
 
 def _write_source_wheel(path: Path) -> dict[str, bytes]:
-    dist_info = "cua_train-0.1.5.dist-info"
+    dist_info = "cua_train-0.1.6.dist-info"
     entries = {
         "cua_train/__init__.py": b"TrainClient = object\n",
         "fleet_sdk/__init__.py": b"CyclopsClient = object\n",
         "fleet_sdk/libcyclops_sdk.so": b"native payload",
-        f"{dist_info}/METADATA": b"Metadata-Version: 2.4\nName: cua-train\nVersion: 0.1.5\nDescription-Content-Type: text/markdown\n\n",
+        f"{dist_info}/METADATA": b"Metadata-Version: 2.4\nName: cua-train\nVersion: 0.1.6\nDescription-Content-Type: text/markdown\n\n",
         f"{dist_info}/WHEEL": b"Wheel-Version: 1.0\nRoot-Is-Purelib: false\nTag: py3-none-manylinux_2_34_x86_64\n",
     }
     record_name = f"{dist_info}/RECORD"
@@ -45,7 +45,7 @@ def _write_source_wheel(path: Path) -> dict[str, bytes]:
 
 
 def test_repack_changes_only_distribution_metadata(tmp_path: Path):
-    source = tmp_path / "cua_train-0.1.5-py3-none-manylinux_2_34_x86_64.whl"
+    source = tmp_path / "cua_train-0.1.6-py3-none-manylinux_2_34_x86_64.whl"
     source_entries = _write_source_wheel(source)
 
     destination = repack(
@@ -67,7 +67,7 @@ def test_repack_changes_only_distribution_metadata(tmp_path: Path):
 
 
 def test_repack_rejects_unpinned_source(tmp_path: Path):
-    source = tmp_path / "cua_train-0.1.5-py3-none-manylinux_2_34_x86_64.whl"
+    source = tmp_path / "cua_train-0.1.6-py3-none-manylinux_2_34_x86_64.whl"
     _write_source_wheel(source)
 
     with pytest.raises(WheelError, match="SHA-256 mismatch"):

--- a/.github/workflows/cd-py-fleet.yml
+++ b/.github/workflows/cd-py-fleet.yml
@@ -9,7 +9,7 @@ on:
       version:
         description: "Patch version to publish (without v prefix)"
         required: true
-        default: "0.0.9"
+        default: "0.0.10"
   workflow_call:
     inputs:
       version:
@@ -86,26 +86,26 @@ jobs:
         include:
           - platform: linux-x86_64
             runner: ubuntu-22.04
-            wheel: cua_train-0.1.5-py3-none-manylinux_2_34_x86_64.whl
-            sha256: 72824b317888d1bbf21585907c8291ce648007e052e92c1e4cd8d475750b57a5
+            wheel: cua_train-0.1.6-py3-none-manylinux_2_34_x86_64.whl
+            sha256: 418db974949f4020fae2f3ed2f5a8d0db6ddce38e34f5db89283ac479d816a55
             library_suffix: .so
             audit: auditwheel
           - platform: linux-aarch64
             runner: ubuntu-24.04-arm
-            wheel: cua_train-0.1.5-py3-none-manylinux_2_34_aarch64.whl
-            sha256: d6adca168fbd9777ef3fccf21f0d39b180cde440494f8f0ff7d47a46de2e6d5a
+            wheel: cua_train-0.1.6-py3-none-manylinux_2_34_aarch64.whl
+            sha256: 80526bf94ed535383b3dddd9a7da800da9fcb32837c21c2e2caa39390e3548c9
             library_suffix: .so
             audit: auditwheel
           - platform: macos-x86_64
             runner: macos-15-intel
-            wheel: cua_train-0.1.5-py3-none-macosx_10_12_x86_64.whl
-            sha256: 605cdd794edbd04a88f5a99f3713fd5b87fa8c634285839015a61894544cd1d1
+            wheel: cua_train-0.1.6-py3-none-macosx_10_12_x86_64.whl
+            sha256: 87cb4220054514ac5f44118d490ae404fbca5c97d2b964cd4fcaf1facd391fc0
             library_suffix: .dylib
             audit: delocate
           - platform: macos-arm64
             runner: macos-14
-            wheel: cua_train-0.1.5-py3-none-macosx_11_0_arm64.whl
-            sha256: 82ec2795fad892dc6238fcbcabb861e78d214f6603d765419a2b10fddef05fda
+            wheel: cua_train-0.1.6-py3-none-macosx_11_0_arm64.whl
+            sha256: 17563c0504c9270e570332924f3092faec3dcdbf48557a70ee830e165ac7751c
             library_suffix: .dylib
             audit: delocate
     steps:

--- a/libs/python/cua-fleet/.bumpversion.cfg
+++ b/libs/python/cua-fleet/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.9
+current_version = 0.0.10
 commit = True
 tag = True
 tag_name = fleet-v{new_version}

--- a/libs/python/cua-fleet/cua_fleet/__init__.py
+++ b/libs/python/cua-fleet/cua_fleet/__init__.py
@@ -4,4 +4,4 @@ from cua_train import TrainClient
 
 __all__ = ["TrainClient"]
 
-__version__ = "0.0.9"
+__version__ = "0.0.10"

--- a/libs/python/cua-fleet/pyproject.toml
+++ b/libs/python/cua-fleet/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cua-fleet"
-version = "0.0.9"
+version = "0.0.10"
 description = "Cua Fleet facade for the Cua Cloud Python SDK"
 readme = "README.md"
 license = "MIT"
@@ -25,7 +25,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 
-dependencies = ["cua-train==0.1.5"]
+dependencies = ["cua-train==0.1.6"]
 
 [project.urls]
 Homepage      = "https://github.com/trycua/cua"

--- a/libs/python/cua-fleet/tests/test_train_facade.py
+++ b/libs/python/cua-fleet/tests/test_train_facade.py
@@ -13,9 +13,9 @@ TRAIN_SOURCE_ROOT = REPOSITORY_ROOT / "libs/python/cua-train/src"
 def test_package_metadata_pins_binding_bearing_cua_train() -> None:
     project = tomllib.loads((PACKAGE_ROOT / "pyproject.toml").read_text())["project"]
 
-    assert project["version"] == "0.0.9"
+    assert project["version"] == "0.0.10"
     assert project["requires-python"] == ">=3.10"
-    assert project["dependencies"] == ["cua-train==0.1.5"]
+    assert project["dependencies"] == ["cua-train==0.1.6"]
 
 
 def test_cua_fleet_reexports_train_client(monkeypatch) -> None:
@@ -29,4 +29,4 @@ def test_cua_fleet_reexports_train_client(monkeypatch) -> None:
 
     assert cua_fleet.TrainClient is cua_train.TrainClient
     assert cua_fleet.__all__ == ["TrainClient"]
-    assert cua_fleet.__version__ == "0.0.9"
+    assert cua_fleet.__version__ == "0.0.10"


### PR DESCRIPTION
Ports the cua-fleet 0.0.10 release wiring (cloud #6373): cua-train 0.1.6 carries random petname claim names (trycua/cloud#6368), fixing the 409 AlreadyExists collisions on retried/concurrent Fleet leases that today's hermes e2e hit.

- cd-py-fleet.yml: matrix wheels/sha256s → verified 0.1.6 digests; dispatch default 0.0.10
- repackage script SOURCE_VERSION → 0.1.6; wiring + repackage tests updated
- libs/python/cua-fleet: 0.0.10, cua-train==0.1.6

After merge: tag fleet-v0.0.10 on the merge commit → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)