### PR TITLE
fix(sandbox): let from_registry name the guest OS

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/image.py
+++ b/libs/python/cua-sandbox/cua_sandbox/image.py
@@ -174,9 +174,26 @@ class Image:
         return cls(os_type="android", distro="android", version=version, kind=kind)
 
     @classmethod
-    def from_registry(cls, ref: str) -> Image:
-        """Create an image from a registry reference. kind is resolved after pull."""
-        return cls(os_type="linux", distro="registry", version="latest", kind=None, _registry=ref)
+    def from_registry(
+        cls,
+        ref: str,
+        *,
+        os_type: str = "linux",
+        kind: Optional[str] = None,
+    ) -> Image:
+        """Create an image from a registry reference.
+
+        os_type selects the firmware: Windows guest disks are built UEFI-only,
+        so a Windows containerDisk pulled from a registry must say so or it is
+        handed BIOS and will not boot. kind is resolved after pull when omitted.
+        """
+        return cls(
+            os_type=os_type,
+            distro="registry",
+            version="latest",
+            kind=kind,
+            _registry=ref,
+        )
 
     @classmethod
     def from_file(

--- a/libs/python/cua-sandbox/tests/test_cloud.py
+++ b/libs/python/cua-sandbox/tests/test_cloud.py
@@ -164,7 +164,9 @@ async def test_cloud_local_creation_never_routes_to_fleet(monkeypatch):
     calls = []
 
     class Runtime:
-        async def start(self, image, name):
+        # Sandbox._create tells the runtime whether the sandbox is ephemeral;
+        # a double that omits it fails the call rather than the assertion.
+        async def start(self, image, name, *, ephemeral=True):
             calls.append(("start", image, name))
             return RuntimeInfo(host="127.0.0.1", api_port=8000, name=name, environment="linux")
 

--- a/libs/python/cua-sandbox/tests/test_from_registry_ostype.py
+++ b/libs/python/cua-sandbox/tests/test_from_registry_ostype.py
@@ -1,0 +1,60 @@
+"""A registry image must be able to say it is Windows.
+
+os_type selects the firmware: Windows guest disks are built UEFI-only, and both
+the local QEMU runtime and the Fleet transport read os_type to decide. With
+from_registry hardcoding "linux", a Windows containerDisk pulled from any
+registry was handed BIOS and could not boot — the same failure fixed for Fleet
+in #3125, through a different door. The only escape was reaching past the
+constructor with dataclasses.replace().
+"""
+
+import inspect
+
+import pytest
+from cua_sandbox import Image
+
+REF = "ghcr.io/trycua/minecraft-workspace:1.20.1"
+
+
+def test_defaults_to_linux_so_existing_callers_are_unaffected():
+    image = Image.from_registry(REF)
+    assert image.os_type == "linux"
+    assert image.kind is None
+
+
+def test_a_windows_container_disk_can_say_so():
+    image = Image.from_registry(REF, os_type="windows", kind="vm")
+    assert image.os_type == "windows"
+    assert image.kind == "vm"
+
+
+def test_the_registry_reference_survives():
+    """Naming the OS must not disturb what gets pulled."""
+    plain = Image.from_registry(REF)
+    windows = Image.from_registry(REF, os_type="windows", kind="vm")
+    assert plain._registry == REF
+    assert windows._registry == REF
+
+
+def test_it_offers_the_same_knobs_as_from_file():
+    """The two constructors build the same object from different sources; a
+    caller should not have to know which one lets them name the guest OS."""
+    from_file = set(inspect.signature(Image.from_file).parameters)
+    from_registry = set(inspect.signature(Image.from_registry).parameters)
+    missing = {"os_type", "kind"} - from_registry
+    assert not missing, f"from_registry lacks knobs from_file has: {sorted(missing)}"
+    assert "os_type" in from_file  # guards the premise, not the fix
+
+
+@pytest.mark.parametrize("os_type", ["windows", "linux", "macos"])
+def test_os_type_is_passed_through_verbatim(os_type):
+    assert Image.from_registry(REF, os_type=os_type).os_type == os_type
+
+
+def test_windows_registry_image_gets_uefi_on_fleet():
+    """The end the bug was actually felt at: firmware selection."""
+    from cua_sandbox.transport.fleet_cloud import FleetCloudTransport
+
+    image = Image.from_registry(REF, os_type="windows", kind="vm")
+    template = FleetCloudTransport(image=image, name="demo")._template_request().spec.vm_template
+    assert template.firmware is not None, "a Windows containerDisk must not be handed BIOS"


### PR DESCRIPTION
`Image.from_registry()` hardcoded `os_type="linux"` and took no parameter to override it:

```python
def from_registry(cls, ref: str) -> Image:
    return cls(os_type="linux", distro="registry", version="latest", kind=None, _registry=ref)
```

`from_file`, the adjacent constructor building the same object from a different source, takes `os_type` **and** `kind` as keyword arguments. Same class, two constructors, inconsistent surface.

`os_type` is what selects UEFI — on the local QEMU runtime and in the Fleet transport alike. So a Windows containerDisk pulled from any registry was handed BIOS and could not boot, and the only way out was reaching past the constructor:

```python
dataclasses.replace(Image.from_registry(ref), os_type='windows', kind='vm')
```

This is the firmware failure fixed for Fleet in #3125 arriving through a different door. It surfaced while publishing a Windows containerDisk to a registry and booting it back, which is a documented workflow.

The default stays `"linux"`, so existing callers are unaffected.

## Tests

`tests/test_from_registry_ostype.py` — the default is preserved, a Windows disk can declare itself, the registry ref survives, `os_type` passes through verbatim, and the constructor offers the same knobs as `from_file`. Plus the end the bug was actually felt at: a Windows registry image must not come out of `_template_request()` with null firmware.

Seven of the eight fail without the source change.

## Also in here: a test that has been red on `main` since #3133

#3133 made `Sandbox._create` pass `ephemeral=` to `runtime.start()`. The fake `Runtime` in `test_cloud.py` does not accept it, so `test_cloud_local_creation_never_routes_to_fleet` has been failing on `main` ever since — it fails the *call*, before it can fail its assertion. Confirmed pre-existing by stashing only this PR's source change and re-running.

**It went unnoticed because `cua-sandbox` is not in the `ci-test-python` package matrix.** That matrix is `core, agent, computer, computer-server, mcp-server, som, cua-auto` — the cua-sandbox suite never runs on pull requests, so nothing here is covered by CI, including the tests in this PR.

That is worth addressing separately and is not a one-line change: the suite currently has other failures and at least one test that hangs, so adding it to the matrix wholesale would land red. Flagging rather than bundling.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
