### PR TITLE
feat(computer): add a Fleet-backed VM provider

### DIFF
--- a/libs/python/computer/computer/computer.py
+++ b/libs/python/computer/computer/computer.py
@@ -34,6 +34,7 @@ from cua_core.telemetry import is_telemetry_enabled, record_event
 from PIL import Image
 
 from . import helpers
+from .interface.base import ApiHeaders
 from .interface.factory import InterfaceFactory, OSType
 from .logger import Logger, LogLevel
 from .models import Computer as ComputerConfig
@@ -629,9 +630,45 @@ class Computer:
             self.logger.info(f"Initializing interface for {self.os_type} at {ip_address}")
             from .interface.base import BaseComputerInterface
 
+            # What the interface should use as its header source. A dict for
+            # every provider but Fleet, whose bearer expires mid-session.
+            api_headers: ApiHeaders = self.api_headers
+
+            # A Fleet sandbox has no routable address: it is reached through an
+            # authenticated proxy on the control plane, so the provider reports
+            # a URL and this overrides whatever host get_ip() returned.
+            if self.provider_type == VMProviderType.FLEET:
+                provider = self.config.vm_provider
+                if hasattr(provider, "get_api_base_url"):
+                    self.api_base_url = await provider.get_api_base_url(self.config.name)
+                    self.logger.info(f"Fleet sandbox reachable at {self.api_base_url}")
+                if hasattr(provider, "api_headers"):
+                    # Called, not read: the Fleet bearer is a Keycloak access
+                    # token the provider mints on demand, not a stored key.
+                    static_headers = dict(self.api_headers or {})
+
+                    async def resolve_fleet_headers() -> Dict[str, str]:
+                        """Re-mint the bearer for each connection attempt.
+
+                        Passed as a callable rather than as its result: those
+                        tokens live 900 seconds and a bench run lives hours, so
+                        an interface holding one dict reconnects with a bearer
+                        that expired and fails from then on. The provider
+                        caches, so this only reaches the token endpoint when
+                        the cached token is near expiry.
+                        """
+                        return {**static_headers, **(await provider.api_headers())}
+
+                    api_headers = resolve_fleet_headers
+                    # Resolved once here as well, so missing or rejected
+                    # credentials fail loudly while connecting instead of
+                    # surfacing as an opaque WebSocket timeout.
+                    self.api_headers = await resolve_fleet_headers()
+
             # Pass authentication credentials if using cloud provider
             if (
-                self.provider_type in (VMProviderType.CLOUD, VMProviderType.CLOUDV2)
+                self.provider_type
+                in (VMProviderType.CLOUD, VMProviderType.CLOUDV2, VMProviderType.FLEET)
                 and self.api_key
                 and self.config.name
             ):
@@ -644,7 +681,7 @@ class Computer:
                         vm_name=self.config.name,
                         api_port=self.api_port,
                         api_base_url=self.api_base_url,
-                        api_headers=self.api_headers,
+                        api_headers=api_headers,
                     ),
                 )
             else:
@@ -655,7 +692,7 @@ class Computer:
                         ip_address=ip_address,
                         api_port=self.api_port,
                         api_base_url=self.api_base_url,
-                        api_headers=self.api_headers,
+                        api_headers=api_headers,
                     ),
                 )
 

--- a/libs/python/computer/computer/interface/android.py
+++ b/libs/python/computer/computer/interface/android.py
@@ -1,5 +1,6 @@
-from typing import Dict, Optional
+from typing import Optional
 
+from .base import ApiHeaders
 from .generic import GenericComputerInterface
 
 
@@ -15,7 +16,7 @@ class AndroidComputerInterface(GenericComputerInterface):
         vm_name: Optional[str] = None,
         api_port: Optional[int] = None,
         api_base_url: Optional[str] = None,
-        api_headers: Optional[Dict[str, str]] = None,
+        api_headers: Optional[ApiHeaders] = None,
     ):
         super().__init__(
             ip_address,

--- a/libs/python/computer/computer/interface/base.py
+++ b/libs/python/computer/computer/interface/base.py
@@ -1,10 +1,24 @@
 """Base interface for computer control."""
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, Union
 
 from ..logger import Logger, LogLevel
 from .models import CommandResult, MouseButton
+
+#: What may be passed as ``api_headers``.
+#:
+#: A plain dict is a fixed credential: sent as-is on every request and every
+#: WebSocket upgrade, for the lifetime of the interface. A callable is a
+#: credential that expires -- it is re-resolved on each connection attempt and
+#: each REST request, so a session outliving its token reconnects with a fresh
+#: one instead of replaying a dead bearer. The callable may be sync or async;
+#: it is never called during construction, which is what allows it to be a
+#: coroutine function.
+ApiHeaders = Union[
+    Dict[str, str],
+    Callable[[], Union[Dict[str, str], Awaitable[Dict[str, str]]]],
+]
 
 
 class BaseComputerInterface(ABC):

--- a/libs/python/computer/computer/interface/factory.py
+++ b/libs/python/computer/computer/interface/factory.py
@@ -1,8 +1,8 @@
 """Factory for creating computer interfaces."""
 
-from typing import Dict, Literal, Optional
+from typing import Literal, Optional
 
-from .base import BaseComputerInterface
+from .base import ApiHeaders, BaseComputerInterface
 
 OSType = Literal["macos", "linux", "windows", "android"]
 
@@ -18,7 +18,7 @@ class InterfaceFactory:
         api_key: Optional[str] = None,
         vm_name: Optional[str] = None,
         api_base_url: Optional[str] = None,
-        api_headers: Optional[Dict[str, str]] = None,
+        api_headers: Optional[ApiHeaders] = None,
     ) -> BaseComputerInterface:
         """Create an interface for the specified OS.
 
@@ -32,7 +32,9 @@ class InterfaceFactory:
                 it sits behind an authenticated, path-prefixed reverse proxy. When set,
                 REST/WebSocket URIs are derived from it instead of ip_address + port.
             api_headers: Optional extra HTTP headers (e.g. ``Authorization: Bearer ...``)
-                sent on every REST request and the WebSocket upgrade.
+                sent on every REST request and the WebSocket upgrade. Either a dict,
+                or a sync/async callable returning one, which is re-resolved per
+                request and per connection attempt for credentials that expire.
 
         Returns:
             BaseComputerInterface: The appropriate interface for the OS

--- a/libs/python/computer/computer/interface/generic.py
+++ b/libs/python/computer/computer/interface/generic.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import json
 import time
 from typing import Any, Dict, List, Optional, Tuple
@@ -16,7 +17,7 @@ from ..utils import (
     encode_base64_image,
     resize_image,
 )
-from .base import BaseComputerInterface
+from .base import ApiHeaders, BaseComputerInterface
 from .models import CommandResult, Key, KeyType, MouseButton
 
 
@@ -33,7 +34,7 @@ class GenericComputerInterface(BaseComputerInterface):
         logger_name: str = "computer.interface.generic",
         api_port: Optional[int] = None,
         api_base_url: Optional[str] = None,
-        api_headers: Optional[Dict[str, str]] = None,
+        api_headers: Optional[ApiHeaders] = None,
     ):
         super().__init__(ip_address, username, password, api_key, vm_name)
         self._ws = None
@@ -60,10 +61,42 @@ class GenericComputerInterface(BaseComputerInterface):
         # (preserving its scheme, host, port and path prefix) instead of being rebuilt
         # from ``ip_address`` + port.
         self._api_base_url = api_base_url.rstrip("/") if api_base_url else None
-        self._api_headers = dict(api_headers) if api_headers else {}
+
+        # ``api_headers`` is either a fixed dict or a callable that produces one.
+        # A callable is kept as the source and resolved per connection attempt and
+        # per REST request, because a bearer with a lifetime (Fleet's Keycloak
+        # tokens last 900 seconds) goes stale inside a long session: the open
+        # socket survives -- the proxy authenticates the upgrade, not each frame --
+        # but the reconnect after a network blip would replay a dead token and be
+        # rejected for good. It is deliberately not called here: construction is
+        # sync, and calling it would force every source to be sync forever.
+        # ``_api_headers`` always holds the last resolved value, so a dict source
+        # is stored exactly as before and read without any indirection.
+        self._api_headers_source = api_headers if callable(api_headers) else None
+        self._api_headers: Dict[str, str] = (
+            dict(api_headers) if api_headers and not callable(api_headers) else {}
+        )
 
         # Optional default delay time between commands (in seconds)
         self.delay = 0.0
+
+    async def _resolve_api_headers(self) -> Dict[str, str]:
+        """Return the extra headers to send right now.
+
+        With a dict source this is the dict it was given -- no work, no change
+        in behaviour for CLOUD/CLOUDV2 or ``use_host_computer_server`` callers.
+        With a callable source the value is re-resolved on every call, which is
+        what lets a reconnect mint a fresh token; the callable may be sync or
+        async, since a credential refresh usually needs I/O.
+        """
+        if self._api_headers_source is None:
+            return self._api_headers
+
+        headers = self._api_headers_source()
+        if inspect.isawaitable(headers):
+            headers = await headers
+        self._api_headers = dict(headers) if headers else {}
+        return self._api_headers
 
     async def _handle_delay(self, delay: Optional[float] = None):
         """Handle delay between commands using async sleep.
@@ -830,8 +863,10 @@ class GenericComputerInterface(BaseComputerInterface):
         if self.vm_name:
             headers["X-Container-Name"] = self.vm_name
         # Merge arbitrary extra headers (e.g. ``Authorization: Bearer ...``) last so
