### PR TITLE
test(cua-cli): align sandbox tests with Fleet SDK

### DIFF
--- a/libs/python/cua-cli/tests/commands/test_sandbox.py
+++ b/libs/python/cua-cli/tests/commands/test_sandbox.py
@@ -1,7 +1,8 @@
 """Tests for sandbox command module."""
 
 import argparse
-from unittest.mock import AsyncMock, MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from cua_cli.commands import sandbox
 
@@ -40,8 +41,8 @@ class TestRegisterParser:
         args = parser.parse_args(["sandbox", "list", "--json"])
         assert args.json is True
 
-    def test_create_command_has_required_args(self):
-        """Test that create command has required arguments."""
+    def test_launch_command_has_required_args(self):
+        """Test that launch accepts its image and optional settings."""
         parser = argparse.ArgumentParser()
         subparsers = parser.add_subparsers()
         sandbox.register_parser(subparsers)
@@ -49,17 +50,16 @@ class TestRegisterParser:
         args = parser.parse_args(
             [
                 "sandbox",
-                "create",
-                "--os",
-                "linux",
-                "--size",
-                "medium",
+                "launch",
+                "ubuntu:24.04",
+                "--name",
+                "test-sandbox",
                 "--region",
                 "north-america",
             ]
         )
-        assert args.os == "linux"
-        assert args.size == "medium"
+        assert args.image == "ubuntu:24.04"
+        assert args.name == "test-sandbox"
         assert args.region == "north-america"
 
 
@@ -72,7 +72,7 @@ class TestExecute:
             command="sandbox", sandbox_command="list", json=False, show_passwords=False
         )
 
-        with patch.object(sandbox, "cmd_list", return_value=0) as mock_cmd:
+        with patch.object(sandbox, "cmd_ls", return_value=0) as mock_cmd:
             result = sandbox.execute(args)
 
         mock_cmd.assert_called_once_with(args)
@@ -82,7 +82,7 @@ class TestExecute:
         """Test dispatch to list command via ls alias."""
         args = args_namespace(command="sb", sandbox_command="ls", json=False, show_passwords=False)
 
-        with patch.object(sandbox, "cmd_list", return_value=0) as mock_cmd:
+        with patch.object(sandbox, "cmd_ls", return_value=0) as mock_cmd:
             sandbox.execute(args)
 
         mock_cmd.assert_called_once_with(args)
@@ -98,213 +98,214 @@ class TestExecute:
         mock_error.assert_called()
 
 
-class TestCmdList:
-    """Tests for cmd_list function."""
+class TestCmdLs:
+    """Tests for cmd_ls function."""
 
-    def test_list_sandboxes_success(self, args_namespace, sample_vm_list, mock_api_key):
-        """Test listing sandboxes successfully."""
-        args = args_namespace(json=False, show_passwords=False)
+    def test_ls_cloud_sandboxes(self, args_namespace, mock_api_key):
+        """Test the default list path uses the cloud Fleet SDK."""
+        args = args_namespace(json=False, local=False, all=False)
+        cloud_sandboxes = [SimpleNamespace(name="cloudbox", status="running")]
+        mock_list = AsyncMock(return_value=cloud_sandboxes)
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.list = mock_list
 
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.list_vms = AsyncMock(return_value=sample_vm_list)
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "print_table") as mock_print:
-                result = sandbox.cmd_list(args)
-
-        assert result == 0
-        mock_print.assert_called_once()
-
-    def test_list_sandboxes_empty(self, args_namespace, mock_api_key):
-        """Test listing when no sandboxes exist."""
-        args = args_namespace(json=False, show_passwords=False)
-
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.list_vms = AsyncMock(return_value=[])
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "print_info") as mock_print:
-                result = sandbox.cmd_list(args)
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch.object(sandbox, "print_table") as mock_table:
+                result = sandbox.cmd_ls(args)
 
         assert result == 0
