### PR TITLE
docs: split sandbox lifecycle guides

### DIFF
--- a/docs/content/docs/how-to-guides/sandbox/choose-local-runtime.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/choose-local-runtime.mdx
@@ -1,0 +1,23 @@
+---
+title: Choose a local sandbox runtime
+description: Run a sandbox on your own machine and let Cua select a compatible runtime for its image type.
+---
+
+Pass `local=True` to use a runtime on your own machine. Cua selects a compatible local runtime from the image type: Docker for Linux containers, QEMU for Linux VMs, Lume for macOS VMs, and QEMU or Hyper-V for Windows VMs.
+
+```python
+import asyncio
+from cua import Image, Sandbox
+
+async def main():
+    # local Docker desktop container
+    async with Sandbox.ephemeral(
+        Image.linux(kind='container'),
+        local=True,
+    ) as sb:
+        await sb.shell.run('echo running locally')
+
+asyncio.run(main())
+```
+
+Choose the image's operating system and isolation level before setting `local=True`. See [Choose and build a sandbox image](/how-to-guides/sandbox/images) for the available image constructors.

--- a/docs/content/docs/how-to-guides/sandbox/create-auto-destroy-sandbox.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/create-auto-destroy-sandbox.mdx
@@ -1,0 +1,21 @@
+---
+title: Create and auto-destroy a sandbox
+description: Use Sandbox.ephemeral for a temporary sandbox that is deleted automatically after a script or job.
+---
+
+Use `Sandbox.ephemeral` for scripts, CI, and one-off tasks.
+
+```python
+import asyncio
+from cua import Image, Sandbox
+
+async def main():
+    async with Sandbox.ephemeral(Image.linux(), local=True) as sb:
+        result = await sb.shell.run('echo hello')
+        print(result.stdout)  # 'hello\n'
+    # sandbox deleted here
+
+asyncio.run(main())
+```
+
+`Sandbox.ephemeral` is **auto-destroyed** when the `async with` block exits. Its context manager tears the sandbox down automatically.

--- a/docs/content/docs/how-to-guides/sandbox/create-persistent-sandbox.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/create-persistent-sandbox.mdx
@@ -1,0 +1,41 @@
+---
+title: Create a persistent sandbox
+description: Create a sandbox that outlives the current script, then disconnect from or permanently delete it.
+---
+
+Use `Sandbox.create` when the sandbox **must outlive the script**. Call `await sb.disconnect()` to drop the connection while the sandbox keeps running.
+
+```python
+import asyncio
+from cua import Image, Sandbox
+
+async def main():
+    sb = await Sandbox.create(
+        Image.linux(),
+        name='my-dev-sandbox',
+        local=True,
+    )
+    await sb.shell.run('apt-get install -y vim')
+    await sb.disconnect()  # sandbox keeps running
+
+asyncio.run(main())
+```
+
+Delete the sandbox when you are done with it.
+
+```python
+import asyncio
+from cua import Sandbox
+
+async def main():
+    async with Sandbox.connect('my-dev-sandbox', local=True) as sb:
+        await sb.destroy()
+
+asyncio.run(main())
+```
+
+| Method                       | Effect                                            | When            |
+| ---------------------------- | ------------------------------------------------- | --------------- |
+| `await sb.disconnect()`      | keeps running                                     | reconnect later |
+| `await sb.destroy()`         | permanently destroyed                             | done with it    |
+| `await Sandbox.delete(name)` | permanently destroyed by name, without connecting | done with it    |

--- a/docs/content/docs/how-to-guides/sandbox/lifecycle.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/lifecycle.mdx
@@ -1,97 +1,28 @@
 ---
-title: Sandbox lifecycle
-description: Choose the right Sandbox SDK lifecycle pattern for temporary, persistent, and reconnectable sandboxes.
+title: Choose a sandbox lifecycle
+description: Choose the right Sandbox SDK lifecycle guide for temporary, persistent, and reconnectable sandboxes.
 ---
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
-Use the **lifecycle pattern** that matches whether you want the sandbox *deleted after the job*, *kept for later*, or *attached to while it is already running*.
+Choose the lifecycle pattern that matches whether you want the sandbox deleted after the job, kept for later, or attached to while it is already running.
 
 ## Create and auto-destroy a sandbox
 
