### PR TITLE
cua-sandbox: Lease API for durable claim lifecycles + configurable Fleet request timeout

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/__init__.py
+++ b/libs/python/cua-sandbox/cua_sandbox/__init__.py
@@ -22,7 +22,7 @@ from cua_sandbox._auth import login, whoami
 from cua_sandbox._config import configure
 from cua_sandbox.image import Image
 from cua_sandbox.localhost import Localhost, localhost
-from cua_sandbox.pool import Pool, Template
+from cua_sandbox.pool import Lease, Pool, Template, supports_claim_renewal
 from cua_sandbox.runtime.compat import (
     RuntimeSupport,
     check_local_support,
@@ -54,7 +54,9 @@ __all__ = [
     "login",
     "whoami",
     "Image",
+    "Lease",
     "Pool",
+    "supports_claim_renewal",
     "Template",
     "TemplateResource",
     "CreatePoolRequest",

--- a/libs/python/cua-sandbox/cua_sandbox/__init__.py
+++ b/libs/python/cua-sandbox/cua_sandbox/__init__.py
@@ -31,12 +31,14 @@ from cua_sandbox.runtime.compat import (
 from cua_sandbox.sandbox import Sandbox, SandboxInfo, sandbox
 from cua_sandbox.transport.cloud import CloudTransport
 from fleet_sdk import (
+    ClaimLifecycle,
     ClaimSpec,
     CreatePoolRequest,
     CreateTemplateRequest,
     Firmware,
     OsGymSandboxTemplateSpec,
     OsGymSandboxWarmPoolSpec,
+    PreservedJson,
     RuntimeKind,
     SandboxService,
     SandboxTemplateRef,
@@ -57,7 +59,9 @@ __all__ = [
     "TemplateResource",
     "CreatePoolRequest",
     "CreateTemplateRequest",
+    "ClaimLifecycle",
     "ClaimSpec",
+    "PreservedJson",
     "SandboxTemplateRef",
     "OsGymSandboxWarmPoolSpec",
     "OsGymSandboxTemplateSpec",

--- a/libs/python/cua-sandbox/cua_sandbox/_config.py
+++ b/libs/python/cua-sandbox/cua_sandbox/_config.py
@@ -9,6 +9,7 @@ from typing import Optional
 _DEFAULT_BASE_URL = "https://api.cua.ai"
 _DEFAULT_FLEET_BASE_URL = "https://run.cua.ai"
 _DEFAULT_TOKEN_URL = "https://auth.cua.ai/realms/cyclops-cs/protocol/openid-connect/token"
+_DEFAULT_FLEET_REQUEST_TIMEOUT = 30.0
 
 
 @dataclass
@@ -19,6 +20,7 @@ class _Config:
     token_url: str = _DEFAULT_TOKEN_URL
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
+    fleet_request_timeout: Optional[float] = None
 
 
 _global_config = _Config()
@@ -32,11 +34,15 @@ def configure(
     token_url: Optional[str] = None,
     client_id: Optional[str] = None,
     client_secret: Optional[str] = None,
+    fleet_request_timeout: Optional[float] = None,
 ) -> None:
     """Set global configuration for cloud sandboxes.
 
     API-key cloud operations use ``base_url``. Fleet uses ``fleet_base_url`` and
-    OAuth client credentials.
+    OAuth client credentials. ``fleet_request_timeout`` is the per-request HTTP
+    timeout (seconds) for Fleet control-plane and ``services.request`` calls;
+    raise it when routing long-blocking service calls (e.g. an MCP ``tools/call``
+    that only answers once the tool finishes) through a claimed sandbox.
     """
     if api_key is not None:
         _global_config.api_key = api_key
@@ -50,6 +56,8 @@ def configure(
         _global_config.client_id = client_id
     if client_secret is not None:
         _global_config.client_secret = client_secret
+    if fleet_request_timeout is not None:
+        _global_config.fleet_request_timeout = fleet_request_timeout
 
 
 def get_api_key(override: Optional[str] = None) -> Optional[str]:
@@ -75,6 +83,21 @@ def get_fleet_base_url() -> str:
 
 def get_token_url() -> str:
     return os.environ.get("CUA_TOKEN_URL") or _global_config.token_url
+
+
+def get_fleet_request_timeout() -> float:
+    """Per-request HTTP timeout (seconds) for Fleet calls.
+
+    Precedence mirrors ``get_fleet_base_url``: the ``CUA_FLEET_REQUEST_TIMEOUT``
+    environment variable wins over ``configure(fleet_request_timeout=...)``,
+    which wins over the 30-second default.
+    """
+    env_value = os.environ.get("CUA_FLEET_REQUEST_TIMEOUT")
+    if env_value:
+        return float(env_value)
+    if _global_config.fleet_request_timeout is not None:
+        return _global_config.fleet_request_timeout
+    return _DEFAULT_FLEET_REQUEST_TIMEOUT
 
 
 def get_client_id(override: Optional[str] = None) -> Optional[str]:

--- a/libs/python/cua-sandbox/cua_sandbox/pool.py
+++ b/libs/python/cua-sandbox/cua_sandbox/pool.py
@@ -1,4 +1,11 @@
-"""Fleet template and pool APIs for reusable cloud sandboxes."""
+"""Fleet template, pool, and lease APIs for reusable cloud sandboxes.
+
+Two claim styles live here. :meth:`Pool.claim` is scope-bound: an ``async
+with`` block leases a sandbox and releases it on exit, which suits scripts and
+notebooks. :meth:`Pool.create_claim` returns a :class:`Lease` — a serializable
+claim reference whose wait/renew/release steps are explicit, for durable
+orchestrators whose claim outlives any single process scope.
+"""
 
 from __future__ import annotations
 
@@ -11,13 +18,31 @@ from cua_sandbox.sandbox import Sandbox
 from cua_sandbox.transport.fleet import FleetTransport
 from cua_sandbox.transport.fleet_cloud import _FleetClient
 from fleet_sdk import (
+    Claim,
     ClaimSpec,
     CreateClaimRequest,
     CreatePoolRequest,
     CreateTemplateRequest,
+    CyclopsClient,
+    ResourceMetadata,
+)
+from fleet_sdk import Sandbox as FleetSandbox
+from fleet_sdk import (
+    SandboxTemplateRef,
 )
 
 logger = logging.getLogger(__name__)
+
+
+def supports_claim_renewal() -> bool:
+    """Whether the installed cua-fleet release can push a claim lease forward.
+
+    ``Lease.renew`` needs ``CyclopsClient.renew_claim``, which older cua-fleet
+    wheels do not ship. Callers that hold a claim beyond one lease should check
+    this once and, when it is False, size the claim's initial
+    ``lifecycle.shutdownTime`` to cover the whole hold instead of renewing.
+    """
+    return hasattr(CyclopsClient, "renew_claim")
 
 
 class Template:
@@ -63,6 +88,136 @@ class Template:
             await client.close()
 
 
+def _claim_stub(namespace: str, name: str) -> Claim:
+    """A minimal Claim carrying only its identity.
+
+    get/delete/renew/wait address a claim purely by metadata (namespace +
+    name), so a reference reconstructed from serialized state needs no spec
+    content — the placeholder template ref is never sent anywhere.
+    """
+    return Claim(
+        api_version="osgym.cua.ai/v1alpha1",
+        kind="OSGymSandboxClaim",
+        metadata=ResourceMetadata(namespace=namespace, name=name, labels=None),
+        spec=ClaimSpec(
+            sandbox_template_ref=SandboxTemplateRef(name=""),
+            warmpool=None,
+            bind_deadline=None,
+            lifecycle=None,
+        ),
+        status=None,
+    )
+
+
+class Lease:
+    """A held Fleet sandbox claim with an explicit, serializable lifecycle.
+
+    :meth:`Pool.claim` scopes a lease to one ``async with`` block — claim and
+    release are welded to a single Python scope, which suits scripts. A Lease
+    instead carries the claim *by reference* (namespace + claim name, plus the
+    bound sandbox record once known), so a durable orchestrator — a Temporal
+    workflow, a queue worker — can create the claim in one process, reattach
+    from serialized state in another, renew periodically, and release from a
+    third. ``to_dict``/``from_dict`` round-trip plain JSON-safe data.
+
+    Nothing is released automatically: the holder owns calling
+    :meth:`release`. Guard against holders that die without releasing by
+    setting ``lifecycle.shutdownTime`` on the claim spec (the pool operator's
+    reaper deletes Bound claims whose deadline passed) and, for holds longer
+    than one lease, pushing it forward with :meth:`renew` — available when
+    :func:`supports_claim_renewal` is true.
+
+    Each method opens and closes its own Fleet client, except :meth:`wait`,
+    whose returned :class:`Sandbox` keeps its client until ``disconnect``.
+    """
+
+    def __init__(self, *, namespace: str, name: str, bound: Any = None) -> None:
+        self._namespace = namespace
+        self._name = name
+        self._bound = bound
+
+    @property
+    def namespace(self) -> str:
+        """The pool namespace the claim lives in."""
+        return self._namespace
+
+    @property
+    def name(self) -> str:
+        """The claim name."""
+        return self._name
+
+    def to_dict(self) -> dict:
+        """JSON-safe reference to this lease, including the bound sandbox
+        record once :meth:`wait` has observed the bind."""
+        data: dict = {"namespace": self._namespace, "name": self._name}
+        if self._bound is not None:
+            data["sandbox"] = {
+                "namespace": self._bound.namespace,
+                "claim": self._bound.claim,
+                "name": self._bound.name,
+                "services": list(self._bound.services),
+            }
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Lease":
+        """Rebuild a lease reference produced by :meth:`to_dict`."""
+        bound = data.get("sandbox")
+        return cls(
+            namespace=data["namespace"],
+            name=data["name"],
+            bound=FleetSandbox(**bound) if bound else None,
+        )
+
+    async def wait(self, *, service: str = "server") -> Sandbox:
+        """Wait for the claim to bind and return a connected :class:`Sandbox`.
+
+        When this lease already carries the bound sandbox record (a reattach
+        via :meth:`from_dict`), no polling happens — the transport connects
+        directly. ``service`` names the sandbox service the default transport
+        pins to; it must be declared by the claim's template. The returned
+        sandbox owns its Fleet client: ``await sandbox.disconnect()`` releases
+        the client's HTTP resources (the claim itself stays held).
+        """
+        client = _FleetClient()
+        try:
+            if self._bound is None:
+                self._bound = await client.wait_claim(_claim_stub(self._namespace, self._name))
+            sandbox = Sandbox(
+                FleetTransport(sdk=client, bound=self._bound, service_name=service, owns_sdk=True),
+                name=self._bound.name,
+            )
+            await sandbox._connect()
+            return sandbox
+        except BaseException:
+            await client.close()
+            raise
+
+    async def renew(self, shutdown_time: str) -> None:
+        """Push the claim's ``spec.lifecycle.shutdownTime`` forward.
+
+        ``shutdown_time`` is an absolute ISO-8601 UTC expiry. Requires a
+        cua-fleet release with ``CyclopsClient.renew_claim`` (see
+        :func:`supports_claim_renewal`); raises ``RuntimeError`` otherwise.
+        """
+        client = _FleetClient()
+        try:
+            await client.renew_claim(_claim_stub(self._namespace, self._name), shutdown_time)
+        finally:
+            await client.close()
+
+    async def release(self) -> None:
+        """Delete the claim, returning the sandbox to the pool.
+
+        Idempotent: releasing an already-deleted (or reaped) claim succeeds.
+        """
+        client = _FleetClient()
+        try:
+            await client.delete_claim(_claim_stub(self._namespace, self._name))
+        finally:
+            await client.close()
+
+
 class Pool:
     """A reconciled Fleet pool that can lease cloud sandboxes.
 
@@ -104,6 +259,36 @@ class Pool:
         client = _FleetClient()
         try:
             return cls(await client.reconcile_pool(request))
+        finally:
+            await client.close()
+
+    @classmethod
+    async def get(cls, name: str) -> "Pool":
+        """Fetch an existing Fleet pool by name without changing its spec.
+
+        Use this when the pool was reconciled elsewhere and the caller only
+        needs a handle to claim against — :meth:`reconcile` would PATCH the
+        spec, :meth:`get` never writes.
+        """
+        client = _FleetClient()
+        try:
+            return cls(await client.get_pool(name))
+        finally:
+            await client.close()
+
+    async def create_claim(self, *, spec: ClaimSpec | None = None) -> Lease:
+        """Create a claim against this pool and return it as a :class:`Lease`.
+
+        The claim is created and left held — nothing waits for the bind and
+        nothing releases on scope exit; the returned lease's ``wait``/
+        ``release`` drive the rest of the lifecycle explicitly, possibly from
+        other processes via ``Lease.to_dict``/``from_dict``. Prefer
+        :meth:`claim` when a single ``async with`` scope fits the caller.
+        """
+        client = _FleetClient()
+        try:
+            claim = await client.create_claim(CreateClaimRequest(pool=self._resource, spec=spec))
+            return Lease(namespace=claim.metadata.namespace, name=claim.metadata.name)
         finally:
             await client.close()
 

--- a/libs/python/cua-sandbox/cua_sandbox/pool.py
+++ b/libs/python/cua-sandbox/cua_sandbox/pool.py
@@ -276,7 +276,9 @@ class Pool:
         finally:
             await client.close()
 
-    async def create_claim(self, *, spec: ClaimSpec | None = None, name: str | None = None) -> Lease:
+    async def create_claim(
+        self, *, spec: ClaimSpec | None = None, name: str | None = None
+    ) -> Lease:
         """Create a claim against this pool and return it as a :class:`Lease`.
 
         The claim is created and left held — nothing waits for the bind and

--- a/libs/python/cua-sandbox/cua_sandbox/pool.py
+++ b/libs/python/cua-sandbox/cua_sandbox/pool.py
@@ -276,7 +276,7 @@ class Pool:
         finally:
             await client.close()
 
-    async def create_claim(self, *, spec: ClaimSpec | None = None) -> Lease:
+    async def create_claim(self, *, spec: ClaimSpec | None = None, name: str | None = None) -> Lease:
         """Create a claim against this pool and return it as a :class:`Lease`.
 
         The claim is created and left held — nothing waits for the bind and
@@ -284,10 +284,27 @@ class Pool:
         ``release`` drive the rest of the lifecycle explicitly, possibly from
         other processes via ``Lease.to_dict``/``from_dict``. Prefer
         :meth:`claim` when a single ``async with`` scope fits the caller.
+
+        A client-supplied ``name`` is used verbatim as the claim name; left
+        unset, the client generates a random ``claim-<petname>`` so concurrent
+        leases and retries cannot collide. Explicit names need a cua-fleet
+        release whose ``CreateClaimRequest`` carries a name field; older wheels
+        raise ``RuntimeError`` with an upgrade pointer.
         """
+        if name is None:
+            request = CreateClaimRequest(pool=self._resource, spec=spec)
+        else:
+            try:
+                request = CreateClaimRequest(pool=self._resource, spec=spec, name=name)
+            except TypeError as error:
+                raise RuntimeError(
+                    "the installed cua-fleet release does not support client-supplied "
+                    "claim names; upgrade to a build whose CreateClaimRequest carries "
+                    "a name field"
+                ) from error
         client = _FleetClient()
         try:
-            claim = await client.create_claim(CreateClaimRequest(pool=self._resource, spec=spec))
+            claim = await client.create_claim(request)
             return Lease(namespace=claim.metadata.namespace, name=claim.metadata.name)
         finally:
             await client.close()

--- a/libs/python/cua-sandbox/cua_sandbox/transport/cyclops_http_client.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/cyclops_http_client.py
@@ -3,14 +3,22 @@
 from __future__ import annotations
 
 import httpx
+from cua_sandbox._config import get_fleet_request_timeout
 from fleet_sdk import HttpClient, HttpError, HttpHeader, HttpRequest, HttpResponse
 
 
 class CyclopsHttpClient(HttpClient):
-    """Execute SDK requests with one shared async httpx client."""
+    """Execute SDK requests with one shared async httpx client.
+
+    The default client's timeout comes from ``get_fleet_request_timeout()``
+    (env ``CUA_FLEET_REQUEST_TIMEOUT`` or ``configure(fleet_request_timeout=…)``,
+    30s otherwise) so callers routing long-blocking service requests — an MCP
+    ``tools/call`` answers only when the tool finishes — can widen it without
+    constructing and threading their own httpx client.
+    """
 
     def __init__(self, client: httpx.AsyncClient | None = None) -> None:
-        self._client = client or httpx.AsyncClient(timeout=30.0)
+        self._client = client or httpx.AsyncClient(timeout=get_fleet_request_timeout())
         self._owns_client = client is None
 
     async def execute(self, request: HttpRequest) -> HttpResponse:

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet.py
@@ -29,12 +29,14 @@ class FleetTransport(Transport):
         bound: Any,
         service_name: str = "api",
         timeout: float = 30.0,
+        owns_sdk: bool = False,
         **_: Any,
     ) -> None:
         self._sdk = sdk
         self._bound = bound
         self._service_name = service_name
         self._timeout = timeout
+        self._owns_sdk = owns_sdk
         self._connected = False
 
     async def connect(self) -> None:
@@ -44,6 +46,11 @@ class FleetTransport(Transport):
 
     async def disconnect(self) -> None:
         self._connected = False
+        # A transport constructed with owns_sdk=True (e.g. by Lease.wait) is the
+        # sole holder of its Fleet client, so disconnect is where that client's
+        # HTTP resources are returned.
+        if self._owns_sdk:
+            await self._sdk.close()
 
     async def request_service(
         self,

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -107,6 +107,15 @@ class _FleetClient:
     async def wait_claim(self, claim: Any) -> Any:
         return await self._client.wait_claim(claim)
 
+    async def renew_claim(self, claim: Any, shutdown_time: str) -> Any:
+        renew = getattr(self._client, "renew_claim", None)
+        if renew is None:
+            raise RuntimeError(
+                "the installed cua-fleet release does not support claim renewal; "
+                "upgrade to a build whose CyclopsClient exposes renew_claim"
+            )
+        return await renew(claim, shutdown_time)
+
     async def delete_claim(self, claim: Any) -> None:
         await self._client.delete_claim(claim)
 

--- a/libs/python/cua-sandbox/tests/test_config.py
+++ b/libs/python/cua-sandbox/tests/test_config.py
@@ -8,6 +8,7 @@ from cua_sandbox._config import (
     get_client_id,
     get_client_secret,
     get_fleet_base_url,
+    get_fleet_request_timeout,
     get_token_url,
 )
 
@@ -22,6 +23,7 @@ class TestConfig:
         )
         _global_config.client_id = None
         _global_config.client_secret = None
+        _global_config.fleet_request_timeout = None
 
     def test_configure_client_credentials_uses_fleet_defaults(self):
         configure(client_id="client-id", client_secret="client-secret")
@@ -54,3 +56,15 @@ class TestConfig:
         monkeypatch.setenv("CUA_API_KEY", "sk-env")
         configure(api_key="sk-configured")
         assert get_api_key() == "sk-configured"
+
+    def test_fleet_request_timeout_defaults_to_thirty_seconds(self):
+        assert get_fleet_request_timeout() == 30.0
+
+    def test_configure_fleet_request_timeout(self):
+        configure(fleet_request_timeout=600.0)
+        assert get_fleet_request_timeout() == 600.0
+
+    def test_fleet_request_timeout_env_overrides_configure(self, monkeypatch):
+        configure(fleet_request_timeout=600.0)
+        monkeypatch.setenv("CUA_FLEET_REQUEST_TIMEOUT", "120")
+        assert get_fleet_request_timeout() == 120.0

--- a/libs/python/cua-sandbox/tests/test_cyclops_http_client.py
+++ b/libs/python/cua-sandbox/tests/test_cyclops_http_client.py
@@ -1,0 +1,43 @@
+"""Unit tests for the httpx bridge behind the generated Cyclops SDK."""
+
+import httpx
+import pytest
+from cua_sandbox._config import _global_config, configure
+from cua_sandbox.transport.cyclops_http_client import CyclopsHttpClient
+
+
+@pytest.fixture(autouse=True)
+def _reset_fleet_request_timeout():
+    _global_config.fleet_request_timeout = None
+    yield
+    _global_config.fleet_request_timeout = None
+
+
+@pytest.mark.asyncio
+async def test_default_client_uses_default_fleet_request_timeout():
+    client = CyclopsHttpClient()
+    try:
+        assert client._client.timeout == httpx.Timeout(30.0)
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_default_client_honors_configured_fleet_request_timeout():
+    configure(fleet_request_timeout=600.0)
+    client = CyclopsHttpClient()
+    try:
+        assert client._client.timeout == httpx.Timeout(600.0)
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_injected_client_keeps_its_own_timeout():
+    configure(fleet_request_timeout=600.0)
+    injected = httpx.AsyncClient(timeout=5.0)
+    client = CyclopsHttpClient(injected)
+    try:
+        assert client._client.timeout == httpx.Timeout(5.0)
+    finally:
+        await injected.aclose()

--- a/libs/python/cua-sandbox/tests/test_pool.py
+++ b/libs/python/cua-sandbox/tests/test_pool.py
@@ -9,6 +9,7 @@ from cua_sandbox import (
     CreatePoolRequest,
     CreateTemplateRequest,
     Firmware,
+    Lease,
     OsGymSandboxTemplateSpec,
     OsGymSandboxWarmPoolSpec,
     Pool,
@@ -19,6 +20,7 @@ from cua_sandbox import (
     ServiceProtocol,
     Template,
     VmTemplate,
+    supports_claim_renewal,
 )
 from cua_sandbox.sync import Pool as SyncPool
 from cua_sandbox.sync import Template as SyncTemplate
@@ -111,6 +113,10 @@ def fleet_template(name: str = "foo") -> SimpleNamespace:
     )
 
 
+def fake_claim(namespace: str = "foo", name: str = "claim-1") -> SimpleNamespace:
+    return SimpleNamespace(metadata=SimpleNamespace(namespace=namespace, name=name))
+
+
 class FakeFleetClient:
     def __init__(
         self,
@@ -125,8 +131,10 @@ class FakeFleetClient:
         self.reconciled: list[object] = []
         self.reconciled_templates: list[object] = []
         self.claims: list[object] = []
-        self.released: list[object] = []
+        self.released: list[str] = []
+        self.renewed: list[tuple[str, str]] = []
         self.service_requests: list[object] = []
+        self.wait_calls = 0
         self.closed = False
 
     async def reconcile_pool(self, request: object) -> object:
@@ -141,12 +149,16 @@ class FakeFleetClient:
             raise self.reconcile_error
         return self.existing or fleet_template(request.name)
 
+    async def get_pool(self, name: str) -> object:
+        return self.existing or fleet_pool(name)
+
     async def create_claim(self, request: object) -> object:
         self.claims.append(request)
-        return "claim-1"
+        return fake_claim()
 
     async def wait_claim(self, claim: object) -> FleetSandbox:
-        assert claim == "claim-1"
+        assert claim.metadata.name == "claim-1"
+        self.wait_calls += 1
         return FleetSandbox(
             namespace="foo",
             claim="claim-1",
@@ -154,12 +166,16 @@ class FakeFleetClient:
             services=["server", "mcp"],
         )
 
+    async def renew_claim(self, claim: object, shutdown_time: str) -> object:
+        self.renewed.append((claim.metadata.name, shutdown_time))
+        return claim
+
     async def service_request(self, sandbox, service, path, request):
         self.service_requests.append((sandbox, service, path, request))
         return SimpleNamespace(status=200, headers=[], body=b'{"result":"ok"}')
 
     async def delete_claim(self, claim: object) -> None:
-        self.released.append(claim)
+        self.released.append(claim.metadata.name)
         if self.release_error:
             raise self.release_error
 
@@ -521,3 +537,161 @@ async def test_claim_without_spec_uses_operator_default(monkeypatch):
     assert request.spec is None
     assert claim_client.released == ["claim-1"]
     assert claim_client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_pool_get_fetches_without_reconciling(monkeypatch):
+    client = FakeFleetClient()
+    monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: client)
+
+    pool = await Pool.get("foo")
+
+    assert pool.name == "foo"
+    assert client.reconciled == []
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_create_claim_returns_a_serializable_lease(monkeypatch):
+    reconcile_client = FakeFleetClient()
+    claim_client = FakeFleetClient()
+    clients = iter([reconcile_client, claim_client])
+    monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: next(clients))
+    pool = await Pool.reconcile(pool_request())
+
+    lease = await pool.create_claim()
+
+    assert (lease.namespace, lease.name) == ("foo", "claim-1")
+    assert claim_client.claims[0].pool is pool.resource
+    assert claim_client.claims[0].spec is None
+    assert claim_client.released == []
+    assert claim_client.closed is True
+    assert lease.to_dict() == {"namespace": "foo", "name": "claim-1"}
+    assert Lease.from_dict(lease.to_dict()).to_dict() == lease.to_dict()
+
+
+@pytest.mark.asyncio
+async def test_lease_wait_connects_to_the_named_service_and_caches_the_bind(monkeypatch):
+    client = FakeFleetClient()
+    monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: client)
+    lease = Lease(namespace="foo", name="claim-1")
+
+    sandbox = await lease.wait(service="mcp")
+
+    assert sandbox.name == "sandbox-1"
+    assert client.wait_calls == 1
+    assert lease.to_dict()["sandbox"] == {
+        "namespace": "foo",
+        "claim": "claim-1",
+        "name": "sandbox-1",
+        "services": ["server", "mcp"],
+    }
+    response = await sandbox.services.request(
+        "mcp", method="POST", path="/mcp", json={"jsonrpc": "2.0", "id": 1}
+    )
+    assert response.status_code == 200
+    assert client.closed is False
+    await sandbox.disconnect()
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_lease_reattaches_from_serialized_state_without_polling(monkeypatch):
+    client = FakeFleetClient()
+    monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: client)
+    lease = Lease.from_dict(
+        {
+            "namespace": "foo",
+            "name": "claim-1",
+            "sandbox": {
+                "namespace": "foo",
+                "claim": "claim-1",
+                "name": "sandbox-1",
+                "services": ["server", "mcp"],
+            },
+        }
+    )
+
+    sandbox = await lease.wait(service="mcp")
+
+    assert sandbox.name == "sandbox-1"
+    assert client.wait_calls == 0
+    await sandbox.disconnect()
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_lease_wait_closes_its_client_when_the_bind_fails(monkeypatch):
+    client = FakeFleetClient()
+
+    async def failing_wait(claim):
+        raise RuntimeError("bind failed")
+
+    client.wait_claim = failing_wait
+    monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: client)
+
+    with pytest.raises(RuntimeError, match="bind failed"):
+        await Lease(namespace="foo", name="claim-1").wait()
+
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_lease_release_deletes_the_claim_by_reference(monkeypatch):
+    client = FakeFleetClient()
+    monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: client)
+
+    await Lease(namespace="foo", name="claim-1").release()
+
+    assert client.released == ["claim-1"]
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_lease_renew_pushes_the_shutdown_time_forward(monkeypatch):
+    client = FakeFleetClient()
+    monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: client)
+
+    await Lease(namespace="foo", name="claim-1").renew("2026-01-01T00:10:00Z")
+
+    assert client.renewed == [("claim-1", "2026-01-01T00:10:00Z")]
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_fleet_client_renew_claim_requires_a_release_with_renew_support():
+    client = object.__new__(_FleetClient)
+    client._client = object()
+
+    with pytest.raises(RuntimeError, match="renew_claim"):
+        await client.renew_claim(fake_claim(), "2026-01-01T00:10:00Z")
+
+
+@pytest.mark.asyncio
+async def test_fleet_client_renew_claim_delegates_when_supported():
+    calls = []
+
+    class GeneratedClient:
+        async def renew_claim(self, claim, shutdown_time):
+            calls.append((claim, shutdown_time))
+            return "renewed"
+
+    client = object.__new__(_FleetClient)
+    client._client = GeneratedClient()
+
+    assert await client.renew_claim("claim", "2026-01-01T00:10:00Z") == "renewed"
+    assert calls == [("claim", "2026-01-01T00:10:00Z")]
+
+
+def test_supports_claim_renewal_reflects_the_generated_client(monkeypatch):
+    class Without:
+        pass
+
+    class With:
+        async def renew_claim(self, claim, shutdown_time):
+            return claim
+
+    monkeypatch.setattr("cua_sandbox.pool.CyclopsClient", Without)
+    assert supports_claim_renewal() is False
+    monkeypatch.setattr("cua_sandbox.pool.CyclopsClient", With)
+    assert supports_claim_renewal() is True

