### PR TITLE
fix(cua-driver): lazily initialize macos clipboard

### DIFF
--- a/libs/cua-driver/rust/crates/platform-macos/src/tools/clipboard.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/tools/clipboard.rs
@@ -1,27 +1,67 @@
-use std::{path::Path, sync::Mutex};
+use std::{
+    any::Any,
+    panic::{catch_unwind, AssertUnwindSafe},
+    path::Path,
+    sync::Mutex,
+};
 
 use clipboard_rs::{common::RustImage, Clipboard, ClipboardContext, ContentFormat};
 use cua_driver_core::clipboard::ClipboardBackend;
 
 pub struct MacosClipboard {
-    context: Result<Mutex<ClipboardContext>, String>,
+    context: Mutex<Option<ClipboardContext>>,
+    initialize: fn() -> Result<ClipboardContext, String>,
 }
 
 impl MacosClipboard {
     pub fn new() -> Self {
         Self {
-            context: ClipboardContext::new()
-                .map(Mutex::new)
-                .map_err(|error| error.to_string()),
+            context: Mutex::new(None),
+            initialize: initialize_context,
         }
     }
 
-    fn context(&self) -> Result<std::sync::MutexGuard<'_, ClipboardContext>, String> {
-        self.context
-            .as_ref()
-            .map_err(Clone::clone)?
+    #[cfg(test)]
+    fn with_initializer(initialize: fn() -> Result<ClipboardContext, String>) -> Self {
+        Self {
+            context: Mutex::new(None),
+            initialize,
+        }
+    }
+
+    fn with_context<T>(
+        &self,
+        operation: impl FnOnce(&ClipboardContext) -> Result<T, String>,
+    ) -> Result<T, String> {
+        let mut context = self
+            .context
             .lock()
-            .map_err(|_| "clipboard lock was poisoned".to_owned())
+            .map_err(|_| "clipboard lock was poisoned".to_owned())?;
+        if context.is_none() {
+            let initialized =
+                catch_unwind(AssertUnwindSafe(|| (self.initialize)())).map_err(|panic| {
+                    format!(
+                        "clipboard initialization panicked: {}",
+                        panic_message(panic)
+                    )
+                })??;
+            *context = Some(initialized);
+        }
+        operation(context.as_ref().expect("clipboard context was initialized"))
+    }
+}
+
+fn initialize_context() -> Result<ClipboardContext, String> {
+    ClipboardContext::new().map_err(|error| error.to_string())
+}
+
+fn panic_message(panic: Box<dyn Any + Send>) -> String {
+    if let Some(message) = panic.downcast_ref::<&str>() {
+        (*message).to_owned()
+    } else if let Some(message) = panic.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "unknown native clipboard failure".to_owned()
     }
 }
 
