### PR TITLE
fix(fleets): probe WIF smoke image on port 3000

### DIFF
--- a/infra/fleets-wif-smoke/main.tf
+++ b/infra/fleets-wif-smoke/main.tf
@@ -25,7 +25,7 @@ resource "fleets_pool" "cua_cli_wif_smoke" {
   cpu_cores            = 4
   memory               = "8Gi"
   container_disk_image = "296062593712.dkr.ecr.us-west-2.amazonaws.com/desktop-workspace:latest"
-  readiness_probe_json = jsonencode({ tcpSocket = { port = 8000 } })
+  readiness_probe_json = jsonencode({ tcpSocket = { port = 3000 } })
 
   autoscaling {
     min_pool_size     = 0
@@ -35,7 +35,7 @@ resource "fleets_pool" "cua_cli_wif_smoke" {
 
   service {
     name        = "server"
-    target_port = 8000
+    target_port = 3000
     protocol    = "TCP"
   }
 }


### PR DESCRIPTION
## What changed

- probe `desktop-workspace:latest` on its Cua driver port `3000`
- expose the Fleet `server` service on the same port

## Why

The merged WIF token refresh fix carried the smoke past the previous five-minute 401, but the pool timed out after 15 minutes with zero ready replicas. The selected desktop image serves its MCP/Cua driver endpoint on port 3000; the Terraform pool was probing port 8000.

## Validation

- exact two-line Terraform diff
- `git diff --check`
- authoritative Terraform plan will run in the protected infra workflow after merge