### PR TITLE
test(cua-driver): validate published manifest examples against the real parser

### DIFF
--- a/.github/workflows/ci-rust-linux.yml
+++ b/.github/workflows/ci-rust-linux.yml
@@ -15,6 +15,13 @@ on:
       - "libs/cua-driver/rust/crates/platform-linux/**"
       - "libs/cua-driver/wayland-helper/**"
       - "libs/cua-driver/tests/fixtures/**"
+      # Manifest examples on these pages are loaded by
+      # cua-driver-core's docs_manifest_examples test; a docs-only
+      # edit must run it so schema drift fails here, not at a
+      # user's daemon startup.
+      - "docs/content/docs/how-to-guides/driver/drive-a-web-page.mdx"
+      - "docs/content/docs/how-to-guides/driver/write-a-bounded-manifest.mdx"
+      - "docs/content/docs/reference/cua-driver/permission-modes.mdx"
       - "nix/**"
       - "flake.nix"
       - "flake.lock"
@@ -34,6 +41,13 @@ on:
       - "libs/cua-driver/rust/crates/platform-linux/**"
       - "libs/cua-driver/wayland-helper/**"
       - "libs/cua-driver/tests/fixtures/**"
+      # Manifest examples on these pages are loaded by
+      # cua-driver-core's docs_manifest_examples test; a docs-only
+      # edit must run it so schema drift fails here, not at a
+      # user's daemon startup.
+      - "docs/content/docs/how-to-guides/driver/drive-a-web-page.mdx"
+      - "docs/content/docs/how-to-guides/driver/write-a-bounded-manifest.mdx"
+      - "docs/content/docs/reference/cua-driver/permission-modes.mdx"
       - "nix/**"
       - "flake.nix"
       - "flake.lock"
@@ -68,6 +82,12 @@ jobs:
       - name: Run Linux Rust tests
         working-directory: libs/cua-driver/rust
         run: cargo test -p cua-driver -p cua-driver-contract -p cua-driver-core -p cua-driver-testkit -p cursor-overlay -p cursor-theme-cli -p platform-linux --all-targets --locked
+      - name: Validate published manifest examples against the real parser
+        # Ignored in --all-targets because it reads docs/ from the repo root,
+        # which the Nix sandbox source does not carry; this step runs it from
+        # the full checkout so docs schema drift fails here (#2847 class).
+        working-directory: libs/cua-driver/rust
+        run: cargo test -p cua-driver-core --test docs_manifest_examples --locked -- --ignored
       - name: Run X11 overlay click-through regression
         working-directory: libs/cua-driver/rust
         run: |

--- a/libs/cua-driver/rust/crates/cua-driver-core/tests/docs_manifest_examples.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/tests/docs_manifest_examples.rs
@@ -1,0 +1,95 @@
+//! Published bounded-manifest examples must stay loadable by the runtime parser.
+//!
+//! Three published examples once drifted from the schema and were refused by
+//! the daemon at startup (#2847). Validating every full manifest example in
+//! the docs through the real `load_manifest` path makes that class of drift
+//! fail in CI instead of in a user's terminal (#2572).
+#![cfg(feature = "yaml")]
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use cua_driver_core::session_manifest::load_manifest;
+
+/// Every docs page that publishes at least one complete session manifest.
+/// A page that moves or stops carrying a full example should update this
+/// list in the same change.
+const MANIFEST_DOC_PAGES: &[&str] = &[
+    "docs/content/docs/how-to-guides/driver/drive-a-web-page.mdx",
+    "docs/content/docs/how-to-guides/driver/write-a-bounded-manifest.mdx",
+    "docs/content/docs/reference/cua-driver/permission-modes.mdx",
+];
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(5)
+        .expect("crate directory should sit five levels below the repo root")
+        .to_path_buf()
+}
+
+/// Fenced ```yaml blocks that declare a complete manifest: partial snippets
+/// (a lone `resources:` section, for example) document one field and are not
+/// expected to load on their own.
+fn full_manifest_blocks(source: &str) -> Vec<String> {
+    let mut blocks = Vec::new();
+    let mut current: Option<Vec<&str>> = None;
+    for line in source.lines() {
+        match current.as_mut() {
+            None => {
+                let fence = line.trim_end();
+                if fence == "```yaml" || fence == "```yml" {
+                    current = Some(Vec::new());
+                }
+            }
+            Some(lines) => {
+                if line.trim_end() == "```" {
+                    let block = lines.join("\n");
+                    let declares_version = lines.iter().any(|l| l.starts_with("version:"));
+                    let declares_mode = lines.iter().any(|l| l.starts_with("mode:"));
+                    if declares_version && declares_mode {
+                        blocks.push(block);
+                    }
+                    current = None;
+                } else {
+                    lines.push(line);
+                }
+            }
+        }
+    }
+    blocks
+}
+
+// Ignored by default because the docs tree is outside the Nix build sandbox
+// (flake.nix's rustTestSrc roots at libs/cua-driver); ci-rust-linux.yml runs
+// it explicitly from the full checkout, like the other `-- --ignored` suites.
+#[test]
+#[ignore = "requires a full repo checkout (reads docs/); run with -- --ignored"]
+fn published_manifest_examples_load() {
+    let root = repo_root();
+    let mut failures = Vec::new();
+    for page in MANIFEST_DOC_PAGES {
+        let path = root.join(page);
+        let source = std::fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("failed to read {page}: {error}"));
+        let manifests = full_manifest_blocks(&source);
+        assert!(
+            !manifests.is_empty(),
+            "{page} no longer contains a complete manifest example; \
+             update MANIFEST_DOC_PAGES if it moved"
+        );
+        for (index, manifest) in manifests.iter().enumerate() {
+            let mut file = tempfile::NamedTempFile::new().expect("create temp manifest");
+            file.write_all(manifest.as_bytes())
+                .expect("write temp manifest");
+            if let Err(error) = load_manifest(file.path()) {
+                failures.push(format!("{page} (manifest example {index}): {error}"));
+            }
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "published manifest examples no longer load:\n{}",
+        failures.join("\n")
+    );
+}


