### PR TITLE
fix(cua-driver): keep named CLI sessions and include X11 overlay in screenshots

### DIFF
--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -2008,13 +2008,80 @@ mod daemon_compatibility_tests {
     }
 }
 
+/// How one `cua-driver call` binds to daemon session lifecycle.
+///
+/// Overlay, recording, and the resurrection guard are owned by the daemon
+/// transport id. `session_end` for that id reaps every public session it
+/// owns, so a named CLI episode must use the public label as the transport
+/// id and must not send `session_end`. A missing `session` still mints a
+/// disposable `cli-{uuid}` and ends it after the response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CliCallSession {
+    session_id: String,
+    end_after_call: bool,
+}
+
+fn public_cli_session_name(json_args: Option<&serde_json::Value>) -> Option<String> {
+    json_args
+        .and_then(|value| value.get("session"))
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn resolve_cli_call_session(json_args: Option<&serde_json::Value>) -> CliCallSession {
+    match public_cli_session_name(json_args) {
+        Some(session_id) => CliCallSession {
+            session_id,
+            end_after_call: false,
+        },
+        None => CliCallSession {
+            session_id: format!("cli-{}", uuid::Uuid::new_v4()),
+            end_after_call: true,
+        },
+    }
+}
+
+fn build_cli_call_requests(
+    tool: &str,
+    json_args: Option<serde_json::Value>,
+) -> (
+    crate::serve::DaemonRequest,
+    Option<crate::serve::DaemonRequest>,
+) {
+    let call_session = resolve_cli_call_session(json_args.as_ref());
+    let mut args_for_daemon =
+        json_args.unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+    cua_driver_core::tool_args::sanitize_reserved_args(&mut args_for_daemon);
+    let req = crate::serve::DaemonRequest {
+        method: "call".into(),
+        name: Some(tool.to_owned()),
+        args: Some(args_for_daemon),
+        session_id: Some(call_session.session_id.clone()),
+        observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
+        client_kind: Some(cua_driver_core::daemon::DaemonClientKind::Cli),
+    };
+    let cleanup = call_session
+        .end_after_call
+        .then(|| crate::serve::DaemonRequest {
+            method: "session_end".into(),
+            name: None,
+            args: None,
+            session_id: Some(call_session.session_id),
+            observation_origin: None,
+            client_kind: Some(cua_driver_core::daemon::DaemonClientKind::Cli),
+        });
+    (req, cleanup)
+}
+
 pub fn run_call(
     tool: &str,
     json_args: Option<serde_json::Value>,
     screenshot_out_file: Option<String>,
     socket_override: Option<String>,
 ) {
-    // One-shot public calls remain service-backed so policy, session state,
+    // Public calls remain service-backed so policy, session state,
     // AppStateEngine caches, and platform identity have one enforcement point.
     // The Windows UIAccess helper is daemon-internal: routing an untrusted CLI
     // directly to it would bypass this authorization path.
@@ -2022,6 +2089,11 @@ pub fn run_call(
     // When `socket_override` is Some (i.e. caller passed `--socket <path>`),
     // route directly to that path and skip the platform default. Used by
     // integration tests to drive a tempfile-socketed daemon.
+    //
+    // An explicit JSON `session` is the daemon transport id and is left live
+    // after the call so later invocations (and `get_agent_cursor_state`) can
+    // continue that overlay. Calls without `session` still mint a disposable
+    // `cli-{uuid}` and send `session_end` after the response.
     let socket_path = socket_override.unwrap_or_else(crate::serve::default_socket_path);
     if !crate::serve::is_daemon_listening(&socket_path) {
         eprintln!(
@@ -2033,34 +2105,12 @@ pub fn run_call(
     require_compatible_daemon(&socket_path);
 
     {
-        let mut args_for_daemon = json_args
-            .clone()
-            .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
-        cua_driver_core::tool_args::sanitize_reserved_args(&mut args_for_daemon);
-        let transport_session = format!("cli-{}", uuid::Uuid::new_v4());
-        let req = crate::serve::DaemonRequest {
-            method: "call".into(),
-            name: Some(tool.to_owned()),
-            args: Some(args_for_daemon),
-            // Every one-shot call owns one disposable implicit transport
-            // session. The daemon closes all lifecycle state attached to it
-            // synchronously after the response is received.
-            session_id: Some(transport_session.clone()),
-            observation_origin: Some(crate::serve::ToolObservationOrigin::Direct),
-            client_kind: Some(cua_driver_core::daemon::DaemonClientKind::Cli),
-        };
+        let (req, cleanup) = build_cli_call_requests(tool, json_args);
         let response = crate::serve::send_request(&socket_path, &req);
-        let cleanup = crate::serve::DaemonRequest {
-            method: "session_end".into(),
-            name: None,
-            args: None,
-            session_id: Some(transport_session),
-            observation_origin: None,
-            client_kind: Some(cua_driver_core::daemon::DaemonClientKind::Cli),
-        };
-        let cleanup_result = crate::serve::send_request(&socket_path, &cleanup);
-        if let Err(error) = cleanup_result {
-            eprintln!("warning: disposable session cleanup failed: {error}");
+        if let Some(cleanup) = cleanup {
+            if let Err(error) = crate::serve::send_request(&socket_path, &cleanup) {
+                eprintln!("warning: disposable session cleanup failed: {error}");
+            }
         }
         match response {
             Ok(resp) => {
@@ -4127,6 +4177,80 @@ mod tests {
             aliased_flag_value(&identical, "--capability-manifest", "--session-policy"),
             Some("/tmp/shared.yaml".to_owned())
         );
+    }
+
+    #[test]
+    fn named_cli_session_is_the_daemon_transport_and_is_not_ended() {
+        let args = serde_json::json!({"session":"demo","x":12,"y":34});
+        let first = resolve_cli_call_session(Some(&args));
+        let second = resolve_cli_call_session(Some(&args));
+        assert_eq!(
+            first,
+            CliCallSession {
+                session_id: "demo".into(),
+                end_after_call: false,
+            }
+        );
+        assert_eq!(first, second);
+
+        let (req, cleanup) = build_cli_call_requests("move_cursor", Some(args));
+        assert_eq!(req.method, "call");
+        assert_eq!(req.name.as_deref(), Some("move_cursor"));
+        assert_eq!(req.session_id.as_deref(), Some("demo"));
+        assert_eq!(
+            req.args.as_ref().and_then(|v| v.get("session")),
+            Some(&serde_json::json!("demo"))
+        );
+        assert!(
+            cleanup.is_none(),
+            "named CLI sessions must not send session_end"
+        );
+    }
+
+    #[test]
+    fn unnamed_cli_call_mints_a_disposable_transport_and_session_ends_it() {
+        let (first_req, first_cleanup) = build_cli_call_requests("move_cursor", None);
+        let (second_req, second_cleanup) =
+            build_cli_call_requests("move_cursor", Some(serde_json::json!({"x":1,"y":2})));
+
+        let first_sid = first_req.session_id.expect("disposable session");
+        let second_sid = second_req.session_id.expect("disposable session");
+        assert!(first_sid.starts_with("cli-"), "{first_sid}");
+        assert!(second_sid.starts_with("cli-"), "{second_sid}");
+        assert_ne!(
+            first_sid, second_sid,
+            "each one-shot call mints its own transport"
+        );
+
+        let first_cleanup = first_cleanup.expect("unnamed call must session_end");
+        let second_cleanup = second_cleanup.expect("unnamed call must session_end");
+        assert_eq!(first_cleanup.method, "session_end");
+        assert_eq!(
+            first_cleanup.session_id.as_deref(),
+            Some(first_sid.as_str())
+        );
+        assert_eq!(
+            second_cleanup.session_id.as_deref(),
+            Some(second_sid.as_str())
+        );
+    }
+
+    #[test]
+    fn blank_or_non_string_session_stays_on_the_disposable_path() {
+        for args in [
+            serde_json::json!({"session":""}),
+            serde_json::json!({"session":"   "}),
+            serde_json::json!({"session":null}),
+            serde_json::json!({"session":12}),
+        ] {
+            let plan = resolve_cli_call_session(Some(&args));
+            assert!(plan.end_after_call, "{args}");
+            assert!(
+                plan.session_id.starts_with("cli-"),
+                "{args} -> {}",
+                plan.session_id
+            );
+        }
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/capture.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/capture.rs
@@ -848,7 +848,11 @@ pub fn png_dimensions_pub(data: &[u8]) -> Result<(u32, u32)> {
 ///   owns the complete GNOME helper → wlroots screencopy →
 ///   ext-image-copy-capture-v1 → portal Screenshot → X11 cascade. An
 ///   available GNOME helper's capture failure is terminal.
-/// - X11 / Wayland-disabled: ImageMagick `import` → x11rb `XGetImage`.
+/// - X11 / Wayland-disabled: ImageMagick `import` → x11rb `XGetImage` on
+///   the root, then a second pass that composites any mapped
+///   `Cua.AgentCursorOverlay.*` window. Root-only `XGetImage` cannot see
+///   that override-redirect pixmap (picom / xorgxrdp / some Xvfb hosts),
+///   so the overlay's own shaped pixels are blended on afterwards.
 pub fn screenshot_display_bytes() -> Result<Vec<u8>> {
     screenshot_display_bytes_with_dispatch(
         crate::wayland::is_wayland(),
@@ -873,7 +877,18 @@ fn screenshot_display_bytes_with_dispatch(
 /// [`crate::wayland::screenshot_display_dispatch`] can call it as a final
 /// fallback without re-entering [`screenshot_display_bytes`] (which would
 /// loop forever once we're on Wayland).
+///
+/// Root capture is not the final buffer when the agent-cursor overlay is
+/// mapped: those pixels live on a shaped override-redirect window that
+/// `import -window root` and root `XGetImage` omit. The overlay pixmap is
+/// composited on afterwards. Disabled or unmapped overlays leave the root
+/// capture unchanged.
 pub(crate) fn screenshot_display_bytes_x11() -> Result<Vec<u8>> {
+    let png = screenshot_root_window_bytes_x11()?;
+    Ok(composite_mapped_agent_cursor_overlays(png))
+}
+
+fn screenshot_root_window_bytes_x11() -> Result<Vec<u8>> {
     // Try `import -window root png:-` (ImageMagick).
     let out = Command::new("import")
         .args(["-window", "root", "png:-"])
@@ -921,6 +936,213 @@ pub(crate) fn screenshot_display_bytes_x11() -> Result<Vec<u8>> {
     cua_driver_core::image_utils::encode_rgba_to_png(&rgba, w, h)
 }
 
+/// One shaped rect of a mapped `Cua.AgentCursorOverlay.*` window, in root
+/// coordinates, with premultiplied RGBA pixels from the overlay pixmap.
+#[derive(Debug, Clone)]
+struct OverlayCaptureTile {
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+    rgba: Vec<u8>,
+}
+
+fn composite_mapped_agent_cursor_overlays(png: Vec<u8>) -> Vec<u8> {
+    match capture_mapped_agent_cursor_overlay_tiles() {
+        Ok(tiles) if !tiles.is_empty() => match apply_overlay_tiles_to_png(&png, &tiles) {
+            Ok(out) => out,
+            Err(error) => {
+                tracing::debug!("X11 overlay composite encode failed: {error:#}");
+                png
+            }
+        },
+        Ok(_) => png,
+        Err(error) => {
+            tracing::debug!("X11 overlay composite skipped: {error:#}");
+            png
+        }
+    }
+}
+
+fn apply_overlay_tiles_to_png(png: &[u8], tiles: &[OverlayCaptureTile]) -> Result<Vec<u8>> {
+    if tiles.is_empty() {
+        return Ok(png.to_vec());
+    }
+    let (mut rgba, width, height) = decode_png_rgba_owned(png)?;
+    for tile in tiles {
+        blend_premultiplied_rgba_over(
+            &mut rgba,
+            width,
+            height,
+            &tile.rgba,
+            tile.x,
+            tile.y,
+            tile.width,
+            tile.height,
+        );
+    }
+    cua_driver_core::image_utils::encode_rgba_to_png(&rgba, width, height)
+}
+
+fn decode_png_rgba_owned(png: &[u8]) -> Result<(Vec<u8>, u32, u32)> {
+    let image = image::load_from_memory_with_format(png, image::ImageFormat::Png)
+        .map_err(|error| anyhow!("decode root PNG for overlay composite: {error}"))?
+        .to_rgba8();
+    let (width, height) = image.dimensions();
+    Ok((image.into_raw(), width, height))
+}
+
+/// Premultiplied `src` over an opaque destination. Tiles that miss the
+/// destination (disabled / unmapped overlay, or a rect off-screen) are a
+/// no-op.
+fn blend_premultiplied_rgba_over(
+    dest: &mut [u8],
+    dest_w: u32,
+    dest_h: u32,
+    src: &[u8],
+    dest_x: i32,
+    dest_y: i32,
+    src_w: u32,
+    src_h: u32,
+) {
+    if src_w == 0 || src_h == 0 {
+        return;
+    }
+    let expected = (src_w as usize)
+        .saturating_mul(src_h as usize)
+        .saturating_mul(4);
+    if src.len() != expected || dest.len() != (dest_w as usize) * (dest_h as usize) * 4 {
+        return;
+    }
+    for row in 0..src_h {
+        let dest_row = dest_y.saturating_add_unsigned(row);
+        if dest_row < 0 || dest_row as u32 >= dest_h {
+            continue;
+        }
+        for col in 0..src_w {
+            let dest_col = dest_x.saturating_add_unsigned(col);
+            if dest_col < 0 || dest_col as u32 >= dest_w {
+                continue;
+            }
+            let src_i = ((row as usize) * (src_w as usize) + col as usize) * 4;
+            let dest_i = ((dest_row as usize) * (dest_w as usize) + dest_col as usize) * 4;
+            let src_a = src[src_i + 3];
+            if src_a == 0 {
+                continue;
+            }
+            if src_a == 255 {
+                dest[dest_i..dest_i + 4].copy_from_slice(&src[src_i..src_i + 4]);
+                dest[dest_i + 3] = 255;
+                continue;
+            }
+            let inv = 255 - src_a;
+            for channel in 0..3 {
+                let blended = u16::from(src[src_i + channel])
+                    + (u16::from(dest[dest_i + channel]) * u16::from(inv) + 127) / 255;
+                dest[dest_i + channel] = blended.min(255) as u8;
+            }
+            dest[dest_i + 3] = 255;
+        }
+    }
+}
+
+fn capture_mapped_agent_cursor_overlay_tiles() -> Result<Vec<OverlayCaptureTile>> {
+    use x11rb::connection::Connection;
+    use x11rb::protocol::shape::{ConnectionExt as ShapeConnectionExt, SK};
+    use x11rb::protocol::xproto::{
+        AtomEnum, ConnectionExt as XprotoConnectionExt, ImageFormat, MapState,
+    };
+    use x11rb::rust_connection::RustConnection;
+
+    let (conn, screen_num) = RustConnection::connect(None)
+        .map_err(|error| anyhow!("{error}{}", crate::no_display_hint()))?;
+    let root = conn.setup().roots[screen_num].root;
+    let prefix = crate::overlay::AGENT_CURSOR_OVERLAY_WM_NAME_PREFIX.as_bytes();
+    let children = conn.query_tree(root)?.reply()?.children;
+    let mut tiles = Vec::new();
+    for window in children {
+        let name = conn
+            .get_property(false, window, AtomEnum::WM_NAME, AtomEnum::STRING, 0, 1024)?
+            .reply()?;
+        if !name.value.starts_with(prefix) {
+            continue;
+        }
+        let attrs = conn.get_window_attributes(window)?.reply()?;
+        if attrs.map_state != MapState::VIEWABLE {
+            continue;
+        }
+        let geom = conn.get_geometry(window)?.reply()?;
+        let shape = conn
+            .shape_get_rectangles(window, SK::BOUNDING)
+            .ok()
+            .and_then(|cookie| cookie.reply().ok());
+        let Some(shape) = shape else {
+            continue;
+        };
+        if shape.rectangles.is_empty() {
+            continue;
+        }
+        for rect in shape.rectangles {
+            if rect.width == 0 || rect.height == 0 {
+                continue;
+            }
+            let Ok(cookie) = conn.get_image(
+                ImageFormat::Z_PIXMAP,
+                window,
+                rect.x,
+                rect.y,
+                rect.width,
+                rect.height,
+                !0u32,
+            ) else {
+                continue;
+            };
+            let Ok(img) = cookie.reply() else {
+                continue;
+            };
+            let Some(rgba) = overlay_zpixmap_to_premultiplied_rgba(
+                &img.data,
+                rect.width,
+                rect.height,
+                img.depth,
+            ) else {
+                continue;
+            };
+            tiles.push(OverlayCaptureTile {
+                x: i32::from(geom.x) + i32::from(rect.x),
+                y: i32::from(geom.y) + i32::from(rect.y),
+                width: u32::from(rect.width),
+                height: u32::from(rect.height),
+                rgba,
+            });
+        }
+    }
+    Ok(tiles)
+}
+
+fn overlay_zpixmap_to_premultiplied_rgba(
+    data: &[u8],
+    width: u16,
+    height: u16,
+    depth: u8,
+) -> Option<Vec<u8>> {
+    let bpp = match depth {
+        32 | 24 => 4usize,
+        _ => return None,
+    };
+    let pixels = usize::from(width) * usize::from(height);
+    if data.len() < pixels * bpp {
+        return None;
+    }
+    let mut rgba = Vec::with_capacity(pixels * 4);
+    for chunk in data.chunks_exact(bpp).take(pixels) {
+        let (b, g, r) = (chunk[0], chunk[1], chunk[2]);
+        let a = if depth == 32 { chunk[3] } else { 255 };
+        rgba.extend_from_slice(&[r, g, b, a]);
+    }
+    Some(rgba)
+}
+
 /// Capture the primary display, returning (base64_png, width, height).
 pub fn screenshot_display() -> Result<(String, u32, u32)> {
     let png_bytes = screenshot_display_bytes()?;
@@ -964,6 +1186,70 @@ mod tests {
             .expect("decode PNG")
             .to_rgba8()
             .into_raw()
+    }
+
+    fn solid_png(r: u8, g: u8, b: u8, w: u32, h: u32) -> Vec<u8> {
+        let mut rgba = Vec::with_capacity((w * h * 4) as usize);
+        for _ in 0..(w * h) {
+            rgba.extend_from_slice(&[r, g, b, 255]);
+        }
+        cua_driver_core::image_utils::encode_rgba_to_png(&rgba, w, h).expect("solid PNG")
+    }
+
+    #[test]
+    fn overlay_tiles_leave_root_capture_unchanged_when_unmapped() {
+        let root = solid_png(0, 0, 255, 4, 2);
+        let out = apply_overlay_tiles_to_png(&root, &[]).expect("empty tiles");
+        assert_eq!(decode_png_rgba(&out), decode_png_rgba(&root));
+    }
+
+    #[test]
+    fn overlay_tiles_paint_premultiplied_cursor_pixels_onto_the_root() {
+        let root = solid_png(0, 0, 255, 4, 2);
+        let tiles = [OverlayCaptureTile {
+            x: 1,
+            y: 0,
+            width: 2,
+            height: 1,
+            // Opaque lime, then 50% premultiplied red (127,0,0,128).
+            rgba: vec![0, 255, 0, 255, 127, 0, 0, 128],
+        }];
+        let out = apply_overlay_tiles_to_png(&root, &tiles).expect("composite");
+        let rgba = decode_png_rgba(&out);
+        assert_eq!(&rgba[0..4], &[0, 0, 255, 255], "untouched dest pixel");
+        assert_eq!(&rgba[4..8], &[0, 255, 0, 255], "opaque overlay pixel");
+        let blended_red = rgba[8];
+        let blended_blue = rgba[10];
+        assert!(
+            blended_red > 100 && blended_blue > 100,
+            "50% red over blue should keep both channels: {rgba:?}"
+        );
+        assert_eq!(rgba[11], 255);
+        assert_eq!(&rgba[12..16], &[0, 0, 255, 255]);
+    }
+
+    #[test]
+    fn transparent_overlay_pixels_do_not_replace_the_root() {
+        let root = solid_png(9, 8, 7, 1, 1);
+        let tiles = [OverlayCaptureTile {
+            x: 0,
+            y: 0,
+            width: 1,
+            height: 1,
+            rgba: vec![1, 2, 3, 0],
+        }];
+        let out = apply_overlay_tiles_to_png(&root, &tiles).expect("composite");
+        assert_eq!(decode_png_rgba(&out), vec![9, 8, 7, 255]);
+    }
+
+    #[test]
+    fn overlay_zpixmap_keeps_argb_alpha_for_compositing() {
+        let rgba = overlay_zpixmap_to_premultiplied_rgba(&[10, 20, 30, 40], 1, 1, 32)
+            .expect("32-bit overlay");
+        assert_eq!(rgba, vec![30, 20, 10, 40]);
+        let opaque = overlay_zpixmap_to_premultiplied_rgba(&[1, 2, 3, 99], 1, 1, 24)
+            .expect("24-bit overlay");
+        assert_eq!(opaque, vec![3, 2, 1, 255]);
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/overlay.rs
@@ -58,6 +58,13 @@ use cursor_overlay::{
     CursorConfig, CursorKey, KeyedOverlayCommand, OverlayCommand, OverlayMsg, RenderStateCore,
 };
 
+/// WM_NAME prefix for the X11 override-redirect overlay window.
+///
+/// Desktop capture looks up mapped windows with this prefix and composites
+/// their shaped pixels onto the root screenshot. Keep this in lockstep with
+/// [`crate::capture`].
+pub const AGENT_CURSOR_OVERLAY_WM_NAME_PREFIX: &str = "Cua.AgentCursorOverlay.";
+
 // ── Global channel ────────────────────────────────────────────────────────
 
 static CMD_TX: OnceLock<std::sync::mpsc::SyncSender<OverlayMsg>> = OnceLock::new();
@@ -1140,7 +1147,7 @@ fn run_overlay_thread(cfg: CursorConfig, rx: std::sync::mpsc::Receiver<OverlayMs
     // Set window title (identifies our overlay, matches Windows convention).
     // `Cua.` namespace mirrors the Windows class-name + install-path
     // convention; was `TropeCUA.` (leaked codename from an early C# ref).
-    let title = format!("Cua.AgentCursorOverlay.{}", cfg.cursor_id);
+    let title = format!("{AGENT_CURSOR_OVERLAY_WM_NAME_PREFIX}{}", cfg.cursor_id);
     conn.change_property8(
         PropMode::REPLACE,
         win,
@@ -2897,7 +2904,7 @@ mod tests {
         init(cfg);
         run_on_thread();
 
-        let title = format!("Cua.AgentCursorOverlay.{cursor_id}");
+        let title = format!("{AGENT_CURSOR_OVERLAY_WM_NAME_PREFIX}{cursor_id}");
         let overlay = find_named_window(&conn, root, title.as_bytes())?;
         wait_for_bounding_shape(&conn, overlay, true, "daemon startup")?;
         assert_click_through(&conn, root, overlay, target, "daemon startup")?;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- One-shot `cua-driver call` (and `cua-driver-local call`) always minted a disposable transport `cli-{uuid}` and sent `session_end` after the response. That reaped every public session owned by that transport, so the agent cursor overlay disappeared immediately. A following `get_agent_cursor_state` with the same public `session` returned "session has ended". A held MCP connection kept the overlay because its transport stayed alive.
- X11 `get_desktop_state` captured the root via ImageMagick `import -window root` or `XGetImage` on root. The overlay is a shaped override-redirect window (`Cua.AgentCursorOverlay.*`). Root reads cannot see those pixels (daemon log: "root reads cannot see this window's own pixels"), so PNG screenshots omitted the cursor even while picom composited it into x11vnc/noVNC.

## What changed

- **Named CLI sessions keep the overlay.** If JSON args include a non-empty `session` string, that public name is the daemon transport id and the CLI does **not** send `session_end`. Later `call` invocations with the same `session` continue that overlay. `end_session` still tears it down. Calls without `session` still mint `cli-{uuid}` and `session_end` it (security / one-shot cleanup unchanged).
- **X11 desktop screenshots include the mapped overlay.** After the root capture, the screenshot path finds mapped `Cua.AgentCursorOverlay.*` windows, reads their shaped pixmap, and blends those premultiplied pixels onto the root buffer. Disabled or unmapped overlays leave the root capture unchanged. Root-only `XGetImage` is no longer the final capture when the overlay is shown.

## Grok Bot / Xvfb reproduction

Observed on a Grok Bot Linux VM (Debian 13, Xvfb `:2`, picom, no root):

1. `cua-driver call move_cursor '{"session":"demo","x":...,"y":...}'` painted the overlay, then tore it down on the synchronous `session_end` of `cli-{uuid}`. `get_agent_cursor_state` with `{"session":"demo"}` then failed with "session has ended". The same sequence over a held MCP connection kept the overlay.
2. `get_desktop_state` / root `XGetImage` omitted the cursor while the x11vnc/noVNC view (picom-composited) showed it.

## Related work

No linked GitHub issue. Aligns CLI with the already-documented public session label ("repeat a short public session on every call"). Not a new SDK/MCP contract; no RFC.

## Compatibility and risk

- User-visible: named `cua-driver call` sessions now persist until `end_session` or idle TTL, matching MCP/SDK. Unnamed one-shot calls are unchanged.
- X11 screenshots may now include overlay pixels when the overlay is mapped. macOS/Windows capture is unchanged.
- Rollback: revert this commit.

## Validation

- `cargo test -p cua-driver --bin cua-driver named_cli_session unnamed_cli_call blank_or_non_string_session`
- `cargo test -p platform-linux capture::` (19 passed, 1 ignored live XShm test)
- Known gap: no live Xvfb overlay-in-screenshot run in this environment. Compositing is covered by focused unit tests (empty/unmapped tiles, opaque and translucent blend, ARGB zpixmap alpha). Linux CI X11 overlay click-through remains the live overlay gate.

## Contributor and release checks

- [x] The PR is focused and the description matches the final diff.
- [x] This change does not require an RFC (documented session-label contract; CLI now honors it).
- [x] Tests and the Xvfb/Grok Bot reproduction are in this description; live screenshot-with-overlay on Xvfb is the remaining CI/maintainer gap.
- [x] Title is a Conventional Commit for the production fix (`fix(cua-driver): ...`).
- [x] No external contribution to attribute.
- [x] Release-tracked: user-visible CLI session + X11 screenshot behavior, so this should release.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48750f98-8e1d-4716-bae8-912c05203c3e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48750f98-8e1d-4716-bae8-912c05203c3e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

