### PR TITLE
docs: rename Tutorials to Get Started

### DIFF
--- a/docs/content/docs/how-to-guides/recipes/automate-a-legacy-windows-app-behind-a-vpn.mdx
+++ b/docs/content/docs/how-to-guides/recipes/automate-a-legacy-windows-app-behind-a-vpn.mdx
@@ -11,7 +11,7 @@ When a desktop app has **no API** and only runs **behind the corporate VPN**, dr
 <VideoDemo
   src="https://github.com/user-attachments/assets/11b248e5-d505-4349-aaae-ad9f95a1162f"
   poster="https://github.com/user-attachments/assets/0fb62243-56ec-4d51-8771-35640a5e6031"
-  title="Drive a legacy postal app while the terminal stays in front"
+  title="Drive a legacy postal app with Cua Driver"
   sourceUrl="https://x.com/trycua/status/2059693301276565841"
 >
   Claude Code fills shipment details and prints receipts in a Windows desktop app with no API. The

--- a/docs/content/docs/tutorials/drive-your-first-app.mdx
+++ b/docs/content/docs/tutorials/drive-your-first-app.mdx
@@ -14,13 +14,13 @@ Linux.
 New to agents that operate applications? Start with [What is computer use?](/concepts/what-is-computer-use) for the model behind the workflow, then return here to build one.
 
 <VideoDemo
-  src="https://github.com/user-attachments/assets/354af433-8769-44ff-beab-b5cb02ff798e"
-  poster="https://github.com/user-attachments/assets/6f878582-8f5d-4400-be44-fc503fcbc1ab"
-  title="Preview: agents play a Windows piano app"
-  sourceUrl="https://x.com/francedot/status/2062231318294131130"
+  src="https://github.com/user-attachments/assets/11b248e5-d505-4349-aaae-ad9f95a1162f"
+  poster="https://github.com/user-attachments/assets/0fb62243-56ec-4d51-8771-35640a5e6031"
+  title="Drive a legacy postal app with Cua Driver"
+  sourceUrl="https://x.com/trycua/status/2059693301276565841"
   className="my-8"
 >
-  Cua Driver coordinates several agent cursors to play a Windows piano app at Microsoft Build. You
+  Cua Driver fills shipment details and prints receipts in a Windows desktop app with no API. You
   will start with a smaller Calculator task below.
 </VideoDemo>
 

--- a/docs/content/docs/tutorials/index.mdx
+++ b/docs/content/docs/tutorials/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: 'Tutorials'
+title: 'Get Started'
 description: 'Learn Cua by following end-to-end builds.'
 ---
 
-Tutorials teach Cua by building something end to end. Start here if you are new to Cua. Each tutorial is *one happy path* you can follow from start to finish.
+Get started with Cua by building something end to end. Each tutorial is *one happy path* you can follow from start to finish.
 
 - [Drive your first app with Cua Driver](/tutorials/drive-your-first-app) - operate a native app in the background.
 - [Your first local sandbox](/tutorials/your-first-local-sandbox) - start a disposable Linux desktop with Docker.

--- a/docs/content/docs/tutorials/meta.json
+++ b/docs/content/docs/tutorials/meta.json
@@ -1,5 +1,5 @@
 {
-  "title": "Tutorials",
+  "title": "Get Started",
   "icon": "GraduationCap",
   "pages": [
     "index",


### PR DESCRIPTION
## Summary

- rename the Tutorials navigation label and landing page to **Get Started**
- keep the existing `docs/content/docs/tutorials` source paths and every `/tutorials/...` href unchanged
- retain the tutorial structure so the Cloud docs projection can expose it as one global onboarding section
- reuse the legacy-Windows recipe video and poster in **Drive your first app**, with tutorial-specific caption copy

## Validation

- `jq empty docs/content/docs/tutorials/meta.json`
- `./node_modules/.bin/tsx scripts/check-hygiene.ts`
- `./node_modules/.bin/tsx scripts/check-links.ts` — 0 errors
- production-style Cloud docs sync fetched this exact commit and confirmed both pages use the same video asset
- audited the final diff and verified every existing tutorial href remains unchanged

## Companion change

- trycua/cloud#6742

The Cloud companion PR is pinned to this exact commit for its Vercel preview. After this PR merges, the automatic docs sync can replace that pin with the resulting main commit.