### PR TITLE
fix(cua-driver): fail closed on unproven Wayland window capture

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -594,7 +594,10 @@ impl Tool for GetWindowStateTool {
                 modality at ACTION time: an element ax action \
                 (element_index/element_token → accessibility rung) or an element px \
                 action (x,y → pixel rung off this screenshot). capture_mode is \
-                deprecated and ignored.\n\n\
+                deprecated and ignored. On Wayland, where output capture cannot prove \
+                the requested surface's identity, the truthful tree is returned without \
+                a screenshot and `screenshot_error.code` is \
+                `surface_identity_unproven`.\n\n\
                 Optional `max_elements` / `max_depth` bound the AT-SPI walk to \
                 mitigate context-window blow-up on Electron / large web apps \
                 that produce 10k+ element trees. When applied, BOTH \
@@ -713,6 +716,7 @@ impl Tool for GetWindowStateTool {
             // of embedding base64; otherwise embed base64. Skipped only when
             // include_screenshot:false and no disk path was requested.
             // Tuple: (Option<b64>, Option<file_path>, w, h, Option<original_w>).
+            let mut screenshot_error = None;
             let screenshot = if should_capture {
                 match crate::wayland::screenshot_dispatch(xid) {
                     Ok(raw) => {
@@ -730,6 +734,10 @@ impl Tool for GetWindowStateTool {
                             Some((Some(B64.encode(&png)), None, w, h, original_w))
                         }
                     }
+                    Err(error) if crate::wayland::is_surface_identity_unproven(&error) => {
+                        screenshot_error = Some(error.to_string());
+                        None
+                    }
                     Err(error) => {
                         return Err(anyhow::anyhow!(
                             "window screenshot failed for window {xid}: {error}"
@@ -739,12 +747,12 @@ impl Tool for GetWindowStateTool {
             } else {
                 None
             };
-            Ok((tree_result, screenshot, bounds))
+            Ok((tree_result, screenshot, bounds, screenshot_error))
         })
         .await;
 
         match result {
-            Ok(Ok((tree_opt, shot_opt, bounds))) => {
+            Ok(Ok((tree_opt, shot_opt, bounds, screenshot_error))) => {
                 let mut content = Vec::new();
                 let mut structured = json!({ "window_id": xid, "pid": pid });
 
@@ -927,6 +935,10 @@ impl Tool for GetWindowStateTool {
                         structured["screenshot_file_path"] = json!(fp);
                     }
                 }
+                if let Some(reason) = screenshot_error {
+                    structured["screenshot_frame_valid"] = json!(false);
+                    structured["screenshot_error"] = surface_identity_unproven_error(xid, reason);
+                }
 
                 ToolResult {
                     content,
@@ -941,7 +953,35 @@ impl Tool for GetWindowStateTool {
     }
 }
 
+fn surface_identity_unproven_error(xid: u64, reason: String) -> Value {
+    json!({
+        "code": "surface_identity_unproven",
+        "window_id": xid,
+        "reason": reason,
+        "suggestion": "capture the full output explicitly, or retry on a compositor backend that supports identified per-window capture"
+    })
+}
+
 // ── launch_app ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod get_window_state_capture_tests {
+    use super::*;
+
+    #[test]
+    fn surface_identity_failure_is_a_typed_screenshot_error() {
+        let error = surface_identity_unproven_error(
+            0x2962,
+            "surface_identity_unproven: fixture".to_owned(),
+        );
+
+        assert_eq!(error["code"], "surface_identity_unproven");
+        assert_eq!(error["window_id"], 0x2962);
+        assert!(error["reason"]
+            .as_str()
+            .is_some_and(|reason| reason.contains("surface_identity_unproven")));
+    }
+}
 
 pub struct LaunchAppTool;
 static LAUNCH_DEF: std::sync::OnceLock<ToolDef> = std::sync::OnceLock::new();

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
@@ -7,8 +7,9 @@
 //! fallback), and synthesises pointer / scroll / drag input via
 //! `zwlr_virtual_pointer_v1`. Per-window image capture is deferred until
 //! `ext-foreign-toplevel-image-capture-source-v1` lands in
-//! `wayland-protocols-wlr`; until then `screenshot_window_dispatch` returns a
-//! typed error on pure Wayland.
+//! `wayland-protocols-wlr`; until then window-scoped screenshot dispatch returns
+//! a typed error on Wayland rather than presenting an output crop as that
+//! window's pixels.
 
 pub mod ext_screencopy;
 pub mod ext_toplevel;
@@ -872,56 +873,51 @@ pub(crate) unsafe fn borrowed_fd(fd: i32) -> std::os::fd::OwnedFd {
     std::os::fd::OwnedFd::from_raw_fd(dup)
 }
 
-/// Capture dispatcher: native Wayland (screencopy with grim fallback) when
-/// applicable, else X11. Mirrors `screenshot_window_dispatch` for the
-/// output-level path used by `get_window_state`'s vision payload.
-pub fn screenshot_dispatch(xid: u64) -> anyhow::Result<Vec<u8>> {
-    if is_wayland() {
-        let bytes = screenshot_display_dispatch()?;
-        if let Some((x, y, width, height)) = window_geometry(xid) {
-            crop_png_to_rect(
-                &bytes,
-                x,
-                y,
-                width,
-                height,
-                &format!("Wayland window {xid}"),
-            )
-        } else {
-            Ok(bytes)
-        }
-    } else {
-        crate::capture::screenshot_window_bytes(xid)
+/// A Wayland output crop cannot prove which surface supplied its pixels. This
+/// is especially unsafe for off-workspace XWayland windows: their X11 geometry
+/// can crop the active workspace at the requested coordinates.
+#[derive(Debug)]
+pub struct SurfaceIdentityUnproven {
+    window_id: u64,
+}
+
+impl std::fmt::Display for SurfaceIdentityUnproven {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "surface_identity_unproven: Wayland output capture cannot prove pixels belong to window {}; per-window compositor capture is unavailable",
+            self.window_id
+        )
     }
 }
 
-fn crop_png_to_rect(
-    output_png: &[u8],
-    rect_x: i32,
-    rect_y: i32,
-    rect_width: u32,
-    rect_height: u32,
-    label: &str,
+impl std::error::Error for SurfaceIdentityUnproven {}
+
+pub fn is_surface_identity_unproven(error: &anyhow::Error) -> bool {
+    error.downcast_ref::<SurfaceIdentityUnproven>().is_some()
+}
+
+fn screenshot_window_bytes_with_dispatch(
+    wayland: bool,
+    xid: u64,
+    x11_capture: impl FnOnce(u64) -> anyhow::Result<Vec<u8>>,
 ) -> anyhow::Result<Vec<u8>> {
-    let image = image::load_from_memory(output_png)?;
-    let image_width = image.width();
-    let image_height = image.height();
-    let x = rect_x.max(0) as u32;
-    let y = rect_y.max(0) as u32;
-    if x >= image_width || y >= image_height {
-        anyhow::bail!(
-            "{label} origin ({x},{y}) is outside captured output {image_width}x{image_height}"
-        );
+    if wayland {
+        return Err(SurfaceIdentityUnproven { window_id: xid }.into());
     }
-    let width = rect_width.min(image_width - x);
-    let height = rect_height.min(image_height - y);
-    if width == 0 || height == 0 {
-        anyhow::bail!("{label} has empty capture geometry");
-    }
-    let cropped = image.crop_imm(x, y, width, height);
-    let mut cursor = std::io::Cursor::new(Vec::new());
-    cropped.write_to(&mut cursor, image::ImageFormat::Png)?;
-    Ok(cursor.into_inner())
+    x11_capture(xid)
+}
+
+/// Window capture dispatcher. X11 uses its per-window capture path. Wayland
+/// fails closed until the compositor can return pixels for an identified
+/// surface; output-level capture remains available through
+/// [`screenshot_display_dispatch`].
+pub fn screenshot_dispatch(xid: u64) -> anyhow::Result<Vec<u8>> {
+    screenshot_window_bytes_with_dispatch(
+        is_wayland(),
+        xid,
+        crate::capture::screenshot_window_bytes,
+    )
 }
 
 /// Display-level capture dispatcher. Cascade:
@@ -989,31 +985,15 @@ fn checked_shell_helper_capture(
         .then(|| capture().ok_or_else(|| anyhow::anyhow!("GNOME compositor helper capture failed")))
 }
 
-/// Per-window capture dispatcher. On X11 forwards to the existing window
-/// capture path; on pure Wayland returns a typed error pointing at the
-/// staging `ext-image-copy-capture-v1` protocol — wlr-screencopy is
-/// output-only, and `foreign-toplevel` exposes no per-window geometry to
-/// crop with.
+/// Per-window capture dispatcher. Kept as the explicit window-capture entry
+/// point for callers outside `get_window_state`; it shares the same fail-closed
+/// Wayland contract as [`screenshot_dispatch`].
 pub fn screenshot_window_dispatch(xid: u64) -> anyhow::Result<Vec<u8>> {
-    if is_wayland() {
-        if let Some((x, y, width, height)) = window_geometry(xid) {
-            return crop_png_to_rect(
-                &screenshot_display_dispatch()?,
-                x,
-                y,
-                width,
-                height,
-                &format!("Wayland window {xid}"),
-            );
-        }
-        anyhow::bail!(
-            "per-window screenshot is not yet supported on native Wayland — \
-             zwlr_screencopy_manager_v1 is output-only and ext-image-copy-capture-v1 \
-             is not yet shipped in wayland-protocols-wlr. Run under XWayland to crop \
-             to a single window, or capture the full output instead."
-        );
-    }
-    crate::capture::screenshot_window_bytes(xid)
+    screenshot_window_bytes_with_dispatch(
+        is_wayland(),
+        xid,
+        crate::capture::screenshot_window_bytes,
+    )
 }
 
 // ── Input session helper ─────────────────────────────────────────────────────
@@ -3322,20 +3302,30 @@ mod tests {
     }
 
     #[test]
-    fn sway_window_capture_is_cropped_to_compositor_geometry() {
-        let source = image::DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
-            8,
-            6,
-            image::Rgba([20, 40, 60, 255]),
-        ));
-        let mut encoded = std::io::Cursor::new(Vec::new());
-        source
-            .write_to(&mut encoded, image::ImageFormat::Png)
-            .expect("encode fixture PNG");
-        let cropped =
-            crop_png_to_rect(encoded.get_ref(), 2, 1, 3, 4, "fixture").expect("crop fixture PNG");
-        let decoded = image::load_from_memory(&cropped).expect("decode cropped PNG");
-        assert_eq!((decoded.width(), decoded.height()), (3, 4));
+    fn wayland_window_capture_fails_closed_without_using_x11_pixels() {
+        let x11_called = std::cell::Cell::new(false);
+        let error = screenshot_window_bytes_with_dispatch(true, 0x2962, |_| {
+            x11_called.set(true);
+            Ok(vec![1, 2, 3])
+        })
+        .expect_err("Wayland output pixels cannot prove a window surface");
+
+        assert!(is_surface_identity_unproven(&error));
+        assert!(error.to_string().contains("window 10594"));
+        assert!(!x11_called.get());
+    }
+
+    #[test]
+    fn x11_window_capture_keeps_the_existing_per_window_path() {
+        let captured_xid = std::cell::Cell::new(None);
+        let bytes = screenshot_window_bytes_with_dispatch(false, 42, |xid| {
+            captured_xid.set(Some(xid));
+            Ok(vec![1, 2, 3])
+        })
+        .expect("X11 per-window capture should remain available");
+
+        assert_eq!(captured_xid.get(), Some(42));
+        assert_eq!(bytes, vec![1, 2, 3]);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- stop treating Wayland output crops as identified window screenshots
- return a typed `surface_identity_unproven` screenshot error while preserving the truthful accessibility tree from `get_window_state`
- keep X11 on its existing scoped per-window capture path
- apply the same fail-closed boundary to other Linux window-capture callers

## Why

On opted-in Wayland, `get_window_state` captured the current output and cropped it using the requested window geometry. For an off-workspace XWayland window, those coordinates can select unrelated pixels from the active workspace and present them as the target window.

Output capture and geometry do not prove surface identity. Until a compositor-backed identified per-window capture path is available, omitting the screenshot is safer than returning plausible pixels from another application.

Fixes #2962.

## User impact

Wayland window-scoped capture now omits unprovable pixels and reports:

```json
{
  "screenshot_frame_valid": false,
  "screenshot_error": {
    "code": "surface_identity_unproven"
  }
}
```

The accessibility tree remains available. Explicit full-display screenshots remain available, and X11 per-window capture is unchanged.

## Validation

Candidate: `4bdee4c2119780d43d9e60cf3f44afda9c0c91cb`

- `cargo fmt --check --all`
- `git diff --check`
- focused regression tests:
  - `wayland_window_capture_fails_closed_without_using_x11_pixels`
  - `x11_window_capture_keeps_the_existing_per_window_path`
  - `surface_identity_failure_is_a_typed_screenshot_error`
- `cargo test -p platform-linux --lib`: 264 passed, 0 failed, 4 existing environment-dependent tests ignored

### Runtime limitation

This host has no Hyprland binary/process, `hyprctl`, Wayland/X11 display variables, or desktop session bus. The exact Hyprland + XWayland off-workspace topology from #2962 could not be reproduced here, so this PR claims source-level and unit-level verification only. The regression test proves the unsafe output/X11 fallback is not invoked at the dispatch boundary; compositor runtime certification remains outstanding.