### PR TITLE
feat(cua-driver): add MiniMax Code setup

### DIFF
--- a/docs/content/docs/how-to-guides/driver/connect-your-agent.mdx
+++ b/docs/content/docs/how-to-guides/driver/connect-your-agent.mdx
@@ -134,6 +134,31 @@ Print the same current guidance from the installed binary:
 cua-driver mcp-config --client prime-agent
 ```
 
+## MiniMax Code
+
+Download and launch [MiniMax Code](https://agent.minimax.io/download) once so
+it creates its local `~/.minimax/` directory. Then generate its Cua Driver MCP
+configuration:
+
+```bash
+cua-driver mcp-config --client minimax
+```
+
+Create `~/.minimax/mcp.json` if it does not exist, or merge the generated
+`cua-driver` entry into the existing top-level `mcpServers` object. Install the
+agent skill for the snapshot/action/verify workflow:
+
+```bash
+cua-driver skills install
+cua-driver skills status
+```
+
+The installer links the skill at `~/.minimax/skills/cua-driver` when MiniMax
+Code's skills directory exists. Fully restart MiniMax Code, start a fresh
+conversation, and ask it to use the Cua Driver skill to list the open apps. A
+successful `list_apps` result verifies the MCP connection without changing the
+desktop.
+
 ## Cursor
 
 Generate the Cursor snippet:

--- a/docs/content/docs/how-to-guides/driver/install-agent-skill.mdx
+++ b/docs/content/docs/how-to-guides/driver/install-agent-skill.mdx
@@ -81,6 +81,11 @@ shared `~/.agents/skills/` location used by Codex. Run `/reload` in Prime Agent
 or start a new session after installing or updating the skill so it reloads the
 guidance.
 
+MiniMax Code is also supported directly. Launch it once to create
+`~/.minimax/skills/`, then rerun `cua-driver skills install`. The installer
+links the pack at `~/.minimax/skills/cua-driver`; fully restart MiniMax Code or
+start a fresh conversation after installing or updating it.
+
 ## Next steps
 
 - [Connect your agent to Cua Driver](/how-to-guides/driver/connect-your-agent): register the MCP server when the agent uses MCP.

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -158,7 +158,8 @@ pub enum Command {
     /// `cua-driver skills {install|update|uninstall|status|path}` —
     /// agent skill-pack management. The verb is the ONLY way a user
     /// installs or updates the cua-driver skill pack into their agent
-    /// dirs (Claude Code / Codex / Prime Agent / OpenClaw / OpenCode); the install
+    /// dirs (Claude Code / Codex / Prime Agent / OpenClaw / OpenCode /
+    /// MiniMax Code); the install
     /// scripts never touch ~/.claude/skills/ etc. directly. `install`
     /// fetches the matching versioned release asset
     /// (`cua-driver-rs-v<v>-skills.tar.gz` — the asset filename keeps
@@ -397,6 +398,7 @@ fn finite_client_kind_from_args(args: &[String]) -> &'static str {
         "antigravity" | "gemini" => "antigravity",
         "qwen" | "qwen-code" => "qwen_code",
         "droid" | "factory" => "factory_droid",
+        "minimax" | "minimax-code" => "minimax_code",
         "zcode" => "zcode",
         _ => "other",
     }
@@ -463,7 +465,7 @@ pub fn parse_command() -> Command {
         println!("skills options (agent skill-pack management, opt-in):");
         println!("  cua-driver skills install       Fetch the versioned skill pack from GitHub Releases and symlink it");
         println!("                                  into each detected agent's skills/ dir (Claude Code, Codex, Prime Agent,");
-        println!("                                  OpenClaw, OpenCode). Idempotent. Never overwrites existing user links.");
+        println!("                                  OpenClaw, OpenCode, MiniMax Code). Idempotent. Never overwrites user links.");
         println!("  cua-driver skills update        Re-fetch the skill pack from GitHub, refreshing the local copy + links.");
         println!("  cua-driver skills uninstall     Remove the agent symlinks. Add --all to also delete the local copy.");
         println!("  cua-driver skills status        Report local install state + per-agent link state. Read-only.");
@@ -1512,7 +1514,7 @@ pub fn build_manifest() -> serde_json::Value {
               ] },
             { "name": "mcp-config",
               "description": "Print client-specific connection guidance (MCP config where supported).",
-              "args": [ { "name": "--client", "type": "string", "description": "One of: claude, codex, cursor, hermes, antigravity, openclaw, opencode, pi, prime-agent, qwen, droid, zcode. Omit for the generic snippet." } ] },
+              "args": [ { "name": "--client", "type": "string", "description": "One of: claude, codex, cursor, hermes, antigravity, openclaw, opencode, pi, prime-agent, qwen, droid, zcode, minimax. Omit for the generic snippet." } ] },
             { "name": "manifest",
               "description": "Emit this machine-readable description of the CLI surface.",
               "args": [ { "name": "--pretty", "type": "flag", "description": "Pretty-print the JSON." } ] },
@@ -1580,7 +1582,8 @@ pub fn build_manifest() -> serde_json::Value {
 /// Print client-specific connection guidance (MCP config where supported).
 ///
 /// `--client <name>` selects one of: claude, codex, cursor, hermes,
-/// antigravity, openclaw, opencode, pi, prime-agent, qwen, droid, zcode.
+/// antigravity, openclaw, opencode, pi, prime-agent, qwen, droid, zcode,
+/// minimax.
 /// Omit for the generic JSON snippet.
 pub fn run_mcp_config(client: Option<&str>) {
     let binary = std::env::current_exe()
@@ -1664,6 +1667,28 @@ pub fn run_mcp_config(client: Option<&str>) {
     }}
   }}
 }}"#
+            );
+        }
+        Some("minimax") | Some("minimax-code") => {
+            let normalised = binary.replace('\\', "/");
+            let full = serde_json::json!({
+                "mcpServers": {
+                    "cua-driver": {
+                        "command": normalised,
+                        "args": ["mcp"],
+                        "type": "stdio",
+                    }
+                }
+            });
+            let pretty = serde_json::to_string_pretty(&full).unwrap_or_else(|_| full.to_string());
+            println!(
+                "# MiniMax Code reads local MCP server configuration from:\n\
+                 #   ~/.minimax/mcp.json   (macOS / Linux)\n\
+                 #   %USERPROFILE%\\.minimax\\mcp.json   (Windows)\n\
+                 #\n\
+                 # Create the file if needed, or merge the server below into its existing\n\
+                 # top-level \"mcpServers\" object. Fully restart MiniMax Code afterward.\n\
+                 {pretty}",
             );
         }
         Some("openclaw") => {
@@ -1808,7 +1833,7 @@ pub fn run_mcp_config(client: Option<&str>) {
             );
         }
         Some(other) => {
-            eprintln!("Unknown client '{other}'. Valid: claude, codex, cursor, antigravity, openclaw, opencode, hermes, pi, prime-agent, qwen, droid, zcode.");
+            eprintln!("Unknown client '{other}'. Valid: claude, codex, cursor, antigravity, openclaw, opencode, hermes, pi, prime-agent, qwen, droid, zcode, minimax.");
             process::exit(2);
         }
     }
@@ -3109,7 +3134,7 @@ fn cli_docs_json() -> serde_json::Value {
             {
                 "name": "mcp-config",
                 "abstract": "Print client-specific connection guidance (MCP config where supported).",
-                "discussion": "Supported clients include claude, codex, cursor, antigravity, openclaw, opencode, hermes, pi, prime-agent, qwen, droid, and zcode.",
+                "discussion": "Supported clients include claude, codex, cursor, antigravity, openclaw, opencode, hermes, pi, prime-agent, qwen, droid, zcode, and minimax.",
                 "arguments": no_args,
                 "options": [{"name":"client","short_name":null,"help":"Client name to print configuration for.","type":"String","default_value":null,"is_optional":true}],
                 "flags": no_flags,
@@ -3968,6 +3993,10 @@ mod tests {
         assert_eq!(
             finite_client_kind_from_args(&args(&["mcp-config", "--client", "prime-agent"])),
             "prime_agent"
+        );
+        assert_eq!(
+            finite_client_kind_from_args(&args(&["mcp-config", "--client", "minimax-code"])),
+            "minimax_code"
         );
         assert_eq!(
             finite_client_kind_from_args(&args(&["mcp-config", "--client", "/private/client"])),

--- a/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
@@ -55,6 +55,8 @@
 //!   repo-bundled `hermes-agent/skills/` tree, which is read-only and
 //!   version-controlled). Hermes' own `computer-use` skill teaches its wrapper
 //!   vocabulary; the cua-driver pack provides the platform deep dives.
+//! - MiniMax Code: `~/.minimax/skills/` — the local skill registry used by
+//!   MiniMax Code alongside its `~/.minimax/mcp.json` MCP configuration.
 //!
 //! Only acts on a given agent when its parent skills dir already
 //! exists (i.e. the agent itself is installed). Never clobbers an
@@ -238,6 +240,10 @@ const AGENTS: &[Agent] = &[
         label: "Hermes",
         parent: AgentParent::Home(".hermes/skills"),
     },
+    Agent {
+        label: "MiniMax Code",
+        parent: AgentParent::Home(".minimax/skills"),
+    },
 ];
 
 impl Agent {
@@ -336,7 +342,7 @@ fn install(flags: &[String], force: bool) -> Result<()> {
         }
     }
     if !linked_any {
-        println!("(No agent skills dirs present yet — install Claude Code / Codex / Prime Agent / OpenClaw / OpenCode / Antigravity / Hermes then re-run.)");
+        println!("(No agent skills dirs present yet — install Claude Code / Codex / Prime Agent / OpenClaw / OpenCode / Antigravity / Hermes / MiniMax Code then re-run.)");
     }
     Ok(())
 }
@@ -795,6 +801,19 @@ mod tests {
         assert!(matches!(
             target.parent,
             AgentParent::Home(".prime/agent/skills")
+        ));
+    }
+
+    #[test]
+    fn minimax_code_target_matches_its_local_skill_directory() {
+        let target = AGENTS
+            .iter()
+            .find(|agent| agent.label == "MiniMax Code")
+            .expect("MiniMax Code must remain a supported skill target");
+
+        assert!(matches!(
+            target.parent,
+            AgentParent::Home(".minimax/skills")
         ));
     }
 

--- a/libs/cua-driver/rust/crates/cua-driver/src/telemetry.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/telemetry.rs
@@ -1998,6 +1998,7 @@ fn fixed_cli_client_kind(command: &str, client_kind: &str) -> &'static str {
         "qwen_code" => "qwen_code",
         "factory_droid" => "factory_droid",
         "zcode" => "zcode",
+        "minimax_code" => "minimax_code",
         _ => "other",
     }
 }
@@ -3709,6 +3710,10 @@ mod tests {
         assert_eq!(
             fixed_cli_client_kind("mcp_config", "claude_code"),
             "claude_code"
+        );
+        assert_eq!(
+            fixed_cli_client_kind("mcp_config", "minimax_code"),
+            "minimax_code"
         );
         assert_eq!(
             fixed_cli_client_kind("mcp_config", "/private/client"),

--- a/libs/cua-driver/rust/crates/cua-driver/tests/compatibility_contract_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/compatibility_contract_test.rs
@@ -102,6 +102,29 @@ fn prime_agent_connection_guidance_uses_the_skill_and_cli_path() {
 }
 
 #[test]
+fn minimax_code_connection_guidance_uses_its_native_config_shape() {
+    let output = Command::new(env!("CARGO_BIN_EXE_cua-driver"))
+        .args(["mcp-config", "--client", "minimax"])
+        .output()
+        .expect("run MiniMax Code connection guidance");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("UTF-8 guidance");
+    assert!(stdout.contains("~/.minimax/mcp.json"), "{stdout}");
+    let json_start = stdout.find('{').expect("guidance includes JSON");
+    let config: Value = serde_json::from_str(&stdout[json_start..]).expect("valid config JSON");
+    let server = &config["mcpServers"]["cua-driver"];
+    assert_eq!(server["args"], json!(["mcp"]));
+    assert_eq!(server["type"], "stdio");
+    assert!(
+        server["command"]
+            .as_str()
+            .is_some_and(|command| !command.is_empty()),
+        "command remains a non-empty executable path"
+    );
+}
+
+#[test]
 fn released_mcp_initialize_tools_list_and_error_fields_remain_compatible() {
     let fixture: Value = serde_json::from_str(MCP_FIXTURE).expect("valid MCP fixture");
     let Some(mut driver) = RawDriver::spawn() else {

--- a/libs/cua-driver/scripts/uninstall-local.ps1
+++ b/libs/cua-driver/scripts/uninstall-local.ps1
@@ -97,7 +97,8 @@ $SkillLinks = @(
     (Join-Path $env:USERPROFILE ".openclaw\skills\cua-driver"),
     (Join-Path $env:APPDATA "opencode\skills\cua-driver"),
     (Join-Path $env:USERPROFILE ".gemini\skills\cua-driver"),
-    (Join-Path $env:USERPROFILE ".hermes\skills\cua-driver")
+    (Join-Path $env:USERPROFILE ".hermes\skills\cua-driver"),
+    (Join-Path $env:USERPROFILE ".minimax\skills\cua-driver")
 )
 foreach ($link in $SkillLinks) {
     if (Test-LocalLinkTarget $link) {

--- a/libs/cua-driver/scripts/uninstall-local.sh
+++ b/libs/cua-driver/scripts/uninstall-local.sh
@@ -136,7 +136,8 @@ for skill_link in \
     "$HOME/.openclaw/skills/cua-driver" \
     "$HOME/.config/opencode/skills/cua-driver" \
     "$HOME/.gemini/skills/cua-driver" \
-    "$HOME/.hermes/skills/cua-driver"; do
+    "$HOME/.hermes/skills/cua-driver" \
+    "$HOME/.minimax/skills/cua-driver"; do
     if [[ -L "$skill_link" ]]; then
         target="$(resolve_link "$skill_link")"
         if is_local_target "$target"; then

--- a/libs/cua-driver/scripts/uninstall.ps1
+++ b/libs/cua-driver/scripts/uninstall.ps1
@@ -190,12 +190,14 @@ $SkillJunctions = @(
     (Join-Path $env:APPDATA      "opencode\skills\cua-driver"),
     (Join-Path $env:USERPROFILE ".gemini\skills\cua-driver"),
     (Join-Path $env:USERPROFILE ".hermes\skills\cua-driver"),
+    (Join-Path $env:USERPROFILE ".minimax\skills\cua-driver"),
     (Join-Path $env:USERPROFILE ".claude\skills\cua-driver-rs"),
     (Join-Path $env:USERPROFILE ".agents\skills\cua-driver-rs"),
     (Join-Path $env:USERPROFILE ".openclaw\skills\cua-driver-rs"),
     (Join-Path $env:APPDATA      "opencode\skills\cua-driver-rs"),
     (Join-Path $env:USERPROFILE ".gemini\skills\cua-driver-rs"),
-    (Join-Path $env:USERPROFILE ".hermes\skills\cua-driver-rs")
+    (Join-Path $env:USERPROFILE ".hermes\skills\cua-driver-rs"),
+    (Join-Path $env:USERPROFILE ".minimax\skills\cua-driver-rs")
 )
 
 # ---------- Log helpers ----------------------------------------------------

--- a/libs/cua-driver/scripts/uninstall.sh
+++ b/libs/cua-driver/scripts/uninstall.sh
@@ -431,12 +431,14 @@ if [[ "$USE_RUST_BACKEND" == "1" ]]; then
             "$HOME/.config/opencode/skills/$SKILL_PACK_NAME" \
             "$HOME/.gemini/skills/$SKILL_PACK_NAME" \
             "$HOME/.hermes/skills/$SKILL_PACK_NAME" \
+            "$HOME/.minimax/skills/$SKILL_PACK_NAME" \
             "$HOME/.claude/skills/$LEGACY_SKILL_PACK_NAME" \
             "$HOME/.agents/skills/$LEGACY_SKILL_PACK_NAME" \
             "$HOME/.openclaw/skills/$LEGACY_SKILL_PACK_NAME" \
             "$HOME/.config/opencode/skills/$LEGACY_SKILL_PACK_NAME" \
             "$HOME/.gemini/skills/$LEGACY_SKILL_PACK_NAME" \
-            "$HOME/.hermes/skills/$LEGACY_SKILL_PACK_NAME"; do
+            "$HOME/.hermes/skills/$LEGACY_SKILL_PACK_NAME" \
+            "$HOME/.minimax/skills/$LEGACY_SKILL_PACK_NAME"; do
             if [[ -L "$SKILL_LINK" ]]; then
                 rm -f "$SKILL_LINK"
                 log "removed skill symlink $SKILL_LINK"
@@ -704,7 +706,8 @@ for SKILL_LINK in \
     "$HOME/.openclaw/skills/cua-driver" \
     "$HOME/.config/opencode/skills/cua-driver" \
     "$HOME/.gemini/skills/cua-driver" \
-    "$HOME/.hermes/skills/cua-driver"; do
+    "$HOME/.hermes/skills/cua-driver" \
+    "$HOME/.minimax/skills/cua-driver"; do
     if [[ -L "$SKILL_LINK" ]] && [[ "$(readlink "$SKILL_LINK")" == "$SKILL_TARGET_EXPECTED" ]]; then
         rm -f "$SKILL_LINK"
         log "removed $SKILL_LINK"


### PR DESCRIPTION
## Summary

- add `cua-driver mcp-config --client minimax` for MiniMax Code's native `~/.minimax/mcp.json` format
- install and report the Cua Driver skill at `~/.minimax/skills/cua-driver`
- document the minimal setup and read-only `list_apps` verification flow
- keep release and local uninstallers symmetric with the new managed skill link

## Why

MiniMax Code supports local stdio MCP servers and agent skills, but Cua Driver did not yet generate its config or target its skill directory. Users had to discover both product-specific paths and adapt the generic MCP snippet manually.

## Validation

- `cargo test -p cua-driver --bin cua-driver` (145 passed)
- MiniMax config and skill target focused Rust tests
- generated MiniMax JSON parsed and contract-checked
- `bash -n` on both changed shell uninstallers
- PowerShell collection syntax audited; Windows execution remains covered by CI
- public docs hygiene and internal-link checks
- Next.js production docs build (94 static pages)
- live download page and shipped app bundle inspected to verify the MiniMax config and skill paths
