### PR TITLE
feat(cua-driver): support Prime Agent skill onboarding

### DIFF
--- a/docs/content/docs/how-to-guides/driver/connect-your-agent.mdx
+++ b/docs/content/docs/how-to-guides/driver/connect-your-agent.mdx
@@ -1,11 +1,11 @@
 ---
 title: Connect your agent to Cua Driver
-description: Register Cua Driver as an MCP server so an agent can drive the host desktop.
+description: Connect an agent to Cua Driver through MCP or the Cua Driver skill and CLI.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-`cua-driver mcp` runs Cua Driver as a stdio MCP server. Register it when you want an MCP-capable [computer-use agent](/concepts/what-is-computer-use) to drive the **host desktop**: installed apps, signed-in browser sessions, local files opened in apps, and the current OS user session.
+Cua Driver lets a [computer-use agent](/concepts/what-is-computer-use) drive the **host desktop**: installed apps, signed-in browser sessions, local files opened in apps, and the current OS user session. MCP-capable agents connect through `cua-driver mcp`; skill-based agents such as Prime Agent call the CLI directly.
 
 <Callout type="info">
   This connects an agent to Cua Driver on the current machine. To create a disposable local desktop, use [Cua Sandbox](/tutorials/your-first-local-sandbox) instead.
@@ -78,6 +78,32 @@ cua-driver skills status
 ```
 
 See [Install the Cua Driver agent skill](/how-to-guides/driver/install-agent-skill) for the ClawHub and direct-install paths.
+
+## Prime Agent
+
+Prime Agent uses Cua Driver through its persistent IPython environment and the
+Cua Driver agent skill. It does not need a local MCP registration.
+
+Install the skill pack after both tools are installed:
+
+```bash
+cua-driver skills install
+cua-driver skills status
+```
+
+Cua Driver links the skill into `~/.prime/agent/skills/` when Prime Agent's
+skill directory exists. Prime Agent also scans the shared `~/.agents/skills/`
+directory, so an existing Codex-targeted link remains discoverable. Run
+`/reload` in Prime Agent or start a new session after installation, then ask it
+to use the Cua Driver skill. Use `/skill:cua-driver` to invoke it explicitly.
+See [Prime Agent's skill documentation](https://github.com/PrimeIntellect-ai/prime-agent/blob/main/packages/coding-agent/docs/skills.md)
+for its complete discovery and invocation behavior.
+
+Print the same current guidance from the installed binary:
+
+```bash
+cua-driver mcp-config --client prime-agent
+```
 
 ## Cursor
 

--- a/docs/content/docs/how-to-guides/driver/install-agent-skill.mdx
+++ b/docs/content/docs/how-to-guides/driver/install-agent-skill.mdx
@@ -75,6 +75,12 @@ Direct installation keeps only the current host's OS guide by default. Pass `--a
 cua-driver skills install --all-platforms
 ```
 
+Prime Agent is supported directly. When `~/.prime/agent/skills/` exists,
+`cua-driver skills install` links the pack there; Prime Agent also discovers the
+shared `~/.agents/skills/` location used by Codex. Run `/reload` in Prime Agent
+or start a new session after installing or updating the skill so it reloads the
+guidance.
+
 ## Next steps
 
 - [Connect your agent to Cua Driver](/how-to-guides/driver/connect-your-agent): register the MCP server when the agent uses MCP.

--- a/docs/content/docs/reference/cua-driver/cli-reference.mdx
+++ b/docs/content/docs/reference/cua-driver/cli-reference.mdx
@@ -135,9 +135,9 @@ Report whether a Cua Driver daemon is running.
 
 ### `cua-driver mcp-config`
 
-Print MCP server config or a client-specific install command.
+Print client-specific connection guidance (MCP config where supported).
 
-Supported clients include claude, codex, cursor, antigravity, openclaw, opencode, hermes, pi, qwen, droid, and zcode.
+Supported clients include claude, codex, cursor, antigravity, openclaw, opencode, hermes, pi, prime-agent, qwen, droid, and zcode.
 
 **Options:**
 

--- a/docs/content/docs/tutorials/drive-your-first-app.mdx
+++ b/docs/content/docs/tutorials/drive-your-first-app.mdx
@@ -8,7 +8,7 @@ import { Callout } from 'fumadocs-ui/components/callout';
 
 By the end of this tutorial, your agent will open Calculator, compute 6 × 7,
 and report 42 through **Cua Driver**. You will install the driver, connect
-Claude Code, Codex, or Hermes, and run the same prompt on macOS, Windows, or
+Claude Code, Codex, Prime Agent, or Hermes, and run the same prompt on macOS, Windows, or
 Linux.
 
 New to agents that operate applications? Start with [What is computer use?](/concepts/what-is-computer-use) for the model behind the workflow, then return here to build one.
@@ -119,7 +119,7 @@ If you see your running apps listed, the plumbing works. That is the only CLI yo
 
 Register Cua Driver with your agent harness once.
 
-<Tabs items={['Claude Code', 'Codex', 'OpenClaw', 'Hermes']}>
+<Tabs items={['Claude Code', 'Codex', 'Prime Agent', 'OpenClaw', 'Hermes']}>
   <Tab value="Claude Code">
     Install the Claude Code skill. This is turnkey: the skill teaches Claude Code how to drive apps through Cua Driver, and you then ask in plain English.
 
@@ -153,6 +153,19 @@ Register Cua Driver with your agent harness once.
     ```
 
     Restart Codex or open a fresh Codex session after registration so the new tools appear.
