### PR TITLE
DO NOT MERGE: verify #3158 guard fires on libs/python/cua-sandbox changes

### DIFF
--- a/libs/python/cua-sandbox/README.md
+++ b/libs/python/cua-sandbox/README.md
@@ -173,3 +173,4 @@ The image must run the CUA computer-server `/cmd` API on the configured `server_
 Windows computer-server images continue to use the default port `8000`.
 
 Fleet currently supports registry images, CPU, memory, replica count, and named TCP services. Local image builds, layers, injected files or environment, snapshots, custom disks, unsupported regions, and provider-crossing serialization raise `NotImplementedError`.
+


### PR DESCRIPTION
Verification only for #3163. The single change is under libs/python/cua-sandbox/**, a path that matched nothing in the old paths: list. Will be closed once the check result is recorded.