@@ -39,41 +79,78 @@ fn absolute_existing_file(path: &str) -> Result<String, String> {
 
 impl ClipboardBackend for MacosClipboard {
     fn available_formats(&self) -> Result<Vec<String>, String> {
-        self.context()?
-            .available_formats()
-            .map_err(|e| e.to_string())
+        self.with_context(|context| context.available_formats().map_err(|e| e.to_string()))
     }
 
     fn read_text(&self) -> Result<Option<String>, String> {
-        let context = self.context()?;
-        if context.has(ContentFormat::Text) {
-            context.get_text().map(Some).map_err(|e| e.to_string())
-        } else {
-            Ok(None)
-        }
+        self.with_context(|context| {
+            if context.has(ContentFormat::Text) {
+                context.get_text().map(Some).map_err(|e| e.to_string())
+            } else {
+                Ok(None)
+            }
+        })
     }
 
     fn write_text(&self, text: String) -> Result<(), String> {
-        self.context()?.set_text(text).map_err(|e| e.to_string())
+        self.with_context(|context| context.set_text(text).map_err(|e| e.to_string()))
     }
 
     fn write_image(&self, absolute_path: &str) -> Result<(), String> {
         let path = absolute_existing_file(absolute_path)?;
         let image = clipboard_rs::RustImageData::from_path(&path).map_err(|e| e.to_string())?;
-        self.context()?.set_image(image).map_err(|e| e.to_string())
+        self.with_context(|context| context.set_image(image).map_err(|e| e.to_string()))
     }
 
     fn write_file_url(&self, absolute_path: &str) -> Result<(), String> {
         let path = absolute_existing_file(absolute_path)?;
-        self.context()?
-            .set_files(vec![path])
-            .map_err(|e| e.to_string())
+        self.with_context(|context| context.set_files(vec![path]).map_err(|e| e.to_string()))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static INITIALIZATION_ATTEMPTS: AtomicUsize = AtomicUsize::new(0);
+
+    fn unavailable_context() -> Result<ClipboardContext, String> {
+        INITIALIZATION_ATTEMPTS.fetch_add(1, Ordering::SeqCst);
+        Err("general pasteboard is unavailable".into())
+    }
+
+    fn panicking_context() -> Result<ClipboardContext, String> {
+        panic!("unexpected NULL returned from +[NSPasteboard generalPasteboard]")
+    }
+
+    #[test]
+    fn construction_does_not_initialize_the_native_clipboard() {
+        INITIALIZATION_ATTEMPTS.store(0, Ordering::SeqCst);
+        let _backend = MacosClipboard::with_initializer(unavailable_context);
+        assert_eq!(INITIALIZATION_ATTEMPTS.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn unavailable_initialization_is_retryable() {
+        INITIALIZATION_ATTEMPTS.store(0, Ordering::SeqCst);
+        let backend = MacosClipboard::with_initializer(unavailable_context);
+        for _ in 0..2 {
+            assert!(backend
+                .available_formats()
+                .unwrap_err()
+                .contains("general pasteboard is unavailable"));
+        }
+        assert_eq!(INITIALIZATION_ATTEMPTS.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn native_initialization_panic_becomes_an_error() {
+        let backend = MacosClipboard::with_initializer(panicking_context);
+        let error = backend.available_formats().unwrap_err();
+        assert!(error.contains("clipboard initialization panicked"));
+        assert!(error.contains("unexpected NULL returned"));
+    }
 
     #[test]
     fn rejects_relative_local_paths_before_clipboard_access() {


### PR DESCRIPTION
closes #2981

## what changed

- make `MacosClipboard::new()` side-effect-free so tool registration and metadata inspection do not acquire the general pasteboard
- initialize the native clipboard context only when a clipboard operation is invoked
- cache successful initialization while leaving failures retryable
- convert a native initializer panic into the backend's normal error path, which the shared clipboard tools publish as `clipboard_unavailable`
- add focused coverage for side-effect-free construction, retryable unavailability, panic containment, path validation, and the native clipboard round trip

## root cause

macos tool registration eagerly constructed `ClipboardContext`. `clipboard-rs` calls objc2's non-null `+[NSPasteboard generalPasteboard]` binding inside that constructor, so a restricted host that receives `NULL` panicked while building the registry. metadata commands and unrelated runtime tools failed before any clipboard operation was requested.

## why this differs from the suggested approach

this follows the suggested lazy backend boundary, but deliberately does not add a separate metadata catalog. a second registration path is disproportionate when the registry becomes metadata-safe by restoring constructor purity.

it also does not change or pin `clipboard-rs`. that would require cross-repository ownership of the native binding fix or an unpublished dependency. cua instead treats the dependency panic as an implementation failure at the macos backend boundary. the backend caches only a successful context; an unavailable pasteboard remains retryable instead of becoming a permanent process-lifetime failure.

this keeps the change local to the optional facility that violates constructor purity. it does not change registry semantics or the shared cross-platform clipboard contract.

## scope and limitation

this is cua-side compatibility containment, not a correction to `clipboard-rs`'s nullability contract. rust runs the process panic hook before `catch_unwind` returns, so an attempted clipboard operation in a restricted host may still emit one panic diagnostic to stderr. the panic does not terminate the process and the caller receives `clipboard_unavailable`. metadata inspection and unrelated runtime startup never call the initializer, so they do not trigger that diagnostic.

## user impact

`list-tools`, `describe`, and `dump-docs` can enumerate clipboard tools without touching appkit. restricted macos runtimes can initialize unrelated tools. an invoked clipboard operation with no pasteboard follows the existing structured `clipboard_unavailable` path instead of terminating the process.

## validation

Refreshed onto current `main` (`31c2184f860b`) in candidate `2ccdb741d97f` while preserving the contributor commit.

- `cargo fmt --check --all`
- `cargo test -p platform-macos --lib clipboard` — 5 passed
- `cargo test -p platform-macos --lib` — 368 passed, 2 ignored
- the initializer-counter tests now use isolated atomics, removing their parallel-test race
- `cargo test -p cua-driver-contract` — 45 passed
- restricted-host metadata proof on the behavior-identical parent `1f1394c6b589`: `list-tools` and `describe clipboard_read` passed 3/3 under a sandbox denying `com.apple.pasteboard.1`; all restricted `list-tools` outputs were byte-identical to the unsandboxed output
- `cargo clippy -p platform-macos --lib` — completes with existing warnings outside this change
- `cargo clippy -p platform-macos --lib -- -D warnings` — blocked by an existing `cursor-overlay/src/session_badge.rs` warning



