### PR TITLE
fix(release): make Driver prerelease copy version-neutral

### DIFF
--- a/.github/release-notes/cua-driver-rs.md
+++ b/.github/release-notes/cua-driver-rs.md
@@ -20,6 +20,6 @@ uninstaller scripts.
 
 GitHub's label is used only to keep this monorepo's repository-wide “Latest”
 pointer from switching between independently released products. A plain Cua
-Driver SemVer such as `0.17.0` is a stable release; npm and PyPI publish it on
+Driver SemVer is a stable release; npm and PyPI publish it on
 their normal stable channels, and the installers resolve the versioned
 `cua-driver-rs-v*` releases directly.

--- a/.github/scripts/tests/test_release_attribution.py
+++ b/.github/scripts/tests/test_release_attribution.py
@@ -198,6 +198,7 @@ def test_cua_driver_release_footer_explains_github_prerelease_label():
     assert "Why GitHub says “Pre-release”" in body
     assert "repository-wide “Latest” pointer" in normalized
     assert "plain Cua Driver SemVer" in normalized
+    assert "0.17.0" not in footer
     assert "npm and PyPI" in normalized
     assert "`cua-driver-rs-v*` releases directly" in normalized
 


### PR DESCRIPTION
## Summary

- remove the hard-coded previous Cua Driver version from the reusable prerelease explanation
- prevent future release notes from publishing stale version examples
- add a focused regression assertion

The already-published 0.18.0 release body was corrected independently.

## Validation

- `git diff --check`
- `uv run --with pytest pytest -q .github/scripts/tests/test_release_attribution.py` (14 passed)