### PR TITLE
Linux driver reliability fixes + Windows window_center perf improvement

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/src/atspi/native.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/atspi/native.rs
@@ -1182,14 +1182,33 @@ fn list_windows_blocking(filter_pid: Option<u32>) -> Vec<crate::x11::WindowInfo>
 ///   2. an editable inside web/document content — for a browser this is the
 ///      page's field, not the address bar (which sorts first in the tree but is
 ///      chrome),
-///   3. the first editable anywhere (covers single-field apps like a GTK dialog
-///      entry, or a GTK4 GtkEntry).
+///   3. the *only* editable, when the app has exactly one (covers single-field
+///      apps like a GTK dialog entry, or a GTK4 GtkEntry).
+///
+/// Rung 3 used to be "the first editable anywhere", and tree order is not a
+/// guess worth making: in Geany the first editable is the toolbar search entry,
+/// several nodes above the document. When nothing reported focus — which happens
+/// whenever another process holds the X input focus, i.e. constantly on a shared
+/// desktop — text written "into Geany" went into that search box, silently, and
+/// the write was reported as confirmed. Editing tasks failed about half the time
+/// with no error anywhere and the file untouched on disk.
+///
+/// With more than one candidate and no focus to choose between them, there is no
+/// right answer available here. Returning `None` lets the caller fall through to
+/// real key events, which go wherever the user's focus actually is.
 fn pick_editable<'v, 'a>(visited: &'v [Visited<'a>]) -> Option<&'v Visited<'a>> {
     visited
         .iter()
         .find(|v| v.has_editable && v.focused)
         .or_else(|| visited.iter().find(|v| v.has_editable && v.in_web_doc))
-        .or_else(|| visited.iter().find(|v| v.has_editable))
+        .or_else(|| {
+            let mut editables = visited.iter().filter(|v| v.has_editable);
+            match (editables.next(), editables.next()) {
+                (Some(only), None) => Some(only),
+                // Ambiguous: refuse rather than guess by tree order.
+                _ => None,
+            }
+        })
 }
 
 /// Try to write `text` into the best editable node in `visited` via AT-SPI

--- a/libs/cua-driver/rust/crates/platform-linux/src/capture.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/capture.rs
@@ -8,7 +8,65 @@
 
 use anyhow::{bail, Result};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// How long a capture subprocess may take before it is killed.
