### PR TITLE
fix(cua-driver): render browser cursor on Linux

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/engine.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/engine.rs
@@ -41,8 +41,8 @@ use super::cdp_ws::{CdpConnection, CdpPool};
 use super::grant::{ExistingProfileGrant, ExistingProfileGrants, GrantLookup};
 use super::mutation::{MutationGates, MutationKey};
 use super::platform::{
-    BrowserConsentOutcome, BrowserConsentRequest, BrowserPlatform, BrowserVisualAction,
-    BrowserVisualActionKind, ExistingProfileSetupRequest,
+    BrowserConsentOutcome, BrowserConsentRequest, BrowserCursorVisibility, BrowserPlatform,
+    BrowserVisualAction, BrowserVisualActionKind, ExistingProfileSetupRequest,
 };
 use super::prepare::ManagedBrowsers;
 use super::reconnect::ReconnectGates;
@@ -72,6 +72,42 @@ pub const MAX_REFS_PER_SNAPSHOT: usize = 300;
 /// compromised or malformed endpoint before its response reaches consumers.
 const MAX_BROWSER_SCREENSHOT_BYTES: usize = 16 * 1024 * 1024;
 
+#[derive(Debug, Default)]
+struct BrowserCursorTracker {
+    window_by_session: HashMap<String, u64>,
+}
+
+impl BrowserCursorTracker {
+    fn update(
+        &mut self,
+        session: &str,
+        window_id: u64,
+        tab_is_active: bool,
+    ) -> Vec<BrowserCursorVisibility> {
+        self.window_by_session.insert(session.to_owned(), window_id);
+
+        if !tab_is_active {
+            return vec![BrowserCursorVisibility {
+                session: session.to_owned(),
+                visible: false,
+            }];
+        }
+
+        self.window_by_session
+            .iter()
+            .filter(|(_, bound_window_id)| **bound_window_id == window_id)
+            .map(|(key, _)| BrowserCursorVisibility {
+                session: key.clone(),
+                visible: key == session,
+            })
+            .collect()
+    }
+
+    fn remove_session(&mut self, session: &str) {
+        self.window_by_session.remove(session);
+    }
+}
+
 pub struct BrowserEngine {
     pub(crate) platform: Arc<dyn BrowserPlatform>,
     pub(crate) store: BrowserStore,
@@ -83,6 +119,7 @@ pub struct BrowserEngine {
     mutation_gates: MutationGates,
     reconnect_gates: ReconnectGates,
     pending_existing_profile_cleanups: Mutex<HashMap<String, Vec<ExistingProfileSetupRequest>>>,
+    browser_cursors: Mutex<BrowserCursorTracker>,
     session_end_hook: Mutex<Option<crate::session::SessionEndHookRegistration>>,
 }
 
@@ -637,6 +674,7 @@ impl BrowserEngine {
             mutation_gates: MutationGates::new(),
             reconnect_gates: ReconnectGates::new(),
             pending_existing_profile_cleanups: Mutex::new(HashMap::new()),
+            browser_cursors: Mutex::new(BrowserCursorTracker::default()),
             session_end_hook: Mutex::new(None),
         });
         let weak: Weak<Self> = Arc::downgrade(&engine);
