### PR TITLE
fix(cua-cli): use Fleet SDK for sandbox shell

### DIFF
--- a/libs/python/cua-cli/cua_cli/commands/sandbox.py
+++ b/libs/python/cua-cli/cua_cli/commands/sandbox.py
@@ -902,30 +902,41 @@ def cmd_shell(args: argparse.Namespace) -> int:
     local = getattr(args, "local", False)
 
     async def _run() -> int:
-        try:
-            api_url, api_key = await _get_sandbox_api_url(args.name, local)
-        except ValueError as e:
-            print_error(str(e))
-            return 1
-
         if not sys.stdin.isatty():
             if not command:
                 print_error("No command provided for non-interactive mode")
                 return 1
-            result = await _exec_noninteractive(args.name, api_url, api_key, command)
-            if not result.get("success", True):
-                print_error(result.get("error", "Command failed"))
+
+            from cua_sandbox import Sandbox
+
+            try:
+                kwargs: dict[str, Any] = {}
+                if not local:
+                    kwargs["api_key"] = await get_access_token()
+                sb = await Sandbox.connect(args.name, local=local, **kwargs)
+            except Exception as e:
+                print_error(f"Failed to connect to sandbox: {e}")
                 return 1
-            stdout = result.get("stdout", "").strip()
-            stderr = result.get("stderr", "").strip()
-            returncode = result.get("returncode") or result.get("return_code") or 0
+
+            try:
+                result = await sb.shell.run(command, timeout=120)
+            except Exception as e:
+                print_error(f"Failed to execute command: {e}")
+                return 1
+            finally:
+                await sb.disconnect()
+
+            stdout = result.stdout.strip()
+            stderr = result.stderr.strip()
             if stdout:
                 print(stdout)
             if stderr:
                 print(stderr, file=sys.stderr)
-            return returncode
+            return result.returncode
 
+        # The SDK terminal API does not expose output streaming or resize yet.
         try:
+            api_url, api_key = await _get_sandbox_api_url(args.name, local)
             return await _shell_interactive(args.name, api_url, api_key, command, cols, rows)
         except ValueError as e:
             print_error(str(e))

--- a/libs/python/cua-cli/tests/commands/test_sandbox.py
+++ b/libs/python/cua-cli/tests/commands/test_sandbox.py
@@ -1,6 +1,7 @@
 """Tests for sandbox command module."""
 
 import argparse
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from cua_cli.commands import sandbox
@@ -484,51 +485,148 @@ class TestCmdShell:
         assert args.name == "my-sandbox"
         assert args.shell_command == ["ls"]
 
-    def test_shell_sandbox_not_found(self, args_namespace, mock_api_key):
-        """Test shell with nonexistent sandbox."""
+    def test_interactive_shell_preserves_terminal_size(self, args_namespace, mock_api_key):
+        """Test interactive shell keeps the existing streaming path and dimensions."""
         args = args_namespace(
-            name="nonexistent",
+            name="test-sandbox",
             shell_command=[],
-            cols=None,
-            rows=None,
+            cols=120,
+            rows=40,
+            local=False,
         )
 
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.get_vm = AsyncMock(return_value={"status": "not_found"})
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "print_error") as mock_error:
-                with patch("sys.stdin") as mock_stdin:
-                    mock_stdin.isatty.return_value = False
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = True
+            with patch.object(
+                sandbox,
+                "_get_sandbox_api_url",
+                new_callable=AsyncMock,
+                return_value=("https://sandbox.example.com", "test-access-token"),
+            ):
+                with patch.object(
+                    sandbox, "_shell_interactive", new_callable=AsyncMock, return_value=0
+                ) as mock_interactive:
                     result = sandbox.cmd_shell(args)
 
-        assert result == 1
-        mock_error.assert_called()
+        assert result == 0
+        mock_interactive.assert_awaited_once_with(
+            "test-sandbox",
+            "https://sandbox.example.com",
+            "test-access-token",
+            None,
+            120,
+            40,
+        )
 
