### PR TITLE
fix(cua-driver): make MCP output schemas object-rooted

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-contract/src/outputs.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-contract/src/outputs.rs
@@ -52,7 +52,7 @@ pub fn refusal_envelope_schema() -> Value {
 /// payloads stay strictly checked — and the refusal envelope joins it as a
 /// sibling variant.
 pub fn advertised_output_schema(success: Value) -> Value {
-    serde_json::json!({ "anyOf": [success, refusal_envelope_schema()] })
+    serde_json::json!({ "type": "object", "anyOf": [success, refusal_envelope_schema()] })
 }
 
 fn output_schema_with_additional_properties<T: JsonSchema>(additional_properties: bool) -> Value {

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -4632,6 +4632,7 @@ mod capability_tests {
             // The success variant is unchanged and still closed; it now sits
             // beside the refusal envelope instead of standing alone.
             let success = &entry["outputSchema"]["anyOf"][0];
+            assert_eq!(entry["outputSchema"]["type"], "object", "{name}");
             assert_eq!(success, &expected, "{name}");
             assert_eq!(success["additionalProperties"], false, "{name}");
         }

--- a/libs/cua-driver/rust/crates/cua-driver/tests/schema_consistency_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/schema_consistency_test.rs
@@ -67,6 +67,12 @@ fn registered_tool_contracts_match_on_active_backend() {
             .unwrap_or_else(|| json!({}));
         violations.extend(shared_schema_violations(name, &schema));
 
+        if let Some(output_schema) = tool.get("outputSchema") {
+            if output_schema.get("type") != Some(&json!("object")) {
+                violations.push(format!("{name}: outputSchema root must have type=object"));
+            }
+        }
+
         let schema_accepts_delivery_mode = schema
             .pointer("/properties/delivery_mode")
             .is_some_and(Value::is_object);


### PR DESCRIPTION
## Summary

- Add the MCP-required object root to advertised output schemas.
- Preserve the existing success and refusal variants and their ordering.
- Enforce object-rooted output schemas in the live tools/list consistency gate.

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p cua-driver-contract --locked`
- `cargo test -p cua-driver-core --locked`
- `cargo build -p cua-driver --locked`
- `cargo test -p cua-driver --test protocol_schema_test --locked`
- `cargo test -p cua-driver --test schema_consistency_test --locked`
- Live `tools/list`: 34 output schemas object-rooted with `anyOf`; 24 tools continue to omit output schemas; zero invalid roots.

Fixes #2977

Thanks @nianchen8 for reporting the strict-client compatibility issue.