### PR TITLE
docs(cua-driver): serve demo media from GitHub attachments

### DIFF
--- a/docs/content/docs/concepts/the-no-foreground-contract.mdx
+++ b/docs/content/docs/concepts/the-no-foreground-contract.mdx
@@ -43,8 +43,8 @@ The Linux recordings below make that separation visible. Synthetic pointers act 
 
 <div className="not-prose my-8 grid gap-5 md:grid-cols-2">
   <VideoDemo
-    src="https://trycua.github.io/assets/videos/cua-driver/linux-multi-pointers.mp4"
-    poster="https://trycua.github.io/assets/posters/cua-driver/linux-multi-pointers.jpg"
+    src="https://github.com/user-attachments/assets/c4e23e2f-1112-4b7b-a575-c6185c78eda4"
+    poster="https://github.com/user-attachments/assets/b8257284-aef6-46a4-8250-61e6bf5fd57c"
     title="Four pointers across two XFCE windows"
     sourceUrl="https://x.com/trycua/status/2067639340738761015"
   >
@@ -52,8 +52,8 @@ The Linux recordings below make that separation visible. Synthetic pointers act 
   </VideoDemo>
 
   <VideoDemo
-    src="https://trycua.github.io/assets/videos/cua-driver/linux-wayland-16-cursors.mp4"
-    poster="https://trycua.github.io/assets/posters/cua-driver/linux-wayland-16-cursors.jpg"
+    src="https://github.com/user-attachments/assets/17696766-210d-40b7-b95a-e81be383cc6f"
+    poster="https://github.com/user-attachments/assets/cd354a0b-b0ca-4236-a640-eeb79c338d0c"
     title="Sixteen background windows on Wayland"
     sourceUrl="https://x.com/trycua/status/2067639344698179789"
   >
@@ -66,8 +66,8 @@ The agent tests and fixes an app while the terminal remains in front.
 
 <VideoDemo
   className="my-8"
-  src="https://trycua.github.io/assets/videos/cua-driver/macos-background-dev-loop.mp4"
-  poster="https://trycua.github.io/assets/posters/cua-driver/macos-background-dev-loop.jpg"
+  src="https://github.com/user-attachments/assets/ef3c7ad5-2689-4de5-b844-1c1bb3b621ae"
+  poster="https://github.com/user-attachments/assets/34217d66-c560-4532-a77b-67ea2f8885af"
   title="Fix and check an app without taking over the desktop"
   sourceUrl="https://x.com/trycua/status/2047383205444251889"
 >

--- a/docs/content/docs/concepts/what-is-cua-bench.mdx
+++ b/docs/content/docs/concepts/what-is-cua-bench.mdx
@@ -9,8 +9,8 @@ repeatable experiment across Linux, Windows, Android, browser, or simulated envi
 
 <VideoDemo
   className="my-8"
-  src="https://trycua.github.io/assets/videos/cua-bench/open-source-overview.mp4"
-  poster="https://trycua.github.io/assets/posters/cua-bench/open-source-overview.jpg"
+  src="https://github.com/user-attachments/assets/35bf5156-d326-4484-ad1a-87a7991c85f6"
+  poster="https://github.com/user-attachments/assets/1b60d1c6-06fb-47e3-97c0-726421cf45fb"
   title="An open-source registry and runner for computer-use tasks"
   sourceUrl="https://x.com/trycua/status/2014406820887183512"
 >

--- a/docs/content/docs/how-to-guides/driver/drive-a-web-page.mdx
+++ b/docs/content/docs/how-to-guides/driver/drive-a-web-page.mdx
@@ -10,8 +10,8 @@ binding.
 
 <VideoDemo
   className="my-8"
-  src="https://trycua.github.io/assets/videos/cua-driver/macos-background-chrome.mp4"
-  poster="https://trycua.github.io/assets/posters/cua-driver/macos-background-chrome.jpg"
+  src="https://github.com/user-attachments/assets/46f4be37-92c2-4360-bc20-bde35401bc71"
+  poster="https://github.com/user-attachments/assets/bcbe275a-9b37-4432-9f76-124d88574f6a"
   title="Chrome remains behind the agent terminal"
   sourceUrl="https://x.com/trycua/status/2047383209244287350"
 >

--- a/docs/content/docs/how-to-guides/driver/record-and-render-a-trajectory.mdx
+++ b/docs/content/docs/how-to-guides/driver/record-and-render-a-trajectory.mdx
@@ -8,8 +8,8 @@ import { Steps, Step } from 'fumadocs-ui/components/steps';
 Record an agent-driven task when you need both the action evidence and a short product demo. Cua Driver saves each action with before-and-after state, screenshots, and arguments. With video enabled, it also captures the display so you can render the trajectory with zoom effects around each action.
 
 <VideoDemo
-  src="https://trycua.github.io/assets/videos/cua-driver/macos-trajectory-capture.mp4"
-  poster="https://trycua.github.io/assets/posters/cua-driver/macos-trajectory-capture.jpg"
+  src="https://github.com/user-attachments/assets/9eafceca-1738-4e34-949a-2fb0dbe1832e"
+  poster="https://github.com/user-attachments/assets/d896dd2f-3f0a-4978-93a3-c9a5c562c3e8"
   title="Turn an agent trajectory into a zoom-on-click demo"
   sourceUrl="https://x.com/trycua/status/2047383207612645426"
 >

--- a/docs/content/docs/how-to-guides/recipes/automate-a-legacy-windows-app-behind-a-vpn.mdx
+++ b/docs/content/docs/how-to-guides/recipes/automate-a-legacy-windows-app-behind-a-vpn.mdx
@@ -9,8 +9,8 @@ import { Steps, Step } from 'fumadocs-ui/components/steps';
 When a desktop app has **no API** and only runs **behind the corporate VPN**, drive it where it already runs, on the Windows box inside the network. **Cua Driver** runs on that machine and exposes the app through MCP stdio tools, so the desktop session, app traffic, and staged files stay inside the VPN boundary. **No data leaves the VPN boundary.**
 
 <VideoDemo
