### PR TITLE
docs(sandbox): explain how to use a sandbox pool

### DIFF
--- a/docs/content/docs/how-to-guides/sandbox/meta.json
+++ b/docs/content/docs/how-to-guides/sandbox/meta.json
@@ -1,1 +1,12 @@
-{ "title": "Sandbox", "pages": ["lifecycle", "secrets", "scale-out", "tunneling", "images", "interactive-shell"] }
+{
+  "title": "Sandbox",
+  "pages": [
+    "lifecycle",
+    "use-a-sandbox-pool",
+    "secrets",
+    "scale-out",
+    "tunneling",
+    "images",
+    "interactive-shell"
+  ]
+}

--- a/docs/content/docs/how-to-guides/sandbox/use-a-sandbox-pool.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/use-a-sandbox-pool.mdx
@@ -51,20 +51,11 @@ Save the following script as `sandbox_pool.py`. Change `CUA_POOL_NAME` if you
 need a different DNS-compatible namespace and pool name.
 
 ```python title="sandbox_pool.py"
+import asyncio
 import os
 from pathlib import Path
 
-from cua_sandbox import (
-    CreatePoolRequestBuilder,
-    CreateTemplateRequestBuilder,
-    OsGymSandboxTemplateSpecBuilder,
-    OsGymSandboxWarmPoolSpecBuilder,
-    SandboxServiceBuilder,
-    SandboxTemplateRefBuilder,
-    ServiceProtocol,
-    VmTemplateBuilder,
-)
-from cua_sandbox.sync import Pool, Template
+from cua_sandbox import Image, Sandbox
 
 POOL_NAME = os.environ.get("CUA_POOL_NAME", "my-sandbox-pool")
 IMAGE = (
@@ -72,49 +63,22 @@ IMAGE = (
     "@sha256:5b9cb82f482834f7541901b87be956e7544d0db13fabc0b372cbc5eca5a74180"
 )
 
-server = (
-    SandboxServiceBuilder()
-    .name("server")
-    .target_port(8000)
-    .protocol(ServiceProtocol.TCP)
-    .build()
-)
-vm = (
-    VmTemplateBuilder()
-    .container_disk_image(IMAGE)
-    .image_pull_secret("ecr-credentials")
-    .cpu_cores(4)
-    .memory("4Gi")
-    .services([server])
-    .build()
-)
-template_request = (
-    CreateTemplateRequestBuilder()
-    .namespace(POOL_NAME)
-    .name("workspace")
-    .spec(OsGymSandboxTemplateSpecBuilder().vm_template(vm).build())
-    .build()
-)
-pool_request = (
-    CreatePoolRequestBuilder()
-    .namespace(POOL_NAME)
-    .spec(
-        OsGymSandboxWarmPoolSpecBuilder()
-        .replicas(1)
-        .sandbox_template_ref(SandboxTemplateRefBuilder().name("workspace").build())
-        .build()
-    )
-    .build()
-)
 
-Template.reconcile(template_request)
-pool = Pool.reconcile(pool_request)
+async def main() -> None:
+    output = Path("sandbox.png")
+    async with Sandbox.ephemeral(
+        Image.from_registry(IMAGE),
+        name=POOL_NAME,
+        cpu=4,
+        memory_mb=4096,
+        time_to_start=900,
+    ) as sandbox:
+        output.write_bytes(await sandbox.screenshot())
 
-output = Path("sandbox.png")
-with pool.claim() as sandbox:
-    output.write_bytes(sandbox.screenshot())
+    print(f"Saved screenshot to {output.resolve()}")
 
-print(f"Saved screenshot to {output.resolve()}")
+
+asyncio.run(main())
 ```
 
 Run it with Python 3.12, the published `cua-sandbox` package, and the Cua wheel
