### PR TITLE
fix(cua-driver): sign Windows release binaries

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -568,6 +568,36 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
             workflow,
         )
 
+    def test_driver_release_signs_and_verifies_every_windows_binary(self) -> None:
+        workflow = self.read(".github/workflows/cd-rust-cua-driver.yml")
+
+        self.assertIn("environment: cua-driver-release-signing", workflow)
+        self.assertIn("id-token: write", workflow)
+        self.assertIn("azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca", workflow)
+        self.assertIn(
+            "azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82",
+            workflow,
+        )
+        self.assertIn("AZURE_ARTIFACT_SIGNING_ENDPOINT", workflow)
+        self.assertIn("AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME", workflow)
+        self.assertIn("AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME", workflow)
+        for name in (
+            "cua-driver.exe",
+            "cua-cursor-theme.exe",
+            "cua-driver-uia.exe",
+            "cua_driver_sdk.dll",
+            "cua_driver_node_runtime.node",
+        ):
+            self.assertGreaterEqual(workflow.count(name), 3, name)
+        self.assertIn("timestamp-rfc3161: http://timestamp.acs.microsoft.com", workflow)
+        self.assertIn('if ($signature.Status -ne "Valid")', workflow)
+        self.assertIn("TimeStamperCertificate", workflow)
+        self.assertLess(
+            workflow.index("name: Sign Windows release binaries"),
+            workflow.index("name: Package", workflow.index("build-windows:")),
+        )
+        self.assertNotIn("currently shipped UNSIGNED", workflow)
+
     def test_installer_compatibility_runs_current_installers_on_releases(
         self,
     ) -> None:

--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -221,6 +221,10 @@ jobs:
     name: windows-${{ matrix.arch }}
     needs: release-attribution-preflight
     runs-on: windows-latest
+    environment: cua-driver-release-signing
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -285,6 +289,66 @@ jobs:
           node scripts/build-node-runtime.mjs \
             --target "${{ matrix.target }}" \
             --output "rust/target/${{ matrix.target }}/release/cua_driver_node_runtime.node"
+      - name: Azure login for release signing
+        if: >-
+          startsWith(github.ref, 'refs/tags/cua-driver-rs-v') ||
+          (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Sign Windows release binaries
+        if: >-
+          startsWith(github.ref, 'refs/tags/cua-driver-rs-v') ||
+          (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
+        with:
+          endpoint: ${{ vars.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ vars.AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ vars.AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME }}
+          files: |
+            ${{ github.workspace }}\libs\cua-driver\rust\target\${{ matrix.target }}\release\cua-driver.exe
+            ${{ github.workspace }}\libs\cua-driver\rust\target\${{ matrix.target }}\release\cua-cursor-theme.exe
+            ${{ github.workspace }}\libs\cua-driver\rust\target\${{ matrix.target }}\release\cua-driver-uia.exe
+            ${{ github.workspace }}\libs\cua-driver\rust\target\${{ matrix.target }}\release\cua_driver_sdk.dll
+            ${{ github.workspace }}\libs\cua-driver\rust\target\${{ matrix.target }}\release\cua_driver_node_runtime.node
+          description: Cua Driver
+          description-url: https://github.com/trycua/cua
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+      - name: Verify Windows release signatures
+        if: >-
+          startsWith(github.ref, 'refs/tags/cua-driver-rs-v') ||
+          (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+        working-directory: libs/cua-driver/rust
+        shell: pwsh
+        run: |
+          $target = "${{ matrix.target }}"
+          $release = Join-Path "target/$target" "release"
+          $files = @(
+            "cua-driver.exe",
+            "cua-cursor-theme.exe",
+            "cua-driver-uia.exe",
+            "cua_driver_sdk.dll",
+            "cua_driver_node_runtime.node"
+          )
+
+          foreach ($name in $files) {
+            $path = Join-Path $release $name
+            $signature = Get-AuthenticodeSignature -LiteralPath $path
+            if ($signature.Status -ne "Valid") {
+              throw "$name Authenticode signature is $($signature.Status): $($signature.StatusMessage)"
+            }
+            if ($null -eq $signature.SignerCertificate) {
+              throw "$name has no signer certificate"
+            }
+            if ($null -eq $signature.TimeStamperCertificate) {
+              throw "$name has no RFC 3161 timestamp certificate"
+            }
+            Write-Host "$name signed by $($signature.SignerCertificate.Subject)"
+          }
       - name: Package
         working-directory: libs/cua-driver/rust
         shell: pwsh
@@ -308,12 +372,9 @@ jobs:
           # wrapper and dumps the files at the archive root, which breaks
           # the installer's path lookup.
           Compress-Archive -Path "release/$stage" -DestinationPath "release/$stage.zip" -Force
-          # Bare-binaries zip: both exes side-by-side (no wrapper dir).
-          # `cua-driver-uia.exe` is currently shipped UNSIGNED in this archive
-          # — until #1602 wires an EV cert into CD, the worker won't elevate
-          # to UIAccess integrity on a default-policy machine. The main CLI/MCP
-          # binary stays fully functional regardless; uia is opt-in dead-weight
-          # until signed.
+          # Bare runtime zip: signed executables and SDK artifacts side-by-side
+          # with no wrapper directory. Signing happens before either archive is
+          # assembled so the UIAccess worker retains its production signature.
           Compress-Archive -Path "release/$stage/cua-driver.exe","release/$stage/cua-cursor-theme.exe","release/$stage/cua-driver-uia.exe","release/$stage/cua_driver_sdk.dll","release/$stage/cua_driver_node_runtime.node","release/$stage/cua_driver_abi.h" -DestinationPath "release/$stage-binary.zip" -Force
           Get-ChildItem "release/$stage*.zip"
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- authenticate Windows release jobs to Azure with GitHub OIDC through the `cua-driver-release-signing` environment
- sign the x64 and ARM64 CLI, cursor-theme helper, UIAccess worker, SDK DLL, and Node runtime before packaging
- require valid Authenticode signer and RFC 3161 timestamp certificates before upload
- pin `azure/login` and `azure/artifact-signing-action` to reviewed release commits

## Why

Cua Driver's Windows release artifacts are currently unsigned. That prevents them from establishing publisher reputation and means the UIAccess worker cannot satisfy Windows' signed-location requirements.

## Validation

- `uv run --with pytest --with jsonschema --with toml python -m pytest .github/scripts/tests -q` — 159 passed, 6 subtests passed
- `python3 .github/scripts/tests/test_cua_driver_release_wiring.py` — 38 passed
- workflow YAML parses successfully
- `git diff --check`
- `actionlint` reports only the existing `macos-26` runner-label and SC2129 findings

## Azure rollout

- [x] Create the `cua-driver-release-signing` GitHub environment and configure its Azure identifiers and signing variables
- [x] Create the single-tenant Entra application and GitHub environment-scoped OIDC credential
- [ ] Wait for Azure public identity validation to complete (currently in progress)
- [ ] Create the `cua-driver` certificate profile and assign `Artifact Signing Certificate Profile Signer` at that exact profile scope