### PR TITLE
docs: link Cua service status

### DIFF
--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -5,6 +5,8 @@ description: 'Open-source computer-use automation for real machines and local is
 
 Cua is an open-source MIT-licensed platform ([github.com/trycua/cua](https://github.com/trycua/cua)) for **computer-use automation**: letting AI agents operate computers by clicking, typing, and reading the screen and accessibility tree. What we refer to as **Computer-Use 2.0** treats the GUI as one tool surface in an agent loop, alongside code, shell, files, and APIs. Use Cua Driver to drive a machine you already have, Cua Sandbox to start an isolated local desktop, or Cua-Bench to evaluate computer-use agents.
 
+For live service availability and incident updates, see [Cua Status](https://status.cua.ai).
+
 import { Card, Cards } from 'fumadocs-ui/components/card';
 
 <Cards>


### PR DESCRIPTION
## What changed

- Adds a prominent Cua Status link to the docs landing page
- Directs readers to live service availability and incident updates

## Validation

- Verified the branch content contains exactly one `https://status.cua.ai` link

Requested in Slack.