### PR TITLE
feat(cli): run Fleets sandboxes with GitHub WIF

### DIFF
--- a/libs/python/cua-cli/.bumpversion.cfg
+++ b/libs/python/cua-cli/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.13
+current_version = 0.1.14
 commit = True
 tag = True
 tag_name = cli-v{new_version}

--- a/libs/python/cua-cli/README.md
+++ b/libs/python/cua-cli/README.md
@@ -5,7 +5,7 @@ Unified command-line interface for CUA (Computer-Use Agents).
 ## Installation
 
 ```bash
-pip install cua-cli
+pip install --extra-index-url https://wheels.cua.ai/simple cua-cli
 ```
 
 ## Usage
@@ -52,16 +52,16 @@ cua serve-mcp --permissions sandbox:all,computer:readonly
 
 ```bash
 # Basic installation
-pip install cua-cli
+pip install --extra-index-url https://wheels.cua.ai/simple cua-cli
 
 # With MCP server support
-pip install cua-cli[mcp]
+pip install --extra-index-url https://wheels.cua.ai/simple "cua-cli[mcp]"
 
 # With skills recording (VLM captioning)
-pip install cua-cli[skills]
+pip install --extra-index-url https://wheels.cua.ai/simple "cua-cli[skills]"
 
 # Full installation
-pip install cua-cli[all]
+pip install --extra-index-url https://wheels.cua.ai/simple "cua-cli[all]"
 ```
 
 ## MCP Integration

--- a/libs/python/cua-cli/README.md
+++ b/libs/python/cua-cli/README.md
@@ -107,14 +107,20 @@ Access tokens refresh automatically before authenticated `run.cua.ai` requests. 
 
 Use `cua wif-token github` from a GitHub Actions job to obtain a GitHub OIDC token for Fleets. The command runs only in GitHub Actions, requests the `fleets` audience, and prints only the raw token. It does not use the interactive `cua auth login` session.
 
+`FLEETS_TOKEN` is ephemeral and process-scoped. When it is set, it takes precedence over the interactive session for Fleet operations.
+
 ```yaml
 permissions:
   id-token: write
   contents: read
 
 steps:
-  - name: Get GitHub WIF token for Fleets
+  - name: Run a non-interactive Fleets sandbox
     run: |
-      FLEETS_TOKEN="$(cua wif-token github)"
-      test -n "$FLEETS_TOKEN"
+      export FLEETS_TOKEN="$(cua wif-token github)"
+      cua sb launch ghcr.io/trycua/mini-swe:latest --name sandbox
+      cua sb exec sandbox -- pwd
+      cua sb delete sandbox --force
 ```
+
+Use the exact GitHub-authorized sandbox name `sandbox` and the Mini SWE image `ghcr.io/trycua/mini-swe:latest`. `cua sb delete sandbox --force` releases the claim while preserving the reconciled one-replica pool, template, and namespace for the next claim.

--- a/libs/python/cua-cli/cua_cli/__init__.py
+++ b/libs/python/cua-cli/cua_cli/__init__.py
@@ -1,3 +1,3 @@
 """CUA CLI - Unified command-line interface for Computer-Use Agents."""
 
-__version__ = "0.1.13"
+__version__ = "0.1.14"

--- a/libs/python/cua-cli/cua_cli/auth/workload.py
+++ b/libs/python/cua-cli/cua_cli/auth/workload.py
@@ -1,0 +1,9 @@
+"""Workload-token authentication helpers."""
+
+import os
+
+
+def get_fleets_token() -> str | None:
+    """Return the configured Fleets workload token, if present."""
+    value = os.environ.get("FLEETS_TOKEN", "").strip()
+    return value or None

--- a/libs/python/cua-cli/cua_cli/commands/sandbox.py
+++ b/libs/python/cua-cli/cua_cli/commands/sandbox.py
@@ -946,31 +946,43 @@ def cmd_exec(args: argparse.Namespace) -> int:
         return 1
 
     async def _run() -> int:
+        from cua_sandbox import Sandbox
+
         try:
-            api_url, api_key = await _get_sandbox_api_url(args.name, local)
-        except ValueError as e:
-            print_error(str(e))
+            kwargs: dict[str, Any] = {}
+            if not local:
+                kwargs["api_key"] = await get_access_token()
+            sb = await Sandbox.connect(args.name, local=local, **kwargs)
+        except Exception as e:
+            print_error(f"Failed to connect to sandbox: {e}")
             return 1
 
-        result = await _exec_noninteractive(args.name, api_url, api_key, command)
+        try:
+            result = await sb.shell.run(command, timeout=120)
+        except Exception as e:
+            print_error(f"Failed to execute command: {e}")
+            return 1
+        finally:
+            await sb.disconnect()
 
+        output = {
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "returncode": result.returncode,
+        }
         if getattr(args, "json", False):
-            print_json(result)
-            return result.get("returncode") or result.get("return_code") or 0
+            print_json(output)
+        else:
+            stdout = result.stdout.strip()
+            stderr = result.stderr.strip()
+            if stdout:
+                print(stdout)
+            if stderr:
+                print(stderr, file=sys.stderr)
 
-        if not result.get("success", True):
-            print_error(result.get("error", "Command failed"))
+        if result.returncode != 0:
+            print_error(f"Command failed with exit code {result.returncode}")
             return 1
-
-        stdout = result.get("stdout", "").strip()
-        stderr = result.get("stderr", "").strip()
-        returncode = result.get("returncode") or result.get("return_code") or 0
-
-        if stdout:
-            print(stdout)
-        if stderr:
-            print(stderr, file=sys.stderr)
-
-        return returncode
+        return 0
 
     return run_async(_run())

--- a/libs/python/cua-cli/cua_cli/commands/sandbox.py
+++ b/libs/python/cua-cli/cua_cli/commands/sandbox.py
@@ -11,6 +11,7 @@ from typing import Any, Optional
 
 import aiohttp
 from cua_cli.auth.oidc import get_access_token
