### PR TITLE
ci(cua-driver): run distro checks after publication

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -190,7 +190,7 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertIn('CUA_DRIVER_RS_TELEMETRY_ENABLED: "false"', workflow)
         self.assertIn('CUA_TELEMETRY_ENABLED: "false"', workflow)
 
-    def test_distro_compat_does_not_run_for_unreleased_source_changes(self) -> None:
+    def test_distro_compat_does_not_run_for_source_changes_or_candidate_tags(self) -> None:
         workflow = self.read(".github/workflows/ci-distro-compat-cua-driver.yml")
 
         self.assertNotIn('      - "libs/cua-driver/rust/**"', workflow)
@@ -198,8 +198,23 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
             workflow.count('      - ".github/workflows/ci-distro-compat-cua-driver.yml"'),
             2,
         )
-        self.assertIn('      - "cua-driver-rs-v*"', workflow)
+        self.assertNotIn('      - "cua-driver-rs-v*"', workflow)
+        self.assertNotIn("  release:\n", workflow.split("permissions:", 1)[0])
         self.assertIn("  workflow_dispatch:", workflow)
+
+    def test_driver_publish_dispatches_distro_compat_after_public_visibility(self) -> None:
+        workflow = self.read(".github/workflows/cd-rust-cua-driver.yml")
+
+        verify = workflow.index("- name: Verify the release and every staged asset are public")
+        dispatch = workflow.index("- name: Dispatch released-binary distro compatibility")
+        self.assertGreater(dispatch, verify)
+        release_job = workflow.index("  release:\n")
+        self.assertIn("      actions: write", workflow[release_job:verify])
+        self.assertNotIn("  actions: write", workflow[:release_job])
+        self.assertIn("gh workflow run ci-distro-compat-cua-driver.yml", workflow)
+        self.assertIn('--ref main', workflow)
+        self.assertIn('-f "version=$VERSION"', workflow)
+        self.assertIn("GH_TOKEN: ${{ github.token }}", workflow[dispatch:])
 
     def test_expensive_rust_workflows_do_not_watch_the_entire_tree(self) -> None:
         for relative_path in (
@@ -552,11 +567,12 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertIn(".stdout(Stdio::null())", telemetry)
         self.assertIn(".stderr(Stdio::null())", telemetry)
 
-    def test_released_linux_smoke_waits_for_assets_and_installs_xkbcommon(self) -> None:
+    def test_released_linux_smoke_waits_only_for_public_cdn_and_installs_xkbcommon(self) -> None:
         workflow = self.read(".github/workflows/ci-distro-compat-cua-driver.yml")
 
-        self.assertIn("for attempt in $(seq 1 90)", workflow)
-        self.assertIn("release asset was still unavailable after 15 minutes", workflow)
+        self.assertIn("for attempt in $(seq 1 12)", workflow)
+        self.assertIn("published release asset was still unavailable after 1 minute", workflow)
+        self.assertNotIn("tag-triggered compatibility run", workflow)
         self.assertEqual(workflow.count("libxkbcommon0"), 4)
         self.assertEqual(workflow.count('libxkbcommon"'), 2)
 

--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -582,6 +582,11 @@ jobs:
       [build-linux, build-windows, build-macos-universal, verify-release-artifacts]
     if: github.event_name == 'workflow_dispatch' && inputs.publish == true
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      issues: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -795,6 +800,16 @@ jobs:
             sed 's/^/  - /' "${RUNNER_TEMP}/missing-release-assets.txt" >&2
           fi
           exit 1
+
+      - name: Dispatch released-binary distro compatibility
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh workflow run ci-distro-compat-cua-driver.yml \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            -f "version=$VERSION"
 
       - name: Generate post-publication GitHub App token
         id: post-publish-app-token

--- a/.github/workflows/ci-distro-compat-cua-driver.yml
+++ b/.github/workflows/ci-distro-compat-cua-driver.yml
@@ -21,13 +21,14 @@ name: "CI: cua-driver distro-compat matrix"
 #     behavior stays in the canonical Rust X11 and Wayland E2E workflows.
 #   - Non-blocking by default (continue-on-error: true) — the released binary
 #     may not exist yet on a fresh branch; the job is informational until the
-#     first linux release tag exists.
+#     first Linux release exists.
 #
 # Trigger workflow changes in PRs and on main so edits to this matrix validate
 # against the current release. Source changes do not run this workflow because
 # it downloads a published binary rather than building the proposed commit.
-# Release tags always run the matrix against the matching artifact, and
-# workflow_dispatch remains available for maintainer-requested validation.
+# The Cua Driver release finalizer dispatches the matrix against the matching
+# public artifact after publication. workflow_dispatch also remains available
+# for maintainer-requested validation.
 #
 # Companion to the Rust desktop E2E workflows; it validates released binaries,
 # not source-built harness behavior.
@@ -37,11 +38,8 @@ on:
     paths:
       - ".github/workflows/ci-distro-compat-cua-driver.yml"
   push:
-    # Path filters do not apply to tag pushes, so every release tag still runs.
     # Main-branch pushes run only when the matrix itself changes.
     branches: [main]
-    tags:
-      - "cua-driver-rs-v*"
     paths:
       - ".github/workflows/ci-distro-compat-cua-driver.yml"
   workflow_dispatch:
@@ -74,8 +72,6 @@ jobs:
         run: |
           if [[ -n "$INPUT_VERSION" ]]; then
             VERSION="$INPUT_VERSION"
-          elif [[ "$GITHUB_REF" == refs/tags/cua-driver-rs-v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/cua-driver-rs-v}"
           else
             # Fetch the latest release that matches the cua-driver-rs-v* pattern.
             # The releases are marked prerelease=true so we use /releases instead
@@ -104,20 +100,19 @@ jobs:
         env:
           BINARY_URL: ${{ steps.pick.outputs.binary_url }}
         run: |
-          # The tag and desktop CD workflows start at the same time. Building,
-          # notarizing, and publishing every platform can take several minutes,
-          # so a tag-triggered compatibility run must wait for the release asset
-          # instead of treating the initial 404 as a broken release.
-          for attempt in $(seq 1 90); do
+          # The release finalizer dispatches only after it verifies the assets
+          # are public. Keep a short retry window for public CDN propagation,
+          # not candidate build or certification time.
+          for attempt in $(seq 1 12); do
             if curl -fsSL "$BINARY_URL" -o cua-driver-release.tar.gz; then
               exit 0
             fi
-            if [[ "$attempt" -eq 90 ]]; then
-              echo "ERROR: release asset was still unavailable after 15 minutes"
+            if [[ "$attempt" -eq 12 ]]; then
+              echo "ERROR: published release asset was still unavailable after 1 minute"
               exit 1
             fi
-            echo "Release asset not available yet (attempt ${attempt}/90); retrying in 10s..."
-            sleep 10
+            echo "Published release asset not available yet (attempt ${attempt}/12); retrying in 5s..."
+            sleep 5
           done
 
       - name: Cache released binary for matrix


### PR DESCRIPTION
## Summary

- stop starting released-binary distro compatibility from the private candidate tag
- dispatch the standalone distro matrix from the Cua Driver finalizer only after it verifies the release and every staged asset are public
- scope `actions: write` to the finalizer job and pass the exact published version to the dispatch
- retain a one-minute retry window only for public CDN propagation
- add release-wiring regressions for the trigger and dispatch ordering

## Root cause

Tag candidate creation and distro compatibility started concurrently, but the release process intentionally keeps tag artifacts in a private draft until post-certification publication. The distro workflow therefore polled a public URL that could not exist during its 15-minute window.

GitHub also suppresses ordinary workflow-triggering events created with `GITHUB_TOKEN`, so this uses an explicit `workflow_dispatch` after publication instead of relying on `release.published`.

Fixes #2896.

## Validation

- `python3 .github/scripts/tests/test_cua_driver_release_wiring.py` (36 passed)
- full `.github/scripts/tests` suite with Python 3.13 and test dependencies (75 passed)
- `actionlint` on the distro workflow
- `actionlint` on the release workflow with its two pre-existing diagnostics excluded (`macos-26` runner catalog and SC2129)
- Prettier check on the distro workflow
- YAML parse checks for both workflows
- `git diff --check`

The active release tag and draft were not changed.