### PR TITLE
fix(cua-bench): fail `cb interact --oracle` when the oracle scores nothing

### DIFF
--- a/libs/cua-bench/cua_bench/cli/commands/interact.py
+++ b/libs/cua-bench/cua_bench/cli/commands/interact.py
@@ -21,6 +21,47 @@ def execute(args):
     return asyncio.run(_execute_async(args))
 
 
+def oracle_validation_failed(result) -> bool:
+    """True when an oracle run produced no evidence that it solved the task.
+
+    ``--oracle`` runs the task's own reference solution, so a non-positive score
+    means the example is broken rather than that the operator performed badly:
+    the oracle is supposed to score. Reporting "Task completed successfully!"
+    for a ``[0.0]`` evaluation presents a failed example as a validated one,
+    which is exactly the signal someone authoring a task is relying on.
+
+    Only ``--oracle`` runs are judged. In a manual interactive run a zero score
+    usually means the human simply did not finish the task, which is not a
+    failure of the task definition and must not fail the command.
+
+    A result that carries no numeric score at all (``None``, empty, or a custom
+    object) is treated as inconclusive rather than failed, so evaluators with a
+    bespoke return shape keep working.
+    """
+    scores = _numeric_scores(result)
+    if not scores:
+        return False
+    return max(scores) <= 0.0
+
+
+def _numeric_scores(result) -> list[float]:
+    """Best-effort extraction of numeric scores from an evaluator result."""
+    if result is None or isinstance(result, (str, bytes, bool)):
+        return []
+    if isinstance(result, (int, float)):
+        return [float(result)]
+    try:
+        candidates = list(result)
+    except TypeError:
+        return []
+    scores = []
+    for item in candidates:
+        if isinstance(item, bool) or not isinstance(item, (int, float)):
+            continue
+        scores.append(float(item))
+    return scores
+
+
 def _detect_task_config(env_path: Path) -> dict:
     """Detect provider type and os_type from task configuration.
 
@@ -234,10 +275,14 @@ async def _execute_simulated_interactive(args, env_path: Path) -> int:
             input()
 
         # Evaluate if function exists
+        oracle_failed = False
         if env.evaluate_task_fn:
             print(f"{CYAN}Running evaluation...{RESET}")
             result = await env.evaluate()
             print(f"{YELLOW}✓ Evaluation result: {BOLD}{result}{RESET}")
+            oracle_failed = bool(getattr(args, "oracle", False)) and oracle_validation_failed(
+                result
+            )
 
         # Save trace if requested
         if (
@@ -262,6 +307,17 @@ async def _execute_simulated_interactive(args, env_path: Path) -> int:
                 print(f"{RED}Failed to save trace: {_e}{RESET}")
 
         await env.close()
+        if oracle_failed:
+            # The task's own reference solution scored nothing. Announcing
+            # success here is what let a broken example look validated.
+            print(
+                f"\n{RED}✗ Oracle run did not solve the task (evaluation scored no points).{RESET}"
+            )
+            print(
+                f"{YELLOW}The task ran to completion, but its reference solution "
+                f"produced no score, so this run does not validate the task.{RESET}"
+            )
+            return 1
         print(f"\n{GREEN}✓ Task completed successfully!{RESET}")
         try:
             if getattr(args, "trace_out", None):
@@ -378,16 +434,29 @@ async def _execute_native_interactive(args, env_path: Path, provider_type: str) 
             input()
 
         # Evaluate if function exists
+        oracle_failed = False
         if env and env.evaluate_task_fn and task_config:
             print(f"\n{CYAN}Running evaluation...{RESET}")
             task_cfg = task_config.get("_task_cfg")
             if task_cfg and session:
                 result = await env.evaluate_task_fn(task_cfg, session)
                 print(f"{YELLOW}✓ Evaluation result: {BOLD}{result}{RESET}")
+                oracle_failed = bool(getattr(args, "oracle", False)) and oracle_validation_failed(
+                    result
+                )
 
         # Cleanup
         print(f"\n{CYAN}Cleaning up environment...{RESET}")
         await cleanup()
+        if oracle_failed:
+            print(
+                f"\n{RED}✗ Oracle run did not solve the task (evaluation scored no points).{RESET}"
+            )
+            print(
+                f"{YELLOW}The task ran to completion, but its reference solution "
+                f"produced no score, so this run does not validate the task.{RESET}"
+            )
+            return 1
         print(f"{GREEN}✓ Task completed successfully!{RESET}")
 
         return 0

--- a/libs/cua-bench/cua_bench/tests/test_interact_oracle_result.py
+++ b/libs/cua-bench/cua_bench/tests/test_interact_oracle_result.py
@@ -1,0 +1,65 @@
+"""Oracle runs must not report success when the reference solution scores nothing.
+
+`cb interact --oracle` runs the task's own reference solution. A non-positive
+score therefore means the task is broken, not that the operator underperformed,
+so the command must not print "Task completed successfully!" and exit 0.
+"""
+
+from cua_bench.cli.commands.interact import oracle_validation_failed
+
+
+def test_zero_score_is_a_failed_oracle():
+    # The reported shape: the bundled 2048 example evaluated to [0.0] while the
+    # CLI still announced success.
+    assert oracle_validation_failed([0.0]) is True
+
+
+def test_any_positive_score_passes():
+    assert oracle_validation_failed([0.25]) is False
+    assert oracle_validation_failed([1.0]) is False
+
+
+def test_mixed_scores_pass_when_any_is_positive():
+    # Multi-metric evaluators return one entry per metric; scoring on any of
+    # them is evidence the oracle drove the environment.
+    assert oracle_validation_failed([0.0, 0.5, 0.0]) is False
+
+
+def test_all_zero_multi_metric_fails():
+    assert oracle_validation_failed([0.0, 0.0]) is True
+
+
+def test_negative_scores_fail():
+    # Penalty-style evaluators can go below zero; that is not a solved task.
+    assert oracle_validation_failed([-1.0]) is True
+
+
+def test_bare_number_is_accepted():
+    assert oracle_validation_failed(0.0) is True
+    assert oracle_validation_failed(1.0) is False
+
+
+def test_missing_or_empty_result_is_inconclusive_not_failed():
+    # An evaluator that returns nothing gives no evidence either way. Failing
+    # here would break tasks that report through a side channel.
+    assert oracle_validation_failed(None) is False
+    assert oracle_validation_failed([]) is False
+
+
+def test_non_numeric_results_are_inconclusive():
+    # Custom evaluator payloads must keep working rather than hard-failing.
+    assert oracle_validation_failed("done") is False
+    assert oracle_validation_failed({"score": 0.0}) is False
+    assert oracle_validation_failed([object()]) is False
+
+
+def test_booleans_are_not_treated_as_scores():
+    # bool is a subclass of int; True must not silently count as a score of 1.0.
+    assert oracle_validation_failed([True]) is False
+    assert oracle_validation_failed(True) is False
+
+
+def test_numeric_entries_are_read_past_non_numeric_ones():
+    # A mixed payload still yields a verdict from the numbers present.
+    assert oracle_validation_failed([None, 0.0, "x"]) is True
+    assert oracle_validation_failed([None, 0.75, "x"]) is False


### PR DESCRIPTION
Addresses the CLI half of #2511.

## The problem

`cb interact --oracle` announced success regardless of what the evaluation returned:

```
✓ Evaluation result: [0.0]
✓ Task completed successfully!
```

and exited `0`.

`--oracle` runs the task's **own reference solution**. A non-positive score there means the task is broken, not that the operator underperformed — so this is the one run where a zero score is unambiguously a failure. Reporting it as validated is precisely the wrong signal for the person it is aimed at: someone authoring or reviewing a task, who is running the oracle *to find out whether the task works*.

Both interactive paths had it — the simulated path (`_execute_simulated_interactive`) and the native/VNC path (`_execute_native_interactive`) each printed the evaluation result and then unconditionally printed `✓ Task completed successfully!` and returned `0`.

The task-code half of #2511 (the 2048 example's unawaited coroutines) is already fixed on `main` — `start`, `evaluate` and `solve` are all `async def` with proper `await`s. Only the CLI's reporting was left.

## What this changes

Failure is judged **only for `--oracle` runs**. In a manual interactive run a zero score usually means the human simply did not finish the task, which says nothing about the task definition and must not fail the command. That gate is the reason this is safe to apply to both paths.

On an oracle run that scored nothing, the command now says what actually happened and returns `1`:

```
✗ Oracle run did not solve the task (evaluation scored no points).
The task ran to completion, but its reference solution produced no score,
so this run does not validate the task.
```

## The rule

`oracle_validation_failed` is kept pure and separate from the async plumbing so the decision is testable without standing up an environment:

- **non-positive maximum score → failure** — covers the reported `[0.0]` and penalty-style negative scores
- **any positive score → pass** — including multi-metric results where only some metrics scored, since scoring on any metric is evidence the oracle drove the environment
- **no numeric score at all → inconclusive, not failed** — `None`, an empty list, or a bespoke payload leaves the command passing, so evaluators with a custom return shape keep working rather than newly failing
- **bools are excluded explicitly** — `bool` subclasses `int`, so `[True]` would otherwise be read as a score of `1.0` and silently pass a task that never scored

## Tests

Ten unit tests in `cua_bench/tests/test_interact_oracle_result.py`, one per rule above plus the reported `[0.0]` case and a mixed numeric/non-numeric payload.

Verified against a stashed baseline rather than assumed:

| | failed | passed |
| --- | --- | --- |
| baseline (change stashed) | 11 | 20 |
| with this change | 11 | 30 |

The 11 failures are pre-existing in `test_gym_interface.py` / `test_run_benchmark.py` and fail identically without this change; the delta is exactly the 10 tests added here. `ruff check` and `ruff format --check` both clean.

Note: `test_worker_*.py` cannot be collected at all without the optional `rl` extra (`torch`), which is also pre-existing and unrelated.

## Limits

- The behaviour change is scoped to the CLI's exit status and final message. Evaluator semantics, the printed `Evaluation result:` line, and non-oracle runs are untouched.
- I did not change `cb run`; if you would like the same honesty applied to batch runs I am happy to follow up, but that path reports aggregate results and deserves its own decision about what "failed" means across a suite.

Refs #2511
