### PR TITLE
fix(cua-driver): report PostMessage pixel fallback truthfully

### DIFF
--- a/.github/workflows/ci-rust-windows.yml
+++ b/.github/workflows/ci-rust-windows.yml
@@ -71,6 +71,9 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "PostMessage read-back tests failed with exit $LASTEXITCODE" }
           cargo test -p platform-windows value_write_readback_tests:: --lib --locked
           if ($LASTEXITCODE -ne 0) { throw "ValuePattern read-back tests failed with exit $LASTEXITCODE" }
+      - name: Run pixel click transport regression
+        working-directory: libs/cua-driver/rust
+        run: cargo test -p platform-windows post_message_pixel_click_reports_synthetic_transport --lib --locked
       - name: Run named-pipe readiness regression
         working-directory: libs/cua-driver/rust
         run: cargo test -p cua-driver-testkit stalled_pipe_attempt_is_bounded_and_does_not_block_the_next_probe --lib --locked

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_web_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_web_test.rs
@@ -305,7 +305,7 @@ fn harness_webview_left_click_px_background() {
         "webview2",
         "left_click",
         Targeting::Px,
-        DriverRoute::UiaInvoke,
+        DriverRoute::Composite,
     );
     let point = Cell::new(None);
     run_web_case_with_preparation(
@@ -376,13 +376,13 @@ fn harness_webview_left_click_px_background() {
                 "WebView2 PX background click failed: {}",
                 click.text()
             );
-            assert_eq!(
-                click.action_route(),
-                Some("accessibility"),
-                "WebView2 PX background click used an unexpected driver route: {}",
-                click.text()
-            );
             wait_for_journal_text(journal, "lbl-counter", "counter=3");
+            let route = click.action_route();
+            assert!(
+                matches!(route, Some("accessibility" | "synthetic_events")),
+                "WebView2 PX background click used an unsupported driver route {route:?}: {}",
+                click.text(),
+            );
         },
     );
 }

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -2809,6 +2809,14 @@ impl Tool for LaunchAppTool {
 
 // ── click ─────────────────────────────────────────────────────────────────────
 
+fn posted_pixel_click_result(pid: u32, click_word: &str) -> ToolResult {
+    ToolResult::text(format!("✅ Posted {click_word} to pid {pid}.")).with_structured(json!({
+        "path": "post_message",
+        "verified": false,
+        "effect": "unverifiable"
+    }))
+}
+
 pub struct ClickTool {
     state: Arc<ToolState>,
 }
@@ -3783,15 +3791,12 @@ impl Tool for ClickTool {
                 };
             }
 
-            // delivery_mode:"background", non-dropped + non-UIA click — e.g. a
-            // right-click or multi-click on a plain Win32 window. Chromium is
-            // never reached here: its mouse events are flagged silently-dropped
-            // above and handled by the injection path, so the only targets that
-            // fall through are ones PostMessage delivers to without a foreground
-            // swap. (Foreground was handled at the top; the legacy `auto`
-            // Chromium-SendInput heuristic was removed in the macOS-alignment
-            // pass — escalating to delivery_mode:"foreground" is now the explicit
-            // path for any target PostMessage can't reach.)
+            // delivery_mode:"background", non-dropped + non-UIA click. This
+            // includes plain Win32 targets and embedded Chromium when its UIA
+            // provider is temporarily unavailable. Attempt PostMessage without a
+            // foreground swap; the caller must verify the resulting fixture state.
+            // Foreground was handled at the top, and known dropped surfaces use
+            // the targeted-injection path above.
 
             // bitmap pixels -> screen (DWM-frame origin + inset). Use
             // post_click_screen so we don't double-ClientToScreen.
@@ -3807,10 +3812,7 @@ impl Tool for ClickTool {
                         3 => "triple-click",
                         _ => "click",
                     };
-                    ToolResult::text(format!("✅ Posted {click_word} to pid {pid}."))
-                        .with_structured(
-                            json!({ "path": "pixel", "verified": false, "effect": "unverifiable" }),
-                        )
+                    posted_pixel_click_result(pid, click_word)
                 }
                 Ok(Err(e)) => ToolResult::error(e.to_string()),
                 Err(e) => ToolResult::error(format!("Task error: {e}")),