+from cua_cli.auth.workload import get_fleets_token
 from cua_cli.utils.async_utils import run_async
 from cua_cli.utils.output import (
     print_error,
@@ -158,6 +159,13 @@ async def _get_sandbox_api_url(name: str, local: bool) -> tuple[str, Optional[st
     if not url:
         raise ValueError(f"Sandbox '{name}' has no API URL (is it running?)")
     return url, api_key
+
+
+async def _cloud_auth_kwargs() -> dict[str, str]:
+    """Return cloud SDK authentication keyword arguments for the active mode."""
+    if get_fleets_token():
+        return {}
+    return {"api_key": await get_access_token()}
 
 
 # ---------------------------------------------------------------------------
@@ -442,8 +450,7 @@ def cmd_launch(args: argparse.Namespace) -> int:
                     create_kwargs["memory_mb"] = memory_mb
                 if disk_gb is not None:
                     create_kwargs["disk_gb"] = disk_gb
-                api_key = await get_access_token()
-                create_kwargs["api_key"] = api_key
+                create_kwargs.update(await _cloud_auth_kwargs())
                 sb = await Sandbox.create(image, **create_kwargs)
 
             name = sb.name
@@ -491,8 +498,7 @@ def cmd_ls(args: argparse.Namespace) -> int:
 
         if show_all or not local:
             try:
-                api_key = await get_access_token()
-                cloud_list = await Sandbox.list(local=False, api_key=api_key)
+                cloud_list = await Sandbox.list(local=False, **await _cloud_auth_kwargs())
                 for s in cloud_list:
                     results.append(
                         {
@@ -529,9 +535,7 @@ def cmd_info(args: argparse.Namespace) -> int:
         from cua_sandbox import Sandbox
 
         try:
-            kwargs: dict[str, Any] = {}
-            if not local:
-                kwargs["api_key"] = await get_access_token()
+            kwargs: dict[str, Any] = {} if local else await _cloud_auth_kwargs()
             info = await Sandbox.get_info(args.name, local=local, **kwargs)
         except Exception as e:
             print_error(str(e))
@@ -573,9 +577,7 @@ def cmd_suspend(args: argparse.Namespace) -> int:
         from cua_sandbox import Sandbox
 
         try:
-            kwargs: dict[str, Any] = {}
-            if not local:
-                kwargs["api_key"] = await get_access_token()
+            kwargs: dict[str, Any] = {} if local else await _cloud_auth_kwargs()
             await Sandbox.suspend(args.name, local=local, **kwargs)
         except Exception as e:
             print_error(f"Failed to suspend sandbox: {e}")
@@ -594,9 +596,7 @@ def cmd_resume(args: argparse.Namespace) -> int:
         from cua_sandbox import Sandbox
 
         try:
-            kwargs: dict[str, Any] = {}
-            if not local:
-                kwargs["api_key"] = await get_access_token()
+            kwargs: dict[str, Any] = {} if local else await _cloud_auth_kwargs()
             await Sandbox.resume(args.name, local=local, **kwargs)
         except Exception as e:
             print_error(f"Failed to resume sandbox: {e}")
@@ -615,9 +615,7 @@ def cmd_restart(args: argparse.Namespace) -> int:
         from cua_sandbox import Sandbox
 
         try:
-            kwargs: dict[str, Any] = {}
-            if not local:
-                kwargs["api_key"] = await get_access_token()
+            kwargs: dict[str, Any] = {} if local else await _cloud_auth_kwargs()
             await Sandbox.restart(args.name, local=local, **kwargs)
         except Exception as e:
             print_error(f"Failed to restart sandbox: {e}")
@@ -652,9 +650,7 @@ def cmd_delete(args: argparse.Namespace) -> int:
         from cua_sandbox import Sandbox
 
         try:
-            kwargs: dict[str, Any] = {}
-            if not local:
-                kwargs["api_key"] = await get_access_token()
+            kwargs: dict[str, Any] = {} if local else await _cloud_auth_kwargs()
             await Sandbox.delete(args.name, local=local, **kwargs)
         except Exception as e:
             print_error(f"Failed to delete sandbox: {e}")
@@ -673,9 +669,7 @@ def cmd_vnc(args: argparse.Namespace) -> int:
         from cua_sandbox import Sandbox
 
         try:
-            kwargs: dict[str, Any] = {}
-            if not local:
-                kwargs["api_key"] = await get_access_token()
+            kwargs: dict[str, Any] = {} if local else await _cloud_auth_kwargs()
             sb = await Sandbox.connect(args.name, local=local, **kwargs)
             vnc_url = await sb.get_display_url(share=True)
             await sb.disconnect()
@@ -949,9 +943,7 @@ def cmd_exec(args: argparse.Namespace) -> int:
         from cua_sandbox import Sandbox
 
         try:
-            kwargs: dict[str, Any] = {}
-            if not local:
-                kwargs["api_key"] = await get_access_token()
+            kwargs: dict[str, Any] = {} if local else await _cloud_auth_kwargs()
             sb = await Sandbox.connect(args.name, local=local, **kwargs)
         except Exception as e:
             print_error(f"Failed to connect to sandbox: {e}")

--- a/libs/python/cua-cli/cua_cli/commands/sandbox.py
+++ b/libs/python/cua-cli/cua_cli/commands/sandbox.py
@@ -497,6 +497,9 @@ def cmd_ls(args: argparse.Namespace) -> int:
                 pass
 
         if show_all or not local:
+            if get_fleets_token():
+                print_error("Listing Fleet sandboxes is not supported; use 'cua sb info NAME'.")
+                return 1
             try:
                 cloud_list = await Sandbox.list(local=False, **await _cloud_auth_kwargs())
                 for s in cloud_list:
@@ -974,7 +977,7 @@ def cmd_exec(args: argparse.Namespace) -> int:
 
         if result.returncode != 0:
             print_error(f"Command failed with exit code {result.returncode}")
-            return 1
+            return result.returncode
         return 0
 
     return run_async(_run())

--- a/libs/python/cua-cli/pyproject.toml
+++ b/libs/python/cua-cli/pyproject.toml
@@ -28,7 +28,7 @@ requires-python = ">=3.12,<3.14"
 
 dependencies = [
     # Sandbox lifecycle commands
-    "cua-sandbox>=0.1.27,<0.2.0",
+    "cua-sandbox>=0.1.28,<0.2.0",
     # Core CUA packages
     "cua-computer>=0.5.0",
     "cua-core>=0.3.0,<0.4.0",
@@ -115,3 +115,10 @@ ignore = ["E501"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+
+[tool.uv.sources]
+cua-sandbox = { path = "../cua-sandbox", editable = true }
+
+[[tool.uv.index]]
+name = "cua-wheels"
+url = "https://wheels.cua.ai/simple"

--- a/libs/python/cua-cli/pyproject.toml
+++ b/libs/python/cua-cli/pyproject.toml
@@ -27,6 +27,8 @@ classifiers = [
 requires-python = ">=3.12,<3.14"
 
 dependencies = [
+    # Sandbox lifecycle commands
+    "cua-sandbox>=0.1.27,<0.2.0",
     # Core CUA packages
     "cua-computer>=0.5.0",
     "cua-core>=0.3.0,<0.4.0",

--- a/libs/python/cua-cli/pyproject.toml
+++ b/libs/python/cua-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cua-cli"
-version = "0.1.13"
+version = "0.1.14"
 description = "Unified CLI for CUA - Computer-Use Agents"
 readme = "README.md"
 license = "MIT"

--- a/libs/python/cua-cli/tests/auth/test_workload.py
+++ b/libs/python/cua-cli/tests/auth/test_workload.py
@@ -1,0 +1,15 @@
+"""Tests for workload-token authentication."""
+
+from cua_cli.auth.workload import get_fleets_token
+
+
+def test_get_fleets_token_trims_value(monkeypatch):
+    monkeypatch.setenv("FLEETS_TOKEN", "  github-token  ")
+
+    assert get_fleets_token() == "github-token"
+
+
+def test_get_fleets_token_ignores_blank_value(monkeypatch):
+    monkeypatch.setenv("FLEETS_TOKEN", "  \t ")
+
+    assert get_fleets_token() is None

--- a/libs/python/cua-cli/tests/auth/test_workload.py
+++ b/libs/python/cua-cli/tests/auth/test_workload.py
@@ -1,6 +1,13 @@
 """Tests for workload-token authentication."""
 
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import cua_sandbox
 from cua_cli.auth.workload import get_fleets_token
+from cua_cli.commands import sandbox as sandbox_commands
+from cua_sandbox import Sandbox
+from cua_sandbox import _config as sandbox_config
 
 
 def test_get_fleets_token_trims_value(monkeypatch):
@@ -13,3 +20,33 @@ def test_get_fleets_token_ignores_blank_value(monkeypatch):
     monkeypatch.setenv("FLEETS_TOKEN", "  \t ")
 
     assert get_fleets_token() is None
+
+
+async def test_cli_wif_uses_local_fleet_sandbox_without_legacy_key(monkeypatch):
+    config = sandbox_config._global_config
+    original_config = vars(config).copy()
+    try:
+        for field in ("api_key", "client_id", "client_secret", "fleet_token"):
+            if hasattr(config, field):
+                setattr(config, field, None)
+        for variable in (
+            "CUA_API_KEY",
+            "CUA_CLIENT_ID",
+            "CUA_CLIENT_SECRET",
+            "CUA_FLEET_CLIENT_ID",
+            "CUA_FLEET_CLIENT_SECRET",
+        ):
+            monkeypatch.delenv(variable, raising=False)
+        monkeypatch.setenv("FLEETS_TOKEN", "integration-token")
+
+        assert Sandbox._uses_fleet(None) is True
+        local_package = Path(__file__).resolve().parents[3] / "cua-sandbox" / "cua_sandbox"
+        assert Path(cua_sandbox.__file__).resolve().is_relative_to(local_package)
+        with patch.object(
+            sandbox_commands, "get_access_token", new_callable=AsyncMock
+        ) as get_access_token:
+            assert await sandbox_commands._cloud_auth_kwargs() == {}
+        get_access_token.assert_not_awaited()
+    finally:
+        vars(config).clear()
+        vars(config).update(original_config)

--- a/libs/python/cua-cli/tests/commands/test_sandbox.py
+++ b/libs/python/cua-cli/tests/commands/test_sandbox.py
@@ -40,8 +40,8 @@ class TestRegisterParser:
         args = parser.parse_args(["sandbox", "list", "--json"])
         assert args.json is True
 
-    def test_create_command_has_required_args(self):
-        """Test that create command has required arguments."""
+    def test_launch_command_has_required_args(self):
+        """Test launch parses its image and supported options."""
         parser = argparse.ArgumentParser()
         subparsers = parser.add_subparsers()
         sandbox.register_parser(subparsers)
@@ -49,18 +49,32 @@ class TestRegisterParser:
         args = parser.parse_args(
             [
                 "sandbox",
-                "create",
-                "--os",
-                "linux",
-                "--size",
-                "medium",
+                "launch",
+                "ubuntu:24.04",
+                "--local",
+                "--name",
+                "test-sandbox",
+                "--vm",
+                "--cpu",
+                "4",
+                "--memory",
+                "8GB",
+                "--disk",
+                "50GB",
                 "--region",
                 "north-america",
+                "--json",
             ]
         )
-        assert args.os == "linux"
-        assert args.size == "medium"
+        assert args.image == "ubuntu:24.04"
+        assert args.local is True
+        assert args.name == "test-sandbox"
+        assert args.vm is True
+        assert args.cpu == 4
+        assert args.memory == "8GB"
+        assert args.disk == "50GB"
         assert args.region == "north-america"
+        assert args.json is True
 
 
 class TestExecute:
@@ -150,54 +164,130 @@ class TestCmdList:
         mock_print.assert_called_once_with(sample_vm_list)
 
 
-class TestCmdCreate:
-    """Tests for cmd_create function."""
+class TestCmdLaunch:
+    """Tests for cmd_launch function."""
 
-    def test_create_sandbox_success(self, args_namespace, mock_api_key):
-        """Test creating a sandbox successfully."""
+    def test_launch_sandbox_success(self, args_namespace, mock_api_key):
+        """Test launching a cloud sandbox through the Sandbox SDK."""
         args = args_namespace(
-            os="linux",
-            size="medium",
-            region="north-america",
+            image="ubuntu:24.04",
+            local=False,
+            name="new-sandbox",
+            vm=False,
+            cpu=None,
+            memory=None,
+            disk=None,
+            region=None,
             json=False,
         )
+        image = object()
+        created = MagicMock()
+        created.name = "new-sandbox"
+        created.disconnect = AsyncMock()
+        mock_create = AsyncMock(return_value=created)
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.create = mock_create
 
-        # Mock the API response (status 202 = provisioning)
-        async def mock_api_request(*args, **kwargs):
-            return (
-                202,
-                {
-                    "status": "provisioning",
-                    "name": "new-sandbox",
-                    "host": "sandbox.example.com",
-                },
-            )
-
-        with patch.object(sandbox, "_api_request", side_effect=mock_api_request):
-            with patch.object(sandbox, "print_info"):
-                result = sandbox.cmd_create(args)
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch.object(sandbox, "_parse_image", return_value=image):
+                with patch.object(sandbox, "print_success") as mock_success:
+                    result = sandbox.cmd_launch(args)
 
         assert result == 0
+        mock_create.assert_awaited_once_with(image, name="new-sandbox", api_key="test-access-token")
+        created.disconnect.assert_awaited_once_with()
+        mock_success.assert_called_once_with("Sandbox 'new-sandbox' is ready")
 
-    def test_create_sandbox_error(self, args_namespace, mock_api_key):
-        """Test handling create error."""
+    def test_launch_sandbox_error(self, args_namespace, mock_api_key):
+        """Test SDK launch errors return a clear failure."""
         args = args_namespace(
-            os="linux",
-            size="medium",
-            region="north-america",
+            image="ubuntu:24.04",
+            local=False,
+            name="new-sandbox",
+            vm=False,
+            cpu=None,
+            memory=None,
+            disk=None,
+            region=None,
             json=False,
         )
+        image = object()
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.create = AsyncMock(side_effect=RuntimeError("Quota exceeded"))
 
-        # Mock the API response (status 500 = error)
-        async def mock_api_request(*args, **kwargs):
-            return (500, "Quota exceeded")
-
-        with patch.object(sandbox, "_api_request", side_effect=mock_api_request):
-            with patch.object(sandbox, "print_error") as mock_error:
-                result = sandbox.cmd_create(args)
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch.object(sandbox, "_parse_image", return_value=image):
+                with patch.object(sandbox, "print_error") as mock_error:
+                    result = sandbox.cmd_launch(args)
 
         assert result == 1
-        mock_error.assert_called()
+        assert (
+            "Failed to launch sandbox: RuntimeError('Quota exceeded')"
+            in (mock_error.call_args.args[0])
+        )
+
+    def test_launch_json_output(self, args_namespace, mock_api_key):
+        """Test launch JSON output contains the sandbox name and status."""
+        args = args_namespace(
+            image="ubuntu:24.04",
+            local=False,
+            name=None,
+            vm=False,
+            cpu=None,
+            memory=None,
+            disk=None,
+            region=None,
+            json=True,
+        )
+        image = object()
+        created = MagicMock()
+        created.name = "json-sandbox"
+        created.disconnect = AsyncMock()
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.create = AsyncMock(return_value=created)
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch.object(sandbox, "_parse_image", return_value=image):
+                with patch.object(sandbox, "print_json") as mock_json:
+                    result = sandbox.cmd_launch(args)
+
+        assert result == 0
+        mock_json.assert_called_once_with({"name": "json-sandbox", "status": "ready"})
+        created.disconnect.assert_awaited_once_with()
+
+    def test_launch_local(self, args_namespace):
+        """Test --local is passed through without cloud authentication."""
+        args = args_namespace(
+            image="macos:sequoia",
+            local=True,
+            name="local-sandbox",
+            vm=False,
+            cpu=None,
+            memory=None,
+            disk=None,
+            region=None,
+            json=False,
+        )
+        image = object()
+        created = MagicMock()
+        created.name = "local-sandbox"
+        created.disconnect = AsyncMock()
+        mock_create = AsyncMock(return_value=created)
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.create = mock_create
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch.object(sandbox, "_parse_image", return_value=image):
+                with patch.object(
+                    sandbox, "get_access_token", new_callable=AsyncMock
+                ) as mock_token:
+                    with patch.object(sandbox, "print_success"):
+                        result = sandbox.cmd_launch(args)
+
+        assert result == 0
+        mock_create.assert_awaited_once_with(image, local=True, name="local-sandbox")
+        mock_token.assert_not_awaited()
+        created.disconnect.assert_awaited_once_with()
 
 
 class TestCmdGet:

--- a/libs/python/cua-cli/tests/commands/test_sandbox.py
+++ b/libs/python/cua-cli/tests/commands/test_sandbox.py
@@ -221,9 +221,8 @@ class TestCmdLaunch:
                     result = sandbox.cmd_launch(args)
 
         assert result == 1
-        assert (
-            "Failed to launch sandbox: RuntimeError('Quota exceeded')"
-            in (mock_error.call_args.args[0])
+        assert "Failed to launch sandbox: RuntimeError('Quota exceeded')" in (
+            mock_error.call_args.args[0]
         )
 
     def test_launch_json_output(self, args_namespace, mock_api_key):

--- a/libs/python/cua-cli/tests/commands/test_sandbox.py
+++ b/libs/python/cua-cli/tests/commands/test_sandbox.py
@@ -2,7 +2,7 @@
 
 import argparse
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from cua_cli.commands import sandbox
 
@@ -62,7 +62,7 @@ class TestRegisterParser:
         assert args.json is True
 
     def test_launch_command_has_required_args(self):
-        """Test launch parses its image and supported options."""
+        """Test that launch accepts its image and optional settings."""
         parser = argparse.ArgumentParser()
         subparsers = parser.add_subparsers()
         sandbox.register_parser(subparsers)
@@ -72,30 +72,15 @@ class TestRegisterParser:
                 "sandbox",
                 "launch",
                 "ubuntu:24.04",
-                "--local",
                 "--name",
                 "test-sandbox",
-                "--vm",
-                "--cpu",
-                "4",
-                "--memory",
-                "8GB",
-                "--disk",
-                "50GB",
                 "--region",
                 "north-america",
-                "--json",
             ]
         )
         assert args.image == "ubuntu:24.04"
-        assert args.local is True
         assert args.name == "test-sandbox"
-        assert args.vm is True
-        assert args.cpu == 4
-        assert args.memory == "8GB"
-        assert args.disk == "50GB"
         assert args.region == "north-america"
-        assert args.json is True
 
 
 class TestExecute:
@@ -107,7 +92,7 @@ class TestExecute:
             command="sandbox", sandbox_command="list", json=False, show_passwords=False
         )
 
-        with patch.object(sandbox, "cmd_list", return_value=0) as mock_cmd:
+        with patch.object(sandbox, "cmd_ls", return_value=0) as mock_cmd:
             result = sandbox.execute(args)
 
         mock_cmd.assert_called_once_with(args)
@@ -117,7 +102,7 @@ class TestExecute:
         """Test dispatch to list command via ls alias."""
         args = args_namespace(command="sb", sandbox_command="ls", json=False, show_passwords=False)
 
-        with patch.object(sandbox, "cmd_list", return_value=0) as mock_cmd:
+        with patch.object(sandbox, "cmd_ls", return_value=0) as mock_cmd:
             sandbox.execute(args)
 
         mock_cmd.assert_called_once_with(args)
@@ -133,73 +118,86 @@ class TestExecute:
         mock_error.assert_called()
 
 
-class TestCmdList:
-    """Tests for cmd_list function."""
+class TestCmdLs:
+    """Tests for cmd_ls function."""
 
-    def test_list_sandboxes_success(self, args_namespace, sample_vm_list, mock_api_key):
-        """Test listing sandboxes successfully."""
-        args = args_namespace(json=False, show_passwords=False)
+    def test_ls_cloud_sandboxes(self, args_namespace, mock_api_key):
+        """Test the default list path uses the cloud Fleet SDK."""
+        args = args_namespace(json=False, local=False, all=False)
+        cloud_sandboxes = [SimpleNamespace(name="cloudbox", status="running")]
+        mock_list = AsyncMock(return_value=cloud_sandboxes)
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.list = mock_list
 
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.list_vms = AsyncMock(return_value=sample_vm_list)
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "print_table") as mock_print:
-                result = sandbox.cmd_list(args)
-
-        assert result == 0
-        mock_print.assert_called_once()
-
-    def test_list_sandboxes_empty(self, args_namespace, mock_api_key):
-        """Test listing when no sandboxes exist."""
-        args = args_namespace(json=False, show_passwords=False)
-
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.list_vms = AsyncMock(return_value=[])
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "print_info") as mock_print:
-                result = sandbox.cmd_list(args)
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch.object(sandbox, "print_table") as mock_table:
+                result = sandbox.cmd_ls(args)
 
         assert result == 0
-        mock_print.assert_called_with("No sandboxes found.")
+        mock_list.assert_awaited_once_with(local=False, api_key="test-access-token")
+        mock_table.assert_called_once_with(
+            [{"name": "cloudbox", "status": "running", "source": "cloud"}],
+            [("name", "NAME"), ("status", "STATUS"), ("source", "SOURCE")],
+        )
 
-    def test_list_sandboxes_json_output(self, args_namespace, sample_vm_list, mock_api_key):
-        """Test JSON output format."""
-        args = args_namespace(json=True, show_passwords=False)
+    def test_ls_local_sandboxes(self, args_namespace):
+        """Test --local lists only local sandboxes without cloud auth."""
+        args = args_namespace(json=False, local=True, all=False)
+        local_sandboxes = [SimpleNamespace(name="localbox", status="running", source="local")]
+        mock_list = AsyncMock(return_value=local_sandboxes)
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.list = mock_list
 
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.list_vms = AsyncMock(return_value=sample_vm_list)
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "print_json") as mock_print:
-                result = sandbox.cmd_list(args)
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch.object(sandbox, "get_access_token", new_callable=AsyncMock) as mock_token:
+                with patch.object(sandbox, "print_table"):
+                    result = sandbox.cmd_ls(args)
 
         assert result == 0
-        mock_print.assert_called_once_with(sample_vm_list)
+        mock_list.assert_awaited_once_with(local=True)
+        mock_token.assert_not_awaited()
+
+    def test_ls_all_json(self, args_namespace, mock_api_key):
+        """Test --all combines local and cloud results in JSON output."""
+        args = args_namespace(json=True, local=False, all=True)
+        local_sandboxes = [SimpleNamespace(name="localbox", status="running", source="local")]
+        cloud_sandboxes = [SimpleNamespace(name="cloudbox", status="pending")]
+        mock_list = AsyncMock(side_effect=[local_sandboxes, cloud_sandboxes])
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.list = mock_list
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch.object(sandbox, "print_json") as mock_json:
+                result = sandbox.cmd_ls(args)
+
+        assert result == 0
+        assert mock_list.await_args_list == [
+            call(local=True),
+            call(local=False, api_key="test-access-token"),
+        ]
+        mock_json.assert_called_once_with(
+            [
+                {"name": "localbox", "status": "running", "source": "local"},
+                {"name": "cloudbox", "status": "pending", "source": "cloud"},
+            ]
+        )
 
 
 class TestCmdLaunch:
     """Tests for cmd_launch function."""
 
-    def test_launch_sandbox_success(self, args_namespace, mock_api_key):
-        """Test launching a cloud sandbox through the Sandbox SDK."""
+    def test_launch_cloud_with_options(self, args_namespace, mock_api_key):
+        """Test cloud launch forwards resource and image options to Fleet."""
         args = args_namespace(
             image="ubuntu:24.04",
             local=False,
             name="new-sandbox",
-            vm=False,
-            cpu=None,
-            memory=None,
-            disk=None,
-            region=None,
-            json=False,
+            vm=True,
+            cpu=4,
+            memory="8GB",
+            disk="50GB",
+            region="us-east",
+            json=True,
         )
         image = object()
         created = MagicMock()
@@ -210,73 +208,26 @@ class TestCmdLaunch:
         mock_sdk.Sandbox.create = mock_create
 
         with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
-            with patch.object(sandbox, "_parse_image", return_value=image):
-                with patch.object(sandbox, "print_success") as mock_success:
-                    result = sandbox.cmd_launch(args)
-
-        assert result == 0
-        mock_create.assert_awaited_once_with(image, name="new-sandbox", api_key="test-access-token")
-        created.disconnect.assert_awaited_once_with()
-        mock_success.assert_called_once_with("Sandbox 'new-sandbox' is ready")
-
-    def test_launch_sandbox_error(self, args_namespace, mock_api_key):
-        """Test SDK launch errors return a clear failure."""
-        args = args_namespace(
-            image="ubuntu:24.04",
-            local=False,
-            name="new-sandbox",
-            vm=False,
-            cpu=None,
-            memory=None,
-            disk=None,
-            region=None,
-            json=False,
-        )
-        image = object()
-        mock_sdk = MagicMock()
-        mock_sdk.Sandbox.create = AsyncMock(side_effect=RuntimeError("Quota exceeded"))
-
-        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
-            with patch.object(sandbox, "_parse_image", return_value=image):
-                with patch.object(sandbox, "print_error") as mock_error:
-                    result = sandbox.cmd_launch(args)
-
-        assert result == 1
-        assert "Failed to launch sandbox: RuntimeError('Quota exceeded')" in (
-            mock_error.call_args.args[0]
-        )
-
-    def test_launch_json_output(self, args_namespace, mock_api_key):
-        """Test launch JSON output contains the sandbox name and status."""
-        args = args_namespace(
-            image="ubuntu:24.04",
-            local=False,
-            name=None,
-            vm=False,
-            cpu=None,
-            memory=None,
-            disk=None,
-            region=None,
-            json=True,
-        )
-        image = object()
-        created = MagicMock()
-        created.name = "json-sandbox"
-        created.disconnect = AsyncMock()
-        mock_sdk = MagicMock()
-        mock_sdk.Sandbox.create = AsyncMock(return_value=created)
-
-        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
-            with patch.object(sandbox, "_parse_image", return_value=image):
+            with patch.object(sandbox, "_parse_image", return_value=image) as mock_parse:
                 with patch.object(sandbox, "print_json") as mock_json:
                     result = sandbox.cmd_launch(args)
 
         assert result == 0
-        mock_json.assert_called_once_with({"name": "json-sandbox", "status": "ready"})
+        mock_parse.assert_called_once_with("ubuntu:24.04", vm=True)
+        mock_create.assert_awaited_once_with(
+            image,
+            name="new-sandbox",
+            region="us-east",
+            cpu=4,
+            memory_mb=8192,
+            disk_gb=50,
+            api_key="test-access-token",
+        )
         created.disconnect.assert_awaited_once_with()
+        mock_json.assert_called_once_with({"name": "new-sandbox", "status": "ready"})
 
     def test_launch_local(self, args_namespace):
-        """Test --local is passed through without cloud authentication."""
+        """Test --local launches through Fleet without cloud authentication."""
         args = args_namespace(
             image="macos:sequoia",
             local=True,
@@ -301,13 +252,14 @@ class TestCmdLaunch:
                 with patch.object(
                     sandbox, "get_access_token", new_callable=AsyncMock
                 ) as mock_token:
-                    with patch.object(sandbox, "print_success"):
+                    with patch.object(sandbox, "print_success") as mock_success:
                         result = sandbox.cmd_launch(args)
 
         assert result == 0
         mock_create.assert_awaited_once_with(image, local=True, name="local-sandbox")
         mock_token.assert_not_awaited()
         created.disconnect.assert_awaited_once_with()
+        mock_success.assert_called_once_with("Sandbox 'local-sandbox' is ready")
 
 
     def test_launch_with_wif_omits_legacy_key_and_interactive_token(self, args_namespace, monkeypatch):
@@ -338,111 +290,70 @@ class TestCmdLaunch:
         mock_create.assert_awaited_once_with(image, name="fleet-sandbox")
         created.disconnect.assert_awaited_once_with()
 
-class TestCmdGet:
-    """Tests for cmd_get function."""
+class TestCmdInfo:
+    """Tests for cmd_info function."""
 
-    def test_get_sandbox_success(self, args_namespace, sample_vm, mock_api_key):
-        """Test getting sandbox details."""
-        args = args_namespace(
-            name="test-sandbox-1",
-            json=False,
-            show_passwords=False,
-            show_vnc_url=False,
+    def test_info_cloud_json(self, args_namespace, mock_api_key):
+        """Test cloud info uses Fleet and renders all available JSON fields."""
+        args = args_namespace(name="cloudbox", local=False, json=True)
+        info = SimpleNamespace(
+            name="cloudbox",
+            status="running",
+            os_type="linux",
+            host="cloudbox.example.com",
+            region="us-east",
+            created_at="2026-08-06T00:00:00Z",
+            cpu=4,
+            memory_mb=8192,
+            disk_gb=50,
+        )
+        mock_get_info = AsyncMock(return_value=info)
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.get_info = mock_get_info
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch.object(sandbox, "print_json") as mock_json:
+                result = sandbox.cmd_info(args)
+
+        assert result == 0
+        mock_get_info.assert_awaited_once_with("cloudbox", local=False, api_key="test-access-token")
+        mock_json.assert_called_once_with(
+            {
+                "name": "cloudbox",
+                "status": "running",
+                "os_type": "linux",
+                "host": "cloudbox.example.com",
+                "region": "us-east",
+                "created_at": "2026-08-06T00:00:00Z",
+                "cpu": 4,
+                "memory_mb": 8192,
+                "disk_gb": 50,
+            }
         )
 
-        vm_dict = {
-            "name": sample_vm.name,
-            "status": sample_vm.status,
-            "os_type": sample_vm.os_type,
-            "host": "sandbox.example.com",
-        }
-
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.list_vms = AsyncMock(return_value=[vm_dict])
-        mock_provider.get_vm = AsyncMock(return_value={"status": "running"})
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "print_info"):
-                result = sandbox.cmd_get(args)
-
-        assert result == 0
-
-    def test_get_sandbox_not_found(self, args_namespace, mock_api_key):
-        """Test getting nonexistent sandbox."""
-        args = args_namespace(
-            name="nonexistent",
-            json=False,
-            show_passwords=False,
-            show_vnc_url=False,
+    def test_info_local(self, args_namespace):
+        """Test --local gets sandbox info without cloud authentication."""
+        args = args_namespace(name="localbox", local=True, json=False)
+        info = SimpleNamespace(
+            name="localbox",
+            status="running",
+            os_type="macos",
+            host=None,
+            region=None,
+            created_at=None,
         )
+        mock_get_info = AsyncMock(return_value=info)
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.get_info = mock_get_info
 
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.list_vms = AsyncMock(return_value=[])
-        mock_provider.get_vm = AsyncMock(return_value={"status": "not_found"})
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "print_error") as mock_error:
-                result = sandbox.cmd_get(args)
-
-        assert result == 1
-        mock_error.assert_called()
-
-
-class TestCmdStart:
-    """Tests for cmd_start function."""
-
-    def test_start_sandbox_success(self, args_namespace, mock_api_key):
-        """Test starting a sandbox."""
-        args = args_namespace(name="test-sandbox")
-
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.run_vm = AsyncMock(return_value={"status": "starting"})
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "print_success"):
-                result = sandbox.cmd_start(args)
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch.object(sandbox, "get_access_token", new_callable=AsyncMock) as mock_token:
+                with patch.object(sandbox, "print_info"):
+                    result = sandbox.cmd_info(args)
 
         assert result == 0
-
-    def test_start_sandbox_not_found(self, args_namespace, mock_api_key):
-        """Test starting nonexistent sandbox."""
-        args = args_namespace(name="nonexistent")
-
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.run_vm = AsyncMock(return_value={"status": "not_found"})
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "print_error"):
-                result = sandbox.cmd_start(args)
-
-        assert result == 1
-
-
-class TestCmdStop:
-    """Tests for cmd_stop function."""
-
-    def test_stop_sandbox_success(self, args_namespace, mock_api_key):
-        """Test stopping a sandbox."""
-        args = args_namespace(name="test-sandbox")
-
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.stop_vm = AsyncMock(return_value={"status": "stopping"})
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "print_success"):
-                result = sandbox.cmd_stop(args)
-
-        assert result == 0
+        mock_get_info.assert_awaited_once_with("localbox", local=True)
+        mock_token.assert_not_awaited()
 
 
 class TestCmdRestart:
@@ -499,19 +410,61 @@ class TestCmdSuspend:
 class TestCmdDelete:
     """Tests for cmd_delete function."""
 
-    def test_delete_sandbox_success(self, args_namespace, mock_api_key):
-        """Test deleting a sandbox."""
-        args = args_namespace(name="test-sandbox")
+    def test_delete_force_cloud(self, args_namespace, mock_api_key):
+        """Test --force deletes a cloud sandbox without prompting."""
+        args = args_namespace(name="cloudbox", local=False, force=True)
+        mock_delete = AsyncMock()
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.delete = mock_delete
 
-        # Mock the API response (status 202 = deleting)
-        async def mock_api_request(*args, **kwargs):
-            return (202, {"status": "deleting"})
-
-        with patch.object(sandbox, "_api_request", side_effect=mock_api_request):
-            with patch.object(sandbox, "print_success"):
-                result = sandbox.cmd_delete(args)
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch("builtins.input") as mock_input:
+                with patch.object(sandbox, "print_success") as mock_success:
+                    result = sandbox.cmd_delete(args)
 
         assert result == 0
+        mock_input.assert_not_called()
+        mock_delete.assert_awaited_once_with("cloudbox", local=False, api_key="test-access-token")
+        mock_success.assert_called_once_with("Sandbox 'cloudbox' is being deleted.")
+
+    def test_delete_confirmation_aborts(self, args_namespace):
+        """Test declining interactive confirmation does not call Fleet."""
+        args = args_namespace(name="cloudbox", local=False, force=False)
+        mock_delete = AsyncMock()
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.delete = mock_delete
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch("sys.stdin") as mock_stdin:
+                mock_stdin.isatty.return_value = True
+                with patch("builtins.input", return_value="n"):
+                    with patch.object(sandbox, "print_info") as mock_info:
+                        result = sandbox.cmd_delete(args)
+
+        assert result == 0
+        mock_delete.assert_not_awaited()
+        mock_info.assert_called_once_with("Aborted.")
+
+    def test_delete_confirmed_local(self, args_namespace):
+        """Test confirming a local delete avoids cloud authentication."""
+        args = args_namespace(name="localbox", local=True, force=False)
+        mock_delete = AsyncMock()
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.delete = mock_delete
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch("sys.stdin") as mock_stdin:
+                mock_stdin.isatty.return_value = True
+                with patch("builtins.input", return_value="yes"):
+                    with patch.object(
+                        sandbox, "get_access_token", new_callable=AsyncMock
+                    ) as mock_token:
+                        with patch.object(sandbox, "print_success"):
+                            result = sandbox.cmd_delete(args)
+
+        assert result == 0
+        mock_delete.assert_awaited_once_with("localbox", local=True)
+        mock_token.assert_not_awaited()
 
 
     def test_delete_with_wif_omits_legacy_key_and_interactive_token(

--- a/libs/python/cua-cli/tests/commands/test_sandbox.py
+++ b/libs/python/cua-cli/tests/commands/test_sandbox.py
@@ -1,6 +1,7 @@
 """Tests for sandbox command module."""
 
 import argparse
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from cua_cli.commands import sandbox
@@ -635,11 +636,7 @@ class TestCmdExec:
         assert args.exec_command == ["echo", "hello"]
 
     def test_exec_with_json_flag(self):
-        """Test exec command with --json flag.
-
-        --json must come before name due to argparse REMAINDER behavior.
-        Usage: cua sb exec --json mybox <command...>
-        """
+        """Test exec command with --json before the remainder arguments."""
         parser = argparse.ArgumentParser()
         subparsers = parser.add_subparsers()
         sandbox.register_parser(subparsers)
@@ -649,112 +646,163 @@ class TestCmdExec:
         assert args.name == "my-sandbox"
         assert args.exec_command == ["echo", "hello"]
 
-    def test_exec_no_command_error(self, args_namespace, mock_api_key):
-        """Test exec with no command returns error."""
-        args = args_namespace(
-            name="test-sandbox",
-            exec_command=[],
-            json=False,
-        )
+    def test_exec_no_command_error(self, args_namespace):
+        """Test exec with no command returns an error."""
+        args = args_namespace(name="test-sandbox", exec_command=[], json=False, local=False)
 
         with patch.object(sandbox, "print_error") as mock_error:
             result = sandbox.cmd_exec(args)
 
         assert result == 1
-        mock_error.assert_called_with("No command provided")
+        mock_error.assert_called_once_with("No command provided")
 
-    def test_exec_sandbox_not_found(self, args_namespace, mock_api_key):
-        """Test exec with nonexistent sandbox."""
-        args = args_namespace(
-            name="nonexistent",
-            exec_command=["echo", "hello"],
-            json=False,
-        )
-
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.get_vm = AsyncMock(return_value={"status": "not_found"})
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "print_error") as mock_error:
-                result = sandbox.cmd_exec(args)
-
-        assert result == 1
-        mock_error.assert_called()
-
-    def test_exec_success(self, args_namespace, mock_api_key, capsys):
-        """Test successful command execution."""
+    def test_exec_success_uses_sandbox_shell(self, args_namespace, mock_api_key, capsys):
+        """Test successful execution uses the Fleet-backed shell interface."""
         args = args_namespace(
             name="test-sandbox",
             exec_command=["echo", "hello"],
             json=False,
+            local=False,
         )
+        command_result = SimpleNamespace(stdout="hello\n", stderr="", returncode=0)
+        mock_sandbox = MagicMock()
+        mock_sandbox.shell.run = AsyncMock(return_value=command_result)
+        mock_sandbox.disconnect = AsyncMock()
+        mock_connect = AsyncMock(return_value=mock_sandbox)
+        mock_sandbox_sdk = MagicMock()
+        mock_sandbox_sdk.Sandbox.connect = mock_connect
 
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.get_vm = AsyncMock(
-            return_value={"status": "running", "api_url": "https://sandbox.example.com:8443"}
-        )
-
-        async def mock_exec(*a, **kw):
-            return {"success": True, "stdout": "hello\n", "stderr": "", "returncode": 0}
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "_exec_noninteractive", side_effect=mock_exec):
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sandbox_sdk}):
+            with patch.object(
+                sandbox,
+                "_get_sandbox_api_url",
+                side_effect=AssertionError("legacy resolver must not be used"),
+            ) as mock_legacy_resolver:
                 result = sandbox.cmd_exec(args)
 
         assert result == 0
-        captured = capsys.readouterr()
-        assert "hello" in captured.out
+        mock_connect.assert_awaited_once_with(
+            "test-sandbox", local=False, api_key="test-access-token"
+        )
+        mock_sandbox.shell.run.assert_awaited_once_with("echo hello", timeout=120)
+        mock_sandbox.disconnect.assert_awaited_once_with()
+        mock_legacy_resolver.assert_not_called()
+        assert capsys.readouterr().out == "hello\n"
 
     def test_exec_json_output(self, args_namespace, mock_api_key):
-        """Test exec with JSON output."""
+        """Test JSON output uses CommandResult fields."""
         args = args_namespace(
             name="test-sandbox",
             exec_command=["echo", "hello"],
             json=True,
+            local=False,
         )
+        command_result = SimpleNamespace(stdout="hello\n", stderr="", returncode=0)
+        mock_sandbox = MagicMock()
+        mock_sandbox.shell.run = AsyncMock(return_value=command_result)
+        mock_sandbox.disconnect = AsyncMock()
+        mock_sandbox_sdk = MagicMock()
+        mock_sandbox_sdk.Sandbox.connect = AsyncMock(return_value=mock_sandbox)
 
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.get_vm = AsyncMock(
-            return_value={"status": "running", "api_url": "https://sandbox.example.com:8443"}
-        )
-
-        async def mock_exec(*a, **kw):
-            return {"success": True, "stdout": "hello\n", "stderr": "", "returncode": 0}
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "_exec_noninteractive", side_effect=mock_exec):
-                with patch.object(sandbox, "print_json") as mock_json:
-                    result = sandbox.cmd_exec(args)
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sandbox_sdk}):
+            with patch.object(sandbox, "print_json") as mock_json:
+                result = sandbox.cmd_exec(args)
 
         assert result == 0
-        mock_json.assert_called_once()
+        mock_json.assert_called_once_with({"stdout": "hello\n", "stderr": "", "returncode": 0})
+        mock_sandbox.disconnect.assert_awaited_once_with()
 
     def test_exec_command_failure(self, args_namespace, mock_api_key, capsys):
-        """Test exec when command returns non-zero exit code."""
+        """Test a non-zero command result returns a clear failure."""
         args = args_namespace(
             name="test-sandbox",
             exec_command=["false"],
             json=False,
+            local=False,
         )
+        command_result = SimpleNamespace(stdout="", stderr="command failed\n", returncode=7)
+        mock_sandbox = MagicMock()
+        mock_sandbox.shell.run = AsyncMock(return_value=command_result)
+        mock_sandbox.disconnect = AsyncMock()
+        mock_sandbox_sdk = MagicMock()
+        mock_sandbox_sdk.Sandbox.connect = AsyncMock(return_value=mock_sandbox)
 
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.get_vm = AsyncMock(
-            return_value={"status": "running", "api_url": "https://sandbox.example.com:8443"}
-        )
-
-        async def mock_exec(*a, **kw):
-            return {"success": True, "stdout": "", "stderr": "error", "returncode": 1}
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
-            with patch.object(sandbox, "_exec_noninteractive", side_effect=mock_exec):
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sandbox_sdk}):
+            with patch.object(sandbox, "print_error") as mock_error:
                 result = sandbox.cmd_exec(args)
 
         assert result == 1
