### PR TITLE
ci: harden Windows FFmpeg setup

### DIFF
--- a/.github/workflows/e2e-rust-standalone-browsers.yml
+++ b/.github/workflows/e2e-rust-standalone-browsers.yml
@@ -66,12 +66,7 @@ jobs:
       - name: Install Windows video tools
         if: runner.os == 'Windows'
         shell: pwsh
-        run: |
-          if (-not (Get-Command ffmpeg.exe -ErrorAction SilentlyContinue)) {
-            choco install ffmpeg -y --no-progress
-          }
-          ffmpeg -version
-          ffprobe -version
+        run: .\scripts\ci\windows\setup-ffmpeg.ps1
       - name: Install Linux desktop dependencies
         if: runner.os == 'Linux'
         shell: bash

--- a/.github/workflows/e2e-rust-windows.yml
+++ b/.github/workflows/e2e-rust-windows.yml
@@ -62,12 +62,7 @@ jobs:
           ref: ${{ needs.source.outputs.sha }}
       - name: Ensure FFmpeg for trajectory video
         shell: pwsh
-        run: |
-          if (-not (Get-Command ffmpeg.exe -ErrorAction SilentlyContinue)) {
-            choco install ffmpeg -y --no-progress
-          }
-          ffmpeg -version
-          ffprobe -version
+        run: .\scripts\ci\windows\setup-ffmpeg.ps1
       - name: Run shared Rust behavior matrix
         shell: pwsh
         env:
@@ -101,12 +96,7 @@ jobs:
           ref: ${{ needs.source.outputs.sha }}
       - name: Ensure FFmpeg for trajectory video
         shell: pwsh
-        run: |
-          if (-not (Get-Command ffmpeg.exe -ErrorAction SilentlyContinue)) {
-            choco install ffmpeg -y --no-progress
-          }
-          ffmpeg -version
-          ffprobe -version
+        run: .\scripts\ci\windows\setup-ffmpeg.ps1
       - name: Run native Rust harnesses
         shell: pwsh
         env:
@@ -140,12 +130,7 @@ jobs:
           ref: ${{ needs.source.outputs.sha }}
       - name: Ensure FFmpeg for trajectory video
         shell: pwsh
-        run: |
-          if (-not (Get-Command ffmpeg.exe -ErrorAction SilentlyContinue)) {
-            choco install ffmpeg -y --no-progress
-          }
-          ffmpeg -version
-          ffprobe -version
+        run: .\scripts\ci\windows\setup-ffmpeg.ps1
       - name: Run capture and desktop-scope contracts
         shell: pwsh
         env:

