### PR TITLE
fix(cua-driver): document Grok Bot as a host without skills auto-link

### DIFF
--- a/docs/content/docs/use-cua-with/grok-bot.mdx
+++ b/docs/content/docs/use-cua-with/grok-bot.mdx
@@ -90,7 +90,7 @@ cua-driver call list_apps '{}'
 
 If `doctor` warns that AT-SPI is unreachable, `get_window_state` will not work until the accessibility bus is available. See [Install Cua Driver](/how-to-guides/driver/install) for Linux libraries and display-server details.
 
-`cua-driver skills install` writes the pack to `~/.cua-driver/skills/cua-driver`. It auto-links only Claude Code, Codex, Prime Agent, OpenClaw, OpenCode, Antigravity, and Hermes. Grok Bot is not in that list. On Grok Bot, save a private skill or workflow that points at that pack and keeps snapshot-before-action, element tokens, and post-action verification.
+`cua-driver skills install` writes the pack to `~/.cua-driver/skills/cua-driver`. It auto-links only Claude Code, Codex, Prime Agent, OpenClaw, OpenCode, Antigravity, and Hermes. Grok Bot is not in that list. On Grok Bot, save a private skill or workflow that points at that pack and keeps snapshot-before-action, element tokens, and post-action verification. Headless Xvfb, missing `/dev/uinput`, AT-SPI, and overlay-session caveats for this class of machine are in the skill pack's `LINUX.md`.
 
 Then give the Bot a narrow UI task on that computer. Cua Driver actions should follow the same loop as the local path: find the window, call `get_window_state`, act through an `element_token` from the latest state, then verify.
 

--- a/libs/cua-driver/rust/Skills/cua-driver/LINUX.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/LINUX.md
@@ -179,6 +179,30 @@ An empty AT-SPI walk is now surfaced honestly: `get_window_state` sets
 caller can tell "this window genuinely has no controls" apart from "the a11y
 bridge isn't up / the daemon isn't on the session bus".
 
+## Headless / cloud bot / Xvfb
+
+Grok Bot cloud computers and similar headless Linux desktops often run
+cua-driver under Xvfb + x11vnc, as a non-root user, without AT-SPI or
+`/dev/uinput`. Treat that as a first-class host, not a broken install.
+
+- **AT-SPI.** `get_window_state` needs `at-spi2-core` and a session bus
+  (`DBUS_SESSION_BUS_ADDRESS` or the auto-discovery above). Without them
+  the walk is empty and the response is `degraded:true`.
+- **`/dev/uinput`.** Background pixel (PX) delivery on X11 uses an MPX
+  virtual pointer that needs a real Xorg + `/dev/uinput`. Xvfb typically
+  has neither. Escalate those clicks with `delivery_mode:"foreground"`.
+- **Overlay session.** One-shot CLI calls (`cua-driver call …`) end the
+  transport session when the process exits, so the agent-cursor overlay
+  is invisible. Hold an MCP connection, or pass the same public `session`
+  label on every call that accepts it.
+- **Screenshot gap.** `get_desktop_state` root captures on compositor-less
+  X11 (including Xvfb) may omit the overlay window. That is not proof the
+  overlay is off; use a persistent session and do not treat a missing
+  overlay in a root screenshot as a cursor failure.
+- **Do not pair `move_cursor` with `click`.** Pixel `click` already glides
+  the overlay. Do not call `move_cursor` immediately before `click` on the
+  same target; that plays two glides. See `SKILL.md` → Agent cursor overlay.
+
 ## The validated modality matrix (X11 / XFCE)
 
 Each input rung and its stable public route:

