### PR TITLE
fix(cua-sandbox): provision Fleet sandboxes with SDK builders

### DIFF
--- a/docs/superpowers/plans/2026-08-07-sandbox-fleet-builder-api.md
+++ b/docs/superpowers/plans/2026-08-07-sandbox-fleet-builder-api.md
@@ -1,0 +1,384 @@
+# Sandbox Fleet Builder API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the Python sandbox SDK and its tests from direct construction of builder-enabled Fleet records to the generated Fleet builder API while preserving all existing public sandbox APIs.
+
+**Architecture:** Re-export the generated builder companions from `cua_sandbox`, then construct Fleet template and pool request graphs with immutable fluent builders at their existing boundaries. Fleet records that do not expose generated builders remain constructor-based. A focused AST contract test prevents regressions to direct constructors for builder-enabled records.
+
+**Tech Stack:** Python 3.11-3.13, pytest, Ruff, generated UniFFI `fleet_sdk` Python bindings.
+
+## Global Constraints
+
+- Preserve all existing `cua_sandbox` public names, signatures, and returned Fleet record types.
+- Add builder exports without removing legacy record exports or constructor compatibility.
+- Pin the sandbox SDK to the builder-enabled `cua-fleet==0.1.7` release.
+- Migrate all direct calls to builder-enabled Fleet records under `libs/python/cua-sandbox/cua_sandbox` and `libs/python/cua-sandbox/tests`.
+- Leave `CreateClaimRequest`, `ClaimSpec`, `HttpHeader`, `HttpRequest`, `HttpResponse`, `CyclopsConfiguration`, `CyclopsCredentials`, and Fleet `Sandbox` constructor calls unchanged because the generated SDK does not provide builders for them.
+- Do not edit generated files under `libs/fleet/sdk-bindings`.
+- Do not create commits unless the user explicitly requests them.
+
+---
+
+### Task 1: Lock the Builder Usage Contract
+
+**Files:**
+- Create: `libs/python/cua-sandbox/tests/test_fleet_builder_usage.py`
+
+**Interfaces:**
+- Consumes: Python source trees `libs/python/cua-sandbox/cua_sandbox` and `libs/python/cua-sandbox/tests`.
+- Produces: `test_builder_enabled_fleet_records_use_generated_builders()`, which rejects direct calls to the seven builder-enabled Fleet record classes. The detector must resolve `from ... import ... as ...` aliases and `import fleet_sdk as ...` or `import cua_sandbox as ...` attribute calls, with focused snippet tests for each import style.
+
+- [ ] **Step 1: Write the failing source contract test**
+
+```python
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+PACKAGE_ROOT = Path(__file__).parents[1]
+BUILDER_ENABLED_RECORDS = {
+    "CreatePoolRequest",
+    "CreateTemplateRequest",
+    "OsGymSandboxTemplateSpec",
+    "OsGymSandboxWarmPoolSpec",
+    "SandboxService",
+    "SandboxTemplateRef",
+    "VmTemplate",
+}
+
+
+def test_builder_enabled_fleet_records_use_generated_builders() -> None:
+    violations: list[str] = []
+    source_roots = (PACKAGE_ROOT / "cua_sandbox", PACKAGE_ROOT / "tests")
+
+    for source_root in source_roots:
+        for path in source_root.rglob("*.py"):
+            tree = ast.parse(path.read_text(), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+                    continue
+                if node.func.id in BUILDER_ENABLED_RECORDS:
+                    relative_path = path.relative_to(PACKAGE_ROOT)
+                    violations.append(f"{relative_path}:{node.lineno}: {node.func.id}")
+
+    assert violations == [], "Direct Fleet record constructors remain:\n" + "\n".join(violations)
+```
+
+- [ ] **Step 2: Run the contract test and verify RED**
+
+Run: `uv run --project libs/python/cua-sandbox pytest libs/python/cua-sandbox/tests/test_fleet_builder_usage.py -q`
+
+Expected: FAIL listing direct constructor calls in `cua_sandbox/transport/fleet_cloud.py` and `tests/test_pool.py`.
+
+---
+
+### Task 2: Export Fleet Builders Through Cua Sandbox
+
+**Files:**
+- Modify: `libs/python/cua-sandbox/pyproject.toml`
+- Modify: `libs/python/cua-sandbox/uv.lock`
+- Modify: `libs/python/cua-sandbox/cua_sandbox/__init__.py`
+- Modify: `libs/python/cua-sandbox/tests/test_pool.py`
+- Modify: `libs/python/cua-sandbox/tests/test_fleet_sdk_packaging.py`
+- Modify: `libs/python/cua-sandbox/tests/test_fleet_sdk_distribution.py`
+
+**Interfaces:**
+- Consumes: generated `fleet_sdk` builder classes from `cua-fleet==0.1.7`.
+- Produces: public imports named `CreatePoolRequestBuilder`, `CreateTemplateRequestBuilder`, `OsGymSandboxTemplateSpecBuilder`, `OsGymSandboxWarmPoolSpecBuilder`, `SandboxServiceBuilder`, `SandboxTemplateRefBuilder`, and `VmTemplateBuilder` from `cua_sandbox`.
+
+- [ ] **Step 1: Add a failing public export test**
+
+Extend the `from cua_sandbox import (...)` list in `tests/test_pool.py` with all seven builder names, then add:
+
+```python
+def test_public_pool_schema_exports_generated_builders() -> None:
+    service = SandboxServiceBuilder().name("server").target_port(8000).build()
+    vm_template = (
+        VmTemplateBuilder()
+        .container_disk_image("registry.example/workspace:latest")
+        .services([service])
+        .build()
+    )
+    template_request = (
+        CreateTemplateRequestBuilder()
+        .namespace("default")
+        .name("workspace")
+        .spec(OsGymSandboxTemplateSpecBuilder().vm_template(vm_template).build())
+        .build()
+    )
+    pool_request = (
+        CreatePoolRequestBuilder()
+        .namespace("default")
+        .spec(
+            OsGymSandboxWarmPoolSpecBuilder()
+            .replicas(1)
+            .sandbox_template_ref(SandboxTemplateRefBuilder().name("workspace").build())
+            .build()
+        )
+        .build()
+    )
+
+    assert template_request.spec.vm_template.services == [service]
+    assert pool_request.spec.sandbox_template_ref.name == "workspace"
+```
+
+- [ ] **Step 2: Run the export test and verify RED**
+
+Run: `uv run --project libs/python/cua-sandbox pytest libs/python/cua-sandbox/tests/test_pool.py::test_public_pool_schema_exports_generated_builders -q`
+
+Expected: collection ERROR because the builder names are not exported from `cua_sandbox`.
+
+- [ ] **Step 3: Pin the builder-enabled Fleet wheel**
+
+Change `cua-fleet==0.0.10` to `cua-fleet==0.1.7` in `pyproject.toml`, then run:
+
+Run: `uv lock --project libs/python/cua-sandbox --upgrade-package cua-fleet`
+
+Expected: `libs/python/cua-sandbox/uv.lock` resolves `cua-fleet` 0.1.7. Remove the unrelated hard-coded `cua-sandbox` project-version assertion from the Fleet packaging test so releases do not require incidental edits. Run the packaging test before updating its assertions to observe RED, then update its expected version to `0.1.7` and expected registry to `https://wheels.cua.ai/simple`, and rerun it to GREEN. Run `test_fleet_sdk_distribution.py` before updating its version assertion to observe RED, then change the expected distribution version from `0.0.7` to `0.1.7` and rerun it to GREEN.
+
+- [ ] **Step 4: Re-export all seven builders**
+
+Add these names to the existing `from fleet_sdk import (...)` blocks in `cua_sandbox/__init__.py`, and add the same names as strings adjacent to their record names in `__all__`:
+
+```python
+CreatePoolRequestBuilder
+CreateTemplateRequestBuilder
+OsGymSandboxTemplateSpecBuilder
+OsGymSandboxWarmPoolSpecBuilder
+SandboxServiceBuilder
+SandboxTemplateRefBuilder
+VmTemplateBuilder
+```
+
+- [ ] **Step 5: Run the export test and verify GREEN**
+
+Run: `uv run --project libs/python/cua-sandbox pytest libs/python/cua-sandbox/tests/test_pool.py::test_public_pool_schema_exports_generated_builders -q`
+
+Expected: PASS.
+
+---
+
+### Task 3: Build Fleet Cloud Requests With Builders
+
+**Files:**
+- Modify: `libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py`
+
+**Interfaces:**
+- Consumes: the seven generated builder classes and existing `PreservedJson`/`ServiceProtocol` values.
+- Produces: `_FleetCloudTransport._template_request() -> CreateTemplateRequest` and `_FleetCloudTransport._pool_request() -> CreatePoolRequest` with unchanged record values.
+
+- [ ] **Step 1: Replace builder-enabled imports**
+
+Keep request record types used in annotations and replace the other builder-enabled record imports with:
+
+```python
+CreatePoolRequestBuilder
+CreateTemplateRequestBuilder
+OsGymSandboxTemplateSpecBuilder
+OsGymSandboxWarmPoolSpecBuilder
+SandboxServiceBuilder
+SandboxTemplateRefBuilder
+VmTemplateBuilder
+```
+
+- [ ] **Step 2: Build service records fluently**
+
+```python
+services = [
+    SandboxServiceBuilder()
+    .name(name)
+    .target_port(port)
+    .protocol(ServiceProtocol.TCP)
+    .build()
+    for name, port in service_ports.items()
+]
+```
+
+- [ ] **Step 3: Build the VM, template spec, and template request**
+
+```python
+vm_template_builder = (
+    VmTemplateBuilder()
+    .container_disk_image(self._image._registry)
+    .image_pull_secret("ecr-credentials")
+    .probes(
+        PreservedJson.from_json(
+            json.dumps({"readinessProbe": {"tcpSocket": {"port": 8000}}})
+        )
+    )
+    .services(services)
+)
+if self._cpu is not None:
+    vm_template_builder = vm_template_builder.cpu_cores(self._cpu)
+if self._memory_mb is not None:
+    vm_template_builder = vm_template_builder.memory(f"{self._memory_mb}Mi")
+
+template_spec = OsGymSandboxTemplateSpecBuilder().vm_template(vm_template_builder.build()).build()
+return (
+    CreateTemplateRequestBuilder()
+    .namespace(self._name)
+    .name(self._name)
+    .spec(template_spec)
+    .build()
+)
+```
+
+Omit optional setters when the existing value is `None`; generated records still contain `None` for those fields.
+
+- [ ] **Step 4: Build the warm-pool spec and request**
+
+```python
+def _pool_request(self) -> CreatePoolRequest:
+    template_ref = SandboxTemplateRefBuilder().name(self._name).build()
+    pool_spec = (
+        OsGymSandboxWarmPoolSpecBuilder()
+        .replicas(self._replicas)
+        .sandbox_template_ref(template_ref)
+        .build()
+    )
+    return CreatePoolRequestBuilder().namespace(self._name).spec(pool_spec).build()
+```
+
+- [ ] **Step 5: Run focused Fleet cloud tests**
+
+Run: `uv run --project libs/python/cua-sandbox pytest libs/python/cua-sandbox/tests/test_fleet_cloud_client.py libs/python/cua-sandbox/tests/test_fleet_cloud_transport.py -q`
+
+Expected: PASS with request fields unchanged.
+
+---
+
+### Task 4: Migrate Sandbox Test Fixtures to Builders
+
+**Files:**
+- Modify: `libs/python/cua-sandbox/tests/test_pool.py`
+
+**Interfaces:**
+- Consumes: builder exports added to `cua_sandbox` in Task 2.
+- Produces: `pool_request()` and `template_request()` fixtures plus the custom VM fixture using builders while preserving each assertion's record identity and values.
+
+- [ ] **Step 1: Convert `pool_request()`**
+
+```python
+def pool_request(
+    *,
+    name: str = "foo",
+    template_name: str | None = None,
+    replicas: int = 1,
+) -> CreatePoolRequest:
+    template_ref = SandboxTemplateRefBuilder().name(template_name or name).build()
+    spec = (
+        OsGymSandboxWarmPoolSpecBuilder()
+        .replicas(replicas)
+        .sandbox_template_ref(template_ref)
+        .build()
+    )
+    return CreatePoolRequestBuilder().namespace(name).spec(spec).build()
+```
+
+- [ ] **Step 2: Convert `template_request()`**
+
+```python
+def template_request(
+    *,
+    name: str = "foo",
+    image: str = "example:latest",
+    services: dict[str, int] | None = None,
+    vm_template: VmTemplate | None = None,
+) -> CreateTemplateRequest:
+    if vm_template is None:
+        built_services = [
+            SandboxServiceBuilder()
+            .name(service_name)
+            .target_port(port)
+            .protocol(ServiceProtocol.TCP)
+            .build()
+            for service_name, port in (services or {"server": 8000}).items()
+        ]
+        vm_template = (
+            VmTemplateBuilder()
+            .container_disk_image(image)
+            .image_pull_secret("ecr-credentials")
+            .services(built_services)
+            .build()
+        )
+
+    spec = OsGymSandboxTemplateSpecBuilder().vm_template(vm_template).build()
+    return CreateTemplateRequestBuilder().namespace(name).name(name).spec(spec).build()
+```
+
+- [ ] **Step 3: Convert the custom VM fixture**
+
+```python
+service = (
+    SandboxServiceBuilder()
+    .name("server")
+    .target_port(8000)
+    .protocol(ServiceProtocol.TCP)
+    .build()
+)
+vm_template = (
+    VmTemplateBuilder()
+    .container_disk_image("registry.example/workspace:latest")
+    .runtime(RuntimeKind.KUBEVIRT)
+    .image_pull_secret("workspace-pull")
+    .cpu_cores(10)
+    .memory("20Gi")
+    .firmware(Firmware.EFI)
+    .services([service])
+    .build()
+)
+request = template_request(vm_template=vm_template)
+```
+
+- [ ] **Step 4: Run the builder usage contract and pool tests**
+
+Run: `uv run --project libs/python/cua-sandbox pytest libs/python/cua-sandbox/tests/test_fleet_builder_usage.py libs/python/cua-sandbox/tests/test_pool.py -q`
+
+Expected: PASS with no direct builder-enabled Fleet constructors reported.
+
+---
+
+### Task 5: Verify Packaging and Code Quality
+
+**Files:**
+- Verify: `libs/python/cua-sandbox/cua_sandbox/__init__.py`
+- Verify: `libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py`
+- Verify: `libs/python/cua-sandbox/tests/test_fleet_builder_usage.py`
+- Verify: `libs/python/cua-sandbox/tests/test_pool.py`
+
+**Interfaces:**
+- Consumes: completed builder migration.
+- Produces: evidence that the builder-enabled Fleet distribution is importable, sandbox packaging remains valid, and edited Python passes lint.
+
+- [ ] **Step 1: Run Fleet SDK distribution and packaging tests**
+
+Run: `uv run --project libs/python/cua-sandbox pytest libs/python/cua-sandbox/tests/test_fleet_sdk_distribution.py libs/python/cua-sandbox/tests/test_fleet_sdk_packaging.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the focused sandbox Fleet suite**
+
+Run: `uv run --project libs/python/cua-sandbox pytest libs/python/cua-sandbox/tests/test_fleet_builder_usage.py libs/python/cua-sandbox/tests/test_pool.py libs/python/cua-sandbox/tests/test_fleet_cloud_client.py libs/python/cua-sandbox/tests/test_fleet_cloud_transport.py libs/python/cua-sandbox/tests/test_fleet_transport.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run Ruff on edited files**
+
+Run: `uv run --project libs/python/cua-sandbox --extra dev ruff check libs/python/cua-sandbox/cua_sandbox/__init__.py libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py libs/python/cua-sandbox/tests/test_fleet_builder_usage.py libs/python/cua-sandbox/tests/test_pool.py`
+
+Expected: PASS with no diagnostics.
+
+- [ ] **Step 4: Smoke-test the release build and public dependency resolution**
+
+In a temporary copy of `libs/python/cua-sandbox`, run `uvx --from pdm==2.20.1 pdm lock` and `uvx --from pdm==2.20.1 pdm build`. Create a clean virtual environment, install the built wheel using the default PyPI index, and verify `fleet_sdk.CreatePoolRequestBuilder` imports successfully.
+
+Expected: PDM locks and builds successfully; the clean install resolves `cua-fleet==0.1.7` from PyPI and exposes the builder API.
+
+- [ ] **Step 5: Review the final diff**
+
+Run: `git diff --check && git diff -- libs/python/cua-sandbox/cua_sandbox/__init__.py libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py libs/python/cua-sandbox/tests/test_fleet_builder_usage.py libs/python/cua-sandbox/tests/test_pool.py`
+
+Expected: `git diff --check` exits 0; the diff contains only builder exports, builder construction, the source contract, and fixture migration.

