### PR TITLE
fix(cua-sandbox): refresh GitHub WIF tokens

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -6,8 +6,12 @@ import asyncio
 import hashlib
 import json
 import logging
+import os
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any, Mapping, Optional
-from urllib.parse import urlparse
+from urllib.parse import parse_qsl, urlencode, urlparse, urlsplit, urlunsplit
+
+import httpx
 
 from cua_sandbox._config import (
     get_client_id,
@@ -21,6 +25,7 @@ from cua_sandbox.transport.cyclops_http_client import CyclopsHttpClient
 from cua_sandbox.transport.fleet import FleetTransport
 from fleet_sdk import (
     AccessTokenProvider,
+    AccessTokenProviderError,
     CreateClaimRequest,
     CreatePoolRequest,
     CreatePoolRequestBuilder,
@@ -61,6 +66,81 @@ def _claim_name(pool_name: str) -> str:
     return f"{prefix}-{hash_suffix}"
 
 
+_GITHUB_WIF_AUDIENCE = "fleets"
+_GitHubTokenRequest = Callable[[str, dict[str, str]], Awaitable[tuple[int, Mapping[str, Any]]]]
+
+
+async def _httpx_json_get(url: str, headers: dict[str, str]) -> tuple[int, Mapping[str, Any]]:
+    async with httpx.AsyncClient(timeout=15) as client:
+        response = await client.get(url, headers=headers)
+    payload = response.json()
+    if not isinstance(payload, Mapping):
+        raise ValueError("GitHub OIDC endpoint returned an invalid response")
+    return response.status_code, payload
+
+
+def _with_audience(request_url: str, audience: str) -> str:
+    parts = urlsplit(request_url)
+    query = [
+        (key, value)
+        for key, value in parse_qsl(parts.query, keep_blank_values=True)
+        if key != "audience"
+    ]
+    query.append(("audience", audience))
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment))
+
+
+class _GitHubActionsAccessTokenProvider(AccessTokenProvider):
+    """Refresh a Fleet workload token through GitHub Actions OIDC after a 401."""
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        environ: Mapping[str, str] | None = None,
+        request: _GitHubTokenRequest = _httpx_json_get,
+    ) -> None:
+        self._token = token
+        self._environ = os.environ if environ is None else environ
+        self._request = request
+
+    async def get_access_token(self, force_refresh: bool) -> str:
+        if not force_refresh:
+            return self._token
+
+        request_url = self._environ.get("ACTIONS_ID_TOKEN_REQUEST_URL", "").strip()
+        request_token = self._environ.get("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "").strip()
+        if not request_url or not request_token:
+            raise AccessTokenProviderError.Failed(
+                "GitHub Actions OIDC environment is unavailable for token refresh"
+            )
+
+        try:
+            status, payload = await self._request(
+                _with_audience(request_url, _GITHUB_WIF_AUDIENCE),
+                {
+                    "Accept": "application/json",
+                    "Authorization": f"bearer {request_token}",
+                },
+            )
+        except AccessTokenProviderError:
+            raise
+        except Exception as error:
+            raise AccessTokenProviderError.Failed("GitHub OIDC token refresh failed") from error
+
+        if status != 200:
+            raise AccessTokenProviderError.Failed(
+                f"GitHub OIDC token refresh failed with HTTP {status}"
+            )
+        token = payload.get("value")
+        if not isinstance(token, str) or not token.strip():
+            raise AccessTokenProviderError.Failed(
+                "GitHub OIDC token refresh returned an empty token"
+            )
+        self._token = token.strip()
+        return self._token
+
+
 class _StaticAccessTokenProvider(AccessTokenProvider):
     """Return a configured Fleet workload token without attempting refresh."""
 
@@ -95,7 +175,14 @@ class _FleetClient:
                 claim_poll_limit=300,
             )
             self._client = CyclopsClient.connect_with_access_token_provider(
-                configuration, _StaticAccessTokenProvider(fleet_token), self._http_client
+                configuration,
+                (
+                    _GitHubActionsAccessTokenProvider(fleet_token)
+                    if os.environ.get("ACTIONS_ID_TOKEN_REQUEST_URL", "").strip()
+                    and os.environ.get("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "").strip()
+                    else _StaticAccessTokenProvider(fleet_token)
+                ),
+                self._http_client,
             )
             return
         configuration = CyclopsConfiguration(

--- a/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
+++ b/libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Any, Mapping, Optional
 from urllib.parse import parse_qsl, urlencode, urlparse, urlsplit, urlunsplit
 
 import httpx
-
 from cua_sandbox._config import (
     get_client_id,
     get_client_secret,

--- a/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
@@ -2,7 +2,10 @@ import logging
 from types import SimpleNamespace
 
 import pytest
-from cua_sandbox.transport.fleet_cloud import _FleetClient, _GitHubActionsAccessTokenProvider
+from cua_sandbox.transport.fleet_cloud import (
+    _FleetClient,
+    _GitHubActionsAccessTokenProvider,
+)
 from fleet_sdk import (
     AccessTokenProviderError,
     CyclopsClient,

--- a/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
+++ b/libs/python/cua-sandbox/tests/test_fleet_cloud_client.py
@@ -2,7 +2,14 @@ import logging
 from types import SimpleNamespace
 
 import pytest
-from cua_sandbox.transport.fleet_cloud import _FleetClient
+from cua_sandbox.transport.fleet_cloud import _FleetClient, _GitHubActionsAccessTokenProvider
+from fleet_sdk import (
+    AccessTokenProviderError,
+    CyclopsClient,
+    CyclopsTokenProviderConfiguration,
+    HttpClient,
+    HttpResponse,
+)
 
 
 @pytest.mark.asyncio
@@ -121,7 +128,107 @@ async def test_service_request_delegates_to_generated_client():
 
 
 @pytest.mark.asyncio
+async def test_github_actions_token_provider_refreshes_and_caches_token():
+    calls = []
+
+    async def request(url, headers):
+        calls.append((url, headers))
+        return 200, {"value": "refreshed-token"}
+
+    provider = _GitHubActionsAccessTokenProvider(
+        "initial-token",
+        environ={
+            "ACTIONS_ID_TOKEN_REQUEST_URL": "https://github.example/oidc?existing=value",
+            "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
+        },
+        request=request,
+    )
+
+    assert await provider.get_access_token(False) == "initial-token"
+    assert calls == []
+    assert await provider.get_access_token(True) == "refreshed-token"
+    assert await provider.get_access_token(False) == "refreshed-token"
+    assert calls == [
+        (
+            "https://github.example/oidc?existing=value&audience=fleets",
+            {
+                "Accept": "application/json",
+                "Authorization": "bearer request-token",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_github_actions_token_provider_maps_refresh_failures():
+    async def request(url, headers):
+        return 403, {"message": "forbidden"}
+
+    provider = _GitHubActionsAccessTokenProvider(
+        "initial-token",
+        environ={
+            "ACTIONS_ID_TOKEN_REQUEST_URL": "https://github.example/oidc",
+            "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
+        },
+        request=request,
+    )
+
+    with pytest.raises(AccessTokenProviderError.Failed, match="HTTP 403"):
+        await provider.get_access_token(True)
+
+
+@pytest.mark.asyncio
+async def test_generated_sdk_retries_unauthorized_request_with_refreshed_github_token():
+    refresh_calls = 0
+
+    async def refresh_token(url, headers):
+        nonlocal refresh_calls
+        refresh_calls += 1
+        return 200, {"value": "refreshed-token"}
+
+    class ScriptedHttpClient(HttpClient):
+        def __init__(self):
+            self.authorization = []
+
+        async def execute(self, request):
+            authorization = next(
+                header.value for header in request.headers if header.name.lower() == "authorization"
+            )
+            self.authorization.append(authorization)
+            if len(self.authorization) == 1:
+                return HttpResponse(status=401, headers=[], body=b'{"error":"expired"}')
+            return HttpResponse(status=200, headers=[], body=b'{"items":[]}')
+
+    provider = _GitHubActionsAccessTokenProvider(
+        "initial-token",
+        environ={
+            "ACTIONS_ID_TOKEN_REQUEST_URL": "https://github.example/oidc",
+            "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
+        },
+        request=refresh_token,
+    )
+    http_client = ScriptedHttpClient()
+    client = CyclopsClient.connect_with_access_token_provider(
+        CyclopsTokenProviderConfiguration(
+            base_url="https://fleet.example",
+            pool_poll_interval_ms=1,
+            pool_poll_limit=1,
+            claim_poll_interval_ms=1,
+            claim_poll_limit=1,
+        ),
+        provider,
+        http_client,
+    )
+
+    assert await client.list_pools("cua-cli-wif-smoke") == []
+    assert http_client.authorization == ["Bearer initial-token", "Bearer refreshed-token"]
+    assert refresh_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_fleet_client_uses_static_workload_token_and_closes_http_client(monkeypatch, caplog):
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_URL", raising=False)
+    monkeypatch.delenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", raising=False)
     from cua_sandbox.transport import fleet_cloud
     from fleet_sdk import AccessTokenProvider, CyclopsTokenProviderConfiguration
 
@@ -172,6 +279,34 @@ async def test_fleet_client_uses_static_workload_token_and_closes_http_client(mo
 
     await client.close()
     assert calls["http_client"].close_calls == 1
+
+
+def test_fleet_client_uses_refreshable_provider_in_github_actions(monkeypatch):
+    from cua_sandbox.transport import fleet_cloud
+
+    calls = {}
+
+    class HttpClient:
+        async def aclose(self):
+            pass
+
+    class Client:
+        @staticmethod
+        def connect_with_access_token_provider(configuration, provider, http_client):
+            calls["provider"] = provider
+            return "token-client"
+
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "https://github.example/oidc")
+    monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "request-token")
+    monkeypatch.setattr(fleet_cloud, "get_fleet_token", lambda: "initial-token")
+    monkeypatch.setattr(fleet_cloud, "get_fleet_base_url", lambda: "https://fleet.example/")
+    monkeypatch.setattr(fleet_cloud, "CyclopsHttpClient", HttpClient)
+    monkeypatch.setattr(fleet_cloud, "CyclopsClient", Client)
+
+    client = _FleetClient()
+
+    assert client._client == "token-client"
+    assert isinstance(calls["provider"], _GitHubActionsAccessTokenProvider)
 
 
 def test_fleet_client_falls_back_to_client_credentials_without_workload_token(monkeypatch):


### PR DESCRIPTION
## What changed

- replace the static Fleet workload-token provider with a GitHub Actions provider when the OIDC request environment is available
- reuse the token from `cua wif-token github` until the Fleet API rejects it
- request a fresh `audience=fleets` token after a 401 and cache it for subsequent polling requests
- retain static-token behavior outside GitHub Actions

## Why

The periodic `cua-cli` Fleets WIF smoke reaches scale-from-zero provisioning, but GitHub's short-lived OIDC token can expire while the SDK polls the pool/claim. The generated Fleet SDK already retries control-plane 401 responses through `AccessTokenProvider`; `cua-sandbox` was supplying a provider that always returned the original token.

## Validation

- `ruff format` and `ruff check` on changed files
- `65 passed, 8 skipped` for Fleet/config sandbox tests
- `70 passed` for CLI auth, WIF token, and sandbox command tests
- contract test verifies the generated SDK retries `Bearer initial-token` with `Bearer refreshed-token` after a 401

## Testing note

The full local sandbox suite also exercises local desktop-driver integration and currently reports unrelated local fixture/driver failures (`28 failed, 264 passed, 84 skipped, 19 errors`).
