### PR TITLE
fix(cua-driver): remove Windows npm VC runtime prerequisite

### DIFF
--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -55,6 +55,16 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertIn("os: windows-11-arm", workflow)
         self.assertEqual(workflow.count("os: windows-latest"), 1)
 
+    def test_windows_node_runtime_statically_links_and_verifies_the_crt(self) -> None:
+        build_script = self.read("libs/cua-driver/scripts/build-node-runtime.mjs")
+        release_workflow = self.read(".github/workflows/cd-rust-cua-driver.yml")
+
+        self.assertIn('target.endsWith("-pc-windows-msvc")', build_script)
+        self.assertIn('"-C target-feature=+crt-static"', build_script)
+        self.assertIn("Verify Node runtime is self-contained on Windows", release_workflow)
+        self.assertIn("dumpbin /DEPENDENTS", release_workflow)
+        self.assertIn("VCRUNTIME|MSVCP|CONCRT|UCRTBASE|api-ms-win-crt-", release_workflow)
+
     def test_npm_publish_uses_explicit_local_tarball_paths(self) -> None:
         workflow = self.read(".github/workflows/cd-py-cua-driver.yml")
 

--- a/.github/scripts/tests/test_cua_driver_release_wiring.py
+++ b/.github/scripts/tests/test_cua_driver_release_wiring.py
@@ -64,6 +64,10 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertIn("Verify Node runtime is self-contained on Windows", release_workflow)
         self.assertIn("dumpbin /DEPENDENTS", release_workflow)
         self.assertIn("VCRUNTIME|MSVCP|CONCRT|UCRTBASE|api-ms-win-crt-", release_workflow)
+        self.assertIn("verify-windows-node-runtime:", release_workflow)
+        self.assertIn("os: windows-11-arm", release_workflow)
+        self.assertIn("Import exact candidate through public SDK", release_workflow)
+        self.assertIn("process.arch !== '${{ matrix.node_arch }}'", release_workflow)
 
     def test_npm_publish_uses_explicit_local_tarball_paths(self) -> None:
         workflow = self.read(".github/workflows/cd-py-cua-driver.yml")
@@ -482,7 +486,7 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
             "github.event_name == 'workflow_dispatch' && inputs.publish && "
             "format('refs/tags/cua-driver-rs-v{0}', inputs.version) || github.ref"
         )