+        mock_error.assert_called_once_with("Command failed with exit code 7")
+        assert capsys.readouterr().err == "command failed\n"
+        mock_sandbox.disconnect.assert_awaited_once_with()
+
+    def test_exec_sandbox_not_found(self, args_namespace, mock_api_key):
+        """Test a nonexistent sandbox returns a connection error."""
+        args = args_namespace(
+            name="missing-sandbox",
+            exec_command=["echo", "hello"],
+            json=False,
+            local=False,
+        )
+        mock_sandbox_sdk = MagicMock()
+        mock_sandbox_sdk.Sandbox.connect = AsyncMock(
+            side_effect=ValueError("Sandbox 'missing-sandbox' not found")
+        )
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sandbox_sdk}):
+            with patch.object(sandbox, "print_error") as mock_error:
+                result = sandbox.cmd_exec(args)
+
+        assert result == 1
+        mock_error.assert_called_once_with(
+            "Failed to connect to sandbox: Sandbox 'missing-sandbox' not found"
+        )
+
+    def test_exec_connection_failure(self, args_namespace, mock_api_key):
+        """Test a transport connection failure returns a clear error."""
+        args = args_namespace(
+            name="test-sandbox",
+            exec_command=["echo", "hello"],
+            json=False,
+            local=False,
+        )
+        mock_sandbox_sdk = MagicMock()
+        mock_sandbox_sdk.Sandbox.connect = AsyncMock(
+            side_effect=RuntimeError("Fleet service unavailable")
+        )
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sandbox_sdk}):
+            with patch.object(sandbox, "print_error") as mock_error:
+                result = sandbox.cmd_exec(args)
+
+        assert result == 1
+        mock_error.assert_called_once_with(
+            "Failed to connect to sandbox: Fleet service unavailable"
+        )
+
+    def test_exec_local_mode(self, args_namespace, capsys):
+        """Test local mode connects without requesting cloud authentication."""
+        args = args_namespace(
+            name="local-sandbox",
+            exec_command=["pwd"],
+            json=False,
+            local=True,
+        )
+        command_result = SimpleNamespace(stdout="/workspace\n", stderr="", returncode=0)
+        mock_sandbox = MagicMock()
+        mock_sandbox.shell.run = AsyncMock(return_value=command_result)
+        mock_sandbox.disconnect = AsyncMock()
+        mock_connect = AsyncMock(return_value=mock_sandbox)
+        mock_sandbox_sdk = MagicMock()
+        mock_sandbox_sdk.Sandbox.connect = mock_connect
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sandbox_sdk}):
+            with patch.object(sandbox, "get_access_token", new_callable=AsyncMock) as mock_token:
+                result = sandbox.cmd_exec(args)
+
+        assert result == 0
+        mock_token.assert_not_awaited()
+        mock_connect.assert_awaited_once_with("local-sandbox", local=True)
+        mock_sandbox.shell.run.assert_awaited_once_with("pwd", timeout=120)
+        mock_sandbox.disconnect.assert_awaited_once_with()
+        assert capsys.readouterr().out == "/workspace\n"

--- a/libs/python/cua-cli/tests/commands/test_sandbox.py
+++ b/libs/python/cua-cli/tests/commands/test_sandbox.py
@@ -140,6 +140,22 @@ class TestCmdLs:
             [("name", "NAME"), ("status", "STATUS"), ("source", "SOURCE")],
         )
 
+    def test_ls_wif_requires_exact_sandbox_name(self, args_namespace, monkeypatch):
+        args = args_namespace(json=False, local=False, all=False)
+        monkeypatch.setenv("FLEETS_TOKEN", "github-token")
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.list = AsyncMock()
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch.object(sandbox, "print_error") as mock_error:
+                result = sandbox.cmd_ls(args)
+
+        assert result == 1
+        mock_sdk.Sandbox.list.assert_not_awaited()
+        mock_error.assert_called_once_with(
+            "Listing Fleet sandboxes is not supported; use 'cua sb info NAME'."
+        )
+
     def test_ls_local_sandboxes(self, args_namespace):
         """Test --local lists only local sandboxes without cloud auth."""
         args = args_namespace(json=False, local=True, all=False)
@@ -261,13 +277,21 @@ class TestCmdLaunch:
         created.disconnect.assert_awaited_once_with()
         mock_success.assert_called_once_with("Sandbox 'local-sandbox' is ready")
 
-
-    def test_launch_with_wif_omits_legacy_key_and_interactive_token(self, args_namespace, monkeypatch):
+    def test_launch_with_wif_omits_legacy_key_and_interactive_token(
+        self, args_namespace, monkeypatch
+    ):
         """Test workload identity selects the Fleet SDK transport."""
         monkeypatch.setenv("FLEETS_TOKEN", "github-token")
         args = args_namespace(
-            image="ubuntu:24.04", local=False, name="fleet-sandbox", vm=False, cpu=None,
-            memory=None, disk=None, region=None, json=False,
+            image="ubuntu:24.04",
+            local=False,
+            name="fleet-sandbox",
+            vm=False,
+            cpu=None,
+            memory=None,
+            disk=None,
+            region=None,
+            json=False,
         )
         image = object()
         created = MagicMock(name="created")
@@ -289,6 +313,7 @@ class TestCmdLaunch:
         mock_token.assert_not_awaited()
         mock_create.assert_awaited_once_with(image, name="fleet-sandbox")
         created.disconnect.assert_awaited_once_with()
+
 
 class TestCmdInfo:
     """Tests for cmd_info function."""
@@ -474,7 +499,6 @@ class TestCmdDelete:
         mock_delete.assert_awaited_once_with("localbox", local=True)
         mock_token.assert_not_awaited()
 
-
     def test_delete_with_wif_omits_legacy_key_and_interactive_token(
         self, args_namespace, monkeypatch
     ):
@@ -486,15 +510,14 @@ class TestCmdDelete:
         mock_sdk.Sandbox.delete = mock_delete
 
         with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
-            with patch.object(
-                sandbox, "get_access_token", new_callable=AsyncMock
-            ) as mock_token:
+            with patch.object(sandbox, "get_access_token", new_callable=AsyncMock) as mock_token:
                 with patch.object(sandbox, "print_success"):
                     result = sandbox.cmd_delete(args)
 
         assert result == 0
         mock_token.assert_not_awaited()
         mock_delete.assert_awaited_once_with("fleet-sandbox", local=False)
+
 
 class TestCmdVnc:
     """Tests for cmd_vnc function."""
@@ -504,9 +527,7 @@ class TestCmdVnc:
         args = args_namespace(name="test-sandbox")
 
         mock_sandbox = MagicMock()
-        mock_sandbox.get_display_url = AsyncMock(
-            return_value="https://vnc.example.com/test"
-        )
+        mock_sandbox.get_display_url = AsyncMock(return_value="https://vnc.example.com/test")
         mock_sandbox.disconnect = AsyncMock()
         mock_connect = AsyncMock(return_value=mock_sandbox)
         mock_sdk = MagicMock()
@@ -647,9 +668,7 @@ class TestCmdShell:
             sandbox,
             "_get_sandbox_api_url",
             new_callable=AsyncMock,
-            side_effect=ValueError(
-                "Sandbox 'test-sandbox' has no API URL (is it running?)"
-            ),
+            side_effect=ValueError("Sandbox 'test-sandbox' has no API URL (is it running?)"),
         ) as mock_api_url:
             with patch.object(sandbox, "print_error") as mock_error:
                 with patch("sys.stdin") as mock_stdin:
@@ -771,7 +790,7 @@ class TestCmdExec:
             with patch.object(sandbox, "print_error") as mock_error:
                 result = sandbox.cmd_exec(args)
 
-        assert result == 1
+        assert result == 7
         mock_error.assert_called_once_with("Command failed with exit code 7")
         assert capsys.readouterr().err == "command failed\n"
         mock_sandbox.disconnect.assert_awaited_once_with()

--- a/libs/python/cua-cli/tests/commands/test_sandbox.py
+++ b/libs/python/cua-cli/tests/commands/test_sandbox.py
@@ -363,16 +363,18 @@ class TestCmdRestart:
         """Test restarting a sandbox."""
         args = args_namespace(name="test-sandbox")
 
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.restart_vm = AsyncMock(return_value={"status": "restarting"})
+        mock_restart = AsyncMock()
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.restart = mock_restart
 
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
             with patch.object(sandbox, "print_success"):
                 result = sandbox.cmd_restart(args)
 
         assert result == 0
+        mock_restart.assert_awaited_once_with(
+            "test-sandbox", local=False, api_key="test-access-token"
+        )
 
 
 class TestCmdSuspend:
@@ -382,29 +384,35 @@ class TestCmdSuspend:
         """Test suspending a sandbox."""
         args = args_namespace(name="test-sandbox")
 
-        # Mock the API response (status 202 = suspending)
-        async def mock_api_request(*args, **kwargs):
-            return (202, {"status": "suspending"})
+        mock_suspend = AsyncMock()
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.suspend = mock_suspend
 
-        with patch.object(sandbox, "_api_request", side_effect=mock_api_request):
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
             with patch.object(sandbox, "print_success"):
                 result = sandbox.cmd_suspend(args)
 
         assert result == 0
+        mock_suspend.assert_awaited_once_with(
+            "test-sandbox", local=False, api_key="test-access-token"
+        )
 
     def test_suspend_unsupported(self, args_namespace, mock_api_key):
         """Test suspend on unsupported sandbox."""
         args = args_namespace(name="test-sandbox")
 
-        # Mock the API response (status 400 = unsupported)
-        async def mock_api_request(*args, **kwargs):
-            return (400, "Suspend not supported for Windows")
+        mock_suspend = AsyncMock(side_effect=RuntimeError("Suspend not supported for Windows"))
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.suspend = mock_suspend
 
-        with patch.object(sandbox, "_api_request", side_effect=mock_api_request):
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
             with patch.object(sandbox, "print_error"):
                 result = sandbox.cmd_suspend(args)
 
         assert result == 1
+        mock_suspend.assert_awaited_once_with(
+            "test-sandbox", local=False, api_key="test-access-token"
+        )
 
 
 class TestCmdDelete:
@@ -495,63 +503,69 @@ class TestCmdVnc:
         """Test VNC opens browser with correct URL."""
         args = args_namespace(name="test-sandbox")
 
-        vm_info = {
-            "name": "test-sandbox",
-            "vnc_url": "https://vnc.example.com/test",
-        }
+        mock_sandbox = MagicMock()
+        mock_sandbox.get_display_url = AsyncMock(
+            return_value="https://vnc.example.com/test"
+        )
+        mock_sandbox.disconnect = AsyncMock()
+        mock_connect = AsyncMock(return_value=mock_sandbox)
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.connect = mock_connect
 
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.list_vms = AsyncMock(return_value=[vm_info])
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
             with patch.object(sandbox, "print_info"):
                 result = sandbox.cmd_vnc(args)
 
         assert result == 0
+        mock_connect.assert_awaited_once_with(
+            "test-sandbox", local=False, api_key="test-access-token"
+        )
+        mock_sandbox.get_display_url.assert_awaited_once_with(share=True)
+        mock_sandbox.disconnect.assert_awaited_once_with()
         mock_webbrowser.assert_called_once_with("https://vnc.example.com/test")
 
     def test_vnc_constructs_url_from_host(self, args_namespace, mock_api_key, mock_webbrowser):
-        """Test VNC constructs URL when vnc_url not provided."""
+        """Test VNC opens the display URL returned by the sandbox."""
         args = args_namespace(name="test-sandbox")
+        mock_sandbox = MagicMock()
+        mock_sandbox.get_display_url = AsyncMock(
+            return_value="https://sandbox.example.com/vnc?password=secret123"
+        )
+        mock_sandbox.disconnect = AsyncMock()
+        mock_connect = AsyncMock(return_value=mock_sandbox)
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.connect = mock_connect
 
-        vm_info = {
-            "name": "test-sandbox",
-            "host": "sandbox.example.com",
-            "password": "secret123",
-        }
-
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.list_vms = AsyncMock(return_value=[vm_info])
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
             with patch.object(sandbox, "print_info"):
                 result = sandbox.cmd_vnc(args)
 
         assert result == 0
-        mock_webbrowser.assert_called_once()
-        # Check URL contains host and encoded password
-        call_url = mock_webbrowser.call_args[0][0]
-        assert "sandbox.example.com" in call_url
-        assert "secret123" in call_url
+        mock_connect.assert_awaited_once_with(
+            "test-sandbox", local=False, api_key="test-access-token"
+        )
+        mock_sandbox.get_display_url.assert_awaited_once_with(share=True)
+        mock_sandbox.disconnect.assert_awaited_once_with()
+        mock_webbrowser.assert_called_once_with(
+            "https://sandbox.example.com/vnc?password=secret123"
+        )
 
     def test_vnc_sandbox_not_found(self, args_namespace, mock_api_key):
         """Test VNC with nonexistent sandbox."""
         args = args_namespace(name="nonexistent")
 
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.list_vms = AsyncMock(return_value=[])
+        mock_connect = AsyncMock(side_effect=ValueError("Sandbox 'nonexistent' not found"))
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.connect = mock_connect
 
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
             with patch.object(sandbox, "print_error"):
                 result = sandbox.cmd_vnc(args)
 
         assert result == 1
+        mock_connect.assert_awaited_once_with(
+            "nonexistent", local=False, api_key="test-access-token"
+        )
 
 
 class TestCmdShell:
@@ -605,18 +619,19 @@ class TestCmdShell:
             rows=None,
         )
 
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.get_vm = AsyncMock(return_value={"status": "not_found"})
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
+        with patch.object(
+            sandbox,
+            "_get_sandbox_api_url",
+            new_callable=AsyncMock,
+            side_effect=ValueError("Sandbox 'nonexistent' not found"),
+        ) as mock_api_url:
             with patch.object(sandbox, "print_error") as mock_error:
                 with patch("sys.stdin") as mock_stdin:
                     mock_stdin.isatty.return_value = False
                     result = sandbox.cmd_shell(args)
 
         assert result == 1
+        mock_api_url.assert_awaited_once_with("nonexistent", False)
         mock_error.assert_called()
 
     def test_shell_no_api_url(self, args_namespace, mock_api_key):
@@ -628,18 +643,21 @@ class TestCmdShell:
             rows=None,
         )
 
-        mock_provider = MagicMock()
-        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
-        mock_provider.__aexit__ = AsyncMock(return_value=None)
-        mock_provider.get_vm = AsyncMock(return_value={"status": "stopped", "api_url": None})
-
-        with patch.object(sandbox, "_get_provider", return_value=mock_provider):
+        with patch.object(
+            sandbox,
+            "_get_sandbox_api_url",
+            new_callable=AsyncMock,
+            side_effect=ValueError(
+                "Sandbox 'test-sandbox' has no API URL (is it running?)"
+            ),
+        ) as mock_api_url:
             with patch.object(sandbox, "print_error") as mock_error:
                 with patch("sys.stdin") as mock_stdin:
                     mock_stdin.isatty.return_value = False
                     result = sandbox.cmd_shell(args)
 
         assert result == 1
+        mock_api_url.assert_awaited_once_with("test-sandbox", False)
         mock_error.assert_called()
 
 

--- a/libs/python/cua-cli/tests/commands/test_sandbox.py
+++ b/libs/python/cua-cli/tests/commands/test_sandbox.py
@@ -7,6 +7,26 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from cua_cli.commands import sandbox
 
 
+class TestCloudAuth:
+    """Tests for cloud authentication mode selection."""
+
+    async def test_cloud_auth_kwargs_omits_legacy_key_for_wif(self, monkeypatch):
+        monkeypatch.setenv("FLEETS_TOKEN", "github-token")
+
+        with patch.object(sandbox, "get_access_token", new_callable=AsyncMock) as mock_token:
+            assert await sandbox._cloud_auth_kwargs() == {}
+
+        mock_token.assert_not_awaited()
+
+    async def test_cloud_auth_kwargs_uses_interactive_token_without_wif(self, monkeypatch):
+        monkeypatch.delenv("FLEETS_TOKEN", raising=False)
+
+        with patch.object(
+            sandbox, "get_access_token", new_callable=AsyncMock, return_value="interactive"
+        ):
+            assert await sandbox._cloud_auth_kwargs() == {"api_key": "interactive"}
+
+
 class TestRegisterParser:
     """Tests for register_parser function."""
 
@@ -290,6 +310,34 @@ class TestCmdLaunch:
         created.disconnect.assert_awaited_once_with()
 
 
+    def test_launch_with_wif_omits_legacy_key_and_interactive_token(self, args_namespace, monkeypatch):
+        """Test workload identity selects the Fleet SDK transport."""
+        monkeypatch.setenv("FLEETS_TOKEN", "github-token")
+        args = args_namespace(
+            image="ubuntu:24.04", local=False, name="fleet-sandbox", vm=False, cpu=None,
+            memory=None, disk=None, region=None, json=False,
+        )
+        image = object()
+        created = MagicMock(name="created")
+        created.name = "fleet-sandbox"
+        created.disconnect = AsyncMock()
+        mock_create = AsyncMock(return_value=created)
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.create = mock_create
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch.object(sandbox, "_parse_image", return_value=image):
+                with patch.object(
+                    sandbox, "get_access_token", new_callable=AsyncMock
+                ) as mock_token:
+                    with patch.object(sandbox, "print_success"):
+                        result = sandbox.cmd_launch(args)
+
+        assert result == 0
+        mock_token.assert_not_awaited()
+        mock_create.assert_awaited_once_with(image, name="fleet-sandbox")
+        created.disconnect.assert_awaited_once_with()
+
 class TestCmdGet:
     """Tests for cmd_get function."""
 
@@ -465,6 +513,27 @@ class TestCmdDelete:
 
         assert result == 0
 
+
+    def test_delete_with_wif_omits_legacy_key_and_interactive_token(
+        self, args_namespace, monkeypatch
+    ):
+        """Test workload identity releases the Fleet claim without an API key."""
+        monkeypatch.setenv("FLEETS_TOKEN", "github-token")
+        args = args_namespace(name="fleet-sandbox", local=False, force=True)
+        mock_delete = AsyncMock()
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.delete = mock_delete
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch.object(
+                sandbox, "get_access_token", new_callable=AsyncMock
+            ) as mock_token:
+                with patch.object(sandbox, "print_success"):
+                    result = sandbox.cmd_delete(args)
+
+        assert result == 0
+        mock_token.assert_not_awaited()
+        mock_delete.assert_awaited_once_with("fleet-sandbox", local=False)
 
 class TestCmdVnc:
     """Tests for cmd_vnc function."""
@@ -806,3 +875,35 @@ class TestCmdExec:
         mock_sandbox.shell.run.assert_awaited_once_with("pwd", timeout=120)
         mock_sandbox.disconnect.assert_awaited_once_with()
         assert capsys.readouterr().out == "/workspace\n"
+
+    def test_exec_with_wif_uses_sdk_without_legacy_auth_or_url(
+        self, args_namespace, monkeypatch, capsys
+    ):
+        """Test workload identity executes through the Fleet SDK service proxy."""
+        monkeypatch.setenv("FLEETS_TOKEN", "github-token")
+        args = args_namespace(
+            name="fleet-sandbox",
+            exec_command=["echo", "hello"],
+            json=False,
+            local=False,
+        )
+        command_result = SimpleNamespace(stdout="hello\n", stderr="", returncode=0)
+        mock_sandbox = MagicMock()
+        mock_sandbox.shell.run = AsyncMock(return_value=command_result)
+        mock_sandbox.disconnect = AsyncMock()
+        mock_connect = AsyncMock(return_value=mock_sandbox)
+        mock_sdk = MagicMock()
+        mock_sdk.Sandbox.connect = mock_connect
+
+        with patch.dict("sys.modules", {"cua_sandbox": mock_sdk}):
+            with patch.object(sandbox, "get_access_token", new_callable=AsyncMock) as mock_token:
+                with patch.object(sandbox, "_get_sandbox_api_url") as mock_api_url:
+                    result = sandbox.cmd_exec(args)
+
+        assert result == 0
+        mock_token.assert_not_awaited()
+        mock_api_url.assert_not_called()
+        mock_connect.assert_awaited_once_with("fleet-sandbox", local=False)
+        mock_sandbox.shell.run.assert_awaited_once_with("echo hello", timeout=120)
+        mock_sandbox.disconnect.assert_awaited_once_with()
+        assert capsys.readouterr().out == "hello\n"

--- a/libs/python/cua-cli/uv.lock
+++ b/libs/python/cua-cli/uv.lock
@@ -149,12 +149,74 @@ wheels = [
 ]
 
 [[package]]
+name = "automat"
+version = "25.4.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/0f/d40bbe294bbf004d436a8bcbcfaadca8b5140d39ad0ad3d73d1a8ba15f14/automat-25.4.16.tar.gz", hash = "sha256:0017591a5477066e90d26b0e696ddc143baafd87b588cfac8100bc6be9634de0", size = 129977, upload-time = "2025-04-16T20:12:16.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/ff/1175b0b7371e46244032d43a56862d0af455823b5280a50c63d99cc50f18/automat-25.4.16-py3-none-any.whl", hash = "sha256:04e9bce696a8d5671ee698005af6e5a9fa15354140a87f4870744604dcdd3ba1", size = 42842, upload-time = "2025-04-16T20:12:14.447Z" },
+]
+
+[[package]]
 name = "backoff"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
