### PR TITLE
fix(pyproject): remove asyncio from pip dependencies

### DIFF
--- a/libs/python/agent/pyproject.toml
+++ b/libs/python/agent/pyproject.toml
@@ -13,7 +13,6 @@ authors = [
 dependencies = [
     "httpx>=0.27.0",
     "aiohttp>=3.9.3",
-    "asyncio",
     "anyio>=4.4.1",
     "typing-extensions>=4.12.2",
     "pydantic>=2.6.4",


### PR DESCRIPTION
This draft supersedes [PR #1914](https://github.com/trycua/cua/pull/1914) and carries its one-line dependency fix onto the direct branch.

Removes `asyncio` from `cua-agent` runtime dependencies because it is part of the Python standard library and is not a package dependency.

Closes #1913

Validation:
- `pyproject.toml` parses successfully with `tomllib`
- `git diff --check` passes
- GitHub Actions checks pass

Attribution:
- `Salvaged from #1914`