### PR TITLE
ci(cua-sandbox): skip periodic live E2E on forks

### DIFF
--- a/.github/scripts/tests/test_periodic_cua_sandbox_live.py
+++ b/.github/scripts/tests/test_periodic_cua_sandbox_live.py
@@ -79,6 +79,15 @@ class TestPeriodicCuaSandboxLive(unittest.TestCase):
         self.assertIn('"lane":"main-source"', prepare_script)
         self.assertIn('"lane":"published-package"', prepare_script)
 
+    def test_jobs_only_run_in_the_upstream_repository(self) -> None:
+        workflow = self.workflow()
+        for job_name in ("prepare", "live"):
+            with self.subTest(job=job_name):
+                self.assertEqual(
+                    workflow["jobs"][job_name]["if"],
+                    "github.repository == 'trycua/cua'",
+                )
+
     def test_prepare_matrix_selects_lanes_for_each_trigger(self) -> None:
         expected_matrices = {
             ("push", ""): {"include": [{"lane": "main-source"}]},
@@ -119,6 +128,7 @@ class TestPeriodicCuaSandboxLive(unittest.TestCase):
         )
         required_contract = (
             "libs/python/cua-fleet/**",
+            "github.repository == 'trycua/cua'",
             "Check Fleet OAuth credentials",
             "step-scoped OAuth credentials",
             "CUA_LIVE_E2E_SOURCE_SHA",

--- a/.github/workflows/periodic-cua-sandbox-live.yml
+++ b/.github/workflows/periodic-cua-sandbox-live.yml
@@ -29,6 +29,7 @@ permissions:
 
 jobs:
   prepare:
+    if: github.repository == 'trycua/cua'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
@@ -50,6 +51,7 @@ jobs:
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   live:
+    if: github.repository == 'trycua/cua'
     needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/docs/superpowers/plans/2026-08-09-periodic-cua-sandbox-live-e2e.md
+++ b/docs/superpowers/plans/2026-08-09-periodic-cua-sandbox-live-e2e.md
@@ -545,6 +545,11 @@ on:
       - ".github/scripts/tests/test_periodic_cua_sandbox_live.py"
 ```
 
+Both the `prepare` and `live` jobs carry
+`if: github.repository == 'trycua/cua'`, so a fork that syncs `main` or
+enables the schedule cannot run the live smoke or post a fork-originated
+alert to Alertmanager.
+
 The `prepare` job emits `main-source` for every `push`, both lanes for
 `schedule`, and the requested `workflow_dispatch` lane. The contract test
 extracts this shell script from parsed YAML, runs it with a temporary

--- a/docs/superpowers/specs/2026-08-09-periodic-cua-sandbox-live-e2e-design.md
+++ b/docs/superpowers/specs/2026-08-09-periodic-cua-sandbox-live-e2e-design.md
@@ -52,6 +52,11 @@ testing the current Fleet-backed public SDK contract.
 3. `workflow_dispatch` accepts `both`, `main-source`, or `published-package`,
    plus manual-only `force_failure`.
 
+Both jobs are guarded with `if: github.repository == 'trycua/cua'`. A fork
+that syncs `main` or enables the schedule therefore never runs the live smoke,
+never fails the credential preflight, and never posts a fork-originated
+`PeriodicCuaSandboxLiveE2EFailed` alert to the public Alertmanager endpoint.
+
 The preparation script emits a JSON matrix: every `push` selects only
 `main-source`; every `schedule` selects both lanes; manual runs select their
 requested lane or both. The workflow contract executes this extracted shell
@@ -206,7 +211,8 @@ source regression with a published-package or shared-infrastructure failure.
 ## Workflow Contract Coverage
 
 The repository-side contract parses the workflow with `yaml.BaseLoader` and
-asserts triggers, path filters, the executed preparation matrix, checkout ref,
+asserts triggers, path filters, the upstream-repository fork guard on both
+jobs, the executed preparation matrix, checkout ref,
 event-and-lane concurrency, credential preflight, copied-suite isolation,
 version output handling, controlled-failure diagnostics, failure-only artifacts,
 Alertmanager labels, full-SHA action pins, and absence of explicit deletion.


### PR DESCRIPTION
## Summary

- Problem this solves: Forks that sync `main` or enable the schedule could run the live smoke test and post fork-originated alerts to the public Alertmanager endpoint, creating noise and potential security concerns.
- What changed: Added `if: github.repository == 'trycua/cua'` guards to both the `prepare` and `live` jobs in the periodic CUA sandbox live workflow, ensuring these jobs only execute in the upstream repository.

## Related work

Refs #

RFC (required for a public SDK, CLI, MCP, protocol, compatibility, permission,
or cross-component contract change): N/A

## Compatibility and risk

- User-visible, API/CLI/MCP, migration, permission, or platform impact: Forks will no longer execute the live smoke test or post alerts to Alertmanager, even if they sync `main` or enable the schedule.
- Risk and rollback: Minimal risk. This is a safety guard that prevents unintended execution in forks. Rollback would be removing the `if` conditions from both jobs.

## Validation

- Focused tests and checks: Added `test_jobs_only_run_in_the_upstream_repository()` to verify both jobs have the correct repository guard. Updated `test_docs_describe_the_remediated_workflow()` to assert the guard is documented in the contract.
- Manual or platform evidence: N/A
- Known gaps or CI still required: None

## Contributor and release checks

- [ ] The PR is focused and the description matches the final diff.
- [ ] This change does not require an RFC, or the accepted RFC is linked above.
- [ ] Tests, documentation, and platform evidence are included or the gap is explained.
- [ ] The PR title is a Conventional Commit describing the production change.
- [ ] External contributor authorship is preserved, or no external contribution is included.
- [ ] If release-tracked files changed but this is intentionally non-releasing, the `no-release` label is applied.

https://claude.ai/code/session_01CEVbjrB7dgfSBg6Ykfhpma