### PR TITLE
fix(cua-driver): report honest macOS browser chrome coverage

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-core/src/window_inspection.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/window_inspection.rs
@@ -1,30 +1,47 @@
 //! Cross-platform window-snapshot coverage signals.
 //!
 //! A browser permission bubble is browser chrome, not page content. Chromium
-//! may composite that chrome in a popup/child surface which is visible in a
-//! desktop capture but absent from a capture of the requested native window.
-//! A single-window backend therefore cannot prove that no browser-owned blocker
-//! exists. Keep that limitation explicit and machine-readable.
+//! may composite that chrome in the requested window or in a popup/child
+//! surface which is visible only in a desktop capture. A single-window backend
+//! therefore cannot always prove that no browser-owned blocker exists. Keep
+//! that platform-specific limitation explicit and machine-readable.
 
 use serde_json::{json, Value};
 
 pub const BROWSER_CHROME_COVERAGE_STATUS: &str = "not_observable_in_window_scope";
+pub const BROWSER_CHROME_MAY_BE_INCOMPLETE_STATUS: &str = "may_be_incomplete_in_window_scope";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BrowserChromeCaptureCoverage {
+    NotObservable,
+    MayBeIncomplete,
+}
+
+impl BrowserChromeCaptureCoverage {
+    fn status(self) -> &'static str {
+        match self {
+            Self::NotObservable => BROWSER_CHROME_COVERAGE_STATUS,
+            Self::MayBeIncomplete => BROWSER_CHROME_MAY_BE_INCOMPLETE_STATUS,
+        }
+    }
+}
 
 /// Describe the browser-chrome coverage limit of a Chromium-family window
 /// snapshot.
 ///
 /// This deliberately does **not** claim that a prompt is present. Presence is