### PR DESCRIPTION
## Problem

#2572's acceptance criteria ask for the browser-guide examples to be "covered by a docs test, checked fixture, or executable smoke test so schema drift fails CI." That guard does not exist yet: #2847 had to repair three published bounded-manifest examples that the daemon refused at startup, and nothing today stops the next drift — the Rust workflows do not even trigger on docs edits.

## Fix

Two pieces, scoped to the #2847 class (full session-manifest examples):

1. **`cua-driver-core/tests/docs_manifest_examples.rs`** extracts every fenced `yaml` block that declares both `version:` and `mode:` (full manifests; the `resources:` fragments on the same pages are deliberately skipped) from the three pages that publish complete manifests, and loads each through the real `session_manifest::load_manifest`. A drifted example fails with the parser's own message, e.g. the exact `unsupported application terminate scope 'never'` string from #2847. The test also fails if a listed page stops yielding a full manifest, so a page move updates the list in the same change.

   The test is `#[ignore]` by default: the Nix check builds `cua-driver-core` from a `libs/cua-driver`-rooted source set with no `docs/`, and Windows CI compiles `--all-targets` without running curated-out suites. A dedicated ci-rust-linux step runs it explicitly from the full checkout, following the workflow's existing `-- --ignored` pattern (X11 overlay, MIT-SHM).

2. **`ci-rust-linux.yml`** adds the three docs pages to both `paths:` filters, so a docs-only edit to a manifest example actually runs the guard. This does mean such an edit pays for the full Linux Rust workflow; there is precedent (`ci-check-docs.yml` builds `cua-driver --release` on reference-doc changes), and a lighter dedicated job is easy to split out later if preferred.

Scope note, stated honestly: this covers the manifest examples (the class that has actually broken). The `jsonc` tool-call snippets on the same pages are not validated by this test; extending coverage to those would need a different extraction contract and is left out deliberately.

## Validation

- `cargo test -p cua-driver-core --test docs_manifest_examples --locked -- --ignored` — 1 passed; validates 4 manifests (1 drive-a-web-page, 2 write-a-bounded-manifest, 1 permission-modes). A repo-wide fence scan confirms these are the only blocks anywhere under `docs/content` declaring both `version:` and `mode:`.
- Default invocation (`--all-targets`) reports the test as ignored, so the Nix and Windows legs are unaffected.
- Negative control: changing the drive-a-web-page example's `terminate: deny` to `terminate: never` makes the explicit run fail with the #2847 error message; restoring turns it green.
- `cargo test -p cua-driver-core --all-targets --locked` — all suites pass; `cargo fmt` clean; workflow YAML parses.

Closes the remaining automation criterion of #2572.
