### PR TITLE
ci(cua-driver): preflight release attribution before builds

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -447,7 +447,7 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
             "github.event_name == 'workflow_dispatch' && inputs.publish && "
             "format('refs/tags/cua-driver-rs-v{0}', inputs.version) || github.ref"
         )
-        self.assertEqual(workflow.count(immutable_ref), 4)
+        self.assertEqual(workflow.count(immutable_ref), 5)
         self.assertIn(
             "name: Ensure Rust target is installed\n"
             "        working-directory: libs/cua-driver/rust",
@@ -462,6 +462,42 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertIn("inputs.publish == true", workflow)
         self.assertIn('--tag "${{ steps.version.outputs.tag }}"', workflow)
         self.assertIn('--sha "${{ steps.version.outputs.sha }}"', workflow)
+
+    def test_driver_attribution_preflight_gates_candidate_builds(self) -> None:
+        workflow = self.read(".github/workflows/cd-rust-cua-driver.yml")
+
+        preflight = workflow.index("  release-attribution-preflight:")
+        linux = workflow.index("  build-linux:", preflight)
+        windows = workflow.index("  build-windows:", linux)
+        macos = workflow.index("  build-macos-universal:", windows)
+        release = workflow.index("  release:", macos)
+        preflight_block = workflow[preflight:linux]
+
+        self.assertIn("name: release attribution preflight", preflight_block)
+        self.assertIn("ref: ${{ github.workflow_sha }}", preflight_block)
+        self.assertIn("path: release-control", preflight_block)
+        self.assertIn(
+            "python3 release-control/.github/scripts/release_attribution.py collect",
+            preflight_block,
+        )
+        self.assertIn('--repo-root "$GITHUB_WORKSPACE"', preflight_block)
+        self.assertIn('--sha "$SHA"', preflight_block)
+        self.assertIn(
+            "No immutable release candidate requested; skipping attribution preflight.",
+            preflight_block,
+        )
+        for block in (
+            workflow[linux:windows],
+            workflow[windows:macos],
+            workflow[macos:release],
+        ):
+            self.assertIn("needs: release-attribution-preflight", block)
+
+        # Keep the publication-time guard as defense in depth.
+        self.assertEqual(
+            workflow.count("python3 .github/scripts/release_attribution.py collect"),
+            1,
+        )
 
     def test_driver_tag_build_cannot_publish_before_manual_e2e_gate(self) -> None:
         workflow = self.read(".github/workflows/cd-rust-cua-driver.yml")

--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -41,6 +41,57 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Certify PR-first attribution from the exact immutable candidate before
+  # starting any platform build. Publish recovery dispatches use current
+  # release-control tooling while keeping all release inputs pinned to the tag.
+  # Manual non-publishing builds intentionally remain available for iteration.
+  release-attribution-preflight:
+    name: release attribution preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.publish && format('refs/tags/cua-driver-rs-v{0}', inputs.version) || github.ref }}
+
+      - name: Check out release control tooling
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: release-control
+          persist-credentials: false
+
+      - name: Validate candidate release attribution
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" == refs/tags/cua-driver-rs-v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/cua-driver-rs-v}"
+          elif [[ "${{ inputs.publish }}" == "true" ]]; then
+            VERSION="${{ inputs.version }}"
+          else
+            echo "No immutable release candidate requested; skipping attribution preflight."
+            exit 0
+          fi
+          TAG="cua-driver-rs-v${VERSION}"
+          SHA=$(git rev-list -n 1 "$TAG")
+          python3 release-control/.github/scripts/release_attribution.py collect \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --repository "${{ github.repository }}" \
+            --product cua-driver-rs \
+            --display-name "Cua Driver" \
+            --version "$VERSION" \
+            --tag "$TAG" \
+            --tag-prefix cua-driver-rs-v \
+            --sha "$SHA" \
+            --path libs/cua-driver \
+            --exclude-path libs/cua-driver/docs \
+            --exclude-path libs/cua-driver/python \
+            --exclude-path libs/cua-driver/tests \
+            --changelog libs/cua-driver/rust/CHANGELOG.md \
+            --output "$RUNNER_TEMP/cua-driver-release-manifest.json"
+
   # ── Linux (x86_64 + arm64) ───────────────────────────────────────────────────
   # One matrixed job per Linux target. x86_64 builds on the standard
   # ubuntu-latest host; arm64 builds NATIVELY on GitHub's hosted ARM runner
@@ -51,6 +102,7 @@ jobs:
   # matching tarball at install time based on the host's `uname -m`.
   build-linux:
     name: linux-${{ matrix.arch }}
+    needs: release-attribution-preflight
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -167,6 +219,7 @@ jobs:
   # the matching zip at install time based on the host's OS architecture.
   build-windows:
     name: windows-${{ matrix.arch }}
+    needs: release-attribution-preflight
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -284,6 +337,7 @@ jobs:
   # expose those symbols, so the transitive Swift bridge fails to compile.
   build-macos-universal:
     name: darwin-universal
+    needs: release-attribution-preflight
     runs-on: macos-26
     # Notarize on tag push (real release); on workflow_dispatch honor the
     # `notarize` input so we can iterate on the build pipeline without


### PR DESCRIPTION
## Summary

- certify PR-first release attribution from the exact immutable Cua Driver tag before any platform build starts
- use current release-control tooling for recovery dispatches while keeping changelog, commits, version, and SHA pinned to the candidate tag
- preserve non-publishing manual build iterations and the existing publish-time fail-closed guard
- gate Linux, Windows, and macOS builds on the preflight and cover the workflow contract with a focused regression test

## Root cause

Attribution collection lived only in the publish job. Run 31049784229 therefore rebuilt all five artifacts and verified the archives before discovering that the 0.18.0 changelog omitted four releasing PRs.

## Validation

- `uv run --with pytest --with jsonschema python -m pytest -q .github/scripts/tests` (154 passed, 6 subtests passed; one existing pytest config warning)
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -ignore 'label "macos-26" is unknown' -ignore 'SC2129' .github/workflows/cd-rust-cua-driver.yml`\n- live `collect` against `cua-driver-rs-v0.18.0` at `726cbbfdc452b2696fed61eadcedffccae8f2c43` (34 attributed changes)\n- `git diff --check`\n\nFixes #2923