### PR TITLE
fix: render Driver nightly attribution after staging

### DIFF
--- a/.github/scripts/release_channels.py
+++ b/.github/scripts/release_channels.py
@@ -50,7 +50,12 @@ def repository_path(root: Path, value: str) -> Path:
     return resolved
 
 
-def load_registry(path: Path = DEFAULT_REGISTRY, *, root: Path = ROOT) -> dict[str, Any]:
+def load_registry(
+    path: Path = DEFAULT_REGISTRY,
+    *,
+    root: Path = ROOT,
+    require_stable_state: bool = True,
+) -> dict[str, Any]:
     registry = read_json(path)
     if registry.get("schemaVersion") != 1:
         raise ChannelError("component registry schemaVersion must be 1")
@@ -122,25 +127,36 @@ def load_registry(path: Path = DEFAULT_REGISTRY, *, root: Path = ROOT) -> dict[s
             raise ChannelError(
                 f"component {name} stable prefix must match Release Please: {expected_prefix}"
             )
-        authority = (
-            repository_path(root, component["versionAuthorityFile"])
-            .read_text(encoding="utf-8")
-            .strip()
-        )
-        if not SEMVER_RE.fullmatch(authority):
-            raise ChannelError(f"component {name} authority is not a stable version: {authority!r}")
-        if release_manifest.get(package_path) != authority:
-            raise ChannelError(
-                f"component {name} authority {authority} differs from Release Please manifest "
-                f"{release_manifest.get(package_path)!r}"
+        if require_stable_state:
+            authority = (
+                repository_path(root, component["versionAuthorityFile"])
+                .read_text(encoding="utf-8")
+                .strip()
             )
+            if not SEMVER_RE.fullmatch(authority):
+                raise ChannelError(
+                    f"component {name} authority is not a stable version: {authority!r}"
+                )
+            if release_manifest.get(package_path) != authority:
+                raise ChannelError(
+                    f"component {name} authority {authority} differs from Release Please manifest "
+                    f"{release_manifest.get(package_path)!r}"
+                )
     return registry
 
 
 def component_descriptor(
-    name: str, path: Path = DEFAULT_REGISTRY, *, root: Path = ROOT
+    name: str,
+    path: Path = DEFAULT_REGISTRY,
+    *,
+    root: Path = ROOT,
+    require_stable_state: bool = True,
 ) -> dict[str, Any]:
-    registry = load_registry(path, root=root)
+    registry = load_registry(
+        path,
+        root=root,
+        require_stable_state=require_stable_state,
+    )
     try:
         return dict(registry["components"][name])
     except KeyError as error:
@@ -391,7 +407,12 @@ def build_manifest(
     attribution_config_path: Path | None = None,
     github: release_attribution.GitHubClient | None = None,
 ) -> dict[str, Any]:
-    component = component_descriptor(name, registry_path, root=root)
+    component = component_descriptor(
+        name,
+        registry_path,
+        root=root,
+        require_stable_state=False,
+    )
     parsed = parse_tag(component, "nightly", tag)
     if parsed != version:
         raise ChannelError(f"tag version {parsed} differs from requested version {version}")
@@ -405,7 +426,11 @@ def build_manifest(
     if not base_sha:
         raise ChannelError(f"nightly attribution base has no commit: {previous_tag}")
     _git(root, "merge-base", "--is-ancestor", base_sha, source_sha)
-    registry = load_registry(registry_path, root=root)
+    registry = load_registry(
+        registry_path,
+        root=root,
+        require_stable_state=False,
+    )
     paths = sorted(
         {
             *(str(path) for path in component["changeDetectionPaths"]),

--- a/.github/scripts/tests/test_release_channels.py
+++ b/.github/scripts/tests/test_release_channels.py
@@ -265,6 +265,50 @@ def test_plan_builds_only_for_declared_relevant_changes(monkeypatch: pytest.Monk
     assert plan["attributionBaseTag"] == plan["previousNightlyTag"]
 
 
+def test_manifest_accepts_an_artifact_tree_with_staged_nightly_versions(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    registry, root = copy_version_fixture(tmp_path, "cua-driver-rs")
+    git(root, "init")
+    git(root, "config", "user.name", "Release Test")
+    git(root, "config", "user.email", "release@example.com")
+    git(root, "add", ".")
+    git(root, "commit", "-m", "chore: seed fixture")
+    git(root, "tag", "cua-driver-rs-v0.19.3")
+    source_sha = git(root, "rev-parse", "HEAD")
+    version = "0.19.4-nightly.20260812.42"
+    apply_version("cua-driver-rs", version, registry_path=registry, root=root)
+
+    with pytest.raises(ChannelError, match="authority is not a stable version"):
+        load_registry(registry, root=root)
+
+    assets = root / "release-upload"
+    assets.mkdir()
+    (assets / "cua-driver.tar.gz").write_bytes(b"nightly")
+
+    def fake_build_manifest(**kwargs):
+        return {"version": kwargs["version"], "tag": kwargs["tag"]}
+
+    monkeypatch.setattr(release_channels.release_attribution, "build_manifest", fake_build_manifest)
+    manifest = build_manifest(
+        "cua-driver-rs",
+        version,
+        f"nightly-cua-driver-rs-v{version}",
+        source_sha,
+        "cua-driver-rs-v0.19.3",
+        assets,
+        repository="trycua/cua",
+        registry_path=registry,
+        root=root,
+        attribution_config_path=ROOT / ".github/release-attribution-config.json",
+        github=object(),
+    )
+    assert manifest == {
+        "version": version,
+        "tag": f"nightly-cua-driver-rs-v{version}",
+    }
+
+
 def test_nightly_manifest_reuses_pr_attribution_and_renders_contributors(tmp_path: Path):
     registry, root = copy_version_fixture(tmp_path, "lume")
     git(root, "init")


### PR DESCRIPTION
## Summary

- let nightly manifest rendering validate registry structure without requiring the already-staged version authority to remain stable
- keep stable authority and Release Please state validation mandatory for planning, validation, and version staging
- cover the exact Driver publish order: stable checkout, nightly staging, then attribution manifest

## Evidence

- Reproduced in [Driver nightly run 31608350705](https://github.com/trycua/cua/actions/runs/31608350705): all platform artifacts passed, then `manifest` rejected the staged nightly authority.
- `.venv/bin/python -m pytest .github/scripts/tests -q` — 213 passed, 18 subtests passed
- Ruff check/format and Python compile checks passed

Refs #3096