### PR TITLE
fix(cua-driver): refresh semantic page title

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/engine.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/engine.rs
@@ -2473,6 +2473,7 @@ impl BrowserEngine {
             .collect_semantic_session(&conn, &cdp_session, &document, local_tree.as_ref(), None)
             .await?;
         semantic.complete &= document_complete;
+        let title = semantic.document_title().unwrap_or(&tab.title).to_owned();
 
         let oopif = if local_tree.is_some() {
             match self.attached_iframe_children(&conn, &cdp_session).await {
@@ -2568,7 +2569,7 @@ impl BrowserEngine {
         let (outcome, refs) = self.semantic_outcome(
             snapshot_id,
             url.clone(),
-            tab.title.clone(),
+            title.clone(),
             page,
             semantic.complete,
             scope,
@@ -2579,6 +2580,8 @@ impl BrowserEngine {
         self.store
             .update_target(session, target_id, |stored_target| {
                 if let Some(stored_tab) = stored_target.tabs.get_mut(tab_id) {
+                    stored_tab.url = url.clone();
+                    stored_tab.title = title;
                     let mut continuations = HashMap::new();
                     if let (Some(token), Some(offset)) = (continuation_token, next_offset) {
                         continuations.insert(

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/semantic.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/semantic.rs
@@ -170,6 +170,13 @@ pub(crate) struct SemanticDocument {
 }
 
 impl SemanticDocument {
+    pub(crate) fn document_title(&self) -> Option<&str> {
+        self.nodes
+            .iter()
+            .find(|node| matches!(node.role.as_str(), "rootwebarea" | "webarea"))
+            .and_then(|node| node.name.as_deref())
+    }
+
     pub(crate) fn extend(&mut self, mut other: Self) {
         let was_empty = self.nodes.is_empty();
         let offset = self.nodes.len();

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/v2_tests.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/v2_tests.rs
@@ -1329,6 +1329,16 @@ async fn snapshot_composes_shadow_iframe_and_oopif_refs() {
 }
 
 #[tokio::test]
+async fn semantic_snapshot_refreshes_bind_time_title_from_main_document() {
+    let f = fixture_with(|st| st.semantic_large_page = true).await;
+    let (target, tab) = bind(&f).await;
+    let snap = semantic_snapshot(&f, &target, &tab).await;
+
+    assert_eq!(snap["status"], "ok", "{snap}");
+    assert_eq!(snap["page"]["title"], "Fixture inbox", "{snap}");
+}
+
+#[tokio::test]
 async fn semantic_snapshot_keeps_visible_content_after_hidden_node_pressure() {
     let f = fixture_with(|st| st.semantic_large_page = true).await;
     let (target, tab) = bind(&f).await;
@@ -1522,6 +1532,7 @@ async fn semantic_continuation_is_opaque_single_use_and_reaches_offscreen_conten
     let continued = semantic_snapshot_with(&f, &target, &tab, json!({"continuation": token})).await;
     assert_eq!(continued["status"], "ok", "{continued}");
     assert_eq!(continued["snapshot"]["scope"], "continuation");
+    assert_eq!(continued["page"]["title"], "Fixture inbox", "{continued}");
     assert!(
         continued["refs"]
             .as_array()


### PR DESCRIPTION
## what changed

- derive `semantic_v2` page titles from the freshly collected main document accessibility root
- refresh cached tab url and title metadata when storing the snapshot
- cover both initial snapshots and continuation snapshots with regression tests

## why

`get_browser_state` returned the title captured when the tab was first bound. after `browser_navigate`, the url and semantic tree were fresh but `page.title` could remain `about:blank`.

this keeps the typed page metadata consistent with the current semantic document on every supported platform.

closes #2959

## validation

- `cargo fmt -p cua-driver-core --check`
- `cargo test -p cua-driver-core` (508 passed, 1 ignored)