### PR TITLE
fix(fleet): clear disabled pool autoscaling

### DIFF
--- a/libs/fleet/sdk/src/pools.rs
+++ b/libs/fleet/sdk/src/pools.rs
@@ -109,7 +109,7 @@ impl CyclopsClient {
 
     pub async fn update_pool(self: Arc<Self>, pool: Pool) -> Result<Pool, SdkError> {
         let item_url = self.pool_item_url(&pool)?;
-        let body = to_json(&pool)?;
+        let body = pool_merge_patch_json(&pool)?;
         self.send_json_crud(
             "update pool",
             merge_patch_request(item_url, Some(body)),
@@ -257,6 +257,16 @@ fn json_request(method: &str, url: Url, body: Option<Vec<u8>>) -> HttpRequest {
         ],
         body,
     }
+}
+
+fn pool_merge_patch_json(pool: &Pool) -> Result<Vec<u8>, SdkError> {
+    let mut value = serde_json::to_value(pool).map_err(|error| SdkError::Body {
+        reason: error.to_string(),
+    })?;
+    if pool.spec.autoscaling.is_none() {
+        value["spec"]["autoscaling"] = serde_json::Value::Null;
+    }
+    to_json(&value)
 }
 
 fn to_json<T: Serialize>(value: &T) -> Result<Vec<u8>, SdkError> {

--- a/libs/fleet/sdk/tests/pool_flow.rs
+++ b/libs/fleet/sdk/tests/pool_flow.rs
@@ -399,7 +399,7 @@ async fn gets_named_pool_and_updates_typed_pools() {
 
     let requests = resource_requests(&http).await;
     assert_request(&requests[0], "GET", ITEM, None);
-    assert_merge_patch_request(&requests[1], ITEM, Some(&json_bytes(&updated)));
+    assert_merge_patch_request(&requests[1], ITEM, Some(&pool_merge_patch_bytes(&updated)));
 }
 
 #[tokio::test]
@@ -433,7 +433,7 @@ async fn reconcile_updates_an_existing_named_pool() {
 
     let requests = resource_requests(&http).await;
     assert_request(&requests[0], "GET", ITEM, None);
-    assert_merge_patch_request(&requests[1], ITEM, Some(&json_bytes(&updated)));
+    assert_merge_patch_request(&requests[1], ITEM, Some(&pool_merge_patch_bytes(&updated)));
 }
 
 #[tokio::test]
@@ -628,7 +628,11 @@ async fn updates_non_lifecycle_pool_resources_without_namespace_cleanup() {
 
     let requests = resource_requests(&http).await;
     assert_eq!(requests.len(), 1);
-    assert_merge_patch_request(&requests[0], &other_item, Some(&json_bytes(&other)));
+    assert_merge_patch_request(
+        &requests[0],
+        &other_item,
+        Some(&pool_merge_patch_bytes(&other)),
+    );
 }
 
 #[tokio::test]
@@ -781,6 +785,14 @@ fn token() -> HttpResponse {
 
 fn json_response(status: u16, value: &impl serde::Serialize) -> HttpResponse {
     response(status, &json_bytes(value))
+}
+
+fn pool_merge_patch_bytes(pool: &Pool) -> Vec<u8> {
+    let mut value = serde_json::to_value(pool).unwrap();
+    if pool.spec.autoscaling.is_none() {
+        value["spec"]["autoscaling"] = serde_json::Value::Null;
+    }
+    serde_json::to_vec(&value).unwrap()
 }
 
 fn json_bytes(value: &impl serde::Serialize) -> Vec<u8> {


### PR DESCRIPTION
## What changed

- serialize `spec.autoscaling: null` when `CyclopsClient.update_pool` disables autoscaling
- keep create serialization unchanged
- cover direct and reconcile pool updates with the JSON Merge Patch contract

## Why

JSON Merge Patch preserves fields that are omitted. The SDK's schema serializer skips `None`, so removing Terraform's `autoscaling` block sent no `spec.autoscaling` key and left KEDA enabled. The subsequent read returned the old autoscaling object and Terraform reported an inconsistent result.

## Validation

- `cargo test --manifest-path libs/fleet/Cargo.toml -p cyclops-sdk --test pool_flow` — 20 passed
- `cargo test --manifest-path libs/fleet/Cargo.toml -p cyclops-sdk --lib` — 5 passed
