### PR TITLE
fix(fleets): use owner key for trust policies

### DIFF
--- a/.github/workflows/infra-fleets-wif-smoke.yml
+++ b/.github/workflows/infra-fleets-wif-smoke.yml
@@ -14,9 +14,9 @@ concurrency:
 env:
   AWS_REGION: us-west-2
   CYCLOPS_ENDPOINT: https://run.cua.ai
-  CYCLOPS_CLIENT_ID: ${{ secrets.CUA_CLIENT_ID }}
-  CYCLOPS_CLIENT_SECRET: ${{ secrets.CUA_CLIENT_SECRET }}
-  CYCLOPS_TOKEN_URL: https://auth.cua.ai/realms/cyclops-cs/protocol/openid-connect/token
+  CYCLOPS_CLIENT_ID: ${{ secrets.FLEETS_TERRAFORM_CLIENT_ID }}
+  CYCLOPS_CLIENT_SECRET: ${{ secrets.FLEETS_TERRAFORM_CLIENT_SECRET }}
+  CYCLOPS_TOKEN_URL: ${{ secrets.FLEETS_TERRAFORM_TOKEN_URL }}
   FLEETS_PROVIDER_COMMIT: d118faeafd288150d574c471a1038b3f3aef7c71
   FLEETS_PROVIDER_VERSION: 1.0.0
   TF_IN_AUTOMATION: "true"

--- a/infra/fleets-wif-smoke/README.md
+++ b/infra/fleets-wif-smoke/README.md
@@ -4,6 +4,10 @@ This stack keeps the `cua-cli-wif-smoke` Fleet pool and namespace available at z
 
 Apply it with the manual `Infra: Fleets WIF smoke pool` workflow. The workflow builds `trycua/terraform-provider-fleets` at the pinned merged commit until `trycua/fleets` is published in the Terraform Registry.
 
-The apply job reuses the protected `CUA_CLIENT_ID` and `CUA_CLIENT_SECRET` repository secrets and the canonical Cua OAuth token endpoint.
+The apply job uses a dedicated user-owned Fleets key stored as protected repository secrets:
+
+- `FLEETS_TERRAFORM_CLIENT_ID`
+- `FLEETS_TERRAFORM_CLIENT_SECRET`
+- `FLEETS_TERRAFORM_TOKEN_URL`
 
 The pool autoscaler is bounded from zero to one replica. The daily smoke workflow claims a UUID-suffixed sandbox, runs commands through `cua sb exec`, deletes the claim, and suspends the pool back to zero replicas.


### PR DESCRIPTION
## What changed
- use the dedicated user-owned Fleets key for Terraform
- keep the general Cua machine credentials isolated from owner-scoped trust-policy management
- document the three encrypted repository secrets created for this stack

## Why
The existing `CUA_CLIENT_ID` service client can create the pool but receives `403 forbidden` from `POST /api/github-trust-policies`. The provider resource requires credentials acting on behalf of a user owner.

## Validation
- dedicated user key created through Cua device authorization
- all three values written directly to encrypted GitHub repository secrets
- `actionlint .github/workflows/infra-fleets-wif-smoke.yml`
- `git diff --check`
