### PR TITLE
fix(cua-cli): use Fleet SDK for sandbox exec

### DIFF
--- a/libs/python/cua-cli/cua_cli/commands/sandbox.py
+++ b/libs/python/cua-cli/cua_cli/commands/sandbox.py
@@ -946,31 +946,43 @@ def cmd_exec(args: argparse.Namespace) -> int:
         return 1
 
     async def _run() -> int:
+        from cua_sandbox import Sandbox
+
         try:
-            api_url, api_key = await _get_sandbox_api_url(args.name, local)
-        except ValueError as e:
-            print_error(str(e))
+            kwargs: dict[str, Any] = {}
+            if not local:
+                kwargs["api_key"] = await get_access_token()
+            sb = await Sandbox.connect(args.name, local=local, **kwargs)
+        except Exception as e:
+            print_error(f"Failed to connect to sandbox: {e}")
             return 1
 
-        result = await _exec_noninteractive(args.name, api_url, api_key, command)
+        try:
+            result = await sb.shell.run(command, timeout=120)
+        except Exception as e:
+            print_error(f"Failed to execute command: {e}")
+            return 1
+        finally:
+            await sb.disconnect()
 
+        output = {
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "returncode": result.returncode,
+        }
         if getattr(args, "json", False):
-            print_json(result)
-            return result.get("returncode") or result.get("return_code") or 0
+            print_json(output)
+        else:
+            stdout = result.stdout.strip()
+            stderr = result.stderr.strip()
+            if stdout:
+                print(stdout)
+            if stderr:
+                print(stderr, file=sys.stderr)
 
-        if not result.get("success", True):
-            print_error(result.get("error", "Command failed"))
+        if result.returncode != 0:
+            print_error(f"Command failed with exit code {result.returncode}")
             return 1
-
-        stdout = result.get("stdout", "").strip()
-        stderr = result.get("stderr", "").strip()
-        returncode = result.get("returncode") or result.get("return_code") or 0
-
-        if stdout:
-            print(stdout)
-        if stderr:
-            print(stderr, file=sys.stderr)
-
-        return returncode
+        return 0
 
     return run_async(_run())

--- a/libs/python/cua-cli/tests/commands/test_sandbox.py
+++ b/libs/python/cua-cli/tests/commands/test_sandbox.py
@@ -1,6 +1,7 @@
 """Tests for sandbox command module."""
 
 import argparse
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from cua_cli.commands import sandbox
@@ -546,11 +547,7 @@ class TestCmdExec:
         assert args.exec_command == ["echo", "hello"]
 
     def test_exec_with_json_flag(self):
-        """Test exec command with --json flag.
-
-        --json must come before name due to argparse REMAINDER behavior.
-        Usage: cua sb exec --json mybox <command...>
-        """
+        """Test exec command with --json before the remainder arguments."""
         parser = argparse.ArgumentParser()
         subparsers = parser.add_subparsers()
         sandbox.register_parser(subparsers)
@@ -560,112 +557,163 @@ class TestCmdExec:
         assert args.name == "my-sandbox"
         assert args.exec_command == ["echo", "hello"]
 
-    def test_exec_no_command_error(self, args_namespace, mock_api_key):
-        """Test exec with no command returns error."""
-        args = args_namespace(
-            name="test-sandbox",
-            exec_command=[],
-            json=False,
-        )
+    def test_exec_no_command_error(self, args_namespace):
+        """Test exec with no command returns an error."""
+        args = args_namespace(name="test-sandbox", exec_command=[], json=False, local=False)
 
         with patch.object(sandbox, "print_error") as mock_error:
             result = sandbox.cmd_exec(args)
 
         assert result == 1
-        mock_error.assert_called_with("No command provided")
+        mock_error.assert_called_once_with("No command provided")
 
-    def test_exec_sandbox_not_found(self, args_namespace, mock_api_key):
-        """Test exec with nonexistent sandbox."""
-        args = args_namespace(
-            name="nonexistent",
-            exec_command=["echo", "hello"],
-            json=False,
-        )
-
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.get_vm = AsyncMock(return_value={"status": "not_found"})
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "print_error") as mock_error:
-                result = sandbox.cmd_exec(args)
-
-        assert result == 1
-        mock_error.assert_called()
-
-    def test_exec_success(self, args_namespace, mock_api_key, capsys):
-        """Test successful command execution."""
+    def test_exec_success_uses_sandbox_shell(self, args_namespace, mock_api_key, capsys):
+        """Test successful execution uses the Fleet-backed shell interface."""
         args = args_namespace(
             name="test-sandbox",
             exec_command=["echo", "hello"],
             json=False,
+            local=False,
         )
