### PR TITLE
docs: link the Cua Driver agent skill from concept guide

### DIFF
--- a/docs/content/docs/concepts/what-is-computer-use.mdx
+++ b/docs/content/docs/concepts/what-is-computer-use.mdx
@@ -86,6 +86,7 @@ Cua Driver exposes [permission policies](/concepts/how-permission-policies-work)
 
 - **Learn it:** [Drive your first app with Cua Driver](/tutorials/drive-your-first-app) on an existing macOS, Windows, or Linux computer.
 - **Use it:** [Install Cua Driver](/how-to-guides/driver/install) and connect it to an agent you already use.
+- **Guide the agent:** [Install the Cua Driver agent skill](/how-to-guides/driver/install-agent-skill) to add cross-platform tool-selection and verification instructions.
 - **Isolate it:** [Start your first local sandbox](/tutorials/your-first-local-sandbox) for an isolated Linux computer.
 - **Understand delivery:** [Browser targeting and background delivery](/concepts/browser-targeting-and-background-delivery) explains how browser tabs map to native windows.
 - **Evaluate it:** [How we continuously validate Cua Driver](/concepts/how-cua-driver-is-validated) describes the evidence used to test desktop behavior.


### PR DESCRIPTION
## Summary

- add the existing Cua Driver agent-skill guide to the concept guide’s further-reading paths
- give readers a direct route to the cross-platform tool-selection and verification instructions

## Why

The concept guide explains how an agent chooses among code, tools, and UI automation, but it did not directly point readers to the existing instructions that teach an agent how to make and verify those choices.

## Validation

- `docs/node_modules/.bin/prettier --write content/docs/concepts/what-is-computer-use.mdx`
- `docs/node_modules/.bin/tsx scripts/check-links.ts`
- `docs/node_modules/.bin/tsx scripts/check-hygiene.ts`
- `docs/node_modules/.bin/next build`