### PR TITLE
fix(cua-driver): normalize legacy dispatch before authorization

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -437,9 +437,7 @@ pub fn default_capabilities_for(tool_name: &str) -> Vec<String> {
 /// richer live schema.
 pub fn advertised_capabilities_for(tool_name: &str, input_schema: &Value) -> Vec<String> {
     let mut capabilities = default_capabilities_for(tool_name);
-    let accepts_delivery_mode = input_schema
-        .pointer("/properties/delivery_mode")
-        .is_some_and(Value::is_object);
+    let accepts_delivery_mode = schema_accepts_delivery_mode(input_schema);
     if accepts_delivery_mode
         && !capabilities
             .iter()
@@ -448,6 +446,53 @@ pub fn advertised_capabilities_for(tool_name: &str, input_schema: &Value) -> Vec
         capabilities.push("input.delivery_mode".into());
     }
     capabilities
+}
+
+fn schema_accepts_delivery_mode(input_schema: &Value) -> bool {
+    input_schema
+        .pointer("/properties/delivery_mode")
+        .is_some_and(Value::is_object)
+}
+
+/// Canonicalize the hidden pre-0.7 Windows `dispatch` compatibility alias.
+///
+/// This runs at the native dispatch boundary before policy, protected-resource
+/// authorization, recording, and platform execution. Every downstream
+/// consumer therefore sees the same modern field and one of the two supported
+/// values. The live schema remains modern-only, and schema gating prevents an
+/// unrelated tool's `dispatch` argument from being reinterpreted.
+///
+/// Presence of `delivery_mode` always wins, including when its value is null or
+/// malformed. As with the platform parsers, only an explicit case-insensitive
+/// `foreground` opts into foreground delivery; every other supplied value,
+/// including the removed legacy `auto`, fails closed to `background`.
+fn normalize_delivery_mode_args(tool: &ToolDef, args: &mut Value) {
+    if !schema_accepts_delivery_mode(&tool.input_schema) {
+        return;
+    }
+    let Some(arguments) = args.as_object_mut() else {
+        return;
+    };
+
+    let supplied = if arguments.contains_key("delivery_mode") {
+        arguments.get("delivery_mode")
+    } else {
+        arguments.get("dispatch")
+    };
+    let Some(supplied) = supplied else {
+        return;
+    };
+    let mode = if supplied
+        .as_str()
+        .is_some_and(|value| value.eq_ignore_ascii_case("foreground"))
+    {
+        "foreground"
+    } else {
+        "background"
+    };
+
+    arguments.remove("dispatch");
+    arguments.insert("delivery_mode".to_owned(), Value::String(mode.to_owned()));
 }
 
 /// Runtime-owned provenance for protected-resource admission.
@@ -1022,6 +1067,9 @@ impl ToolRegistry {
             return ToolResult::error(format!("Unknown tool: {name}"));
         };
 
+        // Normalize deprecated public argument spellings before any policy,
+        // consent, recording, or implementation layer interprets the call.
+        normalize_delivery_mode_args(tool.def(), &mut args);
         if let Err(result) = crate::action_target::normalize_action_target(resolved_name, &mut args)
         {
             return result;
@@ -3569,6 +3617,46 @@ resources:
     }
 
     #[tokio::test]
