### PR TITLE
fix(cua-driver): block uinput pointer hotplug on KDE X11

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/input/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/input/mod.rs
@@ -390,8 +390,77 @@ fn real_pointer_capabilities_available(
     server_supported: bool,
     xvfb: bool,
     uinput_accessible: bool,
+    unsafe_hotplug_session: bool,
 ) -> bool {
-    server_supported && !xvfb && uinput_accessible
+    server_supported && !xvfb && uinput_accessible && !unsafe_hotplug_session
+}
+
+fn nonempty(value: Option<&str>) -> bool {
+    value.is_some_and(|value| !value.trim().is_empty())
+}
+
+fn desktop_value_is_kde(value: Option<&str>) -> bool {
+    value.is_some_and(|value| {
+        value
+            .split([':', ';', ','])
+            .map(str::trim)
+            .any(|token| token.eq_ignore_ascii_case("kde") || token.eq_ignore_ascii_case("plasma"))
+    })
+}
+
+/// KDE Plasma 6 / Qt 6.11 applications on X11 can crash session-wide when an
+/// ephemeral uinput pointer is hotplugged into Xorg. Foreground input does not
+/// need that device: the click, drag, scroll, and keyboard tools already use
+/// XTEST after activating the target window. Disable only the MPX/uinput
+/// capability here so callers retain their existing foreground escalation and
+/// XSendEvent fallback behavior.
+fn kde_x11_uinput_hotplug_is_unsafe(
+    session_type: Option<&str>,
+    current_desktop: Option<&str>,
+    session_desktop: Option<&str>,
+    desktop_session: Option<&str>,
+    kde_full_session: Option<&str>,
+    display: Option<&str>,
+    wayland_display: Option<&str>,
+) -> bool {
+    let explicit_x11 = session_type.is_some_and(|value| value.eq_ignore_ascii_case("x11"));
+    let explicit_wayland = session_type.is_some_and(|value| value.eq_ignore_ascii_case("wayland"));
+    if explicit_wayland || (!explicit_x11 && nonempty(wayland_display)) {
+        return false;
+    }
+
+    let x11 = explicit_x11 || nonempty(display);
+    let kde = desktop_value_is_kde(current_desktop)
+        || desktop_value_is_kde(session_desktop)
+        || desktop_value_is_kde(desktop_session)
+        || kde_full_session.is_some_and(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes"
+            )
+        });
+
+    x11 && kde
+}
+
+fn kde_x11_uinput_hotplug_is_unsafe_from_env() -> bool {
+    let session_type = std::env::var("XDG_SESSION_TYPE").ok();
+    let current_desktop = std::env::var("XDG_CURRENT_DESKTOP").ok();
+    let session_desktop = std::env::var("XDG_SESSION_DESKTOP").ok();
+    let desktop_session = std::env::var("DESKTOP_SESSION").ok();
+    let kde_full_session = std::env::var("KDE_FULL_SESSION").ok();
+    let display = std::env::var("DISPLAY").ok();
+    let wayland_display = std::env::var("WAYLAND_DISPLAY").ok();
+
+    kde_x11_uinput_hotplug_is_unsafe(
+        session_type.as_deref(),
+        current_desktop.as_deref(),
+        session_desktop.as_deref(),
+        desktop_session.as_deref(),
+        kde_full_session.as_deref(),
+        display.as_deref(),
+        wayland_display.as_deref(),
+    )
 }
 
 fn uinput_accessible() -> bool {
@@ -403,6 +472,13 @@ fn uinput_accessible() -> bool {
 }
 
 pub fn real_pointer_input_available() -> bool {
+    // Do not even probe /dev/uinput on an affected KDE/X11 session. Creating
+    // the device is itself the dangerous operation; a later fallback is too
+    // late once Xorg has announced the hotplug to Qt clients.
+    if kde_x11_uinput_hotplug_is_unsafe_from_env() {
+        return false;
+    }
+
     // `ensure_master_pointer` creates an XI2 master before attaching the
     // uinput slave. If this process cannot open /dev/uinput, attempting that
     // path on every click/scroll would create and abandon an XInput master
@@ -418,12 +494,26 @@ pub fn real_pointer_input_available() -> bool {
         supports_parallel_pointer_injection(display).is_ok(),
         is_xvfb_process_running(),
         true,
+        false,
     );
     unsafe { x11::xlib::XCloseDisplay(display) };
     supported
 }
 
 fn ensure_master_pointer(cursor_id: &str) -> Result<MasterPointerIds> {
+    ensure_master_pointer_for_session(cursor_id, kde_x11_uinput_hotplug_is_unsafe_from_env())
+}
+
+fn ensure_master_pointer_for_session(
+    cursor_id: &str,
+    unsafe_hotplug_session: bool,
+) -> Result<MasterPointerIds> {
+    if unsafe_hotplug_session {
+        return Err(uinput_unavailable(
+            "disabled on KDE Plasma X11; retry with delivery_mode='foreground'",
+        ));
+    }
+
     if let Some(ids) = mpx_pointers().lock().unwrap().get(cursor_id).copied() {
         return Ok(ids);
     }
@@ -2817,7 +2907,8 @@ exit 0"#,
 #[cfg(test)]
 mod path_tests {
     use super::{
-        create_uinput_pointer, guarded_uinput_creation, is_uinput_unavailable, master_pointer_name,
+        create_uinput_pointer, ensure_master_pointer_for_session, guarded_uinput_creation,
+        is_uinput_unavailable, kde_x11_uinput_hotplug_is_unsafe, master_pointer_name,
         modifiers_to_state, normalize_uinput_device_name, path_cumulative, point_on_path,
         real_pointer_capabilities_available, sample_function, slave_pointer_name,
         EVDEV_UINPUT_NAME_MAX_BYTES, UINPUT_POINTER_SUFFIX,
@@ -2929,10 +3020,76 @@ mod path_tests {
 
     #[test]
     fn real_pointer_capabilities_require_uinput_access() {
-        assert!(real_pointer_capabilities_available(true, false, true));
-        assert!(!real_pointer_capabilities_available(true, false, false));
-        assert!(!real_pointer_capabilities_available(false, false, true));
-        assert!(!real_pointer_capabilities_available(true, true, true));
+        assert!(real_pointer_capabilities_available(
+            true, false, true, false
+        ));
+        assert!(!real_pointer_capabilities_available(
+            true, false, false, false
+        ));
+        assert!(!real_pointer_capabilities_available(
+            false, false, true, false
+        ));
+        assert!(!real_pointer_capabilities_available(
+            true, true, true, false
+        ));
+        assert!(!real_pointer_capabilities_available(
+            true, false, true, true
+        ));
+    }
+
+    #[test]
+    fn kde_x11_sessions_disable_uinput_pointer_hotplug() {
+        assert!(kde_x11_uinput_hotplug_is_unsafe(
+            Some("x11"),
+            Some("KDE"),
+            None,
+            None,
+            None,
+            Some(":0"),
+            None,
+        ));
+        assert!(kde_x11_uinput_hotplug_is_unsafe(
+            Some("x11"),
+            Some("KDE"),
+            None,
+            None,
+            None,
+            Some(":0"),
+            Some("wayland-0"),
+        ));
+        assert!(kde_x11_uinput_hotplug_is_unsafe(
+            None,
+            None,
+            Some("plasma"),
+            None,
+            Some("true"),
+            Some(":1"),
+            None,
+        ));
+
+        assert!(!kde_x11_uinput_hotplug_is_unsafe(
+            Some("wayland"),
+            Some("KDE"),
+            None,
+            None,
+            Some("true"),
+            Some(":0"),
+            Some("wayland-0"),
+        ));
+        assert!(!kde_x11_uinput_hotplug_is_unsafe(
+            Some("x11"),
+            Some("GNOME"),
+            None,
+            None,
+            None,
+            Some(":0"),
+            None,
+        ));
+
+        let error = ensure_master_pointer_for_session("regression-test", true)
+            .expect_err("the creation choke point must refuse before opening X11 or uinput");
+        assert!(is_uinput_unavailable(&error));
+        assert!(error.to_string().contains("delivery_mode='foreground'"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #2304 by preventing Linux MPX/uinput pointer creation on KDE Plasma X11 sessions, where XInput hotplug can trigger a Qt/XCB session-wide crash cascade.

- Detect KDE Plasma X11 from standard session environment markers.
- Disable real-pointer capability before probing `/dev/uinput`.
- Enforce the same refusal inside `ensure_master_pointer`, the single creation choke point, so direct parallel-pointer callers cannot bypass the capability check.
- Return the existing typed `uinput_unavailable` error with a `delivery_mode='foreground'` retry hint.
- Leave Wayland and non-KDE X11 behavior unchanged.

CUA's existing foreground X11 paths use XTEST/AT-SPI and do not create an input device. Standard background actions can use their existing synthetic fallback; MPX-only operations now refuse explicitly rather than risking the desktop session.

## Root cause / evidence

On Plasma X11 with Qt 6.11.1, the kernel announced a temporary `CUA ... uinput pointer`; KWin, Plasma, Konsole, KScreen, and other Qt X11 clients began crashing 73–83 ms later in two captured incidents. Representative stacks included `libQt6XcbQpa.so.6.11.1`.

This is deliberately a compatibility containment fix, not a claim to repair Qt's internal hotplug handling. Static lifecycle analysis indicates the strongest deeper hypothesis is CUA's tightly packed per-action uinput-slave/XI2-master creation and teardown, including slave removal before master removal. A session-persistent pointer with reverse-order synchronized shutdown is the generic follow-up to investigate. Until that lifecycle is isolated and certified on Plasma X11, this PR fails closed only in the affected environment and preserves the existing foreground XTEST path.

Native validation of the contribution ran on a secondary CachyOS worker under an isolated Xvfb X11 session with KDE/X11 environment markers and writable `/dev/uinput`:

- A foreground XTEST click reached independent Xlib fixture state; the fixture observed `button=1 x=50 y=50`.
- SHA-256 of `/proc/bus/input/devices` was identical before and after background-fallback plus foreground calls.
- No `CUA ... uinput pointer` device existed after the run.
- The same no-device and foreground-state checks passed with an intentionally stale `WAYLAND_DISPLAY` alongside explicit `XDG_SESSION_TYPE=x11`, covering the fail-closed precedence regression.

## Certification

Final candidate: `7d1168b818d03b1d29441ea11a89b8170418d269` (rebased on `9bf47f65dda1bc33bdd19dabb94c56b691f39ca0`; contributor authorship preserved).

Focused exact-SHA checks:

- `cargo fmt --all -- --check`
- `cargo test --locked -p platform-linux -- --test-threads=1` — 279 passed, 5 ignored, 0 failed
- Real writable-uinput creation test — 1 passed
- KDE/X11 capability and creation-choke-point test with explicit X11, KDE desktop markers, and stale `WAYLAND_DISPLAY` — 1 passed; `/proc/bus/input/devices` unchanged and no residual `CUA` uinput device

Canonical Linux E2E exact-SHA lanes:

- [Capture and desktop scope](https://github.com/trycua/cua/actions/runs/32310430530/job/96252145992) — passed
- [Installer smoke](https://github.com/trycua/cua/actions/runs/32310430530/job/96252145913) — passed
- [GTK3 + GTK4 native harnesses](https://github.com/trycua/cua/actions/runs/32310430530/job/96252145924) — passed
- [Shared Electron + Tauri](https://github.com/trycua/cua/actions/runs/32310430530/job/96252145950) — passed

The canonical `all` workflow ran at the same exact SHA. Every canonical lane and its matrix summary passed. All ordinary PR checks, including contributor attribution, Linux unit/compile, Nix, contract parity, rustfmt, and release metadata, are green.

`cargo clippy -p platform-linux --tests --no-deps -- -D warnings` reaches existing warnings across unchanged platform-linux files; the changed code adds no Clippy-specific warning in the normal build/test output.

## Related integration

A companion Hermes Agent change forces affected KDE/X11 computer-use actions to CUA's existing foreground path so users retain click, drag, scroll, and keyboard control rather than relying on background fallbacks: NousResearch/hermes-agent#79481.