+  </Tab>
+  <Tab value="Prime Agent">
+    Install the Cua Driver skill pack. Prime Agent discovers it from its native
+    skill directory and calls Cua Driver from the persistent IPython environment;
+    no MCP registration is required.
+
+    ```bash
+    cua-driver skills install
+    cua-driver mcp-config --client prime-agent
+    ```
+
+    Run `/reload` in Prime Agent or start a new session after installation so
+    the skill appears. Use `/skill:cua-driver` to load it explicitly.
   </Tab>
   <Tab value="OpenClaw">
     Print the OpenClaw registration command:
@@ -201,7 +214,7 @@ Using Cursor, Gemini/Antigravity, OpenCode, or Pi instead? See [Connect your age
 
 You can now prompt your agent in plain English, and it will drive Cua Driver for you.
 
-<Tabs items={['Claude Code', 'Codex']}>
+<Tabs items={['Claude Code', 'Codex', 'Prime Agent']}>
   <Tab value="Claude Code">
     ```text
     > Using the cua-computer-use MCP, open the Calculator, compute 6 × 7, and tell me the result.
@@ -227,6 +240,20 @@ You can now prompt your agent in plain English, and it will drive Cua Driver for
     → click 6 [element_index=11]
     → click = [element_index=22]
     → get_window_state
+    ✓ The result is 42.
+    ```
+  </Tab>
+  <Tab value="Prime Agent">
+    ```text
+    > Using the Cua Driver skill, open the Calculator, compute 6 × 7, and read the result back.
+
+    → launch_app Calculator
+    → get_window_state
+    → click 7
+    → click ×
+    → click 6
+    → click =
+    → verify_state
     ✓ The result is 42.
     ```
   </Tab>

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -158,7 +158,7 @@ pub enum Command {
     /// `cua-driver skills {install|update|uninstall|status|path}` —
     /// agent skill-pack management. The verb is the ONLY way a user
     /// installs or updates the cua-driver skill pack into their agent
-    /// dirs (Claude Code / Codex / OpenClaw / OpenCode); the install
+    /// dirs (Claude Code / Codex / Prime Agent / OpenClaw / OpenCode); the install
     /// scripts never touch ~/.claude/skills/ etc. directly. `install`
     /// fetches the matching versioned release asset
     /// (`cua-driver-rs-v<v>-skills.tar.gz` — the asset filename keeps
@@ -393,6 +393,7 @@ fn finite_client_kind_from_args(args: &[String]) -> &'static str {
         "opencode" => "opencode",
         "hermes" => "hermes",
         "pi" => "pi",
+        "prime-agent" => "prime_agent",
         "antigravity" | "gemini" => "antigravity",
         "qwen" | "qwen-code" => "qwen_code",
         "droid" | "factory" => "factory_droid",
@@ -461,8 +462,8 @@ pub fn parse_command() -> Command {
         println!();
         println!("skills options (agent skill-pack management, opt-in):");
         println!("  cua-driver skills install       Fetch the versioned skill pack from GitHub Releases and symlink it");
-        println!("                                  into each detected agent's skills/ dir (Claude Code, Codex, OpenClaw,");
-        println!("                                  OpenCode). Idempotent. Never overwrites existing user links.");
+        println!("                                  into each detected agent's skills/ dir (Claude Code, Codex, Prime Agent,");
+        println!("                                  OpenClaw, OpenCode). Idempotent. Never overwrites existing user links.");
         println!("  cua-driver skills update        Re-fetch the skill pack from GitHub, refreshing the local copy + links.");
         println!("  cua-driver skills uninstall     Remove the agent symlinks. Add --all to also delete the local copy.");
         println!("  cua-driver skills status        Report local install state + per-agent link state. Read-only.");
@@ -1510,8 +1511,8 @@ pub fn build_manifest() -> serde_json::Value {
                   { "name": "--socket", "type": "string", "description": "Override the required daemon socket path." }
               ] },
             { "name": "mcp-config",
-              "description": "Print the MCP server config snippet or a client-specific install command.",
-              "args": [ { "name": "--client", "type": "string", "description": "One of: claude, codex, cursor, hermes, antigravity, openclaw, opencode, pi, qwen, droid, zcode. Omit for the generic snippet." } ] },
+              "description": "Print client-specific connection guidance (MCP config where supported).",
+              "args": [ { "name": "--client", "type": "string", "description": "One of: claude, codex, cursor, hermes, antigravity, openclaw, opencode, pi, prime-agent, qwen, droid, zcode. Omit for the generic snippet." } ] },
             { "name": "manifest",
               "description": "Emit this machine-readable description of the CLI surface.",
               "args": [ { "name": "--pretty", "type": "flag", "description": "Pretty-print the JSON." } ] },
@@ -1576,10 +1577,11 @@ pub fn build_manifest() -> serde_json::Value {
     })
 }
 
