### PR TITLE
docs(cua-driver): document Muse Code setup

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -361,6 +361,17 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertIn("launches the installed", shared_hints)
         self.assertNotIn("launches CuaDriver", shared_hints)
 
+    def test_post_install_hints_include_muse_stdio_mcp_config(self) -> None:
+        shared_hints = self.read("libs/cua-driver/scripts/post-install-hints.txt")
+
+        self.assertIn("Muse Code (macOS / Linux", shared_hints)
+        self.assertIn("$XDG_CONFIG_HOME/muse/settings.json", shared_hints)
+        self.assertIn('"mcp_servers": {', shared_hints)
+        self.assertIn('"transport": "stdio"', shared_hints)
+        self.assertIn('"command": "{{BINARY}}"', shared_hints)
+        self.assertIn('"args": ["mcp"]', shared_hints)
+        self.assertIn("MCP servers load at startup", shared_hints)
+
     def test_local_macos_signing_uses_an_unambiguous_identity_hash(self) -> None:
         signing = self.read("libs/cua-driver/scripts/_local-signing.sh")
 

--- a/libs/cua-driver/README.md
+++ b/libs/cua-driver/README.md
@@ -80,6 +80,31 @@ For direct agent integrations, see the
 SDK examples. They connect the agent to `cua-driver mcp` without importing a
 generated Cua client.
 
+## Muse Code
+
+[Muse Code](https://research.meta.ai/blog/introducing-muse-code-and-muse-spark-1-2)
+can use Cua Driver as a local stdio MCP server on macOS and Linux. Merge the
+following entry into `$XDG_CONFIG_HOME/muse/settings.json`, or
+`~/.config/muse/settings.json` when `XDG_CONFIG_HOME` is not set:
+
+```json
+{
+  "mcp_servers": {
+    "cua-driver": {
+      "enabled": true,
+      "transport": "stdio",
+      "command": "/absolute/path/to/cua-driver",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Use the installed binary's absolute path, which `command -v cua-driver` prints.
+Merge the `cua-driver` entry with any existing `mcp_servers` instead of
+replacing the settings file. Start a new Muse session after saving the file;
+Muse loads MCP servers at session startup.
+
 Contributor documentation:
 
 - `docs/cursor-themes.md` documents the default semantic cursor and custom

--- a/libs/cua-driver/scripts/post-install-hints.txt
+++ b/libs/cua-driver/scripts/post-install-hints.txt
@@ -60,6 +60,20 @@ Next steps:
          {{BINARY}} mcp-config --client opencode   # JSON for opencode.json
          {{BINARY}} mcp-config --client hermes     # YAML for ~/.hermes/config.yaml
 
+     • Muse Code (macOS / Linux — merge into
+       $XDG_CONFIG_HOME/muse/settings.json, or ~/.config/muse/settings.json):
+         {
+           "mcp_servers": {
+             "cua-driver": {
+               "enabled": true,
+               "transport": "stdio",
+               "command": "{{BINARY}}",
+               "args": ["mcp"]
+             }
+           }
+         }
+       Start a new Muse session after saving; MCP servers load at startup.
+
      • ZCode (Z.ai — GUI app; paste in Settings → MCP Servers):
          {{BINARY}} mcp-config --client zcode
 


### PR DESCRIPTION
## What changed

- document how Muse Code connects to Cua Driver over local stdio MCP
- add the Muse `mcp_servers` settings block to the shared post-install hints
- cover the config path, XDG fallback, absolute binary path, and restart requirement
- add a regression assertion for the rendered post-install configuration

## Why

Muse Code uses `muse` as its CLI and configuration namespace, but Cua Driver's documentation and post-install output did not explain how to register the driver. This leaves users to adapt a generic or OpenCode configuration, whose settings shape is not compatible with Muse.

## User impact

macOS and Linux users can now copy the configuration directly into `$XDG_CONFIG_HOME/muse/settings.json` or the default `~/.config/muse/settings.json`, then start a new Muse session.

## Validation

- `python3 .github/scripts/tests/test_cua_driver_release_wiring.py` (36 tests)
- parsed the rendered Muse template as JSON after substituting an absolute binary path
- `git diff --check`
- verified the official Muse announcement link resolves
- checked the configuration shape against Muse stable `0.1.0-R708.1`