### PR TITLE
fix(cua-cli): add open alias for sandbox vnc

### DIFF
--- a/libs/python/cua-cli/cua_cli/commands/sandbox.py
+++ b/libs/python/cua-cli/cua_cli/commands/sandbox.py
@@ -313,6 +313,7 @@ def register_parser(subparsers: argparse._SubParsersAction) -> None:
         # -- vnc -------------------------------------------------------------
         vnc_parser = sb_subparsers.add_parser(
             "vnc",
+            aliases=["open"],
             help="Open sandbox in browser via VNC",
         )
         vnc_parser.add_argument("name", help="Sandbox name")
@@ -393,7 +394,7 @@ def execute(args: argparse.Namespace) -> int:
         return cmd_restart(args)
     elif cmd == "delete":
         return cmd_delete(args)
-    elif cmd == "vnc":
+    elif cmd in ("vnc", "open"):
         return cmd_vnc(args)
     elif cmd == "shell":
         return cmd_shell(args)

--- a/libs/python/cua-cli/tests/commands/test_sandbox.py
+++ b/libs/python/cua-cli/tests/commands/test_sandbox.py
@@ -87,6 +87,15 @@ class TestExecute:
 
         mock_cmd.assert_called_once_with(args)
 
+    def test_dispatch_to_vnc_open_alias(self, args_namespace):
+        args = args_namespace(command="sb", sandbox_command="open", name="my-sandbox")
+
+        with patch.object(sandbox, "cmd_vnc", return_value=0) as mock_cmd:
+            result = sandbox.execute(args)
+
+        mock_cmd.assert_called_once_with(args)
+        assert result == 0
+
     def test_unknown_command_returns_error(self, args_namespace):
         """Test that unknown command returns error."""
         args = args_namespace(command="sandbox", sandbox_command=None)
@@ -378,6 +387,16 @@ class TestCmdDelete:
 
 class TestCmdVnc:
     """Tests for cmd_vnc function."""
+
+    def test_open_alias_parses_as_vnc(self):
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers()
+        sandbox.register_parser(subparsers)
+
+        args = parser.parse_args(["sb", "open", "my-sandbox"])
+
+        assert args.sandbox_command == "open"
+        assert args.name == "my-sandbox"
 
     def test_vnc_opens_browser(self, args_namespace, mock_api_key, mock_webbrowser):
         """Test VNC opens browser with correct URL."""


### PR DESCRIPTION
## What changed

- add the legacy `open` alias for `cua sb vnc`
- dispatch the alias through the existing VNC implementation
- cover parser registration and command dispatch

Linear: CUA-993
Parent: CUA-964

## Shannon decomposition

Pinned methodology: `olaservo/shannon-thinking@ba01de122e577082928228f3f9f11c03857bdd34`

- Problem definition (uncertainty 0.10): choose one independently reviewable Python CLI parity gap.
- Constraints (0.15): one child/branch/PR; current `origin/main`; no churn for complete commands; legacy TypeScript defines parity.
- Model (0.15): minimize effort, behavioral risk, and dependencies; parser aliases dominate lifecycle/network changes.
- Proof/validation (0.05): TypeScript registers `vnc`/`open`; Python rejected `open`; the focused test failed before the change and passes after it.
- Implementation (0.05): register `aliases=["open"]`, route `open` to `cmd_vnc`, and add two focused tests.

Assumptions: the user-provided child list is current; exact GitHub title/body/head searches found no existing child-linked PR. Linear API access was unavailable in this runtime.

## Tests

- `uv run --project libs/python/cua-cli pytest libs/python/cua-cli/tests/commands/test_sandbox.py::TestExecute::test_dispatch_to_vnc_open_alias libs/python/cua-cli/tests/commands/test_sandbox.py::TestCmdVnc::test_open_alias_parses_as_vnc -q`
- `uv run --project libs/python/cua-cli ruff check libs/python/cua-cli/cua_cli/commands/sandbox.py libs/python/cua-cli/tests/commands/test_sandbox.py`
- `uv run --project libs/python/cua-cli ruff format --check libs/python/cua-cli/cua_cli/commands/sandbox.py libs/python/cua-cli/tests/commands/test_sandbox.py`
- `uvx pyright --project pyrightconfig.json libs/python/cua-cli/cua_cli/commands/sandbox.py`
- `uv run --project libs/python/cua-cli python -m cua_cli.main sb open --help`

## Baseline note

The broader existing parser class still fails `test_create_command_has_required_args` because current main exposes `launch`, not the stale `create` test. Pyright on the entire existing sandbox test file likewise reports stale references such as `cmd_list` and `cmd_create`; this PR does not expand into those unrelated children.