-        mock_print.assert_called_with("No sandboxes found.")
-
-    def test_list_sandboxes_json_output(self, args_namespace, sample_vm_list, mock_api_key):
-        """Test JSON output format."""
-        args = args_namespace(json=True, show_passwords=False)
-
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.list_vms = AsyncMock(return_value=sample_vm_list)
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "print_json") as mock_print:
-                result = sandbox.cmd_list(args)
-
-        assert result == 0
-        mock_print.assert_called_once_with(sample_vm_list)
-
-
-class TestCmdCreate:
-    """Tests for cmd_create function."""
-
-    def test_create_sandbox_success(self, args_namespace, mock_api_key):
-        """Test creating a sandbox successfully."""
-        args = args_namespace(
-            os="linux",
-            size="medium",
-            region="north-america",
-            json=False,
+        mock_list.assert_awaited_once_with(local=False, api_key="test-access-token")
+        mock_table.assert_called_once_with(
+            [{"name": "cloudbox", "status": "running", "source": "cloud"}],
+            [("name", "NAME"), ("status", "STATUS"), ("source", "SOURCE")],
         )
 
-        # Mock the API response (status 202 = provisioning)
-        async def mock_api_request(*args, **kwargs):
-            return (
-                202,
-                {
-                    "status": "provisioning",
-                    "name": "new-sandbox",
-                    "host": "sandbox.example.com",
-                },
-            )
+    def test_ls_local_sandboxes(self, args_namespace):
+        """Test --local lists only local sandboxes without cloud auth."""
+        args = args_namespace(json=False, local=True, all=False)
+        local_sandboxes = [SimpleNamespace(name="localbox", status="running", source="local")]
+        mock_list = AsyncMock(return_value=local_sandboxes)
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.list = mock_list
 
-        with patch.object(sandbox, "_api_request", side_effect=mock_api_request):
-            with patch.object(sandbox, "print_info"):
-                result = sandbox.cmd_create(args)
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch.object(sandbox, "get_access_token", new_callable=AsyncMock) as mock_token:
+                with patch.object(sandbox, "print_table"):
+                    result = sandbox.cmd_ls(args)
 
         assert result == 0
+        mock_list.assert_awaited_once_with(local=True)
+        mock_token.assert_not_awaited()
 
-    def test_create_sandbox_error(self, args_namespace, mock_api_key):
-        """Test handling create error."""
-        args = args_namespace(
-            os="linux",
-            size="medium",
-            region="north-america",
-            json=False,
+    def test_ls_all_json(self, args_namespace, mock_api_key):
+        """Test --all combines local and cloud results in JSON output."""
+        args = args_namespace(json=True, local=False, all=True)
+        local_sandboxes = [SimpleNamespace(name="localbox", status="running", source="local")]
+        cloud_sandboxes = [SimpleNamespace(name="cloudbox", status="pending")]
+        mock_list = AsyncMock(side_effect=[local_sandboxes, cloud_sandboxes])
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.list = mock_list
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch.object(sandbox, "print_json") as mock_json:
+                result = sandbox.cmd_ls(args)
+
+        assert result == 0
+        assert mock_list.await_args_list == [
+            call(local=True),
+            call(local=False, api_key="test-access-token"),
+        ]
+        mock_json.assert_called_once_with(
+            [
+                {"name": "localbox", "status": "running", "source": "local"},
+                {"name": "cloudbox", "status": "pending", "source": "cloud"},
+            ]
         )
 
-        # Mock the API response (status 500 = error)
-        async def mock_api_request(*args, **kwargs):
-            return (500, "Quota exceeded")
 
-        with patch.object(sandbox, "_api_request", side_effect=mock_api_request):
-            with patch.object(sandbox, "print_error") as mock_error:
-                result = sandbox.cmd_create(args)
+class TestCmdLaunch:
+    """Tests for cmd_launch function."""
 
-        assert result == 1
-        mock_error.assert_called()
-
-
-class TestCmdGet:
-    """Tests for cmd_get function."""
-
-    def test_get_sandbox_success(self, args_namespace, sample_vm, mock_api_key):
-        """Test getting sandbox details."""
+    def test_launch_cloud_with_options(self, args_namespace, mock_api_key):
+        """Test cloud launch forwards resource and image options to Fleet."""
         args = args_namespace(
-            name="test-sandbox-1",
+            image="ubuntu:24.04",
+            local=False,
+            name="new-sandbox",
+            vm=True,
+            cpu=4,
+            memory="8GB",
+            disk="50GB",
+            region="us-east",
+            json=True,
+        )
+        image = object()
+        created = MagicMock()
+        created.name = "new-sandbox"
+        created.disconnect = AsyncMock()
+        mock_create = AsyncMock(return_value=created)
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.create = mock_create
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch.object(sandbox, "_parse_image", return_value=image) as mock_parse:
+                with patch.object(sandbox, "print_json") as mock_json:
+                    result = sandbox.cmd_launch(args)
+
+        assert result == 0
+        mock_parse.assert_called_once_with("ubuntu:24.04", vm=True)
+        mock_create.assert_awaited_once_with(
+            image,
+            name="new-sandbox",
+            region="us-east",
+            cpu=4,
+            memory_mb=8192,
+            disk_gb=50,
+            api_key="test-access-token",
+        )
+        created.disconnect.assert_awaited_once_with()
+        mock_json.assert_called_once_with({"name": "new-sandbox", "status": "ready"})
+
+    def test_launch_local(self, args_namespace):
+        """Test --local launches through Fleet without cloud authentication."""
+        args = args_namespace(
+            image="macos:sequoia",
+            local=True,
+            name="local-sandbox",
+            vm=False,
+            cpu=None,
+            memory=None,
+            disk=None,
+            region=None,
             json=False,
-            show_passwords=False,
-            show_vnc_url=False,
+        )
+        image = object()
+        created = MagicMock()
+        created.name = "local-sandbox"
+        created.disconnect = AsyncMock()
+        mock_create = AsyncMock(return_value=created)
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.create = mock_create
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch.object(sandbox, "_parse_image", return_value=image):
+                with patch.object(
+                    sandbox, "get_access_token", new_callable=AsyncMock
+                ) as mock_token:
+                    with patch.object(sandbox, "print_success") as mock_success:
+                        result = sandbox.cmd_launch(args)
+
+        assert result == 0
+        mock_create.assert_awaited_once_with(image, local=True, name="local-sandbox")
+        mock_token.assert_not_awaited()
+        created.disconnect.assert_awaited_once_with()
+        mock_success.assert_called_once_with("Sandbox 'local-sandbox' is ready")
+
+
+class TestCmdInfo:
+    """Tests for cmd_info function."""
+
+    def test_info_cloud_json(self, args_namespace, mock_api_key):
+        """Test cloud info uses Fleet and renders all available JSON fields."""
+        args = args_namespace(name="cloudbox", local=False, json=True)
+        info = SimpleNamespace(
+            name="cloudbox",
+            status="running",
+            os_type="linux",
+            host="cloudbox.example.com",
+            region="us-east",
+            created_at="2026-08-06T00:00:00Z",
+            cpu=4,
+            memory_mb=8192,
+            disk_gb=50,
+        )
+        mock_get_info = AsyncMock(return_value=info)
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.get_info = mock_get_info
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch.object(sandbox, "print_json") as mock_json:
+                result = sandbox.cmd_info(args)
+
+        assert result == 0
+        mock_get_info.assert_awaited_once_with("cloudbox", local=False, api_key="test-access-token")
+        mock_json.assert_called_once_with(
+            {
+                "name": "cloudbox",
+                "status": "running",
+                "os_type": "linux",
+                "host": "cloudbox.example.com",
+                "region": "us-east",
+                "created_at": "2026-08-06T00:00:00Z",
+                "cpu": 4,
+                "memory_mb": 8192,
+                "disk_gb": 50,
+            }
         )
 
-        vm_dict = {
-            "name": sample_vm.name,
-            "status": sample_vm.status,
-            "os_type": sample_vm.os_type,
-            "host": "sandbox.example.com",
-        }
-
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.list_vms = AsyncMock(return_value=[vm_dict])
-        mock_provider.get_vm = AsyncMock(return_value={"status": "running"})
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "print_info"):
-                result = sandbox.cmd_get(args)
-
-        assert result == 0
-
-    def test_get_sandbox_not_found(self, args_namespace, mock_api_key):
-        """Test getting nonexistent sandbox."""
-        args = args_namespace(
-            name="nonexistent",
-            json=False,
-            show_passwords=False,
-            show_vnc_url=False,
+    def test_info_local(self, args_namespace):
+        """Test --local gets sandbox info without cloud authentication."""
+        args = args_namespace(name="localbox", local=True, json=False)
+        info = SimpleNamespace(
+            name="localbox",
+            status="running",
+            os_type="macos",
+            host=None,
+            region=None,
+            created_at=None,
         )
+        mock_get_info = AsyncMock(return_value=info)
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.get_info = mock_get_info
 
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.list_vms = AsyncMock(return_value=[])
-        mock_provider.get_vm = AsyncMock(return_value={"status": "not_found"})
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "print_error") as mock_error:
-                result = sandbox.cmd_get(args)
-
-        assert result == 1
-        mock_error.assert_called()
-
-
-class TestCmdStart:
-    """Tests for cmd_start function."""
-
-    def test_start_sandbox_success(self, args_namespace, mock_api_key):
-        """Test starting a sandbox."""
-        args = args_namespace(name="test-sandbox")
-
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.run_vm = AsyncMock(return_value={"status": "starting"})
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "print_success"):
-                result = sandbox.cmd_start(args)
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch.object(sandbox, "get_access_token", new_callable=AsyncMock) as mock_token:
+                with patch.object(sandbox, "print_info"):
+                    result = sandbox.cmd_info(args)
 
         assert result == 0
