### PR TITLE
feat(cua-sandbox): 0.1.26 — service request headers passthrough, cua-fleet 0.0.10

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/interfaces/services.py
+++ b/libs/python/cua-sandbox/cua_sandbox/interfaces/services.py
@@ -20,6 +20,7 @@ class Services:
         method: str,
         path: str,
         json: Any = None,
+        headers: dict[str, str] | None = None,
     ) -> Any:
         """Send a request to a named service on this sandbox.
 
@@ -27,4 +28,6 @@ class Services:
         transports raise :class:`NotImplementedError` unless they expose named
         services as well.
         """
-        return await self._transport.request_service(name, method=method, path=path, json_body=json)
+        return await self._transport.request_service(
+            name, method=method, path=path, json_body=json, headers=headers
+        )

--- a/libs/python/cua-sandbox/cua_sandbox/transport/base.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/base.py
@@ -73,6 +73,7 @@ class Transport(ABC):
         method: str,
         path: str,
         json_body: Any = None,
+        headers: Any = None,
     ) -> Any:
         """Request an auxiliary named service exposed by this sandbox."""
         raise NotImplementedError(f"{type(self).__name__} does not support named service requests.")

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
@@ -52,10 +52,13 @@ class FleetTransport(Transport):
         method: str,
         path: str,
         json_body: Any = None,
+        headers: dict[str, str] | None = None,
     ) -> httpx.Response:
         if name not in self._bound.services:
             raise ValueError(f"Fleet sandbox does not expose service {name!r}")