-    def test_shell_no_api_url(self, args_namespace, mock_api_key):
-        """Test shell when sandbox has no API URL."""
+    def test_shell_command_uses_fleet_sdk(self, args_namespace, mock_api_key, capsys):
+        """Test non-interactive shell commands run through the Fleet SDK."""
         args = args_namespace(
             name="test-sandbox",
             shell_command=["echo", "hello"],
             cols=None,
             rows=None,
+            local=False,
+        )
+        command_result = SimpleNamespace(stdout="hello\n", stderr="", returncode=0)
+        mock_sandbox = MagicMock()
+        mock_sandbox.shell.run = AsyncMock(return_value=command_result)
+        mock_sandbox.disconnect = AsyncMock()
+        mock_connect = AsyncMock(return_value=mock_sandbox)
+        mock_sandbox_sdk = MagicMock()
+        mock_sandbox_sdk.Sandbox.connect = mock_connect
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sandbox_sdk}):
+            with patch("sys.stdin") as mock_stdin:
+                mock_stdin.isatty.return_value = False
+                result = sandbox.cmd_shell(args)
+
+        assert result == 0
+        mock_connect.assert_awaited_once_with(
+            "test-sandbox", local=False, api_key="test-access-token"
+        )
+        mock_sandbox.shell.run.assert_awaited_once_with("echo hello", timeout=120)
+        mock_sandbox.disconnect.assert_awaited_once_with()
+        assert capsys.readouterr().out == "hello\n"
+
+    def test_shell_command_failure(self, args_namespace, mock_api_key):
+        """Test command execution failures return a clear error."""
+        args = args_namespace(
+            name="test-sandbox",
+            shell_command=["false"],
+            cols=None,
+            rows=None,
+            local=False,
+        )
+        mock_sandbox = MagicMock()
+        mock_sandbox.shell.run = AsyncMock(side_effect=RuntimeError("command transport failed"))
+        mock_sandbox.disconnect = AsyncMock()
+        mock_sandbox_sdk = MagicMock()
+        mock_sandbox_sdk.Sandbox.connect = AsyncMock(return_value=mock_sandbox)
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sandbox_sdk}):
+            with patch("sys.stdin") as mock_stdin:
+                mock_stdin.isatty.return_value = False
+                with patch.object(sandbox, "print_error") as mock_error:
+                    result = sandbox.cmd_shell(args)
+
+        assert result == 1
+        mock_error.assert_called_once_with("Failed to execute command: command transport failed")
+        mock_sandbox.disconnect.assert_awaited_once_with()
+
+    def test_shell_sandbox_not_found(self, args_namespace, mock_api_key):
+        """Test a nonexistent sandbox returns a connection error."""
+        args = args_namespace(
+            name="nonexistent",
+            shell_command=["echo", "hello"],
+            cols=None,
+            rows=None,
+            local=False,
+        )
+        mock_sandbox_sdk = MagicMock()
+        mock_sandbox_sdk.Sandbox.connect = AsyncMock(
+            side_effect=ValueError("Sandbox 'nonexistent' not found")
         )
 
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.get_vm = AsyncMock(return_value={"status": "stopped", "api_url": None})
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sandbox_sdk}):
+            with patch("sys.stdin") as mock_stdin:
+                mock_stdin.isatty.return_value = False
+                with patch.object(sandbox, "print_error") as mock_error:
+                    result = sandbox.cmd_shell(args)
 
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "print_error") as mock_error:
+        assert result == 1
+        mock_error.assert_called_once_with(
+            "Failed to connect to sandbox: Sandbox 'nonexistent' not found"
+        )
+
+    def test_shell_local_mode(self, args_namespace, capsys):
+        """Test local shell commands connect without cloud authentication."""
+        args = args_namespace(
+            name="local-sandbox",
+            shell_command=["pwd"],
+            cols=None,
+            rows=None,
+            local=True,
+        )
+        command_result = SimpleNamespace(stdout="/workspace\n", stderr="", returncode=0)
+        mock_sandbox = MagicMock()
+        mock_sandbox.shell.run = AsyncMock(return_value=command_result)
+        mock_sandbox.disconnect = AsyncMock()
+        mock_connect = AsyncMock(return_value=mock_sandbox)
+        mock_sandbox_sdk = MagicMock()
+        mock_sandbox_sdk.Sandbox.connect = mock_connect
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sandbox_sdk}):
+            with patch.object(sandbox, "get_access_token", new_callable=AsyncMock) as mock_token:
                 with patch("sys.stdin") as mock_stdin:
                     mock_stdin.isatty.return_value = False
                     result = sandbox.cmd_shell(args)
 