+        command_result = SimpleNamespace(stdout="hello\n", stderr="", returncode=0)
+        mock_sandbox = MagicMock()
+        mock_sandbox.shell.run = AsyncMock(return_value=command_result)
+        mock_sandbox.disconnect = AsyncMock()
+        mock_connect = AsyncMock(return_value=mock_sandbox)
+        mock_sandbox_sdk = MagicMock()
+        mock_sandbox_sdk.Sandbox.connect = mock_connect
 
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.get_vm = AsyncMock(
-            return_value={"status": "running", "api_url": "https://sandbox.example.com:8443"}
-        )
-
-        async def mock_exec(*a, **kw):
-            return {"success": True, "stdout": "hello\n", "stderr": "", "returncode": 0}
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "_exec_noninteractive", side_effect=mock_exec):
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sandbox_sdk}):
+            with patch.object(
+                sandbox,
+                "_get_sandbox_api_url",
+                side_effect=AssertionError("legacy resolver must not be used"),
+            ) as mock_legacy_resolver:
                 result = sandbox.cmd_exec(args)
 
         assert result == 0
-        captured = capsys.readouterr()
-        assert "hello" in captured.out
+        mock_connect.assert_awaited_once_with(
+            "test-sandbox", local=False, api_key="test-access-token"
+        )
+        mock_sandbox.shell.run.assert_awaited_once_with("echo hello", timeout=120)
+        mock_sandbox.disconnect.assert_awaited_once_with()
+        mock_legacy_resolver.assert_not_called()
+        assert capsys.readouterr().out == "hello\n"
 
     def test_exec_json_output(self, args_namespace, mock_api_key):
-        """Test exec with JSON output."""
+        """Test JSON output uses CommandResult fields."""
         args = args_namespace(
             name="test-sandbox",
             exec_command=["echo", "hello"],
             json=True,
+            local=False,
         )
+        command_result = SimpleNamespace(stdout="hello\n", stderr="", returncode=0)
+        mock_sandbox = MagicMock()
+        mock_sandbox.shell.run = AsyncMock(return_value=command_result)
+        mock_sandbox.disconnect = AsyncMock()
+        mock_sandbox_sdk = MagicMock()
+        mock_sandbox_sdk.Sandbox.connect = AsyncMock(return_value=mock_sandbox)
 
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.get_vm = AsyncMock(
-            return_value={"status": "running", "api_url": "https://sandbox.example.com:8443"}
-        )
-
-        async def mock_exec(*a, **kw):
-            return {"success": True, "stdout": "hello\n", "stderr": "", "returncode": 0}
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "_exec_noninteractive", side_effect=mock_exec):
-                with patch.object(sandbox, "print_json") as mock_json:
-                    result = sandbox.cmd_exec(args)
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sandbox_sdk}):
+            with patch.object(sandbox, "print_json") as mock_json:
+                result = sandbox.cmd_exec(args)
 
         assert result == 0
-        mock_json.assert_called_once()
+        mock_json.assert_called_once_with({"stdout": "hello\n", "stderr": "", "returncode": 0})
+        mock_sandbox.disconnect.assert_awaited_once_with()
 
     def test_exec_command_failure(self, args_namespace, mock_api_key, capsys):
-        """Test exec when command returns non-zero exit code."""
+        """Test a non-zero command result returns a clear failure."""
         args = args_namespace(
             name="test-sandbox",
             exec_command=["false"],
             json=False,
+            local=False,
         )
+        command_result = SimpleNamespace(stdout="", stderr="command failed\n", returncode=7)
+        mock_sandbox = MagicMock()
+        mock_sandbox.shell.run = AsyncMock(return_value=command_result)
+        mock_sandbox.disconnect = AsyncMock()
+        mock_sandbox_sdk = MagicMock()
+        mock_sandbox_sdk.Sandbox.connect = AsyncMock(return_value=mock_sandbox)
 
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.get_vm = AsyncMock(
-            return_value={"status": "running", "api_url": "https://sandbox.example.com:8443"}
-        )
-
-        async def mock_exec(*a, **kw):
-            return {"success": True, "stdout": "", "stderr": "error", "returncode": 1}
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "_exec_noninteractive", side_effect=mock_exec):
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sandbox_sdk}):
+            with patch.object(sandbox, "print_error") as mock_error:
                 result = sandbox.cmd_exec(args)
 
         assert result == 1
