### PR TITLE
fix(sandbox): forward Image.expose() ports on the local QEMU path

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/runtime/base.py
+++ b/libs/python/cua-sandbox/cua_sandbox/runtime/base.py
@@ -36,6 +36,9 @@ class RuntimeInfo:
     environment: Optional[str] = None  # OS type hint for QMP transport
     agent_type: Optional[str] = None  # e.g. "osworld" for OSWorld Flask server
     guest_server_port: int = 8000  # Port the guest server listens on
+    # guest port -> host port for each Image.expose() port that was forwarded.
+    # Empty when the runtime cannot forward extra ports.
+    exposed_ports: Optional[dict] = None
     ssh_port: Optional[int] = None  # SSH port on the guest
     ssh_username: Optional[str] = None
     ssh_password: Optional[str] = None

--- a/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
+++ b/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
@@ -310,6 +310,23 @@ class QEMUBaremetalRuntime(Runtime):
         # Detect guest server port from transport hint
         guest_port = 5000 if image._agent_type == "osworld" else 8000
 
+        # Image.expose() ports. Without these the port is silently unreachable
+        # from the host: the guest listens, nothing forwards, and nothing errors.
+        exposed_ports: dict = {}
+        extra_hostfwd = ""
+        for exposed in dict.fromkeys(image._ports):
+            if exposed == guest_port:
+                # already forwarded as the computer-server port
+                exposed_ports[exposed] = hostfwd_port
+                continue
+            host_port = _find_free_port(exposed)
+            while host_port in exposed_ports.values() or host_port in (hostfwd_port, qmp_port):
+                host_port = _find_free_port(host_port + 1)
+            exposed_ports[exposed] = host_port
+            extra_hostfwd += f",hostfwd=tcp:127.0.0.1:{host_port}-:{exposed}"
+        if exposed_ports:
+            logger.info(f"Forwarding exposed ports (guest -> host): {exposed_ports}")
+
         # Detect disk format from extension
         disk_ext = Path(disk_path).suffix.lower()
         disk_fmt = {".qcow2": "qcow2", ".vhdx": "vhdx", ".raw": "raw", ".img": "raw"}.get(
@@ -377,7 +394,8 @@ class QEMUBaremetalRuntime(Runtime):
                 "-drive",
                 f"file={disk_path},format={disk_fmt},if=virtio",
                 "-netdev",
-                f"user,id=net0,restrict=on,hostfwd=tcp:127.0.0.1:{hostfwd_port}-:{guest_port}",
+                f"user,id=net0,restrict=on,"
+                f"hostfwd=tcp:127.0.0.1:{hostfwd_port}-:{guest_port}{extra_hostfwd}",
                 "-device",
                 "virtio-net-pci,netdev=net0,mac=52:55:00:d1:55:01",
                 "-vnc",
@@ -435,6 +453,7 @@ class QEMUBaremetalRuntime(Runtime):
         info = RuntimeInfo(
             host="localhost",
             api_port=hostfwd_port,
+            exposed_ports=exposed_ports or None,
             vnc_port=5900 + vnc_display,
             name=name,
             qmp_port=qmp_port if use_qmp else None,
@@ -460,6 +479,7 @@ class QEMUBaremetalRuntime(Runtime):
                 image=image.to_dict(),
                 host="localhost",
                 api_port=hostfwd_port,
+                exposed_ports=exposed_ports or None,
                 vnc_port=5900 + vnc_display,
                 qmp_port=qmp_port,
                 disk_path=str(disk_path) if disk_path else None,

--- a/libs/python/cua-sandbox/tests/test_docs_regressions.py
+++ b/libs/python/cua-sandbox/tests/test_docs_regressions.py
@@ -120,6 +120,26 @@ class TestConcurrentLocalVMsDoNotCollide:
         b = Path("/s/beta.qcow2").with_suffix(".efivars.fd")
         assert a != b
 
+    def test_expose_forwards_ports_on_the_local_qemu_path(self):
+        """Image.expose() recorded ports the local runtime never read, so an exposed
+        port was silently unreachable: the guest listened, nothing forwarded, and
+        nothing errored. Verified live against cua-driver's MCP on guest :3000,
+        which answered /healthz and an MCP initialize once forwarded."""
+        src = inspect.getsource(
+            __import__("cua_sandbox.runtime.qemu", fromlist=["x"]).QEMUBaremetalRuntime.start
+        )
+        assert "image._ports" in src, "expose() ports are never read"
+        assert "extra_hostfwd" in src
+        assert "{extra_hostfwd}" in src, "forwards are built but never passed to qemu"
+        assert "exposed_ports=exposed_ports" in src, "caller cannot find the host port"
+
+    def test_runtime_info_can_report_exposed_ports(self):
+        from cua_sandbox.runtime.base import RuntimeInfo
+
+        info = RuntimeInfo(host="localhost", api_port=1, exposed_ports={3000: 41041})
+        assert info.exposed_ports == {3000: 41041}
+        assert RuntimeInfo(host="localhost", api_port=1).exposed_ports is None
+
     def test_qmp_port_is_allocated_not_fixed(self):
         src = inspect.getsource(
             __import__("cua_sandbox.runtime.qemu", fromlist=["x"]).QEMUBaremetalRuntime.start


### PR DESCRIPTION
## The bug

`Image.expose(port)` recorded ports that the local QEMU runtime never read. The bare-metal netdev line forwarded the computer-server port and nothing else:

```python
f"user,id=net0,restrict=on,hostfwd=tcp:127.0.0.1:{hostfwd_port}-:{guest_port}"
```

So an exposed port was **silently unreachable from the host**: the guest listened, nothing forwarded, and nothing errored. The sandbox reported healthy and the port simply did not exist. The Fleet cloud transport turns the same `_ports` into services, so this was a local/cloud divergence in a method whose entire purpose is reaching a port.

Found while trying to reach cua-driver's MCP server, which the Windows containerDisk runs on guest `:3000` alongside computer-server on `:8000` and noVNC on `:6080`. Only `:8000` was reachable, with no indication why.

## The change

Build one `hostfwd` per exposed port, each on its own free host port, and report the guest→host mapping on `RuntimeInfo.exposed_ports` so a caller can find where a port landed. A port that is already the computer-server port maps to the existing forward rather than being forwarded twice; allocated ports are checked against the API and QMP ports so they cannot collide.

## Verified live

A throwaway Windows sandbox with `Image.windows().expose(3000)`, on bare-metal QEMU:

```
image._ports: (3000,)
exposed_ports from RuntimeInfo: {3000: 41041}
guest hostname: DOCKERW-K5E4442
guest :3000 -> host :41041
  GET /healthz   -> 200 b'ok'
  MCP initialize -> 200 event: message
                    {"jsonrpc":"2.0","id":1,"result":{"capabilities":{"tools":{}},
                     "instructions":"cua-driver: cross-platform background computer-use automation..."}}
```

So the port forwards, cua-driver answers its health check, and it completes an MCP `initialize` handshake over the forwarded port.

Two regression tests, both confirmed failing against the unfixed source and passing with it — the fix is asserted to reach the qemu command line, not merely to compute a mapping that goes nowhere, which is the shape the original bug took.

## Note

This is the gap recorded as a known limitation in #3128 ("`expose()` is honoured in the cloud and silently ignored on local VMs because the bare-metal runtime never reads `image._ports`"). This closes it.