-/// Print the MCP server config snippet or a client-specific install command.
+/// Print client-specific connection guidance (MCP config where supported).
 ///
 /// `--client <name>` selects one of: claude, codex, cursor, hermes,
-/// antigravity, openclaw, opencode, pi. Omit for the generic JSON snippet.
+/// antigravity, openclaw, opencode, pi, prime-agent, qwen, droid, zcode.
+/// Omit for the generic JSON snippet.
 pub fn run_mcp_config(client: Option<&str>) {
     let binary = std::env::current_exe()
         .ok()
@@ -1755,6 +1757,18 @@ pub fn run_mcp_config(client: Option<&str>) {
                  exactly the shape Pi is designed around."
             );
         }
+        Some("prime-agent") => {
+            println!(
+                "Prime Agent loads Agent Skills and can call cua-driver directly from its\n\
+                 persistent IPython control environment. No MCP registration is required.\n\n\
+                 Install and verify the Cua Driver skill pack:\n\n\
+                     {binary} skills install\n\
+                     {binary} skills status\n\n\
+                 Then run /reload in Prime Agent (or start a new session) and ask it to\n\
+                 use the Cua Driver skill. Use /skill:cua-driver to invoke it explicitly.\n\
+                 The skill calls the cua-driver CLI with a snapshot/action/verify workflow."
+            );
+        }
         Some("qwen") | Some("qwen-code") => {
             // Qwen Code (Alibaba's open-source coding CLI, a Gemini-CLI fork).
             // Config: ~/.qwen/settings.json (user) or .qwen/settings.json
@@ -1794,7 +1808,7 @@ pub fn run_mcp_config(client: Option<&str>) {
             );
         }
         Some(other) => {
-            eprintln!("Unknown client '{other}'. Valid: claude, codex, cursor, antigravity, openclaw, opencode, hermes, pi, qwen, droid, zcode.");
+            eprintln!("Unknown client '{other}'. Valid: claude, codex, cursor, antigravity, openclaw, opencode, hermes, pi, prime-agent, qwen, droid, zcode.");
             process::exit(2);
         }
     }
