### PR TITLE
ci: map local Francesco coauthor identity

### DIFF
--- a/.github/release-attribution-config.json
+++ b/.github/release-attribution-config.json
@@ -22,6 +22,7 @@
     "ddupont@mit.edu": "ddupont808",
     "egnichtel@crosscode.com": "ngnichtel",
     "f@trycua.com": "f-trycua",
+    "fbonacci@fbonacci-xfce-vm.b40fumexvs1ujlod2ppcyfh5qa.bx.internal.cloudapp.net": "f-trycua",
     "i@jyunko.cn": "HsiangNianian",
     "klymenko@adobe.com": "pavelklymenko",
     "m.fuechtenkoetter@posteo.de": "ai-ag2026",


### PR DESCRIPTION
## Summary

- map the machine-local Francesco coauthor identity from #2889 to the verified `f-trycua` account
- unblock trusted attribution for the Cua Driver 0.18.0 release manifest

Salvaged from #2889

## Validation

- exact release-PR attribution replay succeeds for 0.18.0
- generated manifest contains 30 changes and 22 contributors
- `git diff --check` passes

This is an identity override for a human contributor, not a bot-ignore rule.