### PR TITLE
fix(cua-driver): stage local installs over a running driver

### DIFF
--- a/libs/cua-driver/scripts/_install-local-rust.sh
+++ b/libs/cua-driver/scripts/_install-local-rust.sh
@@ -253,10 +253,34 @@ echo ""
 
 echo "${BOLD}Staging into $VERSIONED_DIR${NORMAL}"
 mkdir -p "$VERSIONED_DIR"
-cp "$BUILT_BINARY" "$VERSIONED_DIR/cua-driver-local"
-cp "$BUILT_THEME_BINARY" "$VERSIONED_DIR/cua-cursor-theme"
-chmod +x "$VERSIONED_DIR/cua-driver-local"
-chmod +x "$VERSIONED_DIR/cua-cursor-theme"
+
+# Copy through a temp file in the same directory, then rename over the
+# destination.
+#
+# A plain `cp` opens the destination with O_TRUNC and writes in place. When a
+# previous cua-driver-local is still running out of that exact path — the
+# common case, since the version tag is stable per config, so every rebuild
+# targets the same file — Linux refuses the open with ETXTBSY and the install
+# dies mid-stage:
+#
+#   cp: cannot create regular file '.../cua-driver-local': Text file busy
+#
+# The daemon stop further below cannot prevent this: it runs after the swap,
+# and a manually launched `serve` is not always reachable by it anyway.
+# rename(2) has no such restriction — the running process keeps executing the
+# old inode until it exits, and the new bytes are published atomically, so a
+# concurrent exec sees either the whole old binary or the whole new one.
+stage_binary() {
+    stage_src="$1"
+    stage_dest="$2"
+    stage_tmp="$stage_dest.stage.$$"
+    rm -f "$stage_tmp"
+    cp "$stage_src" "$stage_tmp"
+    chmod +x "$stage_tmp"
+    mv -f "$stage_tmp" "$stage_dest"
+}
+stage_binary "$BUILT_BINARY" "$VERSIONED_DIR/cua-driver-local"
+stage_binary "$BUILT_THEME_BINARY" "$VERSIONED_DIR/cua-cursor-theme"
 
 # Re-sign with a fresh ad-hoc signature.
 #

--- a/libs/cua-driver/scripts/_install-local-rust.sh
+++ b/libs/cua-driver/scripts/_install-local-rust.sh
@@ -13,6 +13,10 @@
 #   --autostart  register an auto-start daemon (macOS: LaunchAgent;
 #                Linux: systemd user unit). Default off; the post-install
 #                message prints the registration command for the platform.
+#   --bin-dir <path>
+#                install the visible symlink to <path> instead of
+#                ~/.local/bin. Takes precedence over
+#                CUA_DRIVER_LOCAL_INSTALL_DIR; must be absolute.
 #
 # Not for end-users — scripts/install.sh fetches a built release from
 # GitHub. This script is for the developer loop (rapid edit/build/test
@@ -77,6 +81,8 @@ fi
 
 BUILD_CONFIG="debug"
 INSTALL_AUTOSTART=false
+# Empty means "not passed" — the env var / default applies instead (see BIN_DIR below).
+BIN_DIR_OVERRIDE=""
 case "${CUA_DRIVER_REQUIRE_STABLE_SIGNING:-0}" in
     0|false|no|"") CUA_DRIVER_REQUIRE_STABLE_SIGNING=0 ;;
     1|true|yes) CUA_DRIVER_REQUIRE_STABLE_SIGNING=1 ;;
@@ -99,6 +105,17 @@ while [ "$#" -gt 0 ]; do
             CUA_DRIVER_REQUIRE_STABLE_SIGNING=1
             export CUA_DRIVER_REQUIRE_STABLE_SIGNING
             ;;
+        --bin-dir)
+            if [ "$#" -lt 2 ]; then
+                echo "${RED}Error: --bin-dir requires a value.${NORMAL}" >&2
+                exit 2
+            fi
+            BIN_DIR_OVERRIDE="$2"
+            shift
+            ;;
+        --bin-dir=*)
+            BIN_DIR_OVERRIDE="${1#*=}"
+            ;;
         --help|-h)
             echo "${BOLD}${BLUE}cua-driver-rs local installer${NORMAL}"
             echo "Usage: $0 [OPTIONS]"
