### PR TITLE
chore: remove unused imports in mcp-server and human_tool ui

### DIFF
--- a/libs/python/agent/cua_agent/human_tool/ui.py
+++ b/libs/python/agent/cua_agent/human_tool/ui.py
@@ -9,7 +9,6 @@ import gradio as gr
 import requests
 from PIL import Image
 
-from .server import completion_queue
 
 
 class HumanCompletionUI:
@@ -411,7 +410,6 @@ class HumanCompletionUI:
             max_seconds: Maximum number of seconds to wait
             check_interval: How often to check for pending calls (in seconds)
         """
-        import time
 
         start_time = time.time()
 

--- a/libs/python/mcp-server/mcp_server/server.py
+++ b/libs/python/mcp-server/mcp_server/server.py
@@ -1,5 +1,4 @@
 import asyncio
-import base64
 import inspect
 import logging
 import os

--- a/libs/python/mcp-server/mcp_server/session_manager.py
+++ b/libs/python/mcp-server/mcp_server/session_manager.py
@@ -13,7 +13,6 @@ import logging
 import os
 import time
 import uuid
-import weakref
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Set


### PR DESCRIPTION
## Summary

Three small cleanups removing imports that are never used in the module:

- `libs/python/mcp-server/mcp_server/server.py`: drop unused `import base64`
- `libs/python/mcp-server/mcp_server/session_manager.py`: drop unused `import weakref` (session pool uses plain lists)
- `libs/python/agent/cua_agent/human_tool/ui.py`: drop unused `from .server import completion_queue` (leftover from an earlier poll-based implementation) and a redundant function-local `import time` that shadowed the module-level import

## Verification

- `grep` confirms each removed name is referenced only by its import line in the respective file
- `python -m py_compile` passes on all three files
- No behavioral change