### PR TITLE
fix(ci): sync Cua Sandbox bump metadata

### DIFF
--- a/libs/python/cua-sandbox/.bumpversion.cfg
+++ b/libs/python/cua-sandbox/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.25
+current_version = 0.1.26
 commit = True
 tag = True
 tag_name = sandbox-v{new_version}


### PR DESCRIPTION
## Summary

- synchronize Cua Sandbox's legacy bump configuration with package version `0.1.26`
- restore the repository-wide release-wiring invariant after #2852
- unblock unrelated release candidates that run the shared wiring suite

## Root cause

#2852 advanced `pyproject.toml` to `0.1.26` but left `.bumpversion.cfg` at `0.1.25`. The shared release-wiring test correctly fails on that drift.

## Validation

- `uv run --with pytest python -m pytest .github/scripts/tests/test_cua_sandbox_release_wiring.py -q` — 1 passed
- `uv run --with pytest python -m pytest .github/scripts/tests -q` — 147 passed
- `git diff --check`

## Release impact

No product behavior changes. This only repairs release metadata consistency.
