### PR TITLE
ci: restore PR #2805 release attribution

### DIFF
--- a/.github/release-attribution-config.json
+++ b/.github/release-attribution-config.json
@@ -27,6 +27,7 @@
     "manfred@ubuntu26.04-vm": "ai-ag2026",
     "me@madhavajay.com": "madhavajay",
     "robert@trycua.com": "enchanted-koala",
+    "rsyuzyov@gmail.com": "rsyuzyov",
     "sarinajin.li@gmail.com": "sarinali",
     "zane.chee.2023@scis.smu.edu.sg": "injaneity",
     "zongxin_yang@hms.harvard.edu": "z-x-yang"

--- a/.github/scripts/tests/test_release_attribution.py
+++ b/.github/scripts/tests/test_release_attribution.py
@@ -517,3 +517,33 @@ def test_unresolved_human_coauthor_fails_closed():
                 "optOutHandles": [],
             },
         )
+
+
+def test_pr_2805_coauthor_resolves_through_trusted_identity_override():
+    config = json.loads((REPO_ROOT / ".github/release-attribution-config.json").read_text())
+    commit = CommitRecord(
+        "aebd9962d2686e75ff9e17e0a3735e303ff96981",
+        "fix(cua-driver): stop Windows update --apply from killing itself (#2805)",
+        "Co-authored-by: Roman Syuzyov <rsyuzyov@gmail.com>",
+    )
+    pull = {
+        "user": {"login": "rsyuzyov"},
+        "author_association": "CONTRIBUTOR",
+        "body": "",
+        "labels": [],
+    }
+
+    contributors, issues, visual_requested = _change_contributors(
+        pull,
+        commit,
+        FakeGitHub(commit.sha),
+        "trycua/cua",
+        config,
+    )
+
+    assert contributors == [
+        {"login": "rsyuzyov", "role": "author", "external": True},
+        {"login": "rsyuzyov", "role": "coauthor", "external": True},
+    ]
+    assert issues == []
+    assert visual_requested is False


### PR DESCRIPTION
## Summary

- map `rsyuzyov@gmail.com` to the verified GitHub identity `rsyuzyov`
- cover the exact PR #2805 squash commit and coauthor trailer in the release collector tests
- retain the existing fail-closed behavior for other unresolved human coauthor emails

## Why

The Cua Driver 0.18.0 release PR #2836 cannot collect attribution for squash commit `aebd9962d2686e75ff9e17e0a3735e303ff96981`. PR #2805 and its source commits establish that Roman Syuzyov's contributor email belongs to GitHub user `rsyuzyov`, but that trusted mapping was absent from the release attribution configuration.

This restores the contributor credit from #2805 without weakening the collector's other attribution checks. It changes release infrastructure and tests only; it does not change product behavior or request another product release.

Salvaged from #2805.

## Validation

- `python3.13 -m pytest .github/scripts/tests/test_release_attribution.py .github/scripts/tests/test_pr_attribution.py -v` — 31 passed
- `python3.13 .github/scripts/release_backfill.py validate` — 146 candidates and 36 explicit skips validated
- `git diff --check`

The broader script suite reached 147 passed with one unrelated existing failure: the Cua Sandbox bump configuration says `0.1.25` while its package metadata says `0.1.26`.