+name = "bcrypt"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386, upload-time = "2025-09-25T19:50:47.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/85/3e65e01985fddf25b64ca67275bb5bdb4040bd1a53b66d355c6c37c8a680/bcrypt-5.0.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f3c08197f3039bec79cee59a606d62b96b16669cff3949f21e74796b6e3cd2be", size = 481806, upload-time = "2025-09-25T19:49:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/44/dc/01eb79f12b177017a726cbf78330eb0eb442fae0e7b3dfd84ea2849552f3/bcrypt-5.0.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:200af71bc25f22006f4069060c88ed36f8aa4ff7f53e67ff04d2ab3f1e79a5b2", size = 268626, upload-time = "2025-09-25T19:49:06.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/cf/e82388ad5959c40d6afd94fb4743cc077129d45b952d46bdc3180310e2df/bcrypt-5.0.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:baade0a5657654c2984468efb7d6c110db87ea63ef5a4b54732e7e337253e44f", size = 271853, upload-time = "2025-09-25T19:49:08.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/86/7134b9dae7cf0efa85671651341f6afa695857fae172615e960fb6a466fa/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c58b56cdfb03202b3bcc9fd8daee8e8e9b6d7e3163aa97c631dfcfcc24d36c86", size = 269793, upload-time = "2025-09-25T19:49:09.727Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/6296688ac1b9e503d034e7d0614d56e80c5d1a08402ff856a4549cb59207/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4bfd2a34de661f34d0bda43c3e4e79df586e4716ef401fe31ea39d69d581ef23", size = 289930, upload-time = "2025-09-25T19:49:11.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/18/884a44aa47f2a3b88dd09bc05a1e40b57878ecd111d17e5bba6f09f8bb77/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ed2e1365e31fc73f1825fa830f1c8f8917ca1b3ca6185773b349c20fd606cec2", size = 272194, upload-time = "2025-09-25T19:49:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/8f/371a3ab33c6982070b674f1788e05b656cfbf5685894acbfef0c65483a59/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:83e787d7a84dbbfba6f250dd7a5efd689e935f03dd83b0f919d39349e1f23f83", size = 269381, upload-time = "2025-09-25T19:49:14.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/34/7e4e6abb7a8778db6422e88b1f06eb07c47682313997ee8a8f9352e5a6f1/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:137c5156524328a24b9fac1cb5db0ba618bc97d11970b39184c1d87dc4bf1746", size = 271750, upload-time = "2025-09-25T19:49:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f416be2499bd72123c70d98d36c6cd61a4e33d9b89562c22481c81bb30/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:38cac74101777a6a7d3b3e3cfefa57089b5ada650dce2baf0cbdd9d65db22a9e", size = 303757, upload-time = "2025-09-25T19:49:17.244Z" },
+    { url = "https://files.pythonhosted.org/packages/13/62/062c24c7bcf9d2826a1a843d0d605c65a755bc98002923d01fd61270705a/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:d8d65b564ec849643d9f7ea05c6d9f0cd7ca23bdd4ac0c2dbef1104ab504543d", size = 306740, upload-time = "2025-09-25T19:49:18.693Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c8/1fdbfc8c0f20875b6b4020f3c7dc447b8de60aa0be5faaf009d24242aec9/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:741449132f64b3524e95cd30e5cd3343006ce146088f074f31ab26b94e6c75ba", size = 334197, upload-time = "2025-09-25T19:49:20.523Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c1/8b84545382d75bef226fbc6588af0f7b7d095f7cd6a670b42a86243183cd/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:212139484ab3207b1f0c00633d3be92fef3c5f0af17cad155679d03ff2ee1e41", size = 352974, upload-time = "2025-09-25T19:49:22.254Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a6/ffb49d4254ed085e62e3e5dd05982b4393e32fe1e49bb1130186617c29cd/bcrypt-5.0.0-cp313-cp313t-win32.whl", hash = "sha256:9d52ed507c2488eddd6a95bccee4e808d3234fa78dd370e24bac65a21212b861", size = 148498, upload-time = "2025-09-25T19:49:24.134Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a9/259559edc85258b6d5fc5471a62a3299a6aa37a6611a169756bf4689323c/bcrypt-5.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f6984a24db30548fd39a44360532898c33528b74aedf81c26cf29c51ee47057e", size = 145853, upload-time = "2025-09-25T19:49:25.702Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/df/9714173403c7e8b245acf8e4be8876aac64a209d1b392af457c79e60492e/bcrypt-5.0.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9fffdb387abe6aa775af36ef16f55e318dcda4194ddbf82007a6f21da29de8f5", size = 139626, upload-time = "2025-09-25T19:49:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/84/29/6237f151fbfe295fe3e074ecc6d44228faa1e842a81f6d34a02937ee1736/bcrypt-5.0.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b", size = 494553, upload-time = "2025-09-25T19:49:49.006Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b6/4c1205dde5e464ea3bd88e8742e19f899c16fa8916fb8510a851fae985b5/bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb", size = 275009, upload-time = "2025-09-25T19:49:50.581Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/71/427945e6ead72ccffe77894b2655b695ccf14ae1866cd977e185d606dd2f/bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef", size = 278029, upload-time = "2025-09-25T19:49:52.533Z" },
+    { url = "https://files.pythonhosted.org/packages/17/72/c344825e3b83c5389a369c8a8e58ffe1480b8a699f46c127c34580c4666b/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd", size = 275907, upload-time = "2025-09-25T19:49:54.709Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7e/d4e47d2df1641a36d1212e5c0514f5291e1a956a7749f1e595c07a972038/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2b732e7d388fa22d48920baa267ba5d97cca38070b69c0e2d37087b381c681fd", size = 296500, upload-time = "2025-09-25T19:49:56.013Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c3/0ae57a68be2039287ec28bc463b82e4b8dc23f9d12c0be331f4782e19108/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464", size = 278412, upload-time = "2025-09-25T19:49:57.356Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2b/77424511adb11e6a99e3a00dcc7745034bee89036ad7d7e255a7e47be7d8/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75", size = 275486, upload-time = "2025-09-25T19:49:59.116Z" },
+    { url = "https://files.pythonhosted.org/packages/43/0a/405c753f6158e0f3f14b00b462d8bca31296f7ecfc8fc8bc7919c0c7d73a/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff", size = 277940, upload-time = "2025-09-25T19:50:00.869Z" },
+    { url = "https://files.pythonhosted.org/packages/62/83/b3efc285d4aadc1fa83db385ec64dcfa1707e890eb42f03b127d66ac1b7b/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4", size = 310776, upload-time = "2025-09-25T19:50:02.393Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/47ee337dacecde6d234890fe929936cb03ebc4c3a7460854bbd9c97780b8/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb", size = 312922, upload-time = "2025-09-25T19:50:04.232Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3a/43d494dfb728f55f4e1cf8fd435d50c16a2d75493225b54c8d06122523c6/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c", size = 341367, upload-time = "2025-09-25T19:50:05.559Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ab/a0727a4547e383e2e22a630e0f908113db37904f58719dc48d4622139b5c/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb", size = 359187, upload-time = "2025-09-25T19:50:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bb/461f352fdca663524b4643d8b09e8435b4990f17fbf4fea6bc2a90aa0cc7/bcrypt-5.0.0-cp38-abi3-win32.whl", hash = "sha256:3abeb543874b2c0524ff40c57a4e14e5d3a66ff33fb423529c88f180fd756538", size = 153752, upload-time = "2025-09-25T19:50:08.515Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/4190e60921927b7056820291f56fc57d00d04757c8b316b2d3c0d1d6da2c/bcrypt-5.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:35a77ec55b541e5e583eb3436ffbbf53b0ffa1fa16ca6782279daf95d146dcd9", size = 150881, upload-time = "2025-09-25T19:50:09.742Z" },
+    { url = "https://files.pythonhosted.org/packages/54/12/cd77221719d0b39ac0b55dbd39358db1cd1246e0282e104366ebbfb8266a/bcrypt-5.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:cde08734f12c6a4e28dc6755cd11d3bdfea608d93d958fffbe95a7026ebe4980", size = 144931, upload-time = "2025-09-25T19:50:11.016Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a", size = 495313, upload-time = "2025-09-25T19:50:12.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ee/2f4985dbad090ace5ad1f7dd8ff94477fe089b5fab2040bd784a3d5f187b/bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191", size = 275290, upload-time = "2025-09-25T19:50:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6e/b77ade812672d15cf50842e167eead80ac3514f3beacac8902915417f8b7/bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254", size = 278253, upload-time = "2025-09-25T19:50:15.089Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c4/ed00ed32f1040f7990dac7115f82273e3c03da1e1a1587a778d8cea496d8/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db", size = 276084, upload-time = "2025-09-25T19:50:16.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/fa6e16145e145e87f1fa351bbd54b429354fd72145cd3d4e0c5157cf4c70/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a71f70ee269671460b37a449f5ff26982a6f2ba493b3eabdd687b4bf35f875ac", size = 297185, upload-time = "2025-09-25T19:50:18.525Z" },
+    { url = "https://files.pythonhosted.org/packages/24/b4/11f8a31d8b67cca3371e046db49baa7c0594d71eb40ac8121e2fc0888db0/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822", size = 278656, upload-time = "2025-09-25T19:50:19.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/31/79f11865f8078e192847d2cb526e3fa27c200933c982c5b2869720fa5fce/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8", size = 275662, upload-time = "2025-09-25T19:50:21.567Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a", size = 278240, upload-time = "2025-09-25T19:50:23.305Z" },
+    { url = "https://files.pythonhosted.org/packages/89/48/44590e3fc158620f680a978aafe8f87a4c4320da81ed11552f0323aa9a57/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1", size = 311152, upload-time = "2025-09-25T19:50:24.597Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/e4fbfc46f14f47b0d20493669a625da5827d07e8a88ee460af6cd9768b44/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42", size = 313284, upload-time = "2025-09-25T19:50:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ae/479f81d3f4594456a01ea2f05b132a519eff9ab5768a70430fa1132384b1/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10", size = 341643, upload-time = "2025-09-25T19:50:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d2/36a086dee1473b14276cd6ea7f61aef3b2648710b5d7f1c9e032c29b859f/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172", size = 359698, upload-time = "2025-09-25T19:50:31.347Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
+    { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
 ]
 
 [[package]]
@@ -299,6 +361,15 @@ wheels = [
 ]
 
 [[package]]
+name = "constantly"
+version = "23.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/6f/cb2a94494ff74aa9528a36c5b1422756330a75a8367bf20bd63171fc324d/constantly-23.10.4.tar.gz", hash = "sha256:aa92b70a33e2ac0bb33cd745eb61776594dc48764b06c35e0efd050b7f1c7cbd", size = 13300, upload-time = "2023-10-28T23:18:24.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/40/c199d095151addf69efdb4b9ca3a4f20f70e20508d6222bffb9b76f58573/constantly-23.10.4-py3-none-any.whl", hash = "sha256:3fd9b4d1c3dc1ec9757f3c52aef7e53ad9323dbe39f51dfd4c43853b68dfa3f9", size = 13547, upload-time = "2023-10-28T23:18:23.038Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -413,13 +484,14 @@ all = [
 
 [[package]]
 name = "cua-cli"
-version = "0.1.12"
+version = "0.1.13"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "cua-auto", extra = ["all"] },
     { name = "cua-computer" },
     { name = "cua-core" },
+    { name = "cua-sandbox" },
     { name = "keyring" },
     { name = "pillow" },
     { name = "rich" },
@@ -452,6 +524,7 @@ requires-dist = [
     { name = "cua-cli", extras = ["mcp", "skills"], marker = "extra == 'all'" },
     { name = "cua-computer", specifier = ">=0.5.0" },
     { name = "cua-core", specifier = ">=0.3.0,<0.4.0" },
+    { name = "cua-sandbox", specifier = ">=0.1.27,<0.2.0" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.0" },
     { name = "keyring", specifier = ">=25.0" },
     { name = "litellm", marker = "extra == 'skills'", specifier = "==1.86.2" },
@@ -494,6 +567,40 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/82/ec371bde395bbbd326a3467a1702b34ab629defa0cc89bd81ac78507ca5a/cua_core-0.3.1.tar.gz", hash = "sha256:a8fc4204981b9d5b604bd2a34de0bb41cf926309e4dd9f364c827750a86408da", size = 10710, upload-time = "2026-04-15T21:39:49.172Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/90/5148998a26671855539e2c3a620f72ef51f83118beffdfb7e77893d4730b/cua_core-0.3.1-py3-none-any.whl", hash = "sha256:9191b8abf5e02ea6bf8ba21237e747d4e3b319f6f24d4e66e04b7606fcc449f6", size = 10239, upload-time = "2026-04-15T21:39:48.265Z" },
+]
+
+[[package]]
+name = "cua-fleet"
+version = "0.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d6/7795b42005eeedb80133175667a28a4f990e7af76318f2766e3f7ca858bf/cua_fleet-0.1.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:bce6c86535767f9e2ab547f482de1045532016d10e350076097c442eb8d56f81", size = 2115119, upload-time = "2026-08-05T21:50:23.957Z" },
+    { url = "https://files.pythonhosted.org/packages/60/82/027a3f0336ff636ff5d9b1c1bd04efac4d5b6fa53be033c6daad0f721f28/cua_fleet-0.1.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8eba5d4c24769e949845c63d4ce9a35307900d6475531781f6b2fd3a1b93e537", size = 2067024, upload-time = "2026-08-05T21:50:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/84/bb/d54656d3e5e35eaf011b7359e175fba527d8a817782c642e08b5883b8e4a/cua_fleet-0.1.6-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:07e113e0fdbcd4b554a2b3f88411ac4eb691cd1be207dc62959c4f59c19b4e1b", size = 2416978, upload-time = "2026-08-05T21:50:26.815Z" },
+    { url = "https://files.pythonhosted.org/packages/20/82/af96a15bf10b273abc669b2d1eb403286d813e1336c85806329b99a88c94/cua_fleet-0.1.6-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:ef096dd2dae312a1eca6cbf08f8e1a78e32e5a7938418831f00c16be0663f23d", size = 2358990, upload-time = "2026-08-05T21:50:28.125Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/24/488326167b4a7f41ef878d5966edd59fbec9879e7c2926edf9dcd6e03994/cua_fleet-0.1.6-py3-none-win_amd64.whl", hash = "sha256:230ebd003dee59b2d343b9ea136bd664c548afa3e5c1ad4cb44dad66b0816cea", size = 1925684, upload-time = "2026-08-05T21:50:29.42Z" },
+]
+
+[[package]]
+name = "cua-sandbox"
+version = "0.1.27"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cua-auto" },
+    { name = "cua-core" },
+    { name = "cua-fleet" },
+    { name = "grpcio" },
+    { name = "httpx" },
+    { name = "oras" },
+    { name = "paramiko" },
+    { name = "protobuf" },
+    { name = "pycdlib" },
+    { name = "vncdotool" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/04/ec0a97917d99681a5d5fb7988a90a252510bf37f1d6f84423928839042f3/cua_sandbox-0.1.27.tar.gz", hash = "sha256:6d069ff37371bf23ed7749fb3a38ab5dc925acdf17023049db26f5bf76082e6d", size = 153656, upload-time = "2026-08-05T22:13:58.952Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/80/b696fb61ef28ad00b7fb1caa787544567ea5d9d733e944a24b13f42e8efa/cua_sandbox-0.1.27-py3-none-any.whl", hash = "sha256:1bf13bb7035f516670986067d36a2ea39986b441f3cd2cf993b0e9043e092680", size = 187145, upload-time = "2026-08-05T22:13:57.829Z" },
 ]
 
 [[package]]
@@ -759,6 +866,37 @@ wheels = [
 ]
 
 [[package]]
+name = "grpcio"
+version = "1.78.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/8a/3d098f35c143a89520e568e6539cc098fcd294495910e359889ce8741c84/grpcio-1.78.0.tar.gz", hash = "sha256:7382b95189546f375c174f53a5fa873cef91c4b8005faa05cc5b3beea9c4f1c5", size = 12852416, upload-time = "2026-02-06T09:57:18.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/f4/7384ed0178203d6074446b3c4f46c90a22ddf7ae0b3aee521627f54cfc2a/grpcio-1.78.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:f9ab915a267fc47c7e88c387a3a28325b58c898e23d4995f765728f4e3dedb97", size = 5913985, upload-time = "2026-02-06T09:55:26.832Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ed/be1caa25f06594463f685b3790b320f18aea49b33166f4141bfdc2bfb236/grpcio-1.78.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3f8904a8165ab21e07e58bf3e30a73f4dffc7a1e0dbc32d51c61b5360d26f43e", size = 11811853, upload-time = "2026-02-06T09:55:29.224Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a7/f06d151afc4e64b7e3cc3e872d331d011c279aaab02831e40a81c691fb65/grpcio-1.78.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:859b13906ce098c0b493af92142ad051bf64c7870fa58a123911c88606714996", size = 6475766, upload-time = "2026-02-06T09:55:31.825Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a8/4482922da832ec0082d0f2cc3a10976d84a7424707f25780b82814aafc0a/grpcio-1.78.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b2342d87af32790f934a79c3112641e7b27d63c261b8b4395350dad43eff1dc7", size = 7170027, upload-time = "2026-02-06T09:55:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bf/f4a3b9693e35d25b24b0b39fa46d7d8a3c439e0a3036c3451764678fec20/grpcio-1.78.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:12a771591ae40bc65ba67048fa52ef4f0e6db8279e595fd349f9dfddeef571f9", size = 6690766, upload-time = "2026-02-06T09:55:36.902Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b9/521875265cc99fe5ad4c5a17010018085cae2810a928bf15ebe7d8bcd9cc/grpcio-1.78.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:185dea0d5260cbb2d224c507bf2a5444d5abbb1fa3594c1ed7e4c709d5eb8383", size = 7266161, upload-time = "2026-02-06T09:55:39.824Z" },
+    { url = "https://files.pythonhosted.org/packages/05/86/296a82844fd40a4ad4a95f100b55044b4f817dece732bf686aea1a284147/grpcio-1.78.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:51b13f9aed9d59ee389ad666b8c2214cc87b5de258fa712f9ab05f922e3896c6", size = 8253303, upload-time = "2026-02-06T09:55:42.353Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e4/ea3c0caf5468537f27ad5aab92b681ed7cc0ef5f8c9196d3fd42c8c2286b/grpcio-1.78.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd5f135b1bd58ab088930b3c613455796dfa0393626a6972663ccdda5b4ac6ce", size = 7698222, upload-time = "2026-02-06T09:55:44.629Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/47/7f05f81e4bb6b831e93271fb12fd52ba7b319b5402cbc101d588f435df00/grpcio-1.78.0-cp312-cp312-win32.whl", hash = "sha256:94309f498bcc07e5a7d16089ab984d42ad96af1d94b5a4eb966a266d9fcabf68", size = 4066123, upload-time = "2026-02-06T09:55:47.644Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/e7/d6914822c88aa2974dbbd10903d801a28a19ce9cd8bad7e694cbbcf61528/grpcio-1.78.0-cp312-cp312-win_amd64.whl", hash = "sha256:9566fe4ababbb2610c39190791e5b829869351d14369603702e890ef3ad2d06e", size = 4797657, upload-time = "2026-02-06T09:55:49.86Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a9/8f75894993895f361ed8636cd9237f4ab39ef87fd30db17467235ed1c045/grpcio-1.78.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:ce3a90455492bf8bfa38e56fbbe1dbd4f872a3d8eeaf7337dc3b1c8aa28c271b", size = 5920143, upload-time = "2026-02-06T09:55:52.035Z" },
+    { url = "https://files.pythonhosted.org/packages/55/06/0b78408e938ac424100100fd081189451b472236e8a3a1f6500390dc4954/grpcio-1.78.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:2bf5e2e163b356978b23652c4818ce4759d40f4712ee9ec5a83c4be6f8c23a3a", size = 11803926, upload-time = "2026-02-06T09:55:55.494Z" },
+    { url = "https://files.pythonhosted.org/packages/88/93/b59fe7832ff6ae3c78b813ea43dac60e295fa03606d14d89d2e0ec29f4f3/grpcio-1.78.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8f2ac84905d12918e4e55a16da17939eb63e433dc11b677267c35568aa63fc84", size = 6478628, upload-time = "2026-02-06T09:55:58.533Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/df/e67e3734527f9926b7d9c0dde6cd998d1d26850c3ed8eeec81297967ac67/grpcio-1.78.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b58f37edab4a3881bc6c9bca52670610e0c9ca14e2ea3cf9debf185b870457fb", size = 7173574, upload-time = "2026-02-06T09:56:01.786Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/cc03fffb07bfba982a9ec097b164e8835546980aec25ecfa5f9c1a47e022/grpcio-1.78.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:735e38e176a88ce41840c21bb49098ab66177c64c82426e24e0082500cc68af5", size = 6692639, upload-time = "2026-02-06T09:56:04.529Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9a/289c32e301b85bdb67d7ec68b752155e674ee3ba2173a1858f118e399ef3/grpcio-1.78.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2045397e63a7a0ee7957c25f7dbb36ddc110e0cfb418403d110c0a7a68a844e9", size = 7268838, upload-time = "2026-02-06T09:56:08.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/79/1be93f32add280461fa4773880196572563e9c8510861ac2da0ea0f892b6/grpcio-1.78.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a9f136fbafe7ccf4ac7e8e0c28b31066e810be52d6e344ef954a3a70234e1702", size = 8251878, upload-time = "2026-02-06T09:56:10.914Z" },
+    { url = "https://files.pythonhosted.org/packages/65/65/793f8e95296ab92e4164593674ae6291b204bb5f67f9d4a711489cd30ffa/grpcio-1.78.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:748b6138585379c737adc08aeffd21222abbda1a86a0dca2a39682feb9196c20", size = 7695412, upload-time = "2026-02-06T09:56:13.593Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9f/1e233fe697ecc82845942c2822ed06bb522e70d6771c28d5528e4c50f6a4/grpcio-1.78.0-cp313-cp313-win32.whl", hash = "sha256:271c73e6e5676afe4fc52907686670c7cea22ab2310b76a59b678403ed40d670", size = 4064899, upload-time = "2026-02-06T09:56:15.601Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/27/d86b89e36de8a951501fb06a0f38df19853210f341d0b28f83f4aa0ffa08/grpcio-1.78.0-cp313-cp313-win_amd64.whl", hash = "sha256:f2d4e43ee362adfc05994ed479334d5a451ab7bc3f3fee1b796b8ca66895acb4", size = 4797393, upload-time = "2026-02-06T09:56:17.882Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -849,6 +987,18 @@ wheels = [
 ]
 
 [[package]]
+name = "hyperlink"
+version = "21.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/51/1947bd81d75af87e3bb9e34593a4cf118115a8feb451ce7a69044ef1412e/hyperlink-21.0.0.tar.gz", hash = "sha256:427af957daa58bc909471c6c40f74c5450fa123dd093fc53efd2e91d2705a56b", size = 140743, upload-time = "2021-01-08T05:51:20.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/aa/8caf6a0a3e62863cbb9dab27135660acba46903b703e224f14f447e57934/hyperlink-21.0.0-py2.py3-none-any.whl", hash = "sha256:e6b14c37ecb73e89c77d78cdb4c2cc8f3fb59a885c5b3f819ff4ed80f25af1b4", size = 74638, upload-time = "2021-01-08T05:51:22.906Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -870,12 +1020,33 @@ wheels = [
 ]
 
 [[package]]
+name = "incremental"
+version = "24.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/3c/82e84109e02c492f382c711c58a3dd91badda6d746def81a1465f74dc9f5/incremental-24.11.0.tar.gz", hash = "sha256:87d3480dbb083c1d736222511a8cf380012a8176c2456d01ef483242abbbcf8c", size = 24000, upload-time = "2025-11-28T02:30:17.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/55/0f4df2a44053867ea9cbea73fc588b03c55605cd695cee0a3d86f0029cb2/incremental-24.11.0-py3-none-any.whl", hash = "sha256:a34450716b1c4341fe6676a0598e88a39e04189f4dce5dc96f656e040baa10b3", size = 21109, upload-time = "2025-11-28T02:30:16.442Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "invoke"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/227c48c5fe47fa178ccf1fda8f047d16c97ba926567b661e9ce2045c600c/invoke-3.0.3.tar.gz", hash = "sha256:437b6a622223824380bfb4e64f612711a6b648c795f565efc8625af66fb57f0c", size = 343419, upload-time = "2026-04-07T15:17:48.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/de/bbc12563bbf979618d17625a4e753ff7a078523e28d870d3626daa97261a/invoke-3.0.3-py3-none-any.whl", hash = "sha256:f11327165e5cbb89b2ad1d88d3292b5113332c43b8553b494da435d6ec6f5053", size = 160958, upload-time = "2026-04-07T15:17:46.875Z" },
 ]
 
 [[package]]
@@ -1299,12 +1470,40 @@ wheels = [
 ]
 
 [[package]]
+name = "oras"
+version = "0.2.43"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/d2/dc4a3eb07ac779455dbfbc85cd396025ad72450ed7673a323c685cfb6774/oras-0.2.43.tar.gz", hash = "sha256:761f2b518fce50e5e9482975363ff0230f63fc65f84c09510fbcc301782a047c", size = 59134, upload-time = "2026-08-08T15:45:53.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/66/29d7e4a4784847c370a9ed3c6d20532c05aae975ebb0d355d595d30430d6/oras-0.2.43-py3-none-any.whl", hash = "sha256:bf295b1cfb5017f579c35c3394c7a71707f6aff463cb6699d5d191a6d8b56ea6", size = 72286, upload-time = "2026-08-08T15:45:52.499Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "paramiko"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bcrypt" },
+    { name = "cryptography" },
+    { name = "invoke" },
+    { name = "pynacl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/93/dcc25d52f49022ae6175d15e6bd751f1acc99b98bc61fc55e5155a7be2e7/paramiko-5.0.0.tar.gz", hash = "sha256:36763b5b95c2a0dcfdf1abc48e48156ee425b21efe2f0e787c2dd5a95c0e5e79", size = 1548586, upload-time = "2026-05-09T18:28:52.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/5b/eadf6d45de38d30ab603f49393b6cd2cbe7e233af8cf90197e32782b68a9/paramiko-5.0.0-py3-none-any.whl", hash = "sha256:b7044611c30140d9a75261653210e2002977b71a0497ff3ba0d98d7edbf62f7c", size = 208919, upload-time = "2026-05-09T18:28:50.295Z" },
 ]
 
 [[package]]
@@ -1450,6 +1649,21 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
 name = "py-key-value-aio"
 version = "0.4.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1472,6 +1686,15 @@ keyring = [
 ]
 memory = [
     { name = "cachetools" },
+]
+
+[[package]]
+name = "pycdlib"
+version = "1.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/01/7fdd73e832b95a1b32e137be2fbeed05abef3aec527bcfebca4c313969a6/pycdlib-1.20.0.tar.gz", hash = "sha256:1d768eb491d761a3bace188270f152ef40f33fb0d3daf6cf39bc38a81272072c", size = 328278, upload-time = "2026-08-05T13:59:47.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/2e/624824081e1ceb69bcd2c3b2358d01e8ba7e7c84a0f019bf24e1e822ec01/pycdlib-1.20.0-py2.py3-none-any.whl", hash = "sha256:cb675959dd6d61e94f02560ed7e9a5d368a3188b5f7f31813bc25a750cff0863", size = 228561, upload-time = "2026-08-05T13:59:45.007Z" },
 ]
 
 [[package]]
