### PR TITLE
chore(sandbox): use public containerDisk images

### DIFF
--- a/.github/workflows/ci-public-containerdisk-refs.yml
+++ b/.github/workflows/ci-public-containerdisk-refs.yml
@@ -1,0 +1,24 @@
+name: "CI: Public ContainerDisk References"
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/ci-public-containerdisk-refs.yml"
+      - "docs/content/docs/how-to-guides/sandbox/**"
+      - "docs/superpowers/plans/2026-08-09-periodic-cua-sandbox-live-e2e.md"
+      - "docs/superpowers/specs/2026-08-09-periodic-cua-sandbox-live-e2e-design.md"
+      - "infra/fleets-wif-smoke/**"
+      - "libs/fleet/backend/auth/**"
+      - "libs/python/cua-sandbox/tests/live/test_fleet_ephemeral.py"
+      - "tests/test_public_containerdisk_refs.py"
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Reject private containerDisk references
+        run: python3 -m unittest tests.test_public_containerdisk_refs

--- a/docs/content/docs/how-to-guides/sandbox/configure-pool-with-terraform.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/configure-pool-with-terraform.mdx
@@ -65,7 +65,7 @@ resource "fleets_pool" "linux" {
   name                 = "linux-pool"
   cpu_cores            = 4
   memory               = "8Gi"
-  container_disk_image = "296062593712.dkr.ecr.us-west-2.amazonaws.com/desktop-workspace-duo:main-38352d34"
+  container_disk_image = "public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04:main-e5d853a9"
   runtime              = "kubevirt"
   firmware             = "bios"
 
@@ -117,7 +117,7 @@ resource "fleets_pool" "windows" {
   name                 = "windows-pool"
   cpu_cores            = 4
   memory               = "4Gi"
-  container_disk_image = "296062593712.dkr.ecr.us-west-2.amazonaws.com/cua-server-windows:latest"
+  container_disk_image = "public.ecr.aws/k5j5w0x5/cua-windows-2022:latest"
   runtime              = "kubevirt"
   firmware             = "efi"
 

--- a/docs/content/docs/how-to-guides/sandbox/create-pool-with-python.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/create-pool-with-python.mdx
@@ -51,8 +51,8 @@ from cua_sandbox import Image, Pool
 
 
 IMAGE = (
-    "296062593712.dkr.ecr.us-west-2.amazonaws.com/desktop-workspace-duo"
-    "@sha256:5b9cb82f482834f7541901b87be956e7544d0db13fabc0b372cbc5eca5a74180"
+    "public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04"
+    "@sha256:82702ebdd32d1f8fc05f2ea409a7c67d0ba9f8f8e4e9f1a89ce40989d5f4475d"
 )
 
 POOL_NAME = os.environ.get("CUA_POOL_NAME", "cua-live-main-source-manual")

--- a/docs/superpowers/plans/2026-08-09-periodic-cua-sandbox-live-e2e.md
+++ b/docs/superpowers/plans/2026-08-09-periodic-cua-sandbox-live-e2e.md
@@ -13,7 +13,7 @@
 - Schedule must remain `7/15 * * * *`, running at `:07`, `:22`, `:37`, and `:52` UTC.
 - Scheduled runs execute both `main-source` and `published-package`; relevant pushes to `main` execute only `main-source`.
 - Manual dispatch accepts `both`, `main-source`, or `published-package`; only manual dispatch may set `force_failure=true`.
-- Use image `296062593712.dkr.ecr.us-west-2.amazonaws.com/desktop-workspace-duo@sha256:5b9cb82f482834f7541901b87be956e7544d0db13fabc0b372cbc5eca5a74180`.
+- Use image `public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04@sha256:82702ebdd32d1f8fc05f2ea409a7c67d0ba9f8f8e4e9f1a89ce40989d5f4475d`.
 - Provision with `cpu=4`, `memory_mb=4096`, `server_port=8000`, `time_to_start=900`, `request_timeout=60`, and `telemetry_enabled=False`.
 - Authenticate only with `CUA_CLIENT_ID`, `CUA_CLIENT_SECRET`, `CUA_FLEET_BASE_URL=https://run.cua.ai`, and the default Cyclops token endpoint.
 - Do not use `CUA_API_KEY`, legacy `/api/keys`, namespace-scoped key creation, repository-private SDK helpers, or mutable image tags.
@@ -386,8 +386,8 @@ from tests.live.fleet_e2e_support import (
 )
 
 IMAGE = (
-    "296062593712.dkr.ecr.us-west-2.amazonaws.com/desktop-workspace-duo"
-    "@sha256:5b9cb82f482834f7541901b87be956e7544d0db13fabc0b372cbc5eca5a74180"
+    "public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04"
+    "@sha256:82702ebdd32d1f8fc05f2ea409a7c67d0ba9f8f8e4e9f1a89ce40989d5f4475d"
 )
 
 

--- a/docs/superpowers/specs/2026-08-09-periodic-cua-sandbox-live-e2e-design.md
+++ b/docs/superpowers/specs/2026-08-09-periodic-cua-sandbox-live-e2e-design.md
@@ -125,7 +125,7 @@ Event-and-lane concurrency serializes each deterministic claim.
 Provision with the exact certified image:
 
 ```text
-296062593712.dkr.ecr.us-west-2.amazonaws.com/desktop-workspace-duo@sha256:5b9cb82f482834f7541901b87be956e7544d0db13fabc0b372cbc5eca5a74180
+public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04@sha256:82702ebdd32d1f8fc05f2ea409a7c67d0ba9f8f8e4e9f1a89ce40989d5f4475d
 ```
 
 Use the public SDK with:

--- a/infra/fleets-wif-smoke/main.tf
+++ b/infra/fleets-wif-smoke/main.tf
@@ -24,7 +24,7 @@ resource "fleets_pool" "cua_cli_wif_smoke" {
   replicas             = 0
   cpu_cores            = 4
   memory               = "8Gi"
-  container_disk_image = "296062593712.dkr.ecr.us-west-2.amazonaws.com/desktop-workspace-duo:latest"
+  container_disk_image = "public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04:latest"
   readiness_probe_json = jsonencode({ tcpSocket = { port = 8000 } })
 
   service {

--- a/libs/python/cua-sandbox/tests/live/test_fleet_ephemeral.py
+++ b/libs/python/cua-sandbox/tests/live/test_fleet_ephemeral.py
@@ -20,8 +20,8 @@ from tests.live.fleet_e2e_support import (
 )
 
 IMAGE = (
-    "296062593712.dkr.ecr.us-west-2.amazonaws.com/desktop-workspace-duo"
-    "@sha256:5b9cb82f482834f7541901b87be956e7544d0db13fabc0b372cbc5eca5a74180"
+    "public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04"
+    "@sha256:82702ebdd32d1f8fc05f2ea409a7c67d0ba9f8f8e4e9f1a89ce40989d5f4475d"
 )
 
 

--- a/tests/test_public_containerdisk_refs.py
+++ b/tests/test_public_containerdisk_refs.py
@@ -1,7 +1,6 @@
-from pathlib import Path
 import subprocess
 import unittest
-
+from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 PRIVATE_REGISTRY = "296062593712.dkr.ecr.us-west-2.amazonaws.com"
@@ -13,12 +12,16 @@ PRIVATE_REPOSITORIES = (
 
 class PublicContainerDiskReferenceTests(unittest.TestCase):
     def test_tracked_files_do_not_reference_private_containerdisk_repositories(self) -> None:
-        tracked_files = subprocess.run(
-            ["git", "ls-files", "-z"],
-            cwd=ROOT,
-            check=True,
-            capture_output=True,
-        ).stdout.decode().split("\0")
+        tracked_files = (
+            subprocess.run(
+                ["git", "ls-files", "-z"],
+                cwd=ROOT,
+                check=True,
+                capture_output=True,
+            )
+            .stdout.decode()
+            .split("\0")
+        )
         violations = []
         for relative_path in tracked_files:
             if not relative_path:

--- a/tests/test_public_containerdisk_refs.py
+++ b/tests/test_public_containerdisk_refs.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import subprocess
+import unittest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+PRIVATE_REGISTRY = "296062593712.dkr.ecr.us-west-2.amazonaws.com"
+PRIVATE_REPOSITORIES = (
+    f"{PRIVATE_REGISTRY}/desktop-workspace-duo",
+    f"{PRIVATE_REGISTRY}/cua-server-windows",
+)
+
+
+class PublicContainerDiskReferenceTests(unittest.TestCase):
+    def test_tracked_files_do_not_reference_private_containerdisk_repositories(self) -> None:
+        tracked_files = subprocess.run(
+            ["git", "ls-files", "-z"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+        ).stdout.decode().split("\0")
+        violations = []
+        for relative_path in tracked_files:
+            if not relative_path:
+                continue
+            path = ROOT / relative_path
+            if not path.is_file():
+                continue
+            try:
+                text = path.read_text()
+            except UnicodeDecodeError:
+                continue
+            for repository in PRIVATE_REPOSITORIES:
+                if repository in text:
+                    violations.append(f"{relative_path}: {repository}")
+        self.assertEqual(
+            violations,
+            [],
+            "Private containerDisk references remain:\n" + "\n".join(violations),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Replace all tracked private Ubuntu/Windows containerDisk references with the public repositories:

- `public.ecr.aws/k5j5w0x5/cua-ubuntu-24.04`
- `public.ecr.aws/k5j5w0x5/cua-windows-2022`

The live Fleet smoke and Python pool guide use the verified immutable Ubuntu digest. Terraform examples preserve their existing tag semantics (`main-e5d853a9` for the pinned guide and `latest` for intentionally rolling smoke/example sites). The canonical Fleet admission policy migration landed through trycua/cloud#6773 and forward-synced to `cua/main`; this PR now contains only Cua-owned consumers and guards.

A path-scoped CI guard scans every tracked regular file and rejects either obsolete private repository.

## Integration tests by change site

| Change site | Validation | Expected result |
| --- | --- | --- |
| Terraform pool guide | Render/build the docs and run the Linux and Windows snippets with unique pool names | Linux accepts `main-e5d853a9`; Windows accepts public `latest` with EFI and reaches the computer-server readiness probe. |
| Python pool guide | Run the documented script with Fleet OAuth credentials | Pool and claim start from Ubuntu digest `sha256:82702e...4475d`, shell and screenshot operations work, and cleanup succeeds. |
| Periodic `cua-sandbox` live smoke | `uv run --frozen --project libs/python/cua-sandbox pytest -q libs/python/cua-sandbox/tests/test_live_fleet_e2e_support.py libs/python/cua-sandbox/tests/live/test_fleet_ephemeral.py`; after merge manually dispatch `periodic-cua-sandbox-live.yml` with `lane=both` | Offline contracts pass; live source and published lanes provision from the public immutable digest without claim leaks. |
| Fleets WIF smoke Terraform | `terraform fmt -check infra/fleets-wif-smoke/main.tf`; manually dispatch `infra-fleets-wif-smoke.yml` after merge | Terraform validates/applies and the GitHub WIF smoke pool reconciles using public Ubuntu `latest`. |
| Periodic workflow contract | `uv run --with pytest python -m pytest -q .github/scripts/tests/test_periodic_cua_sandbox_live.py` | Workflow trigger, credential, cleanup, and alert contracts remain valid. |
| Repository migration guard | `python3 -m unittest tests.test_public_containerdisk_refs` | No tracked private Ubuntu/Windows containerDisk reference remains. |
| Public registry availability | Anonymous OCI manifest `HEAD` checks | Ubuntu `main-e5d853a9`/digest/`latest` and Windows `latest` resolve publicly to their verified digests. |

## Validation performed

- repository ref guard — passed
- canonical Fleet policy validation in trycua/cloud#6773 — OPA 182 passed and forward sync completed
- live Fleet support + opt-in scenario — 38 passed, 1 credential-gated skip
- periodic workflow contract — 8 passed, 12 subtests passed
- Terraform formatting — passed
- anonymous public ECR digest checks — passed
- `git diff --check` — passed

## Follow-up

PR #3091 currently introduces the old private Ubuntu repository in `Image.linux()`. It must use the public Ubuntu reference before merging so this repository-wide guard remains green.