--- a/libs/python/cua-sandbox/cua_sandbox/__init__.py
+++ b/libs/python/cua-sandbox/cua_sandbox/__init__.py
@@ -33,18 +33,25 @@ from cua_sandbox.transport.cloud import CloudTransport
 from fleet_sdk import (
     ClaimSpec,
     CreatePoolRequest,
+    CreatePoolRequestBuilder,
     CreateTemplateRequest,
+    CreateTemplateRequestBuilder,
     Firmware,
     OsGymSandboxTemplateSpec,
+    OsGymSandboxTemplateSpecBuilder,
     OsGymSandboxWarmPoolSpec,
+    OsGymSandboxWarmPoolSpecBuilder,
     RuntimeKind,
     SandboxService,
+    SandboxServiceBuilder,
     SandboxTemplateRef,
+    SandboxTemplateRefBuilder,
     ServiceProtocol,
 )
 from fleet_sdk import Template as TemplateResource
 from fleet_sdk import (
     VmTemplate,
+    VmTemplateBuilder,
 )
 
 __all__ = [
@@ -56,14 +63,21 @@ __all__ = [
     "Template",
     "TemplateResource",
     "CreatePoolRequest",
+    "CreatePoolRequestBuilder",
     "CreateTemplateRequest",
+    "CreateTemplateRequestBuilder",
     "ClaimSpec",
     "SandboxTemplateRef",
+    "SandboxTemplateRefBuilder",
     "OsGymSandboxWarmPoolSpec",
+    "OsGymSandboxWarmPoolSpecBuilder",
     "OsGymSandboxTemplateSpec",
+    "OsGymSandboxTemplateSpecBuilder",
     "RuntimeKind",
     "VmTemplate",
+    "VmTemplateBuilder",
     "SandboxService",
+    "SandboxServiceBuilder",
     "ServiceProtocol",
     "Firmware",
     "Sandbox",

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -20,18 +20,20 @@ from cua_sandbox.transport.fleet import FleetTransport
 from fleet_sdk import (
     CreateClaimRequest,
     CreatePoolRequest,
+    CreatePoolRequestBuilder,
     CreateTemplateRequest,
+    CreateTemplateRequestBuilder,
     CyclopsClient,
     CyclopsConfiguration,
     CyclopsCredentials,
     HttpRequest,
-    OsGymSandboxTemplateSpec,
-    OsGymSandboxWarmPoolSpec,
+    OsGymSandboxTemplateSpecBuilder,
+    OsGymSandboxWarmPoolSpecBuilder,
     PreservedJson,
-    SandboxService,
-    SandboxTemplateRef,
+    SandboxServiceBuilder,
+    SandboxTemplateRefBuilder,
     ServiceProtocol,
-    VmTemplate,
+    VmTemplateBuilder,
 )
 
 if TYPE_CHECKING:
@@ -375,43 +377,49 @@ class FleetCloudTransport(FleetTransport):
             **{f"port-{port}": port for port in self._image._ports if port != 8000},
         }
         services = [
-            SandboxService(name=name, target_port=port, protocol=ServiceProtocol.TCP)
+            SandboxServiceBuilder()
+            .name(name)
+            .target_port(port)
+            .protocol(ServiceProtocol.TCP)
+            .build()
             for name, port in service_ports.items()
         ]
-        return CreateTemplateRequest(
-            namespace=self._name,
-            name=self._name,
-            spec=OsGymSandboxTemplateSpec(
-                vm_template=VmTemplate(
-                    container_disk_image=self._image._registry,
-                    command=None,
-                    runtime=None,
-                    runtime_class_name=None,
-                    node_selector=None,
-                    tolerations=None,
-                    image_pull_policy=None,
-                    image_pull_secret="ecr-credentials",
-                    cpu_cores=self._cpu,
-                    memory=None if self._memory_mb is None else f"{self._memory_mb}Mi",
-                    firmware=None,
-                    probes=PreservedJson.from_json(
-                        json.dumps({"readinessProbe": {"tcpSocket": {"port": 8000}}})
-                    ),
-                    services=services,
-                    oidc=None,
-                ),
-            ),
+        vm_template_builder = (
+            VmTemplateBuilder()
+            .container_disk_image(self._image._registry)
+            .image_pull_secret("ecr-credentials")
+            .probes(
+                PreservedJson.from_json(
+                    json.dumps({"readinessProbe": {"tcpSocket": {"port": 8000}}})
+                )
+            )
+            .services(services)
+        )
+        if self._cpu is not None:
+            vm_template_builder = vm_template_builder.cpu_cores(self._cpu)
+        if self._memory_mb is not None:
+            vm_template_builder = vm_template_builder.memory(f"{self._memory_mb}Mi")
+
+        template_spec = (
+            OsGymSandboxTemplateSpecBuilder().vm_template(vm_template_builder.build()).build()
+        )
+        return (
+            CreateTemplateRequestBuilder()
+            .namespace(self._name)
+            .name(self._name)
+            .spec(template_spec)
+            .build()
         )
 
     def _pool_request(self) -> CreatePoolRequest:
-        return CreatePoolRequest(
-            namespace=self._name,
-            spec=OsGymSandboxWarmPoolSpec(
-                replicas=self._replicas,
-                sandbox_template_ref=SandboxTemplateRef(name=self._name),
-                autoscaling=None,
-            ),
+        template_ref = SandboxTemplateRefBuilder().name(self._name).build()
+        pool_spec = (
+            OsGymSandboxWarmPoolSpecBuilder()
+            .replicas(self._replicas)
+            .sandbox_template_ref(template_ref)
+            .build()
         )
+        return CreatePoolRequestBuilder().namespace(self._name).spec(pool_spec).build()
 
     @staticmethod
     def _service_names(template: Any) -> list[str]:

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -33,6 +33,7 @@ from fleet_sdk import (
     SandboxServiceBuilder,
     SandboxTemplateRefBuilder,
     ServiceProtocol,
+    SdkError,
     VmTemplateBuilder,
 )
 
@@ -86,6 +87,15 @@ class _FleetClient:
 
     async def delete_template(self, template: Any) -> None:
         await self._client.delete_template(template)
+
+    async def get_namespace(self, name: str) -> Any:
+        return await self._client.get_namespace(name)
+
+    async def create_namespace(self, name: str) -> Any:
+        return await self._client.create_namespace(name)
+
+    async def delete_namespace(self, name: str) -> None:
+        await self._client.delete_namespace(name)
 
     async def create_claim(self, request: CreateClaimRequest) -> Any:
         return await self._client.create_claim(request)
@@ -232,6 +242,8 @@ class FleetCloudTransport(FleetTransport):
         self._services = dict(services) if services is not None else None
         self._provisioned = False
         self._owns_resources = image is not None
+        self._namespace: Any = None
+        self._owns_namespace = False
         self._template: Any = None
         self._pool: Any = None
         self._claim: Any = None
@@ -251,6 +263,7 @@ class FleetCloudTransport(FleetTransport):
                         self._pool = await self._sdk.get_pool(self._name)
                     else:
                         self._validate_image(self._image)
+                        await self._ensure_namespace()
                         self._template = await self._sdk.create_template(self._template_request())
                         self._pool = await self._sdk.create_pool(self._pool_request())
                         self._pool = await self._sdk.wait_pool(self._pool)
@@ -316,7 +329,26 @@ class FleetCloudTransport(FleetTransport):
         if self._template is not None:
             await self._sdk.delete_template(self._template)
             self._template = None
+        if self._owns_namespace:
+            await self._sdk.delete_namespace(self._name)
+            self._namespace = None
+            self._owns_namespace = False
         self._provisioned = False
+
+    async def _ensure_namespace(self) -> None:
+        try:
+            self._namespace = await self._sdk.get_namespace(self._name)
+        except SdkError.Status as error:
+            if error.status != 404:
+                raise
+            try:
+                self._namespace = await self._sdk.create_namespace(self._name)
+            except SdkError.Status as create_error:
+                if create_error.status != 409:
+                    raise
+                self._namespace = await self._sdk.get_namespace(self._name)
+            else:
+                self._owns_namespace = True
 
     @classmethod
     async def list_sandboxes(cls) -> list[Any]:

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -32,8 +32,8 @@ from fleet_sdk import (
     PreservedJson,
     SandboxServiceBuilder,
     SandboxTemplateRefBuilder,
-    ServiceProtocol,
     SdkError,
+    ServiceProtocol,
     VmTemplateBuilder,
 )
 

--- a/libs/python/cua-sandbox/pyproject.toml
+++ b/libs/python/cua-sandbox/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = ">=3.11,<3.14"
 dependencies = [
     "cua-core>=0.3.0,<0.4.0",
     "cua-auto>=0.1.2",
-    "cua-fleet==0.0.10",
+    "cua-fleet==0.1.7",
     "websockets>=12.0",
     "httpx>=0.27.0",
     "oras>=0.2.40",

--- a/libs/python/cua-sandbox/pyproject.toml
+++ b/libs/python/cua-sandbox/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = ">=3.11,<3.14"
 dependencies = [
     "cua-core>=0.3.0,<0.4.0",
     "cua-auto>=0.1.2",
-    "cua-fleet==0.1.7",
+    "cua-fleet==0.1.8",
     "websockets>=12.0",
     "httpx>=0.27.0",
     "oras>=0.2.40",

--- a/libs/python/cua-sandbox/tests/test_fleet_builder_usage.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_builder_usage.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+PACKAGE_ROOT = Path(__file__).parents[1]
+FLEET_MODULES = {"cua_sandbox", "fleet_sdk"}
+BUILDER_ENABLED_RECORDS = {
+    "CreatePoolRequest",
+    "CreateTemplateRequest",
+    "OsGymSandboxTemplateSpec",
+    "OsGymSandboxWarmPoolSpec",
+    "SandboxService",
+    "SandboxTemplateRef",
+    "VmTemplate",
+}
+MODULE_ALIAS = object()
+OTHER_BINDING = object()
+
+
+class _BindingScope:
+    def __init__(self, parent: _BindingScope | None, kind: str) -> None:
+        self.parent = parent
+        self.kind = kind
+        self.bindings: dict[str, object] = {}
+
+    def bind(self, name: str, binding: object) -> None:
+        self.bindings[name] = binding
+
+    def resolve(self, name: str) -> object | None:
+        scope: _BindingScope | None = self
+        while scope is not None:
+            if name in scope.bindings:
+                return scope.bindings[name]
+            scope = scope.parent
+        return None
+
+
+class _BuilderRecordCallVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, str]] = []
+        self.scope = _BindingScope(parent=None, kind="module")
+
+    def _bind_other(self, name: str) -> None:
+        self.scope.bind(name, OTHER_BINDING)
+
+    def _bind_target(self, target: ast.expr) -> None:
+        if isinstance(target, ast.Name):
+            self._bind_other(target.id)
+        elif isinstance(target, (ast.List, ast.Tuple)):
+            for element in target.elts:
+                self._bind_target(element)
+        elif isinstance(target, ast.Starred):
+            self._bind_target(target.value)
+
+    def _visit_arguments(self, arguments: ast.arguments) -> None:
+        positional = (*arguments.posonlyargs, *arguments.args)
+        for argument in (*positional, *arguments.kwonlyargs):
+            if argument.annotation is not None:
+                self.visit(argument.annotation)
+        if arguments.vararg is not None and arguments.vararg.annotation is not None:
+            self.visit(arguments.vararg.annotation)
+        if arguments.kwarg is not None and arguments.kwarg.annotation is not None:
+            self.visit(arguments.kwarg.annotation)
+        for default in (*arguments.defaults, *arguments.kw_defaults):
+            if default is not None:
+                self.visit(default)
+
+    def _bind_arguments(self, arguments: ast.arguments) -> None:
+        for argument in (*arguments.posonlyargs, *arguments.args, *arguments.kwonlyargs):
+            self._bind_other(argument.arg)
+        if arguments.vararg is not None:
+            self._bind_other(arguments.vararg.arg)
+        if arguments.kwarg is not None:
+            self._bind_other(arguments.kwarg.arg)
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        self._visit_arguments(node.args)
+        if node.returns is not None:
+            self.visit(node.returns)
+        for type_parameter in getattr(node, "type_params", ()):
+            self.visit(type_parameter)
+
+        outer_scope = self.scope
+        self._bind_other(node.name)
+        parent_scope = outer_scope.parent if outer_scope.kind == "class" else outer_scope
+        self.scope = _BindingScope(parent=parent_scope, kind="function")
+        try:
+            self._bind_arguments(node.args)
+            for statement in node.body:
+                self.visit(statement)
+        finally:
+            self.scope = outer_scope
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        for alias in node.names:
+            if alias.name == "*":
+                continue
+            local_name = alias.asname or alias.name
+            if node.level == 0 and node.module in FLEET_MODULES and alias.name in BUILDER_ENABLED_RECORDS:
+                self.scope.bind(local_name, alias.name)
+            else:
+                self._bind_other(local_name)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            local_name = alias.asname or alias.name.split(".", maxsplit=1)[0]
+            binding = MODULE_ALIAS if alias.name in FLEET_MODULES else OTHER_BINDING
+            self.scope.bind(local_name, binding)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        record_name: str | None = None
+        if isinstance(node.func, ast.Name):
+            binding = self.scope.resolve(node.func.id)
+            if isinstance(binding, str):
+                record_name = binding
+        elif (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and self.scope.resolve(node.func.value.id) is MODULE_ALIAS
+            and node.func.attr in BUILDER_ENABLED_RECORDS
+        ):
+            record_name = node.func.attr
+
+        if record_name is not None:
+            self.calls.append((node.lineno, record_name))
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        self.visit(node.value)
+        for target in node.targets:
+            self._bind_target(target)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        self.visit(node.annotation)
+        if node.value is not None:
+            self.visit(node.value)
+        self._bind_target(node.target)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        self.visit(node.target)
+        self.visit(node.value)
+        self._bind_target(node.target)
+
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        self.visit(node.value)
+        self._bind_target(node.target)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        for keyword in node.keywords:
+            self.visit(keyword)
+        for type_parameter in getattr(node, "type_params", ()):
+            self.visit(type_parameter)
+
+        outer_scope = self.scope
+        self.scope = _BindingScope(parent=outer_scope, kind="class")
+        try:
+            for statement in node.body:
+                self.visit(statement)
+        finally:
+            self.scope = outer_scope
+        self._bind_other(node.name)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        self._visit_arguments(node.args)
+        outer_scope = self.scope
+        parent_scope = outer_scope.parent if outer_scope.kind == "class" else outer_scope
+        self.scope = _BindingScope(parent=parent_scope, kind="function")
+        try:
+            self._bind_arguments(node.args)
+            self.visit(node.body)
+        finally:
+            self.scope = outer_scope
+
+
+def _find_builder_record_calls(source: str, *, filename: str = "<unknown>") -> list[tuple[int, str]]:
+    visitor = _BuilderRecordCallVisitor()
+    visitor.visit(ast.parse(source, filename=filename))
+    return visitor.calls
+
+
+def test_finds_direct_builder_record_imports() -> None:
+    source = (
+        "from fleet_sdk import VmTemplate\n"
+        "from cua_sandbox import SandboxService\n"
+        "VmTemplate()\n"
+        "SandboxService()\n"
+    )
+
+    assert _find_builder_record_calls(source) == [(3, "VmTemplate"), (4, "SandboxService")]
+
+
+def test_finds_aliased_builder_record_imports() -> None:
+    source = (
+        "from fleet_sdk import VmTemplate as FleetVm\n"
+        "from cua_sandbox import SandboxService as FleetService\n"
+        "FleetVm()\n"
+        "FleetService()\n"
+    )
+
+    assert _find_builder_record_calls(source) == [(3, "VmTemplate"), (4, "SandboxService")]
+
+
+def test_finds_builder_record_module_attributes() -> None:
+    source = (
+        "import fleet_sdk as fleet\n"
+        "import cua_sandbox as cua\n"
+        "fleet.VmTemplate()\n"
+        "cua.SandboxService()\n"
+    )
+
+    assert _find_builder_record_calls(source) == [(3, "VmTemplate"), (4, "SandboxService")]
+
+
+def test_ignores_unrelated_local_builder_record_name() -> None:
+    source = "class VmTemplate:\n    pass\n\nVmTemplate()\n"
+
+    assert _find_builder_record_calls(source) == []
+
+
+def test_ignores_direct_import_after_local_shadowing() -> None:
+    sources = (
+        "from fleet_sdk import VmTemplate\nclass VmTemplate:\n    pass\nVmTemplate()\n",
+        "from fleet_sdk import VmTemplate\ndef VmTemplate():\n    pass\nVmTemplate()\n",
+        "from fleet_sdk import VmTemplate\nVmTemplate = object()\nVmTemplate()\n",
+    )
+
+    for source in sources:
+        assert _find_builder_record_calls(source) == []
+
+
+def test_function_imports_do_not_leak_to_sibling_or_outer_scopes() -> None:
+    source = (
+        "def fleet_user():\n"
+        "    from fleet_sdk import VmTemplate\n"
+        "    VmTemplate()\n"
+        "\n"
+        "def sibling():\n"
+        "    class VmTemplate:\n"
+        "        pass\n"
+        "    VmTemplate()\n"
+        "\n"
+        "def VmTemplate():\n"
+        "    pass\n"
+        "\n"
+        "VmTemplate()\n"
+    )
+
+    assert _find_builder_record_calls(source) == [(3, "VmTemplate")]
+
+
+def test_ignores_module_attribute_after_alias_rebinding() -> None:
+    source = "import fleet_sdk as fleet\nfleet = object()\nfleet.VmTemplate()\n"
+
+    assert _find_builder_record_calls(source) == []
+
+
+def test_nested_scope_resolves_unshadowed_outer_fleet_binding() -> None:
+    source = "from fleet_sdk import VmTemplate\ndef build():\n    VmTemplate()\n"
+
+    assert _find_builder_record_calls(source) == [(3, "VmTemplate")]
+
+
+def test_builder_enabled_fleet_records_use_generated_builders() -> None:
+    violations: list[str] = []
+    source_roots = (PACKAGE_ROOT / "cua_sandbox", PACKAGE_ROOT / "tests")
+
+    for source_root in source_roots:
+        for path in source_root.rglob("*.py"):
+            calls = _find_builder_record_calls(path.read_text(), filename=str(path))
+            relative_path = path.relative_to(PACKAGE_ROOT)
+            violations.extend(f"{relative_path}:{line}: {name}" for line, name in calls)
+
+    assert violations == [], "Direct Fleet record constructors remain:\n" + "\n".join(violations)

--- a/libs/python/cua-sandbox/tests/test_fleet_builder_usage.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_builder_usage.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-
 PACKAGE_ROOT = Path(__file__).parents[1]
 FLEET_MODULES = {"cua_sandbox", "fleet_sdk"}
 BUILDER_ENABLED_RECORDS = {
@@ -100,7 +99,11 @@ class _BuilderRecordCallVisitor(ast.NodeVisitor):
             if alias.name == "*":
                 continue
             local_name = alias.asname or alias.name
-            if node.level == 0 and node.module in FLEET_MODULES and alias.name in BUILDER_ENABLED_RECORDS:
+            if (
+                node.level == 0
+                and node.module in FLEET_MODULES
+                and alias.name in BUILDER_ENABLED_RECORDS
+            ):
                 self.scope.bind(local_name, alias.name)
             else:
                 self._bind_other(local_name)
@@ -186,7 +189,9 @@ class _BuilderRecordCallVisitor(ast.NodeVisitor):
             self.scope = outer_scope
 
 
-def _find_builder_record_calls(source: str, *, filename: str = "<unknown>") -> list[tuple[int, str]]:
+def _find_builder_record_calls(
+    source: str, *, filename: str = "<unknown>"
+) -> list[tuple[int, str]]:
     visitor = _BuilderRecordCallVisitor()
     visitor.visit(ast.parse(source, filename=filename))
     return visitor.calls

--- a/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
@@ -61,6 +61,30 @@ async def test_template_calls_delegate_to_generated_client():
 
 
 @pytest.mark.asyncio
+async def test_namespace_calls_delegate_to_generated_client():
+    client = _FleetClient.__new__(_FleetClient)
+    calls = []
+
+    class SDK:
+        async def get_namespace(self, name):
+            calls.append(("get", name))
+            return "namespace"
+
+        async def create_namespace(self, name):
+            calls.append(("create", name))
+            return "namespace"
+
+        async def delete_namespace(self, name):
+            calls.append(("delete", name))
+
+    client._client = SDK()
+    assert await client.get_namespace("demo") == "namespace"
+    assert await client.create_namespace("demo") == "namespace"
+    assert await client.delete_namespace("demo") is None
+    assert calls == [("get", "demo"), ("create", "demo"), ("delete", "demo")]
+
+
+@pytest.mark.asyncio
 async def test_list_pools_enumerates_namespaces(monkeypatch):
     client = _FleetClient.__new__(_FleetClient)
 

--- a/libs/python/cua-sandbox/tests/test_fleet_cloud_transport.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_cloud_transport.py
@@ -2,7 +2,7 @@ import pytest
 from cua_sandbox import Image
 from cua_sandbox.transport import fleet_cloud
 from cua_sandbox.transport.fleet_cloud import FleetCloudTransport
-from fleet_sdk import Sandbox
+from fleet_sdk import Sandbox, SdkError
 
 
 def test_registry_image_becomes_typed_template_request():
@@ -50,6 +50,14 @@ async def test_connect_creates_template_before_pool_and_defaults_the_claim(monke
     order = []
 
     class Client:
+        async def get_namespace(self, name):
+            order.append("get-namespace")
+            raise SdkError.Status("get namespace", 404, "missing")
+
+        async def create_namespace(self, name):
+            order.append("create-namespace")
+            return "namespace"
+
         async def create_template(self, request):
             order.append("template")
             assert request.spec.vm_template.container_disk_image == "example:latest"
@@ -78,9 +86,326 @@ async def test_connect_creates_template_before_pool_and_defaults_the_claim(monke
 
     await FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo").connect()
 
-    assert order == ["template", "pool"]
+    assert order == ["get-namespace", "create-namespace", "template", "pool"]
     assert len(requests) == 1
     assert requests[0].spec is None
+
+
+@pytest.mark.asyncio
+async def test_connect_creates_missing_namespace_before_template(monkeypatch):
+    order = []
+
+    class Client:
+        async def get_namespace(self, name):
+            order.append(("get-namespace", name))
+            raise SdkError.Status("get namespace", 404, "missing")
+
+        async def create_namespace(self, name):
+            order.append(("create-namespace", name))
+            return object()
+
+        async def create_template(self, request):
+            order.append(("template", request.name))
+            raise RuntimeError("template failed")
+
+        async def delete_namespace(self, namespace):
+            order.append(("delete-namespace", namespace))
+
+    client = Client()
+    monkeypatch.setattr(fleet_cloud, "_FleetClient", lambda: client)
+
+    with pytest.raises(RuntimeError, match="template failed"):
+        await FleetCloudTransport(
+            image=Image.from_registry("example:latest"), name="demo"
+        ).connect()
+
+    assert order == [
+        ("get-namespace", "demo"),
+        ("create-namespace", "demo"),
+        ("template", "demo"),
+        ("delete-namespace", "demo"),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [403, 500])
+async def test_connect_propagates_unexpected_namespace_lookup_errors_without_create(
+    monkeypatch, status
+):
+    calls = []
+
+    class Client:
+        async def get_namespace(self, name):
+            calls.append(("get-namespace", name))
+            raise SdkError.Status("get namespace", status, "unexpected")
+
+        async def create_namespace(self, name):
+            calls.append(("create-namespace", name))
+            raise AssertionError("unexpected namespace lookup errors must not create namespaces")
+
+    monkeypatch.setattr(fleet_cloud, "_FleetClient", Client)
+
+    with pytest.raises(SdkError.Status) as error:
+        await FleetCloudTransport(
+            image=Image.from_registry("example:latest"), name="demo"
+        ).connect()
+
+    assert error.value.status == status
+    assert calls == [("get-namespace", "demo")]
+
+
+@pytest.mark.asyncio
+async def test_connect_propagates_non_conflict_namespace_create_error(monkeypatch):
+    calls = []
+
+    class Client:
+        async def get_namespace(self, name):
+            calls.append(("get-namespace", name))
+            raise SdkError.Status("get namespace", 404, "missing")
+
+        async def create_namespace(self, name):
+            calls.append(("create-namespace", name))
+            raise SdkError.Status("create namespace", 500, "failed")
+
+        async def create_template(self, request):
+            calls.append(("create-template", request.name))
+            raise AssertionError("failed namespace creation must not provision a template")
+
+    monkeypatch.setattr(fleet_cloud, "_FleetClient", Client)
+
+    with pytest.raises(SdkError.Status) as error:
+        await FleetCloudTransport(
+            image=Image.from_registry("example:latest"), name="demo"
+        ).connect()
+
+    assert error.value.status == 500
+    assert calls == [("get-namespace", "demo"), ("create-namespace", "demo")]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_stage", ["template", "pool"])
+async def test_connect_preserves_existing_namespace_after_provisioning_failure(
+    monkeypatch, failure_stage
+):
+    calls = []
+
+    class Client:
+        async def get_namespace(self, name):
+            calls.append(("get-namespace", name))
+            return object()
+
+        async def create_namespace(self, name):
+            raise AssertionError("existing namespaces must not be created")
+
+        async def create_template(self, request):
+            calls.append(("create-template", request.name))
+            if failure_stage == "template":
+                raise RuntimeError("template failed")
+            return "template"
+
+        async def create_pool(self, request):
+            calls.append(("create-pool", request.namespace))
+            raise RuntimeError("pool failed")
+
+        async def delete_template(self, template):
+            calls.append(("delete-template", template))
+
+        async def delete_namespace(self, name):
+            raise AssertionError("existing namespaces must not be deleted")
+
+    monkeypatch.setattr(fleet_cloud, "_FleetClient", Client)
+
+    with pytest.raises(RuntimeError, match=f"{failure_stage} failed"):
+        await FleetCloudTransport(
+            image=Image.from_registry("example:latest"), name="demo"
+        ).connect()
+
+    expected_calls = [("get-namespace", "demo"), ("create-template", "demo")]
+    if failure_stage == "pool":
+        expected_calls.extend([("create-pool", "demo"), ("delete-template", "template")])
+    assert calls == expected_calls
+
+
+@pytest.mark.asyncio
+async def test_connect_refetches_namespace_after_create_race(monkeypatch):
+    namespace = "existing-namespace"
+    order = []
+    pool = type("Pool", (), {"metadata": type("Metadata", (), {"name": "demo"})()})()
+
+    class Client:
+        def __init__(self):
+            self.get_calls = 0
+
+        async def get_namespace(self, name):
+            self.get_calls += 1
+            order.append(("get-namespace", name))
+            if self.get_calls == 1:
+                raise SdkError.Status("get namespace", 404, "missing")
+            return namespace
+
+        async def create_namespace(self, name):
+            order.append(("create-namespace", name))
+            raise SdkError.Status("create namespace", 409, "exists")
+
+        async def create_template(self, request):
+            order.append(("template", request.name))
+            return "template"
+
+        async def create_pool(self, request):
+            order.append(("pool", request.namespace))
+            return pool
+
+        async def wait_pool(self, created_pool):
+            return created_pool
+
+        async def create_claim(self, request):
+            return "claim"
+
+        async def wait_claim(self, claim):
+            return Sandbox(namespace="demo", claim=claim, name="sandbox", services=["server"])
+
+        async def wait_service_ready(self, sandbox, service, time_to_start):
+            return None
+
+        async def delete_claim(self, claim):
+            order.append(("delete-claim", claim))
+
+        async def delete_pool(self, created_pool):
+            order.append(("delete-pool", created_pool))
+
+        async def delete_template(self, template):
+            order.append(("delete-template", template))
+
+        async def delete_namespace(self, created_namespace):
+            order.append(("delete-namespace", created_namespace))
+
+    client = Client()
+    monkeypatch.setattr(fleet_cloud, "_FleetClient", lambda: client)
+    transport = FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo")
+
+    await transport.connect()
+    await transport.delete_vm()
+
+    assert order == [
+        ("get-namespace", "demo"),
+        ("create-namespace", "demo"),
+        ("get-namespace", "demo"),
+        ("template", "demo"),
+        ("pool", "demo"),
+        ("delete-claim", "claim"),
+        ("delete-pool", pool),
+        ("delete-template", "template"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_connect_rolls_back_template_then_owned_namespace_after_pool_failure(monkeypatch):
+    order = []
+
+    class Client:
+        async def get_namespace(self, name):
+            raise SdkError.Status("get namespace", 404, "missing")
+
+        async def create_namespace(self, name):
+            order.append(("create-namespace", name))
+            return object()
+
+        async def create_template(self, request):
+            order.append(("create-template", request.name))
+            return "template"
+
+        async def create_pool(self, request):
+            order.append(("create-pool", request.namespace))
+            raise RuntimeError("pool failed")
+
+        async def delete_template(self, template):
+            order.append(("delete-template", template))
+
+        async def delete_namespace(self, namespace):
+            order.append(("delete-namespace", namespace))
+
+    client = Client()
+    monkeypatch.setattr(fleet_cloud, "_FleetClient", lambda: client)
+
+    with pytest.raises(RuntimeError, match="pool failed"):
+        await FleetCloudTransport(
+            image=Image.from_registry("example:latest"), name="demo"
+        ).connect()
+
+    assert order == [
+        ("create-namespace", "demo"),
+        ("create-template", "demo"),
+        ("create-pool", "demo"),
+        ("delete-template", "template"),
+        ("delete-namespace", "demo"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_preserves_existing_namespace():
+    transport = FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo")
+    calls = []
+
+    class Client:
+        async def delete_template(self, template):
+            calls.append(("template", template))
+
+        async def delete_namespace(self, namespace):
+            calls.append(("namespace", namespace))
+
+    transport._sdk = Client()
+    transport._template = "template"
+    transport._owns_namespace = False
+
+    await transport._cleanup_resources()
+
+    assert calls == [("template", "template")]
+
+
+@pytest.mark.asyncio
+async def test_connect_with_existing_pool_skips_namespace_crud(monkeypatch):
+    calls = []
+    pool = type("Pool", (), {"metadata": type("Metadata", (), {"name": "demo"})()})()
+
+    class Client:
+        async def get_namespace(self, name):
+            calls.append(("get-namespace", name))
+            raise AssertionError("existing pools must not manage namespaces")
+
+        async def create_namespace(self, name):
+            calls.append(("create-namespace", name))
+            raise AssertionError("existing pools must not manage namespaces")
+
+        async def delete_namespace(self, namespace):
+            calls.append(("delete-namespace", namespace))
+            raise AssertionError("existing pools must not manage namespaces")
+
+        async def get_pool(self, name):
+            calls.append(("get-pool", name))
+            return pool
+
+        async def get_claim(self, existing_pool):
+            calls.append(("get-claim", existing_pool))
+            return "claim"
+
+        async def wait_claim(self, claim):
+            calls.append(("wait-claim", claim))
+            return Sandbox(namespace="demo", claim=claim, name="sandbox", services=["server"])
+
+        async def wait_service_ready(self, sandbox, service, time_to_start):
+            calls.append(("wait-service-ready", service))
+
+    client = Client()
+    monkeypatch.setattr(fleet_cloud, "_FleetClient", lambda: client)
+
+    await FleetCloudTransport(image=None, name="demo").connect()
+
+    assert calls == [
+        ("get-pool", "demo"),
+        ("get-claim", pool),
+        ("wait-claim", "claim"),
+        ("wait-service-ready", "server"),
+    ]
 
 
 @pytest.mark.asyncio
@@ -105,7 +430,7 @@ async def test_cleanup_stops_after_claim_failure():
 
 
 @pytest.mark.asyncio
-async def test_cleanup_releases_claim_pool_then_template():
+async def test_cleanup_releases_claim_pool_template_then_owned_namespace():
     transport = FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo")
     calls = []
 
@@ -119,12 +444,21 @@ async def test_cleanup_releases_claim_pool_then_template():
         async def delete_template(self, template):
             calls.append(("template", template))
 
+        async def delete_namespace(self, name):
+            calls.append(("namespace", name))
+
     transport._sdk = Client()
     transport._claim = "claim"
     transport._pool = "pool"
     transport._template = "template"
+    transport._owns_namespace = True
     await transport._cleanup_resources()
-    assert calls == [("claim", "claim"), ("pool", "pool"), ("template", "template")]
+    assert calls == [
+        ("claim", "claim"),
+        ("pool", "pool"),
+        ("template", "template"),
+        ("namespace", "demo"),
+    ]
     assert transport._template is None
 
 

--- a/libs/python/cua-sandbox/tests/test_fleet_sdk_distribution.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_sdk_distribution.py
@@ -10,6 +10,6 @@ def test_fleet_sdk_is_provided_by_published_fleet_distribution():
     distribution_root = Path(cua_fleet_distribution.locate_file(".")).resolve()
     binding_path = Path(fleet_sdk.__file__).resolve()
 
-    assert cua_fleet_distribution.version == "0.0.7"
+    assert cua_fleet_distribution.version == "0.1.7"
     assert "fleet_sdk/__init__.py" in installed_files
     assert binding_path.is_relative_to(distribution_root)

--- a/libs/python/cua-sandbox/tests/test_fleet_sdk_distribution.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_sdk_distribution.py
@@ -10,6 +10,6 @@ def test_fleet_sdk_is_provided_by_published_fleet_distribution():
     distribution_root = Path(cua_fleet_distribution.locate_file(".")).resolve()
     binding_path = Path(fleet_sdk.__file__).resolve()
 
-    assert cua_fleet_distribution.version == "0.1.7"
+    assert cua_fleet_distribution.version == "0.1.8"
     assert "fleet_sdk/__init__.py" in installed_files
     assert binding_path.is_relative_to(distribution_root)

--- a/libs/python/cua-sandbox/tests/test_fleet_sdk_packaging.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_sdk_packaging.py
@@ -17,9 +17,8 @@ class FleetSdkPackagingTests(unittest.TestCase):
         with PYPROJECT_PATH.open("rb") as pyproject_file:
             project = tomllib.load(pyproject_file)
 
-        self.assertEqual(project["project"]["version"], "0.1.25")
         dependencies = project["project"]["dependencies"]
-        self.assertIn("cua-fleet==0.0.10", dependencies)
+        self.assertIn("cua-fleet==0.1.7", dependencies)
         self.assertFalse(any(dependency.startswith("cua-train") for dependency in dependencies))
         self.assertNotIn("cua-fleet", project["tool"]["uv"]["sources"])
         self.assertNotIn("cua-train", project["tool"]["uv"]["sources"])
@@ -44,14 +43,14 @@ class FleetSdkPackagingTests(unittest.TestCase):
             for requirement in packages["cua-sandbox"]["metadata"]["requires-dist"]
         }
         fleet_dependencies = {
-            dependency["name"] for dependency in packages["cua-fleet"]["dependencies"]
+            dependency["name"] for dependency in packages["cua-fleet"].get("dependencies", [])
         }
         self.assertIn("cua-fleet", sandbox_dependencies)
         self.assertNotIn("cua-train", sandbox_dependencies)
         self.assertIn("cua-fleet", sandbox_requires_dist)
         self.assertNotIn("cua-train", sandbox_requires_dist)
-        self.assertEqual(packages["cua-fleet"]["version"], "0.0.10")
-        self.assertEqual(packages["cua-fleet"]["source"], {"registry": "https://pypi.org/simple"})
+        self.assertEqual(packages["cua-fleet"]["version"], "0.1.7")
+        self.assertEqual(packages["cua-fleet"]["source"], {"registry": "https://wheels.cua.ai/simple"})
         self.assertNotIn("cua-train", fleet_dependencies)
         self.assertNotIn("cua-train", packages)
 

--- a/libs/python/cua-sandbox/tests/test_fleet_sdk_packaging.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_sdk_packaging.py
@@ -18,7 +18,7 @@ class FleetSdkPackagingTests(unittest.TestCase):
             project = tomllib.load(pyproject_file)
 
         dependencies = project["project"]["dependencies"]
-        self.assertIn("cua-fleet==0.1.7", dependencies)
+        self.assertIn("cua-fleet==0.1.8", dependencies)
         self.assertFalse(any(dependency.startswith("cua-train") for dependency in dependencies))
         self.assertNotIn("cua-fleet", project["tool"]["uv"]["sources"])
         self.assertNotIn("cua-train", project["tool"]["uv"]["sources"])
@@ -49,7 +49,7 @@ class FleetSdkPackagingTests(unittest.TestCase):
         self.assertNotIn("cua-train", sandbox_dependencies)
         self.assertIn("cua-fleet", sandbox_requires_dist)
         self.assertNotIn("cua-train", sandbox_requires_dist)
-        self.assertEqual(packages["cua-fleet"]["version"], "0.1.7")
+        self.assertEqual(packages["cua-fleet"]["version"], "0.1.8")
         self.assertEqual(packages["cua-fleet"]["source"], {"registry": "https://wheels.cua.ai/simple"})
         self.assertNotIn("cua-train", fleet_dependencies)
         self.assertNotIn("cua-train", packages)

--- a/libs/python/cua-sandbox/tests/test_fleet_sdk_packaging.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_sdk_packaging.py
@@ -50,7 +50,9 @@ class FleetSdkPackagingTests(unittest.TestCase):
         self.assertIn("cua-fleet", sandbox_requires_dist)
         self.assertNotIn("cua-train", sandbox_requires_dist)
         self.assertEqual(packages["cua-fleet"]["version"], "0.1.8")
-        self.assertEqual(packages["cua-fleet"]["source"], {"registry": "https://wheels.cua.ai/simple"})
+        self.assertEqual(
+            packages["cua-fleet"]["source"], {"registry": "https://wheels.cua.ai/simple"}
+        )
         self.assertNotIn("cua-train", fleet_dependencies)
         self.assertNotIn("cua-train", packages)
 

--- a/libs/python/cua-sandbox/tests/test_pool.py
+++ b/libs/python/cua-sandbox/tests/test_pool.py
@@ -6,17 +6,20 @@ import pytest
 from cua_sandbox import (
     ClaimSpec,
     CreatePoolRequest,
+    CreatePoolRequestBuilder,
     CreateTemplateRequest,
+    CreateTemplateRequestBuilder,
     Firmware,
-    OsGymSandboxTemplateSpec,
-    OsGymSandboxWarmPoolSpec,
+    OsGymSandboxTemplateSpecBuilder,
+    OsGymSandboxWarmPoolSpecBuilder,
     Pool,
     RuntimeKind,
-    SandboxService,
-    SandboxTemplateRef,
+    SandboxServiceBuilder,
+    SandboxTemplateRefBuilder,
     ServiceProtocol,
     Template,
     VmTemplate,
+    VmTemplateBuilder,
 )
 from cua_sandbox.sync import Pool as SyncPool
 from cua_sandbox.sync import Template as SyncTemplate
@@ -28,20 +31,51 @@ def test_public_pool_schema_exports_runtime_kind() -> None:
     assert RuntimeKind.KUBEVIRT.value == 0
 
 
+def test_public_pool_schema_exports_generated_builders() -> None:
+    service = SandboxServiceBuilder().name("server").target_port(8000).build()
+    vm_template = (
+        VmTemplateBuilder()
+        .container_disk_image("registry.example/workspace:latest")
+        .services([service])
+        .build()
+    )
+    template_request = (
+        CreateTemplateRequestBuilder()
+        .namespace("default")
+        .name("workspace")
+        .spec(OsGymSandboxTemplateSpecBuilder().vm_template(vm_template).build())
+        .build()
+    )
+    pool_request = (
+        CreatePoolRequestBuilder()
+        .namespace("default")
+        .spec(
+            OsGymSandboxWarmPoolSpecBuilder()
+            .replicas(1)
+            .sandbox_template_ref(SandboxTemplateRefBuilder().name("workspace").build())
+            .build()
+        )
+        .build()
+    )
+
+    assert template_request.spec.vm_template.services == [service]
+    assert pool_request.spec.sandbox_template_ref.name == "workspace"
+
+
 def pool_request(
     *,
     name: str = "foo",
     template_name: str | None = None,
     replicas: int = 1,
 ) -> CreatePoolRequest:
-    return CreatePoolRequest(
-        namespace=name,
-        spec=OsGymSandboxWarmPoolSpec(
-            replicas=replicas,
-            sandbox_template_ref=SandboxTemplateRef(name=template_name or name),
-            autoscaling=None,
-        ),
+    template_ref = SandboxTemplateRefBuilder().name(template_name or name).build()
+    spec = (
+        OsGymSandboxWarmPoolSpecBuilder()
+        .replicas(replicas)
+        .sandbox_template_ref(template_ref)
+        .build()
     )
+    return CreatePoolRequestBuilder().namespace(name).spec(spec).build()
 
 
 def template_request(
@@ -51,34 +85,25 @@ def template_request(
     services: dict[str, int] | None = None,
     vm_template: VmTemplate | None = None,
 ) -> CreateTemplateRequest:
-    return CreateTemplateRequest(
-        namespace=name,
-        name=name,
-        spec=OsGymSandboxTemplateSpec(
-            vm_template=vm_template
-            or VmTemplate(
-                container_disk_image=image,
-                command=None,
-                runtime=None,
-                runtime_class_name=None,
-                node_selector=None,
-                tolerations=None,
-                image_pull_policy=None,
-                image_pull_secret="ecr-credentials",
-                cpu_cores=None,
-                memory=None,
-                firmware=None,
-                probes=None,
-                services=[
-                    SandboxService(
-                        name=service_name, target_port=port, protocol=ServiceProtocol.TCP
-                    )
-                    for service_name, port in (services or {"server": 8000}).items()
-                ],
-                oidc=None,
-            ),
-        ),
-    )
+    if vm_template is None:
+        built_services = [
+            SandboxServiceBuilder()
+            .name(service_name)
+            .target_port(port)
+            .protocol(ServiceProtocol.TCP)
+            .build()
+            for service_name, port in (services or {"server": 8000}).items()
+        ]
+        vm_template = (
+            VmTemplateBuilder()
+            .container_disk_image(image)
+            .image_pull_secret("ecr-credentials")
+            .services(built_services)
+            .build()
+        )
+
+    spec = OsGymSandboxTemplateSpecBuilder().vm_template(vm_template).build()
+    return CreateTemplateRequestBuilder().namespace(name).name(name).spec(spec).build()
 
 
 def fleet_pool(name: str = "foo") -> SimpleNamespace:
@@ -364,7 +389,7 @@ def test_sync_pool_matches_blocking_context_manager(monkeypatch):
 
     pool = SyncPool.reconcile(pool_request())
     spec = ClaimSpec(
-        sandbox_template_ref=SandboxTemplateRef(name=pool.name),
+        sandbox_template_ref=SandboxTemplateRefBuilder().name(pool.name).build(),
         warmpool=None,
         bind_deadline=900,
         lifecycle=None,
@@ -424,23 +449,24 @@ async def test_template_reconcile_forwards_native_request_unchanged(monkeypatch)
     client = FakeFleetClient()
     monkeypatch.setattr("cua_sandbox.pool._FleetClient", lambda: client)
     request = template_request(
-        vm_template=VmTemplate(
-            container_disk_image="registry.example/workspace:latest",
-            command=None,
-            runtime=RuntimeKind.KUBEVIRT,
-            runtime_class_name=None,
-            node_selector=None,
-            tolerations=None,
-            image_pull_policy=None,
-            image_pull_secret="workspace-pull",
-            cpu_cores=10,
-            memory="20Gi",
-            firmware=Firmware.EFI,
-            probes=None,
-            services=[
-                SandboxService(name="server", target_port=8000, protocol=ServiceProtocol.TCP)
-            ],
-            oidc=None,
+        vm_template=(
+            VmTemplateBuilder()
+            .container_disk_image("registry.example/workspace:latest")
+            .runtime(RuntimeKind.KUBEVIRT)
+            .image_pull_secret("workspace-pull")
+            .cpu_cores(10)
+            .memory("20Gi")
+            .firmware(Firmware.EFI)
+            .services(
+                [
+                    SandboxServiceBuilder()
+                    .name("server")
+                    .target_port(8000)
+                    .protocol(ServiceProtocol.TCP)
+                    .build()
+                ]
+            )
+            .build()
         ),
     )
 
@@ -480,7 +506,7 @@ async def test_claim_forwards_native_claim_spec_unchanged(monkeypatch):
     pool = await Pool.reconcile(pool_request())
 
     spec = ClaimSpec(
-        sandbox_template_ref=SandboxTemplateRef(name=pool.name),
+        sandbox_template_ref=SandboxTemplateRefBuilder().name(pool.name).build(),
         warmpool=None,
         bind_deadline=900,
         lifecycle=None,

--- a/libs/python/cua-sandbox/uv.lock
+++ b/libs/python/cua-sandbox/uv.lock
@@ -539,18 +539,14 @@ dev = [{ name = "pytest", specifier = ">=8.3.5" }]
 
 [[package]]
 name = "cua-fleet"
-version = "0.0.10"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "httpx" },
-    { name = "python-dateutil" },
-]
+version = "0.1.7"
+source = { registry = "https://wheels.cua.ai/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/4c/f56f16300b568542d6c048cfdd772cd720db2530231f14fe660b9d4dbbb0/cua_fleet-0.0.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5abe2a9aae0cc57b1dcc6680ffed4fac75af3072f69af059c14665517bae7cd5", size = 2144518, upload-time = "2026-08-04T18:43:55.9Z" },
-    { url = "https://files.pythonhosted.org/packages/48/31/7a57fa871fc74ccf8fcba4682ebd15a8af177190cfc75a78d24a01fe213d/cua_fleet-0.0.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8ca4e5c8c4c201fa24c61a16f274d83336406bef25d06d4076c36d3bb4abca59", size = 2102936, upload-time = "2026-08-04T18:43:57.404Z" },
-    { url = "https://files.pythonhosted.org/packages/70/13/a51ca4999eec9f299a02046531294e6a420a893573a9d736cb7157fd43a3/cua_fleet-0.0.10-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:8337016011479466d67ff0cfca27cdc752444c81d4948f58a3babfe71bfaac69", size = 2447788, upload-time = "2026-08-04T18:43:58.853Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/45/e6bde23f40f6be2cc81ac8b10e946eae08134283c987a28a1b98a83f47b8/cua_fleet-0.0.10-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:234a8632072c2a97a3574b1a302ce09ff6d450569d68c3db3d10da23348dde4d", size = 2388452, upload-time = "2026-08-04T18:44:00.105Z" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:75411c1dddb6eafbcdc2e7547dc7c313b9cb079b3fa6717703ffde064507c9db" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2790320f36c84dcf5f275c478dde7520c9eb693785181c0a4d9914ec9c29b75d" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.7-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:fd253cd7c59bf0b9f871b030c3bc4fbe2af80de52d96e5544847a9659b0dd082" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.7-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:bb4867fa06b8b8fd0c28f97c9a3fb986e908ad1d9d77c7125cec84309f3d18b6" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.7-py3-none-win_amd64.whl", hash = "sha256:e0f787405d9de5d3899e09cef7d7f73bb430d9f60cc9b31e8ecb1932a96b62dc" },
 ]
 
 [[package]]
@@ -592,7 +588,7 @@ dev = [
 requires-dist = [
     { name = "cua-auto", specifier = ">=0.1.2" },
     { name = "cua-core", specifier = ">=0.3.0,<0.4.0" },
-    { name = "cua-fleet", specifier = "==0.0.10" },
+    { name = "cua-fleet", specifier = "==0.1.7" },
     { name = "grpcio", specifier = "==1.78.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "oras", specifier = ">=0.2.40" },

--- a/libs/python/cua-sandbox/uv.lock
+++ b/libs/python/cua-sandbox/uv.lock
@@ -539,14 +539,14 @@ dev = [{ name = "pytest", specifier = ">=8.3.5" }]
 
 [[package]]
 name = "cua-fleet"
-version = "0.1.7"
+version = "0.1.8"
 source = { registry = "https://wheels.cua.ai/simple" }
 wheels = [
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:75411c1dddb6eafbcdc2e7547dc7c313b9cb079b3fa6717703ffde064507c9db" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2790320f36c84dcf5f275c478dde7520c9eb693785181c0a4d9914ec9c29b75d" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.7-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:fd253cd7c59bf0b9f871b030c3bc4fbe2af80de52d96e5544847a9659b0dd082" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.7-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:bb4867fa06b8b8fd0c28f97c9a3fb986e908ad1d9d77c7125cec84309f3d18b6" },
-    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.7-py3-none-win_amd64.whl", hash = "sha256:e0f787405d9de5d3899e09cef7d7f73bb430d9f60cc9b31e8ecb1932a96b62dc" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:20611a14c185157e6f41502e1bbdcc1e98663347e94463ca538755b0efc173bb" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7c21d0a36a8d74bfe0768422e4f3d9367ee51837920e2c22ee57521fc93c4f3b" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.8-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:d7604668a7186d06cefb2bd23974b033c0b2cda61ccbe88d944af622b37f58d3" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.8-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:0bac329552d351604ad15b7eb4f4f3ed944921083238d74f51277d657d8f0a34" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.8-py3-none-win_amd64.whl", hash = "sha256:d78fe6934a2f650dcf5b105a08833418245c720765da9c3b40e160b86a3d203d" },
 ]
 
 [[package]]
@@ -588,7 +588,7 @@ dev = [
 requires-dist = [
     { name = "cua-auto", specifier = ">=0.1.2" },
     { name = "cua-core", specifier = ">=0.3.0,<0.4.0" },
-    { name = "cua-fleet", specifier = "==0.1.7" },
+    { name = "cua-fleet", specifier = "==0.1.8" },
     { name = "grpcio", specifier = "==1.78.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "oras", specifier = ">=0.2.40" },


### PR DESCRIPTION
## What changed
- migrate `cua-sandbox` Fleet record construction to the generated builder API
- re-export Fleet builders while preserving legacy record exports
- upgrade `cua-fleet` to `0.1.7` and align distribution/packaging contracts
- add a scope-aware regression test preventing direct builder-enabled constructors

## Verification
- 59 focused sandbox/Fleet tests passed
- Ruff passed on all edited Python files
- PDM lock/build smoke passed
- clean PyPI-only install resolved `cua-fleet==0.1.7` and exposed `CreatePoolRequestBuilder`
- final whole-branch review reported no findings