### PR TITLE
fix(cua-driver): constrain incompatible zune-core resolution

### DIFF
--- a/libs/cua-driver/rust/Cargo.lock
+++ b/libs/cua-driver/rust/Cargo.lock
@@ -1059,6 +1059,7 @@ dependencies = [
  "url",
  "uuid",
  "windows 0.58.0",
+ "zune-core",
 ]
 
 [[package]]

--- a/libs/cua-driver/rust/Cargo.toml
+++ b/libs/cua-driver/rust/Cargo.toml
@@ -34,6 +34,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 base64 = "0.22"
 uuid = { version = "1", features = ["v4"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
+# zune-jpeg 0.5.15 accepts zune-core ^0.5, but zune-core 0.5.2 changed its
+# disabled logging macros in a source-incompatible way. Keep fresh downstream
+# resolution on the last compatible pair until zune-jpeg publishes its fix.
+zune-core = "=0.5.1"
 uniffi = "=0.31.0"
 postcard = { version = "1", features = ["alloc"] }
 sha2 = "0.10"

--- a/libs/cua-driver/rust/crates/cua-driver-core/Cargo.toml
+++ b/libs/cua-driver/rust/crates/cua-driver-core/Cargo.toml
@@ -25,6 +25,10 @@ regorus = { version = "0.10.1", optional = true }
 # helpers extracted from `platform-{macos,windows,linux}/src/capture.rs` so
 # all three platforms call the same code path.
 image = { workspace = true }
+# Compatibility constraint for image's zune-jpeg decoder. This dependency is
+# intentionally direct so SDK consumers without this workspace lockfile cannot
+# resolve the incompatible zune-core 0.5.2 release.
+zune-core = { workspace = true }
 # Used by the `browser` module's pooled CDP browser-endpoint WebSocket.
 # Same versions platform-macos already depends on, to avoid duplicate
 # crate versions in the workspace graph. No TLS features: the endpoint


### PR DESCRIPTION
## Summary

- pin `zune-core` to the last version compatible with `zune-jpeg 0.5.15`
- make the constraint part of `cua-driver-core` so fresh SDK consumers inherit it without the workspace lockfile
- restore the Rust compatibility fixture on macOS, Linux, and Windows

## Why

`zune-core 0.5.2` changed disabled logging macros in a way that does not compile with `zune-jpeg 0.5.15`. Fresh downstream resolution selected that pair and broke the portable contract parity jobs on #2983 across all three operating systems.

## Verification

- `cargo check -p cua-driver-core`
- fresh `cargo check --manifest-path libs/cua-driver/compat-fixtures/apps/rust/Cargo.toml` resolves `zune-core 0.5.1` and passes
- `cargo test -p cua-driver-core --locked` (502 unit tests plus contract and lifecycle suites)
- `cargo fmt --all -- --check`
- `git diff --check`