-Use `Sandbox.ephemeral` for scripts, CI, and one-off tasks.
-
-```python
-import asyncio
-from cua import Sandbox, Image
-
-async def main():
-    async with Sandbox.ephemeral(Image.linux(), local=True) as sb:
-        result = await sb.shell.run('echo hello')
-        print(result.stdout)  # 'hello\n'
-    # sandbox deleted here
-
-asyncio.run(main())
-```
-
-`Sandbox.ephemeral` is **auto-destroyed** when the `async with` block exits. Its context manager tears the sandbox down automatically.
+For scripts, CI, and one-off tasks, [create an ephemeral sandbox that deletes itself when the job exits](/how-to-guides/sandbox/create-auto-destroy-sandbox).
 
 ## Create a persistent sandbox
 
-Use `Sandbox.create` when the sandbox **must outlive the script**. Call `await sb.disconnect()` to drop the connection while the sandbox keeps running.
-
-```python
-sb = await Sandbox.create(Image.linux(), name='my-dev-sandbox', local=True)
-await sb.shell.run('apt-get install -y vim')
-await sb.disconnect()  # sandbox keeps running
-```
-
-Delete the sandbox when you are done with it.
-
-```python
-async with Sandbox.connect('my-dev-sandbox', local=True) as sb:
-    await sb.destroy()
-```
-
-| Method | Effect | When |
-|--------|--------|------|
-| `await sb.disconnect()` | keeps running | reconnect later |
-| `await sb.destroy()` | permanently destroyed | done with it |
-| `await Sandbox.delete(name)` | permanently destroyed (by name, no connect) | classmethod |
+When state must outlive the current script, [create a persistent sandbox and disconnect from it without stopping it](/how-to-guides/sandbox/create-persistent-sandbox).
 
 ## Reconnect to a running sandbox
 
-Use `Sandbox.connect` to attach to an already-running sandbox.
-
-<Callout type="info">
-  Sandbox.connect never starts or stops the sandbox. It only manages the network connection.
-</Callout>
-
-Reconnect by name.
-
-```python
-async with Sandbox.connect('my-dev-sandbox', local=True) as sb:
-    result = await sb.shell.run('vim --version')
-    print(result.stdout)
-```
-
-`Sandbox.connect` supports both `await` and `async with`. Its context manager calls `disconnect()` automatically, so the sandbox keeps running after the connection closes.
-
-```python
-async with Sandbox.connect('my-sandbox', local=True) as sb:
-    await sb.shell.run('echo reconnected')
-# connection dropped, sandbox keeps running
-```
+To continue work in an existing sandbox, [attach by name without starting or stopping it](/how-to-guides/sandbox/reconnect-running-sandbox).
 
 ## List running sandboxes
 
-List available sandboxes, then filter to local runtimes when needed.
-
-```python
-sandboxes = await Sandbox.list(local=True)
-for info in sandboxes:
-    print(info.name, info.os_type, info.status)
-```
+To discover local or cloud sandboxes, [list their names, operating systems, and statuses](/how-to-guides/sandbox/list-sandboxes).
 
 ## Choose a local runtime
 
-Pass `local=True` to use a runtime on your own machine. Cua selects a compatible local runtime from the image type: Docker for Linux containers, QEMU for Linux VMs, Lume for macOS VMs, and QEMU or Hyper-V for Windows VMs.
+To run on your own machine, [choose an image and let Cua select its compatible local runtime](/how-to-guides/sandbox/choose-local-runtime).
 
-```python
-# local Docker desktop container
-async with Sandbox.ephemeral(
-    Image.linux(kind='container'),
-    local=True,
-) as sb:
-    ...
-```
+Start with the auto-destroy pattern unless the sandbox must outlive the current job. Use a persistent sandbox when you need to install software or keep state for a later connection.