+///
+/// A screenshot of a single window is tens of milliseconds. Anything past a
+/// couple of seconds is not slow, it is stuck.
+const CAPTURE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Run a capture command, killing it if it outstays [`CAPTURE_TIMEOUT`].
+///
+/// `Command::output()` waits forever, and that is not a theoretical problem
+/// here: ImageMagick's `import` takes an X server grab, and a grab held by a
+/// wedged process blocks *every other X client on the display*. One `import`
+/// stuck against a window that was being torn down froze the whole desktop —
+/// a click task that normally finishes in 25 seconds took 445, `wmctrl` hung,
+/// and even `docker exec` blocked. Nothing logged an error; runs simply got
+/// slower and then stopped returning, which reads as a flaky benchmark rather
+/// than as one wedged subprocess.
+///
+/// The output is read on a worker thread rather than after the wait, because a
+/// PNG is far larger than a pipe buffer: polling `try_wait` while nothing
+/// drains stdout would deadlock on any screenshot big enough to matter, which
+/// is all of them.
+fn output_bounded(mut command: Command) -> Result<Vec<u8>> {
+    let mut child = command.stdout(Stdio::piped()).stderr(Stdio::null()).spawn()?;
+    let pid = child.id() as i32;
+
+    let mut stdout = child.stdout.take().expect("stdout was piped");
+    let reader = std::thread::spawn(move || {
+        use std::io::Read as _;
+        let mut buffer = Vec::new();
+        let _ = stdout.read_to_end(&mut buffer);
+        buffer
+    });
+
+    let deadline = Instant::now() + CAPTURE_TIMEOUT;
+    loop {
+        match child.try_wait()? {
+            Some(status) => {
+                let bytes = reader.join().unwrap_or_default();
+                if !status.success() || bytes.is_empty() {
+                    bail!("capture command failed");
+                }
+                return Ok(bytes);
+            }
+            None if Instant::now() >= deadline => {
+                // SIGKILL, not SIGTERM. A process wedged holding an X grab is
+                // by definition not servicing anything, so asking politely
+                // leaves the grab in place for the full grace period.
+                unsafe { libc::kill(pid, libc::SIGKILL) };
+                let _ = child.wait();
+                let _ = reader.join();
+                bail!("capture command exceeded {CAPTURE_TIMEOUT:?} and was killed");
+            }
+            None => std::thread::sleep(Duration::from_millis(20)),
+        }
+    }
+}
 
 /// Capture a window by X11 XID. Returns raw PNG bytes.
 pub fn screenshot_window_bytes(xid: u64) -> Result<Vec<u8>> {
@@ -36,13 +94,9 @@ pub fn screenshot_window(xid: u64) -> Result<(String, u32, u32)> {
 }
 
 fn capture_via_import(xid: u64) -> Result<Vec<u8>> {
-    let out = Command::new("import")
-        .args(["-window", &xid.to_string(), "png:-"])
-        .output()?;
-    if !out.status.success() || out.stdout.is_empty() {
-        bail!("import failed");
-    }
-    Ok(out.stdout)
+    let mut command = Command::new("import");
+    command.args(["-window", &xid.to_string(), "png:-"]);
+    output_bounded(command)
 }
 
 fn capture_via_xgetimage(xid: u64) -> Result<(String, u32, u32)> {
@@ -136,13 +190,10 @@ fn screenshot_display_bytes_with_dispatch(
 /// loop forever once we're on Wayland).
 pub(crate) fn screenshot_display_bytes_x11() -> Result<Vec<u8>> {
     // Try `import -window root png:-` (ImageMagick).
-    let out = Command::new("import")
-        .args(["-window", "root", "png:-"])
-        .output();
-    if let Ok(o) = out {
-        if o.status.success() && !o.stdout.is_empty() {
-            return Ok(o.stdout);
-        }
+    let mut command = Command::new("import");
+    command.args(["-window", "root", "png:-"]);
+    if let Ok(bytes) = output_bounded(command) {
+        return Ok(bytes);
     }
     // Fallback: x11rb XGetImage on the root window.
     use x11rb::connection::Connection;

--- a/libs/cua-driver/rust/crates/platform-linux/src/input/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/input/mod.rs
@@ -2465,8 +2465,24 @@ fn char_to_keycode_shift(mapping: &GetKeyboardMappingReply, keysym: u32) -> Opti
 /// resolution — no server interaction — split out from keycode lookup so the
 /// keysym can be remapped onto a spare keycode when the keymap lacks it.
 fn key_name_to_keysym(key: &str) -> Result<u32> {
-    // Common X11 keysym names.
-    let keysym: u32 = match key.to_lowercase().as_str() {
+    // Separators dropped before matching, so the X keysym spelling and the
+    // compact spelling are the same key.
+    //
+    // The table below spells these `pagedown`, but the name X itself uses is
+    // `Page_Down`, and that is what a caller reading xmodmap output — or a model
+    // that learned X keysyms — will send. It was rejected outright: an agent
+    // scrolling a long list pressed `Page_Down` twice, got "Unknown key" twice,
+    // and fell back to a worse strategy. A rejected key is not a neutral event
+    // in a measurement; it pushes the run toward whatever the model tries next.
+    //
+    // Only the separators are removed, never characters, so `underscore` and
+    // `minus` still name themselves and the single-character branch is
+    // untouched.
+    let normalised = key.to_lowercase().replace(['_', '-', ' '], "");
+    // The single-character branch must see the original: " " is the space key,
+    // and normalising it away would turn it into the empty string.
+    let lookup = if key.chars().count() == 1 { key.to_lowercase() } else { normalised };
+    let keysym: u32 = match lookup.as_str() {
         "return" | "enter" => 0xFF0D,
         "tab" => 0xFF09,
         "escape" | "esc" => 0xFF1B,

--- a/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
@@ -171,6 +171,21 @@ pub fn send_command_for(key: CursorKey, cmd: OverlayCommand) {
     if key.is_empty() {
         return;
     }
+    // The embedder tap first, before anything can drop the command.
+    //
+    // Only the Windows dispatcher did this, so on Linux — where every dataset
+    // actually runs — `cursor.jsonl` was empty for every run ever recorded, and
+    // the timeline had no cursor to draw. It matters most for accessibility
+    // clicks: an `element_index` action resolves to a point that only the
+    // overlay ever computes, so with nothing tapping the command there is no
+    // record anywhere of *where* the agent clicked. The pixel coordinates are
+    // not in the tool arguments to fall back on.
+    //
+    // Emitted ahead of the channel send for the same reason Windows does it:
+    // recording must see the interaction even when no overlay thread is
+    // running, which is the normal case for headless capture.
+    cursor_overlay::tap::emit(&key, &cmd);
+
     let msg = OverlayMsg::Cmd(KeyedOverlayCommand {
         key: key.clone(),
         cmd: cmd.clone(),

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -2835,11 +2835,30 @@ impl Tool for TypeTextTool {
                 Err(e) => ToolResult::error(format!("Task error: {e}")),
             };
         }
-        // Foreground means the caller explicitly permits activation. Chromium
-        // and WebKitGTK can acknowledge an accessibility write without
-        // producing the renderer input event, so web embedders use real XTest
-        // key events. Native toolkits keep their verifiable AT-SPI path below.
-        if delivery.is_foreground() && (is_chromium_embedder(pid) || is_webkitgtk_embedder(pid)) {
+        // Foreground means the caller explicitly permits activation, so it gets
+        // real key events — for every toolkit, not just the web embedders.
+        //
+        // This used to be gated on `is_chromium_embedder || is_webkitgtk_embedder`,
+        // on the reasoning that native toolkits have a "verifiable AT-SPI path
+        // below". That path is not verifiable, and for native GTK it was wrong
+        // often enough to invalidate a whole calibration campaign:
+        //
+        //   * `type_text{delivery_mode:"foreground", text:"import math"}` into
+        //     Geany fell through to AT-SPI, which picked the *first editable in
+        //     tree order* — the toolbar search entry — and the eleven characters
+        //     were never seen again. `press_key` and `hotkey ctrl+s` on the same
+        //     window landed correctly, so the file saved with a blank first line
+        //     and no import.
+        //   * The call returned "Typed 11 character(s) (via AT-SPI)" and
+        //     `verified: true`. The agent then searched the accessibility tree,
+        //     *found* "import math" in the entry, and correctly concluded it had
+        //     succeeded.
+        //
+        // Roughly half of all such calls no-opped this way. Silently downgrading
+        // an explicit foreground request to a background widget guess is the bug;
+        // the embedder check belongs on choosing the *default*, never on honouring
+        // what the caller asked for.
+        if delivery.is_foreground() {
             if let Some(idx) = resolved_elem_idx {
                 let focused =
                     tokio::task::spawn_blocking(move || crate::atspi::focus_element(pid, idx))

--- a/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -113,6 +113,44 @@ fn resolve_onscreen_point_with_scroll(
 /// hook) we degrade to `GetWindowRect.top-left + (px, py)` — matches
 /// the capture fallback which also keeps the full PrintWindow bitmap
 /// without crop.
+/// The centre of a window in screen coordinates, from the window itself.
+///
+/// Uses the DWM extended frame bounds where available, for the same reason
+/// [`bitmap_to_screen`] does: `GetWindowRect` on a composited window includes
+/// the invisible resize border, so its centre is a few pixels off from what a
+/// person sees. Returns `None` only when the window has no rect at all —
+/// destroyed, or never shown.
+fn window_center(hwnd: u64) -> Option<(i32, i32)> {
+    use windows::Win32::Foundation::{HWND, RECT};
+    use windows::Win32::Graphics::Dwm::{DwmGetWindowAttribute, DWMWA_EXTENDED_FRAME_BOUNDS};
+    use windows::Win32::UI::WindowsAndMessaging::GetWindowRect;
+
+    let h = HWND(hwnd as *mut _);
+    unsafe {
+        let mut dwm = RECT::default();
+        let hr = DwmGetWindowAttribute(
+            h,
+            DWMWA_EXTENDED_FRAME_BOUNDS,
+            &mut dwm as *mut _ as *mut _,
+            std::mem::size_of::<RECT>() as u32,
+        );
+        let rect = if hr.is_ok() && dwm.right > dwm.left && dwm.bottom > dwm.top {
+            dwm
+        } else {
+            let mut plain = RECT::default();
+            GetWindowRect(h, &mut plain).ok()?;
+            plain
+        };
+        if rect.right <= rect.left || rect.bottom <= rect.top {
+            return None;
+        }
+        Some((
+            rect.left + (rect.right - rect.left) / 2,
+            rect.top + (rect.bottom - rect.top) / 2,
+        ))
+    }
+}
+
 fn bitmap_to_screen(hwnd: u64, px: i32, py: i32) -> (i32, i32) {
     use windows::Win32::Foundation::{HWND, RECT};
     use windows::Win32::Graphics::Dwm::{DwmGetWindowAttribute, DWMWA_EXTENDED_FRAME_BOUNDS};
@@ -5656,15 +5694,13 @@ impl Tool for ScrollTool {
             let center = if let (Some(x), Some(y)) = (px, py) {
                 Some(bitmap_to_screen(hwnd, x as i32, y as i32))
             } else {
-                tokio::task::spawn_blocking(move || {
-                    crate::win32::list_windows(Some(pid))
-                        .into_iter()
-                        .find(|w| w.hwnd == hwnd)
-                        .map(|w| (w.x + w.width / 2, w.y + w.height / 2))
-                })
-                .await
-                .ok()
-                .flatten()
+                // The window's own rect, not a search through every window the
+                // process owns. `list_windows` enumerates and inspects each
+                // window it finds; measured against a WinForms app it cost
+                // ~2.5s per call, which made a foreground scroll feel like it
+                // had been ignored (27ms once resolved directly). The HWND is
+                // already known here — there is nothing to look up.
+                window_center(hwnd)
             };
             let (cx, cy) = match center {
                 Some(c) => c,


### PR DESCRIPTION
## Summary

Five independent reliability fixes, each addressing a real observed failure mode:

- **AT-SPI editable-picking ambiguity** (`platform-linux/src/atspi/native.rs`): `pick_editable`'s third rung used to be "the first editable anywhere" by tree order. In Geany the first editable is the toolbar search entry, several nodes above the document. Whenever nothing reported focus — which happens constantly on a shared desktop whenever another process holds X input focus — text meant for the document silently landed in that search box instead, and the write was reported as confirmed. The rung now only fires when there is exactly *one* editable candidate; with more than one and no focus signal to disambiguate, it refuses rather than guesses, falling through to real key events at wherever focus actually is.

- **Foreground `type_text` no longer silently downgrades to AT-SPI for native toolkits** (`platform-linux/src/tools/impl_.rs`): the foreground path used to be gated on `is_chromium_embedder || is_webkitgtk_embedder`, on the theory that native toolkits have a "verifiable" AT-SPI path below. That path is not verifiable, and for native GTK it picked the wrong widget often enough (the same Geany toolbar-search-entry issue) to invalidate roughly half of all such calls in a calibration campaign — while still reporting `verified: true`. An explicit foreground request now gets real key events for every toolkit, not just web embedders.

- **Capture-subprocess hang fix** (`platform-linux/src/capture.rs`): the capture helper now enforces a 5s timeout with SIGKILL and reads stdout on a background thread instead of blocking synchronously, so a wedged capture subprocess can no longer hang the calling tool indefinitely.

- **Keysym normalization** (`platform-linux/src/input/mod.rs`): both spellings of keysyms like `Page_Down` and `pagedown` are now accepted, instead of only one canonical form.

- **Overlay/cursor-recording gap fix** (`platform-linux/src/overlay.rs`): Linux never emitted the tap event that the Windows overlay already emits on click dispatch, so `cursor.jsonl` was empty on every Linux recording ever made. Linux now emits the same tap.

- **Windows `window_center()` perf fix** (`platform-windows/src/tools/impl_.rs`): `ScrollTool`'s no-explicit-target path used to resolve a window's center by calling `list_windows(Some(pid))` and searching every window the process owns. Measured against a WinForms app this cost ~2.5s per call, making a foreground scroll feel like it had been ignored. The HWND is already known at that call site, so `window_center(hwnd)` now reads its rect directly via `DwmGetWindowAttribute`/`GetWindowRect` — 27ms once resolved directly.

## Testing

- `cargo check -p platform-windows -p cua-driver -p cua-driver-sdk` — clean (worked around a pre-existing local MSVC Spectre-libs gap by building with the `stable-x86_64-pc-windows-gnu` toolchain).
- `platform-linux` changes were applied with careful line-by-line context verification against current `main` (this repo moves fast; the local dev checkout this work started from had drifted meaningfully from origin/main — several related fixes, e.g. foreground XTest clicks for modified clicks, were found already shipped upstream and were **not** re-applied to avoid duplicating/conflicting with existing work) but could not be locally cross-compiled on this Windows dev machine — no Linux C toolchain available for the `x86_64-unknown-linux-gnu` target. Recommend CI confirms the Linux build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZhbsmHmJ6vxt4RF87MsvU