### PR TITLE
fix(cua-driver): classify DOM click effects with readback

### DIFF
--- a/libs/cua-driver/docs/action-result-contract.md
+++ b/libs/cua-driver/docs/action-result-contract.md
@@ -55,6 +55,12 @@ The invariants are:
 - `partial` has `delivery.delivered_count`;
 - `refused` has neither delivery nor evidence.
 
+`suspected_noop` is advisory. It means a bounded readable state remained
+unchanged, not that the action failed. For a ref-targeted browser DOM click,
+the readback covers bounded semantic and form state on the target plus the
+document URL and active-element identity. Effects elsewhere on the page can be
+invisible to that readback, so verify the expected postcondition before retrying.
+
 ## Window target resolution
 
 Window-scoped actions accept a PID without `window_id` only when that process

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/tools.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/tools.rs
@@ -6,10 +6,16 @@
 //! `{"status": "ok" | "refused", ...}`.
 
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use serde_json::{json, Value};
 
+use crate::action_record::{
+    effect_from_value_readback, ActionEffect, ActionEscalation, ActionEvidence,
+    ActionExecutionRecord, ActionTransport, ActualDelivery, EscalationKind, EvidenceKind,
+    RequestedDelivery,
+};
 use crate::protocol::{Content, ToolResult};
 use crate::tool::{ProtectedResourceOwnership, Tool, ToolDef, ToolRegistry};
 use crate::tool_args::ArgsExt;
@@ -42,6 +48,161 @@ pub fn register_browser_tools(engine: &Arc<BrowserEngine>, registry: &mut ToolRe
 }
 
 // ── Shared helpers ───────────────────────────────────────────────────────────
