### PR TITLE
fix(cua-driver): tolerate missing local autostart task

### DIFF
--- a/libs/cua-driver/scripts/install-local.ps1
+++ b/libs/cua-driver/scripts/install-local.ps1
@@ -148,7 +148,17 @@ function Register-CuaDriverAutostart {
 }
 
 function Stop-CuaDriverLocalDaemons {
-    & schtasks.exe /End /TN "cua-driver-local-serve" 2>$null | Out-Null
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        # A missing or already-stopped task is expected during a first local
+        # install. Windows PowerShell can surface native stderr as a terminating
+        # error under the installer's ErrorActionPreference=Stop even though it
+        # is redirected, so keep this best-effort operation non-terminating.
+        & schtasks.exe /End /TN "cua-driver-local-serve" 2>$null | Out-Null
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
     Get-Process -Name "cua-driver-local","cua-driver-uia-local" -ErrorAction SilentlyContinue |
         Stop-Process -Force -ErrorAction SilentlyContinue
 }

--- a/libs/cua-driver/scripts/tests/install-windows-regression.ps1
+++ b/libs/cua-driver/scripts/tests/install-windows-regression.ps1
@@ -1,6 +1,7 @@
 [CmdletBinding()]
 param(
-    [string]$InstallerPath = (Join-Path (Split-Path -Parent $PSScriptRoot) "install.ps1")
+    [string]$InstallerPath = (Join-Path (Split-Path -Parent $PSScriptRoot) "install.ps1"),
+    [string]$LocalInstallerPath = (Join-Path (Split-Path -Parent $PSScriptRoot) "install-local.ps1")
 )
 
 Set-StrictMode -Version Latest
@@ -42,17 +43,37 @@ if ($parseErrors.Count -ne 0) {
 Import-InstallerFunction -Ast $ast -Name "Get-AncestorProcessIds"
 Import-InstallerFunction -Ast $ast -Name "Remove-LegacyInstall"
 
+$localTokens = $null
+$localParseErrors = $null
+$localAst = [System.Management.Automation.Language.Parser]::ParseFile(
+    $LocalInstallerPath,
+    [ref]$localTokens,
+    [ref]$localParseErrors)
+if ($localParseErrors.Count -ne 0) {
+    throw "install-local.ps1 parse errors: $($localParseErrors -join '; ')"
+}
+Import-InstallerFunction -Ast $localAst -Name "Stop-CuaDriverLocalDaemons"
+
 $script:Steps = @()
 $script:TaskkillCalls = @()
 $script:ScheduledTaskCalls = @()
 $script:StoppedProcessIds = @()
 $script:Processes = @()
 $script:ParentByPid = @{}
+$script:SchtasksMissingTask = $false
 
 function Write-Step { param($Message); $script:Steps += [string]$Message }
 function Start-Sleep { [CmdletBinding()] param([int]$Milliseconds, [int]$Seconds) }
 function taskkill.exe { $script:TaskkillCalls += ,@($args); $global:LASTEXITCODE = 0 }
-function schtasks.exe { $script:ScheduledTaskCalls += ,@($args); $global:LASTEXITCODE = 0 }
+function schtasks.exe {
+    $script:ScheduledTaskCalls += ,@($args)
+    if ($script:SchtasksMissingTask) {
+        $global:LASTEXITCODE = 1
+        Write-Error "ERROR: The system cannot find the file specified."
+        return
+    }
+    $global:LASTEXITCODE = 0
+}
 function Get-CimInstance {
     [CmdletBinding()]
     param([string]$ClassName, [string]$Filter)
@@ -72,6 +93,30 @@ function Stop-Process {
     [CmdletBinding()]
     param([int]$Id, [switch]$Force)
     $script:StoppedProcessIds += $Id
+}
+
+# Windows PowerShell 5.1 can promote a native program's stderr to a
+# terminating error when the caller uses ErrorActionPreference=Stop. A missing
+# local autostart task is normal on first install and must not prevent the
+# process cleanup fallback or change the caller's preference.
+$script:SchtasksMissingTask = $true
+$script:Processes = @(
+    [pscustomobject]@{ Id = 4400; ProcessName = "cua-driver-local" }
+)
+$savedErrorActionPreference = $ErrorActionPreference
+try {
+    $ErrorActionPreference = "Stop"
+    Stop-CuaDriverLocalDaemons
+    Assert-True ($ErrorActionPreference -eq "Stop") `
+        "local daemon cleanup did not restore ErrorActionPreference"
+    Assert-True ($script:StoppedProcessIds -contains 4400) `
+        "missing local autostart task prevented process cleanup"
+}
+finally {
+    $script:SchtasksMissingTask = $false
+    $script:Processes = @()
+    $script:StoppedProcessIds = @()
+    $ErrorActionPreference = $savedErrorActionPreference
 }
 
 $savedInstallDir = $env:CUA_DRIVER_RS_INSTALL_DIR


### PR DESCRIPTION
## What changed

- make the local Windows installer's Scheduled Task stop best-effort under `ErrorActionPreference=Stop`
- restore the caller's error preference in `finally`
- extend the Windows installer regression test with a simulated missing-task stderr path and process-cleanup assertion

## Root cause

Windows PowerShell 5.1 can surface stderr from `schtasks.exe /End` as a terminating native-command error even when stderr is redirected. A missing `cua-driver-local-serve` task is normal on first install, but the exception aborted `install-local.ps1` after it had already renamed the previous destination binary.

The production installer helper already contains the same defensive error-preference pattern for its best-effort task cleanup; this applies it to the local installer.

## Impact

The first local install/update no longer requires a second run when the local autostart task is absent or already stopped. Real process cleanup still runs, and the caller's error behavior is unchanged after the helper returns.

Fixes #2898.

## Validation

- `git diff --check`
- Windows PowerShell 5.1 parse check for both changed scripts
- focused Windows regression with simulated `schtasks` missing-task stderr under `ErrorActionPreference=Stop`: process fallback ran and the caller preference was restored
- full repository Windows checks: pending on this draft PR