@@ -3094,8 +3108,8 @@ fn cli_docs_json() -> serde_json::Value {
             },
             {
                 "name": "mcp-config",
-                "abstract": "Print MCP server config or a client-specific install command.",
-                "discussion": "Supported clients include claude, codex, cursor, antigravity, openclaw, opencode, hermes, pi, qwen, droid, and zcode.",
+                "abstract": "Print client-specific connection guidance (MCP config where supported).",
+                "discussion": "Supported clients include claude, codex, cursor, antigravity, openclaw, opencode, hermes, pi, prime-agent, qwen, droid, and zcode.",
                 "arguments": no_args,
                 "options": [{"name":"client","short_name":null,"help":"Client name to print configuration for.","type":"String","default_value":null,"is_optional":true}],
                 "flags": no_flags,
@@ -3950,6 +3964,10 @@ mod tests {
         assert_eq!(
             finite_client_kind_from_args(&args(&["mcp-config", "--client", "antigravity"])),
             "antigravity"
+        );
+        assert_eq!(
+            finite_client_kind_from_args(&args(&["mcp-config", "--client", "prime-agent"])),
+            "prime_agent"
         );
         assert_eq!(
             finite_client_kind_from_args(&args(&["mcp-config", "--client", "/private/client"])),

--- a/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
@@ -43,6 +43,7 @@
 //!
 //! - Claude Code: `~/.claude/skills/`
 //! - Codex:       `~/.agents/skills/`
+//! - Prime Agent: `~/.prime/agent/skills/`
 //! - OpenClaw:    `~/.openclaw/skills/`
 //! - OpenCode: `~/.config/opencode/skills/` (macOS / Linux),
 //!   `%APPDATA%\opencode\skills\` (Windows)
@@ -201,6 +202,10 @@ const AGENTS: &[Agent] = &[
         parent: AgentParent::Home(".agents/skills"),
     },
     Agent {
+        label: "Prime Agent",
+        parent: AgentParent::Home(".prime/agent/skills"),
+    },
+    Agent {
         label: "OpenClaw",
         parent: AgentParent::Home(".openclaw/skills"),
     },
@@ -331,7 +336,7 @@ fn install(flags: &[String], force: bool) -> Result<()> {
         }
     }
     if !linked_any {
-        println!("(No agent skills dirs present yet — install Claude Code / Codex / OpenClaw / OpenCode / Antigravity / Hermes then re-run.)");
+        println!("(No agent skills dirs present yet — install Claude Code / Codex / Prime Agent / OpenClaw / OpenCode / Antigravity / Hermes then re-run.)");
     }
     Ok(())
 }
@@ -776,9 +781,22 @@ fn print_path() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_tar_gz, SKILL_FILES};
+    use super::{extract_tar_gz, AgentParent, AGENTS, SKILL_FILES};
     use std::path::PathBuf;
     use tempfile::tempdir;
+
+    #[test]
+    fn prime_agent_target_matches_its_native_global_skill_directory() {
+        let target = AGENTS
+            .iter()
+            .find(|agent| agent.label == "Prime Agent")
+            .expect("Prime Agent must remain a supported skill target");
+
+        assert!(matches!(
+            target.parent,
+            AgentParent::Home(".prime/agent/skills")
+        ));
+    }
 
     /// Build a gzipped tarball with the entries given as
     /// `(path, contents)` pairs. Returns the raw `.tar.gz` bytes.

--- a/libs/cua-driver/rust/crates/cua-driver/tests/compatibility_contract_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/compatibility_contract_test.rs
@@ -84,6 +84,24 @@ fn released_cli_help_and_manifest_fields_remain_compatible() {
 }
 
 #[test]