+
+const DOM_CLICK_READBACK: &str = r#"function() {
+  const bounded = value => typeof value === 'string' ? value.slice(0, 512) : null;
+  const attr = name => bounded(this.getAttribute(name));
+  const active = this.ownerDocument && this.ownerDocument.activeElement;
+  const activeIdentity = active ? [
+    active.tagName,
+    bounded(active.id) || null,
+    bounded(active.getAttribute('name')),
+    bounded(active.getAttribute('data-cua-id'))
+  ] : null;
+  return {
+    ariaPressed: attr('aria-pressed'),
+    ariaSelected: attr('aria-selected'),
+    ariaChecked: attr('aria-checked'),
+    ariaExpanded: attr('aria-expanded'),
+    ariaCurrent: attr('aria-current'),
+    ariaDisabled: attr('aria-disabled'),
+    disabled: 'disabled' in this ? Boolean(this.disabled) : null,
+    checked: 'checked' in this ? Boolean(this.checked) : null,
+    value: 'value' in this ? bounded(String(this.value)) : null,
+    innerText: bounded(this.innerText),
+    href: this.ownerDocument && this.ownerDocument.location
+      ? bounded(this.ownerDocument.location.href)
+      : null,
+    activeElement: activeIdentity
+  };
+}"#;
+
+const DOM_CLICK_READBACK_DEADLINE: Duration = Duration::from_millis(400);
+const DOM_CLICK_READBACK_INTERVAL: Duration = Duration::from_millis(25);
+
+struct DomClickObservation {
+    effect: ActionEffect,
+    observed: Option<Value>,
+    observed_after_ms: u64,
+    readback_available: bool,
+}
+
+async fn read_dom_click_state(conn: &CdpConnection, cdp: &str, object_id: &str) -> Option<Value> {
+    conn.call(
+        Some(cdp),
+        "Runtime.callFunctionOn",
+        json!({
+            "objectId": object_id,
+            "functionDeclaration": DOM_CLICK_READBACK,
+            "returnByValue": true,
+        }),
+    )
+    .await
+    .ok()
+    .and_then(|reply| reply.pointer("/result/value").cloned())
+    .filter(Value::is_object)
+}
+
+fn dom_click_delta(before: &Value, after: &Value) -> Option<Value> {
+    let (Some(before), Some(after)) = (before.as_object(), after.as_object()) else {
+        return None;
+    };
+    let mut observed = serde_json::Map::new();
+    for key in before.keys().chain(after.keys()) {
+        if observed.contains_key(key) {
+            continue;
+        }
+        let old = before.get(key).unwrap_or(&Value::Null);
+        let new = after.get(key).unwrap_or(&Value::Null);
+        if old != new {
+            observed.insert(key.clone(), json!([old, new]));
+        }
+    }
+    (!observed.is_empty()).then_some(Value::Object(observed))
+}
+
+async fn observe_dom_click(
+    conn: &CdpConnection,
+    cdp: &str,
+    object_id: &str,
+    before: Option<Value>,
+) -> DomClickObservation {
+    let Some(before) = before else {
+        return DomClickObservation {
+            effect: effect_from_value_readback(false, false, false),
+            observed: None,
+            observed_after_ms: 0,
+            readback_available: false,
+        };
+    };
+    let started = Instant::now();
+    let mut readable_after = false;
+    loop {
+        if let Some(after) = read_dom_click_state(conn, cdp, object_id).await {
+            readable_after = true;
+            if let Some(observed) = dom_click_delta(&before, &after) {
+                return DomClickObservation {
+                    effect: effect_from_value_readback(true, true, true),
+                    observed: Some(observed),
+                    observed_after_ms: started.elapsed().as_millis() as u64,
+                    readback_available: true,
+                };
+            }
+        }
+        if started.elapsed() >= DOM_CLICK_READBACK_DEADLINE {
+            return DomClickObservation {
+                effect: effect_from_value_readback(false, false, readable_after),
+                observed: readable_after.then(|| json!({})),
+                observed_after_ms: started.elapsed().as_millis() as u64,
+                readback_available: readable_after,
+            };
+        }
+        tokio::time::sleep(DOM_CLICK_READBACK_INTERVAL).await;
+    }
+}
+
+fn dom_click_effect_name(effect: ActionEffect) -> &'static str {
+    match effect {
+        ActionEffect::Confirmed => "confirmed",
+        ActionEffect::SuspectedNoop => "suspected_noop",
+        ActionEffect::Unverifiable => "unverifiable",
+        ActionEffect::Partial => "partial",
+        ActionEffect::Refused => "refused",
+    }
+}
+
+fn dom_click_action_record(observation: &DomClickObservation) -> ActionExecutionRecord {
+    let mut builder = ActionExecutionRecord::builder(
+        observation.effect,
+        ActionTransport::BrowserCdpRuntimeFunction,
+        RequestedDelivery::NotApplicable,
+    )
+    .actual_delivery(ActualDelivery::Background);
+    if observation.readback_available {
+        builder = builder.evidence(ActionEvidence {
+            kind: EvidenceKind::BrowserReadback,
+            detail: if observation.effect == ActionEffect::Confirmed {
+                "bounded semantic target state changed".to_owned()
+            } else {
+                "bounded semantic target state remained unchanged".to_owned()
+            },
+        });
+    }
+    if observation.effect != ActionEffect::Confirmed {
+        builder = builder.escalation(ActionEscalation {
+            kind: EscalationKind::RetryWithPageAction,
+            detail: Some(if observation.effect == ActionEffect::SuspectedNoop {
+                "bounded semantic target state remained unchanged; this is advisory, not proof of failure"
+                    .to_owned()
+            } else {
+                "semantic target readback was unavailable".to_owned()
+            }),
+        });
+    }
+    builder
+        .build()
+        .expect("DOM click action record must satisfy the stable contract")
+}
 
 /// The public caller session id, falling back to the daemon's internal mirror.
 fn session_of(args: &Value) -> String {
@@ -1135,6 +1296,7 @@ impl Tool for BrowserClickTool {
                         .await;
                 }
             }
