### PR TITLE
fix(fleet): publish canonical 0.1.8 wheels

### DIFF
--- a/.github/scripts/tests/test_cua_fleet_release_wiring.py
+++ b/.github/scripts/tests/test_cua_fleet_release_wiring.py
@@ -8,19 +8,21 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 class TestCuaFleetReleaseWiring(unittest.TestCase):
-    """Keep Fleet's promotion workflow aligned with the published train wheel."""
+    """Keep Fleet's promotion workflow aligned with canonical SDK wheels."""
 
-    def test_publisher_promotes_cua_train_0_1_5(self) -> None:
+    def test_publisher_promotes_cua_fleet_0_1_8(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/cd-py-fleet.yml").read_text()
-        repackager = (REPO_ROOT / ".github/scripts/repackage_cua_train_wheel.py").read_text()
         expected_sources = {
-            "cua_train-0.1.6-py3-none-manylinux_2_34_x86_64.whl": "418db974949f4020fae2f3ed2f5a8d0db6ddce38e34f5db89283ac479d816a55",
-            "cua_train-0.1.6-py3-none-manylinux_2_34_aarch64.whl": "80526bf94ed535383b3dddd9a7da800da9fcb32837c21c2e2caa39390e3548c9",
-            "cua_train-0.1.6-py3-none-macosx_10_12_x86_64.whl": "87cb4220054514ac5f44118d490ae404fbca5c97d2b964cd4fcaf1facd391fc0",
-            "cua_train-0.1.6-py3-none-macosx_11_0_arm64.whl": "17563c0504c9270e570332924f3092faec3dcdbf48557a70ee830e165ac7751c",
+            "cua_fleet-0.1.8-py3-none-manylinux_2_34_x86_64.whl": "0bac329552d351604ad15b7eb4f4f3ed944921083238d74f51277d657d8f0a34",
+            "cua_fleet-0.1.8-py3-none-manylinux_2_34_aarch64.whl": "d7604668a7186d06cefb2bd23974b033c0b2cda61ccbe88d944af622b37f58d3",
+            "cua_fleet-0.1.8-py3-none-macosx_10_12_x86_64.whl": "20611a14c185157e6f41502e1bbdcc1e98663347e94463ca538755b0efc173bb",
+            "cua_fleet-0.1.8-py3-none-macosx_11_0_arm64.whl": "7c21d0a36a8d74bfe0768422e4f3d9367ee51837920e2c22ee57521fc93c4f3b",
+            "cua_fleet-0.1.8-py3-none-win_amd64.whl": "d78fe6934a2f650dcf5b105a08833418245c720765da9c3b40e160b86a3d203d",
         }
 
-        self.assertIn('SOURCE_VERSION = "0.1.6"', repackager)
+        self.assertIn("https://wheels.cua.ai/simple/cua-fleet/$WHEEL", workflow)
+        self.assertNotIn("repackage_cua_train_wheel.py", workflow)
+        self.assertNotIn("unsupported-windows", workflow)
         for wheel, digest in expected_sources.items():
             self.assertIn(f"wheel: {wheel}\n            sha256: {digest}", workflow)
 

--- a/.github/workflows/cd-py-fleet.yml
+++ b/.github/workflows/cd-py-fleet.yml
@@ -7,13 +7,13 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Patch version to publish (without v prefix)"
+        description: "Canonical cua-fleet version to publish"
         required: true
-        default: "0.0.10"
+        default: "0.1.8"
   workflow_call:
     inputs:
       version:
-        description: "Patch version to publish"
+        description: "Canonical cua-fleet version to publish"
         required: true
         type: string
     secrets:
@@ -29,7 +29,7 @@ jobs:
     outputs:
       version: ${{ steps.get-version.outputs.version }}
     steps:
-      - name: Determine and validate patch version
+      - name: Determine and validate canonical version
         id: get-version
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -49,36 +49,15 @@ jobs:
             exit 1
           fi
 
-          curl --fail --silent --show-error --location \
-            https://pypi.org/pypi/cua-fleet/json > /tmp/cua-fleet-pypi.json
-          python3 - "$VERSION" /tmp/cua-fleet-pypi.json <<'PY'
-          import json
-          import re
-          import sys
-
-          version, metadata_path = sys.argv[1:]
-          if not re.fullmatch(r"0\.0\.[0-9]+", version):
-              raise SystemExit("cua-fleet releases must be 0.0.x patches")
-
-          releases = json.load(open(metadata_path))["releases"]
-          stable = sorted(
-              int(match.group(1))
-              for candidate in releases
-              if (match := re.fullmatch(r"0\.0\.([0-9]+)", candidate))
-          )
-          if not stable:
-              raise SystemExit("PyPI does not contain a stable cua-fleet patch release")
-          latest = stable[-1]
-          proposed = int(version.rsplit(".", 1)[1])
-          if proposed not in {latest, latest + 1}:
-              raise SystemExit(f"expected 0.0.{latest + 1}, got {version}")
-          print(f"Validated cua-fleet patch version {version}")
-          PY
+          if [[ "$VERSION" != "0.1.8" ]]; then
+            echo "::error::This workflow promotes the hash-pinned cua-fleet 0.1.8 wheel set, not $VERSION."
+            exit 1
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-  repackage:
+  promote:
     needs: prepare
-    name: Repackage ${{ matrix.platform }} wheel
+    name: Promote ${{ matrix.platform }} wheel
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -86,28 +65,34 @@ jobs:
         include:
           - platform: linux-x86_64
             runner: ubuntu-22.04
-            wheel: cua_train-0.1.6-py3-none-manylinux_2_34_x86_64.whl
-            sha256: 418db974949f4020fae2f3ed2f5a8d0db6ddce38e34f5db89283ac479d816a55
-            library_suffix: .so
+            wheel: cua_fleet-0.1.8-py3-none-manylinux_2_34_x86_64.whl
+            sha256: 0bac329552d351604ad15b7eb4f4f3ed944921083238d74f51277d657d8f0a34
+            native_library: libcyclops_sdk.so
             audit: auditwheel
           - platform: linux-aarch64
             runner: ubuntu-24.04-arm
-            wheel: cua_train-0.1.6-py3-none-manylinux_2_34_aarch64.whl
-            sha256: 80526bf94ed535383b3dddd9a7da800da9fcb32837c21c2e2caa39390e3548c9
-            library_suffix: .so
+            wheel: cua_fleet-0.1.8-py3-none-manylinux_2_34_aarch64.whl
+            sha256: d7604668a7186d06cefb2bd23974b033c0b2cda61ccbe88d944af622b37f58d3
+            native_library: libcyclops_sdk.so
             audit: auditwheel
           - platform: macos-x86_64
             runner: macos-15-intel
-            wheel: cua_train-0.1.6-py3-none-macosx_10_12_x86_64.whl
-            sha256: 87cb4220054514ac5f44118d490ae404fbca5c97d2b964cd4fcaf1facd391fc0
-            library_suffix: .dylib
+            wheel: cua_fleet-0.1.8-py3-none-macosx_10_12_x86_64.whl
+            sha256: 20611a14c185157e6f41502e1bbdcc1e98663347e94463ca538755b0efc173bb
+            native_library: libcyclops_sdk.dylib
             audit: delocate
           - platform: macos-arm64
             runner: macos-14
-            wheel: cua_train-0.1.6-py3-none-macosx_11_0_arm64.whl
-            sha256: 17563c0504c9270e570332924f3092faec3dcdbf48557a70ee830e165ac7751c
-            library_suffix: .dylib
+            wheel: cua_fleet-0.1.8-py3-none-macosx_11_0_arm64.whl
+            sha256: 7c21d0a36a8d74bfe0768422e4f3d9367ee51837920e2c22ee57521fc93c4f3b
+            native_library: libcyclops_sdk.dylib
             audit: delocate
+          - platform: windows-x86_64
+            runner: windows-latest
+            wheel: cua_fleet-0.1.8-py3-none-win_amd64.whl
+            sha256: d78fe6934a2f650dcf5b105a08833418245c720765da9c3b40e160b86a3d203d
+            native_library: cyclops_sdk.dll
+            audit: none
     steps:
       - uses: actions/checkout@v4
 
@@ -116,50 +101,54 @@ jobs:
           python-version: "3.11"
 
       - name: Download and verify canonical native wheel
+        shell: bash
         env:
           WHEEL: ${{ matrix.wheel }}
           SHA256: ${{ matrix.sha256 }}
         run: |
           set -euo pipefail
+          mkdir -p dist
           curl --fail --location --retry 3 \
-            --output "$WHEEL" \
-            "https://wheels.cua.ai/simple/cua-train/$WHEEL"
+            --output "dist/$WHEEL" \
+            "https://wheels.cua.ai/simple/cua-fleet/$WHEEL"
+          python - "$SHA256" "dist/$WHEEL" <<'PY'
+          import hashlib
+          from pathlib import Path
+          import sys
 
-      - name: Repackage as cua-fleet
-        env:
-          VERSION: ${{ needs.prepare.outputs.version }}
-          WHEEL: ${{ matrix.wheel }}
-          SHA256: ${{ matrix.sha256 }}
-        run: |
-          python .github/scripts/repackage_cua_train_wheel.py \
-            --source "$WHEEL" \
-            --expected-sha256 "$SHA256" \
-            --destination-version "$VERSION" \
-            --outdir dist
-          python .github/scripts/repackage_cua_train_wheel.py --verify dist/*.whl
+          expected, wheel_path = sys.argv[1:]
+          actual = hashlib.sha256(Path(wheel_path).read_bytes()).hexdigest()
+          if actual != expected:
+              raise SystemExit(f"SHA-256 mismatch for {wheel_path}: expected {expected}, got {actual}")
+          PY
 
       - name: Audit native dependencies without modifying the wheel
+        if: matrix.audit != 'none'
+        shell: bash
         env:
           AUDIT: ${{ matrix.audit }}
+          WHEEL: ${{ matrix.wheel }}
         run: |
           set -euo pipefail
           if [[ "$AUDIT" == "auditwheel" ]]; then
             python -m pip install --upgrade auditwheel
-            auditwheel show dist/*.whl
+            auditwheel show "dist/$WHEEL"
           else
             python -m pip install --upgrade delocate
-            delocate-listdeps dist/*.whl
+            delocate-listdeps "dist/$WHEEL"
           fi
 
-      - name: Install only the promoted wheel and load native bindings
+      - name: Install promoted wheel and load native bindings
+        shell: bash
         env:
-          LIBRARY_SUFFIX: ${{ matrix.library_suffix }}
+          WHEEL: ${{ matrix.wheel }}
+          NATIVE_LIBRARY: ${{ matrix.native_library }}
         run: |
           set -euo pipefail
-          python -m venv /tmp/cua-fleet-wheel-smoke
-          /tmp/cua-fleet-wheel-smoke/bin/pip install --no-index --no-deps dist/*.whl
-          /tmp/cua-fleet-wheel-smoke/bin/python - "$LIBRARY_SUFFIX" <<'PY'
+          python -m pip install --no-index --no-deps --target wheel-smoke "dist/$WHEEL"
+          PYTHONPATH=wheel-smoke python - "$NATIVE_LIBRARY" <<'PY'
           import ctypes
+          import os
           from pathlib import Path
           import sys
 
@@ -180,7 +169,10 @@ jobs:
           )
 
           package = Path(fleet_sdk.__file__).resolve().parent
-          native = package / f"libcyclops_sdk{sys.argv[1]}"
+          dll_directory = None
+          if os.name == "nt":
+              dll_directory = os.add_dll_directory(str(package))
+          native = package / sys.argv[1]
           assert native.is_file(), native
           ctypes.CDLL(str(native))
           assert all((
@@ -199,21 +191,30 @@ jobs:
           ))
           PY
 
-      - name: Exercise the example startup boundary without credentials
+      - name: Exercise example startup boundary without credentials
+        shell: bash
         run: |
-          set +e
-          env -i PATH="$PATH" HOME="$HOME" \
-            /tmp/cua-fleet-wheel-smoke/bin/python \
-            libs/fleet/sdk-bindings/examples/python/live_app_controlled.py \
-            > /tmp/live-app.stdout 2> /tmp/live-app.stderr
-          status=$?
-          set -e
-          test "$status" -ne 0
-          grep -Fq "KeyError: 'CUA_CLIENT_ID'" /tmp/live-app.stderr
-          if grep -Eq "ModuleNotFoundError|cannot open shared object|Library not loaded" /tmp/live-app.stderr; then
-            cat /tmp/live-app.stderr
-            exit 1
-          fi
+          set -euo pipefail
+          PYTHONPATH=wheel-smoke python - <<'PY'
+          import os
+          from pathlib import Path
+          import subprocess
+          import sys
+
+          environment = os.environ.copy()
+          environment.pop("CUA_CLIENT_ID", None)
+          environment.pop("CUA_CLIENT_SECRET", None)
+          result = subprocess.run(
+              [sys.executable, "libs/fleet/sdk-bindings/examples/python/live_app_controlled.py"],
+              env=environment,
+              capture_output=True,
+              text=True,
+          )
+          assert result.returncode != 0, result.stdout
+          assert "KeyError: 'CUA_CLIENT_ID'" in result.stderr, result.stderr
+          native_errors = ("ModuleNotFoundError", "cannot open shared object", "Library not loaded")
+          assert not any(error in result.stderr for error in native_errors), result.stderr
+          PY
 
       - uses: actions/upload-artifact@v4
         with:
@@ -222,10 +223,9 @@ jobs:
           if-no-files-found: error
 
   validate:
-    needs: [prepare, repackage]
+    needs: [prepare, promote]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -233,43 +233,41 @@ jobs:
         with:
           path: dist
           merge-multiple: true
-      - name: Verify four promoted wheels and packaging metadata
+      - name: Verify five promoted wheels and packaging metadata
         run: |
           set -euo pipefail
           python -m pip install --upgrade twine
           python -m twine check dist/*.whl
-          python .github/scripts/repackage_cua_train_wheel.py --verify dist/*.whl
           python - "${{ needs.prepare.outputs.version }}" dist <<'PY'
+          import hashlib
           from pathlib import Path
           import sys
+          from zipfile import ZipFile
 
           version, dist_directory = sys.argv[1:]
-          wheels = sorted(Path(dist_directory).glob("*.whl"))
           expected = {
-              f"cua_fleet-{version}-py3-none-manylinux_2_34_x86_64.whl",
-              f"cua_fleet-{version}-py3-none-manylinux_2_34_aarch64.whl",
-              f"cua_fleet-{version}-py3-none-macosx_10_12_x86_64.whl",
-              f"cua_fleet-{version}-py3-none-macosx_11_0_arm64.whl",
+              f"cua_fleet-{version}-py3-none-manylinux_2_34_x86_64.whl": "0bac329552d351604ad15b7eb4f4f3ed944921083238d74f51277d657d8f0a34",
+              f"cua_fleet-{version}-py3-none-manylinux_2_34_aarch64.whl": "d7604668a7186d06cefb2bd23974b033c0b2cda61ccbe88d944af622b37f58d3",
+              f"cua_fleet-{version}-py3-none-macosx_10_12_x86_64.whl": "20611a14c185157e6f41502e1bbdcc1e98663347e94463ca538755b0efc173bb",
+              f"cua_fleet-{version}-py3-none-macosx_11_0_arm64.whl": "7c21d0a36a8d74bfe0768422e4f3d9367ee51837920e2c22ee57521fc93c4f3b",
+              f"cua_fleet-{version}-py3-none-win_amd64.whl": "d78fe6934a2f650dcf5b105a08833418245c720765da9c3b40e160b86a3d203d",
           }
-          actual = {wheel.name for wheel in wheels}
-          assert actual == expected, (actual, expected)
+          wheels = {wheel.name: wheel for wheel in Path(dist_directory).glob("*.whl")}
+          assert set(wheels) == set(expected), (set(wheels), set(expected))
+          for name, digest in expected.items():
+              wheel = wheels[name]
+              assert hashlib.sha256(wheel.read_bytes()).hexdigest() == digest, name
+              with ZipFile(wheel) as archive:
+                  metadata_name = next(
+                      candidate for candidate in archive.namelist() if candidate.endswith(".dist-info/METADATA")
+                  )
+                  metadata = archive.read(metadata_name).decode()
+                  assert "Name: cua-fleet\n" in metadata, name
+                  assert f"Version: {version}\n" in metadata, name
           PY
 
-  unsupported-windows:
-    needs: [prepare, repackage]
-    runs-on: windows-latest
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          path: dist
-          merge-multiple: true
-      - name: Reject native wheels on Windows
-        shell: pwsh
-        run: |
-          python -c "import subprocess, sys; result = subprocess.run([sys.executable, '-m', 'pip', 'install', '--no-index', '--no-deps', '--find-links', 'dist', 'cua-fleet==${{ needs.prepare.outputs.version }}']); raise SystemExit('Windows unexpectedly resolved a native cua-fleet wheel' if result.returncode == 0 else 0)"
-
   publish:
-    needs: [prepare, validate, unsupported-windows]
+    needs: [prepare, validate]
     runs-on: ubuntu-latest
     environment: pypi-fleet
     steps:
@@ -291,13 +289,21 @@ jobs:
           import sys
 
           version, dist_dir, metadata_path = sys.argv[1:]
-          expected = {wheel.name: hashlib.sha256(wheel.read_bytes()).hexdigest() for wheel in Path(dist_dir).glob("*.whl")}
+          expected = {
+              wheel.name: hashlib.sha256(wheel.read_bytes()).hexdigest()
+              for wheel in Path(dist_dir).glob("*.whl")
+          }
           releases = json.load(open(metadata_path))["releases"]
-          existing = {item["filename"]: item["digests"]["sha256"] for item in releases.get(version, [])}
+          existing = {
+              item["filename"]: item["digests"]["sha256"]
+              for item in releases.get(version, [])
+          }
           unexpected = set(existing) - set(expected)
           mismatched = {name for name, digest in existing.items() if expected.get(name) != digest}
           if unexpected or mismatched:
-              raise SystemExit(f"PyPI {version} conflicts: unexpected={unexpected}, mismatched={mismatched}")
+              raise SystemExit(
+                  f"PyPI {version} conflicts: unexpected={unexpected}, mismatched={mismatched}"
+              )
           missing = sorted(set(expected) - set(existing))
           Path("/tmp/cua-fleet-missing-wheels.txt").write_text("\n".join(missing))
           PY


### PR DESCRIPTION
## Problem

`cua-sandbox==0.2.0` requires `cua-fleet==0.1.8`, but public PyPI only contains `cua-fleet` through `0.1.7`. The Fleet release workflow still validates the old `0.0.x` line, repackages stale `cua_train==0.1.6` wheels, and rejects Windows.

## Change

- promote the canonical `cua-fleet==0.1.8` SDK wheel set directly from `wheels.cua.ai`
- pin and verify SHA-256 for Linux x86_64/aarch64, macOS x86_64/arm64, and Windows x86_64
- install and load each native SDK wheel on its matching runner
- reconcile PyPI and upload only missing hash-matching files
- update the release wiring regression test

## Validation

- `uv run --frozen --with pytest pytest -q .github/scripts/tests` (`168 passed`, `18 subtests passed`)
- local Linux x86_64 wheel install/import/native `ctypes.CDLL` smoke
- `actionlint` passes (ignoring only the pre-existing custom `macos-15-intel` runner label warning)
- all five downloaded wheel hashes match the canonical index
