### PR TITLE
test(cua-cli): cover sandbox resume command

### DIFF
--- a/libs/python/cua-cli/tests/commands/test_sandbox.py
+++ b/libs/python/cua-cli/tests/commands/test_sandbox.py
@@ -358,6 +358,59 @@ class TestCmdSuspend:
         assert result == 1
 
 
+class TestCmdResume:
+    """Tests for cmd_resume function."""
+
+    def test_resume_sandbox_success(self, args_namespace, mock_api_key):
+        """Test resuming a cloud sandbox."""
+        args = args_namespace(name="test-sandbox", local=False)
+        mock_resume = AsyncMock()
+        mock_sandbox_sdk = MagicMock()
+        mock_sandbox_sdk.Sandbox.resume = mock_resume
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sandbox_sdk}):
+            with patch.object(sandbox, "print_success"):
+                result = sandbox.cmd_resume(args)
+
+        assert result == 0
+        mock_resume.assert_awaited_once_with(
+            "test-sandbox", local=False, api_key="test-access-token"
+        )
+
+    def test_resume_sandbox_not_found(self, args_namespace, mock_api_key):
+        """Test resuming a sandbox that does not exist."""
+        args = args_namespace(name="missing-sandbox", local=False)
+        mock_resume = AsyncMock(side_effect=ValueError("Sandbox not found"))
+        mock_sandbox_sdk = MagicMock()
+        mock_sandbox_sdk.Sandbox.resume = mock_resume
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sandbox_sdk}):
+            with patch.object(sandbox, "print_error") as mock_error:
+                result = sandbox.cmd_resume(args)
+
+        assert result == 1
+        mock_resume.assert_awaited_once_with(
+            "missing-sandbox", local=False, api_key="test-access-token"
+        )
+        mock_error.assert_called_once_with("Failed to resume sandbox: Sandbox not found")
+
+    def test_resume_local_sandbox(self, args_namespace):
+        """Test resuming a local sandbox without cloud authentication."""
+        args = args_namespace(name="local-sandbox", local=True)
+        mock_resume = AsyncMock()
+        mock_sandbox_sdk = MagicMock()
+        mock_sandbox_sdk.Sandbox.resume = mock_resume
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sandbox_sdk}):
+            with patch.object(sandbox, "get_access_token", new_callable=AsyncMock) as mock_token:
+                with patch.object(sandbox, "print_success"):
+                    result = sandbox.cmd_resume(args)
+
+        assert result == 0
+        mock_token.assert_not_awaited()
+        mock_resume.assert_awaited_once_with("local-sandbox", local=True)
+
+
 class TestCmdDelete:
     """Tests for cmd_delete function."""
 


### PR DESCRIPTION
## What changed

- add focused coverage for successful cloud sandbox resume
- cover sandbox-not-found error handling
- verify local resume bypasses cloud authentication
- leave the existing resume implementation unchanged

Linear: CUA-990
Parent: CUA-964

## Shannon decomposition

Pinned methodology: `olaservo/shannon-thinking@ba01de122e577082928228f3f9f11c03857bdd34`

- Problem definition (u=0.10): `cmd_resume` is implemented with local and cloud paths but had no focused test coverage.
- Constraints (u=0.15): one child, branch, and PR; fresh `origin/main`; no manufactured production churn; follow adjacent lifecycle test patterns.
- Model (u=0.15): cover the three smallest behavioral partitions—cloud success with API key, not-found failure, and local success without authentication.
- Proof/validation (u=0.05): assert the exact awaited `Sandbox.resume` calls, return codes, error output, and skipped authentication on the local path.
- Implementation (u=0.05): add only `TestCmdResume` to `test_sandbox.py`; do not modify `sandbox.py`.

Assumptions: `Sandbox.resume(name, *, local=False, api_key=None)` is the current SDK contract. The isolated `cua-cli` test environment does not install `cua_sandbox`, so tests inject the lazy-import SDK boundary through `sys.modules`.

Uncertainty: if the SDK signature changes, the exact-call assertions will intentionally fail and identify the parity change.

## Tests

- `uv run --project libs/python/cua-cli pytest libs/python/cua-cli/tests/commands/test_sandbox.py::TestCmdResume -q` — `3 passed in 0.22s`
- `uv run --project libs/python/cua-cli ruff check libs/python/cua-cli/tests/commands/test_sandbox.py` — passed
- `uv run --project libs/python/cua-cli ruff format --check libs/python/cua-cli/tests/commands/test_sandbox.py` — passed
- `git diff --check` — passed

## Existing type-check baseline

`uvx pyright --project pyrightconfig.json libs/python/cua-cli/tests/commands/test_sandbox.py` still reports ten pre-existing stale references (`cmd_list`, `cmd_create`, `cmd_get`, `cmd_start`, and `cmd_stop`) before the new class. The added resume tests introduce no Pyright diagnostics.
