### PR TITLE
Bump cua-sandbox to v0.3.4

### DIFF
--- a/libs/python/cua-sandbox/.bumpversion.cfg
+++ b/libs/python/cua-sandbox/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.3
+current_version = 0.3.4
 commit = True
 tag = True
 tag_name = sandbox-v{new_version}

--- a/libs/python/cua-sandbox/pyproject.toml
+++ b/libs/python/cua-sandbox/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cua-sandbox"
-version = "0.3.3"
+version = "0.3.4"
 description = "CUA Sandbox — ephemeral and persistent sandboxed computer environments"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Problem this solves: Releases the warm pool autoscaling support for `Pool.apply()` merged in #3168 as cua-sandbox v0.3.4 on PyPI.
- What changed: Version bump 0.3.3 → 0.3.4 in `pyproject.toml` and `.bumpversion.cfg`, produced by `bump2version patch` (the same operation as the "Legacy packages: Bump Version" workflow, which could not be dispatched from this session). After this merges, the `sandbox-v0.3.4` tag will be pushed at the merged commit to trigger the `CD: cua-sandbox (PyPI)` publish workflow.

## Related work

Refs #3168

RFC (required for a public SDK, CLI, MCP, protocol, compatibility, permission, or cross-component contract change): N/A — version bump only

## Compatibility and risk

- User-visible, API/CLI/MCP, migration, permission, or platform impact: Publishes cua-sandbox 0.3.4 containing the additive, optional `autoscaling` parameter for `Pool.apply()`. No breaking changes.
- Risk and rollback: Low. Version metadata change only; the release itself can be yanked from PyPI if needed.

## Validation

- Focused tests and checks: CI on #3168 was fully green at the released content; this PR changes version metadata only.
- Manual or platform evidence: N/A
- Known gaps or CI still required: `CD: cua-sandbox (PyPI)` runs on the tag push after merge.

## Contributor and release checks

- [x] The PR is focused and the description matches the final diff.
- [x] This change does not require an RFC, or the accepted RFC is linked above.
- [x] Tests, documentation, and platform evidence are included or the gap is explained.
- [x] The PR title is a Conventional Commit describing the production change.
- [x] External contributor authorship is preserved, or no external contribution is included.
- [x] If release-tracked files changed but this is intentionally non-releasing, the `no-release` label is applied.

https://claude.ai/code/session_01GXGC2B4EsEw9dHBPWbKrBz

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXGC2B4EsEw9dHBPWbKrBz)_