--- a/libs/cua-driver/rust/Skills/cua-driver/README.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/README.md
@@ -51,6 +51,20 @@ directories:
 cua-driver skills install
 ```
 
+`skills install` auto-links only when that agent's skills directory already
+exists: Claude Code (`~/.claude/skills/`), Codex (`~/.agents/skills/`),
+Prime Agent (`~/.prime/agent/skills/`), OpenClaw (`~/.openclaw/skills/`),
+OpenCode (`~/.config/opencode/skills/` on macOS/Linux,
+`%APPDATA%\opencode\skills\` on Windows), Antigravity (`~/.gemini/skills/`),
+and Hermes (`~/.hermes/skills/`).
+
+**Grok Bot is a cua-driver host but is not auto-linked.** It has no agent
+skills directory. After install, run `cua-driver skills path` and load
+`SKILL.md` (plus `LINUX.md` on a Linux / Xvfb cloud computer) from that
+pack, or save a private Grok Bot skill / workflow that points at it.
+`cua-driver skills status` reports this explicitly so you do not look for
+a missing symlink.
+
 The direct installer keeps only the current host's platform guide by default.
 Use `--all-platforms` when the agent assists users across operating systems.
 `cua-driver skills update` refreshes the pack to match a later driver release.

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -170,8 +170,10 @@ pub enum Command {
     /// `cua-driver skills {install|update|uninstall|status|path}` —
     /// agent skill-pack management. The verb is the ONLY way a user
     /// installs or updates the cua-driver skill pack into their agent
-    /// dirs (Claude Code / Codex / Prime Agent / OpenClaw / OpenCode); the install
-    /// scripts never touch ~/.claude/skills/ etc. directly. `install`
+    /// dirs (Claude Code / Codex / Prime Agent / OpenClaw / OpenCode /
+    /// Antigravity / Hermes). Grok Bot is a host but is not auto-linked
+    /// (no agent skills dir). The install scripts never touch
+    /// ~/.claude/skills/ etc. directly. `install`
     /// fetches the matching versioned release asset
     /// (`cua-driver-rs-v<v>-skills.tar.gz` — the asset filename keeps
     /// the legacy `-rs` for backward-compat with pinned URLs) from
@@ -517,7 +519,10 @@ pub fn parse_command() -> Command {
         println!("skills options (agent skill-pack management, opt-in):");
         println!("  cua-driver skills install       Fetch the versioned skill pack from GitHub Releases and symlink it");
         println!("                                  into each detected agent's skills/ dir (Claude Code, Codex, Prime Agent,");
-        println!("                                  OpenClaw, OpenCode). Idempotent. Never overwrites existing user links.");
+        println!("                                  OpenClaw, OpenCode, Antigravity, Hermes). Grok Bot is not auto-linked.");
+        println!(
+            "                                  Idempotent. Never overwrites existing user links."
+        );
         println!("  cua-driver skills update        Re-fetch the skill pack from GitHub, refreshing the local copy + links.");
         println!("  cua-driver skills uninstall     Remove the agent symlinks. Add --all to also delete the local copy.");
         println!("  cua-driver skills status        Report local install state + per-agent link state. Read-only.");

--- a/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/skills.rs
@@ -55,6 +55,13 @@
 //!   version-controlled). Hermes' own `computer-use` skill teaches its wrapper
 //!   vocabulary; the cua-driver pack provides the platform deep dives.
 //!
+//! Grok Bot is a cua-driver host (local CLI, or the bot's own Linux cloud
+//! computer) but has **no documented agent skills directory**. `skills
+//! install` never auto-links it. Do not invent a `~/.grok/skills` path.
+//! `skills status` still names Grok Bot so agents load `SKILL.md` from
+//! `cua-driver skills path` / the installed pack, or save a private Grok
+//! Bot skill / workflow that points at that pack.
+//!
 //! Only acts on a given agent when its parent skills dir already
 //! exists (i.e. the agent itself is installed). Never clobbers an
 //! existing `<agent_skills>/cua-driver` link — preserves dev users'
@@ -240,6 +247,25 @@ const AGENTS: &[Agent] = &[
         parent: AgentParent::Home(".hermes/skills"),
     },
 ];
