### PR TITLE
fix: make Driver and Lume nightly staging portable

### DIFF
--- a/.github/scripts/release_channels.py
+++ b/.github/scripts/release_channels.py
@@ -33,8 +33,8 @@ class ChannelError(RuntimeError):
 
 def read_json(path: Path) -> Any:
     try:
-        return json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError) as error:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
         raise ChannelError(f"cannot read JSON from {path}: {error}") from error
 
 
@@ -122,7 +122,11 @@ def load_registry(path: Path = DEFAULT_REGISTRY, *, root: Path = ROOT) -> dict[s
             raise ChannelError(
                 f"component {name} stable prefix must match Release Please: {expected_prefix}"
             )
-        authority = repository_path(root, component["versionAuthorityFile"]).read_text().strip()
+        authority = (
+            repository_path(root, component["versionAuthorityFile"])
+            .read_text(encoding="utf-8")
+            .strip()
+        )
         if not SEMVER_RE.fullmatch(authority):
             raise ChannelError(f"component {name} authority is not a stable version: {authority!r}")
         if release_manifest.get(package_path) != authority:
@@ -195,7 +199,7 @@ def parse_tag(component: Mapping[str, Any], channel: str, tag: str) -> str:
 
 
 def _workspace_package_names(manifest_path: Path) -> set[str]:
-    manifest = manifest_path.read_text()
+    manifest = manifest_path.read_text(encoding="utf-8")
     members_match = re.search(r"(?ms)^members\s*=\s*\[(.*?)\]", manifest)
     if not members_match:
         raise ChannelError(f"Cargo workspace members are missing from {manifest_path}")
@@ -205,7 +209,7 @@ def _workspace_package_names(manifest_path: Path) -> set[str]:
         for member in manifest_path.parent.glob(str(pattern)):
             package_manifest = member / "Cargo.toml"
             if package_manifest.is_file():
-                package_text = package_manifest.read_text()
+                package_text = package_manifest.read_text(encoding="utf-8")
                 package_block = re.search(r"(?ms)^\[package\]\s*(.*?)(?=^\[|\Z)", package_text)
                 if not package_block or not re.search(
                     r"(?m)^version\.workspace\s*=\s*true\s*$", package_block.group(1)
@@ -226,7 +230,7 @@ def _rewrite_cargo_lock(
     lock_path: Path, manifest_path: Path, old_version: str, new_version: str
 ) -> int:
     names = _workspace_package_names(manifest_path)
-    original = lock_path.read_text()
+    original = lock_path.read_text(encoding="utf-8")
     seen: set[str] = set()
 
     def replace_block(match: re.Match[str]) -> str:
@@ -254,7 +258,7 @@ def _rewrite_cargo_lock(
         raise ChannelError(
             f"Cargo.lock is missing workspace packages: {', '.join(sorted(missing))}"
         )
-    lock_path.write_text(rewritten)
+    lock_path.write_text(rewritten, encoding="utf-8")
     return len(seen)
 
 
@@ -268,18 +272,18 @@ def apply_version(
     nightly_version(version)
     component = component_descriptor(name, registry_path, root=root)
     authority = repository_path(root, component["versionAuthorityFile"])
-    old_version = authority.read_text().strip()
+    old_version = authority.read_text(encoding="utf-8").strip()
     stable_version(old_version)
     changed: list[str] = []
     for site in component["buildVersionSites"]:
         path = repository_path(root, site["path"])
         kind = site["kind"]
         if kind == "plain":
-            if path.read_text().strip() != old_version:
+            if path.read_text(encoding="utf-8").strip() != old_version:
                 raise ChannelError(f"plain version site {site['path']} differs from {old_version}")
-            path.write_text(f"{version}\n")
+            path.write_text(f"{version}\n", encoding="utf-8")
         elif kind == "regex":
-            original = path.read_text()
+            original = path.read_text(encoding="utf-8")
             replacement = str(site["replacement"]).replace("{version}", version)
             rewritten, count = re.subn(str(site["pattern"]), replacement, original)
             if count != int(site["expectedMatches"]):
@@ -287,7 +291,7 @@ def apply_version(
                     f"version site {site['path']} matched {count} times, "
                     f"expected {site['expectedMatches']}"
                 )
-            path.write_text(rewritten)
+            path.write_text(rewritten, encoding="utf-8")
         elif kind == "cargo-workspace-lock":
             manifest = repository_path(root, site["manifestPath"])
             _rewrite_cargo_lock(path, manifest, old_version, version)
@@ -318,7 +322,9 @@ def plan_nightly(
     if not SHA_RE.fullmatch(source_sha):
         raise ChannelError(f"source SHA must be 40 lowercase hex characters: {source_sha!r}")
     component = component_descriptor(name, registry_path, root=root)
-    base = repository_path(root, component["versionAuthorityFile"]).read_text().strip()
+    base = (
+        repository_path(root, component["versionAuthorityFile"]).read_text(encoding="utf-8").strip()
+    )
     version = derive_nightly_version(base, date, run)
     tag = format_tag(component, "nightly", version)
     candidates: list[Mapping[str, Any]] = []
@@ -521,7 +527,7 @@ def write_github_outputs(values: Mapping[str, Any], path: Path) -> None:
         if value is None:
             rendered = ""
         lines.append(f"{key}={rendered}")
-    with path.open("a") as handle:
+    with path.open("a", encoding="utf-8") as handle:
         handle.write("\n".join(lines) + "\n")
 
 
@@ -579,7 +585,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"validated {len(registry['components'])} release-channel components")
         elif args.command == "derive":
             component = component_descriptor(args.component, args.registry, root=root)
-            base = repository_path(root, component["versionAuthorityFile"]).read_text().strip()
+            base = (
+                repository_path(root, component["versionAuthorityFile"])
+                .read_text(encoding="utf-8")
+                .strip()
+            )
             version = derive_nightly_version(base, args.date, args.run)
             print(
                 json.dumps({"version": version, "tag": format_tag(component, "nightly", version)})
@@ -608,7 +618,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             rendered = json.dumps(result, indent=2) + "\n"
             if args.output:
-                args.output.write_text(rendered)
+                args.output.write_text(rendered, encoding="utf-8")
             else:
                 print(rendered, end="")
             if args.github_output:
@@ -625,10 +635,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                 registry_path=args.registry,
                 root=root,
             )
-            args.output.write_text(json.dumps(manifest, indent=2) + "\n")
+            args.output.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
         elif args.command == "render-nightly":
             manifest = read_json(args.manifest)
-            args.body.write_text(render_nightly_body(manifest))
+            args.body.write_text(render_nightly_body(manifest), encoding="utf-8")
     except (ChannelError, OSError, ValueError) as error:
         print(f"release channel error: {error}", file=sys.stderr)
         return 1

--- a/.github/scripts/tests/test_nightly_release_wiring.py
+++ b/.github/scripts/tests/test_nightly_release_wiring.py
@@ -46,6 +46,7 @@ def test_driver_nightly_reuses_builder_without_stable_state_mutation():
 
 def test_lume_nightly_reuses_notarized_builder_and_never_becomes_latest():
     nightly = source("nightly-lume.yml")
+    builder = source("cd-swift-lume.yml")
     assert "uses: ./.github/workflows/cd-swift-lume.yml" in nightly
     assert "bundle_version: ${{ needs.plan.outputs.bundle_version }}" in nightly
     assert "--create-if-missing" in nightly
@@ -56,6 +57,17 @@ def test_lume_nightly_reuses_notarized_builder_and_never_becomes_latest():
     assert "needs.plan.outputs.attribution_base_tag" in nightly
     assert "issues: read" in nightly
     assert "pull-requests: read" in nightly
+    assert builder.index("- name: Set version") < builder.index(
+        "- name: Stage nightly artifact version"
+    )
+    set_version = builder[
+        builder.index("- name: Set version") : builder.index(
+            "- name: Stage nightly artifact version"
+        )
+    ]
+    assert set_version.index('inputs.channel }}" == "nightly"') < set_version.index(
+        "SOURCE_VERSION=$(tr -d"
+    )
 
 
 def test_planner_requires_main_ancestry_and_preserves_immutable_evidence():

--- a/.github/scripts/tests/test_release_channels.py
+++ b/.github/scripts/tests/test_release_channels.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import json
 from pathlib import Path
 import shutil
@@ -25,6 +26,25 @@ from release_channels import (
 
 ROOT = Path(__file__).resolve().parents[3]
 REGISTRY = ROOT / ".github/releases/components.json"
+
+
+def test_release_channel_repository_io_is_explicitly_utf8():
+    source_path = ROOT / ".github/scripts/release_channels.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in {"read_text", "write_text", "open"}
+    ]
+    assert calls
+    for call in calls:
+        encoding = next(
+            (keyword.value for keyword in call.keywords if keyword.arg == "encoding"), None
+        )
+        assert isinstance(encoding, ast.Constant), ast.unparse(call)
+        assert encoding.value == "utf-8", ast.unparse(call)
 
 
 def git(root: Path, *args: str) -> str:

--- a/.github/workflows/cd-swift-lume.yml
+++ b/.github/workflows/cd-swift-lume.yml
@@ -78,22 +78,6 @@ jobs:
         with:
           ref: ${{ inputs.source_ref || github.ref }}
 
-      - name: Stage nightly artifact version
-        if: inputs.channel == 'nightly'
-        run: python3 .github/scripts/release_channels.py apply-version --component lume --version "${{ inputs.version }}"
-
-      - name: Select Xcode 16.3
-        run: |
-          sudo xcode-select -s /Applications/Xcode_16.3.app
-          xcodebuild -version
-
-      - name: Install dependencies
-        run: |
-          brew install cpio
-
-      - name: Create .release directory
-        run: mkdir -p .release
-
       - name: Set version
         id: set_version
         run: |
@@ -109,22 +93,38 @@ jobs:
             exit 1
           fi
 
-          SOURCE_VERSION=$(tr -d '[:space:]' < libs/lume/VERSION)
-          if [[ "$SOURCE_VERSION" != "$VERSION" ]]; then
-            echo "Tag/input version $VERSION does not match libs/lume/VERSION ($SOURCE_VERSION)"
-            exit 1
-          fi
           if [[ "${{ inputs.channel }}" == "nightly" ]]; then
             python3 .github/scripts/release_channels.py parse-tag \
               --component lume \
               --channel nightly \
               --tag "nightly-lume-v${VERSION}" >/dev/null
           else
+            SOURCE_VERSION=$(tr -d '[:space:]' < libs/lume/VERSION)
+            if [[ "$SOURCE_VERSION" != "$VERSION" ]]; then
+              echo "Tag/input version $VERSION does not match libs/lume/VERSION ($SOURCE_VERSION)"
+              exit 1
+            fi
             python3 .github/scripts/validate_release_versions.py --product lume
           fi
 
           # Set output for later steps
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Stage nightly artifact version
+        if: inputs.channel == 'nightly'
+        run: python3 .github/scripts/release_channels.py apply-version --component lume --version "${{ inputs.version }}"
+
+      - name: Select Xcode 16.3
+        run: |
+          sudo xcode-select -s /Applications/Xcode_16.3.app
+          xcodebuild -version
+
+      - name: Install dependencies
+        run: |
+          brew install cpio
+
+      - name: Create .release directory
+        run: mkdir -p .release
 
       - name: Import Certificates
         env:


### PR DESCRIPTION
Refs #3096.

## Summary

- make release-channel repository I/O explicitly UTF-8 so Windows nightly builders do not depend on the legacy locale
- validate Lume nightly identity while source authority is still stable, then stage the nightly version
- pin both invariants with focused source and workflow tests

## Evidence

Reproduced by exact-main nightly runs [Driver 31607737649](https://github.com/trycua/cua/actions/runs/31607737649) and [Lume 31607740242](https://github.com/trycua/cua/actions/runs/31607740242). No public release was created.

## Validation

Candidate: `15ca66c6e`

- release-channel and nightly-wiring tests: 76 passed
- Python compile checks passed
- formatting and diff checks passed

## Progress

- [x] implementation and focused tests
- [ ] ordinary PR CI
- [ ] merge and exact-main nightly retry
- [ ] public artifact and channel-switch verification