### PR TITLE
fix(cua-driver): stage current skill pack on Windows local installs

### DIFF
--- a/libs/cua-driver/scripts/_install-local-rust.sh
+++ b/libs/cua-driver/scripts/_install-local-rust.sh
@@ -522,7 +522,7 @@ unset _daemon_bin
 
 # Agent skill pack symlinks: NOT auto-created. Run
 # `cua-driver skills install --local` to symlink agent dirs to the
-# staged copy at $VERSIONED_DIR/Skills/cua-driver-rs above.
+# staged copy at $VERSIONED_DIR/Skills/cua-driver above.
 echo ""
 
 # --- Autostart (optional) ----------------------------------------------

--- a/libs/cua-driver/scripts/install-local.ps1
+++ b/libs/cua-driver/scripts/install-local.ps1
@@ -246,12 +246,12 @@ if (Test-Path -LiteralPath $BuiltUiaBinary) {
 $installedBinary = $DestBinary
 
 # Stage the skill pack alongside the binary. install-local mirrors what
-# install.ps1 does from a release zip — copies Skills/cua-driver-rs/ from
+# install.ps1 does from a release zip — copies Skills/cua-driver/ from
 # the repo into the versioned dir so the `current` junction below
 # transparently exposes it to agents.
-$SourceSkills = Join-Path $RepoRoot "Skills\cua-driver-rs"
+$SourceSkills = Join-Path $RepoRoot "Skills\cua-driver"
 if (Test-Path -LiteralPath $SourceSkills) {
-    $StagedSkills = Join-Path $VersionedDir "Skills\cua-driver-rs"
+    $StagedSkills = Join-Path $VersionedDir "Skills\cua-driver"
     if (Test-Path -LiteralPath $StagedSkills) {
         Remove-Item -LiteralPath $StagedSkills -Recurse -Force
     }

--- a/libs/cua-driver/scripts/tests/test_install_local.py
+++ b/libs/cua-driver/scripts/tests/test_install_local.py
@@ -11,6 +11,24 @@ import pytest
 INSTALL_LOCAL = Path(__file__).resolve().parents[1] / "_install-local-rust.sh"
 LOCAL_SIGNING = INSTALL_LOCAL.with_name("_local-signing.sh")
 DISPATCHER = INSTALL_LOCAL.with_name("install-local.sh")
+WINDOWS_INSTALL_LOCAL = INSTALL_LOCAL.with_name("install-local.ps1")
+SKILL_PACK = INSTALL_LOCAL.parents[1] / "rust/Skills/cua-driver"
+
+
+def test_local_installers_stage_the_canonical_skill_pack() -> None:
+    windows = WINDOWS_INSTALL_LOCAL.read_text(encoding="utf-8")
+
+    assert 'Join-Path $RepoRoot "Skills\\cua-driver"' in windows
+    assert 'Join-Path $VersionedDir "Skills\\cua-driver"' in windows
+    assert "Skills\\cua-driver-rs" not in windows
+    assert "Skills/cua-driver-rs" not in INSTALL_LOCAL.read_text(encoding="utf-8")
+    assert {path.name for path in SKILL_PACK.iterdir()} >= {
+        "SKILL.md",
+        "BROWSER.md",
+        "MACOS.md",
+        "WINDOWS.md",
+        "LINUX.md",
+    }
 
 
 def _write_executable(path: Path, body: str) -> None:


### PR DESCRIPTION
## Summary

- stage the canonical `Skills/cua-driver` pack from Windows `install-local.ps1`
- align the Unix local-installer guidance comment with the current directory name
- pin both installer paths and all required companion files in a focused regression test

Fixes #3080.

## Evidence

The 0.19.3 installed-product certification found that the Windows build/install succeeded while `Skills/cua-driver/SKILL.md` was absent from the local package staging directory. Source inspection showed the guarded copy still named `cua-driver-rs`, so it silently skipped the actual source directory.

Local validation:

- `uv run --with pytest python -m pytest libs/cua-driver/scripts/tests/test_install_local.py -q` — 7 passed, 1 skipped
- `git diff --check`

Installed Windows replay through the active FreeRDP user session:

- `install-local.ps1` built and installed exact commit `7605ec52c38556b0aae37bb6567a0d7c2fdf41d0` as 0.19.3
- the installed `packages/current/Skills/cua-driver` tree contains `SKILL.md`, `BROWSER.md`, `WINDOWS.md`, and `LINUX.md`
- the replay ran in interactive RDP session 3 with Explorer in the same session


