### PR TITLE
docs(cua-driver): document Grok Bot cloud computer setup

### DIFF
--- a/docs/content/docs/how-to-guides/driver/connect-your-agent.mdx
+++ b/docs/content/docs/how-to-guides/driver/connect-your-agent.mdx
@@ -5,7 +5,7 @@ description: Connect an agent to Cua Driver through MCP or the Cua Driver skill 
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-Cua Driver lets a [computer-use agent](/concepts/what-is-computer-use) drive the **host desktop**: installed apps, signed-in browser sessions, local files opened in apps, and the current OS user session. MCP-capable agents connect through `cua-driver mcp`; skill-based agents such as Prime Agent call the CLI directly.
+Cua Driver lets a [computer-use agent](/concepts/what-is-computer-use) drive the **host desktop**: installed apps, signed-in browser sessions, local files opened in apps, and the current OS user session. MCP-capable agents connect through `cua-driver mcp`; skill-based agents such as Prime Agent call the CLI directly. [Grok Bot](/use-cua-with/grok-bot) is a separate path; it is not Grok Build and does not use stdio MCP.
 
 <Callout type="info">
   This connects an agent to Cua Driver on the current machine. To create a disposable local desktop,
@@ -204,6 +204,19 @@ It returns:
 
 After saving the config, restart the client and confirm the `cua-driver` server is connected.
 
+## Grok Bot
+
+Grok Bot is not Grok Build. It has no `mcp-config` preset and does not use stdio
+MCP. See [Grok Bot](/use-cua-with/grok-bot).
+
+Two valid setups:
+
+1. **Your local Mac or Windows computer.** Install Cua Driver there. Grok Bot
+   uses local-command execution (`cua-driver call …`) behind its local-computer
+   approval policy.
+2. **Grok Bot's persistent cloud Linux computer.** If that machine is the
+   desktop being driven, install Cua Driver there and call `cua-driver` on it.
+
 ## Clients without a dedicated preset
 
 Some MCP clients can run Cua Driver directly even though `mcp-config` does not yet have a named
@@ -211,7 +224,7 @@ preset for them. Resolve the absolute executable path first with `command -v cua
 the client's native command:
 
 ```bash
-# Grok Build
+# Grok Build (xAI coding CLI, not Grok Bot)
 grok mcp add cua-driver -- /absolute/path/to/cua-driver mcp
 grok mcp doctor cua-driver
 

--- a/docs/content/docs/how-to-guides/driver/install-agent-skill.mdx
+++ b/docs/content/docs/how-to-guides/driver/install-agent-skill.mdx
@@ -81,6 +81,11 @@ shared `~/.agents/skills/` location used by Codex. Run `/reload` in Prime Agent
 or start a new session after installing or updating the skill so it reloads the
 guidance.
 
+`cua-driver skills install` auto-links Claude Code, Codex, Prime Agent, OpenClaw,
+OpenCode, Antigravity, and Hermes. Grok Bot is not in that list. On Grok Bot,
+save a private skill that follows the installed pack at
+`~/.cua-driver/skills/cua-driver`. See [Grok Bot](/use-cua-with/grok-bot).
+
 ## Next steps
 
 - [Connect your agent to Cua Driver](/how-to-guides/driver/connect-your-agent): register the MCP server when the agent uses MCP.

--- a/docs/content/docs/tutorials/drive-your-first-app.mdx
+++ b/docs/content/docs/tutorials/drive-your-first-app.mdx
@@ -211,7 +211,7 @@ Register Cua Driver with your agent harness once.
   </Tab>
 </Tabs>
 
-Using Cursor, Gemini/Antigravity, OpenCode, or Pi instead? See [Connect your agent](/how-to-guides/driver/connect-your-agent).
+Using Cursor, Gemini/Antigravity, OpenCode, or Pi instead? See [Connect your agent](/how-to-guides/driver/connect-your-agent). For Grok Bot, see [Grok Bot](/use-cua-with/grok-bot).
 
 ## 4. Ask your agent
 