-
-    def test_start_sandbox_not_found(self, args_namespace, mock_api_key):
-        """Test starting nonexistent sandbox."""
-        args = args_namespace(name="nonexistent")
-
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.run_vm = AsyncMock(return_value={"status": "not_found"})
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "print_error"):
-                result = sandbox.cmd_start(args)
-
-        assert result == 1
-
-
-class TestCmdStop:
-    """Tests for cmd_stop function."""
-
-    def test_stop_sandbox_success(self, args_namespace, mock_api_key):
-        """Test stopping a sandbox."""
-        args = args_namespace(name="test-sandbox")
-
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.stop_vm = AsyncMock(return_value={"status": "stopping"})
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "print_success"):
-                result = sandbox.cmd_stop(args)
-
-        assert result == 0
+        mock_get_info.assert_awaited_once_with("localbox", local=True)
+        mock_token.assert_not_awaited()
 
 
 class TestCmdRestart:
@@ -361,19 +362,61 @@ class TestCmdSuspend:
 class TestCmdDelete:
     """Tests for cmd_delete function."""
 
-    def test_delete_sandbox_success(self, args_namespace, mock_api_key):
-        """Test deleting a sandbox."""
-        args = args_namespace(name="test-sandbox")
+    def test_delete_force_cloud(self, args_namespace, mock_api_key):
+        """Test --force deletes a cloud sandbox without prompting."""
+        args = args_namespace(name="cloudbox", local=False, force=True)
+        mock_delete = AsyncMock()
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.delete = mock_delete
 