+    async fn canonical_dispatch_normalizes_legacy_delivery_mode_before_execution() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let last_args = Arc::new(Mutex::new(None));
+        let mut registry = super::ToolRegistry::new();
+        registry.register(Box::new(ArgumentProbe {
+            hits: hits.clone(),
+            last_args: last_args.clone(),
+            def: super::ToolDef {
+                name: "click".into(),
+                description: "test input".into(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "delivery_mode": crate::tool_schema::delivery_mode_schema()
+                    }
+                }),
+                read_only: false,
+                destructive: false,
+                idempotent: false,
+                open_world: false,
+            },
+        }));
+        let registry = Arc::new(registry);
+
+        let result = registry
+            .invoke_with_context(
+                "click",
+                serde_json::json!({"dispatch": "foreground"}),
+                standard_context(),
+            )
+            .await;
+
+        assert_ne!(result.is_error, Some(true));
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+        let received = last_args.lock().unwrap().clone().expect("arguments");
+        assert_eq!(received["delivery_mode"], "foreground");
+        assert!(received.get("dispatch").is_none());
+    }
+
+    #[tokio::test]
     async fn standard_file_transfer_is_promptless_and_still_canonicalizes_paths() {
         let files = tempfile::tempdir().unwrap();
         let first = files.path().join("first.txt");
@@ -5034,6 +5122,77 @@ mod capability_tests {
                 .iter()
                 .any(|capability| capability == "input.delivery_mode")
         );
+    }
+
+    #[test]
+    fn delivery_mode_normalization_is_schema_gated_modern_first_and_fail_closed() {
+        let with_delivery_mode = super::ToolDef {
+            name: "click".into(),
+            description: "test input".into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "delivery_mode": crate::tool_schema::delivery_mode_schema()
+                }
+            }),
+            read_only: false,
+            destructive: false,
+            idempotent: false,
+            open_world: false,
+        };
+        let without_delivery_mode = super::ToolDef {
+            name: "other".into(),
+            description: "unrelated tool".into(),
+            input_schema: serde_json::json!({"type": "object", "properties": {}}),
+            read_only: false,
+            destructive: false,
+            idempotent: false,
+            open_world: false,
+        };
+
+        for (mut args, expected) in [
+            (serde_json::json!({"dispatch": "foreground"}), "foreground"),
+            (serde_json::json!({"dispatch": "Foreground"}), "foreground"),
+            (serde_json::json!({"dispatch": "background"}), "background"),
+            (serde_json::json!({"dispatch": "auto"}), "background"),
+            (serde_json::json!({"dispatch": "unknown"}), "background"),
+            (serde_json::json!({"dispatch": null}), "background"),
+            (
+                serde_json::json!({"delivery_mode": "Foreground"}),
+                "foreground",
+            ),
+            (
+                serde_json::json!({"delivery_mode": "unknown"}),
+                "background",
+            ),
+            (serde_json::json!({"delivery_mode": null}), "background"),
+            (
+                serde_json::json!({
+                    "delivery_mode": "background",
+                    "dispatch": "foreground"
+                }),
+                "background",
+            ),
+            (
+                serde_json::json!({
+                    "delivery_mode": null,
+                    "dispatch": "foreground"
+                }),
+                "background",
+            ),
+        ] {
+            super::normalize_delivery_mode_args(&with_delivery_mode, &mut args);
+            assert_eq!(args["delivery_mode"], expected, "arguments: {args}");
+            assert!(args.get("dispatch").is_none(), "arguments: {args}");
+        }
+
+        let mut absent = serde_json::json!({"x": 1});
+        super::normalize_delivery_mode_args(&with_delivery_mode, &mut absent);
+        assert_eq!(absent, serde_json::json!({"x": 1}));
+
+        let mut unrelated = serde_json::json!({"dispatch": "foreground"});
+        super::normalize_delivery_mode_args(&without_delivery_mode, &mut unrelated);
+        assert_eq!(unrelated, serde_json::json!({"dispatch": "foreground"}));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-windows/src/input/delivery.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/input/delivery.rs
@@ -95,8 +95,23 @@ impl DeliveryMode {
     }
 
     /// Parse from a tool's JSON args, reading the `delivery_mode` field.
