### PR TITLE
fix(sandbox): explain a QEMURuntime mode/argument mismatch (#3160)

### DIFF
--- a/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
+++ b/libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
@@ -1,13 +1,18 @@
 """QEMU runtime — bare-metal or Docker-wrapped QEMU VMs.
 
-Two modes:
+Three modes:
   QEMURuntime(mode="docker")     — default, uses trycua/cua-qemu-* Docker images
   QEMURuntime(mode="bare-metal") — launches qemu-system-* directly on the host
+  QEMURuntime(mode="wsl2")       — launches qemu-system-* inside WSL2, for KVM
+
+Only the modes that build the QEMU command line themselves — bare-metal and
+wsl2 — accept extra_args.
 """
 
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json as _json
 import logging
 import platform as _plat
@@ -1092,14 +1097,62 @@ class QEMUWSL2Runtime(Runtime):
         raise TimeoutError(f"WSL2 QEMU VM {info.name} not ready after {timeout}s")
 
 
+_QEMU_RUNTIME_MODES: dict[str, type[Runtime]] = {
+    "docker": QEMUDockerRuntime,
+    "bare-metal": QEMUBaremetalRuntime,
+    "wsl2": QEMUWSL2Runtime,
+}
+
+
+def _accepted_kwargs(runtime_cls: type[Runtime]) -> set[str]:
+    """Keyword argument names a runtime constructor accepts."""
+    return {
+        name
+        for name, param in inspect.signature(runtime_cls.__init__).parameters.items()
+        if name != "self" and param.kind in (param.KEYWORD_ONLY, param.POSITIONAL_OR_KEYWORD)
+    }
+
+
 def QEMURuntime(mode: str = "docker", **kwargs) -> Runtime:
     """Factory that returns the appropriate QEMU runtime.
 
     Args:
         mode: "docker" (default), "bare-metal", or "wsl2"
+
+    The three modes do not share a constructor signature — only the two that
+    build the QEMU command line themselves take ``extra_args``. An argument the
+    selected mode cannot use raises a TypeError naming ``mode`` and the modes
+    that do accept it, instead of one naming a class the caller never mentioned.
     """
-    if mode == "wsl2":
-        return QEMUWSL2Runtime(**kwargs)
-    if mode == "bare-metal":
-        return QEMUBaremetalRuntime(**kwargs)
-    return QEMUDockerRuntime(**kwargs)
+    runtime_cls = _QEMU_RUNTIME_MODES.get(mode)
+    if runtime_cls is None:
+        raise ValueError(
+            f"Unknown QEMURuntime mode {mode!r}; expected one of "
+            + ", ".join(repr(m) for m in _QEMU_RUNTIME_MODES)
+        )
+
+    unknown = sorted(set(kwargs) - _accepted_kwargs(runtime_cls))
+    if unknown:
+        details = []
+        for name in unknown:
+            elsewhere = [
+                m
+                for m, cls in _QEMU_RUNTIME_MODES.items()
+                if m != mode and name in _accepted_kwargs(cls)
+            ]
+            if elsewhere:
+                modes = " or ".join(f"mode={m!r}" for m in elsewhere)
+                details.append(f"{name} (accepted by {modes})")
+            else:
+                details.append(name)
+        message = f"QEMURuntime(mode={mode!r}) does not accept: " + ", ".join(details) + "."
+        if "extra_args" in unknown:
+            message += (
+                " Raw QEMU flags such as -cpu host go in extra_args, which only the"
+                " modes that build the QEMU command line themselves accept;"
+                " mode='docker' (the default) runs a prebuilt image whose command"
+                " line is fixed."
+            )
+        raise TypeError(message)
+
+    return runtime_cls(**kwargs)

--- a/libs/python/cua-sandbox/tests/test_qemu_runtime_modes.py
+++ b/libs/python/cua-sandbox/tests/test_qemu_runtime_modes.py
@@ -1,0 +1,71 @@
+"""QEMURuntime must explain a mode/argument mismatch in its own terms.
+
+The factory defaults to mode="docker", which routes to QEMUDockerRuntime — a
+constructor that does not take extra_args. extra_args is how -cpu host is
+passed, the documented fix for the commonest local failure in the Minecraft
+how-to (the game exiting during resource loading under the default qemu64
+model). So QEMURuntime(extra_args=["-cpu", "host"]) used to fail with
+"QEMUDockerRuntime.__init__() got an unexpected keyword argument 'extra_args'",
+naming a class the caller never mentioned and saying nothing about mode.
+"""
+
+import pytest
+from cua_sandbox.runtime.qemu import (
+    QEMUBaremetalRuntime,
+    QEMUDockerRuntime,
+    QEMURuntime,
+    QEMUWSL2Runtime,
+)
+
+
+def test_extra_args_on_the_default_mode_names_mode_and_the_fix():
+    with pytest.raises(TypeError) as excinfo:
+        QEMURuntime(extra_args=["-cpu", "host"])
+
+    message = str(excinfo.value)
+    assert "extra_args" in message
+    # Names the knob that actually selects the backend...
+    assert "mode='docker'" in message
+    # ...and the modes that can take the argument.
+    assert "mode='bare-metal'" in message
+    assert "mode='wsl2'" in message
+    # ...not an implementation class the caller never mentioned.
+    assert "QEMUDockerRuntime" not in message
+
+
+def test_the_modes_that_build_the_command_line_still_take_extra_args():
+    runtime = QEMURuntime(mode="bare-metal", extra_args=["-cpu", "host"])
+    assert isinstance(runtime, QEMUBaremetalRuntime)
+    assert runtime.extra_args == ["-cpu", "host"]
+
+    runtime = QEMURuntime(mode="wsl2", extra_args=["-cpu", "host"])
+    assert isinstance(runtime, QEMUWSL2Runtime)
+    assert runtime.extra_args == ["-cpu", "host"]
+
+
+def test_an_argument_no_mode_accepts_is_reported_without_a_redirect():
+    with pytest.raises(TypeError) as excinfo:
+        QEMURuntime(mode="bare-metal", definitely_not_a_qemu_option=1)
+
+    message = str(excinfo.value)
+    assert "definitely_not_a_qemu_option" in message
+    assert "accepted by" not in message
+
+
+def test_a_misspelled_mode_is_rejected_instead_of_falling_back_to_docker():
+    with pytest.raises(ValueError, match="Unknown QEMURuntime mode 'baremetal'"):
+        QEMURuntime(mode="baremetal")
+
+
+def test_the_default_backend_is_unchanged():
+    """Every existing caller keeps the runtime it had."""
+    assert isinstance(QEMURuntime(), QEMUDockerRuntime)
+    assert isinstance(QEMURuntime(mode="docker"), QEMUDockerRuntime)
+    assert isinstance(QEMURuntime(mode="bare-metal"), QEMUBaremetalRuntime)
+    assert isinstance(QEMURuntime(mode="wsl2"), QEMUWSL2Runtime)
+
+
+def test_valid_arguments_still_reach_the_selected_runtime():
+    runtime = QEMURuntime(mode="docker", api_port=18001, vnc_port=18006, ephemeral=True)
+    assert isinstance(runtime, QEMUDockerRuntime)
+    assert runtime.api_port == 18001


### PR DESCRIPTION
Fixes #3160.

`QEMURuntime(mode: str = "docker", **kwargs)` routes to `QEMUDockerRuntime`, whose constructor has no `extra_args`. `extra_args` is how `-cpu host` is passed — the documented fix for the commonest local failure in the Minecraft how-to (the game exiting during resource loading under the default `qemu64` model). So the most natural call fails with a type error about a class the caller never named:

```
TypeError: QEMUDockerRuntime.__init__() got an unexpected keyword argument 'extra_args'
```

Nothing in that mentions `mode`, which is the knob that actually decides.

### What this does

The factory validates the passed kwargs against the constructor of the **selected mode** and reports the mismatch in the caller's own vocabulary:

```
>>> QEMURuntime(extra_args=["-cpu", "host"])
TypeError: QEMURuntime(mode='docker') does not accept: extra_args (accepted by
mode='bare-metal' or mode='wsl2'). Raw QEMU flags such as -cpu host go in
extra_args, which only the modes that build the QEMU command line themselves
accept; mode='docker' (the default) runs a prebuilt image whose command line is
fixed.

>>> QEMURuntime(mode="bare-metal", vnc_port=1)
TypeError: QEMURuntime(mode='bare-metal') does not accept: vnc_port (accepted by mode='docker').

>>> QEMURuntime(mode="baremetal")
ValueError: Unknown QEMURuntime mode 'baremetal'; expected one of 'docker', 'bare-metal', 'wsl2'
```

The accepted names come from `inspect.signature` of each runtime, so the modes cannot drift apart from the message. The unknown-mode check is the same defect one layer up: `mode="baremetal"` used to fall through to Docker in silence.

### Why this option and not the others

- **Catching the `TypeError` and re-raising** would fix the wording and nothing else — the message would still be assembled from whatever CPython happened to say, and `mode="baremetal"` would still silently give you Docker.
- **Accept and ignore** is the worst outcome for this particular flag: a caller who passes `-cpu host` and gets a VM booted without it sees the exact Minecraft failure they were trying to fix, with no error to explain it.
- **Dispatch on capability** (let `extra_args` select bare-metal by itself) changes which backend runs for an existing caller without being asked. bare-metal is not a drop-in substitute for docker — it needs `qemu-system-*` on PATH and a disk image on disk — so guessing here trades a clear error for an obscure boot failure.

**The default mode is unchanged.** Every `QEMURuntime(` call site in the repo was checked against the new validation:

```
libs/python/cua-sandbox/cua_sandbox/sandbox.py:288 mode='docker'     kwargs=[] -> OK
libs/python/cua-sandbox/cua_sandbox/sandbox.py:255 mode='bare-metal' kwargs=[] -> OK
...
tests/integration/sandbox_sdk/test_linux_local_osworld_vm.py:76 mode='bare-metal' kwargs=['api_port', 'cpu_count', 'memory_mb', 'vnc_display'] -> OK

call sites that would newly raise: 0
```

### Test

`libs/python/cua-sandbox/tests/test_qemu_runtime_modes.py`. It fails on `main`'s runtime source — stashing only the source file, keeping the test:

```
$ git stash push -- libs/python/cua-sandbox/cua_sandbox/runtime/qemu.py
$ uv run --frozen python -m pytest tests/test_qemu_runtime_modes.py -q
E  assert "mode='docker'" in "QEMUDockerRuntime.__init__() got an unexpected keyword argument 'extra_args'"
E  Failed: DID NOT RAISE ValueError
2 failed, 4 passed
```

and passes with it restored (`6 passed`). One case covers the default backend explicitly, so a later change to the default breaks a test instead of breaking callers quietly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
