### PR TITLE
fix: isolate nightly release staging

### DIFF
--- a/.github/scripts/github_release.py
+++ b/.github/scripts/github_release.py
@@ -149,10 +149,7 @@ def unique_release(api: GitHubApi, repository: str, tag: str) -> dict[str, Any]:
 
 
 def validate_registered_nightly_tag(tag: str) -> None:
-    # Driver publication runs after its exact nightly version has been staged
-    # into the checkout. Tag validation needs registry shape and namespaces,
-    # not the stable source-state invariant enforced by planning and builds.
-    registry = release_channels.load_registry(require_stable_state=False)
+    registry = release_channels.load_registry()
     matches = []
     for name, component in registry["components"].items():
         try:

--- a/.github/scripts/release_channels.py
+++ b/.github/scripts/release_channels.py
@@ -9,8 +9,10 @@ import json
 import os
 from pathlib import Path, PurePosixPath
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
 from typing import Any, Mapping, Sequence
 
 import release_attribution
@@ -54,7 +56,6 @@ def load_registry(
     path: Path = DEFAULT_REGISTRY,
     *,
     root: Path = ROOT,
-    require_stable_state: bool = True,
 ) -> dict[str, Any]:
     registry = read_json(path)
     if registry.get("schemaVersion") != 1:
