### PR TITLE
ci: run the cua-sandbox test suite on pull requests

### DIFF
--- a/.github/workflows/ci-test-python.yml
+++ b/.github/workflows/ci-test-python.yml
@@ -11,6 +11,9 @@ jobs:
   test:
     name: Test ${{ matrix.package }}
     runs-on: ubuntu-latest
+    # A test that waits on a sandbox which never boots would otherwise hold the
+    # runner for the six-hour default.
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false # Test all packages even if one fails
@@ -23,6 +26,7 @@ jobs:
           - mcp-server
           - som
           - cua-auto
+          - cua-sandbox
 
     steps:
       - name: Checkout code

--- a/libs/python/cua-sandbox/cua_sandbox/registry/manifest.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/manifest.py
@@ -14,6 +14,8 @@ from cua_sandbox.registry.media_types import (
     CONTAINER_CONFIG_TYPES,
     CONTAINER_LAYER_TYPES,
     LEGACY_DISK_CHUNK,
+    LUME_DISK,
+    LUME_PART_NUMBER_ANNOTATION,
     OCI_VM_CONFIG,
     OCI_VM_CONFIG_LEGACY,
     OCI_VM_DISK,
@@ -109,10 +111,14 @@ def detect_format(manifest: dict) -> ImageFormat:
     if any(layer.get("mediaType") == LEGACY_DISK_CHUNK for layer in layers):
         return ImageFormat.LEGACY_LZ4
 
-    # Chunked-parts: standard OCI layer type but with ;part.number= suffix
+    # Chunked-parts: one layer per disk part. The part index lives either in a
+    # ";part.number=" suffix on the media type or — for what lume pushes today —
+    # in an org.trycua.lume.part.number annotation on the layer.
     for layer in layers:
         mt = layer.get("mediaType", "")
         if "part.number=" in mt:
+            return ImageFormat.CHUNKED_PARTS
+        if mt == LUME_DISK or LUME_PART_NUMBER_ANNOTATION in layer.get("annotations", {}):
             return ImageFormat.CHUNKED_PARTS
 
     # QEMU (cua): trycua.qemu config or disk layers

--- a/libs/python/cua-sandbox/cua_sandbox/registry/media_types.py
+++ b/libs/python/cua-sandbox/cua_sandbox/registry/media_types.py
@@ -43,6 +43,16 @@ LEGACY_DISK_CHUNK = "application/vnd.trycua.lume.disk.chunk.lz4"
 LEGACY_AUX = "application/vnd.trycua.lume.aux.image.v1"
 LEGACY_CONFIG = "application/vnd.trycua.lume.config.v1+json"
 
+# ── Lume (chunked disk parts) ──────────────────────────────────────────────
+#
+# What lume pushes today, e.g. ghcr.io/trycua/macos-sequoia-cua:latest: one
+# layer per disk.img.part.N, part number/total carried in org.trycua.lume.part.*
+# annotations rather than in the media type string.
+
+LUME_DISK = "application/vnd.trycua.lume.disk.v1"
+LUME_NVRAM = "application/vnd.trycua.lume.nvram.v1"
+LUME_PART_NUMBER_ANNOTATION = "org.trycua.lume.part.number"
+
 # ── Standard OCI / Docker container ────────────────────────────────────────
 
 OCI_IMAGE_LAYER = "application/vnd.oci.image.layer.v1.tar+gzip"
@@ -67,6 +77,8 @@ VM_MEDIA_TYPES = frozenset(
         LEGACY_DISK_CHUNK,
         LEGACY_AUX,
         LEGACY_CONFIG,
+        LUME_DISK,
+        LUME_NVRAM,
         TART_CONFIG,
         TART_DISK,
         TART_NVRAM,

--- a/libs/python/cua-sandbox/tests/conftest.py
+++ b/libs/python/cua-sandbox/tests/conftest.py
@@ -91,6 +91,16 @@ def _local_enabled() -> bool:
 
 LOCAL_ENABLED = _local_enabled()
 LOCAL_SKIP_REASON = "no controllable local desktop (set CUA_TEST_LOCAL=1 to force, 0 to silence)"
+
+# Tests that provision a real sandbox — pull a multi-gigabyte image, boot a VM or
+# an emulator, then wait for it to answer — are opt-in. Whether the tooling is
+# installed is not the question: a GitHub runner ships the Android SDK and Docker
+# and still cannot boot either in the time a PR check is allowed to take.
+RUNTIME_TESTS_ENABLED = _env_bool("CUA_TEST_RUNTIME")
+RUNTIME_SKIP_REASON = (
+    "provisions a real sandbox (multi-GB pull + boot); set CUA_TEST_RUNTIME=1 to run"
+)
+requires_runtime_optin = pytest.mark.skipif(not RUNTIME_TESTS_ENABLED, reason=RUNTIME_SKIP_REASON)
 WS_URL = os.environ.get("CUA_TEST_WS_URL")
 HTTP_URL = os.environ.get("CUA_TEST_HTTP_URL")
 API_KEY = os.environ.get("CUA_TEST_API_KEY")

--- a/libs/python/cua-sandbox/tests/conftest.py
+++ b/libs/python/cua-sandbox/tests/conftest.py
@@ -6,7 +6,12 @@ all available backends.
 
 Environment variables control which backends are exercised:
 
-    CUA_TEST_LOCAL=1              Enable localhost/local-sandbox tests (default: on)
+    CUA_TEST_LOCAL=1              Force localhost/local-sandbox tests on/off.
+                                  Unset means "auto": they run only when this
+                                  host actually has a controllable desktop
+                                  (pynput importable + a screenshot succeeds),
+                                  so a headless CI runner skips them instead of
+                                  failing on a missing DISPLAY.
     CUA_TEST_WS_URL=ws://...     Enable WebSocket transport tests
     CUA_TEST_HTTP_URL=http://...  Enable HTTP transport tests
     CUA_TEST_API_KEY=sk-...       API key for remote transports
@@ -15,7 +20,10 @@ Environment variables control which backends are exercised:
 
 from __future__ import annotations
 
+import functools
 import os
+import subprocess
+import sys
 
 import pytest
 import pytest_asyncio
@@ -37,7 +45,52 @@ def _env_bool(key: str, default: bool = False) -> bool:
     return val.lower() in ("1", "true", "yes")
 
 
-LOCAL_ENABLED = _env_bool("CUA_TEST_LOCAL", default=True)
+_DESKTOP_PROBE = """
+import cua_auto.keyboard
+import cua_auto.mouse
+from cua_auto.screen import screenshot
+
+screenshot()
+"""
+
+
+@functools.lru_cache(maxsize=1)
+def local_desktop_available() -> bool:
+    """True when this host can actually be driven as a Localhost sandbox.
+
+    The Localhost backend types on the real keyboard and grabs the real screen
+    through cua-auto/pynput. On a headless machine (CI runners included) the
+    import raises, so every localhost test fails for a reason that has nothing
+    to do with the code under test.
+
+    The probe runs in a subprocess on purpose: against an X display with no
+    window manager, pynput's Xlib backend terminates the interpreter outright
+    rather than raising, which would take the whole pytest session down during
+    collection.
+    """
+    if sys.platform.startswith("linux") and not (
+        os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")
+    ):
+        return False
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", _DESKTOP_PROBE],
+            capture_output=True,
+            timeout=60,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 0
+
+
+def _local_enabled() -> bool:
+    if os.environ.get("CUA_TEST_LOCAL", ""):
+        return _env_bool("CUA_TEST_LOCAL")
+    return local_desktop_available()
+
+
+LOCAL_ENABLED = _local_enabled()
+LOCAL_SKIP_REASON = "no controllable local desktop (set CUA_TEST_LOCAL=1 to force, 0 to silence)"
 WS_URL = os.environ.get("CUA_TEST_WS_URL")
 HTTP_URL = os.environ.get("CUA_TEST_HTTP_URL")
 API_KEY = os.environ.get("CUA_TEST_API_KEY")
@@ -85,7 +138,7 @@ async def http_transport():
 @pytest_asyncio.fixture
 async def local_sandbox():
     if not LOCAL_ENABLED:
-        pytest.skip("CUA_TEST_LOCAL disabled")
+        pytest.skip(LOCAL_SKIP_REASON)
     async with Localhost.connect() as host:
         yield host
 
@@ -116,7 +169,7 @@ async def http_sandbox():
 @pytest_asyncio.fixture
 async def localhost_instance():
     if not LOCAL_ENABLED:
-        pytest.skip("CUA_TEST_LOCAL disabled")
+        pytest.skip(LOCAL_SKIP_REASON)
     async with Localhost.connect() as host:
         yield host
 
@@ -145,9 +198,13 @@ def any_sandbox_name(request):
     return request.param
 
 
-@pytest_asyncio.fixture
-async def any_sandbox(any_sandbox_name, request):
-    """Yields a Sandbox connected via whichever transport is being parametrized."""
-    # Dynamically request the named fixture
-    sb = request.getfixturevalue(any_sandbox_name)
-    return sb
+@pytest.fixture
+def any_sandbox(any_sandbox_name, request):
+    """Returns a Sandbox connected via whichever transport is being parametrized.
+
+    Deliberately a *sync* fixture: the backend fixtures it forwards to are
+    async-generator fixtures, and pytest-asyncio can only set those up from
+    outside a running event loop. Resolving them from an async fixture raises
+    "Runner.run() cannot be called from a running event loop".
+    """
+    return request.getfixturevalue(any_sandbox_name)

--- a/libs/python/cua-sandbox/tests/test_android_multitouch.py
+++ b/libs/python/cua-sandbox/tests/test_android_multitouch.py
@@ -52,6 +52,8 @@ from cua_sandbox.runtime.android_emulator import AndroidEmulatorRuntime
 from cua_sandbox.runtime.compat import skip_if_unsupported
 from cua_sandbox.sandbox import Sandbox
 
+from tests.conftest import requires_runtime_optin
+
 # ── Config ─────────────────────────────────────────────────────────────────
 
 _APK_RELEASE_URL = (
@@ -428,6 +430,10 @@ class _MultitouchTests:
 # ══════════════════════════════════════════════════════════════════════════════
 
 
+# Boots a real Android emulator through the SDK. skip_if_unsupported() lets this
+# through on a GitHub runner — the SDK is auto-installable there — and the launch
+# then dies on "This user doesn't have permissions to use KVM (/dev/kvm)".
+@requires_runtime_optin
 @pytest.mark.asyncio
 class TestAndroidMultitouchLocal(_MultitouchTests):
     """Full touch action suite against a bare-metal AndroidEmulatorRuntime."""

--- a/libs/python/cua-sandbox/tests/test_docs_regressions.py
+++ b/libs/python/cua-sandbox/tests/test_docs_regressions.py
@@ -100,10 +100,14 @@ class TestConcurrentLocalVMsDoNotCollide:
 
         from cua_sandbox.runtime.qemu import _find_free_vnc_display
 
+        # Occupy whichever display the helper hands out first: that has to push
+        # the next answer somewhere else. Binding a hardcoded 5900 instead blows
+        # up with EADDRINUSE on any host that already has a VNC server.
+        first = _find_free_vnc_display(0)
         with socket.socket() as taken:
-            taken.bind(("", 5900))
+            taken.bind(("", 5900 + first))
             taken.listen(1)
-            assert _find_free_vnc_display(0) != 0
+            assert _find_free_vnc_display(0) != first
 
     def test_efivars_is_per_vm_not_shared(self):
         """Every session disk lives in one directory; a shared efivars.fd would

--- a/libs/python/cua-sandbox/tests/test_integration_sync.py
+++ b/libs/python/cua-sandbox/tests/test_integration_sync.py
@@ -1,8 +1,18 @@
-"""Integration tests for the synchronous API wrappers."""
+"""Integration tests for the synchronous API wrappers.
+
+These drive the *real* host desktop (they type on the real keyboard and grab
+the real screen), so they are skipped unless this machine has a controllable
+desktop. See tests/conftest.py::local_desktop_available.
+"""
 
 from __future__ import annotations
 
+import pytest
 from cua_sandbox.sync import localhost
+
+from tests.conftest import LOCAL_ENABLED, LOCAL_SKIP_REASON
+
+pytestmark = pytest.mark.skipif(not LOCAL_ENABLED, reason=LOCAL_SKIP_REASON)
 
 
 class TestSyncLocalhost:

--- a/libs/python/cua-sandbox/tests/test_oci.py
+++ b/libs/python/cua-sandbox/tests/test_oci.py
@@ -8,6 +8,8 @@ fetch real manifests from ghcr.io and require network access.
 
 from __future__ import annotations
 
+import os
+
 import pytest
 from cua_sandbox.registry.manifest import (
     ImageFormat,
@@ -19,7 +21,10 @@ from cua_sandbox.registry.manifest import (
 from cua_sandbox.registry.media_types import (
     DOCKER_IMAGE_CONFIG,
     DOCKER_IMAGE_LAYER,
+    LEGACY_CONFIG,
     LEGACY_DISK_CHUNK,
+    LUME_DISK,
+    LUME_NVRAM,
     OCI_IMAGE_CONFIG,
     OCI_IMAGE_LAYER,
     OCI_VM_AUX,
@@ -199,12 +204,91 @@ class TestGetLayerInfo:
 
 
 # ═════════════════════════════════════════════════════════════════════════════
+# Real manifest shapes, captured offline
+# ═════════════════════════════════════════════════════════════════════════════
+
+
+def _lume_chunked_manifest() -> dict:
+    """Trimmed copy of ghcr.io/trycua/macos-sequoia-cua:latest.
+
+    Two disk parts instead of 160; everything else is verbatim. This is what
+    `lume push` produces today: trycua.lume media types with the part index in
+    annotations, not in the media type string.
+    """
+    return {
+        "annotations": {"org.trycua.lume.os": "macOS"},
+        "config": {
+            "mediaType": LEGACY_CONFIG,
+            "digest": "sha256:478d66",
+            "size": 611,
+        },
+        "layers": [
+            {
+                "mediaType": LUME_NVRAM,
+                "digest": "sha256:921d54",
+                "size": 33579164,
+                "annotations": {"org.opencontainers.image.title": "nvram.bin"},
+            },
+            {
+                "mediaType": LUME_DISK,
+                "digest": "sha256:14d748",
+                "size": 1123260,
+                "annotations": {
+                    "org.opencontainers.image.title": "disk.img.part.0",
+                    "org.trycua.lume.part.number": "0",
+                    "org.trycua.lume.part.total": "160",
+                },
+            },
+            {
+                "mediaType": LUME_DISK,
+                "digest": "sha256:603f15",
+                "size": 5728169,
+                "annotations": {
+                    "org.opencontainers.image.title": "disk.img.part.1",
+                    "org.trycua.lume.part.number": "1",
+                    "org.trycua.lume.part.total": "160",
+                },
+            },
+        ],
+    }
+
+
+class TestLumeChunkedManifest:
+    """A lume-pushed macOS image classified as UNKNOWN, so `cua pull` logged
+    "(unknown, vm)" and no format-specific handling could ever match it."""
+
+    def test_format_is_chunked_parts(self):
+        assert detect_format(_lume_chunked_manifest()) == ImageFormat.CHUNKED_PARTS
+
+    def test_kind_and_os(self):
+        manifest = _lume_chunked_manifest()
+        assert detect_kind(manifest) == "vm"
+        assert detect_os(manifest) == "macos"
+
+    def test_layer_parts_are_numbered(self):
+        info = get_layer_info(_lume_chunked_manifest())
+        disk_parts = [layer for layer in info if layer["part_number"] is not None]
+        assert [layer["part_number"] for layer in disk_parts] == [0, 1]
+        assert all(layer["part_total"] == 160 for layer in disk_parts)
+
+    def test_lz4_still_wins_over_chunked(self):
+        """Legacy LZ4 images share the lume config type — they must not be
+        reclassified just because the config media type matches."""
+        manifest = _lume_chunked_manifest()
+        manifest["layers"] = [{"mediaType": LEGACY_DISK_CHUNK, "digest": "sha256:a", "size": 1}]
+        assert detect_format(manifest) == ImageFormat.LEGACY_LZ4
+
+
+# ═════════════════════════════════════════════════════════════════════════════
 # Live registry tests (require network)
 # ═════════════════════════════════════════════════════════════════════════════
 
+# These reach out to ghcr.io / docker.io over the network. Anonymous pulls from
+# a shared CI runner are rate-limited, so the whole class is opt-in; the offline
+# regression tests above cover the same detection logic against real manifests.
 oci_live = pytest.mark.skipif(
-    not pytest.importorskip("oras", reason="oras-py not installed"),
-    reason="oras-py not installed",
+    os.environ.get("CUA_TEST_REGISTRY", "").lower() not in ("1", "true", "yes"),
+    reason="hits a live registry; set CUA_TEST_REGISTRY=1 to run",
 )
 
 

--- a/libs/python/cua-sandbox/tests/test_runtime.py
+++ b/libs/python/cua-sandbox/tests/test_runtime.py
@@ -20,6 +20,16 @@ pytestmark = pytest.mark.asyncio
 IS_WINDOWS = platform.system() == "Windows"
 IS_MACOS = platform.system() == "Darwin"
 
+# Every async test in this module boots a real sandbox: it pulls a multi-gigabyte
+# image and then waits for a full desktop or VM to come up. Having Docker
+# installed is not enough to make that a sane thing to do on a shared CI runner,
+# where the pull alone outlives the job, so provisioning tests are opt-in.
+RUNTIME_TESTS_ENABLED = os.environ.get("CUA_TEST_RUNTIME", "").lower() in ("1", "true", "yes")
+requires_runtime_optin = pytest.mark.skipif(
+    not RUNTIME_TESTS_ENABLED,
+    reason="provisions a real sandbox (multi-GB pull + boot); set CUA_TEST_RUNTIME=1 to run",
+)
+
 
 def _has_cua_api_key() -> bool:
     return bool(os.environ.get("CUA_API_KEY"))
@@ -77,6 +87,7 @@ def _has_android_image() -> bool:
 # ── 1. Linux container (Docker) ─────────────────────────────────────────────
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not _has_docker(), reason="Docker not available")
 async def test_linux_container():
     from cua_sandbox.runtime import DockerRuntime
@@ -98,6 +109,7 @@ async def test_linux_container():
 # ── 2. Linux VM (QEMU-in-Docker) ────────────────────────────────────────────
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not _has_docker(), reason="Docker not available")
 async def test_linux_vm():
     from cua_sandbox.runtime import QEMURuntime
@@ -119,6 +131,7 @@ async def test_linux_vm():
 # ── 3. Windows VM (bare-metal QEMU on Windows host) ─────────────────────────
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not IS_WINDOWS, reason="Windows host only")
 @pytest.mark.skipif(not _has_qemu(), reason="QEMU not available")
 async def test_windows_vm():
@@ -140,6 +153,7 @@ async def test_windows_vm():
 # ── 3b. Windows VM (Hyper-V) ────────────────────────────────────────────────
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not _has_hyperv(), reason="Hyper-V not available")
 async def test_windows_hyperv():
     from cua_sandbox.runtime import HyperVRuntime
@@ -160,6 +174,7 @@ async def test_windows_hyperv():
 # ── 4. macOS VM (Lume) ──────────────────────────────────────────────────────
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not IS_MACOS or not _has_lume(), reason="Lume only on macOS")
 async def test_macos_vm():
     from cua_sandbox.runtime import LumeRuntime
@@ -195,6 +210,7 @@ def _get_android_iso() -> str:
     return str(isos[0]) if isos else ""
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not _has_qemu(), reason="QEMU not available")
 @pytest.mark.skipif(
     not _has_android_image(),
@@ -220,6 +236,7 @@ async def test_android_vm_baremetal():
         assert len(screenshot) > 1000
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not _has_qemu(), reason="QEMU not available")
 @pytest.mark.skipif(not _has_android_iso(), reason="No android-x86*.iso in ~/Downloads")
 async def test_android_vm_from_iso():
@@ -262,6 +279,7 @@ async def test_android_vm_from_iso():
 # ── 5b. Android VM (QEMU-in-Docker) ──────────────────────────────────────────
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not _has_docker(), reason="Docker not available")
 async def test_android_vm_docker():
     """Test Android VM via QEMU inside Docker."""
@@ -287,6 +305,7 @@ def _has_osworld_image() -> bool:
     return any(cache.rglob("Ubuntu.qcow2")) if cache.exists() else False
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not _has_qemu(), reason="QEMU not available")
 @pytest.mark.skipif(not _has_osworld_image(), reason="OSWorld Ubuntu.qcow2 not in image cache")
 async def test_osworld_ubuntu_vm():
@@ -328,6 +347,7 @@ def _has_android_sdk() -> bool:
         return False
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not _has_android_sdk(), reason="Android SDK not available")
 async def test_android_emulator():
     """Test Android emulator boots to homescreen."""
@@ -344,6 +364,7 @@ async def test_android_emulator():
         assert len(screenshot) > 10000
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not _has_android_sdk(), reason="Android SDK not available")
 async def test_android_emulator_apk_install():
     """Test Android emulator with F-Droid APK installed from URL."""
@@ -373,6 +394,7 @@ def _has_tart() -> bool:
     return shutil.which("tart") is not None
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not IS_MACOS, reason="Tart only on macOS")
 @pytest.mark.skipif(not _has_tart(), reason="Tart CLI not available")
 async def test_tart_ubuntu():
@@ -394,6 +416,7 @@ async def test_tart_ubuntu():
         assert "Linux" in result.stdout
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not IS_MACOS, reason="Tart only on macOS")
 @pytest.mark.skipif(not _has_tart(), reason="Tart CLI not available")
 async def test_tart_macos_tahoe():
@@ -411,6 +434,7 @@ async def test_tart_macos_tahoe():
         assert len(screenshot) > 1000
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not IS_MACOS, reason="Tart only on macOS")
 @pytest.mark.skipif(not _has_tart(), reason="Tart CLI not available")
 async def test_tart_macos_sequoia_cua():
@@ -428,6 +452,7 @@ async def test_tart_macos_sequoia_cua():
         assert len(screenshot) > 1000
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not IS_MACOS or not _has_lume(), reason="Lume only on macOS")
 async def test_lume_macos_tahoe_cua():
     """Test CUA macOS Tahoe image via Lume from ghcr.io/trycua/macos-tahoe-cua:latest."""
@@ -463,6 +488,7 @@ def test_qemu_baremetal_missing_binary_error():
 # ── 10. Auto-runtime (local=True, no explicit runtime) ───────────────────────
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not _has_docker(), reason="Docker not available")
 async def test_auto_runtime_linux_container():
     """local=True with no runtime auto-selects DockerRuntime for linux container images."""
@@ -479,6 +505,7 @@ async def test_auto_runtime_linux_container():
         assert screenshot[:4] == b"\x89PNG"
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not _has_docker(), reason="Docker not available")
 async def test_auto_runtime_linux_vm():
     """local=True with no runtime auto-selects QEMURuntime(docker) for linux vm images."""
@@ -495,6 +522,7 @@ async def test_auto_runtime_linux_vm():
         assert screenshot[:4] == b"\x89PNG"
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not IS_MACOS or not _has_lume(), reason="Lume only on macOS")
 async def test_auto_runtime_macos():
     """local=True with no runtime auto-selects LumeRuntime for macOS images."""
@@ -511,6 +539,7 @@ async def test_auto_runtime_macos():
         assert screenshot[:4] == b"\x89PNG"
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not _has_android_sdk(), reason="Android SDK not available")
 async def test_auto_runtime_android():
     """local=True with no runtime auto-selects AndroidEmulatorRuntime for android images."""
@@ -524,6 +553,7 @@ async def test_auto_runtime_android():
         assert len(screenshot) > 10000
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not IS_WINDOWS, reason="Windows host only")
 @pytest.mark.skipif(not _has_qemu(), reason="QEMU not available")
 async def test_auto_runtime_windows():
@@ -543,6 +573,7 @@ async def test_auto_runtime_windows():
 # ── 11. Cloud sandboxes (local=False) ────────────────────────────────────────
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not _has_cua_api_key(), reason="CUA_API_KEY not set")
 async def test_cloud_linux_ephemeral():
     """Cloud sandbox: Sandbox.ephemeral with linux image (local=False)."""
@@ -557,6 +588,7 @@ async def test_cloud_linux_ephemeral():
         assert screenshot[:4] == b"\x89PNG"
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not _has_cua_api_key(), reason="CUA_API_KEY not set")
 async def test_cloud_android_ephemeral():
     """Cloud sandbox: Sandbox.ephemeral with android image (local=False)."""
@@ -571,6 +603,7 @@ async def test_cloud_android_ephemeral():
 # ── 12. Sandbox.create (persistent) ─────────────────────────────────────────
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not _has_docker(), reason="Docker not available")
 async def test_create_persistent_linux():
     """Sandbox.create provisions a persistent sandbox that survives disconnect."""
@@ -593,6 +626,7 @@ async def test_create_persistent_linux():
         await sb.disconnect()
 
 
+@requires_runtime_optin
 @pytest.mark.skipif(not _has_cua_api_key(), reason="CUA_API_KEY not set")
 async def test_create_persistent_cloud_linux():
     """Sandbox.create provisions a persistent cloud sandbox."""

--- a/libs/python/cua-sandbox/tests/test_runtime.py
+++ b/libs/python/cua-sandbox/tests/test_runtime.py
@@ -15,20 +15,12 @@ from pathlib import Path
 import pytest
 from cua_sandbox import Image, Sandbox
 
+from tests.conftest import requires_runtime_optin
+
 pytestmark = pytest.mark.asyncio
 
 IS_WINDOWS = platform.system() == "Windows"
 IS_MACOS = platform.system() == "Darwin"
-
-# Every async test in this module boots a real sandbox: it pulls a multi-gigabyte
-# image and then waits for a full desktop or VM to come up. Having Docker
-# installed is not enough to make that a sane thing to do on a shared CI runner,
-# where the pull alone outlives the job, so provisioning tests are opt-in.
-RUNTIME_TESTS_ENABLED = os.environ.get("CUA_TEST_RUNTIME", "").lower() in ("1", "true", "yes")
-requires_runtime_optin = pytest.mark.skipif(
-    not RUNTIME_TESTS_ENABLED,
-    reason="provisions a real sandbox (multi-GB pull + boot); set CUA_TEST_RUNTIME=1 to run",
-)
 
 
 def _has_cua_api_key() -> bool:


### PR DESCRIPTION
Closes #3157.

`cua-sandbox` is now in the `ci-test-python` package matrix. Getting there meant triaging the suite first — it had five failures and four tests that make the run appear to hang.

## What was actually wrong

### A real source bug: lume chunked-part images classify as `UNKNOWN`

`detect_format()` only recognised part indices carried in a `;part.number=` suffix on the layer media type. What `lume push` produces today uses `application/vnd.trycua.lume.disk.v1` layers with the index in `org.trycua.lume.part.*` **annotations** — so every current macOS image fell through to `ImageFormat.UNKNOWN`, `ghcr.io/trycua/macos-sequoia-cua:latest` included:

```
$ python -c "from cua_sandbox.registry.manifest import *; \
             print(detect_format(get_manifest('ghcr.io/trycua/macos-sequoia-cua:latest')))"
ImageFormat.UNKNOWN
```

`pull_image()` still worked (it falls back on `detect_kind` → `vm`), but it logged `(unknown, vm)` and no format-specific handling could ever match. `get_layer_info()` already read the annotation form, so the two halves of the module disagreed about the same manifest.

Fixed in `registry/media_types.py` + `registry/manifest.py`. Legacy LZ4 images share the same *config* media type, so the new check sits after the `LEGACY_LZ4` branch; `test_lz4_still_wins_over_chunked` pins that ordering. This is what `TestLiveRegistry::test_macos_chunked_parts` was failing on — the test was right and the source was wrong.

### A stale test double: `any_sandbox`

`any_sandbox` was an async fixture calling `request.getfixturevalue()` on async-generator fixtures. pytest-asyncio ≥ 1.0 refuses that (`Runner.run() cannot be called from a running event loop`) — 19 errors in `test_integration_interfaces.py`, all in fixture setup, none of them reaching an assertion. Same flavour of drift as the `Runtime` double fixed in #3154. Now a sync fixture.

### A host-dependent assertion

`test_vnc_display_skips_a_busy_port` bound a hardcoded `5900` to simulate a busy display, so it died with `EADDRINUSE` on any machine already running a VNC server. It now occupies whichever display `_find_free_vnc_display()` hands out first and asserts the next answer differs — the same property, and strictly harder to pass by accident.

### Localhost tests on a machine with no desktop

`test_integration_agent.py`, `test_integration_interfaces.py` and `test_integration_sync.py` type on the real keyboard and grab the real screen via cua-auto/pynput. `CUA_TEST_LOCAL` defaulted to *on*, so on any headless machine they failed with `ModuleNotFoundError: pynput._util.xorg` / `screenshot failed: No module named 'mss'` — nothing to do with the code under test.

Unset now means "probe this host"; explicit `CUA_TEST_LOCAL=1`/`0` still forces either way. The probe runs in a **subprocess** deliberately: against an X display with no window manager, pynput's Xlib backend terminates the interpreter rather than raising, which silently kills the whole pytest session during collection. Verified — an in-process probe under bare Xvfb produced a zero-output `exit 1`.

## What is skipped, and why

Two groups are now skipped by default. Both say so in their skip reason, and neither was passing before this PR.

**`test_runtime.py` — 24 provisioning tests, opt-in behind `CUA_TEST_RUNTIME=1`.** These are the hang. Each pulls a multi-gigabyte image and then blocks 120s inside `DockerRuntime.is_ready()` waiting for a desktop to come up. On a box with the image already cached:

```
FAILED tests/test_runtime.py::test_linux_container -
  TimeoutError: Container cua-test-linux-container not ready after 120s
1 failed in 139.68s
```

Four of them are reachable whenever Docker is present (`test_linux_container`, `test_linux_vm`, `test_android_vm_docker`, `test_create_persistent_linux`), which is always on `ubuntu-latest`. With a cold cache the pulls alone outlive the job. Having Docker installed is not a signal that booting a full desktop VM is a sane thing to do on a 2-core runner, so the gate is now explicit rather than inferred. The one pure unit test in the module, `test_qemu_baremetal_missing_binary_error`, still runs.

**`test_android_multitouch.py::TestAndroidMultitouchLocal` — 17 tests, same `CUA_TEST_RUNTIME=1` gate.** Its only gate was `skip_if_unsupported()`, which passes on any Linux host because the Android SDK is *auto-installable*. That includes a GitHub runner, so the first CI run of this branch dutifully downloaded the SDK and the test APK and then died in fixture setup:

```
RuntimeError: Emulator crashed on launch: ProbeKVM: This user doesn't have
permissions to use KVM (/dev/kvm).
```

Worth flagging as a triage lesson: this one is invisible on a dev box without the Android SDK — it only appeared once CI ran it.

**`test_oci.py::TestLiveRegistry` — opt-in behind `CUA_TEST_REGISTRY=1`.** It fetches manifests from ghcr.io and docker.io; anonymous Docker Hub pulls from CI runner IPs are rate-limited, so it would be a flake source. To avoid losing the coverage that caught the bug above, the same detection is now asserted **offline** in `TestLumeChunkedManifest` against a captured copy of the real `macos-sequoia-cua:latest` manifest (two disk parts instead of 160, everything else verbatim). The live class still passes with the fix:

```
$ CUA_TEST_REGISTRY=1 pytest tests/test_oci.py -q
30 passed in 1.95s
```

The `Sandbox`/transport/pool/fleet/image/cloud tests — the ones that were doing the real work — all still run.

## Known gap, not fixed here

`cua-sandbox` depends on plain `cua-auto`, but `mss` is an optional extra (`cua-auto[mss]`). On Linux `ImageGrab` fails and the fallback is missing, so `Localhost.screenshot()` cannot work out of the box. That is a packaging question for cua-auto/cua-sandbox rather than a CI one, and the desktop probe correctly reports "unavailable" when it happens — worth a separate issue.

## Verification

Through the exact steps CI runs (per-package editable install, then `--group test` from the root, then `pytest tests/`), in a clean `python:3.12` container rather than the uv workspace:

```
================= 427 passed, 131 skipped, 2 warnings in 6.70s =================
PYTEST_RC=0
```

and then on the runner itself — see the `Test cua-sandbox` job on this PR.

Also added `timeout-minutes: 20` to the test job so a future hang cannot hold a runner for the six-hour default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
