### PR TITLE
fix(cua-driver): use WinRects geometry for GNOME window capture

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/mod.rs
@@ -877,21 +877,45 @@ pub(crate) unsafe fn borrowed_fd(fd: i32) -> std::os::fd::OwnedFd {
 /// output-level path used by `get_window_state`'s vision payload.
 pub fn screenshot_dispatch(xid: u64) -> anyhow::Result<Vec<u8>> {
     if is_wayland() {
+        let geometry = capture_geometry(xid).ok_or_else(|| {
+            anyhow::anyhow!("Wayland window {xid} has no compositor-attested capture geometry")
+        })?;
         let bytes = screenshot_display_dispatch()?;
-        if let Some((x, y, width, height)) = window_geometry(xid) {
-            crop_png_to_rect(
-                &bytes,
-                x,
-                y,
-                width,
-                height,
-                &format!("Wayland window {xid}"),
-            )
-        } else {
-            Ok(bytes)
-        }
+        let (x, y, width, height) = geometry;
+        crop_png_to_rect(
+            &bytes,
+            x,
+            y,
+            width,
+            height,
+            &format!("Wayland window {xid}"),
+        )
     } else {
         crate::capture::screenshot_window_bytes(xid)
+    }
+}
+
+type CaptureGeometry = (i32, i32, u32, u32);
+
+fn capture_geometry(window_id: u64) -> Option<CaptureGeometry> {
+    let helper_available = shell_helper::available();
+    let helper_geometry = helper_available
+        .then(|| shell_helper::trusted_window_geometry(window_id))
+        .flatten();
+    select_capture_geometry(helper_available, helper_geometry, || {
+        window_geometry(window_id)
+    })
+}
+
+fn select_capture_geometry(
+    helper_available: bool,
+    helper_geometry: Option<CaptureGeometry>,
+    fallback_geometry: impl FnOnce() -> Option<CaptureGeometry>,
+) -> Option<CaptureGeometry> {
+    if helper_available {
+        helper_geometry
+    } else {
+        fallback_geometry()
     }
 }
 
@@ -996,7 +1020,7 @@ fn checked_shell_helper_capture(
 /// crop with.
 pub fn screenshot_window_dispatch(xid: u64) -> anyhow::Result<Vec<u8>> {
     if is_wayland() {
-        if let Some((x, y, width, height)) = window_geometry(xid) {
+        if let Some((x, y, width, height)) = capture_geometry(xid) {
             return crop_png_to_rect(
                 &screenshot_display_dispatch()?,
                 x,
@@ -3336,6 +3360,30 @@ mod tests {
             crop_png_to_rect(encoded.get_ref(), 2, 1, 3, 4, "fixture").expect("crop fixture PNG");
         let decoded = image::load_from_memory(&cropped).expect("decode cropped PNG");
         assert_eq!((decoded.width(), decoded.height()), (3, 4));
+    }
+
+    #[test]
+    fn compositor_helper_missing_target_rejects_fallback_geometry() {
+        let synthetic_atspi_geometry = Some((10, 10, 1440, 1000));
+        assert_eq!(
+            select_capture_geometry(true, None, || synthetic_atspi_geometry),
+            None
+        );
+    }
+
+    #[test]
+    fn compositor_helper_exact_target_wins_over_fallback_geometry() {
+        let exact = Some((1100, 428, 360, 616));
+        assert_eq!(
+            select_capture_geometry(true, exact, || Some((10, 10, 1440, 1000))),
+            exact
+        );
+    }
+
+    #[test]
+    fn non_helper_compositor_retains_existing_geometry_fallback() {
+        let fallback = Some((20, 30, 800, 600));
+        assert_eq!(select_capture_geometry(false, None, || fallback), fallback);
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/shell_helper.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/shell_helper.rs
@@ -346,6 +346,17 @@ pub fn trusted_window_for_id(pid: u32, window_id: u64) -> Option<WindowInfo> {
         .map(|window| window.info)
 }
 
+/// Compositor-attested capture geometry for one exact GNOME window id.
+pub fn trusted_window_geometry(window_id: u64) -> Option<(i32, i32, u32, u32)> {
+    trusted_shell_windows(None)?
+        .into_iter()
+        .find(|window| window.info.xid == window_id)
+        .map(|window| {
+            let info = window.info;
+            (info.x, info.y, info.width, info.height)
+        })
+}
+
 /// Enumerate exact browser-window ids for one process through the verified
 /// GNOME Shell helper. `None` means no trusted helper is available; an empty
 /// vector means the trusted helper found no owned windows.


### PR DESCRIPTION
## What changed

- When the verified GNOME WinRects helper is active, get capture geometry only from that helper for the exact window id.
- If the helper is active and the window is not in WinRects, fail the targeted capture. Do not crop with synthetic AT-SPI bounds.
- Keep the existing geometry fallback for compositors that do not use the GNOME helper.
- Add unit tests for helper present, helper missing target, and non-helper fallback.

## Why

On GNOME Wayland with WinRects installed, `screenshot_dispatch` can crop a full-stage capture with geometry from AT-SPI when WinRects has no matching window.

AT-SPI can report a frame for a process that has no real Mutter toplevel. One case is a headless browser process. The crop then uses desktop-sized bounds and returns desktop pixels as a targeted window screenshot.

WinRects geometry is compositor-attested. Use it when the helper is active. Do not treat AT-SPI bounds as capture-safe on that path.

## User impact

- Targeted window capture on GNOME with WinRects needs an exact WinRects window id and returns only that window crop when geometry is present.
- Targeted capture fails when the helper is active and the window is missing from WinRects. The caller must refresh `list_windows`.
- X11 capture does not change.
- Non-GNOME Wayland paths that do not use WinRects keep the prior geometry fallback.

## Validation

Candidate: `633ab1193a97d66791369aba18f6dcc928e72873`

- `cargo fmt --all`
- `git diff --check`
- focused tests:
  - `compositor_helper_missing_target_rejects_fallback_geometry`
  - `compositor_helper_exact_target_wins_over_fallback_geometry`
  - `non_helper_compositor_retains_existing_geometry_fallback`
- `cargo test -p platform-linux --lib`: 267 passed, 0 failed, 4 ignored

### Runtime check on GNOME Shell 50.1 Wayland

- WinRects helper active and serving `GetRects`
- Launch Calculator through `launch_app`
- Drive Calculator with Computer Use: enter `7 x 6 =` and read result `42`
- Targeted capture size: 360x616 Calculator window
- Full display capture size: 2560x1440 desktop with the same Calculator visible
- Unknown window id fails closed: stale target error, no desktop image

## Related

- Related to open #2964, which fails closed when surface identity is not proven on Wayland.
- This change is narrower. It accepts GNOME stage crop only when WinRects attests the exact window rectangle.

## Risk

Low. Scope is limited to Linux Wayland geometry selection for window screenshots when the GNOME helper is available. Non-helper paths keep prior behavior.