--- a/docs/content/docs/use-cua-with/grok-bot.mdx
+++ b/docs/content/docs/use-cua-with/grok-bot.mdx
@@ -1,16 +1,23 @@
 ---
 title: Grok Bot
-description: Let Grok Bot operate desktop apps through Cua Driver on your local computer.
+description: Let Grok Bot operate desktop apps through Cua Driver on your local computer or on its own cloud computer.
 icon: Bot
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-[Grok Bot](https://docs.x.ai/grok-bot/overview) runs on a persistent cloud computer. Cua Driver can give it a separate path to native apps on your Mac or Windows computer.
+<Callout type="info">
+  This page is Grok Bot, the persistent cloud agent. It is not [Grok Build](/use-cua-with/grok-build), xAI's coding CLI over stdio MCP.
+</Callout>
 
-Use Grok Bot's local-command execution for the first setup. This keeps Cua Driver on the computer it controls and leaves each command behind Grok Bot's local-computer approval policy.
+[Grok Bot](https://docs.x.ai/grok-bot/overview) runs on a persistent cloud Linux computer, separate from your laptop. Cua Driver can drive either desktop:
 
-## Before you start
+- **Your local Mac or Windows computer.** Install Cua Driver there. Grok Bot uses local-command execution (`cua-driver call …`) with approval.
+- **Grok Bot's own cloud computer.** If that is the GUI being driven, install Cua Driver on that machine and call `cua-driver` there.
+
+Use command execution for the first setup on either path. This keeps Cua Driver on the computer it controls.
+
+## Drive your local computer
 
 Install Cua Driver on the computer with the apps you want to control, grant the required operating-system permissions, and start its daemon. Verify the local CLI before involving Grok Bot:
 
@@ -57,6 +64,36 @@ Read [Agent action policy](/reference/cua-driver/action-selection-policy) for th
   Grok Bot's local-command approval controls whether a command may run. Cua Driver's permission mode controls what that command may do. Keep both boundaries enabled. Do not set Grok Bot to **Always allowed** or run Cua Driver in unrestricted mode for routine use.
 </Callout>
 
+## Drive Grok Bot's cloud computer
+
+If the desktop being driven is Grok Bot's own computer, install Cua Driver there — not on your laptop. That machine is persistent cloud Linux, separate from your Mac or Windows computer.
+
+Stable is the default:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://cua.ai/driver/install.sh)"
+```
+
+To follow nightly instead:
+
+```bash
+curl -fsSL https://cua.ai/driver/install.sh | bash -s -- --channel nightly
+```
+
+Linux requirements: x86_64, with X11 or XWayland. `get_window_state` needs AT-SPI 2. After install, verify:
+
+```bash
+cua-driver --version
+cua-driver doctor
+cua-driver call list_apps '{}'
+```
+
+If `doctor` warns that AT-SPI is unreachable, `get_window_state` will not work until the accessibility bus is available. See [Install Cua Driver](/how-to-guides/driver/install) for Linux libraries and display-server details.
+
+`cua-driver skills install` writes the pack to `~/.cua-driver/skills/cua-driver`. It auto-links only Claude Code, Codex, Prime Agent, OpenClaw, OpenCode, Antigravity, and Hermes. Grok Bot is not in that list. On Grok Bot, save a private skill or workflow that points at that pack and keeps snapshot-before-action, element tokens, and post-action verification.
+
+Then give the Bot a narrow UI task on that computer. Cua Driver actions should follow the same loop as the local path: find the window, call `get_window_state`, act through an `element_token` from the latest state, then verify.
+
 ## Save the workflow as a Grok Bot skill
 
 Once a safe task succeeds, ask Grok Bot to save the method as a private skill:
@@ -64,11 +101,12 @@ Once a safe task succeeds, ask Grok Bot to save the method as a private skill:
 ```text
 Save the Cua Driver process we just used as a skill. Preserve the fresh-state,
 snapshot-bound element-token, and post-action verification rules. Require my
-approval for consequential actions. Keep Cua Driver commands on my local
-computer and report any refusal instead of bypassing it.
+approval for consequential actions. Keep Cua Driver on the computer it is
+driving — my local computer, or Grok Bot's cloud computer when that is the
+desktop — and report any refusal instead of bypassing it.
 ```
 
-Test the saved skill on a disposable example before attaching it to a routine. Grok Bot routines can run while your laptop is closed, but a routine that depends on local commands also depends on your computer being reachable and Cua Driver running.
+Test the saved skill on a disposable example before attaching it to a routine. Grok Bot routines can run while your laptop is closed, but a routine that depends on local commands also depends on your computer being reachable and Cua Driver running. A routine that drives Grok Bot's own computer does not depend on your laptop.
 
 ## Custom MCP is an advanced route
 

--- a/docs/content/docs/use-cua-with/grok-build.mdx
+++ b/docs/content/docs/use-cua-with/grok-build.mdx
@@ -4,6 +4,8 @@ description: Connect xAI's Grok Build coding agent to Cua Driver over MCP.
 icon: TerminalSquare
 ---
 
+Grok Build is xAI's coding CLI over stdio MCP. It is not [Grok Bot](/use-cua-with/grok-bot).
+
 Grok Build supports local stdio MCP servers. Find the installed Cua Driver path, then register it:
 
 ```bash

--- a/docs/content/docs/use-cua-with/xai.mdx
+++ b/docs/content/docs/use-cua-with/xai.mdx
@@ -4,15 +4,15 @@ description: Use Grok Build or Grok Bot with Cua Driver.
 icon: Orbit
 ---
 
-Use Grok Build when the agent and Cua Driver run on the same computer. Use Grok Bot when you want a persistent cloud agent to operate apps on your local computer.
+Use Grok Build when the agent and Cua Driver run on the same computer. Use Grok Bot when a persistent cloud agent should operate apps on your local computer, or when it should drive Grok Bot's own cloud computer.
 
 | Start here when…                          | Recommended path                                                                 |
 | ----------------------------------------- | -------------------------------------------------------------------------------- |
 | You use Grok Build                        | [Connect Grok Build to Cua Driver](/use-cua-with/grok-build)                     |
-| You use Grok Bot                          | [Let Grok Bot operate local apps](/use-cua-with/grok-bot)                       |
+| You use Grok Bot                          | [Let Grok Bot drive local or cloud-computer apps](/use-cua-with/grok-bot)        |
 | You are building a custom Grok agent      | Call Cua Driver through [MCP](/reference/cua-driver/mcp-tools) or the CLI        |
 | You want to manage the agent from T3 Code | Configure Grok Build first, then [use it through T3 Code](/use-cua-with/t3-code) |
 
-Cua Driver does not call the Grok API directly. Grok Build can launch Cua Driver as a local tool server. Grok Bot can invoke the local CLI under its local-computer policy or reach an authenticated Streamable HTTP MCP endpoint through a gateway.
+Cua Driver does not call the Grok API directly. Grok Build can launch Cua Driver as a local tool server. Grok Bot can invoke the local CLI under its local-computer policy, install Cua Driver on its own cloud computer, or reach an authenticated Streamable HTTP MCP endpoint through a gateway.
 
 See xAI's [Grok Build overview](https://docs.x.ai/build/overview), [MCP server guide](https://docs.x.ai/build/features/mcp-servers), and [Grok Bot overview](https://docs.x.ai/grok-bot/overview).


### PR DESCRIPTION
## Summary

- distinguish Grok Bot from the Grok Build coding CLI across the Cua Driver docs
- document using Cua Driver on either a local computer or Grok Bot's persistent cloud computer
- clarify skill discovery, Linux requirements, safety boundaries, and verification steps

## Validation

- `git diff --check origin/main...origin/docs/grok-bot-cloud-computer`
- reviewed the complete documentation-only diff against current `origin/main`