### PR TITLE
fix(cua-driver): reject misplaced MCP permission flags

### DIFF
--- a/.github/scripts/cua-driver-mcp-compat/verify.mjs
+++ b/.github/scripts/cua-driver-mcp-compat/verify.mjs
@@ -27,10 +27,11 @@ const EXPECTED_OUTPUT_SCHEMA_COUNT =
 const DRIVER_ARGS = [
   "mcp",
   "--direct",
-  "--dangerously-bypass-approvals",
 ];
 const PROBE_ENV = {
   ...process.env,
+  CUA_DRIVER_PERMISSION_MODE: "unrestricted",
+  CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS: "1",
   CUA_DRIVER_RS_TELEMETRY_ENABLED: "false",
   CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
   DISABLE_AUTOUPDATER: "1",

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -233,6 +233,33 @@ const VALUE_FLAGS: &[&str] = &[
     "--experimental-pip-geometry",
 ];
 
+/// Authorization selectors are trusted-daemon startup inputs. Direct MCP
+/// accepts their environment-variable equivalents, while a daemon-backed MCP
+/// client inherits the already-fixed profile through `--socket`. Silently
+/// consuming these flags on `mcp` would leave the default profile active while
+/// telling the operator nothing.
+const SERVE_ONLY_AUTHORIZATION_FLAGS: &[&str] = &[
+    "--permission-mode",
+    "--capability-manifest",
+    "--approve-capability-manifest",
+    "--session-policy",
+    "--approve-session-policy",
+    "--dangerously-bypass-approvals",
+    "--allow-legacy-existing-profile-approval",
+    "--no-permissions-gate",
+];
+
+fn serve_only_authorization_flag(args: &[String]) -> Option<&'static str> {
+    SERVE_ONLY_AUTHORIZATION_FLAGS.iter().copied().find(|flag| {
+        args.iter().any(|arg| {
+            arg == flag
+                || arg
+                    .strip_prefix(flag)
+                    .is_some_and(|remainder| remainder.starts_with('='))
+        })
+    })
+}
+
 /// Classify the requested finite command without parsing its arguments. The
 /// parent process uses this before `parse_command` so invalid JSON and other
 /// parser exits are still observed as completed failures.
@@ -652,6 +679,15 @@ pub fn parse_command() -> Command {
         } else {
             positionals.push(a);
             i += 1;
+        }
+    }
+
+    if matches!(positionals.first().copied(), None | Some("mcp")) {
+        if let Some(flag) = serve_only_authorization_flag(&args) {
+            eprintln!("cua-driver mcp does not accept {flag}; authorization flags belong to `cua-driver serve`.");
+            eprintln!("For direct MCP, use CUA_DRIVER_PERMISSION_MODE and the related CUA_DRIVER_* environment variables.");
+            eprintln!("Otherwise start a configured daemon and connect with `cua-driver mcp --socket <path>`." );
+            process::exit(64);
         }
     }
 

--- a/libs/cua-driver/rust/crates/cua-driver/tests/permission_policy_startup_test.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/tests/permission_policy_startup_test.rs
@@ -1,7 +1,7 @@
 //! Explicit permission-policy configuration must fail before a daemon exposes
 //! an action endpoint.
 
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 fn test_socket(directory: &tempfile::TempDir, suffix: &str) -> String {
     #[cfg(unix)]
@@ -33,6 +33,74 @@ fn rejected_serve(socket: &str, extra_args: &[&str]) -> std::process::Output {
         .env("CUA_DRIVER_RS_TELEMETRY_ENABLED", "false")
         .output()
         .expect("run rejected cua-driver serve configuration")
+}
+
+#[test]
+fn mcp_rejects_serve_only_authorization_flags() {
+    let cases: &[(&[&str], &str)] = &[
+        (
+            &["mcp", "--direct", "--permission-mode", "bounded"],
+            "--permission-mode",
+        ),
+        (
+            &["mcp", "--capability-manifest", "unused.yaml"],
+            "--capability-manifest",
+        ),
+        (
+            &["mcp", "--approve-capability-manifest"],
+            "--approve-capability-manifest",
+        ),
+        (
+            &["mcp", "--dangerously-bypass-approvals"],
+            "--dangerously-bypass-approvals",
+        ),
+        (
+            &["mcp", "--session-policy", "unused.yaml"],
+            "--session-policy",
+        ),
+        (
+            &["mcp", "--approve-session-policy"],
+            "--approve-session-policy",
+        ),
+        (&["--permission-mode=bounded"], "--permission-mode"),
+    ];
+
+    for (args, rejected_flag) in cases {
+        let output = Command::new(env!("CARGO_BIN_EXE_cua-driver"))
+            .args(*args)
+            .stdin(Stdio::null())
+            .env("CUA_DRIVER_RS_TELEMETRY_ENABLED", "false")
+            .output()
+            .expect("run cua-driver mcp with a serve-only authorization flag");
+        assert_eq!(output.status.code(), Some(64), "args={args:?}");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains(&format!("does not accept {rejected_flag}")),
+            "args={args:?}, stderr={stderr}"
+        );
+        assert!(
+            stderr.contains("CUA_DRIVER_PERMISSION_MODE"),
+            "args={args:?}, stderr={stderr}"
+        );
+        assert!(
+            stderr.contains("mcp --socket"),
+            "args={args:?}, stderr={stderr}"
+        );
+    }
+}
+
+#[test]
+fn direct_mcp_still_reads_permission_profile_from_environment() {
+    let output = Command::new(env!("CARGO_BIN_EXE_cua-driver"))
+        .args(["mcp", "--direct"])
+        .stdin(Stdio::null())
+        .env("CUA_DRIVER_PERMISSION_MODE", "bounded")
+        .env("CUA_DRIVER_RS_TELEMETRY_ENABLED", "false")
+        .output()
+        .expect("run direct MCP with bounded profile from the environment");
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("requires --capability-manifest"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- reject serve-only authorization flags when they are supplied to explicit or default MCP startup
- return exit code 64 with the documented direct-environment and configured-daemon alternatives
- preserve direct MCP profile selection through `CUA_DRIVER_*` environment variables
- align the pinned-client release probe with the supported direct-MCP environment configuration

Fixes #3082.

## Evidence

The installed 0.19.3 certification showed that `cua-driver mcp --direct --permission-mode bounded` exited successfully without a manifest. This did not bypass an active bounded profile: the generic parser silently consumed a flag that `Command::Mcp` does not support, so startup retained the default profile. The same certification verified that standard, bounded, and unrestricted direct MCP all enforce a capability manifest correctly when configured through their documented environment variables.

Local validation:

- `cargo fmt --manifest-path libs/cua-driver/rust/Cargo.toml --all -- --check`
- `cargo test --manifest-path libs/cua-driver/rust/Cargo.toml -p cua-driver --test permission_policy_startup_test -- --test-threads=1` — 14 passed
- pinned MCP client release probe — raw wire, official TypeScript SDK, Claude Code 2.1.224, and Codex 0.146.1 passed
- `git diff --check`

The new cases cover explicit and default MCP forms, bounded mode, manifest and approval flags, unrestricted acknowledgement, deprecated aliases, and direct environment selection.

Installed Windows replay through the active FreeRDP user session:

- `install-local.ps1` built and installed exact commit `b29d18c7f9b610af636fe27ae4b6c98aa80b8f1f` as 0.19.3
- `mcp --direct --permission-mode bounded` exited 64 and named both supported configuration routes
- `CUA_DRIVER_PERMISSION_MODE=bounded mcp --direct` still failed closed without a capability manifest
- replay ran in interactive RDP session 3 with Explorer in the same session