@@ -3819,6 +3821,39 @@ impl Tool for ClickTool {
             // Match Swift's error wording for the missing-target case.
             ToolResult::error("Provide element_index or (x, y) to address the click target.")
         }
+    }
+}
+
+#[cfg(test)]
+mod pixel_click_transport_tests {
+    use super::posted_pixel_click_result;
+    use cua_driver_core::action_record::{
+        ActionExecutionRecord, ActionTransport, ActualDelivery, RequestedDelivery,
+    };
+
+    #[test]
+    fn post_message_pixel_click_reports_synthetic_transport() {
+        let result = posted_pixel_click_result(42, "click");
+        let structured = result
+            .structured_content
+            .as_ref()
+            .expect("posted click should expose legacy transport metadata");
+        assert_eq!(structured["path"], "post_message");
+
+        let record = ActionExecutionRecord::from_legacy(
+            "click",
+            &serde_json::json!({ "delivery_mode": "background" }),
+            structured,
+        )
+        .expect("posted click should normalize into the public action contract");
+        assert_eq!(record.transport, ActionTransport::WindowsPostMessage);
+        assert_eq!(record.requested_delivery, RequestedDelivery::Background);
+        assert_eq!(record.actual_delivery, Some(ActualDelivery::Background));
+
+        let public = serde_json::to_value(record.public_result().expect("valid ActionResult"))
+            .expect("serialize ActionResult");
+        assert_eq!(public["route"], "synthetic_events");
+        assert_eq!(public["delivery"]["mode"], "background");
     }
 }
 


### PR DESCRIPTION
## Problem

Windows background pixel clicks already fall back to `PostMessage` when UI Automation does not land, but that fallback reports legacy `path:"pixel"`. The public action contract therefore normalizes an actual `WindowsPostMessage` transport as `WindowsTargetedInjection` / `route:"global_input"`.

The WebView2 native harness also requires only `route:"accessibility"`, even though a temporarily unavailable UIA provider can legitimately reach the fixture through the existing background-safe PostMessage fallback.

## Change

- report the PostMessage pixel fallback as `path:"post_message"`, which normalizes to `WindowsPostMessage` / `route:"synthetic_events"`;
- add a focused Windows unit regression that asserts both the internal transport and serialized public `route:"synthetic_events"` / background delivery;
- classify the WebView2 PX background case as composite and accept only `accessibility` or `synthetic_events`;
- prove `counter=3` fixture state before validating the route, while retaining the harness's Focus, ZOrder, Cursor, and NoLeakedInput background oracles.

This does not make UIA availability mandatory and does not allow `global_input` as a successful background route.

## Validation

Exact base `7e0d6bcb5d7ca55d9da1ff3e8acc1bdddf6fa422`; exact head `0b84193508ffe1392b986af8102b0da738dd32a3`.

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- workflow YAML parse
- [Windows unit and compile](https://github.com/trycua/cua/actions/runs/30977224681): passed, including the focused PostMessage-to-public-contract regression.
- [Exact native Windows lane](https://github.com/trycua/cua/actions/runs/30977237240): passed. The web harness passed 4/4; the WebView2 PX background case delivered and passed FixtureState, Focus, ZOrder, Cursor, and NoLeakedInput with video evidence; the full WPF, WinUI3, and WebView2 lane was green.
- All attached PR checks passed, including release metadata, contributor attribution, contract parity, Rust format, Linux and Windows Rust, Nix, docs, and SPDX.

Bounded residual: the exact green native run did not log which of the two accepted public routes was selected and likely exercised `accessibility`. The prior native failures prove that the PostMessage fallback is selected when UIA exceeds its deadline, while the focused Windows unit deterministically proves that fallback now projects as `route:"synthetic_events"` with background delivery. The native run therefore validates the route-agnostic delivery and background oracles, but is not an independent end-to-end observation of PostMessage selection.

The defect was reproduced in two exact native runs while certifying #2701, and independently exists in a main ancestor: [failing baseline](https://github.com/trycua/cua/actions/runs/30946689923), [same-SHA passing baseline](https://github.com/trycua/cua/actions/runs/30945773083).