-  src="https://trycua.github.io/assets/videos/cua-driver/windows-legacy-postal-app.mp4"
-  poster="https://trycua.github.io/assets/posters/cua-driver/windows-legacy-postal-app.jpg"
+  src="https://github.com/user-attachments/assets/11b248e5-d505-4349-aaae-ad9f95a1162f"
+  poster="https://github.com/user-attachments/assets/0fb62243-56ec-4d51-8771-35640a5e6031"
   title="Drive a legacy postal app while the terminal stays in front"
   sourceUrl="https://x.com/trycua/status/2059693301276565841"
 >

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -29,8 +29,8 @@ These recordings show agents operating desktop apps while the user's active wind
 
 <div className="not-prose my-8 grid gap-5 md:grid-cols-2">
   <VideoDemo
-    src="https://trycua.github.io/assets/videos/cua-driver/windows-wpf-agent-qa.mp4"
-    poster="https://trycua.github.io/assets/posters/cua-driver/windows-wpf-agent-qa.jpg"
+    src="https://github.com/user-attachments/assets/4159f98d-9623-40d0-a85f-37c913b1403b"
+    poster="https://github.com/user-attachments/assets/54536146-328a-431c-95b4-14a799248026"
     title="Build and check a WPF app on Windows"
     sourceUrl="https://x.com/trycua/status/2059688966085853245"
   >
@@ -38,8 +38,8 @@ These recordings show agents operating desktop apps while the user's active wind
   </VideoDemo>
 
   <VideoDemo
-    src="https://trycua.github.io/assets/videos/cua-driver/linux-headless-spreadsheet.mp4"
-    poster="https://trycua.github.io/assets/posters/cua-driver/linux-headless-spreadsheet.jpg"
+    src="https://github.com/user-attachments/assets/7096c772-aa24-4286-a453-6aedfbeb3e23"
+    poster="https://github.com/user-attachments/assets/74d428cb-1adc-4ebc-bc43-590f0966e84b"
     title="Fill a Linux spreadsheet over SSH"
     sourceUrl="https://x.com/trycua/status/2067639346719826213"
   >

--- a/docs/content/docs/reference/cua-driver/process-model.mdx
+++ b/docs/content/docs/reference/cua-driver/process-model.mdx
@@ -114,8 +114,8 @@ Concurrent hosts should always declare an explicit session.
 
 <VideoDemo
   className="my-8"
-  src="https://trycua.github.io/assets/videos/cua-driver/windows-hermes-four-agent-windows.mp4"
-  poster="https://trycua.github.io/assets/posters/cua-driver/windows-hermes-four-agent-windows.jpg"
+  src="https://github.com/user-attachments/assets/dcc5a81f-6379-4378-a225-adaf5dfa5dcd"
+  poster="https://github.com/user-attachments/assets/15091959-0f93-4076-9338-18ef3a737091"
   title="Four agent sessions share one Windows desktop"
   sourceUrl="https://x.com/francedot/status/2061706670208897279"
 >

--- a/docs/content/docs/tutorials/drive-your-first-app.mdx
+++ b/docs/content/docs/tutorials/drive-your-first-app.mdx
@@ -14,8 +14,8 @@ Linux.
 New to agents that operate applications? Start with [What is computer use?](/concepts/what-is-computer-use) for the model behind the workflow, then return here to build one.
 
 <VideoDemo
-  src="https://trycua.github.io/assets/videos/cua-driver/windows-msbuild-piano.mp4"
-  poster="https://trycua.github.io/assets/posters/cua-driver/windows-msbuild-piano.jpg"
+  src="https://github.com/user-attachments/assets/354af433-8769-44ff-beab-b5cb02ff798e"
+  poster="https://github.com/user-attachments/assets/6f878582-8f5d-4400-be44-fc503fcbc1ab"
   title="Preview: agents play a Windows piano app"
   sourceUrl="https://x.com/francedot/status/2062231318294131130"
   className="my-8"


### PR DESCRIPTION
Migrates the docs' demo media off the second asset host and onto GitHub user attachments.

## Why

The 11 video/poster pairs in the docs pointed at `trycua.github.io/assets`, backed by the separate `trycua/assets` repo. The blog already embeds its media as GitHub user attachments (~80 of them), so the docs were the outlier. This retires the extra host for docs media.

## What changed

All 22 files (11 `.mp4` + 11 `.jpg` posters) across 8 pages now reference `github.com/user-attachments/...`. Only the URLs changed — no prose, alt text, poster/`src` pairing, or page structure.

Assets were minted on the new `assets` branch (`ASSETS.md`), which exists solely to host attachments and is never merged. GitHub only publishes an attachment once the minting edit is committed, so that branch is what makes these URLs public.

## Verification

Every one of the 22 URLs returns **200** unauthenticated with the expected content type:

- 11 posters → `image/jpeg`
- 11 videos → `video/mp4`

Each also returns a byte size matching its source file exactly. That mattered for more than a spot-check: images are inserted with the source filename as alt text, but **videos are inserted as a bare URL with no identifying text**, so byte size is how each video URL was mapped back to its filename. All 11 video sizes are distinct, making the mapping unambiguous.

- Index page renders 200 locally with the new URLs and **zero** remaining `trycua.github.io/assets` references anywhere in `docs/content`.
- `pnpm docs:check-links` — 0 errors. `pnpm docs:check-hygiene` — passed.

## Note

`trycua/assets` still hosts the originals; nothing there was deleted. Retiring it is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)