### PR TITLE
docs(cua-driver): state that --remote-debugging-port is ignored on the default profile

### DIFF
--- a/docs/content/docs/concepts/browser-targeting-and-background-delivery.mdx
+++ b/docs/content/docs/concepts/browser-targeting-and-background-delivery.mdx
@@ -164,6 +164,14 @@ browser was started and for closing remote debugging when it is no longer
 needed.
 
 Chromium applies its own protections to remote debugging on default profiles.
+Concretely, Chrome and Edge ignore `--remote-debugging-port` when the browser
+runs on its default user-data directory: no listener opens and no
+`DevToolsActivePort` file is written. The flag takes effect only alongside a
+non-default `--user-data-dir`, which is a different, unauthenticated profile.
+This is a browser-side protection, not a Cua Driver restriction, and it is why
+the browser's own remote-debugging toggle is the only sanctioned route into a
+real profile — the route `browser_prepare` drives under explicit approval.
+
 Cua Driver does not bypass those protections, copy a profile, or weaken the
 browser's data encryption. See Chromium's
 [remote-debugging security guidance](https://developer.chrome.com/blog/remote-debugging-port)

--- a/docs/content/docs/how-to-guides/driver/drive-a-web-page.mdx
+++ b/docs/content/docs/how-to-guides/driver/drive-a-web-page.mdx
@@ -36,6 +36,17 @@ Do not pass remote-debugging flags or a user-data directory through
 `launch_app`. Cua Driver rejects those flags because they could expose a
 person's normal profile to DevTools.
 
+Relaunching the browser yourself with `--remote-debugging-port` is not a
+workaround. Chrome and Edge ignore that flag when the browser runs on its
+**default** user-data directory, which is exactly the case an existing-profile
+attachment is for: no listener opens, and no `DevToolsActivePort` file is
+written. The flag only takes effect alongside a non-default `--user-data-dir`,
+which is a different profile and therefore not the authenticated one you wanted.
+On a real profile the browser's own remote-debugging toggle is the only route
+that works — see [Attach to an existing Chrome or Edge
+profile](#attach-to-an-existing-chrome-or-edge-profile), which is the route
+`browser_prepare` drives for you.
+
 ## Prepare an isolated browser when required
 
 If inspection returns `browser_requires_setup`, call `browser_prepare` as a

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/page.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/page.rs
@@ -252,10 +252,12 @@ async fn resolve_cdp_port(pid: i32, cdp_port: Option<u16>, action: &str) -> anyh
              the browser to have been launched with a CDP port on a NON-default profile — \
              Chrome refuses to open --remote-debugging-port on its default data directory \
              (even if you pass --user-data-dir explicitly pointing at that same default \
-             path). Relaunch via launch_app with cdp_debugging_port AND \
-             additional_arguments: [\"--user-data-dir=<some other path>\"], e.g. a \
-             dedicated automation profile — this will not have the user's existing \
-             logins/session. Alternatively, if you already enabled Chrome's own \
+             path). Call browser_prepare for this pid: profile mode isolated_new starts a \
+             driver-owned automation profile (no existing logins/session), and \
+             existing_profile drives the browser's own remote-debugging toggle under \
+             explicit approval when the authenticated profile is required. Do not relaunch \
+             with remote-debugging flags through launch_app — it refuses them, so that \
+             route cannot succeed. Alternatively, if you already enabled Chrome's own \
              remote-debugging toggle for this profile (chrome://inspect/#remote-debugging), \
              pass that port explicitly via cdp_port — auto-discovery can't confirm it."
         )


### PR DESCRIPTION
Addresses #2916.

## The gap

A caller who cannot attach to an existing profile reasonably tries relaunching the browser themselves with `--remote-debugging-port`. On Chrome and Edge that silently does nothing **for the profile they care about**: the flag is ignored on the default user-data directory — no listener opens, no `DevToolsActivePort` file is written. It takes effect only alongside a non-default `--user-data-dir`, which is a different, unauthenticated profile.

Nothing in the published documentation said so. The existing text explains why Cua Driver *rejects* those flags:

> Do not pass remote-debugging flags or a user-data directory through `launch_app`. Cua Driver rejects those flags because they could expose a person's normal profile to DevTools.

That is a security rationale. It reads as a driver-side restriction to route around, when the browser would refuse anyway. The concept page came closest — "Chromium applies its own protections to remote debugging on default profiles" — without saying what those protections do.

## What this changes

Documentation only, in the two places a caller actually looks:

- **`drive-a-web-page.mdx`** — immediately after the existing `launch_app` rejection, so the "then I'll just launch it myself" thought is answered where it occurs, pointing at the existing-profile section as the route that does work.
- **`browser-targeting-and-background-delivery.mdx`** — makes the existing "Chromium applies its own protections" sentence concrete, and states plainly that this is a browser-side protection rather than a Cua Driver restriction.

## One correction beyond the docs

The only place in the tree that *did* document this limitation is the macOS `page` tool's `resolve_cdp_port` error (`platform-macos/src/tools/page.rs:249-262`). Its remediation is now stale:

> Relaunch via launch_app with cdp_debugging_port AND additional_arguments: ["--user-data-dir=&lt;some other path&gt;"]

`launch_app` refuses remote-debugging flags on every platform, so following that advice cannot succeed — the one message that explained the limitation also sent people into a refusal. It now points at `browser_prepare` and names which profile mode answers which need (`isolated_new` for a clean automation profile, `existing_profile` when the authenticated one is genuinely required).

## Verification and limits

- The two `.mdx` files are hand-written, not generated, so there is no `mcp-tools.mdx` generator drift to regenerate. The in-page anchor added by the how-to change resolves to the existing `## Attach to an existing Chrome or Edge profile` heading (`drive-a-web-page.mdx:85`).
- **I could not compile `platform-macos`** — this machine is Windows with a GNU Rust toolchain, and that crate is `cfg(target_os = "macos")`. The change there is confined to one string literal: I verified the literal still contains exactly its two format placeholders (`{pid}`, `{action}`) and no other braces, and that the em-dashes survived the edit, but CI should be treated as the real check on that file.
- I did not touch the Windows or Linux `page` tools; neither carries an equivalent message today. If you would like the same explanation surfaced there, or as a structured refusal rather than prose, say so and I will follow up.

Refs #2916