--- a/docs/content/docs/how-to-guides/sandbox/list-sandboxes.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/list-sandboxes.mdx
@@ -1,0 +1,20 @@
+---
+title: List sandboxes
+description: List existing local or cloud sandboxes and inspect their names, operating systems, and statuses.
+---
+
+List available sandboxes, then filter to local runtimes when needed.
+
+```python
+import asyncio
+from cua import Sandbox
+
+async def main():
+    sandboxes = await Sandbox.list(local=True)
+    for info in sandboxes:
+        print(info.name, info.os_type, info.status)
+
+asyncio.run(main())
+```
+
+Pass `local=True` to list sandboxes on your machine. Omit it to list cloud sandboxes.

--- a/docs/content/docs/how-to-guides/sandbox/meta.json
+++ b/docs/content/docs/how-to-guides/sandbox/meta.json
@@ -2,6 +2,11 @@
   "title": "Sandbox",
   "pages": [
     "lifecycle",
+    "create-auto-destroy-sandbox",
+    "create-persistent-sandbox",
+    "reconnect-running-sandbox",
+    "list-sandboxes",
+    "choose-local-runtime",
     "configure-pool-with-terraform",
     "create-pool-with-python",
     "secrets",

--- a/docs/content/docs/how-to-guides/sandbox/reconnect-running-sandbox.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/reconnect-running-sandbox.mdx
@@ -1,0 +1,40 @@
+---
+title: Reconnect to a running sandbox
+description: Attach to an existing sandbox by name without starting or stopping it.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Use `Sandbox.connect` to attach to an already-running sandbox.
+
+<Callout type="info">
+  `Sandbox.connect` never starts or stops the sandbox. It only manages the network connection.
+</Callout>
+
+Reconnect by name.
+
+```python
+import asyncio
+from cua import Sandbox
+
+async def main():
+    async with Sandbox.connect('my-dev-sandbox', local=True) as sb:
+        result = await sb.shell.run('vim --version')
+        print(result.stdout)
+
+asyncio.run(main())
+```
+
+`Sandbox.connect` supports both `await` and `async with`. Its context manager calls `disconnect()` automatically, so the sandbox keeps running after the connection closes.
+
+```python
+import asyncio
+from cua import Sandbox
+
+async def main():
+    async with Sandbox.connect('my-sandbox', local=True) as sb:
+        await sb.shell.run('echo reconnected')
+    # connection dropped, sandbox keeps running
+
+asyncio.run(main())
+```

--- a/docs/content/docs/tutorials/your-first-local-sandbox.mdx
+++ b/docs/content/docs/tutorials/your-first-local-sandbox.mdx
@@ -67,7 +67,8 @@ When the `async with` block exited, **the sandbox destroyed itself**. No cleanup
 
 ## Next steps
 
-- [Manage sandbox lifecycle](/how-to-guides/sandbox/lifecycle)
+- [Create and auto-destroy a sandbox](/how-to-guides/sandbox/create-auto-destroy-sandbox)
+- [Choose a sandbox lifecycle](/how-to-guides/sandbox/lifecycle)
 - [Choose and build a sandbox image](/how-to-guides/sandbox/images)
 - [Open an interactive sandbox shell](/how-to-guides/sandbox/interactive-shell)
 - [Sandbox SDK API reference](/reference/sandbox-sdk)


### PR DESCRIPTION
## What changed

- split the five practical sandbox lifecycle sections into standalone how-to guides
- keep `/how-to-guides/sandbox/lifecycle` as a concise chooser while preserving its existing heading anchors
- add every new guide explicitly to the Sandbox sidebar
- update the local sandbox tutorial to link directly to the auto-destroy guide

## Validation

- `corepack pnpm docs:check -- --changed` — passed; no generated-reference changes detected
- `corepack pnpm docs:check-hygiene` — passed
- `corepack pnpm docs:check-links` — passed (`0 errored file, 0 errors`)
- `corepack pnpm build` — passed; 121 static pages generated
- parsed all 7 new Python code blocks with `ast.parse` — passed
- Prettier check for all 8 changed docs files — passed
- `git diff --check` — passed

## Known environment limitation

The unfiltered `corepack pnpm docs:check` cannot complete in this environment because the native generated-reference checks require Rust/Cargo and Swift, neither of which is installed. The changed-path generator check passes and confirms this manual docs-only change does not affect generated references.