### PR TITLE
fix: ignore Driver installer state bumps in attribution

### DIFF
--- a/.github/scripts/release_attribution.py
+++ b/.github/scripts/release_attribution.py
@@ -60,6 +60,11 @@ VERIFIED_IDENTITY_PR_RE = re.compile(
 )
 TRAILING_PR_RE = re.compile(r"\s+\(#(?P<number>\d+)\)\s*$")
 LEGACY_RELEASE_BUMP_RE = re.compile(r"^Bump (?:cua-driver-rs|lume) to v\S+$", re.IGNORECASE)
+PUBLISHED_INSTALLER_BUMP_RE = re.compile(
+    r"^chore\(cua-driver\): advance published installer version to "
+    r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*) \[skip ci\]$",
+    re.IGNORECASE,
+)
 NOREPLY_RE = re.compile(
     r"^(?:\d+\+)?(?P<login>[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})(?:\[bot\])?)@users\.noreply\.github\.com$",
     re.IGNORECASE,
@@ -870,9 +875,11 @@ def build_manifest(
     visual_requested = False
 
     for commit in commits_in_range(repo_root, previous_tag, current_ref, paths, exclude_paths):
-        if re.match(
-            r"^chore(?:\([^)]+\))?: release\b", commit.subject, re.IGNORECASE
-        ) or LEGACY_RELEASE_BUMP_RE.match(commit.subject):
+        if (
+            re.match(r"^chore(?:\([^)]+\))?: release\b", commit.subject, re.IGNORECASE)
+            or LEGACY_RELEASE_BUMP_RE.match(commit.subject)
+            or PUBLISHED_INSTALLER_BUMP_RE.match(commit.subject)
+        ):
             continue
         parsed_subject = parse_conventional_line(commit.subject)
         included_types = ALLOWED_TITLE_TYPES if channel == "nightly" else RELEASING_TYPES

--- a/.github/scripts/tests/test_release_attribution.py
+++ b/.github/scripts/tests/test_release_attribution.py
@@ -10,6 +10,7 @@ from jsonschema import Draft202012Validator
 from release_attribution import (
     CommitRecord,
     LEGACY_RELEASE_BUMP_RE,
+    PUBLISHED_INSTALLER_BUMP_RE,
     ReleaseError,
     _change_contributors,
     build_manifest,
@@ -331,6 +332,18 @@ def test_legacy_release_bump_subject_is_recognized():
     assert LEGACY_RELEASE_BUMP_RE.match("Bump cua-driver-rs to v0.8.3")
     assert LEGACY_RELEASE_BUMP_RE.match("Bump lume to v0.3.16")
     assert not LEGACY_RELEASE_BUMP_RE.match("feat(driver): bump reconnect retries")
+
+
+def test_published_installer_bump_subject_is_recognized_narrowly():
+    assert PUBLISHED_INSTALLER_BUMP_RE.match(
+        "chore(cua-driver): advance published installer version to 0.19.3 [skip ci]"
+    )
+    assert not PUBLISHED_INSTALLER_BUMP_RE.match(
+        "chore(cua-driver): advance published installer version to nightly [skip ci]"
+    )
+    assert not PUBLISHED_INSTALLER_BUMP_RE.match(
+        "feat(cua-driver): advance published installer version to 0.19.3 [skip ci]"
+    )
 
 
 def test_changelog_accepts_verified_commit_link_when_pr_suffix_is_missing():


### PR DESCRIPTION
## Summary

- classify the exact release-bot Driver installer-state bump as release machinery, alongside existing Release Please and legacy bump commits
- keep the skip grammar narrow to stable semantic versions and the generated `[skip ci]` subject
- add regression coverage for accepted and rejected subjects

## Evidence

- Reproduced in [Driver nightly run 31610252853](https://github.com/trycua/cua/actions/runs/31610252853): all platform artifacts and contracts passed, then attribution rejected direct release-bot commit `54a17b7d`.
- Audited the entire Driver range from `cua-driver-rs-v0.19.3` to `71bd161b`; this is the only unassociated commit and is generated by the stable Driver publish workflow.
- Ran the real staged-nightly manifest and renderer against that exact range with GitHub attribution resolution; it produced all 12 PR-backed changes and contributors successfully.
- `.venv/bin/python -m pytest .github/scripts/tests -q` — 214 passed, 18 subtests passed
- Focused attribution/channel/wiring suite — 41 passed
- Ruff and diff checks passed

Refs #3096