### PR TITLE
ci: ignore Hermes service coauthor in release attribution

### DIFF
--- a/.github/release-attribution-config.json
+++ b/.github/release-attribution-config.json
@@ -12,6 +12,7 @@
     "coding-sub-agent@trycua.com",
     "codex@openai.com",
     "cua@cua.localdomain",
+    "hermes@hermes.home.arpa",
     "noreply@anthropic.com"
   ],
   "coauthorOverrides": {


### PR DESCRIPTION
## Summary

- classify the Hermes service-account coauthor email as non-human release metadata
- unblock contributor manifest generation for Cua Driver 0.18.0

## Root cause

The 0.18.0 release commit range includes an automated coauthor trailer for `hermes@hermes.home.arpa`. Release attribution treated that service identity as an unresolved human contributor and failed closed.

## Validation

- `uv run --with pytest pytest .github/scripts/tests/test_release_attribution.py .github/scripts/tests/test_pr_attribution.py -q` (31 passed)
- replayed `release_attribution.py collect` against the current #2836 head with this config (29 changes, 22 contributors)