--- a/scripts/ci/windows/setup-ffmpeg.ps1
+++ b/scripts/ci/windows/setup-ffmpeg.ps1
@@ -1,0 +1,134 @@
+# Ensure FFmpeg is available for Windows E2E trajectory recording.
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$chocolateyAttempts = 3
+$fallbackAttempts = 3
+$retryDelaySeconds = 5
+$fallbackBaseUrl = "https://www.gyan.dev/ffmpeg/builds"
+
+function Update-ProcessPath {
+    $machinePath = [Environment]::GetEnvironmentVariable("PATH", "Machine")
+    $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+    $env:PATH = "$machinePath;$userPath;$($env:PATH)"
+}
+
+function Test-FFmpegAvailable {
+    return (
+        $null -ne (Get-Command ffmpeg.exe -ErrorAction SilentlyContinue) -and
+        $null -ne (Get-Command ffprobe.exe -ErrorAction SilentlyContinue)
+    )
+}
+
+function Invoke-DownloadWithRetry {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Uri,
+        [Parameter(Mandatory = $true)]
+        [string]$OutFile
+    )
+
+    for ($attempt = 1; $attempt -le $fallbackAttempts; $attempt++) {
+        try {
+            Invoke-WebRequest -Uri $Uri -OutFile $OutFile -UseBasicParsing
+            return
+        }
+        catch {
+            Remove-Item -LiteralPath $OutFile -Force -ErrorAction SilentlyContinue
+            if ($attempt -eq $fallbackAttempts) { throw }
+            Write-Warning "Download attempt $attempt of $fallbackAttempts failed; retrying in $retryDelaySeconds seconds: $($_.Exception.Message)"
+            Start-Sleep -Seconds $retryDelaySeconds
+        }
+    }
+}
+
+function Install-VerifiedFallback {
+    $architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    if ($architecture -ne [System.Runtime.InteropServices.Architecture]::X64) {
+        throw "The verified FFmpeg fallback supports only Windows x64; detected $architecture"
+    }
+
+    $tempBase = if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
+        [System.IO.Path]::GetTempPath()
+    } else {
+        $env:RUNNER_TEMP
+    }
+    $installRoot = Join-Path $tempBase ("cua-ffmpeg-" + [guid]::NewGuid().ToString("N"))
+    $versionFile = Join-Path $installRoot "ffmpeg-release.ver"
+    New-Item -ItemType Directory -Force -Path $installRoot | Out-Null
+
+    Invoke-DownloadWithRetry `
+        -Uri "$fallbackBaseUrl/ffmpeg-release-essentials.zip.ver" `
+        -OutFile $versionFile
+    $version = (Get-Content -LiteralPath $versionFile -Raw).Trim()
+    if ($version -notmatch '^\d+\.\d+(?:\.\d+)?$') {
+        throw "Unexpected FFmpeg fallback version: $version"
+    }
+
+    $archiveName = "ffmpeg-$version-essentials_build.zip"
+    $packageBaseUrl = "$fallbackBaseUrl/packages"
+    $archivePath = Join-Path $installRoot $archiveName
+    $checksumPath = "$archivePath.sha256"
+    Invoke-DownloadWithRetry -Uri "$packageBaseUrl/$archiveName" -OutFile $archivePath
+    Invoke-DownloadWithRetry -Uri "$packageBaseUrl/$archiveName.sha256" -OutFile $checksumPath
+
+    $checksumText = Get-Content -LiteralPath $checksumPath -Raw
+    $checksumMatch = [regex]::Match($checksumText, '(?i)\b[0-9a-f]{64}\b')
+    if (-not $checksumMatch.Success) {
+        throw "The FFmpeg fallback did not publish a valid SHA-256 checksum"
+    }
+    $expectedHash = $checksumMatch.Value.ToUpperInvariant()
+    $actualHash = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash
+    if ($actualHash -ne $expectedHash) {
+        throw "FFmpeg fallback checksum mismatch: expected $expectedHash, received $actualHash"
+    }
+
+    $expandedPath = Join-Path $installRoot "expanded"
+    Expand-Archive -LiteralPath $archivePath -DestinationPath $expandedPath -Force
+    $ffmpeg = Get-ChildItem -LiteralPath $expandedPath -Filter ffmpeg.exe -File -Recurse |
+        Select-Object -First 1
+    if ($null -eq $ffmpeg) {
+        throw "The verified FFmpeg fallback archive did not contain ffmpeg.exe"
+    }
+    $binPath = $ffmpeg.Directory.FullName
+    if (-not (Test-Path -LiteralPath (Join-Path $binPath "ffprobe.exe") -PathType Leaf)) {
+        throw "The verified FFmpeg fallback archive did not contain ffprobe.exe"
+    }
+
+    $env:PATH = "$binPath;$($env:PATH)"
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_PATH)) {
+        Add-Content -LiteralPath $env:GITHUB_PATH -Value $binPath
+    }
+    Write-Host "Installed checksum-verified FFmpeg $version fallback from gyan.dev"
+}
+
+if (-not (Test-FFmpegAvailable)) {
+    $choco = Get-Command choco.exe -ErrorAction SilentlyContinue
+    if ($null -ne $choco) {
+        for ($attempt = 1; $attempt -le $chocolateyAttempts; $attempt++) {
+            Write-Host "Installing FFmpeg with Chocolatey (attempt $attempt of $chocolateyAttempts)"
+            & $choco.Source install ffmpeg -y --no-progress
+            $chocolateyExitCode = $LASTEXITCODE
+            Update-ProcessPath
+            if ($chocolateyExitCode -eq 0 -and (Test-FFmpegAvailable)) { break }
+            if ($attempt -lt $chocolateyAttempts) {
+                Write-Warning "Chocolatey FFmpeg setup failed with exit code $chocolateyExitCode; retrying in $retryDelaySeconds seconds"
+                Start-Sleep -Seconds $retryDelaySeconds
+            }
+        }
+    }
+
+    if (-not (Test-FFmpegAvailable)) {
+        Write-Warning "Chocolatey did not provide FFmpeg and ffprobe; using the checksum-verified fallback"
+        Install-VerifiedFallback
+    }
+}
+
+foreach ($toolName in @("ffmpeg.exe", "ffprobe.exe")) {
+    $tool = Get-Command $toolName -ErrorAction Stop
+    Write-Host "Verified $toolName at $($tool.Source)"
+    & $tool.Source -version
+    if ($LASTEXITCODE -ne 0) {
+        throw "$toolName -version failed with exit code $LASTEXITCODE"
+    }
+}


### PR DESCRIPTION
## Summary

- centralize Windows E2E FFmpeg setup in a repository-owned PowerShell script
- retry Chocolatey installation three times for transient feed failures
- fall back to the FFmpeg-linked Gyan Windows build, selecting a versioned archive and verifying its published SHA-256 before extraction
- resolve and execute both `ffmpeg.exe` and `ffprobe.exe` before any E2E test starts

## Root cause and impact

Three parallel Windows jobs failed before running tests when the Chocolatey V2 feed returned HTTP 504, while another parallel job succeeded. The shared setup keeps the existing preinstalled-tool fast path and exact-source-SHA E2E behavior while removing the single-attempt dependency on that feed.

Closes #2917

## Validation

- `git diff --check`
- Ruby YAML parse for both changed workflows
- `actionlint` 1.7.7 for both changed workflows
- [Windows interactive exact-SHA run](https://github.com/trycua/cua/actions/runs/31042236016): passed all shared, native, capture, installer, and summary jobs
- [Standalone-browser exact-SHA run](https://github.com/trycua/cua/actions/runs/31042238151): passed Windows Chrome/Edge and Linux Chrome jobs
- all four Windows setup invocations resolved and executed FFmpeg 9.0 plus ffprobe 9.0 before tests

## Fallback integrity

The fallback uses the Gyan Windows build linked from ffmpeg.org. It resolves the release marker once, downloads the corresponding immutable versioned ZIP and companion SHA-256 over HTTPS, and refuses extraction on a checksum mismatch.