### PR TITLE
docs: move pool guides under sandbox

### DIFF
--- a/docs/content/docs/how-to-guides/fleets/meta.json
+++ b/docs/content/docs/how-to-guides/fleets/meta.json
@@ -1,4 +1,0 @@
-{
-  "title": "Fleets",
-  "pages": ["configure-run-cua-fleets"]
-}

--- a/docs/content/docs/how-to-guides/meta.json
+++ b/docs/content/docs/how-to-guides/meta.json
@@ -1,14 +1,5 @@
 {
   "title": "How-to guides",
   "icon": "Wrench",
-  "pages": [
-    "index",
-    "driver",
-    "sandbox",
-    "fleets",
-    "lume",
-    "cua-bench",
-    "recipes",
-    "agent-context"
-  ]
+  "pages": ["index", "driver", "sandbox", "lume", "cua-bench", "recipes", "agent-context"]
 }

--- a/docs/content/docs/how-to-guides/sandbox/configure-pool-with-terraform.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/configure-pool-with-terraform.mdx
@@ -1,14 +1,15 @@
 ---
-title: Configure Fleets with Terraform
-description: Create Linux and Windows run.cua.ai fleets with Terraform and the public Cua Fleets provider.
+title: Configure a sandbox pool with Terraform
+description: Configure reusable Linux and Windows sandbox pools on run.cua.ai with Terraform.
 ---
 
-Use this guide to create a run.cua.ai fleet backed by the public Cua Fleets
-provider. Terraform represents each fleet as a `fleets_pool` resource.
+Use this guide to configure a reusable sandbox pool on run.cua.ai with the
+public Cua Fleets provider. Terraform represents each pool as a `fleets_pool`
+resource.
 
 ## Prerequisites
 
-- A run.cua.ai user key or access token with permission to manage Fleet pools.
+- A run.cua.ai user key or access token with permission to manage sandbox pools.
   Keep credentials in environment variables or a secret manager, not in source
   control.
 - Terraform or OpenTofu.
@@ -41,7 +42,7 @@ In autoscaling mode, do not configure `replicas`; after apply and refresh it
 reports the current pool target. If you later switch to static mode, review the
 plan because the pool will use the `replicas` value you configure.
 
-## Create a Linux fleet
+## Configure a Linux pool
 
 Create a new directory, save this as `main.tf`, and choose a unique lowercase
 DNS-label pool name. This example creates a KubeVirt Linux pool and exposes SSH.
@@ -61,7 +62,7 @@ provider "fleets" {
 }
 
 resource "fleets_pool" "linux" {
-  name                 = "linux-fleet"
+  name                 = "linux-pool"
   cpu_cores            = 4
   memory               = "8Gi"
   container_disk_image = "296062593712.dkr.ecr.us-west-2.amazonaws.com/desktop-workspace-duo:main-38352d34"
@@ -81,7 +82,7 @@ resource "fleets_pool" "linux" {
   }
 }
 
