### PR TITLE
fix(lume): handle reused OCI disk layer digests

### DIFF
--- a/libs/lume/src/ContainerRegistry/ImageContainerRegistry.swift
+++ b/libs/lume/src/ContainerRegistry/ImageContainerRegistry.swift
@@ -40,6 +40,62 @@ func sha256OfFile(at url: URL) throws -> String {
     return hash.map { String(format: "%02x", $0) }.joined()
 }
 
+private let sparseHoleGranularityBytes = 4 * 1024 * 1024
+private let sparseZeroChunk = Data(count: sparseHoleGranularityBytes)
+
+/// Gunzip-decompress a chunk and write it sparsely into an output file handle,
+/// skipping zero-filled 4 MiB blocks to create holes in the sparse file.
+func gunzipChunkAndWriteSparse(
+    inputPath: URL, outputHandle: FileHandle, startOffset: UInt64
+) throws -> UInt64 {
+    guard FileManager.default.fileExists(atPath: inputPath.path) else {
+        throw PullError.layerDownloadFailed(inputPath.lastPathComponent)
+    }
+
+    // Apple's Compression framework (.zlib) only handles raw DEFLATE, not
+    // gzip headers, so stream through the system gunzip executable first.
+    let decompressedPath = inputPath.appendingPathExtension("raw")
+    defer { try? FileManager.default.removeItem(at: decompressedPath) }
+
+    FileManager.default.createFile(atPath: decompressedPath.path, contents: nil)
+    let tempHandle = try FileHandle(forWritingTo: decompressedPath)
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/gunzip")
+    process.arguments = ["-c", inputPath.path]
+    process.standardOutput = tempHandle
+    try process.run()
+    process.waitUntilExit()
+    try tempHandle.close()
+
+    guard process.terminationStatus == 0 else {
+        throw PullError.layerDownloadFailed(inputPath.lastPathComponent)
+    }
+
+    let readHandle = try FileHandle(forReadingFrom: decompressedPath)
+    defer { try? readHandle.close() }
+
+    var currentWriteOffset = startOffset
+    var totalDecompressedBytes: UInt64 = 0
+
+    while true {
+        let decompressedData = readHandle.readData(ofLength: sparseHoleGranularityBytes)
+        if decompressedData.isEmpty { break }
+
+        if decompressedData.count == sparseHoleGranularityBytes
+            && decompressedData == sparseZeroChunk
+        {
+            currentWriteOffset += UInt64(decompressedData.count)
+        } else {
+            try outputHandle.seek(toOffset: currentWriteOffset)
+            try outputHandle.write(contentsOf: decompressedData)
+            currentWriteOffset += UInt64(decompressedData.count)
+        }
+        totalDecompressedBytes += UInt64(decompressedData.count)
+    }
+
+    return totalDecompressedBytes
+}
+
 // Push-related errors
 enum PushError: Error {
     case uploadInitiationFailed
@@ -102,11 +158,47 @@ struct OCIConfig: Codable {
     let annotations: Annotations?  // Optional annotations
 }
 
-struct Layer: Codable, Equatable {
+struct Layer: Codable, Equatable, Sendable {
     let mediaType: String
     let digest: String
     let size: Int
     let annotations: [String: String]?
+}
+
+struct OCIChunkReference: Equatable, Sendable {
+    let index: Int
+    let offset: UInt64
+}
+
+struct OCIChunkGroup: Equatable, Sendable {
+    let layer: Layer
+    var references: [OCIChunkReference]
+}
+
+/// Groups logical disk parts by their shared OCI blob while preserving the
+/// order in which each unique digest first appears in the manifest.
+func groupOCIChunksByDigest(_ layers: [Layer]) -> [OCIChunkGroup] {
+    var groups: [OCIChunkGroup] = []
+    var groupIndexByDigest: [String: Int] = [:]
+
+    for (index, layer) in layers.enumerated() {
+        let reference = OCIChunkReference(
+            index: index,
+            offset: UInt64(layer.annotations?[OCIAnnotation.partOffset] ?? "0") ?? 0)
+        if let groupIndex = groupIndexByDigest[layer.digest] {
+            groups[groupIndex].references.append(reference)
+        } else {
+            groupIndexByDigest[layer.digest] = groups.count
+            groups.append(OCIChunkGroup(layer: layer, references: [reference]))
+        }
+    }
+
+    return groups
+}
+
+func uniqueLayersByDigest(_ layers: [Layer]) -> [Layer] {
+    var seenDigests: Swift.Set<String> = []
+    return layers.filter { seenDigests.insert($0.digest).inserted }
 }
 
 struct Manifest: Codable {
@@ -3900,8 +3992,8 @@ class ImageContainerRegistry: ImageRegistry, @unchecked Sendable {
         inputPath: String, outputHandle: FileHandle, startOffset: UInt64
     ) throws -> UInt64 {
         guard FileManager.default.fileExists(atPath: inputPath) else {
-            Logger.error("Compressed chunk not found at: \(inputPath)")
-            return 0  // Or throw an error
+            throw PullError.layerDownloadFailed(
+                URL(fileURLWithPath: inputPath).lastPathComponent)
         }
 
         let sourceData = try Data(
@@ -4096,62 +4188,6 @@ class ImageContainerRegistry: ImageRegistry, @unchecked Sendable {
         guard process.terminationStatus == 0 else {
             throw PullError.layerDownloadFailed(inputPath.lastPathComponent)
         }
-    }
-
-    /// Gunzip-decompress a chunk and write it sparsely into an output file handle,
-    /// skipping zero-filled 4 MB blocks to create holes in the sparse file.
-    private func gunzipChunkAndWriteSparse(
-        inputPath: URL, outputHandle: FileHandle, startOffset: UInt64
-    ) throws -> UInt64 {
-        guard FileManager.default.fileExists(atPath: inputPath.path) else {
-            Logger.error("Compressed chunk not found at: \(inputPath.path)")
-            return 0
-        }
-
-        // Decompress gzip to a temp file via /usr/bin/gunzip, then read in
-        // granularity-sized blocks for sparse writing.  Apple's Compression
-        // framework (.zlib) only handles raw DEFLATE — not gzip headers.
-        let decompressedPath = inputPath.appendingPathExtension("raw")
-        defer { try? FileManager.default.removeItem(at: decompressedPath) }
-
-        FileManager.default.createFile(atPath: decompressedPath.path, contents: nil)
-        let tempHandle = try FileHandle(forWritingTo: decompressedPath)
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/gunzip")
-        process.arguments = ["-c", inputPath.path]
-        process.standardOutput = tempHandle
-        try process.run()
-        process.waitUntilExit()
-        try tempHandle.close()
-
-        guard process.terminationStatus == 0 else {
-            throw PullError.layerDownloadFailed(inputPath.lastPathComponent)
-        }
-
-        let readHandle = try FileHandle(forReadingFrom: decompressedPath)
-        defer { try? readHandle.close() }
-
-        var currentWriteOffset = startOffset
-        var totalDecompressedBytes: UInt64 = 0
-
-        while true {
-            let decompressedData = readHandle.readData(ofLength: Self.holeGranularityBytes)
-            if decompressedData.isEmpty { break }
-
-            if decompressedData.count == Self.holeGranularityBytes
-                && decompressedData == Self.zeroChunk
-            {
-                // Zero chunk — skip write, leave as sparse hole
-                currentWriteOffset += UInt64(decompressedData.count)
-            } else {
-                try outputHandle.seek(toOffset: currentWriteOffset)
-                try outputHandle.write(contentsOf: decompressedData)
-                currentWriteOffset += UInt64(decompressedData.count)
-            }
-            totalDecompressedBytes += UInt64(decompressedData.count)
-        }
-
-        return totalDecompressedBytes
     }
 
     /// Build the OCI config JSON blob from a VMConfig.
@@ -4702,6 +4738,54 @@ class ImageContainerRegistry: ImageRegistry, @unchecked Sendable {
         }
     }
 
+    private func downloadOCIChunkGroup(
+        _ chunkGroup: OCIChunkGroup,
+        repository: String,
+        token: String,
+        manifestId: String,
+        tempDir: URL,
+        pullProgress: LayerProgressDisplay
+    ) async throws -> (String, URL) {
+        for reference in chunkGroup.references {
+            await pullProgress.updateStatus(
+                id: "chunk-\(reference.index)", status: .downloading)
+        }
+
+        let chunk = chunkGroup.layer
+        let cachedChunkPath = cachingEnabled
+            ? getCachedLayerPath(manifestId: manifestId, digest: chunk.digest)
+            : nil
+        let blobDest = tempDir.appendingPathComponent(
+            chunk.digest.replacingOccurrences(of: ":", with: "_") + ".gz")
+
+        if let cached = cachedChunkPath,
+            FileManager.default.fileExists(atPath: cached.path)
+        {
+            Logger.info(
+                "Chunk found in cache, skipping download (\(chunk.digest.prefix(19))…)"
+            )
+            await downloadProgress.addProgress(Int64(chunk.size))
+            // Each pull gets its own path so the sibling `.raw` file created by
+            // sparse decompression cannot race with another Lume process.
+            try FileManager.default.copyItem(at: cached, to: blobDest)
+        } else {
+            try await downloadLayer(
+                repository: repository,
+                digest: chunk.digest,
+                mediaType: chunk.mediaType,
+                token: token,
+                to: blobDest,
+                maxRetries: 5,
+                progress: downloadProgress
+            )
+            if let cached = cachedChunkPath {
+                try? FileManager.default.copyItem(at: blobDest, to: cached)
+            }
+        }
+
+        return (chunk.digest, blobDest)
+    }
+
     /// Pull an OCI-compliant image (kubelet format) into `destination` as a Lume VM directory.
     private func pullOCI(
         manifest: Manifest,
@@ -4743,8 +4827,12 @@ class ImageContainerRegistry: ImageRegistry, @unchecked Sendable {
 
         // Set total download size so progress % is meaningful
         let allLayers = manifest.layers + (manifest.config.map { [$0] } ?? [])
-        let totalDownloadBytes = allLayers.reduce(Int64(0)) { $0 + Int64($1.size) }
-        let totalFiles = allLayers.filter { $0.mediaType != "application/vnd.oci.empty.v1+json" }.count
+        let downloadableLayers = uniqueLayersByDigest(
+            allLayers.filter { $0.mediaType != "application/vnd.oci.empty.v1+json" })
+        let totalDownloadBytes = downloadableLayers.reduce(Int64(0)) {
+            $0 + Int64($1.size)
+        }
+        let totalFiles = downloadableLayers.count
         await downloadProgress.setTotal(totalDownloadBytes, files: totalFiles)
 
         // ── Download config & aux (shared by both paths) ─────────────────────
@@ -4927,97 +5015,71 @@ class ImageContainerRegistry: ImageRegistry, @unchecked Sendable {
                     mode: .pull)
             }
 
-            // Download chunks in parallel (4 concurrent)
-            // Result tuple: (chunkIndex, blobPath, chunkOffset, isFromCache)
-            try await withThrowingTaskGroup(of: (Int, URL, UInt64, Bool).self) { group in
-                let maxConcurrent = 4
-                var enqueued = 0
+            let chunkGroups = groupOCIChunksByDigest(sortedChunks)
+            let chunkGroupsByDigest = Dictionary(
+                uniqueKeysWithValues: chunkGroups.map { ($0.layer.digest, $0) })
+            if chunkGroups.count < sortedChunks.count {
+                Logger.info(
+                    "Reusing \(chunkGroups.count) unique blobs across \(sortedChunks.count) disk parts"
+                )
+            }
 
-                for (idx, chunk) in sortedChunks.enumerated() {
-                    // Throttle: wait for one to complete before adding more
-                    if enqueued >= maxConcurrent {
-                        guard let result = try await group.next() else {
-                            Logger.error("Task group unexpectedly empty while throttling downloads")
-                            continue
-                        }
-                        let (completedIdx, completedPath, completedOffset, completedFromCache) =
-                            result
-                        await pullProgress.updateStatus(
-                            id: "chunk-\(completedIdx)", status: .decompressing)
-                        let handle = try FileHandle(forWritingTo: diskDest)
-                        let _ = try gunzipChunkAndWriteSparse(
-                            inputPath: completedPath, outputHandle: handle,
-                            startOffset: completedOffset)
-                        try handle.close()
-                        if !completedFromCache {
-                            try? FileManager.default.removeItem(at: completedPath)
-                        }
-                        await pullProgress.markDone(id: "chunk-\(completedIdx)")
-                    }
-
-                    let chunkOffset =
-                        UInt64(chunk.annotations?[OCIAnnotation.partOffset] ?? "0") ?? 0
-
+            // Download up to four unique blobs concurrently. As each blob
+            // arrives, write every logical part that references it before
+            // removing the per-pull copy.
+            try await withThrowingTaskGroup(of: (String, URL).self) { group in
+                let initialCount = min(4, chunkGroups.count)
+                for groupIndex in 0..<initialCount {
+                    let chunkGroup = chunkGroups[groupIndex]
                     group.addTask {
-                        let cachedChunkPath = self.cachingEnabled
-                            ? self.getCachedLayerPath(manifestId: manifestId, digest: chunk.digest)
-                            : nil
-                        let blobDest: URL
-                        if let cached = cachedChunkPath,
-                            FileManager.default.fileExists(atPath: cached.path)
-                        {
-                            await pullProgress.updateStatus(
-                                id: "chunk-\(idx)", status: .downloading)
-                            Logger.info(
-                                "Chunk \(idx) found in cache, skipping download (\(chunk.digest.prefix(19))…)"
-                            )
-                            await self.downloadProgress.addProgress(Int64(chunk.size))
-                            // Copy to a unique temp path to avoid sibling .raw race when
-                            // multiple pulls decompress the same cached file concurrently.
-                            let tmpCopy = tempDir.appendingPathComponent(
-                                UUID().uuidString + ".gz")
-                            try FileManager.default.copyItem(at: cached, to: tmpCopy)
-                            blobDest = tmpCopy
-                            return (idx, blobDest, chunkOffset, false)
-                        } else {
-                            blobDest = tempDir.appendingPathComponent(
-                                chunk.digest.replacingOccurrences(of: ":", with: "_"))
-                            await pullProgress.updateStatus(
-                                id: "chunk-\(idx)", status: .downloading)
-                            try await self.downloadLayer(
-                                repository: repository,
-                                digest: chunk.digest,
-                                mediaType: chunk.mediaType,
-                                token: token,
-                                to: blobDest,
-                                maxRetries: 5,
-                                progress: self.downloadProgress
-                            )
-                            // Save chunk to cache
-                            if let cached = cachedChunkPath {
-                                try? FileManager.default.copyItem(at: blobDest, to: cached)
-                            }
-                            return (idx, blobDest, chunkOffset, false)
-                        }
+                        try await self.downloadOCIChunkGroup(
+                            chunkGroup,
+                            repository: repository,
+                            token: token,
+                            manifestId: manifestId,
+                            tempDir: tempDir,
+                            pullProgress: pullProgress)
                     }
-                    enqueued += 1
                 }
 
-                // Drain remaining
-                for try await (completedIdx, completedPath, completedOffset, completedFromCache)
-                    in group
-                {
-                    await pullProgress.updateStatus(
-                        id: "chunk-\(completedIdx)", status: .decompressing)
-                    let handle = try FileHandle(forWritingTo: diskDest)
-                    let _ = try gunzipChunkAndWriteSparse(
-                        inputPath: completedPath, outputHandle: handle,
-                        startOffset: completedOffset)
-                    try handle.close()
-                    if !completedFromCache {
-                        try? FileManager.default.removeItem(at: completedPath)
+                var nextGroupIndex = initialCount
+                while let (completedDigest, completedPath) = try await group.next() {
+                    guard let completedGroup = chunkGroupsByDigest[completedDigest] else {
+                        throw PullError.reassemblyFailed(
+                            "Downloaded an unexpected OCI blob \(completedDigest)")
                     }
-                    await pullProgress.markDone(id: "chunk-\(completedIdx)")
+
+                    for reference in completedGroup.references {
+                        await pullProgress.updateStatus(
+                            id: "chunk-\(reference.index)", status: .decompressing)
+                        let handle = try FileHandle(forWritingTo: diskDest)
+                        do {
+                            let _ = try gunzipChunkAndWriteSparse(
+                                inputPath: completedPath,
+                                outputHandle: handle,
+                                startOffset: reference.offset)
+                            try handle.close()
+                        } catch {
+                            try? handle.close()
+                            throw error
+                        }
+                        await pullProgress.markDone(id: "chunk-\(reference.index)")
+                    }
+                    try? FileManager.default.removeItem(at: completedPath)
+
+                    if nextGroupIndex < chunkGroups.count {
+                        let chunkGroup = chunkGroups[nextGroupIndex]
+                        nextGroupIndex += 1
+                        group.addTask {
+                            try await self.downloadOCIChunkGroup(
+                                chunkGroup,
+                                repository: repository,
+                                token: token,
+                                manifestId: manifestId,
+                                tempDir: tempDir,
+                                pullProgress: pullProgress)
+                        }
+                    }
                 }
             }
 

--- a/libs/lume/tests/OCIChunkReuseTests.swift
+++ b/libs/lume/tests/OCIChunkReuseTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Testing
+
+@testable import lume
+
+struct OCIChunkReuseTests {
+  private func makeLayer(digest: String, part: Int, offset: UInt64) -> Layer {
+    Layer(
+      mediaType: OCIMediaType.disk,
+      digest: digest,
+      size: 512,
+      annotations: [
+        OCIAnnotation.partNumber: String(part),
+        OCIAnnotation.partOffset: String(offset),
+      ])
+  }
+
+  private func gzip(_ data: Data, to destination: URL) throws {
+    let source = destination.deletingPathExtension().appendingPathExtension("raw-source")
+    try data.write(to: source)
+    defer { try? FileManager.default.removeItem(at: source) }
+
+    FileManager.default.createFile(atPath: destination.path, contents: nil)
+    let output = try FileHandle(forWritingTo: destination)
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/gzip")
+    process.arguments = ["-c", source.path]
+    process.standardOutput = output
+    try process.run()
+    process.waitUntilExit()
+    try output.close()
+    #expect(process.terminationStatus == 0)
+  }
+
+  @Test("logical OCI chunks are grouped by digest without losing offsets")
+  func groupsRepeatedDigests() {
+    let layers = [
+      makeLayer(digest: "sha256:nonzero", part: 0, offset: 0),
+      makeLayer(digest: "sha256:zero", part: 1, offset: 4_194_304),
+      makeLayer(digest: "sha256:nonzero", part: 2, offset: 8_388_608),
+      makeLayer(digest: "sha256:zero", part: 3, offset: 12_582_912),
+    ]
+
+    let groups = groupOCIChunksByDigest(layers)
+
+    #expect(groups.count == 2)
+    #expect(groups[0].layer.digest == "sha256:nonzero")
+    #expect(
+      groups[0].references
+        == [
+          OCIChunkReference(index: 0, offset: 0),
+          OCIChunkReference(index: 2, offset: 8_388_608),
+        ])
+    #expect(groups[1].layer.digest == "sha256:zero")
+    #expect(
+      groups[1].references
+        == [
+          OCIChunkReference(index: 1, offset: 4_194_304),
+          OCIChunkReference(index: 3, offset: 12_582_912),
+        ])
+    #expect(uniqueLayersByDigest(layers).map(\.digest) == ["sha256:nonzero", "sha256:zero"])
+  }
+
+  @Test("one compressed zero or nonzero blob can populate multiple logical parts")
+  func reusesCompressedBlobAtMultipleOffsets() throws {
+    let tempDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("lume-oci-chunk-reuse-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let nonzero = Data("reused-nonzero-chunk".utf8)
+    let zero = Data(count: 4 * 1024 * 1024)
+    let nonzeroGzip = tempDir.appendingPathComponent("nonzero.gz")
+    let zeroGzip = tempDir.appendingPathComponent("zero.gz")
+    try gzip(nonzero, to: nonzeroGzip)
+    try gzip(zero, to: zeroGzip)
+
+    let outputURL = tempDir.appendingPathComponent("disk.img")
+    FileManager.default.createFile(atPath: outputURL.path, contents: nil)
+    let output = try FileHandle(forWritingTo: outputURL)
+    defer { try? output.close() }
+    try output.truncate(atOffset: 12 * 1024 * 1024)
+
+    #expect(
+      try gunzipChunkAndWriteSparse(
+        inputPath: nonzeroGzip, outputHandle: output, startOffset: 0)
+        == UInt64(nonzero.count))
+    #expect(
+      try gunzipChunkAndWriteSparse(
+        inputPath: nonzeroGzip, outputHandle: output, startOffset: 64)
+        == UInt64(nonzero.count))
+    #expect(
+      try gunzipChunkAndWriteSparse(
+        inputPath: zeroGzip, outputHandle: output, startOffset: 4 * 1024 * 1024)
+        == UInt64(zero.count))
+    #expect(
+      try gunzipChunkAndWriteSparse(
+        inputPath: zeroGzip, outputHandle: output, startOffset: 8 * 1024 * 1024)
+        == UInt64(zero.count))
+
+    let reader = try FileHandle(forReadingFrom: outputURL)
+    defer { try? reader.close() }
+    try reader.seek(toOffset: 0)
+    #expect(reader.readData(ofLength: nonzero.count) == nonzero)
+    try reader.seek(toOffset: 64)
+    #expect(reader.readData(ofLength: nonzero.count) == nonzero)
+    try reader.seek(toOffset: 4 * 1024 * 1024)
+    #expect(reader.readData(ofLength: 4096) == Data(count: 4096))
+    try reader.seek(toOffset: 8 * 1024 * 1024)
+    #expect(reader.readData(ofLength: 4096) == Data(count: 4096))
+  }
+
+  @Test("a missing compressed chunk fails closed")
+  func missingCompressedChunkThrows() throws {
+    let tempDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("lume-oci-missing-chunk-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let outputURL = tempDir.appendingPathComponent("disk.img")
+    FileManager.default.createFile(atPath: outputURL.path, contents: nil)
+    let output = try FileHandle(forWritingTo: outputURL)
+    defer { try? output.close() }
+    let missing = tempDir.appendingPathComponent("missing.gz")
+
+    do {
+      _ = try gunzipChunkAndWriteSparse(
+        inputPath: missing, outputHandle: output, startOffset: 0)
+      Issue.record("Expected a missing compressed chunk to fail the pull")
+    } catch PullError.layerDownloadFailed(let filename) {
+      #expect(filename == "missing.gz")
+    } catch {
+      Issue.record("Unexpected error: \(error)")
+    }
+  }
+}


### PR DESCRIPTION
## What changed

- group OCI disk descriptors by digest before download
- download each unique blob once, then write it to every referenced disk offset
- keep each per-pull blob until all references have been written
- isolate cached blobs per pull so sibling decompression files cannot collide
- fail the pull when a compressed chunk is missing instead of treating it as a sparse hole
- count unique blobs in download progress

## Why

OCI manifests may reuse one blob digest for several logical disk parts. The pull path used the digest as the temporary filename while scheduling every part independently. Concurrent tasks could overwrite or remove the shared file before another task decompressed it. Missing files then returned zero bytes, which could silently corrupt repeated non-zero chunks.

## Impact

Repeated zero and non-zero chunks now share one safe download, and missing compressed input fails closed.

## Checks

Exact candidate: `5502da8309f3fd47183ed8dba20e8f8bbb6dd1d3`

- `swift test --package-path libs/lume --filter OCIChunkReuseTests` — 3 tests passed
- `swift test --package-path libs/lume` — 110 tests passed
- `swift build --package-path libs/lume -c release`
- `ubuntu-noble-vanilla:latest` — 26 unique blobs populated 40 logical parts; 40/40 completed in 41s with no missing-chunk or error lines; valid 20 GiB protective-MBR/GPT disk
- `macos-tahoe-vanilla:latest` — 59 unique blobs populated 200 logical parts; 200/200 completed in 4m08s with no missing-chunk or error lines; valid 100 GiB protective-MBR/GPT sparse disk

Both disposable verification VMs were deleted after validation.

Closes #3065