### PR TITLE
fix(release): resolve Cua wheel dependencies with PDM

### DIFF
--- a/libs/python/cua-cli/pyproject.toml
+++ b/libs/python/cua-cli/pyproject.toml
@@ -122,3 +122,8 @@ cua-sandbox = { path = "../cua-sandbox", editable = true }
 [[tool.uv.index]]
 name = "cua-wheels"
 url = "https://wheels.cua.ai/simple"
+
+[[tool.pdm.source]]
+name = "cua-wheels"
+url = "https://wheels.cua.ai/simple"
+include_packages = ["cua-fleet"]

--- a/libs/python/cua-sandbox/pyproject.toml
+++ b/libs/python/cua-sandbox/pyproject.toml
@@ -100,3 +100,8 @@ cua-agent = { path = "../agent", editable = true }
 [[tool.uv.index]]
 name = "cua-wheels"
 url = "https://wheels.cua.ai/simple"
+
+[[tool.pdm.source]]
+name = "cua-wheels"
+url = "https://wheels.cua.ai/simple"
+include_packages = ["cua-fleet"]


### PR DESCRIPTION
## Problem
The `cua-sandbox 0.1.28` release workflow fails during `pdm lock` because PDM does not read `tool.uv.index` and cannot resolve `cua-fleet==0.1.8` from the public Cua wheel index.

## Fix
- declare `https://wheels.cua.ai/simple` as a PDM source for `cua-fleet` in `cua-sandbox`
- declare the same source in `cua-cli`, whose release dependency graph also includes `cua-fleet`

## Validation
- isolated PDM 2.28.0 `lock --prod` succeeds for `cua-sandbox 0.1.28`
- isolated PDM build produces the sandbox wheel and sdist

This unblocks the already-merged Fleets WIF release sequence.