### PR TITLE
test(cua-driver): derive filesystem roots portably

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver-core/src/session_manifest.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-core/src/session_manifest.rs
@@ -1816,7 +1816,11 @@ allow:
     #[cfg(feature = "yaml")]
     #[test]
     fn manifest_file_resources_reject_filesystem_roots() {
-        let root = std::path::Path::new(std::path::MAIN_SEPARATOR_STR)
+        let current_dir = std::env::current_dir().unwrap();
+        let root = current_dir
+            .ancestors()
+            .last()
+            .expect("an absolute current directory has a filesystem root")
             .to_string_lossy()
             .into_owned();
         let error = validate_manifest_paths("files.write", vec![root]).unwrap_err();


### PR DESCRIPTION
## Summary

- derive the test filesystem root from the absolute current directory
- exercise a real drive root on Windows and `/` on Unix
- leave production capability-manifest validation unchanged

Fixes #3081.

## Evidence

The 0.19.3 Windows certification passed 12 of 13 focused manifest tests. The skipped row used `Path::new(MAIN_SEPARATOR_STR)`, but `\` is drive-relative on Windows and therefore cannot reach the root-refusal assertion. An independent installed-product probe confirmed that an actual Windows drive root is rejected correctly.

Local validation:

- `cargo fmt --all -- --check`
- `cargo test -p cua-driver-core session_manifest::tests::manifest_file_resources_reject_filesystem_roots -- --test-threads=1`
- `git diff --check`

CI validation:

- Rust Windows unit and compile passed the corrected root construction
- Linux unit, Nix unit/policy/package, format, contracts, and release-metadata rerun are green