-        # Mock the API response (status 202 = deleting)
-        async def mock_api_request(*args, **kwargs):
-            return (202, {"status": "deleting"})
-
-        with patch.object(sandbox, "_api_request", side_effect=mock_api_request):
-            with patch.object(sandbox, "print_success"):
-                result = sandbox.cmd_delete(args)
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch("builtins.input") as mock_input:
+                with patch.object(sandbox, "print_success") as mock_success:
+                    result = sandbox.cmd_delete(args)
 
         assert result == 0
+        mock_input.assert_not_called()
+        mock_delete.assert_awaited_once_with("cloudbox", local=False, api_key="test-access-token")
+        mock_success.assert_called_once_with("Sandbox 'cloudbox' is being deleted.")
+
+    def test_delete_confirmation_aborts(self, args_namespace):
+        """Test declining interactive confirmation does not call Fleet."""
+        args = args_namespace(name="cloudbox", local=False, force=False)
+        mock_delete = AsyncMock()
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.delete = mock_delete
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch("sys.stdin") as mock_stdin:
+                mock_stdin.isatty.return_value = True
+                with patch("builtins.input", return_value="n"):
+                    with patch.object(sandbox, "print_info") as mock_info:
+                        result = sandbox.cmd_delete(args)
+
+        assert result == 0
+        mock_delete.assert_not_awaited()
+        mock_info.assert_called_once_with("Aborted.")
+
+    def test_delete_confirmed_local(self, args_namespace):
+        """Test confirming a local delete avoids cloud authentication."""
+        args = args_namespace(name="localbox", local=True, force=False)
+        mock_delete = AsyncMock()
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.delete = mock_delete
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch("sys.stdin") as mock_stdin:
+                mock_stdin.isatty.return_value = True
+                with patch("builtins.input", return_value="yes"):
+                    with patch.object(
+                        sandbox, "get_access_token", new_callable=AsyncMock
+                    ) as mock_token:
+                        with patch.object(sandbox, "print_success"):
+                            result = sandbox.cmd_delete(args)
+
+        assert result == 0
+        mock_delete.assert_awaited_once_with("localbox", local=True)
+        mock_token.assert_not_awaited()
 
 
 class TestCmdVnc:


