### PR TITLE
fix(cua-driver): isolate Wayland cursors across outputs

### DIFF
--- a/libs/cua-driver/rust/crates/platform-linux/Cargo.toml
+++ b/libs/cua-driver/rust/crates/platform-linux/Cargo.toml
@@ -50,7 +50,7 @@ wayland-protocols-wlr = { version = "0.3", features = ["client"] }
 # wp-viewporter (HiDPI for the layer-shell overlay). The transitive pull
 # from wayland-protocols-wlr does NOT enable `staging`; declaring it here
 # unifies the feature globally.
-wayland-protocols = { version = "0.32", features = ["client", "staging"] }
+wayland-protocols = { version = "0.32", features = ["client", "staging", "unstable"] }
 # xdg-desktop-portal client: display-screenshot tier
 # (org.freedesktop.portal.Screenshot), per-window ScreenCast
 # (org.freedesktop.portal.ScreenCast), and the libei input session

--- a/libs/cua-driver/rust/crates/platform-linux/src/lib.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/lib.rs
@@ -146,7 +146,7 @@ pub fn register_tools_with_cursor_and_provider(
     #[cfg(target_os = "linux")]
     wayland::ensure_nested_session();
     #[cfg(target_os = "linux")]
-    wayland::overlay::set_config_enabled(cfg.enabled);
+    wayland::overlay::set_config(cfg.clone());
     if cfg.enabled {
         overlay::init(cfg.clone());
         overlay::run_on_thread();

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
@@ -161,6 +161,12 @@ struct OverlayState {
     /// Usually this contains exactly one output; keeping a set makes hide,
     /// removal, and topology changes clear every previously painted surface.
     painted_outputs: HashSet<u32>,
+    /// Configured layer surfaces that have received at least one wl_buffer.
+    /// This is intentionally separate from `painted_outputs`: every new or
+    /// reconfigured surface needs a one-shot transparent commit to complete
+    /// its layer-shell handshake, but stable empty surfaces must not trigger
+    /// recurring full-output SHM redraws.
+    initialized_outputs: HashSet<u32>,
     topology_dirty: bool,
     /// Keyed render cores mirror the X11 native overlay contract. Removing a
     /// named key records it in `ended`, so already-queued late commands cannot
@@ -307,6 +313,7 @@ impl OverlayState {
             xdg_output_manager: None,
             outputs: HashMap::new(),
             painted_outputs: HashSet::new(),
+            initialized_outputs: HashSet::new(),
             topology_dirty: false,
             cores,
             template,
@@ -409,6 +416,7 @@ fn output_contains(layout: &OutputLayout, x: f64, y: f64) -> bool {
 fn frame_plan(
     layouts: &[OutputLayout],
     painted_outputs: &HashSet<u32>,
+    initialized_outputs: &HashSet<u32>,
     cursor_positions: impl IntoIterator<Item = (f64, f64)>,
 ) -> (HashSet<u32>, Vec<FrameTarget>) {
     let selected: HashSet<u32> = cursor_positions
@@ -416,6 +424,12 @@ fn frame_plan(
         .filter_map(|(x, y)| select_output(layouts, x, y).map(|output| output.id))
         .collect();
     let mut ids: Vec<u32> = painted_outputs.iter().copied().collect();
+    ids.extend(
+        layouts
+            .iter()
+            .map(|layout| layout.id)
+            .filter(|id| !initialized_outputs.contains(id)),
+    );
     for id in &selected {
         if !ids.contains(id) {
             ids.push(*id);
@@ -556,6 +570,13 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
     }
     dbg(&format!("configured outputs: {configured_outputs}"));
     state.topology_dirty = false;
+
+    // A layer-shell surface is not fully initialized until the first buffer is
+    // attached after configure. Commit one transparent buffer to every empty
+    // output now, before entering the demand-driven loop; a cursor already
+    // selected on an output can share this same first frame.
+    redraw(&mut state, &shm, &qh)?;
+    queue.roundtrip(&mut state)?;
 
     // Demand-driven main loop. Stable cursors perform only a cheap Wayland
     // maintenance roundtrip once per second so output topology changes are
@@ -788,7 +809,12 @@ fn redraw(
         .values()
         .filter(|core| core.visible && core.pos.0 >= -100.0 && core.idle_alpha >= 0.004)
         .map(|core| core.pos);
-    let (selected, targets) = frame_plan(&layouts, &state.painted_outputs, cursor_positions);
+    let (selected, targets) = frame_plan(
+        &layouts,
+        &state.painted_outputs,
+        &state.initialized_outputs,
+        cursor_positions,
+    );
 
     for target in targets {
         redraw_output(state, shm, qh, target, &layouts)?;
@@ -823,14 +849,6 @@ fn redraw_output(
         .and_then(|stride| stride.checked_mul(h as usize))
         .ok_or_else(|| anyhow::anyhow!("overlay output {w}x{h} buffer size overflow"))?;
 
-    // Reuses the same anon_shm pattern as the screencopy path in mod.rs.
-    let (fd, ptr) =
-        super::anon_shm(size).map_err(|e| anyhow::anyhow!("overlay shm allocation failed: {e}"))?;
-
-    // SAFETY: ptr came from mmap of `size` bytes, lifetime bounded to this
-    // function.
-    let pixels: &mut [u8] = unsafe { std::slice::from_raw_parts_mut(ptr as *mut u8, size) };
-
     // A clearing target intentionally stays transparent. Each cursor selected
     // for this output subtracts its logical compositor origin from the global
     // position; this is the same origin contract used by the Windows virtual
@@ -847,6 +865,15 @@ fn redraw_output(
             "tiny_skia::Pixmap::new({w}, {h}) failed — out of memory for the overlay buffer"
         ),
     };
+
+    // Reuses the same anon_shm pattern as the screencopy path in mod.rs. The
+    // pixmap is allocated first so a tiny-skia OOM cannot strand this mmap/fd.
+    let (fd, ptr) =
+        super::anon_shm(size).map_err(|e| anyhow::anyhow!("overlay shm allocation failed: {e}"))?;
+
+    // SAFETY: ptr came from mmap of `size` bytes and is transferred to
+    // `pending_buffers` before this function returns successfully.
+    let pixels: &mut [u8] = unsafe { std::slice::from_raw_parts_mut(ptr as *mut u8, size) };
     let mut painted_positions = Vec::new();
     {
         // HashMap iteration is intentionally normalized by key so overlapping
@@ -932,6 +959,9 @@ fn redraw_output(
     surface.attach(Some(&buffer), 0, 0);
     surface.damage_buffer(0, 0, w as i32, h as i32);
     surface.commit();
+    // Mark initialized only after the buffer attach + surface commit succeed.
+    // An early return above leaves the output pending for the next plan.
+    state.initialized_outputs.insert(target.id);
     pool.destroy();
     Ok(())
 }
@@ -1003,6 +1033,7 @@ impl Dispatch<wl_registry::WlRegistry, ()> for OverlayState {
             }
             wl_registry::Event::GlobalRemove { name } => {
                 state.painted_outputs.remove(&name);
+                state.initialized_outputs.remove(&name);
                 if let Some(mut output) = state.outputs.remove(&name) {
                     output.destroy_surfaces();
                     // wl_output.release was added in v3. On an older generic
@@ -1154,12 +1185,17 @@ impl Dispatch<ZwlrLayerSurfaceV1, LayerData> for OverlayState {
                         if width > 0 { width } else { fallback.0 },
                         if height > 0 { height } else { fallback.1 },
                     );
-                    state.topology_dirty |= output.configured_size != Some(configured_size);
+                    // Each configure starts a new layer-surface buffer cycle.
+                    // Queue exactly one matching clear/paint frame even when
+                    // the compositor repeats the same logical size.
+                    state.initialized_outputs.remove(&data.id);
+                    state.topology_dirty = true;
                     output.configured_size = Some(configured_size);
                 }
             }
             zwlr_layer_surface_v1::Event::Closed => {
                 state.painted_outputs.remove(&data.id);
+                state.initialized_outputs.remove(&data.id);
                 if let Some(output) = state.outputs.get_mut(&data.id) {
                     output.closed = true;
                     output.close_layer();
@@ -1277,6 +1313,10 @@ mod tests {
         ]
     }
 
+    fn initialized(layouts: &[OutputLayout]) -> HashSet<u32> {
+        layouts.iter().map(|layout| layout.id).collect()
+    }
+
     #[test]
     fn selects_output_and_converts_global_to_output_local_coordinates() {
         let layouts = three_monitor_layout();
@@ -1335,10 +1375,76 @@ mod tests {
     }
 
     #[test]
+    fn initial_configured_outputs_each_plan_one_transparent_frame() {
+        let layouts = three_monitor_layout();
+        let (selected, targets) = frame_plan(
+            &layouts,
+            &HashSet::new(),
+            &HashSet::new(),
+            std::iter::empty::<(f64, f64)>(),
+        );
+
+        assert!(selected.is_empty());
+        assert_eq!(
+            targets.iter().map(|target| target.id).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+    }
+
+    #[test]
+    fn initialized_stable_outputs_plan_no_idle_frame() {
+        let layouts = three_monitor_layout();
+        let (selected, targets) = frame_plan(
+            &layouts,
+            &HashSet::new(),
+            &initialized(&layouts),
+            std::iter::empty::<(f64, f64)>(),
+        );
+
+        assert!(selected.is_empty());
+        assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn hotplugged_output_plans_one_initial_transparent_frame() {
+        let layouts = three_monitor_layout();
+        let already_initialized = HashSet::from([1, 2]);
+        let (selected, targets) = frame_plan(
+            &layouts,
+            &HashSet::new(),
+            &already_initialized,
+            std::iter::empty::<(f64, f64)>(),
+        );
+
+        assert!(selected.is_empty());
+        assert_eq!(targets, vec![FrameTarget { id: 3 }]);
+    }
+
+    #[test]
+    fn selected_output_combines_initialization_and_cursor_paint_in_one_frame() {
+        let layouts = three_monitor_layout();
+        let already_initialized = HashSet::from([1, 3]);
+        let (selected, targets) = frame_plan(
+            &layouts,
+            &HashSet::new(),
+            &already_initialized,
+            Some((2500.0, 100.0)),
+        );
+
+        assert_eq!(selected, HashSet::from([2]));
+        assert_eq!(targets, vec![FrameTarget { id: 2 }]);
+    }
+
+    #[test]
     fn crossing_outputs_clears_the_old_surface_and_paints_the_new_one() {
+        let layouts = three_monitor_layout();
         let painted = HashSet::from([1]);
-        let (selected, targets) =
-            frame_plan(&three_monitor_layout(), &painted, Some((2500.0, 100.0)));
+        let (selected, targets) = frame_plan(
+            &layouts,
+            &painted,
+            &initialized(&layouts),
+            Some((2500.0, 100.0)),
+        );
 
         assert_eq!(selected, HashSet::from([2]));
         assert_eq!(targets, vec![FrameTarget { id: 1 }, FrameTarget { id: 2 }]);
@@ -1346,10 +1452,12 @@ mod tests {
 
     #[test]
     fn hide_or_session_removal_clears_every_previously_painted_output() {
+        let layouts = three_monitor_layout();
         let painted = HashSet::from([1, 2, 3]);
         let (selected, targets) = frame_plan(
-            &three_monitor_layout(),
+            &layouts,
             &painted,
+            &initialized(&layouts),
             std::iter::empty::<(f64, f64)>(),
         );
 
@@ -1363,6 +1471,7 @@ mod tests {
 
     #[test]
     fn fresh_sentinel_overlay_uses_only_topology_maintenance() {
+        let layouts = three_monitor_layout();
         let core = RenderStateCore::new(CursorConfig::default());
         let cores = HashMap::from([("default".to_owned(), core)]);
         assert_eq!(
@@ -1375,8 +1484,9 @@ mod tests {
             WlWait::Maintenance(Duration::ZERO)
         );
         assert!(frame_plan(
-            &three_monitor_layout(),
+            &layouts,
             &HashSet::new(),
+            &initialized(&layouts),
             std::iter::empty::<(f64, f64)>()
         )
         .1
@@ -1492,6 +1602,7 @@ mod tests {
         let (painted, targets) = frame_plan(
             &layouts,
             &HashSet::new(),
+            &initialized(&layouts),
             cores.values().map(|core| core.pos),
         );
         assert_eq!(painted, HashSet::from([1, 2]));
@@ -1512,8 +1623,12 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["session-b"]
         );
-        let (selected, targets) =
-            frame_plan(&layouts, &painted, cores.values().map(|core| core.pos));
+        let (selected, targets) = frame_plan(
+            &layouts,
+            &painted,
+            &initialized(&layouts),
+            cores.values().map(|core| core.pos),
+        );
         assert_eq!(selected, HashSet::from([2]));
         assert_eq!(targets, vec![FrameTarget { id: 1 }, FrameTarget { id: 2 }]);
 

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
@@ -26,7 +26,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crossbeam_channel::{bounded, Receiver, Sender};
-use cursor_overlay::{CursorConfig, OverlayCommand, OverlayMsg, RenderStateCore};
+use cursor_overlay::{CursorConfig, CursorKey, OverlayCommand, OverlayMsg, RenderStateCore};
 use wayland_client::{
     protocol::{
         wl_buffer::WlBuffer,
@@ -54,8 +54,8 @@ use wayland_protocols_wlr::layer_shell::v1::client::{
 /// SetPressed) are forwarded as-is so the layer-shell overlay matches the
 /// X11 visual: bloom + animated arrow + click pulse + press ring.
 enum WlOverlayCmd {
-    Cmd { cmd: OverlayCommand },
-    Remove,
+    Cmd { key: CursorKey, cmd: OverlayCommand },
+    Remove(CursorKey),
     Shutdown,
 }
 
@@ -64,9 +64,11 @@ static TX: OnceLock<Sender<WlOverlayCmd>> = OnceLock::new();
 // opt the native Wayland overlay in with the daemon's CursorConfig. This keeps
 // lazy forwarding from bypassing --no-overlay before any window exists.
 static CONFIG_ENABLED: AtomicBool = AtomicBool::new(false);
+static CONFIG_TEMPLATE: OnceLock<CursorConfig> = OnceLock::new();
 
-pub fn set_config_enabled(enabled: bool) {
-    CONFIG_ENABLED.store(enabled, Ordering::Release);
+pub fn set_config(config: CursorConfig) {
+    CONFIG_ENABLED.store(config.enabled, Ordering::Release);
+    let _ = CONFIG_TEMPLATE.set(config);
 }
 
 fn tx() -> Option<&'static Sender<WlOverlayCmd>> {
@@ -117,22 +119,17 @@ pub fn forward(msg: &OverlayMsg) -> bool {
         return false;
     }
     let Some(tx) = tx() else { return false };
+    map_overlay_msg(msg).is_some_and(|cmd| tx.try_send(cmd).is_ok())
+}
+
+fn map_overlay_msg(msg: &OverlayMsg) -> Option<WlOverlayCmd> {
     match msg {
-        OverlayMsg::Remove(k) => {
-            let _ = k;
-            let _ = tx.try_send(WlOverlayCmd::Remove);
-            true
-        }
-        OverlayMsg::Cmd(kc) => {
-            if matches!(&kc.cmd, OverlayCommand::ShowFocusRect(_)) {
-                return false;
-            }
-            let _ = tx.try_send(WlOverlayCmd::Cmd {
-                cmd: kc.cmd.clone(),
-            });
-            true
-        }
-        OverlayMsg::Revive(_) => true,
+        OverlayMsg::Remove(key) => Some(WlOverlayCmd::Remove(key.clone())),
+        OverlayMsg::Cmd(kc) if matches!(&kc.cmd, OverlayCommand::ShowFocusRect(_)) => None,
+        OverlayMsg::Cmd(kc) => Some(WlOverlayCmd::Cmd {
+            key: kc.key.clone(),
+            cmd: kc.cmd.clone(),
+        }),
     }
 }
 
@@ -165,9 +162,12 @@ struct OverlayState {
     /// removal, and topology changes clear every previously painted surface.
     painted_outputs: HashSet<u32>,
     topology_dirty: bool,
-    /// Cross-platform render core: position, animation, gradient arrow,
-    /// bloom, click pulse, idle-fade. Shared verbatim with the X11 path.
-    core: RenderStateCore,
+    /// Keyed render cores mirror the X11 native overlay contract. Removing a
+    /// named key records it in `ended`, so already-queued late commands cannot
+    /// recreate a cursor after end_session.
+    cores: HashMap<CursorKey, RenderStateCore>,
+    template: CursorConfig,
+    ended: HashSet<CursorKey>,
     /// In-flight wl_shm buffers awaiting `wl_buffer.release` from the
     /// compositor. Keyed by `WlBuffer` object id; value is the
     /// `(mmap ptr, mmap size, memfd fd)` triple that must be unmapped +
@@ -266,7 +266,6 @@ struct SelectedOutput {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct FrameTarget {
     id: u32,
-    paint_cursor: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -287,8 +286,20 @@ struct LayerData {
 // explicit assertion.
 unsafe impl Send for OverlayState {}
 
-impl Default for OverlayState {
-    fn default() -> Self {
+impl Drop for OverlayState {
+    fn drop(&mut self) {
+        for (_, (ptr, size, fd)) in std::mem::take(&mut self.pending_buffers) {
+            super::cleanup_mmap(ptr, size, fd);
+        }
+    }
+}
+
+impl OverlayState {
+    fn new(template: CursorConfig) -> Self {
+        let mut cores = HashMap::new();
+        // Match the X11 contract: the compatibility/default slot preserves the
+        // launch-time cursor id, while lazily-created named slots override it.
+        cores.insert("default".to_owned(), RenderStateCore::new(template.clone()));
         Self {
             compositor: None,
             shm: None,
@@ -297,10 +308,72 @@ impl Default for OverlayState {
             outputs: HashMap::new(),
             painted_outputs: HashSet::new(),
             topology_dirty: false,
-            core: RenderStateCore::new(CursorConfig::default()),
+            cores,
+            template,
+            ended: HashSet::new(),
             pending_buffers: HashMap::new(),
         }
     }
+}
+
+fn render_core_for_key(template: &CursorConfig, key: &str) -> RenderStateCore {
+    let mut config = template.clone();
+    config.cursor_id = key.to_owned();
+    RenderStateCore::new(config)
+}
+
+fn apply_keyed_command(
+    cores: &mut HashMap<CursorKey, RenderStateCore>,
+    template: &CursorConfig,
+    ended: &HashSet<CursorKey>,
+    key: CursorKey,
+    cmd: OverlayCommand,
+) -> bool {
+    if ended.contains(&key) {
+        tracing::debug!(key = %key, cmd = ?cmd, "wayland overlay: command dropped — key was ended");
+        return false;
+    }
+
+    let core = cores
+        .entry(key.clone())
+        .or_insert_with(|| render_core_for_key(template, &key));
+    // Seed from the off-screen sentinel near the first targeted action so a
+    // spring animation begins on-screen. This mirrors the X11 renderer.
+    let seed_target = match &cmd {
+        OverlayCommand::MoveTo { x, y, .. }
+        | OverlayCommand::SnapTo { x, y, .. }
+        | OverlayCommand::ClickPulse { x, y } => Some((*x, *y)),
+        _ => None,
+    };
+    if let Some((target_x, target_y)) = seed_target {
+        if core.pos.0 < -50.0 {
+            const SEED_OFFSET: f64 = 16.0;
+            core.pos = (
+                (target_x - SEED_OFFSET).max(2.0),
+                (target_y - SEED_OFFSET).max(2.0),
+            );
+        }
+    }
+
+    let disabling = matches!(&cmd, OverlayCommand::SetEnabled(false));
+    let dirty = core.apply_command_base(cmd, false, false);
+    if disabling {
+        quiesce_hidden(core);
+    }
+    dirty
+}
+
+fn remove_keyed_core(
+    cores: &mut HashMap<CursorKey, RenderStateCore>,
+    ended: &mut HashSet<CursorKey>,
+    key: CursorKey,
+) -> bool {
+    if key == "default" {
+        return false;
+    }
+    let removed = cores.remove(&key).is_some();
+    ended.insert(key);
+    removed
 }
 
 fn dbg(msg: &str) {
@@ -315,12 +388,7 @@ fn select_output(layouts: &[OutputLayout], x: f64, y: f64) -> Option<SelectedOut
     }
     layouts
         .iter()
-        .filter(|layout| {
-            x >= f64::from(layout.origin_x)
-                && y >= f64::from(layout.origin_y)
-                && x < f64::from(layout.origin_x) + f64::from(layout.width)
-                && y < f64::from(layout.origin_y) + f64::from(layout.height)
-        })
+        .filter(|layout| output_contains(layout, x, y))
         .min_by_key(|layout| layout.id)
         .map(|layout| SelectedOutput {
             id: layout.id,
@@ -329,28 +397,53 @@ fn select_output(layouts: &[OutputLayout], x: f64, y: f64) -> Option<SelectedOut
         })
 }
 
+fn output_contains(layout: &OutputLayout, x: f64, y: f64) -> bool {
+    x.is_finite()
+        && y.is_finite()
+        && x >= f64::from(layout.origin_x)
+        && y >= f64::from(layout.origin_y)
+        && x < f64::from(layout.origin_x) + f64::from(layout.width)
+        && y < f64::from(layout.origin_y) + f64::from(layout.height)
+}
+
 fn frame_plan(
     layouts: &[OutputLayout],
     painted_outputs: &HashSet<u32>,
-    cursor_position: Option<(f64, f64)>,
-) -> (Option<SelectedOutput>, Vec<FrameTarget>) {
-    let selected = cursor_position.and_then(|(x, y)| select_output(layouts, x, y));
+    cursor_positions: impl IntoIterator<Item = (f64, f64)>,
+) -> (HashSet<u32>, Vec<FrameTarget>) {
+    let selected: HashSet<u32> = cursor_positions
+        .into_iter()
+        .filter_map(|(x, y)| select_output(layouts, x, y).map(|output| output.id))
+        .collect();
     let mut ids: Vec<u32> = painted_outputs.iter().copied().collect();
-    if let Some(selected) = selected {
-        if !ids.contains(&selected.id) {
-            ids.push(selected.id);
+    for id in &selected {
+        if !ids.contains(id) {
+            ids.push(*id);
         }
     }
     ids.sort_unstable();
     ids.dedup();
-    let targets = ids
-        .into_iter()
-        .map(|id| FrameTarget {
-            id,
-            paint_cursor: selected.is_some_and(|selected| selected.id == id),
+    let targets = ids.into_iter().map(|id| FrameTarget { id }).collect();
+    (selected, targets)
+}
+
+fn visible_cores_for_output<'a>(
+    cores: &'a HashMap<CursorKey, RenderStateCore>,
+    layouts: &[OutputLayout],
+    output_id: u32,
+) -> Vec<(&'a CursorKey, &'a RenderStateCore)> {
+    let mut visible_cores: Vec<_> = cores
+        .iter()
+        .filter(|(_, core)| {
+            core.visible
+                && core.pos.0 >= -100.0
+                && core.idle_alpha >= 0.004
+                && select_output(layouts, core.pos.0, core.pos.1)
+                    .is_some_and(|selected| selected.id == output_id)
         })
         .collect();
-    (selected, targets)
+    visible_cores.sort_by(|(left, _), (right, _)| left.cmp(right));
+    visible_cores
 }
 
 fn ensure_output_resources(state: &mut OverlayState, qh: &QueueHandle<OverlayState>) {
@@ -415,7 +508,8 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
     let qh = queue.handle();
     let _registry = conn.display().get_registry(&qh, ());
 
-    let mut state = OverlayState::default();
+    let template = CONFIG_TEMPLATE.get().cloned().unwrap_or_default();
+    let mut state = OverlayState::new(template);
     queue.roundtrip(&mut state)?;
 
     state
@@ -469,7 +563,7 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
     let mut last_tick = Instant::now();
     let mut frame_tick_needed = false;
     loop {
-        let wait = next_wait(&state.core, frame_tick_needed, state.topology_dirty);
+        let wait = next_wait(&state.cores, frame_tick_needed, state.topology_dirty);
         let (first_cmd, timed_out) = match wait_for_work(&rx, wait) {
             WlWake::Command(cmd) => (Some(cmd), None),
             WlWake::Timeout => (None, Some(wait)),
@@ -490,44 +584,17 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
                     shutdown = true;
                     break;
                 }
-                Ok(WlOverlayCmd::Cmd { cmd }) => {
-                    // Seed: if the cursor is still at the off-screen sentinel
-                    // `(-200, -200)` from `RenderStateCore::new`, snap to a
-                    // point near the MoveTo / SnapTo target so the spring
-                    // animation starts on-screen. Mirrors X11 overlay.rs's
-                    // `seed_start_if_sentinel` helper — without it, the
-                    // spring oscillates around the sentinel and the cursor
-                    // never reaches the screen.
-                    let seed_target = match &cmd {
-                        OverlayCommand::MoveTo { x, y, .. }
-                        | OverlayCommand::SnapTo { x, y, .. }
-                        | OverlayCommand::ClickPulse { x, y } => Some((*x, *y)),
-                        _ => None,
-                    };
-                    if let Some((tx, ty)) = seed_target {
-                        if state.core.pos.0 < -50.0 {
-                            const SEED_OFFSET: f64 = 16.0;
-                            let sx = (tx - SEED_OFFSET).max(2.0);
-                            let sy = (ty - SEED_OFFSET).max(2.0);
-                            state.core.pos = (sx, sy);
-                        }
-                    }
-                    // apply_command_base consumes every variant the X11
-                    // path handles. `move_to_snap_sentinel` / `click_pulse
-                    // _sentinel_only` are both `false` here — same as X11.
-                    let disabling = matches!(&cmd, OverlayCommand::SetEnabled(false));
-                    dirty |= state.core.apply_command_base(cmd, false, false);
-                    if disabling {
-                        quiesce_hidden(&mut state.core);
-                    }
+                Ok(WlOverlayCmd::Cmd { key, cmd }) => {
+                    dirty |= apply_keyed_command(
+                        &mut state.cores,
+                        &state.template,
+                        &state.ended,
+                        key,
+                        cmd,
+                    );
                 }
-                Ok(WlOverlayCmd::Remove) => {
-                    // Single-cursor overlay: removing the active cursor
-                    // hides it. Multi-cursor wlroots support can layer on
-                    // top of this in a follow-up if needed.
-                    dirty |= state.core.visible || state.core.pos.0 >= -100.0;
-                    state.core.visible = false;
-                    quiesce_hidden(&mut state.core);
+                Ok(WlOverlayCmd::Remove(key)) => {
+                    dirty |= remove_keyed_core(&mut state.cores, &mut state.ended, key);
                 }
                 Err(crossbeam_channel::TryRecvError::Empty) => break,
                 Err(crossbeam_channel::TryRecvError::Disconnected) => {
@@ -546,17 +613,26 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
         if let Some(timeout_kind) = timed_out {
             match timeout_kind {
                 WlWait::Frame => {
-                    state.core.tick_motion(elapsed.min(0.05));
+                    tick_all_cores(&mut state.cores, elapsed.min(0.05));
                     dirty = true;
                 }
                 WlWait::Deadline(_) => {
-                    state.core.tick_motion(elapsed);
+                    tick_all_cores(&mut state.cores, elapsed);
                     dirty = true;
                 }
                 WlWait::Maintenance(_) => {
-                    let idle_alpha = state.core.idle_alpha;
-                    state.core.tick_motion(elapsed);
-                    dirty |= state.core.idle_alpha != idle_alpha || needs_frame_tick(&state.core);
+                    let before: HashMap<CursorKey, f64> = state
+                        .cores
+                        .iter()
+                        .map(|(key, core)| (key.clone(), core.idle_alpha))
+                        .collect();
+                    tick_all_cores(&mut state.cores, elapsed);
+                    dirty |= state.cores.iter().any(|(key, core)| {
+                        before
+                            .get(key)
+                            .is_none_or(|alpha| *alpha != core.idle_alpha)
+                            || needs_frame_tick(core)
+                    });
 
                     let topology_was_dirty = state.topology_dirty;
                     state.topology_dirty = false;
@@ -567,7 +643,7 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
                 }
             }
         }
-        let next_frame_tick_needed = needs_frame_tick(&state.core);
+        let next_frame_tick_needed = any_core_needs_frame_tick(&state.cores);
         if dirty || frame_tick_needed || next_frame_tick_needed {
             redraw(&mut state, &shm, &qh)?;
             // Flush the committed frame and dispatch wl_buffer.release before
@@ -617,16 +693,34 @@ fn wait_for_work(rx: &Receiver<WlOverlayCmd>, wait: WlWait) -> WlWake {
 
 const TOPOLOGY_MAINTENANCE_INTERVAL: Duration = Duration::from_secs(1);
 
-fn next_wait(core: &RenderStateCore, frame_tick_needed: bool, topology_dirty: bool) -> WlWait {
+fn next_wait(
+    cores: &HashMap<CursorKey, RenderStateCore>,
+    frame_tick_needed: bool,
+    topology_dirty: bool,
+) -> WlWait {
     if topology_dirty {
         return WlWait::Maintenance(Duration::ZERO);
     }
-    if frame_tick_needed || needs_frame_tick(core) {
+    if frame_tick_needed || any_core_needs_frame_tick(cores) {
         return WlWait::Frame;
     }
-    match idle_fade_wait(core) {
+    match earliest_idle_fade_wait(cores) {
         Some(wait) if wait <= TOPOLOGY_MAINTENANCE_INTERVAL => WlWait::Deadline(wait),
         _ => WlWait::Maintenance(TOPOLOGY_MAINTENANCE_INTERVAL),
+    }
+}
+
+fn any_core_needs_frame_tick(cores: &HashMap<CursorKey, RenderStateCore>) -> bool {
+    cores.values().any(needs_frame_tick)
+}
+
+fn earliest_idle_fade_wait(cores: &HashMap<CursorKey, RenderStateCore>) -> Option<Duration> {
+    cores.values().filter_map(idle_fade_wait).min()
+}
+
+fn tick_all_cores(cores: &mut HashMap<CursorKey, RenderStateCore>, dt: f64) {
+    for core in cores.values_mut() {
+        core.tick_motion(dt);
     }
 }
 
@@ -665,8 +759,8 @@ fn quiesce_hidden(core: &mut RenderStateCore) {
     core.click_t = None;
 }
 
-/// Render the selected output plus a transparent clearing frame on every
-/// previously painted output the cursor has left.
+/// Composite all visible cursor cores into their selected output and attach a
+/// transparent clearing frame to every previously painted output now empty.
 ///
 /// Pipeline:
 /// 1. Allocate a memfd-backed wl_shm pool sized at output_w × output_h.
@@ -678,9 +772,7 @@ fn quiesce_hidden(core: &mut RenderStateCore) {
 ///    in `ext_screencopy::encode_buffer_to_png`.
 /// 4. Attach + damage + commit on the layer surface.
 ///
-/// When the cursor is hidden (`core.visible == false`, idle-faded, or
-/// off-screen sentinel) the pixmap is all zeros — the surface remains
-/// transparent and click-through.
+/// Hidden, idle-faded, or off-screen cores paint nothing.
 fn redraw(
     state: &mut OverlayState,
     shm: &WlShm,
@@ -691,19 +783,18 @@ fn redraw(
         .iter()
         .filter_map(|(&id, output)| output.layout(id))
         .collect();
-    let cursor_position =
-        (state.core.visible && state.core.pos.0 >= -100.0 && state.core.idle_alpha >= 0.004)
-            .then_some(state.core.pos);
-    let (selected, targets) = frame_plan(&layouts, &state.painted_outputs, cursor_position);
+    let cursor_positions = state
+        .cores
+        .values()
+        .filter(|core| core.visible && core.pos.0 >= -100.0 && core.idle_alpha >= 0.004)
+        .map(|core| core.pos);
+    let (selected, targets) = frame_plan(&layouts, &state.painted_outputs, cursor_positions);
 
     for target in targets {
-        redraw_output(state, shm, qh, target)?;
+        redraw_output(state, shm, qh, target, &layouts)?;
     }
 
-    state.painted_outputs.clear();
-    if let Some(selected) = selected {
-        state.painted_outputs.insert(selected.id);
-    }
+    state.painted_outputs = selected;
     Ok(())
 }
 
@@ -712,6 +803,7 @@ fn redraw_output(
     shm: &WlShm,
     qh: &QueueHandle<OverlayState>,
     target: FrameTarget,
+    layouts: &[OutputLayout],
 ) -> anyhow::Result<()> {
     let Some((surface, layout)) = state
         .outputs
@@ -739,9 +831,10 @@ fn redraw_output(
     // function.
     let pixels: &mut [u8] = unsafe { std::slice::from_raw_parts_mut(ptr as *mut u8, size) };
 
-    // A clearing target intentionally stays transparent. The selected target
-    // subtracts its logical compositor origin from the global cursor position;
-    // this is the same origin contract used by the Windows virtual desktop.
+    // A clearing target intentionally stays transparent. Each cursor selected
+    // for this output subtracts its logical compositor origin from the global
+    // position; this is the same origin contract used by the Windows virtual
+    // desktop.
     let pm_result = tiny_skia::Pixmap::new(w, h);
     let mut pm = match pm_result {
         Some(p) => p,
@@ -754,15 +847,21 @@ fn redraw_output(
             "tiny_skia::Pixmap::new({w}, {h}) failed — out of memory for the overlay buffer"
         ),
     };
-    if target.paint_cursor {
-        cursor_overlay::paint_cursor(
-            &mut pm,
-            &state.core,
-            f64::from(layout.origin_x),
-            f64::from(layout.origin_y),
-            None,
-            1.0,
-        );
+    let mut painted_positions = Vec::new();
+    {
+        // HashMap iteration is intentionally normalized by key so overlapping
+        // named cursors composite deterministically from frame to frame.
+        for (_, core) in visible_cores_for_output(&state.cores, layouts, target.id) {
+            cursor_overlay::paint_cursor(
+                &mut pm,
+                core,
+                f64::from(layout.origin_x),
+                f64::from(layout.origin_y),
+                None,
+                1.0,
+            );
+            painted_positions.push(core.pos);
+        }
     }
 
     // CUA_OVERLAY_DEBUG=1 paints a 60x60 magenta square at the cursor's
@@ -770,23 +869,24 @@ fn redraw_output(
     // layer-shell visibility on a new compositor — the gradient arrow is
     // small at native scale and easy to miss in a screenshot, while the
     // magenta block is impossible to miss.
-    if target.paint_cursor && std::env::var_os("CUA_OVERLAY_DEBUG").is_some() {
-        let (cx, cy) = state.core.pos;
-        let cx = (cx - f64::from(layout.origin_x)) as i32;
-        let cy = (cy - f64::from(layout.origin_y)) as i32;
-        let half = 30i32;
-        for dy in -half..half {
-            for dx in -half..half {
-                let px = cx + dx;
-                let py = cy + dy;
-                if px < 0 || py < 0 || px >= w as i32 || py >= h as i32 {
-                    continue;
+    if std::env::var_os("CUA_OVERLAY_DEBUG").is_some() {
+        for &(cursor_x, cursor_y) in &painted_positions {
+            let cx = (cursor_x - f64::from(layout.origin_x)) as i32;
+            let cy = (cursor_y - f64::from(layout.origin_y)) as i32;
+            let half = 30i32;
+            for dy in -half..half {
+                for dx in -half..half {
+                    let px = cx + dx;
+                    let py = cy + dy;
+                    if px < 0 || py < 0 || px >= w as i32 || py >= h as i32 {
+                        continue;
+                    }
+                    let off = ((py as usize) * (w as usize) + (px as usize)) * 4;
+                    pm.data_mut()[off] = 0xFF; // R
+                    pm.data_mut()[off + 1] = 0x00; // G
+                    pm.data_mut()[off + 2] = 0xFF; // B
+                    pm.data_mut()[off + 3] = 0xFF; // A
                 }
-                let off = ((py as usize) * (w as usize) + (px as usize)) * 4;
-                pm.data_mut()[off] = 0xFF; // R
-                pm.data_mut()[off + 1] = 0x00; // G
-                pm.data_mut()[off + 2] = 0xFF; // B
-                pm.data_mut()[off + 3] = 0xFF; // A
             }
         }
     }
@@ -823,13 +923,11 @@ fn redraw_output(
     state.pending_buffers.insert(buffer_id, (ptr, size, fd));
 
     dbg(&format!(
-        "redraw output={} origin=({}, {}) w={w} h={h} stride={stride} buf_id={buffer_id} pos=({:.1},{:.1}) paint={}",
+        "redraw output={} origin=({}, {}) w={w} h={h} stride={stride} buf_id={buffer_id} cursors={}",
         output_label(state, target.id),
         layout.origin_x,
         layout.origin_y,
-        state.core.pos.0,
-        state.core.pos.1,
-        target.paint_cursor,
+        painted_positions.len(),
     ));
     surface.attach(Some(&buffer), 0, 0);
     surface.damage_buffer(0, 0, w as i32, h as i32);
@@ -1210,35 +1308,53 @@ mod tests {
     }
 
     #[test]
+    fn overlapping_outputs_use_the_same_deterministic_selection_for_compositing() {
+        let layouts = vec![
+            OutputLayout {
+                id: 8,
+                origin_x: 0,
+                origin_y: 0,
+                width: 1920,
+                height: 1080,
+            },
+            OutputLayout {
+                id: 4,
+                origin_x: 0,
+                origin_y: 0,
+                width: 1920,
+                height: 1080,
+            },
+        ];
+        let mut core = positioned_core();
+        core.pos = (400.0, 300.0);
+        let cores = HashMap::from([("session".to_owned(), core)]);
+
+        assert_eq!(select_output(&layouts, 400.0, 300.0).unwrap().id, 4);
+        assert_eq!(visible_cores_for_output(&cores, &layouts, 4).len(), 1);
+        assert!(visible_cores_for_output(&cores, &layouts, 8).is_empty());
+    }
+
+    #[test]
     fn crossing_outputs_clears_the_old_surface_and_paints_the_new_one() {
         let painted = HashSet::from([1]);
         let (selected, targets) =
             frame_plan(&three_monitor_layout(), &painted, Some((2500.0, 100.0)));
 
-        assert_eq!(selected.map(|output| output.id), Some(2));
-        assert_eq!(
-            targets,
-            vec![
-                FrameTarget {
-                    id: 1,
-                    paint_cursor: false,
-                },
-                FrameTarget {
-                    id: 2,
-                    paint_cursor: true,
-                },
-            ]
-        );
+        assert_eq!(selected, HashSet::from([2]));
+        assert_eq!(targets, vec![FrameTarget { id: 1 }, FrameTarget { id: 2 }]);
     }
 
     #[test]
     fn hide_or_session_removal_clears_every_previously_painted_output() {
         let painted = HashSet::from([1, 2, 3]);
-        let (selected, targets) = frame_plan(&three_monitor_layout(), &painted, None);
+        let (selected, targets) = frame_plan(
+            &three_monitor_layout(),
+            &painted,
+            std::iter::empty::<(f64, f64)>(),
+        );
 
-        assert!(selected.is_none());
+        assert!(selected.is_empty());
         assert_eq!(targets.len(), 3);
-        assert!(targets.iter().all(|target| !target.paint_cursor));
         assert_eq!(
             targets.iter().map(|target| target.id).collect::<Vec<_>>(),
             vec![1, 2, 3]
@@ -1248,29 +1364,35 @@ mod tests {
     #[test]
     fn fresh_sentinel_overlay_uses_only_topology_maintenance() {
         let core = RenderStateCore::new(CursorConfig::default());
+        let cores = HashMap::from([("default".to_owned(), core)]);
         assert_eq!(
-            next_wait(&core, false, false),
+            next_wait(&cores, false, false),
             WlWait::Maintenance(TOPOLOGY_MAINTENANCE_INTERVAL)
         );
-        assert!(!needs_frame_tick(&core));
+        assert!(!any_core_needs_frame_tick(&cores));
         assert_eq!(
-            next_wait(&core, false, true),
+            next_wait(&cores, false, true),
             WlWait::Maintenance(Duration::ZERO)
         );
-        assert!(frame_plan(&three_monitor_layout(), &HashSet::new(), None)
-            .1
-            .is_empty());
+        assert!(frame_plan(
+            &three_monitor_layout(),
+            &HashSet::new(),
+            std::iter::empty::<(f64, f64)>()
+        )
+        .1
+        .is_empty());
     }
 
     #[test]
     fn stable_visible_overlay_sleeps_until_idle_fade_deadline() {
         let mut core = positioned_core();
         core.idle_secs = 0.25;
+        let cores = HashMap::from([("cursor-a".to_owned(), core)]);
         assert_eq!(
-            next_wait(&core, false, false),
+            next_wait(&cores, false, false),
             WlWait::Deadline(Duration::from_millis(750))
         );
-        assert!(!needs_frame_tick(&core));
+        assert!(!any_core_needs_frame_tick(&cores));
     }
 
     #[test]
@@ -1278,13 +1400,15 @@ mod tests {
         let mut core = positioned_core();
         core.click_t = Some(0.0);
         assert!(needs_frame_tick(&core));
-        assert_eq!(next_wait(&core, false, false), WlWait::Frame);
+        let mut cores = HashMap::from([("cursor-a".to_owned(), core)]);
+        assert_eq!(next_wait(&cores, false, false), WlWait::Frame);
 
+        let core = cores.get_mut("cursor-a").unwrap();
         core.click_t = None;
         core.idle_secs = 1.0;
         core.idle_alpha = 1.0;
-        assert!(needs_frame_tick(&core));
-        assert_eq!(next_wait(&core, false, false), WlWait::Frame);
+        assert!(needs_frame_tick(core));
+        assert_eq!(next_wait(&cores, false, false), WlWait::Frame);
     }
 
     #[test]
@@ -1296,25 +1420,165 @@ mod tests {
         assert!(core.click_t.is_none());
         assert!(core.path.is_none());
         assert!(core.spring.is_none());
+        let cores = HashMap::from([("cursor-a".to_owned(), core)]);
         assert_eq!(
-            next_wait(&core, false, false),
+            next_wait(&cores, false, false),
             WlWait::Maintenance(TOPOLOGY_MAINTENANCE_INTERVAL)
         );
     }
 
     #[test]
+    fn forward_mapping_preserves_named_cursor_keys() {
+        let snap = message(OverlayCommand::SnapTo {
+            x: 10.0,
+            y: 20.0,
+            heading_radians: None,
+        });
+        assert!(matches!(
+            map_overlay_msg(&snap),
+            Some(WlOverlayCmd::Cmd { key, .. }) if key == "test"
+        ));
+        assert!(matches!(
+            map_overlay_msg(&OverlayMsg::Remove("session-a".to_owned())),
+            Some(WlOverlayCmd::Remove(key)) if key == "session-a"
+        ));
+    }
+
+    #[test]
+    fn named_cursors_render_on_independent_outputs_and_removal_clears_only_one() {
+        let template = CursorConfig::default();
+        let mut cores = HashMap::new();
+        let mut ended = HashSet::new();
+        assert!(apply_keyed_command(
+            &mut cores,
+            &template,
+            &ended,
+            "session-a".to_owned(),
+            OverlayCommand::SnapTo {
+                x: 100.0,
+                y: 100.0,
+                heading_radians: None,
+            },
+        ));
+        assert!(apply_keyed_command(
+            &mut cores,
+            &template,
+            &ended,
+            "session-b".to_owned(),
+            OverlayCommand::SnapTo {
+                x: 2500.0,
+                y: 100.0,
+                heading_radians: None,
+            },
+        ));
+        assert_eq!(cores["session-a"].cfg.cursor_id, "session-a");
+        assert_eq!(cores["session-b"].cfg.cursor_id, "session-b");
+
+        let layouts = three_monitor_layout();
+        assert_eq!(
+            visible_cores_for_output(&cores, &layouts, 1)
+                .into_iter()
+                .map(|(key, _)| key.as_str())
+                .collect::<Vec<_>>(),
+            vec!["session-a"]
+        );
+        assert_eq!(
+            visible_cores_for_output(&cores, &layouts, 2)
+                .into_iter()
+                .map(|(key, _)| key.as_str())
+                .collect::<Vec<_>>(),
+            vec!["session-b"]
+        );
+        let (painted, targets) = frame_plan(
+            &layouts,
+            &HashSet::new(),
+            cores.values().map(|core| core.pos),
+        );
+        assert_eq!(painted, HashSet::from([1, 2]));
+        assert_eq!(targets, vec![FrameTarget { id: 1 }, FrameTarget { id: 2 }]);
+
+        assert!(remove_keyed_core(
+            &mut cores,
+            &mut ended,
+            "session-a".to_owned()
+        ));
+        assert!(!cores.contains_key("session-a"));
+        assert!(cores.contains_key("session-b"));
+        assert!(visible_cores_for_output(&cores, &layouts, 1).is_empty());
+        assert_eq!(
+            visible_cores_for_output(&cores, &layouts, 2)
+                .into_iter()
+                .map(|(key, _)| key.as_str())
+                .collect::<Vec<_>>(),
+            vec!["session-b"]
+        );
+        let (selected, targets) =
+            frame_plan(&layouts, &painted, cores.values().map(|core| core.pos));
+        assert_eq!(selected, HashSet::from([2]));
+        assert_eq!(targets, vec![FrameTarget { id: 1 }, FrameTarget { id: 2 }]);
+
+        // A queued command cannot resurrect an ended named session.
+        assert!(!apply_keyed_command(
+            &mut cores,
+            &template,
+            &ended,
+            "session-a".to_owned(),
+            OverlayCommand::SnapTo {
+                x: 200.0,
+                y: 200.0,
+                heading_radians: None,
+            },
+        ));
+        assert!(!cores.contains_key("session-a"));
+    }
+
+    #[test]
+    fn named_cursors_schedule_animation_and_idle_deadlines_independently() {
+        let mut idle = positioned_core();
+        idle.idle_secs = 0.25;
+        let mut animated = positioned_core();
+        animated.motion.idle_hide_ms = 4_000.0;
+        animated.click_t = Some(0.0);
+        let mut cores =
+            HashMap::from([("idle".to_owned(), idle), ("animated".to_owned(), animated)]);
+
+        assert_eq!(next_wait(&cores, false, false), WlWait::Frame);
+        cores.get_mut("animated").unwrap().click_t = None;
+        assert_eq!(
+            next_wait(&cores, false, false),
+            WlWait::Deadline(Duration::from_millis(750))
+        );
+    }
+
+    #[test]
+    fn default_cursor_is_not_removed_or_marked_ended() {
+        let mut cores = HashMap::from([(
+            "default".to_owned(),
+            RenderStateCore::new(CursorConfig::default()),
+        )]);
+        let mut ended = HashSet::new();
+        assert!(!remove_keyed_core(
+            &mut cores,
+            &mut ended,
+            "default".to_owned()
+        ));
+        assert!(cores.contains_key("default"));
+        assert!(!ended.contains("default"));
+    }
+
+    #[test]
     fn maintenance_scheduler_wakes_immediately_on_command_arrival() {
         let (tx, rx) = bounded(1);
-        tx.send(WlOverlayCmd::Remove).unwrap();
+        tx.send(WlOverlayCmd::Remove("test".to_owned())).unwrap();
         assert!(matches!(
             wait_for_work(&rx, WlWait::Maintenance(Duration::from_secs(1))),
-            WlWake::Command(WlOverlayCmd::Remove)
+            WlWake::Command(WlOverlayCmd::Remove(key)) if key == "test"
         ));
     }
 
     #[test]
     fn disabled_config_refuses_forwarding_and_thread_startup() {
-        set_config_enabled(false);
+        CONFIG_ENABLED.store(false, Ordering::Release);
         let msg = message(OverlayCommand::SnapTo {
             x: 10.0,
             y: 20.0,

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
@@ -56,6 +56,7 @@ use wayland_protocols_wlr::layer_shell::v1::client::{
 enum WlOverlayCmd {
     Cmd { key: CursorKey, cmd: OverlayCommand },
     Remove(CursorKey),
+    Revive(CursorKey),
     Shutdown,
 }
 
@@ -104,9 +105,9 @@ pub fn forward(msg: &OverlayMsg) -> bool {
     if !should_forward(CONFIG_ENABLED.load(Ordering::Acquire), msg) {
         return false;
     }
-    // The native Wayland path owns one cursor and does not keep keyed session
-    // tombstones. Accept revival without starting the compositor thread.
-    if matches!(msg, OverlayMsg::Revive(_)) {
+    // If the owner has never started, it cannot hold a tombstone. Accept the
+    // lifecycle transition without paying the compositor startup cost.
+    if matches!(msg, OverlayMsg::Revive(_)) && tx().is_none() {
         return true;
     }
     // Lazy startup: spawning the layer-shell owner thread + connecting to
@@ -130,6 +131,7 @@ fn map_overlay_msg(msg: &OverlayMsg) -> Option<WlOverlayCmd> {
             key: kc.key.clone(),
             cmd: kc.cmd.clone(),
         }),
+        OverlayMsg::Revive(key) => Some(WlOverlayCmd::Revive(key.clone())),
     }
 }
 
@@ -383,6 +385,12 @@ fn remove_keyed_core(
     removed
 }
 
+fn revive_key(ended: &mut HashSet<CursorKey>, key: CursorKey) {
+    if key != "default" {
+        ended.remove(&key);
+    }
+}
+
 fn dbg(msg: &str) {
     if std::env::var_os("CUA_OVERLAY_DEBUG").is_some() {
         eprintln!("[cua-overlay-wl] {msg}");
@@ -616,6 +624,9 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
                 }
                 Ok(WlOverlayCmd::Remove(key)) => {
                     dirty |= remove_keyed_core(&mut state.cores, &mut state.ended, key);
+                }
+                Ok(WlOverlayCmd::Revive(key)) => {
+                    revive_key(&mut state.ended, key);
                 }
                 Err(crossbeam_channel::TryRecvError::Empty) => break,
                 Err(crossbeam_channel::TryRecvError::Disconnected) => {
@@ -1552,6 +1563,10 @@ mod tests {
             map_overlay_msg(&OverlayMsg::Remove("session-a".to_owned())),
             Some(WlOverlayCmd::Remove(key)) if key == "session-a"
         ));
+        assert!(matches!(
+            map_overlay_msg(&OverlayMsg::Revive("session-a".to_owned())),
+            Some(WlOverlayCmd::Revive(key)) if key == "session-a"
+        ));
     }
 
     #[test]
@@ -1645,6 +1660,21 @@ mod tests {
             },
         ));
         assert!(!cores.contains_key("session-a"));
+
+        revive_key(&mut ended, "session-a".to_owned());
+        assert!(!ended.contains("session-a"));
+        assert!(apply_keyed_command(
+            &mut cores,
+            &template,
+            &ended,
+            "session-a".to_owned(),
+            OverlayCommand::SnapTo {
+                x: 200.0,
+                y: 200.0,
+                heading_radians: None,
+            },
+        ));
+        assert!(cores.contains_key("session-a"));
     }
 
     #[test]

--- a/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
+++ b/libs/cua-driver/rust/crates/platform-linux/src/wayland/overlay.rs
@@ -2,7 +2,7 @@
 //!
 //! Replaces the X11-only `overlay.rs` render loop on wlroots compositors
 //! (sway, labwc, kwin 5.27+, hyprland) by creating a full-screen,
-//! click-through, always-on-top `wl_surface` anchored to the first output
+//! click-through, always-on-top `wl_surface` on every enabled output
 //! via `zwlr_layer_shell_v1`. The surface renders the same gradient-arrow
 //! cursor as the X11 path by sharing `cursor_overlay::RenderStateCore` —
 //! bloom, click-pulse, idle-fade, and motion all work identically.
@@ -15,9 +15,9 @@
 //! owner thread (`cua-overlay-wl`) holds the wayland Connection +
 //! EventQueue + layer surface; commands flow in over a `crossbeam-channel`.
 //! The render core wakes at frame cadence only while pixels can change;
-//! stable or hidden state blocks on the command channel without polling.
+//! stable or hidden state performs only a cheap, one-second topology check.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     OnceLock,
@@ -39,6 +39,10 @@ use wayland_client::{
         wl_surface::WlSurface,
     },
     Connection, Dispatch, Proxy, QueueHandle,
+};
+use wayland_protocols::xdg::xdg_output::zv1::client::{
+    zxdg_output_manager_v1::ZxdgOutputManagerV1,
+    zxdg_output_v1::{self, ZxdgOutputV1},
 };
 use wayland_protocols_wlr::layer_shell::v1::client::{
     zwlr_layer_shell_v1::{Layer, ZwlrLayerShellV1},
@@ -154,12 +158,13 @@ struct OverlayState {
     compositor: Option<WlCompositor>,
     shm: Option<WlShm>,
     layer_shell: Option<ZwlrLayerShellV1>,
-    output: Option<WlOutput>,
-    output_w: u32,
-    output_h: u32,
-    surface: Option<WlSurface>,
-    layer_surface: Option<ZwlrLayerSurfaceV1>,
-    configured: bool,
+    xdg_output_manager: Option<ZxdgOutputManagerV1>,
+    outputs: HashMap<u32, NativeOutput>,
+    /// Outputs whose most recently committed buffer contains cursor pixels.
+    /// Usually this contains exactly one output; keeping a set makes hide,
+    /// removal, and topology changes clear every previously painted surface.
+    painted_outputs: HashSet<u32>,
+    topology_dirty: bool,
     /// Cross-platform render core: position, animation, gradient arrow,
     /// bloom, click pulse, idle-fade. Shared verbatim with the X11 path.
     core: RenderStateCore,
@@ -170,6 +175,108 @@ struct OverlayState {
     /// Replaces the per-redraw `mem::forget` leak: the previous frame's
     /// memory is reclaimed as soon as the compositor releases it.
     pending_buffers: HashMap<u32, (*mut libc::c_void, usize, i32)>,
+}
+
+struct NativeOutput {
+    output: WlOutput,
+    xdg_output: Option<ZxdgOutputV1>,
+    surface: Option<WlSurface>,
+    layer_surface: Option<ZwlrLayerSurfaceV1>,
+    wl_origin: Option<(i32, i32)>,
+    logical_origin: Option<(i32, i32)>,
+    logical_size: Option<(u32, u32)>,
+    configured_size: Option<(u32, u32)>,
+    mode_size: Option<(u32, u32)>,
+    scale: i32,
+    name: Option<String>,
+    closed: bool,
+}
+
+impl NativeOutput {
+    fn new(output: WlOutput) -> Self {
+        Self {
+            output,
+            xdg_output: None,
+            surface: None,
+            layer_surface: None,
+            wl_origin: None,
+            logical_origin: None,
+            logical_size: None,
+            configured_size: None,
+            mode_size: None,
+            scale: 1,
+            name: None,
+            closed: false,
+        }
+    }
+
+    fn layout(&self, id: u32) -> Option<OutputLayout> {
+        if self.layer_surface.is_none() || self.configured_size.is_none() {
+            return None;
+        }
+        let (origin_x, origin_y) = self.logical_origin.or(self.wl_origin).unwrap_or((0, 0));
+        let (width, height) = self.logical_size.or(self.configured_size).or_else(|| {
+            let scale = self.scale.max(1) as u32;
+            self.mode_size
+                .map(|(width, height)| ((width / scale).max(1), (height / scale).max(1)))
+        })?;
+        (width > 0 && height > 0).then_some(OutputLayout {
+            id,
+            origin_x,
+            origin_y,
+            width,
+            height,
+        })
+    }
+
+    fn destroy_surfaces(&mut self) {
+        self.close_layer();
+        if let Some(xdg_output) = self.xdg_output.take() {
+            xdg_output.destroy();
+        }
+    }
+
+    fn close_layer(&mut self) {
+        if let Some(layer_surface) = self.layer_surface.take() {
+            layer_surface.destroy();
+        }
+        if let Some(surface) = self.surface.take() {
+            surface.destroy();
+        }
+        self.configured_size = None;
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct OutputLayout {
+    id: u32,
+    origin_x: i32,
+    origin_y: i32,
+    width: u32,
+    height: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct SelectedOutput {
+    id: u32,
+    local_x: f64,
+    local_y: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FrameTarget {
+    id: u32,
+    paint_cursor: bool,
+}
+
+#[derive(Clone, Copy)]
+struct OutputData {
+    id: u32,
+}
+
+#[derive(Clone, Copy)]
+struct LayerData {
+    id: u32,
 }
 
 // SAFETY: the raw pointers in pending_buffers point at mmap regions owned
@@ -186,12 +293,10 @@ impl Default for OverlayState {
             compositor: None,
             shm: None,
             layer_shell: None,
-            output: None,
-            output_w: 0,
-            output_h: 0,
-            surface: None,
-            layer_surface: None,
-            configured: false,
+            xdg_output_manager: None,
+            outputs: HashMap::new(),
+            painted_outputs: HashSet::new(),
+            topology_dirty: false,
             core: RenderStateCore::new(CursorConfig::default()),
             pending_buffers: HashMap::new(),
         }
@@ -204,6 +309,106 @@ fn dbg(msg: &str) {
     }
 }
 
+fn select_output(layouts: &[OutputLayout], x: f64, y: f64) -> Option<SelectedOutput> {
+    if !x.is_finite() || !y.is_finite() {
+        return None;
+    }
+    layouts
+        .iter()
+        .filter(|layout| {
+            x >= f64::from(layout.origin_x)
+                && y >= f64::from(layout.origin_y)
+                && x < f64::from(layout.origin_x) + f64::from(layout.width)
+                && y < f64::from(layout.origin_y) + f64::from(layout.height)
+        })
+        .min_by_key(|layout| layout.id)
+        .map(|layout| SelectedOutput {
+            id: layout.id,
+            local_x: x - f64::from(layout.origin_x),
+            local_y: y - f64::from(layout.origin_y),
+        })
+}
+
+fn frame_plan(
+    layouts: &[OutputLayout],
+    painted_outputs: &HashSet<u32>,
+    cursor_position: Option<(f64, f64)>,
+) -> (Option<SelectedOutput>, Vec<FrameTarget>) {
+    let selected = cursor_position.and_then(|(x, y)| select_output(layouts, x, y));
+    let mut ids: Vec<u32> = painted_outputs.iter().copied().collect();
+    if let Some(selected) = selected {
+        if !ids.contains(&selected.id) {
+            ids.push(selected.id);
+        }
+    }
+    ids.sort_unstable();
+    ids.dedup();
+    let targets = ids
+        .into_iter()
+        .map(|id| FrameTarget {
+            id,
+            paint_cursor: selected.is_some_and(|selected| selected.id == id),
+        })
+        .collect();
+    (selected, targets)
+}
+
+fn ensure_output_resources(state: &mut OverlayState, qh: &QueueHandle<OverlayState>) {
+    let ids: Vec<u32> = state.outputs.keys().copied().collect();
+    for id in ids {
+        ensure_xdg_output(state, id, qh);
+        ensure_layer_surface(state, id, qh);
+    }
+}
+
+fn ensure_xdg_output(state: &mut OverlayState, id: u32, qh: &QueueHandle<OverlayState>) {
+    let Some(manager) = state.xdg_output_manager.clone() else {
+        return;
+    };
+    let Some(output) = state.outputs.get_mut(&id) else {
+        return;
+    };
+    if output.xdg_output.is_none() {
+        output.xdg_output = Some(manager.get_xdg_output(&output.output, qh, OutputData { id }));
+    }
+}
+
+fn ensure_layer_surface(state: &mut OverlayState, id: u32, qh: &QueueHandle<OverlayState>) {
+    let (Some(compositor), Some(layer_shell)) =
+        (state.compositor.clone(), state.layer_shell.clone())
+    else {
+        return;
+    };
+    let Some(output) = state.outputs.get_mut(&id) else {
+        return;
+    };
+    if output.layer_surface.is_some() || output.closed {
+        return;
+    }
+
+    let surface = compositor.create_surface(qh, ());
+    let layer_surface = layer_shell.get_layer_surface(
+        &surface,
+        Some(&output.output),
+        Layer::Overlay,
+        "cua-agent-cursor".to_string(),
+        qh,
+        LayerData { id },
+    );
+    layer_surface.set_anchor(Anchor::Top | Anchor::Bottom | Anchor::Left | Anchor::Right);
+    layer_surface.set_size(0, 0);
+    layer_surface.set_exclusive_zone(-1);
+    layer_surface.set_keyboard_interactivity(KeyboardInteractivity::None);
+
+    let region: WlRegion = compositor.create_region(qh, ());
+    surface.set_input_region(Some(&region));
+    region.destroy();
+
+    surface.commit();
+    output.surface = Some(surface);
+    output.layer_surface = Some(layer_surface);
+}
+
 fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
     let conn = Connection::connect_to_env()?;
     let mut queue = conn.new_event_queue::<OverlayState>();
@@ -212,11 +417,8 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
 
     let mut state = OverlayState::default();
     queue.roundtrip(&mut state)?;
-    for _ in 0..3 {
-        queue.roundtrip(&mut state)?;
-    }
 
-    let compositor = state
+    state
         .compositor
         .clone()
         .ok_or_else(|| anyhow::anyhow!("compositor does not expose wl_compositor"))?;
@@ -224,75 +426,50 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
         .shm
         .clone()
         .ok_or_else(|| anyhow::anyhow!("compositor does not expose wl_shm"))?;
-    let layer_shell = state
+    state
         .layer_shell
         .clone()
         .ok_or_else(|| anyhow::anyhow!("compositor does not expose zwlr_layer_shell_v1"))?;
-    let output = state
-        .output
-        .clone()
-        .ok_or_else(|| anyhow::anyhow!("compositor exposed no wl_output"))?;
-
-    // Build the layer surface: fullscreen, overlay layer, click-through.
-    let surface = compositor.create_surface(&qh, ());
-    let layer_surface = layer_shell.get_layer_surface(
-        &surface,
-        Some(&output),
-        Layer::Overlay,
-        "cua-agent-cursor".to_string(),
-        &qh,
-        (),
-    );
-    // Anchor to all four edges = full screen.
-    layer_surface.set_anchor(Anchor::Top | Anchor::Bottom | Anchor::Left | Anchor::Right);
-    layer_surface.set_size(0, 0);
-    layer_surface.set_exclusive_zone(-1);
-    layer_surface.set_keyboard_interactivity(KeyboardInteractivity::None);
-
-    // Click-through: empty input region. Standard Wayland intentionally does
-    // not expose another client's global pointer position, so this surface
-    // cannot implement the macOS/Windows/X11 badge-hover reveal without a
-    // compositor-owned adapter. Giving it an input region would steal the
-    // user's pointer events instead of observing them.
-    let region: WlRegion = compositor.create_region(&qh, ());
-    surface.set_input_region(Some(&region));
-    region.destroy();
-
-    state.surface = Some(surface);
-    state.layer_surface = Some(layer_surface);
-
-    // First commit kicks off the configure handshake.
-    if let Some(s) = state.surface.as_ref() {
-        s.commit();
+    if state.outputs.is_empty() {
+        anyhow::bail!("compositor exposed no wl_output");
     }
 
-    // Wait for the first configure event so we know the output dimensions
-    // before drawing.
+    // Build one fullscreen, click-through layer surface per advertised output.
+    ensure_output_resources(&mut state, &qh);
+
+    // Give every enabled output a chance to configure. Disabled outputs may
+    // stay advertised without configuring and are excluded from selection.
     for _ in 0..10 {
         queue.roundtrip(&mut state)?;
-        if state.configured && state.output_w > 0 && state.output_h > 0 {
+        ensure_output_resources(&mut state, &qh);
+        if state
+            .outputs
+            .values()
+            .filter(|output| output.layer_surface.is_some())
+            .all(|output| output.configured_size.is_some())
+        {
             break;
         }
-        std::thread::sleep(std::time::Duration::from_millis(50));
     }
 
-    if !state.configured {
-        anyhow::bail!("layer surface never received configure event");
+    let configured_outputs = state
+        .outputs
+        .values()
+        .filter(|output| output.configured_size.is_some())
+        .count();
+    if configured_outputs == 0 {
+        anyhow::bail!("no layer surface received a configure event");
     }
-    dbg(&format!(
-        "configured: w={} h={}",
-        state.output_w, state.output_h
-    ));
+    dbg(&format!("configured outputs: {configured_outputs}"));
+    state.topology_dirty = false;
 
-    // Demand-driven main loop. A stable cursor blocks on the command channel;
-    // only active motion, click/fade animation, or the exact idle-fade
-    // deadline schedules a wake. This avoids display-sized SHM allocation and
-    // conversion at 60Hz when no pixel can change while preserving immediate
-    // command wakeups.
+    // Demand-driven main loop. Stable cursors perform only a cheap Wayland
+    // maintenance roundtrip once per second so output topology changes are
+    // observed; full-display SHM work remains limited to visual changes.
     let mut last_tick = Instant::now();
     let mut frame_tick_needed = false;
     loop {
-        let wait = next_wait(&state.core, frame_tick_needed);
+        let wait = next_wait(&state.core, frame_tick_needed, state.topology_dirty);
         let (first_cmd, timed_out) = match wait_for_work(&rx, wait) {
             WlWake::Command(cmd) => (Some(cmd), None),
             WlWake::Timeout => (None, Some(wait)),
@@ -367,16 +544,31 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
         // applies the new state at dt=0, avoiding a jump proportional to how
         // long the loop was parked.
         if let Some(timeout_kind) = timed_out {
-            let dt = match timeout_kind {
-                WlWait::Frame => elapsed.min(0.05),
-                WlWait::Deadline(_) => elapsed,
-                WlWait::Block => unreachable!("a blocking receive cannot time out"),
-            };
-            state.core.tick_motion(dt);
-            dirty = true;
+            match timeout_kind {
+                WlWait::Frame => {
+                    state.core.tick_motion(elapsed.min(0.05));
+                    dirty = true;
+                }
+                WlWait::Deadline(_) => {
+                    state.core.tick_motion(elapsed);
+                    dirty = true;
+                }
+                WlWait::Maintenance(_) => {
+                    let idle_alpha = state.core.idle_alpha;
+                    state.core.tick_motion(elapsed);
+                    dirty |= state.core.idle_alpha != idle_alpha || needs_frame_tick(&state.core);
+
+                    let topology_was_dirty = state.topology_dirty;
+                    state.topology_dirty = false;
+                    queue.roundtrip(&mut state)?;
+                    ensure_output_resources(&mut state, &qh);
+                    dirty |= topology_was_dirty || state.topology_dirty;
+                    state.topology_dirty = false;
+                }
+            }
         }
         let next_frame_tick_needed = needs_frame_tick(&state.core);
-        if state.configured && (dirty || frame_tick_needed || next_frame_tick_needed) {
+        if dirty || frame_tick_needed || next_frame_tick_needed {
             redraw(&mut state, &shm, &qh)?;
             // Flush the committed frame and dispatch wl_buffer.release before
             // parking. The buffer map remains authoritative until release, so
@@ -386,11 +578,8 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
         frame_tick_needed = next_frame_tick_needed;
     }
 
-    if let Some(ls) = state.layer_surface.take() {
-        ls.destroy();
-    }
-    if let Some(s) = state.surface.take() {
-        s.destroy();
+    for output in state.outputs.values_mut() {
+        output.destroy_surfaces();
     }
     queue.roundtrip(&mut state)?;
     Ok(())
@@ -398,9 +587,9 @@ fn owner_thread(rx: Receiver<WlOverlayCmd>) -> anyhow::Result<()> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum WlWait {
-    Block,
     Frame,
     Deadline(Duration),
+    Maintenance(Duration),
 }
 
 enum WlWake {
@@ -411,30 +600,34 @@ enum WlWake {
 
 fn wait_for_work(rx: &Receiver<WlOverlayCmd>, wait: WlWait) -> WlWake {
     match wait {
-        WlWait::Block => match rx.recv() {
-            Ok(cmd) => WlWake::Command(cmd),
-            Err(_) => WlWake::Disconnected,
-        },
         WlWait::Frame => match rx.recv_timeout(Duration::from_millis(16)) {
             Ok(cmd) => WlWake::Command(cmd),
             Err(crossbeam_channel::RecvTimeoutError::Timeout) => WlWake::Timeout,
             Err(crossbeam_channel::RecvTimeoutError::Disconnected) => WlWake::Disconnected,
         },
-        WlWait::Deadline(timeout) => match rx.recv_timeout(timeout) {
-            Ok(cmd) => WlWake::Command(cmd),
-            Err(crossbeam_channel::RecvTimeoutError::Timeout) => WlWake::Timeout,
-            Err(crossbeam_channel::RecvTimeoutError::Disconnected) => WlWake::Disconnected,
-        },
+        WlWait::Deadline(timeout) | WlWait::Maintenance(timeout) => {
+            match rx.recv_timeout(timeout) {
+                Ok(cmd) => WlWake::Command(cmd),
+                Err(crossbeam_channel::RecvTimeoutError::Timeout) => WlWake::Timeout,
+                Err(crossbeam_channel::RecvTimeoutError::Disconnected) => WlWake::Disconnected,
+            }
+        }
     }
 }
 
-fn next_wait(core: &RenderStateCore, frame_tick_needed: bool) -> WlWait {
+const TOPOLOGY_MAINTENANCE_INTERVAL: Duration = Duration::from_secs(1);
+
+fn next_wait(core: &RenderStateCore, frame_tick_needed: bool, topology_dirty: bool) -> WlWait {
+    if topology_dirty {
+        return WlWait::Maintenance(Duration::ZERO);
+    }
     if frame_tick_needed || needs_frame_tick(core) {
         return WlWait::Frame;
     }
-    idle_fade_wait(core)
-        .map(WlWait::Deadline)
-        .unwrap_or(WlWait::Block)
+    match idle_fade_wait(core) {
+        Some(wait) if wait <= TOPOLOGY_MAINTENANCE_INTERVAL => WlWait::Deadline(wait),
+        _ => WlWait::Maintenance(TOPOLOGY_MAINTENANCE_INTERVAL),
+    }
 }
 
 fn needs_frame_tick(core: &RenderStateCore) -> bool {
@@ -472,8 +665,8 @@ fn quiesce_hidden(core: &mut RenderStateCore) {
     core.click_t = None;
 }
 
-/// Render one cursor frame into a fresh wl_shm ARGB8888 buffer and attach
-/// it to the layer surface.
+/// Render the selected output plus a transparent clearing frame on every
+/// previously painted output the cursor has left.
 ///
 /// Pipeline:
 /// 1. Allocate a memfd-backed wl_shm pool sized at output_w × output_h.
@@ -493,13 +686,50 @@ fn redraw(
     shm: &WlShm,
     qh: &QueueHandle<OverlayState>,
 ) -> anyhow::Result<()> {
-    let Some(surface) = state.surface.as_ref() else {
+    let layouts: Vec<OutputLayout> = state
+        .outputs
+        .iter()
+        .filter_map(|(&id, output)| output.layout(id))
+        .collect();
+    let cursor_position =
+        (state.core.visible && state.core.pos.0 >= -100.0 && state.core.idle_alpha >= 0.004)
+            .then_some(state.core.pos);
+    let (selected, targets) = frame_plan(&layouts, &state.painted_outputs, cursor_position);
+
+    for target in targets {
+        redraw_output(state, shm, qh, target)?;
+    }
+
+    state.painted_outputs.clear();
+    if let Some(selected) = selected {
+        state.painted_outputs.insert(selected.id);
+    }
+    Ok(())
+}
+
+fn redraw_output(
+    state: &mut OverlayState,
+    shm: &WlShm,
+    qh: &QueueHandle<OverlayState>,
+    target: FrameTarget,
+) -> anyhow::Result<()> {
+    let Some((surface, layout)) = state
+        .outputs
+        .get(&target.id)
+        .and_then(|output| Some((output.surface.clone()?, output.layout(target.id)?)))
+    else {
         return Ok(());
     };
-    let w = state.output_w.max(1);
-    let h = state.output_h.max(1);
-    let stride = w as i32 * 4;
-    let size = (stride as usize) * (h as usize);
+    let w = layout.width.max(1);
+    let h = layout.height.max(1);
+    let stride = w
+        .checked_mul(4)
+        .and_then(|stride| i32::try_from(stride).ok())
+        .ok_or_else(|| anyhow::anyhow!("overlay output {w}x{h} has an invalid stride"))?;
+    let size = usize::try_from(stride)
+        .ok()
+        .and_then(|stride| stride.checked_mul(h as usize))
+        .ok_or_else(|| anyhow::anyhow!("overlay output {w}x{h} buffer size overflow"))?;
 
     // Reuses the same anon_shm pattern as the screencopy path in mod.rs.
     let (fd, ptr) =
@@ -509,10 +739,9 @@ fn redraw(
     // function.
     let pixels: &mut [u8] = unsafe { std::slice::from_raw_parts_mut(ptr as *mut u8, size) };
 
-    // Paint the cursor into a tiny_skia pixmap. paint_cursor early-returns
-    // when the cursor is hidden / off-screen / idle-faded, so the pixmap
-    // is left fully transparent in those cases (which is also what we want
-    // for the click-through layer surface).
+    // A clearing target intentionally stays transparent. The selected target
+    // subtracts its logical compositor origin from the global cursor position;
+    // this is the same origin contract used by the Windows virtual desktop.
     let pm_result = tiny_skia::Pixmap::new(w, h);
     let mut pm = match pm_result {
         Some(p) => p,
@@ -525,20 +754,26 @@ fn redraw(
             "tiny_skia::Pixmap::new({w}, {h}) failed — out of memory for the overlay buffer"
         ),
     };
-    // backing_scale=1.0 matches the X11 path; per-output Wayland scale is
-    // a follow-up (would consume `wl_output.scale` and `preferred_buffer
-    // _scale` from wl_surface v6).
-    cursor_overlay::paint_cursor(&mut pm, &state.core, 0.0, 0.0, None, 1.0);
+    if target.paint_cursor {
+        cursor_overlay::paint_cursor(
+            &mut pm,
+            &state.core,
+            f64::from(layout.origin_x),
+            f64::from(layout.origin_y),
+            None,
+            1.0,
+        );
+    }
 
     // CUA_OVERLAY_DEBUG=1 paints a 60x60 magenta square at the cursor's
     // current pos on top of the gradient arrow. Useful when validating
     // layer-shell visibility on a new compositor — the gradient arrow is
     // small at native scale and easy to miss in a screenshot, while the
     // magenta block is impossible to miss.
-    if std::env::var_os("CUA_OVERLAY_DEBUG").is_some() {
+    if target.paint_cursor && std::env::var_os("CUA_OVERLAY_DEBUG").is_some() {
         let (cx, cy) = state.core.pos;
-        let cx = cx as i32;
-        let cy = cy as i32;
+        let cx = (cx - f64::from(layout.origin_x)) as i32;
+        let cy = (cy - f64::from(layout.origin_y)) as i32;
         let half = 30i32;
         for dy in -half..half {
             for dx in -half..half {
@@ -588,14 +823,27 @@ fn redraw(
     state.pending_buffers.insert(buffer_id, (ptr, size, fd));
 
     dbg(&format!(
-        "redraw w={w} h={h} stride={stride} buf_id={buffer_id} pos=({:.1},{:.1}) visible={}",
-        state.core.pos.0, state.core.pos.1, state.core.visible
+        "redraw output={} origin=({}, {}) w={w} h={h} stride={stride} buf_id={buffer_id} pos=({:.1},{:.1}) paint={}",
+        output_label(state, target.id),
+        layout.origin_x,
+        layout.origin_y,
+        state.core.pos.0,
+        state.core.pos.1,
+        target.paint_cursor,
     ));
     surface.attach(Some(&buffer), 0, 0);
     surface.damage_buffer(0, 0, w as i32, h as i32);
     surface.commit();
     pool.destroy();
     Ok(())
+}
+
+fn output_label(state: &OverlayState, id: u32) -> String {
+    state
+        .outputs
+        .get(&id)
+        .and_then(|output| output.name.clone())
+        .unwrap_or_else(|| format!("wl_output#{id}"))
 }
 
 // ── Wayland Dispatch impls ───────────────────────────────────────────────
@@ -609,32 +857,67 @@ impl Dispatch<wl_registry::WlRegistry, ()> for OverlayState {
         _conn: &Connection,
         qh: &QueueHandle<Self>,
     ) {
-        if let wl_registry::Event::Global {
-            name,
-            interface,
-            version,
-        } = event
-        {
-            match interface.as_str() {
-                "wl_compositor" => {
-                    state.compositor =
-                        Some(registry.bind::<WlCompositor, _, _>(name, version.min(6), qh, ()));
-                }
-                "wl_shm" => {
-                    state.shm = Some(registry.bind::<WlShm, _, _>(name, version.min(1), qh, ()));
-                }
-                "wl_output" => {
-                    if state.output.is_none() {
-                        state.output =
-                            Some(registry.bind::<WlOutput, _, _>(name, version.min(4), qh, ()));
+        match event {
+            wl_registry::Event::Global {
+                name,
+                interface,
+                version,
+            } => {
+                match interface.as_str() {
+                    "wl_compositor" => {
+                        state.compositor =
+                            Some(registry.bind::<WlCompositor, _, _>(name, version.min(6), qh, ()));
                     }
+                    "wl_shm" => {
+                        state.shm =
+                            Some(registry.bind::<WlShm, _, _>(name, version.min(1), qh, ()));
+                    }
+                    "wl_output" => {
+                        let output = registry.bind::<WlOutput, _, _>(
+                            name,
+                            version.min(4),
+                            qh,
+                            OutputData { id: name },
+                        );
+                        state.outputs.insert(name, NativeOutput::new(output));
+                        state.topology_dirty = true;
+                    }
+                    "zwlr_layer_shell_v1" => {
+                        state.layer_shell = Some(registry.bind::<ZwlrLayerShellV1, _, _>(
+                            name,
+                            version.min(4),
+                            qh,
+                            (),
+                        ));
+                    }
+                    "zxdg_output_manager_v1" => {
+                        state.xdg_output_manager =
+                            Some(registry.bind::<ZxdgOutputManagerV1, _, _>(
+                                name,
+                                version.min(3),
+                                qh,
+                                (),
+                            ));
+                    }
+                    _ => {}
                 }
-                "zwlr_layer_shell_v1" => {
-                    state.layer_shell =
-                        Some(registry.bind::<ZwlrLayerShellV1, _, _>(name, version.min(4), qh, ()));
-                }
-                _ => {}
+                ensure_output_resources(state, qh);
             }
+            wl_registry::Event::GlobalRemove { name } => {
+                state.painted_outputs.remove(&name);
+                if let Some(mut output) = state.outputs.remove(&name) {
+                    output.destroy_surfaces();
+                    // wl_output.release was added in v3. On an older generic
+                    // wlroots compositor, dropping the client proxy is the only
+                    // valid cleanup; issuing the newer request would be a
+                    // protocol error.
+                    if output.output.version() >= 3 {
+                        output.output.release();
+                    }
+                    state.topology_dirty = true;
+                }
+            }
+            _ => {}
         }
     }
 }
@@ -663,21 +946,77 @@ impl Dispatch<WlShm, ()> for OverlayState {
     }
 }
 
-impl Dispatch<WlOutput, ()> for OverlayState {
+impl Dispatch<WlOutput, OutputData> for OverlayState {
     fn event(
         state: &mut Self,
         _: &WlOutput,
         event: <WlOutput as wayland_client::Proxy>::Event,
-        _: &(),
+        data: &OutputData,
         _: &Connection,
         _: &QueueHandle<Self>,
     ) {
         use wayland_client::protocol::wl_output;
-        if let wl_output::Event::Mode { width, height, .. } = event {
-            if width > 0 && height > 0 {
-                state.output_w = width as u32;
-                state.output_h = height as u32;
+        let Some(output) = state.outputs.get_mut(&data.id) else {
+            return;
+        };
+        match event {
+            wl_output::Event::Geometry { x, y, .. } => {
+                state.topology_dirty |= output.wl_origin != Some((x, y));
+                output.wl_origin = Some((x, y));
             }
+            wl_output::Event::Mode { width, height, .. } if width > 0 && height > 0 => {
+                state.topology_dirty |= output.mode_size != Some((width as u32, height as u32));
+                output.mode_size = Some((width as u32, height as u32));
+            }
+            wl_output::Event::Scale { factor } => {
+                state.topology_dirty |= output.scale != factor.max(1);
+                output.scale = factor.max(1);
+            }
+            wl_output::Event::Name { name } => {
+                output.name = Some(name);
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Dispatch<ZxdgOutputManagerV1, ()> for OverlayState {
+    fn event(
+        _: &mut Self,
+        _: &ZxdgOutputManagerV1,
+        _: <ZxdgOutputManagerV1 as Proxy>::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<ZxdgOutputV1, OutputData> for OverlayState {
+    fn event(
+        state: &mut Self,
+        _: &ZxdgOutputV1,
+        event: <ZxdgOutputV1 as Proxy>::Event,
+        data: &OutputData,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        let Some(output) = state.outputs.get_mut(&data.id) else {
+            return;
+        };
+        match event {
+            zxdg_output_v1::Event::LogicalPosition { x, y } => {
+                state.topology_dirty |= output.logical_origin != Some((x, y));
+                output.logical_origin = Some((x, y));
+            }
+            zxdg_output_v1::Event::LogicalSize { width, height } if width > 0 && height > 0 => {
+                state.topology_dirty |= output.logical_size != Some((width as u32, height as u32));
+                output.logical_size = Some((width as u32, height as u32));
+            }
+            zxdg_output_v1::Event::Name { name } => {
+                output.name = Some(name);
+            }
+            _ => {}
         }
     }
 }
@@ -694,29 +1033,42 @@ impl Dispatch<ZwlrLayerShellV1, ()> for OverlayState {
     }
 }
 
-impl Dispatch<ZwlrLayerSurfaceV1, ()> for OverlayState {
+impl Dispatch<ZwlrLayerSurfaceV1, LayerData> for OverlayState {
     fn event(
         state: &mut Self,
         layer: &ZwlrLayerSurfaceV1,
         event: <ZwlrLayerSurfaceV1 as wayland_client::Proxy>::Event,
-        _: &(),
+        data: &LayerData,
         _: &Connection,
         _: &QueueHandle<Self>,
     ) {
-        if let zwlr_layer_surface_v1::Event::Configure {
-            serial,
-            width,
-            height,
-        } = event
-        {
-            layer.ack_configure(serial);
-            if width > 0 {
-                state.output_w = width;
+        match event {
+            zwlr_layer_surface_v1::Event::Configure {
+                serial,
+                width,
+                height,
+            } => {
+                layer.ack_configure(serial);
+                if let Some(output) = state.outputs.get_mut(&data.id) {
+                    output.closed = false;
+                    let fallback = output.logical_size.or(output.mode_size).unwrap_or((1, 1));
+                    let configured_size = (
+                        if width > 0 { width } else { fallback.0 },
+                        if height > 0 { height } else { fallback.1 },
+                    );
+                    state.topology_dirty |= output.configured_size != Some(configured_size);
+                    output.configured_size = Some(configured_size);
+                }
             }
-            if height > 0 {
-                state.output_h = height;
+            zwlr_layer_surface_v1::Event::Closed => {
+                state.painted_outputs.remove(&data.id);
+                if let Some(output) = state.outputs.get_mut(&data.id) {
+                    output.closed = true;
+                    output.close_layer();
+                    state.topology_dirty = true;
+                }
             }
-            state.configured = true;
+            _ => {}
         }
     }
 }
@@ -798,11 +1150,116 @@ mod tests {
         core
     }
 
+    fn three_monitor_layout() -> Vec<OutputLayout> {
+        vec![
+            // 1920x1080 logical laptop panel at 2x backing scale.
+            OutputLayout {
+                id: 1,
+                origin_x: 0,
+                origin_y: 0,
+                width: 1920,
+                height: 1080,
+            },
+            // 2560x1440 logical external display, raised above the laptop.
+            OutputLayout {
+                id: 2,
+                origin_x: 1920,
+                origin_y: -200,
+                width: 2560,
+                height: 1440,
+            },
+            // Fractionally scaled portrait display left of the laptop.
+            OutputLayout {
+                id: 3,
+                origin_x: -1280,
+                origin_y: 56,
+                width: 1280,
+                height: 1024,
+            },
+        ]
+    }
+
     #[test]
-    fn fresh_sentinel_overlay_blocks_without_frame_polling() {
+    fn selects_output_and_converts_global_to_output_local_coordinates() {
+        let layouts = three_monitor_layout();
+        assert_eq!(
+            select_output(&layouts, 2500.0, 100.0),
+            Some(SelectedOutput {
+                id: 2,
+                local_x: 580.0,
+                local_y: 300.0,
+            })
+        );
+        assert_eq!(
+            select_output(&layouts, -1000.0, 256.0),
+            Some(SelectedOutput {
+                id: 3,
+                local_x: 280.0,
+                local_y: 200.0,
+            })
+        );
+        assert_eq!(
+            select_output(&layouts, 1919.0, 500.0).map(|output| output.id),
+            Some(1)
+        );
+        assert_eq!(
+            select_output(&layouts, 1920.0, 500.0).map(|output| output.id),
+            Some(2)
+        );
+        assert_eq!(select_output(&layouts, 5000.0, 5000.0), None);
+    }
+
+    #[test]
+    fn crossing_outputs_clears_the_old_surface_and_paints_the_new_one() {
+        let painted = HashSet::from([1]);
+        let (selected, targets) =
+            frame_plan(&three_monitor_layout(), &painted, Some((2500.0, 100.0)));
+
+        assert_eq!(selected.map(|output| output.id), Some(2));
+        assert_eq!(
+            targets,
+            vec![
+                FrameTarget {
+                    id: 1,
+                    paint_cursor: false,
+                },
+                FrameTarget {
+                    id: 2,
+                    paint_cursor: true,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn hide_or_session_removal_clears_every_previously_painted_output() {
+        let painted = HashSet::from([1, 2, 3]);
+        let (selected, targets) = frame_plan(&three_monitor_layout(), &painted, None);
+
+        assert!(selected.is_none());
+        assert_eq!(targets.len(), 3);
+        assert!(targets.iter().all(|target| !target.paint_cursor));
+        assert_eq!(
+            targets.iter().map(|target| target.id).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+    }
+
+    #[test]
+    fn fresh_sentinel_overlay_uses_only_topology_maintenance() {
         let core = RenderStateCore::new(CursorConfig::default());
-        assert_eq!(next_wait(&core, false), WlWait::Block);
+        assert_eq!(
+            next_wait(&core, false, false),
+            WlWait::Maintenance(TOPOLOGY_MAINTENANCE_INTERVAL)
+        );
         assert!(!needs_frame_tick(&core));
+        assert_eq!(
+            next_wait(&core, false, true),
+            WlWait::Maintenance(Duration::ZERO)
+        );
+        assert!(frame_plan(&three_monitor_layout(), &HashSet::new(), None)
+            .1
+            .is_empty());
     }
 
     #[test]
@@ -810,7 +1267,7 @@ mod tests {
         let mut core = positioned_core();
         core.idle_secs = 0.25;
         assert_eq!(
-            next_wait(&core, false),
+            next_wait(&core, false, false),
             WlWait::Deadline(Duration::from_millis(750))
         );
         assert!(!needs_frame_tick(&core));
@@ -821,13 +1278,13 @@ mod tests {
         let mut core = positioned_core();
         core.click_t = Some(0.0);
         assert!(needs_frame_tick(&core));
-        assert_eq!(next_wait(&core, false), WlWait::Frame);
+        assert_eq!(next_wait(&core, false, false), WlWait::Frame);
 
         core.click_t = None;
         core.idle_secs = 1.0;
         core.idle_alpha = 1.0;
         assert!(needs_frame_tick(&core));
-        assert_eq!(next_wait(&core, false), WlWait::Frame);
+        assert_eq!(next_wait(&core, false, false), WlWait::Frame);
     }
 
     #[test]
@@ -839,15 +1296,18 @@ mod tests {
         assert!(core.click_t.is_none());
         assert!(core.path.is_none());
         assert!(core.spring.is_none());
-        assert_eq!(next_wait(&core, false), WlWait::Block);
+        assert_eq!(
+            next_wait(&core, false, false),
+            WlWait::Maintenance(TOPOLOGY_MAINTENANCE_INTERVAL)
+        );
     }
 
     #[test]
-    fn blocked_scheduler_wakes_on_command_arrival() {
+    fn maintenance_scheduler_wakes_immediately_on_command_arrival() {
         let (tx, rx) = bounded(1);
         tx.send(WlOverlayCmd::Remove).unwrap();
         assert!(matches!(
-            wait_for_work(&rx, WlWait::Block),
+            wait_for_work(&rx, WlWait::Maintenance(Duration::from_secs(1))),
             WlWake::Command(WlOverlayCmd::Remove)
         ));
     }


### PR DESCRIPTION
## Scope

- create one click-through layer-shell surface per enabled Wayland output
- route global cursor coordinates into deterministic output-local coordinates
- clear the previous surface when cursors move, hide, or end
- keep named session render state and lifecycle tombstones independent
- commit the first transparent buffer on every configured or hotplugged surface
- preserve demand-driven idle scheduling
- adapt the extracted work to current implicit-session revival semantics

This PR is intentionally limited to the native Wayland cursor overlay. It does not add Hyprland window discovery, capture, or input routing; browser cursor visualization; or the negative-coordinate placement-state change from #3019.

## Existing work and coordination

- Fixes #3150.
- Refs #2879 for the broader cross-platform visible pointer and badge oracle.
- PR #3019 touches `wayland/overlay.rs` for a distinct negative-coordinate fix. This draft should be rebased after whichever same-file change lands first; it does not supersede that PR.
- Hyprland capture and input remain owned by #2964 and stacked #3052.

The first three commits were moved with `git cherry-pick -x` from `spencerbull/cua`, preserving Spencer Bull as their author and recording each source SHA. The final commit is the current-main lifecycle adaptation.

## Validation

Candidate: `dbb306c3c7fad34e3fdb3444a2309f1f4d14f46b`

- `git diff --check refs/remotes/upstream/main...HEAD`
- `cargo fmt --all -- --check`
- `cargo test -p platform-linux wayland::overlay --lib`: 18 passed
- `cargo test -p platform-linux --lib`: 278 passed, 4 environment-dependent ignored
- `cargo test -p cua-driver --test wayland_overlay_idle_test`: compiled; 2 live-display tests ignored without an isolated Wayland runtime
- `cargo check -p platform-linux --all-targets`

## Known gap before readiness

The extracted candidate has not yet been replayed through the canonical Linux desktop E2E harness on a current-main Hyprland or Sway runtime. The original source commits were live-tested on a three-output Hyprland session, including capture completion with every overlay layer active, but that earlier source SHA is supporting evidence rather than certification of this rebased candidate.