-output "linux_fleet" {
+output "linux_pool" {
   value = {
     name             = fleets_pool.linux.name
     namespace        = fleets_pool.linux.namespace
@@ -92,7 +93,7 @@ output "linux_fleet" {
 }
 ```
 
-## Create a Windows fleet
+## Configure a Windows pool
 
 Use a distinct name for Windows. The Windows computer-server image requires
 UEFI, so this example sets `firmware = "efi"` and waits for the service on port
@@ -113,7 +114,7 @@ provider "fleets" {
 }
 
 resource "fleets_pool" "windows" {
-  name                 = "windows-fleet"
+  name                 = "windows-pool"
   cpu_cores            = 4
   memory               = "4Gi"
   container_disk_image = "296062593712.dkr.ecr.us-west-2.amazonaws.com/cua-server-windows:latest"
@@ -141,7 +142,7 @@ resource "fleets_pool" "windows" {
   }
 }
 
-output "windows_fleet" {
+output "windows_pool" {
   value = {
     name             = fleets_pool.windows.name
     namespace        = fleets_pool.windows.namespace
@@ -172,7 +173,7 @@ status visible in the plan and outputs.
 
 The provider returns the backing `namespace` and template name, the live
 `replicas` target, and the `current_replicas` and `ready_replicas` status counts.
-A ready fleet has at least one ready sandbox after its warm pool provisions.
+A ready pool has at least one ready sandbox after its warm capacity provisions.
 
 Destroy the pool when finished. This deletes both the pool and its same-named
 namespace:

--- a/docs/content/docs/how-to-guides/sandbox/create-pool-with-python.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/create-pool-with-python.mdx
@@ -1,0 +1,135 @@
+---
+title: Create a sandbox pool with Python
+description: Create a reusable warm sandbox pool, claim a sandbox, and run commands with the Cua Sandbox SDK.
+---
+
+Use the Cua Sandbox SDK when you want to create and claim a reusable sandbox
+pool from Python. This guide applies a one-replica pool, connects to a named
+claim, takes a screenshot, and runs a shell command.
+
+## Prerequisites
+
+- Python `>=3.11,<3.14`.
+- [`uv`](https://docs.astral.sh/uv/) to run the self-contained script.
+- A run.cua.ai access token or OAuth user key with permission to manage sandbox
+  pools.
+
+The SDK connects to `https://run.cua.ai` by default. Authenticate with a Fleet
+access token:
+
+```bash
+export FLEETS_TOKEN="<your-access-token>"
+```
+
+Or authenticate with OAuth client credentials:
+
+```bash
+export CUA_CLIENT_ID="<your-client-id>"
+export CUA_CLIENT_SECRET="<your-client-secret>"
+```
+
+Set `CUA_FLEET_BASE_URL` only when you need to use a different Fleet API
+endpoint.
+
+## Create and claim the pool
+
+Save the following script as `create_pool.py`:
+
+```python title="create_pool.py"
+# /// script
+# requires-python = ">=3.11,<3.14"
+# dependencies = [
+#   "cua-sandbox",
+# ]
+# ///
+
+import asyncio
+import os
+from pathlib import Path
+
+from cua_sandbox import Image, Pool
+
+
+IMAGE = (
+    "296062593712.dkr.ecr.us-west-2.amazonaws.com/desktop-workspace-duo"
+    "@sha256:5b9cb82f482834f7541901b87be956e7544d0db13fabc0b372cbc5eca5a74180"
+)
+
+POOL_NAME = os.environ.get("CUA_POOL_NAME", "cua-live-main-source-manual")
+CLAIM_NAME = os.environ.get("CUA_CLAIM_NAME", POOL_NAME)
+
+
+async def main() -> None:
+    # Create or reconcile the warm pool and its template.
+    pool = await Pool.apply(
+        Image.from_registry(IMAGE),
+        name=POOL_NAME,
+        replicas=1,
+        cpu=4,
+        memory_mb=4096,
+        services={"server": 8000},
+    )
+
+    # Create or reconnect to the named claim.
+    # Exiting this block releases the claim but leaves the pool warm.
+    async with pool.claim(
+        name=CLAIM_NAME,
+        service="server",
+        time_to_start=900,
+    ) as sandbox:
+        print(f"Pool:    {sandbox.pool_name}")
+        print(f"Claim:   {sandbox.claim_name}")
+        print(f"Sandbox: {sandbox.name}")
+
+        screenshot = Path("sandbox.png")
+        screenshot.write_bytes(await sandbox.screenshot())
+        print(f"Screenshot: {screenshot.resolve()}")
+
+        result = await sandbox.shell.run("uname -a")
+        if not result.success:
+            raise RuntimeError(result.stderr)
+
+        print(result.stdout.strip())
+
+
+asyncio.run(main())
+```
+
+Run it with `uv`. The script metadata installs `cua-sandbox` in an isolated
+environment automatically:
+
+```bash
+uv run create_pool.py
+```
+
+`Pool.apply()` creates the pool and its sandbox template when they do not exist.
+If the named pool already exists, it reconciles the pool to the image, replica,
+CPU, memory, and service configuration in the script.
+
+`pool.claim()` creates or reconnects to the named claim and waits up to 900
+seconds for the `server` service on port `8000`. Exiting the `async with` block
+releases the claim, but the pool and its one warm replica remain available for
+the next claim.
+
+The script writes `sandbox.png` in the current directory and raises an error if
+`uname -a` does not complete successfully.
+
+## Choose pool and claim names
+
+The defaults use the same value for the pool and claim. Override either name
+without editing the script:
+
+```bash
+export CUA_POOL_NAME="my-sandbox-pool"
+export CUA_CLAIM_NAME="my-sandbox-claim"
+uv run create_pool.py
+```
+
+Use stable names when later runs should reconcile the same pool and reuse the
+same claim identity. Names must be lowercase DNS labels.
+
+## Delete the pool
+
+The example intentionally leaves the pool warm. If you no longer need it, call
+`await pool.delete()` after the claim context exits. This deletes the pool and
+the template created by that `Pool.apply()` call.

--- a/docs/content/docs/how-to-guides/sandbox/meta.json
+++ b/docs/content/docs/how-to-guides/sandbox/meta.json
@@ -1,1 +1,13 @@
-{ "title": "Sandbox", "pages": ["lifecycle", "secrets", "scale-out", "tunneling", "images", "interactive-shell"] }
+{
+  "title": "Sandbox",
+  "pages": [
+    "lifecycle",
+    "configure-pool-with-terraform",
+    "create-pool-with-python",
+    "secrets",
+    "scale-out",
+    "tunneling",
+    "images",
+    "interactive-shell"
+  ]
+}

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -66,6 +66,16 @@ const config = {
         permanent: true,
       },
       {
+        source: '/how-to-guides/fleets/configure-run-cua-fleets',
+        destination: '/how-to-guides/sandbox/configure-pool-with-terraform',
+        permanent: true,
+      },
+      {
+        source: '/how-to-guides/(fleets)/configure-run-cua-fleets',
+        destination: '/how-to-guides/sandbox/configure-pool-with-terraform',
+        permanent: true,
+      },
+      {
         source: '/how-to-guides/skills/record-a-demonstration',
         destination: '/how-to-guides',
         permanent: true,

--- a/docs/superpowers/plans/2026-08-12-sandbox-pool-guides.md
+++ b/docs/superpowers/plans/2026-08-12-sandbox-pool-guides.md
@@ -1,0 +1,165 @@
+# Sandbox Pool Guides Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move Fleets documentation into two directly nested Sandbox how-to guides: one for Terraform and one for Python.
+
+**Architecture:** The public MDX content and local-preview redirects live in `trycua/cua`; production redirects live in `trycua/cloud`. The Terraform page preserves the provider-specific `fleets_pool` vocabulary while presenting the user-facing concept as a sandbox pool, and the Python page uses the supplied PEP 723 script unchanged except for surrounding instructional prose.
+
+**Tech Stack:** MDX, Fumadocs metadata, Next.js redirects, TypeScript, Vitest, Terraform HCL, Python 3.11+
+
+## Global Constraints
+
+- Work only in `/home/node/workspace/repos/cua/.worktrees/sandbox-pool-docs` and `/home/node/workspace/repos/cloud/.worktrees/sandbox-pool-redirect`.
+- Put both new pages directly under `docs/content/docs/how-to-guides/sandbox/`; do not create a nested `pools/` directory.
+- Preserve `/docs/how-to-guides/fleets/configure-run-cua-fleets` with a permanent redirect to `/docs/how-to-guides/sandbox/configure-pool-with-terraform`.
+- Redirect the older `/docs/how-to-guides/(fleets)/configure-run-cua-fleets` alias directly to the same destination.
+- Do not commit changes unless the user explicitly requests a commit.
+
+---
+
+### Task 1: Add Production Redirect Coverage
+
+**Files:**
+
+- Modify: `/home/node/workspace/repos/cloud/.worktrees/sandbox-pool-redirect/src/website/app/lib/docs/redirects.test.ts`
+- Modify: `/home/node/workspace/repos/cloud/.worktrees/sandbox-pool-redirect/src/website/app/lib/docs/redirects.ts`
+
+**Interfaces:**
+
+- Consumes: `resolveDocsRedirect(slug: string): string | null`
+- Produces: Permanent legacy mappings for both Fleets guide slugs.
+
+- [ ] **Step 1: Add failing redirect cases**
+
+Add these cases to the `it.each` table:
+
+```ts
+[
+  'how-to-guides/fleets/configure-run-cua-fleets',
+  '/docs/how-to-guides/sandbox/configure-pool-with-terraform',
+],
+[
+  'how-to-guides/(fleets)/configure-run-cua-fleets',
+  '/docs/how-to-guides/sandbox/configure-pool-with-terraform',
+],
+```
+
+- [ ] **Step 2: Verify the new current-route case fails**
+
+Run: `corepack pnpm test -- app/lib/docs/redirects.test.ts`
+
+Expected: FAIL because `how-to-guides/fleets/configure-run-cua-fleets` has no redirect and the parenthesized alias still targets the removed Fleets route.
+
+- [ ] **Step 3: Add both production redirects**
+
+Add direct entries to `DOCS_REDIRECTS`:
+
+```ts
+'how-to-guides/fleets/configure-run-cua-fleets':
+  '/docs/how-to-guides/sandbox/configure-pool-with-terraform',
+'how-to-guides/(fleets)/configure-run-cua-fleets':
+  '/docs/how-to-guides/sandbox/configure-pool-with-terraform',
+```
+
+- [ ] **Step 4: Verify the redirect test passes**
+
+Run: `corepack pnpm test -- app/lib/docs/redirects.test.ts`
+
+Expected: PASS with all redirect cases green.
+
+### Task 2: Restructure Sandbox Pool Documentation
+
+**Files:**
+
+- Create: `/home/node/workspace/repos/cua/.worktrees/sandbox-pool-docs/docs/content/docs/how-to-guides/sandbox/configure-pool-with-terraform.mdx`
+- Create: `/home/node/workspace/repos/cua/.worktrees/sandbox-pool-docs/docs/content/docs/how-to-guides/sandbox/create-pool-with-python.mdx`
+- Delete: `/home/node/workspace/repos/cua/.worktrees/sandbox-pool-docs/docs/content/docs/how-to-guides/fleets/configure-run-cua-fleets.mdx`
+- Delete: `/home/node/workspace/repos/cua/.worktrees/sandbox-pool-docs/docs/content/docs/how-to-guides/fleets/meta.json`
+- Modify: `/home/node/workspace/repos/cua/.worktrees/sandbox-pool-docs/docs/content/docs/how-to-guides/meta.json`
+- Modify: `/home/node/workspace/repos/cua/.worktrees/sandbox-pool-docs/docs/content/docs/how-to-guides/sandbox/meta.json`
+
+**Interfaces:**
+
+- Consumes: Existing Terraform guide content and the user-supplied `cua_sandbox.Image`/`Pool` script.
+- Produces: `/how-to-guides/sandbox/configure-pool-with-terraform` and `/how-to-guides/sandbox/create-pool-with-python`.
+
+- [ ] **Step 1: Verify the desired structure is absent**
+
+Run:
+
+```bash
+test -f docs/content/docs/how-to-guides/sandbox/configure-pool-with-terraform.mdx &&
+test -f docs/content/docs/how-to-guides/sandbox/create-pool-with-python.mdx &&
+! test -d docs/content/docs/how-to-guides/fleets
+```
+
+Expected: FAIL because both new pages are absent and the Fleets directory exists.
+
+- [ ] **Step 2: Move and reframe the Terraform guide**
+
+Move the existing guide to `sandbox/configure-pool-with-terraform.mdx`, use the title `Configure a sandbox pool with Terraform`, replace general user-facing “fleet” wording with “sandbox pool,” retain literal provider/API identifiers such as `trycua/fleets`, `fleets_pool`, and Fleet authentication names, and keep the Linux/Windows, sizing, apply, verify, destroy, and troubleshooting sections.
+
+- [ ] **Step 3: Add the Python guide**
+
+Create `sandbox/create-pool-with-python.mdx` with:
+
+```yaml
+---
+title: Create a sandbox pool with Python
+description: Create a reusable warm sandbox pool, claim a sandbox, and run commands with the Cua Sandbox SDK.
+---
+```
+
+Document Python `>=3.11,<3.14`, `uv`, Fleet authentication through `FLEETS_TOKEN` or `CUA_CLIENT_ID` plus `CUA_CLIENT_SECRET`, the default `https://run.cua.ai` endpoint, the supplied PEP 723 script, `uv run create_pool.py`, reusable pool behavior, claim release on context-manager exit, screenshot output, shell result checking, and optional `CUA_POOL_NAME`/`CUA_CLAIM_NAME` overrides.
+
+- [ ] **Step 4: Flatten navigation metadata**
+
+Remove `fleets` from `how-to-guides/meta.json`. Add `configure-pool-with-terraform` and `create-pool-with-python` to the Sandbox page list after `lifecycle` in `sandbox/meta.json`.
+
+- [ ] **Step 5: Remove the old Fleets section**
+
+Delete the now-empty `docs/content/docs/how-to-guides/fleets/` directory.
+
+- [ ] **Step 6: Verify the structure check passes**
+
+Run the Step 1 command again.
+
+Expected: PASS.
+
+### Task 3: Add Local Redirects and Validate
+
+**Files:**
+
+- Modify: `/home/node/workspace/repos/cua/.worktrees/sandbox-pool-docs/docs/next.config.mjs`
+
+**Interfaces:**
+
+- Consumes: The two retired Fleets URLs.
+- Produces: Permanent redirects in the local Next.js preview matching production behavior.
+
+- [ ] **Step 1: Add local-preview redirects**
+
+Add permanent redirect objects for `/how-to-guides/fleets/configure-run-cua-fleets` and `/how-to-guides/(fleets)/configure-run-cua-fleets`, both targeting `/how-to-guides/sandbox/configure-pool-with-terraform`.
+
+- [ ] **Step 2: Run Cua docs validation**
+
+Run:
+
+```bash
+corepack pnpm docs:check-links
+corepack pnpm docs:check-hygiene
+corepack pnpm build
+```
+
+Expected: All commands pass; the static route list includes both new Sandbox guide paths and excludes the removed Fleets page.
+
+- [ ] **Step 3: Run Cloud redirect validation**
+
+Run: `corepack pnpm test -- app/lib/docs/redirects.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 4: Review both worktree diffs**
+
+Run `git diff --check` and `git status --short` in both worktrees. Confirm no generated files, dependency lockfiles, or unrelated paths changed.


### PR DESCRIPTION
## What changed

- move the Terraform pool guide from the top-level Fleets section into Sandbox
- add a Python guide for creating, claiming, and using a reusable sandbox pool
- flatten both guides directly under the Sandbox navigation
- preserve the former Fleets guide URLs in the local docs preview

## Validation

- `corepack pnpm docs:check-links`
- `corepack pnpm docs:check-hygiene`
- `corepack pnpm build`
- extracted Python example compiles successfully

## Follow-up

The production website redirect is handled by a companion `trycua/cloud` pull request.
