### PR TITLE
fix(cua-driver): allow UIA ValuePattern type_text on Chromium when el…

### DIFF
--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -4156,8 +4156,8 @@ impl Tool for TypeTextTool {
         // conditional: indexed text still has a working UIA ValuePattern route,
         // while unindexed text would be posted to the top-level and disappear.
         if delivery == DeliveryMode::Background
-            && (crate::input::delivery::would_be_silently_dropped(hwnd, EventKind::TextInput)
-                || (elem_idx.is_none() && crate::input::delivery::is_wpf_target_window(hwnd)))
+            && elem_idx.is_none()
+            && crate::input::delivery::would_be_silently_dropped(hwnd, EventKind::TextInput)
         {
             return crate::input::delivery::background_unavailable_error(
                 hwnd,


### PR DESCRIPTION
…ement_index is provided

When element_index is supplied, the type_text tool already has a working UIA ValuePattern.SetValue path that handles Chromium/Electron background text input correctly. However, the would_be_silently_dropped() pre-check unconditionally refuses all Chromium background TextInput events, blocking the UIA path before it can be reached.

Add elem_idx.is_none() guard so indexed elements bypass the Chromium pre-check and reach the UIA ValuePattern code path.