### PR TITLE
fix(fleets): use exec-capable WIF smoke image

### DIFF
--- a/infra/fleets-wif-smoke/main.tf
+++ b/infra/fleets-wif-smoke/main.tf
@@ -24,8 +24,8 @@ resource "fleets_pool" "cua_cli_wif_smoke" {
   replicas             = 0
   cpu_cores            = 4
   memory               = "8Gi"
-  container_disk_image = "296062593712.dkr.ecr.us-west-2.amazonaws.com/desktop-workspace:latest"
-  readiness_probe_json = jsonencode({ tcpSocket = { port = 3000 } })
+  container_disk_image = "296062593712.dkr.ecr.us-west-2.amazonaws.com/desktop-workspace-duo:latest"
+  readiness_probe_json = jsonencode({ tcpSocket = { port = 8000 } })
 
   autoscaling {
     min_pool_size     = 0
@@ -35,7 +35,7 @@ resource "fleets_pool" "cua_cli_wif_smoke" {
 
   service {
     name        = "server"
-    target_port = 3000
+    target_port = 8000
     protocol    = "TCP"
   }
 }


### PR DESCRIPTION
## What changed

- use `desktop-workspace-duo:latest` for the persistent WIF smoke pool
- probe and expose its computer-server endpoint on port `8000`

## Why

The plain `desktop-workspace:latest` reference does not exist in ECR and that image family is MCP-only. The smoke exercises `cua sb exec`, which requires the computer-server API. `desktop-workspace-duo:latest` exists (digest `sha256:5b9cb82f...`) and its build smoke-tests computer-server `/status` on port 8000.

## Validation

- confirmed the `latest` tag exists in ECR and was pushed on August 4, 2026
- confirmed the duo image build starts and smoke-tests computer-server on `:8000`
- `git diff --check`