### PR TITLE
docs(cua-driver): converge canonical desktop E2E guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,32 @@ After merge, run a short main-branch smoke and release-path verification. Repeat
 the full matrix after merge only when the merge result materially differs from
 the certified candidate or the smoke test exposes a regression.
 
+## Canonical Cua Driver desktop E2E
+
+Use the repository harnesses as the source of truth for desktop behavior:
+
+```text
+Windows: .\scripts\ci\windows\run-rust-e2e.ps1 -RequireGui
+Linux:   scripts/ci/linux/run-rust-e2e.sh
+macOS:   libs/cua-driver/tests/runners/macos-lume/run-all.sh
+```
+
+- Prefer the GitHub-hosted Windows workflow when its strict preflight proves an
+  interactive desktop. Do not assume that GitHub-hosted Windows runs in Session
+  0. Azure RDP is an optional environment-parity replay, not the canonical gate.
+- Use the GitHub-hosted Linux X11 workflow for the supported Linux gate. Keep
+  Nix source checks and compositor-specific Wayland lanes as their documented
+  separate gates.
+- Run macOS through the logged-in, TCC-authorized Lume maintainer wrapper. When
+  installed-browser behavior is in scope, include `--standalone-browser`.
+- Treat one-off Calculator, browser, or other app smokes and manually produced
+  recordings as supporting diagnostics. They never replace the complete
+  harness result at the exact candidate SHA.
+
+Historical plans, journals, and evidence reports describe the environments used
+at the time. They do not override the current commands and authority defined in
+`libs/cua-driver/docs/test-harnesses-guide.md` and `scripts/ci/README.md`.
+
 ## Pull request titles and component releases
 
 Pull requests are squash-merged, so the pull request title becomes the commit

--- a/libs/cua-driver/docs/test-harnesses-guide.md
+++ b/libs/cua-driver/docs/test-harnesses-guide.md
@@ -30,6 +30,26 @@ The OS workflow may fan the complete matrix out into independent jobs for
 reporting and failure isolation. That is an execution detail; contributors
 should think of it as one canonical suite.
 
+### Evidence authority
+
+A canonical result is the complete repository harness run at the exact source
+SHA. A one-off app smoke, manually assembled script, video, or environment
+replay can diagnose a failure or provide release presentation evidence, but it
+does not replace the complete matrix.
+
+Windows and Linux use the repository's GitHub-hosted workflows when their
+strict environment preflights pass. Windows Azure RDP runs are optional
+environment-parity replays or a fallback when the hosted preflight cannot prove
+a required capability. macOS uses the logged-in Lume maintainer wrapper.
+For browser-facing changes or browser-use release certification, also run the
+standalone Chrome/Edge matrix: the macOS wrapper accepts
+`--standalone-browser`, while the Windows and Linux workflow is
+`.github/workflows/e2e-rust-standalone-browsers.yml`.
+
+Historical `*-plan.md`, `*-journal.md`, and release evidence documents record
+what was run at that time. They are not current execution instructions and do
+not override this guide or `scripts/ci/README.md`.
+
 ## Repository Map
 
 ```text

--- a/libs/cua-driver/tests/runners/windows-sandbox/README.md
+++ b/libs/cua-driver/tests/runners/windows-sandbox/README.md
@@ -1,8 +1,7 @@
-# Windows Sandbox Runner
+# Legacy Windows Sandbox runner
 
-Legacy Windows Sandbox runner for local smoke checks. It predates the Azure/RDP
-GUI validation flow and should not be treated as the canonical Windows desktop
-test entrypoint.
+This runner exists only for local smoke checks and must not be treated as the
+canonical Windows desktop test entrypoint.
 
 Run it from `libs/cua-driver` on a Windows host with Windows Sandbox enabled:
 
@@ -15,5 +14,9 @@ The host script builds selected Rust test binaries and Windows fixtures, maps
 `libs/cua-driver` into the sandbox as `C:\cua-driver`, and streams logs from the
 inside-sandbox runner.
 
-For current GUI validation, prefer a real user desktop session such as the
-Azure RDP/scheduled-task runner described in the Rust test README.
+For canonical GUI validation, dispatch `.github/workflows/e2e-rust-windows.yml`
+on the exact candidate SHA. Its GitHub-hosted runner is accepted only when the
+strict interactive-desktop preflight passes, then it runs
+`scripts/ci/windows/run-rust-e2e.ps1 -RequireGui`. Use Azure RDP only for an
+optional environment-parity replay or when the hosted preflight cannot prove a
+required capability.

--- a/libs/cua-driver/tests/runners/windows/README.md
+++ b/libs/cua-driver/tests/runners/windows/README.md
@@ -1,6 +1,15 @@
-# Windows Rust Runner
+# Windows Rust runner
 
-Canonical Windows Rust harness runner for an interactive user desktop.
+This directory keeps a local convenience wrapper for an interactive user
+desktop. From the repository root, the canonical command is:
+
+```powershell
+.\scripts\ci\windows\run-rust-e2e.ps1 -RequireGui
+```
+
+Maintainer certification normally dispatches
+`.github/workflows/e2e-rust-windows.yml` on the exact candidate SHA. The
+GitHub-hosted runner is canonical when its strict desktop preflight passes.
 
 Run from `libs/cua-driver` in an RDP or console session:
 
@@ -9,6 +18,7 @@ Run from `libs/cua-driver` in an RDP or console session:
 .\tests\runners\windows\run-all.ps1 -RequireGui
 ```
 
-The runner builds repo-local Windows fixtures and runs the Rust unit and typed
-harness matrix. It intentionally skips optional external-app suites such as
-LibreOffice because those require extra software on the VM image.
+The convenience wrapper delegates to the same canonical runner, builds
+repo-local Windows fixtures, and runs the Rust unit and typed harness matrix.
+It intentionally skips optional external-app suites such as LibreOffice because
+those require extra software on the environment image.

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -94,6 +94,12 @@ private `CUA_E2E_INTERNAL_LANE` partition to `shared`, `native`, or `capture`
 when it fans the same matrix into independent jobs. Those values are not public
 alternate suites.
 
+The complete harness result at the exact source SHA is the behavioral gate.
+Manual app smokes, standalone videos, legacy runners, and environment-parity
+replays are useful diagnostics but cannot replace it. When installed-browser
+behavior is in scope, run the standalone browser suite in addition to the
+complete repo-local matrix.
+
 The maintainer-facing macOS command is
 `libs/cua-driver/tests/runners/macos-lume/run-all.sh`. It verifies the private
 Lume seed, installs the exact committed source, and then delegates to the thin


### PR DESCRIPTION
## What changed

- defines the complete repository harness at the exact candidate SHA as the canonical desktop E2E gate
- uses GitHub-hosted Windows and Linux workflows when their strict environment preflights pass
- keeps Azure RDP as an optional parity replay or fallback, not the default Windows gate
- labels manual app smokes, recordings, legacy runners, and historical plans as supporting evidence rather than substitutes for the canonical matrix
- points browser-use certification to the standalone Chrome and Edge matrix in addition to the OS harness

## Why

The active documentation still contained legacy Azure-first wording and did not consistently distinguish canonical certification from useful manual diagnostics. That made release validation easy to misread.

## Validation

- `git diff --check`
- audited active Cua Driver E2E docs, runner READMEs, and workflow entrypoints for contradictory Azure-first or manual-smoke-as-gate guidance
- verified the documented commands and workflow paths exist at `81a2e42f122087d23b4fe6bf68069848f63e1a09`