-        assert result == 1
-        mock_error.assert_called()
+        assert result == 0
+        mock_token.assert_not_awaited()
+        mock_connect.assert_awaited_once_with("local-sandbox", local=True)
+        mock_sandbox.shell.run.assert_awaited_once_with("pwd", timeout=120)
+        mock_sandbox.disconnect.assert_awaited_once_with()
+        assert capsys.readouterr().out == "/workspace\n"
 
 
 class TestCmdExec:


### PR DESCRIPTION
Linear: CUA-994
Parent: CUA-964

## What changed

- Route non-interactive `cua sb shell <name> <command...>` through `Sandbox.connect()` and `sb.shell.run(command, timeout=120)`.
- Preserve cloud authentication, `--local`, stdout/stderr, command exit codes, and sandbox disconnection.
- Keep the existing interactive WebSocket path because the current Fleet SDK terminal contract exposes PTY create/input/info/close but does not expose output streaming or terminal resize.
- Replace stale provider mocks with tests at the `Sandbox.connect()` / `sb.shell.run()` SDK boundary.

## Shannon decomposition

Pinned method revision: `olaservo/shannon-thinking@ba01de122e577082928228f3f9f11c03857bdd34`

- **Problem definition (u=0.10):** Non-interactive `cmd_shell` bypasses Fleet SDK discovery and command execution through `_get_sandbox_api_url()` plus raw HTTP `_exec_noninteractive()`.
- **Constraints (u=0.15):** One child and PR from current `origin/main`; modify only shell behavior/tests; preserve `--local`, `--cols`, `--rows`, cloud auth, interactive behavior, and command exit semantics; do not touch exec or VNC.
- **Model (u=0.15):** For non-TTY calls, connect with `Sandbox.connect(name, local=..., api_key=...)`, run with `sb.shell.run(command, timeout=120)`, and disconnect in `finally`. Retain the existing interactive transport until the SDK exposes streaming output and resize.
- **Proof/validation (u=0.05):** SDK-bound tests were written first. RED was `4 failed, 3 passed` because all command cases still entered the legacy URL/HTTP path. GREEN is `8 passed` after implementation, including cloud, local, connection failure, execution failure, and terminal dimension preservation.
- **Implementation (u=0.05):** Update only `cmd_shell` and `TestCmdShell`.
- **Assumptions:** `Sandbox.connect()` accepts `name`, `local`, and optional `api_key`; `sb.shell.run()` returns `stdout`, `stderr`, and `returncode`; `sb.disconnect()` is async.
- **Uncertainty:** Interactive Fleet parity remains blocked by the SDK terminal interface lacking an output-stream and resize contract; the existing interactive path remains functional and covered.

## Validation

```text
uv run --project libs/python/cua-cli pytest libs/python/cua-cli/tests/commands/test_sandbox.py::TestCmdShell -q
........                                                                 [100%]
8 passed in 0.18s

uv run --project libs/python/cua-cli ruff check libs/python/cua-cli/cua_cli/commands/sandbox.py libs/python/cua-cli/tests/commands/test_sandbox.py
All checks passed!

uv run --project libs/python/cua-cli ruff format --check libs/python/cua-cli/cua_cli/commands/sandbox.py libs/python/cua-cli/tests/commands/test_sandbox.py
2 files already formatted

git diff --check
(clean)
```