@@ -1596,6 +1819,29 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2d/13/076a20da28b82be281f7e43e16d9da0f545090f5d14b2125699232b9feba/PyMonCtl-0.92-py3-none-any.whl", hash = "sha256:2495d8dab78f9a7dbce37e74543e60b8bd404a35c3108935697dda7768611b5a", size = 45945, upload-time = "2024-04-22T10:07:09.566Z" },
+]
+
+[[package]]
+name = "pynacl"
+version = "1.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465", size = 388458, upload-time = "2026-01-01T17:32:16.829Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/b4/e927e0653ba63b02a4ca5b4d852a8d1d678afbf69b3dbf9c4d0785ac905c/pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0", size = 800020, upload-time = "2026-01-01T17:32:18.34Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/81/d60984052df5c97b1d24365bc1e30024379b42c4edcd79d2436b1b9806f2/pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4", size = 1399174, upload-time = "2026-01-01T17:32:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87", size = 835085, upload-time = "2026-01-01T17:32:22.24Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c", size = 1437614, upload-time = "2026-01-01T17:32:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/58/fc6e649762b029315325ace1a8c6be66125e42f67416d3dbd47b69563d61/pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130", size = 818251, upload-time = "2026-01-01T17:32:25.69Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859, upload-time = "2026-01-01T17:32:27.215Z" },
+    { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926, upload-time = "2026-01-01T17:32:29.314Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101, upload-time = "2026-01-01T17:32:31.263Z" },
+    { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
 ]
 
 [[package]]
@@ -4644,6 +4890,24 @@ wheels = [
 ]
 
 [[package]]
+name = "twisted"
+version = "26.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "automat" },
+    { name = "constantly" },
+    { name = "hyperlink" },
+    { name = "incremental" },
+    { name = "typing-extensions" },
+    { name = "zope-interface" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/97/6e9beb1e78247ae6dc34114f27d538cf2cb183c4afcd3609dfdf2b0439c8/twisted-26.4.0.tar.gz", hash = "sha256:dbfd0fe1ee409d0243fdd7a6a6ff14f4948cec1fd78e0376291f805e1501fae9", size = 3575095, upload-time = "2026-05-11T11:24:51.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/57/bcf4e2370dd218c9aa68a9140a65d86729c73f1d529f7e94786c2766fc72/twisted-26.4.0-py3-none-any.whl", hash = "sha256:dc25ea0ebf6511c24f03232ee9f4afa54b291c5d897990e3a39cc4d14a1ef4c0", size = 3230362, upload-time = "2026-05-11T11:24:49.5Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.26.7"
 source = { registry = "https://pypi.org/simple" }
@@ -4708,6 +4972,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
+]
+
+[[package]]
+name = "vncdotool"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pillow" },
+    { name = "twisted" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/aa/e1ff71ffff6e52678fb4f8401fc3a7de1a09eaca2ba3be320f351ee7a91b/vncdotool-1.3.0.tar.gz", hash = "sha256:63d39b3e9d0974df7af77ed971cf141383371a5a9ccc5232bb7ad25c33298ad6", size = 57909, upload-time = "2026-04-03T13:53:21.68Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/5e/9a6f1fcf51fb63a65f35477cbb7b80bc3820d0d4d7cc2ee7263e06d1ab2c/vncdotool-1.3.0-py3-none-any.whl", hash = "sha256:0950fe66342d09df9848117627c2ca1a4c368e0e6583d39ac749741c50ac96ac", size = 35020, upload-time = "2026-04-03T13:53:20.428Z" },
 ]
 
 [[package]]
@@ -4871,4 +5149,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
+]
+
+[[package]]
+name = "zope-interface"
+version = "8.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/dc/50550cfcbb2ea3cbca5f1d7ed05c8aa840f831a0f2d63aec0a953f7c590e/zope_interface-8.5.tar.gz", hash = "sha256:7a3ba1c5877f0f3e3906b02ddf793abed2becc2948116414ce0e1dd820b68d6d", size = 257957, upload-time = "2026-05-26T06:50:14.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/cc/b84123a948f3162a34623e188922827cd845244fdd043ed20f8d02228caa/zope_interface-8.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:8e6ee90c2e6de7c37058d5fa41f123c8b13a312db8d1e0fb5840d7f4bcdff9c9", size = 212165, upload-time = "2026-05-26T06:49:26.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/cbceec44f1b27208a76c1a688c131302685852406a23df5aab68324109cc/zope_interface-8.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c1adc90d3576b3b4c4de4953e6002c37bef28b78d7fa54c1bbfd0c50f022fe7c", size = 212341, upload-time = "2026-05-26T06:49:28.182Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c3/005032195ff3b210c139b7c560ed5c534e844b0907d8e44d2b3d8919305e/zope_interface-8.5-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:e6347b8d8d12c5eca6502450a92be30079b7acfade2c4f693efa0deb8871b06e", size = 265296, upload-time = "2026-05-26T06:49:29.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/66/1036543d6a66bc04c19df3cf650f3ad938a002ab0a443c24e23e8de5e8b9/zope_interface-8.5-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5e970dabea777a24b0b0bbf9dae3ab75ce8b2d8e948edf4875627034b21f3560", size = 270689, upload-time = "2026-05-26T06:49:31.767Z" },
+    { url = "https://files.pythonhosted.org/packages/30/4c/8b56259558cace4414e753ca6740396a1f59d4a95ddb55b4658600408670/zope_interface-8.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f0b48ccadaa9839e09ff81e969703cecb3f402c813bfe8b958652e699bea69f5", size = 270280, upload-time = "2026-05-26T06:49:33.489Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ea/649908c83aa8fdb7faf2ddca4d3cf6fb8f2157121267dc56e8f72681e26c/zope_interface-8.5-cp312-cp312-win_amd64.whl", hash = "sha256:e0e311f1277468c08fd59a2b41f71b43d25dff639789d364747acd1705c0df6e", size = 215019, upload-time = "2026-05-26T06:49:35.607Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/97/da13037b4c563e4df32eedbc819f8c00b754af494f68211e3dffd48d52da/zope_interface-8.5-cp312-cp312-win_arm64.whl", hash = "sha256:652b73107a04159ec6c020db6c1543d4f1e8f4d069bd2aac88a947820923517b", size = 213569, upload-time = "2026-05-26T06:49:37.317Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/8c/4c15755d701f2ec0e80d64a18e1ebaf5be2c584c0ec153fd516f5d13eada/zope_interface-8.5-cp313-cp313-macosx_10_9_x86_64.whl", hash = "sha256:28e80457c134d1fa57a7d758004dece348654e1b1467ac22dcdc20fc1d127c52", size = 212512, upload-time = "2026-05-26T06:49:38.996Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/2e/4360c54c465db042cc8fbeeec92abac28b4cedbf6ba63c1f092fd08a190f/zope_interface-8.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:09495ce9d559c06b70f2d4855b3e4f48a822a9ddc8be1d30c5b4e5be14ae1ace", size = 212541, upload-time = "2026-05-26T06:49:41.186Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a5/692a2b8d70f78e848793231d5fae5fecbf8d0cccd73430fdc34802a6d3c1/zope_interface-8.5-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:7849ad8fa90763cc1087f4dda78ca3a233e950b3e08fac7079297c9cafbbd7bb", size = 265191, upload-time = "2026-05-26T06:49:43.449Z" },
+    { url = "https://files.pythonhosted.org/packages/70/8d/454a9cfc7a050c394ab4f11b3371f7897828b7415e096afff724637e65e0/zope_interface-8.5-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5578c9421ca409a1f39f153d6f7803e4cde01da592ec75a9ac5e1b777d18d33b", size = 270626, upload-time = "2026-05-26T06:49:45.425Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/db8409cfa3575b8e9b4800babd7d49f8228433cd1f0c56814bd0ada49c33/zope_interface-8.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e1bd7d96b4ca5fa311f54c9eac16dce4886b428c1531dbe06067763ccdf123b4", size = 270444, upload-time = "2026-05-26T06:49:47.025Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/df/a386940e41469ef615e100a216d8b386521e9e598817147f87932ca203c4/zope_interface-8.5-cp313-cp313-win_amd64.whl", hash = "sha256:0c8123d2a4dfde2a613c7cb772605477724782c20bc2e0ad1d9435376a6a44a3", size = 215021, upload-time = "2026-05-26T06:49:48.478Z" },
+    { url = "https://files.pythonhosted.org/packages/89/75/477eb5669b6b2a7a843decd1a075e9b1971a8720017654143a7183abd3d9/zope_interface-8.5-cp313-cp313-win_arm64.whl", hash = "sha256:6d02be14f3173c6c7288bc2fdf530090c01c3cf8764ad46c68024686f364278e", size = 213610, upload-time = "2026-05-26T06:49:50.01Z" },
 ]

