### PR TITLE
fix(cua-driver): diagnose Linux hosts and refuse dishonest background PX

### DIFF
--- a/libs/cua-driver/rust/Skills/cua-driver/LINUX.md
+++ b/libs/cua-driver/rust/Skills/cua-driver/LINUX.md
@@ -195,10 +195,12 @@ Each input rung and its stable public route:
 takes the focus-free AT-SPI `do_action`-at-point path (`x11_atspi`), exactly
 like the macOS/Windows background pixel click. It falls to the MPX
 virtual-pointer path (`x11_pixel`) only for non-AX surfaces, **and that path
-needs a real Xorg + `/dev/uinput`** — under Xvnc / minimal containers without
-uinput, escalate to `delivery_mode:"foreground"`. (`type_text` in the
-`background` rung is focus-dependent for non-editable widgets; that's the one
-genuine background limitation, and `foreground` is the documented escalation.)
+needs a real Xorg + `/dev/uinput`** — under Xvfb / Xvnc / minimal containers
+without uinput, the driver returns `background_unavailable` instead of a quiet
+`effect:"unverifiable"` XSendEvent success. Retry with
+`delivery_mode:"foreground"`. (`type_text` in the `background` rung is
+focus-dependent for non-editable widgets; that's the one genuine background
+limitation, and `foreground` is the documented escalation.)
 
 ## Wayland
 
@@ -236,10 +238,15 @@ raw background PX possible on a standard compositor.
 
 If a tool call surprises you on Linux:
 
-1. `cua-driver doctor` — reports the display server (X11 / Wayland),
-   **whether `org.a11y.Bus` actually answers on the session bus** (not just
-   "is there a bus"), the discovered `DBUS_SESSION_BUS_ADDRESS`, and
-   `ffmpeg` availability (for recording).
+1. `cua-driver doctor` — reports the display server (X11 / Xvfb / Xorg /
+   Wayland), compositor, **whether `/dev/uinput` is accessible**, session-bus
+   / `XDG_RUNTIME_DIR` presence, **whether `org.a11y.Bus` actually answers
+   on the session bus** (not just "is there a bus"), and whether background
+   MPX is available. On Xvfb or a host without uinput it warns that
+   background PX/scroll/drag cannot use MPX and should use
+   `delivery_mode:"foreground"`. `cua-driver diagnose` prints the same host
+   facts as a paste-able Linux section (macOS TCC / codesign is skipped).
+   Doctor does not install `at-spi2-core`.
 2. Check `XDG_SESSION_TYPE` — `x11` is fully supported; `wayland`
    needs `CUA_DRIVER_RS_ENABLE_WAYLAND=1` for the native backend,
    else XWayland.

--- a/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -3575,25 +3575,40 @@ pub fn run_dump_docs_with_type(tools_list: &serde_json::Value, pretty: bool, doc
     println!("{}", out.unwrap_or_else(|_| "{}".into()));
 }
 
-/// `cua-driver diagnose` — print a paste-able bundle-path / install-layout / TCC report.
+/// `cua-driver diagnose` — print a paste-able host / install-layout report.
 ///
-/// Mirrors Swift `DiagnoseCommand`. Covers:
-///   - running process identity (path, pid, version)
-///   - codesign info (cdhash, team-id, authority) via `codesign -dvvv`
-///   - AX + screen recording TCC status (check_permissions tool)
-///   - install layout (/Applications/CuaDriver.app, ~/.local/bin/cua-driver)
-///   - TCC DB rows for com.trycua.driver (sqlite3, best-effort)
-///   - config + state paths with existence booleans
+/// On macOS this mirrors Swift `DiagnoseCommand` (bundle path, codesign, TCC).
+/// On Linux it prints a host section (display server, compositor, uinput,
+/// session bus, AT-SPI, background MPX) and explicitly skips the macOS TCC
+/// dump so the command is usable on headless Xvfb VMs.
 pub fn run_diagnose_cmd() {
-    let sections = [
-        diagnose_runtime_section(),
-        diagnose_signature_section(),
-        diagnose_tcc_section(),
-        diagnose_install_layout_section(),
-        diagnose_tcc_db_section(),
-        diagnose_config_paths_section(),
-    ];
-    println!("{}", sections.join("\n\n"));
+    println!("{}", diagnose_report());
+}
+
+fn diagnose_report() -> String {
+    #[cfg(target_os = "linux")]
+    {
+        return [
+            diagnose_runtime_section(),
+            platform_linux::diagnostics::LinuxHostSnapshot::collect().format_diagnose(),
+            platform_linux::diagnostics::diagnose_macos_skipped_section(),
+            diagnose_linux_install_layout_section(),
+            diagnose_linux_config_paths_section(),
+        ]
+        .join("\n\n");
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        [
+            diagnose_runtime_section(),
+            diagnose_signature_section(),
+            diagnose_tcc_section(),
+            diagnose_install_layout_section(),
+            diagnose_tcc_db_section(),
+            diagnose_config_paths_section(),
+        ]
+        .join("\n\n")
+    }
 }
 
 fn diagnose_runtime_section() -> String {
@@ -3615,6 +3630,7 @@ fn diagnose_runtime_section() -> String {
     )
 }
 
+#[cfg(not(target_os = "linux"))]
 fn diagnose_signature_section() -> String {
     let exe = std::env::current_exe()
         .ok()
@@ -3654,6 +3670,7 @@ fn diagnose_signature_section() -> String {
     )
 }
 
+#[cfg(not(target_os = "linux"))]
 fn diagnose_tcc_section() -> String {
     let socket = crate::serve::default_socket_path();
     let status = crate::serve::is_daemon_listening(&socket)
@@ -3695,6 +3712,7 @@ fn diagnose_tcc_section() -> String {
     )
 }
 