+            let before = read_dom_click_state(conn, cdp, &object_id).await;
             return match conn
                 .call(
                     Some(cdp),
@@ -1146,25 +1308,56 @@ impl Tool for BrowserClickTool {
                 )
                 .await
             {
-                Ok(_) => ToolResult::text(format!(
-                    "dispatched synthetic DOM click on {} in {tab_id}; application effect not \
-                     verified (trust-gated controls may ignore untrusted events). Refresh page \
-                     state and verify the expected postcondition",
-                    ext_ref.as_deref().unwrap_or("?")
-                ))
-                .with_structured(json!({
-                    "status": "ok",
-                    "effect": "unverifiable",
-                    "route": "dom_event",
-                    "target_id": target_id,
-                    "tab_id": tab_id,
-                    "ref": ext_ref,
-                    "frame": frame_kind,
-                    "escalation": {
-                        "recommended": "page",
-                        "reason": "synthetic DOM dispatch cannot prove control activation; refresh page state and verify the expected postcondition",
-                    },
-                })),
+                Ok(_) => {
+                    let observation = observe_dom_click(conn, cdp, &object_id, before).await;
+                    let effect = dom_click_effect_name(observation.effect);
+                    let text = match observation.effect {
+                        ActionEffect::Confirmed => format!(
+                            "dispatched synthetic DOM click on {} in {tab_id}; bounded semantic \
+                             readback confirmed a target-state change",
+                            ext_ref.as_deref().unwrap_or("?")
+                        ),
+                        ActionEffect::SuspectedNoop => format!(
+                            "dispatched synthetic DOM click on {} in {tab_id}; bounded semantic \
+                             target state remained unchanged (suspected no-op is advisory, not \
+                             proof of failure). Refresh page state and verify the expected \
+                             postcondition",
+                            ext_ref.as_deref().unwrap_or("?")
+                        ),
+                        _ => format!(
+                            "dispatched synthetic DOM click on {} in {tab_id}; application effect \
+                             not verified because semantic target readback was unavailable. Refresh \
+                             page state and verify the expected postcondition",
+                            ext_ref.as_deref().unwrap_or("?")
+                        ),
+                    };
+                    let escalation = (observation.effect != ActionEffect::Confirmed).then(|| {
+                        json!({
+                            "recommended": "page",
+                            "reason": if observation.effect == ActionEffect::SuspectedNoop {
+                                "bounded semantic target state remained unchanged; this is advisory, not proof of failure"
+                            } else {
+                                "semantic target readback was unavailable"
+                            },
+                        })
+                    });
+                    let action_record = dom_click_action_record(&observation);
+                    ToolResult::text(text)
+                        .with_structured(json!({
+                            "status": "ok",
+                            "effect": effect,
+                            "route": "dom_event",
+                            "target_id": target_id,
+                            "tab_id": tab_id,
+                            "ref": ext_ref,
+                            "frame": frame_kind,
+                            "observed": observation.observed,
+                            "observed_after_ms": observation.observed_after_ms,
+                            "readback_available": observation.readback_available,
+                            "escalation": escalation,
+                        }))
+                        .with_action_record(action_record)
+                }
                 Err(e) => ToolResult::error(format!("DOM click failed: {e}")),
             };
         }

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/tools.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/tools.rs
@@ -82,8 +82,6 @@ const DOM_CLICK_READBACK_INTERVAL: Duration = Duration::from_millis(25);
 
 struct DomClickObservation {
     effect: ActionEffect,
-    observed: Option<Value>,
-    observed_after_ms: u64,
     readback_available: bool,
 }
 
@@ -103,22 +101,11 @@ async fn read_dom_click_state(conn: &CdpConnection, cdp: &str, object_id: &str) 
     .filter(Value::is_object)
 }
 