@@ -112,6 +129,10 @@ while [ "$#" -gt 0 ]; do
             echo "                is attributed to com.trycua.driver.local (not your terminal),"
             echo "                so you grant Accessibility + Screen Recording once and"
             echo "                every cua-driver-local call/mcp routes through it correctly."
+            echo "  --bin-dir <path>"
+            echo "                Install the visible cua-driver-local symlink to <path>"
+            echo "                instead of ~/.local/bin. Must be an absolute path; takes"
+            echo "                precedence over CUA_DRIVER_LOCAL_INSTALL_DIR."
             echo "  --require-stable-signing"
             echo "                On macOS, stop before replacing the installed app unless"
             echo "                a certificate-backed identity is available. Recommended"
@@ -142,7 +163,18 @@ case "$OS" in
 esac
 
 HOME_DIR="${CUA_DRIVER_LOCAL_HOME:-$HOME/.cua-driver-local}"
-BIN_DIR="${CUA_DRIVER_LOCAL_INSTALL_DIR:-$HOME/.local/bin}"
+BIN_DIR="${BIN_DIR_OVERRIDE:-${CUA_DRIVER_LOCAL_INSTALL_DIR:-$HOME/.local/bin}}"
+# The symlink is created after this script cds into the Cargo workspace, so a
+# relative path would silently land inside rust/ — and uninstall-local.sh
+# rejects relative values outright, leaving it unremovable. Fail loudly instead.
+case "$BIN_DIR" in
+    /*) ;;
+    *)
+        echo "${RED}Error: bin dir must be an absolute path (got: $BIN_DIR).${NORMAL}" >&2
+        echo "Set it via --bin-dir /abs/path or CUA_DRIVER_LOCAL_INSTALL_DIR=/abs/path." >&2
+        exit 2
+        ;;
+esac
 RELEASES_DIR="$HOME_DIR/packages/releases"
 CURRENT_LINK="$HOME_DIR/packages/current"
 

--- a/libs/cua-driver/scripts/tests/test_install_local.py
+++ b/libs/cua-driver/scripts/tests/test_install_local.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -206,6 +207,46 @@ def test_relative_bin_dir_is_rejected(tmp_path: Path) -> None:
 
     assert result.returncode == 2, result.stdout + result.stderr
     assert "absolute path" in result.stderr
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"), reason="ETXTBSY on a running binary is Linux-specific"
+)
+def test_reinstall_over_a_running_driver(tmp_path: Path) -> None:
+    """Staging must replace the versioned binary by rename, not write through it.
+
+    The version tag is stable per build config, so every rebuild targets the
+    same path. If a previous cua-driver-local is still executing out of it, a
+    write-in-place `cp` fails with ETXTBSY ("Text file busy") and the install
+    dies mid-stage. Reproduce that with a real running executable.
+    """
+    scripts_dir, _, env = _linux_fixture(tmp_path)
+    versioned = (
+        tmp_path / "local-home/packages/releases/0.0.0-local-debug-x86_64-unknown-linux-gnu"
+    )
+    versioned.mkdir(parents=True)
+    busy = versioned / "cua-driver-local"
+    shutil.copy2("/bin/sleep", busy)
+
+    running = subprocess.Popen([str(busy), "60"])
+    try:
+        result = subprocess.run(
+            ["/bin/bash", str(scripts_dir / DISPATCHER.name)],
+            cwd=scripts_dir.parent,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    finally:
+        running.terminate()
+        running.wait(timeout=10)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Text file busy" not in result.stderr
+    assert busy.read_text() == "fresh driver\n"
+    # The rename must not leave the temp file behind.
+    assert not list(versioned.glob("*.stage.*"))
 
 
 def test_bin_dir_without_value_is_rejected(tmp_path: Path) -> None:

--- a/libs/cua-driver/scripts/tests/test_install_local.py
+++ b/libs/cua-driver/scripts/tests/test_install_local.py
@@ -9,6 +9,7 @@ import pytest
 
 INSTALL_LOCAL = Path(__file__).resolve().parents[1] / "_install-local-rust.sh"
 LOCAL_SIGNING = INSTALL_LOCAL.with_name("_local-signing.sh")
+DISPATCHER = INSTALL_LOCAL.with_name("install-local.sh")
 
 
 def _write_executable(path: Path, body: str) -> None:
@@ -112,3 +113,112 @@ esac
     ).read_text() == '{"version":5}\n'
     assert (installed_helper / "metadata.json").read_text() == '{"version":5}\n'
     assert (installed_helper / "extension.js").read_text() == "// semantic cursor v5\n"
+
+
+def _linux_fixture(tmp_path: Path) -> tuple[Path, Path, dict[str, str]]:
+    """Stage a minimal Linux install-local fixture: (scripts_dir, fake_bin, env)."""
+    fixture_root = tmp_path / "cua-driver"
+    scripts_dir = fixture_root / "scripts"
+    rust_dir = fixture_root / "rust"
+    scripts_dir.mkdir(parents=True)
+    rust_dir.mkdir()
+    for script in (INSTALL_LOCAL, LOCAL_SIGNING, DISPATCHER):
+        shutil.copy2(script, scripts_dir / script.name)
+
+    fake_bin = tmp_path / "fake-bin"
+    _write_executable(
+        fake_bin / "cargo",
+        """set -eu
+mkdir -p "$CARGO_TARGET_DIR/debug"
+printf 'fresh driver\n' > "$CARGO_TARGET_DIR/debug/cua-driver"
+printf 'fresh cursor theme compiler\n' > "$CARGO_TARGET_DIR/debug/cua-cursor-theme"
+chmod +x "$CARGO_TARGET_DIR/debug/cua-driver"
+chmod +x "$CARGO_TARGET_DIR/debug/cua-cursor-theme"
+""",
+    )
+    _write_executable(
+        fake_bin / "uname",
+        """case "${1:-}" in
+    -s) printf 'Linux\n' ;;
+    -m) printf 'x86_64\n' ;;
+    *) exit 2 ;;
+esac
+""",
+    )
+    _write_executable(fake_bin / "systemctl", "exit 0")
+    _write_executable(fake_bin / "pkill", "exit 0")
+
+    env = os.environ.copy()
+    env.pop("SUDO_USER", None)
+    env.pop("CARGO_TARGET_DIR", None)
+    env.pop("CUA_DRIVER_LOCAL_INSTALL_DIR", None)
+    env.update(
+        {
+            "HOME": str(tmp_path / "home"),
+            "PATH": f"{fake_bin}:/usr/bin:/bin",
+            "CUA_DRIVER_SOURCE_SHA": "a" * 40,
+            "CUA_DRIVER_LOCAL_HOME": str(tmp_path / "local-home"),
+        }
+    )
+    return scripts_dir, fake_bin, env
+
+
+@pytest.mark.parametrize(
+    "flag_form",
+    [["--bin-dir", "{bin}"], ["--bin-dir={bin}"]],
+    ids=["separate", "equals"],
+)
+def test_dispatcher_forwards_bin_dir_override(tmp_path: Path, flag_form: list[str]) -> None:
+    """--bin-dir is documented by install-local.sh and forwarded verbatim; the
+    helper must accept both spellings and honor them over the env default."""
+    scripts_dir, _, env = _linux_fixture(tmp_path)
+    flag_bin = tmp_path / "flag-bin"
+    env["CUA_DRIVER_LOCAL_INSTALL_DIR"] = str(tmp_path / "env-bin")
+    args = [arg.format(bin=flag_bin) for arg in flag_form]
+
+    result = subprocess.run(
+        ["/bin/bash", str(scripts_dir / DISPATCHER.name), *args],
+        cwd=scripts_dir.parent,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (flag_bin / "cua-driver-local").read_text() == "fresh driver\n"
+    assert not (tmp_path / "env-bin").exists()
+
+
+def test_relative_bin_dir_is_rejected(tmp_path: Path) -> None:
+    """A relative bin dir would land inside the Cargo workspace (the symlink is
+    created after cd'ing there) and uninstall-local.sh could never remove it."""
+    scripts_dir, _, env = _linux_fixture(tmp_path)
+
+    result = subprocess.run(
+        ["/bin/bash", str(scripts_dir / DISPATCHER.name), "--bin-dir", "relative/bin"],
+        cwd=scripts_dir.parent,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "absolute path" in result.stderr
+
+
+def test_bin_dir_without_value_is_rejected(tmp_path: Path) -> None:
+    scripts_dir, _, env = _linux_fixture(tmp_path)
+
+    result = subprocess.run(
+        ["/bin/bash", str(scripts_dir / DISPATCHER.name), "--bin-dir"],
+        cwd=scripts_dir.parent,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "--bin-dir requires a value" in result.stderr


### PR DESCRIPTION
## Behavior

Two defects in the cua-driver local/debug installer.

### 1. Re-installing over a running driver aborts mid-stage (primary)

Re-running `install-local.sh` while a `cua-driver-local` daemon is still executing kills the install:

```
Staging into ~/.cua-driver-local/packages/releases/0.0.0-local-debug-x86_64-unknown-linux-gnu
cp: cannot create regular file '.../cua-driver-local': Text file busy
```

The version tag is stable per build config (`0.0.0-local-$BUILD_CONFIG`), so every rebuild stages to the *same* path. `cp` opens that path with `O_TRUNC` to write in place, and Linux refuses the open with `ETXTBSY` while the file is being executed. This hits the normal developer loop — build, run, rebuild.

The script's own daemon stop cannot cover it: despite being titled "Stop any pre-swap cua-driver daemons", it runs ~200 lines *after* the staging copy, and a manually launched `serve` is not always reachable by it anyway.

Fix: copy to a temp file in the same directory and `mv` over the destination. `rename(2)` has no such restriction — the running process keeps executing the old inode until it exits, and the new bytes are published atomically, so a concurrent exec sees either the whole old binary or the whole new one. Applied to both staged binaries.

### 2. The documented `--bin-dir` flag was never implemented

`install-local.sh:14` documents `--bin-dir <path>` and its catch-all forwards it verbatim, but `_install-local-rust.sh` had no case for it, so every use exited 1 with `Unknown option: --bin-dir` before building anything.

- Parses `--bin-dir <path>` and `--bin-dir=<path>`, the two spellings the release installer already accepts (`_install-rust.sh:149-150`). Missing value exits 2.
- Precedence flag → `CUA_DRIVER_LOCAL_INSTALL_DIR` → `~/.local/bin`, applied at the existing `BIN_DIR` assignment, so the env-var path is unchanged.
- Rejects a relative bin dir (exit 2): the visible symlink is created after the script `cd`s into the Cargo workspace, so a relative path landed inside `rust/`, and `uninstall-local.sh:47` refuses relative values, leaving it unremovable.
- Documented in the header comment and `--help`.

No production driver code changes; developer-loop installer only.

## Validation

Added to `scripts/tests/test_install_local.py`, on a shared minimal Linux fixture:

- **`test_reinstall_over_a_running_driver`** — copies a real ELF (`/bin/sleep`) to the exact versioned path, executes it, then runs the installer and asserts success, no `Text file busy`, updated content, and no leftover temp file. Skipped off Linux, where `ETXTBSY` does not apply. This test fails on the parent commit with the error above.
- both `--bin-dir` spellings routed through the dispatcher, asserting the binary lands in the flag dir and the env dir is not created;
- relative bin dir and missing value each rejected with exit 2.

Locally I could not run pytest (not installed, package installs unavailable in my environment), so I verified with equivalent shell harnesses driving the real scripts, including a before/after comparison against the parent commit that reproduces the `ETXTBSY` failure and shows it resolved. CI (`CI: Test Scripts`, triggered by `libs/cua-driver/scripts/**`) is the authority on the pytest run.

## Known gaps

Unrelated stale comment left alone: `_install-local-rust.sh` refers to the staged skills dir as `Skills/cua-driver-rs`, but it stages `Skills/cua-driver`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)