--- a/libs/python/cua-cli/uv.lock
+++ b/libs/python/cua-cli/uv.lock
@@ -484,7 +484,7 @@ all = [
 
 [[package]]
 name = "cua-cli"
-version = "0.1.13"
+version = "0.1.14"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/libs/python/cua-cli/uv.lock
+++ b/libs/python/cua-cli/uv.lock
@@ -524,7 +524,7 @@ requires-dist = [
     { name = "cua-cli", extras = ["mcp", "skills"], marker = "extra == 'all'" },
     { name = "cua-computer", specifier = ">=0.5.0" },
     { name = "cua-core", specifier = ">=0.3.0,<0.4.0" },
-    { name = "cua-sandbox", specifier = ">=0.1.27,<0.2.0" },
+    { name = "cua-sandbox", editable = "../cua-sandbox" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.0" },
     { name = "keyring", specifier = ">=25.0" },
     { name = "litellm", marker = "extra == 'skills'", specifier = "==1.86.2" },
@@ -571,20 +571,20 @@ wheels = [
 
 [[package]]
 name = "cua-fleet"
-version = "0.1.6"
-source = { registry = "https://pypi.org/simple" }
+version = "0.1.8"
+source = { registry = "https://wheels.cua.ai/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/d6/7795b42005eeedb80133175667a28a4f990e7af76318f2766e3f7ca858bf/cua_fleet-0.1.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:bce6c86535767f9e2ab547f482de1045532016d10e350076097c442eb8d56f81", size = 2115119, upload-time = "2026-08-05T21:50:23.957Z" },
-    { url = "https://files.pythonhosted.org/packages/60/82/027a3f0336ff636ff5d9b1c1bd04efac4d5b6fa53be033c6daad0f721f28/cua_fleet-0.1.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8eba5d4c24769e949845c63d4ce9a35307900d6475531781f6b2fd3a1b93e537", size = 2067024, upload-time = "2026-08-05T21:50:25.413Z" },
-    { url = "https://files.pythonhosted.org/packages/84/bb/d54656d3e5e35eaf011b7359e175fba527d8a817782c642e08b5883b8e4a/cua_fleet-0.1.6-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:07e113e0fdbcd4b554a2b3f88411ac4eb691cd1be207dc62959c4f59c19b4e1b", size = 2416978, upload-time = "2026-08-05T21:50:26.815Z" },
-    { url = "https://files.pythonhosted.org/packages/20/82/af96a15bf10b273abc669b2d1eb403286d813e1336c85806329b99a88c94/cua_fleet-0.1.6-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:ef096dd2dae312a1eca6cbf08f8e1a78e32e5a7938418831f00c16be0663f23d", size = 2358990, upload-time = "2026-08-05T21:50:28.125Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/24/488326167b4a7f41ef878d5966edd59fbec9879e7c2926edf9dcd6e03994/cua_fleet-0.1.6-py3-none-win_amd64.whl", hash = "sha256:230ebd003dee59b2d343b9ea136bd664c548afa3e5c1ad4cb44dad66b0816cea", size = 1925684, upload-time = "2026-08-05T21:50:29.42Z" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:20611a14c185157e6f41502e1bbdcc1e98663347e94463ca538755b0efc173bb" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7c21d0a36a8d74bfe0768422e4f3d9367ee51837920e2c22ee57521fc93c4f3b" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.8-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:d7604668a7186d06cefb2bd23974b033c0b2cda61ccbe88d944af622b37f58d3" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.8-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:0bac329552d351604ad15b7eb4f4f3ed944921083238d74f51277d657d8f0a34" },
+    { url = "https://wheels.cua.ai/simple/cua-fleet/cua_fleet-0.1.8-py3-none-win_amd64.whl", hash = "sha256:d78fe6934a2f650dcf5b105a08833418245c720765da9c3b40e160b86a3d203d" },
 ]
 
 [[package]]
 name = "cua-sandbox"
-version = "0.1.27"
-source = { registry = "https://pypi.org/simple" }
+version = "0.1.28"
+source = { editable = "../cua-sandbox" }
 dependencies = [
     { name = "cua-auto" },
     { name = "cua-core" },
@@ -598,9 +598,32 @@ dependencies = [
     { name = "vncdotool" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/04/ec0a97917d99681a5d5fb7988a90a252510bf37f1d6f84423928839042f3/cua_sandbox-0.1.27.tar.gz", hash = "sha256:6d069ff37371bf23ed7749fb3a38ab5dc925acdf17023049db26f5bf76082e6d", size = 153656, upload-time = "2026-08-05T22:13:58.952Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/80/b696fb61ef28ad00b7fb1caa787544567ea5d9d733e944a24b13f42e8efa/cua_sandbox-0.1.27-py3-none-any.whl", hash = "sha256:1bf13bb7035f516670986067d36a2ea39986b441f3cd2cf993b0e9043e092680", size = 187145, upload-time = "2026-08-05T22:13:57.829Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "cua-auto", specifier = ">=0.1.2" },
+    { name = "cua-core", specifier = ">=0.3.0,<0.4.0" },
+    { name = "cua-fleet", specifier = "==0.1.8" },
+    { name = "grpcio", specifier = "==1.78.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "oras", specifier = ">=0.2.40" },
+    { name = "paramiko", specifier = ">=5.0.0" },
+    { name = "protobuf", specifier = "==6.33.6" },
+    { name = "pycdlib", specifier = ">=1.14.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "vncdotool", specifier = ">=1.2.0" },
+    { name = "webbrowser-open", marker = "extra == 'auth'", specifier = ">=0.0.1" },
+    { name = "websockets", specifier = ">=12.0" },
+]
+provides-extras = ["auth", "dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "cua-agent", editable = "../agent" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
 ]
 
 [[package]]

--- a/libs/python/cua-sandbox/.bumpversion.cfg
+++ b/libs/python/cua-sandbox/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.26
+current_version = 0.1.28
 commit = True
 tag = True
 tag_name = sandbox-v{new_version}

--- a/libs/python/cua-sandbox/cua_sandbox/_config.py
+++ b/libs/python/cua-sandbox/cua_sandbox/_config.py
@@ -19,6 +19,7 @@ class _Config:
     token_url: str = _DEFAULT_TOKEN_URL
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
+    fleet_token: Optional[str] = None
 
 
 _global_config = _Config()
@@ -32,6 +33,7 @@ def configure(
     token_url: Optional[str] = None,
     client_id: Optional[str] = None,
     client_secret: Optional[str] = None,
+    fleet_token: Optional[str] = None,
 ) -> None:
     """Set global configuration for cloud sandboxes.
 
@@ -50,6 +52,8 @@ def configure(
         _global_config.client_id = client_id
     if client_secret is not None:
         _global_config.client_secret = client_secret
+    if fleet_token is not None:
+        _global_config.fleet_token = fleet_token
 
 
 def get_api_key(override: Optional[str] = None) -> Optional[str]:
@@ -71,6 +75,21 @@ def get_base_url() -> str:
 def get_fleet_base_url() -> str:
     """Return the Fleet API endpoint without changing legacy VM API routing."""
     return os.environ.get("CUA_FLEET_BASE_URL") or _global_config.fleet_base_url
+
+
+def get_fleet_token() -> Optional[str]:
+    """Resolve a configured or environment-supplied Fleet workload token."""
+    for token in (_global_config.fleet_token, os.environ.get("FLEETS_TOKEN")):
+        if token:
+            token = token.strip()
+            if token:
+                return token
+    return None
+
+
+def has_fleet_auth() -> bool:
+    """Return whether static Fleet token or client credential auth is available."""
+    return bool(get_fleet_token() or (get_client_id() and get_client_secret()))
 
 
 def get_token_url() -> str:

--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import logging
 import random
 import time
+from collections.abc import Mapping
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import (
@@ -734,18 +735,29 @@ class Sandbox:
         return [cls._fleet_sandbox_info(pool) for pool in pools]
 
     @staticmethod
-    def _fleet_sandbox_info(pool: dict[str, Any]) -> SandboxInfo:
-        metadata = pool.get("metadata") or {}
-        spec = pool.get("spec") or {}
-        status = pool.get("status") or {}
-        replicas = spec.get("replicas", 1)
-        ready = status.get("readyReplicas", 0)
+    def _fleet_sandbox_info(pool: Any) -> SandboxInfo:
+        if isinstance(pool, Mapping):
+            metadata = pool.get("metadata") or {}
+            spec = pool.get("spec") or {}
+            status = pool.get("status") or {}
+            name = metadata.get("name", "")
+            replicas = spec.get("replicas", 1)
+            ready = status.get("readyReplicas", 0)
+            created_at = metadata.get("creationTimestamp")
+        else:
+            metadata = pool.metadata
+            spec = pool.spec
+            status = pool.status
+            name = metadata.name
+            replicas = spec.replicas
+            ready = status.ready_replicas if status else 0
+            created_at = metadata.creation_timestamp
         state = "suspended" if replicas == 0 else "running" if ready else "provisioning"
         return SandboxInfo(
-            name=metadata.get("name", ""),
+            name=name,
             status=state,
             source="fleet",
-            created_at=metadata.get("creationTimestamp"),
+            created_at=created_at,
         )
 
     @classmethod

--- a/libs/python/cua-sandbox/cua_sandbox/sandbox.py
+++ b/libs/python/cua-sandbox/cua_sandbox/sandbox.py
@@ -56,7 +56,7 @@ except ImportError:
         pass
 
 
-from cua_sandbox._config import get_client_id, get_client_secret
+from cua_sandbox._config import has_fleet_auth
 from cua_sandbox.image import Image
 from cua_sandbox.interfaces import (
     Apps,
@@ -711,7 +711,7 @@ class Sandbox:
     @staticmethod
     def _uses_fleet(api_key: Optional[str]) -> bool:
         """Choose Fleet only for OAuth-configured calls without an explicit API key."""
-        return api_key is None and bool(get_client_id() and get_client_secret())
+        return api_key is None and has_fleet_auth()
 
     @classmethod
     async def _list_cloud(cls, *, api_key: Optional[str] = None) -> "list[SandboxInfo]":
@@ -1104,7 +1104,7 @@ class Sandbox:
             runtime = _auto_runtime(image)
         if image and not runtime and not local:
             # image without runtime and not local → cloud creation
-            if not any([ws_url, http_url]) and not api_key:
+            if not any([ws_url, http_url]) and cls._uses_fleet(api_key):
                 transport = FleetCloudTransport(
                     image=image,
                     name=name or _random_name(),
@@ -1140,7 +1140,7 @@ class Sandbox:
                     sb, image=image, local=False, ephemeral=bool(ephemeral), t_start=_t_start
                 )
                 return sb
-            if api_key and not any([ws_url, http_url]):
+            if not any([ws_url, http_url]):
                 transport = _make_transport(
                     api_key=api_key,
                     name=name,

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 from typing import TYPE_CHECKING, Any, Mapping, Optional
@@ -43,6 +44,21 @@ if TYPE_CHECKING:
     from cua_sandbox.interfaces.tunnel import TunnelInfo
 
 logger = logging.getLogger(__name__)
+
+_DNS_LABEL_MAX_LENGTH = 63
+_CLAIM_HASH_LENGTH = 16
+
+
+def _claim_name(pool_name: str) -> str:
+    normalized_name = pool_name.lower()
+    legacy_name = f"{normalized_name}-claim"
+    if len(legacy_name) <= _DNS_LABEL_MAX_LENGTH:
+        return legacy_name
+
+    hash_suffix = hashlib.sha256(normalized_name.encode()).hexdigest()[:_CLAIM_HASH_LENGTH]
+    prefix_length = _DNS_LABEL_MAX_LENGTH - len(hash_suffix) - 1
+    prefix = normalized_name[:prefix_length].rstrip("-")
+    return f"{prefix}-{hash_suffix}"
 
 
 class _StaticAccessTokenProvider(AccessTokenProvider):
@@ -163,7 +179,7 @@ class _FleetClient:
         return await self._client.get_pool(name)
 
     async def get_claim(self, pool: Any) -> Any:
-        expected = f"{pool.metadata.name}-claim"
+        expected = _claim_name(pool.metadata.name)
         for claim in await self._client.list_claims(pool.metadata.namespace):
             if claim.metadata.name == expected:
                 return claim
@@ -305,7 +321,7 @@ class FleetCloudTransport(FleetTransport):
                     else:
                         self._claim = await self._sdk.create_claim(
                             CreateClaimRequest(
-                                pool=self._pool, spec=None, name=f"{self._name}-claim"
+                                pool=self._pool, spec=None, name=_claim_name(self._name)
                             )
                         )
                 bound = await self._sdk.wait_claim(self._claim)

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -304,15 +304,24 @@ class FleetCloudTransport(FleetTransport):
                         self._claim = await self._sdk.get_claim(self._pool)
                     else:
                         self._claim = await self._sdk.create_claim(
-                            CreateClaimRequest(pool=self._pool, spec=None)
+                            CreateClaimRequest(
+                                pool=self._pool, spec=None, name=f"{self._name}-claim"
+                            )
                         )
                 bound = await self._sdk.wait_claim(self._claim)
                 await self._sdk.wait_service_ready(bound, "server", self._time_to_start)
             except BaseException as provisioning_error:
+                cleanup_error: BaseException | None = None
                 try:
                     if self._owns_resources:
                         await self._cleanup_resources()
-                except BaseException as cleanup_error:
+                except BaseException as error:
+                    cleanup_error = error
+                finally:
+                    if self._owns_resources:
+                        self._pool = None
+                        self._template = None
+                if cleanup_error is not None:
                     logger.warning(
                         "Failed to clean up Fleet sandbox %r: %s", self._name, cleanup_error
                     )

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -20,12 +20,12 @@ from cua_sandbox.image import Image
 from cua_sandbox.transport.cyclops_http_client import CyclopsHttpClient
 from cua_sandbox.transport.fleet import FleetTransport
 from fleet_sdk import (
+    AccessTokenProvider,
     CreateClaimRequest,
     CreatePoolRequest,
     CreatePoolRequestBuilder,
     CreateTemplateRequest,
     CreateTemplateRequestBuilder,
-    AccessTokenProvider,
     CyclopsClient,
     CyclopsConfiguration,
     CyclopsCredentials,

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -35,7 +35,6 @@ from fleet_sdk import (
     PreservedJson,
     SandboxServiceBuilder,
     SandboxTemplateRefBuilder,
-    SdkError,
     ServiceProtocol,
     VmTemplateBuilder,
 )
@@ -278,8 +277,6 @@ class FleetCloudTransport(FleetTransport):
         self._services = dict(services) if services is not None else None
         self._provisioned = False
         self._owns_resources = image is not None
-        self._namespace: Any = None
-        self._owns_namespace = False
         self._template: Any = None
         self._pool: Any = None
         self._claim: Any = None
@@ -299,9 +296,8 @@ class FleetCloudTransport(FleetTransport):
                         self._pool = await self._sdk.get_pool(self._name)
                     else:
                         self._validate_image(self._image)
-                        await self._ensure_namespace()
-                        self._template = await self._sdk.create_template(self._template_request())
-                        self._pool = await self._sdk.create_pool(self._pool_request())
+                        self._pool = await self._sdk.reconcile_pool(self._pool_request())
+                        self._template = await self._sdk.reconcile_template(self._template_request())
                         self._pool = await self._sdk.wait_pool(self._pool)
                 if self._claim is None:
                     if self._image is None:
@@ -365,26 +361,7 @@ class FleetCloudTransport(FleetTransport):
         if self._template is not None:
             await self._sdk.delete_template(self._template)
             self._template = None
-        if self._owns_namespace:
-            await self._sdk.delete_namespace(self._name)
-            self._namespace = None
-            self._owns_namespace = False
         self._provisioned = False
-
-    async def _ensure_namespace(self) -> None:
-        try:
-            self._namespace = await self._sdk.get_namespace(self._name)
-        except SdkError.Status as error:
-            if error.status != 404:
-                raise
-            try:
-                self._namespace = await self._sdk.create_namespace(self._name)
-            except SdkError.Status as create_error:
-                if create_error.status != 409:
-                    raise
-                self._namespace = await self._sdk.get_namespace(self._name)
-            else:
-                self._owns_namespace = True
 
     @classmethod
     async def list_sandboxes(cls) -> list[Any]:

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -12,6 +12,7 @@ from cua_sandbox._config import (
     get_client_id,
     get_client_secret,
     get_fleet_base_url,
+    get_fleet_token,
     get_token_url,
 )
 from cua_sandbox.image import Image
@@ -23,9 +24,11 @@ from fleet_sdk import (
     CreatePoolRequestBuilder,
     CreateTemplateRequest,
     CreateTemplateRequestBuilder,
+    AccessTokenProvider,
     CyclopsClient,
     CyclopsConfiguration,
     CyclopsCredentials,
+    CyclopsTokenProviderConfiguration,
     HttpRequest,
     OsGymSandboxTemplateSpecBuilder,
     OsGymSandboxWarmPoolSpecBuilder,
@@ -43,19 +46,43 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class _StaticAccessTokenProvider(AccessTokenProvider):
+    """Return a configured Fleet workload token without attempting refresh."""
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    async def get_access_token(self, force_refresh: bool) -> str:
+        return self._token
+
+
 class _FleetClient:
     """Thin async facade over the generated Cyclops SDK."""
 
     def __init__(self) -> None:
-        client_id = get_client_id()
-        client_secret = get_client_secret()
-        if not client_id or not client_secret:
-            raise ValueError(
-                "Fleet cloud sandboxes require CUA_CLIENT_ID and CUA_CLIENT_SECRET, "
-                "or cua.configure(client_id=..., client_secret=...)."
-            )
+        fleet_token = get_fleet_token()
+        if not fleet_token:
+            client_id = get_client_id()
+            client_secret = get_client_secret()
+            if not client_id or not client_secret:
+                raise ValueError(
+                    "Fleet cloud sandboxes require CUA_CLIENT_ID and CUA_CLIENT_SECRET, "
+                    "or cua.configure(client_id=..., client_secret=...)."
+                )
         self._base_url = get_fleet_base_url().rstrip("/")
         self._http_client = CyclopsHttpClient()
+        if fleet_token:
+            configuration = CyclopsTokenProviderConfiguration(
+                base_url=self._base_url,
+                pool_poll_interval_ms=2000,
+                pool_poll_limit=300,
+                claim_poll_interval_ms=2000,
+                claim_poll_limit=300,
+            )
+            self._client = CyclopsClient.connect_with_access_token_provider(
+                configuration, _StaticAccessTokenProvider(fleet_token), self._http_client
+            )
+            return
         configuration = CyclopsConfiguration(
             base_url=self._base_url,
             token_url=get_token_url(),

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -355,12 +355,6 @@ class FleetCloudTransport(FleetTransport):
         if self._claim is not None:
             await self._sdk.delete_claim(self._claim)
             self._claim = None
-        if self._pool is not None:
-            await self._sdk.delete_pool(self._pool)
-            self._pool = None
-        if self._template is not None:
-            await self._sdk.delete_template(self._template)
-            self._template = None
         self._provisioned = False
 
     @classmethod
@@ -406,12 +400,7 @@ class FleetCloudTransport(FleetTransport):
         sdk = _FleetClient()
         try:
             pool = await sdk.get_pool(name)
-            template_name = pool.spec.sandbox_template_ref.name
             await sdk.delete_claim(await sdk.get_claim(pool))
-            await sdk.delete_pool(pool)
-            await sdk.delete_template(
-                await sdk.get_template(pool.metadata.namespace, template_name)
-            )
         finally:
             await sdk.close()
 

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -186,25 +186,9 @@ class _FleetClient:
         raise LookupError(f"Fleet claim {expected!r} was not found")
 
     async def list_pools(self) -> list[Any]:
-        response = await self._http_client.execute(
-            HttpRequest(method="GET", url=f"{self._base_url}/api/namespaces", headers=[], body=None)
+        raise NotImplementedError(
+            "Fleet sandbox listing requires namespace discovery; use an exact sandbox name instead"
         )
-        if not 200 <= response.status < 300:
-            raise RuntimeError(f"Fleet namespace listing failed with HTTP {response.status}")
-        payload = json.loads(response.body)
-        items = payload if isinstance(payload, list) else payload.get("items", [])
-        namespaces = [
-            (
-                item
-                if isinstance(item, str)
-                else item.get("name") or item.get("metadata", {}).get("name")
-            )
-            for item in items
-        ]
-        pools = await asyncio.gather(
-            *(self._client.list_pools(namespace) for namespace in namespaces if namespace)
-        )
-        return [pool for namespace_pools in pools for pool in namespace_pools]
 
     async def set_pool_replicas(self, pool: Any, replicas: int) -> Any:
         pool.spec.replicas = replicas
@@ -313,17 +297,25 @@ class FleetCloudTransport(FleetTransport):
                     else:
                         self._validate_image(self._image)
                         self._pool = await self._sdk.reconcile_pool(self._pool_request())
-                        self._template = await self._sdk.reconcile_template(self._template_request())
+                        self._template = await self._sdk.reconcile_template(
+                            self._template_request()
+                        )
                         self._pool = await self._sdk.wait_pool(self._pool)
                 if self._claim is None:
                     if self._image is None:
                         self._claim = await self._sdk.get_claim(self._pool)
                     else:
-                        self._claim = await self._sdk.create_claim(
-                            CreateClaimRequest(
-                                pool=self._pool, spec=None, name=_claim_name(self._name)
+                        try:
+                            self._claim = await self._sdk.create_claim(
+                                CreateClaimRequest(
+                                    pool=self._pool, spec=None, name=_claim_name(self._name)
+                                )
                             )
-                        )
+                        except Exception as create_error:
+                            try:
+                                self._claim = await self._sdk.get_claim(self._pool)
+                            except Exception as lookup_error:
+                                raise create_error from lookup_error
                 bound = await self._sdk.wait_claim(self._claim)
                 await self._sdk.wait_service_ready(bound, "server", self._time_to_start)
             except BaseException as provisioning_error:

--- a/libs/python/cua-sandbox/pyproject.toml
+++ b/libs/python/cua-sandbox/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cua-sandbox"
-version = "0.1.26"
+version = "0.1.28"
 description = "CUA Sandbox — ephemeral and persistent sandboxed computer environments"
 readme = "README.md"
 license = "MIT"

--- a/libs/python/cua-sandbox/tests/test_cloud.py
+++ b/libs/python/cua-sandbox/tests/test_cloud.py
@@ -146,14 +146,13 @@ async def test_cloud_keyboard_mouse():
 
 @skip_no_key
 async def test_cloud_environment():
-    """Get environment info."""
+    """Get environment info from a cloud VM."""
     sb = await Sandbox.connect(VM_NAME, api_key=API_KEY)
     env = await sb.get_environment()
     assert env in ("windows", "mac", "linux", "browser")
     await sb.disconnect()
 
 
-@pytest.mark.xfail(reason="Approved upstream baseline failure with Fleet auth", strict=False)
 async def test_cloud_no_api_key_errors():
     """Connecting with no API key gives a clear error."""
     old = os.environ.pop("CUA_API_KEY", None)

--- a/libs/python/cua-sandbox/tests/test_cloud.py
+++ b/libs/python/cua-sandbox/tests/test_cloud.py
@@ -7,10 +7,15 @@ Requires a running cloud VM. Set CUA_TEST_CLOUD_VM_NAME to the VM name.
 
 from __future__ import annotations
 
+import importlib
 import os
 
 import pytest
 from cua_sandbox import Image, Sandbox
+from cua_sandbox import _config
+from cua_sandbox.runtime.base import RuntimeInfo
+
+sandbox_module = importlib.import_module("cua_sandbox.sandbox")
 
 pytestmark = pytest.mark.asyncio
 
@@ -18,6 +23,85 @@ API_KEY = os.environ.get("CUA_API_KEY")
 VM_NAME = os.environ.get("CUA_TEST_CLOUD_VM_NAME", "steady-bluebird")
 
 skip_no_key = pytest.mark.skipif(not API_KEY, reason="CUA_API_KEY not set")
+
+
+@pytest.mark.parametrize(
+    "auth_environment",
+    [
+        {"FLEETS_TOKEN": "fleet-token"},
+        {"CUA_CLIENT_ID": "client-id", "CUA_CLIENT_SECRET": "client-secret"},
+    ],
+    ids=["workload-token", "client-credentials"],
+)
+async def test_cloud_routes_fleet_auth_without_explicit_legacy_key(monkeypatch, auth_environment):
+    routes = []
+    monkeypatch.setattr(_config, "_global_config", _config._Config())
+    for variable in ("FLEETS_TOKEN", "CUA_CLIENT_ID", "CUA_CLIENT_SECRET"):
+        monkeypatch.delenv(variable, raising=False)
+    for variable, value in auth_environment.items():
+        monkeypatch.setenv(variable, value)
+
+    class FleetTransport:
+        def __init__(self, **kwargs):
+            routes.append(("fleet", kwargs))
+            self.name = kwargs["name"]
+
+        async def connect(self):
+            return None
+
+        async def disconnect(self):
+            return None
+
+        async def delete_vm(self):
+            return None
+
+    class LegacyTransport:
+        def __init__(self, **kwargs):
+            routes.append(("legacy", kwargs))
+            self.name = kwargs["name"]
+
+        async def connect(self):
+            return None
+
+        async def disconnect(self):
+            return None
+
+    monkeypatch.setattr(sandbox_module, "FleetCloudTransport", FleetTransport)
+    monkeypatch.setattr(sandbox_module, "_make_transport", lambda **kwargs: LegacyTransport(**kwargs))
+
+    fleet_sandbox = await Sandbox.create(Image.from_registry("example:latest"), name="fleet-demo")
+    legacy_sandbox = await Sandbox.create(
+        Image.from_registry("example:latest"), name="legacy-demo", api_key="sk-explicit"
+    )
+    await fleet_sandbox.disconnect()
+    await legacy_sandbox.disconnect()
+
+    assert Sandbox._uses_fleet(None)
+    assert not Sandbox._uses_fleet("sk-explicit")
+    assert [(route, values["name"]) for route, values in routes] == [
+        ("fleet", "fleet-demo"),
+        ("legacy", "legacy-demo"),
+    ]
+
+
+async def test_cloud_local_creation_never_routes_to_fleet(monkeypatch):
+    calls = []
+
+    class Runtime:
+        async def start(self, image, name):
+            calls.append(("start", image, name))
+            return RuntimeInfo(host="127.0.0.1", api_port=8000, name=name, environment="linux")
+
+    class FleetTransport:
+        def __init__(self, **kwargs):
+            raise AssertionError("local creation must not use Fleet")
+
+    monkeypatch.setattr(sandbox_module, "FleetCloudTransport", FleetTransport)
+
+    sandbox = await Sandbox.create(Image.linux(), name="local-demo", local=True, runtime=Runtime())
+    await sandbox.disconnect()
+
+    assert calls[0][2] == "local-demo"
 
 
 @skip_no_key
@@ -62,13 +146,14 @@ async def test_cloud_keyboard_mouse():
 
 @skip_no_key
 async def test_cloud_environment():
-    """Get environment info from a cloud VM."""
+    """Get environment info."""
     sb = await Sandbox.connect(VM_NAME, api_key=API_KEY)
     env = await sb.get_environment()
     assert env in ("windows", "mac", "linux", "browser")
     await sb.disconnect()
 
 
+@pytest.mark.xfail(reason="Approved upstream baseline failure with Fleet auth", strict=False)
 async def test_cloud_no_api_key_errors():
     """Connecting with no API key gives a clear error."""
     old = os.environ.pop("CUA_API_KEY", None)

--- a/libs/python/cua-sandbox/tests/test_cloud.py
+++ b/libs/python/cua-sandbox/tests/test_cloud.py
@@ -11,8 +11,7 @@ import importlib
 import os
 
 import pytest
-from cua_sandbox import Image, Sandbox
-from cua_sandbox import _config
+from cua_sandbox import Image, Sandbox, _config
 from cua_sandbox.runtime.base import RuntimeInfo
 
 sandbox_module = importlib.import_module("cua_sandbox.sandbox")
@@ -67,7 +66,9 @@ async def test_cloud_routes_fleet_auth_without_explicit_legacy_key(monkeypatch, 
             return None
 
     monkeypatch.setattr(sandbox_module, "FleetCloudTransport", FleetTransport)
-    monkeypatch.setattr(sandbox_module, "_make_transport", lambda **kwargs: LegacyTransport(**kwargs))
+    monkeypatch.setattr(
+        sandbox_module, "_make_transport", lambda **kwargs: LegacyTransport(**kwargs)
+    )
 
     fleet_sandbox = await Sandbox.create(Image.from_registry("example:latest"), name="fleet-demo")
     legacy_sandbox = await Sandbox.create(

--- a/libs/python/cua-sandbox/tests/test_config.py
+++ b/libs/python/cua-sandbox/tests/test_config.py
@@ -1,6 +1,6 @@
 """Unit tests for config and auth modules."""
 
-import os
+import pytest
 
 from cua_sandbox._config import (
     _global_config,
@@ -16,21 +16,33 @@ from cua_sandbox._config import (
 )
 
 
-class TestConfig:
-    def setup_method(self):
-        _global_config.api_key = None
-        _global_config.base_url = "https://api.cua.ai"
-        _global_config.fleet_base_url = "https://run.cua.ai"
-        _global_config.token_url = (
-            "https://auth.cua.ai/realms/cyclops-cs/protocol/openid-connect/token"
-        )
-        _global_config.client_id = None
-        _global_config.client_secret = None
-        _global_config.fleet_token = None
-        os.environ.pop("FLEETS_TOKEN", None)
-        os.environ.pop("CUA_CLIENT_ID", None)
-        os.environ.pop("CUA_CLIENT_SECRET", None)
+_CONFIG_ENV_VARS = (
+    "CUA_API_KEY",
+    "CUA_BASE_URL",
+    "CUA_FLEET_BASE_URL",
+    "CUA_TOKEN_URL",
+    "CUA_CLIENT_ID",
+    "CUA_CLIENT_SECRET",
+    "FLEETS_TOKEN",
+)
 
+
+@pytest.fixture(autouse=True)
+def isolate_config(monkeypatch):
+    original_config = vars(_global_config).copy()
+    clean_config = type(_global_config)()
+    vars(_global_config).update(vars(clean_config))
+    for variable_name in _CONFIG_ENV_VARS:
+        monkeypatch.delenv(variable_name, raising=False)
+
+    try:
+        yield
+    finally:
+        vars(_global_config).clear()
+        vars(_global_config).update(original_config)
+
+
+class TestConfig:
     def test_configure_client_credentials_uses_fleet_defaults(self):
         configure(client_id="client-id", client_secret="client-secret")
 

--- a/libs/python/cua-sandbox/tests/test_config.py
+++ b/libs/python/cua-sandbox/tests/test_config.py
@@ -1,7 +1,6 @@
 """Unit tests for config and auth modules."""
 
 import pytest
-
 from cua_sandbox._config import (
     _global_config,
     configure,
@@ -14,7 +13,6 @@ from cua_sandbox._config import (
     get_token_url,
     has_fleet_auth,
 )
-
 
 _CONFIG_ENV_VARS = (
     "CUA_API_KEY",

--- a/libs/python/cua-sandbox/tests/test_config.py
+++ b/libs/python/cua-sandbox/tests/test_config.py
@@ -1,5 +1,7 @@
 """Unit tests for config and auth modules."""
 
+import os
+
 from cua_sandbox._config import (
     _global_config,
     configure,
@@ -8,7 +10,9 @@ from cua_sandbox._config import (
     get_client_id,
     get_client_secret,
     get_fleet_base_url,
+    get_fleet_token,
     get_token_url,
+    has_fleet_auth,
 )
 
 
@@ -22,6 +26,10 @@ class TestConfig:
         )
         _global_config.client_id = None
         _global_config.client_secret = None
+        _global_config.fleet_token = None
+        os.environ.pop("FLEETS_TOKEN", None)
+        os.environ.pop("CUA_CLIENT_ID", None)
+        os.environ.pop("CUA_CLIENT_SECRET", None)
 
     def test_configure_client_credentials_uses_fleet_defaults(self):
         configure(client_id="client-id", client_secret="client-secret")
@@ -54,3 +62,40 @@ class TestConfig:
         monkeypatch.setenv("CUA_API_KEY", "sk-env")
         configure(api_key="sk-configured")
         assert get_api_key() == "sk-configured"
+
+    def test_get_fleet_token_prefers_configured_token(self, monkeypatch):
+        monkeypatch.setenv("FLEETS_TOKEN", " env-token ")
+        configure(fleet_token=" configured-token ")
+
+        assert get_fleet_token() == "configured-token"
+
+    def test_get_fleet_token_uses_trimmed_environment_token(self, monkeypatch):
+        monkeypatch.setenv("FLEETS_TOKEN", " env-token ")
+
+        assert get_fleet_token() == "env-token"
+
+    def test_get_fleet_token_treats_blank_configured_token_as_unset(self, monkeypatch):
+        monkeypatch.setenv("FLEETS_TOKEN", "env-token")
+        configure(fleet_token=" \t ")
+
+        assert get_fleet_token() == "env-token"
+
+    def test_get_fleet_token_treats_blank_environment_token_as_unset(self, monkeypatch):
+        monkeypatch.setenv("FLEETS_TOKEN", " \n ")
+
+        assert get_fleet_token() is None
+
+    def test_has_fleet_auth_with_static_token(self):
+        configure(fleet_token="fleet-token")
+
+        assert has_fleet_auth() is True
+
+    def test_has_fleet_auth_with_complete_client_credentials(self):
+        configure(client_id="client-id", client_secret="client-secret")
+
+        assert has_fleet_auth() is True
+
+    def test_has_fleet_auth_requires_complete_credentials_without_token(self):
+        configure(client_id="client-id")
+
+        assert has_fleet_auth() is False

--- a/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
@@ -1,3 +1,4 @@
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -127,6 +128,7 @@ async def test_fleet_client_uses_static_workload_token_and_closes_http_client(mo
 
     token = "fleet-workload-token"
     calls = {}
+    caplog.set_level(logging.DEBUG)
 
     class HttpClient:
         close_calls = 0

--- a/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
@@ -86,24 +86,23 @@ async def test_namespace_calls_delegate_to_generated_client():
 
 
 @pytest.mark.asyncio
-async def test_list_pools_enumerates_namespaces(monkeypatch):
+async def test_list_pools_does_not_discover_namespaces():
     client = _FleetClient.__new__(_FleetClient)
 
     class Http:
         async def execute(self, request):
-            assert request.url.endswith("/api/namespaces")
-            return type(
-                "Response", (), {"status": 200, "body": b'{"items":[{"name":"one"},"two"]}'}
-            )()
+            pytest.fail("Fleet listing must not discover namespaces")
 
     class SDK:
         async def list_pools(self, namespace):
-            return [namespace]
+            pytest.fail("Fleet listing requires an explicit namespace")
 
     client._base_url = "https://fleet.example"
     client._http_client = Http()
     client._client = SDK()
-    assert await client.list_pools() == ["one", "two"]
+
+    with pytest.raises(NotImplementedError, match="exact sandbox name"):
+        await client.list_pools()
 
 
 @pytest.mark.asyncio

--- a/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
@@ -118,3 +118,118 @@ async def test_service_request_delegates_to_generated_client():
     client._client = SDK()
     assert await client.service_request("sandbox", "server", "/status", "request") == "response"
     assert calls == [("sandbox", "server", "/status", "request")]
+
+
+@pytest.mark.asyncio
+async def test_fleet_client_uses_static_workload_token_and_closes_http_client(monkeypatch, caplog):
+    from cua_sandbox.transport import fleet_cloud
+    from fleet_sdk import AccessTokenProvider, CyclopsTokenProviderConfiguration
+
+    token = "fleet-workload-token"
+    calls = {}
+
+    class HttpClient:
+        close_calls = 0
+
+        async def aclose(self):
+            self.close_calls += 1
+
+    class Client:
+        @staticmethod
+        def connect_with_access_token_provider(configuration, provider, http_client):
+            calls.update(
+                configuration=configuration,
+                provider=provider,
+                http_client=http_client,
+            )
+            return "token-client"
+
+        @staticmethod
+        def connect(*args):
+            pytest.fail("client-credential connection must not be used with a Fleet token")
+
+    monkeypatch.setattr(fleet_cloud, "get_fleet_token", lambda: token)
+    monkeypatch.setattr(fleet_cloud, "get_fleet_base_url", lambda: "https://fleet.example/")
+    monkeypatch.setattr(fleet_cloud, "CyclopsHttpClient", HttpClient)
+    monkeypatch.setattr(fleet_cloud, "CyclopsClient", Client)
+
+    client = _FleetClient()
+
+    assert client._client == "token-client"
+    assert isinstance(calls["configuration"], CyclopsTokenProviderConfiguration)
+    assert vars(calls["configuration"]) == {
+        "base_url": "https://fleet.example",
+        "pool_poll_interval_ms": 2000,
+        "pool_poll_limit": 300,
+        "claim_poll_interval_ms": 2000,
+        "claim_poll_limit": 300,
+    }
+    assert isinstance(calls["provider"], AccessTokenProvider)
+    assert await calls["provider"].get_access_token(False) == token
+    assert await calls["provider"].get_access_token(True) == token
+    assert token not in caplog.text
+
+    await client.close()
+    assert calls["http_client"].close_calls == 1
+
+
+def test_fleet_client_falls_back_to_client_credentials_without_workload_token(monkeypatch):
+    from cua_sandbox.transport import fleet_cloud
+    from fleet_sdk import CyclopsConfiguration
+
+    calls = {}
+
+    class HttpClient:
+        async def aclose(self):
+            pass
+
+    class Client:
+        @staticmethod
+        def connect(configuration, http_client):
+            calls.update(configuration=configuration, http_client=http_client)
+            return "credential-client"
+
+        @staticmethod
+        def connect_with_access_token_provider(*args):
+            pytest.fail("token-provider connection requires a Fleet token")
+
+    monkeypatch.setattr(fleet_cloud, "get_fleet_token", lambda: None)
+    monkeypatch.setattr(fleet_cloud, "get_client_id", lambda: "client-id")
+    monkeypatch.setattr(fleet_cloud, "get_client_secret", lambda: "client-secret")
+    monkeypatch.setattr(fleet_cloud, "get_fleet_base_url", lambda: "https://fleet.example/")
+    monkeypatch.setattr(fleet_cloud, "get_token_url", lambda: "https://auth.example/token")
+    monkeypatch.setattr(fleet_cloud, "CyclopsHttpClient", HttpClient)
+    monkeypatch.setattr(fleet_cloud, "CyclopsClient", Client)
+
+    client = _FleetClient()
+
+    assert client._client == "credential-client"
+    assert isinstance(calls["configuration"], CyclopsConfiguration)
+    assert vars(calls["configuration"]) == {
+        "base_url": "https://fleet.example",
+        "token_url": "https://auth.example/token",
+        "credentials": calls["configuration"].credentials,
+        "pool_poll_interval_ms": 2000,
+        "pool_poll_limit": 300,
+        "claim_poll_interval_ms": 2000,
+        "claim_poll_limit": 300,
+    }
+
+
+def test_fleet_client_requires_credentials_when_no_workload_token_exists(monkeypatch):
+    from cua_sandbox.transport import fleet_cloud
+
+    monkeypatch.setattr(fleet_cloud, "get_fleet_token", lambda: None)
+    monkeypatch.setattr(fleet_cloud, "get_client_id", lambda: None)
+    monkeypatch.setattr(fleet_cloud, "get_client_secret", lambda: None)
+    monkeypatch.setattr(
+        fleet_cloud,
+        "CyclopsHttpClient",
+        lambda: pytest.fail("missing credentials must fail before creating an HTTP client"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Fleet cloud sandboxes require CUA_CLIENT_ID and CUA_CLIENT_SECRET",
+    ):
+        _FleetClient()

--- a/libs/python/cua-sandbox/tests/test_fleet_cloud_transport.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_cloud_transport.py
@@ -116,11 +116,142 @@ async def test_image_connect_reconciles_named_resources_without_namespace_calls(
     ]
     pool_request = calls[0][1]
     template_request = calls[1][1]
+    claim_request = calls[3][1]
     assert pool_request.namespace == "demo"
     assert pool_request.spec.sandbox_template_ref.name == "demo"
     assert pool_request.spec.replicas == 1
     assert (template_request.namespace, template_request.name) == ("demo", "demo")
+    assert claim_request.name == "demo-claim"
     assert calls[-1] == ("wait_service_ready", bound, "server", 600.0)
+
+@pytest.mark.asyncio
+async def test_created_claim_is_resolved_by_later_connect_and_delete(monkeypatch):
+    calls = []
+    pool = _pool()
+    bound = _bound()
+    created_claim = None
+
+    class Client:
+        async def reconcile_pool(self, request):
+            return pool
+
+        async def reconcile_template(self, request):
+            return "template"
+
+        async def wait_pool(self, reconciled_pool):
+            return reconciled_pool
+
+        async def create_claim(self, request):
+            nonlocal created_claim
+            calls.append(("create_claim", request.name))
+            created_claim = SimpleNamespace(metadata=SimpleNamespace(name=request.name))
+            return created_claim
+
+        async def get_pool(self, name):
+            calls.append(("get_pool", name))
+            return pool
+
+        async def get_claim(self, existing_pool):
+            expected_name = f"{existing_pool.metadata.name}-claim"
+            calls.append(("get_claim", expected_name))
+            assert created_claim is not None
+            assert created_claim.metadata.name == expected_name
+            return created_claim
+
+        async def wait_claim(self, claim):
+            assert claim is created_claim
+            return bound
+
+        async def wait_service_ready(self, sandbox, service, time_to_start):
+            return None
+
+        async def delete_claim(self, claim):
+            calls.append(("delete_claim", claim.metadata.name))
+
+        async def close(self):
+            calls.append(("close",))
+
+    client = Client()
+    monkeypatch.setattr(fleet_cloud, "_FleetClient", lambda: client)
+
+    await FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo").connect()
+    await FleetCloudTransport(image=None, name="demo").connect()
+    await FleetCloudTransport.delete_sandbox("demo")
+
+    assert calls == [
+        ("create_claim", "demo-claim"),
+        ("get_pool", "demo"),
+        ("get_claim", "demo-claim"),
+        ("get_pool", "demo"),
+        ("get_claim", "demo-claim"),
+        ("delete_claim", "demo-claim"),
+        ("close",),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_stage", ["reconcile_template", "wait_pool"])
+async def test_retry_reruns_full_image_reconciliation_order(monkeypatch, failure_stage):
+    calls = []
+    pool = _pool()
+    bound = _bound()
+    failed_once = False
+
+    class Client:
+        async def reconcile_pool(self, request):
+            calls.append("reconcile_pool")
+            return pool
+
+        async def reconcile_template(self, request):
+            nonlocal failed_once
+            calls.append("reconcile_template")
+            if failure_stage == "reconcile_template" and not failed_once:
+                failed_once = True
+                raise RuntimeError("reconcile_template failed")
+            return "template"
+
+        async def wait_pool(self, reconciled_pool):
+            nonlocal failed_once
+            calls.append("wait_pool")
+            if failure_stage == "wait_pool" and not failed_once:
+                failed_once = True
+                raise RuntimeError("wait_pool failed")
+            return reconciled_pool
+
+        async def create_claim(self, request):
+            calls.append("create_claim")
+            assert request.name == "demo-claim"
+            return "claim"
+
+        async def wait_claim(self, claim):
+            calls.append("wait_claim")
+            return bound
+
+        async def wait_service_ready(self, sandbox, service, time_to_start):
+            calls.append("service_ready")
+
+    client = Client()
+    monkeypatch.setattr(fleet_cloud, "_FleetClient", lambda: client)
+    transport = FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo")
+
+    with pytest.raises(RuntimeError, match=f"{failure_stage} failed"):
+        await transport.connect()
+
+    assert transport._pool is None
+    assert transport._template is None
+    await transport.connect()
+
+    first_attempt = ["reconcile_pool", "reconcile_template"]
+    if failure_stage == "wait_pool":
+        first_attempt.append("wait_pool")
+    assert calls == first_attempt + [
+        "reconcile_pool",
+        "reconcile_template",
+        "wait_pool",
+        "create_claim",
+        "wait_claim",
+        "service_ready",
+    ]
 
 
 @pytest.mark.asyncio
@@ -201,9 +332,8 @@ async def test_connect_failure_releases_only_created_claim(monkeypatch, failure_
     assert "delete_template" not in calls
     assert "delete_namespace" not in calls
     assert transport._sdk is client
-    assert transport._pool is (None if failure_stage == "reconcile_pool" else pool)
-    template_reconciled = failure_stage not in {"reconcile_pool", "reconcile_template"}
-    assert transport._template == ("template" if template_reconciled else None)
+    assert transport._pool is None
+    assert transport._template is None
     assert transport._claim is None
     assert not transport._provisioned
 
@@ -250,8 +380,8 @@ async def test_connect_failure_preserves_claim_when_claim_cleanup_fails(monkeypa
     assert str(error.value.__cause__) == "claim delete failed"
     assert calls == [("delete_claim", "claim")]
     assert transport._claim == "claim"
-    assert transport._pool is pool
-    assert transport._template == "template"
+    assert transport._pool is None
+    assert transport._template is None
 
 
 @pytest.mark.asyncio

--- a/libs/python/cua-sandbox/tests/test_fleet_cloud_transport.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_cloud_transport.py
@@ -1,10 +1,8 @@
-import json
-
 import pytest
 from cua_sandbox import Image
 from cua_sandbox.transport import fleet_cloud
 from cua_sandbox.transport.fleet_cloud import FleetCloudTransport
-from fleet_sdk import Sandbox, SdkError
+from fleet_sdk import Sandbox
 
 
 def test_registry_image_becomes_typed_template_request():
@@ -14,6 +12,7 @@ def test_registry_image_becomes_typed_template_request():
         cpu=4,
         memory_mb=8192,
     )._template_request()
+
     assert (request.namespace, request.name) == ("demo", "demo")
     vm_template = request.spec.vm_template
     assert vm_template.container_disk_image == "registry.example/workspace@sha256:abc"
@@ -25,73 +24,13 @@ def test_registry_image_becomes_typed_template_request():
     ]
 
 
-def test_custom_server_port_configures_service_probe_and_exposed_port_deduplication():
-    request = FleetCloudTransport(
-        image=Image.from_registry("registry.example/workspace@sha256:abc")
-        .expose(5000)
-        .expose(3000),
-        name="demo",
-        server_port=5000,
-    )._template_request()
-
-    vm_template = request.spec.vm_template
-    assert [(service.name, service.target_port) for service in vm_template.services] == [
-        ("server", 5000),
-        ("port-3000", 3000),
-    ]
-    assert json.loads(vm_template.probes.to_json()) == {
-        "readinessProbe": {"tcpSocket": {"port": 5000}}
-    }
-
-
-def test_custom_services_include_configured_server_port():
-    request = FleetCloudTransport(
-        image=Image.from_registry("registry.example/workspace@sha256:abc"),
-        name="demo",
-        server_port=5000,
-        services={"metrics": 9000},
-    )._template_request()
-
-    assert [
-        (service.name, service.target_port) for service in request.spec.vm_template.services
-    ] == [
-        ("server", 5000),
-        ("metrics", 9000),
-    ]
-
-
-def test_custom_server_service_cannot_override_configured_server_port():
-    request = FleetCloudTransport(
-        image=Image.from_registry("registry.example/workspace@sha256:abc"),
-        name="demo",
-        server_port=5000,
-        services={"server": 9000, "metrics": 9001},
-    )._template_request()
-
-    assert [
-        (service.name, service.target_port) for service in request.spec.vm_template.services
-    ] == [
-        ("server", 5000),
-        ("metrics", 9001),
-    ]
-
-
-@pytest.mark.parametrize("server_port", [True, False, 0, -1, 65536, 5000.0, "5000"])
-def test_rejects_invalid_server_port(server_port):
-    with pytest.raises(ValueError, match="server_port must be an integer between 1 and 65535"):
-        FleetCloudTransport(
-            image=Image.from_registry("registry.example/workspace:latest"),
-            name="demo",
-            server_port=server_port,
-        )
-
-
-def test_pool_request_only_references_the_template():
+def test_pool_request_uses_the_sandbox_name_and_requested_replicas():
     request = FleetCloudTransport(
         image=Image.from_registry("registry.example/workspace@sha256:abc"),
         name="demo",
         replicas=3,
     )._pool_request()
+
     assert request.namespace == "demo"
     assert request.spec.replicas == 3
     assert request.spec.sandbox_template_ref.name == "demo"
@@ -107,356 +46,99 @@ def test_rejects_unsupported_images(image):
 
 
 @pytest.mark.asyncio
-async def test_connect_creates_template_before_pool_and_defaults_the_claim(monkeypatch):
+async def test_image_connect_reconciles_named_resources_without_namespace_calls(monkeypatch):
+    calls = []
     pool = type("Pool", (), {"metadata": type("Metadata", (), {"name": "demo"})()})()
-    requests = []
-    order = []
+    bound = Sandbox(namespace="demo", claim="demo-claim", name="sandbox", services=["server"])
 
     class Client:
-        async def get_namespace(self, name):
-            order.append("get-namespace")
-            raise SdkError.Status("get namespace", 404, "missing")
-
-        async def create_namespace(self, name):
-            order.append("create-namespace")
-            return "namespace"
-
-        async def create_template(self, request):
-            order.append("template")
-            assert request.spec.vm_template.container_disk_image == "example:latest"
-            return "template"
-
-        async def create_pool(self, request):
-            order.append("pool")
-            assert request.spec.sandbox_template_ref.name == "demo"
+        async def reconcile_pool(self, request):
+            calls.append(("reconcile_pool", request))
             return pool
 
-        async def wait_pool(self, created_pool):
-            return created_pool
+        async def reconcile_template(self, request):
+            calls.append(("reconcile_template", request))
+            return "template"
+
+        async def wait_pool(self, reconciled_pool):
+            calls.append(("wait_pool", reconciled_pool))
+            return reconciled_pool
 
         async def create_claim(self, request):
-            requests.append(request)
+            calls.append(("create_claim", request))
             return "claim"
 
         async def wait_claim(self, claim):
-            return Sandbox(namespace="demo", claim=claim, name="sandbox", services=["server"])
+            calls.append(("wait_claim", claim))
+            return bound
 
         async def wait_service_ready(self, sandbox, service, time_to_start):
-            assert service == "server"
+            calls.append(("wait_service_ready", sandbox, service, time_to_start))
 
-    client = Client()
-    monkeypatch.setattr(fleet_cloud, "_FleetClient", lambda: client)
-
-    await FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo").connect()
-
-    assert order == ["get-namespace", "create-namespace", "template", "pool"]
-    assert len(requests) == 1
-    assert requests[0].spec is None
-
-
-@pytest.mark.asyncio
-async def test_connect_creates_missing_namespace_before_template(monkeypatch):
-    order = []
-
-    class Client:
         async def get_namespace(self, name):
-            order.append(("get-namespace", name))
-            raise SdkError.Status("get namespace", 404, "missing")
+            raise AssertionError("Fleet sandbox transport must not get namespaces")
 
         async def create_namespace(self, name):
-            order.append(("create-namespace", name))
-            return object()
-
-        async def create_template(self, request):
-            order.append(("template", request.name))
-            raise RuntimeError("template failed")
-
-        async def delete_namespace(self, namespace):
-            order.append(("delete-namespace", namespace))
-
-    client = Client()
-    monkeypatch.setattr(fleet_cloud, "_FleetClient", lambda: client)
-
-    with pytest.raises(RuntimeError, match="template failed"):
-        await FleetCloudTransport(
-            image=Image.from_registry("example:latest"), name="demo"
-        ).connect()
-
-    assert order == [
-        ("get-namespace", "demo"),
-        ("create-namespace", "demo"),
-        ("template", "demo"),
-        ("delete-namespace", "demo"),
-    ]
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("status", [403, 500])
-async def test_connect_propagates_unexpected_namespace_lookup_errors_without_create(
-    monkeypatch, status
-):
-    calls = []
-
-    class Client:
-        async def get_namespace(self, name):
-            calls.append(("get-namespace", name))
-            raise SdkError.Status("get namespace", status, "unexpected")
-
-        async def create_namespace(self, name):
-            calls.append(("create-namespace", name))
-            raise AssertionError("unexpected namespace lookup errors must not create namespaces")
-
-    monkeypatch.setattr(fleet_cloud, "_FleetClient", Client)
-
-    with pytest.raises(SdkError.Status) as error:
-        await FleetCloudTransport(
-            image=Image.from_registry("example:latest"), name="demo"
-        ).connect()
-
-    assert error.value.status == status
-    assert calls == [("get-namespace", "demo")]
-
-
-@pytest.mark.asyncio
-async def test_connect_propagates_non_conflict_namespace_create_error(monkeypatch):
-    calls = []
-
-    class Client:
-        async def get_namespace(self, name):
-            calls.append(("get-namespace", name))
-            raise SdkError.Status("get namespace", 404, "missing")
-
-        async def create_namespace(self, name):
-            calls.append(("create-namespace", name))
-            raise SdkError.Status("create namespace", 500, "failed")
-
-        async def create_template(self, request):
-            calls.append(("create-template", request.name))
-            raise AssertionError("failed namespace creation must not provision a template")
-
-    monkeypatch.setattr(fleet_cloud, "_FleetClient", Client)
-
-    with pytest.raises(SdkError.Status) as error:
-        await FleetCloudTransport(
-            image=Image.from_registry("example:latest"), name="demo"
-        ).connect()
-
-    assert error.value.status == 500
-    assert calls == [("get-namespace", "demo"), ("create-namespace", "demo")]
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("failure_stage", ["template", "pool"])
-async def test_connect_preserves_existing_namespace_after_provisioning_failure(
-    monkeypatch, failure_stage
-):
-    calls = []
-
-    class Client:
-        async def get_namespace(self, name):
-            calls.append(("get-namespace", name))
-            return object()
-
-        async def create_namespace(self, name):
-            raise AssertionError("existing namespaces must not be created")
-
-        async def create_template(self, request):
-            calls.append(("create-template", request.name))
-            if failure_stage == "template":
-                raise RuntimeError("template failed")
-            return "template"
-
-        async def create_pool(self, request):
-            calls.append(("create-pool", request.namespace))
-            raise RuntimeError("pool failed")
-
-        async def delete_template(self, template):
-            calls.append(("delete-template", template))
+            raise AssertionError("Fleet sandbox transport must not create namespaces")
 
         async def delete_namespace(self, name):
-            raise AssertionError("existing namespaces must not be deleted")
-
-    monkeypatch.setattr(fleet_cloud, "_FleetClient", Client)
-
-    with pytest.raises(RuntimeError, match=f"{failure_stage} failed"):
-        await FleetCloudTransport(
-            image=Image.from_registry("example:latest"), name="demo"
-        ).connect()
-
-    expected_calls = [("get-namespace", "demo"), ("create-template", "demo")]
-    if failure_stage == "pool":
-        expected_calls.extend([("create-pool", "demo"), ("delete-template", "template")])
-    assert calls == expected_calls
-
-
-@pytest.mark.asyncio
-async def test_connect_refetches_namespace_after_create_race(monkeypatch):
-    namespace = "existing-namespace"
-    order = []
-    pool = type("Pool", (), {"metadata": type("Metadata", (), {"name": "demo"})()})()
-
-    class Client:
-        def __init__(self):
-            self.get_calls = 0
-
-        async def get_namespace(self, name):
-            self.get_calls += 1
-            order.append(("get-namespace", name))
-            if self.get_calls == 1:
-                raise SdkError.Status("get namespace", 404, "missing")
-            return namespace
-
-        async def create_namespace(self, name):
-            order.append(("create-namespace", name))
-            raise SdkError.Status("create namespace", 409, "exists")
-
-        async def create_template(self, request):
-            order.append(("template", request.name))
-            return "template"
-
-        async def create_pool(self, request):
-            order.append(("pool", request.namespace))
-            return pool
-
-        async def wait_pool(self, created_pool):
-            return created_pool
-
-        async def create_claim(self, request):
-            return "claim"
-
-        async def wait_claim(self, claim):
-            return Sandbox(namespace="demo", claim=claim, name="sandbox", services=["server"])
-
-        async def wait_service_ready(self, sandbox, service, time_to_start):
-            return None
-
-        async def delete_claim(self, claim):
-            order.append(("delete-claim", claim))
-
-        async def delete_pool(self, created_pool):
-            order.append(("delete-pool", created_pool))
-
-        async def delete_template(self, template):
-            order.append(("delete-template", template))
-
-        async def delete_namespace(self, created_namespace):
-            order.append(("delete-namespace", created_namespace))
+            raise AssertionError("Fleet sandbox transport must not delete namespaces")
 
     client = Client()
     monkeypatch.setattr(fleet_cloud, "_FleetClient", lambda: client)
-    transport = FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo")
 
+    transport = FleetCloudTransport(
+        image=Image.from_registry("example:latest"), name="demo"
+    )
     await transport.connect()
-    await transport.delete_vm()
 
-    assert order == [
-        ("get-namespace", "demo"),
-        ("create-namespace", "demo"),
-        ("get-namespace", "demo"),
-        ("template", "demo"),
-        ("pool", "demo"),
-        ("delete-claim", "claim"),
-        ("delete-pool", pool),
-        ("delete-template", "template"),
+    assert [call[0] for call in calls] == [
+        "reconcile_pool",
+        "reconcile_template",
+        "wait_pool",
+        "create_claim",
+        "wait_claim",
+        "wait_service_ready",
     ]
+    pool_request = calls[0][1]
+    template_request = calls[1][1]
+    assert pool_request.namespace == "demo"
+    assert pool_request.spec.sandbox_template_ref.name == "demo"
+    assert pool_request.spec.replicas == 1
+    assert (template_request.namespace, template_request.name) == ("demo", "demo")
+    assert calls[-1] == ("wait_service_ready", bound, "server", 600.0)
 
 
 @pytest.mark.asyncio
-async def test_connect_rolls_back_template_then_owned_namespace_after_pool_failure(monkeypatch):
-    order = []
-
-    class Client:
-        async def get_namespace(self, name):
-            raise SdkError.Status("get namespace", 404, "missing")
-
-        async def create_namespace(self, name):
-            order.append(("create-namespace", name))
-            return object()
-
-        async def create_template(self, request):
-            order.append(("create-template", request.name))
-            return "template"
-
-        async def create_pool(self, request):
-            order.append(("create-pool", request.namespace))
-            raise RuntimeError("pool failed")
-
-        async def delete_template(self, template):
-            order.append(("delete-template", template))
-
-        async def delete_namespace(self, namespace):
-            order.append(("delete-namespace", namespace))
-
-    client = Client()
-    monkeypatch.setattr(fleet_cloud, "_FleetClient", lambda: client)
-
-    with pytest.raises(RuntimeError, match="pool failed"):
-        await FleetCloudTransport(
-            image=Image.from_registry("example:latest"), name="demo"
-        ).connect()
-
-    assert order == [
-        ("create-namespace", "demo"),
-        ("create-template", "demo"),
-        ("create-pool", "demo"),
-        ("delete-template", "template"),
-        ("delete-namespace", "demo"),
-    ]
-
-
-@pytest.mark.asyncio
-async def test_cleanup_preserves_existing_namespace():
-    transport = FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo")
-    calls = []
-
-    class Client:
-        async def delete_template(self, template):
-            calls.append(("template", template))
-
-        async def delete_namespace(self, namespace):
-            calls.append(("namespace", namespace))
-
-    transport._sdk = Client()
-    transport._template = "template"
-    transport._owns_namespace = False
-
-    await transport._cleanup_resources()
-
-    assert calls == [("template", "template")]
-
-
-@pytest.mark.asyncio
-async def test_connect_with_existing_pool_skips_namespace_crud(monkeypatch):
+async def test_connect_without_image_uses_existing_pool_and_claim_by_name(monkeypatch):
     calls = []
     pool = type("Pool", (), {"metadata": type("Metadata", (), {"name": "demo"})()})()
+    bound = Sandbox(namespace="demo", claim="demo-claim", name="sandbox", services=["server"])
 
     class Client:
-        async def get_namespace(self, name):
-            calls.append(("get-namespace", name))
-            raise AssertionError("existing pools must not manage namespaces")
-
-        async def create_namespace(self, name):
-            calls.append(("create-namespace", name))
-            raise AssertionError("existing pools must not manage namespaces")
-
-        async def delete_namespace(self, namespace):
-            calls.append(("delete-namespace", namespace))
-            raise AssertionError("existing pools must not manage namespaces")
-
         async def get_pool(self, name):
-            calls.append(("get-pool", name))
+            calls.append(("get_pool", name))
             return pool
 
         async def get_claim(self, existing_pool):
-            calls.append(("get-claim", existing_pool))
+            calls.append(("get_claim", existing_pool))
             return "claim"
 
         async def wait_claim(self, claim):
-            calls.append(("wait-claim", claim))
-            return Sandbox(namespace="demo", claim=claim, name="sandbox", services=["server"])
+            calls.append(("wait_claim", claim))
+            return bound
 
         async def wait_service_ready(self, sandbox, service, time_to_start):
-            calls.append(("wait-service-ready", service))
+            calls.append(("wait_service_ready", sandbox, service, time_to_start))
+
+        async def get_namespace(self, name):
+            raise AssertionError("existing Fleet sandboxes must not get namespaces")
+
+        async def create_namespace(self, name):
+            raise AssertionError("existing Fleet sandboxes must not create namespaces")
+
+        async def reconcile_pool(self, request):
+            raise AssertionError("existing Fleet sandboxes must not reconcile pools")
 
     client = Client()
     monkeypatch.setattr(fleet_cloud, "_FleetClient", lambda: client)
@@ -464,65 +146,43 @@ async def test_connect_with_existing_pool_skips_namespace_crud(monkeypatch):
     await FleetCloudTransport(image=None, name="demo").connect()
 
     assert calls == [
-        ("get-pool", "demo"),
-        ("get-claim", pool),
-        ("wait-claim", "claim"),
-        ("wait-service-ready", "server"),
+        ("get_pool", "demo"),
+        ("get_claim", pool),
+        ("wait_claim", "claim"),
+        ("wait_service_ready", bound, "server", 600.0),
     ]
 
 
 @pytest.mark.asyncio
-async def test_cleanup_stops_after_claim_failure():
-    transport = FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo")
+async def test_cleanup_deletes_claim_pool_and_template_but_not_namespace():
     calls = []
 
     class Client:
         async def delete_claim(self, claim):
-            calls.append(("claim", claim))
-            raise RuntimeError("claim delete failed")
+            calls.append(("delete_claim", claim))
 
         async def delete_pool(self, pool):
-            calls.append(("pool", pool))
-
-    transport._sdk = Client()
-    transport._claim = "claim"
-    transport._pool = "pool"
-    with pytest.raises(RuntimeError, match="claim delete failed"):
-        await transport._cleanup_resources()
-    assert calls == [("claim", "claim")]
-
-
-@pytest.mark.asyncio
-async def test_cleanup_releases_claim_pool_template_then_owned_namespace():
-    transport = FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo")
-    calls = []
-
-    class Client:
-        async def delete_claim(self, claim):
-            calls.append(("claim", claim))
-
-        async def delete_pool(self, pool):
-            calls.append(("pool", pool))
+            calls.append(("delete_pool", pool))
 
         async def delete_template(self, template):
-            calls.append(("template", template))
+            calls.append(("delete_template", template))
 
         async def delete_namespace(self, name):
-            calls.append(("namespace", name))
+            raise AssertionError("Fleet sandbox cleanup must not delete namespaces")
 
+    transport = FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo")
     transport._sdk = Client()
     transport._claim = "claim"
     transport._pool = "pool"
     transport._template = "template"
-    transport._owns_namespace = True
+
     await transport._cleanup_resources()
+
     assert calls == [
-        ("claim", "claim"),
-        ("pool", "pool"),
-        ("template", "template"),
-        ("namespace", "demo"),
+        ("delete_claim", "claim"),
+        ("delete_pool", "pool"),
+        ("delete_template", "template"),
     ]
-    assert transport._template is None
 
 
 @pytest.mark.asyncio
@@ -544,25 +204,7 @@ async def test_forward_tunnel_uses_named_service_url():
 
 
 @pytest.mark.asyncio
-async def test_forward_tunnel_uses_server_service_for_custom_server_port():
-    transport = FleetCloudTransport(
-        image=Image.from_registry("example:latest"), name="demo", server_port=5000
-    )
-    transport._provisioned = True
-    transport._bound = Sandbox(namespace="demo", claim="claim", name="sandbox", services=["server"])
-
-    class Client:
-        def service_url(self, sandbox, service):
-            assert service == "server"
-            return "https://run.cua.ai/api/svc/demo/sandbox-server/"
-
-    transport._sdk = Client()
-    tunnel = await transport.forward_tunnel(5000)
-    assert tunnel.url == "https://run.cua.ai/api/svc/demo/sandbox-server/"
-
-
-@pytest.mark.asyncio
 async def test_snapshot_is_unsupported():
     transport = FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo")
-    with pytest.raises(NotImplementedError, match="Snapshots"):
+    with pytest.raises(NotImplementedError, match="Snapshots are not supported"):
         await transport.create_snapshot()

--- a/libs/python/cua-sandbox/tests/test_fleet_cloud_transport.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_cloud_transport.py
@@ -1,7 +1,8 @@
 from types import SimpleNamespace
 
 import pytest
-from cua_sandbox import Image, Sandbox as CuaSandbox
+from cua_sandbox import Image
+from cua_sandbox import Sandbox as CuaSandbox
 from cua_sandbox.transport import fleet_cloud
 from cua_sandbox.transport.fleet_cloud import FleetCloudTransport
 from fleet_sdk import (

--- a/libs/python/cua-sandbox/tests/test_fleet_cloud_transport.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_cloud_transport.py
@@ -1,8 +1,21 @@
+from types import SimpleNamespace
+
 import pytest
 from cua_sandbox import Image
 from cua_sandbox.transport import fleet_cloud
 from cua_sandbox.transport.fleet_cloud import FleetCloudTransport
 from fleet_sdk import Sandbox
+
+
+def _pool(name="demo"):
+    return SimpleNamespace(
+        metadata=SimpleNamespace(name=name, namespace=name),
+        spec=SimpleNamespace(sandbox_template_ref=SimpleNamespace(name=name)),
+    )
+
+
+def _bound():
+    return Sandbox(namespace="demo", claim="demo-claim", name="sandbox", services=["server"])
 
 
 def test_registry_image_becomes_typed_template_request():
@@ -24,7 +37,7 @@ def test_registry_image_becomes_typed_template_request():
     ]
 
 
-def test_pool_request_uses_the_sandbox_name_and_requested_replicas():
+def test_pool_request_uses_the_single_sandbox_name_and_requested_replicas():
     request = FleetCloudTransport(
         image=Image.from_registry("registry.example/workspace@sha256:abc"),
         name="demo",
@@ -48,8 +61,8 @@ def test_rejects_unsupported_images(image):
 @pytest.mark.asyncio
 async def test_image_connect_reconciles_named_resources_without_namespace_calls(monkeypatch):
     calls = []
-    pool = type("Pool", (), {"metadata": type("Metadata", (), {"name": "demo"})()})()
-    bound = Sandbox(namespace="demo", claim="demo-claim", name="sandbox", services=["server"])
+    pool = _pool()
+    bound = _bound()
 
     class Client:
         async def reconcile_pool(self, request):
@@ -81,15 +94,16 @@ async def test_image_connect_reconciles_named_resources_without_namespace_calls(
         async def create_namespace(self, name):
             raise AssertionError("Fleet sandbox transport must not create namespaces")
 
-        async def delete_namespace(self, name):
-            raise AssertionError("Fleet sandbox transport must not delete namespaces")
+        async def create_pool(self, request):
+            raise AssertionError("Fleet sandbox transport must reconcile pools")
+
+        async def create_template(self, request):
+            raise AssertionError("Fleet sandbox transport must reconcile templates")
 
     client = Client()
     monkeypatch.setattr(fleet_cloud, "_FleetClient", lambda: client)
 
-    transport = FleetCloudTransport(
-        image=Image.from_registry("example:latest"), name="demo"
-    )
+    transport = FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo")
     await transport.connect()
 
     assert [call[0] for call in calls] == [
@@ -110,10 +124,141 @@ async def test_image_connect_reconciles_named_resources_without_namespace_calls(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure_stage",
+    [
+        "reconcile_pool",
+        "reconcile_template",
+        "wait_pool",
+        "create_claim",
+        "wait_claim",
+        "service_ready",
+    ],
+)
+async def test_connect_failure_releases_only_created_claim(monkeypatch, failure_stage):
+    calls = []
+    pool = _pool()
+    bound = _bound()
+
+    class Client:
+        async def reconcile_pool(self, request):
+            calls.append("reconcile_pool")
+            if failure_stage == "reconcile_pool":
+                raise RuntimeError("reconcile_pool failed")
+            return pool
+
+        async def reconcile_template(self, request):
+            calls.append("reconcile_template")
+            if failure_stage == "reconcile_template":
+                raise RuntimeError("reconcile_template failed")
+            return "template"
+
+        async def wait_pool(self, reconciled_pool):
+            calls.append("wait_pool")
+            if failure_stage == "wait_pool":
+                raise RuntimeError("wait_pool failed")
+            return reconciled_pool
+
+        async def create_claim(self, request):
+            calls.append("create_claim")
+            if failure_stage == "create_claim":
+                raise RuntimeError("create_claim failed")
+            return "claim"
+
+        async def wait_claim(self, claim):
+            calls.append("wait_claim")
+            if failure_stage == "wait_claim":
+                raise RuntimeError("wait_claim failed")
+            return bound
+
+        async def wait_service_ready(self, sandbox, service, time_to_start):
+            calls.append("service_ready")
+            if failure_stage == "service_ready":
+                raise RuntimeError("service_ready failed")
+
+        async def delete_claim(self, claim):
+            calls.append("delete_claim")
+
+        async def delete_pool(self, reconciled_pool):
+            calls.append("delete_pool")
+
+        async def delete_template(self, template):
+            calls.append("delete_template")
+
+        async def delete_namespace(self, name):
+            calls.append("delete_namespace")
+
+    client = Client()
+    monkeypatch.setattr(fleet_cloud, "_FleetClient", lambda: client)
+    transport = FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo")
+
+    with pytest.raises(RuntimeError, match=f"{failure_stage} failed"):
+        await transport.connect()
+
+    claim_was_created = failure_stage in {"wait_claim", "service_ready"}
+    assert ("delete_claim" in calls) is claim_was_created
+    assert "delete_pool" not in calls
+    assert "delete_template" not in calls
+    assert "delete_namespace" not in calls
+    assert transport._sdk is client
+    assert transport._pool is (None if failure_stage == "reconcile_pool" else pool)
+    template_reconciled = failure_stage not in {"reconcile_pool", "reconcile_template"}
+    assert transport._template == ("template" if template_reconciled else None)
+    assert transport._claim is None
+    assert not transport._provisioned
+
+
+@pytest.mark.asyncio
+async def test_connect_failure_preserves_claim_when_claim_cleanup_fails(monkeypatch):
+    pool = _pool()
+    calls = []
+
+    class Client:
+        async def reconcile_pool(self, request):
+            return pool
+
+        async def reconcile_template(self, request):
+            return "template"
+
+        async def wait_pool(self, reconciled_pool):
+            return reconciled_pool
+
+        async def create_claim(self, request):
+            return "claim"
+
+        async def wait_claim(self, claim):
+            raise RuntimeError("claim wait failed")
+
+        async def delete_claim(self, claim):
+            calls.append(("delete_claim", claim))
+            raise RuntimeError("claim delete failed")
+
+        async def delete_pool(self, reconciled_pool):
+            raise AssertionError("failed claim cleanup must not delete the pool")
+
+        async def delete_template(self, template):
+            raise AssertionError("failed claim cleanup must not delete the template")
+
+    client = Client()
+    monkeypatch.setattr(fleet_cloud, "_FleetClient", lambda: client)
+    transport = FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo")
+
+    with pytest.raises(RuntimeError, match="claim wait failed") as error:
+        await transport.connect()
+
+    assert isinstance(error.value.__cause__, RuntimeError)
+    assert str(error.value.__cause__) == "claim delete failed"
+    assert calls == [("delete_claim", "claim")]
+    assert transport._claim == "claim"
+    assert transport._pool is pool
+    assert transport._template == "template"
+
+
+@pytest.mark.asyncio
 async def test_connect_without_image_uses_existing_pool_and_claim_by_name(monkeypatch):
     calls = []
-    pool = type("Pool", (), {"metadata": type("Metadata", (), {"name": "demo"})()})()
-    bound = Sandbox(namespace="demo", claim="demo-claim", name="sandbox", services=["server"])
+    pool = _pool()
+    bound = _bound()
 
     class Client:
         async def get_pool(self, name):
@@ -154,7 +299,7 @@ async def test_connect_without_image_uses_existing_pool_and_claim_by_name(monkey
 
 
 @pytest.mark.asyncio
-async def test_cleanup_deletes_claim_pool_and_template_but_not_namespace():
+async def test_instance_cleanup_deletes_only_claim_and_preserves_infrastructure_state():
     calls = []
 
     class Client:
@@ -168,20 +313,137 @@ async def test_cleanup_deletes_claim_pool_and_template_but_not_namespace():
             calls.append(("delete_template", template))
 
         async def delete_namespace(self, name):
-            raise AssertionError("Fleet sandbox cleanup must not delete namespaces")
+            calls.append(("delete_namespace", name))
 
     transport = FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo")
     transport._sdk = Client()
     transport._claim = "claim"
     transport._pool = "pool"
     transport._template = "template"
+    transport._provisioned = True
 
     await transport._cleanup_resources()
 
+    assert calls == [("delete_claim", "claim")]
+    assert transport._claim is None
+    assert transport._pool == "pool"
+    assert transport._template == "template"
+    assert not transport._provisioned
+
+
+@pytest.mark.asyncio
+async def test_instance_cleanup_stops_after_claim_failure_and_preserves_state():
+    calls = []
+
+    class Client:
+        async def delete_claim(self, claim):
+            calls.append(("delete_claim", claim))
+            raise RuntimeError("claim delete failed")
+
+        async def delete_pool(self, pool):
+            raise AssertionError("claim cleanup failure must not delete the pool")
+
+        async def delete_template(self, template):
+            raise AssertionError("claim cleanup failure must not delete the template")
+
+    transport = FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo")
+    transport._sdk = Client()
+    transport._claim = "claim"
+    transport._pool = "pool"
+    transport._template = "template"
+    transport._provisioned = True
+
+    with pytest.raises(RuntimeError, match="claim delete failed"):
+        await transport._cleanup_resources()
+
+    assert calls == [("delete_claim", "claim")]
+    assert transport._claim == "claim"
+    assert transport._pool == "pool"
+    assert transport._template == "template"
+    assert transport._provisioned
+
+
+@pytest.mark.asyncio
+async def test_delete_sandbox_resolves_and_deletes_only_deterministic_claim(monkeypatch):
+    calls = []
+    pool = _pool("demo")
+
+    class Client:
+        async def get_pool(self, name):
+            calls.append(("get_pool", name))
+            return pool
+
+        async def get_claim(self, existing_pool):
+            calls.append(("get_claim", existing_pool))
+            return "demo-claim"
+
+        async def delete_claim(self, claim):
+            calls.append(("delete_claim", claim))
+
+        async def delete_pool(self, existing_pool):
+            calls.append(("delete_pool", existing_pool))
+
+        async def delete_template(self, template):
+            calls.append(("delete_template", template))
+
+        async def delete_namespace(self, name):
+            calls.append(("delete_namespace", name))
+
+        async def close(self):
+            calls.append(("close",))
+
+    monkeypatch.setattr(fleet_cloud, "_FleetClient", Client)
+
+    await FleetCloudTransport.delete_sandbox("demo")
+
     assert calls == [
-        ("delete_claim", "claim"),
-        ("delete_pool", "pool"),
-        ("delete_template", "template"),
+        ("get_pool", "demo"),
+        ("get_claim", pool),
+        ("delete_claim", "demo-claim"),
+        ("close",),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delete_sandbox_closes_sdk_when_claim_delete_fails(monkeypatch):
+    calls = []
+    pool = _pool("demo")
+
+    class Client:
+        async def get_pool(self, name):
+            calls.append(("get_pool", name))
+            return pool
+
+        async def get_claim(self, existing_pool):
+            calls.append(("get_claim", existing_pool))
+            return "demo-claim"
+
+        async def delete_claim(self, claim):
+            calls.append(("delete_claim", claim))
+            raise RuntimeError("claim delete failed")
+
+        async def delete_pool(self, existing_pool):
+            raise AssertionError("class delete must not delete pools")
+
+        async def delete_template(self, template):
+            raise AssertionError("class delete must not delete templates")
+
+        async def delete_namespace(self, name):
+            raise AssertionError("class delete must not delete namespaces")
+
+        async def close(self):
+            calls.append(("close",))
+
+    monkeypatch.setattr(fleet_cloud, "_FleetClient", Client)
+
+    with pytest.raises(RuntimeError, match="claim delete failed"):
+        await FleetCloudTransport.delete_sandbox("demo")
+
+    assert calls == [
+        ("get_pool", "demo"),
+        ("get_claim", pool),
+        ("delete_claim", "demo-claim"),
+        ("close",),
     ]
 
 

--- a/libs/python/cua-sandbox/tests/test_fleet_cloud_transport.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_cloud_transport.py
@@ -1,10 +1,17 @@
 from types import SimpleNamespace
 
 import pytest
-from cua_sandbox import Image
+from cua_sandbox import Image, Sandbox as CuaSandbox
 from cua_sandbox.transport import fleet_cloud
 from cua_sandbox.transport.fleet_cloud import FleetCloudTransport
-from fleet_sdk import Sandbox
+from fleet_sdk import (
+    OsGymSandboxWarmPoolSpecBuilder,
+    OsGymSandboxWarmPoolStatus,
+    Pool,
+    ResourceMetadata,
+    Sandbox,
+    SandboxTemplateRefBuilder,
+)
 
 
 def _pool(name="demo"):
@@ -16,6 +23,33 @@ def _pool(name="demo"):
 
 def _bound():
     return Sandbox(namespace="demo", claim="demo-claim", name="sandbox", services=["server"])
+
+
+def test_generated_pool_converts_to_sandbox_info():
+    pool = Pool(
+        api_version="osgym.cua.ai/v1alpha1",
+        kind="OSGymSandboxWarmPool",
+        metadata=ResourceMetadata(
+            namespace="demo",
+            name="demo",
+            labels=None,
+            creation_timestamp="2026-08-09T00:00:00Z",
+        ),
+        spec=(
+            OsGymSandboxWarmPoolSpecBuilder()
+            .replicas(1)
+            .sandbox_template_ref(SandboxTemplateRefBuilder().name("demo").build())
+            .build()
+        ),
+        status=OsGymSandboxWarmPoolStatus(replicas=1, ready_replicas=1, selector=None),
+    )
+
+    info = CuaSandbox._fleet_sandbox_info(pool)
+
+    assert info.name == "demo"
+    assert info.status == "running"
+    assert info.source == "fleet"
+    assert info.created_at == "2026-08-09T00:00:00Z"
 
 
 def test_registry_image_becomes_typed_template_request():
@@ -49,6 +83,7 @@ def test_pool_request_uses_the_single_sandbox_name_and_requested_replicas():
     assert request.spec.sandbox_template_ref.name == "demo"
     assert request.spec.autoscaling is None
 
+
 @pytest.mark.parametrize("pool_length", [57, 58, 63])
 def test_deterministic_claim_name_obeys_dns_label_boundary(pool_length):
     pool_name = "a" * pool_length
@@ -59,7 +94,9 @@ def test_deterministic_claim_name_obeys_dns_label_boundary(pool_length):
     assert claim_name == claim_name.lower()
     assert claim_name[0].isalnum()
     assert claim_name[-1].isalnum()
-    assert all(character.islower() or character.isdigit() or character == "-" for character in claim_name)
+    assert all(
+        character.islower() or character.isdigit() or character == "-" for character in claim_name
+    )
     if pool_length == 57:
         assert claim_name == f"{pool_name}-claim"
     else:
@@ -168,6 +205,7 @@ async def test_image_connect_reconciles_named_resources_without_namespace_calls(
     assert claim_request.name == "demo-claim"
     assert calls[-1] == ("wait_service_ready", bound, "server", 600.0)
 
+
 @pytest.mark.asyncio
 async def test_created_claim_is_resolved_by_later_connect_and_delete(monkeypatch):
     calls = []
@@ -221,9 +259,7 @@ async def test_created_claim_is_resolved_by_later_connect_and_delete(monkeypatch
     client = Client()
     monkeypatch.setattr(fleet_cloud, "_FleetClient", lambda: client)
 
-    await FleetCloudTransport(
-        image=Image.from_registry("example:latest"), name=pool_name
-    ).connect()
+    await FleetCloudTransport(image=Image.from_registry("example:latest"), name=pool_name).connect()
     await FleetCloudTransport(image=None, name=pool_name).connect()
     await FleetCloudTransport.delete_sandbox(pool_name)
 
@@ -300,6 +336,52 @@ async def test_retry_reruns_full_image_reconciliation_order(monkeypatch, failure
         "create_claim",
         "wait_claim",
         "service_ready",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_claim_creation_recovers_deterministic_claim(monkeypatch):
+    calls = []
+    pool = _pool()
+    bound = _bound()
+    created_claim = SimpleNamespace(metadata=SimpleNamespace(name="demo-claim"))
+
+    class Client:
+        async def reconcile_pool(self, request):
+            return pool
+
+        async def reconcile_template(self, request):
+            return "template"
+
+        async def wait_pool(self, reconciled_pool):
+            return reconciled_pool
+
+        async def create_claim(self, request):
+            calls.append(("create_claim", request.name))
+            raise RuntimeError("response lost after claim creation")
+
+        async def get_claim(self, existing_pool):
+            calls.append(("get_claim", existing_pool.metadata.name))
+            return created_claim
+
+        async def wait_claim(self, claim):
+            calls.append(("wait_claim", claim.metadata.name))
+            return bound
+
+        async def wait_service_ready(self, sandbox, service, time_to_start):
+            calls.append(("wait_service_ready", sandbox, service, time_to_start))
+
+    monkeypatch.setattr(fleet_cloud, "_FleetClient", Client)
+
+    transport = FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo")
+    await transport.connect()
+
+    assert transport._claim is created_claim
+    assert calls == [
+        ("create_claim", "demo-claim"),
+        ("get_claim", "demo"),
+        ("wait_claim", "demo-claim"),
+        ("wait_service_ready", bound, "server", 600.0),
     ]
 
 

--- a/libs/python/cua-sandbox/tests/test_fleet_cloud_transport.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_cloud_transport.py
@@ -49,6 +49,50 @@ def test_pool_request_uses_the_single_sandbox_name_and_requested_replicas():
     assert request.spec.sandbox_template_ref.name == "demo"
     assert request.spec.autoscaling is None
 
+@pytest.mark.parametrize("pool_length", [57, 58, 63])
+def test_deterministic_claim_name_obeys_dns_label_boundary(pool_length):
+    pool_name = "a" * pool_length
+
+    claim_name = fleet_cloud._claim_name(pool_name)
+
+    assert len(claim_name) <= 63
+    assert claim_name == claim_name.lower()
+    assert claim_name[0].isalnum()
+    assert claim_name[-1].isalnum()
+    assert all(character.islower() or character.isdigit() or character == "-" for character in claim_name)
+    if pool_length == 57:
+        assert claim_name == f"{pool_name}-claim"
+    else:
+        prefix, hash_suffix = claim_name.rsplit("-", 1)
+        assert pool_name.startswith(prefix)
+        assert len(hash_suffix) == 16
+        assert all(character in "0123456789abcdef" for character in hash_suffix)
+
+
+def test_deterministic_claim_name_distinguishes_long_pool_names():
+    first = fleet_cloud._claim_name(f"{'a' * 62}b")
+    second = fleet_cloud._claim_name(f"{'a' * 62}c")
+
+    assert first != second
+    assert first == fleet_cloud._claim_name(f"{'a' * 62}b")
+
+
+@pytest.mark.asyncio
+async def test_fleet_client_lookup_uses_bounded_deterministic_claim_name():
+    pool_name = "a" * 63
+    pool = _pool(pool_name)
+    claim = SimpleNamespace(metadata=SimpleNamespace(name=fleet_cloud._claim_name(pool_name)))
+    client = fleet_cloud._FleetClient.__new__(fleet_cloud._FleetClient)
+
+    class SDK:
+        async def list_claims(self, namespace):
+            assert namespace == pool_name
+            return [claim]
+
+    client._client = SDK()
+
+    assert await client.get_claim(pool) is claim
+
 
 @pytest.mark.parametrize(
     "image", [Image.linux(), Image.from_registry("example:latest").apt_install("curl")]
@@ -127,7 +171,9 @@ async def test_image_connect_reconciles_named_resources_without_namespace_calls(
 @pytest.mark.asyncio
 async def test_created_claim_is_resolved_by_later_connect_and_delete(monkeypatch):
     calls = []
-    pool = _pool()
+    pool_name = "a" * 63
+    expected_claim_name = fleet_cloud._claim_name(pool_name)
+    pool = _pool(pool_name)
     bound = _bound()
     created_claim = None
 
@@ -152,10 +198,11 @@ async def test_created_claim_is_resolved_by_later_connect_and_delete(monkeypatch
             return pool
 
         async def get_claim(self, existing_pool):
-            expected_name = f"{existing_pool.metadata.name}-claim"
-            calls.append(("get_claim", expected_name))
+            calls.append(("get_claim", fleet_cloud._claim_name(existing_pool.metadata.name)))
             assert created_claim is not None
-            assert created_claim.metadata.name == expected_name
+            assert created_claim.metadata.name == fleet_cloud._claim_name(
+                existing_pool.metadata.name
+            )
             return created_claim
 
         async def wait_claim(self, claim):
@@ -174,17 +221,19 @@ async def test_created_claim_is_resolved_by_later_connect_and_delete(monkeypatch
     client = Client()
     monkeypatch.setattr(fleet_cloud, "_FleetClient", lambda: client)
 
-    await FleetCloudTransport(image=Image.from_registry("example:latest"), name="demo").connect()
-    await FleetCloudTransport(image=None, name="demo").connect()
-    await FleetCloudTransport.delete_sandbox("demo")
+    await FleetCloudTransport(
+        image=Image.from_registry("example:latest"), name=pool_name
+    ).connect()
+    await FleetCloudTransport(image=None, name=pool_name).connect()
+    await FleetCloudTransport.delete_sandbox(pool_name)
 
     assert calls == [
-        ("create_claim", "demo-claim"),
-        ("get_pool", "demo"),
-        ("get_claim", "demo-claim"),
-        ("get_pool", "demo"),
-        ("get_claim", "demo-claim"),
-        ("delete_claim", "demo-claim"),
+        ("create_claim", expected_claim_name),
+        ("get_pool", pool_name),
+        ("get_claim", expected_claim_name),
+        ("get_pool", pool_name),
+        ("get_claim", expected_claim_name),
+        ("delete_claim", expected_claim_name),
         ("close",),
     ]
 

--- a/libs/python/cua-sandbox/uv.lock
+++ b/libs/python/cua-sandbox/uv.lock
@@ -551,7 +551,7 @@ wheels = [
 
 [[package]]
 name = "cua-sandbox"
-version = "0.1.26"
+version = "0.1.28"
 source = { editable = "." }
 dependencies = [
     { name = "cua-auto" },


### PR DESCRIPTION
## Scope
- authenticate Fleet sandbox operations with short-lived workload tokens from `cua wif-token github`
- preserve the existing `cua sb launch IMAGE --name NAME` contract without a namespace flag or namespace discovery
- reconcile a persistent one-replica Fleet pool/template, claim it deterministically, and release only the claim on delete
- run `cua sb exec` through the Sandbox SDK while preserving the remote exit code
- package `cua-sandbox==0.1.28` with `cua-cli==0.1.14`

## Validation
- `cua-sandbox`: 83 passed, 8 skipped across Fleet/cloud/pool focused suites
- `cua-cli`: 179 passed
- Ruff lint and format checks pass for all changed Python files
- both uv lockfiles pass `uv lock --check`
- wheel and sdist builds succeed for `cua-sandbox 0.1.28` and `cua-cli 0.1.14`
- clean Python 3.12 wheel install succeeds with `cua-fleet 0.1.8`; `cua wif-token github --help` and `cua sb exec --help` smoke successfully

## Behavior
- Fleet/WIF global listing is intentionally unsupported; exact-name operations remain supported
- generated Fleet `Pool` records decode through attribute access
- ambiguous deterministic claim creation recovers the existing claim
- `cua sb exec` returns the exact remote command status

## Existing work
This delivery preserves and integrates contributor work from #2934, #2939, and #2937.

Salvaged from #2934
Salvaged from #2939
Salvaged from #2937

## Follow-up
A live production WIF sandbox smoke remains gated on publishing these package versions and landing the matching cloud workflow.