### PR TITLE
fix(fleets): let CLI scale WIF smoke pool

### DIFF
--- a/infra/fleets-wif-smoke/README.md
+++ b/infra/fleets-wif-smoke/README.md
@@ -10,6 +10,6 @@ The apply job uses a dedicated user-owned Fleets key stored as protected reposit
 - `FLEETS_TERRAFORM_CLIENT_SECRET`
 - `FLEETS_TERRAFORM_TOKEN_URL`
 
-The pool autoscaler is bounded from zero to one replica. The daily smoke workflow claims a UUID-suffixed sandbox, runs commands through `cua sb exec`, deletes the claim, and suspends the pool back to zero replicas.
+The pool starts at zero replicas. The daily smoke workflow scales it to one, claims a UUID-suffixed sandbox, runs commands through `cua sb exec`, deletes the claim, and suspends the pool back to zero replicas.
 
 If the pool was previously created with different credentials, manually dispatch the apply workflow once with `recreate_pool` enabled. The recovery deletes only the managed pool with the original bootstrap credentials, then recreates the pool and trust policy under the dedicated owner key.

--- a/infra/fleets-wif-smoke/main.tf
+++ b/infra/fleets-wif-smoke/main.tf
@@ -27,12 +27,6 @@ resource "fleets_pool" "cua_cli_wif_smoke" {
   container_disk_image = "296062593712.dkr.ecr.us-west-2.amazonaws.com/desktop-workspace-duo:latest"
   readiness_probe_json = jsonencode({ tcpSocket = { port = 8000 } })
 
-  autoscaling {
-    min_pool_size     = 0
-    initial_pool_size = 0
-    max_pool_size     = 1
-  }
-
   service {
     name        = "server"
     target_port = 8000


### PR DESCRIPTION
## What changed

- remove claim-driven KEDA autoscaling from the dedicated CLI WIF smoke pool
- keep the pool at zero replicas in Terraform
- document that `cua sb launch --pool` scales it to one and cleanup suspends it back to zero

## Why

The CLI intentionally scales a pre-created pool to one and waits for readiness before creating its named claim. With autoscaling `0..1` enabled, KEDA sees no claim during that wait and immediately forces `spec.replicas` back to zero. Production observation during run `31373593413` showed no Sandbox, VM, VMI, or pod was ever created while the CLI waited.

Removing the conflicting autoscaler preserves the requested orchestration: scale pool to one, claim it, delete the claim, suspend to zero.

## Validation

- observed live pool generation change followed by `spec.replicas: 0` while launch was still waiting
- observed no generated resources for the namespace across the run
- known working non-autoscaled pools use the same `desktop-workspace-duo` digest
- `git diff --check`