### PR TITLE
Use a placeholder account in the pull-secret test

### DIFF
--- a/libs/python/cua-sandbox/tests/test_pull_secret.py
+++ b/libs/python/cua-sandbox/tests/test_pull_secret.py
@@ -14,7 +14,7 @@ from cua_sandbox.transport.fleet_cloud import (
     _needs_ecr_pull_secret,
 )
 
-PRIVATE = "296062593712.dkr.ecr.us-west-2.amazonaws.com/cua-server-windows:main-bac7daa3"
+PRIVATE = "123456789012.dkr.ecr.us-west-2.amazonaws.com/example-workspace:main-bac7daa3"
 PUBLIC_ECR = "public.ecr.aws/k5j5w0x5/cua-windows-2022:main-bac7daa3"
 
 


### PR DESCRIPTION
`tests/test_public_containerdisk_refs.py` rejects any tracked file naming the private ECR repositories. The test added in #3148 hardcoded `cua-server-windows`, so that guard now fails on main — my fault: I merged #3148 with `--admin` before the guard had run against it.

The test only needs a reference *shaped* like private ECR to exercise the host check, so a placeholder account and repository are a better fit than a real one.

Verified: `python3 -m unittest tests.test_public_containerdisk_refs` passes, and the 11 pull-secret tests still pass.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)