### PR TITLE
docs(cua-driver): add an OpenClaw tab to the first-app tutorial

### DIFF
--- a/docs/content/docs/tutorials/drive-your-first-app.mdx
+++ b/docs/content/docs/tutorials/drive-your-first-app.mdx
@@ -119,7 +119,7 @@ If you see your running apps listed, the plumbing works. That is the only CLI yo
 
 Register Cua Driver with your agent harness once.
 
-<Tabs items={['Claude Code', 'Codex', 'Hermes']}>
+<Tabs items={['Claude Code', 'Codex', 'OpenClaw', 'Hermes']}>
   <Tab value="Claude Code">
     Install the Claude Code skill. This is turnkey: the skill teaches Claude Code how to drive apps through Cua Driver, and you then ask in plain English.
 
@@ -154,6 +154,23 @@ Register Cua Driver with your agent harness once.
 
     Restart Codex or open a fresh Codex session after registration so the new tools appear.
   </Tab>
+  <Tab value="OpenClaw">
+    Print the OpenClaw registration command:
+
+    ```bash
+    cua-driver mcp-config --client openclaw
+    ```
+
+    It prints a command you run to register the server, using the absolute installed binary path:
+
+    ```bash
+    openclaw mcp set cua-driver '{"command":"/Users/you/.local/bin/cua-driver","args":["mcp"]}'
+    ```
+
+    <Callout type="warn">
+      On macOS, a server spawned this way by the gateway does not inherit OpenClaw.app's own Accessibility and Screen Recording grants. If you are embedding Cua Driver inside OpenClaw rather than registering it as a separate MCP server, follow [Embedding](/reference/cua-driver/embedding) so the host owns the grants.
+    </Callout>
+  </Tab>
   <Tab value="Hermes">
     Print the Hermes snippet:
 
@@ -178,7 +195,7 @@ Register Cua Driver with your agent harness once.
   </Tab>
 </Tabs>
 
-Using Cursor, Gemini/Antigravity, OpenCode, OpenClaw, or Pi instead? See [Connect your agent](/how-to-guides/driver/connect-your-agent).
+Using Cursor, Gemini/Antigravity, OpenCode, or Pi instead? See [Connect your agent](/how-to-guides/driver/connect-your-agent).
 
 ## 4. Ask your agent
 


### PR DESCRIPTION
Follows an annotation on the tutorial's **3. Connect your agent** tabs.

## What changed

OpenClaw gets its own tab alongside Claude Code, Codex, and Hermes. Registering it is a one-liner just like the others, but it was only reachable via the "using something else?" link at the bottom of the step, so it's now removed from that trailing list.

The command is what `cua-driver mcp-config --client openclaw` actually emits — I ran it rather than composing one:

```
openclaw mcp set cua-driver '{"command":"/Users/you/.local/bin/cua-driver","args":["mcp"]}'
```

## macOS caveat included

The client table in `connect-your-agent.mdx` already records that a gateway-spawned MCP server does **not** inherit OpenClaw.app's own Accessibility and Screen Recording grants. That matters a lot in this tutorial, which is otherwise all about getting those grants attached to the right app, so the tab carries a `warn` callout pointing embedding hosts at [Embedding](/reference/cua-driver/embedding).

## Verification

- Page renders 200 locally; the tab, the `mcp-config` command, the emitted `openclaw mcp set` line, and the caveat all appear in the rendered output.
- `pnpm docs:check-links` — 0 errors. `pnpm docs:check-hygiene` — passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)