+
+/// Hosts that run cua-driver but have no documented agent skills
+/// directory. `skills install` never auto-links these. Status still
+/// names them so agents stop inventing a symlink path.
+#[derive(Debug, Clone, Copy)]
+struct NonAutoLinkedHost {
+    label: &'static str,
+    /// Printed after the em dash. Must not invent a skills-dir path.
+    note: &'static str,
+}
+
+const NON_AUTO_LINKED_HOSTS: &[NonAutoLinkedHost] = &[NonAutoLinkedHost {
+    label: "Grok Bot",
+    note: "not auto-linked (no agent skills dir; load SKILL.md from `cua-driver skills path` / the installed pack)",
+}];
+
+fn non_auto_linked_status_line(host: &NonAutoLinkedHost) -> String {
+    format!("  {} — {}", host.label, host.note)
+}
 
 impl Agent {
     fn parent_path(&self) -> Result<PathBuf> {
@@ -797,6 +823,9 @@ fn status() -> Result<()> {
             );
         }
     }
+    for host in NON_AUTO_LINKED_HOSTS {
+        println!("{}", non_auto_linked_status_line(host));
+    }
     Ok(())
 }
 
@@ -808,9 +837,104 @@ fn print_path() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_tar_gz, skill_release_url, AgentParent, AGENTS, SKILL_FILES};
+    use super::{
+        extract_tar_gz, non_auto_linked_status_line, skill_release_url, AgentParent, AGENTS,
+        NON_AUTO_LINKED_HOSTS, SKILL_FILES,
+    };
     use std::path::PathBuf;
     use tempfile::tempdir;
