### PR TITLE
ci(cua-driver): auto-publish SDKs from dispatch releases

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -20,6 +20,20 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertIn('workflows: ["CD: Cua Driver (cross-platform)"]', workflow)
         self.assertNotIn("branches:\n      - main", workflow)
         self.assertIn("github.event.workflow_run.conclusion == 'success'", workflow)
+        self.assertIn("  actions: read", workflow)
+        self.assertIn('RUN_ID="${{ github.event.workflow_run.id }}"', workflow)
+        self.assertIn(
+            'actions/runs/$RUN_ID/artifacts?per_page=100',
+            workflow,
+        )
+        self.assertIn("cua-driver-release-metadata-", workflow)
+        self.assertIn('"${#RELEASE_VERSIONS[@]}" -gt 1', workflow)
+        sha_fallback = 'HEAD_SHA="${{ github.event.workflow_run.head_sha }}"'
+        self.assertIn(sha_fallback, workflow)
+        self.assertLess(
+            workflow.index("cua-driver-release-metadata-"),
+            workflow.index(sha_fallback),
+        )
         self.assertIn('gh release view "$TAG" --repo "$GITHUB_REPOSITORY"', workflow)
 
     def test_python_publish_defaults_to_current_rust_version(self) -> None:

--- a/.github/workflows/cd-py-cua-driver.yml
+++ b/.github/workflows/cd-py-cua-driver.yml
@@ -17,6 +17,7 @@ on:
       - completed
 
 permissions:
+  actions: read
   contents: read
   id-token: write
 
@@ -46,29 +47,55 @@ jobs:
             fi
             SHOULD_PUBLISH="true"
           else
-            # Extract from the tag that triggered the workflow_run
-            # Validate SHA format to prevent injection
-            HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
-            if ! echo "$HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
-              echo "Invalid SHA format: $HEAD_SHA"
-              VERSION="0.0.0"
-              SHOULD_PUBLISH="false"
+            # Publish dispatches run from main, so workflow_run.head_sha is the
+            # workflow revision rather than the immutable release tag. Resolve
+            # those runs from the exact metadata artifact produced by the
+            # successful release job.
+            RUN_ID="${{ github.event.workflow_run.id }}"
+            if ! echo "$RUN_ID" | grep -qE '^[0-9]+$'; then
+              echo "Invalid workflow run ID: $RUN_ID" >&2
+              exit 1
+            fi
+            ARTIFACTS_FILE="$RUNNER_TEMP/cua-driver-release-metadata-artifacts.txt"
+            gh api --paginate \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/artifacts?per_page=100" \
+              --jq '.artifacts[] | select(.expired == false) | .name' \
+              > "$ARTIFACTS_FILE"
+            mapfile -t RELEASE_VERSIONS < <(
+              sed -nE \
+                's/^cua-driver-release-metadata-([0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?)$/\1/p' \
+                "$ARTIFACTS_FILE" | sort -u
+            )
+
+            if [ "${#RELEASE_VERSIONS[@]}" -gt 1 ]; then
+              echo "Multiple Cua Driver release metadata artifacts found for run $RUN_ID" >&2
+              printf '  %s\n' "${RELEASE_VERSIONS[@]}" >&2
+              exit 1
+            elif [ "${#RELEASE_VERSIONS[@]}" -eq 1 ]; then
+              VERSION="${RELEASE_VERSIONS[0]}"
+              TAG="cua-driver-rs-v$VERSION"
             else
+              # Tag-triggered candidate builds do not run the release job and
+              # therefore have no release metadata artifact. Preserve the tag
+              # SHA fallback so those runs continue to skip until publication.
+              HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+              if ! echo "$HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+                echo "Invalid SHA format: $HEAD_SHA" >&2
+                exit 1
+              fi
               git fetch --tags
               TAG=$(git tag --points-at "$HEAD_SHA" | grep '^cua-driver-rs-v' | head -1 || echo "")
-              if [ -n "$TAG" ]; then
-                VERSION="${TAG#cua-driver-rs-v}"
-                if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-                  SHOULD_PUBLISH="true"
-                else
-                  echo "GitHub Release $TAG is not available; skipping PyPI publish."
-                  SHOULD_PUBLISH="false"
-                fi
-              else
-                # No matching tag, skip
-                VERSION="0.0.0"
-                SHOULD_PUBLISH="false"
-              fi
+              VERSION="${TAG#cua-driver-rs-v}"
+            fi
+
+            if [ -n "$TAG" ] && gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              SHOULD_PUBLISH="true"
+            elif [ -n "$TAG" ]; then
+              echo "GitHub Release $TAG is not available; skipping SDK publish."
+              SHOULD_PUBLISH="false"
+            else
+              VERSION="0.0.0"
+              SHOULD_PUBLISH="false"
             fi
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- resolve an automatic SDK publication from the triggering Cua Driver run's exact release-metadata artifact
- retain the tag-SHA fallback for tag-triggered candidate builds that do not publish a release
- fail closed when the triggering run ID is invalid, the artifacts API fails, or multiple release metadata artifacts are present

## Root cause

A publish recovery uses `workflow_dispatch` from `main`, so `workflow_run.head_sha` identifies the workflow revision rather than the immutable source tag. The SDK workflow therefore resolved `0.0.0` and skipped every build/publish job even though the cross-platform workflow had published the release.

The release job already uploads `cua-driver-release-metadata-<version>` as a run-scoped artifact. Using that artifact name associates the version with the exact successful triggering run without relying on "latest" release ordering or timestamps.

Closes #2924.

## Validation

- `python3 .github/scripts/tests/test_cua_driver_release_wiring.py` (37 tests after rebasing onto #2927)
- `uv run --python 3.13 --with pytest python -m unittest discover -s .github/scripts/tests -p 'test_*.py'` (76 tests)
- `git diff --check origin/main...HEAD`
- resolver query against publish run 31051914052 returned exactly `0.18.0`
- resolver query against tag-candidate run 31051325124 returned no metadata artifact, exercising the intended SHA fallback condition
- actionlint v1.7.7 introduced no new findings versus the original `origin/main` baseline (both report the existing SC2129 style warning and unrecognized `windows-11-arm` hosted-runner label)

## Release impact

No component release. This changes release automation only and does not alter shipped Cua Driver runtime behavior.