### PR DESCRIPTION
Linear: CUA-964

## What changed

- Replace stale `TestCmdList`, `TestCmdCreate`, and `TestCmdGet` coverage with `TestCmdLs`, `TestCmdLaunch`, and `TestCmdInfo` tests at the live Fleet SDK boundary.
- Verify cloud, local, all, JSON, image/resource, and authentication behavior through `Sandbox.list()`, `Sandbox.create()`, and `Sandbox.get_info()`.
- Rewrite delete tests around `Sandbox.delete()`, including forced deletion, declined confirmation, and confirmed local deletion.
- Remove tests for nonexistent `start` and `stop` commands.
- Align the adjacent launch parser and list dispatcher assertions with the current command names.
- Modify tests only; production code is unchanged.

## Baseline

The old focused classes failed before the rewrite:

```text
FFFFFFFFFFF                                                              [100%]
11 failed in 0.89s
```

Failures referenced removed `_get_provider`, `_api_request`, `cmd_list`, `cmd_create`, `cmd_get`, `cmd_start`, and `cmd_stop` symbols.

## Validation

```text
uv run --project libs/python/cua-cli pytest \
  libs/python/cua-cli/tests/commands/test_sandbox.py::TestRegisterParser \
  libs/python/cua-cli/tests/commands/test_sandbox.py::TestExecute \
  libs/python/cua-cli/tests/commands/test_sandbox.py::TestCmdLs \
  libs/python/cua-cli/tests/commands/test_sandbox.py::TestCmdLaunch \
  libs/python/cua-cli/tests/commands/test_sandbox.py::TestCmdInfo \
  libs/python/cua-cli/tests/commands/test_sandbox.py::TestCmdDelete -q
.................                                                        [100%]
17 passed in 0.19s

uv run --project libs/python/cua-cli ruff check libs/python/cua-cli/tests/commands/test_sandbox.py
All checks passed!

uv run --project libs/python/cua-cli ruff format --check libs/python/cua-cli/tests/commands/test_sandbox.py
1 file already formatted

git diff --check
(clean)
```