+        mock_error.assert_called_once_with("Command failed with exit code 7")
+        assert capsys.readouterr().err == "command failed\n"
+        mock_sandbox.disconnect.assert_awaited_once_with()
+
+    def test_exec_sandbox_not_found(self, args_namespace, mock_api_key):
+        """Test a nonexistent sandbox returns a connection error."""
+        args = args_namespace(
+            name="missing-sandbox",
+            exec_command=["echo", "hello"],
+            json=False,
+            local=False,
+        )
+        mock_sandbox_sdk = MagicMock()
+        mock_sandbox_sdk.Sandbox.connect = AsyncMock(
+            side_effect=ValueError("Sandbox 'missing-sandbox' not found")
+        )
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sandbox_sdk}):
+            with patch.object(sandbox, "print_error") as mock_error:
+                result = sandbox.cmd_exec(args)
+
+        assert result == 1
+        mock_error.assert_called_once_with(
+            "Failed to connect to sandbox: Sandbox 'missing-sandbox' not found"
+        )
+
+    def test_exec_connection_failure(self, args_namespace, mock_api_key):
+        """Test a transport connection failure returns a clear error."""
+        args = args_namespace(
+            name="test-sandbox",
+            exec_command=["echo", "hello"],
+            json=False,
+            local=False,
+        )
+        mock_sandbox_sdk = MagicMock()
+        mock_sandbox_sdk.Sandbox.connect = AsyncMock(
+            side_effect=RuntimeError("Fleet service unavailable")
+        )
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sandbox_sdk}):
+            with patch.object(sandbox, "print_error") as mock_error:
+                result = sandbox.cmd_exec(args)
+
+        assert result == 1
+        mock_error.assert_called_once_with(
+            "Failed to connect to sandbox: Fleet service unavailable"
+        )
+
+    def test_exec_local_mode(self, args_namespace, capsys):
+        """Test local mode connects without requesting cloud authentication."""
+        args = args_namespace(
+            name="local-sandbox",
+            exec_command=["pwd"],
+            json=False,
+            local=True,
+        )
+        command_result = SimpleNamespace(stdout="/workspace\n", stderr="", returncode=0)
+        mock_sandbox = MagicMock()
+        mock_sandbox.shell.run = AsyncMock(return_value=command_result)
+        mock_sandbox.disconnect = AsyncMock()
+        mock_connect = AsyncMock(return_value=mock_sandbox)
+        mock_sandbox_sdk = MagicMock()
+        mock_sandbox_sdk.Sandbox.connect = mock_connect
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sandbox_sdk}):
+            with patch.object(sandbox, "get_access_token", new_callable=AsyncMock) as mock_token:
+                result = sandbox.cmd_exec(args)
+
+        assert result == 0
+        mock_token.assert_not_awaited()
+        mock_connect.assert_awaited_once_with("local-sandbox", local=True)
+        mock_sandbox.shell.run.assert_awaited_once_with("pwd", timeout=120)
+        mock_sandbox.disconnect.assert_awaited_once_with()
+        assert capsys.readouterr().out == "/workspace\n"


### PR DESCRIPTION
## What changed

- replace the legacy API URL lookup and raw `/cmd` HTTP request in `cua sb exec`
- connect through `Sandbox.connect()` and execute through `sb.shell.run(..., timeout=120)`
- preserve cloud authentication, `--local`, `--json`, stdout/stderr, and exit handling
- disconnect after command execution and report connection/command failures clearly
- replace stale provider/raw-HTTP tests with SDK-bound exec tests

Linear: CUA-995
Parent: CUA-964

## Shannon decomposition

Pinned methodology: `olaservo/shannon-thinking@ba01de122e577082928228f3f9f11c03857bdd34`

- Problem definition (u=0.10): `cmd_exec` bypasses the Fleet-capable SDK by resolving a legacy computer-server URL and POSTing directly to `/cmd`.
- Constraints (u=0.15): one child/branch/PR; current `origin/main`; preserve `--local` and `--json`; do not change shell, VNC, aliases, or provisioning.
- Model (u=0.15): connect with `Sandbox.connect`, run with `sb.shell.run(command, timeout=120)`, serialize `CommandResult`, and disconnect.
- Proof/validation (u=0.05): the focused RED suite failed because the legacy resolver/raw HTTP path was called; the GREEN suite verifies SDK connect/run/disconnect, cloud auth, local mode, JSON, nonzero results, not-found, and connection failures.
- Implementation (u=0.05): update only `cmd_exec` in production and replace the stale `TestCmdExec` mocks.

Assumptions: `Sandbox.connect(name, local=..., api_key=...)` and `shell.run(command, timeout=120)` retain their current SDK signatures; `CommandResult` exposes `stdout`, `stderr`, and `returncode`.

Uncertainty: disconnect errors continue to propagate as SDK errors; this change does not redefine SDK lifecycle semantics.

## Tests

- RED: `TestCmdExec` — `6 failed, 3 passed` because current main used the legacy resolver/raw HTTP path.
- GREEN: `uv run pytest tests/commands/test_sandbox.py::TestCmdExec -q` — `9 passed in 0.43s`.
- `uv run ruff check cua_cli/commands/sandbox.py` — passed.
- `uv run ruff check tests/commands/test_sandbox.py` — passed.
- `uv run ruff format --check cua_cli/commands/sandbox.py tests/commands/test_sandbox.py` — passed (`2 files already formatted`).
- `git diff HEAD^ --check` — passed.

## Existing test-file baseline

`uv run pytest tests/commands/test_sandbox.py -x -q` stops before exec at the pre-existing stale parser test `TestRegisterParser::test_create_command_has_required_args`: `1 failed, 3 passed`. Current main registers `launch`, not the stale `create` command. This PR intentionally does not expand into CUA-986 test-only cleanup.
