### PR TITLE
fix(cua-driver): keep Windows cursor visible without focus theft

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/tests/agent_cursor_windows_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/agent_cursor_windows_test.rs
@@ -45,7 +45,7 @@ fn agent_cursor_overlay_obeys_untargeted_and_targeted_z_order() {
         let mut driver = McpDriver::spawn_named_with_overlay("windows-desktop-agent-cursor-px")
             .expect("required source-built driver with cursor overlay did not start");
         *evidence = recording_evidence(driver.recording_dir());
-        let (_target_profile, target) = launch_normal_window(&mut driver, "target");
+        let target = launch_wpf_window(&mut driver);
         bring_to_front(&mut driver, target);
         driver.start_behavior_recording();
         let (x, y) = window_center(target.native_id);
@@ -369,6 +369,24 @@ fn launch_normal_window(driver: &mut McpDriver, label: &str) -> (tempfile::TempD
         .find_window(pid as i64, "CuaTestHarness Electron")
         .expect("ordinary Electron harness window did not appear");
     (profile, TargetWindow { pid, native_id })
+}
+
+fn launch_wpf_window(driver: &mut McpDriver) -> TargetWindow {
+    let executable = harness_app("harness-wpf", "CuaTestHarness.Wpf.exe");
+    assert!(
+        executable.exists(),
+        "WPF harness missing at {}; run the Windows harness build first",
+        executable.display()
+    );
+    let mut command = Command::new(executable);
+    command.stdout(Stdio::null()).stderr(Stdio::null());
+    let child = spawn_in_job(&mut command).expect("launch ordinary WPF harness window");
+    let pid = child.id();
+    driver.reaper().push(child);
+    let (native_id, _) = driver
+        .find_window(pid as i64, "CuaTestHarness WPF")
+        .expect("ordinary WPF harness window did not appear");
+    TargetWindow { pid, native_id }
 }
 
 fn bring_to_front(driver: &mut McpDriver, target: TargetWindow) {

--- a/libs/cua-driver/rust/crates/cua-driver/tests/agent_cursor_windows_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/agent_cursor_windows_test.rs
@@ -2,18 +2,29 @@
 
 #![cfg(target_os = "windows")]
 
-use std::time::Duration;
+use std::ffi::OsStr;
+use std::net::TcpListener;
+use std::os::windows::ffi::OsStrExt;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 use cua_driver_testkit::e2e::{
     execute_case, recording_evidence, CaseSpec, Delivery, DriverRoute, Evidence, Observation,
     OracleKind, Scope, Targeting,
 };
+use cua_driver_testkit::observer::TargetWindow;
 use cua_driver_testkit::sentinel::ForegroundSentinel;
-use cua_driver_testkit::{Driver, McpDriver};
+use cua_driver_testkit::{ax, harness_app, spawn_in_job, Driver, McpDriver};
+use windows::core::PCWSTR;
+use windows::Win32::Foundation::{HWND, POINT, RECT};
+use windows::Win32::UI::WindowsAndMessaging::{
+    FindWindowW, GetCursorPos, GetForegroundWindow, GetWindow, GetWindowLongPtrW, GetWindowRect,
+    GWL_EXSTYLE, GW_HWNDPREV, WS_EX_TOPMOST,
+};
 
 #[test]
 #[ignore]
-fn agent_cursor_overlay_is_visible_without_moving_real_cursor() {
+fn agent_cursor_overlay_obeys_untargeted_and_targeted_z_order() {
     let case = CaseSpec::delivered(
         "windows-desktop-agent-cursor-px",
         "desktop",
@@ -28,57 +39,65 @@ fn agent_cursor_overlay_is_visible_without_moving_real_cursor() {
             OracleKind::Focus,
             OracleKind::ZOrder,
             OracleKind::Cursor,
-            OracleKind::NoLeakedInput,
         ],
     );
     execute_case(case, |evidence| {
         let mut driver = McpDriver::spawn_named("windows-desktop-agent-cursor-px")
             .expect("required source-built driver did not start");
         *evidence = recording_evidence(driver.recording_dir());
-        let sentinel = ForegroundSentinel::launch(&mut driver);
+        let (_target_profile, target) = launch_normal_window(&mut driver, "target");
+        bring_to_front(&mut driver, target);
         driver.start_behavior_recording();
-        let screen = driver.call("get_screen_size", serde_json::json!({}));
-        assert!(
-            !screen.is_error(),
-            "get_screen_size failed: {}",
-            screen.text()
-        );
-        let width = screen.structured()["width"].as_f64().unwrap_or(0.0);
-        let height = screen.structured()["height"].as_f64().unwrap_or(0.0);
-        assert!(
-            width >= 80.0 && height >= 80.0,
-            "invalid screen size {width}x{height}"
-        );
-        let (x, y) = (width / 2.0, height / 2.0);
+        let (x, y) = window_center(target.native_id);
         let cursor_id = "windows-agent-cursor-e2e";
+        let foreground_before = unsafe { GetForegroundWindow() };
+        assert_eq!(foreground_before.0 as u64, target.native_id);
+        let real_cursor_before = real_cursor_position();
 
-        let (_, mut passed) = sentinel
-            .observe_desktop(|| {
-                for (tool, arguments) in [
-                    (
-                        "set_agent_cursor_enabled",
-                        serde_json::json!({"enabled": true, "cursor_id": cursor_id}),
-                    ),
-                    (
-                        "set_agent_cursor_motion",
-                        serde_json::json!({
-                            "cursor_id": cursor_id,
-                            "glide_duration_ms": 100,
-                            "idle_hide_ms": 0
-                        }),
-                    ),
-                    (
-                        "move_cursor",
-                        serde_json::json!({"x": x, "y": y, "cursor_id": cursor_id}),
-                    ),
-                ] {
-                    let response = driver.call(tool, arguments);
-                    assert!(!response.is_error(), "{tool} failed: {}", response.text());
-                }
-                std::thread::sleep(Duration::from_millis(350));
-            })
-            .unwrap_or_else(|error| panic!("agent cursor disturbed the real desktop: {error}"));
-        assert_required_background_oracles(&passed);
+        for (tool, arguments) in [
+            (
+                "set_agent_cursor_enabled",
+                serde_json::json!({"enabled": true, "cursor_id": cursor_id}),
+            ),
+            (
+                "set_agent_cursor_motion",
+                serde_json::json!({
+                    "cursor_id": cursor_id,
+                    "glide_duration_ms": 100,
+                    "idle_hide_ms": 0
+                }),
+            ),
+            (
+                "move_cursor",
+                serde_json::json!({
+                    "x": x,
+                    "y": y,
+                    "scope": "desktop",
+                    "cursor_id": cursor_id
+                }),
+            ),
+        ] {
+            let response = driver.call(tool, arguments);
+            assert!(!response.is_error(), "{tool} failed: {}", response.text());
+        }
+        std::thread::sleep(Duration::from_millis(350));
+
+        let overlay = wait_for_overlay();
+        assert_eq!(
+            unsafe { GetForegroundWindow() },
+            foreground_before,
+            "move-only cursor stole focus"
+        );
+        assert_eq!(
+            real_cursor_position(),
+            real_cursor_before,
+            "move-only agent cursor moved the real pointer"
+        );
+        assert_not_topmost(overlay);
+        assert!(
+            window_is_above(overlay, HWND(target.native_id as *mut _)),
+            "move-only overlay did not reach the top of the ordinary band"
+        );
 
         let png = platform_windows::capture::screenshot_display_bytes()
             .expect("screenshot_display_bytes failed");
@@ -114,6 +133,76 @@ fn agent_cursor_overlay_is_visible_without_moving_real_cursor() {
             "agent cursor not visible at ({x:.0},{y:.0}): only {visible_pixels} qualifying pixels"
         );
 
+        // A targeted cursor remains exactly above its target while an
+        // independent ordinary foreground window stays above both. This
+        // guards the pre-existing PinAbove semantics while exercising the new
+        // no-target branch in the same hosted desktop.
+        let (_foreground_profile, foreground) = launch_normal_window(&mut driver, "foreground");
+        bring_to_front(&mut driver, foreground);
+        assert!(
+            window_is_above(
+                HWND(foreground.native_id as *mut _),
+                HWND(target.native_id as *mut _)
+            ),
+            "independent foreground window did not cover target"
+        );
+        let target_state = driver.call(
+            "get_window_state",
+            serde_json::json!({
+                "pid": target.pid,
+                "window_id": target.native_id,
+                "capture_mode": "ax"
+            }),
+        );
+        assert!(
+            !target_state.is_error(),
+            "target snapshot failed: {}",
+            target_state.text()
+        );
+        let button_index = ax::element_index_by_id(target_state.tree_text(), "btn-increment")
+            .expect("target increment button missing from UIA snapshot");
+        assert!(target_state.tree_text().contains("counter=0"));
+        let foreground_state_before = window_state(&mut driver, foreground);
+        assert!(foreground_state_before.tree_text().contains("counter=0"));
+        let targeted = driver.call(
+            "click",
+            serde_json::json!({
+                "pid": target.pid,
+                "window_id": target.native_id,
+                "element_index": button_index,
+                "snapshot_id": target_state.snapshot_id(),
+                "delivery_mode": "background",
+                "cursor_id": cursor_id
+            }),
+        );
+        assert!(
+            !targeted.is_error(),
+            "targeted background click failed: {}",
+            targeted.text()
+        );
+        let target_state_after = wait_for_window_text(&mut driver, target, "counter=1");
+        assert!(
+            target_state_after.tree_text().contains("counter=1"),
+            "targeted click did not change the background target: {}",
+            target_state_after.tree_text()
+        );
+        let foreground_state_after = window_state(&mut driver, foreground);
+        assert!(
+            foreground_state_after.tree_text().contains("counter=0"),
+            "targeted click leaked into the independent foreground window: {}",
+            foreground_state_after.tree_text()
+        );
+        wait_until(Duration::from_secs(2), || {
+            window_is_above(overlay, HWND(target.native_id as *mut _))
+                && window_is_above(HWND(foreground.native_id as *mut _), overlay)
+        });
+        assert_eq!(
+            unsafe { GetForegroundWindow().0 as u64 },
+            foreground.native_id,
+            "target-bound overlay or action stole foreground"
+        );
+        assert_not_topmost(overlay);
+
         let disabled = driver.call(
             "set_agent_cursor_enabled",
             serde_json::json!({"enabled": false, "cursor_id": cursor_id}),
@@ -123,9 +212,121 @@ fn agent_cursor_overlay_is_visible_without_moving_real_cursor() {
             "failed to disable agent cursor: {}",
             disabled.text()
         );
-        passed.push(OracleKind::Pixels);
+        let passed = vec![
+            OracleKind::Pixels,
+            OracleKind::Focus,
+            OracleKind::ZOrder,
+            OracleKind::Cursor,
+        ];
         Observation::delivered(passed, Evidence::default())
     });
+}
+
+#[test]
+#[ignore]
+fn agent_cursor_move_does_not_leak_input() {
+    let case = CaseSpec::delivered(
+        "windows-desktop-agent-cursor-no-input-leak",
+        "desktop",
+        "win32",
+        "agent_cursor",
+        Targeting::Px,
+        Delivery::NotApplicable,
+        Scope::Desktop,
+        DriverRoute::WindowsOverlay,
+        vec![
+            OracleKind::Focus,
+            OracleKind::ZOrder,
+            OracleKind::Cursor,
+            OracleKind::NoLeakedInput,
+        ],
+    );
+    execute_case(case, |evidence| {
+        let mut driver = McpDriver::spawn_named("windows-desktop-agent-cursor-no-input-leak")
+            .expect("required source-built driver did not start");
+        *evidence = recording_evidence(driver.recording_dir());
+        let sentinel = ForegroundSentinel::launch(&mut driver);
+        driver.start_behavior_recording();
+        let screen = driver.call("get_screen_size", serde_json::json!({}));
+        assert!(
+            !screen.is_error(),
+            "get_screen_size failed: {}",
+            screen.text()
+        );
+        let x = screen.structured()["width"].as_f64().unwrap_or(0.0) / 2.0;
+        let y = screen.structured()["height"].as_f64().unwrap_or(0.0) / 2.0;
+        let cursor_id = "windows-agent-cursor-no-input-leak";
+        let (_, passed) = sentinel
+            .observe_desktop(|| {
+                for (tool, arguments) in [
+                    (
+                        "set_agent_cursor_enabled",
+                        serde_json::json!({"enabled": true, "cursor_id": cursor_id}),
+                    ),
+                    (
+                        "set_agent_cursor_motion",
+                        serde_json::json!({
+                            "cursor_id": cursor_id,
+                            "glide_duration_ms": 100,
+                            "idle_hide_ms": 0
+                        }),
+                    ),
+                    (
+                        "move_cursor",
+                        serde_json::json!({
+                            "x": x,
+                            "y": y,
+                            "scope": "desktop",
+                            "cursor_id": cursor_id
+                        }),
+                    ),
+                ] {
+                    let response = driver.call(tool, arguments);
+                    assert!(!response.is_error(), "{tool} failed: {}", response.text());
+                }
+                std::thread::sleep(Duration::from_millis(350));
+            })
+            .unwrap_or_else(|error| panic!("agent cursor disturbed the real desktop: {error}"));
+        assert_required_background_oracles(&passed);
+        Observation::delivered(passed, Evidence::default())
+    });
+}
+
+fn window_state(driver: &mut McpDriver, target: TargetWindow) -> cua_driver_testkit::ToolResponse {
+    let response = driver.call(
+        "get_window_state",
+        serde_json::json!({
+            "pid": target.pid,
+            "window_id": target.native_id,
+            "capture_mode": "ax"
+        }),
+    );
+    assert!(
+        !response.is_error(),
+        "window snapshot failed: {}",
+        response.text()
+    );
+    response
+}
+
+fn wait_for_window_text(
+    driver: &mut McpDriver,
+    target: TargetWindow,
+    expected: &str,
+) -> cua_driver_testkit::ToolResponse {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let state = window_state(driver, target);
+        if state.tree_text().contains(expected) {
+            return state;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "window state did not contain {expected:?}: {}",
+            state.tree_text()
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
 }
 
 fn assert_required_background_oracles(passed: &[OracleKind]) {
@@ -139,5 +340,112 @@ fn assert_required_background_oracles(passed: &[OracleKind]) {
             passed.contains(&required),
             "agent cursor test omitted required {required:?} oracle"
         );
+    }
+}
+
+fn launch_normal_window(driver: &mut McpDriver, label: &str) -> (tempfile::TempDir, TargetWindow) {
+    let executable = harness_app("harness-electron", "CuaTestHarness.Electron.exe");
+    assert!(
+        executable.exists(),
+        "Electron harness missing at {}; run the Windows harness build first",
+        executable.display()
+    );
+    let profile = tempfile::Builder::new()
+        .prefix(&format!("cua-agent-cursor-{label}-"))
+        .tempdir()
+        .expect("create Electron profile");
+    let port = TcpListener::bind(("127.0.0.1", 0))
+        .and_then(|listener| listener.local_addr())
+        .expect("allocate Electron CDP port")
+        .port();
+    let mut command = Command::new(executable);
+    command
+        .env("CUA_ELECTRON_CDP_PORT", port.to_string())
+        .env("CUA_E2E_USER_DATA_DIR", profile.path())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let child = spawn_in_job(&mut command).expect("launch ordinary Electron harness window");
+    let pid = child.id();
+    driver.reaper().push(child);
+    let (native_id, _) = driver
+        .find_window(pid as i64, "CuaTestHarness Electron")
+        .expect("ordinary Electron harness window did not appear");
+    (profile, TargetWindow { pid, native_id })
+}
+
+fn bring_to_front(driver: &mut McpDriver, target: TargetWindow) {
+    let response = driver.call(
+        "bring_to_front",
+        serde_json::json!({"pid": target.pid, "window_id": target.native_id}),
+    );
+    assert!(
+        !response.is_error(),
+        "bring_to_front failed: {}",
+        response.text()
+    );
+    wait_until(Duration::from_secs(2), || unsafe {
+        GetForegroundWindow().0 as u64 == target.native_id
+    });
+}
+
+fn wait_for_overlay() -> HWND {
+    let class_name: Vec<u16> = OsStr::new("Cua.AgentCursorOverlay\0")
+        .encode_wide()
+        .collect();
+    let mut overlay = HWND::default();
+    wait_until(Duration::from_secs(2), || {
+        overlay =
+            unsafe { FindWindowW(PCWSTR(class_name.as_ptr()), PCWSTR::null()) }.unwrap_or_default();
+        !overlay.0.is_null()
+    });
+    overlay
+}
+
+fn window_center(window_id: u64) -> (f64, f64) {
+    let mut rect = RECT::default();
+    unsafe { GetWindowRect(HWND(window_id as *mut _), &mut rect) }
+        .expect("read ordinary foreground window bounds");
+    (
+        f64::from(rect.left + (rect.right - rect.left) / 2),
+        f64::from(rect.top + (rect.bottom - rect.top) / 2),
+    )
+}
+
+fn real_cursor_position() -> (i32, i32) {
+    let mut point = POINT::default();
+    unsafe { GetCursorPos(&mut point) }.expect("read real cursor position");
+    (point.x, point.y)
+}
+
+fn assert_not_topmost(window: HWND) {
+    let ex_style = unsafe { GetWindowLongPtrW(window, GWL_EXSTYLE) } as u32;
+    assert_eq!(
+        ex_style & WS_EX_TOPMOST.0,
+        0,
+        "agent cursor overlay remained persistently topmost"
+    );
+}
+
+fn window_is_above(upper: HWND, lower: HWND) -> bool {
+    let mut cursor = lower;
+    loop {
+        cursor = unsafe { GetWindow(cursor, GW_HWNDPREV) }.unwrap_or_default();
+        if cursor.0.is_null() {
+            return false;
+        }
+        if cursor == upper {
+            return true;
+        }
+    }
+}
+
+fn wait_until(timeout: Duration, mut predicate: impl FnMut() -> bool) {
+    let deadline = Instant::now() + timeout;
+    while !predicate() {
+        assert!(
+            Instant::now() < deadline,
+            "condition timed out after {timeout:?}"
+        );
+        std::thread::sleep(Duration::from_millis(25));
     }
 }

--- a/libs/cua-driver/rust/crates/cua-driver/tests/agent_cursor_windows_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/agent_cursor_windows_test.rs
@@ -132,6 +132,19 @@ fn agent_cursor_overlay_obeys_untargeted_and_targeted_z_order() {
             "agent cursor not visible at ({x:.0},{y:.0}): only {visible_pixels} qualifying pixels"
         );
 
+        // Capture the target while it is still foreground. Electron may prune
+        // parts of its UIA tree once another full-size window covers it, but
+        // the snapshot remains a stable handle for the later background click.
+        let target_state = window_state(&mut driver, target);
+        let button_index = ax::element_index_by_id(target_state.tree_text(), "btn-increment")
+            .unwrap_or_else(|| {
+                panic!(
+                    "target increment button missing from foreground UIA snapshot: {}",
+                    target_state.tree_text()
+                )
+            });
+        assert!(target_state.tree_text().contains("counter=0"));
+
         // A targeted cursor remains exactly above its target while an
         // independent ordinary foreground window stays above both. This
         // guards the pre-existing PinAbove semantics while exercising the new
@@ -145,24 +158,6 @@ fn agent_cursor_overlay_obeys_untargeted_and_targeted_z_order() {
             ),
             "independent foreground window did not cover target"
         );
-        let target_state = driver.call(
-            "get_window_state",
-            serde_json::json!({
-                "pid": target.pid,
-                "window_id": target.native_id,
-                "capture_mode": "ax"
-            }),
-        );
-        assert!(
-            !target_state.is_error(),
-            "target snapshot failed: {}",
-            target_state.text()
-        );
-        let button_index = ax::element_index_by_id(target_state.tree_text(), "btn-increment")
-            .expect("target increment button missing from UIA snapshot");
-        assert!(target_state.tree_text().contains("counter=0"));
-        let foreground_state_before = window_state(&mut driver, foreground);
-        assert!(foreground_state_before.tree_text().contains("counter=0"));
         let targeted = driver.call(
             "click",
             serde_json::json!({

--- a/libs/cua-driver/rust/crates/cua-driver/tests/agent_cursor_windows_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/agent_cursor_windows_test.rs
@@ -135,7 +135,7 @@ fn agent_cursor_overlay_obeys_untargeted_and_targeted_z_order() {
         // Capture the target while it is still foreground. Electron may prune
         // parts of its UIA tree once another full-size window covers it, but
         // the snapshot remains a stable handle for the later background click.
-        let target_state = window_state(&mut driver, target);
+        let target_state = wait_for_window_text(&mut driver, target, "btn-increment");
         let button_index = ax::element_index_by_id(target_state.tree_text(), "btn-increment")
             .unwrap_or_else(|| {
                 panic!(

--- a/libs/cua-driver/rust/crates/cua-driver/tests/agent_cursor_windows_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/agent_cursor_windows_test.rs
@@ -72,7 +72,6 @@ fn agent_cursor_overlay_obeys_untargeted_and_targeted_z_order() {
                 serde_json::json!({
                     "x": x,
                     "y": y,
-                    "scope": "desktop",
                     "cursor_id": cursor_id
                 }),
             ),
@@ -276,7 +275,6 @@ fn agent_cursor_move_does_not_leak_input() {
                         serde_json::json!({
                             "x": x,
                             "y": y,
-                            "scope": "desktop",
                             "cursor_id": cursor_id
                         }),
                     ),

--- a/libs/cua-driver/rust/crates/cua-driver/tests/agent_cursor_windows_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/agent_cursor_windows_test.rs
@@ -42,8 +42,8 @@ fn agent_cursor_overlay_obeys_untargeted_and_targeted_z_order() {
         ],
     );
     execute_case(case, |evidence| {
-        let mut driver = McpDriver::spawn_named("windows-desktop-agent-cursor-px")
-            .expect("required source-built driver did not start");
+        let mut driver = McpDriver::spawn_named_with_overlay("windows-desktop-agent-cursor-px")
+            .expect("required source-built driver with cursor overlay did not start");
         *evidence = recording_evidence(driver.recording_dir());
         let (_target_profile, target) = launch_normal_window(&mut driver, "target");
         bring_to_front(&mut driver, target);
@@ -191,10 +191,14 @@ fn agent_cursor_overlay_obeys_untargeted_and_targeted_z_order() {
             "targeted click leaked into the independent foreground window: {}",
             foreground_state_after.tree_text()
         );
-        wait_until(Duration::from_secs(2), || {
-            window_is_above(overlay, HWND(target.native_id as *mut _))
-                && window_is_above(HWND(foreground.native_id as *mut _), overlay)
-        });
+        wait_until(
+            Duration::from_secs(2),
+            "target-bound overlay z-order",
+            || {
+                window_is_above(overlay, HWND(target.native_id as *mut _))
+                    && window_is_above(HWND(foreground.native_id as *mut _), overlay)
+            },
+        );
         assert_eq!(
             unsafe { GetForegroundWindow().0 as u64 },
             foreground.native_id,
@@ -241,8 +245,9 @@ fn agent_cursor_move_does_not_leak_input() {
         ],
     );
     execute_case(case, |evidence| {
-        let mut driver = McpDriver::spawn_named("windows-desktop-agent-cursor-no-input-leak")
-            .expect("required source-built driver did not start");
+        let mut driver =
+            McpDriver::spawn_named_with_overlay("windows-desktop-agent-cursor-no-input-leak")
+                .expect("required source-built driver with cursor overlay did not start");
         *evidence = recording_evidence(driver.recording_dir());
         let sentinel = ForegroundSentinel::launch(&mut driver);
         driver.start_behavior_recording();
@@ -381,9 +386,11 @@ fn bring_to_front(driver: &mut McpDriver, target: TargetWindow) {
         "bring_to_front failed: {}",
         response.text()
     );
-    wait_until(Duration::from_secs(2), || unsafe {
-        GetForegroundWindow().0 as u64 == target.native_id
-    });
+    wait_until(
+        Duration::from_secs(2),
+        "ordinary window foreground",
+        || unsafe { GetForegroundWindow().0 as u64 == target.native_id },
+    );
 }
 
 fn wait_for_overlay() -> HWND {
@@ -391,11 +398,15 @@ fn wait_for_overlay() -> HWND {
         .encode_wide()
         .collect();
     let mut overlay = HWND::default();
-    wait_until(Duration::from_secs(2), || {
-        overlay =
-            unsafe { FindWindowW(PCWSTR(class_name.as_ptr()), PCWSTR::null()) }.unwrap_or_default();
-        !overlay.0.is_null()
-    });
+    wait_until(
+        Duration::from_secs(2),
+        "agent cursor overlay window",
+        || {
+            overlay = unsafe { FindWindowW(PCWSTR(class_name.as_ptr()), PCWSTR::null()) }
+                .unwrap_or_default();
+            !overlay.0.is_null()
+        },
+    );
     overlay
 }
 
@@ -437,12 +448,12 @@ fn window_is_above(upper: HWND, lower: HWND) -> bool {
     }
 }
 
-fn wait_until(timeout: Duration, mut predicate: impl FnMut() -> bool) {
+fn wait_until(timeout: Duration, description: &str, mut predicate: impl FnMut() -> bool) {
     let deadline = Instant::now() + timeout;
     while !predicate() {
         assert!(
             Instant::now() < deadline,
-            "condition timed out after {timeout:?}"
+            "timed out after {timeout:?} waiting for {description}"
         );
         std::thread::sleep(Duration::from_millis(25));
     }

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/z_order.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/z_order.rs
@@ -17,9 +17,11 @@
 //!   currently above the target, the overlay must appear **below** it so
 //!   the user's foreground keeps rendering on top of the synthetic cursor.
 //!
-//! - `target = None` — the overlay must sit at the top of the **non-topmost**
-//!   band. It must never be promoted into the OS "always-on-top" band
-//!   (`HWND_TOPMOST`, `NSStatusWindowLevel`, override-redirect raise).
+//! - `target = None` — the overlay must reliably sit at the top of the
+//!   **non-topmost** band. It must never remain persistently promoted into the
+//!   OS "always-on-top" band. A platform may use a non-activating transient
+//!   transition through that band when required to defeat a foreground lock,
+//!   provided the operation ends in the ordinary band.
 //!
 //! - `wid` no longer maps to a live window — fall back to the `None`
 //!   behaviour for this tick. Do not error; the next tick may have a

--- a/libs/cua-driver/rust/crates/platform-windows/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/overlay.rs
@@ -1362,6 +1362,20 @@ struct WinZOrderEnforcer {
     hwnd_isize: isize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WinZOrderPlacement {
+    AboveTarget,
+    ForceFrontNonTopmost,
+}
+
+fn win_z_order_placement(has_live_target: bool) -> WinZOrderPlacement {
+    if has_live_target {
+        WinZOrderPlacement::AboveTarget
+    } else {
+        WinZOrderPlacement::ForceFrontNonTopmost
+    }
+}
+
 /// Of the given window ids, return the one highest in the current z-order (the
 /// first encountered walking top→bottom), or `None` if none are present. Used to
 /// pick the single window the overlay should pin just above so it covers every
@@ -1426,39 +1440,55 @@ impl ZOrderEnforcer for WinZOrderEnforcer {
             //      pitfall macOS / Linux dodge by virtue of their explicit
             //      `orderWindow:above:` / `StackMode::ABOVE` APIs.
             //
-            // Fallback when there's no live pin: HWND_TOP — top of non-topmost
-            // band, NOT the topmost band. So a "no pin" overlay still respects
-            // the user's foreground stack.
-            let _ = SetWindowPos(
-                hwnd,
-                HWND_NOTOPMOST,
-                0,
-                0,
-                0,
-                0,
-                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOOWNERZORDER,
-            );
-
-            let insert_after = match pinned_target {
-                Some(target) => {
+            match (
+                win_z_order_placement(pinned_target.is_some()),
+                pinned_target,
+            ) {
+                (WinZOrderPlacement::AboveTarget, Some(target)) => {
+                    // Preserve the target-bound contract: normalize out of the
+                    // topmost band, then insert exactly one slot above target.
+                    let _ = SetWindowPos(
+                        hwnd,
+                        HWND_NOTOPMOST,
+                        0,
+                        0,
+                        0,
+                        0,
+                        SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOOWNERZORDER,
+                    );
                     let prev = GetWindow(target, GW_HWNDPREV).unwrap_or(HWND(std::ptr::null_mut()));
-                    if !prev.0.is_null() {
-                        prev
-                    } else {
-                        HWND_TOP
-                    }
+                    let insert_after = if !prev.0.is_null() { prev } else { HWND_TOP };
+                    let _ = SetWindowPos(
+                        hwnd,
+                        insert_after,
+                        0,
+                        0,
+                        0,
+                        0,
+                        SWP_NOMOVE
+                            | SWP_NOSIZE
+                            | SWP_NOACTIVATE
+                            | SWP_SHOWWINDOW
+                            | SWP_NOOWNERZORDER,
+                    );
                 }
-                None => HWND_TOP,
-            };
-            let _ = SetWindowPos(
-                hwnd,
-                insert_after,
-                0,
-                0,
-                0,
-                0,
-                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW | SWP_NOOWNERZORDER,
-            );
+                (WinZOrderPlacement::ForceFrontNonTopmost, None) => {
+                    // HWND_TOP is subject to the foreground lock and can leave
+                    // the overlay in a stale ordinary-band slot. A temporary
+                    // topmost transition is lock-free; immediately demoting it
+                    // lands at the reliable front of the ordinary band. Both
+                    // calls are non-activating, and the final state is never
+                    // persistent topmost.
+                    let flags = SWP_NOMOVE
+                        | SWP_NOSIZE
+                        | SWP_NOACTIVATE
+                        | SWP_SHOWWINDOW
+                        | SWP_NOOWNERZORDER;
+                    let _ = SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, flags);
+                    let _ = SetWindowPos(hwnd, HWND_NOTOPMOST, 0, 0, 0, 0, flags);
+                }
+                _ => unreachable!("z-order placement must match target liveness"),
+            }
 
             let _ = target;
         }
@@ -1480,6 +1510,15 @@ mod tests {
     fn keyed_render_state_carries_the_session_color_identity() {
         let state = render_state_for_key(&CursorConfig::default(), "session-blueprint");
         assert_eq!(state.core.cfg.cursor_id, "session-blueprint");
+    }
+
+    #[test]
+    fn windows_z_order_branch_tracks_live_target_presence() {
+        assert_eq!(win_z_order_placement(true), WinZOrderPlacement::AboveTarget);
+        assert_eq!(
+            win_z_order_placement(false),
+            WinZOrderPlacement::ForceFrontNonTopmost
+        );
     }
 
     fn empty_map() -> RenderMap {


### PR DESCRIPTION
## Summary

- make the un-targeted Windows cursor overlay reliably reach the front of the ordinary z-order band with a non-activating transient `HWND_TOPMOST` → `HWND_NOTOPMOST` transition
- preserve target-bound placement exactly between the target and an independent foreground window
- add a pure branch-selection regression plus hosted Windows coverage for move-only visibility, final non-topmost state, unchanged focus and real cursor, targeted effect isolation, and the existing no-leaked-input oracle

Fixes #2802

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p platform-windows --lib` — 41 passed
- `cargo test -p cursor-overlay --lib` — 42 passed
- `cargo test -p cua-driver --test agent_cursor_windows_test` — compiles on the local non-Windows host; 0 Windows-gated tests run
- `cargo check --target x86_64-pc-windows-msvc -p cua-driver --test agent_cursor_windows_test` — local cross-check cannot complete because the macOS host lacks Windows SDK/MSVC C headers required by transitive native dependencies; the canonical interactive Windows lane is the authoritative compile and behavior gate

## Hosted Windows certification

- exact source: `4f1e63bbfbd7b22ac16c2d0559f6a4934e32d2ba`
- canonical native-lane dispatch: https://github.com/trycua/cua/actions/runs/30965712916
- `windows-desktop-agent-cursor-px` — PASS (Pixels, Focus, ZOrder, Cursor); proves visible un-targeted overlay at the top of the ordinary band, final non-topmost state, unchanged foreground and physical pointer, then target-bound placement between the WPF target and an independent Electron foreground window with target counter effect and no foreground leak
- `windows-desktop-agent-cursor-no-input-leak` — PASS (Focus, ZOrder, Cursor, NoLeakedInput)
- the cursor test binary completed `2 passed; 0 failed`
- downloaded `results.jsonl` SHA-256: `7ee13e3ea9dbfbade0be1303d440a657d724a27054cad72da295d1ac5e98123c`
- downloaded `summary.md` SHA-256: `6d980c825c05c3a0bf3288f84d797e5f8c1e107066b1b76d43cfb9fb946c5dba`

The native lane's only failing cell was the unrelated existing `windows-webview2-left-click-px-background`: UIA desktop enumeration exceeded its 2-second deadline and the action fell back to `global_input` while that cell expected `accessibility`. That cell passed in the two preceding exact-head native runs ([30963333853](https://github.com/trycua/cua/actions/runs/30963333853) and [30964551564](https://github.com/trycua/cua/actions/runs/30964551564)); the final-head change only replaces the cursor test's target fixture. All 41 other final-run matrix cells, including both cursor cells, passed or produced their expected refusal.

Standard PR checks are green, including the bounded Nix unit-test retry. The installer compatibility summary was still queued at the time this evidence was attached.

This PR remains draft for final audit; it has not been graduated or merged.
