### PR TITLE
fix(cua-driver): activate exact macOS window for foreground drag

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/tests/cross_platform_behavior_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/cross_platform_behavior_test.rs
@@ -630,6 +630,29 @@ fn fixture_marker_number(fixture: &Fixture, id: &str, prefix: &str) -> Option<u6
         .and_then(|value| value.parse().ok())
 }
 
+fn drag_event_was_observed(events: &str, required: &str) -> bool {
+    events
+        .strip_prefix("drag_events=")
+        .is_some_and(|observed| observed.split(',').any(|event| event == required))
+}
+
+#[test]
+fn drag_event_evidence_matches_complete_event_names_only() {
+    let events = "drag_events=pointerdown,pointermove,dragstart,dragover,drop,pointerup";
+    for required in [
+        "pointerdown",
+        "pointermove",
+        "pointerup",
+        "dragstart",
+        "dragover",
+        "drop",
+    ] {
+        assert!(drag_event_was_observed(events, required));
+    }
+    assert!(!drag_event_was_observed(events, "drag"));
+    assert!(!drag_event_was_observed("pointerdown,drop", "drop"));
+}
+
 fn action_target_args(
     fixture: &Fixture,
     state: &ToolResponse,
@@ -1047,12 +1070,11 @@ fn run_drag_action(fixture: &mut Fixture, delivery: &str) -> Observation {
     let target = require_element(&pre, "drop-target");
     let origin = window_origin(fixture, &pre);
     let scale = screenshot_scale(&pre);
-    let point = |index: u64| {
-        let (x, y) = element_center(&pre, index);
-        ((x - origin.0) * scale, (y - origin.1) * scale)
-    };
-    let (from_x, from_y) = point(source);
-    let (to_x, to_y) = point(target);
+    let from_screen = element_center(&pre, source);
+    let to_screen = element_center(&pre, target);
+    let point = |(x, y): (f64, f64)| ((x - origin.0) * scale, (y - origin.1) * scale);
+    let (from_x, from_y) = point(from_screen);
+    let (to_x, to_y) = point(to_screen);
     let response = fixture.driver.call(
         "drag",
         serde_json::json!({
@@ -1078,6 +1100,33 @@ fn run_drag_action(fixture: &mut Fixture, delivery: &str) -> Observation {
         response.raw
     );
     assert_fixture_contains(fixture, "drag_status=dropped");
+    if cfg!(target_os = "macos") && fixture.name == "electron" && delivery == "foreground" {
+        let events = fixture
+            .journal
+            .text("drag-events")
+            .unwrap_or_else(|| "drag_events=".to_owned());
+        for required in [
+            "pointerdown",
+            "pointermove",
+            "pointerup",
+            "dragstart",
+            "dragover",
+            "drop",
+        ] {
+            assert!(
+                drag_event_was_observed(&events, required),
+                "{}: foreground pixel drag did not emit {required}; events={events}; \
+                 window_local=({from_x:.1},{from_y:.1})->({to_x:.1},{to_y:.1}); \
+                 screen=({:.1},{:.1})->({:.1},{:.1}); route={}",
+                fixture.name,
+                from_screen.0,
+                from_screen.1,
+                to_screen.0,
+                to_screen.1,
+                response.structured()["path"].as_str().unwrap_or("unknown"),
+            );
+        }
+    }
     delivered_observation()
 }
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/drag.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/drag.rs
@@ -18,7 +18,6 @@ use serde_json::Value;
 use std::sync::Arc;
 
 use super::ToolState;
-use crate::apps;
 use crate::focus_guard;
 use crate::input::mouse::DragButton;
 use crate::window_change_detector::WindowChangeDetector;
@@ -292,7 +291,7 @@ impl Tool for DragTool {
         // windows (drop on Dock, drop on background app icon) and the
         // mouseDown half-event alone can activate the target app on some
         // Chromium builds. Wrap to catch + report both.
-        let prior_front = apps::frontmost_pid();
+        let prior_front = crate::apps::frontmost_pid();
         let snapshot = WindowChangeDetector::snapshot(prior_front);
 
         // Dispatch blocking drag synthesis.
@@ -316,28 +315,27 @@ impl Tool for DragTool {
                     let do_it = move || -> anyhow::Result<()> {
                         let m: Vec<&str> = mods_owned.iter().map(String::as_str).collect();
                         if fg {
-                            // HID delivery is global, so foreground mode must
-                            // establish a real active application before the
-                            // gesture begins. The SkyLight flash can be
-                            // unavailable for Electron child windows; the
-                            // documented Cocoa activation is the fallback.
-                            apps::activate_pid(pid);
-                            std::thread::sleep(std::time::Duration::from_millis(40));
                             let observed_cursor = cursor_for_drag.clone();
-                            return crate::input::mouse::drag_at_xy_foreground_observed(
-                                from_sx,
-                                from_sy,
-                                to_sx,
-                                to_sy,
-                                duration_ms,
-                                steps,
-                                &m,
-                                button,
-                                move |x, y| {
-                                    crate::cursor::overlay::send_command(
-                                        observed_cursor.clone(),
-                                        cursor_overlay::track_pointer_command(x, y),
-                                    );
+                            return crate::input::skylight::with_foreground_hid_activation(
+                                pid as libc::pid_t,
+                                window_id.expect("foreground drag requires a window"),
+                                || {
+                                    crate::input::mouse::drag_at_xy_foreground_observed(
+                                        from_sx,
+                                        from_sy,
+                                        to_sx,
+                                        to_sy,
+                                        duration_ms,
+                                        steps,
+                                        &m,
+                                        button,
+                                        move |x, y| {
+                                            crate::cursor::overlay::send_command(
+                                                observed_cursor.clone(),
+                                                cursor_overlay::track_pointer_command(x, y),
+                                            );
+                                        },
+                                    )
                                 },
                             );
                         }
@@ -363,22 +361,7 @@ impl Tool for DragTool {
                             },
                         )
                     };
-                    // Foreground rung: activate for the complete HID gesture,
-                    // then restore the prior app after pointer capture settles.
-                    match (fg, window_id) {
-                        (true, Some(_wid)) => {
-                            let result = do_it();
-                            std::thread::sleep(std::time::Duration::from_millis(100));
-                            if let Some(previous_pid) = prior_front {
-                                if previous_pid != pid {
-                                    apps::activate_pid(previous_pid);
-                                }
-                            }
-                            result?;
-                            Ok(())
-                        }
-                        _ => do_it(),
-                    }
+                    do_it()
                 })
                 .await
             },

--- a/libs/cua-driver/tests/fixtures/shared/web/index.html
+++ b/libs/cua-driver/tests/fixtures/shared/web/index.html
@@ -110,9 +110,10 @@
   <fieldset>
     <legend>drag_task</legend>
     <div class="row">
-      <div id="drag-source" data-cua-id="drag-source" aria-label="drag-source">Drag source</div>
+      <div id="drag-source" data-cua-id="drag-source" aria-label="drag-source" draggable="true">Drag source</div>
       <div id="drop-target" data-cua-id="drop-target" aria-label="drop-target">Drop target</div>
       <span class="mirror" id="drag-status" data-cua-id="drag-status">drag_status=idle</span>
+      <span class="mirror" id="drag-events" data-cua-id="drag-events">drag_events=</span>
     </div>
   </fieldset>
 
@@ -254,20 +255,52 @@
     const source = $('drag-source');
     const target = $('drop-target');
     let dragging = false;
+    const observed = [];
+    const record = event => {
+      // One occurrence of each transition is sufficient evidence and keeps
+      // high-frequency pointermove/dragover events deterministic.
+      if (!observed.includes(event.type)) {
+        observed.push(event.type);
+        $('drag-events').textContent = `drag_events=${observed.join(',')}`;
+      }
+    };
+    for (const kind of ['pointerdown', 'pointermove', 'pointerup', 'dragstart', 'dragover', 'drop']) {
+      document.addEventListener(kind, record, true);
+    }
     source.addEventListener('pointerdown', event => {
       dragging = true;
-      source.setPointerCapture(event.pointerId);
       $('drag-status').textContent = 'drag_status=started';
     });
     source.addEventListener('pointermove', event => {
       if (dragging) $('drag-status').textContent = 'drag_status=moved';
     });
-    source.addEventListener('pointerup', event => {
+    // Keep the pointer fallback document-scoped: unlike pointer capture it
+    // does not suppress Chromium's native HTML drag negotiation, and it still
+    // preserves the existing canvas-style background-drag oracle on hosts
+    // whose injected stream does not begin an HTML drag.
+    document.addEventListener('pointerup', event => {
+      if (!dragging) return;
       dragging = false;
       const rect = target.getBoundingClientRect();
       const inside = event.clientX >= rect.left && event.clientX <= rect.right &&
         event.clientY >= rect.top && event.clientY <= rect.bottom;
       $('drag-status').textContent = inside ? 'drag_status=dropped' : 'drag_status=outside';
+    });
+    source.addEventListener('dragstart', event => {
+      dragging = true;
+      event.dataTransfer.setData('text/plain', 'cua-drag-source');
+      event.dataTransfer.effectAllowed = 'move';
+    });
+    target.addEventListener('dragover', event => {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = 'move';
+    });
+    target.addEventListener('drop', event => {
+      event.preventDefault();
+      dragging = false;
+      $('drag-status').textContent = event.dataTransfer.getData('text/plain') === 'cua-drag-source'
+        ? 'drag_status=dropped'
+        : 'drag_status=rejected';
     });
   })();
 


### PR DESCRIPTION
## Summary

- activate the exact macOS window for foreground HID drag using the shared WindowServer activation guard
- add complete Electron pointer and HTML5 drag event evidence to the shared fixture
- require macOS foreground Electron drag coverage to prove the full receiver event sequence

## Root cause

The first missing receiver event was `pointerdown`. The foreground drag path used app-level activation plus a fixed delay, so Electron could receive the HID gesture before the requested native window owned focus. The click path already used exact-window activation; drag now uses the same fail-closed guard for the whole gesture.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p platform-macos --lib` (331 passed)
- `cargo test -p cua-driver --test cross_platform_behavior_test drag_event_evidence_matches_complete_event_names_only`
- exact-SHA macOS Lume certification is in progress before ready-for-review

Closes #2906
