### PR TITLE
docs(cua-driver): start Windows daemon after installation

### DIFF
--- a/docs/content/docs/how-to-guides/driver/install.mdx
+++ b/docs/content/docs/how-to-guides/driver/install.mdx
@@ -32,9 +32,10 @@ If `~/.local/bin` is missing from your PATH, the installer detects your shell (`
 
 ```powershell
 irm https://cua.ai/driver/install.ps1 | iex
+cua-driver autostart kick
 ```
 
-The installer downloads the release under `%USERPROFILE%\.cua-driver\packages\releases\` and exposes `cua-driver.exe` from `%LOCALAPPDATA%\Programs\Cua\cua-driver\bin`. It runs without administrator privileges, detects whether the host is x64 or arm64, and appends the install directory to your User-scope `Path` so new PowerShell windows can resolve `cua-driver.exe`. It also attempts to register the `cua-driver-serve` autostart task; that step needs an interactive session, so on a non-interactive or SSH install it is skipped — set it up later with [`cua-driver autostart enable`](/how-to-guides/driver/keep-running).
+The installer downloads the release under `%USERPROFILE%\.cua-driver\packages\releases\` and exposes `cua-driver.exe` from `%LOCALAPPDATA%\Programs\Cua\cua-driver\bin`. It runs without administrator privileges, detects whether the host is x64 or arm64, and appends the install directory to your User-scope `Path` so new PowerShell windows can resolve `cua-driver.exe`. It also attempts to register the `cua-driver-serve` autostart task; `kick` starts that task immediately, so you do not need to sign out or restart Windows. Registration needs an interactive session, so on a non-interactive or SSH install it is skipped — set it up later with [`cua-driver autostart enable`](/how-to-guides/driver/keep-running).
 
 To skip the PATH change, pass the no-update flag:
 

--- a/docs/content/docs/tutorials/drive-your-first-app.mdx
+++ b/docs/content/docs/tutorials/drive-your-first-app.mdx
@@ -82,7 +82,10 @@ Use the same one-line installer on every platform; it picks the right path for t
 
     ```powershell
     irm https://cua.ai/driver/install.ps1 | iex
+    cua-driver autostart kick
     ```
+
+    The installer registers Cua Driver to start automatically at sign-in. `kick` starts it immediately, so you do not need to sign out or restart Windows before continuing.
 
   </Tab>
   <Tab value="Linux">


### PR DESCRIPTION
## What changed

- run `cua-driver autostart kick` immediately after the Windows installer in the first-app tutorial
- add the same required step to the canonical Cua Driver install guide
- explain that `kick` starts the registered task without waiting for sign-out or restart

## Why

The Windows installer registers the `cua-driver-serve` Scheduled Task but does not start it in the current session. Without `kick`, the tutorial's next verification step can fail until the user signs in again or restarts Windows.

## Validation

- `pnpm docs:check-hygiene`
- `pnpm docs:check-links`
- `pnpm build`
- rendered both affected Windows tabs in an isolated Chrome profile and verified the command and explanation through Cua Driver snapshots