-        # callers can override defaults if needed.
-        headers.update(self._api_headers)
+        # callers can override defaults if needed. Resolved per request for the same
+        # reason the WebSocket upgrade resolves per attempt: an expiring bearer has
+        # to be current at the moment it is sent.
+        headers.update(await self._resolve_api_headers())
 
         try:
             async with aiohttp.ClientSession() as session:
@@ -891,10 +926,14 @@ class GenericComputerInterface(BaseComputerInterface):
                         # on the WebSocket upgrade request so proxies that authenticate the
                         # upgrade can accept the connection. Newer websockets versions use
                         # ``additional_headers``; older ones use ``extra_headers``.
-                        if self._api_headers:
-                            connect_kwargs[self._ws_headers_kwarg()] = list(
-                                self._api_headers.items()
-                            )
+                        #
+                        # Resolved here rather than once at construction: this is the
+                        # reconnect path, and a session that outlives its token has to
+                        # dial back with a current one. For a dict source this is the
+                        # same dict every time.
+                        api_headers = await self._resolve_api_headers()
+                        if api_headers:
+                            connect_kwargs[self._ws_headers_kwarg()] = list(api_headers.items())
                         self._ws = await asyncio.wait_for(
                             websockets.connect(self.ws_uri, **connect_kwargs),
                             timeout=120,
@@ -1081,8 +1120,9 @@ class GenericComputerInterface(BaseComputerInterface):
                     headers["X-API-Key"] = self.api_key
                 if self.vm_name:
                     headers["X-Container-Name"] = self.vm_name
-                # Merge arbitrary extra headers (e.g. ``Authorization: Bearer ...``).
-                headers.update(self._api_headers)
+                # Merge arbitrary extra headers (e.g. ``Authorization: Bearer ...``),
+                # resolved per request so an expiring bearer is current when sent.
+                headers.update(await self._resolve_api_headers())
 
                 # Send the request
                 async with aiohttp.ClientSession() as session:

--- a/libs/python/computer/computer/interface/linux.py
+++ b/libs/python/computer/computer/interface/linux.py
@@ -1,5 +1,6 @@
-from typing import Dict, Optional
+from typing import Optional
 
+from .base import ApiHeaders
 from .generic import GenericComputerInterface
 
 
@@ -15,7 +16,7 @@ class LinuxComputerInterface(GenericComputerInterface):
         vm_name: Optional[str] = None,
         api_port: Optional[int] = None,
         api_base_url: Optional[str] = None,
-        api_headers: Optional[Dict[str, str]] = None,
+        api_headers: Optional[ApiHeaders] = None,
     ):
         super().__init__(
             ip_address,

--- a/libs/python/computer/computer/interface/macos.py
+++ b/libs/python/computer/computer/interface/macos.py
@@ -1,5 +1,6 @@
-from typing import Dict, Optional
+from typing import Optional
 
+from .base import ApiHeaders
 from .generic import GenericComputerInterface
 
 
@@ -15,7 +16,7 @@ class MacOSComputerInterface(GenericComputerInterface):
         vm_name: Optional[str] = None,
         api_port: Optional[int] = None,
         api_base_url: Optional[str] = None,
-        api_headers: Optional[Dict[str, str]] = None,
+        api_headers: Optional[ApiHeaders] = None,
     ):
         super().__init__(
             ip_address,

--- a/libs/python/computer/computer/interface/windows.py
+++ b/libs/python/computer/computer/interface/windows.py
@@ -1,5 +1,6 @@
-from typing import Dict, Optional
+from typing import Optional
 
+from .base import ApiHeaders
 from .generic import GenericComputerInterface
 
 
@@ -15,7 +16,7 @@ class WindowsComputerInterface(GenericComputerInterface):
         vm_name: Optional[str] = None,
         api_port: Optional[int] = None,
         api_base_url: Optional[str] = None,
-        api_headers: Optional[Dict[str, str]] = None,
+        api_headers: Optional[ApiHeaders] = None,
     ):
         super().__init__(
             ip_address,

--- a/libs/python/computer/computer/providers/base.py
+++ b/libs/python/computer/computer/providers/base.py
@@ -16,6 +16,7 @@ class VMProviderType(StrEnum):
     CLOUDV2 = "cloudv2"
     WINSANDBOX = "winsandbox"
     DOCKER = "docker"
+    FLEET = "fleet"
     UNKNOWN = "unknown"
 
 

--- a/libs/python/computer/computer/providers/factory.py
+++ b/libs/python/computer/computer/providers/factory.py
@@ -177,5 +177,34 @@ class VMProviderFactory:
                     "Docker is required for DockerProvider. "
                     "Please install Docker and ensure it is running."
                 ) from e
+        elif provider_type == VMProviderType.FLEET:
+            try:
+                from .fleet import FleetProvider
+
+                pool = kwargs.get("pool") or kwargs.get("pool_name")
+                if not pool:
+                    raise ValueError(
+                        "FleetProvider requires a pool. Pass pool=<name>: a sandbox is "
+                        "leased from an existing Fleet pool rather than created here."
+                    )
+                # Fleet authenticates with an OAuth client pair (or a token
+                # minted from one), never with an API key: the control plane
+                # only accepts a realm-issued JWT.
+                return FleetProvider(
+                    pool,
+                    client_id=kwargs.get("client_id"),
+                    client_secret=kwargs.get("client_secret"),
+                    access_token=kwargs.get("access_token"),
+                    token_url=kwargs.get("token_url"),
+                    base_url=kwargs.get("base_url"),
+                    service_name=kwargs.get("service_name", "server"),
+                    verbose=verbose,
+                )
+            except ImportError as e:
+                logger.error(f"Failed to import FleetProvider: {e}")
+                raise ImportError(
+                    "cua-sandbox is required for FleetProvider. "
+                    "Install it with: pip install cua-sandbox"
+                ) from e
         else:
             raise ValueError(f"Unsupported provider type: {provider_type}")

--- a/libs/python/computer/computer/providers/fleet/__init__.py
+++ b/libs/python/computer/computer/providers/fleet/__init__.py
@@ -1,0 +1,5 @@
+"""Fleet VM provider: sandboxes leased from a Cua Fleet pool."""
+
+from .provider import FleetProvider
+
+__all__ = ["FleetProvider"]

