### PR TITLE
fix(cua-driver): hide embedded daemon console on Windows

### DIFF
--- a/.github/release-attribution-config.json
+++ b/.github/release-attribution-config.json
@@ -29,6 +29,7 @@
     "manfred@ubuntu26.04-vm": "ai-ag2026",
     "me@madhavajay.com": "madhavajay",
     "robert@trycua.com": "enchanted-koala",
+    "rwendt1337@gmail.com": "r33drichards",
     "rsyuzyov@gmail.com": "rsyuzyov",
     "sarinajin.li@gmail.com": "sarinali",
     "zane.chee.2023@scis.smu.edu.sg": "injaneity",

--- a/libs/cua-driver/rust/crates/cua-driver-sdk/src/embedded.rs
+++ b/libs/cua-driver/rust/crates/cua-driver-sdk/src/embedded.rs
@@ -22,6 +22,9 @@ const DEFAULT_STARTUP_TIMEOUT_MS: u64 = 10_000;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS: u64 = 2_000;
 const HANDSHAKE_ATTEMPT_TIMEOUT_MS: u64 = 500;
 
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
 pub enum EmbeddedPermissionMode {
     Standard,
@@ -47,6 +50,8 @@ pub struct EmbeddedDriverHostOptions {
     pub approve_session_policy: bool,
     pub dangerously_bypass_approvals: bool,
     pub environment: Vec<EmbeddedEnvironmentVariable>,
+    /// Inherit daemon stderr. On Windows, disabling inheritance also prevents
+    /// the console-subsystem daemon from allocating a visible console.
     pub inherit_stderr: bool,
 }
 
@@ -422,12 +427,8 @@ impl EmbeddedCuaDriverHost {
             .env_clear()
             .stdin(Stdio::piped())
             .stdout(Stdio::null())
-            .stderr(if self.options.inherit_stderr {
-                Stdio::inherit()
-            } else {
-                Stdio::null()
-            })
             .kill_on_drop(true);
+        configure_embedded_child(&mut command, self.options.inherit_stderr);
         for variable in safe_environment(&self.options.environment) {
             command.env(variable.name, variable.value);
         }
@@ -681,6 +682,22 @@ impl EmbeddedCuaDriverHost {
             },
             other => inner.phase = other,
         }
+    }
+}
+
+fn configure_embedded_child(command: &mut Command, inherit_stderr: bool) {
+    command.stderr(if inherit_stderr {
+        Stdio::inherit()
+    } else {
+        Stdio::null()
+    });
+
+    #[cfg(windows)]
+    if !inherit_stderr {
+        // Redirecting stderr does not prevent a console-subsystem executable
+        // from allocating a console. Embedded GUI hosts that suppress driver
+        // diagnostics also expect the daemon to remain windowless.
+        command.creation_flags(CREATE_NO_WINDOW);
     }
 }
 
@@ -1111,6 +1128,9 @@ async fn terminate_startup_child(child: &mut Child, liveness: &mut ChildStdin) {
 mod tests {
     use super::*;
 
+    #[cfg(windows)]
+    const CONSOLE_PROBE_ENV: &str = "CUA_DRIVER_SDK_CONSOLE_PROBE";
+
     fn options(mode: EmbeddedPermissionMode) -> EmbeddedDriverHostOptions {
         EmbeddedDriverHostOptions {
             binary_path: std::env::current_dir()
@@ -1262,6 +1282,44 @@ mod tests {
         assert_ne!(first, second);
         #[cfg(unix)]
         assert!(first.len() < 104);
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn embedded_child_without_inherited_stderr_has_no_console() {
+        if std::env::var_os(CONSOLE_PROBE_ENV).is_some() {
+            #[link(name = "kernel32")]
+            extern "system" {
+                fn GetConsoleWindow() -> *mut std::ffi::c_void;
+            }
+
+            // SAFETY: GetConsoleWindow takes no arguments and returns either a
+            // valid HWND or null without transferring ownership.
+            let console = unsafe { GetConsoleWindow() };
+            assert!(
+                console.is_null(),
+                "embedded child unexpectedly owns a console"
+            );
+            return;
+        }
+
+        let mut command = Command::new(std::env::current_exe().expect("current test executable"));
+        command
+            .args([
+                "--exact",
+                "embedded::tests::embedded_child_without_inherited_stderr_has_no_console",
+                "--nocapture",
+            ])
+            .env(CONSOLE_PROBE_ENV, "1")
+            .stdout(Stdio::piped());
+        configure_embedded_child(&mut command, false);
+
+        let output = command.output().await.expect("spawn console probe");
+        assert!(
+            output.status.success(),
+            "console probe failed: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## What changed

- apply `CREATE_NO_WINDOW` when an embedded Windows host disables daemon stderr inheritance
- keep the existing stderr behavior unchanged on other platforms and when inheritance is enabled
- add a Windows regression test that starts a console-subsystem child through the production command configuration and verifies that it owns no console

## Root cause

`inherit_stderr: false` redirected the embedded daemon stderr to null, but redirecting standard handles does not suppress Windows console allocation. Because `cua-driver.exe` is a console-subsystem executable, GUI embedding hosts could still cause a visible console window when the daemon started.

## Impact

GUI applications can continue using the Rust-owned embedded host lifecycle with `inherit_stderr: false` without displaying a Cua Driver console window. No public option or protocol shape changes.

## Validation

- `cargo fmt --all -- --check`
- `DOCS_RS=1 cargo check -p cua-driver-sdk --tests --locked`
- Windows-target metadata compilation of the `tokio::process::Command::creation_flags` and `GetConsoleWindow` probe
- local three-way merge simulation against current `trycua/cua` main completed without conflicts

The complete local macOS test executable is blocked by a Swift compiler/SDK version mismatch on the contributor machine. The new Windows-only runtime probe is intended to execute in the repository Windows test lane.

## Publication note

The fork cannot fast-forward workflow-containing upstream history with its current OAuth scope. The branch therefore also aligns `.github/release-attribution-config.json` to the exact blob already on the target branch so the trusted attribution validator evaluates current metadata. That file produces no effective merge change; its blob hash matches current `trycua/cua` main.
