### PR TITLE
ci: run the containerdisk guard on every pull request (#3158)

### DIFF
--- a/.github/workflows/ci-public-containerdisk-refs.yml
+++ b/.github/workflows/ci-public-containerdisk-refs.yml
@@ -2,15 +2,6 @@ name: "CI: Public ContainerDisk References"
 
 on:
   pull_request:
-    paths:
-      - ".github/workflows/ci-public-containerdisk-refs.yml"
-      - "docs/content/docs/how-to-guides/sandbox/**"
-      - "docs/superpowers/plans/2026-08-09-periodic-cua-sandbox-live-e2e.md"
-      - "docs/superpowers/specs/2026-08-09-periodic-cua-sandbox-live-e2e-design.md"
-      - "infra/fleets-wif-smoke/**"
-      - "libs/fleet/backend/auth/**"
-      - "libs/python/cua-sandbox/tests/live/test_fleet_ephemeral.py"
-      - "tests/test_public_containerdisk_refs.py"
 
 permissions:
   contents: read


### PR DESCRIPTION
Fixes #3158.

`tests/test_public_containerdisk_refs.py` scans **every tracked file** for the two private ECR repository names. The workflow that runs it fired on an eight-entry `paths:` list. The trigger and the scope did not match.

### How big the gap was

Evaluating the old `paths:` globs against the whole tree:

```
Tracked files the test scans:                 4261
Tracked files the OLD paths filter covered:     91  (2.14%)
```

And against the files #3148 actually changed:

```
libs/python/cua-sandbox/cua_sandbox/transport/fleet_cloud.py: no match -> job SKIPPED
libs/python/cua-sandbox/tests/test_pull_secret.py:            no match -> job SKIPPED
```

The only `libs/python/cua-sandbox` entry on the list was the single file `tests/live/test_fleet_ephemeral.py`, so nothing else under that package could ever trigger the guard. That is how the `cua-server-windows` reference in #3148 reached `main` and then failed on an unrelated docs PR, fixed after the fact in #3149.

### Why remove the filter rather than extend it

The test's scope is "every tracked file". Any `paths:` list short of `- "**"` is a second, hand-maintained copy of that scope that drifts the moment a directory is added — exactly the failure being fixed. Removing the filter makes the trigger match the scope by construction.

The cost is one checkout plus one unittest:

```
$ time python3 -m unittest tests.test_public_containerdisk_refs
Ran 1 test in 0.367s
OK
real  0m0.442s
```

Several `ci-*.yml` workflows in this repo already run unfiltered on every pull request (`ci-contributor-attribution.yml`, `ci-release-metadata.yml`, `ci-cua-driver-installer-compat.yml`, …), so this is not a new pattern.

### Verification

The change to the workflow file matched the old filter too, so this PR alone proves nothing. Evidence comes from #3164: a branch off this one whose **only** change is under `libs/python/cua-sandbox/**` — a path that matched nothing on the old list. The guard ran there and passed:

```
$ gh run view 31748187467 --json workflowName,event,headBranch,conclusion
{"workflowName":"CI: Public ContainerDisk References",
 "event":"pull_request",
 "headBranch":"verify/3158-cua-sandbox-path",
 "conclusion":"success"}
```

https://github.com/trycua/cua/actions/runs/31748187467 — 11 seconds, including checkout.

The negative case is on the record already: `gh pr checks 3148` lists 17 checks and none of them is this guard.

A second, unplanned instance of the gap is open right now: #3166 changes only `libs/python/cua-sandbox/**`, and `gh pr checks 3166` does not list this guard at all. That is the same hole #3148 fell through, still open on `main`.

#3164 is verification only and has been closed; nothing there is meant to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