--- a/libs/python/cua-sandbox/tests/test_pool.py
+++ b/libs/python/cua-sandbox/tests/test_pool.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 from cua_sandbox import (
+    ClaimLifecycle,
     ClaimSpec,
     CreatePoolRequest,
     CreateTemplateRequest,
@@ -11,6 +12,7 @@ from cua_sandbox import (
     OsGymSandboxTemplateSpec,
     OsGymSandboxWarmPoolSpec,
     Pool,
+    PreservedJson,
     RuntimeKind,
     SandboxService,
     SandboxTemplateRef,
@@ -26,6 +28,15 @@ from fleet_sdk import Sandbox as FleetSandbox
 
 def test_public_pool_schema_exports_runtime_kind() -> None:
     assert RuntimeKind.KUBEVIRT.value == 0
+
+
+def test_public_pool_schema_exports_claim_lifecycle_and_preserved_json() -> None:
+    lifecycle = ClaimLifecycle(
+        shutdown_time="2026-01-01T00:00:00Z", shutdown_policy=None, auto_renew=False
+    )
+    assert lifecycle.shutdown_time == "2026-01-01T00:00:00Z"
+    assert lifecycle.auto_renew is False
+    assert hasattr(PreservedJson, "from_json")
 
 
 def pool_request(

--- a/libs/python/cua-sandbox/tests/test_pool.py
+++ b/libs/python/cua-sandbox/tests/test_pool.py
@@ -695,3 +695,42 @@ def test_supports_claim_renewal_reflects_the_generated_client(monkeypatch):
     assert supports_claim_renewal() is False
     monkeypatch.setattr("cua_sandbox.pool.CyclopsClient", With)
     assert supports_claim_renewal() is True
+
+
+@pytest.mark.asyncio
+async def test_create_claim_passes_a_client_supplied_name_when_supported(monkeypatch):
+    reconcile_client = FakeFleetClient()
+    claim_client = FakeFleetClient()
+    clients = iter([reconcile_client, claim_client])
+    monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: next(clients))
+
+    class NamedCreateClaimRequest:
+        def __init__(self, *, pool, spec, name=None):
+            self.pool = pool
+            self.spec = spec
+            self.name = name
+
+    monkeypatch.setattr("cua_sandbox.pool.CreateClaimRequest", NamedCreateClaimRequest)
+    pool = await Pool.reconcile(pool_request())
+
+    await pool.create_claim(name="claim-pinned")
+
+    assert claim_client.claims[0].name == "claim-pinned"
+    assert claim_client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_create_claim_names_require_a_fleet_release_with_the_name_field(monkeypatch):
+    reconcile_client = FakeFleetClient()
+    monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: reconcile_client)
+
+    class LegacyCreateClaimRequest:
+        def __init__(self, *, pool, spec):
+            self.pool = pool
+            self.spec = spec
+
+    monkeypatch.setattr("cua_sandbox.pool.CreateClaimRequest", LegacyCreateClaimRequest)
+    pool = await Pool.reconcile(pool_request())
+
+    with pytest.raises(RuntimeError, match="claim names"):
+        await pool.create_claim(name="claim-pinned")


### PR DESCRIPTION
## Summary
Two additions to `cua-sandbox` that let durable orchestrators (the Temporal mini-swe worker in trycua/cloud#6446) drive sandbox fleets through the public SDK instead of raw OSGymSandboxClaim HTTP calls.

## Lease API (`6f7c604`)
`pool.claim()` welds claim and release to one `async with` scope, which suits scripts but shuts out durable orchestrators: a Temporal workflow cannot hold a Python scope open across activities and workers. `Pool.create_claim()` now returns a **`Lease`** — the claim *by reference* (namespace + claim name, plus the bound sandbox record once observed) — with each lifecycle step explicit and usable from a different process via `to_dict()`/`from_dict()`:

- `Lease.wait(service=...)` — polls to Bound, or reattaches **without a poll** when the serialized handle already carries the bound record; returns a connected `Sandbox` that owns its Fleet client (`disconnect()` releases the client, the claim stays held)
- `Lease.renew(shutdown_time)` — pushes `spec.lifecycle.shutdownTime` forward via the new `CyclopsClient.renew_claim`; `supports_claim_renewal()` reports whether the installed cua-fleet ships it so holders on older wheels can size one budget lease instead
- `Lease.release()` — deletes the claim, 404-tolerant

Also: `Pool.get(name)` fetches a pool handle without reconciling (reconcile PATCHes the spec; get never writes), and `FleetTransport` grows an `owns_sdk` flag so lease-built transports close their client on disconnect. `pool.claim()` is unchanged and remains the scoped path.

Note: `CyclopsClient.renew_claim` itself lands in the canonical fleet SDK via trycua/cloud#6446 (`libs/fleet/` here is a read-only mirror); `Lease.renew` degrades with a clear error until a cua-fleet release ships it.

## Fleet request timeout + schema exports (`67a2eb4`)
- `configure(fleet_request_timeout=...)` / `CUA_FLEET_REQUEST_TIMEOUT`: the default `CyclopsHttpClient` pinned every Fleet request to 30s, which severs long-blocking `services.request` calls — an MCP `tools/call` only answers once the tool finishes. Env wins over `configure()` (mirroring `get_fleet_base_url`); injected httpx clients keep their own timeout.
- Re-export `ClaimLifecycle` and `PreservedJson` from `cua_sandbox` — `pool.py` promises nested schema types are importable from the facade, but the lifecycle record and probes wrapper were missing.

## Testing
- 20 new unit tests (Lease lifecycle, serialization round-trips, reattach-without-poll, client ownership, renewal gating, timeout config); full cua-sandbox unit suite passes (75 tests across the touched areas)
- isort/black/ruff clean

https://claude.ai/code/session_01S18UHcvEuUP4X1BREc6KAG