+fn prime_agent_connection_guidance_uses_the_skill_and_cli_path() {
+    let output = Command::new(env!("CARGO_BIN_EXE_cua-driver"))
+        .args(["mcp-config", "--client", "prime-agent"])
+        .output()
+        .expect("run Prime Agent connection guidance");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("UTF-8 guidance");
+    assert!(stdout.contains("skills install"), "{stdout}");
+    assert!(stdout.contains("skills status"), "{stdout}");
+    assert!(
+        stdout.contains("No MCP registration is required"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("snapshot/action/verify"), "{stdout}");
+}
+
+#[test]
 fn released_mcp_initialize_tools_list_and_error_fields_remain_compatible() {
     let fixture: Value = serde_json::from_str(MCP_FIXTURE).expect("valid MCP fixture");
     let Some(mut driver) = RawDriver::spawn() else {

--- a/libs/cua-driver/rust/crates/platform-windows/examples/mcp_config_parity.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/examples/mcp_config_parity.rs
@@ -47,6 +47,10 @@ fn main() {
             vec!["--client", "pi"],
             vec!["does not support MCP natively"],
         ),
+        (
+            vec!["--client", "prime-agent"],
+            vec!["No MCP registration is required", "skills install"],
+        ),
     ];
 
     for (args, needles) in cases {
@@ -77,7 +81,7 @@ fn main() {
     );
     println!("unknown-client err OK");
 
-    println!("\n✅ PASS: mcp-config 8 client paths + unknown-client error verified");
+    println!("\n✅ PASS: mcp-config 9 client paths + unknown-client error verified");
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/libs/cua-driver/scripts/post-install-hints.txt
+++ b/libs/cua-driver/scripts/post-install-hints.txt
@@ -16,8 +16,14 @@ Next steps:
 
   3. Agent skill pack (optional):
        {{BINARY}} skills install   # fetch + link the cua-driver skill pack
-                                   # into Claude Code / Codex / OpenClaw / OpenCode.
-                                   # The install never touches your agent dirs.
+                                   # into Claude Code / Codex / Prime Agent /
+                                   # OpenClaw / OpenCode and other supported agents.
+                                   # The binary installer never touches your agent dirs.
+
+     Prime Agent needs no MCP registration. It loads the installed skill and
+     calls cua-driver from its persistent IPython environment. Print its setup:
+       {{BINARY}} mcp-config --client prime-agent
+     Then run /reload in Prime Agent (or start a new session).
 
   4. As an MCP server — run the one matching your client. Each is also
      available via '{{BINARY}} mcp-config --client <name>':
@@ -93,4 +99,4 @@ Next steps:
          {{BINARY}} serve --permission-mode unrestricted \
            --dangerously-bypass-approvals
 
-Docs: https://github.com/trycua/cua/tree/main/libs/cua-driver/rust
+Docs: https://cua.ai/docs/how-to-guides/driver/connect-your-agent


### PR DESCRIPTION
## Summary

- detect the native Prime Agent skill directory in `cua-driver skills install`
- add `mcp-config --client prime-agent` guidance for the supported skill/CLI path
- surface Prime Agent in post-install output, tutorials, how-to docs, and generated CLI reference
- cover connection guidance, telemetry classification, and Windows CLI parity

Prime Agent currently exposes local capabilities through Agent Skills and persistent IPython. Its custom MCP integration path supports remote HTTP rather than local stdio, so this deliberately installs the existing Cua Driver skill instead of emitting a misleading MCP registration.

## Validation

- `cargo test --manifest-path libs/cua-driver/rust/Cargo.toml -p cua-driver prime_agent`
- `cargo test --manifest-path libs/cua-driver/rust/Cargo.toml -p cua-driver finite_mcp_config_clients_are_closed_before_worker_handoff`
- `cargo fmt --manifest-path libs/cua-driver/rust/Cargo.toml --all -- --check`
- Cua Driver documentation generator drift check
- public docs hygiene and internal link checks
- production Next.js docs build (94 static pages)

## Limits

- Windows parity coverage is updated, but the Windows-only example was not executed locally on macOS.
- No Cua Driver desktop runtime behavior changes; the representative desktop E2E matrix is not required for this onboarding-only change.