-        self.assertEqual(workflow.count(immutable_ref), 5)
+        self.assertEqual(workflow.count(immutable_ref), 6)
         self.assertIn(
             "name: Ensure Rust target is installed\n"
             "        working-directory: libs/cua-driver/rust",
@@ -574,6 +578,7 @@ class TestCuaDriverReleaseWiring(unittest.TestCase):
         self.assertIn("ref: ${{ github.workflow_sha }}", workflow)
         self.assertIn(
             "[build-linux, build-windows, build-macos-universal, "
+            "verify-windows-node-runtime, "
             "verify-release-artifacts, verify-mcp-client-discovery]",
             workflow,
         )

--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -347,6 +347,68 @@ jobs:
           path: libs/cua-driver/rust/release/cua-driver-rs-*-windows-${{ matrix.arch }}*.zip
           if-no-files-found: error
 
+  # Load the exact candidate Node runtime on native x64 and ARM64 Windows.
+  # The build job also rejects dynamic CRT imports, while this job proves the
+  # staged addon and SDK DLL work together through the public TypeScript API.
+  verify-windows-node-runtime:
+    name: Windows ${{ matrix.node_arch }} packaged Node runtime
+    needs: build-windows
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            release_arch: x86_64
+            node_arch: x64
+          - os: windows-11-arm
+            release_arch: arm64
+            node_arch: arm64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.publish && format('refs/tags/cua-driver-rs-v{0}', inputs.version) || github.ref }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: libs/cua-driver/typescript/package-lock.json
+      - uses: actions/download-artifact@v4
+        with:
+          name: cua-driver-rs-windows-${{ matrix.release_arch }}
+          path: artifacts
+      - name: Build TypeScript SDK
+        working-directory: libs/cua-driver/typescript
+        run: |
+          npm ci
+          npm run build
+      - name: Stage exact candidate native package
+        shell: pwsh
+        run: |
+          $archives = @(Get-ChildItem artifacts -Recurse `
+            -Filter "*-windows-${{ matrix.release_arch }}-binary.zip")
+          if ($archives.Count -ne 1) {
+            throw "Expected one Windows candidate archive, found $($archives.Count)"
+          }
+          $candidate = Join-Path $env:RUNNER_TEMP "cua-driver-node-candidate"
+          Expand-Archive -LiteralPath $archives[0].FullName -DestinationPath $candidate
+
+          $triple = "win32-${{ matrix.node_arch }}-msvc"
+          $package = "libs/cua-driver/typescript/node_modules/@trycua/cua-driver-$triple"
+          New-Item -ItemType Directory -Force -Path $package | Out-Null
+          Copy-Item (Join-Path $candidate "cua_driver_sdk.dll") $package
+          Copy-Item (Join-Path $candidate "cua_driver_node_runtime.node") $package
+          @{
+            name = "@trycua/cua-driver-$triple"
+            version = "0.0.0-candidate"
+            private = $true
+          } | ConvertTo-Json | Set-Content (Join-Path $package "package.json")
+      - name: Import exact candidate through public SDK
+        shell: pwsh
+        run: |
+          node --input-type=module -e `
+            "if (process.arch !== '${{ matrix.node_arch }}') throw new Error('unexpected Node architecture ' + process.arch); const sdk = await import('./libs/cua-driver/typescript/dist/index.js'); const driver = sdk.CuaDriver.connect(undefined); console.log(process.platform, process.arch, driver.socketPath()); driver.uniffiDestroy();"
+
   # ── macOS universal (arm64 + x86_64 → lipo) ─────────────────────────────────
   # Mirrors cd-swift-cua-driver.yml's approach: build both arches in one job
   # on macos-26, then combine into a universal binary via `lipo -create`.
@@ -718,7 +780,7 @@ jobs:
   # evidence exists.
   release:
     needs:
-      [build-linux, build-windows, build-macos-universal, verify-release-artifacts, verify-mcp-client-discovery]
+      [build-linux, build-windows, build-macos-universal, verify-windows-node-runtime, verify-release-artifacts, verify-mcp-client-discovery]
     if: github.event_name == 'workflow_dispatch' && inputs.publish == true
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cd-rust-cua-driver.yml
+++ b/.github/workflows/cd-rust-cua-driver.yml
@@ -285,6 +285,31 @@ jobs:
           node scripts/build-node-runtime.mjs \
             --target "${{ matrix.target }}" \
             --output "rust/target/${{ matrix.target }}/release/cua_driver_node_runtime.node"
+      - name: Verify Node runtime is self-contained on Windows
+        working-directory: libs/cua-driver
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $installation = & $vswhere -latest -products * `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+            -property installationPath
+          if (-not $installation) { throw "Visual Studio Build Tools were not found" }
+          $dumpbin = Get-ChildItem `
+            "$installation\VC\Tools\MSVC\*\bin\Hostx64\x64\dumpbin.exe" |
+            Sort-Object FullName | Select-Object -Last 1 -ExpandProperty FullName
+          if (-not $dumpbin) { throw "dumpbin.exe was not found" }
+
+          $runtime = "rust/target/${{ matrix.target }}/release/cua_driver_node_runtime.node"
+          $imports = & $dumpbin /DEPENDENTS $runtime 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            throw "dumpbin failed for $runtime with exit $LASTEXITCODE"
+          }
+          $imports | Write-Host
+          $dynamicCrt = $imports | Select-String -Pattern `
+            '(?i)\b(?:VCRUNTIME|MSVCP|CONCRT|UCRTBASE|api-ms-win-crt-)[^\s]*\.dll\b'
+          if ($dynamicCrt) {
+            throw "Windows Node runtime has a dynamic VC/UCRT dependency: $($dynamicCrt -join ', ')"
+          }
       - name: Package
         working-directory: libs/cua-driver/rust
         shell: pwsh

--- a/libs/cua-driver/scripts/build-node-runtime.mjs
+++ b/libs/cua-driver/scripts/build-node-runtime.mjs
@@ -44,6 +44,24 @@ const targetIndex = process.argv.indexOf("--target")
 const target = targetIndex < 0 ? undefined : process.argv[targetIndex + 1]
 if (targetIndex >= 0 && !target) throw new Error("missing --target value")
 
+function cargoEnvironment() {
+  const environment = { ...process.env }
+  const buildsWindowsMsvc = target
+    ? target.endsWith("-pc-windows-msvc")
+    : process.platform === "win32"
+  if (!buildsWindowsMsvc) return environment
+
+  // Native npm packages must load on a clean Windows installation. The
+  // upstream N-API runtime includes C++ objects, so MSVC's default dynamic
+  // CRT linkage otherwise leaves VCRUNTIME140.dll as an undeclared system
+  // prerequisite before any Cua code can run.
+  environment.RUSTFLAGS = [
+    environment.RUSTFLAGS?.trim(),
+    "-C target-feature=+crt-static",
+  ].filter(Boolean).join(" ")
+  return environment
+}
+
 const manifest = JSON.parse(readFileSync(join(typescriptRoot, "package.json"), "utf8"))
 const expectedVersion = manifest.devDependencies?.["uniffi-bindgen-react-native"]
 const upstreamManifestPath = join(upstreamRoot, "package.json")
@@ -142,7 +160,10 @@ try {
 
   const args = ["build", "--release", "--manifest-path", join(runtimeRoot, "napi", "Cargo.toml")]
   if (target) args.push("--target", target)
-  const result = spawnSync("cargo", args, { stdio: "inherit" })
+  const result = spawnSync("cargo", args, {
+    env: cargoEnvironment(),
+    stdio: "inherit",
+  })
   if (result.error) throw result.error
   if (result.status !== 0) throw new Error(`cargo exited with status ${result.status}`)
 

--- a/libs/cua-driver/typescript/README.md
+++ b/libs/cua-driver/typescript/README.md
@@ -174,6 +174,10 @@ OS and CPU. It does not bundle the `cua-driver` executable: ship that executable
 outside ASAR, preserve its executable bit, and sign it before signing and
 notarizing the enclosing app.
 
+Windows native packages statically link the Microsoft C runtime, so importing
+the SDK on a clean x64 or ARM64 Windows installation does not require a separate
+Visual C++ Redistributable installation.
+
 Each native package also carries Cua's copy-mode build of the pinned
 `@ubjs/node` N-API runtime. Upstream `0.31.0-3` returns Rust-owned memory through
 external ArrayBuffers, which Electron 20 and newer intentionally reject because


### PR DESCRIPTION
## Summary

- statically link the MSVC CRT into the custom Windows N-API runtime
- fail the Windows release build if the packaged runtime imports VC/UCRT DLLs
- smoke-test the packaged SDK on native Windows x64 and Windows 11 ARM runners
- keep the standalone driver and SDK library behavior unchanged

## Root cause

The custom `cua_driver_node_runtime.node` includes C++ objects and inherited MSVC's dynamic CRT default. The published Windows x64 and ARM64 addons therefore imported `VCRUNTIME140.dll`, so a clean Windows 11 ARM installation could fail during module import before Cua Driver could start or report a diagnostic.

Fixes #3035

## Validation

- `uv run --with pytest python -m pytest .github/scripts/tests/test_cua_driver_release_wiring.py -q` — 39 passed
- `uv run --with pytest --with jsonschema --with toml --with pyyaml python -m pytest .github/scripts/tests -q` — 167 passed, 16 subtests passed
- `node --check libs/cua-driver/scripts/build-node-runtime.mjs`
- `git diff --check`
- [Exact candidate release run](https://github.com/trycua/cua/actions/runs/31387187910) at `ef3bd60da3f91b3d7c7c7b7b3e5e2fb714a5227e` — passed
  - [x] Windows x64 and ARM64 release runtimes built and packaged
  - [x] Both PE import-table gates found no dynamic VC/UCRT dependency
  - [x] Packaged SDK imported and connected on native Windows x64
  - [x] Packaged SDK imported and connected on native Windows 11 ARM64
  - [x] Cross-platform release artifact contract passed
- [Windows canonical desktop matrix](https://github.com/trycua/cua/actions/runs/31379104024) — passed
- [Linux canonical desktop matrix](https://github.com/trycua/cua/actions/runs/31379104095) — passed
- [x] Required pull-request checks passed at the final candidate SHA

The desktop results were carried across a rebase whose only intervening `main`
change removed one Python-agent dependency entry (`libs/python/agent/pyproject.toml`).
The macOS desktop matrix was not repeated because this production path activates
only for `-pc-windows-msvc`; the final candidate's macOS universal release build
and portable contract check both passed.
