### PR TITLE
fix(fleets): recover pool ownership before WIF policy

### DIFF
--- a/.github/workflows/infra-fleets-wif-smoke.yml
+++ b/.github/workflows/infra-fleets-wif-smoke.yml
@@ -2,6 +2,12 @@ name: "Infra: Fleets WIF smoke pool"
 
 on:
   workflow_dispatch:
+    inputs:
+      recreate_pool:
+        description: "Recreate a pool that was previously owned by different credentials"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -17,6 +23,9 @@ env:
   CYCLOPS_CLIENT_ID: ${{ secrets.FLEETS_TERRAFORM_CLIENT_ID }}
   CYCLOPS_CLIENT_SECRET: ${{ secrets.FLEETS_TERRAFORM_CLIENT_SECRET }}
   CYCLOPS_TOKEN_URL: ${{ secrets.FLEETS_TERRAFORM_TOKEN_URL }}
+  POOL_BOOTSTRAP_CLIENT_ID: ${{ secrets.CUA_CLIENT_ID }}
+  POOL_BOOTSTRAP_CLIENT_SECRET: ${{ secrets.CUA_CLIENT_SECRET }}
+  POOL_BOOTSTRAP_TOKEN_URL: https://auth.cua.ai/realms/cyclops-cs/protocol/openid-connect/token
   FLEETS_PROVIDER_COMMIT: d118faeafd288150d574c471a1038b3f3aef7c71
   FLEETS_PROVIDER_VERSION: 1.0.0
   TF_IN_AUTOMATION: "true"
@@ -90,5 +99,12 @@ jobs:
         run: |
           terraform init -input=false
           terraform validate
+          if [ "${{ inputs.recreate_pool }}" = "true" ]; then
+            CYCLOPS_CLIENT_ID="$POOL_BOOTSTRAP_CLIENT_ID" \
+            CYCLOPS_CLIENT_SECRET="$POOL_BOOTSTRAP_CLIENT_SECRET" \
+            CYCLOPS_TOKEN_URL="$POOL_BOOTSTRAP_TOKEN_URL" \
+              terraform destroy -input=false -auto-approve \
+                -target=fleets_pool.cua_cli_wif_smoke
+          fi
           terraform plan -input=false -out=tfplan
           terraform apply -input=false -auto-approve tfplan

--- a/infra/fleets-wif-smoke/README.md
+++ b/infra/fleets-wif-smoke/README.md
@@ -11,3 +11,5 @@ The apply job uses a dedicated user-owned Fleets key stored as protected reposit
 - `FLEETS_TERRAFORM_TOKEN_URL`
 
 The pool autoscaler is bounded from zero to one replica. The daily smoke workflow claims a UUID-suffixed sandbox, runs commands through `cua sb exec`, deletes the claim, and suspends the pool back to zero replicas.
+
+If the pool was previously created with different credentials, manually dispatch the apply workflow once with `recreate_pool` enabled. The recovery deletes only the managed pool with the original bootstrap credentials, then recreates the pool and trust policy under the dedicated owner key.


### PR DESCRIPTION
## What changed
- add an opt-in `recreate_pool` workflow-dispatch input
- when enabled, delete only the Terraform-managed pool using the credentials that originally created it
- recreate the pool and GitHub trust policy under the same dedicated user-owned Terraform key

## Why
The first apply created `cua-cli-wif-smoke` with the general machine client. GitHub trust policies are owner-scoped, so the dedicated user key could read that pool but received `403 forbidden` when authorizing its namespace. Both resources need the same owner identity.

## Safety
- recovery is disabled by default
- the targeted destroy is limited to `fleets_pool.cua_cli_wif_smoke`
- normal applies never recreate the pool

## Validation
- `actionlint .github/workflows/infra-fleets-wif-smoke.yml`
- `git diff --check`
