### PR TITLE
fix: validate Driver nightly tags after staging

### DIFF
--- a/.github/scripts/github_release.py
+++ b/.github/scripts/github_release.py
@@ -149,7 +149,10 @@ def unique_release(api: GitHubApi, repository: str, tag: str) -> dict[str, Any]:
 
 
 def validate_registered_nightly_tag(tag: str) -> None:
-    registry = release_channels.load_registry()
+    # Driver publication runs after its exact nightly version has been staged
+    # into the checkout. Tag validation needs registry shape and namespaces,
+    # not the stable source-state invariant enforced by planning and builds.
+    registry = release_channels.load_registry(require_stable_state=False)
     matches = []
     for name, component in registry["components"].items():
         try:

--- a/.github/scripts/tests/test_github_release.py
+++ b/.github/scripts/tests/test_github_release.py
@@ -225,6 +225,36 @@ def test_nightly_can_create_a_private_draft_at_the_exact_sha():
     ]
 
 
+def test_nightly_creation_validates_registry_namespaces_after_artifact_staging(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls = []
+
+    def fake_registry(*, require_stable_state: bool):
+        calls.append(require_stable_state)
+        return {
+            "components": {
+                "cua-driver-rs": {
+                    "stableTagPrefix": "cua-driver-rs-v",
+                    "nightlyTagPrefix": "nightly-cua-driver-rs-v",
+                }
+            }
+        }
+
+    monkeypatch.setattr(github_release.release_channels, "load_registry", fake_registry)
+    api = FakeApi("a" * 40)
+    api.release = None
+    ensure_release(
+        api,
+        "trycua/cua",
+        "nightly-cua-driver-rs-v0.19.4-nightly.20260812.42",
+        "a" * 40,
+        channel="nightly",
+        create_if_missing=True,
+    )
+    assert calls == [False]
+
+
 def test_stable_and_unregistered_tags_cannot_create_drafts():
     api = FakeApi("a" * 40)
     api.release = None


### PR DESCRIPTION
## Summary

- validate the registered nightly tag namespace without reapplying stable source-state validation after Driver artifact staging
- retain strict stable source-state checks in planning, validation, and builds
- pin the publisher call to the staged-state-safe registry mode with a focused regression test

## Evidence

- Reproduced in [Driver nightly run 31611807075](https://github.com/trycua/cua/actions/runs/31611807075): all builds, artifact contracts, attribution rendering, and evidence preservation passed; draft creation then revalidated the staged version authority as stable.
- `.venv/bin/python -m pytest .github/scripts/tests -q` — 215 passed, 18 subtests passed
- Focused publisher/channel/wiring suite — 35 passed
- Ruff, compile, and diff checks passed

Refs #3096