-fn dom_click_delta(before: &Value, after: &Value) -> Option<Value> {
-    let (Some(before), Some(after)) = (before.as_object(), after.as_object()) else {
-        return None;
-    };
-    let mut observed = serde_json::Map::new();
-    for key in before.keys().chain(after.keys()) {
-        if observed.contains_key(key) {
-            continue;
-        }
-        let old = before.get(key).unwrap_or(&Value::Null);
-        let new = after.get(key).unwrap_or(&Value::Null);
-        if old != new {
-            observed.insert(key.clone(), json!([old, new]));
-        }
-    }
-    (!observed.is_empty()).then_some(Value::Object(observed))
+fn dom_click_state_changed(before: &Value, after: &Value) -> bool {
+    before
+        .as_object()
+        .zip(after.as_object())
+        .is_some_and(|(before, after)| before != after)
 }
 
 async fn observe_dom_click(
@@ -130,8 +117,6 @@ async fn observe_dom_click(
     let Some(before) = before else {
         return DomClickObservation {
             effect: effect_from_value_readback(false, false, false),
-            observed: None,
-            observed_after_ms: 0,
             readback_available: false,
         };
     };
@@ -140,11 +125,9 @@ async fn observe_dom_click(
     loop {
         if let Some(after) = read_dom_click_state(conn, cdp, object_id).await {
             readable_after = true;
-            if let Some(observed) = dom_click_delta(&before, &after) {
+            if dom_click_state_changed(&before, &after) {
                 return DomClickObservation {
                     effect: effect_from_value_readback(true, true, true),
-                    observed: Some(observed),
-                    observed_after_ms: started.elapsed().as_millis() as u64,
                     readback_available: true,
                 };
             }
@@ -152,22 +135,10 @@ async fn observe_dom_click(
         if started.elapsed() >= DOM_CLICK_READBACK_DEADLINE {
             return DomClickObservation {
                 effect: effect_from_value_readback(false, false, readable_after),
-                observed: readable_after.then(|| json!({})),
-                observed_after_ms: started.elapsed().as_millis() as u64,
                 readback_available: readable_after,
             };
         }
         tokio::time::sleep(DOM_CLICK_READBACK_INTERVAL).await;
-    }
-}
-
-fn dom_click_effect_name(effect: ActionEffect) -> &'static str {
-    match effect {
-        ActionEffect::Confirmed => "confirmed",
-        ActionEffect::SuspectedNoop => "suspected_noop",
-        ActionEffect::Unverifiable => "unverifiable",
-        ActionEffect::Partial => "partial",
-        ActionEffect::Refused => "refused",
     }
 }
 
@@ -1310,7 +1281,6 @@ impl Tool for BrowserClickTool {
             {
                 Ok(_) => {
                     let observation = observe_dom_click(conn, cdp, &object_id, before).await;
-                    let effect = dom_click_effect_name(observation.effect);
                     let text = match observation.effect {
                         ActionEffect::Confirmed => format!(
                             "dispatched synthetic DOM click on {} in {tab_id}; bounded semantic \
@@ -1331,32 +1301,8 @@ impl Tool for BrowserClickTool {
                             ext_ref.as_deref().unwrap_or("?")
                         ),
                     };
-                    let escalation = (observation.effect != ActionEffect::Confirmed).then(|| {
-                        json!({
-                            "recommended": "page",
-                            "reason": if observation.effect == ActionEffect::SuspectedNoop {
-                                "bounded semantic target state remained unchanged; this is advisory, not proof of failure"
-                            } else {
-                                "semantic target readback was unavailable"
-                            },
-                        })
-                    });
                     let action_record = dom_click_action_record(&observation);
-                    ToolResult::text(text)
-                        .with_structured(json!({
-                            "status": "ok",
-                            "effect": effect,
-                            "route": "dom_event",
-                            "target_id": target_id,
-                            "tab_id": tab_id,
-                            "ref": ext_ref,
-                            "frame": frame_kind,
-                            "observed": observation.observed,
-                            "observed_after_ms": observation.observed_after_ms,
-                            "readback_available": observation.readback_available,
-                            "escalation": escalation,
-                        }))
-                        .with_action_record(action_record)
+                    ToolResult::text(text).with_action_record(action_record)
                 }
                 Err(e) => ToolResult::error(format!("DOM click failed: {e}")),
             };

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/v2_tests.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/v2_tests.rs
@@ -15,7 +15,6 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
 use serde_json::{json, Value};
 
-use crate::action_record::ActionExecutionRecord;
 use crate::protocol::{Content, ToolResult};
 use crate::tool::Tool;
 
@@ -63,6 +62,9 @@ struct FixtureState {
     viewport_css_width: f64,
     viewport_css_height: f64,
     tab_visible: bool,
+    dom_click_changes_readback: bool,
+    dom_click_readback_available: bool,
+    dom_click_generation: u64,
     /// Every incoming CDP call: (sessionId, method, params).
     calls: Vec<(Option<String>, String, Value)>,
 }
@@ -89,6 +91,9 @@ impl Default for FixtureState {
             viewport_css_width: 800.0,
             viewport_css_height: 600.0,
             tab_visible: true,
+            dom_click_changes_readback: true,
+            dom_click_readback_available: true,
+            dom_click_generation: 0,
             calls: Vec::new(),
         }
     }
@@ -651,7 +656,28 @@ fn fixture_handler(state: SharedState) -> MockHandler {
             "DOM.resolveNode" => MockReply::ok(json!({
                 "object": { "objectId": format!("obj-{}", call.params["backendNodeId"]) }
             })),
-            "Runtime.callFunctionOn" => MockReply::ok(json!({ "result": { "value": true } })),
+            "Runtime.callFunctionOn"
+                if call.params["functionDeclaration"]
+                    .as_str()
+                    .is_some_and(|function| function.contains("ariaPressed")) =>
+            {
+                if !st.dom_click_readback_available {
+                    return MockReply::err(-32000, "semantic click readback unavailable");
+                }
+                MockReply::ok(json!({
+                    "result": {
+                        "value": {
+                            "innerText": format!("counter={}", st.dom_click_generation)
+                        }
+                    }
+                }))
+            }
+            "Runtime.callFunctionOn" => {
+                if st.dom_click_changes_readback {
+                    st.dom_click_generation += 1;
+                }
+                MockReply::ok(json!({ "result": { "value": true } }))
+            }
             other => MockReply::method_not_found(other),
         }
     })
@@ -2013,35 +2039,111 @@ async fn trusted_click_refuses_when_standalone_background_posture_is_unavailable
         .invoke(synthetic_args.clone())
         .await;
     assert_eq!(structured(&synthetic)["status"], "ok");
-    assert_eq!(structured(&synthetic)["effect"], "unverifiable");
-    assert_eq!(structured(&synthetic)["escalation"]["recommended"], "page");
+    assert_eq!(structured(&synthetic)["effect"], "confirmed");
+    assert_eq!(
+        structured(&synthetic)["observed"]["innerText"],
+        json!(["counter=0", "counter=1"])
+    );
+    assert!(structured(&synthetic)["escalation"].is_null());
     assert!(synthetic.content.iter().any(|content| matches!(
         content,
         crate::protocol::Content::Text { text, .. }
-            if text.contains("application effect not verified")
-                && text.contains("trust-gated controls")
+            if text.contains("confirmed a target-state change")
     )));
-    let public = ActionExecutionRecord::from_legacy(
-        "browser_click",
-        &synthetic_args,
-        structured(&synthetic),
-    )
-    .expect("browser click action record")
-    .public_result()
-    .expect("public browser click result");
+    let public = synthetic
+        .action_record
+        .as_ref()
+        .expect("typed browser click action record")
+        .public_result()
+        .expect("public browser click result");
     let public = serde_json::to_value(public).expect("serialize public result");
-    assert_eq!(public["effect"], "unverifiable", "{public}");
+    assert_eq!(public["effect"], "confirmed", "{public}");
     assert_eq!(public["route"], "dom", "{public}");
     assert_eq!(public["delivery"]["mode"], "background", "{public}");
-    assert_eq!(public["escalation"]["target"], "page", "{public}");
-    assert_eq!(
-        public["escalation"]["reason"], "effect_unconfirmed",
-        "{public}"
-    );
+    assert_eq!(public["evidence"][0]["kind"], "value_readback", "{public}");
+    assert!(public["escalation"].is_null(), "{public}");
     assert!(public.get("status").is_none(), "{public}");
     assert!(!recorded_calls(&f, "Runtime.callFunctionOn").is_empty());
     assert!(recorded_calls(&f, "Page.bringToFront").is_empty());
     assert!(recorded_calls(&f, "Target.activateTarget").is_empty());
+}
+
+#[tokio::test]
+async fn dom_event_click_reports_suspected_noop_for_readable_unchanged_target_state() {
+    let f = fixture_with(|state| state.dom_click_changes_readback = false).await;
+    let (target, tab) = bind(&f).await;
+    let snap = snapshot(&f, &target, &tab).await;
+    let main_ref = ref_of(&snap, "main", "main-btn");
+
+    let result = BrowserClickTool::new(f.engine.clone())
+        .invoke(json!({
+            "target_id": target,
+            "tab_id": tab,
+            "ref": main_ref,
+            "input_route": "dom_event",
+            "session": SESSION,
+        }))
+        .await;
+
+    assert_eq!(structured(&result)["effect"], "suspected_noop");
+    assert_eq!(structured(&result)["observed"], json!({}));
+    assert_eq!(structured(&result)["readback_available"], true);
+    assert!(result.content.iter().any(|content| matches!(
+        content,
+        Content::Text { text, .. }
+            if text.contains("suspected no-op is advisory, not proof of failure")
+    )));
+    let public = result
+        .action_record
+        .as_ref()
+        .expect("typed browser click action record")
+        .public_result()
+        .expect("public browser click result");
+    let public = serde_json::to_value(public).expect("serialize public result");
+    assert_eq!(public["effect"], "suspected_noop", "{public}");
+    assert_eq!(public["evidence"][0]["kind"], "value_readback", "{public}");
+    assert_eq!(public["escalation"]["target"], "page", "{public}");
+    assert_eq!(public["escalation"]["reason"], "suspected_noop", "{public}");
+}
+
+#[tokio::test]
+async fn dom_event_click_remains_unverifiable_when_semantic_readback_is_unavailable() {
+    let f = fixture_with(|state| state.dom_click_readback_available = false).await;
+    let (target, tab) = bind(&f).await;
+    let snap = snapshot(&f, &target, &tab).await;
+    let main_ref = ref_of(&snap, "main", "main-btn");
+
+    let result = BrowserClickTool::new(f.engine.clone())
+        .invoke(json!({
+            "target_id": target,
+            "tab_id": tab,
+            "ref": main_ref,
+            "input_route": "dom_event",
+            "session": SESSION,
+        }))
+        .await;
+
+    assert_eq!(structured(&result)["effect"], "unverifiable");
+    assert!(structured(&result)["observed"].is_null());
+    assert_eq!(structured(&result)["readback_available"], false);
+    assert!(result.content.iter().any(|content| matches!(
+        content,
+        Content::Text { text, .. }
+            if text.contains("semantic target readback was unavailable")
+    )));
+    let public = result
+        .action_record
+        .as_ref()
+        .expect("typed browser click action record")
+        .public_result()
+        .expect("public browser click result");
+    let public = serde_json::to_value(public).expect("serialize public result");
+    assert_eq!(public["effect"], "unverifiable", "{public}");
+    assert!(public["evidence"].is_null(), "{public}");
+    assert_eq!(
+        public["escalation"]["reason"], "effect_unconfirmed",
+        "{public}"
+    );
 }
 
 #[tokio::test]

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/v2_tests.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/v2_tests.rs
@@ -1685,10 +1685,8 @@ async fn browser_visual_feedback_probes_live_tab_visibility_without_activating_i
         .await;
 
     assert_eq!(
-        structured(&result)["status"],
-        "ok",
-        "{}",
-        structured(&result)
+        result.action_record.as_ref().map(|record| record.effect),
+        Some(crate::action_record::ActionEffect::Confirmed)
     );
     let visibility = recorded_calls(&f, "Runtime.evaluate");
     assert_eq!(visibility.len(), 1, "{visibility:?}");
@@ -2036,15 +2034,8 @@ async fn trusted_click_refuses_when_standalone_background_posture_is_unavailable
         "input_route": "dom_event", "session": SESSION
     });
     let synthetic = BrowserClickTool::new(f.engine.clone())