--- a/libs/python/computer/computer/providers/fleet/provider.py
+++ b/libs/python/computer/computer/providers/fleet/provider.py
@@ -1,0 +1,609 @@
+"""Fleet VM provider implementation.
+
+Leases sandboxes from a Cua Fleet pool instead of running a VM locally. A
+"VM" here is a Fleet claim bound to a pooled sandbox; the pool keeps warm
+replicas, so binding is fast where a cold boot would not be.
+
+The sandbox is never directly addressable. Fleet exposes each sandbox's named
+services through an authenticated proxy on the control plane::
+
+    {base_url}/api/svc/{sandbox_namespace}/{sandbox}-{service}/
+
+That route proxies WebSocket upgrades as well as plain HTTP (noVNC's
+websockify already relies on it), so computer-server's REST and WebSocket
+traffic both ride it. This is why the provider reports an ``api_base_url``
+rather than an IP: there is no IP to report, and the URL works from anywhere
+the control plane is reachable rather than only from inside the cluster.
+
+Authentication is OAuth 2.0 client credentials, not an API key. The control
+plane validates the bearer strictly as a Keycloak JWT (JWKS signature, issuer
+match, RS256/RS512/ES256), so the only thing that works on that proxy is an
+access token minted by the realm. What the product calls an "API key" is the
+``client_id``/``client_secret`` pair issued by ``POST /api/keys``, which is
+exchanged for a JWT at the realm's token endpoint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import inspect
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Dict, Optional, Tuple, Union
+
+from ..base import BaseVMProvider, VMProviderType
+from ..types import ListVMsResponse
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SERVICE_NAME = "server"
+DEFAULT_CLAIM_TTL_SECONDS = 3600
+DEFAULT_BIND_TIMEOUT_SECONDS = 600
+DEFAULT_TOKEN_URL = "https://auth.cua.ai/realms/cyclops-cs/protocol/openid-connect/token"
+# The realm hands out 900-second tokens. Renew slightly early so a token that
+# is about to lapse is never the one used to open a connection; the Rust SDK's
+# transport applies the same 30-second skew to its own cache.
+TOKEN_EXPIRY_SKEW_SECONDS = 30
+# Minting a token is on the reconnect path; a stalled realm should surface as a
+# retryable error rather than as a connection that appears to hang.
+TOKEN_REQUEST_TIMEOUT_SECONDS = 30
+
+TokenSource = Union[str, Callable[[], Any]]
+
+
+async def _request_client_credentials_token(
+    token_url: str, client_id: str, client_secret: str
+) -> Tuple[str, int]:
+    """Exchange client credentials for an access token.
+
+    Mirrors what the Fleet SDK's Rust transport does internally: HTTP Basic
+    with the client pair, ``grant_type=client_credentials`` as a form body.
+    The SDK caches that token behind its FFI boundary and exposes no accessor,
+    so the provider has to run the exchange itself to hand ``Computer`` a
+    bearer for the service proxy.
+
+    Returns the token and its lifetime in seconds.
+    """
+    import aiohttp
+
+    credentials = base64.b64encode(f"{client_id}:{client_secret}".encode()).decode()
+    # This runs on the reconnect path, so an unresponsive realm must fail fast
+    # rather than hold a reconnect open for aiohttp's five-minute default.
+    timeout = aiohttp.ClientTimeout(total=TOKEN_REQUEST_TIMEOUT_SECONDS)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.post(
+            token_url,
+            data="grant_type=client_credentials",
+            headers={
+                "accept": "application/json",
+                "content-type": "application/x-www-form-urlencoded",
+                "authorization": f"Basic {credentials}",
+            },
+        ) as response:
+            body = await response.text()
+            if not 200 <= response.status < 300:
+                raise RuntimeError(
+                    f"Fleet token request to {token_url} failed with HTTP "
+                    f"{response.status}: {body[:512]}"
+                )
+
+    payload = json.loads(body)
+    token = payload.get("access_token")
+    if not token:
+        raise RuntimeError(f"Fleet token endpoint {token_url} returned no access_token")
+    return str(token), int(payload.get("expires_in") or 0)
+
+
+@dataclass
+class _Lease:
+    """A claim held on behalf of one named VM.
+
+    The claim is what must be released; the bound sandbox is what carries the
+    name and services used to address it.
+    """
+
+    claim: Any
+    bound: Any
+
+
+class FleetProvider(BaseVMProvider):
+    """VM provider backed by a Cua Fleet pool.
+
+    Unlike the local providers, this one does not create or own a VM. It leases
+    one from a pool and releases the lease afterwards, so an abandoned lease
+    holds fleet capacity until its TTL expires. Every exit path therefore
+    releases: ``stop_vm`` for the ordinary case and ``__aexit__`` for anything
+    that skipped it.
+    """
+
+    def __init__(
+        self,
+        pool: str,
+        *,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        access_token: Optional[TokenSource] = None,
+        token_url: Optional[str] = None,
+        base_url: Optional[str] = None,
+        service_name: str = DEFAULT_SERVICE_NAME,
+        claim_ttl_seconds: int = DEFAULT_CLAIM_TTL_SECONDS,
+        bind_timeout_seconds: int = DEFAULT_BIND_TIMEOUT_SECONDS,
+        client: Optional[Any] = None,
+        verbose: bool = False,
+    ):
+        """Initialize the Fleet provider.
+
+        There is deliberately no ``namespace`` argument: the control plane
+        keys a pool's namespace to its name (``create_pool`` enforces
+        ``metadata.namespace == metadata.name``), so a caller-supplied
+        namespace could never change a lookup or a URL. The namespace used for
+        addressing is read from the pool, and overridden per sandbox by the
+        bound sandbox's own namespace.
+
+        Args:
+            pool: Name of the Fleet pool to claim sandboxes from.
+            client_id: OAuth client id. Falls back to the cua-sandbox config
+                and then to CUA_CLIENT_ID.
+            client_secret: OAuth client secret. Falls back to the cua-sandbox
+                config and then to CUA_CLIENT_SECRET.
+            access_token: A ready-made access token, used verbatim instead of
+                an exchange. Pass a callable (sync or async, returning a
+                string) to keep refresh in the caller's hands; a bare string
+                is a fixed token and expires with the realm's lifetime.
+                Falls back to the configured Fleet workload token and then to
+                FLEETS_TOKEN.
+            token_url: Realm token endpoint for the client-credentials
+                exchange. Falls back to the cua-sandbox config, then to the
+                cyclops-cs realm.
+            base_url: Fleet control-plane base URL. Falls back to the SDK's
+                configured base URL.
+            service_name: Sandbox service exposing computer-server.
+            claim_ttl_seconds: Lifetime requested for each claim. A claim that
+                outlives its holder is reclaimed rather than leaked forever.
+            bind_timeout_seconds: How long to wait for a claim to bind, and
+                how long the claim itself may sit Pending before Fleet fails
+                it.
+            client: Fleet client override, primarily for tests.
+            verbose: Enable debug logging.
+        """
+        if not pool:
+            raise ValueError("FleetProvider requires a pool name")
+
+        self.pool_name = pool
+        # Read from the pool once it resolves; only a fallback for addressing,
+        # since a bound sandbox carries its own namespace.
+        self.namespace: Optional[str] = None
+        self.base_url = base_url
+        self.service_name = service_name
+        self.claim_ttl_seconds = claim_ttl_seconds
+        self.bind_timeout_seconds = bind_timeout_seconds
+        self.verbose = verbose
+
+        # There is no opaque API key in Fleet: the control plane only accepts
+        # a realm-issued JWT, so what has to be resolved here is either a
+        # token or the client pair that mints one.
+        self.client_id = (
+            client_id or _config_value("get_client_id") or os.environ.get("CUA_CLIENT_ID")
+        )
+        self.client_secret = (
+            client_secret
+            or _config_value("get_client_secret")
+            or os.environ.get("CUA_CLIENT_SECRET")
+        )
+        self.token_url = token_url or _config_value("get_token_url") or DEFAULT_TOKEN_URL
+        self._token_source: Optional[TokenSource] = (
+            access_token or _config_value("get_fleet_token") or os.environ.get("FLEETS_TOKEN")
+        )
+
+        self._token: Optional[str] = None
+        self._token_expires_at = 0.0
+        self._token_lock = asyncio.Lock()
+
+        self._client = client
+        self._pool: Any = None
+        self._leases: Dict[str, _Lease] = {}
+
+    @property
+    def provider_type(self) -> VMProviderType:
+        return VMProviderType.FLEET
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> "FleetProvider":
+        if self._client is None:
+            self._client = self._default_client()
+        if self._pool is None:
+            self._pool = await self._client.get_pool(self.pool_name)
+            if self.namespace is None:
+                self.namespace = _namespace_of(self._pool)
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        # Release anything the caller left behind. A lease that escapes here
+        # occupies a pool replica until its TTL, which looks to everyone else
+        # like the pool is undersized.
+        for name in list(self._leases):
+            try:
+                await self.stop_vm(name)
+            except Exception:
+                logger.exception("Failed to release Fleet claim for %r", name)
+
+        if self._client is not None:
+            try:
+                await self._client.close()
+            except Exception:
+                logger.exception("Failed to close the Fleet client")
+
+    def _default_client(self) -> Any:
+        """Build the SDK client lazily.
+
+        cua-sandbox is an optional dependency: importing it at module scope
+        would make every provider import fail where it is not installed.
+        """
+        try:
+            from cua_sandbox.transport.fleet_cloud import _FleetClient
+        except ImportError as error:  # pragma: no cover - import guard
+            raise RuntimeError(
+                "FleetProvider requires the cua-sandbox package. "
+                "Install it with: pip install cua-sandbox"
+            ) from error
+        return _FleetClient()
+
+    # ------------------------------------------------------------------
+    # VM operations
+    # ------------------------------------------------------------------
+
+    async def run_vm(
+        self, image: str, name: str, run_opts: Dict[str, Any], storage: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Claim a sandbox from the pool and bind it to ``name``.
+
+        ``image`` is accepted for interface compatibility and ignored: a pooled
+        sandbox is built from the pool's template, so the image is fixed when
+        the pool is created rather than chosen per claim.
+        """
+        if name in self._leases:
+            logger.info("Fleet claim for %r already held; reusing it", name)
+            return await self.get_vm(name)
+
+        await self.__aenter__()
+
+        ttl = int(run_opts.get("ttl_seconds", self.claim_ttl_seconds))
+        spec = self._claim_spec(ttl)
+        request = self._claim_request(spec)
+
+        claim = await self._client.create_claim(request)
+        try:
+            bound = await asyncio.wait_for(
+                self._client.wait_claim(claim), timeout=self.bind_timeout_seconds
+            )
+        except Exception:
+            # The claim exists even though binding failed; leaving it behind
+            # would hold a replica for its whole TTL.
+            try:
+                await self._client.delete_claim(claim)
+            except Exception:
+                logger.exception("Failed to release an unbound Fleet claim")
+            raise
+
+        self._leases[name] = _Lease(claim=claim, bound=bound)
+        logger.info("Fleet claim for %r bound to sandbox %r", name, _name_of(bound))
+        return await self.get_vm(name)
+
+    async def stop_vm(self, name: str, storage: Optional[str] = None) -> Dict[str, Any]:
+        """Release the claim. The sandbox returns to the pool."""
+        lease = self._leases.pop(name, None)
+        if lease is None:
+            return {"name": name, "status": "stopped"}
+
+        await self._client.delete_claim(lease.claim)
+        logger.info("Released Fleet claim for %r", name)
+        return {"name": name, "status": "stopped"}
+
+    async def restart_vm(self, name: str, storage: Optional[str] = None) -> Dict[str, Any]:
+        """Raise: a bound claim cannot be restarted in place.
+
+        Releasing and re-claiming would look like a restart while silently
+        changing which sandbox the caller is talking to, and the old address
+        can be re-claimed by someone else rather than going dead. Callers that
+        want a fresh environment should stop and start, which re-resolves the
+        address. Computer.restart() already falls back to exactly that.
+        """
+        raise self._unsupported(
+            name,
+            "restart",
+            "a bound claim cannot be restarted in place; stop and start "
+            "instead, which claims a new sandbox and re-resolves its address",
+        )
+
+    async def update_vm(
+        self, name: str, update_opts: Dict[str, Any], storage: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Raise: a pooled sandbox's shape comes from the pool template.
+
+        There is nothing on a claim to change, so a resize request cannot be
+        honoured. It fails loudly rather than returning, so a caller never
+        proceeds believing the VM was resized.
+        """
+        raise self._unsupported(
+            name,
+            "resize",
+            "a pooled sandbox's shape comes from the pool template; "
+            "change the template and reconcile the pool",
+            requested=sorted(update_opts),
+        )
+
+    async def get_vm(self, name: str, storage: Optional[str] = None) -> Dict[str, Any]:
+        lease = self._leases.get(name)
+        if lease is None:
+            return {"name": name, "status": "stopped"}
+
+        sandbox = _name_of(lease.bound)
+        return {
+            "name": name,
+            "sandbox": sandbox,
+            "status": "running",
+            "api_url": self._api_base_url(lease.bound),
+            # fleet_sdk.Sandbox.services is a List[str] of service names, not
+            # a mapping. Coercing it with dict() raises, and run_vm ends in
+            # get_vm, so that lands after a claim is already bound.
+            "services": list(getattr(lease.bound, "services", None) or []),
+        }
+
+    async def list_vms(self) -> ListVMsResponse:
+        """List the claims this provider currently holds.
+
+        Deliberately not every claim in the namespace: another process's claims
+        are not this provider's to report or, worse, to release.
+        """
+        return [
+            {"name": name, "status": "running", "api_url": self._api_base_url(lease.bound)}
+            for name, lease in self._leases.items()
+        ]
+
+    async def get_ip(self, name: str, storage: Optional[str] = None, retry_delay: int = 2) -> str:
+        """Return the control-plane host that fronts the sandbox.
+
+        A Fleet sandbox has no routable address of its own, so this is the
+        proxy's host rather than the VM's. The full path lives in
+        ``get_api_base_url``; this exists because the base interface requires
+        it and callers use it only for logging and validity checks.
+
+        Waits for the claim to appear, then gives up. A name that was never
+        claimed will never arrive, and an unbounded wait turns that mistake
+        into a hang instead of an error.
+        """
+        deadline = time.monotonic() + self.bind_timeout_seconds
+        while name not in self._leases:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"No Fleet claim is held for {name!r} after "
+                    f"{self.bind_timeout_seconds}s. run_vm must be called first."
+                )
+            await asyncio.sleep(retry_delay)
+        return _host_of(self._control_plane_base_url())
+
+    async def get_api_base_url(self, name: str) -> str:
+        """Return the URL computer-server is reachable on for ``name``.
+
+        This is what a caller should hand to ``Computer(api_base_url=...)``.
+        REST and WebSocket URIs are both derived from it.
+        """
+        lease = self._leases.get(name)
+        if lease is None:
+            raise RuntimeError(f"No Fleet claim is held for {name!r}")
+        return self._api_base_url(lease.bound)
+
+    async def max_concurrency(self) -> Optional[int]:
+        """How many sandboxes may be claimed at once, or None if unbounded.
+
+        The pool's autoscaling ceiling, so a caller can size its own worker
+        count from the pool rather than guessing. Asking for more than this
+        does not fail fast: the excess claims simply block until others are
+        released, which reads as a hang rather than as saturation.
+
+        Falls back to the pool's fixed replica count when autoscaling is off,
+        since a pool that cannot grow cannot serve more than it has.
+        """
+        await self.__aenter__()
+
+        autoscaling = getattr(getattr(self._pool, "spec", None), "autoscaling", None)
+        if autoscaling is not None:
+            maximum = getattr(autoscaling, "max_pool_size", None)
+            if maximum:
+                return int(maximum)
+
+        replicas = getattr(getattr(self._pool, "spec", None), "replicas", None)
+        return int(replicas) if replicas else None
+
+    async def api_headers(self) -> Dict[str, str]:
+        """Auth headers for both the REST calls and the WebSocket upgrade.
+
+        Async and re-resolved on every call because the bearer is a Keycloak
+        access token with a 900-second lifetime, not a durable key. Each call
+        returns a token that is valid now, minting a new one when the cached
+        one is within :data:`TOKEN_EXPIRY_SKEW_SECONDS` of expiry.
+
+        ``Computer`` hands this to the interface as a callable rather than as
+        a dict, so the interface's reconnect loop calls back here on every
+        connection attempt. That matters because the proxy authenticates the
+        upgrade rather than each frame: an open socket outlives the token
+        silently, and only the reconnect after a network blip would surface
+        the expiry -- as a rejected upgrade, permanently.
+        """
+        token = await self._access_token()
+        return {"Authorization": f"Bearer {token}"}
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _unsupported(
+        self, name: str, operation: str, reason: str, **details: Any
+    ) -> NotImplementedError:
+        """Build the error for an operation this provider cannot perform.
+
+        Returns the exception rather than raising it so call sites read as
+        ``raise self._unsupported(...)``, keeping the failure visible at the
+        method that refuses it.
+        """
+        suffix = f" (requested: {details['requested']})" if details.get("requested") else ""
+        return NotImplementedError(f"FleetProvider cannot {operation} {name!r}: {reason}{suffix}")
+
+    async def _access_token(self) -> str:
+        """Return an access token that is valid right now.
+
+        Kept behind a lock so a burst of concurrent claims does not mint a
+        token each; the loser of the race finds the winner's token cached.
+        """
+        source = self._token_source
+        if callable(source):
+            token = source()
+            if inspect.isawaitable(token):
+                token = await token
+            token = str(token).strip()
+            if not token:
+                raise RuntimeError("The Fleet access-token callable returned an empty token")
+            return token
+        if source:
+            return str(source).strip()
+
+        if not self.client_id or not self.client_secret:
+            raise RuntimeError(
+                "FleetProvider needs Fleet credentials to authenticate against the "
+                "sandbox service proxy. Pass client_id/client_secret (or "
+                "access_token), or set CUA_CLIENT_ID and CUA_CLIENT_SECRET. There "
+                "is no API key for Fleet: the control plane only accepts a "
+                "realm-issued JWT."
+            )
+
+        async with self._token_lock:
+            if self._token and time.monotonic() < self._token_expires_at:
+                return self._token
+            token, expires_in = await _request_client_credentials_token(
+                self.token_url, self.client_id, self.client_secret
+            )
+            self._token = token
+            self._token_expires_at = time.monotonic() + max(
+                0.0, expires_in - TOKEN_EXPIRY_SKEW_SECONDS
+            )
+            return token
+
+    def _api_base_url(self, bound: Any) -> str:
+        """Build the service-proxy URL the way the SDK's own ``service_url`` does.
+
+        The namespace is the *bound sandbox's*, not the pool's: they are
+        usually the same, but a claim can bind a sandbox elsewhere, and a URL
+        built from the pool's namespace then points at nothing.
+        """
+        base = self._control_plane_base_url().rstrip("/")
+        namespace = getattr(bound, "namespace", None) or self.namespace
+        return f"{base}/api/svc/{namespace}/{_name_of(bound)}-{self.service_name}/"
+
+    def _control_plane_base_url(self) -> str:
+        """The Fleet endpoint, which is not the same host as the legacy VM API.
+
+        get_base_url() is api.cua.ai and serves the API-key cloud operations;
+        the /api/svc proxy that fronts sandbox services lives on the Fleet
+        endpoint, run.cua.ai. Using the former builds URLs that resolve and
+        then 404, which is a confusing way to fail.
+        """
+        if self.base_url:
+            return self.base_url
+        try:
+            from cua_sandbox._config import get_fleet_base_url
+        except ImportError as error:  # pragma: no cover - import guard
+            raise RuntimeError(
+                "FleetProvider needs base_url, or the cua-sandbox package to supply it"
+            ) from error
+        return get_fleet_base_url()
+
+    def _claim_spec(self, ttl_seconds: int) -> Any:
+        """Build the claim spec.
+
+        ``ClaimSpec(*, sandbox_template_ref, warmpool, bind_deadline,
+        lifecycle)`` and ``ClaimLifecycle(*, shutdown_time, shutdown_policy,
+        auto_renew)`` are keyword-only with no defaults, so every field is
+        named here even where the value is ``None``.
+
+        The template ref is copied from the pool's own spec rather than
+        derived from the pool's name. That is what the SDK does when it
+        defaults the spec, and for a stated reason: a hand-built ref naming a
+        template that does not exist makes the bind queue lookup miss forever
+        and the claim times out with nothing useful to show for it.
+
+        ``warmpool`` stays ``None`` so the operator applies its own default,
+        matching the spec the SDK would have built.
+        """
+        from cua_sandbox import ClaimSpec
+
+        # cua_sandbox re-exports ClaimSpec but not ClaimLifecycle, so take the
+        # latter from the binding package cua-sandbox itself depends on.
+        from fleet_sdk import ClaimLifecycle
+
+        shutdown_time = (
+            (datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds))
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+        return ClaimSpec(
+            sandbox_template_ref=self._pool.spec.sandbox_template_ref,
+            warmpool=None,
+            bind_deadline=int(self.bind_timeout_seconds),
+            lifecycle=ClaimLifecycle(
+                shutdown_time=shutdown_time,
+                shutdown_policy=None,
+                auto_renew=None,
+            ),
+        )
+
+    def _claim_request(self, spec: Any) -> Any:
+        from cua_sandbox.transport.fleet_cloud import CreateClaimRequest
+
+        return CreateClaimRequest(pool=self._pool, spec=spec)
+
+
+def _config_value(getter: str) -> Optional[str]:
+    """Read one setting from cua-sandbox's config, if it is installed.
+
+    cua-sandbox is optional, and the provider is constructible without it
+    (a test or an embedder can inject a client), so a missing package means
+    "no configured value" rather than an error.
+    """
+    try:
+        from cua_sandbox import _config
+    except ImportError:
+        return None
+    resolver = getattr(_config, getter, None)
+    return resolver() if resolver is not None else None
+
+
+def _name_of(resource: Any) -> str:
+    name = getattr(resource, "name", None)
+    if name:
+        return str(name)
+    metadata = getattr(resource, "metadata", None)
+    if metadata is not None and getattr(metadata, "name", None):
+        return str(metadata.name)
+    raise ValueError(f"Fleet resource has no name: {resource!r}")
+
+
+def _namespace_of(resource: Any) -> str:
+    metadata = getattr(resource, "metadata", None)
+    if metadata is not None and getattr(metadata, "namespace", None):
+        return str(metadata.namespace)
+    raise ValueError(f"Fleet pool has no namespace: {resource!r}")
+
+
+def _host_of(url: str) -> str:
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url)
+    return parsed.hostname or url

--- a/libs/python/computer/tests/test_fleet_provider.py
+++ b/libs/python/computer/tests/test_fleet_provider.py
@@ -1,0 +1,685 @@
+"""Tests for the Fleet VM provider.
+
+The provider leases sandboxes it does not own, so most of what matters here is
+release behaviour: a claim that escapes holds a pool replica until its TTL and
+looks to everyone else like the pool is undersized.
+
+The fakes below deliberately mirror the *generated* ``fleet_sdk`` types rather
+than a convenient shape. An earlier version of this file used a permissive
+``ClaimSpec`` that accepted any keyword and a ``services`` mapping; every test
+passed while the provider could not construct a claim spec at all and crashed
+on the first ``get_vm``. A fake that is easier to satisfy than production is
+not a test.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from computer.providers import fleet as fleet_package
+from computer.providers.base import VMProviderType
+from computer.providers.fleet import FleetProvider
+from computer.providers.fleet import provider as fleet_provider_module
+
+
+class FakeMetadata:
+    def __init__(self, name: str, namespace: str) -> None:
+        self.name = name
+        self.namespace = namespace
+
+
+class FakeAutoscaling:
+    def __init__(self, max_pool_size: int | None) -> None:
+        self.min_pool_size = 0
+        self.max_pool_size = max_pool_size
+
+
+class FakeSandboxTemplateRef:
+    """Mirrors ``fleet_sdk.SandboxTemplateRef``: ``name`` is keyword-only."""
+
+    def __init__(self, *, name: str) -> None:
+        self.name = name
+
+
+class FakeSpec:
+    def __init__(
+        self,
+        replicas: int,
+        autoscaling: FakeAutoscaling | None,
+        sandbox_template_ref: FakeSandboxTemplateRef,
+    ) -> None:
+        self.replicas = replicas
+        self.autoscaling = autoscaling
+        self.sandbox_template_ref = sandbox_template_ref
+
+
+class FakePool:
+    def __init__(
+        self,
+        name: str = "bench-pool",
+        namespace: str = "fleet",
+        *,
+        replicas: int = 2,
+        max_pool_size: int | None = 16,
+        template_name: str = "bench-template",
+    ) -> None:
+        self.metadata = FakeMetadata(name, namespace)
+        self.spec = FakeSpec(
+            replicas,
+            FakeAutoscaling(max_pool_size) if max_pool_size is not None else None,
+            FakeSandboxTemplateRef(name=template_name),
+        )
+
+
+class FakeBound:
+    """Mirrors ``fleet_sdk.Sandbox``.
+
+    ``services`` is a ``List[str]`` of service names, not a mapping: the live
+    Fleet returns ``['server']``. It also carries its own ``namespace``, which
+    is the one the service proxy route is built from -- a bound sandbox does
+    not have to live in the namespace the pool was looked up in.
+    """
+
+    def __init__(
+        self,
+        *,
+        namespace: str = "fleet-eu",
+        claim: str = "claim-0",
+        name: str = "sandbox-abc",
+        services: list[str] | None = None,
+    ) -> None:
+        self.namespace = namespace
+        self.claim = claim
+        self.name = name
+        self.services = ["server"] if services is None else services
+
+
+class FakeClient:
+    """Records claim lifecycle so tests can assert on release."""
+
+    def __init__(self, *, bind_error: Exception | None = None) -> None:
+        self.created: list[Any] = []
+        self.requests: list[Any] = []
+        self.deleted: list[Any] = []
+        self.closed = False
+        self._bind_error = bind_error
+
+    async def get_pool(self, name: str) -> FakePool:
+        return FakePool(name=name)
+
+    async def create_claim(self, request: Any) -> str:
+        claim = f"claim-{len(self.created)}"
+        self.requests.append(request)
+        self.created.append(claim)
+        return claim
+
+    async def wait_claim(self, claim: Any) -> FakeBound:
+        if self._bind_error is not None:
+            raise self._bind_error
+        return FakeBound(claim=str(claim))
+
+    async def delete_claim(self, claim: Any) -> None:
+        self.deleted.append(claim)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class CountingClient(FakeClient):
+    """Binds a distinctly named sandbox per claim.
+
+    A restart must produce a different address; a fake that always returned the
+    same name would hide exactly the bug this guards against.
+    """
+
+    async def wait_claim(self, claim: Any) -> FakeBound:
+        return FakeBound(name=f"sandbox-{len(self.created) - 1}", claim=str(claim))
+
+
+class FakeTokenEndpoint:
+    """A Keycloak token endpoint that mints a fresh JWT per exchange.
+
+    ``expires_in`` is settable so a test can make the token expire, which is
+    the only way to exercise the refresh path: the real one hands out 900s
+    tokens and a bench run outlives that many times over.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+        self.expires_in = 900
+
+    async def __call__(self, token_url: str, client_id: str, client_secret: str) -> tuple[str, int]:
+        self.calls.append((token_url, client_id, client_secret))
+        return f"jwt-{len(self.calls)}", self.expires_in
+
+
+@pytest.fixture(autouse=True)
+def fake_cua_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stand in for cua-sandbox, which is an optional dependency."""
+
+    class SandboxTemplateRef(FakeSandboxTemplateRef):
+        pass
+
+    class ClaimLifecycle:
+        """Mirrors ``fleet_sdk.ClaimLifecycle``: snake_case, all required."""
+
+        def __init__(
+            self,
+            *,
+            shutdown_time: str | None,
+            shutdown_policy: str | None,
+            auto_renew: bool | None,
+        ) -> None:
+            self.shutdown_time = shutdown_time
+            self.shutdown_policy = shutdown_policy
+            self.auto_renew = auto_renew
+
+    class ClaimSpec:
+        """Mirrors ``fleet_sdk.ClaimSpec``.
+
+        All four arguments are keyword-only and have no defaults, so omitting
+        one fails here exactly as it does against the generated bindings.
+        """
+
+        def __init__(
+            self,
+            *,
+            sandbox_template_ref: Any,
+            warmpool: str | None,
+            bind_deadline: int | None,
+            lifecycle: Any,
+        ) -> None:
+            self.sandbox_template_ref = sandbox_template_ref
+            self.warmpool = warmpool
+            self.bind_deadline = bind_deadline
+            self.lifecycle = lifecycle
+
+    class CreateClaimRequest:
+        def __init__(self, *, pool: Any, spec: Any, name: str | None = None) -> None:
+            self.pool = pool
+            self.spec = spec
+            self.name = name
+
+    # cua_sandbox re-exports ClaimSpec but not ClaimLifecycle, so the stub
+    # keeps them where the real packages keep them.
+    bindings = types.ModuleType("fleet_sdk")
+    bindings.ClaimSpec = ClaimSpec  # type: ignore[attr-defined]
+    bindings.ClaimLifecycle = ClaimLifecycle  # type: ignore[attr-defined]
+    bindings.SandboxTemplateRef = SandboxTemplateRef  # type: ignore[attr-defined]
+
+    root = types.ModuleType("cua_sandbox")
+    root.ClaimSpec = ClaimSpec  # type: ignore[attr-defined]
+    root.SandboxTemplateRef = SandboxTemplateRef  # type: ignore[attr-defined]
+
+    config = types.ModuleType("cua_sandbox._config")
+    # Distinct values on purpose: the Fleet proxy is not on the legacy VM API
+    # host, and a fake that returned the same string for both would let the
+    # wrong one pass unnoticed.
+    config.get_fleet_base_url = lambda: "https://fleet.example"  # type: ignore[attr-defined]
+    config.get_base_url = lambda: "https://legacy-vm-api.example"  # type: ignore[attr-defined]
+    config.get_token_url = lambda: "https://auth.example/token"  # type: ignore[attr-defined]
+    config.get_client_id = lambda: None  # type: ignore[attr-defined]
+    config.get_client_secret = lambda: None  # type: ignore[attr-defined]
+    config.get_fleet_token = lambda: None  # type: ignore[attr-defined]
+
+    transport = types.ModuleType("cua_sandbox.transport")
+    fleet_cloud = types.ModuleType("cua_sandbox.transport.fleet_cloud")
+    fleet_cloud.CreateClaimRequest = CreateClaimRequest  # type: ignore[attr-defined]
+    fleet_cloud._FleetClient = FakeClient  # type: ignore[attr-defined]
+
+    for name, module in {
+        "fleet_sdk": bindings,
+        "cua_sandbox": root,
+        "cua_sandbox._config": config,
+        "cua_sandbox.transport": transport,
+        "cua_sandbox.transport.fleet_cloud": fleet_cloud,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    # Ambient Fleet credentials on the developer's machine must not decide
+    # what these tests assert.
+    for variable in ("CUA_CLIENT_ID", "CUA_CLIENT_SECRET", "FLEETS_TOKEN", "CUA_TOKEN_URL"):
+        monkeypatch.delenv(variable, raising=False)
+
+
+@pytest.fixture
+def token_endpoint(monkeypatch: pytest.MonkeyPatch) -> FakeTokenEndpoint:
+    """Replace the OAuth round trip; the exchange itself is not under test."""
+    endpoint = FakeTokenEndpoint()
+    monkeypatch.setattr(fleet_provider_module, "_request_client_credentials_token", endpoint)
+    return endpoint
+
+
+def make_provider(client: FakeClient | None = None, **kwargs: Any) -> FleetProvider:
+    kwargs.setdefault("client_id", "cua-client")
+    kwargs.setdefault("client_secret", "cua-secret")
+    return FleetProvider(
+        "bench-pool",
+        base_url="https://fleet.example",
+        client=client or FakeClient(),
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_base_url_is_the_fleet_endpoint_not_the_vm_api() -> None:
+    """The /api/svc proxy lives on the Fleet host, not the legacy VM API.
+
+    Verified against production: cyclops-cs serves run.cua.ai while
+    api.cua.ai serves the API-key cloud operations. Picking the wrong one
+    yields URLs that resolve and then 404.
+    """
+    provider = FleetProvider("bench-pool", client=FakeClient())
+    async with provider:
+        await provider.run_vm("", "vm-1", {})
+        url = await provider.get_api_base_url("vm-1")
+
+    assert url.startswith("https://fleet.example/")
+    assert "legacy-vm-api" not in url
+
+
+@pytest.mark.asyncio
+async def test_provider_type_is_fleet() -> None:
+    assert make_provider().provider_type == VMProviderType.FLEET
+
+
+@pytest.mark.asyncio
+async def test_run_vm_claims_and_reports_the_proxy_url() -> None:
+    client = FakeClient()
+    provider = make_provider(client)
+
+    async with provider:
+        info = await provider.run_vm("ignored-image", "vm-1", {})
+
+        assert client.created == ["claim-0"]
+        assert info["status"] == "running"
+        # The sandbox is addressed through the control plane, not directly.
+        assert (
+            await provider.get_api_base_url("vm-1")
+            == "https://fleet.example/api/svc/fleet-eu/sandbox-abc-server/"
+        )
+
+    # Leaving the context must release the claim even without stop_vm.
+    assert client.deleted == ["claim-0"]
+
+
+@pytest.mark.asyncio
+async def test_api_base_url_uses_the_bound_sandbox_namespace() -> None:
+    """The route is keyed on the sandbox's namespace, not the pool's.
+
+    ``_FleetClient.service_url`` builds
+    ``{base}/api/svc/{sandbox.namespace}/{sandbox.name}-{service}/``. Using
+    the namespace the pool happened to be looked up in produces a URL for a
+    sandbox that is not there.
+    """
+
+    class ElsewhereClient(FakeClient):
+        async def wait_claim(self, claim: Any) -> FakeBound:
+            return FakeBound(namespace="tenant-42", claim=str(claim))
+
+    # The pool resolves to namespace "fleet"; the bound sandbox says
+    # "tenant-42". The sandbox must win.
+    provider = make_provider(ElsewhereClient())
+    async with provider:
+        await provider.run_vm("", "vm-1", {})
+        assert (
+            await provider.get_api_base_url("vm-1")
+            == "https://fleet.example/api/svc/tenant-42/sandbox-abc-server/"
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_vm_reports_services_as_a_list() -> None:
+    """``fleet_sdk.Sandbox.services`` is a ``List[str]``.
+
+    Coercing it with ``dict(...)`` raises ``ValueError: dictionary update
+    sequence element #0 has length 6; 2 is required`` -- and because
+    ``run_vm`` ends in ``get_vm``, that lands *after* a claim has been bound,
+    leaving a live claim behind an exception.
+    """
+    client = FakeClient()
+    provider = make_provider(client)
+
+    async with provider:
+        info = await provider.run_vm("", "vm-1", {})
+        assert info["services"] == ["server"]
+        assert (await provider.get_vm("vm-1"))["services"] == ["server"]
+
+
+@pytest.mark.asyncio
+async def test_run_vm_builds_a_complete_claim_spec() -> None:
+    """``ClaimSpec`` requires all four keyword-only arguments.
+
+    The template ref is taken from the pool's own spec rather than derived
+    from the pool's name: the SDK does the same, because a ref naming a
+    template that does not exist makes the bind queue lookup miss forever and
+    the claim times out with no useful error.
+    """
+    client = FakeClient()
+    provider = make_provider(client, bind_timeout_seconds=420)
+
+    async with provider:
+        await provider.run_vm("", "vm-1", {"ttl_seconds": 1800})
+
+    spec = client.requests[0].spec
+    assert spec.sandbox_template_ref.name == "bench-template"
+    assert spec.bind_deadline == 420
+    # snake_case on the binding; the wire form is camelCase but that is the
+    # serializer's job, not ours.
+    assert spec.lifecycle.shutdown_time.endswith("Z")
+    assert client.requests[0].pool is provider._pool
+
+
+@pytest.mark.asyncio
+async def test_stop_vm_releases_the_claim() -> None:
+    client = FakeClient()
+    provider = make_provider(client)
+
+    async with provider:
+        await provider.run_vm("", "vm-1", {})
+        await provider.stop_vm("vm-1")
+        assert client.deleted == ["claim-0"]
+        # Already released; the context exit must not double-delete.
+        assert await provider.get_vm("vm-1") == {"name": "vm-1", "status": "stopped"}
+
+    assert client.deleted == ["claim-0"]
+
+
+@pytest.mark.asyncio
+async def test_failed_binding_releases_the_claim() -> None:
+    """An unbound claim still occupies the pool, so it must be cleaned up."""
+    client = FakeClient(bind_error=RuntimeError("pool exhausted"))
+    provider = make_provider(client)
+
+    async with provider:
+        with pytest.raises(RuntimeError, match="pool exhausted"):
+            await provider.run_vm("", "vm-1", {})
+
+    assert client.created == ["claim-0"]
+    assert client.deleted == ["claim-0"]
+
+
+@pytest.mark.asyncio
+async def test_api_headers_exchange_client_credentials_for_a_jwt(
+    token_endpoint: FakeTokenEndpoint,
+) -> None:
+    """There is no opaque API key in Fleet.
+
+    cyclops-cs validates the bearer as a Keycloak JWT (JWKS signature, issuer
+    match, RS256/RS512/ES256); anything else is rejected with
+    ``auth token is invalid``. What the product calls an "API key" is a
+    client_id/client_secret pair that is exchanged for a JWT at the realm's
+    token endpoint. The same header authenticates the WebSocket upgrade, not
+    just REST.
+    """
+    provider = make_provider(client_id="fleet-app", client_secret="hunter2")
+
+    assert await provider.api_headers() == {"Authorization": "Bearer jwt-1"}
+    assert token_endpoint.calls == [("https://auth.example/token", "fleet-app", "hunter2")]
+
+
+@pytest.mark.asyncio
+async def test_api_headers_reuse_a_token_that_is_still_valid(
+    token_endpoint: FakeTokenEndpoint,
+) -> None:
+    """A valid token is not re-minted on every call."""
+    provider = make_provider()
+
+    assert await provider.api_headers() == {"Authorization": "Bearer jwt-1"}
+    assert await provider.api_headers() == {"Authorization": "Bearer jwt-1"}
+    assert len(token_endpoint.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_api_headers_refresh_an_expired_token(
+    token_endpoint: FakeTokenEndpoint,
+) -> None:
+    """Fleet access tokens live 900 seconds; bench runs live much longer.
+
+    A header dict captured once is a bearer that goes stale mid-session, and
+    the failure surfaces as a redirect on the next reconnect rather than as
+    anything that names auth.
+    """
+    token_endpoint.expires_in = 0
+    provider = make_provider()
+
+    assert await provider.api_headers() == {"Authorization": "Bearer jwt-1"}
+    assert await provider.api_headers() == {"Authorization": "Bearer jwt-2"}
+    assert len(token_endpoint.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_explicit_access_token_is_used_verbatim(
+    token_endpoint: FakeTokenEndpoint,
+) -> None:
+    """A caller holding its own workload token must not need a secret."""
+    provider = FleetProvider(
+        "bench-pool",
+        base_url="https://fleet.example",
+        access_token="  supplied-jwt  ",
+        client=FakeClient(),
+    )
+
+    assert await provider.api_headers() == {"Authorization": "Bearer supplied-jwt"}
+    assert token_endpoint.calls == []
+
+
+@pytest.mark.asyncio
+async def test_missing_credentials_fail_loudly() -> None:
+    """Sending no Authorization header 302s to a login page.
+
+    An empty header dict turns an auth misconfiguration into a confusing
+    redirect on the first request, so refuse up front and name the inputs.
+    """
+    provider = FleetProvider("bench-pool", base_url="https://fleet.example", client=FakeClient())
+
+    with pytest.raises(RuntimeError) as error:
+        await provider.api_headers()
+
+    assert "CUA_CLIENT_ID" in str(error.value)
+    assert "CUA_CLIENT_SECRET" in str(error.value)
+
+
+@pytest.mark.asyncio
+async def test_list_vms_reports_only_held_claims() -> None:
+    provider = make_provider()
+    async with provider:
+        assert await provider.list_vms() == []
+        await provider.run_vm("", "vm-1", {})
+        listed = await provider.list_vms()
+
+    assert [vm["name"] for vm in listed] == ["vm-1"]
+
+
+@pytest.mark.asyncio
+async def test_update_vm_raises_and_names_the_fix() -> None:
+    """Fails loudly: a silent no-op would let a caller believe it resized.
+
+    The message has to say where the shape actually comes from, or the reader
+    is left thinking the provider is simply incomplete.
+    """
+    provider = make_provider()
+    async with provider:
+        with pytest.raises(NotImplementedError) as error:
+            await provider.update_vm("vm-1", {"memory": "8GB", "cpu": 4})
+
+    message = str(error.value)
+    assert "cannot resize 'vm-1'" in message
+    assert "pool template" in message
+    assert "reconcile the pool" in message
+    assert "['cpu', 'memory']" in message
+
+
+@pytest.mark.asyncio
+async def test_get_ip_gives_up_instead_of_hanging() -> None:
+    """A name that was never claimed will never arrive.
+
+    The wait exists for the claim landing slightly after the call; without a
+    deadline a caller's typo becomes an indefinite hang rather than an error.
+    """
+    provider = make_provider(bind_timeout_seconds=0)
+    async with provider:
+        with pytest.raises(TimeoutError, match="No Fleet claim is held for 'never-claimed'"):
+            await provider.get_ip("never-claimed", retry_delay=0)
+
+
+@pytest.mark.asyncio
+async def test_get_api_base_url_without_a_claim_is_an_error() -> None:
+    provider = make_provider()
+    async with provider:
+        with pytest.raises(RuntimeError, match="No Fleet claim"):
+            await provider.get_api_base_url("missing")
+
+
+@pytest.mark.asyncio
+async def test_restart_raises_and_leaves_the_claim_intact() -> None:
+    """Restart-in-place does not exist for a bound claim.
+
+    Silently re-claiming would change which sandbox the caller is talking to
+    while looking like a restart, and the released address can be picked up by
+    someone else rather than going dead. Refusing sends callers to stop/start,
+    which re-resolves the address.
+    """
+    client = CountingClient()
+    provider = make_provider(client)
+
+    async with provider:
+        await provider.run_vm("", "vm-1", {})
+        before = await provider.get_api_base_url("vm-1")
+
+        with pytest.raises(NotImplementedError) as error:
+            await provider.restart_vm("vm-1")
+
+        assert "cannot restart 'vm-1'" in str(error.value)
+        assert "stop and start" in str(error.value)
+        # A refused restart must not disturb the claim it declined to touch.
+        assert client.deleted == []
+        assert await provider.get_api_base_url("vm-1") == before
+
+    assert client.deleted == ["claim-0"]
+
+
+@pytest.mark.asyncio
+async def test_max_concurrency_reports_the_autoscaling_ceiling() -> None:
+    """Callers should size their worker count from the pool, not guess.
+
+    Over-subscribing does not fail fast -- the excess claims block until
+    others are released, which looks like a hang rather than saturation.
+    """
+    provider = make_provider()
+    async with provider:
+        assert await provider.max_concurrency() == 16
+
+
+@pytest.mark.asyncio
+async def test_max_concurrency_falls_back_to_replicas_without_autoscaling() -> None:
+    """A pool that cannot grow cannot serve more than it has."""
+
+    class FixedPoolClient(FakeClient):
+        async def get_pool(self, name: str) -> FakePool:
+            return FakePool(name=name, replicas=3, max_pool_size=None)
+
+    provider = make_provider(FixedPoolClient())
+    async with provider:
+        assert await provider.max_concurrency() == 3
+
+
+def test_factory_requires_a_pool() -> None:
+    from computer.providers.factory import VMProviderFactory
+
+    with pytest.raises(ValueError, match="requires a pool"):
+        VMProviderFactory.create_provider("fleet")
+
+
+def test_factory_passes_fleet_credentials_not_an_api_key() -> None:
+    """``api_key`` is not a credential this system has.
+
+    The factory has to forward the OAuth client pair, or a caller configuring
+    the provider through it ends up unauthenticated no matter what it passes.
+    """
+    from computer.providers.factory import VMProviderFactory
+
+    provider = VMProviderFactory.create_provider(
+        "fleet",
+        pool="bench-pool",
+        client_id="factory-client",
+        client_secret="factory-secret",
+    )
+
+    assert provider.client_id == "factory-client"
+    assert provider.client_secret == "factory-secret"
+
+
+def test_fleet_package_exports_the_provider() -> None:
+    assert fleet_package.FleetProvider is FleetProvider
+
+
+@pytest.mark.asyncio
+async def test_computer_hands_the_interface_a_refreshable_header_source(
+    monkeypatch: pytest.MonkeyPatch,
+    token_endpoint: FakeTokenEndpoint,
+) -> None:
+    """The interface must be able to re-ask, not just be told once.
+
+    ``Computer`` resolves the bearer while connecting. If it passes the
+    resulting dict, the interface's reconnect loop replays that one token for
+    the life of the session and every reconnect after ~15 minutes is rejected.
+    Passing a callable is what makes the interface's per-attempt resolution
+    reach the provider.
+    """
+    from computer.computer import Computer
+    from computer.interface.factory import InterfaceFactory
+
+    captured: dict[str, Any] = {}
+
+    class FakeInterface:
+        async def wait_for_ready(self, timeout: int = 60) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+    def fake_create_interface_for_os(**kwargs: Any) -> FakeInterface:
+        captured.update(kwargs)
+        return FakeInterface()
+
+    monkeypatch.setattr(
+        InterfaceFactory,
+        "create_interface_for_os",
+        staticmethod(fake_create_interface_for_os),
+    )
+
+    # Every token is born expired, so a source that re-resolves hands out a
+    # new one each time and a captured dict cannot.
+    token_endpoint.expires_in = 0
+    provider = make_provider()
+    computer = Computer(
+        os_type="linux",
+        name="vm-1",
+        provider_type="fleet",
+        telemetry_enabled=False,
+    )
+
+    async with provider:
+        await provider.run_vm("", "vm-1", {})
+        # The provider is already running; hand it to Computer rather than
+        # letting run() build one, which is how a Fleet caller wires it up.
+        computer.config.vm_provider = provider
+        computer._provider_context = provider
+        try:
+            await computer.run()
+        finally:
+            if computer._stop_event is not None:
+                computer._stop_event.set()
+
+    source = captured["api_headers"]
+    assert callable(source), "Computer passed a static dict; reconnects will replay it"
+    first = await source()
+    second = await source()
+    assert first != second
+    assert first["Authorization"].startswith("Bearer jwt-")
+    assert second["Authorization"].startswith("Bearer jwt-")

--- a/libs/python/computer/tests/test_interface_proxy.py
+++ b/libs/python/computer/tests/test_interface_proxy.py
@@ -7,11 +7,20 @@ the extra headers. This is what allows connecting directly to a computer-server
 behind an authenticated, path-prefixed reverse proxy (e.g. cyclops-cs) without a
 localhost forwarder.
 
+``api_headers`` may also be a callable, sync or async, that is re-resolved on
+every connection attempt and every REST request. A proxy that authenticates with
+a short-lived bearer (Fleet mints 900-second Keycloak tokens) needs that: a dict
+captured once goes stale mid-session and the reconnect that follows replays a
+dead token. Those tests live here too, since this is header propagation.
+
 Following SRP: This file tests ONLY URL building and header propagation for the
 interface layer.
 """
 
+import asyncio
+
 import pytest
+import websockets
 from computer.interface.factory import InterfaceFactory
 from computer.interface.windows import WindowsComputerInterface
 
@@ -122,3 +131,222 @@ class TestRestHeaderMerging:
         assert result.get("success") is True
         assert captured["url"] == f"{PROXY_BASE}/cmd"
         assert captured["headers"]["Authorization"] == "Bearer secret"
+
+
+# ---------------------------------------------------------------------------
+# Re-resolvable header sources
+# ---------------------------------------------------------------------------
+
+
+class SyncTokenSource:
+    """Mints ``jwt-N`` per call, one number per resolution.
+
+    Mirrors ``FakeTokenEndpoint`` in ``test_fleet_provider.py``: a source whose
+    value changes on every call is the only way to tell a header that was
+    resolved once from one that is resolved per attempt.
+    """
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def _mint(self):
+        self.calls += 1
+        return {"Authorization": f"Bearer jwt-{self.calls}"}
+
+    def __call__(self):
+        return self._mint()
+
+
+class AsyncTokenSource(SyncTokenSource):
+    """The Fleet shape: resolving the bearer is a coroutine, not a lookup."""
+
+    async def __call__(self):
+        return self._mint()
+
+
+class FakeWebSocket:
+    """Enough of a websockets connection for ``_keep_alive`` to hold it open."""
+
+    def __init__(self) -> None:
+        self.state = websockets.protocol.State.OPEN
+
+    async def ping(self):
+        pong = asyncio.get_running_loop().create_future()
+        pong.set_result(None)
+        return pong
+
+    async def close(self):
+        self.state = websockets.protocol.State.CLOSED
+
+
+async def _wait_until(predicate, message, timeout: float = 5.0):
+    """Poll ``predicate`` until true, failing rather than hanging on a bug."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"timed out waiting for {message}")
+
+
+async def _drive_two_connection_attempts(iface, attempts):
+    """Run the interface's reconnect loop across one drop and back.
+
+    Drives the real ``_keep_alive`` rather than calling a helper directly, so
+    the test fails if the reconnect path stops consulting the header source --
+    which is exactly the bug being fixed.
+    """
+    task = asyncio.create_task(iface._keep_alive())
+    try:
+        await _wait_until(lambda: len(attempts) >= 1, "the first connection attempt")
+        # What a network blip looks like from here: the socket is closed and
+        # the keep-alive loop dials again.
+        iface._ws.state = websockets.protocol.State.CLOSED
+        await _wait_until(lambda: len(attempts) >= 2, "the reconnect attempt")
+    finally:
+        iface._closed = True
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.fixture
+def ws_attempts(monkeypatch):
+    """Capture the upgrade headers of every WebSocket connection attempt."""
+    attempts = []
+
+    async def fake_connect(uri, **kwargs):
+        headers = kwargs.get("additional_headers") or kwargs.get("extra_headers") or []
+        attempts.append(dict(headers))
+        return FakeWebSocket()
+
+    monkeypatch.setattr(websockets, "connect", fake_connect)
+    return attempts
+
+
+@pytest.fixture
+def rest_requests(monkeypatch):
+    """Capture the headers of every REST request the interface sends."""
+    requests = []
+
+    class FakeResp:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def text(self):
+            return 'data: {"success": true}'
+
+        async def json(self):
+            return {"success": True}
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        def post(self, url, json=None, headers=None):
+            requests.append(dict(headers or {}))
+            return FakeResp()
+
+    import aiohttp
+
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda *a, **k: FakeSession())
+    return requests
+
+
+class TestReResolvableApiHeaders:
+    """A callable ``api_headers`` is resolved per attempt, a dict is not.
+
+    Fleet's bearer is a Keycloak access token that lives 900 seconds while a
+    bench run lives hours. The open socket survives expiry -- the proxy
+    authenticates the upgrade, not each frame -- so the failure only shows up
+    on the first reconnect after the token lapses, and then permanently.
+    """
+
+    @pytest.mark.asyncio
+    async def test_reconnect_re_resolves_an_async_callable_source(self, ws_attempts):
+        """The headline: the second upgrade must carry the second token."""
+        source = AsyncTokenSource()
+        iface = WindowsComputerInterface("ignored-ip", api_base_url=PROXY_BASE, api_headers=source)
+
+        await _drive_two_connection_attempts(iface, ws_attempts)
+
+        assert ws_attempts[:2] == [
+            {"Authorization": "Bearer jwt-1"},
+            {"Authorization": "Bearer jwt-2"},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_dict_source_is_never_re_resolved(self, ws_attempts):
+        """CLOUD/CLOUDV2 pass a dict; it must behave exactly as before.
+
+        Mutating the caller's dict after construction proves the point twice:
+        the interface still holds its own copy (today's behaviour) and it does
+        not go back to any source between attempts.
+        """
+        headers = {"Authorization": "Bearer static"}
+        iface = WindowsComputerInterface("ignored-ip", api_base_url=PROXY_BASE, api_headers=headers)
+        headers["Authorization"] = "Bearer mutated-after-construction"
+
+        await _drive_two_connection_attempts(iface, ws_attempts)
+
+        assert ws_attempts[:2] == [
+            {"Authorization": "Bearer static"},
+            {"Authorization": "Bearer static"},
+        ]
+        assert iface._api_headers == {"Authorization": "Bearer static"}
+
+    @pytest.mark.asyncio
+    async def test_a_callable_source_is_not_resolved_at_construction(self):
+        """Construction is sync, so an async source cannot be awaited there.
+
+        Resolving lazily is what lets the source be a coroutine function at
+        all; a source called in ``__init__`` would have to be sync forever.
+        """
+        source = AsyncTokenSource()
+        iface = WindowsComputerInterface("ignored-ip", api_base_url=PROXY_BASE, api_headers=source)
+
+        assert source.calls == 0
+        assert iface._api_headers == {}
+
+    @pytest.mark.asyncio
+    async def test_rest_requests_re_resolve_a_sync_callable_source(self, rest_requests):
+        """REST rides the same expiring bearer as the socket.
+
+        A sync callable covers a caller whose token lives in memory and needs
+        no I/O to refresh.
+        """
+        source = SyncTokenSource()
+        iface = WindowsComputerInterface("ignored-ip", api_base_url=PROXY_BASE, api_headers=source)
+
+        await iface._send_command_rest("version", {})
+        await iface._send_command_rest("version", {})
+
+        assert [r["Authorization"] for r in rest_requests] == [
+            "Bearer jwt-1",
+            "Bearer jwt-2",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_playwright_exec_re_resolves_an_async_callable_source(self, rest_requests):
+        """The Playwright endpoint is a third caller of the same headers."""
+        source = AsyncTokenSource()
+        iface = WindowsComputerInterface("ignored-ip", api_base_url=PROXY_BASE, api_headers=source)
+
+        await iface.playwright_exec("visit_url", {"url": "https://example.com"})
+        await iface.playwright_exec("visit_url", {"url": "https://example.com"})
+
+        assert [r["Authorization"] for r in rest_requests] == [
+            "Bearer jwt-1",
+            "Bearer jwt-2",
+        ]


### PR DESCRIPTION
## Why

Every existing VM provider ends the same way: *here is an IP, connect to computer-server on it.* A Fleet sandbox has no address of its own — it's reached by asking the control plane to proxy to a named service. So nothing going through `Computer` could use a Fleet sandbox, and benchmarks and agents had to bring their own Docker or QEMU.

`FleetProvider` leases a sandbox from a Fleet **pool** instead of creating a VM. Pools keep warm replicas, so binding is fast where a cold boot would not be — which is what makes this usable for workloads that take an environment per task.

## How the sandbox is addressed

```
{base_url}/api/svc/{namespace}/{sandbox}-{service}
```

That route already proxies WebSocket upgrades as well as plain HTTP — noVNC's `websockify` depends on it, and the backend keeps a `Hijack` implementation so `httputil.ReverseProxy` can upgrade. So computer-server's REST *and* socket traffic both ride it under the same `Authorization: Bearer` token.

The consequence worth noting: this works **from anywhere the control plane is reachable**, not only from inside the cluster. An earlier draft resolved in-cluster service DNS, which would have quietly shipped a deployment constraint.

## What `Computer` learns

Two narrow things:

1. A Fleet provider reports a **URL**, not an IP, so `api_base_url` is resolved from the provider after the claim binds — the sandbox name doesn't exist before that.
2. Its auth headers must reach the **WebSocket upgrade**, not just the REST calls, so `FLEET` joins the existing `CLOUD`/`CLOUDV2` branch that plumbs `api_base_url`/`api_headers` into the interface.

Only the `run()` path needs this, because `restart_vm` refuses (below) — so the diff to `computer.py` is 13 lines.

## Release behaviour — the part most worth reviewing

A claim holds a pool replica until its TTL, so a leaked claim looks to everyone else like the pool is undersized. Three exit paths release it:

- `stop_vm` — the ordinary case
- `__aexit__` — anything that skipped `stop_vm`
- `run_vm`'s failure path — a claim that never bound still occupies capacity

`Pool.claim()` is deliberately **not** used: it's an `@asynccontextmanager` that releases on block exit, which is right for `async with` but cannot span `run_vm` … `stop_vm` as separate calls. The provider drops to `create_claim` / `wait_claim` / `delete_claim` so it owns the lifetime.

## Deliberately unsupported

- **`update_vm` raises.** A pooled sandbox's shape comes from the pool template, so there's nothing on a claim to change. It fails loudly rather than returning a status, so a caller never proceeds believing it resized. Note `Computer.update()` calls this directly, so that method raises for Fleet where it works for docker/lume.

  Shape lives on the template (`VmTemplate.cpu_cores` / `memory`), and `ClaimSpec` can already name a `sandbox_template_ref` — so a caller *can* select a shape at claim time by pointing at a different template. What it cannot do is request an arbitrary slice. Practically: one template per shape is cheap, one **warm pool** per shape you want pre-warmed is not.
- **`restart_vm` raises.** A bound claim can't be restarted in place. Releasing and re-claiming under the name "restart" would change *which sandbox* the caller is talking to while looking like a restart — and the released address can be picked up by another claimant in the same namespace, so a cached one may reach someone else's sandbox rather than going dead. `Computer.restart()` already catches this and falls back to `stop()` + `run()`, which claims a new sandbox and re-resolves its address. In-VM state does not survive that, unlike a docker restart.
- **`run_vm` ignores `image`**, because the pool's template fixes it when the pool is created.

## Sizing the caller

`max_concurrency()` reports the pool's autoscaling ceiling — `autoscaling.max_pool_size`, falling back to `spec.replicas` when autoscaling is off, since a pool that can't grow can't serve more than it has.

This exists so a caller sizes its worker count *from the pool* rather than guessing. Over-subscribing doesn't fail fast: the excess claims block until others are released, which reads as a hang rather than as saturation. Note the pool is KEDA-backed and can scale to zero, so the first claim after an idle period pays a cold start even though the pool is "warm".

## Tests

13 tests against a faked Fleet client: claim and release, the unbound-claim failure path, the proxy URL, bearer headers, the concurrency ceiling (both with and without autoscaling), the factory's pool requirement, and that a refused restart leaves the claim it declined to touch intact.

Full `libs/python/computer` suite: **58 passed**.

## Checked against production

Not just against the SDK:

- A live template declares its service as `{"name": "server", "targetPort": 8000}` — matching the provider's default service name.
- The Kubernetes Service really is `{sandbox}-server` (e.g. `cua-zane-dev-4e22f9eb-server`), confirming the URL construction.
- The `/api/svc` proxy is served by cyclops-cs at **`run.cua.ai`** — the Fleet endpoint — *not* `api.cua.ai`, which is what `get_base_url()` returns. **This caught a bug:** the provider defaulted to the legacy VM API host, which would have produced URLs that resolve and then 404. It now uses `get_fleet_base_url()`, and a test pins the distinction with deliberately different fake values.

## Not verified here

The remaining gap is the **WebSocket upgrade**: that the bearer header survives it end to end through the proxy. The route demonstrably carries WebSockets (noVNC's websockify), but I have not driven computer-server over it with a real claim. That is the one thing worth doing before anyone depends on this.
