### PR TITLE
fix(cua-driver): preserve direct MCP session ownership

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-core/src/server.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/server.rs
@@ -852,6 +852,33 @@ pub async fn handle_request(
     id: serde_json::Value,
     provider: &dyn ToolProvider,
 ) -> Response {
+    handle_request_inner(req, id, provider, None).await
+}
+
+/// Dispatch one MCP request with a transport identity proved by the local
+/// adapter rather than supplied by the MCP client.
+///
+/// The ordinary untrusted entry point above must continue to discard every
+/// reserved argument. Direct stdio and authenticated HTTP each own a transport
+/// lease, so their adapters pass that lease here after parsing the untrusted
+/// request. The inner boundary sanitizes caller claims first and then stamps
+/// this trusted owner onto both implicit and explicitly named lifecycle
+/// sessions.
+pub async fn handle_request_with_transport_session(
+    req: Request,
+    id: serde_json::Value,
+    provider: &dyn ToolProvider,
+    transport_session: &str,
+) -> Response {
+    handle_request_inner(req, id, provider, Some(transport_session)).await
+}
+
+async fn handle_request_inner(
+    req: Request,
+    id: serde_json::Value,
+    provider: &dyn ToolProvider,
+    transport_session: Option<&str>,
+) -> Response {
     match req.method.as_str() {
         "initialize" => Response::ok(id, initialize_result()),
 
@@ -877,17 +904,19 @@ pub async fn handle_request(
                     .and_then(serde_json::Value::as_str)
                     .filter(|session| !session.is_empty())
                     .map(str::to_owned);
-                if let (Some(arguments), Some(session)) =
-                    (call.args.as_object_mut(), public_session)
-                {
-                    arguments.insert(
-                        "_session_id".to_owned(),
-                        serde_json::Value::String(session.clone()),
-                    );
-                    arguments.insert(
-                        "_transport_session_id".to_owned(),
-                        serde_json::Value::String(session.clone()),
-                    );
+                if let Some(arguments) = call.args.as_object_mut() {
+                    if let Some(session) = public_session.as_deref().or(transport_session) {
+                        arguments.insert(
+                            "_session_id".to_owned(),
+                            serde_json::Value::String(session.to_owned()),
+                        );
+                    }
+                    if let Some(owner) = transport_session.or(public_session.as_deref()) {
+                        arguments.insert(
+                            "_transport_session_id".to_owned(),
+                            serde_json::Value::String(owner.to_owned()),
+                        );
+                    }
                 }
                 if call.name == "browser_prepare" {
                     if let Some(arguments) = call.args.as_object_mut() {
@@ -989,6 +1018,75 @@ mod observation_tests {
         assert_eq!(arguments["_transport_session_id"], "public");
         assert_eq!(arguments["_cua_browser_download_mcp_host_approved"], true);
         assert!(arguments.get("_protected_process_fingerprint").is_none());
+    }
+
+    #[tokio::test]
+    async fn trusted_transport_boundary_keeps_public_label_separate_from_owner() {
+        let provider = CapturingProvider {
+            arguments: Mutex::new(None),
+        };
+        let request: Request = serde_json::from_value(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "browser_download",
+                "arguments": {
+                    "session": "public",
+                    "_session_id": "forged-owner",
+                    "_transport_session_id": "forged-transport",
+                    "_cua_browser_download_mcp_host_approved": false,
+                    "_protected_process_fingerprint": {"pid": 1}
+                }
+            }
+        }))
+        .unwrap();
+        let response = handle_request_with_transport_session(
+            request,
+            serde_json::json!(1),
+            &provider,
+            "mcp-trusted-lease",
+        )
+        .await;
+        assert!(matches!(response.body, ResponseBody::Result { .. }));
+
+        let arguments = provider.arguments.lock().unwrap().clone().unwrap();
+        assert_eq!(arguments["_session_id"], "public");
+        assert_eq!(arguments["_transport_session_id"], "mcp-trusted-lease");
+        assert_eq!(arguments["_cua_browser_download_mcp_host_approved"], true);
+        assert!(arguments.get("_protected_process_fingerprint").is_none());
+    }
+
+    #[tokio::test]
+    async fn trusted_transport_boundary_mints_implicit_identity_from_lease() {
+        let provider = CapturingProvider {
+            arguments: Mutex::new(None),
+        };
+        let request: Request = serde_json::from_value(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "get_config",
+                "arguments": {
+                    "_session_id": "forged-owner",
+                    "_transport_session_id": "forged-transport"
+                }
+            }
+        }))
+        .unwrap();
+        let response = handle_request_with_transport_session(
+            request,
+            serde_json::json!(1),
+            &provider,
+            "mcp-trusted-lease",
+        )
+        .await;
+        assert!(matches!(response.body, ResponseBody::Result { .. }));
+
+        let arguments = provider.arguments.lock().unwrap().clone().unwrap();
+        assert_eq!(arguments["_session_id"], "mcp-trusted-lease");
+        assert_eq!(arguments["_transport_session_id"], "mcp-trusted-lease");
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/cua-driver/src/mcp_http.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/mcp_http.rs
@@ -22,7 +22,9 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use cua_driver_core::protocol::{Request, Response};
-use cua_driver_core::server::{handle_request, tool_observation_timer, StdioExecutionPath};
+use cua_driver_core::server::{
+    handle_request_with_transport_session, tool_observation_timer, StdioExecutionPath,
+};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tracing::{debug, info, warn};
@@ -178,7 +180,8 @@ async fn dispatch(
     });
     let id = req.id.clone().unwrap_or(serde_json::Value::Null);
     let timer = http_tool_observation_timer(&req, |name| sdk.is_known_tool(name));
