### PR TITLE
fix(cua-driver): make install.ps1 survive the piped invocation it documents

### DIFF
--- a/libs/cua-driver/scripts/install.ps1
+++ b/libs/cua-driver/scripts/install.ps1
@@ -79,7 +79,11 @@
 [CmdletBinding()]
 param(
     [string]$Release = "latest",
-    [ValidateSet("stable", "nightly")]
+    # No [ValidateSet] here. This script is documented to be run as
+    # `irm ... | iex`, where param() becomes a set of attributed *variable*
+    # declarations rather than a parameter block: [string]$Channel is then
+    # initialised to '' and the set rejects its own default before the body
+    # ever runs. Validated in Resolve-SelectedChannel instead.
     [string]$Channel,
     # Default-on: cua-driver-serve is what makes the agent flow work
     # across logon / reboot. Without the scheduled task the user has
@@ -979,7 +983,16 @@ function Resolve-SelectedChannel {
         Write-ErrorStep "-Channel cannot be combined with an exact release pin; pins do not change saved channel state"
         exit 2
     }
-    if ($ChannelWasExplicit) { return $Channel }
+    if ($ChannelWasExplicit) {
+        # Validated here rather than with [ValidateSet] on the parameter;
+        # see the note in param(). Same accepted values and same wording as
+        # the saved-channel check below.
+        if ($Channel -notin @('stable', 'nightly')) {
+            Write-ErrorStep "invalid -Channel '$Channel'; expected stable or nightly"
+            exit 2
+        }
+        return $Channel
+    }
     if ($env:CUA_DRIVER_RS_VERSION -or $Release -ne 'latest') {
         # Exact pins are one-shot and outrank persisted preference. This also
         # preserves a recovery path when the preference file is malformed.


### PR DESCRIPTION
`install.ps1` documents itself as an `irm ... | iex` install, and that invocation has been failing outright:

```
The attribute cannot be added because variable Channel with value  would no longer be valid.
```

## Cause

Piped into `Invoke-Expression`, a `param()` block is not a parameter block — it becomes a set of attributed **variable** declarations. `[string]$Channel` is therefore initialised to `''`, and its own `[ValidateSet("stable", "nightly")]` rejects that default before the body ever runs. The parameter has no default in the set, so the failure is unconditional: it happens for every `iex` caller, whether or not they pass `-Channel`.

Run as a real script file the same code is fine, because an unbound parameter is never assigned and validation never fires. That asymmetry is why it survived review.

## Fix

Drop the attribute and validate at the point of use, keeping the same accepted values and the same wording as the saved-channel check immediately below it.

## Verification

All against `mcr.microsoft.com/powershell` with the real script, not a reduction:

- **Bug reproduced verbatim.** Piping the unmodified `install.ps1` into `Invoke-Expression` gives exactly the error above.
- **Fix clears it.** The patched script proceeds past argument handling into real work — with network disabled it now reaches a socket error against `cua.ai:443`, where before it died at the param block immediately.
- **Guard verified in isolation.** Driving `Resolve-SelectedChannel` directly: `nightly` → `nightly`, `stable` → `stable`, `bogus` → `invalid -Channel 'bogus'; expected stable or nightly`. Case-insensitivity is unchanged, since both `-notin` and `ValidateSet` are case-insensitive.

**Not verified, and worth a reviewer's attention:** I could not run the whole script through on Windows — on Linux it stops on Windows-only environment assumptions well before channel resolution — so the end-to-end install is unproven from here, as is the image build below.

## Why it matters beyond the one-liner

The Windows workspace image installs the driver by piping this script into `Invoke-Expression`, so its build fails at the `install cua-driver` step. That blocks rebuilding the Windows image at all, which in turn blocks anything that needs a newer driver in the image — including #3132, whose tool-listing fix cannot reach users until the image is rebuilt.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