-        return await self._request(method, path, json_body=json_body, service_name=name)
+        return await self._request(
+            method, path, json_body=json_body, service_name=name, extra_headers=headers
+        )
 
     async def _request(
         self,
@@ -64,12 +67,15 @@ class FleetTransport(Transport):
         *,
         json_body: Any = None,
         service_name: str | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> httpx.Response:
         assert self._connected, "Transport not connected"
         body = None if json_body is None else json.dumps(json_body).encode()
         headers = (
             [] if body is None else [HttpHeader(name="content-type", value="application/json")]
         )
+        for name, value in (extra_headers or {}).items():
+            headers.append(HttpHeader(name=name, value=value))
         result = await self._sdk.service_request(
             self._bound,
             service_name or self._service_name,

--- a/libs/python/cua-sandbox/pyproject.toml
+++ b/libs/python/cua-sandbox/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cua-sandbox"
-version = "0.1.25"
+version = "0.1.26"
 description = "CUA Sandbox — ephemeral and persistent sandboxed computer environments"
 readme = "README.md"
 license = "MIT"
@@ -29,7 +29,7 @@ requires-python = ">=3.11,<3.14"
 dependencies = [
     "cua-core>=0.3.0,<0.4.0",
     "cua-auto>=0.1.2",
-    "cua-fleet==0.0.9",
+    "cua-fleet==0.0.10",
     "websockets>=12.0",
     "httpx>=0.27.0",
     "oras>=0.2.40",

--- a/libs/python/cua-sandbox/tests/test_fleet_sdk_packaging.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_sdk_packaging.py
@@ -19,7 +19,7 @@ class FleetSdkPackagingTests(unittest.TestCase):
 
         self.assertEqual(project["project"]["version"], "0.1.25")
         dependencies = project["project"]["dependencies"]
-        self.assertIn("cua-fleet==0.0.9", dependencies)
+        self.assertIn("cua-fleet==0.0.10", dependencies)
         self.assertFalse(any(dependency.startswith("cua-train") for dependency in dependencies))
         self.assertNotIn("cua-fleet", project["tool"]["uv"]["sources"])
         self.assertNotIn("cua-train", project["tool"]["uv"]["sources"])
@@ -50,7 +50,7 @@ class FleetSdkPackagingTests(unittest.TestCase):
         self.assertNotIn("cua-train", sandbox_dependencies)
         self.assertIn("cua-fleet", sandbox_requires_dist)
         self.assertNotIn("cua-train", sandbox_requires_dist)
-        self.assertEqual(packages["cua-fleet"]["version"], "0.0.9")
+        self.assertEqual(packages["cua-fleet"]["version"], "0.0.10")
         self.assertEqual(packages["cua-fleet"]["source"], {"registry": "https://pypi.org/simple"})
         self.assertNotIn("cua-train", fleet_dependencies)
         self.assertNotIn("cua-train", packages)

--- a/libs/python/cua-sandbox/uv.lock
+++ b/libs/python/cua-sandbox/uv.lock
@@ -539,7 +539,7 @@ dev = [{ name = "pytest", specifier = ">=8.3.5" }]
 
 [[package]]
 name = "cua-fleet"
-version = "0.0.9"
+version = "0.0.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -547,15 +547,15 @@ dependencies = [
     { name = "python-dateutil" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/b8/fd15a0649a94c576af69d5cda60a78a47cd37a7d5abab6bcfe43456ef0f1/cua_fleet-0.0.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:1041153f664fb84fb68e1bf453db611590a28518fe56f511b531dd4e6c931aa4", size = 2109242, upload-time = "2026-08-04T15:35:40.587Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/c0/19c161a492e1e051c7f8c6462a6df18d73d2539c8246bec97ef61c6c1521/cua_fleet-0.0.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:10177ae5d468461fa38ffccf8c34fccf10ac0a31e025d91a529174d2621718cf", size = 2020725, upload-time = "2026-08-04T15:35:42.226Z" },
-    { url = "https://files.pythonhosted.org/packages/39/ef/fb57cdb3f348b3ce763742b0a2954b7488fd73ddf26e669c74b36d1fa33f/cua_fleet-0.0.9-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:84f82e365671f6d33daf7dfcabde26434d0ed4c2bcfdebcf11f28c6ec31f0459", size = 2288295, upload-time = "2026-08-04T15:35:43.437Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/d2/3915a34260d65685460334941bf2c4d7803a673243e5ed8c7caab03f01c9/cua_fleet-0.0.9-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:0f3558227fd9e86870d6f32ab4f2e0ae70d0453246b40ece8795743d7102f717", size = 2337412, upload-time = "2026-08-04T15:35:44.529Z" },
+    { url = "https://files.pythonhosted.org/packages/44/4c/f56f16300b568542d6c048cfdd772cd720db2530231f14fe660b9d4dbbb0/cua_fleet-0.0.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5abe2a9aae0cc57b1dcc6680ffed4fac75af3072f69af059c14665517bae7cd5", size = 2144518, upload-time = "2026-08-04T18:43:55.9Z" },
+    { url = "https://files.pythonhosted.org/packages/48/31/7a57fa871fc74ccf8fcba4682ebd15a8af177190cfc75a78d24a01fe213d/cua_fleet-0.0.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8ca4e5c8c4c201fa24c61a16f274d83336406bef25d06d4076c36d3bb4abca59", size = 2102936, upload-time = "2026-08-04T18:43:57.404Z" },
+    { url = "https://files.pythonhosted.org/packages/70/13/a51ca4999eec9f299a02046531294e6a420a893573a9d736cb7157fd43a3/cua_fleet-0.0.10-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:8337016011479466d67ff0cfca27cdc752444c81d4948f58a3babfe71bfaac69", size = 2447788, upload-time = "2026-08-04T18:43:58.853Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/45/e6bde23f40f6be2cc81ac8b10e946eae08134283c987a28a1b98a83f47b8/cua_fleet-0.0.10-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:234a8632072c2a97a3574b1a302ce09ff6d450569d68c3db3d10da23348dde4d", size = 2388452, upload-time = "2026-08-04T18:44:00.105Z" },
 ]
 
 [[package]]
 name = "cua-sandbox"
-version = "0.1.25"
+version = "0.1.26"
 source = { editable = "." }
 dependencies = [
     { name = "cua-auto" },
@@ -592,7 +592,7 @@ dev = [
 requires-dist = [
     { name = "cua-auto", specifier = ">=0.1.2" },
     { name = "cua-core", specifier = ">=0.3.0,<0.4.0" },
-    { name = "cua-fleet", specifier = "==0.0.9" },
+    { name = "cua-fleet", specifier = "==0.0.10" },
     { name = "grpcio", specifier = "==1.78.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "oras", specifier = ">=0.2.40" },


### PR DESCRIPTION
Two changes needed by the hermes-kubevirt fleet e2e:

- `Services.request` / `Transport.request_service` gain an optional `headers` mapping, appended to the lease-authenticated request by the fleet transport. Callers need this to satisfy spec-compliant streamable-HTTP MCP servers (`accept: application/json, text/event-stream` + `mcp-session-id`) — without it the sandbox MCP answers 406/400, which is exactly how the hermes computer-use smoke failed.
- Repin to cua-fleet 0.0.10 (cua-train 0.1.6: random petname claim names, trycua/cloud#6368), fixing 409 AlreadyExists on retried/concurrent Fleet leases.

After merge: tag `sandbox-v0.1.26` on the merge commit → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)