-        .invoke(synthetic_args.clone())
+        .invoke(synthetic_args)
         .await;
-    assert_eq!(structured(&synthetic)["status"], "ok");
-    assert_eq!(structured(&synthetic)["effect"], "confirmed");
-    assert_eq!(
-        structured(&synthetic)["observed"]["innerText"],
-        json!(["counter=0", "counter=1"])
-    );
-    assert!(structured(&synthetic)["escalation"].is_null());
     assert!(synthetic.content.iter().any(|content| matches!(
         content,
         crate::protocol::Content::Text { text, .. }
@@ -2085,9 +2076,6 @@ async fn dom_event_click_reports_suspected_noop_for_readable_unchanged_target_st
         }))
         .await;
 
-    assert_eq!(structured(&result)["effect"], "suspected_noop");
-    assert_eq!(structured(&result)["observed"], json!({}));
-    assert_eq!(structured(&result)["readback_available"], true);
     assert!(result.content.iter().any(|content| matches!(
         content,
         Content::Text { text, .. }
@@ -2123,9 +2111,6 @@ async fn dom_event_click_remains_unverifiable_when_semantic_readback_is_unavaila
         }))
         .await;
 
-    assert_eq!(structured(&result)["effect"], "unverifiable");
-    assert!(structured(&result)["observed"].is_null());
-    assert_eq!(structured(&result)["readback_available"], false);
     assert!(result.content.iter().any(|content| matches!(
         content,
         Content::Text { text, .. }

--- a/libs/cua-driver/rust/crates/cua-driver/tests/standalone_browser_behavior_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/standalone_browser_behavior_test.rs
@@ -45,6 +45,23 @@ fn standalone_fixture_html() -> String {
     )
 }
 
+fn standalone_observable_click_html() -> String {
+    standalone_fixture_html()
+        .replace(
+            r#"<button id="btn-increment"  data-cua-id="btn-increment">Increment</button>"#,
+            r#"<button id="btn-increment"  data-cua-id="btn-increment">counter=0</button>"#,
+        )
+        .replace(
+            "</body>",
+            r#"<script>
+  document.getElementById('btn-increment').addEventListener('click', event => {
+    event.currentTarget.textContent = document.getElementById('lbl-counter').textContent;
+  });
+</script>
+</body>"#,
+        )
+}
+
 /// Synthetic control that records event delivery but deliberately rejects the
 /// application action unless the browser marks the click as trusted.
 fn standalone_trust_gated_click_html() -> String {
@@ -1558,7 +1575,8 @@ fn run_roundtrip(spec: &BrowserSpec) {
         spec.name
     );
     execute_case(case(&spec.name, "browser_tool_roundtrip"), |evidence| {
-        let mut fixture = launch_browser(spec, &scenario);
+        let mut fixture =
+            launch_browser_with_html(spec, &scenario, standalone_observable_click_html());
         *evidence = recording_evidence(fixture.driver.recording_dir());
         run_with_background_oracles(&mut fixture, |fixture| {
             let session = format!("standalone-roundtrip-{}", fixture.pid);
@@ -1574,7 +1592,13 @@ fn run_roundtrip(spec: &BrowserSpec) {
                     "session": session,
                 }),
             );
-            assert_eq!(click.action_effect(), Some("unverifiable"), "{}", click.raw);
+            assert_eq!(click.action_effect(), Some("confirmed"), "{}", click.raw);
+            assert_eq!(
+                click.structured()["evidence"][0]["kind"],
+                "value_readback",
+                "{}",
+                click.raw
+            );
             wait_for_text(&fixture.server, "lbl-counter", "counter=1");
 
             let snapshot = fixture.driver.call(
@@ -1629,7 +1653,12 @@ fn run_trust_gated_dom_click(spec: &BrowserSpec) {
                 }),
             );
 
-            assert_eq!(click.action_effect(), Some("unverifiable"), "{}", click.raw);
+            assert_eq!(
+                click.action_effect(),
+                Some("suspected_noop"),
+                "{}",
+                click.raw
+            );
             assert_eq!(click.action_route(), Some("dom"), "{}", click.raw);
             assert_eq!(
                 click.action_delivery_mode(),
@@ -1645,16 +1674,18 @@ fn run_trust_gated_dom_click(spec: &BrowserSpec) {
             );
             assert_eq!(
                 click.structured()["escalation"]["reason"],
-                "effect_unconfirmed",
+                "suspected_noop",
                 "{}",
                 click.raw
             );
             assert!(
-                click.text().contains("application effect not verified")
-                    && click.text().contains("trust-gated controls"),
+                click
+                    .text()
+                    .contains("suspected no-op is advisory, not proof of failure"),
                 "{}",
                 click.raw
             );
+            assert_eq!(click.structured()["evidence"][0]["kind"], "value_readback");
             wait_for_text(
                 &fixture.server,
                 "standalone-trust-gated-state",


### PR DESCRIPTION
## Summary

- add a bounded 400 ms semantic readback around ref-targeted `dom_event` browser clicks
- publish `confirmed`, `suspected_noop`, or `unverifiable` through the existing closed action-result contract
- document that `suspected_noop` is advisory and must not trigger a blind retry

## Root cause

The DOM click path hardcoded `effect: unverifiable`, so a state-changing click, a readable no-op, and unavailable verification looked identical.

## Design

The driver samples bounded target semantics, form state, the document URL, and active-element identity before dispatch, then polls for up to 400 ms. A delta confirms an observable effect. Readable unchanged state produces an advisory suspected no-op. Missing readback remains unverifiable.

The observed values stay inside the classifier. The public result remains the existing closed `ActionResult`: effect, route, delivery, evidence kind, and optional escalation. This avoids leaking target or page data and removes a second payload that canonical dispatch would discard.

## Scope

This changes the shared browser DOM-click path. It does not change desktop actions, trusted browser input, or Linux trusted-route refusal behavior.

Addresses the browser portion of #2883.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p cua-driver-core` — 499 unit tests, 2 contract-parity tests, and 3 session-lifecycle tests passed
- `cargo clippy -p cua-driver-core --all-targets` — passed with the existing 29 warnings in untouched code
- controlled-fixture coverage for confirmed, suspected-no-op, and unavailable-readback outcomes
- existing Linux trusted-route refusal coverage remains passing

The standalone browser fixture covers observable and trust-gated clicks. Running that optional target locally still requires browser/display and X11 development dependencies unavailable on this host.

## Attribution

The issue reporter's contribution remains preserved in the commit co-author trailers.