### PR TITLE
test(cua-driver): guard legacy action result normalization

### DIFF
--- a/libs/cua-driver/docs/action-result-contract.md
+++ b/libs/cua-driver/docs/action-result-contract.md
@@ -39,7 +39,8 @@ The action-result tools are:
 `click`, `double_click`, `right_click`, `scroll`, `drag`, `mouse_drag`,
 `parallel_mouse_drag`, `move_cursor`, `mouse_button_down`, `mouse_button_up`,
 `type_text`, `type_text_chars`, `press_key`, `hotkey`, `set_value`,
-`browser_click`, `browser_pointer`, and `browser_type`.
+`set_window_frame`, `invoke_menu`, `browser_click`, `browser_pointer`, and
+`browser_type`.
 
 Other mutating tools such as application launch, window activation, browser
 navigation, dialogs, uploads, and downloads retain their own typed results.

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/action_record.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/action_record.rs
@@ -1820,4 +1820,45 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn every_legacy_text_only_action_is_conservatively_unverifiable() {
+        let tools = [
+            "click",
+            "double_click",
+            "right_click",
+            "scroll",
+            "drag",
+            "mouse_drag",
+            "parallel_mouse_drag",
+            "move_cursor",
+            "mouse_button_down",
+            "mouse_button_up",
+            "type_text",
+            "type_text_chars",
+            "press_key",
+            "hotkey",
+            "set_value",
+            "browser_click",
+            "browser_pointer",
+            "browser_type",
+        ];
+
+        for tool in tools {
+            let record = ActionExecutionRecord::from_legacy(
+                tool,
+                &serde_json::json!({}),
+                &serde_json::Value::Null,
+            )
+            .unwrap_or_else(|| panic!("legacy text-only action {tool} must normalize"));
+            assert_eq!(
+                record.effect,
+                ActionEffect::Unverifiable,
+                "legacy text-only action {tool} must never imply confirmation"
+            );
+            record
+                .public_result()
+                .unwrap_or_else(|error| panic!("{tool} must publish: {error:?}"));
+        }
+    }
 }


### PR DESCRIPTION
## What changed

- add a regression test proving every remaining text-only legacy action becomes `unverifiable`
- add `set_window_frame` and `invoke_menu` to the documented action-result tool list

## Why

The #2885 investigation found that the shared dispatch seam already prevents platform-local legacy success payloads from becoming public false confirmation. This test keeps that behavior explicit without adding a second audit document.

## Validation

- `cargo fmt --all --check`
- `cargo test -p cua-driver-core` — 502 passed
- `cargo test -p cua-driver-contract` — 30 passed
- `cargo test -p platform-macos --lib` — 327 passed

Addresses #2885.