### PR TITLE
fix(cua-driver): render cursors across macos displays

### DIFF
--- a/libs/cua-driver/rust/crates/cursor-overlay/examples/export_gallery_frames.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/examples/export_gallery_frames.rs
@@ -141,6 +141,7 @@ fn export_state(output: &Path, state: GalleryState) {
             f64::from(SIZE) / (2.0 * f64::from(PREVIEW_BACKING_SCALE)),
             f64::from(SIZE) / (2.0 * f64::from(PREVIEW_BACKING_SCALE)),
         );
+        core.placed = true;
         core.heading = f64::from(std::f32::consts::FRAC_PI_4);
         if let Some(session_label) = state.session_label {
             core.apply_command_base(

--- a/libs/cua-driver/rust/crates/cursor-overlay/examples/export_gallery_frames.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/examples/export_gallery_frames.rs
@@ -137,13 +137,17 @@ fn export_state(output: &Path, state: GalleryState) {
         config.cursor_id = "gallery-session".into();
         let mut core = RenderStateCore::new(config);
         core.motion.idle_hide_ms = 0.0;
-        core.pos = Some((
+        core.pos = (
             f64::from(SIZE) / (2.0 * f64::from(PREVIEW_BACKING_SCALE)),
             f64::from(SIZE) / (2.0 * f64::from(PREVIEW_BACKING_SCALE)),
-        ));
+        );
         core.heading = f64::from(std::f32::consts::FRAC_PI_4);
         if let Some(session_label) = state.session_label {
-            core.apply_command_base(OverlayCommand::SetSessionLabel(session_label.into()), true);
+            core.apply_command_base(
+                OverlayCommand::SetSessionLabel(session_label.into()),
+                false,
+                false,
+            );
         }
         core.apply_command_base(
             OverlayCommand::BeginAction {
@@ -151,7 +155,8 @@ fn export_state(output: &Path, state: GalleryState) {
                 delivery: state.delivery,
                 target: state.target,
             },
-            true,
+            false,
+            false,
         );
         core.visual.elapsed_secs = f64::from(frame) / f64::from(FPS);
         let pixmap = render_frame(&core, SIZE, SIZE, 0.0, 0.0, None, PREVIEW_BACKING_SCALE);

--- a/libs/cua-driver/rust/crates/cursor-overlay/examples/export_gallery_frames.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/examples/export_gallery_frames.rs
@@ -137,17 +137,13 @@ fn export_state(output: &Path, state: GalleryState) {
         config.cursor_id = "gallery-session".into();
         let mut core = RenderStateCore::new(config);
         core.motion.idle_hide_ms = 0.0;
-        core.pos = (
+        core.pos = Some((
             f64::from(SIZE) / (2.0 * f64::from(PREVIEW_BACKING_SCALE)),
             f64::from(SIZE) / (2.0 * f64::from(PREVIEW_BACKING_SCALE)),
-        );
+        ));
         core.heading = f64::from(std::f32::consts::FRAC_PI_4);
         if let Some(session_label) = state.session_label {
-            core.apply_command_base(
-                OverlayCommand::SetSessionLabel(session_label.into()),
-                false,
-                false,
-            );
+            core.apply_command_base(OverlayCommand::SetSessionLabel(session_label.into()), true);
         }
         core.apply_command_base(
             OverlayCommand::BeginAction {
@@ -155,8 +151,7 @@ fn export_state(output: &Path, state: GalleryState) {
                 delivery: state.delivery,
                 target: state.target,
             },
-            false,
-            false,
+            true,
         );
         core.visual.elapsed_secs = f64::from(frame) / f64::from(FPS);
         let pixmap = render_frame(&core, SIZE, SIZE, 0.0, 0.0, None, PREVIEW_BACKING_SCALE);

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/lib.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/lib.rs
@@ -23,8 +23,8 @@ pub use bezier::CubicBezier;
 pub use motion::{MotionConfig, Spring};
 pub use path_planner::{PathPlanner, PathState, PlannedPath};
 pub use render_state::{
-    paint_cursor, render_frame, FocusRect, RenderStateCore, SESSION_BADGE_FADE_SECS,
-    SESSION_BADGE_HOLD_SECS,
+    paint_cursor, paint_cursor_art, render_frame, FocusRect, RenderStateCore,
+    SESSION_BADGE_FADE_SECS, SESSION_BADGE_HOLD_SECS,
 };
 pub use session_badge::{
     paint_session_badge, sanitize_session_label, session_badge_extents, session_badge_layout,

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
@@ -18,16 +18,18 @@
 //!   SetEnabled / SetMotion / SetTheme / semantic action events / PinAbove).
 //!   Returns `false` for variants the core doesn't handle so platforms can
 //!   layer their own behaviour on top (e.g. macOS ShowFocusRect).
-//! - [`render_frame`] — the tiny-skia paint of the selected cursor theme,
-//!   parameterized by pixmap dimensions and a global origin offset.
+//! - [`render_frame`] — the tiny-skia paint of the selected cursor theme.
+//!   Parametrised by pixmap dimensions and an origin offset so Windows can
+//!   pass `(virt_x, virt_y)` while macOS / Linux pass `(0, 0)`.
 //!
 //! ## What stays per-platform
 //!
 //! - The OS window / surface (NSWindow / HWND / X11 Window) and its message
 //!   loop or run-loop.
-//! - The paint dispatch: Core Animation child layers on macOS,
-//!   `UpdateLayeredWindow` (BGRA DIB), and `XPutImage` (BGRA ZPixmap).
-//! - Origin/coordinate translation from global points into native surfaces.
+//! - The paint dispatch: `dispatch_set_layer_contents` (CGImage),
+//!   `UpdateLayeredWindow` (BGRA DIB), `XPutImage` (BGRA ZPixmap).
+//! - Origin/coordinate translation (Windows uses virtual-screen offset;
+//!   macOS uses NSScreen coordinates; Linux uses display coordinates).
 //! - Platform-specific extras like macOS's `focus_rect` (post-arrival
 //!   element highlight — drawn inside [`render_frame`] when the caller
 //!   supplies one via the optional argument).
@@ -50,8 +52,8 @@ pub struct RenderStateCore {
     pub cfg: CursorConfig,
     /// Current motion / timing config (mutable via [`OverlayCommand::SetMotion`]).
     pub motion: MotionConfig,
-    /// Current rendered position, or `None` until the cursor is first placed.
-    pub pos: Option<(f64, f64)>,
+    /// Current rendered position in screen / overlay-window coordinates.
+    pub pos: (f64, f64),
     /// Visual heading in radians (tip direction = motion_dir + π).
     pub heading: f64,
     /// In-flight planned path; `None` = at rest.
@@ -70,8 +72,6 @@ pub struct RenderStateCore {
     pub visual: CursorVisualState,
     /// Decoded installed or embedded theme.
     pub theme: Option<Arc<CompiledTheme>>,
-    /// Conservative logical radius touched by any frame of the active theme.
-    theme_paint_radius: f64,
     /// Non-fatal launch-time fallback reason, if an installed theme failed.
     pub theme_fallback: Option<String>,
     /// User-controlled visibility.
@@ -100,7 +100,9 @@ pub struct RenderStateCore {
 
 impl RenderStateCore {
     /// Build the core from a launch-time CursorConfig.
-    /// `pos` starts empty so the first placement can snap rather than animate.
+    /// `pos` starts at the off-screen sentinel `(-200, -200)` to indicate
+    /// "never placed on screen yet" — the click path uses this to detect
+    /// first-placement and snap rather than animate.
     pub fn new(cfg: CursorConfig) -> Self {
         let motion = cfg.motion.clone();
         let visual = CursorVisualState {
@@ -118,15 +120,13 @@ impl RenderStateCore {
                 )),
             ),
         };
-        let theme_paint_radius = theme.as_deref().map_or(64.0, CompiledTheme::paint_radius);
         Self {
             cfg,
             motion,
             visual,
             theme,
-            theme_paint_radius,
             theme_fallback,
-            pos: None,
+            pos: (-200.0, -200.0),
             heading: std::f64::consts::FRAC_PI_4,
             path: None,
             dist: 0.0,
@@ -146,14 +146,8 @@ impl RenderStateCore {
         }
     }
 
-    /// Conservative logical radius around `pos` touched by cursor artwork.
-    pub fn paint_radius(&self) -> f64 {
-        self.theme_paint_radius.max(2.0)
-    }
-
-    /// Return whether cursor pixels and related UI may be shown.
-    pub fn cursor_is_revealed(&self) -> bool {
-        self.visible && self.pos.is_some() && self.idle_alpha >= 0.004
+    fn cursor_is_revealed(&self) -> bool {
+        self.visible && self.idle_alpha >= 0.004
     }
 
     fn reveal_session_badge(&mut self) {
@@ -213,39 +207,36 @@ impl RenderStateCore {
 
     /// Update hover state from a platform-native hardware pointer sample.
     ///
-    /// The placed position is the centre of the cursor artwork. The hit radius is a
+    /// `self.pos` is the centre of the cursor artwork. The hit radius is a
     /// little larger than the 42 point production artwork so the interaction
     /// remains comfortable around the white outline and glow.
     pub fn update_session_badge_hover(&mut self, pointer: Option<(f64, f64)>) -> bool {
         const HOVER_RADIUS: f64 = crate::theme::DISPLAY_SIZE as f64 * 0.82;
         let hovered = self.session_badge_needs_hover_poll()
-            && self
-                .pos
-                .zip(pointer)
-                .is_some_and(|((cursor_x, cursor_y), (x, y))| {
-                    let dx = x - cursor_x;
-                    let dy = y - cursor_y;
-                    if dx * dx + dy * dy <= HOVER_RADIUS * HOVER_RADIUS {
-                        return true;
-                    }
-                    crate::session_badge_layout(crate::SessionBadgeInput {
-                        label: self.session_label.as_deref(),
-                        delivery: self.badge_modifiers.and_then(|modifiers| modifiers.0),
-                        target: self.badge_modifiers.and_then(|modifiers| modifiers.1),
-                        cursor: (cursor_x as f32, cursor_y as f32),
-                        backing_scale: 1.0,
-                        label_alpha: self.session_badge_alpha(),
-                        chip_alpha: self.session_badge_chip_alpha(),
-                        clip: None,
-                    })
-                    .is_some_and(|layout| {
-                        let rect = layout.rect;
-                        x >= rect.x() as f64
-                            && x <= (rect.x() + rect.width()) as f64
-                            && y >= rect.y() as f64
-                            && y <= (rect.y() + rect.height()) as f64
-                    })
-                });
+            && pointer.is_some_and(|(x, y)| {
+                let dx = x - self.pos.0;
+                let dy = y - self.pos.1;
+                if dx * dx + dy * dy <= HOVER_RADIUS * HOVER_RADIUS {
+                    return true;
+                }
+                crate::session_badge_layout(crate::SessionBadgeInput {
+                    label: self.session_label.as_deref(),
+                    delivery: self.badge_modifiers.and_then(|modifiers| modifiers.0),
+                    target: self.badge_modifiers.and_then(|modifiers| modifiers.1),
+                    cursor: (self.pos.0 as f32, self.pos.1 as f32),
+                    backing_scale: 1.0,
+                    label_alpha: self.session_badge_alpha(),
+                    chip_alpha: self.session_badge_chip_alpha(),
+                    clip: None,
+                })
+                .is_some_and(|layout| {
+                    let rect = layout.rect;
+                    x >= rect.x() as f64
+                        && x <= (rect.x() + rect.width()) as f64
+                        && y >= rect.y() as f64
+                        && y <= (rect.y() + rect.height()) as f64
+                })
+            });
         let changed = hovered != self.session_badge_hovered;
         self.session_badge_hovered = hovered;
         changed
@@ -329,14 +320,14 @@ impl RenderStateCore {
                     vy: impulse * 0.5 * vh.sin(),
                 });
                 self.spring_tgt = Some((end.x, end.y, end_heading));
-                self.pos = Some((end.x, end.y));
+                self.pos = (end.x, end.y);
                 self.heading = end_heading;
                 self.path = None;
                 self.dist = 0.0;
                 fire_arrival = true;
             } else {
                 let s: PathState = p.sample(self.dist);
-                self.pos = Some((s.x, s.y));
+                self.pos = (s.x, s.y);
                 // Point the arrow exactly along the path tangent (the renderer
                 // adds π, so we store tangent+π). Assigned directly rather than
                 // rate-limited toward it, so the tip actually tracks the
@@ -353,10 +344,10 @@ impl RenderStateCore {
                     s.ox += s.vx * sdt;
                     s.oy += s.vy * sdt;
                 }
-                self.pos = Some((tx + s.ox, ty + s.oy));
+                self.pos = (tx + s.ox, ty + s.oy);
                 self.heading = th;
                 if s.ox.hypot(s.oy) < 0.3 && s.vx.hypot(s.vy) < 2.0 {
-                    self.pos = Some((tx, ty));
+                    self.pos = (tx, ty);
                     self.spring = None;
                 } else {
                     self.spring = Some(s);
@@ -441,14 +432,14 @@ impl RenderStateCore {
                     vy: impulse * SPRING_OVERSHOOT * vh.sin(),
                 });
                 self.spring_tgt = Some((end.x, end.y, end_heading));
-                self.pos = Some((end.x, end.y));
+                self.pos = (end.x, end.y);
                 self.heading = end_heading;
                 self.path = None;
                 self.dist = 0.0;
                 fire_arrival = true;
             } else {
                 let s: PathState = p.sample(self.dist);
-                self.pos = Some((s.x, s.y));
+                self.pos = (s.x, s.y);
                 // Point the arrow exactly along the path tangent (renderer adds
                 // π, so store tangent+π). Direct assignment, not rate-limited, so
                 // the tip tracks the trajectory instead of lagging on fast moves.
@@ -464,10 +455,10 @@ impl RenderStateCore {
                     s.ox += s.vx * sdt;
                     s.oy += s.vy * sdt;
                 }
-                self.pos = Some((tx + s.ox, ty + s.oy));
+                self.pos = (tx + s.ox, ty + s.oy);
                 self.heading = th;
                 if s.ox.hypot(s.oy) < 0.3 && s.vx.hypot(s.vy) < 2.0 {
-                    self.pos = Some((tx, ty));
+                    self.pos = (tx, ty);
                     self.spring = None;
                 } else {
                     self.spring = Some(s);
@@ -542,10 +533,22 @@ impl RenderStateCore {
     /// for variants the platform must handle itself (e.g. macOS's
     /// `ShowFocusRect`).
     ///
-    /// `click_repositions` is false on macOS, where a completed glide already
-    /// owns the cursor position, and true on Windows/Linux, where click pulses
-    /// snap to their command coordinates.
-    pub fn apply_command_base(&mut self, cmd: OverlayCommand, click_repositions: bool) -> bool {
+    /// `move_to_snap_sentinel` controls macOS-only behaviour: when `true`,
+    /// `MoveTo` snaps `self.pos` to the offset target if the cursor is
+    /// still at the off-screen sentinel (`pos.0 < -50.0`).  Windows/Linux
+    /// pass `false` here.
+    ///
+    /// `click_pulse_sentinel_only` likewise controls macOS-only behaviour:
+    /// when `true`, `ClickPulse` only updates `self.pos` if the cursor is
+    /// still at the sentinel (the animation already landed it there
+    /// otherwise).  Windows/Linux pass `false`, which always snaps
+    /// `self.pos` to the click point.
+    pub fn apply_command_base(
+        &mut self,
+        cmd: OverlayCommand,
+        move_to_snap_sentinel: bool,
+        click_pulse_sentinel_only: bool,
+    ) -> bool {
         match cmd {
             OverlayCommand::MoveTo {
                 x,
@@ -562,8 +565,12 @@ impl RenderStateCore {
                 let tx = x + end_heading_radians.cos() * CLICK_OFFSET;
                 let ty = y + end_heading_radians.sin() * CLICK_OFFSET;
 
-                let (x0, y0) = self.pos.unwrap_or((tx, ty));
-                self.pos = Some((x0, y0));
+                // macOS-only: if the cursor is still at the initial off-screen
+                // sentinel, snap it to the offset target so the path starts on-screen.
+                if move_to_snap_sentinel && self.pos.0 < -50.0 {
+                    self.pos = (tx, ty);
+                }
+                let (x0, y0) = self.pos;
                 let th0 = self.heading + std::f64::consts::PI;
                 let th1 = end_heading_radians + std::f64::consts::PI;
                 let plan =
@@ -593,7 +600,7 @@ impl RenderStateCore {
                 heading_radians,
             } => {
                 let reveal_badge = !self.cursor_is_revealed();
-                self.pos = Some((x, y));
+                self.pos = (x, y);
                 if let Some(heading) = heading_radians {
                     self.heading = heading;
                 }
@@ -618,20 +625,20 @@ impl RenderStateCore {
             }
             OverlayCommand::ClickPulse { x, y } => {
                 let reveal_badge = !self.cursor_is_revealed();
-                if click_repositions || self.pos.is_none() {
-                    let position = if click_repositions {
-                        (x, y)
-                    } else {
-                        // macOS applies the MoveTo offset on first placement
-                        // so the cursor tip lands at the click point.
+                if click_pulse_sentinel_only {
+                    // macOS: only snap position on first placement (sentinel state).
+                    // After that the cursor stays where the animation landed.
+                    if self.pos.0 < -50.0 {
+                        // Apply same click offset so tip lands at click point.
                         const CLICK_OFFSET: f64 = 16.0;
                         let angle = std::f64::consts::FRAC_PI_4;
-                        (
+                        self.pos = (
                             x + angle.cos() * CLICK_OFFSET,
                             y + angle.sin() * CLICK_OFFSET,
-                        )
-                    };
-                    self.pos = Some(position);
+                        );
+                    }
+                } else {
+                    self.pos = (x, y);
                 }
                 self.click_t = Some(0.0);
                 if matches!(
@@ -702,8 +709,6 @@ impl RenderStateCore {
             } => {
                 match crate::resolve_theme_selection(&theme_id) {
                     Ok(theme) => {
-                        self.theme_paint_radius =
-                            theme.as_deref().map_or(64.0, CompiledTheme::paint_radius);
                         self.theme = theme;
                         self.theme_fallback = None;
                         self.cfg.theme_id = theme_id;
@@ -749,7 +754,7 @@ pub struct FocusRect {
 /// Render the cursor + bloom + click-pulse + (optional) focus-rect into a
 /// fresh tiny-skia [`tiny_skia::Pixmap`] of `(width, height)`.
 ///
-/// `origin_x`, `origin_y` are subtracted from the cursor position before
+/// `origin_x`, `origin_y` are subtracted from the cursor `core.pos` before
 /// drawing — Windows passes the virtual-screen `(virt_x, virt_y)` so the
 /// pixmap is laid out in window-local coordinates.  macOS / Linux pass
 /// `(0.0, 0.0)`.
@@ -780,9 +785,9 @@ pub fn render_frame(
 /// them with later calls drawn on top — this is what lets the macOS overlay
 /// render N owned cursors into one buffer / one NSWindow.
 ///
-/// `origin_x` / `origin_y` are subtracted from the placed position before drawing
+/// `origin_x` / `origin_y` are subtracted from `core.pos` before drawing
 /// (Windows passes the virtual-screen origin; macOS / Linux pass `(0.0, 0.0)`).
-/// Both are in **logical** screen points, just like the cursor position.
+/// Both are in **logical** screen points, just like `core.pos`.
 ///
 /// `backing_scale` is the destination-pixmap-pixels per logical-point ratio.
 /// On a 2× retina macOS display the caller sizes the pixmap at the screen's
@@ -816,8 +821,8 @@ pub fn paint_cursor(
     );
 }
 
-/// Paint cursor artwork without its host-owned session badge. Tile renderers
-/// use this to compose artwork first, then paint one display-clamped badge.
+/// Paint cursor artwork on a neighboring display without duplicating the
+/// display-clamped session badge owned by the cursor's anchor display.
 pub fn paint_cursor_art(
     pm: &mut tiny_skia::Pixmap,
     core: &RenderStateCore,
@@ -850,9 +855,7 @@ fn paint_cursor_impl(
     if !core.cursor_is_revealed() {
         return;
     }
-    let Some((cursor_x, cursor_y)) = core.pos else {
-        return;
-    };
+    let (cursor_x, cursor_y) = core.pos;
 
     let s = backing_scale.max(1.0) as f64; // logical-pt → pixmap-pixel scale
     let sf = s as f32;
@@ -968,77 +971,6 @@ fn paint_cursor_impl(
 }
 
 #[cfg(test)]
-mod placement_tests {
-    use super::*;
-    use crate::CursorConfig;
-
-    #[test]
-    fn only_unplaced_cursors_are_unrevealed() {
-        let mut core = RenderStateCore::new(CursorConfig::default());
-        assert_eq!(core.pos, None);
-        assert!(!core.cursor_is_revealed());
-
-        for position in [(-867.0, 400.0), (400.0, -867.0), (-200.0, -200.0)] {
-            core.pos = Some(position);
-            assert!(core.cursor_is_revealed(), "position={position:?}");
-        }
-    }
-
-    #[test]
-    fn macos_commands_preserve_a_placed_cursor_on_a_left_display() {
-        let mut core = RenderStateCore::new(CursorConfig::default());
-        core.pos = Some((-867.0, 400.0));
-
-        assert!(core.apply_command_base(
-            OverlayCommand::MoveTo {
-                x: 40.0,
-                y: 60.0,
-                end_heading_radians: 0.0,
-            },
-            false,
-        ));
-        assert_eq!(core.pos, Some((-867.0, 400.0)));
-
-        assert!(core.apply_command_base(OverlayCommand::ClickPulse { x: 40.0, y: 60.0 }, false,));
-
-        assert_eq!(core.pos, Some((-867.0, 400.0)));
-    }
-
-    #[test]
-    fn paint_cursor_renders_negative_global_x_with_a_virtual_screen_origin() {
-        let mut core = RenderStateCore::new(CursorConfig::default());
-        core.pos = Some((-867.0, 120.0));
-        let mut pixmap = tiny_skia::Pixmap::new(400, 300).unwrap();
-
-        paint_cursor(&mut pixmap, &core, -1000.0, 0.0, None, 1.0);
-
-        assert!(pixmap.data().chunks_exact(4).any(|pixel| pixel[3] > 0));
-    }
-
-    #[test]
-    fn focus_rect_uses_the_same_display_origin_as_the_cursor() {
-        let mut core = RenderStateCore::new(CursorConfig::default());
-        core.pos = Some((-10.0, 80.0));
-        let mut pixmap = tiny_skia::Pixmap::new(120, 120).unwrap();
-
-        paint_cursor(
-            &mut pixmap,
-            &core,
-            -100.0,
-            0.0,
-            Some(FocusRect {
-                rect: [-90.0, 10.0, 20.0, 20.0],
-                t: 0.0,
-            }),
-            1.0,
-        );
-
-        let alpha_at_focus = pixmap.data()[((15 * 120 + 15) * 4 + 3) as usize];
-        assert!(alpha_at_focus > 0);
-    }
-}
-
-#[cfg(test)]
 mod glide_duration_tests {
     use super::*;
     use crate::{CursorConfig, PathPlanner};
@@ -1050,7 +982,7 @@ mod glide_duration_tests {
         let mut core = RenderStateCore::new(CursorConfig::default());
         core.motion.glide_duration_ms = glide_ms;
         core.motion.idle_hide_ms = 0.0;
-        core.pos = Some((0.0, 0.0));
+        core.pos = (0.0, 0.0);
         // Aligned headings → an effectively straight path of length ~dist_pts.
         core.path = Some(PathPlanner::plan(
             0.0, 0.0, 0.0, dist_pts, 0.0, 0.0, 0.0, 80.0,
@@ -1107,7 +1039,11 @@ mod session_badge_and_action_tests {
     fn session_badge_holds_then_fades_once() {
         let mut core = RenderStateCore::new(CursorConfig::default());
         assert_eq!(core.session_badge_alpha(), 0.0);
-        assert!(core.apply_command_base(OverlayCommand::SetSessionLabel("Research".into()), true,));
+        assert!(core.apply_command_base(
+            OverlayCommand::SetSessionLabel("Research".into()),
+            false,
+            false,
+        ));
         assert_eq!(core.session_badge_alpha(), 1.0);
 
         core.tick_motion(SESSION_BADGE_HOLD_SECS - 0.05);
@@ -1122,21 +1058,37 @@ mod session_badge_and_action_tests {
     #[test]
     fn repeated_session_label_metadata_does_not_restart_badge_timer() {
         let mut core = RenderStateCore::new(CursorConfig::default());
-        core.apply_command_base(OverlayCommand::SetSessionLabel("Research".into()), true);
+        core.apply_command_base(
+            OverlayCommand::SetSessionLabel("Research".into()),
+            false,
+            false,
+        );
         core.tick_motion(SESSION_BADGE_HOLD_SECS + SESSION_BADGE_FADE_SECS);
         assert_eq!(core.session_badge_alpha(), 0.0);
 
-        core.apply_command_base(OverlayCommand::SetSessionLabel("Research".into()), true);
+        core.apply_command_base(
+            OverlayCommand::SetSessionLabel("Research".into()),
+            false,
+            false,
+        );
         assert_eq!(core.session_badge_alpha(), 0.0);
 
-        core.apply_command_base(OverlayCommand::SetSessionLabel("Writing".into()), true);
+        core.apply_command_base(
+            OverlayCommand::SetSessionLabel("Writing".into()),
+            false,
+            false,
+        );
         assert_eq!(core.session_badge_alpha(), 1.0);
     }
 
     #[test]
     fn revealing_hidden_cursor_restarts_badge_without_restarting_on_every_move() {
         let mut core = RenderStateCore::new(CursorConfig::default());
-        core.apply_command_base(OverlayCommand::SetSessionLabel("Research".into()), true);
+        core.apply_command_base(
+            OverlayCommand::SetSessionLabel("Research".into()),
+            false,
+            false,
+        );
         core.tick_motion(SESSION_BADGE_HOLD_SECS + SESSION_BADGE_FADE_SECS);
         assert_eq!(core.session_badge_alpha(), 0.0);
 
@@ -1146,7 +1098,8 @@ mod session_badge_and_action_tests {
                 y: 100.0,
                 heading_radians: None,
             },
-            true,
+            false,
+            false,
         );
         assert_eq!(core.session_badge_alpha(), 1.0);
         assert!(core.session_badge_needs_frame_tick());
@@ -1158,7 +1111,8 @@ mod session_badge_and_action_tests {
                 y: 120.0,
                 heading_radians: None,
             },
-            true,
+            false,
+            false,
         );
         assert_eq!(core.session_badge_secs, elapsed);
         core.tick_motion(SESSION_BADGE_HOLD_SECS + SESSION_BADGE_FADE_SECS);
@@ -1168,8 +1122,12 @@ mod session_badge_and_action_tests {
     #[test]
     fn hardware_pointer_hover_reveals_only_while_over_cursor() {
         let mut core = RenderStateCore::new(CursorConfig::default());
-        core.pos = Some((300.0, 240.0));
-        core.apply_command_base(OverlayCommand::SetSessionLabel("Research".into()), true);
+        core.pos = (300.0, 240.0);
+        core.apply_command_base(
+            OverlayCommand::SetSessionLabel("Research".into()),
+            false,
+            false,
+        );
         core.tick_motion(SESSION_BADGE_HOLD_SECS + SESSION_BADGE_FADE_SECS);
         assert_eq!(core.session_badge_alpha(), 0.0);
         assert!(core.session_badge_needs_hover_poll());
@@ -1186,14 +1144,15 @@ mod session_badge_and_action_tests {
     #[test]
     fn movement_preserves_the_active_semantic_action() {
         let mut core = RenderStateCore::new(CursorConfig::default());
-        core.pos = Some((20.0, 20.0));
+        core.pos = (20.0, 20.0);
         core.apply_command_base(
             OverlayCommand::BeginAction {
                 action: CursorAction::Text,
                 delivery: None,
                 target: Some(TargetModifier::Ax),
             },
-            true,
+            false,
+            false,
         );
         core.apply_command_base(
             OverlayCommand::MoveTo {
@@ -1201,11 +1160,16 @@ mod session_badge_and_action_tests {
                 y: 100.0,
                 end_heading_radians: 0.0,
             },
-            true,
+            false,
+            false,
         );
         assert_eq!(core.visual.resolved_action, CursorAction::Text);
         assert_eq!(core.visual.target, Some(TargetModifier::Ax));
-        core.apply_command_base(OverlayCommand::ClickPulse { x: 200.0, y: 100.0 }, true);
+        core.apply_command_base(
+            OverlayCommand::ClickPulse { x: 200.0, y: 100.0 },
+            false,
+            false,
+        );
         assert_eq!(core.visual.resolved_action, CursorAction::Text);
         assert_eq!(core.visual.target, Some(TargetModifier::Ax));
     }
@@ -1213,14 +1177,15 @@ mod session_badge_and_action_tests {
     #[test]
     fn modifiers_live_in_the_badge_then_fade_after_action_completion() {
         let mut core = RenderStateCore::new(CursorConfig::default());
-        core.pos = Some((200.0, 200.0));
+        core.pos = (200.0, 200.0);
         core.apply_command_base(
             OverlayCommand::BeginAction {
                 action: CursorAction::Click,
                 delivery: Some(DeliveryModifier::Foreground),
                 target: Some(TargetModifier::Pixel),
             },
-            true,
+            false,
+            false,
         );
         assert_eq!(
             core.badge_modifiers,
@@ -1254,7 +1219,8 @@ mod session_badge_and_action_tests {
                 delivery: Some(DeliveryModifier::Background),
                 target: Some(TargetModifier::Ax),
             },
-            true,
+            false,
+            false,
         );
         core.apply_command_base(
             OverlayCommand::BeginAction {
@@ -1262,7 +1228,8 @@ mod session_badge_and_action_tests {
                 delivery: Some(DeliveryModifier::Foreground),
                 target: Some(TargetModifier::Browser),
             },
-            true,
+            false,
+            false,
         );
         assert_eq!(
             core.badge_modifiers,
@@ -1284,9 +1251,14 @@ mod session_badge_and_action_tests {
                 delivery: Some(DeliveryModifier::Background),
                 target: Some(TargetModifier::Ax),
             },
-            true,
+            false,
+            false,
         );
-        core.apply_command_base(OverlayCommand::ClickPulse { x: 40.0, y: 60.0 }, true);
+        core.apply_command_base(
+            OverlayCommand::ClickPulse { x: 40.0, y: 60.0 },
+            false,
+            false,
+        );
         assert_eq!(
             (core.visual.delivery, core.visual.target),
             (Some(DeliveryModifier::Background), Some(TargetModifier::Ax))
@@ -1335,7 +1307,7 @@ mod backing_scale_tests {
         // Place the cursor at the centre of the logical area and disable
         // idle-fade so the arrow paints at full alpha regardless of timing.
         let centre = logical_size as f64 / 2.0;
-        core.pos = Some((centre, centre));
+        core.pos = (centre, centre);
         core.idle_alpha = 1.0;
         core.visible = true;
 

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
@@ -52,8 +52,8 @@ pub struct RenderStateCore {
     pub cfg: CursorConfig,
     /// Current motion / timing config (mutable via [`OverlayCommand::SetMotion`]).
     pub motion: MotionConfig,
-    /// Current rendered position in screen / overlay-window coordinates.
-    pub pos: (f64, f64),
+    /// Current rendered position, or `None` until the cursor is first placed.
+    pub pos: Option<(f64, f64)>,
     /// Visual heading in radians (tip direction = motion_dir + π).
     pub heading: f64,
     /// In-flight planned path; `None` = at rest.
@@ -100,9 +100,7 @@ pub struct RenderStateCore {
 
 impl RenderStateCore {
     /// Build the core from a launch-time CursorConfig.
-    /// `pos` starts at the off-screen sentinel `(-200, -200)` to indicate
-    /// "never placed on screen yet" — the click path uses this to detect
-    /// first-placement and snap rather than animate.
+    /// `pos` starts empty so the first placement can snap rather than animate.
     pub fn new(cfg: CursorConfig) -> Self {
         let motion = cfg.motion.clone();
         let visual = CursorVisualState {
@@ -126,7 +124,7 @@ impl RenderStateCore {
             visual,
             theme,
             theme_fallback,
-            pos: (-200.0, -200.0),
+            pos: None,
             heading: std::f64::consts::FRAC_PI_4,
             path: None,
             dist: 0.0,
@@ -146,8 +144,9 @@ impl RenderStateCore {
         }
     }
 
-    fn cursor_is_revealed(&self) -> bool {
-        self.visible && self.pos.0 >= -100.0 && self.idle_alpha >= 0.004
+    /// Return whether cursor pixels and related UI may be shown.
+    pub fn cursor_is_revealed(&self) -> bool {
+        self.visible && self.pos.is_some() && self.idle_alpha >= 0.004
     }
 
     fn reveal_session_badge(&mut self) {
@@ -207,36 +206,39 @@ impl RenderStateCore {
 
     /// Update hover state from a platform-native hardware pointer sample.
     ///
-    /// `self.pos` is the centre of the cursor artwork. The hit radius is a
+    /// The placed position is the centre of the cursor artwork. The hit radius is a
     /// little larger than the 42 point production artwork so the interaction
     /// remains comfortable around the white outline and glow.
     pub fn update_session_badge_hover(&mut self, pointer: Option<(f64, f64)>) -> bool {
         const HOVER_RADIUS: f64 = crate::theme::DISPLAY_SIZE as f64 * 0.82;
         let hovered = self.session_badge_needs_hover_poll()
-            && pointer.is_some_and(|(x, y)| {
-                let dx = x - self.pos.0;
-                let dy = y - self.pos.1;
-                if dx * dx + dy * dy <= HOVER_RADIUS * HOVER_RADIUS {
-                    return true;
-                }
-                crate::session_badge_layout(crate::SessionBadgeInput {
-                    label: self.session_label.as_deref(),
-                    delivery: self.badge_modifiers.and_then(|modifiers| modifiers.0),
-                    target: self.badge_modifiers.and_then(|modifiers| modifiers.1),
-                    cursor: (self.pos.0 as f32, self.pos.1 as f32),
-                    backing_scale: 1.0,
-                    label_alpha: self.session_badge_alpha(),
-                    chip_alpha: self.session_badge_chip_alpha(),
-                    clip: None,
-                })
-                .is_some_and(|layout| {
-                    let rect = layout.rect;
-                    x >= rect.x() as f64
-                        && x <= (rect.x() + rect.width()) as f64
-                        && y >= rect.y() as f64
-                        && y <= (rect.y() + rect.height()) as f64
-                })
-            });
+            && self
+                .pos
+                .zip(pointer)
+                .is_some_and(|((cursor_x, cursor_y), (x, y))| {
+                    let dx = x - cursor_x;
+                    let dy = y - cursor_y;
+                    if dx * dx + dy * dy <= HOVER_RADIUS * HOVER_RADIUS {
+                        return true;
+                    }
+                    crate::session_badge_layout(crate::SessionBadgeInput {
+                        label: self.session_label.as_deref(),
+                        delivery: self.badge_modifiers.and_then(|modifiers| modifiers.0),
+                        target: self.badge_modifiers.and_then(|modifiers| modifiers.1),
+                        cursor: (cursor_x as f32, cursor_y as f32),
+                        backing_scale: 1.0,
+                        label_alpha: self.session_badge_alpha(),
+                        chip_alpha: self.session_badge_chip_alpha(),
+                        clip: None,
+                    })
+                    .is_some_and(|layout| {
+                        let rect = layout.rect;
+                        x >= rect.x() as f64
+                            && x <= (rect.x() + rect.width()) as f64
+                            && y >= rect.y() as f64
+                            && y <= (rect.y() + rect.height()) as f64
+                    })
+                });
         let changed = hovered != self.session_badge_hovered;
         self.session_badge_hovered = hovered;
         changed
@@ -320,14 +322,14 @@ impl RenderStateCore {
                     vy: impulse * 0.5 * vh.sin(),
                 });
                 self.spring_tgt = Some((end.x, end.y, end_heading));
-                self.pos = (end.x, end.y);
+                self.pos = Some((end.x, end.y));
                 self.heading = end_heading;
                 self.path = None;
                 self.dist = 0.0;
                 fire_arrival = true;
             } else {
                 let s: PathState = p.sample(self.dist);
-                self.pos = (s.x, s.y);
+                self.pos = Some((s.x, s.y));
                 // Point the arrow exactly along the path tangent (the renderer
                 // adds π, so we store tangent+π). Assigned directly rather than
                 // rate-limited toward it, so the tip actually tracks the
@@ -344,10 +346,10 @@ impl RenderStateCore {
                     s.ox += s.vx * sdt;
                     s.oy += s.vy * sdt;
                 }
-                self.pos = (tx + s.ox, ty + s.oy);
+                self.pos = Some((tx + s.ox, ty + s.oy));
                 self.heading = th;
                 if s.ox.hypot(s.oy) < 0.3 && s.vx.hypot(s.vy) < 2.0 {
-                    self.pos = (tx, ty);
+                    self.pos = Some((tx, ty));
                     self.spring = None;
                 } else {
                     self.spring = Some(s);
@@ -432,14 +434,14 @@ impl RenderStateCore {
                     vy: impulse * SPRING_OVERSHOOT * vh.sin(),
                 });
                 self.spring_tgt = Some((end.x, end.y, end_heading));
-                self.pos = (end.x, end.y);
+                self.pos = Some((end.x, end.y));
                 self.heading = end_heading;
                 self.path = None;
                 self.dist = 0.0;
                 fire_arrival = true;
             } else {
                 let s: PathState = p.sample(self.dist);
-                self.pos = (s.x, s.y);
+                self.pos = Some((s.x, s.y));
                 // Point the arrow exactly along the path tangent (renderer adds
                 // π, so store tangent+π). Direct assignment, not rate-limited, so
                 // the tip tracks the trajectory instead of lagging on fast moves.
@@ -455,10 +457,10 @@ impl RenderStateCore {
                     s.ox += s.vx * sdt;
                     s.oy += s.vy * sdt;
                 }
-                self.pos = (tx + s.ox, ty + s.oy);
+                self.pos = Some((tx + s.ox, ty + s.oy));
                 self.heading = th;
                 if s.ox.hypot(s.oy) < 0.3 && s.vx.hypot(s.vy) < 2.0 {
-                    self.pos = (tx, ty);
+                    self.pos = Some((tx, ty));
                     self.spring = None;
                 } else {
                     self.spring = Some(s);
@@ -533,22 +535,10 @@ impl RenderStateCore {
     /// for variants the platform must handle itself (e.g. macOS's
     /// `ShowFocusRect`).
     ///
-    /// `move_to_snap_sentinel` controls macOS-only behaviour: when `true`,
-    /// `MoveTo` snaps `self.pos` to the offset target if the cursor is
-    /// still at the off-screen sentinel (`pos.0 < -50.0`).  Windows/Linux
-    /// pass `false` here.
-    ///
-    /// `click_pulse_sentinel_only` likewise controls macOS-only behaviour:
-    /// when `true`, `ClickPulse` only updates `self.pos` if the cursor is
-    /// still at the sentinel (the animation already landed it there
-    /// otherwise).  Windows/Linux pass `false`, which always snaps
-    /// `self.pos` to the click point.
-    pub fn apply_command_base(
-        &mut self,
-        cmd: OverlayCommand,
-        move_to_snap_sentinel: bool,
-        click_pulse_sentinel_only: bool,
-    ) -> bool {
+    /// `click_repositions` is false on macOS, where a completed glide already
+    /// owns the cursor position, and true on Windows/Linux, where click pulses
+    /// snap to their command coordinates.
+    pub fn apply_command_base(&mut self, cmd: OverlayCommand, click_repositions: bool) -> bool {
         match cmd {
             OverlayCommand::MoveTo {
                 x,
@@ -565,12 +555,8 @@ impl RenderStateCore {
                 let tx = x + end_heading_radians.cos() * CLICK_OFFSET;
                 let ty = y + end_heading_radians.sin() * CLICK_OFFSET;
 
-                // macOS-only: if the cursor is still at the initial off-screen
-                // sentinel, snap it to the offset target so the path starts on-screen.
-                if move_to_snap_sentinel && self.pos.0 < -50.0 {
-                    self.pos = (tx, ty);
-                }
-                let (x0, y0) = self.pos;
+                let (x0, y0) = self.pos.unwrap_or((tx, ty));
+                self.pos = Some((x0, y0));
                 let th0 = self.heading + std::f64::consts::PI;
                 let th1 = end_heading_radians + std::f64::consts::PI;
                 let plan =
@@ -600,7 +586,7 @@ impl RenderStateCore {
                 heading_radians,
             } => {
                 let reveal_badge = !self.cursor_is_revealed();
-                self.pos = (x, y);
+                self.pos = Some((x, y));
                 if let Some(heading) = heading_radians {
                     self.heading = heading;
                 }
@@ -625,20 +611,20 @@ impl RenderStateCore {
             }
             OverlayCommand::ClickPulse { x, y } => {
                 let reveal_badge = !self.cursor_is_revealed();
-                if click_pulse_sentinel_only {
-                    // macOS: only snap position on first placement (sentinel state).
-                    // After that the cursor stays where the animation landed.
-                    if self.pos.0 < -50.0 {
-                        // Apply same click offset so tip lands at click point.
+                if click_repositions || self.pos.is_none() {
+                    let position = if click_repositions {
+                        (x, y)
+                    } else {
+                        // macOS applies the MoveTo offset on first placement
+                        // so the cursor tip lands at the click point.
                         const CLICK_OFFSET: f64 = 16.0;
                         let angle = std::f64::consts::FRAC_PI_4;
-                        self.pos = (
+                        (
                             x + angle.cos() * CLICK_OFFSET,
                             y + angle.sin() * CLICK_OFFSET,
-                        );
-                    }
-                } else {
-                    self.pos = (x, y);
+                        )
+                    };
+                    self.pos = Some(position);
                 }
                 self.click_t = Some(0.0);
                 if matches!(
@@ -754,7 +740,7 @@ pub struct FocusRect {
 /// Render the cursor + bloom + click-pulse + (optional) focus-rect into a
 /// fresh tiny-skia [`tiny_skia::Pixmap`] of `(width, height)`.
 ///
-/// `origin_x`, `origin_y` are subtracted from the cursor `core.pos` before
+/// `origin_x`, `origin_y` are subtracted from the cursor position before
 /// drawing — Windows passes the virtual-screen `(virt_x, virt_y)` so the
 /// pixmap is laid out in window-local coordinates.  macOS / Linux pass
 /// `(0.0, 0.0)`.
@@ -785,9 +771,9 @@ pub fn render_frame(
 /// them with later calls drawn on top — this is what lets the macOS overlay
 /// render N owned cursors into one buffer / one NSWindow.
 ///
-/// `origin_x` / `origin_y` are subtracted from `core.pos` before drawing
+/// `origin_x` / `origin_y` are subtracted from the placed position before drawing
 /// (Windows passes the virtual-screen origin; macOS / Linux pass `(0.0, 0.0)`).
-/// Both are in **logical** screen points, just like `core.pos`.
+/// Both are in **logical** screen points, just like the cursor position.
 ///
 /// `backing_scale` is the destination-pixmap-pixels per logical-point ratio.
 /// On a 2× retina macOS display the caller sizes the pixmap at the screen's
@@ -810,16 +796,19 @@ pub fn paint_cursor(
     focus_rect: Option<FocusRect>,
     backing_scale: f32,
 ) {
-    if !core.visible || core.pos.0 < -100.0 || core.idle_alpha < 0.004 {
+    if !core.cursor_is_revealed() {
         return;
     }
+    let Some((cursor_x, cursor_y)) = core.pos else {
+        return;
+    };
 
     let s = backing_scale.max(1.0) as f64; // logical-pt → pixmap-pixel scale
     let sf = s as f32;
 
     // Cursor anchor in pixmap-pixel space: subtract the (logical) origin
     // first, then scale into pixmap pixels.
-    let (px, py) = ((core.pos.0 - origin_x) * s, (core.pos.1 - origin_y) * s);
+    let (px, py) = ((cursor_x - origin_x) * s, (cursor_y - origin_y) * s);
     let heading = core.heading;
     let alpha_scale = core.idle_alpha as f32;
 
@@ -926,6 +915,55 @@ pub fn paint_cursor(
 }
 
 #[cfg(test)]
+mod placement_tests {
+    use super::*;
+    use crate::CursorConfig;
+
+    #[test]
+    fn only_unplaced_cursors_are_unrevealed() {
+        let mut core = RenderStateCore::new(CursorConfig::default());
+        assert_eq!(core.pos, None);
+        assert!(!core.cursor_is_revealed());
+
+        for position in [(-867.0, 400.0), (400.0, -867.0), (-200.0, -200.0)] {
+            core.pos = Some(position);
+            assert!(core.cursor_is_revealed(), "position={position:?}");
+        }
+    }
+
+    #[test]
+    fn macos_commands_preserve_a_placed_cursor_on_a_left_display() {
+        let mut core = RenderStateCore::new(CursorConfig::default());
+        core.pos = Some((-867.0, 400.0));
+
+        assert!(core.apply_command_base(
+            OverlayCommand::MoveTo {
+                x: 40.0,
+                y: 60.0,
+                end_heading_radians: 0.0,
+            },
+            false,
+        ));
+        assert_eq!(core.pos, Some((-867.0, 400.0)));
+
+        assert!(core.apply_command_base(OverlayCommand::ClickPulse { x: 40.0, y: 60.0 }, false,));
+
+        assert_eq!(core.pos, Some((-867.0, 400.0)));
+    }
+
+    #[test]
+    fn paint_cursor_renders_negative_global_x_with_a_virtual_screen_origin() {
+        let mut core = RenderStateCore::new(CursorConfig::default());
+        core.pos = Some((-867.0, 120.0));
+        let mut pixmap = tiny_skia::Pixmap::new(400, 300).unwrap();
+
+        paint_cursor(&mut pixmap, &core, -1000.0, 0.0, None, 1.0);
+
+        assert!(pixmap.data().chunks_exact(4).any(|pixel| pixel[3] > 0));
+    }
+}
+
+#[cfg(test)]
 mod glide_duration_tests {
     use super::*;
     use crate::{CursorConfig, PathPlanner};
@@ -937,7 +975,7 @@ mod glide_duration_tests {
         let mut core = RenderStateCore::new(CursorConfig::default());
         core.motion.glide_duration_ms = glide_ms;
         core.motion.idle_hide_ms = 0.0;
-        core.pos = (0.0, 0.0);
+        core.pos = Some((0.0, 0.0));
         // Aligned headings → an effectively straight path of length ~dist_pts.
         core.path = Some(PathPlanner::plan(
             0.0, 0.0, 0.0, dist_pts, 0.0, 0.0, 0.0, 80.0,
@@ -994,11 +1032,7 @@ mod session_badge_and_action_tests {
     fn session_badge_holds_then_fades_once() {
         let mut core = RenderStateCore::new(CursorConfig::default());
         assert_eq!(core.session_badge_alpha(), 0.0);
-        assert!(core.apply_command_base(
-            OverlayCommand::SetSessionLabel("Research".into()),
-            false,
-            false,
-        ));
+        assert!(core.apply_command_base(OverlayCommand::SetSessionLabel("Research".into()), true,));
         assert_eq!(core.session_badge_alpha(), 1.0);
 
         core.tick_motion(SESSION_BADGE_HOLD_SECS - 0.05);
@@ -1013,37 +1047,21 @@ mod session_badge_and_action_tests {
     #[test]
     fn repeated_session_label_metadata_does_not_restart_badge_timer() {
         let mut core = RenderStateCore::new(CursorConfig::default());
-        core.apply_command_base(
-            OverlayCommand::SetSessionLabel("Research".into()),
-            false,
-            false,
-        );
+        core.apply_command_base(OverlayCommand::SetSessionLabel("Research".into()), true);
         core.tick_motion(SESSION_BADGE_HOLD_SECS + SESSION_BADGE_FADE_SECS);
         assert_eq!(core.session_badge_alpha(), 0.0);
 
-        core.apply_command_base(
-            OverlayCommand::SetSessionLabel("Research".into()),
-            false,
-            false,
-        );
+        core.apply_command_base(OverlayCommand::SetSessionLabel("Research".into()), true);
         assert_eq!(core.session_badge_alpha(), 0.0);
 
-        core.apply_command_base(
-            OverlayCommand::SetSessionLabel("Writing".into()),
-            false,
-            false,
-        );
+        core.apply_command_base(OverlayCommand::SetSessionLabel("Writing".into()), true);
         assert_eq!(core.session_badge_alpha(), 1.0);
     }
 
     #[test]
     fn revealing_hidden_cursor_restarts_badge_without_restarting_on_every_move() {
         let mut core = RenderStateCore::new(CursorConfig::default());
-        core.apply_command_base(
-            OverlayCommand::SetSessionLabel("Research".into()),
-            false,
-            false,
-        );
+        core.apply_command_base(OverlayCommand::SetSessionLabel("Research".into()), true);
         core.tick_motion(SESSION_BADGE_HOLD_SECS + SESSION_BADGE_FADE_SECS);
         assert_eq!(core.session_badge_alpha(), 0.0);
 
@@ -1053,8 +1071,7 @@ mod session_badge_and_action_tests {
                 y: 100.0,
                 heading_radians: None,
             },
-            false,
-            false,
+            true,
         );
         assert_eq!(core.session_badge_alpha(), 1.0);
         assert!(core.session_badge_needs_frame_tick());
@@ -1066,8 +1083,7 @@ mod session_badge_and_action_tests {
                 y: 120.0,
                 heading_radians: None,
             },
-            false,
-            false,
+            true,
         );
         assert_eq!(core.session_badge_secs, elapsed);
         core.tick_motion(SESSION_BADGE_HOLD_SECS + SESSION_BADGE_FADE_SECS);
@@ -1077,12 +1093,8 @@ mod session_badge_and_action_tests {
     #[test]
     fn hardware_pointer_hover_reveals_only_while_over_cursor() {
         let mut core = RenderStateCore::new(CursorConfig::default());
-        core.pos = (300.0, 240.0);
-        core.apply_command_base(
-            OverlayCommand::SetSessionLabel("Research".into()),
-            false,
-            false,
-        );
+        core.pos = Some((300.0, 240.0));
+        core.apply_command_base(OverlayCommand::SetSessionLabel("Research".into()), true);
         core.tick_motion(SESSION_BADGE_HOLD_SECS + SESSION_BADGE_FADE_SECS);
         assert_eq!(core.session_badge_alpha(), 0.0);
         assert!(core.session_badge_needs_hover_poll());
@@ -1099,15 +1111,14 @@ mod session_badge_and_action_tests {
     #[test]
     fn movement_preserves_the_active_semantic_action() {
         let mut core = RenderStateCore::new(CursorConfig::default());
-        core.pos = (20.0, 20.0);
+        core.pos = Some((20.0, 20.0));
         core.apply_command_base(
             OverlayCommand::BeginAction {
                 action: CursorAction::Text,
                 delivery: None,
                 target: Some(TargetModifier::Ax),
             },
-            false,
-            false,
+            true,
         );
         core.apply_command_base(
             OverlayCommand::MoveTo {
@@ -1115,16 +1126,11 @@ mod session_badge_and_action_tests {
                 y: 100.0,
                 end_heading_radians: 0.0,
             },
-            false,
-            false,
+            true,
         );
         assert_eq!(core.visual.resolved_action, CursorAction::Text);
         assert_eq!(core.visual.target, Some(TargetModifier::Ax));
-        core.apply_command_base(
-            OverlayCommand::ClickPulse { x: 200.0, y: 100.0 },
-            false,
-            false,
-        );
+        core.apply_command_base(OverlayCommand::ClickPulse { x: 200.0, y: 100.0 }, true);
         assert_eq!(core.visual.resolved_action, CursorAction::Text);
         assert_eq!(core.visual.target, Some(TargetModifier::Ax));
     }
@@ -1132,15 +1138,14 @@ mod session_badge_and_action_tests {
     #[test]
     fn modifiers_live_in_the_badge_then_fade_after_action_completion() {
         let mut core = RenderStateCore::new(CursorConfig::default());
-        core.pos = (200.0, 200.0);
+        core.pos = Some((200.0, 200.0));
         core.apply_command_base(
             OverlayCommand::BeginAction {
                 action: CursorAction::Click,
                 delivery: Some(DeliveryModifier::Foreground),
                 target: Some(TargetModifier::Pixel),
             },
-            false,
-            false,
+            true,
         );
         assert_eq!(
             core.badge_modifiers,
@@ -1174,8 +1179,7 @@ mod session_badge_and_action_tests {
                 delivery: Some(DeliveryModifier::Background),
                 target: Some(TargetModifier::Ax),
             },
-            false,
-            false,
+            true,
         );
         core.apply_command_base(
             OverlayCommand::BeginAction {
@@ -1183,8 +1187,7 @@ mod session_badge_and_action_tests {
                 delivery: Some(DeliveryModifier::Foreground),
                 target: Some(TargetModifier::Browser),
             },
-            false,
-            false,
+            true,
         );
         assert_eq!(
             core.badge_modifiers,
@@ -1206,14 +1209,9 @@ mod session_badge_and_action_tests {
                 delivery: Some(DeliveryModifier::Background),
                 target: Some(TargetModifier::Ax),
             },
-            false,
-            false,
+            true,
         );
-        core.apply_command_base(
-            OverlayCommand::ClickPulse { x: 40.0, y: 60.0 },
-            false,
-            false,
-        );
+        core.apply_command_base(OverlayCommand::ClickPulse { x: 40.0, y: 60.0 }, true);
         assert_eq!(
             (core.visual.delivery, core.visual.target),
             (Some(DeliveryModifier::Background), Some(TargetModifier::Ax))
@@ -1262,7 +1260,7 @@ mod backing_scale_tests {
         // Place the cursor at the centre of the logical area and disable
         // idle-fade so the arrow paints at full alpha regardless of timing.
         let centre = logical_size as f64 / 2.0;
-        core.pos = (centre, centre);
+        core.pos = Some((centre, centre));
         core.idle_alpha = 1.0;
         core.visible = true;
 

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
@@ -18,18 +18,16 @@
 //!   SetEnabled / SetMotion / SetTheme / semantic action events / PinAbove).
 //!   Returns `false` for variants the core doesn't handle so platforms can
 //!   layer their own behaviour on top (e.g. macOS ShowFocusRect).
-//! - [`render_frame`] — the tiny-skia paint of the selected cursor theme.
-//!   Parametrised by pixmap dimensions and an origin offset so Windows can
-//!   pass `(virt_x, virt_y)` while macOS / Linux pass `(0, 0)`.
+//! - [`render_frame`] — the tiny-skia paint of the selected cursor theme,
+//!   parameterized by pixmap dimensions and a global origin offset.
 //!
 //! ## What stays per-platform
 //!
 //! - The OS window / surface (NSWindow / HWND / X11 Window) and its message
 //!   loop or run-loop.
-//! - The paint dispatch: `dispatch_set_layer_contents` (CGImage),
-//!   `UpdateLayeredWindow` (BGRA DIB), `XPutImage` (BGRA ZPixmap).
-//! - Origin/coordinate translation (Windows uses virtual-screen offset;
-//!   macOS uses NSScreen coordinates; Linux uses display coordinates).
+//! - Native surface presentation through Core Animation, `UpdateLayeredWindow`,
+//!   or `XPutImage`.
+//! - Translation from global coordinates into native surfaces.
 //! - Platform-specific extras like macOS's `focus_rect` (post-arrival
 //!   element highlight — drawn inside [`render_frame`] when the caller
 //!   supplies one via the optional argument).
@@ -54,6 +52,8 @@ pub struct RenderStateCore {
     pub motion: MotionConfig,
     /// Current rendered position in screen / overlay-window coordinates.
     pub pos: (f64, f64),
+    /// Whether the cursor has received its first real placement.
+    pub placed: bool,
     /// Visual heading in radians (tip direction = motion_dir + π).
     pub heading: f64,
     /// In-flight planned path; `None` = at rest.
@@ -72,6 +72,8 @@ pub struct RenderStateCore {
     pub visual: CursorVisualState,
     /// Decoded installed or embedded theme.
     pub theme: Option<Arc<CompiledTheme>>,
+    /// Conservative logical radius touched by any frame of the active theme.
+    theme_paint_radius: f64,
     /// Non-fatal launch-time fallback reason, if an installed theme failed.
     pub theme_fallback: Option<String>,
     /// User-controlled visibility.
@@ -100,9 +102,6 @@ pub struct RenderStateCore {
 
 impl RenderStateCore {
     /// Build the core from a launch-time CursorConfig.
-    /// `pos` starts at the off-screen sentinel `(-200, -200)` to indicate
-    /// "never placed on screen yet" — the click path uses this to detect
-    /// first-placement and snap rather than animate.
     pub fn new(cfg: CursorConfig) -> Self {
         let motion = cfg.motion.clone();
         let visual = CursorVisualState {
@@ -120,13 +119,16 @@ impl RenderStateCore {
                 )),
             ),
         };
+        let theme_paint_radius = theme.as_deref().map_or(64.0, CompiledTheme::paint_radius);
         Self {
             cfg,
             motion,
             visual,
             theme,
+            theme_paint_radius,
             theme_fallback,
             pos: (-200.0, -200.0),
+            placed: false,
             heading: std::f64::consts::FRAC_PI_4,
             path: None,
             dist: 0.0,
@@ -146,8 +148,13 @@ impl RenderStateCore {
         }
     }
 
+    pub fn paint_radius(&self) -> f64 {
+        // Cover host-owned bloom and click-pulse effects as well as theme art.
+        self.theme_paint_radius.max(64.0)
+    }
+
     fn cursor_is_revealed(&self) -> bool {
-        self.visible && self.idle_alpha >= 0.004
+        self.visible && self.placed && self.idle_alpha >= 0.004
     }
 
     fn reveal_session_badge(&mut self) {
@@ -533,21 +540,13 @@ impl RenderStateCore {
     /// for variants the platform must handle itself (e.g. macOS's
     /// `ShowFocusRect`).
     ///
-    /// `move_to_snap_sentinel` controls macOS-only behaviour: when `true`,
-    /// `MoveTo` snaps `self.pos` to the offset target if the cursor is
-    /// still at the off-screen sentinel (`pos.0 < -50.0`).  Windows/Linux
-    /// pass `false` here.
-    ///
-    /// `click_pulse_sentinel_only` likewise controls macOS-only behaviour:
-    /// when `true`, `ClickPulse` only updates `self.pos` if the cursor is
-    /// still at the sentinel (the animation already landed it there
-    /// otherwise).  Windows/Linux pass `false`, which always snaps
-    /// `self.pos` to the click point.
+    /// The placement flags preserve each platform's existing first-move and
+    /// click behavior without reserving any coordinate as a sentinel.
     pub fn apply_command_base(
         &mut self,
         cmd: OverlayCommand,
-        move_to_snap_sentinel: bool,
-        click_pulse_sentinel_only: bool,
+        move_to_places_unplaced: bool,
+        click_pulse_unplaced_only: bool,
     ) -> bool {
         match cmd {
             OverlayCommand::MoveTo {
@@ -565,12 +564,11 @@ impl RenderStateCore {
                 let tx = x + end_heading_radians.cos() * CLICK_OFFSET;
                 let ty = y + end_heading_radians.sin() * CLICK_OFFSET;
 
-                // macOS-only: if the cursor is still at the initial off-screen
-                // sentinel, snap it to the offset target so the path starts on-screen.
-                if move_to_snap_sentinel && self.pos.0 < -50.0 {
+                if move_to_places_unplaced && !self.placed {
                     self.pos = (tx, ty);
                 }
                 let (x0, y0) = self.pos;
+                self.placed = true;
                 let th0 = self.heading + std::f64::consts::PI;
                 let th1 = end_heading_radians + std::f64::consts::PI;
                 let plan =
@@ -601,6 +599,7 @@ impl RenderStateCore {
             } => {
                 let reveal_badge = !self.cursor_is_revealed();
                 self.pos = (x, y);
+                self.placed = true;
                 if let Some(heading) = heading_radians {
                     self.heading = heading;
                 }
@@ -625,21 +624,19 @@ impl RenderStateCore {
             }
             OverlayCommand::ClickPulse { x, y } => {
                 let reveal_badge = !self.cursor_is_revealed();
-                if click_pulse_sentinel_only {
-                    // macOS: only snap position on first placement (sentinel state).
-                    // After that the cursor stays where the animation landed.
-                    if self.pos.0 < -50.0 {
-                        // Apply same click offset so tip lands at click point.
+                if !click_pulse_unplaced_only || !self.placed {
+                    self.pos = if click_pulse_unplaced_only {
                         const CLICK_OFFSET: f64 = 16.0;
                         let angle = std::f64::consts::FRAC_PI_4;
-                        self.pos = (
+                        (
                             x + angle.cos() * CLICK_OFFSET,
                             y + angle.sin() * CLICK_OFFSET,
-                        );
-                    }
-                } else {
-                    self.pos = (x, y);
+                        )
+                    } else {
+                        (x, y)
+                    };
                 }
+                self.placed = true;
                 self.click_t = Some(0.0);
                 if matches!(
                     self.visual.resolved_action,
@@ -709,6 +706,8 @@ impl RenderStateCore {
             } => {
                 match crate::resolve_theme_selection(&theme_id) {
                     Ok(theme) => {
+                        self.theme_paint_radius =
+                            theme.as_deref().map_or(64.0, CompiledTheme::paint_radius);
                         self.theme = theme;
                         self.theme_fallback = None;
                         self.cfg.theme_id = theme_id;
@@ -983,6 +982,7 @@ mod glide_duration_tests {
         core.motion.glide_duration_ms = glide_ms;
         core.motion.idle_hide_ms = 0.0;
         core.pos = (0.0, 0.0);
+        core.placed = true;
         // Aligned headings → an effectively straight path of length ~dist_pts.
         core.path = Some(PathPlanner::plan(
             0.0, 0.0, 0.0, dist_pts, 0.0, 0.0, 0.0, 80.0,
@@ -1123,6 +1123,7 @@ mod session_badge_and_action_tests {
     fn hardware_pointer_hover_reveals_only_while_over_cursor() {
         let mut core = RenderStateCore::new(CursorConfig::default());
         core.pos = (300.0, 240.0);
+        core.placed = true;
         core.apply_command_base(
             OverlayCommand::SetSessionLabel("Research".into()),
             false,
@@ -1145,6 +1146,7 @@ mod session_badge_and_action_tests {
     fn movement_preserves_the_active_semantic_action() {
         let mut core = RenderStateCore::new(CursorConfig::default());
         core.pos = (20.0, 20.0);
+        core.placed = true;
         core.apply_command_base(
             OverlayCommand::BeginAction {
                 action: CursorAction::Text,
@@ -1178,6 +1180,7 @@ mod session_badge_and_action_tests {
     fn modifiers_live_in_the_badge_then_fade_after_action_completion() {
         let mut core = RenderStateCore::new(CursorConfig::default());
         core.pos = (200.0, 200.0);
+        core.placed = true;
         core.apply_command_base(
             OverlayCommand::BeginAction {
                 action: CursorAction::Click,
@@ -1308,6 +1311,7 @@ mod backing_scale_tests {
         // idle-fade so the arrow paints at full alpha regardless of timing.
         let centre = logical_size as f64 / 2.0;
         core.pos = (centre, centre);
+        core.placed = true;
         core.idle_alpha = 1.0;
         core.visible = true;
 

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
@@ -72,6 +72,8 @@ pub struct RenderStateCore {
     pub visual: CursorVisualState,
     /// Decoded installed or embedded theme.
     pub theme: Option<Arc<CompiledTheme>>,
+    /// Conservative logical radius touched by any frame of the active theme.
+    theme_paint_radius: f64,
     /// Non-fatal launch-time fallback reason, if an installed theme failed.
     pub theme_fallback: Option<String>,
     /// User-controlled visibility.
@@ -118,11 +120,13 @@ impl RenderStateCore {
                 )),
             ),
         };
+        let theme_paint_radius = theme.as_deref().map_or(64.0, CompiledTheme::paint_radius);
         Self {
             cfg,
             motion,
             visual,
             theme,
+            theme_paint_radius,
             theme_fallback,
             pos: None,
             heading: std::f64::consts::FRAC_PI_4,
@@ -142,6 +146,11 @@ impl RenderStateCore {
             badge_modifiers: None,
             badge_modifier_fade_secs: None,
         }
+    }
+
+    /// Conservative logical radius around `pos` touched by cursor artwork.
+    pub fn paint_radius(&self) -> f64 {
+        self.theme_paint_radius.max(2.0)
     }
 
     /// Return whether cursor pixels and related UI may be shown.
@@ -695,6 +704,8 @@ impl RenderStateCore {
             } => {
                 match crate::resolve_theme_selection(&theme_id) {
                     Ok(theme) => {
+                        self.theme_paint_radius =
+                            theme.as_deref().map_or(64.0, CompiledTheme::paint_radius);
                         self.theme = theme;
                         self.theme_fallback = None;
                         self.cfg.theme_id = theme_id;
@@ -807,8 +818,8 @@ pub fn paint_cursor(
     );
 }
 
-/// Paint cursor artwork on a neighboring display without duplicating the
-/// display-clamped session badge owned by the cursor's anchor display.
+/// Paint cursor artwork without its host-owned session badge. Tile renderers
+/// use this to compose artwork first, then paint one display-clamped badge.
 pub fn paint_cursor_art(
     pm: &mut tiny_skia::Pixmap,
     core: &RenderStateCore,

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
@@ -824,8 +824,8 @@ pub fn paint_cursor(
         let (cr, cg, cb) = (0x5Eu8, 0xC0u8, 0xE8u8);
 
         if let Some(rect) = tiny_skia::Rect::from_xywh(
-            (fx * s) as f32,
-            (fy * s) as f32,
+            ((fx - origin_x) * s) as f32,
+            ((fy - origin_y) * s) as f32,
             (fw * s) as f32,
             (fh * s) as f32,
         ) {
@@ -960,6 +960,28 @@ mod placement_tests {
         paint_cursor(&mut pixmap, &core, -1000.0, 0.0, None, 1.0);
 
         assert!(pixmap.data().chunks_exact(4).any(|pixel| pixel[3] > 0));
+    }
+
+    #[test]
+    fn focus_rect_uses_the_same_display_origin_as_the_cursor() {
+        let mut core = RenderStateCore::new(CursorConfig::default());
+        core.pos = Some((-10.0, 80.0));
+        let mut pixmap = tiny_skia::Pixmap::new(120, 120).unwrap();
+
+        paint_cursor(
+            &mut pixmap,
+            &core,
+            -100.0,
+            0.0,
+            Some(FocusRect {
+                rect: [-90.0, 10.0, 20.0, 20.0],
+                t: 0.0,
+            }),
+            1.0,
+        );
+
+        let alpha_at_focus = pixmap.data()[((15 * 120 + 15) * 4 + 3) as usize];
+        assert!(alpha_at_focus > 0);
     }
 }
 

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
@@ -103,7 +103,6 @@ impl RenderStateCore {
     /// `pos` starts empty so the first placement can snap rather than animate.
     pub fn new(cfg: CursorConfig) -> Self {
         let motion = cfg.motion.clone();
-        let visible = cfg.enabled;
         let visual = CursorVisualState {
             reduced_motion: cfg.reduced_motion,
             ..CursorVisualState::default()
@@ -135,7 +134,7 @@ impl RenderStateCore {
             spring_tgt: None,
             click_t: None,
             pressed: false,
-            visible,
+            visible: true,
             idle_secs: 0.0,
             idle_alpha: 1.0,
             pinned_wid: None,
@@ -972,18 +971,6 @@ fn paint_cursor_impl(
 mod placement_tests {
     use super::*;
     use crate::CursorConfig;
-
-    #[test]
-    fn launch_visibility_has_one_source_of_truth() {
-        let mut config = CursorConfig::default();
-        config.enabled = false;
-        let mut core = RenderStateCore::new(config);
-        assert!(!core.visible);
-        assert!(!core.cursor_is_revealed());
-
-        core.apply_command_base(OverlayCommand::SetEnabled(true), true);
-        assert!(core.visible);
-    }
 
     #[test]
     fn only_unplaced_cursors_are_unrevealed() {

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
@@ -127,7 +127,7 @@ impl RenderStateCore {
             theme,
             theme_paint_radius,
             theme_fallback,
-            pos: (-200.0, -200.0),
+            pos: (0.0, 0.0),
             placed: false,
             heading: std::f64::consts::FRAC_PI_4,
             path: None,
@@ -966,6 +966,22 @@ fn paint_cursor_impl(
                 alpha_scale,
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod placement_tests {
+    use super::*;
+    use crate::CursorConfig;
+
+    #[test]
+    fn visibility_uses_placement_not_coordinate_sign() {
+        let mut core = RenderStateCore::new(CursorConfig::default());
+        core.pos = (-867.0, -200.0);
+        assert!(!core.cursor_is_revealed());
+
+        core.placed = true;
+        assert!(core.cursor_is_revealed());
     }
 }
 

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
@@ -796,6 +796,48 @@ pub fn paint_cursor(
     focus_rect: Option<FocusRect>,
     backing_scale: f32,
 ) {
+    paint_cursor_impl(
+        pm,
+        core,
+        origin_x,
+        origin_y,
+        focus_rect,
+        backing_scale,
+        true,
+    );
+}
+
+/// Paint cursor artwork on a neighboring display without duplicating the
+/// display-clamped session badge owned by the cursor's anchor display.
+pub fn paint_cursor_art(
+    pm: &mut tiny_skia::Pixmap,
+    core: &RenderStateCore,
+    origin_x: f64,
+    origin_y: f64,
+    focus_rect: Option<FocusRect>,
+    backing_scale: f32,
+) {
+    paint_cursor_impl(
+        pm,
+        core,
+        origin_x,
+        origin_y,
+        focus_rect,
+        backing_scale,
+        false,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn paint_cursor_impl(
+    pm: &mut tiny_skia::Pixmap,
+    core: &RenderStateCore,
+    origin_x: f64,
+    origin_y: f64,
+    focus_rect: Option<FocusRect>,
+    backing_scale: f32,
+    paint_badge: bool,
+) {
     if !core.cursor_is_revealed() {
         return;
     }
@@ -894,23 +936,25 @@ pub fn paint_cursor(
         );
     }
 
-    let (delivery, target) = core.badge_modifiers.unwrap_or((None, None));
-    if let Some(layout) = crate::session_badge_layout(crate::SessionBadgeInput {
-        label: core.session_label.as_deref(),
-        delivery,
-        target,
-        cursor: (px as f32, py as f32),
-        backing_scale: backing_scale.max(1.0),
-        label_alpha: core.session_badge_alpha(),
-        chip_alpha: core.session_badge_chip_alpha(),
-        clip: Some((pm.width() as f32, pm.height() as f32)),
-    }) {
-        crate::paint_session_badge(
-            pm,
-            &layout,
-            crate::session_fill_rgba(&core.cfg.cursor_id),
-            alpha_scale,
-        );
+    if paint_badge {
+        let (delivery, target) = core.badge_modifiers.unwrap_or((None, None));
+        if let Some(layout) = crate::session_badge_layout(crate::SessionBadgeInput {
+            label: core.session_label.as_deref(),
+            delivery,
+            target,
+            cursor: (px as f32, py as f32),
+            backing_scale: backing_scale.max(1.0),
+            label_alpha: core.session_badge_alpha(),
+            chip_alpha: core.session_badge_chip_alpha(),
+            clip: Some((pm.width() as f32, pm.height() as f32)),
+        }) {
+            crate::paint_session_badge(
+                pm,
+                &layout,
+                crate::session_fill_rgba(&core.cfg.cursor_id),
+                alpha_scale,
+            );
+        }
     }
 }
 

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
@@ -18,18 +18,16 @@
 //!   SetEnabled / SetMotion / SetTheme / semantic action events / PinAbove).
 //!   Returns `false` for variants the core doesn't handle so platforms can
 //!   layer their own behaviour on top (e.g. macOS ShowFocusRect).
-//! - [`render_frame`] — the tiny-skia paint of the selected cursor theme.
-//!   Parametrised by pixmap dimensions and an origin offset so Windows can
-//!   pass `(virt_x, virt_y)` while macOS / Linux pass `(0, 0)`.
+//! - [`render_frame`] — the tiny-skia paint of the selected cursor theme,
+//!   parameterized by pixmap dimensions and a global origin offset.
 //!
 //! ## What stays per-platform
 //!
 //! - The OS window / surface (NSWindow / HWND / X11 Window) and its message
 //!   loop or run-loop.
-//! - The paint dispatch: `dispatch_set_layer_contents` (CGImage),
-//!   `UpdateLayeredWindow` (BGRA DIB), `XPutImage` (BGRA ZPixmap).
-//! - Origin/coordinate translation (Windows uses virtual-screen offset;
-//!   macOS uses NSScreen coordinates; Linux uses display coordinates).
+//! - The paint dispatch: Core Animation child layers on macOS,
+//!   `UpdateLayeredWindow` (BGRA DIB), and `XPutImage` (BGRA ZPixmap).
+//! - Origin/coordinate translation from global points into native surfaces.
 //! - Platform-specific extras like macOS's `focus_rect` (post-arrival
 //!   element highlight — drawn inside [`render_frame`] when the caller
 //!   supplies one via the optional argument).
@@ -105,6 +103,7 @@ impl RenderStateCore {
     /// `pos` starts empty so the first placement can snap rather than animate.
     pub fn new(cfg: CursorConfig) -> Self {
         let motion = cfg.motion.clone();
+        let visible = cfg.enabled;
         let visual = CursorVisualState {
             reduced_motion: cfg.reduced_motion,
             ..CursorVisualState::default()
@@ -136,7 +135,7 @@ impl RenderStateCore {
             spring_tgt: None,
             click_t: None,
             pressed: false,
-            visible: true,
+            visible,
             idle_secs: 0.0,
             idle_alpha: 1.0,
             pinned_wid: None,
@@ -973,6 +972,18 @@ fn paint_cursor_impl(
 mod placement_tests {
     use super::*;
     use crate::CursorConfig;
+
+    #[test]
+    fn launch_visibility_has_one_source_of_truth() {
+        let mut config = CursorConfig::default();
+        config.enabled = false;
+        let mut core = RenderStateCore::new(config);
+        assert!(!core.visible);
+        assert!(!core.cursor_is_revealed());
+
+        core.apply_command_base(OverlayCommand::SetEnabled(true), true);
+        assert!(core.visible);
+    }
 
     #[test]
     fn only_unplaced_cursors_are_unrevealed() {

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/render_state.rs
@@ -153,7 +153,7 @@ impl RenderStateCore {
         self.theme_paint_radius.max(64.0)
     }
 
-    fn cursor_is_revealed(&self) -> bool {
+    pub fn cursor_is_revealed(&self) -> bool {
         self.visible && self.placed && self.idle_alpha >= 0.004
     }
 

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/session_badge.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/session_badge.rs
@@ -57,6 +57,28 @@ pub struct SessionBadgeLayout {
     pub scale: f32,
 }
 
+impl SessionBadgeLayout {
+    /// Translate a resolved layout into a cursor-local presentation tile.
+    pub fn translated(mut self, dx: f32, dy: f32) -> Self {
+        let translate_rect = |rect: Rect| {
+            Rect::from_xywh(rect.x() + dx, rect.y() + dy, rect.width(), rect.height())
+                .expect("translating a valid badge rectangle remains valid")
+        };
+        self.rect = translate_rect(self.rect);
+        if let Some(label) = self.label.as_mut() {
+            label.origin.0 += dx;
+            label.origin.1 += dy;
+        }
+        if let Some(chip) = self.delivery_chip.as_mut() {
+            chip.rect = translate_rect(chip.rect);
+        }
+        if let Some(chip) = self.target_chip.as_mut() {
+            chip.rect = translate_rect(chip.rect);
+        }
+        self
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct SessionBadgeInput<'a> {
     pub label: Option<&'a str>,

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/session_badge.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/session_badge.rs
@@ -57,28 +57,6 @@ pub struct SessionBadgeLayout {
     pub scale: f32,
 }
 
-impl SessionBadgeLayout {
-    /// Translate a resolved layout into a cursor-local presentation tile.
-    pub fn translated(mut self, dx: f32, dy: f32) -> Self {
-        let translate_rect = |rect: Rect| {
-            Rect::from_xywh(rect.x() + dx, rect.y() + dy, rect.width(), rect.height())
-                .expect("translating a valid badge rectangle remains valid")
-        };
-        self.rect = translate_rect(self.rect);
-        if let Some(label) = self.label.as_mut() {
-            label.origin.0 += dx;
-            label.origin.1 += dy;
-        }
-        if let Some(chip) = self.delivery_chip.as_mut() {
-            chip.rect = translate_rect(chip.rect);
-        }
-        if let Some(chip) = self.target_chip.as_mut() {
-            chip.rect = translate_rect(chip.rect);
-        }
-        self
-    }
-}
-
 #[derive(Debug, Clone, Copy)]
 pub struct SessionBadgeInput<'a> {
     pub label: Option<&'a str>,

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/theme_artifact.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/theme_artifact.rs
@@ -115,50 +115,6 @@ pub struct CompiledTheme {
 }
 
 impl CompiledTheme {
-    /// Conservative logical-point radius around the cursor anchor that can be
-    /// touched by any frame in this artifact. Computing this once when a theme
-    /// is selected lets platform renderers allocate bounded cursor-local tiles.
-    pub fn paint_radius(&self) -> f64 {
-        let mut radius = 1.0f64;
-        for command in self
-            .actions
-            .values()
-            .flat_map(|animation| &animation.frames)
-            .flat_map(|frame| &frame.commands)
-        {
-            let mut builder = PathBuilder::new();
-            for geometry in &command.geometries {
-                append_geometry(&mut builder, geometry);
-            }
-            let Some(path) = builder
-                .finish()
-                .and_then(|path| path.transform(compiled_transform(command.transform)))
-            else {
-                continue;
-            };
-            let bounds = path.bounds();
-            let geometry_radius = [
-                (bounds.left(), bounds.top()),
-                (bounds.right(), bounds.top()),
-                (bounds.left(), bounds.bottom()),
-                (bounds.right(), bounds.bottom()),
-            ]
-            .into_iter()
-            .map(|(x, y)| f64::from(x - 64.0).hypot(f64::from(y - 64.0)))
-            .fold(0.0, f64::max);
-            let stroke_radius = command.stroke.map_or(0.0, |stroke| {
-                let scale = command.transform.scale[0]
-                    .abs()
-                    .max(command.transform.scale[1].abs());
-                // tiny-skia's default miter limit is four half-widths.
-                f64::from(stroke.width * scale * 2.0)
-            });
-            radius = radius.max(geometry_radius + stroke_radius);
-        }
-        // Include anti-aliasing and the default theme's shared float motion.
-        (radius * f64::from(crate::theme::DISPLAY_SIZE / crate::theme::CANVAS_SIZE) + 8.0).max(8.0)
-    }
-
     pub fn content_hash(&self) -> String {
         let mut hasher = Sha256::new();
         if let Ok(bytes) = postcard::to_allocvec(self) {
@@ -906,16 +862,6 @@ mod tests {
         let bytes = encode_theme(&theme).unwrap();
         assert_eq!(decode_theme(&bytes).unwrap(), theme);
         assert!(decode_theme(&bytes[..20]).is_err());
-    }
-
-    #[test]
-    fn paint_radius_includes_authored_transforms() {
-        let mut theme = minimal_theme();
-        for animation in theme.actions.values_mut() {
-            animation.frames[0].commands[0].transform.position = [400.0, 64.0];
-        }
-        assert!(theme.paint_radius() > 100.0);
-        assert!(theme.paint_radius() < 150.0);
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/theme_artifact.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/theme_artifact.rs
@@ -120,61 +120,40 @@ impl CompiledTheme {
     /// is selected lets platform renderers allocate bounded cursor-local tiles.
     pub fn paint_radius(&self) -> f64 {
         let mut radius = 1.0f64;
-        for animation in self.actions.values() {
-            for frame in &animation.frames {
-                for command in &frame.commands {
-                    let transform = command.transform;
-                    let radians = f64::from(transform.rotation_degrees).to_radians();
-                    let (sin, cos) = radians.sin_cos();
-                    let mut command_radius = 0.0f64;
-                    let mut include = |point: [f32; 2]| {
-                        let sx = f64::from(point[0] - transform.anchor[0])
-                            * f64::from(transform.scale[0]);
-                        let sy = f64::from(point[1] - transform.anchor[1])
-                            * f64::from(transform.scale[1]);
-                        let x = sx * cos - sy * sin + f64::from(transform.position[0]);
-                        let y = sx * sin + sy * cos + f64::from(transform.position[1]);
-                        command_radius = command_radius.max((x - 64.0).hypot(y - 64.0));
-                    };
-                    for geometry in &command.geometries {
-                        match geometry {
-                            CompiledGeometry::Path {
-                                vertices,
-                                in_tangents,
-                                out_tangents,
-                                ..
-                            } => {
-                                for (index, vertex) in vertices.iter().copied().enumerate() {
-                                    include(vertex);
-                                    if let Some(tangent) = in_tangents.get(index) {
-                                        include([vertex[0] + tangent[0], vertex[1] + tangent[1]]);
-                                    }
-                                    if let Some(tangent) = out_tangents.get(index) {
-                                        include([vertex[0] + tangent[0], vertex[1] + tangent[1]]);
-                                    }
-                                }
-                            }
-                            CompiledGeometry::Ellipse { center, size }
-                            | CompiledGeometry::Rectangle { center, size, .. } => {
-                                let rx = size[0] * 0.5;
-                                let ry = size[1] * 0.5;
-                                for x in [center[0] - rx, center[0] + rx] {
-                                    for y in [center[1] - ry, center[1] + ry] {
-                                        include([x, y]);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    let stroke = command.stroke.map_or(0.0, |stroke| {
-                        let scale = transform.scale[0].abs().max(transform.scale[1].abs());
-                        // tiny-skia's default miter limit can extend a join to
-                        // four half-widths beyond the path.
-                        f64::from(stroke.width * scale * 2.0)
-                    });
-                    radius = radius.max(command_radius + stroke);
-                }
+        for command in self
+            .actions
+            .values()
+            .flat_map(|animation| &animation.frames)
+            .flat_map(|frame| &frame.commands)
+        {
+            let mut builder = PathBuilder::new();
+            for geometry in &command.geometries {
+                append_geometry(&mut builder, geometry);
             }
+            let Some(path) = builder
+                .finish()
+                .and_then(|path| path.transform(compiled_transform(command.transform)))
+            else {
+                continue;
+            };
+            let bounds = path.bounds();
+            let geometry_radius = [
+                (bounds.left(), bounds.top()),
+                (bounds.right(), bounds.top()),
+                (bounds.left(), bounds.bottom()),
+                (bounds.right(), bounds.bottom()),
+            ]
+            .into_iter()
+            .map(|(x, y)| f64::from(x - 64.0).hypot(f64::from(y - 64.0)))
+            .fold(0.0, f64::max);
+            let stroke_radius = command.stroke.map_or(0.0, |stroke| {
+                let scale = command.transform.scale[0]
+                    .abs()
+                    .max(command.transform.scale[1].abs());
+                // tiny-skia's default miter limit is four half-widths.
+                f64::from(stroke.width * scale * 2.0)
+            });
+            radius = radius.max(geometry_radius + stroke_radius);
         }
         // Include anti-aliasing and the default theme's shared float motion.
         (radius * f64::from(crate::theme::DISPLAY_SIZE / crate::theme::CANVAS_SIZE) + 8.0).max(8.0)

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/theme_artifact.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/theme_artifact.rs
@@ -115,6 +115,71 @@ pub struct CompiledTheme {
 }
 
 impl CompiledTheme {
+    /// Conservative logical-point radius around the cursor anchor that can be
+    /// touched by any frame in this artifact. Computing this once when a theme
+    /// is selected lets platform renderers allocate bounded cursor-local tiles.
+    pub fn paint_radius(&self) -> f64 {
+        let mut radius = 1.0f64;
+        for animation in self.actions.values() {
+            for frame in &animation.frames {
+                for command in &frame.commands {
+                    let transform = command.transform;
+                    let radians = f64::from(transform.rotation_degrees).to_radians();
+                    let (sin, cos) = radians.sin_cos();
+                    let mut command_radius = 0.0f64;
+                    let mut include = |point: [f32; 2]| {
+                        let sx = f64::from(point[0] - transform.anchor[0])
+                            * f64::from(transform.scale[0]);
+                        let sy = f64::from(point[1] - transform.anchor[1])
+                            * f64::from(transform.scale[1]);
+                        let x = sx * cos - sy * sin + f64::from(transform.position[0]);
+                        let y = sx * sin + sy * cos + f64::from(transform.position[1]);
+                        command_radius = command_radius.max((x - 64.0).hypot(y - 64.0));
+                    };
+                    for geometry in &command.geometries {
+                        match geometry {
+                            CompiledGeometry::Path {
+                                vertices,
+                                in_tangents,
+                                out_tangents,
+                                ..
+                            } => {
+                                for (index, vertex) in vertices.iter().copied().enumerate() {
+                                    include(vertex);
+                                    if let Some(tangent) = in_tangents.get(index) {
+                                        include([vertex[0] + tangent[0], vertex[1] + tangent[1]]);
+                                    }
+                                    if let Some(tangent) = out_tangents.get(index) {
+                                        include([vertex[0] + tangent[0], vertex[1] + tangent[1]]);
+                                    }
+                                }
+                            }
+                            CompiledGeometry::Ellipse { center, size }
+                            | CompiledGeometry::Rectangle { center, size, .. } => {
+                                let rx = size[0] * 0.5;
+                                let ry = size[1] * 0.5;
+                                for x in [center[0] - rx, center[0] + rx] {
+                                    for y in [center[1] - ry, center[1] + ry] {
+                                        include([x, y]);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    let stroke = command.stroke.map_or(0.0, |stroke| {
+                        let scale = transform.scale[0].abs().max(transform.scale[1].abs());
+                        // tiny-skia's default miter limit can extend a join to
+                        // four half-widths beyond the path.
+                        f64::from(stroke.width * scale * 2.0)
+                    });
+                    radius = radius.max(command_radius + stroke);
+                }
+            }
+        }
+        // Include anti-aliasing and the default theme's shared float motion.
+        (radius * f64::from(crate::theme::DISPLAY_SIZE / crate::theme::CANVAS_SIZE) + 8.0).max(8.0)
+    }
+
     pub fn content_hash(&self) -> String {
         let mut hasher = Sha256::new();
         if let Ok(bytes) = postcard::to_allocvec(self) {
@@ -862,6 +927,16 @@ mod tests {
         let bytes = encode_theme(&theme).unwrap();
         assert_eq!(decode_theme(&bytes).unwrap(), theme);
         assert!(decode_theme(&bytes[..20]).is_err());
+    }
+
+    #[test]
+    fn paint_radius_includes_authored_transforms() {
+        let mut theme = minimal_theme();
+        for animation in theme.actions.values_mut() {
+            animation.frames[0].commands[0].transform.position = [400.0, 64.0];
+        }
+        assert!(theme.paint_radius() > 100.0);
+        assert!(theme.paint_radius() < 150.0);
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cursor-overlay/src/theme_artifact.rs
+++ b/libs/cua-driver/rust/crates/cursor-overlay/src/theme_artifact.rs
@@ -115,6 +115,48 @@ pub struct CompiledTheme {
 }
 
 impl CompiledTheme {
+    /// Conservative logical radius around the cursor anchor touched by any frame.
+    pub fn paint_radius(&self) -> f64 {
+        let mut radius = 1.0f64;
+        for command in self
+            .actions
+            .values()
+            .flat_map(|animation| &animation.frames)
+            .flat_map(|frame| &frame.commands)
+        {
+            let mut builder = PathBuilder::new();
+            for geometry in &command.geometries {
+                append_geometry(&mut builder, geometry);
+            }
+            let Some(path) = builder
+                .finish()
+                .and_then(|path| path.transform(compiled_transform(command.transform)))
+            else {
+                continue;
+            };
+            let bounds = path.bounds();
+            let geometry_radius = [
+                (bounds.left(), bounds.top()),
+                (bounds.right(), bounds.top()),
+                (bounds.left(), bounds.bottom()),
+                (bounds.right(), bounds.bottom()),
+            ]
+            .into_iter()
+            .map(|(x, y)| f64::from(x - 64.0).hypot(f64::from(y - 64.0)))
+            .fold(0.0, f64::max);
+            let stroke_radius = command.stroke.map_or(0.0, |stroke| {
+                let scale = command.transform.scale[0]
+                    .abs()
+                    .max(command.transform.scale[1].abs());
+                // tiny-skia's default miter limit is four half-widths.
+                f64::from(stroke.width * scale * 2.0)
+            });
+            radius = radius.max(geometry_radius + stroke_radius);
+        }
+        // Include anti-aliasing and the shared floating motion.
+        (radius * f64::from(crate::theme::DISPLAY_SIZE / crate::theme::CANVAS_SIZE) + 8.0).max(8.0)
+    }
+
     pub fn content_hash(&self) -> String {
         let mut hasher = Sha256::new();
         if let Ok(bytes) = postcard::to_allocvec(self) {
@@ -862,6 +904,16 @@ mod tests {
         let bytes = encode_theme(&theme).unwrap();
         assert_eq!(decode_theme(&bytes).unwrap(), theme);
         assert!(decode_theme(&bytes[..20]).is_err());
+    }
+
+    #[test]
+    fn paint_radius_includes_authored_transforms() {
+        let mut theme = minimal_theme();
+        for animation in theme.actions.values_mut() {
+            animation.frames[0].commands[0].transform.position = [400.0, 64.0];
+        }
+        assert!(theme.paint_radius() > 100.0);
+        assert!(theme.paint_radius() < 150.0);
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
@@ -399,21 +399,30 @@ pub fn is_visible_for_session(key: &str) -> bool {
             guard
                 .as_ref()
                 .and_then(|map| map.cursors.get(key))
-                .map(|rs| rs.core.cfg.enabled && rs.core.cursor_is_revealed())
+                .map(|rs| {
+                    rs.core.cfg.enabled
+                        && rs.core.visible
+                        && rs.core.idle_alpha >= 0.004
+                        && rs.core.pos.0 >= -100.0
+                })
         })
         .unwrap_or(false)
 }
 
-pub fn current_position() -> Option<(f64, f64)> {
+pub fn current_position() -> (f64, f64) {
     current_position_for("default")
 }
 
-pub fn current_position_for(key: &str) -> Option<(f64, f64)> {
-    RENDER.lock().ok().and_then(|g| {
-        g.as_ref()
-            .and_then(|m| m.cursors.get(key))
-            .and_then(|rs| rs.core.pos)
-    })
+pub fn current_position_for(key: &str) -> (f64, f64) {
+    RENDER
+        .lock()
+        .ok()
+        .and_then(|g| {
+            g.as_ref()
+                .and_then(|m| m.cursors.get(key))
+                .map(|rs| rs.core.pos)
+        })
+        .unwrap_or((-200.0, -200.0))
 }
 
 pub fn current_motion_for(key: &str) -> cursor_overlay::MotionConfig {
@@ -450,7 +459,7 @@ pub fn current_theme_state_for(
     Some((id, version, profile, fallback, state.core.visual.clone()))
 }
 
-fn seed_start_if_unplaced(key: &CursorKey, target_x: f64, target_y: f64) -> bool {
+fn seed_start_if_sentinel(key: &CursorKey, target_x: f64, target_y: f64) -> bool {
     const SEED_OFFSET: f64 = 140.0;
     let mut guard = RENDER.lock().unwrap();
     let Some(map) = guard.as_mut() else {
@@ -465,7 +474,7 @@ fn seed_start_if_unplaced(key: &CursorKey, target_x: f64, target_y: f64) -> bool
         .cursors
         .entry(key.clone())
         .or_insert_with(|| render_state_for_key(&template, &k));
-    if !(rs.core.cfg.enabled && rs.core.pos.is_none()) {
+    if !(rs.core.cfg.enabled && rs.core.pos.0 < -50.0) {
         return false;
     }
     let max_x = map.scr_w.max(2) as f64 - 2.0;
@@ -476,7 +485,7 @@ fn seed_start_if_unplaced(key: &CursorKey, target_x: f64, target_y: f64) -> bool
         sx = (target_x + SEED_OFFSET).clamp(2.0, max_x);
         sy = (target_y + SEED_OFFSET).clamp(2.0, max_y);
     }
-    rs.core.pos = Some((sx, sy));
+    rs.core.pos = (sx, sy);
     true
 }
 
@@ -488,11 +497,11 @@ pub async fn animate_cursor_to_for(key: CursorKey, x: f64, y: f64) {
     if key.is_empty() {
         return;
     }
-    seed_start_if_unplaced(&key, x, y);
+    seed_start_if_sentinel(&key, x, y);
     let should_animate = {
         let guard = RENDER.lock().unwrap();
         match guard.as_ref().and_then(|m| m.cursors.get(&key)) {
-            Some(rs) if rs.core.cfg.enabled && rs.core.visible && rs.core.pos.is_some() => true,
+            Some(rs) if rs.core.cfg.enabled && rs.core.visible && rs.core.pos.0 > -50.0 => true,
             _ => false,
         }
     };
@@ -611,16 +620,17 @@ impl RenderState {
     }
 
     fn apply_command(&mut self, cmd: OverlayCommand) {
-        // Linux click pulses update the cursor position unconditionally.
+        // Linux uses the non-sentinel-snap behaviour for both MoveTo and
+        // ClickPulse: every command updates `self.pos` unconditionally.
         // Custom-shape / gradient / focus-rect commands are not rendered on
         // Linux at present; `apply_command_base` consumes SetShape +
         // SetGradient and returns false for ShowFocusRect — both cases drop
         // the visual update silently so callers don't see an error.
-        let _ = self.core.apply_command_base(cmd, true);
+        let _ = self.core.apply_command_base(cmd, false, false);
     }
 
     /// True while the render loop must wake at frame cadence because the next
-    /// tick can change pixels. A brand-new unplaced cursor is deliberately
+    /// tick can change pixels. A brand-new sentinel cursor is deliberately
     /// quiescent, so an idle MCP server can park on bounded maintenance waits
     /// instead of rebuilding and repainting X11 cursor tiles at 60 fps.
     #[cfg(target_os = "linux")]
@@ -637,10 +647,13 @@ impl RenderState {
             // mid-swing on Linux while macOS keeps levitating. The term dies
             // with `idle_alpha` once the idle fade completes, returning the
             // parked-overlay fast path to the fully hidden cursor.
-            || (self.core.cursor_is_revealed()
+            || (self.core.visible
+                && self.core.pos.0 >= -100.0
+                && self.core.idle_alpha >= 0.004
                 && self.core.visual.reduced_motion != cursor_overlay::ReducedMotion::On)
             || (self.core.motion.idle_hide_ms > 0.0
-                && self.core.cursor_is_revealed()
+                && self.core.visible
+                && self.core.pos.0 >= -100.0
                 && self.core.idle_secs >= fade_start
                 && self.core.idle_alpha >= 0.004)
     }
@@ -653,7 +666,9 @@ fn render_map_needs_frame_tick(map: &RenderMap) -> bool {
 
 #[cfg(target_os = "linux")]
 fn render_map_needs_z_order_tick(map: &RenderMap) -> bool {
-    map.cursors.values().any(|rs| rs.core.cursor_is_revealed())
+    map.cursors
+        .values()
+        .any(|rs| rs.core.visible && rs.core.idle_alpha >= 0.004 && rs.core.pos.0 >= -100.0)
 }
 
 #[cfg(target_os = "linux")]
@@ -725,7 +740,8 @@ fn render_map_idle_wait_interval(map: &RenderMap) -> Option<Duration> {
         .values()
         .filter_map(|rs| {
             let core = &rs.core;
-            if !core.cursor_is_revealed()
+            if !core.visible
+                || core.pos.0 < -100.0
                 || core.motion.idle_hide_ms <= 0.0
                 || core.path.is_some()
                 || core.spring.is_some()
@@ -2050,10 +2066,9 @@ fn cursor_tile_bounds(
     screen_width: u32,
     screen_height: u32,
 ) -> Option<X11TileBounds> {
-    if !core.cursor_is_revealed() {
+    if !core.visible || core.pos.0 < -100.0 || core.idle_alpha < 0.004 {
         return None;
     }
-    let (cursor_x, cursor_y) = core.pos?;
 
     let screen_width = i32::try_from(screen_width).ok()?;
     let screen_height = i32::try_from(screen_height).ok()?;
@@ -2062,10 +2077,10 @@ fn cursor_tile_bounds(
     } else {
         X11_CURSOR_TILE_MARGIN
     };
-    let left = (cursor_x - horizontal_margin).floor() as i32;
-    let top = (cursor_y - X11_CURSOR_TILE_MARGIN).floor() as i32;
-    let right = (cursor_x + horizontal_margin).ceil() as i32;
-    let bottom = (cursor_y + X11_CURSOR_TILE_MARGIN).ceil() as i32;
+    let left = (core.pos.0 - horizontal_margin).floor() as i32;
+    let top = (core.pos.1 - X11_CURSOR_TILE_MARGIN).floor() as i32;
+    let right = (core.pos.0 + horizontal_margin).ceil() as i32;
+    let bottom = (core.pos.1 + X11_CURSOR_TILE_MARGIN).ceil() as i32;
 
     let left = left.clamp(0, screen_width);
     let top = top.clamp(0, screen_height);
@@ -2828,19 +2843,22 @@ mod tests {
         fn wait_for_cursor_move_from(x: f64, y: f64, phase: &str) -> anyhow::Result<()> {
             let deadline = Instant::now() + Duration::from_secs(3);
             while Instant::now() < deadline {
-                if let Some(position) = current_position() {
-                    if (position.0 - x).hypot(position.1 - y) > 32.0 {
-                        eprintln!(
-                            "{phase}: cursor moved from ({x}, {y}) to ({}, {})",
-                            position.0, position.1
-                        );
-                        return Ok(());
-                    }
+                let position = current_position();
+                if (position.0 - x).hypot(position.1 - y) > 32.0 {
+                    eprintln!(
+                        "{phase}: cursor moved from ({x}, {y}) to ({}, {})",
+                        position.0, position.1
+                    );
+                    return Ok(());
                 }
                 std::thread::sleep(Duration::from_millis(10));
             }
             let position = current_position();
-            anyhow::bail!("cursor position remained {position:?} near ({x}, {y}) during {phase}")
+            anyhow::bail!(
+                "cursor position remained ({}, {}) near ({x}, {y}) during {phase}",
+                position.0,
+                position.1
+            )
         }
 
         let (conn, screen_num) = x11rb::connect(None)?;
@@ -3261,7 +3279,7 @@ mod tests {
     fn maintenance_tick_advances_the_full_elapsed_interval() {
         let mut map = default_render_map();
         let cursor = map.cursors.get_mut("default").unwrap();
-        cursor.core.pos = Some((10.0, 10.0));
+        cursor.core.pos = (10.0, 10.0);
         cursor.core.motion.idle_hide_ms = 500.0;
         let (_tx, rx) = std::sync::mpsc::channel();
 
@@ -3440,7 +3458,7 @@ mod tests {
         let mut map = default_render_map();
         map.scr_w = 1920;
         map.scr_h = 2160;
-        map.cursors.get_mut("default").unwrap().core.pos = Some((100.0, 2000.0));
+        map.cursors.get_mut("default").unwrap().core.pos = (100.0, 2000.0);
         assert_eq!(render_x11_tiles(&map).len(), 1);
 
         update_render_map_geometry(&mut map, 1920, 1080);
@@ -3448,7 +3466,7 @@ mod tests {
     }
 
     #[test]
-    fn unplaced_default_cursor_does_not_require_frame_ticks() {
+    fn sentinel_default_cursor_does_not_require_frame_ticks() {
         let map = default_render_map();
         assert!(!render_map_needs_frame_tick(&map));
         assert!(!render_map_needs_z_order_tick(&map));
@@ -3461,7 +3479,7 @@ mod tests {
     fn resting_visible_cursor_only_requires_cheap_z_order_ticks() {
         let mut map = default_render_map();
         let cursor = map.cursors.get_mut("default").unwrap();
-        cursor.core.pos = Some((100.0, 100.0));
+        cursor.core.pos = (100.0, 100.0);
         cursor.core.motion.idle_hide_ms = 0.0;
         cursor.core.visual.reduced_motion = cursor_overlay::ReducedMotion::On;
 
@@ -3473,7 +3491,7 @@ mod tests {
     fn resting_visible_cursor_keeps_ticking_for_the_float_bob() {
         let mut map = default_render_map();
         let cursor = map.cursors.get_mut("default").unwrap();
-        cursor.core.pos = Some((100.0, 100.0));
+        cursor.core.pos = (100.0, 100.0);
         cursor.core.motion.idle_hide_ms = 0.0;
 
         // Default reduced_motion (auto) floats, so frames keep flowing while
@@ -3490,7 +3508,7 @@ mod tests {
     fn disabling_settled_cursor_clears_once_then_parks() {
         let mut map = default_render_map();
         let cursor = map.cursors.get_mut("default").unwrap();
-        cursor.core.pos = Some((100.0, 100.0));
+        cursor.core.pos = (100.0, 100.0);
         cursor.core.motion.idle_hide_ms = 0.0;
         cursor.core.visual.reduced_motion = cursor_overlay::ReducedMotion::On;
         let (_tx, rx) = std::sync::mpsc::channel();
@@ -3537,7 +3555,7 @@ mod tests {
         let cursor = map.cursors.get_mut("default").unwrap();
         // The public animate path seeds a newly created cursor near its target
         // before sending MoveTo; mirror that valid on-screen starting state.
-        cursor.core.pos = Some((100.0, 100.0));
+        cursor.core.pos = (100.0, 100.0);
         cursor.core.motion.idle_hide_ms = 500.0;
         cursor.core.visual.reduced_motion = cursor_overlay::ReducedMotion::On;
         cursor.apply_command(OverlayCommand::MoveTo {
@@ -3573,7 +3591,7 @@ mod tests {
         let mut map = default_render_map();
         {
             let cursor = map.cursors.get_mut("default").unwrap();
-            cursor.core.pos = Some((10.0, 10.0));
+            cursor.core.pos = (10.0, 10.0);
             cursor.core.motion.idle_hide_ms = 500.0;
         }
         let other = render_state_for_key(&map.template, "other");
@@ -3613,11 +3631,11 @@ mod tests {
         let mut map = default_render_map();
         {
             let cursor = map.cursors.get_mut("default").unwrap();
-            cursor.core.pos = Some((10.0, 10.0));
+            cursor.core.pos = (10.0, 10.0);
             cursor.core.motion.idle_hide_ms = 500.0;
         }
         let mut other = render_state_for_key(&map.template, "other");
-        other.core.pos = Some((20.0, 20.0));
+        other.core.pos = (20.0, 20.0);
         map.cursors.insert("other".to_owned(), other);
 
         // Model a command arriving after recv_timeout returned Timeout but
@@ -3640,7 +3658,7 @@ mod tests {
         assert_eq!(map.cursors["default"].core.idle_secs, 0.08);
         let other = &map.cursors["other"].core;
         assert!(other.path.is_some());
-        assert_eq!(other.pos, Some((20.0, 20.0)));
+        assert_eq!(other.pos, (20.0, 20.0));
         assert_eq!(other.dist, 0.0);
     }
 
@@ -3648,7 +3666,7 @@ mod tests {
     fn click_pulse_drained_after_maintenance_timeout_starts_at_zero_dt() {
         let mut map = default_render_map();
         let cursor = map.cursors.get_mut("default").unwrap();
-        cursor.core.pos = Some((20.0, 20.0));
+        cursor.core.pos = (20.0, 20.0);
 
         let (tx, rx) = std::sync::mpsc::channel();
         tx.send(OverlayMsg::Cmd(KeyedOverlayCommand {
@@ -3662,7 +3680,7 @@ mod tests {
         assert!(arrived.is_empty());
         assert!(had_msg);
         let cursor = &map.cursors["default"].core;
-        assert_eq!(cursor.pos, Some((40.0, 50.0)));
+        assert_eq!(cursor.pos, (40.0, 50.0));
         assert_eq!(cursor.click_t, Some(0.0));
     }
 
@@ -3671,7 +3689,7 @@ mod tests {
         let mut map = default_render_map();
         {
             let cursor = map.cursors.get_mut("default").unwrap();
-            cursor.core.pos = Some((20.0, 20.0));
+            cursor.core.pos = (20.0, 20.0);
             cursor.apply_command(OverlayCommand::MoveTo {
                 x: 80.0,
                 y: 80.0,
@@ -3709,7 +3727,7 @@ mod tests {
         let mut map = default_render_map();
         {
             let cursor = map.cursors.get_mut("default").unwrap();
-            cursor.core.pos = Some((100.0, 100.0));
+            cursor.core.pos = (100.0, 100.0);
             cursor.core.motion.idle_hide_ms = 500.0;
             cursor.core.visual.reduced_motion = cursor_overlay::ReducedMotion::On;
 
@@ -3775,7 +3793,7 @@ mod tests {
         map.scr_w = 7680;
         map.scr_h = 2160;
         let cursor = map.cursors.get_mut("default").unwrap();
-        cursor.core.pos = Some((4000.0, 1000.0));
+        cursor.core.pos = (4000.0, 1000.0);
 
         let tiles = render_x11_tiles(&map);
 
@@ -3793,7 +3811,7 @@ mod tests {
         map.scr_w = 7680;
         map.scr_h = 2160;
         let cursor = map.cursors.get_mut("default").unwrap();
-        cursor.core.pos = Some((4000.0, 1000.0));
+        cursor.core.pos = (4000.0, 1000.0);
         cursor.apply_command(OverlayCommand::SetSessionLabel("research-run".to_owned()));
 
         let tiles = render_x11_tiles(&map);
@@ -3810,7 +3828,7 @@ mod tests {
         map.scr_w = 7680;
         map.scr_h = 2160;
         let cursor = map.cursors.get_mut("default").unwrap();
-        cursor.core.pos = Some((4000.0, 1000.0));
+        cursor.core.pos = (4000.0, 1000.0);
         cursor.apply_command(OverlayCommand::BeginAction {
             action: CursorAction::Click,
             delivery: Some(cursor_overlay::DeliveryModifier::Foreground),
@@ -3830,7 +3848,7 @@ mod tests {
         map.scr_w = 1920;
         map.scr_h = 1080;
         let cursor = map.cursors.get_mut("default").unwrap();
-        cursor.core.pos = Some((10.0, 12.0));
+        cursor.core.pos = (10.0, 12.0);
 
         let tiles = render_x11_tiles(&map);
         assert_eq!(tiles.len(), 1);
@@ -3853,9 +3871,9 @@ mod tests {
         let mut map = default_render_map();
         map.scr_w = 7680;
         map.scr_h = 2160;
-        map.cursors.get_mut("default").unwrap().core.pos = Some((100.0, 100.0));
+        map.cursors.get_mut("default").unwrap().core.pos = (100.0, 100.0);
         let mut other = render_state_for_key(&map.template, "other");
-        other.core.pos = Some((7400.0, 1800.0));
+        other.core.pos = (7400.0, 1800.0);
         map.cursors.insert("other".to_owned(), other);
 
         let tiles = render_x11_tiles(&map);

--- a/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
@@ -3812,6 +3812,7 @@ mod tests {
         map.scr_h = 2160;
         let cursor = map.cursors.get_mut("default").unwrap();
         cursor.core.pos = (4000.0, 1000.0);
+        cursor.core.placed = true;
         cursor.apply_command(OverlayCommand::SetSessionLabel("research-run".to_owned()));
 
         let tiles = render_x11_tiles(&map);
@@ -3829,6 +3830,7 @@ mod tests {
         map.scr_h = 2160;
         let cursor = map.cursors.get_mut("default").unwrap();
         cursor.core.pos = (4000.0, 1000.0);
+        cursor.core.placed = true;
         cursor.apply_command(OverlayCommand::BeginAction {
             action: CursorAction::Click,
             delivery: Some(cursor_overlay::DeliveryModifier::Foreground),

--- a/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
@@ -399,12 +399,7 @@ pub fn is_visible_for_session(key: &str) -> bool {
             guard
                 .as_ref()
                 .and_then(|map| map.cursors.get(key))
-                .map(|rs| {
-                    rs.core.cfg.enabled
-                        && rs.core.visible
-                        && rs.core.idle_alpha >= 0.004
-                        && rs.core.pos.0 >= -100.0
-                })
+                .map(|rs| rs.core.cfg.enabled && rs.core.cursor_is_revealed())
         })
         .unwrap_or(false)
 }
@@ -422,7 +417,20 @@ pub fn current_position_for(key: &str) -> (f64, f64) {
                 .and_then(|m| m.cursors.get(key))
                 .map(|rs| rs.core.pos)
         })
-        .unwrap_or((-200.0, -200.0))
+        .unwrap_or_default()
+}
+
+pub fn is_placed_for(key: &str) -> bool {
+    RENDER
+        .lock()
+        .ok()
+        .and_then(|guard| {
+            guard
+                .as_ref()
+                .and_then(|map| map.cursors.get(key))
+                .map(|state| state.core.placed)
+        })
+        .unwrap_or(false)
 }
 
 pub fn current_motion_for(key: &str) -> cursor_overlay::MotionConfig {
@@ -459,7 +467,7 @@ pub fn current_theme_state_for(
     Some((id, version, profile, fallback, state.core.visual.clone()))
 }
 
-fn seed_start_if_sentinel(key: &CursorKey, target_x: f64, target_y: f64) -> bool {
+fn seed_start_if_unplaced(key: &CursorKey, target_x: f64, target_y: f64) -> bool {
     const SEED_OFFSET: f64 = 140.0;
     let mut guard = RENDER.lock().unwrap();
     let Some(map) = guard.as_mut() else {
@@ -474,7 +482,7 @@ fn seed_start_if_sentinel(key: &CursorKey, target_x: f64, target_y: f64) -> bool
         .cursors
         .entry(key.clone())
         .or_insert_with(|| render_state_for_key(&template, &k));
-    if !(rs.core.cfg.enabled && rs.core.pos.0 < -50.0) {
+    if !(rs.core.cfg.enabled && !rs.core.placed) {
         return false;
     }
     let max_x = map.scr_w.max(2) as f64 - 2.0;
@@ -486,6 +494,7 @@ fn seed_start_if_sentinel(key: &CursorKey, target_x: f64, target_y: f64) -> bool
         sy = (target_y + SEED_OFFSET).clamp(2.0, max_y);
     }
     rs.core.pos = (sx, sy);
+    rs.core.placed = true;
     true
 }
 
@@ -497,13 +506,13 @@ pub async fn animate_cursor_to_for(key: CursorKey, x: f64, y: f64) {
     if key.is_empty() {
         return;
     }
-    seed_start_if_sentinel(&key, x, y);
+    seed_start_if_unplaced(&key, x, y);
     let should_animate = {
         let guard = RENDER.lock().unwrap();
-        match guard.as_ref().and_then(|m| m.cursors.get(&key)) {
-            Some(rs) if rs.core.cfg.enabled && rs.core.visible && rs.core.pos.0 > -50.0 => true,
-            _ => false,
-        }
+        matches!(
+            guard.as_ref().and_then(|map| map.cursors.get(&key)),
+            Some(state) if state.core.cfg.enabled && state.core.visible && state.core.placed
+        )
     };
     if !should_animate {
         return;
@@ -620,8 +629,7 @@ impl RenderState {
     }
 
     fn apply_command(&mut self, cmd: OverlayCommand) {
-        // Linux uses the non-sentinel-snap behaviour for both MoveTo and
-        // ClickPulse: every command updates `self.pos` unconditionally.
+        // Linux updates the position for every MoveTo and ClickPulse.
         // Custom-shape / gradient / focus-rect commands are not rendered on
         // Linux at present; `apply_command_base` consumes SetShape +
         // SetGradient and returns false for ShowFocusRect — both cases drop
@@ -630,7 +638,7 @@ impl RenderState {
     }
 
     /// True while the render loop must wake at frame cadence because the next
-    /// tick can change pixels. A brand-new sentinel cursor is deliberately
+    /// tick can change pixels. A brand-new unplaced cursor is deliberately
     /// quiescent, so an idle MCP server can park on bounded maintenance waits
     /// instead of rebuilding and repainting X11 cursor tiles at 60 fps.
     #[cfg(target_os = "linux")]
@@ -647,15 +655,11 @@ impl RenderState {
             // mid-swing on Linux while macOS keeps levitating. The term dies
             // with `idle_alpha` once the idle fade completes, returning the
             // parked-overlay fast path to the fully hidden cursor.
-            || (self.core.visible
-                && self.core.pos.0 >= -100.0
-                && self.core.idle_alpha >= 0.004
+            || (self.core.cursor_is_revealed()
                 && self.core.visual.reduced_motion != cursor_overlay::ReducedMotion::On)
             || (self.core.motion.idle_hide_ms > 0.0
-                && self.core.visible
-                && self.core.pos.0 >= -100.0
-                && self.core.idle_secs >= fade_start
-                && self.core.idle_alpha >= 0.004)
+                && self.core.cursor_is_revealed()
+                && self.core.idle_secs >= fade_start)
     }
 }
 
@@ -668,7 +672,7 @@ fn render_map_needs_frame_tick(map: &RenderMap) -> bool {
 fn render_map_needs_z_order_tick(map: &RenderMap) -> bool {
     map.cursors
         .values()
-        .any(|rs| rs.core.visible && rs.core.idle_alpha >= 0.004 && rs.core.pos.0 >= -100.0)
+        .any(|state| state.core.cursor_is_revealed())
 }
 
 #[cfg(target_os = "linux")]
@@ -740,8 +744,7 @@ fn render_map_idle_wait_interval(map: &RenderMap) -> Option<Duration> {
         .values()
         .filter_map(|rs| {
             let core = &rs.core;
-            if !core.visible
-                || core.pos.0 < -100.0
+            if !core.cursor_is_revealed()
                 || core.motion.idle_hide_ms <= 0.0
                 || core.path.is_some()
                 || core.spring.is_some()
@@ -2066,7 +2069,7 @@ fn cursor_tile_bounds(
     screen_width: u32,
     screen_height: u32,
 ) -> Option<X11TileBounds> {
-    if !core.visible || core.pos.0 < -100.0 || core.idle_alpha < 0.004 {
+    if !core.cursor_is_revealed() {
         return None;
     }
 

--- a/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
@@ -399,7 +399,7 @@ pub fn is_visible_for_session(key: &str) -> bool {
             guard
                 .as_ref()
                 .and_then(|map| map.cursors.get(key))
-                .map(|rs| rs.core.cfg.enabled && rs.core.cursor_is_revealed())
+                .map(|rs| rs.core.cursor_is_revealed())
         })
         .unwrap_or(false)
 }
@@ -465,7 +465,7 @@ fn seed_start_if_unplaced(key: &CursorKey, target_x: f64, target_y: f64) -> bool
         .cursors
         .entry(key.clone())
         .or_insert_with(|| render_state_for_key(&template, &k));
-    if !(rs.core.cfg.enabled && rs.core.pos.is_none()) {
+    if !(rs.core.visible && rs.core.pos.is_none()) {
         return false;
     }
     let max_x = map.scr_w.max(2) as f64 - 2.0;
@@ -492,7 +492,7 @@ pub async fn animate_cursor_to_for(key: CursorKey, x: f64, y: f64) {
     let should_animate = {
         let guard = RENDER.lock().unwrap();
         match guard.as_ref().and_then(|m| m.cursors.get(&key)) {
-            Some(rs) if rs.core.cfg.enabled && rs.core.visible && rs.core.pos.is_some() => true,
+            Some(rs) if rs.core.visible && rs.core.pos.is_some() => true,
             _ => false,
         }
     };

--- a/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
@@ -399,30 +399,21 @@ pub fn is_visible_for_session(key: &str) -> bool {
             guard
                 .as_ref()
                 .and_then(|map| map.cursors.get(key))
-                .map(|rs| {
-                    rs.core.cfg.enabled
-                        && rs.core.visible
-                        && rs.core.idle_alpha >= 0.004
-                        && rs.core.pos.0 >= -100.0
-                })
+                .map(|rs| rs.core.cfg.enabled && rs.core.cursor_is_revealed())
         })
         .unwrap_or(false)
 }
 
-pub fn current_position() -> (f64, f64) {
+pub fn current_position() -> Option<(f64, f64)> {
     current_position_for("default")
 }
 
-pub fn current_position_for(key: &str) -> (f64, f64) {
-    RENDER
-        .lock()
-        .ok()
-        .and_then(|g| {
-            g.as_ref()
-                .and_then(|m| m.cursors.get(key))
-                .map(|rs| rs.core.pos)
-        })
-        .unwrap_or((-200.0, -200.0))
+pub fn current_position_for(key: &str) -> Option<(f64, f64)> {
+    RENDER.lock().ok().and_then(|g| {
+        g.as_ref()
+            .and_then(|m| m.cursors.get(key))
+            .and_then(|rs| rs.core.pos)
+    })
 }
 
 pub fn current_motion_for(key: &str) -> cursor_overlay::MotionConfig {
@@ -459,7 +450,7 @@ pub fn current_theme_state_for(
     Some((id, version, profile, fallback, state.core.visual.clone()))
 }
 
-fn seed_start_if_sentinel(key: &CursorKey, target_x: f64, target_y: f64) -> bool {
+fn seed_start_if_unplaced(key: &CursorKey, target_x: f64, target_y: f64) -> bool {
     const SEED_OFFSET: f64 = 140.0;
     let mut guard = RENDER.lock().unwrap();
     let Some(map) = guard.as_mut() else {
@@ -474,7 +465,7 @@ fn seed_start_if_sentinel(key: &CursorKey, target_x: f64, target_y: f64) -> bool
         .cursors
         .entry(key.clone())
         .or_insert_with(|| render_state_for_key(&template, &k));
-    if !(rs.core.cfg.enabled && rs.core.pos.0 < -50.0) {
+    if !(rs.core.cfg.enabled && rs.core.pos.is_none()) {
         return false;
     }
     let max_x = map.scr_w.max(2) as f64 - 2.0;
@@ -485,7 +476,7 @@ fn seed_start_if_sentinel(key: &CursorKey, target_x: f64, target_y: f64) -> bool
         sx = (target_x + SEED_OFFSET).clamp(2.0, max_x);
         sy = (target_y + SEED_OFFSET).clamp(2.0, max_y);
     }
-    rs.core.pos = (sx, sy);
+    rs.core.pos = Some((sx, sy));
     true
 }
 
@@ -497,11 +488,11 @@ pub async fn animate_cursor_to_for(key: CursorKey, x: f64, y: f64) {
     if key.is_empty() {
         return;
     }
-    seed_start_if_sentinel(&key, x, y);
+    seed_start_if_unplaced(&key, x, y);
     let should_animate = {
         let guard = RENDER.lock().unwrap();
         match guard.as_ref().and_then(|m| m.cursors.get(&key)) {
-            Some(rs) if rs.core.cfg.enabled && rs.core.visible && rs.core.pos.0 > -50.0 => true,
+            Some(rs) if rs.core.cfg.enabled && rs.core.visible && rs.core.pos.is_some() => true,
             _ => false,
         }
     };
@@ -620,17 +611,16 @@ impl RenderState {
     }
 
     fn apply_command(&mut self, cmd: OverlayCommand) {
-        // Linux uses the non-sentinel-snap behaviour for both MoveTo and
-        // ClickPulse: every command updates `self.pos` unconditionally.
+        // Linux click pulses update the cursor position unconditionally.
         // Custom-shape / gradient / focus-rect commands are not rendered on
         // Linux at present; `apply_command_base` consumes SetShape +
         // SetGradient and returns false for ShowFocusRect — both cases drop
         // the visual update silently so callers don't see an error.
-        let _ = self.core.apply_command_base(cmd, false, false);
+        let _ = self.core.apply_command_base(cmd, true);
     }
 
     /// True while the render loop must wake at frame cadence because the next
-    /// tick can change pixels. A brand-new sentinel cursor is deliberately
+    /// tick can change pixels. A brand-new unplaced cursor is deliberately
     /// quiescent, so an idle MCP server can park on bounded maintenance waits
     /// instead of rebuilding and repainting X11 cursor tiles at 60 fps.
     #[cfg(target_os = "linux")]
@@ -647,13 +637,10 @@ impl RenderState {
             // mid-swing on Linux while macOS keeps levitating. The term dies
             // with `idle_alpha` once the idle fade completes, returning the
             // parked-overlay fast path to the fully hidden cursor.
-            || (self.core.visible
-                && self.core.pos.0 >= -100.0
-                && self.core.idle_alpha >= 0.004
+            || (self.core.cursor_is_revealed()
                 && self.core.visual.reduced_motion != cursor_overlay::ReducedMotion::On)
             || (self.core.motion.idle_hide_ms > 0.0
-                && self.core.visible
-                && self.core.pos.0 >= -100.0
+                && self.core.cursor_is_revealed()
                 && self.core.idle_secs >= fade_start
                 && self.core.idle_alpha >= 0.004)
     }
@@ -666,9 +653,7 @@ fn render_map_needs_frame_tick(map: &RenderMap) -> bool {
 
 #[cfg(target_os = "linux")]
 fn render_map_needs_z_order_tick(map: &RenderMap) -> bool {
-    map.cursors
-        .values()
-        .any(|rs| rs.core.visible && rs.core.idle_alpha >= 0.004 && rs.core.pos.0 >= -100.0)
+    map.cursors.values().any(|rs| rs.core.cursor_is_revealed())
 }
 
 #[cfg(target_os = "linux")]
@@ -740,8 +725,7 @@ fn render_map_idle_wait_interval(map: &RenderMap) -> Option<Duration> {
         .values()
         .filter_map(|rs| {
             let core = &rs.core;
-            if !core.visible
-                || core.pos.0 < -100.0
+            if !core.cursor_is_revealed()
                 || core.motion.idle_hide_ms <= 0.0
                 || core.path.is_some()
                 || core.spring.is_some()
@@ -2066,9 +2050,10 @@ fn cursor_tile_bounds(
     screen_width: u32,
     screen_height: u32,
 ) -> Option<X11TileBounds> {
-    if !core.visible || core.pos.0 < -100.0 || core.idle_alpha < 0.004 {
+    if !core.cursor_is_revealed() {
         return None;
     }
+    let (cursor_x, cursor_y) = core.pos?;
 
     let screen_width = i32::try_from(screen_width).ok()?;
     let screen_height = i32::try_from(screen_height).ok()?;
@@ -2077,10 +2062,10 @@ fn cursor_tile_bounds(
     } else {
         X11_CURSOR_TILE_MARGIN
     };
-    let left = (core.pos.0 - horizontal_margin).floor() as i32;
-    let top = (core.pos.1 - X11_CURSOR_TILE_MARGIN).floor() as i32;
-    let right = (core.pos.0 + horizontal_margin).ceil() as i32;
-    let bottom = (core.pos.1 + X11_CURSOR_TILE_MARGIN).ceil() as i32;
+    let left = (cursor_x - horizontal_margin).floor() as i32;
+    let top = (cursor_y - X11_CURSOR_TILE_MARGIN).floor() as i32;
+    let right = (cursor_x + horizontal_margin).ceil() as i32;
+    let bottom = (cursor_y + X11_CURSOR_TILE_MARGIN).ceil() as i32;
 
     let left = left.clamp(0, screen_width);
     let top = top.clamp(0, screen_height);
@@ -2843,22 +2828,19 @@ mod tests {
         fn wait_for_cursor_move_from(x: f64, y: f64, phase: &str) -> anyhow::Result<()> {
             let deadline = Instant::now() + Duration::from_secs(3);
             while Instant::now() < deadline {
-                let position = current_position();
-                if (position.0 - x).hypot(position.1 - y) > 32.0 {
-                    eprintln!(
-                        "{phase}: cursor moved from ({x}, {y}) to ({}, {})",
-                        position.0, position.1
-                    );
-                    return Ok(());
+                if let Some(position) = current_position() {
+                    if (position.0 - x).hypot(position.1 - y) > 32.0 {
+                        eprintln!(
+                            "{phase}: cursor moved from ({x}, {y}) to ({}, {})",
+                            position.0, position.1
+                        );
+                        return Ok(());
+                    }
                 }
                 std::thread::sleep(Duration::from_millis(10));
             }
             let position = current_position();
-            anyhow::bail!(
-                "cursor position remained ({}, {}) near ({x}, {y}) during {phase}",
-                position.0,
-                position.1
-            )
+            anyhow::bail!("cursor position remained {position:?} near ({x}, {y}) during {phase}")
         }
 
         let (conn, screen_num) = x11rb::connect(None)?;
@@ -3279,7 +3261,7 @@ mod tests {
     fn maintenance_tick_advances_the_full_elapsed_interval() {
         let mut map = default_render_map();
         let cursor = map.cursors.get_mut("default").unwrap();
-        cursor.core.pos = (10.0, 10.0);
+        cursor.core.pos = Some((10.0, 10.0));
         cursor.core.motion.idle_hide_ms = 500.0;
         let (_tx, rx) = std::sync::mpsc::channel();
 
@@ -3458,7 +3440,7 @@ mod tests {
         let mut map = default_render_map();
         map.scr_w = 1920;
         map.scr_h = 2160;
-        map.cursors.get_mut("default").unwrap().core.pos = (100.0, 2000.0);
+        map.cursors.get_mut("default").unwrap().core.pos = Some((100.0, 2000.0));
         assert_eq!(render_x11_tiles(&map).len(), 1);
 
         update_render_map_geometry(&mut map, 1920, 1080);
@@ -3466,7 +3448,7 @@ mod tests {
     }
 
     #[test]
-    fn sentinel_default_cursor_does_not_require_frame_ticks() {
+    fn unplaced_default_cursor_does_not_require_frame_ticks() {
         let map = default_render_map();
         assert!(!render_map_needs_frame_tick(&map));
         assert!(!render_map_needs_z_order_tick(&map));
@@ -3479,7 +3461,7 @@ mod tests {
     fn resting_visible_cursor_only_requires_cheap_z_order_ticks() {
         let mut map = default_render_map();
         let cursor = map.cursors.get_mut("default").unwrap();
-        cursor.core.pos = (100.0, 100.0);
+        cursor.core.pos = Some((100.0, 100.0));
         cursor.core.motion.idle_hide_ms = 0.0;
         cursor.core.visual.reduced_motion = cursor_overlay::ReducedMotion::On;
 
@@ -3491,7 +3473,7 @@ mod tests {
     fn resting_visible_cursor_keeps_ticking_for_the_float_bob() {
         let mut map = default_render_map();
         let cursor = map.cursors.get_mut("default").unwrap();
-        cursor.core.pos = (100.0, 100.0);
+        cursor.core.pos = Some((100.0, 100.0));
         cursor.core.motion.idle_hide_ms = 0.0;
 
         // Default reduced_motion (auto) floats, so frames keep flowing while
@@ -3508,7 +3490,7 @@ mod tests {
     fn disabling_settled_cursor_clears_once_then_parks() {
         let mut map = default_render_map();
         let cursor = map.cursors.get_mut("default").unwrap();
-        cursor.core.pos = (100.0, 100.0);
+        cursor.core.pos = Some((100.0, 100.0));
         cursor.core.motion.idle_hide_ms = 0.0;
         cursor.core.visual.reduced_motion = cursor_overlay::ReducedMotion::On;
         let (_tx, rx) = std::sync::mpsc::channel();
@@ -3555,7 +3537,7 @@ mod tests {
         let cursor = map.cursors.get_mut("default").unwrap();
         // The public animate path seeds a newly created cursor near its target
         // before sending MoveTo; mirror that valid on-screen starting state.
-        cursor.core.pos = (100.0, 100.0);
+        cursor.core.pos = Some((100.0, 100.0));
         cursor.core.motion.idle_hide_ms = 500.0;
         cursor.core.visual.reduced_motion = cursor_overlay::ReducedMotion::On;
         cursor.apply_command(OverlayCommand::MoveTo {
@@ -3591,7 +3573,7 @@ mod tests {
         let mut map = default_render_map();
         {
             let cursor = map.cursors.get_mut("default").unwrap();
-            cursor.core.pos = (10.0, 10.0);
+            cursor.core.pos = Some((10.0, 10.0));
             cursor.core.motion.idle_hide_ms = 500.0;
         }
         let other = render_state_for_key(&map.template, "other");
@@ -3631,11 +3613,11 @@ mod tests {
         let mut map = default_render_map();
         {
             let cursor = map.cursors.get_mut("default").unwrap();
-            cursor.core.pos = (10.0, 10.0);
+            cursor.core.pos = Some((10.0, 10.0));
             cursor.core.motion.idle_hide_ms = 500.0;
         }
         let mut other = render_state_for_key(&map.template, "other");
-        other.core.pos = (20.0, 20.0);
+        other.core.pos = Some((20.0, 20.0));
         map.cursors.insert("other".to_owned(), other);
 
         // Model a command arriving after recv_timeout returned Timeout but
@@ -3658,7 +3640,7 @@ mod tests {
         assert_eq!(map.cursors["default"].core.idle_secs, 0.08);
         let other = &map.cursors["other"].core;
         assert!(other.path.is_some());
-        assert_eq!(other.pos, (20.0, 20.0));
+        assert_eq!(other.pos, Some((20.0, 20.0)));
         assert_eq!(other.dist, 0.0);
     }
 
@@ -3666,7 +3648,7 @@ mod tests {
     fn click_pulse_drained_after_maintenance_timeout_starts_at_zero_dt() {
         let mut map = default_render_map();
         let cursor = map.cursors.get_mut("default").unwrap();
-        cursor.core.pos = (20.0, 20.0);
+        cursor.core.pos = Some((20.0, 20.0));
 
         let (tx, rx) = std::sync::mpsc::channel();
         tx.send(OverlayMsg::Cmd(KeyedOverlayCommand {
@@ -3680,7 +3662,7 @@ mod tests {
         assert!(arrived.is_empty());
         assert!(had_msg);
         let cursor = &map.cursors["default"].core;
-        assert_eq!(cursor.pos, (40.0, 50.0));
+        assert_eq!(cursor.pos, Some((40.0, 50.0)));
         assert_eq!(cursor.click_t, Some(0.0));
     }
 
@@ -3689,7 +3671,7 @@ mod tests {
         let mut map = default_render_map();
         {
             let cursor = map.cursors.get_mut("default").unwrap();
-            cursor.core.pos = (20.0, 20.0);
+            cursor.core.pos = Some((20.0, 20.0));
             cursor.apply_command(OverlayCommand::MoveTo {
                 x: 80.0,
                 y: 80.0,
@@ -3727,7 +3709,7 @@ mod tests {
         let mut map = default_render_map();
         {
             let cursor = map.cursors.get_mut("default").unwrap();
-            cursor.core.pos = (100.0, 100.0);
+            cursor.core.pos = Some((100.0, 100.0));
             cursor.core.motion.idle_hide_ms = 500.0;
             cursor.core.visual.reduced_motion = cursor_overlay::ReducedMotion::On;
 
@@ -3793,7 +3775,7 @@ mod tests {
         map.scr_w = 7680;
         map.scr_h = 2160;
         let cursor = map.cursors.get_mut("default").unwrap();
-        cursor.core.pos = (4000.0, 1000.0);
+        cursor.core.pos = Some((4000.0, 1000.0));
 
         let tiles = render_x11_tiles(&map);
 
@@ -3811,7 +3793,7 @@ mod tests {
         map.scr_w = 7680;
         map.scr_h = 2160;
         let cursor = map.cursors.get_mut("default").unwrap();
-        cursor.core.pos = (4000.0, 1000.0);
+        cursor.core.pos = Some((4000.0, 1000.0));
         cursor.apply_command(OverlayCommand::SetSessionLabel("research-run".to_owned()));
 
         let tiles = render_x11_tiles(&map);
@@ -3828,7 +3810,7 @@ mod tests {
         map.scr_w = 7680;
         map.scr_h = 2160;
         let cursor = map.cursors.get_mut("default").unwrap();
-        cursor.core.pos = (4000.0, 1000.0);
+        cursor.core.pos = Some((4000.0, 1000.0));
         cursor.apply_command(OverlayCommand::BeginAction {
             action: CursorAction::Click,
             delivery: Some(cursor_overlay::DeliveryModifier::Foreground),
@@ -3848,7 +3830,7 @@ mod tests {
         map.scr_w = 1920;
         map.scr_h = 1080;
         let cursor = map.cursors.get_mut("default").unwrap();
-        cursor.core.pos = (10.0, 12.0);
+        cursor.core.pos = Some((10.0, 12.0));
 
         let tiles = render_x11_tiles(&map);
         assert_eq!(tiles.len(), 1);
@@ -3871,9 +3853,9 @@ mod tests {
         let mut map = default_render_map();
         map.scr_w = 7680;
         map.scr_h = 2160;
-        map.cursors.get_mut("default").unwrap().core.pos = (100.0, 100.0);
+        map.cursors.get_mut("default").unwrap().core.pos = Some((100.0, 100.0));
         let mut other = render_state_for_key(&map.template, "other");
-        other.core.pos = (7400.0, 1800.0);
+        other.core.pos = Some((7400.0, 1800.0));
         map.cursors.insert("other".to_owned(), other);
 
         let tiles = render_x11_tiles(&map);

--- a/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
@@ -3461,7 +3461,9 @@ mod tests {
         let mut map = default_render_map();
         map.scr_w = 1920;
         map.scr_h = 2160;
-        map.cursors.get_mut("default").unwrap().core.pos = (100.0, 2000.0);
+        let cursor = &mut map.cursors.get_mut("default").unwrap().core;
+        cursor.pos = (100.0, 2000.0);
+        cursor.placed = true;
         assert_eq!(render_x11_tiles(&map).len(), 1);
 
         update_render_map_geometry(&mut map, 1920, 1080);
@@ -3483,6 +3485,7 @@ mod tests {
         let mut map = default_render_map();
         let cursor = map.cursors.get_mut("default").unwrap();
         cursor.core.pos = (100.0, 100.0);
+        cursor.core.placed = true;
         cursor.core.motion.idle_hide_ms = 0.0;
         cursor.core.visual.reduced_motion = cursor_overlay::ReducedMotion::On;
 
@@ -3495,6 +3498,7 @@ mod tests {
         let mut map = default_render_map();
         let cursor = map.cursors.get_mut("default").unwrap();
         cursor.core.pos = (100.0, 100.0);
+        cursor.core.placed = true;
         cursor.core.motion.idle_hide_ms = 0.0;
 
         // Default reduced_motion (auto) floats, so frames keep flowing while
@@ -3512,6 +3516,7 @@ mod tests {
         let mut map = default_render_map();
         let cursor = map.cursors.get_mut("default").unwrap();
         cursor.core.pos = (100.0, 100.0);
+        cursor.core.placed = true;
         cursor.core.motion.idle_hide_ms = 0.0;
         cursor.core.visual.reduced_motion = cursor_overlay::ReducedMotion::On;
         let (_tx, rx) = std::sync::mpsc::channel();
@@ -3595,6 +3600,7 @@ mod tests {
         {
             let cursor = map.cursors.get_mut("default").unwrap();
             cursor.core.pos = (10.0, 10.0);
+            cursor.core.placed = true;
             cursor.core.motion.idle_hide_ms = 500.0;
         }
         let other = render_state_for_key(&map.template, "other");
@@ -3731,6 +3737,7 @@ mod tests {
         {
             let cursor = map.cursors.get_mut("default").unwrap();
             cursor.core.pos = (100.0, 100.0);
+            cursor.core.placed = true;
             cursor.core.motion.idle_hide_ms = 500.0;
             cursor.core.visual.reduced_motion = cursor_overlay::ReducedMotion::On;
 
@@ -3797,6 +3804,7 @@ mod tests {
         map.scr_h = 2160;
         let cursor = map.cursors.get_mut("default").unwrap();
         cursor.core.pos = (4000.0, 1000.0);
+        cursor.core.placed = true;
 
         let tiles = render_x11_tiles(&map);
 
@@ -3854,6 +3862,7 @@ mod tests {
         map.scr_h = 1080;
         let cursor = map.cursors.get_mut("default").unwrap();
         cursor.core.pos = (10.0, 12.0);
+        cursor.core.placed = true;
 
         let tiles = render_x11_tiles(&map);
         assert_eq!(tiles.len(), 1);
@@ -3876,9 +3885,12 @@ mod tests {
         let mut map = default_render_map();
         map.scr_w = 7680;
         map.scr_h = 2160;
-        map.cursors.get_mut("default").unwrap().core.pos = (100.0, 100.0);
+        let cursor = &mut map.cursors.get_mut("default").unwrap().core;
+        cursor.pos = (100.0, 100.0);
+        cursor.placed = true;
         let mut other = render_state_for_key(&map.template, "other");
         other.core.pos = (7400.0, 1800.0);
+        other.core.placed = true;
         map.cursors.insert("other".to_owned(), other);
 
         let tiles = render_x11_tiles(&map);

--- a/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
@@ -399,7 +399,7 @@ pub fn is_visible_for_session(key: &str) -> bool {
             guard
                 .as_ref()
                 .and_then(|map| map.cursors.get(key))
-                .map(|rs| rs.core.cursor_is_revealed())
+                .map(|rs| rs.core.cfg.enabled && rs.core.cursor_is_revealed())
         })
         .unwrap_or(false)
 }
@@ -465,7 +465,7 @@ fn seed_start_if_unplaced(key: &CursorKey, target_x: f64, target_y: f64) -> bool
         .cursors
         .entry(key.clone())
         .or_insert_with(|| render_state_for_key(&template, &k));
-    if !(rs.core.visible && rs.core.pos.is_none()) {
+    if !(rs.core.cfg.enabled && rs.core.pos.is_none()) {
         return false;
     }
     let max_x = map.scr_w.max(2) as f64 - 2.0;
@@ -492,7 +492,7 @@ pub async fn animate_cursor_to_for(key: CursorKey, x: f64, y: f64) {
     let should_animate = {
         let guard = RENDER.lock().unwrap();
         match guard.as_ref().and_then(|m| m.cursors.get(&key)) {
-            Some(rs) if rs.core.visible && rs.core.pos.is_some() => true,
+            Some(rs) if rs.core.cfg.enabled && rs.core.visible && rs.core.pos.is_some() => true,
             _ => false,
         }
     };

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -2055,8 +2055,7 @@ async fn overlay_glide_to_for(cursor_id: &str, sx: f64, sy: f64) {
     if crate::wayland::is_wayland() {
         crate::wayland::shell_helper::move_cursor(sx as i32, sy as i32);
     }
-    let pos = crate::overlay::current_position_for(cursor_id);
-    if pos.0 < 0.0 && pos.1 < 0.0 {
+    if !crate::overlay::is_placed_for(cursor_id) {
         crate::overlay::send_command_for(
             cursor_id.to_owned(),
             cursor_overlay::OverlayCommand::ClickPulse { x: sx, y: sy },

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -2056,7 +2056,7 @@ async fn overlay_glide_to_for(cursor_id: &str, sx: f64, sy: f64) {
         crate::wayland::shell_helper::move_cursor(sx as i32, sy as i32);
     }
     let pos = crate::overlay::current_position_for(cursor_id);
-    if pos.0 < 0.0 && pos.1 < 0.0 {
+    if pos.is_none() {
         crate::overlay::send_command_for(
             cursor_id.to_owned(),
             cursor_overlay::OverlayCommand::ClickPulse { x: sx, y: sy },

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -2056,7 +2056,7 @@ async fn overlay_glide_to_for(cursor_id: &str, sx: f64, sy: f64) {
         crate::wayland::shell_helper::move_cursor(sx as i32, sy as i32);
     }
     let pos = crate::overlay::current_position_for(cursor_id);
-    if pos.is_none() {
+    if pos.0 < 0.0 && pos.1 < 0.0 {
         crate::overlay::send_command_for(
             cursor_id.to_owned(),
             cursor_overlay::OverlayCommand::ClickPulse { x: sx, y: sy },

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
@@ -314,8 +314,13 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
                     break;
                 }
                 Ok(WlOverlayCmd::Cmd { cmd }) => {
-                    // Seed an unplaced cursor near the target so its first
-                    // spring animation starts on-screen, matching X11.
+                    // Seed: if the cursor is still at the off-screen sentinel
+                    // `(-200, -200)` from `RenderStateCore::new`, snap to a
+                    // point near the MoveTo / SnapTo target so the spring
+                    // animation starts on-screen. Mirrors X11 overlay.rs's
+                    // `seed_start_if_sentinel` helper — without it, the
+                    // spring oscillates around the sentinel and the cursor
+                    // never reaches the screen.
                     let seed_target = match &cmd {
                         OverlayCommand::MoveTo { x, y, .. }
                         | OverlayCommand::SnapTo { x, y, .. }
@@ -323,16 +328,18 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
                         _ => None,
                     };
                     if let Some((tx, ty)) = seed_target {
-                        if state.core.pos.is_none() {
+                        if state.core.pos.0 < -50.0 {
                             const SEED_OFFSET: f64 = 16.0;
                             let sx = (tx - SEED_OFFSET).max(2.0);
                             let sy = (ty - SEED_OFFSET).max(2.0);
-                            state.core.pos = Some((sx, sy));
+                            state.core.pos = (sx, sy);
                         }
                     }
-                    // apply_command_base consumes every variant X11 handles.
+                    // apply_command_base consumes every variant the X11
+                    // path handles. `move_to_snap_sentinel` / `click_pulse
+                    // _sentinel_only` are both `false` here — same as X11.
                     let disabling = matches!(&cmd, OverlayCommand::SetEnabled(false));
-                    dirty |= state.core.apply_command_base(cmd, true);
+                    dirty |= state.core.apply_command_base(cmd, false, false);
                     if disabling {
                         quiesce_hidden(&mut state.core);
                     }
@@ -341,7 +348,7 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
                     // Single-cursor overlay: removing the active cursor
                     // hides it. Multi-cursor wlroots support can layer on
                     // top of this in a follow-up if needed.
-                    dirty |= state.core.visible || state.core.pos.is_some();
+                    dirty |= state.core.visible || state.core.pos.0 >= -100.0;
                     state.core.visible = false;
                     quiesce_hidden(&mut state.core);
                 }
@@ -431,7 +438,7 @@ fn next_wait(core: &RenderStateCore, frame_tick_needed: bool) -> WlWait {
 }
 
 fn needs_frame_tick(core: &RenderStateCore) -> bool {
-    if !core.cursor_is_revealed() {
+    if !core.visible || core.pos.0 < -100.0 {
         return false;
     }
     let fade_start = core.motion.idle_hide_ms / 1000.0;
@@ -446,7 +453,7 @@ fn needs_frame_tick(core: &RenderStateCore) -> bool {
 
 fn idle_fade_wait(core: &RenderStateCore) -> Option<Duration> {
     if !core.visible
-        || core.pos.is_none()
+        || core.pos.0 < -100.0
         || core.motion.idle_hide_ms <= 0.0
         || core.path.is_some()
         || core.spring.is_some()
@@ -479,7 +486,7 @@ fn quiesce_hidden(core: &mut RenderStateCore) {
 /// 4. Attach + damage + commit on the layer surface.
 ///
 /// When the cursor is hidden (`core.visible == false`, idle-faded, or
-/// unplaced) the pixmap is all zeros — the surface remains
+/// off-screen sentinel) the pixmap is all zeros — the surface remains
 /// transparent and click-through.
 fn redraw(
     state: &mut OverlayState,
@@ -528,7 +535,8 @@ fn redraw(
     // layer-shell visibility on a new compositor — the gradient arrow is
     // small at native scale and easy to miss in a screenshot, while the
     // magenta block is impossible to miss.
-    if let (Some((cx, cy)), Some(_)) = (state.core.pos, std::env::var_os("CUA_OVERLAY_DEBUG")) {
+    if std::env::var_os("CUA_OVERLAY_DEBUG").is_some() {
+        let (cx, cy) = state.core.pos;
         let cx = cx as i32;
         let cy = cy as i32;
         let half = 30i32;
@@ -580,8 +588,8 @@ fn redraw(
     state.pending_buffers.insert(buffer_id, (ptr, size, fd));
 
     dbg(&format!(
-        "redraw w={w} h={h} stride={stride} buf_id={buffer_id} pos={:?} visible={}",
-        state.core.pos, state.core.visible
+        "redraw w={w} h={h} stride={stride} buf_id={buffer_id} pos=({:.1},{:.1}) visible={}",
+        state.core.pos.0, state.core.pos.1, state.core.visible
     ));
     surface.attach(Some(&buffer), 0, 0);
     surface.damage_buffer(0, 0, w as i32, h as i32);
@@ -785,13 +793,13 @@ mod tests {
 
     fn positioned_core() -> RenderStateCore {
         let mut core = RenderStateCore::new(CursorConfig::default());
-        core.pos = Some((100.0, 100.0));
+        core.pos = (100.0, 100.0);
         core.motion.idle_hide_ms = 1_000.0;
         core
     }
 
     #[test]
-    fn fresh_unplaced_overlay_blocks_without_frame_polling() {
+    fn fresh_sentinel_overlay_blocks_without_frame_polling() {
         let core = RenderStateCore::new(CursorConfig::default());
         assert_eq!(next_wait(&core, false), WlWait::Block);
         assert!(!needs_frame_tick(&core));

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
@@ -314,13 +314,8 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
                     break;
                 }
                 Ok(WlOverlayCmd::Cmd { cmd }) => {
-                    // Seed: if the cursor is still at the off-screen sentinel
-                    // `(-200, -200)` from `RenderStateCore::new`, snap to a
-                    // point near the MoveTo / SnapTo target so the spring
-                    // animation starts on-screen. Mirrors X11 overlay.rs's
-                    // `seed_start_if_sentinel` helper — without it, the
-                    // spring oscillates around the sentinel and the cursor
-                    // never reaches the screen.
+                    // Give an unplaced cursor an on-screen start point near the
+                    // target so its first spring animation is visible.
                     let seed_target = match &cmd {
                         OverlayCommand::MoveTo { x, y, .. }
                         | OverlayCommand::SnapTo { x, y, .. }
@@ -328,16 +323,15 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
                         _ => None,
                     };
                     if let Some((tx, ty)) = seed_target {
-                        if state.core.pos.0 < -50.0 {
+                        if !state.core.placed {
                             const SEED_OFFSET: f64 = 16.0;
                             let sx = (tx - SEED_OFFSET).max(2.0);
                             let sy = (ty - SEED_OFFSET).max(2.0);
                             state.core.pos = (sx, sy);
+                            state.core.placed = true;
                         }
                     }
-                    // apply_command_base consumes every variant the X11
-                    // path handles. `move_to_snap_sentinel` / `click_pulse
-                    // _sentinel_only` are both `false` here — same as X11.
+                    // Apply the command with the same placement behavior as X11.
                     let disabling = matches!(&cmd, OverlayCommand::SetEnabled(false));
                     dirty |= state.core.apply_command_base(cmd, false, false);
                     if disabling {
@@ -348,7 +342,7 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
                     // Single-cursor overlay: removing the active cursor
                     // hides it. Multi-cursor wlroots support can layer on
                     // top of this in a follow-up if needed.
-                    dirty |= state.core.visible || state.core.pos.0 >= -100.0;
+                    dirty |= state.core.cursor_is_revealed();
                     state.core.visible = false;
                     quiesce_hidden(&mut state.core);
                 }
@@ -438,7 +432,7 @@ fn next_wait(core: &RenderStateCore, frame_tick_needed: bool) -> WlWait {
 }
 
 fn needs_frame_tick(core: &RenderStateCore) -> bool {
-    if !core.visible || core.pos.0 < -100.0 {
+    if !core.visible || !core.placed {
         return false;
     }
     let fade_start = core.motion.idle_hide_ms / 1000.0;
@@ -453,7 +447,7 @@ fn needs_frame_tick(core: &RenderStateCore) -> bool {
 
 fn idle_fade_wait(core: &RenderStateCore) -> Option<Duration> {
     if !core.visible
-        || core.pos.0 < -100.0
+        || !core.placed
         || core.motion.idle_hide_ms <= 0.0
         || core.path.is_some()
         || core.spring.is_some()
@@ -485,8 +479,8 @@ fn quiesce_hidden(core: &mut RenderStateCore) {
 ///    in `ext_screencopy::encode_buffer_to_png`.
 /// 4. Attach + damage + commit on the layer surface.
 ///
-/// When the cursor is hidden (`core.visible == false`, idle-faded, or
-/// off-screen sentinel) the pixmap is all zeros — the surface remains
+/// When the cursor is hidden, unplaced, or idle-faded, the pixmap is all
+/// zeros — the surface remains
 /// transparent and click-through.
 fn redraw(
     state: &mut OverlayState,

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
@@ -788,6 +788,7 @@ mod tests {
     fn positioned_core() -> RenderStateCore {
         let mut core = RenderStateCore::new(CursorConfig::default());
         core.pos = (100.0, 100.0);
+        core.placed = true;
         core.motion.idle_hide_ms = 1_000.0;
         core
     }

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
@@ -314,13 +314,8 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
                     break;
                 }
                 Ok(WlOverlayCmd::Cmd { cmd }) => {
-                    // Seed: if the cursor is still at the off-screen sentinel
-                    // `(-200, -200)` from `RenderStateCore::new`, snap to a
-                    // point near the MoveTo / SnapTo target so the spring
-                    // animation starts on-screen. Mirrors X11 overlay.rs's
-                    // `seed_start_if_sentinel` helper — without it, the
-                    // spring oscillates around the sentinel and the cursor
-                    // never reaches the screen.
+                    // Seed an unplaced cursor near the target so its first
+                    // spring animation starts on-screen, matching X11.
                     let seed_target = match &cmd {
                         OverlayCommand::MoveTo { x, y, .. }
                         | OverlayCommand::SnapTo { x, y, .. }
@@ -328,18 +323,16 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
                         _ => None,
                     };
                     if let Some((tx, ty)) = seed_target {
-                        if state.core.pos.0 < -50.0 {
+                        if state.core.pos.is_none() {
                             const SEED_OFFSET: f64 = 16.0;
                             let sx = (tx - SEED_OFFSET).max(2.0);
                             let sy = (ty - SEED_OFFSET).max(2.0);
-                            state.core.pos = (sx, sy);
+                            state.core.pos = Some((sx, sy));
                         }
                     }
-                    // apply_command_base consumes every variant the X11
-                    // path handles. `move_to_snap_sentinel` / `click_pulse
-                    // _sentinel_only` are both `false` here — same as X11.
+                    // apply_command_base consumes every variant X11 handles.
                     let disabling = matches!(&cmd, OverlayCommand::SetEnabled(false));
-                    dirty |= state.core.apply_command_base(cmd, false, false);
+                    dirty |= state.core.apply_command_base(cmd, true);
                     if disabling {
                         quiesce_hidden(&mut state.core);
                     }
@@ -348,7 +341,7 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
                     // Single-cursor overlay: removing the active cursor
                     // hides it. Multi-cursor wlroots support can layer on
                     // top of this in a follow-up if needed.
-                    dirty |= state.core.visible || state.core.pos.0 >= -100.0;
+                    dirty |= state.core.visible || state.core.pos.is_some();
                     state.core.visible = false;
                     quiesce_hidden(&mut state.core);
                 }
@@ -438,7 +431,7 @@ fn next_wait(core: &RenderStateCore, frame_tick_needed: bool) -> WlWait {
 }
 
 fn needs_frame_tick(core: &RenderStateCore) -> bool {
-    if !core.visible || core.pos.0 < -100.0 {
+    if !core.cursor_is_revealed() {
         return false;
     }
     let fade_start = core.motion.idle_hide_ms / 1000.0;
@@ -453,7 +446,7 @@ fn needs_frame_tick(core: &RenderStateCore) -> bool {
 
 fn idle_fade_wait(core: &RenderStateCore) -> Option<Duration> {
     if !core.visible
-        || core.pos.0 < -100.0
+        || core.pos.is_none()
         || core.motion.idle_hide_ms <= 0.0
         || core.path.is_some()
         || core.spring.is_some()
@@ -486,7 +479,7 @@ fn quiesce_hidden(core: &mut RenderStateCore) {
 /// 4. Attach + damage + commit on the layer surface.
 ///
 /// When the cursor is hidden (`core.visible == false`, idle-faded, or
-/// off-screen sentinel) the pixmap is all zeros — the surface remains
+/// unplaced) the pixmap is all zeros — the surface remains
 /// transparent and click-through.
 fn redraw(
     state: &mut OverlayState,
@@ -535,8 +528,7 @@ fn redraw(
     // layer-shell visibility on a new compositor — the gradient arrow is
     // small at native scale and easy to miss in a screenshot, while the
     // magenta block is impossible to miss.
-    if std::env::var_os("CUA_OVERLAY_DEBUG").is_some() {
-        let (cx, cy) = state.core.pos;
+    if let (Some((cx, cy)), Some(_)) = (state.core.pos, std::env::var_os("CUA_OVERLAY_DEBUG")) {
         let cx = cx as i32;
         let cy = cy as i32;
         let half = 30i32;
@@ -588,8 +580,8 @@ fn redraw(
     state.pending_buffers.insert(buffer_id, (ptr, size, fd));
 
     dbg(&format!(
-        "redraw w={w} h={h} stride={stride} buf_id={buffer_id} pos=({:.1},{:.1}) visible={}",
-        state.core.pos.0, state.core.pos.1, state.core.visible
+        "redraw w={w} h={h} stride={stride} buf_id={buffer_id} pos={:?} visible={}",
+        state.core.pos, state.core.visible
     ));
     surface.attach(Some(&buffer), 0, 0);
     surface.damage_buffer(0, 0, w as i32, h as i32);
@@ -793,13 +785,13 @@ mod tests {
 
     fn positioned_core() -> RenderStateCore {
         let mut core = RenderStateCore::new(CursorConfig::default());
-        core.pos = (100.0, 100.0);
+        core.pos = Some((100.0, 100.0));
         core.motion.idle_hide_ms = 1_000.0;
         core
     }
 
     #[test]
-    fn fresh_sentinel_overlay_blocks_without_frame_polling() {
+    fn fresh_unplaced_overlay_blocks_without_frame_polling() {
         let core = RenderStateCore::new(CursorConfig::default());
         assert_eq!(next_wait(&core, false), WlWait::Block);
         assert!(!needs_frame_tick(&core));

--- a/libs/cua-driver/rust/crates/platform-macos/src/cursor/display_layout.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/cursor/display_layout.rs
@@ -1,0 +1,244 @@
+//! Pure macOS display geometry for agent-cursor presentation.
+//!
+//! Cua cursor coordinates use CoreGraphics' global top-left coordinate space.
+//! AppKit window frames use a bottom-left origin. Keeping both frames here
+//! prevents either convention from leaking into cursor state or rendering.
+
+use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+pub(crate) type DisplayId = u32;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct GlobalPoint {
+    pub x: f64,
+    pub y: f64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct DisplayGeometry {
+    pub id: DisplayId,
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+    pub backing_scale: f64,
+    pub is_primary: bool,
+}
+
+impl DisplayGeometry {
+    pub(crate) fn contains(self, point: GlobalPoint) -> bool {
+        point.x >= self.x
+            && point.x < self.x + self.width
+            && point.y >= self.y
+            && point.y < self.y + self.height
+    }
+
+    pub(crate) fn local_point(self, point: GlobalPoint) -> GlobalPoint {
+        GlobalPoint {
+            x: point.x - self.x,
+            y: point.y - self.y,
+        }
+    }
+
+    pub(crate) fn pixel_size(self) -> (u32, u32) {
+        let scale = self.backing_scale.max(1.0);
+        (
+            (self.width * scale).round().max(1.0) as u32,
+            (self.height * scale).round().max(1.0) as u32,
+        )
+    }
+
+    /// Convert the CoreGraphics top-left frame into AppKit's bottom-left frame.
+    pub(crate) fn appkit_frame(self, primary_height: f64) -> NSRect {
+        NSRect::new(
+            NSPoint::new(self.x, primary_height - self.y - self.height),
+            NSSize::new(self.width, self.height),
+        )
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(crate) struct DisplayLayout {
+    pub generation: u64,
+    pub displays: Vec<DisplayGeometry>,
+}
+
+impl DisplayLayout {
+    pub(crate) fn route(&self, point: GlobalPoint) -> Option<(DisplayId, GlobalPoint)> {
+        self.displays
+            .iter()
+            .find(|display| display.contains(point))
+            .map(|display| (display.id, display.local_point(point)))
+    }
+
+    pub(crate) fn display(&self, id: DisplayId) -> Option<DisplayGeometry> {
+        self.displays
+            .iter()
+            .copied()
+            .find(|display| display.id == id)
+    }
+
+    pub(crate) fn display_for_or_primary(&self, point: GlobalPoint) -> Option<DisplayGeometry> {
+        self.displays
+            .iter()
+            .copied()
+            .find(|display| display.contains(point))
+            .or_else(|| {
+                self.displays
+                    .iter()
+                    .copied()
+                    .find(|display| display.is_primary)
+            })
+            .or_else(|| self.displays.first().copied())
+    }
+
+    pub(crate) fn primary_height(&self) -> Option<f64> {
+        self.displays
+            .iter()
+            .find(|display| display.is_primary)
+            .or_else(|| self.displays.first())
+            .map(|display| display.height)
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn active_layout(generation: u64) -> Result<DisplayLayout, i32> {
+    use core_graphics::display::CGDisplay;
+
+    let primary_id = CGDisplay::main().id;
+    let mut displays = CGDisplay::active_displays()?
+        .into_iter()
+        .filter_map(|id| {
+            let display = CGDisplay::new(id);
+            // A mirrored destination shares its source's coordinate space and
+            // already receives that source window through system mirroring.
+            if display.mirrors_display() != 0 {
+                return None;
+            }
+            let bounds = display.bounds();
+            let width = bounds.size.width;
+            let height = bounds.size.height;
+            if !width.is_finite() || !height.is_finite() || width <= 0.0 || height <= 0.0 {
+                return None;
+            }
+            let scale = crate::tools::get_screen_size::get_backing_scale(id);
+            Some(DisplayGeometry {
+                id,
+                x: bounds.origin.x,
+                y: bounds.origin.y,
+                width,
+                height,
+                backing_scale: if scale.is_finite() && scale > 0.0 {
+                    scale
+                } else {
+                    1.0
+                },
+                is_primary: id == primary_id,
+            })
+        })
+        .collect::<Vec<_>>();
+    displays.sort_by_key(|display| (!display.is_primary, display.id));
+    Ok(DisplayLayout {
+        generation,
+        displays,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn layout() -> DisplayLayout {
+        DisplayLayout {
+            generation: 7,
+            displays: vec![
+                DisplayGeometry {
+                    id: 1,
+                    x: 0.0,
+                    y: 0.0,
+                    width: 1440.0,
+                    height: 900.0,
+                    backing_scale: 2.0,
+                    is_primary: true,
+                },
+                DisplayGeometry {
+                    id: 2,
+                    x: -1920.0,
+                    y: -180.0,
+                    width: 1920.0,
+                    height: 1080.0,
+                    backing_scale: 1.0,
+                    is_primary: false,
+                },
+                DisplayGeometry {
+                    id: 3,
+                    x: 0.0,
+                    y: -1200.0,
+                    width: 1200.0,
+                    height: 1200.0,
+                    backing_scale: 1.5,
+                    is_primary: false,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn routes_negative_axes_into_display_local_points() {
+        let layout = layout();
+        assert_eq!(
+            layout.route(GlobalPoint {
+                x: -867.0,
+                y: 400.0
+            }),
+            Some((
+                2,
+                GlobalPoint {
+                    x: 1053.0,
+                    y: 580.0
+                }
+            ))
+        );
+        assert_eq!(
+            layout.route(GlobalPoint {
+                x: 300.0,
+                y: -867.0
+            }),
+            Some((3, GlobalPoint { x: 300.0, y: 333.0 }))
+        );
+    }
+
+    #[test]
+    fn seams_are_half_open_and_owned_once() {
+        let layout = layout();
+        assert_eq!(
+            layout
+                .route(GlobalPoint {
+                    x: -0.001,
+                    y: 100.0
+                })
+                .unwrap()
+                .0,
+            2
+        );
+        assert_eq!(layout.route(GlobalPoint { x: 0.0, y: 100.0 }).unwrap().0, 1);
+    }
+
+    #[test]
+    fn each_display_keeps_its_own_pixel_scale() {
+        let layout = layout();
+        assert_eq!(layout.display(1).unwrap().pixel_size(), (2880, 1800));
+        assert_eq!(layout.display(2).unwrap().pixel_size(), (1920, 1080));
+        assert_eq!(layout.display(3).unwrap().pixel_size(), (1800, 1800));
+    }
+
+    #[test]
+    fn appkit_frame_flips_global_y_around_the_primary_display() {
+        let display = layout().display(3).unwrap();
+        let frame = display.appkit_frame(900.0);
+        assert_eq!(frame.origin.x, 0.0);
+        assert_eq!(frame.origin.y, 900.0);
+        assert_eq!(frame.size.width, 1200.0);
+        assert_eq!(frame.size.height, 1200.0);
+    }
+}

--- a/libs/cua-driver/rust/crates/platform-macos/src/cursor/display_layout.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/cursor/display_layout.rs
@@ -71,6 +71,7 @@ impl DisplayLayout {
             .map(|display| (display.id, display.local_point(point)))
     }
 
+    #[cfg(test)]
     pub(crate) fn display(&self, id: DisplayId) -> Option<DisplayGeometry> {
         self.displays
             .iter()

--- a/libs/cua-driver/rust/crates/platform-macos/src/cursor/display_layout.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/cursor/display_layout.rs
@@ -9,12 +9,6 @@ use objc2_foundation::{NSPoint, NSRect, NSSize};
 pub(crate) type DisplayId = u32;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub(crate) struct GlobalPoint {
-    pub x: f64,
-    pub y: f64,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct DisplayGeometry {
     pub id: DisplayId,
     pub x: f64,
@@ -26,18 +20,8 @@ pub(crate) struct DisplayGeometry {
 }
 
 impl DisplayGeometry {
-    pub(crate) fn contains(self, point: GlobalPoint) -> bool {
-        point.x >= self.x
-            && point.x < self.x + self.width
-            && point.y >= self.y
-            && point.y < self.y + self.height
-    }
-
-    pub(crate) fn local_point(self, point: GlobalPoint) -> GlobalPoint {
-        GlobalPoint {
-            x: point.x - self.x,
-            y: point.y - self.y,
-        }
+    pub(crate) fn contains(self, x: f64, y: f64) -> bool {
+        x >= self.x && x < self.x + self.width && y >= self.y && y < self.y + self.height
     }
 
     pub(crate) fn pixel_size(self) -> (u32, u32) {
@@ -64,26 +48,15 @@ pub(crate) struct DisplayLayout {
 }
 
 impl DisplayLayout {
-    pub(crate) fn route(&self, point: GlobalPoint) -> Option<(DisplayId, GlobalPoint)> {
-        self.displays
-            .iter()
-            .find(|display| display.contains(point))
-            .map(|display| (display.id, display.local_point(point)))
-    }
-
-    #[cfg(test)]
-    pub(crate) fn display(&self, id: DisplayId) -> Option<DisplayGeometry> {
+    pub(crate) fn display_at(&self, x: f64, y: f64) -> Option<DisplayGeometry> {
         self.displays
             .iter()
             .copied()
-            .find(|display| display.id == id)
+            .find(|display| display.contains(x, y))
     }
 
-    pub(crate) fn display_for_or_primary(&self, point: GlobalPoint) -> Option<DisplayGeometry> {
-        self.displays
-            .iter()
-            .copied()
-            .find(|display| display.contains(point))
+    pub(crate) fn display_for_or_primary(&self, x: f64, y: f64) -> Option<DisplayGeometry> {
+        self.display_at(x, y)
             .or_else(|| {
                 self.displays
                     .iter()
@@ -185,57 +158,36 @@ mod tests {
     }
 
     #[test]
-    fn routes_negative_axes_into_display_local_points() {
+    fn routes_negative_axes_to_their_displays() {
         let layout = layout();
-        assert_eq!(
-            layout.route(GlobalPoint {
-                x: -867.0,
-                y: 400.0
-            }),
-            Some((
-                2,
-                GlobalPoint {
-                    x: 1053.0,
-                    y: 580.0
-                }
-            ))
-        );
-        assert_eq!(
-            layout.route(GlobalPoint {
-                x: 300.0,
-                y: -867.0
-            }),
-            Some((3, GlobalPoint { x: 300.0, y: 333.0 }))
-        );
+        assert_eq!(layout.display_at(-867.0, 400.0).unwrap().id, 2);
+        assert_eq!(layout.display_at(300.0, -867.0).unwrap().id, 3);
     }
 
     #[test]
     fn seams_are_half_open_and_owned_once() {
         let layout = layout();
-        assert_eq!(
-            layout
-                .route(GlobalPoint {
-                    x: -0.001,
-                    y: 100.0
-                })
-                .unwrap()
-                .0,
-            2
-        );
-        assert_eq!(layout.route(GlobalPoint { x: 0.0, y: 100.0 }).unwrap().0, 1);
+        assert_eq!(layout.display_at(-0.001, 100.0).unwrap().id, 2);
+        assert_eq!(layout.display_at(0.0, 100.0).unwrap().id, 1);
     }
 
     #[test]
     fn each_display_keeps_its_own_pixel_scale() {
         let layout = layout();
-        assert_eq!(layout.display(1).unwrap().pixel_size(), (2880, 1800));
-        assert_eq!(layout.display(2).unwrap().pixel_size(), (1920, 1080));
-        assert_eq!(layout.display(3).unwrap().pixel_size(), (1800, 1800));
+        let pixel_sizes = layout
+            .displays
+            .iter()
+            .map(|display| (display.id, display.pixel_size()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            pixel_sizes,
+            vec![(1, (2880, 1800)), (2, (1920, 1080)), (3, (1800, 1800))]
+        );
     }
 
     #[test]
     fn appkit_frame_flips_global_y_around_the_primary_display() {
-        let display = layout().display(3).unwrap();
+        let display = layout().displays[2];
         let frame = display.appkit_frame(900.0);
         assert_eq!(frame.origin.x, 0.0);
         assert_eq!(frame.origin.y, 900.0);

--- a/libs/cua-driver/rust/crates/platform-macos/src/cursor/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/cursor/mod.rs
@@ -5,6 +5,7 @@
 //! - `overlay::run_on_main_thread()` — called from `main()` on the main thread
 //! - `overlay::send_command(cmd)` — called from tool implementations
 
+mod display_layout;
 pub mod overlay;
 pub mod state;
 

--- a/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
@@ -236,12 +236,6 @@ pub fn send_command(key: CursorKey, cmd: OverlayCommand) {
     }
 }
 
-/// Convenience for callsites not yet threaded with a session key: drives the
-/// seeded `"default"` cursor (the anonymous / one-shot identity).
-pub fn send_command_default(cmd: OverlayCommand) {
-    send_command("default".to_owned(), cmd);
-}
-
 /// Truthful render acknowledgement for lifecycle inspection. This never falls
 /// back to the default cursor: an absent, unplaced, disabled, or idle-faded
 /// session cursor is not reported as visible.
@@ -455,15 +449,13 @@ pub fn run_on_main_thread() {
         }
     };
 
-    let cfg = {
-        let guard = RENDER.lock().unwrap();
-        match guard.as_ref() {
-            Some(m) => m.template.clone(),
-            None => return,
-        }
-    };
+    let enabled = RENDER
+        .lock()
+        .unwrap()
+        .as_ref()
+        .is_some_and(|map| map.template.enabled);
 
-    if !cfg.enabled {
+    if !enabled {
         loop {
             std::thread::park();
         }
@@ -489,7 +481,7 @@ pub fn run_on_main_thread() {
     // ------------------------------------------------------------------
     // AppKit setup (all on the main thread).
     // ------------------------------------------------------------------
-    unsafe { run_appkit(cfg, rx) };
+    unsafe { run_appkit(rx) };
 }
 
 // ── Animation / render state ──────────────────────────────────────────────
@@ -602,6 +594,16 @@ struct NativeSurface {
     layer_ptr: usize,
 }
 
+impl NativeSurface {
+    unsafe fn close(self) {
+        use objc2::runtime::AnyObject;
+        let win = self.win_ptr as *mut AnyObject;
+        let _: () = objc2::msg_send![win, orderOut: std::ptr::null_mut::<AnyObject>()];
+        let _: () = objc2::msg_send![win, setReleasedWhenClosed: true];
+        let _: () = objc2::msg_send![win, close];
+    }
+}
+
 struct AppKitOverlayHost {
     generation: u64,
     surfaces: HashMap<DisplayId, NativeSurface>,
@@ -610,14 +612,12 @@ struct AppKitOverlayHost {
 impl AppKitOverlayHost {
     unsafe fn create(layout: &DisplayLayout) -> Option<Self> {
         let primary_height = layout.primary_height()?;
-        let mut surfaces = HashMap::new();
+        let mut surfaces = HashMap::<DisplayId, NativeSurface>::new();
         for geometry in &layout.displays {
             let Some(surface) = create_native_surface(*geometry, primary_height) else {
-                Self {
-                    generation: layout.generation,
-                    surfaces,
+                for surface in surfaces.into_values() {
+                    surface.close();
                 }
-                .close();
                 return None;
             };
             surfaces.insert(geometry.id, surface);
@@ -629,12 +629,8 @@ impl AppKitOverlayHost {
     }
 
     unsafe fn close(self) {
-        use objc2::runtime::AnyObject;
         for surface in self.surfaces.into_values() {
-            let win = surface.win_ptr as *mut AnyObject;
-            let _: () = objc2::msg_send![win, orderOut: std::ptr::null_mut::<AnyObject>()];
-            let _: () = objc2::msg_send![win, setReleasedWhenClosed: true];
-            let _: () = objc2::msg_send![win, close];
+            surface.close();
         }
     }
 }
@@ -713,7 +709,7 @@ unsafe fn rebuild_appkit_host() -> bool {
     true
 }
 
-unsafe fn run_appkit(_cfg: CursorConfig, rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
+unsafe fn run_appkit(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
     use objc2::runtime::AnyObject;
     use objc2::{class, msg_send};
 
@@ -803,7 +799,6 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
             arrived,
             had_msg,
             cursor_commanded,
-            layout_changed,
             hover_changed,
             next_frame_tick_needed,
             next_hover_poll_needed,
@@ -814,7 +809,6 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
             };
             let mut had_msg = false;
             let mut cursor_commanded = false;
-            let mut layout_changed = false;
 
             let mut apply = |message: MacOverlayMsg| {
                 had_msg = true;
@@ -826,7 +820,7 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
                         };
                         apply_msg(map, message);
                     }
-                    MacOverlayMsg::LayoutChanged => layout_changed = true,
+                    MacOverlayMsg::LayoutChanged => {}
                 }
             };
             if let Some(message) = first_msg {
@@ -874,7 +868,6 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
                 arrived,
                 had_msg,
                 cursor_commanded,
-                layout_changed,
                 hover_changed,
                 next_frame_tick_needed,
                 next_hover_poll_needed,
@@ -918,14 +911,10 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
                     break;
                 };
                 let painted = painted_display_ids(map);
-                let mut displays_to_present = presented_displays
+                let displays_to_present = presented_displays
                     .union(&painted)
                     .copied()
                     .collect::<HashSet<_>>();
-                if layout_changed {
-                    displays_to_present
-                        .extend(map.layout.displays.iter().map(|display| display.id));
-                }
                 let frames = displays_to_present
                     .into_iter()
                     .filter_map(|display_id| {
@@ -935,7 +924,11 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
                             .copied()
                             .find(|display| display.id == display_id)
                             .map(|display| {
-                                (map.layout.generation, display, render_display(map, display))
+                                (
+                                    map.layout.generation,
+                                    display.id,
+                                    render_display(map, display),
+                                )
                             })
                     })
                     .collect::<Vec<_>>();
@@ -943,8 +936,8 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
                 frames
             };
 
-            for (generation, display, pixmap) in frames {
-                dispatch_present(generation, display.id, pixmap);
+            for (generation, display_id, pixmap) in frames {
+                dispatch_present(generation, display_id, pixmap);
             }
         }
 
@@ -1049,10 +1042,7 @@ fn hardware_cursor_position() -> Option<(f64, f64)> {
 }
 
 fn cursor_is_visible(state: &RenderState) -> bool {
-    state.core.placed
-        && state.core.cfg.enabled
-        && state.core.visible
-        && state.core.idle_alpha >= 0.004
+    state.core.cfg.enabled && state.core.cursor_is_revealed()
 }
 
 type MainWork = Box<dyn FnOnce() + Send>;

--- a/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
@@ -94,6 +94,9 @@ static REBUILD_PENDING: AtomicBool = AtomicBool::new(false);
 struct RenderMap {
     cursors: IndexMap<CursorKey, RenderState>,
     layout: DisplayLayout,
+    /// Most recently commanded cursor. Its live position determines which
+    /// display surface owns target-relative z-order while it animates.
+    active_key: Option<CursorKey>,
     /// Frozen launch-time config used as the template for lazily-created cursors.
     template: CursorConfig,
     /// Render-side tombstone of ended session cursor keys. A `Cmd`
@@ -118,15 +121,16 @@ fn render_state_for_key(template: &CursorConfig, key: &str) -> RenderState {
 /// out as a pure function so the per-session ownership + removal lifecycle is
 /// unit-testable without AppKit.
 ///
-/// Returns the resolved cursor key for a `Cmd` (so the caller can track the
-/// last-active key for z-order pinning); `None` for a lifecycle message.
-fn apply_msg(map: &mut RenderMap, msg: OverlayMsg) -> Option<CursorKey> {
+fn apply_msg(map: &mut RenderMap, msg: OverlayMsg) {
     match msg {
         OverlayMsg::Remove(key) => {
             // The "default" cursor backs the anonymous / one-shot path and
             // must survive every session_end + the daemon lifetime.
             if key != "default" {
                 map.cursors.shift_remove(&key);
+                if map.active_key.as_ref() == Some(&key) {
+                    map.active_key = None;
+                }
                 if let Ok(mut guard) = ARRIVAL_TX.lock() {
                     if let Some(m) = guard.as_mut() {
                         m.remove(&key);
@@ -137,29 +141,26 @@ fn apply_msg(map: &mut RenderMap, msg: OverlayMsg) -> Option<CursorKey> {
                 // re-create the just-removed cursor. Never tombstone "default".
                 map.ended.insert(key);
             }
-            None
         }
         OverlayMsg::Revive(key) => {
             if key != "default" {
                 map.ended.remove(&key);
             }
-            None
         }
         OverlayMsg::Cmd(KeyedOverlayCommand { key, cmd }) => {
             // Drop a command for an already-ended session WITHOUT get-or-create
             // — this is the resurrection guard. Without it, a ClickPulse/MoveTo
             // landing after Remove would re-insert (and re-leak) the cursor.
             if map.ended.contains(&key) {
-                return None;
+                return;
             }
             let template = map.template.clone();
-            let k = key.clone();
             let rs = map
                 .cursors
-                .entry(key)
-                .or_insert_with(|| render_state_for_key(&template, &k));
+                .entry(key.clone())
+                .or_insert_with(|| render_state_for_key(&template, &key));
             rs.apply_command(cmd);
-            Some(k)
+            map.active_key = Some(key);
         }
     }
 }
@@ -179,6 +180,7 @@ pub fn init(cfg: CursorConfig) {
         *RENDER.lock().unwrap() = Some(RenderMap {
             cursors,
             layout: DisplayLayout::default(),
+            active_key: None,
             template: cfg,
             ended: std::collections::HashSet::new(),
         });
@@ -569,6 +571,28 @@ fn render_map_needs_frame_tick(map: &RenderMap) -> bool {
     map.cursors.values().any(RenderState::needs_frame_tick)
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ZOrderRoute {
+    generation: u64,
+    display_id: DisplayId,
+    target_wid: Option<u64>,
+}
+
+fn z_order_route(map: &RenderMap) -> Option<ZOrderRoute> {
+    let state = map
+        .active_key
+        .as_ref()
+        .and_then(|key| map.cursors.get(key))
+        .filter(|state| cursor_is_externally_visible(state))?;
+    let (x, y) = state.core.pos?;
+    let (display_id, _) = map.layout.route(GlobalPoint { x, y })?;
+    Some(ZOrderRoute {
+        generation: map.layout.generation,
+        display_id,
+        target_wid: state.core.pinned_wid,
+    })
+}
+
 // ── AppKit / CGImage plumbing ─────────────────────────────────────────────
 
 struct NativeSurface {
@@ -748,10 +772,9 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
     let mut last_tick = Instant::now();
     let mut frame_tick_needed = false;
     let mut hover_poll_needed = false;
-    let mut last_pinned: Option<u64> = None;
-    let mut last_display: Option<DisplayId> = None;
+    let mut presented_displays = HashSet::<DisplayId>::new();
+    let mut presented_z_order: Option<ZOrderRoute> = None;
     let mut repin_frames: u32 = 0;
-    let mut previously_active = HashSet::<DisplayId>::new();
 
     loop {
         let (first_msg, hover_poll_tick) = if frame_tick_needed {
@@ -779,11 +802,10 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
         last_tick = now;
 
         let (
-            pinned_wid,
-            active_display,
-            raise_unpinned,
+            z_order,
             arrived,
             had_msg,
+            cursor_commanded,
             layout_changed,
             hover_changed,
             next_frame_tick_needed,
@@ -793,17 +815,19 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
             let Some(map) = guard.as_mut() else {
                 break;
             };
-            let mut last_key: Option<CursorKey> = None;
             let mut had_msg = false;
+            let mut cursor_commanded = false;
             let mut layout_changed = false;
 
             let mut apply = |message: MacOverlayMsg| {
                 had_msg = true;
                 match message {
                     MacOverlayMsg::Cursor(message) => {
-                        if let Some(key) = apply_msg(map, message) {
-                            last_key = Some(key);
-                        }
+                        cursor_commanded |= match &message {
+                            OverlayMsg::Cmd(command) => !map.ended.contains(&command.key),
+                            _ => false,
+                        };
+                        apply_msg(map, message);
                     }
                     MacOverlayMsg::DisplaysChanged => layout_changed = true,
                 }
@@ -841,17 +865,7 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
                 }
             }
 
-            let active_state = last_key.as_ref().and_then(|key| map.cursors.get(key));
-            let pinned = active_state
-                .map(|state| state.core.pinned_wid)
-                .unwrap_or(last_pinned);
-            let active_display = active_state
-                .and_then(|state| state.core.pos)
-                .and_then(|(x, y)| map.layout.route(GlobalPoint { x, y }))
-                .map(|(display, _)| display)
-                .or_else(|| last_display.filter(|display| map.layout.display(*display).is_some()));
-            let raise_unpinned =
-                active_state.is_some_and(cursor_is_externally_visible) && pinned.is_none();
+            let z_order = z_order_route(map);
             let next_frame_tick_needed = render_map_needs_frame_tick(map);
             let next_hover_poll_needed = map
                 .cursors
@@ -859,11 +873,10 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
                 .any(|state| state.core.session_badge_needs_hover_poll());
 
             (
-                pinned,
-                active_display,
-                raise_unpinned,
+                z_order,
                 arrived,
                 had_msg,
+                cursor_commanded,
                 layout_changed,
                 hover_changed,
                 next_frame_tick_needed,
@@ -877,18 +890,20 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
 
         if frame_tick_needed || had_msg {
             repin_frames += 1;
-            let pin_changed = pinned_wid != last_pinned || active_display != last_display;
-            last_pinned = pinned_wid;
-            last_display = active_display;
-            if let Some(display_id) = active_display {
-                if pinned_wid.is_some() && (pin_changed || repin_frames >= 60) {
-                    MacZOrderEnforcer { display_id }.reassert(pinned_wid);
+            let route_changed = z_order != presented_z_order;
+            if let Some(route) = z_order {
+                if route.target_wid.is_some() && (route_changed || repin_frames >= 60) {
+                    MacZOrderEnforcer {
+                        display_id: route.display_id,
+                    }
+                    .reassert(route.target_wid);
                     repin_frames = 0;
-                } else if raise_unpinned {
-                    dispatch_order_front(display_id);
+                } else if route.target_wid.is_none() && (route_changed || cursor_commanded) {
+                    dispatch_order_front(route.display_id);
                     repin_frames = 0;
                 }
             }
+            presented_z_order = z_order;
             if repin_frames >= 60 {
                 repin_frames = 0;
             }
@@ -900,15 +915,16 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
                 let Some(map) = guard.as_ref() else {
                     break;
                 };
-                let active = active_display_ids(map);
-                let mut dirty = previously_active
-                    .union(&active)
+                let painted = painted_display_ids(map);
+                let mut displays_to_present = presented_displays
+                    .union(&painted)
                     .copied()
                     .collect::<HashSet<_>>();
                 if layout_changed {
-                    dirty.extend(map.layout.displays.iter().map(|display| display.id));
+                    displays_to_present
+                        .extend(map.layout.displays.iter().map(|display| display.id));
                 }
-                let frames = dirty
+                let frames = displays_to_present
                     .into_iter()
                     .filter_map(|display_id| {
                         map.layout.display(display_id).map(|display| {
@@ -916,7 +932,7 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
                         })
                     })
                     .collect::<Vec<_>>();
-                previously_active = active;
+                presented_displays = painted;
                 frames
             };
 
@@ -936,25 +952,47 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
     }
 }
 
-fn active_display_ids(map: &RenderMap) -> HashSet<DisplayId> {
-    let mut active = HashSet::new();
+// Matches the established default-theme envelope used by the X11 tile path.
+const DEFAULT_CURSOR_PAINT_RADIUS: f64 = 64.0;
+
+/// Displays whose buffers can contain pixels in the current frame. This is
+/// based on painted bounds, not cursor ownership: artwork may span a seam.
+fn painted_display_ids(map: &RenderMap) -> HashSet<DisplayId> {
+    let mut painted = HashSet::new();
     for state in map.cursors.values() {
         if cursor_is_externally_visible(state) {
             if let Some((x, y)) = state.core.pos {
-                if let Some((display, _)) = map.layout.route(GlobalPoint { x, y }) {
-                    active.insert(display);
+                let custom_theme = state
+                    .core
+                    .theme
+                    .as_deref()
+                    .is_some_and(|theme| theme.id != cursor_overlay::DEFAULT_THEME_ID);
+                for display in &map.layout.displays {
+                    if custom_theme
+                        || rectangles_intersect(
+                            (
+                                x - DEFAULT_CURSOR_PAINT_RADIUS,
+                                y - DEFAULT_CURSOR_PAINT_RADIUS,
+                                DEFAULT_CURSOR_PAINT_RADIUS * 2.0,
+                                DEFAULT_CURSOR_PAINT_RADIUS * 2.0,
+                            ),
+                            *display,
+                        )
+                    {
+                        painted.insert(display.id);
+                    }
                 }
             }
         }
         if let Some([x, y, width, height]) = state.focus_rect {
             for display in &map.layout.displays {
                 if rectangles_intersect((x, y, width, height), *display) {
-                    active.insert(display.id);
+                    painted.insert(display.id);
                 }
             }
         }
     }
-    active
+    painted
 }
 
 fn rectangles_intersect(rect: (f64, f64, f64, f64), display: DisplayGeometry) -> bool {
@@ -976,7 +1014,17 @@ fn render_display(map: &RenderMap, display: DisplayGeometry) -> tiny_skia::Pixma
             rect,
             t: state.focus_rect_t,
         });
-        cursor_overlay::paint_cursor(
+        let anchor_display = state
+            .core
+            .pos
+            .and_then(|(x, y)| map.layout.route(GlobalPoint { x, y }))
+            .map(|(display_id, _)| display_id);
+        let painter = if anchor_display == Some(display.id) {
+            cursor_overlay::paint_cursor
+        } else {
+            cursor_overlay::paint_cursor_art
+        };
+        painter(
             &mut pixmap,
             &state.core,
             display.x,
@@ -1300,6 +1348,7 @@ mod tests {
                     is_primary: true,
                 }],
             },
+            active_key: None,
             template: CursorConfig::default(),
             ended: std::collections::HashSet::new(),
         }
@@ -1428,11 +1477,7 @@ mod tests {
 
         // A late in-flight Cmd for the ended session must be dropped WITHOUT
         // re-inserting (no get-or-create resurrection).
-        let resolved = apply_msg(&mut map, move_msg("sessA", 99.0, 99.0));
-        assert!(
-            resolved.is_none(),
-            "ended-session Cmd must be dropped, not resolved"
-        );
+        apply_msg(&mut map, move_msg("sessA", 99.0, 99.0));
         assert!(
             !map.cursors.contains_key("sessA"),
             "tombstone must block resurrection"
@@ -1449,15 +1494,16 @@ mod tests {
         let mut map = empty_map();
         apply_msg(&mut map, move_msg("sessA", 10.0, 10.0));
         apply_msg(&mut map, OverlayMsg::Remove("sessA".to_owned()));
-        assert!(apply_msg(&mut map, move_msg("sessA", 20.0, 20.0)).is_none());
+        apply_msg(&mut map, move_msg("sessA", 20.0, 20.0));
+        assert!(!map.cursors.contains_key("sessA"));
 
         apply_msg(&mut map, OverlayMsg::Revive("sessA".to_owned()));
         assert!(!map.cursors.contains_key("sessA"));
         assert!(!map.ended.contains("sessA"));
 
-        let resolved = apply_msg(&mut map, move_msg("sessA", 30.0, 30.0));
-        assert_eq!(resolved.as_deref(), Some("sessA"));
+        apply_msg(&mut map, move_msg("sessA", 30.0, 30.0));
         assert!(map.cursors.contains_key("sessA"));
+        assert_eq!(map.active_key.as_deref(), Some("sessA"));
     }
 
     #[test]
@@ -1469,9 +1515,9 @@ mod tests {
         assert!(map.cursors.contains_key("default"));
         assert!(!map.ended.contains("default"));
 
-        let resolved = apply_msg(&mut map, move_msg("default", 5.0, 5.0));
-        assert_eq!(resolved.as_deref(), Some("default"));
+        apply_msg(&mut map, move_msg("default", 5.0, 5.0));
         assert!(map.cursors.contains_key("default"));
+        assert_eq!(map.active_key.as_deref(), Some("default"));
     }
 
     #[test]
@@ -1544,14 +1590,61 @@ mod tests {
         seed_start_in_map(&mut map, &"sessA".to_owned(), -867.0, 400.0);
         map.cursors.get_mut("sessA").unwrap().core.pos = Some((-867.0, 400.0));
 
-        assert_eq!(active_display_ids(&map), HashSet::from([2]));
+        assert_eq!(painted_display_ids(&map), HashSet::from([2]));
         let pixmap = render_display(&map, secondary);
         assert!(pixmap.data().chunks_exact(4).any(|pixel| pixel[3] > 0));
     }
 
     #[test]
-    fn moved_cursor_drops_the_old_display_from_the_active_set() {
+    fn cursor_art_routes_to_both_sides_of_a_display_seam_then_clears() {
         let mut map = empty_map();
+        map.layout.displays[0].width = 1440.0;
+        map.layout.displays[0].height = 900.0;
+        let secondary = DisplayGeometry {
+            id: 2,
+            x: -1920.0,
+            y: 0.0,
+            width: 1920.0,
+            height: 1080.0,
+            backing_scale: 1.0,
+            is_primary: false,
+        };
+        map.layout.displays.push(secondary);
+        seed_start_in_map(&mut map, &"sessA".to_owned(), -867.0, 400.0);
+
+        map.cursors.get_mut("sessA").unwrap().core.pos = Some((-1.0, 400.0));
+        assert_eq!(painted_display_ids(&map), HashSet::from([1, 2]));
+        let primary = map.layout.display(1).unwrap();
+        let primary_art = render_display(&map, primary);
+        let secondary_art = render_display(&map, secondary);
+        for pixmap in [&primary_art, &secondary_art] {
+            assert!(pixmap.data().chunks_exact(4).any(|pixel| pixel[3] > 0));
+        }
+
+        map.cursors
+            .get_mut("sessA")
+            .unwrap()
+            .apply_command(OverlayCommand::SetSessionLabel("research".to_owned()));
+        assert_eq!(
+            render_display(&map, primary).data(),
+            primary_art.data(),
+            "the neighboring display must not duplicate the anchor display's badge"
+        );
+        assert_ne!(render_display(&map, secondary).data(), secondary_art.data());
+
+        map.cursors.get_mut("sessA").unwrap().core.pos = Some((400.0, 400.0));
+        assert_eq!(painted_display_ids(&map), HashSet::from([1]));
+        assert!(render_display(&map, secondary)
+            .data()
+            .chunks_exact(4)
+            .all(|pixel| pixel[3] == 0));
+    }
+
+    #[test]
+    fn z_order_follows_the_active_cursor_and_layout_generation() {
+        let mut map = empty_map();
+        map.layout.displays[0].width = 1440.0;
+        map.layout.displays[0].height = 900.0;
         map.layout.displays.push(DisplayGeometry {
             id: 2,
             x: -1920.0,
@@ -1561,12 +1654,29 @@ mod tests {
             backing_scale: 1.0,
             is_primary: false,
         });
-        seed_start_in_map(&mut map, &"sessA".to_owned(), -867.0, 400.0);
-        map.cursors.get_mut("sessA").unwrap().core.pos = Some((-867.0, 40.0));
-        assert_eq!(active_display_ids(&map), HashSet::from([2]));
+        seed_start_in_map(&mut map, &"sessA".to_owned(), 400.0, 400.0);
+        apply_msg(
+            &mut map,
+            OverlayMsg::Cmd(KeyedOverlayCommand {
+                key: "sessA".to_owned(),
+                cmd: OverlayCommand::PinAbove(77),
+            }),
+        );
 
-        map.cursors.get_mut("sessA").unwrap().core.pos = Some((40.0, 40.0));
-        assert_eq!(active_display_ids(&map), HashSet::from([1]));
+        assert_eq!(
+            z_order_route(&map),
+            Some(ZOrderRoute {
+                generation: 1,
+                display_id: 1,
+                target_wid: Some(77),
+            })
+        );
+
+        map.cursors.get_mut("sessA").unwrap().core.pos = Some((-400.0, 400.0));
+        assert_eq!(z_order_route(&map).unwrap().display_id, 2);
+
+        map.layout.generation = 2;
+        assert_eq!(z_order_route(&map).unwrap().generation, 2);
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
@@ -4,15 +4,14 @@
 //!
 //! The MCP/tokio server runs on a **background thread** (spawned in
 //! `cua-driver/src/main.rs`).  AppKit MUST run on the **main thread**.
-//! The two sides communicate through a bounded process-global channel:
+//! The two sides communicate through a global lock-free channel:
 //!
 //! - MCP tool calls → `send_command(OverlayCommand)` → `CMD_TX` (SyncSender)
-//! - render worker → bounded per-display tiles → one-slot presentation mailbox
-//! - main thread → `AppKitOverlayHost` child layers
+//! - render worker → per-display pixmaps → main-thread `AppKitOverlayHost`
 //!
 //! One shared render map owns cursor state. The AppKit host owns one transparent
-//! window and one movable content layer per active display, and replaces that
-//! surface set after display-layout changes.
+//! presentation surface per active display and replaces that surface set after
+//! display-layout changes.
 //!
 //! ## Coordinate system
 //!
@@ -39,7 +38,7 @@ use std::time::{Duration, Instant};
 
 use cursor_overlay::{
     CursorConfig, CursorKey, FocusRect, KeyedOverlayCommand, MotionConfig, OverlayCommand,
-    OverlayMsg, RenderStateCore,
+    OverlayMsg, RenderStateCore, ZOrderEnforcer,
 };
 use indexmap::IndexMap;
 
@@ -77,7 +76,7 @@ fn arrival_fire(key: &CursorKey) {
 
 enum MacOverlayMsg {
     Cursor(OverlayMsg),
-    LayoutChanged,
+    DisplaysChanged,
 }
 
 static CMD_TX: OnceLock<std::sync::mpsc::SyncSender<MacOverlayMsg>> = OnceLock::new();
@@ -86,8 +85,7 @@ static CMD_RX_CELL: Mutex<Option<std::sync::mpsc::Receiver<MacOverlayMsg>>> = Mu
 static RENDER: Mutex<Option<RenderMap>> = Mutex::new(None);
 static HOST: Mutex<Option<AppKitOverlayHost>> = Mutex::new(None);
 static DISPLAY_GENERATION: AtomicU64 = AtomicU64::new(0);
-static REBUILD_REQUESTED: AtomicBool = AtomicBool::new(false);
-static REBUILD_SCHEDULED: AtomicBool = AtomicBool::new(false);
+static REBUILD_PENDING: AtomicBool = AtomicBool::new(false);
 
 /// The keyed, insertion-ordered collection of owned cursors that the render
 /// loop composites every frame. Insertion order = stable z-order (later keys
@@ -108,7 +106,7 @@ struct RenderMap {
     /// resurrection race). An explicit owner-checked `start_session` revival
     /// clears this tombstone before the cursor is reused. "default" is never
     /// tombstoned.
-    ended: HashSet<CursorKey>,
+    ended: std::collections::HashSet<CursorKey>,
 }
 
 /// Build the `RenderState` for a lazily-created session cursor from the
@@ -184,7 +182,7 @@ pub fn init(cfg: CursorConfig) {
             layout: DisplayLayout::default(),
             active_key: None,
             template: cfg,
-            ended: HashSet::new(),
+            ended: std::collections::HashSet::new(),
         });
     });
     cua_driver_core::cursor_events::install_cursor_event_sink(std::sync::Arc::new(
@@ -227,7 +225,7 @@ pub fn init(cfg: CursorConfig) {
 /// Send a keyed command from any thread (MCP tool, etc.).  Non-blocking; drops
 /// if the channel is full (old commands are less important than new ones).
 pub fn send_command(key: CursorKey, cmd: OverlayCommand) {
-    // An empty key disables cursors for direct platform calls
+    // Empty key is the explicit no-cursor sentinel for direct platform calls
     // that bypass lifecycle dispatch.
     if key.is_empty() {
         return;
@@ -246,7 +244,7 @@ pub fn send_command_default(cmd: OverlayCommand) {
 }
 
 /// Truthful render acknowledgement for lifecycle inspection. This never falls
-/// back to the seeded default cursor: an absent, unplaced, disabled, or
+/// back to the seeded default cursor: an absent, off-screen, disabled, or
 /// idle-faded session cursor is not reported as visible.
 pub fn is_visible_for_session(key: &str) -> bool {
     RENDER
@@ -256,7 +254,7 @@ pub fn is_visible_for_session(key: &str) -> bool {
             guard
                 .as_ref()
                 .and_then(|map| map.cursors.get(key))
-                .map(|state| state.core.cursor_is_revealed())
+                .map(cursor_is_externally_visible)
         })
         .unwrap_or(false)
 }
@@ -365,7 +363,7 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
         .cursors
         .entry(key.clone())
         .or_insert_with(|| render_state_for_key(&template, &k));
-    if !(rs.core.cfg.enabled && rs.core.pos.is_none()) {
+    if !(rs.core.cfg.enabled && !rs.placed) {
         return false;
     }
     let mut sx = target_x - SEED_OFFSET;
@@ -384,7 +382,8 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
             sy = (target_y + SEED_OFFSET).min(max_y);
         }
     }
-    rs.core.pos = Some((sx, sy));
+    rs.core.pos = (sx, sy);
+    rs.placed = true;
     true
 }
 
@@ -398,7 +397,7 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
 /// in (it previously snapped silently via `ClickPulse`, invisible on a pure-AX
 /// run).
 pub async fn animate_cursor_to(key: CursorKey, x: f64, y: f64) {
-    // An empty key disables cursors for direct platform calls.
+    // Empty key is the explicit no-cursor sentinel → nothing to animate.
     if key.is_empty() {
         return;
     }
@@ -413,7 +412,7 @@ pub async fn animate_cursor_to(key: CursorKey, x: f64, y: f64) {
         let guard = RENDER.lock().unwrap();
         matches!(
             guard.as_ref().and_then(|m| m.cursors.get(&key)),
-            Some(rs) if rs.core.cfg.enabled && rs.core.pos.is_some()
+            Some(rs) if rs.core.cfg.enabled && rs.placed
         )
     };
     if !should_animate {
@@ -498,10 +497,12 @@ pub fn run_on_main_thread() {
 //
 // The platform-agnostic fields + tick + apply_command + render pipeline live
 // in `cursor_overlay::render_state` (2026-05 dedup audit). What stays here
-// is the macOS-specific focus-rect overlay and native presentation host.
+// is the macOS-specific NSScreen window dimensions and the focus-rect
+// overlay (a macOS-only post-arrival element highlight).
 
 struct RenderState {
     core: RenderStateCore,
+    placed: bool,
     /// Focus-highlight rectangle `[x, y, w, h]` in screen coords; None = not shown.
     focus_rect: Option<[f64; 4]>,
     /// Fade progress for the focus rect: 0.0 = fully visible, 1.0 = gone.
@@ -512,6 +513,7 @@ impl RenderState {
     fn new(cfg: CursorConfig) -> Self {
         RenderState {
             core: RenderStateCore::new(cfg),
+            placed: false,
             focus_rect: None,
             focus_rect_t: 1.0,
         }
@@ -546,7 +548,14 @@ impl RenderState {
                 self.focus_rect_t = 0.0; // reset fade to fully visible
             }
             other => {
-                let _ = self.core.apply_command_base(other, false);
+                let places = matches!(
+                    other,
+                    OverlayCommand::MoveTo { .. }
+                        | OverlayCommand::SnapTo { .. }
+                        | OverlayCommand::ClickPulse { .. }
+                );
+                let _ = self.core.apply_command_base(other, true, true);
+                self.placed |= places;
             }
         }
     }
@@ -554,14 +563,14 @@ impl RenderState {
     /// True while the render loop must wake at frame cadence because the next
     /// tick can change pixels. A brand-new unplaced cursor is deliberately
     /// quiescent, so `serve` with no agent activity can block on the command
-    /// channel instead of producing empty frames at 60 fps.
+    /// channel instead of compositing an empty fullscreen pixmap at 60fps.
     fn needs_frame_tick(&self) -> bool {
         self.core.path.is_some()
             || self.core.spring.is_some()
             || self.core.click_t.is_some()
             || self.focus_rect.is_some()
             || self.core.session_badge_needs_frame_tick()
-            || (self.core.motion.idle_hide_ms > 0.0 && self.core.cursor_is_revealed())
+            || (self.core.motion.idle_hide_ms > 0.0 && cursor_is_externally_visible(self))
     }
 }
 
@@ -576,23 +585,19 @@ struct ZOrderRoute {
     target_wid: Option<u64>,
 }
 
-fn z_order_routes(map: &RenderMap) -> Vec<ZOrderRoute> {
-    let Some(state) = map
+fn z_order_route(map: &RenderMap) -> Option<ZOrderRoute> {
+    let state = map
         .active_key
         .as_ref()
         .and_then(|key| map.cursors.get(key))
-        .filter(|state| state.core.cursor_is_revealed())
-    else {
-        return Vec::new();
-    };
-    state_display_ids(map, state)
-        .into_iter()
-        .map(|display_id| ZOrderRoute {
-            generation: map.layout.generation,
-            display_id,
-            target_wid: state.core.pinned_wid,
-        })
-        .collect()
+        .filter(|state| cursor_is_externally_visible(state))?;
+    let (x, y) = state.core.pos;
+    let display_id = map.layout.display_at(x, y)?.id;
+    Some(ZOrderRoute {
+        generation: map.layout.generation,
+        display_id,
+        target_wid: state.core.pinned_wid,
+    })
 }
 
 // ── AppKit / CGImage plumbing ─────────────────────────────────────────────
@@ -600,8 +605,6 @@ fn z_order_routes(map: &RenderMap) -> Vec<ZOrderRoute> {
 struct NativeSurface {
     win_ptr: usize,
     layer_ptr: usize,
-    logical_height: f64,
-    backing_scale: f64,
 }
 
 struct AppKitOverlayHost {
@@ -673,24 +676,17 @@ unsafe fn create_native_surface(
 
     let content_view: *mut AnyObject = msg_send![win, contentView];
     let _: () = msg_send![content_view, setWantsLayer: true];
-    let root_layer: *mut AnyObject = msg_send![content_view, layer];
-    let _: () = msg_send![root_layer, setGeometryFlipped: false];
-    let _: () = msg_send![root_layer, setMasksToBounds: true];
-    let layer: *mut AnyObject = msg_send![class!(CALayer), layer];
-    let scale = geometry.backing_scale.max(1.0);
-    let _: () = msg_send![layer, setContentsScale: scale];
+    let layer: *mut AnyObject = msg_send![content_view, layer];
+    let _: () = msg_send![layer, setContentsScale: geometry.backing_scale.max(1.0)];
     let gravity_ns: *mut AnyObject = msg_send![class!(NSString),
-        stringWithUTF8String: c"resize".as_ptr().cast::<u8>()
+        stringWithUTF8String: c"topLeft".as_ptr().cast::<u8>()
     ];
     let _: () = msg_send![layer, setContentsGravity: gravity_ns];
-    let _: () = msg_send![root_layer, addSublayer: layer];
     let _: () = msg_send![win, orderFrontRegardless];
 
     Some(NativeSurface {
         win_ptr: win as usize,
         layer_ptr: layer as usize,
-        logical_height: geometry.height,
-        backing_scale: scale,
     })
 }
 
@@ -763,27 +759,16 @@ fn register_display_reconfiguration_callback() {
 }
 
 fn dispatch_rebuild_appkit_host() {
-    REBUILD_REQUESTED.store(true, Ordering::Release);
-    if REBUILD_SCHEDULED.swap(true, Ordering::AcqRel) {
+    if REBUILD_PENDING.swap(true, Ordering::AcqRel) {
         return;
     }
     dispatch_on_main(Box::new(|| unsafe {
-        loop {
-            REBUILD_REQUESTED.store(false, Ordering::Release);
-            if rebuild_appkit_host() {
-                if let Some(tx) = CMD_TX.get() {
-                    let _ = tx.try_send(MacOverlayMsg::LayoutChanged);
-                }
+        let rebuilt = rebuild_appkit_host();
+        REBUILD_PENDING.store(false, Ordering::Release);
+        if rebuilt {
+            if let Some(tx) = CMD_TX.get() {
+                let _ = tx.try_send(MacOverlayMsg::DisplaysChanged);
             }
-            if !REBUILD_REQUESTED.swap(false, Ordering::AcqRel) {
-                break;
-            }
-        }
-        REBUILD_SCHEDULED.store(false, Ordering::Release);
-        // Close the race where a callback marks the layout dirty after the
-        // loop's final check but before the scheduled marker is released.
-        if REBUILD_REQUESTED.load(Ordering::Acquire) {
-            dispatch_rebuild_appkit_host();
         }
     }));
 }
@@ -794,7 +779,8 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
     let mut last_tick = Instant::now();
     let mut frame_tick_needed = false;
     let mut hover_poll_needed = false;
-    let mut presented_z_order = Vec::<ZOrderRoute>::new();
+    let mut presented_displays = HashSet::<DisplayId>::new();
+    let mut presented_z_order: Option<ZOrderRoute> = None;
     let mut repin_frames: u32 = 0;
 
     loop {
@@ -827,6 +813,7 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
             arrived,
             had_msg,
             cursor_commanded,
+            layout_changed,
             hover_changed,
             next_frame_tick_needed,
             next_hover_poll_needed,
@@ -837,15 +824,19 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
             };
             let mut had_msg = false;
             let mut cursor_commanded = false;
+            let mut layout_changed = false;
 
             let mut apply = |message: MacOverlayMsg| {
                 had_msg = true;
-                if let MacOverlayMsg::Cursor(message) = message {
-                    cursor_commanded |= match &message {
-                        OverlayMsg::Cmd(command) => !map.ended.contains(&command.key),
-                        _ => false,
-                    };
-                    apply_msg(map, message);
+                match message {
+                    MacOverlayMsg::Cursor(message) => {
+                        cursor_commanded |= match &message {
+                            OverlayMsg::Cmd(command) => !map.ended.contains(&command.key),
+                            _ => false,
+                        };
+                        apply_msg(map, message);
+                    }
+                    MacOverlayMsg::DisplaysChanged => layout_changed = true,
                 }
             };
             if let Some(message) = first_msg {
@@ -881,7 +872,7 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
                 }
             }
 
-            let z_order = z_order_routes(map);
+            let z_order = z_order_route(map);
             let next_frame_tick_needed = render_map_needs_frame_tick(map);
             let next_hover_poll_needed = map
                 .cursors
@@ -893,6 +884,7 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
                 arrived,
                 had_msg,
                 cursor_commanded,
+                layout_changed,
                 hover_changed,
                 next_frame_tick_needed,
                 next_hover_poll_needed,
@@ -906,48 +898,59 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
         if frame_tick_needed || had_msg {
             repin_frames += 1;
             let route_changed = z_order != presented_z_order;
-            let periodic_repin = repin_frames >= 60;
-            let mut ordered = false;
-            for route in &z_order {
-                match route.target_wid {
-                    Some(target_wid) if periodic_repin || !presented_z_order.contains(route) => {
-                        dispatch_pin_above(route.generation, route.display_id, target_wid);
-                        ordered = true;
+            if let Some(route) = z_order {
+                if route.target_wid.is_some() && (route_changed || repin_frames >= 60) {
+                    MacZOrderEnforcer {
+                        display_id: route.display_id,
                     }
-                    None if route_changed || cursor_commanded => {
-                        dispatch_order_front(route.generation, route.display_id);
-                        ordered = true;
-                    }
-                    _ => {}
+                    .reassert(route.target_wid);
+                    repin_frames = 0;
+                } else if route.target_wid.is_none() && (route_changed || cursor_commanded) {
+                    dispatch_order_front(route.display_id);
+                    repin_frames = 0;
                 }
             }
-            if periodic_repin || ordered {
+            presented_z_order = z_order;
+            if repin_frames >= 60 {
                 repin_frames = 0;
             }
-            presented_z_order = z_order;
         }
 
         if had_msg || hover_changed || frame_tick_needed || next_frame_tick_needed {
-            let batch = {
+            let frames = {
                 let guard = RENDER.lock().unwrap();
                 let Some(map) = guard.as_ref() else {
                     break;
                 };
-                FrameBatch {
-                    generation: map.layout.generation,
-                    surfaces: map
-                        .layout
-                        .displays
-                        .iter()
-                        .copied()
-                        .map(|display| SurfaceFrame {
-                            display_id: display.id,
-                            tile: render_display_tile(map, display),
-                        })
-                        .collect(),
+                let painted = painted_display_ids(map);
+                let mut displays_to_present = presented_displays
+                    .union(&painted)
+                    .copied()
+                    .collect::<HashSet<_>>();
+                if layout_changed {
+                    displays_to_present
+                        .extend(map.layout.displays.iter().map(|display| display.id));
                 }
+                let frames = displays_to_present
+                    .into_iter()
+                    .filter_map(|display_id| {
+                        map.layout
+                            .displays
+                            .iter()
+                            .copied()
+                            .find(|display| display.id == display_id)
+                            .map(|display| {
+                                (map.layout.generation, display, render_display(map, display))
+                            })
+                    })
+                    .collect::<Vec<_>>();
+                presented_displays = painted;
+                frames
             };
-            queue_present(batch);
+
+            for (generation, display, pixmap) in frames {
+                dispatch_present(generation, display.id, pixmap);
+            }
         }
 
         frame_tick_needed = next_frame_tick_needed;
@@ -961,197 +964,90 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct PixelRect {
-    x: u32,
-    y: u32,
-    width: u32,
-    height: u32,
-}
+// Matches the established default-theme envelope used by the X11 tile path.
+const DEFAULT_CURSOR_PAINT_RADIUS: f64 = 64.0;
 
-impl PixelRect {
-    fn union(self, other: Self) -> Self {
-        let x0 = self.x.min(other.x);
-        let y0 = self.y.min(other.y);
-        let x1 = (self.x + self.width).max(other.x + other.width);
-        let y1 = (self.y + self.height).max(other.y + other.height);
-        Self {
-            x: x0,
-            y: y0,
-            width: x1 - x0,
-            height: y1 - y0,
-        }
-    }
-}
-
-fn tile_layer_frame(
-    bounds: PixelRect,
-    logical_height: f64,
-    scale: f64,
-) -> objc2_foundation::NSRect {
-    use objc2_foundation::{NSPoint, NSRect, NSSize};
-
-    NSRect::new(
-        NSPoint::new(
-            f64::from(bounds.x) / scale,
-            logical_height - f64::from(bounds.y + bounds.height) / scale,
-        ),
-        NSSize::new(
-            f64::from(bounds.width) / scale,
-            f64::from(bounds.height) / scale,
-        ),
-    )
-}
-
-struct RenderedTile {
-    bounds: PixelRect,
-    pixmap: tiny_skia::Pixmap,
-}
-
-fn logical_rect_to_pixels(
-    rect: (f64, f64, f64, f64),
-    display: DisplayGeometry,
-    padding: f64,
-) -> Option<PixelRect> {
-    let (x, y, width, height) = rect;
-    if width <= 0.0 || height <= 0.0 {
-        return None;
-    }
-    let scale = display.backing_scale.max(1.0);
-    let (pixel_width, pixel_height) = display.pixel_size();
-    let x0 = ((x - padding - display.x) * scale)
-        .floor()
-        .clamp(0.0, f64::from(pixel_width)) as u32;
-    let y0 = ((y - padding - display.y) * scale)
-        .floor()
-        .clamp(0.0, f64::from(pixel_height)) as u32;
-    let x1 = ((x + width + padding - display.x) * scale)
-        .ceil()
-        .clamp(0.0, f64::from(pixel_width)) as u32;
-    let y1 = ((y + height + padding - display.y) * scale)
-        .ceil()
-        .clamp(0.0, f64::from(pixel_height)) as u32;
-    (x1 > x0 && y1 > y0).then_some(PixelRect {
-        x: x0,
-        y: y0,
-        width: x1 - x0,
-        height: y1 - y0,
-    })
-}
-
-fn badge_layout_for_display(
-    map: &RenderMap,
-    state: &RenderState,
-    display: DisplayGeometry,
-) -> Option<cursor_overlay::SessionBadgeLayout> {
-    if !state.core.cursor_is_revealed() {
-        return None;
-    }
-    let (x, y) = state.core.pos?;
-    if map.layout.display_at(x, y)?.id != display.id {
-        return None;
-    }
-    let scale = display.backing_scale.max(1.0) as f32;
-    let (width, height) = display.pixel_size();
-    let (delivery, target) = state.core.badge_modifiers.unwrap_or((None, None));
-    cursor_overlay::session_badge_layout(cursor_overlay::SessionBadgeInput {
-        label: state.core.session_label.as_deref(),
-        delivery,
-        target,
-        cursor: (
-            ((x - display.x) * f64::from(scale)) as f32,
-            ((y - display.y) * f64::from(scale)) as f32,
-        ),
-        backing_scale: scale,
-        label_alpha: state.core.session_badge_alpha(),
-        chip_alpha: state.core.session_badge_chip_alpha(),
-        clip: Some((width as f32, height as f32)),
-    })
-}
-
-fn state_pixel_bounds(
-    map: &RenderMap,
-    state: &RenderState,
-    display: DisplayGeometry,
-) -> Option<PixelRect> {
-    if !state.core.cursor_is_revealed() {
-        return None;
-    }
-    let (x, y) = state.core.pos?;
-    let radius = state.core.paint_radius();
-    let mut bounds = logical_rect_to_pixels(
-        (x - radius, y - radius, radius * 2.0, radius * 2.0),
-        display,
-        2.0,
-    );
-    if let Some([x, y, width, height]) = state.focus_rect {
-        if let Some(focus) = logical_rect_to_pixels((x, y, width, height), display, 3.0) {
-            bounds = Some(bounds.map_or(focus, |bounds| bounds.union(focus)));
-        }
-    }
-    if let Some(layout) = badge_layout_for_display(map, state, display) {
-        let rect = layout.rect;
-        let scale = display.backing_scale.max(1.0);
-        let badge = logical_rect_to_pixels(
-            (
-                display.x + f64::from(rect.x()) / scale,
-                display.y + f64::from(rect.y()) / scale,
-                f64::from(rect.width()) / scale,
-                f64::from(rect.height()) / scale,
-            ),
-            display,
-            8.0,
-        );
-        if let Some(badge) = badge {
-            bounds = Some(bounds.map_or(badge, |bounds| bounds.union(badge)));
-        }
-    }
-    bounds
-}
-
-fn state_display_ids(map: &RenderMap, state: &RenderState) -> Vec<DisplayId> {
-    map.layout
-        .displays
-        .iter()
-        .copied()
-        .filter(|display| state_pixel_bounds(map, state, *display).is_some())
-        .map(|display| display.id)
-        .collect()
-}
-
-fn render_display_tile(map: &RenderMap, display: DisplayGeometry) -> Option<RenderedTile> {
-    let bounds = map
-        .cursors
-        .values()
-        .filter_map(|state| state_pixel_bounds(map, state, display))
-        .reduce(PixelRect::union)?;
-    let mut pixmap = tiny_skia::Pixmap::new(bounds.width, bounds.height)?;
-    let scale = display.backing_scale.max(1.0);
-    let origin_x = display.x + f64::from(bounds.x) / scale;
-    let origin_y = display.y + f64::from(bounds.y) / scale;
+/// Displays whose buffers can contain pixels in the current frame. This is
+/// based on painted bounds, not cursor ownership: artwork may span a seam.
+fn painted_display_ids(map: &RenderMap) -> HashSet<DisplayId> {
+    let mut painted = HashSet::new();
     for state in map.cursors.values() {
+        if cursor_is_externally_visible(state) {
+            let (x, y) = state.core.pos;
+            let custom_theme = state
+                .core
+                .theme
+                .as_deref()
+                .is_some_and(|theme| theme.id != cursor_overlay::DEFAULT_THEME_ID);
+            for display in &map.layout.displays {
+                if custom_theme
+                    || rectangles_intersect(
+                        (
+                            x - DEFAULT_CURSOR_PAINT_RADIUS,
+                            y - DEFAULT_CURSOR_PAINT_RADIUS,
+                            DEFAULT_CURSOR_PAINT_RADIUS * 2.0,
+                            DEFAULT_CURSOR_PAINT_RADIUS * 2.0,
+                        ),
+                        *display,
+                    )
+                {
+                    painted.insert(display.id);
+                }
+            }
+        }
+        if let Some([x, y, width, height]) = state.focus_rect {
+            for display in &map.layout.displays {
+                if rectangles_intersect((x, y, width, height), *display) {
+                    painted.insert(display.id);
+                }
+            }
+        }
+    }
+    painted
+}
+
+fn rectangles_intersect(rect: (f64, f64, f64, f64), display: DisplayGeometry) -> bool {
+    let (x, y, width, height) = rect;
+    width > 0.0
+        && height > 0.0
+        && x < display.x + display.width
+        && x + width > display.x
+        && y < display.y + display.height
+        && y + height > display.y
+}
+
+fn render_display(map: &RenderMap, display: DisplayGeometry) -> tiny_skia::Pixmap {
+    let (width, height) = display.pixel_size();
+    let mut pixmap = tiny_skia::Pixmap::new(width, height)
+        .unwrap_or_else(|| tiny_skia::Pixmap::new(1, 1).unwrap());
+    for state in map.cursors.values() {
+        if !cursor_is_externally_visible(state) {
+            continue;
+        }
         let focus = state.focus_rect.map(|rect| FocusRect {
             rect,
             t: state.focus_rect_t,
         });
-        cursor_overlay::paint_cursor_art(
+        let anchor_display = state
+            .placed
+            .then_some(state.core.pos)
+            .and_then(|(x, y)| map.layout.display_at(x, y))
+            .map(|display| display.id);
+        let painter = if anchor_display == Some(display.id) {
+            cursor_overlay::paint_cursor
+        } else {
+            cursor_overlay::paint_cursor_art
+        };
+        painter(
             &mut pixmap,
             &state.core,
-            origin_x,
-            origin_y,
+            display.x,
+            display.y,
             focus,
-            scale as f32,
+            display.backing_scale as f32,
         );
-        if let Some(layout) = badge_layout_for_display(map, state, display) {
-            cursor_overlay::paint_session_badge(
-                &mut pixmap,
-                &layout.translated(-(bounds.x as f32), -(bounds.y as f32)),
-                cursor_overlay::session_fill_rgba(&state.core.cfg.cursor_id),
-                state.core.idle_alpha as f32,
-            );
-        }
     }
-    Some(RenderedTile { bounds, pixmap })
+    pixmap
 }
 
 fn hardware_cursor_position() -> Option<(f64, f64)> {
@@ -1166,18 +1062,9 @@ fn hardware_cursor_position() -> Option<(f64, f64)> {
     Some((location.x, location.y))
 }
 
-struct SurfaceFrame {
-    display_id: DisplayId,
-    tile: Option<RenderedTile>,
+fn cursor_is_externally_visible(state: &RenderState) -> bool {
+    state.placed && state.core.cfg.enabled && state.core.visible && state.core.idle_alpha >= 0.004
 }
-
-struct FrameBatch {
-    generation: u64,
-    surfaces: Vec<SurfaceFrame>,
-}
-
-static PRESENT_MAILBOX: Mutex<Option<FrameBatch>> = Mutex::new(None);
-static PRESENT_SCHEDULED: AtomicBool = AtomicBool::new(false);
 
 type MainWork = Box<dyn FnOnce() + Send>;
 
@@ -1204,67 +1091,29 @@ fn dispatch_on_main(work: MainWork) {
     }
 }
 
-/// Replace the pending presentation batch. At most one batch is queued on the
-/// main thread, so a busy renderer drops stale frames instead of retaining
-/// unbounded image buffers.
-fn queue_present(batch: FrameBatch) {
-    *PRESENT_MAILBOX.lock().unwrap() = Some(batch);
-    schedule_present();
-}
-
-fn schedule_present() {
-    if PRESENT_SCHEDULED.swap(true, Ordering::AcqRel) {
-        return;
-    }
-    dispatch_on_main(Box::new(|| unsafe {
-        if let Some(batch) = PRESENT_MAILBOX.lock().unwrap().take() {
-            present_frames(batch);
-        }
-        PRESENT_SCHEDULED.store(false, Ordering::Release);
-        if PRESENT_MAILBOX.lock().unwrap().is_some() {
-            schedule_present();
-        }
-    }));
-}
-
-unsafe fn present_frames(batch: FrameBatch) {
-    use objc2::{class, msg_send};
-
-    extern "C" {
-        fn CGImageRelease(image: *mut c_void);
-    }
-
-    let host = HOST.lock().unwrap();
-    let Some(host) = host.as_ref() else {
+/// Present one display-local pixmap. AppKit objects remain main-thread-owned;
+/// stale frames are rejected by display-layout generation.
+fn dispatch_present(generation: u64, display_id: DisplayId, pixmap: tiny_skia::Pixmap) {
+    let Some(cg_image_ptr) = pixmap_to_cgimage(&pixmap) else {
         return;
     };
-    if host.generation != batch.generation {
-        return;
-    }
-    let _: () = msg_send![class!(CATransaction), begin];
-    let _: () = msg_send![class!(CATransaction), setDisableActions: true];
-    for frame in batch.surfaces {
-        let Some(surface) = host.surfaces.get(&frame.display_id) else {
-            continue;
-        };
-        let layer = surface.layer_ptr as *mut objc2::runtime::AnyObject;
-        let Some(tile) = frame.tile else {
-            let _: () = objc2::msg_send![layer,
-                setContents: std::ptr::null_mut::<objc2::runtime::AnyObject>()
-            ];
-            continue;
-        };
-        let Some(cg_image_ptr) = pixmap_to_cgimage(&tile.pixmap) else {
-            continue;
-        };
-        let bounds = tile.bounds;
-        let layer_frame = tile_layer_frame(bounds, surface.logical_height, surface.backing_scale);
-        let _: () = objc2::msg_send![layer, setFrame: layer_frame];
-        let image = cg_image_ptr as *mut objc2::runtime::AnyObject;
-        let _: () = objc2::msg_send![layer, setContents: image];
+    dispatch_on_main(Box::new(move || unsafe {
+        extern "C" {
+            fn CGImageRelease(image: *mut c_void);
+        }
+
+        let host = HOST.lock().unwrap();
+        if let Some(surface) = host
+            .as_ref()
+            .filter(|host| host.generation == generation)
+            .and_then(|host| host.surfaces.get(&display_id))
+        {
+            let layer = surface.layer_ptr as *mut objc2::runtime::AnyObject;
+            let image = cg_image_ptr as *mut objc2::runtime::AnyObject;
+            let _: () = objc2::msg_send![layer, setContents: image];
+        }
         CGImageRelease(cg_image_ptr as *mut c_void);
-    }
-    let _: () = msg_send![class!(CATransaction), commit];
+    }));
 }
 
 /// Raise the normal-level overlay without activating the driver application.
@@ -1272,12 +1121,11 @@ unsafe fn present_frames(batch: FrameBatch) {
 /// This is used only for an externally visible cursor with no target window.
 /// Target-bound actions continue to use [`dispatch_pin_above`] so background
 /// delivery remains below unrelated foreground applications.
-fn dispatch_order_front(generation: u64, display_id: DisplayId) {
+fn dispatch_order_front(display_id: DisplayId) {
     dispatch_on_main(Box::new(move || unsafe {
         let host = HOST.lock().unwrap();
         if let Some(surface) = host
             .as_ref()
-            .filter(|host| host.generation == generation)
             .and_then(|host| host.surfaces.get(&display_id))
         {
             let win = surface.win_ptr as *mut objc2::runtime::AnyObject;
@@ -1317,7 +1165,7 @@ fn target_is_frontmost_visible_window(
         .is_some_and(|window| u64::from(window.window_id) == target_wid)
 }
 
-fn dispatch_pin_above(generation: u64, display_id: DisplayId, target_wid: u64) {
+fn dispatch_pin_above(display_id: DisplayId, target_wid: u64) {
     let windows = crate::windows::visible_windows();
     let raise_front =
         target_is_frontmost_visible_window(target_wid, crate::apps::frontmost_pid(), &windows);
@@ -1325,7 +1173,6 @@ fn dispatch_pin_above(generation: u64, display_id: DisplayId, target_wid: u64) {
         let host = HOST.lock().unwrap();
         if let Some(surface) = host
             .as_ref()
-            .filter(|host| host.generation == generation)
             .and_then(|host| host.surfaces.get(&display_id))
         {
             let win = surface.win_ptr as *mut objc2::runtime::AnyObject;
@@ -1335,6 +1182,29 @@ fn dispatch_pin_above(generation: u64, display_id: DisplayId, target_wid: u64) {
             }
         }
     }));
+}
+
+// ── Z-order enforcer (macOS impl of cursor_overlay::ZOrderEnforcer) ──────
+
+/// macOS implementation of [`cursor_overlay::ZOrderEnforcer`].
+///
+/// Identifies the display surface and dispatches target-relative ordering to
+/// the main-thread AppKit host.
+///
+/// `target = None` is treated as a no-op here. Direct unpinned cursor commands
+/// raise the overlay once in the render loop, while this enforcer remains
+/// responsible only for target-relative ordering.
+struct MacZOrderEnforcer {
+    display_id: DisplayId,
+}
+
+impl ZOrderEnforcer for MacZOrderEnforcer {
+    fn reassert(&self, target: Option<u64>) {
+        if let Some(wid) = target {
+            dispatch_pin_above(self.display_id, wid);
+        }
+        // target = None → no-op; see struct doc comment.
+    }
 }
 
 /// Create a `CGImage` from a `tiny_skia::Pixmap` (premultiplied RGBA).
@@ -1446,24 +1316,6 @@ mod tests {
     use std::collections::HashMap;
 
     #[test]
-    fn tile_frame_converts_pixel_top_left_to_appkit_points() {
-        let frame = tile_layer_frame(
-            PixelRect {
-                x: 200,
-                y: 100,
-                width: 400,
-                height: 300,
-            },
-            900.0,
-            2.0,
-        );
-        assert_eq!(frame.origin.x, 100.0);
-        assert_eq!(frame.origin.y, 700.0);
-        assert_eq!(frame.size.width, 200.0);
-        assert_eq!(frame.size.height, 150.0);
-    }
-
-    #[test]
     fn keyed_render_state_carries_the_session_color_identity() {
         let state = render_state_for_key(&CursorConfig::default(), "session-blueprint");
         assert_eq!(state.core.cfg.cursor_id, "session-blueprint");
@@ -1512,7 +1364,7 @@ mod tests {
             },
             active_key: None,
             template: CursorConfig::default(),
-            ended: HashSet::new(),
+            ended: std::collections::HashSet::new(),
         }
     }
 
@@ -1683,17 +1535,18 @@ mod tests {
     }
 
     #[test]
-    fn seed_places_cursor_inside_a_display_for_first_action() {
-        // A brand-new session cursor needs a display-valid start so the first
-        // MoveTo produces a visible glide instead of a zero-length path.
+    fn seed_places_cursor_on_screen_for_first_action() {
+        // BUG 2 regression: a brand-new session cursor without a position must be
+        // seeded on-screen (pos.0 > -50) so the immediately-following MoveTo
+        // glides instead of silently snapping via ClickPulse.
         let mut map = empty_map(); // 100x100 frame
                                    // No "sessA" cursor exists yet — the seed must get-or-create it.
         let seeded = seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
         assert!(seeded, "unplaced cursor must be seeded");
-        let pos = map.cursors["sessA"].core.pos.expect("seeded position");
+        let pos = map.cursors["sessA"].core.pos;
         assert!(
-            map.layout.display_at(pos.0, pos.1).is_some(),
-            "seed must be inside a display, got {pos:?}"
+            pos.0 > -50.0 && pos.1 > -50.0,
+            "seed must be on-screen, got {pos:?}"
         );
         // And it must be a DIFFERENT point from the target so there is a glide.
         assert!(
@@ -1703,16 +1556,19 @@ mod tests {
     }
 
     #[test]
-    fn seed_is_noop_when_cursor_is_already_placed() {
-        // A later action must start from the cursor's current placement.
+    fn seed_is_noop_when_cursor_already_on_screen() {
+        // A second action: the cursor already landed somewhere on-screen, so the
+        // seed must NOT move it (the MoveTo path should start from where it is).
         let mut map = empty_map();
+        // Put sessA on-screen first.
         seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
-        map.cursors.get_mut("sessA").unwrap().core.pos = Some((30.0, 30.0));
+        map.cursors.get_mut("sessA").unwrap().core.pos = (30.0, 30.0);
+        map.cursors.get_mut("sessA").unwrap().placed = true;
         let seeded_again = seed_start_in_map(&mut map, &"sessA".to_owned(), 80.0, 80.0);
-        assert!(!seeded_again, "placed cursor must not be re-seeded");
+        assert!(!seeded_again, "on-screen cursor must not be re-seeded");
         assert_eq!(
             map.cursors["sessA"].core.pos,
-            Some((30.0, 30.0)),
+            (30.0, 30.0),
             "pos must be untouched"
         );
     }
@@ -1721,7 +1577,8 @@ mod tests {
     fn negative_display_coordinates_are_visible_and_not_reseeded() {
         let mut map = empty_map();
         seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
-        map.cursors.get_mut("sessA").unwrap().core.pos = Some((-867.0, 400.0));
+        map.cursors.get_mut("sessA").unwrap().core.pos = (-867.0, 400.0);
+        map.cursors.get_mut("sessA").unwrap().placed = true;
 
         assert!(!seed_start_in_map(
             &mut map,
@@ -1729,8 +1586,8 @@ mod tests {
             80.0,
             80.0
         ));
-        assert_eq!(map.cursors["sessA"].core.pos, Some((-867.0, 400.0)));
-        assert!(map.cursors["sessA"].core.cursor_is_revealed());
+        assert_eq!(map.cursors["sessA"].core.pos, (-867.0, 400.0));
+        assert!(cursor_is_externally_visible(&map.cursors["sessA"]));
     }
 
     #[test]
@@ -1747,39 +1604,12 @@ mod tests {
         };
         map.layout.displays.push(secondary);
         seed_start_in_map(&mut map, &"sessA".to_owned(), -867.0, 400.0);
-        map.cursors.get_mut("sessA").unwrap().core.pos = Some((-867.0, 400.0));
+        map.cursors.get_mut("sessA").unwrap().core.pos = (-867.0, 400.0);
+        map.cursors.get_mut("sessA").unwrap().placed = true;
 
-        let state = &map.cursors["sessA"];
-        assert_eq!(state_display_ids(&map, state), vec![2]);
-        let tile = render_display_tile(&map, secondary).unwrap();
-        assert!(tile.pixmap.data().chunks_exact(4).any(|pixel| pixel[3] > 0));
-        assert!(tile.bounds.width < secondary.pixel_size().0);
-        assert!(tile.bounds.height < secondary.pixel_size().1);
-    }
-
-    #[test]
-    fn bounded_tile_preserves_the_full_display_pixels() {
-        let mut map = empty_map();
-        map.layout.displays[0].width = 1440.0;
-        map.layout.displays[0].height = 900.0;
-        seed_start_in_map(&mut map, &"sessA".to_owned(), 400.0, 400.0);
-        let state = map.cursors.get_mut("sessA").unwrap();
-        state.core.pos = Some((400.0, 400.0));
-        state.apply_command(OverlayCommand::SetSessionLabel("research".to_owned()));
-        let display = map.layout.displays[0];
-
-        let tile = render_display_tile(&map, display).unwrap();
-        let mut full = tiny_skia::Pixmap::new(1440, 900).unwrap();
-        cursor_overlay::paint_cursor(&mut full, &map.cursors["sessA"].core, 0.0, 0.0, None, 1.0);
-        let alpha_sum = |pixels: &[u8]| {
-            pixels
-                .chunks_exact(4)
-                .map(|pixel| u64::from(pixel[3]))
-                .sum::<u64>()
-        };
-        assert_eq!(alpha_sum(tile.pixmap.data()), alpha_sum(full.data()));
-        assert!(tile.bounds.width < display.pixel_size().0 / 4);
-        assert!(tile.bounds.height < display.pixel_size().1 / 4);
+        assert_eq!(painted_display_ids(&map), HashSet::from([2]));
+        let pixmap = render_display(&map, secondary);
+        assert!(pixmap.data().chunks_exact(4).any(|pixel| pixel[3] > 0));
     }
 
     #[test]
@@ -1799,34 +1629,34 @@ mod tests {
         map.layout.displays.push(secondary);
         seed_start_in_map(&mut map, &"sessA".to_owned(), -867.0, 400.0);
 
-        map.cursors.get_mut("sessA").unwrap().core.pos = Some((-1.0, 400.0));
-        assert_eq!(state_display_ids(&map, &map.cursors["sessA"]), vec![1, 2]);
+        map.cursors.get_mut("sessA").unwrap().core.pos = (-1.0, 400.0);
+        map.cursors.get_mut("sessA").unwrap().placed = true;
+        assert_eq!(painted_display_ids(&map), HashSet::from([1, 2]));
         let primary = map.layout.displays[0];
-        let primary_art = render_display_tile(&map, primary).unwrap();
-        let secondary_art = render_display_tile(&map, secondary).unwrap();
-        for tile in [&primary_art, &secondary_art] {
-            assert!(tile.pixmap.data().chunks_exact(4).any(|pixel| pixel[3] > 0));
+        let primary_art = render_display(&map, primary);
+        let secondary_art = render_display(&map, secondary);
+        for pixmap in [&primary_art, &secondary_art] {
+            assert!(pixmap.data().chunks_exact(4).any(|pixel| pixel[3] > 0));
         }
 
         map.cursors
             .get_mut("sessA")
             .unwrap()
             .apply_command(OverlayCommand::SetSessionLabel("research".to_owned()));
-        let primary_with_badge = render_display_tile(&map, primary).unwrap();
-        assert_eq!(primary_with_badge.bounds, primary_art.bounds);
         assert_eq!(
-            primary_with_badge.pixmap.data(),
-            primary_art.pixmap.data(),
+            render_display(&map, primary).data(),
+            primary_art.data(),
             "the neighboring display must not duplicate the anchor display's badge"
         );
-        assert_ne!(
-            render_display_tile(&map, secondary).unwrap().bounds,
-            secondary_art.bounds
-        );
+        assert_ne!(render_display(&map, secondary).data(), secondary_art.data());
 
-        map.cursors.get_mut("sessA").unwrap().core.pos = Some((400.0, 400.0));
-        assert_eq!(state_display_ids(&map, &map.cursors["sessA"]), vec![1]);
-        assert!(render_display_tile(&map, secondary).is_none());
+        map.cursors.get_mut("sessA").unwrap().core.pos = (400.0, 400.0);
+        map.cursors.get_mut("sessA").unwrap().placed = true;
+        assert_eq!(painted_display_ids(&map), HashSet::from([1]));
+        assert!(render_display(&map, secondary)
+            .data()
+            .chunks_exact(4)
+            .all(|pixel| pixel[3] == 0));
     }
 
     #[test]
@@ -1853,27 +1683,20 @@ mod tests {
         );
 
         assert_eq!(
-            z_order_routes(&map),
-            vec![ZOrderRoute {
+            z_order_route(&map),
+            Some(ZOrderRoute {
                 generation: 1,
                 display_id: 1,
                 target_wid: Some(77),
-            }]
+            })
         );
 
-        map.cursors.get_mut("sessA").unwrap().core.pos = Some((-1.0, 400.0));
-        assert_eq!(
-            z_order_routes(&map)
-                .into_iter()
-                .map(|route| route.display_id)
-                .collect::<Vec<_>>(),
-            vec![1, 2]
-        );
+        map.cursors.get_mut("sessA").unwrap().core.pos = (-400.0, 400.0);
+        map.cursors.get_mut("sessA").unwrap().placed = true;
+        assert_eq!(z_order_route(&map).unwrap().display_id, 2);
 
         map.layout.generation = 2;
-        assert!(z_order_routes(&map)
-            .iter()
-            .all(|route| route.generation == 2));
+        assert_eq!(z_order_route(&map).unwrap().generation, 2);
     }
 
     #[test]
@@ -1892,11 +1715,23 @@ mod tests {
 
     #[test]
     fn unplaced_default_cursor_does_not_require_frame_ticks() {
-        // Regression for idle CPU: a freshly-started serve daemon has only an
-        // unplaced default cursor. With no commands in flight, the render loop
+        // Regression for idle CPU: a freshly-started serve daemon seeds only the
+        // off-screen default cursor. With no commands in flight, the render loop
         // should be able to block on rx.recv() instead of repainting at 60fps.
         let map = empty_map();
         assert!(!render_map_needs_frame_tick(&map));
+    }
+
+    #[test]
+    fn only_enabled_on_screen_cursor_is_externally_visible() {
+        let mut map = empty_map();
+        assert!(!cursor_is_externally_visible(&map.cursors["default"]));
+
+        seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
+        assert!(cursor_is_externally_visible(&map.cursors["sessA"]));
+
+        map.cursors.get_mut("sessA").unwrap().core.cfg.enabled = false;
+        assert!(!cursor_is_externally_visible(&map.cursors["sessA"]));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
@@ -25,7 +25,7 @@
 //! Animation state + render pipeline live in `cursor_overlay::render_state`
 //! (`RenderStateCore`, `tick_swift_constants`, `apply_command_base`,
 //! `render_frame`).  macOS uses the hardcoded Swift reference constants
-//! (peakSpeed=900, springK=400, overshoot=0.8) and the sentinel-snap
+//! (peakSpeed=900, springK=400, overshoot=0.8) and first-placement
 //! variants of MoveTo / ClickPulse — see the wrapper around
 //! `apply_command_base` below.
 
@@ -313,19 +313,19 @@ pub fn current_theme_state(
     Some((id, version, profile, fallback, state.core.visual.clone()))
 }
 
-/// Seed a brand-new (sentinel-positioned) cursor at an on-screen start point
+/// Seed a brand-new cursor at an on-screen start point
 /// offset up-left of `(target_x, target_y)` so the immediately-following
 /// `MoveTo` glides INTO the target instead of silently snapping. Without this,
 /// a cursor's very first action (common on a pure-AX run — launch app, AX-press
 /// a button) produces no visible motion: `animate_cursor_to` early-returned at
-/// the sentinel and only `ClickPulse` snapped a static arrow, which is easy to
+/// no position and only `ClickPulse` placed a static arrow, which is easy to
 /// miss. See the AX-no-glide report.
 ///
-/// No-op when the cursor is already on-screen (pos.0 > -50.0) or absent. The
+/// No-op when the cursor is already placed or absent. The
 /// seed is clamped to the main screen frame so it never starts off-display.
-/// Returns true if a seed was applied (i.e. the cursor was at the sentinel and
+/// Returns true if a seed was applied (i.e. the cursor was unplaced and
 /// is now primed to glide).
-fn seed_start_if_sentinel(key: &CursorKey, target_x: f64, target_y: f64) -> bool {
+fn seed_start_if_unplaced(key: &CursorKey, target_x: f64, target_y: f64) -> bool {
     let mut guard = RENDER.lock().unwrap();
     let Some(map) = guard.as_mut() else {
         return false;
@@ -334,7 +334,7 @@ fn seed_start_if_sentinel(key: &CursorKey, target_x: f64, target_y: f64) -> bool
 }
 
 /// Pure seed step operating on a borrowed [`RenderMap`] — factored out of
-/// `seed_start_if_sentinel` so the get-or-create + clamp logic is unit-testable
+/// `seed_start_if_unplaced` so the get-or-create + clamp logic is unit-testable
 /// without the global `RENDER` static or AppKit.
 fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target_y: f64) -> bool {
     // Offset the start up-left of the target so the Dubins path has room to
@@ -356,7 +356,7 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
         .cursors
         .entry(key.clone())
         .or_insert_with(|| render_state_for_key(&template, &k));
-    if !(rs.core.cfg.enabled && rs.core.pos.0 < -50.0) {
+    if !(rs.core.cfg.enabled && rs.core.pos.is_none()) {
         return false;
     }
     let mut sx = target_x - SEED_OFFSET;
@@ -374,7 +374,7 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
             sy = (target_y + SEED_OFFSET).min(win_h - 2.0);
         }
     }
-    rs.core.pos = (sx, sy);
+    rs.core.pos = Some((sx, sy));
     true
 }
 
@@ -383,8 +383,8 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
 ///
 /// Mirrors Swift's `AgentCursor.shared.animateAndWait(to:)`.
 /// Returns immediately (no animation) only when the overlay is disabled for
-/// this cursor. A brand-new cursor still at the off-screen sentinel is first
-/// seeded on-screen via [`seed_start_if_sentinel`] so its FIRST action glides
+/// this cursor. A brand-new cursor is first seeded on-screen via
+/// [`seed_start_if_unplaced`] so its first action glides
 /// in (it previously snapped silently via `ClickPulse`, invisible on a pure-AX
 /// run).
 pub async fn animate_cursor_to(key: CursorKey, x: f64, y: f64) {
@@ -392,10 +392,10 @@ pub async fn animate_cursor_to(key: CursorKey, x: f64, y: f64) {
     if key.is_empty() {
         return;
     }
-    // Seed a sentinel cursor on-screen so the MoveTo below glides instead of
-    // being short-circuited. After this the cursor's pos.0 > -50.0, so the
-    // should-animate check passes on the first action just like later ones.
-    seed_start_if_sentinel(&key, x, y);
+    // Seed an unplaced cursor on-screen so the MoveTo below glides instead of
+    // being short-circuited. After this the cursor has a position, so
+    // the should-animate check passes on the first action just like later ones.
+    seed_start_if_unplaced(&key, x, y);
 
     // Check whether animation should run for THIS cursor. A disabled cursor
     // never animates; an absent cursor (seed found nothing to prime) is skipped.
@@ -403,7 +403,7 @@ pub async fn animate_cursor_to(key: CursorKey, x: f64, y: f64) {
         let guard = RENDER.lock().unwrap();
         matches!(
             guard.as_ref().and_then(|m| m.cursors.get(&key)),
-            Some(rs) if rs.core.cfg.enabled && rs.core.pos.0 > -50.0
+            Some(rs) if rs.core.cfg.enabled && rs.core.pos.is_some()
         )
     };
     if !should_animate {
@@ -529,25 +529,21 @@ impl RenderState {
     }
 
     fn apply_command(&mut self, cmd: OverlayCommand) {
-        // macOS uses the sentinel-snap variants of MoveTo / ClickPulse:
-        //   - MoveTo only snaps `self.pos` if the cursor is still at the
-        //     off-screen sentinel `(-200, -200)` (otherwise the path starts
-        //     from the current position so the animation is continuous).
-        //   - ClickPulse only updates `self.pos` if the cursor is still at
-        //     the sentinel (otherwise the animation already landed it there).
+        // A macOS click pulse preserves the position reached by its glide.
+        // The shared core places an unplaced cursor on first use.
         match cmd {
             OverlayCommand::ShowFocusRect(rect) => {
                 self.focus_rect = rect;
                 self.focus_rect_t = 0.0; // reset fade to fully visible
             }
             other => {
-                let _ = self.core.apply_command_base(other, true, true);
+                let _ = self.core.apply_command_base(other, false);
             }
         }
     }
 
     /// True while the render loop must wake at frame cadence because the next
-    /// tick can change pixels. A brand-new sentinel cursor is deliberately
+    /// tick can change pixels. A brand-new unplaced cursor is deliberately
     /// quiescent, so `serve` with no agent activity can block on the command
     /// channel instead of compositing an empty fullscreen pixmap at 60fps.
     fn needs_frame_tick(&self) -> bool {
@@ -556,10 +552,7 @@ impl RenderState {
             || self.core.click_t.is_some()
             || self.focus_rect.is_some()
             || self.core.session_badge_needs_frame_tick()
-            || (self.core.motion.idle_hide_ms > 0.0
-                && self.core.visible
-                && self.core.pos.0 >= -100.0
-                && self.core.idle_alpha >= 0.004)
+            || (self.core.motion.idle_hide_ms > 0.0 && self.core.cursor_is_revealed())
     }
 }
 
@@ -926,11 +919,7 @@ fn hardware_cursor_position() -> Option<(f64, f64)> {
 }
 
 fn cursor_is_externally_visible(state: &RenderState) -> bool {
-    state.core.cfg.enabled
-        && state.core.visible
-        && state.core.pos.0 > -50.0
-        && state.core.pos.1 > -50.0
-        && state.core.idle_alpha >= 0.004
+    state.core.cfg.enabled && state.core.cursor_is_revealed()
 }
 
 /// Convert a `tiny_skia::Pixmap` to a `CGImage` and set it as the contents
@@ -1446,15 +1435,15 @@ mod tests {
     }
 
     #[test]
-    fn seed_moves_sentinel_cursor_on_screen_for_first_action() {
-        // BUG 2 regression: a brand-new session cursor at the sentinel must be
+    fn seed_places_cursor_on_screen_for_first_action() {
+        // BUG 2 regression: a brand-new session cursor without a position must be
         // seeded on-screen (pos.0 > -50) so the immediately-following MoveTo
         // glides instead of silently snapping via ClickPulse.
         let mut map = empty_map(); // 100x100 frame
                                    // No "sessA" cursor exists yet — the seed must get-or-create it.
         let seeded = seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
-        assert!(seeded, "sentinel cursor must be seeded");
-        let pos = map.cursors["sessA"].core.pos;
+        assert!(seeded, "unplaced cursor must be seeded");
+        let pos = map.cursors["sessA"].core.pos.expect("seeded position");
         assert!(
             pos.0 > -50.0 && pos.1 > -50.0,
             "seed must be on-screen, got {pos:?}"
@@ -1473,14 +1462,30 @@ mod tests {
         let mut map = empty_map();
         // Put sessA on-screen first.
         seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
-        map.cursors.get_mut("sessA").unwrap().core.pos = (30.0, 30.0);
+        map.cursors.get_mut("sessA").unwrap().core.pos = Some((30.0, 30.0));
         let seeded_again = seed_start_in_map(&mut map, &"sessA".to_owned(), 80.0, 80.0);
         assert!(!seeded_again, "on-screen cursor must not be re-seeded");
         assert_eq!(
             map.cursors["sessA"].core.pos,
-            (30.0, 30.0),
+            Some((30.0, 30.0)),
             "pos must be untouched"
         );
+    }
+
+    #[test]
+    fn negative_display_coordinates_are_visible_and_not_reseeded() {
+        let mut map = empty_map();
+        seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
+        map.cursors.get_mut("sessA").unwrap().core.pos = Some((-867.0, 400.0));
+
+        assert!(!seed_start_in_map(
+            &mut map,
+            &"sessA".to_owned(),
+            80.0,
+            80.0
+        ));
+        assert_eq!(map.cursors["sessA"].core.pos, Some((-867.0, 400.0)));
+        assert!(cursor_is_externally_visible(&map.cursors["sessA"]));
     }
 
     #[test]
@@ -1498,7 +1503,7 @@ mod tests {
     }
 
     #[test]
-    fn sentinel_default_cursor_does_not_require_frame_ticks() {
+    fn unplaced_default_cursor_does_not_require_frame_ticks() {
         // Regression for idle CPU: a freshly-started serve daemon seeds only the
         // off-screen default cursor. With no commands in flight, the render loop
         // should be able to block on rx.recv() instead of repainting at 60fps.

--- a/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
@@ -365,7 +365,7 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
         .cursors
         .entry(key.clone())
         .or_insert_with(|| render_state_for_key(&template, &k));
-    if !(rs.core.visible && rs.core.pos.is_none()) {
+    if !(rs.core.cfg.enabled && rs.core.pos.is_none()) {
         return false;
     }
     let mut sx = target_x - SEED_OFFSET;
@@ -413,7 +413,7 @@ pub async fn animate_cursor_to(key: CursorKey, x: f64, y: f64) {
         let guard = RENDER.lock().unwrap();
         matches!(
             guard.as_ref().and_then(|m| m.cursors.get(&key)),
-            Some(rs) if rs.core.visible && rs.core.pos.is_some()
+            Some(rs) if rs.core.cfg.enabled && rs.core.pos.is_some()
         )
     };
     if !should_animate {

--- a/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
@@ -7,18 +7,19 @@
 //! The two sides communicate through a global lock-free channel:
 //!
 //! - MCP tool calls → `send_command(OverlayCommand)` → `CMD_TX` (SyncSender)
-//! - main thread → `run_on_main_thread()` → drains `CMD_RX` every frame
+//! - render worker → per-display pixmaps → main-thread `AppKitOverlayHost`
 //!
-//! The render loop uses a GCD background thread at ~60 fps.  Each tick it
-//! renders the animation state into a `tiny_skia::Pixmap`, converts to a
-//! `CGImage`, and dispatches `CALayer.setContents` back to the main queue.
+//! One shared render map owns cursor state. The AppKit host owns one transparent
+//! presentation surface per active display and replaces that surface set after
+//! display-layout changes.
 //!
 //! ## Coordinate system
 //!
 //! All coordinates are **screen points** with the **top-left origin**
 //! (matching `OverlayCommand::MoveTo` and AX element coordinates).  The
-//! NSWindow covers `NSScreen.mainScreen.frame` which AppKit places with
-//! a bottom-left origin, so we flip Y when drawing into the Pixmap.
+//! Display geometry records both CoreGraphics' global top-left frame and the
+//! corresponding AppKit bottom-left window frame. Rendering subtracts each
+//! display's global origin and uses that display's backing scale.
 //!
 //! ## Cross-platform note (2026-05 dedup audit)
 //!
@@ -29,8 +30,9 @@
 //! variants of MoveTo / ClickPulse — see the wrapper around
 //! `apply_command_base` below.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ffi::c_void;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -39,6 +41,8 @@ use cursor_overlay::{
     OverlayMsg, RenderStateCore, ZOrderEnforcer,
 };
 use indexmap::IndexMap;
+
+use super::display_layout::{DisplayGeometry, DisplayId, DisplayLayout, GlobalPoint};
 
 // ── Arrival-signal channels (one waiter slot per cursor key) ──────────────
 //
@@ -70,25 +74,26 @@ fn arrival_fire(key: &CursorKey) {
 
 // ── Global overlay state ──────────────────────────────────────────────────
 
-static CMD_TX: OnceLock<std::sync::mpsc::SyncSender<OverlayMsg>> = OnceLock::new();
+enum MacOverlayMsg {
+    Cursor(OverlayMsg),
+    DisplaysChanged,
+}
+
+static CMD_TX: OnceLock<std::sync::mpsc::SyncSender<MacOverlayMsg>> = OnceLock::new();
 // Single-consumer slot; receiver is moved into run_on_main_thread().
-static CMD_RX_CELL: Mutex<Option<std::sync::mpsc::Receiver<OverlayMsg>>> = Mutex::new(None);
+static CMD_RX_CELL: Mutex<Option<std::sync::mpsc::Receiver<MacOverlayMsg>>> = Mutex::new(None);
 static RENDER: Mutex<Option<RenderMap>> = Mutex::new(None);
+static HOST: Mutex<Option<AppKitOverlayHost>> = Mutex::new(None);
+static DISPLAY_GENERATION: AtomicU64 = AtomicU64::new(0);
+static REBUILD_PENDING: AtomicBool = AtomicBool::new(false);
 
 /// The keyed, insertion-ordered collection of owned cursors that the render
 /// loop composites every frame. Insertion order = stable z-order (later keys
-/// paint on top). `win_w` / `win_h` are screen-global, hoisted out of the
-/// per-cursor `RenderState` (written once in `run_appkit`).
+/// paint on top). Display geometry is explicit and replaceable; cursor state
+/// never owns an AppKit window or assumes a main-screen origin.
 struct RenderMap {
     cursors: IndexMap<CursorKey, RenderState>,
-    win_w: f64,
-    win_h: f64,
-    /// `NSScreen.backingScaleFactor` of the screen the overlay window sits on.
-    /// 1.0 on a non-retina display, 2.0 on a typical retina Mac. Drives the
-    /// physical-pixel pixmap sizing + `paint_cursor` `backing_scale` so the
-    /// rendered cursor is crisp at native resolution instead of being
-    /// bilinear-upsampled by Core Animation from a logical-pixel buffer.
-    backing_scale: f64,
+    layout: DisplayLayout,
     /// Frozen launch-time config used as the template for lazily-created cursors.
     template: CursorConfig,
     /// Render-side tombstone of ended session cursor keys. A `Cmd`
@@ -173,9 +178,7 @@ pub fn init(cfg: CursorConfig) {
         cursors.insert("default".to_owned(), RenderState::new(cfg.clone()));
         *RENDER.lock().unwrap() = Some(RenderMap {
             cursors,
-            win_w: 0.0,
-            win_h: 0.0,
-            backing_scale: 1.0, // overwritten in run_appkit() once the NSScreen is known
+            layout: DisplayLayout::default(),
             template: cfg,
             ended: std::collections::HashSet::new(),
         });
@@ -226,7 +229,9 @@ pub fn send_command(key: CursorKey, cmd: OverlayCommand) {
         return;
     }
     if let Some(tx) = CMD_TX.get() {
-        let _ = tx.try_send(OverlayMsg::Cmd(KeyedOverlayCommand { key, cmd }));
+        let _ = tx.try_send(MacOverlayMsg::Cursor(OverlayMsg::Cmd(
+            KeyedOverlayCommand { key, cmd },
+        )));
     }
 }
 
@@ -261,7 +266,7 @@ pub fn remove_cursor(key: CursorKey) {
         return;
     }
     if let Some(tx) = CMD_TX.get() {
-        let _ = tx.try_send(OverlayMsg::Remove(key));
+        let _ = tx.try_send(MacOverlayMsg::Cursor(OverlayMsg::Remove(key)));
     }
 }
 
@@ -272,7 +277,7 @@ pub fn revive_cursor(key: CursorKey) {
         return;
     }
     if let Some(tx) = CMD_TX.get() {
-        let _ = tx.try_send(OverlayMsg::Revive(key));
+        let _ = tx.try_send(MacOverlayMsg::Cursor(OverlayMsg::Revive(key)));
     }
 }
 
@@ -321,8 +326,8 @@ pub fn current_theme_state(
 /// no position and only `ClickPulse` placed a static arrow, which is easy to
 /// miss. See the AX-no-glide report.
 ///
-/// No-op when the cursor is already placed or absent. The
-/// seed is clamped to the main screen frame so it never starts off-display.
+/// No-op when the cursor is already placed or absent. The seed is clamped to
+/// the display containing the target so it never starts off-display.
 /// Returns true if a seed was applied (i.e. the cursor was unplaced and
 /// is now primed to glide).
 fn seed_start_if_unplaced(key: &CursorKey, target_x: f64, target_y: f64) -> bool {
@@ -340,7 +345,10 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
     // Offset the start up-left of the target so the Dubins path has room to
     // curve in; 140pt is enough to read as motion at 900pt/s peak speed.
     const SEED_OFFSET: f64 = 140.0;
-    let (win_w, win_h) = (map.win_w, map.win_h);
+    let target_display = map.layout.display_for_or_primary(GlobalPoint {
+        x: target_x,
+        y: target_y,
+    });
     // Respect the resurrection guard: never seed (and thus re-create) a cursor
     // whose session already ended.
     if map.ended.contains(key) {
@@ -361,17 +369,18 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
     }
     let mut sx = target_x - SEED_OFFSET;
     let mut sy = target_y - SEED_OFFSET;
-    // Clamp into the screen frame when we know it (win_w/h are 0 until the
-    // AppKit window is up; in that headless case the unclamped seed is still
-    // on-screen-by-construction for any realistic target).
-    if win_w > 0.0 && win_h > 0.0 {
-        sx = sx.clamp(2.0, win_w - 2.0);
-        sy = sy.clamp(2.0, win_h - 2.0);
+    if let Some(display) = target_display {
+        let min_x = display.x + 2.0;
+        let min_y = display.y + 2.0;
+        let max_x = display.x + display.width - 2.0;
+        let max_y = display.y + display.height - 2.0;
+        sx = sx.clamp(min_x, max_x);
+        sy = sy.clamp(min_y, max_y);
         // If clamping collapsed the seed onto the target (target in a corner),
         // nudge it the other way so there is still a visible glide distance.
         if (sx - target_x).abs() < 8.0 && (sy - target_y).abs() < 8.0 {
-            sx = (target_x + SEED_OFFSET).min(win_w - 2.0);
-            sy = (target_y + SEED_OFFSET).min(win_h - 2.0);
+            sx = (target_x + SEED_OFFSET).min(max_x);
+            sy = (target_y + SEED_OFFSET).min(max_y);
         }
     }
     rs.core.pos = Some((sx, sy));
@@ -562,63 +571,65 @@ fn render_map_needs_frame_tick(map: &RenderMap) -> bool {
 
 // ── AppKit / CGImage plumbing ─────────────────────────────────────────────
 
-unsafe fn run_appkit(_cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMsg>) {
-    use objc2::runtime::AnyObject;
-    use objc2::{class, msg_send};
-    use objc2_foundation::NSRect;
+struct NativeSurface {
+    win_ptr: usize,
+    layer_ptr: usize,
+}
 
-    // ---- NSApplication ----
-    // Verify main thread (MainThreadMarker is a zero-size compile-time token).
-    let _mtm = objc2_foundation::MainThreadMarker::new()
-        .expect("run_appkit must be called from the main thread");
+struct AppKitOverlayHost {
+    generation: u64,
+    surfaces: HashMap<DisplayId, NativeSurface>,
+}
 
-    let app: *mut AnyObject = msg_send![class!(NSApplication), sharedApplication];
-    // NSApplicationActivationPolicyAccessory = 1 (no Dock icon, no menu bar)
-    // setActivationPolicy: returns BOOL (success), not void.
-    let _: bool = msg_send![app, setActivationPolicy: 1i64];
-    // Finish launching without presenting a UI (needed for NSApp.run())
-    let _: () = msg_send![app, finishLaunching];
-
-    // ---- Main screen frame ----
-    let main_screen: *mut AnyObject = msg_send![class!(NSScreen), mainScreen];
-    if main_screen.is_null() {
-        // Headless environment (CI without display) — skip overlay entirely.
-        // The MCP server continues on the background thread.
-        return;
+impl AppKitOverlayHost {
+    unsafe fn create(layout: &DisplayLayout) -> Option<Self> {
+        let primary_height = layout.primary_height()?;
+        let mut surfaces = HashMap::new();
+        for geometry in &layout.displays {
+            let Some(surface) = create_native_surface(*geometry, primary_height) else {
+                Self {
+                    generation: layout.generation,
+                    surfaces,
+                }
+                .close();
+                return None;
+            };
+            surfaces.insert(geometry.id, surface);
+        }
+        Some(Self {
+            generation: layout.generation,
+            surfaces,
+        })
     }
-    let screen_frame: NSRect = msg_send![main_screen, frame];
-    let win_w = screen_frame.size.width;
-    let win_h = screen_frame.size.height;
-    // NSScreen.backingScaleFactor is the most direct source of truth — it's
-    // what AppKit will use for the layer's native backing surface anyway.
-    // Fall back to the CG estimator (current-mode pixels ÷ points) when
-    // the AppKit call returns a non-positive value, since downstream paint
-    // math divides by this and a 0.0 would zero out the cursor.
-    let mut backing_scale: f64 = msg_send![main_screen, backingScaleFactor];
-    if backing_scale.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
-        use core_graphics::display::CGMainDisplayID;
-        let display_id = CGMainDisplayID();
-        backing_scale = crate::tools::get_screen_size::get_backing_scale(display_id);
-        if backing_scale.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
-            backing_scale = 1.0;
+
+    unsafe fn close(self) {
+        use objc2::runtime::AnyObject;
+        for surface in self.surfaces.into_values() {
+            let win = surface.win_ptr as *mut AnyObject;
+            let _: () = objc2::msg_send![win, orderOut: std::ptr::null_mut::<AnyObject>()];
+            let _: () = objc2::msg_send![win, setReleasedWhenClosed: true];
+            let _: () = objc2::msg_send![win, close];
         }
     }
+}
 
-    // ---- NSWindow: single alloc + initWithContentRect:... ----
-    let win: *mut AnyObject = {
-        let allocated: *mut AnyObject = msg_send![class!(NSWindow), alloc];
-        // NSWindowStyleMaskBorderless = 0
-        // NSBackingStoreBuffered = 2
-        let w: *mut AnyObject = msg_send![allocated,
-            initWithContentRect: screen_frame
-            styleMask: 0u64
-            backing: 2u64
-            defer: false
-        ];
-        w
-    };
+unsafe fn create_native_surface(
+    geometry: DisplayGeometry,
+    primary_height: f64,
+) -> Option<NativeSurface> {
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send};
+
+    let frame = geometry.appkit_frame(primary_height);
+    let allocated: *mut AnyObject = msg_send![class!(NSWindow), alloc];
+    let win: *mut AnyObject = msg_send![allocated,
+        initWithContentRect: frame
+        styleMask: 0u64
+        backing: 2u64
+        defer: false
+    ];
     if win.is_null() {
-        return;
+        return None;
     }
 
     let _: () = msg_send![win, setOpaque: false];
@@ -626,84 +637,123 @@ unsafe fn run_appkit(_cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
     let _: () = msg_send![win, setBackgroundColor: clear];
     let _: () = msg_send![win, setHasShadow: false];
     let _: () = msg_send![win, setIgnoresMouseEvents: true];
-    // NSWindowSharingReadOnly = 1. AppKit documents this as the default, but
-    // set it explicitly for the transparent agent overlay so ScreenCaptureKit
-    // includes browser-session cursors in Cua Driver recordings. Tahoe can
-    // otherwise show the overlay live while omitting it from an in-process
-    // display recording.
     let _: () = msg_send![win, setSharingType: 1u64];
-    // NSNormalWindowLevel = 0.  The overlay lives at the normal window level so
-    // it appears in CGWindowList layer=0 results (which agents inspect via
-    // list_windows).  Z-ordering above the target is managed dynamically via
-    // orderWindow:relativeTo: (see dispatch_pin_above / render_loop repin).
     let _: () = msg_send![win, setLevel: 0i64];
-    // NSWindowCollectionBehaviorCanJoinAllSpaces(1<<0) | FullScreenAuxiliary(1<<8) | Stationary(1<<4)
-    let _: () = msg_send![win, setCollectionBehavior: (1u64 | (1<<8) | (1<<4))];
+    let _: () = msg_send![win, setCollectionBehavior: (1u64 | (1 << 8) | (1 << 4))];
     let _: () = msg_send![win, setReleasedWhenClosed: false];
     let _: () = msg_send![win, setHidesOnDeactivate: false];
 
-    // ---- Layer-backed content view ----
     let content_view: *mut AnyObject = msg_send![win, contentView];
     let _: () = msg_send![content_view, setWantsLayer: true];
     let layer: *mut AnyObject = msg_send![content_view, layer];
-
-    // Set layer geometry. contentsScale tells Core Animation that the CGImage
-    // we hand to setContents: is already at retina (`backing_scale`×) pixel
-    // density — without this, CA would treat our physical-pixel pixmap as a
-    // 1× asset and bilinear-downsample it back to logical pixels on screen,
-    // re-introducing the blur this pipeline exists to eliminate.
-    let _: () = msg_send![layer, setContentsScale: backing_scale];
-    // kCAGravityTopLeft — the string literal "topLeft"
+    let _: () = msg_send![layer, setContentsScale: geometry.backing_scale.max(1.0)];
     let gravity_ns: *mut AnyObject = msg_send![class!(NSString),
         stringWithUTF8String: c"topLeft".as_ptr().cast::<u8>()
     ];
     let _: () = msg_send![layer, setContentsGravity: gravity_ns];
-
-    // ---- Update RenderMap header with screen size (screen-global) ----
-    {
-        let mut guard = RENDER.lock().unwrap();
-        if let Some(m) = guard.as_mut() {
-            m.win_w = win_w;
-            m.win_h = win_h;
-            m.backing_scale = backing_scale;
-        }
-    }
-
-    // ---- Show the window ----
     let _: () = msg_send![win, orderFrontRegardless];
 
-    // ---- Render thread (60 fps) ----
-    let layer_ptr = layer as usize;
-    let win_ptr = win as usize;
-    std::thread::spawn(move || {
-        render_loop(layer_ptr, win_ptr, rx, win_w, win_h);
-    });
+    Some(NativeSurface {
+        win_ptr: win as usize,
+        layer_ptr: layer as usize,
+    })
+}
 
-    // ---- NSApplication run loop (blocks until process exits) ----
+unsafe fn rebuild_appkit_host() -> bool {
+    let generation = DISPLAY_GENERATION.fetch_add(1, Ordering::AcqRel) + 1;
+    let layout = match super::display_layout::active_layout(generation) {
+        Ok(layout) if !layout.displays.is_empty() => layout,
+        Ok(_) => return false,
+        Err(error) => {
+            tracing::warn!(
+                error,
+                "macOS cursor overlay could not enumerate active displays"
+            );
+            return false;
+        }
+    };
+    let Some(host) = AppKitOverlayHost::create(&layout) else {
+        tracing::warn!("macOS cursor overlay could not create every display surface");
+        return false;
+    };
+
+    if let Some(map) = RENDER.lock().unwrap().as_mut() {
+        map.layout = layout;
+    }
+    let previous = HOST.lock().unwrap().replace(host);
+    if let Some(previous) = previous {
+        previous.close();
+    }
+    true
+}
+
+unsafe fn run_appkit(_cfg: CursorConfig, rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send};
+
+    let _mtm = objc2_foundation::MainThreadMarker::new()
+        .expect("run_appkit must be called from the main thread");
+
+    let app: *mut AnyObject = msg_send![class!(NSApplication), sharedApplication];
+    let _: bool = msg_send![app, setActivationPolicy: 1i64];
+    let _: () = msg_send![app, finishLaunching];
+
+    if !rebuild_appkit_host() {
+        return;
+    }
+    register_display_reconfiguration_callback();
+
+    std::thread::spawn(move || render_loop(rx));
     let _: () = msg_send![app, run];
 }
 
-fn render_loop(
-    layer_ptr: usize,
-    win_ptr: usize,
-    rx: std::sync::mpsc::Receiver<OverlayMsg>,
-    _win_w: f64,
-    _win_h: f64,
-) {
-    let target_frame_ms = Duration::from_millis(16); // ~60 fps while pixels can change
+fn register_display_reconfiguration_callback() {
+    use core_graphics::display::CGDisplayRegisterReconfigurationCallback;
+
+    unsafe extern "C" fn changed(_display: u32, flags: u32, _context: *const c_void) {
+        use core_graphics::display::CGDisplayChangeSummaryFlags;
+        if flags & CGDisplayChangeSummaryFlags::kCGDisplayBeginConfigurationFlag.bits() != 0 {
+            return;
+        }
+        dispatch_rebuild_appkit_host();
+    }
+
+    let result = unsafe { CGDisplayRegisterReconfigurationCallback(changed, std::ptr::null()) };
+    if result != 0 {
+        tracing::warn!(
+            result,
+            "macOS cursor overlay could not observe display changes"
+        );
+    }
+}
+
+fn dispatch_rebuild_appkit_host() {
+    if REBUILD_PENDING.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    dispatch_on_main(Box::new(|| unsafe {
+        let rebuilt = rebuild_appkit_host();
+        REBUILD_PENDING.store(false, Ordering::Release);
+        if rebuilt {
+            if let Some(tx) = CMD_TX.get() {
+                let _ = tx.try_send(MacOverlayMsg::DisplaysChanged);
+            }
+        }
+    }));
+}
+
+fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
+    let target_frame_ms = Duration::from_millis(16);
     let hover_poll_ms = Duration::from_millis(80);
     let mut last_tick = Instant::now();
     let mut frame_tick_needed = false;
     let mut hover_poll_needed = false;
-    // Repin bookkeeping: track last pinned wid and a frame counter for
-    // the periodic defensive-repin (every ~60 active frames ≈ 1 s).
     let mut last_pinned: Option<u64> = None;
+    let mut last_display: Option<DisplayId> = None;
     let mut repin_frames: u32 = 0;
+    let mut previously_active = HashSet::<DisplayId>::new();
 
     loop {
-        // When no cursor animation/fade is active, block until the MCP side
-        // sends a command. This is the idle-server fast path: no fullscreen
-        // pixmap allocation, no CGImage conversion, no 60fps wakeup.
         let (first_msg, hover_poll_tick) = if frame_tick_needed {
             (None, hover_poll_needed)
         } else if hover_poll_needed {
@@ -722,188 +772,220 @@ fn render_loop(
         let woke_from_idle = first_msg.is_some();
         let now = Instant::now();
         let dt = if woke_from_idle {
-            // The blocking recv() above can span an arbitrarily long idle period.
-            // Do not charge that time to the first animation tick after a command;
-            // let the wake-up frame render the newly-applied state at t=0.
             0.0
         } else {
             now.duration_since(last_tick).as_secs_f64().min(0.05)
         };
         last_tick = now;
 
-        // ── Phase 1: drain + tick all cursors (one lock acquisition) ──────
-        // `pinned_wid` follows the most-recently-updated cursor: a single
-        // NSWindow can occupy only one z-band, so the last-active cursor's
-        // target wins. `arrived` collects the keys whose path just ended.
         let (
             pinned_wid,
+            active_display,
             raise_unpinned,
             arrived,
-            win_w,
-            win_h,
             had_msg,
+            layout_changed,
             hover_changed,
             next_frame_tick_needed,
             next_hover_poll_needed,
         ) = {
             let mut guard = RENDER.lock().unwrap();
-            match guard.as_mut() {
-                Some(map) => {
-                    // Drain via get-or-create; track the last-touched key so we
-                    // can read its pinned_wid after ticking.
-                    let mut last_key: Option<CursorKey> = None;
-                    let mut had_msg = false;
-                    if let Some(msg) = first_msg {
-                        had_msg = true;
-                        if let Some(k) = apply_msg(map, msg) {
-                            last_key = Some(k);
-                        }
-                    }
-                    while let Ok(msg) = rx.try_recv() {
-                        had_msg = true;
-                        if let Some(k) = apply_msg(map, msg) {
-                            last_key = Some(k);
-                        }
-                    }
-                    // Tick every cursor while an animation/fade is in progress
-                    // or immediately after a command changed render state. The
-                    // latter lets a just-created path/click/focus rect start on
-                    // this frame without waiting for the next 16ms tick.
-                    let mut arrived: Vec<CursorKey> = Vec::new();
-                    if frame_tick_needed || had_msg {
-                        for (k, rs) in map.cursors.iter_mut() {
-                            if rs.tick(dt) {
-                                arrived.push(k.clone());
-                            }
-                        }
-                    }
-                    let pointer = if hover_poll_tick
-                        || map
-                            .cursors
-                            .values()
-                            .any(|rs| rs.core.session_badge_needs_hover_poll())
-                    {
-                        hardware_cursor_position()
-                    } else {
-                        None
-                    };
-                    let mut hover_changed = false;
-                    if pointer.is_some() || hover_poll_tick {
-                        for rs in map.cursors.values_mut() {
-                            hover_changed |= rs.core.update_session_badge_hover(pointer);
-                        }
-                    }
-                    let pinned = last_key
-                        .as_ref()
-                        .and_then(|k| map.cursors.get(k))
-                        .map(|rs| rs.core.pinned_wid)
-                        .unwrap_or(last_pinned);
-                    let raise_unpinned = last_key
-                        .as_ref()
-                        .and_then(|k| map.cursors.get(k))
-                        .is_some_and(cursor_is_externally_visible)
-                        && pinned.is_none();
-                    let next_frame_tick_needed = render_map_needs_frame_tick(map);
-                    let next_hover_poll_needed = map
-                        .cursors
-                        .values()
-                        .any(|rs| rs.core.session_badge_needs_hover_poll());
-                    (
-                        pinned,
-                        raise_unpinned,
-                        arrived,
-                        map.win_w,
-                        map.win_h,
-                        had_msg,
-                        hover_changed,
-                        next_frame_tick_needed,
-                        next_hover_poll_needed,
-                    )
-                }
-                None => break,
-            }
-        };
+            let Some(map) = guard.as_mut() else {
+                break;
+            };
+            let mut last_key: Option<CursorKey> = None;
+            let mut had_msg = false;
+            let mut layout_changed = false;
 
-        // Fire arrival signals so each session's animate_cursor_to() unblocks.
-        for k in &arrived {
-            arrival_fire(k);
-        }
-
-        // Repin: immediately on target change, then defensive every ~1 s while
-        // the render loop is active. When quiescent, z-order is left unchanged
-        // until the next command wakes the loop.
-        if frame_tick_needed || had_msg {
-            repin_frames += 1;
-            let pin_changed = pinned_wid != last_pinned;
-            last_pinned = pinned_wid;
-            if pinned_wid.is_some() && (pin_changed || repin_frames >= 60) {
-                MacZOrderEnforcer { win_ptr }.reassert(pinned_wid);
-                repin_frames = 0;
-            } else if raise_unpinned {
-                // A direct move_cursor has no target window to pin against.
-                // Raise the normal-level, click-through overlay without
-                // activating the driver so a later foreground application
-                // cannot cover a standalone session cursor.
-                dispatch_order_front(win_ptr);
-                repin_frames = 0;
-            } else if repin_frames >= 60 {
-                repin_frames = 0;
-            }
-        }
-
-        // ── Phase 2: composite every cursor into ONE pixmap ───────────────
-        // Render only when a command arrived or the previous/next tick can
-        // change pixels. A final frame is emitted as animations/fades finish so
-        // the layer is left in the completed/cleared state before blocking.
-        if had_msg || hover_changed || frame_tick_needed || next_frame_tick_needed {
-            let pixmap = {
-                let guard = RENDER.lock().unwrap();
-                if let Some(map) = guard.as_ref() {
-                    // Allocate the pixmap at the screen's PHYSICAL pixel
-                    // dimensions so the cursor rasterises at retina resolution.
-                    // The cursor's logical coordinates are scaled into pixmap
-                    // pixels inside `paint_cursor` (it multiplies px/py/sizes
-                    // by `backing_scale`).
-                    let scale = map.backing_scale.max(1.0);
-                    let w = (win_w * scale).max(1.0) as u32;
-                    let h = (win_h * scale).max(1.0) as u32;
-                    let mut pm = tiny_skia::Pixmap::new(w.max(1), h.max(1))
-                        .unwrap_or_else(|| tiny_skia::Pixmap::new(1, 1).unwrap());
-                    let backing_scale_f32 = scale as f32;
-                    for (_k, rs) in &map.cursors {
-                        let focus = rs.focus_rect.map(|rect| FocusRect {
-                            rect,
-                            t: rs.focus_rect_t,
-                        });
-                        cursor_overlay::paint_cursor(
-                            &mut pm,
-                            &rs.core,
-                            0.0,
-                            0.0, // macOS uses screen-local coords (no origin offset)
-                            focus,
-                            backing_scale_f32,
-                        );
+            let mut apply = |message: MacOverlayMsg| {
+                had_msg = true;
+                match message {
+                    MacOverlayMsg::Cursor(message) => {
+                        if let Some(key) = apply_msg(map, message) {
+                            last_key = Some(key);
+                        }
                     }
-                    pm
-                } else {
-                    break;
+                    MacOverlayMsg::DisplaysChanged => layout_changed = true,
                 }
             };
+            if let Some(message) = first_msg {
+                apply(message);
+            }
+            while let Ok(message) = rx.try_recv() {
+                apply(message);
+            }
 
-            // Convert to CGImage and update layer on the main queue.
-            dispatch_set_layer_contents(layer_ptr, pixmap);
+            let mut arrived = Vec::new();
+            if frame_tick_needed || had_msg {
+                for (key, state) in map.cursors.iter_mut() {
+                    if state.tick(dt) {
+                        arrived.push(key.clone());
+                    }
+                }
+            }
+
+            let pointer = if hover_poll_tick
+                || map
+                    .cursors
+                    .values()
+                    .any(|state| state.core.session_badge_needs_hover_poll())
+            {
+                hardware_cursor_position()
+            } else {
+                None
+            };
+            let mut hover_changed = false;
+            if pointer.is_some() || hover_poll_tick {
+                for state in map.cursors.values_mut() {
+                    hover_changed |= state.core.update_session_badge_hover(pointer);
+                }
+            }
+
+            let active_state = last_key.as_ref().and_then(|key| map.cursors.get(key));
+            let pinned = active_state
+                .map(|state| state.core.pinned_wid)
+                .unwrap_or(last_pinned);
+            let active_display = active_state
+                .and_then(|state| state.core.pos)
+                .and_then(|(x, y)| map.layout.route(GlobalPoint { x, y }))
+                .map(|(display, _)| display)
+                .or_else(|| last_display.filter(|display| map.layout.display(*display).is_some()));
+            let raise_unpinned =
+                active_state.is_some_and(cursor_is_externally_visible) && pinned.is_none();
+            let next_frame_tick_needed = render_map_needs_frame_tick(map);
+            let next_hover_poll_needed = map
+                .cursors
+                .values()
+                .any(|state| state.core.session_badge_needs_hover_poll());
+
+            (
+                pinned,
+                active_display,
+                raise_unpinned,
+                arrived,
+                had_msg,
+                layout_changed,
+                hover_changed,
+                next_frame_tick_needed,
+                next_hover_poll_needed,
+            )
+        };
+
+        for key in &arrived {
+            arrival_fire(key);
+        }
+
+        if frame_tick_needed || had_msg {
+            repin_frames += 1;
+            let pin_changed = pinned_wid != last_pinned || active_display != last_display;
+            last_pinned = pinned_wid;
+            last_display = active_display;
+            if let Some(display_id) = active_display {
+                if pinned_wid.is_some() && (pin_changed || repin_frames >= 60) {
+                    MacZOrderEnforcer { display_id }.reassert(pinned_wid);
+                    repin_frames = 0;
+                } else if raise_unpinned {
+                    dispatch_order_front(display_id);
+                    repin_frames = 0;
+                }
+            }
+            if repin_frames >= 60 {
+                repin_frames = 0;
+            }
+        }
+
+        if had_msg || hover_changed || frame_tick_needed || next_frame_tick_needed {
+            let frames = {
+                let guard = RENDER.lock().unwrap();
+                let Some(map) = guard.as_ref() else {
+                    break;
+                };
+                let active = active_display_ids(map);
+                let mut dirty = previously_active
+                    .union(&active)
+                    .copied()
+                    .collect::<HashSet<_>>();
+                if layout_changed {
+                    dirty.extend(map.layout.displays.iter().map(|display| display.id));
+                }
+                let frames = dirty
+                    .into_iter()
+                    .filter_map(|display_id| {
+                        map.layout.display(display_id).map(|display| {
+                            (map.layout.generation, display, render_display(map, display))
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                previously_active = active;
+                frames
+            };
+
+            for (generation, display, pixmap) in frames {
+                dispatch_present(generation, display.id, pixmap);
+            }
         }
 
         frame_tick_needed = next_frame_tick_needed;
         hover_poll_needed = next_hover_poll_needed;
         if frame_tick_needed {
-            // Sleep remainder of frame budget.
             let elapsed = Instant::now().duration_since(last_tick);
             if let Some(remaining) = target_frame_ms.checked_sub(elapsed) {
                 std::thread::sleep(remaining);
             }
         }
     }
+}
+
+fn active_display_ids(map: &RenderMap) -> HashSet<DisplayId> {
+    let mut active = HashSet::new();
+    for state in map.cursors.values() {
+        if cursor_is_externally_visible(state) {
+            if let Some((x, y)) = state.core.pos {
+                if let Some((display, _)) = map.layout.route(GlobalPoint { x, y }) {
+                    active.insert(display);
+                }
+            }
+        }
+        if let Some([x, y, width, height]) = state.focus_rect {
+            for display in &map.layout.displays {
+                if rectangles_intersect((x, y, width, height), *display) {
+                    active.insert(display.id);
+                }
+            }
+        }
+    }
+    active
+}
+
+fn rectangles_intersect(rect: (f64, f64, f64, f64), display: DisplayGeometry) -> bool {
+    let (x, y, width, height) = rect;
+    width > 0.0
+        && height > 0.0
+        && x < display.x + display.width
+        && x + width > display.x
+        && y < display.y + display.height
+        && y + height > display.y
+}
+
+fn render_display(map: &RenderMap, display: DisplayGeometry) -> tiny_skia::Pixmap {
+    let (width, height) = display.pixel_size();
+    let mut pixmap = tiny_skia::Pixmap::new(width, height)
+        .unwrap_or_else(|| tiny_skia::Pixmap::new(1, 1).unwrap());
+    for state in map.cursors.values() {
+        let focus = state.focus_rect.map(|rect| FocusRect {
+            rect,
+            t: state.focus_rect_t,
+        });
+        cursor_overlay::paint_cursor(
+            &mut pixmap,
+            &state.core,
+            display.x,
+            display.y,
+            focus,
+            display.backing_scale as f32,
+        );
+    }
+    pixmap
 }
 
 fn hardware_cursor_position() -> Option<(f64, f64)> {
@@ -922,26 +1004,11 @@ fn cursor_is_externally_visible(state: &RenderState) -> bool {
     state.core.cfg.enabled && state.core.cursor_is_revealed()
 }
 
-/// Convert a `tiny_skia::Pixmap` to a `CGImage` and set it as the contents
-/// of the given `CALayer` via `dispatch_async(main_queue, ...)`.
-fn dispatch_set_layer_contents(layer_ptr: usize, pixmap: tiny_skia::Pixmap) {
-    // Build the CGImage from the pixmap bytes.
-    let cg_image_ptr = match pixmap_to_cgimage(&pixmap) {
-        Some(p) => p,
-        None => return,
-    };
+type MainWork = Box<dyn FnOnce() + Send>;
 
-    // Box the payload for the C callback.
-    let payload = Box::new((layer_ptr, cg_image_ptr));
-
-    // GCD symbols from libdispatch (part of the macOS system library stubs).
-    // `dispatch_get_main_queue()` is an inline C function; the underlying
-    // symbol is `_dispatch_main_q`, a *struct* (not a pointer).
-    // We declare it as `u8` (opaque placeholder) and take its ADDRESS to
-    // obtain the `dispatch_queue_t` (pointer to the struct).
+fn dispatch_on_main(work: MainWork) {
     #[link(name = "dispatch", kind = "dylib")]
     extern "C" {
-        // Opaque placeholder — we only ever take &_dispatch_main_q, never read it.
         static _dispatch_main_q: u8;
         fn dispatch_async_f(
             queue: *const c_void,
@@ -950,30 +1017,41 @@ fn dispatch_set_layer_contents(layer_ptr: usize, pixmap: tiny_skia::Pixmap) {
         );
     }
 
-    unsafe extern "C" fn set_contents_cb(ctx: *mut c_void) {
-        let (layer_ptr, cg_image_ptr): (usize, usize) = *Box::from_raw(ctx as *mut _);
-        let layer = layer_ptr as *mut objc2::runtime::AnyObject;
-        // setContents: expects an `id` (type '@'), not a raw void pointer.
-        // CGImageRef is toll-free bridged to NSObject, so we cast it to *mut AnyObject.
-        let cg_id = cg_image_ptr as *mut objc2::runtime::AnyObject;
-        let _: () = objc2::msg_send![layer, setContents: cg_id];
-        // Release the CGImage ref we retained in pixmap_to_cgimage.
-        CGImageRelease(cg_image_ptr as *mut c_void);
+    unsafe extern "C" fn run(ctx: *mut c_void) {
+        let work: Box<MainWork> = Box::from_raw(ctx.cast());
+        work();
     }
 
-    extern "C" {
-        fn CGImageRelease(image: *mut c_void);
-    }
-
+    let payload = Box::new(work);
     unsafe {
-        // &_dispatch_main_q is the queue pointer (same as dispatch_get_main_queue()).
         let main_queue = &raw const _dispatch_main_q as *const c_void;
-        dispatch_async_f(
-            main_queue,
-            Box::into_raw(payload) as *mut c_void,
-            set_contents_cb,
-        );
+        dispatch_async_f(main_queue, Box::into_raw(payload).cast(), run);
     }
+}
+
+/// Present one display-local pixmap. AppKit objects remain main-thread-owned;
+/// stale frames are rejected by display-layout generation.
+fn dispatch_present(generation: u64, display_id: DisplayId, pixmap: tiny_skia::Pixmap) {
+    let Some(cg_image_ptr) = pixmap_to_cgimage(&pixmap) else {
+        return;
+    };
+    dispatch_on_main(Box::new(move || unsafe {
+        extern "C" {
+            fn CGImageRelease(image: *mut c_void);
+        }
+
+        let host = HOST.lock().unwrap();
+        if let Some(surface) = host
+            .as_ref()
+            .filter(|host| host.generation == generation)
+            .and_then(|host| host.surfaces.get(&display_id))
+        {
+            let layer = surface.layer_ptr as *mut objc2::runtime::AnyObject;
+            let image = cg_image_ptr as *mut objc2::runtime::AnyObject;
+            let _: () = objc2::msg_send![layer, setContents: image];
+        }
+        CGImageRelease(cg_image_ptr as *mut c_void);
+    }));
 }
 
 /// Raise the normal-level overlay without activating the driver application.
@@ -981,42 +1059,22 @@ fn dispatch_set_layer_contents(layer_ptr: usize, pixmap: tiny_skia::Pixmap) {
 /// This is used only for an externally visible cursor with no target window.
 /// Target-bound actions continue to use [`dispatch_pin_above`] so background
 /// delivery remains below unrelated foreground applications.
-fn dispatch_order_front(win_ptr: usize) {
-    use std::ffi::c_void;
-
-    #[link(name = "dispatch", kind = "dylib")]
-    extern "C" {
-        static _dispatch_main_q: u8;
-        fn dispatch_async_f(
-            queue: *const c_void,
-            context: *mut c_void,
-            work: unsafe extern "C" fn(*mut c_void),
-        );
-    }
-
-    unsafe extern "C" fn order_front_cb(ctx: *mut c_void) {
-        let win_ptr = *Box::from_raw(ctx as *mut usize);
-        let win = win_ptr as *mut objc2::runtime::AnyObject;
-        let _: () = objc2::msg_send![win, orderFrontRegardless];
-    }
-
-    let payload = Box::new(win_ptr);
-    unsafe {
-        let main_queue = &raw const _dispatch_main_q as *const c_void;
-        dispatch_async_f(
-            main_queue,
-            Box::into_raw(payload) as *mut c_void,
-            order_front_cb,
-        );
-    }
+fn dispatch_order_front(display_id: DisplayId) {
+    dispatch_on_main(Box::new(move || unsafe {
+        let host = HOST.lock().unwrap();
+        if let Some(surface) = host
+            .as_ref()
+            .and_then(|host| host.surfaces.get(&display_id))
+        {
+            let win = surface.win_ptr as *mut objc2::runtime::AnyObject;
+            let _: () = objc2::msg_send![win, orderFrontRegardless];
+        }
+    }));
 }
 
-/// Order the overlay NSWindow just above `target_wid` in the global window
-/// server list.  Called from the render thread; dispatches to the main queue
-/// (AppKit must be used on the main thread).
-///
-/// `NSWindowAbove = 1`; `orderWindow:relativeTo:` accepts any CGWindowID as
-/// the `relativeTo` argument — it works cross-application via CGS.
+/// Apply the existing best-effort target-relative order to one display
+/// surface. AppKit does not guarantee cross-process `z+1`; when the exact
+/// target is already frontmost we safely raise the click-through overlay.
 fn target_is_frontmost_visible_window(
     target_wid: u64,
     frontmost_pid: Option<i32>,
@@ -1045,70 +1103,43 @@ fn target_is_frontmost_visible_window(
         .is_some_and(|window| u64::from(window.window_id) == target_wid)
 }
 
-fn dispatch_pin_above(win_ptr: usize, target_wid: u64) {
-    use std::ffi::c_void;
-
-    #[link(name = "dispatch", kind = "dylib")]
-    extern "C" {
-        static _dispatch_main_q: u8;
-        fn dispatch_async_f(
-            queue: *const c_void,
-            context: *mut c_void,
-            work: unsafe extern "C" fn(*mut c_void),
-        );
-    }
-
-    unsafe extern "C" fn reorder_cb(ctx: *mut c_void) {
-        let (win_ptr, target_wid, raise_front): (usize, u64, bool) =
-            *Box::from_raw(ctx as *mut (usize, u64, bool));
-        let win = win_ptr as *mut objc2::runtime::AnyObject;
-        // NSWindowAbove = 1; relativeTo: takes NSInteger (i64 on 64-bit)
-        let _: () = objc2::msg_send![win, orderWindow: 1i64 relativeTo: target_wid as i64];
-
-        // Tahoe can leave a normal-level transparent window behind an
-        // already-frontmost cross-process target even after the relative
-        // ordering request. `orderFrontRegardless` does not activate the
-        // driver app. Use it only when the exact target is already the
-        // frontmost visible normal window, so background browser actions do
-        // not put the overlay above the user's foreground app.
-        if raise_front {
-            let _: () = objc2::msg_send![win, orderFrontRegardless];
-        }
-    }
-
+fn dispatch_pin_above(display_id: DisplayId, target_wid: u64) {
     let windows = crate::windows::visible_windows();
     let raise_front =
         target_is_frontmost_visible_window(target_wid, crate::apps::frontmost_pid(), &windows);
-    let payload = Box::new((win_ptr, target_wid, raise_front));
-    unsafe {
-        let main_queue = &raw const _dispatch_main_q as *const c_void;
-        dispatch_async_f(
-            main_queue,
-            Box::into_raw(payload) as *mut c_void,
-            reorder_cb,
-        );
-    }
+    dispatch_on_main(Box::new(move || unsafe {
+        let host = HOST.lock().unwrap();
+        if let Some(surface) = host
+            .as_ref()
+            .and_then(|host| host.surfaces.get(&display_id))
+        {
+            let win = surface.win_ptr as *mut objc2::runtime::AnyObject;
+            let _: () = objc2::msg_send![win, orderWindow: 1i64 relativeTo: target_wid as i64];
+            if raise_front {
+                let _: () = objc2::msg_send![win, orderFrontRegardless];
+            }
+        }
+    }));
 }
 
 // ── Z-order enforcer (macOS impl of cursor_overlay::ZOrderEnforcer) ──────
 
 /// macOS implementation of [`cursor_overlay::ZOrderEnforcer`].
 ///
-/// Holds the NSWindow pointer as a `usize` and dispatches the
-/// `orderWindow:relativeTo:` call to the main queue (AppKit must run on
-/// the main thread).
+/// Identifies the display surface and dispatches target-relative ordering to
+/// the main-thread AppKit host.
 ///
 /// `target = None` is treated as a no-op here. Direct unpinned cursor commands
 /// raise the overlay once in the render loop, while this enforcer remains
 /// responsible only for target-relative ordering.
 struct MacZOrderEnforcer {
-    win_ptr: usize,
+    display_id: DisplayId,
 }
 
 impl ZOrderEnforcer for MacZOrderEnforcer {
     fn reassert(&self, target: Option<u64>) {
         if let Some(wid) = target {
-            dispatch_pin_above(self.win_ptr, wid);
+            dispatch_pin_above(self.display_id, wid);
         }
         // target = None → no-op; see struct doc comment.
     }
@@ -1257,9 +1288,18 @@ mod tests {
         );
         RenderMap {
             cursors,
-            win_w: 100.0,
-            win_h: 100.0,
-            backing_scale: 1.0,
+            layout: DisplayLayout {
+                generation: 1,
+                displays: vec![DisplayGeometry {
+                    id: 1,
+                    x: 0.0,
+                    y: 0.0,
+                    width: 100.0,
+                    height: 100.0,
+                    backing_scale: 1.0,
+                    is_primary: true,
+                }],
+            },
             template: CursorConfig::default(),
             ended: std::collections::HashSet::new(),
         }
@@ -1486,6 +1526,47 @@ mod tests {
         ));
         assert_eq!(map.cursors["sessA"].core.pos, Some((-867.0, 400.0)));
         assert!(cursor_is_externally_visible(&map.cursors["sessA"]));
+    }
+
+    #[test]
+    fn negative_x_cursor_paints_into_the_secondary_display_buffer() {
+        let mut map = empty_map();
+        let secondary = DisplayGeometry {
+            id: 2,
+            x: -1920.0,
+            y: 0.0,
+            width: 1920.0,
+            height: 1080.0,
+            backing_scale: 1.0,
+            is_primary: false,
+        };
+        map.layout.displays.push(secondary);
+        seed_start_in_map(&mut map, &"sessA".to_owned(), -867.0, 400.0);
+        map.cursors.get_mut("sessA").unwrap().core.pos = Some((-867.0, 400.0));
+
+        assert_eq!(active_display_ids(&map), HashSet::from([2]));
+        let pixmap = render_display(&map, secondary);
+        assert!(pixmap.data().chunks_exact(4).any(|pixel| pixel[3] > 0));
+    }
+
+    #[test]
+    fn moved_cursor_drops_the_old_display_from_the_active_set() {
+        let mut map = empty_map();
+        map.layout.displays.push(DisplayGeometry {
+            id: 2,
+            x: -1920.0,
+            y: 0.0,
+            width: 1920.0,
+            height: 1080.0,
+            backing_scale: 1.0,
+            is_primary: false,
+        });
+        seed_start_in_map(&mut map, &"sessA".to_owned(), -867.0, 400.0);
+        map.cursors.get_mut("sessA").unwrap().core.pos = Some((-867.0, 40.0));
+        assert_eq!(active_display_ids(&map), HashSet::from([2]));
+
+        map.cursors.get_mut("sessA").unwrap().core.pos = Some((40.0, 40.0));
+        assert_eq!(active_display_ids(&map), HashSet::from([1]));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
@@ -7,11 +7,12 @@
 //! The two sides communicate through a global lock-free channel:
 //!
 //! - MCP tool calls → `send_command(OverlayCommand)` → `CMD_TX` (SyncSender)
-//! - render worker → per-display pixmaps → main-thread `AppKitOverlayHost`
+//! - render worker → bounded per-display tiles → one-slot presentation mailbox
+//! - main thread → `AppKitOverlayHost` child layers
 //!
 //! One shared render map owns cursor state. The AppKit host owns one transparent
-//! presentation surface per active display and replaces that surface set after
-//! display-layout changes.
+//! window and one movable content layer per active display, and replaces that
+//! surface set after display-layout changes.
 //!
 //! ## Coordinate system
 //!
@@ -30,7 +31,7 @@
 //! variants of MoveTo / ClickPulse — see the wrapper around
 //! `apply_command_base` below.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::ffi::c_void;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
@@ -85,7 +86,8 @@ static CMD_RX_CELL: Mutex<Option<std::sync::mpsc::Receiver<MacOverlayMsg>>> = Mu
 static RENDER: Mutex<Option<RenderMap>> = Mutex::new(None);
 static HOST: Mutex<Option<AppKitOverlayHost>> = Mutex::new(None);
 static DISPLAY_GENERATION: AtomicU64 = AtomicU64::new(0);
-static REBUILD_PENDING: AtomicBool = AtomicBool::new(false);
+static REBUILD_REQUESTED: AtomicBool = AtomicBool::new(false);
+static REBUILD_SCHEDULED: AtomicBool = AtomicBool::new(false);
 
 /// The keyed, insertion-ordered collection of owned cursors that the render
 /// loop composites every frame. Insertion order = stable z-order (later keys
@@ -578,19 +580,23 @@ struct ZOrderRoute {
     target_wid: Option<u64>,
 }
 
-fn z_order_route(map: &RenderMap) -> Option<ZOrderRoute> {
-    let state = map
+fn z_order_routes(map: &RenderMap) -> Vec<ZOrderRoute> {
+    let Some(state) = map
         .active_key
         .as_ref()
         .and_then(|key| map.cursors.get(key))
-        .filter(|state| cursor_is_externally_visible(state))?;
-    let (x, y) = state.core.pos?;
-    let (display_id, _) = map.layout.route(GlobalPoint { x, y })?;
-    Some(ZOrderRoute {
-        generation: map.layout.generation,
-        display_id,
-        target_wid: state.core.pinned_wid,
-    })
+        .filter(|state| cursor_is_externally_visible(state))
+    else {
+        return Vec::new();
+    };
+    state_display_ids(map, state)
+        .into_iter()
+        .map(|display_id| ZOrderRoute {
+            generation: map.layout.generation,
+            display_id,
+            target_wid: state.core.pinned_wid,
+        })
+        .collect()
 }
 
 // ── AppKit / CGImage plumbing ─────────────────────────────────────────────
@@ -598,6 +604,8 @@ fn z_order_route(map: &RenderMap) -> Option<ZOrderRoute> {
 struct NativeSurface {
     win_ptr: usize,
     layer_ptr: usize,
+    logical_height: f64,
+    backing_scale: f64,
 }
 
 struct AppKitOverlayHost {
@@ -669,17 +677,24 @@ unsafe fn create_native_surface(
 
     let content_view: *mut AnyObject = msg_send![win, contentView];
     let _: () = msg_send![content_view, setWantsLayer: true];
-    let layer: *mut AnyObject = msg_send![content_view, layer];
-    let _: () = msg_send![layer, setContentsScale: geometry.backing_scale.max(1.0)];
+    let root_layer: *mut AnyObject = msg_send![content_view, layer];
+    let _: () = msg_send![root_layer, setGeometryFlipped: false];
+    let _: () = msg_send![root_layer, setMasksToBounds: true];
+    let layer: *mut AnyObject = msg_send![class!(CALayer), layer];
+    let scale = geometry.backing_scale.max(1.0);
+    let _: () = msg_send![layer, setContentsScale: scale];
     let gravity_ns: *mut AnyObject = msg_send![class!(NSString),
-        stringWithUTF8String: c"topLeft".as_ptr().cast::<u8>()
+        stringWithUTF8String: c"resize".as_ptr().cast::<u8>()
     ];
     let _: () = msg_send![layer, setContentsGravity: gravity_ns];
+    let _: () = msg_send![root_layer, addSublayer: layer];
     let _: () = msg_send![win, orderFrontRegardless];
 
     Some(NativeSurface {
         win_ptr: win as usize,
         layer_ptr: layer as usize,
+        logical_height: geometry.height,
+        backing_scale: scale,
     })
 }
 
@@ -752,16 +767,27 @@ fn register_display_reconfiguration_callback() {
 }
 
 fn dispatch_rebuild_appkit_host() {
-    if REBUILD_PENDING.swap(true, Ordering::AcqRel) {
+    REBUILD_REQUESTED.store(true, Ordering::Release);
+    if REBUILD_SCHEDULED.swap(true, Ordering::AcqRel) {
         return;
     }
     dispatch_on_main(Box::new(|| unsafe {
-        let rebuilt = rebuild_appkit_host();
-        REBUILD_PENDING.store(false, Ordering::Release);
-        if rebuilt {
-            if let Some(tx) = CMD_TX.get() {
-                let _ = tx.try_send(MacOverlayMsg::DisplaysChanged);
+        loop {
+            REBUILD_REQUESTED.store(false, Ordering::Release);
+            if rebuild_appkit_host() {
+                if let Some(tx) = CMD_TX.get() {
+                    let _ = tx.try_send(MacOverlayMsg::DisplaysChanged);
+                }
             }
+            if !REBUILD_REQUESTED.swap(false, Ordering::AcqRel) {
+                break;
+            }
+        }
+        REBUILD_SCHEDULED.store(false, Ordering::Release);
+        // Close the race where a callback marks the layout dirty after the
+        // loop's final check but before the scheduled marker is released.
+        if REBUILD_REQUESTED.load(Ordering::Acquire) {
+            dispatch_rebuild_appkit_host();
         }
     }));
 }
@@ -772,8 +798,7 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
     let mut last_tick = Instant::now();
     let mut frame_tick_needed = false;
     let mut hover_poll_needed = false;
-    let mut presented_displays = HashSet::<DisplayId>::new();
-    let mut presented_z_order: Option<ZOrderRoute> = None;
+    let mut presented_z_order = Vec::<ZOrderRoute>::new();
     let mut repin_frames: u32 = 0;
 
     loop {
@@ -806,7 +831,6 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
             arrived,
             had_msg,
             cursor_commanded,
-            layout_changed,
             hover_changed,
             next_frame_tick_needed,
             next_hover_poll_needed,
@@ -817,7 +841,6 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
             };
             let mut had_msg = false;
             let mut cursor_commanded = false;
-            let mut layout_changed = false;
 
             let mut apply = |message: MacOverlayMsg| {
                 had_msg = true;
@@ -829,7 +852,7 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
                         };
                         apply_msg(map, message);
                     }
-                    MacOverlayMsg::DisplaysChanged => layout_changed = true,
+                    MacOverlayMsg::DisplaysChanged => {}
                 }
             };
             if let Some(message) = first_msg {
@@ -865,7 +888,7 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
                 }
             }
 
-            let z_order = z_order_route(map);
+            let z_order = z_order_routes(map);
             let next_frame_tick_needed = render_map_needs_frame_tick(map);
             let next_hover_poll_needed = map
                 .cursors
@@ -877,7 +900,6 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
                 arrived,
                 had_msg,
                 cursor_commanded,
-                layout_changed,
                 hover_changed,
                 next_frame_tick_needed,
                 next_hover_poll_needed,
@@ -891,17 +913,24 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
         if frame_tick_needed || had_msg {
             repin_frames += 1;
             let route_changed = z_order != presented_z_order;
-            if let Some(route) = z_order {
-                if route.target_wid.is_some() && (route_changed || repin_frames >= 60) {
+            for route in &z_order {
+                let surface_changed = !presented_z_order.contains(route);
+                if route.target_wid.is_some() && (surface_changed || repin_frames >= 60) {
                     MacZOrderEnforcer {
+                        generation: route.generation,
                         display_id: route.display_id,
                     }
                     .reassert(route.target_wid);
-                    repin_frames = 0;
                 } else if route.target_wid.is_none() && (route_changed || cursor_commanded) {
-                    dispatch_order_front(route.display_id);
-                    repin_frames = 0;
+                    dispatch_order_front(route.generation, route.display_id);
                 }
+            }
+            if (z_order.iter().any(|route| route.target_wid.is_some())
+                && (route_changed || repin_frames >= 60))
+                || (z_order.iter().any(|route| route.target_wid.is_none())
+                    && (route_changed || cursor_commanded))
+            {
+                repin_frames = 0;
             }
             presented_z_order = z_order;
             if repin_frames >= 60 {
@@ -915,30 +944,18 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
                 let Some(map) = guard.as_ref() else {
                     break;
                 };
-                let painted = painted_display_ids(map);
-                let mut displays_to_present = presented_displays
-                    .union(&painted)
+                map.layout
+                    .displays
+                    .iter()
                     .copied()
-                    .collect::<HashSet<_>>();
-                if layout_changed {
-                    displays_to_present
-                        .extend(map.layout.displays.iter().map(|display| display.id));
-                }
-                let frames = displays_to_present
-                    .into_iter()
-                    .filter_map(|display_id| {
-                        map.layout.display(display_id).map(|display| {
-                            (map.layout.generation, display, render_display(map, display))
-                        })
+                    .map(|display| DisplayFrame {
+                        generation: map.layout.generation,
+                        display_id: display.id,
+                        tile: render_display_tile(map, display),
                     })
-                    .collect::<Vec<_>>();
-                presented_displays = painted;
-                frames
+                    .collect()
             };
-
-            for (generation, display, pixmap) in frames {
-                dispatch_present(generation, display.id, pixmap);
-            }
+            queue_present(frames);
         }
 
         frame_tick_needed = next_frame_tick_needed;
@@ -952,88 +969,197 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
     }
 }
 
-// Matches the established default-theme envelope used by the X11 tile path.
-const DEFAULT_CURSOR_PAINT_RADIUS: f64 = 64.0;
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct PixelRect {
+    x: u32,
+    y: u32,
+    width: u32,
+    height: u32,
+}
 
-/// Displays whose buffers can contain pixels in the current frame. This is
-/// based on painted bounds, not cursor ownership: artwork may span a seam.
-fn painted_display_ids(map: &RenderMap) -> HashSet<DisplayId> {
-    let mut painted = HashSet::new();
-    for state in map.cursors.values() {
-        if cursor_is_externally_visible(state) {
-            if let Some((x, y)) = state.core.pos {
-                let custom_theme = state
-                    .core
-                    .theme
-                    .as_deref()
-                    .is_some_and(|theme| theme.id != cursor_overlay::DEFAULT_THEME_ID);
-                for display in &map.layout.displays {
-                    if custom_theme
-                        || rectangles_intersect(
-                            (
-                                x - DEFAULT_CURSOR_PAINT_RADIUS,
-                                y - DEFAULT_CURSOR_PAINT_RADIUS,
-                                DEFAULT_CURSOR_PAINT_RADIUS * 2.0,
-                                DEFAULT_CURSOR_PAINT_RADIUS * 2.0,
-                            ),
-                            *display,
-                        )
-                    {
-                        painted.insert(display.id);
-                    }
-                }
-            }
-        }
-        if let Some([x, y, width, height]) = state.focus_rect {
-            for display in &map.layout.displays {
-                if rectangles_intersect((x, y, width, height), *display) {
-                    painted.insert(display.id);
-                }
-            }
+impl PixelRect {
+    fn union(self, other: Self) -> Self {
+        let x0 = self.x.min(other.x);
+        let y0 = self.y.min(other.y);
+        let x1 = (self.x + self.width).max(other.x + other.width);
+        let y1 = (self.y + self.height).max(other.y + other.height);
+        Self {
+            x: x0,
+            y: y0,
+            width: x1 - x0,
+            height: y1 - y0,
         }
     }
-    painted
 }
 
-fn rectangles_intersect(rect: (f64, f64, f64, f64), display: DisplayGeometry) -> bool {
+fn tile_layer_frame(
+    bounds: PixelRect,
+    logical_height: f64,
+    scale: f64,
+) -> objc2_foundation::NSRect {
+    use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+    NSRect::new(
+        NSPoint::new(
+            f64::from(bounds.x) / scale,
+            logical_height - f64::from(bounds.y + bounds.height) / scale,
+        ),
+        NSSize::new(
+            f64::from(bounds.width) / scale,
+            f64::from(bounds.height) / scale,
+        ),
+    )
+}
+
+struct RenderedTile {
+    bounds: PixelRect,
+    pixmap: tiny_skia::Pixmap,
+}
+
+fn logical_rect_to_pixels(
+    rect: (f64, f64, f64, f64),
+    display: DisplayGeometry,
+    padding: f64,
+) -> Option<PixelRect> {
     let (x, y, width, height) = rect;
-    width > 0.0
-        && height > 0.0
-        && x < display.x + display.width
-        && x + width > display.x
-        && y < display.y + display.height
-        && y + height > display.y
+    if width <= 0.0 || height <= 0.0 {
+        return None;
+    }
+    let scale = display.backing_scale.max(1.0);
+    let (pixel_width, pixel_height) = display.pixel_size();
+    let x0 = ((x - padding - display.x) * scale)
+        .floor()
+        .clamp(0.0, f64::from(pixel_width)) as u32;
+    let y0 = ((y - padding - display.y) * scale)
+        .floor()
+        .clamp(0.0, f64::from(pixel_height)) as u32;
+    let x1 = ((x + width + padding - display.x) * scale)
+        .ceil()
+        .clamp(0.0, f64::from(pixel_width)) as u32;
+    let y1 = ((y + height + padding - display.y) * scale)
+        .ceil()
+        .clamp(0.0, f64::from(pixel_height)) as u32;
+    (x1 > x0 && y1 > y0).then_some(PixelRect {
+        x: x0,
+        y: y0,
+        width: x1 - x0,
+        height: y1 - y0,
+    })
 }
 
-fn render_display(map: &RenderMap, display: DisplayGeometry) -> tiny_skia::Pixmap {
+fn badge_layout_for_display(
+    map: &RenderMap,
+    state: &RenderState,
+    display: DisplayGeometry,
+) -> Option<cursor_overlay::SessionBadgeLayout> {
+    if !cursor_is_externally_visible(state) {
+        return None;
+    }
+    let (x, y) = state.core.pos?;
+    if map.layout.route(GlobalPoint { x, y })?.0 != display.id {
+        return None;
+    }
+    let scale = display.backing_scale.max(1.0) as f32;
     let (width, height) = display.pixel_size();
-    let mut pixmap = tiny_skia::Pixmap::new(width, height)
-        .unwrap_or_else(|| tiny_skia::Pixmap::new(1, 1).unwrap());
+    let (delivery, target) = state.core.badge_modifiers.unwrap_or((None, None));
+    cursor_overlay::session_badge_layout(cursor_overlay::SessionBadgeInput {
+        label: state.core.session_label.as_deref(),
+        delivery,
+        target,
+        cursor: (
+            ((x - display.x) * f64::from(scale)) as f32,
+            ((y - display.y) * f64::from(scale)) as f32,
+        ),
+        backing_scale: scale,
+        label_alpha: state.core.session_badge_alpha(),
+        chip_alpha: state.core.session_badge_chip_alpha(),
+        clip: Some((width as f32, height as f32)),
+    })
+}
+
+fn state_pixel_bounds(
+    map: &RenderMap,
+    state: &RenderState,
+    display: DisplayGeometry,
+) -> Option<PixelRect> {
+    if !cursor_is_externally_visible(state) {
+        return None;
+    }
+    let (x, y) = state.core.pos?;
+    let radius = state.core.paint_radius();
+    let mut bounds = logical_rect_to_pixels(
+        (x - radius, y - radius, radius * 2.0, radius * 2.0),
+        display,
+        2.0,
+    );
+    if let Some([x, y, width, height]) = state.focus_rect {
+        if let Some(focus) = logical_rect_to_pixels((x, y, width, height), display, 3.0) {
+            bounds = Some(bounds.map_or(focus, |bounds| bounds.union(focus)));
+        }
+    }
+    if let Some(layout) = badge_layout_for_display(map, state, display) {
+        let rect = layout.rect;
+        let scale = display.backing_scale.max(1.0);
+        let badge = logical_rect_to_pixels(
+            (
+                display.x + f64::from(rect.x()) / scale,
+                display.y + f64::from(rect.y()) / scale,
+                f64::from(rect.width()) / scale,
+                f64::from(rect.height()) / scale,
+            ),
+            display,
+            8.0,
+        );
+        if let Some(badge) = badge {
+            bounds = Some(bounds.map_or(badge, |bounds| bounds.union(badge)));
+        }
+    }
+    bounds
+}
+
+fn state_display_ids(map: &RenderMap, state: &RenderState) -> Vec<DisplayId> {
+    map.layout
+        .displays
+        .iter()
+        .copied()
+        .filter(|display| state_pixel_bounds(map, state, *display).is_some())
+        .map(|display| display.id)
+        .collect()
+}
+
+fn render_display_tile(map: &RenderMap, display: DisplayGeometry) -> Option<RenderedTile> {
+    let bounds = map
+        .cursors
+        .values()
+        .filter_map(|state| state_pixel_bounds(map, state, display))
+        .reduce(PixelRect::union)?;
+    let mut pixmap = tiny_skia::Pixmap::new(bounds.width, bounds.height)?;
+    let scale = display.backing_scale.max(1.0);
+    let origin_x = display.x + f64::from(bounds.x) / scale;
+    let origin_y = display.y + f64::from(bounds.y) / scale;
     for state in map.cursors.values() {
         let focus = state.focus_rect.map(|rect| FocusRect {
             rect,
             t: state.focus_rect_t,
         });
-        let anchor_display = state
-            .core
-            .pos
-            .and_then(|(x, y)| map.layout.route(GlobalPoint { x, y }))
-            .map(|(display_id, _)| display_id);
-        let painter = if anchor_display == Some(display.id) {
-            cursor_overlay::paint_cursor
-        } else {
-            cursor_overlay::paint_cursor_art
-        };
-        painter(
+        cursor_overlay::paint_cursor_art(
             &mut pixmap,
             &state.core,
-            display.x,
-            display.y,
+            origin_x,
+            origin_y,
             focus,
-            display.backing_scale as f32,
+            scale as f32,
         );
+        if let Some(layout) = badge_layout_for_display(map, state, display) {
+            cursor_overlay::paint_session_badge(
+                &mut pixmap,
+                &layout.translated(-(bounds.x as f32), -(bounds.y as f32)),
+                cursor_overlay::session_fill_rgba(&state.core.cfg.cursor_id),
+                state.core.idle_alpha as f32,
+            );
+        }
     }
-    pixmap
+    Some(RenderedTile { bounds, pixmap })
 }
 
 fn hardware_cursor_position() -> Option<(f64, f64)> {
@@ -1051,6 +1177,15 @@ fn hardware_cursor_position() -> Option<(f64, f64)> {
 fn cursor_is_externally_visible(state: &RenderState) -> bool {
     state.core.cfg.enabled && state.core.cursor_is_revealed()
 }
+
+struct DisplayFrame {
+    generation: u64,
+    display_id: DisplayId,
+    tile: Option<RenderedTile>,
+}
+
+static PRESENT_MAILBOX: Mutex<Option<Vec<DisplayFrame>>> = Mutex::new(None);
+static PRESENT_SCHEDULED: AtomicBool = AtomicBool::new(false);
 
 type MainWork = Box<dyn FnOnce() + Send>;
 
@@ -1077,29 +1212,67 @@ fn dispatch_on_main(work: MainWork) {
     }
 }
 
-/// Present one display-local pixmap. AppKit objects remain main-thread-owned;
-/// stale frames are rejected by display-layout generation.
-fn dispatch_present(generation: u64, display_id: DisplayId, pixmap: tiny_skia::Pixmap) {
-    let Some(cg_image_ptr) = pixmap_to_cgimage(&pixmap) else {
+/// Replace the pending presentation batch. At most one batch is queued on the
+/// main thread, so a busy renderer drops stale frames instead of retaining
+/// unbounded image buffers.
+fn queue_present(frames: Vec<DisplayFrame>) {
+    *PRESENT_MAILBOX.lock().unwrap() = Some(frames);
+    schedule_present();
+}
+
+fn schedule_present() {
+    if PRESENT_SCHEDULED.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    dispatch_on_main(Box::new(|| unsafe {
+        if let Some(frames) = PRESENT_MAILBOX.lock().unwrap().take() {
+            present_frames(frames);
+        }
+        PRESENT_SCHEDULED.store(false, Ordering::Release);
+        if PRESENT_MAILBOX.lock().unwrap().is_some() {
+            schedule_present();
+        }
+    }));
+}
+
+unsafe fn present_frames(frames: Vec<DisplayFrame>) {
+    use objc2::{class, msg_send};
+
+    extern "C" {
+        fn CGImageRelease(image: *mut c_void);
+    }
+
+    let host = HOST.lock().unwrap();
+    let Some(host) = host.as_ref() else {
         return;
     };
-    dispatch_on_main(Box::new(move || unsafe {
-        extern "C" {
-            fn CGImageRelease(image: *mut c_void);
+    let _: () = msg_send![class!(CATransaction), begin];
+    let _: () = msg_send![class!(CATransaction), setDisableActions: true];
+    for frame in frames {
+        if host.generation != frame.generation {
+            continue;
         }
-
-        let host = HOST.lock().unwrap();
-        if let Some(surface) = host
-            .as_ref()
-            .filter(|host| host.generation == generation)
-            .and_then(|host| host.surfaces.get(&display_id))
-        {
-            let layer = surface.layer_ptr as *mut objc2::runtime::AnyObject;
-            let image = cg_image_ptr as *mut objc2::runtime::AnyObject;
-            let _: () = objc2::msg_send![layer, setContents: image];
-        }
+        let Some(surface) = host.surfaces.get(&frame.display_id) else {
+            continue;
+        };
+        let layer = surface.layer_ptr as *mut objc2::runtime::AnyObject;
+        let Some(tile) = frame.tile else {
+            let _: () = objc2::msg_send![layer,
+                setContents: std::ptr::null_mut::<objc2::runtime::AnyObject>()
+            ];
+            continue;
+        };
+        let Some(cg_image_ptr) = pixmap_to_cgimage(&tile.pixmap) else {
+            continue;
+        };
+        let bounds = tile.bounds;
+        let layer_frame = tile_layer_frame(bounds, surface.logical_height, surface.backing_scale);
+        let _: () = objc2::msg_send![layer, setFrame: layer_frame];
+        let image = cg_image_ptr as *mut objc2::runtime::AnyObject;
+        let _: () = objc2::msg_send![layer, setContents: image];
         CGImageRelease(cg_image_ptr as *mut c_void);
-    }));
+    }
+    let _: () = msg_send![class!(CATransaction), commit];
 }
 
 /// Raise the normal-level overlay without activating the driver application.
@@ -1107,11 +1280,12 @@ fn dispatch_present(generation: u64, display_id: DisplayId, pixmap: tiny_skia::P
 /// This is used only for an externally visible cursor with no target window.
 /// Target-bound actions continue to use [`dispatch_pin_above`] so background
 /// delivery remains below unrelated foreground applications.
-fn dispatch_order_front(display_id: DisplayId) {
+fn dispatch_order_front(generation: u64, display_id: DisplayId) {
     dispatch_on_main(Box::new(move || unsafe {
         let host = HOST.lock().unwrap();
         if let Some(surface) = host
             .as_ref()
+            .filter(|host| host.generation == generation)
             .and_then(|host| host.surfaces.get(&display_id))
         {
             let win = surface.win_ptr as *mut objc2::runtime::AnyObject;
@@ -1151,7 +1325,7 @@ fn target_is_frontmost_visible_window(
         .is_some_and(|window| u64::from(window.window_id) == target_wid)
 }
 
-fn dispatch_pin_above(display_id: DisplayId, target_wid: u64) {
+fn dispatch_pin_above(generation: u64, display_id: DisplayId, target_wid: u64) {
     let windows = crate::windows::visible_windows();
     let raise_front =
         target_is_frontmost_visible_window(target_wid, crate::apps::frontmost_pid(), &windows);
@@ -1159,6 +1333,7 @@ fn dispatch_pin_above(display_id: DisplayId, target_wid: u64) {
         let host = HOST.lock().unwrap();
         if let Some(surface) = host
             .as_ref()
+            .filter(|host| host.generation == generation)
             .and_then(|host| host.surfaces.get(&display_id))
         {
             let win = surface.win_ptr as *mut objc2::runtime::AnyObject;
@@ -1181,13 +1356,14 @@ fn dispatch_pin_above(display_id: DisplayId, target_wid: u64) {
 /// raise the overlay once in the render loop, while this enforcer remains
 /// responsible only for target-relative ordering.
 struct MacZOrderEnforcer {
+    generation: u64,
     display_id: DisplayId,
 }
 
 impl ZOrderEnforcer for MacZOrderEnforcer {
     fn reassert(&self, target: Option<u64>) {
         if let Some(wid) = target {
-            dispatch_pin_above(self.display_id, wid);
+            dispatch_pin_above(self.generation, self.display_id, wid);
         }
         // target = None → no-op; see struct doc comment.
     }
@@ -1300,6 +1476,24 @@ fn pixmap_to_cgimage(pixmap: &tiny_skia::Pixmap) -> Option<usize> {
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    #[test]
+    fn tile_frame_converts_pixel_top_left_to_appkit_points() {
+        let frame = tile_layer_frame(
+            PixelRect {
+                x: 200,
+                y: 100,
+                width: 400,
+                height: 300,
+            },
+            900.0,
+            2.0,
+        );
+        assert_eq!(frame.origin.x, 100.0);
+        assert_eq!(frame.origin.y, 700.0);
+        assert_eq!(frame.size.width, 200.0);
+        assert_eq!(frame.size.height, 150.0);
+    }
 
     #[test]
     fn keyed_render_state_carries_the_session_color_identity() {
@@ -1590,9 +1784,37 @@ mod tests {
         seed_start_in_map(&mut map, &"sessA".to_owned(), -867.0, 400.0);
         map.cursors.get_mut("sessA").unwrap().core.pos = Some((-867.0, 400.0));
 
-        assert_eq!(painted_display_ids(&map), HashSet::from([2]));
-        let pixmap = render_display(&map, secondary);
-        assert!(pixmap.data().chunks_exact(4).any(|pixel| pixel[3] > 0));
+        let state = &map.cursors["sessA"];
+        assert_eq!(state_display_ids(&map, state), vec![2]);
+        let tile = render_display_tile(&map, secondary).unwrap();
+        assert!(tile.pixmap.data().chunks_exact(4).any(|pixel| pixel[3] > 0));
+        assert!(tile.bounds.width < secondary.pixel_size().0);
+        assert!(tile.bounds.height < secondary.pixel_size().1);
+    }
+
+    #[test]
+    fn bounded_tile_preserves_the_full_display_pixels() {
+        let mut map = empty_map();
+        map.layout.displays[0].width = 1440.0;
+        map.layout.displays[0].height = 900.0;
+        seed_start_in_map(&mut map, &"sessA".to_owned(), 400.0, 400.0);
+        let state = map.cursors.get_mut("sessA").unwrap();
+        state.core.pos = Some((400.0, 400.0));
+        state.apply_command(OverlayCommand::SetSessionLabel("research".to_owned()));
+        let display = map.layout.displays[0];
+
+        let tile = render_display_tile(&map, display).unwrap();
+        let mut full = tiny_skia::Pixmap::new(1440, 900).unwrap();
+        cursor_overlay::paint_cursor(&mut full, &map.cursors["sessA"].core, 0.0, 0.0, None, 1.0);
+        let alpha_sum = |pixels: &[u8]| {
+            pixels
+                .chunks_exact(4)
+                .map(|pixel| u64::from(pixel[3]))
+                .sum::<u64>()
+        };
+        assert_eq!(alpha_sum(tile.pixmap.data()), alpha_sum(full.data()));
+        assert!(tile.bounds.width < display.pixel_size().0 / 4);
+        assert!(tile.bounds.height < display.pixel_size().1 / 4);
     }
 
     #[test]
@@ -1613,31 +1835,33 @@ mod tests {
         seed_start_in_map(&mut map, &"sessA".to_owned(), -867.0, 400.0);
 
         map.cursors.get_mut("sessA").unwrap().core.pos = Some((-1.0, 400.0));
-        assert_eq!(painted_display_ids(&map), HashSet::from([1, 2]));
-        let primary = map.layout.display(1).unwrap();
-        let primary_art = render_display(&map, primary);
-        let secondary_art = render_display(&map, secondary);
-        for pixmap in [&primary_art, &secondary_art] {
-            assert!(pixmap.data().chunks_exact(4).any(|pixel| pixel[3] > 0));
+        assert_eq!(state_display_ids(&map, &map.cursors["sessA"]), vec![1, 2]);
+        let primary = map.layout.displays[0];
+        let primary_art = render_display_tile(&map, primary).unwrap();
+        let secondary_art = render_display_tile(&map, secondary).unwrap();
+        for tile in [&primary_art, &secondary_art] {
+            assert!(tile.pixmap.data().chunks_exact(4).any(|pixel| pixel[3] > 0));
         }
 
         map.cursors
             .get_mut("sessA")
             .unwrap()
             .apply_command(OverlayCommand::SetSessionLabel("research".to_owned()));
+        let primary_with_badge = render_display_tile(&map, primary).unwrap();
+        assert_eq!(primary_with_badge.bounds, primary_art.bounds);
         assert_eq!(
-            render_display(&map, primary).data(),
-            primary_art.data(),
+            primary_with_badge.pixmap.data(),
+            primary_art.pixmap.data(),
             "the neighboring display must not duplicate the anchor display's badge"
         );
-        assert_ne!(render_display(&map, secondary).data(), secondary_art.data());
+        assert_ne!(
+            render_display_tile(&map, secondary).unwrap().bounds,
+            secondary_art.bounds
+        );
 
         map.cursors.get_mut("sessA").unwrap().core.pos = Some((400.0, 400.0));
-        assert_eq!(painted_display_ids(&map), HashSet::from([1]));
-        assert!(render_display(&map, secondary)
-            .data()
-            .chunks_exact(4)
-            .all(|pixel| pixel[3] == 0));
+        assert_eq!(state_display_ids(&map, &map.cursors["sessA"]), vec![1]);
+        assert!(render_display_tile(&map, secondary).is_none());
     }
 
     #[test]
@@ -1664,19 +1888,27 @@ mod tests {
         );
 
         assert_eq!(
-            z_order_route(&map),
-            Some(ZOrderRoute {
+            z_order_routes(&map),
+            vec![ZOrderRoute {
                 generation: 1,
                 display_id: 1,
                 target_wid: Some(77),
-            })
+            }]
         );
 
-        map.cursors.get_mut("sessA").unwrap().core.pos = Some((-400.0, 400.0));
-        assert_eq!(z_order_route(&map).unwrap().display_id, 2);
+        map.cursors.get_mut("sessA").unwrap().core.pos = Some((-1.0, 400.0));
+        assert_eq!(
+            z_order_routes(&map)
+                .into_iter()
+                .map(|route| route.display_id)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
 
         map.layout.generation = 2;
-        assert_eq!(z_order_route(&map).unwrap().generation, 2);
+        assert!(z_order_routes(&map)
+            .iter()
+            .all(|route| route.generation == 2));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
@@ -4,7 +4,7 @@
 //!
 //! The MCP/tokio server runs on a **background thread** (spawned in
 //! `cua-driver/src/main.rs`).  AppKit MUST run on the **main thread**.
-//! The two sides communicate through a global lock-free channel:
+//! The two sides communicate through a bounded process-global channel:
 //!
 //! - MCP tool calls → `send_command(OverlayCommand)` → `CMD_TX` (SyncSender)
 //! - render worker → per-display pixmaps → main-thread `AppKitOverlayHost`
@@ -32,13 +32,13 @@
 
 use std::collections::{HashMap, HashSet};
 use std::ffi::c_void;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use cursor_overlay::{
     CursorConfig, CursorKey, FocusRect, KeyedOverlayCommand, MotionConfig, OverlayCommand,
-    OverlayMsg, RenderStateCore, ZOrderEnforcer,
+    OverlayMsg, RenderStateCore,
 };
 use indexmap::IndexMap;
 
@@ -76,7 +76,7 @@ fn arrival_fire(key: &CursorKey) {
 
 enum MacOverlayMsg {
     Cursor(OverlayMsg),
-    DisplaysChanged,
+    LayoutChanged,
 }
 
 static CMD_TX: OnceLock<std::sync::mpsc::SyncSender<MacOverlayMsg>> = OnceLock::new();
@@ -85,7 +85,6 @@ static CMD_RX_CELL: Mutex<Option<std::sync::mpsc::Receiver<MacOverlayMsg>>> = Mu
 static RENDER: Mutex<Option<RenderMap>> = Mutex::new(None);
 static HOST: Mutex<Option<AppKitOverlayHost>> = Mutex::new(None);
 static DISPLAY_GENERATION: AtomicU64 = AtomicU64::new(0);
-static REBUILD_PENDING: AtomicBool = AtomicBool::new(false);
 
 /// The keyed, insertion-ordered collection of owned cursors that the render
 /// loop composites every frame. Insertion order = stable z-order (later keys
@@ -106,7 +105,7 @@ struct RenderMap {
     /// resurrection race). An explicit owner-checked `start_session` revival
     /// clears this tombstone before the cursor is reused. "default" is never
     /// tombstoned.
-    ended: std::collections::HashSet<CursorKey>,
+    ended: HashSet<CursorKey>,
 }
 
 /// Build the `RenderState` for a lazily-created session cursor from the
@@ -182,7 +181,7 @@ pub fn init(cfg: CursorConfig) {
             layout: DisplayLayout::default(),
             active_key: None,
             template: cfg,
-            ended: std::collections::HashSet::new(),
+            ended: HashSet::new(),
         });
     });
     cua_driver_core::cursor_events::install_cursor_event_sink(std::sync::Arc::new(
@@ -225,7 +224,7 @@ pub fn init(cfg: CursorConfig) {
 /// Send a keyed command from any thread (MCP tool, etc.).  Non-blocking; drops
 /// if the channel is full (old commands are less important than new ones).
 pub fn send_command(key: CursorKey, cmd: OverlayCommand) {
-    // Empty key is the explicit no-cursor sentinel for direct platform calls
+    // An empty key disables cursors for direct platform calls
     // that bypass lifecycle dispatch.
     if key.is_empty() {
         return;
@@ -244,8 +243,8 @@ pub fn send_command_default(cmd: OverlayCommand) {
 }
 
 /// Truthful render acknowledgement for lifecycle inspection. This never falls
-/// back to the seeded default cursor: an absent, off-screen, disabled, or
-/// idle-faded session cursor is not reported as visible.
+/// back to the default cursor: an absent, unplaced, disabled, or idle-faded
+/// session cursor is not reported as visible.
 pub fn is_visible_for_session(key: &str) -> bool {
     RENDER
         .lock()
@@ -254,7 +253,7 @@ pub fn is_visible_for_session(key: &str) -> bool {
             guard
                 .as_ref()
                 .and_then(|map| map.cursors.get(key))
-                .map(cursor_is_externally_visible)
+                .map(cursor_is_visible)
         })
         .unwrap_or(false)
 }
@@ -363,7 +362,7 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
         .cursors
         .entry(key.clone())
         .or_insert_with(|| render_state_for_key(&template, &k));
-    if !(rs.core.cfg.enabled && !rs.placed) {
+    if !(rs.core.cfg.enabled && !rs.core.placed) {
         return false;
     }
     let mut sx = target_x - SEED_OFFSET;
@@ -383,7 +382,7 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
         }
     }
     rs.core.pos = (sx, sy);
-    rs.placed = true;
+    rs.core.placed = true;
     true
 }
 
@@ -397,7 +396,7 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
 /// in (it previously snapped silently via `ClickPulse`, invisible on a pure-AX
 /// run).
 pub async fn animate_cursor_to(key: CursorKey, x: f64, y: f64) {
-    // Empty key is the explicit no-cursor sentinel → nothing to animate.
+    // An empty key disables cursors for direct platform calls.
     if key.is_empty() {
         return;
     }
@@ -412,7 +411,7 @@ pub async fn animate_cursor_to(key: CursorKey, x: f64, y: f64) {
         let guard = RENDER.lock().unwrap();
         matches!(
             guard.as_ref().and_then(|m| m.cursors.get(&key)),
-            Some(rs) if rs.core.cfg.enabled && rs.placed
+            Some(rs) if rs.core.cfg.enabled && rs.core.placed
         )
     };
     if !should_animate {
@@ -497,12 +496,10 @@ pub fn run_on_main_thread() {
 //
 // The platform-agnostic fields + tick + apply_command + render pipeline live
 // in `cursor_overlay::render_state` (2026-05 dedup audit). What stays here
-// is the macOS-specific NSScreen window dimensions and the focus-rect
-// overlay (a macOS-only post-arrival element highlight).
+// is macOS display presentation and the focus-rect overlay.
 
 struct RenderState {
     core: RenderStateCore,
-    placed: bool,
     /// Focus-highlight rectangle `[x, y, w, h]` in screen coords; None = not shown.
     focus_rect: Option<[f64; 4]>,
     /// Fade progress for the focus rect: 0.0 = fully visible, 1.0 = gone.
@@ -513,7 +510,6 @@ impl RenderState {
     fn new(cfg: CursorConfig) -> Self {
         RenderState {
             core: RenderStateCore::new(cfg),
-            placed: false,
             focus_rect: None,
             focus_rect_t: 1.0,
         }
@@ -548,14 +544,7 @@ impl RenderState {
                 self.focus_rect_t = 0.0; // reset fade to fully visible
             }
             other => {
-                let places = matches!(
-                    other,
-                    OverlayCommand::MoveTo { .. }
-                        | OverlayCommand::SnapTo { .. }
-                        | OverlayCommand::ClickPulse { .. }
-                );
                 let _ = self.core.apply_command_base(other, true, true);
-                self.placed |= places;
             }
         }
     }
@@ -563,14 +552,14 @@ impl RenderState {
     /// True while the render loop must wake at frame cadence because the next
     /// tick can change pixels. A brand-new unplaced cursor is deliberately
     /// quiescent, so `serve` with no agent activity can block on the command
-    /// channel instead of compositing an empty fullscreen pixmap at 60fps.
+    /// channel instead of compositing empty display pixmaps at 60fps.
     fn needs_frame_tick(&self) -> bool {
         self.core.path.is_some()
             || self.core.spring.is_some()
             || self.core.click_t.is_some()
             || self.focus_rect.is_some()
             || self.core.session_badge_needs_frame_tick()
-            || (self.core.motion.idle_hide_ms > 0.0 && cursor_is_externally_visible(self))
+            || (self.core.motion.idle_hide_ms > 0.0 && cursor_is_visible(self))
     }
 }
 
@@ -578,10 +567,10 @@ fn render_map_needs_frame_tick(map: &RenderMap) -> bool {
     map.cursors.values().any(RenderState::needs_frame_tick)
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct ZOrderRoute {
     generation: u64,
-    display_id: DisplayId,
+    display_ids: Vec<DisplayId>,
     target_wid: Option<u64>,
 }
 
@@ -590,12 +579,18 @@ fn z_order_route(map: &RenderMap) -> Option<ZOrderRoute> {
         .active_key
         .as_ref()
         .and_then(|key| map.cursors.get(key))
-        .filter(|state| cursor_is_externally_visible(state))?;
-    let (x, y) = state.core.pos;
-    let display_id = map.layout.display_at(x, y)?.id;
-    Some(ZOrderRoute {
+        .filter(|state| cursor_is_visible(state))?;
+    let display_ids = map
+        .layout
+        .displays
+        .iter()
+        .copied()
+        .filter(|display| state_paints_display(state, *display))
+        .map(|display| display.id)
+        .collect::<Vec<_>>();
+    (!display_ids.is_empty()).then_some(ZOrderRoute {
         generation: map.layout.generation,
-        display_id,
+        display_ids,
         target_wid: state.core.pinned_wid,
     })
 }
@@ -759,15 +754,10 @@ fn register_display_reconfiguration_callback() {
 }
 
 fn dispatch_rebuild_appkit_host() {
-    if REBUILD_PENDING.swap(true, Ordering::AcqRel) {
-        return;
-    }
     dispatch_on_main(Box::new(|| unsafe {
-        let rebuilt = rebuild_appkit_host();
-        REBUILD_PENDING.store(false, Ordering::Release);
-        if rebuilt {
+        if rebuild_appkit_host() {
             if let Some(tx) = CMD_TX.get() {
-                let _ = tx.try_send(MacOverlayMsg::DisplaysChanged);
+                let _ = tx.try_send(MacOverlayMsg::LayoutChanged);
             }
         }
     }));
@@ -836,7 +826,7 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
                         };
                         apply_msg(map, message);
                     }
-                    MacOverlayMsg::DisplaysChanged => layout_changed = true,
+                    MacOverlayMsg::LayoutChanged => layout_changed = true,
                 }
             };
             if let Some(message) = first_msg {
@@ -898,16 +888,21 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
         if frame_tick_needed || had_msg {
             repin_frames += 1;
             let route_changed = z_order != presented_z_order;
-            if let Some(route) = z_order {
-                if route.target_wid.is_some() && (route_changed || repin_frames >= 60) {
-                    MacZOrderEnforcer {
-                        display_id: route.display_id,
+            if let Some(route) = z_order.as_ref() {
+                match route.target_wid {
+                    Some(target_wid) if route_changed || repin_frames >= 60 => {
+                        for display_id in &route.display_ids {
+                            dispatch_pin_above(*display_id, target_wid);
+                        }
+                        repin_frames = 0;
                     }
-                    .reassert(route.target_wid);
-                    repin_frames = 0;
-                } else if route.target_wid.is_none() && (route_changed || cursor_commanded) {
-                    dispatch_order_front(route.display_id);
-                    repin_frames = 0;
+                    None if route_changed || cursor_commanded => {
+                        for display_id in &route.display_ids {
+                            dispatch_order_front(*display_id);
+                        }
+                        repin_frames = 0;
+                    }
+                    _ => {}
                 }
             }
             presented_z_order = z_order;
@@ -964,46 +959,36 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
     }
 }
 
-// Matches the established default-theme envelope used by the X11 tile path.
-const DEFAULT_CURSOR_PAINT_RADIUS: f64 = 64.0;
-
 /// Displays whose buffers can contain pixels in the current frame. This is
 /// based on painted bounds, not cursor ownership: artwork may span a seam.
 fn painted_display_ids(map: &RenderMap) -> HashSet<DisplayId> {
-    let mut painted = HashSet::new();
-    for state in map.cursors.values() {
-        if cursor_is_externally_visible(state) {
-            let (x, y) = state.core.pos;
-            let custom_theme = state
-                .core
-                .theme
-                .as_deref()
-                .is_some_and(|theme| theme.id != cursor_overlay::DEFAULT_THEME_ID);
-            for display in &map.layout.displays {
-                if custom_theme
-                    || rectangles_intersect(
-                        (
-                            x - DEFAULT_CURSOR_PAINT_RADIUS,
-                            y - DEFAULT_CURSOR_PAINT_RADIUS,
-                            DEFAULT_CURSOR_PAINT_RADIUS * 2.0,
-                            DEFAULT_CURSOR_PAINT_RADIUS * 2.0,
-                        ),
-                        *display,
-                    )
-                {
-                    painted.insert(display.id);
-                }
-            }
-        }
-        if let Some([x, y, width, height]) = state.focus_rect {
-            for display in &map.layout.displays {
-                if rectangles_intersect((x, y, width, height), *display) {
-                    painted.insert(display.id);
-                }
-            }
-        }
+    map.cursors
+        .values()
+        .flat_map(|state| {
+            map.layout
+                .displays
+                .iter()
+                .copied()
+                .filter(|display| state_paints_display(state, *display))
+                .map(|display| display.id)
+        })
+        .collect()
+}
+
+fn state_paints_display(state: &RenderState, display: DisplayGeometry) -> bool {
+    if !cursor_is_visible(state) {
+        return false;
     }
-    painted
+    let (x, y) = state.core.pos;
+    let radius = state.core.paint_radius();
+    let cursor_intersects = rectangles_intersect(
+        (x - radius, y - radius, radius * 2.0, radius * 2.0),
+        display,
+    );
+    let focus_intersects = state
+        .focus_rect
+        .is_some_and(|[x, y, width, height]| rectangles_intersect((x, y, width, height), display));
+    cursor_intersects || focus_intersects
 }
 
 fn rectangles_intersect(rect: (f64, f64, f64, f64), display: DisplayGeometry) -> bool {
@@ -1021,7 +1006,7 @@ fn render_display(map: &RenderMap, display: DisplayGeometry) -> tiny_skia::Pixma
     let mut pixmap = tiny_skia::Pixmap::new(width, height)
         .unwrap_or_else(|| tiny_skia::Pixmap::new(1, 1).unwrap());
     for state in map.cursors.values() {
-        if !cursor_is_externally_visible(state) {
+        if !state_paints_display(state, display) {
             continue;
         }
         let focus = state.focus_rect.map(|rect| FocusRect {
@@ -1029,6 +1014,7 @@ fn render_display(map: &RenderMap, display: DisplayGeometry) -> tiny_skia::Pixma
             t: state.focus_rect_t,
         });
         let anchor_display = state
+            .core
             .placed
             .then_some(state.core.pos)
             .and_then(|(x, y)| map.layout.display_at(x, y))
@@ -1062,8 +1048,11 @@ fn hardware_cursor_position() -> Option<(f64, f64)> {
     Some((location.x, location.y))
 }
 
-fn cursor_is_externally_visible(state: &RenderState) -> bool {
-    state.placed && state.core.cfg.enabled && state.core.visible && state.core.idle_alpha >= 0.004
+fn cursor_is_visible(state: &RenderState) -> bool {
+    state.core.placed
+        && state.core.cfg.enabled
+        && state.core.visible
+        && state.core.idle_alpha >= 0.004
 }
 
 type MainWork = Box<dyn FnOnce() + Send>;
@@ -1182,29 +1171,6 @@ fn dispatch_pin_above(display_id: DisplayId, target_wid: u64) {
             }
         }
     }));
-}
-
-// ── Z-order enforcer (macOS impl of cursor_overlay::ZOrderEnforcer) ──────
-
-/// macOS implementation of [`cursor_overlay::ZOrderEnforcer`].
-///
-/// Identifies the display surface and dispatches target-relative ordering to
-/// the main-thread AppKit host.
-///
-/// `target = None` is treated as a no-op here. Direct unpinned cursor commands
-/// raise the overlay once in the render loop, while this enforcer remains
-/// responsible only for target-relative ordering.
-struct MacZOrderEnforcer {
-    display_id: DisplayId,
-}
-
-impl ZOrderEnforcer for MacZOrderEnforcer {
-    fn reassert(&self, target: Option<u64>) {
-        if let Some(wid) = target {
-            dispatch_pin_above(self.display_id, wid);
-        }
-        // target = None → no-op; see struct doc comment.
-    }
 }
 
 /// Create a `CGImage` from a `tiny_skia::Pixmap` (premultiplied RGBA).
@@ -1364,7 +1330,7 @@ mod tests {
             },
             active_key: None,
             template: CursorConfig::default(),
-            ended: std::collections::HashSet::new(),
+            ended: HashSet::new(),
         }
     }
 
@@ -1535,20 +1501,18 @@ mod tests {
     }
 
     #[test]
-    fn seed_places_cursor_on_screen_for_first_action() {
-        // BUG 2 regression: a brand-new session cursor without a position must be
-        // seeded on-screen (pos.0 > -50) so the immediately-following MoveTo
-        // glides instead of silently snapping via ClickPulse.
+    fn seed_places_cursor_inside_a_display_for_first_action() {
+        // The first MoveTo needs a display-valid start to produce a visible glide.
         let mut map = empty_map(); // 100x100 frame
                                    // No "sessA" cursor exists yet — the seed must get-or-create it.
         let seeded = seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
         assert!(seeded, "unplaced cursor must be seeded");
         let pos = map.cursors["sessA"].core.pos;
         assert!(
-            pos.0 > -50.0 && pos.1 > -50.0,
-            "seed must be on-screen, got {pos:?}"
+            map.layout.display_at(pos.0, pos.1).is_some(),
+            "seed must be inside a display, got {pos:?}"
         );
-        // And it must be a DIFFERENT point from the target so there is a glide.
+        // It must differ from the target so there is a glide.
         assert!(
             (pos.0 - 60.0).abs() > 4.0 || (pos.1 - 60.0).abs() > 4.0,
             "seed must differ from target to produce a visible glide, got {pos:?}"
@@ -1556,16 +1520,13 @@ mod tests {
     }
 
     #[test]
-    fn seed_is_noop_when_cursor_already_on_screen() {
-        // A second action: the cursor already landed somewhere on-screen, so the
-        // seed must NOT move it (the MoveTo path should start from where it is).
+    fn seed_is_noop_when_cursor_is_already_placed() {
         let mut map = empty_map();
-        // Put sessA on-screen first.
         seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
         map.cursors.get_mut("sessA").unwrap().core.pos = (30.0, 30.0);
-        map.cursors.get_mut("sessA").unwrap().placed = true;
+        map.cursors.get_mut("sessA").unwrap().core.placed = true;
         let seeded_again = seed_start_in_map(&mut map, &"sessA".to_owned(), 80.0, 80.0);
-        assert!(!seeded_again, "on-screen cursor must not be re-seeded");
+        assert!(!seeded_again, "placed cursor must not be re-seeded");
         assert_eq!(
             map.cursors["sessA"].core.pos,
             (30.0, 30.0),
@@ -1578,7 +1539,7 @@ mod tests {
         let mut map = empty_map();
         seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
         map.cursors.get_mut("sessA").unwrap().core.pos = (-867.0, 400.0);
-        map.cursors.get_mut("sessA").unwrap().placed = true;
+        map.cursors.get_mut("sessA").unwrap().core.placed = true;
 
         assert!(!seed_start_in_map(
             &mut map,
@@ -1587,7 +1548,14 @@ mod tests {
             80.0
         ));
         assert_eq!(map.cursors["sessA"].core.pos, (-867.0, 400.0));
-        assert!(cursor_is_externally_visible(&map.cursors["sessA"]));
+        assert!(cursor_is_visible(&map.cursors["sessA"]));
+
+        apply_msg(&mut map, move_msg("sessA", -500.0, 400.0));
+        assert_eq!(
+            map.cursors["sessA"].core.pos,
+            (-867.0, 400.0),
+            "negative placement must remain the path start"
+        );
     }
 
     #[test]
@@ -1605,7 +1573,7 @@ mod tests {
         map.layout.displays.push(secondary);
         seed_start_in_map(&mut map, &"sessA".to_owned(), -867.0, 400.0);
         map.cursors.get_mut("sessA").unwrap().core.pos = (-867.0, 400.0);
-        map.cursors.get_mut("sessA").unwrap().placed = true;
+        map.cursors.get_mut("sessA").unwrap().core.placed = true;
 
         assert_eq!(painted_display_ids(&map), HashSet::from([2]));
         let pixmap = render_display(&map, secondary);
@@ -1630,7 +1598,7 @@ mod tests {
         seed_start_in_map(&mut map, &"sessA".to_owned(), -867.0, 400.0);
 
         map.cursors.get_mut("sessA").unwrap().core.pos = (-1.0, 400.0);
-        map.cursors.get_mut("sessA").unwrap().placed = true;
+        map.cursors.get_mut("sessA").unwrap().core.placed = true;
         assert_eq!(painted_display_ids(&map), HashSet::from([1, 2]));
         let primary = map.layout.displays[0];
         let primary_art = render_display(&map, primary);
@@ -1651,7 +1619,7 @@ mod tests {
         assert_ne!(render_display(&map, secondary).data(), secondary_art.data());
 
         map.cursors.get_mut("sessA").unwrap().core.pos = (400.0, 400.0);
-        map.cursors.get_mut("sessA").unwrap().placed = true;
+        map.cursors.get_mut("sessA").unwrap().core.placed = true;
         assert_eq!(painted_display_ids(&map), HashSet::from([1]));
         assert!(render_display(&map, secondary)
             .data()
@@ -1686,14 +1654,16 @@ mod tests {
             z_order_route(&map),
             Some(ZOrderRoute {
                 generation: 1,
-                display_id: 1,
+                display_ids: vec![1],
                 target_wid: Some(77),
             })
         );
 
+        map.cursors.get_mut("sessA").unwrap().core.pos = (-1.0, 400.0);
+        assert_eq!(z_order_route(&map).unwrap().display_ids, vec![1, 2]);
+
         map.cursors.get_mut("sessA").unwrap().core.pos = (-400.0, 400.0);
-        map.cursors.get_mut("sessA").unwrap().placed = true;
-        assert_eq!(z_order_route(&map).unwrap().display_id, 2);
+        assert_eq!(z_order_route(&map).unwrap().display_ids, vec![2]);
 
         map.layout.generation = 2;
         assert_eq!(z_order_route(&map).unwrap().generation, 2);
@@ -1715,23 +1685,22 @@ mod tests {
 
     #[test]
     fn unplaced_default_cursor_does_not_require_frame_ticks() {
-        // Regression for idle CPU: a freshly-started serve daemon seeds only the
-        // off-screen default cursor. With no commands in flight, the render loop
-        // should be able to block on rx.recv() instead of repainting at 60fps.
+        // An untouched cursor must let the render loop block instead of
+        // repainting at 60 fps.
         let map = empty_map();
         assert!(!render_map_needs_frame_tick(&map));
     }
 
     #[test]
-    fn only_enabled_on_screen_cursor_is_externally_visible() {
+    fn only_enabled_placed_cursor_is_visible() {
         let mut map = empty_map();
-        assert!(!cursor_is_externally_visible(&map.cursors["default"]));
+        assert!(!cursor_is_visible(&map.cursors["default"]));
 
         seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
-        assert!(cursor_is_externally_visible(&map.cursors["sessA"]));
+        assert!(cursor_is_visible(&map.cursors["sessA"]));
 
         map.cursors.get_mut("sessA").unwrap().core.cfg.enabled = false;
-        assert!(!cursor_is_externally_visible(&map.cursors["sessA"]));
+        assert!(!cursor_is_visible(&map.cursors["sessA"]));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/cursor/overlay.rs
@@ -4,7 +4,7 @@
 //!
 //! The MCP/tokio server runs on a **background thread** (spawned in
 //! `cua-driver/src/main.rs`).  AppKit MUST run on the **main thread**.
-//! The two sides communicate through a global lock-free channel:
+//! The two sides communicate through a bounded process-global channel:
 //!
 //! - MCP tool calls → `send_command(OverlayCommand)` → `CMD_TX` (SyncSender)
 //! - render worker → bounded per-display tiles → one-slot presentation mailbox
@@ -31,7 +31,7 @@
 //! variants of MoveTo / ClickPulse — see the wrapper around
 //! `apply_command_base` below.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ffi::c_void;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
@@ -39,11 +39,11 @@ use std::time::{Duration, Instant};
 
 use cursor_overlay::{
     CursorConfig, CursorKey, FocusRect, KeyedOverlayCommand, MotionConfig, OverlayCommand,
-    OverlayMsg, RenderStateCore, ZOrderEnforcer,
+    OverlayMsg, RenderStateCore,
 };
 use indexmap::IndexMap;
 
-use super::display_layout::{DisplayGeometry, DisplayId, DisplayLayout, GlobalPoint};
+use super::display_layout::{DisplayGeometry, DisplayId, DisplayLayout};
 
 // ── Arrival-signal channels (one waiter slot per cursor key) ──────────────
 //
@@ -77,7 +77,7 @@ fn arrival_fire(key: &CursorKey) {
 
 enum MacOverlayMsg {
     Cursor(OverlayMsg),
-    DisplaysChanged,
+    LayoutChanged,
 }
 
 static CMD_TX: OnceLock<std::sync::mpsc::SyncSender<MacOverlayMsg>> = OnceLock::new();
@@ -108,7 +108,7 @@ struct RenderMap {
     /// resurrection race). An explicit owner-checked `start_session` revival
     /// clears this tombstone before the cursor is reused. "default" is never
     /// tombstoned.
-    ended: std::collections::HashSet<CursorKey>,
+    ended: HashSet<CursorKey>,
 }
 
 /// Build the `RenderState` for a lazily-created session cursor from the
@@ -184,7 +184,7 @@ pub fn init(cfg: CursorConfig) {
             layout: DisplayLayout::default(),
             active_key: None,
             template: cfg,
-            ended: std::collections::HashSet::new(),
+            ended: HashSet::new(),
         });
     });
     cua_driver_core::cursor_events::install_cursor_event_sink(std::sync::Arc::new(
@@ -227,7 +227,7 @@ pub fn init(cfg: CursorConfig) {
 /// Send a keyed command from any thread (MCP tool, etc.).  Non-blocking; drops
 /// if the channel is full (old commands are less important than new ones).
 pub fn send_command(key: CursorKey, cmd: OverlayCommand) {
-    // Empty key is the explicit no-cursor sentinel for direct platform calls
+    // An empty key disables cursors for direct platform calls
     // that bypass lifecycle dispatch.
     if key.is_empty() {
         return;
@@ -246,7 +246,7 @@ pub fn send_command_default(cmd: OverlayCommand) {
 }
 
 /// Truthful render acknowledgement for lifecycle inspection. This never falls
-/// back to the seeded default cursor: an absent, off-screen, disabled, or
+/// back to the seeded default cursor: an absent, unplaced, disabled, or
 /// idle-faded session cursor is not reported as visible.
 pub fn is_visible_for_session(key: &str) -> bool {
     RENDER
@@ -256,7 +256,7 @@ pub fn is_visible_for_session(key: &str) -> bool {
             guard
                 .as_ref()
                 .and_then(|map| map.cursors.get(key))
-                .map(cursor_is_externally_visible)
+                .map(|state| state.core.cursor_is_revealed())
         })
         .unwrap_or(false)
 }
@@ -349,10 +349,7 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
     // Offset the start up-left of the target so the Dubins path has room to
     // curve in; 140pt is enough to read as motion at 900pt/s peak speed.
     const SEED_OFFSET: f64 = 140.0;
-    let target_display = map.layout.display_for_or_primary(GlobalPoint {
-        x: target_x,
-        y: target_y,
-    });
+    let target_display = map.layout.display_for_or_primary(target_x, target_y);
     // Respect the resurrection guard: never seed (and thus re-create) a cursor
     // whose session already ended.
     if map.ended.contains(key) {
@@ -368,7 +365,7 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
         .cursors
         .entry(key.clone())
         .or_insert_with(|| render_state_for_key(&template, &k));
-    if !(rs.core.cfg.enabled && rs.core.pos.is_none()) {
+    if !(rs.core.visible && rs.core.pos.is_none()) {
         return false;
     }
     let mut sx = target_x - SEED_OFFSET;
@@ -401,7 +398,7 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
 /// in (it previously snapped silently via `ClickPulse`, invisible on a pure-AX
 /// run).
 pub async fn animate_cursor_to(key: CursorKey, x: f64, y: f64) {
-    // Empty key is the explicit no-cursor sentinel → nothing to animate.
+    // An empty key disables cursors for direct platform calls.
     if key.is_empty() {
         return;
     }
@@ -416,7 +413,7 @@ pub async fn animate_cursor_to(key: CursorKey, x: f64, y: f64) {
         let guard = RENDER.lock().unwrap();
         matches!(
             guard.as_ref().and_then(|m| m.cursors.get(&key)),
-            Some(rs) if rs.core.cfg.enabled && rs.core.pos.is_some()
+            Some(rs) if rs.core.visible && rs.core.pos.is_some()
         )
     };
     if !should_animate {
@@ -501,8 +498,7 @@ pub fn run_on_main_thread() {
 //
 // The platform-agnostic fields + tick + apply_command + render pipeline live
 // in `cursor_overlay::render_state` (2026-05 dedup audit). What stays here
-// is the macOS-specific NSScreen window dimensions and the focus-rect
-// overlay (a macOS-only post-arrival element highlight).
+// is the macOS-specific focus-rect overlay and native presentation host.
 
 struct RenderState {
     core: RenderStateCore,
@@ -558,7 +554,7 @@ impl RenderState {
     /// True while the render loop must wake at frame cadence because the next
     /// tick can change pixels. A brand-new unplaced cursor is deliberately
     /// quiescent, so `serve` with no agent activity can block on the command
-    /// channel instead of compositing an empty fullscreen pixmap at 60fps.
+    /// channel instead of producing empty frames at 60 fps.
     fn needs_frame_tick(&self) -> bool {
         self.core.path.is_some()
             || self.core.spring.is_some()
@@ -585,7 +581,7 @@ fn z_order_routes(map: &RenderMap) -> Vec<ZOrderRoute> {
         .active_key
         .as_ref()
         .and_then(|key| map.cursors.get(key))
-        .filter(|state| cursor_is_externally_visible(state))
+        .filter(|state| state.core.cursor_is_revealed())
     else {
         return Vec::new();
     };
@@ -776,7 +772,7 @@ fn dispatch_rebuild_appkit_host() {
             REBUILD_REQUESTED.store(false, Ordering::Release);
             if rebuild_appkit_host() {
                 if let Some(tx) = CMD_TX.get() {
-                    let _ = tx.try_send(MacOverlayMsg::DisplaysChanged);
+                    let _ = tx.try_send(MacOverlayMsg::LayoutChanged);
                 }
             }
             if !REBUILD_REQUESTED.swap(false, Ordering::AcqRel) {
@@ -844,15 +840,12 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
 
             let mut apply = |message: MacOverlayMsg| {
                 had_msg = true;
-                match message {
-                    MacOverlayMsg::Cursor(message) => {
-                        cursor_commanded |= match &message {
-                            OverlayMsg::Cmd(command) => !map.ended.contains(&command.key),
-                            _ => false,
-                        };
-                        apply_msg(map, message);
-                    }
-                    MacOverlayMsg::DisplaysChanged => {}
+                if let MacOverlayMsg::Cursor(message) = message {
+                    cursor_commanded |= match &message {
+                        OverlayMsg::Cmd(command) => !map.ended.contains(&command.key),
+                        _ => false,
+                    };
+                    apply_msg(map, message);
                 }
             };
             if let Some(message) = first_msg {
@@ -913,49 +906,48 @@ fn render_loop(rx: std::sync::mpsc::Receiver<MacOverlayMsg>) {
         if frame_tick_needed || had_msg {
             repin_frames += 1;
             let route_changed = z_order != presented_z_order;
+            let periodic_repin = repin_frames >= 60;
+            let mut ordered = false;
             for route in &z_order {
-                let surface_changed = !presented_z_order.contains(route);
-                if route.target_wid.is_some() && (surface_changed || repin_frames >= 60) {
-                    MacZOrderEnforcer {
-                        generation: route.generation,
-                        display_id: route.display_id,
+                match route.target_wid {
+                    Some(target_wid) if periodic_repin || !presented_z_order.contains(route) => {
+                        dispatch_pin_above(route.generation, route.display_id, target_wid);
+                        ordered = true;
                     }
-                    .reassert(route.target_wid);
-                } else if route.target_wid.is_none() && (route_changed || cursor_commanded) {
-                    dispatch_order_front(route.generation, route.display_id);
+                    None if route_changed || cursor_commanded => {
+                        dispatch_order_front(route.generation, route.display_id);
+                        ordered = true;
+                    }
+                    _ => {}
                 }
             }
-            if (z_order.iter().any(|route| route.target_wid.is_some())
-                && (route_changed || repin_frames >= 60))
-                || (z_order.iter().any(|route| route.target_wid.is_none())
-                    && (route_changed || cursor_commanded))
-            {
+            if periodic_repin || ordered {
                 repin_frames = 0;
             }
             presented_z_order = z_order;
-            if repin_frames >= 60 {
-                repin_frames = 0;
-            }
         }
 
         if had_msg || hover_changed || frame_tick_needed || next_frame_tick_needed {
-            let frames = {
+            let batch = {
                 let guard = RENDER.lock().unwrap();
                 let Some(map) = guard.as_ref() else {
                     break;
                 };
-                map.layout
-                    .displays
-                    .iter()
-                    .copied()
-                    .map(|display| DisplayFrame {
-                        generation: map.layout.generation,
-                        display_id: display.id,
-                        tile: render_display_tile(map, display),
-                    })
-                    .collect()
+                FrameBatch {
+                    generation: map.layout.generation,
+                    surfaces: map
+                        .layout
+                        .displays
+                        .iter()
+                        .copied()
+                        .map(|display| SurfaceFrame {
+                            display_id: display.id,
+                            tile: render_display_tile(map, display),
+                        })
+                        .collect(),
+                }
             };
-            queue_present(frames);
+            queue_present(batch);
         }
 
         frame_tick_needed = next_frame_tick_needed;
@@ -1052,11 +1044,11 @@ fn badge_layout_for_display(
     state: &RenderState,
     display: DisplayGeometry,
 ) -> Option<cursor_overlay::SessionBadgeLayout> {
-    if !cursor_is_externally_visible(state) {
+    if !state.core.cursor_is_revealed() {
         return None;
     }
     let (x, y) = state.core.pos?;
-    if map.layout.route(GlobalPoint { x, y })?.0 != display.id {
+    if map.layout.display_at(x, y)?.id != display.id {
         return None;
     }
     let scale = display.backing_scale.max(1.0) as f32;
@@ -1082,7 +1074,7 @@ fn state_pixel_bounds(
     state: &RenderState,
     display: DisplayGeometry,
 ) -> Option<PixelRect> {
-    if !cursor_is_externally_visible(state) {
+    if !state.core.cursor_is_revealed() {
         return None;
     }
     let (x, y) = state.core.pos?;
@@ -1174,17 +1166,17 @@ fn hardware_cursor_position() -> Option<(f64, f64)> {
     Some((location.x, location.y))
 }
 
-fn cursor_is_externally_visible(state: &RenderState) -> bool {
-    state.core.cfg.enabled && state.core.cursor_is_revealed()
-}
-
-struct DisplayFrame {
-    generation: u64,
+struct SurfaceFrame {
     display_id: DisplayId,
     tile: Option<RenderedTile>,
 }
 
-static PRESENT_MAILBOX: Mutex<Option<Vec<DisplayFrame>>> = Mutex::new(None);
+struct FrameBatch {
+    generation: u64,
+    surfaces: Vec<SurfaceFrame>,
+}
+
+static PRESENT_MAILBOX: Mutex<Option<FrameBatch>> = Mutex::new(None);
 static PRESENT_SCHEDULED: AtomicBool = AtomicBool::new(false);
 
 type MainWork = Box<dyn FnOnce() + Send>;
@@ -1215,8 +1207,8 @@ fn dispatch_on_main(work: MainWork) {
 /// Replace the pending presentation batch. At most one batch is queued on the
 /// main thread, so a busy renderer drops stale frames instead of retaining
 /// unbounded image buffers.
-fn queue_present(frames: Vec<DisplayFrame>) {
-    *PRESENT_MAILBOX.lock().unwrap() = Some(frames);
+fn queue_present(batch: FrameBatch) {
+    *PRESENT_MAILBOX.lock().unwrap() = Some(batch);
     schedule_present();
 }
 
@@ -1225,8 +1217,8 @@ fn schedule_present() {
         return;
     }
     dispatch_on_main(Box::new(|| unsafe {
-        if let Some(frames) = PRESENT_MAILBOX.lock().unwrap().take() {
-            present_frames(frames);
+        if let Some(batch) = PRESENT_MAILBOX.lock().unwrap().take() {
+            present_frames(batch);
         }
         PRESENT_SCHEDULED.store(false, Ordering::Release);
         if PRESENT_MAILBOX.lock().unwrap().is_some() {
@@ -1235,7 +1227,7 @@ fn schedule_present() {
     }));
 }
 
-unsafe fn present_frames(frames: Vec<DisplayFrame>) {
+unsafe fn present_frames(batch: FrameBatch) {
     use objc2::{class, msg_send};
 
     extern "C" {
@@ -1246,12 +1238,12 @@ unsafe fn present_frames(frames: Vec<DisplayFrame>) {
     let Some(host) = host.as_ref() else {
         return;
     };
+    if host.generation != batch.generation {
+        return;
+    }
     let _: () = msg_send![class!(CATransaction), begin];
     let _: () = msg_send![class!(CATransaction), setDisableActions: true];
-    for frame in frames {
-        if host.generation != frame.generation {
-            continue;
-        }
+    for frame in batch.surfaces {
         let Some(surface) = host.surfaces.get(&frame.display_id) else {
             continue;
         };
@@ -1343,30 +1335,6 @@ fn dispatch_pin_above(generation: u64, display_id: DisplayId, target_wid: u64) {
             }
         }
     }));
-}
-
-// ── Z-order enforcer (macOS impl of cursor_overlay::ZOrderEnforcer) ──────
-
-/// macOS implementation of [`cursor_overlay::ZOrderEnforcer`].
-///
-/// Identifies the display surface and dispatches target-relative ordering to
-/// the main-thread AppKit host.
-///
-/// `target = None` is treated as a no-op here. Direct unpinned cursor commands
-/// raise the overlay once in the render loop, while this enforcer remains
-/// responsible only for target-relative ordering.
-struct MacZOrderEnforcer {
-    generation: u64,
-    display_id: DisplayId,
-}
-
-impl ZOrderEnforcer for MacZOrderEnforcer {
-    fn reassert(&self, target: Option<u64>) {
-        if let Some(wid) = target {
-            dispatch_pin_above(self.generation, self.display_id, wid);
-        }
-        // target = None → no-op; see struct doc comment.
-    }
 }
 
 /// Create a `CGImage` from a `tiny_skia::Pixmap` (premultiplied RGBA).
@@ -1544,7 +1512,7 @@ mod tests {
             },
             active_key: None,
             template: CursorConfig::default(),
-            ended: std::collections::HashSet::new(),
+            ended: HashSet::new(),
         }
     }
 
@@ -1715,18 +1683,17 @@ mod tests {
     }
 
     #[test]
-    fn seed_places_cursor_on_screen_for_first_action() {
-        // BUG 2 regression: a brand-new session cursor without a position must be
-        // seeded on-screen (pos.0 > -50) so the immediately-following MoveTo
-        // glides instead of silently snapping via ClickPulse.
+    fn seed_places_cursor_inside_a_display_for_first_action() {
+        // A brand-new session cursor needs a display-valid start so the first
+        // MoveTo produces a visible glide instead of a zero-length path.
         let mut map = empty_map(); // 100x100 frame
                                    // No "sessA" cursor exists yet — the seed must get-or-create it.
         let seeded = seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
         assert!(seeded, "unplaced cursor must be seeded");
         let pos = map.cursors["sessA"].core.pos.expect("seeded position");
         assert!(
-            pos.0 > -50.0 && pos.1 > -50.0,
-            "seed must be on-screen, got {pos:?}"
+            map.layout.display_at(pos.0, pos.1).is_some(),
+            "seed must be inside a display, got {pos:?}"
         );
         // And it must be a DIFFERENT point from the target so there is a glide.
         assert!(
@@ -1736,15 +1703,13 @@ mod tests {
     }
 
     #[test]
-    fn seed_is_noop_when_cursor_already_on_screen() {
-        // A second action: the cursor already landed somewhere on-screen, so the
-        // seed must NOT move it (the MoveTo path should start from where it is).
+    fn seed_is_noop_when_cursor_is_already_placed() {
+        // A later action must start from the cursor's current placement.
         let mut map = empty_map();
-        // Put sessA on-screen first.
         seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
         map.cursors.get_mut("sessA").unwrap().core.pos = Some((30.0, 30.0));
         let seeded_again = seed_start_in_map(&mut map, &"sessA".to_owned(), 80.0, 80.0);
-        assert!(!seeded_again, "on-screen cursor must not be re-seeded");
+        assert!(!seeded_again, "placed cursor must not be re-seeded");
         assert_eq!(
             map.cursors["sessA"].core.pos,
             Some((30.0, 30.0)),
@@ -1765,7 +1730,7 @@ mod tests {
             80.0
         ));
         assert_eq!(map.cursors["sessA"].core.pos, Some((-867.0, 400.0)));
-        assert!(cursor_is_externally_visible(&map.cursors["sessA"]));
+        assert!(map.cursors["sessA"].core.cursor_is_revealed());
     }
 
     #[test]
@@ -1927,23 +1892,11 @@ mod tests {
 
     #[test]
     fn unplaced_default_cursor_does_not_require_frame_ticks() {
-        // Regression for idle CPU: a freshly-started serve daemon seeds only the
-        // off-screen default cursor. With no commands in flight, the render loop
+        // Regression for idle CPU: a freshly-started serve daemon has only an
+        // unplaced default cursor. With no commands in flight, the render loop
         // should be able to block on rx.recv() instead of repainting at 60fps.
         let map = empty_map();
         assert!(!render_map_needs_frame_tick(&map));
-    }
-
-    #[test]
-    fn only_enabled_on_screen_cursor_is_externally_visible() {
-        let mut map = empty_map();
-        assert!(!cursor_is_externally_visible(&map.cursors["default"]));
-
-        seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
-        assert!(cursor_is_externally_visible(&map.cursors["sessA"]));
-
-        map.cursors.get_mut("sessA").unwrap().core.cfg.enabled = false;
-        assert!(!cursor_is_externally_visible(&map.cursors["sessA"]));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/move_cursor.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/move_cursor.rs
@@ -96,10 +96,8 @@ impl Tool for MoveCursorTool {
 
         self.state.cursor_registry.update_position(&cursor_id, x, y);
         // Drive the DRAWN cursor via the same path as click's animation. A raw
-        // `MoveTo` doesn't reliably bring a brand-new session cursor on-screen —
-        // it sits at the off-screen sentinel until a click seeds it, so the
-        // visible cursor wouldn't move (the reported position would, but the
-        // overlay wouldn't). `animate_cursor_to` seeds the sentinel on-screen
+        // `MoveTo` doesn't reliably bring a brand-new session cursor on-screen.
+        // `animate_cursor_to` gives an unplaced cursor a visible start point,
         // then glides in, identical to `click`. No-op for an empty (anonymous)
         // key or when the overlay is disabled for this cursor.
         crate::cursor::overlay::animate_cursor_to(cursor_id.clone(), x, y).await;

--- a/libs/cua-driver/rust/crates/platform-windows/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/overlay.rs
@@ -343,7 +343,7 @@ pub fn is_visible_for_session(key: &str) -> bool {
             guard
                 .as_ref()
                 .and_then(|map| map.cursors.get(key))
-                .map(|rs| rs.core.cfg.enabled && rs.core.cursor_is_revealed())
+                .map(|rs| rs.core.cursor_is_revealed())
         })
         .unwrap_or(false)
 }
@@ -424,7 +424,7 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
         .cursors
         .entry(key.clone())
         .or_insert_with(|| render_state_for_key(&template, &k));
-    if !(rs.core.cfg.enabled && rs.core.pos.is_none()) {
+    if !(rs.core.visible && rs.core.pos.is_none()) {
         return false;
     }
     let mut sx = target_x - SEED_OFFSET;
@@ -466,7 +466,7 @@ pub async fn animate_cursor_to(key: CursorKey, x: f64, y: f64) {
     let should_animate = {
         let guard = RENDER.lock().unwrap();
         match guard.as_ref().and_then(|m| m.cursors.get(&key)) {
-            Some(rs) if rs.core.cfg.enabled && rs.core.pos.is_some() => true,
+            Some(rs) if rs.core.visible && rs.core.pos.is_some() => true,
             _ => false,
         }
     };
@@ -1767,15 +1767,18 @@ mod tests {
     }
 
     #[test]
-    fn seed_places_cursor_on_screen_for_first_action() {
+    fn seed_places_cursor_inside_the_virtual_desktop() {
         let mut map = empty_map(); // 100x100 frame at origin
                                    // No "sessA" cursor exists yet — the seed must get-or-create it.
         let seeded = seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
         assert!(seeded, "unplaced cursor must be seeded");
         let pos = map.cursors["sessA"].core.pos.expect("seeded position");
         assert!(
-            pos.0 > -50.0 && pos.1 > -50.0,
-            "seed must be on-screen, got {pos:?}"
+            pos.0 >= f64::from(map.virt_x)
+                && pos.0 < f64::from(map.virt_x + map.virt_w)
+                && pos.1 >= f64::from(map.virt_y)
+                && pos.1 < f64::from(map.virt_y + map.virt_h),
+            "seed must be inside the virtual desktop, got {pos:?}"
         );
         assert!(
             (pos.0 - 60.0).abs() > 4.0 || (pos.1 - 60.0).abs() > 4.0,
@@ -1784,12 +1787,12 @@ mod tests {
     }
 
     #[test]
-    fn seed_is_noop_when_cursor_already_on_screen() {
+    fn seed_is_noop_when_cursor_is_already_placed() {
         let mut map = empty_map();
         seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
         map.cursors.get_mut("sessA").unwrap().core.pos = Some((30.0, 30.0));
         let seeded_again = seed_start_in_map(&mut map, &"sessA".to_owned(), 80.0, 80.0);
-        assert!(!seeded_again, "on-screen cursor must not be re-seeded");
+        assert!(!seeded_again, "placed cursor must not be re-seeded");
         assert_eq!(
             map.cursors["sessA"].core.pos,
             Some((30.0, 30.0)),

--- a/libs/cua-driver/rust/crates/platform-windows/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/overlay.rs
@@ -86,7 +86,7 @@ fn arrival_fire(key: &CursorKey) {
 struct RenderMap {
     cursors: IndexMap<CursorKey, RenderState>,
     /// Virtual screen dimensions set after window creation (Win32 DIPs).
-    /// `virt_x/y` are subtracted from each placed cursor when rendering
+    /// `virt_x/y` are subtracted from each cursor's `core.pos` when rendering
     /// so the pixmap is laid out in window-local coordinates.
     virt_x: i32,
     virt_y: i32,
@@ -343,7 +343,12 @@ pub fn is_visible_for_session(key: &str) -> bool {
             guard
                 .as_ref()
                 .and_then(|map| map.cursors.get(key))
-                .map(|rs| rs.core.cfg.enabled && rs.core.cursor_is_revealed())
+                .map(|rs| {
+                    rs.core.cfg.enabled
+                        && rs.core.visible
+                        && rs.core.idle_alpha >= 0.004
+                        && rs.core.pos.0 >= -100.0
+                })
         })
         .unwrap_or(false)
 }
@@ -384,21 +389,27 @@ pub fn current_theme_state(
     Some((id, version, profile, fallback, state.core.visual.clone()))
 }
 
-/// Current screen position of the cursor for `key`, if it has been placed.
-pub fn current_position(key: &str) -> Option<(f64, f64)> {
-    RENDER.lock().ok().and_then(|g| {
-        g.as_ref()
-            .and_then(|m| m.cursors.get(key))
-            .and_then(|rs| rs.core.pos)
-    })
+/// Current screen position of the cursor for `key` (the off-screen sentinel
+/// `(-200, -200)` if it has never been placed). A session with no own cursor
+/// yet reports the sentinel so the click path treats it as first-placement.
+pub fn current_position(key: &str) -> (f64, f64) {
+    RENDER
+        .lock()
+        .ok()
+        .and_then(|g| {
+            g.as_ref()
+                .and_then(|m| m.cursors.get(key))
+                .map(|rs| rs.core.pos)
+        })
+        .unwrap_or((-200.0, -200.0))
 }
 
-/// Seed a brand-new cursor at an on-screen start point
+/// Seed a brand-new (sentinel-positioned) cursor at an on-screen start point
 /// offset up-left of `(target_x, target_y)` so the immediately-following
 /// `MoveTo` glides INTO the target instead of silently snapping. No-op when the
 /// cursor is already on-screen or its session already ended. Returns true if a
 /// seed was applied. Mirrors `platform_macos::cursor::overlay::seed_start_*`.
-fn seed_start_if_unplaced(key: &CursorKey, target_x: f64, target_y: f64) -> bool {
+fn seed_start_if_sentinel(key: &CursorKey, target_x: f64, target_y: f64) -> bool {
     let mut guard = RENDER.lock().unwrap();
     let Some(map) = guard.as_mut() else {
         return false;
@@ -424,7 +435,7 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
         .cursors
         .entry(key.clone())
         .or_insert_with(|| render_state_for_key(&template, &k));
-    if !(rs.core.cfg.enabled && rs.core.pos.is_none()) {
+    if !(rs.core.cfg.enabled && rs.core.pos.0 < -50.0) {
         return false;
     }
     let mut sx = target_x - SEED_OFFSET;
@@ -440,7 +451,7 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
             sy = (target_y + SEED_OFFSET).min(virt_y + virt_h - 2.0);
         }
     }
-    rs.core.pos = Some((sx, sy));
+    rs.core.pos = (sx, sy);
     true
 }
 
@@ -452,21 +463,21 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
 /// - the key is empty (anonymous run → no cursor), or
 /// - the cursor for `key` is disabled.
 ///
-/// A brand-new cursor is first seeded on-screen via [`seed_start_if_unplaced`]
-/// so its first action glides in.
+/// A brand-new cursor still at the off-screen sentinel is first seeded
+/// on-screen via [`seed_start_if_sentinel`] so its FIRST action glides in.
 /// Mirrors `platform_macos::cursor::overlay::animate_cursor_to`.
 pub async fn animate_cursor_to(key: CursorKey, x: f64, y: f64) {
     if key.is_empty() {
         return;
     }
-    // Seed an unplaced cursor on-screen so the MoveTo below glides instead of
+    // Seed a sentinel cursor on-screen so the MoveTo below glides instead of
     // being short-circuited.
-    seed_start_if_unplaced(&key, x, y);
+    seed_start_if_sentinel(&key, x, y);
 
     let should_animate = {
         let guard = RENDER.lock().unwrap();
         match guard.as_ref().and_then(|m| m.cursors.get(&key)) {
-            Some(rs) if rs.core.cfg.enabled && rs.core.pos.is_some() => true,
+            Some(rs) if rs.core.cfg.enabled && rs.core.pos.0 > -50.0 => true,
             _ => false,
         }
     };
@@ -548,16 +559,18 @@ impl RenderState {
     }
 
     fn apply_command(&mut self, cmd: OverlayCommand) {
-        // Windows click pulses update the cursor position unconditionally.
+        // Windows uses the non-sentinel-snap behaviour for both MoveTo and
+        // ClickPulse: every command updates `self.pos` unconditionally.
         // `ShowFocusRect` is not rendered on Windows — `apply_command_base`
         // returns `false` for it and we silently drop it here.
-        let _ = self.core.apply_command_base(cmd, true);
+        let _ = self.core.apply_command_base(cmd, false, false);
     }
 
     /// True while the render loop must keep ticking at frame cadence because
     /// the next tick can still change pixels: an in-flight glide path, a
     /// spring-settle, a click pulse, or an idle-fade actively fading
-    /// (`0.004 <= idle_alpha < 1.0`). A brand-new unplaced cursor, one that has already faded to
+    /// (`0.004 <= idle_alpha < 1.0`). A brand-new sentinel cursor (off-screen
+    /// at `(-200, -200)`), a cursor that has already faded to
     /// `idle_alpha ≈ 0`, AND a cursor resting at constant `idle_alpha == 1.0`
     /// waiting out the idle-hide countdown are all non-rendering states: the
     /// countdown phase leaves every frame pixel-identical, so compositing a
@@ -572,7 +585,9 @@ impl RenderState {
             || self.core.click_t.is_some()
             || self.core.session_badge_needs_frame_tick()
             || (self.core.motion.idle_hide_ms > 0.0
-                && self.core.cursor_is_revealed()
+                && self.core.visible
+                && self.core.pos.0 >= -100.0
+                && self.core.idle_alpha >= 0.004
                 && self.core.idle_alpha < 1.0)
     }
 
@@ -587,7 +602,8 @@ impl RenderState {
             && self.core.spring.is_none()
             && self.core.click_t.is_none()
             && self.core.motion.idle_hide_ms > 0.0
-            && self.core.cursor_is_revealed()
+            && self.core.visible
+            && self.core.pos.0 >= -100.0
             && self.core.idle_alpha >= 1.0
     }
 }
@@ -970,14 +986,11 @@ fn composite_dirty(map: &RenderMap) -> Option<DirtyRect> {
         // (mirrors paint_cursor's own visibility early-return).
         let mut current: Option<DirtyRect> = None;
         for rs in map.cursors.values() {
-            if !rs.core.cursor_is_revealed() {
+            if !rs.core.visible || rs.core.pos.0 < -100.0 || rs.core.idle_alpha < 0.004 {
                 continue;
             }
-            let Some((cursor_x, cursor_y)) = rs.core.pos else {
-                continue;
-            };
-            let cx = (cursor_x - map.virt_x as f64).round() as i32;
-            let cy = (cursor_y - map.virt_y as f64).round() as i32;
+            let cx = (rs.core.pos.0 - map.virt_x as f64).round() as i32;
+            let cy = (rs.core.pos.1 - map.virt_y as f64).round() as i32;
             let custom_theme = rs
                 .core
                 .theme
@@ -1526,7 +1539,7 @@ impl ZOrderEnforcer for WinZOrderEnforcer {
 //
 // These prove the per-session ownership data model, the session_end removal
 // lifecycle, the "default" guard, the resurrection tombstone, and the
-// first-placement seed WITHOUT any Win32 window. The on-screen rendering
+// sentinel seed WITHOUT any Win32 window. The on-screen rendering
 // (UpdateLayeredWindow) still needs a real display and is verified separately.
 
 #[cfg(test)]
@@ -1767,18 +1780,15 @@ mod tests {
     }
 
     #[test]
-    fn seed_places_cursor_inside_the_virtual_desktop() {
+    fn seed_moves_sentinel_cursor_on_screen_for_first_action() {
         let mut map = empty_map(); // 100x100 frame at origin
                                    // No "sessA" cursor exists yet — the seed must get-or-create it.
         let seeded = seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
-        assert!(seeded, "unplaced cursor must be seeded");
-        let pos = map.cursors["sessA"].core.pos.expect("seeded position");
+        assert!(seeded, "sentinel cursor must be seeded");
+        let pos = map.cursors["sessA"].core.pos;
         assert!(
-            pos.0 >= f64::from(map.virt_x)
-                && pos.0 < f64::from(map.virt_x + map.virt_w)
-                && pos.1 >= f64::from(map.virt_y)
-                && pos.1 < f64::from(map.virt_y + map.virt_h),
-            "seed must be inside the virtual desktop, got {pos:?}"
+            pos.0 > -50.0 && pos.1 > -50.0,
+            "seed must be on-screen, got {pos:?}"
         );
         assert!(
             (pos.0 - 60.0).abs() > 4.0 || (pos.1 - 60.0).abs() > 4.0,
@@ -1787,32 +1797,17 @@ mod tests {
     }
 
     #[test]
-    fn seed_is_noop_when_cursor_is_already_placed() {
+    fn seed_is_noop_when_cursor_already_on_screen() {
         let mut map = empty_map();
         seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
-        map.cursors.get_mut("sessA").unwrap().core.pos = Some((30.0, 30.0));
+        map.cursors.get_mut("sessA").unwrap().core.pos = (30.0, 30.0);
         let seeded_again = seed_start_in_map(&mut map, &"sessA".to_owned(), 80.0, 80.0);
-        assert!(!seeded_again, "placed cursor must not be re-seeded");
+        assert!(!seeded_again, "on-screen cursor must not be re-seeded");
         assert_eq!(
             map.cursors["sessA"].core.pos,
-            Some((30.0, 30.0)),
+            (30.0, 30.0),
             "pos must be untouched"
         );
-    }
-
-    #[test]
-    fn negative_virtual_screen_coordinates_are_not_reseeded() {
-        let mut map = empty_map();
-        seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
-        map.cursors.get_mut("sessA").unwrap().core.pos = Some((-867.0, 400.0));
-
-        assert!(!seed_start_in_map(
-            &mut map,
-            &"sessA".to_owned(),
-            80.0,
-            80.0
-        ));
-        assert_eq!(map.cursors["sessA"].core.pos, Some((-867.0, 400.0)));
     }
 
     #[test]
@@ -1828,16 +1823,16 @@ mod tests {
     }
 
     #[test]
-    fn unplaced_cursor_is_quiescent_no_frame_tick() {
+    fn sentinel_cursor_is_quiescent_no_frame_tick() {
         // A brand-new `mcp`/`serve` with no agent activity holds only the
-        // unplaced "default" cursor. It must NOT
+        // "default" cursor at the off-screen sentinel (-200, -200). It must NOT
         // request frame ticks, so the render timer can drop to the slow idle
         // cadence instead of compositing a full-screen pixmap at ~125 Hz
         // (issue #1808 idle-CPU burn).
         let map = empty_map();
         assert!(
             !render_map_needs_frame_tick(&map),
-            "an untouched unplaced overlay must be quiescent"
+            "an untouched sentinel-only overlay must be quiescent"
         );
     }
 

--- a/libs/cua-driver/rust/crates/platform-windows/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/overlay.rs
@@ -343,7 +343,7 @@ pub fn is_visible_for_session(key: &str) -> bool {
             guard
                 .as_ref()
                 .and_then(|map| map.cursors.get(key))
-                .map(|rs| rs.core.cursor_is_revealed())
+                .map(|rs| rs.core.cfg.enabled && rs.core.cursor_is_revealed())
         })
         .unwrap_or(false)
 }
@@ -424,7 +424,7 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
         .cursors
         .entry(key.clone())
         .or_insert_with(|| render_state_for_key(&template, &k));
-    if !(rs.core.visible && rs.core.pos.is_none()) {
+    if !(rs.core.cfg.enabled && rs.core.pos.is_none()) {
         return false;
     }
     let mut sx = target_x - SEED_OFFSET;
@@ -466,7 +466,7 @@ pub async fn animate_cursor_to(key: CursorKey, x: f64, y: f64) {
     let should_animate = {
         let guard = RENDER.lock().unwrap();
         match guard.as_ref().and_then(|m| m.cursors.get(&key)) {
-            Some(rs) if rs.core.visible && rs.core.pos.is_some() => true,
+            Some(rs) if rs.core.cfg.enabled && rs.core.pos.is_some() => true,
             _ => false,
         }
     };

--- a/libs/cua-driver/rust/crates/platform-windows/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/overlay.rs
@@ -343,12 +343,7 @@ pub fn is_visible_for_session(key: &str) -> bool {
             guard
                 .as_ref()
                 .and_then(|map| map.cursors.get(key))
-                .map(|rs| {
-                    rs.core.cfg.enabled
-                        && rs.core.visible
-                        && rs.core.idle_alpha >= 0.004
-                        && rs.core.pos.0 >= -100.0
-                })
+                .map(|rs| rs.core.cfg.enabled && rs.core.cursor_is_revealed())
         })
         .unwrap_or(false)
 }
@@ -389,27 +384,25 @@ pub fn current_theme_state(
     Some((id, version, profile, fallback, state.core.visual.clone()))
 }
 
-/// Current screen position of the cursor for `key` (the off-screen sentinel
-/// `(-200, -200)` if it has never been placed). A session with no own cursor
-/// yet reports the sentinel so the click path treats it as first-placement.
-pub fn current_position(key: &str) -> (f64, f64) {
+pub fn is_placed(key: &str) -> bool {
     RENDER
         .lock()
         .ok()
-        .and_then(|g| {
-            g.as_ref()
-                .and_then(|m| m.cursors.get(key))
-                .map(|rs| rs.core.pos)
+        .and_then(|guard| {
+            guard
+                .as_ref()
+                .and_then(|map| map.cursors.get(key))
+                .map(|state| state.core.placed)
         })
-        .unwrap_or((-200.0, -200.0))
+        .unwrap_or(false)
 }
 
-/// Seed a brand-new (sentinel-positioned) cursor at an on-screen start point
-/// offset up-left of `(target_x, target_y)` so the immediately-following
+/// Seed a brand-new cursor at an on-screen start point offset up-left of
+/// `(target_x, target_y)` so the immediately-following
 /// `MoveTo` glides INTO the target instead of silently snapping. No-op when the
 /// cursor is already on-screen or its session already ended. Returns true if a
 /// seed was applied. Mirrors `platform_macos::cursor::overlay::seed_start_*`.
-fn seed_start_if_sentinel(key: &CursorKey, target_x: f64, target_y: f64) -> bool {
+fn seed_start_if_unplaced(key: &CursorKey, target_x: f64, target_y: f64) -> bool {
     let mut guard = RENDER.lock().unwrap();
     let Some(map) = guard.as_mut() else {
         return false;
@@ -435,7 +428,7 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
         .cursors
         .entry(key.clone())
         .or_insert_with(|| render_state_for_key(&template, &k));
-    if !(rs.core.cfg.enabled && rs.core.pos.0 < -50.0) {
+    if !(rs.core.cfg.enabled && !rs.core.placed) {
         return false;
     }
     let mut sx = target_x - SEED_OFFSET;
@@ -452,6 +445,7 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
         }
     }
     rs.core.pos = (sx, sy);
+    rs.core.placed = true;
     true
 }
 
@@ -463,23 +457,22 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
 /// - the key is empty (anonymous run → no cursor), or
 /// - the cursor for `key` is disabled.
 ///
-/// A brand-new cursor still at the off-screen sentinel is first seeded
-/// on-screen via [`seed_start_if_sentinel`] so its FIRST action glides in.
+/// A brand-new cursor is first seeded on-screen via
+/// [`seed_start_if_unplaced`] so its first action glides in.
 /// Mirrors `platform_macos::cursor::overlay::animate_cursor_to`.
 pub async fn animate_cursor_to(key: CursorKey, x: f64, y: f64) {
     if key.is_empty() {
         return;
     }
-    // Seed a sentinel cursor on-screen so the MoveTo below glides instead of
-    // being short-circuited.
-    seed_start_if_sentinel(&key, x, y);
+    // Seed an unplaced cursor so the MoveTo below glides on its first use.
+    seed_start_if_unplaced(&key, x, y);
 
     let should_animate = {
         let guard = RENDER.lock().unwrap();
-        match guard.as_ref().and_then(|m| m.cursors.get(&key)) {
-            Some(rs) if rs.core.cfg.enabled && rs.core.pos.0 > -50.0 => true,
-            _ => false,
-        }
+        matches!(
+            guard.as_ref().and_then(|map| map.cursors.get(&key)),
+            Some(state) if state.core.cfg.enabled && state.core.placed
+        )
     };
     if !should_animate {
         return;
@@ -559,8 +552,7 @@ impl RenderState {
     }
 
     fn apply_command(&mut self, cmd: OverlayCommand) {
-        // Windows uses the non-sentinel-snap behaviour for both MoveTo and
-        // ClickPulse: every command updates `self.pos` unconditionally.
+        // Windows updates the position for every MoveTo and ClickPulse.
         // `ShowFocusRect` is not rendered on Windows — `apply_command_base`
         // returns `false` for it and we silently drop it here.
         let _ = self.core.apply_command_base(cmd, false, false);
@@ -569,9 +561,9 @@ impl RenderState {
     /// True while the render loop must keep ticking at frame cadence because
     /// the next tick can still change pixels: an in-flight glide path, a
     /// spring-settle, a click pulse, or an idle-fade actively fading
-    /// (`0.004 <= idle_alpha < 1.0`). A brand-new sentinel cursor (off-screen
-    /// at `(-200, -200)`), a cursor that has already faded to
-    /// `idle_alpha ≈ 0`, AND a cursor resting at constant `idle_alpha == 1.0`
+    /// (`0.004 <= idle_alpha < 1.0`). An unplaced cursor, a cursor that has
+    /// already faded to `idle_alpha ≈ 0`, and a cursor resting at constant
+    /// `idle_alpha == 1.0`
     /// waiting out the idle-hide countdown are all non-rendering states: the
     /// countdown phase leaves every frame pixel-identical, so compositing a
     /// full virtual-screen pixmap through it burned ~1 core for the whole
@@ -585,9 +577,7 @@ impl RenderState {
             || self.core.click_t.is_some()
             || self.core.session_badge_needs_frame_tick()
             || (self.core.motion.idle_hide_ms > 0.0
-                && self.core.visible
-                && self.core.pos.0 >= -100.0
-                && self.core.idle_alpha >= 0.004
+                && self.core.cursor_is_revealed()
                 && self.core.idle_alpha < 1.0)
     }
 
@@ -603,7 +593,7 @@ impl RenderState {
             && self.core.click_t.is_none()
             && self.core.motion.idle_hide_ms > 0.0
             && self.core.visible
-            && self.core.pos.0 >= -100.0
+            && self.core.placed
             && self.core.idle_alpha >= 1.0
     }
 }
@@ -986,7 +976,7 @@ fn composite_dirty(map: &RenderMap) -> Option<DirtyRect> {
         // (mirrors paint_cursor's own visibility early-return).
         let mut current: Option<DirtyRect> = None;
         for rs in map.cursors.values() {
-            if !rs.core.visible || rs.core.pos.0 < -100.0 || rs.core.idle_alpha < 0.004 {
+            if !rs.core.cursor_is_revealed() {
                 continue;
             }
             let cx = (rs.core.pos.0 - map.virt_x as f64).round() as i32;
@@ -1780,14 +1770,16 @@ mod tests {
     }
 
     #[test]
-    fn seed_moves_sentinel_cursor_on_screen_for_first_action() {
+    fn seed_places_unplaced_cursor_on_screen_for_first_action() {
         let mut map = empty_map(); // 100x100 frame at origin
                                    // No "sessA" cursor exists yet — the seed must get-or-create it.
         let seeded = seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
-        assert!(seeded, "sentinel cursor must be seeded");
-        let pos = map.cursors["sessA"].core.pos;
+        assert!(seeded, "unplaced cursor must be seeded");
+        let state = &map.cursors["sessA"].core;
+        let pos = state.pos;
+        assert!(state.placed);
         assert!(
-            pos.0 > -50.0 && pos.1 > -50.0,
+            pos.0 >= 0.0 && pos.0 < 100.0 && pos.1 >= 0.0 && pos.1 < 100.0,
             "seed must be on-screen, got {pos:?}"
         );
         assert!(
@@ -1797,17 +1789,16 @@ mod tests {
     }
 
     #[test]
-    fn seed_is_noop_when_cursor_already_on_screen() {
+    fn negative_coordinates_remain_placed_and_visible() {
         let mut map = empty_map();
         seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
-        map.cursors.get_mut("sessA").unwrap().core.pos = (30.0, 30.0);
+        map.cursors.get_mut("sessA").unwrap().core.pos = (-867.0, -200.0);
+
         let seeded_again = seed_start_in_map(&mut map, &"sessA".to_owned(), 80.0, 80.0);
-        assert!(!seeded_again, "on-screen cursor must not be re-seeded");
-        assert_eq!(
-            map.cursors["sessA"].core.pos,
-            (30.0, 30.0),
-            "pos must be untouched"
-        );
+
+        assert!(!seeded_again, "placed cursor must not be re-seeded");
+        assert_eq!(map.cursors["sessA"].core.pos, (-867.0, -200.0));
+        assert!(map.cursors["sessA"].core.cursor_is_revealed());
     }
 
     #[test]
@@ -1823,16 +1814,14 @@ mod tests {
     }
 
     #[test]
-    fn sentinel_cursor_is_quiescent_no_frame_tick() {
-        // A brand-new `mcp`/`serve` with no agent activity holds only the
-        // "default" cursor at the off-screen sentinel (-200, -200). It must NOT
-        // request frame ticks, so the render timer can drop to the slow idle
-        // cadence instead of compositing a full-screen pixmap at ~125 Hz
-        // (issue #1808 idle-CPU burn).
+    fn unplaced_cursor_is_quiescent_no_frame_tick() {
+        // A brand-new `mcp`/`serve` must not request frame ticks, so the render
+        // timer can drop to the slow idle cadence instead of compositing a
+        // full-screen pixmap at ~125 Hz (issue #1808 idle-CPU burn).
         let map = empty_map();
         assert!(
             !render_map_needs_frame_tick(&map),
-            "an untouched sentinel-only overlay must be quiescent"
+            "an untouched overlay must be quiescent"
         );
     }
 

--- a/libs/cua-driver/rust/crates/platform-windows/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/overlay.rs
@@ -86,7 +86,7 @@ fn arrival_fire(key: &CursorKey) {
 struct RenderMap {
     cursors: IndexMap<CursorKey, RenderState>,
     /// Virtual screen dimensions set after window creation (Win32 DIPs).
-    /// `virt_x/y` are subtracted from each cursor's `core.pos` when rendering
+    /// `virt_x/y` are subtracted from each placed cursor when rendering
     /// so the pixmap is laid out in window-local coordinates.
     virt_x: i32,
     virt_y: i32,
@@ -343,12 +343,7 @@ pub fn is_visible_for_session(key: &str) -> bool {
             guard
                 .as_ref()
                 .and_then(|map| map.cursors.get(key))
-                .map(|rs| {
-                    rs.core.cfg.enabled
-                        && rs.core.visible
-                        && rs.core.idle_alpha >= 0.004
-                        && rs.core.pos.0 >= -100.0
-                })
+                .map(|rs| rs.core.cfg.enabled && rs.core.cursor_is_revealed())
         })
         .unwrap_or(false)
 }
@@ -389,27 +384,21 @@ pub fn current_theme_state(
     Some((id, version, profile, fallback, state.core.visual.clone()))
 }
 
-/// Current screen position of the cursor for `key` (the off-screen sentinel
-/// `(-200, -200)` if it has never been placed). A session with no own cursor
-/// yet reports the sentinel so the click path treats it as first-placement.
-pub fn current_position(key: &str) -> (f64, f64) {
-    RENDER
-        .lock()
-        .ok()
-        .and_then(|g| {
-            g.as_ref()
-                .and_then(|m| m.cursors.get(key))
-                .map(|rs| rs.core.pos)
-        })
-        .unwrap_or((-200.0, -200.0))
+/// Current screen position of the cursor for `key`, if it has been placed.
+pub fn current_position(key: &str) -> Option<(f64, f64)> {
+    RENDER.lock().ok().and_then(|g| {
+        g.as_ref()
+            .and_then(|m| m.cursors.get(key))
+            .and_then(|rs| rs.core.pos)
+    })
 }
 
-/// Seed a brand-new (sentinel-positioned) cursor at an on-screen start point
+/// Seed a brand-new cursor at an on-screen start point
 /// offset up-left of `(target_x, target_y)` so the immediately-following
 /// `MoveTo` glides INTO the target instead of silently snapping. No-op when the
 /// cursor is already on-screen or its session already ended. Returns true if a
 /// seed was applied. Mirrors `platform_macos::cursor::overlay::seed_start_*`.
-fn seed_start_if_sentinel(key: &CursorKey, target_x: f64, target_y: f64) -> bool {
+fn seed_start_if_unplaced(key: &CursorKey, target_x: f64, target_y: f64) -> bool {
     let mut guard = RENDER.lock().unwrap();
     let Some(map) = guard.as_mut() else {
         return false;
@@ -435,7 +424,7 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
         .cursors
         .entry(key.clone())
         .or_insert_with(|| render_state_for_key(&template, &k));
-    if !(rs.core.cfg.enabled && rs.core.pos.0 < -50.0) {
+    if !(rs.core.cfg.enabled && rs.core.pos.is_none()) {
         return false;
     }
     let mut sx = target_x - SEED_OFFSET;
@@ -451,7 +440,7 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
             sy = (target_y + SEED_OFFSET).min(virt_y + virt_h - 2.0);
         }
     }
-    rs.core.pos = (sx, sy);
+    rs.core.pos = Some((sx, sy));
     true
 }
 
@@ -463,21 +452,21 @@ fn seed_start_in_map(map: &mut RenderMap, key: &CursorKey, target_x: f64, target
 /// - the key is empty (anonymous run → no cursor), or
 /// - the cursor for `key` is disabled.
 ///
-/// A brand-new cursor still at the off-screen sentinel is first seeded
-/// on-screen via [`seed_start_if_sentinel`] so its FIRST action glides in.
+/// A brand-new cursor is first seeded on-screen via [`seed_start_if_unplaced`]
+/// so its first action glides in.
 /// Mirrors `platform_macos::cursor::overlay::animate_cursor_to`.
 pub async fn animate_cursor_to(key: CursorKey, x: f64, y: f64) {
     if key.is_empty() {
         return;
     }
-    // Seed a sentinel cursor on-screen so the MoveTo below glides instead of
+    // Seed an unplaced cursor on-screen so the MoveTo below glides instead of
     // being short-circuited.
-    seed_start_if_sentinel(&key, x, y);
+    seed_start_if_unplaced(&key, x, y);
 
     let should_animate = {
         let guard = RENDER.lock().unwrap();
         match guard.as_ref().and_then(|m| m.cursors.get(&key)) {
-            Some(rs) if rs.core.cfg.enabled && rs.core.pos.0 > -50.0 => true,
+            Some(rs) if rs.core.cfg.enabled && rs.core.pos.is_some() => true,
             _ => false,
         }
     };
@@ -559,18 +548,16 @@ impl RenderState {
     }
 
     fn apply_command(&mut self, cmd: OverlayCommand) {
-        // Windows uses the non-sentinel-snap behaviour for both MoveTo and
-        // ClickPulse: every command updates `self.pos` unconditionally.
+        // Windows click pulses update the cursor position unconditionally.
         // `ShowFocusRect` is not rendered on Windows — `apply_command_base`
         // returns `false` for it and we silently drop it here.
-        let _ = self.core.apply_command_base(cmd, false, false);
+        let _ = self.core.apply_command_base(cmd, true);
     }
 
     /// True while the render loop must keep ticking at frame cadence because
     /// the next tick can still change pixels: an in-flight glide path, a
     /// spring-settle, a click pulse, or an idle-fade actively fading
-    /// (`0.004 <= idle_alpha < 1.0`). A brand-new sentinel cursor (off-screen
-    /// at `(-200, -200)`), a cursor that has already faded to
+    /// (`0.004 <= idle_alpha < 1.0`). A brand-new unplaced cursor, one that has already faded to
     /// `idle_alpha ≈ 0`, AND a cursor resting at constant `idle_alpha == 1.0`
     /// waiting out the idle-hide countdown are all non-rendering states: the
     /// countdown phase leaves every frame pixel-identical, so compositing a
@@ -585,9 +572,7 @@ impl RenderState {
             || self.core.click_t.is_some()
             || self.core.session_badge_needs_frame_tick()
             || (self.core.motion.idle_hide_ms > 0.0
-                && self.core.visible
-                && self.core.pos.0 >= -100.0
-                && self.core.idle_alpha >= 0.004
+                && self.core.cursor_is_revealed()
                 && self.core.idle_alpha < 1.0)
     }
 
@@ -602,8 +587,7 @@ impl RenderState {
             && self.core.spring.is_none()
             && self.core.click_t.is_none()
             && self.core.motion.idle_hide_ms > 0.0
-            && self.core.visible
-            && self.core.pos.0 >= -100.0
+            && self.core.cursor_is_revealed()
             && self.core.idle_alpha >= 1.0
     }
 }
@@ -986,11 +970,14 @@ fn composite_dirty(map: &RenderMap) -> Option<DirtyRect> {
         // (mirrors paint_cursor's own visibility early-return).
         let mut current: Option<DirtyRect> = None;
         for rs in map.cursors.values() {
-            if !rs.core.visible || rs.core.pos.0 < -100.0 || rs.core.idle_alpha < 0.004 {
+            if !rs.core.cursor_is_revealed() {
                 continue;
             }
-            let cx = (rs.core.pos.0 - map.virt_x as f64).round() as i32;
-            let cy = (rs.core.pos.1 - map.virt_y as f64).round() as i32;
+            let Some((cursor_x, cursor_y)) = rs.core.pos else {
+                continue;
+            };
+            let cx = (cursor_x - map.virt_x as f64).round() as i32;
+            let cy = (cursor_y - map.virt_y as f64).round() as i32;
             let custom_theme = rs
                 .core
                 .theme
@@ -1539,7 +1526,7 @@ impl ZOrderEnforcer for WinZOrderEnforcer {
 //
 // These prove the per-session ownership data model, the session_end removal
 // lifecycle, the "default" guard, the resurrection tombstone, and the
-// sentinel seed WITHOUT any Win32 window. The on-screen rendering
+// first-placement seed WITHOUT any Win32 window. The on-screen rendering
 // (UpdateLayeredWindow) still needs a real display and is verified separately.
 
 #[cfg(test)]
@@ -1780,12 +1767,12 @@ mod tests {
     }
 
     #[test]
-    fn seed_moves_sentinel_cursor_on_screen_for_first_action() {
+    fn seed_places_cursor_on_screen_for_first_action() {
         let mut map = empty_map(); // 100x100 frame at origin
                                    // No "sessA" cursor exists yet — the seed must get-or-create it.
         let seeded = seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
-        assert!(seeded, "sentinel cursor must be seeded");
-        let pos = map.cursors["sessA"].core.pos;
+        assert!(seeded, "unplaced cursor must be seeded");
+        let pos = map.cursors["sessA"].core.pos.expect("seeded position");
         assert!(
             pos.0 > -50.0 && pos.1 > -50.0,
             "seed must be on-screen, got {pos:?}"
@@ -1800,14 +1787,29 @@ mod tests {
     fn seed_is_noop_when_cursor_already_on_screen() {
         let mut map = empty_map();
         seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
-        map.cursors.get_mut("sessA").unwrap().core.pos = (30.0, 30.0);
+        map.cursors.get_mut("sessA").unwrap().core.pos = Some((30.0, 30.0));
         let seeded_again = seed_start_in_map(&mut map, &"sessA".to_owned(), 80.0, 80.0);
         assert!(!seeded_again, "on-screen cursor must not be re-seeded");
         assert_eq!(
             map.cursors["sessA"].core.pos,
-            (30.0, 30.0),
+            Some((30.0, 30.0)),
             "pos must be untouched"
         );
+    }
+
+    #[test]
+    fn negative_virtual_screen_coordinates_are_not_reseeded() {
+        let mut map = empty_map();
+        seed_start_in_map(&mut map, &"sessA".to_owned(), 60.0, 60.0);
+        map.cursors.get_mut("sessA").unwrap().core.pos = Some((-867.0, 400.0));
+
+        assert!(!seed_start_in_map(
+            &mut map,
+            &"sessA".to_owned(),
+            80.0,
+            80.0
+        ));
+        assert_eq!(map.cursors["sessA"].core.pos, Some((-867.0, 400.0)));
     }
 
     #[test]
@@ -1823,16 +1825,16 @@ mod tests {
     }
 
     #[test]
-    fn sentinel_cursor_is_quiescent_no_frame_tick() {
+    fn unplaced_cursor_is_quiescent_no_frame_tick() {
         // A brand-new `mcp`/`serve` with no agent activity holds only the
-        // "default" cursor at the off-screen sentinel (-200, -200). It must NOT
+        // unplaced "default" cursor. It must NOT
         // request frame ticks, so the render timer can drop to the slow idle
         // cadence instead of compositing a full-screen pixmap at ~125 Hz
         // (issue #1808 idle-CPU burn).
         let map = empty_map();
         assert!(
             !render_map_needs_frame_tick(&map),
-            "an untouched sentinel-only overlay must be quiescent"
+            "an untouched unplaced overlay must be quiescent"
         );
     }
 

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -231,9 +231,8 @@ fn screen_to_bitmap(hwnd: u64, sx: i32, sy: i32) -> (i32, i32) {
 /// Animate the agent cursor to (sx, sy) in screen coordinates and wait for the
 /// glide to finish before returning.  No-op when the overlay is not enabled.
 ///
-/// On the very first call the cursor is at the off-screen initial position
-/// (-200, -200).  Animating from there would cause a jarring off-screen fly-in,
-/// so we snap to the target with a ClickPulse first and skip the glide wait.
+/// On the first call, an unplaced cursor would otherwise produce a jarring
+/// fly-in, so we snap to the target with a ClickPulse and skip the glide wait.
 ///
 /// For all subsequent calls this defers to
 /// [`crate::overlay::animate_cursor_to`], which sends `MoveTo` and awaits the
@@ -251,8 +250,7 @@ async fn overlay_glide_to(key: &str, sx: f64, sy: f64) {
     if !crate::overlay::is_enabled(key) {
         return;
     }
-    let pos = crate::overlay::current_position(key);
-    if pos.0 < 0.0 && pos.1 < 0.0 {
+    if !crate::overlay::is_placed(key) {
         // Snap to target on first use; no animation to wait for.
         crate::overlay::send_command(
             key.to_owned(),

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -231,9 +231,8 @@ fn screen_to_bitmap(hwnd: u64, sx: i32, sy: i32) -> (i32, i32) {
 /// Animate the agent cursor to (sx, sy) in screen coordinates and wait for the
 /// glide to finish before returning.  No-op when the overlay is not enabled.
 ///
-/// On the very first call the cursor is at the off-screen initial position
-/// (-200, -200).  Animating from there would cause a jarring off-screen fly-in,
-/// so we snap to the target with a ClickPulse first and skip the glide wait.
+/// On the first call the cursor has no position, so we place it with a
+/// `ClickPulse` and skip the glide wait.
 ///
 /// For all subsequent calls this defers to
 /// [`crate::overlay::animate_cursor_to`], which sends `MoveTo` and awaits the
@@ -252,7 +251,7 @@ async fn overlay_glide_to(key: &str, sx: f64, sy: f64) {
         return;
     }
     let pos = crate::overlay::current_position(key);
-    if pos.0 < 0.0 && pos.1 < 0.0 {
+    if pos.is_none() {
         // Snap to target on first use; no animation to wait for.
         crate::overlay::send_command(
             key.to_owned(),

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -231,8 +231,9 @@ fn screen_to_bitmap(hwnd: u64, sx: i32, sy: i32) -> (i32, i32) {
 /// Animate the agent cursor to (sx, sy) in screen coordinates and wait for the
 /// glide to finish before returning.  No-op when the overlay is not enabled.
 ///
-/// On the first call the cursor has no position, so we place it with a
-/// `ClickPulse` and skip the glide wait.
+/// On the very first call the cursor is at the off-screen initial position
+/// (-200, -200).  Animating from there would cause a jarring off-screen fly-in,
+/// so we snap to the target with a ClickPulse first and skip the glide wait.
 ///
 /// For all subsequent calls this defers to
 /// [`crate::overlay::animate_cursor_to`], which sends `MoveTo` and awaits the
@@ -251,7 +252,7 @@ async fn overlay_glide_to(key: &str, sx: f64, sy: f64) {
         return;
     }
     let pos = crate::overlay::current_position(key);
-    if pos.is_none() {
+    if pos.0 < 0.0 && pos.1 < 0.0 {
         // Snap to target on first use; no animation to wait for.
         crate::overlay::send_command(
             key.to_owned(),


### PR DESCRIPTION
## summary

- replace cursor-coordinate sentinels with explicit shared placement state
- create one macos cursor surface per connected display
- render each surface in global coordinates with its own backing scale
- rebuild surfaces after display changes and reject stale frames

## implementation

cursor visibility and first placement no longer infer state from coordinate signs. the shared cursor state now carries `placed`, and macos, windows, x11, and wayland use it consistently. negative coordinates are therefore ordinary display coordinates rather than hidden-state markers.

macos keeps one shared cursor state and render worker, while appkit owns one transparent surface per display. cursor artwork is rendered into every display it intersects, so seam crossings do not clip the pointer. only displays with current or previous pixels are rendered, which also clears the old display after movement.

placement is explicit instead of encoded as a coordinate. theme-derived paint bounds select intersecting displays without rendering every display for custom themes. the session badge remains on the cursor's anchor display, and target-relative z-order applies to every surface carrying cursor pixels.

rebasing onto main preserves the current display-mode backing-scale calculation from [#3328](https://github.com/trycua/cua/pull/3328) for every display.

candidate: `d27f6a89d8aeef0f56363ee9bb60bbc565912b1e`

## validation

- `cargo test -p cursor-overlay --locked` — 44 passed
- `cargo test -p platform-macos --lib --locked` — 352 passed, 2 environment-mutating/native-display tests ignored
- `cargo test -p platform-linux --lib --locked` — 16 host-available tests passed
- `cargo test -p platform-windows --lib --locked` — 42 host-available tests passed
- `cargo check -p platform-linux --locked`
- `cargo check -p platform-windows --locked`
- rustfmt and diff checks passed
- linux and nix ci repair: test fixtures that assigned `core.pos` directly now also set the explicit `placed` state; the production command paths already did this. local rustfmt and diff checks pass. the full local linux suite is blocked before this crate because the container lacks `pkg-config` and x11 development metadata.
- exact-candidate github ci passed, including linux and nix rust unit tests, windows compile/tests, cross-platform rustfmt, portable contract parity, generated bindings, docs, and release metadata.

## remaining validation gap

the exact candidate still needs the canonical cross-platform desktop e2e matrix. macos coverage must include left, upper, mixed-scale, cross-display, and hotplug layouts.

refs #2992