+    ///
+    /// Back-compat: clients built against the 0.5.x tool surface (e.g. apps
+    /// that bundle-and-pin the driver) send the field under its old name
+    /// `dispatch`. Unknown JSON fields are silently ignored by the arg
+    /// parsers, so without this alias such a client's explicit
+    /// `dispatch:"foreground"` degraded to the Background default — and with
+    /// the non-client drag pre-flight the client then received
+    /// `background_unavailable` advising the very escalation it had already
+    /// requested, an escalation loop with no exit. `delivery_mode` wins when
+    /// both are present. The removed legacy value `"auto"` still resolves to
+    /// `Background` via `parse` (never silently fronts).
     pub fn from_args(args: &Value) -> Self {
-        Self::parse(args.get("delivery_mode").and_then(|v| v.as_str()))
+        let arg = args
+            .get("delivery_mode")
+            .or_else(|| args.get("dispatch"))
+            .and_then(|v| v.as_str());
+        Self::parse(arg)
     }
 
     pub fn is_foreground(self) -> bool {
@@ -428,6 +443,40 @@ mod tests {
         // Case-insensitive, matching macOS DeliveryMode::parse.
         assert_eq!(
             DeliveryMode::from_args(&j("Foreground")),
+            DeliveryMode::Foreground
+        );
+    }
+
+    #[test]
+    fn delivery_mode_accepts_legacy_dispatch_alias() {
+        // 0.5.x-era clients (apps bundling a pinned driver) send the field as
+        // `dispatch`. Without the alias their explicit foreground escalation
+        // silently degraded to Background — an escalation loop with no exit
+        // once the NC-drag pre-flight started refusing background window moves.
+        assert_eq!(
+            DeliveryMode::from_args(&serde_json::json!({"dispatch": "foreground"})),
+            DeliveryMode::Foreground
+        );
+        assert_eq!(
+            DeliveryMode::from_args(&serde_json::json!({"dispatch": "background"})),
+            DeliveryMode::Background
+        );
+        // Removed legacy value "auto" must never silently front.
+        assert_eq!(
+            DeliveryMode::from_args(&serde_json::json!({"dispatch": "auto"})),
+            DeliveryMode::Background
+        );
+        // The modern field wins when both are present.
+        assert_eq!(
+            DeliveryMode::from_args(
+                &serde_json::json!({"delivery_mode": "background", "dispatch": "foreground"})
+            ),
+            DeliveryMode::Background
+        );
+        assert_eq!(
+            DeliveryMode::from_args(
+                &serde_json::json!({"delivery_mode": "foreground", "dispatch": "background"})
+            ),
             DeliveryMode::Foreground
         );
     }

--- a/libs/cua-driver/rust/crates/platform-windows/src/input/delivery.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/input/delivery.rs
@@ -95,23 +95,8 @@ impl DeliveryMode {
     }
 
     /// Parse from a tool's JSON args, reading the `delivery_mode` field.
-    ///
-    /// Back-compat: clients built against the 0.5.x tool surface (e.g. apps
-    /// that bundle-and-pin the driver) send the field under its old name
-    /// `dispatch`. Unknown JSON fields are silently ignored by the arg
-    /// parsers, so without this alias such a client's explicit
-    /// `dispatch:"foreground"` degraded to the Background default — and with
-    /// the non-client drag pre-flight the client then received
-    /// `background_unavailable` advising the very escalation it had already
-    /// requested, an escalation loop with no exit. `delivery_mode` wins when
-    /// both are present. The removed legacy value `"auto"` still resolves to
-    /// `Background` via `parse` (never silently fronts).
     pub fn from_args(args: &Value) -> Self {
-        let arg = args
-            .get("delivery_mode")
-            .or_else(|| args.get("dispatch"))
-            .and_then(|v| v.as_str());
-        Self::parse(arg)
+        Self::parse(args.get("delivery_mode").and_then(|v| v.as_str()))
     }
 
     pub fn is_foreground(self) -> bool {
@@ -443,40 +428,6 @@ mod tests {
         // Case-insensitive, matching macOS DeliveryMode::parse.
         assert_eq!(
             DeliveryMode::from_args(&j("Foreground")),
-            DeliveryMode::Foreground
-        );
-    }
-
-    #[test]
-    fn delivery_mode_accepts_legacy_dispatch_alias() {
-        // 0.5.x-era clients (apps bundling a pinned driver) send the field as
-        // `dispatch`. Without the alias their explicit foreground escalation
-        // silently degraded to Background — an escalation loop with no exit
-        // once the NC-drag pre-flight started refusing background window moves.
-        assert_eq!(
-            DeliveryMode::from_args(&serde_json::json!({"dispatch": "foreground"})),
-            DeliveryMode::Foreground
-        );
-        assert_eq!(
-            DeliveryMode::from_args(&serde_json::json!({"dispatch": "background"})),
-            DeliveryMode::Background
-        );
-        // Removed legacy value "auto" must never silently front.
-        assert_eq!(
-            DeliveryMode::from_args(&serde_json::json!({"dispatch": "auto"})),
-            DeliveryMode::Background
-        );
-        // The modern field wins when both are present.
-        assert_eq!(
-            DeliveryMode::from_args(
-                &serde_json::json!({"delivery_mode": "background", "dispatch": "foreground"})
-            ),
-            DeliveryMode::Background
-        );
-        assert_eq!(
-            DeliveryMode::from_args(
-                &serde_json::json!({"delivery_mode": "foreground", "dispatch": "background"})
-            ),
             DeliveryMode::Foreground
         );
     }


### PR DESCRIPTION
## Summary

Normalize the legacy Cua Driver 0.5.x Windows `dispatch` argument at the shared native dispatch boundary before policy, protected-resource authorization, recording, replay, and platform execution.

## Root cause

Older clients retry foreground delivery as `dispatch:"foreground"`, while current drivers expect `delivery_mode`. Unknown JSON fields were ignored, so the retry silently fell back to background and could repeat the same `background_unavailable` refusal.

A Windows parser-only compatibility alias fixes execution too late: earlier request consumers can still interpret different semantics from the platform adapter.

## Change

- Gate compatibility on the concrete tool schema supporting `delivery_mode`.
- Give the modern field precedence whenever it is present.
- Canonicalize legacy foreground case-insensitively.
- Fail closed to background for background, removed auto, null, malformed, or unknown supplied values.
- Remove `dispatch` after normalization so all downstream consumers see one modern field.
- Keep the advertised schema modern-only.
- Add focused registry and table coverage for execution-boundary normalization, schema gating, modern precedence, and fail-closed behavior.

The final aggregate diff is shared-core only; the contributor's intermediate Windows parser fallback is superseded by the canonical boundary implementation.

## Validation

Revalidated after rebasing onto `9a61050e3`:

- `cargo fmt --all -- --check` — passed
- `cargo metadata --no-deps --format-version 1` — passed
- `git diff --check` — passed
- `cargo test -p cua-driver-core delivery_mode_normalization_is_schema_gated_modern_first_and_fail_closed --locked` — passed
- `cargo test -p cua-driver-core canonical_dispatch_normalizes_legacy_delivery_mode_before_execution --locked` — passed

The contributor also verified the original compatibility behavior end-to-end with a real 0.5.x-era client. Native Windows execution was not repeated during this Linux rebase.

## Attribution

Salvaged from #2560.

Edwin Gnichtel's original commit is preserved as author with `cherry-pick -x`; the boundary-level adaptation also retains explicit co-author credit.