### PR TITLE
chore: remove unused imports in mcp-server and human_tool ui

### DIFF
--- a/libs/python/agent/cua_agent/human_tool/ui.py
+++ b/libs/python/agent/cua_agent/human_tool/ui.py
@@ -9,7 +9,6 @@ import gradio as gr
 import requests
 from PIL import Image
 
-from .server import completion_queue
 
 
 class HumanCompletionUI:
@@ -411,7 +410,6 @@ class HumanCompletionUI:
             max_seconds: Maximum number of seconds to wait
             check_interval: How often to check for pending calls (in seconds)
         """
-        import time
 
         start_time = time.time()
 

--- a/libs/python/agent/cua_agent/human_tool/ui.py
+++ b/libs/python/agent/cua_agent/human_tool/ui.py
@@ -10,7 +10,6 @@ import requests
 from PIL import Image
 
 
-
 class HumanCompletionUI:
     def __init__(self, server_url: str = "http://localhost:8002"):
         self.server_url = server_url

--- a/libs/python/mcp-server/mcp_server/server.py
+++ b/libs/python/mcp-server/mcp_server/server.py
@@ -1,5 +1,4 @@
 import asyncio
-import base64
 import inspect
 import logging
 import os

--- a/libs/python/mcp-server/mcp_server/session_manager.py
+++ b/libs/python/mcp-server/mcp_server/session_manager.py
@@ -13,7 +13,6 @@ import logging
 import os
 import time
 import uuid
-import weakref
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Set


### PR DESCRIPTION
## Summary

- remove unused `base64` and `weakref` imports from the Python MCP server
- remove the unused `completion_queue` import and redundant function-local `time` import from the human-tool UI
- normalize the resulting import spacing so the repository isort check passes

There is no user-visible behavior change. The UI continues to use its module-level `time` import, and supported human-tool entry points already load the server explicitly or through package initialization.

## CI root cause addressed

The original fork PR's Python lint job failed because deleting the relative import left an extra blank line before `HumanCompletionUI`. Its release-reminder job also could not post a PR comment because fork workflow tokens are read-only; this internal landing PR avoids that permission limitation.

## Verification

- `isort --check-only` on all three changed files
- `black --check` on all three changed files
- `ruff check` on all three changed files
- `python3 -m py_compile` on all three changed files
- `git diff --check`

Salvaged from #3001. The contributor's commit was cherry-picked with provenance and its author normalized to the GitHub-linked `pxmpsdev` identity.