-/// not observable from a single native-window surface on every supported
-/// platform. It also carries no prompt text or choices, so routine traces can
-/// retain the recovery signal without retaining permission content.
-pub fn mark_browser_chrome_capture_coverage(structured: &mut Value, chromium_family_window: bool) {
-    if !chromium_family_window {
-        return;
-    }
+/// not reliably complete from a single native-window surface on every
+/// supported platform. It also carries no prompt text or choices, so routine
+/// traces can retain the recovery signal without retaining permission content.
+pub fn mark_browser_chrome_capture_coverage(
+    structured: &mut Value,
+    coverage: Option<BrowserChromeCaptureCoverage>,
+) {
+    let Some(coverage) = coverage else { return };
 
     structured["capture_coverage"] = json!({
         "browser_chrome": {
-            "status": BROWSER_CHROME_COVERAGE_STATUS
+            "status": coverage.status()
         },
         "recovery": {
             "when": "verified_window_action_ineffective",
@@ -54,8 +71,14 @@ mod tests {
         });
         let mut after_visible_browser_blocker = before.clone();
 
-        mark_browser_chrome_capture_coverage(&mut before, true);
-        mark_browser_chrome_capture_coverage(&mut after_visible_browser_blocker, true);
+        mark_browser_chrome_capture_coverage(
+            &mut before,
+            Some(BrowserChromeCaptureCoverage::NotObservable),
+        );
+        mark_browser_chrome_capture_coverage(
+            &mut after_visible_browser_blocker,
+            Some(BrowserChromeCaptureCoverage::NotObservable),
+        );
 
         // Even when the page-owned state is byte-for-byte unchanged, callers
         // receive an explicit recovery branch instead of treating the window
@@ -87,11 +110,18 @@ mod tests {
     fn signal_is_privacy_minimal_and_does_not_change_non_browser_snapshots() {
         let mut ordinary = json!({"window_id": 9, "pid": 3});
         let unchanged = ordinary.clone();
-        mark_browser_chrome_capture_coverage(&mut ordinary, false);
+        mark_browser_chrome_capture_coverage(&mut ordinary, None);
         assert_eq!(ordinary, unchanged);
 
         let mut browser = unchanged;
-        mark_browser_chrome_capture_coverage(&mut browser, true);
+        mark_browser_chrome_capture_coverage(
+            &mut browser,
+            Some(BrowserChromeCaptureCoverage::MayBeIncomplete),
+        );
+        assert_eq!(
+            browser["capture_coverage"]["browser_chrome"]["status"],
+            BROWSER_CHROME_MAY_BE_INCOMPLETE_STATUS
+        );
         let public = browser.to_string();
         for sensitive_key in ["text", "message", "choice", "allow", "deny"] {
             assert!(

--- a/libs/cua-driver/rust/crates/cua-driver/tests/standalone_browser_behavior_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/standalone_browser_behavior_test.rs
@@ -3641,6 +3641,13 @@ fn run_browser_owned_permission_prompt(spec: &BrowserSpec) {
                 "Linux window capture already includes the browser-owned prompt surface: {}",
                 before.raw
             );
+        } else if cfg!(target_os = "macos") {
+            assert_eq!(
+                before.structured()["capture_coverage"]["browser_chrome"]["status"],
+                "may_be_incomplete_in_window_scope",
+                "{}",
+                before.raw
+            );
         } else {
             assert_eq!(
                 before.structured()["capture_coverage"]["browser_chrome"]["status"],
@@ -3648,6 +3655,8 @@ fn run_browser_owned_permission_prompt(spec: &BrowserSpec) {
                 "{}",
                 before.raw
             );
+        }
+        if !cfg!(target_os = "linux") {
             assert_eq!(
                 before.structured()["capture_coverage"]["recovery"]["when"],
                 "verified_window_action_ineffective",
@@ -3741,6 +3750,13 @@ fn run_browser_owned_permission_prompt(spec: &BrowserSpec) {
             assert!(
                 window.structured()["capture_coverage"]["browser_chrome"].is_null(),
                 "Linux window capture already includes the browser-owned prompt surface: {}",
+                window.raw
+            );
+        } else if cfg!(target_os = "macos") {
+            assert_eq!(
+                window.structured()["capture_coverage"]["browser_chrome"]["status"],
+                "may_be_incomplete_in_window_scope",
+                "{}",
                 window.raw
             );
         } else {
@@ -3923,6 +3939,11 @@ fn run_browser_owned_permission_prompt(spec: &BrowserSpec) {
             assert!(
                 !desktop_has_materially_more_prompt_pixels,
                 "Linux desktop capture unexpectedly contained materially more permission UI than window capture: {metrics}"
+            );
+        } else if cfg!(target_os = "macos") {
+            assert!(
+                window_changed_pixels >= minimum_prompt_pixels,
+                "macOS window capture omitted the tested notification permission surface: {metrics}"
             );
         } else {
             assert!(

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/get_window_state.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/get_window_state.rs
@@ -643,7 +643,9 @@ impl Tool for GetWindowStateTool {
         }
         cua_driver_core::window_inspection::mark_browser_chrome_capture_coverage(
             &mut structured,
-            chromium_browser_window(pid),
+            chromium_browser_window(pid).then_some(
+                cua_driver_core::window_inspection::BrowserChromeCaptureCoverage::MayBeIncomplete,
+            ),
         );
         ToolResult {
             content,

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -1503,7 +1503,9 @@ impl Tool for GetWindowStateTool {
 
                 cua_driver_core::window_inspection::mark_browser_chrome_capture_coverage(
                     &mut structured,
-                    is_standalone_chromium_browser_process(pid),
+                    is_standalone_chromium_browser_process(pid).then_some(
+                        cua_driver_core::window_inspection::BrowserChromeCaptureCoverage::NotObservable,
+                    ),
                 );
 
                 ToolResult {


### PR DESCRIPTION
## Summary

- report macOS Chromium window capture as `may_be_incomplete_in_window_scope` instead of categorically `not_observable_in_window_scope`
- preserve the stronger Windows contract and Linux's certified window-observable behavior
- keep the same deterministic desktop escalation path when a verified window action is ineffective
- update the standalone permission fixture to certify the current macOS behavior without relying on unrelated desktop notification changes

## Why

The 0.18.0 macOS release certification captured Chrome's complete notification permission prompt in `get_window_state`. The response nevertheless claimed the prompt was not observable in window scope. Unrelated macOS notification banners then inflated desktop pixel differences, making the old 2x comparison both flaky and inconsistent with the screenshots.

This keeps the product honest: macOS Chromium browser chrome can be present in the requested window for some prompts and outside it for others, so the window snapshot may be incomplete but is not categorically blind.

Refs #2589.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p cua-driver-core window_inspection --lib`
- `cargo check -p cua-driver --test standalone_browser_behavior_test`
- `cargo test -p platform-macos --lib` (331 passed)
- exact-SHA macOS Lume certification at `fe261d08a90aad9821775c6e5470b1e2ee8b0e52`
  - focused owned-permission row: 1/1 passed with FixtureState and Pixels oracles
  - full standalone browser matrix: 18/18 passed
  - all 19 MP4 recordings are ffprobe-readable and every result evidence reference exists

## Privacy

The structured signal contains fixed capability and recovery codes only. It includes no prompt text, origin, user choice, or desktop content.
