### PR TITLE
fix(cua-driver): keep remote debugging enabled when a restart is needed

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
@@ -892,6 +892,54 @@ impl BrowserPlatform for LinuxBrowserPlatform {
         };
         let endpoint = match endpoint_result {
             Ok(endpoint) => endpoint,
+            // The toggle took, but no endpoint appeared. That is Chromium's
+            // documented-by-behaviour semantics rather than a failure: "Allow
+            // remote debugging for this browser instance" persists a preference
+            // that the browser acts on at its NEXT launch — verified on Chrome
+            // 151 by enabling it and observing no listener for 25s, then a
+            // listener on 127.0.0.1 plus a DevToolsActivePort file immediately
+            // after a restart with no --remote-debugging-port flag.
+            //
+            // Rolling back here erased the setting moments before the restart
+            // that would activate it, so this path could never succeed. Keep the
+            // preference, close the temporary tab, and tell the caller the one
+            // thing it needs to do. The profile is armed, not broken.
+            Err(error)
+                if enabled_remote_debugging
+                    && error.code == BrowserRefusalCode::BrowserRequiresSetup =>
+            {
+                let closed = tokio::task::spawn_blocking(move || handle.close_for_success())
+                    .await
+                    .map_err(|join_error| {
+                        refusal(
+                            BrowserRefusalCode::BrowserRouteUnavailable,
+                            format!("could not finish browser setup cleanup: {join_error}"),
+                        )
+                    })??;
+                return Err(refusal(
+                    BrowserRefusalCode::BrowserRequiresSetup,
+                    format!(
+                        "remote debugging is now enabled for this {} profile, but {} only opens \
+                         its debugging endpoint at startup. Restart the browser, then call \
+                         browser_prepare again — the setting persists and does not need to be \
+                         applied twice.",
+                        descriptor.product_name, descriptor.product_name
+                    ),
+                )
+                .with_detail(serde_json::json!({
+                    "restart_required": true,
+                    "remote_debugging_enabled": true,
+                    "setup_side_effects": {
+                        "opened_setup_page": opened_setup_page,
+                        "closed_setup_page": closed.unwrap_or(false),
+                        "enabled_remote_debugging": true,
+                        "restored_remote_debugging": false,
+                        "focused_setup_address_field": focused_setup_address_field,
+                        "foregrounded_window": foregrounded_window,
+                        "injected_global_input": injected_global_input,
+                    },
+                })));
+            }
             Err(error) => {
                 let error = tokio::task::spawn_blocking(move || handle.abort(error))
                     .await


### PR DESCRIPTION
Follow-up to #2895. Re-cut onto `main` after that merged (the original stacked PR, #2910, merged into its intermediate base rather than `main`).

## The bug

`setup_existing_profile_endpoint` toggles "Allow remote debugging for this browser instance", polls ~6s for a loopback endpoint, and on timeout **rolls the toggle back**.

That checkbox persists a *preference*. On a default user-data-dir Chrome acts on it at next launch, not immediately. Measured on Chrome 151 — enabled by hand, left enabled:

```
t=5s..25s   listeners=0
DevToolsActivePort: absent
```

Then restarted with **no** `--remote-debugging-port` flag:

```
LISTEN 127.0.0.1:9222  users:(("chrome",pid=111565,fd=142))
~/.config/google-chrome/DevToolsActivePort
```

The rollback erased the setting moments before the restart that would have activated it, so the route could never succeed on such a profile.

## The change

Treat that state as armed rather than broken: keep the preference, close the temporary tab, and refuse with the one action the caller must take. The refusal carries `restart_required: true` alongside the side-effect record so callers branch on a field instead of parsing prose. Genuine failures still roll back unchanged — the branch is guarded on `enabled_remote_debugging && code == BrowserRequiresSetup`.

## Verified / not verified

**Verified end to end** on Chrome 151: on a *non-default* user-data-dir the toggle opens a listener inside the existing 6s window and setup completes outright — navigate, match the exact checkbox, toggle, close the tab, attach:

```json
{"action":"attached_existing_profile","prepared":true,
 "endpoint_ownership":{"detail":"new PID-owned approval listener correlated with exact setup"},
 "side_effects":{"enabled_remote_debugging":true,"closed_setup_page":true}}
```

That is the first time this route has worked at all on Linux, and it comes from the navigation fix in #2895.

**Not re-observed after the change**: the restart-required branch itself. Reproducing needs a default-user-data-dir profile with debugging currently off, and the profile I measured it on now has debugging enabled. The branch is reasoned from the measurement above rather than re-triggered. It is strictly safer than the previous behaviour regardless — rolling back a persisted preference cannot be correct.

## Why it matters

Chrome ≥136 ignores `--remote-debugging-port` on the default user-data-dir (verified: same flag, same build, listener appears only with a non-default `--user-data-dir`). That makes this checkbox the only sanctioned route to CDP on a real user profile.

Tests: 229 passing.

Refs #2892

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zpeGjLTLSALtHsuxKLkNp