+#[cfg(not(target_os = "linux"))]
 fn diagnose_install_layout_section() -> String {
     let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
     let mut lines = vec!["## install layout".to_owned()];
@@ -3751,6 +3769,7 @@ fn diagnose_install_layout_section() -> String {
     lines.join("\n")
 }
 
+#[cfg(not(target_os = "linux"))]
 fn diagnose_tcc_db_section() -> String {
     let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
     let db = format!("{home}/Library/Application Support/com.apple.TCC/TCC.db");
@@ -3791,6 +3810,7 @@ fn diagnose_tcc_db_section() -> String {
     lines.join("\n")
 }
 
+#[cfg(not(target_os = "linux"))]
 fn diagnose_config_paths_section() -> String {
     let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
     let paths: &[(&str, String)] = &[
@@ -3816,6 +3836,50 @@ fn diagnose_config_paths_section() -> String {
         (
             "daemon plist",
             format!("{home}/Library/LaunchAgents/com.trycua.cua_driver_daemon.plist"),
+        ),
+    ];
+    let mut lines = vec!["## config + state paths".to_owned()];
+    for (label, path) in paths {
+        let exists = std::path::Path::new(path).exists();
+        lines.push(format!("{:<18} exists={exists}   {path}", label));
+    }
+    lines.join("\n")
+}
+
+#[cfg(target_os = "linux")]
+fn diagnose_linux_install_layout_section() -> String {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    let mut lines = vec!["## install layout".to_owned()];
+    let cli_paths = [
+        ("symlink", format!("{home}/.local/bin/cua-driver")),
+        ("legacy symlink", "/usr/local/bin/cua-driver".to_owned()),
+    ];
+    for (label, path) in &cli_paths {
+        let exists = std::path::Path::new(path).exists();
+        lines.push(format!("{label}: {path}   exists={exists}"));
+        if exists {
+            if let Ok(target) = std::fs::read_link(path) {
+                lines.push(format!("  resolves to: {}", target.display()));
+            }
+        }
+    }
+    lines.join("\n")
+}
+
+#[cfg(target_os = "linux")]
+fn diagnose_linux_config_paths_section() -> String {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    let paths: &[(&str, String)] = &[
+        (
+            "user data dir",
+            format!("{home}/{}", crate::bundle::user_home_subdirectory()),
+        ),
+        (
+            "telemetry id",
+            format!(
+                "{home}/{}/.telemetry_id",
+                crate::bundle::user_home_subdirectory()
+            ),
         ),
     ];
     let mut lines = vec!["## config + state paths".to_owned()];
@@ -4041,6 +4105,40 @@ fn read_stdin_json() -> Option<serde_json::Value> {
     // chars, so a single `'\u{feff}'` is the right comparand.
     let stripped = trimmed.strip_prefix('\u{feff}').unwrap_or(trimmed);
     serde_json::from_str(stripped).ok()
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod diagnose_linux_tests {
+    use super::*;
+
+    #[test]
+    fn diagnose_report_is_linux_shaped() {
+        let text = diagnose_report();
+        assert!(text.contains("## running process"), "{text}");
+        assert!(text.contains("## linux host"), "{text}");
+        assert!(text.contains("display server:"), "{text}");
+        assert!(text.contains("/dev/uinput:"), "{text}");
+        assert!(text.contains("background MPX:"), "{text}");
+        assert!(text.contains("## macOS TCC / codesign (skipped)"), "{text}");
+        assert!(text.contains("not applicable on Linux"), "{text}");
+        assert!(
+            !text.contains("## tcc probes (daemon)"),
+            "macOS TCC dump must be skipped on Linux:\n{text}"
+        );
+        assert!(!text.contains("kTCCServiceAccessibility"), "{text}");
+        assert!(
+            !text.contains("Library/Application Support/com.apple.TCC"),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn linux_install_layout_omits_macos_bundle() {
+        let text = diagnose_linux_install_layout_section();
+        assert!(text.contains("## install layout"));
+        assert!(text.contains(".local/bin/cua-driver"));
+        assert!(!text.contains("/Applications/CuaDriver.app"));
+    }
 }
 
 #[cfg(test)]

--- a/libs/cua-driver/rust/crates/cua-driver/src/doctor.rs
+++ b/libs/cua-driver/rust/crates/cua-driver/src/doctor.rs
@@ -17,8 +17,9 @@
 //!   telemetry state.
 //! - **Windows**: interactive desktop session detection (Session 0 warning),
 //!   UI Automation COM availability, top-level window enumeration count.
-//! - **Linux**: `DISPLAY` / `WAYLAND_DISPLAY` presence, X11 connection
-//!   reachability, AT-SPI bus availability hint.
+//! - **Linux**: display server (X11 / Xvfb / Xorg / Wayland), compositor,
+//!   `/dev/uinput`, session bus / `XDG_RUNTIME_DIR`, AT-SPI, and whether
+//!   background MPX is available. Xvfb and missing uinput are warnings.
 //! - **macOS**: existing legacy-cleanup steps (LaunchAgent plist + update
 //!   script), plus a hint to run `cua-driver diagnose` for a full
 //!   TCC / cdhash / install layout dump.
@@ -369,108 +370,32 @@ fn append_platform_probes(report: &mut Report) {
     report.push(probe);
 }
 
-/// Run `gdbus introspect` against the AT-SPI accessibility bus and report
-/// whether it returned success within `timeout`. Any of: spawn failure,
-/// timeout elapsed, non-zero exit — all collapse to `false` (the caller
-/// only cares about reachability, not the failure mode).
-///
-/// Kept separate from `append_platform_probes` so it's straightforward to
-/// unit-test the timeout path without invoking the full doctor run.
-#[cfg(target_os = "linux")]
-fn probe_at_spi_bus_via_gdbus(timeout: std::time::Duration) -> bool {
-    use std::process::{Command, Stdio};
-
-    let mut child = match Command::new("gdbus")
-        .args([
-            "introspect",
-            "--session",
-            "--dest",
-            "org.a11y.Bus",
-            "--object-path",
-            "/org/a11y/bus",
-        ])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-    {
-        Ok(c) => c,
-        Err(_) => return false,
-    };
-    match wait_for_child(&mut child, timeout) {
-        Ok(Some(status)) => status.success(),
-        Ok(None) | Err(_) => {
-            // Timed out or failed — kill the stuck child so we don't leave a
-            // gdbus process hanging around after `doctor` exits.
-            let _ = child.kill();
-            let _ = child.wait();
-            false
-        }
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn wait_for_child(
-    child: &mut std::process::Child,
-    timeout: std::time::Duration,
-) -> std::io::Result<Option<std::process::ExitStatus>> {
-    let deadline = std::time::Instant::now() + timeout;
-    loop {
-        if let Some(status) = child.try_wait()? {
-            return Ok(Some(status));
-        }
-
-        let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now()) else {
-            return Ok(None);
-        };
-        if remaining.is_zero() {
-            return Ok(None);
-        }
-        std::thread::sleep(remaining.min(std::time::Duration::from_millis(15)));
-    }
-}
-
 #[cfg(target_os = "linux")]
 fn append_platform_probes(report: &mut Report) {
-    // Display server probe. Order matters: Wayland wins when both are set
-    // (XWayland leaves DISPLAY pointing at the X server XWayland exposes,
-    // but the actual session is still Wayland).
-    let display = std::env::var("DISPLAY").ok().filter(|v| !v.is_empty());
-    let wayland = std::env::var("WAYLAND_DISPLAY")
-        .ok()
-        .filter(|v| !v.is_empty());
-    match (display.as_deref(), wayland.as_deref()) {
-        (None, None) => report.push(
-            Probe::warn(
-                "display server",
-                "neither DISPLAY nor WAYLAND_DISPLAY set — window-driving tools will fail",
-            )
-            .with_detail(
-                "run from an interactive desktop session (X11 / Wayland with XWayland) or set DISPLAY explicitly.",
-            ),
-        ),
-        (Some(d), None) => report.push(Probe::ok(
-            "display server",
-            format!("X11 (DISPLAY={d})"),
-        )),
-        (None, Some(w)) => report.push(
-            Probe::warn(
-                "display server",
-                format!("Wayland only (WAYLAND_DISPLAY={w}, DISPLAY unset)"),
-            )
-            .with_detail(
-                "X11 tools (list_windows, screenshot) need XWayland — start your session with XWayland enabled.",
-            ),
-        ),
-        (Some(d), Some(w)) => report.push(Probe::ok(
-            "display server",
-            format!("Wayland+XWayland (WAYLAND_DISPLAY={w}, DISPLAY={d})"),
-        )),
+    let snapshot = platform_linux::diagnostics::LinuxHostSnapshot::collect();
+    for host in platform_linux::diagnostics::doctor_host_probes(&snapshot) {
+        let probe = if host.warn {
+            Probe::warn(host.label, host.message)
+        } else {
+            Probe::ok(host.label, host.message)
+        };
+        report.push(match host.detail {
+            Some(detail) => probe.with_detail(detail),
+            None => probe,
+        });
+        // Keep the live X11 connection probe next to the display-server
+        // classification so a disconnected DISPLAY is visible beside "Xvfb".
+        if host.label == "compositor" {
+            push_x11_connection_probe(report);
+        }
     }
+}
 
-    // X11 window enumeration probe. An empty result could mean either an
-    // unreachable display or a healthy display with no top-level windows
-    // open — `list_windows` doesn't distinguish the two — so the warning
-    // hedges instead of asserting a connection failure.
+#[cfg(target_os = "linux")]
+fn push_x11_connection_probe(report: &mut Report) {
+    // An empty result could mean either an unreachable display or a healthy
+    // display with no top-level windows — `list_windows` doesn't distinguish
+    // the two — so the warning hedges instead of asserting a connection failure.
     match platform_linux::x11::list_windows(None) {
         v if v.is_empty() => report.push(Probe::warn(
             "X11 connection",
@@ -484,39 +409,6 @@ fn append_platform_probes(report: &mut Report) {
                 if v.len() == 1 { "" } else { "s" }
             ),
         )),
-    }
-
-    // AT-SPI bus probe. We don't link D-Bus directly — instead, check for
-    // the AT_SPI_BUS env var which the at-spi daemon advertises when
-    // running, and fall back to checking gdbus's view of the
-    // org.a11y.Bus name.
-    let at_spi_env = std::env::var("AT_SPI_BUS").ok().filter(|v| !v.is_empty());
-    match at_spi_env {
-        Some(addr) => report.push(Probe::ok(
-            "AT-SPI",
-            format!("bus address present (AT_SPI_BUS={addr})"),
-        )),
-        None => {
-            // Bounded wait — a hung session bus daemon would otherwise
-            // block `doctor` indefinitely. 3s is enough for a healthy
-            // gdbus introspect to complete (single round-trip on the
-            // session bus) and short enough that a stuck bus surfaces
-            // as a warning instead of looking like the binary froze.
-            let bus_ok = probe_at_spi_bus_via_gdbus(std::time::Duration::from_secs(3));
-            if bus_ok {
-                report.push(Probe::ok(
-                    "AT-SPI",
-                    "org.a11y.Bus reachable via session bus",
-                ));
-            } else {
-                report.push(
-                    Probe::warn("AT-SPI", "accessibility bus not reachable")
-                        .with_detail(
-                            "install at-spi2-core and ensure the user session has D-Bus running for get_window_state to work.",
-                        ),
-                );
-            }
-        }
     }
 }
 
@@ -635,25 +527,25 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn wait_for_child_reports_exit() {
-        let mut child = std::process::Command::new("true").spawn().unwrap();
-        let status = wait_for_child(&mut child, std::time::Duration::from_secs(1))
-            .unwrap()
-            .unwrap();
-        assert!(status.success());
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn wait_for_child_times_out() {
-        let mut child = std::process::Command::new("sleep")
-            .arg("5")
-            .spawn()
-            .unwrap();
-        let status = wait_for_child(&mut child, std::time::Duration::from_millis(10)).unwrap();
-        assert!(status.is_none());
-        child.kill().unwrap();
-        child.wait().unwrap();
+    fn linux_doctor_emits_pointer_capability_probes() {
+        let report = run();
+        let labels: Vec<&str> = report.probes.iter().map(|p| p.label.as_str()).collect();
+        for need in [
+            "display server",
+            "compositor",
+            "X11 connection",
+            "uinput",
+            "session bus",
+            "AT-SPI",
+            "background MPX",
+        ] {
+            assert!(labels.contains(&need), "missing {need} in {labels:?}");
+        }
+        assert!(
+            !report.to_text().contains("/Applications/CuaDriver.app"),
+            "{}",
+            report.to_text()
+        );
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/diagnostics.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/diagnostics.rs
@@ -1,0 +1,648 @@
+//! Linux host probes shared by `cua-driver doctor` and `cua-driver diagnose`.
+//!
+//! Headless / Grok-Bot-style VMs (Xvfb, no `/dev/uinput`, no systemd user
+//! session, no AT-SPI) are a supported *observation* environment: doctor and
+//! diagnose must describe them honestly so an agent knows background MPX
+//! pixel input cannot land and should retry with `delivery_mode: foreground`.
+//! These probes never install packages and never start AT-SPI.
+
+use std::fs;
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+
+/// `/dev/uinput` open result. Distinguishes "node missing" from "present but
+/// this user cannot open it" so doctor can say which remediation applies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UinputStatus {
+    Accessible,
+    Missing,
+    Inaccessible,
+}
+
+impl UinputStatus {
+    pub fn probe() -> Self {
+        match fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/uinput")
+        {
+            Ok(_) => Self::Accessible,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Self::Missing,
+            Err(_) => Self::Inaccessible,
+        }
+    }
+
+    pub fn is_accessible(self) -> bool {
+        matches!(self, Self::Accessible)
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Accessible => "accessible",
+            Self::Missing => "missing",
+            Self::Inaccessible => "inaccessible",
+        }
+    }
+}
+
+/// One doctor line produced from a [`LinuxHostSnapshot`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostProbe {
+    pub label: &'static str,
+    pub warn: bool,
+    pub message: String,
+    pub detail: Option<String>,
+}
+
+/// Read-only snapshot of the Linux input / session environment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinuxHostSnapshot {
+    pub display: Option<String>,
+    pub wayland_display: Option<String>,
+    pub x_session_type: Option<String>,
+    pub x_server: Option<String>,
+    pub compositors: Vec<String>,
+    pub desktop: Option<String>,
+    pub uinput: UinputStatus,
+    pub xdg_runtime_dir: Option<String>,
+    pub runtime_user_dir: String,
+    pub runtime_user_dir_exists: bool,
+    pub session_bus_socket: String,
+    pub session_bus_socket_exists: bool,
+    pub dbus_session_bus_address: Option<String>,
+    pub at_spi_reachable: bool,
+    pub background_mpx_available: bool,
+}
+
+impl LinuxHostSnapshot {
+    /// Probe the calling process environment. Cheap and side-effect-free
+    /// aside from opening the X display (for the MPX capability check) and
+    /// a session-bus name lookup for `org.a11y.Bus`.
+    pub fn collect() -> Self {
+        let uid = current_uid();
+        let runtime_user_dir = format!("/run/user/{uid}");
+        let session_bus_socket = format!("{runtime_user_dir}/bus");
+        Self {
+            display: env_nonempty("DISPLAY"),
+            wayland_display: env_nonempty("WAYLAND_DISPLAY"),
+            x_session_type: env_nonempty("XDG_SESSION_TYPE"),
+            x_server: crate::input::x_server_exe_name(),
+            compositors: running_compositors(),
+            desktop: env_nonempty("XDG_CURRENT_DESKTOP")
+                .or_else(|| env_nonempty("DESKTOP_SESSION")),
+            uinput: UinputStatus::probe(),
+            xdg_runtime_dir: env_nonempty("XDG_RUNTIME_DIR"),
+            runtime_user_dir_exists: Path::new(&runtime_user_dir).is_dir(),
+            runtime_user_dir,
+            session_bus_socket_exists: Path::new(&session_bus_socket).exists(),
+            session_bus_socket,
+            dbus_session_bus_address: env_nonempty("DBUS_SESSION_BUS_ADDRESS"),
+            at_spi_reachable: crate::health_report::probe_a11y_bus(),
+            background_mpx_available: crate::input::real_pointer_input_available(),
+        }
+    }
+
+    /// Classify the display server for doctor / diagnose. Xvfb and Xtigervnc
+    /// are called out by name because they cannot host an MPX/uinput slave.
+    pub fn display_server_kind(&self) -> &'static str {
+        if self.wayland_display.is_some() && self.display.is_none() {
+            return "Wayland";
+        }
+        match self.x_server.as_deref() {
+            Some("Xvfb") => "Xvfb",
+            Some("Xorg") => "Xorg",
+            Some("Xtigervnc") => "Xtigervnc",
+            Some("Xwayland") => {
+                if self.wayland_display.is_some() {
+                    "Wayland+XWayland"
+                } else {
+                    "Xwayland"
+                }
+            }
+            Some(_) | None if self.display.is_some() => "X11",
+            _ => "none",
+        }
+    }
+
+    /// True when this host is known not to expose a real X input slave for
+    /// uinput (Xvfb has no udev/libinput hotplug; Xtigervnc exposes only its
+    /// built-in VNC/XTEST devices).
+    pub fn is_virtual_pointer_host(&self) -> bool {
+        matches!(self.x_server.as_deref(), Some("Xvfb") | Some("Xtigervnc"))
+    }
+
+    pub fn format_diagnose(&self) -> String {
+        let display = self.display.as_deref().unwrap_or("unset");
+        let wayland = self.wayland_display.as_deref().unwrap_or("unset");
+        let session_type = self.x_session_type.as_deref().unwrap_or("unset");
+        let x_server = self.x_server.as_deref().unwrap_or("unknown");
+        let compositors = if self.compositors.is_empty() {
+            "none detected".to_owned()
+        } else {
+            self.compositors.join(", ")
+        };
+        let desktop = self.desktop.as_deref().unwrap_or("unset");
+        let xdg_runtime = self.xdg_runtime_dir.as_deref().unwrap_or("unset");
+        let dbus = self.dbus_session_bus_address.as_deref().unwrap_or("unset");
+        let at_spi = if self.at_spi_reachable {
+            "reachable"
+        } else {
+            "not reachable"
+        };
+        let mpx = if self.background_mpx_available {
+            "available".to_owned()
+        } else {
+            format!("unavailable ({})", self.mpx_unavailable_reason())
+        };
+
+        format!(
+            "## linux host\n\
+             display server:            {kind}\n\
+             DISPLAY:                   {display}\n\
+             WAYLAND_DISPLAY:           {wayland}\n\
+             XDG_SESSION_TYPE:          {session_type}\n\
+             X server binary:           {x_server}\n\
+             compositor:                {compositors}\n\
+             desktop:                   {desktop}\n\
+             /dev/uinput:               {uinput}\n\
+             XDG_RUNTIME_DIR:           {xdg_runtime}\n\
+             /run/user/<uid>:           {runtime} exists={runtime_exists}\n\
+             session bus socket:        {bus} exists={bus_exists}\n\
+             DBUS_SESSION_BUS_ADDRESS:  {dbus}\n\
+             AT-SPI org.a11y.Bus:       {at_spi}\n\
+             background MPX:            {mpx}\n\
+             \n\
+             {hint}",
+            kind = self.display_server_kind(),
+            uinput = self.uinput.label(),
+            runtime = self.runtime_user_dir,
+            runtime_exists = self.runtime_user_dir_exists,
+            bus = self.session_bus_socket,
+            bus_exists = self.session_bus_socket_exists,
+            hint = self.background_pointer_hint(),
+        )
+    }
+
+    pub fn mpx_unavailable_reason(&self) -> String {
+        let mut parts = Vec::new();
+        if self.is_virtual_pointer_host() {
+            parts.push(format!(
+                "{} is not a real pointer host",
+                self.x_server.as_deref().unwrap_or("this X server")
+            ));
+        }
+        if !self.uinput.is_accessible() {
+            parts.push(format!("/dev/uinput is {}", self.uinput.label()));
+        }
+        if parts.is_empty() {
+            "MPX/uinput pointer is not available on this X server".to_owned()
+        } else {
+            parts.join("; ")
+        }
+    }
+
+    pub fn background_pointer_hint(&self) -> &'static str {
+        if self.background_mpx_available {
+            "Background pixel click/scroll/drag can use the MPX/uinput pointer."
+        } else {
+            "Background pixel click/scroll/drag cannot use MPX/uinput on this host. \
+             When AT-SPI-at-point also misses, retry with delivery_mode:\"foreground\"."
+        }
+    }
+}
+
+/// Doctor probes for the Linux host. Warnings (never errors) when the X
+/// server cannot host a real pointer or `/dev/uinput` is missing — CI and
+/// headless VMs are valid places to run `doctor`.
+pub fn doctor_host_probes(snapshot: &LinuxHostSnapshot) -> Vec<HostProbe> {
+    let mut probes = Vec::new();
+
+    let display_env = snapshot.display.as_deref();
+    let wayland_env = snapshot.wayland_display.as_deref();
+    match (display_env, wayland_env, snapshot.display_server_kind()) {
+        (None, None, _) => probes.push(HostProbe {
+            label: "display server",
+            warn: true,
+            message: "neither DISPLAY nor WAYLAND_DISPLAY set — window-driving tools will fail"
+                .into(),
+            detail: Some(
+                "run from an interactive desktop session (X11 / Wayland with XWayland) or set DISPLAY explicitly.".into(),
+            ),
+        }),
+        (_, _, "Xvfb") => probes.push(HostProbe {
+            label: "display server",
+            warn: true,
+            message: format!(
+                "Xvfb (DISPLAY={}) — not a real pointer host; background PX/scroll/drag cannot use MPX",
+                snapshot.display.as_deref().unwrap_or("?")
+            ),
+            detail: Some(
+                "Xvfb has no udev/libinput hotplug, so a uinput device never becomes an X input slave. \
+                 Use delivery_mode:\"foreground\" for pixel click/scroll/drag when AT-SPI-at-point cannot land."
+                    .into(),
+            ),
+        }),
+        (_, _, "Xtigervnc") => probes.push(HostProbe {
+            label: "display server",
+            warn: true,
+            message: format!(
+                "Xtigervnc (DISPLAY={}) — not a real pointer host; background PX/scroll/drag cannot use MPX",
+                snapshot.display.as_deref().unwrap_or("?")
+            ),
+            detail: Some(
+                "Xtigervnc exposes only its built-in VNC/XTEST devices. \
+                 Use delivery_mode:\"foreground\" for pixel click/scroll/drag when AT-SPI-at-point cannot land."
+                    .into(),
+            ),
+        }),
+        (None, Some(w), _) => probes.push(HostProbe {
+            label: "display server",
+            warn: true,
+            message: format!("Wayland only (WAYLAND_DISPLAY={w}, DISPLAY unset)"),
+            detail: Some(
+                "X11 tools (list_windows, screenshot) need XWayland — start your session with XWayland enabled.".into(),
+            ),
+        }),
+        (Some(d), Some(w), kind) => probes.push(HostProbe {
+            label: "display server",
+            warn: false,
+            message: format!("{kind} (WAYLAND_DISPLAY={w}, DISPLAY={d})"),
+            detail: None,
+        }),
+        (Some(d), None, kind) => probes.push(HostProbe {
+            label: "display server",
+            warn: false,
+            message: format!("{kind} (DISPLAY={d})"),
+            detail: None,
+        }),
+    }
+
+    let compositor_msg = if snapshot.compositors.is_empty() {
+        snapshot
+            .desktop
+            .as_deref()
+            .map(|desktop| format!("none detected (desktop={desktop})"))
+            .unwrap_or_else(|| "none detected".into())
+    } else {
+        snapshot.compositors.join(", ")
+    };
+    probes.push(HostProbe {
+        label: "compositor",
+        warn: false,
+        message: compositor_msg,
+        detail: None,
+    });
+
+    match snapshot.uinput {
+        UinputStatus::Accessible => probes.push(HostProbe {
+            label: "uinput",
+            warn: false,
+            message: "/dev/uinput is accessible".into(),
+            detail: None,
+        }),
+        UinputStatus::Missing => probes.push(HostProbe {
+            label: "uinput",
+            warn: true,
+            message: "/dev/uinput is missing — background MPX pointer cannot be created".into(),
+            detail: Some(
+                "background pixel click/scroll/drag needs a real Xorg plus /dev/uinput. \
+                 Use delivery_mode:\"foreground\" on this host. cua-driver does not install kernel modules."
+                    .into(),
+            ),
+        }),
+        UinputStatus::Inaccessible => probes.push(HostProbe {
+            label: "uinput",
+            warn: true,
+            message: "/dev/uinput exists but is not writable by this user".into(),
+            detail: Some(
+                "background MPX needs write access to /dev/uinput (usually the `input` group). \
+                 Use delivery_mode:\"foreground\" until that is granted."
+                    .into(),
+            ),
+        }),
+    }
+
+    let runtime = match (
+        snapshot.xdg_runtime_dir.as_deref(),
+        snapshot.session_bus_socket_exists,
+        snapshot.dbus_session_bus_address.as_deref(),
+    ) {
+        (Some(dir), true, Some(addr)) => HostProbe {
+            label: "session bus",
+            warn: false,
+            message: format!("XDG_RUNTIME_DIR={dir}; bus at {addr}"),
+            detail: None,
+        },
+        (Some(dir), true, None) => HostProbe {
+            label: "session bus",
+            warn: false,
+            message: format!(
+                "XDG_RUNTIME_DIR={dir}; {} exists (DBUS_SESSION_BUS_ADDRESS unset)",
+                snapshot.session_bus_socket
+            ),
+            detail: None,
+        },
+        _ => HostProbe {
+            label: "session bus",
+            warn: true,
+            message: format!(
+                "XDG_RUNTIME_DIR={}; {} exists={}; DBUS_SESSION_BUS_ADDRESS={}",
+                snapshot.xdg_runtime_dir.as_deref().unwrap_or("unset"),
+                snapshot.session_bus_socket,
+                snapshot.session_bus_socket_exists,
+                snapshot
+                    .dbus_session_bus_address
+                    .as_deref()
+                    .unwrap_or("unset"),
+            ),
+            detail: Some(
+                "AT-SPI lives on the session bus. A missing /run/user/<uid>/bus and unset \
+                 DBUS_SESSION_BUS_ADDRESS is typical on headless VMs without systemd --user."
+                    .into(),
+            ),
+        },
+    };
+    probes.push(runtime);
+
+    if snapshot.at_spi_reachable {
+        probes.push(HostProbe {
+            label: "AT-SPI",
+            warn: false,
+            message: "org.a11y.Bus reachable via session bus".into(),
+            detail: None,
+        });
+    } else {
+        probes.push(HostProbe {
+            label: "AT-SPI",
+            warn: true,
+            message: "accessibility bus not reachable".into(),
+            detail: Some(
+                "install at-spi2-core and ensure the user session has D-Bus running for get_window_state to work. \
+                 cua-driver does not apt-install packages."
+                    .into(),
+            ),
+        });
+    }
+
+    if snapshot.background_mpx_available {
+        probes.push(HostProbe {
+            label: "background MPX",
+            warn: false,
+            message: "real MPX/uinput pointer is available".into(),
+            detail: None,
+        });
+    } else {
+        probes.push(HostProbe {
+            label: "background MPX",
+            warn: true,
+            message: format!(
+                "unavailable ({}) — background PX/scroll/drag should use delivery_mode:\"foreground\"",
+                snapshot.mpx_unavailable_reason()
+            ),
+            detail: Some(snapshot.background_pointer_hint().into()),
+        });
+    }
+
+    probes
+}
+
+/// macOS-only diagnose sections, printed as an explicit skip on Linux so the
+/// command no longer looks like a broken TCC dump.
+pub fn diagnose_macos_skipped_section() -> String {
+    "## macOS TCC / codesign (skipped)\n\
+     not applicable on Linux — no TCC, codesign, /Applications/CuaDriver.app, \
+     or ~/Library TCC.db.\n\
+     See the linux host section above. sqlite3 is not required."
+        .to_owned()
+}
+
+fn env_nonempty(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|value| !value.is_empty())
+}
+
+fn current_uid() -> u32 {
+    fs::metadata("/proc/self")
+        .map(|meta| meta.uid())
+        .unwrap_or(0)
+}
+
+const COMPOSITOR_COMMS: &[&str] = &[
+    "xfwm4",
+    "picom",
+    "compton",
+    "mutter",
+    "gnome-shell",
+    "kwin_x11",
+    "kwin_wayland",
+    "kwin",
+    "sway",
+    "labwc",
+    "openbox",
+    "i3",
+    "Hyprland",
+    "hyprland",
+    "weston",
+    "wayfire",
+    "niri",
+    "compiz",
+    "marco",
+];
+
+/// Match `/proc/<pid>/comm` names against known compositor / compositor-helper
+/// processes. Split out so the table is unit-tested without walking /proc.
+pub fn compositors_from_comms(comms: &[&str]) -> Vec<String> {
+    let mut found = Vec::new();
+    for comm in comms {
+        if COMPOSITOR_COMMS.iter().any(|known| *known == *comm) && !found.iter().any(|s| s == comm)
+        {
+            found.push((*comm).to_owned());
+        }
+    }
+    found
+}
+
+fn running_compositors() -> Vec<String> {
+    let Ok(entries) = fs::read_dir("/proc") else {
+        return Vec::new();
+    };
+    let mut comms = Vec::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        if !name
+            .to_str()
+            .is_some_and(|s| !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()))
+        {
+            continue;
+        }
+        if let Ok(comm) = fs::read_to_string(entry.path().join("comm")) {
+            comms.push(comm.trim().to_owned());
+        }
+    }
+    let refs: Vec<&str> = comms.iter().map(String::as_str).collect();
+    compositors_from_comms(&refs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn grok_bot_snapshot() -> LinuxHostSnapshot {
+        LinuxHostSnapshot {
+            display: Some(":2".into()),
+            wayland_display: None,
+            x_session_type: None,
+            x_server: Some("Xvfb".into()),
+            compositors: vec!["xfwm4".into(), "picom".into()],
+            desktop: None,
+            uinput: UinputStatus::Missing,
+            xdg_runtime_dir: None,
+            runtime_user_dir: "/run/user/1000".into(),
+            runtime_user_dir_exists: false,
+            session_bus_socket: "/run/user/1000/bus".into(),
+            session_bus_socket_exists: false,
+            dbus_session_bus_address: None,
+            at_spi_reachable: false,
+            background_mpx_available: false,
+        }
+    }
+
+    #[test]
+    fn xvfb_is_classified_as_virtual_pointer_host() {
+        let snap = grok_bot_snapshot();
+        assert_eq!(snap.display_server_kind(), "Xvfb");
+        assert!(snap.is_virtual_pointer_host());
+        assert!(snap.mpx_unavailable_reason().contains("Xvfb"));
+        assert!(snap.mpx_unavailable_reason().contains("/dev/uinput"));
+    }
+
+    #[test]
+    fn diagnose_linux_host_section_lists_grok_bot_facts() {
+        let text = grok_bot_snapshot().format_diagnose();
+        assert!(text.starts_with("## linux host"), "{text}");
+        assert!(text.contains("display server:            Xvfb"), "{text}");
+        assert!(text.contains("DISPLAY:                   :2"), "{text}");
+        assert!(
+            text.contains("compositor:                xfwm4, picom"),
+            "{text}"
+        );
+        assert!(
+            text.contains("/dev/uinput:               missing"),
+            "{text}"
+        );
+        assert!(text.contains("XDG_RUNTIME_DIR:           unset"), "{text}");
+        assert!(text.contains("/run/user/1000 exists=false"), "{text}");
+        assert!(text.contains("/run/user/1000/bus exists=false"), "{text}");
+        assert!(
+            text.contains("AT-SPI org.a11y.Bus:       not reachable"),
+            "{text}"
+        );
+        assert!(
+            text.contains("background MPX:            unavailable"),
+            "{text}"
+        );
+        assert!(text.contains("delivery_mode:\"foreground\""), "{text}");
+        assert!(!text.contains("TCC"), "{text}");
+        assert!(!text.contains("/Applications/CuaDriver.app"), "{text}");
+    }
+
+    #[test]
+    fn doctor_warns_on_xvfb_and_missing_uinput() {
+        let probes = doctor_host_probes(&grok_bot_snapshot());
+        let by_label: Vec<_> = probes
+            .iter()
+            .map(|p| (p.label, p.warn, &p.message))
+            .collect();
+        let display = probes.iter().find(|p| p.label == "display server").unwrap();
+        assert!(display.warn, "{by_label:?}");
+        assert!(display.message.contains("Xvfb"), "{}", display.message);
+        assert!(
+            display.message.contains("not a real pointer host"),
+            "{}",
+            display.message
+        );
+
+        let uinput = probes.iter().find(|p| p.label == "uinput").unwrap();
+        assert!(uinput.warn, "{by_label:?}");
+        assert!(
+            uinput.message.contains("/dev/uinput is missing"),
+            "{}",
+            uinput.message
+        );
+
+        let mpx = probes.iter().find(|p| p.label == "background MPX").unwrap();
+        assert!(mpx.warn, "{by_label:?}");
+        assert!(
+            mpx.message.contains("delivery_mode:\"foreground\""),
+            "{}",
+            mpx.message
+        );
+
+        let at_spi = probes.iter().find(|p| p.label == "AT-SPI").unwrap();
+        assert!(at_spi.warn);
+        assert!(at_spi
+            .detail
+            .as_deref()
+            .unwrap_or("")
+            .contains("does not apt-install"));
+    }
+
+    #[test]
+    fn doctor_ok_on_real_xorg_with_uinput() {
+        let snap = LinuxHostSnapshot {
+            display: Some(":0".into()),
+            wayland_display: None,
+            x_session_type: Some("x11".into()),
+            x_server: Some("Xorg".into()),
+            compositors: vec!["mutter".into()],
+            desktop: Some("GNOME".into()),
+            uinput: UinputStatus::Accessible,
+            xdg_runtime_dir: Some("/run/user/1000".into()),
+            runtime_user_dir: "/run/user/1000".into(),
+            runtime_user_dir_exists: true,
+            session_bus_socket: "/run/user/1000/bus".into(),
+            session_bus_socket_exists: true,
+            dbus_session_bus_address: Some("unix:path=/run/user/1000/bus".into()),
+            at_spi_reachable: true,
+            background_mpx_available: true,
+        };
+        assert_eq!(snap.display_server_kind(), "Xorg");
+        assert!(!snap.is_virtual_pointer_host());
+        let probes = doctor_host_probes(&snap);
+        assert!(
+            probes.iter().all(|p| !p.warn),
+            "{:?}",
+            probes
+                .iter()
+                .filter(|p| p.warn)
+                .map(|p| p.label)
+                .collect::<Vec<_>>()
+        );
+        let display = probes.iter().find(|p| p.label == "display server").unwrap();
+        assert_eq!(display.message, "Xorg (DISPLAY=:0)");
+    }
+
+    #[test]
+    fn compositor_comm_table_matches_xfce_and_picom() {
+        assert_eq!(
+            compositors_from_comms(&["bash", "xfwm4", "picom", "chromium"]),
+            vec!["xfwm4".to_owned(), "picom".to_owned()]
+        );
+        assert!(compositors_from_comms(&["sshd", "bash"]).is_empty());
+    }
+
+    #[test]
+    fn macos_skip_section_is_explicit() {
+        let text = diagnose_macos_skipped_section();
+        assert!(text.contains("skipped"));
+        assert!(text.contains("not applicable on Linux"));
+        assert!(text.contains("TCC"));
+        assert!(text.contains("linux host section"));
+    }
+
+    #[test]
+    fn uinput_status_labels_are_stable() {
+        assert_eq!(UinputStatus::Accessible.label(), "accessible");
+        assert_eq!(UinputStatus::Missing.label(), "missing");
+        assert_eq!(UinputStatus::Inaccessible.label(), "inaccessible");
+    }
+}

--- a/libs/cua-driver/rust/crates/platform-linux/src/input/delivery.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/input/delivery.rs
@@ -104,6 +104,10 @@ pub enum BackgroundUnavailable {
     /// WebKitGTK rejects synthetic XSendEvent input and no real target-addressed
     /// pointer backend is available in this session.
     WebKitSyntheticInput,
+    /// AT-SPI-at-point missed and this X server cannot host an MPX/uinput
+    /// pointer (Xvfb and/or `/dev/uinput` inaccessible). XSendEvent is not
+    /// reported as a landed click on those hosts.
+    NoMpxPointer,
 }
 
 impl BackgroundUnavailable {
@@ -113,6 +117,7 @@ impl BackgroundUnavailable {
             Self::ChromiumInput => "background_unavailable",
             Self::FocusedInputOnly => "background_unavailable",
             Self::WebKitSyntheticInput => "background_unavailable",
+            Self::NoMpxPointer => "background_unavailable",
         }
     }
     fn detail(self) -> &'static str {
@@ -132,6 +137,11 @@ impl BackgroundUnavailable {
             }
             Self::WebKitSyntheticInput => {
                 "WebKitGTK rejects synthetic XSendEvent input and this session has no real target-addressed pointer backend"
+            }
+            Self::NoMpxPointer => {
+                "AT-SPI-at-point did not land and this X server cannot host an \
+                 MPX/uinput pointer (Xvfb and/or /dev/uinput inaccessible); \
+                 XSendEvent is not treated as a landed click"
             }
         }
     }
@@ -220,6 +230,25 @@ mod tests {
             .as_str()
             .expect("delivery_mode description");
         assert!(!description.contains("bring_to_front"));
+    }
+
+    #[test]
+    fn no_mpx_pointer_refusal_is_background_unavailable() {
+        let r = background_unavailable_error(BackgroundUnavailable::NoMpxPointer);
+        assert_eq!(r.is_error, Some(true));
+        let structured = r.structured_content.as_ref().unwrap();
+        assert_eq!(
+            structured["code"],
+            serde_json::json!("background_unavailable")
+        );
+        assert_eq!(
+            structured["escalation"]["recommended"].as_str(),
+            Some("foreground")
+        );
+        let detail = structured["detail"].as_str().unwrap_or_default();
+        assert!(detail.contains("Xvfb"), "{detail}");
+        assert!(detail.contains("uinput"), "{detail}");
+        assert!(detail.contains("XSendEvent"), "{detail}");
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/input/mod.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/input/mod.rs
@@ -339,7 +339,7 @@ pub fn check_parallel_pointer_support() -> Result<()> {
 /// The file name of the X server binary backing `DISPLAY`, read from the PID in
 /// the server's standard `/tmp/.X{N}-lock` file. Used to recognise servers that
 /// can't expose uinput/libinput pointers as real X input slaves.
-fn x_server_exe_name() -> Option<String> {
+pub fn x_server_exe_name() -> Option<String> {
     let display = std::env::var("DISPLAY").unwrap_or_default();
     let display_num = display
         .rsplit(':')
@@ -375,6 +375,12 @@ fn x_server_exe_name() -> Option<String> {
 /// timeout per attempt before failing.
 fn is_xvfb_process_running() -> bool {
     x_server_exe_name().as_deref() == Some("Xvfb")
+}
+
+/// True when `DISPLAY` is served by a headless Xvfb. Public alias for doctor
+/// and diagnose so they share the same lock-file probe as the MPX gate.
+pub fn is_xvfb_display() -> bool {
+    is_xvfb_process_running()
 }
 
 /// Cheap up-front probe (no device creation, no slave-bind wait) for whether the

--- a/libs/cua-driver/rust/crates/platform-linux/src/lib.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/lib.rs
@@ -71,6 +71,9 @@ pub mod xauth;
 #[cfg(target_os = "linux")]
 pub mod session_bus;
 
+#[cfg(target_os = "linux")]
+pub mod diagnostics;
+
 /// Pure WSL-detection predicate, split out from [`is_wsl`] so both branches
 /// are unit-testable without the process-global env / `OnceLock` cache.
 /// `wsl_env` mirrors `$WSL_DISTRO_NAME`/`$WSL_INTEROP` being set; `osrelease`

--- a/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/tools/impl_.rs
@@ -1784,6 +1784,33 @@ fn chromium_background_must_refuse(
     chromium && !foreground && !focus_free_inject_mode
 }
 
+/// After AT-SPI-at-point misses, background pixel delivery must not claim an
+/// XSendEvent success on hosts that cannot bind an MPX/uinput pointer (Xvfb,
+/// missing `/dev/uinput`). Chromium/GTK/Qt drop those synthetic events; the
+/// caller retries with `delivery_mode: foreground`.
+fn background_pixel_without_mpx_must_refuse(
+    foreground: bool,
+    atspi_at_point_landed: bool,
+    mpx_available: bool,
+) -> bool {
+    !foreground && !atspi_at_point_landed && !mpx_available
+}
+
+fn unavailable_background_pointer_without_mpx(
+    delivery: crate::input::delivery::DeliveryMode,
+) -> Option<ToolResult> {
+    background_pixel_without_mpx_must_refuse(
+        delivery.is_foreground(),
+        false,
+        crate::input::real_pointer_input_available() || crate::wayland::is_inject_mode(),
+    )
+    .then(|| {
+        crate::input::delivery::background_unavailable_error(
+            crate::input::delivery::BackgroundUnavailable::NoMpxPointer,
+        )
+    })
+}
+
 /// Screen-absolute center of a window (top-left from translate_coordinates plus
 /// half its geometry). Used to position the no-focus-steal scroll over the
 /// window's content. Blocking — call inside spawn_blocking.
@@ -1804,15 +1831,14 @@ fn window_screen_center(xid: u64) -> anyhow::Result<(i32, i32)> {
     ))
 }
 
-/// X11 no-focus-steal pixel click with graceful fallback. On a real Xorg host
-/// the MPX uinput pointer + XI2 shield grab lands a *true* button event on
-/// XInput2 toolkits (GTK3/4) that silently drop synthetic `XSendEvent` pointers
-/// — so right / middle / double clicks actually register. On Xvfb / Xtigervnc /
-/// unsupported servers (`real_pointer_input_available()` returns false) or if
-/// the MPX attempt fails, it falls back to the legacy `XSendEvent` path so
-/// headless tests and core-only toolkits keep working. `lx`,`ly` are
-/// window-local; screen-absolute coords for the warp are derived here. Blocking
-/// — call inside spawn_blocking.
+/// X11 no-focus-steal pixel click. On a real Xorg host the MPX uinput pointer
+/// + XI2 shield grab lands a *true* button event on XInput2 toolkits (GTK3/4)
+/// that silently drop synthetic `XSendEvent` pointers. Background callers must
+/// refuse with `background_unavailable` when `real_pointer_input_available()`
+/// is false (Xvfb / Xtigervnc / no uinput) instead of reporting an XSendEvent
+/// success that Chromium/GTK/Qt will drop. This helper still falls back to
+/// XSendEvent if an MPX attempt fails on a host that looked capable.
+/// `lx`,`ly` are window-local. Blocking — call inside spawn_blocking.
 fn x11_pixel_click_no_focus_steal(
     cursor_id: &str,
     xid: u64,
@@ -2594,6 +2620,13 @@ impl Tool for ClickTool {
                         return Ok("x11_atspi");
                     }
                 }
+                if background_pixel_without_mpx_must_refuse(
+                    fg,
+                    false,
+                    crate::input::real_pointer_input_available(),
+                ) {
+                    return Ok("background_unavailable_no_mpx");
+                }
                 if fg {
                     // Foreground: the window is already activated. Deliver a REAL
                     // XTest warp+button click. Synthetic XSendEvent button events
@@ -2654,6 +2687,11 @@ impl Tool for ClickTool {
             Ok(Ok("background_unavailable")) => {
                 crate::input::delivery::background_unavailable_error(
                     crate::input::delivery::BackgroundUnavailable::FocusedInputOnly,
+                )
+            }
+            Ok(Ok("background_unavailable_no_mpx")) => {
+                crate::input::delivery::background_unavailable_error(
+                    crate::input::delivery::BackgroundUnavailable::NoMpxPointer,
                 )
             }
             // A pixel/coordinate click is never driver-verifiable (no read-back) —
@@ -4345,6 +4383,9 @@ impl Tool for ScrollTool {
         if let Some(refusal) = unavailable_gtk_pointer_background(pid, delivery) {
             return refusal;
         }
+        if let Some(refusal) = unavailable_background_pointer_without_mpx(delivery) {
+            return refusal;
+        }
 
         // An element-addressed scroll must land over the element. The old
         // fallback used (0, 0) in the window, which can report success while
@@ -4527,6 +4568,9 @@ impl Tool for DoubleClickTool {
             return refusal;
         }
         if let Some(refusal) = unavailable_gtk_pointer_background(pid, delivery) {
+            return refusal;
+        }
+        if let Some(refusal) = unavailable_background_pointer_without_mpx(delivery) {
             return refusal;
         }
         if let Some(refusal) = unavailable_wayland_focused_input_background(delivery, true) {
@@ -4761,6 +4805,9 @@ impl Tool for RightClickTool {
             return refusal;
         }
         if let Some(refusal) = unavailable_gtk_pointer_background(pid, delivery) {
+            return refusal;
+        }
+        if let Some(refusal) = unavailable_background_pointer_without_mpx(delivery) {
             return refusal;
         }
         if let Some(refusal) = unavailable_wayland_focused_input_background(delivery, true) {
@@ -5059,6 +5106,9 @@ impl Tool for DragTool {
             return refusal;
         }
         if let Some(refusal) = unavailable_gtk_pointer_background(pid, delivery) {
+            return refusal;
+        }
+        if let Some(refusal) = unavailable_background_pointer_without_mpx(delivery) {
             return refusal;
         }
         if let Some(refusal) = unavailable_wayland_focused_input_background(delivery, true) {
@@ -8007,7 +8057,10 @@ pub fn build_registry_with_provider(
 
 #[cfg(test)]
 mod click_button_schema_tests {
-    use super::{chromium_background_must_refuse, maps_indicate_gtk, ClickTool};
+    use super::{
+        background_pixel_without_mpx_must_refuse, chromium_background_must_refuse,
+        maps_indicate_gtk, ClickTool,
+    };
     use cua_driver_core::tool::Tool;
 
     /// Surface 5: schema must advertise the three canonical button values and
@@ -8050,6 +8103,22 @@ mod click_button_schema_tests {
         assert!(!chromium_background_must_refuse(false, true, true));
         assert!(!chromium_background_must_refuse(true, false, true));
         assert!(!chromium_background_must_refuse(false, false, false));
+    }
+
+    #[test]
+    fn background_pixel_refuses_xsend_event_when_atspi_and_mpx_are_unavailable() {
+        assert!(background_pixel_without_mpx_must_refuse(
+            false, false, false
+        ));
+        assert!(!background_pixel_without_mpx_must_refuse(
+            false, true, false
+        ));
+        assert!(!background_pixel_without_mpx_must_refuse(
+            false, false, true
+        ));
+        assert!(!background_pixel_without_mpx_must_refuse(
+            true, false, false
+        ));
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Problem this solves: `cua-driver diagnose` on Linux printed a broken macOS TCC dump, and `doctor` did not warn that Xvfb / missing `/dev/uinput` cannot host background MPX. Background pixel clicks on those hosts fell through to XSendEvent and returned `effect: unverifiable`, which looks like a landed click.
- What changed: Linux `diagnose` prints a host section (display server, compositor, uinput, session bus, AT-SPI, background MPX) and explicitly skips macOS TCC/codesign. Linux `doctor` warns on Xvfb/Xtigervnc and missing/inaccessible `/dev/uinput`. When AT-SPI-at-point misses and MPX cannot run, background PX/scroll/drag returns structured `background_unavailable` so the caller retries with `delivery_mode: foreground`.

## Reproduction (Grok Bot Linux VM)

Debian 13, user `box`, no root:

- Display: `Xvfb :2 -screen 0 1280x800x24` plus `x11vnc`. `xfwm4 --compositor=off` and `picom --backend xrender`.
- `XDG_RUNTIME_DIR` unset, `/run/user/1000` does not exist, `DBUS_SESSION_BUS_ADDRESS` unset in the agent shell, no systemd user (`systemctl` missing), no `xfce4-session`.
- `/dev/uinput` does not exist.
- `at-spi2-core` not installed; `at-spi-bus-launcher` absent; `org.a11y.Bus` ServiceUnknown. `get_window_state` returns `degraded: true` with that reason.
- Before this change, `doctor` warned AT-SPI only. It did not warn about Xvfb or missing uinput.
- `diagnose` was macOS-shaped (TCC, `/Applications/CuaDriver.app`, `~/Library/.../TCC.db`, LaunchAgents) and needed `sqlite3`.
- Background PX on Chromium cannot use MPX; AT-SPI-at-point is dead; remaining rungs were XSendEvent (unreliable on Chrome) or `delivery_mode: foreground`. Clicks often returned `effect: unverifiable`.

## Related work

No linked intake issue. Small, self-contained fix from maintainer-selected Cloud Agent work.

RFC (required for a public SDK, CLI, MCP, protocol, compatibility, permission, or cross-component contract change): not required. The `background_unavailable` / `delivery_mode: foreground` contract is unchanged; the driver now emits it when the host cannot land background PX.

## Compatibility and risk

- User-visible, API/CLI/MCP, migration, permission, or platform impact: Linux `doctor`/`diagnose` output changes. Background PX/scroll/drag on Xvfb or no-uinput hosts now refuse with `code: background_unavailable` instead of a quiet unverifiable success. Foreground delivery and AT-SPI-at-point are unchanged. macOS diagnose is unchanged.
- Risk and rollback: revert this commit. GTK3 harness already expected this refusal when MPX is unavailable (except left-click AT-SPI).

## Validation

- Focused tests and checks:
  - `cargo test -p platform-linux --locked --lib` filters: `diagnostics::`, `background_pixel_refuses`, `no_mpx_pointer`, `real_pointer_capabilities`
  - `cargo test -p cua-driver --locked --bin cua-driver` filters: `doctor::`, `diagnose_linux`
  - `cargo fmt --all -- --check`
- Manual or platform evidence: unit tests inject the Grok Bot facts (Xvfb `:2`, missing uinput, unset `XDG_RUNTIME_DIR`, no `/run/user/1000/bus`, AT-SPI down). Full desktop E2E matrix not rerun; this is probe/honesty logic, not a harness-app behavior change on real Xorg.
- Known gaps or CI still required: ordinary PR CI (`CI: Release metadata`, Linux Rust unit/compile). Doctor does not apt-install `at-spi2-core`.

## Contributor and release checks

- [x] The PR is focused and the description matches the final diff.
- [x] This change does not require an RFC, or the accepted RFC is linked above.
- [x] Tests, documentation, and platform evidence are included or the gap is explained.
- [x] The PR title is a Conventional Commit describing the production change.
- [x] External contributor authorship is preserved, or no external contribution is included.
- [x] If release-tracked files changed but this is intentionally non-releasing, the `no-release` label is applied.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a34fdd6b-94f8-4a1f-bff6-0c78d89c161f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a34fdd6b-94f8-4a1f-bff6-0c78d89c161f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