@@ -646,6 +684,11 @@ impl BrowserEngine {
                 if let Some(engine) = weak.upgrade() {
                     engine.store.remove_session(session_id);
                     engine.cleanup_prepared_session(session_id);
+                    engine
+                        .browser_cursors
+                        .lock()
+                        .unwrap()
+                        .remove_session(session_id);
                     let pending = {
                         let mut pending = engine.pending_existing_profile_cleanups.lock().unwrap();
                         let mut requests = pending.remove(session_id).unwrap_or_default();
@@ -1663,6 +1706,10 @@ impl BrowserEngine {
         viewport_y: f64,
         kind: BrowserVisualActionKind,
     ) {
+        if session.is_empty() || crate::session::is_session_ended(session) {
+            return;
+        }
+
         // `document.visibilityState` distinguishes the selected tab without
         // focusing its native window or invoking any CDP activation command.
         // Treat an unavailable or malformed proof as inactive: omitting
@@ -1706,15 +1753,21 @@ impl BrowserEngine {
         let (screen_x, screen_y) = screen_point
             .map(|(x, y)| (Some(x), Some(y)))
             .unwrap_or((None, None));
+        let visibility_updates = {
+            let mut browser_cursors = self.browser_cursors.lock().unwrap();
+            if crate::session::is_session_ended(session) {
+                return;
+            }
+            browser_cursors.update(session, validated.native.window_id, tab_is_active)
+        };
         self.platform
             .visualize_browser_action(BrowserVisualAction {
                 session: session.to_owned(),
                 window_id: validated.native.window_id,
-                cdp_target_id: validated.tab.cdp_target_id.clone(),
-                tab_is_active,
                 screen_x,
                 screen_y,
                 kind,
+                visibility_updates,
             })
             .await;
     }
@@ -2882,6 +2935,76 @@ fn collect_interactive(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn browser_cursor_tracker_keeps_one_active_tab_per_native_window() {
+        let mut tracker = BrowserCursorTracker::default();
+        assert_eq!(
+            tracker.update("session-red", 77, false),
+            vec![BrowserCursorVisibility {
+                session: "session-red".to_owned(),
+                visible: false,
+            }]
+        );
+
+        let mut updates = tracker.update("session-blue", 77, true);
+        updates.sort_by(|left, right| left.session.cmp(&right.session));
+        assert_eq!(
+            updates,
+            vec![
+                BrowserCursorVisibility {
+                    session: "session-blue".to_owned(),
+                    visible: true,
+                },
+                BrowserCursorVisibility {
+                    session: "session-red".to_owned(),
+                    visible: false,
+                },
+            ]
+        );
+
+        assert_eq!(
+            tracker.update("session-green", 88, true),
+            vec![BrowserCursorVisibility {
+                session: "session-green".to_owned(),
+                visible: true,
+            }]
+        );
+    }
+
+    #[test]
+    fn browser_visual_action_kind_pulses_only_discrete_mutations() {
+        for kind in [
+            BrowserVisualActionKind::Click,
+            BrowserVisualActionKind::Type,
+            BrowserVisualActionKind::RightClick,
+            BrowserVisualActionKind::DoubleClick,
+            BrowserVisualActionKind::Drag,
+        ] {
+            assert!(kind.shows_click_pulse(), "{kind:?} should pulse");
+        }
+        for kind in [
+            BrowserVisualActionKind::Hover,
+            BrowserVisualActionKind::Scroll,
+        ] {
+            assert!(!kind.shows_click_pulse(), "{kind:?} must not pulse");
+        }
+    }
+
+    #[test]
+    fn browser_cursor_tracker_forgets_ended_sessions() {
+        let mut tracker = BrowserCursorTracker::default();
+        tracker.update("ended", 77, true);
+        tracker.remove_session("ended");
+
+        assert_eq!(
+            tracker.update("current", 77, true),
+            vec![BrowserCursorVisibility {
+                session: "current".to_owned(),
+                visible: true,
+            }]
+        );
+    }
 
     #[test]
     fn endpoint_access_policy_requires_grants_for_standalone_consumers() {

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/platform.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/platform.rs
@@ -220,17 +220,25 @@ pub enum BrowserVisualActionKind {
     Drag,
 }
 
+impl BrowserVisualActionKind {
+    pub fn shows_click_pulse(self) -> bool {
+        matches!(
+            self,
+            Self::Click | Self::Type | Self::RightClick | Self::DoubleClick | Self::Drag
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserCursorVisibility {
+    pub session: String,
+    pub visible: bool,
+}
+
 #[derive(Debug, Clone)]
 pub struct BrowserVisualAction {
     pub session: String,
     pub window_id: u64,
-    /// Real CDP page target that owns this cursor. Platform adapters may use
-    /// it to keep several session cursors associated with separate tabs.
-    pub cdp_target_id: String,
-    /// Live, non-activating page-visibility proof collected immediately
-    /// before the action. False also covers an unavailable proof so visual
-    /// feedback fails closed instead of appearing over the wrong tab.
-    pub tab_is_active: bool,
     /// Screen coordinates in the platform-normalized device-independent
     /// space used by [`NativeWindowInfo::bounds`]. Child-frame or
     /// untrustworthy geometry intentionally produces no visual point while
@@ -238,6 +246,17 @@ pub struct BrowserVisualAction {
     pub screen_x: Option<f64>,
     pub screen_y: Option<f64>,
     pub kind: BrowserVisualActionKind,
+    /// Shared core owns active-tab arbitration so native adapters only map this
+    /// plan onto their existing overlay router.
+    pub visibility_updates: Vec<BrowserCursorVisibility>,
+}
+
+impl BrowserVisualAction {
+    pub fn current_session_visible(&self) -> bool {
+        self.visibility_updates
+            .iter()
+            .any(|update| update.session == self.session && update.visible)
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/platform.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/platform.rs
@@ -287,10 +287,10 @@ pub trait BrowserPlatform: Send + Sync {
     }
 
     /// Best-effort, visual-only feedback for an authorized browser action.
-    /// The default is a no-op so platforms without an agent-cursor overlay do
-    /// not change behavior. Implementations must not deliver input or alter
-    /// focus/z-order; failures are intentionally not part of browser results.
-    async fn visualize_browser_action(&self, _action: BrowserVisualAction) {}
+    /// Implementations without an agent-cursor overlay must explicitly opt out
+    /// with a no-op. Implementations must not deliver input or alter focus or
+    /// z-order; failures are intentionally not part of browser results.
+    async fn visualize_browser_action(&self, action: BrowserVisualAction);
 
     /// Classify `pid`: is it a browser, which engine family, can it do
     /// CDP at all. Must not have side effects.

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/tools.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/tools.rs
@@ -2482,7 +2482,9 @@ impl Tool for BrowserSetInputFilesTool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::browser::platform::{BrowserPlatform, PrepareOutcome, PrepareRequest};
+    use crate::browser::platform::{
+        BrowserPlatform, BrowserVisualAction, PrepareOutcome, PrepareRequest,
+    };
     use crate::browser::types::{
         BrowserClassification, BrowserEngineFamily, BrowserProduct, NativeWindowInfo,
         OwnedEndpoint, ProcessFingerprint,
@@ -2495,6 +2497,8 @@ mod tests {
 
     #[async_trait]
     impl BrowserPlatform for MockPlatform {
+        async fn visualize_browser_action(&self, _action: BrowserVisualAction) {}
+
         async fn classify_browser(
             &self,
             pid: i64,

--- a/libs/cua-driver/rust/crates/cua-driver-core/src/browser/v2_tests.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/browser/v2_tests.rs
@@ -22,8 +22,9 @@ use crate::tool::Tool;
 use super::engine::BrowserEngine;
 use super::mock_cdp::{MockCdpServer, MockEvent, MockHandler, MockReply};
 use super::platform::{
-    BrowserConsentOutcome, BrowserConsentRequest, BrowserPlatform, ExistingProfileSetupOutcome,
-    ExistingProfileSetupRequest, PrepareAction, PrepareOutcome, PrepareRequest,
+    BrowserConsentOutcome, BrowserConsentRequest, BrowserPlatform, BrowserVisualAction,
+    ExistingProfileSetupOutcome, ExistingProfileSetupRequest, PrepareAction, PrepareOutcome,
+    PrepareRequest,
 };
 use super::pointer::BrowserPointerTool;
 use super::refusal::BrowserRefusal;
@@ -677,6 +678,8 @@ impl BrowserPlatform for FixturePlatform {
         self.trusted_input_limited
             .then_some("fixture trusted input raises the standalone window")
     }
+
+    async fn visualize_browser_action(&self, _action: BrowserVisualAction) {}
 
     async fn classify_browser(&self, _pid: i64) -> Result<BrowserClassification, BrowserRefusal> {
         Ok(BrowserClassification {

--- a/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
@@ -3,14 +3,15 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
 use cua_driver_core::browser::existing_profile_setup_descriptor;
 use cua_driver_core::browser::platform::{
     select_isolated_browser_executable, BrowserConsentOutcome, BrowserConsentRequest,
-    BrowserPlatform, ExistingProfileSetupOutcome, ExistingProfileSetupRequest, PrepareAction,
-    PrepareOutcome, PrepareRequest,
+    BrowserPlatform, BrowserVisualAction, BrowserVisualActionKind, ExistingProfileSetupOutcome,
+    ExistingProfileSetupRequest, PrepareAction, PrepareOutcome, PrepareRequest,
 };
 use cua_driver_core::browser::refusal::{BrowserRefusal, BrowserRefusalCode};
 use cua_driver_core::browser::types::{
@@ -20,8 +21,69 @@ use cua_driver_core::browser::types::{
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+pub struct LinuxBrowserPlatform {
+    cursor_registry: Arc<cursor_overlay::CursorRegistry>,
+    browser_cursors: Mutex<BrowserCursorTracker>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BrowserCursorBinding {
+    window_id: u64,
+    cdp_target_id: String,
+}
+
 #[derive(Debug, Default)]
-pub struct LinuxBrowserPlatform;
+struct BrowserCursorTracker {
+    bindings: HashMap<String, BrowserCursorBinding>,
+}
+
+impl BrowserCursorTracker {
+    fn update(
+        &mut self,
+        session: &str,
+        window_id: u64,
+        cdp_target_id: &str,
+        tab_is_active: bool,
+    ) -> Vec<(String, bool)> {
+        self.bindings.insert(
+            session.to_owned(),
+            BrowserCursorBinding {
+                window_id,
+                cdp_target_id: cdp_target_id.to_owned(),
+            },
+        );
+
+        if !tab_is_active {
+            return vec![(session.to_owned(), false)];
+        }
+
+        self.bindings
+            .iter()
+            .filter(|(_, binding)| binding.window_id == window_id)
+            .map(|(key, binding)| {
+                (
+                    key.clone(),
+                    key == session && binding.cdp_target_id == cdp_target_id,
+                )
+            })
+            .collect()
+    }
+}
+
+impl LinuxBrowserPlatform {
+    pub fn new(cursor_registry: Arc<cursor_overlay::CursorRegistry>) -> Self {
+        Self {
+            cursor_registry,
+            browser_cursors: Mutex::new(BrowserCursorTracker::default()),
+        }
+    }
+}
+
+impl Default for LinuxBrowserPlatform {
+    fn default() -> Self {
+        Self::new(Arc::new(cursor_overlay::CursorRegistry::new()))
+    }
+}
 
 fn refusal(code: BrowserRefusalCode, message: impl Into<String>) -> BrowserRefusal {
     BrowserRefusal::new(code, message)
@@ -491,6 +553,76 @@ impl BrowserPlatform for LinuxBrowserPlatform {
 
     fn standalone_trusted_input_background_limitation(&self) -> Option<&'static str> {
         Some("Chromium's trusted CDP Input route activates its standalone browser window on Linux")
+    }
+
+    async fn visualize_browser_action(&self, action: BrowserVisualAction) {
+        if action.session.is_empty()
+            || action.cdp_target_id.is_empty()
+            || cua_driver_core::session::is_session_ended(&action.session)
+        {
+            return;
+        }
+
+        let visibility_updates = self.browser_cursors.lock().unwrap().update(
+            &action.session,
+            action.window_id,
+            &action.cdp_target_id,
+            action.tab_is_active,
+        );
+        let cursor_enabled = self
+            .cursor_registry
+            .get_or_create(&action.session)
+            .config
+            .enabled;
+        for (key, visible) in visibility_updates {
+            let enabled = if key == action.session {
+                visible && cursor_enabled
+            } else {
+                visible
+                    && self
+                        .cursor_registry
+                        .get(&key)
+                        .is_some_and(|state| state.config.enabled)
+            };
+            crate::overlay::send_command_for(
+                key,
+                cursor_overlay::OverlayCommand::SetEnabled(enabled),
+            );
+        }
+        if !action.tab_is_active || !cursor_enabled {
+            return;
+        }
+        let (Some(screen_x), Some(screen_y)) = (action.screen_x, action.screen_y) else {
+            return;
+        };
+        if !screen_x.is_finite() || !screen_y.is_finite() {
+            return;
+        }
+
+        crate::overlay::send_command_for(
+            action.session.clone(),
+            cursor_overlay::OverlayCommand::PinAbove(action.window_id),
+        );
+        crate::overlay::animate_cursor_to_for(action.session.clone(), screen_x, screen_y).await;
+        self.cursor_registry
+            .update_position(&action.session, screen_x, screen_y);
+
+        if matches!(
+            action.kind,
+            BrowserVisualActionKind::Click
+                | BrowserVisualActionKind::Type
+                | BrowserVisualActionKind::RightClick
+                | BrowserVisualActionKind::DoubleClick
+                | BrowserVisualActionKind::Drag
+        ) {
+            crate::overlay::send_command_for(
+                action.session,
+                cursor_overlay::OverlayCommand::ClickPulse {
+                    x: screen_x,
+                    y: screen_y,
+                },
+            );
+        }
     }
 
     async fn classify_browser(&self, pid: i64) -> Result<BrowserClassification, BrowserRefusal> {
@@ -1214,6 +1346,79 @@ mod tests {
         .expect("cleanup worker");
 
         assert!(cleaned);
+    }
+
+    #[tokio::test]
+    async fn browser_visual_feedback_updates_the_declared_session_cursor() {
+        let registry = Arc::new(cursor_overlay::CursorRegistry::new());
+        let platform = LinuxBrowserPlatform::new(registry.clone());
+        platform
+            .visualize_browser_action(BrowserVisualAction {
+                session: "browser-cursor-test".to_owned(),
+                window_id: 77,
+                cdp_target_id: "tab-A".to_owned(),
+                tab_is_active: true,
+                screen_x: Some(321.0),
+                screen_y: Some(456.0),
+                kind: BrowserVisualActionKind::Click,
+            })
+            .await;
+
+        let state = registry
+            .get("browser-cursor-test")
+            .expect("browser action should materialize its session cursor");
+        assert_eq!((state.x, state.y), (Some(321.0), Some(456.0)));
+    }
+
+    #[tokio::test]
+    async fn inactive_tab_feedback_materializes_but_does_not_move_its_cursor() {
+        let registry = Arc::new(cursor_overlay::CursorRegistry::new());
+        let platform = LinuxBrowserPlatform::new(registry.clone());
+        platform
+            .visualize_browser_action(BrowserVisualAction {
+                session: "browser-cursor-hidden".to_owned(),
+                window_id: 77,
+                cdp_target_id: "tab-hidden".to_owned(),
+                tab_is_active: false,
+                screen_x: Some(321.0),
+                screen_y: Some(456.0),
+                kind: BrowserVisualActionKind::Click,
+            })
+            .await;
+
+        let state = registry
+            .get("browser-cursor-hidden")
+            .expect("browser action should establish its session-to-tab binding");
+        assert!(
+            state.x.is_none() && state.y.is_none(),
+            "an inactive tab must not animate or move its visible cursor"
+        );
+    }
+
+    #[test]
+    fn browser_cursor_tracker_shows_only_the_active_tabs_session_per_window() {
+        let mut tracker = BrowserCursorTracker::default();
+        assert_eq!(
+            tracker.update("session-red", 77, "tab-A", false),
+            vec![("session-red".to_owned(), false)]
+        );
+
+        let first_active = tracker.update("session-red", 77, "tab-A", true);
+        assert_eq!(first_active, vec![("session-red".to_owned(), true)]);
+
+        let second_active = tracker
+            .update("session-blue", 77, "tab-B", true)
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+        assert_eq!(second_active.get("session-red"), Some(&false));
+        assert_eq!(second_active.get("session-blue"), Some(&true));
+
+        let other_window = tracker.update("session-green", 88, "tab-C", true);
+        assert_eq!(
+            other_window,
+            vec![("session-green".to_owned(), true)],
+            "an active tab in another native window must not hide this window"
+        );
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/browser_platform.rs
@@ -3,15 +3,15 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use cua_driver_core::browser::existing_profile_setup_descriptor;
 use cua_driver_core::browser::platform::{
     select_isolated_browser_executable, BrowserConsentOutcome, BrowserConsentRequest,
-    BrowserPlatform, BrowserVisualAction, BrowserVisualActionKind, ExistingProfileSetupOutcome,
-    ExistingProfileSetupRequest, PrepareAction, PrepareOutcome, PrepareRequest,
+    BrowserPlatform, BrowserVisualAction, ExistingProfileSetupOutcome, ExistingProfileSetupRequest,
+    PrepareAction, PrepareOutcome, PrepareRequest,
 };
 use cua_driver_core::browser::refusal::{BrowserRefusal, BrowserRefusalCode};
 use cua_driver_core::browser::types::{
@@ -23,65 +23,11 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 pub struct LinuxBrowserPlatform {
     cursor_registry: Arc<cursor_overlay::CursorRegistry>,
-    browser_cursors: Mutex<BrowserCursorTracker>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct BrowserCursorBinding {
-    window_id: u64,
-    cdp_target_id: String,
-}
-
-#[derive(Debug, Default)]
-struct BrowserCursorTracker {
-    bindings: HashMap<String, BrowserCursorBinding>,
-}
-
-impl BrowserCursorTracker {
-    fn update(
-        &mut self,
-        session: &str,
-        window_id: u64,
-        cdp_target_id: &str,
-        tab_is_active: bool,
-    ) -> Vec<(String, bool)> {
-        self.bindings.insert(
-            session.to_owned(),
-            BrowserCursorBinding {
-                window_id,
-                cdp_target_id: cdp_target_id.to_owned(),
-            },
-        );
-
-        if !tab_is_active {
-            return vec![(session.to_owned(), false)];
-        }
-
-        self.bindings
-            .iter()
-            .filter(|(_, binding)| binding.window_id == window_id)
-            .map(|(key, binding)| {
-                (
-                    key.clone(),
-                    key == session && binding.cdp_target_id == cdp_target_id,
-                )
-            })
-            .collect()
-    }
 }
 
 impl LinuxBrowserPlatform {
     pub fn new(cursor_registry: Arc<cursor_overlay::CursorRegistry>) -> Self {
-        Self {
-            cursor_registry,
-            browser_cursors: Mutex::new(BrowserCursorTracker::default()),
-        }
-    }
-}
-
-impl Default for LinuxBrowserPlatform {
-    fn default() -> Self {
-        Self::new(Arc::new(cursor_overlay::CursorRegistry::new()))
+        Self { cursor_registry }
     }
 }
 
@@ -490,6 +436,22 @@ fn process_identity(pid: i64) -> Result<(u64, Option<String>), BrowserRefusal> {
     Ok((started, executable))
 }
 
+pub(crate) async fn process_fingerprint(pid: i64) -> Result<ProcessFingerprint, BrowserRefusal> {
+    let (start_time, executable) = tokio::task::spawn_blocking(move || process_identity(pid))
+        .await
+        .map_err(|error| {
+            refusal(
+                BrowserRefusalCode::BrowserRouteUnavailable,
+                format!("process fingerprint task failed: {error}"),
+            )
+        })??;
+    Ok(ProcessFingerprint {
+        pid,
+        start_time: Some(start_time),
+        executable,
+    })
+}
+
 async fn browser_websocket_url(port: u16) -> Option<String> {
     tokio::time::timeout(Duration::from_secs(2), async move {
         let mut stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
@@ -556,40 +518,27 @@ impl BrowserPlatform for LinuxBrowserPlatform {
     }
 
     async fn visualize_browser_action(&self, action: BrowserVisualAction) {
-        if action.session.is_empty()
-            || action.cdp_target_id.is_empty()
-            || cua_driver_core::session::is_session_ended(&action.session)
-        {
-            return;
-        }
-
-        let visibility_updates = self.browser_cursors.lock().unwrap().update(
-            &action.session,
-            action.window_id,
-            &action.cdp_target_id,
-            action.tab_is_active,
-        );
         let cursor_enabled = self
             .cursor_registry
             .get_or_create(&action.session)
             .config
             .enabled;
-        for (key, visible) in visibility_updates {
-            let enabled = if key == action.session {
-                visible && cursor_enabled
+        for update in &action.visibility_updates {
+            let enabled = if update.session == action.session {
+                update.visible && cursor_enabled
             } else {
-                visible
+                update.visible
                     && self
                         .cursor_registry
-                        .get(&key)
+                        .get(&update.session)
                         .is_some_and(|state| state.config.enabled)
             };
             crate::overlay::send_command_for(
-                key,
+                update.session.clone(),
                 cursor_overlay::OverlayCommand::SetEnabled(enabled),
             );
         }
-        if !action.tab_is_active || !cursor_enabled {
+        if !action.current_session_visible() || !cursor_enabled {
             return;
         }
         let (Some(screen_x), Some(screen_y)) = (action.screen_x, action.screen_y) else {
@@ -607,14 +556,7 @@ impl BrowserPlatform for LinuxBrowserPlatform {
         self.cursor_registry
             .update_position(&action.session, screen_x, screen_y);
 
-        if matches!(
-            action.kind,
-            BrowserVisualActionKind::Click
-                | BrowserVisualActionKind::Type
-                | BrowserVisualActionKind::RightClick
-                | BrowserVisualActionKind::DoubleClick
-                | BrowserVisualActionKind::Drag
-        ) {
+        if action.kind.shows_click_pulse() {
             crate::overlay::send_command_for(
                 action.session,
                 cursor_overlay::OverlayCommand::ClickPulse {
@@ -1288,19 +1230,7 @@ impl BrowserPlatform for LinuxBrowserPlatform {
     }
 
     async fn process_fingerprint(&self, pid: i64) -> Result<ProcessFingerprint, BrowserRefusal> {
-        let (start_time, executable) = tokio::task::spawn_blocking(move || process_identity(pid))
-            .await
-            .map_err(|error| {
-                refusal(
-                    BrowserRefusalCode::BrowserRouteUnavailable,
-                    format!("process fingerprint task failed: {error}"),
-                )
-            })??;
-        Ok(ProcessFingerprint {
-            pid,
-            start_time: Some(start_time),
-            executable,
-        })
+        process_fingerprint(pid).await
     }
 
     async fn prepare_endpoint(
@@ -1333,6 +1263,7 @@ impl BrowserPlatform for LinuxBrowserPlatform {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cua_driver_core::browser::platform::{BrowserCursorVisibility, BrowserVisualActionKind};
 
     #[tokio::test(flavor = "multi_thread")]
     async fn existing_profile_cleanup_can_drive_atspi_runtime_from_async_session_teardown() {
@@ -1356,11 +1287,13 @@ mod tests {
             .visualize_browser_action(BrowserVisualAction {
                 session: "browser-cursor-test".to_owned(),
                 window_id: 77,
-                cdp_target_id: "tab-A".to_owned(),
-                tab_is_active: true,
                 screen_x: Some(321.0),
                 screen_y: Some(456.0),
                 kind: BrowserVisualActionKind::Click,
+                visibility_updates: vec![BrowserCursorVisibility {
+                    session: "browser-cursor-test".to_owned(),
+                    visible: true,
+                }],
             })
             .await;
 
@@ -1378,11 +1311,13 @@ mod tests {
             .visualize_browser_action(BrowserVisualAction {
                 session: "browser-cursor-hidden".to_owned(),
                 window_id: 77,
-                cdp_target_id: "tab-hidden".to_owned(),
-                tab_is_active: false,
                 screen_x: Some(321.0),
                 screen_y: Some(456.0),
                 kind: BrowserVisualActionKind::Click,
+                visibility_updates: vec![BrowserCursorVisibility {
+                    session: "browser-cursor-hidden".to_owned(),
+                    visible: false,
+                }],
             })
             .await;
 
@@ -1392,32 +1327,6 @@ mod tests {
         assert!(
             state.x.is_none() && state.y.is_none(),
             "an inactive tab must not animate or move its visible cursor"
-        );
-    }
-
-    #[test]
-    fn browser_cursor_tracker_shows_only_the_active_tabs_session_per_window() {
-        let mut tracker = BrowserCursorTracker::default();
-        assert_eq!(
-            tracker.update("session-red", 77, "tab-A", false),
-            vec![("session-red".to_owned(), false)]
-        );
-
-        let first_active = tracker.update("session-red", 77, "tab-A", true);
-        assert_eq!(first_active, vec![("session-red".to_owned(), true)]);
-
-        let second_active = tracker
-            .update("session-blue", 77, "tab-B", true)
-            .into_iter()
-            .collect::<HashMap<_, _>>();
-        assert_eq!(second_active.get("session-red"), Some(&false));
-        assert_eq!(second_active.get("session-blue"), Some(&true));
-
-        let other_window = tracker.update("session-green", 88, "tab-C", true);
-        assert_eq!(
-            other_window,
-            vec![("session-green".to_owned(), true)],
-            "an active tab in another native window must not hide this window"
         );
     }
 

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -7366,14 +7366,12 @@ impl Tool for KillAppTool {
         if adapter_id != "process_control" {
             return Ok(None);
         }
-        use cua_driver_core::browser::platform::BrowserPlatform;
         let pid = args
             .get("pid")
             .and_then(Value::as_i64)
             .filter(|pid| *pid > 0)
             .ok_or_else(|| "kill_app requires a positive integer pid".to_owned())?;
-        let fingerprint = crate::browser_platform::LinuxBrowserPlatform::default()
-            .process_fingerprint(pid)
+        let fingerprint = crate::browser_platform::process_fingerprint(pid)
             .await
             .map_err(|error| error.message)?;
         Ok(Some(json!({

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -7372,7 +7372,7 @@ impl Tool for KillAppTool {
             .and_then(Value::as_i64)
             .filter(|pid| *pid > 0)
             .ok_or_else(|| "kill_app requires a positive integer pid".to_owned())?;
-        let fingerprint = crate::browser_platform::LinuxBrowserPlatform
+        let fingerprint = crate::browser_platform::LinuxBrowserPlatform::default()
             .process_fingerprint(pid)
             .await
             .map_err(|error| error.message)?;
@@ -8036,7 +8036,9 @@ pub fn build_registry_with_provider(
         super::page::LinuxPageBackend::new(),
     ))));
     let browser_engine = cua_driver_core::browser::BrowserEngine::new_with_runtime_services(
-        Arc::new(crate::browser_platform::LinuxBrowserPlatform),
+        Arc::new(crate::browser_platform::LinuxBrowserPlatform::new(
+            state.cursor_registry.clone(),
+        )),
         r.approval_broker(),
         r.protected_resource_ownership(),
     );

--- a/libs/cua-driver/rust/crates/platform-macos/src/browser/platform.rs
+++ b/libs/cua-driver/rust/crates/platform-macos/src/browser/platform.rs
@@ -1,18 +1,17 @@
 //! macOS identity and endpoint evidence for the first-class browser tools.
 
-use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 use std::process::Stdio;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use cua_driver_core::browser::existing_profile_setup_descriptor;
 use cua_driver_core::browser::platform::{
     select_isolated_browser_executable, BrowserConsentOutcome, BrowserConsentRequest,
-    BrowserPlatform, BrowserVisualAction, BrowserVisualActionKind, ExistingProfileSetupOutcome,
-    ExistingProfileSetupRequest, PrepareAction, PrepareOutcome, PrepareRequest,
+    BrowserPlatform, BrowserVisualAction, ExistingProfileSetupOutcome, ExistingProfileSetupRequest,
+    PrepareAction, PrepareOutcome, PrepareRequest,
 };
 use cua_driver_core::browser::refusal::{BrowserRefusal, BrowserRefusalCode};
 use cua_driver_core::browser::types::{
@@ -25,63 +24,11 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 #[derive(Clone)]
 pub struct MacOsBrowserPlatform {
     cursor_registry: Arc<crate::cursor::CursorRegistry>,
-    browser_cursors: Arc<Mutex<BrowserCursorTracker>>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct BrowserCursorBinding {
-    window_id: u64,
-    cdp_target_id: String,
-}
-
-#[derive(Debug, Default)]
-struct BrowserCursorTracker {
-    bindings: HashMap<String, BrowserCursorBinding>,
-}
-
-impl BrowserCursorTracker {
-    /// Record the session-to-tab binding and return the exact overlay
-    /// visibility changes needed for this action. An active tab owns the sole
-    /// visible browser cursor in its native window. An inactive tab hides only
-    /// its own cursor and never disturbs the cursor for the selected tab.
-    fn update(
-        &mut self,
-        session: &str,
-        window_id: u64,
-        cdp_target_id: &str,
-        tab_is_active: bool,
-    ) -> Vec<(String, bool)> {
-        self.bindings.insert(
-            session.to_owned(),
-            BrowserCursorBinding {
-                window_id,
-                cdp_target_id: cdp_target_id.to_owned(),
-            },
-        );
-
-        if !tab_is_active {
-            return vec![(session.to_owned(), false)];
-        }
-
-        self.bindings
-            .iter()
-            .filter(|(_, binding)| binding.window_id == window_id)
-            .map(|(key, binding)| {
-                (
-                    key.clone(),
-                    key == session && binding.cdp_target_id == cdp_target_id,
-                )
-            })
-            .collect()
-    }
 }
 
 impl MacOsBrowserPlatform {
     pub fn new(cursor_registry: Arc<crate::cursor::CursorRegistry>) -> Self {
-        Self {
-            cursor_registry,
-            browser_cursors: Arc::new(Mutex::new(BrowserCursorTracker::default())),
-        }
+        Self { cursor_registry }
     }
 }
 
@@ -586,40 +533,27 @@ impl BrowserPlatform for MacOsBrowserPlatform {
     }
 
     async fn visualize_browser_action(&self, action: BrowserVisualAction) {
-        if action.session.is_empty()
-            || action.cdp_target_id.is_empty()
-            || cua_driver_core::session::is_session_ended(&action.session)
-        {
-            return;
-        }
-
-        let visibility_updates = self.browser_cursors.lock().unwrap().update(
-            &action.session,
-            action.window_id,
-            &action.cdp_target_id,
-            action.tab_is_active,
-        );
         let cursor_enabled = self
             .cursor_registry
             .get_or_create(&action.session)
             .config
             .enabled;
-        for (key, visible) in visibility_updates {
-            let enabled = if key == action.session {
-                visible && cursor_enabled
+        for update in &action.visibility_updates {
+            let enabled = if update.session == action.session {
+                update.visible && cursor_enabled
             } else {
-                visible
+                update.visible
                     && self
                         .cursor_registry
-                        .get(&key)
+                        .get(&update.session)
                         .is_some_and(|state| state.config.enabled)
             };
             crate::cursor::overlay::send_command(
-                key,
+                update.session.clone(),
                 cursor_overlay::OverlayCommand::SetEnabled(enabled),
             );
         }
-        if !action.tab_is_active || !cursor_enabled {
+        if !action.current_session_visible() || !cursor_enabled {
             return;
         }
         let (Some(screen_x), Some(screen_y)) = (action.screen_x, action.screen_y) else {
@@ -637,14 +571,7 @@ impl BrowserPlatform for MacOsBrowserPlatform {
         self.cursor_registry
             .update_position(&action.session, screen_x, screen_y);
 
-        if matches!(
-            action.kind,
-            BrowserVisualActionKind::Click
-                | BrowserVisualActionKind::Type
-                | BrowserVisualActionKind::RightClick
-                | BrowserVisualActionKind::DoubleClick
-                | BrowserVisualActionKind::Drag
-        ) {
+        if action.kind.shows_click_pulse() {
             crate::cursor::overlay::send_command(
                 action.session,
                 cursor_overlay::OverlayCommand::ClickPulse {
@@ -1185,6 +1112,7 @@ impl BrowserPlatform for MacOsBrowserPlatform {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cua_driver_core::browser::platform::{BrowserCursorVisibility, BrowserVisualActionKind};
 
     #[test]
     fn isolated_browser_candidates_are_vendor_attested_system_installs() {
@@ -1254,11 +1182,13 @@ mod tests {
             .visualize_browser_action(BrowserVisualAction {
                 session: "browser-cursor-test".to_owned(),
                 window_id: 77,
-                cdp_target_id: "tab-A".to_owned(),
-                tab_is_active: true,
                 screen_x: Some(321.0),
                 screen_y: Some(456.0),
                 kind: BrowserVisualActionKind::Click,
+                visibility_updates: vec![BrowserCursorVisibility {
+                    session: "browser-cursor-test".to_owned(),
+                    visible: true,
+                }],
             })
             .await;
 
@@ -1277,11 +1207,13 @@ mod tests {
             .visualize_browser_action(BrowserVisualAction {
                 session: "browser-cursor-hidden".to_owned(),
                 window_id: 77,
-                cdp_target_id: "tab-hidden".to_owned(),
-                tab_is_active: false,
                 screen_x: Some(321.0),
                 screen_y: Some(456.0),
                 kind: BrowserVisualActionKind::Click,
+                visibility_updates: vec![BrowserCursorVisibility {
+                    session: "browser-cursor-hidden".to_owned(),
+                    visible: false,
+                }],
             })
             .await;
 
@@ -1291,32 +1223,6 @@ mod tests {
         assert!(
             state.position.is_none(),
             "an inactive tab must not animate or move its visible cursor"
-        );
-    }
-
-    #[test]
-    fn browser_cursor_tracker_shows_only_the_active_tabs_session_per_window() {
-        let mut tracker = BrowserCursorTracker::default();
-        assert_eq!(
-            tracker.update("session-red", 77, "tab-A", false),
-            vec![("session-red".to_owned(), false)]
-        );
-
-        let first_active = tracker.update("session-red", 77, "tab-A", true);
-        assert_eq!(first_active, vec![("session-red".to_owned(), true)]);
-
-        let second_active = tracker
-            .update("session-blue", 77, "tab-B", true)
-            .into_iter()
-            .collect::<HashMap<_, _>>();
-        assert_eq!(second_active.get("session-red"), Some(&false));
-        assert_eq!(second_active.get("session-blue"), Some(&true));
-
-        let other_window = tracker.update("session-green", 88, "tab-C", true);
-        assert_eq!(
-            other_window,
-            vec![("session-green".to_owned(), true)],
-            "an active tab in another native window must not hide this window"
         );
     }
 

--- a/libs/cua-driver/rust/crates/platform-windows/src/browser_platform.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/browser_platform.rs
@@ -4,15 +4,15 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::path::PathBuf;
 use std::process::Stdio;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use cua_driver_core::browser::existing_profile_setup_descriptor;
 use cua_driver_core::browser::platform::{
     select_isolated_browser_executable, BrowserConsentOutcome, BrowserConsentRequest,
-    BrowserPlatform, BrowserVisualAction, BrowserVisualActionKind, ExistingProfileSetupOutcome,
-    ExistingProfileSetupRequest, PrepareAction, PrepareOutcome, PrepareRequest,
+    BrowserPlatform, BrowserVisualAction, ExistingProfileSetupOutcome, ExistingProfileSetupRequest,
+    PrepareAction, PrepareOutcome, PrepareRequest,
 };
 use cua_driver_core::browser::refusal::{BrowserRefusal, BrowserRefusalCode};
 use cua_driver_core::browser::types::{
@@ -44,59 +44,11 @@ use windows::Win32::UI::WindowsAndMessaging::{GetAncestor, GetWindowRect, GA_ROO
 #[derive(Clone)]
 pub struct WindowsBrowserPlatform {
     cursor_registry: Arc<cursor_overlay::CursorRegistry>,
-    browser_cursors: Arc<Mutex<BrowserCursorTracker>>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct BrowserCursorBinding {
-    window_id: u64,
-    cdp_target_id: String,
-}
-
-#[derive(Debug, Default)]
-struct BrowserCursorTracker {
-    bindings: HashMap<String, BrowserCursorBinding>,
-}
-
-impl BrowserCursorTracker {
-    fn update(
-        &mut self,
-        session: &str,
-        window_id: u64,
-        cdp_target_id: &str,
-        tab_is_active: bool,
-    ) -> Vec<(String, bool)> {
-        self.bindings.insert(
-            session.to_owned(),
-            BrowserCursorBinding {
-                window_id,
-                cdp_target_id: cdp_target_id.to_owned(),
-            },
-        );
-
-        if !tab_is_active {
-            return vec![(session.to_owned(), false)];
-        }
-
-        self.bindings
-            .iter()
-            .filter(|(_, binding)| binding.window_id == window_id)
-            .map(|(key, binding)| {
-                (
-                    key.clone(),
-                    key == session && binding.cdp_target_id == cdp_target_id,
-                )
-            })
-            .collect()
-    }
 }
 
 impl WindowsBrowserPlatform {
     pub fn new(cursor_registry: Arc<cursor_overlay::CursorRegistry>) -> Self {
-        Self {
-            cursor_registry,
-            browser_cursors: Arc::new(Mutex::new(BrowserCursorTracker::default())),
-        }
+        Self { cursor_registry }
     }
 }
 
@@ -1331,37 +1283,27 @@ impl BrowserPlatform for WindowsBrowserPlatform {
     }
 
     async fn visualize_browser_action(&self, action: BrowserVisualAction) {
-        if action.session.is_empty()
-            || action.cdp_target_id.is_empty()
-            || cua_driver_core::session::is_session_ended(&action.session)
-        {
-            return;
-        }
-
-        let visibility_updates = self.browser_cursors.lock().unwrap().update(
-            &action.session,
-            action.window_id,
-            &action.cdp_target_id,
-            action.tab_is_active,
-        );
         let cursor_enabled = self
             .cursor_registry
             .get_or_create(&action.session)
             .config
             .enabled;
-        for (key, visible) in visibility_updates {
-            let enabled = if key == action.session {
-                visible && cursor_enabled
+        for update in &action.visibility_updates {
+            let enabled = if update.session == action.session {
+                update.visible && cursor_enabled
             } else {
-                visible
+                update.visible
                     && self
                         .cursor_registry
-                        .get(&key)
+                        .get(&update.session)
                         .is_some_and(|state| state.config.enabled)
             };
-            crate::overlay::send_command(key, cursor_overlay::OverlayCommand::SetEnabled(enabled));
+            crate::overlay::send_command(
+                update.session.clone(),
+                cursor_overlay::OverlayCommand::SetEnabled(enabled),
+            );
         }
-        if !action.tab_is_active || !cursor_enabled {
+        if !action.current_session_visible() || !cursor_enabled {
             return;
         }
         let (Some(screen_x), Some(screen_y)) = (action.screen_x, action.screen_y) else {
@@ -1384,14 +1326,7 @@ impl BrowserPlatform for WindowsBrowserPlatform {
         self.cursor_registry
             .update_position(&action.session, screen_x, screen_y);
 
-        if matches!(
-            action.kind,
-            BrowserVisualActionKind::Click
-                | BrowserVisualActionKind::Type
-                | BrowserVisualActionKind::RightClick
-                | BrowserVisualActionKind::DoubleClick
-                | BrowserVisualActionKind::Drag
-        ) {
+        if action.kind.shows_click_pulse() {
             crate::overlay::send_command(
                 action.session,
                 cursor_overlay::OverlayCommand::ClickPulse {
@@ -2124,33 +2059,6 @@ mod tests {
     }
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
-
-    #[test]
-    fn browser_cursor_tracker_shows_only_the_active_tabs_session_per_window() {
-        let mut tracker = BrowserCursorTracker::default();
-        assert_eq!(
-            tracker.update("tab-a", 101, "target-a", false),
-            vec![("tab-a".to_owned(), false)]
-        );
-        assert_eq!(
-            tracker.update("tab-b", 101, "target-b", false),
-            vec![("tab-b".to_owned(), false)]
-        );
-
-        let mut updates = tracker.update("tab-a", 101, "target-a", true);
-        updates.sort();
-        assert_eq!(
-            updates,
-            vec![("tab-a".to_owned(), true), ("tab-b".to_owned(), false)]
-        );
-
-        let mut updates = tracker.update("tab-b", 101, "target-b", true);
-        updates.sort();
-        assert_eq!(
-            updates,
-            vec![("tab-a".to_owned(), false), ("tab-b".to_owned(), true)]
-        );
-    }
 
     #[test]
     fn netstat_parser_requires_loopback_listening_and_browser_process_tree() {


### PR DESCRIPTION
## Summary

- Problem this solves: Linux implemented the browser platform but not `visualize_browser_action`, so the shared browser tools successfully delivered actions while the visual feedback hook silently used the trait's no-op default.
- What changed: make the shared browser engine own active-tab cursor arbitration and session cleanup, remove the duplicated macOS/Windows trackers, connect `LinuxBrowserPlatform` to the existing session cursor registry and overlay router, and make the platform hook required so future omissions are explicit.

No new rendering path is introduced. Each native adapter now only maps the shared visibility plan onto its existing overlay commands; X11 and native Wayland continue through the existing Linux dispatch, animation, cursor configuration, and session identity machinery.

## Related work

Refs #2884

RFC (required for a public SDK, CLI, MCP, protocol, compatibility, permission,
or cross-component contract change): Not required; this is an internal platform adapter implementation and compile-time trait guard.

## Compatibility and risk

- User-visible, API/CLI/MCP, migration, permission, or platform impact: browser click/type/hover/scroll/drag actions on Linux can now render the configured agent cursor for the active tab. Browser input delivery, action results, endpoint discovery defaults, focus, and permissions are unchanged.
- Risk and rollback: risk is confined to best-effort visual feedback and per-session cursor visibility. Reverting this pull request restores the prior behavior.

## Validation

Rebased candidate: `78b440a2180e0a9ad0458474861086c2860f284d`

- Current rebase checks:
  - `cargo fmt --manifest-path libs/cua-driver/rust/Cargo.toml --all -- --check`: passed.
  - `git diff --check`: passed.
  - `cargo check -p cua-driver-core`: passed.
  - `cargo test -p cua-driver-core browser_cursor --lib`: 2 passed.
  - `cargo test -p cua-driver-core browser_visual_action_kind --lib`: 1 passed.
  - `cargo test -p platform-linux --lib browser_platform::tests`: blocked before crate compilation because the review container lacks `pkg-config` and X11 development metadata; fresh CI is required.
- Earlier focused evidence on pre-rebase candidate `2a25b89e050857038b4426e66d704489720ea995`:
  - `cargo test --release -p platform-linux --lib browser_platform::tests`: 10 passed.
  - Complete built `platform-linux` unit-test binary: 267 passed, 4 environment-dependent tests ignored.
  - Patched `cua-driver` release build with `portal-input`: passed.
  - `git diff --check`: passed.
- Manual or platform evidence:
  - X11/Xvfb + Xfwm + native Chrome: the foreground overlay-enabled `standalone_browser_pointer_actions` scenario passed. The retained 8.57-second recording contains hover, right-click, double-click, scroll, and drag actions.
  - X11 screenshot analysis separated the agent pointer around `(505, 503)` from the browser badge below it (`x=454..568`, `y=522..537`) and from the page's own scroll-state change.
  - Native Wayland/Sway 1.9 headless, with `DISPLAY` unset and `CUA_DRIVER_RS_ENABLE_WAYLAND=1`: the overlay-enabled native-Chrome `standalone_browser_pointer_actions` scenario passed.
  - The native Wayland strict showcase oracle passed both its pointer and independent badge pixel thresholds before the diagnostic intentionally stopped at the absent recording-directory requirement. Sway also logged a layer-shell surface with namespace `cua-agent-cursor` alongside Chrome's native `google-chrome` xdg-toplevel.
- Known gaps or CI still required:
  - `wf-recorder` is unavailable on this disk-constrained host, so the native-Wayland browser-action pass and native-Wayland rendered-pixel pass are separate diagnostics rather than one retained browser video.

## Contributor and release checks

- [x] The PR is focused and the description matches the final diff.
- [x] This change does not require an RFC, or the accepted RFC is linked above.
- [x] Tests, documentation, and platform evidence are included or the gap is explained.
- [x] The PR title is a Conventional Commit describing the production change.
- [x] External contributor authorship is preserved, or no external contribution is included.
- [x] If release-tracked files changed but this is intentionally non-releasing, the `no-release` label is applied.