### PR TITLE
fix(cua-driver): remove Claude MCP registrations on uninstall

### DIFF
--- a/libs/cua-driver/scripts/tests/test_uninstall_autostart.py
+++ b/libs/cua-driver/scripts/tests/test_uninstall_autostart.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 import subprocess
@@ -153,3 +154,60 @@ def test_current_autostart_file_is_a_rust_install_marker(
 
     assert not autostart_file.exists()
     assert not skill_link.is_symlink()
+
+
+def test_uninstall_removes_generated_claude_mcp_registration(tmp_path: Path) -> None:
+    home, _calls, env = _sandbox(tmp_path, "Linux")
+    driver_home = home / ".cua-driver"
+    driver_home.mkdir()
+    (driver_home / ".telemetry_id").write_text("fixture\n", encoding="utf-8")
+
+    release_cli = home / ".local/bin/cua-driver"
+    claude_json = home / ".claude.json"
+    claude_json.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "cua-computer-use": {
+                        "command": str(release_cli),
+                        "args": ["mcp"],
+                    },
+                    "renamed-cua": {
+                        "command": str(release_cli),
+                        "args": ["mcp"],
+                    },
+                    "unrelated": {
+                        "command": "/usr/bin/example",
+                        "args": ["mcp"],
+                    },
+                },
+                "projects": {
+                    "/workspace": {
+                        "mcpServers": {
+                            "cua-computer-use": {
+                                "command": str(release_cli),
+                                "args": ["mcp"],
+                            },
+                            "project-tool": {"command": "/usr/bin/project-tool"},
+                        }
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run_uninstall(env)
+
+    config = json.loads(claude_json.read_text(encoding="utf-8"))
+    assert set(config["mcpServers"]) == {"unrelated"}
+    assert set(config["projects"]["/workspace"]["mcpServers"]) == {"project-tool"}
+    assert "user:cua-computer-use" in result.stdout
+    assert "user:renamed-cua" in result.stdout
+
+
+def test_windows_uninstaller_names_shipped_claude_mcp_server() -> None:
+    script = (UNINSTALL.parent / "uninstall.ps1").read_text(encoding="utf-8-sig")
+
+    assert "claude mcp remove cua-computer-use -s user" in script
+    assert "claude mcp remove cua-driver-rs\"" not in script

--- a/libs/cua-driver/scripts/uninstall.ps1
+++ b/libs/cua-driver/scripts/uninstall.ps1
@@ -39,7 +39,7 @@
 # Conservative on Claude MCP cleanup: we DON'T auto-edit %USERPROFILE%\
 # .claude.json on Windows (mirrors the macOS uninstall.sh's stance for
 # environments without python3). The closing message prints the
-# `claude mcp remove cua-driver-rs` command for the user to run.
+# `claude mcp remove cua-computer-use` command for the user to run.
 #
 # Env overrides (mirror install.ps1's variable names):
 #   $env:CUA_DRIVER_RS_INSTALL_DIR   visible bin dir to remove
@@ -469,10 +469,10 @@ if (-not $Purge) {
     Write-Host ""
 }
 Write-Host "Claude Code MCP registrations:" -ForegroundColor Yellow
-Write-Host "  We don't auto-edit ~/.claude.json on Windows. If you registered cua-driver-rs"
+Write-Host "  We don't auto-edit ~/.claude.json on Windows. If you registered cua-computer-use"
 Write-Host "  with Claude Code, remove it manually:"
 Write-Host ""
-Write-Host "    claude mcp remove cua-driver-rs"
+Write-Host "    claude mcp remove cua-computer-use -s user"
 Write-Host ""
 Write-Host "  Or edit ~/.claude.json directly and delete entries whose 'command' points at"
 Write-Host "  cua-driver.exe under %LOCALAPPDATA%\Programs\Cua\cua-driver\bin\"

--- a/libs/cua-driver/scripts/uninstall.sh
+++ b/libs/cua-driver/scripts/uninstall.sh
@@ -8,18 +8,7 @@
 #   --backend=rust/swift            → no-op (Rust is the only supported backend)
 #   --experimental-rust             → legacy alias (no-op)
 #
-# Swift uninstall removes:
-#   - ~/.local/bin/cua-driver symlink (+ legacy /usr/local/bin/cua-driver)
-#   - /Applications/CuaDriver.app bundle
-#   - ~/.cua-driver/ (telemetry id + install marker)
-#   - ~/Library/Application Support/Cua Driver/ (config.json)
-#   - ~/Library/Caches/cua-driver/ (daemon/cache state)
-#   - Skill symlinks under ~/.claude/skills/cua-driver, ~/.agents/skills/
-#     cua-driver, ~/.openclaw/skills/cua-driver, ~/.config/opencode/
-#     skills/cua-driver (only when they point at our app bundle)
-#   - Claude MCP registrations in ~/.claude.json (cua-driver / cua-computer-use)
-#
-# Rust uninstall removes:
+# Uninstall removes:
 #   Linux:
 #     - ~/.local/bin/cua-driver symlink (only when it resolves to a
 #       cua-driver path — a Swift-driver symlink is left in place)
@@ -41,15 +30,16 @@
 #       was used via install-local.sh — unload + remove), plus the legacy
 #       com.trycua.cua-driver-rs.plist LaunchAgent
 #     - Skill symlinks under ~/.claude/skills/cua-driver(-rs), etc.
+#   all hosts:
+#     - Claude MCP registrations in ~/.claude.json named cua-driver,
+#       cua-driver-rs, or cua-computer-use, plus registrations whose command
+#       points at the installed release binary
 #
 # Shared-path safety: /Applications/CuaDriver.app + its ~/.local/bin
 # symlink use the same bundle id (com.trycua.driver) as the Swift driver,
 # so they're only removed when an unambiguous Rust marker is on disk
 # (~/.cua-driver/packages/, legacy ~/.cua-driver-rs/, CuaDriverRs.app,
 # the LaunchAgent/systemd unit, or current Rust telemetry state).
-#
-# Also scrubs Claude MCP registrations in ~/.claude.json that match
-# the active backend.
 #
 # Revokes TCC grants on macOS by default (Accessibility + Screen Recording)
 # so the next install prompts cleanly under the new signing identity. Pass
@@ -451,9 +441,9 @@ if [[ "$USE_RUST_BACKEND" == "1" ]]; then
     fi
 
     # --- Claude Code MCP registrations ---
-    # Same scrub shape as the Swift branch, keyed on the cua-driver-rs
-    # binary name + the per-platform install paths. Unrelated MCP
-    # servers are left alone.
+    # Scrub the current and legacy server names plus registrations whose
+    # command points at an installed release binary. Unrelated MCP servers
+    # are left alone.
     CLAUDE_JSON="$HOME/.claude.json"
     if [[ -f "$CLAUDE_JSON" ]] && command -v python3 >/dev/null 2>&1; then
         PY_OUTPUT="$(
@@ -485,20 +475,22 @@ def text_parts(value):
         return [item for item in value if isinstance(item, str)]
     return []
 
-def invokes_cua_driver_rs(server):
+def invokes_cua_driver(server):
     if not isinstance(server, dict):
         return False
     parts = []
     parts.extend(text_parts(server.get("command")))
     parts.extend(text_parts(server.get("args")))
     joined = " ".join(parts)
-    # Match the Rust-port-specific anchors: bundle name, package home,
-    # explicit ".cua-driver-rs" segment. Plain "cua-driver" alone is
-    # ambiguous (the Swift binary uses the same filename). The shared
+    release_link = os.path.join(os.path.expanduser("~"), ".local", "bin", "cua-driver")
+    # Match the installed CLI link and Rust-port-specific anchors: bundle
+    # name, package home, and explicit ".cua-driver-rs" segment. The shared
     # /Applications/CuaDriver.app path is ALSO ambiguous (Rust took
     # over the Swift bundle id) — only count it as Rust when a Rust
     # install marker is on disk; otherwise it is almost certainly a
     # Swift registration we should not scrub.
+    if release_link in parts:
+        return True
     if home_dir and home_dir in joined:
         return True
     if "CuaDriverRs.app" in joined or ".cua-driver-rs" in joined or "cua-driver-rs" in joined:
@@ -508,7 +500,7 @@ def invokes_cua_driver_rs(server):
     return False
 
 def should_remove(name, server):
-    return name in {"cua-driver-rs"} or invokes_cua_driver_rs(server)
+    return name in {"cua-driver", "cua-driver-rs", "cua-computer-use"} or invokes_cua_driver(server)
 
 def scrub_servers(servers, scope):
     if not isinstance(servers, dict):
@@ -529,7 +521,7 @@ if isinstance(projects, dict):
 if not removed:
     raise SystemExit(0)
 
-backup = f"{path}.bak-cua-driver-rs-uninstall-{int(time.time())}"
+backup = f"{path}.bak-cua-driver-uninstall-{int(time.time())}"
 shutil.copy2(path, backup)
 
 directory = os.path.dirname(path) or "."
@@ -560,7 +552,7 @@ PY
                 log "$line"
             done <<< "$PY_OUTPUT"
         else
-            log "no Claude MCP registrations for cua-driver-rs found in $CLAUDE_JSON"
+            log "no Claude MCP registrations for cua-driver found in $CLAUDE_JSON"
         fi
     else
         log "no Claude config cleanup via python3 (missing $CLAUDE_JSON or python3)"
@@ -570,7 +562,7 @@ PY
     # active project / user scopes — fine to run; it's a no-op when the
     # entries were already scrubbed above.
     if command -v claude >/dev/null 2>&1; then
-        for SERVER in cua-driver-rs; do
+        for SERVER in cua-driver cua-driver-rs cua-computer-use; do
             for SCOPE in local project user; do
                 if claude mcp remove "$SERVER" -s "$SCOPE" >/dev/null 2>&1; then
                     log "removed Claude MCP server $SERVER from $SCOPE scope"
@@ -623,226 +615,4 @@ TELEMETRYUNMSG
         fi
     fi
     exit 0
-fi
-
-USER_BIN_LINK="$HOME/.local/bin/cua-driver"
-SYSTEM_BIN_LINK="/usr/local/bin/cua-driver"
-APP_BUNDLE="/Applications/CuaDriver.app"
-USER_DATA="$HOME/.cua-driver"
-CONFIG_DIR="$HOME/Library/Application Support/Cua Driver"
-CACHE_DIR="$HOME/Library/Caches/cua-driver"
-# Legacy — remove if present from older installs.
-LEGACY_UPDATE_SCRIPT="/usr/local/bin/cua-driver-update"
-LEGACY_UPDATER_PLIST="$HOME/Library/LaunchAgents/com.trycua.cua_driver_updater.plist"
-
-# CLI symlinks. Try the user-bin first (no sudo), then the legacy
-# /usr/local/bin path (needs sudo on default macOS).
-for BIN_LINK in "$USER_BIN_LINK" "$SYSTEM_BIN_LINK"; do
-    if [[ -L "$BIN_LINK" ]] || [[ -e "$BIN_LINK" ]]; then
-        SUDO=""
-        [[ ! -w "$(dirname "$BIN_LINK")" ]] && SUDO="sudo"
-        $SUDO rm -f "$BIN_LINK"
-        log "removed $BIN_LINK"
-    fi
-done
-
-# Legacy update script + LaunchAgent (present in installs before 0.0.6).
-if [[ -f "$LEGACY_UPDATE_SCRIPT" ]]; then
-    SUDO=""; [[ ! -w "$(dirname "$LEGACY_UPDATE_SCRIPT")" ]] && SUDO="sudo"
-    $SUDO rm -f "$LEGACY_UPDATE_SCRIPT"
-    log "removed legacy $LEGACY_UPDATE_SCRIPT"
-fi
-if [[ -f "$LEGACY_UPDATER_PLIST" ]]; then
-    launchctl unload "$LEGACY_UPDATER_PLIST" 2>/dev/null || true
-    rm -f "$LEGACY_UPDATER_PLIST"
-    log "removed legacy $LEGACY_UPDATER_PLIST"
-fi
-
-# .app bundle (in /Applications, usually writable by the user).
-if [[ -d "$APP_BUNDLE" ]]; then
-    SUDO=""
-    if [[ ! -w "$(dirname "$APP_BUNDLE")" ]]; then
-        SUDO="sudo"
-    fi
-    $SUDO rm -rf "$APP_BUNDLE"
-    log "removed $APP_BUNDLE"
-else
-    log "no app bundle at $APP_BUNDLE (skipping)"
-fi
-
-# User-data directory (telemetry id + install marker).
-if [[ -d "$USER_DATA" ]]; then
-    rm -rf "$USER_DATA"
-    log "removed $USER_DATA"
-else
-    log "no user data at $USER_DATA (skipping)"
-fi
-
-# Persisted config.
-if [[ -d "$CONFIG_DIR" ]]; then
-    rm -rf "$CONFIG_DIR"
-    log "removed $CONFIG_DIR"
-else
-    log "no config at $CONFIG_DIR (skipping)"
-fi
-
-# Cache / daemon state.
-if [[ -d "$CACHE_DIR" ]]; then
-    rm -rf "$CACHE_DIR"
-    log "removed $CACHE_DIR"
-else
-    log "no cache at $CACHE_DIR (skipping)"
-fi
-
-# Agent skill symlinks (Claude Code + Codex). Only remove when the link
-# is ours — a dev user pointing the symlink at a working copy of the
-# repo keeps theirs untouched.
-SKILL_TARGET_EXPECTED="$APP_BUNDLE/Contents/Resources/Skills/cua-driver"
-for SKILL_LINK in \
-    "$HOME/.claude/skills/cua-driver" \
-    "$HOME/.agents/skills/cua-driver" \
-    "$HOME/.openclaw/skills/cua-driver" \
-    "$HOME/.config/opencode/skills/cua-driver" \
-    "$HOME/.gemini/skills/cua-driver" \
-    "$HOME/.hermes/skills/cua-driver"; do
-    if [[ -L "$SKILL_LINK" ]] && [[ "$(readlink "$SKILL_LINK")" == "$SKILL_TARGET_EXPECTED" ]]; then
-        rm -f "$SKILL_LINK"
-        log "removed $SKILL_LINK"
-    else
-        log "no install-created skill symlink at $SKILL_LINK (skipping)"
-    fi
-done
-
-# Claude Code MCP registrations. `claude mcp remove` only removes from
-# the current project / user scopes, while ~/.claude.json can also
-# contain stale project entries for other directories. Scrub only
-# registrations explicitly named cua-driver or whose command points at
-# a cua-driver binary, so unrelated servers named "computer-use" are
-# left alone.
-CLAUDE_JSON="$HOME/.claude.json"
-if [[ -f "$CLAUDE_JSON" ]] && command -v python3 >/dev/null 2>&1; then
-    PY_OUTPUT="$(
-        CLAUDE_JSON="$CLAUDE_JSON" python3 <<'PY'
-import json
-import os
-import shutil
-import sys
-import tempfile
-import time
-
-path = os.environ["CLAUDE_JSON"]
-
-try:
-    with open(path, "r", encoding="utf-8") as f:
-        data = json.load(f)
-except Exception as exc:
-    print(f"could not read Claude config {path}: {exc}", file=sys.stderr)
-    raise SystemExit(0)
-
-removed = []
-
-def text_parts(value):
-    if isinstance(value, str):
-        return [value]
-    if isinstance(value, list):
-        return [item for item in value if isinstance(item, str)]
-    return []
-
-def invokes_cua_driver(server):
-    if not isinstance(server, dict):
-        return False
-    parts = []
-    parts.extend(text_parts(server.get("command")))
-    parts.extend(text_parts(server.get("args")))
-    joined = " ".join(parts)
-    return "cua-driver" in joined or "CuaDriver.app" in joined
-
-def should_remove(name, server):
-    return name in {"cua-driver", "cua-computer-use"} or invokes_cua_driver(server)
-
-def scrub_servers(servers, scope):
-    if not isinstance(servers, dict):
-        return
-    for name in list(servers.keys()):
-        if should_remove(name, servers[name]):
-            del servers[name]
-            removed.append(f"{scope}:{name}")
-
-scrub_servers(data.get("mcpServers"), "user")
-
-projects = data.get("projects")
-if isinstance(projects, dict):
-    for project in projects.values():
-        if isinstance(project, dict):
-            scrub_servers(project.get("mcpServers"), "project")
-
-if not removed:
-    raise SystemExit(0)
-
-backup = f"{path}.bak-cua-driver-uninstall-{int(time.time())}"
-shutil.copy2(path, backup)
-
-directory = os.path.dirname(path) or "."
-fd, tmp_path = tempfile.mkstemp(
-    prefix=".claude.json.",
-    suffix=".tmp",
-    dir=directory,
-    text=True,
-)
-try:
-    with os.fdopen(fd, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
-        f.write("\n")
-    os.replace(tmp_path, path)
-except Exception:
-    try:
-        os.unlink(tmp_path)
-    except OSError:
-        pass
-    raise
-
-print(f"removed Claude MCP registration(s): {', '.join(removed)}")
-print(f"backed up Claude config to {backup}")
-PY
-    )"
-    if [[ -n "$PY_OUTPUT" ]]; then
-        while IFS= read -r line; do
-            log "$line"
-        done <<< "$PY_OUTPUT"
-    else
-        log "no Claude MCP registrations for cua-driver found in $CLAUDE_JSON"
-    fi
-else
-    log "no Claude config cleanup via python3 (missing $CLAUDE_JSON or python3)"
-fi
-
-# Best-effort CLI cleanup for the active Claude project. This covers
-# .mcp.json / current-working-directory scopes when present and is
-# harmless when the entries were already removed above.
-if command -v claude >/dev/null 2>&1; then
-    for SERVER in cua-driver cua-computer-use; do
-        for SCOPE in local project user; do
-            if claude mcp remove "$SERVER" -s "$SCOPE" >/dev/null 2>&1; then
-                log "removed Claude MCP server $SERVER from $SCOPE scope"
-            fi
-        done
-    done
-else
-    log "claude CLI not found (skipping Claude MCP CLI cleanup)"
-fi
-
-maybe_reset_tcc
-
-echo ""
-echo "cua-driver uninstalled."
-if [[ "$RESET_TCC" != "1" ]]; then
-    cat << 'FINALUNMSG'
-
-TCC grants (Accessibility + Screen Recording) remain in System
-Settings > Privacy & Security because uninstall was run with --keep-tcc.
-Reset them explicitly if you want a clean re-install flow:
-
-  tccutil reset Accessibility com.trycua.driver
-  tccutil reset ScreenCapture com.trycua.driver
-FINALUNMSG
 fi


### PR DESCRIPTION
## what changed

- remove `cua-driver`, `cua-driver-rs`, and `cua-computer-use` registrations from user and project scopes in `~/.claude.json`
- recognize the canonical `~/.local/bin/cua-driver` command path for renamed registrations
- try all current and legacy server names through the Claude CLI fallback
- print the correct Windows manual removal command
- remove the unreachable retired Swift uninstall block
- add regression coverage for the exact registration shape emitted by `cua-driver mcp-config --client claude`

## root cause

The live Rust uninstall branch only matched the legacy `cua-driver-rs` name and Rust-specific bundle paths. The shipped registration is named `cua-computer-use` and invokes the `~/.local/bin/cua-driver` symlink, so neither matcher selected it. The correct current-name matcher existed only in dead code after an unconditional `exit 0`.

## impact

A full uninstall now removes stale Claude Code MCP registrations without touching unrelated servers. Windows users receive a working manual cleanup command.

## validation

- `bash -n libs/cua-driver/scripts/uninstall.sh`
- `uv run --with pytest pytest libs/cua-driver/scripts/tests` — 119 passed, 6 skipped

Fixes #2936