### PR TITLE
test(cua-driver): diagnose embedded early-exit status

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/tests/embedded_host_sdk_mcp_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/embedded_host_sdk_mcp_test.rs
@@ -301,10 +301,19 @@ async fn early_child_exit_resets_the_host_to_stopped() {
         "com.trycua.embedded-early-exit-test".into(),
     )
     .expect("construct host");
-    let error = host.clone().start().await.unwrap_err();
-    assert!(matches!(
-        error,
-        cua_driver_sdk::EmbeddedDriverError::ExitedBeforeReady { code: Some(7) }
-    ));
-    assert_eq!(host.state(), EmbeddedDriverHostState::Stopped);
+    for attempt in 1..=64 {
+        let error = host.clone().start().await.unwrap_err();
+        assert!(
+            matches!(
+                &error,
+                cua_driver_sdk::EmbeddedDriverError::ExitedBeforeReady { code: Some(7) }
+            ),
+            "attempt {attempt}/64 returned {error:?}"
+        );
+        assert_eq!(
+            host.state(),
+            EmbeddedDriverHostState::Stopped,
+            "attempt {attempt}/64 did not reset the host after {error:?}"
+        );
+    }
 }


### PR DESCRIPTION
Refs #2466

## Summary

- stress the embedded host's early-child-exit lifecycle across 64 consecutive starts
- preserve the contract that every exit reports `ExitedBeforeReady { code: Some(7) }` and resets the host to `Stopped`
- print the exact attempt and `EmbeddedDriverError` variant/status if that contract fails again

## Diagnosis

The assertion failed without diagnostics in Nix Rust-unit jobs [89041306283](https://github.com/trycua/cua/actions/runs/29954863446/job/89041306283) and [92193065879](https://github.com/trycua/cua/actions/runs/30970330922/job/92193065879). Both failures happened within milliseconds, before a readiness timeout was possible, and both failed the returned variant/status assertion rather than the subsequent `Stopped` assertion.

The older July revision still used a hard-coded `/bin/sh` fixture; the portable shell resolver added later removed that known Nix hazard. The August recurrence already contained that resolver, so the old logs do not preserve enough evidence to infer its actual returned variant safely.

Issue #2466 intentionally remains open: the strengthened test passed under Linux and Nix stress, so this draft adds the missing evidence for a future recurrence without claiming an unverified production fix.

## Validation

- `cargo fmt --manifest-path libs/cua-driver/rust/Cargo.toml --all -- --check`
- `git diff --check`
- [Linux Rust unit and compile](https://github.com/trycua/cua/actions/runs/30972040666/job/92198291878): 64 early-exit starts passed in 3.31s
- [Nix Rust unit tests](https://github.com/trycua/cua/actions/runs/30972040658/job/92198291861): 64 early-exit starts passed in 3.31s
- all standard pull-request checks passed at `933b27cf5e7f984bdc9c2d8d7685bed6e35ea444`