-    let response = handle_request(req, id, sdk.as_ref()).await;
+    let response =
+        handle_request_with_transport_session(req, id, sdk.as_ref(), transport_session).await;
     if let Some(timer) = timer {
         let outcome = timer.finish(&response);
         if let Some(context) = session_context {

--- a/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/proxy.rs
@@ -21,8 +21,8 @@ use std::sync::Arc;
 use cua_driver_core::policy::{authorize_tool_call, validate_configured_policy};
 use cua_driver_core::protocol::{initialize_result, Request, Response};
 use cua_driver_core::server::{
-    handle_request, observe_proxy_session_started, observe_proxy_tool_completed,
-    tool_observation_timer, StdioExecutionPath,
+    observe_proxy_session_started, observe_proxy_tool_completed, tool_observation_timer,
+    StdioExecutionPath,
 };
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 use tracing::{debug, error, warn};
@@ -97,7 +97,13 @@ pub async fn run_direct(driver: Arc<cua_driver_sdk::CuaDriver>) -> anyhow::Resul
                     StdioExecutionPath::DirectDaemon,
                 );
                 let id = request.id.clone().unwrap_or(serde_json::Value::Null);
-                let response = handle_request(request, id, sdk.as_ref()).await;
+                let response = cua_driver_core::server::handle_request_with_transport_session(
+                    request,
+                    id,
+                    sdk.as_ref(),
+                    &transport_session,
+                )
+                .await;
                 if let Some(metadata) = initialize_metadata {
                     observe_proxy_session_started(metadata);
                     session_observed = true;


### PR DESCRIPTION
## Summary

- preserve the authenticated transport lease separately from a caller-visible session label at the shared direct-MCP boundary
- use that trusted lease for owner-scoped `list_sessions` and transport-close cleanup in stdio and authenticated HTTP
- continue sanitizing every client-supplied reserved field before trusted values are stamped

Fixes #3078.

## Evidence

The defect was reproduced through an installed Cua Driver 0.19.3 build at `f9192dde69dd85ff6c5ad0bf4731d33ebc7d20d3`: one direct transport could create an implicit and a named session, but owner-scoped listing omitted the named run and lifecycle provenance did not identify MCP.

Focused validation on this branch:

- `cargo fmt --all -- --check`
- `cargo test -p cua-driver-core server::observation_tests -- --test-threads=1`
- `cargo test -p cua-driver proxy::tests -- --test-threads=1`
- `cargo test -p cua-driver mcp_http::tests -- --test-threads=1`

Installed Windows replay through the active FreeRDP user session:

- `install-local.ps1` built and installed exact commit `d231dc8b1a07db262699e7dea8506f4de0deb51d` as 0.19.3
- the enhanced 40-assertion session/permission probe passed both corrected owner/provenance assertions
- the only remaining failed row was the independent unsupported-MCP-flag finding tracked by #3082 / #3085

Cross-platform accounting:

- the canonical Windows desktop matrix passed with 109 delivered actions, 26 expected refusals, 0 failures, and 0 skips on the release candidate
- the focused Linux session/permission probe reproduced and then cleared this ownership defect; the unrelated full-harness Tauri fixture failures remain tracked in #3088
- macOS desktop capacity was unavailable for this certification window; the behavior is implemented at the shared MCP boundary and the macOS portable checks are green
