### PR TITLE
docs: add guide for using images on Cua Cloud

### DIFF
--- a/docs/content/docs/how-to-guides/sandbox/images.mdx
+++ b/docs/content/docs/how-to-guides/sandbox/images.mdx
@@ -134,6 +134,46 @@ Image.from_file('https://example.com/disk.qcow2', os_type='linux')
 
 Images are cached in `~/.cua/cua-sandbox/image-cache/`.
 
+## Use images on Cua Cloud
+
+Sandboxes run on Cua Cloud by default: omit `local=True` and set the `CUA_API_KEY` environment variable. The built-in constructors all work in the cloud.
+
+```python
+from cua import Sandbox, Image
+
+img = Image.linux().apt_install('curl', 'git').pip_install('requests')
+
+async with Sandbox.ephemeral(img) as sb:  # no local=True, so this runs on Cua Cloud
+    ...
+```
+
+Cua Cloud provisions the sandbox from a managed base image matching the image's OS type — `Image.linux()`, `Image.windows()`, `Image.macos()`, or `Image.android()` — then applies your builder layers (packages, environment variables, setup commands, copied files) once the sandbox is running.
+
+Size the cloud machine on the `Sandbox` call, not the Image. `cpu`, `memory_mb`, `disk_gb`, and `region` are cloud-only parameters.
+
+```python
+sb = await Sandbox.create(
+    Image.linux(),
+    name='my-cloud-sandbox',
+    cpu=4,
+    memory_mb=8192,
+    disk_gb=64,
+    region='us-east-1',
+)
+```
+
+<Callout type="info">
+  Image.from_registry() and Image.from_file() are supported on local runtimes only. To reuse a customized environment in the cloud, snapshot a running cloud sandbox instead.
+</Callout>
+
+Snapshot a cloud sandbox to capture its disk state as a new Image, then start any number of forks from it without repeating setup work.
+
+```python
+snap = await sb.snapshot()                    # returns an Image
+async with Sandbox.ephemeral(snap) as fork:   # starts from the snapshot
+    ...
+```
+
 ## Inspect an image
 
 Call `.to_dict()` to inspect the final image spec before using it.


### PR DESCRIPTION
## Summary

- Problem this solves: Users need documentation on how to use custom images with Cua Cloud sandboxes, including cloud-specific parameters, limitations, and the snapshot workflow.
- What changed: Added a new "Use images on Cua Cloud" section to the images documentation explaining cloud sandbox provisioning, machine sizing, registry/file limitations, and snapshotting.

## Related work

Refs #

## Compatibility and risk

- User-visible, API/CLI/MCP, migration, permission, or platform impact: Documentation only; no code changes.
- Risk and rollback: None. This is purely additive documentation.

## Validation

- Focused tests and checks: N/A (documentation change)
- Manual or platform evidence: Documentation review
- Known gaps or CI still required: None

## Contributor and release checks

- [x] The PR is focused and the description matches the final diff.
- [x] This change does not require an RFC, or the accepted RFC is linked above.
- [x] Tests, documentation, and platform evidence are included or the gap is explained.
- [x] The PR title is a Conventional Commit describing the production change.
- [x] External contributor authorship is preserved, or no external contribution is included.
- [x] If release-tracked files changed but this is intentionally non-releasing, the `no-release` label is applied.

https://claude.ai/code/session_014qUGPb6dqSH9XrxqxDYtjj