### PR TITLE
Make S3 publishing replace stale index files instead of accumulating

### DIFF
--- a/docs/scripts/modal_app.py
+++ b/docs/scripts/modal_app.py
@@ -469,6 +469,48 @@ async def crawl_docs():
     return summary
 
 
+def _publish_dir(s3, bucket: str, local_dir, prefix: str) -> int:
+    """Publish local_dir to s3://bucket/prefix, removing anything stale.
+
+    Uploads every file, then deletes keys under the prefix that the current
+    build did not write. Plain upload-only publishing is what broke docs
+    vector search: the indexer rebuilds docs.lance from scratch, but old
+    files were never removed from S3, so manifests from a previous Lance
+    format lingered next to the new ones. Lance then refused to open the
+    table ("Found multiple manifest naming schemes in the same directory:
+    V1 and V2") and the server reported it as a missing database.
+
+    Deletes run after the uploads, not before, so the prefix is never empty
+    and the S3->PVC sync job cannot mirror a half-published table.
+    """
+    uploaded_keys = set()
+    count = 0
+    for fpath in sorted(local_dir.rglob("*")):
+        if fpath.is_file():
+            key = f"{prefix}{fpath.relative_to(local_dir).as_posix()}"
+            s3.upload_file(str(fpath), bucket, key)
+            uploaded_keys.add(key)
+            count += 1
+
+    stale = []
+    for page in s3.get_paginator("list_objects_v2").paginate(
+        Bucket=bucket, Prefix=prefix
+    ):
+        for obj in page.get("Contents", []):
+            if obj["Key"] not in uploaded_keys:
+                stale.append({"Key": obj["Key"]})
+
+    for batch_start in range(0, len(stale), 1000):
+        s3.delete_objects(
+            Bucket=bucket,
+            Delete={"Objects": stale[batch_start : batch_start + 1000]},
+        )
+    if stale:
+        print(f"  Removed {len(stale)} stale object(s) under {prefix}")
+
+    return count
+
+
 @app.function(
     image=image,
     volumes={VOLUME_PATH: docs_volume, CODE_VOLUME_PATH: code_volume},
@@ -527,11 +569,7 @@ def sync_to_s3(bucket: str = S3_BUCKET_NAME):
         # LanceDB directory
         lance_dir = docs_db_dir / "docs.lance"
         if lance_dir.exists():
-            for fpath in lance_dir.rglob("*"):
-                if fpath.is_file():
-                    key = f"docs_db/docs.lance/{fpath.relative_to(lance_dir)}"
-                    s3.upload_file(str(fpath), bucket, key)
-                    uploaded += 1
+            uploaded += _publish_dir(s3, bucket, lance_dir, "docs_db/docs.lance/")
             print("  Uploaded docs LanceDB directory")
 
     # --- code databases ---
@@ -548,11 +586,9 @@ def sync_to_s3(bucket: str = S3_BUCKET_NAME):
         # Aggregated LanceDB directory
         code_lance = code_db_dir / "code_index.lancedb"
         if code_lance.exists():
-            for fpath in code_lance.rglob("*"):
-                if fpath.is_file():
-                    key = f"code_db/code_index.lancedb/{fpath.relative_to(code_lance)}"
-                    s3.upload_file(str(fpath), bucket, key)
-                    uploaded += 1
+            uploaded += _publish_dir(
+                s3, bucket, code_lance, "code_db/code_index.lancedb/"
+            )
             print("  Uploaded code LanceDB directory")
 
     print(f"S3 sync complete: {uploaded} files uploaded to s3://{bucket}/")


### PR DESCRIPTION
## The bug

`sync_to_s3` uploaded every file of `docs.lance` and `code_index.lancedb` but never deleted anything:

```python
for fpath in lance_dir.rglob("*"):
    if fpath.is_file():
        key = f"docs_db/docs.lance/{fpath.relative_to(lance_dir)}"
        s3.upload_file(str(fpath), bucket, key)
```

The indexer rebuilds `docs.lance` from scratch each run, so the bucket accumulated every previous generation of the table indefinitely.

## What it caused

When the indexer moved to a newer Lance release, it began writing V2-style manifests (`u64::MAX - version`) into a prefix that still held V1 manifests from February. Lance refuses to open that:

```
lance error: Found multiple manifest naming schemes in the same directory: V1 and V2.
Use `migrate_manifest_paths_v2` to migrate the directory.
```

The server reported it as `Database not found. Ensure the docs database is mounted at DOCS_DB_PATH.` — which accuses the volume mount, though the mount was fine and `docs.sqlite` loaded from the same directory. `query_docs_vectors` failed on every call and the assistant silently fell back to SQLite full-text search, so nothing looked broken from the outside.

At the point of diagnosis the prefix held **42 V1 manifests alongside 45 V2** manifests.

## The fix

`_publish_dir` uploads every file, then deletes keys under the prefix that this build did not write — `aws s3 sync --delete` semantics.

Deletes run **after** the uploads, deliberately. Purging first would leave a window where the prefix is empty, and the `docs-mcp-s3-sync` CronJob pulls S3 → PVC with `--delete`; if the two overlapped, the server's PVC would be emptied.

Applied to both indexes. `code_db` had the identical latent bug and simply had not hit a format change yet.

## Permissions

No IAM change needed — the Modal write role already grants `s3:DeleteObject`, `s3:PutObject` and `s3:ListBucket` (`terraform/aws/docs-mcp-storage/main.tf:175-188` in trycua/cloud).

## Test

- `python -m py_compile docs/scripts/modal_app.py`
- Verified `_publish_dir` is a plain module-level helper and the `@app.function(...)` decorator still binds to `sync_to_s3`

Not executed against Modal or S3. The behaviour it prevents was reproduced and fixed by hand: the 42 stale V1 manifests were deleted from the bucket, the sync job re-run, and the server now logs `Docs LanceDB loaded from /data/docs_db` with `query_docs_vectors` succeeding on cua.ai/docs. This change stops it recurring on the next format bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)