### PR TITLE
fix(fleets): reuse existing Cua OAuth secrets

### DIFF
--- a/.github/workflows/infra-fleets-wif-smoke.yml
+++ b/.github/workflows/infra-fleets-wif-smoke.yml
@@ -14,9 +14,9 @@ concurrency:
 env:
   AWS_REGION: us-west-2
   CYCLOPS_ENDPOINT: https://run.cua.ai
-  CYCLOPS_CLIENT_ID: ${{ secrets.FLEETS_TERRAFORM_CLIENT_ID }}
-  CYCLOPS_CLIENT_SECRET: ${{ secrets.FLEETS_TERRAFORM_CLIENT_SECRET }}
-  CYCLOPS_TOKEN_URL: ${{ secrets.FLEETS_TERRAFORM_TOKEN_URL }}
+  CYCLOPS_CLIENT_ID: ${{ secrets.CUA_CLIENT_ID }}
+  CYCLOPS_CLIENT_SECRET: ${{ secrets.CUA_CLIENT_SECRET }}
+  CYCLOPS_TOKEN_URL: https://auth.cua.ai/realms/cyclops-cs/protocol/openid-connect/token
   FLEETS_PROVIDER_COMMIT: d118faeafd288150d574c471a1038b3f3aef7c71
   FLEETS_PROVIDER_VERSION: 1.0.0
   TF_IN_AUTOMATION: "true"

--- a/infra/fleets-wif-smoke/README.md
+++ b/infra/fleets-wif-smoke/README.md
@@ -4,10 +4,6 @@ This stack keeps the `cua-cli-wif-smoke` Fleet pool and namespace available at z
 
 Apply it with the manual `Infra: Fleets WIF smoke pool` workflow. The workflow builds `trycua/terraform-provider-fleets` at the pinned merged commit until `trycua/fleets` is published in the Terraform Registry.
 
-The apply job requires these protected repository or environment secrets from a Fleets user key:
-
-- `FLEETS_TERRAFORM_CLIENT_ID`
-- `FLEETS_TERRAFORM_CLIENT_SECRET`
-- `FLEETS_TERRAFORM_TOKEN_URL`
+The apply job reuses the protected `CUA_CLIENT_ID` and `CUA_CLIENT_SECRET` repository secrets and the canonical Cua OAuth token endpoint.
 
 The pool autoscaler is bounded from zero to one replica. The daily smoke workflow claims a UUID-suffixed sandbox, runs commands through `cua sb exec`, deletes the claim, and suspends the pool back to zero replicas.


### PR DESCRIPTION
## What changed
- use the existing protected `CUA_CLIENT_ID` and `CUA_CLIENT_SECRET` secrets for the Fleets Terraform provider
- use the canonical Cua OAuth token endpoint already used by `cua-sandbox`
- remove the unconfigured duplicate Terraform secret names from the infrastructure documentation

## Validation
- `actionlint .github/workflows/infra-fleets-wif-smoke.yml`
- `git diff --check`

Follow-up to #3020 so the merged infrastructure workflow can be dispatched without provisioning duplicate credentials.