+
+    #[test]
+    fn grok_bot_is_not_an_auto_link_target() {
+        assert!(
+            AGENTS.iter().all(|agent| agent.label != "Grok Bot"),
+            "Grok Bot has no agent skills dir; do not invent a path in AGENTS"
+        );
+        assert!(
+            !NON_AUTO_LINKED_HOSTS
+                .iter()
+                .any(|host| host.note.contains("/.grok/") || host.note.contains("~/.grok")),
+            "must not invent a Grok Bot skills directory"
+        );
+    }
+
+    #[test]
+    fn skills_status_names_grok_bot_as_not_auto_linked() {
+        let grok = NON_AUTO_LINKED_HOSTS
+            .iter()
+            .find(|host| host.label == "Grok Bot")
+            .expect("Grok Bot must remain a named non-auto-linked host");
+        let line = non_auto_linked_status_line(grok);
+        assert!(
+            line.contains("Grok Bot — not auto-linked (no agent skills dir; load SKILL.md from `cua-driver skills path` / the installed pack)"),
+            "skills status must name Grok Bot without implying a symlink: {line}"
+        );
+    }
+
+    #[test]
+    fn linux_skill_keeps_headless_cloud_bot_guidance() {
+        let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let linux = std::fs::read_to_string(crate_dir.join("../../Skills/cua-driver/LINUX.md"))
+            .expect("canonical Linux skill must be readable");
+
+        for required in [
+            "Headless / cloud bot / Xvfb",
+            "Xvfb",
+            "/dev/uinput",
+            "at-spi2-core",
+            "degraded",
+            "delivery_mode:\"foreground\"",
+            "One-shot CLI",
+            "get_desktop_state",
+            "Pixel `click` already glides",
+        ] {
+            assert!(
+                linux.contains(required),
+                "LINUX.md lost required headless/cloud-bot guidance: {required}"
+            );
+        }
+        assert!(
+            !linux.contains("~/.grok/skills"),
+            "LINUX.md must not invent a Grok Bot skills directory"
+        );
+    }
+
+    #[test]
+    fn skill_readme_names_grok_bot_without_inventing_a_skills_dir() {
+        let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let readme = std::fs::read_to_string(crate_dir.join("../../Skills/cua-driver/README.md"))
+            .expect("canonical skill README must be readable");
+
+        for required in ["Grok Bot", "not auto-linked", "cua-driver skills path"] {
+            assert!(
+                readme.contains(required),
+                "skill README lost required Grok Bot host guidance: {required}"
+            );
+        }
+        assert!(
+            !readme.contains("~/.grok/skills"),
+            "skill README must not invent a Grok Bot skills directory"
+        );
+    }
+
+    #[test]
+    fn bundled_skill_keeps_overlay_click_already_glides() {
+        let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let skill = std::fs::read_to_string(crate_dir.join("../../Skills/cua-driver/SKILL.md"))
+            .expect("canonical skill must be readable");
+
+        for required in [
+            "Pixel `click` already glides the overlay.",
+            "Do not call `move_cursor`",
+            "immediately before `click` on the same target",
+            "that plays two glides",
+        ] {
+            assert!(
+                skill.contains(required),
+                "skill lost the overlay pairing footnote: {required}"
+            );
+        }
+    }
 
     #[test]
     fn prime_agent_target_matches_its_native_global_skill_directory() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Problem this solves: Grok Bot is a cua-driver host (local CLI or the bot's own Linux cloud computer), but `skills install` cannot attach the pack and `skills status` never named it. Agents then invent a missing `~/.grok/skills` symlink. The skill pack also omitted Xvfb / cloud-bot caveats that this class of VM hits.
- What changed: `skills status` now always lists Grok Bot as not auto-linked (no agent skills dir; load `SKILL.md` from `cua-driver skills path` / the installed pack). The skill README states the auto-link list honestly. `LINUX.md` adds a short headless / cloud bot / Xvfb section (AT-SPI, `/dev/uinput`, overlay session, `get_desktop_state` screenshot gap, foreground escalation, and the click / `move_cursor` pairing). One sentence on the existing Grok Bot docs page points at `LINUX.md`. Cursor is not added: no documented in-tree Cursor skills directory.

## Related work

Refs #3142 (Grok Bot discoverability + cloud-computer install). Overlay pairing wording already on main via #3143 / `skill/overlay-click-already-glides`; this PR does not fight that branch.

RFC (required for a public SDK, CLI, MCP, protocol, compatibility, permission,
or cross-component contract change): not required — status text and skill-pack documentation only; no new auto-link path.

## Compatibility and risk

- User-visible, API/CLI/MCP, migration, permission, or platform impact: `skills status` gains one extra Grok Bot line. `skills install` still does not symlink Grok Bot. Help text lists the real auto-link set and says Grok Bot is not auto-linked. No fake filesystem paths.
- Risk and rollback: documentation / status-text only. Revert the commit if the status line is unwanted.

## Validation

- Focused tests and checks: `cargo test -p cua-driver --bin cua-driver skills::` — 19 passed, including `skills_status_names_grok_bot_as_not_auto_linked`, `grok_bot_is_not_an_auto_link_target`, `linux_skill_keeps_headless_cloud_bot_guidance`, `skill_readme_names_grok_bot_without_inventing_a_skills_dir`, and `bundled_skill_keeps_overlay_click_already_glides`.
- Manual or platform evidence: not required for this docs/status change.
- Known gaps or CI still required: ordinary PR CI. No desktop E2E matrix.

## Contributor and release checks

- [x] The PR is focused and the description matches the final diff.
- [x] This change does not require an RFC, or the accepted RFC is linked above.
- [x] Tests, documentation, and platform evidence are included or the gap is explained.
- [x] The PR title is a Conventional Commit describing the production change (`fix` so the skill pack and status line ship).
- [x] External contributor authorship is preserved, or no external contribution is included.
- [x] Release-tracked files changed and the title is releasing; `no-release` is not applied.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c50cf25-bb6c-4c59-87c9-93d3ad2d5bb7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c50cf25-bb6c-4c59-87c9-93d3ad2d5bb7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