@@ -127,13 +91,12 @@ uv run --python 3.12 \
   sandbox_pool.py
 ```
 
-The first run creates or updates the template and one-replica warm pool. It can
-take several minutes for the sandbox to become ready. The claim context waits
-for a sandbox, saves the PNG bytes returned by `screenshot()` to `sandbox.png`,
-and releases the claim on exit. Reconciliation is idempotent, so later runs
-update the same named resources instead of creating duplicates.
+The high-level builder creates or updates the template and one-replica pool,
+then waits for its claim to bind. Provisioning can take several minutes. The
+context saves the PNG bytes returned by `screenshot()` to `sandbox.png` and
+releases the claim on exit.
 
 <Callout type="info">
-  Exiting the claim releases the sandbox but does not delete the warm pool. Remove pools you no
-  longer need in [run.cua.ai](https://run.cua.ai/#/pools) to avoid keeping resources allocated.
+  Exiting the context releases the claim but leaves the reconciled pool and template in place.
+  Remove pools you no longer need from the [run.cua.ai pools page](https://run.cua.ai/#/pools).
 </Callout>

--- a/docs/content/docs/how-to-guides/sandbox/use-a-sandbox-pool.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/use-a-sandbox-pool.mdx
@@ -1,0 +1,139 @@
+---
+title: How to use a sandbox pool
+description: Reconcile a warm run.cua.ai sandbox pool, claim a sandbox, and save a screenshot with Python.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+A sandbox pool keeps reusable cloud sandboxes warm. Reconcile the pool once,
+then claim a sandbox whenever your program needs one. The claim is released
+automatically when its context manager exits.
+
+## Create OAuth credentials
+
+Open [User API keys](https://run.cua.ai/#/user-keys), select **Create key**, and
+copy the Client ID and Client Secret. The Client Secret is shown only once.
+
+Keep both values in a password manager or secret manager. Do not commit them,
+paste them into source code, or include them in logs. Export them in the shell
+where you will run the example:
+
+```bash
+export CUA_CLIENT_ID="<your-client-id>"
+export CUA_CLIENT_SECRET="<your-client-secret>"
+```
+
+<Callout type="warn">
+  Replace the placeholders locally. Never put real credentials in a script, `.env` file committed to
+  Git, issue, or support message.
+</Callout>
+
+## Install uv
+
+On macOS or Linux, use uv's official standalone installer:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+On Windows, run the official installer in PowerShell:
+
+```powershell
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+See the [uv installation guide](https://docs.astral.sh/uv/getting-started/installation/)
+for package-manager and version-pinning options.
+
+## Reconcile and claim a pool
+
+Save the following script as `sandbox_pool.py`. Change `CUA_POOL_NAME` if you
+need a different DNS-compatible namespace and pool name.
+
+```python title="sandbox_pool.py"
+import os
+from pathlib import Path
+
+from cua_sandbox import (
+    CreatePoolRequestBuilder,
+    CreateTemplateRequestBuilder,
+    OsGymSandboxTemplateSpecBuilder,
+    OsGymSandboxWarmPoolSpecBuilder,
+    SandboxServiceBuilder,
+    SandboxTemplateRefBuilder,
+    ServiceProtocol,
+    VmTemplateBuilder,
+)
+from cua_sandbox.sync import Pool, Template
+
+POOL_NAME = os.environ.get("CUA_POOL_NAME", "my-sandbox-pool")
+IMAGE = (
+    "296062593712.dkr.ecr.us-west-2.amazonaws.com/desktop-workspace-duo"
+    "@sha256:5b9cb82f482834f7541901b87be956e7544d0db13fabc0b372cbc5eca5a74180"
+)
+
+server = (
+    SandboxServiceBuilder()
+    .name("server")
+    .target_port(8000)
+    .protocol(ServiceProtocol.TCP)
+    .build()
+)
+vm = (
+    VmTemplateBuilder()
+    .container_disk_image(IMAGE)
+    .image_pull_secret("ecr-credentials")
+    .cpu_cores(4)
+    .memory("4Gi")
+    .services([server])
+    .build()
+)
+template_request = (
+    CreateTemplateRequestBuilder()
+    .namespace(POOL_NAME)
+    .name("workspace")
+    .spec(OsGymSandboxTemplateSpecBuilder().vm_template(vm).build())
+    .build()
+)
+pool_request = (
+    CreatePoolRequestBuilder()
+    .namespace(POOL_NAME)
+    .spec(
+        OsGymSandboxWarmPoolSpecBuilder()
+        .replicas(1)
+        .sandbox_template_ref(SandboxTemplateRefBuilder().name("workspace").build())
+        .build()
+    )
+    .build()
+)
+
+Template.reconcile(template_request)
+pool = Pool.reconcile(pool_request)
+
+output = Path("sandbox.png")
+with pool.claim() as sandbox:
+    output.write_bytes(sandbox.screenshot())
+
+print(f"Saved screenshot to {output.resolve()}")
+```
+
+Run it with Python 3.12, the published `cua-sandbox` package, and the Cua wheel
+index used for its Fleet dependency:
+
+```bash
+uv run --python 3.12 \
+  --extra-index-url https://wheels.cua.ai/simple \
+  --with cua-sandbox \
+  sandbox_pool.py
+```
+
+The first run creates or updates the template and one-replica warm pool. It can
+take several minutes for the sandbox to become ready. The claim context waits
+for a sandbox, saves the PNG bytes returned by `screenshot()` to `sandbox.png`,
+and releases the claim on exit. Reconciliation is idempotent, so later runs
+update the same named resources instead of creating duplicates.
+
+<Callout type="info">
+  Exiting the claim releases the sandbox but does not delete the warm pool. Remove pools you no
+  longer need in [run.cua.ai](https://run.cua.ai/#/pools) to avoid keeping resources allocated.
+</Callout>


### PR DESCRIPTION
## What changed

- add a how-to guide for reconciling and claiming a run.cua.ai sandbox pool
- link directly to the User API keys page for Client ID and Client Secret creation
- document safe environment-variable handling and official uv installation
- use the current high-level `Image.from_registry(...)` + `Sandbox.ephemeral(...)` API to reconcile the pool, claim a sandbox, save screenshot bytes, and release the claim
- add the guide to the Sandbox how-to navigation

## Validation

- `python3 -m py_compile /tmp/cua930-sandbox_pool.py`
- exact extracted snippet run with `uv run --isolated --python 3.12 --extra-index-url https://wheels.cua.ai/simple --with cua-sandbox` against a fake Fleet API boundary
- fake boundary verified the generated one-replica pool and template configuration, claim binding, service readiness, PNG file output, and claim release
- `corepack pnpm docs:check-hygiene`
- `corepack pnpm docs:check-links`
- `corepack pnpm exec prettier --check content/docs/how-to-guides/sandbox/use-a-sandbox-pool.mdx content/docs/how-to-guides/sandbox/meta.json`
- `corepack pnpm build`
- all external links in the guide returned HTTP 200 after redirects

Live Fleet provisioning was not run because `CUA_CLIENT_ID` and `CUA_CLIENT_SECRET` are unavailable in this environment.

Refs [CUA-930](https://linear.app/cua/issue/CUA-930)