### PR TITLE
feat(cua-driver): expose Windows control IDs in structured snapshots

### DIFF
--- a/docs/content/docs/reference/cua-driver/mcp-tool-notes.mdx
+++ b/docs/content/docs/reference/cua-driver/mcp-tool-notes.mdx
@@ -61,6 +61,16 @@ Action tools (`click`, `double_click`, `right_click`, `drag`, `scroll`, `type_te
 
 ## Per-tool notes
 
+### `get_window_state` developer-assigned IDs
+
+On Windows, a structured `elements` row may include `id`, populated from a
+non-empty native UIA `AutomationId`. Renderer-owned web content never exposes
+this field. A native control with an ID can remain indexed even when it has no
+UIA action pattern; the ID identifies the control but does not imply that an
+action will succeed. ID-only rows do not suppress the existing empty-wrapper
+fallback or prove that the accessibility tree has actionable controls. Other
+platforms currently omit `id`.
+
 ### `get_window_state` degraded results
 
 On Linux (and macOS/Windows), the structured result may include `degraded: true` alongside a `degraded_reason` string when the accessibility walk completed but found no actionable elements. This distinguishes "a11y bridge not up, daemon not on the session D-Bus, or non-AX surface" from a window that genuinely has no controls. Treat `elements: []` as incomplete when `degraded: true` is set, and act by `px` off the screenshot returned in the same response.

--- a/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/SKILL.md
@@ -762,6 +762,11 @@ the grab (a perf knob, not a modality choice).
 
 The response carries:
 
+- `elements` — preferred structured rows with `element_index`, `element_token`,
+  role, label, geometry, and optional platform fields. On Windows, native
+  controls with a non-empty UIA `AutomationId` expose it as `id`; renderer-owned
+  web content does not. An ID can keep an otherwise patternless native control
+  indexed, but it does not imply that the control accepts an action.
 - `tree_markdown` — every actionable element tagged `[N]`; the structured row
   with the same `element_index` carries its opaque `element_token`. The tree can be very large (Finder is
   ~1600 elements, ~190 KB); when it exceeds token limits the MCP

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_winui3_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_winui3_test.rs
@@ -151,6 +151,9 @@ fn harness_winui3_smoke() {
                 snap.text()
             );
             let text = snap.text();
+            let elements = snap.structured()["elements"]
+                .as_array()
+                .expect("WinUI3 snapshot needs structured elements");
             for aid in [
                 "btn-increment",
                 "btn-reset",
@@ -162,7 +165,17 @@ fn harness_winui3_smoke() {
                     text.contains(&format!("id={aid}")),
                     "missing AutomationId {aid} in WinUI3 UIA snapshot"
                 );
+                assert!(
+                    elements.iter().any(|element| element["id"] == aid),
+                    "missing structured ID {aid} in WinUI3 UIA snapshot"
+                );
             }
+            assert!(
+                elements
+                    .iter()
+                    .any(|element| element["id"] == "lbl-counter"),
+                "ID-only WinUI3 text control was not indexed in structured elements"
+            );
             assert!(
                 text.contains("HARNESS_TEXT_MARKER_v1"),
                 "WinUI3 text_body marker not in snapshot"

--- a/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/harness_wpf_test.rs
@@ -268,6 +268,9 @@ fn harness_wpf_smoke() {
             let snap = snapshot(driver, pid, wid);
             assert!(!snap.is_error(), "WPF AX snapshot failed: {}", snap.text());
             let text = snap.text();
+            let elements = snap.structured()["elements"]
+                .as_array()
+                .expect("WPF snapshot needs structured elements");
             for aid in [
                 "btn-increment",
                 "btn-reset",
@@ -282,7 +285,17 @@ fn harness_wpf_smoke() {
                     ax::has_id(text, aid),
                     "missing AutomationId {aid} in WPF UIA snapshot"
                 );
+                assert!(
+                    elements.iter().any(|element| element["id"] == aid),
+                    "missing structured ID {aid} in WPF UIA snapshot"
+                );
             }
+            assert!(
+                elements
+                    .iter()
+                    .any(|element| element["id"] == "lbl-counter"),
+                "ID-only WPF text control was not indexed in structured elements"
+            );
             for marker in ["HARNESS_TEXT_MARKER_v1", "counter=0", "accel_fired=0"] {
                 assert!(text.contains(marker), "missing WPF AX marker {marker}");
             }

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -1076,6 +1076,14 @@ fn fold_max_dimension(ceiling: u32, per_call: Option<u32>) -> u32 {
     }
 }
 
+fn structured_id(node: &crate::uia::UiaNode) -> Option<&str> {
+    (!crate::uia::is_document_or_descendant(node.in_web_content, &node.control_type))
+        .then_some(())?;
+    node.automation_id
+        .as_deref()
+        .filter(|id| !id.trim().is_empty())
+}
+
 pub struct GetWindowStateTool {
     state: Arc<ToolState>,
 }
@@ -1101,7 +1109,10 @@ impl Tool for GetWindowStateTool {
                 the next snapshot of the same (pid, window_id).\n\n\
                 PREFERRED CONSUMERS read `structuredContent.elements` (one entry per \
                 indexed row with `element_index`, `role`, `label`, `value`, `enabled`, \
-                `selected`, `frame: {x,y,w,h}`, `parent_index`, `depth`). The markdown \
+                `selected`, `frame: {x,y,w,h}`, `parent_index`, `depth`, and optional \
+                developer-assigned `id`. On Windows, `id` is a non-empty native UIA \
+                AutomationId outside web content; an ID-only native control can therefore \
+                appear as an indexed row even without an action pattern. The markdown \
                 `tree_markdown` stays available \
                 and unchanged in shape for existing text-parsing callers — but new \
                 fields will only be added to the structured side.\n\n\
@@ -1401,7 +1412,7 @@ impl Tool for GetWindowStateTool {
                     // Structured `elements` array — preferred consumption
                     // path. Shape matches the cross-platform spec:
                     // `{element_index, element_token, role, label, depth,
-                    // parent_index?, frame?: {x,y,w,h}}`. Frame is
+                    // parent_index?, id?, frame?: {x,y,w,h}}`. Frame is
                     // included when UIA reported a usable BoundingRectangle.
                     let elements: Vec<serde_json::Value> = tr
                         .nodes
@@ -1445,6 +1456,9 @@ impl Tool for GetWindowStateTool {
                             }
                             if let Some(selected) = n.selected {
                                 entry["selected"] = json!(selected);
+                            }
+                            if let Some(id) = structured_id(n) {
+                                entry["id"] = json!(id);
                             }
                             if let Some(parent) = n.parent_element_index {
                                 entry["parent_index"] = json!(parent);
@@ -1497,16 +1511,20 @@ impl Tool for GetWindowStateTool {
                              Cua Driver used a partial MSAA tree. Treat it as discovery \
                              evidence only; it cannot prove checked state."
                         );
-                    } else if count == 0 {
+                    } else if !crate::uia::has_actionable_nodes(&tr.nodes) {
                         structured["degraded"] = json!(true);
-                        structured["degraded_reason"] = json!(
+                        structured["degraded_reason"] = json!(if count == 0 {
                             "ax_tree_empty: the UIA walk returned no actionable elements. \
                              The window may be a non-UIA surface (canvas/WebGL/custom-drawn) \
                              or its accessibility tree was not ready (Chromium/Electron \
                              require a UIA-enable + settle). Do not treat element data as \
                              authoritative — re-snapshot if the app just launched, otherwise \
                              switch to the visual path."
-                        );
+                        } else {
+                            "ax_tree_no_actions: the UIA walk returned indexed native IDs \
+                             but no actionable elements. IDs remain observation targets; \
+                             they do not prove action support or a complete accessibility tree."
+                        });
                         structured["escalation"] = json!({
                             "recommended": "px",
                             "reason": "non-AX surface — act by pixel (x,y) off the \
@@ -9848,6 +9866,55 @@ pub fn build_registry_with_provider(
     r.register_recording_tools();
     r.register_session_tools();
     r
+}
+
+#[cfg(test)]
+mod windows_structured_id_tests {
+    use super::structured_id;
+    use crate::uia::UiaNode;
+
+    fn node(automation_id: Option<&str>, in_web_content: bool) -> UiaNode {
+        UiaNode {
+            element_index: Some(0),
+            control_type: "Edit".into(),
+            name: None,
+            value: None,
+            automation_id: automation_id.map(str::to_owned),
+            help_text: None,
+            actions: Vec::new(),
+            enabled: None,
+            selected: None,
+            element_ptr: 0,
+            center_x: 0,
+            center_y: 0,
+            rect: None,
+            msaa_role: None,
+            depth: 0,
+            parent_element_index: None,
+            in_web_content,
+        }
+    }
+
+    #[test]
+    fn exposes_only_non_empty_native_ids() {
+        assert_eq!(
+            structured_id(&node(Some("workspace_name_input"), false)),
+            Some("workspace_name_input")
+        );
+        assert_eq!(structured_id(&node(Some(""), false)), None);
+        assert_eq!(structured_id(&node(Some("  "), false)), None);
+        assert_eq!(structured_id(&node(None, false)), None);
+        assert_eq!(structured_id(&node(Some("dom-id"), true)), None);
+    }
+
+    #[test]
+    fn document_root_id_is_excluded_with_the_existing_ancestor_flag() {
+        // A root Document has no Document ancestor. Browser setup relies on
+        // that distinction; ID projection must exclude the root by its type.
+        let mut document = node(Some("document-dom-id"), false);
+        document.control_type = "Document".into();
+        assert_eq!(structured_id(&document), None);
+    }
 }
 
 #[cfg(test)]

--- a/libs/cua-driver/rust/crates/platform-windows/src/uia/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/uia/mod.rs
@@ -88,8 +88,9 @@ pub struct UiaNode {
     /// `element_index` of the nearest actionable ancestor, if any.
     /// Mirrors the markdown's parent-of-this-row.
     pub parent_element_index: Option<usize>,
-    /// True when this node is below a UIA Document control. Browser-owned
-    /// consent chrome must never match renderer-controlled descendants.
+    /// True when this node is below a UIA Document control. The Document root
+    /// itself remains false so browser setup can distinguish it from nested
+    /// documents. ID projection excludes both roots and descendants by type.
     pub in_web_content: bool,
 }
 
@@ -410,15 +411,15 @@ unsafe fn walk_tree_unsafe(
     // we mirror that here when the primary path yields nothing actionable.
     //
     // Trigger: walk produced zero actionable nodes (the primary path may have
-    // still pushed a wrapper-only node — that's why we filter on
-    // `element_index.is_some()`).
+    // still pushed a wrapper-only node). An AutomationId can now index that
+    // wrapper without making it actionable, so inspect action support directly.
     //
     // Stage the fallback walk into fresh accumulators and only swap them in
     // if the fallback actually finds actionable elements. Otherwise the
     // wrapper-only node from the primary walk stays the result — better than
     // erasing it AND leaving the consumed `MAX_TOTAL_ELEMENTS` budget intact
     // for the fallback (which would then truncate large trees prematurely).
-    if nodes.iter().filter(|n| n.element_index.is_some()).count() == 0 {
+    if !has_actionable_nodes(&nodes) {
         // Skip the desktop-root walk-by-pid fallback for VCL / SAL
         // targets (LibreOffice, OpenOffice). The fallback does its own
         // `BuildUpdatedCache(TreeScope.Subtree)` per matched top-level
@@ -469,7 +470,7 @@ unsafe fn walk_tree_unsafe(
                     max_depth,
                 );
 
-                if fallback_nodes.iter().any(|n| n.element_index.is_some()) {
+                if has_actionable_nodes(&fallback_nodes) {
                     nodes = fallback_nodes;
                     lines = fallback_lines;
                     // counter/total aren't read after this point — they're
@@ -667,6 +668,7 @@ unsafe fn walk_cached_bounded(
     *total += 1;
 
     let control_type = read_cached_control_type(element);
+    let id_in_web_content = is_document_or_descendant(in_web_content, &control_type);
     let name = read_cached_bstr_name(element);
     let value = read_cached_bstr_value(element);
     let automation_id = read_cached_bstr(element, UIA_AutomationIdPropertyId);
@@ -677,7 +679,12 @@ unsafe fn walk_cached_bounded(
     let is_enabled = enabled.unwrap_or(true);
     let selected = read_cached_selected(element);
     let actions = detect_cached_actions(element, &control_type, is_enabled);
-    let is_actionable = !actions.is_empty() && is_enabled;
+    let is_indexable = should_index_node(
+        &actions,
+        is_enabled,
+        automation_id.as_deref(),
+        id_in_web_content,
+    );
     let has_content = name
         .as_deref()
         .map(|s| !s.trim().is_empty())
@@ -688,12 +695,12 @@ unsafe fn walk_cached_bounded(
             .unwrap_or(false);
 
     let mut emitted_parent: Option<usize> = parent_index;
-    if is_actionable || has_content {
+    if is_indexable || has_content {
         let retained: IUIAutomationElement = element.clone();
         let ptr = retained.as_raw() as usize;
         std::mem::forget(retained);
 
-        let node = if is_actionable {
+        let node = if is_indexable {
             let idx = *counter;
             *counter += 1;
             let (center_x, center_y, rect) = read_cached_bounding_rect_full(element);
@@ -752,7 +759,7 @@ unsafe fn walk_cached_bounded(
                     &child,
                     depth + 1,
                     emitted_parent,
-                    in_web_content || control_type.eq_ignore_ascii_case("Document"),
+                    id_in_web_content,
                     nodes,
                     lines,
                     counter,
@@ -763,6 +770,29 @@ unsafe fn walk_cached_bounded(
             }
         }
     }
+}
+
+pub(crate) fn is_document_or_descendant(parent_in_web_content: bool, control_type: &str) -> bool {
+    parent_in_web_content || control_type.eq_ignore_ascii_case("Document")
+}
+
+/// Indexed host IDs are observation targets, not proof of action support.
+/// Preserve the empty-wrapper fallback and degraded-result policy when such
+/// a wrapper is the only node the primary UIA walk can reach.
+pub(crate) fn has_actionable_nodes(nodes: &[UiaNode]) -> bool {
+    nodes
+        .iter()
+        .any(|node| node.enabled != Some(false) && !node.actions.is_empty())
+}
+
+fn should_index_node(
+    actions: &[String],
+    is_enabled: bool,
+    automation_id: Option<&str>,
+    in_web_content: bool,
+) -> bool {
+    (!actions.is_empty() && is_enabled)
+        || (!in_web_content && automation_id.is_some_and(|id| !id.trim().is_empty()))
 }
 
 fn read_cached_control_type(element: &IUIAutomationElement) -> String {
@@ -1054,4 +1084,65 @@ fn filter_tree(markdown: &str, query: &str) -> String {
     let mut r = output.join("\n");
     r.push('\n');
     r
+}
+
+#[cfg(test)]
+mod developer_assigned_id_index_tests {
+    use super::{has_actionable_nodes, is_document_or_descendant, should_index_node, UiaNode};
+
+    #[test]
+    fn document_nodes_and_descendants_are_web_content() {
+        assert!(is_document_or_descendant(false, "Document"));
+        assert!(is_document_or_descendant(true, "Button"));
+        assert!(!is_document_or_descendant(false, "Button"));
+    }
+
+    #[test]
+    fn native_ids_keep_patternless_controls_indexed() {
+        assert!(should_index_node(
+            &[],
+            true,
+            Some("app.terms-accept"),
+            false
+        ));
+        assert!(should_index_node(&[], false, Some("app.disabled"), false));
+        assert!(!should_index_node(&[], true, Some("dom-node"), true));
+        assert!(!should_index_node(&[], true, Some("  "), false));
+        assert!(!should_index_node(&[], true, None, false));
+        assert!(should_index_node(&["invoke".into()], true, None, true));
+    }
+
+    #[test]
+    fn indexed_id_only_wrapper_does_not_suppress_action_fallback() {
+        let mut wrapper = UiaNode {
+            element_index: Some(0),
+            control_type: "Window".into(),
+            name: None,
+            value: None,
+            automation_id: Some("native-wrapper".into()),
+            help_text: None,
+            actions: Vec::new(),
+            enabled: Some(true),
+            selected: None,
+            element_ptr: 0,
+            center_x: 0,
+            center_y: 0,
+            rect: None,
+            msaa_role: None,
+            depth: 0,
+            parent_element_index: None,
+            in_web_content: false,
+        };
+        assert!(should_index_node(
+            &wrapper.actions,
+            true,
+            wrapper.automation_id.as_deref(),
+            false
+        ));
+        assert!(!has_actionable_nodes(std::slice::from_ref(&wrapper)));
+        wrapper.actions.push("invoke".into());
+        assert!(has_actionable_nodes(std::slice::from_ref(&wrapper)));
+        wrapper.enabled = Some(false);
+        assert!(!has_actionable_nodes(std::slice::from_ref(&wrapper)));
+    }
 }


### PR DESCRIPTION
## Summary

Adds an optional `id` field to Windows `get_window_state` structured elements, populated from a non-empty native UIA `AutomationId`.

- Native controls with an ID remain indexed even without an action pattern, including disabled controls.
- UIA `Document` nodes and their descendants never expose IDs. The existing Document-ancestor flag retains its original meaning.
- Existing action-pattern indexing, empty-wrapper fallback, degraded actionability decisions, and Markdown row syntax remain unchanged.
- Public reference docs and the shipped CUA Driver skill document the field and its limits.

Related to #2798.

The comparison against current `main` is 6 files, +214/-15.

## Compatibility

The field is optional and additive. Existing clients may ignore it. Snapshots may gain rows for native controls that previously had an ID but no action pattern. An ID identifies a control; it does not imply that an action will succeed.

## Testing

Exact candidate `1e775233bd970738adcc96f87112e626e3bb55ab` is one commit on tested main base `7c58a4d5b078b81f657d8e7e906712f8e3a96148`. Its complete source tree matches the prior history-preserving update; original Chris authorship and Friday coauthor credit remain. Later main changes are not included in that local test result. The following gates ran on this exact tree:

- `cargo test -p platform-windows`: 207 passed, 0 failed, 3 ignored.
- Regression coverage includes Document-root exclusion, Document-ancestor compatibility, ID-only indexing, and actionability fallback. The Document-root projection regression failed before repair.
- Source-built WPF and WinUI native smoke tests: 1 passed each, including actionable IDs and an ID-only text control.
- Driver build, `cargo fmt --all -- --check`, and diff checks pass.
- Ordinary all-target platform Clippy completes; warnings-denied Clippy fails in unchanged core and cursor-overlay baseline code.
- Docs production build, internal-link check, and hygiene check pass; internal links report zero errors.

Local limits:

- This workstation lacks Visual Studio's Spectre-mitigated libraries, so Rust validation used a local-only Rego-disabled dependency configuration. The manifest was restored byte-for-byte before commit; those edits are absent from the diff.
- Local native smoke covers the two structured-ID fixtures. Hosted Windows CI remains a separate gate for the full native behavior matrix.
- Driver-generated documentation is platform-specific on Windows, so generator drift remains a CI gate. The edited hand-maintained reference passed the production docs build.