@@ -127,21 +128,18 @@ def load_registry(
             raise ChannelError(
                 f"component {name} stable prefix must match Release Please: {expected_prefix}"
             )
-        if require_stable_state:
-            authority = (
-                repository_path(root, component["versionAuthorityFile"])
-                .read_text(encoding="utf-8")
-                .strip()
+        authority = (
+            repository_path(root, component["versionAuthorityFile"])
+            .read_text(encoding="utf-8")
+            .strip()
+        )
+        if not SEMVER_RE.fullmatch(authority):
+            raise ChannelError(f"component {name} authority is not a stable version: {authority!r}")
+        if release_manifest.get(package_path) != authority:
+            raise ChannelError(
+                f"component {name} authority {authority} differs from Release Please manifest "
+                f"{release_manifest.get(package_path)!r}"
             )
-            if not SEMVER_RE.fullmatch(authority):
-                raise ChannelError(
-                    f"component {name} authority is not a stable version: {authority!r}"
-                )
-            if release_manifest.get(package_path) != authority:
-                raise ChannelError(
-                    f"component {name} authority {authority} differs from Release Please manifest "
-                    f"{release_manifest.get(package_path)!r}"
-                )
     return registry
 
 
@@ -150,13 +148,8 @@ def component_descriptor(
     path: Path = DEFAULT_REGISTRY,
     *,
     root: Path = ROOT,
-    require_stable_state: bool = True,
 ) -> dict[str, Any]:
-    registry = load_registry(
-        path,
-        root=root,
-        require_stable_state=require_stable_state,
-    )
+    registry = load_registry(path, root=root)
     try:
         return dict(registry["components"][name])
     except KeyError as error:
@@ -278,6 +271,39 @@ def _rewrite_cargo_lock(
     return len(seen)
 
 
+def _rewrite_version_site(
+    site: Mapping[str, Any],
+    path: Path,
+    old_version: str,
+    new_version: str,
+    *,
+    manifest_path: Path | None = None,
+) -> None:
+    kind = site["kind"]
+    if kind == "plain":
+        if path.read_text(encoding="utf-8").strip() != old_version:
+            raise ChannelError(f"plain version site {site['path']} differs from {old_version}")
+        path.write_text(f"{new_version}\n", encoding="utf-8")
+    elif kind == "regex":
+        original = path.read_text(encoding="utf-8")
+        replacement = str(site["replacement"]).replace("{version}", new_version)
+        rewritten, count = re.subn(str(site["pattern"]), replacement, original)
+        if count != int(site["expectedMatches"]):
+            raise ChannelError(
+                f"version site {site['path']} matched {count} times, "
+                f"expected {site['expectedMatches']}"
+            )
+        path.write_text(rewritten, encoding="utf-8")
+    elif kind == "cargo-workspace-lock":
+        if manifest_path is None:
+            raise ChannelError(
+                f"cargo lock version site {site['path']} requires its manifest in the staged tree"
+            )
+        _rewrite_cargo_lock(path, manifest_path, old_version, new_version)
+    else:
+        raise ChannelError(f"unsupported version site kind: {kind!r}")
+
+
 def apply_version(
     name: str,
     version: str,
@@ -293,27 +319,83 @@ def apply_version(
     changed: list[str] = []
     for site in component["buildVersionSites"]:
         path = repository_path(root, site["path"])
-        kind = site["kind"]
-        if kind == "plain":
-            if path.read_text(encoding="utf-8").strip() != old_version:
-                raise ChannelError(f"plain version site {site['path']} differs from {old_version}")
-            path.write_text(f"{version}\n", encoding="utf-8")
-        elif kind == "regex":
-            original = path.read_text(encoding="utf-8")
-            replacement = str(site["replacement"]).replace("{version}", version)
-            rewritten, count = re.subn(str(site["pattern"]), replacement, original)
-            if count != int(site["expectedMatches"]):
-                raise ChannelError(
-                    f"version site {site['path']} matched {count} times, "
-                    f"expected {site['expectedMatches']}"
-                )
-            path.write_text(rewritten, encoding="utf-8")
-        elif kind == "cargo-workspace-lock":
-            manifest = repository_path(root, site["manifestPath"])
-            _rewrite_cargo_lock(path, manifest, old_version, version)
-        else:
-            raise ChannelError(f"unsupported version site kind: {kind!r}")
+        manifest = (
+            repository_path(root, site["manifestPath"])
+            if site["kind"] == "cargo-workspace-lock"
+            else None
+        )
+        _rewrite_version_site(site, path, old_version, version, manifest_path=manifest)
         changed.append(str(site["path"]))
+    return changed
+
+
+def stage_versioned_tree(
+    name: str,
+    version: str,
+    source: str,
+    destination: str,
+    *,
+    registry_path: Path = DEFAULT_REGISTRY,
+    root: Path = ROOT,
+) -> list[str]:
+    """Copy one source tree and rewrite only its declared version sites."""
+    nightly_version(version)
+    component = component_descriptor(name, registry_path, root=root)
+    authority = repository_path(root, component["versionAuthorityFile"])
+    old_version = authority.read_text(encoding="utf-8").strip()
+    stable_version(old_version)
+    source_path = repository_path(root, source)
+    destination_path = repository_path(root, destination)
+    if not source_path.is_dir():
+        raise ChannelError(f"versioned tree source is not a directory: {source}")
+    if destination_path.exists():
+        raise ChannelError(f"versioned tree destination already exists: {destination}")
+    if destination_path.resolve().is_relative_to(source_path.resolve()):
+        raise ChannelError("versioned tree destination cannot be inside its source")
+
+    source_pure = PurePosixPath(source)
+    selected: list[tuple[Mapping[str, Any], PurePosixPath]] = []
+    for site in component["buildVersionSites"]:
+        try:
+            relative = PurePosixPath(str(site["path"])).relative_to(source_pure)
+        except ValueError:
+            continue
+        selected.append((site, relative))
+    if not selected:
+        raise ChannelError(
+            f"versioned tree {source!r} contains no declared buildVersionSites for {name}"
+        )
+
+    destination_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(
+        dir=destination_path.parent,
+        prefix=f".{destination_path.name}.stage-",
+    ) as temporary:
+        staged = Path(temporary) / destination_path.name
+        shutil.copytree(source_path, staged)
+        changed: list[str] = []
+        for site, relative in selected:
+            manifest = None
+            if site["kind"] == "cargo-workspace-lock":
+                try:
+                    manifest_relative = PurePosixPath(str(site["manifestPath"])).relative_to(
+                        source_pure
+                    )
+                except ValueError as error:
+                    raise ChannelError(
+                        f"cargo lock version site {site['path']} cannot be staged without "
+                        f"manifest {site['manifestPath']}"
+                    ) from error
+                manifest = staged / manifest_relative
+            _rewrite_version_site(
+                site,
+                staged / relative,
+                old_version,
+                version,
+                manifest_path=manifest,
+            )
+            changed.append(str(PurePosixPath(destination) / relative))
+        staged.rename(destination_path)
     return changed
 
 
@@ -407,12 +489,7 @@ def build_manifest(
     attribution_config_path: Path | None = None,
     github: release_attribution.GitHubClient | None = None,
 ) -> dict[str, Any]:
-    component = component_descriptor(
-        name,
-        registry_path,
-        root=root,
-        require_stable_state=False,
-    )
+    component = component_descriptor(name, registry_path, root=root)
     parsed = parse_tag(component, "nightly", tag)
     if parsed != version:
         raise ChannelError(f"tag version {parsed} differs from requested version {version}")
@@ -426,11 +503,7 @@ def build_manifest(
     if not base_sha:
         raise ChannelError(f"nightly attribution base has no commit: {previous_tag}")
     _git(root, "merge-base", "--is-ancestor", base_sha, source_sha)
-    registry = load_registry(
-        registry_path,
-        root=root,
-        require_stable_state=False,
-    )
+    registry = load_registry(registry_path, root=root)
     paths = sorted(
         {
             *(str(path) for path in component["changeDetectionPaths"]),
@@ -576,6 +649,12 @@ def parser() -> argparse.ArgumentParser:
     apply.add_argument("--component", required=True)
     apply.add_argument("--version", required=True)
 
+    stage = subparsers.add_parser("stage-versioned-tree")
+    stage.add_argument("--component", required=True)
+    stage.add_argument("--version", required=True)
+    stage.add_argument("--source", required=True)
+    stage.add_argument("--destination", required=True)
+
     plan = subparsers.add_parser("plan")
     plan.add_argument("--component", required=True)
     plan.add_argument("--source-sha", required=True)
@@ -625,6 +704,16 @@ def main(argv: Sequence[str] | None = None) -> int:
         elif args.command == "apply-version":
             for changed in apply_version(
                 args.component, args.version, registry_path=args.registry, root=root
+            ):
+                print(changed)
+        elif args.command == "stage-versioned-tree":
+            for changed in stage_versioned_tree(
+                args.component,
+                args.version,
+                args.source,
+                args.destination,
+                registry_path=args.registry,
+                root=root,
             ):
                 print(changed)
         elif args.command == "plan":

--- a/.github/scripts/tests/test_github_release.py
+++ b/.github/scripts/tests/test_github_release.py
@@ -225,13 +225,13 @@ def test_nightly_can_create_a_private_draft_at_the_exact_sha():
     ]
 
 
-def test_nightly_creation_validates_registry_namespaces_after_artifact_staging(
+def test_nightly_creation_validates_registry_with_stable_authority(
     monkeypatch: pytest.MonkeyPatch,
 ):
     calls = []
 
-    def fake_registry(*, require_stable_state: bool):
-        calls.append(require_stable_state)
+    def fake_registry():
+        calls.append(True)
         return {
             "components": {
                 "cua-driver-rs": {
@@ -252,7 +252,7 @@ def test_nightly_creation_validates_registry_namespaces_after_artifact_staging(
         channel="nightly",
         create_if_missing=True,
     )
-    assert calls == [False]
+    assert calls == [True]
 
 
 def test_stable_and_unregistered_tags_cannot_create_drafts():

--- a/.github/scripts/tests/test_nightly_release_wiring.py
+++ b/.github/scripts/tests/test_nightly_release_wiring.py
@@ -42,6 +42,11 @@ def test_driver_nightly_reuses_builder_without_stable_state_mutation():
     assert "needs.plan.outputs.attribution_base_tag" in nightly
     assert "issues: read" in nightly
     assert "pull-requests: read" in nightly
+    assert "release_channels.py apply-version" not in nightly
+    assert "release_channels.py stage-versioned-tree" in nightly
+    assert nightly.index("stage-versioned-tree") < nightly.index(
+        "Collect PR-first attribution and render nightly body"
+    )
 
 
 def test_lume_nightly_reuses_notarized_builder_and_never_becomes_latest():

--- a/.github/scripts/tests/test_release_channels.py
+++ b/.github/scripts/tests/test_release_channels.py
@@ -23,6 +23,7 @@ from release_channels import (
     plan_nightly,
     repository_path,
     render_nightly_body,
+    stage_versioned_tree,
 )
 
 
@@ -267,7 +268,7 @@ def test_plan_builds_only_for_declared_relevant_changes(monkeypatch: pytest.Monk
     assert plan["attributionBaseTag"] == plan["previousNightlyTag"]
 
 
-def test_manifest_accepts_an_artifact_tree_with_staged_nightly_versions(
+def test_manifest_uses_stable_authority_with_a_separately_versioned_asset_tree(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):
     registry, root = copy_version_fixture(tmp_path, "cua-driver-rs")
@@ -279,10 +280,22 @@ def test_manifest_accepts_an_artifact_tree_with_staged_nightly_versions(
     git(root, "tag", "cua-driver-rs-v0.19.3")
     source_sha = git(root, "rev-parse", "HEAD")
     version = "0.19.4-nightly.20260812.42"
-    apply_version("cua-driver-rs", version, registry_path=registry, root=root)
+    source_skill = root / "libs/cua-driver/rust/Skills/cua-driver/SKILL.md"
+    source_before = source_skill.read_text(encoding="utf-8")
+    staged = root / "release-stage/cua-driver-skills"
+    changed = stage_versioned_tree(
+        "cua-driver-rs",
+        version,
+        "libs/cua-driver/rust/Skills/cua-driver",
+        "release-stage/cua-driver-skills",
+        registry_path=registry,
+        root=root,
+    )
 
-    with pytest.raises(ChannelError, match="authority is not a stable version"):
-        load_registry(registry, root=root)
+    assert changed == ["release-stage/cua-driver-skills/SKILL.md"]
+    assert source_skill.read_text(encoding="utf-8") == source_before
+    assert version in (staged / "SKILL.md").read_text(encoding="utf-8")
+    load_registry(registry, root=root)
 
     assets = root / "release-upload"
     assets.mkdir()
@@ -309,6 +322,25 @@ def test_manifest_accepts_an_artifact_tree_with_staged_nightly_versions(
         "version": version,
         "tag": f"nightly-cua-driver-rs-v{version}",
     }
+
+    with pytest.raises(ChannelError, match="destination already exists"):
+        stage_versioned_tree(
+            "cua-driver-rs",
+            version,
+            "libs/cua-driver/rust/Skills/cua-driver",
+            "release-stage/cua-driver-skills",
+            registry_path=registry,
+            root=root,
+        )
+    with pytest.raises(ChannelError, match="contains no declared buildVersionSites"):
+        stage_versioned_tree(
+            "cua-driver-rs",
+            version,
+            ".github",
+            "release-stage/metadata",
+            registry_path=registry,
+            root=root,
+        )
 
 
 def test_nightly_manifest_reuses_pr_attribution_and_renders_contributors(tmp_path: Path):
@@ -473,24 +505,28 @@ class RehearsalReleaseApi:
 
 
 @pytest.mark.parametrize(
-    ("component_name", "change_path", "title"),
+    ("component_name", "change_path", "stage_source", "title"),
     [
         (
             "cua-driver-rs",
             "libs/cua-driver/rust/nightly-rehearsal.txt",
+            "libs/cua-driver/rust/Skills/cua-driver",
             "fix(cua-driver): rehearse nightly publication",
         ),
         (
             "lume",
             "libs/lume/nightly-rehearsal.txt",
+            "libs/lume/src",
             "fix(lume): rehearse nightly publication",
         ),
     ],
 )
 def test_nightly_transaction_rehearses_plan_stage_manifest_publish_and_retry(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
     component_name: str,
     change_path: str,
+    stage_source: str,
     title: str,
 ):
     registry_path, root = copy_version_fixture(tmp_path, component_name)
@@ -527,73 +563,136 @@ def test_nightly_transaction_rehearses_plan_stage_manifest_publish_and_retry(
     git(root, "commit", "-m", f"{title} (#42)")
     source_sha = git(root, "rev-parse", "HEAD")
 
-    plan = plan_nightly(
-        component_name,
-        source_sha,
-        "20260812",
-        "42",
-        [],
-        registry_path=registry_path,
-        root=root,
+    monkeypatch.setattr(release_channels, "ROOT", root)
+    releases_path = root / "published-releases.json"
+    releases_path.write_text("[]\n", encoding="utf-8")
+    plan_path = root / "release-plan.json"
+    assert (
+        release_channels.main(
+            [
+                "--registry",
+                str(registry_path),
+                "plan",
+                "--component",
+                component_name,
+                "--source-sha",
+                source_sha,
+                "--date",
+                "20260812",
+                "--run",
+                "42",
+                "--releases",
+                str(releases_path),
+                "--output",
+                str(plan_path),
+            ]
+        )
+        == 0
     )
+    plan = json.loads(plan_path.read_text(encoding="utf-8"))
     assert plan["shouldBuild"] is True
     assert plan["attributionBaseTag"] == stable_tag
 
-    apply_version(
-        component_name,
-        plan["version"],
-        registry_path=registry_path,
-        root=root,
+    stage_destination = f"release-stage/{component_name}"
+    assert (
+        release_channels.main(
+            [
+                "--registry",
+                str(registry_path),
+                "stage-versioned-tree",
+                "--component",
+                component_name,
+                "--version",
+                plan["version"],
+                "--source",
+                stage_source,
+                "--destination",
+                stage_destination,
+            ]
+        )
+        == 0
     )
+    assert repository_path(root, component["versionAuthorityFile"]).read_text().strip() == (
+        stable_version
+    )
+    staged_text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (root / stage_destination).rglob("*")
+        if path.is_file()
+    )
+    assert plan["version"] in staged_text
     assets = root / "release-upload"
     assets.mkdir()
     (assets / f"{component_name}.tar.gz").write_bytes(b"nightly artifact")
-    manifest = build_manifest(
-        component_name,
-        plan["version"],
-        plan["tag"],
-        source_sha,
-        plan["attributionBaseTag"],
-        assets,
-        repository="trycua/cua",
-        registry_path=registry_path,
-        root=root,
-        attribution_config_path=attribution_config,
-        github=RehearsalGitHub(source_sha, title),
+    monkeypatch.setattr(
+        release_channels.release_attribution,
+        "GitHubClient",
+        lambda *_args: RehearsalGitHub(source_sha, title),
     )
-    body = render_nightly_body(manifest)
-    (assets / "release-manifest.json").write_text(
-        json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+    manifest_path = root / "release-manifest.json"
+    assert (
+        release_channels.main(
+            [
+                "--registry",
+                str(registry_path),
+                "manifest",
+                "--component",
+                component_name,
+                "--version",
+                plan["version"],
+                "--tag",
+                plan["tag"],
+                "--source-sha",
+                source_sha,
+                "--previous-tag",
+                plan["attributionBaseTag"],
+                "--asset-dir",
+                str(assets),
+                "--repository",
+                "trycua/cua",
+                "--output",
+                str(manifest_path),
+            ]
+        )
+        == 0
     )
+    body_path = root / "release-body.md"
+    assert (
+        release_channels.main(
+            [
+                "render-nightly",
+                "--manifest",
+                str(manifest_path),
+                "--body",
+                str(body_path),
+            ]
+        )
+        == 0
+    )
+    shutil.copy2(manifest_path, assets / "release-manifest.json")
 
     api = RehearsalReleaseApi(source_sha)
-    first = github_release.finalize_release(
-        api=api,
-        repository="trycua/cua",
-        tag=plan["tag"],
-        expected_sha=source_sha,
-        body=body,
-        asset_dir=assets,
-        prerelease=True,
-        make_latest=False,
-        channel="nightly",
-        create_if_missing=True,
-    )
+    monkeypatch.setattr(github_release, "GitHubApi", lambda *_args, **_kwargs: api)
+    publish_args = [
+        "--repository",
+        "trycua/cua",
+        "--tag",
+        plan["tag"],
+        "--sha",
+        source_sha,
+        "--body",
+        str(body_path),
+        "--asset-dir",
+        str(assets),
+        "--channel",
+        "nightly",
+        "--create-if-missing",
+        "--prerelease",
+    ]
+    assert github_release.main(publish_args) == 0
     first_counts = (len(api.posts), len(api.uploads), len(api.patches))
-    second = github_release.finalize_release(
-        api=api,
-        repository="trycua/cua",
-        tag=plan["tag"],
-        expected_sha=source_sha,
-        body=body,
-        asset_dir=assets,
-        prerelease=True,
-        make_latest=False,
-        channel="nightly",
-        create_if_missing=True,
-    )
+    assert github_release.main(publish_args) == 0
 
-    assert first["draft"] is False
-    assert first["prerelease"] is True
-    assert second == first
+    assert api.release["draft"] is False
+    assert api.release["prerelease"] is True
     assert first_counts == (len(api.posts), len(api.uploads), len(api.patches))

--- a/.github/workflows/nightly-cua-driver.yml
+++ b/.github/workflows/nightly-cua-driver.yml
@@ -65,9 +65,7 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${{ needs.plan.outputs.version }}"
-          python3 .github/scripts/release_channels.py apply-version \
-            --component cua-driver-rs --version "$VERSION"
-          mkdir -p release-upload release-metadata
+          mkdir -p release-upload release-metadata release-stage
           find artifacts -type f \( -name "*.tar.gz" -o -name "*.zip" \) \
             -exec cp {} release-upload/ \;
           cp libs/cua-driver/scripts/install.sh release-upload/install.sh
@@ -75,10 +73,14 @@ jobs:
           cp libs/cua-driver/scripts/_install-rust.sh release-upload/_install-rust.sh
           cp libs/cua-driver/scripts/uninstall.sh release-upload/uninstall.sh
           cp libs/cua-driver/scripts/uninstall.ps1 release-upload/uninstall.ps1
-          SKILLS_STAGE="cua-driver-rs-v${VERSION}-skills"
-          mkdir -p "$SKILLS_STAGE"
-          cp -R libs/cua-driver/rust/Skills/cua-driver/. "$SKILLS_STAGE/"
-          tar -czf "release-upload/${SKILLS_STAGE}.tar.gz" "$SKILLS_STAGE"
+          SKILLS_NAME="cua-driver-rs-v${VERSION}-skills"
+          python3 .github/scripts/release_channels.py stage-versioned-tree \
+            --component cua-driver-rs \
+            --version "$VERSION" \
+            --source libs/cua-driver/rust/Skills/cua-driver \
+            --destination "release-stage/$SKILLS_NAME"
+          tar -czf "release-upload/${SKILLS_NAME}.tar.gz" \
+            -C release-stage "$SKILLS_NAME"
           (
             cd release-upload
             shasum -a 256 * | sort > checksums.txt


### PR DESCRIPTION
## Summary

- add a reusable `stage-versioned-tree` release-control command that copies a registered source tree and rewrites only its declared version sites
- stage the Driver skill pack in an isolated release tree instead of running `apply-version` against the publish checkout
- restore strict stable-authority validation for manifest creation and nightly tag publication
- make staging transactional: existing destinations, unregistered trees, overlapping paths, and incomplete Cargo trees fail closed
- upgrade the stack's transaction rehearsal to execute the same CLI entry points and argument shapes used by Actions

## Root cause

The Driver publish job mutated its source checkout to the nightly version before attribution and publication validation. Those later phases also used the checkout as stable-version authority, which forced exceptions such as `require_stable_state=False` and caused two initial rollout failures.

## Impact

Nightly artifacts are unchanged in shape: the skill tarball still contains the nightly-versioned skill, while installers and verified platform archives retain their existing contracts. The difference is architectural: stable source authority remains immutable throughout publication.

## Validation

- `uv run --no-project --with pytest --with jsonschema --with pyyaml --with toml pytest .github/scripts/tests/ -q` — 218 passed, 18 subtests passed
- `python3 .github/scripts/release_channels.py validate` — 2 components validated
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/nightly-cua-driver.yml .github/workflows/ci-test-scripts.yml`
- Ruff check and format validation for all changed Python files
- PyYAML parse of both changed workflows
- `git diff --check`

## Stack

1. [#3173](https://github.com/trycua/cua/pull/3173) — CI path coverage and full synthetic nightly transaction rehearsal.
2. This PR — isolated versioned staging and restored strict authority validation.

## Exclusions

- no schedule, channel-selection, installer-default, stable-release, signing, or notarization changes
- no public nightly is triggered by this PR

Refs #3096
